### PR TITLE
[MTIA ATen Backend][1/n] Migrate "_unsafe_view" and "view" ops from out-of-tree to pytorch in-tree

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -8120,7 +8120,7 @@
   device_check: NoCheck
   device_guard: False
   dispatch:
-    ZeroTensor, Meta, CPU, CUDA, QuantizedCPU, QuantizedCUDA, MPS: view
+    ZeroTensor, Meta, CPU, CUDA, QuantizedCPU, QuantizedCUDA, MPS, MTIA: view
     MkldnnCPU: mkldnn_view
     NestedTensorCPU, NestedTensorHPU, NestedTensorCUDA: view_nested
   tags: core

--- a/build.bzl
+++ b/build.bzl
@@ -79,6 +79,8 @@ def define_targets(rules):
         aten_ufunc_generated_cuda_sources()
     )
 
+    gen_aten_outs_mtia = GENERATED_H_MTIA + GENERATED_CPP_MTIA
+
     gen_aten_outs = (
         GENERATED_H + GENERATED_H_CORE +
         GENERATED_CPP + GENERATED_CPP_CORE +
@@ -86,7 +88,7 @@ def define_targets(rules):
         aten_ufunc_generated_cpu_sources() +
         aten_ufunc_generated_cpu_kernel_sources() + [
             "Declarations.yaml",
-        ] + gen_aten_outs_cuda
+        ] + gen_aten_outs_cuda + gen_aten_outs_mtia
     )
 
     rules.genrule(
@@ -206,6 +208,15 @@ GENERATED_CPP_CUDA = [
     "RegisterSparseCUDA_0.cpp",
     "RegisterSparseCsrCUDA_0.cpp",
     "RegisterQuantizedCUDA_0.cpp",
+]
+
+GENERATED_H_MTIA = [
+    "MTIAFunctions.h",
+    "MTIAFunctions_inl.h",
+]
+
+GENERATED_CPP_MTIA = [
+    "RegisterMTIA_0.cpp",
 ]
 
 GENERATED_CPP = [

--- a/torchgen/gen.py
+++ b/torchgen/gen.py
@@ -2977,6 +2977,7 @@ def main() -> None:
         DispatchKey.CompositeExplicitAutograd,
         DispatchKey.CompositeExplicitAutogradNonFunctional,
         DispatchKey.Meta,
+        DispatchKey.MTIA,
     }
 
     aoti_backends = {

--- a/torchgen/model.py
+++ b/torchgen/model.py
@@ -305,6 +305,7 @@ dispatch_keys = [
     DispatchKey.QuantizedMeta,
     DispatchKey.NestedTensorMeta,
     DispatchKey.ZeroTensor,
+    DispatchKey.MTIA,
 ]
 
 


### PR DESCRIPTION
Summary:
# Context
The MTIA New Aten Backend work is essentially to move MTIA operators from pytorch out-of-tree to in-tree, with following benefits:
1. Avoid duplicate code copied from pytorch, e.g. view ops implementation, util functions.
2. Utilize TensorIterator and structured kernel codegen, avoid manual implementation of broadcasting, dtype casting, asserting, etc.
3. Eliminate MTIA's own codegen flow, which is unnecessary complexity.
4. Overall make MTIA's aten backend more pytorch native.

Differential Revision: D74672464




cc @egienvalue