### PR TITLE
[ROCm][Windows] Fix building torch 2.8 wheel with ROCm (added hipblasLt and rocblas directories)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -749,23 +749,22 @@ class build_ext(setuptools.command.build_ext.build_ext):
             self.copy_file(export_lib, target_lib)
 
             # In ROCm on Windows case copy rocblas and hipblaslt files into torch/lib/rocblas/library and torch/lib/hipblaslt/library
-            env_value = os.environ.get('ROCM_DIR')
-            if env_value:
-                rocm_bin_path = os.path.join(env_value, 'bin')
+            use_rocm = os.environ.get('USE_ROCM')
+            if use_rocm:
+                rocm_dir_path = os.environ.get('ROCM_DIR')
+                rocm_bin_path = os.path.join(rocm_dir_path, 'bin')
 
                 rocblas_dir = os.path.join(rocm_bin_path, 'rocblas')
                 target_rocblas_dir = os.path.join(target_dir, 'rocblas')
-                if not os.path.exists(target_rocblas_dir):
-                    os.makedirs(target_rocblas_dir)
+                os.makedirs(target_rocblas_dir, exist_ok=True)
                 self.copy_tree(rocblas_dir, target_rocblas_dir)
 
                 hipblaslt_dir = os.path.join(rocm_bin_path, 'hipblaslt')
                 target_hipblaslt_dir = os.path.join(target_dir, 'hipblaslt')
-                if not os.path.exists(target_hipblaslt_dir):
-                    os.makedirs(target_hipblaslt_dir)
+                os.makedirs(target_hipblaslt_dir, exist_ok=True)
                 self.copy_tree(hipblaslt_dir, target_hipblaslt_dir)
             else:
-                print("The specified environment variable does not exist.") 
+                report("The specified environment variable does not exist.") 
 
     def build_extensions(self):
         self.create_compile_commands()

--- a/setup.py
+++ b/setup.py
@@ -748,23 +748,24 @@ class build_ext(setuptools.command.build_ext.build_ext):
 
             self.copy_file(export_lib, target_lib)
 
-            # In ROCm on Windows case copy rocblas and hipblaslt files into torch/lib/rocblas/library and torch/lib/hipblaslt/library
-            use_rocm = os.environ.get('USE_ROCM')
+            # In ROCm on Windows case copy rocblas and hipblaslt files into
+            # torch/lib/rocblas/library and torch/lib/hipblaslt/library
+            use_rocm = os.environ.get("USE_ROCM")
             if use_rocm:
-                rocm_dir_path = os.environ.get('ROCM_DIR')
-                rocm_bin_path = os.path.join(rocm_dir_path, 'bin')
+                rocm_dir_path = os.environ.get("ROCM_DIR")
+                rocm_bin_path = os.path.join(rocm_dir_path, "bin")
 
-                rocblas_dir = os.path.join(rocm_bin_path, 'rocblas')
-                target_rocblas_dir = os.path.join(target_dir, 'rocblas')
+                rocblas_dir = os.path.join(rocm_bin_path, "rocblas")
+                target_rocblas_dir = os.path.join(target_dir, "rocblas")
                 os.makedirs(target_rocblas_dir, exist_ok=True)
                 self.copy_tree(rocblas_dir, target_rocblas_dir)
 
-                hipblaslt_dir = os.path.join(rocm_bin_path, 'hipblaslt')
-                target_hipblaslt_dir = os.path.join(target_dir, 'hipblaslt')
+                hipblaslt_dir = os.path.join(rocm_bin_path, "hipblaslt")
+                target_hipblaslt_dir = os.path.join(target_dir, "hipblaslt")
                 os.makedirs(target_hipblaslt_dir, exist_ok=True)
                 self.copy_tree(hipblaslt_dir, target_hipblaslt_dir)
             else:
-                report("The specified environment variable does not exist.") 
+                report("The specified environment variable does not exist.")
 
     def build_extensions(self):
         self.create_compile_commands()

--- a/setup.py
+++ b/setup.py
@@ -748,6 +748,25 @@ class build_ext(setuptools.command.build_ext.build_ext):
 
             self.copy_file(export_lib, target_lib)
 
+            # In ROCm on Windows case copy rocblas and hipblaslt files into torch/lib/rocblas/library and torch/lib/hipblaslt/library
+            env_value = os.environ.get('ROCM_DIR')
+            if env_value:
+                rocm_bin_path = os.path.join(env_value, 'bin')
+
+                rocblas_dir = os.path.join(rocm_bin_path, 'rocblas')
+                target_rocblas_dir = os.path.join(target_dir, 'rocblas')
+                if not os.path.exists(target_rocblas_dir):
+                    os.makedirs(target_rocblas_dir)
+                self.copy_tree(rocblas_dir, target_rocblas_dir)
+
+                hipblaslt_dir = os.path.join(rocm_bin_path, 'hipblaslt')
+                target_hipblaslt_dir = os.path.join(target_dir, 'hipblaslt')
+                if not os.path.exists(target_hipblaslt_dir):
+                    os.makedirs(target_hipblaslt_dir)
+                self.copy_tree(hipblaslt_dir, target_hipblaslt_dir)
+            else:
+                print("The specified environment variable does not exist.") 
+
     def build_extensions(self):
         self.create_compile_commands()
 


### PR DESCRIPTION
Since rocblas.dll and hipblaslt.dll are copied to torch/lib, rocblas and hipblaslt directories are needed to be stored there too (otherwise we have an error after wheel installation while searching for files in rocblas/library and hipblaslt/library which doesn't exist). This PR fixes this issue. 

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd