### PR TITLE
[cutlass backend][ez] remove indent for cutlass config serialization

### DIFF
--- a/torch/_inductor/codegen/cuda/serialization.py
+++ b/torch/_inductor/codegen/cuda/serialization.py
@@ -29,7 +29,7 @@ class CUTLASSOperationSerializer:
     ]
 
     @classmethod
-    def serialize(cls, operation: "GemmOperation", indent: int = 2):  # type: ignore[name-defined]  # noqa: F821
+    def serialize(cls, operation: "GemmOperation"):  # type: ignore[name-defined]  # noqa: F821
         """Serialize a GEMM operation to JSON string.
 
         Args:
@@ -42,8 +42,7 @@ class CUTLASSOperationSerializer:
         assert operation.__class__.__qualname__ == "GemmOperation", (
             "Only GemmOperation objects are supported via the main API"
         )
-        ret = json.dumps(cls._gemm_operation_to_json(operation), indent=indent)
-        return ret
+        return json.dumps(cls._gemm_operation_to_json(operation))
 
     @classmethod
     def deserialize(cls, json_str: str) -> "GemmOperation":  # type: ignore[name-defined]  # noqa: F821


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #154573



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov

Differential Revision: [D75566642](https://our.internmc.facebook.com/intern/diff/D75566642)