### PR TITLE
Removed duplicate patterns from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,15 +212,6 @@ docs/source/scripts/lr_scheduler_images/
 # Compiled MATLAB
 *.mex*
 
-# IPython notebook checkpoints
-.ipynb_checkpoints
-
-# Editor temporaries
-*.swn
-*.swo
-*.swp
-*~
-
 # NFS handle files
 **/.nfs*
 


### PR DESCRIPTION
Removed duplicate patterns from gitignore. These patterns are duplicated verbatim on lines 148-169.
