### PR TITLE
Build clang20 image for ASAN tests

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -229,9 +229,9 @@ case "$tag" in
     VISION=yes
     TRITON=yes
     ;;
-  pytorch-linux-jammy-py3-clang18-asan)
+  pytorch-linux-jammy-py3-clang20-asan)
     ANACONDA_PYTHON_VERSION=3.10
-    CLANG_VERSION=18
+    CLANG_VERSION=20
     VISION=yes
     ;;
   pytorch-linux-jammy-py3.10-gcc11)

--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -229,7 +229,7 @@ case "$tag" in
     VISION=yes
     TRITON=yes
     ;;
-  pytorch-linux-jammy-py3-clang20-asan)
+  pytorch-linux-noble-py3-clang20-asan)
     ANACONDA_PYTHON_VERSION=3.10
     CLANG_VERSION=20
     VISION=yes

--- a/.ci/docker/common/install_clang.sh
+++ b/.ci/docker/common/install_clang.sh
@@ -11,14 +11,11 @@ if [ -n "$CLANG_VERSION" ]; then
     if [[ $CLANG_VERSION == 18 ]]; then
       apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main"
     fi
-    if [[ $CLANG_VERSION == 20 ]]; then
-      apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main"
-    fi
   fi
 
   sudo apt-get update
   if [[ $CLANG_VERSION -ge 18 ]]; then
-    apt-get install -y libomp-${CLANG_VERSION} libclang-rt-${CLANG_VERSION} clang-"$CLANG_VERSION" llvm-"$CLANG_VERSION"
+    apt-get install -y libomp-${CLANG_VERSION}-dev libclang-rt-${CLANG_VERSION}-dev clang-"$CLANG_VERSION" llvm-"$CLANG_VERSION"
   else
     apt-get install -y --no-install-recommends clang-"$CLANG_VERSION" llvm-"$CLANG_VERSION"
   fi

--- a/.ci/docker/common/install_clang.sh
+++ b/.ci/docker/common/install_clang.sh
@@ -11,11 +11,14 @@ if [ -n "$CLANG_VERSION" ]; then
     if [[ $CLANG_VERSION == 18 ]]; then
       apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main"
     fi
+    if [[ $CLANG_VERSION == 20 ]]; then
+      apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main"
+    fi
   fi
 
   sudo apt-get update
   if [[ $CLANG_VERSION -ge 18 ]]; then
-    apt-get install -y libomp-${CLANG_VERSION}-dev libclang-rt-${CLANG_VERSION}-dev clang-"$CLANG_VERSION" llvm-"$CLANG_VERSION"
+    apt-get install -y libomp-${CLANG_VERSION} libclang-rt-${CLANG_VERSION} clang-"$CLANG_VERSION" llvm-"$CLANG_VERSION"
   else
     apt-get install -y --no-install-recommends clang-"$CLANG_VERSION" llvm-"$CLANG_VERSION"
   fi

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -235,7 +235,7 @@ if [[ "$BUILD_ENVIRONMENT" == *asan* ]]; then
     export PYTORCH_TEST_WITH_ASAN=1
     export PYTORCH_TEST_WITH_UBSAN=1
     # TODO: Figure out how to avoid hard-coding these paths
-    export ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-18/bin/llvm-symbolizer
+    export ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-20/bin/llvm-symbolizer
     export TORCH_USE_RTLD_GLOBAL=1
     # NB: We load libtorch.so with RTLD_GLOBAL for UBSAN, unlike our
     # default behavior.

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -67,7 +67,7 @@ jobs:
           pytorch-linux-jammy-py3.12-halide,
           pytorch-linux-jammy-xpu-n-1-py3,
           pytorch-linux-jammy-xpu-n-py3,
-          pytorch-linux-jammy-py3-clang20-asan,
+          pytorch-linux-noble-py3-clang20-asan,
           pytorch-linux-jammy-py3-clang12-onnx,
           pytorch-linux-jammy-linter,
           pytorch-linux-jammy-cuda12.8-cudnn9-py3.10-linter,

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -67,7 +67,7 @@ jobs:
           pytorch-linux-jammy-py3.12-halide,
           pytorch-linux-jammy-xpu-n-1-py3,
           pytorch-linux-jammy-xpu-n-py3,
