### PR TITLE
[pytorch][triton] Enabling TMA for flex-attention for supported device types

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -122,12 +122,13 @@ def rmse(ref, res):
     return torch.sqrt(torch.mean(torch.square(ref - res)))
 
 
-def create_attention(score_mod, block_mask, enable_gqa=False):
+def create_attention(score_mod, block_mask, enable_gqa=False, kernel_options=None):
     return functools.partial(
         flex_attention,
         score_mod=score_mod,
         block_mask=block_mask,
         enable_gqa=enable_gqa,
+        kernel_options=kernel_options,
     )
 
 
@@ -670,6 +671,7 @@ class TestFlexAttention(InductorTestCase):
         dtype: torch.dtype,
         device: str,
         block_mask: Optional[BlockMask] = None,
+        kernel_options: Optional[dict] = None,
     ) -> tuple[Tensor, Tensor]:
         B, Q_H, Q_S, KV_H, KV_S = (
             q.shape[0],
@@ -705,6 +707,7 @@ class TestFlexAttention(InductorTestCase):
                 block_mask=converted_block_mask,
                 score_mod=converted_score_mod,
                 enable_gqa=(not Q_H == KV_H),
+                kernel_options=kernel_options,
             )
         else:
             return_lse = False
@@ -717,6 +720,7 @@ class TestFlexAttention(InductorTestCase):
                 block_mask=converted_block_mask,
                 score_mod=converted_score_mod,
                 enable_gqa=(not Q_H == KV_H),
+                kernel_options=kernel_options,
             )
         return compiled_out, compiled_lse
 
@@ -1442,7 +1446,7 @@ class TestFlexAttention(InductorTestCase):
             # broadcasting reasons i think
         ],
     )
-    @common_utils.parametrize("do_s", test_strides[:3])
+    @common_utils.parametrize("do_s", test_strides[:1])
     def test_strided_inputs(self, device, dtype: torch.dtype, q_s, k_s, v_s, do_s):
         q1 = torch.randn((B * H * S * D * 2), dtype=dtype, device=device)
         k1 = torch.randn((B * H * S * D * 2), dtype=dtype, device=device)
@@ -1469,10 +1473,12 @@ class TestFlexAttention(InductorTestCase):
         k = coerce_to_strides(k1, k_shape, k_s)
         v = coerce_to_strides(v1, v_shape, v_s)
         do = coerce_to_strides(do1, do_shape, do_s)
-
+        kernel_options = {"USE_TMA": False}
         block_mask = _create_empty_block_mask(q, k)
         score_mod = _generate_alibi_bias(8)
-        sdpa_partial = create_attention(score_mod=score_mod, block_mask=block_mask)
+        sdpa_partial = create_attention(
+            score_mod=score_mod, block_mask=block_mask, kernel_options=kernel_options
+        )
         compiled_sdpa = torch.compile(sdpa_partial, fullgraph=True)
         ref_out = sdpa_partial(q, k, v)
         compiled_out = compiled_sdpa(q, k, v)
@@ -1515,7 +1521,7 @@ class TestFlexAttention(InductorTestCase):
         # test paged attention which does not support backward
         q.requires_grad, k.requires_grad, v.requires_grad = False, False, False
         paged_compiled_out, _ = self.run_paged_attention(
-            score_mod, q, k, v, dtype, device=device
+            score_mod, q, k, v, dtype, device=device, kernel_options=kernel_options
         )
         torch.testing.assert_close(
             ref_out, paged_compiled_out, atol=tolerance.atol, rtol=tolerance.rtol

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -17,6 +17,7 @@ from torch.utils._ordered_set import OrderedSet
 from torch.utils._pytree import tree_map
 from torch.utils._sympy.numbers import int_oo
 from torch.utils._sympy.value_ranges import ValueRanges
+from torch.utils._triton import has_triton_stable_tma_api
 
 from ..ir import (
     Buffer,
@@ -1447,7 +1448,7 @@ def flex_attention(
     original_kernel_options = kernel_options.copy()
     # Default config for warp specialization
     num_consumer_groups, num_buffers_warp_spec = 0, 0
-
+    USE_TMA = has_triton_stable_tma_api()
     for conf in configs:
         if (
             SPARSE_KV_BLOCK_SIZE % conf.block_n != 0
@@ -1478,8 +1479,7 @@ def flex_attention(
                 "num_buffers_warp_spec", num_buffers_warp_spec
             )
 
-        # Disabling TMA by default, only explicit kernel_options supported for now
-        cur_kernel_options.setdefault("USE_TMA", False)
+        cur_kernel_options.setdefault("USE_TMA", USE_TMA)
 
         cur_kernel_options.setdefault("BLOCK_M", conf.block_m)
         cur_kernel_options.setdefault("BLOCK_N", conf.block_n)


### PR DESCRIPTION
Summary:
Currently flex-attention defaults to `USE_TMA=False`.

We can enable TMA on devices which support it based on `has_triton_tma_device`.

Test Plan:
# Tritonbench results

```
buck2 run mode/opt //pytorch/tritonbench:run -- --op flex_attention --use-tma --mod-type all
.
.
.
(B, Hq, M, Hkv, N, D)     |       Mask Type    compiled-latency    compiled-tflops
- USE_TMA =  False
(8, 16, 128, 16, 128, 128) |            noop   0.027936 (±5.61%)            38.5859
(8, 16, 128, 16, 128, 128) |          causal   0.017760 (±3.42%)            60.6946
(8, 16, 128, 16, 128, 128) |             rel   0.028384 (±5.07%)            37.9769
(8, 16, 128, 16, 128, 128) |       head_bias   0.027712 (±4.27%)            38.8978
(8, 16, 128, 16, 128, 128) |           alibi   0.017920 (±3.21%)            60.1527
- USE_TMA = True
(8, 16, 128, 16, 128, 128) |            noop   0.025632 (±5.74%)            42.0543
(8, 16, 128, 16, 128, 128) |          causal   0.015328 (±3.97%)            70.3246
(8, 16, 128, 16, 128, 128) |             rel   0.025824 (±4.96%)            41.7416
(8, 16, 128, 16, 128, 128) |       head_bias   0.025472 (±4.90%)            42.3185
(8, 16, 128, 16, 128, 128) |           alibi   0.015392 (±3.74%)            70.0322
```

Differential Revision: D74841543




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben