### PR TITLE
Fix two error messages involving Tensor.dense()

### DIFF
--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -822,7 +822,7 @@ class TensorVariable(VariableTracker):
             unimplemented("Tensor.numpy(). NumPy is not available")
         if self.layout != torch.strided:
             raise TypeError(
-                f"can't convert {self.layout} layout tensor to numpy. Use Tensor.dense() first"
+                f"can't convert {self.layout} layout tensor to numpy. Use Tensor.to_dense() first"
             )
         from ..symbolic_convert import InstructionTranslator
 

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -132,7 +132,7 @@ PyObject* tensor_to_numpy(const at::Tensor& tensor, bool force /*=false*/) {
       "can't convert ",
       c10::str(tensor.layout()).c_str(),
       " layout tensor to numpy. ",
-      "Use Tensor.dense() first.");
+      "Use Tensor.to_dense() first.");
 
   if (!force) {
     TORCH_CHECK_TYPE(


### PR DESCRIPTION
Two error messages in the codebase instruct the user to use `Tendor.dense()`. This method doesn't exist, but `Tensor.to_dense()` does, and this is what the user should be using instead.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames