### PR TITLE
[nativert] Free stale execution frames

### DIFF
--- a/torch/nativert/executor/ExecutorConfig.h
+++ b/torch/nativert/executor/ExecutorConfig.h
@@ -11,10 +11,13 @@ struct ExecutorConfig {
   bool enableStaticCPUKernels = false;
   bool enableStaticMemoryPlanning = false;
   bool runConstFolding = false;
+  bool doExecutionFrameCleanup = true;
   // allows up to max number of concurrent threads.
   int64_t maxNumConcurrentThreads = 8;
   // allows up to max number of parallel ops.
   int64_t maxParallelOps = 1;
+  int64_t minNumExecutionFrames = 1;
+  int64_t executionFramePoolCleanupIntervalSec = 600;
   std::string modelName = "unknown";
 };
 


### PR DESCRIPTION
Summary:
This was implemented in SR due to caching of runtime instances building up and causing some memory usage spikes after some large amount traffic went through the model, and then once traffic went down, SR was still caching all the previous usage.

We need something similar on the Sigmoid side to make sure the static dispatch modules aren't hogging memory. Currently, all ExecutionFrame objects are being cached, and never freed if stale.

Test Plan:
Added extra execution frames in tmp commit D75257998 and ran local replayer test to confirm extra execution frames get cleaned up down to min size, which is set at 8

 {F1978532047}


Also tested by modifying load_net_predictor (modifications also in D75257998) to run benchmarkNumIterations twice - once with benchmarkNumThreads, and once with only one thread. Also set clearing interval at one second. Verified that execution frames get cleared when we drop down to one thread.

 {F1978558984}


```
buck2 test 'mode/dev-nosan' fbcode//sigmoid/inference/test_gpu:model_runner_test -- ModelRunnerTest.Basic_InterpreterCuda_Multithread_Cleanup --run-disabled --print-passing-details
```

Differential Revision: D75257992


