### PR TITLE
[Ez][BE]: Ensure matplotlib remains optional dependency via fake_quantize

### DIFF
--- a/torch/ao/quantization/experimental/observer.py
+++ b/torch/ao/quantization/experimental/observer.py
@@ -6,8 +6,6 @@ the values observed during calibration (PTQ) or training (QAT).
 
 import itertools
 
-import matplotlib.pyplot as plt
-
 import torch
 from torch.ao.quantization.experimental.apot_utils import apot_to_float, float_to_apot
 from torch.ao.quantization.observer import ObserverBase
@@ -148,6 +146,9 @@ class APoTObserver(ObserverBase):
     """
 
     def quant_levels_visualization(self, signed=False):
+        # matplotlib is optional dep
+        import matplotlib.pyplot as plt
+
         alpha, _gamma, quantization_levels, level_indices = self.calculate_qparams(
             signed
         )


### PR DESCRIPTION
Unblocks #153055 and ensure that matplotlib should always be optional in PyTorch.