### PR TITLE
[aoti] return a specific error code for sticky cuda errors

### DIFF
--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -95,6 +95,7 @@ using AOTIProxyExecutorHandle = AOTIProxyExecutorOpaque*;
 using AOTITorchError = int32_t;
 #define AOTI_TORCH_SUCCESS 0
 #define AOTI_TORCH_FAILURE 1
+#define AOTI_TORCH_CUDA_STICKY_ERROR 2
 
 // Getter functions for retrieving various constants from the runtime, that
 // can subsequently be passed to other aoti_* functions.  By hiding these


### PR DESCRIPTION
Summary:
More contexts in https://fb.workplace.com/groups/gpuinference/permalink/3133450583470255/.

Basically we want to correctly handle AOTI errors in bad request recorder.

Test Plan: replayer test and observe the correct error message

Differential Revision: D73954362


