### PR TITLE
[AOTI] SlimTensor-based codegen

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -671,6 +671,14 @@ flatbuffer_cc_library(
 )
 
 cc_library(
+    name = "torch_standalone_headers",
+    hdrs = glob([
+        "torch/standalone/**/*.h"
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
     name = "torch_headers",
     hdrs = if_cuda(
         torch_cuda_headers,
@@ -758,6 +766,7 @@ cc_library(
     deps = [
         ":caffe2",
         ":torch_headers",
+        ":torch_standalone_headers",
         "@kineto",
         "@cpp-httplib",
         "@nlohmann",

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1301,7 +1301,9 @@ target_include_directories(torch_cpu PRIVATE
 target_include_directories(torch_cpu PRIVATE
   ${TORCH_ROOT}/third_party/nlohmann/include)
 
-install(DIRECTORY "${TORCH_SRC_DIR}/csrc"
+install(DIRECTORY
+  "${TORCH_SRC_DIR}/csrc"
+  "${TORCH_SRC_DIR}/standalone"
   DESTINATION ${TORCH_INSTALL_INCLUDE_DIR}/torch
   FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp")
 install(FILES

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -156,6 +156,18 @@ class AOTInductorTestsTemplate:
                 model, example_inputs, "AOTInductorModelRunMinimalArrayrefInterface(", 1
             )
 
+    def test_cos(self):
+        class Model(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+
+            def forward(self, x):
+                y = torch.cos(x)
+                return y
+
+        example_inputs = (torch.randn(16, 10, device=self.device),)
+        self.check_model(Model(), example_inputs)
+
     def test_small_constant(self):
         class Model(torch.nn.Module):
             def __init__(self) -> None:

--- a/test/inductor/test_aot_inductor_standalone.py
+++ b/test/inductor/test_aot_inductor_standalone.py
@@ -1,0 +1,128 @@
+# Owner(s): ["module: inductor"]
+import copy
+import functools
+import sys
+import unittest
+
+from torch._inductor import config
+from torch._inductor.test_case import TestCase
+from torch.testing._internal.common_utils import (
+    IS_CI,
+    IS_WINDOWS,
+    skipIfRocm,
+    skipIfXpu,
+)
+from torch.testing._internal.inductor_utils import GPU_TYPE
+
+
+if IS_WINDOWS and IS_CI:
+    sys.stderr.write(
+        "Windows CI does not have necessary dependencies for test_torchinductor yet\n"
+    )
+    if __name__ == "__main__":
+        sys.exit(0)
+    raise unittest.SkipTest("requires sympy/functorch/filelock")
+
+try:
+    try:
+        from .test_aot_inductor import (
+            AOTInductorTestsTemplate,
+            check_model,
+            check_model_with_multiple_inputs,
+            code_check_count,
+        )
+    except ImportError:
+        from test_aot_inductor import (  # @manual
+            AOTInductorTestsTemplate,
+            check_model,
+            check_model_with_multiple_inputs,
+            code_check_count,
+        )
+except (unittest.SkipTest, ImportError):
+    if __name__ == "__main__":
+        sys.exit(0)
+    raise
+
+
+# Similar to copy_tests in test_torchinductor.py, but only takes a whitelist of tests
+def copy_tests(my_cls, other_cls, suffix, whitelist):  # noqa: B902
+    for name, value in my_cls.__dict__.items():
+        if name.startswith("test_") and name in whitelist:
+            # You cannot copy functions in Python, so we use closures here to
+            # create objects with different ids. Otherwise, unittest.skip
+            # would modify all methods sharing the same object id. Also, by
+            # using a default argument, we create a copy instead of a
+            # reference. Otherwise, we would lose access to the value.
+
+            @functools.wraps(value)
+            @config.patch(
+                {
+                    "aot_inductor.codegen_standalone": True,
+                    "max_autotune_gemm_backends": "TRITON",
+                    "max_autotune_conv_backends": "TRITON",
+                }
+            )
+            @skipIfXpu
+            @skipIfRocm
+            def new_test(self, value=value):
+                return value(self)
+
+            # Copy __dict__ which may contain test metadata
+            new_test.__dict__ = copy.deepcopy(value.__dict__)
+            setattr(other_cls, f"{name}_{suffix}", new_test)
+
+    # Special case convenience routine
+    if hasattr(my_cls, "is_dtype_supported"):
+        other_cls.is_dtype_supported = my_cls.is_dtype_supported
+
+
+test_list_cpu = {
+    # Need to sort out third-party library build issues, e.g. blas, sleef
+}
+
+
+class AOTInductorTestLibtorchFreeCpu(TestCase):
+    device = "cpu"
+    device_type = "cpu"
+    check_model = check_model
+    check_model_with_multiple_inputs = check_model_with_multiple_inputs
+    code_check_count = code_check_count
+    allow_stack_allocation = False
+    use_minimal_arrayref_interface = False
+
+
+copy_tests(
+    AOTInductorTestsTemplate,
+    AOTInductorTestLibtorchFreeCpu,
+    "cpu_standalone",
+    test_list_cpu,
+)
+
+test_list_gpu = {
+    "test_cos",
+}
+
+
+@unittest.skipIf(sys.platform == "darwin", "No CUDA on MacOS")
+class AOTInductorTestLibtorchFreeGpu(TestCase):
+    device = GPU_TYPE
+    device_type = GPU_TYPE
+    check_model = check_model
+    check_model_with_multiple_inputs = check_model_with_multiple_inputs
+    code_check_count = code_check_count
+    allow_stack_allocation = False
+    use_minimal_arrayref_interface = False
+
+
+copy_tests(
+    AOTInductorTestsTemplate,
+    AOTInductorTestLibtorchFreeGpu,
+    f"{GPU_TYPE}_standalone",
+    test_list_gpu,
+)
+
+
+if __name__ == "__main__":
+    from torch._inductor.test_case import run_tests
+
+    run_tests(needs="filelock")

--- a/test/inductor/test_aot_inductor_standalone.py
+++ b/test/inductor/test_aot_inductor_standalone.py
@@ -13,6 +13,7 @@ from torch.testing._internal.common_utils import (
     skipIfXpu,
 )
 from torch.testing._internal.inductor_utils import GPU_TYPE
+from torch.testing._internal.triton_utils import HAS_GPU
 
 
 if IS_WINDOWS and IS_CI:
@@ -81,7 +82,7 @@ test_list_cpu = {
 }
 
 
-class AOTInductorTestLibtorchFreeCpu(TestCase):
+class AOTInductorTestStandaloneCpu(TestCase):
     device = "cpu"
     device_type = "cpu"
     check_model = check_model
@@ -93,7 +94,7 @@ class AOTInductorTestLibtorchFreeCpu(TestCase):
 
 copy_tests(
     AOTInductorTestsTemplate,
-    AOTInductorTestLibtorchFreeCpu,
+    AOTInductorTestStandaloneCpu,
     "cpu_standalone",
     test_list_cpu,
 )
@@ -104,7 +105,7 @@ test_list_gpu = {
 
 
 @unittest.skipIf(sys.platform == "darwin", "No CUDA on MacOS")
-class AOTInductorTestLibtorchFreeGpu(TestCase):
+class AOTInductorTestStandaloneGpu(TestCase):
     device = GPU_TYPE
     device_type = GPU_TYPE
     check_model = check_model
@@ -116,7 +117,7 @@ class AOTInductorTestLibtorchFreeGpu(TestCase):
 
 copy_tests(
     AOTInductorTestsTemplate,
-    AOTInductorTestLibtorchFreeGpu,
+    AOTInductorTestStandaloneGpu,
     f"{GPU_TYPE}_standalone",
     test_list_gpu,
 )
@@ -125,4 +126,5 @@ copy_tests(
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests
 
-    run_tests(needs="filelock")
+    if HAS_GPU:
+        run_tests(needs="filelock")

--- a/torch/_inductor/codegen/cpp_template.py
+++ b/torch/_inductor/codegen/cpp_template.py
@@ -124,8 +124,13 @@ class CppTemplate(KernelTemplate):
         res = IndentedBuffer()
         res.writeline("#include <torch/csrc/inductor/cpp_prefix.h>")
         # TODO: add c10::ForcedUnroll test to test_aoti_abi_check
-        res.splice("""#include <c10/util/Unroll.h>""")
-        res.splice("""#include <torch/csrc/inductor/aoti_torch/c/shim.h>""")
+        res.splice("""
+            #include <c10/util/Unroll.h>
+            #ifdef AOTI_STANDALONE
+            #include <torch/csrc/inductor/aoti_standalone/c/shim.h>
+            #else
+            #include <torch/csrc/inductor/aoti_torch/c/shim.h>
+            #endif // AOTI_STANDALONE""")
         enable_kernel_profile = config.cpp.enable_kernel_profile and sys.platform in [
             "linux",
             "win32",

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -172,7 +172,9 @@ class CppWrapperCpu(PythonWrapperCodegen):
         # present.
         self.header.splice(self.get_device_include_path(device))
         extend_aoti_c_shim_include = (
-            f"torch/csrc/inductor/aoti_torch/generated/extend/c_shim_{self.device}.h"
+            f"torch/csrc/inductor/aoti_standalone/{self.device}/c_shim_{self.device}.h"
+            if config.aot_inductor.codegen_standalone
+            else f"torch/csrc/inductor/aoti_torch/generated/extend/c_shim_{self.device}.h"
         )
         extend_aoti_c_shim_path = os.path.join(
             os.path.dirname(torch.__file__),
@@ -942,6 +944,8 @@ class CppWrapperCpu(PythonWrapperCodegen):
             self.codegen_const_run_driver()
             aot_mode_decls.writeline("} // namespace torch::aot_inductor")
             aot_mode_decls.writeline("using namespace torch::aot_inductor;")
+            if config.aot_inductor.codegen_standalone:
+                aot_mode_decls.writeline("using namespace torch::standalone;")
 
         self.prefix = cache_decls = IndentedBuffer()
         for dtype in self.used_cached_dtypes:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1261,7 +1261,7 @@ class aot_inductor:
     force_mmap_weights: bool = False
 
     package: bool = False
-    package_cpp_only: bool = False
+    package_cpp_only: bool = os.environ.get("AOT_INDUCTOR_PACKAGE_CPP_ONLY", "0") == "1"
 
     # Dictionary of metadata users might want to save to pass to the runtime.
     # TODO: Move this somewhere else, since it's no longer really a config
@@ -1305,6 +1305,11 @@ class aot_inductor:
 
     # Experimental.  Controls automatic precompiling of common AOTI include files.
     precompile_headers: bool = not is_fbcode()
+
+    # Experimental.  Controls whether to generate model code in a standalone way.
+    codegen_standalone: bool = (
+        os.environ.get("AOT_INDUCTOR_CODEGEN_STANDALONE", "0") == "1"
+    )
 
     # Embed generated .cubin files into the .so
     embed_cubin: bool = False

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -528,8 +528,8 @@ class BuildOptionsBase:
             json.dump(attrs, f)
 
 
-def _get_warning_all_cflag(warning_all: bool = True) -> list[str]:
-    if not _IS_WINDOWS:
+def _get_warning_all_cflag(cpp_compiler: str, warning_all: bool = True) -> list[str]:
+    if not _IS_WINDOWS and "nvcc" not in cpp_compiler:
         return ["Wall"] if warning_all else []
     else:
         return []
@@ -566,6 +566,8 @@ def _get_os_related_cpp_cflags(cpp_compiler: str) -> list[str]:
             "EHsc",
         ]
     else:
+        if "nvcc" in cpp_compiler:
+            return []
         cflags = ["Wno-unused-variable", "Wno-unknown-pragmas"]
         if _is_clang(cpp_compiler):
             ignored_optimization_argument = (
@@ -610,6 +612,11 @@ def _get_optimization_cflags(
             if config.aot_inductor.debug_compile
             else [wrapper_opt_level if min_optimize else "O3", "DNDEBUG"]
         )
+        if "nvcc" in cpp_compiler:
+            from .codecache import _nvcc_get_arch_option
+
+            return [_nvcc_get_arch_option()]
+
         cflags += _get_ffast_math_flags()
         cflags.append("fno-finite-math-only")
         if not config.cpp.enable_unsafe_math_opt_flag:
@@ -664,7 +671,7 @@ def get_cpp_options(
     cflags = (
         _get_shared_cflag(do_link)
         + _get_optimization_cflags(cpp_compiler, min_optimize)
-        + _get_warning_all_cflag(warning_all)
+        + _get_warning_all_cflag(cpp_compiler, warning_all)
         + _get_cpp_std_cflag()
         + _get_os_related_cpp_cflags(cpp_compiler)
     )
@@ -746,7 +753,10 @@ def _get_glibcxx_abi_build_flags() -> list[str]:
 
 
 def _get_torch_cpp_wrapper_definition() -> list[str]:
-    return ["TORCH_INDUCTOR_CPP_WRAPPER", "STANDALONE_TORCH_HEADER"]
+    macros = ["TORCH_INDUCTOR_CPP_WRAPPER", "STANDALONE_TORCH_HEADER"]
+    if config.aot_inductor.codegen_standalone:
+        macros.append("AOTI_STANDALONE")
+    return macros
 
 
 def _use_custom_generated_macros() -> list[str]:
@@ -838,7 +848,11 @@ def _get_torch_related_args(
     include_dirs = include_paths()
     libraries_dirs = [TORCH_LIB_PATH]
     libraries = []
-    if sys.platform != "darwin" and not config.is_fbcode():
+    if (
+        sys.platform != "darwin"
+        and not config.is_fbcode()
+        and not config.aot_inductor.codegen_standalone
+    ):
         libraries = ["torch", "torch_cpu"]
         if not aot_mode:
             libraries.append("torch_python")
@@ -1102,7 +1116,9 @@ def get_cpp_torch_options(
         sys_libs_passthrough_args,
     ) = _setup_standard_sys_libs(cpp_compiler, aot_mode, use_relative_path)
 
-    isa_macros, isa_ps_args_build_flags = _get_build_args_of_chosen_isa(vec_isa)
+    isa_macros, isa_ps_args_build_flags = (
+        ([], []) if "nvcc" in cpp_compiler else _get_build_args_of_chosen_isa(vec_isa)
+    )
 
     (
         torch_include_dirs,
@@ -1139,7 +1155,7 @@ def get_cpp_torch_options(
         + torch_include_dirs
         + omp_include_dir_paths
     )
-    cflags = sys_libs_cflags + omp_cflags
+    cflags = [] if "nvcc" in cpp_compiler else sys_libs_cflags + omp_cflags
     ldflags = omp_ldflags
     libraries_dirs = python_libraries_dirs + torch_libraries_dirs + omp_lib_dir_paths
     libraries = torch_libraries + omp_lib
@@ -1288,6 +1304,7 @@ def get_cpp_torch_device_options(
 
     include_dirs = cpp_extension.include_paths(device_type)
     libraries_dirs = cpp_extension.library_paths(device_type)
+
     if device_type == "cuda":
         definitions.append(" USE_ROCM" if torch.version.hip else " USE_CUDA")
 
@@ -1298,13 +1315,14 @@ def get_cpp_torch_device_options(
                 libraries += ["c10_hip", "torch_hip"]
             definitions.append(" __HIP_PLATFORM_AMD__")
         else:
-            if config.is_fbcode():
-                libraries += ["cuda"]
-            else:
-                libraries += ["c10_cuda", "cuda", "torch_cuda"]
+            libraries.append("cuda")
+            if config.aot_inductor.codegen_standalone:
+                libraries.append("cublas")
+            if not config.is_fbcode() and not config.aot_inductor.codegen_standalone:
+                libraries.extend(["c10_cuda", "torch_cuda"])
             _transform_cuda_paths(libraries_dirs)
 
-    if device_type == "xpu":
+    elif device_type == "xpu":
         definitions.append(" USE_XPU")
         # Suppress multi-line comment warnings in sycl headers
         cflags += ["Wno-comment"]
@@ -1344,6 +1362,7 @@ class CppTorchDeviceOptions(CppTorchOptions):
 
     def __init__(
         self,
+        compiler: str = "",
         vec_isa: VecISA = invalid_vec_isa,
         include_pytorch: bool = False,
         device_type: str = "cuda",
@@ -1358,6 +1377,7 @@ class CppTorchDeviceOptions(CppTorchOptions):
         preprocessing: bool = False,
     ) -> None:
         super().__init__(
+            compiler=compiler,
             vec_isa=vec_isa,
             include_pytorch=include_pytorch,
             aot_mode=aot_mode,

--- a/torch/csrc/inductor/aoti_runner/model_container_runner.h
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner.h
@@ -33,6 +33,12 @@ class TORCH_API AOTIModelContainerRunner {
       std::vector<at::Tensor>&& inputs,
       void* stream_handle = nullptr);
 
+  // inputs and outputs are flattened, used for calling from
+  // AtenTensor to SlimTensor
+  virtual std::vector<at::Tensor> slim_tensor_run(
+      std::vector<at::Tensor>&& inputs,
+      void* stream_handle = nullptr);
+
   std::unordered_map<std::string, std::string> getConstantNamesToOriginalFQNs()
       const;
   std::unordered_map<std::string, int32_t> getConstantNamesToDtypes() const;
@@ -70,6 +76,11 @@ class TORCH_API AOTIModelContainerRunner {
       std::vector<AtenTensorHandle>& input_handles,
       void* stream_handle);
 
+  std::vector<at::Tensor> slim_tensor_run_impl(
+      std::vector<at::Tensor>&& inputs,
+      void* stream_handle,
+      const std::function<void(void*)>& deleter);
+
   std::unique_ptr<at::DynamicLibrary> model_so_;
   decltype(&AOTInductorModelContainerCreateWithDevice) create_func_{nullptr};
   decltype(&AOTInductorModelContainerDelete) delete_func_{nullptr};
@@ -100,9 +111,9 @@ class TORCH_API AOTIModelContainerRunner {
       free_inactive_constant_buffer_func_{nullptr};
   decltype(&AOTInductorModelContainerGetCallSpec) get_call_spec_func_{nullptr};
 
-  AOTInductorModelContainerHandle container_handle_ = nullptr;
+  AOTInductorModelContainerHandle container_handle_{nullptr};
 
-  AOTIProxyExecutorHandle proxy_executor_handle_;
+  AOTIProxyExecutorHandle proxy_executor_handle_{nullptr};
 
  private:
   std::unique_ptr<torch::aot_inductor::ProxyExecutor> proxy_executor_;

--- a/torch/csrc/inductor/aoti_runner/model_container_runner_cuda.h
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner_cuda.h
@@ -29,6 +29,10 @@ class TORCH_CUDA_CPP_API AOTIModelContainerRunnerCuda
   std::vector<at::Tensor> run_with_cuda_stream(
       const std::vector<at::Tensor>& inputs,
       const at::cuda::CUDAStream& cuda_stream);
+
+  std::vector<at::Tensor> slim_tensor_run(
+      std::vector<at::Tensor>&& inputs,
+      void* stream_handle = nullptr) override;
 };
 
 } // namespace torch::inductor

--- a/torch/csrc/inductor/aoti_runner/model_container_runner_xpu.cpp
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner_xpu.cpp
@@ -50,6 +50,8 @@ std::unique_ptr<AOTIModelContainerRunner> create_aoti_runner_xpu(
 }
 } // namespace
 
-RegisterAOTIModelRunner register_xpu_runner("xpu", &create_aoti_runner_xpu);
+static RegisterAOTIModelRunner register_xpu_runner(
+    "xpu",
+    &create_aoti_runner_xpu);
 } // namespace torch::inductor
 #endif

--- a/torch/csrc/inductor/aoti_runtime/arrayref_tensor.h
+++ b/torch/csrc/inductor/aoti_runtime/arrayref_tensor.h
@@ -2,8 +2,11 @@
 
 #include <torch/csrc/inductor/aoti_runtime/mini_array_ref.h>
 #include <torch/csrc/inductor/aoti_runtime/utils.h>
+#ifdef AOTI_STANDALONE
+#include <torch/csrc/inductor/aoti_standalone/c/shim.h>
+#else
 #include <torch/csrc/inductor/aoti_torch/c/shim.h>
-
+#endif // AOTI_STANDALONE
 #include <cassert>
 #include <cstdint>
 #include <cstring>

--- a/torch/csrc/inductor/aoti_runtime/model.h
+++ b/torch/csrc/inductor/aoti_runtime/model.h
@@ -609,6 +609,7 @@ class AOTInductorModelBase {
     auto magic_number =
         reinterpret_cast<const uint64_t*>(_binary_constants_bin_start)[1];
     auto weights_offset = fsize - weights_size;
+
     AOTI_RUNTIME_CHECK(
         (weights_offset & 0x3fff) == 0,
         "weights_offset must be aligned to 16K boundary");

--- a/torch/csrc/inductor/aoti_runtime/scalar_to_tensor.h
+++ b/torch/csrc/inductor/aoti_runtime/scalar_to_tensor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#ifndef AOTI_STANDALONE
 #include <c10/util/complex.h>
 #include <torch/csrc/inductor/aoti_runtime/utils.h>
 
@@ -36,3 +37,4 @@ AOTI_RUNTIME_SCALAR_TO_TENSOR(complex128, c10::complex<double>)
 #undef AOTI_RUNTIME_SCALAR_TO_TENSOR
 
 } // namespace torch::aot_inductor
+#endif // AOTI_STANDALONE

--- a/torch/csrc/inductor/aoti_runtime/utils.h
+++ b/torch/csrc/inductor/aoti_runtime/utils.h
@@ -11,7 +11,11 @@
 // in model.so, and should not refer to any aten/c10 headers except the stable
 // C ABI defined in torch/csrc/inductor/aoti_torch/c/shim.h. The same rule
 // applies to other files under torch/csrc/inductor/aoti_runtime/.
+#ifdef AOTI_STANDALONE
+#include <torch/csrc/inductor/aoti_standalone/c/shim.h>
+#else
 #include <torch/csrc/inductor/aoti_torch/c/shim.h>
+#endif // AOTI_STANDALONE
 
 #if defined(__GNUC__) || defined(__clang__)
 #define AOTI_NOINLINE __attribute__((noinline))
@@ -351,6 +355,7 @@ inline AtenTensorHandle wrap_with_raii_handle_if_needed(
 // This should only be called in cases where the C-shim API expects an optional
 // input argument (passed by pointer), and a temporary needs to be passed to it.
 template <class T>
+// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
 T& temporary_reference(T&& t) {
   return t;
 }

--- a/torch/csrc/inductor/aoti_runtime/utils_cuda.h
+++ b/torch/csrc/inductor/aoti_runtime/utils_cuda.h
@@ -1,10 +1,15 @@
 #pragma once
 
-#ifdef USE_CUDA
 // WARNING: Be careful when adding new includes here. This header will be used
 // in model.so, and should not refer to any aten/c10 headers except the stable
 // C ABI defined in torch/csrc/inductor/aoti_torch/c/shim.h. The same rule
 // applies to other files under torch/csrc/inductor/aoti_runtime/.
+
+#ifdef USE_CUDA
+#ifdef AOTI_STANDALONE
+#include <torch/csrc/inductor/aoti_standalone/cuda/utils.h>
+
+#else // AOTI_STANDALONE
 #include <torch/csrc/inductor/aoti_runtime/utils.h>
 
 #include <cuda.h>
@@ -59,4 +64,5 @@ class AOTICudaStreamGuard {
 };
 
 } // namespace torch::aot_inductor
+#endif // AOTI_STANDALONE
 #endif // USE_CUDA

--- a/torch/csrc/inductor/aoti_standalone/c/shim.h
+++ b/torch/csrc/inductor/aoti_standalone/c/shim.h
@@ -5,6 +5,7 @@
 #include <torch/csrc/inductor/aoti_standalone/c/shim_device.h>
 #include <torch/csrc/inductor/aoti_standalone/c/shim_dtype.h>
 #include <torch/csrc/inductor/aoti_standalone/c/shim_layout.h>
+#include <torch/csrc/inductor/aoti_standalone/utils.h>
 #include <torch/standalone/slim_tensor/slim_tensor.h>
 
 using AtenTensorOpaque = torch::standalone::SlimTensor;

--- a/torch/csrc/inductor/aoti_standalone/c/shim.h
+++ b/torch/csrc/inductor/aoti_standalone/c/shim.h
@@ -1,0 +1,222 @@
+#pragma once
+
+// This header mimics APIs in aoti_torch/c/shim.h in a standalone way
+
+#include <torch/csrc/inductor/aoti_standalone/c/shim_device.h>
+#include <torch/csrc/inductor/aoti_standalone/c/shim_dtype.h>
+#include <torch/csrc/inductor/aoti_standalone/c/shim_layout.h>
+#include <torch/standalone/slim_tensor/slim_tensor.h>
+
+using AtenTensorOpaque = torch::standalone::SlimTensor;
+using AtenTensorHandle = torch::standalone::SlimTensor*;
+
+// AOTIProxyExecutorHandle isn't supported in standalone mode.
+// Just defining it to void* to make the code compile
+using AOTIProxyExecutorHandle = void*;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+inline bool aoti_torch_grad_mode_is_enabled() {
+  return false;
+}
+
+inline void aoti_torch_grad_mode_set_enabled(bool enabled) {
+  // do nothing
+}
+
+inline AOTITorchError aoti_torch_delete_tensor_object(AtenTensorHandle tensor) {
+  delete tensor;
+  return AOTI_TORCH_SUCCESS;
+}
+
+inline AOTITorchError aoti_torch_get_data_ptr(
+    AtenTensorHandle tensor,
+    void** ret_data_ptr) {
+  *ret_data_ptr = tensor->data_ptr();
+  return AOTI_TORCH_SUCCESS;
+}
+
+inline AOTITorchError aoti_torch_get_dtype(
+    AtenTensorHandle tensor,
+    int32_t* ret_dtype) {
+  *ret_dtype = static_cast<int32_t>(tensor->dtype());
+  return AOTI_TORCH_SUCCESS;
+}
+
+inline AOTITorchError aoti_torch_get_device_type(
+    AtenTensorHandle tensor,
+    int32_t* ret_device_type) {
+  *ret_device_type = static_cast<int32_t>(tensor->device_type());
+  return AOTI_TORCH_SUCCESS;
+}
+
+inline AOTITorchError aoti_torch_get_device_index(
+    AtenTensorHandle tensor,
+    int32_t* ret_device_index) {
+  *ret_device_index = static_cast<uint8_t>(tensor->device_index());
+  return AOTI_TORCH_SUCCESS;
+}
+
+inline AOTITorchError aoti_torch_get_sizes(
+    AtenTensorHandle tensor,
+    int64_t** ret_sizes) {
+  *ret_sizes = (int64_t*)tensor->sizes().data();
+  return AOTI_TORCH_SUCCESS;
+}
+
+inline AOTITorchError aoti_torch_get_size(
+    AtenTensorHandle tensor,
+    int64_t d,
+    int64_t* ret_size) {
+  *ret_size = tensor->size(d);
+  return AOTI_TORCH_SUCCESS;
+}
+
+inline AOTITorchError aoti_torch_get_strides(
+    AtenTensorHandle tensor,
+    int64_t** ret_strides) {
+  *ret_strides = (int64_t*)tensor->strides().data();
+  return AOTI_TORCH_SUCCESS;
+}
+
+inline AOTITorchError aoti_torch_get_stride(
+    AtenTensorHandle tensor,
+    int64_t d,
+    int64_t* ret_stride) {
+  *ret_stride = tensor->stride(d);
+  return AOTI_TORCH_SUCCESS;
+}
+
+inline AOTITorchError aoti_torch_get_storage_size(
+    AtenTensorHandle tensor,
+    int64_t* ret_size) {
+  *ret_size = static_cast<int64_t>(tensor->nbytes());
+  return AOTI_TORCH_SUCCESS;
+}
+
+inline AOTITorchError aoti_torch_get_storage_offset(
+    AtenTensorHandle tensor,
+    int64_t* ret_storage_offset) {
+  *ret_storage_offset = tensor->storage_offset();
+  return AOTI_TORCH_SUCCESS;
+}
+
+inline AOTITorchError aoti_torch_new_tensor_handle(
+    AtenTensorHandle orig_handle,
+    AtenTensorHandle* new_handle) {
+  *new_handle = new torch::standalone::SlimTensor(*orig_handle);
+  return AOTI_TORCH_SUCCESS;
+}
+
+inline AOTITorchError aoti_torch_create_tensor_from_blob_v2(
+    void* data,
+    int64_t ndim,
+    const int64_t* sizes_ptr,
+    const int64_t* strides_ptr,
+    int64_t storage_offset,
+    int32_t dtype,
+    int32_t device_type,
+    int32_t device_index,
+    AtenTensorHandle* ret_new_tensor,
+    int32_t layout,
+    const uint8_t* opaque_metadata,
+    int64_t opaque_metadata_size) {
+  torch::standalone::ArrayRef sizes(sizes_ptr, ndim);
+  torch::standalone::ArrayRef strides(strides_ptr, ndim);
+  *ret_new_tensor = new torch::standalone::SlimTensor(create_tensor_from_blob(
+      data,
+      sizes,
+      strides,
+      static_cast<c10::ScalarType>(dtype),
+      {static_cast<c10::DeviceType>(device_type),
+       static_cast<c10::DeviceIndex>(device_index)},
+      storage_offset));
+  return AOTI_TORCH_SUCCESS;
+}
+
+inline AOTITorchError aoti_torch_empty_strided(
+    int64_t ndim,
+    const int64_t* sizes_ptr,
+    const int64_t* strides_ptr,
+    int32_t dtype,
+    int32_t device_type,
+    int32_t device_index,
+    AtenTensorHandle* ret_new_tensor) {
+  torch::standalone::ArrayRef sizes(sizes_ptr, ndim);
+  torch::standalone::ArrayRef strides(strides_ptr, ndim);
+  *ret_new_tensor = new torch::standalone::SlimTensor(create_empty_tensor(
+      sizes,
+      strides,
+      static_cast<c10::ScalarType>(dtype),
+      {static_cast<c10::DeviceType>(device_type),
+       static_cast<c10::DeviceIndex>(device_index)},
+      0));
+  return AOTI_TORCH_SUCCESS;
+}
+
+inline AOTITorchError aoti_torch__reinterpret_tensor(
+    AtenTensorHandle self,
+    int64_t ndim,
+    const int64_t* sizes_ptr,
+    const int64_t* strides_ptr,
+    int64_t offset_increment,
+    AtenTensorHandle* ret_new_tensor) {
+  torch::standalone::ArrayRef sizes(sizes_ptr, ndim);
+  torch::standalone::ArrayRef strides(strides_ptr, ndim);
+  *ret_new_tensor = new torch::standalone::SlimTensor(
+      self->storage(),
+      sizes,
+      strides,
+      self->dtype(),
+      self->storage_offset() + offset_increment);
+  return AOTI_TORCH_SUCCESS;
+}
+
+inline AOTITorchError aoti_torch_as_strided(
+    AtenTensorHandle self,
+    const int64_t* sizes_ptr,
+    const int64_t* strides_ptr,
+    AtenTensorHandle* ret) {
+  torch::standalone::ArrayRef sizes(sizes_ptr, self->dim());
+  torch::standalone::ArrayRef strides(strides_ptr, self->dim());
+  *ret = new torch::standalone::SlimTensor(
+      self->storage(), sizes, strides, self->dtype(), self->storage_offset());
+  return AOTI_TORCH_SUCCESS;
+}
+
+inline AOTITorchError aoti_torch_clone(
+    AtenTensorHandle self,
+    AtenTensorHandle* ret) {
+  torch::standalone::SlimTensor tmp_tensor = create_empty_tensor(
+      self->sizes(),
+      self->strides(),
+      self->dtype(),
+      {self->device_type(), self->device_index()},
+      0);
+  tmp_tensor.copy_(*self);
+  *ret = new torch::standalone::SlimTensor(tmp_tensor);
+  return AOTI_TORCH_SUCCESS;
+}
+
+inline AOTITorchError aoti_torch_clone_preserve_strides(
+    AtenTensorHandle self,
+    AtenTensorHandle* ret) {
+  int64_t needed_size = 1;
+  for (size_t i = 0; i < self->dim(); i++) {
+    if (self->size(i) == 0) {
+      needed_size = 0;
+      break;
+    }
+    needed_size += (self->size(i) - 1) * self->stride(i);
+  }
+  torch::standalone::SlimTensor tmp_tensor = *self;
+  tmp_tensor.as_strided_({needed_size}, {1}, 0);
+  aoti_torch_clone(&tmp_tensor, ret);
+  (*ret)->as_strided_(self->sizes(), self->strides(), self->storage_offset());
+  return AOTI_TORCH_SUCCESS;
+}
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/torch/csrc/inductor/aoti_standalone/c/shim_device.h
+++ b/torch/csrc/inductor/aoti_standalone/c/shim_device.h
@@ -1,0 +1,25 @@
+#pragma once
+
+// This header mimics APIs in aoti_torch/c/shim.h in a standalone way
+
+// TODO: Move DeviceType to a header-only directory
+#include <c10/core/DeviceType.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define AOTI_TORCH_DEVICE_TYPE_IMPL(device_str, device_type) \
+  inline int32_t aoti_torch_device_type_##device_str() {     \
+    return (int32_t)c10::DeviceType::device_type;            \
+  }
+
+AOTI_TORCH_DEVICE_TYPE_IMPL(cpu, CPU)
+AOTI_TORCH_DEVICE_TYPE_IMPL(cuda, CUDA)
+AOTI_TORCH_DEVICE_TYPE_IMPL(mps, MPS)
+AOTI_TORCH_DEVICE_TYPE_IMPL(xpu, XPU)
+#undef AOTI_TORCH_DEVICE_TYPE_IMPL
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/torch/csrc/inductor/aoti_standalone/c/shim_dtype.h
+++ b/torch/csrc/inductor/aoti_standalone/c/shim_dtype.h
@@ -1,0 +1,40 @@
+#pragma once
+
+// This header mimics APIs in aoti_torch/c/shim.h in a standalone way
+
+// TODO: Move ScalarType to a header-only directory
+#include <c10/core/ScalarType.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#define AOTI_TORCH_DTYPE_IMPL(dtype, stype)   \
+  inline int32_t aoti_torch_dtype_##dtype() { \
+    return (int32_t)c10::ScalarType::stype;   \
+  }
+
+AOTI_TORCH_DTYPE_IMPL(float8_e5m2, Float8_e5m2)
+AOTI_TORCH_DTYPE_IMPL(float8_e4m3fn, Float8_e4m3fn)
+AOTI_TORCH_DTYPE_IMPL(float8_e5m2fnuz, Float8_e5m2fnuz)
+AOTI_TORCH_DTYPE_IMPL(float8_e4m3fnuz, Float8_e4m3fnuz)
+AOTI_TORCH_DTYPE_IMPL(bfloat16, BFloat16)
+AOTI_TORCH_DTYPE_IMPL(float16, Half)
+AOTI_TORCH_DTYPE_IMPL(float32, Float)
+AOTI_TORCH_DTYPE_IMPL(float64, Double)
+AOTI_TORCH_DTYPE_IMPL(uint8, Byte)
+AOTI_TORCH_DTYPE_IMPL(uint16, UInt16)
+AOTI_TORCH_DTYPE_IMPL(uint32, UInt32)
+AOTI_TORCH_DTYPE_IMPL(uint64, UInt64)
+AOTI_TORCH_DTYPE_IMPL(int8, Char)
+AOTI_TORCH_DTYPE_IMPL(int16, Short)
+AOTI_TORCH_DTYPE_IMPL(int32, Int)
+AOTI_TORCH_DTYPE_IMPL(int64, Long)
+AOTI_TORCH_DTYPE_IMPL(bool, Bool)
+AOTI_TORCH_DTYPE_IMPL(complex32, ComplexHalf)
+AOTI_TORCH_DTYPE_IMPL(complex64, ComplexFloat)
+AOTI_TORCH_DTYPE_IMPL(complex128, ComplexDouble)
+#undef AOTI_TORCH_DTYPE_IMPL
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/torch/csrc/inductor/aoti_standalone/c/shim_layout.h
+++ b/torch/csrc/inductor/aoti_standalone/c/shim_layout.h
@@ -1,0 +1,29 @@
+#pragma once
+
+// This header mimics APIs in aoti_torch/c/shim.h in a standalone way
+
+// TODO: Move Layout to a header-only directory
+#include <c10/core/Layout.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define AOTI_LAYOUT_IMPL(layout_str, layout_type)   \
+  inline int32_t aoti_torch_layout_##layout_str() { \
+    return (int32_t)c10::Layout::layout_type;       \
+  }
+
+AOTI_LAYOUT_IMPL(strided, Strided)
+AOTI_LAYOUT_IMPL(sparse, Sparse)
+AOTI_LAYOUT_IMPL(sparse_csr, SparseCsr)
+AOTI_LAYOUT_IMPL(mkldnn, Mkldnn)
+AOTI_LAYOUT_IMPL(sparse_csc, SparseCsc)
+AOTI_LAYOUT_IMPL(sparse_bsr, SparseBsr)
+AOTI_LAYOUT_IMPL(sparse_bsc, SparseBsc)
+AOTI_LAYOUT_IMPL(jagged, Jagged)
+#undef AOTI_LAYOUT_IMPL
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/torch/csrc/inductor/aoti_standalone/cuda/utils.h
+++ b/torch/csrc/inductor/aoti_standalone/cuda/utils.h
@@ -1,0 +1,175 @@
+#pragma once
+#ifdef USE_CUDA
+
+#include <cuda.h>
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <iostream>
+#include <stdexcept>
+#include <unordered_map>
+
+#include <c10/core/Device.h>
+
+namespace torch::standalone {
+
+inline void throw_cuda_error(cudaError_t err) {
+  if (err != cudaSuccess) {
+    throw std::runtime_error(std::string(cudaGetErrorString(err)));
+  }
+}
+
+// Used in destructor because can't throw in destructor
+inline void print_cuda_error(cudaError_t err) {
+  if (err != cudaSuccess) {
+    // NOLINTNEXTLINE(performance-avoid-endl)
+    std::cerr << cudaGetErrorString(err) << std::endl;
+  }
+}
+
+class AOTICudaGuard {
+ public:
+  AOTICudaGuard(int32_t device_index) : device_(device_index) {
+    // Save original device
+    throw_cuda_error(cudaGetDevice(&prev_device_));
+    // Switch to the target device if necessary
+    if (prev_device_ != device_) {
+      throw_cuda_error(cudaSetDevice(device_));
+    }
+  }
+
+  AOTICudaGuard(const c10::Device& device)
+      : AOTICudaGuard(static_cast<int32_t>(device.index())) {}
+
+  AOTICudaGuard() = delete;
+  AOTICudaGuard(const AOTICudaGuard&) = delete;
+  AOTICudaGuard& operator=(const AOTICudaGuard&) = delete;
+  AOTICudaGuard(AOTICudaGuard&& other) = delete;
+  AOTICudaGuard& operator=(AOTICudaGuard&& other) = delete;
+
+  ~AOTICudaGuard() {
+    // Restore the original device if necessary
+    if (prev_device_ != device_) {
+      print_cuda_error(cudaSetDevice(prev_device_));
+    }
+  }
+
+  void set_index(int32_t device_index) {
+    device_ = device_index;
+    throw_cuda_error(cudaSetDevice(device_));
+  }
+
+ private:
+  int32_t prev_device_ = 0;
+  int32_t device_;
+};
+
+inline std::unordered_map<int, cudaStream_t> current_streams;
+
+// Get the current stream for a specific device
+inline cudaStream_t get_current_stream(int32_t device) {
+  auto it = current_streams.find(device);
+  return (it != current_streams.end()) ? it->second : 0; // Default stream is 0
+}
+
+// Set the current stream for a specific device
+inline void set_current_stream(int32_t device, cudaStream_t stream) {
+  current_streams[device] = stream;
+}
+
+class AOTICudaStreamGuard {
+ public:
+  AOTICudaStreamGuard(cudaStream_t stream, int32_t device_index = 0)
+      : stream_(stream), device_(device_index) {
+    // Save original device
+    throw_cuda_error(cudaGetDevice(&prev_device_));
+
+    // Switch to the target device if necessary
+    if (prev_device_ != device_) {
+      throw_cuda_error(cudaSetDevice(device_));
+    }
+
+    // Save the original stream for the current device
+    prev_stream_ = get_current_stream(device_);
+    // Set the new stream
+    set_current_stream(device_, stream_);
+  }
+
+  ~AOTICudaStreamGuard() {
+    // Restore the original stream for the current device
+    set_current_stream(device_, prev_stream_);
+
+    // Restore the original device if necessary
+    if (prev_device_ != device_) {
+      print_cuda_error(cudaSetDevice(prev_device_));
+    }
+  }
+
+  AOTICudaStreamGuard() = delete;
+  AOTICudaStreamGuard(const AOTICudaStreamGuard&) = delete;
+  AOTICudaStreamGuard& operator=(const AOTICudaStreamGuard&) = delete;
+  AOTICudaStreamGuard(AOTICudaStreamGuard&& other) = delete;
+  AOTICudaStreamGuard& operator=(AOTICudaStreamGuard&& other) = delete;
+
+ private:
+  cudaStream_t prev_stream_; // Original stream on the target device
+  cudaStream_t stream_; // Target stream to set
+  int32_t prev_device_ = 0; // Original device at construction
+  int32_t device_; // Target device for the guard
+};
+
+class AOTICudaStream {
+ public:
+  AOTICudaStream(int32_t device_index = 0) : device_index_(device_index) {
+    throw_cuda_error(cudaSetDevice(device_index_));
+    throw_cuda_error(cudaStreamCreate(&stream_));
+  }
+
+  ~AOTICudaStream() {
+    if (stream_) {
+      print_cuda_error(cudaStreamDestroy(stream_));
+    }
+  }
+
+  // Disable copy constructor and copy assignment
+  AOTICudaStream(const AOTICudaStream&) = delete;
+  AOTICudaStream& operator=(const AOTICudaStream&) = delete;
+
+  // Move constructor
+  AOTICudaStream(AOTICudaStream&& other) noexcept : stream_(other.stream_) {
+    other.stream_ = nullptr;
+  }
+
+  // Move assignment
+  AOTICudaStream& operator=(AOTICudaStream&& other) noexcept {
+    if (this != &other) {
+      if (stream_) {
+        print_cuda_error(cudaStreamDestroy(stream_));
+      }
+      stream_ = other.stream_;
+      other.stream_ = nullptr;
+    }
+    return *this;
+  }
+
+  cudaStream_t get() const {
+    return stream_;
+  }
+
+ private:
+  int32_t device_index_{0};
+  cudaStream_t stream_{nullptr};
+};
+
+#define CUDA_CHECK(EXPR)                                            \
+  do {                                                              \
+    const cudaError_t __err = EXPR;                                 \
+    if (__err != cudaSuccess) {                                     \
+      throw std::runtime_error(                                     \
+          "CUDA error: " + std::string(cudaGetErrorString(__err))); \
+    }                                                               \
+  } while (0)
+
+} // namespace torch::standalone
+#endif // USE_CUDA

--- a/torch/csrc/inductor/aoti_standalone/runner.h
+++ b/torch/csrc/inductor/aoti_standalone/runner.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <vector>
+
+#include <torch/csrc/inductor/aoti_standalone/c/shim.h>
+
+// Define AOTI_STANDALONE here to avoid redefined symbols seen by linter
+#ifndef AOTI_STANDALONE
+#define AOTI_STANDALONE
+#endif
+#include <torch/csrc/inductor/aoti_runtime/model_container.h>
+
+#ifdef USE_CUDA
+#include <torch/csrc/inductor/aoti_standalone/cuda/utils.h>
+#endif
+
+namespace torch::standalone {
+namespace {
+std::vector<SlimTensor*> unsafe_alloc_new_handles_from_tensors(
+    const std::vector<SlimTensor>& tensors) {
+  std::vector<SlimTensor*> result;
+  result.reserve(tensors.size());
+  for (auto tensor : tensors) {
+    auto allocated = new SlimTensor(std::move(tensor));
+    result.push_back(allocated);
+  }
+  return result;
+}
+
+std::vector<SlimTensor> alloc_tensors_by_stealing_from_handles(
+    std::vector<SlimTensor*>& outputs) {
+  // Find duplicates by recording the last known index for each handle.
+  std::unordered_map<SlimTensor*, size_t> lastKnownIdx;
+  size_t length = outputs.size();
+  for (size_t i = 0; i < length; i++) {
+    lastKnownIdx[outputs[i]] = i;
+  }
+
+  std::vector<SlimTensor> result;
+  result.reserve(length);
+  for (size_t i = 0; i < length; i++) {
+    if (outputs[i] == nullptr) {
+      result.emplace_back();
+      continue;
+    }
+
+    SlimTensor tensor = *outputs[i];
+    result.emplace_back(std::move(tensor));
+    if (lastKnownIdx[outputs[i]] == i) {
+      delete outputs[i];
+    }
+  }
+  outputs.clear();
+  return result;
+}
+} // namespace
+
+class SlimTensorRunner : public torch::aot_inductor::AOTInductorModelContainer {
+ public:
+  SlimTensorRunner(const c10::Device& device)
+      : torch::aot_inductor::AOTInductorModelContainer(1, device.str()) {}
+
+  std::vector<SlimTensor> run(const std::vector<SlimTensor>& inputs) {
+    std::vector<SlimTensor*> input_handles =
+        unsafe_alloc_new_handles_from_tensors(inputs);
+    std::vector<SlimTensor*> output_handles(this->num_outputs());
+
+#ifdef USE_CUDA
+    AOTICudaStream cuda_stream;
+    torch::aot_inductor::DeviceStreamType stream = cuda_stream.get();
+#else
+    torch::aot_inductor::DeviceStreamType stream = nullptr;
+#endif
+    // auto* model = static_cast<Model*>(this);
+    this->run_single_threaded(
+        input_handles.data(), output_handles.data(), stream, nullptr);
+    return alloc_tensors_by_stealing_from_handles(output_handles);
+  }
+};
+} // namespace torch::standalone

--- a/torch/csrc/inductor/aoti_standalone/utils.h
+++ b/torch/csrc/inductor/aoti_standalone/utils.h
@@ -1,0 +1,25 @@
+#pragma once
+
+using AOTITorchError = int32_t;
+#define AOTI_TORCH_SUCCESS 0
+#define AOTI_TORCH_FAILURE 1
+
+// TODO: implement a proper logging mechanism or simply reuse the c10 logging
+#ifndef AOTI_TORCH_CHECK
+#define AOTI_TORCH_CHECK(...) ((void)0);
+#endif
+#ifndef AOTI_TORCH_WARN
+#define AOTI_TORCH_WARN(...) ((void)0);
+#endif
+
+#define AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(...)   \
+  try {                                                   \
+    __VA_ARGS__                                           \
+  } catch (const std::exception& e) {                     \
+    std::cerr << "Exception in aoti_torch: " << e.what(); \
+    return AOTI_TORCH_FAILURE;                            \
+  } catch (...) {                                         \
+    std::cerr << "Exception in aoti_torch: UNKNOWN";      \
+    return AOTI_TORCH_FAILURE;                            \
+  }                                                       \
+  return AOTI_TORCH_SUCCESS;

--- a/torch/csrc/inductor/aoti_standalone/utils.h
+++ b/torch/csrc/inductor/aoti_standalone/utils.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 using AOTITorchError = int32_t;
 #define AOTI_TORCH_SUCCESS 0
 #define AOTI_TORCH_FAILURE 1

--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -795,5 +795,5 @@ DEFINE_DTYPE_SPECIALIZATION(int32_t, int32)
 DEFINE_DTYPE_SPECIALIZATION(int64_t, int64)
 DEFINE_DTYPE_SPECIALIZATION(bool, bool)
 
-#endif
+#endif // __cplusplus
 #endif // AOTI_TORCH_SHIM

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -1181,11 +1181,11 @@ void aoti_torch_print_tensor_handle(AtenTensorHandle self, const char* msg) {
   // Print dtypes and for float types, print exact precision
   auto scalarType = t->scalar_type();
   if (scalarType == at::ScalarType::Float) {
-    std::cout << "Dtype: float32" << std::endl;
+    std::cout << "Dtype: float32\n";
   } else if (scalarType == at::ScalarType::Half) {
-    std::cout << "Dtype: float16" << std::endl;
+    std::cout << "Dtype: float16\n";
   } else if (scalarType == at::ScalarType::BFloat16) {
-    std::cout << "Dtype: bfloat16" << std::endl;
+    std::cout << "Dtype: bfloat16\n";
   } else {
     std::cout << "Dtype: " << t->dtype() << '\n';
   }
@@ -1304,6 +1304,7 @@ static StableIValue from_ivalue(
   switch (type->kind()) {
     case c10::TypeKind::TensorType: {
       AtenTensorHandle ath = torch::aot_inductor::new_tensor_handle(
+          // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
           std::move(const_cast<at::Tensor&>(ivalue.toTensor())));
       return from(ath);
     }

--- a/torch/csrc/inductor/cpp_prefix.h
+++ b/torch/csrc/inductor/cpp_prefix.h
@@ -30,7 +30,11 @@
 #include <c10/util/TypeCast.h>
 #include <c10/util/generic_math.h>
 #include <c10/util/irange.h>
+#ifdef AOTI_STANDALONE
+#include <torch/csrc/inductor/aoti_standalone/c/shim.h>
+#else
 #include <torch/csrc/inductor/aoti_torch/c/shim.h>
+#endif // AOTI_STANDALONE
 
 #if defined(CPU_CAPABILITY_AVX512) || defined(CPU_CAPABILITY_AVX2) ||  \
     defined(CPU_CAPABILITY_ZVECTOR) || defined(CPU_CAPABILITY_NEON) || \

--- a/torch/csrc/inductor/cpp_wrapper/device_internal/cpu.h
+++ b/torch/csrc/inductor/cpp_wrapper/device_internal/cpu.h
@@ -1,3 +1,5 @@
 #pragma once
 
+#ifndef AOTI_STANDALONE
 #include <torch/csrc/inductor/aoti_torch/generated/c_shim_cpu.h>
+#endif

--- a/torch/csrc/inductor/cpp_wrapper/device_internal/cuda.h
+++ b/torch/csrc/inductor/cpp_wrapper/device_internal/cuda.h
@@ -1,4 +1,8 @@
 #pragma once
 
+#ifdef AOTI_STANDALONE
+#include <torch/csrc/inductor/aoti_standalone/cuda/utils.h>
+#else
 #include <torch/csrc/inductor/aoti_runtime/utils_cuda.h>
 #include <torch/csrc/inductor/aoti_torch/generated/c_shim_cuda.h>
+#endif

--- a/torch/csrc/inductor/cpp_wrapper/device_internal/xpu.h
+++ b/torch/csrc/inductor/cpp_wrapper/device_internal/xpu.h
@@ -2,4 +2,6 @@
 
 #include <torch/csrc/inductor/aoti_runtime/sycl_runtime_wrappers.h>
 #include <torch/csrc/inductor/aoti_runtime/utils_xpu.h>
+#ifndef AOTI_STANDALONE
 #include <torch/csrc/inductor/aoti_torch/generated/c_shim_xpu.h>
+#endif


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #153841
* #153739

Summary: Add C shim interfaces based on SlimTensor and update AOTInductor codegen to genrate correponding code. This PR is not meant to reach SlimTensor C shim coverage parity. It only works for simple point-wise ops now as shown in the added unit test. When running test_aot_inductor_standalone, AOTInductor will compile a model into a package that uses SlimTensors for its inputs, outputs, and all the intermediate tensors. The test harness takes care of AtenTensor<->SlimTensor conversion for the test inputs and outputs.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben