### PR TITLE
Fixes OpInfo gradient checks for ctc_loss

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -97,6 +97,7 @@ from torch.testing._internal.opinfo.core import (  # noqa: F401
     sample_inputs_foreach,
     ForeachFuncInfo,
     gradcheck_wrapper_hermitian_input,
+    gradcheck_wrapper_ctc_loss,
     gradcheck_wrapper_triangular_input,
     gradcheck_wrapper_triangular_input_real_positive_diagonal,
     gradcheck_wrapper_masked_operation,
@@ -8352,16 +8353,17 @@ def sample_inputs_ctc_loss(op_info, device, dtype, requires_grad, **kwargs):
     num_char = 20
     target_length = 30
 
-    def make_log_probs(s):
-        t = make_tensor(s, device=device, dtype=dtype)
-        log_probs = t.log_softmax(2).to(device=device, dtype=dtype).detach().requires_grad_(requires_grad=requires_grad)
-        return log_probs
+    # Test ctc_loss gradient behavior for the regime in which it is currently accurate and consistent across devices:
+    # normalized inputs and gradients wrt. unnormalized inputs.
+    # See https://github.com/pytorch/pytorch/issues/52241
+    def make_input(s):
+        return make_tensor(s, device=device, dtype=dtype).detach().requires_grad_(requires_grad=requires_grad)
 
     reductions = ('none', 'mean', 'sum')
     zero_inf = (True, False)
     lengths_type = (list, torch.Tensor)
     for r, z, lt in product(reductions, zero_inf, lengths_type):
-        log_probs = make_log_probs((input_length, batch, num_char))
+        log_probs = make_input((input_length, batch, num_char))
         targets = torch.randint(1, num_char, (batch, target_length), dtype=torch.long, device=device)
         input_lengths = torch.full((batch, ), input_length, dtype=torch.long, device=device)
         target_lengths = torch.randint(10, target_length, (batch, ), dtype=torch.long, device=device)
@@ -8374,7 +8376,9 @@ def sample_inputs_ctc_loss(op_info, device, dtype, requires_grad, **kwargs):
             input_lengths = input_lengths.tolist()
             target_lengths = target_lengths.tolist()
 
-        yield SampleInput(log_probs, args=(targets, input_lengths, target_lengths,), kwargs=dict(reduction=r, zero_infinity=z))
+        yield SampleInput(log_probs, args=(targets, input_lengths, target_lengths),
+                          kwargs=dict(reduction=r, zero_infinity=z))
+
 
 def sample_inputs_nll_loss(op_info, device, dtype, requires_grad, **kwargs):
     shape = (2, 3)
@@ -21347,15 +21351,10 @@ op_db: list[OpInfo] = [
         dtypes=floating_types(),
         supports_out=False,
         sample_inputs_func=sample_inputs_ctc_loss,
+        # gradcheck_wrapper to check gradients wrt. unnormalized inputs.
+        # see https://github.com/pytorch/pytorch/issues/52241
+        gradcheck_wrapper=gradcheck_wrapper_ctc_loss,
         skips=(
-            # https://github.com/pytorch/pytorch/issues/67462
-            # torch.autograd.gradcheck.GradcheckError: Jacobian mismatch for output 0 with respect to input 0
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestBwdGradients",
-                "test_fn_grad",
-                dtypes=(torch.float64,),
-            ),
             # RuntimeError: derivative for aten::_ctc_loss_backward is not implemented
             DecorateInfo(
                 unittest.expectedFailure,

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -3126,8 +3126,7 @@ def gradcheck_wrapper_hermitian_input(op, input, *args, **kwargs):
 
 
 def gradcheck_wrapper_ctc_loss(op, input, *args, **kwargs):
-    """Gradcheck wrapper for ctc loss. This is needed to test the existing restricted cases in which the
-    ctc loss implementation is accurate and consistent across devices."""
+    """Gradcheck wrapper for ctc loss to project onto log-simplex space."""
     # See https://github.com/pytorch/pytorch/issues/52241
     return op(input.log_softmax(dim=2), *args, **kwargs)
 

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -3125,6 +3125,13 @@ def gradcheck_wrapper_hermitian_input(op, input, *args, **kwargs):
     return op(input + input.mH, *args, **kwargs)
 
 
+def gradcheck_wrapper_ctc_loss(op, input, *args, **kwargs):
+    """Gradcheck wrapper for ctc loss. This is needed to test the existing restricted cases in which the
+    ctc loss implementation is accurate and consistent across devices."""
+    # See https://github.com/pytorch/pytorch/issues/52241
+    return op(input.log_softmax(dim=2), *args, **kwargs)
+
+
 def gradcheck_wrapper_triangular_input(op, *args, upper=False, idx=0, **kwargs):
     """Gradcheck wrapper for functions that take lower or upper triangular matrices as input.
 


### PR DESCRIPTION
Fixes #67462

Re-enables `OpInfo` gradient checks for the restricted scenarios where the current `ctc_loss` implementation is accurate and consistent.


The desired `ctc_loss` gradient behavior appears to be an ongoing discussion, see 
https://github.com/pytorch/pytorch/issues/52241. The `OpInfo` gradient checks can be updated if/as the underlying implementation advances.
