### PR TITLE
Add env var to disable WaitCounters

### DIFF
--- a/torch/monitor/__init__.py
+++ b/torch/monitor/__init__.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 from torch._C._monitor import *  # noqa: F403
-from torch._C._monitor import _WaitCounter, _WaitCounterTracker
+from torch.monitor.waitcounter import _WaitCounter, _WaitCounterTracker  # noqa: F403
 
 
 if TYPE_CHECKING:

--- a/torch/monitor/waitcounter.py
+++ b/torch/monitor/waitcounter.py
@@ -1,0 +1,31 @@
+import os
+
+from torch._C._monitor import _WaitCounter as _OriginalWaitCounter, _WaitCounterTracker
+
+
+class _NoopWaitCounterTracker:
+    def __enter__(self) -> None:
+        pass
+
+    def __exit__(self, *args: object, **kwargs: object) -> None:
+        pass
+
+
+class _NoopWaitCounter:
+    def __init__(self, key: str) -> None:
+        pass
+
+    def guard(self) -> _WaitCounterTracker:
+        return _NoopWaitCounterTracker()  # type: ignore[return-value]
+
+
+class _WaitCounter:
+    """
+    Wrapper around torch._C._monitor._WaitCounter to control enable/disable
+    """
+
+    def __new__(cls, key: str) -> _OriginalWaitCounter:  # type: ignore[misc]
+        if os.getenv("TORCH_DISABLE_WAIT_COUNTERS", "0") == "1":
+            return _NoopWaitCounter(key)  # type: ignore[return-value]
+        else:
+            return _OriginalWaitCounter(key)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #154450

WaitCounters emit a TON of logs in fbcode, forking 80 processes results in 12000+ lines of logs, and makes debugging really hard. This PR adds an env var to disable waitcounter for local development.
