### PR TITLE
Clean PR: Replace _device_t with torch.types.Device and fix lint issues (#152952)

### DIFF
--- a/torch/accelerator/__init__.py
+++ b/torch/accelerator/__init__.py
@@ -7,8 +7,8 @@ from typing_extensions import deprecated
 
 import torch
 
-from ._utils import _device_t, _get_device_index
-
+from ._utils import _get_device_index
+from torch.types import Device
 
 __all__ = [
     "current_accelerator",
@@ -120,7 +120,7 @@ current_device_idx = deprecated(
 )(current_device_index)
 
 
-def set_device_index(device: _device_t, /) -> None:
+def set_device_index(device: Device, /) -> None:
     r"""Set the current device index to a given device.
 
     Args:
@@ -139,7 +139,7 @@ set_device_idx = deprecated(
 )(set_device_index)
 
 
-def current_stream(device: _device_t = None, /) -> torch.Stream:
+def current_stream(device: Device = None, /) -> torch.Stream:
     r"""Return the currently selected stream for a given device.
 
     Args:
@@ -165,7 +165,7 @@ def set_stream(stream: torch.Stream) -> None:
     torch._C._accelerator_setStream(stream)
 
 
-def synchronize(device: _device_t = None, /) -> None:
+def synchronize(device: Device = None, /) -> None:
     r"""Wait for all kernels in all streams on the given device to complete.
 
     Args:

--- a/torch/accelerator/_utils.py
+++ b/torch/accelerator/_utils.py
@@ -1,10 +1,10 @@
 from typing import Optional
 
 import torch
-from torch.types import Device as _device_t
+from torch.types import Device
 
 
-def _get_device_index(device: _device_t, optional: bool = False) -> int:
+def _get_device_index(device: Device, optional: bool = False) -> int:
     if isinstance(device, int):
         return device
     if isinstance(device, str):

--- a/torch/cpu/__init__.py
+++ b/torch/cpu/__init__.py
@@ -5,9 +5,10 @@ to facilitate writing device-agnostic code.
 """
 
 from contextlib import AbstractContextManager
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 import torch
+from torch.types import Device
 
 from .. import device as _device
 from . import amp
@@ -26,8 +27,6 @@ __all__ = [
     "StreamContext",
     "Event",
 ]
-
-_device_t = Union[_device, str, int, None]
 
 
 def _is_avx2_supported() -> bool:
@@ -75,7 +74,7 @@ def is_available() -> bool:
     return True
 
 
-def synchronize(device: _device_t = None) -> None:
+def synchronize(device: Device = None) -> None:
     r"""Waits for all kernels in all streams on the CPU device to complete.
 
     Args:
@@ -121,7 +120,7 @@ _default_cpu_stream = Stream()
 _current_stream = _default_cpu_stream
 
 
-def current_stream(device: _device_t = None) -> Stream:
+def current_stream(device: Device = None) -> Stream:
     r"""Returns the currently selected :class:`Stream` for a given device.
 
     Args:
@@ -181,7 +180,7 @@ def device_count() -> int:
     return 1
 
 
-def set_device(device: _device_t) -> None:
+def set_device(device: Device) -> None:
     r"""Sets the current device, in CPU we do nothing.
 
     N.B. This function only exists to facilitate device-agnostic code

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -50,7 +50,6 @@ _queued_calls: list[
     tuple[Callable[[], None], list[str]]
 ] = []  # don't invoke these until initialization occurs
 _is_in_bad_fork = getattr(torch._C, "_cuda_isInBadFork", lambda: False)
-_device_t = Union[_device, str, int, None]
 
 _HAS_PYNVML = False
 _PYNVML_ERR = None
@@ -208,7 +207,7 @@ def is_bf16_supported(including_emulation: bool = True):
 
 
 @lru_cache(maxsize=16)
-def _check_bf16_tensor_supported(device: _device_t):
+def _check_bf16_tensor_supported(device: Device):
     try:
         torch.tensor([1.0], dtype=torch.bfloat16, device=device)
         return True
@@ -524,7 +523,7 @@ class device_of(device):
         super().__init__(idx)
 
 
-def set_device(device: _device_t) -> None:
+def set_device(device: Device) -> None:
     r"""Set the current device.
 
     Usage of this function is discouraged in favor of :any:`device`. In most
@@ -539,7 +538,7 @@ def set_device(device: _device_t) -> None:
         torch._C._cuda_setDevice(device)
 
 
-def get_device_name(device: Optional[_device_t] = None) -> str:
+def get_device_name(device: Optional[Device] = None) -> str:
     r"""Get the name of a device.
 
     Args:
@@ -554,7 +553,7 @@ def get_device_name(device: Optional[_device_t] = None) -> str:
     return get_device_properties(device).name
 
 
-def get_device_capability(device: Optional[_device_t] = None) -> tuple[int, int]:
+def get_device_capability(device: Optional[Device] = None) -> tuple[int, int]:
     r"""Get the cuda capability of a device.
 
     Args:
@@ -571,7 +570,7 @@ def get_device_capability(device: Optional[_device_t] = None) -> tuple[int, int]
     return prop.major, prop.minor
 
 
-def get_device_properties(device: Optional[_device_t] = None) -> _CudaDeviceProperties:
+def get_device_properties(device: Optional[Device] = None) -> _CudaDeviceProperties:
     r"""Get the properties of a device.
 
     Args:
@@ -590,7 +589,7 @@ def get_device_properties(device: Optional[_device_t] = None) -> _CudaDeviceProp
     return _get_device_properties(device)  # type: ignore[name-defined]
 
 
-def can_device_access_peer(device: _device_t, peer_device: _device_t) -> bool:
+def can_device_access_peer(device: Device, peer_device: Device) -> bool:
     r"""Check if peer access between two devices is possible."""
     _lazy_init()
     device = _get_device_index(device, optional=True)
@@ -1042,7 +1041,7 @@ def current_device() -> int:
     return torch._C._cuda_getDevice()
 
 
-def synchronize(device: Optional[_device_t] = None) -> None:
+def synchronize(device: Optional[Device] = None) -> None:
     r"""Wait for all kernels in all streams on a CUDA device to complete.
 
     Args:
@@ -1068,7 +1067,7 @@ def ipc_collect():
     return torch._C._cuda_ipc_collect()
 
 
-def current_stream(device: Optional[_device_t] = None) -> Stream:
+def current_stream(device: Optional[Device] = None) -> Stream:
     r"""Return the currently selected :class:`Stream` for a given device.
 
     Args:
@@ -1086,7 +1085,7 @@ def current_stream(device: Optional[_device_t] = None) -> Stream:
     )
 
 
-def default_stream(device: Optional[_device_t] = None) -> Stream:
+def default_stream(device: Optional[Device] = None) -> Stream:
     r"""Return the default :class:`Stream` for a given device.
 
     Args:
@@ -1105,7 +1104,7 @@ def default_stream(device: Optional[_device_t] = None) -> Stream:
 
 
 def get_stream_from_external(
-    data_ptr: int, device: Optional[_device_t] = None
+    data_ptr: int, device: Optional[Device] = None
 ) -> Stream:
     r"""Return a :class:`Stream` from an externally allocated CUDA stream.
 

--- a/torch/mtia/memory.py
+++ b/torch/mtia/memory.py
@@ -6,11 +6,12 @@ from typing import Any, Optional
 
 import torch
 
-from . import _device_t, is_initialized
+from torch.types import Device
+from . import is_initialized
 from ._utils import _get_device_index
 
 
-def memory_stats(device: Optional[_device_t] = None) -> dict[str, Any]:
+def memory_stats(device: Optional[Device] = None) -> dict[str, Any]:
     r"""Return a dictionary of MTIA memory allocator statistics for a given device.
 
     Args:
@@ -23,7 +24,7 @@ def memory_stats(device: Optional[_device_t] = None) -> dict[str, Any]:
     return torch._C._mtia_memoryStats(_get_device_index(device, optional=True))
 
 
-def max_memory_allocated(device: Optional[_device_t] = None) -> int:
+def max_memory_allocated(device: Optional[Device] = None) -> int:
     r"""Return the maximum memory allocated in bytes for a given device.
 
     Args:
@@ -36,7 +37,7 @@ def max_memory_allocated(device: Optional[_device_t] = None) -> int:
     return memory_stats(device).get("dram", 0).get("peak_bytes", 0)
 
 
-def reset_peak_memory_stats(device: Optional[_device_t] = None) -> None:
+def reset_peak_memory_stats(device: Optional[Device] = None) -> None:
     r"""Reset the peak memory stats for a given device.
 
 

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -15,6 +15,7 @@ import torch
 import torch._C
 from torch import device as _device
 from torch._utils import _dummy_type, _LazySeedTracker
+from torch.types import Device
 
 from ._utils import _get_device_index
 from .streams import Event, Stream
@@ -27,7 +28,6 @@ _queued_calls: list[
     tuple[Callable[[], None], list[str]]
 ] = []  # don't invoke these until initialization occurs
 _is_in_bad_fork = getattr(torch._C, "_xpu_isInBadFork", lambda: False)
-_device_t = Union[_device, str, int, None]
 _lazy_seed_tracker = _LazySeedTracker()
 default_generators: tuple[torch._C.Generator] = ()  # type: ignore[assignment]
 
@@ -192,7 +192,7 @@ class device_of(device):
         super().__init__(idx)
 
 
-def set_device(device: _device_t) -> None:
+def set_device(device: Device) -> None:
     r"""Set the current device.
 
     Args:
@@ -205,7 +205,7 @@ def set_device(device: _device_t) -> None:
         torch._C._xpu_setDevice(device)
 
 
-def get_device_name(device: Optional[_device_t] = None) -> str:
+def get_device_name(device: Optional[Device] = None) -> str:
     r"""Get the name of a device.
 
     Args:
@@ -221,7 +221,7 @@ def get_device_name(device: Optional[_device_t] = None) -> str:
 
 
 @lru_cache(None)
-def get_device_capability(device: Optional[_device_t] = None) -> dict[str, Any]:
+def get_device_capability(device: Optional[Device] = None) -> dict[str, Any]:
     r"""Get the xpu capability of a device.
 
     Args:
@@ -247,7 +247,7 @@ def get_device_capability(device: Optional[_device_t] = None) -> dict[str, Any]:
     }
 
 
-def get_device_properties(device: Optional[_device_t] = None) -> _XpuDeviceProperties:
+def get_device_properties(device: Optional[Device] = None) -> _XpuDeviceProperties:
     r"""Get the properties of a device.
 
     Args:
@@ -365,7 +365,7 @@ def set_stream(stream: Stream):
     )
 
 
-def current_stream(device: Optional[_device_t] = None) -> Stream:
+def current_stream(device: Optional[Device] = None) -> Stream:
     r"""Return the currently selected :class:`Stream` for a given device.
 
     Args:
@@ -384,7 +384,7 @@ def current_stream(device: Optional[_device_t] = None) -> Stream:
 
 
 def get_stream_from_external(
-    data_ptr: int, device: Optional[_device_t] = None
+    data_ptr: int, device: Optional[Device] = None
 ) -> Stream:
     r"""Return a :class:`Stream` from an external SYCL queue.
 
@@ -410,7 +410,7 @@ def get_stream_from_external(
     )
 
 
-def synchronize(device: _device_t = None) -> None:
+def synchronize(device: Device = None) -> None:
     r"""Wait for all kernels in all streams on a XPU device to complete.
 
     Args:

--- a/torch/xpu/memory.py
+++ b/torch/xpu/memory.py
@@ -1,13 +1,10 @@
 import collections
-from typing import Any, Union
+from typing import Any
 
 import torch
 from torch.types import Device
 
 from . import _get_device_index, is_initialized
-
-
-_device_t = Union[Device, str, int, None]
 
 
 def empty_cache() -> None:
@@ -23,7 +20,7 @@ def empty_cache() -> None:
         torch._C._xpu_emptyCache()
 
 
-def reset_peak_memory_stats(device: _device_t = None) -> None:
+def reset_peak_memory_stats(device: Device = None) -> None:
     r"""Reset the "peak" stats tracked by the XPU memory allocator.
 
     See :func:`~torch.xpu.memory_stats` for details. Peak stats correspond to the
@@ -38,7 +35,7 @@ def reset_peak_memory_stats(device: _device_t = None) -> None:
     return torch._C._xpu_resetPeakMemoryStats(device)
 
 
-def reset_accumulated_memory_stats(device: _device_t = None) -> None:
+def reset_accumulated_memory_stats(device: Device = None) -> None:
     r"""Reset the "accumulated" (historical) stats tracked by the XPU memory allocator.
 
     See :func:`~torch.xpu.memory_stats` for details. Accumulated stats correspond to
@@ -53,7 +50,7 @@ def reset_accumulated_memory_stats(device: _device_t = None) -> None:
     return torch._C._xpu_resetAccumulatedMemoryStats(device)
 
 
-def memory_stats_as_nested_dict(device: _device_t = None) -> dict[str, Any]:
+def memory_stats_as_nested_dict(device: Device = None) -> dict[str, Any]:
     r"""Return the result of :func:`~torch.xpu.memory_stats` as a nested dictionary."""
     if not is_initialized():
         return {}
@@ -61,7 +58,7 @@ def memory_stats_as_nested_dict(device: _device_t = None) -> dict[str, Any]:
     return torch._C._xpu_memoryStats(device)
 
 
-def memory_stats(device: _device_t = None) -> dict[str, Any]:
+def memory_stats(device: Device = None) -> dict[str, Any]:
     r"""Return a dictionary of XPU memory allocator statistics for a given device.
 
     The return value of this function is a dictionary of statistics, each of
@@ -117,7 +114,7 @@ def memory_stats(device: _device_t = None) -> dict[str, Any]:
     return collections.OrderedDict(result)
 
 
-def memory_allocated(device: _device_t = None) -> int:
+def memory_allocated(device: Device = None) -> int:
     r"""Return the current GPU memory occupied by tensors in bytes for a given device.
 
     Args:
@@ -133,7 +130,7 @@ def memory_allocated(device: _device_t = None) -> int:
     return memory_stats(device=device).get("allocated_bytes.all.current", 0)
 
 
-def max_memory_allocated(device: _device_t = None) -> int:
+def max_memory_allocated(device: Device = None) -> int:
     r"""Return the maximum GPU memory occupied by tensors in bytes for a given device.
 
     By default, this returns the peak allocated memory since the beginning of
@@ -150,7 +147,7 @@ def max_memory_allocated(device: _device_t = None) -> int:
     return memory_stats(device=device).get("allocated_bytes.all.peak", 0)
 
 
-def memory_reserved(device: _device_t = None) -> int:
+def memory_reserved(device: Device = None) -> int:
     r"""Return the current GPU memory managed by the caching allocator in bytes for a given device.
 
     Args:
@@ -161,7 +158,7 @@ def memory_reserved(device: _device_t = None) -> int:
     return memory_stats(device=device).get("reserved_bytes.all.current", 0)
 
 
-def max_memory_reserved(device: _device_t = None) -> int:
+def max_memory_reserved(device: Device = None) -> int:
     r"""Return the maximum GPU memory managed by the caching allocator in bytes for a given device.
 
     By default, this returns the peak cached memory since the beginning of this
@@ -178,7 +175,7 @@ def max_memory_reserved(device: _device_t = None) -> int:
     return memory_stats(device=device).get("reserved_bytes.all.peak", 0)
 
 
-def mem_get_info(device: _device_t = None) -> tuple[int, int]:
+def mem_get_info(device: Device = None) -> tuple[int, int]:
     r"""Return the global free and total GPU memory for a given device.
 
     Args:


### PR DESCRIPTION
Fixes #152952

This PR removes redundant type aliases for `_device_t` and replaces them with `torch.types.Device` in several PyTorch modules where applicable. This improves type clarity and consistency across the codebase and aligns with recent efforts to modernize type annotations.


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @EikanWang @voznesenskym @penguinwu @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @Lucaskabela