### PR TITLE
[nativert] move executor config to torch

### DIFF
--- a/torch/nativert/executor/ExecutorConfig.h
+++ b/torch/nativert/executor/ExecutorConfig.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace torch::nativert {
+
+struct ExecutorConfig {
+  bool validateInputs = false;
+  bool debugNan = false;
+  bool enableStaticCPUKernels = false;
+  bool enableStaticMemoryPlanning = false;
+  bool runConstFolding = false;
+  // allows up to max number of concurrent threads.
+  int64_t maxNumConcurrentThreads = 8;
+  // allows up to max number of parallel ops.
+  int64_t maxParallelOps = 1;
+  std::string modelName = "unknown";
+};
+
+} // namespace torch::nativert


### PR DESCRIPTION
Summary:
nativert RFC: https://github.com/zhxchen17/rfcs/blob/master/RFC-0043-torch-native-runtime.md

To land the runtime into PyTorch core, we will gradually land logical parts of the code into the Github issue and get each piece properly reviewed.

This diff moves the executor config to torch. since it's header-only this requires some changes to the libtorch build configs

Test Plan: CI

Differential Revision: D74278789
