### PR TITLE
Fix test_side_stream_backward_overlap flakiness

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -13351,14 +13351,6 @@ class TestAutogradStreamSynchronization(TestCase):
                 events["side_backward_start"].elapsed_time(events["side_backward_end"])
                 > 0
             )
-            # Although the autograd backward should always execute SideBw before MainBw,
-            # there is still a small chance the recorded events won't be in that order.
-            # self.assertTrue(
-            #     events["side_backward_start"].elapsed_time(
-            #         events["main_backward_start"]
-            #     )
-            #     > 0
-            # )
             # Overlap check: side's backward starts before side backward ends
             self.assertTrue(
                 events["main_backward_start"].elapsed_time(events["side_backward_end"])

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -13351,13 +13351,14 @@ class TestAutogradStreamSynchronization(TestCase):
                 events["side_backward_start"].elapsed_time(events["side_backward_end"])
                 > 0
             )
-            # Sanity check: main's backward started after side's backward started
-            self.assertTrue(
-                events["side_backward_start"].elapsed_time(
-                    events["main_backward_start"]
-                )
-                > 0
-            )
+            # Although the autograd backward should always execute SideBw before MainBw,
+            # there is still a small chance the recorded events won't be in that order.
+            # self.assertTrue(
+            #     events["side_backward_start"].elapsed_time(
+            #         events["main_backward_start"]
+            #     )
+            #     > 0
+            # )
             # Overlap check: side's backward starts before side backward ends
             self.assertTrue(
                 events["main_backward_start"].elapsed_time(events["side_backward_end"])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #153963

Fixes https://github.com/pytorch/pytorch/issues/153927


Although the autograd backward should always execute SideBw before MainBw, there is still a small chance the recorded events won't be in that order.