### PR TITLE
[pytorch] Expose `c10_retrieve_device_side_assertion_info()` for use by external code

### DIFF
--- a/c10/cuda/CUDADeviceAssertionHost.h
+++ b/c10/cuda/CUDADeviceAssertionHost.h
@@ -148,7 +148,7 @@ class C10_CUDA_API CUDAKernelLaunchRegistry {
 #endif
 };
 
-std::string c10_retrieve_device_side_assertion_info();
+C10_CUDA_API std::string c10_retrieve_device_side_assertion_info();
 
 } // namespace c10::cuda
 


### PR DESCRIPTION
Summary: - Expose `c10_retrieve_device_side_assertion_info()` for use by external code.  The motivating use case is FBGEMM kernel launcher utilities, which add FBGEMM-specific context to the errors coming out of Torch DSA

Test Plan: OSS CI

Differential Revision: D74432771


