### PR TITLE
Remove mut marker for fused_adagrad in native_functions.yaml

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -15844,7 +15844,7 @@
     MPS: _fused_sgd_kernel_mps_
   autogen: _fused_sgd.tensor_lr, _fused_sgd.tensor_lr_out
 
-- func: _fused_adagrad_(Tensor(a!)[] self, Tensor(b!)[] grads, Tensor(c!)[] state_sums, Tensor(d!)[] state_steps, *, float lr, float lr_decay, float weight_decay, float eps, bool maximize, Tensor? grad_scale=None, Tensor? found_inf=None) -> ()
+- func: _fused_adagrad_(Tensor(a!)[] self, Tensor(b!)[] grads, Tensor(c!)[] state_sums, Tensor[] state_steps, *, float lr, float lr_decay, float weight_decay, float eps, bool maximize, Tensor? grad_scale=None, Tensor? found_inf=None) -> ()
   variants: function
   dispatch:
     CPU: _fused_adagrad_kernel_cpu_


### PR DESCRIPTION
Split from https://github.com/pytorch/pytorch/pull/153078 (https://github.com/pytorch/pytorch/pull/153078#discussion_r2079884388).

Changes the marker on _fused_adagrad to denote that `state_steps` is not mutated.

cc: @janeyx99 