### PR TITLE
[BE]: Update ruff linter to 0.11.10

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -1457,7 +1457,7 @@ init_command = [
     'black==23.12.1',
     'usort==1.0.8.post1',
     'isort==5.13.2',
-    'ruff==0.11.8',  # sync with RUFF
+    'ruff==0.11.10',  # sync with RUFF
 ]
 is_formatter = true
 
@@ -1518,7 +1518,12 @@ command = [
 
 [[linter]]
 code = 'RUFF'
-include_patterns = ['**/*.py', '**/*.pyi', 'torch/utils/data/*.ipynb']
+include_patterns = [
+    '**/*.py',
+    '**/*.pyi',
+    'torch/utils/data/*.ipynb',
+    'pyproject.toml',
+]
 exclude_patterns = [
     'caffe2/**',
     'functorch/docs/**',
@@ -1543,7 +1548,7 @@ init_command = [
     'python3',
     'tools/linter/adapters/pip_init.py',
     '--dry-run={{DRYRUN}}',
-    'ruff==0.11.8',  # sync with PYFMT
+    'ruff==0.11.10',  # sync with PYFMT
 ]
 is_formatter = true
 


### PR DESCRIPTION
Fixes a bug with #153543 where I forgot to add pyproject.toml to the list of files RUF can scan and also updates it to the latest version (which is just minor bugfixes).