### PR TITLE
[BE][Ez]: Update flatbuffers to 25.2.10

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -41,13 +41,11 @@ fbscribelogger==0.1.7
 #Pinned versions: 0.1.6
 #test that import:
 
-flatbuffers==2.0 ; platform_machine != "s390x"
+flatbuffers==25.2.10
+#Keep in sync with submodule
 #Description: cross platform serialization library
-#Pinned versions: 2.0
+#Pinned versions: 25.2.10
 #test that import:
-
-flatbuffers ; platform_machine == "s390x"
-#Description: cross platform serialization library; Newer version is required on s390x for new python version
 
 hypothesis==5.35.1
 # Pin hypothesis to avoid flakiness: https://github.com/pytorch/pytorch/issues/31136


### PR DESCRIPTION
I was surprised to learn recently that flatbuffers are forward and backwards compatible (unlike protobuf). This means we can and should probably update our flatbuffers. This also simplifies our dependencies a bit.

* https://github.com/google/flatbuffers/blob/master/CHANGELOG.md Only points out changes in the advanced API (which we don't use anyway), so I don't see any breaking changes that should block us from updating.
* Only actual breaking change might be the BAZEL 7 upgrade, let's see how old the CI Bazel is