### PR TITLE
Enable ruff check for all ipynb files

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -1521,7 +1521,7 @@ code = 'RUFF'
 include_patterns = [
     '**/*.py',
     '**/*.pyi',
-    'torch/utils/data/*.ipynb',
+    '**/*.ipynb',
     'pyproject.toml',
 ]
 exclude_patterns = [


### PR DESCRIPTION
Fixes #146411, following #148654

After test, seems this could be enabled for all ipynb file.

```bash
lintrunner --take RUFF --all-files
Warning: Could not find a lintrunner config at: '.lintrunner.private.toml'. Continuing without using configuration file.
ok No lint issues.
```

