### PR TITLE
Fix bug visualizing 1D Tensor using rich

### DIFF
--- a/torch/distributed/tensor/debug/_visualize_sharding.py
+++ b/torch/distributed/tensor/debug/_visualize_sharding.py
@@ -79,8 +79,8 @@ def _create_rich_table(
     import rich.style
     import rich.table
 
-    dtensor_height = shape[0] if len(shape) > 0 else 1
-    dtensor_width = shape[1] if len(shape) > 0 else shape[0]
+    dtensor_height = shape[0]
+    dtensor_width = shape[1] if len(shape) == 2 else 1
 
     row_ranges = sorted({s[0] for s in shards})
     col_ranges = sorted({s[1] for s in shards})
@@ -193,6 +193,15 @@ def visualize_sharding(dtensor, header="", use_rich: bool = False):
             dtensor.placements,
         )
         for device_index in device_coords
+    }
+
+    # Extend shards in a 1D tensor to 2D
+    device_shard_shape_and_offsets = {
+        device_index: (
+            shape if len(shape) == 2 else (shape[0], 1),
+            offset if len(offset) == 2 else (offset[0], 0),
+        )
+        for device_index, (shape, offset) in device_shard_shape_and_offsets.items()
     }
 
     shards = [

--- a/torch/distributed/tensor/examples/visualize_sharding_example.py
+++ b/torch/distributed/tensor/examples/visualize_sharding_example.py
@@ -5,31 +5,32 @@ TERM=xterm-256color torchrun --nproc-per-node=4 visualize_sharding_example.py
 
 import os
 
+import rich
+import rich.rule
+
 import torch
 import torch.distributed as dist
 import torch.distributed.tensor as dt
-from torch.distributed.tensor.debug import visualize_sharding
-import rich
-import rich.rule
+import torch.distributed.tensor.debug
 
 
 assert int(os.getenv("WORLD_SIZE", "1")) >= 4, "We need at least 4 devices"
 rank = int(os.environ["RANK"])
 
 
-def section(msg: str):
+def section(msg: str) -> None:
     if rank == 0:
         rich.print(rich.rule.Rule(msg))
 
 
-def visualize(t, msg: str = ""):
+def visualize(t: dt.DTensor, msg: str = "") -> None:
     if rank == 0:
         rich.print(msg)
         dt.debug.visualize_sharding(t, use_rich=False)
         dt.debug.visualize_sharding(t, use_rich=True)
 
 
-section(f"[bold]1D Tensor; 1D Mesh[/bold]")
+section("[bold]1D Tensor; 1D Mesh[/bold]")
 m = dist.init_device_mesh("cuda", (4,))
 t = torch.ones(4)
 visualize(
@@ -41,7 +42,7 @@ visualize(
     "Shard along the only tensor dimension",
 )
 
-section(f"[bold]2D Tensor; 1D Mesh[/bold]")
+section("[bold]2D Tensor; 1D Mesh[/bold]")
 m = dist.init_device_mesh("cuda", (4,))
 t = torch.ones(4, 4)
 visualize(
@@ -57,7 +58,7 @@ visualize(
     "Shard along the second tensor dimension along the only mesh dimension",
 )
 
-section(f"[bold]1D Tensor; 2D Mesh[/bold]")
+section("[bold]1D Tensor; 2D Mesh[/bold]")
 m = dist.init_device_mesh("cuda", (2, 2))
 t = torch.ones(4)
 visualize(
@@ -77,7 +78,7 @@ visualize(
     "Shard the only tensor dimension along the second mesh dimension",
 )
 
-section(f"[bold]2D Tensor; 2D Mesh[/bold]")
+section("[bold]2D Tensor; 2D Mesh[/bold]")
 m = dist.init_device_mesh("cuda", (2, 2))
 t = torch.ones(4, 4)
 visualize(

--- a/torch/distributed/tensor/examples/visualize_sharding_example.py
+++ b/torch/distributed/tensor/examples/visualize_sharding_example.py
@@ -1,81 +1,127 @@
 """
 To run the example, use the following command:
-torchrun --standalone --nnodes=1 --nproc-per-node=4 visualize_sharding_example.py
+TERM=xterm-256color torchrun --nproc-per-node=4 visualize_sharding_example.py
 """
 
 import os
 
 import torch
+import torch.distributed as dist
 import torch.distributed.tensor as dt
 from torch.distributed.tensor.debug import visualize_sharding
+import rich
+import rich.rule
 
 
-world_size = int(os.environ["WORLD_SIZE"])
+assert int(os.getenv("WORLD_SIZE", "1")) >= 4, "We need at least 4 devices"
 rank = int(os.environ["RANK"])
 
-tensor = torch.ones((2, 2)) * rank
 
-# Case 1: 1D mesh
-mesh = dt.DeviceMesh("cuda", list(range(world_size)))
-visualize_sharding(dt.DTensor.from_local(tensor, mesh, [dt.Replicate()]))
-visualize_sharding(dt.DTensor.from_local(tensor, mesh, [dt.Replicate()]), use_rich=True)
-visualize_sharding(dt.DTensor.from_local(tensor, mesh, [dt.Shard(dim=0)]))
-visualize_sharding(
-    dt.DTensor.from_local(tensor, mesh, [dt.Shard(dim=0)]), use_rich=True
+def section(msg: str):
+    if rank == 0:
+        rich.print(rich.rule.Rule(msg))
+
+
+def visualize(t, msg: str = ""):
+    if rank == 0:
+        rich.print(msg)
+        dt.debug.visualize_sharding(t, use_rich=False)
+        dt.debug.visualize_sharding(t, use_rich=True)
+
+
+section(f"[bold]1D Tensor; 1D Mesh[/bold]")
+m = dist.init_device_mesh("cuda", (4,))
+t = torch.ones(4)
+visualize(
+    dt.distribute_tensor(t, m, [dt.Replicate()]),
+    "Replicate along the only mesh dimension",
 )
-visualize_sharding(dt.DTensor.from_local(tensor, mesh, [dt.Shard(dim=1)]))
-visualize_sharding(
-    dt.DTensor.from_local(tensor, mesh, [dt.Shard(dim=1)]), use_rich=True
+visualize(
+    dt.distribute_tensor(t, m, [dt.Shard(dim=0)]),
+    "Shard along the only tensor dimension",
 )
 
-# Case 2: 2D mesh
-mesh = dt.DeviceMesh("cuda", [[0, 1], [2, 3]])
-visualize_sharding(
-    dt.DTensor.from_local(tensor, mesh, [dt.Replicate(), dt.Replicate()])
+section(f"[bold]2D Tensor; 1D Mesh[/bold]")
+m = dist.init_device_mesh("cuda", (4,))
+t = torch.ones(4, 4)
+visualize(
+    dt.distribute_tensor(t, m, [dt.Replicate()]),
+    "Replicate along the only mesh dimension",
 )
-visualize_sharding(
-    dt.DTensor.from_local(tensor, mesh, [dt.Replicate(), dt.Replicate()]),
-    use_rich=True,
+visualize(
+    dt.distribute_tensor(t, m, [dt.Shard(dim=0)]),
+    "Shard alone the first tensor dimension along the only mesh dimension",
 )
-visualize_sharding(
-    dt.DTensor.from_local(tensor, mesh, [dt.Shard(dim=0), dt.Replicate()])
+visualize(
+    dt.distribute_tensor(t, m, [dt.Shard(dim=1)]),
+    "Shard along the second tensor dimension along the only mesh dimension",
 )
-visualize_sharding(
-    dt.DTensor.from_local(tensor, mesh, [dt.Shard(dim=0), dt.Replicate()]),
-    use_rich=True,
+
+section(f"[bold]1D Tensor; 2D Mesh[/bold]")
+m = dist.init_device_mesh("cuda", (2, 2))
+t = torch.ones(4)
+visualize(
+    dt.distribute_tensor(t, m, [dt.Replicate(), dt.Replicate()]),
+    "Replicate along both mesh dimensions",
 )
-visualize_sharding(
-    dt.DTensor.from_local(tensor, mesh, [dt.Replicate(), dt.Shard(dim=1)])
+visualize(
+    dt.distribute_tensor(t, m, [dt.Shard(dim=0), dt.Shard(dim=0)]),
+    "Shard the only tensor dimension along both mesh dimensions",
 )
-visualize_sharding(
-    dt.DTensor.from_local(tensor, mesh, [dt.Replicate(), dt.Shard(dim=1)]),
-    use_rich=True,
+visualize(
+    dt.distribute_tensor(t, m, [dt.Shard(dim=0), dt.Replicate()]),
+    "Shard the only tensor dimension along the first mesh dimension",
 )
-visualize_sharding(
-    dt.DTensor.from_local(tensor, mesh, [dt.Shard(dim=1), dt.Replicate()])
+visualize(
+    dt.distribute_tensor(t, m, [dt.Replicate(), dt.Shard(dim=0)]),
+    "Shard the only tensor dimension along the second mesh dimension",
 )
-visualize_sharding(
-    dt.DTensor.from_local(tensor, mesh, [dt.Shard(dim=1), dt.Replicate()]),
-    use_rich=True,
+
+section(f"[bold]2D Tensor; 2D Mesh[/bold]")
+m = dist.init_device_mesh("cuda", (2, 2))
+t = torch.ones(4, 4)
+visualize(
+    dt.distribute_tensor(t, m, [dt.Replicate(), dt.Replicate()]),
+    "Replicate along both mesh dimensions",
 )
-visualize_sharding(
-    dt.DTensor.from_local(tensor, mesh, [dt.Replicate(), dt.Shard(dim=0)])
+visualize(
+    dt.distribute_tensor(t, m, [dt.Shard(dim=0), dt.Shard(dim=0)]),
+    "Shard the first tensor dimension along both mesh dimensions",
 )
-visualize_sharding(
-    dt.DTensor.from_local(tensor, mesh, [dt.Replicate(), dt.Shard(dim=0)]),
-    use_rich=True,
+visualize(
+    dt.distribute_tensor(t, m, [dt.Shard(dim=1), dt.Shard(dim=1)]),
+    "Shard the second tensor dimension along both mesh dimensions",
 )
-visualize_sharding(
-    dt.DTensor.from_local(tensor, mesh, [dt.Shard(dim=0), dt.Shard(dim=1)])
+visualize(
+    dt.distribute_tensor(t, m, [dt.Shard(dim=0), dt.Shard(dim=1)]),
+    "Shard the first tensor dimension along the first mesh dimension, "
+    + "the second tensor dimension along the second mesh dimension",
 )
-visualize_sharding(
-    dt.DTensor.from_local(tensor, mesh, [dt.Shard(dim=0), dt.Shard(dim=1)]),
-    use_rich=True,
+visualize(
+    dt.distribute_tensor(t, m, [dt.Shard(dim=1), dt.Shard(dim=0)]),
+    "Shard the first tensor dimension along the second mesh dimension, "
+    + "the second tensor dimension along the first mesh dimension",
 )
-visualize_sharding(
-    dt.DTensor.from_local(tensor, mesh, [dt.Shard(dim=1), dt.Shard(dim=0)])
+visualize(
+    dt.distribute_tensor(t, m, [dt.Shard(dim=0), dt.Replicate()]),
+    "Shard the first tensor dimension along the first mesh dimension, "
+    + "replicate the second tensor dimension along the second mesh dimension",
 )
-visualize_sharding(
-    dt.DTensor.from_local(tensor, mesh, [dt.Shard(dim=1), dt.Shard(dim=0)]),
-    use_rich=True,
+visualize(
+    dt.distribute_tensor(t, m, [dt.Replicate(), dt.Shard(dim=0)]),
+    "Shard the first tensor dimension along the second mesh dimension, "
+    + "replicate the second tensor dimension along the first mesh dimension",
 )
+visualize(
+    dt.distribute_tensor(t, m, [dt.Shard(dim=1), dt.Replicate()]),
+    "Shard the second tensor dimension along the first mesh dimension, "
+    + "replicate the second tensor dimension along the second mesh dimension",
+)
+visualize(
+    dt.distribute_tensor(t, m, [dt.Replicate(), dt.Shard(dim=1)]),
+    "Shard the second tensor dimension along the second mesh dimension, "
+    + "replicate the second tensor dimension along the first mesh dimension",
+)
+
+
+dist.destroy_process_group()


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/152848

I didn't fix the bug earlier because the example script didn't exhaustively present all combinations of 1D/2D tensor, 1D/2D mesh, and all possible sharding specs. Therefore, in this PR, I enriched the example script to cover all possible combinations.

<img width="1008" alt="f" src="https://github.com/user-attachments/assets/1745a804-a004-4f98-8332-d7498453f397" />

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k