### PR TITLE
[ez] remove unused function _constrain_symbol_range

### DIFF
--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1515,12 +1515,6 @@ def guard_scalar(
         raise AssertionError(f"unrecognized scalar {a}")
 
 
-def _constrain_symbol_range(
-    shape_env: ShapeEnv, s: sympy.Symbol, compiler_min: int, compiler_max: int
-) -> None:
-    shape_env.constrain_symbol_range(s, compiler_min, compiler_max)
-
-
 def _advise_is_size(a: SymInt) -> None:
     """
     Don't use this directly; use torch._check_is_size instead.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #154400
* #154399
* #154398
* #154397
* #154396
* #154403
* #154402
* #154385
* #154384
* #154383
* #154381
* #154380
* #154379
* #154378
* #154377
* #154405
* #154404
* #154401
* __->__ #154386
* #154376



cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv