### PR TITLE
Parameterized CUDA Graph Launch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -890,19 +890,22 @@ if(USE_ROCM)
   endif()
 endif()
 
-string(APPEND CMAKE_CUDA_FLAGS_DEBUG " -G")
+# Uncoditionally generate debug info
+# string(APPEND CMAKE_CUDA_FLAGS "-v -keep --no-lineinfo-inlined-at --cicc-options '-g'")
 
-if(DEBUG_CUDA)
-  string(APPEND CMAKE_CUDA_FLAGS_DEBUG " -G")
-  string(APPEND CMAKE_CUDA_FLAGS_DEBUG " -lineinfo")
-  string(APPEND CMAKE_CUDA_FLAGS_RELWITHDEBINFO " -lineinfo")
-  # CUDA-12.1 crashes when trying to compile with --source-in-ptx See
-  # https://github.com/pytorch/pytorch/issues/102372#issuecomment-1572526893
-  if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 12.1)
-    string(APPEND CMAKE_CUDA_FLAGS_DEBUG " --source-in-ptx")
-    string(APPEND CMAKE_CUDA_FLAGS_RELWITHDEBINFO " --source-in-ptx")
-  endif()
-endif(DEBUG_CUDA)
+# string(APPEND CMAKE_CUDA_FLAGS_DEBUG " -G")
+
+# if(DEBUG_CUDA)
+#   string(APPEND CMAKE_CUDA_FLAGS_DEBUG " -G")
+#   string(APPEND CMAKE_CUDA_FLAGS_DEBUG " -lineinfo")
+#   string(APPEND CMAKE_CUDA_FLAGS_RELWITHDEBINFO " -lineinfo")
+#   # CUDA-12.1 crashes when trying to compile with --source-in-ptx See
+#   # https://github.com/pytorch/pytorch/issues/102372#issuecomment-1572526893
+#   if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 12.1)
+#     string(APPEND CMAKE_CUDA_FLAGS_DEBUG " --source-in-ptx")
+#     string(APPEND CMAKE_CUDA_FLAGS_RELWITHDEBINFO " --source-in-ptx")
+#   endif()
+# endif(DEBUG_CUDA)
 
 if(USE_FBGEMM)
   string(APPEND CMAKE_CXX_FLAGS " -DUSE_FBGEMM")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -890,7 +890,10 @@ if(USE_ROCM)
   endif()
 endif()
 
+string(APPEND CMAKE_CUDA_FLAGS_DEBUG " -G")
+
 if(DEBUG_CUDA)
+  string(APPEND CMAKE_CUDA_FLAGS_DEBUG " -G")
   string(APPEND CMAKE_CUDA_FLAGS_DEBUG " -lineinfo")
   string(APPEND CMAKE_CUDA_FLAGS_RELWITHDEBINFO " -lineinfo")
   # CUDA-12.1 crashes when trying to compile with --source-in-ptx See
@@ -1243,6 +1246,20 @@ endif()
 if(USE_MIMALLOC AND USE_MIMALLOC_ON_MKL)
   add_definitions(-DUSE_MIMALLOC_ON_MKL)
 endif()
+
+include(FetchContent)
+
+FetchContent_Declare(
+            libdwarf-code
+            GIT_REPOSITORY https://github.com/davea42/libdwarf-code.git
+            GIT_TAG 623511122046fca0aefcfbd86f9e41338e95b083
+            CMAKE_ARGS -DBUILD_SHARED=YES -DBUILD_NON_SHARED=NO
+            EXCLUDE_FROM_ALL
+        )
+
+FetchContent_MakeAvailable(libdwarf-code)
+FetchContent_GetProperties(libdwarf-code)
+# Depend upon libdwarf::dwarf-shared
 
 # ---[ Main build
 add_subdirectory(c10)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -893,19 +893,19 @@ endif()
 # Uncoditionally generate debug info
 # string(APPEND CMAKE_CUDA_FLAGS "-v -keep --no-lineinfo-inlined-at --cicc-options '-g'")
 
-# string(APPEND CMAKE_CUDA_FLAGS_DEBUG " -G")
+string(APPEND CMAKE_CUDA_FLAGS " -G")
 
-# if(DEBUG_CUDA)
-#   string(APPEND CMAKE_CUDA_FLAGS_DEBUG " -G")
-#   string(APPEND CMAKE_CUDA_FLAGS_DEBUG " -lineinfo")
-#   string(APPEND CMAKE_CUDA_FLAGS_RELWITHDEBINFO " -lineinfo")
-#   # CUDA-12.1 crashes when trying to compile with --source-in-ptx See
-#   # https://github.com/pytorch/pytorch/issues/102372#issuecomment-1572526893
-#   if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 12.1)
-#     string(APPEND CMAKE_CUDA_FLAGS_DEBUG " --source-in-ptx")
-#     string(APPEND CMAKE_CUDA_FLAGS_RELWITHDEBINFO " --source-in-ptx")
-#   endif()
-# endif(DEBUG_CUDA)
+if(DEBUG_CUDA)
+  string(APPEND CMAKE_CUDA_FLAGS_DEBUG " -G")
+  string(APPEND CMAKE_CUDA_FLAGS_DEBUG " -lineinfo")
+  string(APPEND CMAKE_CUDA_FLAGS_RELWITHDEBINFO " -lineinfo")
+  # CUDA-12.1 crashes when trying to compile with --source-in-ptx See
+  # https://github.com/pytorch/pytorch/issues/102372#issuecomment-1572526893
+  if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 12.1)
+    string(APPEND CMAKE_CUDA_FLAGS_DEBUG " --source-in-ptx")
+    string(APPEND CMAKE_CUDA_FLAGS_RELWITHDEBINFO " --source-in-ptx")
+  endif()
+endif(DEBUG_CUDA)
 
 if(USE_FBGEMM)
   string(APPEND CMAKE_CXX_FLAGS " -DUSE_FBGEMM")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -893,7 +893,7 @@ endif()
 # Uncoditionally generate debug info
 # string(APPEND CMAKE_CUDA_FLAGS "-v -keep --no-lineinfo-inlined-at --cicc-options '-g'")
 
-string(APPEND CMAKE_CUDA_FLAGS " -G")
+# string(APPEND CMAKE_CUDA_FLAGS " -G")
 
 if(DEBUG_CUDA)
   string(APPEND CMAKE_CUDA_FLAGS_DEBUG " -G")

--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -1,15 +1,121 @@
+#include <ATen/Functions.h>
+#include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/CUDAGeneratorImpl.h>
 #include <ATen/cuda/CUDAGraph.h>
 #include <ATen/cuda/Exceptions.h>
-#include <ATen/Functions.h>
+#include <ATen/cuda/nvrtc_stub/ATenNVRTC.h>
+#include <c10/core/CPUAllocator.h>
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAFunctions.h>
 
 #include <cstddef>
 
+#include <dlfcn.h>
+
+#include "nv_decode.h"  // Assuming this header defines __cu_demangle.
+
+#include <GetTypeInformation.h>
+
 namespace at::cuda {
 
 static bool _cuda_graphs_debug = false;
+
+std::optional<std::tuple<size_t, size_t>>
+checkAllocationWithinGraph(void* ptr, const std::vector<DynamicGraphAllocation>& sorted_allocations) {
+  // since allocations is sorted in ptr order, we can search it in log time
+
+  // finds first allocation base address is greater than ptr. That seems pretty wrong to me...
+  auto it = std::upper_bound(sorted_allocations.begin(), sorted_allocations.end(), ptr, [](const void* p, const DynamicGraphAllocation& alloc) {
+    return p < alloc.ptr;
+  });
+  // upper_bound finds the first allocation whose ptr is strictly greater than our search
+  if (it == sorted_allocations.begin()) {
+    return std::nullopt; // the ptr is before our first allocation
+  }
+  // so we must decrement to get to the one we actually want
+  // okay, that works. Or does it? What if my allocation is not within one of my alloations?
+  --it;
+  // something seems wrong here...
+  void* begin = it->ptr;
+  void* end = (char*) begin + it->size;
+  if (ptr >= begin && ptr < end) {
+    size_t offset = (char*) ptr - (char*) begin;
+    return std::make_tuple(it->alloc_idx, offset);
+  }
+  return std::nullopt;
+}
+
+  std::vector<std::tuple<size_t, size_t, size_t>> gather_pointers_in_node(
+    const std::variant<BasicType, StructType, ArrayType>& type_info,
+    char *arg_buffer,
+    const std::vector<DynamicGraphAllocation>& sorted_allocations,
+    size_t global_offset_bytes) {
+  std::vector<std::tuple<size_t, size_t, size_t>> results;
+  std::visit([&results, global_offset_bytes, &sorted_allocations, &arg_buffer](auto&& arg) {
+    using T = std::decay_t<decltype(arg)>;
+    if constexpr (std::is_same_v<T, BasicType>) {
+      size_t offset = global_offset_bytes + arg.offset;
+      if (arg.is_pointer) {
+        TORCH_INTERNAL_ASSERT(offset % 8 == 0, "All pointers should be 8 byte aligned.");
+        if (auto result = checkAllocationWithinGraph(*((void**)(arg_buffer + offset)), sorted_allocations)) {
+          results.push_back({std::get<0>(*result), std::get<1>(*result), offset});
+        }
+      }
+    } else if constexpr (std::is_same_v<T, StructType>) {
+      size_t base_offset = global_offset_bytes + arg.offset;
+      for (auto&& [_, member]: arg.members) {
+        auto &&recursive_results = gather_pointers_in_node(member, arg_buffer, sorted_allocations, base_offset);
+        results.insert(results.end(), recursive_results.begin(), recursive_results.end());
+      }
+    } else if constexpr (std::is_same_v<T, ArrayType>) {
+      size_t element_size = std::visit([](auto&& element) -> size_t {
+        using ElementT = std::decay_t<decltype(element)>;
+        if constexpr (std::is_same_v<ElementT, BasicType>) {
+          return element.size;
+        } else if constexpr (std::is_same_v<ElementT, StructType>) {
+          return element.size;
+        }
+        return 0; // Should not happen
+      }, arg.element_type);
+
+      size_t base_offset = global_offset_bytes;
+
+      for (size_t i = 0; i < arg.num_elements; ++i) {
+        auto &&up_cast = std::visit(conversion_visitor, arg.element_type);
+        auto &&recursive_results = gather_pointers_in_node(up_cast, arg_buffer, sorted_allocations, base_offset);
+        results.insert(results.end(), recursive_results.begin(), recursive_results.end());
+        base_offset += element_size;
+      }
+    }
+  }, type_info);
+  return results;
+}
+
+
+
+std::string demangle(const std::string &mangled) {
+    size_t length = 0;
+    int status = 0;
+    char* output_buffer = nullptr;
+    
+    // Call the demangling function.
+    char* demangled = __cu_demangle(mangled.c_str(), output_buffer, &length, &status);
+    
+    // Check if demangling was successful.
+    if (status != 0 || demangled == nullptr) {
+        // In case of error, return the original mangled string.
+        return mangled;
+    }
+    
+    // Convert the demangled C-string into a std::string.
+    std::string result(demangled);
+    
+    // Free the memory allocated by __cu_demangle.
+    free(demangled);
+    
+    return result;
+}
+
 
 MempoolId_t graph_pool_handle() {
   // Sets just the second value, to distinguish it from MempoolId_ts created from
@@ -56,7 +162,7 @@ void CUDAGraph::register_generator_state(const at::Generator& generator) {
   cuda_gen->register_graph(this);
 }
 
-void CUDAGraph::capture_begin(MempoolId_t pool/*=0*/, cudaStreamCaptureMode capture_mode) {
+void CUDAGraph::capture_begin(MempoolId_t pool/*=0*/, cudaStreamCaptureMode capture_mode, bool dynamic_graph) {
   TORCH_CHECK(!has_graph_exec_,
               "This CUDAGraph instance already owns a captured graph. "
               "To capture a new graph, create a new instance.");
@@ -104,6 +210,8 @@ void CUDAGraph::capture_begin(MempoolId_t pool/*=0*/, cudaStreamCaptureMode capt
       AT_CUDA_CHECK(cudaStreamGetCaptureInfo(stream, &status, &stream_capture_id));
       return status == cudaStreamCaptureStatus::cudaStreamCaptureStatusActive && stream_capture_id == capture_id_;
   });
+
+  dynamic_graph_ = dynamic_graph;
 
   // cudaStreamCaptureModeGlobal is the most conservative option to
   // prevent potentially unsafe CUDA API calls during capture.  See
@@ -158,6 +266,12 @@ void CUDAGraph::instantiate() {
     TORCH_CHECK(keep_graph_, "instantiate() is intended to be called by the user only when keep_graph=true");
     AT_CUDA_CHECK(cudaGraphExecDestroy(graph_exec_));
   }
+
+  if (dynamic_graph_) {
+    // skip all instantiaton and such
+    return;
+  }
+
   // In typical graph usage some tensors (e.g. the tensors used for graph IO) are not freed
   // between replays.
   // If Pytorch compiles and runs with a CUDA 11.4+ toolkit, there's a chance the allocator backend
@@ -197,6 +311,7 @@ void CUDAGraph::instantiate() {
 void CUDAGraph::replay() {
   TORCH_CHECK(capture_ended_,
               "Called CUDAGraph::replay without a preceding successful capture.");
+  TORCH_CHECK(!dynamic_graph_, "Call replay_dynamic instead");
 
   if (!has_graph_exec_) {
     TORCH_INTERNAL_ASSERT(keep_graph_);
@@ -286,6 +401,12 @@ void CUDAGraph::reset() {
     C10_CUDA_CHECK_WARN(cudaGraphExecDestroy(graph_exec_));
     has_graph_exec_ = false;
   }
+  if (dynamic_graph_) {
+    allocations_.clear();
+    kernel_param_updates_.clear();
+    graph_node_param_updates_.clear();
+    dynamic_graph_ = false;
+  }
 }
 
 // Returns an id another graph's capture_begin can use to share the same memory pool as this graph.
@@ -315,4 +436,735 @@ CUDAGraph::~CUDAGraph() {
 #endif
 }
 
+void CUDAGraph::add_dynamic_update(const std::tuple<size_t, size_t, size_t>& result,
+                                   cudaGraphNode_t node,
+                                   size_t param_offset) {
+  auto [alloc_idx, offset, address_start] = result;
+  cudaKernelNodeAttrValue attr_value = {
+    .deviceUpdatableKernelNode = {
+      .deviceUpdatable = 1,
+      .devNode = nullptr,
+    }
+  };
+  AT_CUDA_CHECK(cudaGraphKernelNodeSetAttribute(
+      node,
+      cudaLaunchAttributeDeviceUpdatableKernelNode,
+      &attr_value));
+  TORCH_CHECK(attr_value.deviceUpdatableKernelNode.devNode != nullptr);
+
+  kernel_param_updates_.push_back({
+      .dev_node = attr_value.deviceUpdatableKernelNode.devNode,
+      .param_offset = param_offset + address_start,
+      .alloc_idx = alloc_idx,
+      .offset = offset,
+    });
+}
+
+// this does not use the pointer diffing approach. Not a big fan of that...
+void CUDAGraph::become_dynamic(const std::vector<at::Tensor>& dynamic_tensors) {
+  TORCH_CHECK(dynamic_graph_, "Graph must have been captured with dynamic_graph=True");
+  TORCH_CHECK(allocations_.empty(), "Must not have already called become_dynamic");
+  TORCH_CHECK(!dynamic_tensors.empty(), "Must have at least one dynamic tensor");
+  TORCH_CHECK(has_graph_, "Must have already captured");
+  TORCH_INTERNAL_ASSERT(!has_graph_exec_);
+
+  for (size_t i = 0; i < dynamic_tensors.size(); i++) {
+    const at::Tensor& tensor = dynamic_tensors[i];
+    // TODO: Reconsider this requirement
+    TORCH_CHECK(tensor.is_contiguous(), "Dynamic tensors must be contiguous");
+    allocations_.push_back(DynamicGraphAllocation{
+      .ptr = (char*) tensor.data_ptr(),
+      .size = tensor.nbytes(),
+      .alloc_idx = i, // record the original order, since the user will use that order again in replay_dynamic
+    });
+  }
+
+  std::vector<DynamicGraphAllocation> sorted_allocations = allocations_;
+  // copy since we're going to mess up allocation order, just for this function
+  // we will need to look up a bunch of pointers, and binary search can speed this up from linear to log time
+  // therefore:
+  std::sort(sorted_allocations.begin(), sorted_allocations.end(), [](auto& a, auto& b) {
+    return a.ptr < b.ptr;
+  });
+
+  for (size_t i = 1; i < sorted_allocations.size(); i++) {
+    auto prev = sorted_allocations[i - 1];
+    TORCH_CHECK(prev.ptr + prev.size <= sorted_allocations[i].ptr, "Dynamic tensors may not overlap");
+  }
+
+  size_t num_nodes;
+  AT_CUDA_CHECK(cudaGraphGetNodes(graph_, nullptr, &num_nodes));
+  std::vector<cudaGraphNode_t> nodes(num_nodes);
+  if (num_nodes != 0) {
+    // return cudaErrorInvalidValue if num_nodes is 0
+    AT_CUDA_CHECK(cudaGraphGetNodes(graph_, nodes.data(), &num_nodes));
+  }
+
+  for (size_t i = 0; i < num_nodes; ++i) {
+    cudaGraphNode_t node = nodes[i];
+
+    cudaGraphNodeType type;
+    AT_CUDA_CHECK(cudaGraphNodeGetType(node, &type));
+
+    if (type == cudaGraphNodeTypeKernel) {
+      CUDA_KERNEL_NODE_PARAMS driver_node_params;
+      AT_CUDA_DRIVER_CHECK(
+          globalContext().getNVRTC().cuGraphKernelNodeGetParams(
+              node, &driver_node_params));
+      // Runtime API has a problem with the triton kernels loaded by
+      // cuModuleLoadData.  It tries to convert the CUfunc to a void*
+      // by looking up the entrypoint that the driver API normally
+      // generates for a CUDA kernel. However, there is no such entry
+      // point for kernel loaded via the cuModuleLoad* APIs IIUC. We
+      // just convert back to a CUfunc/cudaFunction_t anyway, so using
+      // the driver API is fine here.
+
+      // cudaKernelNodeParams nodeParams;
+      // AT_CUDA_CHECK(cudaGraphKernelNodeGetParams(node, &nodeParams));
+      // AT_CUDA_CHECK(cudaGetFuncBySymbol(&func, nodeParams.func));
+
+      cudaFunction_t func = driver_node_params.func;
+
+      const char* func_name;
+      AT_CUDA_DRIVER_CHECK(
+          globalContext().getNVRTC().cuFuncGetName(&func_name, func));
+
+      TORCH_CHECK(
+          driver_node_params.kernelParams && !driver_node_params.extra,
+          "Kernel launches that use `extra` instead of `kernelParams` are not supported");
+
+      size_t param_offset;
+      size_t param_size;
+
+      ArgumentInformation type_info = get_argument_information(func);
+      for (size_t param_index = 0;
+           globalContext().getNVRTC().cuFuncGetParamInfo(func, param_index, &param_offset, &param_size) != CUDA_ERROR_INVALID_VALUE; param_index++) {
+        if (type_info.members.empty()) {
+          if (param_index == 0) {
+            TORCH_WARN("No type information for", func_name);
+          }
+          char** arg1_speculative_pointer =
+            (char**)driver_node_params.kernelParams[param_index];
+
+          // ABI guarantees that pointers have 8-byte alignment
+          for (size_t address_start = 0; param_size - address_start >= 8;
+               address_start += 8) {
+            char* arg1_value = arg1_speculative_pointer[address_start / 8];
+            if (auto result = checkAllocationWithinGraph(arg1_value, sorted_allocations)) {
+              auto [alloc_idx, offset] = *result;
+              std::cout << "LEIJURV: I have decided that " << address_start << " bytes into argument #" << param_index << " of kernel " <<
+                func_name << " is actually allocation " << alloc_idx <<
+                " with base address " << (void*) allocations_[alloc_idx].ptr << " and size " << allocations_[alloc_idx].size  <<
+                " indexed to offset " << offset << std::endl;
+
+              add_dynamic_update({std::get<0>(*result), std::get<1>(*result), address_start},
+                                 node, param_offset);
+            }
+          }
+        } else {
+          // check using type information
+          char* arg =
+            (char*)driver_node_params.kernelParams[param_index];
+
+          // is this empty for some reason?
+          std::vector<std::tuple<size_t, size_t, size_t>> results =
+            gather_pointers_in_node(type_info.members[param_index].second, arg, sorted_allocations, 0);
+
+          for (auto&& result: results) {
+            add_dynamic_update(result, node, param_offset);
+          }
+        }
+      }
+    } else if (type == cudaGraphNodeTypeMemcpy) {
+      cudaMemcpy3DParms memcpyParams1;
+      AT_CUDA_CHECK(cudaGraphMemcpyNodeGetParams(node, &memcpyParams1));
+      auto srcPtrResult = checkAllocationWithinGraph(memcpyParams1.srcPtr.ptr, sorted_allocations);
+      auto dstPtrResult = checkAllocationWithinGraph(memcpyParams1.dstPtr.ptr, sorted_allocations);
+      if (!srcPtrResult && !dstPtrResult) {
+        continue;
+      }
+      
+      graph_node_param_updates_.push_back({
+        .node = node,
+        .compute_new_params = [memcpyParams1, srcPtrResult, dstPtrResult](std::vector<void*> actualDataPtrs) {
+          cudaPitchedPtr srcPtr = memcpyParams1.srcPtr;
+          cudaPitchedPtr dstPtr = memcpyParams1.dstPtr;
+          if (srcPtrResult) {
+            auto [alloc_idx, offset] = *srcPtrResult;
+            srcPtr.ptr = (char*)actualDataPtrs[alloc_idx] + offset;
+          }
+          if (dstPtrResult) {
+            auto [alloc_idx, offset] = *dstPtrResult;
+            dstPtr.ptr = (char*)actualDataPtrs[alloc_idx] + offset;
+          }
+          return cudaGraphNodeParams{
+            .type = cudaGraphNodeTypeMemcpy,
+            .memcpy = {
+              .copyParams = {
+                .srcArray = memcpyParams1.srcArray,
+                .srcPos = memcpyParams1.srcPos,
+                .srcPtr = srcPtr,
+                .dstArray = memcpyParams1.dstArray,
+                .dstPos = memcpyParams1.dstPos,
+                .dstPtr = dstPtr,
+                .extent = memcpyParams1.extent,
+                .kind = memcpyParams1.kind
+              },
+            },
+          };
+        },
+      });
+    } else if (type == cudaGraphNodeTypeMemset) {
+      cudaMemsetParams memsetParams1;
+      AT_CUDA_CHECK(cudaGraphMemsetNodeGetParams(node, &memsetParams1));
+
+      auto dstPtrResult = checkAllocationWithinGraph(memsetParams1.dst, sorted_allocations);
+      if (!dstPtrResult) {
+        continue;
+      }
+      
+      graph_node_param_updates_.push_back({
+        .node = node,
+        .compute_new_params = [memsetParams1, dstPtrResult](std::vector<void*> actualDataPtrs) {
+          void* dstPtr = memsetParams1.dst;
+          if (dstPtrResult) {
+            auto [alloc_idx, offset] = *dstPtrResult;
+            dstPtr = (char*)actualDataPtrs[alloc_idx] + offset;
+          }
+          return cudaGraphNodeParams{
+            .type = cudaGraphNodeTypeMemset,
+            .memset = {
+              .dst = dstPtr,
+              .pitch = memsetParams1.pitch,
+              .value = memsetParams1.value,
+              .elementSize = memsetParams1.elementSize,
+              .width = memsetParams1.width,
+              .height = memsetParams1.height,
+            },
+          };
+        },
+      });
+    } else if (type == cudaGraphNodeTypeGraph || type == cudaGraphNodeTypeConditional) {
+      throw std::runtime_error("horrible. please don't make me support these.");
+      assert(false);
+    } else if (
+      type == cudaGraphNodeTypeEmpty ||
+      type == cudaGraphNodeTypeWaitEvent ||
+      type == cudaGraphNodeTypeHost ||
+      type == cudaGraphNodeTypeEventRecord ||
+      type == cudaGraphNodeTypeExtSemaphoreSignal ||
+      type == cudaGraphNodeTypeExtSemaphoreWait ||
+      type == cudaGraphNodeTypeMemAlloc ||
+      type == cudaGraphNodeTypeMemFree
+    ) {
+      // this is fine
+    } else {
+      throw std::runtime_error("graph node type unknown");
+      assert(false);
+    }
+  }
+  AT_CUDA_CHECK(cudaGraphInstantiate(&graph_exec_, graph_, 0));
+
+  // We must call cudaGraphUpload() to allocate memory for the
+  // updatable device nodes. Otherwise, cudaGraphLaunch will
+  // fail.
+
+  // From
+  // https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__GRAPH.html#group__CUDART__GRAPH_1ge546432e411b4495b93bdcbf2fc0b2bd:
+  // "[cudaGraphUpload] Uses memory cached by stream to back the allocations
+  // owned by graphExec."
+
+  // Normally, cudaGraphUpload() must be called on the stream for that
+  // will do cudaGraphLaunch(). However, here we can actually use any
+  // arbitrary stream (thus, the stream we caputred on works) for the
+  // memory backing device nodes. This differs from the usual case for
+  // graphs using memory allocation and free nodes. TODO: Figure out
+  // precisely why.
+
+  // Can this stream ever be deleted while still retain a reference to it?
+  // Yes, if an external stream is used. That is probably very rare.
+  // I suppose we know that torch streams will never be deallocated, so this is
+  // fine...
+  AT_CUDA_CHECK(cudaGraphUpload(graph_exec_, capture_stream_));
+  capture_stream_.synchronize();
+  has_graph_exec_ = true;
+}
+
+template<bool VOLTA_OR_LATER>
+void CUDAGraph::launch_dynamic_updaters(const std::vector<void*>& actualDataPtrs) {
+  using KernelUpdateSOA = KernelUpdateSOA<VOLTA_OR_LATER>;
+  static_assert(KernelUpdateSOA::MAX_NUM_UPDATES > 0);
+  static_assert(sizeof(KernelUpdateSOA) <= KernelUpdateSOA::KERNEL_PARAM_LIMIT_BYTES);
+  static_assert(sizeof(KernelUpdateSOA) + KernelUpdateSOA::PER_UPDATE > KernelUpdateSOA::KERNEL_PARAM_LIMIT_BYTES);
+
+  for (size_t off = 0; off < kernel_param_updates_.size(); off += KernelUpdateSOA::MAX_NUM_UPDATES) {
+    // (overwhelmingly likely that this loop only runs once)
+    size_t num_updates = std::min(KernelUpdateSOA::MAX_NUM_UPDATES, kernel_param_updates_.size() - off);
+    KernelUpdateSOA update_soa{
+      .num_updates = num_updates,
+    };
+    for (size_t i = 0; i < num_updates; i++) {
+      auto update = kernel_param_updates_[off + i];
+      update_soa.device_nodes[i] = update.dev_node;
+      update_soa.new_pointers[i] =
+          (char*)actualDataPtrs[update.alloc_idx] + update.offset;
+      update_soa.param_offsets[i] = update.param_offset;
+    }
+    dynamic_graph_updater<VOLTA_OR_LATER>(update_soa);
+  }
+}
+
+void CUDAGraph::replay_dynamic(const std::vector<at::Tensor>& dynamic_tensors) {
+  TORCH_CHECK(dynamic_graph_, "Must be a dynamic graph");
+  TORCH_CHECK(has_graph_exec_, "Called CUDAGraph::replay_dynamic without a preceding successful capture.");
+  TORCH_CHECK(!allocations_.empty(), "Must have already called become_dynamic");
+  TORCH_CHECK(dynamic_tensors.size() == allocations_.size(), "Must pass the same number of tensors as are dynamic");
+  c10::OptionalDeviceGuard device_guard{capture_stream_.device()};
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  // take the allocations that were requested during the capture, and allocate them "for real"
+  std::vector<void*> actualDataPtrs;
+  for (size_t i = 0; i < allocations_.size(); i++) {
+    TORCH_INTERNAL_ASSERT(allocations_[i].alloc_idx == i);
+    TORCH_CHECK(dynamic_tensors[i].is_contiguous(), "All tensors must be contiguous");
+    // TODO ^ this isn't quite right. really, the assert should be that the stride is the same as the original input arg.
+    TORCH_CHECK(dynamic_tensors[i].nbytes() == allocations_[i].size, "Prefilled tensors must be same shape");
+    actualDataPtrs.push_back(dynamic_tensors[i].data_ptr());
+  }
+
+  for (auto& update : graph_node_param_updates_) {
+    // run the updates that can't be done device-side
+    // note that this is quite rare - it only applies to a few misc memsets/memcpys
+    cudaGraphNodeParams newParams = update.compute_new_params(actualDataPtrs);
+    AT_CUDA_CHECK(cudaGraphExecNodeSetParams(graph_exec_, update.node, &newParams));
+  }
+
+  // do we need to cache this call somehow?
+  if (at::cuda::getCurrentDeviceProperties()->major >= 7) {
+    launch_dynamic_updaters<true>(actualDataPtrs);
+  } else {
+    launch_dynamic_updaters<false>(actualDataPtrs);
+  }
+
+  AT_CUDA_CHECK(cudaGraphLaunch(graph_exec_, stream));
+}
+
+bool dim3_equal(const dim3& a, const dim3& b) {
+  return a.x == b.x && a.y == b.y && a.z == b.z;
+}
+
+void check_differences(void *buf1, void *buf2, size_t n) {
+    // Cast the void pointers to unsigned char pointers for byte-wise access
+    unsigned char* a = static_cast<unsigned char*>(buf1);
+    unsigned char* b = static_cast<unsigned char*>(buf2);
+
+    size_t i = 0;
+    while (i < n) {
+        // If the current bytes differ, mark the start of a difference region.
+        if (a[i] != b[i]) {
+            size_t start = i;
+            // Continue advancing until we hit bytes that are the same or the end.
+            while (i < n && a[i] != b[i])
+                ++i;
+            // Print the region where differences were found in the [start, end) format.
+            std::cout << "GALVEZ wrong region: [" << start << ", " << i << ")\n";
+        } else {
+            ++i;
+        }
+    }
+}
+
+/**
+ * Check equality between two cudaMemsetParams structs
+ * @param a First cudaMemsetParams struct
+ * @param b Second cudaMemsetParams struct
+ * @return true if all members are equal, false otherwise
+ */
+bool is_equal(const cudaMemsetParams& a, const cudaMemsetParams& b) {
+    return a.dst == b.dst &&
+           a.pitch == b.pitch &&
+           a.value == b.value &&
+           a.elementSize == b.elementSize &&
+           a.width == b.width &&
+           a.height == b.height;
+}
+
+/**
+ * Check equality between two cudaMemcpy3DParms structs
+ * @param a First cudaMemcpy3DParms struct
+ * @param b Second cudaMemcpy3DParms struct
+ * @return true if all members are equal, false otherwise
+ */
+bool is_equal(const cudaMemcpy3DParms& a, const cudaMemcpy3DParms& b) {
+    // Compare array pointers
+    if (a.srcArray != b.srcArray || a.dstArray != b.dstArray)
+        return false;
+    
+    // Compare positions
+    if (a.srcPos.x != b.srcPos.x || a.srcPos.y != b.srcPos.y || a.srcPos.z != b.srcPos.z ||
+        a.dstPos.x != b.dstPos.x || a.dstPos.y != b.dstPos.y || a.dstPos.z != b.dstPos.z)
+        return false;
+    
+    // Compare pitched pointers
+    if (a.srcPtr.ptr != b.srcPtr.ptr || a.srcPtr.pitch != b.srcPtr.pitch ||
+        a.srcPtr.xsize != b.srcPtr.xsize || a.srcPtr.ysize != b.srcPtr.ysize ||
+        a.dstPtr.ptr != b.dstPtr.ptr || a.dstPtr.pitch != b.dstPtr.pitch ||
+        a.dstPtr.xsize != b.dstPtr.xsize || a.dstPtr.ysize != b.dstPtr.ysize)
+        return false;
+    
+    // Compare extent
+    if (a.extent.width != b.extent.width || a.extent.height != b.extent.height ||
+        a.extent.depth != b.extent.depth)
+        return false;
+    
+    // Compare kind
+    return a.kind == b.kind;
+}
+
+#include <iostream>
+#include <iomanip>   // for std::hex, std::setw, std::setfill
+#include <cstddef>   // for std::size_t
+
+// Prints the first n bytes starting at 'data' as a hex string (e.g. "0a1f2b...")
+void printHex(const void* data, std::size_t n) {
+    // Treat the data as a sequence of unsigned bytes
+    const unsigned char* bytes = static_cast<const unsigned char*>(data);
+    
+    // Set up cout for hex, two digits per byte, zero-padded
+    std::cout << std::hex << std::setfill('0');
+    
+    for (std::size_t i = 0; i < n; ++i) {
+        // Each byte is cast to an unsigned int so it's printed as a number,
+        // then setw(2) ensures two hex digits (e.g. 0a, ff, etc.)
+        std::cout << std::setw(2) << static_cast<unsigned int>(bytes[i]);
+    }
+    
+    // Go back to decimal for any further output
+    std::cout << std::dec;
+}
+
+
+bool graphs_equal(cudaGraph_t graph1, cudaGraph_t graph2) {
+  TORCH_CHECK(graph1 != graph2);
+
+  bool is_equal_var = true;
+  
+  size_t num_nodes1;
+  AT_CUDA_CHECK(cudaGraphGetNodes(graph1, nullptr, &num_nodes1));
+
+  size_t num_nodes2;
+  AT_CUDA_CHECK(cudaGraphGetNodes(graph2, nullptr, &num_nodes2));
+
+  if(num_nodes1 != num_nodes2) {
+    TORCH_WARN("graphs_equal: number of nodes mismatch: graph1 has ", num_nodes1,
+               " nodes, graph2 has ", num_nodes2, " nodes.");
+    return false;
+  }
+
+  std::vector<cudaGraphNode_t> nodes1(num_nodes1);
+  AT_CUDA_CHECK(cudaGraphGetNodes(graph1, nodes1.data(), &num_nodes1));
+
+  std::vector<cudaGraphNode_t> nodes2(num_nodes2);
+  AT_CUDA_CHECK(cudaGraphGetNodes(graph2, nodes2.data(), &num_nodes2));
+
+  std::size_t num_edges1, num_edges2;
+  AT_CUDA_CHECK(cudaGraphGetEdges(graph1, nullptr, nullptr, &num_edges1));
+  AT_CUDA_CHECK(cudaGraphGetEdges(graph2, nullptr, nullptr, &num_edges2));
+
+  if (num_edges1 != num_edges2) {
+    TORCH_WARN("graphs_equal: number of edges mismatch: graph1 has ", num_edges1,
+               " edges, graph2 has ", num_edges2, " edges.");
+    return false;
+  }
+
+  for (size_t i = 0; i < num_nodes1; ++i) {
+    cudaGraphNode_t node1 = nodes1[i];
+    cudaGraphNode_t node2 = nodes2[i];
+
+    cudaGraphNodeType type1, type2;
+    AT_CUDA_CHECK(cudaGraphNodeGetType(node1, &type1));
+    AT_CUDA_CHECK(cudaGraphNodeGetType(node2, &type2));
+    if (type1 != type2) {
+      TORCH_WARN("graphs_equal: Node type mismatch at index ", i,
+                 ": graph1 type = ", type1, ", graph2 type = ", type2);
+      return false;
+    }
+
+    if (type1 == cudaGraphNodeTypeKernel) {
+      cudaKernelNodeParams nodeParams1, nodeParams2;
+      AT_CUDA_CHECK(cudaGraphKernelNodeGetParams(node1, &nodeParams1));
+      AT_CUDA_CHECK(cudaGraphKernelNodeGetParams(node2, &nodeParams2));
+      if (nodeParams1.func != nodeParams2.func) {
+        TORCH_WARN("graphs_equal: Kernel function mismatch at node index ", i,
+                   ": graph1 function pointer = ", nodeParams1.func,
+                   ", graph2 function pointer = ", nodeParams2.func);
+        return false;
+      }
+      cudaFunction_t func1;
+      AT_CUDA_CHECK(cudaGetFuncBySymbol(&func1, nodeParams1.func));
+
+      const char* func_name;
+      globalContext().getNVRTC().cuFuncGetName(&func_name, func1);
+
+      std::cout << "GALVEZ: kernel name=" << func_name << std::endl;
+
+      if (!dim3_equal(nodeParams1.gridDim, nodeParams2.gridDim)) {
+        TORCH_WARN("graphs_equal: Kernel gridDim mismatch at node index ", i);
+        return false;
+      }
+      if (!dim3_equal(nodeParams1.blockDim, nodeParams2.blockDim)) {
+        TORCH_WARN("graphs_equal: Kernel blockDim mismatch at node index ", i);
+        return false;
+      }
+      if (nodeParams1.sharedMemBytes != nodeParams2.sharedMemBytes) {
+        TORCH_WARN("graphs_equal: Kernel shared memory bytes mismatch at node index ", i,
+                   ": graph1 sharedMemBytes = ", nodeParams1.sharedMemBytes,
+                   ", graph2 sharedMemBytes = ", nodeParams2.sharedMemBytes);
+        return false;
+      }
+
+      size_t param_offset;
+      size_t param_size;
+
+      ArgumentInformation type_info = get_argument_information(func1);
+      for (size_t param_index = 0;
+           globalContext().getNVRTC().cuFuncGetParamInfo(func1, param_index, &param_offset, &param_size) != CUDA_ERROR_INVALID_VALUE; param_index++) {
+
+        if (type_info.members.empty()) {
+          if (param_index == 0) {
+            TORCH_WARN("No type information for", func_name);
+          }
+          if (std::memcmp(nodeParams1.kernelParams[param_index],
+                          nodeParams2.kernelParams[param_index],
+                          param_size) != 0) {
+            TORCH_WARN("graphs_equal: Kernel parameter mismatch at node index ", i,
+                       ", parameter index ", param_index, " for function ", func_name);
+            check_differences(nodeParams1.kernelParams[param_index], nodeParams2.kernelParams[param_index], param_size);
+            is_equal_var = false;
+            // return false;
+          }
+        } else {
+          // TORCH_INTERNAL_ASSERT(type_info.at(func_name).size() == 1);
+          if (!is_equal(nodeParams1.kernelParams[param_index],
+                        nodeParams2.kernelParams[param_index],
+                        type_info.members[param_index].second)) {
+
+            // TODO: Double check whether we have a void * "data" field.
+            TORCH_WARN("graphs_equal: Have type information, but Kernel parameter mismatch at node index ", i,
+                       ", parameter index ", param_index, " for function ", func_name);
+            // check_differences(nodeParams1.kernelParams[param_index], nodeParams2.kernelParams[param_index], param_size);
+            // std::vector<ArgumentInformation> type_info_dup = get_argument_information(func1);
+            TORCH_WARN("type info");
+            prettyPrintArgumentInfo(type_info);
+            TORCH_WARN("end type info");
+            is_equal_var = false;
+
+
+            std::cout << "First argument" << std::endl;
+            printHex(nodeParams1.kernelParams[param_index], param_size);
+            std::cout << std::endl;
+            std::cout << "Second argument" << std::endl;
+            printHex(nodeParams2.kernelParams[param_index], param_size);
+            std::cout << std::endl;
+            // return false;
+          }
+        }
+      }
+    } else if (type1 == cudaGraphNodeTypeMemcpy) {
+      cudaMemcpy3DParms nodeParams1, nodeParams2;
+      // todo make an llm write the rest of these equality
+      // comparisons. Does C++ generate == implementations? I don't
+      // think so. Correct, it doesn't.
+      AT_CUDA_CHECK(cudaGraphMemcpyNodeGetParams(node1, &nodeParams1));
+      AT_CUDA_CHECK(cudaGraphMemcpyNodeGetParams(node2, &nodeParams2));
+      if (!is_equal(nodeParams1, nodeParams2)) {
+        return false;
+      }
+    } else if (type1 == cudaGraphNodeTypeMemset) {
+      cudaMemsetParams nodeParams1, nodeParams2;
+      AT_CUDA_CHECK(cudaGraphMemsetNodeGetParams(node1, &nodeParams1));
+      AT_CUDA_CHECK(cudaGraphMemsetNodeGetParams(node2, &nodeParams2));
+      if (!is_equal(nodeParams1, nodeParams2)) {
+        return false;
+      }
+    } else if (type1 == cudaGraphNodeTypeHost) {
+      // This one is tricky. We don't know how to interpret the void*
+      // userArgs field. We can check that the function is the
+      // same... But we won't be able to, say, mutate any fields
+      // inside of this. How can we handle this one? It is sensible to
+      // see how nccl creates its host nodes, since that is the one
+      // case that pytorch cares about right now...
+      
+      // We know for a fact that nccl always passes the type
+      // ncclKernelPlan as its single argument
+    } else if (type1 == cudaGraphNodeTypeGraph) {
+      // Do recursion, but this case does not exist in pytorch at this time.
+      TORCH_INTERNAL_ASSERT(false, "Unexpected node type");
+      // return graphs_equal();
+    } else if (type1 == cudaGraphNodeTypeWaitEvent) {
+      // External events are not used yet in pytorch. The challenge
+      // with it is that we unfortunately cannot assume that both
+      // events are the same. This is a bit funky, since presumably
+      // external events are intended to be passed to other functions,
+      // which will either record or wait on this event. I definitely
+      // need to consider this situation carefully.
+      TORCH_INTERNAL_ASSERT(false, "Unexpected node type");
+    } else {
+      TORCH_INTERNAL_ASSERT(false, "Unexpected node type");
+    }
+  }
+  // return true;
+  return is_equal_var;
+}
+
+// bool  CUDAGraph::get_differences(cudaGraph_t graph1, cudaGraph_t graph2,
+//                              const std::vector<at::Tensor>& dynamic_tensors1,
+//                              const std::vector<at::Tensor>& dynamic_tensors2) {
+//   TORCH_CHECK(dynamic_tensors1.size() == dynamic_tensors2.size());
+//   TORCH_CHECK(graph1 != graph2);
+
+//   // fill in kernel_param_updates_ and graph_node_param_updates_
+  
+//   size_t num_nodes1;
+//   AT_CUDA_CHECK(cudaGraphGetNodes(graph1, nullptr, &num_nodes1));
+
+//   size_t num_nodes2;
+//   AT_CUDA_CHECK(cudaGraphGetNodes(graph2, nullptr, &num_nodes2));
+
+//   if(num_nodes1 != num_nodes2) {
+//     return false;
+//   }
+
+//   std::vector<cudaGraphNode_t> nodes1(num_nodes1);
+//   AT_CUDA_CHECK(cudaGraphGetNodes(graph1, nodes1.data(), &num_nodes1));
+
+//   std::vector<cudaGraphNode_t> nodes2(num_nodes2);
+//   AT_CUDA_CHECK(cudaGraphGetNodes(graph2, nodes2.data(), &num_nodes2));
+
+//   std::size_t num_edges1, num_edges2;
+//   AT_CUDA_CHECK(cudaGraphGetEdges(graph1, nullptr, nullptr, &num_edges1));
+//   AT_CUDA_CHECK(cudaGraphGetEdges(graph2, nullptr, nullptr, &num_edges2));
+
+//   if (num_edges1 != num_edges2) {
+//     return false;
+//   }
+
+//   for (size_t i = 0; i < num_nodes1; ++i) {
+//     cudaGraphNode_t node1 = nodes1[i];
+//     cudaGraphNode_t node2 = nodes2[i];
+
+//     cudaGraphNodeType type1, type2;
+//     AT_CUDA_CHECK(cudaGraphNodeGetType(node1, &type1));
+//     AT_CUDA_CHECK(cudaGraphNodeGetType(node2, &type2));
+//     if (type1 != type2) {
+//       return false;
+//     }
+
+//     if (type1 == cudaGraphNodeTypeKernel) {
+//       cudaKernelNodeParams nodeParams1, nodeParams2;
+//       AT_CUDA_CHECK(cudaGraphKernelNodeGetParams(node1, &nodeParams1));
+//       AT_CUDA_CHECK(cudaGraphKernelNodeGetParams(node2, &nodeParams2));
+//       if (nodeParams1.func != nodeParams2.func) {
+//         return false;
+//       }
+//       cudaFunction_t func1;
+//       AT_CUDA_CHECK(cudaGetFuncBySymbol(&func1, nodeParams1.func));
+
+//       const char* func_name;
+//       globalContext().getNVRTC().cuFuncGetName(&func_name, func1);
+
+//       std::cout << "GALVEZ: kernel name=" << func_name << std::endl;
+
+//       if (!dim3_equal(nodeParams1.gridDim, nodeParams2.gridDim)) {
+//         return false;
+//       }
+//       if (!dim3_equal(nodeParams1.blockDim, nodeParams2.blockDim)) {
+//         return false;
+//       }
+//       if (nodeParams1.sharedMemBytes != nodeParams2.sharedMemBytes) {
+//         return false;
+//       }
+
+//       std::cout << "GALVEZ:" << ((float*)nodeParams1.kernelParams[2]) << " " << ((float*)nodeParams1.kernelParams[2] + 1) << std::endl;
+//       std::cout << "GALVEZ:" << ((float*)nodeParams2.kernelParams[2]) << " " << ((float*)nodeParams2.kernelParams[2] + 1) << std::endl;
+
+//       size_t param_offset;
+//       size_t param_size;
+//       for (size_t param_index = 0;
+//            globalContext().getNVRTC().cuFuncGetParamInfo(func1, param_index, &param_offset, &param_size) != CUDA_ERROR_INVALID_VALUE; param_index++) {
+//         std::cout << "GALVEZ:" << param_index << " " << param_offset << " " << param_size << std::endl;
+
+//         if (std::memcmp(nodeParams1.kernelParams[param_index], nodeParams2.kernelParams[param_index], param_size) != 0) {
+//           return false;
+//         }
+//       }
+//     } else if (type1 == cudaGraphNodeTypeMemcpy) {
+//       cudaMemcpyNodeParams nodeParams1, nodeParams2;
+//       // todo make an llm write the rest of these equality
+//       // comparisons. Does C++ generate == implementations? I don't
+//       // think so. Correct, it doesn't.
+//     } else if (type1 == cudaGraphNodeTypeMemset) {
+      
+//     } else if (type1 == cudaGraphNodeTypeHost) {
+//       // This one is tricky. We don't know how to interpret the void*
+//       // userArgs field. We can check that the function is the
+//       // same... But we won't be able to, say, mutate any fields
+//       // inside of this. How can we handle this one? It is sensible to
+//       // see how nccl creates its host nodes, since that is the one
+//       // case that pytorch cares about right now...
+      
+//       // We know for a fact that nccl always passes the type
+//       // ncclKernelPlan as its single argument
+//     } else if (type1 == cudaGraphNodeTypeGraph) {
+//       // Do recursion, but this case does not exist in pytorch at this time.
+//       TORCH_INTERNAL_ASSERT(false, "Unexpected node type");
+//       // return graphs_equal();
+//     } else if (type1 == cudaGraphNodeTypeWaitEvent) {
+//       // External events are not used yet in pytorch. The challenge
+//       // with it is that we unfortunately cannot assume that both
+//       // events are the same. This is a bit funky, since presumably
+//       // external events are intended to be passed to other functions,
+//       // which will either record or wait on this event. I definitely
+//       // need to consider this situation carefully.
+//       TORCH_INTERNAL_ASSERT(false, "Unexpected node type");
+//     } else {
+//       TORCH_INTERNAL_ASSERT(false, "Unexpected node type");
+//     }
+//   }
+//   return true;
+// }
+
+
+bool operator==(const CUDAGraph& left, const CUDAGraph& right) {
+    return graphs_equal(left.graph_, right.graph_);
+  }
+
+bool operator!=(const CUDAGraph& left, const CUDAGraph& right) {
+    return !(left == right);
+  }
+
+
 } // namespace at::cuda
+
+// __nv_hdl_wrapper_t(const __nv_hdl_wrapper_t &in) : f1(in.f1) ,f2(in.f2) ,f3(in.f3) , data(__nv_hdl_helper<Tag, OpFuncR, OpFuncArgs...>::fp_copier(in.data)) { }
+// this explains things. Basically, my field f3 is not taking 8 bytes. It has 4 bytesof padding. So many padding problems...
+
+// typename __nv_lambda_field_type<F1>::type f1;
+// typename __nv_lambda_field_type<F2>::type f2;
+// typename __nv_lambda_field_type<F3>::type f3;
+// typename __nv_lambda_field_type<F4>::type f4;
+
+//  typedef OpFuncR(__opfunc_t)(OpFuncArgs...);
+//  void *data;
+
+// I believe that the void *data holds a pointer to the lambda itself. But I'm not certain.
+
+
+// *** Dumping AST Record Layout
+//          0 | struct __nv_hdl_wrapper_t<false, false, false, struct __nv_dl_tag<void (*)(struct at::TensorIteratorBase &, class c10::Scalar, class c10::Scalar, enum at::native::detail::ClampLimits), &at::native::_GLOBAL__N__485385bc_16_TensorCompare_cu_71e06f4e::launch_clamp_scalar, 1>, long (long), enum at::native::detail::ClampLimits, long, long>
+//          0 |   typename __nv_lambda_field_type<enum ClampLimits>::type f1
+//          8 |   typename __nv_lambda_field_type<long>::type f2
+//         16 |   typename __nv_lambda_field_type<long>::type f3
+//         24 |   void * data
+//            | [sizeof=32, dsize=32, align=8,
+//            |  nvsize=32, nvalign=8]

--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -689,6 +689,7 @@ void CUDAGraph::become_dynamic(const std::vector<std::pair<void*, size_t>>& dyna
         }
       }
     } else if (type == cudaGraphNodeTypeMemcpy) {
+      TORCH_INTERNAL_ASSERT(false, "memcpy nodes should have been removed");
       cudaMemcpy3DParms memcpyParams1;
       AT_CUDA_CHECK(cudaGraphMemcpyNodeGetParams(node, &memcpyParams1));
 
@@ -759,6 +760,7 @@ void CUDAGraph::become_dynamic(const std::vector<std::pair<void*, size_t>>& dyna
         }
       }
     } else if (type == cudaGraphNodeTypeMemset) {
+      TORCH_INTERNAL_ASSERT(false, "memcpy nodes should have been removed");
       cudaMemsetParams memsetParams1;
       AT_CUDA_CHECK(cudaGraphMemsetNodeGetParams(node, &memsetParams1));
 
@@ -766,7 +768,7 @@ void CUDAGraph::become_dynamic(const std::vector<std::pair<void*, size_t>>& dyna
       if (!dstPtrResult) {
         continue;
       }
-      
+
       graph_node_param_updates_.push_back({
         .node = node,
         .compute_new_params = [memsetParams1, dstPtrResult](std::vector<void*> actualDataPtrs) {
@@ -1326,13 +1328,6 @@ bool operator==(const CUDAGraph& left, const CUDAGraph& right) {
 bool operator!=(const CUDAGraph& left, const CUDAGraph& right) {
     return !(left == right);
   }
-
-void cumem_handle_deleter(cudaStream_t* stream) {
-  if (stream != nullptr) {
-    AT_CUDA_CHECK(cudaStreamDestroy(*stream));
-    delete stream;
-  }
-}
 
   // my invariants:
   

--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -689,7 +689,7 @@ void CUDAGraph::become_dynamic(const std::vector<std::pair<void*, size_t>>& dyna
         }
       }
     } else if (type == cudaGraphNodeTypeMemcpy) {
-      TORCH_INTERNAL_ASSERT(false, "memcpy nodes should have been removed");
+      // TORCH_INTERNAL_ASSERT(false, "memcpy nodes should have been removed");
       cudaMemcpy3DParms memcpyParams1;
       AT_CUDA_CHECK(cudaGraphMemcpyNodeGetParams(node, &memcpyParams1));
 
@@ -760,7 +760,7 @@ void CUDAGraph::become_dynamic(const std::vector<std::pair<void*, size_t>>& dyna
         }
       }
     } else if (type == cudaGraphNodeTypeMemset) {
-      TORCH_INTERNAL_ASSERT(false, "memcpy nodes should have been removed");
+      // TORCH_INTERNAL_ASSERT(false, "memset nodes should have been removed");
       cudaMemsetParams memsetParams1;
       AT_CUDA_CHECK(cudaGraphMemsetNodeGetParams(node, &memsetParams1));
 
@@ -1357,7 +1357,7 @@ public:
 };
 
 void* DynamicCUDAGraphMemoryAllocator::cudagraph_malloc(size_t size, int device, cudaStream_t stream) {
-  std::cout << "GALVEZ:cudagraph_malloc" << std::endl;
+  // std::cout << "GALVEZ:cudagraph_malloc" << std::endl;
   at::cuda::OptionalCUDAGuard gpuGuard(device);
 
     static MemHandleHolder handleHolder;
@@ -1402,7 +1402,7 @@ void* DynamicCUDAGraphMemoryAllocator::cudagraph_malloc(size_t size, int device,
 
     AT_CUDA_CHECK(cudaPointerGetAttributes(&attributes, ptr));
 
-    std::cout << "GALVEZ: cudaPointerGetAttributes device pointer " << attributes.devicePointer << " host pointer " << attributes.hostPointer << std::endl;
+    // std::cout << "GALVEZ: cudaPointerGetAttributes device pointer " << attributes.devicePointer << " host pointer " << attributes.hostPointer << std::endl;
 
     graph_->unbacked_memory.emplace_back(CUDAGraph::AllocationMetadata{ptr, size});
     return ptr;
@@ -1410,7 +1410,7 @@ void* DynamicCUDAGraphMemoryAllocator::cudagraph_malloc(size_t size, int device,
 
 void DynamicCUDAGraphMemoryAllocator::cudagraph_free(void *ptr, size_t size, int device, cudaStream_t stream) {
   // I should really get a backtrace here to see what is causing this.
-  std::cout << "GALVEZ:cudagraph_free" << std::endl;
+  // std::cout << "GALVEZ:cudagraph_free" << std::endl;
   at::cuda::OptionalCUDAGuard gpuGuard(device);
 
   cudaStreamCaptureStatus status{};

--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -865,7 +865,8 @@ void CUDAGraph::replay_dynamic(const std::vector<at::Tensor>& dynamic_tensors) {
     actualDataPtrs.push_back(dynamic_tensors[i].data_ptr());
     std::cout << "GALVEZ: replacing [" << (uintptr_t)allocations_[i].ptr << ", " << (uintptr_t)allocations_[i].ptr + allocations_[i].size <<
       ") with [" << (uintptr_t)dynamic_tensors[i].data_ptr() << ", " << (uintptr_t)dynamic_tensors[i].data_ptr() + dynamic_tensors[i].nbytes() << ")" << std::endl;
-    TORCH_CHECK(dynamic_tensors[i].nbytes() == allocations_[i].size, "Prefilled tensors must be same shape");
+    // nbytes is not actually the size of an allocation. It is the size of its view.
+    // TORCH_CHECK(dynamic_tensors[i].nbytes() == allocations_[i].size, "Prefilled tensors must be same shape");
   }
 
   // TODO: Do we need to synchronize before doing this?

--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -934,7 +934,11 @@ void check_differences(void *buf1, void *buf2, size_t n) {
             while (i < n && a[i] != b[i])
                 ++i;
             // Print the region where differences were found in the [start, end) format.
-            std::cout << "GALVEZ wrong region: [" << start << ", " << i << ")\n";
+            if (i - start < 4) {
+
+            } else {
+              std::cout << "GALVEZ wrong region: [" << start << ", " << i << ")" << std::endl;
+            }
         } else {
             ++i;
         }
@@ -1072,7 +1076,7 @@ bool graphs_equal(cudaGraph_t graph1, cudaGraph_t graph2, bool topological_and_n
       const char* func_name2;
       globalContext().getNVRTC().cuFuncGetName(&func_name2, nodeParams2.func);
 
-      // std::cout << "GALVEZ: kernel name=" << func_name << std::endl;
+      std::cout << "GALVEZ: kernel name=" << func_name << std::endl;
 
       if (nodeParams1.func != nodeParams2.func) {
         TORCH_WARN("graphs_equal: Kernel function mismatch at node index ", i,
@@ -1133,6 +1137,8 @@ bool graphs_equal(cudaGraph_t graph1, cudaGraph_t graph2, bool topological_and_n
           if (!is_equal(nodeParams1.kernelParams[param_index],
                         nodeParams2.kernelParams[param_index],
                         type_info.members[param_index].second)) {
+
+            std::cout << "graphs_equal: Have type information, but Kernel parameter mismatch at node index " <<  i << "parameter index "<<param_index<<" for function "<<func_name << std::endl;
 
             // TODO: Double check whether we have a void * "data" field.
             TORCH_WARN("graphs_equal: Have type information, but Kernel parameter mismatch at node index ", i,
@@ -1394,7 +1400,7 @@ void* DynamicCUDAGraphMemoryAllocator::cudagraph_malloc(size_t size, int device,
 
 void DynamicCUDAGraphMemoryAllocator::cudagraph_free(void *ptr, size_t size, int device, cudaStream_t stream) {
   // I should really get a backtrace here to see what is causing this.
-  // std::cout << "GALVEZ:cudagraph_free" << std::endl;
+  std::cout << "GALVEZ:cudagraph_free" << std::endl;
   at::cuda::OptionalCUDAGuard gpuGuard(device);
 
   cudaStreamCaptureStatus status{};
@@ -1498,6 +1504,9 @@ void CUDAGraph::become_dynamic(const std::vector<std::pair<void*, size_t>>& dyna
           if (bool(graph1_result) && bool(graph2_result)) {
             add_dynamic_update({std::get<0>(*graph1_result), std::get<1>(*graph1_result), address_start},
                                node, param_offset);
+            std::cout << "GALVEZ: allocation1: [" << (void*)allocations_[std::get<0>(*graph1_result)].ptr << ", " << (void*)(allocations_[std::get<0>(*graph1_result)].ptr + allocations_[std::get<0>(*graph1_result)].size) << ")" << ", value1: " << (void*) arg1_value << std::endl;
+            std::cout << "GALVEZ: allocation2: [" << (void*)graph2->allocations_[std::get<0>(*graph2_result)].ptr << ", " << (void*)(graph2->allocations_[std::get<0>(*graph2_result)].ptr + graph2->allocations_[std::get<0>(*graph2_result)].size) << ")" << ", value2: " << (void*) arg2_value << std::endl;
+            // std::cout << "GALVEZ: allocation2: [" <<  << ", " << << ")" << std::endl;
           } else if (bool(graph1_result) || bool(graph2_result)) {
             std::cout << "GALVEZ: filtered out a false positive at param_index=" << param_index << " offset=" << address_start << " for potential address=" << (void*) arg1_value << std::endl;
           }

--- a/aten/src/ATen/cuda/CUDAGraph.cu
+++ b/aten/src/ATen/cuda/CUDAGraph.cu
@@ -1,0 +1,60 @@
+#include <ATen/cuda/CUDAGraph.h>
+
+namespace at::cuda {
+
+// the best way to speed this up would be to minimize the number of
+// global memory stalls.  We can pass three arrays: nodes, offsets,
+// and pValues, to avoid filling in the other fields.  Right now,
+// dynamic_graph_updater_kernel kernel takes about 5.0 microseconds on
+// average, but dynamic_graph_updater_kernel2 takes about 2.8
+// microseconds on average. There might be other potential speed ups,
+// but this is pretty good.
+template <size_t BLOCK_SIZE, bool VOLTA_OR_LATER>
+__global__ void __launch_bounds__(BLOCK_SIZE) dynamic_graph_updater_kernel(
+    __grid_constant__ const KernelUpdateSOA<VOLTA_OR_LATER> update_soa) {
+  __shared__ const void* pointer_indirection[BLOCK_SIZE];
+  __shared__ alignas(cudaGraphKernelNodeUpdate) char
+      shared_updates_wrong_type[BLOCK_SIZE * sizeof(cudaGraphKernelNodeUpdate)];
+  cudaGraphKernelNodeUpdate* shared_updates =
+      (cudaGraphKernelNodeUpdate*)shared_updates_wrong_type;
+
+  // for (size_t i = threadIdx.x + blockIdx.x * blockDim.x; i <
+  // update_soa.num_updates; i += gridDim.x * blockDim.x) {
+  size_t i = threadIdx.x + blockIdx.x * blockDim.x;
+  if (i < update_soa.num_updates) {
+    pointer_indirection[threadIdx.x] = update_soa.new_pointers[i];
+    shared_updates[threadIdx.x] = cudaGraphKernelNodeUpdate{
+        .node = update_soa.device_nodes[i],
+        .field = cudaGraphKernelNodeFieldParam,
+        .updateData = {
+            .param = {
+                .pValue = &pointer_indirection[threadIdx.x],
+                .offset = update_soa.param_offsets[i],
+                .size = sizeof(void*),
+            },
+        },
+    };
+
+    cudaError_t error =
+        cudaGraphKernelNodeUpdatesApply(&shared_updates[threadIdx.x], 1);
+    CUDA_KERNEL_ASSERT_MSG(
+        error == cudaSuccess,
+        "cudaGraphKernelNodeUpdatesApply did not succeed");
+  }
+}
+
+template<bool VOLTA_OR_LATER>
+void dynamic_graph_updater(const KernelUpdateSOA<VOLTA_OR_LATER>& update_soa) {
+  constexpr size_t BLOCK_SIZE = std::min<size_t>(64, KernelUpdateSOA<VOLTA_OR_LATER>::MAX_NUM_UPDATES);
+  dynamic_graph_updater_kernel<BLOCK_SIZE, VOLTA_OR_LATER>
+      <<<(update_soa.num_updates + BLOCK_SIZE - 1) / BLOCK_SIZE,
+         BLOCK_SIZE,
+         0,
+         getCurrentCUDAStream()>>>(update_soa);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+template void dynamic_graph_updater(const KernelUpdateSOA<false>& update_soa);
+template void dynamic_graph_updater(const KernelUpdateSOA<true>& update_soa);
+
+} // namespace at::cuda

--- a/aten/src/ATen/cuda/CUDAGraph.h
+++ b/aten/src/ATen/cuda/CUDAGraph.h
@@ -91,6 +91,7 @@ struct TORCH_CUDA_CPP_API CUDAGraph {
 
   TORCH_CUDA_CPP_API friend bool operator==(const CUDAGraph& left, const CUDAGraph& right);
   TORCH_CUDA_CPP_API friend bool operator!=(const CUDAGraph& left, const CUDAGraph& right);
+  static std::shared_ptr<c10::Allocator> get_mem_allocator();
 
  protected:
   void add_dynamic_update(const std::tuple<size_t, size_t, size_t>& result, cudaGraphNode_t node, size_t param_offset);

--- a/aten/src/ATen/cuda/CUDAGraph.h
+++ b/aten/src/ATen/cuda/CUDAGraph.h
@@ -179,6 +179,8 @@ struct TORCH_CUDA_CPP_API CUDAGraph {
 
   friend class DynamicCUDAGraphMemoryAllocator;
 
+  std::vector<std::pair<void *, size_t>> unbacked_memory_;
+
   std::unique_ptr<DynamicCUDAGraphMemoryAllocator> allocator_;
   std::shared_ptr<c10::cuda::CUDACachingAllocator::CUDAAllocator> pluggable_allocator_;
 };

--- a/aten/src/ATen/cuda/CUDAGraph.h
+++ b/aten/src/ATen/cuda/CUDAGraph.h
@@ -105,12 +105,14 @@ struct TORCH_CUDA_CPP_API CUDAGraph {
   void debug_dump(const std::string& debug_path);
   cudaGraph_t raw_cuda_graph();
   void become_dynamic(const std::vector<std::pair<void*, size_t>>& dynamic_tensors);
+  void become_dynamic(const std::vector<std::pair<void*, size_t>>& dynamic_tensors, CUDAGraph* graph2, const std::vector<std::pair<void*, size_t>>& graph2_dynamic_tensors);
   void replay_dynamic(const std::vector<at::Tensor>& dynamic_tensors);
 
   TORCH_CUDA_CPP_API friend bool operator==(const CUDAGraph& left, const CUDAGraph& right);
   TORCH_CUDA_CPP_API friend bool operator!=(const CUDAGraph& left, const CUDAGraph& right);
   std::shared_ptr<c10::Allocator> get_mem_allocator();
-  void release_physical_memory();
+ private:
+ std::vector<DynamicGraphAllocation> create_and_sort_allocations(const std::vector<std::pair<void*, size_t>>& dynamic_tensors);
 
  protected:
   void add_dynamic_update(const std::tuple<size_t, size_t, size_t>& result, cudaGraphNode_t node, size_t param_offset);

--- a/aten/src/ATen/cuda/CUDAGraph.h
+++ b/aten/src/ATen/cuda/CUDAGraph.h
@@ -6,6 +6,11 @@
 #include <c10/cuda/CUDAStream.h>
 #include <c10/util/flat_hash_map.h>
 
+// Forward declare just so we can have a shared_ptr member.
+namespace c10::cuda::CUDACachingAllocator {
+  struct CUDAAllocator;
+}
+
 namespace at {
 
 struct Generator;
@@ -172,28 +177,10 @@ struct TORCH_CUDA_CPP_API CUDAGraph {
 
   bool keep_graph_;
 
-  struct AllocationMetadata {
-    void *ptr;
-    size_t size;
-  };
-
-  // need the CUDAGraph * to be able to iterate over the pointers that
-  // it allocated.
-
-  // static ska::flat_hash_map<CUDAGraph*, AllocationMetadata> temporary_memory_pointers;
-  // these pointers do not have backing physical memory yet
-  // once we create backing physical memory (in instantiate()), remove
-  // them from this data structure
-  std::vector<AllocationMetadata> unbacked_memory;
-  // TODO: We need to split unbacked_memory into both temporaries and
-  // outputs. How?
-
-  // Map a pointer to its corresponding CUDAGraph. But why?
-  static ska::flat_hash_map<void*, CUDAGraph*> memory_pointer_to_graph;
-
   friend class DynamicCUDAGraphMemoryAllocator;
 
   std::unique_ptr<DynamicCUDAGraphMemoryAllocator> allocator_;
+  std::shared_ptr<c10::cuda::CUDACachingAllocator::CUDAAllocator> pluggable_allocator_;
 };
 
 } // namespace cuda

--- a/aten/src/ATen/cuda/GetTypeInformation.cpp
+++ b/aten/src/ATen/cuda/GetTypeInformation.cpp
@@ -1,0 +1,1136 @@
+#include <iostream>
+#include <string>
+#include <functional>
+#include <optional>
+#include <memory>
+#include <variant>
+#include <fcntl.h>
+#include <unistd.h>
+#include <cstring>
+#include <cassert>
+#include <iomanip>
+#include <sstream>
+
+#include <dwarf.h>
+#include <libdwarf.h>
+
+#include <link.h>
+
+#include "GetTypeInformation.h"
+
+#include <ATen/Functions.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/CUDAGeneratorImpl.h>
+#include <ATen/cuda/CUDAGraph.h>
+#include <ATen/cuda/Exceptions.h>
+#include <ATen/cuda/nvrtc_stub/ATenNVRTC.h>
+#include <c10/core/CPUAllocator.h>
+#include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/cuda/CUDAFunctions.h>
+
+#include <etbl_private.h>
+
+#include <iostream>
+#include <fstream>
+
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <sys/syscall.h>
+
+#ifndef MFD_CLOEXEC
+#define MFD_CLOEXEC 0x0001U
+#endif
+
+// memfd_create wrapper for systems where it isn't in glibc yet
+int memfd_create(const char *name, unsigned int flags) {
+    return syscall(SYS_memfd_create, name, flags);
+}
+
+Dwarf_Die get_type_follow_typedefs(Dwarf_Debug dbg, Dwarf_Die typeDie) {
+  Dwarf_Half typeTag;
+  Dwarf_Error error;
+  if (dwarf_tag(typeDie, &typeTag, &error) != DW_DLV_OK) {
+    std::cerr << "GALVEZ: error!" << std::endl;
+    return nullptr; // Return original die on error
+  }
+
+  if (typeTag == DW_TAG_typedef) {
+    // Follow the typedef to its underlying type
+    Dwarf_Attribute typeAttr;
+    int res = dwarf_attr(typeDie, DW_AT_type, &typeAttr, &error);
+    if (res == DW_DLV_OK) {
+      Dwarf_Off typeOffset;
+      Dwarf_Bool is_info;
+      Dwarf_Die typeDieTmp;
+      
+      if (dwarf_global_formref(typeAttr, &typeOffset, &error) == DW_DLV_OK) {
+        is_info = dwarf_get_die_infotypes_flag(typeDie);
+        
+        if (dwarf_offdie_b(dbg, typeOffset, 
+                         is_info, &typeDieTmp, &error) == DW_DLV_OK) {
+          // Clean up before recursion
+          dwarf_dealloc_attribute(typeAttr);
+
+          // maybe typeDieTmp does not have a CU context when obtained via dwarf_offdie_b?
+          
+          // Recursively follow the typedef
+          Dwarf_Die result = get_type_follow_typedefs(dbg, typeDieTmp);
+          // is this dealloc correct? Yes.
+          // dwarf_dealloc_die(typeDieTmp);
+          return result;
+        }
+      }
+      dwarf_dealloc_attribute(typeAttr);
+    }
+  }
+  return typeDie; // Return when we've found a non-typedef
+}
+
+// Function declarations
+bool findFunctionWithLinkageName(Dwarf_Debug dbg, Dwarf_Die cu_die, 
+                               const char* linkageName,
+                               ArgumentInformation& result);
+void extractFunctionArguments(Dwarf_Debug dbg, Dwarf_Die function_die, 
+                           ArgumentInformation& result);
+void processType(Dwarf_Debug dbg, Dwarf_Die type_die, 
+              std::variant<BasicType, StructType, ArrayType>& member);
+void processBasicType(Dwarf_Debug dbg, Dwarf_Die type_die, 
+                      std::variant<BasicType, StructType, ArrayType>& member);
+void processStructType(Dwarf_Debug dbg, Dwarf_Die struct_die,
+                    std::variant<BasicType, StructType, ArrayType>& member);
+void processArrayType(Dwarf_Debug dbg, Dwarf_Die array_die, 
+                   std::variant<BasicType, StructType, ArrayType>& member);
+int dwarf_attr_string(Dwarf_Die die, Dwarf_Half attr_code, char** result, Dwarf_Error* error);
+
+ArgumentInformation
+getArgumentInformation(const char* linkageName, void *buffer, size_t buffer_size) {
+    int fd = memfd_create("galvezanonymous", MFD_CLOEXEC);
+    if (fd == -1) {
+      perror("memfd_create");
+      free(buffer);
+      exit(EXIT_FAILURE);
+    }
+
+    if (ftruncate(fd, buffer_size) == -1) {
+      perror("ftruncate");
+      free(buffer);
+      close(fd);
+      exit(EXIT_FAILURE);
+    }
+
+    void* mapped = mmap(NULL, buffer_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (mapped == MAP_FAILED) {
+        perror("mmap");
+        free(buffer);
+        close(fd);
+        exit(EXIT_FAILURE);
+    }
+
+    memcpy(mapped, buffer, buffer_size);
+
+    // std::ofstream outFile("my_elf_files/"+ std::string(linkageName) + ".elf", std::ios::binary);
+    // if (!outFile) {
+    //     std::cerr << "Failed to open file: " << linkageName << std::endl;
+    //     abort();
+    // }
+    // outFile.write(static_cast<const char*>(mapped), buffer_size);
+    // outFile.close();
+
+    // Result vector to return
+    ArgumentInformation result;
+    
+    // Variables for error handling
+    Dwarf_Error error = nullptr;
+    int res = DW_DLV_ERROR;
+    
+    // Open the DWARF debug info
+    Dwarf_Debug dbg = nullptr;
+
+    res = dwarf_init_b(fd, DW_GROUPNUMBER_ANY, nullptr, nullptr, &dbg, &error);
+    // res = dwarf_init_path(elfPath.c_str(), nullptr, 0, 
+    //                      DW_GROUPNUMBER_ANY, nullptr, nullptr, &dbg, &error);
+    if (res != DW_DLV_OK) {
+        if (res == DW_DLV_ERROR) {
+            dwarf_dealloc_error(dbg, error);
+        }
+        return result; // Empty result
+    }
+    
+    // Iterate through compilation units
+    Dwarf_Unsigned next_cu_offset;
+
+
+    bool ran_twice = false;
+
+    while (true) {
+        Dwarf_Die cu_die = nullptr;
+        Dwarf_Unsigned cu_header_length = 0;
+        Dwarf_Half version_stamp = 0;
+        Dwarf_Unsigned abbrev_offset = 0;
+        Dwarf_Half address_size = 0;
+        Dwarf_Half length_size = 0;
+        Dwarf_Half extension_size = 0;
+        Dwarf_Unsigned next_cu_header_offset = 0;
+        Dwarf_Half cu_type = 0;
+
+        // std::cout << "GALVEZ: while(true)" << std::endl;
+
+        // Get next CU
+        res = dwarf_next_cu_header_e(dbg, true, &cu_die, 
+            &cu_header_length, &version_stamp, &abbrev_offset, &address_size,
+            &length_size, &extension_size, nullptr, nullptr, &next_cu_header_offset,
+            &cu_type, &error);
+            
+        if (res != DW_DLV_OK) {
+            std::cout << "GALVEZ: no more CUs" << std::endl;
+            break; // No more CUs or error
+        }
+
+        if (ran_twice) {
+          std::cout << "GALVEZ: ran twice!!!" << std::endl;
+          abort();
+        }
+        
+        // Find function DIE with the specified linkage name
+        bool found = findFunctionWithLinkageName(dbg, cu_die, linkageName, result);
+        
+        // Clean up the CU DIE
+        dwarf_dealloc_die(cu_die);
+
+        if (found) {
+          break;
+        }
+        
+        // Move to the next CU
+        next_cu_offset = next_cu_header_offset;
+
+        ran_twice = true;
+    }
+    
+    // Clean up DWARF debug info
+    dwarf_finish(dbg);
+
+    std::cout << "GALVEZ: getArgumentInformation() done" << std::endl;
+
+    // if (result.empty()) {
+    //   std::cout << "GALVEZ: failed to get information of kernel was empty:" << std::endl;
+    // }
+    
+    return result;
+}
+
+ArgumentInformation
+getArgumentInformation(const char* linkageName, const std::string& elfPath) {
+    // Result vector to return
+    ArgumentInformation result;
+    
+    // Variables for error handling
+    Dwarf_Error error = nullptr;
+    int res = DW_DLV_ERROR;
+    
+    // Open the DWARF debug info
+    Dwarf_Debug dbg = nullptr;
+    res = dwarf_init_path(elfPath.c_str(), nullptr, 0, 
+                         DW_GROUPNUMBER_ANY, nullptr, nullptr, &dbg, &error);
+    if (res != DW_DLV_OK) {
+        if (res == DW_DLV_ERROR) {
+            dwarf_dealloc_error(dbg, error);
+        }
+        return result; // Empty result
+    }
+    
+    // Iterate through compilation units
+    Dwarf_Unsigned next_cu_offset;
+    while (true) {
+        Dwarf_Die cu_die = nullptr;
+        Dwarf_Unsigned cu_header_length = 0;
+        Dwarf_Half version_stamp = 0;
+        Dwarf_Unsigned abbrev_offset = 0;
+        Dwarf_Half address_size = 0;
+        Dwarf_Half length_size = 0;
+        Dwarf_Half extension_size = 0;
+        Dwarf_Unsigned next_cu_header_offset = 0;
+        Dwarf_Half cu_type = 0;
+        
+        // Get next CU
+        res = dwarf_next_cu_header_e(dbg, true, &cu_die, 
+            &cu_header_length, &version_stamp, &abbrev_offset, &address_size,
+            &length_size, &extension_size, nullptr, nullptr, &next_cu_header_offset,
+            &cu_type, &error);
+            
+        if (res != DW_DLV_OK) {
+            break; // No more CUs or error
+        }
+        
+        // Find function DIE with the specified linkage name
+        findFunctionWithLinkageName(dbg, cu_die, linkageName, result);
+        
+        // Clean up the CU DIE
+        dwarf_dealloc_die(cu_die);
+        
+        // Move to the next CU
+        next_cu_offset = next_cu_header_offset;
+    }
+    
+    // Clean up DWARF debug info
+    dwarf_finish(dbg);
+    
+    return result;
+}
+
+// Helper function to find a function with the specified linkage name
+bool findFunctionWithLinkageName(Dwarf_Debug dbg, Dwarf_Die cu_die, 
+                                const char* linkageName,
+                                ArgumentInformation& result) {
+    if (!cu_die) {
+      std::cout << "GALVEZ: cu_die is empty" << std::endl;
+        return false;
+    }
+    
+    // Get the first child of the CU DIE
+    Dwarf_Die child = nullptr;
+    Dwarf_Error error = nullptr;
+    int res = dwarf_child(cu_die, &child, &error);
+    if (res != DW_DLV_OK) {
+      // std::cout << "GALVEZ: no child" << std::endl;
+        return false;
+    }
+    
+    // Iterate through siblings
+    Dwarf_Die current_die = child;
+    while (current_die) {
+      // std::cout << "GALVEZ: current_die" << std::endl;
+        // Check if this is a subprogram (function) DIE
+        Dwarf_Half tag = 0;
+        res = dwarf_tag(current_die, &tag, &error);
+        if (res == DW_DLV_OK && tag == DW_TAG_subprogram) {
+            // Check for DW_AT_linkage_name attribute
+            char* name_str = nullptr;
+            res = dwarf_attr_string(current_die, DW_AT_linkage_name, &name_str, &error);
+            if (res != DW_DLV_OK) {
+                // Try DW_AT_MIPS_linkage_name as fallback
+                res = dwarf_attr_string(current_die, DW_AT_MIPS_linkage_name, &name_str, &error);
+            }
+
+            
+            // Check if it matches our target linkage name
+            if (res == DW_DLV_OK && name_str && strcmp(name_str, linkageName) == 0) {
+              std::cout << "GALVEZ: found linkage_name=" << name_str << std::endl;
+              // Found the function, extract its arguments
+                extractFunctionArguments(dbg, current_die, result);
+                return true; // We found the function, no need to continue
+            }
+        }
+        
+        // Recursively search in children
+        if (findFunctionWithLinkageName(dbg, current_die, linkageName, result)) {
+          return true;
+        }
+        
+        // Move to next sibling
+        Dwarf_Die sibling_die = nullptr;
+        res = dwarf_siblingof_c(current_die, &sibling_die, &error);
+        if (res != DW_DLV_OK) {
+            break;
+        }
+        
+        // Free current DIE and move to sibling
+        dwarf_dealloc_die(current_die);
+        current_die = sibling_die;
+    }
+    return false;
+}
+
+// Helper to extract function parameter information from a function DIE
+void extractFunctionArguments(Dwarf_Debug dbg, Dwarf_Die function_die, 
+                              ArgumentInformation& result) {
+    Dwarf_Error error = nullptr;
+    int res = DW_DLV_ERROR;
+    
+    // Get the first child of the function DIE (parameters are children)
+    Dwarf_Die child = nullptr;
+    res = dwarf_child(function_die, &child, &error);
+    if (res != DW_DLV_OK) {
+        return;
+    }
+    
+    // Iterate through the function DIE's children
+    Dwarf_Die current_die = child;
+    while (current_die) {
+        // Check if this is a formal parameter DIE
+        Dwarf_Half tag = 0;
+        res = dwarf_tag(current_die, &tag, &error);
+        if (res == DW_DLV_OK && tag == DW_TAG_formal_parameter) {
+            // This is a function parameter, extract its information
+            // Get parameter name
+            char* name_str = nullptr;
+            res = dwarf_attr_string(current_die, DW_AT_name, &name_str, &error);
+            if (res != DW_DLV_OK && name_str) {
+                // argInfo.name = std::string(name_str);
+            }
+            
+            result.members.emplace_back(std::string(name_str), std::variant<BasicType, StructType, ArrayType>());
+            // Get parameter type
+            Dwarf_Attribute type_attr = nullptr;
+            res = dwarf_attr(current_die, DW_AT_type, &type_attr, &error);
+            if (res == DW_DLV_OK) {
+                // Get DIE offset from the type attribute
+                Dwarf_Off type_offset = 0;
+                Dwarf_Bool is_info = 0;
+                res = dwarf_global_formref_b(type_attr, &type_offset, &is_info, &error);
+                if (res == DW_DLV_OK) {
+                    // Get the type DIE
+                    Dwarf_Die type_die = nullptr;
+                    res = dwarf_offdie_b(dbg, type_offset, is_info, &type_die, &error);
+                    if (res == DW_DLV_OK) {
+                        // Process the type
+                      processType(dbg, type_die, result.members.back().second);
+                        dwarf_dealloc_die(type_die);
+                    }
+                }
+                dwarf_dealloc_attribute(type_attr);
+            }
+            
+            // Add the parameter information to the result
+            // result.push_back(std::move(argInfo));
+        }
+        
+        // Move to next sibling
+        Dwarf_Die sibling_die = nullptr;
+        res = dwarf_siblingof_c(current_die, &sibling_die, &error);
+        if (res != DW_DLV_OK) {
+            break;
+        }
+        
+        // Free current DIE and move to sibling
+        dwarf_dealloc_die(current_die);
+        current_die = sibling_die;
+    }
+}
+
+// Helper function to extract type information
+void processType(Dwarf_Debug dbg, Dwarf_Die type_die, 
+                 std::variant<BasicType, StructType, ArrayType>& member) {
+    // Follow typedefs to get the actual type
+    Dwarf_Die actual_type_die = get_type_follow_typedefs(dbg, type_die);
+    if (!actual_type_die) {
+        return;
+    }
+    
+    Dwarf_Error error = nullptr;
+    int res = DW_DLV_ERROR;
+    
+    // Get the tag of the type
+    Dwarf_Half tag = 0;
+    res = dwarf_tag(actual_type_die, &tag, &error);
+    if (res != DW_DLV_OK) {
+        return;
+    }
+    
+    // Process based on the type of DIE
+    switch (tag) {
+        case DW_TAG_base_type:
+        case DW_TAG_pointer_type:
+        case DW_TAG_reference_type:
+            processBasicType(dbg, actual_type_die, member);
+            break;
+            
+        case DW_TAG_structure_type:
+        case DW_TAG_class_type:
+        case DW_TAG_union_type:
+            processStructType(dbg, actual_type_die, member);
+            break;
+            
+        case DW_TAG_array_type:
+            processArrayType(dbg, actual_type_die, member);
+            break;
+            
+        default:
+            // For other types, we'll just treat them as basic types
+            processBasicType(dbg, actual_type_die, member);
+            break;
+    }
+    
+    // Clean up if we've made a copy of the DIE
+    if (actual_type_die != type_die) {
+        dwarf_dealloc_die(actual_type_die);
+    }
+}
+
+// Process a basic type or pointer/reference
+void processBasicType(Dwarf_Debug dbg, Dwarf_Die type_die, 
+                     std::variant<BasicType, StructType, ArrayType>& member) {
+    Dwarf_Error error = nullptr;
+    BasicType basicType;
+    
+    // Check if it's a pointer or reference
+    Dwarf_Half tag = 0;
+    int res = dwarf_tag(type_die, &tag, &error);
+    // TODO: I'm not sure that it is correct to call this a pointer
+    // type if it's a reference type...
+    basicType.is_pointer = (tag == DW_TAG_pointer_type || tag == DW_TAG_reference_type);
+
+    // Get type name
+    char* name_str = nullptr;
+    res = dwarf_attr_string(type_die, DW_AT_name, &name_str, &error);
+    if (res == DW_DLV_OK && name_str) {
+        basicType.type_name = std::string(name_str);
+    } else if (tag == DW_TAG_pointer_type || tag == DW_TAG_reference_type) {
+        // int res = dwarf_attr(type_die, DW_AT_type, &typeAttr, &error);
+        // if (dwarf_global_formref(typeAttr, &typeOffset, &error) == DW_DLV_OK) {
+        //   bool is_info = dwarf_get_die_infotypes_flag(typeDie);
+        //   if (dwarf_offdie_b(dbg, typeOffset, 
+        //                      is_info, &typeDieTmp, &error) == DW_DLV_OK) {
+        //     get_type_follow_typedefs(dbg, typeDieTmp);
+        //     res = dwarf_attr_string(type_die, DW_AT_name, &name_str, &error);
+        //     type_die
+        //   }
+        // }
+        basicType.type_name =  "*";
+    } else {
+        basicType.type_name = "unnamed_type";
+    }
+    
+    // Get byte size
+    Dwarf_Unsigned size = 0;
+    res = dwarf_bytesize(type_die, &size, &error);
+    if (res == DW_DLV_OK) {
+        basicType.size = size;
+    } else if(res != DW_DLV_OK && basicType.is_pointer) {
+        // clang does not generate size information for pointers for whatever reason.
+        basicType.size = 8;
+    } else {
+        basicType.size = 0;
+    }
+    
+    // Get the offset (member position)
+    basicType.offset = 0; // Default to 0 for standalone types
+    
+    // Add to the members list
+    member = basicType;
+}
+
+// Process a struct/class/union type
+void processStructType(Dwarf_Debug dbg, Dwarf_Die struct_die, 
+                      std::variant<BasicType, StructType, ArrayType>& member) {
+    Dwarf_Error error = nullptr;
+    StructType structType;
+    
+    // Get struct name
+    char* name_str = nullptr;
+    int res = dwarf_attr_string(struct_die, DW_AT_name, &name_str, &error);
+    if (res == DW_DLV_OK && name_str) {
+        structType.type_name = std::string(name_str);
+    } else {
+        structType.type_name = "unnamed_struct";
+    }
+
+
+    Dwarf_Unsigned size;
+    res = dwarf_bytesize(struct_die, &size, &error);
+    TORCH_INTERNAL_ASSERT(res == DW_DLV_OK, "Must have a size for structs");
+    structType.size = size;
+    
+    // Initialize members vector
+    // structType.members = std::vector<std::variant<BasicType, StructType, ArrayType>>();
+    
+    // Process struct members
+    Dwarf_Die child = nullptr;
+    res = dwarf_child(struct_die, &child, &error);
+    if (res == DW_DLV_OK) {
+        Dwarf_Die current_die = child;
+        while (current_die) {
+            // Check if this is a member
+            Dwarf_Half tag = 0;
+            res = dwarf_tag(current_die, &tag, &error);
+            if (res == DW_DLV_OK && tag == DW_TAG_member) {
+                // Get member type
+                Dwarf_Attribute type_attr = nullptr;
+                res = dwarf_attr(current_die, DW_AT_type, &type_attr, &error);
+                if (res == DW_DLV_OK) {
+                    // Get DIE offset from the type attribute
+                    Dwarf_Off type_offset = 0;
+                    Dwarf_Bool is_info = 0;
+                    res = dwarf_global_formref_b(type_attr, &type_offset, &is_info, &error);
+                    if (res == DW_DLV_OK) {
+                        // Get the type DIE
+                        Dwarf_Die type_die = nullptr;
+                        res = dwarf_offdie_b(dbg, type_offset, is_info, &type_die, &error);
+                        if (res == DW_DLV_OK) {
+                            // Get data member offset
+                            Dwarf_Unsigned member_offset = 0;
+                            Dwarf_Attribute offset_attr = nullptr;
+                            res = dwarf_attr(current_die, DW_AT_data_member_location, &offset_attr, &error);
+                            if (res == DW_DLV_OK) {
+                                // The attribute could be either a constant or an exprloc
+                                Dwarf_Half form = 0;
+                                res = dwarf_whatform(offset_attr, &form, &error);
+                                if (res == DW_DLV_OK) {
+                                    if (form == DW_FORM_data1 || form == DW_FORM_data2 || 
+                                        form == DW_FORM_data4 || form == DW_FORM_data8 ||
+                                        form == DW_FORM_udata) {
+                                        // It's a constant
+                                        Dwarf_Unsigned offset_val = 0;
+                                        res = dwarf_formudata(offset_attr, &offset_val, &error);
+                                        if (res == DW_DLV_OK) {
+                                            member_offset = offset_val;
+                                        }
+                                    } else if (form == DW_FORM_exprloc || form == DW_FORM_block1 ||
+                                              form == DW_FORM_block2 || form == DW_FORM_block4) {
+                                        // It's a location expression
+                                        Dwarf_Loc_Head_c loc_head = nullptr;
+                                        Dwarf_Unsigned loc_count = 0;
+                                        res = dwarf_get_loclist_c(offset_attr, &loc_head, &loc_count, &error);
+                                        if (res == DW_DLV_OK && loc_count > 0) {
+                                            // Process the first location description
+                                            Dwarf_Small lle_value = 0;
+                                            Dwarf_Unsigned raw_lowpc = 0, raw_highpc = 0;
+                                            Dwarf_Bool debug_addr_unavailable = false;
+                                            Dwarf_Addr lowpc = 0, highpc = 0;
+                                            Dwarf_Unsigned loc_expr_op_count = 0;
+                                            Dwarf_Locdesc_c locdesc = nullptr;
+                                            Dwarf_Small loclist_source = 0;
+                                            Dwarf_Unsigned expr_offset = 0, locdesc_offset = 0;
+                                            
+                                            res = dwarf_get_locdesc_entry_d(loc_head, 0,
+                                                &lle_value, &raw_lowpc, &raw_highpc,
+                                                &debug_addr_unavailable, &lowpc, &highpc,
+                                                &loc_expr_op_count, &locdesc,
+                                                &loclist_source, &expr_offset, &locdesc_offset,
+                                                &error);
+                                                
+                                            if (res == DW_DLV_OK && loc_expr_op_count > 0) {
+                                                // Check if the expression is a simple constant
+                                                Dwarf_Small op = 0;
+                                                Dwarf_Unsigned op1 = 0, op2 = 0, op3 = 0, offset_for_branch = 0;
+                                                
+                                                res = dwarf_get_location_op_value_c(locdesc, 0,
+                                                    &op, &op1, &op2, &op3, &offset_for_branch, &error);
+                                                    
+                                                if (res == DW_DLV_OK && op == DW_OP_plus_uconst) {
+                                                    member_offset = op1;
+                                                }
+                                            }
+                                            dwarf_dealloc_loc_head_c(loc_head);
+                                        }
+                                    }
+                                }
+                                dwarf_dealloc_attribute(offset_attr);
+                            }
+                            
+                            // Now process the member type, but we need to create a vector for its members
+                            std::variant<BasicType, StructType, ArrayType> member_data;
+                            processType(dbg, type_die, member_data);
+                            
+                            // Update the offset of the first member based on the location
+                            std::visit([member_offset](auto&& arg) {
+                              using T = std::decay_t<decltype(arg)>;
+                              if constexpr (std::is_same_v<T, BasicType>) {
+                                arg.offset = member_offset;
+                              } else if constexpr (std::is_same_v<T, StructType>) {
+                                arg.offset = member_offset;
+                              } else if constexpr (std::is_same_v<T, ArrayType>) {
+                                arg.offset = member_offset;
+                              }
+                            }, member_data);
+
+
+                            std::string member_name;
+                            res = dwarf_attr_string(current_die, DW_AT_name, &name_str, &error);
+                            if (res == DW_DLV_OK) {
+                              member_name = name_str;
+                            } else {
+                              member_name = "Could not get member name";
+                            }
+                            
+                            // Add all the member data to the struct
+                            structType.members.emplace_back(member_name, member_data);
+                            
+                            dwarf_dealloc_die(type_die);
+                        }
+                    }
+                    dwarf_dealloc_attribute(type_attr);
+                }
+            }
+            
+            // Move to next sibling
+            Dwarf_Die sibling_die = nullptr;
+            res = dwarf_siblingof_c(current_die, &sibling_die, &error);
+            if (res != DW_DLV_OK) {
+                break;
+            }
+            
+            // Free current DIE and move to sibling
+            dwarf_dealloc_die(current_die);
+            current_die = sibling_die;
+        }
+    }
+    
+    // Add the struct to the members list
+    member = structType;
+}
+
+
+using In  = std::variant<BasicType, StructType, ArrayType>;
+using Out = std::variant<BasicType, StructType>;
+
+// helper for overloaded lambdas
+template<class... Fs> struct overloaded : Fs... { using Fs::operator()...; };
+template<class... Fs> overloaded(Fs...) -> overloaded<Fs...>;
+
+Out filter(In const& in) {
+    return std::visit(overloaded {
+        // BasicType  → keep as-is
+        [](BasicType const& b) -> Out { 
+            return b; 
+        },
+        // StructType → keep as-is
+        [](StructType const& s) -> Out { 
+            return s; 
+        },
+        // ArrayType  → error
+        [](ArrayType const&) -> Out { 
+            throw std::runtime_error("ArrayType not allowed here"); 
+        }
+    }, in);
+}
+
+// Process an array type
+void processArrayType(Dwarf_Debug dbg, Dwarf_Die array_die, 
+                     std::variant<BasicType, StructType, ArrayType>& member) {
+    Dwarf_Error error = nullptr;
+    ArrayType arrayType;
+    
+    arrayType.type_name = "array";
+    arrayType.num_elements = 0;
+    
+    // Get the element type
+    Dwarf_Attribute type_attr = nullptr;
+    int res = dwarf_attr(array_die, DW_AT_type, &type_attr, &error);
+    if (res == DW_DLV_OK) {
+        // Get DIE offset from the type attribute
+        Dwarf_Off type_offset = 0;
+        Dwarf_Bool is_info = 0;
+        res = dwarf_global_formref_b(type_attr, &type_offset, &is_info, &error);
+        if (res == DW_DLV_OK) {
+            // Get the type DIE
+            Dwarf_Die type_die = nullptr;
+            res = dwarf_offdie_b(dbg, type_offset, is_info, &type_die, &error);
+            if (res == DW_DLV_OK) {
+                // We need to create a vector for the element type
+                std::variant<BasicType, StructType, ArrayType> element_data;
+                processType(dbg, type_die, element_data);
+
+                arrayType.element_type = filter(element_data);
+                
+                dwarf_dealloc_die(type_die);
+            }
+        }
+        dwarf_dealloc_attribute(type_attr);
+    }
+    
+    // Try to get the array size
+    Dwarf_Die child = nullptr;
+    res = dwarf_child(array_die, &child, &error);
+    if (res == DW_DLV_OK) {
+        Dwarf_Die current_die = child;
+        while (current_die) {
+            // Check if this is a subrange type
+            Dwarf_Half tag = 0;
+            res = dwarf_tag(current_die, &tag, &error);
+            if (res == DW_DLV_OK && tag == DW_TAG_subrange_type) {
+                // Get the upper bound or count
+                Dwarf_Attribute count_attr = nullptr;
+                res = dwarf_attr(current_die, DW_AT_count, &count_attr, &error);
+                if (res == DW_DLV_OK) {
+                    Dwarf_Unsigned count = 0;
+                    res = dwarf_formudata(count_attr, &count, &error);
+                    if (res == DW_DLV_OK) {
+                        arrayType.num_elements = count;
+                    }
+                    dwarf_dealloc_attribute(count_attr);
+                } else {
+                    // Try upper bound
+                    Dwarf_Attribute upper_attr = nullptr;
+                    res = dwarf_attr(current_die, DW_AT_upper_bound, &upper_attr, &error);
+                    if (res == DW_DLV_OK) {
+                        Dwarf_Unsigned upper = 0;
+                        res = dwarf_formudata(upper_attr, &upper, &error);
+                        if (res == DW_DLV_OK) {
+                            // Array size is upper bound + 1
+                            arrayType.num_elements = upper + 1;
+                        }
+                        dwarf_dealloc_attribute(upper_attr);
+                    }
+                }
+            }
+            
+            // Move to next sibling
+            Dwarf_Die sibling_die = nullptr;
+            res = dwarf_siblingof_c(current_die, &sibling_die, &error);
+            if (res != DW_DLV_OK) {
+                break;
+            }
+            
+            // Free current DIE and move to sibling
+            dwarf_dealloc_die(current_die);
+            current_die = sibling_die;
+        }
+    }
+    
+    // Add the array to the members list
+    member = arrayType;
+}
+
+// Helper function to get a stringified value from an attribute
+int dwarf_attr_string(Dwarf_Die die, Dwarf_Half attr_code, char** result, Dwarf_Error* error) {
+    Dwarf_Attribute attr = nullptr;
+    int res = dwarf_attr(die, attr_code, &attr, error);
+    if (res != DW_DLV_OK) {
+        return res;
+    }
+    
+    res = dwarf_formstring(attr, result, error);
+    dwarf_dealloc_attribute(attr);
+    return res;
+}
+
+// Forward declarations for the print operators
+std::ostream& operator<<(std::ostream& os, const BasicType& bt);
+std::ostream& operator<<(std::ostream& os, const StructType& st);
+std::ostream& operator<<(std::ostream& os, const ArrayType& at);
+
+// Helper function to print indentation
+inline std::string indent(int level) {
+    return std::string(level * 2, ' ');
+}
+
+// Generic visitor for std::variant printing
+struct VariantPrinter {
+    std::ostream& os;
+    int indent_level;
+    
+    VariantPrinter(std::ostream& os, int indent_level) : os(os), indent_level(indent_level) {}
+    
+    void operator()(const BasicType& bt) const {
+        os << bt;
+    }
+    
+    void operator()(const StructType& st) const {
+        os << st;
+    }
+    
+    void operator()(const ArrayType& at) const {
+        os << at;
+    }
+};
+
+// Print operator for BasicType
+std::ostream& operator<<(std::ostream& os, const BasicType& bt) {
+    os << "BasicType { ";
+    os << "type_name: \"" << bt.type_name << "\", ";
+    os << "offset: " << bt.offset << ", ";
+    os << "size: " << bt.size << ", ";
+    os << "is_pointer: " << (bt.is_pointer ? "true" : "false");
+    os << " }";
+    return os;
+}
+
+// Print operator for StructType
+std::ostream& operator<<(std::ostream& os, const StructType& st) {
+    os << "StructType { type_name: \"" << st.type_name << "\"";
+    
+    if (!st.members.empty()) {
+        os << ", members: [\n";
+        
+        for (size_t i = 0; i < st.members.size(); ++i) {
+            os << indent(1) << st.members[i].first << ": ";
+            
+            // Use a new VariantPrinter with increased indent level
+            std::visit([&os, i](const auto& value) {
+                os << value;
+            }, st.members[i].second);
+            
+            if (i < st.members.size() - 1) {
+                os << ",";
+            }
+            os << "\n";
+        }
+        
+        os << "  ]";
+    } else {
+        os << ", members: []";
+    }
+    
+    os << " }";
+    return os;
+}
+
+// Print operator for ArrayType
+std::ostream& operator<<(std::ostream& os, const ArrayType& at) {
+    os << "ArrayType { ";
+    os << "type_name: \"" << at.type_name << "\", ";
+    os << "num_elements: " << at.num_elements;
+    
+    os << ", element_type: ";
+    std::visit([&os](const auto& value) {
+        os << value;
+    }, at.element_type);
+    
+    os << " }";
+    return os;
+}
+
+// Specialized print function with proper indentation for nested structures
+void prettyPrintType(std::ostream& os, const std::variant<BasicType, StructType, ArrayType>& type, int level = 0) {
+    std::visit(overloaded {
+        [&os, level](const BasicType& bt) {
+            os << indent(level) << bt;
+        },
+        [&os, level](const StructType& st) {
+            os << indent(level) << "StructType { type_name: \"" << st.type_name << "\"";
+            
+            if (!st.members.empty()) {
+                os << ", members: [\n";
+                
+                for (size_t i = 0; i < st.members.size(); ++i) {
+                    os << indent(level + 1) << st.members[i].first << ": ";
+                    prettyPrintType(os, st.members[i].second, level + 2);
+                    
+                    if (i < st.members.size() - 1) {
+                        os << ",";
+                    }
+                    os << "\n";
+                }
+                
+                os << indent(level) << "]";
+            } else {
+                os << ", members: []";
+            }
+            
+            os << " }";
+        },
+        [&os, level](const ArrayType& at) {
+            os << indent(level) << "ArrayType { ";
+            os << "type_name: \"" << at.type_name << "\", ";
+            os << "num_elements: " << at.num_elements;
+            
+            os << ", element_type: ";
+            prettyPrintType(os, std::visit(conversion_visitor, at.element_type), level + 1);
+            
+            os << " }";
+        }
+    }, type);
+}
+
+// Updated prettyPrintArgumentInfo to use the new formatting
+void prettyPrintArgumentInfo(const ArgumentInformation& args) {
+    if (args.members.empty()) {
+        std::cout << "No arguments found." << std::endl;
+        return;
+    }
+    
+    std::cout << "Arguments information:" << std::endl;
+    
+    std::cout << "StructType { type_name: \"" << args.type_name << "\"";
+    
+    if (!args.members.empty()) {
+        std::cout << ", members: [\n";
+        
+        for (size_t i = 0; i < args.members.size(); ++i) {
+            std::cout << indent(1) << args.members[i].first << ": ";
+            prettyPrintType(std::cout, args.members[i].second, 1);
+            
+            if (i < args.members.size() - 1) {
+                std::cout << ",";
+            }
+            std::cout << "\n";
+        }
+        
+        std::cout << "  ]";
+    } else {
+        std::cout << ", members: []";
+    }
+    
+    std::cout << " }" << std::endl;
+}
+
+
+int collect_so_file_elf_paths(struct dl_phdr_info *info, size_t size, void *data) {
+  auto paths = (std::vector<const char*>*) data;
+  std::string_view view(info->dlpi_name);
+  if (view.find("libtorch_cuda") != std::string_view::npos) {
+    paths->push_back(info->dlpi_name);
+  }
+  return 0;
+}
+
+
+std::unordered_map<std::string, ArgumentInformation>
+get_argument_information(const std::vector<std::string> &function_names) {
+  std::vector<const char*> paths;
+  dl_iterate_phdr(collect_so_file_elf_paths, &paths);
+
+  for (auto&& path: paths) {
+    std::cout << "GALVEZ: SO path=" << path << std::endl;
+  }
+  
+  std::unordered_map<std::string, ArgumentInformation> function_to_data;
+  for(auto&& function_name: function_names) {
+    for(auto&& path: paths) {
+      ArgumentInformation type_information = getArgumentInformation(function_name.c_str(), path);
+      // TODO: What if the function takes no arguments
+      if (!type_information.members.empty()) {
+        function_to_data.emplace(function_name, std::move(type_information));
+        break;
+      }
+    }
+  }
+  return function_to_data;
+}
+
+ArgumentInformation
+get_argument_information(CUfunction func) {
+  const char* func_name;
+  AT_CUDA_DRIVER_CHECK(
+                       at::globalContext().getNVRTC().cuFuncGetName(&func_name, func));
+
+  CUmodule module;
+  AT_CUDA_DRIVER_CHECK(
+                       at::globalContext().getNVRTC().cuFuncGetModule(&module, func));
+
+  size_t image_size;
+  void *void_image;
+  module_get_image(module, &void_image, &image_size);
+  // char *image = new char[image_size];
+  // void *void_image = reinterpret_cast<void*>(image);
+  // module_get_image(module, &void_image, &image_size);
+
+  ArgumentInformation type_information = getArgumentInformation(func_name, void_image, image_size);
+// delete image;
+  return type_information;
+}
+
+
+bool sizeof_type(const std::variant<BasicType, StructType, ArrayType>& type_info) {
+  return std::visit([](auto&& arg) {
+    using T = std::decay_t<decltype(arg)>;
+    if constexpr (std::is_same_v<T, BasicType>) {
+      return arg.size;
+    } else if constexpr (std::is_same_v<T, StructType>) {
+      // TODO: Double check that that this is always true.
+      // not true: https://chatgpt.com/share/67dd036a-a250-8000-9355-8dd04db0c6c6
+      // tail padding exists
+      // I need to have a size field for Structs unfortunately
+      // TODO: Fill this out properly!!!
+      return arg.size;  // offsetof_type(arg.members->back()) + sizeof_type(arg.members->back())
+    } else if constexpr (std::is_same_v<T, ArrayType>) {
+
+
+      return arg.num_elements * sizeof_type(std::visit(conversion_visitor, arg.element_type));
+    }
+  }, type_info);
+}
+
+struct A {
+  bool b;
+  struct B {
+    int c;
+    bool d;
+    double e;
+  };
+  struct C {
+    int f;
+    bool g;
+    double h;
+    struct D {
+      int i;
+    };
+  };
+};
+
+bool is_equal(char *arg1, char *arg2,
+              const std::variant<BasicType, StructType, ArrayType>& type_info,
+              bool is_last_member_of_struct,
+              size_t global_offset_bytes, const std::string& name) {
+  return std::visit([arg1, arg2, &is_last_member_of_struct, &global_offset_bytes, &name](auto&& arg) -> bool {
+    using T = std::decay_t<decltype(arg)>;
+    if constexpr (std::is_same_v<T, BasicType>) {
+      // TODO: Check if this is a void pointer to be extract precise.
+      // also check name of struct? Don't know if we can verify that a struct is a lambda though.
+      if (is_last_member_of_struct && arg.is_pointer && name == "Could not get member name") {
+        // not always true, but works around a tricky situation with
+        // host-device lambdas, which store a host pointer in the
+        // final field of the class called "data". We know that device
+        // code will never access this. For some reason, "data" is not
+        // being put into the dwarf debug info, though, which is
+        // strange... Maybe because it is never accessed by the cuda
+        // kernel?
+        return true;
+      } else {
+        // Calculate the absolute offset including array offset if inside an array
+        size_t offset = global_offset_bytes + arg.offset;
+        return std::memcmp(arg1 + offset, arg2 + offset, arg.size) == 0;
+      }
+    } else if constexpr (std::is_same_v<T, StructType>) {
+      // For structs, we need to consider its base offset plus any array offset
+      size_t base_offset = global_offset_bytes + arg.offset;
+      
+      for (size_t i = 0; i < arg.members.size(); ++i) {
+        // Pass the adjusted pointers that already include the base_offset
+        bool equal = is_equal(arg1,
+                              arg2,
+                              arg.members[i].second,
+                              i == arg.members.size() - 1,
+                              base_offset,
+                              arg.members[i].first);
+
+        if (!equal) {
+          return false;
+        } else {
+          // base_offset = next_offset;
+        }
+      }
+      return true;
+    } else if constexpr (std::is_same_v<T, ArrayType>) {
+      // Calculate the base offset of the array
+      
+      // Calculate the size of each element in this array
+      size_t element_size = std::visit([](auto&& element) -> size_t {
+        using ElementT = std::decay_t<decltype(element)>;
+        if constexpr (std::is_same_v<ElementT, BasicType>) {
+          return element.size;
+        } else if constexpr (std::is_same_v<ElementT, StructType>) {
+          return element.size;
+        }
+        return 0; // Should not happen
+      }, arg.element_type);
+      
+      // Check each element of the array
+      for (size_t i = 0; i < arg.num_elements; ++i) {
+        auto &&up_cast = std::visit(conversion_visitor, arg.element_type);
+        // Pass the base pointers and let the recursive call handle the element offset
+
+        bool equal = is_equal(arg1, arg2, up_cast, false, global_offset_bytes, std::string("array[") + std::to_string(i) + "]");
+
+        if (!equal) {
+          return false;
+        } else {
+          global_offset_bytes += element_size;
+        }
+      }
+
+      return true;
+    }
+    return false;
+  }, type_info);
+}
+
+bool is_equal(void *arg1, void *arg2, std::variant<BasicType, StructType, ArrayType> info) {
+  return is_equal((char *)arg1, (char *)arg2, info, false, 0, "Parameters");
+}

--- a/aten/src/ATen/cuda/GetTypeInformation.h
+++ b/aten/src/ATen/cuda/GetTypeInformation.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <cuda.h>
+#include <c10/util/flat_hash_map.h>
+
+// there is no name for BasicTypes that sit within Arrays. This is a
+// mistake on my part.
+struct BasicType {
+  std::string type_name;
+  size_t offset = 0;
+  size_t size;
+  bool is_pointer;
+};
+
+struct ArrayType;
+
+// StructType has no copy constructor because of the presence of unique_ptr
+struct StructType {
+  std::string type_name;
+  // std::unique_ptr<std::vector<std::variant<BasicType, StructType, ArrayType>>> members;
+  std::vector<std::pair<std::string, std::variant<BasicType, StructType, ArrayType>>> members;
+  size_t offset = 0;
+  // we need a size field because structs can have tail padding.
+  size_t size;
+};
+
+struct ArrayType {
+  std::string type_name;
+  // dwarf debug information will never allow an array to be nested
+  // within an array. Instead, you will just have multiple
+  // "subranges".
+  size_t offset = 0;
+  std::variant<BasicType, StructType> element_type;
+  // std::unique_ptr<std::variant<BasicType, StructType, ArrayType>> element_type;
+  size_t num_elements;
+};
+
+// in this case, the first element of each pair in members refers to
+// the name of the argument. "type_name" has no meaning. "size" also
+// has no meaning.
+using ArgumentInformation = StructType;
+
+inline auto conversion_visitor = [](auto&& value) {
+  using T = std::decay_t<decltype(value)>;
+  return std::variant<BasicType, StructType, ArrayType>{
+    std::in_place_type<T>,
+    std::forward<decltype(value)>(value) };
+};
+
+ArgumentInformation
+getArgumentInformation(const char* linkageName, const std::string& elfPath);
+
+ArgumentInformation
+getArgumentInformation(const char* linkageName, void *buffer, size_t buffer_size);
+
+std::unordered_map<std::string, ArgumentInformation>
+get_argument_information(const std::vector<std::string> &function_names);
+
+ArgumentInformation
+get_argument_information(CUfunction func);
+
+bool is_equal(void *arg1, void *arg2, std::variant<BasicType, StructType, ArrayType> info);
+
+void prettyPrintArgumentInfo(const ArgumentInformation& args);

--- a/aten/src/ATen/cuda/detail/LazyNVRTC.cpp
+++ b/aten/src/ATen/cuda/detail/LazyNVRTC.cpp
@@ -172,7 +172,12 @@ CUDA_STUB3(cuLinkComplete, CUlinkState, void **, size_t *)
 CUDA_STUB3(cuFuncSetAttribute, CUfunction, CUfunction_attribute, int)
 CUDA_STUB3(cuFuncGetAttribute, int*, CUfunction_attribute, CUfunction)
 CUDA_STUB3(cuPointerGetAttribute, void*, CUpointer_attribute, CUdeviceptr)
-
+CUDA_STUB2(cuGraphKernelNodeGetParams, CUgraphNode, CUDA_KERNEL_NODE_PARAMS*)
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 12040
+CUDA_STUB4(cuFuncGetParamInfo, CUfunction, size_t, size_t*, size_t*)
+CUDA_STUB2(cuFuncGetName, const char**, CUfunction)
+CUDA_STUB2(cuFuncGetModule, CUmodule*, CUfunction)
+#endif
 
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 12000
 CUresult CUDAAPI

--- a/aten/src/ATen/cuda/detail/TensorInfo.cuh
+++ b/aten/src/ATen/cuda/detail/TensorInfo.cuh
@@ -30,8 +30,8 @@ struct TensorInfo {
   }
 
   T* data;
-  IndexType sizes[MAX_TENSORINFO_DIMS];
-  IndexType strides[MAX_TENSORINFO_DIMS];
+  IndexType sizes[MAX_TENSORINFO_DIMS]{};
+  IndexType strides[MAX_TENSORINFO_DIMS]{};
   int dims;
 };
 

--- a/aten/src/ATen/cuda/nvrtc_stub/ATenNVRTC.h
+++ b/aten/src/ATen/cuda/nvrtc_stub/ATenNVRTC.h
@@ -64,8 +64,11 @@ namespace at::cuda {
   _(cuPointerGetAttribute)                       \
   _(cuFuncSetCacheConfig)                        \
   _(cuDeviceGetAttribute)                        \
-  _(cuDeviceGet)                        \
-
+  _(cuDeviceGet)                                 \
+  _(cuFuncGetParamInfo)                          \
+  _(cuFuncGetName)                               \
+  _(cuGraphKernelNodeGetParams)                  \
+  _(cuFuncGetModule)
 
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 12000
 #define AT_FORALL_NVRTC_EXTENDED(_)              \

--- a/aten/src/ATen/native/cuda/CUDALoops.cuh
+++ b/aten/src/ATen/native/cuda/CUDALoops.cuh
@@ -540,6 +540,7 @@ static void launch_legacy_kernel(int64_t N, const func_t& f) {
   dim3 block(nt);
   dim3 grid((N + block.x * vt - 1) / (block.x * vt));
   auto stream = at::cuda::getCurrentCUDAStream();
+  // so this memory buffer is not contiguous. That might mean something.
   elementwise_kernel<nt, vt, func_t><<<grid, block, 0, stream>>>(N, f);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
@@ -657,6 +658,7 @@ void gpu_kernel_impl_nocast(TensorIteratorBase& iter, const func_t& f) {
   }
   auto offset_calc = ::make_offset_calculator<traits::arity + 1>(iter);
 #ifndef USE_ROCM
+  // I may be enterint this region. Yes, definitely this region.
   constexpr int unroll_factor = sizeof(arg0_t) >= 4 ? 2 : 4;
   launch_legacy_kernel<128, unroll_factor>(numel, [=] GPU_LAMBDA(int idx) {
     auto offsets = offset_calc.get(idx);

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -173,6 +173,7 @@ void float8_copy_kernel_cuda(TensorIteratorBase &iter) {
 
 // TODO: We probably can use the opaque type trick to avoid creating duplicate
 // kernels for equivalent bit lengths
+  // the kernel is rom here
 void direct_copy_kernel_cuda(TensorIteratorBase &iter) {
   ScalarType dtype = iter.dtype(0);
   if (isQIntType(dtype)) {

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -546,6 +546,7 @@ static ReduceMaximum reduce_maximum;
 
 }
 
+// this assertion is triggering
 static Tensor wrapIndexOnce(const Tensor & index, int64_t dim, int64_t dim_size, bool check_range=true) {
 //we don't need to check range in backward - if there were out of bounds indices forward should already have errored out
   if (index.numel() != 0 && check_range) {

--- a/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
+++ b/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
@@ -15,7 +15,7 @@ C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wmissing-field-initializers")
 // https://github.com/NVIDIA/cutlass/issues/1571
 #if !defined(USE_ROCM) && !defined(_WIN32) && defined(CUDA_VERSION) && CUDA_VERSION >= 12000
 
-#define BUILD_ROWWISE_FP8_KERNEL
+// #define BUILD_ROWWISE_FP8_KERNEL
 #endif
 
 #if defined(BUILD_ROWWISE_FP8_KERNEL)

--- a/aten/src/ATen/native/cuda/TensorCompare.cu
+++ b/aten/src/ATen/native/cuda/TensorCompare.cu
@@ -6,7 +6,7 @@
 #include <ATen/native/TensorCompare.h>
 #include <ATen/native/cuda/Loops.cuh>
 #include <c10/core/Scalar.h>
-
+#include <c10/cuda/CUDAGraphsC10Utils.h>
 
 namespace at::native {
 
@@ -125,6 +125,10 @@ void _assert_async_msg_cuda(const Tensor& self_tensor, std::string_view assert_m
   TORCH_CHECK(n != 0, "Boolean value of Tensor with no values is ambiguous");
   TORCH_CHECK(n < 2, "Boolean value of Tensor with more than one value is ambiguous");
   auto stream = at::cuda::getCurrentCUDAStream();
+  bool is_capturing = at::cuda::currentStreamCaptureStatusMayInitCtx() != at::cuda::CaptureStatus::None;
+  if (is_capturing) {
+    std::cout << "Adding an assertion to capturing graph" << std::endl;
+  }
   Msg msg;
   size_t copy_length = assert_msg.length();
   TORCH_CHECK(copy_length < Msg::MAX_MSG_LENGTH - 1, "Message length must be smaller than " + std::to_string(Msg::MAX_MSG_LENGTH - 1));

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -924,6 +924,7 @@ struct PrivatePool {
   PrivatePool(MempoolId_t id, CUDAAllocator* allocator = nullptr)
       : id(std::move(id)),
         allocator_(allocator),
+        // PrivatePool is assigned here.
         large_blocks(/*small=*/false, this),
         small_blocks(/*small=*/true, this) {}
   PrivatePool(const PrivatePool&) = delete;
@@ -1352,12 +1353,16 @@ class DeviceCachingAllocator {
         // Search pool
         get_free_block(params)
         // Trigger callbacks and retry search
+        // how do I set these callbacks? Why might I want to do that? This is used for CUDA IPC only right now apparently.
         || (trigger_free_memory_callbacks(params) && get_free_block(params));
 
     // Can't reuse an existing block; try to get a new one.
     if (!block_found) {
       // Do garbage collection if the flag is set.
+
+      // why doesn't garbage collection garbage collect for mempools?
       if (C10_UNLIKELY(
+              // set to 0.0 apparently
               set_fraction &&
               CUDAAllocatorConfig::garbage_collection_threshold() > 0.0)) {
         garbage_collect_cached_blocks(context);
@@ -1389,9 +1394,12 @@ class DeviceCachingAllocator {
             return std::this_thread::get_id() == tid;
           };
           beginAllocateToPool(mempool_id, filter);
+          // there are apparently two different pools for each
+          // PrivatePool, one for small and large blocks.
           auto& mempool = get_pool(size, stream);
           AllocParams mempool_params(
               device, size, stream, &mempool, alloc_size, stats);
+          // what is this for?
           mempool_params.stat_types = get_stat_types_for_pool(mempool);
           block_found = get_free_block(mempool_params);
           endAllocateToPool(mempool_id);
@@ -2968,8 +2976,7 @@ class DeviceCachingAllocator {
   }
 
   /** Free one or more oversize blocks to the system allocator.  But only enough
-   * **/
-  /** to satisfy the target size **/
+   *  to satisfy the target size **/
   bool release_available_cached_blocks(
       const AllocParams& p,
       const std::shared_ptr<GatheredContext>& context) {
@@ -3078,6 +3085,7 @@ class DeviceCachingAllocator {
     delete block;
   }
 
+  // when is release_block called?
   void release_block(
       Block* block,
       const std::shared_ptr<GatheredContext>& context) {
@@ -3092,6 +3100,7 @@ class DeviceCachingAllocator {
         block->pool->owner_MempoolId(),
         context ? context : block->context_when_segment_allocated);
 
+    // when is release_block called?
     auto* pool = block->pool;
     if (pool->owner_PrivatePool && pool->owner_PrivatePool->allocator()) {
       // If there is an active mempool with a given allocator,

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1000,6 +1000,7 @@ struct MempoolIdHash {
   }
 };
 
+// so this gets called if we have a private pool with an allocator
 cudaError_t allocPrimitive(void** ptr, size_t size, AllocParams& p) {
   if (p.pool->owner_PrivatePool && p.pool->owner_PrivatePool->allocator()) {
     *ptr = p.pool->owner_PrivatePool->allocator()->raw_alloc(size);
@@ -3108,7 +3109,7 @@ class DeviceCachingAllocator {
       pool->owner_PrivatePool->allocator()->raw_delete((void*)block->ptr);
     } else {
       // lol, does cudaFree() on memory allocated by cuMemCreate actually work? Fishy...
-      std::cout << "GALVEZ:cudaFree() fallback" << std::endl;
+      // std::cout << "GALVEZ:cudaFree() fallback" << std::endl;
       C10_CUDA_CHECK(cudaFree((void*)block->ptr));
     }
     total_allocated_memory -= block->size;

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -2222,6 +2222,8 @@ class DeviceCachingAllocator {
     }
   }
 
+  // okay, so the allocator is passed here... I need a subtype of
+  // CUDAAllocator, I suppose...
   void createOrIncrefPool(MempoolId_t mempool_id, CUDAAllocator* allocator) {
     // Create a PrivatePool object if it does not exist yet
     // and increment its use_count

--- a/c10/cuda/driver_api.h
+++ b/c10/cuda/driver_api.h
@@ -27,6 +27,7 @@
   _(cuMemMap, 12000)                       \
   _(cuMemAddressFree, 12000)               \
   _(cuMemSetAccess, 12000)                 \
+  _(cuMemRetainAllocationHandle, 12000)    \
   _(cuMemUnmap, 12000)                     \
   _(cuMemCreate, 12000)                    \
   _(cuMemGetAllocationGranularity, 12000)  \

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -968,6 +968,11 @@ elseif(USE_CUDA)
   endif()
   set(CUDA_LINK_LIBRARIES_KEYWORD)
   torch_compile_options(torch_cuda)  # see cmake/public/utils.cmake
+  _CUDAToolkit_find_and_add_import_lib(cufilt)
+  target_link_libraries(torch_cuda PRIVATE cufilt)
+
+  target_link_libraries(torch_cuda PRIVATE dwarf)  # libdwarf::dwarf-shared)
+
   target_compile_definitions(torch_cuda PRIVATE USE_CUDA)
 
   if(USE_CUFILE)

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5201,6 +5201,7 @@ class TestMemPool(TestCase):
         pre_reserved = torch.cuda.memory_reserved(device)
         total_allowed = additional_allowed_memory_in_mb * mb + pre_reserved
         fraction_allowed = total_allowed / all_memory
+        # How does this work?
         torch.cuda.memory.set_per_process_memory_fraction(fraction_allowed, device)
 
         dtype = torch.int8

--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -409,6 +409,7 @@ class CMake:
 
         from .env import build_type
 
+        # Need to add to this.
         build_args = [
             "--build",
             ".",
@@ -442,6 +443,7 @@ class CMake:
 
             # CMake 3.12 provides a '-j' option.
             build_args += ["-j", max_jobs]
+        build_args += ["--", "-k", "0"]
         self.run(build_args, my_env)
 
     def clear_cache(self) -> None:

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -365,6 +365,7 @@ def get_builtins_dict(global_scope):
     return f_builtins
 
 
+# TODO: Can I access the OutputGraph in a torch.compile backend?
 class OutputGraph(OutputGraphGuardsState):
     """
     Wrapper class to hold outputs of InstructionTranslator.  Mainly the

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -808,6 +808,7 @@ class SideEffects:
             )
         return self.ca_final_callbacks_var
 
+    # Can I inspect this generated code somehow?
     def codegen_update_mutated(self, cg: PyCodegen):
         suffixes = []
         for var in self._get_modified_vars():
@@ -1100,6 +1101,7 @@ class SideEffects:
                     cg.call_function(1, False)
                     cg.pop_top()
             elif isinstance(var, variables.RandomVariable):
+                # This one is interes
                 # set correct random seed state
                 def gen_fn():
                     cg(var.source)  # type: ignore[attr-defined]

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -3042,6 +3042,7 @@ def same(
                         tol,
                         use_larger_multiplier_for_smaller_tensor,
                     )
+                    # import ipdb; ipdb.set_trace()
                 return passes_test
 
             if ignore_non_fp:

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2875,6 +2875,7 @@ def same(
         assert set(ref.keys()) == set(res.keys()), (
             f"keys mismatch {set(ref.keys())} == {set(res.keys())}"
         )
+        is_same = True
         for k in sorted(ref.keys()):
             if not (
                 same(
@@ -2893,8 +2894,8 @@ def same(
                 )
             ):
                 log_error("Accuracy failed for key name %s", k)
-                return False
-        return True
+                is_same = False
+        return is_same
     elif isinstance(ref, set):
         assert isinstance(res, set)
         assert set(ref) == set(res), f"elements mismatch {set(ref)} == {set(res)}"
@@ -3033,7 +3034,7 @@ def same(
                 if not passes_test:
                     log_error(
                         "RMSE (res-fp64): %.5f, (ref-fp64): %.5f and shape=%s. res.dtype: %s, multiplier: %f, tol: %f"
-                        ", use_larger_multiplier_for_smaller_tensor: %d",
+                        ", use_larger_multiplier_for_smaller_tensor: %d, res sum: %f, ref sum: %f",
                         res_error,
                         ref_error,
                         res.size(),
@@ -3041,6 +3042,8 @@ def same(
                         multiplier,
                         tol,
                         use_larger_multiplier_for_smaller_tensor,
+                        torch.sum(res),
+                        torch.sum(ref),
                     )
                     # import ipdb; ipdb.set_trace()
                 return passes_test

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1719,8 +1719,10 @@ class VariableBuilder:
     def mark_static_input(self, value: torch.Tensor, guard: bool):
         from ..decorators import mark_static_address
 
+        # import ipdb; ipdb.set_trace()
+
         static_inputs_log.debug(
-            "Marking static input %s, id: %s)", self.source.name(), id(value)
+            "Marking static input %s, id: %s, type: %s)", self.source.name(), id(value), type(value)
         )
         mark_static_address(value, guard=guard)
 
@@ -1728,6 +1730,7 @@ class VariableBuilder:
         # As long as this runs before AOT this is sound
         if value in self.tx.output.side_effects:
             var = self.tx.output.side_effects[value]
+            # _dynamo_static
             var.proxy.node.meta["tensor_dict"]["_dynamo_static_input_type"] = (
                 value._dynamo_static_input_type
             )

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -235,6 +235,7 @@ class CacheBase:
 
 class LocalCache(CacheBase):
     def lookup(self, *keys: str) -> Optional[dict[str, Any]]:
+        print("GALVEZ: cache lookup")
         cache = self.get_local_cache()
 
         sub_cache = cache

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import bisect
 import contextlib
 import enum
 import functools
@@ -1657,6 +1658,10 @@ def get_input_idxs_to_check(
     return ids_to_check
 
 
+# It seems that this is called after torch.compile...
+
+# Unfortunately, it is not called every time afterwards. I need to
+# somehow make the chosen implementation depend upon this...
 def cudagraphify(
     model: Callable[..., Any],
     static_input_idxs: Sequence[int] = (),
@@ -1669,12 +1674,15 @@ def cudagraphify(
     placeholders: Sequence[PlaceholderInfo] = (),
     mutated_input_idxs: tuple[int, ...] = (),
 ) -> Callable[..., Any]:
+    # import ipdb; ipdb.set_trace()
     from torch._inductor.cudagraph_trees import (
         cudagraphify_impl as new_cudagraphify_impl,
     )
 
     cudagraphify_fn: Callable[..., Any]
+    print("post-compile cudagraph trees:", config.triton.cudagraph_trees)
     if config.triton.cudagraph_trees:
+        print("cudagraph trees")
         cudagraphify_fn = functools.partial(
             new_cudagraphify_impl,
             device_index=device_index,
@@ -1687,6 +1695,7 @@ def cudagraphify(
             compile_id=torch._guards.CompileContext.current_compile_id(),
         )
     else:
+        print("parameterized graphs")
         cudagraphify_fn = cudagraphify_impl
 
     compiled_fn = None
@@ -1718,7 +1727,139 @@ def index_expanded_dims_and_copy_(
     src = index_expanded_dims(src, expanded_dims)
     dst.copy_(src)
 
+def cuda_python_error_check(function_call_output):
+    """Makes calls to cuda-python's cuda runtime functions more
+    pythonic by throwing an exception if they return a status
+    which is not cudaSuccess
+    """
+    import cuda.bindings  # type: ignore[import]
 
+    error, *others = function_call_output
+    if (isinstance(error, cuda.bindings.runtime.cudaError_t)
+        and error != cuda.bindings.runtime.cudaError_t.cudaSuccess):
+        raise ValueError(f"CUDA failure! {error}")
+    elif (isinstance(error, cuda.bindings.driver.CUresult)
+          and error != cuda.bindings.driver.CUresult.CUDA_SUCCESS):
+        raise ValueError(f"CUDA failure! {error}")
+    else:
+        return tuple(others)
+
+keep = []
+
+def insert_empty_nodes_after_each_node(graph):
+    """
+    Insert a new empty node after every existing node in a chain-like CUDA graph.
+    
+    Parameters:
+        graph (cudaGraph_t): A CUDA graph that is known to be a chain
+        
+    Returns:
+        None: The function modifies the graph in place
+    """
+    import cuda.bindings.runtime as cudart
+    import cuda.bindings.driver as cuda
+
+    from torch.cuda import _compile_kernel
+
+    kernel_source = r"""
+    __global__ void printer(char *name) {
+        static int i = 0;
+        printf("running kernel %d %s\n", i++, name);
+    }
+    """
+
+    kernel_pointer = _compile_kernel(kernel_source, "printer")
+
+    # Get all nodes in the graph
+    _, num_nodes = cuda_python_error_check(cudart.cudaGraphGetNodes(graph))
+    if num_nodes == 0:
+        return
+    nodes, _ = cuda_python_error_check(cudart.cudaGraphGetNodes(graph, num_nodes))
+
+    for node in nodes:
+        # Get the dependent nodes (there should be 0 or 1 for a chain)
+        # import ipdb; ipdb.set_trace()
+        _, num_dependent_nodes = cuda_python_error_check(cudart.cudaGraphNodeGetDependentNodes(node))
+        if num_dependent_nodes == 0:
+            continue
+        assert num_dependent_nodes == 1
+
+        dependent_nodes, _ = cuda_python_error_check(cudart.cudaGraphNodeGetDependentNodes(node, num_dependent_nodes))
+
+        node_params, = cuda_python_error_check(cuda.cuGraphKernelNodeGetParams(node))
+        name, = cuda_python_error_check(cuda.cuFuncGetName(node_params.func))
+        print("GALVEZ: name=", name)
+        name_gpu_memory = torch.tensor(list(name) + [0], dtype=torch.int8, device="cuda")
+        keep.append(name_gpu_memory)
+        # import ipdb; ipdb.set_trace()
+
+        # empty_node,  = cuda_python_error_check(cuda.cudaGraphAddEmptyNode(graph, [node], 1))
+        params = cuda.CUDA_KERNEL_NODE_PARAMS()
+        # params.func = kernel_pointer.func
+        params.func = kernel_pointer.func.value
+        params.gridDimX = 1
+        params.gridDimY = 1
+        params.gridDimZ = 1
+        params.blockDimX = 1
+        params.blockDimY = 1
+        params.blockDimZ = 1
+        import numpy as np
+        arg0 = np.array([name_gpu_memory.data_ptr()], dtype=np.uint64)
+        args = np.array(arg0.ctypes.data, dtype=np.uint64)
+        params.kernelParams = args.ctypes.data
+        new_node,  = cuda_python_error_check(cuda.cuGraphAddKernelNode(graph, [node], 1, params))
+
+        next_node = dependent_nodes[0]
+
+        # Remove the direct dependency from current node to next node
+        cuda_python_error_check(cudart.cudaGraphRemoveDependencies(graph, [node], [next_node], 1))
+
+        # Add dependency from empty node to next node
+        cuda_python_error_check(cudart.cudaGraphAddDependencies(graph, [new_node], [next_node], 1))
+
+import torch
+from typing import Tuple, Optional
+
+def same_metadata(a: torch.Tensor, b: torch.Tensor, 
+                  include_names: bool = False) -> bool:
+    """
+    Check whether two tensors have identical metadata.
+
+    Args:
+        a, b: tensors to compare.
+        include_names: if False, ignore named-tensor 'names' even if present.
+
+    Returns:
+        True if shape, stride, dtype, device, layout, requires_grad,
+        pinned memory status, and (optionally) names all match.
+    """
+    # basic properties
+    if a.size()      != b.size():      return False
+    # print("size check passed")
+    if a.stride()    != b.stride():    return False
+    # print("stride check passed")
+    if a.dtype       != b.dtype:       return False
+    # print("dtype check passed")
+    if a.device      != b.device:      return False
+    # print("device check passed")
+    if a.layout      != b.layout:      return False
+    # print("layout check passed")
+    # if a.requires_grad != b.requires_grad: return False
+    # print("requires_grad check passed")
+    if a.is_pinned() != b.is_pinned(): return False
+    # print("is_pinned check passed")
+
+    # named-tensor support
+    if include_names:
+        # .names may be None or a tuple of strings
+        names_a = getattr(a, 'names', None)
+        names_b = getattr(b, 'names', None)
+        if names_a != names_b:
+            return False
+
+    return True
+
+        
 def cudagraphify_impl(
     model: Callable[..., Any],
     inputs: list[torch.Tensor],
@@ -1727,11 +1868,17 @@ def cudagraphify_impl(
     """
     Assumes inputs[static_input_idxs[i]] are always the same memory address
     """
+
+    import operator
+    fn_cache: dict[tuple[int, ...], Callable[..., Any]] = {}
+    int_key = [i for i, v in enumerate(inputs) if isinstance(v, int)]
+    get_ints: Any = operator.itemgetter(*int_key) if int_key else lambda _: None
+
     check_input_idxs = get_input_idxs_to_check(inputs, static_input_idxs)  # type: ignore[arg-type]
     static_input_idxs: OrderedSet[int] = OrderedSet(
         remove_unaligned_input_idxs(inputs, static_input_idxs)  # type: ignore[arg-type]
     )
-    # copy #1
+    # copy #1, but this happens only once, hmmm...
     copy_misaligned_inputs(inputs, check_input_idxs)  # type: ignore[arg-type]
 
     assert isinstance(inputs, list)
@@ -1744,7 +1891,7 @@ def cudagraphify_impl(
     # allocate static tensor inputs
     static_inputs = [
         (
-            x
+            x # So we can have non-tensor inputs here...
             if not isinstance(x, torch.Tensor)
             else static_input(x)
             # TODO: figure out how static_input_idxs is derived
@@ -1773,48 +1920,149 @@ def cudagraphify_impl(
     # better by using relaxed stream capture to do warmup.  CUDA Graph
     # trees avoids the issues by not running a cuda graph for the very
     # first run. (i.e., the first run is the warmup)
+    
+    # Relaxed stream capture usually works, but can fail if someone
+    # tries to do benchmarking on the currently capturing stream
+    # (triton does this).
     with torch.cuda.stream(stream):
         model(list(static_inputs))
     stream.synchronize()
     torch.cuda.current_stream().wait_stream(stream)
     torch.cuda.synchronize()
 
+    assert config.size_asserts
+
     # record
-    graph = torch.cuda.CUDAGraph()
+    graph = torch.cuda.CUDAGraph(keep_graph=True)
     dynamic_graph_arguments = (config.size_asserts and
                                config.triton.cudagraphs_elide_input_output_copies)
+    # import nvtx
+    # pr = nvtx.Profile()
+    # torch.cuda.cudart().cudaProfilerStart()
+    # pr.enable()
     with torch.cuda.graph(graph, stream=stream, capture_error_mode="thread_local",
                           dynamic_graph=dynamic_graph_arguments):
+        # Can't I get the underlying fxgraph here?
         static_outputs = model(list(static_inputs))
+    # import ipdb; ipdb.set_trace()
+    # pr.disable()
+    # torch.cuda.cudart().cudaProfilerStop()
     if not isinstance(static_outputs, (list, tuple)):
         static_outputs = (static_outputs,)
 
     if config.size_asserts and config.triton.cudagraphs_elide_input_output_copies:
-        graph.become_dynamic(list(static_inputs) + list(static_outputs))
+        # raw_graph = graph.raw_cuda_graph()
+        # insert_empty_nodes_after_each_node(raw_graph)
+
+        # Okay, so
+        static_inputs_not_changing = [input for idx, input in enumerate(static_inputs) if idx not in static_input_idxs]
+        dynamic_tensors_tmp = list(static_inputs_not_changing) + list(static_outputs)
+        # print(f"GALVEZ: {len(dynamic_tensors_tmp)=}")
+        # print(f"GALVEZ: {dynamic_tensors_tmp=}")
+        graph.become_dynamic(dynamic_tensors_tmp)
+
+        dynamic_input_idxs = OrderedSet([idx for idx in range(len(static_inputs)) if idx not in static_input_idxs])
+
+        memory_snapshot = torch.cuda.memory_snapshot(graph.pool())
+        memory_snapshot.sort(key=lambda x: x['address'])
+
+        segment_address_starts = [segment_snapshot['address'] for segment_snapshot in memory_snapshot]
+        segment_sizes = [segment_snapshot['total_size'] for segment_snapshot in memory_snapshot]
+
+        containing_segment_idxs = []
+
+        for static_output in static_outputs:
+            # This bisect works only if my snapshots are sorted... There is no guarantee of that right now...
+            # TODO: This bisect could be precomputed.
+            containing_segment_idxs.append(bisect.bisect(segment_address_starts, static_output.data_ptr()) - 1)
+
         def run(new_inputs):
             assert len(static_inputs) == len(new_inputs)
 
             dynamic_tensors = []
 
-            for idx, (dst, src, expanded_dims) in enumerate(
-                zip(static_inputs, new_inputs, inps_expanded_dims)
-            ):
-                if not isinstance(dst, torch.Tensor):
-                    pass
-                elif idx in static_input_idxs:
-                    assert dst.data_ptr() == src.data_ptr()
-                else:
-                    # TODO: We should check that alignment
-                    # requirements are meant on the input tensors...
-                    # Investigate copy_misaligned_inputs()'s implementation.
-                    dynamic_tensors.append(src)
+            for idx in dynamic_input_idxs:
+                dynamic_tensors.append(new_inputs[idx])
 
-            output_tensors = [torch.empty_like(static_output) for static_output in static_outputs]
+            # for idx, (dst, src, expanded_dims) in enumerate(
+            #     zip(static_inputs, new_inputs, inps_expanded_dims)
+            # ):
+            #     assert same_metadata(dst, src)
+            #     if not isinstance(dst, torch.Tensor):
+            #         # print(idx, "not a tensor")
+            #         pass
+            #     elif idx in static_input_idxs:
+            #         # print(idx, "data_ptr match")
+            #         assert dst.data_ptr() == src.data_ptr()
+            #     else:
+            #         # print(idx, "old input", hex(dst.data_ptr()), hex(dst.data_ptr() + dst.nbytes), dst.data_ptr(), dst.nbytes)
+            #         # print(idx, "new input", hex(src.data_ptr()), hex(src.data_ptr() + src.nbytes), src.data_ptr(), src.nbytes)
+            #         # TODO: We should check that alignment
+            #         # requirements are meant on the input tensors...
+            #         # Investigate copy_misaligned_inputs()'s implementation.
+            #         dynamic_tensors.append(src)
 
-            dynamic_tensors.extend(output_tensors)
-            new_inputs.clear()
+            # output_tensors = [static_output for static_output in static_outputs]
+            # output_tensors[0] = output_tensors[0].clone()
+
+            output_tensors = []
+
+            # unique_segments = set()
+
+            # for static_output in static_outputs:
+            #     # This bisect works only if my snapshots are sorted... There is no guarantee of that right now...
+            #     containing_segment_idx = bisect.bisect(segment_address_starts, static_output.data_ptr()) - 1
+            #     containing_segment_size_bytes = segment_sizes[containing_segment_idx]
+
+            #     unique_segments.add(containing_segment_idx)
+
+            # print(len(unique_segments), len(static_outputs))
+
+            # # TODO: I am assuming that each output belongs to its own segment. This is not correct. I need to consolidate them.
+            # assert len(unique_segments) == len(static_outptu)
+
+            # import ipdb; ipdb.set_trace()
+
+            # TODO: I am
+
+            for i, static_output in enumerate(static_outputs):
+                # This bisect works only if my snapshots are sorted... There is no guarantee of that right now...
+                # TODO: This bisect could be precomputed.
+                containing_segment_idx = containing_segment_idxs[i]
+                containing_segment_size_bytes = segment_sizes[containing_segment_idx]
+
+                # I believe this assert is handling by torch.Tensor.set_
+                # assert static_output.data_ptr() < segment_address_starts[containing_segment_idx] + containing_segment_size_bytes
+
+                storage_offset = static_output.data_ptr() - segment_address_starts[containing_segment_idx]
+
+                # torch.cuda.nvtx.range_push("static_output creation")
+
+                storage_tensor = torch.empty(containing_segment_size_bytes, dtype=torch.int8, device=static_output.device, layout=static_output.layout)
+                dynamic_tensors.append(storage_tensor[storage_offset:])
+
+            # dynamic_tensors.extend(output_tensors)
             graph.replay_dynamic(dynamic_tensors)
+
+            for i, static_output in enumerate(static_outputs):
+                storage_tensor = dynamic_tensors[len(dynamic_input_idxs) + i]
+                containing_segment_idx = containing_segment_idxs[i]
+                storage_offset = static_output.data_ptr() - segment_address_starts[containing_segment_idx]
+
+                # true_output_tensor = storage_tensor[storage_offset:storage_offset + static_output.nbytes].view(static_output.dtype).view(static_output.size())
+                # assert true_output_tensor.stride() == static_output.stride()
+                true_output_tensor = torch.empty((), device=static_output.device, dtype=static_output.dtype)
+
+                # So, I could finish creating these after calling replay_dynamic(). After all, all I need is to pass pointers, right?
+                true_output_tensor.set_(storage_tensor.untyped_storage(),
+                                        storage_offset=storage_offset,
+                                        stride=static_output.stride(),
+                                        size=static_output.size())
+                # torch.cuda.nvtx.range_pop()
+                output_tensors.append(true_output_tensor)
+                
             return output_tensors
+        graph.debug_dump("cudagraph.dot")
 
     elif config.size_asserts:
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1118,6 +1118,10 @@ class triton:
     # Use cudagraphs on output code
     cudagraphs = os.environ.get("TORCHINDUCTOR_CUDAGRAPHS") == "1"
 
+    # Elide input and output copies when using cudagraphs when
+    # possible. Simplifies a lot of things.
+    cudagraphs_elide_input_output_copies = True
+
     # Use cudagraph trees for memory pooling if `cudagraphs` is True
     cudagraph_trees = True
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -199,6 +199,7 @@ static_weight_shapes = True
 
 # put correctness assertions in generated code
 size_asserts = os.environ.get("TORCHINDUCTOR_SIZE_ASSERTS", "1") == "1"
+# This seems incredibly valuable.
 nan_asserts = os.environ.get("TORCHINDUCTOR_NAN_ASSERTS") == "1"
 scalar_asserts = os.environ.get("TORCHINDUCTOR_SCALAR_ASSERTS", "1") == "1"
 
@@ -1122,6 +1123,21 @@ class triton:
     # possible. Simplifies a lot of things.
     cudagraphs_elide_input_output_copies = True
 
+    # # Use cudagraphs on output code
+    # _cudagraph_trees = True  # Use a private field to store the actual value
+    
+    # @property
+    # @classmethod
+    # def cudagraph_trees(cls):
+    #     return cls._cudagraph_trees
+    
+    # @cudagraph_trees.setter
+    # @classmethod
+    # def cudagraph_trees(cls, value):
+    #     import traceback
+    #     print("GALVEZ: setting cudagraph_trees")
+    #     traceback.print_stack()
+    #     cls._cudagraph_trees = value
     # Use cudagraph trees for memory pooling if `cudagraphs` is True
     cudagraph_trees = True
 
@@ -1807,5 +1823,6 @@ if TYPE_CHECKING:
     from torch.utils._config_typing import *  # noqa: F401, F403
 
 
+# Okay, so patch definition is here.
 # adds patch, save_config, etc
 install_config_module(sys.modules[__name__])

--- a/torch/_inductor/cudagraph_digraphs.py
+++ b/torch/_inductor/cudagraph_digraphs.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+import bisect
+import contextlib
+import dataclasses
+import functools
+import gc
+import itertools
+import operator
+import sys
+import threading
+import traceback
+import warnings
+import weakref
+from collections import defaultdict
+from contextlib import AbstractContextManager
+from enum import auto, Enum
+from typing import Any, Callable, cast, Optional, TYPE_CHECKING, TypeVar, Union
+
+import torch.fx
+from torch import Tensor
+from torch._dynamo.callback import CallbackTrigger
+from torch._dynamo.mutation_guard import GenerationTracker
+from torch._dynamo.utils import counters, dynamo_timed, preserve_rng_state
+from torch._inductor.compile_fx import (
+    align_inputs_from_check_idxs,
+    copy_misaligned_inputs,
+    get_expanded_dims,
+    get_input_idxs_to_check,
+    index_expanded_dims,
+    remove_unaligned_input_idxs,
+    static_input,
+)
+from torch._inductor.cudagraph_utils import (
+    check_for_mutation,
+    CheckInvariantStatus,
+    FunctionID,
+    log_cudagraph_skip_and_bump_counter,
+    log_data_ptr_mismatch,
+    maybe_warning_due_to_dynamic_shape,
+    ModelType,
+    OutputType,
+    PlaceholderInfo,
+    WrappedFunction,
+)
+from torch.multiprocessing.reductions import StorageWeakRef
+from torch.storage import UntypedStorage
+from torch.utils import _pytree as pytree
+from torch.utils._ordered_set import OrderedSet
+from torch.utils.weak import TensorWeakRef
+
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterator, Sequence
+
+    from torch._guards import CompileId
+    from torch._inductor.utils import InputType
+    from torch.types import _bool
+
+StorageWeakRefPointer = int
+StorageDataPtr = int
+NBytes = int
+S = TypeVar("S", bound="StorageWeakRefWrapper")
+
+
+if torch.backends.cuda.is_built():
+    from torch._C import (
+        _cuda_CUDAAllocator_AllocatorState as AllocatorState,
+        _set_cached_tensors_enabled as _set_cached_tensors_enabled,
+    )
+else:
+
+    class AllocatorState:  # type: ignore[no-redef]
+        pass
+
+    def _set_cached_tensors_enabled(enabled: _bool) -> None:
+        pass
+
+
+log = torch._logging.getArtifactLogger(__name__, "cudagraphs")
+
+
+from . import config
+
+def cudagraphify_impl(
+    model: ModelType,
+    # Some inputs are ints, while others are SymInts, hmmm....
+    inputs: list[InputType],
+    static_input_idxs: Sequence[int],
+    *args: Any,
+    **kwargs: Any,
+) -> ModelType:
+    fn_cache: dict[tuple[int, ...], Callable[..., Any]] = {}
+
+    # Detect int inputs: we need to index on these
+    int_key = [i for i, v in enumerate(inputs) if isinstance(v, int)]
+    get_ints: Any = operator.itemgetter(*int_key) if int_key else lambda _: None
+
+    has_warn = False
+
+    del inputs
+
+    def deferred_cudagraphify(inputs: list[InputType]) -> OutputType:
+        nonlocal has_warn
+
+        # Okay, so these form a key that we use to create different
+        # cuda graphs.
+        int_key = get_ints(inputs)
+        fn = fn_cache.get(int_key)
+        if fn is not None:
+            # print("GALVEZ: getting cached cudagraph!")
+            return fn(inputs)
+
+        # Yeah, recording a graph key
+        if int_key is None:
+            log.info("recording cudagraph tree for graph without symints")
+        else:
+            log.info("recording cudagraph tree for symint key %s", int_key)
+
+        if not has_warn:
+            has_warn = maybe_warning_due_to_dynamic_shape(fn_cache, int_key)
+
+        # first get indices we need to check to align, then update our static inputs,
+        # and finally copy
+        check_input_idxs = get_input_idxs_to_check(inputs, static_input_idxs)
+        new_static_input_idxs = remove_unaligned_input_idxs(inputs, static_input_idxs)
+        copy_misaligned_inputs(inputs, check_input_idxs)
+
+        # here is the real cudagraphify. If I understand correctly, it
+        # will run eagerly first, and then do stream capture. That
+        # works, right?
+        fn, out = cudagraphify(model, inputs, new_static_input_idxs, *args, **kwargs)
+        fn_cache[int_key] = fn
+
+        return out
+
+    return deferred_cudagraphify
+
+def cudagraphify(
+    model: ModelType,
+    inputs: list[InputType],
+    static_input_idxs: Sequence[int] = (),
+    *,
+    device_index: int,
+    is_backward: bool,
+    is_inference: bool,
+    stack_traces: Optional[StackTraces] = None,
+    constants: tuple[torch.Tensor, ...] = (),
+    placeholders: tuple[PlaceholderInfo, ...] = (),
+    mutated_input_idxs: tuple[int, ...] = (),
+    compile_id: Optional[CompileId] = None,
+) -> tuple[ModelType, OutputType]:
+    # inps_expanded_dims = [
+    #     get_expanded_dims(x) if idx not in static_input_idxs else []
+    #     for idx, x in enumerate(inputs)
+    # ]
+
+    print("GALVEZ:cudagraph_digraphs.py cudagraphify")
+
+    graph = torch.cuda.CUDAGraph(keep_graph=True)
+    dynamic_graph_arguments = True
+    mem_allocator = graph.get_mem_allocator()
+    pool = torch.cuda.MemPool(mem_allocator)
+
+    torch.cuda.memory._record_memory_history(True)
+
+    with torch.cuda.use_mem_pool(pool):
+        static_inputs = [
+            (
+                x
+                if not isinstance(x, torch.Tensor)
+                else static_input(x)
+                if idx not in static_input_idxs
+                else x.detach() # Interesting to detatch these...
+            )
+            for idx, x in enumerate(inputs)
+        ]
+
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    print("GALVEZ: inputs=", len(inputs))
+    with torch.cuda.stream(stream):
+        outputs = model(inputs)
+
+    print("GALVEZ: outputs=", len(outputs))
+
+    torch.cuda.synchronize()
+
+    # Commeting pool.id fixes everythin for me. Hmm... The
+    # "inactive" part is a bit worrisome.Can I inspect to see when
+    # segments become inactive?
+
+    print("GALVEZ: input + output memory snapshots:")
+    memory_snapshot = torch.cuda.memory_snapshot(pool.id)
+    import pprint
+    pprint.pprint(memory_snapshot)
+
+    with torch.cuda.graph(graph, stream=stream, capture_error_mode="thread_local",
+                          dynamic_graph=dynamic_graph_arguments, pool=pool.id):
+        # Can't I get the underlying fxgraph here? No.
+        static_outputs = model(list(static_inputs))
+
+    print("GALVEZ: input + output memory snapshots:")
+    memory_snapshot = torch.cuda.memory_snapshot(pool.id)
+    import pprint
+    pprint.pprint(memory_snapshot)
+
+    # import ipdb; ipdb.set_trace()
+
+    # TODO: Why this? I should really be iterating over the outptuts as if they are a pytree...
+    if not isinstance(static_outputs, (list, tuple)):
+        static_outputs = (static_outputs,)
+
+    memory_snapshot = torch.cuda.memory_snapshot(graph.pool())
+    memory_snapshot.sort(key=lambda x: x['address'])
+
+    segment_address_starts = [segment_snapshot['address'] for segment_snapshot in memory_snapshot]
+    segment_sizes = [segment_snapshot['total_size'] for segment_snapshot in memory_snapshot]
+    segment_devices = [torch.device("cuda", segment_snapshot['device']) for segment_snapshot in memory_snapshot]
+
+    containing_segment_idxs = OrderedSet()
+    segment_idx_containing_this_output_tensor = []
+    dynamic_idx_containing_this_output_tensor = []
+
+    # I need to map each segment index to all output tensors, I think.
+    for static_output in static_outputs:
+        segment_idx = bisect.bisect(segment_address_starts, static_output.data_ptr()) - 1
+        if segment_idx in containing_segment_idxs:
+            for i, containing_segment_idx in enumerate(containing_segment_idxs):
+                if segment_idx == containing_segment_idx:
+                    dynamic_idx_containing_this_output_tensor.append(i)
+                    break
+        else:
+            dynamic_idx_containing_this_output_tensor.append(len(containing_segment_idxs))
+        containing_segment_idxs.add(segment_idx)
+        segment_idx_containing_this_output_tensor.append(segment_idx)
+
+    # assert len(containing_segment_idxs) == len(set(containing_segment_idxs)), "GALVEZ: detected output pointers sharing a segment!"
+
+    static_output_segment_tensors = []
+
+    for segment_idx in containing_segment_idxs:
+        static_output_segment_tensors.append((segment_address_starts[segment_idx], segment_sizes[segment_idx]))
+
+    torch.cuda.synchronize()
+
+    # does this include tensors? I think so...
+    static_inputs_only_tensors = [(input.data_ptr(), input.nbytes) for idx, input in enumerate(static_inputs) if idx not in static_input_idxs and isinstance(input, torch.Tensor) and input.is_cuda]
+    dynamic_tensors = list(static_inputs_only_tensors) + static_output_segment_tensors
+    graph.become_dynamic(dynamic_tensors)
+
+    dynamic_input_idxs = OrderedSet([idx for idx in range(len(static_inputs)) if idx not in static_input_idxs and isinstance(static_inputs[idx], torch.Tensor)])
+
+    def run(new_inputs):
+        assert len(static_inputs) == len(new_inputs)
+
+        dynamic_tensors = []
+
+        for idx in dynamic_input_idxs:
+            dynamic_tensors.append(new_inputs[idx])
+
+        torch.cuda.nvtx.range_push("Dynamic outputs creation")
+        for segment_idx in containing_segment_idxs:
+            containing_segment_size_bytes = segment_sizes[segment_idx]
+            containing_segment_device = segment_devices[segment_idx]
+
+            storage_tensor = torch.empty(containing_segment_size_bytes, dtype=torch.int8, device=containing_segment_device)
+            dynamic_tensors.append(storage_tensor)
+        torch.cuda.nvtx.range_pop()
+
+        graph.replay_dynamic(dynamic_tensors)
+
+        output_tensors = []
+
+        for i, static_output in enumerate(static_outputs):
+            dynamic_segment_idx = dynamic_idx_containing_this_output_tensor[i]
+            containing_segment_idx = segment_idx_containing_this_output_tensor[i]
+            # print("GALVEZ:", i, dynamic_segment_idx, containing_segment_idx, len(dynamic_tensors), len(dynamic_input_idxs))
+            storage_tensor = dynamic_tensors[len(dynamic_input_idxs) + dynamic_segment_idx]
+            storage_offset = static_output.data_ptr() - segment_address_starts[containing_segment_idx]
+            true_output_tensor = torch.empty((), device=static_output.device, dtype=static_output.dtype)
+            # print("GALVEZ:", static_output.size(), static_output.stride(), storage_offset)
+            true_output_tensor.set_(storage_tensor.untyped_storage(),
+                                    storage_offset=storage_offset,
+                                    stride=static_output.stride(),
+                                    size=static_output.size())
+            output_tensors.append(true_output_tensor)
+
+        return output_tensors
+
+    return run, outputs

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -569,6 +569,7 @@ def maybe_deref(
     return r, weak_ref.data_ptr()
 
 
+# Be worried about this.
 @contextlib.contextmanager
 def _use_cuda_memory_pool_manager(
     device: int, mem_pool: tuple[int, int], stream: torch.cuda.Stream

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -1692,7 +1692,9 @@ class CUDAGraphNode:
                     assert isinstance(inp, (int, torch.Generator))
                     recording_inputs.append(inp)
                 elif i not in self.static_input_idxs:
-                    # static_input does an allocation!
+                    # static_input does an allocation. Therefore, you
+                    # could say that it forbids inputs from
+                    # overlapping...
                     recording_inputs.append(static_input(inp))
                 else:
                     recording_inputs.append(inp)

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -331,6 +331,8 @@ def get_container(device_index: int) -> TreeManagerContainer:
     container_dict = get_obj(local, "tree_manager_containers")
     lock = get_obj(local, "tree_manager_locks")[device_index]
 
+    # What does the lock do if the lock sits in thread-local storage?
+    # Inforce sequential consistency?
     with lock:
         if device_index not in container_dict:
             container_dict[device_index] = TreeManagerContainer(device_index)
@@ -359,6 +361,7 @@ def is_cudagraph_capture_sizes(int_key: Union[int, tuple[int, ...]]) -> bool:
 
 def cudagraphify_impl(
     model: ModelType,
+    # Some inputs are ints, while others are SymInts, hmmm....
     inputs: list[InputType],
     static_input_idxs: Sequence[int],
     *args: Any,
@@ -377,6 +380,8 @@ def cudagraphify_impl(
     def deferred_cudagraphify(inputs: list[InputType]) -> OutputType:
         nonlocal has_warn
 
+        # Okay, so these form a key that we use to create different
+        # cuda graphs.
         int_key = get_ints(inputs)
 
         if not is_cudagraph_capture_sizes(int_key):
@@ -386,6 +391,7 @@ def cudagraphify_impl(
         if fn is not None:
             return fn(inputs)
 
+        # Yeah, recording a graph key
         if int_key is None:
             log.info("recording cudagraph tree for graph without symints")
         else:
@@ -400,6 +406,7 @@ def cudagraphify_impl(
         new_static_input_idxs = remove_unaligned_input_idxs(inputs, static_input_idxs)
         copy_misaligned_inputs(inputs, check_input_idxs)
 
+        # here is thre real cudagraphify
         fn, out = cudagraphify(model, inputs, new_static_input_idxs, *args, **kwargs)
         # cudagraph will already clones input locally, no need to copy back
         mutated_input_idxs: OrderedSet[int] = OrderedSet()
@@ -456,6 +463,7 @@ def cudagraphify(
         else (CompilationMode.INFERENCE if is_inference else CompilationMode.FORWARD)
     )
 
+    # What is this context manager good for?
     with dynamo_timed_cudagraph("cudagraphify.get_container", compile_id, mode):
         manager = get_container(device_index).get_tree_manager()
 

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -995,6 +995,9 @@ class CUDAGraphNode:
         # we reconstruct tensors at the correct data pointers of our inputs which are
         # non owning and do not prevent deallocation. On subsequent executions, input values
         # will be copied over to these tensors.
+
+        # Okay, so he reconstructs the state of this cuda
+        # graph. Should I do this as well? Unclear...
         self.reconstructed_inputs: list[InputType] = [
             self._reconstruct_from_tensor_metadata(self._tensor_metadata(x))
             if isinstance(x, torch.Tensor)
@@ -1111,6 +1114,7 @@ class CUDAGraphNode:
         return outputs
 
     def run(self, new_inputs: list[InputType]) -> OutputType:
+        # Okay, here is what I need to play around with.
         self.check_static_inputs_are_stable(new_inputs)
 
         self._copy_inputs_and_remove_from_src(self.reconstructed_inputs, new_inputs)
@@ -1673,6 +1677,7 @@ class CUDAGraphNode:
         self.stream.wait_stream(torch.cuda.current_stream())
         recording_inputs: list[InputType] = []
 
+        # The recording inputs get allocated within this cudagraph itself...
         with (
             warnings.catch_warnings(record=True),
             torch.cuda.device(self.device),
@@ -1692,6 +1697,7 @@ class CUDAGraphNode:
                 else:
                     recording_inputs.append(inp)
 
+            # Why is it important to do this copy here?
             self._copy_inputs_and_remove_from_src(recording_inputs, inputs)
 
         return recording_inputs

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -1913,6 +1913,7 @@ class CUDAGraphTreeManager:
         # warn only once if a function mutates inputs
         self.warned_mutation: OrderedSet[FunctionID] = OrderedSet()
 
+        # Good to know:
         # NB: cuda caching allocator will remember the stream a segment is allocated to
         # and only allocate that segment to the same stream. we need to use a single stream
         # for all allocations to the memory pool, otherwise the allocations to separate streams
@@ -1924,7 +1925,7 @@ class CUDAGraphTreeManager:
             self.stream = torch.cuda.Stream()
             self.stream.wait_stream(torch.cuda.current_stream())
 
-            # Keeps Memory Pool Alive
+            # Keeps Memory Pool Alive <- Clever
             self.graph: Optional[torch.cuda.CUDAGraph] = torch.cuda.CUDAGraph()
             self.cuda_graphs_thread_pool = torch.cuda.graph_pool_handle()
 

--- a/torch/_inductor/cudagraph_utils.py
+++ b/torch/_inductor/cudagraph_utils.py
@@ -345,6 +345,8 @@ class CudagraphCachedInfo:
     placeholders: Sequence[PlaceholderInfo]
     stack_traces: list[Optional[str]]
     cudagraph_fail_reasons: list[str]
+    # gm: GraphModule #TODO!
+    # outputs_only_for_side_effects: None # TODO!
 
 
 @dataclasses.dataclass(frozen=True)

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -212,6 +212,7 @@ def cudagraph_post_compile(
         placeholders = cached_info.placeholders
         stack_traces = cached_info.stack_traces
 
+        # What does this do?
         prepare_cudagraph_post_compile(
             compiled_graph, example_inputs, boxed_forward_device_index
         )
@@ -220,6 +221,7 @@ def cudagraph_post_compile(
 
         current_callable = compiled_graph.current_callable
         assert current_callable is not None
+        # Okay, I just need to pass compiled_graph into here, somehow...
         compiled_graph.current_callable = cudagraphify(
             current_callable,
             static_input_idxs=static_input_idxs or (),
@@ -452,6 +454,7 @@ class CompiledFxGraph(OutputCode):
         inductor_post_grad_graph_str: str,
         compiled_fn_runner: Optional[Any] = None,
     ) -> None:
+        # TODO: How is this 
         self.current_callable = current_callable
         self.compiled_fn_runner = compiled_fn_runner
         self.recursively_apply_fns = (
@@ -542,6 +545,7 @@ class CompiledFxGraph(OutputCode):
                     # Check mutation later to support cudagraph-managed tensors
                     has_mutation = None
 
+                # What cases might have complex memory overlap?
                 cudagraph_tests = [
                     (not has_mutation, "mutated inputs"),
                     (not complex_memory_overlap_inputs, "complex memory overlap"),
@@ -585,6 +589,7 @@ class CompiledFxGraph(OutputCode):
     def __call__(self, inputs: Sequence[Any]) -> Any:
         assert self.current_callable is not None
         try:
+            # This does not have access to my GraphModule
             return self.current_callable(inputs)
         finally:
             get_runtime_metrics_context().finish()

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -203,6 +203,8 @@ def cudagraph_post_compile(
     is_inference = compiled_graph.fx_kwargs["is_inference"]
     is_backward = compiled_graph.fx_kwargs["is_backward"]
 
+    print("GALVEZ:cudagraph_post_compile")
+
     if not cudagraph_fail_reasons:
         fx_kwargs = compiled_graph.fx_kwargs
         static_input_idxs = fx_kwargs["static_input_idxs"]
@@ -387,6 +389,8 @@ class CompiledFxGraphConstantsWithGm(CompiledFxGraphConstants):
         return {**constants, **frozen_params}
 
 
+# So this is not being called more than once.
+# I imagine that this is being hit twice...
 @dataclasses.dataclass
 class CompiledFxGraph(OutputCode):
     """
@@ -606,6 +610,11 @@ class CompiledFxGraph(OutputCode):
         assert graph_kwargs["is_backward"] is not None
         is_backward = graph_kwargs["is_backward"]
         cudagraphs: BoxedBool = graph_kwargs["cudagraphs"]
+
+        print("GALVEZ:post_compile")
+
+        # import ipdb; ipdb.set_trace()
+
         if cudagraphs:
             # It's possible that cudagraphs is enabled, but was disabled
             # during a previous compilation we're loading from the cache.

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -405,6 +405,7 @@ def ceildiv(
     return runtime_ceildiv(number, denom)
 
 
+# Can I grab types this way somehow?
 def _type_of(key: Optional[torch.dtype]) -> str:
     # Use the function here to get rid of dependencies on the Triton during the codegen.
     # Refer to Triton implementation here:
@@ -2759,6 +2760,7 @@ def clone_preserve_strides(x: torch.Tensor) -> torch.Tensor:
     return torch.as_strided(buffer, x.size(), x.stride())
 
 
+# So there is always a copy if we are misaligned. This is due to triton IIRC
 def copy_misaligned_inputs(
     new_inputs: list[InputType],
     check_inputs_idxs: Sequence[int],

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -950,6 +950,8 @@ def get_first_incompatible_cudagraph_node(
 ) -> Optional[torch.fx.Node]:
     from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols
 
+    # TODO: Understand why precisely these ops are banned inside of
+    # cuda graphs.
     forbidden_set = OrderedSet(
         [
             "aten._fused_moving_avg_obs_fq_helper.default",
@@ -977,7 +979,7 @@ def get_first_incompatible_cudagraph_node(
                 "aten.scatter.reduce",
                 "aten.scatter.value_reduce",
                 "aten.scatter_add_",
-                "aten.scatter_add.default",
+                # "aten.scatter_add.default",
                 "aten.scatter_reduce.two",
                 "aten.scatter_reduce_.two",
                 "aten.scatter_reduce.two_out",

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -965,8 +965,8 @@ def get_first_incompatible_cudagraph_node(
             # assert_scalar with constant arguments can be validly run
             # with CUDA graphs, but the operator is also pointless with
             # constant arguments, so might as well ban
-            "aten._assert_scalar",
-        ]
+            "aten._assert_scalar", 
+       ]
     )
     if torch.are_deterministic_algorithms_enabled():
         forbidden_set.update(
@@ -980,7 +980,7 @@ def get_first_incompatible_cudagraph_node(
                 "aten.scatter.value_reduce",
                 "aten.scatter_add_",
                 # "aten.scatter_add.default",
-                "aten.scatter_reduce.two",
+                # "aten.scatter_reduce.two",
                 "aten.scatter_reduce_.two",
                 "aten.scatter_reduce.two_out",
             )

--- a/torch/csrc/cuda/CUDAPluggableAllocator.cpp
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.cpp
@@ -39,12 +39,15 @@ _AllocationMetadata::_AllocationMetadata(
 // This is a fast API to just register allocators
 // based on function pointers (ie. external .so libraries)
 // This avoids having to link against libtorch for C++ based custom allocators
+// ^ Hmm... I guess it simplifies deployment. I really need to be able to pass in the 
+// begin_allocate_to_pool_fn_ and end_allocate_to_pool_fn_ and relase_pool_fn_ options though...
 // And also use this from python
 CUDAPluggableAllocator::CUDAPluggableAllocator(
     std::function<MallocFuncType> alloc_fn,
     std::function<FreeFuncType> free_fn)
     : alloc_fn_(std::move(alloc_fn)), free_fn_(std::move(free_fn)) {}
 
+// how do I set these?
 CUDAPluggableAllocator::CUDAPluggableAllocator(CUDAPluggableAllocator& other)
     : alloc_fn_(other.alloc_fn_),
       free_fn_(other.free_fn_),
@@ -266,6 +269,8 @@ void CUDAPluggableAllocator::beginAllocateToPool(
     c10::DeviceIndex device,
     c10::cuda::MempoolId_t mempool_id,
     std::function<bool(cudaStream_t)> filter) {
+  // here is what we need to interact with. But how do I set begin_allocate_to_pool_fn_? Ugh.
+  std::cout << "GALVEZ:CUDAPluggableAllocator::beginAllocateToPool" << std::endl;
   if (begin_allocate_to_pool_fn_) {
     begin_allocate_to_pool_fn_(device, mempool_id, std::move(filter));
   }
@@ -371,6 +376,7 @@ void CUDAPluggableAllocator::copy_data(
       cudaMemcpy(dest, src, count, cudaMemcpyKind::cudaMemcpyDeviceToDevice));
 }
 
+// how is this used?
 std::shared_ptr<c10::cuda::CUDACachingAllocator::CUDAAllocator>
     current_custom_allocator;
 

--- a/torch/csrc/cuda/CUDAPluggableAllocator.cpp
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.cpp
@@ -117,8 +117,11 @@ c10::DataPtr CUDAPluggableAllocator::allocate(size_t size) {
   C10_CUDA_CHECK(c10::cuda::GetDevice(&device));
   cudaStream_t stream = c10::cuda::getCurrentCUDAStream(device);
   void* r = this->malloc(size, device, stream);
+  // this is how cudagraph_free is called. Unfortunately, it is not
+  // called for me...
   auto* ctx = new CUDAPluggableAllocatorDeleterContext(
       free_fn_, r, size, device, stream);
+  // who holds this?
   c10::DataPtr data_ptr = {
       r, ctx, raw_deleter(), c10::Device(c10::DeviceType::CUDA, device)};
   return data_ptr;

--- a/torch/csrc/cuda/CUDAPluggableAllocator.h
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.h
@@ -66,6 +66,8 @@ struct _AllocationMetadata {
   cudaStream_t stream{};
 };
 
+// this is totally distinct from NativeCachingAllocator. Both
+// implement the CUDAAllocator interface. Why would 
 struct TORCH_CUDA_CPP_API CUDAPluggableAllocator
     : public c10::cuda::CUDACachingAllocator::CUDAAllocator {
   CUDAPluggableAllocator(

--- a/torch/csrc/cuda/Graph.cpp
+++ b/torch/csrc/cuda/Graph.cpp
@@ -122,5 +122,9 @@ void THCPGraph_init(PyObject* module) {
           },
           py::call_guard<py::gil_scoped_release>())
       .def(py::self == py::self)
-      .def(py::self != py::self);
+      .def(py::self != py::self)
+      .def_static(
+          "get_mem_allocator",
+          torch::wrap_pybind_function_no_gil(
+              &::at::cuda::CUDAGraph::get_mem_allocator));
 }

--- a/torch/csrc/cuda/Graph.cpp
+++ b/torch/csrc/cuda/Graph.cpp
@@ -1,6 +1,7 @@
 #include <torch/csrc/python_headers.h>
 
 #include <pybind11/chrono.h>
+#include <pybind11/operators.h>
 
 #include <torch/csrc/jit/python/pybind_utils.h>
 #include <torch/csrc/utils/pybind.h>
@@ -31,7 +32,8 @@ void THCPGraph_init(PyObject* module) {
           "capture_begin",
           [](::at::cuda::CUDAGraph& self,
              std::optional<c10::cuda::MempoolId_t> pool_opt,
-             const std::string& capture_error_mode) {
+             const std::string& capture_error_mode,
+             bool dynamic_graph) {
             cudaStreamCaptureMode capture_mode{};
             c10::cuda::MempoolId_t pool = pool_opt.has_value()
                 ? pool_opt.value()
@@ -48,10 +50,11 @@ void THCPGraph_init(PyObject* module) {
                   "Unknown capture error mode. Expected `global`, `thread_local`, or `relaxed`, got ",
                   capture_error_mode);
             }
-            return self.capture_begin(pool, capture_mode);
+            return self.capture_begin(pool, capture_mode, dynamic_graph);
           },
           py::arg("pool"),
           py::arg("capture_error_mode"),
+          py::arg("dynamic_graph"),
           py::call_guard<py::gil_scoped_release>())
       .def(
           "capture_end",
@@ -72,6 +75,22 @@ void THCPGraph_init(PyObject* module) {
       .def(
           "replay",
           torch::wrap_pybind_function_no_gil(&at::cuda::CUDAGraph::replay))
+    .def("become_dynamic",
+         torch::wrap_pybind_function_no_gil(&at::cuda::CUDAGraph::become_dynamic))
+          // "become_dynamic",
+          // [](::at::cuda::CUDAGraph& self, const std::vector<at::Tensor>& dynamic_tensors, ::at::cuda::CUDAGraph& graph2) {
+          //   py::gil_scoped_release release;
+          //   self.become_dynamic(dynamic_tensors, graph2);
+          // },
+          // py::arg("dynamic_tensors"),
+          // py::arg("graph2"))
+      .def(
+          "replay_dynamic",
+          [](::at::cuda::CUDAGraph& self, const std::vector<at::Tensor>& dynamic_tensors) {
+            py::gil_scoped_release release;
+            self.replay_dynamic(dynamic_tensors);
+          },
+          py::arg("dynamic_tensors"))
       .def(
           "reset",
           torch::wrap_pybind_function_no_gil(&at::cuda::CUDAGraph::reset))
@@ -101,5 +120,7 @@ void THCPGraph_init(PyObject* module) {
             // compile error.
             return reinterpret_cast<uintptr_t>(graph);
           },
-          py::call_guard<py::gil_scoped_release>());
+          py::call_guard<py::gil_scoped_release>())
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 }

--- a/torch/csrc/cuda/Graph.cpp
+++ b/torch/csrc/cuda/Graph.cpp
@@ -123,7 +123,7 @@ void THCPGraph_init(PyObject* module) {
           py::call_guard<py::gil_scoped_release>())
       .def(py::self == py::self)
       .def(py::self != py::self)
-      .def_static(
+      .def(
           "get_mem_allocator",
           torch::wrap_pybind_function_no_gil(
               &::at::cuda::CUDAGraph::get_mem_allocator));

--- a/torch/csrc/cuda/Graph.cpp
+++ b/torch/csrc/cuda/Graph.cpp
@@ -75,9 +75,7 @@ void THCPGraph_init(PyObject* module) {
       .def(
           "replay",
           torch::wrap_pybind_function_no_gil(&at::cuda::CUDAGraph::replay))
-    .def(// "become_dynamic",
-         // torch::wrap_pybind_function_no_gil(&at::cuda::CUDAGraph::become_dynamic))
-          "become_dynamic",
+    .def("become_dynamic",
           [](::at::cuda::CUDAGraph& self, const std::vector<std::pair<uintptr_t, size_t>>& dynamic_tensors) {
             py::gil_scoped_release release;
 
@@ -92,6 +90,31 @@ void THCPGraph_init(PyObject* module) {
             self.become_dynamic(dynamic_tensors_ptrs);
           },
           py::arg("dynamic_tensors"))
+    .def("become_dynamic2",
+         [](::at::cuda::CUDAGraph& self, const std::vector<std::pair<uintptr_t, size_t>>& dynamic_tensors,
+            ::at::cuda::CUDAGraph* graph2, const std::vector<std::pair<uintptr_t, size_t>>& dynamic_tensors2) {
+            py::gil_scoped_release release;
+
+            std::vector<std::pair<void*, size_t>> dynamic_tensors_ptrs;
+            dynamic_tensors_ptrs.reserve(dynamic_tensors.size());
+            for (auto const& p : dynamic_tensors) {
+              void* ptr = reinterpret_cast<void*>(p.first);
+              dynamic_tensors_ptrs.emplace_back(ptr, p.second);
+            }
+
+            std::vector<std::pair<void*, size_t>> dynamic_tensors_ptrs2;
+            dynamic_tensors_ptrs.reserve(dynamic_tensors2.size());
+            for (auto const& p : dynamic_tensors2) {
+              void* ptr = reinterpret_cast<void*>(p.first);
+              dynamic_tensors_ptrs2.emplace_back(ptr, p.second);
+            }
+
+            self.become_dynamic(dynamic_tensors_ptrs, graph2, dynamic_tensors_ptrs2);
+          },
+         py::arg("dynamic_tensors"),
+         py::arg("graph2"),
+         py::arg("graph2_dynamic_tensors")
+         )
       .def(
           "replay_dynamic",
           [](::at::cuda::CUDAGraph& self, const std::vector<at::Tensor>& dynamic_tensors) {

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -1366,6 +1366,7 @@ static void registerCudaPluggableAllocator(PyObject* module) {
         return true;
       });
 
+  // This may be very helpful for me. I could basically create tensors at arbitrary offsets.
   m.def(
       "_construct_CUDA_Tensor_From_Storage_And_Metadata",
       [](py::dict& metadata, c10::Storage s) {

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -1197,6 +1197,7 @@ static void registerCudaPluggableAllocator(PyObject* module) {
   auto m = py::handle(module).cast<py::module>();
 
   // NOLINTNEXTLINE(bugprone-unused-raii)
+  // okay, so this looks fine to me...
   py::class_<
       c10::cuda::CUDACachingAllocator::CUDAAllocator,
       std::shared_ptr<c10::cuda::CUDACachingAllocator::CUDAAllocator>>(
@@ -1212,6 +1213,7 @@ static void registerCudaPluggableAllocator(PyObject* module) {
         torch::cuda::CUDAPluggableAllocator::changeCurrentAllocator(allocator);
       });
   py::class_<
+      // Right, so I need to create this one! Piece of cake! 
       torch::cuda::CUDAPluggableAllocator::CUDAPluggableAllocator,
       c10::cuda::CUDACachingAllocator::CUDAAllocator,
       std::shared_ptr<
@@ -1288,7 +1290,7 @@ static void registerCudaPluggableAllocator(PyObject* module) {
                 reinterpret_cast<FuncType*>(func_ptr);
             self.set_end_allocate_to_pool_fn(func);
           })
-      .def(
+      .def( // Do I use this?
           "set_release_pool",
           [](torch::cuda::CUDAPluggableAllocator::CUDAPluggableAllocator& self,
              uint64_t func_ptr) {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -5704,6 +5704,7 @@ static void _ncclMemFree(void* ptr, size_t size, int device, void* stream) {
 #endif // NCCL_HAS_MEM_ALLOC
 }
 
+// Let's try this one
 // Create a `CUDAPluggableAllocator` that uses the above functions.
 std::shared_ptr<c10::Allocator> ProcessGroupNCCL::getMemAllocator() {
   C10_LOG_API_USAGE_ONCE("ProcessGroupNCCL.getMemAllocator");

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -73,7 +73,7 @@ class CUDAGraph(torch._C._CUDAGraph):
     def __new__(cls, keep_graph=False):
         return super().__new__(cls, keep_graph)
 
-    def capture_begin(self, pool=None, capture_error_mode="global"):
+    def capture_begin(self, pool=None, capture_error_mode="global", dynamic_graph=False):
         r"""Begin capturing CUDA work on the current stream.
 
         Typically, you shouldn't call ``capture_begin`` yourself.
@@ -90,7 +90,7 @@ class CUDAGraph(torch._C._CUDAGraph):
                 actions in the current thread, and "relaxed" will not error on these actions. Do NOT change this setting
                 unless you're familiar with `cudaStreamCaptureMode <https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__STREAM.html#group__CUDART__STREAM_1g9d0535d93a214cbf126835257b16ba85>`_
         """  # noqa: B950
-        super().capture_begin(pool=pool, capture_error_mode=capture_error_mode)
+        super().capture_begin(pool=pool, capture_error_mode=capture_error_mode, dynamic_graph=dynamic_graph)
 
     def capture_end(self):
         r"""End CUDA graph capture on the current stream.
@@ -115,6 +115,14 @@ class CUDAGraph(torch._C._CUDAGraph):
     def replay(self):
         r"""Replay the CUDA work captured by this graph."""
         super().replay()
+
+    def become_dynamic(self, dynamic_tensors):
+        r"""Become a dynamic graph, where the dynamic_tensors can vary in future replays."""
+        super().become_dynamic(dynamic_tensors)
+
+    def replay_dynamic(self, dynamic_tensors):
+        r"""Replay the CUDA work captured by this graph, upon new data."""
+        super().replay_dynamic(dynamic_tensors)
 
     def reset(self):
         r"""Delete the graph currently held by this instance."""
@@ -188,6 +196,7 @@ class graph:
         pool=None,
         stream=None,
         capture_error_mode: str = "global",
+        dynamic_graph=False
     ):
         # Lazy-init of default_capture_stream helps avoid circular-import errors.
         # Not thread safe, but graphs already have the general (explicitly documented)
@@ -203,6 +212,7 @@ class graph:
         self.stream_ctx = torch.cuda.stream(self.capture_stream)
         self.cuda_graph = cuda_graph
         self.capture_error_mode = capture_error_mode
+        self.dynamic_graph = dynamic_graph
 
     def __enter__(self):
         # Free as much memory as we can for the graph
@@ -215,7 +225,7 @@ class graph:
         self.stream_ctx.__enter__()
 
         self.cuda_graph.capture_begin(
-            *self.pool, capture_error_mode=self.capture_error_mode
+            *self.pool, capture_error_mode=self.capture_error_mode, dynamic_graph=self.dynamic_graph
         )
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -122,6 +122,7 @@ class CUDAGraph(torch._C._CUDAGraph):
 
     def replay_dynamic(self, dynamic_tensors):
         r"""Replay the CUDA work captured by this graph, upon new data."""
+        # import ipdb; ipdb.set_trace()
         super().replay_dynamic(dynamic_tensors)
 
     def reset(self):

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -1235,9 +1235,11 @@ def use_mem_pool(pool: MemPool, device: "Device" = None):
     device_index = (
         torch.cuda.current_device() if device is None else _get_device_index(device)
     )
+    # Just pray that you never use more than one thread during stream capture...
     _cuda_beginAllocateCurrentThreadToPool(device_index, pool.id)
     try:
         yield
     finally:
         _cuda_endAllocateToPool(device_index, pool.id)
+        # Why is releasePool okay here? What is keeping the pool alive?
         _cuda_releasePool(device_index, pool.id)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3459,6 +3459,7 @@ def cross_entropy(
         )
     if size_average is not None or reduce is not None:
         reduction = _Reduction.legacy_get_string(size_average, reduce)
+    # This is failing
     return torch._C._nn.cross_entropy_loss(
         input,
         target,


### PR DESCRIPTION
This is a follow on to #137318 .

The main concern with that PR was robustness: We had no real way of knowing whether or not a particular 8-byte aligned 8-byte value in a parameter was really a pointer. This made it basically impossible to 100% guarantee correctness of replacing the arguments of a cuda graph, since you might accidentally replace a false positive. However, the compiler does in fact know the types of every argument to a cuda kernel; the only way this is exposed right now is via dwarf debug information, so I parsed the dwarf debug information.

Disappointingly, this PR cannot be built on its own. I am currently depending upon a private API to get the ELF file holding a given cuda kernel (since that elf file contains the dwarf debug information we need) that sits in a header file called etbl_private.h (which I did not upload). Exposing internal APIs publicly will take time.

Another challenge with this PR is that it requires you to build all CUDA code with nvcc's "-G" flag. This creates dwarf debug symbols, but at the cost of disabling optimizations. This both slows down compilation and means we don't benefit from this change yet, since your kernels will be way slower.

A final concern is that this doesn't work with code generated via compilers other than nvcc. In particular, triton doesn't seem to generate dwarf debug symbols. I'm not very concerned about this right now, since triton's kernels apparently have very simple parameters (just basic types no structs): https://github.com/triton-lang/triton/blob/bb60d9efe15534c1d0514e19cdf5da14d38779a2/third_party/nvidia/backend/driver.py#L100-L122

That may all sound underwhelming, but I hope this paves the way towards calling cuda graphs as if they are functions. (i.e., you will no longer have to worry about an errant graph.replay() call clobbering an output value from a previous graph.replay()). The ability to reliably detect pointers in a cuda graph also would allow us to prevent cuda graphed code from "hogging" memory from non cuda graphed code. This is because we could "unmap" the physical memory backing virtual addresses of temporary allocations in a cuda graph. It remains to be seen whether this can be done perfomantly @eellison .

I hope this dovetails nicely with @BoyuanFeng 's work on inductor graph partition and removing all of the constraints and workarounds in cudagraph trees.

@eellison @BoyuanFeng @leijurv @zdevito 

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov