### PR TITLE
Add deprecation warning for `torch.ao.quantization`

### DIFF
--- a/torch/ao/quantization/__init__.py
+++ b/torch/ao/quantization/__init__.py
@@ -42,7 +42,7 @@ warnings.warn(
     "API instead (prepare_pt2e, convert_pt2e) \n"
     "3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) \n"
     "see https://dev-discuss.pytorch.org/t/torch-ao-quantization-migration-plan/2810 for more details",
-    FutureWarning,
+    DeprecationWarning,
 )
 
 # ensure __module__ is set correctly for public APIs

--- a/torch/ao/quantization/__init__.py
+++ b/torch/ao/quantization/__init__.py
@@ -35,7 +35,9 @@ from .stubs import *  # noqa: F403
 warnings.warn(
     "torch.ao.quantization is deprecated. Plan is to: \n"
     "1. Remove eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead \n"
-    "2. Remove fx graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx, torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) \n"
+    "2. Remove fx graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,"
+    "torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization "
+    "API instead (prepare_pt2e, convert_pt2e) \n"
     "3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) \n"
     "see https://dev-discuss.pytorch.org/t/torch-ao-quantization-migration-plan/2810 for more details",
     FutureWarning,

--- a/torch/ao/quantization/__init__.py
+++ b/torch/ao/quantization/__init__.py
@@ -32,19 +32,6 @@ from .quantize_jit import *  # noqa: F403
 from .stubs import *  # noqa: F403
 
 
-warnings.warn(
-    "torch.ao.quantization is deprecated. Plan is to: \n"
-    "1. Remove eager mode quantization (torch.ao.quantization.quantize, "
-    "torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode "
-    "quantize_ API instead \n"
-    "2. Remove fx graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,"
-    "torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization "
-    "API instead (prepare_pt2e, convert_pt2e) \n"
-    "3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) \n"
-    "see https://dev-discuss.pytorch.org/t/torch-ao-quantization-migration-plan/2810 for more details",
-    DeprecationWarning,
-)
-
 # ensure __module__ is set correctly for public APIs
 ObserverOrFakeQuantize = Union[ObserverBase, FakeQuantizeBase]
 ObserverOrFakeQuantize.__module__ = "torch.ao.quantization"

--- a/torch/ao/quantization/__init__.py
+++ b/torch/ao/quantization/__init__.py
@@ -1,6 +1,5 @@
 # mypy: allow-untyped-defs
 
-import warnings
 from typing import Callable, Optional, Union
 
 import torch

--- a/torch/ao/quantization/__init__.py
+++ b/torch/ao/quantization/__init__.py
@@ -34,7 +34,9 @@ from .stubs import *  # noqa: F403
 
 warnings.warn(
     "torch.ao.quantization is deprecated. Plan is to: \n"
-    "1. Remove eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead \n"
+    "1. Remove eager mode quantization (torch.ao.quantization.quantize, "
+    "torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode "
+    "quantize_ API instead \n"
     "2. Remove fx graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,"
     "torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization "
     "API instead (prepare_pt2e, convert_pt2e) \n"

--- a/torch/ao/quantization/__init__.py
+++ b/torch/ao/quantization/__init__.py
@@ -30,6 +30,15 @@ from .quantize import *  # noqa: F403
 from .quantize_jit import *  # noqa: F403
 from .stubs import *  # noqa: F403
 
+import warnings
+
+print("printing warning")
+warnings.warn(
+    "torch.ao.quantization is deprecated. Plan is to: \n"
+    "1. Remove eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead \n"
+    "2. Remove fx graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx, torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) \n"
+    "3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) \n"
+    "see https://dev-discuss.pytorch.org/t/torch-ao-quantization-migration-plan/2810 for more details", DeprecationWarning)
 
 # ensure __module__ is set correctly for public APIs
 ObserverOrFakeQuantize = Union[ObserverBase, FakeQuantizeBase]

--- a/torch/ao/quantization/__init__.py
+++ b/torch/ao/quantization/__init__.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 
+import warnings
 from typing import Callable, Optional, Union
 
 import torch
@@ -30,14 +31,15 @@ from .quantize import *  # noqa: F403
 from .quantize_jit import *  # noqa: F403
 from .stubs import *  # noqa: F403
 
-import warnings
 
 warnings.warn(
     "torch.ao.quantization is deprecated. Plan is to: \n"
     "1. Remove eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead \n"
     "2. Remove fx graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx, torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) \n"
     "3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) \n"
-    "see https://dev-discuss.pytorch.org/t/torch-ao-quantization-migration-plan/2810 for more details", DeprecationWarning)
+    "see https://dev-discuss.pytorch.org/t/torch-ao-quantization-migration-plan/2810 for more details",
+    DeprecationWarning,
+)
 
 # ensure __module__ is set correctly for public APIs
 ObserverOrFakeQuantize = Union[ObserverBase, FakeQuantizeBase]

--- a/torch/ao/quantization/__init__.py
+++ b/torch/ao/quantization/__init__.py
@@ -38,7 +38,7 @@ warnings.warn(
     "2. Remove fx graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx, torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) \n"
     "3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) \n"
     "see https://dev-discuss.pytorch.org/t/torch-ao-quantization-migration-plan/2810 for more details",
-    DeprecationWarning,
+    FutureWarning,
 )
 
 # ensure __module__ is set correctly for public APIs

--- a/torch/ao/quantization/__init__.py
+++ b/torch/ao/quantization/__init__.py
@@ -32,7 +32,6 @@ from .stubs import *  # noqa: F403
 
 import warnings
 
-print("printing warning")
 warnings.warn(
     "torch.ao.quantization is deprecated. Plan is to: \n"
     "1. Remove eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead \n"

--- a/torch/ao/quantization/quantize.py
+++ b/torch/ao/quantization/quantize.py
@@ -2,6 +2,7 @@
 import copy
 import inspect
 import itertools
+import typing_extensions
 import warnings
 
 import torch
@@ -30,7 +31,11 @@ from torch.ao.quantization.quantization_mappings import (
 from torch.ao.quantization.stubs import DeQuantStub, QuantWrapper
 from torch.nn.utils.parametrize import type_before_parametrizations
 
-from .utils import get_qparam_dict, has_no_children_ignoring_parametrizations
+from .utils import (
+    DEPRECATION_WARNING,
+    get_qparam_dict,
+    has_no_children_ignoring_parametrizations,
+)
 
 
 __all__ = [
@@ -332,6 +337,7 @@ def add_quant_dequant(module):
     return module
 
 
+@typing_extensions.deprecated(DEPRECATION_WARNING)
 def prepare(
     model,
     inplace=False,
@@ -442,6 +448,7 @@ def _remove_qconfig(module):
     _remove_activation_post_process(module)
 
 
+@typing_extensions.deprecated(DEPRECATION_WARNING)
 def quantize(model, run_fn, run_args, mapping=None, inplace=False):
     r"""Quantize the input float model with post training static quantization.
 
@@ -471,6 +478,7 @@ def quantize(model, run_fn, run_args, mapping=None, inplace=False):
     return model
 
 
+@typing_extensions.deprecated(DEPRECATION_WARNING)
 def quantize_dynamic(
     model, qconfig_spec=None, dtype=torch.qint8, mapping=None, inplace=False
 ):
@@ -561,6 +569,7 @@ def quantize_dynamic(
     return model
 
 
+@typing_extensions.deprecated(DEPRECATION_WARNING)
 def prepare_qat(model, mapping=None, inplace=False):
     r"""
     Prepares a copy of the model for quantization calibration or
@@ -590,6 +599,7 @@ def prepare_qat(model, mapping=None, inplace=False):
     return model
 
 
+@typing_extensions.deprecated(DEPRECATION_WARNING)
 def quantize_qat(model, run_fn, run_args, inplace=False):
     r"""Do quantization aware training and output a quantized model
 
@@ -613,6 +623,7 @@ def quantize_qat(model, run_fn, run_args, inplace=False):
     return model
 
 
+@typing_extensions.deprecated(DEPRECATION_WARNING)
 def convert(
     module,
     mapping=None,

--- a/torch/ao/quantization/quantize_fx.py
+++ b/torch/ao/quantization/quantize_fx.py
@@ -1,4 +1,5 @@
 import copy
+import typing_extensions
 import warnings
 from typing import Any, Optional, Union
 
@@ -18,6 +19,7 @@ from .fx.utils import (  # noqa: F401
     get_skipped_module_name_and_classes,
 )
 from .qconfig_mapping import QConfigMapping
+from .utils import DEPRECATION_WARNING
 
 
 def attach_preserved_attrs_to_model(
@@ -249,6 +251,7 @@ def fuse_fx(
     return graph_module
 
 
+@typing_extensions.deprecated(DEPRECATION_WARNING)
 def prepare_fx(
     model: torch.nn.Module,
     qconfig_mapping: Union[QConfigMapping, dict[str, Any]],
@@ -400,6 +403,7 @@ def prepare_fx(
     )
 
 
+@typing_extensions.deprecated(DEPRECATION_WARNING)
 def prepare_qat_fx(
     model: torch.nn.Module,
     qconfig_mapping: Union[QConfigMapping, dict[str, Any]],
@@ -554,6 +558,7 @@ def _convert_fx(
     return quantized
 
 
+@typing_extensions.deprecated(DEPRECATION_WARNING)
 def convert_fx(
     graph_module: GraphModule,
     convert_custom_config: Union[ConvertCustomConfig, dict[str, Any], None] = None,

--- a/torch/ao/quantization/quantize_pt2e.py
+++ b/torch/ao/quantization/quantize_pt2e.py
@@ -1,3 +1,5 @@
+import typing_extensions
+
 import torch
 from torch._export.passes.constant_folding import constant_fold
 from torch.ao.quantization.pt2e.duplicate_dq_pass import DuplicateDQPass
@@ -19,6 +21,7 @@ from .pt2e.qat_utils import _fold_conv_bn_qat, _fuse_conv_bn_qat
 from .pt2e.representation import reference_representation_rewrite
 from .pt2e.utils import _disallow_eval_train, _fuse_conv_bn_, _get_node_name_to_scope
 from .quantize_fx import _convert_to_reference_decomposed_fx
+from .utils import DEPRECATION_WARNING
 
 
 __all__ = [
@@ -28,6 +31,7 @@ __all__ = [
 ]
 
 
+@typing_extensions.deprecated(DEPRECATION_WARNING)
 def prepare_pt2e(
     model: GraphModule,
     quantizer: Quantizer,
@@ -107,6 +111,7 @@ def prepare_pt2e(
     return model
 
 
+@typing_extensions.deprecated(DEPRECATION_WARNING)
 def prepare_qat_pt2e(
     model: GraphModule,
     quantizer: Quantizer,
@@ -203,6 +208,7 @@ def _quant_node_constraint(n: Node) -> bool:
     return n.op == "call_function" and n.target in _QUANT_OPS
 
 
+@typing_extensions.deprecated(DEPRECATION_WARNING)
 def convert_pt2e(
     model: GraphModule,
     use_reference_representation: bool = False,

--- a/torch/ao/quantization/quantizer/xnnpack_quantizer.py
+++ b/torch/ao/quantization/quantizer/xnnpack_quantizer.py
@@ -239,7 +239,8 @@ def _get_not_module_type_or_name_filter(
 
 @compatibility(is_backward_compatible=False)
 @typing_extensions.deprecated(
-    "XNNPACKQuantizer is deprecated! Please use xnnpack quantizer in ExecuTorch (https://github.com/pytorch/executorch/tree/main/backends/xnnpack/quantizer) instead."
+    "XNNPACKQuantizer is deprecated! Please use xnnpack quantizer in "
+    "ExecuTorch (https://github.com/pytorch/executorch/tree/main/backends/xnnpack/quantizer) instead."
 )
 class XNNPACKQuantizer(Quantizer):
     """

--- a/torch/ao/quantization/quantizer/xnnpack_quantizer.py
+++ b/torch/ao/quantization/quantizer/xnnpack_quantizer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import copy
 import functools
-import warnings
+import typing_extensions
 from typing import Any, Callable, Optional, TYPE_CHECKING
 
 import torch
@@ -238,6 +238,9 @@ def _get_not_module_type_or_name_filter(
 
 
 @compatibility(is_backward_compatible=False)
+@typing_extensions.deprecated(
+    "XNNPACKQuantizer is deprecated! Please use xnnpack quantizer in ExecuTorch (https://github.com/pytorch/executorch/tree/main/backends/xnnpack/quantizer) instead."
+)
 class XNNPACKQuantizer(Quantizer):
     """
     !!! DEPRECATED !!!
@@ -278,10 +281,6 @@ class XNNPACKQuantizer(Quantizer):
 
     def __init__(self) -> None:
         super().__init__()
-        warnings.warn(
-            f"{self.__class__.__name__} is deprecated! Please use xnnpack quantizer in ExecuTorch (https://github.com/pytorch/executorch/tree/main/backends/xnnpack/quantizer) instead",
-            DeprecationWarning,
-        )
         self.global_config: Optional[QuantizationConfig] = None
         self.operator_type_config: dict[
             torch._ops.OpOverloadPacket, Optional[QuantizationConfig]

--- a/torch/ao/quantization/quantizer/xnnpack_quantizer.py
+++ b/torch/ao/quantization/quantizer/xnnpack_quantizer.py
@@ -278,7 +278,7 @@ class XNNPACKQuantizer(Quantizer):
 
     def __init__(self) -> None:
         super().__init__()
-        warnings.warn(f"{self.__class__.__name__} is deprecated!")
+        warnings.warn(f"{self.__class__.__name__} is deprecated! Please use xnnpack quantizer in ExecuTorch (https://github.com/pytorch/executorch/tree/main/backends/xnnpack/quantizer) instead", DeprecationWarning)
         self.global_config: Optional[QuantizationConfig] = None
         self.operator_type_config: dict[
             torch._ops.OpOverloadPacket, Optional[QuantizationConfig]

--- a/torch/ao/quantization/quantizer/xnnpack_quantizer.py
+++ b/torch/ao/quantization/quantizer/xnnpack_quantizer.py
@@ -278,7 +278,10 @@ class XNNPACKQuantizer(Quantizer):
 
     def __init__(self) -> None:
         super().__init__()
-        warnings.warn(f"{self.__class__.__name__} is deprecated! Please use xnnpack quantizer in ExecuTorch (https://github.com/pytorch/executorch/tree/main/backends/xnnpack/quantizer) instead", DeprecationWarning)
+        warnings.warn(
+            f"{self.__class__.__name__} is deprecated! Please use xnnpack quantizer in ExecuTorch (https://github.com/pytorch/executorch/tree/main/backends/xnnpack/quantizer) instead",
+            DeprecationWarning,
+        )
         self.global_config: Optional[QuantizationConfig] = None
         self.operator_type_config: dict[
             torch._ops.OpOverloadPacket, Optional[QuantizationConfig]

--- a/torch/ao/quantization/utils.py
+++ b/torch/ao/quantization/utils.py
@@ -800,7 +800,7 @@ DEPRECATION_WARNING = (
     "torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization "
     "API instead (prepare_pt2e, convert_pt2e) \n"
     "3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) \n"
-    "see https://github.com/pytorch/ao/issues/2259 for more details",
+    "see https://github.com/pytorch/ao/issues/2259 for more details"
 )
 
 

--- a/torch/ao/quantization/utils.py
+++ b/torch/ao/quantization/utils.py
@@ -790,6 +790,20 @@ def _assert_and_get_unique_device(module: torch.nn.Module) -> Any:
     return device
 
 
+DEPRECATION_WARNING = (
+    "torch.ao.quantization is deprecated and will be removed in 2.10. \n"
+    "For migrations of users: \n"
+    "1. Eager mode quantization (torch.ao.quantization.quantize, "
+    "torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode "
+    "quantize_ API instead \n"
+    "2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,"
+    "torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization "
+    "API instead (prepare_pt2e, convert_pt2e) \n"
+    "3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) \n"
+    "see https://github.com/pytorch/ao/issues/2259 for more details",
+)
+
+
 __all__ = [
     "NodePattern",
     "Pattern",
@@ -819,4 +833,5 @@ __all__ = [
     "to_underlying_dtype",
     "determine_qparams",
     "validate_qmin_qmax",
+    "DEPRECATION_WARNING",
 ]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #153892

Summary:
att

Test Plan:
```
(ao) $ PYTHONWARNINGS='default' python
Python 3.10.14 | packaged by conda-forge | (main, Mar 20 2024, 12:45:18) [GCC 12.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from torch.ao.quantization.quantizer.xnnpack_quantizer import XNNPACKQuantizer
printing warning
*/anaconda3/envs/ao/lib/python3.10/site-packages/torch/ao/quantization/__init__.py:36: DeprecationWarning: torch.ao.quantization is deprecated. Plan is to
1. Remove eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead
2. Remove fx graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx, torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e)
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e)
see https://dev-discuss.pytorch.org/t/torch-ao-quantization-migration-plan/2810 for more details
  warnings.warn(
>>> a = XNNPACKQuantizer()
*/anaconda3/envs/ao/lib/python3.10/site-packages/torch/ao/quantization/quantizer/xnnpack_quantizer.py:281: DeprecationWarning: XNNPACKQuantizer is deprecated! Please use xnnpack quantizer in ExecuTorch (https://github.com/pytorch/executorch/tree/main/backends/xnnpack/quantizer) instead
  warnings.warn(f"{self.__class__.__name__} is deprecated! Please use xnnpack quantizer in ExecuTorch (https://github.com/pytorch/executorch/tree/main/backends/xnnpack/quantizer) instead", DeprecationWarning)
>>>
```

Reviewers:

Subscribers:

Tasks:

Tags: