### PR TITLE
[BE]: Enable ruff YTT linter for Python version checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,6 +198,7 @@ select = [
     "TRY203",
     "TRY401", # verbose-log-message
     "UP",
+    "YTT",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/torch/package/_stdlib.py
+++ b/torch/package/_stdlib.py
@@ -20,7 +20,7 @@ def _get_stdlib_modules():
     if sys.version_info.major == 3:
         if sys.version_info.minor == 9:
             return stdlib3_9
-        if sys.version_info.minor >= 10:
+        if sys.version_info.minor >= 10:  # noqa: YTT204
             return sys.stdlib_module_names  # type: ignore[attr-defined]
     elif sys.version_info.major > 3:
         return sys.stdlib_module_names  # type: ignore[attr-defined]

--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -439,7 +439,7 @@ def get_pip_packages(run_lambda, patterns=None):
     if patterns is None:
         patterns = PIP_PATTERNS + COMMON_PATTERNS + NVIDIA_PATTERNS
 
-    pip_version = 'pip3' if sys.version[0] == '3' else 'pip'
+    pip_version = 'pip3' if sys.version_info.major == 3 else 'pip'
 
     os.environ['PIP_DISABLE_PIP_VERSION_CHECK'] = '1'
     # People generally have pip as `pip` or `pip3`


### PR DESCRIPTION
Adds ruff YTT checks to help future proof version checks and follow best practices here. Also makes it easier for static linters like mypy to detect python version branching.