### PR TITLE
[EZ/Memory Snapshot] Remove Handle even if compile_context not set

### DIFF
--- a/torch/csrc/cuda/memory_snapshot.cpp
+++ b/torch/csrc/cuda/memory_snapshot.cpp
@@ -184,7 +184,7 @@ void setRecordFunctionCallbacks(bool enabled, bool compileContext) {
       at::removeCallback(callbackManager.getAnnotationHandle());
       callbackManager.setAnnotationHandle(0);
     }
-    if (compileContext && callbackManager.getCompileContextHandle() != 0) {
+    if (callbackManager.getCompileContextHandle() != 0) {
       at::removeCallback(callbackManager.getCompileContextHandle());
       callbackManager.setCompileContextHandle(0);
     }


### PR DESCRIPTION
Summary: When setting the memory snapshot callback we register and unregister callbacks for performance reasons. For ease of use, it makes sense to just remove all callbacks regardless of which flags are enabled. The enable stays behind a feature flag, this just changes the disable to ignore the flag itself.

Test Plan: Ran without any flags and saw all callbacks removed.

Differential Revision: D75636035


