### PR TITLE
get right function declaration on windows inductor

### DIFF
--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -5185,6 +5185,9 @@ class CppScheduling(BaseScheduling):
         # excluding the the first line including cpp_prefix.h.
         first_char = src_code.rfind('extern "C"')
         last_char = src_code.find(")", first_char)
+        if _IS_WINDOWS:
+            # get_export_declaration introduced one more ')' in Windows
+            last_char = src_code.find(")", last_char + 1)
         kernel_definition = f"{src_code[first_char : last_char + 1]};\n"
 
         compile_wrapper = IndentedBuffer()


### PR DESCRIPTION
Fixes #152251 

`get_export_declaration` introduced one more ')' in Windows platform, which cause this pattern of function declaration different with Linux. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov