### PR TITLE
[MPS] Migrate div roudning modes

### DIFF
--- a/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
@@ -236,7 +236,7 @@ struct div_trunc_functor {
       typename T,
       ::metal::enable_if_t<!::metal::is_integral_v<T>, bool> = true>
   inline T operator()(const T a, const T b) {
-    return metal::trunc(c10::metal::div(a, b));
+    return T(metal::trunc(c10::metal::div(a, b)));
   }
   template <
       typename T,
@@ -310,8 +310,8 @@ REGISTER_BINARY_OP(div_floor, char, char);
 REGISTER_BINARY_OP(div_floor, bool, bool);
 REGISTER_BINARY_OP(div_trunc, long, long);
 REGISTER_BINARY_OP(div_trunc, int, int);
-REGISTER_OPMATH_BINARY_OP(div_trunc, float, float);
-REGISTER_OPMATH_BINARY_OP(div_trunc, half, half);
+REGISTER_BINARY_OP(div_trunc, float, float);
+REGISTER_BINARY_OP(div_trunc, half, half);
 REGISTER_BINARY_OP(div_trunc, short, short);
 REGISTER_BINARY_OP(div_trunc, uchar, uchar);
 REGISTER_BINARY_OP(div_trunc, char, char);
@@ -366,7 +366,7 @@ REGISTER_BINARY_OP(add, bfloat, bfloat);
 REGISTER_OPMATH_BINARY_OP(mul, bfloat, bfloat);
 REGISTER_BINARY_OP(sub, bfloat, bfloat);
 REGISTER_OPMATH_BINARY_OP(div_floor, bfloat, bfloat);
-REGISTER_OPMATH_BINARY_OP(div_trunc, bfloat, bfloat);
+REGISTER_BINARY_OP(div_trunc, bfloat, bfloat);
 REGISTER_OPMATH_BINARY_OP(div_true, bfloat, bfloat);
 REGISTER_BINARY_ALPHA_OP(add_alpha, bfloat, bfloat);
 REGISTER_BINARY_ALPHA_OP(sub_alpha, bfloat, bfloat);

--- a/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
@@ -202,6 +202,50 @@ struct div_true_functor {
   }
 };
 
+struct div_floor_functor {
+  template <
+      typename T,
+      ::metal::enable_if_t<!::metal::is_integral_v<T>, bool> = true>
+  inline T operator()(const T a, const T b) {
+    return metal::floor(c10::metal::div(a, b));
+  }
+  template <
+      typename T,
+      ::metal::enable_if_t<
+          ::metal::is_integral_v<T>&& ::metal::is_signed_v<T>,
+          bool> = true>
+  inline T operator()(const T a, const T b) {
+    const auto quot = a / b;
+    if ((a < 0) == (b < 0)) {
+      return quot;
+    }
+    return a % b != 0 ? quot - 1 : quot;
+  }
+  template <
+      typename T,
+      ::metal::enable_if_t<
+          ::metal::is_integral_v<T> && !::metal::is_signed_v<T>,
+          bool> = true>
+  inline T operator()(const T a, const T b) {
+    return a / b;
+  }
+};
+
+struct div_trunc_functor {
+  template <
+      typename T,
+      ::metal::enable_if_t<!::metal::is_integral_v<T>, bool> = true>
+  inline T operator()(const T a, const T b) {
+    return metal::trunc(c10::metal::div(a, b));
+  }
+  template <
+      typename T,
+      ::metal::enable_if_t<::metal::is_integral_v<T>, bool> = true>
+  inline T operator()(const T a, const T b) {
+    return a / b;
+  }
+};
+
 REGISTER_BINARY_OP(copysign, long, float);
 REGISTER_BINARY_OP(copysign, int, float);
 REGISTER_BINARY_OP(copysign, float, float);
@@ -256,6 +300,22 @@ REGISTER_BINARY_OP(sub, short, short);
 REGISTER_BINARY_OP(sub, uchar, uchar);
 REGISTER_BINARY_OP(sub, char, char);
 REGISTER_BINARY_OP(sub, bool, bool);
