### PR TITLE
gloo: cuda

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -696,6 +696,7 @@ libtorch_cuda_distributed_extra_sources = [
     "torch/csrc/distributed/c10d/NCCLUtils.cpp",
     "torch/csrc/distributed/c10d/FlightRecorder.cpp",
     "torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp",
+    "torch/csrc/distributed/c10d/ProcessGroupGlooCuda.cpp",
     "torch/csrc/distributed/c10d/ProcessGroupUCC.cpp",
     "torch/csrc/distributed/c10d/UCCTracing.cpp",
     "torch/csrc/distributed/c10d/UCCUtils.cpp",

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
@@ -7,6 +7,7 @@
 #include <torch/csrc/distributed/c10d/GlooDeviceFactory.hpp>
 #include <torch/csrc/distributed/c10d/PrefixStore.hpp>
 #include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
+#include <torch/csrc/distributed/c10d/ProcessGroupGlooDetail.hpp>
 #include <chrono>
 #include <exception>
 
@@ -24,17 +25,6 @@
 #include <type_traits>
 #include <utility>
 
-#include <gloo/allgather.h>
-#include <gloo/allgatherv.h>
-#include <gloo/allreduce.h>
-#include <gloo/alltoall.h>
-#include <gloo/alltoallv.h>
-#include <gloo/barrier.h>
-#include <gloo/broadcast.h>
-#include <gloo/gather.h>
-#include <gloo/reduce.h>
-#include <gloo/scatter.h>
-
 #include <ATen/ThreadLocalState.h>
 #include <ATen/native/SparseTensorUtils.h>
 
@@ -44,72 +34,6 @@
 #include <gloo/config.h>
 #include <gloo/rendezvous/context.h>
 #include <gloo/rendezvous/prefix_store.h>
-
-#ifdef _WIN32
-#define GENERATE_ALL_TYPES(type, func, ...)      \
-  switch (type) {                                \
-    case ::at::ScalarType::Float:                \
-      func<float>(__VA_ARGS__);                  \
-      break;                                     \
-    case ::at::ScalarType::Double:               \
-      func<double>(__VA_ARGS__);                 \
-      break;                                     \
-    case ::at::ScalarType::Half:                 \
-      func<gloo::float16>(__VA_ARGS__);          \
-      break;                                     \
-    case ::at::ScalarType::BFloat16:             \
-      func<c10::BFloat16>(__VA_ARGS__);          \
-      break;                                     \
-    case ::at::ScalarType::Char:                 \
-      func<int8_t>(__VA_ARGS__);                 \
-      break;                                     \
-    case ::at::ScalarType::Byte:                 \
-    case ::at::ScalarType::Bool:                 \
-      func<uint8_t>(__VA_ARGS__);                \
-      break;                                     \
-    case ::at::ScalarType::Int:                  \
-      func<int32_t>(__VA_ARGS__);                \
-      break;                                     \
-    case ::at::ScalarType::Long:                 \
-      func<int64_t>(__VA_ARGS__);                \
-      break;                                     \
-    default:                                     \
-      TORCH_CHECK(false, "Invalid scalar type"); \
-  }
-
-#define HOST_NAME_MAX 256
-#else
-#define GENERATE_ALL_TYPES(type, func, args...)  \
-  switch (type) {                                \
-    case ::at::ScalarType::Float:                \
-      func<float>(args);                         \
-      break;                                     \
-    case ::at::ScalarType::Double:               \
-      func<double>(args);                        \
-      break;                                     \
-    case ::at::ScalarType::Half:                 \
-      func<gloo::float16>(args);                 \
-      break;                                     \
-    case ::at::ScalarType::BFloat16:             \
-      func<c10::BFloat16>(args);                 \
-      break;                                     \
-    case ::at::ScalarType::Char:                 \
-      func<int8_t>(args);                        \
-      break;                                     \
-    case ::at::ScalarType::Byte:                 \
-    case ::at::ScalarType::Bool:                 \
-      func<uint8_t>(args);                       \
-      break;                                     \
-    case ::at::ScalarType::Int:                  \
-      func<int32_t>(args);                       \
-      break;                                     \
-    case ::at::ScalarType::Long:                 \
-      func<int64_t>(args);                       \
-      break;                                     \
-    default:                                     \
-      TORCH_CHECK(false, "Invalid scalar type"); \
-  }
-#endif
 
 namespace c10d {
 
@@ -172,153 +96,9 @@ void checkRemainingTime(
   }
 }
 
-typedef void (*ReduceFunc)(void*, const void*, const void*, size_t);
+const auto kLoopbackAddress = "127.0.0.1";
 
-template <typename T, std::enable_if_t<!std::is_integral_v<T>, int> = 0>
-ReduceFunc toFunction(const ReduceOp& r) {
-  switch (r) {
-    case ReduceOp::SUM:
-    case ReduceOp::AVG:
-      return ReduceFunc(&::gloo::sum<T>);
-    case ReduceOp::PRODUCT:
-      return ReduceFunc(&::gloo::product<T>);
-    case ReduceOp::MIN:
-      return ReduceFunc(&::gloo::min<T>);
-    case ReduceOp::MAX:
-      return ReduceFunc(&::gloo::max<T>);
-    case ReduceOp::BAND:
-      TORCH_CHECK(false, "Cannot use ReduceOp.BAND with non-integral dtype");
-      break;
-    case ReduceOp::BOR:
-      TORCH_CHECK(false, "Cannot use ReduceOp.BOR with non-integral dtype");
-      break;
-    case ReduceOp::BXOR:
-      TORCH_CHECK(false, "Cannot use ReduceOp.BXOR with non-integral dtype");
-      break;
-    case ReduceOp::PREMUL_SUM:
-      TORCH_CHECK(false, "Cannot use ReduceOp.PREMUL_SUM with Gloo");
-      break;
-    case ReduceOp::UNUSED:
-    default:
-      break;
-  }
-
-  TORCH_CHECK(false, "Unhandled ReduceOp");
-}
-
-// Bitwise AND with SFINAE guard for integral types.
-template <typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
-void band(void* c, const void* a, const void* b, size_t n) {
-  auto tc = static_cast<T*>(c);
-  auto ta = static_cast<const T*>(a);
-  auto tb = static_cast<const T*>(b);
-  for (const auto i : c10::irange(n)) {
-    tc[i] = ta[i] & tb[i];
-  }
-}
-
-// Bitwise OR with SFINAE guard for integral types.
-template <typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
-void bor(void* c, const void* a, const void* b, size_t n) {
-  auto tc = static_cast<T*>(c);
-  auto ta = static_cast<const T*>(a);
-  auto tb = static_cast<const T*>(b);
-  for (const auto i : c10::irange(n)) {
-    tc[i] = ta[i] | tb[i];
-  }
-}
-
-// Bitwise XOR with SFINAE guard for integral types.
-template <typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
-void bxor(void* c, const void* a, const void* b, size_t n) {
-  auto tc = static_cast<T*>(c);
-  auto ta = static_cast<const T*>(a);
-  auto tb = static_cast<const T*>(b);
-  for (const auto i : c10::irange(n)) {
-    tc[i] = ta[i] ^ tb[i];
-  }
-}
-
-template <typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
-ReduceFunc toFunction(const ReduceOp& r) {
-  switch (r) {
-    case ReduceOp::SUM:
-    case ReduceOp::AVG:
-      return ReduceFunc(&::gloo::sum<T>);
-    case ReduceOp::PRODUCT:
-      return ReduceFunc(&::gloo::product<T>);
-    case ReduceOp::MIN:
-      return ReduceFunc(&::gloo::min<T>);
-    case ReduceOp::MAX:
-      return ReduceFunc(&::gloo::max<T>);
-    case ReduceOp::BAND:
-      return ReduceFunc(&band<T>);
-    case ReduceOp::BOR:
-      return ReduceFunc(&bor<T>);
-    case ReduceOp::BXOR:
-      return ReduceFunc(&bxor<T>);
-    case ReduceOp::PREMUL_SUM:
-      TORCH_CHECK(false, "Cannot use ReduceOp.PREMUL_SUM with Gloo");
-      break;
-    case ReduceOp::UNUSED:
-    default:
-      break;
-  }
-
-  TORCH_CHECK(false, "Unhandled ReduceOp");
-}
-
-template <typename T, typename O>
-void setInputs(O& opts, std::vector<at::Tensor>& tensors) {
-  opts.setInputs(getDataPointers<T>(tensors), tensors[0].numel());
-}
-
-template <typename T, typename O>
-void setInput(O& opts, at::Tensor& tensor) {
-  opts.setInput(getDataPointer<T>(tensor), tensor.numel());
-}
-
-template <typename T, typename O>
-void setInput(O& opts, at::Tensor& tensor, std::vector<size_t>& counts) {
-  opts.setInput(getDataPointer<T>(tensor), counts);
-}
-
-template <typename T, typename O>
-void setInput(O& opts, at::Tensor& tensor, std::vector<int64_t>& counts) {
-  opts.setInput(getDataPointer<T>(tensor), counts);
-}
-
-template <typename T, typename O>
-void setOutputs(O& opts, std::vector<at::Tensor>& tensors) {
-  opts.setOutputs(getDataPointers<T>(tensors), tensors[0].numel());
-}
-
-template <typename T, typename O>
-void setOutput(O& opts, at::Tensor& tensor) {
-  opts.setOutput(getDataPointer<T>(tensor), tensor.numel());
-}
-
-template <typename T, typename O>
-void setOutput(O& opts, at::Tensor& tensor, std::vector<size_t>& counts) {
-  opts.setOutput(getDataPointer<T>(tensor), counts);
-}
-
-template <typename T, typename O>
-void setOutput(O& opts, at::Tensor& tensor, std::vector<int64_t>& counts) {
-  opts.setOutput(getDataPointer<T>(tensor), counts);
-}
-
-at::Tensor pinnedLike(at::Tensor& tensor) {
-  auto* allocator = at::detail::getCUDAHooks().getPinnedMemoryAllocator();
-  auto storage = c10::Storage(
-      c10::Storage::use_byte_size_t(),
-      static_cast<int64_t>(at::detail::computeStorageNbytes(
-          tensor.sizes(), tensor.strides(), tensor.dtype().itemsize())),
-      allocator,
-      /*resizable=*/false);
-  return at::empty({0}, tensor.options().device(at::kCPU))
-      .set_(storage, 0, tensor.sizes(), tensor.strides());
-}
+} // namespace
 
 // This function initializes a vector of CUDA streams, one for every
 // tensor in the input tensor vector, and ensures that these streams are
@@ -338,7 +118,7 @@ void initializeStreamsEvents(
     events.emplace_back(device.type());
     events[i].record(impl.getStream(device));
     // Get a non-default stream to execute asynchronous CUDA operations
-    // on for this device. This ensures that the default stream used
+    // on this device. This ensures that the default stream used
     // by the caller is not occupied by c10d related operations.
     streams.push_back(
         impl.getStreamFromGlobalPool(device, /*isHighPriority=*/true));
@@ -410,10 +190,6 @@ void initializeStreamsEvents(
     }
   }
 }
-
-const auto kLoopbackAddress = "127.0.0.1";
-
-} // namespace
 
 bool getDefaultGlooLazyInit() {
   return ::c10d::getCvarBool(TORCH_GLOO_LAZY_INIT, false);
@@ -1043,481 +819,6 @@ c10::intrusive_ptr<Work> ProcessGroupGloo::broadcast(
   return work;
 }
 
-namespace {
-
-class AsyncAllreduceWork : public ProcessGroupGloo::AsyncWork {
- public:
-  AsyncAllreduceWork(
-      std::shared_ptr<gloo::Context> context,
-      std::vector<at::Tensor>& inputs,
-      ReduceOp reduceOp,
-      uint32_t tag,
-      uint64_t seq)
-      : ProcessGroupGloo::AsyncWork(
-            {inputs},
-            OpType::ALLREDUCE,
-            seq,
-            "gloo:all_reduce",
-            inputs),
-        context(std::move(context)),
-        inputs(inputs),
-        reduceOp(std::move(reduceOp)),
-        tag(tag) {}
-
-  std::shared_ptr<gloo::Context> context;
-  std::vector<at::Tensor> inputs{};
-  const ReduceOp reduceOp;
-  const uint32_t tag;
-
-  void allreduce(std::vector<at::Tensor>& tensors) {
-    const auto& scalarType = tensors[0].scalar_type();
-    gloo::AllreduceOptions opts(context);
-    opts.setReduceFunction(getFunction(scalarType, reduceOp));
-    opts.setTag(tag);
-    GENERATE_ALL_TYPES(scalarType, setOutputs, opts, tensors);
-    gloo::allreduce(opts);
-
-    // Gloo doesn't support AVG so we use SUM + division.
-    if (reduceOp == ReduceOp::AVG) {
-      tensors[0] /= context->size;
-    }
-  }
-
-  void run() override {
-    allreduce(inputs);
-  }
-
-  template <typename T>
-  void getFunction(gloo::AllreduceOptions::Func& fn, const ReduceOp op) {
-    fn = toFunction<T>(op);
-  }
-
-  gloo::AllreduceOptions::Func getFunction(
-      const at::ScalarType& dtype,
-      const ReduceOp& op) {
-    gloo::AllreduceOptions::Func fn;
-    GENERATE_ALL_TYPES(dtype, getFunction, fn, op);
-    return fn;
-  }
-};
-
-class AsyncAllreduceCoalescedWork : public AsyncAllreduceWork {
- public:
-  AsyncAllreduceCoalescedWork(
-      const std::shared_ptr<gloo::Context>& context,
-      std::vector<at::Tensor>& inputs,
-      ReduceOp reduceOp,
-      uint32_t tag,
-      uint64_t seq)
-      : AsyncAllreduceWork(context, inputs, std::move(reduceOp), tag, seq) {}
-
-  void run() override {
-    allreduceCoalesced(inputs);
-  }
-
- private:
-  void allreduceCoalesced(std::vector<at::Tensor>& tensors) {
-    // reduce coalesced, flattened tensors.
-    at::Tensor coalescedTensor = flattenDenseTensors(tensors);
-    std::vector<at::Tensor> allreduceInput = {coalescedTensor};
-    allreduce(allreduceInput);
-
-    // separate and reshape tensors.
-    size_t offset = 0;
-    for (at::Tensor& tensor : tensors) {
-      const int64_t tensorNumel = tensor.numel();
-      const c10::IntArrayRef tensorShape = tensor.sizes();
-      tensor.copy_(coalescedTensor.slice(0, offset, offset + tensorNumel)
-                       .view(tensorShape));
-      offset += tensorNumel;
-    }
-  }
-};
-
-class AsyncSparseAllreduceWork : public ProcessGroupGloo::AsyncWork {
- public:
-  AsyncSparseAllreduceWork(
-      std::shared_ptr<gloo::Context> context,
-      std::vector<at::Tensor>& inputs,
-      uint32_t tag,
-      uint64_t seq)
-      : ProcessGroupGloo::AsyncWork(
-            {inputs},
-            OpType::_ALLREDUCE_SPARSE,
-            seq,
-            "gloo:sparse_all_reduce",
-            inputs),
-        context(std::move(context)),
-        inputs(inputs),
-        tag(tag) {}
-
-  std::shared_ptr<gloo::Context> context;
-  std::vector<at::Tensor> inputs{};
-  const uint32_t tag;
-
-  // We share dimensionality about the sparse tensors before collecting
-  // their contents. We assume here that the maximum number of sparse
-  // and dense dimensions is 4. This is stored in a contiguous piece of
-  // memory so that we can easily run allgather on it.
-  //
-  // The layout of this memory is as follows:
-  //
-  //   - [0:4]: sparse dims
-  //   - [4:8]: dense dims
-  //   -   [8]: nnz
-  //
-  class SparseTensorMetadata {
-   public:
-    static constexpr auto dim = 9;
-
-    // Construct from an existing metadata tensor to facilitate structured
-    // access to metadata from peers, after gathering it.
-    explicit SparseTensorMetadata(at::Tensor metadata)
-        : metadata_(std::move(metadata)),
-          data_(metadata_.mutable_data_ptr<int64_t>()) {
-      AT_ASSERT(metadata_.scalar_type() == at::kLong);
-      AT_ASSERT(metadata_.dim() == 1);
-      AT_ASSERT(metadata_.size(0) == dim);
-    }
-
-    // Populate the metadata.
-    void populate_from_sparse_tensor(const at::Tensor& tensor) {
-      const auto sparse_dim = tensor.sparse_dim();
-      AT_ASSERT(sparse_dim <= 4);
-      for (const auto i : c10::irange(4)) {
-        if (i < sparse_dim) {
-          data_[i] = tensor.size(i);
-        }
-      }
-      const auto dense_dim = tensor.dense_dim();
-      AT_ASSERT(dense_dim <= 4);
-      for (const auto i : c10::irange(4)) {
-        if (i < dense_dim) {
-          data_[i + 4] = tensor.size(sparse_dim + i);
-        }
-      }
-      data_[8] = tensor._nnz();
-    }
-
-    std::vector<int64_t> sizes() const {
-      std::vector<int64_t> sizes;
-      // Sparse sizes
-      for (const auto i : c10::irange(4)) {
-        if (data_[i] <= 0) {
-          break;
-        }
-        sizes.push_back(data_[i]);
-      }
-      // Dense sizes
-      for (const auto i : c10::irange(4, 8)) {
-        if (data_[i] <= 0) {
-          break;
-        }
-        sizes.push_back(data_[i]);
-      }
-      return sizes;
-    }
-
-    int64_t nnz() const {
-      return data_[8];
-    }
-
-   protected:
-    at::Tensor metadata_;
-    int64_t* data_;
-  };
-
-  // Sparse allreduce is implemented with allgather on indices and values.
-  // Every process then sums the resulting sparse tensors locally.
-  // The nnz for sparse tensors may be different across processes, so first
-  // we run allgather on the nnz, and then allgather with max(nnz).
-  at::Tensor allreduce(std::vector<at::Tensor>& tensors) {
-    // TODO: This is a massive hack!  There is some confusion about
-    // Variable/Tensor inside the body of this function.  Turning off
-    // grad smooths over the confusion for now.  This fixes
-    // test/test_c10d_gloo.py ProcessGroupGlooTest.test_sparse_allreduce_basics
-    //
-    // The correct fix is to stop allocating tensors that are not variables,
-    // but to conveniently do this c10d must depend on torch not ATen
-    at::AutoDispatchBelowAutograd guard;
-    auto input = tensors[0];
-
-    // Perform local reduction if we have multiple inputs.
-    for (const auto i : c10::irange(1, tensors.size())) {
-      input += tensors[i];
-    }
-
-    // Need to coalesce before we can access indices and values.
-    input = input.coalesce();
-
-    // Gather metadata information from all ranks.
-    auto metadata = allgather_metadata(input);
-
-    // Sanity check dimensionality across ranks.
-    {
-      const auto expected = metadata[context->rank].sizes();
-      for (const auto i : c10::irange(context->size)) {
-        if (i == context->rank) {
-          continue;
-        }
-        const auto actual = metadata[i].sizes();
-        TORCH_CHECK(actual == expected, "Sparse dimensions do not match");
-      }
-    }
-
-    // Gather all indices and all values.
-    auto indices = allgather_indices(input, metadata);
-    auto values = allgather_values(input, metadata);
-
-    // Perform global reduction.
-    AT_ASSERT(static_cast<int>(indices.size()) == context->size);
-    AT_ASSERT(static_cast<int>(values.size()) == context->size);
-    auto output = at::sparse_coo_tensor(
-        indices[0], values[0], input.sizes(), input.options());
-    for (const auto i : c10::irange(1, context->size)) {
-      output += at::sparse_coo_tensor(
-          indices[i], values[i], input.sizes(), input.options());
-    }
-
-    // Coalesce for good measure.
-    return output.coalesce();
-  }
-
-  void run() override {
-    auto output = allreduce(inputs);
-
-    // This copy is needed when we run a multi-gpu version of reduce (multiple
-    // inputs per rank).
-    for (const auto i : c10::irange(inputs.size())) {
-      inputs[i].copy_(output);
-    }
-  }
-
- private:
-  std::vector<SparseTensorMetadata> allgather_metadata(
-      const at::Tensor& tensor) {
-    auto buffer =
-        at::zeros({context->size, SparseTensorMetadata::dim}, at::kLong);
-
-    // Prepare metadata vector (1 entry per rank)
-    std::vector<SparseTensorMetadata> metadata;
-    metadata.reserve(context->size);
-    for (const auto i : c10::irange(context->size)) {
-      metadata.emplace_back(buffer.select(0, i));
-    }
-
-    // Populate data for this rank
-    metadata[context->rank].populate_from_sparse_tensor(tensor);
-
-    // Allgather metadata
-    gloo::AllgatherOptions opts(context);
-    opts.setOutput(buffer.mutable_data_ptr<int64_t>(), buffer.numel());
-    opts.setTag(tag);
-    gloo::allgather(opts);
-
-    return metadata;
-  }
-
-  std::vector<at::Tensor> allgather_indices(
-      const at::Tensor& tensor,
-      const std::vector<SparseTensorMetadata>& metadata) {
-    const auto sparseDim = tensor.sparse_dim();
-
-    std::vector<size_t> counts(context->size);
-    size_t totalSize = 0;
-    for (const auto i : c10::irange(metadata.size())) {
-      counts[i] = metadata[i].nnz() * sparseDim;
-      totalSize += counts[i];
-    }
-
-    auto output = at::empty({static_cast<int64_t>(totalSize)}, at::kLong);
-
-    // tensors copied from cuda may not be contiguous, get a contiguous
-    // tensor before use its data_ptr
-    auto input = tensor.indices().contiguous();
-
-    // Allgatherv indices.
-    gloo::AllgathervOptions opts(context);
-    opts.setInput(
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-        const_cast<int64_t*>(input.const_data_ptr<int64_t>()),
-        input.numel());
-    opts.setOutput(output.mutable_data_ptr<int64_t>(), counts);
-    opts.setTag(tag);
-    gloo::allgatherv(opts);
-
-    // Compile indices tensor per rank.
-    std::vector<at::Tensor> indices;
-    indices.reserve(metadata.size());
-    int64_t offset = 0;
-    for (const auto& i : metadata) {
-      const auto nnz = i.nnz();
-      const auto numel = sparseDim * nnz;
-      indices.push_back(
-          output.narrow(0, offset, numel).reshape({sparseDim, nnz}));
-      offset += numel;
-    }
-
-    return indices;
-  }
-
-  std::vector<at::Tensor> allgather_values(
-      const at::Tensor& tensor,
-      const std::vector<SparseTensorMetadata>& metadata) {
-    // There are nnz #dense_dim()-dimensional tensors per rank.
-    const auto valueShape = tensor.sizes().slice(tensor.sparse_dim());
-    int64_t denseNumel = 1;
-    for (auto dim : valueShape) {
-      denseNumel *= dim;
-    }
-
-    std::vector<size_t> counts(context->size);
-    int64_t totalSize = 0;
-    for (const auto i : c10::irange(metadata.size())) {
-      counts[i] = metadata[i].nnz() * denseNumel;
-      totalSize += static_cast<int64_t>(counts[i]);
-    }
-
-    auto output = at::empty({totalSize}, tensor.scalar_type());
-
-    // Allgatherv indices.
-    gloo::AllgathervOptions opts(context);
-    // tensors copied from cuda may not be contiguous, get a contiguous
-    // tensor before use its data_ptr
-    at::Tensor valueTensor = tensor.values().contiguous();
-    GENERATE_ALL_TYPES(valueTensor.scalar_type(), setInput, opts, valueTensor);
-    GENERATE_ALL_TYPES(
-        valueTensor.scalar_type(), setOutput, opts, output, counts);
-    opts.setTag(tag);
-    gloo::allgatherv(opts);
-
-    // Compile values tensor per rank.
-    std::vector<at::Tensor> values;
-    values.reserve(metadata.size());
-    int64_t offset = 0;
-    for (const auto& i : metadata) {
-      const auto nnz = i.nnz();
-      const auto numel = denseNumel * nnz;
-      auto tensorShape = std::vector<int64_t>({(int64_t)nnz});
-      std::copy(
-          valueShape.begin(),
-          valueShape.end(),
-          std::back_inserter(tensorShape));
-      values.push_back(output.narrow(0, offset, numel).reshape(tensorShape));
-      offset += numel;
-    }
-
-    return values;
-  }
-};
-
-class AsyncAllreduceCUDAWork : public AsyncAllreduceWork {
- public:
-  AsyncAllreduceCUDAWork(
-      const std::shared_ptr<gloo::Context>& context,
-      std::vector<at::Tensor>& inputs,
-      ReduceOp reduceOp,
-      uint32_t tag,
-      uint64_t seq)
-      : AsyncAllreduceWork(context, inputs, std::move(reduceOp), tag, seq) {
-    initializeStreamsEvents(inputs, streams, events);
-
-    // Kick off copy from CUDA tensors to pinned CPU tensors.
-    tmp.reserve(inputs.size());
-    c10::OptionalStreamGuard guard;
-    for (const auto i : c10::irange(inputs.size())) {
-      guard.reset_stream(streams[i]);
-      tmp.push_back(pinnedLike(inputs[i]).copy_(inputs[i], true));
-    }
-  }
-
-  void run() override {
-    // Synchronize with copy operations.
-    for (const auto i : c10::irange(inputs.size())) {
-      streams[i].synchronize();
-    }
-
-    // Run allreduce on host side tensors.
-    allreduce(tmp);
-
-    c10::OptionalStreamGuard guard;
-    for (const auto i : c10::irange(inputs.size())) {
-      guard.reset_stream(streams[i]);
-      inputs[i].copy_(tmp[i], /* non_blocking */ true);
-      events[i].record(streams[i]);
-    }
-  }
-
-  void synchronize() override {
-    // Synchronize with the copy back to CUDA tensors.
-    for (const auto i : c10::irange(inputs.size())) {
-      c10::Device device = inputs[i].device();
-      events[i].block(
-          c10::impl::VirtualGuardImpl(device.type()).getStream(device));
-    }
-  }
-
-  std::vector<at::Tensor> tmp;
-  std::vector<c10::Stream> streams{};
-  std::vector<c10::Event> events{};
-};
-
-class AsyncSparseAllreduceCUDAWork : public AsyncSparseAllreduceWork {
- public:
-  AsyncSparseAllreduceCUDAWork(
-      const std::shared_ptr<gloo::Context>& context,
-      std::vector<at::Tensor>& inputs,
-      uint32_t tag,
-      uint64_t seq)
-      : AsyncSparseAllreduceWork(context, inputs, tag, seq) {
-    initializeStreamsEvents(inputs, streams, events);
-
-    // Kick off copy from CUDA tensors to CPU tensors.
-    // Note that both coalescing the sparse tensor and copying it to CPU
-    // memory must be performed asynchronously, or we block the caller.
-    tmp.reserve(inputs.size());
-    c10::OptionalStreamGuard guard;
-    for (const auto i : c10::irange(inputs.size())) {
-      guard.reset_stream(streams[i]);
-      tmp.push_back(
-          inputs[i].coalesce().to(at::DeviceType::CPU, /*non_blocking=*/true));
-    }
-  }
-
-  void run() override {
-    // Synchronize with copy operations.
-    for (const auto i : c10::irange(inputs.size())) {
-      streams[i].synchronize();
-    }
-
-    // Run allreduce on host side tensors.
-    auto output = allreduce(tmp);
-
-    // Kick off copy back to the CUDA tensors.
-    c10::OptionalStreamGuard guard;
-    for (const auto i : c10::irange(inputs.size())) {
-      guard.reset_stream(streams[i]);
-      inputs[i].copy_(output, /*non_blocking=*/true);
-      events[i].record(streams[i]);
-    }
-  }
-
-  void synchronize() override {
-    // Synchronize with the copy back to CUDA tensors.
-    for (const auto i : c10::irange(inputs.size())) {
-      c10::Device device = inputs[i].device();
-      events[i].block(
-          c10::impl::VirtualGuardImpl(device.type()).getStream(device));
-    }
-  }
-
-  std::vector<at::Tensor> tmp{};
-  std::vector<c10::Stream> streams{};
-  std::vector<c10::Event> events{};
-};
-
-} // namespace
-
 c10::intrusive_ptr<Work> ProcessGroupGloo::allreduce(
     std::vector<at::Tensor>& inputs,
     const AllreduceOptions& opts) {
@@ -1552,33 +853,48 @@ c10::intrusive_ptr<Work> ProcessGroupGloo::allreduce(
   auto tag = nextTag();
   auto context = getContext(tag);
   ++seq_;
-  if (device.type() == at::kCPU) {
-    if (layout == c10::kStrided) {
-      work = c10::make_intrusive<AsyncAllreduceWork>(
-          std::move(context), inputs, opts.reduceOp, tag, seq_);
-    } else if (layout == c10::kSparse) {
-      work = c10::make_intrusive<AsyncSparseAllreduceWork>(
-          std::move(context), inputs, tag, seq_);
-    } else {
-      invalidArgument("unsupported layout");
-    }
-  } else if (device.type() == at::kCUDA) {
-    if (layout == c10::kStrided) {
-      work = c10::make_intrusive<AsyncAllreduceCUDAWork>(
-          std::move(context), inputs, opts.reduceOp, tag, seq_);
-    } else if (layout == c10::kSparse) {
-      work = c10::make_intrusive<AsyncSparseAllreduceCUDAWork>(
-          std::move(context), inputs, tag, seq_);
-    } else {
-      invalidArgument("unsupported layout");
-    }
-  } else {
-    TORCH_CHECK(false, "Invalid backend");
-  }
+
+  work = GlooAllreduceRegistry()->Create(
+      device.type(), context, inputs, opts.reduceOp, tag, seq_);
 
   enqueue(work);
   return work;
 }
+
+static c10::intrusive_ptr<ProcessGroupGloo::AsyncWork> makeAllreduceCPUWork(
+    std::shared_ptr<gloo::Context> context,
+    std::vector<at::Tensor>& inputs,
+    ReduceOp reduceOp,
+    uint32_t tag,
+    uint64_t seq) {
+  auto layout = inputs[0].layout();
+
+  if (layout == c10::kStrided) {
+    return c10::make_intrusive<AsyncAllreduceWork>(
+        std::move(context), inputs, reduceOp, tag, seq);
+  } else if (layout == c10::kSparse) {
+    return c10::make_intrusive<AsyncSparseAllreduceWork>(
+        std::move(context), inputs, tag, seq);
+  } else {
+    TORCH_CHECK(false, "ProcessGroupGloo::allreduce: unsupported layout");
+  }
+}
+
+C10_DEFINE_TYPED_REGISTRY(
+    GlooAllreduceRegistry,
+    c10::DeviceType,
+    ProcessGroupGloo::AsyncWork,
+    c10::intrusive_ptr,
+    std::shared_ptr<gloo::Context>,
+    std::vector<at::Tensor>&,
+    ReduceOp,
+    uint32_t,
+    uint64_t)
+
+C10_REGISTER_TYPED_CREATOR(
+    GlooAllreduceRegistry,
+    at::kCPU,
+    makeAllreduceCPUWork)
 
 c10::intrusive_ptr<Work> ProcessGroupGloo::allreduce_sparse(
     std::vector<at::Tensor>& inputs,

--- a/torch/csrc/distributed/c10d/ProcessGroupGlooCuda.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGlooCuda.cpp
@@ -1,0 +1,200 @@
+#ifdef USE_C10D_GLOO
+#include <torch/csrc/distributed/c10d/ProcessGroupGloo.hpp>
+#include <torch/csrc/distributed/c10d/ProcessGroupGlooDetail.hpp>
+
+#include <gloo/cuda_allreduce_ring_chunked.h>
+
+namespace c10d {
+
+class AsyncAllreduceCUDADeviceWork : public ProcessGroupGloo::AsyncWork {
+ public:
+  AsyncAllreduceCUDADeviceWork(
+      const std::shared_ptr<gloo::Context>& context,
+      std::vector<at::Tensor>& inputs,
+      ReduceOp reduceOp,
+      uint32_t tag,
+      uint64_t seq)
+      : ProcessGroupGloo::AsyncWork(
+            {inputs},
+            OpType::ALLREDUCE,
+            seq,
+            "gloo:all_reduce",
+            inputs),
+        context_(context),
+        inputs_(inputs),
+        reduceOp_(reduceOp) {}
+
+  template <typename T>
+  void createAlgorithm(std::unique_ptr<gloo::Algorithm>& algo) {
+    auto count = inputs_.at(0).numel();
+    std::vector<T*> ptrs;
+    for (const auto& tensor : inputs_) {
+      TORCH_CHECK_EQ(tensor.numel(), count);
+      ptrs.push_back(static_cast<T*>(tensor.data_ptr()));
+    }
+    algo = std::make_unique<
+        gloo::CudaAllreduceRingChunked<T, gloo::CudaDeviceWorkspace<T>>>(
+        context_, ptrs, count);
+  }
+
+  void run() override {
+    const auto& scalarType = inputs_.at(0).scalar_type();
+
+    std::unique_ptr<gloo::Algorithm> algo;
+    GENERATE_ALL_TYPES(scalarType, createAlgorithm, algo);
+    algo->run();
+
+    // Gloo doesn't support AVG so we use SUM + division.
+    if (reduceOp_ == ReduceOp::AVG) {
+      inputs_[0] /= context_->size;
+    } else {
+      TORCH_CHECK_EQ(reduceOp_, ReduceOp::SUM);
+    }
+  }
+
+  void synchronize() override {
+    // TODO: is synchronization needed?
+  }
+
+ private:
+  std::shared_ptr<gloo::Context> context_;
+  std::vector<at::Tensor> inputs_;
+  const ReduceOp reduceOp_;
+};
+
+class AsyncAllreduceCUDAHostWork : public AsyncAllreduceWork {
+ public:
+  AsyncAllreduceCUDAHostWork(
+      const std::shared_ptr<gloo::Context>& context,
+      std::vector<at::Tensor>& inputs,
+      ReduceOp reduceOp,
+      uint32_t tag,
+      uint64_t seq)
+      : AsyncAllreduceWork(context, inputs, std::move(reduceOp), tag, seq) {
+    initializeStreamsEvents(inputs, streams, events);
+
+    // Kick off copy from CUDA tensors to pinned CPU tensors.
+    tmp.reserve(inputs.size());
+    c10::OptionalStreamGuard guard;
+    for (const auto i : c10::irange(inputs.size())) {
+      guard.reset_stream(streams[i]);
+      tmp.push_back(pinnedLike(inputs[i]).copy_(inputs[i], true));
+    }
+  }
+
+  void run() override {
+    // Synchronize with copy operations.
+    for (const auto i : c10::irange(inputs.size())) {
+      streams[i].synchronize();
+    }
+
+    // Run allreduce on host side tensors.
+    allreduce(tmp);
+
+    c10::OptionalStreamGuard guard;
+    for (const auto i : c10::irange(inputs.size())) {
+      guard.reset_stream(streams[i]);
+      inputs[i].copy_(tmp[i], /* non_blocking */ true);
+      events[i].record(streams[i]);
+    }
+  }
+
+  void synchronize() override {
+    // Synchronize with the copy back to CUDA tensors.
+    for (const auto i : c10::irange(inputs.size())) {
+      c10::Device device = inputs[i].device();
+      events[i].block(
+          c10::impl::VirtualGuardImpl(device.type()).getStream(device));
+    }
+  }
+
+  std::vector<at::Tensor> tmp;
+  std::vector<c10::Stream> streams{};
+  std::vector<c10::Event> events{};
+};
+
+class AsyncSparseAllreduceCUDAWork : public AsyncSparseAllreduceWork {
+ public:
+  AsyncSparseAllreduceCUDAWork(
+      const std::shared_ptr<gloo::Context>& context,
+      std::vector<at::Tensor>& inputs,
+      uint32_t tag,
+      uint64_t seq)
+      : AsyncSparseAllreduceWork(context, inputs, tag, seq) {
+    initializeStreamsEvents(inputs, streams, events);
+
+    // Kick off copy from CUDA tensors to CPU tensors.
+    // Note that both coalescing the sparse tensor and copying it to CPU
+    // memory must be performed asynchronously, or we block the caller.
+    tmp.reserve(inputs.size());
+    c10::OptionalStreamGuard guard;
+    for (const auto i : c10::irange(inputs.size())) {
+      guard.reset_stream(streams[i]);
+      tmp.push_back(
+          inputs[i].coalesce().to(at::DeviceType::CPU, /*non_blocking=*/true));
+    }
+  }
+
+  void run() override {
+    // Synchronize with copy operations.
+    for (const auto i : c10::irange(inputs.size())) {
+      streams[i].synchronize();
+    }
+
+    // Run allreduce on host side tensors.
+    auto output = allreduce(tmp);
+
+    // Kick off copy back to the CUDA tensors.
+    c10::OptionalStreamGuard guard;
+    for (const auto i : c10::irange(inputs.size())) {
+      guard.reset_stream(streams[i]);
+      inputs[i].copy_(output, /*non_blocking=*/true);
+      events[i].record(streams[i]);
+    }
+  }
+
+  void synchronize() override {
+    // Synchronize with the copy back to CUDA tensors.
+    for (const auto i : c10::irange(inputs.size())) {
+      c10::Device device = inputs[i].device();
+      events[i].block(
+          c10::impl::VirtualGuardImpl(device.type()).getStream(device));
+    }
+  }
+
+  std::vector<at::Tensor> tmp{};
+  std::vector<c10::Stream> streams{};
+  std::vector<c10::Event> events{};
+};
+
+static c10::intrusive_ptr<ProcessGroupGloo::AsyncWork> makeAllreduceCUDAWork(
+    std::shared_ptr<gloo::Context> context,
+    std::vector<at::Tensor>& inputs,
+    ReduceOp reduceOp,
+    uint32_t tag,
+    uint64_t seq) {
+  auto layout = inputs[0].layout();
+
+  if (layout == c10::kStrided) {
+    if (context->getDevice()->hasGPUDirect()) {
+      return c10::make_intrusive<AsyncAllreduceCUDADeviceWork>(
+          std::move(context), inputs, reduceOp, tag, seq);
+    } else {
+      return c10::make_intrusive<AsyncAllreduceCUDAHostWork>(
+          std::move(context), inputs, reduceOp, tag, seq);
+    }
+  } else if (layout == c10::kSparse) {
+    return c10::make_intrusive<AsyncSparseAllreduceCUDAWork>(
+        std::move(context), inputs, tag, seq);
+  } else {
+    TORCH_CHECK(false, "ProcessGroupGloo::allreduce: unsupported layout");
+  }
+}
+
+C10_REGISTER_TYPED_CREATOR(
+    GlooAllreduceRegistry,
+    at::kCUDA,
+    makeAllreduceCUDAWork)
+} // namespace c10d
+
+#endif // USE_C10D_GLOO

--- a/torch/csrc/distributed/c10d/ProcessGroupGlooDetail.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGlooDetail.hpp
@@ -1,0 +1,633 @@
+#pragma once
+
+#ifdef USE_C10D_GLOO
+
+#include <c10/util/Registry.h>
+#include <torch/csrc/distributed/c10d/ProcessGroupGloo.hpp>
+
+#include <gloo/allgather.h>
+#include <gloo/allgatherv.h>
+#include <gloo/allreduce.h>
+#include <gloo/alltoall.h>
+#include <gloo/alltoallv.h>
+#include <gloo/barrier.h>
+#include <gloo/broadcast.h>
+#include <gloo/gather.h>
+#include <gloo/reduce.h>
+#include <gloo/scatter.h>
+
+#ifdef _WIN32
+#define GENERATE_ALL_TYPES(type, func, ...)      \
+  switch (type) {                                \
+    case ::at::ScalarType::Float:                \
+      func<float>(__VA_ARGS__);                  \
+      break;                                     \
+    case ::at::ScalarType::Double:               \
+      func<double>(__VA_ARGS__);                 \
+      break;                                     \
+    case ::at::ScalarType::Half:                 \
+      func<gloo::float16>(__VA_ARGS__);          \
+      break;                                     \
+    case ::at::ScalarType::BFloat16:             \
+      func<c10::BFloat16>(__VA_ARGS__);          \
+      break;                                     \
+    case ::at::ScalarType::Char:                 \
+      func<int8_t>(__VA_ARGS__);                 \
+      break;                                     \
+    case ::at::ScalarType::Byte:                 \
+    case ::at::ScalarType::Bool:                 \
+      func<uint8_t>(__VA_ARGS__);                \
+      break;                                     \
+    case ::at::ScalarType::Int:                  \
+      func<int32_t>(__VA_ARGS__);                \
+      break;                                     \
+    case ::at::ScalarType::Long:                 \
+      func<int64_t>(__VA_ARGS__);                \
+      break;                                     \
+    default:                                     \
+      TORCH_CHECK(false, "Invalid scalar type"); \
+  }
+
+#define HOST_NAME_MAX 256
+#else
+#define GENERATE_ALL_TYPES(type, func, args...)  \
+  switch (type) {                                \
+    case ::at::ScalarType::Float:                \
+      func<float>(args);                         \
+      break;                                     \
+    case ::at::ScalarType::Double:               \
+      func<double>(args);                        \
+      break;                                     \
+    case ::at::ScalarType::Half:                 \
+      func<gloo::float16>(args);                 \
+      break;                                     \
+    case ::at::ScalarType::BFloat16:             \
+      func<c10::BFloat16>(args);                 \
+      break;                                     \
+    case ::at::ScalarType::Char:                 \
+      func<int8_t>(args);                        \
+      break;                                     \
+    case ::at::ScalarType::Byte:                 \
+    case ::at::ScalarType::Bool:                 \
+      func<uint8_t>(args);                       \
+      break;                                     \
+    case ::at::ScalarType::Int:                  \
+      func<int32_t>(args);                       \
+      break;                                     \
+    case ::at::ScalarType::Long:                 \
+      func<int64_t>(args);                       \
+      break;                                     \
+    default:                                     \
+      TORCH_CHECK(false, "Invalid scalar type"); \
+  }
+#endif
+
+namespace c10d {
+
+TORCH_DECLARE_TYPED_REGISTRY(
+    GlooAllreduceRegistry,
+    c10::DeviceType,
+    ProcessGroupGloo::AsyncWork,
+    c10::intrusive_ptr,
+    std::shared_ptr<gloo::Context>,
+    std::vector<at::Tensor>&,
+    ReduceOp,
+    uint32_t,
+    uint64_t);
+
+// This function initializes a vector of CUDA streams, one for every
+// tensor in the input tensor vector, and ensures that these streams are
+// synchronized with the current default streams. This is needed so
+// that new work on the new streams is serialized w.r.t. all operations
+// on the tensors.
+TORCH_API void initializeStreamsEvents(
+    const std::vector<at::Tensor>& tensors,
+    std::vector<c10::Stream>& streams,
+    std::vector<c10::Event>& events);
+
+// This function initializes a vector of CUDA streams, one per device,
+// and ensures that these streams are synchronized with the current default
+// streams. It is assumed that the tensors in the nested tensor vectors are
+// on the same device.
+TORCH_API void initializeStreamsEvents(
+    std::vector<std::vector<at::Tensor>>& tensors,
+    std::vector<c10::Stream>& streams,
+    std::vector<c10::Event>& events);
+
+typedef void (*ReduceFunc)(void*, const void*, const void*, size_t);
+
+template <typename T, std::enable_if_t<!std::is_integral_v<T>, int> = 0>
+ReduceFunc toFunction(const ReduceOp& r) {
+  switch (r) {
+    case ReduceOp::SUM:
+    case ReduceOp::AVG:
+      return ReduceFunc(&::gloo::sum<T>);
+    case ReduceOp::PRODUCT:
+      return ReduceFunc(&::gloo::product<T>);
+    case ReduceOp::MIN:
+      return ReduceFunc(&::gloo::min<T>);
+    case ReduceOp::MAX:
+      return ReduceFunc(&::gloo::max<T>);
+    case ReduceOp::BAND:
+      TORCH_CHECK(false, "Cannot use ReduceOp.BAND with non-integral dtype");
+      break;
+    case ReduceOp::BOR:
+      TORCH_CHECK(false, "Cannot use ReduceOp.BOR with non-integral dtype");
+      break;
+    case ReduceOp::BXOR:
+      TORCH_CHECK(false, "Cannot use ReduceOp.BXOR with non-integral dtype");
+      break;
+    case ReduceOp::PREMUL_SUM:
+      TORCH_CHECK(false, "Cannot use ReduceOp.PREMUL_SUM with Gloo");
+      break;
+    case ReduceOp::UNUSED:
+    default:
+      break;
+  }
+
+  TORCH_CHECK(false, "Unhandled ReduceOp");
+}
+
+// Bitwise AND with SFINAE guard for integral types.
+template <typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
+void band(void* c, const void* a, const void* b, size_t n) {
+  auto tc = static_cast<T*>(c);
+  auto ta = static_cast<const T*>(a);
+  auto tb = static_cast<const T*>(b);
+  for (const auto i : c10::irange(n)) {
+    tc[i] = ta[i] & tb[i];
+  }
+}
+
+// Bitwise OR with SFINAE guard for integral types.
+template <typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
+void bor(void* c, const void* a, const void* b, size_t n) {
+  auto tc = static_cast<T*>(c);
+  auto ta = static_cast<const T*>(a);
+  auto tb = static_cast<const T*>(b);
+  for (const auto i : c10::irange(n)) {
+    tc[i] = ta[i] | tb[i];
+  }
+}
+
+// Bitwise XOR with SFINAE guard for integral types.
+template <typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
+void bxor(void* c, const void* a, const void* b, size_t n) {
+  auto tc = static_cast<T*>(c);
+  auto ta = static_cast<const T*>(a);
+  auto tb = static_cast<const T*>(b);
+  for (const auto i : c10::irange(n)) {
+    tc[i] = ta[i] ^ tb[i];
+  }
+}
+
+template <typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
+ReduceFunc toFunction(const ReduceOp& r) {
+  switch (r) {
+    case ReduceOp::SUM:
+    case ReduceOp::AVG:
+      return ReduceFunc(&::gloo::sum<T>);
+    case ReduceOp::PRODUCT:
+      return ReduceFunc(&::gloo::product<T>);
+    case ReduceOp::MIN:
+      return ReduceFunc(&::gloo::min<T>);
+    case ReduceOp::MAX:
+      return ReduceFunc(&::gloo::max<T>);
+    case ReduceOp::BAND:
+      return ReduceFunc(&band<T>);
+    case ReduceOp::BOR:
+      return ReduceFunc(&bor<T>);
+    case ReduceOp::BXOR:
+      return ReduceFunc(&bxor<T>);
+    case ReduceOp::PREMUL_SUM:
+      TORCH_CHECK(false, "Cannot use ReduceOp.PREMUL_SUM with Gloo");
+      break;
+    case ReduceOp::UNUSED:
+    default:
+      break;
+  }
+
+  TORCH_CHECK(false, "Unhandled ReduceOp");
+}
+
+template <typename T, typename O>
+void setInputs(O& opts, std::vector<at::Tensor>& tensors) {
+  opts.setInputs(getDataPointers<T>(tensors), tensors[0].numel());
+}
+
+template <typename T, typename O>
+void setInput(O& opts, at::Tensor& tensor) {
+  opts.setInput(getDataPointer<T>(tensor), tensor.numel());
+}
+
+template <typename T, typename O>
+void setInput(O& opts, at::Tensor& tensor, std::vector<size_t>& counts) {
+  opts.setInput(getDataPointer<T>(tensor), counts);
+}
+
+template <typename T, typename O>
+void setInput(O& opts, at::Tensor& tensor, std::vector<int64_t>& counts) {
+  opts.setInput(getDataPointer<T>(tensor), counts);
+}
+
+template <typename T, typename O>
+void setOutputs(O& opts, std::vector<at::Tensor>& tensors) {
+  opts.setOutputs(getDataPointers<T>(tensors), tensors[0].numel());
+}
+
+template <typename T, typename O>
+void setOutput(O& opts, at::Tensor& tensor) {
+  opts.setOutput(getDataPointer<T>(tensor), tensor.numel());
+}
+
+template <typename T, typename O>
+void setOutput(O& opts, at::Tensor& tensor, std::vector<size_t>& counts) {
+  opts.setOutput(getDataPointer<T>(tensor), counts);
+}
+
+template <typename T, typename O>
+void setOutput(O& opts, at::Tensor& tensor, std::vector<int64_t>& counts) {
+  opts.setOutput(getDataPointer<T>(tensor), counts);
+}
+
+static at::Tensor pinnedLike(at::Tensor& tensor) {
+  auto* allocator = at::detail::getCUDAHooks().getPinnedMemoryAllocator();
+  auto storage = c10::Storage(
+      c10::Storage::use_byte_size_t(),
+      static_cast<int64_t>(at::detail::computeStorageNbytes(
+          tensor.sizes(), tensor.strides(), tensor.dtype().itemsize())),
+      allocator,
+      /*resizable=*/false);
+  return at::empty({0}, tensor.options().device(at::kCPU))
+      .set_(storage, 0, tensor.sizes(), tensor.strides());
+}
+
+class AsyncAllreduceWork : public ProcessGroupGloo::AsyncWork {
+ public:
+  AsyncAllreduceWork(
+      std::shared_ptr<gloo::Context> context,
+      std::vector<at::Tensor>& inputs,
+      ReduceOp reduceOp,
+      uint32_t tag,
+      uint64_t seq)
+      : ProcessGroupGloo::AsyncWork(
+            {inputs},
+            OpType::ALLREDUCE,
+            seq,
+            "gloo:all_reduce",
+            inputs),
+        context(std::move(context)),
+        inputs(inputs),
+        reduceOp(std::move(reduceOp)),
+        tag(tag) {}
+
+  std::shared_ptr<gloo::Context> context;
+  std::vector<at::Tensor> inputs{};
+  const ReduceOp reduceOp;
+  const uint32_t tag;
+
+  void allreduce(std::vector<at::Tensor>& tensors) {
+    const auto& scalarType = tensors[0].scalar_type();
+    gloo::AllreduceOptions opts(context);
+    opts.setReduceFunction(getFunction(scalarType, reduceOp));
+    opts.setTag(tag);
+    GENERATE_ALL_TYPES(scalarType, setOutputs, opts, tensors);
+    gloo::allreduce(opts);
+
+    // Gloo doesn't support AVG so we use SUM + division.
+    if (reduceOp == ReduceOp::AVG) {
+      tensors[0] /= context->size;
+    }
+  }
+
+  void run() override {
+    allreduce(inputs);
+  }
+
+  template <typename T>
+  void getFunction(gloo::AllreduceOptions::Func& fn, const ReduceOp op) {
+    fn = toFunction<T>(op);
+  }
+
+  gloo::AllreduceOptions::Func getFunction(
+      const at::ScalarType& dtype,
+      const ReduceOp& op) {
+    gloo::AllreduceOptions::Func fn;
+    GENERATE_ALL_TYPES(dtype, getFunction, fn, op);
+    return fn;
+  }
+};
+
+class AsyncAllreduceCoalescedWork : public AsyncAllreduceWork {
+ public:
+  AsyncAllreduceCoalescedWork(
+      const std::shared_ptr<gloo::Context>& context,
+      std::vector<at::Tensor>& inputs,
+      ReduceOp reduceOp,
+      uint32_t tag,
+      uint64_t seq)
+      : AsyncAllreduceWork(context, inputs, std::move(reduceOp), tag, seq) {}
+
+  void run() override {
+    allreduceCoalesced(inputs);
+  }
+
+ private:
+  void allreduceCoalesced(std::vector<at::Tensor>& tensors) {
+    // reduce coalesced, flattened tensors.
+    at::Tensor coalescedTensor = flattenDenseTensors(tensors);
+    std::vector<at::Tensor> allreduceInput = {coalescedTensor};
+    allreduce(allreduceInput);
+
+    // separate and reshape tensors.
+    size_t offset = 0;
+    for (at::Tensor& tensor : tensors) {
+      const int64_t tensorNumel = tensor.numel();
+      const c10::IntArrayRef tensorShape = tensor.sizes();
+      tensor.copy_(coalescedTensor.slice(0, offset, offset + tensorNumel)
+                       .view(tensorShape));
+      offset += tensorNumel;
+    }
+  }
+};
+
+class AsyncSparseAllreduceWork : public ProcessGroupGloo::AsyncWork {
+ public:
+  AsyncSparseAllreduceWork(
+      std::shared_ptr<gloo::Context> context,
+      std::vector<at::Tensor>& inputs,
+      uint32_t tag,
+      uint64_t seq)
+      : ProcessGroupGloo::AsyncWork(
+            {inputs},
+            OpType::_ALLREDUCE_SPARSE,
+            seq,
+            "gloo:sparse_all_reduce",
+            inputs),
+        context(std::move(context)),
+        inputs(inputs),
+        tag(tag) {}
+
+  std::shared_ptr<gloo::Context> context;
+  std::vector<at::Tensor> inputs{};
+  const uint32_t tag;
+
+  // We share dimensionality about the sparse tensors before collecting
+  // their contents. We assume here that the maximum number of sparse
+  // and dense dimensions is 4. This is stored in a contiguous piece of
+  // memory so that we can easily run allgather on it.
+  //
+  // The layout of this memory is as follows:
+  //
+  //   - [0:4]: sparse dims
+  //   - [4:8]: dense dims
+  //   -   [8]: nnz
+  //
+  class SparseTensorMetadata {
+   public:
+    static constexpr auto dim = 9;
+
+    // Construct from an existing metadata tensor to facilitate structured
+    // access to metadata from peers, after gathering it.
+    explicit SparseTensorMetadata(at::Tensor metadata)
+        : metadata_(std::move(metadata)),
+          data_(metadata_.mutable_data_ptr<int64_t>()) {
+      AT_ASSERT(metadata_.scalar_type() == at::kLong);
+      AT_ASSERT(metadata_.dim() == 1);
+      AT_ASSERT(metadata_.size(0) == dim);
+    }
+
+    // Populate the metadata.
+    void populate_from_sparse_tensor(const at::Tensor& tensor) {
+      const auto sparse_dim = tensor.sparse_dim();
+      AT_ASSERT(sparse_dim <= 4);
+      for (const auto i : c10::irange(4)) {
+        if (i < sparse_dim) {
+          data_[i] = tensor.size(i);
+        }
+      }
+      const auto dense_dim = tensor.dense_dim();
+      AT_ASSERT(dense_dim <= 4);
+      for (const auto i : c10::irange(4)) {
+        if (i < dense_dim) {
+          data_[i + 4] = tensor.size(sparse_dim + i);
+        }
+      }
+      data_[8] = tensor._nnz();
+    }
+
+    std::vector<int64_t> sizes() const {
+      std::vector<int64_t> sizes;
+      // Sparse sizes
+      for (const auto i : c10::irange(4)) {
+        if (data_[i] <= 0) {
+          break;
+        }
+        sizes.push_back(data_[i]);
+      }
+      // Dense sizes
+      for (const auto i : c10::irange(4, 8)) {
+        if (data_[i] <= 0) {
+          break;
+        }
+        sizes.push_back(data_[i]);
+      }
+      return sizes;
+    }
+
+    int64_t nnz() const {
+      return data_[8];
+    }
+
+   protected:
+    at::Tensor metadata_;
+    int64_t* data_;
+  };
+
+  // Sparse allreduce is implemented with allgather on indices and values.
+  // Every process then sums the resulting sparse tensors locally.
+  // The nnz for sparse tensors may be different across processes, so first
+  // we run allgather on the nnz, and then allgather with max(nnz).
+  at::Tensor allreduce(std::vector<at::Tensor>& tensors) {
+    // TODO: This is a massive hack!  There is some confusion about
+    // Variable/Tensor inside the body of this function.  Turning off
+    // grad smooths over the confusion for now.  This fixes
+    // test/test_c10d_gloo.py ProcessGroupGlooTest.test_sparse_allreduce_basics
+    //
+    // The correct fix is to stop allocating tensors that are not variables,
+    // but to conveniently do this c10d must depend on torch not ATen
+    at::AutoDispatchBelowAutograd guard;
+    auto input = tensors[0];
+
+    // Perform local reduction if we have multiple inputs.
+    for (const auto i : c10::irange(1, tensors.size())) {
+      input += tensors[i];
+    }
+
+    // Need to coalesce before we can access indices and values.
+    input = input.coalesce();
+
+    // Gather metadata information from all ranks.
+    auto metadata = allgather_metadata(input);
+
+    // Sanity check dimensionality across ranks.
+    {
+      const auto expected = metadata[context->rank].sizes();
+      for (const auto i : c10::irange(context->size)) {
+        if (i == context->rank) {
+          continue;
+        }
+        const auto actual = metadata[i].sizes();
+        TORCH_CHECK(actual == expected, "Sparse dimensions do not match");
+      }
+    }
+
+    // Gather all indices and all values.
+    auto indices = allgather_indices(input, metadata);
+    auto values = allgather_values(input, metadata);
+
+    // Perform global reduction.
+    AT_ASSERT(static_cast<int>(indices.size()) == context->size);
+    AT_ASSERT(static_cast<int>(values.size()) == context->size);
+    auto output = at::sparse_coo_tensor(
+        indices[0], values[0], input.sizes(), input.options());
+    for (const auto i : c10::irange(1, context->size)) {
+      output += at::sparse_coo_tensor(
+          indices[i], values[i], input.sizes(), input.options());
+    }
+
+    // Coalesce for good measure.
+    return output.coalesce();
+  }
+
+  void run() override {
+    auto output = allreduce(inputs);
+
+    // This copy is needed when we run a multi-gpu version of reduce (multiple
+    // inputs per rank).
+    for (const auto i : c10::irange(inputs.size())) {
+      inputs[i].copy_(output);
+    }
+  }
+
+ private:
+  std::vector<SparseTensorMetadata> allgather_metadata(
+      const at::Tensor& tensor) {
+    auto buffer =
+        at::zeros({context->size, SparseTensorMetadata::dim}, at::kLong);
+
+    // Prepare metadata vector (1 entry per rank)
+    std::vector<SparseTensorMetadata> metadata;
+    metadata.reserve(context->size);
+    for (const auto i : c10::irange(context->size)) {
+      metadata.emplace_back(buffer.select(0, i));
+    }
+
+    // Populate data for this rank
+    metadata[context->rank].populate_from_sparse_tensor(tensor);
+
+    // Allgather metadata
+    gloo::AllgatherOptions opts(context);
+    opts.setOutput(buffer.mutable_data_ptr<int64_t>(), buffer.numel());
+    opts.setTag(tag);
+    gloo::allgather(opts);
+
+    return metadata;
+  }
+
+  std::vector<at::Tensor> allgather_indices(
+      const at::Tensor& tensor,
+      const std::vector<SparseTensorMetadata>& metadata) {
+    const auto sparseDim = tensor.sparse_dim();
+
+    std::vector<size_t> counts(context->size);
+    size_t totalSize = 0;
+    for (const auto i : c10::irange(metadata.size())) {
+      counts[i] = metadata[i].nnz() * sparseDim;
+      totalSize += counts[i];
+    }
+
+    auto output = at::empty({static_cast<int64_t>(totalSize)}, at::kLong);
+
+    // tensors copied from cuda may not be contiguous, get a contiguous
+    // tensor before use its data_ptr
+    auto input = tensor.indices().contiguous();
+
+    // Allgatherv indices.
+    gloo::AllgathervOptions opts(context);
+    opts.setInput(
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+        const_cast<int64_t*>(input.const_data_ptr<int64_t>()),
+        input.numel());
+    opts.setOutput(output.mutable_data_ptr<int64_t>(), counts);
+    opts.setTag(tag);
+    gloo::allgatherv(opts);
+
+    // Compile indices tensor per rank.
+    std::vector<at::Tensor> indices;
+    indices.reserve(metadata.size());
+    int64_t offset = 0;
+    for (const auto& i : metadata) {
+      const auto nnz = i.nnz();
+      const auto numel = sparseDim * nnz;
+      indices.push_back(
+          output.narrow(0, offset, numel).reshape({sparseDim, nnz}));
+      offset += numel;
+    }
+
+    return indices;
+  }
+
+  std::vector<at::Tensor> allgather_values(
+      const at::Tensor& tensor,
+      const std::vector<SparseTensorMetadata>& metadata) {
+    // There are nnz #dense_dim()-dimensional tensors per rank.
+    const auto valueShape = tensor.sizes().slice(tensor.sparse_dim());
+    int64_t denseNumel = 1;
+    for (auto dim : valueShape) {
+      denseNumel *= dim;
+    }
+
+    std::vector<size_t> counts(context->size);
+    int64_t totalSize = 0;
+    for (const auto i : c10::irange(metadata.size())) {
+      counts[i] = metadata[i].nnz() * denseNumel;
+      totalSize += static_cast<int64_t>(counts[i]);
+    }
+
+    auto output = at::empty({totalSize}, tensor.scalar_type());
+
+    // Allgatherv indices.
+    gloo::AllgathervOptions opts(context);
+    // tensors copied from cuda may not be contiguous, get a contiguous
+    // tensor before use its data_ptr
+    at::Tensor valueTensor = tensor.values().contiguous();
+    GENERATE_ALL_TYPES(valueTensor.scalar_type(), setInput, opts, valueTensor);
+    GENERATE_ALL_TYPES(
+        valueTensor.scalar_type(), setOutput, opts, output, counts);
+    opts.setTag(tag);
+    gloo::allgatherv(opts);
+
+    // Compile values tensor per rank.
+    std::vector<at::Tensor> values;
+    values.reserve(metadata.size());
+    int64_t offset = 0;
+    for (const auto& i : metadata) {
+      const auto nnz = i.nnz();
+      const auto numel = denseNumel * nnz;
+      auto tensorShape = std::vector<int64_t>({(int64_t)nnz});
+      std::copy(
+          valueShape.begin(),
+          valueShape.end(),
+          std::back_inserter(tensorShape));
+      values.push_back(output.narrow(0, offset, numel).reshape(tensorShape));
+      offset += numel;
+    }
+
+    return values;
+  }
+};
+
+} // namespace c10d
+
+#endif

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -8585,6 +8585,7 @@ PYTORCH_SPECIFIC_MAPPINGS = collections.OrderedDict(
             ("gloo/hip_allreduce_halving_doubling_pipelined.h", API_PYTORCH),
         ),
         ("gloo/cuda_allreduce_ring.h", ("gloo/hip_allreduce_ring.h", API_PYTORCH)),
+        ("gloo/cuda_allreduce_ring_chunked.h", ("gloo/hip_allreduce_ring_chunked.h", API_PYTORCH)),
         (
             "gloo/cuda_broadcast_one_to_all.h",
             ("gloo/hip_broadcast_one_to_all.h", API_PYTORCH),
@@ -8592,6 +8593,10 @@ PYTORCH_SPECIFIC_MAPPINGS = collections.OrderedDict(
         (
             "gloo::CudaAllreduceHalvingDoublingPipelined",
             ("gloo::HipAllreduceHalvingDoublingPipelined", API_PYTORCH),
+        ),
+        (
+            "gloo::CudaAllreduceRingChunked",
+            ("gloo::HipAllreduceRingChunked", API_PYTORCH),
         ),
         ("gloo::CudaBroadcastOneToAll", ("gloo::HipBroadcastOneToAll", API_PYTORCH)),
         ("gloo::CudaHostWorkspace", ("gloo::HipHostWorkspace", API_PYTORCH)),


### PR DESCRIPTION
This enables Gloo CUDA when used with a backend that supports GPUDirect which currently is only the IBVERBS backend.

This requires some changes to Gloo which are in https://github.com/pytorch/gloo/pull/441

Since we're now depending on gloo_cuda we need to split ProcessGroupGloo into two pieces, one with the CPU bits (libtorch_cpu) and one with CUDA kernels in libtorch_cuda. This unfortunately requires some major refactoring as some CPU code is shared across both.

The gloo submodule is updated to depend on the new Gloo changes

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab

Test plan:

```py
import os
import time

transport = "TCP"
#transport = "IBVERBS"

os.environ["GLOO_DEVICE_TRANSPORT"] = transport
rank = int(os.environ["RANK"])
os.environ["CUDA_VISIBLE_DEVICES"] = str(rank)

ibv = "mlx5_0:1,mlx5_3:1,mlx5_4:1,mlx5_5:1,mlx5_6:1,mlx5_9:1,mlx5_10:1,mlx5_11:1".split(",")[rank]
ibv_name, ibv_port = ibv.split(":")
os.environ["TORCH_GLOO_IBV_NAME"] = ibv_name
os.environ["TORCH_GLOO_IBV_PORT"] = ibv_port
os.environ["TORCH_GLOO_IBV_INDEX"] = "3"

import torch
import torch.distributed as dist

dist.init_process_group("gloo")

rank = dist.get_rank()

# initial sanity check
#device = "cpu"
#t = torch.zeros(10, device=device)
#dist.all_reduce(t)
#print("sanity complete")

device = "cpu"

iters = 10
warmup_iters = 2

for nelem in [10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000]:
    t = torch.zeros(nelem, device=device)

    torch.cuda.current_stream().synchronize()
    for i in range(warmup_iters):
        dist.all_reduce(t)

    torch.cuda.current_stream().synchronize()

    start = time.perf_counter()

    for i in range(iters):
        dist.all_reduce(t)

    torch.cuda.current_stream().synchronize()

    dur = (time.perf_counter() - start)
    qps = iters/dur

    bandwidth_gb = t.nbytes * iters / dur / 1e9

    gb = t.nbytes / 1e9

    if rank == 0:
        print(f"{transport=} {device=} {iters=} {nelem=} {qps=} {gb=} {bandwidth_gb=}\n", end="")
```
