### PR TITLE
Extract DeviceType to a standalone header file

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -671,6 +671,14 @@ flatbuffer_cc_library(
 )
 
 cc_library(
+    name = "torch_standalone_headers",
+    hdrs = glob([
+        "torch/standalone/**/*.h"
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
     name = "torch_headers",
     hdrs = if_cuda(
         torch_cuda_headers,

--- a/buckbuild.bzl
+++ b/buckbuild.bzl
@@ -945,6 +945,7 @@ def define_buck_targets(
             [
                 ("torch/csrc/api/include", "torch/**/*.h"),
                 ("", "torch/csrc/**/*.h"),
+                ("", "torch/standalone/**/*.h"),
                 ("", "torch/script.h"),
                 ("", "torch/library.h"),
                 ("", "torch/custom_class.h"),

--- a/c10/core/DeviceType.cpp
+++ b/c10/core/DeviceType.cpp
@@ -7,108 +7,6 @@
 #include <mutex>
 
 namespace c10 {
-
-std::string DeviceTypeName(DeviceType d, bool lower_case) {
-  switch (d) {
-    // I considered instead using ctype::tolower to lower-case the strings
-    // on the fly, but this seemed a bit much.
-    case DeviceType::CPU:
-      return lower_case ? "cpu" : "CPU";
-    case DeviceType::CUDA:
-      return lower_case ? "cuda" : "CUDA";
-    case DeviceType::OPENGL:
-      return lower_case ? "opengl" : "OPENGL";
-    case DeviceType::OPENCL:
-      return lower_case ? "opencl" : "OPENCL";
-    case DeviceType::MKLDNN:
-      return lower_case ? "mkldnn" : "MKLDNN";
-    case DeviceType::IDEEP:
-      return lower_case ? "ideep" : "IDEEP";
-    case DeviceType::HIP:
-      return lower_case ? "hip" : "HIP";
-    case DeviceType::VE:
-      return lower_case ? "ve" : "VE";
-    case DeviceType::FPGA:
-      return lower_case ? "fpga" : "FPGA";
-    case DeviceType::MAIA:
-      return lower_case ? "maia" : "MAIA";
-    case DeviceType::XLA:
-      return lower_case ? "xla" : "XLA";
-    case DeviceType::Lazy:
-      return lower_case ? "lazy" : "LAZY";
-    case DeviceType::MPS:
-      return lower_case ? "mps" : "MPS";
-    case DeviceType::Vulkan:
-      return lower_case ? "vulkan" : "VULKAN";
-    case DeviceType::Metal:
-      return lower_case ? "metal" : "METAL";
-    case DeviceType::XPU:
-      return lower_case ? "xpu" : "XPU";
-    case DeviceType::Meta:
-      return lower_case ? "meta" : "META";
-    case DeviceType::HPU:
-      return lower_case ? "hpu" : "HPU";
-    case DeviceType::IPU:
-      return lower_case ? "ipu" : "IPU";
-    case DeviceType::MTIA:
-      return lower_case ? "mtia" : "MTIA";
-    case DeviceType::PrivateUse1:
-      return get_privateuse1_backend(/*lower_case=*/lower_case);
-    default:
-      TORCH_CHECK(
-          false,
-          "Unknown device: ",
-          static_cast<int16_t>(d),
-          ". If you have recently updated the caffe2.proto file to add a new "
-          "device type, did you forget to update the DeviceTypeName() "
-          "function to reflect such recent changes?");
-      // The below code won't run but is needed to suppress some compiler
-      // warnings.
-      return "";
-  }
-}
-
-// NB: Per the C++ standard (e.g.,
-// https://stackoverflow.com/questions/18195312/what-happens-if-you-static-cast-invalid-value-to-enum-class)
-// as long as you cast from the same underlying type, it is always valid to cast
-// into an enum class (even if the value would be invalid by the enum.)  Thus,
-// the caller is allowed to cast a possibly invalid int16_t to DeviceType and
-// then pass it to this function.  (I considered making this function take an
-// int16_t directly, but that just seemed weird.)
-bool isValidDeviceType(DeviceType d) {
-  switch (d) {
-    case DeviceType::CPU:
-    case DeviceType::CUDA:
-    case DeviceType::OPENGL:
-    case DeviceType::OPENCL:
-    case DeviceType::MKLDNN:
-    case DeviceType::IDEEP:
-    case DeviceType::HIP:
-    case DeviceType::VE:
-    case DeviceType::FPGA:
-    case DeviceType::MAIA:
-    case DeviceType::XLA:
-    case DeviceType::Lazy:
-    case DeviceType::MPS:
-    case DeviceType::Vulkan:
-    case DeviceType::Metal:
-    case DeviceType::XPU:
-    case DeviceType::Meta:
-    case DeviceType::HPU:
-    case DeviceType::IPU:
-    case DeviceType::MTIA:
-    case DeviceType::PrivateUse1:
-      return true;
-    default:
-      return false;
-  }
-}
-
-std::ostream& operator<<(std::ostream& stream, DeviceType type) {
-  stream << DeviceTypeName(type, /* lower case */ true);
-  return stream;
-}
-
 // We use both a mutex and an atomic here because:
 // (1) Mutex is needed during writing:
 //     We need to first check the value and potentially error,
@@ -164,5 +62,4 @@ void register_privateuse1_backend(const std::string& backend_name) {
 bool is_privateuse1_backend_registered() {
   return privateuse1_backend_name_set.load(std::memory_order_acquire);
 }
-
 } // namespace c10

--- a/c10/core/DeviceType.h
+++ b/c10/core/DeviceType.h
@@ -6,116 +6,12 @@
 // If you modify me, keep me synchronized with that file.
 
 #include <c10/macros/Export.h>
-
-#include <cstddef>
-#include <cstdint>
-#include <functional>
-#include <ostream>
-#include <string>
+#include <torch/standalone/core/DeviceType.h>
 
 namespace c10 {
-
-// These contains all device types that also have a BackendComponent
-// and therefore participate in per-backend functionality dispatch keys.
-// This is most backends except PrivateUse2 and PrivateUse3
-#define C10_FORALL_BACKEND_DEVICE_TYPES(_, extra) \
-  _(CPU, extra)                                   \
-  _(CUDA, extra)                                  \
-  _(HIP, extra)                                   \
-  _(XLA, extra)                                   \
-  _(MPS, extra)                                   \
-  _(IPU, extra)                                   \
-  _(XPU, extra)                                   \
-  _(HPU, extra)                                   \
-  _(VE, extra)                                    \
-  _(Lazy, extra)                                  \
-  _(Meta, extra)                                  \
-  _(MTIA, extra)                                  \
-  _(PrivateUse1, extra)
-
-enum class DeviceType : int8_t {
-  CPU = 0,
-  CUDA = 1, // CUDA.
-  MKLDNN = 2, // Reserved for explicit MKLDNN
-  OPENGL = 3, // OpenGL
-  OPENCL = 4, // OpenCL
-  IDEEP = 5, // IDEEP.
-  HIP = 6, // AMD HIP
-  FPGA = 7, // FPGA
-  MAIA = 8, // ONNX Runtime / Microsoft
-  XLA = 9, // XLA / TPU
-  Vulkan = 10, // Vulkan
-  Metal = 11, // Metal
-  XPU = 12, // XPU
-  MPS = 13, // MPS
-  Meta = 14, // Meta (tensors with no data)
-  HPU = 15, // HPU / HABANA
-  VE = 16, // SX-Aurora / NEC
-  Lazy = 17, // Lazy Tensors
-  IPU = 18, // Graphcore IPU
-  MTIA = 19, // Meta training and inference devices
-  PrivateUse1 = 20, // PrivateUse1 device
-  // NB: If you add more devices:
-  //  - Change the implementations of DeviceTypeName and isValidDeviceType
-  //    in DeviceType.cpp
-  //  - Change the number below
-  COMPILE_TIME_MAX_DEVICE_TYPES = 21,
-};
-
-constexpr DeviceType kCPU = DeviceType::CPU;
-constexpr DeviceType kCUDA = DeviceType::CUDA;
-constexpr DeviceType kHIP = DeviceType::HIP;
-constexpr DeviceType kFPGA = DeviceType::FPGA;
-constexpr DeviceType kMAIA = DeviceType::MAIA;
-constexpr DeviceType kXLA = DeviceType::XLA;
-constexpr DeviceType kMPS = DeviceType::MPS;
-constexpr DeviceType kMeta = DeviceType::Meta;
-constexpr DeviceType kVulkan = DeviceType::Vulkan;
-constexpr DeviceType kMetal = DeviceType::Metal;
-constexpr DeviceType kXPU = DeviceType::XPU;
-constexpr DeviceType kHPU = DeviceType::HPU;
-constexpr DeviceType kVE = DeviceType::VE;
-constexpr DeviceType kLazy = DeviceType::Lazy;
-constexpr DeviceType kIPU = DeviceType::IPU;
-constexpr DeviceType kMTIA = DeviceType::MTIA;
-constexpr DeviceType kPrivateUse1 = DeviceType::PrivateUse1;
-
-// define explicit int constant
-constexpr int COMPILE_TIME_MAX_DEVICE_TYPES =
-    static_cast<int>(DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES);
-
-static_assert(
-    COMPILE_TIME_MAX_DEVICE_TYPES <= 21,
-    "Hey!  You seem to be adding a lot of new DeviceTypes.  The intent was "
-    "for this constant to reflect the actual number of DeviceTypes we support "
-    "in PyTorch; it's important that this number is not too large as we "
-    "use this to allocate stack arrays in some places in our code.  If you "
-    "are indeed just adding the 20th device type, feel free to change "
-    "the check to 32; but if you are adding some sort of extensible device "
-    "types registration, please be aware that you are affecting code that "
-    "this number is small.  Try auditing uses of this constant.");
-
-C10_API std::string DeviceTypeName(DeviceType d, bool lower_case = false);
-
-C10_API bool isValidDeviceType(DeviceType d);
-
-C10_API std::ostream& operator<<(std::ostream& stream, DeviceType type);
-
 C10_API void register_privateuse1_backend(const std::string& backend_name);
-C10_API std::string get_privateuse1_backend(bool lower_case = true);
-
 C10_API bool is_privateuse1_backend_registered();
-
 } // namespace c10
-
-namespace std {
-template <>
-struct hash<c10::DeviceType> {
-  std::size_t operator()(c10::DeviceType k) const {
-    return std::hash<int>()(static_cast<int>(k));
-  }
-};
-} // namespace std
 
 namespace torch {
 // NOLINTNEXTLINE(misc-unused-using-decls)

--- a/c10/core/build.bzl
+++ b/c10/core/build.bzl
@@ -80,6 +80,7 @@ def define_targets(rules):
         deps = [
             ":ScalarType",
             "//third_party/cpuinfo",
+            "//:torch_standalone_headers",
             "//c10/macros",
             "//c10/util:TypeCast",
             "//c10/util:base",

--- a/c10/macros/Export.h
+++ b/c10/macros/Export.h
@@ -1,95 +1,10 @@
-#ifndef C10_MACROS_EXPORT_H_
-#define C10_MACROS_EXPORT_H_
-
-/* Header file to define the common scaffolding for exported symbols.
- *
- * Export is by itself a quite tricky situation to deal with, and if you are
- * hitting this file, make sure you start with the background here:
- * - Linux: https://gcc.gnu.org/wiki/Visibility
- * - Windows:
- * https://docs.microsoft.com/en-us/cpp/cpp/dllexport-dllimport?view=vs-2017
- *
- * Do NOT include this file directly. Instead, use c10/macros/Macros.h
- */
-
-// You do not need to edit this part of file unless you are changing the core
-// pytorch export abstractions.
-//
-// This part defines the C10 core export and import macros. This is controlled
-// by whether we are building shared libraries or not, which is determined
-// during build time and codified in c10/core/cmake_macros.h.
-// When the library is built as a shared lib, EXPORT and IMPORT will contain
-// visibility attributes. If it is being built as a static lib, then EXPORT
-// and IMPORT basically have no effect.
-
-// As a rule of thumb, you should almost NEVER mix static and shared builds for
-// libraries that depend on c10. AKA, if c10 is built as a static library, we
-// recommend everything dependent on c10 to be built statically. If c10 is built
-// as a shared library, everything dependent on it should be built as shared. In
-// the PyTorch project, all native libraries shall use the macro
-// C10_BUILD_SHARED_LIB to check whether pytorch is building shared or static
-// libraries.
-
-// For build systems that do not directly depend on CMake and directly build
-// from the source directory (such as Buck), one may not have a cmake_macros.h
-// file at all. In this case, the build system is responsible for providing
-// correct macro definitions corresponding to the cmake_macros.h.in file.
-//
-// In such scenarios, one should define the macro
-//     C10_USING_CUSTOM_GENERATED_MACROS
-// to inform this header that it does not need to include the cmake_macros.h
-// file.
+#pragma once
 
 #ifndef C10_USING_CUSTOM_GENERATED_MACROS
 #include <c10/macros/cmake_macros.h>
 #endif // C10_USING_CUSTOM_GENERATED_MACROS
 
-#ifdef _WIN32
-#define C10_HIDDEN
-#if defined(C10_BUILD_SHARED_LIBS)
-#define C10_EXPORT __declspec(dllexport)
-#define C10_IMPORT __declspec(dllimport)
-#else
-#define C10_EXPORT
-#define C10_IMPORT
-#endif
-#else // _WIN32
-#if defined(__GNUC__)
-#define C10_EXPORT __attribute__((__visibility__("default")))
-#define C10_HIDDEN __attribute__((__visibility__("hidden")))
-#else // defined(__GNUC__)
-#define C10_EXPORT
-#define C10_HIDDEN
-#endif // defined(__GNUC__)
-#define C10_IMPORT C10_EXPORT
-#endif // _WIN32
-
-#ifdef NO_EXPORT
-#undef C10_EXPORT
-#define C10_EXPORT
-#endif
-
-// Definition of an adaptive XX_API macro, that depends on whether you are
-// building the library itself or not, routes to XX_EXPORT and XX_IMPORT.
-// Basically, you will need to do this for each shared library that you are
-// building, and the instruction is as follows: assuming that you are building
-// a library called libawesome.so. You should:
-// (1) for your cmake target (usually done by "add_library(awesome, ...)"),
-//     define a macro called AWESOME_BUILD_MAIN_LIB using
-//     target_compile_options.
-// (2) define the AWESOME_API macro similar to the one below.
-// And in the source file of your awesome library, use AWESOME_API to
-// annotate public symbols.
-
-// Here, for the C10 library, we will define the macro C10_API for both import
-// and export.
-
-// This one is being used by libc10.so
-#ifdef C10_BUILD_MAIN_LIB
-#define C10_API C10_EXPORT
-#else
-#define C10_API C10_IMPORT
-#endif
+#include <torch/standalone/core/Export.h>
 
 // This one is being used by libtorch.so
 #ifdef CAFFE2_BUILD_MAIN_LIB
@@ -151,12 +66,3 @@
 #else
 #define TORCH_XPU_API C10_IMPORT
 #endif
-
-// Enums only need to be exported on windows for non-CUDA files
-#if defined(_WIN32) && defined(__CUDACC__)
-#define C10_API_ENUM C10_API
-#else
-#define C10_API_ENUM
-#endif
-
-#endif // C10_MACROS_MACROS_H_

--- a/c10/macros/build.bzl
+++ b/c10/macros/build.bzl
@@ -12,6 +12,9 @@ def define_targets(rules):
         linkstatic = True,
         local_defines = ["C10_BUILD_MAIN_LIB"],
         visibility = ["//visibility:public"],
+        deps = [
+            "//:torch_standalone_headers",
+        ],
     )
 
     rules.cmake_configure_file(

--- a/c10/ovrsource_defs.bzl
+++ b/c10/ovrsource_defs.bzl
@@ -74,6 +74,7 @@ def define_c10_ovrsource(name, is_mobile):
             ],
         }),
         exported_deps = [
+            "//xplat/caffe2:torch_standalone_headers",
             ":ovrsource_c10_cmake_macros.h",
             "//arvr/third-party/gflags:gflags",
             "//third-party/cpuinfo:cpuinfo",

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1289,7 +1289,8 @@ endif()
 target_include_directories(torch_cpu PRIVATE ${ATen_CPU_INCLUDE})
 
 target_include_directories(torch_cpu PRIVATE
-  ${TORCH_SRC_DIR}/csrc)
+  ${TORCH_SRC_DIR}/csrc
+  ${TORCH_SRC_DIR}/standalone)
 
 target_include_directories(torch_cpu PRIVATE
   ${TORCH_ROOT}/third_party/miniz-3.0.2)
@@ -1308,9 +1309,12 @@ target_include_directories(torch_cpu PRIVATE
 target_include_directories(torch_cpu PRIVATE
   ${TORCH_ROOT}/third_party/nlohmann/include)
 
-install(DIRECTORY "${TORCH_SRC_DIR}/csrc"
+install(DIRECTORY
+  "${TORCH_SRC_DIR}/csrc"
+  "${TORCH_SRC_DIR}/standalone"
   DESTINATION ${TORCH_INSTALL_INCLUDE_DIR}/torch
   FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp")
+
 install(FILES
   "${TORCH_SRC_DIR}/script.h"
   "${TORCH_SRC_DIR}/extension.h"

--- a/test/cpp/aoti_abi_check/CMakeLists.txt
+++ b/test/cpp/aoti_abi_check/CMakeLists.txt
@@ -4,6 +4,7 @@ set(AOTI_ABI_CHECK_TEST_ROOT ${TORCH_ROOT}/test/cpp/aoti_abi_check)
 set(AOTI_ABI_CHECK_TEST_SRCS
   ${AOTI_ABI_CHECK_TEST_ROOT}/main.cpp
   ${AOTI_ABI_CHECK_TEST_ROOT}/test_cast.cpp
+  ${AOTI_ABI_CHECK_TEST_ROOT}/test_core.cpp
   ${AOTI_ABI_CHECK_TEST_ROOT}/test_dtype.cpp
   ${AOTI_ABI_CHECK_TEST_ROOT}/test_math.cpp
   ${AOTI_ABI_CHECK_TEST_ROOT}/test_rand.cpp
@@ -16,6 +17,7 @@ add_executable(test_aoti_abi_check
 
 # TODO temporary until we can delete the old gtest polyfills.
 target_compile_definitions(test_aoti_abi_check PRIVATE USE_GTEST)
+target_compile_definitions(test_aoti_abi_check PRIVATE TORCH_STANDALONE)
 
 # WARNING: DO NOT LINK torch!!!
 # The purpose is to check if the used aten/c10 headers are writtern in a header-only way

--- a/test/cpp/aoti_abi_check/test_core.cpp
+++ b/test/cpp/aoti_abi_check/test_core.cpp
@@ -1,0 +1,52 @@
+#include <gtest/gtest.h>
+
+#include <torch/standalone/core/DeviceType.h>
+
+namespace torch {
+namespace aot_inductor {
+using namespace torch::standalone;
+
+TEST(TestCore, TestDeviceType) {
+  // clang-format off
+  constexpr DeviceType expected_device_types[] = {
+    kCPU,
+    kCUDA,
+    kMKLDNN,
+    kOPENGL,
+    kOPENCL,
+    kIDEEP,
+    kHIP,
+    kFPGA,
+    kMAIA,
+    kXLA,
+    kVulkan,
+    kMetal,
+    kXPU,
+    kMPS,
+    kMeta,
+    kHPU,
+    kVE,
+    kLazy,
+    kIPU,
+    kMTIA,
+    kPrivateUse1,
+  };
+  // clang-format on
+  for (int8_t i = 0;
+       i < static_cast<int8_t>(DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES);
+       ++i) {
+    EXPECT_EQ(static_cast<DeviceType>(i), expected_device_types[i]);
+  }
+}
+
+TEST(TestCore, PrintDeviceType) {
+  for (int8_t i = 0;
+       i < static_cast<int8_t>(DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES);
+       ++i) {
+    std::cout << i << ": DeviceType::" << static_cast<DeviceType>(i)
+              << std::endl;
+  }
+}
+
+} // namespace aot_inductor
+} // namespace torch

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -74,6 +74,7 @@ set(TORCH_PYTHON_INCLUDE_DIRECTORIES
     ${TORCH_SRC_DIR}/csrc
     ${TORCH_SRC_DIR}/csrc/api/include
     ${TORCH_SRC_DIR}/lib
+    ${TORCH_SRC_DIR}/standalone
     )
 
 list(APPEND TORCH_PYTHON_INCLUDE_DIRECTORIES ${LIBSHM_SRCDIR})

--- a/torch/standalone/core/DeviceType.h
+++ b/torch/standalone/core/DeviceType.h
@@ -1,0 +1,260 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <ostream>
+#include <string>
+
+#include <torch/standalone/core/Export.h>
+#include <c10/util/Exception.h>
+
+namespace c10 {
+// Keep DeviceType in the c10 namespace for Backwards Compatibility.
+// Some user code could call certain c10 functions without spelling
+// out the namespace, but relying on Argument Dependent Lookup (ADL)
+// to find the right functions. If we put DeviceType in the new
+// torch::standalone namespace, and create a name alias in the c10
+// namespace, existing function calls that rely on ADL will break,
+// because ADL will use the base type instead of the aliased type
+// for lookup.
+//
+// These contains all device types that also have a BackendComponent
+// and therefore participate in per-backend functionality dispatch keys.
+// This is most backends except PrivateUse2 and PrivateUse3
+#define C10_FORALL_BACKEND_DEVICE_TYPES(_, extra) \
+  _(CPU, extra)                                   \
+  _(CUDA, extra)                                  \
+  _(HIP, extra)                                   \
+  _(XLA, extra)                                   \
+  _(MPS, extra)                                   \
+  _(IPU, extra)                                   \
+  _(XPU, extra)                                   \
+  _(HPU, extra)                                   \
+  _(VE, extra)                                    \
+  _(Lazy, extra)                                  \
+  _(Meta, extra)                                  \
+  _(MTIA, extra)                                  \
+  _(PrivateUse1, extra)
+
+enum class DeviceType : int8_t {
+  CPU = 0,
+  CUDA = 1, // CUDA.
+  MKLDNN = 2, // Reserved for explicit MKLDNN
+  OPENGL = 3, // OpenGL
+  OPENCL = 4, // OpenCL
+  IDEEP = 5, // IDEEP.
+  HIP = 6, // AMD HIP
+  FPGA = 7, // FPGA
+  MAIA = 8, // ONNX Runtime / Microsoft
+  XLA = 9, // XLA / TPU
+  Vulkan = 10, // Vulkan
+  Metal = 11, // Metal
+  XPU = 12, // XPU
+  MPS = 13, // MPS
+  Meta = 14, // Meta (tensors with no data)
+  HPU = 15, // HPU / HABANA
+  VE = 16, // SX-Aurora / NEC
+  Lazy = 17, // Lazy Tensors
+  IPU = 18, // Graphcore IPU
+  MTIA = 19, // Meta training and inference devices
+  PrivateUse1 = 20, // PrivateUse1 device
+  // NB: If you add more devices:
+  //  - Change the implementations of DeviceTypeName and isValidDeviceType
+  //  - Change the number below
+  COMPILE_TIME_MAX_DEVICE_TYPES = 21,
+};
+
+constexpr DeviceType kCPU = DeviceType::CPU;
+constexpr DeviceType kCUDA = DeviceType::CUDA;
+constexpr DeviceType kMKLDNN = DeviceType::MKLDNN;
+constexpr DeviceType kOPENGL = DeviceType::OPENGL;
+constexpr DeviceType kOPENCL = DeviceType::OPENCL;
+constexpr DeviceType kIDEEP = DeviceType::IDEEP;
+constexpr DeviceType kHIP = DeviceType::HIP;
+constexpr DeviceType kFPGA = DeviceType::FPGA;
+constexpr DeviceType kMAIA = DeviceType::MAIA;
+constexpr DeviceType kXLA = DeviceType::XLA;
+constexpr DeviceType kVulkan = DeviceType::Vulkan;
+constexpr DeviceType kMetal = DeviceType::Metal;
+constexpr DeviceType kXPU = DeviceType::XPU;
+constexpr DeviceType kMPS = DeviceType::MPS;
+constexpr DeviceType kMeta = DeviceType::Meta;
+constexpr DeviceType kHPU = DeviceType::HPU;
+constexpr DeviceType kVE = DeviceType::VE;
+constexpr DeviceType kLazy = DeviceType::Lazy;
+constexpr DeviceType kIPU = DeviceType::IPU;
+constexpr DeviceType kMTIA = DeviceType::MTIA;
+constexpr DeviceType kPrivateUse1 = DeviceType::PrivateUse1;
+
+// define explicit int constant
+constexpr int COMPILE_TIME_MAX_DEVICE_TYPES =
+    static_cast<int>(DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES);
+
+static_assert(
+    COMPILE_TIME_MAX_DEVICE_TYPES <= 21,
+    "Hey!  You seem to be adding a lot of new DeviceTypes.  The intent was "
+    "for this constant to reflect the actual number of DeviceTypes we support "
+    "in PyTorch; it's important that this number is not too large as we "
+    "use this to allocate stack arrays in some places in our code.  If you "
+    "are indeed just adding the 20th device type, feel free to change "
+    "the check to 32; but if you are adding some sort of extensible device "
+    "types registration, please be aware that you are affecting code that "
+    "this number is small.  Try auditing uses of this constant.");
+
+// NB: Per the C++ standard (e.g.,
+// https://stackoverflow.com/questions/18195312/what-happens-if-you-static-cast-invalid-value-to-enum-class)
+// as long as you cast from the same underlying type, it is always valid to cast
+// into an enum class (even if the value would be invalid by the enum.)  Thus,
+// the caller is allowed to cast a possibly invalid int16_t to DeviceType and
+// then pass it to this function.  (I considered making this function take an
+// int16_t directly, but that just seemed weird.)
+inline C10_API bool isValidDeviceType(DeviceType d) {
+  switch (d) {
+    case DeviceType::CPU:
+    case DeviceType::CUDA:
+    case DeviceType::OPENGL:
+    case DeviceType::OPENCL:
+    case DeviceType::MKLDNN:
+    case DeviceType::IDEEP:
+    case DeviceType::HIP:
+    case DeviceType::VE:
+    case DeviceType::FPGA:
+    case DeviceType::MAIA:
+    case DeviceType::XLA:
+    case DeviceType::Lazy:
+    case DeviceType::MPS:
+    case DeviceType::Vulkan:
+    case DeviceType::Metal:
+    case DeviceType::XPU:
+    case DeviceType::Meta:
+    case DeviceType::HPU:
+    case DeviceType::IPU:
+    case DeviceType::MTIA:
+    case DeviceType::PrivateUse1:
+      return true;
+    default:
+      return false;
+  }
+}
+
+#ifdef TORCH_STANDALONE
+// The standalone mode doesn't support register_privateuse1_backend
+inline C10_API std::string get_privateuse1_backend(bool lower_case = true) {
+    return lower_case ? "privateuse1" : "PrivateUse1";
+}
+#else
+C10_API std::string get_privateuse1_backend(bool lower_case = true);
+#endif
+
+inline C10_API std::string DeviceTypeName(DeviceType d, bool lower_case = false) {
+  switch (d) {
+    // I considered instead using ctype::tolower to lower-case the strings
+    // on the fly, but this seemed a bit much.
+    case DeviceType::CPU:
+      return lower_case ? "cpu" : "CPU";
+    case DeviceType::CUDA:
+      return lower_case ? "cuda" : "CUDA";
+    case DeviceType::OPENGL:
+      return lower_case ? "opengl" : "OPENGL";
+    case DeviceType::OPENCL:
+      return lower_case ? "opencl" : "OPENCL";
+    case DeviceType::MKLDNN:
+      return lower_case ? "mkldnn" : "MKLDNN";
+    case DeviceType::IDEEP:
+      return lower_case ? "ideep" : "IDEEP";
+    case DeviceType::HIP:
+      return lower_case ? "hip" : "HIP";
+    case DeviceType::VE:
+      return lower_case ? "ve" : "VE";
+    case DeviceType::FPGA:
+      return lower_case ? "fpga" : "FPGA";
+    case DeviceType::MAIA:
+      return lower_case ? "maia" : "MAIA";
+    case DeviceType::XLA:
+      return lower_case ? "xla" : "XLA";
+    case DeviceType::Lazy:
+      return lower_case ? "lazy" : "LAZY";
+    case DeviceType::MPS:
+      return lower_case ? "mps" : "MPS";
+    case DeviceType::Vulkan:
+      return lower_case ? "vulkan" : "VULKAN";
+    case DeviceType::Metal:
+      return lower_case ? "metal" : "METAL";
+    case DeviceType::XPU:
+      return lower_case ? "xpu" : "XPU";
+    case DeviceType::Meta:
+      return lower_case ? "meta" : "META";
+    case DeviceType::HPU:
+      return lower_case ? "hpu" : "HPU";
+    case DeviceType::IPU:
+      return lower_case ? "ipu" : "IPU";
+    case DeviceType::MTIA:
+      return lower_case ? "mtia" : "MTIA";
+    case DeviceType::PrivateUse1:
+      return get_privateuse1_backend(lower_case);
+    default:
+      TORCH_CHECK(
+          false,
+          "Unknown device: ",
+          static_cast<int16_t>(d),
+          ". If you have recently updated the caffe2.proto file to add a new "
+          "device type, did you forget to update the DeviceTypeName() "
+          "function to reflect such recent changes?");
+      // The below code won't run but is needed to suppress some compiler
+      // warnings.
+      return "";
+  }
+}
+
+inline C10_API std::ostream& operator<<(std::ostream& stream, DeviceType type) {
+  stream << DeviceTypeName(type, /* lower case */ true);
+  return stream;
+}
+} // namespace c10
+
+
+namespace torch::standalone {
+// Create name aliases in the torch::standalone namespace.
+// For any new code calling the torch standalone APIs, it is recommended to use
+// the torch::standalone namespace and always spell out the namespace.
+
+using c10::DeviceType;
+// clang-format off
+// Turn off clang-format for this section to avoid reordering
+using c10::kCPU;
+using c10::kCUDA;
+using c10::kMKLDNN;
+using c10::kOPENGL;
+using c10::kOPENCL;
+using c10::kIDEEP;
+using c10::kHIP;
+using c10::kFPGA;
+using c10::kMAIA;
+using c10::kXLA;
+using c10::kVulkan;
+using c10::kMetal;
+using c10::kXPU;
+using c10::kMPS;
+using c10::kMeta;
+using c10::kHPU;
+using c10::kVE;
+using c10::kLazy;
+using c10::kIPU;
+using c10::kMTIA;
+using c10::kPrivateUse1;
+using c10::COMPILE_TIME_MAX_DEVICE_TYPES;
+// clang-format on
+
+using c10::DeviceTypeName;
+using c10::get_privateuse1_backend;
+using c10::isValidDeviceType;
+}
+
+namespace std {
+template <>
+struct hash<c10::DeviceType> {
+  std::size_t operator()(c10::DeviceType k) const {
+    return std::hash<int>()(static_cast<int>(k));
+  }
+};
+} // namespace std

--- a/torch/standalone/core/Export.h
+++ b/torch/standalone/core/Export.h
@@ -1,0 +1,94 @@
+#pragma once
+
+/* Header file to define the common scaffolding for exported symbols.
+ *
+ * Export is by itself a quite tricky situation to deal with, and if you are
+ * hitting this file, make sure you start with the background here:
+ * - Linux: https://gcc.gnu.org/wiki/Visibility
+ * - Windows:
+ * https://docs.microsoft.com/en-us/cpp/cpp/dllexport-dllimport?view=vs-2017
+ *
+ * Do NOT include this file directly. Instead, use c10/macros/Macros.h
+ */
+
+// You do not need to edit this part of file unless you are changing the core
+// pytorch export abstractions.
+//
+// This part defines the C10 core export and import macros. This is controlled
+// by whether we are building shared libraries or not, which is determined
+// during build time and codified in c10/core/cmake_macros.h.
+// When the library is built as a shared lib, EXPORT and IMPORT will contain
+// visibility attributes. If it is being built as a static lib, then EXPORT
+// and IMPORT basically have no effect.
+
+// As a rule of thumb, you should almost NEVER mix static and shared builds for
+// libraries that depend on c10. AKA, if c10 is built as a static library, we
+// recommend everything dependent on c10 to be built statically. If c10 is built
+// as a shared library, everything dependent on it should be built as shared. In
+// the PyTorch project, all native libraries shall use the macro
+// C10_BUILD_SHARED_LIB to check whether pytorch is building shared or static
+// libraries.
+
+// For build systems that do not directly depend on CMake and directly build
+// from the source directory (such as Buck), one may not have a cmake_macros.h
+// file at all. In this case, the build system is responsible for providing
+// correct macro definitions corresponding to the cmake_macros.h.in file.
+//
+// In such scenarios, one should define the macro
+//     C10_USING_CUSTOM_GENERATED_MACROS
+// to inform this header that it does not need to include the cmake_macros.h
+// file.
+
+#ifdef _WIN32
+#define C10_HIDDEN
+#if defined(C10_BUILD_SHARED_LIBS)
+#define C10_EXPORT __declspec(dllexport)
+#define C10_IMPORT __declspec(dllimport)
+#else
+#define C10_EXPORT
+#define C10_IMPORT
+#endif
+#else // _WIN32
+#if defined(__GNUC__)
+#define C10_EXPORT __attribute__((__visibility__("default")))
+#define C10_HIDDEN __attribute__((__visibility__("hidden")))
+#else // defined(__GNUC__)
+#define C10_EXPORT
+#define C10_HIDDEN
+#endif // defined(__GNUC__)
+#define C10_IMPORT C10_EXPORT
+#endif // _WIN32
+
+#ifdef NO_EXPORT
+#undef C10_EXPORT
+#define C10_EXPORT
+#endif
+
+// Definition of an adaptive XX_API macro, that depends on whether you are
+// building the library itself or not, routes to XX_EXPORT and XX_IMPORT.
+// Basically, you will need to do this for each shared library that you are
+// building, and the instruction is as follows: assuming that you are building
+// a library called libawesome.so. You should:
+// (1) for your cmake target (usually done by "add_library(awesome, ...)"),
+//     define a macro called AWESOME_BUILD_MAIN_LIB using
+//     target_compile_options.
+// (2) define the AWESOME_API macro similar to the one below.
+// And in the source file of your awesome library, use AWESOME_API to
+// annotate public symbols.
+
+// Here, for the C10 library, we will define the macro C10_API for both import
+// and export.
+
+// This one is being used by libc10.so
+#ifdef C10_BUILD_MAIN_LIB
+#define C10_API C10_EXPORT
+#else
+#define C10_API C10_IMPORT
+#endif
+
+// Enums only need to be exported on windows for non-CUDA files
+#if defined(_WIN32) && defined(__CUDACC__)
+#define C10_API_ENUM C10_API
+#else
+#define C10_API_ENUM
+#endif


### PR DESCRIPTION
Summary:
The goal of this PR and future follow-up PRs is to group a set of header files required by AOTInductor Standalone in a separate directory, ensuring they are implemented in a header-only manner. More specifically, here is what this PR does:
* Extract the DeviceType enum class into a standalone header file in a new torch/standalone/header_only directory
* Retain the existing c10/core/DeviceType.[h|cpp] files to handle complex logic and static variables
* Import symbols from the new torch::standalone namespace into c10 for backward compatibility

This is an updated version of https://github.com/pytorch/pytorch/pull/152787, because we need to land in fbcode first. See the original comments and discussions in https://github.com/pytorch/pytorch/pull/152787.

Differential Revision: D75605373
