### PR TITLE
[caffe2] Make c10::str works with scoped enum

### DIFF
--- a/c10/test/util/string_util_test.cpp
+++ b/c10/test/util/string_util_test.cpp
@@ -133,4 +133,12 @@ TEST(tryToTest, Double) {
   EXPECT_FALSE(c10::tryToNumber<double>(nullptr).has_value());
 }
 } // namespace test_try_to
+
+namespace test_str_enum {
+TEST(StringUtilTest, testStrEnum) {
+  enum class Foo {Bar = 1, Baz = 2};
+  EXPECT_EQ(c10::str(Foo::Baz, Foo::Bar), "21");
+}
+} // namespace test_str_enum
+
 } // namespace

--- a/c10/util/StringUtil.h
+++ b/c10/util/StringUtil.h
@@ -10,6 +10,7 @@
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <type_traits>
 
 C10_CLANG_DIAGNOSTIC_PUSH()
 #if C10_CLANG_HAS_WARNING("-Wshorten-64-to-32")
@@ -52,9 +53,13 @@ inline std::ostream& _str(std::ostream& ss) {
 
 template <typename T>
 inline std::ostream& _str(std::ostream& ss, const T& t) {
-  // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
-  ss << t;
-  return ss;
+  if constexpr (std::is_enum_v<T>) {
+    return _str(ss, static_cast<typename std::underlying_type<T>::type>(t));
+  } else {
+    // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
+    ss << t;
+    return ss;
+  }
 }
 
 template <typename T>


### PR DESCRIPTION
Test Plan:
```
buck2 test fbcode//caffe2/c10/test:util_base_tests --fail-fast
```

Differential Revision: D73872860


