### PR TITLE
[EASY] use guard_or_false instead of gso in Meta converter

### DIFF
--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -1813,9 +1813,9 @@ class MetaConverter(Generic[_TensorT]):
             # Thanks to storage resizing, it's possible to end up with a tensor
             # that advertises a real size, but has a storage that actually has zero bytes.
             # Need to reflect this in the generated FakeTensor.
-            from torch.fx.experimental.symbolic_shapes import guard_size_oblivious
+            from torch.fx.experimental.symbolic_shapes import guard_or_false
 
-            if t.storage is not None and guard_size_oblivious(t.storage.size == 0):
+            if t.storage is not None and guard_or_false(t.storage.size == 0):
                 r.untyped_storage().resize_(0)
 
             if t.is_parameter:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #154234
* #154172
* #154167
* #154164
* #154154

this was added in https://github.com/pytorch/pytorch/pull/141659, the current change keep the same intention
"i do not want to fail here if i cant tell if the size is zero or not"
i am not familiar enough in the code to know if we need here a runtime check, but looking at current 
impl it seems that guard_or_false is appropriate to match current behaviour  and have the same effect of guard_size_oblivious here. 