### PR TITLE
[Inductor] Fallback bmm to mm when batch == 1

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -671,7 +671,7 @@ class TestPatternMatcher(TestCase):
         expected_multi = fn(a_multi, b_multi)
         torch.testing.assert_close(result_multi, expected_multi)
 
-        FileCheck().check("bmm").run(code_multi)
+        FileCheck().check("extern_kernels.bmm(").run(code_multi)
 
     def test_cat_mm(self):
         def fn(a, b, c):

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -31,6 +31,7 @@ from ..pattern_matcher import (
     register_graph_pattern,
     stable_topological_sort,
 )
+from .decompose_mem_bound_mm import check_device
 from .replace_random import replace_random_passes
 
 
@@ -725,7 +726,11 @@ def bmm_to_mm(match: Match, mat1: torch.fx.Node, mat2: torch.fx.Node):
     def repl(a, b):
         return torch.mm(a.squeeze(0), b.squeeze(0)).unsqueeze(0)
 
-    if mat1.meta["val"].shape[0] == 1 and mat2.meta["val"].shape[0] == 1:
+    if (
+        check_device(mat1.meta["val"], mat2.meta["val"], "cuda")
+        and mat1.meta["val"].shape[0] == 1
+        and mat2.meta["val"].shape[0] == 1
+    ):
         match.replace_by_example(repl, [mat1, mat2])
 
 

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -728,8 +728,8 @@ def bmm_to_mm(match: Match, mat1: torch.fx.Node, mat2: torch.fx.Node):
 
     if (
         check_device(mat1.meta["val"], mat2.meta["val"], "cuda")
-        and mat1.meta["val"].shape[0] == 1
-        and mat2.meta["val"].shape[0] == 1
+        and statically_known_true(mat1.meta["val"].shape[0] == 1)
+        and statically_known_true(mat2.meta["val"].shape[0] == 1)
     ):
         match.replace_by_example(repl, [mat1, mat2])
 

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -21,6 +21,7 @@ from torch.utils._ordered_set import OrderedSet
 
 from .. import config
 from ..pattern_matcher import (
+    Arg,
     CallFunction,
     init_once_fakemode,
     KeywordArg,
@@ -708,6 +709,24 @@ def pointless_permute_pair(match: Match, arg, perm1, perm2):
     node = match.output_node()
     node.replace_all_uses_with(arg)
     match.erase_nodes()
+
+
+@register_graph_pattern(
+    CallFunction(
+        aten.bmm,
+        Arg(),
+        Arg(),
+    ),
+    pass_dict=patterns,
+)
+def bmm_to_mm(match: Match, mat1: torch.fx.Node, mat2: torch.fx.Node):
+    """Convert bmm to mm when batch size is 1"""
+
+    def repl(a, b):
+        return torch.mm(a.squeeze(0), b.squeeze(0)).unsqueeze(0)
+
+    if mat1.meta["val"].shape[0] == 1 and mat2.meta["val"].shape[0] == 1:
+        match.replace_by_example(repl, [mat1, mat2])
 
 
 # When softmax is used with temperature or other scaling, we get the pattern

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -20,7 +20,6 @@ from ..utils import (
     use_triton_template,
 )
 from ..virtualized import V
-from .mm import tuned_mm
 from .mm_common import (
     _is_static_problem,
     addmm_epilogue,
@@ -138,13 +137,6 @@ def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
     """
     Lowering for autotuning aten.bmm with different backends (Aten, Triton, CUTLASS, etc.)
     """
-    # Fallback to mm if the batch size is 1
-    if mat1.get_size()[0] == mat2.get_size()[0] == 1:
-        return L.unsqueeze(
-            tuned_mm(L.squeeze(mat1, dim=0), L.squeeze(mat2, dim=0), layout=layout),
-            dim=0,
-        )
-
     if all(x.get_device().type == "cpu" for x in [mat1, mat2]):
         # decompose to small ops when memory bound
         if mat1.get_size()[1] == 1 or mat2.get_size()[2] == 1:

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -138,11 +138,12 @@ def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
     """
     Lowering for autotuning aten.bmm with different backends (Aten, Triton, CUTLASS, etc.)
     """
-    # if mat1.get_size()[0] == mat2.get_size()[0] == 1:
-    #     return L.unsqueeze(
-    #         tuned_mm(L.squeeze(mat1, dim=0), L.squeeze(mat2, dim=0), layout=layout),
-    #         dim=0,
-    #     )
+    # Fallback to mm if the batch size is 1
+    if mat1.get_size()[0] == mat2.get_size()[0] == 1:
+        return L.unsqueeze(
+            tuned_mm(L.squeeze(mat1, dim=0), L.squeeze(mat2, dim=0), layout=layout),
+            dim=0,
+        )
 
     if all(x.get_device().type == "cpu" for x in [mat1, mat2]):
         # decompose to small ops when memory bound

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -20,6 +20,7 @@ from ..utils import (
     use_triton_template,
 )
 from ..virtualized import V
+from .mm import tuned_mm
 from .mm_common import (
     _is_static_problem,
     addmm_epilogue,
@@ -137,6 +138,12 @@ def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
     """
     Lowering for autotuning aten.bmm with different backends (Aten, Triton, CUTLASS, etc.)
     """
+    # if mat1.get_size()[0] == mat2.get_size()[0] == 1:
+    #     return L.unsqueeze(
+    #         tuned_mm(L.squeeze(mat1, dim=0), L.squeeze(mat2, dim=0), layout=layout),
+    #         dim=0,
+    #     )
+
     if all(x.get_device().type == "cpu" for x in [mat1, mat2]):
         # decompose to small ops when memory bound
         if mat1.get_size()[1] == 1 or mat2.get_size()[2] == 1:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #153572

Summary:
This change introduces a fallback path from `bmm` to `mm` when the batch dimension is `1`.
The motivation is to unlock specialized `mm` kernel paths (e.g., `decomposeK`, `persistent+TMA`, etc.) which often don't have `bmm` equivalents.

### Rationale

- **No regression:** On shapes where the fallback triggers, we see no performance loss.

- **Performance wins:** On select shapes (especially with large `K`), we observe measurable speedups by triggering `mm`-specific optimizations.
  For example, on `bmm` shapes of the form `(1, H, K, H)` where `H ∈ {16, 32, 48, 64}` and `K ∈ {4096 ... 32768}`, we see an **average speedup of 10%**.

- **Prevalence in prod:** Internal workloads frequently emit `bmm` ops with `batch=1`, making this fallback broadly useful in practice.

Test Plan:
contbuild & OSS CI

Tests in test/inductor/test_torchinductor.py

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov