### PR TITLE
[Inductor] Fix kernel argument ordering when using dynamic shapes with workspace

### DIFF
--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -41,10 +41,7 @@ if TYPE_CHECKING:
 
     from torch._inductor.select_algorithm import TritonTemplateCaller
 
-    from .codegen.common import WorkspaceArg
-
 from . import config
-from .codegen.common import WorkspaceZeroMode
 from .runtime.benchmarking import benchmarker
 from .virtualized import V
 
@@ -583,7 +580,6 @@ class TritonBenchmarkRequest(BenchmarkRequest):
         matrix_instr_nonkdim: int = 0,  # only used for hip to choose the shape of mfma instruction.
         waves_per_eu: int = 0,  # only used for hip to schedule waves per execution unit
         kpack: int = 0,  # ROCm specific gemm paramete
-        workspace_arg: Optional[WorkspaceArg] = None,
     ) -> None:
         super().__init__(kernel_name, input_tensor_meta, output_tensor_meta, extra_args)
         self.module_path = module_path
@@ -595,7 +591,6 @@ class TritonBenchmarkRequest(BenchmarkRequest):
         self.matrix_instr_nonkdim = matrix_instr_nonkdim
         self.waves_per_eu = waves_per_eu
         self.kpack = kpack
-        self.workspace_arg = workspace_arg
 
     def make_run_fn(
         self, *input_tensors: torch.Tensor, output_tensor: torch.Tensor
@@ -628,36 +623,6 @@ class TritonBenchmarkRequest(BenchmarkRequest):
                 self.output_tensor_meta.device.index
             )
 
-        if self.workspace_arg is not None:
-            # Create a function that handles both workspace creation and kernel execution
-            workspace_arg = self.workspace_arg
-
-            def run_with_workspace():
-                # Create workspace tensor
-                workspace_size = workspace_arg.count
-                workspace_tensor = torch.empty_strided(
-                    (workspace_size,),
-                    (1,),
-                    dtype=torch.uint8,
-                    device=output_tensor.device,
-                )
-
-                # Handle zero initialization if needed
-                if workspace_arg.zero_mode != WorkspaceZeroMode.UNINITIALIZED:
-                    workspace_tensor.zero_()
-
-                # Run the kernel with workspace
-                run_method(
-                    *input_tensors,
-                    output_tensor,
-                    workspace_tensor,
-                    *extra_args,
-                    **warmup_arg,
-                    stream=stream,
-                    benchmark_run=True,
-                )
-
-            return run_with_workspace
         if isinstance(
             getattr(mod, self.kernel_name),
             torch._inductor.runtime.triton_heuristics.DebugAutotuner,

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -47,6 +47,7 @@ from .codegen.common import (
     KernelTemplate,
     OpOverrides,
     WorkspaceArg,
+    WorkspaceZeroMode,
 )
 from .codegen.simd_kernel_features import SIMDKernelFeatures
 from .codegen.subgraph import SubgraphChoiceCaller
@@ -1309,6 +1310,23 @@ class TritonTemplate(KernelTemplate):
 
         kernel_hash_name = f"triton_{self.name}_{next(self.index_counter)}"
 
+        workspace_args = []
+        if workspace_arg is not None:
+            # Create workspace tensor
+            workspace_size = workspace_arg.count
+            workspace_tensor = torch.empty_strided(
+                (workspace_size,),
+                (1,),
+                dtype=torch.uint8,
+                device=layout.device.type,
+            )
+
+            # Handle zero initialization if needed
+            if workspace_arg.zero_mode != WorkspaceZeroMode.UNINITIALIZED:
+                workspace_tensor.zero_()
+
+            workspace_args.append(workspace_tensor)
+
         options = result.kernel_options
 
         def make_kernel_render(out_node):
@@ -1345,7 +1363,7 @@ class TritonTemplate(KernelTemplate):
             module_path=result.mod.__file__,
             module_cache_key=result.mod.key,
             kernel_name=f"triton_{self.name}",
-            extra_args=[*extra_args, *grid],
+            extra_args=[*extra_args, *workspace_args, *grid],
             num_stages=num_stages,
             num_warps=num_warps,
             num_consumer_groups=num_consumer_groups,
@@ -1355,7 +1373,6 @@ class TritonTemplate(KernelTemplate):
             kpack=kwargs.get("kpack", 2),
             input_tensor_meta=TensorMeta.from_irnodes(full_input_nodes),  # type: ignore[arg-type]
             output_tensor_meta=TensorMeta.from_irnodes(layout),
-            workspace_arg=workspace_arg,
         )
 
         return TritonTemplateCaller(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #152660

Summary:
This PR fixes a bug in the Triton kernel invocation path where the `workspace_tensor` was inserted before the unpacked `extra_args` list in the final kernel argument list. This broke the expected ordering of arguments when dynamic shape size hints are emitted.

When dynamic shapes are used, `extra_args` contains both size hint arguments and grid arguments. The kernel expects the argument list to follow the order: **size hints → workspace tensor → grid args**. But previously, the `workspace_tensor` was inserted before unpacking `extra_args`, resulting in: **workspace tensor → size hints → grid args**, which is incorrect.

This fix constructs the workspace tensor earlier, allowing it to be slotted in after the size hints and before the grid arguments, restoring the expected argument layout.

Test Plan:
contbuild and OSS CI

Reviewers: paulzhan

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov