### PR TITLE
Fix memory leaks in mps_linear_nograph

### DIFF
--- a/aten/src/ATen/native/mps/operations/Linear.mm
+++ b/aten/src/ATen/native/mps/operations/Linear.mm
@@ -35,14 +35,14 @@ static void _mps_linear_nograph(const Tensor& input, const Tensor& weight, const
                                                                                 shape:getMPSShape(weight.sizes())];
       weightDesc.preferPackedRows = YES;
       [weightDesc transposeDimension:0 withDimension:1];
-      MPSNDArray* weightNDArray = [[MPSNDArray alloc] initWithBuffer:weightBuf
+      MPSNDArray* weightNDArray = [[[MPSNDArray alloc] initWithBuffer:weightBuf
                                                               offset:weight.storage_offset() * weight.element_size()
-                                                          descriptor:weightDesc];
+                                                          descriptor:weightDesc] autorelease];
 
       if (is_bias_defined) {
         auto biasNDArray = getMPSNDArray(bias, bias.sizes(), bias.strides());
         auto cachedKernel = LookUpOrCreateCachedKernel<MPSCachedKernel>(
-            key, [&]() { return [[MPSNDArrayMatrixMultiplication alloc] initWithDevice:device sourceCount:3]; });
+            key, [&]() { return [[[MPSNDArrayMatrixMultiplication alloc] initWithDevice:device sourceCount:3] autorelease]; });
         auto kernel = cachedKernel->kernel<MPSNDArrayMatrixMultiplication>();
 
         getMPSProfiler().beginProfileKernel(kernel, "mps_linear", {input, weight, bias});
@@ -53,7 +53,7 @@ static void _mps_linear_nograph(const Tensor& input, const Tensor& weight, const
         getMPSProfiler().endProfileKernel(kernel);
       } else {
         auto cachedKernel = LookUpOrCreateCachedKernel<MPSCachedKernel>(
-            key, [&]() { return [[MPSNDArrayMatrixMultiplication alloc] initWithDevice:device sourceCount:2]; });
+            key, [&]() { return [[[MPSNDArrayMatrixMultiplication alloc] initWithDevice:device sourceCount:2] autorelease]; });
         auto kernel = cachedKernel->kernel<MPSNDArrayMatrixMultiplication>();
         getMPSProfiler().beginProfileKernel(kernel, "mps_linear", {input, weight, bias});
         [kernel encodeToCommandEncoder:computeEncoder

--- a/aten/src/ATen/native/mps/operations/Linear.mm
+++ b/aten/src/ATen/native/mps/operations/Linear.mm
@@ -36,13 +36,14 @@ static void _mps_linear_nograph(const Tensor& input, const Tensor& weight, const
       weightDesc.preferPackedRows = YES;
       [weightDesc transposeDimension:0 withDimension:1];
       MPSNDArray* weightNDArray = [[[MPSNDArray alloc] initWithBuffer:weightBuf
-                                                              offset:weight.storage_offset() * weight.element_size()
-                                                          descriptor:weightDesc] autorelease];
+                                                               offset:weight.storage_offset() * weight.element_size()
+                                                           descriptor:weightDesc] autorelease];
 
       if (is_bias_defined) {
         auto biasNDArray = getMPSNDArray(bias, bias.sizes(), bias.strides());
-        auto cachedKernel = LookUpOrCreateCachedKernel<MPSCachedKernel>(
-            key, [&]() { return [[[MPSNDArrayMatrixMultiplication alloc] initWithDevice:device sourceCount:3] autorelease]; });
+        auto cachedKernel = LookUpOrCreateCachedKernel<MPSCachedKernel>(key, [&]() {
+          return [[[MPSNDArrayMatrixMultiplication alloc] initWithDevice:device sourceCount:3] autorelease];
+        });
         auto kernel = cachedKernel->kernel<MPSNDArrayMatrixMultiplication>();
 
         getMPSProfiler().beginProfileKernel(kernel, "mps_linear", {input, weight, bias});
@@ -52,8 +53,9 @@ static void _mps_linear_nograph(const Tensor& input, const Tensor& weight, const
                       destinationArray:outNDArray];
         getMPSProfiler().endProfileKernel(kernel);
       } else {
-        auto cachedKernel = LookUpOrCreateCachedKernel<MPSCachedKernel>(
-            key, [&]() { return [[[MPSNDArrayMatrixMultiplication alloc] initWithDevice:device sourceCount:2] autorelease]; });
+        auto cachedKernel = LookUpOrCreateCachedKernel<MPSCachedKernel>(key, [&]() {
+          return [[[MPSNDArrayMatrixMultiplication alloc] initWithDevice:device sourceCount:2] autorelease];
+        });
         auto kernel = cachedKernel->kernel<MPSNDArrayMatrixMultiplication>();
         getMPSProfiler().beginProfileKernel(kernel, "mps_linear", {input, weight, bias});
         [kernel encodeToCommandEncoder:computeEncoder


### PR DESCRIPTION
Fixes some memory leaks which were identified as part of the investigation of https://github.com/pytorch/pytorch/issues/154329. This doesn't appear to be the whole solution but wanted to merge this anyway since it's a quick fix

In my tests I see roughly 3MB of unexpected memory growth before this change, and after this change I see 2.2MB of memory growth