### PR TITLE
Fix test/test_optim.py error message.

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1179,7 +1179,7 @@ class TestOptimRenewed(TestCase):
         opt_name = optim_cls.__name__
         if opt_name in ("SGD", "Adagrad") and impl == "capturable":
             # Capturable SGD/Adagrad does not exist
-            self.skipTest("SGD does not currently support capturable")
+            self.skipTest(f"{opt_name} does not currently support capturable")
         if _get_device_type(device) == "cpu":
             self.skipTest("Test is only for non-cpu devices")
         elif (


### PR DESCRIPTION
Fixes an error message in test/test_optim.py

Current behavior: If running the test with Adagrad, the error message reads: "SGD does not currently support capturable".

Fix: The error message now says correctly: "Adagrad does not currently support capturable".