### PR TITLE
Forward fix for test_frame_traced_hook in internal testing

### DIFF
--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -143,7 +143,10 @@ class TestUtils(TestCase):
             self.assertEqual(compilation_events[-1].num_graph_breaks, 2)
 
     def test_frame_traced_hook(self):
-        from utils import add, break_it
+        try:
+            from .utils import add, break_it
+        except ImportError:
+            from utils import add, break_it
 
         traced_code_lists = []
 


### PR DESCRIPTION
Summary: Fixes the newly-added dynamo test test_frame_traced_hook so it can run internally

Test Plan: This is a test change

Differential Revision: D75616787




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames