### PR TITLE
Add Support for transposed convolution with Padding Mode 'same' and 'valid'

### DIFF
--- a/aten/src/ATen/functorch/BatchRulesDecompositions.cpp
+++ b/aten/src/ATen/functorch/BatchRulesDecompositions.cpp
@@ -318,6 +318,10 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatchedDecomposition, m) {
   m.impl("conv_transpose1d", native::conv_transpose1d_symint);
   m.impl("conv_transpose2d.input", native::conv_transpose2d_symint);
   m.impl("conv_transpose3d.input", native::conv_transpose3d_symint);
+  m.impl("conv_transpose1d.padding", native::conv_transpose1d_padding_symint);
+  m.impl("conv_transpose2d.padding", native::conv_transpose2d_padding_symint);
+  m.impl("conv_transpose3d.padding", native::conv_transpose3d_padding_symint);
+  m.impl("_convolution_transpose_mode", native::_convolution_transpose_mode_symint);
   m.impl("conv1d", native::conv1d_symint);
   m.impl("conv2d", native::conv2d_symint);
   m.impl("conv3d", native::conv3d_symint);

--- a/aten/src/ATen/native/ConvUtils.h
+++ b/aten/src/ATen/native/ConvUtils.h
@@ -234,6 +234,33 @@ inline void convolution_shape_check(
   checkSameDim(c, input, output);
 }
 
+// Adapted from jax.
+// https://github.com/jax-ml/jax/blob/6a6a13dcfe5f6dbca4155410dd32dfc2d5bf1cec/jax/_src/lax/convolution.py#L253
+template <typename T>
+std::pair<T, T> _conv_transpose_same_mode_padding_lr(
+  T kernelSize, T stride) {
+  auto total_padding = kernelSize + stride - 2;
+  T left_pad;
+  if (stride >= kernelSize) {
+    left_pad = kernelSize - 1;
+  } else {
+    // The padding on the left is ceil(total_padding / 2)
+    left_pad = (total_padding / 2) + (total_padding % 2);
+  }
+  return {std::move(left_pad), std::move(total_padding - left_pad)};
+}
+
+inline std::pair<int64_t, int64_t> conv_transpose_same_mode_padding_lr(
+    int64_t kernelSize, int64_t stride) {
+  return _conv_transpose_same_mode_padding_lr(kernelSize, stride);
+}
+
+inline std::pair<c10::SymInt, c10::SymInt> conv_transpose_same_mode_padding_lr(
+    c10::SymInt kernelSize, c10::SymInt stride) {
+  return _conv_transpose_same_mode_padding_lr(
+      std::move(kernelSize), std::move(stride));
+}
+
 // NB: conv_output_size and conv_input_size are not bijections,
 // as conv_output_size loses information; this is why conv_input_size
 // takes an extra output_padding argument to resolve the ambiguity.

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -44,6 +44,8 @@
 #include <ATen/ops/_convolution_mode.h>
 #include <ATen/ops/_convolution_mode_native.h>
 #include <ATen/ops/_convolution_native.h>
+#include <ATen/ops/_convolution_transpose_mode.h>
+#include <ATen/ops/_convolution_transpose_mode_native.h>
 #include <ATen/ops/_mps_convolution.h>
 #include <ATen/ops/_mps_convolution_transpose.h>
 #include <ATen/ops/_nnpack_available.h>
@@ -1169,6 +1171,211 @@ at::Tensor conv3d_padding_symint(
     output = complex_convolution_mode(input, weight, bias, stride, padding, dilation, groups);
   } else {
     output = at::_convolution_mode_symint(input, weight, bias, stride, padding, dilation, groups);
+  }
+  return is_batched ? std::move(output) : output.squeeze(0);
+}
+
+// Follows same argument order as conv_transpose*d_symint
+static Tensor convolution_transpose_same(
+    const Tensor& input,
+    const Tensor& weight,
+    const Tensor& bias,
+    SymIntArrayRef stride,
+    SymIntArrayRef output_padding,
+    const c10::SymInt& groups,
+    SymIntArrayRef dilation) {
+  auto k = weight.dim();
+  auto dim = static_cast<size_t>(k - 2);
+  auto weight_sizes = weight.sym_sizes();
+  TORCH_CHECK(k > 2, "weight should have at least three dimensions");
+  TORCH_CHECK(groups > 0, "non-positive groups is not supported");
+  TORCH_CHECK(
+      k == input.dim(),
+      "Expected ",
+      k,
+      "-dimensional input for ",
+      k,
+      "-dimensional weight",
+      weight_sizes,
+      ", but got ",
+      input.dim(),
+      "-dimensional input of size ",
+      input.sizes(),
+      " instead");
+  TORCH_CHECK(
+      stride.size() == dim || stride.size() == 1U,
+      "stride cannot broadcast to ",
+      dim,
+      " dimensions");
+  TORCH_CHECK(
+      dilation.size() == dim || dilation.size() == 1U,
+      "dilation cannot broadcast to ",
+      dim,
+      " dimensions");
+  TORCH_CHECK(
+      output_padding.size() == dim || output_padding.size() == 1U,
+      "output_padding cannot broadcast to ",
+      dim,
+      " dimensions");
+
+  // NOTE: This restriction is here because it exists for traditional
+  // convolutions.
+  for (auto i : c10::irange(stride.size())) {
+    TORCH_CHECK(
+        stride[i] == 1,
+        "padding='same' is not supported for strided convolutions");
+  }
+
+  for (auto i : c10::irange(output_padding.size())) {
+    TORCH_CHECK(
+        output_padding[i] == 0,
+        "padding='same' only supports output_padding=0");
+  }
+
+  // Compute the required padding for each spatial dimension.
+  SymDimVector common_pad_lr, extra_pad_left;
+  for (auto i : c10::irange(dim)) {
+    auto dim_dilation = dilation.size() == 1 ? dilation[0] : dilation[i];
+    auto dim_stride = stride.size() == 1 ? stride[0] : stride[i];
+    auto effective_kernel = dim_dilation * (weight_sizes[i + 2] - 1) + 1;
+    auto pad =
+        conv_transpose_same_mode_padding_lr(effective_kernel, dim_stride);
+
+    auto min_pad = pad.second < pad.first ? pad.second : pad.first;
+    common_pad_lr.push_back(min_pad);
+    extra_pad_left.push_back(pad.first - pad.second);
+  }
+
+  // Compute the convolution, using the smallest needed padding
+  auto convolution_result = at::convolution_symint(
+      input,
+      weight,
+      bias,
+      stride,
+      /*padding=*/common_pad_lr,
+      dilation,
+      /*transposed=*/true,
+      output_padding,
+      groups);
+
+  // crop on the left side to ensure that the output size will be the same as
+  // the input size.
+  // The output is not modified for symmetric convolutions, as extra_pad_left[i]
+  // = 0 for all i.
+  for (auto i : c10::irange(dim)) {
+    if (extra_pad_left[i] > 0) { // Crop left
+      convolution_result = convolution_result.slice_symint(
+          (int64_t)i + 2, extra_pad_left[i]);
+    } else if (extra_pad_left[i] < 0) { // Crop right
+      // NOTE: this section never runs, as stride == 1.
+      // NOTE: this section only runs when:
+      // right_pad > left_pad -> stride > effective_kernel.
+      // See [conv_transpose_same_mode_padding_lr]
+      convolution_result = convolution_result.slice_symint(
+          (int64_t)i + 2,
+          /*start=*/ 0,
+          /*end=*/ convolution_result.size((int64_t)i + 2) + extra_pad_left[i]);
+    }
+  }
+  return convolution_result;
+}
+
+Tensor _convolution_transpose_mode_symint(
+    const Tensor& input, const Tensor& weight, const std::optional<Tensor>& bias_opt,
+    SymIntArrayRef stride, std::string_view padding, SymIntArrayRef output_padding,
+    c10::SymInt groups, SymIntArrayRef dilation) {
+  c10::MaybeOwned<Tensor> bias_maybe_owned = at::borrow_from_optional_tensor(bias_opt);
+  const Tensor& bias = *bias_maybe_owned;
+
+  if (padding == "same") {
+    return at::native::convolution_transpose_same(
+        input, weight, bias, stride, output_padding, groups, dilation);
+  } else if (padding == "valid") {
+    return at::convolution_symint(
+        input, weight, bias, stride, /*padding=*/ {{0}}, dilation, /*transposed=*/ true, output_padding, groups);
+  }
+  TORCH_CHECK(false, "Invalid padding string: '", padding, "'");
+}
+
+static at::Tensor complex_convolution_transpose_mode(
+    const at::Tensor& input, const at::Tensor& weight, const std::optional<at::Tensor>& bias_opt,
+    c10::SymIntArrayRef stride, std::string_view padding, SymIntArrayRef output_padding,
+    const c10::SymInt& groups, c10::SymIntArrayRef dilation) {
+  auto bias = bias_opt.value_or(Tensor());
+  check_input_same_type_as_parameters(input, weight, bias);
+  auto [i_r, i_i] = complex_to_real(input.resolve_conj());
+  auto [w_r, w_i] = complex_to_real(weight.resolve_conj());
+
+  // See [NOTE] Complex Convolution
+  Tensor a, b, c;
+  if (!bias.defined()) {
+    a = at::_convolution_transpose_mode_symint(
+        i_r, w_r, bias, stride, padding, output_padding, groups, dilation);
+    b = at::_convolution_transpose_mode_symint(
+        i_i, w_i, bias, stride, padding, output_padding, groups, dilation);
+    c = at::_convolution_transpose_mode_symint(
+        i_r + i_i, w_r + w_i, bias, stride, padding, output_padding, groups, dilation);
+  } else {
+    auto [b_r, b_i] = complex_to_real(bias.resolve_conj());
+    a = at::_convolution_transpose_mode_symint(
+        i_r, w_r, b_r, stride, padding, output_padding, groups, dilation);
+    b = at::_convolution_transpose_mode_symint(
+        i_i, w_i, Tensor(), stride, padding, output_padding, groups, dilation);
+    c = at::_convolution_transpose_mode_symint(
+        i_r + i_i, w_r + w_i, b_r + b_i, stride, padding, output_padding, groups, dilation);
+  }
+
+  auto i = c10::Scalar(c10::complex<double>(0, 1));
+  return a - b + i * (c - a - b);
+}
+
+at::Tensor conv_transpose1d_padding_symint(
+    const Tensor& input_, const Tensor& weight, const std::optional<Tensor>& bias_opt,
+    c10::SymIntArrayRef stride, std::string_view padding, SymIntArrayRef output_padding,
+  c10::SymInt groups, c10::SymIntArrayRef dilation) {
+  c10::MaybeOwned<Tensor> bias_maybe_owned = at::borrow_from_optional_tensor(bias_opt);
+  const Tensor& bias = *bias_maybe_owned;
+
+  auto [input, is_batched] = batchify(input_, /*num_spatial_dims=*/ 1, "conv_transpose1d");
+  Tensor output;
+  if (at::isComplexType(input_.scalar_type())) {
+    output = complex_convolution_transpose_mode(input, weight, bias, stride, padding, output_padding, groups, dilation);
+  } else {
+    output = at::_convolution_transpose_mode_symint(input, weight, bias, stride, padding, output_padding, groups, dilation);
+  }
+  return is_batched ? std::move(output) : output.squeeze(0);
+}
+
+at::Tensor conv_transpose2d_padding_symint(
+    const Tensor& input_, const Tensor& weight, const std::optional<Tensor>& bias_opt,
+    c10::SymIntArrayRef stride, std::string_view padding, SymIntArrayRef output_padding,
+  c10::SymInt groups, c10::SymIntArrayRef dilation) {
+  c10::MaybeOwned<Tensor> bias_maybe_owned = at::borrow_from_optional_tensor(bias_opt);
+  const Tensor& bias = *bias_maybe_owned;
+
+  auto [input, is_batched] = batchify(input_, /*num_spatial_dims=*/ 2, "conv_transpose2d");
+  Tensor output;
+  if (at::isComplexType(input_.scalar_type())) {
+    output = complex_convolution_transpose_mode(input, weight, bias, stride, padding, output_padding, groups, dilation);
+  } else {
+    output = at::_convolution_transpose_mode_symint(input, weight, bias, stride, padding, output_padding, groups, dilation);
+  }
+  return is_batched ? std::move(output) : output.squeeze(0);
+}
+
+at::Tensor conv_transpose3d_padding_symint(
+    const Tensor& input_, const Tensor& weight, const std::optional<Tensor>& bias_opt,
+    c10::SymIntArrayRef stride, std::string_view padding, SymIntArrayRef output_padding,
+  c10::SymInt groups, c10::SymIntArrayRef dilation) {
+  c10::MaybeOwned<Tensor> bias_maybe_owned = at::borrow_from_optional_tensor(bias_opt);
+  const Tensor& bias = *bias_maybe_owned;
+
+  auto [input, is_batched] = batchify(input_, /*num_spatial_dims=*/ 3, "conv_transpose3d");
+  Tensor output;
+  if (at::isComplexType(input_.scalar_type())) {
+    output = complex_convolution_transpose_mode(input, weight, bias, stride, padding, output_padding, groups, dilation);
+  } else {
+    output = at::_convolution_transpose_mode_symint(input, weight, bias, stride, padding, output_padding, groups, dilation);
   }
   return is_batched ? std::move(output) : output.squeeze(0);
 }

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -1242,7 +1242,7 @@ static Tensor convolution_transpose_same(
         conv_transpose_same_mode_padding_lr(effective_kernel, dim_stride);
 
     auto min_pad = pad.second < pad.first ? pad.second : pad.first;
-    common_pad_lr.push_back(min_pad);
+    common_pad_lr.push_back(std::move(min_pad));
     extra_pad_left.push_back(pad.first - pad.second);
   }
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1749,6 +1749,10 @@
 
 - func: conv_tbc_backward(Tensor self, Tensor input, Tensor weight, Tensor bias, int pad) -> (Tensor, Tensor, Tensor)
 
+- func: _convolution_transpose_mode(Tensor input, Tensor weight, Tensor? bias, SymInt[] stride, str padding, SymInt[] output_padding, SymInt groups, SymInt[] dilation) -> Tensor
+  dispatch:
+    CompositeImplicitAutograd: _convolution_transpose_mode_symint
+
 # NB: we inherit the goofy argument order from PyTorch torch.nn.functional
 - func: conv_transpose1d(Tensor input, Tensor weight, Tensor? bias=None, SymInt[1] stride=1, SymInt[1] padding=0, SymInt[1] output_padding=0, SymInt groups=1, SymInt[1] dilation=1) -> Tensor
   dispatch:
@@ -1761,6 +1765,18 @@
 - func: conv_transpose3d.input(Tensor input, Tensor weight, Tensor? bias=None, SymInt[3] stride=1, SymInt[3] padding=0, SymInt[3] output_padding=0, SymInt groups=1, SymInt[3] dilation=1) -> Tensor
   dispatch:
     CompositeImplicitAutograd: conv_transpose3d_symint
+
+- func: conv_transpose1d.padding(Tensor input, Tensor weight, Tensor? bias=None, SymInt[1] stride=1, str padding="valid", SymInt[1] output_padding=0, SymInt groups=1, SymInt[1] dilation=1) -> Tensor
+  dispatch:
+    CompositeImplicitAutograd: conv_transpose1d_padding_symint
+
+- func: conv_transpose2d.padding(Tensor input, Tensor weight, Tensor? bias=None, SymInt[2] stride=1, str padding="valid", SymInt[2] output_padding=0, SymInt groups=1, SymInt[2] dilation=1) -> Tensor
+  dispatch:
+    CompositeImplicitAutograd: conv_transpose2d_padding_symint
+
+- func: conv_transpose3d.padding(Tensor input, Tensor weight, Tensor? bias=None, SymInt[3] stride=1, str padding="valid", SymInt[3] output_padding=0, SymInt groups=1, SymInt[3] dilation=1) -> Tensor
+  dispatch:
+    CompositeImplicitAutograd: conv_transpose3d_padding_symint
 
 - func: copy(Tensor self, Tensor src, bool non_blocking=False) -> Tensor
   variants: function

--- a/test/allowlist_for_publicAPI.json
+++ b/test/allowlist_for_publicAPI.json
@@ -1129,7 +1129,6 @@
     "_convert_indices_from_csr_to_coo",
     "_convolution",
     "_convolution_mode",
-    "_convolution_transpose_mode",
     "_copy_from",
     "_copy_from_and_resize",
     "_ctc_loss",

--- a/test/allowlist_for_publicAPI.json
+++ b/test/allowlist_for_publicAPI.json
@@ -1129,6 +1129,7 @@
     "_convert_indices_from_csr_to_coo",
     "_convolution",
     "_convolution_mode",
+    "_convolution_transpose_mode",
     "_copy_from",
     "_copy_from_and_resize",
     "_ctc_loss",

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -447,7 +447,9 @@ TEST_F(ModulesTest, ConvTranspose3dSameOutputPadding) {
   options.stride({1, 1, 1}).output_padding({0, 0, 0}).padding(torch::kSame);
   ConvTranspose3d model_valid(options);
   ASSERT_THROWS_WITH(
-      [&] { ConvTranspose3d model_invalid(options.output_padding({0, 0, 3})); }(),
+      [&] {
+        ConvTranspose3d model_invalid(options.output_padding({0, 0, 3}));
+      }(),
       "padding='same' only supports output_padding=0, but got 3 at dimension 2.");
 }
 

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -203,6 +203,68 @@ TEST_F(ModulesTest, ConvTranspose1d) {
   ASSERT_EQ(model->weight.grad().numel(), 3 * 2 * 3);
 }
 
+TEST_F(ModulesTest, ConvTranspose1dSameForwardSymmetric) {
+  ConvTranspose1d model(
+      ConvTranspose1dOptions(3, 2, 3).stride(1).bias(false).padding(
+          torch::kSame));
+  model->weight.set_data(torch::arange(18.).view({2, 3, 3}));
+  auto x = torch::arange(20.).reshape({2, 2, 5});
+  auto y = model(x);
+  auto expected = torch::tensor(
+      {{{104., 179., 212., 245., 188.},
+        {140., 242., 293., 344., 260.},
+        {176., 305., 374., 443., 332.}},
+       {{304., 509., 542., 575., 428.},
+        {460., 752., 803., 854., 620.},
+        {616., 995., 1064., 1133., 812.}}});
+  ASSERT_TRUE(torch::allclose(y, expected));
+
+  torch::Tensor s = y.sum();
+  s.backward();
+  ASSERT_EQ(s.ndimension(), 0);
+  ASSERT_EQ(model->weight.grad().numel(), 3 * 2 * 3);
+}
+
+TEST_F(ModulesTest, ConvTranspose1dSameForwardAsymmetric) {
+  ConvTranspose1d model(
+      ConvTranspose1dOptions(3, 2, 3).stride(1).bias(false).padding(
+          torch::kSame));
+  model->weight.set_data(torch::arange(24.).view({2, 3, 4}));
+  auto x = torch::arange(20.).reshape({2, 2, 5});
+  auto y = model(x);
+  auto expected = torch::tensor(
+      {{{233., 350., 410., 350., 263.},
+        {317., 478., 570., 482., 359.},
+        {401., 606., 730., 614., 455.}},
+       {{653., 950., 1010., 830., 603.},
+        {977., 1398., 1490., 1202., 859.},
+        {1301., 1846., 1970., 1574., 1115.}}});
+  ASSERT_TRUE(torch::allclose(y, expected));
+
+  torch::Tensor s = y.sum();
+  s.backward();
+  ASSERT_EQ(s.ndimension(), 0);
+  ASSERT_EQ(model->weight.grad().numel(), 3 * 2 * 4);
+}
+
+TEST_F(ModulesTest, ConvTranspose1dSameStrided) {
+  auto options = ConvTranspose1dOptions(3, 2, 3);
+  options.stride(1).padding(torch::kSame);
+  ConvTranspose1d model_valid(options);
+  ASSERT_THROWS_WITH(
+      [&] { ConvTranspose1d model_invalid(options.stride(2)); }(),
+      "padding='same' is not supported for strided convolutions");
+}
+
+TEST_F(ModulesTest, ConvTranspose1dSameOutputPadding) {
+  auto options = ConvTranspose1dOptions(3, 2, 3);
+  options.stride(1).output_padding(0).padding(torch::kSame);
+  ConvTranspose1d model_valid(options);
+  ASSERT_THROWS_WITH(
+      [&] { ConvTranspose1d model_invalid(options.output_padding(1)); }(),
+      "padding='same' only supports output_padding=0, but got 1 at dimension 0.");
+}
+
 TEST_F(ModulesTest, ConvTranspose2dEven) {
   ConvTranspose2d model(ConvTranspose2dOptions(3, 2, 3).stride(1).bias(false));
   model->weight.set_data(torch::arange(54.).view({2, 3, 3, 3}));
@@ -274,6 +336,62 @@ TEST_F(ModulesTest, ConvTranspose2dUneven) {
   ASSERT_EQ(model->weight.grad().numel(), 3 * 2 * 3 * 2);
 }
 
+TEST_F(ModulesTest, ConvTranspose2dSameForward) {
+  ConvTranspose2d model(ConvTranspose2dOptions(3, 2, {3, 2})
+                            .stride(1)
+                            .bias(false)
+                            .padding(torch::kSame));
+  model->weight.set_data(torch::arange(36.).view({2, 3, 3, 2}));
+  auto x = torch::arange(50.).view({1, 2, 5, 5});
+  auto y = model(x);
+
+  // NOTE: The padding is symmetric on Height dimension (crop 1 on each side).
+  // The padding is asymmetric on width dimension,
+  // crop 1 on left and 0 on right.
+  auto expected = torch::tensor(
+      {{{{2180., 2264., 2348., 2432., 1276.},
+         {3751., 3889., 4027., 4165., 2183.},
+         {4441., 4579., 4717., 4855., 2543.},
+         {5131., 5269., 5407., 5545., 2903.},
+         {3928., 4028., 4128., 4228., 2208.}},
+
+        {{2924., 3056., 3188., 3320., 1732.},
+         {5047., 5257., 5467., 5677., 2957.},
+         {6097., 6307., 6517., 6727., 3497.},
+         {7147., 7357., 7567., 7777., 4037.},
+         {5392., 5540., 5688., 5836., 3024.}},
+
+        {{3668., 3848., 4028., 4208., 2188.},
+         {6343., 6625., 6907., 7189., 3731.},
+         {7753., 8035., 8317., 8599., 4451.},
+         {9163., 9445., 9727., 10009., 5171.},
+         {6856., 7052., 7248., 7444., 3840.}}}});
+  ASSERT_TRUE(torch::allclose(y, expected));
+
+  torch::Tensor s = y.sum();
+  s.backward();
+  ASSERT_EQ(s.ndimension(), 0);
+  ASSERT_EQ(model->weight.grad().numel(), 3 * 2 * 3 * 2);
+}
+
+TEST_F(ModulesTest, ConvTranspose2dSameStrided) {
+  auto options = ConvTranspose2dOptions(3, 2, {3, 2});
+  options.stride({1, 1}).padding(torch::kSame);
+  ConvTranspose2d model_valid(options);
+  ASSERT_THROWS_WITH(
+      [&] { ConvTranspose2d model_invalid(options.stride({1, 2})); }(),
+      "padding='same' is not supported for strided convolutions");
+}
+
+TEST_F(ModulesTest, ConvTranspose2dSameOutputPadding) {
+  auto options = ConvTranspose2dOptions(3, 2, {3, 2});
+  options.stride({1, 1}).output_padding({0, 0}).padding(torch::kSame);
+  ConvTranspose2d model_valid(options);
+  ASSERT_THROWS_WITH(
+      [&] { ConvTranspose2d model_invalid(options.output_padding({0, 1})); }(),
+      "padding='same' only supports output_padding=0, but got 1 at dimension 1.");
+}
+
 TEST_F(ModulesTest, ConvTranspose3d) {
   ConvTranspose3d model(ConvTranspose3dOptions(2, 2, 2).stride(1).bias(false));
   model->weight.set_data(torch::arange(32.).reshape({2, 2, 2, 2, 2}));
@@ -292,6 +410,45 @@ TEST_F(ModulesTest, ConvTranspose3d) {
   s.backward();
   ASSERT_EQ(s.ndimension(), 0);
   ASSERT_TRUE(model->weight.grad().numel() == 2 * 2 * 2 * 2 * 2);
+}
+
+TEST_F(ModulesTest, ConvTranspose3dSameForward) {
+  ConvTranspose3d model(
+      ConvTranspose3dOptions(2, 2, 2).stride(1).bias(false).padding(
+          torch::kSame));
+  model->weight.set_data(torch::arange(72.).reshape({2, 3, 2, 3, 2}));
+  auto x = torch::arange(16.).reshape({1, 2, 2, 2, 2});
+  auto y = model(x);
+  // crops (left, right): 1st_dim (1, 0); 2nd_dim (1, 1); 3rd_dim (1, 0).
+  auto expected = torch::tensor(
+      {{{{3736., 1992.}, {3976., 2120.}}, {{2504., 1324.}, {2656., 1404.}}},
+       {{{5176., 2760.}, {5416., 2888.}}, {{3416., 1804.}, {3568., 1884.}}},
+       {{{6616., 3528.}, {6856., 3656.}}, {{4328., 2284.}, {4480., 2364.}}}});
+
+  ASSERT_TRUE(torch::allclose(y, expected));
+
+  torch::Tensor s = y.sum();
+  s.backward();
+  ASSERT_EQ(s.ndimension(), 0);
+  ASSERT_TRUE(model->weight.grad().numel() == 2 * 3 * 2 * 3 * 2);
+}
+
+TEST_F(ModulesTest, ConvTranspose3dSameStrided) {
+  auto options = ConvTranspose3dOptions(2, 2, 2);
+  options.stride({1, 1, 1}).padding(torch::kSame);
+  ConvTranspose3d model_valid(options);
+  ASSERT_THROWS_WITH(
+      [&] { ConvTranspose3d model_invalid(options.stride({1, 2, 1})); }(),
+      "padding='same' is not supported for strided convolutions");
+}
+
+TEST_F(ModulesTest, ConvTranspose3dSameOutputPadding) {
+  auto options = ConvTranspose3dOptions(2, 2, 2);
+  options.stride({1, 1, 1}).output_padding({0, 0, 0}).padding(torch::kSame);
+  ConvTranspose3d model_valid(options);
+  ASSERT_THROWS_WITH(
+      [&] { ConvTranspose3d model_invalid(options.output_padding({0, 0, 3})); }(),
+      "padding='same' only supports output_padding=0, but got 3 at dimension 2.");
 }
 
 TEST_F(ModulesTest, MaxPool1d) {
@@ -4629,6 +4786,15 @@ TEST_F(ModulesTest, PrettyPrintConvTranspose) {
   ASSERT_EQ(
       c10::str(ConvTranspose1d(3, 4, 5)),
       "torch::nn::ConvTranspose1d(3, 4, kernel_size=5, stride=1)");
+  {
+    auto options = ConvTranspose1dOptions(3, 4, 5);
+    ASSERT_EQ(
+        c10::str(ConvTranspose1d(options.padding(torch::kSame))),
+        "torch::nn::ConvTranspose1d(3, 4, kernel_size=5, stride=1, padding='same')");
+    ASSERT_EQ(
+        c10::str(ConvTranspose1d(options.padding(torch::kValid))),
+        "torch::nn::ConvTranspose1d(3, 4, kernel_size=5, stride=1, padding='valid')");
+  }
 
   ASSERT_EQ(
       c10::str(ConvTranspose2d(3, 4, 5)),
@@ -4636,6 +4802,15 @@ TEST_F(ModulesTest, PrettyPrintConvTranspose) {
   ASSERT_EQ(
       c10::str(ConvTranspose2d(ConvTranspose2dOptions(3, 4, 5).stride(2))),
       "torch::nn::ConvTranspose2d(3, 4, kernel_size=[5, 5], stride=[2, 2])");
+  {
+    auto options = ConvTranspose2dOptions(3, 4, std::vector<int64_t>{5, 6});
+    ASSERT_EQ(
+        c10::str(ConvTranspose2d(options.padding(torch::kSame))),
+        "torch::nn::ConvTranspose2d(3, 4, kernel_size=[5, 6], stride=[1, 1], padding='same')");
+    ASSERT_EQ(
+        c10::str(ConvTranspose2d(options.padding(torch::kValid))),
+        "torch::nn::ConvTranspose2d(3, 4, kernel_size=[5, 6], stride=[1, 1], padding='valid')");
+  }
   {
     const auto options =
         ConvTranspose2dOptions(3, 4, std::vector<int64_t>{5, 6}).stride({1, 2});
@@ -4668,6 +4843,15 @@ TEST_F(ModulesTest, PrettyPrintConvTranspose) {
         "groups=2, "
         "bias=false, "
         "padding_mode=kCircular)");
+  }
+  {
+    auto options = ConvTranspose3dOptions(3, 4, std::vector<int64_t>{5, 6, 7});
+    ASSERT_EQ(
+        c10::str(ConvTranspose3d(options.padding(torch::kSame))),
+        "torch::nn::ConvTranspose3d(3, 4, kernel_size=[5, 6, 7], stride=[1, 1, 1], padding='same')");
+    ASSERT_EQ(
+        c10::str(ConvTranspose3d(options.padding(torch::kValid))),
+        "torch::nn::ConvTranspose3d(3, 4, kernel_size=[5, 6, 7], stride=[1, 1, 1], padding='valid')");
   }
 }
 

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -2265,6 +2265,549 @@ class TestConvolutionNNDeviceType(NNTestCase):
             check_fwd_over_rev=check_forward_ad,
         )
 
+    # conv_transpose*d_padding_* tests adapted from conv*d_padding_*
+
+    def test_ConvTranspose1d_module_same_padding(self):
+        # Compare module against functional: without strides/dilation, asymmetric padding
+        x = torch.rand(1, 1, 20)
+        module = nn.ConvTranspose1d(
+            in_channels=1, out_channels=1, kernel_size=10, padding="same"
+        )
+        expect = F.conv_transpose1d(x, module.weight, module.bias, padding="same")
+        self.assertEqual(expect, module(x))
+
+        # Test dilation, symmetric padding
+        module = nn.ConvTranspose1d(
+            in_channels=1, out_channels=1, kernel_size=10, padding="same", dilation=2
+        )
+        expect = F.conv_transpose1d(
+            x, module.weight, module.bias, padding="same", dilation=2
+        )
+        self.assertEqual(expect, module(x))
+
+        # Test connstruction with invalid padding string raises
+        with self.assertRaisesRegex(ValueError, "Invalid padding string"):
+            module = nn.ConvTranspose1d(
+                in_channels=3, out_channels=33, kernel_size=10, padding="foo"
+            )
+
+        # Test connstruction with same padding and strides raises
+        with self.assertRaisesRegex(
+            ValueError, "^padding='same' is not supported for strided convolutions$"
+        ):
+            module = nn.ConvTranspose1d(
+                in_channels=3, out_channels=33, kernel_size=10, padding="same", stride=2
+            )
+
+    def test_ConvTranspose2d_module_same_padding(self):
+        # Compare module against functional:
+        # without strides/dilation, both symmetric and asymmetric padding
+        x = torch.rand(1, 1, 9, 20)
+        module = nn.ConvTranspose2d(
+            in_channels=1, out_channels=1, kernel_size=(5, 10), padding="same"
+        )
+        expect = F.conv_transpose2d(x, module.weight, module.bias, padding="same")
+        self.assertEqual(expect, module(x))
+
+        # with dilation, symmetric padding
+        module = nn.ConvTranspose2d(
+            in_channels=1,
+            out_channels=1,
+            kernel_size=(3, 4),
+            padding="same",
+            dilation=(1, 2),
+        )
+        expect = F.conv_transpose2d(
+            x, module.weight, module.bias, padding="same", dilation=(1, 2)
+        )
+        self.assertEqual(expect, module(x))
+
+        # Test connstruction with invalid padding string raises
+        with self.assertRaisesRegex(ValueError, "Invalid padding string"):
+            module = nn.ConvTranspose2d(
+                in_channels=3, out_channels=33, kernel_size=10, padding="foo"
+            )
+
+        # Test connstruction with same padding and strides raises
+        with self.assertRaisesRegex(
+            ValueError, "^padding='same' is not supported for strided convolutions$"
+        ):
+            module = nn.ConvTranspose2d(
+                in_channels=3, out_channels=33, kernel_size=10, padding="same", stride=2
+            )
+        with self.assertRaisesRegex(
+            ValueError, "^padding='same' is not supported for strided convolutions$"
+        ):
+            module = nn.ConvTranspose2d(
+                in_channels=3,
+                out_channels=33,
+                kernel_size=10,
+                padding="same",
+                stride=(1, 3),
+            )
+        with self.assertRaisesRegex(
+            ValueError, "^padding='same' is not supported for strided convolutions$"
+        ):
+            module = nn.ConvTranspose2d(
+                in_channels=3,
+                out_channels=33,
+                kernel_size=10,
+                padding="same",
+                stride=(4, 1),
+            )
+
+    def test_ConvTranspose3d_module_same_padding(self):
+        # Compare module against functional:
+        x = torch.rand(1, 1, 4, 4, 4)
+        # without dilation, both symmetric and asymmetric padding
+        module = nn.ConvTranspose3d(
+            in_channels=1, out_channels=1, kernel_size=(2, 3, 4), padding="same"
+        )
+        expect = F.conv_transpose3d(x, module.weight, module.bias, padding="same")
+        self.assertEqual(expect, module(x))
+
+        # with dilation, both symmetric and asymmetric padding
+        module = nn.ConvTranspose3d(
+            in_channels=1,
+            out_channels=1,
+            kernel_size=(2, 3, 4),
+            padding="same",
+            dilation=(3, 2, 1),
+        )
+        expect = F.conv_transpose3d(
+            x, module.weight, module.bias, padding="same", dilation=(3, 2, 1)
+        )
+        self.assertEqual(expect, module(x))
+
+        # Test connstruction with invalid padding string raises
+        with self.assertRaisesRegex(ValueError, "Invalid padding string"):
+            module = nn.ConvTranspose3d(
+                in_channels=3, out_channels=33, kernel_size=10, padding="foo"
+            )
+
+        # Test connstruction with same padding and strides raises
+        with self.assertRaisesRegex(
+            ValueError, "^padding='same' is not supported for strided convolutions$"
+        ):
+            module = nn.ConvTranspose3d(
+                in_channels=3, out_channels=33, kernel_size=10, padding="same", stride=2
+            )
+        with self.assertRaisesRegex(
+            ValueError, "^padding='same' is not supported for strided convolutions$"
+        ):
+            module = nn.ConvTranspose3d(
+                in_channels=3,
+                out_channels=33,
+                kernel_size=10,
+                padding="same",
+                stride=(1, 1, 3),
+            )
+        with self.assertRaisesRegex(
+            ValueError, "^padding='same' is not supported for strided convolutions$"
+        ):
+            module = nn.ConvTranspose3d(
+                in_channels=3,
+                out_channels=33,
+                kernel_size=10,
+                padding="same",
+                stride=(1, 4, 1),
+            )
+        with self.assertRaisesRegex(
+            ValueError, "^padding='same' is not supported for strided convolutions$"
+        ):
+            module = nn.ConvTranspose3d(
+                in_channels=3,
+                out_channels=33,
+                kernel_size=10,
+                padding="same",
+                stride=(5, 1, 1),
+            )
+
+    @dtypesIfMPS(
+        *([torch.float] if MACOS_VERSION < 14.0 else [torch.float, torch.cfloat])
+    )  # Complex not supported on MacOS13
+    @dtypes(torch.float, torch.cfloat)
+    def test_conv_transpose1d_same_padding(self, device, dtype):
+        if dtype is torch.cfloat:
+            rtol, atol = 2e-6, 2e-6
+        else:
+            rtol, atol = None, None
+
+        # Test padding='same' outputs the correct shape and results
+        test_args = [
+            # in_size
+            range(50, 55),
+            # kernel_size
+            [1, 2, 3, 100, 101],
+            # dilation
+            range(1, 4),
+            # stride
+            [1],
+        ]
+        for in_size, k_size, dilation, stride in itertools.product(*test_args):
+            input_ = torch.rand(1, 1, in_size, device=device, dtype=dtype)
+            kernel = torch.rand(1, 1, k_size, device=device, dtype=dtype)
+            actual = F.conv_transpose1d(
+                input_, kernel, padding="same", dilation=dilation, stride=stride
+            )
+
+            # test output_size is equal to input_size
+            self.assertEqual(actual.size(2), in_size)
+
+            effective_kernel_size = dilation * (k_size - 1)
+            is_asymmetric_padding = effective_kernel_size % 2 == 1
+            common_pad = effective_kernel_size // 2
+
+            expect = F.conv_transpose1d(
+                input_, kernel, stride=stride, padding=common_pad, dilation=dilation
+            )
+
+            # asymmetric padding for transposed convolution removes the extra value on the right side
+            if is_asymmetric_padding:
+                expect = expect[:, :, 1:]
+
+            self.assertEqual(expect, actual, rtol=rtol, atol=atol)
+
+    @dtypesIfMPS(
+        *([torch.float] if MACOS_VERSION < 14.0 else [torch.float, torch.cfloat])
+    )  # Complex not supported on MacOS13
+    @dtypes(torch.float, torch.cfloat)
+    def test_conv_transpose2d_same_padding(self, device, dtype):
+        if dtype is torch.cfloat:
+            rtol, atol = 2e-6, 2e-6
+        else:
+            rtol, atol = None, None
+        # transpose convolution output size:
+        # o = (i - 1) * s + (k - 1) * d - (2 * p) + 1
+
+        # Compare F.conv_transpose2d padding='same' output against manual padding
+        # Without strides/dilation
+        x = torch.rand(1, 1, 10, 11, device=device, dtype=dtype)  # Bsize, Cin, Hin, Win
+        y = torch.rand(1, 1, 4, 5, device=device, dtype=dtype)
+        # same convolution ensures that o = i
+        # To satisfy this, p = (k - 1) / 2
+        # for k = 4, the padding is asymmetric (p = 1.5),
+        # so we will slice two units on the left and one on the right.
+        # For k = 5, the padding is symetric (p = 2)
+        expect = F.conv_transpose2d(x, y, padding=(1, 2))[..., 1:, :]
+        actual = F.conv_transpose2d(x, y, padding="same")
+        self.assertEqual(expect, actual, rtol=rtol, atol=atol)
+
+        # With dilation, the padding is p = d * (k-1) / 2
+        expect = F.conv_transpose2d(x, y, padding=(3, 4), dilation=2)
+        actual = F.conv_transpose2d(x, y, padding="same", dilation=2)
+        self.assertEqual(expect, actual, rtol=rtol, atol=atol)
+
+        # Dilation with asymmetric padding
+        y = torch.rand(1, 1, 4, 4, device=device, dtype=dtype)
+        expect = F.conv_transpose2d(x, y, padding=10, dilation=7)[..., 1:, 1:]
+        actual = F.conv_transpose2d(x, y, padding="same", dilation=7)
+        self.assertEqual(expect, actual, rtol=rtol, atol=atol)
+
+    @dtypes(torch.float, torch.cfloat)
+    def test_conv_transpose3d_same_padding(self, device, dtype):
+        if dtype is torch.cfloat:
+            rtol, atol = 2e-6, 2e-6
+        else:
+            rtol, atol = None, None
+        # Compare F.conv3d padding='same' output against manual padding
+        # Without strides/dilation
+        x = torch.rand(1, 1, 10, 11, 12, device=device, dtype=dtype)
+        y = torch.rand(1, 1, 1, 2, 5, device=device, dtype=dtype)
+        expect = F.conv_transpose3d(x, y, padding=(0, 0, 2))[..., :, 1:, :]
+        actual = F.conv_transpose3d(x, y, padding="same")
+        self.assertEqual(expect, actual, rtol=rtol, atol=atol)
+
+        # With dilation
+        expect = F.conv_transpose3d(x, y, padding=(0, 1, 4), dilation=2)
+        actual = F.conv_transpose3d(x, y, padding="same", dilation=2)
+        self.assertEqual(expect, actual, rtol=rtol, atol=atol)
+
+        # Dilation with asymmetric padding
+        y = torch.rand(1, 1, 4, 4, 4, device=device, dtype=dtype)
+        expect = F.conv_transpose3d(x, y, padding=4, dilation=3)[..., 1:, 1:, 1:]
+        actual = F.conv_transpose3d(x, y, padding="same", dilation=3)
+        self.assertEqual(expect, actual, rtol=rtol, atol=atol)
+
+    @dtypes(torch.float, torch.cfloat)
+    @dtypesIfMPS(
+        *([torch.float] if MACOS_VERSION < 14.0 else [torch.float, torch.cfloat])
+    )  # Complex not supported on MacOS13
+    def test_conv_transpose1d_valid_padding(self, device, dtype):
+        # Test F.conv_transpose1d padding='valid' is the same as no padding
+        x = torch.rand(1, 1, 10, device=device, dtype=dtype)
+        y = torch.rand(1, 1, 4, device=device, dtype=dtype)
+        expect = F.conv_transpose1d(x, y)
+        actual = F.conv_transpose1d(x, y, padding="valid")
+        self.assertEqual(expect, actual)
+
+    @dtypes(torch.float, torch.cfloat)
+    @dtypesIfMPS(
+        *([torch.float] if MACOS_VERSION < 14.0 else [torch.float, torch.cfloat])
+    )  # Complex not supported on MacOS13
+    def test_conv_transpose2d_valid_padding(self, device, dtype):
+        # Test F.conv_transpose2d padding='valid' is the same as no padding
+        x = torch.rand(1, 1, 1, 10, device=device, dtype=dtype)
+        y = torch.rand(1, 1, 1, 4, device=device, dtype=dtype)
+        expect = F.conv_transpose2d(x, y)
+        actual = F.conv_transpose2d(x, y, padding="valid")
+        self.assertEqual(expect, actual)
+
+    @dtypes(torch.float, torch.cfloat)
+    def test_conv_transpose3d_valid_padding(self, device, dtype):
+        # Test F.conv_transpose3d padding='valid' is the same as no padding
+        x = torch.rand(1, 1, 1, 1, 10, dtype=dtype, device=device)
+        y = torch.rand(1, 1, 1, 1, 4, dtype=dtype, device=device)
+        expect = F.conv_transpose3d(x, y)
+        actual = F.conv_transpose3d(x, y, padding="valid")
+        self.assertEqual(expect, actual)
+
+    @dtypes(torch.float, torch.cfloat)
+    @dtypesIfMPS(torch.float)
+    def test_conv_transpose1d_same_padding_backward(self, device, dtype):
+        # Test F.conv_transpose1d gradients work with padding='same'
+        x = torch.rand(1, 1, 12, dtype=dtype, device=device, requires_grad=True)
+        y = torch.rand(1, 1, 4, dtype=dtype, device=device, requires_grad=True)
+
+        # Symmetric padding
+        z = F.conv_transpose1d(x, y, padding=3, dilation=2)
+        z.sum().abs().backward()
+        gx_expect, gy_expect = x.grad, y.grad
+        x.grad, y.grad = None, None
+
+        z = F.conv_transpose1d(x, y, padding="same", dilation=2)
+        z.sum().abs().backward()
+        self.assertEqual(gx_expect, x.grad)
+        self.assertEqual(gy_expect, y.grad)
+        x.grad, y.grad = None, None
+
+        # Asymmetric padding
+        z = F.conv_transpose1d(x, y, padding=1)[..., 1:]
+        z.sum().abs().backward()
+        gx_expect, gy_expect = x.grad, y.grad
+        x.grad, y.grad = None, None
+
+        z = F.conv_transpose1d(x, y, padding="same")
+        z.sum().abs().backward()
+        self.assertEqual(gx_expect, x.grad)
+        self.assertEqual(gy_expect, y.grad)
+
+    @dtypes(torch.float, torch.cfloat)
+    @dtypesIfMPS(
+        *([torch.float] if MACOS_VERSION < 14.0 else [torch.float, torch.cfloat])
+    )  # Complex not supported on MacOS13
+    @tf32_on_and_off(0.001)
+    def test_conv_transpose2d_same_padding_backward(self, device, dtype):
+        # Test F.conv_transpose2d gradients work with padding='same'
+        x = torch.rand(1, 1, 10, 11, device=device, dtype=dtype, requires_grad=True)
+        y = torch.rand(1, 1, 4, 5, device=device, dtype=dtype, requires_grad=True)
+
+        # Symmetric padding
+        z = F.conv_transpose2d(x, y, padding=(3, 4), dilation=2)
+        z.sum().abs().backward()
+        gx_expect, gy_expect = x.grad, y.grad
+        x.grad, y.grad = None, None
+
+        z = F.conv_transpose2d(x, y, padding="same", dilation=2)
+        z.sum().abs().backward()
+        self.assertEqual(gx_expect, x.grad)
+        self.assertEqual(gy_expect, y.grad)
+        x.grad, y.grad = None, None
+
+        # Asymmetric padding
+        y = torch.rand(1, 1, 4, 4, device=device, dtype=dtype, requires_grad=True)
+        z = F.conv_transpose2d(x, y, padding=1)[..., 1:, 1:]
+        z.sum().abs().backward()
+        gx_expect, gy_expect = x.grad, y.grad
+        x.grad, y.grad = None, None
+
+        z = F.conv_transpose2d(x, y, padding="same")
+        z.sum().abs().backward()
+        self.assertEqual(gx_expect, x.grad)
+        self.assertEqual(gy_expect, y.grad)
+
+    @dtypes(torch.double, torch.cdouble)
+    @dtypesIfMPS(
+        torch.float, torch.cfloat
+    )  # Double, complex double not supported on MPS
+    @expectedFailureMPS  # https://github.com/pytorch/pytorch/issues/107214
+    def test_conv_transpose3d_same_padding_backward(self, device, dtype):
+        check_forward_ad = torch.device(device).type != "xla"
+
+        # Test F.conv_transpose3d gradients work with padding='same'
+        x = torch.rand(1, 1, 1, 11, 12, dtype=dtype, device=device, requires_grad=True)
+        y = torch.rand(1, 1, 1, 2, 5, dtype=dtype, device=device, requires_grad=True)
+
+        # Symmetric padding
+        z = F.conv_transpose3d(x, y, padding=(0, 1, 4), dilation=2)
+        z.sum().abs().backward()
+        gx_expect, gy_expect = x.grad, y.grad
+        x.grad, y.grad = None, None
+
+        z = F.conv_transpose3d(x, y, padding="same", dilation=2)
+        z.sum().abs().backward()
+        self.assertEqual(gx_expect, x.grad)
+        self.assertEqual(gy_expect, y.grad)
+        x.grad, y.grad = None, None
+
+        gradcheck(
+            lambda x, y: F.conv_transpose3d(x, y, padding="same", dilation=2),
+            (x, y),
+            check_forward_ad=check_forward_ad,
+            nondet_tol=1e-5,
+        )
+        if torch.device(device).type != "cuda":
+            gradgradcheck(
+                lambda x, y: F.conv_transpose3d(x, y, padding="same", dilation=2),
+                (x, y),
+                check_fwd_over_rev=True,
+            )
+
+        # Asymmetric padding
+        y = torch.rand(1, 1, 1, 4, 8, dtype=dtype, device=device, requires_grad=True)
+        z = F.conv_transpose3d(x, y, padding=(0, 1, 3))[..., 1:, 1:]
+        z.sum().abs().backward()
+        gx_expect, gy_expect = x.grad, y.grad
+        x.grad, y.grad = None, None
+
+        z = F.conv_transpose3d(x, y, padding="same")
+        z.sum().abs().backward()
+        self.assertEqual(gx_expect, x.grad)
+        self.assertEqual(gy_expect, y.grad)
+
+        gradcheck(
+            lambda x, y: F.conv_transpose3d(x, y, padding="same"),
+            (x, y),
+            check_forward_ad=check_forward_ad,
+            nondet_tol=1e-5,
+        )
+        if torch.device(device).type != "cuda":
+            gradgradcheck(
+                lambda x, y: F.conv_transpose3d(x, y, padding="same"),
+                (x, y),
+                check_fwd_over_rev=True,
+            )
+
+    @dtypes(torch.float, torch.cfloat)
+    @dtypesIfMPS(
+        *([torch.float] if MACOS_VERSION < 14.0 else [torch.float, torch.cfloat])
+    )  # Complex not supported on MacOS13
+    def test_conv_transpose1d_valid_padding_backward(self, device, dtype):
+        # Test F.conv_transpose1d gradients work with padding='valid'
+        x = torch.rand(1, 1, 10, dtype=dtype, device=device, requires_grad=True)
+        y = torch.rand(1, 1, 4, dtype=dtype, device=device, requires_grad=True)
+        F.conv_transpose1d(x, y, padding=0).sum().abs().backward()
+        gx_expect, gy_expect = x.grad, y.grad
+        x.grad, y.grad = None, None
+
+        F.conv_transpose1d(x, y, padding="valid").sum().abs().backward()
+        gx_actual, gy_actual = x.grad, y.grad
+        self.assertEqual(gx_expect, gx_actual)
+        self.assertEqual(gy_expect, gy_actual)
+
+    @dtypes(torch.float, torch.complex64)
+    @dtypesIfMPS(
+        *([torch.float] if MACOS_VERSION < 14.0 else [torch.float, torch.cfloat])
+    )  # Complex not supported on MacOS13
+    def test_conv_transpose2d_valid_padding_backward(self, device, dtype):
+        # Test F.conv_transpose2d gradients work with padding='valid'
+        x = torch.rand(1, 1, 1, 10, device=device, dtype=dtype, requires_grad=True)
+        y = torch.rand(1, 1, 1, 4, device=device, dtype=dtype, requires_grad=True)
+        F.conv_transpose2d(x, y, padding=0).sum().abs().backward()
+        gx_expect, gy_expect = x.grad, y.grad
+        x.grad, y.grad = None, None
+
+        F.conv_transpose2d(x, y, padding="valid").sum().abs().backward()
+        gx_actual, gy_actual = x.grad, y.grad
+        self.assertEqual(gx_expect, gx_actual)
+        self.assertEqual(gy_expect, gy_actual)
+
+    @dtypes(torch.double, torch.cdouble)
+    @dtypesIfMPS(
+        torch.float, torch.cfloat
+    )  # Double, complex double not supported on MPS
+    @expectedFailureMPS  # https://github.com/pytorch/pytorch/issues/107214
+    def test_conv_transpose3d_valid_padding_backward(self, device, dtype):
+        check_forward_ad = torch.device(device).type != "xla"
+
+        # Test F.conv_transpose3d gradients work with padding='valid'
+        x = torch.rand(1, 1, 1, 1, 10, dtype=dtype, device=device, requires_grad=True)
+        y = torch.rand(1, 1, 1, 1, 4, dtype=dtype, device=device, requires_grad=True)
+        F.conv_transpose3d(x, y, padding=0).sum().abs().backward()
+        gx_expect, gy_expect = x.grad, y.grad
+        x.grad, y.grad = None, None
+
+        F.conv_transpose3d(x, y, padding="valid").sum().abs().backward()
+        gx_actual, gy_actual = x.grad, y.grad
+        self.assertEqual(gx_expect, gx_actual)
+        self.assertEqual(gy_expect, gy_actual)
+
+        gradcheck(
+            lambda x, y: F.conv_transpose3d(x, y, padding="valid"),
+            (x, y),
+            check_forward_ad=check_forward_ad,
+            nondet_tol=1e-5,
+        )
+        gradgradcheck(
+            lambda x, y: F.conv_transpose3d(x, y, padding="valid"),
+            (x, y),
+            check_fwd_over_rev=check_forward_ad,
+            nondet_tol=1e-5,
+        )
+
+    @dtypes(torch.double, torch.cdouble)
+    @dtypesIfMPS(
+        torch.float, torch.cfloat
+    )  # Double, complex double not supported on MPS
+    @parametrize_test(
+        arg_str="N",
+        arg_values=[
+            subtest(arg_values=(1), name="conv_transpose1d"),
+            subtest(arg_values=(2), name="conv_transpose2d"),
+            subtest(arg_values=(3), name="conv_transpose3d"),
+        ],
+    )
+    def test_conv_transposeNd_same_padding_incompatible_with_output_padding(
+        self, device, dtype, N
+    ):
+        conv_transposeNd = getattr(F, f"conv_transpose{N}d")
+        if N == 1:
+            x = torch.rand(1, 1, 10, device=device, dtype=dtype, requires_grad=True)
+            y = torch.rand(1, 1, 4, device=device, dtype=dtype, requires_grad=True)
+            output_paddings = [(1,)]
+        elif N == 2:
+            x = torch.rand(1, 1, 2, 10, device=device, dtype=dtype, requires_grad=True)
+            y = torch.rand(1, 1, 4, 3, device=device, dtype=dtype, requires_grad=True)
+            output_paddings = [(1, 1), (1, 0), (0, 1)]
+        elif N == 3:
+            x = torch.rand(
+                1, 1, 2, 2, 10, device=device, dtype=dtype, requires_grad=True
+            )
+            y = torch.rand(
+                1, 1, 4, 3, 4, device=device, dtype=dtype, requires_grad=True
+            )
+            # fmt: off
+            output_paddings = [
+                (1, 1, 1), (1, 1, 0), (1, 0, 1), (1, 0, 0),
+                (0, 1, 1), (0, 1, 0), (0, 0, 1),
+            ]
+            # fmt: on
+        else:
+            raise ValueError(f"Test for {N=} undefined")
+
+        # test int
+        with self.assertRaisesRegex(
+            RuntimeError, "^padding='same' only supports output_padding=0$"
+        ):
+            conv_transposeNd(x, y, padding="same", output_padding=1)
+
+        # test tuple
+        for output_padding in output_paddings:
+            with self.assertRaisesRegex(
+                RuntimeError, "^padding='same' only supports output_padding=0$"
+            ):
+                conv_transposeNd(x, y, padding="same", output_padding=output_padding)
+
     @parametrize_test(
         arg_str="N",
         arg_values=[

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -2729,6 +2729,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
         torch.float, torch.cfloat
     )  # Double, complex double not supported on MPS
     @expectedFailureMPS  # https://github.com/pytorch/pytorch/issues/107214
+    @skipIfTorchDynamo("Doesn't work for complex128. Similar to conv3d")
     def test_conv_transpose3d_valid_padding_backward(self, device, dtype):
         check_forward_ad = torch.device(device).type != "xla"
 

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -58,6 +58,7 @@ from torch.testing._internal.common_utils import (
     run_tests,
     serialTest,
     set_default_dtype,
+    skipIfTorchDynamo,
     subtest,
     TEST_SCIPY,
     TEST_WITH_ROCM,
@@ -2631,6 +2632,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
         torch.float, torch.cfloat
     )  # Double, complex double not supported on MPS
     @expectedFailureMPS  # https://github.com/pytorch/pytorch/issues/107214
+    @skipIfTorchDynamo("Doesn't work for complex128. Similar to conv3d")
     def test_conv_transpose3d_same_padding_backward(self, device, dtype):
         check_forward_ad = torch.device(device).type != "xla"
 

--- a/torch/csrc/api/include/torch/nn/functional/conv.h
+++ b/torch/csrc/api/include/torch/nn/functional/conv.h
@@ -166,12 +166,16 @@ inline Tensor conv_transpose1d(
     const Tensor& weight,
     const Tensor& bias,
     IntArrayRef stride,
-    IntArrayRef padding,
+    const ConvTranspose1dFuncOptions::padding_t& padding,
     IntArrayRef output_padding,
     int64_t groups,
     IntArrayRef dilation) {
-  return torch::conv_transpose1d(
-      input, weight, bias, stride, padding, output_padding, groups, dilation);
+  return std::visit(
+      [&](const auto& pad) {
+        return torch::conv_transpose1d(
+            input, weight, bias, stride, padding_unwrap(pad), output_padding, groups, dilation);
+      },
+      padding);
 }
 } // namespace detail
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
@@ -211,12 +215,16 @@ inline Tensor conv_transpose2d(
     const Tensor& weight,
     const Tensor& bias,
     IntArrayRef stride,
-    IntArrayRef padding,
+    const ConvTranspose2dFuncOptions::padding_t& padding,
     IntArrayRef output_padding,
     int64_t groups,
     IntArrayRef dilation) {
-  return torch::conv_transpose2d(
-      input, weight, bias, stride, padding, output_padding, groups, dilation);
+  return std::visit(
+      [&](const auto& pad) {
+        return torch::conv_transpose2d(
+            input, weight, bias, stride, padding_unwrap(pad), output_padding, groups, dilation);
+      },
+      padding);
 }
 } // namespace detail
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
@@ -256,12 +264,16 @@ inline Tensor conv_transpose3d(
     const Tensor& weight,
     const Tensor& bias,
     IntArrayRef stride,
-    IntArrayRef padding,
+    const ConvTranspose3dFuncOptions::padding_t& padding,
     IntArrayRef output_padding,
     int64_t groups,
     IntArrayRef dilation) {
-  return torch::conv_transpose3d(
-      input, weight, bias, stride, padding, output_padding, groups, dilation);
+  return std::visit(
+      [&](const auto& pad) {
+        return torch::conv_transpose3d(
+            input, weight, bias, stride, padding_unwrap(pad), output_padding, groups, dilation);
+      },
+      padding);
 }
 } // namespace detail
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */

--- a/torch/csrc/api/include/torch/nn/functional/conv.h
+++ b/torch/csrc/api/include/torch/nn/functional/conv.h
@@ -173,7 +173,14 @@ inline Tensor conv_transpose1d(
   return std::visit(
       [&](const auto& pad) {
         return torch::conv_transpose1d(
-            input, weight, bias, stride, padding_unwrap(pad), output_padding, groups, dilation);
+            input,
+            weight,
+            bias,
+            stride,
+            padding_unwrap(pad),
+            output_padding,
+            groups,
+            dilation);
       },
       padding);
 }
@@ -222,7 +229,14 @@ inline Tensor conv_transpose2d(
   return std::visit(
       [&](const auto& pad) {
         return torch::conv_transpose2d(
-            input, weight, bias, stride, padding_unwrap(pad), output_padding, groups, dilation);
+            input,
+            weight,
+            bias,
+            stride,
+            padding_unwrap(pad),
+            output_padding,
+            groups,
+            dilation);
       },
       padding);
 }
