### PR TITLE
Fix doc cosineannealinglr 152081

### DIFF
--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1028,9 +1028,6 @@ class CosineAnnealingLR(LRScheduler):
         **without restarts**, so :math:`T_{cur} = t` and increases monotonically with each call
         to :meth:`step`.
 
-    To retrieve the exact closed-form learning rate at any point, use the
-    :meth:`_get_closed_form_lr` method.
-
     Args:
         optimizer (Optimizer): Wrapped optimizer.
         T_max (int): Maximum number of iterations.
@@ -1041,13 +1038,13 @@ class CosineAnnealingLR(LRScheduler):
         https://arxiv.org/abs/1608.03983
 
     Example:
-    >>> # xdoctest: +SKIP
-    >>> num_epochs = 100
-    >>> scheduler = CosineAnnealingLR(optimizer, T_max=num_epochs)
-    >>> for epoch in range(num_epochs):
-    >>>     train(...)
-    >>>     validate(...)
-    >>>     scheduler.step()
+        >>> # xdoctest: +SKIP
+        >>> num_epochs = 100
+        >>> scheduler = CosineAnnealingLR(optimizer, T_max=num_epochs)
+        >>> for epoch in range(num_epochs):
+        >>>     train(...)
+        >>>     validate(...)
+        >>>     scheduler.step()
 
     .. image:: ../scripts/lr_scheduler_images/CosineAnnealingLR.png
     """

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1000,53 +1000,45 @@ class PolynomialLR(LRScheduler):
 
 
 class CosineAnnealingLR(LRScheduler):
-    r"""Set the learning rate of each parameter group using a cosine annealing schedule.
+    r"""
+    Set the learning rate of each parameter group using a cosine annealing schedule.
 
-    The :math:`\eta_{max}` is set to the initial lr and
-    :math:`T_{cur}` is the number of epochs since the last restart in SGDR:
-
-    .. math::
-        \begin{aligned}
-            \eta_t & = \eta_{min} + \frac{1}{2}(\eta_{max} - \eta_{min})\left(1
-            + \cos\left(\frac{T_{cur}}{T_{max}}\pi\right)\right),
-            & T_{cur} \neq (2k+1)T_{max}; \\
-            \eta_{t+1} & = \eta_{t} + \frac{1}{2}(\eta_{max} - \eta_{min})
-            \left(1 - \cos\left(\frac{1}{T_{max}}\pi\right)\right),
-            & T_{cur} = (2k+1)T_{max}.
-        \end{aligned}
-
-    When last_epoch=-1, sets initial lr as lr. Notice that because the schedule
-    is defined recursively, the learning rate can be simultaneously modified
-    outside this scheduler by other operators. If the learning rate is set
-    solely by this scheduler, the learning rate at each step becomes:
+    The learning rate is updated recursively using:
 
     .. math::
-        \eta_t = \eta_{min} + \frac{1}{2}(\eta_{max} - \eta_{min})\left(1 +
-        \cos\left(\frac{T_{cur}}{T_{max}}\pi\right)\right)
+        \eta_{t+1} = \eta_{\min} + (\eta_t - \eta_{\min}) \cdot
+        \frac{1 + \cos\left(\frac{(T_{cur}+1) \pi}{T_{max}}\right)}
+            {1 + \cos\left(\frac{T_{cur} \pi}{T_{max}}\right)}
 
-    It has been proposed in
-    `SGDR: Stochastic Gradient Descent with Warm Restarts`_. Note that this only
-    implements the cosine annealing part of SGDR, and not the restarts.
+    This implements a recursive approximation of the closed-form schedule proposed in
+    `SGDR: Stochastic Gradient Descent with Warm Restarts`_:
+
+    .. math::
+        \eta_t = \eta_{\min} + \frac{1}{2}(\eta_{\max} - \eta_{\min}) \left(
+            1 + \cos\left(\frac{T_{cur} \pi}{T_{max}}\right) \right)
+
+    where:
+
+    - :math:`\eta_t` is the learning rate at step :math:`t`
+    - :math:`T_{cur}` is the number of epochs since the last restart
+    - :math:`T_{max}` is the maximum number of epochs in a cycle
+
+    Note:
+        Although SGDR includes periodic restarts, this implementation performs cosine annealing
+        **without restarts**, so :math:`T_{cur} = t` and increases monotonically with each call
+        to :meth:`step`.
+
+    To retrieve the exact closed-form learning rate at any point, use the
+    :meth:`_get_closed_form_lr` method.
 
     Args:
         optimizer (Optimizer): Wrapped optimizer.
         T_max (int): Maximum number of iterations.
         eta_min (float): Minimum learning rate. Default: 0.
-        last_epoch (int): The index of last epoch. Default: -1.
+        last_epoch (int): The index of the last epoch. Default: -1.
 
     .. _SGDR\: Stochastic Gradient Descent with Warm Restarts:
         https://arxiv.org/abs/1608.03983
-
-    Example:
-        >>> # xdoctest: +SKIP
-        >>> num_epochs = 100
-        >>> scheduler = CosineAnnealingLR(optimizer, T_max=num_epochs)
-        >>> for epoch in range(num_epochs):
-        >>>     train(...)
-        >>>     validate(...)
-        >>>     scheduler.step()
-
-    .. image:: ../scripts/lr_scheduler_images/CosineAnnealingLR.png
     """
 
     def __init__(

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1039,6 +1039,17 @@ class CosineAnnealingLR(LRScheduler):
 
     .. _SGDR\: Stochastic Gradient Descent with Warm Restarts:
         https://arxiv.org/abs/1608.03983
+
+    Example:
+    >>> # xdoctest: +SKIP
+    >>> num_epochs = 100
+    >>> scheduler = CosineAnnealingLR(optimizer, T_max=num_epochs)
+    >>> for epoch in range(num_epochs):
+    >>>     train(...)
+    >>>     validate(...)
+    >>>     scheduler.step()
+
+    .. image:: ../scripts/lr_scheduler_images/CosineAnnealingLR.png
     """
 
     def __init__(


### PR DESCRIPTION
## Summary

This PR updates the docstring for `CosineAnnealingLR` to accurately reflect its recursive learning rate schedule. The previous docstring displayed only the SGDR closed-form expression, which doesn't match the actual recursive implementation in code.

Changes:

- Added the recursive update formula used in `get_lr()`
- Retained the original closed-form SGDR expression for reference
- Clarified that warm restarts are not implemented in this scheduler

This addresses confusion raised in issue #152081.

## Related issue

[#152081](https://github.com/pytorch/pytorch/issues/152081)

## Testing

Doc-only change. Ran pre-commit to verify formatting.

