### PR TITLE
[ATen][CUDA][CUB] Implement changes to CCCL (CUB/Thrust/LibCUDACXX) usage in ATen

### DIFF
--- a/aten/src/ATen/cuda/cub.cu
+++ b/aten/src/ATen/cuda/cub.cu
@@ -2,10 +2,8 @@
 #include <ATen/cuda/cub.cuh>
 #include <ATen/cuda/CUDAConfig.h>
 
-#if CUB_V3_PLUS()
 #include <cuda/std/functional>
 #include <thrust/iterator/transform_iterator.h>
-#endif
 
 namespace at::cuda::cub {
 
@@ -20,12 +18,7 @@ struct SumOp {
 
 template <typename input_t, typename output_t>
 void inclusive_sum_truncating(const input_t *input, output_t *output, int64_t num_items) {
-#if CUB_V3_PLUS()
   inclusive_scan(input, output, ::cuda::std::plus<>{}, num_items);
-#else
-  using NO_ROCM(at_cuda_detail)::cub::Sum;
-  inclusive_scan(input, output, Sum{}, num_items);
-#endif
 }
 
 template void inclusive_sum_truncating(const int32_t *input, int32_t *output, int64_t num_items);
@@ -51,12 +44,7 @@ struct CountMaskOp {
 
 void mask_exclusive_sum(const uint8_t *mask, int64_t *output_idx, int64_t n) {
   CountMaskOp op{};
-#if CUB_V3_PLUS()
   auto iter = thrust::transform_iterator<decltype(op), decltype(mask)>(mask, op);
-#else
-  auto iter = NO_ROCM(at_cuda_detail)::cub::TransformInputIterator<
-      bool, decltype(op), decltype(mask)>(mask, op);
-#endif
   exclusive_scan(iter, output_idx, SumOp<int64_t>{}, int64_t{0}, n);
 }
 

--- a/aten/src/ATen/cuda/cub.cu
+++ b/aten/src/ATen/cuda/cub.cu
@@ -3,7 +3,6 @@
 #include <ATen/cuda/CUDAConfig.h>
 
 #include <cuda/std/functional>
-#include <thrust/iterator/transform_iterator.h>
 
 namespace at::cuda::cub {
 
@@ -44,7 +43,7 @@ struct CountMaskOp {
 
 void mask_exclusive_sum(const uint8_t *mask, int64_t *output_idx, int64_t n) {
   CountMaskOp op{};
-  auto iter = thrust::transform_iterator<decltype(op), decltype(mask)>(mask, op);
+  auto iter = ATEN_CUB_TRANSFORM_ITERATOR(bool, decltype(op), decltype(mask))(mask, op);
   exclusive_scan(iter, output_idx, SumOp<int64_t>{}, int64_t{0}, n);
 }
 

--- a/aten/src/ATen/cuda/cub.cu
+++ b/aten/src/ATen/cuda/cub.cu
@@ -2,6 +2,11 @@
 #include <ATen/cuda/cub.cuh>
 #include <ATen/cuda/CUDAConfig.h>
 
+#if CUB_V3_PLUS()
+#include <cuda/std/functional>
+#include <thrust/iterator/transform_iterator.h>
+#endif
+
 namespace at::cuda::cub {
 
 namespace {
@@ -15,8 +20,12 @@ struct SumOp {
 
 template <typename input_t, typename output_t>
 void inclusive_sum_truncating(const input_t *input, output_t *output, int64_t num_items) {
+#if CUB_V3_PLUS()
+  inclusive_scan(input, output, ::cuda::std::plus<>{}, num_items);
+#else
   using NO_ROCM(at_cuda_detail)::cub::Sum;
   inclusive_scan(input, output, Sum{}, num_items);
+#endif
 }
 
 template void inclusive_sum_truncating(const int32_t *input, int32_t *output, int64_t num_items);
@@ -42,8 +51,12 @@ struct CountMaskOp {
 
 void mask_exclusive_sum(const uint8_t *mask, int64_t *output_idx, int64_t n) {
   CountMaskOp op{};
+#if CUB_V3_PLUS()
+  auto iter = thrust::transform_iterator<decltype(op), decltype(mask)>(mask, op);
+#else
   auto iter = NO_ROCM(at_cuda_detail)::cub::TransformInputIterator<
       bool, decltype(op), decltype(mask)>(mask, op);
+#endif
   exclusive_scan(iter, output_idx, SumOp<int64_t>{}, int64_t{0}, n);
 }
 

--- a/aten/src/ATen/cuda/cub.cu
+++ b/aten/src/ATen/cuda/cub.cu
@@ -2,8 +2,6 @@
 #include <ATen/cuda/cub.cuh>
 #include <ATen/cuda/CUDAConfig.h>
 
-#include <cuda/std/functional>
-
 namespace at::cuda::cub {
 
 namespace {

--- a/aten/src/ATen/cuda/cub.cu
+++ b/aten/src/ATen/cuda/cub.cu
@@ -15,7 +15,7 @@ struct SumOp {
 
 template <typename input_t, typename output_t>
 void inclusive_sum_truncating(const input_t *input, output_t *output, int64_t num_items) {
-  inclusive_scan(input, output, ::cuda::std::plus<>{}, num_items);
+  inclusive_scan(input, output, NO_ROCM(::cuda)::std::plus<>{}, num_items);
 }
 
 template void inclusive_sum_truncating(const int32_t *input, int32_t *output, int64_t num_items);

--- a/aten/src/ATen/cuda/cub.cuh
+++ b/aten/src/ATen/cuda/cub.cuh
@@ -59,13 +59,15 @@
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/constant_iterator.h>
-#define ATEN_CUB_TRANSFORM_ITERATOR(ValueType, ...) thrust::transform_iterator<__VA_ARGS__>
-#define ATEN_CUB_COUNTING_ITERATOR(...) thrust::counting_iterator<__VA_ARGS__>
-#define ATEN_CUB_CONSTANT_ITERATOR(...) thrust::constant_iterator<__VA_ARGS__>
+#define ATEN_CUB_TRANSFORM_ITERATOR(ValueType, ...) ::thrust::transform_iterator<__VA_ARGS__>
+#define ATEN_CUB_COUNTING_ITERATOR(...) ::thrust::counting_iterator<__VA_ARGS__>
+#define ATEN_CUB_CONSTANT_ITERATOR(...) ::thrust::constant_iterator<__VA_ARGS__>
+#define ATEN_CUB_MAXIMUM() ::cuda::maximum<>()
 #else
 #define ATEN_CUB_TRANSFORM_ITERATOR(...) NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::TransformInputIterator<__VA_ARGS__>
 #define ATEN_CUB_COUNTING_ITERATOR(...) NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::CountingInputIterator<__VA_ARGS__>
 #define ATEN_CUB_CONSTANT_ITERATOR(...) NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::ConstantInputIterator<__VA_ARGS__>
+#define ATEN_CUB_MAXIMUM() NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::Max()
 #endif
 
 #if (!defined(USE_ROCM) && !CUB_SUPPORTS_NV_BFLOAT16()) || defined(USE_ROCM)

--- a/aten/src/ATen/cuda/cub.cuh
+++ b/aten/src/ATen/cuda/cub.cuh
@@ -43,9 +43,9 @@
 #define ATEN_CUB_COUNTING_ITERATOR(...) thrust::counting_iterator<__VA_ARGS__>
 #define ATEN_CUB_CONSTANT_ITERATOR(...) thrust::constant_iterator<__VA_ARGS__>
 #else
-#define ATEN_CUB_TRANSFORM_ITERATOR(...) cub::TransformInputIterator<__VA_ARGS__>
-#define ATEN_CUB_COUNTING_ITERATOR(...) cub::CountingInputIterator<__VA_ARGS__>
-#define ATEN_CUB_CONSTANT_ITERATOR(...) cub::ConstantInputIterator<__VA_ARGS__>
+#define ATEN_CUB_TRANSFORM_ITERATOR(...) NO_ROCM(at_cuda_detail)::cub::TransformInputIterator<__VA_ARGS__>
+#define ATEN_CUB_COUNTING_ITERATOR(...) NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::CountingInputIterator<__VA_ARGS__>
+#define ATEN_CUB_CONSTANT_ITERATOR(...) NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::ConstantInputIterator<__VA_ARGS__>
 #endif
 
 // handle the temporary storage and 'twice' calls for cub API

--- a/aten/src/ATen/cuda/cub.cuh
+++ b/aten/src/ATen/cuda/cub.cuh
@@ -63,7 +63,7 @@
 #define ATEN_CUB_COUNTING_ITERATOR(...) thrust::counting_iterator<__VA_ARGS__>
 #define ATEN_CUB_CONSTANT_ITERATOR(...) thrust::constant_iterator<__VA_ARGS__>
 #else
-#define ATEN_CUB_TRANSFORM_ITERATOR(...) NO_ROCM(at_cuda_detail)::cub::TransformInputIterator<__VA_ARGS__>
+#define ATEN_CUB_TRANSFORM_ITERATOR(...) NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::TransformInputIterator<__VA_ARGS__>
 #define ATEN_CUB_COUNTING_ITERATOR(...) NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::CountingInputIterator<__VA_ARGS__>
 #define ATEN_CUB_CONSTANT_ITERATOR(...) NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::ConstantInputIterator<__VA_ARGS__>
 #endif

--- a/aten/src/ATen/cuda/cub.cuh
+++ b/aten/src/ATen/cuda/cub.cuh
@@ -270,7 +270,8 @@ inline void inclusive_scan(InputIteratorT input, OutputIteratorT output, ScanOpT
         return x.value;
       }
     };
-    auto input_ = thrust::make_transform_iterator(ArgIndexInputIterator(input + i), input_iter_transform);
+    auto input_ = thrust::thrust::transform_iterator<decltype(input_iter_transform), ArgIndexInputIterator>(
+        ArgIndexInputIterator(input + i), input_iter_transform);
     CUB_WRAPPER(NO_ROCM(at_cuda_detail)::cub::DeviceScan::InclusiveScan,
         input_,
         output + i,
@@ -424,7 +425,7 @@ __global__ void calc_block_sums(const T * d_in, aggT * agg, int64_t nelem, int i
     aggT data[ITEMS_PER_THREAD];
     aggT agg_val = 0;
     TransformFunctor<T, aggT, nonzero> transform_functor;
-    auto iter_in = thrust::make_transform_iterator(d_in, transform_functor);
+    auto iter_in = thrust::transform_iterator<TransformFunctor<T, aggT, nonzero>, const T*>(d_in, transform_functor);
     for (int i=0; i<iters_per_cta; i++){
       if (remaining >= BLOCK_THREADS * ITEMS_PER_THREAD) {
         BlockLoadT(temp_storage.load).Load(iter_in, data);

--- a/aten/src/ATen/cuda/cub.cuh
+++ b/aten/src/ATen/cuda/cub.cuh
@@ -45,7 +45,7 @@
 #else
 #define ATEN_CUB_TRANSFORM_ITERATOR(...) cub::TransformInputIterator<__VA_ARGS__>
 #define ATEN_CUB_COUNTING_ITERATOR(...) cub::CountingInputIterator<__VA_ARGS__>
-#define ATEN_CUB_COUNTING_ITERATOR(...) cub::ConstantInputIterator<__VA_ARGS__>
+#define ATEN_CUB_CONSTANT_ITERATOR(...) cub::ConstantInputIterator<__VA_ARGS__>
 #endif
 
 // handle the temporary storage and 'twice' calls for cub API

--- a/aten/src/ATen/cuda/cub.cuh
+++ b/aten/src/ATen/cuda/cub.cuh
@@ -585,7 +585,7 @@ inline void inclusive_sum_by_key(KeysInputIteratorT keys, ValuesInputIteratorT i
     "cub InclusiveSumByKey does not support more than INT_MAX elements");
 #if !defined(USE_ROCM)
   CUB_WRAPPER(at_cuda_detail::cub::DeviceScan::InclusiveSumByKey,
-      keys, input, output, num_items, ::cuda::std::equal_to<>(), at::cuda::getCurrentCUDAStream());
+      keys, input, output, num_items, NO_ROCM(::cuda)::std::equal_to<>(), at::cuda::getCurrentCUDAStream());
 #else
   CUB_WRAPPER(cub::DeviceScan::InclusiveSumByKey,
       keys, input, output, num_items, hipcub::Equality(), at::cuda::getCurrentCUDAStream());
@@ -598,7 +598,7 @@ inline void inclusive_scan_by_key(KeysInputIteratorT keys, ValuesInputIteratorT 
     "cub InclusiveSumByKey does not support more than INT_MAX elements");
 #if !defined(USE_ROCM)
   CUB_WRAPPER(at_cuda_detail::cub::DeviceScan::InclusiveScanByKey,
-      keys, input, output, scan_op, num_items, ::cuda::std::equal_to<>(), at::cuda::getCurrentCUDAStream());
+      keys, input, output, scan_op, num_items, NO_ROCM(::cuda)::std::equal_to<>(), at::cuda::getCurrentCUDAStream());
 #else
   CUB_WRAPPER(cub::DeviceScan::InclusiveScanByKey,
       keys, input, output, scan_op, num_items, hipcub::Equality(), at::cuda::getCurrentCUDAStream());

--- a/aten/src/ATen/cuda/cub.cuh
+++ b/aten/src/ATen/cuda/cub.cuh
@@ -6,6 +6,10 @@
 #include <iterator>
 #include <limits>
 
+#ifndef USE_ROCM
+#include <cuda/std/functional>
+#endif
+
 #include <ATen/cuda/cub_definitions.cuh>
 #include <ATen/cuda/CUDAContextLight.h>
 
@@ -34,20 +38,6 @@
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAStream.h>
 
-
-#if CUB_V3_PLUS()
-#include <thrust/iterator/transform_iterator.h>
-#include <thrust/iterator/counting_iterator.h>
-#include <thrust/iterator/constant_iterator.h>
-#define ATEN_CUB_TRANSFORM_ITERATOR(ValueType, ...) thrust::transform_iterator<__VA_ARGS__>
-#define ATEN_CUB_COUNTING_ITERATOR(...) thrust::counting_iterator<__VA_ARGS__>
-#define ATEN_CUB_CONSTANT_ITERATOR(...) thrust::constant_iterator<__VA_ARGS__>
-#else
-#define ATEN_CUB_TRANSFORM_ITERATOR(...) NO_ROCM(at_cuda_detail)::cub::TransformInputIterator<__VA_ARGS__>
-#define ATEN_CUB_COUNTING_ITERATOR(...) NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::CountingInputIterator<__VA_ARGS__>
-#define ATEN_CUB_CONSTANT_ITERATOR(...) NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::ConstantInputIterator<__VA_ARGS__>
-#endif
-
 // handle the temporary storage and 'twice' calls for cub API
 #define CUB_WRAPPER(func, ...) do {                                       \
   size_t temp_storage_bytes = 0;                                          \
@@ -63,6 +53,19 @@
 #else
 #define NO_ROCM(x) x
 #define ROCM_HIPCUB(x) x
+#endif
+
+#if CUB_V3_PLUS()
+#include <thrust/iterator/transform_iterator.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/constant_iterator.h>
+#define ATEN_CUB_TRANSFORM_ITERATOR(ValueType, ...) thrust::transform_iterator<__VA_ARGS__>
+#define ATEN_CUB_COUNTING_ITERATOR(...) thrust::counting_iterator<__VA_ARGS__>
+#define ATEN_CUB_CONSTANT_ITERATOR(...) thrust::constant_iterator<__VA_ARGS__>
+#else
+#define ATEN_CUB_TRANSFORM_ITERATOR(...) NO_ROCM(at_cuda_detail)::cub::TransformInputIterator<__VA_ARGS__>
+#define ATEN_CUB_COUNTING_ITERATOR(...) NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::CountingInputIterator<__VA_ARGS__>
+#define ATEN_CUB_CONSTANT_ITERATOR(...) NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::ConstantInputIterator<__VA_ARGS__>
 #endif
 
 #if (!defined(USE_ROCM) && !CUB_SUPPORTS_NV_BFLOAT16()) || defined(USE_ROCM)

--- a/aten/src/ATen/cuda/cub.cuh
+++ b/aten/src/ATen/cuda/cub.cuh
@@ -9,11 +9,6 @@
 #include <ATen/cuda/cub_definitions.cuh>
 #include <ATen/cuda/CUDAContextLight.h>
 
-#if CUB_V3_PLUS()
-#include <cuda/std/functional>
-#include <thrust/iterator/transform_iterator.h>
-#endif
-
 #if USE_GLOBAL_CUB_WRAPPED_NAMESPACE()
 
 #include <cub/cub.cuh>
@@ -275,13 +270,7 @@ inline void inclusive_scan(InputIteratorT input, OutputIteratorT output, ScanOpT
         return x.value;
       }
     };
-#if CUB_V3_PLUS()
-    auto input_ = thrust::transform_iterator<decltype(input_iter_transform), ArgIndexInputIterator>(
-      ArgIndexInputIterator(input + i), input_iter_transform);
-#else
-    auto input_ = NO_ROCM(at_cuda_detail)::cub::TransformInputIterator<input_t, decltype(input_iter_transform), ArgIndexInputIterator>(
-      ArgIndexInputIterator(input + i), input_iter_transform);
-#endif
+    auto input_ = thrust::make_transform_iterator(ArgIndexInputIterator(input + i), input_iter_transform);
     CUB_WRAPPER(NO_ROCM(at_cuda_detail)::cub::DeviceScan::InclusiveScan,
         input_,
         output + i,
@@ -435,11 +424,7 @@ __global__ void calc_block_sums(const T * d_in, aggT * agg, int64_t nelem, int i
     aggT data[ITEMS_PER_THREAD];
     aggT agg_val = 0;
     TransformFunctor<T, aggT, nonzero> transform_functor;
-#if CUB_V3_PLUS()
-    auto iter_in = thrust::transform_iterator<TransformFunctor<T, aggT, nonzero>, const T*>(d_in, transform_functor);
-#else
-    auto iter_in = ROCM_HIPCUB(at_cuda_detail::cub)::TransformInputIterator<aggT, TransformFunctor<T, aggT, nonzero>, const T*>(d_in, transform_functor);
-#endif
+    auto iter_in = thrust::make_transform_iterator(d_in, transform_functor);
     for (int i=0; i<iters_per_cta; i++){
       if (remaining >= BLOCK_THREADS * ITEMS_PER_THREAD) {
         BlockLoadT(temp_storage.load).Load(iter_in, data);
@@ -581,13 +566,8 @@ inline void inclusive_sum_by_key(KeysInputIteratorT keys, ValuesInputIteratorT i
   TORCH_CHECK(num_items <= std::numeric_limits<int>::max(),
     "cub InclusiveSumByKey does not support more than INT_MAX elements");
 #if !defined(USE_ROCM)
-#if CUB_V3_PLUS()
   CUB_WRAPPER(at_cuda_detail::cub::DeviceScan::InclusiveSumByKey,
       keys, input, output, num_items, ::cuda::std::equal_to<>(), at::cuda::getCurrentCUDAStream());
-#else
-  CUB_WRAPPER(at_cuda_detail::cub::DeviceScan::InclusiveSumByKey,
-      keys, input, output, num_items, at_cuda_detail::cub::Equality(), at::cuda::getCurrentCUDAStream());
-#endif // CUB_V3_PLUS()
 #else
   CUB_WRAPPER(cub::DeviceScan::InclusiveSumByKey,
       keys, input, output, num_items, hipcub::Equality(), at::cuda::getCurrentCUDAStream());
@@ -599,13 +579,8 @@ inline void inclusive_scan_by_key(KeysInputIteratorT keys, ValuesInputIteratorT 
   TORCH_CHECK(num_items <= std::numeric_limits<int>::max(),
     "cub InclusiveSumByKey does not support more than INT_MAX elements");
 #if !defined(USE_ROCM)
-#if CUB_V3_PLUS()
   CUB_WRAPPER(at_cuda_detail::cub::DeviceScan::InclusiveScanByKey,
       keys, input, output, scan_op, num_items, ::cuda::std::equal_to<>(), at::cuda::getCurrentCUDAStream());
-#else
-  CUB_WRAPPER(at_cuda_detail::cub::DeviceScan::InclusiveScanByKey,
-      keys, input, output, scan_op, num_items, at_cuda_detail::cub::Equality(), at::cuda::getCurrentCUDAStream());
-#endif // CUB_V3_PLUS()
 #else
   CUB_WRAPPER(cub::DeviceScan::InclusiveScanByKey,
       keys, input, output, scan_op, num_items, hipcub::Equality(), at::cuda::getCurrentCUDAStream());

--- a/aten/src/ATen/cuda/cub_definitions.cuh
+++ b/aten/src/ATen/cuda/cub_definitions.cuh
@@ -51,3 +51,12 @@
 #else
 #define CUB_SUPPORTS_FUTURE_VALUE() false
 #endif
+
+// cub
+// There were many bc-breaking changes in major version release of CCCL v3.0.0
+// Please see https://nvidia.github.io/cccl/cccl/3.0_migration_guide.html
+#if CUB_VERSION >= 300000
+#define CUB_V3_PLUS() true
+#else
+#define CUB_V3_PLUS() false
+#endif

--- a/aten/src/ATen/cuda/cub_definitions.cuh
+++ b/aten/src/ATen/cuda/cub_definitions.cuh
@@ -52,7 +52,6 @@
 #define CUB_SUPPORTS_FUTURE_VALUE() false
 #endif
 
-// cub
 // There were many bc-breaking changes in major version release of CCCL v3.0.0
 // Please see https://nvidia.github.io/cccl/cccl/3.0_migration_guide.html
 #if CUB_VERSION >= 300000

--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -19,10 +19,8 @@
 #include <thrust/iterator/reverse_iterator.h>
 #endif
 
-#if CUB_V3_PLUS()
 #include <cuda/functional>
 #include <thrust/iterator/constant_iterator.h>
-#endif
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -322,11 +320,7 @@ Tensor embedding_dense_backward_cuda(const Tensor & grad_, const Tensor & indice
       auto count_data = count.mutable_data_ptr<index_t>();
       cuda::cub::inclusive_sum_by_key(
         sorted_data,
-#if CUB_V3_PLUS()
         thrust::constant_iterator<index_t>(1),
-#else
-        NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::ConstantInputIterator<index_t>(1),
-#endif
         count_data,
         num_indices
       );

--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -329,11 +329,7 @@ Tensor embedding_dense_backward_cuda(const Tensor & grad_, const Tensor & indice
         thrust::make_reverse_iterator(sorted_data + num_indices),
         thrust::make_reverse_iterator(static_cast<const index_t*>(count_data) + num_indices),
         thrust::make_reverse_iterator(count_data + num_indices),
-#if CUB_V3_PLUS()
-       ::cuda::maximum<>(),
-#else
-        NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::Max(),
-#endif
+	ATEN_CUB_MAXIMUM(),
         num_indices
       );
     });

--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -19,9 +19,6 @@
 #include <thrust/iterator/reverse_iterator.h>
 #endif
 
-#include <cuda/functional>
-#include <thrust/iterator/constant_iterator.h>
-
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
@@ -320,7 +317,7 @@ Tensor embedding_dense_backward_cuda(const Tensor & grad_, const Tensor & indice
       auto count_data = count.mutable_data_ptr<index_t>();
       cuda::cub::inclusive_sum_by_key(
         sorted_data,
-        thrust::constant_iterator<index_t>(1),
+        ATEN_CUB_CONSTANT_ITERATOR(index_t)(1),
         count_data,
         num_indices
       );
@@ -333,7 +330,7 @@ Tensor embedding_dense_backward_cuda(const Tensor & grad_, const Tensor & indice
         thrust::make_reverse_iterator(static_cast<const index_t*>(count_data) + num_indices),
         thrust::make_reverse_iterator(count_data + num_indices),
 #if CUB_V3_PLUS()
-        ::cuda::maximum<>{},
+       ::cuda::maximum<>{},
 #else
         NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::Max(),
 #endif

--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -330,7 +330,7 @@ Tensor embedding_dense_backward_cuda(const Tensor & grad_, const Tensor & indice
         thrust::make_reverse_iterator(static_cast<const index_t*>(count_data) + num_indices),
         thrust::make_reverse_iterator(count_data + num_indices),
 #if CUB_V3_PLUS()
-       ::cuda::maximum<>{},
+       ::cuda::maximum<>(),
 #else
         NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::Max(),
 #endif

--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -329,7 +329,7 @@ Tensor embedding_dense_backward_cuda(const Tensor & grad_, const Tensor & indice
         thrust::make_reverse_iterator(sorted_data + num_indices),
         thrust::make_reverse_iterator(static_cast<const index_t*>(count_data) + num_indices),
         thrust::make_reverse_iterator(count_data + num_indices),
-	ATEN_CUB_MAXIMUM(),
+        ATEN_CUB_MAXIMUM(),
         num_indices
       );
     });

--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -222,11 +222,7 @@ Tensor embedding_bag_backward_cuda_sum_avg(
         thrust::make_reverse_iterator(sorted_data + num_indices),
         thrust::make_reverse_iterator(count_data + num_indices),
         thrust::make_reverse_iterator(count_data + num_indices),
-#if CUB_V3_PLUS()
-        ::cuda::maximum<>(),
-#else
-        NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::Max(),
-#endif
+	ATEN_CUB_MAXIMUM(),
         num_indices
       );
     });

--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -35,11 +35,6 @@
 #include <thrust/iterator/reverse_iterator.h>
 #endif
 
-#if CUB_V3_PLUS()
-#include <cuda/functional>
-#endif
-#include <thrust/iterator/constant_iterator.h>
-
 namespace at::native {
 
 #if !CUB_SUPPORTS_SCAN_BY_KEY()
@@ -215,7 +210,7 @@ Tensor embedding_bag_backward_cuda_sum_avg(
       auto count_data = count.mutable_data_ptr<index_t>();
       cuda::cub::inclusive_sum_by_key(
         sorted_data,
-        thrust::constant_iterator<index_t>(1),
+        ATEN_CUB_CONSTANT_ITERATOR(index_t)(1),
         count_data,
         num_indices
       );

--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -37,8 +37,8 @@
 
 #if CUB_V3_PLUS()
 #include <cuda/functional>
-#include <thrust/iterator/constant_iterator.h>
 #endif
+#include <thrust/iterator/constant_iterator.h>
 
 namespace at::native {
 
@@ -215,11 +215,7 @@ Tensor embedding_bag_backward_cuda_sum_avg(
       auto count_data = count.mutable_data_ptr<index_t>();
       cuda::cub::inclusive_sum_by_key(
         sorted_data,
-#if CUB_V3_PLUS()
         thrust::constant_iterator<index_t>(1),
-#else
-        NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::ConstantInputIterator<index_t>(1),
-#endif
         count_data,
         num_indices
       );

--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -222,7 +222,7 @@ Tensor embedding_bag_backward_cuda_sum_avg(
         thrust::make_reverse_iterator(sorted_data + num_indices),
         thrust::make_reverse_iterator(count_data + num_indices),
         thrust::make_reverse_iterator(count_data + num_indices),
-	ATEN_CUB_MAXIMUM(),
+        ATEN_CUB_MAXIMUM(),
         num_indices
       );
     });

--- a/aten/src/ATen/native/cuda/Nonzero.cu
+++ b/aten/src/ATen/native/cuda/Nonzero.cu
@@ -16,9 +16,6 @@
 #include <ATen/ops/nonzero_native.h>
 #endif
 
-#include <thrust/iterator/transform_iterator.h>
-#include <thrust/iterator/counting_iterator.h>
-
 namespace at::native {
 
 namespace {
@@ -97,7 +94,7 @@ __global__ void flag_kernel(const T* d_in, int64_t * d_out, const int64_t * agg,
 
   // Specialize BlockScan type for our thread block
   using BlockScanT = ROCM_HIPCUB(at_cuda_detail::cub)::BlockScan<int, BLOCK_THREADS, ROCM_HIPCUB(at_cuda_detail::cub)::BLOCK_SCAN_WARP_SCANS>;
-  using TransformInputIteratorT = thrust::transform_iterator<NonZeroOp<T>, const T*>;
+  using TransformInputIteratorT = ATEN_CUB_TRANSFORM_ITERATOR(int, NonZeroOp<T>, const T*);
   using BlockExchangeT =  ROCM_HIPCUB(at_cuda_detail::cub)::BlockExchange<int, BLOCK_THREADS, ITEMS_PER_THREAD>;
 
   // Shared memory
@@ -187,7 +184,7 @@ void nonzero_cuda_out_impl(const Tensor& self, Tensor& out) {
   auto num_nonzeros = allocator.allocate(sizeof(int) * num_chunks);
   for (int64_t idx = 0; idx < num_chunks; idx++) {
     int64_t remaining = std::min(chunk_size, self.numel() - idx * chunk_size);
-    thrust::transform_iterator<NonZeroOp<scalar_t>, const scalar_t*> itr(
+    ATEN_CUB_TRANSFORM_ITERATOR(bool, NonZeroOp<scalar_t>, const scalar_t*) itr(
         self_.const_data_ptr<scalar_t>() + idx * chunk_size,
         NonZeroOp<scalar_t>());
     AT_CUDA_CHECK(cub::DeviceReduce::Sum(
@@ -246,8 +243,8 @@ void nonzero_cuda_out_impl(const Tensor& self, Tensor& out) {
     for (int64_t idx = 0; idx < num_chunks; idx++) {
       int remaining = std::min(chunk_size, self.numel() - idx * chunk_size);
 
-      thrust::counting_iterator<int64_t> counting_itr(idx * chunk_size);
-      thrust::transform_iterator<NonZeroOp<scalar_t>, const scalar_t*>
+      ATEN_CUB_COUNTING_ITERATOR(int64_t) counting_itr(idx * chunk_size);
+      ATEN_CUB_TRANSFORM_ITERATOR(bool, NonZeroOp<scalar_t>, const scalar_t*)
           itr(self_.const_data_ptr<scalar_t>() + idx * chunk_size,
               NonZeroOp<scalar_t>());
       temp_storage_bytes = 0;

--- a/aten/src/ATen/native/cuda/Nonzero.cu
+++ b/aten/src/ATen/native/cuda/Nonzero.cu
@@ -16,10 +16,8 @@
 #include <ATen/ops/nonzero_native.h>
 #endif
 
-#if CUB_V3_PLUS()
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
-#endif
 
 namespace at::native {
 
@@ -99,11 +97,7 @@ __global__ void flag_kernel(const T* d_in, int64_t * d_out, const int64_t * agg,
 
   // Specialize BlockScan type for our thread block
   using BlockScanT = ROCM_HIPCUB(at_cuda_detail::cub)::BlockScan<int, BLOCK_THREADS, ROCM_HIPCUB(at_cuda_detail::cub)::BLOCK_SCAN_WARP_SCANS>;
-#if CUB_V3_PLUS()
   using TransformInputIteratorT = thrust::transform_iterator<NonZeroOp<T>, const T*>;
-#else
-  using TransformInputIteratorT = ROCM_HIPCUB(at_cuda_detail::cub)::TransformInputIterator<int, NonZeroOp<T>, const T*>;
-#endif
   using BlockExchangeT =  ROCM_HIPCUB(at_cuda_detail::cub)::BlockExchange<int, BLOCK_THREADS, ITEMS_PER_THREAD>;
 
   // Shared memory
@@ -193,15 +187,9 @@ void nonzero_cuda_out_impl(const Tensor& self, Tensor& out) {
   auto num_nonzeros = allocator.allocate(sizeof(int) * num_chunks);
   for (int64_t idx = 0; idx < num_chunks; idx++) {
     int64_t remaining = std::min(chunk_size, self.numel() - idx * chunk_size);
-#if CUB_V3_PLUS()
     thrust::transform_iterator<NonZeroOp<scalar_t>, const scalar_t*> itr(
         self_.const_data_ptr<scalar_t>() + idx * chunk_size,
         NonZeroOp<scalar_t>());
-#else
-    cub::TransformInputIterator<bool, NonZeroOp<scalar_t>, const scalar_t*> itr(
-        self_.const_data_ptr<scalar_t>() + idx * chunk_size,
-        NonZeroOp<scalar_t>());
-#endif
     AT_CUDA_CHECK(cub::DeviceReduce::Sum(
         nullptr,
         temp_storage_bytes,
@@ -258,17 +246,10 @@ void nonzero_cuda_out_impl(const Tensor& self, Tensor& out) {
     for (int64_t idx = 0; idx < num_chunks; idx++) {
       int remaining = std::min(chunk_size, self.numel() - idx * chunk_size);
 
-#if CUB_V3_PLUS()
       thrust::counting_iterator<int64_t> counting_itr(idx * chunk_size);
       thrust::transform_iterator<NonZeroOp<scalar_t>, const scalar_t*>
           itr(self_.const_data_ptr<scalar_t>() + idx * chunk_size,
               NonZeroOp<scalar_t>());
-#else
-      cub::CountingInputIterator<int64_t> counting_itr(idx * chunk_size);
-      cub::TransformInputIterator<bool, NonZeroOp<scalar_t>, const scalar_t*>
-          itr(self_.const_data_ptr<scalar_t>() + idx * chunk_size,
-              NonZeroOp<scalar_t>());
-#endif
       temp_storage_bytes = 0;
       AT_CUDA_CHECK(cub::DeviceSelect::Flagged(
           nullptr,

--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -17,9 +17,6 @@
 
 #include <c10/macros/Macros.h>
 
-#include <thrust/iterator/transform_iterator.h>
-#include <thrust/iterator/counting_iterator.h>
-
 using namespace at::native;
 
 namespace at::native {
@@ -724,8 +721,8 @@ void launch(
     desired, counts, num_blocks, blocks_per_slice, kthCounts);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
   // Do a prefix scan of withinKCounts and kthCounts using slice_idx as keys to get the starting index of each block
-  using counting_iter_t = thrust::counting_iterator<uint32_t, uint32_t>;
-  using slice_idx_iter_t = thrust::transform_iterator<BlockIdxToKey, counting_iter_t>;
+  using counting_iter_t = ATEN_CUB_COUNTING_ITERATOR(uint32_t, uint32_t);
+  using slice_idx_iter_t = ATEN_CUB_TRANSFORM_ITERATOR(uint32_t, BlockIdxToKey, counting_iter_t);
   slice_idx_iter_t slice_idx_iter(counting_iter_t(0), BlockIdxToKey(blocks_per_slice));
   at::cuda::cub::inclusive_sum_by_key(slice_idx_iter, withinKCounts, withinKCounts, num_blocks);
   at::cuda::cub::inclusive_sum_by_key(slice_idx_iter, kthCounts, kthCounts, num_blocks);

--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -17,10 +17,8 @@
 
 #include <c10/macros/Macros.h>
 
-#if CUB_V3_PLUS()
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
-#endif
 
 using namespace at::native;
 
@@ -726,13 +724,8 @@ void launch(
     desired, counts, num_blocks, blocks_per_slice, kthCounts);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
   // Do a prefix scan of withinKCounts and kthCounts using slice_idx as keys to get the starting index of each block
-#if CUB_V3_PLUS()
   using counting_iter_t = thrust::counting_iterator<uint32_t, uint32_t>;
   using slice_idx_iter_t = thrust::transform_iterator<BlockIdxToKey, counting_iter_t>;
-#else
-  using counting_iter_t = cub::CountingInputIterator<uint32_t, uint32_t>;
-  using slice_idx_iter_t = cub::TransformInputIterator<uint32_t, BlockIdxToKey, counting_iter_t>;
-#endif
   slice_idx_iter_t slice_idx_iter(counting_iter_t(0), BlockIdxToKey(blocks_per_slice));
   at::cuda::cub::inclusive_sum_by_key(slice_idx_iter, withinKCounts, withinKCounts, num_blocks);
   at::cuda::cub::inclusive_sum_by_key(slice_idx_iter, kthCounts, kthCounts, num_blocks);

--- a/aten/src/ATen/native/cuda/UniqueCub.cu
+++ b/aten/src/ATen/native/cuda/UniqueCub.cu
@@ -262,7 +262,7 @@ struct UniqueCub<bool> {
     ATEN_CUB_TRANSFORM_ITERATOR(int, MapNumberOfTrueValues, const uint8_t*, int)
         data_iter(reinterpret_cast<const uint8_t*>(self_data), op);
     at::cuda::cub::reduce(data_iter, tmp_num_true.get(), num_inp,
-                          ::cuda::std::plus<>{}, 0);
+                          NO_ROCM(::cuda)::std::plus<>{}, 0);
 
     auto options = self.options();
     output = at::empty({2}, self.options());

--- a/aten/src/ATen/native/cuda/UniqueCub.cu
+++ b/aten/src/ATen/native/cuda/UniqueCub.cu
@@ -17,7 +17,6 @@
 #endif
 
 #include <cuda/std/functional>
-#include <thrust/iterator/transform_iterator.h>
 
 namespace at::native::internal {
 
@@ -57,7 +56,8 @@ struct LoadBoolOp {
 auto wrap_input_iterator(const bool *data) {
   // See NOTE [Loading boolean values]
   LoadBoolOp op;
-  return thrust::transform_iterator<LoadBoolOp, const uint8_t*, int>(reinterpret_cast<const uint8_t*>(data), op);
+  return ATEN_CUB_TRANSFORM_ITERATOR(bool, LoadBoolOp, const uint8_t*, int)(
+      reinterpret_cast<const uint8_t*>(data), op);
 }
 
 // A variation of compute_unique (defined in Unique.cu) that doesn't allow
@@ -261,7 +261,7 @@ struct UniqueCub<bool> {
 
     const bool* self_data = self.const_data_ptr<bool>();
     MapNumberOfTrueValues op;
-    thrust::transform_iterator<MapNumberOfTrueValues, const uint8_t*, int>
+    ATEN_CUB_TRANSFORM_ITERATOR(int, MapNumberOfTrueValues, const uint8_t*, int)
         data_iter(reinterpret_cast<const uint8_t*>(self_data), op);
     at::cuda::cub::reduce(data_iter, tmp_num_true.get(), num_inp,
                           ::cuda::std::plus<>{}, 0);

--- a/aten/src/ATen/native/cuda/UniqueCub.cu
+++ b/aten/src/ATen/native/cuda/UniqueCub.cu
@@ -16,8 +16,6 @@
 #include <ATen/ops/empty.h>
 #endif
 
-#include <cuda/std/functional>
-
 namespace at::native::internal {
 
 namespace {

--- a/aten/src/ATen/native/cuda/UniqueCub.cu
+++ b/aten/src/ATen/native/cuda/UniqueCub.cu
@@ -16,10 +16,8 @@
 #include <ATen/ops/empty.h>
 #endif
 
-#if CUB_V3_PLUS()
 #include <cuda/std/functional>
 #include <thrust/iterator/transform_iterator.h>
-#endif
 
 namespace at::native::internal {
 
@@ -59,13 +57,7 @@ struct LoadBoolOp {
 auto wrap_input_iterator(const bool *data) {
   // See NOTE [Loading boolean values]
   LoadBoolOp op;
-#if CUB_V3_PLUS()
-  return thrust::transform_iterator<LoadBoolOp, const uint8_t*, int>(
-      reinterpret_cast<const uint8_t*>(data), op);
-#else
-  return NO_ROCM(at_cuda_detail)::cub::TransformInputIterator<bool, LoadBoolOp, const uint8_t*, int>(
-      reinterpret_cast<const uint8_t*>(data), op);
-#endif
+  return thrust::make_transform_iterator(reinterpret_cast<const uint8_t*>(data), op);
 }
 
 // A variation of compute_unique (defined in Unique.cu) that doesn't allow
@@ -269,17 +261,9 @@ struct UniqueCub<bool> {
 
     const bool* self_data = self.const_data_ptr<bool>();
     MapNumberOfTrueValues op;
-#if CUB_V3_PLUS()
-    thrust::transform_iterator<MapNumberOfTrueValues, const uint8_t*, int>
-        data_iter(reinterpret_cast<const uint8_t*>(self_data), op);
+    auto data_iter = thrust::make_transform_iterator(reinterpret_cast<const uint8_t*>(self_data), op);
     at::cuda::cub::reduce(data_iter, tmp_num_true.get(), num_inp,
                           ::cuda::std::plus<>{}, 0);
-#else
-    NO_ROCM(at_cuda_detail)::cub::TransformInputIterator<int, MapNumberOfTrueValues, const uint8_t*, int>
-        data_iter(reinterpret_cast<const uint8_t*>(self_data), op);
-    at::cuda::cub::reduce(data_iter, tmp_num_true.get(), num_inp,
-                          NO_ROCM(at_cuda_detail)::cub::Sum{}, 0);
-#endif
 
     auto options = self.options();
     output = at::empty({2}, self.options());

--- a/aten/src/ATen/native/cuda/UniqueCub.cu
+++ b/aten/src/ATen/native/cuda/UniqueCub.cu
@@ -57,7 +57,7 @@ struct LoadBoolOp {
 auto wrap_input_iterator(const bool *data) {
   // See NOTE [Loading boolean values]
   LoadBoolOp op;
-  return thrust::make_transform_iterator(reinterpret_cast<const uint8_t*>(data), op);
+  return thrust::transform_iterator<LoadBoolOp, const uint8_t*, int>(reinterpret_cast<const uint8_t*>(data), op);
 }
 
 // A variation of compute_unique (defined in Unique.cu) that doesn't allow
@@ -261,7 +261,8 @@ struct UniqueCub<bool> {
 
     const bool* self_data = self.const_data_ptr<bool>();
     MapNumberOfTrueValues op;
-    auto data_iter = thrust::make_transform_iterator(reinterpret_cast<const uint8_t*>(self_data), op);
+    thrust::transform_iterator<MapNumberOfTrueValues, const uint8_t*, int>
+        data_iter(reinterpret_cast<const uint8_t*>(self_data), op);
     at::cuda::cub::reduce(data_iter, tmp_num_true.get(), num_inp,
                           ::cuda::std::plus<>{}, 0);
 

--- a/aten/src/ATen/test/cuda_cub_test.cu
+++ b/aten/src/ATen/test/cuda_cub_test.cu
@@ -146,8 +146,8 @@ TEST(InclusiveScanSplit, CubTest) {
   cudaMallocManaged(&output1, sizeof(int) * 10);
 
   cudaDeviceSynchronize();
-  at::cuda::cub::inclusive_scan<int *, int *, ::cuda::std::plus<>, /*max_cub_size=*/2>(
-    input, output1, ::cuda::std::plus<>(), 10);
+  at::cuda::cub::inclusive_scan<int *, int *, NO_ROCM(::cuda)::std::plus<>, /*max_cub_size=*/2>(
+    input, output1, NO_ROCM(::cuda)::std::plus<>(), 10);
   cudaDeviceSynchronize();
 
   ASSERT_EQ(output1[0], 1);
@@ -172,8 +172,8 @@ TEST(ExclusiveScanSplit, CubTest) {
   cudaMallocManaged(&output2, sizeof(int) * 10);
 
   cudaDeviceSynchronize();
-  at::cuda::cub::exclusive_scan<int *, int *, ::cuda::std::plus<>, int, /*max_cub_size=*/2>(
-    input, output2, ::cuda::std::plus<>(), 0, 10);
+  at::cuda::cub::exclusive_scan<int *, int *, NO_ROCM(::cuda)::std::plus<>, int, /*max_cub_size=*/2>(
+    input, output2, NO_ROCM(::cuda)::std::plus<>(), 0, 10);
   cudaDeviceSynchronize();
 
   ASSERT_EQ(output2[0], 0);

--- a/aten/src/ATen/test/cuda_cub_test.cu
+++ b/aten/src/ATen/test/cuda_cub_test.cu
@@ -1,7 +1,6 @@
 #include <ATen/cuda/cub.cuh>
 #include <ATen/cuda/CUDAContext.h>
 #include <gtest/gtest.h>
-#include <cuda/std/functional>
 
 
 TEST(NumBits, CubTest) {

--- a/aten/src/ATen/test/cuda_cub_test.cu
+++ b/aten/src/ATen/test/cuda_cub_test.cu
@@ -2,6 +2,11 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <gtest/gtest.h>
 
+#if CUB_V3_PLUS()
+#include <cuda/std/functional>
+#endif
+
+
 TEST(NumBits, CubTest) {
   using at::cuda::cub::get_num_bits;
   ASSERT_EQ(get_num_bits(0b0000000000000000000000000000000000000000000000000000000000000000UL), 1);
@@ -146,8 +151,13 @@ TEST(InclusiveScanSplit, CubTest) {
   cudaMallocManaged(&output1, sizeof(int) * 10);
 
   cudaDeviceSynchronize();
+#if CUB_V3_PLUS()
+  at::cuda::cub::inclusive_scan<int *, int *, ::cuda::std::plus<>, /*max_cub_size=*/2>(
+    input, output1, ::cuda::std::plus<>(), 10);
+#else
   at::cuda::cub::inclusive_scan<int *, int *, ::at_cuda_detail::cub::Sum, /*max_cub_size=*/2>(
     input, output1, ::at_cuda_detail::cub::Sum(), 10);
+#endif
   cudaDeviceSynchronize();
 
   ASSERT_EQ(output1[0], 1);
@@ -172,8 +182,13 @@ TEST(ExclusiveScanSplit, CubTest) {
   cudaMallocManaged(&output2, sizeof(int) * 10);
 
   cudaDeviceSynchronize();
+#if CUB_V3_PLUS()
+  at::cuda::cub::exclusive_scan<int *, int *, ::cuda::std::plus<>, int, /*max_cub_size=*/2>(
+    input, output2, ::cuda::std::plus<>(), 0, 10);
+#else
   at::cuda::cub::exclusive_scan<int *, int *, ::at_cuda_detail::cub::Sum, int, /*max_cub_size=*/2>(
     input, output2, ::at_cuda_detail::cub::Sum(), 0, 10);
+#endif
   cudaDeviceSynchronize();
 
   ASSERT_EQ(output2[0], 0);

--- a/aten/src/ATen/test/cuda_cub_test.cu
+++ b/aten/src/ATen/test/cuda_cub_test.cu
@@ -1,7 +1,6 @@
 #include <ATen/cuda/cub.cuh>
 #include <ATen/cuda/CUDAContext.h>
 #include <gtest/gtest.h>
-
 #include <cuda/std/functional>
 
 

--- a/aten/src/ATen/test/cuda_cub_test.cu
+++ b/aten/src/ATen/test/cuda_cub_test.cu
@@ -2,9 +2,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <gtest/gtest.h>
 
-#if CUB_V3_PLUS()
 #include <cuda/std/functional>
-#endif
 
 
 TEST(NumBits, CubTest) {
@@ -151,13 +149,8 @@ TEST(InclusiveScanSplit, CubTest) {
   cudaMallocManaged(&output1, sizeof(int) * 10);
 
   cudaDeviceSynchronize();
-#if CUB_V3_PLUS()
   at::cuda::cub::inclusive_scan<int *, int *, ::cuda::std::plus<>, /*max_cub_size=*/2>(
     input, output1, ::cuda::std::plus<>(), 10);
-#else
-  at::cuda::cub::inclusive_scan<int *, int *, ::at_cuda_detail::cub::Sum, /*max_cub_size=*/2>(
-    input, output1, ::at_cuda_detail::cub::Sum(), 10);
-#endif
   cudaDeviceSynchronize();
 
   ASSERT_EQ(output1[0], 1);
@@ -182,13 +175,8 @@ TEST(ExclusiveScanSplit, CubTest) {
   cudaMallocManaged(&output2, sizeof(int) * 10);
 
   cudaDeviceSynchronize();
-#if CUB_V3_PLUS()
   at::cuda::cub::exclusive_scan<int *, int *, ::cuda::std::plus<>, int, /*max_cub_size=*/2>(
     input, output2, ::cuda::std::plus<>(), 0, 10);
-#else
-  at::cuda::cub::exclusive_scan<int *, int *, ::at_cuda_detail::cub::Sum, int, /*max_cub_size=*/2>(
-    input, output2, ::at_cuda_detail::cub::Sum(), 0, 10);
-#endif
   cudaDeviceSynchronize();
 
   ASSERT_EQ(output2[0], 0);

--- a/aten/src/ATen/test/cuda_cub_test.cu
+++ b/aten/src/ATen/test/cuda_cub_test.cu
@@ -2,7 +2,6 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <gtest/gtest.h>
 
-
 TEST(NumBits, CubTest) {
   using at::cuda::cub::get_num_bits;
   ASSERT_EQ(get_num_bits(0b0000000000000000000000000000000000000000000000000000000000000000UL), 1);


### PR DESCRIPTION
A major release of CCCL 3.0.0 will introduce some bc-breaking changes. Namely iterators like TransformInputIterator and ConstantInputIterator were moved from CUB to Thrust, some operators like Max and Sum were moved to LibCUDACXX.

For the more info on changes please visit: https://nvidia.github.io/cccl/cccl/3.0_migration_guide.html

This is a follow up to PR #147493. A description from the original PR:
> Several cub iterators have been deprecated and removed in the latest CCCL (cub) development https://github.com/NVIDIA/cccl/pull/3831. This PR replaced the usage of those cub iterators with thrust iterators.
>
> Some cub thread operators were also deprecated and removed in https://github.com/NVIDIA/cccl/pull/3918. This PR replaced those operators with libcudacxx ops.
>
> This might also affect ROCM usability a bit.
>
> This patch is tested to work with CCCL commit at https://github.com/NVIDIA/cccl/commit/82befb089420cc5e0f5bb08a083c0b14c8984af6
>
> Tracking of CCCL/CUB deprecations in the most recent development https://github.com/NVIDIA/cccl/issues/101


cc @ptrblck @msaroufim @eqy @jerryzh168 @manuelcandales @SherlockNoMad @angelayi @xwang233 @miscco