### PR TITLE
[nativert] Move AutoTimer to c10.

### DIFF
--- a/c10/test/util/AutoTimer_test.cpp
+++ b/c10/test/util/AutoTimer_test.cpp
@@ -1,0 +1,126 @@
+/*
+ * Ported from folly/logging/test/AutoTimerTest.cpp
+ */
+
+#include <c10/util/AutoTimer.h>
+#include <c10/util/ScopeExit.h>
+#include <gtest/gtest.h>
+
+using namespace c10;
+
+struct StubLogger {
+  void operator()(std::string_view msg, std::chrono::duration<double> sec) {
+    m = std::string(msg);
+    t = sec.count();
+  }
+  static std::string m;
+  static double t;
+};
+
+std::string StubLogger::m = "";
+double StubLogger::t = 0;
+
+struct StubClock {
+  typedef std::chrono::seconds duration;
+
+  static std::chrono::time_point<StubClock> now() {
+    return std::chrono::time_point<StubClock>(std::chrono::duration<int>(t));
+  }
+  static int t;
+};
+
+int StubClock::t = 0;
+
+TEST(TestAutoTimer, HandleBasicClosure) {
+  auto logger = [](std::string_view mesg, auto sec) {
+    return StubLogger()(mesg, sec);
+  };
+  StubClock::t = 1;
+  // Here decltype is needed. But since most users are expected to use this
+  // method with the default clock, template specification won't be needed even
+  // when they use a closure. See test case HandleRealTimerClosure
+  auto timer = makeAutoTimer<decltype(logger), StubClock>(
+      "", std::chrono::duration<double>::zero(), std::move(logger));
+  StubClock::t = 3;
+  timer.log("foo");
+  ASSERT_EQ("foo", StubLogger::m);
+  ASSERT_EQ(2, StubLogger::t);
+  timer.logFormat(fmt::runtime("bar {}"), 5e-2);
+  ASSERT_EQ("bar 0.05", StubLogger::m);
+  ASSERT_EQ(0, StubLogger::t);
+}
+
+TEST(TestAutoTimer, HandleBasic) {
+  StubClock::t = 1;
+  AutoTimer<StubLogger, StubClock> timer;
+  StubClock::t = 3;
+  timer.log("foo");
+  ASSERT_EQ("foo", StubLogger::m);
+  ASSERT_EQ(2, StubLogger::t);
+  timer.logFormat(fmt::runtime("bar {}"), 5e-2);
+  ASSERT_EQ("bar 0.05", StubLogger::m);
+  ASSERT_EQ(0, StubLogger::t);
+}
+
+TEST(TestAutoTimer, HandleLogOnDestruct) {
+  {
+    StubClock::t = 0;
+    AutoTimer<StubLogger, StubClock> timer("message");
+    StubClock::t = 3;
+    timer.log("foo");
+    EXPECT_EQ("foo", StubLogger::m);
+    EXPECT_EQ(3, StubLogger::t);
+    StubClock::t = 5;
+  }
+  ASSERT_EQ("message", StubLogger::m);
+  ASSERT_EQ(2, StubLogger::t);
+}
+
+TEST(TestAutoTimer, HandleRealTimerClosure) {
+  auto t = makeAutoTimer(
+      "Third message on destruction",
+      std::chrono::duration<double>::zero(),
+      [](std::string_view mesg, auto sec) {
+        GoogleLogger<GoogleLoggerStyle::MILLISECONDS>()(mesg, sec);
+      });
+  t.log("First message");
+  t.log("Second message");
+}
+
+TEST(TestAutoTimer, HandleRealTimer) {
+  AutoTimer<> t("Third message on destruction");
+  t.log("First message");
+  t.log("Second message");
+}
+
+TEST(TestAutoTimer, HandleMinLogTime) {
+  StubClock::t = 1;
+  AutoTimer<StubLogger, StubClock> timer("", std::chrono::duration<double>(3));
+  StubClock::t = 3;
+  // only 2 "seconds" have passed, so this shouldn't log
+  StubLogger::t = 0;
+  ASSERT_EQ(std::chrono::duration<double>(2), timer.log("foo"));
+  ASSERT_EQ(std::chrono::duration<double>::zero().count(), StubLogger::t);
+}
+
+TEST(TestAutoTimer, MovedObjectDestructionDoesntLog) {
+  const std::vector<std::string> expectedMsgs = {
+      "BEFORE_MOVE", "AFTER_MOVE", "END"};
+  int32_t current = 0;
+  auto scope_guard = make_scope_exit([&]() { EXPECT_EQ(3, current); });
+
+  auto timer = [&expectedMsgs, &current] {
+    auto oldTimer = makeAutoTimer(
+        "END",
+        std::chrono::duration<double>::zero(),
+        [&expectedMsgs, &current](
+            std::string_view msg, const std::chrono::duration<double>&) {
+          EXPECT_EQ(expectedMsgs.at(current), msg);
+          current++;
+        });
+    oldTimer.log("BEFORE_MOVE");
+    auto newTimer = std::move(oldTimer); // force the move-ctor
+    return newTimer;
+  }();
+  timer.log("AFTER_MOVE");
+}

