### PR TITLE
Use property instead of ClassVar for `Uniform.arg_constraints` and `Wishart.arg_constraints`

### DIFF
--- a/torch/distributions/uniform.py
+++ b/torch/distributions/uniform.py
@@ -29,12 +29,15 @@ class Uniform(Distribution):
         high (float or Tensor): upper range (exclusive).
     """
 
-    # TODO allow (loc,scale) parameterization to allow independent constraints.
-    arg_constraints = {
-        "low": constraints.dependent(is_discrete=False, event_dim=0),
-        "high": constraints.dependent(is_discrete=False, event_dim=0),
-    }
     has_rsample = True
+
+    @property
+    def arg_constraints(self):
+        # TODO allow (loc,scale) parameterization to allow independent constraints.
+        return {
+            "low": constraints.less_than(self.high),
+            "high": constraints.greater_than(self.low),
+        }
 
     @property
     def mean(self) -> Tensor:
@@ -65,9 +68,6 @@ class Uniform(Distribution):
         else:
             batch_shape = self.low.size()
         super().__init__(batch_shape, validate_args=validate_args)
-
-        if self._validate_args and not torch.lt(self.low, self.high).all():
-            raise ValueError("Uniform is not defined when low>= high")
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Uniform, _instance)

--- a/torch/distributions/wishart.py
+++ b/torch/distributions/wishart.py
@@ -64,15 +64,18 @@ class Wishart(ExponentialFamily):
     [5] Ku, Y.-C. & Bloomfield, P., 2010. `Generating Random Wishart Matrices with Fractional Degrees of Freedom in OX`.
     """
 
-    arg_constraints = {
-        "covariance_matrix": constraints.positive_definite,
-        "precision_matrix": constraints.positive_definite,
-        "scale_tril": constraints.lower_cholesky,
-        "df": constraints.greater_than(0),
-    }
     support = constraints.positive_definite
     has_rsample = True
     _mean_carrier_measure = 0
+
+    @property
+    def arg_constraints(self):
+        return {
+            "covariance_matrix": constraints.positive_definite,
+            "precision_matrix": constraints.positive_definite,
+            "scale_tril": constraints.lower_cholesky,
+            "df": constraints.greater_than(self.event_shape[-1] - 1),
+        }
 
     def __init__(
         self,
@@ -119,7 +122,6 @@ class Wishart(ExponentialFamily):
         elif precision_matrix is not None:
             self.precision_matrix = param.expand(batch_shape + (-1, -1))
 
-        self.arg_constraints["df"] = constraints.greater_than(event_shape[-1] - 1)
         if self.df.lt(event_shape[-1]).any():
             warnings.warn(
                 "Low df values detected. Singular samples are highly likely to occur for ndim - 1 < df < ndim."


### PR DESCRIPTION
Fixes #154355

For these two distributions, the constraints depend on the actual values, and so `arg_constraints` cannot be a `ClassVar`.

cc @fritzo @neerajprad @alicanb @nikitaved @Skylion007 