### PR TITLE
[et/triton kernel] Assign correct stream_id from cudaStream

### DIFF
--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1139,6 +1139,10 @@ class CachingAutotuner(KernelInterface):
                 f"{k}={v}" for (k, v) in launcher.config.kwargs.items()
             )
 
+            if self.device_props.type == "cuda":
+                from torch._C import _cuda_getStreamId as getStreamId
+                stream = getStreamId(stream)
+
             profiler_kwargs = {
                 "kernel_file": (self.filename or ""),
                 "kernel_hash": self.kernel_hash,


### PR DESCRIPTION
Summary:
The impact of this diff is the code will now make a call to `cudaGetStreamId` each time kernel fusion is performed.

`cudaGetStreamId` is a simple memory address read op.

The diff in `/param_bench/et_replay/tools/et_replay.py` is a hack to get that test to pass while the working change in `caffe2` is landed.

Related: D72424039

Test Plan:
```
cd fbcode
buck2 run mode/opt caffe2/test:test_profiler_cuda -- profiler.test_execution_trace.TestExecutionTraceCUDA.test_execution_trace_with_pt2_cuda
```

```
{
        "id": 18, "name": "triton_poi_fused_add_cos_neg_sin_0", "ctrl_deps": 7,
        "inputs": {"values": [[16,17,0,16,4,"cuda:0"],[12,13,0,16,4,"cuda:0"],[19,20,0,16,4,"cuda:0"],[21,22,0,16,4,"cuda:0"],16,21], "shapes": [[4,4],[4,4],[4,4],[4,4],[],[]], "types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Int","Int"], "strides": [[4,1],[4,1],[4,1],[4,1],[]]},
        "outputs": {"values": [], "shapes": [], "types": [], "strides": []},
        "attrs": [{"name": "rf_id", "type": "uint64", "value": 7},{"name": "fw_parent", "type": "uint64", "value": 0},{"name": "seq_id", "type": "int64", "value": -1},{"name": "scope", "type": "uint64", "value": 0},{"name": "tid", "type": "uint64", "value": 1},{"name": "fw_tid", "type": "uint64", "value": 0},{"name": "op_schema", "type": "string", "value": ""},{"name": "kernel_backend", "type": "string", "value": "triton"},{"name": "kernel_file", "type": "string", "value": "cn4ejvy4vwvn6ul6addnshujact5ewopfbheek55ycbks6yp2i4h.py"},{"name": "tensor_range", "type": "string", "value": ""}]
      },
```

Proper dereferenced stream id is `21`

```
{
    "ph": "X", "cat": "cpu_op", "name": "triton_poi_fused_add_cos_neg_sin_0", "pid": 3935871, "tid": 3935871,
    "ts": 4259010522408.995, "dur": 175.571,
    "args": {
      "External id": 7,"kernel_hash": "cn4ejvy4vwvn6ul6addnshujact5ewopfbheek55ycbks6yp2i4h", "num_stages": 1, "kernel_kwargs": "XBLOCK=16", "Record function id": 7, "stream": 21, "num_warps": 1, "Concrete Inputs": ["", "", "", "", "16"], "kernel_file": "/var/tmp/torchinductor_leonlin6/n4/cn4ejvy4vwvn6ul6addnshujact5ewopfbheek55ycbks6yp2i4h.py", "kernel_backend": "triton", "Input type": ["float", "float", "float", "float", "Scalar"], "Input Strides": [[4, 1], [4, 1], [4, 1], [4, 1], []], "Input Dims": [[4, 4], [4, 4], [4, 4], [4, 4], []], "Ev Idx": 6
    }
  },
```

Verified with the Kineto trace as well

Differential Revision: D72420519




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben