### PR TITLE
[mergebot] Do not block on autoformat workflow

### DIFF
--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -939,6 +939,12 @@ class GitHubPR:
                     summary=None,
                 )
 
+        # Making an exception for Apply lint auggestions/autoformat because the
+        # bot adds a merged label -> triggers workflow -> sometimes needs
+        # approval -> is read as failure, which results in a blocked merge, but
+        # this workflow doesn't provide mergability info
+        del self.conclusions["Apply lint suggestions"]
+
         return self.conclusions
 
     def get_authors(self) -> dict[str, str]:

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -943,7 +943,7 @@ class GitHubPR:
         # bot adds a merged label -> triggers workflow -> sometimes needs
         # approval -> is read as failure, which results in a blocked merge, but
         # this workflow doesn't provide mergability info
-        del self.conclusions["Apply lint suggestions"]
+        self.conclusions.pop("Apply lint suggestions", None)
 
         return self.conclusions
 


### PR DESCRIPTION
Helps with https://github.com/pytorch/pytorch/issues/154084

Merge sometimes fails due to autoformat failing.  I believe it's because author doesn't have write perms/workflow running perms -> needs approval for workflows.  On merge, the bot adds the merge label -> triggers autoformat workflow -> needs approval (even though it will end up getting get skipped because the label doesn't match) -> merge sees and fails

So I put an ugly exception for the workflow in mergebot

Some restrictions to keep in mind:
* Need to checkout the PRs code changes to run lint/format on them -> possible security issue if someone modifies a linter/formatter
* The (third party) reusable action used in the autoformat workflow requires the trigger to be pull_request
