### PR TITLE
[MPSInductor] Fix multistage reduction suffixes

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -160,13 +160,6 @@ class MPSBasicTests(TestCase):
 
         self.common(fn, (torch.rand(10), torch.ones(10)))
 
-    def test_multistage_norm(self):
-        # Regression test for https://github.com/pytorch/pytorch/issues/152155
-        def fn(x):
-            return x / x.sum()
-
-        self.common(fn, (torch.rand(2048),))
-
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -160,6 +160,13 @@ class MPSBasicTests(TestCase):
 
         self.common(fn, (torch.rand(10), torch.ones(10)))
 
+    def test_multistage_norm(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/152155
+        def fn(x):
+            return x / x.sum()
+
+        self.common(fn, (torch.rand(2048),))
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -12759,6 +12759,9 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         a = torch.randn(512, 4096, requires_grad=True)
         b = torch.randint(size=(512,), low=0, high=4095)
 
+        if self.device == "mps" and MACOS_VERSION < 13.3:
+            raise unittest.SkipTest("Fails with internal compiler error on MacOS-13")
+
         self.common(forward, (a, b))
 
     @xfail_if_mps_unimplemented

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -12808,7 +12808,6 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         b = torch.randn(2, 1, requires_grad=True)
         self.common(forward, (a, b))
 
-    @xfail_if_mps
     @config.patch(implicit_fallbacks=True)
     def test_weight_norm_bwd(self):
         """

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -12747,7 +12747,6 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         self.assertTrue((actual == 1).all())
 
     @skip_if_gpu_halide
-    @xfail_if_mps  # Inductor syntax error
     def test_pattern_matcher_multi_user(self):
         # Reproducer for https://github.com/pytorch/pytorch/issues/129685
 

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -759,7 +759,7 @@ class MetalKernel(SIMDKernel):
                 self.body.splice(self.compute)
             self.body.writeline("}")
             # Invalidate variables instantiated inside loop
-            self.cse.invalidate(OrderedSet(self.cse.store_cache.values()))
+            self.cse.invalidate(OrderedSet(self.cse.reduction_cache.values()))
             # And loop codegen
             self.multistage_reduction_entry.cache_clear()
             self.multistage_reduction_entry = None

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -472,6 +472,7 @@ class MetalKernel(SIMDKernel):
     sexpr = MetalExprPrinter().doprint
     kexpr = sexpr
     headers: OrderedSet[str] = OrderedSet(["utils"])
+    multistage_reduction_entry: Optional[IterationRangesEntry] = None
 
     def __init__(
         self,
@@ -480,7 +481,6 @@ class MetalKernel(SIMDKernel):
     ) -> None:
         super().__init__(tiling, **kwargs)
         self.acc_var_ids = itertools.count()
-        self.multistage_reduction = False
 
     def dtype_to_str(self, dtype: torch.dtype) -> str:
         return DTYPE_TO_METAL[dtype]
@@ -617,7 +617,7 @@ class MetalKernel(SIMDKernel):
             acc_buf = self._new_idxvar(
                 acc_dtype, ceildiv(acc_buf_size, self.simd_group_size)
             )
-            if not self.multistage_reduction:
+            if not self.multistage_reduction_entry:
                 val = value
             else:
                 default_val, reduction_op = (
@@ -636,7 +636,7 @@ class MetalKernel(SIMDKernel):
             acc_buf = self._new_idxvar(src_dtype, acc_buf_size)
             acc_thread_var = f"{acc_buf}[{reduction_idx}]"
             src_metal_type = DTYPE_TO_METAL[src_dtype]
-            if not self.multistage_reduction:
+            if not self.multistage_reduction_entry:
                 self.compute.splice(
                     f"{acc_thread_var} = static_cast<{src_metal_type}>({value});"
                 )
@@ -677,7 +677,7 @@ class MetalKernel(SIMDKernel):
                 dtype=dtype,
             )
         if reduction_type == "welford_reduce":
-            if not self.multistage_reduction:
+            if not self.multistage_reduction_entry:
                 acc_buf = self._new_idxvar(src_dtype, acc_buf_size)
                 self.compute.splice(f"{acc_buf}[{reduction_idx}] = {value};")
                 wf_res = self.cse.generate(
@@ -702,7 +702,7 @@ class MetalKernel(SIMDKernel):
             acc_thread_var = f"{acc_buf}[{reduction_idx}]"
             inp_value = f"float3({value[0]}, {value[1]}, {value[2]})"
             self.indexing_code.splice(f"{acc_thread_var} = 0.0;")
-            if self.multistage_reduction:
+            if self.multistage_reduction_entry:
                 self.indexing_code.splice(f"{acc_thread_var} = 0.0;")
                 self.compute.writeline(
                     f"{acc_thread_var} = ::c10::metal::welford_combine({acc_thread_var}, {inp_value});"
@@ -710,7 +710,7 @@ class MetalKernel(SIMDKernel):
             else:
                 self.compute.writeline(f"{acc_thread_var} = {inp_value};")
             wf_res = self.cse.generate(
-                self.stores if self.multistage_reduction else self.compute,
+                self.stores if self.multistage_reduction_entry else self.compute,
                 f"c10::metal::threadgroup_{reduction_type}({acc_buf}, {acc_buf_size})",
             )
             return OpsWrapper._unwrap((f"{wf_res}.x", f"{wf_res}.y", f"{wf_res}.z"))
@@ -719,9 +719,9 @@ class MetalKernel(SIMDKernel):
     def codegen_iteration_ranges_entry(self, entry: IterationRangesEntry) -> None:
         index_expr = self.rename_indexing(entry.expr)
         index_str = self.sexpr(index_expr)  # type: ignore[misc]
-        if entry.is_reduction:
-            self.multistage_reduction = entry.root.numel > self.max_threadgroup_size
-        if not entry.is_reduction or not self.multistage_reduction:
+        if entry.is_reduction and entry.root.numel > self.max_threadgroup_size:
+            self.multistage_reduction_entry = entry
+        if self.multistage_reduction_entry is None:
             self.indexing_code.writeline(
                 f"{self.index_dtype} {entry.name} = {index_str};"
             )
@@ -753,12 +753,16 @@ class MetalKernel(SIMDKernel):
         For reduction kernels, this generates a loop over the reduction
         axis.
         """
-        if self.multistage_reduction:
+        if self.multistage_reduction_entry:
             with self.body.indent():
                 self.body.splice(self.loads)
                 self.body.splice(self.compute)
             self.body.writeline("}")
-            self.multistage_reduction = False
+            # Invalidate variables instantiated inside loop
+            self.cse.invalidate(OrderedSet(self.cse.store_cache.values()))
+            # And loop codegen
+            self.multistage_reduction_entry.cache_clear()
+            self.multistage_reduction_entry = None
         else:
             self.body.splice(self.loads)
             self.body.splice(self.compute)

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -721,7 +721,7 @@ class MetalKernel(SIMDKernel):
         index_str = self.sexpr(index_expr)  # type: ignore[misc]
         if entry.is_reduction and entry.root.numel > self.max_threadgroup_size:
             self.multistage_reduction_entry = entry
-        if self.multistage_reduction_entry is None:
+        if not entry.is_reduction or self.multistage_reduction_entry is None:
             self.indexing_code.writeline(
                 f"{self.index_dtype} {entry.name} = {index_str};"
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #153362


By invalidating all variable created during the loop except for the context of iterator_cache, as storage can be done inside reduction loop and clear `IteratorRangeEntry` codegen cache.

Which results in the following kernel for `x / x.sum()` if x size is 2048 and max thread group size is 1024
```metal
[[max_total_threads_per_threadgroup(1024)]]
kernel void generated_kernel(
    device half* out_ptr1,
    constant half* in_ptr0, 
    uint2 thread_pos [[thread_position_in_grid]],
    uint2 group_pos [[thread_position_in_threadgroup]]
) {
    auto xindex = thread_pos.x;
    auto r0_index = thread_pos.y;
    threadgroup float tmp_acc_0[32];
    float tmp_acc_1 = 0;
    for(auto r0_0_cnt = 0; r0_0_cnt < 2; ++r0_0_cnt) {
        int r0_0 = 2 * r0_index + r0_0_cnt;
        auto tmp0 = static_cast<float>(in_ptr0[r0_0]);
        tmp_acc_1 += tmp0;
    } 
    auto tmp1 = c10::metal::threadgroup_sum(tmp_acc_0, tmp_acc_1, r0_index * 1, 1024);   
    for(auto r0_0_cnt = 0; r0_0_cnt < 2; ++r0_0_cnt) {
        int r0_0 = 2 * r0_index + r0_0_cnt;
        auto tmp2 = static_cast<float>(in_ptr0[r0_0]);
        auto tmp3 = tmp2 / tmp1;
        out_ptr1[r0_0] = static_cast<half>(tmp3);
    } 
}
```

Fixes compilation report reported while running `GPUTests.test_pattern_matcher_multi_user_mps` and `GPUTests.test_weight_norm_bwd_mps`

Fixes https://github.com/pytorch/pytorch/issues/152155

Though inductor tests are still failing, need to keep refining the variable invalidation

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov