### PR TITLE
add envvar to bisect number of graphs compiled

### DIFF
--- a/torch/_dynamo/__init__.py
+++ b/torch/_dynamo/__init__.py
@@ -48,7 +48,13 @@ from .external_utils import is_compiling
 from .mutation_guard import GenerationTracker
 from .pgo import reset_code_state
 from .symbolic_convert import TensorifyState
-from .utils import graph_break_reasons, guard_failures, orig_code_map, reset_frame_count
+from .utils import (
+    graph_break_reasons,
+    GraphsCompiledState,
+    guard_failures,
+    orig_code_map,
+    reset_frame_count,
+)
 
 
 # Register polyfill functions
@@ -131,6 +137,7 @@ def reset() -> None:
         callback_handler.clear()
         GenerationTracker.clear()
         TensorifyState.clear()
+        GraphsCompiledState.clear()
         torch._dynamo.utils.warn_once_cache.clear()
         torch._dynamo.utils.user_obj_id_to_weakref.clear()
         torch._C._autograd._saved_tensors_hooks_set_tracing(False)

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -243,6 +243,14 @@ repro_ignore_non_fp = os.environ.get("TORCHDYNAMO_REPRO_IGNORE_NON_FP") == "1"
 # [@compile_ignored: runtime_behaviour]
 same_two_models_use_fp64 = True
 
+# maximum number of dynamo graphs to compile.
+# if we exceed this limit, we will raise a SkipFrame
+debug_max_graphs = os.environ.get("TORCH_BISECT_MAX_GRAPHS", None)
+
+# maximum number of dynamo graphs to invoke with compiled bakcend
+# if we exeed this limit, we will defer to aot_eager
+debug_max_backend_graphs = os.environ.get("TORCH_BISECT_MAX_BACKEND_GRAPHS", None)
+
 # Not all backends support scalars. Some calls on torch.Tensor (like .item()) return a scalar type.
 # When this flag is set to False, we introduce a graph break instead of capturing.
 # This requires dynamic_shapes to be True.

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -4544,6 +4544,26 @@ class CompileTimeInstructionCounter:
                 cls.end()
 
 
+class GraphsCompiledState:
+    """
+    Tracks number of compiled graphs.
+    """
+
+    num_graphs: int = 0
+
+    @classmethod
+    def clear(cls) -> None:
+        cls.num_graphs = 0
+
+    @classmethod
+    def increment(cls) -> None:
+        cls.num_graphs += 1
+
+    @classmethod
+    def get_num_graphs(cls) -> int:
+        return cls.num_graphs
+
+
 def set_feature_use(feature: str, usage: bool):
     """
     Records whether we are using a feature


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #154543

Adds both a config/envvar for max number of graphs sent to inductor and max number of graphs before falling back to aot_eager (some models dont work in eager).


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela