### PR TITLE
[CI] Update MacOS numba and scipy versions

### DIFF
--- a/.github/requirements/pip-requirements-macOS.txt
+++ b/.github/requirements/pip-requirements-macOS.txt
@@ -5,9 +5,7 @@ fbscribelogger==0.1.7
 librosa>=0.6.2
 mpmath==1.3.0
 networkx==2.8.7
-# Use numba-0.49.1 or older on Intel Macs, but 0.56.0 on M1 machines, as older numba is not available
-numba==0.56.0; platform_machine == "arm64"
-numba<=0.49.1; platform_machine != "arm64"
+numba==0.59.0
 opt-einsum>=3.3
 psutil==5.9.1
 nvidia-ml-py==11.525.84
@@ -18,7 +16,7 @@ pytest-xdist==3.3.1
 pytest-rerunfailures==10.3
 pytest-flakefinder==1.1.0
 pytest-subtests==0.13.1
-scipy==1.10.1
+scipy==1.12.0
 sympy==1.13.3
 unittest-xml-reporting<=3.2.0,>=2.0.0
 xdoctest==1.1.0


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #154177
* #154270
* __->__ #154269
* #154271
* #154268

Pick versions that supported by both 3.9 and 3.12