### PR TITLE
[aotinductor] Don't alloc weights if they don't exist

### DIFF
--- a/torch/csrc/inductor/aoti_runtime/model.h
+++ b/torch/csrc/inductor/aoti_runtime/model.h
@@ -292,14 +292,14 @@ class AOTInductorModelBase {
         num_constants - num_folded_constants);
     size_t blob_size = 0;
     compute_constant_blob(blob_size, constants_internal_offset);
+    if (!include_weights) {
+      return;
+    }
 #if defined(USE_CUDA) || defined(USE_XPU)
     constant_blob_ = RAII_gpuMalloc(blob_size);
 #else
     constant_blob_ = RAII_cpuMalloc(blob_size);
 #endif
-    if (!include_weights) {
-      return;
-    }
 
     size_t bytes_read = 0;
     for (size_t i = 0; i < num_constants; i++) {


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/152356


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov