### PR TITLE
[BE]: Enable misc RUF rules and fix pyproject.toml indent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,16 +3,16 @@ name = "torch"
 requires-python = ">=3.9"
 license = {text = "BSD-3-Clause"}
 dynamic = [
-  "authors",
-  "classifiers",
-  "entry-points",
-  "dependencies",
-  "description",
-  "keywords",
-  "optional-dependencies",
-  "readme",
-  "scripts",
-  "version",
+    "authors",
+    "classifiers",
+    "entry-points",
+    "dependencies",
+    "description",
+    "keywords",
+    "optional-dependencies",
+    "readme",
+    "scripts",
+    "version",
 ]
 
 [project.urls]
@@ -188,9 +188,13 @@ select = [
     "RUF017",
     "RUF018", # no assignment in assert
     "RUF019", # unnecessary-key-check
+    "RUF020", # never union
     "RUF024", # from keys mutable
     "RUF026", # default factory kwarg
     "RUF030", # No print statement in assert
+    "RUF033", # default values __post_init__ dataclass
+    "RUF041", # simplify nested Literal
+    "RUF048", # properly parse `__version__`
     "RUF200", # validate pyproject.toml
     "S324", # for hashlib FIPS compliance
     "SLOT",


### PR DESCRIPTION
Enables a variety of misc ruff rules and fixes some incorrect indentation in the file. Now that we updated ruff recently we can enable this rule lints. Most of these lints I've already applied, but now they are out of preview can apply them as stable lints.

Including:
* Do not bother why typing union with Never as this gets cancelled otu
* Simplify nested Literal into a single Literal
* Properly use packaging to parse version instead of `map(int(`