### PR TITLE
Revert D74898941 (#154188)

### DIFF
--- a/torch/ao/quantization/pt2e/utils.py
+++ b/torch/ao/quantization/pt2e/utils.py
@@ -167,11 +167,7 @@ def _is_conv_node(n: Node):
     """
     return n.op == "call_function" and n.target in [
         torch.ops.aten.conv1d.default,
-        torch.ops.aten.conv1d.padding,
         torch.ops.aten.conv2d.default,
-        torch.ops.aten.conv2d.padding,
-        torch.ops.aten.conv3d.default,
-        torch.ops.aten.conv3d.padding,
     ]
 
 

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -3184,11 +3184,11 @@ class TestHelperModules:
             return x
 
     class ConvWithBNRelu(torch.nn.Module):
-        def __init__(self, relu, dim=2, bn=True, bias=True, padding=0):
+        def __init__(self, relu, dim=2, bn=True, bias=True):
             super().__init__()
-            convs = {1: torch.nn.Conv1d, 2: torch.nn.Conv2d, 3: torch.nn.Conv3d}
-            bns = {1: torch.nn.BatchNorm1d, 2: torch.nn.BatchNorm2d, 3: torch.nn.BatchNorm3d}
-            self.conv = convs[dim](3, 3, 3, bias=bias, padding=padding)
+            convs = {1: torch.nn.Conv1d, 2: torch.nn.Conv2d}
+            bns = {1: torch.nn.BatchNorm1d, 2: torch.nn.BatchNorm2d}
+            self.conv = convs[dim](3, 3, 3, bias=bias)
 
             if bn:
                 self.bn = bns[dim](3)


### PR DESCRIPTION
Summary:

This diff reverts D74898941
this broke a ton of tests in torchao
GitHub Repo: pytorch/ao

diff-train-source-id: 446f07d5a20f997d8ddcb418b9dfd63fb9b4643e

Test Plan: NA

Reviewed By: HDCharles

Differential Revision: D75270791


