### PR TITLE
[nativert] move intrusive list to c10/util

### DIFF
--- a/c10/test/util/IntrusiveList_test.cpp
+++ b/c10/test/util/IntrusiveList_test.cpp
@@ -1,0 +1,123 @@
+#include <c10/util/IntrusiveList.h>
+#include <c10/util/irange.h>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+class ListItem : public c10::IntrusiveListHook {};
+
+template <typename TItem>
+void check_containers_equal(
+    c10::IntrusiveList<TItem>& c1,
+    std::vector<std::unique_ptr<TItem>>& c2) {
+  EXPECT_EQ(c1.size(), c2.size());
+  {
+    auto it = c1.begin();
+    for (const auto i : c10::irange(c1.size())) {
+      EXPECT_EQ(&*it, c2[i].get());
+      EXPECT_EQ(it, c1.iterator_to(*c2[i]));
+      ++it;
+    }
+  }
+  {
+    auto it = c1.rbegin();
+    for (const auto i : c10::irange(c1.size())) {
+      EXPECT_EQ(&*it, c2[c2.size() - 1 - i].get());
+      ++it;
+    }
+  }
+};
+
+} // namespace
+
+TEST(IntrusiveList, TestInsert) {
+  c10::IntrusiveList<ListItem> l;
+  std::vector<std::unique_ptr<ListItem>> v;
+
+  auto size = 50;
+
+  for ([[maybe_unused]] const auto i : c10::irange(size)) {
+    v.push_back(std::make_unique<ListItem>());
+    l.insert(l.end(), *v.back());
+    check_containers_equal(l, v);
+  }
+}
+
+TEST(IntrusiveList, TestUnlink) {
+  c10::IntrusiveList<ListItem> l;
+  std::vector<std::unique_ptr<ListItem>> v;
+
+  auto size = 50;
+
+  for ([[maybe_unused]] const auto i : c10::irange(size)) {
+    v.push_back(std::make_unique<ListItem>());
+    l.insert(l.end(), *v.back());
+  }
+
+  for ([[maybe_unused]] const auto i : c10::irange(size)) {
+    auto first = l.begin();
+    EXPECT_TRUE(first->is_linked());
+    first->unlink();
+    EXPECT_FALSE(first->is_linked());
+    v.erase(v.begin());
+    check_containers_equal(l, v);
+  }
+}
+
+TEST(IntrusiveList, TestMoveElement) {
+  c10::IntrusiveList<ListItem> l;
+  std::vector<std::unique_ptr<ListItem>> v;
+
+  auto size = 5;
+
+  for ([[maybe_unused]] const auto i : c10::irange(size)) {
+    v.push_back(std::make_unique<ListItem>());
+    l.insert(l.end(), *v.back());
+  }
+
+  // move 3rd element to the end of the list
+  {
+    auto it = l.iterator_to(*v[2]);
+    EXPECT_TRUE(it->is_linked());
+    l.iterator_to(*v[2])->unlink();
+    EXPECT_FALSE(it->is_linked());
+    l.insert(l.end(), *v[2]);
+  }
+  {
+    auto it = v.begin() + 2;
+    std::rotate(it, it + 1, v.end());
+  }
+
+  check_containers_equal(l, v);
+}
+
+TEST(IntrusiveList, TestEmpty) {
+  c10::IntrusiveList<ListItem> l;
+  ListItem i;
+
+  EXPECT_TRUE(l.empty());
+  l.insert(l.end(), i);
+  EXPECT_FALSE(l.empty());
+  l.begin()->unlink();
+  EXPECT_TRUE(l.empty());
+}
+TEST(IntrusiveList, TestUnlinkUnlinked) {
+  EXPECT_ANY_THROW(ListItem().unlink());
+}
+
+TEST(IntrusiveList, TestInitializerListCtro) {
+  ListItem i, j;
+  c10::IntrusiveList<ListItem> l({i, j});
+
+  EXPECT_EQ(l.size(), 2);
+  EXPECT_EQ(l.iterator_to(i), l.begin());
+  EXPECT_EQ(l.iterator_to(j), ++l.begin());
+}
+
+TEST(IntrusiveList, TestNullListIterator) {
+  auto null_iter = c10::ListIterator<c10::IntrusiveListHook, ListItem>{nullptr};
+
+  EXPECT_ANY_THROW(--null_iter);
+  EXPECT_ANY_THROW(++null_iter);
+}

--- a/c10/util/IntrusiveList.h
+++ b/c10/util/IntrusiveList.h
@@ -1,0 +1,206 @@
+#pragma once
+
+#include <c10/util/Exception.h>
+
+namespace c10 {
+
+template <typename T>
+class IntrusiveList;
+
+class IntrusiveListHook {
+  template <typename P, typename T>
+  friend class ListIterator;
+
+  template <typename T>
+  friend class IntrusiveList;
+
+  IntrusiveListHook* next_{nullptr};
+  IntrusiveListHook* prev_{nullptr};
+
+  void link_before(IntrusiveListHook* next_node) {
+    next_ = next_node;
+    prev_ = next_node->prev_;
+    next_node->prev_ = this;
+    prev_->next_ = this;
+  }
+
+ public:
+  IntrusiveListHook() : next_(this), prev_(this) {}
+
+  IntrusiveListHook(const IntrusiveListHook&) = delete;
+  IntrusiveListHook& operator=(const IntrusiveListHook&) = delete;
+  IntrusiveListHook(IntrusiveListHook&&) = delete;
+  IntrusiveListHook& operator=(IntrusiveListHook&&) = delete;
+
+  void unlink() {
+    TORCH_CHECK(is_linked());
+    next_->prev_ = prev_;
+    prev_->next_ = next_;
+    next_ = this;
+    prev_ = this;
+  }
+
+  ~IntrusiveListHook() {
+    if (is_linked()) {
+      unlink();
+    }
+  }
+
+  bool is_linked() const {
+    return next_ != this;
+  }
+};
+
+template <typename P, typename T>
+class ListIterator {
+  static_assert(std::is_same_v<std::remove_const_t<P>, IntrusiveListHook>);
+  static_assert(std::is_base_of_v<IntrusiveListHook, T>);
+  P* ptr_;
+
+  friend class IntrusiveList<T>;
+
+ public:
+  using iterator_category = std::bidirectional_iterator_tag;
+  using value_type = std::conditional_t<std::is_const_v<P>, const T, T>;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type*;
+  using reference = value_type&;
+
+  explicit ListIterator(P* ptr) : ptr_(ptr) {}
+  ~ListIterator() = default;
+
+  ListIterator(const ListIterator&) = default;
+  ListIterator& operator=(const ListIterator&) = default;
+  ListIterator(ListIterator&&) = default;
+  ListIterator& operator=(ListIterator&&) = default;
+
+  template <
+      typename Q,
+      class = std::enable_if_t<std::is_const_v<P> && !std::is_const_v<Q>>>
+  ListIterator(const ListIterator<Q, T>& rhs) : ptr_(rhs.ptr_) {}
+
+  template <
+      typename Q,
+      class = std::enable_if_t<std::is_const_v<P> && !std::is_const_v<Q>>>
+  ListIterator& operator=(const ListIterator<Q, T>& rhs) {
+    ptr_ = rhs.ptr_;
+    return *this;
+  }
+
+  template <typename Q>
+  bool operator==(const ListIterator<Q, T>& other) const {
+    return ptr_ == other.ptr_;
+  }
+
+  template <typename Q>
+  bool operator!=(const ListIterator<Q, T>& other) const {
+    return !(*this == other);
+  }
+
+  auto& operator*() const {
+    return static_cast<reference>(*ptr_);
+  }
+
+  ListIterator& operator++() {
+    TORCH_CHECK(ptr_);
+    ptr_ = ptr_->next_;
+    return *this;
+  }
+
+  ListIterator& operator--() {
+    TORCH_CHECK(ptr_);
+    ptr_ = ptr_->prev_;
+    return *this;
+  }
+
+  auto* operator->() const {
+    return static_cast<pointer>(ptr_);
+  }
+};
+
+template <typename T>
+class IntrusiveList {
+  static_assert(std::is_base_of_v<IntrusiveListHook, T>);
+
+ public:
+  IntrusiveList() = default;
+  IntrusiveList(const std::initializer_list<std::reference_wrapper<T>>& items) {
+    for (auto& item : items) {
+      insert(this->end(), item);
+    }
+  }
+  ~IntrusiveList() {
+    while (head_.is_linked()) {
+      head_.next_->unlink();
+    }
+  }
+  IntrusiveList(const IntrusiveList&) = delete;
+  IntrusiveList& operator=(const IntrusiveList&) = delete;
+  IntrusiveList(IntrusiveList&&) = delete;
+  IntrusiveList& operator=(IntrusiveList&&) = delete;
+
+  using iterator = ListIterator<IntrusiveListHook, T>;
+  using const_iterator = ListIterator<const IntrusiveListHook, T>;
+
+  auto begin() const {
+    return ++const_iterator{&head_};
+  }
+
+  auto begin() {
+    return ++iterator{&head_};
+  }
+
+  auto end() const {
+    return const_iterator{&head_};
+  }
+
+  auto end() {
+    return iterator{&head_};
+  }
+
+  auto rbegin() const {
+    return std::reverse_iterator{end()};
+  }
+
+  auto rbegin() {
+    return std::reverse_iterator{end()};
+  }
+
+  auto rend() const {
+    return std::reverse_iterator{begin()};
+  }
+
+  auto rend() {
+    return std::reverse_iterator{begin()};
+  }
+
+  auto iterator_to(const T& n) const {
+    return const_iterator{&n};
+  }
+
+  auto iterator_to(T& n) {
+    return iterator{&n};
+  }
+
+  iterator insert(iterator pos, T& n) {
+    n.link_before(pos.ptr_);
+    return iterator{&n};
+  }
+
+  size_t size() const {
+    size_t ret = 0;
+    for ([[maybe_unused]] auto& _ : *this) {
+      ret++;
+    }
+    return ret;
+  }
+
+  bool empty() const {
+    return !head_.is_linked();
+  }
+
+ private:
+  IntrusiveListHook head_;
+};
+
+} // namespace c10


### PR DESCRIPTION
Summary:
nativert RFC: https://github.com/zhxchen17/rfcs/blob/master/RFC-0043-torch-native-runtime.md

To land the runtime into PyTorch core, we will gradually land logical parts of the code into the Github issue and get each piece properly reviewed.

This diff moves intrusive list to c10/util

Test Plan: CI

Differential Revision: D74104595
