### PR TITLE
[Graph Partition] Maintain relative order within partition during reordering

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -381,9 +381,6 @@ autotune_num_choices_displayed: Optional[int] = 10
 # enable inductor graph partition to allow multiple inductor graphs for the same dynamo graph
 graph_partition = False
 
-# whether enabling debug mode for graph partition
-debug_graph_partition = False
-
 # force cublas and triton to use the same precision; cublas supports TF32 for matmul operations
 # when m, n, k are multiples of 16, 16, 8, whereas triton supports TF32 for matmul operations
 # for any combinations of m, n, k, regardless of their alignment. setting this flag will ensure

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -381,6 +381,9 @@ autotune_num_choices_displayed: Optional[int] = 10
 # enable inductor graph partition to allow multiple inductor graphs for the same dynamo graph
 graph_partition = False
 
+# whether enabling debug mode for graph partition
+debug_graph_partition = False
+
 # force cublas and triton to use the same precision; cublas supports TF32 for matmul operations
 # when m, n, k are multiples of 16, 16, 8, whereas triton supports TF32 for matmul operations
 # for any combinations of m, n, k, regardless of their alignment. setting this flag will ensure

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -4294,17 +4294,19 @@ class Scheduler:
         change relative orders of two cudagraphable nodes, nor the
         relative order of two non_cudagraphable nodes.
         """
+        import heapq
+
         node_to_indegree: dict[BaseSchedulerNode, int] = dict()
-        cudagraphable_nodes: collections.deque[BaseSchedulerNode] = collections.deque()
-        non_cudagraphable_nodes: collections.deque[BaseSchedulerNode] = (
-            collections.deque()
-        )
+        cudagraphable_nodes: list[tuple[int, BaseSchedulerNode]] = []
+        non_cudagraphable_nodes: list[tuple[int, BaseSchedulerNode]] = []
+        node_to_index = {node: idx for idx, node in enumerate(nodes)}
 
         def insert_pending_nodes(node: BaseSchedulerNode) -> None:
+            node_with_index = (node_to_index[node], node)
             if self.should_partition(node):
-                non_cudagraphable_nodes.append(node)
+                heapq.heappush(non_cudagraphable_nodes, node_with_index)
             else:
-                cudagraphable_nodes.append(node)
+                heapq.heappush(cudagraphable_nodes, node_with_index)
 
         def update_indegree(node: BaseSchedulerNode) -> None:
             for succ_node in node.mpi_node.succ_nodes:
@@ -4324,12 +4326,12 @@ class Scheduler:
             non_cudagraphable_nodes or cudagraphable_nodes
         ):
             while non_cudagraphable_nodes:
-                node = non_cudagraphable_nodes.popleft()
+                _, node = heapq.heappop(non_cudagraphable_nodes)
                 schedule.append(node)
                 update_indegree(node)
 
             while cudagraphable_nodes:
-                node = cudagraphable_nodes.popleft()
+                _, node = heapq.heappop(cudagraphable_nodes)
                 schedule.append(node)
                 update_indegree(node)
 


### PR DESCRIPTION
PR #151968 adds `reorder_for_minimizing_partition` for the minimal number of partitions. If reordering two nodes cannot reduce the number of partitions, `reorder_for_minimizing_partition` should maintain the relative order of these two nodes and rely on other reorder passes for some nice features, such as shorter liveness duration or less peak memory. In an extreme case, when all nodes are on gpu and can be cudagraphed, `reorder_for_minimizing_partition` should not reorder any nodes. 

This PR improves `reorder_for_minimizing_partition` for the invariant: relative order of nodes within the same graph partition are maintained. To do so, we record the index of each node in the input `nodes: list[BaseSchedulerNode]` and use a heap to pop the node with the smallest index. So we always scheduler a node with smaller index in the same graph partition and respects the invariant. Previous implementation tried to use a queue to achieve that but failed. Because node_N at the end may rely on node_1 at the start, such that node_N is added to queue once node_1 is scheduled.


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov