### PR TITLE
[BE] Use latest mkl-include and mkl-devel on Windows CI

### DIFF
--- a/.ci/pytorch/win-test-helpers/build_pytorch.bat
+++ b/.ci/pytorch/win-test-helpers/build_pytorch.bat
@@ -42,7 +42,7 @@ call choco upgrade -y cmake --no-progress --installargs 'ADD_CMAKE_TO_PATH=Syste
 if errorlevel 1 goto fail
 if not errorlevel 0 goto fail
 
-call pip install mkl-include==2021.4.0 mkl-devel==2021.4.0
+call pip install mkl-include==2025.1.0 mkl-devel==2025.1.0
 if errorlevel 1 goto fail
 if not errorlevel 0 goto fail
 


### PR DESCRIPTION
These two packages provide MKL libraries for MKL integration tests or MAGMA fallback in Windows CI jobs, see `` Note [Extra MKL symbols for MAGMA in torch_cpu]``.
