### PR TITLE
[CUDA] Allow cuDNN or flash attn in `test_activation_checkpointing` pattern match check

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -1366,50 +1366,20 @@ Non-primal fwd outputs from model w/o backward hook: {mod_no_hook_fwd_outputs_no
         opt_fn(*args1).sum().backward()
 
         fwd_graph = aot_graphs[0]
-        try:
-            op = torch.ops.aten._scaled_dot_product_flash_attention.default
-            self.assertTrue(
-                count_ops(
-                    fwd_graph,
-                    [],
-                    freq=1,
-                    op=op,
-                )
-            )
-        except AssertionError:
-            op = torch.ops.aten._scaled_dot_product_cudnn_attention.default
-            self.assertTrue(
-                count_ops(
-                    fwd_graph,
-                    [],
-                    freq=1,
-                    op=op,
-                )
-            )
+        op1 = torch.ops.aten._scaled_dot_product_flash_attention.default
+        op2 = torch.ops.aten._scaled_dot_product_cudnn_attention.default
+        self.assertTrue(
+            count_ops(fwd_graph, [], freq=1, op=op1,) or
+            count_ops(fwd_graph, [], freq=1, op=op2,)
+        )
         bwd_graph = aot_graphs[1]
         # Check that sin is not recomputed in the backward graph - checks percolate tags
         self.assertTrue(count_ops(bwd_graph, [], freq=0, op=torch.ops.aten.sin.default))
         # Check that the sdpa op is recomputed in the backward graph
-        try:
-            op = torch.ops.aten._scaled_dot_product_flash_attention.default
-            self.assertTrue(
-                count_ops(
-                    bwd_graph,
-                    [],
-                    freq=1,
-                    op=op,
-                )
-            )
-        except AssertionError:
-            op = torch.ops.aten._scaled_dot_product_cudnn_attention.default
-            self.assertTrue(
-                count_ops(
-                    bwd_graph,
-                    [],
-                    freq=1,
-                    op=op,
-                )
-            )
+        self.assertTrue(
+            count_ops(bwd_graph, [], freq=1, op=op1,) or
+            count_ops(bwd_graph, [], freq=1, op=op2,)
+        )
 
     @requires_distributed()
     @requires_cuda

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -17,10 +17,6 @@ from functorch.compile import min_cut_rematerialization_partition
 from torch._dynamo.backends.common import aot_autograd
 from torch._dynamo.testing import CompileCounterWithBackend
 from torch._higher_order_ops.wrap import tag_activation_checkpoint
-from torch.testing._internal.common_cuda import (
-    PLATFORM_SUPPORTS_CUDNN_ATTENTION,
-    SM90OrLater,
-)
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import IS_WINDOWS, skipIfHpu, skipIfRocm
 from torch.testing._internal.inductor_utils import HAS_CUDA
@@ -1380,7 +1376,7 @@ Non-primal fwd outputs from model w/o backward hook: {mod_no_hook_fwd_outputs_no
                     op=op,
                 )
             )
-        except AssertionError as e:
+        except AssertionError:
             op = torch.ops.aten._scaled_dot_product_cudnn_attention.default
             self.assertTrue(
                 count_ops(
@@ -1404,7 +1400,7 @@ Non-primal fwd outputs from model w/o backward hook: {mod_no_hook_fwd_outputs_no
                     op=op,
                 )
             )
-        except AssertionError as e:
+        except AssertionError:
             op = torch.ops.aten._scaled_dot_product_cudnn_attention.default
             self.assertTrue(
                 count_ops(
@@ -1414,7 +1410,6 @@ Non-primal fwd outputs from model w/o backward hook: {mod_no_hook_fwd_outputs_no
                     op=op,
                 )
             )
-
 
     @requires_distributed()
     @requires_cuda

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -1369,16 +1369,35 @@ Non-primal fwd outputs from model w/o backward hook: {mod_no_hook_fwd_outputs_no
         op1 = torch.ops.aten._scaled_dot_product_flash_attention.default
         op2 = torch.ops.aten._scaled_dot_product_cudnn_attention.default
         self.assertTrue(
-            count_ops(fwd_graph, [], freq=1, op=op1,) or
-            count_ops(fwd_graph, [], freq=1, op=op2,)
+            count_ops(
+                fwd_graph,
+                [],
+                freq=1,
+                op=op1,
+            )
+            or count_ops(
+                fwd_graph,
+                [],
+                freq=1,
+                op=op2,
+            )
         )
         bwd_graph = aot_graphs[1]
         # Check that sin is not recomputed in the backward graph - checks percolate tags
         self.assertTrue(count_ops(bwd_graph, [], freq=0, op=torch.ops.aten.sin.default))
         # Check that the sdpa op is recomputed in the backward graph
         self.assertTrue(
-            count_ops(bwd_graph, [], freq=1, op=op1,) or
-            count_ops(bwd_graph, [], freq=1, op=op2,)
+            count_ops(
+                bwd_graph,
+                [],
+                freq=1,
+                op=op1,
+            ) or count_ops(
+                bwd_graph,
+                [],
+                freq=1,
+                op=op2,
+            )
         )
 
     @requires_distributed()

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -1392,7 +1392,8 @@ Non-primal fwd outputs from model w/o backward hook: {mod_no_hook_fwd_outputs_no
                 [],
                 freq=1,
                 op=op1,
-            ) or count_ops(
+            )
+            or count_ops(
                 bwd_graph,
                 [],
                 freq=1,


### PR DESCRIPTION
Seems more robust than maintaining a mirror of dispatch condition based on compute capability etc

cc @soulitzer @ptrblck @msaroufim @jerryzh168 @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames