### PR TITLE
Add a project section to pyproject.toml, making uv sync work

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,34 @@
+[project]
+name = "torch"
+version = "2.8.0a0"
+description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
+readme = "README.md"
+requires-python = ">=3.9"
+license = {text = "BSD"}
+dependencies = [
+  "astunparse",
+  "cmake",
+  "expecttest>=0.3.0",
+  "filelock",
+  "fsspec",
+  "hypothesis",
+  "jinja2",
+  "lintrunner; platform_machine != \"s390x\"",
+  "networkx",
+  "ninja",
+  "numpy",
+  "optree>=0.13.0",
+  "packaging",
+  "psutil",
+  "pyyaml",
+  "requests",
+  # issue on Windows after >=75.8.2 – https://github.com/pytorch/pytorch/issues/148877
+  "setuptools>=62.3.0,<75.9",
+  "sympy>=1.13.3",
+  "types-dataclasses",
+  "typing-extensions>=4.10.0",
+]
+
 [build-system]
 requires = [
     # After 75.8.2 dropped dep disttools API. Please fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,33 +1,10 @@
 [project]
 name = "torch"
-version = "2.8.0a0"
 description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
 readme = "README.md"
 requires-python = ">=3.9"
 license = {text = "BSD"}
-dependencies = [
-  "astunparse",
-  "cmake",
-  "expecttest>=0.3.0",
-  "filelock",
-  "fsspec",
-  "hypothesis",
-  "jinja2",
-  "lintrunner; platform_machine != \"s390x\"",
-  "networkx",
-  "ninja",
-  "numpy",
-  "optree>=0.13.0",
-  "packaging",
-  "psutil",
-  "pyyaml",
-  "requests",
-  # issue on Windows after >=75.8.2 – https://github.com/pytorch/pytorch/issues/148877
-  "setuptools>=62.3.0,<75.9",
-  "sympy>=1.13.3",
-  "types-dataclasses",
-  "typing-extensions>=4.10.0",
-]
+dynamic = ["version", "dependencies"]
 
 [build-system]
 requires = [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #153020

With this change, I can now run `uv sync -v` and get all dependencies I need and then trigger build of PyTorch. (The `-v` is good because the build takes a long time and uv hides progress by default.)

Signed-off-by: Edward Z. Yang <ezyang@mit.edu>