### PR TITLE
[BE][Ez]: RUF200 - validate pyproject.toml metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,7 @@ select = [
     "RUF024", # from keys mutable
     "RUF026", # default factory kwarg
     "RUF030", # No print statement in assert
+    "RUF200", # validate pyproject.toml
     "S324", # for hashlib FIPS compliance
     "SLOT",
     "TC",


### PR DESCRIPTION
Since we have pyproject.toml metadata for [project] and [build-requires], let's turn on the linter rules which validates this optional metadata to make sure it's properly formatted and follows the correct schema for standard Python build tools. 

Right now, incorrect metadata could silently error with how our CI is invoked or only provide warnings for invalid metadata. This check will help surface those errors.