### PR TITLE
[ROCm] Fix SymmetricMemory build error on NAVI arch

### DIFF
--- a/torch/csrc/distributed/c10d/CUDASymmetricMemory-inl.h
+++ b/torch/csrc/distributed/c10d/CUDASymmetricMemory-inl.h
@@ -60,7 +60,7 @@ __device__ __forceinline__ void trap() {
 __device__ __forceinline__ size_t global_timer_ns() {
 #if defined(USE_ROCM)
   static constexpr double MI300_FREQ_GHZ = 2.1;
-  return __builtin_amdgcn_s_memtime() / MI300_FREQ_GHZ;
+  return clock64() / MI300_FREQ_GHZ;
 #else
   size_t val;
   asm volatile("mov.u64 %0, %globaltimer;" : "=l"(val) : : "memory");


### PR DESCRIPTION
NAVI arch doesn't support `__builtin_amdgcn_s_memtime()`, using `clock64()` instead which works for both NAVI and MI archs.

Fixes #ISSUE_NUMBER


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd