### PR TITLE
[Intel GPU] fix matmul accuracy when offset > 0

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -294,6 +294,13 @@ bool is_onednn_matmul_strides(const at::Tensor& tensor) {
   if (tensor.is_contiguous())
     return true;
 
+  if (tensor.storage_offset() > 0) {
+    // currently onednn asks 64 byte alignment
+    constexpr int alignment_byte = 64;
+    if (reinterpret_cast<uintptr_t>(tensor.data_ptr()) % alignment_byte > 0)
+      return false;
+  }
+
   // the overlaped cases are not supported
   dnnl::memory::dims strides = get_onednn_strides(tensor);
   int64_t storage_size = 1;

--- a/test/xpu/test_gemm.py
+++ b/test/xpu/test_gemm.py
@@ -1346,24 +1346,23 @@ class TestBasicGEMM(TestCase):
 
     def test_mm_with_offset(self, device):
         from torch._dynamo.testing import rand_strided
+
         offset = 997
-        a = rand_strided((2, 4, 128, 64),
-                         (65536, 16384, 64, 1),
-                         dtype=torch.float16,
-                         device=device,
-                         extra_size=offset)
-        a = a.as_strided((2, 4, 128, 64),
-                         (65536, 16384, 64, 1),
-                         storage_offset=offset)
-        b = rand_strided((2, 4, 64, 256),
-                         (65536, 16384, 1, 64),
-                         dtype=torch.float16,
-                         device=device)
+        a = rand_strided(
+            (2, 4, 128, 64),
+            (65536, 16384, 64, 1),
+            dtype=torch.float16,
+            device=device,
+            extra_size=offset,
+        )
+        a = a.as_strided((2, 4, 128, 64), (65536, 16384, 64, 1), storage_offset=offset)
+        b = rand_strided(
+            (2, 4, 64, 256), (65536, 16384, 1, 64), dtype=torch.float16, device=device
+        )
 
         gpu_out = torch.matmul(a, b)
         cpu_out = torch.matmul(a.cpu(), b.cpu())
         self.assertEqual(gpu_out.cpu(), cpu_out)
-
 
 
 instantiate_device_type_tests(TestBasicGEMM, globals(), only_for="xpu", allow_xpu=True)

--- a/test/xpu/test_gemm.py
+++ b/test/xpu/test_gemm.py
@@ -1344,6 +1344,27 @@ class TestBasicGEMM(TestCase):
             mean_err = ((res - ref).abs() / ref).mean()
             self.assertTrue(mean_err < 0.05)
 
+    def test_mm_with_offset(self, device):
+        from torch._dynamo.testing import rand_strided
+        offset = 997
+        a = rand_strided((2, 4, 128, 64),
+                         (65536, 16384, 64, 1),
+                         dtype=torch.float16,
+                         device=device,
+                         extra_size=offset)
+        a = a.as_strided((2, 4, 128, 64),
+                         (65536, 16384, 64, 1),
+                         storage_offset=offset)
+        b = rand_strided((2, 4, 64, 256),
+                         (65536, 16384, 1, 64),
+                         dtype=torch.float16,
+                         device=device)
+
+        gpu_out = torch.matmul(a, b)
+        cpu_out = torch.matmul(a.cpu(), b.cpu())
+        self.assertEqual(gpu_out.cpu(), cpu_out)
+
+
 
 instantiate_device_type_tests(TestBasicGEMM, globals(), only_for="xpu", allow_xpu=True)
 


### PR DESCRIPTION
This pr will make matmul tensors contiguous if they are not 64 byte alignment. oneDNN requires a minimal alignment of 64 https://uxlfoundation.github.io/oneDNN/dev_guide_c_and_cpp_apis.html#intel-r-processor-graphics-and-xe-architecture-graphics

Fixes https://github.com/intel/torch-xpu-ops/issues/1656


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168