### PR TITLE
[CUDA] Fused optimizers - write lerp with fma instead of regular lerp

### DIFF
--- a/aten/src/ATen/native/cuda/fused_adam_utils.cuh
+++ b/aten/src/ATen/native/cuda/fused_adam_utils.cuh
@@ -63,8 +63,8 @@ C10_DEVICE inline void adam_math(
       }
     }
     // ref: https://developer.nvidia.com/blog/lerp-faster-cuda/
-    exp_avg = fma(beta1, exp_avg, fma(-beta1, grad, grad));
-    exp_avg_sq = fma(beta2, exp_avg_sq, fma(-beta2, grad * grad, grad * grad));
+    exp_avg = std::fma(beta1, exp_avg, std::fma(-beta1, grad, grad));
+    exp_avg_sq = std::fma(beta2, exp_avg_sq, std::fma(-beta2, grad * grad, grad * grad));
     const opmath_t step_size = lr / bias_correction1;
     opmath_t denom;
     if (amsgrad) {

--- a/aten/src/ATen/native/cuda/fused_adam_utils.cuh
+++ b/aten/src/ATen/native/cuda/fused_adam_utils.cuh
@@ -63,9 +63,8 @@ C10_DEVICE inline void adam_math(
       }
     }
     // ref: https://developer.nvidia.com/blog/lerp-faster-cuda/
-    exp_avg = std::fma(beta1, exp_avg, std::fma(-beta1, grad, grad));
-    exp_avg_sq =
-        std::fma(beta2, exp_avg_sq, std::fma(-beta2, grad * grad, grad * grad));
+    exp_avg = fma(beta1, exp_avg, fma(-beta1, grad, grad));
+    exp_avg_sq = fma(beta2, exp_avg_sq, fma(-beta2, grad * grad, grad * grad));
     const opmath_t step_size = lr / bias_correction1;
     opmath_t denom;
     if (amsgrad) {

--- a/aten/src/ATen/native/cuda/fused_adam_utils.cuh
+++ b/aten/src/ATen/native/cuda/fused_adam_utils.cuh
@@ -62,10 +62,9 @@ C10_DEVICE inline void adam_math(
         param -= lr * weight_decay * param;
       }
     }
-    // todo(crcrpar): use lerp
     // ref: https://developer.nvidia.com/blog/lerp-faster-cuda/
-    exp_avg = beta1 * exp_avg + (1 - beta1) * grad;
-    exp_avg_sq = beta2 * exp_avg_sq + (1 - beta2) * grad * grad;
+    exp_avg = fma(beta1, exp_avg, fma(-beta1, grad, grad));
+    exp_avg_sq = fma(beta2, exp_avg_sq, fma(-beta2, grad * grad, grad * grad));
     const opmath_t step_size = lr / bias_correction1;
     opmath_t denom;
     if (amsgrad) {

--- a/aten/src/ATen/native/cuda/fused_adam_utils.cuh
+++ b/aten/src/ATen/native/cuda/fused_adam_utils.cuh
@@ -64,7 +64,8 @@ C10_DEVICE inline void adam_math(
     }
     // ref: https://developer.nvidia.com/blog/lerp-faster-cuda/
     exp_avg = std::fma(beta1, exp_avg, std::fma(-beta1, grad, grad));
-    exp_avg_sq = std::fma(beta2, exp_avg_sq, std::fma(-beta2, grad * grad, grad * grad));
+    exp_avg_sq =
+        std::fma(beta2, exp_avg_sq, std::fma(-beta2, grad * grad, grad * grad));
     const opmath_t step_size = lr / bias_correction1;
     opmath_t denom;
     if (amsgrad) {


### PR DESCRIPTION
Fixes TODO in the file. Gives a small perf boost. Use following script for benchmarking:
```
import torch
import torch.nn as nn
import torch.optim as optim
import time


class DummyModel(nn.Module):
    def __init__(self):
        super(DummyModel, self).__init__()
        self.fc1 = nn.Linear(512, 512)
        self.fc2 = nn.Linear(512, 10)

    def forward(self, x):
        x = self.fc1(x)
        x = torch.relu(x)
        x = self.fc2(x)
        return x

device = "cuda"
model = DummyModel().to(device)

optimizer = optim.Adam(
    model.parameters(), 
    lr=0.001, 
    betas=(0.9, 0.999), 
    eps=1e-8, 
    weight_decay=0, 
    amsgrad=False, 
    fused=True
)

loss_fn = nn.CrossEntropyLoss()

batch_size = 128
inputs = torch.randn(batch_size, 512, device=device)
labels = torch.randint(0, 10, (batch_size,), device=device)

for _ in range(10):
    optimizer.zero_grad()
    outputs = model(inputs)
    loss = loss_fn(outputs, labels)
    loss.backward()
    optimizer.step()
torch.cuda.synchronize()

iterations = 1000
start_time = time.time()

for _ in range(iterations):
    optimizer.zero_grad()
    outputs = model(inputs)
    loss = loss_fn(outputs, labels)
    loss.backward()
    optimizer.step()
    torch.cuda.synchronize()

end_time = time.time()
total_time = end_time - start_time
print(f"Total time for {iterations} iterations: {total_time:.6f} seconds")
print(f"Average time per iteration: {total_time / iterations * 1000:.6f} ms")

```

H100:
**New**: 0.754434 ms
**Old**: 0.765947 ms

cc @vincentqb @jbschlosser @albanD @janeyx99 @crcrpar @ptrblck @msaroufim @eqy @jerryzh168