### PR TITLE
[DRAFT] avoidance strategy for reshape_view_helper guards in compile: call _view_simple if inputs has dynamic dimensions.

### DIFF
--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -3793,7 +3793,7 @@ def _compute_stride(old_shape, old_stride, new_shape):
 
 # if a is contiguous, we can always reshape with as_strided and contiguous_strides.
 # if a is not contiguous and _compute_stride succeed we also use as_strided without clone.
-def _view_simple(a: TensorLikeType, shape, data_dependent_error) -> TensorLikeType:
+def _view_simple(a: TensorLikeType, shape) -> TensorLikeType:
     from torch.fx.experimental.symbolic_shapes import statically_known_true, sym_eq
 
     # Creates a valid shape
@@ -3822,20 +3822,13 @@ def _view_simple(a: TensorLikeType, shape, data_dependent_error) -> TensorLikeTy
     if a.is_contiguous():
         return a.as_strided(shape, utils.make_contiguous_strides_for(shape))
 
-    raise data_dependent_error
+    msg = f"Cannot view a tensor with shape {a.shape} and strides {a.stride()} as a tensor with shape {shape}!"
+    raise ValueError(msg)
 
 
 def _reshape_view_helper_core_alg(
     a: TensorLikeType, shape, allow_copy: bool
 ) -> TensorLikeType:
-    from torch.fx.experimental.symbolic_shapes import (
-        guard_or_false,
-        guard_or_true,
-        GuardOnDataDependentSymNode,
-    )
-
-    deferred: list[Callable[[], bool]] = []
-
     # NOTE [Reshape Algorithm]
     # This algorithm works by attempting to greedily construct the desired dimensions in
     # the output shape, left to right. It does this by, conceptually, accumulating
@@ -3867,34 +3860,13 @@ def _reshape_view_helper_core_alg(
             continue
 
         # Skips dimensions that are already the correct length
-        if guard_or_false(length == a_.shape[idx]):
+        if length == a_.shape[idx]:
             idx = idx + 1
             continue
 
-        # Gathers enough original dimensions such that this new dimension can be created
-        # Note that this accumulation will terminate because we've verified a and the shape
-        # specify the same number of elements above
-        def maybe_throw_dde():
-            # NOTE: if you've hit a data-dependent error here, it's because in trying to accumulate input
-            # tensor dimensions to match the target shape (length), we've hit data-dependent errors testing
-            # divisibility (accum % length != 0), and have deferred raising them, in the hope that we'd
-            # figure out a valid reshape later in the loop.
-            # But we failed, either by running out of dimensions, or we couldn't figure out the strides,
-            # and we've decided to re-raise to either graph break out, or provide the exact guard so the user
-            # can torch._check() to avoid this.
-            for f in deferred:
-                f()
-
         accum = a_.shape[idx]
         end = idx
-        while True:
-            try:
-                if accum % length == 0:
-                    break
-            except GuardOnDataDependentSymNode:
-                deferred.append(lambda: bool(accum % length == 0))
-            if end == a_.ndim - 1:
-                maybe_throw_dde()
+        while accum % length != 0:
             end += 1
             accum *= a_.shape[end]
         if end != idx:
@@ -3908,7 +3880,6 @@ def _reshape_view_helper_core_alg(
                 if allow_copy:
                     return prims.reshape(a, shape)
 
-                maybe_throw_dde()
                 msg = f"Cannot view a tensor with shape {a.shape} and strides {a.stride()} as a tensor with shape {shape}!"
                 raise ValueError(msg)
 
@@ -3916,7 +3887,7 @@ def _reshape_view_helper_core_alg(
 
         # Splits the (possibly flattened) dimension to create the desired dim length.
         # guard_or_true is safe due to the tail unsqueeze routine.
-        if guard_or_true(accum != length):
+        if accum != length:
             a_ = prims.split_dim(a_, idx, length)
 
         idx = idx + 1
@@ -3936,10 +3907,7 @@ def _reshape_view_helper_core_alg(
 
 
 def _reshape_view_helper(a: TensorLikeType, *shape, allow_copy: bool) -> TensorLikeType:
-    from torch.fx.experimental.symbolic_shapes import (
-        guard_or_false,
-        GuardOnDataDependentSymNode,
-    )
+    from torch.fx.experimental.symbolic_shapes import guard_or_false
 
     # Creates a valid shape
     shape = utils.extract_shape_from_varargs(shape, validate=False)
@@ -3988,18 +3956,20 @@ def _reshape_view_helper(a: TensorLikeType, *shape, allow_copy: bool) -> TensorL
         a.numel() == shape_numel,
         f"Could not reshape a tensor with shape {a.shape} as a tensor with shape {shape}!",
     )
-    try:
-        # Handles general case: a 1+D tensor reshaped into a distinct 1+D shape
-        return _reshape_view_helper_core_alg(a, shape, allow_copy)
-    except GuardOnDataDependentSymNode as e:
-        # dynamic shapes do not show up in eager. For compile this function is on
-        if not allow_copy:
-            return _view_simple(a, shape, e)
-        else:
-            # this should not be reachable since reshape_symint, will do the clone and compose to view
-            # before calling this for compile stack. and GuardOnDataDependentSymNode should now show up
-            # for eager.
-            raise
+    # For compile we only calling this function for
+    has_dynamic = False
+    for s in itertools.chain(a.size(), a.stride(), shape):
+        if isinstance(s, torch.SymInt):
+            has_dynamic = True
+            break
+
+    if has_dynamic:
+        # This does not happen in eager but only in compile. (we dont have symints in eager).
+        # In compile we only use this function to for fake tensor tracing, but not for proxy tracing.
+        # Hence there is no value for tracing _reshape_view_helper_core_alg, and adding guards or hitting
+        # data dependent errors. We avoid those by calling the simpler version.
+        return _view_simple(a, shape)
+    return _reshape_view_helper_core_alg(a, shape, allow_copy)
 
 
 # CompositeImplicitAutograd - don't register decomp

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -3958,12 +3958,13 @@ def _reshape_view_helper(a: TensorLikeType, *shape, allow_copy: bool) -> TensorL
     )
     # For compile we only calling this function for
     has_dynamic = False
-    for s in itertools.chain(a.size(), a.stride(), shape):
-        if isinstance(s, torch.SymInt):
-            has_dynamic = True
-            break
+    if not allow_copy : 
+        for s in itertools.chain(a.size(), a.stride(), shape):
+            if isinstance(s, torch.SymInt):
+                has_dynamic = True
+                break
 
-    if has_dynamic:
+    if has_dynamic and not allow_copy:
         # This does not happen in eager but only in compile. (we dont have symints in eager).
         # In compile we only use this function to for fake tensor tracing, but not for proxy tracing.
         # Hence there is no value for tracing _reshape_view_helper_core_alg, and adding guards or hitting


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #153521
* #153441
* #153432
* #153198
* #152657

