### PR TITLE
Extract DeviceType to a standalone header file

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -671,6 +671,14 @@ flatbuffer_cc_library(
 )
 
 cc_library(
+    name = "torch_standalone_headers",
+    hdrs = glob([
+        "torch/standalone/**/*.h"
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
     name = "torch_headers",
     hdrs = if_cuda(
         torch_cuda_headers,

--- a/buckbuild.bzl
+++ b/buckbuild.bzl
@@ -944,6 +944,7 @@ def define_buck_targets(
             [
                 ("torch/csrc/api/include", "torch/**/*.h"),
                 ("", "torch/csrc/**/*.h"),
+                ("", "torch/standalone/**/*.h"),
                 ("", "torch/script.h"),
                 ("", "torch/library.h"),
                 ("", "torch/custom_class.h"),

--- a/c10/core/DeviceType.cpp
+++ b/c10/core/DeviceType.cpp
@@ -6,109 +6,7 @@
 #include <atomic>
 #include <mutex>
 
-namespace c10 {
-
-std::string DeviceTypeName(DeviceType d, bool lower_case) {
-  switch (d) {
-    // I considered instead using ctype::tolower to lower-case the strings
-    // on the fly, but this seemed a bit much.
-    case DeviceType::CPU:
-      return lower_case ? "cpu" : "CPU";
-    case DeviceType::CUDA:
-      return lower_case ? "cuda" : "CUDA";
-    case DeviceType::OPENGL:
-      return lower_case ? "opengl" : "OPENGL";
-    case DeviceType::OPENCL:
-      return lower_case ? "opencl" : "OPENCL";
-    case DeviceType::MKLDNN:
-      return lower_case ? "mkldnn" : "MKLDNN";
-    case DeviceType::IDEEP:
-      return lower_case ? "ideep" : "IDEEP";
-    case DeviceType::HIP:
-      return lower_case ? "hip" : "HIP";
-    case DeviceType::VE:
-      return lower_case ? "ve" : "VE";
-    case DeviceType::FPGA:
-      return lower_case ? "fpga" : "FPGA";
-    case DeviceType::MAIA:
-      return lower_case ? "maia" : "MAIA";
-    case DeviceType::XLA:
-      return lower_case ? "xla" : "XLA";
-    case DeviceType::Lazy:
-      return lower_case ? "lazy" : "LAZY";
-    case DeviceType::MPS:
-      return lower_case ? "mps" : "MPS";
-    case DeviceType::Vulkan:
-      return lower_case ? "vulkan" : "VULKAN";
-    case DeviceType::Metal:
-      return lower_case ? "metal" : "METAL";
-    case DeviceType::XPU:
-      return lower_case ? "xpu" : "XPU";
-    case DeviceType::Meta:
-      return lower_case ? "meta" : "META";
-    case DeviceType::HPU:
-      return lower_case ? "hpu" : "HPU";
-    case DeviceType::IPU:
-      return lower_case ? "ipu" : "IPU";
-    case DeviceType::MTIA:
-      return lower_case ? "mtia" : "MTIA";
-    case DeviceType::PrivateUse1:
-      return get_privateuse1_backend(/*lower_case=*/lower_case);
-    default:
-      TORCH_CHECK(
-          false,
-          "Unknown device: ",
-          static_cast<int16_t>(d),
-          ". If you have recently updated the caffe2.proto file to add a new "
-          "device type, did you forget to update the DeviceTypeName() "
-          "function to reflect such recent changes?");
-      // The below code won't run but is needed to suppress some compiler
-      // warnings.
-      return "";
-  }
-}
-
-// NB: Per the C++ standard (e.g.,
-// https://stackoverflow.com/questions/18195312/what-happens-if-you-static-cast-invalid-value-to-enum-class)
-// as long as you cast from the same underlying type, it is always valid to cast
-// into an enum class (even if the value would be invalid by the enum.)  Thus,
-// the caller is allowed to cast a possibly invalid int16_t to DeviceType and
-// then pass it to this function.  (I considered making this function take an
-// int16_t directly, but that just seemed weird.)
-bool isValidDeviceType(DeviceType d) {
-  switch (d) {
-    case DeviceType::CPU:
-    case DeviceType::CUDA:
-    case DeviceType::OPENGL:
-    case DeviceType::OPENCL:
-    case DeviceType::MKLDNN:
-    case DeviceType::IDEEP:
-    case DeviceType::HIP:
-    case DeviceType::VE:
-    case DeviceType::FPGA:
-    case DeviceType::MAIA:
-    case DeviceType::XLA:
-    case DeviceType::Lazy:
-    case DeviceType::MPS:
-    case DeviceType::Vulkan:
-    case DeviceType::Metal:
-    case DeviceType::XPU:
-    case DeviceType::Meta:
-    case DeviceType::HPU:
-    case DeviceType::IPU:
-    case DeviceType::MTIA:
-    case DeviceType::PrivateUse1:
-      return true;
-    default:
-      return false;
-  }
-}
-
-std::ostream& operator<<(std::ostream& stream, DeviceType type) {
-  stream << DeviceTypeName(type, /* lower case */ true);
-  return stream;
-}
-
+namespace {
 // We use both a mutex and an atomic here because:
 // (1) Mutex is needed during writing:
 //     We need to first check the value and potentially error,
@@ -121,10 +19,12 @@ std::ostream& operator<<(std::ostream& stream, DeviceType type) {
 //     set this variable at the same time that another thread is print the
 //     device name. We could re-use the same mutex, but reading the atomic will
 //     be much faster.
-static std::atomic<bool> privateuse1_backend_name_set;
-static std::string privateuse1_backend_name;
-static std::mutex privateuse1_lock;
+std::atomic<bool> privateuse1_backend_name_set;
+std::string privateuse1_backend_name;
+std::mutex privateuse1_lock;
+} // namespace
 
+namespace torch::standalone {
 std::string get_privateuse1_backend(bool lower_case) {
   // Applying the same atomic read memory ordering logic as in Note [Memory
   // ordering on Python interpreter tag].
@@ -139,7 +39,9 @@ std::string get_privateuse1_backend(bool lower_case) {
       backend_name.begin(), backend_name.end(), backend_name.begin(), op_case);
   return backend_name;
 }
+} // namespace torch::standalone
 
+namespace c10 {
 void register_privateuse1_backend(const std::string& backend_name) {
   std::lock_guard<std::mutex> guard(privateuse1_lock);
   TORCH_CHECK(
@@ -164,5 +66,4 @@ void register_privateuse1_backend(const std::string& backend_name) {
 bool is_privateuse1_backend_registered() {
   return privateuse1_backend_name_set.load(std::memory_order_acquire);
 }
-
 } // namespace c10

--- a/c10/core/DeviceType.h
+++ b/c10/core/DeviceType.h
@@ -5,117 +5,43 @@
 // ATen/core (which would require a lot more build system hacking.)
 // If you modify me, keep me synchronized with that file.
 
-#include <c10/macros/Export.h>
-
-#include <cstddef>
-#include <cstdint>
-#include <functional>
-#include <ostream>
-#include <string>
+#include <torch/standalone/core/DeviceType.h>
 
 namespace c10 {
+using torch::standalone::DeviceType;
+// clang-format off
+// Turn off clang-format for this section to avoid reordering
+using torch::standalone::kCPU;
+using torch::standalone::kCUDA;
+using torch::standalone::kMKLDNN;
+using torch::standalone::kOPENGL;
+using torch::standalone::kOPENCL;
+using torch::standalone::kIDEEP;
+using torch::standalone::kHIP;
+using torch::standalone::kFPGA;
+using torch::standalone::kMAIA;
+using torch::standalone::kXLA;
+using torch::standalone::kVulkan;
+using torch::standalone::kMetal;
+using torch::standalone::kXPU;
+using torch::standalone::kMPS;
+using torch::standalone::kMeta;
+using torch::standalone::kHPU;
+using torch::standalone::kVE;
+using torch::standalone::kLazy;
+using torch::standalone::kIPU;
+using torch::standalone::kMTIA;
+using torch::standalone::kPrivateUse1;
+using torch::standalone::COMPILE_TIME_MAX_DEVICE_TYPES;
+// clang-format on
 
-// These contains all device types that also have a BackendComponent
-// and therefore participate in per-backend functionality dispatch keys.
-// This is most backends except PrivateUse2 and PrivateUse3
-#define C10_FORALL_BACKEND_DEVICE_TYPES(_, extra) \
-  _(CPU, extra)                                   \
-  _(CUDA, extra)                                  \
-  _(HIP, extra)                                   \
-  _(XLA, extra)                                   \
-  _(MPS, extra)                                   \
-  _(IPU, extra)                                   \
-  _(XPU, extra)                                   \
-  _(HPU, extra)                                   \
-  _(VE, extra)                                    \
-  _(Lazy, extra)                                  \
-  _(Meta, extra)                                  \
-  _(MTIA, extra)                                  \
-  _(PrivateUse1, extra)
-
-enum class DeviceType : int8_t {
-  CPU = 0,
-  CUDA = 1, // CUDA.
-  MKLDNN = 2, // Reserved for explicit MKLDNN
-  OPENGL = 3, // OpenGL
-  OPENCL = 4, // OpenCL
-  IDEEP = 5, // IDEEP.
-  HIP = 6, // AMD HIP
-  FPGA = 7, // FPGA
-  MAIA = 8, // ONNX Runtime / Microsoft
-  XLA = 9, // XLA / TPU
-  Vulkan = 10, // Vulkan
-  Metal = 11, // Metal
-  XPU = 12, // XPU
-  MPS = 13, // MPS
-  Meta = 14, // Meta (tensors with no data)
-  HPU = 15, // HPU / HABANA
-  VE = 16, // SX-Aurora / NEC
-  Lazy = 17, // Lazy Tensors
-  IPU = 18, // Graphcore IPU
-  MTIA = 19, // Meta training and inference devices
-  PrivateUse1 = 20, // PrivateUse1 device
-  // NB: If you add more devices:
-  //  - Change the implementations of DeviceTypeName and isValidDeviceType
-  //    in DeviceType.cpp
-  //  - Change the number below
-  COMPILE_TIME_MAX_DEVICE_TYPES = 21,
-};
-
-constexpr DeviceType kCPU = DeviceType::CPU;
-constexpr DeviceType kCUDA = DeviceType::CUDA;
-constexpr DeviceType kHIP = DeviceType::HIP;
-constexpr DeviceType kFPGA = DeviceType::FPGA;
-constexpr DeviceType kMAIA = DeviceType::MAIA;
-constexpr DeviceType kXLA = DeviceType::XLA;
-constexpr DeviceType kMPS = DeviceType::MPS;
-constexpr DeviceType kMeta = DeviceType::Meta;
-constexpr DeviceType kVulkan = DeviceType::Vulkan;
-constexpr DeviceType kMetal = DeviceType::Metal;
-constexpr DeviceType kXPU = DeviceType::XPU;
-constexpr DeviceType kHPU = DeviceType::HPU;
-constexpr DeviceType kVE = DeviceType::VE;
-constexpr DeviceType kLazy = DeviceType::Lazy;
-constexpr DeviceType kIPU = DeviceType::IPU;
-constexpr DeviceType kMTIA = DeviceType::MTIA;
-constexpr DeviceType kPrivateUse1 = DeviceType::PrivateUse1;
-
-// define explicit int constant
-constexpr int COMPILE_TIME_MAX_DEVICE_TYPES =
-    static_cast<int>(DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES);
-
-static_assert(
-    COMPILE_TIME_MAX_DEVICE_TYPES <= 21,
-    "Hey!  You seem to be adding a lot of new DeviceTypes.  The intent was "
-    "for this constant to reflect the actual number of DeviceTypes we support "
-    "in PyTorch; it's important that this number is not too large as we "
-    "use this to allocate stack arrays in some places in our code.  If you "
-    "are indeed just adding the 20th device type, feel free to change "
-    "the check to 32; but if you are adding some sort of extensible device "
-    "types registration, please be aware that you are affecting code that "
-    "this number is small.  Try auditing uses of this constant.");
-
-C10_API std::string DeviceTypeName(DeviceType d, bool lower_case = false);
-
-C10_API bool isValidDeviceType(DeviceType d);
-
-C10_API std::ostream& operator<<(std::ostream& stream, DeviceType type);
+using torch::standalone::DeviceTypeName;
+using torch::standalone::get_privateuse1_backend;
+using torch::standalone::isValidDeviceType;
 
 C10_API void register_privateuse1_backend(const std::string& backend_name);
-C10_API std::string get_privateuse1_backend(bool lower_case = true);
-
 C10_API bool is_privateuse1_backend_registered();
-
 } // namespace c10
-
-namespace std {
-template <>
-struct hash<c10::DeviceType> {
-  std::size_t operator()(c10::DeviceType k) const {
-    return std::hash<int>()(static_cast<int>(k));
-  }
-};
-} // namespace std
 
 namespace torch {
 // NOLINTNEXTLINE(misc-unused-using-decls)

--- a/c10/core/build.bzl
+++ b/c10/core/build.bzl
@@ -80,6 +80,7 @@ def define_targets(rules):
         deps = [
             ":ScalarType",
             "//third_party/cpuinfo",
+            "//:torch_standalone_headers",
             "//c10/macros",
             "//c10/util:TypeCast",
             "//c10/util:base",

--- a/c10/ovrsource_defs.bzl
+++ b/c10/ovrsource_defs.bzl
@@ -74,6 +74,7 @@ def define_c10_ovrsource(name, is_mobile):
             ],
         }),
         exported_deps = [
+            "//xplat/caffe2:torch_standalone_headers",
             ":ovrsource_c10_cmake_macros.h",
             "//arvr/third-party/gflags:gflags",
             "//third-party/cpuinfo:cpuinfo",

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1289,7 +1289,8 @@ endif()
 target_include_directories(torch_cpu PRIVATE ${ATen_CPU_INCLUDE})
 
 target_include_directories(torch_cpu PRIVATE
-  ${TORCH_SRC_DIR}/csrc)
+  ${TORCH_SRC_DIR}/csrc
+  ${TORCH_SRC_DIR}/standalone)
 
 target_include_directories(torch_cpu PRIVATE
   ${TORCH_ROOT}/third_party/miniz-3.0.2)
@@ -1308,9 +1309,12 @@ target_include_directories(torch_cpu PRIVATE
 target_include_directories(torch_cpu PRIVATE
   ${TORCH_ROOT}/third_party/nlohmann/include)
 
-install(DIRECTORY "${TORCH_SRC_DIR}/csrc"
+install(DIRECTORY
+  "${TORCH_SRC_DIR}/csrc"
+  "${TORCH_SRC_DIR}/standalone"
   DESTINATION ${TORCH_INSTALL_INCLUDE_DIR}/torch
   FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp")
+
 install(FILES
   "${TORCH_SRC_DIR}/script.h"
   "${TORCH_SRC_DIR}/extension.h"

--- a/test/cpp/aoti_abi_check/CMakeLists.txt
+++ b/test/cpp/aoti_abi_check/CMakeLists.txt
@@ -4,6 +4,7 @@ set(AOTI_ABI_CHECK_TEST_ROOT ${TORCH_ROOT}/test/cpp/aoti_abi_check)
 set(AOTI_ABI_CHECK_TEST_SRCS
   ${AOTI_ABI_CHECK_TEST_ROOT}/main.cpp
   ${AOTI_ABI_CHECK_TEST_ROOT}/test_cast.cpp
+  ${AOTI_ABI_CHECK_TEST_ROOT}/test_core.cpp
   ${AOTI_ABI_CHECK_TEST_ROOT}/test_dtype.cpp
   ${AOTI_ABI_CHECK_TEST_ROOT}/test_math.cpp
   ${AOTI_ABI_CHECK_TEST_ROOT}/test_rand.cpp
@@ -16,6 +17,7 @@ add_executable(test_aoti_abi_check
 
 # TODO temporary until we can delete the old gtest polyfills.
 target_compile_definitions(test_aoti_abi_check PRIVATE USE_GTEST)
+target_compile_definitions(test_aoti_abi_check PRIVATE TORCH_STANDALONE)
 
 # WARNING: DO NOT LINK torch!!!
 # The purpose is to check if the used aten/c10 headers are writtern in a header-only way

--- a/test/cpp/aoti_abi_check/test_core.cpp
+++ b/test/cpp/aoti_abi_check/test_core.cpp
@@ -1,0 +1,49 @@
+#include <gtest/gtest.h>
+
+#include <torch/standalone/core/DeviceType.h>
+
+namespace torch {
+namespace standalone {
+TEST(TestCore, TestDeviceType) {
+  // clang-format off
+  constexpr DeviceType expected_device_types[] = {
+    kCPU,
+    kCUDA,
+    kMKLDNN,
+    kOPENGL,
+    kOPENCL,
+    kIDEEP,
+    kHIP,
+    kFPGA,
+    kMAIA,
+    kXLA,
+    kVulkan,
+    kMetal,
+    kXPU,
+    kMPS,
+    kMeta,
+    kHPU,
+    kVE,
+    kLazy,
+    kIPU,
+    kMTIA,
+    kPrivateUse1,
+  };
+  // clang-format on
+  for (int8_t i = 0;
+       i < static_cast<int8_t>(DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES);
+       ++i) {
+    EXPECT_EQ(static_cast<DeviceType>(i), expected_device_types[i]);
+  }
+}
+
+TEST(TestCore, PrintDeviceType) {
+  for (int8_t i = 0;
+       i < static_cast<int8_t>(DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES);
+       ++i) {
+    std::cout << i << ": DeviceType::" << static_cast<DeviceType>(i)
+              << std::endl;
+  }
+}
+} // namespace standalone
+} // namespace torch

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -74,6 +74,7 @@ set(TORCH_PYTHON_INCLUDE_DIRECTORIES
     ${TORCH_SRC_DIR}/csrc
     ${TORCH_SRC_DIR}/csrc/api/include
     ${TORCH_SRC_DIR}/lib
+    ${TORCH_SRC_DIR}/standalone
     )
 
 list(APPEND TORCH_PYTHON_INCLUDE_DIRECTORIES ${LIBSHM_SRCDIR})

--- a/torch/csrc/PyInterpreter.cpp
+++ b/torch/csrc/PyInterpreter.cpp
@@ -20,24 +20,25 @@ namespace {
 // because passing in constexpr char* as template argument breaks some
 // versions of MSVC that are being used internally at Meta.
 // MSVC 14.16.27023 (vs2017_15.9)
-#define CONCRETE_GPU_TRACE(device_type, func_name, ...)                       \
-  at::impl::MaybeSetTLSOnEntryGuard guard;                                    \
-  if (Py_IsInitialized()) {                                                   \
-    pybind11::gil_scoped_acquire gil;                                         \
-    try {                                                                     \
-      /* Masquerade hip as cuda because hip uses `torch.cuda` module. */      \
-      if (device_type == at::kHIP) {                                          \
-        device_type = at::kCUDA;                                              \
-      }                                                                       \
-      std::string module_name = "torch." + DeviceTypeName(device_type, true); \
-      py::module mod = py::module::import(module_name.c_str());               \
-      py::object hook =                                                       \
-          mod.attr("_gpu_trace").attr(func_name).attr("fire_callbacks");      \
-      hook(__VA_ARGS__);                                                      \
-    } catch (const std::exception& e) {                                       \
-      LOG(ERROR) << device_type                                               \
-                 << " trace hook execution failed: " << e.what();             \
-    }                                                                         \
+#define CONCRETE_GPU_TRACE(device_type, func_name, ...)                  \
+  at::impl::MaybeSetTLSOnEntryGuard guard;                               \
+  if (Py_IsInitialized()) {                                              \
+    pybind11::gil_scoped_acquire gil;                                    \
+    try {                                                                \
+      /* Masquerade hip as cuda because hip uses `torch.cuda` module. */ \
+      if (device_type == at::kHIP) {                                     \
+        device_type = at::kCUDA;                                         \
+      }                                                                  \
+      std::string module_name =                                          \
+          "torch." + c10::DeviceTypeName(device_type, true);             \
+      py::module mod = py::module::import(module_name.c_str());          \
+      py::object hook =                                                  \
+          mod.attr("_gpu_trace").attr(func_name).attr("fire_callbacks"); \
+      hook(__VA_ARGS__);                                                 \
+    } catch (const std::exception& e) {                                  \
+      LOG(ERROR) << device_type                                          \
+                 << " trace hook execution failed: " << e.what();        \
+    }                                                                    \
   }
 
 struct ConcretePyInterpreterVTable final

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -1032,7 +1032,8 @@ static const std::vector<OperatorGeneratorArgs> opGenArgs{
         [](Stack& stack) {
           auto d = pop(stack);
           push(
-              stack, DeviceTypeName(d.toDevice().type(), /* lower_case=*/true));
+              stack,
+              c10::DeviceTypeName(d.toDevice().type(), /* lower_case=*/true));
         },
         aliasAnalysisFromSchema()),
     // tensor length op (size of 1st dimension)

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -620,7 +620,7 @@ PickleOpCode Unpickler::readInstruction() {
             "supported devices include CPU, CUDA, HPU and ",
             c10::get_privateuse1_backend(),
             " however got ",
-            DeviceTypeName(device.type(), false));
+            c10::DeviceTypeName(device.type(), false));
       }
       stack_.emplace_back(std::move(tensor));
     } break;

--- a/torch/standalone/core/DeviceType.h
+++ b/torch/standalone/core/DeviceType.h
@@ -1,0 +1,221 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <ostream>
+#include <string>
+
+#include <c10/macros/Export.h>
+#include <c10/util/Exception.h>
+
+// Need to follow C10_API's behavior here
+// TODO: refactor part of c10/macros/Export.h to torch/standalone
+#ifdef C10_BUILD_MAIN_LIB
+#define TORCH_STANDALONE_API C10_EXPORT
+#else
+#define TORCH_STANDALONE_API C10_IMPORT
+#endif
+
+namespace torch::standalone {
+// These contains all device types that also have a BackendComponent
+// and therefore participate in per-backend functionality dispatch keys.
+// This is most backends except PrivateUse2 and PrivateUse3
+#define C10_FORALL_BACKEND_DEVICE_TYPES(_, extra) \
+  _(CPU, extra)                                   \
+  _(CUDA, extra)                                  \
+  _(HIP, extra)                                   \
+  _(XLA, extra)                                   \
+  _(MPS, extra)                                   \
+  _(IPU, extra)                                   \
+  _(XPU, extra)                                   \
+  _(HPU, extra)                                   \
+  _(VE, extra)                                    \
+  _(Lazy, extra)                                  \
+  _(Meta, extra)                                  \
+  _(MTIA, extra)                                  \
+  _(PrivateUse1, extra)
+
+enum class DeviceType : int8_t {
+  CPU = 0,
+  CUDA = 1, // CUDA.
+  MKLDNN = 2, // Reserved for explicit MKLDNN
+  OPENGL = 3, // OpenGL
+  OPENCL = 4, // OpenCL
+  IDEEP = 5, // IDEEP.
+  HIP = 6, // AMD HIP
+  FPGA = 7, // FPGA
+  MAIA = 8, // ONNX Runtime / Microsoft
+  XLA = 9, // XLA / TPU
+  Vulkan = 10, // Vulkan
+  Metal = 11, // Metal
+  XPU = 12, // XPU
+  MPS = 13, // MPS
+  Meta = 14, // Meta (tensors with no data)
+  HPU = 15, // HPU / HABANA
+  VE = 16, // SX-Aurora / NEC
+  Lazy = 17, // Lazy Tensors
+  IPU = 18, // Graphcore IPU
+  MTIA = 19, // Meta training and inference devices
+  PrivateUse1 = 20, // PrivateUse1 device
+  // NB: If you add more devices:
+  //  - Change the implementations of DeviceTypeName and isValidDeviceType
+  //  - Change the number below
+  COMPILE_TIME_MAX_DEVICE_TYPES = 21,
+};
+
+constexpr DeviceType kCPU = DeviceType::CPU;
+constexpr DeviceType kCUDA = DeviceType::CUDA;
+constexpr DeviceType kMKLDNN = DeviceType::MKLDNN;
+constexpr DeviceType kOPENGL = DeviceType::OPENGL;
+constexpr DeviceType kOPENCL = DeviceType::OPENCL;
+constexpr DeviceType kIDEEP = DeviceType::IDEEP;
+constexpr DeviceType kHIP = DeviceType::HIP;
+constexpr DeviceType kFPGA = DeviceType::FPGA;
+constexpr DeviceType kMAIA = DeviceType::MAIA;
+constexpr DeviceType kXLA = DeviceType::XLA;
+constexpr DeviceType kVulkan = DeviceType::Vulkan;
+constexpr DeviceType kMetal = DeviceType::Metal;
+constexpr DeviceType kXPU = DeviceType::XPU;
+constexpr DeviceType kMPS = DeviceType::MPS;
+constexpr DeviceType kMeta = DeviceType::Meta;
+constexpr DeviceType kHPU = DeviceType::HPU;
+constexpr DeviceType kVE = DeviceType::VE;
+constexpr DeviceType kLazy = DeviceType::Lazy;
+constexpr DeviceType kIPU = DeviceType::IPU;
+constexpr DeviceType kMTIA = DeviceType::MTIA;
+constexpr DeviceType kPrivateUse1 = DeviceType::PrivateUse1;
+
+// define explicit int constant
+constexpr int COMPILE_TIME_MAX_DEVICE_TYPES =
+    static_cast<int>(DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES);
+
+static_assert(
+    COMPILE_TIME_MAX_DEVICE_TYPES <= 21,
+    "Hey!  You seem to be adding a lot of new DeviceTypes.  The intent was "
+    "for this constant to reflect the actual number of DeviceTypes we support "
+    "in PyTorch; it's important that this number is not too large as we "
+    "use this to allocate stack arrays in some places in our code.  If you "
+    "are indeed just adding the 20th device type, feel free to change "
+    "the check to 32; but if you are adding some sort of extensible device "
+    "types registration, please be aware that you are affecting code that "
+    "this number is small.  Try auditing uses of this constant.");
+
+// NB: Per the C++ standard (e.g.,
+// https://stackoverflow.com/questions/18195312/what-happens-if-you-static-cast-invalid-value-to-enum-class)
+// as long as you cast from the same underlying type, it is always valid to cast
+// into an enum class (even if the value would be invalid by the enum.)  Thus,
+// the caller is allowed to cast a possibly invalid int16_t to DeviceType and
+// then pass it to this function.  (I considered making this function take an
+// int16_t directly, but that just seemed weird.)
+inline TORCH_STANDALONE_API bool isValidDeviceType(DeviceType d) {
+  switch (d) {
+    case DeviceType::CPU:
+    case DeviceType::CUDA:
+    case DeviceType::OPENGL:
+    case DeviceType::OPENCL:
+    case DeviceType::MKLDNN:
+    case DeviceType::IDEEP:
+    case DeviceType::HIP:
+    case DeviceType::VE:
+    case DeviceType::FPGA:
+    case DeviceType::MAIA:
+    case DeviceType::XLA:
+    case DeviceType::Lazy:
+    case DeviceType::MPS:
+    case DeviceType::Vulkan:
+    case DeviceType::Metal:
+    case DeviceType::XPU:
+    case DeviceType::Meta:
+    case DeviceType::HPU:
+    case DeviceType::IPU:
+    case DeviceType::MTIA:
+    case DeviceType::PrivateUse1:
+      return true;
+    default:
+      return false;
+  }
+}
+
+#ifdef TORCH_STANDALONE
+// The standalone mode doesn't support register_privateuse1_backend
+inline TORCH_STANDALONE_API std::string get_privateuse1_backend(bool lower_case = true) {
+    return lower_case ? "privateuse1" : "PrivateUse1";
+}
+#else
+TORCH_STANDALONE_API std::string get_privateuse1_backend(bool lower_case = true);
+#endif
+
+inline TORCH_STANDALONE_API std::string DeviceTypeName(DeviceType d, bool lower_case = false) {
+  switch (d) {
+    // I considered instead using ctype::tolower to lower-case the strings
+    // on the fly, but this seemed a bit much.
+    case DeviceType::CPU:
+      return lower_case ? "cpu" : "CPU";
+    case DeviceType::CUDA:
+      return lower_case ? "cuda" : "CUDA";
+    case DeviceType::OPENGL:
+      return lower_case ? "opengl" : "OPENGL";
+    case DeviceType::OPENCL:
+      return lower_case ? "opencl" : "OPENCL";
+    case DeviceType::MKLDNN:
+      return lower_case ? "mkldnn" : "MKLDNN";
+    case DeviceType::IDEEP:
+      return lower_case ? "ideep" : "IDEEP";
+    case DeviceType::HIP:
+      return lower_case ? "hip" : "HIP";
+    case DeviceType::VE:
+      return lower_case ? "ve" : "VE";
+    case DeviceType::FPGA:
+      return lower_case ? "fpga" : "FPGA";
+    case DeviceType::MAIA:
+      return lower_case ? "maia" : "MAIA";
+    case DeviceType::XLA:
+      return lower_case ? "xla" : "XLA";
+    case DeviceType::Lazy:
+      return lower_case ? "lazy" : "LAZY";
+    case DeviceType::MPS:
+      return lower_case ? "mps" : "MPS";
+    case DeviceType::Vulkan:
+      return lower_case ? "vulkan" : "VULKAN";
+    case DeviceType::Metal:
+      return lower_case ? "metal" : "METAL";
+    case DeviceType::XPU:
+      return lower_case ? "xpu" : "XPU";
+    case DeviceType::Meta:
+      return lower_case ? "meta" : "META";
+    case DeviceType::HPU:
+      return lower_case ? "hpu" : "HPU";
+    case DeviceType::IPU:
+      return lower_case ? "ipu" : "IPU";
+    case DeviceType::MTIA:
+      return lower_case ? "mtia" : "MTIA";
+    case DeviceType::PrivateUse1:
+      return get_privateuse1_backend(lower_case);
+    default:
+      TORCH_CHECK(
+          false,
+          "Unknown device: ",
+          static_cast<int16_t>(d),
+          ". If you have recently updated the caffe2.proto file to add a new "
+          "device type, did you forget to update the DeviceTypeName() "
+          "function to reflect such recent changes?");
+      // The below code won't run but is needed to suppress some compiler
+      // warnings.
+      return "";
+  }
+}
+
+inline TORCH_STANDALONE_API std::ostream& operator<<(std::ostream& stream, DeviceType type) {
+  stream << DeviceTypeName(type, /* lower case */ true);
+  return stream;
+}
+} // namespace torch::standalone
+
+namespace std {
+template <>
+struct hash<torch::standalone::DeviceType> {
+  std::size_t operator()(torch::standalone::DeviceType k) const {
+    return std::hash<int>()(static_cast<int>(k));
+  }
+};
+} // namespace std


### PR DESCRIPTION
Summary:
The goal of this PR and future follow-up PRs is to group a set of header files required by AOTInductor Standalone in a separate directory, ensuring they are implemented in a header-only manner. More specifically, here is what this PR does:
* Extract the DeviceType enum class into a standalone header file in a new torch/standalone/header_only directory
* Retain the existing c10/core/DeviceType.[h|cpp] files to handle complex logic and static variables
* Import symbols from the new torch::standalone namespace into c10 for backward compatibility

This is an updated version of https://github.com/pytorch/pytorch/pull/152787, because we need to land in fbcode first. See the original comments and discussions in https://github.com/pytorch/pytorch/pull/152787.

Test Plan: CI

Differential Revision: D75313723




cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel