### PR TITLE
Update lint_urls.sh

### DIFF
--- a/scripts/lint_urls.sh
+++ b/scripts/lint_urls.sh
@@ -23,10 +23,6 @@ while IFS=: read -r filepath url; do
     fi
     if [ "$code" -lt 200 ] || [ "$code" -ge 400 ]; then
       sleep 1
-      code=$(curl -k -gsLm30 --retry 3 --retry-delay 3 --retry-connrefused -o /dev/null -w "%{http_code}" -A "$user_agent" "$url") || code=000
-    fi
-    if [ "$code" -lt 200 ] || [ "$code" -ge 400 ]; then
-      sleep 1
       request_id=$(curl -sS -G -H 'Accept: application/json' \
         --data-urlencode "host=$url" \
         --data-urlencode "max_nodes=1" \
@@ -66,7 +62,7 @@ while IFS=: read -r filepath url; do
     sleep 1
   done
  done < <(
-  pattern='(?!.*@lint-ignore)(?<!git\+)(?<!\$\{)https?://(?![^/]*@)(?![^\s<>\")]*[<>\{\}\$])[^[:space:]<>")\[\]\\]+'
+  pattern='(?!.*@lint-ignore)(?<!git\+)(?<!\$\{)https?://(?![^/]*@)(?![^\s<>\")]*[<>\{\}\$])[^[:space:]<>")\[\]\\|]+'
   excludes=(
     ':(exclude,glob)**/.*'
     ':(exclude,glob)**/*.lock'

--- a/scripts/lint_urls.sh
+++ b/scripts/lint_urls.sh
@@ -46,14 +46,14 @@ while IFS=: read -r filepath url; do
     fi
     # Treat Cloudflare JS-challenge and rate-limit as success.
     if [[ "$code" == "403" || "$code" == "429" || "$code" == "503" ]]; then
-      printf "${yellow}%s${reset} ${cyan}%s${reset} %s\n" "$code" "$url" "$filepath"
+      printf "${yellow}WARN %s${reset} ${cyan}%s${reset} %s\n" "$code" "$url" "$filepath"
       exit 0
     fi
     if [ "$code" -lt 200 ] || [ "$code" -ge 400 ]; then
-      printf "${red}%s${reset} ${yellow}%s${reset} %s\n" "$code" "$url" "$filepath" >&2
+      printf "${red}FAIL %s${reset} ${yellow}%s${reset} %s\n" "$code" "$url" "$filepath" >&2
       exit 1
     else
-      printf "${green}%s${reset} ${cyan}%s${reset} %s\n" "$code" "$url" "$filepath"
+      printf "${green} OK  %s${reset} ${cyan}%s${reset} %s\n" "$code" "$url" "$filepath"
       exit 0
     fi
   ) &

--- a/scripts/lint_urls.sh
+++ b/scripts/lint_urls.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+trap 'kill 0' SIGINT
+
 status=0
 green='\e[1;32m'; red='\e[1;31m'; cyan='\e[1;36m'; yellow='\e[1;33m'; reset='\e[0m'
 user_agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36"
@@ -16,9 +18,15 @@ while IFS=: read -r filepath url; do
   (
     code=$(curl -k -gsLm30 --retry 3 --retry-delay 3 --retry-connrefused -o /dev/null -w "%{http_code}" -I "$url") || code=000
     if [ "$code" -lt 200 ] || [ "$code" -ge 400 ]; then
+      sleep 1
       code=$(curl -k -gsLm30 --retry 3 --retry-delay 3 --retry-connrefused -o /dev/null -w "%{http_code}" -r 0-0 -A "$user_agent" "$url") || code=000
     fi
     if [ "$code" -lt 200 ] || [ "$code" -ge 400 ]; then
+      sleep 1
+      code=$(curl -k -gsLm30 --retry 3 --retry-delay 3 --retry-connrefused -o /dev/null -w "%{http_code}" -A "$user_agent" "$url") || code=000
+    fi
+    if [ "$code" -lt 200 ] || [ "$code" -ge 400 ]; then
+      sleep 1
       request_id=$(curl -sS -G -H 'Accept: application/json' \
         --data-urlencode "host=$url" \
         --data-urlencode "max_nodes=1" \
@@ -58,7 +66,7 @@ while IFS=: read -r filepath url; do
     sleep 1
   done
  done < <(
-  pattern='(?!.*@lint-ignore)(?<!git\+)(?<!\$\{)https?://(?![^/]*@)(?![^\s<>\")]*[<>\{\}\$])[^[:space:]<>")\[\]\\|]+'
+  pattern='(?!.*@lint-ignore)(?<!git\+)(?<!\$\{)https?://(?![^/]*@)(?![^\s<>\")]*[<>\{\}\$])[^[:space:]<>")\[\]\\]+'
   excludes=(
     ':(exclude,glob)**/.*'
     ':(exclude,glob)**/*.lock'

--- a/scripts/lint_urls.sh
+++ b/scripts/lint_urls.sh
@@ -58,7 +58,7 @@ while IFS=: read -r filepath url; do
     sleep 1
   done
  done < <(
-  pattern='(?!.*@lint-ignore)(?<!git\+)(?<!\$\{)https?://(?![^/]*@)(?![^\s<>\")]*[<>\{\}\$])[^[:space:]<>")\[\]\\]+'
+  pattern='(?!.*@lint-ignore)(?<!git\+)(?<!\$\{)https?://(?![^/]*@)(?![^\s<>\")]*[<>\{\}\$])[^[:space:]<>")\[\]\\|]+'
   excludes=(
     ':(exclude,glob)**/.*'
     ':(exclude,glob)**/*.lock'


### PR DESCRIPTION
Treat 403, 429 and 503 http errors as success.
Ignore non-verbal hostnames.
Kill child jobs immediately.