### PR TITLE
Patch the _is_conv_node function

### DIFF
--- a/torch/ao/quantization/pt2e/utils.py
+++ b/torch/ao/quantization/pt2e/utils.py
@@ -167,7 +167,11 @@ def _is_conv_node(n: Node):
     """
     return n.op == "call_function" and n.target in [
         torch.ops.aten.conv1d.default,
+        torch.ops.aten.conv1d.padding,
         torch.ops.aten.conv2d.default,
+        torch.ops.aten.conv2d.padding,
+        torch.ops.aten.conv3d.default,
+        torch.ops.aten.conv3d.padding,
     ]
 
 

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -3184,11 +3184,11 @@ class TestHelperModules:
             return x
 
     class ConvWithBNRelu(torch.nn.Module):
-        def __init__(self, relu, dim=2, bn=True, bias=True):
+        def __init__(self, relu, dim=2, bn=True, bias=True, padding=0):
             super().__init__()
-            convs = {1: torch.nn.Conv1d, 2: torch.nn.Conv2d}
-            bns = {1: torch.nn.BatchNorm1d, 2: torch.nn.BatchNorm2d}
-            self.conv = convs[dim](3, 3, 3, bias=bias)
+            convs = {1: torch.nn.Conv1d, 2: torch.nn.Conv2d, 3: torch.nn.Conv3d}
+            bns = {1: torch.nn.BatchNorm1d, 2: torch.nn.BatchNorm2d, 3: torch.nn.BatchNorm3d}
+            self.conv = convs[dim](3, 3, 3, bias=bias, padding=padding)
 
             if bn:
                 self.bn = bns[dim](3)


### PR DESCRIPTION
Summary: torch.ops.aten.conv2d.padding is also conv2d node

Differential Revision: D74898941


