### PR TITLE
[submodule] Update fbgemm pinned version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -144,8 +144,8 @@ new_local_repository(
 
 new_local_repository(
     name = "asmjit",
-    build_file = "//third_party:fbgemm/third_party/asmjit.BUILD",
-    path = "third_party/fbgemm/third_party/asmjit",
+    build_file = "//third_party:fbgemm/external/asmjit.BUILD",
+    path = "third_party/fbgemm/external/asmjit",
 )
 
 new_local_repository(

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -681,11 +681,12 @@ if(USE_FBGEMM)
     set_property(TARGET fbgemm_avx2 PROPERTY POSITION_INDEPENDENT_CODE ON)
     set_property(TARGET fbgemm_avx512 PROPERTY POSITION_INDEPENDENT_CODE ON)
     set_property(TARGET fbgemm PROPERTY POSITION_INDEPENDENT_CODE ON)
-    # TODO: Remove next two lines after fbgemm pin is updated
 
-    # For more details see https://github.com/pytorch/pytorch/issues/150846
-    target_compile_options_if_supported(fbgemm_avx512 -Wno-maybe-uninitialized)
-    target_compile_options_if_supported(fbgemm_avx512 -Wno-uninitialized)
+    # Disabling autovec in fbgemm due to large library size causing symbol relocation issues, which is only allowed in static builds.
+    # Long-term solution involves modularizing fbgemm targets.
+    target_compile_definitions(fbgemm_generic PUBLIC DISABLE_FBGEMM_AUTOVEC)
+    target_compile_definitions(fbgemm_avx2 PUBLIC DISABLE_FBGEMM_AUTOVEC)
+    target_compile_definitions(fbgemm_avx512 PUBLIC DISABLE_FBGEMM_AUTOVEC)
 
     if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 13.0.0)
       # See https://github.com/pytorch/pytorch/issues/74352
@@ -697,8 +698,8 @@ if(USE_FBGEMM)
       target_compile_options_if_supported(fbgemm -Wno-extra-semi)
     endif()
   endif()
-
   if(USE_FBGEMM)
+    target_compile_definitions(fbgemm PUBLIC DISABLE_FBGEMM_AUTOVEC)
     list(APPEND Caffe2_DEPENDENCY_LIBS fbgemm)
   endif()
 endif()

--- a/setup.py
+++ b/setup.py
@@ -443,7 +443,7 @@ def check_submodules():
             ],
         )
     check_for_files(
-        os.path.join(third_party_path, "fbgemm", "third_party", "asmjit"),
+        os.path.join(third_party_path, "fbgemm", "external", "asmjit"),
         ["CMakeLists.txt"],
     )
 


### PR DESCRIPTION
Summary:
Update fbgemm pinned version in PyTroch.
Related update in fbgemm: D74434751

Included changes:
Update fbgemm external dependencies directory in setup.py
Add DISABLE_FBGEMM_AUTOVEC flag to disable fbgemm's autovec

Test Plan: PyTorch OSS CI

Differential Revision: D75073516
