### PR TITLE
Add TEST_HPU flag to set device type

### DIFF
--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -340,10 +340,7 @@ class DTensorTestBase(MultiProcessTestCase):
     @property
     def device_type(self) -> str:
         # if enough GPU/XPU/HPU we can use those devices, otherwise we fallback to CPU
-        if (
-            not (TEST_CUDA or TEST_XPU or TEST_HPU)
-            or DEVICE_COUNT < self.world_size
-        ):
+        if not (TEST_CUDA or TEST_XPU or TEST_HPU) or DEVICE_COUNT < self.world_size:
             return "cpu"
         else:
             return DEVICE_TYPE

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -58,7 +58,7 @@ else:
 NUM_DEVICES = 4
 
 # We use this as a proxy for "multiple GPUs exist"
-if (TEST_CUDA or TEST_XPU) and DEVICE_COUNT > 1:
+if (TEST_CUDA or TEST_XPU or TEST_HPU) and DEVICE_COUNT > 1:
     # when we actually have multiple GPUs, relax the requirement to smaller counts.
     NUM_DEVICES = min(NUM_DEVICES, DEVICE_COUNT)
 
@@ -339,10 +339,10 @@ class DTensorTestBase(MultiProcessTestCase):
 
     @property
     def device_type(self) -> str:
-        # if enough GPU we can use GPU, otherwise we fallback to CPU
+        # if enough GPU/XPU/HPU we can use those devices, otherwise we fallback to CPU
         if (
-            not (TEST_CUDA or TEST_XPU)
-            or torch.accelerator.device_count() < self.world_size
+            not (TEST_CUDA or TEST_XPU or TEST_HPU)
+            or DEVICE_COUNT < self.world_size
         ):
             return "cpu"
         else:


### PR DESCRIPTION
MOTIVATION
This PR includes a minor change to check for TEST_HPU flag as well before falling back to CPU. Without this flag, some tests were falling back to CPU causing them to fail.
Please refer to this RFC as well: https://github.com/pytorch/rfcs/pull/66

CHANGES
add TEST_HPU flag to some of the conditions checking the environment
use DEVICE_COUNT variable instead of torch.accelerator.device_count() API since the later is not supported on out-of-tree devices like Intel Gaudi.
@ankurneog , @EikanWang , @cyyever , @guangyey


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k