### PR TITLE
[BE] Remove unused `conda-env-Linux-X64`

### DIFF
--- a/.github/requirements/conda-env-Linux-X64.txt
+++ b/.github/requirements/conda-env-Linux-X64.txt
@@ -1,8 +1,0 @@
-cmake=3.22.*
-mkl=2022.1.0
-mkl-include=2022.1.0
-ninja=1.10.2
-numpy=1.23.3
-pyyaml=6.0
-setuptools=72.1.0
-typing-extensions=4.11.0


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #154309
* #154307
* #154305
* #154304
* __->__ #154303

According to https://github.com/search?type=code&q=conda-env-++repo%3Apytorch%2Fpytorch it's not referenced anywhere and has been replaced with `conda-env-ci` a while ago