### PR TITLE
[BE][Ez] Update deprecated pybind11 functions

### DIFF
--- a/torch/csrc/distributed/c10d/python_comm_hook.cpp
+++ b/torch/csrc/distributed/c10d/python_comm_hook.cpp
@@ -28,7 +28,7 @@ c10::intrusive_ptr<c10::ivalue::Future> PythonCommHook::runHook(
   try {
     return py_fut.cast<std::shared_ptr<torch::jit::PythonFutureWrapper>>()->fut;
   } catch (const py::cast_error& e) {
-    auto type = py::type::of(py_fut);
+    auto type = py::type::handle_of(py_fut);
     auto errMsg = c10::str(
         e.what(),
         ". DDP communication hook's callback must return a "

--- a/torch/csrc/distributed/c10d/python_comm_hook.cpp
+++ b/torch/csrc/distributed/c10d/python_comm_hook.cpp
@@ -28,7 +28,7 @@ c10::intrusive_ptr<c10::ivalue::Future> PythonCommHook::runHook(
   try {
     return py_fut.cast<std::shared_ptr<torch::jit::PythonFutureWrapper>>()->fut;
   } catch (const py::cast_error& e) {
-    auto type = py_fut.get_type();
+    auto type = py::type::of(py_fut);
     auto errMsg = c10::str(
         e.what(),
         ". DDP communication hook's callback must return a "

--- a/torch/csrc/distributed/rpc/py_rref.cpp
+++ b/torch/csrc/distributed/rpc/py_rref.cpp
@@ -87,11 +87,12 @@ TypePtr tryInferTypeWithTypeHint(
   // because it will try to script the class that value is in instance of, and
   // this should be avoided.
   py::bool_ can_compile = py::module::import("torch._jit_internal")
-                              .attr("can_compile_class")(value.get_type());
+                              .attr("can_compile_class")(py::type::of(value));
 
   if (py::cast<bool>(can_compile)) {
-    py::object existing_ty = py::module::import("torch.jit._state")
-                                 .attr("_get_script_class")(value.get_type());
+    py::object existing_ty =
+        py::module::import("torch.jit._state")
+            .attr("_get_script_class")(py::type::of(value));
 
     if (existing_ty.is_none()) {
       return PyObjectType::get();

--- a/torch/csrc/distributed/rpc/py_rref.cpp
+++ b/torch/csrc/distributed/rpc/py_rref.cpp
@@ -86,13 +86,14 @@ TypePtr tryInferTypeWithTypeHint(
   // Check if value is an instance of a ScriptClass. If not, skip type inference
   // because it will try to script the class that value is in instance of, and
   // this should be avoided.
-  py::bool_ can_compile = py::module::import("torch._jit_internal")
-                              .attr("can_compile_class")(py::type::of(value));
+  py::bool_ can_compile =
+      py::module::import("torch._jit_internal")
+          .attr("can_compile_class")(py::type::handle_of(value));
 
   if (py::cast<bool>(can_compile)) {
     py::object existing_ty =
         py::module::import("torch.jit._state")
-            .attr("_get_script_class")(py::type::of(value));
+            .attr("_get_script_class")(py::type::handle_of(value));
 
     if (existing_ty.is_none()) {
       return PyObjectType::get();

--- a/torch/csrc/distributed/rpc/python_rpc_handler.cpp
+++ b/torch/csrc/distributed/rpc/python_rpc_handler.cpp
@@ -14,7 +14,7 @@ constexpr auto kInternalModule = "torch.distributed.rpc.internal";
 #define PROFILE_GIL_SCOPED_ACQUIRE                                       \
   std::chrono::time_point<std::chrono::high_resolution_clock> startTime; \
   auto shouldProfileGIL =                                                \
-      RpcAgent::getCurrentRpcAgent()->isGILProfilingEnabled();           \
+      RpcAgent::getCurrentRpcAgent() -> isGILProfilingEnabled();         \
   if (shouldProfileGIL) {                                                \
     startTime = std::chrono::high_resolution_clock::now();               \
   }                                                                      \
@@ -174,7 +174,7 @@ void PythonRpcHandler::handleExceptionGILHeld(const py::object& obj) {
 
 bool PythonRpcHandler::isRemoteException(const py::object& obj) {
   PROFILE_GIL_SCOPED_ACQUIRE;
-  auto type = obj.get_type();
+  auto type = py::type::of(obj);
   auto moduleName = type.attr("__module__").cast<std::string>();
   auto qualName = type.attr("__qualname__").cast<std::string>();
   return moduleName == kInternalModule && qualName == "RemoteException";

--- a/torch/csrc/distributed/rpc/python_rpc_handler.cpp
+++ b/torch/csrc/distributed/rpc/python_rpc_handler.cpp
@@ -14,7 +14,7 @@ constexpr auto kInternalModule = "torch.distributed.rpc.internal";
 #define PROFILE_GIL_SCOPED_ACQUIRE                                       \
   std::chrono::time_point<std::chrono::high_resolution_clock> startTime; \
   auto shouldProfileGIL =                                                \
-      RpcAgent::getCurrentRpcAgent() -> isGILProfilingEnabled();         \
+      RpcAgent::getCurrentRpcAgent()->isGILProfilingEnabled();         \
   if (shouldProfileGIL) {                                                \
     startTime = std::chrono::high_resolution_clock::now();               \
   }                                                                      \

--- a/torch/csrc/distributed/rpc/python_rpc_handler.cpp
+++ b/torch/csrc/distributed/rpc/python_rpc_handler.cpp
@@ -14,7 +14,7 @@ constexpr auto kInternalModule = "torch.distributed.rpc.internal";
 #define PROFILE_GIL_SCOPED_ACQUIRE                                       \
   std::chrono::time_point<std::chrono::high_resolution_clock> startTime; \
   auto shouldProfileGIL =                                                \
-      RpcAgent::getCurrentRpcAgent()->isGILProfilingEnabled();         \
+      RpcAgent::getCurrentRpcAgent()->isGILProfilingEnabled();           \
   if (shouldProfileGIL) {                                                \
     startTime = std::chrono::high_resolution_clock::now();               \
   }                                                                      \

--- a/torch/csrc/distributed/rpc/python_rpc_handler.cpp
+++ b/torch/csrc/distributed/rpc/python_rpc_handler.cpp
@@ -174,7 +174,7 @@ void PythonRpcHandler::handleExceptionGILHeld(const py::object& obj) {
 
 bool PythonRpcHandler::isRemoteException(const py::object& obj) {
   PROFILE_GIL_SCOPED_ACQUIRE;
-  auto type = py::type::of(obj);
+  auto type = py::type::handle_of(obj);
   auto moduleName = type.attr("__module__").cast<std::string>();
   auto qualName = type.attr("__qualname__").cast<std::string>();
   return moduleName == kInternalModule && qualName == "RemoteException";

--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -134,7 +134,7 @@ c10::intrusive_ptr<JitFuture> RequestCallbackImpl::runPythonFunction(
   try {
     return result.cast<jit::PythonFutureWrapper&>().fut;
   } catch (const py::cast_error& e) {
-    auto type = py::type::of(result);
+    auto type = py::type::handle_of(result);
     auto errMsg = c10::str(
         e.what(),
         ". Functions decorated with @rpc.async_function must return a "

--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -134,7 +134,7 @@ c10::intrusive_ptr<JitFuture> RequestCallbackImpl::runPythonFunction(
   try {
     return result.cast<jit::PythonFutureWrapper&>().fut;
   } catch (const py::cast_error& e) {
-    auto type = result.get_type();
+    auto type = py::type::of(result);
     auto errMsg = c10::str(
         e.what(),
         ". Functions decorated with @rpc.async_function must return a "

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -448,7 +448,8 @@ void NodeToONNX(
       std::ostringstream ss;
       ss << "Error casting results of symbolic for " << op_name
          << ": expected to return list of op nodes, instead received type ''"
-         << py::str(py::type::of(raw_output)) << "': " << py::str(raw_output);
+         << py::str(py::type::handle_of(raw_output))
+         << "': " << py::str(raw_output);
       throw std::runtime_error(ss.str());
     }
 

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -448,7 +448,7 @@ void NodeToONNX(
       std::ostringstream ss;
       ss << "Error casting results of symbolic for " << op_name
          << ": expected to return list of op nodes, instead received type ''"
-         << py::str(raw_output.get_type()) << "': " << py::str(raw_output);
+         << py::str(py::type::of(raw_output)) << "': " << py::str(raw_output);
       throw std::runtime_error(ss.str());
     }
 

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -470,7 +470,7 @@ IValue toIValue(py::handle obj, const TypePtr& type, std::optional<int32_t> N) {
         // and then create a ivalue::Object from that class type.
         py::str qualified_name =
             py::module::import("torch._jit_internal")
-                .attr("_qualified_name")(py::type::of(obj));
+                .attr("_qualified_name")(py::type::handle_of(obj));
         auto pyCu = get_python_cu();
         classType = pyCu->get_class(c10::QualifiedName(qualified_name));
         if (!classType) {

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -468,8 +468,9 @@ IValue toIValue(py::handle obj, const TypePtr& type, std::optional<int32_t> N) {
       } else {
         // We inspect the value to found the compiled TorchScript class
         // and then create a ivalue::Object from that class type.
-        py::str qualified_name = py::module::import("torch._jit_internal")
-                                     .attr("_qualified_name")(obj.get_type());
+        py::str qualified_name =
+            py::module::import("torch._jit_internal")
+                .attr("_qualified_name")(py::type::of(obj));
         auto pyCu = get_python_cu();
         classType = pyCu->get_class(c10::QualifiedName(qualified_name));
         if (!classType) {

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -433,20 +433,22 @@ inline InferredType tryToInferType(py::handle input) {
   }
 
   py::bool_ isClass =
-      py::module::import("inspect").attr("isclass")(input.get_type());
+      py::module::import("inspect").attr("isclass")(py::type::of(input));
   if (py::cast<bool>(isClass)) {
     // Assume that the class is compiled already or will compile. Invalidate
     // this later if needed.
     bool class_compiled = true;
 
     // Check if the type is already compiled.
-    py::object existing_ty = py::module::import("torch.jit._state")
-                                 .attr("_get_script_class")(input.get_type());
+    py::object existing_ty =
+        py::module::import("torch.jit._state")
+            .attr("_get_script_class")(py::type::of(input));
 
     if (existing_ty.is_none()) {
       // If not, try to compile it.
-      py::bool_ can_compile = py::module::import("torch._jit_internal")
-                                  .attr("can_compile_class")(input.get_type());
+      py::bool_ can_compile =
+          py::module::import("torch._jit_internal")
+              .attr("can_compile_class")(py::type::of(input));
 
       if (py::cast<bool>(can_compile)) {
         // Try to compile the class. This is wrapped in a try-catch because
@@ -456,7 +458,7 @@ inline InferredType tryToInferType(py::handle input) {
         try {
           py::module::import("torch.jit._script")
               .attr("_recursive_compile_class")(
-                  input.get_type(), SourceRange());
+                  py::type::of(input), SourceRange());
         } catch (...) {
           // Invalidate the assumption that the class compiled so that we don't
           // look up and return its JIT type as the type for the input.
@@ -469,7 +471,7 @@ inline InferredType tryToInferType(py::handle input) {
     // qualified name and return it.
     if (class_compiled) {
       auto script_class = py::module::import("torch.jit._state")
-                              .attr("_get_script_class")(input.get_type());
+                              .attr("_get_script_class")(py::type::of(input));
 
       if (!script_class.is_none()) {
         auto class_type = py::cast<ClassTypePtr>(script_class);
@@ -642,7 +644,7 @@ inline InferredType tryToInferContainerType(
           "are supported ",
           "as inputs or outputs of traced functions",
           ", but instead got value of type ",
-          py::str(input.get_type().attr("__name__")),
+          py::str(py::type::of(input).attr("__name__")),
           "."));
     } else {
       // TODO: this message is not correct anymore, since this InferredType is
@@ -653,7 +655,7 @@ inline InferredType tryToInferContainerType(
           "are supported ",
           "as inputs or outputs of traced functions",
           ", but instead got value of type ",
-          py::str(input.get_type().attr("__name__")),
+          py::str(py::type::of(input).attr("__name__")),
           "."));
     }
   }
@@ -780,7 +782,7 @@ inline std::string friendlyTypeName(py::handle obj) {
     auto field_names =
         py::cast<std::vector<std::string>>(py::getattr(obj, "_fields"));
     std::stringstream ss;
-    ss << py::str(obj.get_type().attr("__name__"));
+    ss << py::str(py::type::of(obj).attr("__name__"));
     ss << " (aka NamedTuple(";
     bool first = true;
     for (auto& field_name : field_names) {
@@ -793,7 +795,7 @@ inline std::string friendlyTypeName(py::handle obj) {
     ss << "))";
     return ss.str();
   } else {
-    return py::str(obj.get_type().attr("__name__"));
+    return py::str(py::type::of(obj).attr("__name__"));
   }
 }
 
@@ -841,7 +843,7 @@ inline IValue returnToIValue(const TypePtr& type, py::handle object) {
         " expected value of type ",
         type->str(),
         " for return value but instead got value of type ",
-        py::str(object.get_type().attr("__name__")),
+        py::str(py::type::of(object).attr("__name__")),
         ".",
         "\nValue: ",
         py::repr(object),

--- a/torch/csrc/jit/python/python_sugared_value.cpp
+++ b/torch/csrc/jit/python/python_sugared_value.cpp
@@ -21,7 +21,7 @@
 namespace torch::jit {
 
 std::string typeString(py::handle h) {
-  return py::str(h.get_type().attr("__name__"));
+  return py::str(py::type::of(h).attr("__name__"));
 }
 
 std::optional<StrongFunctionPtr> as_function(const py::object& obj) {

--- a/torch/csrc/jit/python/python_sugared_value.cpp
+++ b/torch/csrc/jit/python/python_sugared_value.cpp
@@ -21,7 +21,7 @@
 namespace torch::jit {
 
 std::string typeString(py::handle h) {
-  return py::str(py::type::of(h).attr("__name__"));
+  return py::str(py::type::handle_of(h).attr("__name__"));
 }
 
 std::optional<StrongFunctionPtr> as_function(const py::object& obj) {

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -272,7 +272,7 @@ static void checkMutableFunctionDefault(
         << "Mutable default parameters are not supported because Python binds them to the function"
         << " and they persist across function calls.\n As a workaround, make the default None and instantiate"
         << " the default parameter within the body of the function. Found "
-        << def_arg.get_type() << " on parameter " << arg.name());
+        << py::type::of(def_arg) << " on parameter " << arg.name());
   }
 }
 

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -272,7 +272,7 @@ static void checkMutableFunctionDefault(
         << "Mutable default parameters are not supported because Python binds them to the function"
         << " and they persist across function calls.\n As a workaround, make the default None and instantiate"
         << " the default parameter within the body of the function. Found "
-        << py::type::of(def_arg) << " on parameter " << arg.name());
+        << py::type::handle_of(def_arg) << " on parameter " << arg.name());
   }
 }
 

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -299,7 +299,7 @@ static py::object maybe_get_registered_torch_dispatch_rule(
 #endif
   auto result = find_torch_dispatch_rule(
       py::reinterpret_borrow<py::object>(torch_api_function),
-      py::type::of(torch_dispatch_object));
+      py::type::handle_of(torch_dispatch_object));
   return result;
 }
 
@@ -350,7 +350,7 @@ static py::object dispatch_on_subclass(
         auto py_arg = py::reinterpret_borrow<py::object>(arg);
         ret = py::reinterpret_steal<py::object>(PyObject_CallFunctionObjArgs(
             torch_function.ptr(),
-            py::type::of(py_arg).ptr(),
+            py::type::handle_of(py_arg).ptr(),
             torch_api_function,
             py_types.ptr(),
             args,

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -299,7 +299,7 @@ static py::object maybe_get_registered_torch_dispatch_rule(
 #endif
   auto result = find_torch_dispatch_rule(
       py::reinterpret_borrow<py::object>(torch_api_function),
-      torch_dispatch_object.get_type());
+      py::type::of(torch_dispatch_object));
   return result;
 }
 
@@ -350,7 +350,7 @@ static py::object dispatch_on_subclass(
         auto py_arg = py::reinterpret_borrow<py::object>(arg);
         ret = py::reinterpret_steal<py::object>(PyObject_CallFunctionObjArgs(
             torch_function.ptr(),
-            py_arg.get_type().ptr(),
+            py::type::of(py_arg).ptr(),
             torch_api_function,
             py_types.ptr(),
             args,

--- a/torch/csrc/utils/six.h
+++ b/torch/csrc/utils/six.h
@@ -13,7 +13,7 @@ namespace six {
 // by a pytorch operator.
 
 inline bool isStructSeq(pybind11::handle input) {
-  return pybind11::cast<std::string>(pybind11::type::of(input).attr(
+  return pybind11::cast<std::string>(pybind11::type::handle_of(input).attr(
              "__module__")) == "torch.return_types";
 }
 

--- a/torch/csrc/utils/six.h
+++ b/torch/csrc/utils/six.h
@@ -13,8 +13,8 @@ namespace six {
 // by a pytorch operator.
 
 inline bool isStructSeq(pybind11::handle input) {
-  return pybind11::cast<std::string>(pybind11::type::of(
-             input.attr("__module__"))) == "torch.return_types";
+  return pybind11::cast<std::string>(pybind11::type::of(input).attr(
+             "__module__")) == "torch.return_types";
 }
 
 inline bool isStructSeq(PyObject* obj) {

--- a/torch/csrc/utils/six.h
+++ b/torch/csrc/utils/six.h
@@ -13,8 +13,8 @@ namespace six {
 // by a pytorch operator.
 
 inline bool isStructSeq(pybind11::handle input) {
-  return pybind11::cast<std::string>(input.get_type().attr("__module__")) ==
-      "torch.return_types";
+  return pybind11::cast<std::string>(pybind11::type::of(
+             input.attr("__module__"))) == "torch.return_types";
 }
 
 inline bool isStructSeq(PyObject* obj) {


### PR DESCRIPTION
* getType() is deprecated, replace it with new/proper static method. These are backwards compatible with old pybind11 versions we support. So break this off before we upgrade to pybind11 3.0 where these methods are dropped in #154115

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @EikanWang @jgong5 @wenzhe-nrv @sanchitintel