### PR TITLE
[typing] Add missing type annotations to torch.nn.init module

### DIFF
--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -1,30 +1,97 @@
-# mypy: allow-untyped-defs
 """This file contains utilities for initializing neural network parameters."""
+
 import math
 import warnings
-from typing import Optional as _Optional
+from typing import Callable, Literal, Optional as _Optional, TypeVar, Union
+from typing_extensions import ParamSpec
 
 import torch
 from torch import Tensor
+
+
+__all__ = [
+    "calculate_gain",
+    "uniform_",
+    "normal_",
+    "trunc_normal_",
+    "constant_",
+    "ones_",
+    "zeros_",
+    "eye_",
+    "dirac_",
+    "xavier_uniform_",
+    "xavier_normal_",
+    "kaiming_uniform_",
+    "kaiming_normal_",
+    "orthogonal_",
+    "sparse_",
+    # Deprecated aliases (for backward compatibility)
+    "uniform",
+    "normal",
+    "constant",
+    "eye",
+    "dirac",
+    "xavier_uniform",
+    "xavier_normal",
+    "kaiming_uniform",
+    "kaiming_normal",
+    "orthogonal",
+    "sparse",
+]
+
+
+_R = TypeVar("_R")
+_P = ParamSpec("_P")
+
+_NonlinearityType = Literal[
+    "linear",
+    "conv1d",
+    "conv2d",
+    "conv3d",
+    "conv_transpose1d",
+    "conv_transpose2d",
+    "conv_transpose3d",
+    "sigmoid",
+    "tanh",
+    "relu",
+    "leaky_relu",
+    "selu",
+]
+
+_FanMode = Literal["fan_in", "fan_out"]
 
 
 # These no_grad_* functions are necessary as wrappers around the parts of these
 # functions that use `with torch.no_grad()`. The JIT doesn't support context
 # managers, so these need to be implemented as builtins. Using these wrappers
 # lets us keep those builtins small and re-usable.
-def _no_grad_uniform_(tensor, a, b, generator=None):
+def _no_grad_uniform_(
+    tensor: Tensor, a: float, b: float, generator: _Optional[torch.Generator] = None
+) -> Tensor:
     with torch.no_grad():
         return tensor.uniform_(a, b, generator=generator)
 
 
-def _no_grad_normal_(tensor, mean, std, generator=None):
+def _no_grad_normal_(
+    tensor: Tensor,
+    mean: float,
+    std: float,
+    generator: _Optional[torch.Generator] = None,
+) -> Tensor:
     with torch.no_grad():
         return tensor.normal_(mean, std, generator=generator)
 
 
-def _no_grad_trunc_normal_(tensor, mean, std, a, b, generator=None):
+def _no_grad_trunc_normal_(
+    tensor: Tensor,
+    mean: float,
+    std: float,
+    a: float,
+    b: float,
+    generator: _Optional[torch.Generator] = None,
+) -> Tensor:
     # Method based on https://people.sc.fsu.edu/~jburkardt/presentations/truncated_normal.pdf
-    def norm_cdf(x):
+    def norm_cdf(x: float) -> float:
         # Computes standard normal cumulative distribution function
         return (1.0 + math.erf(x / math.sqrt(2.0))) / 2.0
 
@@ -59,17 +126,19 @@ def _no_grad_trunc_normal_(tensor, mean, std, a, b, generator=None):
         return tensor
 
 
-def _no_grad_fill_(tensor, val):
+def _no_grad_fill_(tensor: Tensor, val: float) -> Tensor:
     with torch.no_grad():
         return tensor.fill_(val)
 
 
-def _no_grad_zero_(tensor):
+def _no_grad_zero_(tensor: Tensor) -> Tensor:
     with torch.no_grad():
         return tensor.zero_()
 
 
-def calculate_gain(nonlinearity, param=None):
+def calculate_gain(
+    nonlinearity: _NonlinearityType, param: _Optional[Union[int, float]] = None
+) -> float:
     r"""Return the recommended gain value for the given nonlinearity function.
 
     The values are as follows:
@@ -268,7 +337,7 @@ def zeros_(tensor: Tensor) -> Tensor:
     return _no_grad_zero_(tensor)
 
 
-def eye_(tensor):
+def eye_(tensor: Tensor) -> Tensor:
     r"""Fill the 2-dimensional input `Tensor` with the identity matrix.
 
     Preserves the identity of the inputs in `Linear` layers, where as
@@ -289,7 +358,7 @@ def eye_(tensor):
     return tensor
 
 
-def dirac_(tensor, groups=1):
+def dirac_(tensor: Tensor, groups: int = 1) -> Tensor:
     r"""Fill the {3, 4, 5}-dimensional input `Tensor` with the Dirac delta function.
 
     Preserves the identity of the inputs in `Convolutional`
@@ -342,7 +411,7 @@ def dirac_(tensor, groups=1):
     return tensor
 
 
-def _calculate_fan_in_and_fan_out(tensor):
+def _calculate_fan_in_and_fan_out(tensor: Tensor) -> tuple[int, int]:
     dimensions = tensor.dim()
     if dimensions < 2:
         raise ValueError(
@@ -443,7 +512,7 @@ def xavier_normal_(
     return _no_grad_normal_(tensor, 0.0, std, generator)
 
 
-def _calculate_correct_fan(tensor, mode):
+def _calculate_correct_fan(tensor: Tensor, mode: _FanMode) -> int:
     mode = mode.lower()
     valid_modes = ["fan_in", "fan_out"]
     if mode not in valid_modes:
@@ -456,10 +525,10 @@ def _calculate_correct_fan(tensor, mode):
 def kaiming_uniform_(
     tensor: Tensor,
     a: float = 0,
-    mode: str = "fan_in",
-    nonlinearity: str = "leaky_relu",
+    mode: _FanMode = "fan_in",
+    nonlinearity: _NonlinearityType = "leaky_relu",
     generator: _Optional[torch.Generator] = None,
-):
+) -> Tensor:
     r"""Fill the input `Tensor` with values using a Kaiming uniform distribution.
 
     The method is described in `Delving deep into rectifiers: Surpassing
@@ -521,10 +590,10 @@ def kaiming_uniform_(
 def kaiming_normal_(
     tensor: Tensor,
     a: float = 0,
-    mode: str = "fan_in",
-    nonlinearity: str = "leaky_relu",
+    mode: _FanMode = "fan_in",
+    nonlinearity: _NonlinearityType = "leaky_relu",
     generator: _Optional[torch.Generator] = None,
-):
+) -> Tensor:
     r"""Fill the input `Tensor` with values using a Kaiming normal distribution.
 
     The method is described in `Delving deep into rectifiers: Surpassing
@@ -572,10 +641,10 @@ def kaiming_normal_(
 
 
 def orthogonal_(
-    tensor,
-    gain=1,
+    tensor: Tensor,
+    gain: float = 1,
     generator: _Optional[torch.Generator] = None,
-):
+) -> Tensor:
     r"""Fill the input `Tensor` with a (semi) orthogonal matrix.
 
     Described in `Exact solutions to the nonlinear dynamics of learning in deep
@@ -623,11 +692,11 @@ def orthogonal_(
 
 
 def sparse_(
-    tensor,
-    sparsity,
-    std=0.01,
+    tensor: Tensor,
+    sparsity: float,
+    std: float = 0.01,
     generator: _Optional[torch.Generator] = None,
-):
+) -> Tensor:
     r"""Fill the 2D input `Tensor` as a sparse matrix.
 
     The non-zero elements will be drawn from the normal distribution
@@ -661,11 +730,11 @@ def sparse_(
 
 
 # for backward compatibility
-def _make_deprecate(meth):
+def _make_deprecate(meth: Callable[_P, _R]) -> Callable[_P, _R]:
     new_name = meth.__name__
     old_name = new_name[:-1]
 
-    def deprecated_init(*args, **kwargs):
+    def deprecated_init(*args: _P.args, **kwargs: _P.kwargs) -> _R:
         warnings.warn(
             f"`nn.init.{old_name}` is now deprecated in favor of `nn.init.{new_name}`.",
             FutureWarning,


### PR DESCRIPTION
## Summary

Adds missing type annotations to `torch.nn.init` and removes `# mypy: allow-untyped-defs` since all functions are now properly typed.

## Changes

- Added missing type annotations to initialization functions in the module.
- Added missing typing imports: `Any`, `Callable`, `Union`
- Removed `# mypy: allow-untyped-defs` comment
- Create Literal types for kaiming initialization mode and nonlinearity.
- Created `__all__`

## Why

Better IDE support, catches type errors earlier, and brings the module up to PyTorch's typing standards. No runtime changes - purely additive typing improvements.

Tested with existing test suite and lintrunner.