### PR TITLE
Change trigger for autoformat, use --all-files

### DIFF
--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -25,7 +25,6 @@ ciflow_push_tags:
 - ciflow/unstable
 - ciflow/xpu
 - ciflow/torchbench
-- ciflow/autoformat
 - ciflow/op-benchmark
 - ciflow/pull
 - ciflow/h100

--- a/.github/workflows/lint-autoformat.yml
+++ b/.github/workflows/lint-autoformat.yml
@@ -26,7 +26,7 @@ jobs:
           set -ex
           python3 -m venv /tmp/venv
           source /tmp/venv/bin/activate
-          export ADDITIONAL_LINTRUNNER_ARGS="format"
+          export ADDITIONAL_LINTRUNNER_ARGS="format --all-files"
           bash .github/scripts/lintrunner.sh
       - name: Check for changes
         id: git-check

--- a/.github/workflows/lint-autoformat.yml
+++ b/.github/workflows/lint-autoformat.yml
@@ -10,9 +10,7 @@ jobs:
       contents: read
       pull-requests: write
     runs-on: lf.linux.2xlarge
-    # Not a true ciflow tag because the reusable action used for suggesting
-    # changes requires pull_request trigger
-    if: ${{ github.repository_owner == 'pytorch' && contains(github.event.pull_request.labels.*.name, 'ciflow/autoformat') }}
+    if: ${{ github.repository_owner == 'pytorch' && contains(github.event.pull_request.labels.*.name, 'autoformat') }}
     steps:
       - name: Checkout pytorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main

--- a/.github/workflows/lint-autoformat.yml
+++ b/.github/workflows/lint-autoformat.yml
@@ -21,7 +21,6 @@ jobs:
           fetch-depth: 0
       - name: Run lintrunner (nonretryable)
         continue-on-error: true
-        # we can't run all files here because only changes around where the diff are shown in the PR UI
         run: |
           set -ex
           python3 -m venv /tmp/venv

--- a/.github/workflows/lint-autoformat.yml
+++ b/.github/workflows/lint-autoformat.yml
@@ -1,10 +1,8 @@
 name: Apply lint suggestions
 
 on:
-
-  push:
-    tags:
-      - ciflow/autoformat/*
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   lintrunner-autoformat:
@@ -12,7 +10,9 @@ jobs:
       contents: read
       pull-requests: write
     runs-on: lf.linux.2xlarge
-    if: ${{ github.repository_owner == 'pytorch' && github.event.pull_request.user.login != 'ezyang' && github.event.pull_request.user.login != 'malfet' && !startsWith(github.head_ref, 'export-') }}
+    # Not a true ciflow tag because the reusable action used for suggesting
+    # changes requires pull_request trigger
+    if: ${{ github.repository_owner == 'pytorch' && contains(github.event.pull_request.labels.*.name, 'ciflow/autoformat') }}
     steps:
       - name: Checkout pytorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main


### PR DESCRIPTION
Change trigger for auto format to be pull_request b/c the reusable action used gets the pr number from the pull_request event context, but only run it if ciflow/autoformat is attached to the PR.  Tested this on a different PR, and it seems to be working

Changed tag name because ciflow prefixed labels have special handling

Also change to run on all files so it will mimic the normal CI lintrunner call, and because lintrunner, either by itself or using -m mergebase can miss some things.  Idk if it would miss for format, but it does for checking lint.  Format seems to take shorter than normal lint.  I don't know if the comment about making suggestions on non edited file changes is a concern.  I didn't really test this part

