### PR TITLE
Skip lintchecks for now

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -283,15 +283,6 @@ jobs:
           # All we need to see is that it passes
           python3 torch/utils/collect_env.py
 
-  link-check:
-    name: Link checks
-    needs: get-label-type
-    uses: ./.github/workflows/_link_check.yml
-    with:
-      runner: ${{ needs.get-label-type.outputs.label-type }}
-      ref:    ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-    secrets: inherit
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true


### PR DESCRIPTION
As devs has been complaining it's failing. Completely remove them from lint.yml as https://github.com/pytorch/pytorch/pull/153157 moved it to nightly

See https://github.com/pytorch/pytorch/issues/152439  as well as https://github.com/pytorch/pytorch/issues/152884 and https://github.com/pytorch/pytorch/issues/152489 for more details


Was introduced in https://github.com/pytorch/pytorch/pull/152377 