### PR TITLE
[BE] Fix `-Wextra-semi` warning

### DIFF
--- a/torch/csrc/jit/ir/alias_analysis.h
+++ b/torch/csrc/jit/ir/alias_analysis.h
@@ -353,7 +353,7 @@ class ValueAndMemoryLocationSet {
   friend class AliasDb;
 
  private:
-  ValueAndMemoryLocationSet(const AliasDb* db) : aliasDb_(db){};
+  ValueAndMemoryLocationSet(const AliasDb* db) : aliasDb_(db) {}
 
   const AliasDb* aliasDb_;
   ValueSet valueSet_;


### PR DESCRIPTION
Introduced by https://github.com/pytorch/pytorch/pull/153645

Semicolon is not needed after closing curly bracket defining a class method.

Not sure why CI did not catch it, but my local builds are now erroring out with
```
[19/97] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/torch/csrc/jit/passes/dead_code_elimination.cpp.o
In file included from /Users/nshulga/git/pytorch/pytorch/torch/csrc/jit/passes/dead_code_elimination.cpp:4:
/Users/nshulga/git/pytorch/pytorch/torch/csrc/jit/ir/alias_analysis.h:356:64: warning: extra ';' after member function definition [-Wextra-semi]
  356 |   ValueAndMemoryLocationSet(const AliasDb* db) : aliasDb_(db){};
      |                                                                ^
```

Fixes #ISSUE_NUMBER


cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel