### PR TITLE
[FSDP2] respect reshard_after_forward=True for root model

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_comm.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_comm.py
@@ -348,9 +348,9 @@ class TestFullyShardCommunication(FSDPTest):
         if reshard_after_forward is False:
             self.assertEqual(len(bwd_comm_counts), 1)
         else:
-            # The root always does not reshard after forward
+            # 2 means two types of collectives (all-gather, reduce-scatter)
             self.assertEqual(len(bwd_comm_counts), 2)
-            self.assertEqual(bwd_comm_counts[c10d_ops._allgather_base_], num_blocks)
+            self.assertEqual(bwd_comm_counts[c10d_ops._allgather_base_], num_blocks + 1)
         self.assertEqual(
             bwd_comm_counts[c10d_ops._reduce_scatter_base_], num_blocks + 1
         )
@@ -478,13 +478,20 @@ class TestFullyShardCommunication(FSDPTest):
         with CommDebugMode() as bwd_comm_mode:
             loss.sum().backward()
         bwd_comm_counts = bwd_comm_mode.get_comm_counts()
-        # If recurse is False, set_reshard_after_forward only affects the root module,
-        # resulting in comm_counts identical to those without set_reshard_after_forward.
-        if recurse == set_reshard_after_forward:
+        # If recurse is False, set_reshard_after_forward only affects the root module
+        if set_reshard_after_forward:
             self.assertEqual(len(bwd_comm_counts), 2)
-            self.assertEqual(bwd_comm_counts[c10d_ops._allgather_base_], num_blocks)
+            self.assertEqual(
+                bwd_comm_counts[c10d_ops._allgather_base_],
+                num_blocks + 1 if recurse else 1,
+            )
         else:
-            self.assertEqual(len(bwd_comm_counts), 1)
+            if recurse:
+                self.assertEqual(len(bwd_comm_counts), 1)
+            else:
+                self.assertEqual(len(bwd_comm_counts), 2)
+                self.assertEqual(bwd_comm_counts[c10d_ops._allgather_base_], num_blocks)
+
         self.assertEqual(
             bwd_comm_counts[c10d_ops._reduce_scatter_base_], num_blocks + 1
         )
@@ -544,8 +551,7 @@ class TestFullyShardPrefetch(FSDPTest):
                 events.clear()
                 loss.sum().backward()
                 expected_events = [
-                    # Root does not reshard after forward so there is no
-                    # unshard event for it in backward
+                    ("unshard", "", TrainingState.PRE_BACKWARD),
                     ("unshard", "layers.2", TrainingState.PRE_BACKWARD),
                     # Explicit backward prefetching moves the unshards early
                     # by one module (note how swapping each unshard down one
@@ -590,15 +596,14 @@ class TestFullyShardPrefetch(FSDPTest):
                 ("unshard", "layers.0", TrainingState.FORWARD),
                 ("unshard", "layers.1", TrainingState.FORWARD),
                 ("unshard", "layers.2", TrainingState.FORWARD),
-                # Root does not reshard after forward so there is not another
-                # unshard event for it
+                ("unshard", "", TrainingState.FORWARD),  # root
                 ("unshard", "layers.0", TrainingState.FORWARD),
                 ("unshard", "layers.1", TrainingState.FORWARD),
                 ("unshard", "layers.2", TrainingState.FORWARD),
             ]
             if reshard_after_forward is False:
                 # No reshard after forward means no second set of unshards
-                expected_events = expected_events[:-3]
+                expected_events = expected_events[:-4]
             self.assertEqual(events, expected_events)
             events.clear()
             (loss1 + loss2).sum().backward()
@@ -608,6 +613,7 @@ class TestFullyShardPrefetch(FSDPTest):
                 # final callback (since the input not requiring gradient means
                 # that we do not have a tensor on which to hook for
                 # post-backward)
+                ("unshard", "", TrainingState.PRE_BACKWARD),
                 ("unshard", "layers.2", TrainingState.PRE_BACKWARD),
                 ("unshard", "layers.1", TrainingState.PRE_BACKWARD),
                 ("post_backward", "layers.2", TrainingState.POST_BACKWARD),
@@ -732,6 +738,7 @@ class TestFullyShardPrefetch(FSDPTest):
         )
         expected_backward_events = [
             # Default backward prefetching
+            ("unshard", "", TrainingState.PRE_BACKWARD),
             ("unshard", "layers.3", TrainingState.PRE_BACKWARD),
             ("unshard", "layers.2", TrainingState.PRE_BACKWARD),
             ("reshard", "layers.3", TrainingState.POST_BACKWARD),
@@ -763,6 +770,7 @@ class TestFullyShardPrefetch(FSDPTest):
                 ("unshard", "layers.3", TrainingState.FORWARD),
                 ("reshard", "layers.2", TrainingState.FORWARD),
                 ("reshard", "layers.3", TrainingState.FORWARD),
+                ("reshard", "", TrainingState.FORWARD),
             ]
             self.assertEqual(events, expected_forward_events)
             events.clear()
@@ -783,6 +791,7 @@ class TestFullyShardPrefetch(FSDPTest):
                 ("reshard", "layers.1", TrainingState.FORWARD),
                 ("reshard", "layers.2", TrainingState.FORWARD),
                 ("reshard", "layers.3", TrainingState.FORWARD),
+                ("reshard", "", TrainingState.FORWARD),
             ]
             self.assertEqual(events, expected_forward_events)
             events.clear()
@@ -831,6 +840,7 @@ class TestFullyShardPrefetch(FSDPTest):
             ("reshard", "layers.2", TrainingState.FORWARD),
             ("unshard", "layers.3", TrainingState.FORWARD),
             ("reshard", "layers.3", TrainingState.FORWARD),
+            ("reshard", "", TrainingState.FORWARD),
         ]
         with patch_unshard(unshard_with_record), patch_reshard(
             reshard_with_record
@@ -841,6 +851,7 @@ class TestFullyShardPrefetch(FSDPTest):
             events.clear()
             loss.sum().backward()
             expected_backward_events = [
+                ("unshard", "", TrainingState.PRE_BACKWARD),
                 # Root prefetches `layers.3` per default
                 ("unshard", "layers.3", TrainingState.PRE_BACKWARD),
                 # `layers.i` prefetches for `layers.i-1` (same as default)
@@ -867,6 +878,7 @@ class TestFullyShardPrefetch(FSDPTest):
             events.clear()
             loss.sum().backward()
             expected_backward_events = [
+                ("unshard", "", TrainingState.PRE_BACKWARD),
                 # Root prefetches `layers.3` per default
                 ("unshard", "layers.3", TrainingState.PRE_BACKWARD),
                 # `layers.i` prefetches for `layers.i-1` and `layers.i-2`

--- a/test/distributed/_composable/fsdp/test_fully_shard_compile.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_compile.py
@@ -898,7 +898,7 @@ val.shape: {[node.meta['val'].shape for node in aliased_graph_inputs]},
             for _, mod in enumerate(model.layers):
                 fully_shard(mod, mesh=mesh, reshard_after_forward=True, **fsdp_config)
             model = fully_shard(
-                model, mesh=mesh, reshard_after_forward=True, **fsdp_config
+                model, mesh=mesh, reshard_after_forward=False, **fsdp_config
             )
             optim = torch.optim.SGD(model.parameters(), lr=1e-4)
             return model, optim

--- a/test/distributed/_composable/fsdp/test_fully_shard_extensions.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_extensions.py
@@ -394,7 +394,7 @@ class TestFullyShardAllGatherExtensionsMultiThread(
                 if "weight" in param_name:
                     param = nn.Parameter(BFloat16AllGatherTensor(param))
                     setattr(module, param_name, param)
-        fully_shard(model)
+        fully_shard(model, reshard_after_forward=False)
         optim = torch.optim.AdamW(model.parameters(), lr=1e-2, fused=True)
         torch.manual_seed(42 + self.rank + 1)
         inp = torch.randn((2, 3), device=device_type)

--- a/test/distributed/_composable/fsdp/test_fully_shard_extensions.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_extensions.py
@@ -394,6 +394,8 @@ class TestFullyShardAllGatherExtensionsMultiThread(
                 if "weight" in param_name:
                     param = nn.Parameter(BFloat16AllGatherTensor(param))
                     setattr(module, param_name, param)
+        # need to fix reshard_after_forward=True
+        # https://github.com/pytorch/pytorch/issues/154836
         fully_shard(model, reshard_after_forward=False)
         optim = torch.optim.AdamW(model.parameters(), lr=1e-2, fused=True)
         torch.manual_seed(42 + self.rank + 1)

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -25,7 +25,7 @@ from torch.distributed.fsdp import (
     OffloadPolicy,
     register_fsdp_forward_method,
 )
-from torch.distributed.tensor import DTensor, init_device_mesh, Replicate, Shard
+from torch.distributed.tensor import DTensor, init_device_mesh, Shard
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
@@ -175,10 +175,6 @@ class FSDPState(_State):
                 state._is_root = False
             self._state_ctx.all_states.append(state)
             visited_states.add(state)
-        if self._fsdp_param_group:
-            # For the root, do not reshard after forward since for training,
-            # the parameters would be freed and all-gathered immediately
-            self._fsdp_param_group.post_forward_mesh_info = None
         self._init_fqns()
         self._init_shared_state()
         # Run parameter group lazy inits after initializing FQNs for improved


### PR DESCRIPTION
resolve https://github.com/pytorch/pytorch/issues/154655

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #154704

`fully_shard(root, reshard_after_forward=True)` didn't really reshard parameters after forward, because we assumed root model will be used in backward immeidately. The assumption becomes invalid in 2 cases
* we have 3 roots for CLIP, T5, FLUX. we should reshard parameters are CLIP and T5 immeidately after their forward
for recommendation model, we may have mutiple root for dense part

Change default beahvior to always respect `reshard_after_forward=True`

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k

Differential Revision: [D75663200](https://our.internmc.facebook.com/intern/diff/D75663200)