### PR TITLE
Forward fix D74196435

### DIFF
--- a/torch/csrc/jit/runtime/static/passes.h
+++ b/torch/csrc/jit/runtime/static/passes.h
@@ -86,5 +86,6 @@ TORCH_API void UseInPlaceGetRealInputsFromOptionalInputsV2(
 
 TORCH_API void PrepackWeights(std::shared_ptr<Graph>& graph);
 
-C10_DECLARE_bool(enable_clip_ranges_gather_fusions);
 } // namespace torch::jit
+
+C10_DECLARE_bool(enable_clip_ranges_gather_fusions);


### PR DESCRIPTION
Summary: Forward fix a misplace declaration from D74196435

Test Plan: Random check with a failed build `buck2 build --config fbcode.enable_gpu_sections=true --flagfile fbcode//mode/opt fbcode//accelerators/workloads/models/emu_flash/tests:test_compile_eager`

Reviewed By: wdvr

Differential Revision: D74225582


cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel