### PR TITLE
ci: add install_llvm_triton.sh to download prebuilt LLVM for Triton

### DIFF
--- a/.ci/docker/common/install_llvm_triton.sh
+++ b/.ci/docker/common/install_llvm_triton.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- Detect platform suffix ---
+detect_suffix() {
+    local arch=$(uname -m)
+    local sys=$(uname -s)
+
+    case "$arch" in
+        x86_64) arch="x64" ;;
+        aarch64|arm64) arch="arm64" ;;
+        *) echo "Unsupported architecture: $arch" >&2; exit 1 ;;
+    esac
+
+    if [[ "$sys" == "Darwin" ]]; then
+        echo "macos-$arch"
+    elif [[ "$sys" == "Linux" ]]; then
+        if [[ "$arch" == "arm64" ]]; then
+            echo "ubuntu-arm64"
+        elif [[ "$arch" == "x64" ]]; then
+            local glibc_ver=$(ldd --version | head -n1 | grep -oP '\d+\.\d+')
+            local major=$(echo "$glibc_ver" | cut -d. -f1)
+            local minor=$(echo "$glibc_ver" | cut -d. -f2)
+            local vglibc=$((major * 100 + minor))
+            if (( vglibc > 228 )); then
+                echo "ubuntu-x64"
+            elif (( vglibc > 217 )); then
+                echo "almalinux-x64"
+            else
+                echo "centos-x64"
+            fi
+        fi
+    else
+        echo "Unsupported system: $sys" >&2
+        exit 1
+    fi
+}
+
+# --- Fetch LLVM hash ---
+get_llvm_hash() {
+    local file="/var/lib/jenkins/triton/cmake/llvm-hash.txt"
+    if [[ -f "$file" ]]; then
+        cut -c1-8 < "$file"
+    else
+        curl -sSL https://raw.githubusercontent.com/triton-lang/triton/main/cmake/llvm-hash.txt | cut -c1-8
+    fi
+}
+
+# --- Download and extract LLVM ---
+download_and_extract() {
+    local url="$1"
+    local dest="$2"
+    local tarball="${url##*/}"
+    local tarpath="$dest/$tarball"
+
+    mkdir -p "$dest"
+    curl -fsSL "$url" -o "$tarpath"
+
+    pushd "$dest" >/dev/null
+    tar --strip-components=1 -zxf "$tarball"
+    rm -f "$tarball"
+    popd >/dev/null
+}
+
+# --- Main ---
+main() {
+    local suffix
+    suffix=$(detect_suffix)
+
+    local hash
+    hash=$(get_llvm_hash)
+
+    local base="llvm-${hash}-${suffix}"
+    local url="https://oaitriton.blob.core.windows.net/public/llvm-builds/${base}.tar.gz"
+    local install_dir="/opt/llvm"
+
+    download_and_extract "$url" "$install_dir"
+
+    echo ""
+    echo "# --- LLVM for Triton ---"
+    echo "export PATH=/opt/llvm/bin:\$PATH"
+    echo "export LD_LIBRARY_PATH=/opt/llvm/lib:\$LD_LIBRARY_PATH"
+    echo "export CMAKE_PREFIX_PATH=/opt/llvm:\$CMAKE_PREFIX_PATH"
+    echo "export LLVM_DIR=/opt/llvm"
+}
+
+main "$@"

--- a/.ci/docker/common/install_triton.sh
+++ b/.ci/docker/common/install_triton.sh
@@ -54,8 +54,8 @@ as_jenkins git submodule update --init --recursive
 cd python
 pip_install pybind11==2.13.6
 
-# TODO: remove patch setup.py once we have a proper fix for https://github.com/triton-lang/triton/issues/4527
-as_jenkins sed -i -e 's/https:\/\/tritonlang.blob.core.windows.net\/llvm-builds/https:\/\/oaitriton.blob.core.windows.net\/public\/llvm-builds/g' setup.py
+#as_jenkins sed -i -e 's/https:\/\/tritonlang.blob.core.windows.net\/llvm-builds/https:\/\/oaitriton.blob.core.windows.net\/public\/llvm-builds/g' setup.py
+as_jenkins eval "$(./install_llvm_triton.sh)"
 
 if [ -n "${UBUNTU_VERSION}" ] && [ -n "${GCC_VERSION}" ] && [[ "${GCC_VERSION}" == "7" ]]; then
   # Triton needs at least gcc-9 to build


### PR DESCRIPTION
Adds a CI script that detects the target platform and glibc version, downloads the appropriate LLVM tarball from Triton's public blob store, extracts it to /opt/llvm, and emits required environment exports.

Modifyies .ci/docker/common/install_triton.sh adding one line: as_jenkins eval

This change removes the need to build LLVM from source during CI docker builds.

Refs triton-lang/triton#4527

Fixes #triton-lang/triton#4527
