### PR TITLE
[ATen-CPU] Use `math.h` for GeLU as well as `cmath`

### DIFF
--- a/aten/src/ATen/native/cpu/Gelu.h
+++ b/aten/src/ATen/native/cpu/Gelu.h
@@ -5,6 +5,7 @@
 #ifdef _WIN32
 #define _USE_MATH_DEFINES
 #include <cmath>
+#include <math.h>
 #endif // _WIN32
 
 #include <ATen/cpu/vec/vec.h>


### PR DESCRIPTION

Summary:
## Context

See https://github.com/pytorch/pytorch/pull/149164 for more context.

Originally, this fix worked but more recently including `cmath` by itself no longer provides access to math constants on Windows platforms. I found that including `math.h` resolves this.

I'm not sure exactly what changed, but this PR updates the header to just use both includes fix the symbols not being found. It might be a bug with a recent Windows update perhaps?

Test Plan:
CI


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168