### PR TITLE
[CI][CUDA] Re-enable the test-nan-assert on CUDA12

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -485,7 +485,7 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(
         # skip for cu126 as well due to https://github.com/pytorch/pytorch/issues/153479
-        not (TEST_MULTIGPU and CUDA_12_AND_ABOVE and False),
+        not (TEST_MULTIGPU and CUDA_12_AND_ABOVE),
         "NCCL test requires 2+ GPUs and Device side assert could cause unexpected errors in lower versions of CUDA",
     )
     @parametrize(
@@ -539,10 +539,15 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
         backend._set_enable_nan_check(False)
         # Note: using all-gather here bc some NCCL/SM version does not support
         # FP8 reduction
-        pg._allgather_base(output, nan_tensor)
+        # temporarily skip due to https://github.com/pytorch/pytorch/issues/153479
+        # pg._allgather_base(output, nan_tensor)
 
         backend._set_enable_nan_check(True)
-        pg._allgather_base(output, nan_tensor)
+        try:
+            pg._allgather_base(output, nan_tensor)
+        except Exception:
+            sys.exit(signal.SIGABRT)
+
         dist.destroy_process_group()
 
         # reset env

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -546,7 +546,7 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
         try:
             pg._allgather_base(output, nan_tensor)
         except Exception:
-            sys.exit(signal.SIGABRT)
+            sys.exit(-signal.SIGABRT)  # This will give -6
 
         dist.destroy_process_group()
 

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -546,7 +546,7 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
         try:
             pg._allgather_base(output, nan_tensor)
         except Exception:
-            sys.exit(-signal.SIGABRT)  # This will give -6
+            os._exit(-signal.SIGABRT)  # This will actually give -6
 
         dist.destroy_process_group()
 

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -285,11 +285,9 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
     def setUp(self):
         super().setUp()
 
-        # These tests are expected to throw SIGABRT(6); adding the negative sign
-        # bc the test return code is actually -6
-        # but somehow the 2's complement of -6 (250 in decimal) is the return code
+        # These tests are expected to throw SIGABRT(6);
         # But if we are in Sandcastle, `skip_but_pass_in_sandcastle` would return 0.
-        TEST_NAN_ASSERT_RETURN = 0 if IS_SANDCASTLE else (256-signal.SIGABRT)
+        TEST_NAN_ASSERT_RETURN = 0 if IS_SANDCASTLE else signal.SIGABRT
         self.special_return_code_checks = {
             self.test_nan_assert_float16.__wrapped__: TEST_NAN_ASSERT_RETURN,
             self.test_nan_assert_float32.__wrapped__: TEST_NAN_ASSERT_RETURN,
@@ -547,7 +545,7 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
         try:
             pg._allgather_base(output, nan_tensor)
         except Exception:
-            os._exit(-signal.SIGABRT)  # This will actually give -6
+            sys.exit(signal.SIGABRT)
 
         dist.destroy_process_group()
 

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -287,8 +287,9 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
 
         # These tests are expected to throw SIGABRT(6); adding the negative sign
         # bc the test return code is actually -6
+        # but somehow the 2's complement of -6 (250 in decimal) is the return code
         # But if we are in Sandcastle, `skip_but_pass_in_sandcastle` would return 0.
-        TEST_NAN_ASSERT_RETURN = 0 if IS_SANDCASTLE else -signal.SIGABRT
+        TEST_NAN_ASSERT_RETURN = 0 if IS_SANDCASTLE else (256-signal.SIGABRT)
         self.special_return_code_checks = {
             self.test_nan_assert_float16.__wrapped__: TEST_NAN_ASSERT_RETURN,
             self.test_nan_assert_float32.__wrapped__: TEST_NAN_ASSERT_RETURN,


### PR DESCRIPTION
We need to reenable this test because there are recent changes that could be relevant to test_nan_assert. 

I've already tested that there would be hang if we don't remove the "pg._allgather_base(output, nan_tensor)" in between the "backend._set_enable_nan_check" calls. 
Why was it "working" previously? Because previously only cu118 distributed was running and this "backend._set_enable_nan_check" change was not tested in the merge process (skip logic is if "not CUDA 12 and above", skip). 

Workaround #153479 

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @kwen2501 @ptrblck @eqy @tinglvv @malfet @atalman 
