### PR TITLE
[easy] Fix internal only test

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -2188,6 +2188,7 @@ class TestAutotuneCache(TestCase):
     @unittest.skipIf(
         TEST_WITH_ROCM, "Requires static cuda launcher, which does not support ROCM"
     )
+    @config.patch({"use_static_cuda_launcher": True})
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})
     @config.patch({"autotune_local_cache": False})
@@ -2212,7 +2213,7 @@ class TestAutotuneCache(TestCase):
         f_compiled = torch.compile(f, fullgraph=True)
 
         with PatchCaches():
-            f_compiled(x, y, a, b)
+            a1 = f_compiled(x, y, a, b)
 
             self.assertEqual(global_stats.autotune_remote, Stats(2, 0, 2))
             self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
@@ -2220,7 +2221,8 @@ class TestAutotuneCache(TestCase):
 
             # Don't reset FxGraphCache, see that it loads again
             torch._dynamo.reset()
-            f_compiled(x, y, a, b)
+            a2 = f_compiled(x, y, a, b)
+            self.assertEqual(a1, a2)
             self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
             self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #154035
* #153565

Internally static cuda launcher isn't enabled, so we need to always enable it

Differential Revision: [D75146584](https://our.internmc.facebook.com/intern/diff/D75146584/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov