### PR TITLE
[BE] Update ruamel to 0.18.10

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -370,7 +370,7 @@ init_command = [
     'python3',
     'tools/linter/adapters/pip_init.py',
     '--dry-run={{DRYRUN}}',
-    'ruamel.yaml==0.17.4',
+    'ruamel.yaml==0.18.10',
 ]
 is_formatter = true
 
@@ -387,7 +387,7 @@ init_command = [
     'python3',
     'tools/linter/adapters/pip_init.py',
     '--dry-run={{DRYRUN}}',
-    'ruamel.yaml==0.17.4',
+    'ruamel.yaml==0.18.10',
 ]
 
 [[linter]]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #152719
* __->__ #153057

To address the feedback from https://github.com/pytorch/pytorch/pull/153013
Previously it was pinned to 0.17.4, that was released in 2021