### PR TITLE
[not for land] small compile-on-one-rank example

### DIFF
--- a/precompile_on_one_symbolic_rank_example.py
+++ b/precompile_on_one_symbolic_rank_example.py
@@ -1,0 +1,200 @@
+import torch
+import os
+import copy
+from torch.testing._internal.distributed.fake_pg import FakeStore
+from torch.distributed._tensor import (
+    DeviceMesh,
+    DTensor,
+    init_device_mesh,
+    Partial,
+    Replicate,
+    Shard,
+)
+from torch.distributed.tensor.parallel import (
+    ColwiseParallel,
+    parallelize_module,
+    PrepareModuleInput,
+    PrepareModuleOutput,
+    RowwiseParallel,
+)
+import torch.multiprocessing as mp
+import torch.distributed as dist
+
+def capture(fn):
+    def inner(*args):
+        gm = None
+        actual_args = None
+        kwargs = None
+
+        def backend(gm_, args_, **kwargs_):
+            nonlocal gm
+            nonlocal actual_args
+            nonlocal kwargs
+            gm = gm_
+            actual_args = args_
+            kwargs = kwargs_
+            return gm
+
+        _ = torch.compile(fn, fullgraph=True, backend=backend)(*args)
+        return gm, actual_args, kwargs
+
+    return inner
+
+class Attention(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.wq = torch.nn.Linear(16, 16)
+        self.wk = torch.nn.Linear(16, 16)
+        self.wv = torch.nn.Linear(16, 16)
+        self.wo = torch.nn.Linear(16, 16)
+
+    def forward(self, x):
+        # make rank 0 graph slightly different
+        # TODO: we're going to need to avoid 0-1 specialization,
+        # but still not error on these conditionals (we need a hint)
+        if torch.distributed.get_rank() >= 3:
+            x = x + 1
+        xq = self.wq(x)
+        xk = self.wk(x)
+        xv = self.wv(x)
+        # fake attention:
+        xo = xq + xk + xv
+        #return xq, xk, xv, xo, self.wo(xo)
+        return self.wo(xo),
+
+class TransformerBlock(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.attn = Attention()
+
+    def forward(self, x):
+        return self.attn(x)
+
+class Transformer(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.block = TransformerBlock()
+
+    def forward(self, input):
+        return self.block(input)
+
+def distribute_model(model, world_size):
+    tp_mesh = init_device_mesh("cuda", (world_size,), mesh_dim_names=("tp",))
+
+    # apply sequence parallel
+    parallel_plan = {
+        "attn": PrepareModuleInput(
+            input_layouts=Shard(0), desired_input_layouts=Replicate()
+        ),
+        "attn.wq": ColwiseParallel(use_local_output=True),
+        "attn.wk": ColwiseParallel(use_local_output=True),
+        "attn.wv": ColwiseParallel(use_local_output=True),
+        "attn.wo": RowwiseParallel(output_layouts=Shard(0)),
+    }
+
+    parallelize_module(
+        module=model.block,
+        device_mesh=tp_mesh,
+        parallelize_plan=parallel_plan,
+    )
+
+def precompile(model, args, dir_path, world_size):
+    # init fake process group
+    fake_store = FakeStore()
+    dist.init_process_group(
+        "fake", store=fake_store, rank=0, world_size=world_size
+    )
+    distribute_model(model, world_size)
+    # precompile
+    gm, args, kwargs = capture(model)(*args)
+    compiled_artifact = torch._inductor.standalone_compile(gm, args, options={'use_symbolic_rank': True})
+    compiled_artifact.save(path=dir_path, format='unpacked')
+    # destroy fake process group
+    dist.destroy_process_group()
+
+
+def dist_setup(rank, world_size):
+    os.environ['MASTER_ADDR'] = '127.0.0.1'  # or your master node's IP
+    os.environ['MASTER_PORT'] = '29500'      # use a free port
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    torch.cuda.set_device(rank)
+
+def get_updated_args(model, args):
+    import torch.utils._pytree as pytree
+    params = {
+        **dict(model.named_parameters(remove_duplicate=False)),
+        **dict(model.named_buffers(remove_duplicate=False)),
+    }
+
+    params_flat, _ = pytree.tree_flatten(params)
+
+    # There is a problem here:
+    # the calling convention is whatever order dynamo
+    # chose to lift params into extra inputs.
+    # Can we enforce an invariant that this ordering respected here?
+    full_args = []
+    # first params
+    full_args.extend(params_flat)
+    # then normal forward args
+    full_args.extend(args)
+    # then current rank
+    full_args.append(torch.distributed.get_rank())
+    return full_args
+
+def launch_precompiled_worker(rank, model, args, artifact_path, world_size):
+    dist_setup(rank, world_size)
+    try:
+        model.to(rank)
+
+        args = [a.to(rank) for a in args]
+        distribute_model(model, world_size)
+
+        loaded = torch._inductor.CompiledArtifact.load(path=artifact_path, format="unpacked", model=model)
+        # TODO: calling convention changes from dynamo need to be recorded somewhere
+        # so we don't have to hardcode them
+        all_args = get_updated_args(model, args)
+
+        compiled_outs = loaded(*all_args)
+        assert isinstance(compiled_outs, list)
+        compiled_outs[-1].sum().backward()
+        compiled_grads = [p.grad.clone() for p in model.parameters()]
+
+        for p in model.parameters():
+            p.grad = None
+
+        eager_outs = model(*args)
+        eager_outs[-1].sum().backward()
+        eager_grads = [p.grad.clone() for p in model.parameters()]
+
+        print("fw outs")
+        for eager_out, compiled_out in zip(eager_outs, compiled_outs):
+            print(torch.allclose(eager_out, compiled_out))
+        print("grads")
+        for eager_grad, compiled_grad in zip(eager_grads, compiled_grads):
+            assert isinstance(eager_grad, DTensor)
+            assert isinstance(compiled_grad, DTensor)
+            print(torch.allclose(eager_grad._local_tensor, compiled_grad._local_tensor))
+    finally:
+        dist.destroy_process_group()
+
+def run_distributed_job(model, args, artifact_path, world_size):
+    mp.spawn(launch_precompiled_worker, args=(model, args, artifact_path, world_size,), nprocs=world_size, join=True, daemon=True)
+
+if __name__ == '__main__':
+    args = (torch.rand(20, 16).to('cuda'),)
+    model = Transformer().to('cuda')
+    world_size = 2
+
+    artifact_path = 'tmp_cache_dir'
+    # compile if we have not already pre-compiled and cached to disk
+    if True or not os.listdir(artifact_path):
+        # clone model because compilation requires DTensor-ifying the passed-in model
+        model_copy = copy.deepcopy(model)
+        precompile(model_copy, args, artifact_path, world_size)
+        assert os.listdir(artifact_path)
+
+    # now run the precompiled distributed job
+    run_distributed_job(model, args, artifact_path=artifact_path, world_size=world_size)
+
+
+

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -593,6 +593,7 @@ class SymInt:
             return hash(self.node.nested_int())
         else:
             # We could support constant SymInts as well, but not doing it for now
+            breakpoint()
             raise TypeError("unhashable type: non-nested SymInt")
             # TODO: Force specialization
             # This can't be done because the TypeError here is load bearing

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -412,7 +412,7 @@ enable_faithful_generator_behavior = True
 
 # Inline inbuilt nn modules
 inline_inbuilt_nn_modules = Config(  # type: ignore[var-annotated]
-    default=True,
+    default=False,
     justknob="pytorch/compiler:inline_inbuilt_nn_modules",
 )
 
@@ -605,6 +605,8 @@ run_gc_after_compile = Config(  # type: ignore[var-annotated]
     justknob="pytorch/compiler:enable_run_gc_after_compile",
     env_name_default="TORCH_DYNAMO_RUN_GC_AFTER_COMPILE",
 )
+
+use_symbolic_rank = True
 
 # Takes the function/module decorated with torch.compile and passes it through a
 # wrapper. This ensures that nn.module hooks are also compiled in the same frame.

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -160,7 +160,7 @@ if torch.distributed.is_available():
     constant_fold_functions.extend(
         [
             torch.distributed.is_initialized,
-            torch.distributed.get_rank,
+            # TODO: support x.device_mesh.get_rank in dynamo
             torch.distributed.get_world_size,
         ]
     )

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -183,6 +183,9 @@ def check_node_safe(node: Node):
         # Tensors always have example values in meta field
         return "example_value" in target.meta
 
+    maybe_name = getattr(node.target, "__name__", "")
+    if 'from_local' in maybe_name or 'to_local' in maybe_name or 'redistribute' in maybe_name:
+        return
     # I'd love to use a match statement here, but it wasn't introduced until py3.10
     if node.op == "call_function":
         # We support only torch.* functions for now

--- a/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
@@ -1217,7 +1217,7 @@ def aot_dispatch_autograd(
                     placeholder_list[i] = ph_arg.as_strided(ph_arg.size(), real_stride)
 
             compiled_bw_func = None
-            if num_symints_saved_for_bw > 0:
+            if num_symints_saved_for_bw > 0 or config.force_eager_backward_compilation:
                 try:
                     # See Note: [Backward graph lazy lowering]
                     compiled_bw_func = aot_config.bw_compiler(

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -255,6 +255,9 @@ strict_autograd_cache = False
 # that any decisions on collectives are made consistently.
 unsafe_allow_optimization_of_collectives = False
 
+
+force_eager_backward_compilation = False
+
 # See Note [AOTAutograd Tangent Subclassness for mutated inputs]
 # TODO(ivankobzarev): Remove this config, being able to deduce it compile time.
 disable_guess_zero_tangent_for_mutated_input_subclass = False

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -155,6 +155,7 @@ def gen_common_triton_imports() -> str:
     imports = IndentedBuffer()
     imports.splice(
         """
+        import torch
         import triton
         import triton.language as tl
         """

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1445,15 +1445,24 @@ class PythonWrapperCodegen(CodeGen):
             self.kernel_declarations.getvaluewithlinemap(),
         )
 
+    def gen_symbolic_rank_binding(self):
+        fake_mode = V.get_fake_mode()
+        if fake_mode.shape_env is not None and fake_mode.shape_env.symbolic_rank is not None:
+            return f'{fake_mode.shape_env.symbolic_rank.node.expr} = {fake_mode.shape_env.symbolic_rank.node.hint}'
+        return ''
+
     def generate_and_run_autotune_block(self):
         """
         Compose self.kernel_autotune_defs and self.kernel_autotune_calls into a single block of
         code and execute it to trigger Triton kernel compilation and auto-tuning
         """
         self.kernel_autotune_defs.splice(
-            """
+            f"""
             async_compile.wait(globals())
             del async_compile
+
+            {self.gen_symbolic_rank_binding()}
+
         """
         )
         scope = {}  # type: ignore[var-annotated]

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1852,7 +1852,7 @@ def get_cuda_device_context(gm: torch.fx.GraphModule) -> AbstractContextManager[
         if isinstance(arg, fx.Node) and isinstance(arg.meta.get("val"), torch.Tensor)
     )
     cuda_devices: OrderedSet[torch.device] = OrderedSet(
-        device for device in (input_devices | out_devices) if device.type == "cuda"
+        device for device in (input_devices | out_devices) if device.type == "cuda" and not isinstance(device.index, torch.SymInt)
     )
 
     return (

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -813,7 +813,7 @@ class GraphLowering(torch.fx.Interpreter):
 
     def add_device_info(self, device: torch.device) -> None:
         self.device_types.add(device.type)
-        if device.index is not None:
+        if device.index is not None and not isinstance(device.index, torch.SymInt):
             self.device_idxs.add(device.index)
         if V.graph.current_node and device not in self.device_node_mapping:
             self.device_node_mapping[device] = V.graph.current_node

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -2198,9 +2198,10 @@ def init_once_fakemode(fn: Callable[..., Any]) -> Callable[[], Any]:
     @functools.lru_cache(None)
     @functools.wraps(fn)
     def lazy_init() -> Any:
+        return
         counters_ref = counters["inductor"].copy()
 
-        with torch._guards.tracing(None), unset_fake_temporarily(), FakeTensorMode():
+        with torch._guards.tracing(None), unset_fake_temporarily(), FakeTensorMode(use_symbolic_rank=torch._dynamo.config.use_symbolic_rank):
             result = fn()
 
         # clear view matches encountered during tracing

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2550,7 +2550,11 @@ def copy_misaligned_inputs(
     new_inputs: list[InputType], check_inputs_idxs: Sequence[int]
 ) -> None:
     for i in check_inputs_idxs:
-        _inp = new_inputs[i]
+        try:
+            _inp = new_inputs[i]
+        except:
+            breakpoint()
+            _inp = new_inputs[i]
         assert isinstance(_inp, torch.Tensor)
         if _inp.data_ptr() % ALIGNMENT:
             new_inputs[i] = clone_preserve_strides(_inp)

--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -373,6 +373,14 @@ class MetaTensorDescriber:
 
         from torch.nested._internal.nested_tensor import _tensor_symint_registry
 
+        # use symbolic rank for device if it is enabled
+        device = t.device
+        if tracing_context := torch._guards.TracingContext.try_get():
+            if tracing_context.fake_mode.shape_env is not None and tracing_context.fake_mode.shape_env.symbolic_rank is not None:
+                device = torch.device(t.device.type, t.device.index, tracing_context.fake_mode.shape_env.symbolic_rank)
+#        else:
+#            breakpoint()
+
         view_func = ViewFunc.from_tensor(t)
 
         # TODO: Is it important to enable torch.inference_mode before querying
@@ -411,7 +419,7 @@ class MetaTensorDescriber:
             ),
             is_functional=is_functional,
             layout=layout,
-            device=t.device,
+            device=device,
             size=t.size(),
             stride=stride,
             storage_offset=storage_offset,

--- a/torch/csrc/Device.h
+++ b/torch/csrc/Device.h
@@ -5,10 +5,13 @@
 
 #include <ATen/Device.h>
 
+#include <c10/core/SymInt.h>
+
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct TORCH_API THPDevice {
   PyObject_HEAD
   at::Device device;
+  std::optional<c10::SymInt> symbolic_rank;
 };
 
 TORCH_API extern PyTypeObject THPDeviceType;
@@ -18,5 +21,6 @@ inline bool THPDevice_Check(PyObject* obj) {
 }
 
 TORCH_API PyObject* THPDevice_New(const at::Device& device);
+TORCH_API PyObject* THPDevice_New(const at::Device& device, c10::SymInt symbolic_rank);
 
 TORCH_API void THPDevice_init(PyObject* module);

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2295,6 +2295,11 @@ def get_rank(group: Optional[ProcessGroup] = None) -> int:
         -1, if not part of the group
 
     """
+    # TODO: figure out if we should support multiple-process-group symbolic rank
+    if fake_mode := torch._C._get_dispatch_mode(torch._C._TorchDispatchModeKey.FAKE):
+        if fake_mode.shape_env is not None and fake_mode.shape_env.symbolic_rank is not None:
+            return fake_mode.shape_env.symbolic_rank
+
     if _rank_not_in_group(group):
         return -1
 

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -110,6 +110,10 @@ def _format_import_statement(name: str, obj: Any, importer: Importer) -> str:
         return _custom_builtins[name].import_str
     if _is_from_torch(name):
         return "import torch"
+    # TERRIBLE HACK (not landable)
+    # The real fix is to remove the one-off hacks for DTensor in dynamo
+    if 'from_local' in name or 'to_local' in name or 'redistribute' in name:
+        return ""
     module_name, attr_name = importer.get_name(obj)
     return f"from {module_name} import {attr_name} as {name}"
 

--- a/torch/package/importer.py
+++ b/torch/package/importer.py
@@ -100,6 +100,7 @@ class Importer(ABC):
             module = self.import_module(module_name)
             obj2, _ = _getattribute(module, name)
         except (ImportError, KeyError, AttributeError):
+            breakpoint()
             raise ObjNotFoundError(
                 f"{obj} was not found as {module_name}.{name}"
             ) from None


### PR DESCRIPTION
This is just for stashing changes (it is full of hacks and is missing features). See `precompile_on_one_symbolic_rank_example.py` for the example code, which splits the job into two steps (pre-compile on a single rank, run distributed job with that shared artifact) 

Linking the generated output code in a bit, where the main feature you can see is that:
(1) rank is an input to the compiled artifact
(2) the triton kernels hardcode `torch.distributed.get_rank()` instead of the rank they were compiled with (to be fair this is not actually what we want, since it implies that each rank needs to compile the triton kernels separately. but at the very least the same compiled artifact python file can be shared by every rank)

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #153743



cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @Lucaskabela