### PR TITLE
[EZ/Profiler] Replace manual GIL calls with pybind GIL calls

### DIFF
--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -1166,7 +1166,7 @@ class PythonMemoryTracer final : public python_tracer::PythonMemoryTracerBase {
 };
 
 static void toggle_memory_tracing(bool enable) {
-  PyGILState_STATE gil_state = PyGILState_Ensure();
+  pybind11::gil_scoped_acquire gil;
   THPObjectPtr torch_cuda_memory_module(
       PyImport_ImportModule("torch.cuda.memory"));
   if (!torch_cuda_memory_module) {
@@ -1190,7 +1190,6 @@ static void toggle_memory_tracing(bool enable) {
   if (result == nullptr) {
     return;
   }
-  PyGILState_Release(gil_state);
 }
 
 void PythonMemoryTracer::start() {
@@ -1198,7 +1197,7 @@ void PythonMemoryTracer::start() {
 }
 
 void PythonMemoryTracer::export_memory_history(const std::string path) {
-  PyGILState_STATE gil_state = PyGILState_Ensure();
+  pybind11::gil_scoped_acquire gil;
   THPObjectPtr torch_cuda_memory_module(
       PyImport_ImportModule("torch.cuda.memory"));
   if (!torch_cuda_memory_module) {
@@ -1217,7 +1216,6 @@ void PythonMemoryTracer::export_memory_history(const std::string path) {
   if (result == nullptr) {
     return;
   }
-  PyGILState_Release(gil_state);
 }
 
 void PythonMemoryTracer::stop() {


### PR DESCRIPTION
Summary: Use pybind11::gil_scoped_acquire instead of old impl as it will automatically take care of error handling. In the original implementation we missed releasing the GIL on each possible error which could put the program in a deadlock

Test Plan: Induced error manually and saw that GIL was released

Differential Revision: D74593564


