### PR TITLE
[Pipelining] Fix _batch_p2p bug for non-NCCL backends (#132644)

### DIFF
--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -397,20 +397,20 @@ class _PipelineSchedule(ABC):
         )
 
 
-def _batch_p2p(p2p_ops: list[dist.P2POp], desc: Optional[str] = None):
+def _batch_p2p(p2p_ops: list[dist.P2POp], desc: Optional[str] = None) -> list[dist.Work]:
     """
     Simple wrapper over batch_isend_irecv from torch.distributed, which just adds a descriptive logger on top.
     """
     if len(p2p_ops) == 0:
-        return None
+        return []
     desc_str = f"{desc}, " if desc else ""
     logger.debug("batch_p2p %s%s", desc_str, p2p_ops)
-    return dist.batch_isend_irecv(p2p_ops).pop()
+    return dist.batch_isend_irecv(p2p_ops)
 
 
 def _sorted_batch_p2p(
     p2p_ops: list[dist.P2POp], desc: Optional[str] = None
-) -> dict[int, dist.Work]:
+) -> dict[int, list[dist.Work]]:
     """
     Sorts the list of P2P ops by the peer rank, and then calls
     batch_isend_irecv. Return a dictionary of works by peer rank. This function
@@ -420,7 +420,7 @@ def _sorted_batch_p2p(
     #   int is the peer rank;
     #   List is the list of ops towards the peer
     ops_by_peer: dict[int, list[dist.P2POp]] = defaultdict(list)
-    work_by_peer: dict[int, dist.Work] = {}
+    work_by_peer: dict[int, list[dist.Work]] = {}
     if len(p2p_ops) == 0:
         return work_by_peer
 
@@ -433,6 +433,14 @@ def _sorted_batch_p2p(
         work_by_peer[peer] = _batch_p2p(ops, desc=desc)
 
     return work_by_peer
+
+
+def _wait_batch_p2p(work: list[dist.Work]):
+    """
+    Waits for a list of dist.Work (typically from _batch_p2p / _sorted_batch_p2p).
+    """
+    for w in work:
+        w.wait()
 
 
 class PipelineScheduleSingle(_PipelineSchedule):
@@ -544,7 +552,7 @@ class _ScheduleForwardOnly(PipelineScheduleSingle):
             self._initialize_stage(arg_mbs[0], kwarg_mbs[0])
 
         # Delay send waits
-        fwd_sends_to_wait: list[dist.Work] = []
+        fwd_sends_to_wait: list[list[dist.Work]] = []
 
         # Run microbatches
         for i in range(self._n_microbatches):
@@ -552,7 +560,7 @@ class _ScheduleForwardOnly(PipelineScheduleSingle):
                 ops = self._stage.get_fwd_recv_ops(i)
                 works = _sorted_batch_p2p(ops, desc="fwd_recv")
                 for work in works.values():
-                    work.wait()
+                    _wait_batch_p2p(work)
 
                 self._stage.forward_one_chunk(i, arg_mbs[i], kwarg_mbs[i])  # type: ignore[index]
 
@@ -566,7 +574,7 @@ class _ScheduleForwardOnly(PipelineScheduleSingle):
         # This should not have performance impact because by the time the first
         # backward arrives all the forward sends should have been finished.
         for work in fwd_sends_to_wait:
-            work.wait()
+            _wait_batch_p2p(work)
 
 
 class ScheduleGPipe(PipelineScheduleSingle):
@@ -595,7 +603,7 @@ class ScheduleGPipe(PipelineScheduleSingle):
             self._initialize_stage(arg_mbs[0], kwarg_mbs[0])
 
         # Delay send waits
-        fwd_sends_to_wait: list[dist.Work] = []
+        fwd_sends_to_wait: list[list[dist.Work]] = []
 
         # Run microbatches
         for i in range(self._n_microbatches):
@@ -603,7 +611,7 @@ class ScheduleGPipe(PipelineScheduleSingle):
                 ops = self._stage.get_fwd_recv_ops(i)
                 works = _sorted_batch_p2p(ops, desc="fwd_recv")
                 for work in works.values():
-                    work.wait()
+                    _wait_batch_p2p(work)
 
                 output = self._stage.forward_one_chunk(i, arg_mbs[i], kwarg_mbs[i])  # type: ignore[index]
 
@@ -619,7 +627,7 @@ class ScheduleGPipe(PipelineScheduleSingle):
         # This should not have performance impact because by the time the first
         # backward arrives all the forward sends should have been finished.
         for work in fwd_sends_to_wait:
-            work.wait()
+            _wait_batch_p2p(work)
 
         # No loss function, no need to run backward
         if not self._has_backward:
@@ -627,13 +635,13 @@ class ScheduleGPipe(PipelineScheduleSingle):
 
         # Run backward
         # Delay send waits
-        bwd_sends_to_wait: list[dist.Work] = []
+        bwd_sends_to_wait: list[list[dist.Work]] = []
         for i in range(self._n_microbatches):
             with record_function(f"Backward {i}"):
                 ops = self._stage.get_bwd_recv_ops(i)
                 works = _sorted_batch_p2p(ops, desc="bwd_recv")
                 for work in works.values():
-                    work.wait()
+                    _wait_batch_p2p(work)
 
                 loss = self._maybe_get_loss(self._stage, i)
                 self._stage.backward_one_chunk(
@@ -657,7 +665,7 @@ class ScheduleGPipe(PipelineScheduleSingle):
 
         # Wait for all backward sends to finish
         for work in bwd_sends_to_wait:
-            work.wait()
+            _wait_batch_p2p(work)
 
 
 class Schedule1F1B(PipelineScheduleSingle):
@@ -697,13 +705,12 @@ class Schedule1F1B(PipelineScheduleSingle):
         bwd_mb_index = 0
 
         # Warmup phase
-        send_work = None
+        send_work = []
         fwd_sends = []
         for _ in range(warmup_chunks):
             # Receive activations
             fwd_recvs = self._stage.get_fwd_recv_ops(fwd_mb_index)
-            if recv_work := _batch_p2p(fwd_recvs, desc="fwd_recv"):
-                recv_work.wait()
+            _wait_batch_p2p(_batch_p2p(fwd_recvs, desc="fwd_recv"))
 
             # Compute
             output = self._stage.forward_one_chunk(
@@ -714,8 +721,7 @@ class Schedule1F1B(PipelineScheduleSingle):
             # finished, otherwise, we are heavily communication bound, in which
             # case it doesn't create a lot of benefit to compute next chunk
             # eagerly either)
-            if send_work:
-                send_work.wait()
+            _wait_batch_p2p(send_work)
 
             # Send activations
             fwd_sends = self._stage.get_fwd_send_ops(fwd_mb_index)
@@ -737,8 +743,7 @@ class Schedule1F1B(PipelineScheduleSingle):
             bwd_recvs = self._stage.get_bwd_recv_ops(bwd_mb_index)
 
             # Now, we need to fire the fwd_sends and bwd_recvs together
-            if fuse_work := _batch_p2p(fwd_sends + bwd_recvs, desc="fwd_send_bwd_recv"):
-                fuse_work.wait()
+            _wait_batch_p2p(_batch_p2p(fwd_sends + bwd_recvs, desc="fwd_send_bwd_recv"))
 
             # Backward one chunk
             loss = self._maybe_get_loss(self._stage, bwd_mb_index)
@@ -760,8 +765,7 @@ class Schedule1F1B(PipelineScheduleSingle):
             fwd_recvs = self._stage.get_fwd_recv_ops(fwd_mb_index)
 
             # Fuse it with bwd_sends above
-            if fuse_work := _batch_p2p(bwd_sends + fwd_recvs, desc="bwd_send_fwd_recv"):
-                fuse_work.wait()
+            _wait_batch_p2p(_batch_p2p(bwd_sends + fwd_recvs, desc="bwd_send_fwd_recv"))
 
             # Now do the fwd
             output = self._stage.forward_one_chunk(
@@ -782,8 +786,7 @@ class Schedule1F1B(PipelineScheduleSingle):
         while bwd_mb_index < self._n_microbatches:
             # prepare bwd recv ops
             bwd_recvs = self._stage.get_bwd_recv_ops(bwd_mb_index)
-            if recv_work := _batch_p2p(bwd_recvs, desc="bwd_recv"):
-                recv_work.wait()
+            _wait_batch_p2p(_batch_p2p(bwd_recvs, desc="bwd_recv"))
 
             # Backward one chunk
             loss = self._maybe_get_loss(self._stage, bwd_mb_index)
@@ -794,8 +797,7 @@ class Schedule1F1B(PipelineScheduleSingle):
             )
 
             # Clear previous chunk's backward sends (hopefully they have well finished)
-            if send_work:
-                send_work.wait()
+            _wait_batch_p2p(send_work)
 
             # Get the bwd send ops, fire it
             bwd_sends = self._stage.get_bwd_send_ops(bwd_mb_index)
@@ -807,8 +809,7 @@ class Schedule1F1B(PipelineScheduleSingle):
         )
 
         # Wait for the last backward send to finish
-        if send_work:
-            send_work.wait()
+        _wait_batch_p2p(send_work)
 
         # Return losses if there is a container passed in
         self._update_losses(self._stage, losses)
@@ -1417,8 +1418,7 @@ class PipelineScheduleMulti(_PipelineSchedule):
                             )
 
                 # do the communication
-                if ops:
-                    _batch_p2p(ops).wait()
+                _wait_batch_p2p(_batch_p2p(ops))
             except Exception as e:
                 logger.error(
                     "[Rank %s] pipeline schedule %s caught the following exception \
@@ -1550,11 +1550,11 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
         )
 
         # recv ops indexed by (stage_idx, mb_idx) need to be waited on before use
-        bwd_recv_ops: dict[tuple[int, int], Work] = {}
-        fwd_recv_ops: dict[tuple[int, int], Work] = {}
+        bwd_recv_ops: dict[tuple[int, int], list[dist.Work]] = {}
+        fwd_recv_ops: dict[tuple[int, int], list[dist.Work]] = {}
 
         # send ops should be waited on before step() exists, mainly for hygeine
-        send_ops: list[Work] = []
+        send_ops: list[list[dist.Work]] = []
 
         # we track which stages are 'active' when used with FSDP, and wait on unshard ops before computing on stages
         unshard_ops: dict[int, UnshardHandle] = {}
@@ -1655,7 +1655,7 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
                             stage_idx,
                             mb_index,
                         ) in fwd_recv_ops, f"Computing {action=} before receiving input"
-                        fwd_recv_ops.pop((stage_idx, mb_index)).wait()
+                        _wait_batch_p2p(fwd_recv_ops.pop((stage_idx, mb_index)))
 
                     output = stage.forward_one_chunk(
                         mb_index, arg_mbs[mb_index], kwarg_mbs[mb_index]
@@ -1684,7 +1684,7 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
                         ) in bwd_recv_ops, (
                             f"Attempted to run compute {action=} before receiving input"
                         )
-                        bwd_recv_ops.pop((stage_idx, mb_index)).wait()
+                        _wait_batch_p2p(bwd_recv_ops.pop((stage_idx, mb_index)))
                     loss = self._maybe_get_loss(stage, mb_index)
                     backward_counter[stage_idx] += 1
                     last_backward = backward_counter[stage_idx] == self._n_microbatches
@@ -1714,7 +1714,7 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
                         ) in bwd_recv_ops, (
                             f"Attempted to run compute {action=} before receiving input"
                         )
-                        bwd_recv_ops.pop((stage_idx, mb_index)).wait()
+                        _wait_batch_p2p(bwd_recv_ops.pop((stage_idx, mb_index)))
                     loss = self._maybe_get_loss(stage, mb_index)
                     stage.backward_one_chunk(
                         mb_index,
@@ -1757,7 +1757,7 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
 
         # Mostly these operations should have finished long ago, but there isn't an obvious time when to wait for them
         while len(send_ops):
-            send_ops.pop().wait()
+            _wait_batch_p2p(send_ops.pop())
 
         assert len(unshard_ops) == 0, "Unused unshard operations"
 

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -9,7 +9,7 @@ import re
 from abc import ABC, abstractmethod
 from collections import Counter, defaultdict
 from enum import Enum
-from typing import Any, Callable, NamedTuple, Optional, TYPE_CHECKING, Union
+from typing import Any, Callable, NamedTuple, Optional, Union
 
 import torch
 import torch.distributed as dist
@@ -395,7 +395,7 @@ class _PipelineSchedule(ABC):
 
 
 def _batch_p2p(
-        p2p_ops: list[dist.P2POp], desc: Optional[str] = None
+    p2p_ops: list[dist.P2POp], desc: Optional[str] = None
 ) -> list[dist.Work]:
     """
     Simple wrapper over batch_isend_irecv from torch.distributed, which just adds a descriptive logger on top.

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -23,9 +23,6 @@ from .microbatch import merge_chunks, split_args_kwargs_into_chunks, TensorChunk
 from .stage import _PipelineStageBase
 
 
-if TYPE_CHECKING:
-    from torch.distributed import Work
-
 __all__ = [
     "get_schedule_class",
     "PipelineScheduleSingle",
@@ -397,7 +394,9 @@ class _PipelineSchedule(ABC):
         )
 
 
-def _batch_p2p(p2p_ops: list[dist.P2POp], desc: Optional[str] = None) -> list[dist.Work]:
+def _batch_p2p(
+        p2p_ops: list[dist.P2POp], desc: Optional[str] = None
+) -> list[dist.Work]:
     """
     Simple wrapper over batch_isend_irecv from torch.distributed, which just adds a descriptive logger on top.
     """
@@ -705,7 +704,7 @@ class Schedule1F1B(PipelineScheduleSingle):
         bwd_mb_index = 0
 
         # Warmup phase
-        send_work = []
+        send_work: list[dist.Work] = []
         fwd_sends = []
         for _ in range(warmup_chunks):
             # Receive activations


### PR DESCRIPTION
Fixes #132644

`_batch_p2p` incorrectly assumes that `dist.batch_isend_irecv` returns a single-element list of `dist.Work`, likely due to NCCL's coalescing behaviour.

For none NCCL backends like Gloo, multiple `dist.Work` objects are returned, causing the code to discard some operations via `.pop()`. This leads to deadlocks during pipeline parallelism.

## Changes:

* Modified `_batch_p2p` to return `list[dist.Work]` instead of popping a single element.
* Added `_wait_batch_p2p` to call `wait()` on multiple `dist.Work` objects, consuming the result of `_batch_p2p`.
* Updated references from `dist.Work` to `list[dist.Work]`.

## Testing:

* `pippy_bert.py` from #132644 now works with gloo.


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k