-          pytorch-linux-jammy-py3-clang18-asan,
+          pytorch-linux-jammy-py3-clang20-asan,
           pytorch-linux-jammy-py3-clang12-onnx,
           pytorch-linux-jammy-linter,
           pytorch-linux-jammy-cuda12.8-cudnn9-py3.10-linter,

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -122,16 +122,16 @@ jobs:
         ]}
     secrets: inherit
 
-  linux-jammy-py3_10-clang20-asan-build:
-    name: linux-jammy-py3.10-clang20-asan
+  linux-noble-py3_10-clang20-asan-build:
+    name: linux-noble-py3.10-clang20-asan
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
       # More memory is needed to build with asan
       runner: linux.2xlarge.memory
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-jammy-py3.10-clang20-asan
-      docker-image-name: ci-image:pytorch-linux-jammy-py3-clang20-asan
+      build-environment: linux-noble-py3.10-clang20-asan
+      docker-image-name: ci-image:pytorch-linux-noble-py3-clang20-asan
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 7, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
@@ -145,16 +145,16 @@ jobs:
       sync-tag: asan-build
     secrets: inherit
 
-  linux-jammy-py3_10-clang20-asan-test:
-    name: linux-jammy-py3.10-clang20-asan
+  linux-noble-py3_10-clang20-asan-test:
+    name: linux-noble-py3.10-clang20-asan
     uses: ./.github/workflows/_linux-test.yml
     needs:
-      - linux-jammy-py3_10-clang20-asan-build
+      - linux-noble-py3_10-clang20-asan-build
       - target-determination
     with:
-      build-environment: linux-jammy-py3.10-clang20-asan
-      docker-image: ${{ needs.linux-jammy-py3_10-clang20-asan-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-py3_10-clang20-asan-build.outputs.test-matrix }}
+      build-environment: linux-noble-py3.10-clang20-asan
+      docker-image: ${{ needs.linux-noble-py3_10-clang20-asan-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-noble-py3_10-clang20-asan-build.outputs.test-matrix }}
       sync-tag: asan-test
     secrets: inherit
 

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -122,16 +122,16 @@ jobs:
         ]}
     secrets: inherit
 
-  linux-jammy-py3_10-clang18-asan-build:
-    name: linux-jammy-py3.10-clang18-asan
+  linux-jammy-py3_10-clang20-asan-build:
+    name: linux-jammy-py3.10-clang20-asan
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
       # More memory is needed to build with asan
       runner: linux.2xlarge.memory
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-jammy-py3.10-clang18-asan
-      docker-image-name: ci-image:pytorch-linux-jammy-py3-clang18-asan
+      build-environment: linux-jammy-py3.10-clang20-asan
+      docker-image-name: ci-image:pytorch-linux-jammy-py3-clang20-asan
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 7, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
@@ -145,16 +145,16 @@ jobs:
       sync-tag: asan-build
     secrets: inherit
 
-  linux-jammy-py3_10-clang18-asan-test:
-    name: linux-jammy-py3.10-clang18-asan
+  linux-jammy-py3_10-clang20-asan-test:
+    name: linux-jammy-py3.10-clang20-asan
     uses: ./.github/workflows/_linux-test.yml
     needs:
-      - linux-jammy-py3_10-clang18-asan-build
+      - linux-jammy-py3_10-clang20-asan-build
       - target-determination
     with:
-      build-environment: linux-jammy-py3.10-clang18-asan
-      docker-image: ${{ needs.linux-jammy-py3_10-clang18-asan-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-py3_10-clang18-asan-build.outputs.test-matrix }}
+      build-environment: linux-jammy-py3.10-clang20-asan
+      docker-image: ${{ needs.linux-jammy-py3_10-clang20-asan-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-py3_10-clang20-asan-build.outputs.test-matrix }}
       sync-tag: asan-test
     secrets: inherit
 

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -135,16 +135,16 @@ jobs:
       test-matrix: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.test-matrix }}
     secrets: inherit
 
-  linux-jammy-py3_10-clang18-asan-build:
-    name: linux-jammy-py3.10-clang18-asan
+  linux-jammy-py3_10-clang20-asan-build:
+    name: linux-jammy-py3.10-clang20-asan
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
       # More memory is needed to build with asan
       runner: linux.2xlarge.memory
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-jammy-py3.10-clang18-asan
-      docker-image-name: ci-image:pytorch-linux-jammy-py3-clang18-asan
+      build-environment: linux-jammy-py3.10-clang20-asan
+      docker-image-name: ci-image:pytorch-linux-jammy-py3-clang20-asan
       test-matrix: |
         { include: [
           { config: "slow", shard: 1, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
@@ -154,15 +154,15 @@ jobs:
       sync-tag: asan-build
     secrets: inherit
 
-  linux-jammy-py3_10-clang18-asan-test:
-    name: linux-jammy-py3.10-clang18-asan
+  linux-jammy-py3_10-clang20-asan-test:
+    name: linux-jammy-py3.10-clang20-asan
     uses: ./.github/workflows/_linux-test.yml
     needs:
-      - linux-jammy-py3_10-clang18-asan-build
+      - linux-jammy-py3_10-clang20-asan-build
       - target-determination
     with:
-      build-environment: linux-jammy-py3.10-clang18-asan
-      docker-image: ${{ needs.linux-jammy-py3_10-clang18-asan-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-py3_10-clang18-asan-build.outputs.test-matrix }}
+      build-environment: linux-jammy-py3.10-clang20-asan
+      docker-image: ${{ needs.linux-jammy-py3_10-clang20-asan-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-py3_10-clang20-asan-build.outputs.test-matrix }}
       sync-tag: asan-test
     secrets: inherit

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -135,16 +135,16 @@ jobs:
       test-matrix: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.test-matrix }}
     secrets: inherit
 
-  linux-jammy-py3_10-clang20-asan-build:
-    name: linux-jammy-py3.10-clang20-asan
+  linux-noble-py3_10-clang20-asan-build:
+    name: linux-noble-py3.10-clang20-asan
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
       # More memory is needed to build with asan
       runner: linux.2xlarge.memory
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-jammy-py3.10-clang20-asan
-      docker-image-name: ci-image:pytorch-linux-jammy-py3-clang20-asan
+      build-environment: linux-noble-py3.10-clang20-asan
+      docker-image-name: ci-image:pytorch-linux-noble-py3-clang20-asan
       test-matrix: |
         { include: [
           { config: "slow", shard: 1, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
@@ -154,15 +154,15 @@ jobs:
       sync-tag: asan-build
     secrets: inherit
 
-  linux-jammy-py3_10-clang20-asan-test:
-    name: linux-jammy-py3.10-clang20-asan
+  linux-noble-py3_10-clang20-asan-test:
+    name: linux-noble-py3.10-clang20-asan
     uses: ./.github/workflows/_linux-test.yml
     needs:
-      - linux-jammy-py3_10-clang20-asan-build
+      - linux-noble-py3_10-clang20-asan-build
       - target-determination
     with:
-      build-environment: linux-jammy-py3.10-clang20-asan
-      docker-image: ${{ needs.linux-jammy-py3_10-clang20-asan-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-py3_10-clang20-asan-build.outputs.test-matrix }}
+      build-environment: linux-noble-py3.10-clang20-asan
+      docker-image: ${{ needs.linux-noble-py3_10-clang20-asan-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-noble-py3_10-clang20-asan-build.outputs.test-matrix }}
       sync-tag: asan-test
     secrets: inherit


### PR DESCRIPTION
Since Clang 21 is out, Clang 20 is mature enough. The most interesting changes are the introduction of ```TypeSanitizer```, see https://clang.llvm.org/docs/TypeSanitizer.html
