### PR TITLE
[aot] fix deepcopying of aot bwd containing real tensors

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -7234,6 +7234,27 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
         output = capturedOutput.getvalue()
         self.assertNotIn("class GraphModule", output)
 
+    def test_deepcopy_constant_tensor_in_aot_bwd(self):
+        class Fn(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                return x + 1
+
+            @staticmethod
+            def backward(ctx, grad_out):
+                return grad_out * torch.tensor(2) * grad_out.shape[0]
+
+
+        def f(x):
+            return Fn.apply(x)
+
+        x = torch.randn(8, requires_grad=True)
+        out = f(x)  # should not raise
+        c_out = torch.compile(f, backend="aot_eager", dynamic=True)(x)
+        expected = torch.autograd.grad(out.sum(), inputs=(x,))
+        actual = torch.autograd.grad(c_out.sum(), inputs=(x,))
+        self.assertEqual(expected, actual)
+
 
 instantiate_parametrized_tests(ReproTests)
 

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -7244,7 +7244,6 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
             def backward(ctx, grad_out):
                 return grad_out * torch.tensor(2) * grad_out.shape[0]
 
-
         def f(x):
             return Fn.apply(x)
 

--- a/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
@@ -1217,6 +1217,9 @@ def aot_dispatch_autograd(
                 try:
                     # See Note: [Backward graph lazy lowering]
                     with torch._subclasses.fake_tensor.unset_fake_temporarily():
+                        # If bw_module contains lifted constants, they will be real tensors stored as
+                        # GraphModule. Deepcopying tensors under fake mode is not supported and will
+                        # raise when attempting to set storage.
                         bw_module_copy = copy.deepcopy(bw_module)
                     compiled_bw_func = aot_config.bw_compiler(
                         bw_module_copy, placeholder_list

--- a/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
@@ -1216,9 +1216,12 @@ def aot_dispatch_autograd(
             if num_symints_saved_for_bw > 0:
                 try:
                     # See Note: [Backward graph lazy lowering]
-                    compiled_bw_func = aot_config.bw_compiler(
-                        copy.deepcopy(bw_module), placeholder_list
-                    )
+                    with torch._subclasses.fake_tensor.unset_fake_temporarily():
+                        bw_module_copy = copy.deepcopy(bw_module)
+                        compiled_bw_func = aot_config.bw_compiler(
+                            bw_module_copy, placeholder_list
+                        )
+                        del bw_module_copy
                 except Exception as e:
                     exc = e
                     trace_structured(

--- a/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
@@ -1218,10 +1218,10 @@ def aot_dispatch_autograd(
                     # See Note: [Backward graph lazy lowering]
                     with torch._subclasses.fake_tensor.unset_fake_temporarily():
                         bw_module_copy = copy.deepcopy(bw_module)
-                        compiled_bw_func = aot_config.bw_compiler(
-                            bw_module_copy, placeholder_list
-                        )
-                        del bw_module_copy
+                    compiled_bw_func = aot_config.bw_compiler(
+                        bw_module_copy, placeholder_list
+                    )
+                    del bw_module_copy
                 except Exception as e:
                     exc = e
                     trace_structured(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #153999

Previously when we lower backward AOT due to symints, the post grad passes would leave the bw_module in a non-runnable state. This caused issues when compiled autograd tried to trace at runtime. So we had inductor operate on a deepcopy of bw_module. 

But with https://github.com/pytorch/pytorch/issues/153993, we see that deepcopying real tensors will fail under fake mode due to the device type mismatch between the fake tensors ("meta" device) and the real tensor. So by disabling fake mode, we avoid these errors. This change is a strict improvement over current, but it does reveal that this deepcopy can theoretically cause OOMs.

FIXES https://github.com/pytorch/pytorch/issues/153993

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames