### PR TITLE
[dynamo] Use UUID for compiled function variable names.

### DIFF
--- a/torch/_dynamo/bytecode_transformation.py
+++ b/torch/_dynamo/bytecode_transformation.py
@@ -22,6 +22,7 @@ import functools
 import itertools
 import sys
 import types
+import uuid
 from collections.abc import Iterator, Sequence
 from typing import Any, Callable, cast, Optional, Union
 
@@ -1547,8 +1548,11 @@ def _cached_cleaned_instructions(code, safe=False) -> Sequence[Instruction]:
 _unique_id_counter = itertools.count()
 
 
-def unique_id(name) -> str:
-    return f"{name}_{next(_unique_id_counter)}"
+def unique_id(name, with_uuid=False) -> str:
+    ret = f"{name}_{next(_unique_id_counter)}"
+    if with_uuid:
+        ret += f"_{uuid.uuid4()}".replace("-", "_")
+    return ret
 
 
 def is_generator(code: types.CodeType) -> bool:

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1486,7 +1486,7 @@ class OutputGraph(OutputGraphGuardsState):
 
             self.run_compiler_collective(tx)
 
-            name = unique_id("__compiled_fn")
+            name = unique_id("__compiled_fn", with_uuid=True)
 
             assert isinstance(rv, list)
             assert isinstance(root, FakeRootModule)

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -3606,7 +3606,7 @@ class InstructionTranslator(InstructionTranslatorBase):
         stack_len = len(self.stack) - len(null_idxes)
         nargs = stack_len + len(argnames)
 
-        name = unique_id(f"__resume_at_{inst.offset}")
+        name = unique_id(f"__resume_at_{inst.offset}", with_uuid=True)
 
         new_code: types.CodeType = ContinueExecutionCache.lookup(
             self.f_code,


### PR DESCRIPTION
Summary:
We previously assign each compiled function variable a name based on in-process global counter. This works fine within the same process but when we're trying to serialize the states with precompile, we need a way to load back these compiled functions without causing collision to the existing global scope.

Changing the counter to a true global uuid seems to resolve this issue.

For example, the new variable name will look like:
```
__compiled_fn_0_7ce7d872_4fe8_4174_b8fd_2496b09b8b43
```

Test Plan: CI

Differential Revision: D75244901




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames