### PR TITLE
[Typing] Improve device typing for `torch.set_default_device()`

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -36,7 +36,7 @@ from typing_extensions import ParamSpec as _ParamSpec
 
 
 if TYPE_CHECKING:
-    from .types import IntLikeType
+    from .types import Device, IntLikeType
 
 
 # multipy/deploy is setting this import before importing torch, this is the most
@@ -1154,9 +1154,7 @@ def get_default_device() -> "torch.device":
         return torch.device("cpu")
 
 
-def set_default_device(
-    device: _Optional[_Union["torch.device", str, builtins.int]],
-) -> None:
+def set_default_device(device: "Device") -> None:
     """Sets the default ``torch.Tensor`` to be allocated on ``device``.  This
     does not affect factory function calls which are called with an explicit
     ``device`` argument.  Factory calls will be performed as if they


### PR DESCRIPTION
Part of: #152952

Here is the definition of `torch.types.Device`:

https://github.com/pytorch/pytorch/blob/ab997d9ff584e8623de146b6eb9c9074081b045b/torch/types.py#L74

So `_Optional[_Union["torch.device", str, builtins.int]]` is equivalent to it.

cc: @Skylion007 