### PR TITLE
Fix torchbind path in AOTI package loader

### DIFF
--- a/test/inductor/test_torchbind.py
+++ b/test/inductor/test_torchbind.py
@@ -283,15 +283,16 @@ class TestTorchbind(TestCase):
         with tempfile.NamedTemporaryFile(suffix=".pt2") as f:
             package_path = package_aoti(f.name, aoti_files)
 
-            with tempfile.TemporaryDirectory() as tmp_dir, zipfile.ZipFile(
-                package_path, "r"
-            ) as zip_ref:
-                zip_ref.extractall(tmp_dir)
-                tmp_path_model = Path(tmp_dir) / "data" / "aotinductor" / "model"
-                tmp_path_constants = Path(tmp_dir) / "data" / "constants"
+            with zipfile.ZipFile(package_path, "r") as zip_ref:
+                all_files = zip_ref.namelist()
+                base_folder = all_files[0].split("/")[0]
+                tmp_path_model = Path(base_folder) / "data" / "aotinductor" / "model"
+                tmp_path_constants = Path(base_folder) / "data" / "constants"
 
-                self.assertTrue((tmp_path_model / "custom_objs_config.json").exists())
-                self.assertTrue((tmp_path_constants / "custom_obj_0").exists())
+                self.assertTrue(
+                    str(tmp_path_model / "custom_objs_config.json") in all_files
+                )
+                self.assertTrue(str(tmp_path_constants / "custom_obj_0") in all_files)
 
     def test_torchbind_aoti(self):
         ep, inputs, orig_res, _ = self.get_exported_model()

--- a/torch/csrc/inductor/aoti_package/model_package_loader.cpp
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.cpp
@@ -412,7 +412,8 @@ AOTIModelPackageLoader::AOTIModelPackageLoader(
   std::vector<std::string> obj_filenames;
   std::string model_directory = file_prefix + "data" + k_separator +
       "aotinductor" + k_separator + model_name;
-  std::string const_directory = "data" + k_separator + "constants";
+  std::string const_directory =
+      file_prefix + "data" + k_separator + "constants";
 
   for (const std::string& filename_str : found_filenames) {
     // Only compile files in the specified model directory


### PR DESCRIPTION
Summary: as title, fix the path in package loader and fix the test to take the additional dir into consideration.

Test Plan:
```
buck run 'fbcode//mode/dev-nosan' fbcode//caffe2/test/inductor:torchbind
```

Reviewed By: angelayi

Differential Revision: D75308904




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov