### PR TITLE
[pgo] log dynamic whitelist in PT2 Compile Events

### DIFF
--- a/torch/_dynamo/pgo.py
+++ b/torch/_dynamo/pgo.py
@@ -611,6 +611,10 @@ def render_code_state(cs: defaultdict[CodeId, CodeState]) -> str:
             "To potentially avoid thisTo reduce shape recompilations by compiling dynamically to start, "
             f'set environment variable TORCH_COMPILE_DYNAMIC_SOURCES="{",".join(dynamic_sources)}"'
         )
+        with dynamo_timed(name := "pgo.dynamic_whitelist", log_pt2_compile_event=True):
+            CompileEventLogger.pt2_compile(
+                name, recompile_dynamic_whitelist=",".join(dynamic_sources)
+            )
     return code_state_str
 
 


### PR DESCRIPTION
Summary: logs the whitelist to PT2 Compile Events

Test Plan: loggercli codegen GeneratedPt2CompileEventsLoggerConfig

Reviewed By: bobrenjc93

Differential Revision: D75617963




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames