### PR TITLE
Fix AOTI cpp tests

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -409,7 +409,10 @@ test_inductor_aoti() {
     python3 tools/amd_build/build_amd.py
   fi
   BUILD_AOT_INDUCTOR_TEST=1 python setup.py develop
-  CPP_TESTS_DIR="${BUILD_BIN_DIR}" LD_LIBRARY_PATH="${TORCH_LIB_DIR}" python test/run_test.py --cpp --verbose -i cpp/test_aoti_abi_check cpp/test_aoti_inference
+  # Uncomment next line and delete two more  when https://github.com/pytorch/pytorch/issues/153422 is resolved
+  # CPP_TESTS_DIR="${BUILD_BIN_DIR}" LD_LIBRARY_PATH="${TORCH_LIB_DIR}" python test/run_test.py --cpp --verbose -i cpp/test_aoti_abi_check cpp/test_aoti_inference
+  build/bin/test_aoti_abi_check
+  LD_LIBRARY_PATH=/opt/conda/envs/py_3.10/lib/:$LD_LIBRARY_PATH gdb bin/test_aoti_inference --gtest_filter=AotInductorTest.BasicTestCuda
 }
 
 test_inductor_cpp_wrapper_shard() {
@@ -1658,9 +1661,9 @@ elif [[ "${TEST_CONFIG}" == *torchbench* ]]; then
 elif [[ "${TEST_CONFIG}" == *inductor_cpp_wrapper* ]]; then
   install_torchaudio cuda
   install_torchvision
+  test_inductor_aoti
   checkout_install_torchbench hf_T5 llama moco
   PYTHONPATH=$(pwd)/torchbench test_inductor_cpp_wrapper_shard "$SHARD_NUMBER"
-  test_inductor_aoti
 elif [[ "${TEST_CONFIG}" == *inductor* ]]; then
   install_torchvision
   test_inductor_shard "${SHARD_NUMBER}"

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -412,7 +412,7 @@ test_inductor_aoti() {
   # Uncomment next line and delete two more  when https://github.com/pytorch/pytorch/issues/153422 is resolved
   # CPP_TESTS_DIR="${BUILD_BIN_DIR}" LD_LIBRARY_PATH="${TORCH_LIB_DIR}" python test/run_test.py --cpp --verbose -i cpp/test_aoti_abi_check cpp/test_aoti_inference
   build/bin/test_aoti_abi_check
-  LD_LIBRARY_PATH=/opt/conda/envs/py_3.10/lib/:$LD_LIBRARY_PATH bin/test_aoti_inference --gtest_filter='-*Cuda'
+  LD_LIBRARY_PATH=/opt/conda/envs/py_3.10/lib/:${TORCH_LIB_DIR}:$LD_LIBRARY_PATH build/bin/test_aoti_inference
 }
 
 test_inductor_cpp_wrapper_shard() {

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -408,11 +408,13 @@ test_inductor_aoti() {
     # We need to hipify before building again
     python3 tools/amd_build/build_amd.py
   fi
-  BUILD_AOT_INDUCTOR_TEST=1 python setup.py develop
-  # Uncomment next line and delete two more  when https://github.com/pytorch/pytorch/issues/153422 is resolved
-  # CPP_TESTS_DIR="${BUILD_BIN_DIR}" LD_LIBRARY_PATH="${TORCH_LIB_DIR}" python test/run_test.py --cpp --verbose -i cpp/test_aoti_abi_check cpp/test_aoti_inference
-  build/bin/test_aoti_abi_check
-  LD_LIBRARY_PATH=/opt/conda/envs/py_3.10/lib/:${TORCH_LIB_DIR}:$LD_LIBRARY_PATH build/bin/test_aoti_inference
+  if [[ "$BUILD_ENVIRONMENT" == *sm86* ]]; then
+    BUILD_AOT_INDUCTOR_TEST=1 TORCH_CUDA_ARCH_LIST=8.6 USE_FLASH_ATTENTION=OFF python setup.py develop
+    CPP_TESTS_DIR="${BUILD_BIN_DIR}" LD_LIBRARY_PATH=$(which python)/../../lib/ python test/run_test.py --cpp --verbose -i cpp/test_aoti_abi_check cpp/test_aoti_inference
+  else
+    BUILD_AOT_INDUCTOR_TEST=1 python setup.py develop
+    CPP_TESTS_DIR="${BUILD_BIN_DIR}" LD_LIBRARY_PATH="${TORCH_LIB_DIR}" python test/run_test.py --cpp --verbose -i cpp/test_aoti_abi_check cpp/test_aoti_inference
+  fi
 }
 
 test_inductor_cpp_wrapper_shard() {

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -412,7 +412,7 @@ test_inductor_aoti() {
   # Uncomment next line and delete two more  when https://github.com/pytorch/pytorch/issues/153422 is resolved
   # CPP_TESTS_DIR="${BUILD_BIN_DIR}" LD_LIBRARY_PATH="${TORCH_LIB_DIR}" python test/run_test.py --cpp --verbose -i cpp/test_aoti_abi_check cpp/test_aoti_inference
   build/bin/test_aoti_abi_check
-  LD_LIBRARY_PATH=/opt/conda/envs/py_3.10/lib/:$LD_LIBRARY_PATH gdb bin/test_aoti_inference --gtest_filter=AotInductorTest.BasicTestCuda
+  LD_LIBRARY_PATH=/opt/conda/envs/py_3.10/lib/:$LD_LIBRARY_PATH bin/test_aoti_inference --gtest_filter='-*Cuda'
 }
 
 test_inductor_cpp_wrapper_shard() {

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -410,7 +410,9 @@ test_inductor_aoti() {
   fi
   if [[ "$BUILD_ENVIRONMENT" == *sm86* ]]; then
     BUILD_AOT_INDUCTOR_TEST=1 TORCH_CUDA_ARCH_LIST=8.6 USE_FLASH_ATTENTION=OFF python setup.py develop
-    CPP_TESTS_DIR="${BUILD_BIN_DIR}" LD_LIBRARY_PATH=$(which python)/../../lib/ python test/run_test.py --cpp --verbose -i cpp/test_aoti_abi_check cpp/test_aoti_inference
+    # TODO: Replace me completely, as one should not use conda libstdc++, nor need special path to TORCH_LIB
+    LD_LIBRARY_PATH=/opt/conda/envs/py_3.10/lib/:${TORCH_LIB_DIR}:$LD_LIBRARY_PATH
+    CPP_TESTS_DIR="${BUILD_BIN_DIR}" python test/run_test.py --cpp --verbose -i cpp/test_aoti_abi_check cpp/test_aoti_inference
   else
     BUILD_AOT_INDUCTOR_TEST=1 python setup.py develop
     CPP_TESTS_DIR="${BUILD_BIN_DIR}" LD_LIBRARY_PATH="${TORCH_LIB_DIR}" python test/run_test.py --cpp --verbose -i cpp/test_aoti_abi_check cpp/test_aoti_inference
@@ -1663,9 +1665,9 @@ elif [[ "${TEST_CONFIG}" == *torchbench* ]]; then
 elif [[ "${TEST_CONFIG}" == *inductor_cpp_wrapper* ]]; then
   install_torchaudio cuda
   install_torchvision
-  test_inductor_aoti
   checkout_install_torchbench hf_T5 llama moco
   PYTHONPATH=$(pwd)/torchbench test_inductor_cpp_wrapper_shard "$SHARD_NUMBER"
+  test_inductor_aoti
 elif [[ "${TEST_CONFIG}" == *inductor* ]]; then
   install_torchvision
   test_inductor_shard "${SHARD_NUMBER}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #153423

`Error in dlopen: /lib/x86_64-linux-gnu/libstdc++.so.6: version GLIBCXX_3.4.30 not found` error  was caused by cmake migration (as conda one probably have some extra link rules), while `C++ exception with description "CUDA error: no kernel image is available for execution on the device` were caused by the fact that test were build for Maxwell, but run on SM_86

Remaining test was failing before, but was probably disabled
TODOs:
 - Move build to the build step
 