### PR TITLE
[dtensor] add privateuse1 SDPA op support to DTensor

### DIFF
--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -5725,6 +5725,40 @@ def meta__scaled_dot_product_fused_attention_overrideable(
 
 @register_meta(
     [
+        aten._scaled_dot_product_fused_attention_overrideable_backward,
+    ]
+)
+def meta__scaled_dot_product_fused_attention_overrideable_backward(
+    grad_out: Tensor,
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    attn_bias: Optional[Tensor],
+    grad_input_mask: list[bool],
+    out: Tensor,
+    logsumexp: Tensor,
+    cum_seq_q: Tensor,
+    cum_seq_k: Tensor,
+    max_q: int,
+    max_k: int,
+    dropout_p: float,
+    is_causal: bool,
+    philox_seed: Tensor,
+    philox_offset: Tensor,
+    scale: Optional[float] = None,
+):
+    grad_q = torch.empty_like(query.transpose(1, 2)).transpose(1, 2)
+    grad_k = torch.empty_like(key.transpose(1, 2)).transpose(1, 2)
+    grad_v = torch.empty_like(value.transpose(1, 2)).transpose(1, 2)
+    grad_bias = None
+    if attn_bias is not None and grad_input_mask[3]:
+        grad_bias = torch.empty_like(attn_bias)
+
+    return grad_q, grad_k, grad_v, grad_bias
+
+
+@register_meta(
+    [
         aten._scaled_dot_product_flash_attention_backward,
     ]
 )

--- a/torch/distributed/tensor/_ops/_matrix_ops.py
+++ b/torch/distributed/tensor/_ops/_matrix_ops.py
@@ -894,6 +894,97 @@ def scaled_scaled_dot_product_cudnn_attention_backward_strategy(
     )
 
 
+@register_op_strategy(
+    aten._scaled_dot_product_fused_attention_overrideable_backward.default
+)
+def scaled_dot_product_fused_attention_overrideable_backward_strategy(
+    op_schema: OpSchema,
+) -> OpStrategy:
+    mesh = op_schema.get_mesh_from_args(validate=False)
+
+    q_input_strategy = op_schema.args_schema[1]
+    assert isinstance(q_input_strategy, OpStrategy)
+    # assuming q/k/v have the same shape
+    has_attn_bias = op_schema.args_schema[4] is not None
+
+    tensor_input_indices = [
+        i
+        for i, arg_spec in enumerate(op_schema.args_schema)
+        if isinstance(arg_spec, OpStrategy)
+    ]
+    num_tensor_inputs = len(tensor_input_indices)
+
+    single_mesh_dim_strategies = []
+
+    # placement list stores placements of [outputs, inputs]
+    # in the spda backward case, we have 4 tensor outputs and 6 to 11 tensor inputs
+    # first we can always accept full replication for both inputs and outputs
+    all_replicate: PlacementList = [Replicate()] * (4 + num_tensor_inputs)
+
+    single_mesh_dim_strategies.append(all_replicate)
+
+    # second we can accept the sharding pattern of tensor parallelism, which
+    # shard on the num of head dim
+    grad_output_sharding = Shard(1)  # num head dim
+    qkv_sharding = Shard(1)  # num head dim
+    output_sharding = Shard(1)  # num head dim
+    logsumexp_sharding = Shard(1)  # num head dim
+    grad_qkv_sharding = Shard(1)  # num head dim
+    grad_bias_sharding = Shard(1) if has_attn_bias else None
+
+    num_heads_dim_sharding: PlacementList = [
+        grad_qkv_sharding,  # grad_q
+        grad_qkv_sharding,  # grad_k
+        grad_qkv_sharding,  # grad_v
+        grad_bias_sharding,  # grad_bias
+        grad_output_sharding,  # grad_output
+        qkv_sharding,  # q
+        qkv_sharding,  # k
+        qkv_sharding,  # v
+        # the place for optional input attn_bias
+        output_sharding,  # output
+        logsumexp_sharding,  # logsumexp
+    ]
+    # accept replicate on the rest tensor inputs, potentially
+    # cum_seq_q, cum_seq_k, philox_seed, philox_offset
+    # at indices 8, 9, 15, 16, respectively
+    num_heads_dim_sharding.extend(
+        [Replicate()] * (num_tensor_inputs - (7 if has_attn_bias else 6))
+    )
+    # input sharding of attn_bias on heads dim if present
+    if has_attn_bias:
+        num_heads_dim_sharding.insert(8, Shard(1))
+    single_mesh_dim_strategies.append(num_heads_dim_sharding)
+
+    # Context Parallelism: shards on the sequence dim
+    seq_dim_sharding: PlacementList = [
+        Shard(2),  # grad_q
+        Shard(2),  # grad_k
+        Shard(2),  # grad_v
+        Shard(1) if has_attn_bias else None,  # grad_bias
+        Shard(2),  # grad_output
+        Shard(2),  # q
+        Shard(2),  # k
+        Shard(2),  # v
+        # the place for optional input attn_bias
+        Shard(2),  # output
+        Shard(2),  # logsumexp
+    ]
+    # accept replicate on the rest tensor inputs, potentially
+    # cum_seq_q, cum_seq_k, philox_seed, philox_offset
+    # at indices 8, 9, 15, 16, respectively
+    seq_dim_sharding.extend(
+        [Replicate()] * (num_tensor_inputs - (7 if has_attn_bias else 6))
+    )
+    if has_attn_bias:
+        num_heads_dim_sharding.insert(8, Shard(1))
+    single_mesh_dim_strategies.append(seq_dim_sharding)
+
+    return expand_to_full_mesh_op_strategy(
+        mesh, op_schema, single_mesh_dim_strategies, input_index=4
+    )
+
+
 @register_op_strategy(aten._grouped_mm.default)
 def grouped_mm_strategy(op_schema: OpSchema) -> OpStrategy:
     mesh = op_schema.get_mesh_from_args()

--- a/torch/distributed/tensor/experimental/_attention.py
+++ b/torch/distributed/tensor/experimental/_attention.py
@@ -283,6 +283,37 @@ def _scaled_dot_product_ring_cudnn_attention(
     )
 
 
+def _scaled_dot_product_ring_fused_attention_overrideable(
+    mesh: DeviceMesh,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_bias: Optional[torch.Tensor] = None,
+    dropout_p: float = 0.0,
+    is_causal: bool = False,
+    return_debug_mask: bool = False,
+    *,
+    scale: Optional[float] = None,
+) -> tuple[torch.Tensor, ...]:
+    if attn_bias is not None:
+        raise NotImplementedError("attn_bias is not supported yet")
+
+    seq_dim = 2
+    return _templated_ring_attention(
+        mesh,
+        seq_dim,
+        aten._scaled_dot_product_fused_attention_overrideable,
+        query=query,
+        key=key,
+        value=value,
+        attn_bias=attn_bias,
+        dropout_p=dropout_p,
+        is_causal=is_causal,
+        return_debug_mask=return_debug_mask,
+        scale=scale,
+    )
+
+
 class _AttentionOp(Protocol):
     def __call__(
         self,
@@ -588,6 +619,12 @@ def _sdpa_handler(
             *op_info.local_args,  # type: ignore[arg-type]
             **op_info.local_kwargs,  # type: ignore[arg-type]
         )
+    elif op_call == aten._scaled_dot_product_fused_attention_overrideable.default:
+        local_results = _scaled_dot_product_ring_fused_attention_overrideable(
+            op_info.compute_mesh,
+            *op_info.local_args,  # type: ignore[arg-type]
+            **op_info.local_kwargs,  # type: ignore[arg-type]
+        )
     else:
         raise NotImplementedError(
             "CP only supports flash attention and memory efficient attention now."
@@ -629,6 +666,15 @@ def _sdpa_backward_handler(
         )
     elif op_call == aten._scaled_dot_product_cudnn_attention_backward.default:
         local_results = _scaled_dot_product_ring_cudnn_attention_backward(
+            op_info.compute_mesh,
+            *op_info.local_args,  # type: ignore[arg-type]
+            **op_info.local_kwargs,  # type: ignore[arg-type]
+        )
+    elif (
+        op_call
+        == aten._scaled_dot_product_fused_attention_overrideable_backward.default
+    ):
+        local_results = _scaled_dot_product_ring_fused_attention_overrideable_backward(
             op_info.compute_mesh,
             *op_info.local_args,  # type: ignore[arg-type]
             **op_info.local_kwargs,  # type: ignore[arg-type]
@@ -935,6 +981,53 @@ def _scaled_dot_product_ring_cudnn_attention_backward(
     )
 
 
+def _scaled_dot_product_ring_fused_attention_overrideable_backward(
+    mesh: DeviceMesh,
+    grad_out: torch.Tensor,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    bias: torch.Tensor,
+    grad_input_mask: tuple[bool, ...],
+    out: torch.Tensor,
+    logsumexp: torch.Tensor,
+    cum_seq_q: torch.Tensor,
+    cum_seq_k: torch.Tensor,
+    max_q: int,
+    max_k: int,
+    dropout_p: float,
+    is_causal: bool,
+    philox_seed: torch.Tensor,
+    philox_offset: torch.Tensor,
+    *,
+    scale: Optional[float] = None,
+) -> tuple[torch.Tensor, ...]:
+    seq_dim = 2
+    return _templated_ring_attention_backward(
+        mesh,
+        seq_dim,
+        aten._scaled_dot_product_fused_attention_overrideable_backward.default,
+        grad_out=grad_out,
+        grad_out_name="grad_out",
+        query=query,
+        key=key,
+        value=value,
+        attn_bias=bias,
+        grad_input_mask=grad_input_mask,
+        out=out,
+        logsumexp=logsumexp,
+        cum_seq_q=cum_seq_q,
+        cum_seq_k=cum_seq_k,
+        max_q=max_q,
+        max_k=max_k,
+        dropout_p=dropout_p,
+        is_causal=is_causal,
+        philox_seed=philox_seed,
+        philox_offset=philox_offset,
+        scale=scale,
+    )
+
+
 customized_ops = {
     aten._scaled_dot_product_flash_attention.default: _sdpa_handler,
     aten._scaled_dot_product_flash_attention_backward.default: _sdpa_backward_handler,
@@ -942,6 +1035,8 @@ customized_ops = {
     aten._scaled_dot_product_efficient_attention_backward.default: _sdpa_backward_handler,
     aten._scaled_dot_product_cudnn_attention.default: _sdpa_handler,
     aten._scaled_dot_product_cudnn_attention_backward.default: _sdpa_backward_handler,
+    aten._scaled_dot_product_fused_attention_overrideable.default: _sdpa_handler,
+    aten._scaled_dot_product_fused_attention_overrideable_backward.default: _sdpa_backward_handler,
 }
 
 


### PR DESCRIPTION
**Summary**
This PR adds _scaled_dot_product_fused_attention_overrideable and _scaled_dot_product_fused_attention_overrideable_backward to DTensor ops



@drisspg @fegin @d4l3k @wanchaol @albanD 

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k