### PR TITLE
Fix typo in vec256 interleave2

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256.h
@@ -205,7 +205,7 @@ std::pair<Vectorized<double>, Vectorized<double>> inline interleave2<double>(
     const Vectorized<double>& a,
     const Vectorized<double>& b) {
   // inputs:
-  //   a = {a0, a1, a3, a3}
+  //   a = {a0, a1, a2, a3}
   //   b = {b0, b1, b2, b3}
 
   // swap lanes:


### PR DESCRIPTION
Fix a typo where the elements in a vector are mislabeled

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168