### PR TITLE
[BE] Remove extra semicolons from SymmetricMemory.hpp

### DIFF
--- a/torch/csrc/distributed/c10d/SymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/SymmetricMemory.hpp
@@ -74,11 +74,11 @@ class TORCH_API SymmetricMemory : public c10::intrusive_ptr_target {
 
   virtual std::vector<int> get_rank_to_global_rank() {
     TORCH_CHECK(false, "NYI");
-  };
+  }
 
   virtual int* get_rank_to_global_rank_dev() {
     TORCH_CHECK(false, "NYI");
-  };
+  }
 };
 
 class SymmetricMemoryAllocator : public c10::intrusive_ptr_target {


### PR DESCRIPTION
Fixes
```
In file included from /Users/malfet/git/pytorch/pytorch/torch/csrc/distributed/c10d/SymmetricMemory.cpp:1:
/Users/malfet/git/pytorch/pytorch/torch/csrc/distributed/c10d/SymmetricMemory.hpp:77:4: warning: extra ';' after member function definition [-Wextra-semi]
   77 |   };
      |    ^
/Users/malfet/git/pytorch/pytorch/torch/csrc/distributed/c10d/SymmetricMemory.hpp:81:4: warning: extra ';' after member function definition [-Wextra-semi]
   81 |   };
      |    ^
2 warnings generated.
```


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k