### PR TITLE
[BE]: Use more portable shutil.which call for cpp_builder

### DIFF
--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -860,7 +860,8 @@ def is_conda_llvm_openmp_installed() -> bool:
 def homebrew_libomp() -> tuple[bool, str]:
     try:
         # check if `brew` is installed
-        subprocess.check_output(["which", "brew"])
+        if shutil.which("brew") is None:
+            return False, ""
         # get the location of `libomp` if it is installed
         # this is the location that `libomp` **would** be installed
         # see https://github.com/Homebrew/brew/issues/10261#issuecomment-756563567 for details

--- a/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
@@ -1,7 +1,7 @@
 """torch.ops.aten operators under the `core` module."""
 # mypy: disable-error-code="misc,arg-type,type-arg,valid-type,assignment,return-value,type-var,operator,no-untyped-def,index"
 # ruff: noqa: TCH001,TCH002
-# flake8: noqa
+# flake8: noqa: B950
 
 from __future__ import annotations
 

--- a/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
@@ -1,7 +1,7 @@
 """torch.ops.aten operators under the `core` module."""
 # mypy: disable-error-code="misc,arg-type,type-arg,valid-type,assignment,return-value,type-var,operator,no-untyped-def,index"
 # ruff: noqa: TCH001,TCH002
-# flake8: noqa: B950
+# flake8: noqa
 
 from __future__ import annotations
 


### PR DESCRIPTION
We should be using shutil.which instead of calling some binary subprocess here for portability and security.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov