### PR TITLE
[Aten Backend] Move all view ops from out-of-tree to in-tree

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -942,7 +942,7 @@
 - func: as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)
   variants: function, method
   dispatch:
-    ZeroTensor, CPU, CUDA: as_strided_tensorimpl
+    ZeroTensor, CPU, CUDA, MTIA: as_strided_tensorimpl
     Meta: as_strided_tensorimpl_meta_symint
     MPS: as_strided_tensorimpl_mps
     QuantizedCPU, QuantizedCUDA: as_strided_qtensorimpl
@@ -4983,7 +4983,7 @@
   device_check: NoCheck
   device_guard: False
   dispatch:
-    CPU, CUDA, Meta, QuantizedCPU, QuantizedCUDA, ZeroTensor, MPS: _reshape_alias
+    CPU, CUDA, Meta, QuantizedCPU, QuantizedCUDA, ZeroTensor, MPS, MTIA: _reshape_alias
     # We don't need to support mkldnn since this is handled explicitly by the reshape operator.
 
 - func: _mkldnn_reshape(Tensor self, int[] shape) -> Tensor
@@ -8123,7 +8123,7 @@
   device_check: NoCheck
   device_guard: False
   dispatch:
-    ZeroTensor, Meta, CPU, CUDA, QuantizedCPU, QuantizedCUDA, MPS: view
+    ZeroTensor, Meta, CPU, CUDA, QuantizedCPU, QuantizedCUDA, MPS, MTIA: view
     MkldnnCPU: mkldnn_view
     NestedTensorCPU, NestedTensorHPU, NestedTensorCUDA: view_nested
   tags: core
@@ -10240,13 +10240,13 @@
   device_check: NoCheck
   device_guard: False
   dispatch:
-    CPU, CUDA, Meta, MPS: unfold
+    CPU, CUDA, Meta, MPS, MTIA: unfold
     QuantizedCPU, QuantizedCUDA: unfold
 
 - func: unfold_backward(Tensor grad_in, SymInt[] input_sizes, int dim, int size, int step) -> Tensor
   variants: function
   dispatch:
-    CPU, CUDA, MPS: unfold_backward
+    CPU, CUDA, MPS, MTIA: unfold_backward
   autogen: unfold_backward.out
 
 - func: equal(Tensor self, Tensor other) -> bool

--- a/build.bzl
+++ b/build.bzl
@@ -79,6 +79,8 @@ def define_targets(rules):
         aten_ufunc_generated_cuda_sources()
     )
 
+    gen_aten_outs_mtia = GENERATED_H_MTIA + GENERATED_CPP_MTIA
+
     gen_aten_outs = (
         GENERATED_H + GENERATED_H_CORE +
         GENERATED_CPP + GENERATED_CPP_CORE +
@@ -86,7 +88,7 @@ def define_targets(rules):
         aten_ufunc_generated_cpu_sources() +
         aten_ufunc_generated_cpu_kernel_sources() + [
             "Declarations.yaml",
-        ] + gen_aten_outs_cuda
+        ] + gen_aten_outs_cuda + gen_aten_outs_mtia
     )
 
     rules.genrule(
@@ -206,6 +208,15 @@ GENERATED_CPP_CUDA = [
     "RegisterSparseCUDA_0.cpp",
     "RegisterSparseCsrCUDA_0.cpp",
     "RegisterQuantizedCUDA_0.cpp",
+]
+
+GENERATED_H_MTIA = [
+    "MTIAFunctions.h",
+    "MTIAFunctions_inl.h",
+]
+
+GENERATED_CPP_MTIA = [
+    "RegisterMTIA_0.cpp",
 ]
 
 GENERATED_CPP = [

--- a/torchgen/gen.py
+++ b/torchgen/gen.py
@@ -2977,6 +2977,7 @@ def main() -> None:
         DispatchKey.CompositeExplicitAutograd,
         DispatchKey.CompositeExplicitAutogradNonFunctional,
         DispatchKey.Meta,
+        DispatchKey.MTIA,
     }
 
     aoti_backends = {

--- a/torchgen/model.py
+++ b/torchgen/model.py
@@ -304,6 +304,7 @@ dispatch_keys = [
     DispatchKey.QuantizedMeta,
     DispatchKey.NestedTensorMeta,
     DispatchKey.ZeroTensor,
+    DispatchKey.MTIA,
 ]
 
 


### PR DESCRIPTION
Summary:
This is the cleaned up version of D73266124. Migrate all view ops from pytorch out-of-tree to in-tree.

Note in this diff, we are deleting the entire `aten_mtia_view_ops.cpp` file.

TODO: need to link github PR

Test Plan:
CI
```
AFG_USE_MTIA_TENSOR=1 buck2 test  mode/opt  mtia/host_runtime/torch_mtia/tests:test_acc_tensor -- -r test_view_ops_view

```

Differential Revision: D74218518


