### PR TITLE
Only do shallow clone when checkout nccl

### DIFF
--- a/tools/build_pytorch_libs.py
+++ b/tools/build_pytorch_libs.py
@@ -99,7 +99,16 @@ def checkout_nccl() -> None:
     nccl_basedir = os.path.join(third_party_path, "nccl")
     if not os.path.exists(nccl_basedir):
         subprocess.check_call(
-            ["git", "clone", "--depth", "1", "--branch", release_tag, "https://github.com/NVIDIA/nccl.git", "nccl"],
+            [
+                "git",
+                "clone",
+                "--depth",
+                "1",
+                "--branch",
+                release_tag,
+                "https://github.com/NVIDIA/nccl.git",
+                "nccl",
+            ],
             cwd=third_party_path,
         )
 

--- a/tools/build_pytorch_libs.py
+++ b/tools/build_pytorch_libs.py
@@ -99,10 +99,9 @@ def checkout_nccl() -> None:
     nccl_basedir = os.path.join(third_party_path, "nccl")
     if not os.path.exists(nccl_basedir):
         subprocess.check_call(
-            ["git", "clone", "https://github.com/NVIDIA/nccl.git", "nccl"],
+            ["git", "clone", "--depth", "1", "--branch", release_tag, "https://github.com/NVIDIA/nccl.git", "nccl"],
             cwd=third_party_path,
         )
-        subprocess.check_call(["git", "checkout", release_tag], cwd=nccl_basedir)
 
 
 def build_pytorch(


### PR DESCRIPTION
Note: `--depth` implies `--single-branch` since git 2.7.6

```sh
git clone https://github.com/NVIDIA/nccl.git
Cloning into 'nccl'...
remote: Enumerating objects: 4205, done.
remote: Counting objects: 100% (238/238), done.
remote: Compressing objects: 100% (122/122), done.
remote: Total 4205 (delta 144), reused 126 (delta 116), pack-reused 3967 (from 3)
Receiving objects: 100% (4205/4205), 4.22 MiB | 7.01 MiB/s, done.
Resolving deltas: 100% (2858/2858), done.
```
```sh
git clone --depth 1 --branch v2.25.1-1 https://github.com/NVIDIA/nccl.git
Cloning into 'nccl'...
remote: Enumerating objects: 249, done.
remote: Counting objects: 100% (249/249), done.
remote: Compressing objects: 100% (227/227), done.
remote: Total 249 (delta 31), reused 111 (delta 15), pack-reused 0 (from 0)
Receiving objects: 100% (249/249), 657.44 KiB | 2.14 MiB/s, done.
Resolving deltas: 100% (31/31), done.
Note: switching to '80f6bda4378b99d99e82b4d76a633791cc45fef0'.
```