### PR TITLE
Fix the type hint of `step()` with default value

### DIFF
--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -1004,7 +1004,7 @@ class Optimizer:
                         torch._foreach_zero_(grads)
 
     @overload
-    def step(self, closure: None = ...) -> None:
+    def step(self, closure: None = None) -> None:
         ...
 
     @overload


### PR DESCRIPTION
Summary: Because the default value of `closure` is `None`, this fixes the situation when `step()`. The previous typing (https://github.com/pytorch/pytorch/pull/102593) could only be used as `step(closure=None)` and `step(None)`.

Test Plan: contbuild & OSS CI

Differential Revision: D74560785




cc @ezyang @malfet @xuzhao9 @gramster