### PR TITLE
convert inductor codecache to use getArtifactLogger

### DIFF
--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -954,6 +954,7 @@ exclusions = {
     "loop_ordering",
     "autotuning",
     "graph_region_expansion",
+    "codecache",
 }
 for name in torch._logging._internal.log_registry.artifact_names:
     if name not in exclusions:

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -10,7 +10,6 @@ import importlib.resources
 import io
 import itertools
 import json
-import logging
 import os
 import pickle
 import pkgutil
@@ -145,7 +144,7 @@ _IS_WINDOWS = sys.platform == "win32"
 LOCK_TIMEOUT = 600
 
 output_code_log = torch._logging.getArtifactLogger(__name__, "output_code")
-log = logging.getLogger(__name__)
+log = torch._logging.getArtifactLogger(__name__, "codecache")
 
 
 def get_cpp_wrapper_cubin_path_name() -> str:

--- a/torch/_logging/_registrations.py
+++ b/torch/_logging/_registrations.py
@@ -26,6 +26,10 @@ register_artifact(
     "cudagraphs",
     "Logs information from wrapping inductor generated code with cudagraphs.",
 )
+register_artifact(
+    "codecache",
+    "Logs information about inductor's code cache",
+)
 
 register_log("dynamic", DYNAMIC)
 register_log("torch", "torch")


### PR DESCRIPTION
I'm not entirely sure of the background for why inductor codecache code uses default python logging instead of the new TORCH_LOGS-based artifact logging, but switching it over to artifact logging makes it easier to use nice testing utils in the next PR.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #153672
* __->__ #153766



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov