### PR TITLE
[AOTI Debugging] Add Environment Variable to control output path

### DIFF
--- a/torch/_inductor/codegen/debug_utils.py
+++ b/torch/_inductor/codegen/debug_utils.py
@@ -63,6 +63,7 @@ class DebugPrinterManager:
         kernel=None,
         arg_signatures: Optional[list[type]] = None,
         kernel_type=None,
+        save_dir=None,
     ):
         self.debug_printer_level = IntermediateValueDebuggingLevel(debug_printer_level)
         self.use_array_ref = use_array_ref
@@ -74,6 +75,7 @@ class DebugPrinterManager:
         self.kernel = kernel
         self.filtered_kernel_names_to_print = self._get_debug_filtered_kernel_names()
         self.kernel_type = None
+        self.save_dir = save_dir
 
     def __enter__(self):
         self._perform_debug_print_or_save_helper(
@@ -204,8 +206,8 @@ class DebugPrinterManager:
                     f'aoti_torch_save_tensor_handle({arg}, "{arg}", "{launch_prefix}", "{kernel_name}");'
                 )
             else:
-                cwd = os.getcwd()
-                saved_dir = cwd + "/tmp/jit_inductor/"
+                base_dir = self.save_dir if self.save_dir else os.getcwd()
+                saved_dir = base_dir + "/tmp/jit_inductor/"
                 if not os.path.exists(saved_dir):
                     log.info(
                         "Creating directory to save inductor intermediate tensor values."

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1289,6 +1289,13 @@ class aot_inductor:
         "AOT_INDUCTOR_DEBUG_INTERMEDIATE_VALUE_PRINTER", "0"
     )  # type: ignore[assignment]
 
+    # Base directory for debug dumping intermediate tensor values
+    # intermediate tensors will be saved to <base_dir>/tmp/aoti_torch/<kernel_name> if debug_intermediate_value_printer is set to 1
+    # if this is not set, the base directory will be set to the current working directory
+    debug_intermediate_value_printer_dir = os.environ.get(
+        "AOT_INDUCTOR_DEBUG_INTERMEDIATE_VALUE_DIR", None
+    )
+
     # filtered nodes to be printed for debug values. Specify this option when debug_intermediate_value_printer is set to 2
     filtered_kernel_names = os.environ.get(
         "AOT_INDUCTOR_FILTERED_KERNELS_TO_PRINT", None

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -1133,7 +1133,13 @@ void aoti_torch_save_tensor_handle(
   at::Tensor* t = tensor_handle_to_tensor_pointer(self);
 #ifndef C10_MOBILE
   // Save tensor to tmp .pt file for tensors and can be torch.load'ed later
-  std::string cwd = get_current_path();
+  std::string cwd;
+  char* envVar = std::getenv("AOT_INDUCTOR_DEBUG_INTERMEDIATE_VALUE_DIR");
+  if (envVar != nullptr) {
+    cwd = std::string(envVar);
+  } else {
+    cwd = get_current_path();
+  }
   std::string tmp_folder = cwd + "/tmp/aoti_torch/";
   if (!file_exists(tmp_folder)) {
     std::cout


### PR DESCRIPTION
Summary: Add AOT_INDUCTOR_DEBUG_INTERMEDIATE_VALUE_DIR to determine the directory that the intermediate value pickle files get dumped into.

Test Plan: Ran locally

Differential Revision: D73398850




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben