### PR TITLE
[logs] Add autotuning data

### DIFF
--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2212,10 +2212,21 @@ class AlgorithmSelectorCache(PersistentCache):
 
         def autotune(choices):
             log.debug("Starting autotuning")
+
+            autotune_data = {
+                "shape": ", ".join(
+                    ["x".join(map(str, n.get_size())) for n in input_nodes]
+                ),
+                "strides": ", ".join([str(n.get_stride()) for n in input_nodes]),
+                "dtypes": ", ".join([str(n.get_dtype()) for n in input_nodes]),
+                "offset": ", ".join([str(n.get_layout().offset) for n in input_nodes]),
+            }
+
             with dynamo_timed(
                 f"{name}_template_autotuning",
                 log_pt2_compile_event=True,
                 dynamo_compile_column_us="compile_time_autotune_time_us",
+                metadata={"autotune_data": autotune_data},
             ):
                 return make_benchmark_fn()(choices)
 


### PR DESCRIPTION
Summary: Add autotuning logging data to scuba/chrome trace.

Test Plan:
```
TORCHINDUCTOR_MAX_AUTOTUNE=1 tlp buck run //scripts/sashko:compilation_sample
```

Open https://interncache-all.fbcdn.net/manifold/perfetto-artifacts/tree/ui/index.html#!/viewer?local_cache_key=00000000-0000-0000-92db-f23383ebf5b5, search for template_autotuning, see in metadata strides (see screenshot)

Differential Revision: D75457770




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov