### PR TITLE
ci: Remove conda-env-macOS-ARM64, prefer pip

### DIFF
--- a/.github/actions/setup-macos/action.yml
+++ b/.github/actions/setup-macos/action.yml
@@ -1,0 +1,26 @@
+name: Setup macOS
+description: Set up macOS environment
+
+inputs:
+  python-version:
+    required: true
+    type: string
+    description: The Python version to use for the environment.
+
+runs:
+  using: composite
+  steps:
+    - name: Install system dependencies
+      shell: bash
+      run: |
+        # Install system dependencies
+        # TODO: We should pin these versions
+        brew install pkgconf
+    
+    # TODO: We should find a way to install libuv (not from conda)
+
+    - name: Setup python + dependencies
+      uses: pytorch/test-infra/.github/actions/setup-miniconda@main
+      with:
+        python-version: ${{ inputs.python-version }}
+        pip-requirements-file: .github/requirements/pip-requirements-macOS.txt

--- a/.github/requirements/conda-env-macOS-ARM64
+++ b/.github/requirements/conda-env-macOS-ARM64
@@ -1,22 +1,3 @@
-numpy=1.22.3
-pyyaml=6.0
-setuptools=72.1.0
-cmake=3.22.*
-typing-extensions=4.11.0
-dataclasses=0.8
-pip=22.2.2
-pillow=10.0.1
-pkg-config=0.29.2
-wheel=0.37.1
-# NB: This is intentionally held back because anaconda main doesn't
-# have updated expecttest, but you don't /need/ the updated version
-# to run the tests.  In the meantime I need to figure out how to
-# cajole anaconda into updating, or get the package from pypi instead...
-expecttest=0.1.3
-
-# Not pinning certifi so that we can always get the latest certificates
-certifi
-
 # Cross-compiling arm64 from x86-64 picks up 1.40.0 while testing on arm64
 # itself only has up to 1.39.0 from upstream conda. Both work though
 libuv>=1.39.0,<=1.40.0

--- a/.github/requirements/pip-requirements-macOS.txt
+++ b/.github/requirements/pip-requirements-macOS.txt
@@ -1,6 +1,5 @@
 boto3==1.35.42
 cmake==3.22.*
-dataclasses==0.8
 expecttest==0.3.0
 fbscribelogger==0.1.7
 filelock==3.6.0

--- a/.github/requirements/pip-requirements-macOS.txt
+++ b/.github/requirements/pip-requirements-macOS.txt
@@ -1,33 +1,41 @@
 boto3==1.35.42
-hypothesis==6.56.4
+cmake==3.22.*
+dataclasses==0.8
 expecttest==0.3.0
 fbscribelogger==0.1.7
+filelock==3.6.0
+hypothesis==6.56.4
 librosa>=0.6.2
 mpmath==1.3.0
 networkx==2.8.7
-# Use numba-0.49.1 or older on Intel Macs, but 0.56.0 on M1 machines, as older numba is not available
-numba==0.56.0; platform_machine == "arm64"
 numba<=0.49.1; platform_machine != "arm64"
-opt-einsum>=3.3
-psutil==5.9.1
+numba==0.56.0; platform_machine == "arm64" # Use numba-0.49.1 or older on Intel Macs, but 0.56.0 on M1 machines, as older numba is not available
+numpy==1.22.3
 nvidia-ml-py==11.525.84
-packaging==23.1
-pygments==2.15.0
-pytest==7.3.2
-pytest-xdist==3.3.1
-pytest-rerunfailures==10.3
-pytest-flakefinder==1.1.0
-pytest-subtests==0.13.1
-scipy==1.10.1
-sympy==1.13.3
-unittest-xml-reporting<=3.2.0,>=2.0.0
-xdoctest==1.1.0
-filelock==3.6.0
-pytest-cpp==2.3.0
-z3-solver==4.12.2.0
-tensorboard==2.13.0
+opt-einsum>=3.3
 optree==0.13.0
-# NB: test_hparams_* from test_tensorboard is failing with protobuf 5.26.0 in
-# which the stringify metadata is wrong when escaping double quote
-protobuf==3.20.2
+packaging==23.1
 parameterized==0.8.1
+Pillow==10.0.1
+protobuf==3.20.2 # NB: test_hparams_* from test_tensorboard is failing with protobuf 5.26.0 in which the stringify metadata is wrong when escaping double quote
+psutil==5.9.1
+pygments==2.15.0
+pytest-cpp==2.3.0
+pytest-flakefinder==1.1.0
+pytest-rerunfailures==10.3
+pytest-subtests==0.13.1
+pytest-xdist==3.3.1
+pytest==7.3.2
+PyYAML==6.0
+scipy==1.10.1
+setuptools==72.1.0
+sympy==1.13.3
+tensorboard==2.13.0
+typing-extensions==4.11.0
+unittest-xml-reporting<=3.2.0,>=2.0.0
+wheel==0.37.1
+xdoctest==1.1.0
+z3-solver==4.12.2.0
+
+# Not pinning certifi so that we can always get the latest certificates
+certifi

--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -81,12 +81,10 @@ jobs:
             echo "DEVELOPER_DIR=/Applications/Xcode_${XCODE_VERSION}.app/Contents/Developer" >> "${GITHUB_ENV}"
           fi
 
-      - name: Setup miniconda
-        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
+      - name: Setup macOS
+        uses: ./.github/actions/set-macos
         with:
           python-version: ${{ inputs.python-version }}
-          environment-file: .github/requirements/conda-env-${{ runner.os }}-${{ runner.arch }}
-          pip-requirements-file: .github/requirements/pip-requirements-${{ runner.os }}.txt
 
       - name: Install sccache (only for non-forked PRs, and pushes to trunk)
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0

--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -82,7 +82,7 @@ jobs:
           fi
 
       - name: Setup macOS
-        uses: ./.github/actions/set-macos
+        uses: ./.github/actions/setup-macos
         with:
           python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -81,12 +81,10 @@ jobs:
           name: ${{ inputs.build-environment }}
           use-gha: true
 
-      - name: Setup miniconda
-        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
+      - name: Setup macOS
+        uses: ./.github/actions/setup-macos
         with:
           python-version: ${{ inputs.python-version }}
-          environment-file: .github/requirements/conda-env-${{ runner.os }}-${{ runner.arch }}
-          pip-requirements-file: .github/requirements/pip-requirements-${{ runner.os }}.txt
 
       - name: Get workflow job id
         id: get-job-id

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -113,12 +113,10 @@ jobs:
         with:
           use-gha: true
 
-      - name: Setup miniconda
-        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
+      - name: Setup macOS
+        uses: ./.github/actions/set-macos
         with:
           python-version: ${{ inputs.python-version }}
-          environment-file: .github/requirements/conda-env-${{ runner.os }}-${{ runner.arch }}
-          pip-requirements-file: .github/requirements/pip-requirements-${{ runner.os }}.txt
 
       - name: Parse ref
         id: parse-ref

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -114,7 +114,7 @@ jobs:
           use-gha: true
 
       - name: Setup macOS
-        uses: ./.github/actions/set-macos
+        uses: ./.github/actions/setup-macos
         with:
           python-version: ${{ inputs.python-version }}
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #152843
* #152545

Also introduces a setup-macos action which should give us some
flexibility on how we set up our macOS jobs

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>