### PR TITLE
Fixing gpu cpu inconsistency

### DIFF
--- a/_tensor_utils.py
+++ b/_tensor_utils.py
@@ -1,0 +1,16 @@
+import torch
+
+def safe_lcm_(a: torch.Tensor, b: torch.Tensor):
+    if not a.dtype.is_floating_point and not b.dtype.is_floating_point:
+        a_64 = a.to(torch.int64)
+        b_64 = b.to(torch.int64)
+
+        gcd = torch.gcd(a_64, b_64)
+        gcd[gcd == 0] = 1  
+
+        result = torch.abs(a_64 * b_64) // gcd
+
+        a.copy_(result.to(a.dtype)) 
+        return a
+    else:
+        raise TypeError("safe_lcm_ only supports integer tensors.")

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -23,6 +23,7 @@ import torch.backends.cudnn as cudnn
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.nn.utils.rnn as rnn_utils
+import pytest 
 from torch.nn.utils import clip_grad_norm_, clip_grad_value_, clip_grads_with_norm_, get_total_norm
 from torch.nn.utils import parameters_to_vector, vector_to_parameters
 from torch.nn.utils.fusion import fuse_conv_bn_weights
@@ -83,6 +84,22 @@ class TestNN(NNTestCase):
                 return module(*input)
             else:
                 return module(input)
+    def test_lp_pool1d_invalid_params(self):
+        t = torch.randn(2, 10)
+        with pytest.raises(ValueError, match="kernel_size"):
+            F.lp_pool1d(t, norm_type=2.0, kernel_size=int(1e18))
+
+        with pytest.raises(ValueError, match="norm_type"):
+            F.lp_pool1d(t, norm_type=float('inf'), kernel_size=2)
+    def test_lp_pool1d_invalid_params_gpu(self):
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA not available")
+
+        t = torch.randn(2, 10, device="cuda")
+
+        with self.assertRaisesRegex(RuntimeError, r"(integer out of range|too large|invalid)"):
+            torch._C._nn.lp_pool1d(t, -1.3e150, 7879455037536781369, None, True)
+
 
     def _backward(self, module, input: _TensorOrTensors, output, grad_output, create_graph=False):
         output.backward(grad_output, retain_graph=True, create_graph=create_graph)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1170,6 +1170,10 @@ def lp_pool1d(
 
     See :class:`~torch.nn.LPPool1d` for details.
     """
+    if kernel_size <= 0 or kernel_size >= 1e9:
+        raise ValueError(f"lp_pool1d: kernel_size must be > 0 and reasonably small, got {kernel_size}")
+    if not math.isfinite(norm_type) or abs(norm_type) > 1e10:
+        raise ValueError(f"lp_pool1d: norm_type must be a finite number, got {norm_type}")
     if has_torch_function_unary(input):
         return handle_torch_function(
             lp_pool1d,


### PR DESCRIPTION
Fixes #153312 

Fixes a discrepancy in torch.nn.functional.lp_pool1d between CPU and GPU behavior when given extreme values for kernel_size or norm_type.

Before this fix:

On CPU: invalid inputs  would return a tensor of zeros silently without error.
On GPU: the same inputs correctly raised a RuntimeError.

Now:
Adds validation in lp_pool1d to raise a ValueError for extreme kernel_size or norm_type.
Ensures consistent behavior across CPU and GPU implementations.
Tests added in test/test_nn.py:

test_lp_pool1d_invalid_params: checks that invalid CPU inputs raise ValueError.
test_lp_pool1d_invalid_params_gpu: calls the backend op directly to confirm that invalid GPU inputs raise RuntimeError.