### PR TITLE
[MPSInductor] Support numpy scalars handling

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -3,9 +3,9 @@ import importlib
 import os
 import sys
 
-import torch
 import numpy as np
 
+import torch
 from torch.testing import make_tensor
 from torch.testing._internal.common_dtype import get_all_dtypes
 from torch.testing._internal.common_utils import (
@@ -166,7 +166,7 @@ class MPSBasicTests(TestCase):
         def fn(x, y):
             return x / y
 
-        self.common(fn, (torch.rand(10), np.exp(.3)))
+        self.common(fn, (torch.rand(10), np.exp(0.3)))
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -4,6 +4,8 @@ import os
 import sys
 
 import torch
+import numpy as np
+
 from torch.testing import make_tensor
 from torch.testing._internal.common_dtype import get_all_dtypes
 from torch.testing._internal.common_utils import (
@@ -159,6 +161,12 @@ class MPSBasicTests(TestCase):
                 return torch.nn.functional.rms_norm(x, x.shape, w)
 
         self.common(fn, (torch.rand(10), torch.ones(10)))
+
+    def test_compile_numpy_scalar(self):
+        def fn(x, y):
+            return x / y
+
+        self.common(fn, (torch.rand(10), np.exp(.3)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #153598

By default, numpy computes results in float64 format, but when passed as an argument to MPS function, must be implicitly converted to float32, which naturally occurs in some networks, for example in speech_transformer

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov