### PR TITLE
Use FMA for CUDA Adam kernel's lerps.

### DIFF
--- a/aten/src/ATen/native/cuda/fused_adam_utils.cuh
+++ b/aten/src/ATen/native/cuda/fused_adam_utils.cuh
@@ -41,6 +41,8 @@ C10_DEVICE inline void adam_math(
     // Load values.
     opmath_t param = static_cast<opmath_t>(r_args[kParamIdx][ii]);
     opmath_t grad = static_cast<opmath_t>(r_args[kGradIdx][ii]);
+    opmath_t casted_beta1 = static_cast<opmath_t>(beta1);
+    opmath_t casted_beta2 = static_cast<opmath_t>(beta2);
     if (grad_scale_ptr) {
       grad /= (static_cast<double>(*grad_scale_ptr));
     }
@@ -62,9 +64,12 @@ C10_DEVICE inline void adam_math(
         param -= lr * weight_decay * param;
       }
     }
-    exp_avg = std::fma(beta1, exp_avg, std::fma(-beta1, grad, grad));
-    exp_avg_sq =
-        std::fma(beta2, exp_avg_sq, std::fma(-beta2, grad * grad, grad * grad));
+    exp_avg =
+        std::fma(casted_beta1, exp_avg, std::fma(-casted_beta1, grad, grad));
+    exp_avg_sq = std::fma(
+        casted_beta2,
+        exp_avg_sq,
+        std::fma(-casted_beta2, grad * grad, grad * grad));
     const opmath_t step_size = lr / bias_correction1;
     opmath_t denom;
     if (amsgrad) {

--- a/aten/src/ATen/native/cuda/fused_adam_utils.cuh
+++ b/aten/src/ATen/native/cuda/fused_adam_utils.cuh
@@ -62,10 +62,9 @@ C10_DEVICE inline void adam_math(
         param -= lr * weight_decay * param;
       }
     }
-    // todo(crcrpar): use lerp
-    // ref: https://developer.nvidia.com/blog/lerp-faster-cuda/
-    exp_avg = beta1 * exp_avg + (1 - beta1) * grad;
-    exp_avg_sq = beta2 * exp_avg_sq + (1 - beta2) * grad * grad;
+    exp_avg = std::fma(beta1, exp_avg, std::fma(-beta1, grad, grad));
+    exp_avg_sq =
+        std::fma(beta2, exp_avg_sq, std::fma(-beta2, grad * grad, grad * grad));
     const opmath_t step_size = lr / bias_correction1;
     opmath_t denom;
     if (amsgrad) {


### PR DESCRIPTION
Switch the calculation of lerps in Adam's fused CUDA kernel to use fma, as proposed by @crcrpar .