### PR TITLE
Remove fbjni

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -70,10 +70,6 @@
     ignore = dirty
     path = third_party/fbgemm
     url = https://github.com/pytorch/fbgemm
-[submodule "android/libs/fbjni"]
-    ignore = dirty
-    path = android/libs/fbjni
-    url = https://github.com/facebookincubator/fbjni.git
 [submodule "third_party/XNNPACK"]
     ignore = dirty
     path = third_party/XNNPACK


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #153741

Summary: as a follow-up to #153656, since we removed android demo app it
seems safe to remove fbjni dependency.