### PR TITLE
Devcontainer: Replace conda with apt-based setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,34 +1,52 @@
-FROM mcr.microsoft.com/vscode/devcontainers/miniconda:0-3
+FROM mcr.microsoft.com/vscode/devcontainers/base:ubuntu-22.04
 
-#  I am suprised this is needed
-RUN conda init
-
-# Copy environment.yml (if found) to a temp location so we update the environment. Also
-# copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.
-COPY .devcontainer/cuda/environment.yml .devcontainer/noop.txt /tmp/conda-tmp/
-RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then umask 0002 && /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml; fi \
-    && sudo rm -rf /tmp/conda-tmp
+# Tools needed for development
+RUN apt-get -y update && \
+    apt-get install -y \
+    build-essential \
+    cmake \
+    ninja-build \
+    git \
+    python3 \
+    python3-pip \
+    python3-dev \
+    python3-venv \
+    libopenblas-dev
 
 # Tools needed for llvm
-RUN sudo apt-get -y update
-RUN sudo apt install -y lsb-release wget software-properties-common gnupg
+RUN apt-get install -y \
+    lsb-release \
+    wget \
+    software-properties-common \
+    gnupg
+
+# Create Python virtual environment
+# RUN python3 -m venv /opt/venv
+# ENV PATH="/opt/venv/bin:$PATH"
+RUN pip3 install --upgrade pip
 
 # Install CLANG if version is specified
 ARG CLANG_VERSION
 RUN if [ -n "$CLANG_VERSION" ]; then \
-    sudo wget https://apt.llvm.org/llvm.sh; \
+    wget https://apt.llvm.org/llvm.sh; \
     chmod +x llvm.sh; \
-    sudo ./llvm.sh "${CLANG_VERSION}"; \
+    ./llvm.sh "${CLANG_VERSION}"; \
     echo 'export CC=clang' >> ~/.bashrc; \
     echo 'export CXX=clang++' >> ~/.bashrc; \
-    sudo apt update; \
-    sudo apt install -y clang; \
-    sudo apt install -y libomp-dev; \
+    apt install -y clang libomp-dev; \
     fi
 
 
-# Install cuda if version is specified
+# Install CUDA if version is specified
 ARG CUDA_VERSION
 RUN if [ -n "$CUDA_VERSION" ]; then \
-       conda install -y cuda -c "nvidia/label/cuda-${CUDA_VERSION}"; \
+    CUDA_REPO_VERSION=$(echo ${CUDA_VERSION} | sed 's/\./\-/g'); \
+    wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb && \
+    dpkg -i cuda-keyring_1.0-1_all.deb && \
+    apt-get install -y cuda-toolkit-${CUDA_VERSION}; \
     fi
+
+# Set PATH for CUDA
+ENV PATH="/usr/local/cuda/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/usr/local/cuda/lib64:${LD_LIBRARY_PATH}"
+ENV PIP_BREAK_SYSTEM_PACKAGES=1

--- a/.devcontainer/cpu/environment.yml
+++ b/.devcontainer/cpu/environment.yml
@@ -1,6 +1,0 @@
-# This environment is specific to Debian
-name: PyTorch
-dependencies:
-  - cmake
-  - ninja
-  - libopenblas

--- a/.devcontainer/cuda/devcontainer.json
+++ b/.devcontainer/cuda/devcontainer.json
@@ -8,7 +8,7 @@
     "args": {
       "USERNAME": "vscode",
       "BUILDKIT_INLINE_CACHE": "0",
-      "CUDA_VERSION": "11.8.0",
+      "CUDA_VERSION": "12.8.0",
       "CLANG_VERSION": ""
     }
   },

--- a/.devcontainer/cuda/environment.yml
+++ b/.devcontainer/cuda/environment.yml
@@ -1,6 +1,0 @@
-# This environment is specific to Debian
-name: PyTorch
-dependencies:
-  - cmake
-  - ninja
-  - libopenblas

--- a/.devcontainer/cuda/requirements.txt
+++ b/.devcontainer/cuda/requirements.txt
@@ -1,0 +1,2 @@
+cmake
+ninja

--- a/.devcontainer/noop.txt
+++ b/.devcontainer/noop.txt
@@ -1,3 +1,0 @@
-This file copied into the container along with environment.yml* from the parent
-folder. This file is included to prevents the Dockerfile COPY instruction from
-failing if no environment.yml is found.

--- a/.devcontainer/scripts/install-dev-tools.sh
+++ b/.devcontainer/scripts/install-dev-tools.sh
@@ -8,6 +8,6 @@ git submodule update --init --recursive
 make setup-lint
 
 # Add CMAKE_PREFIX_PATH to bashrc
-echo 'export CMAKE_PREFIX_PATH=${CONDA_PREFIX:-"$(dirname $(which conda))/../"}' >> ~/.bashrc
+echo 'export CMAKE_PREFIX_PATH=/usr/local' >> ~/.bashrc
 # Add linker path so that cuda-related libraries can be found
-echo 'export LDFLAGS="-L${CONDA_PREFIX}/lib/ $LDFLAGS"' >> ~/.bashrc
+echo 'export LDFLAGS="-L/usr/local/cuda/lib64/ $LDFLAGS"' >> ~/.bashrc


### PR DESCRIPTION
## Summary
- Replaced miniconda base image with base Ubuntu 22.04 image
- Installed Python and required dependencies using apt
- Replaced conda-based CUDA installation with apt-based version 
- Updated paths in install-dev-tools.sh to reflect the new non-conda environment
- Removed conda-specific files and added requirements.txt for Python dependencies

## Test plan
Test by building and running the devcontainer in VS Code with both CPU and CUDA configurations