### PR TITLE
[BE]: Enable ruff rule TC007

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,6 @@ ignore = [
     "SIM118",
     "UP007", # keep-runtime-typing
     "TC006",
-    "TC007",
 ]
 select = [
     "B",


### PR DESCRIPTION
Enables [TC007] https://docs.astral.sh/ruff/rules/unquoted-type-alias/#unquoted-type-alias-tc007 this finds type aliases that should be quoted if they have to interact with IF TYPE_CHECKING blocks: https://docs.astral.sh/ruff/rules/unquoted-type-alias/#unquoted-type-alias-tc007

Disabled it when we updated RUFF, but really should only have disabled TC006 as that is the one that is going to cause some changes codebase wide.