### PR TITLE
[Release-Only] Make pull linux-jammy-py3.9-gcc11 green

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -79,6 +79,7 @@ jobs:
       build-environment: linux-jammy-py3.9-gcc11
       docker-image: ${{ needs.linux-jammy-py3_9-gcc11-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_9-gcc11-build.outputs.test-matrix }}
+      timeout-minutes: 300
     secrets: inherit
 
   linux-docs:


### PR DESCRIPTION
Adjust timeout, hopefully should make this signal green on release:

<img width="258" alt="Screenshot 2025-05-15 at 11 18 16 AM" src="https://github.com/user-attachments/assets/fd4980ff-9640-4653-8516-612d4e032250" />


Failure: https://github.com/pytorch/pytorch/actions/runs/15033800662/job/42260580888
```
Error: The action 'Test' has timed out after 210 minutes.
```
