### PR TITLE
Enhance testing infrastructure to add half-precision support for `histc` on XPU

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -19539,6 +19539,7 @@ op_db: list[OpInfo] = [
     OpInfo('histc',
            dtypes=floating_types_and(torch.bfloat16, torch.float16),
            dtypesIfCUDA=floating_types_and(torch.int8, torch.uint8, torch.int16, torch.int32, torch.int64),
+           dtypesIfXPU=floating_types_and(torch.int8, torch.uint8, torch.int16, torch.int32, torch.int64, torch.bfloat16, torch.float16),
            sample_inputs_func=sample_inputs_histc,
            supports_out=True,
            supports_autograd=False,


### PR DESCRIPTION
**Motivation:**
Enable unit tests in torch-xpu-ops for the newly added `half` support in `histc` via opdb updates.

**Relevant issue:**
https://github.com/intel/torch-xpu-ops/issues/1681
