### PR TITLE
[Monitoring] Enable perf tests 

### DIFF
--- a/.github/actions/upload-utilization-stats/action.yml
+++ b/.github/actions/upload-utilization-stats/action.yml
@@ -44,7 +44,7 @@ runs:
         retry_wait_seconds: 30
         command: |
           set -eu
-          python3 -m pip install python-dateutil==2.8.2 boto3==1.35.42 pandas==2.1.3
+          python3 -m pip install python-dateutil==2.8.2 boto3==1.35.42 pandas==2.1.3 dataclasses_json==0.6.7
     - name: Upload utilizatoin stats to s3
       shell: bash
       run: |

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -124,7 +124,7 @@ jobs:
           MONITOR_LOG_INTERVAL: ${{ inputs.monitor-log-interval }}
           MONITOR_DATA_COLLECT_INTERVAL: ${{ inputs.monitor-data-collect-interval }}
         run: |
-          ${CONDA_RUN} python3 -m pip install psutil==5.9.1 dataclasses_json==0.6.7
+          ${CONDA_RUN} python3 -m pip install psutil==5.9.1 dataclasses_json==0.6.7 
           ${CONDA_RUN} python3 -m tools.stats.monitor --log-interval "$MONITOR_LOG_INTERVAL" --data-collect-interval "$MONITOR_DATA_COLLECT_INTERVAL" > usage_log.txt 2>&1 &
           echo "monitor-script-pid=${!}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -124,7 +124,7 @@ jobs:
           MONITOR_LOG_INTERVAL: ${{ inputs.monitor-log-interval }}
           MONITOR_DATA_COLLECT_INTERVAL: ${{ inputs.monitor-data-collect-interval }}
         run: |
-          ${CONDA_RUN} python3 -m pip install psutil==5.9.1 dataclasses_json==0.6.7 
+          ${CONDA_RUN} python3 -m pip install psutil==5.9.1 dataclasses_json==0.6.7
           ${CONDA_RUN} python3 -m tools.stats.monitor --log-interval "$MONITOR_LOG_INTERVAL" --data-collect-interval "$MONITOR_DATA_COLLECT_INTERVAL" > usage_log.txt 2>&1 &
           echo "monitor-script-pid=${!}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/inductor-perf-compare.yml
+++ b/.github/workflows/inductor-perf-compare.yml
@@ -52,7 +52,7 @@ jobs:
       docker-image: ${{ needs.linux-focal-cuda12_6-py3_10-gcc9-inductor-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-focal-cuda12_6-py3_10-gcc9-inductor-build.outputs.test-matrix }}
       # disable monitor in perf tests for more investigation
-      disable-monitor: true
+      disable-monitor: false
       monitor-log-interval: 15
       monitor-data-collect-interval: 4
     secrets: inherit

--- a/.github/workflows/inductor-perf-test-nightly-aarch64.yml
+++ b/.github/workflows/inductor-perf-test-nightly-aarch64.yml
@@ -129,7 +129,9 @@ jobs:
       test-matrix: ${{ needs.linux-jammy-aarch64-py3_10-inductor-build.outputs.test-matrix }}
       timeout-minutes: 720
       # disable monitor in perf tests for more investigation
-      disable-monitor: true
+      disable-monitor: false
+      monitor-log-interval: 15
+      monitor-data-collect-interval: 4
     secrets: inherit
 
 

--- a/.github/workflows/inductor-perf-test-nightly-h100.yml
+++ b/.github/workflows/inductor-perf-test-nightly-h100.yml
@@ -156,7 +156,7 @@ jobs:
       test-matrix: ${{ needs.build.outputs.test-matrix }}
       timeout-minutes: 720
       # disable monitor in perf tests for more investigation
-      disable-monitor: falase
+      disable-monitor: false
       monitor-log-interval: 15
       monitor-data-collect-interval: 4
     secrets: inherit

--- a/.github/workflows/inductor-perf-test-nightly-h100.yml
+++ b/.github/workflows/inductor-perf-test-nightly-h100.yml
@@ -122,7 +122,7 @@ jobs:
       test-matrix: ${{ needs.build.outputs.test-matrix }}
       timeout-minutes: 720
       # disable monitor in perf tests, next step is to enable it
-      disable-monitor: true
+      disable-monitor: false
       monitor-log-interval: 15
       monitor-data-collect-interval: 4
     secrets: inherit
@@ -139,7 +139,7 @@ jobs:
       test-matrix: ${{ needs.build.outputs.test-matrix }}
       timeout-minutes: 1440
       # disable monitor in perf tests, next step is to enable it
-      disable-monitor: true
+      disable-monitor: false
       monitor-log-interval: 15
       monitor-data-collect-interval: 4
     secrets: inherit
@@ -156,7 +156,7 @@ jobs:
       test-matrix: ${{ needs.build.outputs.test-matrix }}
       timeout-minutes: 720
       # disable monitor in perf tests for more investigation
