### PR TITLE
Fix in pytorch do_bench_using_profiling

### DIFF
--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -288,6 +288,7 @@ def do_bench_using_profiling(
     for _ in range(n_warmup):
         fn()
 
+    torch.cuda.synchronize()
     with torch.profiler.profile(
         activities=[
             torch.profiler.ProfilerActivity.CUDA,
@@ -300,7 +301,6 @@ def do_bench_using_profiling(
             # record time of `fn`
             fn()
         # Record clocks
-        torch.cuda.synchronize()
 
     log.debug("raw events")
     log.debug(p.key_averages().table(sort_by="self_device_time_total", row_limit=-1))


### PR DESCRIPTION
Summary:
Local testing with benchmark demonstrated a decrease in the error message frequency:

"Failed to divide all profiling events into #repeat groups. "
            "#CUDA events: %d, #repeats: %s"

However, this is not a comprehensive solution and does not solve the problem every time.

Test Plan: Please refer to the next diff.

Differential Revision: D75698662




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben