### PR TITLE
Fix tcp init when using port 0

### DIFF
--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -191,6 +191,17 @@ def simple_multi_input_reduce_tests(rank, world_size):
     ]
 
 
+class RendezvousTCPTest(TestCase):
+    @retry_on_connect_failures
+    def test_tcp_init(self):
+        rendezvous_iterator = dist.rendezvous("tcp://127.0.0.1:0", rank=0, world_size=1)
+        store, rank, world_size = next(rendezvous_iterator)
+        self.assertEqual(rank, 0)
+        self.assertEqual(world_size, 1)
+        # port number should get assigned
+        self.assertNotEqual(store.port, "0")
+
+
 class RendezvousEnvTest(TestCase):
     @requires_gloo()
     @retry_on_connect_failures

--- a/torch/distributed/rendezvous.py
+++ b/torch/distributed/rendezvous.py
@@ -213,7 +213,7 @@ def _tcp_rendezvous_handler(
         return _rendezvous_error("tcp:// rendezvous: " + msg)
 
     result = urlparse(url)
-    if result.port is not None:
+    if result.port is None:
         raise _error("port number missing")
     query_dict = _query_to_dict(result.query)
     if "rank" not in query_dict:

--- a/torch/distributed/rendezvous.py
+++ b/torch/distributed/rendezvous.py
@@ -213,7 +213,7 @@ def _tcp_rendezvous_handler(
         return _rendezvous_error("tcp:// rendezvous: " + msg)
 
     result = urlparse(url)
-    if not result.port:
+    if result.port is not None:
         raise _error("port number missing")
     query_dict = _query_to_dict(result.query)
     if "rank" not in query_dict:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #154156

I hit this in tests when calling `init_process_group(init_method="tcp://localhost:0", ...)`. You can't use port 0 due to the bug in the conditional and will get error `ValueError: Error initializing torch.distributed using tcp:// rendezvous: port number missing`

cc @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k