### PR TITLE
Vary batch size when running dynamic shapes benchmarks

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import random
 import argparse
 import collections
 import contextlib
@@ -15,6 +14,7 @@ import itertools
 import json
 import logging
 import os
+import random
 import shutil
 import signal
 import subprocess

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -726,7 +726,7 @@ def timed(
     # Dont collect outputs to correctly measure timing
     for _ in range(times):
         if batch_size:
-            new_batch_size = torch.randint(1, 1025, ()).item()
+            new_batch_size = torch.randint(1, 33, ()).item()
             example_inputs = tree_map_only(
                 torch.Tensor, lambda x: vary_batch(x, new_batch_size), example_inputs
             )

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -689,17 +689,47 @@ def timed(
     times=1,
     return_result=False,
     collect_outputs=False,
+    batch_size=None,
 ):
     use_xla = tensor_is_on_xla(example_inputs)
     synchronize()
+
+    if batch_size:
+        patch_torch_manual_seed()
 
     if use_xla:
         xm.mark_step()
         xm.wait_device_ops()
 
+    def vary_batch(t: torch.Tensor, new_batch_size) -> torch.Tensor:
+        for i, s in enumerate(t.size()):
+            if s == batch_size:
+                # If new batch is smaller, we truncate
+                if new_batch_size < batch_size:
+                    indexer = [slice(None)] * t.ndim
+                    indexer[i] = slice(0, new_batch_size)
+                    t = t[tuple(indexer)]
+                # If new batch is greater, we just duplicate the last row
+                # over and over until we hit the desired batch size
+                elif new_batch_size > batch_size:
+                    indexer = [slice(None)] * t.ndim
+                    indexer[i] = -1
+                    last_slice = t[tuple(indexer)].unsqueeze(i)
+                    repeat_shape = list(t.shape)
+                    repeat_shape[i] = new_batch_size - batch_size
+                    padding = last_slice.expand(*repeat_shape)
+                    t = torch.cat([t, padding], dim=i)
+                break
+        return t
+
     time_total = 0
     # Dont collect outputs to correctly measure timing
     for _ in range(times):
+        if batch_size:
+            new_batch_size = torch.randint(1, 1025, ()).item()
+            example_inputs = tree_map_only(
+                torch.Tensor, lambda x: vary_batch(x, new_batch_size), example_inputs
+            )
         # Put this call inside the loop to reset the seed for each iteration.
         # Don't include reset_rng_state() to correctly measure timing
         reset_rng_state(use_xla)
@@ -1070,6 +1100,7 @@ def speedup_experiment(args, model_iter_fn, model, example_inputs, **kwargs):
                     return_result=True,
                     times=times,
                     collect_outputs=args.collect_outputs,
+                    batch_size=kwargs.get("batch_size"),
                 )
 
             # call mark_step between the 2 calls to make the comparison fair.
@@ -2477,7 +2508,14 @@ class BenchmarkRunner:
             return " ".join(map(str, results))
 
     def run_performance_test(
-        self, name, model, example_inputs, optimize_ctx, experiment, tag=None
+        self,
+        name,
+        model,
+        example_inputs,
+        optimize_ctx,
+        experiment,
+        tag=None,
+        batch_size=None,
     ):
         if self.args.xla:
             with self.pick_grad(name, self.args.training):
@@ -2535,6 +2573,7 @@ class BenchmarkRunner:
         with self.pick_grad(name, self.args.training), ctx:
             ok, total = Stats.reset_counters()
             experiment_kwargs = {}
+            experiment_kwargs["batch_size"] = batch_size
             if tag is not None:
                 experiment_kwargs["tag"] = tag
             results = []
@@ -2698,6 +2737,7 @@ class BenchmarkRunner:
         experiment,
         explain=False,
         tag=None,
+        batch_size=None,
     ):
         mode = "train" if self.args.training else "eval"
         msg = f"{current_device:4} {mode:5} {current_name:34} "
@@ -2726,7 +2766,13 @@ class BenchmarkRunner:
                 )
             else:
                 status = self.run_performance_test(
-                    name, model, example_inputs, optimize_ctx, experiment, tag
+                    name,
+                    model,
+                    example_inputs,
+                    optimize_ctx,
+                    experiment,
+                    tag,
+                    batch_size=batch_size,
                 )
             print(status)
         empty_gpu_cache(current_device)
@@ -4048,6 +4094,7 @@ def run(runner, args, original_dir=None):
                         experiment,
                         explain=args.explain,
                         tag=args.tag,
+                        batch_size=batch_size if args.dynamic_batch_only else None,
                     )
         if args.generate_aot_autograd_stats:
             stats_file = output_filename.split(".csv")[0] + "_stats.csv"

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -728,7 +728,7 @@ def timed(
     for _ in range(times):
         if batch_size:
             # Calculate new batch size by varying the original batch size by up to 20%
-            # Ensure it's at least greater than or equal to 1
+            # Ensure it's at least greater than 1
             variation = random.uniform(0.8, 1.2)
             new_batch_size = max(2, int(batch_size * variation))
             example_inputs = tree_map_only(

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import random
 import argparse
 import collections
 import contextlib
@@ -726,7 +727,10 @@ def timed(
     # Dont collect outputs to correctly measure timing
     for _ in range(times):
         if batch_size:
-            new_batch_size = torch.randint(1, 33, ()).item()
+            # Calculate new batch size by varying the original batch size by up to 20%
+            # Ensure it's at least greater than or equal to 1
+            variation = random.uniform(0.8, 1.2)
+            new_batch_size = max(2, int(batch_size * variation))
             example_inputs = tree_map_only(
                 torch.Tensor, lambda x: vary_batch(x, new_batch_size), example_inputs
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #154818
* __->__ #154805
* #154823
* #154822
* #154826

This better measures the actual runtime performance of dynamic shapes
where we aren't guaranteed to have similar shapes as the original hint.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames