### PR TITLE
[ROCm] Added unit test to test the cuda_pluggable allocator 

### DIFF
--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -1194,18 +1194,17 @@ class TestCppExtensionJIT(common.TestCase):
         self.assertEqual(abs_t, torch.abs(t))
         self.assertEqual(floor_t, torch.floor(t))
 
-
     @unittest.skipIf(not (TEST_CUDA or TEST_ROCM), "CUDA not found")
     def test_cuda_pluggable_allocator_include(self):
         """
         This method creates a minimal example to replicate the apex setup.py to build nccl_allocator extension
         """
 
-        #the cpp source includes CUDAPluggableAllocator and has an empty exported function
+        # the cpp source includes CUDAPluggableAllocator and has an empty exported function
         cpp_source = """
                 #include <torch/csrc/cuda/CUDAPluggableAllocator.h>
                 #include <torch/extension.h>
-                int get_nccl_allocator() { 
+                int get_nccl_allocator() {
                     return 0;
                 }
                 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
@@ -1219,24 +1218,24 @@ class TestCppExtensionJIT(common.TestCase):
         with open(src_path, mode="w") as f:
             f.write(cpp_source)
 
-        #initially success is false
+        # initially success is false
         success = False
         try:
-            #try to build the module
+            # try to build the module
             module = torch.utils.cpp_extension.load(
                 name="nccl_allocator",
                 sources=src_path,
                 verbose=True,
                 with_cuda=True,
             )
-            #set success as true if built successfully
+            # set success as true if built successfully
             success = True
         except Exception as e:
             print(f"Failed to load the module: {e}")
 
-        #test if build was successful
+        # test if build was successful
         self.assertEqual(success, True)
 
-        
+
 if __name__ == "__main__":
     common.run_tests()

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -1216,10 +1216,10 @@ class TestCppExtensionJIT(common.TestCase):
         build_dir = tempfile.mkdtemp()
         src_path = os.path.join(build_dir, "NCCLAllocator.cpp")
 
-        with open(src_path, encoding="gbk", mode="w") as f:
+        with open(src_path, mode="w") as f:
             f.write(cpp_source)
 
-        #initially success is true
+        #initially success is false
         success = False
         try:
             #try to build the module

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -1222,7 +1222,7 @@ class TestCppExtensionJIT(common.TestCase):
         success = False
         try:
             # try to build the module
-            module = torch.utils.cpp_extension.load(
+            torch.utils.cpp_extension.load(
                 name="nccl_allocator",
                 sources=src_path,
                 verbose=True,


### PR DESCRIPTION
Added unit test to include the cuda_pluggable allocator and replicate the apex setup.py to build nccl_allocator extension


This test to check if this commit https://github.com/pytorch/pytorch/pull/152179 helps to build the cuda pluggable allocator in Rocm/Apex

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd