### PR TITLE
[Ez][BE]: Fix KeyError LOGNAME

### DIFF
--- a/torch/distributed/checkpoint/examples/fsdp_checkpoint_example.py
+++ b/torch/distributed/checkpoint/examples/fsdp_checkpoint_example.py
@@ -20,7 +20,7 @@ from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp.fully_sharded_data_parallel import StateDictType
 
 
-CHECKPOINT_DIR = f"/scratch/{os.environ['LOGNAME']}/checkpoint"
+CHECKPOINT_DIR = f"/scratch/{os.environ.get('LOGNAME', '')}/checkpoint"
 
 
 def opt_at(opt, idx):

--- a/torch/distributed/checkpoint/examples/stateful_example.py
+++ b/torch/distributed/checkpoint/examples/stateful_example.py
@@ -20,7 +20,7 @@ from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
 
-CHECKPOINT_DIR = f"~/{os.environ['LOGNAME']}/checkpoint"
+CHECKPOINT_DIR = f"~/{os.environ.get('LOGNAME', '')}/checkpoint"
 
 
 class Model(torch.nn.Module):


### PR DESCRIPTION
Unblocks #153020 which accidentally improves the CircularImportLinter to check all Python files. It doesn't set a logname so it errors, there is another FSDP script which already defaults LOGNAME to '' if not specified, this does the same.

cc @LucasLLC @pradeepfn @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k