### PR TITLE
Make PGO code state not sensitive to file path by hashing file content when the file is available. 

### DIFF
--- a/test/dynamo/test_pgo.py
+++ b/test/dynamo/test_pgo.py
@@ -195,7 +195,7 @@ def run(cnt):
         self.assertTrue("hash(390fe689)" in state)
         self.assertTrue("/example.py:4:func:" in state)
         self.assertTrue(" L['x']: tensor size=[?] stride=[1]" in state)
-        # We should coompile this only once due to PGO.
+        # We should compile this only once due to PGO.
         cnts.clear()
         write_load_and_run(path2)
         self.assertEqual(cnts.frame_count, 1)

--- a/test/dynamo/test_pgo.py
+++ b/test/dynamo/test_pgo.py
@@ -1,7 +1,9 @@
 # Owner(s): ["module: dynamo"]
 
 import contextlib
+import importlib.util
 import os
+import tempfile
 
 import torch._dynamo.config
 import torch._dynamo.test_case
@@ -155,6 +157,49 @@ class PgoTest(torch._dynamo.test_case.TestCase):
                 self.assertEqual(
                     mock_cache.global_stats.dynamo_pgo, mock_cache.Stats(4, 1, 2)
                 )
+
+    # Test that if the same file is appears in two different paths for two different compilations.
+    # pgo still works.
+    def test_different_file_paths_local_pgo(self):
+        content = """
+import torch
+def run(cnt):
+    @torch.compile(backend=cnt, fullgraph=True)
+    def func(x):
+        return x*10
+    func(torch.rand(10))
+    func(torch.rand(20))
+    func(torch.rand(30))
+"""
+        temp_dir1 = tempfile.TemporaryDirectory()
+        temp_dir2 = tempfile.TemporaryDirectory()
+
+        path1 = os.path.join(temp_dir1.name, "example.py")
+        path2 = os.path.join(temp_dir2.name, "example.py")
+        cnts = CompileCounter()
+
+        assert path1 != path2
+
+        def write_load_and_run(path):
+            with open(path, "w") as file:
+                file.write(content)
+            spec = importlib.util.spec_from_file_location("example", path1)
+            assert spec is not None
+            module = importlib.util.module_from_spec(spec)
+            assert spec.loader is not None
+            spec.loader.exec_module(module)
+            module.run(cnts)
+
+        write_load_and_run(path1)
+        self.assertEqual(cnts.frame_count, 2)
+        state = torch._dynamo.pgo.render_code_state(torch._dynamo.pgo.get_code_state())
+        self.assertTrue("hash(390fe689)" in state)
+        self.assertTrue("/example.py:4:func:" in state)
+        self.assertTrue(" L['x']: tensor size=[?] stride=[1]" in state)
+        # We should coompile this only once due to PGO.
+        cnts.clear()
+        write_load_and_run(path2)
+        self.assertEqual(cnts.frame_count, 1)
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_pgo.py
+++ b/test/dynamo/test_pgo.py
@@ -158,8 +158,7 @@ class PgoTest(torch._dynamo.test_case.TestCase):
                     mock_cache.global_stats.dynamo_pgo, mock_cache.Stats(4, 1, 2)
                 )
 
-    # Test that if the same file is appears in two different paths for two different compilations.
-    # pgo still works.
+    # Test that if the same file appears in two different paths for two different compilations PGO still works.
     def test_different_file_paths_local_pgo(self):
         content = """
 import torch

--- a/torch/_dynamo/pgo.py
+++ b/torch/_dynamo/pgo.py
@@ -127,7 +127,7 @@ class CodeId:
     # code state it will refer to the first seen file path.
     file_hash: str
 
-    # execlude file name.
+    # Exclude file name.
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, CodeId):
             return False
@@ -137,7 +137,7 @@ class CodeId:
             and self.name == other.name
         )
 
-    # Ensure if two CodeIds are the same, then they have the same hash by execluding filename.
+    # Ensure if two CodeIds are the same, then they have the same hash by excluding filename.
     def __hash__(self) -> int:
         return hash((self.file_hash, self.name, self.firstlineno))
 

--- a/torch/_dynamo/pgo.py
+++ b/torch/_dynamo/pgo.py
@@ -107,6 +107,10 @@ LOCK_TIMEOUT = 10
 
 @functools.cache
 def _hash_containing_file(filepath: str) -> str:
+    # if the file does not exists we consider filepath to be the hash.
+    if not os.path.exists(filepath):
+        return filepath
+
     with open(filepath, "rb") as file:
         content = file.read()
         crc32_value = zlib.crc32(content)

--- a/torch/_dynamo/pgo.py
+++ b/torch/_dynamo/pgo.py
@@ -127,7 +127,7 @@ class CodeId:
     # code state it will refer to the first seen file path.
     file_hash: str
 
-    # Ensure if two CodeIds are the same, then they have the same hash by execluding filename.
+    # execlude file name.
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, CodeId):
             return False
@@ -137,6 +137,7 @@ class CodeId:
             and self.name == other.name
         )
 
+    # Ensure if two CodeIds are the same, then they have the same hash by execluding filename.
     def __hash__(self) -> int:
         return hash((self.file_hash, self.name, self.firstlineno))
 

--- a/torch/_dynamo/pgo.py
+++ b/torch/_dynamo/pgo.py
@@ -114,18 +114,18 @@ def _hash_containing_file(filepath: str) -> str:
         return hash
 
 
+@dataclasses.dataclass(frozen=True)
 class CodeId:
-    def __init__(self, code: types.CodeType) -> None:
-        self.filename: str = code.co_filename
-        self.firstlineno: int = code.co_firstlineno
-        self.name: str = code.co_name
-        # When a job restart, the code can be copied to a different path than the previous attempt. In that case
-        # self.filename will have a different value,  we do not want to consider those differences. Instead we
-        # hash the content of the file and use it as an identifier of the file.
-        #
-        # self.filename is kept in the object to give readable information/pointer to the actual file, in a local
-        # code state it will refer to the first seen file path.
-        self.file_hash = _hash_containing_file(self.filename)
+    filename: str
+    firstlineno: int
+    name: str
+    # When a job restart, the code can be copied to a different path than the previous attempt. In that case
+    # self.filename will have a different value,  we do not want to consider those differences. Instead we
+    # hash the content of the file and use it as an identifier of the file.
+    #
+    # self.filename is kept in the object to give readable information/pointer to the actual file, in a local
+    # code state it will refer to the first seen file path.
+    file_hash: str
 
     # Ensure if two CodeIds are the same, then they have the same hash by execluding filename.
     def __eq__(self, other: object) -> bool:
@@ -142,6 +142,15 @@ class CodeId:
 
     def __str__(self) -> str:
         return f"hash({self.file_hash}){self.filename}:{self.firstlineno}:{self.name}"
+
+    @staticmethod
+    def make(code: types.CodeType) -> CodeId:
+        return CodeId(
+            code.co_filename,
+            code.co_firstlineno,
+            code.co_name,
+            _hash_containing_file(code.co_filename),
+        )
 
 
 @dataclasses.dataclass
@@ -352,9 +361,8 @@ def update_automatic_dynamic(
     *,
     is_unspecialized_nn_module: bool = False,
 ) -> FrameStateSizeEntry:
-    code_id = CodeId(tx.f_code)
+    code_id = CodeId.make(tx.f_code)
     frame_state = get_code_state()[code_id]
-    print
     is_update = name in frame_state.automatic_dynamic
     mut_entry = frame_state.automatic_dynamic[name]
     old_entry = copy.copy(mut_entry)
@@ -588,7 +596,7 @@ def get_remote_cache() -> Optional[RemoteCache[JsonDataTy]]:
 
 def render_code_state(cs: defaultdict[CodeId, CodeState]) -> str:
     return "\n".join(
-        f"{str(k)}:\n"
+        f"{k}:\n"
         + "\n".join(
             f"  {src}: {fs.render()}" for src, fs in v.automatic_dynamic.items()
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #152628

In some internal frameworks, on second attempts the actual code is copied to a different path than previous attempts. 
but its still the same. PGO will not work on those cased due to the following, sate entries before this PR used to be identified by (filepath, function name, line number).

after this PR they are identified by (hash(filepath) , function name, line number). This way PGO will work for those jobs on future attempts and re-compilations of static versions will be avoided.

Sometimes we do not have access to the source code, (file does not exists)
This seems to happen mostly when we re-trace a compiled function but generally it can happen . 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames