### PR TITLE
[Typing] Apply `torch.types.Device` in `torch/cuda/memory.py`

### DIFF
--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -8,7 +8,7 @@ import pickle
 import sys
 import warnings
 from inspect import signature
-from typing import Any, Literal, Optional
+from typing import Any, Literal, Optional, TYPE_CHECKING
 from typing_extensions import deprecated
 
 import torch
@@ -23,6 +23,10 @@ from . import (
     is_initialized,
 )
 from ._memory_viz import memory as _memory, segments as _segments
+
+
+if TYPE_CHECKING:
+    from torch.types import Device
 
 
 __all__ = [
@@ -102,7 +106,7 @@ def _free_mutex():
         torch._C._cuda_unlock_mutex()
 
 
-def caching_allocator_alloc(size, device: torch.types.Device = None, stream=None):
+def caching_allocator_alloc(size, device: "Device" = None, stream=None):
     r"""Perform a memory allocation using the CUDA memory allocator.
 
     Memory is allocated for a given device and a stream, this
@@ -161,9 +165,7 @@ def caching_allocator_enable(value: bool = True) -> None:
         torch._C._cuda_cudaCachingAllocator_enable(value)
 
 
-def set_per_process_memory_fraction(
-    fraction, device: torch.types.Device = None
-) -> None:
+def set_per_process_memory_fraction(fraction, device: "Device" = None) -> None:
     r"""Set memory fraction for a process.
 
     The fraction is used to limit an caching allocator to allocated memory on a CUDA device.
@@ -190,7 +192,7 @@ def set_per_process_memory_fraction(
     torch._C._cuda_setMemoryFraction(fraction, device)
 
 
-def get_per_process_memory_fraction(device: torch.types.Device = None) -> float:
+def get_per_process_memory_fraction(device: "Device" = None) -> float:
     r"""Get memory fraction for a process.
 
     Args:
@@ -221,7 +223,7 @@ def empty_cache() -> None:
         torch._C._cuda_emptyCache()
 
 
-def memory_stats(device: torch.types.Device = None) -> dict[str, Any]:
+def memory_stats(device: "Device" = None) -> dict[str, Any]:
     r"""Return a dictionary of CUDA memory allocator statistics for a given device.
 
     The return value of this function is a dictionary of statistics, each of
@@ -326,7 +328,7 @@ def memory_stats(device: torch.types.Device = None) -> dict[str, Any]:
     return collections.OrderedDict(result)
 
 
-def memory_stats_as_nested_dict(device: torch.types.Device = None) -> dict[str, Any]:
+def memory_stats_as_nested_dict(device: "Device" = None) -> dict[str, Any]:
     r"""Return the result of :func:`~torch.cuda.memory_stats` as a nested dictionary."""
     if not is_initialized():
         return {}
@@ -334,7 +336,7 @@ def memory_stats_as_nested_dict(device: torch.types.Device = None) -> dict[str, 
     return torch._C._cuda_memoryStats(device)
 
 
-def reset_accumulated_memory_stats(device: torch.types.Device = None) -> None:
+def reset_accumulated_memory_stats(device: "Device" = None) -> None:
     r"""Reset the "accumulated" (historical) stats tracked by the CUDA memory allocator.
 
     See :func:`~torch.cuda.memory_stats` for details. Accumulated stats correspond to
@@ -354,7 +356,7 @@ def reset_accumulated_memory_stats(device: torch.types.Device = None) -> None:
     return torch._C._cuda_resetAccumulatedMemoryStats(device)
 
 
-def reset_peak_memory_stats(device: torch.types.Device = None) -> None:
+def reset_peak_memory_stats(device: "Device" = None) -> None:
     r"""Reset the "peak" stats tracked by the CUDA memory allocator.
 
     See :func:`~torch.cuda.memory_stats` for details. Peak stats correspond to the
@@ -467,7 +469,7 @@ def reset_peak_host_memory_stats() -> None:
     return torch._C._cuda_resetPeakHostMemoryStats()
 
 
-def reset_max_memory_allocated(device: torch.types.Device = None) -> None:
+def reset_max_memory_allocated(device: "Device" = None) -> None:
     r"""Reset the starting point in tracking maximum GPU memory occupied by tensors for a given device.
 
     See :func:`~torch.cuda.max_memory_allocated` for details.
@@ -493,7 +495,7 @@ def reset_max_memory_allocated(device: torch.types.Device = None) -> None:
     return reset_peak_memory_stats(device=device)
 
 
-def reset_max_memory_cached(device: torch.types.Device = None) -> None:
+def reset_max_memory_cached(device: "Device" = None) -> None:
     r"""Reset the starting point in tracking maximum GPU memory managed by the caching allocator for a given device.
 
     See :func:`~torch.cuda.max_memory_cached` for details.
@@ -519,7 +521,7 @@ def reset_max_memory_cached(device: torch.types.Device = None) -> None:
     return reset_peak_memory_stats(device=device)
 
 
-def memory_allocated(device: torch.types.Device = None) -> int:
+def memory_allocated(device: "Device" = None) -> int:
     r"""Return the current GPU memory occupied by tensors in bytes for a given device.
 
     Args:
@@ -536,7 +538,7 @@ def memory_allocated(device: torch.types.Device = None) -> int:
     return memory_stats(device=device).get("allocated_bytes.all.current", 0)
 
 
-def max_memory_allocated(device: torch.types.Device = None) -> int:
+def max_memory_allocated(device: "Device" = None) -> int:
     r"""Return the maximum GPU memory occupied by tensors in bytes for a given device.
 
     By default, this returns the peak allocated memory since the beginning of
@@ -557,7 +559,7 @@ def max_memory_allocated(device: torch.types.Device = None) -> int:
     return memory_stats(device=device).get("allocated_bytes.all.peak", 0)
 
 
-def memory_reserved(device: torch.types.Device = None) -> int:
+def memory_reserved(device: "Device" = None) -> int:
     r"""Return the current GPU memory managed by the caching allocator in bytes for a given device.
 
     Args:
@@ -572,7 +574,7 @@ def memory_reserved(device: torch.types.Device = None) -> int:
     return memory_stats(device=device).get("reserved_bytes.all.current", 0)
 
 
-def max_memory_reserved(device: torch.types.Device = None) -> int:
+def max_memory_reserved(device: "Device" = None) -> int:
     r"""Return the maximum GPU memory managed by the caching allocator in bytes for a given device.
 
     By default, this returns the peak cached memory since the beginning of this
@@ -597,7 +599,7 @@ def max_memory_reserved(device: torch.types.Device = None) -> int:
     "`torch.cuda.memory_cached` has been renamed to `torch.cuda.memory_reserved`",
     category=FutureWarning,
 )
-def memory_cached(device: torch.types.Device = None) -> int:
+def memory_cached(device: "Device" = None) -> int:
     r"""Deprecated; see :func:`~torch.cuda.memory_reserved`."""
     return memory_reserved(device=device)
 
@@ -606,7 +608,7 @@ def memory_cached(device: torch.types.Device = None) -> int:
     "`torch.cuda.max_memory_cached` has been renamed to `torch.cuda.max_memory_reserved`",
     category=FutureWarning,
 )
-def max_memory_cached(device: torch.types.Device = None) -> int:
+def max_memory_cached(device: "Device" = None) -> int:
     r"""Deprecated; see :func:`~torch.cuda.max_memory_reserved`."""
     return max_memory_reserved(device=device)
 
@@ -624,7 +626,7 @@ def memory_snapshot():
     return torch._C._cuda_memorySnapshot()["segments"]
 
 
-def memory_summary(device: torch.types.Device = None, abbreviated: bool = False) -> str:
+def memory_summary(device: "Device" = None, abbreviated: bool = False) -> str:
     r"""Return a human-readable printout of the current memory allocator statistics for a given device.
 
     This can be useful to display periodically during training, or when
@@ -751,7 +753,7 @@ def memory_summary(device: torch.types.Device = None, abbreviated: bool = False)
     return "|" + "|\n|".join(lines).format(**fmt_dict) + "|\n"
 
 
-def list_gpu_processes(device: torch.types.Device = None) -> str:
+def list_gpu_processes(device: "Device" = None) -> str:
     r"""Return a human-readable printout of the running processes and their GPU memory use for a given device.
 
     This can be useful to display periodically during training, or when
@@ -816,7 +818,7 @@ def list_gpu_processes(device: torch.types.Device = None) -> str:
     return "\n".join(lines)
 
 
-def mem_get_info(device: torch.types.Device = None) -> tuple[int, int]:
+def mem_get_info(device: "Device" = None) -> tuple[int, int]:
     r"""Return the global free and total GPU memory for a given device using cudaMemGetInfo.
 
     Args:
@@ -840,7 +842,7 @@ def _record_memory_history_legacy(
     record_context=True,
     trace_alloc_max_entries=1,
     trace_alloc_record_context=False,
-    device: torch.types.Device = None,
+    device: "Device" = None,
     record_context_cpp=False,
     clear_history=False,
 ):
@@ -904,7 +906,7 @@ def _record_memory_history_impl(
     context: Optional[str] = "all",
     stacks: str = "all",
     max_entries: int = sys.maxsize,
-    device: torch.types.Device = None,
+    device: "Device" = None,
     clear_history: bool = False,
 ):
     _C._cuda_record_memory_history(enabled, context, stacks, max_entries, clear_history)
@@ -913,7 +915,7 @@ def _record_memory_history_impl(
 _record_memory_history.__signature__ = signature(_record_memory_history_impl)  # type: ignore[attr-defined]
 
 
-def _snapshot(device: torch.types.Device = None):
+def _snapshot(device: "Device" = None):
     """Save a snapshot of CUDA memory state at the time it was called.
 
     The state is represented as a dictionary with the following structure.
@@ -1175,7 +1177,7 @@ class MemPool(_MemPool):
 
 
 @contextlib.contextmanager
-def use_mem_pool(pool: MemPool, device: torch.types.Device = None):
+def use_mem_pool(pool: MemPool, device: "Device" = None):
     r"""A context manager that routes allocations to a given pool.
 
     Args:

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -8,13 +8,12 @@ import pickle
 import sys
 import warnings
 from inspect import signature
-from typing import Any, Literal, Optional, Union
+from typing import Any, Literal, Optional
 from typing_extensions import deprecated
 
 import torch
 from torch import _C
 from torch._utils import _dummy_type
-from torch.types import Device
 
 from . import (
     _get_amdsmi_device_index,
@@ -103,7 +102,7 @@ def _free_mutex():
         torch._C._cuda_unlock_mutex()
 
 
-def caching_allocator_alloc(size, device: Union[Device, int] = None, stream=None):
+def caching_allocator_alloc(size, device: torch.types.Device = None, stream=None):
     r"""Perform a memory allocation using the CUDA memory allocator.
 
     Memory is allocated for a given device and a stream, this
@@ -163,7 +162,7 @@ def caching_allocator_enable(value: bool = True) -> None:
 
 
 def set_per_process_memory_fraction(
-    fraction, device: Union[Device, int] = None
+    fraction, device: torch.types.Device = None
 ) -> None:
     r"""Set memory fraction for a process.
 
@@ -191,7 +190,7 @@ def set_per_process_memory_fraction(
     torch._C._cuda_setMemoryFraction(fraction, device)
 
 
-def get_per_process_memory_fraction(device: Union[Device, int] = None) -> float:
+def get_per_process_memory_fraction(device: torch.types.Device = None) -> float:
     r"""Get memory fraction for a process.
 
     Args:
@@ -222,7 +221,7 @@ def empty_cache() -> None:
         torch._C._cuda_emptyCache()
 
 
-def memory_stats(device: Union[Device, int] = None) -> dict[str, Any]:
+def memory_stats(device: torch.types.Device = None) -> dict[str, Any]:
     r"""Return a dictionary of CUDA memory allocator statistics for a given device.
 
     The return value of this function is a dictionary of statistics, each of
@@ -327,7 +326,7 @@ def memory_stats(device: Union[Device, int] = None) -> dict[str, Any]:
     return collections.OrderedDict(result)
 
 
-def memory_stats_as_nested_dict(device: Union[Device, int] = None) -> dict[str, Any]:
+def memory_stats_as_nested_dict(device: torch.types.Device = None) -> dict[str, Any]:
     r"""Return the result of :func:`~torch.cuda.memory_stats` as a nested dictionary."""
     if not is_initialized():
         return {}
@@ -335,7 +334,7 @@ def memory_stats_as_nested_dict(device: Union[Device, int] = None) -> dict[str, 
     return torch._C._cuda_memoryStats(device)
 
 
-def reset_accumulated_memory_stats(device: Union[Device, int] = None) -> None:
+def reset_accumulated_memory_stats(device: torch.types.Device = None) -> None:
     r"""Reset the "accumulated" (historical) stats tracked by the CUDA memory allocator.
 
     See :func:`~torch.cuda.memory_stats` for details. Accumulated stats correspond to
@@ -355,7 +354,7 @@ def reset_accumulated_memory_stats(device: Union[Device, int] = None) -> None:
     return torch._C._cuda_resetAccumulatedMemoryStats(device)
 
 
-def reset_peak_memory_stats(device: Union[Device, int] = None) -> None:
+def reset_peak_memory_stats(device: torch.types.Device = None) -> None:
     r"""Reset the "peak" stats tracked by the CUDA memory allocator.
 
     See :func:`~torch.cuda.memory_stats` for details. Peak stats correspond to the
@@ -468,7 +467,7 @@ def reset_peak_host_memory_stats() -> None:
     return torch._C._cuda_resetPeakHostMemoryStats()
 
 
-def reset_max_memory_allocated(device: Union[Device, int] = None) -> None:
+def reset_max_memory_allocated(device: torch.types.Device = None) -> None:
     r"""Reset the starting point in tracking maximum GPU memory occupied by tensors for a given device.
 
     See :func:`~torch.cuda.max_memory_allocated` for details.
@@ -494,7 +493,7 @@ def reset_max_memory_allocated(device: Union[Device, int] = None) -> None:
     return reset_peak_memory_stats(device=device)
 
 
-def reset_max_memory_cached(device: Union[Device, int] = None) -> None:
+def reset_max_memory_cached(device: torch.types.Device = None) -> None:
     r"""Reset the starting point in tracking maximum GPU memory managed by the caching allocator for a given device.
 
     See :func:`~torch.cuda.max_memory_cached` for details.
@@ -520,7 +519,7 @@ def reset_max_memory_cached(device: Union[Device, int] = None) -> None:
     return reset_peak_memory_stats(device=device)
 
 
-def memory_allocated(device: Union[Device, int] = None) -> int:
+def memory_allocated(device: torch.types.Device = None) -> int:
     r"""Return the current GPU memory occupied by tensors in bytes for a given device.
 
     Args:
@@ -537,7 +536,7 @@ def memory_allocated(device: Union[Device, int] = None) -> int:
     return memory_stats(device=device).get("allocated_bytes.all.current", 0)
 
 
-def max_memory_allocated(device: Union[Device, int] = None) -> int:
+def max_memory_allocated(device: torch.types.Device = None) -> int:
     r"""Return the maximum GPU memory occupied by tensors in bytes for a given device.
 
     By default, this returns the peak allocated memory since the beginning of
@@ -558,7 +557,7 @@ def max_memory_allocated(device: Union[Device, int] = None) -> int:
     return memory_stats(device=device).get("allocated_bytes.all.peak", 0)
 
 
-def memory_reserved(device: Union[Device, int] = None) -> int:
+def memory_reserved(device: torch.types.Device = None) -> int:
     r"""Return the current GPU memory managed by the caching allocator in bytes for a given device.
 
     Args:
@@ -573,7 +572,7 @@ def memory_reserved(device: Union[Device, int] = None) -> int:
     return memory_stats(device=device).get("reserved_bytes.all.current", 0)
 
 
-def max_memory_reserved(device: Union[Device, int] = None) -> int:
+def max_memory_reserved(device: torch.types.Device = None) -> int:
     r"""Return the maximum GPU memory managed by the caching allocator in bytes for a given device.
 
     By default, this returns the peak cached memory since the beginning of this
@@ -598,7 +597,7 @@ def max_memory_reserved(device: Union[Device, int] = None) -> int:
     "`torch.cuda.memory_cached` has been renamed to `torch.cuda.memory_reserved`",
     category=FutureWarning,
 )
-def memory_cached(device: Union[Device, int] = None) -> int:
+def memory_cached(device: torch.types.Device = None) -> int:
     r"""Deprecated; see :func:`~torch.cuda.memory_reserved`."""
     return memory_reserved(device=device)
 
@@ -607,7 +606,7 @@ def memory_cached(device: Union[Device, int] = None) -> int:
     "`torch.cuda.max_memory_cached` has been renamed to `torch.cuda.max_memory_reserved`",
     category=FutureWarning,
 )
-def max_memory_cached(device: Union[Device, int] = None) -> int:
+def max_memory_cached(device: torch.types.Device = None) -> int:
     r"""Deprecated; see :func:`~torch.cuda.max_memory_reserved`."""
     return max_memory_reserved(device=device)
 
@@ -625,7 +624,7 @@ def memory_snapshot():
     return torch._C._cuda_memorySnapshot()["segments"]
 
 
-def memory_summary(device: Union[Device, int] = None, abbreviated: bool = False) -> str:
+def memory_summary(device: torch.types.Device = None, abbreviated: bool = False) -> str:
     r"""Return a human-readable printout of the current memory allocator statistics for a given device.
 
     This can be useful to display periodically during training, or when
@@ -752,7 +751,7 @@ def memory_summary(device: Union[Device, int] = None, abbreviated: bool = False)
     return "|" + "|\n|".join(lines).format(**fmt_dict) + "|\n"
 
 
-def list_gpu_processes(device: Union[Device, int] = None) -> str:
+def list_gpu_processes(device: torch.types.Device = None) -> str:
     r"""Return a human-readable printout of the running processes and their GPU memory use for a given device.
 
     This can be useful to display periodically during training, or when
@@ -817,7 +816,7 @@ def list_gpu_processes(device: Union[Device, int] = None) -> str:
     return "\n".join(lines)
 
 
-def mem_get_info(device: Union[Device, int] = None) -> tuple[int, int]:
+def mem_get_info(device: torch.types.Device = None) -> tuple[int, int]:
     r"""Return the global free and total GPU memory for a given device using cudaMemGetInfo.
 
     Args:
@@ -841,7 +840,7 @@ def _record_memory_history_legacy(
     record_context=True,
     trace_alloc_max_entries=1,
     trace_alloc_record_context=False,
-    device: Union[Device, int] = None,
+    device: torch.types.Device = None,
     record_context_cpp=False,
     clear_history=False,
 ):
@@ -905,7 +904,7 @@ def _record_memory_history_impl(
     context: Optional[str] = "all",
     stacks: str = "all",
     max_entries: int = sys.maxsize,
-    device: Union[Device, int] = None,
+    device: torch.types.Device = None,
     clear_history: bool = False,
 ):
     _C._cuda_record_memory_history(enabled, context, stacks, max_entries, clear_history)
@@ -914,7 +913,7 @@ def _record_memory_history_impl(
 _record_memory_history.__signature__ = signature(_record_memory_history_impl)  # type: ignore[attr-defined]
 
 
-def _snapshot(device: Union[Device, int] = None):
+def _snapshot(device: torch.types.Device = None):
     """Save a snapshot of CUDA memory state at the time it was called.
 
     The state is represented as a dictionary with the following structure.
@@ -1176,7 +1175,7 @@ class MemPool(_MemPool):
 
 
 @contextlib.contextmanager
-def use_mem_pool(pool: MemPool, device: Union[Device, int] = None):
+def use_mem_pool(pool: MemPool, device: torch.types.Device = None):
     r"""A context manager that routes allocations to a given pool.
 
     Args:

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -8,7 +8,7 @@ import pickle
 import sys
 import warnings
 from inspect import signature
-from typing import Any, Literal, Optional, TYPE_CHECKING
+from typing import Any, Literal, Optional
 from typing_extensions import deprecated
 
 import torch
@@ -23,10 +23,6 @@ from . import (
     is_initialized,
 )
 from ._memory_viz import memory as _memory, segments as _segments
-
-
-if TYPE_CHECKING:
-    from torch.types import Device as _device_t
 
 
 __all__ = [
@@ -106,7 +102,7 @@ def _free_mutex():
         torch._C._cuda_unlock_mutex()
 
 
-def caching_allocator_alloc(size, device: "_device_t" = None, stream=None):
+def caching_allocator_alloc(size, device: torch.types.Device = None, stream=None):
     r"""Perform a memory allocation using the CUDA memory allocator.
 
     Memory is allocated for a given device and a stream, this
@@ -165,7 +161,9 @@ def caching_allocator_enable(value: bool = True) -> None:
         torch._C._cuda_cudaCachingAllocator_enable(value)
 
 
-def set_per_process_memory_fraction(fraction, device: "_device_t" = None) -> None:
+def set_per_process_memory_fraction(
+    fraction, device: torch.types.Device = None
+) -> None:
     r"""Set memory fraction for a process.
 
     The fraction is used to limit an caching allocator to allocated memory on a CUDA device.
@@ -192,7 +190,7 @@ def set_per_process_memory_fraction(fraction, device: "_device_t" = None) -> Non
     torch._C._cuda_setMemoryFraction(fraction, device)
 
 
-def get_per_process_memory_fraction(device: "_device_t" = None) -> float:
+def get_per_process_memory_fraction(device: torch.types.Device = None) -> float:
     r"""Get memory fraction for a process.
 
     Args:
@@ -223,7 +221,7 @@ def empty_cache() -> None:
         torch._C._cuda_emptyCache()
 
 
-def memory_stats(device: "_device_t" = None) -> dict[str, Any]:
+def memory_stats(device: torch.types.Device = None) -> dict[str, Any]:
     r"""Return a dictionary of CUDA memory allocator statistics for a given device.
 
     The return value of this function is a dictionary of statistics, each of
@@ -328,7 +326,7 @@ def memory_stats(device: "_device_t" = None) -> dict[str, Any]:
     return collections.OrderedDict(result)
 
 
-def memory_stats_as_nested_dict(device: "_device_t" = None) -> dict[str, Any]:
+def memory_stats_as_nested_dict(device: torch.types.Device = None) -> dict[str, Any]:
     r"""Return the result of :func:`~torch.cuda.memory_stats` as a nested dictionary."""
     if not is_initialized():
         return {}
@@ -336,7 +334,7 @@ def memory_stats_as_nested_dict(device: "_device_t" = None) -> dict[str, Any]:
     return torch._C._cuda_memoryStats(device)
 
 
-def reset_accumulated_memory_stats(device: "_device_t" = None) -> None:
+def reset_accumulated_memory_stats(device: torch.types.Device = None) -> None:
     r"""Reset the "accumulated" (historical) stats tracked by the CUDA memory allocator.
 
     See :func:`~torch.cuda.memory_stats` for details. Accumulated stats correspond to
@@ -356,7 +354,7 @@ def reset_accumulated_memory_stats(device: "_device_t" = None) -> None:
     return torch._C._cuda_resetAccumulatedMemoryStats(device)
 
 
-def reset_peak_memory_stats(device: "_device_t" = None) -> None:
+def reset_peak_memory_stats(device: torch.types.Device = None) -> None:
     r"""Reset the "peak" stats tracked by the CUDA memory allocator.
 
     See :func:`~torch.cuda.memory_stats` for details. Peak stats correspond to the
@@ -469,7 +467,7 @@ def reset_peak_host_memory_stats() -> None:
     return torch._C._cuda_resetPeakHostMemoryStats()
 
 
-def reset_max_memory_allocated(device: "_device_t" = None) -> None:
+def reset_max_memory_allocated(device: torch.types.Device = None) -> None:
     r"""Reset the starting point in tracking maximum GPU memory occupied by tensors for a given device.
 
     See :func:`~torch.cuda.max_memory_allocated` for details.
@@ -495,7 +493,7 @@ def reset_max_memory_allocated(device: "_device_t" = None) -> None:
     return reset_peak_memory_stats(device=device)
 
 
-def reset_max_memory_cached(device: "_device_t" = None) -> None:
+def reset_max_memory_cached(device: torch.types.Device = None) -> None:
     r"""Reset the starting point in tracking maximum GPU memory managed by the caching allocator for a given device.
 
     See :func:`~torch.cuda.max_memory_cached` for details.
@@ -521,7 +519,7 @@ def reset_max_memory_cached(device: "_device_t" = None) -> None:
     return reset_peak_memory_stats(device=device)
 
 
-def memory_allocated(device: "_device_t" = None) -> int:
+def memory_allocated(device: torch.types.Device = None) -> int:
     r"""Return the current GPU memory occupied by tensors in bytes for a given device.
 
     Args:
@@ -538,7 +536,7 @@ def memory_allocated(device: "_device_t" = None) -> int:
     return memory_stats(device=device).get("allocated_bytes.all.current", 0)
 
 
-def max_memory_allocated(device: "_device_t" = None) -> int:
+def max_memory_allocated(device: torch.types.Device = None) -> int:
     r"""Return the maximum GPU memory occupied by tensors in bytes for a given device.
 
     By default, this returns the peak allocated memory since the beginning of
@@ -559,7 +557,7 @@ def max_memory_allocated(device: "_device_t" = None) -> int:
     return memory_stats(device=device).get("allocated_bytes.all.peak", 0)
 
 
-def memory_reserved(device: "_device_t" = None) -> int:
+def memory_reserved(device: torch.types.Device = None) -> int:
     r"""Return the current GPU memory managed by the caching allocator in bytes for a given device.
 
     Args:
@@ -574,7 +572,7 @@ def memory_reserved(device: "_device_t" = None) -> int:
     return memory_stats(device=device).get("reserved_bytes.all.current", 0)
 
 
-def max_memory_reserved(device: "_device_t" = None) -> int:
+def max_memory_reserved(device: torch.types.Device = None) -> int:
     r"""Return the maximum GPU memory managed by the caching allocator in bytes for a given device.
 
     By default, this returns the peak cached memory since the beginning of this
@@ -599,7 +597,7 @@ def max_memory_reserved(device: "_device_t" = None) -> int:
     "`torch.cuda.memory_cached` has been renamed to `torch.cuda.memory_reserved`",
     category=FutureWarning,
 )
-def memory_cached(device: "_device_t" = None) -> int:
+def memory_cached(device: torch.types.Device = None) -> int:
     r"""Deprecated; see :func:`~torch.cuda.memory_reserved`."""
     return memory_reserved(device=device)
 
@@ -608,7 +606,7 @@ def memory_cached(device: "_device_t" = None) -> int:
     "`torch.cuda.max_memory_cached` has been renamed to `torch.cuda.max_memory_reserved`",
     category=FutureWarning,
 )
-def max_memory_cached(device: "_device_t" = None) -> int:
+def max_memory_cached(device: torch.types.Device = None) -> int:
     r"""Deprecated; see :func:`~torch.cuda.max_memory_reserved`."""
     return max_memory_reserved(device=device)
 
@@ -626,7 +624,7 @@ def memory_snapshot():
     return torch._C._cuda_memorySnapshot()["segments"]
 
 
-def memory_summary(device: "_device_t" = None, abbreviated: bool = False) -> str:
+def memory_summary(device: torch.types.Device = None, abbreviated: bool = False) -> str:
     r"""Return a human-readable printout of the current memory allocator statistics for a given device.
 
     This can be useful to display periodically during training, or when
@@ -753,7 +751,7 @@ def memory_summary(device: "_device_t" = None, abbreviated: bool = False) -> str
     return "|" + "|\n|".join(lines).format(**fmt_dict) + "|\n"
 
 
-def list_gpu_processes(device: "_device_t" = None) -> str:
+def list_gpu_processes(device: torch.types.Device = None) -> str:
     r"""Return a human-readable printout of the running processes and their GPU memory use for a given device.
 
     This can be useful to display periodically during training, or when
@@ -818,7 +816,7 @@ def list_gpu_processes(device: "_device_t" = None) -> str:
     return "\n".join(lines)
 
 
-def mem_get_info(device: "_device_t" = None) -> tuple[int, int]:
+def mem_get_info(device: torch.types.Device = None) -> tuple[int, int]:
     r"""Return the global free and total GPU memory for a given device using cudaMemGetInfo.
 
     Args:
@@ -842,7 +840,7 @@ def _record_memory_history_legacy(
     record_context=True,
     trace_alloc_max_entries=1,
     trace_alloc_record_context=False,
-    device: "_device_t" = None,
+    device: torch.types.Device = None,
     record_context_cpp=False,
     clear_history=False,
 ):
@@ -906,7 +904,7 @@ def _record_memory_history_impl(
     context: Optional[str] = "all",
     stacks: str = "all",
     max_entries: int = sys.maxsize,
-    device: "_device_t" = None,
+    device: torch.types.Device = None,
     clear_history: bool = False,
 ):
     _C._cuda_record_memory_history(enabled, context, stacks, max_entries, clear_history)
@@ -915,7 +913,7 @@ def _record_memory_history_impl(
 _record_memory_history.__signature__ = signature(_record_memory_history_impl)  # type: ignore[attr-defined]
 
 
-def _snapshot(device: "_device_t" = None):
+def _snapshot(device: torch.types.Device = None):
     """Save a snapshot of CUDA memory state at the time it was called.
 
     The state is represented as a dictionary with the following structure.
@@ -1177,7 +1175,7 @@ class MemPool(_MemPool):
 
 
 @contextlib.contextmanager
-def use_mem_pool(pool: MemPool, device: "_device_t" = None):
+def use_mem_pool(pool: MemPool, device: torch.types.Device = None):
     r"""A context manager that routes allocations to a given pool.
 
     Args:

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -8,7 +8,7 @@ import pickle
 import sys
 import warnings
 from inspect import signature
-from typing import Any, Literal, Optional
+from typing import Any, Literal, Optional, TYPE_CHECKING
 from typing_extensions import deprecated
 
 import torch
@@ -23,6 +23,10 @@ from . import (
     is_initialized,
 )
 from ._memory_viz import memory as _memory, segments as _segments
+
+
+if TYPE_CHECKING:
+    from torch.types import Device as _device_t
 
 
 __all__ = [
@@ -102,7 +106,7 @@ def _free_mutex():
         torch._C._cuda_unlock_mutex()
 
 
-def caching_allocator_alloc(size, device: torch.types.Device = None, stream=None):
+def caching_allocator_alloc(size, device: "_device_t" = None, stream=None):
     r"""Perform a memory allocation using the CUDA memory allocator.
 
     Memory is allocated for a given device and a stream, this
@@ -161,9 +165,7 @@ def caching_allocator_enable(value: bool = True) -> None:
         torch._C._cuda_cudaCachingAllocator_enable(value)
 
 
-def set_per_process_memory_fraction(
-    fraction, device: torch.types.Device = None
-) -> None:
+def set_per_process_memory_fraction(fraction, device: "_device_t" = None) -> None:
     r"""Set memory fraction for a process.
 
     The fraction is used to limit an caching allocator to allocated memory on a CUDA device.
@@ -190,7 +192,7 @@ def set_per_process_memory_fraction(
     torch._C._cuda_setMemoryFraction(fraction, device)
 
 
-def get_per_process_memory_fraction(device: torch.types.Device = None) -> float:
+def get_per_process_memory_fraction(device: "_device_t" = None) -> float:
     r"""Get memory fraction for a process.
 
     Args:
@@ -221,7 +223,7 @@ def empty_cache() -> None:
         torch._C._cuda_emptyCache()
 
 
-def memory_stats(device: torch.types.Device = None) -> dict[str, Any]:
+def memory_stats(device: "_device_t" = None) -> dict[str, Any]:
     r"""Return a dictionary of CUDA memory allocator statistics for a given device.
 
     The return value of this function is a dictionary of statistics, each of
@@ -326,7 +328,7 @@ def memory_stats(device: torch.types.Device = None) -> dict[str, Any]:
     return collections.OrderedDict(result)
 
 
-def memory_stats_as_nested_dict(device: torch.types.Device = None) -> dict[str, Any]:
+def memory_stats_as_nested_dict(device: "_device_t" = None) -> dict[str, Any]:
     r"""Return the result of :func:`~torch.cuda.memory_stats` as a nested dictionary."""
     if not is_initialized():
         return {}
@@ -334,7 +336,7 @@ def memory_stats_as_nested_dict(device: torch.types.Device = None) -> dict[str, 
     return torch._C._cuda_memoryStats(device)
 
 
-def reset_accumulated_memory_stats(device: torch.types.Device = None) -> None:
+def reset_accumulated_memory_stats(device: "_device_t" = None) -> None:
     r"""Reset the "accumulated" (historical) stats tracked by the CUDA memory allocator.
 
     See :func:`~torch.cuda.memory_stats` for details. Accumulated stats correspond to
@@ -354,7 +356,7 @@ def reset_accumulated_memory_stats(device: torch.types.Device = None) -> None:
     return torch._C._cuda_resetAccumulatedMemoryStats(device)
 
 
-def reset_peak_memory_stats(device: torch.types.Device = None) -> None:
+def reset_peak_memory_stats(device: "_device_t" = None) -> None:
     r"""Reset the "peak" stats tracked by the CUDA memory allocator.
 
     See :func:`~torch.cuda.memory_stats` for details. Peak stats correspond to the
@@ -467,7 +469,7 @@ def reset_peak_host_memory_stats() -> None:
     return torch._C._cuda_resetPeakHostMemoryStats()
 
 
-def reset_max_memory_allocated(device: torch.types.Device = None) -> None:
+def reset_max_memory_allocated(device: "_device_t" = None) -> None:
     r"""Reset the starting point in tracking maximum GPU memory occupied by tensors for a given device.
 
     See :func:`~torch.cuda.max_memory_allocated` for details.
@@ -493,7 +495,7 @@ def reset_max_memory_allocated(device: torch.types.Device = None) -> None:
     return reset_peak_memory_stats(device=device)
 
 
-def reset_max_memory_cached(device: torch.types.Device = None) -> None:
+def reset_max_memory_cached(device: "_device_t" = None) -> None:
     r"""Reset the starting point in tracking maximum GPU memory managed by the caching allocator for a given device.
 
     See :func:`~torch.cuda.max_memory_cached` for details.
@@ -519,7 +521,7 @@ def reset_max_memory_cached(device: torch.types.Device = None) -> None:
     return reset_peak_memory_stats(device=device)
 
 
-def memory_allocated(device: torch.types.Device = None) -> int:
+def memory_allocated(device: "_device_t" = None) -> int:
     r"""Return the current GPU memory occupied by tensors in bytes for a given device.
 
     Args:
@@ -536,7 +538,7 @@ def memory_allocated(device: torch.types.Device = None) -> int:
     return memory_stats(device=device).get("allocated_bytes.all.current", 0)
 
 
-def max_memory_allocated(device: torch.types.Device = None) -> int:
+def max_memory_allocated(device: "_device_t" = None) -> int:
     r"""Return the maximum GPU memory occupied by tensors in bytes for a given device.
 
     By default, this returns the peak allocated memory since the beginning of
@@ -557,7 +559,7 @@ def max_memory_allocated(device: torch.types.Device = None) -> int:
     return memory_stats(device=device).get("allocated_bytes.all.peak", 0)
 
 
-def memory_reserved(device: torch.types.Device = None) -> int:
+def memory_reserved(device: "_device_t" = None) -> int:
     r"""Return the current GPU memory managed by the caching allocator in bytes for a given device.
 
     Args:
@@ -572,7 +574,7 @@ def memory_reserved(device: torch.types.Device = None) -> int:
     return memory_stats(device=device).get("reserved_bytes.all.current", 0)
 
 
-def max_memory_reserved(device: torch.types.Device = None) -> int:
+def max_memory_reserved(device: "_device_t" = None) -> int:
     r"""Return the maximum GPU memory managed by the caching allocator in bytes for a given device.
 
     By default, this returns the peak cached memory since the beginning of this
@@ -597,7 +599,7 @@ def max_memory_reserved(device: torch.types.Device = None) -> int:
     "`torch.cuda.memory_cached` has been renamed to `torch.cuda.memory_reserved`",
     category=FutureWarning,
 )
-def memory_cached(device: torch.types.Device = None) -> int:
+def memory_cached(device: "_device_t" = None) -> int:
     r"""Deprecated; see :func:`~torch.cuda.memory_reserved`."""
     return memory_reserved(device=device)
 
@@ -606,7 +608,7 @@ def memory_cached(device: torch.types.Device = None) -> int:
     "`torch.cuda.max_memory_cached` has been renamed to `torch.cuda.max_memory_reserved`",
     category=FutureWarning,
 )
-def max_memory_cached(device: torch.types.Device = None) -> int:
+def max_memory_cached(device: "_device_t" = None) -> int:
     r"""Deprecated; see :func:`~torch.cuda.max_memory_reserved`."""
     return max_memory_reserved(device=device)
 
@@ -624,7 +626,7 @@ def memory_snapshot():
     return torch._C._cuda_memorySnapshot()["segments"]
 
 
-def memory_summary(device: torch.types.Device = None, abbreviated: bool = False) -> str:
+def memory_summary(device: "_device_t" = None, abbreviated: bool = False) -> str:
     r"""Return a human-readable printout of the current memory allocator statistics for a given device.
 
     This can be useful to display periodically during training, or when
@@ -751,7 +753,7 @@ def memory_summary(device: torch.types.Device = None, abbreviated: bool = False)
     return "|" + "|\n|".join(lines).format(**fmt_dict) + "|\n"
 
 
-def list_gpu_processes(device: torch.types.Device = None) -> str:
+def list_gpu_processes(device: "_device_t" = None) -> str:
     r"""Return a human-readable printout of the running processes and their GPU memory use for a given device.
 
     This can be useful to display periodically during training, or when
@@ -816,7 +818,7 @@ def list_gpu_processes(device: torch.types.Device = None) -> str:
     return "\n".join(lines)
 
 
-def mem_get_info(device: torch.types.Device = None) -> tuple[int, int]:
+def mem_get_info(device: "_device_t" = None) -> tuple[int, int]:
     r"""Return the global free and total GPU memory for a given device using cudaMemGetInfo.
 
     Args:
@@ -840,7 +842,7 @@ def _record_memory_history_legacy(
     record_context=True,
     trace_alloc_max_entries=1,
     trace_alloc_record_context=False,
-    device: torch.types.Device = None,
+    device: "_device_t" = None,
     record_context_cpp=False,
     clear_history=False,
 ):
@@ -904,7 +906,7 @@ def _record_memory_history_impl(
     context: Optional[str] = "all",
     stacks: str = "all",
     max_entries: int = sys.maxsize,
-    device: torch.types.Device = None,
+    device: "_device_t" = None,
     clear_history: bool = False,
 ):
     _C._cuda_record_memory_history(enabled, context, stacks, max_entries, clear_history)
@@ -913,7 +915,7 @@ def _record_memory_history_impl(
 _record_memory_history.__signature__ = signature(_record_memory_history_impl)  # type: ignore[attr-defined]
 
 
-def _snapshot(device: torch.types.Device = None):
+def _snapshot(device: "_device_t" = None):
     """Save a snapshot of CUDA memory state at the time it was called.
 
     The state is represented as a dictionary with the following structure.
@@ -1175,7 +1177,7 @@ class MemPool(_MemPool):
 
 
 @contextlib.contextmanager
-def use_mem_pool(pool: MemPool, device: torch.types.Device = None):
+def use_mem_pool(pool: MemPool, device: "_device_t" = None):
     r"""A context manager that routes allocations to a given pool.
 
     Args:


### PR DESCRIPTION
Part of: #152952

Here is the definition of `torch.types.Device`:

https://github.com/pytorch/pytorch/blob/ab997d9ff584e8623de146b6eb9c9074081b045b/torch/types.py#L74

It contains `int`, so the `int` in `Union[Device, int]` is redundant.

cc: @Skylion007
