### PR TITLE
Address the ignored warnings for `-Wmissing-field-initializers `in the file fbcode/caffe2/aten/src/ATen/native/cuda/RowwiseScaledMM.cu

### DIFF
--- a/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
+++ b/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
@@ -8,6 +8,7 @@
 // Two warninngs in Cutlass included header files
 C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wset-but-not-used")
 C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wunused-but-set-parameter")
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wmissing-field-initializers")
 
 // Determine if the architecture supports rowwise scaled mm
 // Currently failing on windows with:


### PR DESCRIPTION
Summary:
the error message  https://www.internalfb.com/sandcastle/workflow/698057942249983018/artifact/actionlog.698057942382778255.stderr.1?selectedLines=66-66-70-148 from D74892646

When switching the host compiler to Clang, maybe we should only silence these warnings in this file.

Test Plan: sandcastle_green

Differential Revision: D75029051


