### PR TITLE
[nativert] Address tooling setup for torch/nativert/

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -84,6 +84,8 @@ include_patterns = [
     'torch/csrc/**/*.h',
     'torch/csrc/**/*.hpp',
     'torch/csrc/**/*.cpp',
+    'torch/nativert/**/*.h',
+    'torch/nativert/**/*.cpp',
     'test/cpp/**/*.h',
     'test/cpp/**/*.cpp',
 ]
@@ -232,6 +234,10 @@ include_patterns = [
     'torch/csrc/**/*.cpp',
     'torch/csrc/jit/serialization/*.h',
     'torch/csrc/jit/serialization/*.cpp',
+    'torch/nativert/*.h',
+    'torch/nativert/*.cpp',
+    'torch/nativert/**/*.h',
+    'torch/nativert/**/*.cpp',
 ]
 exclude_patterns = [
     # The negative filters below are to exclude files that include onnx_pb.h or
@@ -533,6 +539,7 @@ include_patterns = [
     'c10/**',
     'aten/**',
     'torch/csrc/**',
+    'torch/nativert/**',
 ]
 exclude_patterns = [
     'aten/src/ATen/native/quantized/cpu/qnnpack/**',
@@ -760,6 +767,7 @@ include_patterns = [
     'aten/**',
     'c10/**',
     'torch/csrc/**',
+    'torch/nativert/**',
 ]
 exclude_patterns = [
     'aten/src/ATen/cuda/CUDAContext.cpp',
@@ -1014,6 +1022,7 @@ include_patterns = [
     'c10/**',
     'aten/**',
     'torch/csrc/**',
+    'torch/nativert/**',
 ]
 exclude_patterns = [
     'c10/util/CallOnce.h',
@@ -1058,6 +1067,7 @@ include_patterns = [
     'c10/**',
     'aten/**',
     'torch/csrc/**',
+    'torch/nativert/**',
 ]
 exclude_patterns = [
     '**/fb/**',

--- a/torch/nativert/graph/TensorMeta.cpp
+++ b/torch/nativert/graph/TensorMeta.cpp
@@ -92,17 +92,16 @@ c10::Layout convertJsonLayout(const torch::_export::Layout& layout) {
 c10::Device convertJsonDevice(const torch::_export::Device& device) {
   c10::Device d(device.get_type());
   if (auto index = device.get_index()) {
-    d.set_index(*index);
+    d.set_index(static_cast<at::DeviceIndex>(*index));
   }
   return d;
 }
 
 TensorMeta::TensorMeta(const torch::_export::TensorMeta& tensorMeta)
-    : device_(convertJsonDevice(tensorMeta.get_device())) {
-  dtype_ = convertJsonScalarType(tensorMeta.get_dtype());
-  layout_ = convertJsonLayout(tensorMeta.get_layout());
-  requiresGrad_ = tensorMeta.get_requires_grad();
-
+    : dtype_(convertJsonScalarType(tensorMeta.get_dtype())),
+      layout_(convertJsonLayout(tensorMeta.get_layout())),
+      requiresGrad_(tensorMeta.get_requires_grad()),
+      device_(convertJsonDevice(tensorMeta.get_device())) {
   if (tensorMeta.get_storage_offset().tag() ==
       torch::_export::SymInt::Tag::AS_INT) {
     storage_offset_ = tensorMeta.get_storage_offset().get_as_int();

--- a/torch/nativert/graph/TensorMeta.h
+++ b/torch/nativert/graph/TensorMeta.h
@@ -3,10 +3,10 @@
 #include <c10/core/Device.h>
 #include <c10/util/Logging.h>
 
+#include <c10/core/Layout.h>
 #include <c10/core/MemoryFormat.h>
 #include <c10/core/ScalarType.h>
 #include <c10/core/TensorOptions.h>
-#include "c10/core/Layout.h"
 #include <c10/util/ArrayRef.h>
 
 #include <torch/csrc/utils/generated_serialization_types.h>


### PR DESCRIPTION
Summary:
As discussed with @malfet , we're porting nativert code to torch/nativert/.
Following up some concerns over the new directory, I'm trying to setup the tooling on OSS so various things (like linters) can run on torch/nativert/ properly.

Test Plan: CI

Differential Revision: D74407808


