### PR TITLE
[Async TP] Fix dim swapping before reduction in fused_scaled_matmul_reduce_scatter

### DIFF
--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -1292,15 +1292,15 @@ def _fused_scaled_matmul_reduce_scatter_impl(
     # stacked partial outputs. The next dims will be A's leading dims (sharded along the original scatter dim),
     # as it was the left operand of the mm op. We can use -1 as the final dim of the view to populate the rest.
     stacked_partials_3D_leading_dims = [group.size()] + list(
-        # We use A from after the dim swap 0<=>scatter_dim, but before the flatten, 
+        # We use A from after the dim swap 0<=>scatter_dim, but before the flatten,
         # to get the leading dims of the 3D+ view of stacked partials.
         A_with_scatter_dim_0.shape[:-1]
     )
 
     # The `group_size` leading dim has been prepended to `stacked_partials_3D_leading_dims`,
     # to capture the partial output from each rank. We need to divide the sharding/scatter dim
-    # by the group size.If the original scatter dim was 0, then
-    # it is now dim 1 in this tensor, since this new `[group_size]` dim was prepended.
+    # by the group size. If the original scatter dim was 0, then it is now dim 1 in this
+    # tensor, since this new `group_size` dim was prepended.
     stacked_partial_scatter_dim = orig_scatter_dim if orig_scatter_dim > 0 else 1
     stacked_partials_3D_leading_dims[stacked_partial_scatter_dim] //= group.size()
 
@@ -1311,7 +1311,7 @@ def _fused_scaled_matmul_reduce_scatter_impl(
         stacked_partials.view(*stacked_partials_3D_leading_dims, -1)
         # We originally swapped 0<=>scatter_dim_after_maybe_reshape. Now after
         # prepending the `group_size` dim, to undo this original swap, we
-        # must do 1<=>scatter_dim_after_maybe_reshape+1.
+        # must swap 1<=>scatter_dim_after_maybe_reshape+1.
         .movedim(1, scatter_dim_after_maybe_reshape + 1),
         # Reduce along the `group_size` dim (0).
         dim=0,

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -1233,10 +1233,10 @@ def _fused_scaled_matmul_reduce_scatter_impl(
     A_with_scatter_dim_0 = A.movedim(scatter_dim_after_maybe_reshape, 0)
 
     # To handle case where A is 3D+, reshape to 2D to prepare for mm which requires 2D inputs.
-    A_with_scatter_dim_0 = A_with_scatter_dim_0.flatten(0, -2)
+    A_2D_with_scatter_dim_0 = A_with_scatter_dim_0.flatten(0, -2)
 
     # Parition A along the first dim to prepare for sharding across TP process group.
-    A_shards = A_with_scatter_dim_0.chunk(group.size())
+    A_shards = A_2D_with_scatter_dim_0.chunk(group.size())
 
     # Now that 'A' is sharded along the first dim, we need to update its scale(s) accordingly.
     # How we do this depends on if we are using tensorwise scaling, rowwise scaling, or no scaling.
@@ -1274,7 +1274,7 @@ def _fused_scaled_matmul_reduce_scatter_impl(
     # have the shape (A_with_scatter_dim_0_tensor.shape[0], B.shape[1]) to align with the formula:
     # (a*b,c) @ (c,d) = (a*b,d)
     stacked_partials = A_with_scatter_dim_0.new_empty(
-        A_with_scatter_dim_0.shape[0], B.shape[1], dtype=out_dtype or A.dtype
+        A_2D_with_scatter_dim_0.shape[0], B.shape[1], dtype=out_dtype or A.dtype
     )
 
     # Execute the pipelined mm/scaled_mm.
@@ -1292,11 +1292,14 @@ def _fused_scaled_matmul_reduce_scatter_impl(
     # stacked partial outputs. The next dims will be A's leading dims (sharded along the original scatter dim),
     # as it was the left operand of the mm op. We can use -1 as the final dim of the view to populate the rest.
     stacked_partials_3D_leading_dims = [group.size()] + list(
+        # We use A from after the dim swap 0<=>scatter_dim, but before the flatten, 
+        # to get the leading dims of the 3D+ view of stacked partials.
         A_with_scatter_dim_0.shape[:-1]
     )
 
-    # A [group_size] leading dim has been prepended to `stacked_partials_3D_leading_dims`,
-    # to capture the partial output from each rank. If the original scatter dim was 0, then
+    # The `group_size` leading dim has been prepended to `stacked_partials_3D_leading_dims`,
+    # to capture the partial output from each rank. We need to divide the sharding/scatter dim
+    # by the group size.If the original scatter dim was 0, then
     # it is now dim 1 in this tensor, since this new `[group_size]` dim was prepended.
     stacked_partial_scatter_dim = orig_scatter_dim if orig_scatter_dim > 0 else 1
     stacked_partials_3D_leading_dims[stacked_partial_scatter_dim] //= group.size()
@@ -1306,9 +1309,12 @@ def _fused_scaled_matmul_reduce_scatter_impl(
     reduced_out = reduce_fn(
         # View 2D stacked partials as 3D+ tensor of shape (`group_size`, ...)
         stacked_partials.view(*stacked_partials_3D_leading_dims, -1)
-        # Swap back the scatter dim (which we moved to 0, and now is `group_size`)
-        .movedim(0, orig_scatter_dim),
-        dim=orig_scatter_dim,  # Reduce along the origal scatter dim (`group_size`)
+        # We originally swapped 0<=>scatter_dim_after_maybe_reshape. Now after
+        # prepending the `group_size` dim, to undo this original swap, we
+        # must do 1<=>scatter_dim_after_maybe_reshape+1.
+        .movedim(1, scatter_dim_after_maybe_reshape + 1),
+        # Reduce along the `group_size` dim (0).
+        dim=0,
     )
 
     # Output shape must be scattered along original scatter dim as well.


### PR DESCRIPTION
## Summary
- The unit test `pytest test/distributed/test_symmetric_memory.py -k test_fused_scaled_matmul_reduce_scatter_scatter` was not running for some reason when #149247 was merged, giving false green CI signals. When it was ran manually recently, the test failed, highlighting a bug causing incorrect numerics when `scatter_dim=1`.
- This PR fixes the bug, which was related to how we swap dims 0<=>scatter_dim at the beginning of the custom op (for more efficient cross-device data movement I believe), then swap it back prior to reduction. 

## Test plan
- I confirmed the unit test `pytest test/distributed/test_symmetric_memory.py -k test_fused_scaled_matmul_reduce_scatter_scatter` is now passing.
- I confirmed e2e training w/ torchtitan looks good ([logs](https://www.internalfb.com/phabricator/paste/view/P1812054188))
- I analyzed the tlparse to verify the fused_all_gather_matmul and fused_scaled_matmul_reduce_scatter both appear at least once in the post grad graphs ([tlparse](https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/.tmpVbUsdG/dedicated_log_torch_trace_65oh3qj_.log/index.html?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=10000))

## Next steps
1. I think for async TP `fused_scaled_matmul_reduce_scatter` we may only need `scatter_dim_after_maybe_reshape` and not `orig_scatter_dim` after all. I can confirm this and refactor if it is the case.
2. This op is specifically designed for async TP, and many of the arguments don't make sense for a user trying to use this as a standalone op. IMO we should have separate standalone custom op without all the extra function args and internal logic that doesn't apply to non-async TP cases. 
3. In a follow up PR I want to add shape annotations to each line (e.g. `# (B, T, H)` etc) to make this easier to debug in the future.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k