### PR TITLE
Add missing arg descriptions for class RMSNorm(Module)

### DIFF
--- a/torch/nn/modules/_nn_docs.py
+++ b/torch/nn/modules/_nn_docs.py
@@ -1,5 +1,12 @@
+# mypy: allow-untyped-defs
+"""Adds docstrings to functions defined in the torch.nn module."""
+from torch._torch_docs import parse_kwargs
+
+
 # Common parameter documentation for nn modules
-COMMON_ARGS = """
+common_args = parse_kwargs(
+    """
     device: the device on which the parameters will be allocated. Default: None
     dtype: the data type of the parameters. Default: None
 """
+)

--- a/torch/nn/modules/_nn_docs.py
+++ b/torch/nn/modules/_nn_docs.py
@@ -1,0 +1,5 @@
+# Common parameter documentation for nn modules
+COMMON_ARGS = """
+    device: the device on which the parameters will be allocated. Default: None
+    dtype: the data type of the parameters. Default: None
+"""

--- a/torch/nn/modules/_nn_docs.py
+++ b/torch/nn/modules/_nn_docs.py
@@ -10,3 +10,16 @@ common_args = parse_kwargs(
     dtype: the data type of the parameters. Default: None
 """
 )
+
+layernorm_args = parse_kwargs(
+    """
+    normalized_shape: input shape from an expected input of size
+        [* x normalized_shape[0] x normalized_shape[1] x ... x normalized_shape[-1]]
+        If a single integer is used, it is treated as a singleton list, and this module will
+        normalize over the last dimension which is expected to be of that specific size.
+    eps: a value added to the denominator for numerical stability. Default: 1e-5
+    elementwise_affine: a boolean value that when set to ``True``, this module
+        has learnable per-element affine parameters initialized to ones (for weights)
+        and zeros (for biases). Default: ``True``.
+"""
+)

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -4,9 +4,9 @@ from typing import Optional, Union
 
 import torch
 from torch import Size, Tensor
-from torch.nn import functional as F, init
-from torch.nn.modules._nn_docs import layernorm_args, common_args
 from torch._C import _add_docstr as add_docstr
+from torch.nn import functional as F, init
+from torch.nn.modules._nn_docs import common_args, layernorm_args
 from torch.nn.parameter import Parameter
 
 from ._functions import CrossMapLRN2d as _cross_map_lrn2d
@@ -125,13 +125,12 @@ class LayerNorm(Module):
         {layernorm_args}
         {common_args}
 
-
     Attributes:
         weight: the learnable weights of the module of shape
-            :math:`\text{{normalized\_shape}}` when :attr:`elementwise_affine` is set to ``True``.
+            :math:`\\text{{normalized\\_shape}}` when :attr:`elementwise_affine` is set to ``True``.
             The values are initialized to 1.
         bias:   the learnable bias of the module of shape
-                :math:`\text{{normalized\_shape}}` when :attr:`elementwise_affine` is set to ``True``.
+                :math:`\\text{{normalized\\_shape}}` when :attr:`elementwise_affine` is set to ``True``.
                 The values are initialized to 0.
 
     Shape:
@@ -159,8 +158,7 @@ class LayerNorm(Module):
         :scale: 50 %
 
     """.format(
-        layernorm_args=layernorm_args.__doc__,
-        common_args=common_args.__doc__
+        layernorm_args=layernorm_args.__doc__, common_args=common_args.__doc__
     )
 
     __constants__ = ["normalized_shape", "eps", "elementwise_affine"]

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -94,7 +94,7 @@ _shape_t = Union[int, list[int], Size]
 
 
 class LayerNorm(Module):
-    r"""Applies Layer Normalization over a mini-batch of inputs.
+    __doc__ = r"""Applies Layer Normalization over a mini-batch of inputs.
 
     This layer implements the operation as described in
     the paper `Layer Normalization <https://arxiv.org/abs/1607.06450>`__

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -4,7 +4,6 @@ from typing import Optional, Union
 
 import torch
 from torch import Size, Tensor
-from torch._C import _add_docstr
 from torch.nn import functional as F, init
 from torch.nn.modules._nn_docs import common_args
 from torch.nn.parameter import Parameter
@@ -227,9 +226,6 @@ class LayerNorm(Module):
             "{normalized_shape}, eps={eps}, "
             "elementwise_affine={elementwise_affine}".format(**self.__dict__)
         )
-
-
-LayerNorm.__doc__ = LayerNorm.__doc__.format(**common_args)
 
 
 class GroupNorm(Module):

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -346,6 +346,8 @@ class RMSNorm(Module):
         eps: a value added to the denominator for numerical stability. Default: :func:`torch.finfo(x.dtype).eps`
         elementwise_affine: a boolean value that when set to ``True``, this module
             has learnable per-element affine parameters initialized to ones (for weights). Default: ``True``.
+        device: the device on which the parameters will be allocated. Default: None.
+        dtype: the data type of the parameters. Default: None.
 
     Shape:
         - Input: :math:`(N, *)`
@@ -358,6 +360,7 @@ class RMSNorm(Module):
         >>> rms_norm(input)
 
     """
+
     __constants__ = ["normalized_shape", "eps", "elementwise_affine"]
     normalized_shape: tuple[int, ...]
     eps: Optional[float]

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -8,6 +8,7 @@ from torch.nn import functional as F, init
 from torch.nn.parameter import Parameter
 
 from ._functions import CrossMapLRN2d as _cross_map_lrn2d
+from ._nn_docs import COMMON_ARGS
 from .module import Module
 
 
@@ -134,9 +135,6 @@ class LayerNorm(Module):
             and zeros (for biases). Default: ``True``.
         bias: If set to ``False``, the layer will not learn an additive bias (only relevant if
             :attr:`elementwise_affine` is ``True``). Default: ``True``.
-        device: the device on which the parameters will be allocated. Default: None
-        dtype: the data type of the parameters. Default: None
-
 
     Attributes:
         weight: the learnable weights of the module of shape
@@ -170,7 +168,9 @@ class LayerNorm(Module):
     .. image:: ../_static/img/nn/layer_norm.jpg
         :scale: 50 %
 
-    """
+    """.format(
+        COMMON_ARGS
+    )
 
     __constants__ = ["normalized_shape", "eps", "elementwise_affine"]
     normalized_shape: tuple[int, ...]
@@ -272,7 +272,9 @@ class GroupNorm(Module):
         >>> m = nn.GroupNorm(1, 6)
         >>> # Activating the module
         >>> output = m(input)
-    """
+    """.format(
+        COMMON_ARGS
+    )
 
     __constants__ = ["num_groups", "num_channels", "eps", "affine"]
     num_groups: int
@@ -349,8 +351,6 @@ class RMSNorm(Module):
         eps: a value added to the denominator for numerical stability. Default: :func:`torch.finfo(x.dtype).eps`
         elementwise_affine: a boolean value that when set to ``True``, this module
             has learnable per-element affine parameters initialized to ones (for weights). Default: ``True``.
-        device: the device on which the parameters will be allocated. Default: None.
-        dtype: the data type of the parameters. Default: None.
 
     Shape:
         - Input: :math:`(N, *)`
@@ -362,7 +362,9 @@ class RMSNorm(Module):
         >>> input = torch.randn(2, 2, 3)
         >>> rms_norm(input)
 
-    """
+    """.format(
+        COMMON_ARGS
+    )
 
     __constants__ = ["normalized_shape", "eps", "elementwise_affine"]
     normalized_shape: tuple[int, ...]

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -136,6 +136,8 @@ class LayerNorm(Module):
             and zeros (for biases). Default: ``True``.
         bias: If set to ``False``, the layer will not learn an additive bias (only relevant if
             :attr:`elementwise_affine` is ``True``). Default: ``True``.
+        {device}
+        {dtype}
 
     Attributes:
         weight: the learnable weights of the module of shape
@@ -227,7 +229,7 @@ class LayerNorm(Module):
         )
 
 
-add_docstr(LayerNorm, LayerNorm.__doc__.format(**common_args))
+LayerNorm.__doc__ = LayerNorm.__doc__.format(**common_args)
 
 
 class GroupNorm(Module):

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -4,11 +4,12 @@ from typing import Optional, Union
 
 import torch
 from torch import Size, Tensor
+from torch._C import _add_docstr
 from torch.nn import functional as F, init
+from torch.nn.modules._nn_docs import common_args
 from torch.nn.parameter import Parameter
 
 from ._functions import CrossMapLRN2d as _cross_map_lrn2d
-from ._nn_docs import COMMON_ARGS
 from .module import Module
 
 
@@ -168,9 +169,7 @@ class LayerNorm(Module):
     .. image:: ../_static/img/nn/layer_norm.jpg
         :scale: 50 %
 
-    """.format(
-        COMMON_ARGS
-    )
+    """
 
     __constants__ = ["normalized_shape", "eps", "elementwise_affine"]
     normalized_shape: tuple[int, ...]
@@ -228,6 +227,9 @@ class LayerNorm(Module):
         )
 
 
+add_docstr(LayerNorm, LayerNorm.__doc__.format(**common_args))
+
+
 class GroupNorm(Module):
     r"""Applies Group Normalization over a mini-batch of inputs.
 
@@ -272,9 +274,7 @@ class GroupNorm(Module):
         >>> m = nn.GroupNorm(1, 6)
         >>> # Activating the module
         >>> output = m(input)
-    """.format(
-        COMMON_ARGS
-    )
+    """
 
     __constants__ = ["num_groups", "num_channels", "eps", "affine"]
     num_groups: int
@@ -362,9 +362,7 @@ class RMSNorm(Module):
         >>> input = torch.randn(2, 2, 3)
         >>> rms_norm(input)
 
-    """.format(
-        COMMON_ARGS
-    )
+    """
 
     __constants__ = ["normalized_shape", "eps", "elementwise_affine"]
     normalized_shape: tuple[int, ...]

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -134,6 +134,9 @@ class LayerNorm(Module):
             and zeros (for biases). Default: ``True``.
         bias: If set to ``False``, the layer will not learn an additive bias (only relevant if
             :attr:`elementwise_affine` is ``True``). Default: ``True``.
+        device: the device on which the parameters will be allocated. Default: None
+        dtype: the data type of the parameters. Default: None
+
 
     Attributes:
         weight: the learnable weights of the module of shape

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -100,7 +100,7 @@ class LayerNorm(Module):
     the paper `Layer Normalization <https://arxiv.org/abs/1607.06450>`__
 
     .. math::
-        y = \frac{{x - \mathrm{{E}}[x]}}{{ \sqrt{{\mathrm{{Var}}[x] + \epsilon}} }} * \gamma + \beta
+        y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
 
     The mean and standard-deviation are calculated over the last `D` dimensions, where `D`
     is the dimension of :attr:`normalized_shape`. For example, if :attr:`normalized_shape`

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -159,7 +159,11 @@ class LayerNorm(Module):
     .. image:: ../_static/img/nn/layer_norm.jpg
         :scale: 50 %
 
-    """
+    """.format(
+        layernorm_args=layernorm_args.__doc__,
+        device=common_args.__doc__.split("device:")[1].split("dtype:")[0],
+        dtype=common_args.__doc__.split("dtype:")[1]
+    )
 
     __constants__ = ["normalized_shape", "eps", "elementwise_affine"]
     normalized_shape: tuple[int, ...]
@@ -216,8 +220,6 @@ class LayerNorm(Module):
             "elementwise_affine={elementwise_affine}".format(**self.__dict__)
         )
 
-docstring = layernorm_args.__doc__ + common_args.__doc__
-add_docstr(LayerNorm, docstring)
 
 class GroupNorm(Module):
     r"""Applies Group Normalization over a mini-batch of inputs.

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -100,7 +100,8 @@ class LayerNorm(Module):
     the paper `Layer Normalization <https://arxiv.org/abs/1607.06450>`__
 
     .. math::
-        y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
+        y = \frac{{x - \mathrm{{E}}[x]}}{{ \sqrt{{\mathrm{{Var}}[x] + \epsilon}} }} * \gamma + \beta
+
 
     The mean and standard-deviation are calculated over the last `D` dimensions, where `D`
     is the dimension of :attr:`normalized_shape`. For example, if :attr:`normalized_shape`
@@ -136,8 +137,7 @@ class LayerNorm(Module):
             and zeros (for biases). Default: ``True``.
         bias: If set to ``False``, the layer will not learn an additive bias (only relevant if
             :attr:`elementwise_affine` is ``True``). Default: ``True``.
-        {device}
-        {dtype}
+
 
     Attributes:
         weight: the learnable weights of the module of shape
@@ -229,7 +229,6 @@ class LayerNorm(Module):
         )
 
 docstr = LayerNorm.__doc__.format(**common_args)
-
 add_docstr(LayerNorm, docstr)
 
 class GroupNorm(Module):

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -229,6 +229,7 @@ class LayerNorm(Module):
         )
 
 docstr = LayerNorm.__doc__.format(**common_args)
+
 add_docstr(LayerNorm, docstr)
 
 class GroupNorm(Module):

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -100,7 +100,7 @@ class LayerNorm(Module):
     the paper `Layer Normalization <https://arxiv.org/abs/1607.06450>`__
 
     .. math::
-        y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
+        y = \frac{{x - \mathrm{{E}}[x]}}{{ \sqrt{{\mathrm{{Var}}[x] + \epsilon}} }} * \gamma + \beta
 
     The mean and standard-deviation are calculated over the last `D` dimensions, where `D`
     is the dimension of :attr:`normalized_shape`. For example, if :attr:`normalized_shape`

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -227,8 +227,9 @@ class LayerNorm(Module):
             "{normalized_shape}, eps={eps}, "
             "elementwise_affine={elementwise_affine}".format(**self.__dict__)
         )
-add_docstr(LayerNorm, LayerNorm.__doc__.format(**common_args))
 
+docstr = LayerNorm.__doc__.format(**common_args)
+add_docstr(LayerNorm, docstr)
 
 class GroupNorm(Module):
     r"""Applies Group Normalization over a mini-batch of inputs.

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -6,6 +6,7 @@ import torch
 from torch import Size, Tensor
 from torch.nn import functional as F, init
 from torch.nn.modules._nn_docs import common_args
+from torch._C import _add_docstr as add_docstr
 from torch.nn.parameter import Parameter
 
 from ._functions import CrossMapLRN2d as _cross_map_lrn2d
@@ -226,6 +227,7 @@ class LayerNorm(Module):
             "{normalized_shape}, eps={eps}, "
             "elementwise_affine={elementwise_affine}".format(**self.__dict__)
         )
+add_docstr(LayerNorm, LayerNorm.__doc__.format(**common_args))
 
 
 class GroupNorm(Module):

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -126,8 +126,8 @@ class LayerNorm(Module):
             of size
 
             .. math::
-                [* \times \text{normalized\_shape}[0] \times \text{normalized\_shape}[1]
-                    \times \ldots \times \text{normalized\_shape}[-1]]
+                [* \times \text{{normalized\_shape}}[0] \times \text{{normalized\_shape}}[1]
+                    \times \ldots \times \text{{normalized\_shape}}[-1]]
 
             If a single integer is used, it is treated as a singleton list, and this module will
             normalize over the last dimension which is expected to be of that specific size.
@@ -137,14 +137,16 @@ class LayerNorm(Module):
             and zeros (for biases). Default: ``True``.
         bias: If set to ``False``, the layer will not learn an additive bias (only relevant if
             :attr:`elementwise_affine` is ``True``). Default: ``True``.
+            {device}
+            {dtype}
 
 
     Attributes:
         weight: the learnable weights of the module of shape
-            :math:`\text{normalized\_shape}` when :attr:`elementwise_affine` is set to ``True``.
+            :math:`\text{{normalized\_shape}}` when :attr:`elementwise_affine` is set to ``True``.
             The values are initialized to 1.
         bias:   the learnable bias of the module of shape
-                :math:`\text{normalized\_shape}` when :attr:`elementwise_affine` is set to ``True``.
+                :math:`\text{{normalized\_shape}}` when :attr:`elementwise_affine` is set to ``True``.
                 The values are initialized to 0.
 
     Shape:
@@ -331,8 +333,8 @@ class RMSNorm(Module):
     the paper `Root Mean Square Layer Normalization <https://arxiv.org/pdf/1910.07467.pdf>`__
 
     .. math::
-        y_i = \frac{x_i}{\mathrm{RMS}(x)} * \gamma_i, \quad
-        \text{where} \quad \text{RMS}(x) = \sqrt{\epsilon + \frac{1}{n} \sum_{i=1}^{n} x_i^2}
+        y_i = \frac{x_i}{{\mathrm{{RMS}}(x)}} * \gamma_i, \quad
+        \text{{where}} \quad \text{{RMS}}(x) = \sqrt{{\epsilon + \frac{{1}}{{n}} \sum_{{i=1}}^{{n}} x_i^2}}
 
     The RMS is taken over the last ``D`` dimensions, where ``D``
     is the dimension of :attr:`normalized_shape`. For example, if :attr:`normalized_shape`
@@ -344,14 +346,16 @@ class RMSNorm(Module):
             of size
 
             .. math::
-                [* \times \text{normalized\_shape}[0] \times \text{normalized\_shape}[1]
-                    \times \ldots \times \text{normalized\_shape}[-1]]
+                [* \times \text{{normalized\_shape}}[0] \times \text{{normalized\_shape}}[1]
+                    \times \ldots \times \text{{normalized\_shape}}[-1]]
 
             If a single integer is used, it is treated as a singleton list, and this module will
             normalize over the last dimension which is expected to be of that specific size.
         eps: a value added to the denominator for numerical stability. Default: :func:`torch.finfo(x.dtype).eps`
         elementwise_affine: a boolean value that when set to ``True``, this module
             has learnable per-element affine parameters initialized to ones (for weights). Default: ``True``.
+        {device}
+        {dtype}
 
     Shape:
         - Input: :math:`(N, *)`

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -5,7 +5,7 @@ from typing import Optional, Union
 import torch
 from torch import Size, Tensor
 from torch.nn import functional as F, init
-from torch.nn.modules._nn_docs import common_args
+from torch.nn.modules._nn_docs import layernorm_args, common_args
 from torch._C import _add_docstr as add_docstr
 from torch.nn.parameter import Parameter
 

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -123,8 +123,7 @@ class LayerNorm(Module):
 
     Args:
         {layernorm_args}
-        {device}
-        {dtype}
+        {common_args}
 
 
     Attributes:
@@ -161,8 +160,7 @@ class LayerNorm(Module):
 
     """.format(
         layernorm_args=layernorm_args.__doc__,
-        device=common_args.__doc__.split("device:")[1].split("dtype:")[0],
-        dtype=common_args.__doc__.split("dtype:")[1]
+        common_args=common_args.__doc__
     )
 
     __constants__ = ["normalized_shape", "eps", "elementwise_affine"]

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -216,8 +216,8 @@ class LayerNorm(Module):
             "elementwise_affine={elementwise_affine}".format(**self.__dict__)
         )
 
-docstr = LayerNorm.__doc__.format(**layernorm_args, **common_args)
-add_docstr(LayerNorm, docstr)
+docstring = layernorm_args.__doc__ + common_args.__doc__
+add_docstr(LayerNorm, docstring)
 
 class GroupNorm(Module):
     r"""Applies Group Normalization over a mini-batch of inputs.

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -122,23 +122,9 @@ class LayerNorm(Module):
     evaluation modes.
 
     Args:
-        normalized_shape (int or list or torch.Size): input shape from an expected input
-            of size
-
-            .. math::
-                [* \times \text{{normalized\_shape}}[0] \times \text{{normalized\_shape}}[1]
-                    \times \ldots \times \text{{normalized\_shape}}[-1]]
-
-            If a single integer is used, it is treated as a singleton list, and this module will
-            normalize over the last dimension which is expected to be of that specific size.
-        eps: a value added to the denominator for numerical stability. Default: 1e-5
-        elementwise_affine: a boolean value that when set to ``True``, this module
-            has learnable per-element affine parameters initialized to ones (for weights)
-            and zeros (for biases). Default: ``True``.
-        bias: If set to ``False``, the layer will not learn an additive bias (only relevant if
-            :attr:`elementwise_affine` is ``True``). Default: ``True``.
-            {device}
-            {dtype}
+        {layernorm_args}
+        {device}
+        {dtype}
 
 
     Attributes:
@@ -230,7 +216,7 @@ class LayerNorm(Module):
             "elementwise_affine={elementwise_affine}".format(**self.__dict__)
         )
 
-docstr = LayerNorm.__doc__.format(**common_args)
+docstr = LayerNorm.__doc__.format(**layernorm_args, **common_args)
 add_docstr(LayerNorm, docstr)
 
 class GroupNorm(Module):


### PR DESCRIPTION
Add missing arg descriptions for RMSNorm(Module)

cc @sekyondaMeta @AlannaBurke