### PR TITLE
fix a compilation issue when TORCH_XPU_ARCH_LIST is an empty string

### DIFF
--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -432,6 +432,9 @@ endif()
 # Preserve XPU arch flags
 if(USE_XPU)
   string(REPLACE "," " " _ARCH_FLAGS_readable "${TORCH_XPU_ARCH_LIST}")
+  if("${TORCH_XPU_ARCH_LIST}" STREQUAL "")
+    set(_ARCH_FLAGS_readable "\\\"\\\"")
+  endif()
   set_source_files_properties(${TORCH_SRC_DIR}/csrc/xpu/Module.cpp PROPERTIES COMPILE_FLAGS "-DXPU_ARCH_FLAGS=\"${_ARCH_FLAGS_readable}\"")
 endif()
 

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -432,9 +432,6 @@ endif()
 # Preserve XPU arch flags
 if(USE_XPU)
   string(REPLACE "," " " _ARCH_FLAGS_readable "${TORCH_XPU_ARCH_LIST}")
-  if("${TORCH_XPU_ARCH_LIST}" STREQUAL "")
-    set(_ARCH_FLAGS_readable "\\\"\\\"")
-  endif()
   set_source_files_properties(${TORCH_SRC_DIR}/csrc/xpu/Module.cpp PROPERTIES COMPILE_FLAGS "-DXPU_ARCH_FLAGS=\"${_ARCH_FLAGS_readable}\"")
 endif()
 

--- a/torch/csrc/xpu/Module.cpp
+++ b/torch/csrc/xpu/Module.cpp
@@ -19,7 +19,10 @@ static PyObject* THXPModule_getArchFlags(PyObject* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
 #ifdef XPU_ARCH_FLAGS
   static const char* flags = C10_STRINGIZE(XPU_ARCH_FLAGS);
-  return THPUtils_packString(flags);
+  // Since C10_STRINGIZE doesn't handle an empty string as its input correctly,
+  // the string "\"\"" will be passed from cmake to indicate an empty string.
+  static const char* EMPTY_FLAGS = "\"\"";
+  return THPUtils_packString(std::strcmp(flags, EMPTY_FLAGS) == 0 ? "" : flags);
 #else
   Py_RETURN_NONE;
 #endif

--- a/torch/csrc/xpu/Module.cpp
+++ b/torch/csrc/xpu/Module.cpp
@@ -18,7 +18,7 @@ using namespace torch;
 static PyObject* THXPModule_getArchFlags(PyObject* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
 #ifdef XPU_ARCH_FLAGS
-  static constexpr const char* flags = std::string(C10_STRINGIZE(XPU_ARCH_FLAGS)).c_str();
+  static const char* flags = std::string(C10_STRINGIZE(XPU_ARCH_FLAGS)).c_str();
   return THPUtils_packString(flags);
 #else
   Py_RETURN_NONE;

--- a/torch/csrc/xpu/Module.cpp
+++ b/torch/csrc/xpu/Module.cpp
@@ -18,7 +18,7 @@ using namespace torch;
 static PyObject* THXPModule_getArchFlags(PyObject* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
 #ifdef XPU_ARCH_FLAGS
-  static const char* flags = std::string(XPU_ARCH_FLAGS).c_str();
+  static constexpr const char* flags = std::string(C10_STRINGIZE(XPU_ARCH_FLAGS)).c_str();
   return THPUtils_packString(flags);
 #else
   Py_RETURN_NONE;

--- a/torch/csrc/xpu/Module.cpp
+++ b/torch/csrc/xpu/Module.cpp
@@ -18,7 +18,7 @@ using namespace torch;
 static PyObject* THXPModule_getArchFlags(PyObject* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
 #ifdef XPU_ARCH_FLAGS
-  static const char* flags = std::string(C10_STRINGIZE(XPU_ARCH_FLAGS)).c_str();
+  static const std::string flags = std::string(C10_STRINGIZE(XPU_ARCH_FLAGS));
   return THPUtils_packString(flags);
 #else
   Py_RETURN_NONE;

--- a/torch/csrc/xpu/Module.cpp
+++ b/torch/csrc/xpu/Module.cpp
@@ -18,11 +18,8 @@ using namespace torch;
 static PyObject* THXPModule_getArchFlags(PyObject* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
 #ifdef XPU_ARCH_FLAGS
-  static const char* flags = C10_STRINGIZE(XPU_ARCH_FLAGS);
-  // Since C10_STRINGIZE doesn't handle an empty string as its input correctly,
-  // the string "\"\"" will be passed from cmake to indicate an empty string.
-  static const char* EMPTY_FLAGS = "\"\"";
-  return THPUtils_packString(std::strcmp(flags, EMPTY_FLAGS) == 0 ? "" : flags);
+  static const char* flags = std::string(XPU_ARCH_FLAGS).c_str();
+  return THPUtils_packString(flags);
 #else
   Py_RETURN_NONE;
 #endif


### PR DESCRIPTION
When `XPU_ARCH_FLAGS` is an empty string, compilation will fail on `C10_STRINGIZE(XPU_ARCH_FLAGS)` in file `torch/csrc/xpu/Module.cpp` on Windows.
This PR fixes this issue by setting `TORCH_XPU_ARCH_LIST` to `""` to avoid an empty string conversion in `C10_STRINGIZE()` when compiling without an AOT.