### PR TITLE
Fix vs2022 caused AVX512 illegal instruction issue.

### DIFF
--- a/.ci/pytorch/windows/internal/vc_install_helper.bat
+++ b/.ci/pytorch/windows/internal/vc_install_helper.bat
@@ -3,6 +3,8 @@ if "%VC_YEAR%" == "2022" powershell windows/internal/vs2022_install.ps1
 
 set VC_VERSION_LOWER=17
 set VC_VERSION_UPPER=18
+:: Please don't delete VS2019 as an alternative, in case some Windows compiler issue.
+:: Reference: https://github.com/pytorch/pytorch/issues/145702#issuecomment-2858693930
 if "%VC_YEAR%" == "2019" (
     set VC_VERSION_LOWER=16
     set VC_VERSION_UPPER=17

--- a/.circleci/scripts/binary_windows_build.sh
+++ b/.circleci/scripts/binary_windows_build.sh
@@ -9,7 +9,7 @@ if [[ "$OS" != "windows-arm64" ]]; then
     export USE_SCCACHE=1
     export SCCACHE_BUCKET=ossci-compiler-cache
     export SCCACHE_IGNORE_SERVER_IO_ERROR=1
-    export VC_YEAR=2019
+    export VC_YEAR=2022
 fi
 
 if [[ "$DESIRED_CUDA" == 'xpu' ]]; then

--- a/.circleci/scripts/binary_windows_test.sh
+++ b/.circleci/scripts/binary_windows_test.sh
@@ -4,7 +4,7 @@ set -eux -o pipefail
 source "${BINARY_ENV_FILE:-/c/w/env}"
 
 export CUDA_VERSION="${DESIRED_CUDA/cu/}"
-export VC_YEAR=2019
+export VC_YEAR=2022
 
 if [[ "$DESIRED_CUDA" == 'xpu' ]]; then
     export VC_YEAR=2022

--- a/.github/ISSUE_TEMPLATE/disable-ci-jobs.md
+++ b/.github/ISSUE_TEMPLATE/disable-ci-jobs.md
@@ -5,7 +5,7 @@ title: "DISABLED [WORKFLOW_NAME] / [PLATFORM_NAME] / [JOB_NAME]"
 labels: "module: ci"
 ---
 
-> For example, DISABLED pull / win-vs2019-cpu-py3 / test (default). Once
+> For example, DISABLED pull / win-vs2022-cpu-py3 / test (default). Once
 > created, the job will be disabled within 15 minutes. You can check the
 > list of disabled jobs at https://ossci-metrics.s3.amazonaws.com/disabled-jobs.json
 

--- a/cmake/public/utils.cmake
+++ b/cmake/public/utils.cmake
@@ -364,6 +364,8 @@ function(torch_compile_options libname)
     endif()
 
     if(${MSVC_TOOLSET_VERSION} GREATER_EQUAL 143)
+      # Add /d2implyavx512upperregs- to disable compiler over-aggressive optimization, which caused involeved AVX512 register on AVX2 machine.
+      # Reference: https://github.com/pytorch/pytorch/issues/145702#issuecomment-2874029459
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /d2implyavx512upperregs-" PARENT_SCOPE)
     endif()
 

--- a/cmake/public/utils.cmake
+++ b/cmake/public/utils.cmake
@@ -363,6 +363,10 @@ function(torch_compile_options libname)
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive-" PARENT_SCOPE)
     endif()
 
+    if(${MSVC_TOOLSET_VERSION} GREATER_EQUAL 143)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /d2implyavx512upperregs-" PARENT_SCOPE)
+    endif()
+
     target_compile_options(${libname} PUBLIC
       $<$<COMPILE_LANGUAGE:CXX>:
         ${MSVC_RUNTIME_LIBRARY_OPTION}

--- a/cmake/public/utils.cmake
+++ b/cmake/public/utils.cmake
@@ -362,19 +362,23 @@ function(torch_compile_options libname)
       #    By default, the /permissive- option is set in new projects created by Visual Studio 2017 version 15.5 and later versions.
       #    We set the /permissive- flag from VS 2019 (MSVC_TOOLSET_VERSION 142) to avoid compiling issues for old toolkit.
       # 2. For MSVC VERSION: https://cmake.org/cmake/help/latest/variable/MSVC_TOOLSET_VERSION.html
-      set(MSVC_APPEND_OPTION "${MSVC_APPEND_OPTION} /permissive-")
+      target_compile_options(${libname} PUBLIC $<$<COMPILE_LANGUAGE:CXX>:/permissive->)
+      message("torch_compile_options: ${libname} append /permissive-")
     endif()
 
     if(${MSVC_TOOLSET_VERSION} GREATER_EQUAL 143)
       # Add /d2implyavx512upperregs- to disable compiler over-aggressive optimization, which caused involeved AVX512 register on AVX2 machine.
       # Reference: https://github.com/pytorch/pytorch/issues/145702#issuecomment-2874029459
-      set(MSVC_APPEND_OPTION "${MSVC_APPEND_OPTION} /d2implyavx512upperregs-")
+      target_compile_options(${libname} PUBLIC $<$<COMPILE_LANGUAGE:CXX>:/d2implyavx512upperregs->)
+      message("torch_compile_options: ${libname} append /d2implyavx512upperregs-")
     endif()
+
+    
 
     target_compile_options(${libname} PUBLIC
       $<$<COMPILE_LANGUAGE:CXX>:
         ${MSVC_RUNTIME_LIBRARY_OPTION}
-        $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:${MSVC_DEBINFO_OPTION} ${MSVC_APPEND_OPTION}>
+        $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:${MSVC_DEBINFO_OPTION}>
         /EHsc
         /bigobj>
       )

--- a/cmake/public/utils.cmake
+++ b/cmake/public/utils.cmake
@@ -353,6 +353,8 @@ function(torch_compile_options libname)
       set(MSVC_DEBINFO_OPTION "/Zi")
     endif()
 
+    set(MSVC_APPEND_CXX_FLAG)
+
     if(${MSVC_TOOLSET_VERSION} GREATER_EQUAL 142)
       # Add /permissive- flag for conformance mode to the compiler.
       # This will force more strict check to the code standard.
@@ -360,14 +362,16 @@ function(torch_compile_options libname)
       #    By default, the /permissive- option is set in new projects created by Visual Studio 2017 version 15.5 and later versions.
       #    We set the /permissive- flag from VS 2019 (MSVC_TOOLSET_VERSION 142) to avoid compiling issues for old toolkit.
       # 2. For MSVC VERSION: https://cmake.org/cmake/help/latest/variable/MSVC_TOOLSET_VERSION.html
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive-" PARENT_SCOPE)
+      set(MSVC_APPEND_CXX_FLAG "${MSVC_APPEND_CXX_FLAG} /permissive-")
     endif()
 
     if(${MSVC_TOOLSET_VERSION} GREATER_EQUAL 143)
       # Add /d2implyavx512upperregs- to disable compiler over-aggressive optimization, which caused involeved AVX512 register on AVX2 machine.
       # Reference: https://github.com/pytorch/pytorch/issues/145702#issuecomment-2874029459
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /d2implyavx512upperregs-" PARENT_SCOPE)
+      set(MSVC_APPEND_CXX_FLAG "${MSVC_APPEND_CXX_FLAG} /d2implyavx512upperregs-")
     endif()
+
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${MSVC_APPEND_CXX_FLAG}" PARENT_SCOPE)
 
     target_compile_options(${libname} PUBLIC
       $<$<COMPILE_LANGUAGE:CXX>:

--- a/cmake/public/utils.cmake
+++ b/cmake/public/utils.cmake
@@ -353,7 +353,7 @@ function(torch_compile_options libname)
       set(MSVC_DEBINFO_OPTION "/Zi")
     endif()
 
-    set(MSVC_APPEND_CXX_FLAG)
+    set(MSVC_APPEND_OPTION)
 
     if(${MSVC_TOOLSET_VERSION} GREATER_EQUAL 142)
       # Add /permissive- flag for conformance mode to the compiler.
@@ -362,21 +362,19 @@ function(torch_compile_options libname)
       #    By default, the /permissive- option is set in new projects created by Visual Studio 2017 version 15.5 and later versions.
       #    We set the /permissive- flag from VS 2019 (MSVC_TOOLSET_VERSION 142) to avoid compiling issues for old toolkit.
       # 2. For MSVC VERSION: https://cmake.org/cmake/help/latest/variable/MSVC_TOOLSET_VERSION.html
-      set(MSVC_APPEND_CXX_FLAG "${MSVC_APPEND_CXX_FLAG} /permissive-")
+      set(MSVC_APPEND_OPTION "${MSVC_APPEND_OPTION} /permissive-")
     endif()
 
     if(${MSVC_TOOLSET_VERSION} GREATER_EQUAL 143)
       # Add /d2implyavx512upperregs- to disable compiler over-aggressive optimization, which caused involeved AVX512 register on AVX2 machine.
       # Reference: https://github.com/pytorch/pytorch/issues/145702#issuecomment-2874029459
-      set(MSVC_APPEND_CXX_FLAG "${MSVC_APPEND_CXX_FLAG} /d2implyavx512upperregs-")
+      set(MSVC_APPEND_OPTION "${MSVC_APPEND_OPTION} /d2implyavx512upperregs-")
     endif()
-
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${MSVC_APPEND_CXX_FLAG}" PARENT_SCOPE)
 
     target_compile_options(${libname} PUBLIC
       $<$<COMPILE_LANGUAGE:CXX>:
         ${MSVC_RUNTIME_LIBRARY_OPTION}
-        $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:${MSVC_DEBINFO_OPTION}>
+        $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:${MSVC_DEBINFO_OPTION} ${MSVC_APPEND_OPTION}>
         /EHsc
         /bigobj>
       )

--- a/cmake/public/utils.cmake
+++ b/cmake/public/utils.cmake
@@ -363,17 +363,15 @@ function(torch_compile_options libname)
       #    We set the /permissive- flag from VS 2019 (MSVC_TOOLSET_VERSION 142) to avoid compiling issues for old toolkit.
       # 2. For MSVC VERSION: https://cmake.org/cmake/help/latest/variable/MSVC_TOOLSET_VERSION.html
       target_compile_options(${libname} PUBLIC $<$<COMPILE_LANGUAGE:CXX>:/permissive->)
-      message("torch_compile_options: ${libname} append /permissive-")
     endif()
 
     if(${MSVC_TOOLSET_VERSION} GREATER_EQUAL 143)
       # Add /d2implyavx512upperregs- to disable compiler over-aggressive optimization, which caused involeved AVX512 register on AVX2 machine.
       # Reference: https://github.com/pytorch/pytorch/issues/145702#issuecomment-2874029459
       target_compile_options(${libname} PUBLIC $<$<COMPILE_LANGUAGE:CXX>:/d2implyavx512upperregs->)
-      message("torch_compile_options: ${libname} append /d2implyavx512upperregs-")
     endif()
 
-    
+
 
     target_compile_options(${libname} PUBLIC
       $<$<COMPILE_LANGUAGE:CXX>:


### PR DESCRIPTION
Fixes #145702

Add `/d2implyavx512upperregs-` to disable compiler over-aggressive optimization, which caused involeved AVX512 register on AVX2 machine.

Reference to: https://github.com/pytorch/pytorch/issues/145702#issuecomment-2874029459 

Local test passed:
<img width="1208" alt="image" src="https://github.com/user-attachments/assets/26f4cb91-6bb5-416f-aa35-c899eb1489b2" />


cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168