### PR TITLE
[ROCm] MIOpen: Get current device from Torch rather than HIP in handle creation

### DIFF
--- a/aten/src/ATen/miopen/Handle.cpp
+++ b/aten/src/ATen/miopen/Handle.cpp
@@ -33,8 +33,8 @@ using MIOpenPoolType = at::cuda::DeviceThreadHandlePool<miopenHandle_t, createMI
 } // namespace
 
 miopenHandle_t getMiopenHandle() {
-  int device;
-  HIP_CHECK(hipGetDevice(&device));
+  c10::DeviceIndex device = 0;
+  MIOPEN_CHECK(c10::cuda::GetDevice(&device));
 
   // Thread local PoolWindows are lazily-initialized
   // to avoid initialization issues that caused hangs on Windows.

--- a/aten/src/ATen/miopen/Handle.cpp
+++ b/aten/src/ATen/miopen/Handle.cpp
@@ -1,8 +1,8 @@
-#include <ATen/cuda/detail/DeviceThreadHandles.h>
+#include <ATen/hip/detail/DeviceThreadHandles.h>
 #include <ATen/miopen/Handle.h>
-#include <c10/cuda/CUDAStream.h>
+#include <c10/hip/HIPStream.h>
 
-#include <ATen/cuda/Exceptions.h>
+#include <ATen/hip/Exceptions.h>
 #include <ATen/miopen/Exceptions.h>
 
 namespace at::native {
@@ -39,7 +39,7 @@ using MIOpenPoolType = at::cuda::DeviceThreadHandlePool<
 
 miopenHandle_t getMiopenHandle() {
   c10::DeviceIndex device = 0;
-  AT_CUDA_CHECK(c10::cuda::GetDevice(&device));
+  AT_CUDA_CHECK(c10::hip::GetDevice(&device));
 
   // Thread local PoolWindows are lazily-initialized
   // to avoid initialization issues that caused hangs on Windows.
@@ -51,7 +51,7 @@ miopenHandle_t getMiopenHandle() {
       pool->newPoolWindow());
 
   auto handle = myPoolWindow->reserve(device);
-  MIOPEN_CHECK(miopenSetStream(handle, c10::cuda::getCurrentCUDAStream()));
+  MIOPEN_CHECK(miopenSetStream(handle, c10::hip::getCurrentHIPStream()));
   return handle;
 }
 

--- a/aten/src/ATen/miopen/Handle.cpp
+++ b/aten/src/ATen/miopen/Handle.cpp
@@ -1,9 +1,11 @@
-#include <ATen/miopen/Exceptions.h>
+#include <ATen/cuda/detail/DeviceThreadHandles.h>
 #include <ATen/miopen/Handle.h>
-#include <ATen/hip/detail/DeviceThreadHandles.h>
-#include <c10/hip/HIPStream.h>
+#include <c10/cuda/CUDAStream.h>
 
-namespace at { namespace native {
+#include <ATen/cuda/Exceptions.h>
+#include <ATen/miopen/Exceptions.h>
+
+namespace at::native {
 namespace {
 
 void createMIOpenHandle(miopenHandle_t *handle) {
@@ -11,30 +13,33 @@ void createMIOpenHandle(miopenHandle_t *handle) {
 }
 
 void destroyMIOpenHandle(miopenHandle_t handle) {
-// this is because of something dumb in the ordering of
-// destruction. Sometimes atexit, the cuda context (or something)
-// would already be destroyed by the time this gets destroyed. It
-// happens in fbcode setting. @colesbury and I decided to not destroy
-// the handle as a workaround.
-//   - @soumith
-//
-// Further note: this is now disabled globally, because we are seeing
-// the same issue as mentioned above in CUDA 11 CI.
-//   - @zasdfgbnm
-//
-// #ifdef NO_MIOPEN_DESTROY_HANDLE
-// #else
-//   miopenDestroy(handle);
-// #endif
+  // this is because of something dumb in the ordering of
+  // destruction. Sometimes atexit, the cuda context (or something)
+  // would already be destroyed by the time this gets destroyed. It
+  // happens in fbcode setting. @colesbury and I decided to not destroy
+  // the handle as a workaround.
+  //   - @soumith
+  //
+  // Further note: this is now disabled globally, because we are seeing
+  // the same issue as mentioned above in CUDA 11 CI.
+  //   - @zasdfgbnm
+  //
+  // #ifdef NO_MIOPEN_DESTROY_HANDLE
+  // #else
+  //   miopenDestroy(handle);
+  // #endif
 }
 
-using MIOpenPoolType = at::cuda::DeviceThreadHandlePool<miopenHandle_t, createMIOpenHandle, destroyMIOpenHandle>;
+using MIOpenPoolType = at::cuda::DeviceThreadHandlePool<
+    miopenHandle_t,
+    createMIOpenHandle,
+    destroyMIOpenHandle>;
 
 } // namespace
 
 miopenHandle_t getMiopenHandle() {
   c10::DeviceIndex device = 0;
-  MIOPEN_CHECK(c10::hip::GetDevice(&device));
+  AT_CUDA_CHECK(c10::cuda::GetDevice(&device));
 
   // Thread local PoolWindows are lazily-initialized
   // to avoid initialization issues that caused hangs on Windows.
@@ -46,8 +51,8 @@ miopenHandle_t getMiopenHandle() {
       pool->newPoolWindow());
 
   auto handle = myPoolWindow->reserve(device);
-  MIOPEN_CHECK(miopenSetStream(handle, at::hip::getCurrentHIPStream()));
+  MIOPEN_CHECK(miopenSetStream(handle, c10::cuda::getCurrentCUDAStream()));
   return handle;
 }
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/miopen/Handle.cpp
+++ b/aten/src/ATen/miopen/Handle.cpp
@@ -34,7 +34,7 @@ using MIOpenPoolType = at::cuda::DeviceThreadHandlePool<miopenHandle_t, createMI
 
 miopenHandle_t getMiopenHandle() {
   c10::DeviceIndex device = 0;
-  MIOPEN_CHECK(c10::cuda::GetDevice(&device));
+  MIOPEN_CHECK(c10::hip::GetDevice(&device));
 
   // Thread local PoolWindows are lazily-initialized
   // to avoid initialization issues that caused hangs on Windows.


### PR DESCRIPTION
Get current device from Torch rather than HIP in MIOpen handle creation. The device may have already been set from torch side, otherwise device is set to 0 for handle.  Additional audits of cudnn vs miopen Handle.cpp file.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd