### PR TITLE
[inductor] Added precompilation_timeout_seconds into a config instead of hardcoded

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -82,9 +82,7 @@ disable_progress = True
 verbose_progress = False
 
 # precompilation timeout
-precompilation_timeout_seconds: int = Config(
-    default=60*60,
-)
+precompilation_timeout_seconds: int = 60*60
 
 # use fx aot graph codegen cache
 fx_graph_cache: bool = Config(

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -81,6 +81,11 @@ disable_progress = True
 # Whether to enable printing the source code for each future
 verbose_progress = False
 
+# precompilation timeout
+precompilation_timeout_seconds: int = Config(
+    default=60*60,
+)
+
 # use fx aot graph codegen cache
 fx_graph_cache: bool = Config(
     justknob="pytorch/remote_cache:enable_local_fx_graph_cache",

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -82,7 +82,7 @@ disable_progress = True
 verbose_progress = False
 
 # precompilation timeout
-precompilation_timeout_seconds: int = 60*60
+precompilation_timeout_seconds: int = 60 * 60
 
 # use fx aot graph codegen cache
 fx_graph_cache: bool = Config(

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2540,6 +2540,8 @@ def autotune_select_algorithm(*args, **kwargs):
             torch._inductor.config.benchmark_epilogue_fusion
         )
 
+    kwargs["precompilation_timeout_seconds"] = config.precompilation_timeout_seconds
+
     return _ALGORITHM_SELECTOR_CACHE(*args, **kwargs)
 
 

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2540,7 +2540,8 @@ def autotune_select_algorithm(*args, **kwargs):
             torch._inductor.config.benchmark_epilogue_fusion
         )
 
-    kwargs["precompilation_timeout_seconds"] = config.precompilation_timeout_seconds
+    if "precompilation_timeout_seconds" not in kwargs:
+        kwargs["precompilation_timeout_seconds"] = config.precompilation_timeout_seconds
 
     return _ALGORITHM_SELECTOR_CACHE(*args, **kwargs)
 


### PR DESCRIPTION
Fixes #153392 

- Updated config.py to add the timeout as a config var to be tuned dynamically (default is 3600s).
- Passed the var as a kwarg during call on instance.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov