### PR TITLE
Avoid  std::chrono::system_clock 

### DIFF
--- a/aten/src/ATen/cuda/CachingHostAllocator.cpp
+++ b/aten/src/ATen/cuda/CachingHostAllocator.cpp
@@ -91,7 +91,7 @@ struct CUDACachingHostAllocatorImpl
           at::Device(at::DeviceType::CUDA, *primary_ctx_device_index));
     }
 
-    auto start = std::chrono::system_clock::now();
+    auto start = std::chrono::steady_clock::now();
     bool use_register = c10::cuda::CUDACachingAllocator::CUDAAllocatorConfig::pinned_use_cuda_host_register();
     if (use_register) {
       allocWithCudaHostRegister(ptr, size);
@@ -102,7 +102,7 @@ struct CUDACachingHostAllocatorImpl
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(use_host_register.count(*ptr) == 0);
     use_host_register[*ptr] = use_register;
 
-    auto end = std::chrono::system_clock::now();
+    auto end = std::chrono::steady_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
 
     // Update the statistics on the time spent on cudaHostAlloc/hostRegister
@@ -113,7 +113,7 @@ struct CUDACachingHostAllocatorImpl
   }
 
   void free_block(Block* block) override {
-    auto start = std::chrono::system_clock::now();
+    auto start = std::chrono::steady_clock::now();
     // Users may change the allocator config at will. torch unit tests do this.
     // However, allocations using cudaHostRegister should use corresonding
     // cudaHostUnregister and similarly for cudaHostAlloc / cudaFreeHost.
@@ -127,7 +127,7 @@ struct CUDACachingHostAllocatorImpl
       AT_CUDA_CHECK(cudaFreeHost(ptr));
     }
     use_host_register.erase(ptr);
-    auto end = std::chrono::system_clock::now();
+    auto end = std::chrono::steady_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
 
     // Update the statistics on the time spent on cudaFreeHost/hostUnregister

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/bench/hgemm.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/bench/hgemm.cc
@@ -40,7 +40,7 @@ class HGEMM : public benchmark::Fixture {
 
    void SetUp(const benchmark::State&) override {
     const uint_fast32_t seed =
-        std::chrono::system_clock::now().time_since_epoch().count();
+        std::chrono::steady_clock::now().time_since_epoch().count();
     auto rng = std::bind(
         fp16_ieee_from_fp32_value,
         std::bind(std::uniform_real_distribution<float>(), std::mt19937(seed)));

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/bench/q8gemm.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/bench/q8gemm.cc
@@ -374,7 +374,7 @@ class GEMMLOWP : public benchmark::Fixture {
  public:
    void SetUp(const benchmark::State& state) override {
     const uint_fast32_t seed =
-        std::chrono::system_clock::now().time_since_epoch().count();
+        std::chrono::steady_clock::now().time_since_epoch().count();
     auto rng =
         std::bind(std::uniform_int_distribution<uint8_t>(), std::mt19937(seed));
 

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/bench/requantization.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/bench/requantization.cc
@@ -43,9 +43,9 @@ class Requantization : public benchmark::Fixture {
     n_ = n_ / 16 * 16;
   }
 
-   void SetUp(const benchmark::State&) override {
+  void SetUp(const benchmark::State&) override {
     const uint_fast32_t seed =
-        std::chrono::system_clock::now().time_since_epoch().count();
+        std::chrono::steady_clock::now().time_since_epoch().count();
     auto rng =
         std::bind(std::uniform_int_distribution<int32_t>(), std::mt19937(seed));
 
@@ -55,7 +55,7 @@ class Requantization : public benchmark::Fixture {
     std::fill(output_.begin(), output_.end(), 0xA5);
   }
 
-   void TearDown(benchmark::State& state) override {
+  void TearDown(benchmark::State& state) override {
     state.SetItemsProcessed(uint64_t(state.iterations()) * n());
     state.SetBytesProcessed(
         uint64_t(state.iterations()) * n() *

--- a/c10/core/GeneratorImpl.cpp
+++ b/c10/core/GeneratorImpl.cpp
@@ -91,9 +91,7 @@ uint64_t getNonDeterministicRandom(bool is_cuda) {
   uint64_t s = 0;
   if (!is_cuda) {
 #ifdef _WIN32
-    s = (uint64_t)std::chrono::steady_clock::now()
-            .time_since_epoch()
-            .count();
+    s = (uint64_t)std::chrono::steady_clock::now().time_since_epoch().count();
 #elif defined(__SGX_ENABLED__)
     TORCH_CHECK(
         sgx_read_rand(reinterpret_cast<uint8_t*>(&s), sizeof(s)) == SGX_SUCCESS,

--- a/c10/core/GeneratorImpl.cpp
+++ b/c10/core/GeneratorImpl.cpp
@@ -91,7 +91,7 @@ uint64_t getNonDeterministicRandom(bool is_cuda) {
   uint64_t s = 0;
   if (!is_cuda) {
 #ifdef _WIN32
-    s = (uint64_t)std::chrono::high_resolution_clock::now()
+    s = (uint64_t)std::chrono::steady_clock::now()
             .time_since_epoch()
             .count();
 #elif defined(__SGX_ENABLED__)

--- a/c10/util/signal_handler.cpp
+++ b/c10/util/signal_handler.cpp
@@ -219,11 +219,10 @@ void FatalSignalHandler::fatalSignalHandler(int signum) {
       if (tid != currentTid) {
         signalReceived = false;
         syscall(SYS_tgkill, pid, tid, SIGUSR2);
-        auto now = std::chrono::system_clock::now();
         using namespace std::chrono_literals;
         // we use wait_until instead of wait because on ROCm there was
         // a single thread that wouldn't receive the SIGUSR2
-        if (std::cv_status::timeout == writingCond.wait_until(ul, now + 2s)) {
+        if (std::cv_status::timeout == writingCond.wait_for(ul, 2s)) {
           if (!signalReceived) {
             std::cerr << "signal lost waiting for stacktrace " << pid << ":"
                       << tid << '\n';

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -2525,15 +2525,16 @@ void ProcessGroupNCCL::runHookLoop() {
         // Hook might grab GIL, unlock first to prevent deadlock
         lock.unlock();
 
+        auto timeFinished = std::chrono::system_clock::now();
         auto timeStarted =
-            std::chrono::system_clock::now() +
-            std::chrono::duration_cast<std::chrono::system_clock::duration>(
+            timeFinished +
+            std::chrono::duration_cast<std::chrono::steady_clock::duration>(
                 work.workStartTime_ - std::chrono::steady_clock::now());
         onCompletionHook_(std::make_shared<WorkInfo>(
             work.retrieveOpType(), // OpType
             work.getSequencenumber(), // seq
             timeStarted, // timeStarted
-            std::chrono::system_clock::now(), // timeFinished
+            timeFinished, // timeFinished
             std::chrono::duration<float, std::milli>(
                 work.getDuration()) // activeDuration
             ));

--- a/torch/csrc/distributed/c10d/UCCTracing.cpp
+++ b/torch/csrc/distributed/c10d/UCCTracing.cpp
@@ -94,7 +94,7 @@ void CommTraceLogger::recordComms(
       (!outputTensors.empty()) ? outputTensors[0].scalar_type() : at::kByte;
   auto devType = (!outputTensors.empty()) ? outputTensors[0].device().type()
                                           : c10::DeviceType::CPU;
-  auto now = std::chrono::system_clock::now();
+  auto now = std::chrono::steady_clock::now();
   static auto startTS = now;
   int64_t time_since_begin =
       std::chrono::duration_cast<std::chrono::nanoseconds>(now - startTS)


### PR DESCRIPTION
This PR replaces most `std::chrono::system_clock` with `std::chrono::steady_clock` if the duration is used in condition variables. Ideally system clocks should be used only to log wall-clock times.

Some `high_resolution_clock` are also changed to `steady_clock` because its resolution is not required in the context.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168