### PR TITLE
Change result for opacus_cifar10 inductor_torchbench_inference

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_inference.csv
@@ -254,7 +254,7 @@ nvidia_deeprecommender,pass,0
 
 
 
-opacus_cifar10,pass,0
+opacus_cifar10,eager_fail_to_run,0
 
 
 


### PR DESCRIPTION
After https://github.com/pytorch/pytorch/pull/154153 the opacus_cifar10 inductor test have regressed

Hud:
https://hud.pytorch.org/hud/pytorch/pytorch/b8452e55bc50109a14add60397fee6c85486ae8d/1?per_page=50&name_filter=inductor_torchbench&mergeEphemeralLF=true




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames