### PR TITLE
[Ez][BE]: Remove accidental classvar

### DIFF
--- a/torch/distributed/_shard/sharding_spec/chunk_sharding_spec.py
+++ b/torch/distributed/_shard/sharding_spec/chunk_sharding_spec.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 from dataclasses import dataclass
 from typing import cast, Optional, TYPE_CHECKING, Union
+from typing_extensions import TypeAlias
 
 import torch
 import torch.distributed as dist
@@ -21,6 +22,8 @@ if TYPE_CHECKING:
     # Only include ShardedTensor when do type checking, exclude it
     # from run-time to resolve circular dependency.
     from torch.distributed._shard.sharded_tensor import ShardedTensor
+
+_ShardingDim: TypeAlias = Union[int, str]
 
 
 @dataclass
@@ -50,9 +53,7 @@ class ChunkShardingSpec(ShardingSpec):
             :class:`torch.distributed._remote_device`
     """
 
-    ShardingDim = Union[int, str]
-
-    dim: ShardingDim
+    dim: _ShardingDim
     placements: list[Union[torch.distributed._remote_device, str]]
 
     def __post_init__(self):


### PR DESCRIPTION
Untyped variables become ClassVar in dataclasses, this type alias should just be a type alias; no need for it to eb a classvar.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta