### PR TITLE
Add __main__ guards to tests

### DIFF
--- a/test/inductor/test_aot_inductor_utils.py
+++ b/test/inductor/test_aot_inductor_utils.py
@@ -16,7 +16,7 @@ from torch._dynamo.testing import same
 from torch._inductor import config
 from torch._inductor.test_case import TestCase
 from torch.testing import FileCheck
-from torch.testing._internal.common_utils import IS_FBCODE
+from torch.testing._internal.common_utils import run_tests, IS_FBCODE
 from torch.testing._internal.inductor_utils import clone_preserve_strides_offset
 from torch.utils import _pytree as pytree
 
@@ -290,3 +290,6 @@ def code_check_count(
             target_count,
             exactly=True,
         ).run(src_code)
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_aot_inductor_utils.py
+++ b/test/inductor/test_aot_inductor_utils.py
@@ -16,7 +16,7 @@ from torch._dynamo.testing import same
 from torch._inductor import config
 from torch._inductor.test_case import TestCase
 from torch.testing import FileCheck
-from torch.testing._internal.common_utils import run_tests, IS_FBCODE
+from torch.testing._internal.common_utils import IS_FBCODE, run_tests
 from torch.testing._internal.inductor_utils import clone_preserve_strides_offset
 from torch.utils import _pytree as pytree
 
@@ -205,11 +205,14 @@ def check_model(
     atol=None,
     rtol=None,
 ):
-    with torch.no_grad(), config.patch(
-        {
-            "aot_inductor.allow_stack_allocation": self.allow_stack_allocation,
-            "aot_inductor.use_minimal_arrayref_interface": self.use_minimal_arrayref_interface,
-        }
+    with (
+        torch.no_grad(),
+        config.patch(
+            {
+                "aot_inductor.allow_stack_allocation": self.allow_stack_allocation,
+                "aot_inductor.use_minimal_arrayref_interface": self.use_minimal_arrayref_interface,
+            }
+        ),
     ):
         torch.manual_seed(0)
         if not isinstance(model, types.FunctionType):
@@ -248,11 +251,14 @@ def check_model_with_multiple_inputs(
     options=None,
     dynamic_shapes=None,
 ):
-    with torch.no_grad(), config.patch(
-        {
-            "aot_inductor.allow_stack_allocation": self.allow_stack_allocation,
-            "aot_inductor.use_minimal_arrayref_interface": self.use_minimal_arrayref_interface,
-        }
+    with (
+        torch.no_grad(),
+        config.patch(
+            {
+                "aot_inductor.allow_stack_allocation": self.allow_stack_allocation,
+                "aot_inductor.use_minimal_arrayref_interface": self.use_minimal_arrayref_interface,
+            }
+        ),
     ):
         torch.manual_seed(0)
         model = model.to(self.device)
@@ -275,11 +281,14 @@ def code_check_count(
     target_str: str,
     target_count: int,
 ):
-    with torch.no_grad(), config.patch(
-        {
-            "aot_inductor.allow_stack_allocation": self.allow_stack_allocation,
-            "aot_inductor.use_minimal_arrayref_interface": self.use_minimal_arrayref_interface,
-        }
+    with (
+        torch.no_grad(),
+        config.patch(
+            {
+                "aot_inductor.allow_stack_allocation": self.allow_stack_allocation,
+                "aot_inductor.use_minimal_arrayref_interface": self.use_minimal_arrayref_interface,
+            }
+        ),
     ):
         package_path = torch._export.aot_compile(model, example_inputs)
 
@@ -290,6 +299,7 @@ def code_check_count(
             target_count,
             exactly=True,
         ).run(src_code)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/lazy/test_bindings.py
+++ b/test/lazy/test_bindings.py
@@ -8,5 +8,6 @@ def test_metrics():
     names = torch._lazy.metrics.counter_names()
     assert len(names) == 0, f"Expected no counter names, but got {names}"
 
+
 if __name__ == "__main__":
     run_tests()

--- a/test/lazy/test_bindings.py
+++ b/test/lazy/test_bindings.py
@@ -1,8 +1,12 @@
 # Owner(s): ["oncall: jit"]
 
 import torch._lazy.metrics
+from torch.testing._internal.common_utils import run_tests
 
 
 def test_metrics():
     names = torch._lazy.metrics.counter_names()
     assert len(names) == 0, f"Expected no counter names, but got {names}"
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/lazy/test_extract_compiled_graph.py
+++ b/test/lazy/test_extract_compiled_graph.py
@@ -16,6 +16,7 @@ import torch
 from torch import fx, nn
 from torch._lazy import config
 from torch._lazy.extract_compiled_graph import extract_compiled_graph
+from torch.testing._internal.common_utils import run_tests
 
 
 class ModuleConstScale(nn.Module):
@@ -206,3 +207,6 @@ class OptimizeTest(unittest.TestCase):
     test_return_multi = maketest(ModuleReturnMulti)
     test_return_dup_tensor = maketest(ModuleReturnDupTensor)
     test_inplace_update = maketest(ModuleInplaceUpdate)
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/lazy/test_extract_compiled_graph.py
+++ b/test/lazy/test_extract_compiled_graph.py
@@ -208,5 +208,6 @@ class OptimizeTest(unittest.TestCase):
     test_return_dup_tensor = maketest(ModuleReturnDupTensor)
     test_inplace_update = maketest(ModuleInplaceUpdate)
 
+
 if __name__ == "__main__":
     run_tests()

--- a/test/lazy/test_extract_compiled_graph.py
+++ b/test/lazy/test_extract_compiled_graph.py
@@ -16,7 +16,6 @@ import torch
 from torch import fx, nn
 from torch._lazy import config
 from torch._lazy.extract_compiled_graph import extract_compiled_graph
-from torch.testing._internal.common_utils import run_tests
 
 
 class ModuleConstScale(nn.Module):
@@ -210,4 +209,7 @@ class OptimizeTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    run_tests()
+    raise RuntimeError(
+        "This test is not currently used and should be "
+        "enabled in discover_tests.py if required."
+    )

--- a/test/lazy/test_meta_kernel.py
+++ b/test/lazy/test_meta_kernel.py
@@ -38,5 +38,6 @@ class TestMetaKernel(TestCase):
         with self.assertRaisesRegex(RuntimeError, ".*not a lazy tensor.*"):
             _ = torch.tensor([1], device="cpu") + torch.tensor([1], device="lazy")
 
+
 if __name__ == "__main__":
     run_tests()

--- a/test/lazy/test_meta_kernel.py
+++ b/test/lazy/test_meta_kernel.py
@@ -4,7 +4,7 @@ import torch
 import torch._lazy
 import torch._lazy.ts_backend
 from torch import float16, float32
-from torch.testing._internal.common_utils import TestCase
+from torch.testing._internal.common_utils import run_tests, TestCase
 
 
 torch._lazy.ts_backend.init()
@@ -37,3 +37,6 @@ class TestMetaKernel(TestCase):
     def test_add_invalid_device(self):
         with self.assertRaisesRegex(RuntimeError, ".*not a lazy tensor.*"):
             _ = torch.tensor([1], device="cpu") + torch.tensor([1], device="lazy")
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/lazy/test_meta_kernel.py
+++ b/test/lazy/test_meta_kernel.py
@@ -4,7 +4,7 @@ import torch
 import torch._lazy
 import torch._lazy.ts_backend
 from torch import float16, float32
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import TestCase
 
 
 torch._lazy.ts_backend.init()
@@ -40,4 +40,7 @@ class TestMetaKernel(TestCase):
 
 
 if __name__ == "__main__":
-    run_tests()
+    raise RuntimeError(
+        "This test is not currently used and should be "
+        "enabled in discover_tests.py if required."
+    )

--- a/test/onnx/test_models_quantized_onnxruntime.py
+++ b/test/onnx/test_models_quantized_onnxruntime.py
@@ -10,6 +10,7 @@ import torchvision
 
 import torch
 from torch import nn
+from torch.testing._internal import common_utils
 
 
 def _get_test_image_tensor():
@@ -95,3 +96,7 @@ class TestQuantizedModelsONNXRuntime(onnx_test_common._TestONNXRuntime):
             pretrained=True, quantize=True
         )
         self.run_test(model, _get_test_image_tensor())
+
+
+if __name__ == "__main__":
+    common_utils.run_tests()

--- a/test/onnx/test_onnxscript_no_runtime.py
+++ b/test/onnx/test_onnxscript_no_runtime.py
@@ -163,4 +163,7 @@ class TestONNXScriptExport(common_utils.TestCase):
 
 
 if __name__ == "__main__":
-    common_utils.run_tests()
+    raise RuntimeError(
+        "This test is not currently used and should be "
+        "enabled in discover_tests.py if required."
+    )

--- a/test/onnx/test_onnxscript_no_runtime.py
+++ b/test/onnx/test_onnxscript_no_runtime.py
@@ -160,3 +160,7 @@ class TestONNXScriptExport(common_utils.TestCase):
         )
         loop_selu_proto = onnx.load(io.BytesIO(saved_model.getvalue()))
         self.assertEqual(len(loop_selu_proto.functions), 1)
+
+
+if __name__ == "__main__":
+    common_utils.run_tests()

--- a/test/test_bundled_images.py
+++ b/test/test_bundled_images.py
@@ -92,3 +92,9 @@ class TestBundledImages(TestCase):
             im2_tensor = torch.ops.fb.image_decode_to_NCHW(byte_tensor, weight, bias)
             self.assertEqual(raw_data.shape, im2_tensor.shape)
             self.assertEqual(raw_data, im2_tensor, atol=0.1, rtol=1e-01)
+
+if __name__ == "__main__":
+    raise RuntimeError(
+        "This test is not currently used and should be "
+        "enabled in discover_tests.py if required."
+    )

--- a/test/test_bundled_images.py
+++ b/test/test_bundled_images.py
@@ -93,6 +93,7 @@ class TestBundledImages(TestCase):
             self.assertEqual(raw_data.shape, im2_tensor.shape)
             self.assertEqual(raw_data, im2_tensor, atol=0.1, rtol=1e-01)
 
+
 if __name__ == "__main__":
     raise RuntimeError(
         "This test is not currently used and should be "

--- a/test/test_hub.py
+++ b/test/test_hub.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 import torch
 import torch.hub as hub
-from torch.testing._internal.common_utils import IS_SANDCASTLE, retry, TestCase
+from torch.testing._internal.common_utils import run_tests, IS_SANDCASTLE, retry, TestCase
 
 
 def sum_of_state_dict(state_dict):
@@ -307,3 +307,6 @@ class TestHub(TestCase):
         torch.hub.load("ailzhang/torchhub_example", "mnist_zip_1_6", trust_repo="check")
 
         self._assert_trusted_list_is_empty()
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/test_hub.py
+++ b/test/test_hub.py
@@ -8,7 +8,12 @@ from unittest.mock import patch
 
 import torch
 import torch.hub as hub
-from torch.testing._internal.common_utils import run_tests, IS_SANDCASTLE, retry, TestCase
+from torch.testing._internal.common_utils import (
+    IS_SANDCASTLE,
+    retry,
+    run_tests,
+    TestCase,
+)
 
 
 def sum_of_state_dict(state_dict):
@@ -307,6 +312,7 @@ class TestHub(TestCase):
         torch.hub.load("ailzhang/torchhub_example", "mnist_zip_1_6", trust_repo="check")
 
         self._assert_trusted_list_is_empty()
+
 
 if __name__ == "__main__":
     run_tests()

--- a/tools/testing/discover_tests.py
+++ b/tools/testing/discover_tests.py
@@ -104,7 +104,10 @@ TESTS = discover_tests(
         "distributed/test_c10d_spawn",
         "distributions/test_transforms",
         "distributions/test_utils",
+        "lazy/test_meta_kernel",
+        "lazy/test_extract_compiled_graph",
         "test/inductor/test_aot_inductor_utils",
+        "onnx/test_onnxscript_no_runtime",
         "onnx/test_pytorch_onnx_onnxruntime_cuda",
         "onnx/test_models",
         # These are not C++ tests


### PR DESCRIPTION
This PR is part of a series attempting to re-submit https://github.com/pytorch/pytorch/pull/134592 as smaller PRs.

Add missing `if __name__ == "__main__":` guards to some tests.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov