### PR TITLE
[RPC] let custom RPCPickler overide pickle library

### DIFF
--- a/torch/distributed/rpc/internal.py
+++ b/torch/distributed/rpc/internal.py
@@ -92,13 +92,20 @@ class _InternalRPCPickler:
         torch.jit.save(script_module, f)
         return (_InternalRPCPickler._script_module_receiver, (f.getvalue(),))
 
+    def _pickler(self, f):
+        """
+        User-defined RPCPickler could derive from this class and overide
+        `_pickler` and `_unpickler` to change the underlying pickler.
+        """
+        return _pickler(f)
+
     def serialize(self, obj):
         r"""
         Serialize non tensor data into binary string, tensor data into
         tensor table
         """
         f = io.BytesIO()
-        p = _pickler(f)
+        p = self._pickler(f)
         p.dispatch_table = self._dispatch_table
 
         # rpc api could accept user picklers inheriting from _InternalRPCPickler to serialize rref,
@@ -145,6 +152,13 @@ class _InternalRPCPickler:
 
         return (f.getvalue(), tensors)
 
+    def _unpickler(self, f):
+        """
+        User-defined RPCPickler could derive from this class and overide
+        `_pickler` and `_unpickler` to change the underlying pickler.
+        """
+        return _unpickler(f)
+
     def deserialize(self, binary_data, tensor_table):
         r"""
         Deserialize binary string + tensor table to original obj
@@ -158,7 +172,7 @@ class _InternalRPCPickler:
         _thread_local_tensor_tables.recv_tables = tensor_table
 
         try:
-            unpickler = _unpickler(io.BytesIO(binary_data))
+            unpickler = self._unpickler(io.BytesIO(binary_data))
             ret = unpickler.load()
         except AttributeError as e:
             # Occurs when function is not found on module/class during


### PR DESCRIPTION
add interface to _InternalRPCPickler for custom RPCPickler to override underlying pickle library easily.

In TorchRPC, users can change the RPC pickler from `dist.rpc.internal._InternalRPCPickler` to user-customed one using the context manager `dist.rpc.api._use_rpc_pickler`. This is convenient for users who want to change the whole pickling logic. However, the underlying pickle library of _InternalRPCPickler is hard coded. If one only wants to change the underlying pickle library without changing the whole logic (e.g. From pickle to dill), he has to create an inheritance class from _InternalRPCPickler, copy & paste the whole serialize and deserialize function to override them, and just change a single line. To make this progress easier, new interfaces of _InternalRPCPickler including `_pickler(self, f)` and `_unpickler(self, f)` are added. In order to change underlying pickler, after inheriting from _InternalRPCPickler, only these interfaces need to be overrided, providing ease of use.

```python
import torch.distributed.rpc as rpc
import dill

class DillRPCPickler(rpc.internal._InternalRPCPickler):
    def _pickler(self, f):
        return dill.Pickler(f)
    def _unpickler(self, f):
        return dill.Unpickler(f)


pickler = DillRPCPickler()
with rpc.api._use_rpc_pickler(pickler):
    rpc.init_rpc("worker1", rank=0, world_size=2)
    main_function()
    rpc.shutdown()
```


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k