+REGISTER_BINARY_OP(div_floor, long, long);
+REGISTER_BINARY_OP(div_floor, int, int);
+REGISTER_OPMATH_BINARY_OP(div_floor, float, float);
+REGISTER_OPMATH_BINARY_OP(div_floor, half, half);
+REGISTER_BINARY_OP(div_floor, short, short);
+REGISTER_BINARY_OP(div_floor, uchar, uchar);
+REGISTER_BINARY_OP(div_floor, char, char);
+REGISTER_BINARY_OP(div_floor, bool, bool);
+REGISTER_BINARY_OP(div_trunc, long, long);
+REGISTER_BINARY_OP(div_trunc, int, int);
+REGISTER_OPMATH_BINARY_OP(div_trunc, float, float);
+REGISTER_OPMATH_BINARY_OP(div_trunc, half, half);
+REGISTER_BINARY_OP(div_trunc, short, short);
+REGISTER_BINARY_OP(div_trunc, uchar, uchar);
+REGISTER_BINARY_OP(div_trunc, char, char);
+REGISTER_BINARY_OP(div_trunc, bool, bool);
 REGISTER_BINARY_OP(div_true, long, float);
 REGISTER_BINARY_OP(div_true, int, float);
 REGISTER_OPMATH_BINARY_OP(div_true, float, float);
@@ -305,6 +365,8 @@ REGISTER_BINARY_OP(hermite_polynomial_he, bfloat, bfloat);
 REGISTER_BINARY_OP(add, bfloat, bfloat);
 REGISTER_OPMATH_BINARY_OP(mul, bfloat, bfloat);
 REGISTER_BINARY_OP(sub, bfloat, bfloat);
+REGISTER_OPMATH_BINARY_OP(div_floor, bfloat, bfloat);
+REGISTER_OPMATH_BINARY_OP(div_trunc, bfloat, bfloat);
 REGISTER_OPMATH_BINARY_OP(div_true, bfloat, bfloat);
 REGISTER_BINARY_ALPHA_OP(add_alpha, bfloat, bfloat);
 REGISTER_BINARY_ALPHA_OP(sub_alpha, bfloat, bfloat);

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.mm
@@ -169,6 +169,14 @@ static void div_true_mps_kernel(TensorIteratorBase& iter) {
   lib.exec_binary_kernel(iter, "div_true");
 }
 
+static void div_floor_mps_kernel(TensorIteratorBase& iter) {
+  lib.exec_binary_kernel(iter, "div_floor");
+}
+
+static void div_trunc_mps_kernel(TensorIteratorBase& iter) {
+  lib.exec_binary_kernel(iter, "div_trunc");
+}
+
 REGISTER_DISPATCH(fmax_stub, &fmax_mps_kernel)
 REGISTER_DISPATCH(fmin_stub, &fmin_mps_kernel)
 REGISTER_DISPATCH(copysign_stub, &copysign_mps_kernel)
@@ -186,4 +194,6 @@ REGISTER_DISPATCH(complex_stub, &complex_mps_kernel);
 REGISTER_DISPATCH(lerp_kernel_scalar_weight, &lerp_scalar_mps_kernel)
 REGISTER_DISPATCH(mul_stub, &mul_mps_kernel)
 REGISTER_DISPATCH(div_true_stub, &div_true_mps_kernel)
+REGISTER_DISPATCH(div_floor_stub, &div_floor_mps_kernel)
+REGISTER_DISPATCH(div_trunc_stub, &div_trunc_mps_kernel)
 } // namespace at::native

--- a/aten/src/ATen/native/mps/operations/BinaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryOps.mm
@@ -336,11 +336,6 @@ TORCH_IMPL_FUNC(atan2_out_mps)(const Tensor& self, const Tensor& other, const Te
   });
 }
 
-TORCH_IMPL_FUNC(div_out_mode_mps)
-(const Tensor& self, const Tensor& other, std::optional<std::string_view> rounding_mode, const Tensor& output) {
-  mps::div_mode_template(self, other, rounding_mode, output, "div_mode_out");
-}
-
 TORCH_IMPL_FUNC(add_out_mps)(const Tensor& self, const Tensor& other, const Scalar& alpha, const Tensor& output) {
   mps::add_sub_lerp_template(self, other, alpha, output, "add");
 }
@@ -355,10 +350,6 @@ TORCH_IMPL_FUNC(pow_Scalar_out_mps)(const Scalar& base, const Tensor& exp, const
   } else {
     at::pow_out(const_cast<Tensor&>(out), mps::wrapped_scalar_tensor_mps(base, exp.device()), exp); // redispatch!
   }
-}
-
-static void div_floor_kernel_mps(TensorIteratorBase& iter) {
-  mps::div_mode_template(iter.input(0), iter.input(1), "floor", iter.output(0), "floor_divide_out");
 }
 
 TORCH_IMPL_FUNC(remainder_out_mps)(const Tensor& self, const Tensor& other, const Tensor& output) {
@@ -434,5 +425,4 @@ TORCH_IMPL_FUNC(xlogy_out_mps)(const Tensor& self, const Tensor& other, const Te
   mps::binaryOpTensor(self, other, output, "xlogy_out_mps", xlogy_op_block);
 }
 
-REGISTER_DISPATCH(div_floor_stub, &div_floor_kernel_mps);
 } // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2197,8 +2197,7 @@
   structured: True
   structured_inherits: TensorIteratorBase
   dispatch:
-    CPU, CUDA: div_out_mode
-    MPS: div_out_mode_mps
+    CPU, CUDA, MPS: div_out_mode
     SparseCPU, SparseCUDA: div_out_sparse_zerodim
   tags: pointwise
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -3373,7 +3373,6 @@ class TestMPS(TestCaseMPS):
 
     def test_div_bugs(self):
         for (dtype, mode) in itertools.product(integral_types(), ['trunc', 'floor']):
-            if dtype != torch.int64:
                 x = torch.tensor(list(range(1, 11)), device='mps', dtype=dtype)
                 y = torch.div(x, 101, rounding_mode=mode)
                 self.assertEqual(y.sum(), 0)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -3373,9 +3373,9 @@ class TestMPS(TestCaseMPS):
 
     def test_div_bugs(self):
         for (dtype, mode) in itertools.product(integral_types(), ['trunc', 'floor']):
-                x = torch.tensor(list(range(1, 11)), device='mps', dtype=dtype)
-                y = torch.div(x, 101, rounding_mode=mode)
-                self.assertEqual(y.sum(), 0)
+            x = torch.tensor(list(range(1, 11)), device='mps', dtype=dtype)
+            y = torch.div(x, 101, rounding_mode=mode)
+            self.assertEqual(y.sum(), 0)
 
     # See https://github.com/pytorch/pytorch/issues/82663
     def test_bool_expand(self):

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -283,8 +283,6 @@ if torch.backends.mps.is_available():
         }
         # Those ops worked on MacOS12, but broken on MacOS13, see https://github.com/pytorch/pytorch/issues/85758
         MACOS_BEFORE_13_3_XFAILLIST = {
-            # float16 seems horribly wrong on MacOS13
-            "floor_divide": [torch.float16],
             # Failures due to precision issues (due to fast-math). These has been fixed in MacOS 13.3+
             "tan": [torch.float32],
             "cdist": [torch.float32],

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -594,7 +594,6 @@ if torch.backends.mps.is_available():
                 torch.int8,
             ],
             # trunc_tensor not working properly for float16 and bfloat16
-            "divtrunc_rounding": [torch.float16, torch.bfloat16],
             "fmod": [torch.float16],
             # round not working properly for float16 and bfloat16
             "round": [torch.float16, torch.bfloat16],
@@ -933,7 +932,6 @@ if torch.backends.mps.is_available():
             "signal.windows.nuttall": [torch.float32],
             "eye": [torch.float16, torch.float32],
             # trunc_tensor not working properly for float16
-            "divtrunc_rounding": [torch.float16],
             "fmod": [torch.float16],
             # round not working properly for float16
             "round": [torch.float16],


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #152788
* __->__ #152758


By implementing `div_floor` and `div_trunc` . Do not mark `div_trunc` as OPMATH, to align following output with CPU(if division is performed in fp32, than result will be truncated to 25
```
import torch
print(torch.tensor([[-7.4688, -3.1289]], dtype=torch.float16,device="cpu").div(torch.tensor([-0.2988, -0.8789], dtype=torch.bfloat16,device="cpu"), rounding_mode="trunc"))
tensor([[24.,  3.]])
```
