### PR TITLE
set CUDA_MODULE_LOADING for older drivers only

### DIFF
--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -18,6 +18,7 @@
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAFunctions.h>
 #include <c10/util/irange.h>
+#include <c10/cuda/driver_api.h>
 
 #if AT_CUDNN_ENABLED()
 #include <ATen/cudnn/cudnn-wrapper.h>
@@ -91,7 +92,26 @@ void CUDAHooks::init() const {
 
   // Sets the CUDA_MODULE_LOADING environment variable
   // if it's not set by the user.
-  c10::utils::set_env("CUDA_MODULE_LOADING", "LAZY", false);
+  // CUDA_MODULE_LOADING="LAZY" is default for all drivers released for CUDA 12.2+.
+  // Check the driver version and only set the env variable if needed.
+  bool set_lazy_module_loading = true;
+  auto driver_api = c10::cuda::DriverAPI::get();
+  // Initialize NVML
+  if (driver_api->nvmlInit_v2_() == NVML_SUCCESS) {
+    // Get the driver version
+    int version = -1;
+    auto res = driver_api->nvmlSystemGetCudaDriverVersion_v2_(&version);
+    if (res == NVML_SUCCESS) {
+      // Check if driver is sufficiently new
+      if (version >= 12020) {
+       LOG(WARNING) << "disabling set_env";
+        set_lazy_module_loading = false;
+      }
+    }
+  }
+  if (set_lazy_module_loading) {
+    c10::utils::set_env("CUDA_MODULE_LOADING", "LAZY", false);
+  }
   const auto num_devices = c10::cuda::device_count_ensure_non_zero();
   c10::cuda::CUDACachingAllocator::init(num_devices);
   at::cuda::detail::init_p2p_access_cache(num_devices);

--- a/c10/cuda/driver_api.h
+++ b/c10/cuda/driver_api.h
@@ -45,12 +45,12 @@
 #define C10_LIBCUDA_DRIVER_API_12030(_)
 #endif
 
-#define C10_NVML_DRIVER_API(_)           \
-  _(nvmlInit_v2)                         \
-  _(nvmlDeviceGetHandleByPciBusId_v2)    \
-  _(nvmlDeviceGetNvLinkRemoteDeviceType) \
-  _(nvmlDeviceGetNvLinkRemotePciInfo_v2) \
-  _(nvmlDeviceGetComputeRunningProcesses)\
+#define C10_NVML_DRIVER_API(_)            \
+  _(nvmlInit_v2)                          \
+  _(nvmlDeviceGetHandleByPciBusId_v2)     \
+  _(nvmlDeviceGetNvLinkRemoteDeviceType)  \
+  _(nvmlDeviceGetNvLinkRemotePciInfo_v2)  \
+  _(nvmlDeviceGetComputeRunningProcesses) \
   _(nvmlSystemGetCudaDriverVersion_v2)
 
 namespace c10::cuda {

--- a/c10/cuda/driver_api.h
+++ b/c10/cuda/driver_api.h
@@ -50,7 +50,8 @@
   _(nvmlDeviceGetHandleByPciBusId_v2)    \
   _(nvmlDeviceGetNvLinkRemoteDeviceType) \
   _(nvmlDeviceGetNvLinkRemotePciInfo_v2) \
-  _(nvmlDeviceGetComputeRunningProcesses)
+  _(nvmlDeviceGetComputeRunningProcesses)\
+  _(nvmlSystemGetCudaDriverVersion_v2)
 
 namespace c10::cuda {
 


### PR DESCRIPTION
`CUDA_MODULE_LOADING=LAZY` is the default for all drivers shipped with CUDA >=12.2 and we should check the driver version before setting the env variable. 

(the `LOG(WARNING)` has to be removed before merging) 

cc @msaroufim @eqy @jerryzh168