### PR TITLE
force computation in opmath_t for CUDA fused optimizers

### DIFF
--- a/aten/src/ATen/native/cuda/FusedSgdKernel.cu
+++ b/aten/src/ATen/native/cuda/FusedSgdKernel.cu
@@ -165,9 +165,8 @@ void _fused_sgd_with_momentum_kernel_cuda_(
     const std::optional<at::Tensor>& grad_scale,
     const std::optional<at::Tensor>& found_inf) {
   TORCH_CHECK_GT(momentum, 0);
-  TORCH_CHECK(
-      at::native::check_fast_path_restrictions(
-          {params, grads, momentum_buffer_list}));
+  TORCH_CHECK(at::native::check_fast_path_restrictions(
+      {params, grads, momentum_buffer_list}));
   float* grad_scale_ptr =
       grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
   float* found_inf_ptr =
@@ -228,9 +227,8 @@ void _fused_sgd_with_momentum_kernel_cuda_(
     return;
   }
   TORCH_CHECK_GT(momentum, 0);
-  TORCH_CHECK(
-      at::native::check_fast_path_restrictions(
-          {params, grads, momentum_buffer_list}));
+  TORCH_CHECK(at::native::check_fast_path_restrictions(
+      {params, grads, momentum_buffer_list}));
   if (grad_scale.has_value()) {
     TORCH_CHECK(
         grad_scale->device() == params[0].device(),

--- a/aten/src/ATen/native/cuda/FusedSgdKernel.cu
+++ b/aten/src/ATen/native/cuda/FusedSgdKernel.cu
@@ -10,27 +10,29 @@ namespace at::native {
 
 namespace {
 
-template <typename scalar_t, int depth>
+constexpr uint8_t kParamIdx = 0;
+constexpr uint8_t kGradIdx = 1;
+constexpr uint8_t kMomentumBufferIdx = 2;
+
+template <typename scalar_t, typename opmath_t, int depth>
 C10_DEVICE __forceinline__ void sgd_math(
     scalar_t r_args[depth][kILP],
-    const double weight_decay,
-    const double momentum,
-    const float* lr_ptr,
-    const double lr,
-    const double dampening,
+    const opmath_t weight_decay,
+    const opmath_t momentum,
+    const opmath_t lr,
+    const opmath_t dampening,
     const bool nesterov,
     const bool maximize,
     const bool is_first_step,
     const float* grad_scale_ptr) {
-  using opmath_t = at::opmath_type<scalar_t>;
-  const double double_lr = lr_ptr != nullptr ? *lr_ptr : lr;
 #pragma unroll
   for (int ii = 0; ii < kILP; ii++) {
-    auto p = static_cast<opmath_t>(r_args[0][ii]);
-    auto g = static_cast<opmath_t>(r_args[1][ii]);
+    opmath_t p = static_cast<opmath_t>(r_args[kParamIdx][ii]);
+    opmath_t g = static_cast<opmath_t>(r_args[kGradIdx][ii]);
+
     if (grad_scale_ptr) {
-      g /= static_cast<double>(*grad_scale_ptr);
-      r_args[1][ii] = g;
+      g /= static_cast<opmath_t>(*grad_scale_ptr);
+      r_args[kGradIdx][ii] = g;
     }
     if (maximize) {
       g *= -1.0;
@@ -38,12 +40,12 @@ C10_DEVICE __forceinline__ void sgd_math(
     if (weight_decay != 0) {
       g += weight_decay * p;
     }
-    if (depth > 2) {
+    if constexpr (depth > 2) {
       const auto momentum_buffer = is_first_step
           ? g
-          : (momentum * static_cast<opmath_t>(r_args[2][ii]) +
+          : (momentum * static_cast<opmath_t>(r_args[kMomentumBufferIdx][ii]) +
              (1 - dampening) * g);
-      r_args[2][ii] = momentum_buffer;
+      r_args[kMomentumBufferIdx][ii] = momentum_buffer;
 
       if (nesterov) {
         g = g + momentum * momentum_buffer;
@@ -51,8 +53,8 @@ C10_DEVICE __forceinline__ void sgd_math(
         g = momentum_buffer;
       }
     }
-    p -= double_lr * g;
-    r_args[0][ii] = p;
+    p -= lr * g;
+    r_args[kParamIdx][ii] = p;
   }
 }
 
@@ -61,6 +63,8 @@ struct FusedSgdMathFunctor {
   static_assert(
       depth == 2 || depth == 3,
       "depth of 2 for SGD w/ momentum == 0, 3 for SGD w/ momentum != 0");
+  using opmath_t = at::opmath_type<scalar_t>;
+
   C10_DEVICE __forceinline__ void operator()(
       const int chunk_size,
       TensorListMetadata<depth>& tl,
@@ -79,12 +83,15 @@ struct FusedSgdMathFunctor {
     }
     const auto tensor_loc = tl.block_to_tensor[blockIdx.x];
     const auto chunk_idx = tl.block_to_chunk[blockIdx.x];
+    const opmath_t lr_opmath =
+        lr_ptr ? static_cast<opmath_t>(*lr_ptr) : static_cast<opmath_t>(lr);
 
     scalar_t* args[depth];
     scalar_t r_args[depth][kILP];
+    const auto n = tl.numel_for_tensor[tensor_loc] - chunk_idx * chunk_size;
+
     const auto all_aligned{
         init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc)};
-    const auto n = tl.numel_for_tensor[tensor_loc] - chunk_idx * chunk_size;
 
     const auto use_faster_load_store =
         (n % kILP == 0) && (chunk_size % kILP == 0) && all_aligned;
@@ -96,13 +103,12 @@ struct FusedSgdMathFunctor {
         for (auto i = 0; i < depth; i++) {
           load_store(r_args[i], args[i], 0, i_start);
         }
-        sgd_math<scalar_t, depth>(
+        sgd_math<scalar_t, opmath_t, depth>(
             r_args,
-            weight_decay,
-            momentum,
-            lr_ptr,
-            lr,
-            dampening,
+            static_cast<opmath_t>(weight_decay),
+            static_cast<opmath_t>(momentum),
+            lr_opmath,
+            static_cast<opmath_t>(dampening),
             nesterov,
             maximize,
             is_first_step,
@@ -119,13 +125,12 @@ struct FusedSgdMathFunctor {
       for (auto i_start = 0; i_start < n && i_start < chunk_size;
            i_start += blockDim.x * kILP) {
         load_args<depth>(r_args, args, i_start, chunk_size, n);
-        sgd_math<scalar_t, depth>(
+        sgd_math<scalar_t, opmath_t, depth>(
             r_args,
-            weight_decay,
-            momentum,
-            lr_ptr,
-            lr,
-            dampening,
+            static_cast<opmath_t>(weight_decay),
+            static_cast<opmath_t>(momentum),
+            lr_opmath,
+            static_cast<opmath_t>(dampening),
             nesterov,
             maximize,
             is_first_step,

--- a/aten/src/ATen/native/cuda/fused_adam_utils.cuh
+++ b/aten/src/ATen/native/cuda/fused_adam_utils.cuh
@@ -127,8 +127,13 @@ struct FusedAdamMathFunctor {
       const float* found_inf_ptr) {
     const auto tensor_loc = tl.block_to_tensor[blockIdx.x];
     const auto chunk_idx = tl.block_to_chunk[blockIdx.x];
+
     const opmath_t lr_opmath =
         lr_ptr ? static_cast<opmath_t>(*lr_ptr) : static_cast<opmath_t>(lr);
+    const opmath_t beta1_opmath = static_cast<opmath_t>(beta1);
+    const opmath_t beta2_opmath = static_cast<opmath_t>(beta2);
+    const opmath_t weight_decay_opmath = static_cast<opmath_t>(weight_decay);
+    const opmath_t eps_opmath = static_cast<opmath_t>(eps);
 
     if (found_inf_ptr && *found_inf_ptr == 1) {
       return;
@@ -140,10 +145,10 @@ struct FusedAdamMathFunctor {
               tl.state_steps_addresses[tensor_loc]));
 
       const opmath_t bias_correction1 =
-          1 - at::native::pow_(static_cast<opmath_t>(beta1), step_count);
+          1 - at::native::pow_(beta1_opmath, step_count);
 
       const opmath_t bias_correction2 =
-          1 - at::native::pow_(static_cast<opmath_t>(beta2), step_count);
+          1 - at::native::pow_(beta2_opmath, step_count);
       const opmath_t bias_correction2_sqrt = std::sqrt(bias_correction2);
 
       return {bias_correction1, bias_correction2_sqrt};
@@ -167,10 +172,10 @@ struct FusedAdamMathFunctor {
         adam_math<scalar_type, opmath_t, depth, adam_mode, amsgrad>(
             r_args,
             lr_opmath,
-            static_cast<opmath_t>(beta1),
-            static_cast<opmath_t>(beta2),
-            static_cast<opmath_t>(weight_decay),
-            static_cast<opmath_t>(eps),
+            beta1_opmath,
+            beta2_opmath,
+            weight_decay_opmath,
+            eps_opmath,
             maximize,
             grad_scale_ptr,
             found_inf_ptr,
@@ -190,10 +195,10 @@ struct FusedAdamMathFunctor {
         adam_math<scalar_type, opmath_t, depth, adam_mode, amsgrad>(
             r_args,
             lr_opmath,
-            beta1,
-            beta2,
-            weight_decay,
-            eps,
+            beta1_opmath,
+            beta2_opmath,
+            weight_decay_opmath,
+            eps_opmath,
             maximize,
             grad_scale_ptr,
             found_inf_ptr,


### PR DESCRIPTION
Fixes #153649

Benchmarks before and after:
```
(On RTX 5070)

Adam
=====================================

Main:
Mean time per run: 11066.4259 µs
Median: 11065.9903

With forced opmath_t:
Mean time per run: 8368.6145 µs
Median: 8367.6631

SGD
=====================================

Main:
Mean time per run: 3679.6347 µs
Median: 3678.9713

With forced opmath_t:
Mean time per run: 3518.2261 µs
Median: 3517.4846
```

