### PR TITLE
[nativert] Move Graph to pytorch core

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -590,6 +590,7 @@ libtorch_core_jit_sources = sorted(jit_sources_full)
 
 
 libtorch_nativert_sources = [
+    "torch/nativert/graph/Graph.cpp",
     "torch/nativert/graph/GraphSignature.cpp",
     "torch/nativert/graph/TensorMeta.cpp",
     "torch/nativert/executor/Placement.cpp",

--- a/test/cpp/nativert/CMakeLists.txt
+++ b/test/cpp/nativert/CMakeLists.txt
@@ -6,6 +6,7 @@ file(GLOB_RECURSE NATIVERT_ALL_TEST_FILES "${NATIVERT_TEST_ROOT}/test_*.cpp")
 set(NATIVERT_TEST_SRCS
   ${NATIVERT_ALL_TEST_FILES}
   ${TORCH_ROOT}/torch/nativert/graph/TensorMeta.cpp
+  ${TORCH_ROOT}/torch/nativert/graph/Graph.cpp
   ${TORCH_ROOT}/torch/nativert/graph/GraphSignature.cpp
   ${TORCH_ROOT}/torch/nativert/executor/PlacementUtils.cpp
   ${TORCH_ROOT}/torch/nativert/common/FileUtil.cpp

--- a/test/cpp/nativert/test_graph.cpp
+++ b/test/cpp/nativert/test_graph.cpp
@@ -1,0 +1,565 @@
+#include <c10/core/Device.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <torch/nativert/graph/Graph.h>
+
+using namespace ::testing;
+
+namespace torch::nativert {
+TEST(GraphTest, Basic) {
+  static constexpr std::string_view source =
+      R"(graph(%foo, %bar, %baz):
+%o1, %o2 = aten.foo(self=%foo, target=%bar, alpha=0.1)
+return(%o2, %baz)
+)";
+  auto graph = stringToGraph(source);
+  EXPECT_EQ(graph->inputs().size(), 3);
+  EXPECT_EQ(graph->inputs()[0]->name(), "foo");
+  EXPECT_EQ(graph->inputs()[1]->name(), "bar");
+  EXPECT_EQ(graph->inputs()[2]->name(), "baz");
+
+  const auto& nodes = graph->nodes();
+  EXPECT_EQ(nodes.size(), 3);
+  // First node is the input node
+  auto it = nodes.begin();
+  {
+    const auto& node = *it;
+    EXPECT_EQ(node.target(), "prim.Input");
+    EXPECT_EQ(node.inputs().size(), 0);
+    EXPECT_EQ(node.outputs().size(), 3);
+    EXPECT_EQ(node.outputs()[0]->name(), "foo");
+    EXPECT_EQ(node.outputs()[1]->name(), "bar");
+    EXPECT_EQ(node.outputs()[2]->name(), "baz");
+  }
+  {
+    std::advance(it, 1);
+    const auto& node = *it;
+    EXPECT_EQ(node.target(), "aten.foo");
+    EXPECT_EQ(node.inputs().size(), 2);
+    EXPECT_EQ(node.inputs()[0].name, "self");
+    EXPECT_EQ(node.inputs()[1].name, "target");
+
+    EXPECT_EQ(node.attributes().size(), 1);
+    EXPECT_EQ(node.attributes()[0].name, "alpha");
+  }
+  {
+    std::advance(it, 1);
+    const auto& node = *it;
+    EXPECT_EQ(node.target(), "prim.Output");
+    EXPECT_EQ(node.inputs().size(), 2);
+    EXPECT_EQ(node.inputs()[0].name, "o2");
+    EXPECT_EQ(node.inputs()[1].name, "baz");
+  }
+  EXPECT_EQ(graph->outputs().size(), 2);
+  EXPECT_EQ(graph->outputs()[0]->name(), "o2");
+  EXPECT_EQ(graph->outputs()[1]->name(), "baz");
+
+  const auto& values = graph->values();
+  EXPECT_EQ(values.size(), 5);
+  std::vector<std::string> valueNames;
+  valueNames.reserve(values.size());
+  for (const auto& v : values) {
+    valueNames.emplace_back(v->name());
+  }
+  std::sort(valueNames.begin(), valueNames.end());
+
+  EXPECT_THAT(
+      valueNames,
+      ContainerEq(std::vector<std::string>({"bar", "baz", "foo", "o1", "o2"})));
+}
+
+TEST(GraphTest, ValueProducer) {
+  static constexpr std::string_view source =
+      R"(graph(%foo, %bar, %baz):
+%o1, %o2 = aten.foo(self=%foo, target=%bar, alpha=0.1)
+return(%o2, %baz)
+)";
+  auto graph = stringToGraph(source);
+  auto foo = graph->getValue("foo");
+  EXPECT_EQ(foo->producer()->target(), "prim.Input");
+  auto o1 = graph->getValue("o1");
+  EXPECT_EQ(o1->producer()->target(), "aten.foo");
+}
+
+TEST(GraphTest, InsertBeforeAfter) {
+  static constexpr std::string_view source =
+      R"(graph(%foo, %bar, %baz):
+%o1, %o2 = aten.foo(self=%foo, target=%bar, alpha=0.1)
+return(%o2, %baz)
+)";
+  auto graph = stringToGraph(source);
+  auto it = graph->nodes().begin();
+  ++it;
+  auto& node = *it;
+  EXPECT_EQ(node.target(), "aten.foo");
+  auto before = graph->createNode("before", {});
+  auto after = graph->createNode("after", {});
+  auto atEnd = graph->createNode("atEnd", {});
+
+  graph->insertBefore(before, &node);
+  graph->insertAfter(after, &node);
+  graph->insert(atEnd);
+
+  static constexpr std::string_view expected =
+      R"(graph(%foo, %bar, %baz):
+ = before()
+%o1, %o2 = aten.foo(self=%foo, target=%bar, alpha=0.1)
+ = after()
+ = atEnd()
+return(%o2, %baz)
+)";
+  EXPECT_EQ(graphToString(*graph), expected);
+}
+
+TEST(GraphTest, ValueUses) {
+  static constexpr std::string_view source =
+      R"(graph(%foo, %bar, %baz):
+%o1, %o2 = aten.foo(self=%foo, target=%bar, alpha=0.1)
+return(%o2, %baz)
+)";
+  auto graph = stringToGraph(source);
+  auto o2 = graph->getValue("o2");
+  EXPECT_EQ(o2->users().size(), 1);
+  EXPECT_EQ(o2->users()[0]->target(), "prim.Output");
+}
+
+TEST(GraphTest, ApplyDevicePlacement) {
+  auto graph = Graph::createGraph();
+  auto node1 = graph->insertNode("node1");
+  auto node2 = graph->insertNode("node2");
+
+  node1->addAttribute({"a", c10::Device(c10::DeviceType::CPU)});
+  node1->addAttribute({"b", c10::Device(c10::DeviceType::CUDA, 0)});
+  node1->addAttribute({"c", c10::Device(c10::DeviceType::CUDA, 1)});
+
+  node2->addAttribute({"d", c10::Device(c10::DeviceType::CUDA, 0)});
+
+  graph->applyDevicePlacement(
+      Placement(std::unordered_map<c10::Device, c10::Device>{
+          {c10::Device(c10::DeviceType::CUDA, 0),
+           c10::Device(c10::DeviceType::CUDA, 1)}}));
+
+  EXPECT_EQ(
+      std::get<c10::Device>(node1->getAttribute("a").value),
+      c10::Device(c10::DeviceType::CPU));
+  EXPECT_EQ(
+      std::get<c10::Device>(node1->getAttribute("b").value),
+      c10::Device(c10::DeviceType::CUDA, 1));
+  EXPECT_EQ(
+      std::get<c10::Device>(node1->getAttribute("c").value),
+      c10::Device(c10::DeviceType::CUDA, 1));
+  EXPECT_EQ(
+      std::get<c10::Device>(node2->getAttribute("d").value),
+      c10::Device(c10::DeviceType::CUDA, 1));
+}
+
+TEST(GraphTest, ReplaceAllUses) {
+  static constexpr std::string_view source =
+      R"(graph(%foo, %bar, %baz):
+%o1, %o2 = aten.foo(self=%foo, target=%bar, alpha=0.1)
+return(%o2, %baz)
+)";
+  auto graph = stringToGraph(source);
+  auto o2 = graph->getValue("o2");
+  auto bar = graph->getValue("bar");
+  auto foo = graph->getValue("foo");
+
+  EXPECT_EQ(o2->users().size(), 1);
+  EXPECT_EQ(bar->users().size(), 1);
+  EXPECT_EQ(foo->users().size(), 1);
+
+  graph->replaceAllUses(o2, bar);
+  EXPECT_EQ(o2->users().size(), 0);
+  EXPECT_EQ(bar->users().size(), 2);
+
+  graph->replaceAllUses(bar, foo);
+  EXPECT_EQ(bar->users().size(), 0);
+  EXPECT_EQ(foo->users().size(), 2);
+  static constexpr std::string_view expected =
+      R"(graph(%foo, %bar, %baz):
+%o1, %o2 = aten.foo(self=%foo, target=%foo, alpha=0.1)
+return(%foo, %baz)
+)";
+  EXPECT_EQ(graphToString(*graph), expected);
+}
+
+TEST(GraphTest, GetUniqueValueName) {
+  static constexpr std::string_view source =
+      R"(graph(%foo, %bar, %baz):
+%o1, %o2 = aten.foo(self=%foo, target=%bar, alpha=0.1)
+return(%o2, %bar)
+)";
+  auto graph = stringToGraph(source);
+  auto o2 = graph->getValue("o2");
+  auto fooNode = o2->producer();
+  auto v0 = graph->getUniqueValueName();
+  graph->addValue(v0, Type::Kind::None, fooNode);
+  auto v1 = graph->getUniqueValueName();
+  graph->addValue(v1, Type::Kind::None, fooNode);
+  auto v2 = graph->getUniqueValueName();
+  EXPECT_EQ(v0, "v0");
+  EXPECT_EQ(v1, "v1");
+  EXPECT_EQ(v2, "v2");
+}
+
+TEST(GraphTest, ReplaceAllUsesMultiUse) {
+  static constexpr std::string_view source =
+      R"(graph(%foo, %bar):
+%o1 = aten.foo(a=%foo, b=%foo, c=%bar)
+return(%o1)
+)";
+  auto graph = stringToGraph(source);
+  auto foo = graph->getValue("foo");
+  auto bar = graph->getValue("bar");
+  graph->replaceAllUses(foo, bar);
+
+  static constexpr std::string_view expected =
+      R"(graph(%foo, %bar):
+%o1 = aten.foo(a=%bar, b=%bar, c=%bar)
+return(%o1)
+)";
+  EXPECT_EQ(graphToString(*graph), expected);
+}
+
+TEST(GraphTest, ReplaceAllUsesAfter) {
+  static constexpr std::string_view source =
+      R"(graph(%foo):
+%o1 = aten.foo1(a=%foo)
+%o2 = aten.foo2(a=%o1, b=%foo)
+%o3 = aten.foo3(a=%o2, b=%o2, c=%foo)
+return(%foo, %o1, %o2, %o3)
+)";
+  auto graph = stringToGraph(source);
+  auto foo = graph->getValue("foo");
+  auto o1 = graph->getValue("o1");
+  auto foo3Node = graph->getValue("o3")->producer();
+  graph->replaceAllUsesAfterNode(foo, o1, foo3Node);
+
+  static constexpr std::string_view expected =
+      R"(graph(%foo):
+%o1 = aten.foo1(a=%foo)
+%o2 = aten.foo2(a=%o1, b=%foo)
+%o3 = aten.foo3(a=%o2, b=%o2, c=%foo)
+return(%o1, %o1, %o2, %o3)
+)";
+  EXPECT_EQ(graphToString(*graph), expected);
+  EXPECT_EQ(foo->users().size(), 3);
+  EXPECT_EQ(o1->users().size(), 2);
+}
+
+TEST(GraphTest, InsertingAfter) {
+  static constexpr std::string_view source =
+      R"(graph(%foo, %bar):
+%o1 = aten.first(a=%foo)
+%o2 = aten.foo(c=%bar)
+return(%o1, %o2)
+)";
+  auto graph = stringToGraph(source);
+  auto origNode = graph->getValue("o1")->producer();
+  {
+    InsertingAfter guard(origNode);
+    graph->insertNode("one");
+    graph->insertNode("two");
+    graph->insertNode("three");
+  }
+  graph->insertNode("four");
+  static constexpr std::string_view expected =
+      R"(graph(%foo, %bar):
+%o1 = aten.first(a=%foo)
+ = one()
+ = two()
+ = three()
+%o2 = aten.foo(c=%bar)
+ = four()
+return(%o1, %o2)
+)";
+  EXPECT_EQ(graphToString(*graph), expected);
+}
+
+TEST(NodeTest, GetInputAndAttribute) {
+  auto graph = Graph::createGraph();
+  auto input1 = graph->addInput("input1", Type::Kind::Tensor);
+  auto input2 = graph->addInput("input2", Type::Kind::Tensor);
+  auto input3 = graph->addInput("input3", Type::Kind::Tensor);
+  auto node = graph->createNode("foo.bar");
+
+  node->addInput({"out_of_order", input1});
+  node->addInput({"arg1", input2});
+  node->addInput({"arg2", input3});
+
+  node->addAttribute({"b", static_cast<int64_t>(0)});
+  node->addAttribute({"a", static_cast<int64_t>(2)});
+  node->addAttribute({"c", static_cast<int64_t>(1)});
+  {
+    const auto& input = node->getInput("out_of_order");
+    EXPECT_EQ(input.name, "out_of_order");
+    EXPECT_EQ(input.value, input1);
+  }
+  {
+    const auto& input = node->getInput("arg1");
+    EXPECT_EQ(input.name, "arg1");
+    EXPECT_EQ(input.value, input2);
+  }
+  {
+    const auto& input = node->getInput("arg2");
+    EXPECT_EQ(input.name, "arg2");
+    EXPECT_EQ(input.value, input3);
+  }
+  {
+    const auto& attr = node->getAttribute("a");
+    EXPECT_EQ(attr.name, "a");
+    EXPECT_EQ(attr.value, Constant(static_cast<int64_t>(2)));
+  }
+  {
+    const auto& attr = node->getAttribute("b");
+    EXPECT_EQ(attr.name, "b");
+    EXPECT_EQ(attr.value, Constant(static_cast<int64_t>(0)));
+  }
+  {
+    const auto& attr = node->getAttribute("c");
+    EXPECT_EQ(attr.name, "c");
+    EXPECT_EQ(attr.value, Constant(static_cast<int64_t>(1)));
+  }
+
+  EXPECT_EQ(node->tryGetInput("doesnotexist"), nullptr);
+  EXPECT_EQ(node->tryGetAttribute("doesnotexist"), nullptr);
+}
+
+TEST(NodeTest, NextPrev) {
+  static constexpr std::string_view source =
+      R"(graph(%foo):
+%o1 = aten.foo1(a=%foo)
+%o2 = aten.foo2(a=%o1, b=%foo)
+%o3 = aten.foo3(a=%o2, b=%o2, c=%foo)
+return(%foo, %o1, %o2, %o3)
+)";
+  auto graph = stringToGraph(source);
+  auto foo1 = graph->getValue("o1")->producer();
+  auto foo2 = graph->getValue("o2")->producer();
+  auto foo3 = graph->getValue("o3")->producer();
+  EXPECT_EQ(foo1->next(), foo2);
+  EXPECT_EQ(foo2->next(), foo3);
+  EXPECT_EQ(foo3->prev(), foo2);
+  EXPECT_EQ(foo3->next(), graph->outputNode());
+  EXPECT_EQ(foo2->prev(), foo1);
+  EXPECT_EQ(foo1->prev(), graph->inputNode());
+  EXPECT_EQ(graph->inputNode()->prev(), nullptr);
+  EXPECT_EQ(graph->outputNode()->next(), nullptr);
+}
+
+TEST(GraphTest, IsBefore) {
+  auto source = R"IR(
+    graph(%foo):
+      %o1 = aten.foo1(a=%foo)
+      %o2 = aten.foo2(a=%o1)
+      %o3 = aten.foo3(a=%o2)
+      return (%o3)
+  )IR";
+
+  auto graph = stringToGraph(source);
+  ASSERT_NE(graph, nullptr);
+
+  auto* o1 = graph->tryGetValue("o1");
+  auto* o2 = graph->tryGetValue("o2");
+  auto* o3 = graph->tryGetValue("o3");
+
+  auto* foo1 = o1->producer();
+  auto* foo2 = o2->producer();
+  auto* foo3 = o3->producer();
+
+  EXPECT_TRUE(foo1->isBefore(foo2)) << "foo1 should appear before foo2";
+  EXPECT_TRUE(foo2->isBefore(foo3)) << "foo2 should appear before foo3";
+  EXPECT_TRUE(foo1->isBefore(foo3)) << "foo1 should appear before foo3";
+
+  EXPECT_FALSE(foo2->isBefore(foo1)) << "foo2 should not appear before foo1";
+  EXPECT_FALSE(foo3->isBefore(foo2)) << "foo3 should not appear before foo2";
+}
+
+TEST(GraphTest, RemoveNodeWithUsers) {
+  // Check we shouldn't be able to remove a node that still has users
+  auto source = R"IR(
+    graph(%foo):
+        %o1 = aten.foo1(a=%foo)
+        %o2 = aten.foo2(a=%o1, b=%foo)
+        %o3 = aten.foo3(a=%o2, b=%o2, c=%foo)
+        return (%foo, %o1, %o3)
+  )IR";
+
+  auto graph = stringToGraph(source);
+  ASSERT_NE(graph, nullptr);
+
+  auto* o2 = graph->tryGetValue("o2");
+  auto* foo2 = o2->producer();
+
+  EXPECT_THROW(graph->removeNode(foo2), c10::Error);
+}
+
+TEST(GraphTest, RemoveNodeUnused) {
+  // Check node removal works as expected
+  auto source = R"IR(
+    graph(%foo):
+      %o1 = aten.foo1(a=%foo)
+      %o2 = aten.foo2(a=%o1, b=%foo)
+      %unused = aten.fooUnused(a=%o2)
+      return(%foo, %o1, %o2)
+  )IR";
+  auto graph = stringToGraph(source);
+
+  auto* valUnused = graph->tryGetValue("unused");
+  Node* nodeUnused = valUnused->producer();
+  EXPECT_EQ(nodeUnused->target(), "aten.fooUnused");
+
+  graph->removeNode(nodeUnused);
+  graph->lint();
+
+  // %unused should now be gone
+  EXPECT_EQ(graph->tryGetValue("unused"), nullptr)
+      << "Value %unused should no longer exist in the graph";
+
+  for (const auto& node : graph->nodes()) {
+    EXPECT_NE(node.target(), "aten.fooUnused");
+    for (const auto* output : node.outputs()) {
+      EXPECT_NE(output->name(), "unused")
+          << "Should not find %unused in any remaining node's outputs";
+    }
+  }
+}
+
+TEST(GraphTest, RemoveValue) {
+  auto source = R"IR(
+    graph(%foo):
+  %o1 = aten.foo1(a=%foo)
+  %o2 = aten.foo2(a=%o1, b=%foo)
+  %o3 = aten.foo3(a=%o2, b=%o2, c=%foo)
+  return (%foo, %o1, %o3)
+  )IR";
+
+  auto graph = stringToGraph(source);
+  auto* val_o1 = graph->tryGetValue("o1");
+
+  {
+    // Check we shouldn't be able to remove a value that still has users
+    EXPECT_THROW(graph->removeValue(val_o1), c10::Error);
+  }
+
+  {
+    // Check value removal works as expected
+    graph->replaceAllUses(val_o1, graph->tryGetValue("foo"));
+    graph->removeValue(val_o1);
+    EXPECT_EQ(graph->tryGetValue("%o1"), nullptr);
+  }
+}
+
+TEST(GraphTest, InsertGraph) {
+  auto source = R"IR(
+    graph(%foo):
+        %o1 = aten.foo1(a=%foo)
+        return (%o1)
+  )IR";
+
+  // Subgraph to be inserted
+  auto subgraphSource = R"IR(
+    graph(%x):
+        %s1 = aten.subFoo1(a=%x)
+        %s2 = aten.subFoo2(a=%s1)
+        return (%s2)
+  )IR";
+
+  auto mainGraph = stringToGraph(source);
+  auto subGraph = stringToGraph(subgraphSource);
+
+  // Insert subGraph into mainGraph. Use %o1 as the subGraph's %x
+  auto val_o1 = mainGraph->tryGetValue("o1");
+  std::unordered_map<const Value*, Value*> valueMap;
+  std::vector<Value*> insertedOutputs =
+      mainGraph->insertGraph(*subGraph, {val_o1}, valueMap);
+
+  EXPECT_EQ(insertedOutputs.size(), 1);
+
+  // Check all new nodes are inserted correctly from the copied %s2
+  auto* newS2 = insertedOutputs.front();
+
+  auto* newSubFoo2 = newS2->producer();
+  EXPECT_EQ(newSubFoo2->target(), "aten.subFoo2");
+
+  auto* newS1 = newSubFoo2->inputs().front().value;
+  auto* newSubFoo1 = newS1->producer();
+  EXPECT_EQ(newSubFoo1->target(), "aten.subFoo1");
+
+  EXPECT_EQ(newSubFoo1->inputs().front().value, val_o1);
+
+  auto* subInputVal = subGraph->inputs().front();
+  EXPECT_EQ(valueMap[subInputVal], val_o1);
+  for (const auto& [val1, val2] : valueMap) {
+    if (val1->name() == "s1") {
+      EXPECT_EQ(val2->name(), newS1->name());
+    }
+    if (val1->name() == "s2") {
+      EXPECT_EQ(val2->name(), newS2->name());
+    }
+    if (val1->name() == "x") {
+      EXPECT_EQ(val2->name(), val_o1->name());
+    }
+  }
+
+  mainGraph->lint();
+}
+
+TEST(GraphTest, CleanupDeadNodes) {
+  // %c is unused
+  const std::string source = R"(
+  graph(%x, %y):
+%a = foo(a=%x, b=%y)
+%b = foo1(c=%a)
+%c = foo2(a=%b, b=%y)
+return(%b)
+)";
+  auto graph = stringToGraph(source);
+
+  // Verify that %c exists initially
+  auto* cVal = graph->tryGetValue("c");
+  ASSERT_NE(nullptr, cVal);
+  size_t nodeCountBefore = graph->nodes().size();
+
+  graph->cleanupDeadNodes();
+
+  // %c should now be gone
+  EXPECT_EQ(nullptr, graph->tryGetValue("c"));
+  // %b should still be there
+  EXPECT_NE(nullptr, graph->tryGetValue("b"));
+  EXPECT_EQ(nodeCountBefore - 1, graph->nodes().size());
+}
+
+TEST(GraphTest, RenumberValues) {
+  const std::string source = R"(
+  graph(%x):
+%a = foo(a=%x)
+%b = foo1(a=%a)
+return (%a)
+)";
+  auto graph = stringToGraph(source);
+  graph->cleanupDeadNodes();
+
+  // %b should now be gone
+  EXPECT_EQ(nullptr, graph->tryGetValue("b"));
+
+  // %a should now be the last value
+  EXPECT_EQ(graph->tryGetValue("a")->id(), graph->numValues() - 1);
+
+  // All values should be renumbered
+  size_t numVals = graph->numValues();
+  std::unordered_set<ValueId> ids;
+  ids.reserve(numVals);
+  for (const auto* val : graph->values()) {
+    ASSERT_LT(val->id(), numVals);
+    ids.insert(val->id());
+  }
+
+  // Check ids are contiguous and unique b/w 0 and numVals
+  EXPECT_EQ(numVals, ids.size());
+  for (size_t i = 0; i < numVals; ++i) {
+    EXPECT_NE(ids.end(), ids.find(i));
+  }
+}
+} // namespace torch::nativert

--- a/torch/nativert/graph/Graph.cpp
+++ b/torch/nativert/graph/Graph.cpp
@@ -1,0 +1,1565 @@
+#include <torch/nativert/graph/Graph.h>
+
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+#include <limits>
+#include <queue>
+
+#include <c10/util/Enumerate.h>
+#include <c10/util/FbcodeMaps.h>
+#include <c10/util/StringUtil.h>
+#include <c10/util/string_view.h>
+#include <torch/nativert/executor/Placement.h> // @manual
+#include <torch/nativert/graph/TensorMeta.h> // @manual
+
+namespace torch::nativert {
+
+namespace {
+
+// Workaround for MSVC bug: "std" ambiguous symbol.
+template <typename T, typename U>
+constexpr bool is_same_v = std::is_same_v<T, U>;
+
+bool isBlank(char n) {
+  return std::isspace(n);
+}
+
+size_t consumeWhitespaceImpl(std::string_view source, size_t curPos) {
+  while (isBlank(source.at(curPos))) {
+    curPos++;
+  }
+  return curPos;
+}
+
+size_t expectImpl(
+    std::string_view source,
+    std::string_view expected,
+    size_t curPos) {
+  curPos = consumeWhitespaceImpl(source, curPos);
+  const auto actual = source.substr(curPos, expected.size());
+  TORCH_CHECK(
+      expected == actual,
+      fmt::format(
+          "Parser error: expected '{}' at postition {}, but found '{}'.",
+          expected,
+          curPos,
+          actual));
+  curPos += expected.size();
+  return curPos;
+}
+
+size_t expectImpl(std::string_view source, char expected, size_t curPos) {
+  curPos = consumeWhitespaceImpl(source, curPos);
+  while (isBlank(source.at(curPos))) {
+    curPos++;
+  }
+  TORCH_CHECK(
+      expected == source[curPos],
+      "Parser error: expected '{}' at postition {}, but found '{}'.",
+      expected,
+      curPos,
+      source[curPos]);
+  curPos++;
+  return curPos;
+}
+} // namespace
+
+bool operator==(const Type& left, const Type& right) {
+  if (left.kind() != right.kind()) {
+    return false;
+  }
+  if (std::holds_alternative<Type::CustomObjData>(left.kind_) &&
+      std::holds_alternative<Type::CustomObjData>(right.kind_)) {
+    return std::get<Type::CustomObjData>(left.kind_).classFqn ==
+        std::get<Type::CustomObjData>(right.kind_).classFqn;
+  }
+  return true;
+}
+
+Graph::Graph()
+    : insertBefore_(nodes_.end()),
+      inputNode_(insertNode("prim.Input", {})),
+      outputNode_(insertNode("prim.Output", {})) {
+  // Set the insertion point to append to the graph
+  insertBefore_ = nodes_.iterator_to(*outputNode_);
+}
+
+std::string Graph::getUniqueValueName() {
+  auto name = fmt::format("v{}", uniqueValueName_);
+  while (values_.find(name) != values_.end()) {
+    name = fmt::format("v{}", uniqueValueName_++);
+  }
+  return name;
+}
+
+// If `name` is null, create a unique value name
+Value* Graph::addValue(
+    const std::optional<std::string>& name,
+    const Type& type,
+    Node* node) {
+  const auto valueName = name.value_or(getUniqueValueName());
+  ValueId valueId = getNextValueId();
+  const auto [it, success] = values_.insert(
+      {valueName, std::make_unique<Value>(valueId, valueName, type, node)});
+  TORCH_CHECK(
+      success,
+      fmt::format(
+          "Tried to create Value with name: '{}', but it already existed",
+          valueName));
+  return it->second.get();
+}
+
+Value* Graph::addInput(std::string_view name, const Type& type) {
+  return inputNode_->addOutput(name, type);
+}
+
+void Graph::addInput() {
+  inputNode_->addOutput();
+}
+
+Value* Graph::addOutput(Value* v) {
+  outputNode_->addInput({std::string(v->name()), v});
+  return v;
+}
+
+void Graph::addConstantOutput(Constant c) {
+  constantOutputs_.push_back(std::move(c));
+}
+
+// Create a node without inserting it into the execution graph.
+Node* Graph::createNode(
+    std::string target,
+    std::vector<NamedArgument> inputs,
+    std::unordered_map<std::string, std::string> metadata) {
+  auto& node = nodesOwner_.emplace_back(std::make_unique<Node>(
+      this, std::move(target), std::move(inputs), std::move(metadata)));
+  return node.get();
+}
+
+Node* Graph::insertBefore(Node* toInsert, Node* insertionPoint) {
+  TORCH_CHECK(insertionPoint != inputNode_, "can't insert before prim.Input");
+  TORCH_CHECK(
+      !toInsert->is_linked(), "expected node to be unlinked: ", *toInsert);
+  TORCH_CHECK(
+      insertionPoint->is_linked(),
+      "expected node to be linked: ",
+      *insertionPoint);
+  auto it = nodes_.insert(nodes_.iterator_to(*insertionPoint), *toInsert);
+  return &*it;
+}
+
+Node* Graph::insert(Node* toInsert) {
+  TORCH_CHECK(
+      !toInsert->is_linked(), "expected node to be unlinked: ", *toInsert);
+  nodes_.insert(insertBefore_, *toInsert);
+  return toInsert;
+}
+
+Node* Graph::insertAfter(Node* toInsert, Node* insertionPoint) {
+  TORCH_CHECK(insertionPoint != outputNode_, "can't insert after prim.Output");
+  TORCH_CHECK(
+      !toInsert->is_linked(), "expected node to be unlinked: ", *toInsert);
+  TORCH_CHECK(
+      insertionPoint->is_linked(),
+      "expected node to be linked: ",
+      *insertionPoint);
+
+  auto insertIt = nodes_.iterator_to(*insertionPoint);
+  // Increment once because we want to insert after the insertion point
+  ++insertIt;
+  auto it = nodes_.insert(insertIt, *toInsert);
+  return &*it;
+}
+
+Node* Graph::insertNode(
+    std::string target,
+    std::vector<NamedArgument> inputs,
+    std::unordered_map<std::string, std::string> metadata) {
+  auto node =
+      createNode(std::move(target), std::move(inputs), std::move(metadata));
+  nodes_.insert(insertBefore_, *node);
+  return node;
+}
+
+std::ostream& operator<<(std::ostream& out, const Type& ty) {
+  std::visit(
+      [&out](auto&& arg) {
+        using T = std::decay_t<decltype(arg)>;
+        if constexpr (is_same_v<T, Type::Kind>) {
+          switch (arg) {
+            case Type::Kind::None:
+              out << "None";
+              break;
+            case Type::Kind::Tensor:
+              out << "Tensor";
+              break;
+            case Type::Kind::TensorList:
+              out << "TensorList";
+              break;
+            case Type::Kind::OptionalTensorList:
+              out << "OptionalTensorList";
+              break;
+            case Type::Kind::SymInt:
+              out << "SymInt";
+              break;
+            case Type::Kind::SymFloat:
+              out << "SymFloat";
+              break;
+            case Type::Kind::SymIntList:
+              out << "SymIntList";
+              break;
+            case Type::Kind::CustomObj:
+              out << "CustomObj";
+              break;
+            default:
+              TORCH_CHECK(false, "Unhandled type");
+          }
+        } else if constexpr (is_same_v<T, Type::CustomObjData>) {
+          out << "CustomObj: " << arg.classFqn;
+        }
+      },
+      ty.kind_);
+  return out;
+}
+
+const NamedArgument* Node::tryGetInput(std::string_view name) const {
+  // Just do a scan over the inputs. We expect there to always be a very small
+  // number of elements, so it shouldn't be slow. This allows us to avoid a
+  // second datastructure for lookups.
+  // Drop a debug check here, just to make sure :)
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(inputs_.size() < 1000);
+  for (const auto& input : inputs_) {
+    if (input.name == name) {
+      return &input;
+    }
+  }
+  return nullptr;
+}
+
+const NamedArgument& Node::getInput(std::string_view name) const {
+  const auto ret = tryGetInput(name);
+  if (ret == nullptr) {
+    TORCH_CHECK(
+        false,
+        fmt::format(
+            "Expected input '{}' on node: '{}' to exist, but it does not.",
+            name,
+            fmt::streamed(*this)));
+  }
+  return *ret;
+}
+
+const Attribute* Node::tryGetAttribute(std::string_view name) const {
+  // Just do a scan over the inputs. We expect there to always be a very small
+  // number of elements, so it shouldn't be slow. This allows us to avoid a
+  // second datastructure for lookups.
+  // Drop a debug check here, just to make sure :)
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(attributes_.size() < 1000);
+  for (const auto& attribute : attributes_) {
+    if (attribute.name == name) {
+      return &attribute;
+    }
+  }
+  return nullptr;
+}
+
+const Attribute& Node::getAttribute(std::string_view name) const {
+  const auto ret = tryGetAttribute(name);
+  if (ret == nullptr) {
+    TORCH_CHECK(
+        false,
+        fmt::format(
+            "Expected attribute '{}' on node: '{}' to exist, but it does not.",
+            name,
+            fmt::streamed(*this)));
+  }
+  return *ret;
+}
+
+void Node::applyDevicePlacement(const Placement& placement) {
+  for (auto& attribute : attributes_) {
+    if (std::holds_alternative<c10::Device>(attribute.value)) {
+      auto device = std::get<c10::Device>(attribute.value);
+      auto targetDevice =
+          placement.getMappedDevice(std::get<c10::Device>(attribute.value));
+      if (!torch::nativert::isSameDevice(targetDevice, device)) {
+        LOG(INFO) << "Overriding " << device.str() << " to "
+                  << targetDevice.str() << " for node " << *this;
+        attribute.value = targetDevice;
+      }
+    }
+  }
+}
+
+Node* Node::next() {
+  return owningGraph()->nodeAfter(this);
+}
+
+const Node* Node::next() const {
+  return owningGraph()->nodeAfter(this);
+}
+
+Node* Node::prev() {
+  return owningGraph()->nodeBefore(this);
+}
+
+const Node* Node::prev() const {
+  return owningGraph()->nodeBefore(this);
+}
+
+bool Node::isBefore(const Node* n) const {
+  if (this == n) {
+    return false;
+  }
+
+  for (const Node* cursor = this->next(); cursor != nullptr;
+       cursor = cursor->next()) {
+    if (cursor == n) {
+      return true;
+    }
+  }
+  // Reached the end without finding n
+  return false;
+}
+
+std::vector<Node*> Node::producers() const {
+  std::vector<Node*> ret;
+
+  if (this->prev() == nullptr /* prim.Input */) {
+    return ret;
+  }
+
+  if (this->next() == nullptr /* prim.Output */) {
+    for (auto& node : owningGraph_->nodes()) {
+      if (node.next() == nullptr /* prim.Output */ ||
+          node.prev() == nullptr /* prim.Input */) {
+        continue;
+      }
+      for (auto* dep : node.users()) {
+        if (dep == this /* prim.Output */) {
+          ret.push_back(&node);
+        }
+      }
+    }
+  } else {
+    std::unordered_set<const Node*> seen;
+
+    for (const auto& input : inputs()) {
+      auto* n = input.value->producer();
+      if (n == nullptr) {
+        continue;
+      }
+      if (const auto [_, inserted] = seen.insert(n); inserted) {
+        ret.push_back(n);
+      }
+    }
+
+    if (ret.empty()) {
+      ret.push_back(owningGraph_->inputNode());
+    }
+  }
+
+  return ret;
+}
+
+std::vector<Node*> Node::users() const {
+  std::vector<Node*> ret;
+
+  if (this->next() == nullptr /* prim.Output */) {
+    return ret;
+  }
+
+  if (this->prev() == nullptr /* prim.Input */) {
+    for (auto& node : owningGraph_->nodes()) {
+      if (node.prev() == nullptr /* prim.Input */ ||
+          node.next() == nullptr /* prim.Output */) {
+        continue;
+      }
+      for (auto* dep : node.producers()) {
+        if (dep == this /* prim.Input */) {
+          ret.push_back(&node);
+        }
+      }
+    }
+  } else {
+    std::unordered_set<const Node*> seen;
+
+    for (const auto* output : outputs()) {
+      for (auto* n : output->users()) {
+        if (const auto [_, inserted] = seen.insert(n); inserted) {
+          ret.push_back(n);
+        }
+      }
+    }
+
+    if (ret.empty()) {
+      ret.push_back(owningGraph_->outputNode());
+    }
+  }
+
+  return ret;
+}
+
+Node* Graph::createListPack(std::vector<Value*> inputs, const Type& inputType) {
+  std::vector<NamedArgument> nodeInputs;
+  nodeInputs.reserve(inputs.size());
+  for (auto [i, input] : c10::enumerate(inputs)) {
+    nodeInputs.push_back({fmt::format("l{}", i), input});
+  }
+  // Create a new named value for this
+  auto name = getUniqueValueName();
+  auto node = createNode("prim.ListPack", std::move(nodeInputs));
+
+  // Make sure all inputs are the same type
+  for (auto& input : inputs) {
+    TORCH_CHECK(input->type() == inputType);
+  }
+
+  if (inputType == Type::Kind::Tensor) {
+    node->addOutput(name, Type::Kind::TensorList);
+  } else if (inputType == Type::Kind::SymInt) {
+    node->addOutput(name, Type::Kind::SymIntList);
+  }
+
+  return node;
+}
+
+Node* Graph::createOptionalListPack(std::vector<Value*> inputs) {
+  std::vector<NamedArgument> nodeInputs;
+  nodeInputs.reserve(inputs.size());
+  for (auto [i, input] : c10::enumerate(inputs)) {
+    nodeInputs.push_back({fmt::format("l{}", i), input});
+  }
+  // Create a new named value for this
+  auto name = getUniqueValueName();
+  auto node = createNode("prim.ListPack", std::move(nodeInputs));
+  // Make sure all inputs are either None or Tensor
+  for (auto& input : inputs) {
+    TORCH_CHECK(
+        input->type() == Type::Kind::None ||
+        input->type() == Type::Kind::Tensor);
+  }
+  node->addOutput(name, Type::Kind::OptionalTensorList);
+
+  return node;
+}
+
+Value* Graph::createConstantSymIntValue(int value) {
+  auto valueName = getUniqueValueName();
+  ValueId valueId = getNextValueId();
+  const auto [it, success] = values_.insert(
+      {valueName,
+       std::make_unique<Value>(
+           valueId, valueName, Type::Kind::SymInt, nullptr)});
+  TORCH_CHECK(
+      success,
+      fmt::format(
+          "Tried to create constant SymInt Value with name: '{}', but it already existed",
+          valueName));
+  constantSymIntValues_[valueId] = value;
+  return it->second.get();
+}
+
+Value* Graph::getValue(std::string_view name) const {
+  // TODO: can eliminate this string copy by enabling heterogeneous lookup for
+  // the container
+  return values_.at(std::string(name)).get();
+}
+
+Value* Graph::tryGetValue(std::string_view name) const {
+  // TODO: can eliminate this string copy by enabling heterogeneous lookup for
+  // the container
+  const auto key = std::string(name);
+  if (values_.find(key) != values_.end()) {
+    return values_.at(key).get();
+  }
+  return nullptr;
+}
+
+void Graph::renumberValues() {
+  std::vector<Value*> currentValues;
+  currentValues.reserve(values_.size());
+  for (auto& kv : values_) {
+    currentValues.push_back(kv.second.get());
+  }
+
+  // Sort values in creation order (by value ids)
+  std::sort(currentValues.begin(), currentValues.end(), [](Value* a, Value* b) {
+    return a->id() < b->id();
+  });
+
+  // Build a new id map with all ids < values_.size()
+  std::unordered_map<ValueId, ValueId> oldToNew;
+  oldToNew.reserve(currentValues.size());
+  ValueId newId = 0;
+  for (Value* v : currentValues) {
+    oldToNew[v->id()] = newId;
+    v->setId(newId);
+    newId++;
+  }
+
+  std::unordered_map<ValueId, int> newSymIntMap;
+  for (auto& [oldId, symIntVal] : constantSymIntValues_) {
+    auto it = oldToNew.find(oldId);
+    if (it != oldToNew.end()) {
+      ValueId updatedId = it->second;
+      newSymIntMap[updatedId] = symIntVal;
+    }
+  }
+  constantSymIntValues_ = std::move(newSymIntMap);
+  uniqueValueId_ = newId;
+}
+
+bool Graph::cleanupDeadNodes() {
+  std::unordered_set<const Node*> visited;
+  std::vector<const Node*> visitStack;
+
+  // Mark reachable nodes from output
+  visitStack.push_back(outputNode_);
+  visited.insert(outputNode_);
+
+  while (!visitStack.empty()) {
+    const Node* current = visitStack.back();
+    visitStack.pop_back();
+
+    for (auto& namedArg : current->inputs()) {
+      Value* val = namedArg.value;
+      Node* producer = val->producer();
+
+      if (!producer) {
+        continue;
+      }
+      if (!visited.count(producer)) {
+        visited.insert(producer);
+        visitStack.push_back(producer);
+      }
+    }
+  }
+
+  // Remove all nodes not in visited (other than input/outputs)
+  std::vector<Node*> toRemove;
+  for (auto& n : nodes()) {
+    if (n.target() == "prim.Input" || n.target() == "prim.Output" ||
+        visited.count(&n)) {
+      continue;
+    }
+    toRemove.push_back(&n);
+  }
+
+  const bool mutated = !toRemove.empty();
+
+  // Remove nodes in reverse order to handle input/output dependencies
+  for (auto it = toRemove.rbegin(); it != toRemove.rend(); ++it) {
+    removeNode(*it);
+  }
+
+  renumberValues();
+  lint();
+
+  return mutated;
+}
+
+void Graph::lint() const {
+  // Check that every value has a producer marked.
+  for (const auto& [name, value] : values_) {
+    // Some constant symint and None don't have producer nodes
+    if (value->type().kind() != Type::Kind::SymInt &&
+        value->type().kind() != Type::Kind::None) {
+      TORCH_CHECK(value->isFolded() || value->producer() != nullptr);
+    }
+  }
+  for (const auto& node : nodes()) {
+    TORCH_CHECK_EQ(node.owningGraph(), this);
+  }
+  // Check that every list type is either produced by a prim.ListPack or
+  // immediately consumed by a prim.ListUnpack. We make use of this invariant
+  // to retrieve list elements in `getListElements`.
+  for (const auto& [_, value] : values_) {
+    if (value->type().kind() != Type::Kind::TensorList) {
+      continue;
+    }
+    const bool producedByListPack =
+        value->producer(/* resolve_folded = */ true)->target() ==
+        "prim.ListPack";
+    const bool consumedByListUnpack = value->users().size() == 1 &&
+        value->users()[0]->target() == "prim.ListUnpack";
+    TORCH_CHECK(producedByListPack || consumedByListUnpack);
+  }
+
+  auto getNames = [](const auto& values) {
+    c10::FastSet<std::string> names;
+    for (const auto* value : values) {
+      if (value) {
+        names.emplace(value->name());
+      }
+    }
+    return names;
+  };
+  signature_.lint(getNames(inputs()), getNames(outputs()));
+}
+
+void Graph::finalize() {
+  // build userOutputs_ view
+  userOutputs_.clear();
+  size_t constantIndex = 0;
+  for (auto& outputName : signature_.userOutputs()) {
+    if (outputName.has_value()) {
+      userOutputs_.emplace_back(getValue(*outputName));
+    } else {
+      if (constantIndex < constantOutputs_.size()) {
+        userOutputs_.emplace_back(std::move(constantOutputs_[constantIndex]));
+        constantIndex++;
+      } else {
+        TORCH_CHECK(false, "No more constant outputs available");
+      }
+    }
+  }
+}
+
+namespace {
+// Scan through a node's inputs, replacing ALL instances of `old` with
+// `replacement`.  Returns true if a replacement occurred, otherwise false.
+bool replace(Node* node, Value* old, Value* replacement) {
+  bool replacementOccurred = false;
+  for (auto& input : node->inputs()) {
+    if (input.value == old) {
+      input.value = replacement;
+      replacementOccurred = true;
+    }
+  }
+  return replacementOccurred;
+}
+} // namespace
+
+void Graph::replaceAllUses(Value* old, Value* replacement) {
+  for (auto user : old->users()) {
+    // Find this use in the input list and replace it
+    auto replaced = replace(user, old, replacement);
+    TORCH_CHECK(replaced);
+    replacement->addUser(user);
+  }
+  old->eraseAllUsers();
+  signature_.replaceAllUses(old->name(), replacement->name());
+}
+
+void Graph::replaceAllUsesAfterNode(
+    Value* old,
+    Value* replacement,
+    Node* afterThis) {
+  auto it = nodes_.iterator_to(*afterThis);
+  // Don't search `afterThis`
+  ++it;
+  // Scan through all node inputs linearly and replace uses
+  for (; it != nodes_.end(); ++it) {
+    Node* node = &*it;
+    const bool replaced = replace(node, old, replacement);
+    if (replaced) {
+      old->eraseUser(node);
+      replacement->addUser(node);
+    }
+  }
+  signature_.replaceAllUses(old->name(), replacement->name());
+}
+
+void Graph::applyDevicePlacement(const Placement& placement) {
+  // TODO: consolidate device info in weight loading here as well.
+  for (auto& node : nodes_) {
+    node.applyDevicePlacement(placement);
+  }
+}
+
+Node* Graph::nodeAfter(Node* n) {
+  TORCH_CHECK_EQ(n->owningGraph(), this);
+  if (n == outputNode_) {
+    return nullptr;
+  }
+  auto it = nodes_.iterator_to(*n);
+  return &*(++it);
+}
+
+const Node* Graph::nodeAfter(const Node* n) const {
+  TORCH_CHECK_EQ(n->owningGraph(), this);
+  if (n == outputNode_) {
+    return nullptr;
+  }
+  auto it = nodes_.iterator_to(*n);
+  return &*(++it);
+}
+
+Node* Graph::nodeBefore(Node* n) {
+  TORCH_CHECK_EQ(n->owningGraph(), this);
+  if (n == inputNode_) {
+    return nullptr;
+  }
+  auto it = nodes_.iterator_to(*n);
+  return &*(--it);
+}
+
+const Node* Graph::nodeBefore(const Node* n) const {
+  TORCH_CHECK_EQ(n->owningGraph(), this);
+  if (n == inputNode_) {
+    return nullptr;
+  }
+  auto it = nodes_.iterator_to(*n);
+  return &*(--it);
+}
+
+void Graph::removeNode(Node* n) {
+  TORCH_CHECK_EQ(n->owningGraph(), this)
+      << "Node does not belong to this graph!";
+
+  for (auto* outputVal : n->outputs()) {
+    TORCH_CHECK(
+        outputVal->users().empty(),
+        "Trying to erase a node that still has users: ",
+        outputVal->name());
+    outputVal->eraseAllUsers();
+    removeValue(outputVal);
+  }
+
+  for (const auto& input : n->inputs()) {
+    input.value->eraseUser(n);
+  }
+
+  TORCH_CHECK(n->is_linked(), "Node is not linked to the graph!");
+  n->unlink();
+
+  auto it = std::find_if(
+      nodesOwner_.begin(),
+      nodesOwner_.end(),
+      [n](const std::unique_ptr<Node>& ptr) { return ptr.get() == n; });
+
+  TORCH_CHECK(it != nodesOwner_.end(), "Node not found in nodesOwner_!");
+  nodesOwner_.erase(it);
+}
+
+void Graph::removeValue(Value* value) {
+  // TODO: assuming not removing from constantSymIntValues_
+  TORCH_CHECK(value->users().empty(), "Cannot erase a value with users.");
+  auto it = values_.find(std::string(value->name()));
+  TORCH_CHECK(
+      it != values_.end(),
+      "Attempted to erase a value not in graph ",
+      value->name());
+  values_.erase(it);
+}
+
+std::vector<Value*> Graph::insertGraph(
+    const Graph& subgraph,
+    std::vector<Value*> inputs,
+    std::unordered_map<const Value*, Value*>& valueMap) {
+  TORCH_CHECK_EQ(subgraph.inputs().size(), inputs.size())
+      << "Input size mismatch";
+  for (auto i : c10::irange(subgraph.inputs().size())) {
+    valueMap[subgraph.inputs()[i]] = inputs[i];
+  }
+
+  // Clone each node from subgraph
+  for (const auto& n : subgraph.nodes()) {
+    if (n.target() == "prim.Input" || n.target() == "prim.Output") {
+      continue;
+    }
+
+    std::vector<NamedArgument> clonedInputs;
+    auto inputs = n.inputs();
+    clonedInputs.reserve(inputs.size());
+    for (auto& inp : inputs) {
+      auto it = valueMap.find(inp.value);
+      TORCH_CHECK(it != valueMap.end(), "Missing input value in subgraph");
+      clonedInputs.push_back({inp.name, it->second});
+    }
+
+    Node* newNode = insertNode(
+        std::string(n.target()), std::move(clonedInputs), n.metadata());
+
+    for (const auto& attr : n.attributes()) {
+      Attribute newAttr;
+      newAttr.name = attr.name;
+
+      std::visit(
+          [&](auto&& val) -> void {
+            // Workaround for MSVC bug: "std" ambiguous symbol.
+            using std::unique_ptr;
+            using std::move;
+            using T = std::decay_t<decltype(val)>;
+            if constexpr (is_same_v<T, unique_ptr<Graph>>) {
+              LOG(ERROR)
+                  << "Graph attributes are not supported yet. Skipping attribute: "
+                  << attr.name;
+            } else {
+              newAttr.value = val;
+#ifdef __clang__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#pragma GCC diagnostic ignored "-Wunqualified-std-cast-call"
+#endif
+              newNode->addAttribute(move(newAttr));
+#ifdef __clang__
+#pragma GCC diagnostic pop
+#endif
+            }
+          },
+          attr.value);
+    }
+
+    for (const auto* outVal : n.outputs()) {
+      const auto& uniqueName = getUniqueValueName();
+      Value* newOut = newNode->addOutput(uniqueName, outVal->type());
+      valueMap[outVal] = newOut;
+    }
+  }
+
+  auto subgraphOutputs = subgraph.outputs();
+  std::vector<Value*> outputValues;
+  outputValues.reserve(subgraphOutputs.size());
+  for (auto* outputValue : subgraphOutputs) {
+    outputValues.emplace_back(valueMap[outputValue]);
+  }
+  lint();
+  return outputValues;
+}
+
+Node::Node(
+    Graph* owningGraph,
+    std::string target,
+    std::vector<NamedArgument> inputs,
+    std::unordered_map<std::string, std::string> metadata)
+    : owningGraph_(owningGraph),
+      target_(std::move(target)),
+      inputs_(std::move(inputs)),
+      metadata_(std::move(metadata)) {
+  for (const auto& input : inputs_) {
+    input.value->addUser(this);
+  }
+}
+
+Value* Node::addInput(NamedArgument input) {
+  inputs_.push_back(std::move(input));
+  auto val = inputs_.back().value;
+  val->addUser(this);
+  return val;
+}
+
+void Node::addInputs(const std::vector<NamedArgument>& inputs) {
+  for (const auto& input : inputs) {
+    addInput(input);
+  }
+}
+
+void Node::addAttribute(Attribute attr) {
+  attributes_.push_back(std::move(attr));
+}
+
+void Node::addOutput() {
+  outputs_.push_back(nullptr);
+}
+
+Value* Node::addOutput(const Type& type) {
+  TORCH_CHECK_EQ(type, Type::Kind::None);
+  Value* v = owningGraph_->addValue(std::nullopt, type, this);
+  outputs_.push_back(v);
+  return v;
+}
+
+Value* Node::addOutput(std::string_view name, const Type& type) {
+  Value* v = owningGraph_->addValue(std::string(name), type, this);
+  outputs_.push_back(v);
+  return v;
+}
+
+void Node::destroy() {
+  owningGraph_->removeNode(this);
+}
+
+void Value::addUser(Node* node) {
+  for (const auto* user : users_) {
+    if (user == node) {
+      return;
+    }
+  }
+  users_.push_back(node);
+}
+
+void Value::eraseUser(Node* node) {
+  users_.erase(
+      std::remove_if(
+          users_.begin(), users_.end(), [&](Node* el) { return el == node; }),
+      users_.end());
+}
+
+std::vector<const Value*> Value::getListElements() const {
+  std::vector<const Value*> ret;
+  if (auto p = producer(); p && p->target() == "prim.ListPack") {
+    for (const auto& tv : p->inputs()) {
+      ret.push_back(tv.value);
+    }
+  } else {
+    TORCH_CHECK_EQ(users().size(), 1);
+    const auto listUnpack = users()[0];
+    TORCH_CHECK_EQ(listUnpack->target(), "prim.ListUnpack");
+    for (const auto v : listUnpack->outputs()) {
+      ret.push_back(v);
+    }
+  }
+  return ret;
+}
+
+template <class>
+[[maybe_unused]] inline constexpr bool AlwaysFalse = false;
+
+c10::IValue constantToIValue(const Constant& constant) {
+  // Workaround for MSVC bug: "std" ambiguous symbol.
+  using std::string;
+  using std::unique_ptr;
+  using std::vector;
+  return std::visit(
+      [](auto&& arg) -> c10::IValue {
+        using T = std::decay_t<decltype(arg)>;
+        if constexpr (is_same_v<T, None>) {
+          return c10::IValue();
+        } else if constexpr (std::is_convertible_v<T, c10::IValue>) {
+          return arg;
+        } else if constexpr (is_same_v<T, unique_ptr<Graph>>) {
+          TORCH_CHECK(
+              false, "subgraph arguments cannot be turned into ivalues!");
+        } else {
+          static_assert(AlwaysFalse<T>, "non-exhaustive visitor!");
+        }
+      },
+      constant);
+}
+
+namespace {
+
+template <class>
+[[maybe_unused]] inline constexpr bool always_false_v = false;
+
+void printDouble(std::ostream& out, double arg) {
+  fmt::print(out, "{}", arg);
+}
+
+template <typename T, typename F>
+std::ostream& printList(
+    std::ostream& out,
+    bool encloseInSquareBrackets,
+    const T& list,
+    F formatter) {
+  if (encloseInSquareBrackets) {
+    out << '[';
+  }
+  for (const auto& [idx, el] : c10::enumerate(list)) {
+    if (idx > 0) {
+      out << ", ";
+    }
+    formatter(out, el);
+  }
+  if (encloseInSquareBrackets) {
+    out << ']';
+  }
+  return out;
+}
+
+std::ostream& operator<<(std::ostream& out, const Constant& constant) {
+  // Workaround for MSVC bug: "std" ambiguous symbol.
+  using std::quoted;
+  using std::string;
+  using std::unique_ptr;
+  using std::vector;
+  std::visit(
+      [&](auto&& arg) {
+        using T = std::decay_t<decltype(arg)>;
+        if constexpr (is_same_v<T, None>) {
+          out << "None";
+        } else if constexpr (is_same_v<T, int64_t> || is_same_v<T, bool>) {
+          out << arg;
+        } else if constexpr (
+            is_same_v<T, vector<int64_t>> || is_same_v<T, vector<bool>>) {
+          out << fmt::format("{}", fmt::streamed(arg));
+        } else if constexpr (is_same_v<T, double>) {
+          printDouble(out, arg);
+        } else if constexpr (is_same_v<T, vector<double>>) {
+          printList(out, true, arg, printDouble);
+        } else if constexpr (is_same_v<T, string>) {
+          out << quoted(arg);
+        } else if constexpr (is_same_v<T, c10::ScalarType>) {
+          out << kScalarTypePrefix << arg;
+        } else if constexpr (is_same_v<T, c10::MemoryFormat>) {
+          out << kMemoryFormatPrefix << arg;
+        } else if constexpr (is_same_v<T, c10::Layout>) {
+          out << kLayoutPrefix << arg;
+        } else if constexpr (is_same_v<T, c10::Device>) {
+          out << kDevicePrefix << "{" << arg << "}";
+        } else if constexpr (is_same_v<T, vector<string>>) {
+          out << fmt::format("[{}]", fmt::join(arg, ","));
+        } else if constexpr (is_same_v<T, unique_ptr<Graph>>) {
+          out << fmt::format("<subgraph>");
+          VLOG(0) << "Subgraph pretty print is not implemented";
+        } else {
+          static_assert(always_false_v<T>, "non-exhaustive visitor!");
+        }
+      },
+      constant);
+  return out;
+}
+
+void printValue(std::ostream& out, const Value* v) {
+  if (!v) {
+    out << "<Constant>";
+    return;
+  }
+  out << *v;
+}
+
+void printNamedArgument(std::ostream& out, const NamedArgument& nv) {
+  out << nv.name << "=" << *nv.value;
+}
+
+void printAttribute(std::ostream& out, const Attribute& nv) {
+  out << nv.name << "=" << nv.value;
+}
+} // namespace
+
+std::ostream& operator<<(std::ostream& out, const Value& v) {
+  out << "%" << v.name();
+  // If a list, distinguish it by adding a []
+  // Looks like %my_list[]
+  if (v.type() == Type::Kind::TensorList) {
+    out << "[]";
+  }
+  return out;
+}
+
+std::ostream& operator<<(std::ostream& out, const Node& node) {
+  // special casing for inputs and outputs
+  if (node.target() == "prim.Input") {
+    out << "graph(";
+    printList(out, false, node.outputs(), printValue);
+    out << "):";
+    return out;
+  }
+  if (node.target() == "prim.Output") {
+    out << "return(";
+    printList(out, false, node.inputs(), [](std::ostream& out, const auto& nv) {
+      out << *nv.value;
+    });
+    out << ")";
+    return out;
+  }
+
+  printList(out, false, node.outputs_, printValue);
+
+  out << " = ";
+  out << node.target_ << "(";
+  printList(out, false, node.inputs_, printNamedArgument);
+  if (!node.inputs_.empty() && !node.attributes_.empty()) {
+    // Emit a connective ',' between inputs and attributes.
+    out << ", ";
+  }
+
+  printList(out, false, node.attributes_, printAttribute);
+  out << ")";
+  return out;
+}
+
+std::ostream& operator<<(std::ostream& out, const Graph& graph) {
+  for (const auto& node : graph.nodes_) {
+    out << node << "\n";
+  }
+  return out;
+}
+
+c10::Device convertDevice(std::string_view symbol) {
+  // Symbol looks like `Device{cuda:1}`
+  const auto typeStart = symbol.find('{') + 1;
+  TORCH_CHECK_LT(typeStart, symbol.size());
+
+  const auto typeEnd = symbol.find(':');
+  TORCH_CHECK_NE(typeEnd, std::string_view::npos);
+
+  const auto type = symbol.substr(typeStart, typeEnd - typeStart);
+  const auto indexStart = typeEnd + 1;
+  TORCH_CHECK_LT(indexStart, symbol.size());
+
+  const auto indexEnd = symbol.find('}');
+  TORCH_CHECK_NE(indexEnd, std::string_view::npos);
+
+  const auto index = symbol.substr(indexStart, indexEnd - indexStart);
+
+  c10::Device device((std::string(type)));
+  auto indexValue = c10::tryToNumber<int64_t>(std::string{index});
+  TORCH_CHECK(indexValue.has_value(), "Invalid device index format");
+  int64_t deviceIndex = indexValue.value();
+  TORCH_CHECK(
+      deviceIndex >= std::numeric_limits<c10::DeviceIndex>::min() &&
+          deviceIndex <= std::numeric_limits<c10::DeviceIndex>::max(),
+      "Device index out of range for int8_t");
+  device.set_index(static_cast<c10::DeviceIndex>(deviceIndex));
+  return device;
+}
+
+Constant convertAtomicConstant(std::string_view symbol) {
+  if (c10::starts_with(symbol, "\"")) {
+    // chop off the outer quotes and return the string
+    TORCH_CHECK_GE(symbol.size(), 2);
+    symbol.remove_prefix(1);
+    symbol.remove_suffix(1);
+    return std::string(symbol);
+  } else if (symbol == "None") {
+    return None();
+  } else if (symbol == "true") {
+    return true;
+  } else if (symbol == "false") {
+    return false;
+  } else if (c10::starts_with(symbol, kMemoryFormatPrefix)) {
+    torch::_export::MemoryFormat value = torch::_export::MemoryFormat::Unknown;
+    symbol.remove_prefix(kMemoryFormatPrefix.length());
+    torch::_export::parseEnum(symbol, value);
+    return convertJsonMemoryFormat(value);
+  } else if (c10::starts_with(symbol, kLayoutPrefix)) {
+    torch::_export::Layout value = torch::_export::Layout::Unknown;
+    symbol.remove_prefix(kLayoutPrefix.length());
+    torch::_export::parseEnum(symbol, value);
+    return convertJsonLayout(value);
+  } else if (c10::starts_with(symbol, kDevicePrefix)) {
+    return convertDevice(symbol);
+  } else if (c10::starts_with(symbol, kScalarTypePrefix)) {
+    torch::_export::ScalarType value = torch::_export::ScalarType::UNKNOWN;
+    symbol.remove_prefix(kScalarTypePrefix.length());
+    torch::_export::parseEnum(symbol, value);
+    return convertJsonScalarType(value);
+  }
+
+  // match number
+  // We need to disambiguate between int and float constants
+  const auto maybeInt = c10::tryToNumber<int64_t>(std::string{symbol});
+
+  // Libraries may happily convert "5.0" to an int 5, but we want that to
+  // become a float. So add an extra check for whether a '.' is in the string
+  // to guard against that.
+  bool hasDecimalSeparator = symbol.find('.') != std::string_view::npos;
+  if (maybeInt.has_value() && !hasDecimalSeparator) {
+    return maybeInt.value();
+  }
+
+  const auto maybeDouble = c10::tryToNumber<double>(std::string{symbol});
+  if (maybeDouble.has_value()) {
+    return maybeDouble.value();
+  }
+
+  TORCH_CHECK(false, "unhandled symbol: ", symbol);
+}
+
+Constant convertListConstant(std::string_view source) {
+  std::vector<Constant> values;
+  size_t curPos = 0;
+  Constant type = None();
+
+  // This basically the same as parseValueList, it's probably better to refactor
+  curPos = expectImpl(source, '[', curPos);
+  while (true) {
+    curPos = consumeWhitespaceImpl(source, curPos);
+
+    size_t start = curPos;
+    while (source.at(curPos) != ',' && source.at(curPos) != ']') {
+      curPos++;
+    }
+    auto symbol = source.substr(start, curPos - start);
+    auto val = convertAtomicConstant(symbol);
+    if (std::holds_alternative<None>(type)) {
+      // First time around; initialize our type sentinel with the first value.
+      // We will use this on subsequent iterations to check that all types are
+      // the same.
+      if (auto intPtr = std::get_if<int64_t>(&val)) {
+        type = *intPtr;
+      } else if (auto doublePtr = std::get_if<double>(&val)) {
+        type = *doublePtr;
+      } else if (auto boolPtr = std::get_if<bool>(&val)) {
+        type = *boolPtr;
+      } else {
+        TORCH_CHECK(false, "constant lists only support int, float, bool");
+      }
+    } else {
+      TORCH_CHECK_EQ(type.index(), val.index())
+          << "lists must have all the same type";
+    }
+    values.push_back(std::move(val));
+    if (source.at(curPos) == ']') {
+      break;
+    }
+    curPos = expectImpl(source, ',', curPos);
+  }
+  expectImpl(source, ']', curPos);
+
+  // Some annoying unwrapping
+  //   std::vector<Constant<T>> -->
+  //   Constant<std::vector<T>>
+  // Do it the dumb way.
+  if (std::holds_alternative<int64_t>(type)) {
+    std::vector<int64_t> inner;
+    inner.reserve(values.size());
+    for (const auto& el : values) {
+      inner.push_back(std::get<int64_t>(el));
+    }
+    return inner;
+  } else if (std::holds_alternative<double>(type)) {
+    std::vector<double> inner;
+    inner.reserve(values.size());
+    for (const auto& el : values) {
+      inner.push_back(std::get<double>(el));
+    }
+    return inner;
+  } else if (std::holds_alternative<bool>(type)) {
+    std::vector<bool> inner;
+    inner.reserve(values.size());
+    for (const auto& el : values) {
+      inner.push_back(std::get<bool>(el));
+    }
+    return inner;
+  }
+  TORCH_CHECK(false, "constant lists only support int, float, bool");
+}
+
+namespace {
+
+/**
+ * Deserialization for graphs: parse the output produced by operator<<(Graph).
+ * This parser really only expects the exact output generated by well-formed
+ * Graph objects, so it is not very permissive and does not give good error
+ * messages.
+ */
+class Parser {
+ public:
+  explicit Parser(std::string_view source)
+      : source_(source), graph_(Graph::createGraph()) {}
+  std::unique_ptr<Graph> parse();
+
+ private:
+  template <typename T>
+  std::vector<T> parseList(
+      char open,
+      char close,
+      const std::function<T()>& parseFn);
+
+  std::string_view parseUntil(
+      const std::function<bool()>& fn,
+      bool includeEnd = false);
+
+  void expect(std::string_view expected);
+  void expect(char expected);
+  bool nextEquals(std::string_view expected) const;
+  bool nextIf(std::string_view expected);
+  bool nextIf(char expected);
+  void consumeWhitespace();
+  bool validIdent(char n);
+  char cur();
+
+  void parseReturn();
+  void parseNode();
+  std::pair<std::string_view, Type> parseOutput();
+  void parseGraphInputs();
+  std::string_view parseString();
+  std::variant<Value*, Constant> parseArgument();
+  std::variant<NamedArgument, Attribute> parseNamedArgument();
+  Value* parseSymbolicArgument();
+  // Symbols look like %v109, with the same valid ident rules as Python
+  // This returns the symbol *without* the % at the front.
+  std::string_view parseAtomicSymbol();
+
+  size_t curPos_ = 0;
+  std::string_view source_;
+  std::unique_ptr<Graph> graph_;
+  torch::_export::GraphSignature signature_;
+};
+
+std::unique_ptr<Graph> Parser::parse() {
+  parseGraphInputs();
+  while (true) {
+    consumeWhitespace();
+    if (nextEquals("return")) {
+      parseReturn();
+      break;
+    }
+    parseNode();
+  }
+  // For graph textual format, it should be safe to assume all
+  // inputs/outputs are from users.
+  graph_->setSignature(torch::nativert::GraphSignature{signature_});
+  graph_->finalize();
+  graph_->lint();
+  // TODO: Might have some source left over, should check it if so.
+  return std::move(graph_);
+}
+
+bool Parser::nextIf(std::string_view expected) {
+  if (nextEquals(expected)) {
+    curPos_ += expected.size();
+    return true;
+  }
+  return false;
+}
+
+bool Parser::nextIf(char expected) {
+  if (cur() == expected) {
+    curPos_++;
+    return true;
+  }
+  return false;
+}
+
+void Parser::parseGraphInputs() {
+  TORCH_CHECK_EQ(curPos_, 0);
+  expect("graph");
+  const auto inputs = parseList<std::string_view>(
+      '(', ')', [&]() { return parseAtomicSymbol(); });
+  std::vector<torch::_export::InputSpec> inputSpecs;
+  inputSpecs.reserve(inputs.size());
+  for (const auto& input : inputs) {
+    graph_->addInput(input, Type::Kind::Tensor);
+
+    torch::_export::TensorArgument inputTensorArg;
+    inputTensorArg.set_name(std::string{input});
+    torch::_export::Argument inputArg;
+    inputArg.set_as_tensor(std::move(inputTensorArg));
+    torch::_export::UserInputSpec userInput;
+    userInput.set_arg(std::move(inputArg));
+    torch::_export::InputSpec inputSpec;
+    inputSpec.set_user_input(std::move(userInput));
+    inputSpecs.push_back(std::move(inputSpec));
+  }
+  signature_.set_input_specs(std::move(inputSpecs));
+  // TODO populate graphinputs
+  expect(":");
+}
+
+template <typename T>
+std::vector<T> Parser::parseList(
+    char open,
+    char close,
+    const std::function<T()>& parseFn) {
+  std::vector<T> ret;
+  expect(open);
+
+  // Handle empty list
+  if (nextIf(close)) {
+    return ret;
+  }
+  while (true) {
+    ret.push_back(parseFn());
+    if (cur() == close) {
+      break;
+    }
+    expect(',');
+  }
+  expect(close);
+  return ret;
+}
+
+// Parse until `fn` returns true, returning the segment of the source that was
+// consumed. If `includeEnd` is true, the returned segment will also include
+// final character, which caused `fn` to return true.
+std::string_view Parser::parseUntil(
+    const std::function<bool()>& fn,
+    bool includeEnd) {
+  size_t start = curPos_;
+  while (!fn()) {
+    curPos_++;
+  }
+  if (includeEnd) {
+    curPos_++;
+  }
+  return source_.substr(start, curPos_ - start);
+}
+
+// Parse a strng, including the outer quotes
+std::string_view Parser::parseString() {
+  size_t start = curPos_;
+  expect('"');
+  while (cur() != '"') {
+    // Handle escaped characters by skipping the next char when we see a
+    // backslash
+    if (cur() == '\\') {
+      curPos_++;
+    }
+    curPos_++;
+  }
+
+  // Consume final quote
+  curPos_++;
+  auto ret = source_.substr(start, curPos_ - start);
+  return ret;
+}
+
+bool Parser::validIdent(char n) {
+  return std::isalpha(n) || n == '_' || std::isdigit(n);
+}
+
+// Symbols look like %v109, with the same valid ident rules as Python
+// This returns the symbol *without* the % at the front.
+std::string_view Parser::parseAtomicSymbol() {
+  expect("%");
+  return parseUntil([&]() { return !validIdent(cur()); });
+}
+
+char Parser::cur() {
+  return source_.at(curPos_);
+}
+
+void Parser::consumeWhitespace() {
+  while (isBlank(cur())) {
+    curPos_++;
+  }
+}
+
+void Parser::expect(std::string_view expected) {
+  curPos_ = expectImpl(source_, expected, curPos_);
+}
+
+void Parser::expect(char expected) {
+  curPos_ = expectImpl(source_, expected, curPos_);
+}
+
+bool Parser::nextEquals(std::string_view expected) const {
+  const auto actual = source_.substr(curPos_, expected.size());
+  return expected == actual;
+}
+
+// %a, %b = aten.foo.default(input=%foo, foo=[7616], blah=%lol)
+void Parser::parseNode() {
+  std::vector<std::pair<std::string_view, Type>> outputs;
+
+  outputs.push_back(parseOutput());
+  while (nextIf(",")) {
+    outputs.push_back(parseOutput());
+  }
+  expect("=");
+  consumeWhitespace();
+
+  // parse target name
+  const auto target = parseUntil([&]() { return cur() == '('; });
+
+  Node* node = graph_->insertNode(std::string(target));
+  for (auto& [name, var] : outputs) {
+    node->addOutput(name, var);
+  }
+
+  auto arguments = parseList<std::variant<NamedArgument, Attribute>>(
+      '(', ')', [&]() { return parseNamedArgument(); });
+
+  // Split the arguments into symbolic inputs and constant attributes
+  for (auto& arg : arguments) {
+    if (std::holds_alternative<NamedArgument>(arg)) {
+      node->addInput(std::get<NamedArgument>(arg));
+    } else {
+      node->addAttribute(std::get<Attribute>(std::move(arg)));
+    }
+  }
+}
+
+void Parser::parseReturn() {
+  expect("return");
+  const auto returns =
+      parseList<Value*>('(', ')', [&]() { return parseSymbolicArgument(); });
+  std::vector<torch::_export::OutputSpec> outputSpecs;
+  outputSpecs.reserve(returns.size());
+  for (const auto ret : returns) {
+    graph_->addOutput(ret);
+
+    torch::_export::TensorArgument retTensorArg;
+    retTensorArg.set_name(std::string{ret->name()});
+    torch::_export::Argument retArg;
+    retArg.set_as_tensor(std::move(retTensorArg));
+    torch::_export::UserOutputSpec userOutput;
+    userOutput.set_arg(std::move(retArg));
+    torch::_export::OutputSpec outputSpec;
+    outputSpec.set_user_output(std::move(userOutput));
+    outputSpecs.push_back(std::move(outputSpec));
+  }
+  signature_.set_output_specs(std::move(outputSpecs));
+}
+
+std::variant<NamedArgument, Attribute> Parser::parseNamedArgument() {
+  consumeWhitespace();
+  // Parse name
+  const auto symbol = parseUntil([&]() { return cur() == '='; });
+  expect('=');
+
+  // Parse value
+  auto value = parseArgument();
+  if (std::holds_alternative<Value*>(value)) {
+    return NamedArgument{std::string(symbol), std::get<Value*>(value)};
+  } else {
+    return Attribute{std::string(symbol), std::get<Constant>(std::move(value))};
+  }
+}
+
+std::pair<std::string_view, Type> Parser::parseOutput() {
+  consumeWhitespace();
+  TORCH_CHECK(cur() == '%', fmt::format("expected % but got {}", cur()));
+
+  auto symbol = parseAtomicSymbol();
+  if (nextIf('[')) {
+    expect(']');
+    return {symbol, Type::Kind::TensorList};
+  } else {
+    return {symbol, Type::Kind::Tensor};
+  }
+}
+
+Value* Parser::parseSymbolicArgument() {
+  consumeWhitespace();
+  TORCH_CHECK(cur() == '%', fmt::format("expected % but got {}", cur()));
+
+  auto symbol = parseAtomicSymbol();
+  std::vector<Value*> listElements;
+  if (cur() == '[') {
+    listElements = parseList<Value*>(
+        '[', ']', [&]() { return graph_->getValue(parseAtomicSymbol()); });
+  }
+  return graph_->getValue(symbol);
+}
+
+std::variant<Value*, Constant> Parser::parseArgument() {
+  consumeWhitespace();
+
+  // match symbol
+  if (cur() == '%') {
+    return parseSymbolicArgument();
+  }
+
+  // match list
+  if (cur() == '[') {
+    const auto symbol =
+        parseUntil([&]() { return cur() == ']'; }, /*includeEnd=*/true);
+    return convertListConstant(symbol);
+  }
+
+  // match string
+  if (cur() == '"') {
+    return convertAtomicConstant(parseString());
+  }
+
+  // otherwise parse this as a value
+  const auto symbol =
+      parseUntil([&]() { return cur() == ',' || cur() == ')'; });
+  return convertAtomicConstant(symbol);
+}
+
+} // namespace
+
+std::unique_ptr<Graph> stringToGraph(std::string_view source) {
+  return Parser(source).parse();
+}
+
+std::string graphToString(const Graph& g, bool include_signature) {
+  std::stringstream ss;
+  ss << g;
+
+  if (include_signature) {
+    ss << "\nGraphSignature\n";
+    ss << g.signature();
+  }
+
+  return ss.str();
+}
+
+} // namespace torch::nativert

--- a/torch/nativert/graph/Graph.h
+++ b/torch/nativert/graph/Graph.h
@@ -1,0 +1,717 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+#include <ATen/core/ivalue.h>
+#include <c10/util/IntrusiveList.h>
+#include <c10/util/Logging.h>
+
+#include <torch/csrc/utils/generated_serialization_types.h>
+#include <torch/nativert/executor/Placement.h>
+#include <torch/nativert/graph/GraphSignature.h>
+#include <torch/nativert/graph/TensorMeta.h>
+
+namespace torch::nativert {
+
+using NodeIndex = size_t;
+
+class Value;
+
+class Type {
+ public:
+  enum class Kind {
+    None,
+    Tensor,
+    TensorList,
+    OptionalTensorList,
+    SymInt,
+    SymIntList,
+    SymBool,
+    SymFloat,
+    CustomObj,
+  };
+
+  // For simple kinds without classFqn
+  /*implicit*/ Type(Kind kind) : kind_(kind) {}
+
+  // For CustomObj kind with classFqn
+  explicit Type(Kind kind, const std::string& classFqn)
+      : kind_(CustomObjData{classFqn}) {
+    TORCH_CHECK(kind == Kind::CustomObj);
+    TORCH_CHECK(!classFqn.empty());
+  }
+
+  Kind kind() const {
+    if (std::holds_alternative<CustomObjData>(kind_)) {
+      return Kind::CustomObj;
+    }
+    return std::get<Kind>(kind_);
+  }
+
+  friend std::ostream& operator<<(std::ostream& out, const Type& ty);
+  friend bool operator==(const Type& left, const Type& right);
+
+  std::string classFqn() const {
+    TORCH_CHECK(
+        kind() == Kind::CustomObj, "Only CustomObj type can have classFqn");
+    return std::get<CustomObjData>(kind_).classFqn;
+  }
+
+ private:
+  struct CustomObjData {
+    std::string classFqn;
+  };
+  std::variant<Kind, CustomObjData> kind_;
+};
+
+// These are all the constant types that are allowed as attributes on Nodes.
+struct None {};
+// None always equals itself
+inline bool operator==(const None&, const None&) {
+  return true;
+}
+
+class Graph;
+
+/**
+ * We distinguish between a symbolic value (Tensor, TensorList, SymInt, SymInts,
+ * etc) and a constant value (int, bool, string, etc). Here Constant is the type
+ * for all possible constant values. Along with a name, they are represented as
+ * Attributes on a Node.
+ */
+using Constant = std::variant<
+    None,
+    int64_t,
+    std::vector<int64_t>,
+    double,
+    std::vector<double>,
+    std::string,
+    c10::ScalarType,
+    c10::MemoryFormat,
+    c10::Layout,
+    c10::Device,
+    bool,
+    std::vector<bool>,
+    std::vector<std::string>,
+    std::unique_ptr<Graph>>;
+
+c10::IValue constantToIValue(const Constant& constant);
+
+class Node;
+
+/**
+ * Represents a single symbolic value (tensor/symint/list of them). Values are
+ * inputs and outputs of Nodes.
+ */
+using ValueId = int;
+class Value {
+ public:
+  explicit Value(ValueId id, std::string name, Type t, Node* producer)
+      : name_(std::move(name)), id_(id), type_(t), producer_(producer) {
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(name_ == this->name());
+  }
+
+  // Each Value should be uniquely created and managed by a Graph. It's not
+  // allowed to copy/move Value instances.
+  Value(Value&&) = delete;
+  Value& operator=(Value&&) = delete;
+  Value(const Value&) = delete;
+  Value& operator=(Value&) = delete;
+
+  Type type() const {
+    return type_;
+  }
+
+  ValueId id() const {
+    return id_;
+  }
+
+  std::string_view name() const {
+    return name_;
+  }
+
+  const Node* producer(bool resolve_folded = false) const {
+    return (!resolve_folded && isFolded()) ? nullptr : producer_;
+  }
+
+  Node* producer() {
+    return producer_;
+  }
+
+  void addUser(Node* node);
+  void eraseUser(Node* node);
+  void eraseAllUsers() {
+    users_.clear();
+  }
+
+  // Throws an exception if the value is not a TensorList
+  std::vector<const Value*> getListElements() const;
+
+  const auto& users() const {
+    return users_;
+  }
+
+  auto& users() {
+    return users_;
+  }
+
+  void setId(ValueId newId) {
+    // This should only be used inside the renumberValues pass
+    id_ = newId;
+  }
+
+  void setIsFolded() {
+    isFolded_ = true;
+  }
+
+  bool isFolded() const {
+    return isFolded_;
+  }
+
+ private:
+  friend std::ostream& operator<<(std::ostream& out, const Value& v);
+  std::string name_;
+  bool isFolded_{false};
+  ValueId id_;
+  Type type_;
+  Node* producer_;
+  // All nodes which have this value as input.
+  // Note that this is a vector to avoid nondeterminism in iteration, but
+  // probably should be an unordered set given usage patterns. If this becomes a
+  // perf problem we should revise.
+  std::vector<Node*> users_;
+};
+
+struct NamedArgument {
+  std::string name;
+  Value* value;
+};
+
+struct Attribute {
+  std::string name;
+  Constant value;
+};
+
+/**
+ * Node represents a single unit of execution, typically a PyTorch operator.
+ * Using an intrusive list allows us to allocate all the memory at once for a
+ * node. This also allows us to track nodes safely without passing around the
+ * list object, as an intrusive list maintains a stronger invariant that
+ * expiration will always cause unlinking.
+ */
+class Node : public c10::IntrusiveListHook {
+ public:
+  Node(
+      Graph* owningGraph,
+      std::string target,
+      std::vector<NamedArgument> inputs,
+      std::unordered_map<std::string, std::string> metadata);
+
+  std::string_view target() const {
+    return target_;
+  }
+
+  void setTarget(std::string_view target) {
+    target_ = target;
+  }
+
+  const auto& inputs() const {
+    return inputs_;
+  }
+
+  auto& inputs() {
+    return inputs_;
+  }
+
+  // NOTE: this invalidates spans given out by inputs()
+  Value* addInput(NamedArgument input);
+  void addInputs(const std::vector<NamedArgument>& inputs);
+
+  // NOTE: this invalidates spans given out by attributes()
+  void addAttribute(Attribute attr);
+
+  // NOTE: this is ONLY for graph's constant inputs and NOT the common case
+  void addOutput();
+
+  Value* addOutput(const Type& type);
+
+  // NOTE: this invalidates spans given out by outputs()
+  Value* addOutput(std::string_view name, const Type& type);
+
+  size_t numInputs() const {
+    return inputs_.size();
+  }
+
+  size_t numOutputs() const {
+    return outputs_.size();
+  }
+
+  // Return the next node in the Graph's node ordering.
+  // NOTE: Calling next on the last node (prim.Output) returns nullptr.
+  Node* next();
+  const Node* next() const;
+
+  // Return the previous node in the Graph's node ordering.
+  // NOTE: Calling prev on the first node (prim.Input) returns nullptr.
+  Node* prev();
+  const Node* prev() const;
+
+  bool isBefore(const Node* n) const;
+
+  std::vector<Node*> producers() const;
+  std::vector<Node*> users() const;
+
+  // Returns nullptr if `name` is not an input
+  const NamedArgument* tryGetInput(std::string_view name) const;
+  // Throws an exception if `name` is not an input
+  const NamedArgument& getInput(std::string_view name) const;
+
+  const auto& attributes() const {
+    return attributes_;
+  }
+
+  // Returns nullptr if `name` is not an attribute
+  const Attribute* tryGetAttribute(std::string_view name) const;
+  // Throws an exception if `name` is not an attribute
+  const Attribute& getAttribute(std::string_view name) const;
+
+  const auto& outputs() const {
+    return outputs_;
+  }
+
+  void applyDevicePlacement(const Placement& placement);
+
+  std::optional<std::string_view> getMetadata(std::string_view key) const {
+    return metadata_.find(std::string{key}) != metadata_.end()
+        ? std::optional(std::string_view{metadata_.at(std::string{key})})
+        : std::nullopt;
+  }
+
+  Graph* owningGraph() {
+    return owningGraph_;
+  }
+
+  const Graph* owningGraph() const {
+    return owningGraph_;
+  }
+
+  void destroy();
+
+  const std::unordered_map<std::string, std::string>& metadata() const {
+    return metadata_;
+  }
+
+  std::string toString() const {
+    std::stringstream ss;
+    ss << *this;
+    return ss.str();
+  }
+
+  void updateInputName(std::string_view oldName, std::string_view newName) {
+    for (auto& input : inputs_) {
+      if (input.name == oldName) {
+        input.name = newName;
+        break;
+      }
+    }
+  }
+
+  void updateAttributeName(std::string_view oldName, std::string_view newName) {
+    for (auto& attr : attributes_) {
+      if (attr.name == oldName) {
+        attr.name = newName;
+        break;
+      }
+    }
+  }
+
+ private:
+  friend std::ostream& operator<<(std::ostream& out, const Node& n);
+  Graph* owningGraph_;
+
+  // Target used to retrieve the actual thing to execute.
+  // If an aten operator, we expect this to be fully qualified, including an
+  // overload name, e.g. "aten.unsqueeze.default"
+  std::string target_;
+  // *Symbolic* inputs to this node. NOTE: this does not match the ATen operator
+  // schema inputs directly. It only represents things that actually participate
+  // in dataflow, like tensors/symints and lists thereof.
+  //
+  // The "name" of the NamedArgument refers to the name of the parameter.
+  std::vector<NamedArgument> inputs_;
+  // Constant inputs to the node. The "name" of the Attribute refers to the
+  // name of the parameter.
+  std::vector<Attribute> attributes_;
+  std::vector<Value*> outputs_;
+
+  // Extra bits of info added to the node. Contents that are guaranteed will be
+  // eventually moved to a first-class field on the json struct of schema.
+  std::unordered_map<std::string, std::string> metadata_;
+};
+
+/**
+ * Graph represents a model's computation graph, which is designed to
+ * facilitate transformation and analysis.
+ *
+ * Ownership semantics:
+ *  - Graph owns Nodes and Values
+ *  - Nodes own their constant attributes (which we treat as value types)
+ *  - Nodes have non-owning pointers back to the graph.
+ *
+ * NOTE: this class is marked noncopyable/nonmovable and only can be
+ * heap-allocated via `createGraph()`. This is to ensure stability of
+ * back-pointers held by Nodes/Values.
+ */
+class Graph {
+ public:
+  static std::unique_ptr<Graph> createGraph() {
+    return std::unique_ptr<Graph>(new Graph());
+  }
+
+  Graph(const Graph&) = delete;
+  Graph& operator=(const Graph&) = delete;
+  Graph(Graph&&) = delete;
+  Graph& operator=(Graph&&) = delete;
+  ~Graph() = default;
+
+  // NOTE: this invalidates spans given out by inputs()
+  Value* addInput(std::string_view name, const Type& type);
+
+  // NOTE: this is ONLY for graph's constant inputs and NOT the common case
+  void addInput();
+
+  // NOTE: this invalidates spans given out by outputs()
+  Value* addOutput(Value* v);
+
+  void addConstantOutput(Constant c);
+
+  // Create and insert a node at insertionPoint_
+  Node* insertNode(
+      std::string target,
+      std::vector<NamedArgument> inputs = {},
+      std::unordered_map<std::string, std::string> metadata = {});
+
+  // Returns the inserted node.
+  Node* insertBefore(Node* toInsert, Node* insertionPoint);
+  // Returns the inserted node.
+  Node* insertAfter(Node* toInsert, Node* insertionPoint);
+  // Insert at the insertionPoint. Returns the inserted node.
+  Node* insert(Node* toInsert);
+
+  // Create a node without inserting it into the execution graph.
+  // A raw pointer to the node is created when `createNode()` on the
+  // owner Graph object is called. It is guranateed that to be valid
+  // until the Graph object is destructed.
+  Node* createNode(
+      std::string target,
+      std::vector<NamedArgument> inputs = {},
+      std::unordered_map<std::string, std::string> metadata = {});
+
+  Value* createConstantSymIntValue(int value);
+
+  Node* createListPack(std::vector<Value*> inputs, const Type& inputType);
+
+  Node* createOptionalListPack(std::vector<Value*> inputs);
+
+  size_t numValues() const {
+    return values_.size();
+  }
+
+  // throws on missing name
+  Value* getValue(std::string_view name) const;
+  // returns nullptr on missing name
+  Value* tryGetValue(std::string_view name) const;
+
+  const std::unordered_map<ValueId, int> getConstantSymIntValues() const {
+    return constantSymIntValues_;
+  }
+
+  Value* addValue(
+      const std::optional<std::string>& name,
+      const Type& type,
+      Node* producer);
+  void removeValue(Value* value);
+
+  void replaceAllUses(Value* old, Value* replacement);
+  void replaceAllUsesAfterNode(Value* old, Value* replacement, Node* afterThis);
+  void removeNode(Node* node);
+
+  void applyDevicePlacement(const Placement& placement);
+
+  std::string getUniqueValueName();
+
+  ValueId getNextValueId() {
+    return uniqueValueId_++;
+  }
+
+  // NOTE: this range can be invalidated by mutations to the graph.
+  const auto& inputs() const {
+    return inputNode_->outputs();
+  }
+
+  c10::ArrayRef<const Value*> userInputs() const {
+    size_t offset = signature().inputsToWeights().size() +
+        signature().inputsToCustomObjs().size();
+    return {inputs().data() + offset, inputs().data() + inputs().size()};
+  }
+
+  c10::ArrayRef<const Value*> weightValues() const {
+    return {
+        inputs().data(),
+        inputs().data() + signature().inputsToWeights().size()};
+  }
+
+  // Return a bidirectional range over `const Value*`
+  // NOTE: this range can be invalidated by mutations to the graph.
+  auto outputs() const {
+    std::vector<const Value*> ret;
+    ret.reserve(outputNode_->inputs().size());
+    for (const auto& namedArg : outputNode_->inputs()) {
+      ret.push_back(namedArg.value);
+    }
+    return ret;
+  }
+
+  // Return a bidirectional range over `Value*`
+  // NOTE: this range can be invalidated by mutations to the graph.
+  auto outputs() {
+    std::vector<Value*> ret;
+    ret.reserve(outputNode_->inputs().size());
+    for (const auto& namedArg : outputNode_->inputs()) {
+      ret.push_back(namedArg.value);
+    }
+    return ret;
+  }
+
+  const auto& userOutputs() const {
+    return userOutputs_;
+  }
+
+  // Return a list over `const Node&`.
+  // NOTE: this can be invalidated by mutations to the graph.
+  const auto& nodes() const {
+    return nodes_;
+  }
+
+  auto& nodes() {
+    return nodes_;
+  }
+
+  // Return a forward range over `const Value*`.
+  // NOTE: this range can be invalidated by mutations to the graph.
+  auto values() const {
+    std::vector<const Value*> ret;
+    ret.reserve(values_.size());
+    for (const auto& [_, value] : values_) {
+      ret.push_back(value.get());
+    }
+    return ret;
+  }
+
+  Node* inputNode() {
+    return inputNode_;
+  }
+
+  Node* outputNode() {
+    return outputNode_;
+  }
+
+  const Node* outputNode() const {
+    return outputNode_;
+  }
+
+  // Assert various graph invariants
+  void lint() const;
+
+  bool /* removed > 0? */ cleanupDeadNodes();
+
+  void finalize();
+
+  Node* insertionPoint() {
+    // This should never happen, since the last-most insertion point is the
+    // prim.Outputs node, not end().
+    TORCH_CHECK(insertBefore_ != nodes_.end());
+    auto& node = *insertBefore_;
+    return &node;
+  }
+
+  void setInsertionPoint(Node* n) {
+    TORCH_CHECK(n != inputNode_, "can't insert before prim.Input");
+    insertBefore_ = nodes_.iterator_to(*n);
+  }
+
+  void setInsertionPointAfter(Node* n) {
+    TORCH_CHECK(n != outputNode_, "can't insert after prim.Output");
+    auto it = nodes_.iterator_to(*n);
+    ++it;
+    insertBefore_ = it;
+  }
+
+  // Return the next node in the Graph's node ordering.
+  // NOTE: Calling on the last node (prim.Output) returns nullptr.
+  Node* nodeAfter(Node* n);
+  const Node* nodeAfter(const Node* n) const;
+
+  // Return the previous node in the Graph's node ordering.
+  // NOTE: Calling on the first node (prim.Input) returns nullptr.
+  Node* nodeBefore(Node* n);
+  const Node* nodeBefore(const Node* n) const;
+
+  // Clone each node from subgraph (except prim.Input/prim.Output) into current
+  // graph.
+  // @param subgraph: the subgraph to be cloned
+  // @param inputs: values from the target graph that will serve as the
+  // subgraph's inputs
+  // @param valueMap: a map from the cloned subgraph's values to the target
+  // graph's values
+  std::vector<Value*> insertGraph(
+      const Graph& subgraph,
+      std::vector<Value*> inputs,
+      std::unordered_map<const Value*, Value*>& valueMap);
+
+  const GraphSignature& signature() const {
+    return signature_;
+  }
+
+  void setSignature(GraphSignature signature) {
+    signature_ = std::move(signature);
+  }
+
+  void setWeightsMeta(
+      const std::unordered_map<std::string, torch::_export::TensorMeta>&
+          tensorsMeta) {
+    for (auto [name, tensorMeta] : tensorsMeta) {
+      weightsMeta_.emplace(name, TensorMeta{tensorMeta});
+    }
+  }
+
+  const std::unordered_map<std::string, TensorMeta>& weightsMeta() const {
+    return weightsMeta_;
+  }
+
+  std::vector<TensorMeta> userInputsMeta() const {
+    std::vector<TensorMeta> userInputsMeta;
+    userInputsMeta.reserve(signature_.userInputs().size());
+    for (auto inputName : signature_.userInputs()) {
+      userInputsMeta.push_back(tensorValuesMeta_.at(inputName));
+    }
+    return userInputsMeta;
+  }
+
+  void setTensorValuesMeta(
+      const std::unordered_map<std::string, torch::_export::TensorMeta>&
+          tensorsMeta) {
+    for (auto [name, tensorMeta] : tensorsMeta) {
+      tensorValuesMeta_.emplace(name, TensorMeta{tensorMeta});
+    }
+  }
+
+  const std::unordered_map<std::string, TensorMeta>& tensorValuesMeta() const {
+    return tensorValuesMeta_;
+  }
+
+  std::string toString() const {
+    std::stringstream ss;
+    ss << *this;
+    return ss.str();
+  }
+
+  /* Reassigns IDs to every Value in this Graph so that they are contiguous from
+   * 0..(numValues()-1). Should be used after values are removed
+   */
+  void renumberValues();
+
+ private:
+  Graph();
+  friend std::ostream& operator<<(std::ostream& out, const Graph& g);
+  GraphSignature signature_;
+
+  // keys are parameters, buffers, tensor_constants' names
+  std::unordered_map<std::string, TensorMeta> weightsMeta_;
+
+  // keys are tensor_values' names
+  std::unordered_map<std::string, TensorMeta> tensorValuesMeta_;
+
+  // Node lifetime is managed by nodesOwner_, but the actual ordering is
+  // maintained intrusively using nodes_.
+  // This is to facilitate quick insertion before/after a given Node*.
+  std::vector<std::unique_ptr<Node>> nodesOwner_;
+  c10::IntrusiveList<Node> nodes_;
+  // The current insertion point. New nodes are inserted before this node.
+  // Defaults to prim.Output.
+  c10::IntrusiveList<Node>::iterator insertBefore_;
+
+  // Graphs always start with an input and output node.
+  // "prim.input() -> Value[]" take no input, and produces some outputs. AKA
+  // "source“ of a graph.
+  Node* inputNode_; // target: prim.Input
+  // "prim.output(Value[]) -> None", take some inputs, but produce no output.
+  // AKA "sink" of a graph.
+  Node* outputNode_; // target: prim.Output
+
+  std::unordered_map<std::string, std::unique_ptr<Value>> values_;
+  // constantSymIntValues_ is a subset of values_
+  std::unordered_map<ValueId, int> constantSymIntValues_;
+  // Output values of the graph, which is a subset of values_.
+  std::vector<std::variant<Value*, Constant>> userOutputs_;
+  // Output constant values of the graph
+  std::vector<Constant> constantOutputs_;
+
+  size_t uniqueValueName_ = 0;
+
+  ValueId uniqueValueId_ = 0;
+};
+
+/**
+ * Scoped utility class for setting temporary insertion points.
+ *
+ * Use like:
+ *   {
+ *       InsertingAfter guard(node)
+ *       graph.insertNode(...)  // this will be inserted after `node`.
+ *   }
+ */
+class InsertingAfter {
+ public:
+  explicit InsertingAfter(Node* n)
+      : insertAfter_(n), prev_(n->owningGraph()->insertionPoint()) {
+    insertAfter_->owningGraph()->setInsertionPointAfter(insertAfter_);
+  }
+  ~InsertingAfter() {
+    insertAfter_->owningGraph()->setInsertionPoint(prev_);
+  }
+
+ private:
+  Node* insertAfter_;
+  Node* prev_;
+};
+
+inline constexpr std::string_view kMemoryFormatPrefix = "MemoryFormat::";
+inline constexpr std::string_view kLayoutPrefix = "Layout::";
+inline constexpr std::string_view kDevicePrefix = "Device";
+inline constexpr std::string_view kScalarTypePrefix = "ScalarType::";
+
+/**
+ * Debug format serialization. The format here is intended to be human readable
+ * and easy to work with, and is intended for debugging and testing only.
+ * If you want stable serialization, use the json conversion utils.
+ *
+ * NOTE: node metadata currently not serialized
+ */
+std::string graphToString(const Graph& g, bool include_signature = false);
+std::unique_ptr<Graph> stringToGraph(std::string_view source);
+
+// Standalone functions to parse common constructs
+// Parse something that looks like `Device{cuda:1}` to a device in json format.
+c10::Device convertDevice(std::string_view symbol);
+// We have separate functions for parsing atomic and list constants because
+// there are restrictive rules about which constants can go in lists (i.e.
+// it's not recursive).
+Constant convertAtomicConstant(std::string_view symbol);
+Constant convertListConstant(std::string_view symbol);
+
+} // namespace torch::nativert


### PR DESCRIPTION
Summary: 
Torch Native Runtime RFC: https://github.com/pytorch/rfcs/pull/72

4 classes have been introduced: `Graph`, `Node`, `Value`, `Type`
- `Type` represents the kind of a `Value`
- `Value` represents a single symbolic value, it could be any kind that exists in `Type`. Values are inputs and outputs of a `Node`. 
- `Node` represents a single unit of execution, typically a PyTorch op. 
- `Graph` represents a model's computation graph, which is designed to facilitate transformation/analysis. 

Test Plan: Added test under `test/cpp/nativert/test_graph.cpp`

Differential Revision: D74749418
