### PR TITLE
[ONNX] Support sym_float

### DIFF
--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -586,6 +586,21 @@ class DynamoExporterTest(common_utils.TestCase):
             [node.op_type for node in onnx_program.model.graph],
         )
 
+    def test_export_sym_float(self):
+        class SymNotModel(torch.nn.Module):
+            def forward(self, x):
+                a = x.shape[0]
+                return torch.sym_float(a)
+
+        inputs = (torch.zeros((2, 2)),)
+        dynamic_shapes = ({0: torch.export.Dim.DYNAMIC, 1: torch.export.Dim.DYNAMIC},)
+        onnx_program = self.export(SymNotModel(), inputs, dynamic_shapes=dynamic_shapes)
+        onnx_testing.assert_onnx_program(onnx_program, args=inputs)
+        self.assertIn(
+            "Cast",
+            [node.op_type for node in onnx_program.model.graph],
+        )
+
     def test_group_norm_opset_21(self):
         class Model(torch.nn.Module):
             def forward(self, x):

--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -594,7 +594,9 @@ class DynamoExporterTest(common_utils.TestCase):
 
         inputs = (torch.zeros((2, 2)),)
         dynamic_shapes = ({0: torch.export.Dim.DYNAMIC, 1: torch.export.Dim.DYNAMIC},)
-        onnx_program = self.export(SymNotModel(), inputs, dynamic_shapes=dynamic_shapes)
+        onnx_program = self.export(
+            SymFloatModel(), inputs, dynamic_shapes=dynamic_shapes
+        )
         onnx_testing.assert_onnx_program(onnx_program, args=inputs)
         self.assertIn(
             "Cast",

--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -587,7 +587,7 @@ class DynamoExporterTest(common_utils.TestCase):
         )
 
     def test_export_sym_float(self):
-        class SymNotModel(torch.nn.Module):
+        class SymFloatModel(torch.nn.Module):
             def forward(self, x):
                 a = x.shape[0]
                 return torch.sym_float(a)

--- a/torch/onnx/_internal/exporter/_torchlib/_tensor_typing.py
+++ b/torch/onnx/_internal/exporter/_torchlib/_tensor_typing.py
@@ -29,7 +29,7 @@ from onnxscript import (
 # NOTE: We do not care about unsigned types beyond UINT8 because PyTorch does not us them.
 # More detail can be found: https://pytorch.org/docs/stable/tensors.html
 
-_TensorType = Union[
+TensorType = Union[
     BFLOAT16,
     BOOL,
     COMPLEX64,
@@ -43,7 +43,7 @@ _TensorType = Union[
     INT64,
     UINT8,
 ]
-FloatType = Union[FLOAT16, FLOAT, DOUBLE, BFLOAT16]
+_FloatType = Union[FLOAT16, FLOAT, DOUBLE, BFLOAT16]
 IntType = Union[INT8, INT16, INT32, INT64]
 RealType = Union[
     BFLOAT16,
@@ -56,12 +56,12 @@ RealType = Union[
     INT64,
 ]
 
-TTensor = TypeVar("TTensor", bound=_TensorType)
+TTensor = TypeVar("TTensor", bound=TensorType)
 # Duplicate TTensor for inputs/outputs that accept the same set of types as TTensor
 # but do not constrain the type to be the same as the other inputs/outputs
-TTensor2 = TypeVar("TTensor2", bound=_TensorType)
-TTensorOrString = TypeVar("TTensorOrString", bound=Union[_TensorType, STRING])
-TFloat = TypeVar("TFloat", bound=FloatType)
+TTensor2 = TypeVar("TTensor2", bound=TensorType)
+TTensorOrString = TypeVar("TTensorOrString", bound=Union[TensorType, STRING])
+TFloat = TypeVar("TFloat", bound=_FloatType)
 TFloatOrUInt8 = TypeVar(
     "TFloatOrUInt8", bound=Union[FLOAT, FLOAT16, DOUBLE, INT8, UINT8]
 )

--- a/torch/onnx/_internal/exporter/_torchlib/_tensor_typing.py
+++ b/torch/onnx/_internal/exporter/_torchlib/_tensor_typing.py
@@ -43,7 +43,7 @@ _TensorType = Union[
     INT64,
     UINT8,
 ]
-_FloatType = Union[FLOAT16, FLOAT, DOUBLE, BFLOAT16]
+FloatType = Union[FLOAT16, FLOAT, DOUBLE, BFLOAT16]
 IntType = Union[INT8, INT16, INT32, INT64]
 RealType = Union[
     BFLOAT16,
@@ -61,7 +61,7 @@ TTensor = TypeVar("TTensor", bound=_TensorType)
 # but do not constrain the type to be the same as the other inputs/outputs
 TTensor2 = TypeVar("TTensor2", bound=_TensorType)
 TTensorOrString = TypeVar("TTensorOrString", bound=Union[_TensorType, STRING])
-TFloat = TypeVar("TFloat", bound=_FloatType)
+TFloat = TypeVar("TFloat", bound=FloatType)
 TFloatOrUInt8 = TypeVar(
     "TFloatOrUInt8", bound=Union[FLOAT, FLOAT16, DOUBLE, INT8, UINT8]
 )

--- a/torch/onnx/_internal/exporter/_torchlib/ops/symops.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/symops.py
@@ -9,8 +9,20 @@ from __future__ import annotations
 from onnxscript.onnx_opset import opset18 as op
 
 import torch
-from torch.onnx._internal.exporter._torchlib._tensor_typing import BOOL, IntType
+from torch.onnx._internal.exporter._torchlib._tensor_typing import (
+    BOOL,
+    FLOAT,
+    FloatType,
+    INT64,
+    IntType,
+)
 from torch.onnx._internal.exporter._torchlib._torchlib_registry import onnx_impl
+
+
+@onnx_impl(torch.sym_float, trace_only=True)
+def sym_float(self: FloatType | IntType) -> FLOAT:
+    """sym_float(SymInt self) -> SymFloat"""
+    return op.Cast(self, to=FLOAT.dtype)
 
 
 @onnx_impl(torch.sym_max, trace_only=True)

--- a/torch/onnx/_internal/exporter/_torchlib/ops/symops.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/symops.py
@@ -12,15 +12,15 @@ import torch
 from torch.onnx._internal.exporter._torchlib._tensor_typing import (
     BOOL,
     FLOAT,
-    FloatType,
     INT64,
     IntType,
+    TensorType,
 )
 from torch.onnx._internal.exporter._torchlib._torchlib_registry import onnx_impl
 
 
 @onnx_impl(torch.sym_float, trace_only=True)
-def sym_float(self: FloatType | IntType) -> FLOAT:
+def sym_float(self: TensorType) -> FLOAT:
     """sym_float(SymInt self) -> SymFloat"""
     return op.Cast(self, to=FLOAT.dtype)
 


### PR DESCRIPTION
Fixes #153115

Note: torch.sym_int is not supported in this PR because it's not appeared in exported program, instead, it's `torch.ops.aten.sym_size.int()`.

```
ExportedProgram:
    class GraphModule(torch.nn.Module):
        def forward(self, x: "f32[s35, s16]"):
             # 
            sym_size_int_1: "Sym(s35)" = torch.ops.aten.sym_size.int(x, 0);  x = None
            return (sym_size_int_1,)
```