### PR TITLE
[BE]: Use shutil.which in inductor codegen

### DIFF
--- a/torch/_inductor/codegen/cuda/cuda_env.py
+++ b/torch/_inductor/codegen/cuda/cuda_env.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+import shutil
 from typing import Optional
 
 import torch
@@ -40,12 +41,5 @@ def get_cuda_version() -> Optional[str]:
 
 
 @functools.lru_cache(None)
-def nvcc_exist(nvcc_path: str = "nvcc") -> bool:
-    if nvcc_path is None:
-        return False
-    import subprocess
-
-    res = subprocess.call(
-        ["which", nvcc_path], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
-    )
-    return res == 0
+def nvcc_exist(nvcc_path: Optional[str] = "nvcc") -> bool:
+    return nvcc_path is not None and shutil.which(nvcc_path) is not None


### PR DESCRIPTION
Use shutil.which instead of subprocess. Is more secure, has better error handling and is more cross platform

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov