### PR TITLE
add graph_code_verbose_log artifact for fx passes

### DIFF
--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -934,6 +934,7 @@ exclusions = {
     "graph_breaks",
     "graph",
     "graph_code",
+    "graph_code_verbose",
     "graph_sizes",
     "ddp_graphs",
     "perf_hints",

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -154,7 +154,6 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 graph_tabular_log = torch._logging.getArtifactLogger(__name__, "graph")
 graph_code_log = torch._logging.getArtifactLogger(__name__, "graph_code")
-graph_code_verbose_log = torch._logging.getArtifactLogger(__name__, "graph_code_verbose")
 graph_sizes_log = torch._logging.getArtifactLogger(__name__, "graph_sizes")
 trace_call_log = torch._logging.getArtifactLogger(__name__, "trace_call")
 

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -154,6 +154,7 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 graph_tabular_log = torch._logging.getArtifactLogger(__name__, "graph")
 graph_code_log = torch._logging.getArtifactLogger(__name__, "graph_code")
+graph_code_verbose_log = torch._logging.getArtifactLogger(__name__, "graph_code_verbose")
 graph_sizes_log = torch._logging.getArtifactLogger(__name__, "graph_sizes")
 trace_call_log = torch._logging.getArtifactLogger(__name__, "trace_call")
 

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -644,6 +644,7 @@ def help_message(verbose=False):
         printed_artifacts = log_registry.artifact_names
     else:
         printed_artifacts = log_registry.visible_artifacts
+        
     if verbose:
         heading = "All registered names"
     else:

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -676,8 +676,6 @@ Examples:
   TORCH_LOGS="+some.random.module,schedule" will set the log level of
   some.random.module to logging.DEBUG and enable the schedule artifact
 
-  TORCH_LOGS="graph_code_verbose" will enable verbose FX pass logs for graph code
-
   TORCH_LOGS_FORMAT="%(levelname)s: %(message)s" or any provided format
   string will set the output format
   Valid keys are "levelname", "message", "pathname", "levelno", "lineno",

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -217,6 +217,7 @@ def set_logs(
     ddp_graphs: bool = False,
     graph: bool = False,
     graph_code: bool = False,
+    graph_code_verbose: bool = False,
     graph_breaks: bool = False,
     graph_sizes: bool = False,
     guards: bool = False,
@@ -344,6 +345,9 @@ def set_logs(
         graph_code (:class:`bool`):
             Whether to emit the python source of the graph captured by TorchDynamo.
             Default: ``False``
+
+        graph_code_verbose (:class:`bool`):
+            Whether to emit verbose/intermediate FX pass logs for graph code. Default: ``False``
 
         graph_breaks (:class:`bool`):
             Whether to emit the graph breaks encountered by TorchDynamo.
@@ -519,6 +523,7 @@ def set_logs(
         dtensor=dtensor,
         graph=graph,
         graph_code=graph_code,
+        graph_code_verbose=graph_code_verbose,
         graph_breaks=graph_breaks,
         graph_sizes=graph_sizes,
         guards=guards,
@@ -640,6 +645,12 @@ def help_message(verbose=False):
     else:
         printed_artifacts = log_registry.visible_artifacts
 
+    # Ensure graph_code_verbose is always listed with a description
+    if verbose and "graph_code_verbose" not in printed_artifacts:
+        printed_artifacts = set(printed_artifacts)
+        printed_artifacts.add("graph_code_verbose")
+        log_registry.artifact_descriptions["graph_code_verbose"] = "Verbose FX pass logs for graph code."
+
     if verbose:
         heading = "All registered names"
     else:
@@ -670,6 +681,8 @@ Examples:
 
   TORCH_LOGS="+some.random.module,schedule" will set the log level of
   some.random.module to logging.DEBUG and enable the schedule artifact
+
+  TORCH_LOGS="graph_code_verbose" will enable verbose FX pass logs for graph code
 
   TORCH_LOGS_FORMAT="%(levelname)s: %(message)s" or any provided format
   string will set the output format

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -644,13 +644,7 @@ def help_message(verbose=False):
         printed_artifacts = log_registry.artifact_names
     else:
         printed_artifacts = log_registry.visible_artifacts
-
-    # Ensure graph_code_verbose is always listed with a description
-    if verbose and "graph_code_verbose" not in printed_artifacts:
-        printed_artifacts = set(printed_artifacts)
-        printed_artifacts.add("graph_code_verbose")
-        log_registry.artifact_descriptions["graph_code_verbose"] = "Verbose FX pass logs for graph code."
-
+        
     if verbose:
         heading = "All registered names"
     else:

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -644,7 +644,6 @@ def help_message(verbose=False):
         printed_artifacts = log_registry.artifact_names
     else:
         printed_artifacts = log_registry.visible_artifacts
-        
     if verbose:
         heading = "All registered names"
     else:

--- a/torch/_logging/_registrations.py
+++ b/torch/_logging/_registrations.py
@@ -71,6 +71,10 @@ register_artifact(
 )
 register_artifact("graph_code", "Like `graph`, but gives you the Python code instead.")
 register_artifact(
+    "graph_code_verbose",
+    "Verbose FX pass logs, e.g. from tensorify_python_scalars and runtime_assert.",
+)
+register_artifact(
     "graph_sizes", "Prints the sizes of all FX nodes in the dynamo graph."
 )
 register_artifact(

--- a/torch/fx/passes/_tensorify_python_scalars.py
+++ b/torch/fx/passes/_tensorify_python_scalars.py
@@ -35,7 +35,7 @@ from torch.utils._sympy.symbol import symbol_is_type, SymT
 __all__: list[str] = []
 
 log = logging.getLogger(__name__)
-graph_code_log = torch._logging.getArtifactLogger(__name__, "graph_code")
+graph_code_log = torch._logging.getArtifactLogger(__name__, "graph_code_verbose")
 
 # The general shape of this transformation is to look for Tensor operations
 # that take a backed SymFloat as an argument, and then redo them as tensor

--- a/torch/fx/passes/runtime_assert.py
+++ b/torch/fx/passes/runtime_assert.py
@@ -28,7 +28,7 @@ from torch.fx.graph_module import GraphModule
 __all__ = ["insert_deferred_runtime_asserts"]
 
 log = logging.getLogger(__name__)
-graph_code_log = torch._logging.getArtifactLogger(__name__, "graph_code")
+graph_code_log = torch._logging.getArtifactLogger(__name__, "graph_code_verbose")
 
 
 def _get_example_value(node: fx.Node) -> Optional[str]:


### PR DESCRIPTION
Fixes #153646

This PR refactors the logging behavior in the FX pass insert_deferred_runtime_asserts and runtime_assert.py to separate verbose/intermediate graph logs from the final output graph log. All verbose logs generated during the FX pass are now routed to a new artifact logger, graph_code_verbose, while only the final output graph remains logged to the original graph_code artifact.

Changes

- Added a new artifact logger: [graph_code_log = torch._logging.getArtifactLogger(__name__, "graph_code_verbose")]
- Updated all verbose/intermediate FX pass logs in [insert_deferred_runtime_asserts] to use the new graph_code_verbose artifact.
- Ensured that only the final output graph is logged to the original graph_code artifact.
- No changes to the FX pass logic or output—only logging behavior is affected.

Notes
This change is backward-compatible and does not affect the functional behavior of FX passes.
No changes to user-facing APIs.

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @chenyang78 @kadeng @chauhang @amjames