### PR TITLE
[BE]: Improve aten formatter with fmtlib

### DIFF
--- a/aten/src/ATen/core/Formatting.cpp
+++ b/aten/src/ATen/core/Formatting.cpp
@@ -226,7 +226,7 @@ static void __printTensor(std::ostream& stream, Tensor& self, int64_t linesize) 
   }
 
   while(true) {
-    for(int64_t i = 0; i < self.ndimension()-2; i++) {
+    for(int64_t i = 0; self.ndimension()-2; i++) {
       counter[i] = counter[i] + 1;
       if(counter[i] >= self.size(i)) {
         if(i == self.ndimension()-3) {

--- a/aten/src/ATen/core/Formatting.cpp
+++ b/aten/src/ATen/core/Formatting.cpp
@@ -187,8 +187,14 @@ static void __printMatrix(std::ostream& stream, const Tensor& self, int64_t line
       if(firstColumn != 0) {
         fmt::print(stream, "\n");
       }
-      fmt::print(stream, "Columns {} to {}", firstColumn+1, lastColumn+1);
-      fmt::print(stream, "{:>{}s}", "", indent);
+      fmt::print(
+          stream,
+          "Columns {} to {}{:>{}s}",
+          firstColumn + 1,
+          lastColumn + 1,
+          "",          // empty string to pad
+          indent       // width to pad to
+      );
     }
 
     if(printFmt.scale != 1) {
@@ -295,8 +301,10 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
   }
 
   if(tensor.ndimension() == 0) {
-    fmt::print(stream, "{}\n", tensor.const_data_ptr<double>()[0]);
-    fmt::print(stream, "[ {}{{}}", tensor_.toString());
+    fmt::print(stream,
+          "{}\n[ {}{{}}",
+          tensor.const_data_ptr<double>()[0],
+          tensor_.toString());
   } else if(tensor.ndimension() == 1) {
     if (tensor.numel() > 0) {
       auto printFmt = __printFormat(tensor);

--- a/aten/src/ATen/core/Formatting.cpp
+++ b/aten/src/ATen/core/Formatting.cpp
@@ -9,7 +9,6 @@
 #include <iostream>
 #include <iterator>
 #include <string>
-#include <string_view>
 #include <tuple>
 
 namespace c10 {

--- a/aten/src/ATen/core/Formatting.cpp
+++ b/aten/src/ATen/core/Formatting.cpp
@@ -184,7 +184,7 @@ static void __printMatrix(std::ostream& stream, const Tensor& self, int64_t line
 
     if(nColumnPerLine < self.size(1)) {
       if(firstColumn != 0) {
-        fmt::print(stream, "\n");
+     stream.put('\n');
       }
       fmt::print(
           stream,
@@ -209,7 +209,7 @@ static void __printMatrix(std::ostream& stream, const Tensor& self, int64_t line
         printValue(stream, row_ptr[c], printFmt);
 
         if(c == lastColumn) {
-          fmt::print(stream, "\n");
+          stream.put('\n');
           if(l != self.size(0)-1) {
             if(printFmt.scale != 1) {
               fmt::print(stream, "{:>{}s} ", "", indent);
@@ -218,7 +218,7 @@ static void __printMatrix(std::ostream& stream, const Tensor& self, int64_t line
             }
           }
         } else {
-          fmt::print(stream, " ");
+      stream.put(' ');
         }
       }
     }
@@ -252,10 +252,10 @@ static void __printTensor(std::ostream& stream, Tensor& self, int64_t linesize) 
     if(start) {
       start = false;
     } else {
-      fmt::print(stream, "\n");
+      stream.put('\n');
     }
 
-    fmt::print(stream, "(");
+    stream.put('(');
     Tensor tensor = self;
     for (const auto i : c10::irange(self.ndimension()-2)) {
       tensor = tensor.select(0, counter[i]);
@@ -313,7 +313,7 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
       const double* tensor_p = tensor.const_data_ptr<double>();
       for (const auto i : c10::irange(tensor.size(0))) {
         printValue(stream, tensor_p[i], printFmt);
-        fmt::print(stream, "\n");
+        stream.put('\n');
       }
     }
     fmt::print(stream, "[ {}{{{}}}", tensor_.toString(), tensor.size(0));

--- a/aten/src/ATen/core/Formatting.cpp
+++ b/aten/src/ATen/core/Formatting.cpp
@@ -42,45 +42,36 @@ std::string toString(const Scalar& s) {
 }
 } // namespace c10
 
+
 namespace at {
 
-//saves/restores number formatting inside scope
-class FormatGuard {
- public:
-  explicit FormatGuard(std::ostream& out) : out(out) {
-    saved.copyfmt(out);
-  }
-  ~FormatGuard() {
-    out.copyfmt(saved);
-  }
-  FormatGuard(const FormatGuard&) = delete;
-  FormatGuard(FormatGuard&&) = delete;
-  FormatGuard& operator=(const FormatGuard&) = delete;
-  FormatGuard& operator=(FormatGuard&&) = delete;
-
- private:
-  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
-  std::ostream& out;
-  std::ios saved{nullptr};
-};
-
-std::ostream& operator<<(std::ostream& out, const DeprecatedTypeProperties& t) {
+std::ostream& operator<<(std::ostream & out, const DeprecatedTypeProperties& t) {
   return out << t.toString();
 }
 
-// Determine formatting options for tensor printing
-static std::tuple<double, int> __printFormat(const Tensor& self) {
+struct PrintFormat {
+  double scale;
+  int width;
+  bool scientific;
+  bool fixed;
+  int precision;
+
+  PrintFormat(double s, int w, bool sci = false, bool fix = false, int prec = 4)
+    : scale(s), width(w), scientific(sci), fixed(fix), precision(prec) {}
+};
+
+static PrintFormat __printFormat(const Tensor& self) {
   auto size = self.numel();
-  if (size == 0) {
-    return std::make_tuple(1.0, 0);
+  if(size == 0) {
+    return PrintFormat(1., 0);
   }
 
   bool intMode = true;
   auto self_p = self.const_data_ptr<double>();
   for (const auto i : c10::irange(size)) {
     auto z = self_p[i];
-    if (std::isfinite(z)) {
-      if (z != std::ceil(z)) {
+    if(std::isfinite(z)) {
+      if(z != std::ceil(z)) {
         intMode = false;
         break;
       }
@@ -88,137 +79,154 @@ static std::tuple<double, int> __printFormat(const Tensor& self) {
   }
 
   int64_t offset = 0;
-  while (offset < size && !std::isfinite(self_p[offset])) {
-    offset++;
+  while(!std::isfinite(self_p[offset])) {
+    offset = offset + 1;
+    if(offset == size) {
+      break;
+    }
   }
 
   double expMin = 1;
   double expMax = 1;
-  if (offset != size) {
+  if(offset != size) {
     expMin = fabs(self_p[offset]);
     expMax = fabs(self_p[offset]);
     for (const auto i : c10::irange(offset, size)) {
       double z = fabs(self_p[i]);
-      if (std::isfinite(z)) {
-        if (z < expMin) {
+      if(std::isfinite(z)) {
+        if(z < expMin) {
           expMin = z;
         }
-        if (self_p[i] > expMax) {
+        if(self_p[i] > expMax) {
           expMax = z;
         }
       }
     }
-
-    expMin = (expMin != 0) ? std::floor(std::log10(expMin)) + 1 : 1;
-    expMax = (expMax != 0) ? std::floor(std::log10(expMax)) + 1 : 1;
+    if(expMin != 0) {
+      expMin = std::floor(std::log10(expMin)) + 1;
+    } else {
+      expMin = 1;
+    }
+    if(expMax != 0) {
+      expMax = std::floor(std::log10(expMax)) + 1;
+    } else {
+      expMax = 1;
+    }
   }
 
   double scale = 1;
   int sz = 11;
 
-  if (intMode) {
-    sz = (expMax > 9) ? 11 : static_cast<int>(expMax) + 1;
-  } else {
-    if (expMax - expMin > 4) {
+  if(intMode) {
+    if(expMax > 9) {
       sz = 11;
-      if (std::fabs(expMax) > 99 || std::fabs(expMin) > 99) {
-        sz++;
-      }
+      return PrintFormat(scale, sz, true, false, 4);  // scientific
     } else {
-      if (expMax > 5 || expMax < 0) {
+      sz = static_cast<int>(expMax) + 1;
+      return PrintFormat(scale, sz);  // default float
+    }
+  } else {
+    if(expMax-expMin > 4) {
+      sz = 11;
+      if(std::fabs(expMax) > 99 || std::fabs(expMin) > 99) {
+        sz = sz + 1;
+      }
+      return PrintFormat(scale, sz, true, false, 4);  // scientific
+    } else {
+      if(expMax > 5 || expMax < 0) {
         sz = 7;
-        scale = std::pow(10, expMax - 1);
+        scale = std::pow(10, expMax-1);
+        return PrintFormat(scale, sz, false, true, 4);  // fixed
       } else {
-        sz = (expMax == 0) ? 7 : static_cast<int>(expMax) + 6;
+        if(expMax == 0) {
+          sz = 7;
+        } else {
+          sz = static_cast<int>(expMax) + 6;
+        }
+        return PrintFormat(scale, sz, false, true, 4);  // fixed
       }
     }
   }
-
-  return std::make_tuple(scale, sz);
 }
 
-// Print indentation
-static std::string __printIndent(int64_t indent) {
-  return std::string(indent, ' ');
+static std::string formatValue(double value, const PrintFormat& fmt) {
+  double scaledValue = value / fmt.scale;
+
+  if (fmt.scientific) {
+    return fmt::format("{:>{}.{}e}", scaledValue, fmt.width, fmt.precision);
+  } else if (fmt.fixed) {
+    return fmt::format("{:>{}.{}f}", scaledValue, fmt.width, fmt.precision);
+  } else {
+    return fmt::format("{:>{}g}", scaledValue, fmt.width);
+  }
 }
 
-// Print scale information
-static std::string printScale(double scale) {
-  return fmt::format("{} *\n", scale);
-}
+static void __printMatrix(std::ostream& stream, const Tensor& self, int64_t linesize, int64_t indent) {
+  auto printFmt = __printFormat(self);
 
-// Print a matrix
-static void __printMatrix(
-    std::ostream& stream,
-    const Tensor& self,
-    int64_t linesize,
-    int64_t indent) {
-  auto [scale, sz] = __printFormat(self);
-  std::string indent_str = __printIndent(indent);
-
-  fmt::print(stream, "{}", indent_str);
-  int64_t nColumnPerLine = (linesize - indent) / (sz + 1);
+  int64_t nColumnPerLine = (linesize - indent) / (printFmt.width + 1);
   int64_t firstColumn = 0;
   int64_t lastColumn = -1;
 
-  while (firstColumn < self.size(1)) {
-    lastColumn = std::min(firstColumn + nColumnPerLine - 1, self.size(1) - 1);
-
-    if (nColumnPerLine < self.size(1)) {
-      if (firstColumn != 0) {
-        fmt::print(stream, "\n");
-      }
-      fmt::print(stream, "Columns {} to {}", firstColumn + 1, lastColumn + 1);
-      fmt::print(stream, "{}", indent_str);
+  while(firstColumn < self.size(1)) {
+    if(firstColumn + nColumnPerLine <= self.size(1)) {
+      lastColumn = firstColumn + nColumnPerLine - 1;
+    } else {
+      lastColumn = self.size(1) - 1;
     }
 
-    if (scale != 1) {
-      fmt::print(stream, "{}", printScale(scale));
-      fmt::print(stream, "{}", indent_str);
+    if(nColumnPerLine < self.size(1)) {
+      if(firstColumn != 0) {
+        fmt::print(stream, "\n");
+      }
+      fmt::print(stream, "{:>{}s}Columns {} to {}",
+                 "", indent, firstColumn+1, lastColumn+1);
+    }
+
+    if(printFmt.scale != 1) {
+      fmt::print(stream, "\n{:>{}s}{} *\n{:>{}s}",
+                 "", indent, printFmt.scale, "", indent);
     }
 
     for (const auto l : c10::irange(self.size(0))) {
       Tensor row = self.select(0, l);
-      const double* row_ptr = row.const_data_ptr<double>();
+      const double *row_ptr = row.const_data_ptr<double>();
 
-      for (const auto c : c10::irange(firstColumn, lastColumn + 1)) {
-        // Print with width but only add space if not the last column
-        if (c < lastColumn) {
-          fmt::print(stream, "{:>{}} ", row_ptr[c] / scale, sz);
-        } else {
-          fmt::print(stream, "{:>{}}", row_ptr[c] / scale, sz);
+      for (const auto c : c10::irange(firstColumn, lastColumn+1)) {
+        fmt::print(stream, "{}", formatValue(row_ptr[c], printFmt));
+
+        if(c == lastColumn) {
           fmt::print(stream, "\n");
-          if (l != self.size(0) - 1) {
-            fmt::print(
-                stream, "{}", scale != 1 ? indent_str + " " : indent_str);
+          if(l != self.size(0)-1) {
+            if(printFmt.scale != 1) {
+              fmt::print(stream, "{:>{}s} ", "", indent);
+            } else {
+              fmt::print(stream, "{:>{}s}", "", indent);
+            }
           }
+        } else {
+          fmt::print(stream, " ");
         }
       }
     }
-
     firstColumn = lastColumn + 1;
   }
 }
 
-// Print a tensor with more than 2 dimensions
-static void __printTensor(
-    std::ostream& stream,
-    Tensor& self,
-    int64_t linesize) {
-  std::vector<int64_t> counter(self.ndimension() - 2);
+static void __printTensor(std::ostream& stream, Tensor& self, int64_t linesize) {
+  std::vector<int64_t> counter(self.ndimension()-2);
   bool start = true;
   bool finished = false;
-
   counter[0] = -1;
   for (const auto i : c10::irange(1, counter.size())) {
     counter[i] = 0;
   }
 
-  while (true) {
-    for (int64_t i = 0; i < self.ndimension() - 2; i++) {
-      counter[i]++;
-      if (counter[i] >= self.size(i)) {
-        if (i == self.ndimension() - 3) {
+  while(true) {
+    for(int64_t i = 0; i < self.ndimension()-2; i++) {
+      counter[i] = counter[i] + 1;
+      if(counter[i] >= self.size(i)) {
+        if(i == self.ndimension()-3) {
           finished = true;
           break;
         }
@@ -227,12 +235,10 @@ static void __printTensor(
         break;
       }
     }
-
-    if (finished) {
+    if(finished) {
       break;
     }
-
-    if (start) {
+    if(start) {
       start = false;
     } else {
       fmt::print(stream, "\n");
@@ -240,41 +246,36 @@ static void __printTensor(
 
     fmt::print(stream, "(");
     Tensor tensor = self;
-    for (const auto i : c10::irange(self.ndimension() - 2)) {
+    for (const auto i : c10::irange(self.ndimension()-2)) {
       tensor = tensor.select(0, counter[i]);
-      fmt::print(stream, "{},", counter[i] + 1);
+      fmt::print(stream, "{},", counter[i]+1);
     }
     fmt::print(stream, ".,.) = \n");
     __printMatrix(stream, tensor, linesize, 1);
   }
 }
 
-void print(const Tensor& t, int64_t linesize) {
+void print(const Tensor & t, int64_t linesize) {
   print(std::cout, t, linesize);
 }
 
-std::ostream& print(
-    std::ostream& stream,
-    const Tensor& tensor_,
-    int64_t linesize) {
-  FormatGuard guard(stream);
-
-  if (!tensor_.defined()) {
+std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesize) {
+  if(!tensor_.defined()) {
     fmt::print(stream, "[ Tensor (undefined) ]");
     return stream;
   }
 
   if (tensor_.is_sparse()) {
-    fmt::print(stream, "[ {}{{}}]\n", tensor_.toString());
-    fmt::print(stream, "indices:\n");
+    fmt::print(stream, "[ {}{{\nindices:\n", tensor_.toString());
     print(stream, tensor_._indices(), linesize);
     fmt::print(stream, "\nvalues:\n");
     print(stream, tensor_._values(), linesize);
-    fmt::print(stream, "\nsize:\n{}\n]", tensor_.sizes());
+    fmt::print(stream, "\nsize:\n{}\n]", fmt::streamed(tensor_.sizes()));
     return stream;
   }
 
   Tensor tensor;
+
   if (tensor_.is_quantized()) {
     tensor = tensor_.dequantize().to(kCPU, kDouble).contiguous();
   } else if (tensor_.is_mkldnn()) {
@@ -287,63 +288,50 @@ std::ostream& print(
     tensor = tensor_.to(kCPU, kDouble).contiguous();
   }
 
-  if (tensor.ndimension() == 0) {
+  if(tensor.ndimension() == 0) {
     fmt::print(stream, "{}\n", tensor.const_data_ptr<double>()[0]);
-    fmt::print(stream, "[ {}{{}}", tensor_.toString());
-  } else if (tensor.ndimension() == 1) {
+    fmt::print(stream, "[ {}{{", tensor_.toString());
+  } else if(tensor.ndimension() == 1) {
     if (tensor.numel() > 0) {
-      auto [scale, sz] = __printFormat(tensor);
-      if (scale != 1) {
-        fmt::print(stream, "{}", printScale(scale));
+      auto printFmt = __printFormat(tensor);
+      if(printFmt.scale != 1) {
+        fmt::print(stream, "{} *\n", printFmt.scale);
       }
-
       const double* tensor_p = tensor.const_data_ptr<double>();
       for (const auto i : c10::irange(tensor.size(0))) {
-        // Match the original format without trailing space
-        fmt::print(stream, "{:>{}}\n", tensor_p[i] / scale, sz);
+        fmt::print(stream, "{}\n", formatValue(tensor_p[i], printFmt));
       }
     }
     fmt::print(stream, "[ {}{{{}}}", tensor_.toString(), tensor.size(0));
-  } else if (tensor.ndimension() == 2) {
+  } else if(tensor.ndimension() == 2) {
     if (tensor.numel() > 0) {
       __printMatrix(stream, tensor, linesize, 0);
     }
-    fmt::print(
-        stream,
-        "[ {}{{{},{}}}",
-        tensor_.toString(),
-        tensor.size(0),
-        tensor.size(1));
+    fmt::print(stream, "[ {}{{{},{}}}",
+               tensor_.toString(), tensor.size(0), tensor.size(1));
   } else {
     if (tensor.numel() > 0) {
       __printTensor(stream, tensor, linesize);
     }
-
-    // Build the size string using fmt::format_to for efficiency
-    fmt::memory_buffer sizes;
-    fmt::format_to(std::back_inserter(sizes), "{}", tensor.size(0));
+    fmt::print(stream, "[ {}{{{}", tensor_.toString(), tensor.size(0));
     for (const auto i : c10::irange(1, tensor.ndimension())) {
-      fmt::format_to(std::back_inserter(sizes), ",{}", tensor.size(i));
+      fmt::print(stream, ",{}", tensor.size(i));
     }
-
-    fmt::print(stream, "[ {}{{{}}}", tensor_.toString(), sizes);
+    fmt::print(stream, "}}");
   }
 
+  // Add quantization info
   if (tensor_.is_quantized()) {
     fmt::print(stream, ", qscheme: {}", toString(tensor_.qscheme()));
-
     if (tensor_.qscheme() == c10::kPerTensorAffine) {
-      fmt::print(stream, ", scale: {}", tensor_.q_scale());
-      fmt::print(stream, ", zero_point: {}", tensor_.q_zero_point());
-    } else if (
-        tensor_.qscheme() == c10::kPerChannelAffine ||
-        tensor_.qscheme() == c10::kPerChannelAffineFloatQParams) {
+      fmt::print(stream, ", scale: {}, zero_point: {}",
+                 tensor_.q_scale(), tensor_.q_zero_point());
+    } else if (tensor_.qscheme() == c10::kPerChannelAffine ||
+               tensor_.qscheme() == c10::kPerChannelAffineFloatQParams) {
       fmt::print(stream, ", scales: ");
-      Tensor scales = tensor_.q_per_channel_scales();
-      print(stream, scales, linesize);
+      print(stream, tensor_.q_per_channel_scales(), linesize);
       fmt::print(stream, ", zero_points: ");
-      Tensor zero_points = tensor_.q_per_channel_zero_points();
-      print(stream, zero_points, linesize);
+      print(stream, tensor_.q_per_channel_zero_points(), linesize);
       fmt::print(stream, ", axis: {}", tensor_.q_per_channel_axis());
     }
   }
@@ -361,4 +349,4 @@ std::ostream& print(
   return stream;
 }
 
-} // namespace at
+}

--- a/aten/src/ATen/core/Formatting.cpp
+++ b/aten/src/ATen/core/Formatting.cpp
@@ -1,6 +1,5 @@
 #include <ATen/core/Formatting.h>
 #include <c10/util/irange.h>
-#include <fmt/core.h>
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 
@@ -39,13 +38,13 @@ std::ostream& operator<<(std::ostream& out, const Scalar& s) {
 }
 
 std::string toString(const Scalar& s) {
-  return fmt::format("{}", s);
+  return fmt::format("{}", fmt::streamed(s));
 }
 } // namespace c10
 
 namespace at {
 
-// Format guard to preserve formatting options
+//saves/restores number formatting inside scope
 class FormatGuard {
  public:
   explicit FormatGuard(std::ostream& out) : out(out) {

--- a/aten/src/ATen/core/Formatting.cpp
+++ b/aten/src/ATen/core/Formatting.cpp
@@ -182,13 +182,13 @@ static void __printMatrix(std::ostream& stream, const Tensor& self, int64_t line
       if(firstColumn != 0) {
         fmt::print(stream, "\n");
       }
-      fmt::print(stream, "{:>{}s}Columns {} to {}",
-                 "", indent, firstColumn+1, lastColumn+1);
+      fmt::print(stream, "Columns {} to {}", firstColumn+1, lastColumn+1);
+      fmt::print(stream, "{:>{}s}", "", indent);
     }
 
     if(printFmt.scale != 1) {
-      fmt::print(stream, "\n{:>{}s}{} *\n{:>{}s}",
-                 "", indent, printFmt.scale, "", indent);
+      fmt::print(stream, "{} *\n{:>{}s}",
+                 printFmt.scale, "", indent);
     }
 
     for (const auto l : c10::irange(self.size(0))) {


### PR DESCRIPTION
Replaces stateful ostream output with stateless fmtlib, which is signficantly faster and more contained. It is especially faster for the type of complex double formatting found here since it uses the newer [DragonBox algorithm](https://github.com/jk-jeon/dragonbox) for faster floating point formatting (which is the main bottleneck here). This also enables some static time checking of the formatting strings

test plan: all tests pass

cc @albanD