### PR TITLE
[PG/nccl] improvements to eager init

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -43,6 +43,11 @@ namespace c10d {
 static std::vector<std::string> TORCH_NCCL_BCAST_UNIQUEID = {
     "TORCH_NCCL_BCAST_UNIQUEID"};
 
+// Control EagerInit P2P serialization warning
+static std::vector<std::string>
+    TORCH_NCCL_SHOW_EAGER_INIT_P2P_SERIALIZATION_WARNING = {
+        "TORCH_NCCL_SHOW_EAGER_INIT_P2P_SERIALIZATION_WARNING"};
+
 // Control whether to always use high priority streams
 static std::vector<std::string> TORCH_NCCL_HIGH_PRIORITY = {
     "TORCH_NCCL_HIGH_PRIORITY"};
@@ -916,6 +921,8 @@ class TORCH_API ProcessGroupNCCL : public Backend {
  protected:
   int globalRankStart_;
   int globalRankStride_;
+ private:
+  bool eagerInit{false};
 
   // Helper that encapsulates work shared across all collective communication
   // primitives.  The callbacks have the following signatures:


### PR DESCRIPTION
Summary:
Cleanup eager init management, to detect and throw a warning when
multiple p2p are issued on the same PG in eager init mode.

Test Plan: CI

Differential Revision: D75157605




cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k