### PR TITLE
Remove std::is_arithmetic specialization from c10/util/strong_type.h

### DIFF
--- a/c10/util/strong_type.h
+++ b/c10/util/strong_type.h
@@ -1604,12 +1604,6 @@ struct hash<::strong::type<T, Tag, M...>>
     return hash<T>::operator()(value_of(tt));
   }
 };
-template <typename T, typename Tag, typename ... M>
-struct is_arithmetic<::strong::type<T, Tag, M...>>
-  : is_base_of<::strong::arithmetic::modifier<::strong::type<T, Tag, M...>>,
-               ::strong::type<T, Tag, M...>>
-{
-};
 
 #if STRONG_HAS_STD_FORMAT
 template<typename T, typename Tag, typename... M, typename Char>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #153424

Specializing std::is_arithmetic has undefined behavior (and breaks builds with -Winvalid-specialization). Should fix #150901

Differential Revision: [D74614724](https://our.internmc.facebook.com/intern/diff/D74614724/)