### PR TITLE
[Dynamo] Use the `gb_type` field of `unimplemented_v2` to count graph breaks

### DIFF
--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -446,13 +446,7 @@ from user code:
         first_graph_break = next(iter(counters["graph_break"].keys()))
         self.assertExpectedInline(
             first_graph_break,
-            """\
-Attempted to call function marked as skipped
-  Explanation: Dynamo cannot trace optree C/C++ function optree._C.PyCapsule.flatten.
-  Hint: Consider using torch.utils._pytree - https://github.com/pytorch/pytorch/blob/main/torch/utils/_pytree.py
-
-  Developer debug context: module: optree._C, qualname: PyCapsule.flatten, skip reason: <missing reason>
-""",
+            "Attempted to call function marked as skipped",
         )
 
     @scoped_load_inline

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -489,16 +489,9 @@ Attempted to call function marked as skipped
 
         first_graph_break = re.sub(r"mylib(_v\d+)?", "mylib", first_graph_break)
 
-        self.assertExpectedInline(
+        self.assertEqual(
             first_graph_break,
-            """\
-Attempted to call function marked as skipped
-  Explanation: Dynamo does not know how to trace the builtin `mylib.PyCapsule.foobar.` This function is either a Python builtin (e.g. _warnings.warn) or a third-party C/C++ Python extension (perhaps created with pybind).
-  Hint: If it is a Python builtin, please file an issue on GitHub so the PyTorch team can add support for it and see the next case for a workaround.
-  Hint: If it is a third-party C/C++ Python extension, please either wrap it into a PyTorch-understood custom operator (see https://pytorch.org/tutorials/advanced/custom_ops_landing_page.html for more details) or, if it is traceable, use `torch.compiler.allow_in_graph`.
-
-  Developer debug context: module: mylib, qualname: PyCapsule.foobar, skip reason: <missing reason>
-""",
+            "Attempted to call function marked as skipped",
         )
 
         cpp_source = """

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -988,7 +988,7 @@ Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especiall
         msg = re.sub(
             r"""(?s)Traceback \(most recent call last\):.*
   File "exc.py", line N, in unimplemented_v2
-    raise Unsupported\(msg\)""",
+    raise Unsupported\(msg, counter_category=gb_type\)""",
             "<Internal traceback>\n",
             msg,
         )

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -1784,9 +1784,15 @@ def forward(self, x_1):
 
         self.assertEqual(len(counters["graph_break"]), 1)
         self.assertEqual(next(iter(counters["graph_break"].values())), 1)
-        self.assertEqual(
-            next(iter(counters["graph_break"].keys())),
-            "Dynamic shape operator",
+        self.assertExpectedInline(
+            next(iter(counters["graph_break"].keys())).replace(";", "\n"),
+            """\
+Dynamic shape operator
+  Explanation: Operator `_torch_testing.numpy_nonzero.default`'s output shape depends on input Tensor data.
+  Hint: Enable tracing of dynamic shape operators with `torch._dynamo.config.capture_dynamic_output_shape_ops = True`
+
+  Developer debug context: _torch_testing.numpy_nonzero.default
+""",
         )
 
     # pre-existing problem: torch.compile(dynamic=True) will, by default,

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -1784,15 +1784,9 @@ def forward(self, x_1):
 
         self.assertEqual(len(counters["graph_break"]), 1)
         self.assertEqual(next(iter(counters["graph_break"].values())), 1)
-        self.assertExpectedInline(
-            next(iter(counters["graph_break"].keys())).replace(";", "\n"),
-            """\
-Dynamic shape operator
-  Explanation: Operator `_torch_testing.numpy_nonzero.default`'s output shape depends on input Tensor data.
-  Hint: Enable tracing of dynamic shape operators with `torch._dynamo.config.capture_dynamic_output_shape_ops = True`
-
-  Developer debug context: _torch_testing.numpy_nonzero.default
-""",
+        self.assertEqual(
+            next(iter(counters["graph_break"].keys())),
+            "Dynamic shape operator",
         )
 
     # pre-existing problem: torch.compile(dynamic=True) will, by default,

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -5538,6 +5538,7 @@ def munge_exc(e, *, suppress_suffix=True, suppress_prefix=True, file=None, skip=
     s = re.sub(r".py:\d+", ".py:N", s)
     s = re.sub(file, _as_posix_path(os.path.basename(file)), s)
     s = re.sub(_as_posix_path(os.path.join(os.path.dirname(torch.__file__), "")), "", s)
+    s = re.sub(r"(https?):/([^/])", r"\1://\2", s)
     if suppress_suffix:
         s = re.sub(r"\n*Set TORCH_LOGS.+", "", s, flags=re.DOTALL)
         s = re.sub(r"\n*You can suppress this exception.+", "", s, flags=re.DOTALL)


### PR DESCRIPTION
Follow up on this comment: https://github.com/pytorch/pytorch/pull/153039#issuecomment-2867827403


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames