### PR TITLE
Pass UNINSTALL_DILL to docker build

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -481,6 +481,7 @@ docker build \
        --build-arg "EXECUTORCH=${EXECUTORCH}" \
        --build-arg "HALIDE=${HALIDE}" \
        --build-arg "XPU_VERSION=${XPU_VERSION}" \
+       --build-arg "UNINSTALL_DILL=${UNINSTALL_DILL}" \
        --build-arg "ACL=${ACL:-}" \
        --build-arg "SKIP_SCCACHE_INSTALL=${SKIP_SCCACHE_INSTALL:-}" \
        --build-arg "SKIP_LLVM_SRC_BUILD_INSTALL=${SKIP_LLVM_SRC_BUILD_INSTALL:-}" \


### PR DESCRIPTION
`UNINSTALL_DILL` was not really passed to docker before.