### PR TITLE
Add assert_fp8_close helper for FP8 tensor comparisons

### DIFF
--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -1525,6 +1525,13 @@ def assert_close(
     "You can find detailed upgrade instructions in https://github.com/pytorch/pytorch/issues/61844.",
     category=FutureWarning,
 )
+def assert_fp8_close(actual, expected, *, rtol=1e-1, atol=1e-2, **kwargs):
+    actual32  = actual.to(torch.float32)
+    expected32 = expected.to(torch.float32)
+    torch.testing.assert_close(
+        actual32, expected32, rtol=rtol, atol=atol, **kwargs
+    )
+
 def assert_allclose(
     actual: Any,
     expected: Any,


### PR DESCRIPTION
This PR adds a new helper function `assert_fp8_close` in `torch/testing/_comparison.py` that makes it easy to compare FP8 tensors with a sane default tolerance:

- Casts both `actual` and `expected` FP8 tensors to `float32`
- Calls `torch.testing.assert_close` with `rtol=1e-1` and `atol=1e-2`
- Allows overriding those tolerances via the usual kwargs

This addresses the problem in #152647 where FP8 comparisons fall back to zero tolerance.  
Fixes #152647
