### PR TITLE
[Torch] Fix error message formatting in fp8 comparison logic

### DIFF
--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -878,8 +878,8 @@ class TensorLikePair(Pair):
                 if rtol != 0.0 or atol != 0.0:
                     raise ErrorMeta(
                         AssertionError,
-                        f"Rtol={rtol} and atol={atol} are not supported for bitwise comparison of low \
-                            dimensional floats. Please use rtol=0.0 and atol=0.0",
+                        f"Rtol={rtol} and atol={atol} are not supported for bitwise comparison of low"
+                        " dimensional floats. Please use rtol=0.0 and atol=0.0.",
                     )
 
                 return self._compare_regular_values_close(


### PR DESCRIPTION
Summary: Using `\` includes all the tabs from the next line in the error message.

Test Plan: Nothing, simply error message fixing

Reviewed By: exclamaforte

Differential Revision: D74539234


