### PR TITLE
Fix unbackend symint error

### DIFF
--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -1145,9 +1145,8 @@ def tuned_scaled_mm(
 
             # On NVIDIA B200 GPUs, K dim must be >= 32 for tcgen05.mma.kind::f8f6f4.* PTX instruction to be valid
             # source: https://docs.nvidia.com/cuda/parallel-thread-execution/#tcgen05-matrix-shape
-            if using_b200() and guard_or_false(k < 32):
-                # Uncommon for real workloads
-                continue
+            if using_b200():
+                torch._check(k >= 32, f"K dim must be >= 32 for B200 GPUs, got k={k}")
 
             kwargs = scaled_mm_options(
                 config, m, n, k, layout, scale_a, scale_b, use_fast_accum

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -1,6 +1,3 @@
-warning: Selection `PLW1507` has no effect because preview is not enabled.
-warning: Selection `RUF041` has no effect because preview is not enabled.
-warning: Selection `RUF048` has no effect because preview is not enabled.
 # mypy: allow-untyped-defs
 import functools
 import logging

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -454,6 +454,12 @@ class SizeVarAllocator:
             last_var = var
         return order
 
+    def guard_or_false(self, left):
+        return self.evaluate_expr(left, fallback_value=False)
+
+    def guard_or_true(self, left):
+        return self.evaluate_expr(left, fallback_value=True)
+
     # The evaluate functions evaluate some symbolic sympy expression
     # (NB: not necessarily an Expr) and return what the concrete result
     # is, guarding on the expression being that result
@@ -466,10 +472,13 @@ class SizeVarAllocator:
         self,
         left: Union[Expr, sympy.logic.boolalg.Boolean],
         size_oblivious: bool = False,
+        fallback_value: Optional[bool] = None,
     ) -> bool:
         assert isinstance(left, (Expr, sympy.logic.boolalg.Boolean)), type(left)
         return self.shape_env.evaluate_expr(
-            sympy.sympify(left), size_oblivious=size_oblivious
+            sympy.sympify(left),
+            size_oblivious=size_oblivious,
+            fallback_value=fallback_value,
         )
 
     def evaluate_min(self, left: Expr, right: Expr) -> Expr:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #154672


## Summary 

Me and @laithsakka  spoke offline about this one, TLDR is that we wanted this 
![image](https://github.com/user-attachments/assets/2e537612-3261-4fbe-a6b9-f8ff92ba3c37)

to also be true for Inductor. In that vein we added two new apis to size-vars which is `guard_or_false`, or `guard_or_true`
with the semantics:

guard_or_false, guard_or_true:

Those APIs may add guards, but will never fail with data-dependent errors; They will try to evaluate the expression with the possibility of adding guards, if that fails due to data dependency, instead of hard failing. False or True are returned. 


When to use this?

Performance optimizations that warrant a recompilation. 

Take the general path and add a runtime check.
```
# Consider this branching.
if x==0:
    return 1
else
    return 10 
# To make data dependent friendly, it can be written as the following: 
if guard_or_false(x==0):
    return 1
else
  torch.check(x!=0) # runtime check
  return 10
```

However there is still 1 more api to add to make this example work which is the torch.check which works with expressions, I will leave that to the @laithsakka 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov