### PR TITLE
[Binary-builds]Use System NCCL by default in CI/CD.

### DIFF
--- a/.ci/aarch64_linux/aarch64_ci_build.sh
+++ b/.ci/aarch64_linux/aarch64_ci_build.sh
@@ -20,6 +20,8 @@ cd /
 # on the mounted pytorch repo
 git config --global --add safe.directory /pytorch
 pip install -r /pytorch/requirements.txt
+
+
 pip install auditwheel==6.2.0
 if [ "$DESIRED_CUDA" = "cpu" ]; then
     echo "BASE_CUDA_VERSION is not set. Building cpu wheel."
@@ -27,6 +29,7 @@ if [ "$DESIRED_CUDA" = "cpu" ]; then
     USE_PRIORITIZED_TEXT_FOR_LD=1 python /pytorch/.ci/aarch64_linux/aarch64_wheel_ci_build.py --enable-mkldnn
 else
     echo "BASE_CUDA_VERSION is set to: $DESIRED_CUDA"
+    export USE_SYSTEM_NCCL=1
     #USE_PRIORITIZED_TEXT_FOR_LD for enable linker script optimization https://github.com/pytorch/pytorch/pull/121975/files
     USE_PRIORITIZED_TEXT_FOR_LD=1 python /pytorch/.ci/aarch64_linux/aarch64_wheel_ci_build.py --enable-mkldnn --enable-cuda
 fi

--- a/.ci/aarch64_linux/aarch64_ci_build.sh
+++ b/.ci/aarch64_linux/aarch64_ci_build.sh
@@ -20,8 +20,6 @@ cd /
 # on the mounted pytorch repo
 git config --global --add safe.directory /pytorch
 pip install -r /pytorch/requirements.txt
-
-
 pip install auditwheel==6.2.0
 if [ "$DESIRED_CUDA" = "cpu" ]; then
     echo "BASE_CUDA_VERSION is not set. Building cpu wheel."

--- a/.ci/manywheel/build_cuda.sh
+++ b/.ci/manywheel/build_cuda.sh
@@ -15,6 +15,9 @@ export INSTALL_TEST=0 # dont install test binaries into site-packages
 export USE_CUPTI_SO=0
 export USE_CUSPARSELT=${USE_CUSPARSELT:-1} # Enable if not disabled by libtorch build
 export USE_CUFILE=${USE_CUFILE:-1}
+export USE_SYSTEM_NCCL=1
+export NCCL_INCLUDE_DIR="/usr/local/cuda/include/"
+export NCCL_LIB_DIR="/usr/local/cuda/lib64/"
 
 # Keep an array of cmake variables to add to
 if [[ -z "$CMAKE_ARGS" ]]; then
@@ -172,12 +175,9 @@ if [[ $CUDA_VERSION == 12* ]]; then
         export LIB_SO_RPATH=$CUDA_RPATHS':$ORIGIN'
         export FORCE_RPATH="--force-rpath"
         export USE_STATIC_NCCL=0
-        export USE_SYSTEM_NCCL=1
         export ATEN_STATIC_CUDA=0
         export USE_CUDA_STATIC_LINK=0
         export USE_CUPTI_SO=1
-        export NCCL_INCLUDE_DIR="/usr/local/cuda/include/"
-        export NCCL_LIB_DIR="/usr/local/cuda/lib64/"
     fi
 elif [[ $CUDA_VERSION == "11.8" ]]; then
     export USE_STATIC_CUDNN=0
@@ -254,12 +254,9 @@ elif [[ $CUDA_VERSION == "11.8" ]]; then
         export LIB_SO_RPATH=$CUDA_RPATHS':$ORIGIN'
         export FORCE_RPATH="--force-rpath"
         export USE_STATIC_NCCL=0
-        export USE_SYSTEM_NCCL=1
         export ATEN_STATIC_CUDA=0
         export USE_CUDA_STATIC_LINK=0
         export USE_CUPTI_SO=1
-        export NCCL_INCLUDE_DIR="/usr/local/cuda/include/"
-        export NCCL_LIB_DIR="/usr/local/cuda/lib64/"
     fi
 else
     echo "Unknown cuda version $CUDA_VERSION"

--- a/cmake/Modules/FindNCCL.cmake
+++ b/cmake/Modules/FindNCCL.cmake
@@ -56,7 +56,6 @@ if(NCCL_FOUND)  # obtaining NCCL version and some sanity checks
   list (APPEND CMAKE_REQUIRED_INCLUDES ${NCCL_INCLUDE_DIRS})
   include(CheckCXXSymbolExists)
   check_cxx_symbol_exists(NCCL_VERSION_CODE nccl.h NCCL_VERSION_DEFINED)
-  message (STATUS "NCCL_VERSION_CODE: ${NCCL_VERSION_CODE}")
 
   # this condition check only works for non static NCCL linking
   if (NCCL_VERSION_DEFINED AND NOT USE_STATIC_NCCL)
@@ -71,12 +70,11 @@ if(NCCL_FOUND)  # obtaining NCCL version and some sanity checks
         ncclGetVersion(&x);
         return x == NCCL_VERSION_CODE;
       }
-  ")
+")
     try_run(NCCL_VERSION_MATCHED compile_result ${PROJECT_BINARY_DIR} ${file}
           RUN_OUTPUT_VARIABLE NCCL_VERSION_FROM_HEADER
           CMAKE_FLAGS  "-DINCLUDE_DIRECTORIES=${NCCL_INCLUDE_DIRS}"
           LINK_LIBRARIES ${NCCL_LIBRARIES})
-
     if (NOT NCCL_VERSION_MATCHED)
       message(FATAL_ERROR "Found NCCL header version and library version do not match! \
 (include: ${NCCL_INCLUDE_DIRS}, library: ${NCCL_LIBRARIES}) Please set NCCL_INCLUDE_DIR and NCCL_LIB_DIR manually.")

--- a/tools/build_pytorch_libs.py
+++ b/tools/build_pytorch_libs.py
@@ -2,10 +2,16 @@ from __future__ import annotations
 
 import os
 import platform
+import subprocess
 from pathlib import Path
 
 from .setup_helpers.cmake import CMake, USE_NINJA
-from .setup_helpers.env import check_negative_env_flag, IS_64BIT, IS_WINDOWS
+from .setup_helpers.env import (
+    check_env_flag,
+    check_negative_env_flag,
+    IS_64BIT,
+    IS_WINDOWS,
+)
 
 
 repo_root = Path(__file__).absolute().parent.parent
@@ -74,6 +80,39 @@ def _create_build_env() -> dict[str, str]:
     return my_env
 
 
+def read_nccl_pin() -> str:
+    nccl_file = "nccl-cu12.txt"
+    if os.getenv("DESIRED_CUDA", "").startswith("11") or os.getenv(
+        "CUDA_VERSION", ""
+    ).startswith("11"):
+        nccl_file = "nccl-cu11.txt"
+    nccl_pin_path = os.path.join(
+        repo_root, ".ci", "docker", "ci_commit_pins", nccl_file
+    )
+    with open(nccl_pin_path) as f:
+        return f.read().strip()
+
+
+def checkout_nccl() -> None:
+    release_tag = read_nccl_pin()
+    print(f"-- Checkout nccl release tag: {release_tag}")
+    nccl_basedir = os.path.join(third_party_path, "nccl")
+    if not os.path.exists(nccl_basedir):
+        subprocess.check_call(
+            [
+                "git",
+                "clone",
+                "--depth",
+                "1",
+                "--branch",
+                release_tag,
+                "https://github.com/NVIDIA/nccl.git",
+                "nccl",
+            ],
+            cwd=third_party_path,
+        )
+
+
 def build_pytorch(
     version: str | None,
     cmake_python_library: str | None,
@@ -83,6 +122,12 @@ def build_pytorch(
     cmake: CMake,
 ) -> None:
     my_env = _create_build_env()
+    if (
+        not check_negative_env_flag("USE_CUDA")
+        and not check_negative_env_flag("USE_NCCL")
+        and not check_env_flag("USE_SYSTEM_NCCL")
+    ):
+        checkout_nccl()
     build_test = not check_negative_env_flag("BUILD_TEST")
     cmake.generate(
         version, cmake_python_library, build_python, build_test, my_env, rerun_cmake

--- a/tools/build_pytorch_libs.py
+++ b/tools/build_pytorch_libs.py
@@ -2,16 +2,10 @@ from __future__ import annotations
 
 import os
 import platform
-import subprocess
 from pathlib import Path
 
 from .setup_helpers.cmake import CMake, USE_NINJA
-from .setup_helpers.env import (
-    check_env_flag,
-    check_negative_env_flag,
-    IS_64BIT,
-    IS_WINDOWS,
-)
+from .setup_helpers.env import check_negative_env_flag, IS_64BIT, IS_WINDOWS
 
 
 repo_root = Path(__file__).absolute().parent.parent
@@ -80,39 +74,6 @@ def _create_build_env() -> dict[str, str]:
     return my_env
 
 
-def read_nccl_pin() -> str:
-    nccl_file = "nccl-cu12.txt"
-    if os.getenv("DESIRED_CUDA", "").startswith("11") or os.getenv(
-        "CUDA_VERSION", ""
-    ).startswith("11"):
-        nccl_file = "nccl-cu11.txt"
-    nccl_pin_path = os.path.join(
-        repo_root, ".ci", "docker", "ci_commit_pins", nccl_file
-    )
-    with open(nccl_pin_path) as f:
-        return f.read().strip()
-
-
-def checkout_nccl() -> None:
-    release_tag = read_nccl_pin()
-    print(f"-- Checkout nccl release tag: {release_tag}")
-    nccl_basedir = os.path.join(third_party_path, "nccl")
-    if not os.path.exists(nccl_basedir):
-        subprocess.check_call(
-            [
-                "git",
-                "clone",
-                "--depth",
-                "1",
-                "--branch",
-                release_tag,
-                "https://github.com/NVIDIA/nccl.git",
-                "nccl",
-            ],
-            cwd=third_party_path,
-        )
-
-
 def build_pytorch(
     version: str | None,
     cmake_python_library: str | None,
@@ -122,12 +83,6 @@ def build_pytorch(
     cmake: CMake,
 ) -> None:
     my_env = _create_build_env()
-    if (
-        not check_negative_env_flag("USE_CUDA")
-        and not check_negative_env_flag("USE_NCCL")
-        and not check_env_flag("USE_SYSTEM_NCCL")
-    ):
-        checkout_nccl()
     build_test = not check_negative_env_flag("BUILD_TEST")
     cmake.generate(
         version, cmake_python_library, build_python, build_test, my_env, rerun_cmake


### PR DESCRIPTION
Use System NCCl by default. The correct nccl version is already built into the Manylinux docker image.

Will followup with PR on detecting if user has NCCL installed and enabling USE_SYSTEM_NCCL by default in this case.
