### PR TITLE
Don't print hinted expression if statically known.

### DIFF
--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -6171,8 +6171,13 @@ class ShapeEnv:
             )
         else:
             desc = "Could not guard on data-dependent expression"
+        if len(expr.free_symbols) == 0:
+            expr = unhinted_expr
+            maybe_unhinted_expr_str = ""
+        else:
+            maybe_unhinted_expr_str = f" (unhinted: {unhinted_expr})"
         msg = (
-            f"{desc} {expr} (unhinted: {unhinted_expr}).  "
+            f"{desc} {expr}{maybe_unhinted_expr_str}.  "
             f"(Size-like symbols: {', '.join(map(str, size_like_symbols)) or 'none'})\n\n"
             f"{size_oblivious_result_msg}"
             f"Caused by: {sloc}\n"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #153173

Fix: #151491 

This PR avoids printing the hinted expression in a data-dependent error if the hinted expression is, in fact, statically known. See the example below:

```python
class Foo(torch.nn.Module):
    def forward(self, a, b):
        u0 = a.item()
        y = torch.zeros(u0, 18, b.shape[0])
        return y.view(-1, 144)

ep = export(
    Foo(),
    (torch.tensor([6]), torch.randn(8)),
    dynamic_shapes={
        "a": None,
        "b": (Dim.DYNAMIC,),
    },
)
```

**Previously:**
```
torch.fx.experimental.symbolic_shapes.GuardOnDataDependentSymNode: Could not guard on data-dependent expression False (unhinted: Ne(Mod(18*s58*u0, ((s58*u0)//8)), 0)).  (Size-like symbols: none)

Caused by: (_refs/__init__.py:3838 in <lambda>)
For more information, run with TORCH_LOGS="dynamic"
For extended logs when we create symbols, also add TORCHDYNAMO_EXTENDED_DEBUG_CREATE_SYMBOL=""
If you suspect the guard was triggered from C++, add TORCHDYNAMO_EXTENDED_DEBUG_CPP=1
For more debugging help, see https://docs.google.com/document/d/1HSuTTVvYH1pTew89Rtpeu84Ht3nQEFTYhAX3Ypa_xJs/edit?usp=sharing

For C++ stack trace, run with TORCHDYNAMO_EXTENDED_DEBUG_CPP=1

The following call raised this error:
  File "/home/ysiraichi/work/pytorch/1/../examples/issue-151491.py", line 10, in forward
    return y.view(-1, 144)

To fix the error, insert one of the following checks before this call:
  1. torch._check(False)
  2. torch._check(True)
```

**This PR:**
```
torch.fx.experimental.symbolic_shapes.GuardOnDataDependentSymNode: Could not guard on data-dependent expression Ne(Mod(18*s58*u0, ((s58*u0)//8)), 0).  (Size-like symbols: none)

Caused by: (_refs/__init__.py:3838 in <lambda>)
For more information, run with TORCH_LOGS="dynamic"
For extended logs when we create symbols, also add TORCHDYNAMO_EXTENDED_DEBUG_CREATE_SYMBOL="s58,u0"
If you suspect the guard was triggered from C++, add TORCHDYNAMO_EXTENDED_DEBUG_CPP=1
For more debugging help, see https://docs.google.com/document/d/1HSuTTVvYH1pTew89Rtpeu84Ht3nQEFTYhAX3Ypa_xJs/edit?usp=sharing

For C++ stack trace, run with TORCHDYNAMO_EXTENDED_DEBUG_CPP=1

The following call raised this error:
  File "/home/ysiraichi/work/pytorch/1/../examples/issue-151491.py", line 10, in forward
    return y.view(-1, 144)

To fix the error, insert one of the following checks before this call:
  1. torch._check(((18*u0*b.shape[0]) % ((u0*b.shape[0]) // 8)) != 0)
  2. torch._check(((18*u0*b.shape[0]) % ((u0*b.shape[0]) // 8)) == 0)
```

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv