### PR TITLE
[dynamo] Guard serialization for WEAKREF_ALIVE

### DIFF
--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -1866,6 +1866,8 @@ class GuardBuilder(GuardBuilderBase):
         )
 
     def WEAKREF_ALIVE(self, guard):
+        if self.serialization_mode == "save":
+            raise RuntimeError("WEAKREF_ALIVE guard cannot be serialized.")
         code = [f"{self.arg_ref(guard)} is not None"]
 
         self._set_guard_export_info(guard, code)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #152723
* #152721
* __->__ #152716
* #152687
* #152616
* #152615

Punt on WEAREF_ALIVE as weakref won't live across the process and users might need to drop them upfront.

Differential Revision: [D74088735](https://our.internmc.facebook.com/intern/diff/D74088735/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames