### PR TITLE
Devcontainer: Fix context path and workspace mount

### DIFF
--- a/.devcontainer/cpu/devcontainer.json
+++ b/.devcontainer/cpu/devcontainer.json
@@ -3,13 +3,19 @@
 {
   "name": "PyTorch - CPU",
   "build": {
-    "context": "../..",
+    "context": "./",
     "dockerfile": "../Dockerfile",
     "args": {
       "USERNAME": "vscode",
       "BUILDKIT_INLINE_CACHE": "0",
       "CLANG_VERSION": ""
     }
+  },
+  // Mount the full repo only after the container starts
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace/pytorch,type=bind,consistency=cached",
+  "workspaceFolder": "/workspace/pytorch",
+  "containerEnv": {
+    "PIP_USER": "0" // <‑‑ disable implicit --user
   },
 
   // Features to add to the dev container. More info: https://containers.dev/features.

--- a/.devcontainer/cuda/devcontainer.json
+++ b/.devcontainer/cuda/devcontainer.json
@@ -3,7 +3,7 @@
 {
   "name": "PyTorch - CUDA",
   "build": {
-    "context": "../..",
+    "context": "./",
     "dockerfile": "../Dockerfile",
     "args": {
       "USERNAME": "vscode",
@@ -12,7 +12,13 @@
       "CLANG_VERSION": ""
     }
   },
-  "runArgs": ["--gpus", "all"],
+  "runArgs": ["--runtime", "nvidia", "--gpus", "all"],
+  // Mount the full repo only after the container starts
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace/pytorch,type=bind,consistency=cached",
+  "workspaceFolder": "/workspace/pytorch",
+  "containerEnv": {
+    "PIP_USER": "0" // <‑‑ disable implicit --user
+  },
 // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
 


### PR DESCRIPTION
## Summary
- Changed the devcontainer context path from '../..' to './' for both CPU and CUDA configurations
- Added workspace mount configuration to properly mount the repository in the container
- Added containerEnv to disable implicit --user pip flag

## Test plan
Test by building and running the devcontainer in VS Code