### PR TITLE
[BE]Enhance _get_clean_triton.py to auto-generate launch_params if missing

### DIFF
--- a/torch/utils/_get_clean_triton.py
+++ b/torch/utils/_get_clean_triton.py
@@ -81,7 +81,9 @@ def add_launch_params(
     return remove_inductor_wrappers
 
 
-def process_file(input_filename: str, output_filename: str, auto_generate_params: bool = True) -> str:
+def process_file(
+    input_filename: str, output_filename: str, auto_generate_params: bool = True
+) -> str:
     with open(input_filename) as file:
         source_code = file.read()
 
@@ -95,30 +97,38 @@ def process_file(input_filename: str, output_filename: str, auto_generate_params
     transformed_code = remove_async_compile(transformed_code)
 
     launch_params_filename = f"{input_filename}.launch_params"
-    
+
     # Auto-generate launch_params if they don't exist and auto_generate_params is True
     if not os.path.exists(launch_params_filename) and auto_generate_params:
         print(f"Launch params file {launch_params_filename} not found. Generating...")
         try:
             # Set environment variable and run the input file
             env = os.environ.copy()
-            env['TORCHINDUCTOR_DUMP_LAUNCH_PARAMS'] = '1'
-            
-            result = subprocess.run([
-                'python', input_filename
-            ], env=env, capture_output=True, text=True, cwd=os.path.dirname(input_filename) or '.')
-            
+            env["TORCHINDUCTOR_DUMP_LAUNCH_PARAMS"] = "1"
+
+            result = subprocess.run(
+                ["python", input_filename],
+                env=env,
+                capture_output=True,
+                text=True,
+                cwd=os.path.dirname(input_filename) or ".",
+            )
+
             if result.returncode != 0:
                 print(f"Error running {input_filename}:")
                 print(f"stdout: {result.stdout}")
                 print(f"stderr: {result.stderr}")
-                raise RuntimeError(f"Failed to generate launch params. Command failed with return code {result.returncode}")
-            
+                raise RuntimeError(
+                    f"Failed to generate launch params. Command failed with return code {result.returncode}"
+                )
+
             print(f"Successfully generated {launch_params_filename}")
-            
+
         except Exception as e:
-            raise RuntimeError(f"Failed to generate launch params by running {input_filename}: {str(e)}")
-    
+            raise RuntimeError(
+                f"Failed to generate launch params by running {input_filename}: {str(e)}"
+            ) from e
+
     if not os.path.exists(launch_params_filename):
         raise RuntimeError(
             f"Missing {launch_params_filename}. Run `TORCHINDUCTOR_DUMP_LAUNCH_PARAMS=1 python {input_filename}` first."
@@ -138,7 +148,9 @@ def process_file(input_filename: str, output_filename: str, auto_generate_params
 
 
 def get_clean_triton(
-    input_path: Path, output_path: Path = Path("triton_only_repro.py"), auto_generate_params: bool = True
+    input_path: Path,
+    output_path: Path = Path("triton_only_repro.py"),
+    auto_generate_params: bool = True,
 ):
     """Run experiments and output results to file
 
@@ -154,7 +166,7 @@ if __name__ == "__main__":
     """Sample usage:
     # Running sweep
     python _get_clean_triton.py output_code.py
-    
+
     # To disable auto-generation of launch params:
     python _get_clean_triton.py output_code.py --no-auto-generate
     """
@@ -175,11 +187,13 @@ if __name__ == "__main__":
     parser.add_argument(
         "--no-auto-generate",
         action="store_true",
-        help="Disable automatic generation of launch_params file"
+        help="Disable automatic generation of launch_params file",
     )
 
     # Parse the arguments
     args = parser.parse_args()
 
     # Call the function with parsed arguments
-    result = get_clean_triton(args.input_path, args.output_path, not args.no_auto_generate)
+    result = get_clean_triton(
+        args.input_path, args.output_path, not args.no_auto_generate
+    )

--- a/torch/utils/_get_clean_triton.py
+++ b/torch/utils/_get_clean_triton.py
@@ -2,6 +2,7 @@
 import argparse
 import os
 import re
+import subprocess
 from pathlib import Path
 
 
@@ -80,7 +81,7 @@ def add_launch_params(
     return remove_inductor_wrappers
 
 
-def process_file(input_filename: str, output_filename: str) -> str:
+def process_file(input_filename: str, output_filename: str, auto_generate_params: bool = True) -> str:
     with open(input_filename) as file:
         source_code = file.read()
 
@@ -94,9 +95,33 @@ def process_file(input_filename: str, output_filename: str) -> str:
     transformed_code = remove_async_compile(transformed_code)
 
     launch_params_filename = f"{input_filename}.launch_params"
+    
+    # Auto-generate launch_params if they don't exist and auto_generate_params is True
+    if not os.path.exists(launch_params_filename) and auto_generate_params:
+        print(f"Launch params file {launch_params_filename} not found. Generating...")
+        try:
+            # Set environment variable and run the input file
+            env = os.environ.copy()
+            env['TORCHINDUCTOR_DUMP_LAUNCH_PARAMS'] = '1'
+            
+            result = subprocess.run([
+                'python', input_filename
+            ], env=env, capture_output=True, text=True, cwd=os.path.dirname(input_filename) or '.')
+            
+            if result.returncode != 0:
+                print(f"Error running {input_filename}:")
+                print(f"stdout: {result.stdout}")
+                print(f"stderr: {result.stderr}")
+                raise RuntimeError(f"Failed to generate launch params. Command failed with return code {result.returncode}")
+            
+            print(f"Successfully generated {launch_params_filename}")
+            
+        except Exception as e:
+            raise RuntimeError(f"Failed to generate launch params by running {input_filename}: {str(e)}")
+    
     if not os.path.exists(launch_params_filename):
         raise RuntimeError(
-            f"Missing {launch_params_filename}. Run `TORCHINDUCTOR_DUMP_LAUNCH_PARAMS=1 python {input_filename} first."
+            f"Missing {launch_params_filename}. Run `TORCHINDUCTOR_DUMP_LAUNCH_PARAMS=1 python {input_filename}` first."
         )
 
     with open(launch_params_filename) as f:
@@ -108,25 +133,30 @@ def process_file(input_filename: str, output_filename: str) -> str:
 
     with open(output_filename, "w") as file:
         file.write(transformed_code)
+    print(f"Successfully generated {output_filename}")
     return transformed_code
 
 
 def get_clean_triton(
-    input_path: Path, output_path: Path = Path("triton_only_repro.py")
+    input_path: Path, output_path: Path = Path("triton_only_repro.py"), auto_generate_params: bool = True
 ):
     """Run experiments and output results to file
 
     Args:
         input_path (Optional[Path]): Path to inductor generated output codede
         output_path (Optional[Path]): Path to write out the new python file
+        auto_generate_params (bool): Whether to automatically generate launch_params if missing
     """
-    return process_file(str(input_path), str(output_path))
+    return process_file(str(input_path), str(output_path), auto_generate_params)
 
 
 if __name__ == "__main__":
     """Sample usage:
     # Running sweep
-    python inputcode.py
+    python _get_clean_triton.py output_code.py
+    
+    # To disable auto-generation of launch params:
+    python _get_clean_triton.py output_code.py --no-auto-generate
     """
     parser = argparse.ArgumentParser(
         description="Clean Inductor generated code to remove Inductor dependencies"
@@ -142,9 +172,14 @@ if __name__ == "__main__":
         default=Path("triton_only_repro.py"),
         help="Path to write out the clean triton output",
     )
+    parser.add_argument(
+        "--no-auto-generate",
+        action="store_true",
+        help="Disable automatic generation of launch_params file"
+    )
 
     # Parse the arguments
     args = parser.parse_args()
 
     # Call the function with parsed arguments
-    result = get_clean_triton(args.input_path, args.output_path)
+    result = get_clean_triton(args.input_path, args.output_path, not args.no_auto_generate)


### PR DESCRIPTION
Previously, @Chillee wrote a script https://github.com/pytorch/pytorch/pull/125811 to remove inductor dependency for inductor compiled triton kernels. We'd like to automate the process of obtaining the launch parameters.

Added functionality to the torch/utils/_get_clean_triton.py to automatically generate the launch_params file if it does not exist and the auto_generate_params flag is set to True. This includes running the input file in a subprocess with the appropriate environment variable. Updated the get_clean_triton function and the main script to support this new feature, allowing users to disable auto-generation via a command-line argument.

# Test Plan
test embedding op in TritonBench
```
# generate inductor compiled triton kernels
TORCH_COMPILE_DEBUG=1 TORCHINDUCTOR_FX_GRAPH_CACHE=0 python run.py --op embedding  --mode fwd  --precision fp32 --metrics nsys_rep --only inductor_embedding  --num-inputs 1 --input-id 11
# run the script to get rid of inductor dependency. By default, triton_only_repro.py is the output file name.
python ~/pytorch/torch/utils/_get_clean_triton.py ~/tritonbench/torch_compile_debug/run_2025_05_29_14_47_50_497790-pid_849274/torchinductor/model__0_forward_1.0/output_code.py
```
