### PR TITLE
[AOTI] Generate unique cubin file names when package_cpp_only

### DIFF
--- a/test/inductor/test_aot_inductor_package.py
+++ b/test/inductor/test_aot_inductor_package.py
@@ -15,17 +15,12 @@ from typing import Callable
 from parameterized import parameterized_class
 
 import torch
-from torch._inductor.codecache import get_actual_cubin_format
+from torch._inductor.codecache import get_kernel_bin_format
 from torch._inductor.package import AOTICompiledModel, load_package, package_aoti
 from torch._inductor.test_case import TestCase
 from torch._inductor.utils import fresh_inductor_cache
 from torch.export import Dim
-from torch.testing._internal.common_utils import (
-    IS_FBCODE,
-    skipIfRocm,
-    skipIfXpu,
-    TEST_CUDA,
-)
+from torch.testing._internal.common_utils import IS_FBCODE, skipIfXpu, TEST_CUDA
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
 
@@ -184,7 +179,6 @@ class TestAOTInductorPackage(TestCase):
         self.check_model(Model(), example_inputs)
 
     @unittest.skipIf(IS_FBCODE, "cmake won't work in fbcode")
-    @skipIfRocm  # build system may be different
     @skipIfXpu  # build system may be different
     def test_compile_after_package(self):
         if not self.package_cpp_only:
@@ -226,13 +220,10 @@ class TestAOTInductorPackage(TestCase):
                 tmp_path = Path(tmp_dir) / "data" / "aotinductor" / "model"
                 self.assertTrue(tmp_path.exists())
                 if self.device == GPU_TYPE:
-                    self.assertTrue(
-                        not list(tmp_path.glob(f"*.{get_actual_cubin_format()}"))
-                    )
-                    # Check if the generated .cubin.o files exist and use unique kernel names
-                    self.assertTrue(
-                        list(tmp_path.glob(f"triton_*.{get_actual_cubin_format()}.o"))
-                    )
+                    kernel_bin = get_kernel_bin_format(self.device)
+                    self.assertTrue(not list(tmp_path.glob(f"*.{kernel_bin}")))
+                    # Check if .cubin.o files exist and use unique kernel names
+                    self.assertTrue(list(tmp_path.glob(f"triton_*.{kernel_bin}.o")))
 
                 build_path = tmp_path / "build"
                 self.assertTrue(not build_path.exists())

--- a/test/inductor/test_aot_inductor_package.py
+++ b/test/inductor/test_aot_inductor_package.py
@@ -15,6 +15,7 @@ from typing import Callable
 from parameterized import parameterized_class
 
 import torch
+from torch._inductor.codecache import get_actual_cubin_format
 from torch._inductor.package import AOTICompiledModel, load_package, package_aoti
 from torch._inductor.test_case import TestCase
 from torch._inductor.utils import fresh_inductor_cache
@@ -225,8 +226,13 @@ class TestAOTInductorPackage(TestCase):
                 tmp_path = Path(tmp_dir) / "data" / "aotinductor" / "model"
                 self.assertTrue(tmp_path.exists())
                 if self.device == GPU_TYPE:
-                    self.assertTrue(not list(tmp_path.glob("*.cubin")))
-                    self.assertTrue(list(tmp_path.glob("*.cubin.o")))
+                    self.assertTrue(
+                        not list(tmp_path.glob(f"*.{get_actual_cubin_format()}"))
+                    )
+                    # Check if the generated .cubin.o files exist and use unique kernel names
+                    self.assertTrue(
+                        list(tmp_path.glob(f"triton_*.{get_actual_cubin_format()}.o"))
+                    )
 
                 build_path = tmp_path / "build"
                 self.assertTrue(not build_path.exists())

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -154,8 +154,13 @@ def get_cpp_wrapper_cubin_path_name() -> str:
     return "cubin_path" if torch.version.hip is None else "hsaco_path"
 
 
-def get_actual_cubin_format() -> str:
-    return "cubin" if torch.version.hip is None else "hsaco"
+def get_kernel_bin_format(device: str) -> str:
+    if device == "cuda":
+        return "cubin" if torch.version.hip is None else "hsaco"
+    elif device == "xpu":
+        return "spv"
+    else:
+        return ""
 
 
 @functools.lru_cache(None)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #153948

Summary:
* When package_cpp_only is specified, generate kernel file names with unique kernel names to make the final packaged package files more readable. Assert on unique_kernel_names in case somehow it was explicitly set to False.
* Fix a rocm test skip, see https://github.com/pytorch/pytorch/pull/153828

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov