### PR TITLE
[ez][CI] Reuse old whl: remove old zip/whl

### DIFF
--- a/.github/actions/reuse-old-whl/reuse_old_whl.py
+++ b/.github/actions/reuse-old-whl/reuse_old_whl.py
@@ -190,6 +190,10 @@ def unzip_artifact_and_replace_files() -> None:
         subprocess.check_output(
             ["unzip", "-o", new_path, "-d", f"artifacts/dist/{new_path.stem}"],
         )
+
+        # Remove the old wheel (which is now a zip file)
+        os.remove(new_path)
+
         # Copy python files into the artifact
         subprocess.check_output(
             ["rsync", "-avz", "torch", f"artifacts/dist/{new_path.stem}"],


### PR DESCRIPTION
Forgot that unzip doesn't get rid of the zip so the old one is still there

Unrelated: figure out how to update the git version