### PR TITLE
Adding view and reduction tags

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -8123,7 +8123,6 @@
 - func: lift_fresh(Tensor(a) self) -> Tensor(a)
   dispatch:
     CompositeExplicitAutograd: lift_fresh
-  tags: view
 
 # Like lift, but it clones the input.
 - func: lift_fresh_copy(Tensor self) -> Tensor

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -419,11 +419,13 @@
   variants: function
   dispatch:
     CPU, CUDA, MPS, Meta: view_as_real
+  tags: view
 
 - func: view_as_complex(Tensor(a) self) -> Tensor(a)
   variants: function
   dispatch:
     CPU, CUDA, MPS, Meta: view_as_complex
+  tags: view
 
 - func: sgn(Tensor self) -> Tensor
   variants: function, method
@@ -468,6 +470,7 @@
   variants: function, method
   dispatch:
     CompositeExplicitAutograd: _conj
+  tags: view
 
 - func: conj(Tensor(a) self) -> Tensor(a)
   variants: function, method
@@ -509,6 +512,7 @@
   variants: function, method
   dispatch:
     CompositeExplicitAutograd: _neg_view
+  tags: view
 
 - func: acos(Tensor self) -> Tensor
   device_check: NoCheck   # TensorIterator
@@ -704,7 +708,7 @@
   variants: function, method
   dispatch:
     NestedTensorCPU, NestedTensorHPU, NestedTensorCUDA: NestedTensor_all
-
+  tags: reduction
 
 - func: all.dims(Tensor self, int[]? dim=None, bool keepdim=False) -> Tensor
   device_check: NoCheck   # TensorIterator
@@ -713,6 +717,7 @@
   cpp_no_default_args: ['dim']
   dispatch:
     CompositeExplicitAutograd: all_dims_default
+  tags: reduction
 
 - func: all.out(Tensor self, int dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
@@ -720,6 +725,7 @@
   dispatch:
     CPU, CUDA: all_out
     MPS: all_out_mps
+  tags: reduction
 
 - func: all.dims_out(Tensor self, int[]? dim=None, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
@@ -728,13 +734,16 @@
     CPU, CUDA: all_dims_out
     CompositeExplicitAutograd: all_dims_out_default
   cpp_no_default_args: ['dim']
+  tags: reduction
 
 - func: all.dimname(Tensor self, Dimname dim, bool keepdim=False) -> Tensor
   device_check: NoCheck   # TensorIterator
   variants: function, method
+  tags: reduction
 
 - func: all.dimname_out(Tensor self, Dimname dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
+  tags: reduction
 
 - func: allclose(Tensor self, Tensor other, float rtol=1e-05, float atol=1e-08, bool equal_nan=False) -> bool
   variants: function, method
@@ -746,14 +755,14 @@
   device_check: NoCheck   # TensorIterator
   structured_delegate: any.out
   variants: function, method
-  tags: core
+  tags: [core, reduction]
 
 - func: any.dims(Tensor self, int[]? dim=None, bool keepdim=False) -> Tensor
   device_check: NoCheck   # TensorIterator
   structured_delegate: any.dims_out
   variants: function, method
   cpp_no_default_args: ['dim']
-  tags: core
+  tags: [core, reduction]
   dispatch:
     CompositeExplicitAutograd: any_dims_default
 
@@ -763,6 +772,7 @@
   dispatch:
     CPU, CUDA: any_out
     MPS: any_out_mps
+  tags: reduction
 
 - func: any.dims_out(Tensor self, int[]? dim=None, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
@@ -771,13 +781,16 @@
     CPU, CUDA: any_dims_out
     CompositeExplicitAutograd: any_dims_out_default
   cpp_no_default_args: ['dim']
+  tags: reduction
 
 - func: any.dimname(Tensor self, Dimname dim, bool keepdim=False) -> Tensor
   device_check: NoCheck   # TensorIterator
   variants: function, method
+  tags: reduction
 
 - func: any.dimname_out(Tensor self, Dimname dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
+  tags: reduction
 
 - func: arange(Scalar end, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
   dispatch:
@@ -822,25 +835,27 @@
   structured_delegate: argmax.out
   device_check: NoCheck   # TensorIterator
   variants: function, method
-  tags: core
+  tags: [core, reduction]
 
 - func: argmax.out(Tensor self, int? dim=None, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
   structured: True
   dispatch:
     CPU, CUDA: argmax_out
     MPS: argmax_out_mps
+  tags: reduction
 
 - func: argmin(Tensor self, int? dim=None, bool keepdim=False) -> Tensor
   structured_delegate: argmin.out
   device_check: NoCheck   # TensorIterator
   variants: function, method
-  tags: core
+  tags: [core, reduction]
 
 - func: argmin.out(Tensor self, int? dim=None, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
   structured: True
   dispatch:
     CPU, CUDA: argmin_out
     MPS: argmin_out_mps
+  tags: reduction
 
 - func: acosh(Tensor self) -> Tensor
   variants: function, method
@@ -948,7 +963,7 @@
     QuantizedCPU, QuantizedCUDA: as_strided_qtensorimpl
   device_check: NoCheck
   device_guard: False
-  tags: core
+  tags: [core, view]
 
 - func: as_strided_(Tensor(a!) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a!)
   use_const_ref_for_mutable_tensors: True
@@ -1865,12 +1880,14 @@
     CUDA: count_nonzero_cuda
     MPS: count_nonzero_mps
   autogen: count_nonzero.dim_IntList_out
+  tags: reduction
 
 - func: count_nonzero(Tensor self, int? dim=None) -> Tensor
   variants: function, method
   dispatch:
     CompositeExplicitAutograd: count_nonzero
   autogen: count_nonzero.out
+  tags: reduction
 
 - func: cov(Tensor self, *, int correction=1, Tensor? fweights=None, Tensor? aweights=None) -> Tensor
   variants: function, method
@@ -2101,7 +2118,7 @@
   variants: function, method
   dispatch:
     CompositeExplicitAutograd: diagonal
-  tags: core
+  tags: [core, view]
 
 - func: linalg_diagonal(Tensor(a) A, *, int offset=0, int dim1=-2, int dim2=-1) -> Tensor(a)
   python_module: linalg
@@ -2646,7 +2663,7 @@
   device_guard: False
   dispatch:
     CompositeExplicitAutograd: expand
-  tags: core
+  tags: [core, view]
 
 - func: expand_as(Tensor(a) self, Tensor other) -> Tensor(a)
   variants: method  # This is method-only to match the previous tensor API. In the future we could make this a function too.
@@ -3767,19 +3784,23 @@
   variants: function, method
   dispatch:
     CompositeExplicitAutograd: logsumexp
+  tags: reduction
 
 - func: logsumexp.out(Tensor self, int[1] dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
   dispatch:
     # calls squeeze
     CompositeExplicitAutogradNonFunctional: logsumexp_out
+  tags: reduction
 
 - func: logsumexp.names(Tensor self, Dimname[1] dim, bool keepdim=False) -> Tensor
   device_check: NoCheck   # TensorIterator
   variants: function, method
+  tags: reduction
 
 - func: logsumexp.names_out(Tensor self, Dimname[1] dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
+  tags: reduction
 
 - func: margin_ranking_loss(Tensor input1, Tensor input2, Tensor target, float margin=0.0, int reduction=Mean) -> Tensor
 
@@ -3818,17 +3839,20 @@
   dispatch:
     CPU, CUDA: _aminmax_all
   autogen: _aminmax.out
+  tags: reduction
 
 # DEPRECATED: Use torch.aminmax instead
 - func: _aminmax.dim(Tensor self, int dim, bool keepdim=False) -> (Tensor, Tensor)
   dispatch:
     CPU, CUDA: _aminmax
   autogen: _aminmax.dim_out
+  tags: reduction
 
 - func: aminmax(Tensor self, *, int? dim=None, bool keepdim=False) -> (Tensor min, Tensor max)
   device_check: NoCheck   # TensorIterator
   structured_delegate: aminmax.out
   variants: function, method
+  tags: reduction
 
 - func: aminmax.out(Tensor self, *, int? dim=None, bool keepdim=False, Tensor(a!) min, Tensor(b!) max) -> (Tensor(a!) min, Tensor(b!) max)
   device_check: NoCheck   # TensorIterator
@@ -3836,6 +3860,7 @@
   dispatch:
     CPU, CUDA: aminmax_out
     MPS: aminmax_out_mps
+  tags: reduction
 
 - func: _compute_linear_combination(Tensor input, Tensor coefficients) -> Tensor
   dispatch:
@@ -3851,7 +3876,7 @@
   variants: function, method
   dispatch:
     QuantizedCPU, QuantizedCUDA: qmax
-  tags: core
+  tags: [core, reduction]
 
 - func: max.dim_max(Tensor self, int dim, bool keepdim=False, *, Tensor(a!) max, Tensor(b!) max_values) -> (Tensor(a!) values, Tensor(b!) indices)
   device_check: NoCheck   # TensorIterator
@@ -3861,13 +3886,16 @@
   dispatch:
     CPU, CUDA: max_out
     MPS: max_out_mps
+  tags: reduction
 
 - func: max.names_dim(Tensor self, Dimname dim, bool keepdim=False) -> (Tensor values, Tensor indices)
   device_check: NoCheck   # TensorIterator
   variants: function, method
+  tags: reduction
 
 - func: max.names_dim_max(Tensor self, Dimname dim, bool keepdim=False, *, Tensor(a!) max, Tensor(b!) max_values) -> (Tensor(a!) values, Tensor(b!) indices)
   device_check: NoCheck   # TensorIterator
+  tags: reduction
 
 - func: value_selecting_reduction_backward(Tensor grad, int dim, Tensor indices, SymInt[] sizes, bool keepdim) -> Tensor
   variants: function
@@ -3880,13 +3908,14 @@
 - func: amax(Tensor self, int[1] dim=[], bool keepdim=False) -> Tensor
   variants: function, method
   structured_delegate: amax.out
-  tags: core
+  tags: [core, reduction]
 
 - func: amax.out(Tensor self, int[1] dim=[], bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
   structured: True
   dispatch:
     CPU, CUDA: amax_out
     MPS: amax_out_mps
+  tags: reduction
 
 # Return: (Tensor output, Tensor indices)
 - func: max_pool1d_with_indices(Tensor self, int[1] kernel_size, int[1] stride=[], int[1] padding=0, int[1] dilation=1, bool ceil_mode=False) -> (Tensor, Tensor)
@@ -3948,13 +3977,14 @@
   variants: function, method
   dispatch:
     CompositeExplicitAutograd: mean
-  tags: core
+  tags: [core, reduction]
 
 # For normal naming convention this should be `mean.out`. However since we already have `mean.out` we have to rename this.
 - func: mean.dtype_out(Tensor self, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
   dispatch:
     CompositeExplicitAutograd: mean_dtype_out
+  tags: reduction
 
 - func: mean.dim(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
   structured_delegate: mean.out
@@ -3962,7 +3992,7 @@
   variants: function, method
   dispatch:
     QuantizedCPU: mean_quantized_cpu
-  tags: core
+  tags: [core, reduction]
 
 - func: mean.out(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
   structured: True
@@ -3971,20 +4001,25 @@
     CPU, CUDA: mean_out
     MPS: mean_out_mps
     QuantizedCPU: mean_out_quantized_cpu
+  tags: reduction
 
 - func: mean.names_dim(Tensor self, Dimname[1] dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
   device_check: NoCheck   # TensorIterator
   variants: function, method
+  tags: reduction
 
 - func: mean.names_out(Tensor self, Dimname[1] dim, bool keepdim=False, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
+  tags: reduction
 
 - func: nanmean(Tensor self, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
   device_check: NoCheck   # Composite
   variants: function, method
+  tags: reduction
 
 - func: nanmean.out(Tensor self, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # Composite
+  tags: reduction
 
 - func: median(Tensor self) -> Tensor
   variants: function, method
@@ -4040,7 +4075,7 @@
   variants: function, method
   dispatch:
     QuantizedCPU, QuantizedCUDA: qmin
-  tags: core
+  tags: [core, reduction]
 
 - func: min.dim_min(Tensor self, int dim, bool keepdim=False, *, Tensor(a!) min, Tensor(b!) min_indices) -> (Tensor(a!) values, Tensor(b!) indices)
   device_check: NoCheck   # TensorIterator
@@ -4050,24 +4085,28 @@
   dispatch:
     CPU, CUDA: min_out
     MPS: min_out_mps
+  tags: reduction
 
 - func: min.names_dim(Tensor self, Dimname dim, bool keepdim=False) -> (Tensor values, Tensor indices)
   device_check: NoCheck   # TensorIterator
   variants: function, method
+  tags: reduction
 
 - func: min.names_dim_min(Tensor self, Dimname dim, bool keepdim=False, *, Tensor(a!) min, Tensor(b!) min_indices) -> (Tensor(a!) values, Tensor(b!) indices)
   device_check: NoCheck   # TensorIterator
+  tags: reduction
 
 - func: amin(Tensor self, int[1] dim=[], bool keepdim=False) -> Tensor
   variants: function, method
   structured_delegate: amin.out
-  tags: core
+  tags: [core, reduction]
 
 - func: amin.out(Tensor self, int[1] dim=[], bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
   structured: True
   dispatch:
     CPU, CUDA: amin_out
     MPS: amin_out_mps
+  tags: reduction
 
 # TODO: Add this function to MPS dispatch key so that we avoid declaring it in
 # native_functions.yaml
@@ -4544,7 +4583,7 @@
     CompositeExplicitAutograd: permute
     MPS: permute_mps
     SparseCPU, SparseCUDA: permute_sparse_coo
-  tags: core
+  tags: [core, view]
 
 - func: movedim.intlist(Tensor(a) self, int[] source, int[] destination) -> Tensor(a)
   variants: function, method
@@ -5215,7 +5254,7 @@
     CompositeExplicitAutograd: select_symint
     SparseCsrCPU, SparseCsrCUDA, SparseCsrMeta: select_sparse_csr
     NestedTensorCPU, NestedTensorHPU, NestedTensorCUDA: select_nested
-  tags: core
+  tags: [core, view]
 
 - func: select_backward(Tensor grad_output, SymInt[] input_sizes, int dim, SymInt index) -> Tensor
   variants: function
@@ -5433,6 +5472,7 @@
     MPS: sinh_out_mps
     SparseCPU, SparseCUDA: sinh_sparse_out
     SparseCsrCPU, SparseCsrCUDA, SparseCsrMeta: sinh_sparse_csr_out
+  tags: pointwise
 
 # Returns a copy of this `Variable` that is detached from its autograd graph.
 # This method is OK to call if the `Variable` is a view.
@@ -5445,12 +5485,12 @@
 # to false to make such changes explicitly illegal, in order to prevent users from
 # changing metadata of the detached tensor and expecting the original tensor to also
 # be updated.
-  tags: pointwise
 - func: detach(Tensor(a) self) -> Tensor(a)
   variants: function, method
   dispatch:
     CompositeExplicitAutograd: detach
     NestedTensorCPU, NestedTensorHPU, NestedTensorCUDA: detach
+  tags: view
 
 # Like `detach()`, but modifies this `Variable` in-place. This method may
 # only be called on non-view `Variable`s. You can use `is_view()` to check
@@ -5499,7 +5539,7 @@
   device_guard: False
   dispatch:
     CompositeExplicitAutograd: slice
-  tags: core
+  tags: [core, view]
 
 # NOTE: The implementation of split_with_sizes bypasses the dispatcher to call this; undo
 # that if adding specific implementations here!
@@ -5616,6 +5656,7 @@
   device_guard: False
   dispatch:
     CompositeExplicitAutograd: split
+  tags: view
 
 - func: split.sizes(Tensor(a -> *) self, SymInt[] split_size, int dim=0) -> Tensor(a)[]
   variants: function, method
@@ -5638,7 +5679,7 @@
   dispatch:
     CompositeExplicitAutograd: split_with_sizes
     NestedTensorCPU, NestedTensorHPU, NestedTensorCUDA: split_with_sizes_nested
-  tags: core
+  tags: [core, view]
 
 - func: hsplit.int(Tensor(a -> *) self, int sections) -> Tensor(a)[]
   variants: function, method
@@ -5666,6 +5707,7 @@
     CompositeExplicitAutograd: squeeze
     QuantizedCPU, QuantizedCUDA: squeeze_quantized
     NestedTensorCPU, NestedTensorHPU, NestedTensorCUDA: squeeze_nested
+  tags: view
 
 - func: squeeze.dim(Tensor(a) self, int dim) -> Tensor(a)
   variants: function, method
@@ -5675,13 +5717,12 @@
     CompositeExplicitAutograd: squeeze
     QuantizedCPU, QuantizedCUDA: squeeze_quantized
     NestedTensorCPU, NestedTensorHPU, NestedTensorCUDA: squeeze_dim_nested
-  tags: core
+  tags: [core, view]
 
 - func: squeeze.dimname(Tensor(a) self, Dimname dim) -> Tensor(a)
   variants: function, method
   device_check: NoCheck
   device_guard: False
-
 
 - func: squeeze.dims(Tensor(a) self, int[] dim) -> Tensor(a)
   variants: function, method
@@ -5691,7 +5732,7 @@
     CompositeExplicitAutograd: squeeze
     QuantizedCPU, QuantizedCUDA: squeeze_quantized
     NestedTensorCPU, NestedTensorHPU, NestedTensorCUDA: squeeze_dim_nested
-  tags: core
+  tags: [core, view]
 
 - func: squeeze_(Tensor(a!) self) -> Tensor(a!)
   variants: method
@@ -5810,6 +5851,7 @@
     SparseCPU, SparseCUDA, SparseMeta: sum_coo
     SparseCsrCPU, SparseCsrCUDA, SparseCsrMeta: sum_csr
   autogen: sum.out
+  tags: reduction
 
 - func: sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
   # TODO: Align the signature of sum.dim_IntList and _sparse_csr_sum.dim_dtype
@@ -5820,11 +5862,12 @@
     NestedTensorCPU: NestedTensor_sum_dim_CPU
     SparseCPU, SparseCUDA: sum_sparse_coo
     SparseCsrCPU, SparseCsrCUDA, SparseCsrMeta: sum_sparse_compressed
-  tags: core
+  tags: [core, reduction]
 
 - func: sum.dim_DimnameList(Tensor self, Dimname[1] dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
   device_check: NoCheck   # TensorIterator
   variants: function, method
+  tags: reduction
 
 - func: sum.IntList_out(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
   structured: True
@@ -5832,9 +5875,11 @@
   dispatch:
     CPU, CUDA: sum_out
     MPS: sum_out_mps
+  tags: reduction
 
 - func: sum.DimnameList_out(Tensor self, Dimname[1] dim, bool keepdim=False, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
+  tags: reduction
 
 # TODO: this function will be replaced once nested expand semantics have been settled on
 - func: _nested_sum_backward(Tensor grad, Tensor self, int[1]? dim, bool keepdim=False) -> Tensor
@@ -5846,11 +5891,13 @@
   dispatch:
     CPU, CUDA: nansum
     MPS: nansum_mps
+  tags: reduction
 
 - func: nansum.out(Tensor self, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU, CUDA: nansum_out
     MPS: nansum_out_mps
+  tags: reduction
 
 - func: sum_to_size(Tensor self, SymInt[] size) -> Tensor
   variants: method
@@ -5905,11 +5952,13 @@
   device_check: NoCheck   # TensorIterator
   variants: function, method
   cpp_no_default_args: ["unbiased"]
+  tags: reduction
 
 - func: std.dim(Tensor self, int[1]? dim, bool unbiased=True, bool keepdim=False) -> Tensor
   device_check: NoCheck   # TensorIterator
   variants: function, method
   cpp_no_default_args: ["unbiased"]
+  tags: reduction
 
 - func: std.correction(Tensor self, int[1]? dim=None, *, Scalar? correction=None, bool keepdim=False) -> Tensor
   device_check: NoCheck   # TensorIterator
@@ -5918,16 +5967,19 @@
     CPU, CUDA: std
     MPS: std_mps
     QuantizedCPU: std_quantized_cpu
+  tags: reduction
 
 - func: std_mean(Tensor self, bool unbiased=True) -> (Tensor, Tensor)
   device_check: NoCheck   # TensorIterator
   variants: function
   cpp_no_default_args: ["unbiased"]
+  tags: reduction
 
 - func: std_mean.dim(Tensor self, int[1]? dim, bool unbiased=True, bool keepdim=False) -> (Tensor, Tensor)
   device_check: NoCheck   # TensorIterator
   variants: function
   cpp_no_default_args: ["unbiased"]
+  tags: reduction
 
 - func: std_mean.correction(Tensor self, int[1]? dim=None, *, Scalar? correction=None, bool keepdim=False) -> (Tensor, Tensor)
   device_check: NoCheck   # TensorIterator
@@ -5936,42 +5988,51 @@
     CPU, CUDA: std_mean
     MPS: std_mean_mps
   autogen: std_mean.correction_out
+  tags: reduction
 
 - func: std_mean.names_dim(Tensor self, Dimname[1] dim, bool unbiased=True, bool keepdim=False) -> (Tensor, Tensor)
   device_check: NoCheck   # TensorIterator
   variants: function
   cpp_no_default_args: ["unbiased"]
+  tags: reduction
 
 - func: std_mean.correction_names(Tensor self, Dimname[1] dim, *, Scalar? correction=None, bool keepdim=False) -> (Tensor, Tensor)
   device_check: NoCheck   # TensorIterator
   variants: function
+  tags: reduction
 
 - func: std.out(Tensor self, int[1]? dim, bool unbiased=True, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
   cpp_no_default_args: ["unbiased"]
+  tags: reduction
 
 - func: std.correction_out(Tensor self, int[1]? dim=None, *, Scalar? correction=None, bool keepdim=False, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
   dispatch:
     CPU, CUDA: std_out
     QuantizedCPU: std_out_quantized_cpu
+  tags: reduction
 
 - func: std.names_dim(Tensor self, Dimname[1] dim, bool unbiased=True, bool keepdim=False) -> Tensor
   device_check: NoCheck   # TensorIterator
   variants: function, method
   cpp_no_default_args: ["unbiased"]
+  tags: reduction
 
 - func: std.names_out(Tensor self, Dimname[1] dim, bool unbiased=True, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
   cpp_no_default_args: ["unbiased"]
+  tags: reduction
 
 - func: std.correction_names(Tensor self, Dimname[1] dim, *, Scalar? correction=None, bool keepdim=False) -> Tensor
   device_check: NoCheck   # TensorIterator
   variants: function, method
+  tags: reduction
 
 - func: std.correction_names_out(Tensor self, Dimname[1] dim, *, Scalar? correction=None, bool keepdim=False, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
   variants: function
+  tags: reduction
 
 - func: prod(Tensor self, *, ScalarType? dtype=None) -> Tensor
   device_check: NoCheck   # TensorIterator
@@ -5980,13 +6041,13 @@
     CPU, CUDA: prod
     MPS: prod_mps
   autogen: prod.out
-  tags: core
+  tags: [core, reduction]
 
 - func: prod.dim_int(Tensor self, int dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
   structured_delegate: prod.int_out
   device_check: NoCheck   # TensorIterator
   variants: function, method
-  tags: core
+  tags: [core, reduction]
 
 - func: prod.int_out(Tensor self, int dim, bool keepdim=False, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
   structured: True
@@ -5994,13 +6055,16 @@
   dispatch:
     CPU, CUDA: prod_out
     MPS: prod_out_mps
+  tags: reduction
 
 - func: prod.dim_Dimname(Tensor self, Dimname dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
   device_check: NoCheck   # TensorIterator
   variants: function, method
+  tags: reduction
 
 - func: prod.Dimname_out(Tensor self, Dimname dim, bool keepdim=False, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
+  tags: reduction
 
 - func: t(Tensor(a) self) -> Tensor(a)
   device_check: NoCheck
@@ -6008,6 +6072,7 @@
   variants: function, method
   dispatch:
     CompositeExplicitAutograd: t
+  tags: view
 
 - func: t_(Tensor(a!) self) -> Tensor(a!)
   device_check: NoCheck
@@ -6137,6 +6202,7 @@
   dispatch:
     CompositeExplicitAutograd: transpose
     NestedTensorCPU, NestedTensorHPU, NestedTensorCUDA: transpose_nested
+  tags: view
 
 - func: transpose.Dimname(Tensor(a) self, Dimname dim0, Dimname dim1) -> Tensor(a)
   variants: function, method
@@ -6444,7 +6510,7 @@
     SparseCPU, SparseCUDA: unsqueeze_sparse
     QuantizedCPU, QuantizedCUDA: unsqueeze_quantized
     NestedTensorCPU, NestedTensorHPU, NestedTensorCUDA: unsqueeze_nested
-  tags: core
+  tags: [core, view]
 
 - func: unsqueeze_(Tensor(a!) self, int dim) -> Tensor(a!)
   variants: method
@@ -6460,12 +6526,13 @@
   device_check: NoCheck   # TensorIterator
   variants: function, method
   cpp_no_default_args: ["unbiased"]
+  tags: reduction
 
 - func: var.dim(Tensor self, int[1]? dim, bool unbiased=True, bool keepdim=False) -> Tensor
   device_check: NoCheck   # TensorIterator
   variants: function, method
-  tags: core
   cpp_no_default_args: ["unbiased"]
+  tags: [core, reduction]
 
 - func: var.correction(Tensor self, int[1]? dim=None, *, Scalar? correction=None, bool keepdim=False) -> Tensor
   device_check: NoCheck   # TensorIterator
@@ -6473,43 +6540,51 @@
   dispatch:
     CPU, CUDA: var
     MPS: var_mps
-  tags: core
+  tags: [core, reduction]
 
 - func: var.out(Tensor self, int[1]? dim, bool unbiased=True, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
   cpp_no_default_args: ["unbiased"]
+  tags: reduction
 
 - func: var.correction_out(Tensor self, int[1]? dim=None, *, Scalar? correction=None, bool keepdim=False, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
   dispatch:
     CPU, CUDA: var_out
+  tags: reduction
 
 - func: var.names_dim(Tensor self, Dimname[1] dim, bool unbiased=True, bool keepdim=False) -> Tensor
   device_check: NoCheck   # TensorIterator
   variants: function, method
   cpp_no_default_args: ["unbiased"]
+  tags: reduction
 
 - func: var.names_out(Tensor self, Dimname[1] dim, bool unbiased=True, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
   cpp_no_default_args: ["unbiased"]
+  tags: reduction
 
 - func: var.correction_names(Tensor self, Dimname[1] dim, *, Scalar? correction=None, bool keepdim=False) -> Tensor
   device_check: NoCheck   # TensorIterator
   variants: function, method
+  tags: reduction
 
 - func: var.correction_names_out(Tensor self, Dimname[1] dim, *, Scalar? correction=None, bool keepdim=False, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
   variants: function
+  tags: reduction
 
 - func: var_mean(Tensor self, bool unbiased=True) -> (Tensor, Tensor)
   device_check: NoCheck   # TensorIterator
   variants: function
   cpp_no_default_args: ["unbiased"]
+  tags: reduction
 
 - func: var_mean.dim(Tensor self, int[1]? dim, bool unbiased=True, bool keepdim=False) -> (Tensor, Tensor)
   device_check: NoCheck   # TensorIterator
   variants: function
   cpp_no_default_args: ["unbiased"]
+  tags: reduction
 
 - func: var_mean.correction(Tensor self, int[1]? dim=None, *, Scalar? correction=None, bool keepdim=False) -> (Tensor, Tensor)
   device_check: NoCheck   # TensorIterator
@@ -6518,15 +6593,18 @@
     CPU, CUDA: var_mean
     MPS: var_mean_mps
   autogen: var_mean.correction_out
+  tags: reduction
 
 - func: var_mean.names_dim(Tensor self, Dimname[1] dim, bool unbiased=True, bool keepdim=False) -> (Tensor, Tensor)
   device_check: NoCheck   # TensorIterator
   variants: function
   cpp_no_default_args: ["unbiased"]
+  tags: reduction
 
 - func: var_mean.correction_names(Tensor self, Dimname[1] dim, *, Scalar? correction=None, bool keepdim=False) -> (Tensor, Tensor)
   device_check: NoCheck   # TensorIterator
   variants: function
+  tags: reduction
 
 - func: view_as(Tensor(a) self, Tensor other) -> Tensor(a)
   variants: method
@@ -6786,6 +6864,7 @@
   dispatch:
     CompositeExplicitAutograd: norm
   autogen: norm.ScalarOpt_dtype_out
+  tags: reduction
 
 - func: norm.Scalar(Tensor self, Scalar p=2) -> Tensor
   device_check: NoCheck   # TensorIterator
@@ -6793,6 +6872,7 @@
   dispatch:
     CompositeExplicitAutograd: norm
   autogen: norm.Scalar_out
+  tags: reduction
 
 - func: norm.ScalarOpt_dim_dtype(Tensor self, Scalar? p, int[1] dim, bool keepdim, *, ScalarType dtype) -> Tensor
   structured_delegate: norm.dtype_out
@@ -6800,6 +6880,7 @@
   variants: function, method
   dispatch:
     SparseCPU, SparseCUDA: sparse_dtype_norm
+  tags: reduction
 
 - func: norm.ScalarOpt_dim(Tensor self, Scalar? p, int[1] dim, bool keepdim=False) -> Tensor
   structured_delegate: norm.out
@@ -6807,6 +6888,7 @@
   variants: function, method
   dispatch:
     SparseCPU, SparseCUDA: sparse_norm
+  tags: reduction
 
 - func: norm.dtype_out(Tensor self, Scalar? p, int[1] dim, bool keepdim, *, ScalarType dtype, Tensor(a!) out) -> Tensor(a!)
   structured: True
@@ -6814,6 +6896,7 @@
   dispatch:
     CPU, CUDA: norm_dtype_out
     MPS: norm_dtype_out_mps
+  tags: reduction
 
 - func: norm.out(Tensor self, Scalar? p, int[1] dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
   structured: True
@@ -6821,21 +6904,26 @@
   dispatch:
     CPU, CUDA: norm_out
     MPS: norm_out_mps
+  tags: reduction
 
 # These four redispatch in their implementation, so OK to be CompositeImplicitAutograd
 - func: norm.names_ScalarOpt_dim_dtype(Tensor self, Scalar? p, Dimname[1] dim, bool keepdim, *, ScalarType dtype) -> Tensor
   device_check: NoCheck   # TensorIterator
   variants: function, method
+  tags: reduction
 
 - func: norm.names_ScalarOpt_dim(Tensor self, Scalar? p, Dimname[1] dim, bool keepdim=False) -> Tensor
   device_check: NoCheck   # TensorIterator
   variants: function, method
+  tags: reduction
 
 - func: norm.names_dtype_out(Tensor self, Scalar? p, Dimname[1] dim, bool keepdim, *, ScalarType dtype, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
+  tags: reduction
 
 - func: norm.names_out(Tensor self, Scalar? p, Dimname[1] dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
+  tags: reduction
 
 - func: frexp.Tensor(Tensor self) -> (Tensor mantissa, Tensor exponent)
   variants: method, function
@@ -7492,6 +7580,7 @@
   dispatch:
     CompositeExplicitAutograd: unbind
     NestedTensorCPU, NestedTensorHPU, NestedTensorCUDA: NestedTensor_unbind
+  tags: view
 
 - func: unbind.Dimname(Tensor(a -> *) self, Dimname dim) -> Tensor(a)[]
   variants: function, method
@@ -8034,6 +8123,7 @@
 - func: lift_fresh(Tensor(a) self) -> Tensor(a)
   dispatch:
     CompositeExplicitAutograd: lift_fresh
+  tags: view
 
 # Like lift, but it clones the input.
 - func: lift_fresh_copy(Tensor self) -> Tensor
@@ -8123,7 +8213,7 @@
     ZeroTensor, Meta, CPU, CUDA, QuantizedCPU, QuantizedCUDA, MPS, MTIA: view
     MkldnnCPU: mkldnn_view
     NestedTensorCPU, NestedTensorHPU, NestedTensorCUDA: view_nested
-  tags: core
+  tags: [core, view]
 
 # Warning: If you want to change the name or overload name of this
 # operator, you might also want to change the `isBlockListedSchema`
@@ -8137,6 +8227,7 @@
   device_guard: False
   dispatch:
     CompositeExplicitAutograd: view_dtype
+  tags: view
 
 - func: put_(Tensor(a!) self, Tensor index, Tensor source, bool accumulate=False) -> Tensor(a!)
   variants: method
@@ -9999,12 +10090,14 @@
     CPU, CUDA: min
     MPS: min_mps
     QuantizedCPU: min_quantized_cpu
+  tags: reduction
 
 - func: min.unary_out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
   dispatch:
     CPU, CUDA: min_unary_out
     QuantizedCPU: min_quantized_unary_out
+  tags: reduction
 
 - func: fmin(Tensor self, Tensor other) -> Tensor
   structured_delegate: fmin.out
@@ -10027,6 +10120,7 @@
     CPU, CUDA: max
     MPS: max_mps
     QuantizedCPU: max_quantized_cpu
+  tags: reduction
 
 - func: fmax(Tensor self, Tensor other) -> Tensor
   structured_delegate: fmax.out
@@ -10073,6 +10167,7 @@
   dispatch:
     CPU, CUDA: max_unary_out
     QuantizedCPU: max_quantized_unary_out
+  tags: reduction
 
 - func: minimum(Tensor self, Tensor other) -> Tensor
   structured_delegate: minimum.out
@@ -10192,6 +10287,7 @@
   device_check: NoCheck   # TensorIterator
   structured_delegate: all.all_out
   variants: method, function
+  tags: reduction
 
 - func: all.all_out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck
@@ -10199,6 +10295,7 @@
   dispatch:
     CPU, CUDA: all_all_out
     MPS: all_all_out_mps
+  tags: reduction
 
 - func: any(Tensor self) -> Tensor
   device_check: NoCheck   # TensorIterator
@@ -10206,7 +10303,7 @@
   variants: method, function
   dispatch:
     SparseCPU, SparseCUDA: any_sparse
-  tags: core
+  tags: [core, reduction]
 
 - func: any.all_out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck
@@ -10214,6 +10311,7 @@
   dispatch:
     CPU, CUDA: any_all_out
     MPS: any_all_out_mps
+  tags: reduction
 
 - func: renorm.out(Tensor self, Scalar p, int dim, Scalar maxnorm, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
@@ -10239,6 +10337,7 @@
   dispatch:
     CPU, CUDA, Meta, MPS: unfold
     QuantizedCPU, QuantizedCUDA: unfold
+  tags: view
 
 - func: unfold_backward(Tensor grad_in, SymInt[] input_sizes, int dim, int size, int step) -> Tensor
   variants: function
@@ -10419,7 +10518,7 @@
   dispatch:
     CompositeExplicitAutograd: alias
     NestedTensorCPU, NestedTensorHPU, NestedTensorCUDA: alias_nested
-  tags: core
+  tags: [core, view]
 
 - func: _amp_foreach_non_finite_check_and_unscale_(Tensor(a!)[] self, Tensor(b!) found_inf, Tensor inv_scale) -> ()
   variants: function
@@ -13587,9 +13686,11 @@
 - func: special_logsumexp(Tensor self, int[1] dim, bool keepdim=False) -> Tensor
   python_module: special
   variants: function
+  tags: reduction
 
 - func: special_logsumexp.out(Tensor self, int[1] dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
   python_module: special
+  tags: reduction
 
 - func: special_expit(Tensor self) -> Tensor
   python_module: special
@@ -14238,6 +14339,7 @@
   python_module: linalg
   variants: function
   structured_delegate: linalg_vector_norm.out
+  tags: reduction
 
 - func: linalg_vector_norm.out(Tensor self, Scalar ord=2, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
   python_module: linalg
@@ -14245,6 +14347,7 @@
   dispatch:
     CPU, CUDA: linalg_vector_norm_out
     MPS: linalg_vector_norm_out_mps
+  tags: reduction
 
 - func: linalg_matrix_norm(Tensor self, Scalar ord, int[] dim=[-2,-1], bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
   python_module: linalg

--- a/aten/src/ATen/native/tags.yaml
+++ b/aten/src/ATen/native/tags.yaml
@@ -82,6 +82,14 @@
           Pointwise operators are operators where each element of the output is computed only by accessing
           the corresponding element of all the broadcasted inputs. The output shape will be the broadcasted
           shape of the inputs.
+- tag: reduction
+  desc: |
+          Reduction operations aggregate tensor elements along one or more dimensions,
+          producing an output with fewer dimensions.
+- tag: view
+  desc: |
+          This tag indicates that the operator creates a pure view/alias Tensor and has an explicit
+          derivative formula in derivates.yaml.
 - tag: maybe_aliasing_or_mutating
   desc: |
           For some ops, we can't statically determine whether the op is functional or not. Note that this is only

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -41,6 +41,7 @@ from torch.testing._internal.common_dtype import (
 from torch.testing._internal.common_methods_invocations import (
     BinaryUfuncInfo,
     op_db,
+    OpInfo,
     ops_and_refs,
     python_ref_db,
     ReductionOpInfo,
@@ -73,6 +74,7 @@ from torch.testing._internal.common_utils import (
     unMarkDynamoStrictTest,
 )
 from torch.testing._internal.inductor_utils import maybe_skip_size_asserts
+from torch.testing._internal.opinfo.utils import compute_reduced_shape
 from torch.utils._python_dispatch import TorchDispatchMode
 from torch.utils._pytree import tree_map
 
@@ -329,7 +331,7 @@ class TestCommon(TestCase):
     def test_view_tag_coverage(self):
         # These operators have the inferred property is_view according to their declaration in native_functions.yaml
         # but they are not pure view operators since they create a copy under certain conditions
-        not_view_operators = ["to", "copy"]
+        not_view_operators = ["to", "copy", "lift_fresh"]
 
         # These are registered in register_prim_ops.cpp or register_special_ops.cpp
         # they are not registered to CompositeExplicitAutograd and hence should not carry the view tag.
@@ -2365,6 +2367,72 @@ class _TestTagsMode(TorchDispatchMode):
         return rs
 
 
+class _TestViewTagsMode(TorchDispatchMode):
+    def __init__(self, test_case: TestCase):
+        super().__init__()
+        self.test_case = test_case
+        self.base_tensors = []
+        self.output_tensors = []
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        # Sometimes, a single operator calls internally to a view operator more than once.
+        # This is why we need to store the outputs in an array
+        # Checking that the output tensor is view inside __torch_dispatch__ doesn't work
+        # since inside the dispatch, the tensor is not yet marked as view of the input tensor
+        output = func(*args, **kwargs)
+        # A detached tensor is not a view according to _is_view()
+        if torch.Tag.view in func.tags and "detach" not in func.name():
+            base_tensor = args[0]._base if args[0]._is_view() else args[0]
+            self.base_tensors.append(base_tensor)
+            self.output_tensors.append(output)
+
+        return output
+
+    def assert_all_views(self):
+        base_tensors, output_tensors = self.base_tensors, self.output_tensors
+        for base, output in zip(base_tensors, output_tensors):
+            # Some operators return list of views, like split
+            outputs = output if isinstance(output, Sequence) else [output]
+            for o in outputs:
+                self._assert_view_of(o, base)
+
+    def _assert_view_of(self, view_tensor, base_tensor):
+        self.test_case.assertTrue(view_tensor._is_view())
+        self.test_case.assertIs(view_tensor._base, base_tensor)
+
+
+class _TestReductionTagsMode(TorchDispatchMode):
+    """
+    This class provides a torch dispatch that verify that all operators marked as reduction indeed reduce the
+    dimension of the input tensor
+    """
+
+    def __init__(self, test_case: TestCase):
+        super().__init__()
+        self.test_case = test_case
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        output = func(*args, **kwargs)
+        # These are reduction operators but with different schema
+        operators_to_skip = [
+            "prims::var",
+            "aten::linalg_vector_norm",
+            "aten::norm.ScalarOpt_dim",
+        ]
+        if torch.Tag.reduction not in func.tags or func.name() in operators_to_skip:
+            return output
+
+        input_tensor = args[0]
+        dims = args[1] if len(args) >= 2 else (kwargs.get("dims") or kwargs.get("dim"))
+        keepdim = args[2] if len(args) >= 3 else kwargs.get("keepdim", False)
+
+        expected_shape = compute_reduced_shape(input_tensor.shape, True, dims, keepdim)
+        outputs = output if isinstance(output, Sequence) else [output]
+        for o in outputs:
+            self.test_case.assertEqual(o.shape, expected_shape)
+        return output
+
+
 # Test to verify the correctness for tags in `tags.yaml`, also available for access through `torch.Tags`
 @unMarkDynamoStrictTest
 class TestTags(TestCase):
@@ -2384,6 +2452,16 @@ class TestTags(TestCase):
                 aten_name = op.aten_name if op.aten_name is not None else op.name
                 opoverloadpacket = getattr(torch.ops.aten, aten_name, None)
                 check_inplace_view(opoverloadpacket, input, rs, old_size, old_stride)
+
+    @ops(op_db, dtypes=OpDTypes.any_one)
+    def test_view_ops(self, device, dtype, op: OpInfo):
+        # Verify that all operators marked with view indeed return a view of the input fake tensor
+        samples = op.sample_inputs(device, dtype, requires_grad=False)
+        for sample in samples:
+            with _TestViewTagsMode(self) as view_tag_mode:
+                op(sample.input, *sample.args, **sample.kwargs)
+
+            view_tag_mode.assert_all_views()
 
 
 class TestSelfKwarg(TestCase):
@@ -2741,16 +2819,7 @@ class TestFakeTensor(TestCase):
                 continue
 
             def run_with_fake_mode_and_verify(fake_mode, match_results=True):
-                def map_to_fake(e):
-                    if isinstance(e, torch.Tensor):
-                        return fake_mode.from_tensor(e)
-                    else:
-                        return e
-
-                input = tree_map(map_to_fake, sample.input)
-                args = tree_map(map_to_fake, sample.args)
-                kwargs = tree_map(map_to_fake, sample.kwargs)
-
+                input, args, kwargs = self._map_sample_to_fake(fake_mode, sample)
                 try:
                     with context():
                         with fake_mode:
@@ -2819,6 +2888,56 @@ class TestFakeTensor(TestCase):
                     allow_dynamic_output_shape_mode, match_results=False
                 )
 
+    def _map_sample_to_fake(self, fake_mode, sample):
+        def map_to_fake(e):
+            if isinstance(e, torch.Tensor):
+                return fake_mode.from_tensor(e)
+            else:
+                return e
+
+        input = tree_map(map_to_fake, sample.input)
+        args = tree_map(map_to_fake, sample.args)
+        kwargs = tree_map(map_to_fake, sample.kwargs)
+        return input, args, kwargs
+
+    def _verify_op_with_fake_mode(self, fake_mode, op, input, args, kwargs):
+        try:
+            with fake_mode:
+                op(input, *args, **kwargs)
+        except RuntimeError:
+            return False
+        return True
+
+    @ops(op_db, dtypes=OpDTypes.any_one)
+    def test_reduction_ops(self, device, dtype, op: OpInfo):
+        samples = op.sample_inputs(device, dtype, requires_grad=False)
+        for sample in samples:
+            fake_mode = FakeTensorMode()
+            input, args, kwargs = self._map_sample_to_fake(fake_mode, sample)
+
+            if not self._verify_op_with_fake_mode(fake_mode, op, input, args, kwargs):
+                continue
+
+            with _TestReductionTagsMode(self):
+                with fake_mode:
+                    op(input, *args, **kwargs)
+
+    @ops(op_db, dtypes=OpDTypes.any_one)
+    def test_view_ops(self, device, dtype, op: OpInfo):
+        samples = op.sample_inputs(device, dtype, requires_grad=False)
+        for sample in samples:
+            fake_mode = FakeTensorMode()
+            input, args, kwargs = self._map_sample_to_fake(fake_mode, sample)
+
+            if not self._verify_op_with_fake_mode(fake_mode, op, input, args, kwargs):
+                continue
+
+            with _TestViewTagsMode(self) as view_tag_mode:
+                with fake_mode:
+                    op(input, *args, **kwargs)
+
+            view_tag_mode.assert_all_views()
+
     @ops(op_db, dtypes=OpDTypes.any_one)
     def test_pointwise_ops(self, device, dtype, op):
         name = op.name
@@ -2853,15 +2972,7 @@ class TestFakeTensor(TestCase):
         for sample in samples:
             mode = FakeTensorMode()
 
-            def map_to_fake(e):
-                if isinstance(e, torch.Tensor):
-                    return mode.from_tensor(e)
-                else:
-                    return e
-
-            input = tree_map(map_to_fake, sample.input)
-            args = tree_map(map_to_fake, sample.args)
-            kwargs = tree_map(map_to_fake, sample.kwargs)
+            input, args, kwargs = self._map_sample_to_fake(mode, sample)
 
             try:
                 op(input, *args, **kwargs)

--- a/torch/testing/_internal/opinfo/utils.py
+++ b/torch/testing/_internal/opinfo/utils.py
@@ -254,6 +254,36 @@ def reference_reduction_numpy(f, supports_keepdims=True):
     return wrapper
 
 
+def compute_reduced_shape(shape, empty_dim_as_none=False, dim=None, keepdim=False):
+    """Computes the expected reduced shape given dim and keepdim
+
+    Args:
+        shape: The shape to reduce
+        empty_dim_as_none: If True, treat dim=[] as reduction along all dimensions (like dim=None)
+        dim: The dimensions to reduce
+        keepdim: If true, reduced dimensions have size 1 in the reduced shape,
+            otherwise they are removed from the reduced shape.
+
+    Returns:
+        The reduced shape
+    """
+    if dim is None or (empty_dim_as_none and dim == []):
+        return [1] * len(shape) if keepdim else []
+
+    # Wrap negative dims
+    dim = dim if isinstance(dim, Sequence) else [dim]
+    dim = {i if i >= 0 else len(shape) + i for i in dim}
+
+    result = []
+    for i, size in enumerate(shape):
+        if i not in dim:
+            result.append(size)
+        elif keepdim:
+            result.append(1)
+
+    return result
+
+
 def prod_numpy(a, *args, **kwargs):
     """
     The function will call np.prod with type as np.int64 if the input type


### PR DESCRIPTION
Fixes #129020

Here's lists of the operator names annotated with view and reduction tags:
`view` overloads:
as_strided, detach, view_as_real, view_as_complex, diagonal, select, slice, transpose, split, t, expand, view, unsqueeze, unfold, squeeze, permute, unbind, split_with_sizes, alias

`reduction` overloads:
sum, mean, amin, amax, argmin, argmax, prod, all, norm, var, std, aminmax, nansum, logsumexp, any, std_mean, var_mean, count_nonzero, linalg_vector_norm, max, min