### PR TITLE
[nativert] move recordfunction (#153088)

### DIFF
--- a/torch/csrc/autograd/record_function_ops.h
+++ b/torch/csrc/autograd/record_function_ops.h
@@ -1,6 +1,8 @@
 #pragma once
+
 #include <ATen/record_function.h>
 #include <torch/custom_class.h>
+#include <torch/library.h>
 #include <optional>
 
 namespace torch::autograd::profiler {
@@ -23,5 +25,30 @@ TORCH_API c10::intrusive_ptr<PythonRecordFunction> record_function_enter_new(
 TORCH_API c10::intrusive_ptr<c10::ivalue::Future> _call_end_callbacks_on_fut_new(
     const c10::intrusive_ptr<PythonRecordFunction>& record,
     const c10::intrusive_ptr<c10::ivalue::Future>& fut);
+
+/**
+ * RAII wrapper that behaves similarly to torch.profiler.record_function.
+ */
+class RecordFunction {
+ public:
+  RecordFunction() = delete;
+  RecordFunction(const RecordFunction&) = delete;
+  RecordFunction& operator=(const RecordFunction&) = delete;
+  RecordFunction(RecordFunction&&) = delete;
+  RecordFunction& operator=(RecordFunction&&) = delete;
+
+  explicit RecordFunction(const std::string& name) {
+    recordFunction_ =
+        torch::autograd::profiler::record_function_enter_new(name);
+  }
+
+  ~RecordFunction() {
+    recordFunction_->record.end();
+  }
+
+ private:
+  c10::intrusive_ptr<torch::autograd::profiler::PythonRecordFunction>
+      recordFunction_;
+};
 
 } // namespace torch::autograd::profiler


### PR DESCRIPTION
Summary:

nativert RFC: https://github.com/zhxchen17/rfcs/blob/master/RFC-0043-torch-native-runtime.md

To land the runtime into PyTorch core, we will gradually land logical parts of the code into the Github issue and get each piece properly reviewed.

This diff moves the our function-recording raii wrapper into record_function_ops

Test Plan: CI

Reviewed By: zhxchen17

Differential Revision: D74771077


