### PR TITLE
Fix TORCH_CHECK error message in FusedSgdKernel

### DIFF
--- a/aten/src/ATen/native/cuda/FusedSgdKernel.cu
+++ b/aten/src/ATen/native/cuda/FusedSgdKernel.cu
@@ -232,7 +232,7 @@ void _fused_sgd_with_momentum_kernel_cuda_(
   }
   TORCH_CHECK(
       lr.device() == params[0].device(),
-      "found_inf must be on the same GPU device as the params");
+      "lr must be on the same GPU device as the params");
   float* grad_scale_ptr =
       grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
   float* found_inf_ptr =


### PR DESCRIPTION
This fixes an issue in the TORCH_CHECK error message in the FusedSgdKernel.

Current behavior: If the LR tensor is not on the same device as the parameters, the error message reads: "found_inf must be on the same GPU device as the params".

Fix: The error message now correctly points out "lr must be on the same GPU device as the params".