--- a/c10/util/AutoTimer.h
+++ b/c10/util/AutoTimer.h
@@ -1,0 +1,139 @@
+/*
+ * Ported from folly/logging/AutoTimer.h
+ */
+
+#pragma once
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include <c10/util/Logging.h>
+#include <fmt/format.h>
+
+namespace c10 {
+
+// Default logger
+enum class GoogleLoggerStyle { SECONDS, MILLISECONDS };
+template <GoogleLoggerStyle>
+struct GoogleLogger;
+
+/**
+ * Automatically times a block of code, printing a specified log message on
+ * destruction or whenever the log() method is called. For example:
+ *
+ *   AutoTimer t("Foo() completed");
+ *   doWork();
+ *   t.log("Do work finished");
+ *   doMoreWork();
+ *
+ * This would print something like:
+ *   "Do work finished in 1.2 seconds"
+ *   "Foo() completed in 4.3 seconds"
+ *
+ * You can customize what you use as the logger and clock. The logger needs
+ * to have an operator()(StringPiece, std::chrono::duration<double>) that
+ * gets a message and a duration. The clock needs to model Clock from
+ * std::chrono.
+ *
+ * The default logger logs usings glog. It only logs if the message is
+ * non-empty, so you can also just use this class for timing, e.g.:
+ *
+ *   AutoTimer t;
+ *   doWork()
+ *   const auto how_long = t.log();
+ */
+template <
+    class Logger = GoogleLogger<GoogleLoggerStyle::MILLISECONDS>,
+    class Clock = std::chrono::high_resolution_clock>
+class AutoTimer final {
+ public:
+  using DoubleSeconds = std::chrono::duration<double>;
+
+  explicit AutoTimer(
+      std::string&& msg = "",
+      const DoubleSeconds& minTimetoLog = DoubleSeconds::zero(),
+      Logger&& logger = Logger())
+      : destructionMessage_(
+            msg.empty() ? nullptr
+                        : std::make_unique<std::string>(std::move(msg))),
+        minTimeToLog_(minTimetoLog),
+        logger_(std::move(logger)) {}
+
+  // It doesn't really make sense to copy AutoTimer
+  // Movable to make sure the helper method for creating an AutoTimer works.
+  AutoTimer(const AutoTimer&) = delete;
+  AutoTimer(AutoTimer&&) = default;
+  AutoTimer& operator=(const AutoTimer&) = delete;
+  AutoTimer& operator=(AutoTimer&&) = default;
+
+  ~AutoTimer() {
+    if (destructionMessage_) {
+      log(*destructionMessage_);
+    }
+  }
+
+  DoubleSeconds log(std::string_view msg = "") {
+    return logImpl(Clock::now(), msg);
+  }
+
+  template <typename... Args>
+  DoubleSeconds logFormat(fmt::format_string<Args...> fmt, Args&&... args) {
+    auto now = Clock::now();
+    return logImpl(now, fmt::format(fmt, std::forward<Args>(args)...));
+  }
+
+ private:
+  // We take in the current time so that we don't measure time to call
+  // to<std::string> or format() in the duration.
+  DoubleSeconds logImpl(
+      std::chrono::time_point<Clock> now,
+      std::string_view msg) {
+    auto duration = now - start_;
+    if (duration >= minTimeToLog_) {
+      logger_(msg, duration);
+    }
+    start_ = Clock::now(); // Don't measure logging time
+    return duration;
+  }
+
+  std::unique_ptr<std::string> destructionMessage_;
+  std::chrono::time_point<Clock> start_ = Clock::now();
+  DoubleSeconds minTimeToLog_;
+  Logger logger_;
+};
+
+template <
+    class Logger = GoogleLogger<GoogleLoggerStyle::MILLISECONDS>,
+    class Clock = std::chrono::high_resolution_clock>
+auto makeAutoTimer(
+    std::string&& msg = "",
+    const std::chrono::duration<double>& minTimeToLog =
+        std::chrono::duration<double>::zero(),
+    Logger&& logger = Logger()) {
+  return AutoTimer<Logger, Clock>(
+      std::move(msg), minTimeToLog, std::move(logger));
+}
+
+template <GoogleLoggerStyle Style>
+struct GoogleLogger final {
+  void operator()(
+      std::string_view msg,
+      const std::chrono::duration<double>& sec) const {
+    if (msg.empty()) {
+      return;
+    }
+    if (Style == GoogleLoggerStyle::SECONDS) {
+      LOG(INFO) << msg << " in " << sec.count() << " seconds";
+    } else if (Style == GoogleLoggerStyle::MILLISECONDS) {
+      LOG(INFO) << msg << " in "
+                << std::chrono::duration_cast<
+                       std::chrono::duration<double, std::milli>>(sec)
+                       .count()
+                << " milliseconds";
+    }
+  }
+};
+
+} // namespace c10


### PR DESCRIPTION
Summary:
Torch Native Runtime RFC: https://github.com/zhxchen17/rfcs/blob/master/RFC-0043-torch-native-runtime.md

To land the runtime into PyTorch core, we will gradually land logical parts of the code into the Github issue and get each piece properly reviewed.

This diff adds a small library utility implementing an auto timer to measure execution time of certain regions for Torch Native Runtime.

Test Plan: c10/test/util/AutoTimer_test

Differential Revision: D74186488
