### PR TITLE
[c10d] Consolidate monitoring thread in PGNCCL

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -935,7 +935,6 @@ std::atomic<bool> ProcessGroupNCCL::watchdogHeartbeatMonitorEnabled_;
 std::mutex ProcessGroupNCCL::monitorMutex_;
 std::condition_variable ProcessGroupNCCL::monitorWakeUpCV_;
 bool ProcessGroupNCCL::dumpOnTimeoutOrEx_;
-bool ProcessGroupNCCL::propagatePgError_;
 std::string ProcessGroupNCCL::globalLogPrefix_;
 std::thread ProcessGroupNCCL::ncclHeartbeatMonitorThread_;
 
@@ -969,6 +968,7 @@ ProcessGroupNCCL::ProcessGroupNCCL(
   desyncDebug_ = getCvarBool(TORCH_NCCL_DESYNC_DEBUG, false) ||
       (dist_debug_level_ >= DebugLevel::Detail);
   rethrowCUDAErrors_ = getCvarBool(TORCH_NCCL_RETHROW_CUDA_ERRORS, true);
+  propagatePgError_ = getCvarBool(TORCH_NCCL_PROPAGATE_ERROR, false);
   // logging C++ stack isn't safe. Introduce a variable to control it.
   logCppStackOnUncleanShutdown_ =
       getCvarBool(TORCH_NCCL_LOG_CPP_STACK_ON_UNCLEAN_SHUTDOWN, true);
@@ -988,7 +988,6 @@ ProcessGroupNCCL::ProcessGroupNCCL(
     // both timeout and other errors.
     dumpOnTimeoutOrEx_ = getCvarBool(TORCH_NCCL_DUMP_ON_TIMEOUT, true) ||
         (dist_debug_level_ >= DebugLevel::Detail);
-    propagatePgError_ = getCvarBool(TORCH_NCCL_PROPAGATE_ERROR, false);
     watchdogHeartbeatMonitorEnabled_.store(
         getCvarBool(TORCH_NCCL_ENABLE_MONITORING, true));
     globalLogPrefix_ = c10::str("[Global Rank ", globalRank(), "] ");

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -925,6 +925,20 @@ constexpr const char* MULTI_DEVICE_ERROR_MSG =
     "https://pytorch.org/docs/stable/distributed.html#multi-gpu-collective-functions. "
     "ProcessGroupNCCL continues supporting multi-process and multi-thread modes.";
 
+std::atomic<bool> ProcessGroupNCCL::terminateHeartbeatMonitorThread_{false};
+c10::once_flag ProcessGroupNCCL::initFlag_;
+std::atomic_uint64_t ProcessGroupNCCL::heartbeat_;
+int ProcessGroupNCCL::heartbeatTimeoutInSec_;
+int ProcessGroupNCCL::waitTimeoutDumpInMilSec_;
+int ProcessGroupNCCL::coordCheckIntervalMilSec_;
+std::atomic<bool> ProcessGroupNCCL::watchdogHeartbeatMonitorEnabled_;
+std::mutex ProcessGroupNCCL::monitorMutex_;
+std::condition_variable ProcessGroupNCCL::monitorWakeUpCV_;
+bool ProcessGroupNCCL::dumpOnTimeoutOrEx_;
+bool ProcessGroupNCCL::propagatePgError_;
+std::string ProcessGroupNCCL::globalLogPrefix_;
+std::thread ProcessGroupNCCL::ncclHeartbeatMonitorThread_;
+
 ProcessGroupNCCL::ProcessGroupNCCL(
     c10::intrusive_ptr<Store> store,
     int rank,
@@ -934,7 +948,6 @@ ProcessGroupNCCL::ProcessGroupNCCL(
       store_(std::move(store)),
       options_(std::move(options)),
       terminateProcessGroup_(false),
-      terminateHeartbeatMonitorThread_(false),
       local_id_(process_group_id++),
       intraNodeComm_(initIntraNodeComm()) {
   TORCH_CHECK_WITH(
@@ -956,33 +969,30 @@ ProcessGroupNCCL::ProcessGroupNCCL(
   desyncDebug_ = getCvarBool(TORCH_NCCL_DESYNC_DEBUG, false) ||
       (dist_debug_level_ >= DebugLevel::Detail);
   rethrowCUDAErrors_ = getCvarBool(TORCH_NCCL_RETHROW_CUDA_ERRORS, true);
-  // TODO, we should either deprecate TORCH_NCCL_DUMP_ON_TIMEOUT
-  // or change its name to reflect that dump happens on exception including
-  // both timeout and other errors.
-  dumpOnTimeoutOrEx_ = getCvarBool(TORCH_NCCL_DUMP_ON_TIMEOUT, true) ||
-      (dist_debug_level_ >= DebugLevel::Detail);
-  propagatePgError_ = getCvarBool(TORCH_NCCL_PROPAGATE_ERROR, false);
   // logging C++ stack isn't safe. Introduce a variable to control it.
   logCppStackOnUncleanShutdown_ =
       getCvarBool(TORCH_NCCL_LOG_CPP_STACK_ON_UNCLEAN_SHUTDOWN, true);
   enableNanCheck_ = getCvarBool(TORCH_NCCL_NAN_CHECK, false);
-  heartbeat_ = 1ULL;
-  monitorThreadEnabled_.store(getCvarBool(TORCH_NCCL_ENABLE_MONITORING, true));
   cudaEventCacheEnabled_.store(getCvarBool(TORCH_NCCL_CUDA_EVENT_CACHE, true));
-  heartbeatTimeoutInSec_ =
-      getCvarInt(TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC, 60 * 8 /*8 Mins*/);
-  waitTimeoutDumpInMilSec_ =
-      getCvarInt(TORCH_NCCL_WAIT_TIMEOUT_DUMP_MILSEC, 15 * 1000 /*15 Sec*/);
-  coordCheckIntervalMilSec_ = getCvarInt(TORCH_NCCL_COORD_CHECK_MILSEC, 1000);
   traceBufferSize_ = getCvarInt(TORCH_NCCL_TRACE_BUFFER_SIZE, 2000);
   enableCollectiveHashDebug_ = (dist_debug_level_ >= DebugLevel::Detail);
-  // store_ usually is wrapped with PrefixStore and the prefix is different
-  // across different ProcessGroupNCCL(PG) instances. We need to get the
-  // underlying non-PrefixStore for sharing global information shared across
-  // different PGs.
-  PrefixStore* prefixStore = dynamic_cast<PrefixStore*>(store_.get());
-  globalStore_ =
-      prefixStore ? prefixStore->getUnderlyingNonPrefixStore() : store_;
+  c10::call_once(initFlag_, [&]() {
+    heartbeat_ = 1ULL;
+    heartbeatTimeoutInSec_ =
+        getCvarInt(TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC, 60 * 8 /*8 Mins*/);
+    waitTimeoutDumpInMilSec_ =
+        getCvarInt(TORCH_NCCL_WAIT_TIMEOUT_DUMP_MILSEC, 15 * 1000 /*15 Sec*/);
+    coordCheckIntervalMilSec_ = getCvarInt(TORCH_NCCL_COORD_CHECK_MILSEC, 1000);
+    // TODO, we should either deprecate TORCH_NCCL_DUMP_ON_TIMEOUT
+    // or change its name to reflect that dump happens on exception including
+    // both timeout and other errors.
+    dumpOnTimeoutOrEx_ = getCvarBool(TORCH_NCCL_DUMP_ON_TIMEOUT, true) ||
+        (dist_debug_level_ >= DebugLevel::Detail);
+    propagatePgError_ = getCvarBool(TORCH_NCCL_PROPAGATE_ERROR, false);
+    watchdogHeartbeatMonitorEnabled_.store(
+        getCvarBool(TORCH_NCCL_ENABLE_MONITORING, true));
+    globalLogPrefix_ = c10::str("[Global Rank ", globalRank(), "] ");
+  });
 #ifdef ENABLE_NCCL_ERROR_CHECKING
   enableTiming_.store(
       getCvarBool(TORCH_NCCL_ENABLE_TIMING, false) || desyncDebug_);
@@ -1046,7 +1056,7 @@ ProcessGroupNCCL::ProcessGroupNCCL(
             << shouldAllCommunicatorsRegisterAllTensors()
 #endif // NCCL_HAS_COMM_REGISTER
             << ", TORCH_NCCL_ENABLE_MONITORING: "
-            << monitorThreadEnabled_.load()
+            << watchdogHeartbeatMonitorEnabled_.load()
             << ", TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC: " << heartbeatTimeoutInSec_
             << ", TORCH_NCCL_TRACE_BUFFER_SIZE: " << traceBufferSize_
             << ", TORCH_NCCL_COORD_CHECK_MILSEC: " << coordCheckIntervalMilSec_
@@ -1521,6 +1531,25 @@ void ProcessGroupNCCL::shutdown() {
   LOG(INFO) << logPrefix() << "Destroy complete.";
 }
 
+void ProcessGroupNCCL::startMonitorThread() {
+  static c10::once_flag startFlag;
+  c10::call_once(startFlag, [this]() {
+    ncclHeartbeatMonitorThread_ =
+        std::thread(&ProcessGroupNCCL::heartbeatMonitor, this);
+  });
+}
+
+void ProcessGroupNCCL::waitMonitorThread() {
+  static c10::once_flag shutdownFlag;
+  c10::call_once(shutdownFlag, [this]() {
+    if (ncclHeartbeatMonitorThread_.joinable()) {
+      ncclHeartbeatMonitorThread_.join();
+      LOG(INFO) << logPrefix()
+                << "ProcessGroupNCCL heart beat monitor thread joined.";
+    }
+  });
+}
+
 // NOLINTNEXTLINE(bugprone-exception-escape)
 ProcessGroupNCCL::~ProcessGroupNCCL() {
   LOG(INFO) << logPrefix() << "ProcessGroupNCCL destructor entered.";
@@ -1571,11 +1600,7 @@ ProcessGroupNCCL::~ProcessGroupNCCL() {
     ncclCommWatchdogThread_.join();
     LOG(INFO) << logPrefix() << "ProcessGroupNCCL watchdog thread joined.";
   }
-  if (ncclHeartbeatMonitorThread_.joinable()) {
-    ncclHeartbeatMonitorThread_.join();
-    LOG(INFO) << logPrefix()
-              << "ProcessGroupNCCL heart beat monitor thread joined.";
-  }
+  waitMonitorThread();
   if (onCompletionHookThread_.joinable()) {
     onCompletionHookThread_.join();
     LOG(INFO) << logPrefix()
@@ -1631,11 +1656,6 @@ std::string ProcessGroupNCCL::getNCCLWatchdogTimeoutErrorMsg(
       "Received a dump signal due to a collective timeout from ",
       extraMsg,
       " and we will try our best to dump the debug info. ",
-      "Last enqueued NCCL work: ",
-      pgStatus_->lastEnqueuedSeq,
-      ", last completed NCCL work: ",
-      pgStatus_->lastCompletedSeq,
-      ".",
       "This is most likely caused by incorrect usages of collectives, e.g., wrong ",
       "sizes used across ranks, the order of collectives is not same for all ranks ",
       "or the scheduled collective, for some reason, didn't run. Additionally, ",
@@ -1660,28 +1680,21 @@ void ProcessGroupNCCL::heartbeatMonitor() {
   c10::setThreadName("pt_nccl_heartbt");
 
   uint64_t heartBeatCounter = 0ULL;
+  bool watchdogThreadHang = false;
   std::string errorMsg;
   std::string exitReason;
-  bool checkDumpSignal = (dumpOnTimeoutOrEx_ && local_id_ == 0);
-  int monitorPollInterval = checkDumpSignal || propagatePgError_
-      ? coordCheckIntervalMilSec_
-      : heartbeatTimeoutInSec_ * 1000;
   auto lastTimePollStore = std::chrono::steady_clock::now();
   auto lastTimeHeartBeatCheck = std::chrono::steady_clock::now();
   std::optional<DumpPipe> dumpPipe = std::nullopt;
-  if (local_id_ == 0) {
-    // DumpPipe is one per-trainer process, and its convenient to name them
-    // after 'global' ranks in the system, So we assume processgroup (uid)==0 is
-    // the global PG and has globally unique rank ids across trainers.
-    dumpPipe.emplace(rank_);
-  }
+  // To use the pipe correctly, one needs to initiate the default PG first.
+  dumpPipe.emplace(globalRank());
   while (true) {
     // This won't have any lock since this lock is only used here.
     // Please be aware that mutex `monitorMutex_` should not be used
     // somewhere else to avoid the deadlock.
     std::unique_lock<std::mutex> lock(monitorMutex_);
     if (monitorWakeUpCV_.wait_for(
-            lock, std::chrono::milliseconds(monitorPollInterval), [&] {
+            lock, std::chrono::milliseconds(coordCheckIntervalMilSec_), [&] {
               return terminateHeartbeatMonitorThread_.load();
             })) {
       // For the normal complete or user interception, monitorWakeUpCV_
@@ -1690,11 +1703,6 @@ void ProcessGroupNCCL::heartbeatMonitor() {
     }
     auto currentTime = std::chrono::steady_clock::now();
 
-    if (propagatePgError_) {
-      // Check and set remote error if it has not been set before
-      checkAndSetRemoteError();
-    }
-
     // We put extra functionality in the thread for the default PG (aka,
     // local_id_=0) because the signal is same across different PGs. We only
     // need to run once per process to avoid duplicate things performed in too
@@ -1702,7 +1710,7 @@ void ProcessGroupNCCL::heartbeatMonitor() {
     // TCPStore periodically to see if any PG on any rank observed a timeout and
     // signaled peers to dump debugging info, and we avoid hammering the
     // TCPStore from all PGs on the same rank.
-    if (checkDumpSignal) {
+    if (dumpOnTimeoutOrEx_) {
       // There are two scenarios where monitor thread will dump on timeout:
       // 1. The current rank is the first to observe a timeout in watchdog.
       // (shouldDump_ was set to true by the watchdog thread).
@@ -1724,7 +1732,7 @@ void ProcessGroupNCCL::heartbeatMonitor() {
         lastTimePollStore = currentTime;
         auto handleError = [&](const std::string& errorMessage) {
           LOG(WARNING)
-              << logPrefix()
+              << globalLogPrefix()
               << "Failed to check the \"should dump\" flag on TCPStore, "
               << "(maybe TCPStore server has shut down too early), with error: "
               << errorMessage;
@@ -1736,7 +1744,7 @@ void ProcessGroupNCCL::heartbeatMonitor() {
         bool checkExceptionDump = false;
         try {
           checkExceptionDump =
-              globalStore_->check({std::string(kStoreDumpKey)});
+              globalStore()->check({std::string(kStoreDumpKey)});
         } catch (const c10::DistNetworkError& e) {
           handleError(e.msg());
         } catch (const std::exception& e) {
@@ -1747,12 +1755,12 @@ void ProcessGroupNCCL::heartbeatMonitor() {
           int timeOutRank = -1;
           if (!shouldDump_.load()) {
             LOG(ERROR)
-                << logPrefix()
+                << globalLogPrefix()
                 << "Observed flight recorder dump signal from another rank via TCPStore.";
           }
           shouldDump_.store(true);
           try {
-            auto vec = globalStore_->get(std::string(kStoreDumpKey));
+            auto vec = globalStore()->get(std::string(kStoreDumpKey));
             TORCH_CHECK_WITH(
                 DistBackendError,
                 vec.size() == sizeof(int),
@@ -1782,7 +1790,7 @@ void ProcessGroupNCCL::heartbeatMonitor() {
         shouldDump_.store(true);
         // Watchdog heartbeat timeout.
         errorMsg = c10::str(
-            logPrefix(),
+            globalLogPrefix(),
             "ProcessGroupNCCL's watchdog got stuck for ",
             heartbeatTimeoutInSec_,
             " seconds without making progress in monitoring enqueued collectives. ",
@@ -1818,7 +1826,7 @@ void ProcessGroupNCCL::heartbeatMonitor() {
   //    TORCH_NCCL_LOG_CPP_STACK_ON_UNCLEAN_SHUTDOWN=0).
 
   // Dump the nccl trace (flight recorder).
-  if (checkDumpSignal && shouldDump_.load()) {
+  if (dumpOnTimeoutOrEx_ && shouldDump_.load()) {
     // Store debug info to storage if no other thread does it. (By default to
     // local disk)
     bool dumpStackTrace = true;
@@ -1844,7 +1852,7 @@ void ProcessGroupNCCL::heartbeatMonitor() {
 
       if (complete) {
         LOG(INFO)
-            << logPrefix()
+            << globalLogPrefix()
             << "Finished flight recorder successfully. Output can be analyzed using the fr_trace script.";
         if (i > 0) {
           debugLog.strings["exception_msg"] = "Dump with stack trace failed.";
@@ -1872,22 +1880,23 @@ void ProcessGroupNCCL::heartbeatMonitor() {
           futStatus != std::future_status::deferred,
           "Expected the future to have been launched eagerly.");
       LOG(ERROR)
-          << logPrefix()
+          << globalLogPrefix()
           << "Could not acquire GIL within 300 ms on exit, possible GIL induced hang";
     }
   } else {
     VLOG(2)
-        << logPrefix()
+        << globalLogPrefix()
         << "GIL checker was not registered, perhaps this is a no-python build?";
   }
 
   // Dump the c++ stacktraces.
   auto& cpp_dumper = get_cpp_trace_dumper();
   if (logCppStackOnUncleanShutdown_ && cpp_dumper.has_value()) {
-    LOG(INFO) << logPrefix() << "Dumping c++ stacktraces:";
-    cpp_dumper.value()(
-        [&](const std::string& line) { LOG(INFO) << logPrefix() << line; });
-    LOG(INFO) << logPrefix() << "Finished c++ stacktraces dump.";
+    LOG(INFO) << globalLogPrefix() << "Dumping c++ stacktraces:";
+    cpp_dumper.value()([&](const std::string& line) {
+      LOG(INFO) << globalLogPrefix() << line;
+    });
+    LOG(INFO) << globalLogPrefix() << "Finished c++ stacktraces dump.";
   }
 
   // There are two possible cases for the watchdog thread exit:
@@ -1898,13 +1907,15 @@ void ProcessGroupNCCL::heartbeatMonitor() {
   // Case two: desync might be slow or get stuck. Or we get stuck in
   // destructors, we will sleep for some time before calling std::abort() to
   // kill the whole process.
-  if ((terminateProcessGroup_.load() || desyncDebug_ || shouldDump_.load()) &&
-      !terminateHeartbeatMonitorThread_.load()) {
-    // Leave another two mins for desync report generation or process group
-    // destroy.
+  auto currentTime = std::chrono::steady_clock::now();
+  if (!watchdogThreadHang && !terminateHeartbeatMonitorThread_.load() &&
+      (computeDeltaMS(lastTimeHeartBeatCheck, currentTime) <
+       heartbeatTimeoutInSec_ * 1000l)) {
     std::this_thread::sleep_for(std::chrono::seconds(heartbeatTimeoutInSec_));
-    LOG(INFO) << logPrefix() << "slept for " << heartbeatTimeoutInSec_
-              << " waiting for desync report or process group destroy.";
+    LOG(INFO)
+        << globalLogPrefix() << "slept for " << heartbeatTimeoutInSec_
+        << " because we want to wait longer to verify there is indeed a watchdog hang.";
+    watchdogThreadHang = (heartbeat_.load() == heartBeatCounter);
   }
 
   // At this point, we either already sleep for another `heartbeatTimeoutInSec_`
@@ -1917,19 +1928,19 @@ void ProcessGroupNCCL::heartbeatMonitor() {
   // check the return value here.  We mainly use a future so we can exit early
   // if done.
 
-  if (!terminateHeartbeatMonitorThread_.load()) {
+  if (!terminateHeartbeatMonitorThread_.load() && watchdogThreadHang) {
     // Create a error message reported from MonitorThread, so
     // we throw exception and make the whole process to be killed.
     // TODO(fduwjj): After having a hang debug wiki, we need to update the wiki
     // url here.
-    if (monitorThreadEnabled_.load()) {
+    if (watchdogHeartbeatMonitorEnabled_.load()) {
       terminateProcess(getNCCLWatchdogTimeoutExitMsg(exitReason));
     } else {
       // Ideally we want to merge this one with the above one, but we are going
       // to remove the kill switch for monitor thread soon, so we keep this one
       // for now.
       LOG(ERROR)
-          << logPrefix()
+          << globalLogPrefix()
           << "ProcessGroupNCCL monitor thread is disabled, but would have terminated the process"
           << "after attempting to dump debug info, due to " << exitReason
           << ".";
@@ -1942,8 +1953,7 @@ void ProcessGroupNCCL::ncclCommWatchdog() {
 
   try {
     VLOG(2) << logPrefix() << "Process group watchdog thread started!";
-    ncclHeartbeatMonitorThread_ =
-        std::thread(&ProcessGroupNCCL::heartbeatMonitor, this);
+    startMonitorThread();
     watchdogHandler();
     VLOG(2) << logPrefix()
             << "Process group watchdog thread terminated normally";
@@ -2098,9 +2108,18 @@ const std::string& ProcessGroupNCCL::logPrefix() const {
   return logPrefix_;
 }
 
+const std::string& ProcessGroupNCCL::globalLogPrefix() {
+  return globalLogPrefix_;
+}
+
 const int& ProcessGroupNCCL::globalRank() const {
   static int globalRank = rank_;
   return globalRank;
+}
+
+const c10::intrusive_ptr<Store>& ProcessGroupNCCL::globalStore() const {
+  static c10::intrusive_ptr<Store> globalStore = store_;
+  return globalStore;
 }
 
 const std::vector<uint64_t>& ProcessGroupNCCL::groupRanks() const {
@@ -2182,7 +2201,8 @@ int ProcessGroupNCCL::getSignalSrcRank(
 
 void ProcessGroupNCCL::broadcastDumpSignal() {
   // broadcast dump signal to all other global ranks.
-  broadcastSignal(globalStore_, std::string(kStoreDumpKey), globalRank());
+  auto global_store = globalStore();
+  broadcastSignal(global_store, std::string(kStoreDumpKey), globalRank());
   // signal the local rank to start dumping
   if (!shouldDump_.load()) {
     LOG(ERROR) << logPrefix() << "First PG on this rank to signal dumping.";
@@ -2298,6 +2318,11 @@ void ProcessGroupNCCL::watchdogHandler() {
       data.strings["pg_desc"] = pg_desc_;
       logger->log(data);
       lastStatusUpdateTime = std::chrono::steady_clock::now();
+    }
+
+    if (propagatePgError_) {
+      // Check and set remote error if it has not been set before
+      checkAndSetRemoteError();
     }
 
     for (auto it = workMetaList_.begin(); it != workMetaList_.end();

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -1035,11 +1035,16 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // Returns the unique prefix created in createLogPrefix
   const std::string& logPrefix() const;
 
+  // Returns the global log prefix, which is the same for all process groups
+  static const std::string& globalLogPrefix();
+
   // Returns the global rank of the device. This function assumes that users
   // always create a default global process group(PG) which includes all
   // devices. It is called in the constructor of ProcessGroupNCCL, so it always
   // return the rank_ of the the very first PG created, aka, default global PG.
   const int& globalRank() const;
+
+  const c10::intrusive_ptr<Store>& globalStore() const;
 
   // Returns the global ranks of a PG.
   const std::vector<uint64_t>& groupRanks() const;
@@ -1096,17 +1101,16 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // the device id to operate on.
   c10::DeviceIndex guessDeviceId() const;
 
+  void startMonitorThread();
+
+  void waitMonitorThread();
+
   static const int64_t kWatchdogThreadSleepMillis;
 
   // The store is used to broadcast the NCCL unique ID of rank 0. This store
   // comes with prefix and it is different across ProcessGroup NCCL instances
   // (aka, different ProcessGroups).
   c10::intrusive_ptr<Store> store_;
-
-  // Reference to the store without prefix so that keys are same across all
-  // ProcessGroup NCCL instances and (key, value) pairs written to the store are
-  // global.
-  c10::intrusive_ptr<Store> globalStore_;
 
   // The lock which protects the write/read of
   // ephemeralTimeoutActive_/ephemeralTimeoutInflight_.
@@ -1168,24 +1172,26 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // Mutex to guard maps like devNCCLCommMap_.
   std::mutex mutex_;
 
+  static c10::once_flag initFlag_;
+
   // Heartbeat of watchdog thread.
-  std::atomic_uint64_t heartbeat_{};
+  static std::atomic_uint64_t heartbeat_;
 
   // The time interval used for deciding whether there is no watchdog heartbeat.
-  int heartbeatTimeoutInSec_;
+  static int heartbeatTimeoutInSec_;
 
   // timeout for the dump to finish.
-  int waitTimeoutDumpInMilSec_;
+  static int waitTimeoutDumpInMilSec_;
 
   // Interval of check coordinated signals in ProcessGroupNCCL from other ranks
   // e.g., trigger the dump of the debugging info for timeout when notified.
-  int coordCheckIntervalMilSec_;
+  static int coordCheckIntervalMilSec_;
 
   // Size of ring buffer where we store NCCL Traces for debugging.
   int traceBufferSize_;
 
   // We gate the heartbeat monitor thread so that we can roll it out gradually.
-  std::atomic<bool> monitorThreadEnabled_{};
+  static std::atomic<bool> watchdogHeartbeatMonitorEnabled_;
 
   // We gate the cudaEventCache so that we can roll it out gradually.
   std::atomic<bool> cudaEventCacheEnabled_{};
@@ -1193,7 +1199,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // Monitor thread which checks the heartbeat of Watchdog thread.
   // If the monitor thread finds there is no heartbeat, it will dump debug info
   // and then kill the watchdog thread to avoid hang.
-  std::thread ncclHeartbeatMonitorThread_;
+  static std::thread ncclHeartbeatMonitorThread_;
 
   // Watchdog thread which looks for errors on the cached NCCL communicators.
   std::thread ncclCommWatchdogThread_;
@@ -1204,7 +1210,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   std::atomic<bool> terminateProcessGroup_;
 
   // Whether or not we should terminate the heartbeat monitoring threads.
-  std::atomic<bool> terminateHeartbeatMonitorThread_;
+  static std::atomic<bool> terminateHeartbeatMonitorThread_;
 
   // Whether there are hooks pending to be fired
   std::atomic<bool> hasPendingHooks_{};
@@ -1226,7 +1232,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   std::mutex workMetaListMutex_;
 
   // Mutex to Guard monitorWakeUpCV_
-  std::mutex monitorMutex_;
+  static std::mutex monitorMutex_;
 
   bool writeDebugInfo_ = false;
 
@@ -1234,9 +1240,9 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   std::condition_variable workMetaListCV_;
 
   // Condition Variable for monitor thread to wake up early
-  std::condition_variable monitorWakeUpCV_;
+  static std::condition_variable monitorWakeUpCV_;
 
-  // Vector to Store WorkNCCL pointers
+  // Vector to store WorkNCCL pointers
   std::list<ProcessGroupNCCL::WorkNCCL> workMetaList_;
 
   std::chrono::time_point<std::chrono::steady_clock> lastWorkListUpdateTime_;
@@ -1304,11 +1310,11 @@ class TORCH_API ProcessGroupNCCL : public Backend {
 
   // Whether or not to dump debug info on exception including both watchdog
   // timeout and nccl errors.
-  bool dumpOnTimeoutOrEx_;
+  static bool dumpOnTimeoutOrEx_;
 
   // Whether or not to propagate detected errors to all ranks in the same PG
   // through TCPStore.
-  bool propagatePgError_;
+  static bool propagatePgError_;
 
   // Whether or not to sleep after an exception is thrown in the watchdog.
   bool sleepAfterException_{};
@@ -1357,6 +1363,8 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   size_t local_id_;
 
   std::string logPrefix_;
+
+  static std::string globalLogPrefix_;
 
   c10::intrusive_ptr<intra_node_comm::IntraNodeComm> intraNodeComm_;
 

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -1314,7 +1314,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
 
   // Whether or not to propagate detected errors to all ranks in the same PG
   // through TCPStore.
-  static bool propagatePgError_;
+  bool propagatePgError_;
 
   // Whether or not to sleep after an exception is thrown in the watchdog.
   bool sleepAfterException_{};


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #153668

This is the start of a series of efforts to consolidating auxiliary threads in PGNCCL, aka watchdog and heartbeat_monitoring threads. Right now we launch these two threads per PG instances, i.e., if users create hundred or thousand instances of PG or subPGs, we will end up with that twice many side threads which is not efficient. We have a RFC to consolidate them (https://github.com/pytorch/pytorch/issues/146956). Right now both threads are assigned with so many functionalities so it is hard to do the consolidations in one shot, we will try to split it into at least two steps (PRs) to make it easier to test and review.

First of all, we start with the heartbeat monitoring thread which is relatively lightweight and conceptually easier to consolidate. What we did in this PR:
1. Make the heartbeat thread class (static) instead of launching it per PGNCCL instance. We make all the logic or variables used in this thread either global or static so that it does not call instance specific API.
2. Remove the dependency on PGStatus which is PG instance specific. (We need to do more around PG Status if we want to consolidate watchdog thread later but it is out of the scope of this PR.)
3. Move the error propagation check to watchdog thread which is more relevant. This is totally fine since we rolled out EventCache out fully so watchdog hang is rare now.

Today there are two major functions inside heartbeat monitoring thread today: 
1. Check the heartbeat of watchdog thread every 8 minutes, we make the heartbeat of watchdog global instead of instance specific. If there are watchdog hang, it should be global. (I am open to better solutions to this one).
2. We check TCPStore every 30 sec to see if any watchdog timeout happens on other ranks, if so we will initiate a dump signal on the current rank as well. 

Previously we only let the thread on the default PG instance to do #2, now with this consolidation, we do FR dump signal every 30 secs and heartbeat check every 8 mins at the same time. If we break the polling loop early we will wait until the full heartbeat timeout (8 mins) before killing the whole program (when we first built heartbeat thread we want to directly kill the program when the watchdog or the whole program hang at CudaEvent destory or NCCL Abort).

cc @H-Huang @awgu @wanchaol @fegin @wz337 @wconstab @d4l3k 