@@ -271,7 +285,14 @@ inline Tensor conv_transpose3d(
   return std::visit(
       [&](const auto& pad) {
         return torch::conv_transpose3d(
-            input, weight, bias, stride, padding_unwrap(pad), output_padding, groups, dilation);
+            input,
+            weight,
+            bias,
+            stride,
+            padding_unwrap(pad),
+            output_padding,
+            groups,
+            dilation);
       },
       padding);
 }

--- a/torch/csrc/api/include/torch/nn/modules/conv.h
+++ b/torch/csrc/api/include/torch/nn/modules/conv.h
@@ -275,9 +275,12 @@ class ConvTransposeNdImpl : public ConvNdImpl<D, Derived> {
       for (const auto i : c10::irange(D)) {
         const auto output_padding = (*options_.output_padding())[i];
         TORCH_CHECK(
-          output_padding == 0,
-          "padding='same' only supports output_padding=0, but got ",
-          output_padding, " at dimension ", i, ".");
+            output_padding == 0,
+            "padding='same' only supports output_padding=0, but got ",
+            output_padding,
+            " at dimension ",
+            i,
+            ".");
       }
     }
   }
@@ -290,15 +293,15 @@ class ConvTransposeNdImpl : public ConvNdImpl<D, Derived> {
            << ", kernel_size=" << this->options.kernel_size()
            << ", stride=" << this->options.stride();
     std::visit(
-      c10::overloaded(
-        [&](enumtype::kValid) { stream << ", padding='valid'"; },
-        [&](enumtype::kSame) { stream << ", padding='same'"; },
-        [&](const ExpandingArray<D>& pad) {
-          if (*pad != *ExpandingArray<D>(0)) {
-            stream << ", padding=" << pad;
-          }
-        }),
-      this->options.padding());
+        c10::overloaded(
+            [&](enumtype::kValid) { stream << ", padding='valid'"; },
+            [&](enumtype::kSame) { stream << ", padding='same'"; },
+            [&](const ExpandingArray<D>& pad) {
+              if (*pad != *ExpandingArray<D>(0)) {
+                stream << ", padding=" << pad;
+              }
+            }),
+        this->options.padding());
     if (*this->options.dilation() != *ExpandingArray<D>(1)) {
       stream << ", dilation=" << this->options.dilation();
     }

--- a/torch/csrc/api/include/torch/nn/options/conv.h
+++ b/torch/csrc/api/include/torch/nn/options/conv.h
@@ -257,6 +257,7 @@ using Conv3dFuncOptions = ConvFuncOptions<3>;
 template <size_t D>
 struct ConvTransposeOptions {
   using padding_mode_t = detail::conv_padding_mode_t;
+  using padding_t = detail::conv_padding_t<D>;
 
   ConvTransposeOptions(
       int64_t in_channels,
@@ -290,7 +291,7 @@ struct ConvTransposeOptions {
   /// For a `D`-dim convolution, must be a single number or a list of `D`
   /// numbers.
   /// This parameter __can__ be changed after construction.
-  TORCH_ARG(ExpandingArray<D>, padding) = 0;
+  TORCH_ARG(padding_t, padding) = 0;
 
   /// For transpose convolutions, the padding to add to output volumes.
   /// For a `D`-dim convolution, must be a single number or a list of `D`
@@ -351,6 +352,7 @@ namespace functional {
 /// Options for a `D`-dimensional convolution functional.
 template <size_t D>
 struct ConvTransposeFuncOptions {
+  using padding_t = torch::nn::detail::conv_padding_t<D>;
   /// optional bias of shape `(out_channels)`. Default: ``None``
   TORCH_ARG(torch::Tensor, bias);
 
@@ -362,7 +364,7 @@ struct ConvTransposeFuncOptions {
   /// Implicit paddings on both sides of the input.
   /// For a `D`-dim convolution, must be a single number or a list of `D`
   /// numbers.
-  TORCH_ARG(ExpandingArray<D>, padding) = 0;
+  TORCH_ARG(padding_t, padding) = 0;
 
   /// Additional size added to one side of each dimension in the output shape.
   /// Default: 0

--- a/torch/csrc/api/src/nn/modules/conv.cpp
+++ b/torch/csrc/api/src/nn/modules/conv.cpp
@@ -161,42 +161,40 @@ template class ConvNdImpl<3, Conv3dImpl>;
 
 template <size_t D, typename Derived>
 std::vector<int64_t> ConvTransposeNdImpl<D, Derived>::_output_padding(
-  const Tensor& input,
-  const std::optional<at::IntArrayRef>& output_size,
-  const ExpandingArray<D>& stride,
-  const detail::conv_padding_t<D>& padding,
-  const ExpandingArray<D>& kernel_size) {
-  return std::visit(c10::overloaded(
-    [&](enumtype::kSame) {
-      if (output_size != std::nullopt) { // check if all output_padding is 0
-        for (const auto i : c10::irange(D)) {
-          const auto output_padding = (*this->options.output_padding())[i];
-          TORCH_CHECK(
-            output_padding == 0,
-            "padding='same' only supports output_padding=0, but got ",
-            output_padding, " at dimension ", i, ".");
-        }
-      }
-      return at::IntArrayRef(this->options.output_padding()).vec();
-    },
-    [&](enumtype::kValid) {
-      ExpandingArray<D> zero_padding(0);
-      return _output_padding(
-        input,
-        output_size,
-        stride,
-        zero_padding,
-        kernel_size);
-    },
-    [&](const ExpandingArray<D>& pad) {
-      return _output_padding(
-        input,
-        output_size,
-        stride,
-        pad,
-        kernel_size);
-    }),
-                    padding);
+    const Tensor& input,
+    const std::optional<at::IntArrayRef>& output_size,
+    const ExpandingArray<D>& stride,
+    const detail::conv_padding_t<D>& padding,
+    const ExpandingArray<D>& kernel_size) {
+  return std::visit(
+      c10::overloaded(
+          [&](enumtype::kSame) {
+            if (output_size !=
+                std::nullopt) { // check if all output_padding is 0
+              for (const auto i : c10::irange(D)) {
+                const auto output_padding =
+                    (*this->options.output_padding())[i];
+                TORCH_CHECK(
+                    output_padding == 0,
+                    "padding='same' only supports output_padding=0, but got ",
+                    output_padding,
+                    " at dimension ",
+                    i,
+                    ".");
+              }
+            }
+            return at::IntArrayRef(this->options.output_padding()).vec();
+          },
+          [&](enumtype::kValid) {
+            ExpandingArray<D> zero_padding(0);
+            return _output_padding(
+                input, output_size, stride, zero_padding, kernel_size);
+          },
+          [&](const ExpandingArray<D>& pad) {
+            return _output_padding(
+                input, output_size, stride, pad, kernel_size);
+          }),
+      padding);
 }
 
 template <size_t D, typename Derived>

--- a/torch/csrc/api/src/nn/modules/conv.cpp
+++ b/torch/csrc/api/src/nn/modules/conv.cpp
@@ -161,6 +161,46 @@ template class ConvNdImpl<3, Conv3dImpl>;
 
 template <size_t D, typename Derived>
 std::vector<int64_t> ConvTransposeNdImpl<D, Derived>::_output_padding(
+  const Tensor& input,
+  const std::optional<at::IntArrayRef>& output_size,
+  const ExpandingArray<D>& stride,
+  const detail::conv_padding_t<D>& padding,
+  const ExpandingArray<D>& kernel_size) {
+  return std::visit(c10::overloaded(
+    [&](enumtype::kSame) {
+      if (output_size != std::nullopt) { // check if all output_padding is 0
+        for (const auto i : c10::irange(D)) {
+          const auto output_padding = (*this->options.output_padding())[i];
+          TORCH_CHECK(
+            output_padding == 0,
+            "padding='same' only supports output_padding=0, but got ",
+            output_padding, " at dimension ", i, ".");
+        }
+      }
+      return at::IntArrayRef(this->options.output_padding()).vec();
+    },
+    [&](enumtype::kValid) {
+      ExpandingArray<D> zero_padding(0);
+      return _output_padding(
+        input,
+        output_size,
+        stride,
+        zero_padding,
+        kernel_size);
+    },
+    [&](const ExpandingArray<D>& pad) {
+      return _output_padding(
+        input,
+        output_size,
+        stride,
+        pad,
+        kernel_size);
+    }),
+                    padding);
+}
+
+template <size_t D, typename Derived>
+std::vector<int64_t> ConvTransposeNdImpl<D, Derived>::_output_padding(
     const Tensor& input,
     const std::optional<at::IntArrayRef>& output_size,
     const ExpandingArray<D>& stride,

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -223,9 +223,14 @@ Args:
     bias: optional bias of shape :math:`(\text{out\_channels})`. Default: None
     stride: the stride of the convolving kernel. Can be a single number or a
       tuple ``(sW,)``. Default: 1
-    padding: ``dilation * (kernel_size - 1) - padding`` zero-padding will be added to both
-      sides of each dimension in the input. Can be a single number or a tuple
-      ``(padW,)``. Default: 0
+    padding: controls the amount of implicit zero-padding added to both sides of each
+      dimension in the input. Can be a string {'valid', 'same'}, a single number,
+      or a tuple `(padW,)`. Default: 0.
+      ``padding='valid'`` means no padding. ``padding='same'`` adds padding so that
+      the output size matches the input size.
+      This mode only supports ``stride=1`` and ``output_padding=0``.
+      When using an integer or tuple, the actual padding added is computed as
+      ``dilation * (kernel_size - 1) - padding``.
     output_padding: additional size added to one side of each dimension in the
       output shape. Can be a single number or a tuple ``(out_padW)``. Default: 0
     groups: split input into groups, :math:`\text{in\_channels}` should be divisible by the
@@ -264,9 +269,14 @@ Args:
     bias: optional bias of shape :math:`(\text{out\_channels})`. Default: None
     stride: the stride of the convolving kernel. Can be a single number or a
       tuple ``(sH, sW)``. Default: 1
-    padding: ``dilation * (kernel_size - 1) - padding`` zero-padding will be added to both
-      sides of each dimension in the input. Can be a single number or a tuple
-      ``(padH, padW)``. Default: 0
+    padding: controls the amount of implicit zero-padding added to both sides of each
+      dimension in the input. Can be a string {'valid', 'same'}, a single number,
+      or a tuple `(padH, padW)`. Default: 0.
+      ``padding='valid'`` means no padding. ``padding='same'`` adds padding so that
+      the output size matches the input size.
+      This mode only supports ``stride=1`` and ``output_padding=0``.
+      When using an integer or tuple, the actual padding added is computed as
+      ``dilation * (kernel_size - 1) - padding``.
     output_padding: additional size added to one side of each dimension in the
       output shape. Can be a single number or a tuple ``(out_padH, out_padW)``.
       Default: 0
@@ -307,9 +317,14 @@ Args:
     bias: optional bias of shape :math:`(\text{out\_channels})`. Default: None
     stride: the stride of the convolving kernel. Can be a single number or a
       tuple ``(sT, sH, sW)``. Default: 1
-    padding: ``dilation * (kernel_size - 1) - padding`` zero-padding will be added to both
-      sides of each dimension in the input. Can be a single number or a tuple
-      ``(padT, padH, padW)``. Default: 0
+    padding: controls the amount of implicit zero-padding added to both sides of each
+      dimension in the input. Can be a string {'valid', 'same'}, a single number,
+      or a tuple `(padT, padH, padW)`. Default: 0.
+      ``padding='valid'`` means no padding. ``padding='same'`` adds padding so that
+      the output size matches the input size.
+      This mode only supports ``stride=1`` and ``output_padding=0``.
+      When using an integer or tuple, the actual padding added is computed as
+      ``dilation * (kernel_size - 1) - padding``.
     output_padding: additional size added to one side of each dimension in the
       output shape. Can be a single number or a tuple
       ``(out_padT, out_padH, out_padW)``. Default: 0

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -847,8 +847,10 @@ class ConvTranspose1d(_ConvTransposeNd):
     * :attr:`stride` controls the stride for the cross-correlation.
 
     * :attr:`padding` controls the amount of implicit zero padding on both
-      sides for ``dilation * (kernel_size - 1) - padding`` number of points. See note
-      below for details.
+      sides for ``dilation * (kernel_size - 1) - padding`` number of points.
+      It can be either a string {{'valid', 'same'}} or a tuple of ints giving
+      the amount of implicit padding applied on both sides.
+      See note below for details.
 
     * :attr:`output_padding` controls the additional size added to one side
       of the output shape. See note below for details.
@@ -873,6 +875,12 @@ class ConvTranspose1d(_ConvTransposeNd):
         not actually add zero-padding to output.
 
     Note:
+        ``padding='valid'`` is the same as no padding.
+        ``padding='same'`` crops the output so that its shape matches the input.
+        Note that ``padding='same'`` only supports a stride of 1 and
+        requires ``output_padding=0``.
+
+    Note:
         In some circumstances when using the CUDA backend with CuDNN, this operator
         may select a nondeterministic algorithm to increase performance. If this is
         undesirable, you can try to make the operation deterministic (potentially at
@@ -886,7 +894,7 @@ class ConvTranspose1d(_ConvTransposeNd):
         out_channels (int): Number of channels produced by the convolution
         kernel_size (int or tuple): Size of the convolving kernel
         stride (int or tuple, optional): Stride of the convolution. Default: 1
-        padding (int or tuple, optional): ``dilation * (kernel_size - 1) - padding`` zero-padding
+        padding (int, tuple or str, optional): ``dilation * (kernel_size - 1) - padding`` zero-padding
             will be added to both sides of the input. Default: 0
         output_padding (int or tuple, optional): Additional size added to one side
             of the output shape. Default: 0
@@ -947,7 +955,7 @@ class ConvTranspose1d(_ConvTransposeNd):
         out_channels: int,
         kernel_size: _size_1_t,
         stride: _size_1_t = 1,
-        padding: _size_1_t = 0,
+        padding: Union[Literal["valid", "same"], _size_1_t] = 0,
         output_padding: _size_1_t = 0,
         groups: int = 1,
         bias: bool = True,
@@ -959,7 +967,7 @@ class ConvTranspose1d(_ConvTransposeNd):
         factory_kwargs = {"device": device, "dtype": dtype}
         kernel_size = _single(kernel_size)
         stride = _single(stride)
-        padding = _single(padding)
+        padding = padding if isinstance(padding, str) else _single(padding)
         dilation = _single(dilation)
         output_padding = _single(output_padding)
         super().__init__(
@@ -983,8 +991,6 @@ class ConvTranspose1d(_ConvTransposeNd):
                 "Only `zeros` padding mode is supported for ConvTranspose1d"
             )
 
-        if not isinstance(self.padding, tuple):
-            raise AssertionError("self.padding must be a tuple")
         # One cannot replace List by Tuple or Sequence in "_output_padding" because
         # TorchScript does not support `Sequence[T]` or `Tuple[T, ...]`.
         num_spatial_dims = 1
@@ -1029,9 +1035,11 @@ class ConvTranspose2d(_ConvTransposeNd):
       behavior of transposed convolutions, which can increase the spatial resolution and is equivalent to a learnable
       upsampling operation.
 
-    * :attr:`padding` controls the amount of implicit zero padding on both
-      sides for ``dilation * (kernel_size - 1) - padding`` number of points. See note
-      below for details.
+    * :attr:`padding` controls the amount of implicit zero padding on both sides
+      for ``dilation * (kernel_size - 1) - padding`` number of points.
+      It can be either a string {{'valid', 'same'}} or a tuple of ints giving
+      the amount of implicit padding applied on both sides.
+      See note below for details.
 
     * :attr:`output_padding` controls the additional size added to one side
       of the output shape. See note below for details.
@@ -1061,6 +1069,12 @@ class ConvTranspose2d(_ConvTransposeNd):
         effectively increasing the calculated output shape on one side. Note
         that :attr:`output_padding` is only used to find output shape, but does
         not actually add zero-padding to output.
+
+    Note:
+        ``padding='valid'`` is the same as no padding.
+        ``padding='same'`` crops the output so that its shape matches the input.
+        Note that ``padding='same'`` only supports a stride of 1 and
+        requires ``output_padding=0``.
 
     Note:
         {cudnn_reproducibility_note}
@@ -1136,7 +1150,7 @@ class ConvTranspose2d(_ConvTransposeNd):
         out_channels: int,
         kernel_size: _size_2_t,
         stride: _size_2_t = 1,
-        padding: _size_2_t = 0,
+        padding: Union[Literal["valid", "same"], _size_2_t] = 0,
         output_padding: _size_2_t = 0,
         groups: int = 1,
         bias: bool = True,
@@ -1148,7 +1162,7 @@ class ConvTranspose2d(_ConvTransposeNd):
         factory_kwargs = {"device": device, "dtype": dtype}
         kernel_size = _pair(kernel_size)
         stride = _pair(stride)
-        padding = _pair(padding)
+        padding = padding if isinstance(padding, str) else _pair(padding)
         dilation = _pair(dilation)
         output_padding = _pair(output_padding)
         super().__init__(
@@ -1180,8 +1194,6 @@ class ConvTranspose2d(_ConvTransposeNd):
                 "Only `zeros` padding mode is supported for ConvTranspose2d"
             )
 
-        if not isinstance(self.padding, tuple):
-            raise AssertionError("self.padding must be a tuple")
         # One cannot replace List by Tuple or Sequence in "_output_padding" because
         # TorchScript does not support `Sequence[T]` or `Tuple[T, ...]`.
         num_spatial_dims = 2
@@ -1226,9 +1238,11 @@ class ConvTranspose3d(_ConvTransposeNd):
 
     * :attr:`stride` controls the stride for the cross-correlation.
 
-    * :attr:`padding` controls the amount of implicit zero padding on both
-      sides for ``dilation * (kernel_size - 1) - padding`` number of points. See note
-      below for details.
+    * :attr:`padding` controls the amount of implicit zero padding on both sides
+      for ``dilation * (kernel_size - 1) - padding`` number of points.
+      It can be either a string {{'valid', 'same'}} or a tuple of ints giving
+      the amount of implicit padding applied on both sides.
+      See note below for details.
 
     * :attr:`output_padding` controls the additional size added to one side
       of the output shape. See note below for details.
@@ -1260,6 +1274,12 @@ class ConvTranspose3d(_ConvTransposeNd):
         not actually add zero-padding to output.
 
     Note:
+        ``padding='valid'`` is the same as no padding.
+        ``padding='same'`` crops the output so that its shape matches the input.
+        Note that ``padding='same'`` only supports a stride of 1 and
+        requires ``output_padding=0``.
+
+    Note:
         {cudnn_reproducibility_note}
 
     Args:
@@ -1267,7 +1287,7 @@ class ConvTranspose3d(_ConvTransposeNd):
         out_channels (int): Number of channels produced by the convolution
         kernel_size (int or tuple): Size of the convolving kernel
         stride (int or tuple, optional): Stride of the convolution. Default: 1
-        padding (int or tuple, optional): ``dilation * (kernel_size - 1) - padding`` zero-padding
+        padding (int, tuple or str, optional): ``dilation * (kernel_size - 1) - padding`` zero-padding
             will be added to both sides of each dimension in the input. Default: 0
         output_padding (int or tuple, optional): Additional size added to one side
             of each dimension in the output shape. Default: 0
@@ -1328,7 +1348,7 @@ class ConvTranspose3d(_ConvTransposeNd):
         out_channels: int,
         kernel_size: _size_3_t,
         stride: _size_3_t = 1,
-        padding: _size_3_t = 0,
+        padding: Union[Literal["valid", "same"], _size_3_t] = 0,
         output_padding: _size_3_t = 0,
         groups: int = 1,
         bias: bool = True,
@@ -1340,7 +1360,7 @@ class ConvTranspose3d(_ConvTransposeNd):
         factory_kwargs = {"device": device, "dtype": dtype}
         kernel_size = _triple(kernel_size)
         stride = _triple(stride)
-        padding = _triple(padding)
+        padding = padding if isinstance(padding, str) else _triple(padding)
         dilation = _triple(dilation)
         output_padding = _triple(output_padding)
         super().__init__(
@@ -1364,8 +1384,6 @@ class ConvTranspose3d(_ConvTransposeNd):
                 "Only `zeros` padding mode is supported for ConvTranspose3d"
             )
 
-        if not isinstance(self.padding, tuple):
-            raise AssertionError("self.padding must be a tuple")
         # One cannot replace List by Tuple or Sequence in "_output_padding" because
         # TorchScript does not support `Sequence[T]` or `Tuple[T, ...]`.
         num_spatial_dims = 3

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -3998,6 +3998,10 @@ def sample_inputs_conv_transpose1d(op_info, device, dtype, requires_grad, **kwar
          {'stride': 2, 'padding': 1, 'output_padding': 1, 'groups': 1, 'dilation': (2,)}),
         ((1, 1, 4), (1, 2, 3), None,
          {'stride': 2, 'padding': 1, 'output_padding': 1, 'groups': 1}),
+        ((1, 2, 4), (2, 2, 3), None,
+         {'stride': 2, 'padding': 'valid'}),
+        ((2, 2, 4), (2, 1, 4), (2,),
+         {'stride': 1, 'padding': 'same', 'groups': 2, 'dilation': (2,)}),
         ((1, 4, 5), (4, 8, 3), None,
          {})
     )
@@ -4029,6 +4033,10 @@ def sample_inputs_conv_transpose2d(op_info, device, dtype, requires_grad, **kwar
          {'stride': 2, 'padding': 1, 'output_padding': 1, 'groups': 1, 'dilation': (2, 3)}),
         ((1, 1, 4, 3), (1, 2, 3, 4), None,
          {'stride': 2, 'padding': 1, 'output_padding': 1, 'groups': 1}),
+        ((1, 2, 4, 4), (2, 2, 3, 3), (2,),
+            {'stride': 2, 'padding': "valid"}),
+        ((1, 3, 4, 5), (3, 2, 3, 4), (2,),
+            {'stride': 1, 'padding': "same", 'dilation': 3}),
         ((2, 4, 4, 4), (4, 1, 3, 3), None, {'groups': 4}),
         ((1, 2, 5, 5), (2, 4, 3, 3), None, {})
     )
@@ -4059,6 +4067,9 @@ def sample_inputs_conv_transpose3d(op_info, device, dtype, requires_grad, **kwar
          {'stride': 2, 'padding': 1, 'output_padding': 1, 'groups': 1, 'dilation': (2, 3, 2)}),
         ((1, 1, 4, 3, 4), (1, 2, 3, 4, 5), None,
          {'stride': 2, 'padding': 1, 'output_padding': 1, 'groups': 1}),
+        ((1, 3, 4, 4, 4), (3, 1, 1, 1, 1), (1,), {'padding': 'same'}),
+        ((1, 1, 1, 1, 10), (1, 1, 1, 1, 4), None, {'padding': 'valid'}),
+        ((1, 1, 2, 4, 6), (1, 1, 4, 4, 4), (1,), {'padding': 'same', 'dilation': 3}),
         ((1, 4, 5, 5, 5), (4, 8, 3, 3, 3), None,
          {})
     )

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -3965,6 +3965,21 @@ def conv_transpose_ref(input, weight, bias, stride=1, padding=0,
         for _ in range(unsqueeze_dims):
             bias = bias.unsqueeze(1)
 
+    # Manage padding as a string
+    ndim = weight.dim() - 2
+    slices = [slice(None)] * (ndim + 2)
+    is_asymmetric_pad = False
+    if isinstance(padding, str):
+        if padding == "valid":
+            padding = 0
+        elif padding == "same":
+            padding, asymmetric_pads = _compute_same_padding_crop(ndim, weight.size(), dilation, stride)
+            if any(pad != slice(None) for pad in asymmetric_pads):
+                is_asymmetric_pad = True
+                slices[2:] = asymmetric_pads
+        else:
+            raise ValueError(f"Invalid padding argument '{padding}'")
+
     grad_output = input
     # Get the input shape for grad_fn.
     conv_transpose_output = fn(grad_output.to('meta'), weight.to('meta'), None,
@@ -3981,7 +3996,42 @@ def conv_transpose_ref(input, weight, bias, stride=1, padding=0,
     if bias is not None:
         out = out + bias
 
+    # This is for asymmetric convolution when using padding="same"
+    if is_asymmetric_pad:
+        out = out[tuple(slices)]
+
     return out.squeeze(0) if not is_batched else out
+
+def _compute_same_padding_crop(ndim: int,
+                               weight_sizes: Sequence[int],
+                               dilation: Sequence[int] | int,
+                               stride: Sequence[int] | int) -> tuple[list[int], list[slice]]:
+    """Computes the padding required so that the output size is the same as the input size.
+    It returns a tuple with 2 elements.
+    The first element is the padding to perform on both sides,
+    the second element is used for asymmetric padding,
+    containing the slices for the correct output shape."""
+    # Adapted from [convolution_transpose_same] in aten/src/ATen/native/Convolution.cpp
+    common_pad_lr: list[int] = [0] * ndim
+    asymmetric_pads: list[slice] = [slice(None)] * ndim
+
+    for i in range(ndim):
+        dim_dilation = dilation if isinstance(dilation, int) else dilation[i]
+        dim_stride = stride if isinstance(stride, int) else stride[i]
+
+        effective_kernel = dim_dilation * (weight_sizes[i + 2] - 1) + 1
+        total_padding = effective_kernel + dim_stride - 2
+        left_pad = math.ceil(total_padding / 2) if (dim_stride < effective_kernel) else effective_kernel - 1
+        right_pad = total_padding - left_pad
+
+        common_pad_lr[i] = min(left_pad, right_pad)
+        epl = left_pad - right_pad
+        if epl > 0:
+            asymmetric_pads[i] = slice(epl, None)
+        elif epl < 0:
+            asymmetric_pads[i] = slice(0, epl)
+
+    return common_pad_lr, asymmetric_pads
 
 
 def sample_inputs_conv_transpose1d(op_info, device, dtype, requires_grad, **kwargs):


### PR DESCRIPTION
This pull request adds support for `'same'` and `'valid'` padding modes for transposed convolutions.

### Implementation Details for `'same'` padding:

1. Compute the minimum required padding for the left and right sides.
2. Perform the convolution using the computed padding.
3. Adjust the output so that its size matches the input size.

### Notes:

* The padding calculation is based on the [JAX implementation](https://github.com/jax-ml/jax/blob/6a6a13dcfe5f6dbca4155410dd32dfc2d5bf1cec/jax/_src/lax/convolution.py#L253).
* For asymmetric convolutions, I slice one extra value on the left side.
* `'valid'` padding is equivalent to `padding=0`.
* `'same'` padding is **not supported** when:

  * The stride is not equal to 1 (`stride != 1`), as it is also unsupported in traditional convolutions, and I could not find any bibliographic references clarifying how it could be implemented in this context.
  * `output_padding != 0`, since this seems to conflict with the intent of `'same'` padding.

Close #80301; Close #3867


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @jerryzh168