### PR TITLE
used guard_or_false instead of  guard_size_oblivious in is_int_or_symint

### DIFF
--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -889,7 +889,7 @@ static bool is_int_or_symint(PyObject* obj) {
   // for regular tensors it's redundant with the test below.
   if (THPVariable_Check(obj)) {
     auto& var = THPVariable_Unpack(obj);
-    if (TORCH_GUARD_SIZE_OBLIVIOUS(var.sym_numel().sym_eq(1)) &&
+    if (TORCH_GUARD_OR_FALSE(var.sym_numel().sym_eq(1)) &&
         at::isIntegralType(var.dtype().toScalarType(), /*include_bool*/ true)) {
       return true;
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #154234
* #154172
* __->__ #154167
* #154164
* #154154

This is a short circuit, that we should not fail on. Before this PR we would not fail on u0, u0+u1,
only if they are size like.  but we will fail on u0-u1.. etc for no need.
guard_or_false seems appropriate for that reason.

This was added in https://github.com/pytorch/pytorch/pull/122145 there was no unit tests for me to verify 
why it was added, i could not repo using the associated issue , the example does not work. 

