### PR TITLE
Add note about using latest clangd for IDE support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -723,6 +723,8 @@ C++ code. You need to `pip install ninja` to generate accurate
 information for the code in `torch/csrc`. More information at:
 - https://sarcasm.github.io/notes/dev/compilation-database.html
 
+If you are using `clangd`, it's recommended to install the latest release from: https://github.com/clangd/clangd/releases/latest. Older system versions may cause crashes or issues parsing `.clang-format` (e.g., unknown keys like `Macros`).
+
 ### Make no-op build fast
 
 #### Use Ninja


### PR DESCRIPTION
While setting up `clangd` for PyTorch C++ development, I ran into repeated crashes due to the .clang-format file. The error was:
```
error: unknown key 'Macros'
```

It turned out the clangd installed through official docs : 
`brew install llvm` 
was outdated. After switching to the latest release from [clangd's GitHub](https://github.com/clangd/clangd/releases/latest), the issue was resolved.

This small addition to the docs can save time for new contributors by pointing them directly to a working setup.