### PR TITLE
[ROCm] enable batched eigen decomposition (syevD_batched) on ROCm

### DIFF
--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -1306,10 +1306,8 @@ static void apply_syevd_batched_rocsolver(const Tensor& values, const Tensor& ve
   // rocsolver will manage the workspace size automatically
    if(!rocblas_is_managing_device_memory(handle))
         TORCH_ROCBLAS_CHECK(rocblas_set_workspace(handle, nullptr, 0));
-  
+
   TORCH_ROCBLAS_CHECK(_rocsolver_syevd_strided_batched<scalar_t>(
-    // static_cast<rocblas_handle>(at::cuda::getCurrentCUDABlasHandle()), // getCurrentCUDASolverDnHandle() can't be used
-    // static_cast<rocblas_handle>(getCurrentCUDASolverDnHandle()),
     handle,
     evect,
     uplo,

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -30,6 +30,7 @@
 
 #if defined(USE_ROCM)
 #include <rocsolver/rocsolver.h>
+#include <ATen/cuda/tunable/GemmRocblas.h>
 #define PYTORCH_ROCSOLVER_VERSION \
   (ROCSOLVER_VERSION_MAJOR * 10000 + ROCSOLVER_VERSION_MINOR * 100 + ROCSOLVER_VERSION_PATCH)
 #if (PYTORCH_ROCSOLVER_VERSION >= 33000)
@@ -1300,7 +1301,7 @@ static void apply_syevd_batched_rocsolver(const Tensor& values, const Tensor& ve
   auto& allocator = *at::cuda::getCUDADeviceAllocator();
   auto work_data = allocator.allocate(sizeof(scalar_t) * work_size);
 
-  TORCH_CUSOLVER_CHECK(static_cast<hipsolverStatus_t>(_rocsolver_syevd_strided_batched<scalar_t>(
+  TORCH_ROCBLAS_CHECK(_rocsolver_syevd_strided_batched<scalar_t>(
     static_cast<rocblas_handle>(at::cuda::getCurrentCUDABlasHandle()), // getCurrentCUDASolverDnHandle() can't be used
     evect,
     uplo,
@@ -1314,7 +1315,7 @@ static void apply_syevd_batched_rocsolver(const Tensor& values, const Tensor& ve
     work_stride,
     infos_data,
     batch_size
-  )));
+  ));
 }
 #endif // USE_ROCM && ROCSOLVER_SYEVD_BATCHED_ENABLED
 

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -1598,9 +1598,9 @@ static void linalg_eigh_rocsolver_syevd_batched(const Tensor& eigenvalues, const
 
 void linalg_eigh_cusolver(const Tensor& eigenvalues, const Tensor& eigenvectors, const Tensor& infos, bool upper, bool compute_eigenvectors) {
 #if defined(USE_ROCM)
-  if (ROCSOLVER_SYEVD_BATCHED_ENABLED && eigenvectors.size(-1) > 1 && (eigenvectors.scalar_type() == at::kFloat || eigenvectors.scalar_type() == at::kDouble))
+  if (ROCSOLVER_SYEVD_BATCHED_ENABLED && batchCount(eigenvectors) > 1 && (eigenvectors.scalar_type() == at::kFloat || eigenvectors.scalar_type() == at::kDouble))
     linalg_eigh_rocsolver_syevd_batched(eigenvalues, eigenvectors, infos, upper, compute_eigenvectors);
-  else // not ROCSOLVER_SYEVD_BATCHED_ENABLED on batch==1 or comllex input
+  else // not ROCSOLVER_SYEVD_BATCHED_ENABLED or batch==1 or complex input
     linalg_eigh_cusolver_syevd(eigenvalues, eigenvectors, infos, upper, compute_eigenvectors);
 #else // not USE_ROCM
   if (use_cusolver_syevj_batched_ && batchCount(eigenvectors) > 1 && eigenvectors.size(-1) <= 32) {

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -1598,9 +1598,11 @@ static void linalg_eigh_rocsolver_syevd_batched(const Tensor& eigenvalues, const
 
 void linalg_eigh_cusolver(const Tensor& eigenvalues, const Tensor& eigenvectors, const Tensor& infos, bool upper, bool compute_eigenvectors) {
 #if defined(USE_ROCM)
-  if (ROCSOLVER_SYEVD_BATCHED_ENABLED && batchCount(eigenvectors) > 1 && (eigenvectors.scalar_type() == at::kFloat || eigenvectors.scalar_type() == at::kDouble))
+#if ROCSOLVER_SYEVD_BATCHED_ENABLED
+  if (batchCount(eigenvectors) > 1 && (eigenvectors.scalar_type() == at::kFloat || eigenvectors.scalar_type() == at::kDouble))
     linalg_eigh_rocsolver_syevd_batched(eigenvalues, eigenvectors, infos, upper, compute_eigenvectors);
   else // not ROCSOLVER_SYEVD_BATCHED_ENABLED or batch==1 or complex input
+#endif // ROCSOLVER_SYEVD_BATCHED_ENABLED
     linalg_eigh_cusolver_syevd(eigenvalues, eigenvectors, infos, upper, compute_eigenvectors);
 #else // not USE_ROCM
   if (use_cusolver_syevj_batched_ && batchCount(eigenvectors) > 1 && eigenvectors.size(-1) <= 32) {

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -1215,6 +1215,7 @@ Tensor& orgqr_helper_cusolver(Tensor& result, const Tensor& tau) {
   return result;
 }
 
+#if defined(USE_ROCM) && ROCSOLVER_SYEVD_BATCHED_ENABLED
 template <typename scalar_t>
 rocblas_status _rocsolver_syevd_strided_batched(
     rocblas_handle handle,
@@ -1315,6 +1316,7 @@ static void apply_syevd_batched_rocsolver(const Tensor& values, const Tensor& ve
     batch_size
   )));
 }
+#endif // USE_ROCM && ROCSOLVER_SYEVD_BATCHED_ENABLED
 
 template <typename scalar_t>
 static void apply_syevd(const Tensor& values, const Tensor& vectors, const Tensor& infos, bool upper, bool compute_eigenvectors) {
@@ -1587,10 +1589,12 @@ static void linalg_eigh_cusolver_syevj_batched(const Tensor& eigenvalues, const 
   });
 }
 
+#if defined(USE_ROCM) && ROCSOLVER_SYEVD_BATCHED_ENABLED
 static void linalg_eigh_rocsolver_syevd_batched(const Tensor& eigenvalues, const Tensor& eigenvectors, const Tensor& infos, bool upper, bool compute_eigenvectors) {
     AT_DISPATCH_FLOATING_TYPES(eigenvectors.scalar_type(), "linalg_eigh_cuda", [&]() {
       apply_syevd_batched_rocsolver<scalar_t>(eigenvalues, eigenvectors, infos, upper, compute_eigenvectors);});
 }
+#endif // USE_ROCM && ROCSOLVER_SYEVD_BATCHED_ENABLED
 
 void linalg_eigh_cusolver(const Tensor& eigenvalues, const Tensor& eigenvectors, const Tensor& infos, bool upper, bool compute_eigenvectors) {
 #if defined(USE_ROCM) && !ROCSOLVER_SYEVD_BATCHED_ENABLED


### PR DESCRIPTION
This PR implements `Batched Eigen Decomposition` (syevD_batched) on ROCm by calling rocSolver directly. 
cuSolver doesn't support syevD_batched and neither does hipSolver. Direct call to rocSolver is required.

`syevD_batched` will be used on ROCm if all the following conditions are met:
- `rocSolver version >= 3.26`
- input data type is `float` or `double` 
- batch size >= 2

Otherwise, non-batched `syevD` will be used on ROCm (complex data types, batch size==1,  rocSolver <3.26)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd