### PR TITLE
[nativert] Improve MPMCQueue tests.

### DIFF
--- a/test/cpp/nativert/CMakeLists.txt
+++ b/test/cpp/nativert/CMakeLists.txt
@@ -1,9 +1,10 @@
 set(NATIVERT_TEST_ROOT ${TORCH_ROOT}/test/cpp/nativert)
 
+file(GLOB_RECURSE NATIVERT_ALL_TEST_FILES "${NATIVERT_TEST_ROOT}/test_*.cpp")
+
 # Build the cpp gtest binary containing the cpp-only tests.
 set(NATIVERT_TEST_SRCS
-  ${NATIVERT_TEST_ROOT}/test_tensor_meta.cpp
-  ${NATIVERT_TEST_ROOT}/test_mpmc_queue.cpp
+  ${NATIVERT_ALL_TEST_FILES}
   ${TORCH_ROOT}/torch/nativert/graph/TensorMeta.cpp
 )
 

--- a/test/cpp/nativert/test_mpmc_queue.cpp
+++ b/test/cpp/nativert/test_mpmc_queue.cpp
@@ -53,6 +53,10 @@ TEST(MPMCQueueTest, ConcurrentAccess) {
       int out = 0;
       while (!queue.readIfNotEmpty(out)) {
         // Wait until an element is available
+        // TODO We could provide a blocking version of read() instead of
+        // looping here. We only provide a non blocking wait API because
+        // for now the queue is paired with a semaphore in executor.
+        std::this_thread::yield();
       }
       EXPECT_LT(out, 5);
     }
@@ -76,6 +80,10 @@ TEST(MPMCQueueTest, MPMCConcurrentAccess) {
         size_t value = i * numElementsPerWriter + j;
         while (!queue.writeIfNotFull(static_cast<int>(value))) {
           // Retry until the queue has space
+          // TODO We could provide a blocking version of read() instead of
+          // looping here. We only provide a non blocking wait API because
+          // for now the queue is paired with a semaphore in executor.
+          std::this_thread::yield();
         }
       }
     });
@@ -90,6 +98,11 @@ TEST(MPMCQueueTest, MPMCConcurrentAccess) {
       while (totalReadCount < numWriters * numElementsPerWriter) {
         if (queue.readIfNotEmpty(value)) {
           ++totalReadCount;
+        } else {
+          // TODO We could provide a blocking version of read() instead of
+          // looping here. We only provide a non blocking wait API because
+          // for now the queue is paired with a semaphore in executor.
+          std::this_thread::yield();
         }
       }
     });


### PR DESCRIPTION
Summary:
- Use std::this_thread::yield and stop busy wating.
- Sort test file orders.

Following up @swolchok's comment from https://github.com/pytorch/pytorch/pull/152837
Test Plan: CI

Differential Revision: D74402536


