### PR TITLE
[Dynamo] Replace `unimplemented` with `unimplemented_v2` in `torch/_dynamo/variables/tensor.py`

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_compile.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_compile.py
@@ -551,7 +551,7 @@ Unsupported Tensor.backward() call
   Hint: This graph break is fundamental - it is unlikely that Dynamo will ever be able to trace through your code. Consider finding a workaround.
 
   Developer debug context: call_method TensorVariable() backward () {}
-""",
+""",  # noqa: B950
                     )
                 else:
                     self.assertGreater(len(counters["graph_break"]), 1)

--- a/test/distributed/_composable/fsdp/test_fully_shard_compile.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_compile.py
@@ -543,7 +543,16 @@ val.shape: {[node.meta['val'].shape for node in aliased_graph_inputs]},
                 )
                 if fwd_fullgraph:
                     self.assertEqual(len(counters["graph_break"]), 1)
-                    self.assertIn("Tensor.backward", counters["graph_break"])
+                    self.assertExpectedInline(
+                        next(iter(counters["graph_break"].keys())),
+                        """\
+Unsupported Tensor.backward() call
+  Explanation: Dynamo currently does not support tracing `Tensor.backward()`.
+  Hint: This graph break is fundamental - it is unlikely that Dynamo will ever be able to trace through your code. Consider finding a workaround.
+
+  Developer debug context: call_method TensorVariable() backward () {}
+""",
+                    )
                 else:
                     self.assertGreater(len(counters["graph_break"]), 1)
                 return res

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -96,7 +96,12 @@ from user code:
                 torch.Tensor([1])
             ),
             """\
-Tensor.item
+Unsupported Tensor.item() call with capture_scalar_outputs=False
+  Explanation: Dynamo does not support tracing `Tensor.item()` with config.capture_scalar_outputs=False.
+  Hint: Set `torch._dynamo.config.capture_scalar_outputs = True` or `export TORCHDYNAMO_CAPTURE_SCALAR_OUTPUTS=1` to include these operations in the captured graph.
+
+  Developer debug context: call_method TensorVariable() item () {}
+
 
 from user code:
    File "test_error_messages.py", line N, in fn

--- a/test/dynamo/test_reorder_logs.py
+++ b/test/dynamo/test_reorder_logs.py
@@ -202,7 +202,16 @@ class ReorderLogsTests(torch._dynamo.test_case.TestCase):
 
         graph_break_key = counters["graph_break"].keys()
         self.assertEqual(len(graph_break_key), 1)
-        self.assertEqual(next(iter(graph_break_key)), "Tensor.item")
+        self.assertExpectedInline(
+            next(iter(graph_break_key)),
+            """\
+Unsupported Tensor.item() call with capture_scalar_outputs=False
+  Explanation: Dynamo does not support tracing `Tensor.item()` with config.capture_scalar_outputs=False.
+  Hint: Set `torch._dynamo.config.capture_scalar_outputs = True` or `export TORCHDYNAMO_CAPTURE_SCALAR_OUTPUTS=1` to include these operations in the captured graph.
+
+  Developer debug context: call_method TensorVariable() item () {}
+""",  # noqa: B950
+        )
 
 
 if __name__ == "__main__":

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -703,7 +703,7 @@ class TensorVariable(VariableTracker):
                     gb_type="Unhandled args for method",
                     context=f"call_method {self} {name} {args} {kwargs}",
                     explanation="Dynamo encountered an error while calling "
-                    f"the method `method_{name}`.",
+                    f"the method `{name}`.",
                     hints=[*graph_break_hints.SUPPORTABLE],
                     from_exc=e,
                 )

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -524,7 +524,7 @@ class TensorVariable(VariableTracker):
             raise NotImplementedError
         return result
 
-    def call_id(self, tx: "InstructionTranslator"):
+    def call_id(self, tx):
         if not self.source:
             unimplemented_v2(
                 gb_type="Unsupported call_id() without source",

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1324,7 +1324,8 @@ class TensorVariable(VariableTracker):
             unimplemented_v2(
                 gb_type="Unsupported Tensor.requires_grad_() call",
                 context=f"call_method {self} requires_grad_",
-                explanation="",
+                explanation="Dynamo does not support changes to a Tensor's "
+                "`requires_grad` through calling `requires_grad_()`.",
                 hints=[],
             )
         else:

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -702,7 +702,7 @@ class TensorVariable(VariableTracker):
                 unimplemented_v2(
                     gb_type="Unhandled args for method",
                     context=f"call_method {self} {name} {args} {kwargs}",
-                    explanation="Dynamo encountered an error while calllling "
+                    explanation="Dynamo encountered an error while calling "
                     f"the method `method_{name}`.",
                     hints=[*graph_break_hints.SUPPORTABLE],
                     from_exc=e,

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -379,7 +379,7 @@ class TensorVariable(VariableTracker):
             gb_type="Tensor.retain_grad() with AOTDispatcher",
             context=f"var_getattr {self} retain_grad",
             explanation="`Tensor.retain_grad()` does not work with AOTDispatcher.",
-            hints=[*graph_break_hints.SUPPORTABLE],
+            hints=[],
         )
 
     def method_attr_data(self, tx):
@@ -393,7 +393,7 @@ class TensorVariable(VariableTracker):
                 gb_type="Tensor with grad_fn()",
                 context=f"var_getattr {self} grad_fn",
                 explanation="Dynamo does not support tracing tensors with a grad_fn directly.",
-                hints=[*graph_break_hints.SUPPORTABLE],
+                hints=[],
             )
         else:
             return variables.ConstantVariable(None)
@@ -443,7 +443,6 @@ class TensorVariable(VariableTracker):
                     hints=[
                         f"Remove `{name}` from the list of banned ops by "
                         "setting `torch._dynamo.config._autograd_backward_strict_mode_banned_ops`.",
-                        *graph_break_hints.SUPPORTABLE,
                     ],
                 )
             elif name in self._strict_mode_conditional_banned_ops():
@@ -630,7 +629,7 @@ class TensorVariable(VariableTracker):
                 context=f"call_method {self} {name} {args} {kwargs}",
                 explanation="Dynamo currently does not support this method "
                 f"({name}) invocation in strict mode.",
-                hints=[*graph_break_hints.SUPPORTABLE],
+                hints=[],
             )
 
         # Only override builtin tensor methods
@@ -704,7 +703,7 @@ class TensorVariable(VariableTracker):
                     context=f"call_method {self} {name} {args} {kwargs}",
                     explanation="Dynamo encountered an error while calling "
                     f"the method `{name}`.",
-                    hints=[*graph_break_hints.SUPPORTABLE],
+                    hints=[],
                     from_exc=e,
                 )
 
@@ -1104,7 +1103,7 @@ class TensorVariable(VariableTracker):
             gb_type="Unsupported Tensor.resize_() call",
             context=f"call_method {self} resize_ {args} {kwargs}",
             explanation="Dynamo currently does not support tracing `Tensor.resize_()`.",
-            hints=[*graph_break_hints.SUPPORTABLE],
+            hints=[],
         )
 
     def method_resize_as_(self, *args, **kwargs):
@@ -1112,7 +1111,7 @@ class TensorVariable(VariableTracker):
             gb_type="Unsupported Tensor.resize_as_() call",
             context=f"call_method {self} resize_as_ {args} {kwargs}",
             explanation="Dynamo currently does not support tracing `Tensor.resize_as_()`.",
-            hints=[*graph_break_hints.SUPPORTABLE],
+            hints=[],
         )
 
     def method_sparse_resize_(self, *args, **kwargs):
@@ -1120,7 +1119,7 @@ class TensorVariable(VariableTracker):
             gb_type="Unsupported Tensor.sparse_resize_() call",
             context=f"call_method {self} sparse_resize_ {args} {kwargs}",
             explanation="Dynamo currently does not support tracing `Tensor.sparse_resize_()`.",
-            hints=[*graph_break_hints.SUPPORTABLE],
+            hints=[],
         )
 
     def method_sparse_resize_and_clear_(self, *args, **kwargs):
@@ -1128,7 +1127,7 @@ class TensorVariable(VariableTracker):
             gb_type="Unsupported Tensor.sparse_resize_and_clear_() call",
             context=f"call_method {self} sparse_resize_and_clear_ {args} {kwargs}",
             explanation="Dynamo currently does not support tracing `Tensor.sparse_resize_and_clear_()`.",
-            hints=[*graph_break_hints.SUPPORTABLE],
+            hints=[],
         )
 
     def method_set_(self, *args, **kwargs):
@@ -1275,7 +1274,7 @@ class TensorVariable(VariableTracker):
                     gb_type="Compilation of intermediate hooks requires compiled autograd",
                     context=f"var_getattr {self} {name}",
                     explanation="Dynamo must be in compiled_autograd to register hooks.",
-                    hints=[*graph_break_hints.SUPPORTABLE],
+                    hints=[],
                 )
 
             hook_name, bw_state_proxy = tx.output.add_backward_state_hook(hook)
@@ -1517,14 +1516,14 @@ class NumpyNdarrayVariable(TensorVariable):
                 gb_type="Unsupported ndarray attribute access",
                 context=f"var_getattr {self} {name}",
                 explanation=f"Dynamo currently does not support tracing `ndarray.{name}`.",
-                hints=[*graph_break_hints.SUPPORTABLE],
+                hints=[],
             )
         elif name in ["__version__"]:
             unimplemented_v2(
                 gb_type="Unsupported ndarray.__version__ access",
                 context=f"var_getattr {self} {name}",
                 explanation=f"Dynamo currently does not support tracing `ndarray.{name}`.",
-                hints=[*graph_break_hints.SUPPORTABLE],
+                hints=[],
             )
         if result is None:
             raise NotImplementedError
@@ -1556,7 +1555,7 @@ class NumpyNdarrayVariable(TensorVariable):
                 gb_type="Unsupported ndarray method call",
                 context=f"call_method {self} {name} {args} {kwargs}",
                 explanation=f"`ndarray.{name}()` is not modelled in `torch._numpy`.",
-                hints=[*graph_break_hints.SUPPORTABLE],
+                hints=[],
             )
         proxy = tx.output.create_proxy(
             "call_function",

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -441,7 +441,8 @@ class TensorVariable(VariableTracker):
                     context=f"var_getattr {self} {name}",
                     explanation=f"Getattr invocation '{name}' in strict mode is not supported.",
                     hints=[
-                        "This operation is banned in strict mode due to potential issues with autograd.",
+                        f"Remove `{name}` from the list of banned ops by "
+                        "setting `torch._dynamo.config._autograd_backward_strict_mode_banned_ops`.",
                         *graph_break_hints.SUPPORTABLE,
                     ],
                 )

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -992,7 +992,7 @@ class TensorVariable(VariableTracker):
             gb_type="Unsupported Tensor.backward() call",
             context=f"call_method {self} backward {args} {kwargs}",
             explanation="Dynamo currently does not support tracing `Tensor.backward()`.",
-            hints=[*graph_break_hints.SUPPORTABLE],
+            hints=[*graph_break_hints.FUNDAMENTAL],
         )
 
     def method_data_ptr(self, *args, **kwargs):

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -45,7 +45,6 @@ from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 from .. import config, graph_break_hints, variables
 from .._trace_wrapped_higher_order_op import trace_wrapped
 from ..exc import (
-    unimplemented,
     unimplemented_v2,
     UnknownPropertiesDuringBackwardTrace,
     UserError,
@@ -376,7 +375,12 @@ class TensorVariable(VariableTracker):
             return ConstantVariable.create(self.is_nested)
 
     def method_attr_retain_grad(self, tx):
-        unimplemented("retain_grad does not work with AOTDispatcher")
+        unimplemented_v2(
+            gb_type="Tensor.retain_grad() with AOTDispatcher",
+            context=f"var_getattr {self} retain_grad",
+            explanation="`Tensor.retain_grad()` does not work with AOTDispatcher.",
+            hints=[*graph_break_hints.SUPPORTABLE],
+        )
 
     def method_attr_data(self, tx):
         return variables.TorchInGraphFunctionVariable(
@@ -385,7 +389,12 @@ class TensorVariable(VariableTracker):
 
     def method_attr_grad_fn(self, tx):
         if self.has_grad_fn:
-            unimplemented("TensorVariable has a grad_fn")
+            unimplemented_v2(
+                gb_type="Tensor with grad_fn()",
+                context=f"var_getattr {self} grad_fn",
+                explanation="Dynamo does not support tracing tensors with a grad_fn directly.",
+                hints=[*graph_break_hints.SUPPORTABLE],
+            )
         else:
             return variables.ConstantVariable(None)
 
@@ -427,8 +436,14 @@ class TensorVariable(VariableTracker):
     def var_getattr(self, tx: "InstructionTranslator", name):
         if self.is_strict_mode(tx):
             if name in self._strict_mode_banned_ops():
-                unimplemented(
-                    f"Getattr invocation {name} in strict mode is not supported"
+                unimplemented_v2(
+                    gb_type="Strict mode banned op",
+                    context=f"var_getattr {self} {name}",
+                    explanation=f"Getattr invocation '{name}' in strict mode is not supported.",
+                    hints=[
+                        "This operation is banned in strict mode due to potential issues with autograd.",
+                        *graph_break_hints.SUPPORTABLE,
+                    ],
                 )
             elif name in self._strict_mode_conditional_banned_ops():
                 raise UnknownPropertiesDuringBackwardTrace(
@@ -509,19 +524,36 @@ class TensorVariable(VariableTracker):
             raise NotImplementedError
         return result
 
-    def call_id(self, tx):
+    def call_id(self, tx: "InstructionTranslator"):
         if not self.source:
-            unimplemented("call_id not supported for sourceless TensorVariable")
+            unimplemented_v2(
+                gb_type="Unsupported call_id() without source",
+                context=f"call_id {self}",
+                explanation="call_id() not supported for sourceless TensorVariable.",
+                hints=[],
+            )
 
         # For local source, we associate the real value. We use this real value
         scope = {"L": tx.output.local_scope, "G": tx.output.global_scope}
         try:
             _input_associated_real_value = eval(self.source.name(), scope)
         except Exception as exc:
-            unimplemented(f"error getting associated real value: {exc}")
+            unimplemented_v2(
+                gb_type="Error getting associated real value",
+                context=f"call_id {self}",
+                explanation="Dynamo encountered an error while trying to "
+                "get the associated real value.",
+                hints=[],
+                from_exc=exc,
+            )
 
         if _input_associated_real_value is None:
-            unimplemented("call_id without associated real value")
+            unimplemented_v2(
+                gb_type="call_id() without associated real value",
+                context=f"call_id {self}",
+                explanation="Dynamo could not find an associated real value for the tensor.",
+                hints=[],
+            )
 
         install_guard(self.source.make_guard(GuardBuilder.ID_MATCH))
         id_value = id(_input_associated_real_value)
@@ -592,7 +624,13 @@ class TensorVariable(VariableTracker):
         from .torch_function import can_dispatch_torch_function, dispatch_torch_function
 
         if self.is_strict_mode(tx) and name in self._strict_mode_banned_ops():
-            unimplemented(f"Illegal method invocation {name} in strict mode")
+            unimplemented_v2(
+                gb_type="Illegal method invocation in strict mode",
+                context=f"call_method {self} {name} {args} {kwargs}",
+                explanation="Dynamo currently does not support this method "
+                f"({name}) invocation in strict mode.",
+                hints=[*graph_break_hints.SUPPORTABLE],
+            )
 
         # Only override builtin tensor methods
         # The user can manually add override handling
@@ -660,7 +698,14 @@ class TensorVariable(VariableTracker):
                 if result:
                     return result
             except TypeError as e:
-                unimplemented(f"unhandled args for {name}: {e}")
+                unimplemented_v2(
+                    gb_type="Unhandled args for method",
+                    context=f"call_method {self} {name} {args} {kwargs}",
+                    explanation="Dynamo encountered an error while calllling "
+                    f"the method `method_{name}`.",
+                    hints=[*graph_break_hints.SUPPORTABLE],
+                    from_exc=e,
+                )
 
         from .builder import wrap_fx_proxy
 
@@ -850,9 +895,26 @@ class TensorVariable(VariableTracker):
 
     def method_numpy(self, *, force=False):
         if not config.trace_numpy:
-            unimplemented("Tensor.numpy(). config.trace_numpy is False")
+            unimplemented_v2(
+                gb_type="Tensor.numpy() with trace_numpy=False",
+                context=f"call_method {self} numpy",
+                explanation="`Tensor.numpy()` was called, but the `trace_numpy` "
+                "configuration was manually disabled.",
+                hints=[
+                    "Set `torch._dynamo.config.trace_numpy = True` to allow "
+                    "Dynamo to trace through NumPy.",
+                ],
+            )
         if not np:
-            unimplemented("Tensor.numpy(). NumPy is not available")
+            unimplemented_v2(
+                gb_type="Tensor.numpy() without NumPy installed",
+                context=f"call_method {self} numpy",
+                explanation="`Tensor.numpy()` was called, but the NumPy library "
+                "is not available in the current environment.",
+                hints=[
+                    "Ensure NumPy is installed in your Python environment.",
+                ],
+            )
         if self.layout != torch.strided:
             raise TypeError(
                 f"can't convert {self.layout} layout tensor to numpy. Use Tensor.to_dense() first"
@@ -898,7 +960,16 @@ class TensorVariable(VariableTracker):
                 torch.int32,
                 torch.int64,
             ]:
-                unimplemented("Input tensor for tolist must be an integer tensor")
+                unimplemented_v2(
+                    gb_type="Tensor.tolist() with non-integer tensor",
+                    context=f"call_method {self} to_list",
+                    explanation="Dynamo currently does not support tracing "
+                    "`tolist()` on non-integer tensors.",
+                    hints=[
+                        "Ensure the input tensor to `tolist()` is an integer "
+                        "type (e.g., int8, int16, int32, int64)."
+                    ],
+                )
 
             if tensor.dim() == 0:
                 return wrap(tensor, sub_proxy)
@@ -916,7 +987,12 @@ class TensorVariable(VariableTracker):
         return VariableTracker.build(tx, out)
 
     def method_backward(self, *args, **kwargs):
-        unimplemented("Tensor.backward")
+        unimplemented_v2(
+            gb_type="Unsupported Tensor.backward() call",
+            context=f"call_method {self} backward {args} {kwargs}",
+            explanation="Dynamo currently does not support tracing `Tensor.backward()`.",
+            hints=[*graph_break_hints.SUPPORTABLE],
+        )
 
     def method_data_ptr(self, *args, **kwargs):
         return DataPtrVariable(self)
@@ -924,7 +1000,17 @@ class TensorVariable(VariableTracker):
     def method_item(self, *args, **kwargs):
         if not config.capture_scalar_outputs:
             self._warn_capture_scalar_outputs()
-            unimplemented("Tensor.item")
+            unimplemented_v2(
+                gb_type="Unsupported Tensor.item() call with capture_scalar_outputs=False",
+                context=f"call_method {self} item {args} {kwargs}",
+                explanation="Dynamo does not support tracing `Tensor.item()` "
+                "with config.capture_scalar_outputs=False.",
+                hints=[
+                    "Set `torch._dynamo.config.capture_scalar_outputs = True` "
+                    "or `export TORCHDYNAMO_CAPTURE_SCALAR_OUTPUTS=1` "
+                    "to include these operations in the captured graph.",
+                ],
+            )
 
     def method___getitem__(self, *args, **kwargs):
         from ..symbolic_convert import InstructionTranslator
@@ -1013,16 +1099,36 @@ class TensorVariable(VariableTracker):
         return ConstantVariable.create(None)
 
     def method_resize_(self, *args, **kwargs):
-        unimplemented("Tensor.resize_")
+        unimplemented_v2(
+            gb_type="Unsupported Tensor.resize_() call",
+            context=f"call_method {self} resize_ {args} {kwargs}",
+            explanation="Dynamo currently does not support tracing `Tensor.resize_()`.",
+            hints=[*graph_break_hints.SUPPORTABLE],
+        )
 
     def method_resize_as_(self, *args, **kwargs):
-        unimplemented("Tensor.resize_as_")
+        unimplemented_v2(
+            gb_type="Unsupported Tensor.resize_as_() call",
+            context=f"call_method {self} resize_as_ {args} {kwargs}",
+            explanation="Dynamo currently does not support tracing `Tensor.resize_as_()`.",
+            hints=[*graph_break_hints.SUPPORTABLE],
+        )
 
     def method_sparse_resize_(self, *args, **kwargs):
-        unimplemented("Tensor.sparse_resize_")
+        unimplemented_v2(
+            gb_type="Unsupported Tensor.sparse_resize_() call",
+            context=f"call_method {self} sparse_resize_ {args} {kwargs}",
+            explanation="Dynamo currently does not support tracing `Tensor.sparse_resize_()`.",
+            hints=[*graph_break_hints.SUPPORTABLE],
+        )
 
     def method_sparse_resize_and_clear_(self, *args, **kwargs):
-        unimplemented("Tensor.sparse_resize_and_clear_")
+        unimplemented_v2(
+            gb_type="Unsupported Tensor.sparse_resize_and_clear_() call",
+            context=f"call_method {self} sparse_resize_and_clear_ {args} {kwargs}",
+            explanation="Dynamo currently does not support tracing `Tensor.sparse_resize_and_clear_()`.",
+            hints=[*graph_break_hints.SUPPORTABLE],
+        )
 
     def method_set_(self, *args, **kwargs):
         if len(args) > 1:
@@ -1032,7 +1138,13 @@ class TensorVariable(VariableTracker):
             # overload and is used by FSDP.
             # graph-breaking on aten::set_source_Tensor_storage_offset for now,
             # unless we find that we need to make it work.
-            unimplemented("Tensor.set_.source_Tensor_storage_offset")
+            unimplemented_v2(
+                gb_type="Unsupported Tensor.set_() call",
+                context=f"call_method {self} set_ {args} {kwargs}",
+                explanation="Dynamo currently does not support tracing `Tensor.set_()` "
+                "overloads that include more than one argument.",
+                hints=[*graph_break_hints.SUPPORTABLE],
+            )
 
     def method_add_(self, other, *, alpha=None):
         if alpha is not None:
@@ -1158,8 +1270,11 @@ class TensorVariable(VariableTracker):
                 # would have no recourse - their forward traces just fine, but will fail at backwards unless
                 # compiled_autograd is enabled. If compiled_autograd fails (there are a lot of failures today)
                 # then they have nothing they can do except disable compile.
-                unimplemented(
-                    "Compilation of intermediate hooks requires compiled autograd"
+                unimplemented_v2(
+                    gb_type="Compilation of intermediate hooks requires compiled autograd",
+                    context=f"var_getattr {self} {name}",
+                    explanation="Dynamo must be in compiled_autograd to register hooks.",
+                    hints=[*graph_break_hints.SUPPORTABLE],
                 )
 
             hook_name, bw_state_proxy = tx.output.add_backward_state_hook(hook)
@@ -1205,7 +1320,12 @@ class TensorVariable(VariableTracker):
             requires_grad = requires_grad.as_python_constant()
 
         if self.as_proxy().node.meta["example_value"].requires_grad != requires_grad:
-            unimplemented("Tensor.requires_grad_")
+            unimplemented_v2(
+                gb_type="Unsupported Tensor.requires_grad_() call",
+                context=f"call_method {self} requires_grad_",
+                explanation="",
+                hints=[],
+            )
         else:
             return self
 
@@ -1391,9 +1511,19 @@ class NumpyNdarrayVariable(TensorVariable):
                 return ConstantVariable.create(int(r))
             return insert_into_graph()
         elif name in ["base", "flags", "dtype"]:
-            unimplemented(f"TODO: add support for ndarray.{name}")
+            unimplemented_v2(
+                gb_type="Unsupported ndarray attribute access",
+                context=f"var_getattr {self} {name}",
+                explanation=f"Dynamo currently does not support tracing `ndarray.{name}`.",
+                hints=[*graph_break_hints.SUPPORTABLE],
+            )
         elif name in ["__version__"]:
-            unimplemented("delegate np.__version__ to NumPy")
+            unimplemented_v2(
+                gb_type="Unsupported ndarray.__version__ access",
+                context=f"var_getattr {self} {name}",
+                explanation=f"Dynamo currently does not support tracing `ndarray.{name}`.",
+                hints=[*graph_break_hints.SUPPORTABLE],
+            )
         if result is None:
             raise NotImplementedError
         return result
@@ -1420,7 +1550,12 @@ class NumpyNdarrayVariable(TensorVariable):
             # delegate back to TensorVariable
             return super().call_method(tx, name, args, kwargs)
         if name in ("tostring", "tobytes", "__delattr__"):
-            unimplemented(f"{name} is not modelled in torch._numpy")
+            unimplemented_v2(
+                gb_type="Unsupported ndarray method call",
+                context=f"call_method {self} {name} {args} {kwargs}",
+                explanation=f"`ndarray.{name}()` is not modelled in `torch._numpy`.",
+                hints=[*graph_break_hints.SUPPORTABLE],
+            )
         proxy = tx.output.create_proxy(
             "call_function",
             numpy_method_wrapper(name),


### PR DESCRIPTION
Part of #147913 

Replace `unimplemented` with`unimplemented_v2` in `torch/_dynamo/variables/tensor.py`


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames