### PR TITLE
[Draft][CUDA] Use runtime driver API for cuStreamWriteValue32

### DIFF
--- a/c10/cuda/driver_api.cpp
+++ b/c10/cuda/driver_api.cpp
@@ -3,6 +3,7 @@
 #include <c10/util/CallOnce.h>
 #include <c10/util/Exception.h>
 #include <dlfcn.h>
+#include <iostream>
 
 namespace c10::cuda {
 
@@ -45,6 +46,48 @@ void* DriverAPI::get_nvml_handle() {
 C10_EXPORT DriverAPI* DriverAPI::get() {
   static DriverAPI singleton = create_driver_api();
   return &singleton;
+}
+
+// Implementation of the new get_entry_point functionality
+void* DriverAPI::load_driver_entry_point(const char* symbol, unsigned int version) {
+  void* entry_point = nullptr;
+  
+  try {
+#if (CUDA_VERSION >= 12050)
+    // Use versioned entry point API if available
+    cudaError_t result = cudaGetDriverEntryPointByVersion(
+        symbol, &entry_point, version, cudaEnableDefault);
+    
+    if (result != cudaSuccess) {
+      // Note: We don't log errors here to avoid spam, as some APIs might not be available
+      // The caller should check for nullptr return value
+      return nullptr;
+    }
+#else
+    // Use standard entry point API
+    (void)version; // Suppress unused parameter warning
+    cudaError_t result = cudaGetDriverEntryPoint(
+        symbol, &entry_point, cudaEnableDefault);
+    
+    if (result != cudaSuccess) {
+      return nullptr;
+    }
+#endif
+    
+    if (entry_point == nullptr) {
+      // cudaGetDriverEntryPoint returned success but null pointer
+      return nullptr;
+    }
+    
+  } catch (const std::exception& e) {
+    // Exception while loading - return nullptr
+    return nullptr;
+  } catch (...) {
+    // Unknown exception while loading - return nullptr
+    return nullptr;
+  }
+  
+  return entry_point;
 }
 
 } // namespace c10::cuda

--- a/c10/cuda/driver_api.cpp
+++ b/c10/cuda/driver_api.cpp
@@ -54,7 +54,7 @@ typedef cudaError_t (*VersionedGetEntryPoint)(const char *, void **, unsigned in
 typedef cudaError_t (*GetEntryPoint)(const char *, void **, unsigned long long,  // NOLINT(*)
                                      cudaDriverEntryPointQueryResult *);
 
-void *get_symbol(const char *symbol, int cuda_version) {
+C10_EXPORT void *get_symbol(const char *symbol, int cuda_version) {
   constexpr char driver_entrypoint[] = "cudaGetDriverEntryPoint";
   constexpr char driver_entrypoint_versioned[] = "cudaGetDriverEntryPointByVersion";
   // We link to the libcudart.so already, so can search for it in the current context

--- a/c10/cuda/driver_api.h
+++ b/c10/cuda/driver_api.h
@@ -2,8 +2,11 @@
 #include <cuda.h>
 #define NVML_NO_UNVERSIONED_FUNC_DEFS
 #include <nvml.h>
+#include <cuda_runtime.h>
 
 #include <c10/util/Exception.h>
+#include <mutex>
+#include <unordered_map>
 
 #define C10_CUDA_DRIVER_CHECK(EXPR)                                        \
   do {                                                                     \
@@ -61,8 +64,148 @@ struct DriverAPI {
   C10_LIBCUDA_DRIVER_API_12030(CREATE_MEMBER)
   C10_NVML_DRIVER_API(CREATE_MEMBER)
 #undef CREATE_MEMBER
+  
+  // Legacy API - maintains backward compatibility
   static DriverAPI* get();
   static void* get_nvml_handle();
+  
+  // New get() API - calls cudaGetDriverEntryPoint directly and returns function pointer
+  template<typename FuncType>
+  FuncType* get_entry_point(const char* symbol, unsigned int version = 11000) {
+    std::lock_guard<std::mutex> lock(entry_point_mutex_);
+    
+    // Check cache first
+    auto it = loaded_entry_points_.find(symbol);
+    if (it != loaded_entry_points_.end()) {
+      return reinterpret_cast<FuncType*>(it->second);
+    }
+    
+    // Load the function using cudaGetDriverEntryPoint
+    void* func_ptr = load_driver_entry_point(symbol, version);
+    
+    // Cache the result (even if nullptr)
+    loaded_entry_points_[symbol] = func_ptr;
+    
+    return reinterpret_cast<FuncType*>(func_ptr);
+  }
+  
+  // Convenience methods for specific CUDA driver APIs using the new get() approach
+  decltype(::cuDeviceGetAttribute)* cuDeviceGetAttribute_() {
+    return get_entry_point<decltype(::cuDeviceGetAttribute)>("cuDeviceGetAttribute", 11000);
+  }
+  
+  decltype(::cuMemAddressReserve)* cuMemAddressReserve_() {
+    return get_entry_point<decltype(::cuMemAddressReserve)>("cuMemAddressReserve", 10020);
+  }
+  
+  decltype(::cuMemRelease)* cuMemRelease_() {
+    return get_entry_point<decltype(::cuMemRelease)>("cuMemRelease", 10020);
+  }
+  
+  decltype(::cuMemMap)* cuMemMap_() {
+    return get_entry_point<decltype(::cuMemMap)>("cuMemMap", 10020);
+  }
+  
+  decltype(::cuMemAddressFree)* cuMemAddressFree_() {
+    return get_entry_point<decltype(::cuMemAddressFree)>("cuMemAddressFree", 10020);
+  }
+  
+  decltype(::cuMemSetAccess)* cuMemSetAccess_() {
+    return get_entry_point<decltype(::cuMemSetAccess)>("cuMemSetAccess", 10020);
+  }
+  
+  decltype(::cuMemUnmap)* cuMemUnmap_() {
+    return get_entry_point<decltype(::cuMemUnmap)>("cuMemUnmap", 10020);
+  }
+  
+  decltype(::cuMemCreate)* cuMemCreate_() {
+    return get_entry_point<decltype(::cuMemCreate)>("cuMemCreate", 10020);
+  }
+  
+  decltype(::cuMemGetAllocationGranularity)* cuMemGetAllocationGranularity_() {
+    return get_entry_point<decltype(::cuMemGetAllocationGranularity)>("cuMemGetAllocationGranularity", 10020);
+  }
+  
+  decltype(::cuMemExportToShareableHandle)* cuMemExportToShareableHandle_() {
+    return get_entry_point<decltype(::cuMemExportToShareableHandle)>("cuMemExportToShareableHandle", 10020);
+  }
+  
+  decltype(::cuMemImportFromShareableHandle)* cuMemImportFromShareableHandle_() {
+    return get_entry_point<decltype(::cuMemImportFromShareableHandle)>("cuMemImportFromShareableHandle", 10020);
+  }
+  
+  decltype(::cuMemsetD32Async)* cuMemsetD32Async_() {
+    return get_entry_point<decltype(::cuMemsetD32Async)>("cuMemsetD32Async", 11000);
+  }
+  
+  decltype(::cuStreamWriteValue32)* cuStreamWriteValue32_() {
+#if (CUDA_VERSION >= 12000)
+    return get_entry_point<decltype(::cuStreamWriteValue32)>("cuStreamWriteValue32", 12000);
+#else
+    return get_entry_point<decltype(::cuStreamWriteValue32)>("cuStreamWriteValue32", 11000);
+#endif
+  }
+  
+  decltype(::cuGetErrorString)* cuGetErrorString_() {
+    return get_entry_point<decltype(::cuGetErrorString)>("cuGetErrorString", 11000);
+  }
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12030)
+  decltype(::cuMulticastAddDevice)* cuMulticastAddDevice_() {
+    return get_entry_point<decltype(::cuMulticastAddDevice)>("cuMulticastAddDevice", 12030);
+  }
+  
+  decltype(::cuMulticastBindMem)* cuMulticastBindMem_() {
+    return get_entry_point<decltype(::cuMulticastBindMem)>("cuMulticastBindMem", 12030);
+  }
+  
+  decltype(::cuMulticastCreate)* cuMulticastCreate_() {
+    return get_entry_point<decltype(::cuMulticastCreate)>("cuMulticastCreate", 12030);
+  }
+#endif
+  
+  // Utility methods
+  bool is_entry_point_available(const char* symbol, unsigned int version = 11000) {
+    return get_entry_point<void>(symbol, version) != nullptr;
+  }
+  
+  void clear_entry_point_cache() {
+    std::lock_guard<std::mutex> lock(entry_point_mutex_);
+    loaded_entry_points_.clear();
+  }
+  
+  size_t get_cache_size() {
+    std::lock_guard<std::mutex> lock(entry_point_mutex_);
+    return loaded_entry_points_.size();
+  }
+
+private:
+  // Helper function for loading driver entry points
+  static void* load_driver_entry_point(const char* symbol, unsigned int version);
+  
+  // Thread-safe cache for loaded entry points
+  mutable std::mutex entry_point_mutex_;
+  mutable std::unordered_map<std::string, void*> loaded_entry_points_;
 };
+
+// Convenience macros for using the new get() API
+#define C10_CUDA_DRIVER_API() c10::cuda::DriverAPI::get()
+
+// Macro to call a driver API function with automatic loading via get_entry_point
+#define C10_CALL_CUDA_DRIVER_API(funcName, ...) \
+  ([&]() { \
+    auto* func_ptr = C10_CUDA_DRIVER_API()->funcName##_(); \
+    TORCH_CHECK(func_ptr != nullptr, \
+                "Failed to load CUDA driver API: ", #funcName); \
+    return func_ptr(__VA_ARGS__); \
+  })()
+
+// Macro to get a function pointer without calling it
+#define C10_GET_CUDA_DRIVER_API(funcName) \
+  C10_CUDA_DRIVER_API()->funcName##_()
+
+// Macro to check if an API is available
+#define C10_IS_CUDA_DRIVER_API_AVAILABLE(funcName) \
+  (C10_CUDA_DRIVER_API()->funcName##_() != nullptr)
 
 } // namespace c10::cuda

--- a/c10/cuda/driver_api.h
+++ b/c10/cuda/driver_api.h
@@ -2,11 +2,8 @@
 #include <cuda.h>
 #define NVML_NO_UNVERSIONED_FUNC_DEFS
 #include <nvml.h>
-#include <cuda_runtime.h>
 
 #include <c10/util/Exception.h>
-#include <mutex>
-#include <unordered_map>
 
 #define C10_CUDA_DRIVER_CHECK(EXPR)                                        \
   do {                                                                     \
@@ -64,148 +61,8 @@ struct DriverAPI {
   C10_LIBCUDA_DRIVER_API_12030(CREATE_MEMBER)
   C10_NVML_DRIVER_API(CREATE_MEMBER)
 #undef CREATE_MEMBER
-  
-  // Legacy API - maintains backward compatibility
   static DriverAPI* get();
   static void* get_nvml_handle();
-  
-  // New get() API - calls cudaGetDriverEntryPoint directly and returns function pointer
-  template<typename FuncType>
-  FuncType* get_entry_point(const char* symbol, unsigned int version = 11000) {
-    std::lock_guard<std::mutex> lock(entry_point_mutex_);
-    
-    // Check cache first
-    auto it = loaded_entry_points_.find(symbol);
-    if (it != loaded_entry_points_.end()) {
-      return reinterpret_cast<FuncType*>(it->second);
-    }
-    
-    // Load the function using cudaGetDriverEntryPoint
-    void* func_ptr = load_driver_entry_point(symbol, version);
-    
-    // Cache the result (even if nullptr)
-    loaded_entry_points_[symbol] = func_ptr;
-    
-    return reinterpret_cast<FuncType*>(func_ptr);
-  }
-  
-  // Convenience methods for specific CUDA driver APIs using the new get() approach
-  decltype(::cuDeviceGetAttribute)* cuDeviceGetAttribute_() {
-    return get_entry_point<decltype(::cuDeviceGetAttribute)>("cuDeviceGetAttribute", 11000);
-  }
-  
-  decltype(::cuMemAddressReserve)* cuMemAddressReserve_() {
-    return get_entry_point<decltype(::cuMemAddressReserve)>("cuMemAddressReserve", 10020);
-  }
-  
-  decltype(::cuMemRelease)* cuMemRelease_() {
-    return get_entry_point<decltype(::cuMemRelease)>("cuMemRelease", 10020);
-  }
-  
-  decltype(::cuMemMap)* cuMemMap_() {
-    return get_entry_point<decltype(::cuMemMap)>("cuMemMap", 10020);
-  }
-  
-  decltype(::cuMemAddressFree)* cuMemAddressFree_() {
-    return get_entry_point<decltype(::cuMemAddressFree)>("cuMemAddressFree", 10020);
-  }
-  
-  decltype(::cuMemSetAccess)* cuMemSetAccess_() {
-    return get_entry_point<decltype(::cuMemSetAccess)>("cuMemSetAccess", 10020);
-  }
-  
-  decltype(::cuMemUnmap)* cuMemUnmap_() {
-    return get_entry_point<decltype(::cuMemUnmap)>("cuMemUnmap", 10020);
-  }
-  
-  decltype(::cuMemCreate)* cuMemCreate_() {
-    return get_entry_point<decltype(::cuMemCreate)>("cuMemCreate", 10020);
-  }
-  
-  decltype(::cuMemGetAllocationGranularity)* cuMemGetAllocationGranularity_() {
-    return get_entry_point<decltype(::cuMemGetAllocationGranularity)>("cuMemGetAllocationGranularity", 10020);
-  }
-  
-  decltype(::cuMemExportToShareableHandle)* cuMemExportToShareableHandle_() {
-    return get_entry_point<decltype(::cuMemExportToShareableHandle)>("cuMemExportToShareableHandle", 10020);
-  }
-  
-  decltype(::cuMemImportFromShareableHandle)* cuMemImportFromShareableHandle_() {
-    return get_entry_point<decltype(::cuMemImportFromShareableHandle)>("cuMemImportFromShareableHandle", 10020);
-  }
-  
-  decltype(::cuMemsetD32Async)* cuMemsetD32Async_() {
-    return get_entry_point<decltype(::cuMemsetD32Async)>("cuMemsetD32Async", 11000);
-  }
-  
-  decltype(::cuStreamWriteValue32)* cuStreamWriteValue32_() {
-#if (CUDA_VERSION >= 12000)
-    return get_entry_point<decltype(::cuStreamWriteValue32)>("cuStreamWriteValue32", 12000);
-#else
-    return get_entry_point<decltype(::cuStreamWriteValue32)>("cuStreamWriteValue32", 11000);
-#endif
-  }
-  
-  decltype(::cuGetErrorString)* cuGetErrorString_() {
-    return get_entry_point<decltype(::cuGetErrorString)>("cuGetErrorString", 11000);
-  }
-
-#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12030)
-  decltype(::cuMulticastAddDevice)* cuMulticastAddDevice_() {
-    return get_entry_point<decltype(::cuMulticastAddDevice)>("cuMulticastAddDevice", 12030);
-  }
-  
-  decltype(::cuMulticastBindMem)* cuMulticastBindMem_() {
-    return get_entry_point<decltype(::cuMulticastBindMem)>("cuMulticastBindMem", 12030);
-  }
-  
-  decltype(::cuMulticastCreate)* cuMulticastCreate_() {
-    return get_entry_point<decltype(::cuMulticastCreate)>("cuMulticastCreate", 12030);
-  }
-#endif
-  
-  // Utility methods
-  bool is_entry_point_available(const char* symbol, unsigned int version = 11000) {
-    return get_entry_point<void>(symbol, version) != nullptr;
-  }
-  
-  void clear_entry_point_cache() {
-    std::lock_guard<std::mutex> lock(entry_point_mutex_);
-    loaded_entry_points_.clear();
-  }
-  
-  size_t get_cache_size() {
-    std::lock_guard<std::mutex> lock(entry_point_mutex_);
-    return loaded_entry_points_.size();
-  }
-
-private:
-  // Helper function for loading driver entry points
-  static void* load_driver_entry_point(const char* symbol, unsigned int version);
-  
-  // Thread-safe cache for loaded entry points
-  mutable std::mutex entry_point_mutex_;
-  mutable std::unordered_map<std::string, void*> loaded_entry_points_;
 };
-
-// Convenience macros for using the new get() API
-#define C10_CUDA_DRIVER_API() c10::cuda::DriverAPI::get()
-
-// Macro to call a driver API function with automatic loading via get_entry_point
-#define C10_CALL_CUDA_DRIVER_API(funcName, ...) \
-  ([&]() { \
-    auto* func_ptr = C10_CUDA_DRIVER_API()->funcName##_(); \
-    TORCH_CHECK(func_ptr != nullptr, \
-                "Failed to load CUDA driver API: ", #funcName); \
-    return func_ptr(__VA_ARGS__); \
-  })()
-
-// Macro to get a function pointer without calling it
-#define C10_GET_CUDA_DRIVER_API(funcName) \
-  C10_CUDA_DRIVER_API()->funcName##_()
-
-// Macro to check if an API is available
-#define C10_IS_CUDA_DRIVER_API_AVAILABLE(funcName) \
-  (C10_CUDA_DRIVER_API()->funcName##_() != nullptr)
 
 } // namespace c10::cuda

--- a/c10/cuda/driver_api.h
+++ b/c10/cuda/driver_api.h
@@ -65,4 +65,7 @@ struct DriverAPI {
   static void* get_nvml_handle();
 };
 
+/*! \brief Get pointer corresponding to symbol in CUDA driver library */
+void *get_symbol(const char *symbol, int cuda_version = 11080);
+
 } // namespace c10::cuda

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -1078,10 +1078,6 @@ class SymmMemSingleProcTest(TestCase):
         not TEST_WITH_ROCM and _get_torch_cuda_version() < (12, 0),
         "stream_write_value32 currently only supports cuda version>=12.0",
     )
-    @skipIf(
-        _get_torch_cuda_version() >= (12, 6),
-        "https://github.com/pytorch/pytorch/issues/154073",
-    )
     @runOnRocmArch(MI300_ARCH)
     def test_stream_write_value32(self):
         tensor = torch.zeros(4, dtype=torch.uint32, device="cuda")

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryOps.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryOps.cu
@@ -3,7 +3,6 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <torch/library.h>
-#include <mutex> // for std::once_flag, std::call_once
 
 #if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
 #include <c10/cuda/driver_api.h>

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryOps.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryOps.cu
@@ -1145,24 +1145,8 @@ at::Tensor stream_write_value32_(
   c10::cuda::CUDAGuard guard(input.device());
 
 #if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
-  // --- Begin dynamic loading of cuStreamWriteValue32 ---
-  typedef CUresult (CUDAAPI *PFN_cuStreamWriteValue32)(
-      CUstream hStream, CUdeviceptr addr, uint32_t value, unsigned int flags);
-  static PFN_cuStreamWriteValue32 pfn_cuStreamWriteValue32 = nullptr;
-  static std::once_flag load_cuStreamWriteValue32_flag;
-  auto load_cuStreamWriteValue32 = []() {
-    CUresult res = static_cast<CUresult>(cudaGetDriverEntryPoint(
-        "cuStreamWriteValue32",
-        reinterpret_cast<void**>(&pfn_cuStreamWriteValue32),
-        0 /* flags, use 0 for default */
-    ));
-    TORCH_CHECK(res == CUDA_SUCCESS && pfn_cuStreamWriteValue32 != nullptr,
-        "Failed to load cuStreamWriteValue32 via cudaGetDriverEntryPoint");
-  };
-  std::call_once(load_cuStreamWriteValue32_flag, load_cuStreamWriteValue32);
-  // --- End dynamic loading ---
-
-  CUresult res = pfn_cuStreamWriteValue32(
+  // Use the new get() API - much simpler than the old PFN approach
+  CUresult res = C10_CALL_CUDA_DRIVER_API(cuStreamWriteValue32,
       at::cuda::getCurrentCUDAStream(),
       reinterpret_cast<CUdeviceptr>(addr),
       val,


### PR DESCRIPTION
Fixes #154073 

Reference: https://github.com/NVIDIA/Fuser/pull/4197 

Local test results on T4: 

root@ab7cb4533ac9:/my_workspace/wei-pytorch# python test/distributed/test_symmetric_memory.py SymmMemSingleProcTest.test_stream_write_value32 -v
test_stream_write_value32 (__main__.SymmMemSingleProcTest.test_stream_write_value32) ... ok

----------------------------------------------------------------------
Ran 1 test in 0.186s

OK

Copying the implementation from: https://github.com/NVIDIA/TransformerEngine/blob/main/transformer_engine/common/util/cuda_driver.cpp and https://github.com/NVIDIA/TransformerEngine/pull/1835 (cc @ptrendx) 

This PR modifies PyTorch to use the runtime driver API for the cuStreamWriteValue32 function  
 Here are the key changes:
1. Added get_symbol Function (c10/cuda/driver_api.cpp & .h)
This function:
Uses cudaGetDriverEntryPoint and cudaGetDriverEntryPointByVersion to dynamically load CUDA driver functions
Searches for driver entry points in the current runtime context
Provides version-aware symbol loading for better compatibility
2. Updated cuStreamWriteValue32 Implementation (CUDASymmetricMemoryOps.cu)
3. Removed Test Skip Condition (test_symmetric_memory.py) 


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @ptrblck @eqy @tinglvv @atalman @malfet @huydhn @wujingyue 
