### PR TITLE
[ez] Fsspec Filesystem ls details should be false

### DIFF
--- a/torch/distributed/checkpoint/_fsspec_filesystem.py
+++ b/torch/distributed/checkpoint/_fsspec_filesystem.py
@@ -92,7 +92,9 @@ class FileSystem(FileSystemBase):
         self.fs.rm(path)
 
     def ls(self, path: Union[str, os.PathLike]) -> list[str]:
-        return self.fs.ls(path)
+        # setting detail to False explictly to keep the list[str] return type,
+        # instead of the list[Dict] return type when detail=True
+        return self.fs.ls(path, detail=False)
 
 
 # TODO: add the dcp.async_save mixin


### PR DESCRIPTION
Summary: The default action for ls for the local filesystem is with details=False, but this isn't the case for all filesystems (eg. huggingface), so setting details=False explicitly so that the return type of ls is a list of strings, and not a list of dictionaries, which is what it would be with details=True.

Test Plan: tested in notebook

Differential Revision: D74080572




cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k