### PR TITLE
[WIP] Add XPU support for FlightRecorder

### DIFF
--- a/aten/src/ATen/core/AcceleratorEvent.h
+++ b/aten/src/ATen/core/AcceleratorEvent.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <optional>
+#include <ATen/Device.h>
+
+namespace at {
+
+struct AcceleratorEvent {
+    virtual ~AcceleratorEvent() = default;
+
+    virtual bool query() const = 0;
+    virtual double elapsed_time(const AcceleratorEvent& other) const = 0;
+};
+
+} // namespace at

--- a/tools/flight_recorder/components/types.py
+++ b/tools/flight_recorder/components/types.py
@@ -388,8 +388,8 @@ class Op:
         self, event: dict[Any, Any], memberships: dict[str, set[Any]], pg_name: str
     ):
         self.profiling_name = event["profiling_name"]
-        nccl, name = self.profiling_name.split(":")
-        assert nccl == "nccl", f"name formatting error? {nccl} != 'nccl'"
+        nccl_name, name = self.profiling_name.split(":")
+        assert nccl_name in ["nccl", "xccl"], f"name formatting error? {nccl_name} is not 'nccl' or 'xccl'"
         parts = name.split(" ")
         type = parts[0]
         meta = parts[1] if len(parts) == 2 else None

--- a/tools/flight_recorder/components/utils.py
+++ b/tools/flight_recorder/components/utils.py
@@ -569,7 +569,7 @@ def find_coalesced_group(
             break
 
     if len(found) > 1:
-        assert found[-1][1]["profiling_name"] == "nccl:coalesced"
+        assert found[-1][1]["profiling_name"].endswith("ccl:coalesced")
         return found
     return []
 
@@ -603,7 +603,7 @@ def find_coalesced_group_with_non_p2p(
 
     if len(found) > 1:
         name = found[-1][1]["profiling_name"]
-        if name.startswith("nccl:") and not name.endswith("_coalesced"):
+        if name[1:].startswith("ccl:") and not name.endswith("_coalesced"):
             logger.error("Rank %s does not have a coalesced end.", rank)
         return found
     return []


### PR DESCRIPTION
This is the first part of bringing XPU/XCCL support for FlightRecorder.

`AcceleratorEvent` is a generic interface for CUDAEvent and XPUEvent, which is used in FlightRecorder to work with both XCCL and NCCL.

Since the actual instantiation of the FlightRecorder and DebugInfoWriter objects happens in ProcessGroupNCCL, a future PR in https://github.com/intel/torch-xpu-ops will provide actual FlightRecorder support in ProcessGroupXCCL.

For now, I avoid any cosmetic changes to classes/functions/variables with "nccl" names, though this could be changed in the future to indicate that code is device agnostic.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k