### PR TITLE
Add `flag _metrics_log_runtime` to disable runtime metric logging by default

### DIFF
--- a/benchmarks/dynamo/microbenchmarks/bench_mm_fusion.py
+++ b/benchmarks/dynamo/microbenchmarks/bench_mm_fusion.py
@@ -89,6 +89,7 @@ def bench(shape, layer_id, p, fusion_types=None):
         row.extend([tflops(torch_mm_ms), tflops(triton_mm_ms)])
 
     p.add_row(row)
+    torch._logging.set_logs()
 
 
 fusion_types = ["", "add", "relu", "add_relu"]

--- a/benchmarks/dynamo/microbenchmarks/bench_mm_fusion.py
+++ b/benchmarks/dynamo/microbenchmarks/bench_mm_fusion.py
@@ -45,6 +45,7 @@ class Func:
 
 
 def bench(shape, layer_id, p, fusion_types=None):
+    torch._logging.set_logs(inductor_metrics=True)
     if fusion_types is None:
         fusion_types = [""]
     dtype = torch.float16

--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -925,6 +925,7 @@ exclusions = {
     "aot_graphs_effects",
     "pre_grad_graphs",
     "post_grad_graphs",
+    "inductor_metrics",
     "ir_pre_fusion",
     "ir_post_fusion",
     "compiled_autograd",

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -3083,6 +3083,7 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
         "inductor backend is not available",
     )
     def test_save_and_load_inductor(self):
+        torch._logging.set_logs(inductor_metrics=True)
         mod = MockModule()
         opt_mod = torch.compile(mod, backend="inductor")
         inp = torch.randn(10, 10)
@@ -3104,6 +3105,7 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
         self.assertGreater(torch._inductor.metrics.generated_kernel_count, 0)
 
     def test_save_and_load_all_backends(self):
+        torch._logging.set_logs(inductor_metrics=True)
         mod = MockModule()
         inp = torch.randn(10, 10)
         for backend in torch._dynamo.list_backends():

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -3103,6 +3103,7 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
         torch._inductor.metrics.generated_kernel_count = 0
         loaded_model(inp)
         self.assertGreater(torch._inductor.metrics.generated_kernel_count, 0)
+        torch._logging.set_logs()
 
     def test_save_and_load_all_backends(self):
         torch._logging.set_logs(inductor_metrics=True)
@@ -3128,6 +3129,8 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
                 self.assertEqual(opt_success, loaded_success)
             except torch._dynamo.exc.BackendCompilerFailed:
                 pass
+
+    torch._logging.set_logs()
 
     def test_monkeypatching_forward(self):
         class FakeModule(torch.nn.Module):

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -1179,6 +1179,7 @@ class TestFxGraphCache(TestCase):
         self.assertEqual(fn(a, b), compiled_fn(a, b))
         self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
         self.assertEqual(metrics.generated_kernel_count, 2)
+        torch._logging.set_logs()
 
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -1156,7 +1156,7 @@ class TestFxGraphCache(TestCase):
         """
         Test that we bump the generated_kernel_count metric on a cache hit.
         """
-
+        torch._logging.set_logs(inductor_metrics=True)
         def fn(x, y):
             return (x * y + y,)
 

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -1157,6 +1157,7 @@ class TestFxGraphCache(TestCase):
         Test that we bump the generated_kernel_count metric on a cache hit.
         """
         torch._logging.set_logs(inductor_metrics=True)
+
         def fn(x, y):
             return (x * y + y,)
 

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -2259,6 +2259,9 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
     @supported_platform
     @skip_on_cpu
     def test_epilogue_fused(self, device):
+        # set so that metrics appear
+        torch._logging.set_logs(inductor_metrics=True)
+
         @torch.compile
         def f(q, k, v):
             out = flex_attention(q, k, v)

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -2280,6 +2280,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         # We need this fudge factor for now as we write the extraneous logsumexp
         num_accesses += 1
         self.assertLess(metrics.num_bytes_accessed, accessed_bytes * num_accesses)
+        torch._logging.set_logs()
 
     @supported_platform
     @dtypes(*device_configs["cpu"].dtypes)

--- a/test/inductor/test_inductor_scheduler.py
+++ b/test/inductor/test_inductor_scheduler.py
@@ -44,7 +44,7 @@ def cT(device, dtype):
 inductor_metrics_log = torch._logging.getArtifactLogger(__name__, "inductor_metrics")
 
 
-def test_cases(device, dtype):
+def _test_cases(device, dtype):
     T = cT(device, dtype)
 
     def composite(x, y, z):
@@ -69,7 +69,7 @@ class TestScheduler(TestCase):
     def test_disable_get_estimated_runtime_logging(self, device, dtype):
         if device == "cpu":
             return
-        tc = test_cases(device, dtype)
+        tc = _test_cases(device, dtype)
         # turn off logging of inductor metrics so that they don't get logged
         torch._logging.set_logs(inductor_metrics=False)
         metrics.reset()
@@ -87,7 +87,7 @@ class TestScheduler(TestCase):
     def test_get_estimated_runtime_logging(self, device, dtype):
         if device == "cpu":
             return
-        tc = test_cases(device, dtype)        
+        tc = _test_cases(device, dtype)        
         expected_metrics = [
             # num_bytes_accessed, number of nonzero node_runtimes
             (74 * dtype.itemsize, 1),
@@ -144,7 +144,7 @@ class TestScheduler(TestCase):
         ):
             return
 
-        tc = test_cases(device, dtype)
+        tc = _test_cases(device, dtype)
 
         torch._logging.set_logs(inductor_metrics=True)
         for op, example_inputs, kwargs in tc:

--- a/test/inductor/test_inductor_scheduler.py
+++ b/test/inductor/test_inductor_scheduler.py
@@ -67,6 +67,8 @@ def test_cases(device, dtype):
 class TestScheduler(TestCase):
     @dtypes(torch.float, torch.float16)
     def test_disable_get_estimated_runtime_logging(self, device, dtype):
+        if device == "cpu":
+            return
         tc = test_cases(device, dtype)
         # turn off logging of inductor metrics so that they don't get logged
         torch._logging.set_logs(inductor_metrics=False)
@@ -83,6 +85,8 @@ class TestScheduler(TestCase):
 
     @dtypes(torch.float, torch.float16)
     def test_get_estimated_runtime_logging(self, device, dtype):
+        if device == "cpu":
+            return
         tc = test_cases(device, dtype)        
         expected_metrics = [
             # num_bytes_accessed, number of nonzero node_runtimes

--- a/test/inductor/test_inductor_scheduler.py
+++ b/test/inductor/test_inductor_scheduler.py
@@ -87,7 +87,7 @@ class TestScheduler(TestCase):
     def test_get_estimated_runtime_logging(self, device, dtype):
         if device == "cpu":
             return
-        tc = _test_cases(device, dtype)        
+        tc = _test_cases(device, dtype)
         expected_metrics = [
             # num_bytes_accessed, number of nonzero node_runtimes
             (74 * dtype.itemsize, 1),
@@ -131,7 +131,6 @@ class TestScheduler(TestCase):
             },
         ],
     )
-
     def test_flop_counter_op(self, device, dtype, options):
         if device == "cpu":
             return

--- a/test/inductor/test_inductor_scheduler.py
+++ b/test/inductor/test_inductor_scheduler.py
@@ -66,6 +66,7 @@ def _test_cases(device, dtype):
 
 class TestScheduler(TestCase):
     @dtypes(torch.float, torch.float16)
+    @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
     def test_disable_get_estimated_runtime_logging(self, device, dtype):
         if device == "cpu":
             return
@@ -84,6 +85,7 @@ class TestScheduler(TestCase):
             metrics.reset()
 
     @dtypes(torch.float, torch.float16)
+    @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
     def test_get_estimated_runtime_logging(self, device, dtype):
         if device == "cpu":
             return

--- a/test/inductor/test_loop_ordering.py
+++ b/test/inductor/test_loop_ordering.py
@@ -25,6 +25,8 @@ from torch.utils._pytree import tree_map
 from torch.utils._sympy.functions import ModularIndexing
 
 
+# set so that metrics appear
+torch._logging.set_logs(inductor_metrics=True)
 DO_PERF_TEST = os.environ.get("DO_PERF_TEST") == "1"
 
 

--- a/test/inductor/test_perf.py
+++ b/test/inductor/test_perf.py
@@ -31,6 +31,9 @@ from torch._inductor.utils import run_and_get_code
 from torch.testing._internal.triton_utils import HAS_CUDA, requires_cuda
 
 
+# set so that metrics appear
+torch._logging.set_logs(inductor_metrics=True)
+
 if HAS_CUDA:
     import triton  # @manual
     import triton.language as tl  # @manual

--- a/test/inductor/test_scatter_optimization.py
+++ b/test/inductor/test_scatter_optimization.py
@@ -13,6 +13,9 @@ from torch._inductor.test_case import TestCase
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
 
+# set so that metrics appear
+torch._logging.set_logs(inductor_metrics=True)
+
 DO_PERF_TEST = os.environ.get("DO_PERF_TEST") == "1"
 
 

--- a/test/inductor/test_snode_runtime.py
+++ b/test/inductor/test_snode_runtime.py
@@ -40,6 +40,7 @@ def calculate_runtime(f, *args) -> float:
     for pair in metrics.node_runtimes:
         ret += pair[1]
 
+    torch._logging.set_logs()
     return ret
 
 

--- a/test/inductor/test_snode_runtime.py
+++ b/test/inductor/test_snode_runtime.py
@@ -32,6 +32,7 @@ def calculate_runtime(f, *args) -> float:
     Assumes all inputs are fp32
     """
     metrics.reset()
+    torch._logging.set_logs(inductor_metrics=True)
     torch.compile(f, backend=compile_but_use_eager)(*args)
     print(metrics.node_runtimes)
 

--- a/test/inductor/test_snode_runtime.py
+++ b/test/inductor/test_snode_runtime.py
@@ -237,6 +237,7 @@ class TestCommAnalysis(TestCase):
         )
         try:
             metrics.reset()
+            torch._logging.set_logs(inductor_metrics=True)
             torch.compile(fn)(*inps)
             found_collective = False
             for snode, runtime in metrics.node_runtimes:
@@ -253,6 +254,7 @@ class TestCommAnalysis(TestCase):
                 self.assertNotZero(runtime)
             # Make sure a collective kernel is found in graph
             self.assertTrue(found_collective)
+            torch._logging.set_logs()
         finally:
             dist.destroy_process_group()
 

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1062,6 +1062,9 @@ class _InProcessFxCompile(FxCompile):
         inputs_to_check: Sequence[int],
         graph_kwargs: _CompileFxKwargs,
     ) -> OutputCode:
+        """
+        Generates the OutputCode from the GraphModule and example_inputs.
+        """
         # Sorry about the mess, we need graph_kwargs to continue to be able
         # to propagate it further on
         # TODO: _CompileFxKwargs actually has stronger types than in the

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1399,10 +1399,11 @@ class _InProcessFxCompile(FxCompile):
                                 compiled_module, "runner", None
                             )
 
-                    num_bytes, nodes_num_elem, node_runtimes = graph.count_bytes()
-                    metrics.num_bytes_accessed += num_bytes
-                    metrics.node_runtimes += node_runtimes
-                    metrics.nodes_num_elem += nodes_num_elem
+                    if config._metrics_log_runtime:
+                        num_bytes, nodes_num_elem, node_runtimes = graph.count_bytes()
+                        metrics.num_bytes_accessed += num_bytes
+                        metrics.node_runtimes += node_runtimes
+                        metrics.nodes_num_elem += nodes_num_elem
 
                     if (
                         cudagraphs

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -201,6 +201,7 @@ post_grad_graphs_log = torch._logging.getArtifactLogger(__name__, "post_grad_gra
 static_inputs_log = torch._logging.getArtifactLogger(
     __name__, "cudagraph_static_inputs"
 )
+inductor_metrics_log = torch._logging.getArtifactLogger(__name__, "inductor_metrics")
 
 
 def get_static_input_idxs(num_fixed: int) -> list[int]:
@@ -1399,11 +1400,20 @@ class _InProcessFxCompile(FxCompile):
                                 compiled_module, "runner", None
                             )
 
-                    if config._metrics_log_runtime:
+                    breakpoint()
+                    if inductor_metrics_log.isEnabledFor(logging.INFO):
                         num_bytes, nodes_num_elem, node_runtimes = graph.count_bytes()
                         metrics.num_bytes_accessed += num_bytes
                         metrics.node_runtimes += node_runtimes
                         metrics.nodes_num_elem += nodes_num_elem
+                        inductor_metrics_log.info(
+                            "Graph Metrics:\n%s",
+                            {
+                                "num_bytes_accessed": num_bytes,
+                                "nodes_num_elem": nodes_num_elem,
+                                "node_runtimes": node_runtimes,
+                            },
+                        )
 
                     if (
                         cudagraphs

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1400,7 +1400,6 @@ class _InProcessFxCompile(FxCompile):
                                 compiled_module, "runner", None
                             )
 
-                    breakpoint()
                     if inductor_metrics_log.isEnabledFor(logging.INFO):
                         num_bytes, nodes_num_elem, node_runtimes = graph.count_bytes()
                         metrics.num_bytes_accessed += num_bytes

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -547,6 +547,10 @@ loop_ordering_after_fusion: bool = (
     os.environ.get("TORCHINDUCTOR_LOOP_ORDERING_AFTER_FUSION", "0") == "1"
 )
 
+# Logging the runtime is a bit expensive in compile time, so put it behind a flag for now
+# TODO Long term, I think we should move these to tlparse.
+_metrics_log_runtime = False
+
 # If fusing two nodes only save less then score_fusion_memory_threshold memory,
 # we should not bother fusing the nodes.
 #

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -547,10 +547,6 @@ loop_ordering_after_fusion: bool = (
     os.environ.get("TORCHINDUCTOR_LOOP_ORDERING_AFTER_FUSION", "0") == "1"
 )
 
-# Logging the runtime is a bit expensive in compile time, so put it behind a flag for now
-# TODO Long term, I think we should move these to tlparse.
-_metrics_log_runtime = False
-
 # If fusing two nodes only save less then score_fusion_memory_threshold memory,
 # we should not bother fusing the nodes.
 #

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -246,6 +246,7 @@ def set_logs(
     benchmarking: bool = False,
     autotuning: bool = False,
     graph_region_expansion: bool = False,
+    inductor_metrics: bool = False,
 ):
     """
     Sets the log level for individual components and toggles individual log
@@ -437,6 +438,8 @@ def set_logs(
         graph_region_expansion (:class:`bool`):
             Whether to emit the detailed steps of the duplicate graph region tracker expansion algorithm. Default: ``False``
 
+        inductor_metrics (:class:`bool`):
+            Whether to estimate the runtimes of the nodes in a graph and log them to the metrics table. Default: ``False``
 
     Example::
 
@@ -548,6 +551,7 @@ def set_logs(
         benchmarking=benchmarking,
         autotuning=autotuning,
         graph_region_expansion=graph_region_expansion,
+        inductor_metrics=inductor_metrics,
     )
 
 

--- a/torch/_logging/_registrations.py
+++ b/torch/_logging/_registrations.py
@@ -218,4 +218,10 @@ register_artifact(
     off_by_default=True,
 )
 
+register_artifact(
+    "inductor_metrics",
+    "Logs Inductor metrics, such as num_bytes, nodes_num_elem, node_runtimes",
+    off_by_default=True,
+)
+
 register_artifact("custom_format_test_artifact", "Testing only", log_format="")


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/152708 expanded support of `get_estimated_runtime` to many more types of `SchedulerNodes`. This caused an increase in compile time because we're always calling `get_estimated_runtime` to populate the metrics table. This PR adds a flag for this logging, which reduces the instruction count by 8%. Long term, we should probably merge metrics.py with TORCH_LOGS/tlparse (suggestion from @xmfan).

Update: added support for TORCH_LOGS for the metrics logging.

Test Plan:
mm_loop.py and many existing tests cover.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov