### PR TITLE
[Inductor] Fix remove_noop_ops pass where the types for the same_meta would differ

### DIFF
--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -891,8 +891,8 @@ def same_meta(node1: torch.fx.Node, node2: torch.fx.Node):
     val1 = node1.meta.get("val")
     val2 = node2.meta.get("val")
     return (
-        type(val1) is torch._subclasses.FakeTensor
-        and type(val2) is torch._subclasses.FakeTensor
+        issubclass(type(val1), torch.Tensor)
+        and issubclass(type(val2), torch.Tensor)
         and statically_known_true(sym_eq(val1.size(), val2.size()))
         and val1.layout == val2.layout
         and val1.dtype == val2.dtype

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -891,8 +891,8 @@ def same_meta(node1: torch.fx.Node, node2: torch.fx.Node):
     val1 = node1.meta.get("val")
     val2 = node2.meta.get("val")
     return (
-        val1 is not None
-        and val2 is not None
+        type(val1) is torch._subclasses.FakeTensor
+        and type(val2) is torch._subclasses.FakeTensor
         and statically_known_true(sym_eq(val1.size(), val2.size()))
         and val1.layout == val2.layout
         and val1.dtype == val2.dtype


### PR DESCRIPTION
Summary: Fixes a bug where the type of `val1` and `val2` for the `same_meta` function would differ. Leading to a compiler crash, since types other than `Tensor` and `FakeTensor` don't have the following attributes.

The problem has been spotted by me in the wild, where `val2` would be of type `SymInt`, while the expected type is `FakeTensor`. The setup is kinda convoluted to reproduce, but here are some other examples of people encountering this problem.

This problem only showed up when I tried to compile a large model using `dynamic=True`, so it's related to that.

https://github.com/chengzeyi/Comfy-WaveSpeed/issues/18
https://github.com/openvinotoolkit/openvino/issues/22412
https://github.com/pytorch/TensorRT/issues/2356

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben