### PR TITLE
[ROCm] Updated default workspace for gfx95

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -672,7 +672,7 @@ class TestCuda(TestCase):
             gcn_arch = str(
                 torch.cuda.get_device_properties(0).gcnArchName.split(":", 1)[0]
             )
-            if "gfx94" in gcn_arch:
+            if "gfx94" in gcn_arch or "gfx95" in gcn_arch:
                 default_workspace_size = 1024 * 128 * 1024  # :1024:128
         else:
             default_workspace_size = (


### PR DESCRIPTION
Fixes test_cuda.py::test_cublas_workspace_explicit_allocation on gfx95


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd