### PR TITLE
[CI] Setup-Win Long Path and Enable Git long path and symlinks

### DIFF
--- a/.github/actions/setup-win/action.yml
+++ b/.github/actions/setup-win/action.yml
@@ -29,7 +29,18 @@ runs:
     - name: Enable long paths on Windows
       shell: powershell
       run: |
-        Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+        if(-not (Test-Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem")) {
+          New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
+        } else {
+          Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+        }
+
+    - name: Enable git long paths and symlinks on Windows and disable fsmonitor daemon
+      shell: bash
+      run: |
+        git config --global core.longpaths true
+        git config --global core.symlinks true
+        git config --global core.fsmonitor false
 
     - name: Setup conda
       shell: bash


### PR DESCRIPTION
1. Modify logic to either use `New-ItemProperty` or `Set-ItemProperty` on Windows
2. Enable git long paths and symlinks on Windows and disable fsmonitor daemon

Same as: https://github.com/pytorch/test-infra/pull/6648

Test PR: https://github.com/pytorch/pytorch/pull/154141
PR With Error: https://github.com/pytorch/pytorch/pull/154139
 