### PR TITLE
[RPC] fix deserialize doesn't respect user pickler

### DIFF
--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -36,7 +36,8 @@ from ._utils import _group_membership_management, _update_group_membership
 from .constants import DEFAULT_SHUTDOWN_TIMEOUT, UNSET_RPC_TIMEOUT
 from .internal import (
     _build_rpc_profiling_key,
-    _internal_rpc_pickler,
+    get_default_pickler,
+    set_default_pickler,
     PythonUDF,
     RPCExecMode,
 )
@@ -67,7 +68,6 @@ logger = logging.getLogger(__name__)
 #
 # To enable RRef leak checking, set this _ignore_rref_leak to False
 _ignore_rref_leak = True
-_default_pickler = _internal_rpc_pickler
 
 
 @contextlib.contextmanager
@@ -75,12 +75,12 @@ def _use_rpc_pickler(rpc_pickler):
     r"""
     rpc_pickler: (.internal._InternalRPCPickler) Overrides the default RPC pickler
     """
-    global _default_pickler
-    _default_pickler = rpc_pickler
+    default_pickler = get_default_pickler()
+    set_default_pickler(rpc_pickler)
     try:
         yield
     finally:
-        _default_pickler = _internal_rpc_pickler
+        set_default_pickler(default_pickler)
 
 
 def _require_initialized(func):
@@ -680,7 +680,7 @@ def remote(to, func, args=None, kwargs=None, timeout=UNSET_RPC_TIMEOUT):
                 **kwargs,
             )
         else:
-            (pickled_python_udf, tensors) = _default_pickler.serialize(
+            (pickled_python_udf, tensors) = get_default_pickler().serialize(
                 PythonUDF(func, args, kwargs)
             )
             rref = _invoke_remote_python_udf(
@@ -736,7 +736,7 @@ def _invoke_rpc(
                 is_async_exec,
             )
         else:
-            (pickled_python_udf, tensors) = _default_pickler.serialize(
+            (pickled_python_udf, tensors) = get_default_pickler().serialize(
                 PythonUDF(func, args, kwargs)
             )
             fut = _invoke_rpc_python_udf(

--- a/torch/distributed/rpc/internal.py
+++ b/torch/distributed/rpc/internal.py
@@ -199,14 +199,22 @@ class _InternalRPCPickler:
 
 # Create _internal_rpc_pickler only once to initialize _dispatch_table only once
 _internal_rpc_pickler = _InternalRPCPickler()
+_default_pickler = _internal_rpc_pickler
+
+def get_default_pickler():
+    return _default_pickler
+
+def set_default_pickler(pickler):
+    global _default_pickler
+    _default_pickler = pickler
 
 
 def serialize(obj):
-    return _internal_rpc_pickler.serialize(obj)
+    return _default_pickler.serialize(obj)
 
 
 def deserialize(binary_data, tensor_table):
-    return _internal_rpc_pickler.deserialize(binary_data, tensor_table)
+    return _default_pickler.deserialize(binary_data, tensor_table)
 
 
 def _run_function(python_udf):

--- a/torch/distributed/rpc/internal.py
+++ b/torch/distributed/rpc/internal.py
@@ -92,13 +92,20 @@ class _InternalRPCPickler:
         torch.jit.save(script_module, f)
         return (_InternalRPCPickler._script_module_receiver, (f.getvalue(),))
 
+    def _pickler(self, f):
+        """
+        User-defined RPCPickler could derive from this class and overide
+        `_pickler` and `_unpickler` to change the underlying pickler.
+        """
+        return _pickler(f)
+
     def serialize(self, obj):
         r"""
         Serialize non tensor data into binary string, tensor data into
         tensor table
         """
         f = io.BytesIO()
-        p = _pickler(f)
+        p = self._pickler(f)
         p.dispatch_table = self._dispatch_table
 
         # rpc api could accept user picklers inheriting from _InternalRPCPickler to serialize rref,
@@ -145,6 +152,13 @@ class _InternalRPCPickler:
 
         return (f.getvalue(), tensors)
 
+    def _unpickler(self, f):
+        """
+        User-defined RPCPickler could derive from this class and overide
+        `_pickler` and `_unpickler` to change the underlying pickler.
+        """
+        return _unpickler(f)
+
     def deserialize(self, binary_data, tensor_table):
         r"""
         Deserialize binary string + tensor table to original obj
@@ -158,7 +172,7 @@ class _InternalRPCPickler:
         _thread_local_tensor_tables.recv_tables = tensor_table
 
         try:
-            unpickler = _unpickler(io.BytesIO(binary_data))
+            unpickler = self._unpickler(io.BytesIO(binary_data))
             ret = unpickler.load()
         except AttributeError as e:
             # Occurs when function is not found on module/class during


### PR DESCRIPTION
TorchRPC provides an interface `_use_rpc_pickler` to override the default pickler. After calling this function, `_default_pickler` is changed, pickle operation in `rpc/api.py` works fine using this variable. However in `rpc/internal.py`, the serialization and deserialization function still use the default `_InternalRPCPickler`, which causes deserialization failure when user custom pickler is used. This PR aims to fix that by moving `_default_pickler` to `rpc/internal.py` and redirecting serialization/deserialization calls to it.

This bug was found when developing #153808. The feature of elegant pickler override in #153808 is also included in this PR,  I will paste the introduction of that PR below.

PR #153808: add interface to _InternalRPCPickler for custom RPCPickler to override underlying pickle library easily.

In TorchRPC, users can change the RPC pickler from `dist.rpc.internal._InternalRPCPickler` to user-customed one using the context manager `dist.rpc.api._use_rpc_pickler`. This is convenient for users who want to change the whole pickling logic. However, the underlying pickle library of _InternalRPCPickler is hard coded. If one only wants to change the underlying pickle library without changing the whole logic (e.g. From pickle to dill), he has to create an inheritance class from _InternalRPCPickler, copy & paste the whole serialize and deserialize function to override them, and just change a single line. To make this progress easier, new interfaces of _InternalRPCPickler including `_pickler(self, f)` and `_unpickler(self, f)` are added. In order to change underlying pickler, after inheriting from _InternalRPCPickler, only these interfaces need to be overrided, providing ease of use.

```python
import torch.distributed.rpc as rpc
import dill

class DillRPCPickler(rpc.internal._InternalRPCPickler):
    def _pickler(self, f):
        return dill.Pickler(f)
    def _unpickler(self, f):
        return dill.Unpickler(f)


pickler = DillRPCPickler()
with rpc.api._use_rpc_pickler(pickler):
    rpc.init_rpc("worker1", rank=0, world_size=2)
    main_function()
    rpc.shutdown()
```


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta