### PR TITLE
[MPS] Add support for two more isin variants

### DIFF
--- a/aten/src/ATen/native/mps/operations/TensorCompare.mm
+++ b/aten/src/ATen/native/mps/operations/TensorCompare.mm
@@ -283,7 +283,6 @@ static void isin_Tensor_Tensor_out_mps(const Tensor& elements,
   if (elements.numel() == 0) {
     return;
   }
-  at::native::resize_output(out, elements.sizes());
 
   if (test_elements.numel() == 0) {
     if (invert) {
@@ -397,6 +396,7 @@ TORCH_IMPL_FUNC(isin_Tensor_Tensor_out_mps)
 }
 TORCH_IMPL_FUNC(isin_Scalar_Tensor_out_mps)
 (const Scalar& elements, const Tensor& test_elements, bool assume_unique, bool invert, const Tensor& out) {
+  at::native::resize_output(out, {});
   mps::isin_Tensor_Tensor_out_mps(
       mps::wrapped_scalar_tensor_mps(elements, kMPS), test_elements, assume_unique, invert, out, __func__);
 }

--- a/aten/src/ATen/native/mps/operations/TensorCompare.mm
+++ b/aten/src/ATen/native/mps/operations/TensorCompare.mm
@@ -1,6 +1,7 @@
 //  Copyright © 2022 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/Dispatch.h>
+#include <ATen/ScalarOps.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/TensorCompare.h>
 #include <ATen/native/mps/OperationUtils.h>
@@ -282,6 +283,7 @@ static void isin_Tensor_Tensor_out_mps(const Tensor& elements,
   if (elements.numel() == 0) {
     return;
   }
+  at::native::resize_output(out, elements.sizes());
 
   if (test_elements.numel() == 0) {
     if (invert) {
@@ -392,6 +394,11 @@ TORCH_IMPL_FUNC(clamp_max_out_mps)
 TORCH_IMPL_FUNC(isin_Tensor_Tensor_out_mps)
 (const Tensor& elements, const Tensor& test_elements, bool assume_unique, bool invert, const Tensor& out) {
   mps::isin_Tensor_Tensor_out_mps(elements, test_elements, assume_unique, invert, out, __func__);
+}
+TORCH_IMPL_FUNC(isin_Scalar_Tensor_out_mps)
+(const Scalar& elements, const Tensor& test_elements, bool assume_unique, bool invert, const Tensor& out) {
+  mps::isin_Tensor_Tensor_out_mps(
+      mps::wrapped_scalar_tensor_mps(elements, kMPS), test_elements, assume_unique, invert, out, __func__);
 }
 
 static void where_kernel_mps(TensorIterator& iter) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3190,7 +3190,8 @@
   variants: function
   structured: True
   dispatch:
-    CPU, CUDA, MPS: isin_Scalar_Tensor_out
+    CPU, CUDA: isin_Scalar_Tensor_out
+    MPS: isin_Scalar_Tensor_out_mps
 
 - func: isin.Scalar_Tensor(Scalar element, Tensor test_elements, *, bool assume_unique=False, bool invert=False) -> Tensor
   variants: function

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3180,7 +3180,7 @@
   variants: function
   structured: True
   dispatch:
-    CPU, CUDA: isin_Tensor_Scalar_out
+    CPU, CUDA, MPS: isin_Tensor_Scalar_out
 
 - func: isin.Tensor_Scalar(Tensor elements, Scalar test_element, *, bool assume_unique=False, bool invert=False) -> Tensor
   variants: function
@@ -3190,7 +3190,7 @@
   variants: function
   structured: True
   dispatch:
-    CPU, CUDA: isin_Scalar_Tensor_out
+    CPU, CUDA, MPS: isin_Scalar_Tensor_out
 
 - func: isin.Scalar_Tensor(Scalar element, Tensor test_elements, *, bool assume_unique=False, bool invert=False) -> Tensor
   variants: function

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -12757,8 +12757,10 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
 
         self.common(forward, (a, b))
 
-    @xfail_if_mps_unimplemented
     def test_isin_tensor_scalar(self):
+        if self.device == "mps" and MACOS_VERSION < 14.0:
+            raise unittest.SkipTest("isin is not implemented on MacOS-13")
+
         for invert in [True, False]:
             torch._dynamo.reset()
             elements = 1

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8073,10 +8073,10 @@ class TestLogical(TestCaseMPS):
 
         [helper(dtype) for dtype in dtypes]
 
+        x = torch.arange(4.0, device="mps")
         # Mixed dtypes (see https://github.com/pytorch/pytorch/issues/151443 )
         # torch.isin is broken in MacOS-13.2 even for the same dtype
         if MACOS_VERSION >= 14.0:
-            x = torch.arange(4.0, device="mps")
             y = torch.tensor([1, 3], device="mps", dtype=torch.float16)
             self.assertEqual(torch.isin(x, y), torch.tensor([False, True, False, True], device="mps"))
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8073,19 +8073,19 @@ class TestLogical(TestCaseMPS):
 
         [helper(dtype) for dtype in dtypes]
 
-        x = torch.arange(4.0, device="mps")
         # Mixed dtypes (see https://github.com/pytorch/pytorch/issues/151443 )
         # torch.isin is broken in MacOS-13.2 even for the same dtype
         if MACOS_VERSION >= 14.0:
+            x = torch.arange(4.0, device="mps")
             y = torch.tensor([1, 3], device="mps", dtype=torch.float16)
             self.assertEqual(torch.isin(x, y), torch.tensor([False, True, False, True], device="mps"))
 
-        # Tensor.Scalar variant (aliases to eq), not covered by OpInfo
-        self.assertEqual(torch.isin(x, 2.0), torch.tensor([False, False, True, False], device="mps"))
-        self.assertEqual(torch.isin(x, 1.0, invert=True), torch.tensor([True, False, True, True], device="mps"))
-        self.assertEqual(torch.isin(x, 8.0), torch.tensor([False, False, False, False], device="mps"))
-        # Scalar.Tensor varaiant(alaises to Scalar.Scalar), not covered by OpInfo
-        self.assertEqual(torch.isin(2.0, x), torch.tensor(True, device="mps"))
+            # Tensor.Scalar variant (aliases to eq), not covered by OpInfo
+            self.assertEqual(torch.isin(x, 2.0), torch.tensor([False, False, True, False], device="mps"))
+            self.assertEqual(torch.isin(x, 1.0, invert=True), torch.tensor([True, False, True, True], device="mps"))
+            self.assertEqual(torch.isin(x, 8.0), torch.tensor([False, False, False, False], device="mps"))
+            # Scalar.Tensor varaiant(alaises to Scalar.Scalar), not covered by OpInfo
+            self.assertEqual(torch.isin(2.0, x), torch.tensor(True, device="mps"))
 
     def test_isin_asserts(self):
         C = torch.randn(size=[1, 4], device='mps', dtype=torch.float32)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8080,10 +8080,12 @@ class TestLogical(TestCaseMPS):
             y = torch.tensor([1, 3], device="mps", dtype=torch.float16)
             self.assertEqual(torch.isin(x, y), torch.tensor([False, True, False, True], device="mps"))
 
-            # Tensor.Scalar variant (aliases to eq)
-            self.assertEqual(torch.isin(x, 2.0), torch.tensor([False, False, True, False], device="mps"))
-            self.assertEqual(torch.isin(x, 2.0, invert=True), torch.tensor([True, True, False, True], device="mps"))
-            self.assertEqual(torch.isin(2, x), torch.tensor(True, device="mps"))
+        # Tensor.Scalar variant (aliases to eq), not covered by OpInfo
+        self.assertEqual(torch.isin(x, 2.0), torch.tensor([False, False, True, False], device="mps"))
+        self.assertEqual(torch.isin(x, 1.0, invert=True), torch.tensor([True, False, True, True], device="mps"))
+        self.assertEqual(torch.isin(x, 8.0), torch.tensor([False, False, False, False], device="mps"))
+        # Scalar.Tensor varaiant(alaises to Scalar.Scalar), not covered by OpInfo
+        self.assertEqual(torch.isin(2.0, x), torch.tensor(True, device="mps"))
 
     def test_isin_asserts(self):
         C = torch.randn(size=[1, 4], device='mps', dtype=torch.float32)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8080,6 +8080,11 @@ class TestLogical(TestCaseMPS):
             y = torch.tensor([1, 3], device="mps", dtype=torch.float16)
             self.assertEqual(torch.isin(x, y), torch.tensor([False, True, False, True], device="mps"))
 
+            # Tensor.Scalar variant (aliases to eq)
+            self.assertEqual(torch.isin(x, 2.0), torch.tensor([False, False, True, False], device="mps"))
+            self.assertEqual(torch.isin(x, 2.0, invert=True), torch.tensor([True, True, False, True], device="mps"))
+            self.assertEqual(torch.isin(2, x), torch.tensor(True, device="mps"))
+
     def test_isin_asserts(self):
         C = torch.randn(size=[1, 4], device='mps', dtype=torch.float32)
         D = torch.randn(size=[1, 4], device='cpu', dtype=torch.float32)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #154010

`isin_Tensor_Scalar_out` is just a redispatch to eq/neq
`isin_Scalar_Tensor_out` redispatches back to generic `isin` op, but needs a small tweak to handle float scalars
Make sure that `out` is resized to an expected value in `isin_Tensor_Tensor_out_mps`

Add unittests to validate that, but skip them on MacOS-13, where MPS op just returns garbage

Before this change both of those failed
```python
>>> import torch
>>> t = torch.tensor([0, 1, 2], device='mps')
>>> torch.isin(t, 1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NotImplementedError: The operator 'aten::isin.Tensor_Scalar_out' is not currently implemented for the MPS device. If you want this op to be considered for addition please comment on https://github.com/pytorch/pytorch/issues/141287 and mention use-case, that resulted in missing op as well as commit hash 3b875c25ea6d8802a0c53af9eb961ddf2f058188. As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` to use the CPU as a fallback for this op. WARNING: this will be slower than running natively on MPS.
>>> torch.isin(1, t)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NotImplementedError: The operator 'aten::isin.Scalar_Tensor_out' is not currently implemented for the MPS device. If you want this op to be considered for addition please comment on https://github.com/pytorch/pytorch/issues/141287 and mention use-case, that resulted in missing op as well as commit hash 3b875c25ea6d8802a0c53af9eb961ddf2f058188. As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` to use the CPU as a fallback for this op. WARNING: this will be slower than running natively on MPS.
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov