### PR TITLE
Improve `lr_scheduler` epoch type and description

### DIFF
--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -173,7 +173,14 @@ class LRScheduler:
         raise NotImplementedError
 
     def step(self, epoch: Optional[int] = None) -> None:
-        """Perform a step."""
+        """Adjust the learning rate of the optimizer.
+
+        Args:
+            epoch (int, optional): The index of the training epoch. Default: None.
+
+                .. deprecated:: 1.3
+                    The ``epoch`` parameter is being deprecated, use ``lr_scheduler.step()``.
+        """
         # Raise a warning if old pattern is detected
         # https://github.com/pytorch/pytorch/issues/20124
         if self._step_count == 1:
@@ -1329,8 +1336,17 @@ class ReduceLROnPlateau(LRScheduler):
         self.cooldown_counter = 0
         self.num_bad_epochs = 0
 
-    def step(self, metrics: SupportsFloat, epoch=None) -> None:  # type: ignore[override]
-        """Perform a step."""
+    def step(self, metrics: SupportsFloat, epoch: Optional[int] = None) -> None:  # type: ignore[override]
+        """
+        Adjust the learning rate of the optimizer.
+
+        Args:
+            metrics (SupportsFloat): Monitored metric used to determine whether the learning rate should be adjusted.
+            epoch (int, optional): The index of the training epoch. Default: None.
+
+                .. deprecated:: 1.3
+                    The ``epoch`` parameter is being deprecated, use ``lr_scheduler.step()``.
+        """
         # convert `metrics` to float, in case it's a zero-dim Tensor
         current = float(metrics)
         if epoch is None:
@@ -1775,8 +1791,14 @@ class CosineAnnealingWarmRestarts(LRScheduler):
         ]
 
     @override
-    def step(self, epoch=None) -> None:
-        """Step could be called after every batch update.
+    def step(self, epoch: Optional[int] = None) -> None:
+        """Adjust the learning rate of the optimizer.
+
+        Args:
+            epoch (int, optional): The index of the training epoch. Default: None.
+
+                .. deprecated:: 1.3
+                    The ``epoch`` parameter is being deprecated, use ``lr_scheduler.step()``.
 
         Example:
             >>> # xdoctest: +SKIP("Undefined vars")


### PR DESCRIPTION
Fixes #69841

- Add int type to `epoch` param in `step` method
- Add clear description about usage and deprecation of `step` method params

And the improvement in https://github.com/pytorch/pytorch/issues/69841#issuecomment-1010269283 about `remove the printing workarounds` already landed via https://github.com/pytorch/pytorch/pull/147301


## Test Result

### Before
**CosineAnnealingWarmRestarts**
![image](https://github.com/user-attachments/assets/0de56f0e-dbdb-4865-8d6a-638a7bc7fcc3)

**LRScheduler**
![image](https://github.com/user-attachments/assets/9db7c16b-cfa7-4e3e-b0a0-42b2b5719576)

**ReduceLROnPlateau**
![image](https://github.com/user-attachments/assets/87775571-a4d2-45cb-be41-3b5a4c7468d9)


### After
**CosineAnnealingWarmRestarts**
![image](https://github.com/user-attachments/assets/a56d6d92-5f71-491d-89cb-d9373c8d3bd5)

**LRScheduler**
![image](https://github.com/user-attachments/assets/cfc68231-0836-47eb-a0b4-f8aeaa26f0cd)


**ReduceLROnPlateau**
![image](https://github.com/user-attachments/assets/a27e87cc-31df-4741-8d75-da1fff9f93c7)

