### PR TITLE
xpu: support custom ops with torch.library on xpu backend

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -167,6 +167,7 @@ class TestCustomOpTesting(CustomOpTestCaseBase):
         lib.impl("foo", Foo.apply, "Autograd")
         lib.impl("foo", foo_impl, "CPU")
         lib.impl("foo", foo_impl, "CUDA")
+        lib.impl("foo", foo_impl, "XPU")
 
         x = torch.tensor(3.14159 / 3, requires_grad=True, device=device)
         with self.assertRaisesRegex(
@@ -271,6 +272,7 @@ class TestCustomOpTesting(CustomOpTestCaseBase):
         lib.impl("foo", Foo.apply, "Autograd")
         lib.impl("foo", foo_impl, "CPU")
         lib.impl("foo", foo_impl, "CUDA")
+        lib.impl("foo", foo_impl, "XPU")
 
         x = torch.tensor([0, 1.0], requires_grad=True)
         with self.assertRaisesRegex(
@@ -312,6 +314,7 @@ class TestCustomOpTesting(CustomOpTestCaseBase):
         lib.impl("foo", Foo.apply, "Autograd")
         lib.impl("foo", foo_impl, "CPU")
         lib.impl("foo", foo_impl, "CUDA")
+        lib.impl("foo", foo_impl, "XPU")
         lib.impl("foo", foo_meta, "Meta")
 
         x = torch.tensor([0, 1.0], requires_grad=True)
@@ -343,6 +346,7 @@ class TestCustomOpTesting(CustomOpTestCaseBase):
         lib.impl("foo", Foo.apply, "Autograd")
         lib.impl("foo", foo_impl, "CPU")
         lib.impl("foo", foo_impl, "CUDA")
+        lib.impl("foo", foo_impl, "XPU")
         lib.impl("foo", foo_meta, "Meta")
 
         x = torch.tensor([0, 1.0])
@@ -369,6 +373,7 @@ class TestCustomOpTesting(CustomOpTestCaseBase):
 
         lib.impl("foo", Foo.apply, "CPU")
         lib.impl("foo", Foo.apply, "CUDA")
+        lib.impl("foo", Foo.apply, "XPU")
         lib.impl("foo", lambda x: x.clone(), "Meta")
 
         x = torch.randn([], requires_grad=True)
@@ -427,19 +432,20 @@ class TestCustomOpTesting(CustomOpTestCaseBase):
             torch.library.opcheck(op.op, args, kwargs)
 
     def test_opcheck_fails_basic(self, device):
-        @custom_op(f"{self.test_ns}::foo")
-        def foo(x: torch.Tensor) -> torch.Tensor: ...
+        lib = self.lib()
+        lib.define("foo(Tensor x) -> Tensor")
+        op = self.ns().foo.default
 
-        @foo.impl(["cpu", "cuda"])
         def foo_impl(x):
             return x.sum()
 
+        lib.impl("foo", foo_impl, "CPU")
+        lib.impl("foo", foo_impl, "CUDA")
+        lib.impl("foo", foo_impl, "XPU")
+
         x = torch.randn(3, device=device, requires_grad=True)
-        # Triggers the CustomOp autograd NYI error
-        with self.assertRaisesRegex(
-            optests.OpCheckError, "Autograd has not been implemented for operator"
-        ):
-            torch.library.opcheck(self.get_op(f"{self.test_ns}::foo"), (x,), {})
+        with self.assertRaisesRegex(AssertionError, "incorrectly registered"):
+            optests.autograd_registration_check(op, (x,), {})
 
     def test_autograd_registration_check_autograd_kernel(self, device):
         lib = self.lib()
@@ -462,6 +468,7 @@ class TestCustomOpTesting(CustomOpTestCaseBase):
         lib.impl("foo", Foo.apply, "Autograd")
         lib.impl("foo", foo_impl, "CPU")
         lib.impl("foo", foo_impl, "CUDA")
+        lib.impl("foo", foo_impl, "XPU")
 
         x = torch.randn(3, requires_grad=True, device=device)
         # Should not raise
@@ -511,6 +518,7 @@ class TestCustomOpTesting(CustomOpTestCaseBase):
 
         lib.impl("foo", Foo.apply, "CPU")
         lib.impl("foo", Foo.apply, "CUDA")
+        lib.impl("foo", Foo.apply, "XPU")
 
         x = torch.randn(3, requires_grad=True, device=device)
         with self.assertRaisesRegex(AssertionError, "incorrectly registered"):
@@ -4677,8 +4685,10 @@ class TestOpProfiles(TestCase):
             loaded = read_profiles_from_yaml(yaml_str)
 
 
-only_for = ("cpu", "cuda")
-instantiate_device_type_tests(TestCustomOpTesting, globals(), only_for=only_for)
+only_for = ("cpu", "cuda", "xpu")
+instantiate_device_type_tests(
+    TestCustomOpTesting, globals(), only_for=only_for, allow_xpu=True
+)
 instantiate_parametrized_tests(TestCustomOp)
 instantiate_parametrized_tests(TestCustomOpAPI)
 

--- a/torch/testing/_internal/optests/autograd_registration.py
+++ b/torch/testing/_internal/optests/autograd_registration.py
@@ -83,15 +83,17 @@ def autograd_registration_check(op, args, kwargs):
 
     # Determine which AutogradBACKEND key to check
     all_device_types = {arg.device.type for arg in all_tensors}
-    if not all_device_types.issubset(["cpu", "cuda"]):
+    if not all_device_types.issubset(["cpu", "cuda", "xpu"]):
         # Don't want to support other keys yet
         raise NotImplementedError(
-            f"autograd_registration_check: NYI devices other than CPU/CUDA, got {all_device_types}"
+            f"autograd_registration_check: NYI devices other than CPU/CUDA/XPU, got {all_device_types}"
         )
     if "cuda" in all_device_types:
         key = "AutogradCUDA"
     elif "cpu" in all_device_types:
         key = "AutogradCPU"
+    elif "xpu" in all_device_types:
+        key = "AutogradXPU"
 
     if torch._C._dispatch_has_kernel_for_dispatch_key(op.name(), key):
         return
@@ -127,6 +129,6 @@ def autograd_registration_check(op, args, kwargs):
         f"which may lead to silently incorrect results. If your operator consists "
         f"of regular PyTorch operations, consider not using an operator at all "
         f"or registering your operator as CompositeImplicitAutograd. If you have "
-        f"an autograd.Function registered to a backend (CPU/CUDA) key, the correct "
+        f"an autograd.Function registered to a backend (CPU/CUDA/XPU) key, the correct "
         f"location for it is the Autograd key."
     )


### PR DESCRIPTION
Fixes: https://github.com/intel/torch-xpu-ops/issues/1626

This PR started enabling of tests for `torch.library`, but more work is needed. Tests are using `torch._custom_ops` deprecated API planned for removal at pytorch 2.6 (not done). I think cleanup of pytorch would be nice before enabling more tests for xpu.
https://github.com/pytorch/pytorch/blob/a2ccda3c605bc37457a465711cee40775df54d2e/torch/_custom_op/impl.py#L47

CC: @EikanWang 