### PR TITLE
[executorch][codegen] support function + method variants.

### DIFF
--- a/torchgen/gen_executorch.py
+++ b/torchgen/gen_executorch.py
@@ -129,19 +129,18 @@ class ComputeFunction:
     is_custom_op: Callable[[NativeFunction], bool]
 
     @method_with_native_function
-    def __call__(self, f: NativeFunction) -> str | None:
+    def __call__(self, f: NativeFunction) -> str | None:        
         is_method_variant = False
         if not self.selector.is_root_operator(f"{f.namespace}::{f.func.name}"):
             return None
 
+        if Variant.function not in f.variants and Variant.method not in f.variants:
+            raise Exception(  # noqa: TRY002
+                f"Expected one of function or method to be in variants for {f.func.name}"
+            )
+
         if Variant.function not in f.variants and Variant.method in f.variants:
             is_method_variant = True
-
-        # only valid remaining case is only function is in f.variants
-        elif not (Variant.function in f.variants and Variant.method not in f.variants):
-            raise Exception(  # noqa: TRY002
-                f"Can't handle native function {f.func} with the following variant specification {f.variants}."
-            )
 
         sig: CppSignature | ExecutorchCppSignature = (
             CppSignatureGroup.from_native_function(


### PR DESCRIPTION
Summary: Previously think we didnt need this so just threw an exception. Now we are adding index_put_ and other inplace ops besides copy_ (which is only function variant) so adding it.

Test Plan: current ci and manuels diff

Differential Revision: D74834513


