### PR TITLE
[EASY] remove guard_size_oblivious from is_nonzero proxy call check

### DIFF
--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -812,12 +812,7 @@ def proxy_call(
 
     if func is torch.ops.aten.is_nonzero.default:
         with proxy_mode:
-            from .symbolic_shapes import guard_size_oblivious
-
-            if guard_size_oblivious(args[0].numel() != 1):  # type: ignore[attr-defined]
-                raise RuntimeError(
-                    "Boolean value of Tensor with more than one value is ambiguous"
-                )
+            torch._check(args[0].numel() == 1, lambda: "Boolean value of Tensor with more than one value is ambiguous")  # type: ignore[attr-defined]
             return (args[0] != 0).item()  # type: ignore[attr-defined]
 
     tracer = proxy_mode.tracer


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #154234
* #154172
* #154167
* __->__ #154164
* #154154

This was added in https://github.com/pytorch/pytorch/pull/149637, 
torch._check can handle unbacked there is no need for size oblivious reasoning here. 

Note this does not make is_nonzero unbacked friendly. but that is a different story. 
I ran the test added in  https://github.com/pytorch/pytorch/pull/149637 for veirfication.


cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv