### PR TITLE
[CI] Use sccache installed in docker image in xla build

### DIFF
--- a/.ci/pytorch/install_cache_xla.sh
+++ b/.ci/pytorch/install_cache_xla.sh
@@ -1,32 +1,51 @@
 #!/bin/bash
 
 # Script for installing sccache on the xla build job, which uses xla's docker
-# image and doesn't have sccache installed on it.  This is mostly copied from
-# .ci/docker/install_cache.sh.  Changes are: removing checks that will always
-# return the same thing, ex checks for for rocm, CUDA, and changing the path
-# where sccache is installed, and not changing /etc/environment.
+# image, which has sccache installed but doesn't write the stubs.  This is
+# mostly copied from .ci/docker/install_cache.sh.  Changes are: removing checks
+# that will always return the same thing, ex checks for for rocm, CUDA, not
+# changing /etc/environment, and not installing/downloading sccache as it is
+# already in the docker image.
 
 set -ex -o pipefail
 
-install_binary() {
-  echo "Downloading sccache binary from S3 repo"
-  curl --retry 3 https://s3.amazonaws.com/ossci-linux/sccache -o /tmp/cache/bin/sccache
-}
-
 mkdir -p /tmp/cache/bin
-mkdir -p /tmp/cache/lib
 export PATH="/tmp/cache/bin:$PATH"
-
-install_binary
-chmod a+x /tmp/cache/bin/sccache
 
 function write_sccache_stub() {
   # Unset LD_PRELOAD for ps because of asan + ps issues
   # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90589
-  # shellcheck disable=SC2086
-  # shellcheck disable=SC2059
-  printf "#!/bin/sh\nif [ \$(env -u LD_PRELOAD ps -p \$PPID -o comm=) != sccache ]; then\n  exec sccache $(which $1) \"\$@\"\nelse\n  exec $(which $1) \"\$@\"\nfi" > "/tmp/cache/bin/$1"
-  chmod a+x "/tmp/cache/bin/$1"
+  if [ $1 == "gcc" ]; then
+    # Do not call sccache recursively when dumping preprocessor argument
+    # For some reason it's very important for the first cached nvcc invocation
+    cat >"/opt/cache/bin/$1" <<EOF
+#!/bin/sh
+
+# sccache does not support -E flag, so we need to call the original compiler directly in order to avoid calling this wrapper recursively
+for arg in "\$@"; do
+  if [ "\$arg" = "-E" ]; then
+    exec $(which $1) "\$@"
+  fi
+done
+
+if [ \$(env -u LD_PRELOAD ps -p \$PPID -o comm=) != sccache ]; then
+  exec sccache $(which $1) "\$@"
+else
+  exec $(which $1) "\$@"
+fi
+EOF
+  else
+    cat >"/opt/cache/bin/$1" <<EOF
+#!/bin/sh
+
+if [ \$(env -u LD_PRELOAD ps -p \$PPID -o comm=) != sccache ]; then
+  exec sccache $(which $1) "\$@"
+else
+  exec $(which $1) "\$@"
+fi
+EOF
+  fi
+  chmod a+x "/opt/cache/bin/$1"
 }
 
 write_sccache_stub cc

--- a/.ci/pytorch/install_cache_xla.sh
+++ b/.ci/pytorch/install_cache_xla.sh
@@ -15,7 +15,7 @@ export PATH="/tmp/cache/bin:$PATH"
 function write_sccache_stub() {
   # Unset LD_PRELOAD for ps because of asan + ps issues
   # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90589
-  if [ $1 == "gcc" ]; then
+  if [ "$1" == "gcc" ]; then
     # Do not call sccache recursively when dumping preprocessor argument
     # For some reason it's very important for the first cached nvcc invocation
     cat >"/tmp/cache/bin/$1" <<EOF
@@ -24,14 +24,14 @@ function write_sccache_stub() {
 # sccache does not support -E flag, so we need to call the original compiler directly in order to avoid calling this wrapper recursively
 for arg in "\$@"; do
   if [ "\$arg" = "-E" ]; then
-    exec $(which $1) "\$@"
+    exec $(which "$1") "\$@"
   fi
 done
 
 if [ \$(env -u LD_PRELOAD ps -p \$PPID -o comm=) != sccache ]; then
-  exec sccache $(which $1) "\$@"
+  exec sccache $(which "$1") "\$@"
 else
-  exec $(which $1) "\$@"
+  exec $(which "$1") "\$@"
 fi
 EOF
   else
@@ -39,9 +39,9 @@ EOF
 #!/bin/sh
 
 if [ \$(env -u LD_PRELOAD ps -p \$PPID -o comm=) != sccache ]; then
-  exec sccache $(which $1) "\$@"
+  exec sccache $(which "$1") "\$@"
 else
-  exec $(which $1) "\$@"
+  exec $(which "$1") "\$@"
 fi
 EOF
   fi


### PR DESCRIPTION
The edited comment should have the info.  The code change looks large, but its copied from the install_cache script that our docker images use https://github.com/pytorch/pytorch/blob/6a8006472e431f872ca40c7aad250b61105de583/.ci/docker/common/install_cache.sh#L42

Sccache stopped working on xla at some point near dec 17 2023.  I am not sure what commit caused it.  I think it was having trouble writing to the cache.

Either way, there is an sccache already installed on the docker image, so we should use that instead of a binary from s3 which we're probably no longer sure where it came from/what commit it was built from

The one in the docker image is installed here https://github.com/pytorch/xla/blob/69d438ee65cc250c974ca80edd80462ffbb2e163/.github/upstream/Dockerfile#L61 and is also very old, so I have https://github.com/pytorch/xla/pull/9102 to update it

sccache still not writing properly, i will investigate, but xla build currently broken after the above xla pr, and this should fix it