-      disable-monitor: true
+      disable-monitor: falase
       monitor-log-interval: 15
       monitor-data-collect-interval: 4
     secrets: inherit

--- a/.github/workflows/inductor-perf-test-nightly-x86.yml
+++ b/.github/workflows/inductor-perf-test-nightly-x86.yml
@@ -103,7 +103,7 @@ jobs:
       test-matrix: ${{ needs.linux-jammy-cpu-py3_9-gcc11-inductor-build.outputs.test-matrix }}
       timeout-minutes: 720
       # disable monitor in perf tests
-      disable-monitor: true
+      disable-monitor: false
       monitor-log-interval: 15
       monitor-data-collect-interval: 4
     secrets: inherit
@@ -121,7 +121,7 @@ jobs:
       test-matrix: ${{ needs.linux-jammy-cpu-py3_9-gcc11-inductor-build.outputs.test-matrix }}
       timeout-minutes: 720
       # disable monitor in perf tests
-      disable-monitor: true
+      disable-monitor: false
       monitor-log-interval: 15
       monitor-data-collect-interval: 4
     secrets: inherit

--- a/.github/workflows/inductor-perf-test-nightly.yml
+++ b/.github/workflows/inductor-perf-test-nightly.yml
@@ -124,7 +124,7 @@ jobs:
       test-matrix: ${{ needs.linux-focal-cuda12_6-py3_10-gcc9-inductor-build.outputs.test-matrix }}
       timeout-minutes: 720
       # disable monitor in perf tests, next step is to enable it
-      disable-monitor: true
+      disable-monitor: false
       monitor-log-interval: 15
       monitor-data-collect-interval: 4
     secrets: inherit
@@ -141,7 +141,7 @@ jobs:
       test-matrix: ${{ needs.linux-focal-cuda12_6-py3_10-gcc9-inductor-build.outputs.test-matrix }}
       timeout-minutes: 1440
       # disable monitor in perf tests, next step is to enable it
-      disable-monitor: true
+      disable-monitor: false
       monitor-log-interval: 15
       monitor-data-collect-interval: 4
     secrets: inherit
@@ -157,8 +157,7 @@ jobs:
       docker-image: ${{ needs.linux-focal-cuda12_6-py3_10-gcc9-inductor-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-focal-cuda12_6-py3_10-gcc9-inductor-build.outputs.test-matrix }}
       timeout-minutes: 720
-      # disable monitor in perf tests, next step is to enable it
-      disable-monitor: true
+      disable-monitor: false
       monitor-log-interval: 15
       monitor-data-collect-interval: 4
     secrets: inherit

--- a/.github/workflows/inductor-perf-test-nightly.yml
+++ b/.github/workflows/inductor-perf-test-nightly.yml
@@ -123,7 +123,6 @@ jobs:
       docker-image: ${{ needs.linux-focal-cuda12_6-py3_10-gcc9-inductor-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-focal-cuda12_6-py3_10-gcc9-inductor-build.outputs.test-matrix }}
       timeout-minutes: 720
-      # disable monitor in perf tests, next step is to enable it
       disable-monitor: false
       monitor-log-interval: 15
       monitor-data-collect-interval: 4

--- a/.github/workflows/inductor-periodic.yml
+++ b/.github/workflows/inductor-periodic.yml
@@ -133,10 +133,6 @@ jobs:
       build-environment: linux-focal-cuda12.6-py3.10-gcc9-sm80
       docker-image: ${{ needs.linux-focal-cuda12_6-py3_10-gcc9-inductor-build-gcp.outputs.docker-image }}
       test-matrix: ${{ needs.linux-focal-cuda12_6-py3_10-gcc9-inductor-build-gcp.outputs.test-matrix }}
-      # disable monitor in perf tests, next step is to enable it
-      disable-monitor: false
-      monitor-log-interval: 15
-      monitor-data-collect-interval: 4
     secrets: inherit
 
   linux-jammy-cpu-py3_9-gcc11-periodic-dynamo-benchmarks-build:

--- a/.github/workflows/inductor-periodic.yml
+++ b/.github/workflows/inductor-periodic.yml
@@ -134,7 +134,7 @@ jobs:
       docker-image: ${{ needs.linux-focal-cuda12_6-py3_10-gcc9-inductor-build-gcp.outputs.docker-image }}
       test-matrix: ${{ needs.linux-focal-cuda12_6-py3_10-gcc9-inductor-build-gcp.outputs.test-matrix }}
       # disable monitor in perf tests, next step is to enable it
-      disable-monitor: true
+      disable-monitor: false
       monitor-log-interval: 15
       monitor-data-collect-interval: 4
     secrets: inherit


### PR DESCRIPTION
Enable monitoring for more perf tests, currently for perf, we collect usage data every 4 seconds and aggregate every 15 seconds.

Can reduce the number down if the monitoring does not affect the perf testx