### PR TITLE
[BE] Move all lint runner to 24.04

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,8 +3,8 @@ self-hosted-runner:
     # GitHub hosted runner that actionlint doesn't recognize because actionlint version (1.6.21) is too old
     - ubuntu-24.04
     # GitHub hosted x86 Linux runners
-    - linux.20_04.4x
-    - linux.20_04.16x
+    - linux.24_04.4x
+    - linux.24_04.16x
     # Organization-wide AWS Linux Runners
     - linux.large
     - linux.2xlarge

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -35,7 +35,7 @@ jobs:
       pull-requests: write
     name: Check labels
     if: github.repository_owner == 'pytorch'
-    runs-on: linux.20_04.4x
+    runs-on: linux.24_04.4x
     steps:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@release/2.7

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -216,7 +216,7 @@ jobs:
   test_run_test:
     name: Test `run_test.py` is usable without boto3
     if: ${{ github.repository == 'pytorch/pytorch' }}
-    runs-on: linux.20_04.4x
+    runs-on: linux.24_04.4x
     steps:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@release/2.7

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -242,7 +242,7 @@ jobs:
   test_collect_env:
     if: ${{ github.repository == 'pytorch/pytorch' }}
     name: Test collect_env
-    runs-on: linux.20_04.4x
+    runs-on: linux.24_04.4x
     strategy:
       matrix:
         test_type: [with_torch, without_torch, older_python_version]
@@ -265,7 +265,7 @@ jobs:
         if: matrix.test_type == 'older_python_version'
         uses: actions/setup-python@v4
         with:
-          python-version: 3.6
+          python-version: 3.8
           architecture: x64
           check-latest: false
           cache: pip

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   do_revert:
     name: try_revert_pr_${{ github.event.client_payload.pr_num }}
-    runs-on: linux.20_04.4x
+    runs-on: linux.24_04.4x
     environment: mergebot
     env:
         GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/trymerge.yml
+++ b/.github/workflows/trymerge.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   do_merge:
     name: try_merge_pr_${{ github.event.client_payload.pr_num }}
-    runs-on: linux.20_04.4x
+    runs-on: linux.24_04.4x
     environment: mergebot
     permissions:
       id-token: write


### PR DESCRIPTION
As Ubuntu-20 reached EOL on Apr 1st, see https://github.com/actions/runner-images/issues/11101
This forces older python version to be 3.8
Delete all linux-20.04 runners from the lintrunner.yml
Cherry-pick of  https://github.com/pytorch/pytorch/pull/150427 into release/2.7 branch

(cherry picked from commit 48af2cdd270c275acccc4a94b04e4ccdb64d557a)

