### PR TITLE
[JIT] add GRAPH_DEBUG for setGraphExecutorOptimize

### DIFF
--- a/torch/csrc/jit/jit_log.h
+++ b/torch/csrc/jit/jit_log.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <c10/util/StringUtil.h>
 #include <torch/csrc/Export.h>
 #include <memory>
 #include <ostream>

--- a/torch/csrc/jit/python/update_graph_executor_opt.cpp
+++ b/torch/csrc/jit/python/update_graph_executor_opt.cpp
@@ -1,3 +1,4 @@
+#include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/python/update_graph_executor_opt.h>
 
 namespace torch::jit {
@@ -5,6 +6,7 @@ namespace torch::jit {
 static thread_local bool kOptimize = true;
 void setGraphExecutorOptimize(bool o) {
   kOptimize = o;
+  GRAPH_DEBUG("GraphExecutorOptimize set to ", o);
 }
 bool getGraphExecutorOptimize() {
   return kOptimize;


### PR DESCRIPTION
Summary: Optionally log when setGraphExecutorOptimize is called, so we can get insight into the GraphExecutor behavior.

Differential Revision: D74692508




cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel