### PR TITLE
Rename the provenance tracing artifact name for kernel <-> post_grad nodes mapping

### DIFF
--- a/test/inductor/test_provenance_tracing.py
+++ b/test/inductor/test_provenance_tracing.py
@@ -64,7 +64,7 @@ class TestProvenanceTracingArtifact(TestCase):
 
     def _check_provenance_tracing_artifact(self, filepath, expected_data):
         self.assertTrue(filepath.is_dir())
-        filename = Path(filepath) / "inductor_triton_kernel_to_post_grad_nodes.json"
+        filename = Path(filepath) / "inductor_generated_kernel_to_post_grad_nodes.json"
         with open(filename) as f:
             actual_data = json.load(f)
         # check that the generated provenance tracing artifact is expected

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -973,7 +973,7 @@ def _compile_fx_inner(
         trace_structured(
             "artifact",
             metadata_fn=lambda: {
-                "name": "inductor_triton_kernel_to_post_grad_nodes",
+                "name": "inductor_generated_kernel_to_post_grad_nodes",
                 "encoding": "json",
             },
             payload_fn=lambda: json.dumps(debug_info),

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -558,7 +558,7 @@ class DebugFormatter:
         shutil.copy(filename, self.filename(f"output_code.{extension}"))
 
     def log_inductor_triton_kernel_to_post_grad_node_info(
-        self, filename: str = "inductor_triton_kernel_to_post_grad_nodes.json"
+        self, filename: str = "inductor_generated_kernel_to_post_grad_nodes.json"
     ) -> tuple[dict[str, list[str]], dict[str, Any]]:
         debug_info = {}
         with self.fopen(filename, "w") as fd:


### PR DESCRIPTION
Summary:
Context:

Recently we've added a couple more kernel types support other than inductor generated triton kernels,

such as cpu cpp kernels, extern kernels.

The name appeared in tlparse chrome link can be confusing to users.



Rename from

`inductor_triton_kernel_to_post_grad_nodes.json`

to `inductor_generated_kernel_to_post_grad_nodes.json`

Test Plan: CI

Differential Revision: D75159042




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov