### PR TITLE
[BE] fix lint errors caused by const SROpFunctor fn

### DIFF
--- a/torch/csrc/jit/runtime/static/ops.h
+++ b/torch/csrc/jit/runtime/static/ops.h
@@ -33,7 +33,7 @@ TORCH_DECLARE_REGISTRY(SROperatorRegistry, SROperatorFunctor);
 
 #define REGISTER_OPERATOR_FUNCTOR(name, id, ...)             \
   struct SROperatorFunctor_##id : public SROperatorFunctor { \
-    const SROpFunctor fn = __VA_ARGS__;                      \
+    SROpFunctor fn = __VA_ARGS__;                            \
     SROperator Generate(Node* n) override {                  \
       return fn(n);                                          \
     }                                                        \
@@ -43,7 +43,7 @@ TORCH_DECLARE_REGISTRY(SROperatorRegistry, SROperatorFunctor);
 TORCH_DECLARE_REGISTRY(SRNativeOperatorRegistry, SROperatorFunctor);
 #define REGISTER_NATIVE_OPERATOR_FUNCTOR(name, id, ...)            \
   struct SRNativeOperatorFunctor_##id : public SROperatorFunctor { \
-    const SROpFunctor fn = __VA_ARGS__;                            \
+    SROpFunctor fn = __VA_ARGS__;                                  \
     SROperator Generate(Node* n) override {                        \
       return fn(n);                                                \
     }                                                              \


### PR DESCRIPTION
Summary: Remove const quaiflier from SR suggsted from CLANGTIDY.

Test Plan: arc lint -a -e extra --take CLANGTIDY caffe2/torch/fb/sparsenn/cpu_operators/to_dense_representation_cpu.cpp

Reviewed By: henryoier

Differential Revision: D75534056




cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel