### PR TITLE
Make precompilation timeout configurable via TORCHINDUCTOR_PRECOMPILATION_TIMEOUT_SECONDS environment variable.

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -8,6 +8,12 @@ from torch._environment import is_fbcode
 from torch.utils._config_module import Config, get_tristate_env, install_config_module
 
 
+precompilation_timeout_seconds: int = Config(
+    env_name="TORCHINDUCTOR_PRECOMPILATION_TIMEOUT_SECONDS",
+    default=60 * 60,
+    type=int,
+)
+
 inplace_padding = os.environ.get("TORCHINDUCTOR_INPLACE_PADDING", "1") == "1"
 can_inplace_pad_graph_input = False  # ease testing
 

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1821,7 +1821,7 @@ class AlgorithmSelectorCache(PersistentCache):
         # arg, the function will be called instead of
         # generating a random torch.Tensor for benchmarking.
         input_gen_fns: Optional[dict[int, Callable[[ir.Buffer], torch.Tensor]]] = None,
-        precompilation_timeout_seconds: int = 60 * 60,
+        precompilation_timeout_seconds: int = config.precompilation_timeout_seconds,
         return_multi_template=False,
     ):
         from .codegen.cuda.cuda_kernel import CUDATemplateCaller


### PR DESCRIPTION
Fix issue with precompilation timeout handling

- Made precompilation timeout configurable via the environment variable TORCHINDUCTOR_PRECOMPILATION_TIMEOUT_SECONDS.
- Default value is set to 3600 seconds (1 hour) if not provided.
- Updated config.py to include a fallback for custom timeout configuration.


Fixes #153392


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov