### PR TITLE
[AOTAutogradCache][Easy] Move `"einops.einops.rearrange"` to `SAFE_NON_TORCH_FUNCTIONS`

### DIFF
--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -135,9 +135,11 @@ def check_node_safe(node: Node):
         "torch._sym_sqrt",
         "torch.sym_float",
         "torch.sym_sum",
-        "einops.einops.rearrange",
     )
-    SAFE_NON_TORCH_FUNCTIONS = ("einops.einops.repeat",)
+    SAFE_NON_TORCH_FUNCTIONS = (
+        "einops.einops.rearrange",
+        "einops.einops.repeat",
+    )
 
     def is_public_torch_api(target):
         # Don't blindly allow private functions in the torch namespace


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #152640

As title.