### PR TITLE
Round the epilogue offset to positive values in cunn_SoftMaxForward

### DIFF
--- a/aten/src/ATen/native/cuda/SoftMax.cu
+++ b/aten/src/ATen/native/cuda/SoftMax.cu
@@ -5,6 +5,7 @@
 #include <ATen/TensorUtils.h>
 #include <ATen/TensorOperators.h>
 #include <ATen/WrapDimUtils.h>
+#include <ATen/ceil_div.h>
 #include <c10/macros/Macros.h>
 
 #include <ATen/AccumulateType.h>
@@ -518,6 +519,10 @@ ilpReduce(index_t shift,
   }
 
   offset = size - last + threadIdx.x;
+  if (offset < 0) {
+    // Ensure offset >= 0
+    offset += round_up<long>(-offset, blockDim.x);
+  }
   // Epilogue
   for (; offset < size; offset += blockDim.x)
     threadVal = r(threadVal, data[offset]);
@@ -581,6 +586,10 @@ WriteFpropResultsVectorized(
   }
 
   offset = size - last + threadIdx.x;
+  if (offset < 0) {
+    // Ensure offset >= 0
+    offset += round_up<long>(-offset, blockDim.x);
+  }
   // handle the tail
   for (; offset < size; offset += blockDim.x) {
     output[offset] = epilogue(input[offset]);
@@ -641,6 +650,10 @@ WriteBpropResultsVectorized(
   }
 
   offset = size - last + threadIdx.x;
+  if (offset < 0) {
+    // Ensure offset >= 0
+    offset += round_up<long>(-offset, blockDim.x);
+  }
   for (; offset < size; offset += blockDim.x) {
     gradInput[offset] = epilogue(gradOutput[offset], output[offset]);
   }


### PR DESCRIPTION
This fixes OOB memory access for followng code
``` python
import torch
qk = torch.randn((9,1017), dtype=torch.float64, device='cuda')
smqk = torch.softmax(qk, dim=-1)
```

Correctness can be confirmed with:
``` python
import torch
import numpy as np
from scipy.special import softmax

qk = torch.randn((9,1017), dtype=torch.float64, device='cuda')
nqk = qk.cpu().numpy()
smqk = torch.softmax(qk, dim=-1)
nsmqk = smqk.cpu().numpy()
smnqk = softmax(nqk, axis=-1)

print(f'{np.allclose(smnqk, nsmqk)}')
```