### PR TITLE
[c10d][CI] Skip return code check in Sandcastle for Nan tests

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -49,6 +49,7 @@ from torch.testing._internal.common_distributed import (
     requires_nccl_version,
     skip_if_lt_x_gpu,
     skip_if_rocm_multiprocess,
+    skip_sandcastle,
     sm_is_or_higher_than,
     TEST_SKIPS,
     with_dist_debug_levels,
@@ -479,6 +480,9 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
         torch.version.cuda is not None and int(torch.version.cuda.split(".")[0]) >= 12
     )
 
+    # This test checks for specific return code (-6).  Have to use
+    # `skip_sandcastle` to return a TEST_SKIP code to avoid a return code check.
+    @skip_sandcastle
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(
         # skip for cu126 as well due to https://github.com/pytorch/pytorch/issues/153479

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -86,6 +86,9 @@ TEST_SKIPS = {
     ),
     "importerror": TestSkip(88, "Test skipped due to missing import"),
     "no_accelerator": TestSkip(89, "accelerator is not available."),
+    "skip_sandcastle": TestSkip(
+        90, "Skip test in Sandcastle returning skip code instead of pass."
+    ),
 }
 
 
@@ -126,6 +129,23 @@ def skip_if_no_gpu(func):
             sys.exit(TEST_SKIPS[f"multi-gpu-{world_size}"].exit_code)
         if TEST_XPU and torch.xpu.device_count < world_size:
             sys.exit(TEST_SKIPS[f"multi-xpu-{world_size}"].exit_code)
+
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def skip_sandcastle(func):
+    """Skips if run in sandcastle, returning skip code 90 instead of pass. This
+    is different from `skip_but_pass_in_sandcastle` which returns pass code 0.
+    Note: for most cases, you should use `skip_but_pass_in_sandcastle`
+    instead"""
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if IS_SANDCASTLE:
+            print("Skip test in Sandcastle returning skip code instead of pass.")
+            sys.exit(TEST_SKIPS["skip_sandcastle"].exit_code)
 
         return func(*args, **kwargs)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #154439
* #153167

Fixing internal error caused by #153167.

`skip_but_pass_in_sandcastle_if` returns exit code 0. But `test_nan_assert` expects exit code -6. 
So we'd need a decorator that return an actual skip code, if order to tell the test to not check for return code.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k