### PR TITLE
Generate unique id for tensor storage object

### DIFF
--- a/c10/core/Storage.h
+++ b/c10/core/Storage.h
@@ -98,6 +98,10 @@ struct C10_API Storage {
     storage_impl_->set_nbytes(std::move(size_bytes));
   }
 
+  size_t get_id() const {
+    return storage_impl_->get_id();
+  }
+
   bool resizable() const {
     return storage_impl_->resizable();
   }

--- a/c10/core/StorageImpl.cpp
+++ b/c10/core/StorageImpl.cpp
@@ -3,6 +3,8 @@
 
 namespace c10 {
 
+std::atomic<size_t> StorageImpl::g_id = 1;
+
 // The array to save function pointer for custom storageImpl create.
 static std::array<StorageImplCreateHelper, at::COMPILE_TIME_MAX_DEVICE_TYPES>
     StorageImplCreate;

--- a/c10/test/core/impl/storage_id_test.cpp
+++ b/c10/test/core/impl/storage_id_test.cpp
@@ -1,0 +1,78 @@
+#include <c10/core/impl/COW.h>
+#include <c10/core/impl/COWDeleter.h>
+
+#include <c10/core/CPUAllocator.h>
+#include <c10/core/StorageImpl.h>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <thread>
+#include <unordered_set>
+
+// NOLINTBEGIN(clang-analyzer-cplusplus*)
+namespace c10::impl {
+namespace {
+
+TEST(storage_id_test, performance) {
+  std::time_t startTime = std::time(nullptr);
+
+  const int numThreads = 64;
+  std::vector<std::thread> threads(numThreads);
+  for (int i = 0; i < numThreads; ++i) {
+    threads[i] = std::thread([]() {
+      // size_t n = 1000000000;
+      size_t n = 100000000;
+      for (size_t j = 0; j < n; j++) {
+        StorageImpl original_storage({}, 6, GetCPUAllocator(), false);
+      }
+    });
+  }
+  // Wait for all threads to finish
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  std::time_t endTime = std::time(nullptr);
+  std::time_t diffTime = endTime - startTime;
+  std::cout << "Time taken: " << diffTime << " seconds"
+            << "\n";
+}
+
+TEST(storage_id_test, uniqueness) {
+  std::unordered_set<size_t> storage_ids;
+
+  const int numThreads = 64;
+  std::vector<std::thread> threads(numThreads);
+  bool found_duplicate = false;
+  std::mutex m;
+  for (int i = 0; i < numThreads; ++i) {
+    threads[i] = std::thread([&found_duplicate, &storage_ids, &m]() {
+      // size_t n = 100000;
+      size_t n = 10000;
+      for (size_t j = 0; j < n; j++) {
+        StorageImpl original_storage({}, 6, GetCPUAllocator(), false);
+        size_t id = original_storage.get_id();
+        {
+          std::lock_guard<std::mutex> lock(m);
+          if (storage_ids.find(id) != storage_ids.end()) {
+            found_duplicate = true;
+            break;
+          }
+          storage_ids.insert(id);
+        }
+      }
+    });
+  }
+  // Wait for all threads to finish
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  ASSERT_FALSE(found_duplicate);
+}
+
+} // namespace
+} // namespace c10::impl
+// NOLINTEND(clang-analyzer-cplusplus*)


### PR DESCRIPTION
Summary:
PyTorch execution trace records tensor storage data in the trace. The tensor storage data includes storage id, offset, number of elements, and number of byte for each element. PARAM et-replay uses this information to allocate/free the tensors.
However, the current implementation of generating tensor storage id does not guarantee it is unique. ExecutionTraceObserver maintains a lookup table to map the memory address of the tensor storage object to an unique id. If a new memory address is found, it will be put into that hash table and associate it to a new id.
This implementation does not guarantee the storage object is unique since the memory that the address points to may be released and then re-allocated to a different tensor storage object.
To fix it, a static global id is used to generate the unique id for storage object. The global id is an atomic variable and initialized to 0. Then when a new storage object is created, its id is set to the global id, and then bump up the global id.

Test Plan: buck2 run mode/opt caffe2/test:torch -- -r test_torch.TestTorchDeviceTypeCPU.test_storage_*

Differential Revision: D75045446


