### PR TITLE
[AOTInductor] Generate kernels separately for const graph and main graph

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -336,7 +336,7 @@ class AOTInductorTestsTemplate:
                 return abs_weight, abs_y
 
         input1 = (torch.rand(2048, 2048, dtype=torch.float16, device=self.device),)
-        model = Model(self.device).cuda()
+        model = Model(self.device).to(self.device)
 
         _ = model(*input1)
 

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -320,12 +320,11 @@ class AOTInductorTestsTemplate:
         with config.patch({"aot_inductor.use_runtime_constant_folding": True}):
             self.check_model(Model(self.device), example_inputs)
 
-    @requires_gpu
     def test_autotune_with_constant_folding(self):
-        class M(torch.nn.Module):
-            def __init__(self, *args, **kwargs) -> None:
-                super().__init__(*args, **kwargs)
-                self.x = torch.randn(2048, 2048, dtype=torch.float16, device="cuda")
+        class Model(torch.nn.Module):
+            def __init__(self, device) -> None:
+                super().__init__()
+                self.x = torch.randn(2048, 2048, dtype=torch.float16, device=device)
 
             def _quantize(self, input):
                 return torch.abs(input)
@@ -336,8 +335,8 @@ class AOTInductorTestsTemplate:
 
                 return abs_weight, abs_y
 
-        input1 = (torch.rand(2048, 2048, dtype=torch.float16, device="cuda"),)
-        model = M().cuda()
+        input1 = (torch.rand(2048, 2048, dtype=torch.float16, device=self.device),)
+        model = Model().cuda()
 
         _ = model(*input1)
 

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -336,7 +336,7 @@ class AOTInductorTestsTemplate:
                 return abs_weight, abs_y
 
         input1 = (torch.rand(2048, 2048, dtype=torch.float16, device=self.device),)
-        model = Model().cuda()
+        model = Model(self.device).cuda()
 
         _ = model(*input1)
 

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1947,12 +1947,7 @@ class GraphLowering(torch.fx.Interpreter):
         )
 
         if self.const_module:
-            # If we have const module, we could reuse the kernels
-            # This could avoid duplication and save time on doing recompilation (if Triton.)
             self.wrapper_code._names_iter = self.const_module.wrapper_code._names_iter
-            self.wrapper_code.src_to_kernel = (
-                self.const_module.wrapper_code.src_to_kernel
-            )
 
     def extract_autotune_inputs(
         self, example_inputs: list[Union[int, float, torch.Tensor]]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #153040

Summary:
We should generate the kernel for const graph and main graph separately.
The reason is that when we run autotuning, we would create separate
kernel calls and we should make sure that main graph also contains the
runner.

Test Plan:
python test/inductor/test_aot_inductor.py -k test_autotune_with_constant_folding

Reviewers:

Subscribers:

Tasks:

Tags:

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @amjames @chauhang @aakhundov

Differential Revision: [D74347765](https://our.internmc.facebook.com/intern/diff/D74347765)