### PR TITLE
Fix the recompilations condition guards

### DIFF
--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -32,6 +32,7 @@ from torch.fx.experimental.symbolic_shapes import (
     free_symbols,
     hint_int,
     is_symbol_binding_fx_node,
+    statically_known_true,
 )
 from torch.fx.passes import graph_drawer
 from torch.utils._ordered_set import OrderedSet
@@ -492,9 +493,9 @@ def should_quantize(node: torch.fx.Node) -> bool:
     # calculate the size of the node
     size_in_mb = calculate_tensor_size(node.meta["val"])
 
-    return size_in_mb >= torch._inductor.config.post_grad_fusion_options[
+    return statically_known_true(size_in_mb >= torch._inductor.config.post_grad_fusion_options[
         "activation_quantization_aten_pass"
-    ].get("size_in_mb", 100)
+    ].get("size_in_mb", 100))
 
 
 def get_quant_type() -> torch.dtype:


### PR DESCRIPTION
Summary:
When the value of tensor size changes, the guard on the condition could fail and trigger recompilations as reported in https://fb.workplace.com/groups/1075192433118967/permalink/1673720956599442/. 
Use `statically_known_true` to avoid that.

Test Plan:
https://www.internalfb.com/mlhub/pipelines/runs/mast/aps-lwb_0514_fp8_quant-780b4db420?job_attempt=0&version=0&tab=summary&env=PRODUCTION

tlparse: https://fburl.com/3yo7yx04

Differential Revision: D75196435


