### PR TITLE
Synchronize in foreach tests after profiling

### DIFF
--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -86,6 +86,7 @@ class ForeachFuncWrapper:
         ):
             with torch.profiler.profile() as p:
                 actual = self.func(*inputs, **kwargs)
+            torch.cuda.synchronize()
             keys = tuple([e.key for e in p.key_averages()])
             mta_called = any("multi_tensor_apply_kernel" in k for k in keys)
             assert mta_called == (expect_fastpath and (not zero_size)), (

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -86,7 +86,8 @@ class ForeachFuncWrapper:
         ):
             with torch.profiler.profile() as p:
                 actual = self.func(*inputs, **kwargs)
-            torch.cuda.synchronize()
+                # synchronize within the profiler context to make sure events happen before exiting
+                torch.cuda.synchronize()
             keys = tuple([e.key for e in p.key_averages()])
             mta_called = any("multi_tensor_apply_kernel" in k for k in keys)
             assert mta_called == (expect_fastpath and (not zero_size)), (


### PR DESCRIPTION
After the CI change from 12.4 -> 12.6 around mid-March, the foreach tests have been flaky and hard to repro due to nondeterminism. Per @davidberard98's suggestion, let's try to add a synchronize before checking profiler results to see whether this fixes the flake! The hope is that the 48 currently open foreach flaky issues will close from this change.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #152857

