### PR TITLE
CMake: update FindCUDAToolkit.cmake, use torch::nvtx3 if present, mod…

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -350,10 +350,15 @@ def _load_global_deps() -> None:
             "cusparselt": "libcusparseLt.so.*[0-9]",
             "cusolver": "libcusolver.so.*[0-9]",
             "nccl": "libnccl.so.*[0-9]",
-            "nvtx": "libnvToolsExt.so.*[0-9]",
             "nvshmem": "libnvshmem_host.so.*[0-9]",
             "cufile": "libcufile.so.*[0-9]",
         }
+
+        # libnvToolsExt.so.*[0-9] is only available on CUDA < 12.9
+        if cuda_version:
+            major, minor, *_ = [__builtins__.int(x) for x in cuda_version.split(".")]
+            if (major, minor) < (12, 9):
+                cuda_libs["nvtx"] = "libnvToolsExt.so.*[0-9]"
 
         is_cuda_lib_err = [
             lib for lib in cuda_libs.values() if lib.split(".")[0] in err.args[0]


### PR DESCRIPTION
CMake: update FindCUDAToolkit.cmake, use torch::nvtx3 if present, modify torch/__init__.py to include libnvToolsExt.so if cuda < 12.9

Fixes #152756

Cuda-12.9 removed libnvToolsExt.so.* and is now pure header nvtx3.

Modify torch/__init__.py to include libnvToolsExt.so only if cuda < 12.9

pytorch/cmake/Modules/FindCUDAToolkit.cmake is old enough to not have any reference to CUDA::**nvtx3**.  I updated to the current version FindCUDAToolkit.cmake.

