### PR TITLE
[libc++ readiness][caffe2] No reason to check for "ext/stdio_filebuf.h"

### DIFF
--- a/torch/csrc/profiler/unwind/unwind_fb.cpp
+++ b/torch/csrc/profiler/unwind/unwind_fb.cpp
@@ -1,6 +1,6 @@
 #if defined(__linux__) && (defined(__x86_64__) || defined(__aarch64__)) && \
-    defined(__has_include) &&                                              \
-    __has_include("ext/stdio_filebuf.h") && defined(FBCODE_CAFFE2)
+    defined(FBCODE_CAFFE2)
+
 #include <c10/util/flat_hash_map.h>
 #include <llvm/DebugInfo/Symbolize/Symbolize.h>
 #include <torch/csrc/profiler/unwind/unwind.h>


### PR DESCRIPTION
Summary: There should be no reason to check for existence of this GNU C++ header here in this file. It doesn't include it. Removing this condition to make it build under libc++.

Differential Revision: D75179136


