### PR TITLE
Allow Inductor backends to attest their own availability

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -915,7 +915,7 @@ class _NullDecorator(contextlib.nullcontext):  # type: ignore[type-arg]
         return fn
 
 
-def check_if_dynamo_supported():
+def raise_if_dynamo_unavailable() -> None:
     if sys.version_info >= (3, 14):
         raise RuntimeError("Python 3.14+ not yet supported for torch.compile")
     elif sysconfig.get_config_var("Py_GIL_DISABLED") == 1 and sys.version_info < (
@@ -929,21 +929,40 @@ def check_if_dynamo_supported():
         )
 
 
-def is_dynamo_supported():
+def is_dynamo_supported() -> bool:
     try:
-        check_if_dynamo_supported()
+        raise_if_dynamo_unavailable()
         return True
     except Exception:
         return False
 
 
-def check_if_inductor_supported():
-    check_if_dynamo_supported()
+def raise_if_inductor_unavailable(device: torch.types.Device = None) -> None:
+    from torch._inductor.codegen.common import (
+        get_scheduling_for_device,
+        init_backend_registration,
+    )
+
+    raise_if_dynamo_unavailable()
+
+    init_backend_registration()
+
+    if device is None:
+        device = torch.get_default_device()
+    elif isinstance(device, (str, int)):
+        device = torch.device(device)
+
+    scheduling_factory = get_scheduling_for_device(device.type)
+    if scheduling_factory is None:
+        raise RuntimeError(
+            f"No Inductor scheduling factory registered for {device.type}"
+        )
+    scheduling_factory(None).raise_if_unavailable(device)
 
 
-def is_inductor_supported():
+def is_inductor_supported(device: torch.types.Device = None) -> bool:
     try:
-        check_if_inductor_supported()
+        raise_if_inductor_unavailable(device)
         return True
     except Exception:
         return False
@@ -1007,7 +1026,7 @@ def _optimize(
         @torch._dynamo.optimize()
         def toy_example(a, b): ...
     """
-    check_if_dynamo_supported()
+    raise_if_dynamo_unavailable()
     check_for_incompatible_configs()
     # Note: The hooks object could be global instead of passed around, *however* that would make
     # for a confusing API usage and plumbing story wherein we nest multiple .optimize calls.
@@ -1580,7 +1599,7 @@ def export(
         f = _f
         specialize_float = _specialize_float
         assume_static_by_default = _assume_static_by_default
-        check_if_dynamo_supported()
+        raise_if_dynamo_unavailable()
         torch._C._log_api_usage_once("torch._dynamo.export")
         if decomposition_table is not None:
             assert aten_graph, (

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -89,7 +89,7 @@ from torch._utils_internal import (
 from torch.fx._utils import _format_graph_code, lazy_format_graph_code
 from torch.monitor import _WaitCounter
 from torch.nn.modules.lazy import LazyModuleMixin
-from torch.utils._triton import has_triton, has_triton_package
+from torch.utils._triton import has_triton_package
 from torch.utils.hooks import RemovableHandle
 
 
@@ -1546,7 +1546,7 @@ def record_compilation_metrics(
         "dynamo_config": _get_dynamo_config_for_logging(),
         "inductor_config": _scrubbed_inductor_config_for_logging(),
         "cuda_version": torch.version.cuda,
-        "triton_version": triton.__version__ if has_triton() else "",
+        "triton_version": triton.__version__ if has_triton_package() else "",
         "remote_cache_version": remote_cache_version,
         "inductor_fx_remote_cache_backend_type": inductor_fx_remote_cache_backend_type,
         "python_version": sys.version,
@@ -3803,18 +3803,10 @@ def build_checkpoint_variable(**options):
     )
 
 
-def is_compile_supported(device_type):
-    from .eval_frame import is_dynamo_supported
+def is_compile_supported(device_type: str) -> bool:
+    from .eval_frame import is_inductor_supported
 
-    type = torch.device(device_type).type
-    compile_supported = is_dynamo_supported()
-    if type == "cpu":
-        pass
-    elif type in ["cuda", "xpu"] and compile_supported:
-        compile_supported = has_triton()
-    else:
-        compile_supported = False
-    return compile_supported
+    return is_inductor_supported(device_type)
 
 
 # The following 3.11 source code functions are adapted from

--- a/torch/_inductor/codegen/cuda_combined_scheduling.py
+++ b/torch/_inductor/codegen/cuda_combined_scheduling.py
@@ -45,8 +45,15 @@ class CUDACombinedScheduling(BaseScheduling):
         self._cuda_cpp_scheduling = CUDACPPScheduling(scheduler)
         self._rocm_cpp_scheduling = ROCmCPPScheduling(scheduler)
 
-    def get_backend_features(self, device: torch.device) -> OrderedSet[BackendFeature]:
-        return self._triton_scheduling.get_backend_features(device)
+    @classmethod
+    def get_backend_features(cls, device: torch.device) -> OrderedSet[BackendFeature]:
+        return TritonScheduling.get_backend_features(device)
+
+    @classmethod
+    def raise_if_unavailable(
+        cls, device: Union[str, torch.device, None] = None
+    ) -> None:
+        TritonScheduling.raise_if_unavailable(device)
 
     def choose_node_backend(self, node: BaseSchedulerNode) -> BaseScheduling:
         if self._cuda_cpp_scheduling.is_cuda_cpp_template(node):

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -886,7 +886,7 @@ class MetalScheduling(SIMDScheduling):
 
     def __init__(self, scheduler: Optional[Scheduler]) -> None:
         super().__init__(scheduler)
-        wrapper = V.graph.wrapper_code
+        wrapper = getattr(V.graph, "wrapper_code", None)
         if wrapper is not None:
             wrapper.header.splice(
                 "from torch._inductor.runtime.runtime_utils import compile_mps_shader"

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import collections
 import dataclasses
 import functools
-import inspect
 import itertools
 import logging
 import math
@@ -31,14 +30,12 @@ from torch._inductor.metrics import get_metric_table, is_metric_table_enabled
 from torch.fx.experimental.symbolic_shapes import free_symbols, free_unbacked_symbols
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.symbol import free_symbol_is_type, symbol_is_type, SymT
-from torch.utils._triton import has_triton
 
 from . import comms, config, dependencies, ir, metrics
 from .analyze_preserves_zero_mask import can_codegen_without_upcasts
 from .codegen.common import BackendFeature, get_scheduling_for_device, Kernel
 from .comm_analysis import estimate_nccl_collective_runtime
 from .dependencies import Dep, MemoryDep, StarDep, WeakDep
-from .exc import GPUTooOldForTriton, TritonMissing
 from .ir import (
     ComputedBuffer,
     get_device_type,
@@ -3967,20 +3964,14 @@ class Scheduler:
         )
         V.graph.add_device_info(device)
 
-        device_scheduling = get_scheduling_for_device(device.type)
-        if device_scheduling is None:
+        scheduling_factory = get_scheduling_for_device(device.type)
+        if scheduling_factory is None:
             raise RuntimeError(f"Unsupported device type: {device.type}")
 
-        if not has_triton():
-            if (
-                device.type == "cuda"
-                and (device_props := torch.cuda.get_device_properties(device)).major < 7
-            ):
-                raise GPUTooOldForTriton(device_props, inspect.currentframe())
-            elif is_gpu(device.type) and not device.type == "mps":
-                raise TritonMissing(inspect.currentframe())
+        scheduling = scheduling_factory(self)
+        scheduling.raise_if_unavailable(device)
 
-        return device_scheduling(self)
+        return scheduling
 
     def get_backend(self, device: Optional[torch.device]) -> BaseScheduling:
         assert device is not None
@@ -4731,6 +4722,17 @@ class BaseScheduling:
     def get_backend_features(self, device: torch.device) -> OrderedSet[BackendFeature]:
         """Return a set of .codegen.common.BackendFeature()"""
         return OrderedSet()
+
+    @classmethod
+    def raise_if_unavailable(
+        cls, device: Union[str, torch.device, None] = None
+    ) -> None:
+        """
+        Raises a RuntimeError if the given device does not support this codegen or required
+        prerequisites are not available with a useful description for the user. If None is given,
+        the default device is checked.
+        """
+        return None
 
     def can_fuse_vertical(
         self, node1: BaseSchedulerNode, node2: BaseSchedulerNode

--- a/torch/utils/_content_store.py
+++ b/torch/utils/_content_store.py
@@ -93,11 +93,11 @@ def hash_storage_kernel(x):
 # SHA-1 if stable_hash=True, otherwise it will consistent for a single
 # process run but not necessarily across processes.
 def hash_storage(storage: torch.UntypedStorage, *, stable_hash: bool = False) -> str:
-    import torch._dynamo
     from torch._dynamo.utils import is_compile_supported
 
     device_type = storage.device.type
-    if stable_hash or not is_compile_supported(device_type):
+    # FIXME: MPS does not yet support some of the ops required for hashing
+    if stable_hash or not is_compile_supported(device_type) or device_type == "mps":
         cpu_storage = storage.cpu()
         # TODO: make storage support buffer protocol so this isn't
         # necessary


### PR DESCRIPTION
Introduce a new classmethod `raise_if_unavailable` to `BaseScheduling` and its subclasses, then call this method when creating the backend in `create_backend` which uses that scheduler implementation.

This allows Inductor backends to present meaningful messages to the user if prerequisites are not satisfied, by simply provide their own implementations of this classmethod. It also removes any hard-coded checks for particular backends (namely Triton) from `create_backend`.

For `TritonScheduling`, this removes the hardcoded check for Triton inside the generic `create_backend` with the use of the device interface's `raise_if_triton_unavailable`, added in [#152529](https://github.com/pytorch/pytorch/pull/152529).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov