### PR TITLE
Remove incorrect assertion

### DIFF
--- a/torch/_inductor/comms.py
+++ b/torch/_inductor/comms.py
@@ -165,7 +165,6 @@ class ReorderInfo:
 
     @property
     def improvement(self):
-        assert self.initial_exposed >= self.final_exposed >= 0
         return self.initial_exposed - self.final_exposed
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #152654
* __->__ #152653
* #152565

It's only aspirational that the 'improvement' value is positive. In fact
the pass could make a collective more exposed and we shouldn't assert
here in that case

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov