### PR TITLE
Clarify wrap_triton doc about optional triton_op usage

### DIFF
--- a/torch/_library/triton.py
+++ b/torch/_library/triton.py
@@ -207,7 +207,7 @@ def wrap_triton(triton_kernel: Callable, /) -> Any:
     The ``wrap_triton`` API wraps a triton kernel into a callable that
     can actually be traced into a graph.
 
-    Please use this API together with :func:`torch.library.triton_op`.
+    You can use this API directly for compiling Triton kernels. Use it with :func:`torch.library.triton_op` only if you need to interpose at the dispatch level (i.e., registering a custom operator).
 
     Examples:
 


### PR DESCRIPTION
This PR updates the docstring for `wrap_triton` to clarify that using `torch.library.triton_op` is optional, and only necessary if dispatch interposition is required. This addresses confusion raised in #152870.
