### PR TITLE
[BE] remove outdated warning about TORCH_CUDA_ARCH_LIST

### DIFF
--- a/cmake/public/utils.cmake
+++ b/cmake/public/utils.cmake
@@ -324,14 +324,6 @@ endmacro()
 #
 macro(torch_cuda_get_nvcc_gencode_flag store_var)
   # setting nvcc arch flags
-  if((NOT DEFINED TORCH_CUDA_ARCH_LIST) AND (DEFINED ENV{TORCH_CUDA_ARCH_LIST}))
-    message(WARNING
-        "In the future we will require one to explicitly pass "
-        "TORCH_CUDA_ARCH_LIST to cmake instead of implicitly setting it as an "
-        "env variable. This will become a FATAL_ERROR in future version of "
-        "pytorch.")
-    set(TORCH_CUDA_ARCH_LIST $ENV{TORCH_CUDA_ARCH_LIST})
-  endif()
   if(DEFINED CUDA_ARCH_NAME)
     message(WARNING
         "CUDA_ARCH_NAME is no longer used. Use TORCH_CUDA_ARCH_LIST instead. "


### PR DESCRIPTION
I saw this warning when compiling a 3rd party lib and did not agree with it. I'm not sure the original reason why we would want to force people to pass in TORCH_CUDA_ARCH_LIST to cmake vs set it as an env var. As a developer, it's much easier to set it as an env var or have it be autodetected. I also realized this warning was from before 2018!!! 7 years ago! And there are no plans to actually enforce this (nor should there be), so let's remove this misleading warning.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #152715

