### PR TITLE
[Easy][Inductor] Adds safety checks in get_estimated_runtime

### DIFF
--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -836,6 +836,8 @@ class BaseSchedulerNode:
         try:
             gpu_memory_bandwidth = get_gpu_dram_gbps()
             gpu_flops = get_device_tflops(dtype) * 10**12
+            assert gpu_memory_bandwidth > 0
+            assert gpu_flops > 0
         except Exception:
             return 0
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -840,7 +840,9 @@ class BaseSchedulerNode:
             # there is a chance to continue execution successfully. Otherwise, it would fail with
             # ZeroDivisionError below.
             if gpu_memory_bandwidth <= 0:
-                raise ValueError(f"gpu_memory_bandwidth cannot be <= 0, but got {gpu_memory_bandwidth}")
+                raise ValueError(
+                    f"gpu_memory_bandwidth cannot be <= 0, but got {gpu_memory_bandwidth}"
+                )
             if gpu_flops <= 0:
                 raise ValueError(f"gpu_flops cannot be <= 0, but got {gpu_flops}")
         except Exception:

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -836,8 +836,13 @@ class BaseSchedulerNode:
         try:
             gpu_memory_bandwidth = get_gpu_dram_gbps()
             gpu_flops = get_device_tflops(dtype) * 10**12
-            assert gpu_memory_bandwidth > 0
-            assert gpu_flops > 0
+            # If cudaGetDeviceProperties returns 0 for gpu_memory_bandwidth or gpu_flops
+            # there is a chance to continue execution successfully. Otherwise, it would fail with
+            # ZeroDivisionError below.
+            if gpu_memory_bandwidth <= 0:
+                raise ValueError(f"gpu_memory_bandwidth cannot be <= 0, but got {gpu_memory_bandwidth}")
+            if gpu_flops <= 0:
+                raise ValueError(f"gpu_flops cannot be <= 0, but got {gpu_flops}")
         except Exception:
             return 0
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -840,11 +840,11 @@ class BaseSchedulerNode:
             # there is a chance to continue execution successfully. Otherwise, it would fail with
             # ZeroDivisionError below.
             if gpu_memory_bandwidth <= 0:
-                raise ValueError(
+                raise AssertionError(
                     f"gpu_memory_bandwidth cannot be <= 0, but got {gpu_memory_bandwidth}"
                 )
             if gpu_flops <= 0:
-                raise ValueError(f"gpu_flops cannot be <= 0, but got {gpu_flops}")
+                raise AssertionError(f"gpu_flops cannot be <= 0, but got {gpu_flops}")
         except Exception:
             return 0
 


### PR DESCRIPTION
This PR adds checks on `gpu_memory_bandwidth` and `gpu_flops` in `get_estimated_runtime`. This will prevent division by zero and other potential incorrect values:
https://github.com/pytorch/pytorch/blob/9210a98b9203c5ff42f39241304a8e38435110b8/torch/_inductor/scheduler.py#L864-L865

https://github.com/pytorch/pytorch/blob/9210a98b9203c5ff42f39241304a8e38435110b8/torch/_inductor/scheduler.py#L874

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov