### PR TITLE
[export] Dynamo symint support

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -3458,7 +3458,7 @@ def forward(self, x):
                     gm, guards = torch._dynamo.export(f)(pred, x)
                     actual = normalize_gm(gm.print_readable(print_output=False))
                     # TODO: This is naughty, EXPECTTEST_ACCEPT=1 doesn't work
-                    self.assertExpectedInline(actual, exp_graph[i])
+                    self.assertExpectedInline(actual, exp_graph[i].format(size=size))
                     dynamo_shape_env_guards = [
                         guard
                         for guard in guards
@@ -3480,9 +3480,9 @@ def forward(self, x):
         true_graph = """\
 class GraphModule(torch.nn.Module):
     def forward(self, pred, x):
-        arg1: "f32[s77, s27]";
+        arg0: "Sym(Eq(s26, {size}))"; arg1: "f32[s77, s27]";
 
-        arg0, arg1, = fx_pytree.tree_flatten_spec(([pred, x], {}), self._in_spec)
+        arg0, arg1, = fx_pytree.tree_flatten_spec(([pred, x], {{}}), self._in_spec)
         l_x_ = arg1
 
         sin: "f32[s77, s27]" = l_x_.sin();  l_x_ = None
@@ -3491,9 +3491,9 @@ class GraphModule(torch.nn.Module):
         false_graph = """\
 class GraphModule(torch.nn.Module):
     def forward(self, pred, x):
-        arg1: "f32[s77, s27]";
+        arg0: "Sym(Eq(s26, {size}))"; arg1: "f32[s77, s27]";
 
-        arg0, arg1, = fx_pytree.tree_flatten_spec(([pred, x], {}), self._in_spec)
+        arg0, arg1, = fx_pytree.tree_flatten_spec(([pred, x], {{}}), self._in_spec)
         l_x_ = arg1
 
         cos: "f32[s77, s27]" = l_x_.cos();  l_x_ = None

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -7001,6 +7001,7 @@ def forward(self, x):
             if node.op == "placeholder":
                 self.assertTrue(isinstance(node.meta["val"], (Tensor, int)))
 
+    @testing.expectedFailureRetraceability  # size gets unflattened into a tuple
     def test_size_input(self):
         class Model(torch.nn.Module):
             def __init__(self):
@@ -10271,28 +10272,27 @@ graph():
 
     @testing.expectedFailureCppRuntime
     def test_symint_input_basic(self):
-        strict = False  # TODO: support strict=True
-
         class M(torch.nn.Module):
             def forward(self, x, y):
                 return x * y
 
         ep = export(M(), (4, 5))
         self.assertEqual(ep.module()(4, 5), 20)
-
         with self.assertRaisesRegex(RuntimeError, r"to be equal to 4, but got 3"):
             self.assertEqual(ep.module()(3, 6), 18)
 
-        ep = export(
-            M(), (4, 5), dynamic_shapes={"x": Dim.DYNAMIC, "y": Dim.AUTO}, strict=strict
-        )
+        ep = export(M(), (4, 5), dynamic_shapes={"x": Dim.DYNAMIC, "y": Dim.AUTO})
         self.assertEqual(ep.module()(4, 5), 20)
         self.assertEqual(ep.module()(3, 6), 18)
 
-        ep = export(
-            M(), (5, 5), dynamic_shapes={"x": None, "y": Dim.AUTO}, strict=strict
-        )
+        ep = export(M(), (4, 5), dynamic_shapes={"x": Dim.DYNAMIC, "y": Dim.AUTO})
+        self.assertEqual(ep.module()(4, 5), 20)
+        self.assertEqual(ep.module()(3, 6), 18)
+
+        ep = export(M(), (5, 5), dynamic_shapes={"x": None, "y": Dim.AUTO})
         self.assertEqual(ep.module()(5, 6), 30)
+        with self.assertRaisesRegex(RuntimeError, r"to be equal to 5, but got 3"):
+            self.assertEqual(ep.module()(3, 5), 18)
 
         class M(torch.nn.Module):
             def forward(self, x, y):
@@ -10302,17 +10302,13 @@ graph():
             M(),
             ({"moo": 2}, torch.ones(3, 3)),
             dynamic_shapes={"x": {"moo": Dim.DYNAMIC}, "y": {0: Dim.DYNAMIC}},
-            strict=strict,
         )
         inp = ({"moo": 3}, torch.ones(4, 3))
         self.assertTrue(torch.allclose(ep.module()(*inp), M()(*inp)))
 
     @testing.expectedFailureCppRuntime
-    @testing.expectedFailureRetraceability
-    @testing.expectedFailureRetraceabilityNonStrict
+    @testing.expectedFailureRetraceabilityNonStrict  # no runtime asserts added for assert x == 3
     def test_symint_input_specialization(self):
-        strict = False  # TODO: support strict=True
-
         class M(torch.nn.Module):
             def forward(self, x, y):
                 assert x == 3
@@ -10328,24 +10324,19 @@ graph():
                 M(),
                 inp,
                 dynamic_shapes=(Dim.DYNAMIC, None),
-                strict=strict,
             )
 
         ep = export(
             M(),
             inp,
             dynamic_shapes=(Dim.AUTO, None),
-            strict=strict,
         )
         with self.assertRaisesRegex(RuntimeError, "to be equal to 3, but got 4"):
             ep.module()(4, torch.randn(4, 4))
 
     @testing.expectedFailureCppRuntime
-    @testing.expectedFailureRetraceability
-    @testing.expectedFailureRetraceabilityNonStrict
+    @testing.expectedFailureRetraceabilityNonStrict  # no runtime asserts added for assert x == 3
     def test_symint_input_ranges(self):
-        strict = False  # TODO: support strict=True
-
         class M(torch.nn.Module):
             def forward(self, x, y):
                 return x * y
@@ -10355,7 +10346,6 @@ graph():
             M(),
             inp,
             dynamic_shapes=(Dim.DYNAMIC(min=3, max=10), None),
-            strict=strict,
         )
 
         ep.module()(4, torch.randn(4, 4))
@@ -10376,10 +10366,8 @@ graph():
             M(),
             inp,
             dynamic_shapes=(Dim.DYNAMIC(min=3, max=10), None),
-            strict=strict,
         )
         constraints = list(ep.range_constraints.values())
-        self.assertEqual(len(constraints), 1)
         constraint = constraints[0]
         self.assertEqual(constraint.lower, 4)
         self.assertEqual(constraint.upper, 5)
@@ -10396,10 +10384,8 @@ graph():
             M(),
             inp,
             dynamic_shapes=(Dim.DYNAMIC(min=3, max=10), None),
-            strict=strict,
         )
         constraints = list(ep.range_constraints.values())
-        self.assertEqual(len(constraints), 1)
         constraint = constraints[0]
         self.assertEqual(constraint.lower, 3)
         self.assertEqual(constraint.upper, 10)
@@ -10419,13 +10405,10 @@ graph():
                 M(),
                 inp,
                 dynamic_shapes=(Dim.DYNAMIC(min=3, max=10), None),
-                strict=strict,
             )
 
     @testing.expectedFailureCppRuntime
     def test_symint_input_additional_inputs(self):
-        strict = False  # TODO: support strict=True
-
         class M(torch.nn.Module):
             def forward(self, x, y):
                 return x + y
@@ -10434,17 +10417,13 @@ graph():
         additional_inputs.add((5, 5))
         additional_inputs.add((3, 5))
         additional_inputs.add((5, 4))
-        ep = torch.export.export(
-            M(), (6, 7), dynamic_shapes=additional_inputs, strict=strict
-        )
+        ep = torch.export.export(M(), (6, 7), dynamic_shapes=additional_inputs)
         self.assertEqual(ep.module()(5, 5), 10)
         self.assertEqual(ep.module()(3, 5), 8)
         self.assertEqual(ep.module()(5, 4), 9)
 
     @testing.expectedFailureCppRuntime
     def test_symint_input_shapes_collection(self):
-        strict = False  # TODO: support strict=True
-
         class M(torch.nn.Module):
             def forward(self, x, y):
                 return x + y
@@ -10456,9 +10435,7 @@ graph():
         shapes_collection = torch.export.ShapesCollection()
         shapes_collection[args[0]] = Dim.DYNAMIC
         shapes_collection[args[1]] = Dim.DYNAMIC
-        ep = torch.export.export(
-            M(), args, dynamic_shapes=shapes_collection, strict=strict
-        )
+        ep = torch.export.export(M(), args, dynamic_shapes=shapes_collection)
         self.assertEqual(ep.module()(5, 5), 10)
         self.assertEqual(ep.module()(3, 5), 8)
         self.assertEqual(ep.module()(5, 4), 9)

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -69,8 +69,12 @@ from torch._subclasses.fake_tensor import unset_fake_temporarily
 from torch._utils_internal import justknobs_check, log_export_usage
 from torch.export.dynamic_shapes import (
     _combine_args,
+    _DimHint,
+    _DimHintType,
+    _IntWrapper,
     _process_dynamic_shapes,
     _RelaxedConstraint,
+    Constraint,
 )
 from torch.fx import GraphModule
 from torch.fx.experimental._dynamism import (
@@ -1198,6 +1202,11 @@ class FlattenInputOutputSignature(torch.fx.Transformer):
                             constraint_sizes=[None] * len(flat_args[i].shape),
                         ),
                     )
+                elif isinstance(flat_args[i], _IntWrapper):
+                    arg.node.meta["val"] = flat_args[i].val
+                else:
+                    arg.node.meta["val"] = flat_args[i]
+
             self.new_args.append(arg)
         self.old_args_gen = (self.new_args[i] for i in matched_input_elements_positions)
         self.matched_output_elements_positions = matched_output_elements_positions
@@ -1337,6 +1346,7 @@ def rewrite_signature(
             torch.SymFloat,
             torch.SymBool,
             torch._C.ScriptObject,
+            _IntWrapper,
         ] + list(common_constant_types)
 
         def is_supported_type(val):
@@ -1533,6 +1543,7 @@ def export(
     prefer_deferred_runtime_asserts_over_guards: bool = False,
     allow_complex_guards_as_runtime_asserts: bool = False,
     _log_export_usage: bool = True,
+    constraints: Optional[list[Constraint]] = None,
     **extra_kwargs,
 ) -> Callable[..., ExportResult]:
     """
@@ -1595,10 +1606,15 @@ def export(
     _f = f
     _specialize_float = specialize_float
     _assume_static_by_default = assume_static_by_default
+    _constraints = constraints
 
     def inner(*args, **kwargs):
-        combined_args = _combine_args(_f, args, kwargs)
-        constraints = _process_dynamic_shapes(combined_args, dynamic_shapes)
+        if not _constraints:
+            combined_args = _combine_args(_f, args, kwargs)
+            constraints = _process_dynamic_shapes(combined_args, dynamic_shapes)
+        else:
+            constraints = _constraints
+
         f = _f
         specialize_float = _specialize_float
         assume_static_by_default = _assume_static_by_default
@@ -1689,8 +1705,35 @@ def export(
                             value, static_shapes=True
                         )
 
-                    fake_graph_inputs = pytree.tree_map(
-                        ambient_fake_mode.from_tensor, graph_inputs
+                    def fakify_with_ambient(path, t):
+                        if isinstance(t, torch.Tensor):
+                            return ambient_fake_mode.from_tensor(t, static_shapes=True)
+                        elif isinstance(t, _IntWrapper):
+                            if (
+                                t.dynamism is not None
+                                and isinstance(t.dynamism, _DimHint)
+                                and t.dynamism.type
+                                in (
+                                    _DimHintType.DYNAMIC,
+                                    _DimHintType.AUTO,
+                                )
+                            ):  # type: ignore[union-attr]
+                                from torch._export.non_strict_utils import (
+                                    key_path_to_source,
+                                )
+
+                                source = key_path_to_source(path)
+                                symint = ambient_fake_mode.shape_env.create_unspecified_symint_and_symbol(  # type: ignore[union-attr]
+                                    t.val, source, DimDynamic.DYNAMIC
+                                )
+                                return symint
+                            else:
+                                return t.val
+                        else:
+                            return t
+
+                    fake_graph_inputs = pytree.tree_map_with_path(
+                        fakify_with_ambient, graph_inputs
                     )
                     graph_captured_result = torch.func.functional_call(
                         graph, fake_params_buffers, fake_graph_inputs
@@ -1829,7 +1872,10 @@ def export(
                 check_signature_rewritable(graph)
 
         # NB: This is mostly hitting the cache; Dynamo already converted these
-        example_fake_inputs = [fake_mode.from_tensor(t) for t in example_inputs]
+        example_fake_inputs = [
+            fake_mode.from_tensor(t) if isinstance(t, torch.Tensor) else t
+            for t in example_inputs
+        ]
 
         if aten_graph:
             # Running graph with interpreter is needed for propagating the stack_trace

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -1687,6 +1687,10 @@ class GuardBuilder(GuardBuilderBase):
                 DeviceMesh,
             )
 
+        from torch.export.dynamic_shapes import _IntWrapper
+
+        ok_types = ok_types + (_IntWrapper,)
+
         import torch.utils._pytree as pytree
 
         assert istype(val, ok_types) or pytree.is_constant_class(type(val)), (

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -66,6 +66,8 @@ from torch.fx.experimental.symbolic_shapes import (
     StatefulSymbolicContext,
     SubclassSymbolicContext,
     SymbolicContext,
+    SymIntSymbolicContext,
+    TrackedFake,
 )
 from torch.fx.immutable_collections import immutable_dict, immutable_list
 from torch.nn.utils._expanded_weights import ExpandedWeight
@@ -260,6 +262,7 @@ from .torch_function import (
 )
 from .user_defined import (
     FrozenDataClassVariable,
+    IntWrapperVariable,
     KeyedJaggedTensorVariable,
     MutableMappingVariable,
     SourcelessGraphModuleVariable,
@@ -1444,6 +1447,23 @@ class VariableBuilder:
                         "Ensure your dict_keys keys are constants (e.g. int, float, strings)",
                     ],
                 )
+        elif IntWrapperVariable.is_matching_object(value):
+            from torch.export.dynamic_shapes import _DimHintType
+
+            if value.dynamism is None or value.dynamism.type == _DimHintType.STATIC:
+                return self.wrap_symint(value.val)
+            elif value.dynamism.type == _DimHintType.DYNAMIC:
+                return self.wrap_symint(
+                    value.val,
+                    dynamism=DimDynamic.DYNAMIC,
+                    context=SymIntSymbolicContext(
+                        constraint=RelaxedUnspecConstraint(warn_only=False)
+                    ),
+                )
+            elif value.dynamism.type == _DimHintType.AUTO:
+                return self.wrap_symint(value.val, dynamism=DimDynamic.DYNAMIC)
+            else:
+                raise RuntimeError(f"Undefined dynamism {value.dynamism}")
         else:
             return self.wrap_user_defined(value)
 
@@ -2086,7 +2106,13 @@ class VariableBuilder:
 
         return numpy_ndarray_variable
 
-    def wrap_symint(self, value, is_forced_allow_list_dynamic=False):
+    def wrap_symint(
+        self,
+        value,
+        is_forced_allow_list_dynamic=False,
+        dynamism: Optional[DimDynamic] = None,
+        context: Optional[SymIntSymbolicContext] = None,
+    ):
         assert type(value) is int
 
         if self.name in self.tx.output.unspec_variable_map:
@@ -2105,10 +2131,11 @@ class VariableBuilder:
         # but the general idea is that we generate kernels that can
         # take unspecialized floats and use them in sizevar computation
         elif not is_constant_source(self.get_source()):
-            if torch._dynamo.config.specialize_int:
+            if dynamism is None and torch._dynamo.config.specialize_int:
                 # If specialize_int is False, also return
                 # a constant (but this should have been handled
-                # in the caller, TBH)
+                # in the caller, TBH). But if `dynamism` is set, then actually
+                # turn it into a symint
                 self.install_guards(GuardBuilder.CONSTANT_MATCH)
                 return ConstantVariable.create(value=value, source=self.source)
 
@@ -2130,7 +2157,10 @@ class VariableBuilder:
             if isinstance(base_source, ChainedSource):
                 base_source = base_source.get_base()
 
-            if is_forced_allow_list_dynamic:
+            if dynamism == DimDynamic.DYNAMIC:
+                log.debug("%s marked %s via IntWrapper", self.source.name(), dynamism)
+                dynamic_dim = dynamism
+            elif is_forced_allow_list_dynamic:
                 log.debug("%s marked dynamic via source whitelist", self.source.name())
                 dynamic_dim = DimDynamic.DYNAMIC
             elif (
@@ -2159,7 +2189,7 @@ class VariableBuilder:
             )
 
             self.tx.output.tracked_fakes.append(
-                TrackedFake(wrapped_value, self.source, None)
+                TrackedFake(wrapped_value, self.source, context)
             )
         else:
             assert is_constant_source(self.get_source())
@@ -2186,11 +2216,6 @@ class VariableBuilder:
         self.tx.output.unspec_variable_map[self.name] = unspec_var
 
         if not is_constant_source(self.get_source()):
-            if self.tx.export and not isinstance(self.get_source(), LocalSource):
-                raise AssertionError(
-                    f"Dynamo attempts to add additional input during export: value={wrapped_value}, source={self.get_source()}"
-                )
-
             proxy.node.meta["grapharg"] = GraphArg(
                 self.get_source(),
                 wrapped_value,
@@ -2900,23 +2925,6 @@ def is_dynamic_source(source_name: str) -> bool:
             )
             return True
     return False
-
-
-# Tracks the sources of all fake tensors we wrap in Dynamo.
-# Used by shape guard computation.
-@dataclasses.dataclass
-class TrackedFake:
-    fake: Union[FakeTensor, SymInt]
-    source: Source
-    symbolic_context: Optional[SymbolicContext]
-
-    def __hash__(self) -> int:
-        return hash((self.fake, self.source.name()))
-
-    def __eq__(self, other: object) -> bool:
-        if isinstance(other, TrackedFake):
-            return self.fake is other.fake and self.source.name() == other.source.name()
-        return False
 
 
 # Performs automatic dynamic dim determination.

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1482,6 +1482,15 @@ class KeyedJaggedTensorVariable(UserDefinedObjectVariable):
         return super().var_getattr(tx, name)
 
 
+class IntWrapperVariable(UserDefinedObjectVariable):
+    # Dummy class to check if the object is an IntWrapper, and turn it into a
+    # symint
+    @staticmethod
+    def is_matching_object(obj):
+        mod = sys.modules.get("torch.export.dynamic_shapes")
+        return mod is not None and type(obj) is mod._IntWrapper
+
+
 class RemovableHandleClass:
     # Dummy class to pass to python_type of RemovableHandleVariable
     # Useful for isinstance check on hooks

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -308,7 +308,13 @@ def _check_symint(
     keypath: KeyPath,
     i: Optional[int] = None,
 ) -> None:
-    if isinstance(arg, torch.SymInt) and not arg.node.expr.is_number:
+    from torch.export.dynamic_shapes import _IntWrapper
+
+    if (
+        isinstance(arg, torch.SymInt)
+        and not arg.node.expr.is_number
+        or isinstance(arg, _IntWrapper)
+    ):
         # This can happen when, say, arg is a fake tensor.
         # We do not run checks on symbolic shapes of fake inputs as
         # such checks can affect the shape env.

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -157,6 +157,7 @@ __all__ = [
     "StatefulSymbolicContext",
     "SubclassSymbolicContext",
     "SymIntSymbolicContext",
+    "TrackedFake",
     "statically_known_true",
     "guard_size_oblivious",
     "check_consistent",
@@ -2004,6 +2005,23 @@ class SubclassSymbolicContext(StatefulSymbolicContext):
         super().__post_init__()
         if self.inner_contexts is None:
             self.inner_contexts = {}
+
+
+# Tracks the sources of all fake tensors we wrap in Dynamo.
+# Used by shape guard computation.
+@dataclass
+class TrackedFake:
+    fake: Union[FakeTensor, SymInt]
+    source: Source
+    symbolic_context: Optional[SymbolicContext]
+
+    def __hash__(self) -> int:
+        return hash((self.fake, self.source.name()))
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, TrackedFake):
+            return self.fake is other.fake and self.source.name() == other.source.name()
+        return False
 
 
 def is_symbolic(


### PR DESCRIPTION
Basically adds native _IntWrapper support to dynamo. Here's my process of trying to make symint input support work on dynamo, and how I ended up with this approach [(doc)](https://docs.google.com/document/d/1GvNRQd8BnxlMay_hrEVgEta6VUeUW_hcFeRuB7q1nDY/edit?tab=t.0).

What I did was, before passing inputs to dynamo.export, I first wrap them with a class, `_IntWrapper`. When processing dynamic shapes, I will then add the corresponding dynamic shape specification to the `dynamism` field stored on the `_IntWrapper`. If there is no dynamism specified, then this will get unwrapped back to an integer. When dynamo tracing, when we encounter an `_IntWrapper`, we will convert this to a symint if the dynamism was specified as `Dim.DYNAMIC/AUTO`. Dynamo will then trace a graph that contains symint inputs, which will get passed to AOTAutograd and so on.

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @chenyang78 @kadeng @chauhang @amjames