### PR TITLE
[BE]: Blacklist broken setuptools until we upgrade MSVC API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,9 @@
 [build-system]
 requires = [
     # After 75.8.2 dropped dep disttools API. Please fix
+    # temporarily restored in 78.1. Please fix
     # min version for recursive glob package data support
-    "setuptools>=62.3.0,<75.9",
+    "setuptools>=62.3.0,!=75.9,!=76.*,!=77.*,!=78.0",
     "wheel",
     "astunparse",
     "numpy",

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,8 @@ psutil
 pyyaml
 requests
 # issue on Windows after >= 75.8.2 - https://github.com/pytorch/pytorch/issues/148877
-setuptools>=62.3.0,<75.9
+# setuptools COMMAND support is deprecated after 80
+setuptools>=62.3.0,!=75.9,!=76.*,!=77.*,!=78.0,<80
 sympy>=1.13.3
 types-dataclasses
 typing-extensions>=4.10.0


### PR DESCRIPTION
Alternative to #153052 where we just ban the broken setuptools version