### PR TITLE
[ez] Use pip instead of conda in run_tests.sh

### DIFF
--- a/.ci/pytorch/run_tests.sh
+++ b/.ci/pytorch/run_tests.sh
@@ -76,7 +76,7 @@ fi
 # Environment initialization
 if [[ "$(uname)" == Darwin ]]; then
     # Install the testing dependencies
-    retry conda install -yq future hypothesis ${NUMPY_PACKAGE} ${PROTOBUF_PACKAGE} pytest setuptools six typing_extensions pyyaml
+    retry pip install -q future hypothesis ${NUMPY_PACKAGE} ${PROTOBUF_PACKAGE} pytest setuptools six typing_extensions pyyaml
 else
     retry pip install -qr requirements.txt || true
     retry pip install -q hypothesis protobuf pytest setuptools || true
@@ -91,7 +91,6 @@ fi
 
 echo "Testing with:"
 pip freeze
-conda list || true
 
 ##############################################################################
 # Smoke tests


### PR DESCRIPTION
Part 1 of https://github.com/pytorch/pytorch/issues/148336.  The rest depends on https://github.com/pytorch/pytorch/issues/148335 to remove conda from Docker build process.