### PR TITLE
Use three-dot diffs in URL and xref lint workflows

### DIFF
--- a/.github/workflows/_link_check.yml
+++ b/.github/workflows/_link_check.yml
@@ -25,9 +25,9 @@ jobs:
       script: |
         ./scripts/lint_urls.sh $(
           [ "${{ github.event_name }}" = "pull_request" ] \
-            && git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} \
+            && git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} \
           || [ "${{ github.event_name }}" = "push" ] \
-            && git diff --name-only ${{ github.event.before }} ${{ github.sha }}
+            && git diff --name-only ${{ github.event.before }}...${{ github.sha }}
         ) || {
           echo
           echo "URL lint failed."
@@ -50,7 +50,7 @@ jobs:
       script: |
         ./scripts/lint_xrefs.sh $(
           [ "${{ github.event_name }}" = "pull_request" ] \
-            && git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} \
+            && git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} \
           || [ "${{ github.event_name }}" = "push" ] \
-            && git diff --name-only ${{ github.event.before }} ${{ github.sha }}
+            && git diff --name-only ${{ github.event.before }}...${{ github.sha }}
         )


### PR DESCRIPTION
Only run on the files actually modified in a PR, not every file touched on main since the branch point

Fixes #152884
