### PR TITLE
[BE] fix skip_if_lt_x_gpu decorator and add test coverage

### DIFF
--- a/test/distributed/test_common_distributed_utils.py
+++ b/test/distributed/test_common_distributed_utils.py
@@ -1,0 +1,63 @@
+# Owner(s): ["oncall: distributed"]
+
+# Description:
+# this file tests the testing utils defined in torch/testing/_internal/common_distributed.py
+# on test classes that are defined to test PyTorch Distributed components such as
+# DTensor and FSDP.
+
+import torch
+
+from torch.testing._internal.common_distributed import MultiProcessTestCase, MultiThreadedTestCase, skip_if_lt_x_gpu
+from torch.testing._internal.common_fsdp import FSDPTest
+from torch.testing._internal.distributed._tensor.common_dtensor import DTensorTestBase, with_comms
+
+# file: torch/testing/_internal/common_fsdp.py
+class UtilsTestOnFSDPTest(FSDPTest):
+    @property
+    def world_size(self):
+        # this is the largest number of GPUs on any test instance
+        return 8
+
+    @skip_if_lt_x_gpu(8)
+    def test_skip_if_lt_x_gpu(self):
+        if torch.cuda.device_count() < 8:
+            raise RuntimeError("This test is supposed to be skipped. Examine why `skip_if_lt_x_gpu` is not working.")
+
+
+# file: torch/testing/_internal/common_distributed.py
+class UtilsTestOnMultiProcessTestCase(MultiProcessTestCase):
+    @property
+    def world_size(self):
+        # this is the largest number of GPUs on any test instance
+        return 8
+
+    @skip_if_lt_x_gpu(8)
+    def test_skip_if_lt_x_gpu(self):
+        if torch.cuda.device_count() < 8:
+            raise RuntimeError("This test is supposed to be skipped. Examine why `skip_if_lt_x_gpu` is not working.")
+
+
+class UtilsTestOnMultiThreadedTestCase(MultiThreadedTestCase):
+    @property
+    def world_size(self):
+        # this is the largest number of GPUs on any test instance
+        return 8
+
+    @skip_if_lt_x_gpu(8)
+    def test_skip_if_lt_x_gpu(self):
+        if torch.cuda.device_count() < 8:
+            raise RuntimeError("This test is supposed to be skipped. Examine why `skip_if_lt_x_gpu` is not working.")
+
+
+# file: torch/testing/_internal/distributed/_tensor/common_dtensor.py
+class UtilsTestOnDTensorTestBase(DTensorTestBase):
+    @property
+    def world_size(self):
+        # this is the largest number of GPUs on any test instance
+        return 8
+
+    @skip_if_lt_x_gpu(8)
+    @with_comms
+    def test_skip_if_lt_x_gpu(self):
+        if torch.cuda.device_count() < 8:
+            raise RuntimeError("This test is supposed to be skipped. Examine why `skip_if_lt_x_gpu` is not working.")


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/144918

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #153291
* __->__ #153295
* #153283

**Summary**
Address the issue reported in https://github.com/pytorch/pytorch/issues/146094

**Test**
`CUDA_VISIBLE_DEVICES="" pytest test/distributed/test_common_distributed_utils.py`
`CUDA_VISIBLE_DEVICES="0,1" pytest test/distributed/test_common_distributed_utils.py`
`CUDA_VISIBLE_DEVICES="0,1,2,3,4,5,6,7" pytest test/distributed/test_common_distributed_utils.py`

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k