### PR TITLE
Follow up to #152209, remove compat patch after docker image rename

### DIFF
--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -110,18 +110,6 @@ jobs:
           always-rebuild: true
           push: true
 
-      - name: Push docker image to old name
-        shell: bash
-        env:
-          ECR_DOCKER_IMAGE: ${{ steps.build-docker-image.outputs.docker-image }}
-        run: |
-          # This can be deleted after people have rebased their PRs/the new name has been in main for a while
-          set -euox pipefail
-          docker_image_name="308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/${{ matrix.docker-image-name }}"
-          foldersha=${ECR_DOCKER_IMAGE##*-}
-          docker tag "${ECR_DOCKER_IMAGE}" "${docker_image_name}:${foldersha}"
-          docker push "${docker_image_name}:${foldersha}"
-
       - name: Pull docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@main
         with:


### PR DESCRIPTION
Remove compat patch that lets PRs that haven't rebased base #152209 still have docker images.

Merge ~2 weeks after the above PR was merged.  ~80% of PRs have a merge base that is <2 weeks old
