### PR TITLE
[Minimizer] Fix the path naming

### DIFF
--- a/torch/fx/passes/net_min_base.py
+++ b/torch/fx/passes/net_min_base.py
@@ -396,17 +396,21 @@ class _MinimizerBase:
             if self.module_exporter:
                 if isinstance(result_key, tuple):  # type: ignore[possibly-undefined]
                     result_key = result_key[-1]
+                # If the result is still a tuple (happens in non-sequential mode),
+                # we only use the first element as name.
+                if isinstance(result_key, tuple):  # type: ignore[possibly-undefined]
+                    result_key = str(result_key[0])
                 # pyre-ignore[29]: not a function
                 self.module_exporter(
                     a_input,
                     submodule,
-                    str(result_key[0]) + "_cpu",  # type: ignore[index]
+                    result_key + "_cpu",
                 )
                 # pyre-ignore[29]: not a function
                 self.module_exporter(
                     b_input,
                     submodule,
-                    str(result_key[0]) + "_acc",  # type: ignore[index]
+                    result_key + "_acc",
                 )
             raise FxNetMinimizerResultMismatchError(f"Result mismatch for {result_key}")  # type: ignore[possibly-undefined]
 


### PR DESCRIPTION
Summary:
Added some logging and captured the indexing. See below image.
{F1977773416}

This is why the saved module path is called `/tmp/jimwan/minimizer_a_acc.pt`

Now the updated module paths are `/tmp/jimwan/minimizer_addmm_default_103_acc.pt`.

Test Plan:
```
MTIAC_USE_DIST_REF_KERNELS=all  buck2 run @//mode/opt mtia/accuracy/minimizer:mtia_minimizer_runner --  --mode sequential  --compare_fn allclose  --pt_save_dir  /tmp/debug3  --atol 1e-4 --rtol 1e-4 --all_outputs --start_idx native_layer_norm_default_80 --end_idx getitem_272 2>&1 | tee ~/test.log
```
{F1977773610}

Reviewed By: qcyuan

Differential Revision: D74369107




cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv