### PR TITLE
Decompose view. 

### DIFF
--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -57,7 +57,7 @@ _quantized = torch.ops._quantized
 quantized_decomposed = torch.ops.quantized_decomposed
 
 inductor_decompositions = get_decompositions(
-    [
+    [   aten.view,
         aten._adaptive_avg_pool2d_backward,
         aten.index_select,
         aten.addmv,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #153278

In autograd we do this complex decomposition of views to try to do it more efficiently
(reshape_view_helper (https://www.internalfb.com/code/fbsource/[c368c540006a]/fbcode/caffe2/torch/_refs/__init__.py?lines=4734) but it seems that we only use it for fake tensor tracing but not during proxy tracing, so we actually do not  decompose before we call  inductor.
two questions:
1. Does inductor prefer a view over a decomposed view if not maybe we should register it https://github.com/pytorch/pytorch/pull/153278

2. if inductor prefer a view, and the functions is only used for fake tensor tracing maybe we shall use a simpler version? we hit so many data dependent errors there for no reason. 
cc @Elias Ellison

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov