### PR TITLE
do not reinplace diagonal_scatter

### DIFF
--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -39,7 +39,6 @@ class InplaceableOp:
 
 
 _SCATTER_OP_TO_VIEW = {
-    torch.ops.aten.diagonal_scatter.default: torch.ops.aten.diagonal.default,
     torch.ops.aten.select_scatter.default: torch.ops.aten.select.int,
     torch.ops.aten.slice_scatter.default: torch.ops.aten.slice.Tensor,
     torch.ops.aten.as_strided_scatter.default: torch.ops.aten.as_strided.default,


### PR DESCRIPTION
In the following code, `copy_` changes values of `mul` which is later read by `torch.mm`. So `torch.mm` has to happen after `copy_`. This info is captured in aot graph. We can see `mm` reads `diagonal_scatter`, which reads `copy`. So we know torch.ops.aten.mm must happen after torch.ops.aten.copy.

However, in post_grad_graph, this info is lost. `diagonal_scatter` is reinplaced. `mm` reads `mul`, and `copy__default` reads `diagonal_default` which also reads `mul`. So there is no dependency between `mm` and `diagonal_default` anymore.

From inductor perspective, we loses this dependency and can reorder `torch.ops.aten.mm` and `torch.ops.aten.copy`, leading to wrong results. To see the error, try `PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=0 python test/inductor/test_torchinductor_opinfo.py TestInductorOpInfoCUDA.test_comprehensive_linalg_eig_cuda_float64` with `torch._inductor.config.graph_partition=True`, which will lead to incorrectness. We need `graph_partition` here for reordering based on dependency, which exposes the issue. This PR fixes the error.

```python
import torch

def f(x, y, z, other):
    mul = x * y
    diag = torch.diagonal(mul)
    diag.copy_(other)
    return torch.mm(mul, z)

f = torch.compile(f)

inps = (torch.randn(3, 3), torch.randn(3, 3), torch.randn(3, 3), torch.randn(3))
f(*inps)
```

![Image](https://github.com/user-attachments/assets/765d0d37-f71b-43af-89fa-ddf61f91e5a1)

![Image](https://github.com/user-attachments/assets/3112fb50-2495-4ee5-a193-76ac33db0f51)


cc @bdhirsh @ezyang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov