### PR TITLE
[Wheel Variant] Experimental Support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -285,3 +285,13 @@ select = [
 "tools/linter/**" = [
     "LOG015" # please fix
 ]
+
+[variant.default-priorities]
+ # the plugins corresponding to these namespaces will be auto-installed at installation
+namespace = ["fictional_hw", "fictional_tech"]  # optional - if empty nothing is auto-installed
+feature = []                                    # optional - Can be skipped if empty - 95%+ packages won't ever need
+property = []                                   # optional - Can be skipped if empty - 95%+ packages won't ever need
+
+[variant.providers.nvidia]
+requires = ["nvidia-variant-provider>=0.0.1,<1.0.0"]
+plugin-api = "nvidia_variant_provider.plugin:NvidiaVariantPlugin"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -287,10 +287,7 @@ select = [
 ]
 
 [variant.default-priorities]
- # the plugins corresponding to these namespaces will be auto-installed at installation
-namespace = ["fictional_hw", "fictional_tech"]  # optional - if empty nothing is auto-installed
-feature = []                                    # optional - Can be skipped if empty - 95%+ packages won't ever need
-property = []                                   # optional - Can be skipped if empty - 95%+ packages won't ever need
+namespace = ["nvidia"]
 
 [variant.providers.nvidia]
 requires = ["nvidia-variant-provider>=0.0.1,<1.0.0"]


### PR DESCRIPTION
@seemethere Can you tag for 2.8.0 and assign yourself ?

- PyTorch: @atalman @seemethere
- NVIDIA: @emmatyping @bdice  @warsaw @msarahan @vyasr @aterrel
- QuanSight: @rgommers @mgorny 
- Astral: @charliermarsh @konstin @geofft @zanieb
- Anaconda: @jezdez

This PR will allow to `Wheel Variant-ize` PyTorch using:

```bash
variantlib make-variant \
    -f /path/to/torch.whl \
    --output-directory . \
    --pyproject-toml=./pyproject.toml \
    -p "nvidia :: cuda :: 12.4"
```

This PR comes in context of the WheelNext initiative - @seemethere @atalman are the point of contacts for PyTorch.

**Some resources:**
- https://wheelnext.dev/proposals/pepxxx_wheel_variant_support/
- https://github.com/wheelnext/pep_xxx_wheel_variants
- https://github.com/pytorch/pytorch/issues/155141

Thanks :) 