### PR TITLE
pin torchao in torchbench jobs

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1641,7 +1641,7 @@ elif [[ "${TEST_CONFIG}" == *torchbench* ]]; then
     install_torchaudio cuda
   fi
   install_torchvision
-  TORCH_CUDA_ARCH_LIST="8.0;8.6" pip_install git+https://github.com/pytorch/ao.git
+  TORCH_CUDA_ARCH_LIST="8.0;8.6" install_torchao
   id=$((SHARD_NUMBER-1))
   # https://github.com/opencv/opencv-python/issues/885
   pip_install opencv-python==4.8.0.74

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1641,7 +1641,7 @@ elif [[ "${TEST_CONFIG}" == *torchbench* ]]; then
     install_torchaudio cuda
   fi
   install_torchvision
-  TORCH_CUDA_ARCH_LIST="8.0;8.6" install_torchao
+  TORCH_CUDA_ARCH_LIST="8.0" install_torchao
   id=$((SHARD_NUMBER-1))
   # https://github.com/opencv/opencv-python/issues/885
   pip_install opencv-python==4.8.0.74


### PR DESCRIPTION
should fix the ongoing issue with torchbench:
https://hud.pytorch.org/hud/pytorch/pytorch/main/1?per_page=50&name_filter=inductor_torchbench

```
2025-05-29T20:56:55.7168233Z       /usr/local/cuda/include/cusparse.h:254:20: note: declared here
2025-05-29T20:56:55.7168495Z         254 | struct pruneInfo* pruneInfo_t CUSPARSE_DEPRECATED_TYPE;
2025-05-29T20:56:55.7168649Z             |                    ^~~~~~~~~~~
2025-05-29T20:56:55.7168837Z       ninja: build stopped: subcommand failed.
```