### PR TITLE
[MPS] Fix float64 scalar tensor handling

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -469,9 +469,9 @@ static inline void mtl_setBuffer(encoder_t encoder, const TensorBase& t, unsigne
       TORCH_CHECK(t.dim() == 0, "Passed CPU tensor to MPS op");
       // MPS does not support doubles, silently downcast CPU scalar to float
       if (C10_UNLIKELY(t.scalar_type() == kDouble)) {
-          auto val = static_cast<float>(*reinterpret_cast<const double *>(t.const_data_ptr()));
-          [encoder setBytes:&val length:sizeof(val) atIndex:idx];
-          return;
+        auto val = static_cast<float>(*reinterpret_cast<const double*>(t.const_data_ptr()));
+        [encoder setBytes:&val length:sizeof(val) atIndex:idx];
+        return;
       }
       [encoder setBytes:t.storage().data() length:t.element_size() atIndex:idx];
     } else {

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -467,6 +467,12 @@ static inline void mtl_setBuffer(encoder_t encoder, const TensorBase& t, unsigne
   if (C10_UNLIKELY(t.device().type() == kCPU)) {
     if constexpr (std::is_same_v<id<MTLComputeCommandEncoder>, encoder_t>) {
       TORCH_CHECK(t.dim() == 0, "Passed CPU tensor to MPS op");
+      // MPS does not support doubles, silently downcast CPU scalar to float
+      if (C10_UNLIKELY(t.scalar_type() == kDouble)) {
+          auto val = static_cast<float>(*reinterpret_cast<const double *>(t.const_data_ptr()));
+          [encoder setBytes:&val length:sizeof(val) atIndex:idx];
+          return;
+      }
       [encoder setBytes:t.storage().data() length:t.element_size() atIndex:idx];
     } else {
       TORCH_CHECK(false, "Passed CPU tensor to MPS op");

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -12317,6 +12317,9 @@ class TestMetalLibrary(TestCaseMPS):
     def test_metal_arange_with_arg_and_scalar_tensor(self):
         self.test_metal_arange_with_arg(step=torch.tensor(.5))
 
+    def test_metal_arange_with_arg_and_scalar_tensor_float64(self):
+        self.test_metal_arange_with_arg(step=torch.tensor(.5, dtype=torch.float64))
+
     def test_metal_arange_with_arg_and_cast(self):
         x = torch.zeros(12, device="mps", dtype=torch.half)
         y = torch.zeros(12, device="mps", dtype=torch.half)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #153582

Current implementation causes silent correction problem with torch.compile when someone tries to `torch.compile` function where one of the arguments is say `np.exp(.3)`, which will be represented as torch.float64 scalar tensor

Add regssion test for this behavior