### PR TITLE
[CI] Upgrade sccache to 0.10.0

### DIFF
--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -9,7 +9,7 @@ install_ubuntu() {
   # Instead use lib and headers from OpenSSL1.1 installed in `install_openssl.sh``
   apt-get install -y cargo
   echo "Checking out sccache repo"
-  git clone https://github.com/mozilla/sccache -b v0.9.1
+  git clone https://github.com/mozilla/sccache -b v0.10.0
   cd sccache
   echo "Building sccache"
   cargo build --release


### PR DESCRIPTION
Newest release handles cuda better, and I think this fixes the cases I saw where some cuda related builds weren't being cached correctly