### PR TITLE
Fix  add enabled in _initRecordAnnotations()

### DIFF
--- a/torch/csrc/cuda/memory_snapshot.cpp
+++ b/torch/csrc/cuda/memory_snapshot.cpp
@@ -170,7 +170,9 @@ void _record_memory_history(
     when = c10::cuda::CUDACachingAllocator::RecordContext::STATE;
   }
   at::globalContext().lazyInitDevice(c10::DeviceType::CUDA);
-  _initRecordAnnotations();
+  if (enabled) {
+    _initRecordAnnotations();
+  }
   if (compileContext) {
     _initCompileContexts();
   }


### PR DESCRIPTION
Fixes #153571
torch.cuda.memory._record_memory_history(enabled=None) does not clean up previously added hooks.Add (enabled=None) check in _initRecordAnnotations()

cc @ptrblck @msaroufim @eqy @jerryzh168