### PR TITLE
[dynamo] Guard serialization for DUPLICATE_INPUT.

### DIFF
--- a/test/dynamo/test_guard_serialization.py
+++ b/test/dynamo/test_guard_serialization.py
@@ -446,6 +446,13 @@ class TestGuardSerialization(torch._inductor.test_case.TestCase):
         with torch._functorch.eager_transforms.grad_increment_nesting():
             self._test_check_fn(ref, loaded, {"x": x}, False)
 
+    def test_duplicate_input(self):
+        def fn(x, x_):
+            return x + x_
+
+        x = torch.randn(3, 2)
+        with self.assertRaisesRegex(RuntimeError, "DUPLICATE_INPUT guard cannot be serialized"):
+            self._test_serialization("DUPLICATE_INPUT", fn, x, x)
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/dynamo/test_guard_serialization.py
+++ b/test/dynamo/test_guard_serialization.py
@@ -451,8 +451,11 @@ class TestGuardSerialization(torch._inductor.test_case.TestCase):
             return x + x_
 
         x = torch.randn(3, 2)
-        with self.assertRaisesRegex(RuntimeError, "DUPLICATE_INPUT guard cannot be serialized"):
+        with self.assertRaisesRegex(
+            RuntimeError, "DUPLICATE_INPUT guard cannot be serialized"
+        ):
             self._test_serialization("DUPLICATE_INPUT", fn, x, x)
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -1838,6 +1838,8 @@ class GuardBuilder(GuardBuilderBase):
 
     # TODO(voz): Deduplicate w/ AOTAutograd dupe input guards
     def DUPLICATE_INPUT(self, guard, source_b):
+        if self.serialization_mode == "save":
+            raise RuntimeError("DUPLICATE_INPUT guard cannot be serialized yet.")
         ref_a = self.arg_ref(guard)
         ref_b = self.arg_ref(source_b.name())
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #152723
* #152721
* #152716
* __->__ #152687
* #152616
* #152615

Seems this guard is not very active. Adding a test to detect error handling at least.

Differential Revision: [D74074837](https://our.internmc.facebook.com/intern/diff/D74074837/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames