### PR TITLE
Almalinux image, install glibc-langpack-en

### DIFF
--- a/.ci/docker/almalinux/Dockerfile
+++ b/.ci/docker/almalinux/Dockerfile
@@ -11,6 +11,8 @@ ARG DEVTOOLSET_VERSION=11
 
 RUN yum -y update
 RUN yum -y install epel-release
+# install glibc-langpack-en make sure en_US.UTF-8 locale is available
+RUN yum -y install glibc-langpack-en
 RUN yum install -y sudo wget curl perl util-linux xz bzip2 git patch which perl zlib-devel openssl-devel yum-utils autoconf automake make gcc-toolset-${DEVTOOLSET_VERSION}-toolchain
 # Just add everything as a safe.directory for git since these will be used in multiple places with git
 RUN git config --global --add safe.directory '*'


### PR DESCRIPTION
After update to: https://hub.docker.com/layers/amd64/almalinux/8/images/sha256-4f63eb966695df3c993deeacec7c73d87728e2ea66d3b48fed4b40cb547fa7c2

Started seeing warning: bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
and random Segfaults when using python like:
https://github.com/pytorch/test-infra/actions/runs/15216565225/job/42901732536
```
+++ python -c 'import torch'
./check_binary.sh: line 258:  2276 Segmentation fault      (core dumped) python -c 'import torch'
```

Installing langpack does  resolve these issues: https://github.com/pytorch/test-infra/actions/runs/15256338815/job/42904808826#step:15:2311


Almalinux Docker build without setlocale warning:
https://github.com/pytorch/pytorch/actions/runs/15030284546/job/42240978131

Almalinux Docker build with setlocale warning:
https://github.com/pytorch/pytorch/actions/runs/15246391200/job/42873875745#step:3:7180