### PR TITLE
Move link check jobs to pull to go with doc build

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -283,15 +283,6 @@ jobs:
           # All we need to see is that it passes
           python3 torch/utils/collect_env.py
 
-  link-check:
-    name: Link checks
-    needs: get-label-type
-    uses: ./.github/workflows/_link_check.yml
-    with:
-      runner: ${{ needs.get-label-type.outputs.label-type }}
-      ref:    ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-    secrets: inherit
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,7 +33,7 @@ jobs:
     uses: ./.github/workflows/_link_check.yml
     with:
       runner: ${{ needs.get-label-type.outputs.label-type }}
-      ref:    ${{ github.sha }}
+      ref: ${{ github.sha }}
     secrets: inherit
 
   docs-build:

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -83,6 +83,15 @@ jobs:
       test-matrix: ${{ needs.linux-jammy-py3_9-gcc11-build.outputs.test-matrix }}
     secrets: inherit
 
+  link-check:
+    name: Link checks
+    needs: get-label-type
+    uses: ./.github/workflows/_link_check.yml
+    with:
+      runner: ${{ needs.get-label-type.outputs.label-type }}
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+    secrets: inherit
+
   linux-docs:
     name: linux-docs
     uses: ./.github/workflows/_docs.yml


### PR DESCRIPTION
The job is flaky atm https://github.com/pytorch/pytorch/issues/152884, it's not a good idea to keep it in a highly visible workflow like lint.  I try to move it to trunk, but keeping it together with the build job in pull makes sense too given that the check also runs nightly with doc build.