### PR TITLE
[BE] Don't run windows builds in pull.yml

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -365,25 +365,6 @@ jobs:
       test-matrix: ${{ needs.linux-focal-py3_9-clang9-xla-build.outputs.test-matrix }}
     secrets: inherit
 
-  win-vs2022-cpu-py3-build:
-    # don't run build twice on main
-    if: github.event_name == 'pull_request'
-    name: win-vs2022-cpu-py3
-    uses: ./.github/workflows/_win-build.yml
-    needs: get-label-type
-    with:
-      build-environment: win-vs2022-cpu-py3
-      cuda-version: cpu
-      sync-tag: win-cpu-build
-      runner: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge.nonephemeral"
-      test-matrix: |
-        { include: [
-          { config: "default", shard: 1, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge.nonephemeral" },
-          { config: "default", shard: 2, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge.nonephemeral" },
-          { config: "default", shard: 3, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge.nonephemeral" },
-        ]}
-    secrets: inherit
-
   linux-focal-cpu-py3_10-gcc11-bazel-test:
     name: linux-focal-cpu-py3.10-gcc11-bazel-test
     uses: ./.github/workflows/_bazel-build-test.yml

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -119,7 +119,6 @@ jobs:
     with:
       build-environment: win-vs2022-cpu-py3
       cuda-version: cpu
-      sync-tag: win-cpu-build
       runner: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge.nonephemeral"
       test-matrix: |
         { include: [


### PR DESCRIPTION
We already run windows builds and tests [during trunk.yml](https://github.com/pytorch/pytorch/blob/c13eeaa718c985782bd72bf47886430f6203a768/.github/workflows/trunk.yml#L115-L130). 

Spot checking for failures of this job in pull.yml shows that the most of the times this job fails, the failure correlates with other build jobs failing as well, so it's not offering much unique signal.

Given that we'll run this job before merging the PR as part of trunk.yml anyways, the trade off of extra signal from getting a windows build signal a little earlier doesn't seem worth the infra investment.