### PR TITLE
add fixes for missing headers, setup.py for local build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -223,6 +223,7 @@
 
 import os
 import sys
+import site
 
 
 if sys.platform == "win32" and sys.maxsize.bit_length() == 31:
@@ -255,6 +256,7 @@ import subprocess
 import sysconfig
 import time
 from collections import defaultdict
+
 
 import setuptools.command.build_ext
 import setuptools.command.install
@@ -1131,6 +1133,17 @@ def print_box(msg):
 
 
 def main():
+   import site
+
+def main():
+    # Patch: Use ~/.local as install prefix if system site-packages is not writable
+    try:
+        site_packages = site.getsitepackages()[0]
+    except AttributeError:
+        site_packages = sysconfig.get_paths()["purelib"]
+    if not os.access(site_packages, os.W_OK):
+        sys.argv += ["--prefix=" + os.path.expanduser("~/.local")]
+        
     if BUILD_LIBTORCH_WHL and BUILD_PYTHON_ONLY:
         raise RuntimeError(
             "Conflict: 'BUILD_LIBTORCH_WHL' and 'BUILD_PYTHON_ONLY' can't both be 1. Set one to 0 and rerun."


### PR DESCRIPTION
Fixes https://discuss.pytorch.org/t/ninja-error-when-installing-pytorch/72810/11
The errors were :

Err 1 :
```
MF third_party/tensorpipe/tensorpipe/CMakeFiles/tensorpipe.dir/common/allocator.cc.o.d -o third_party/tensorpipe/tensorpipe/CMakeFiles/tensorpipe.dir/common/allocator.cc.o -c /home/sumantro/pytorch/third_party/tensorpipe/tensorpipe/common/allocator.cc

```
Err 2 :
```

home/sumantro/pytorch/third_party/tensorpipe/tensorpipe/common/memory.h:48:9: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/home/sumantro/pytorch/third_party/tensorpipe/tensorpipe/common/memory.h:70:19: error: ‘uint8_t’ was not declared in this scope
   70 |   std::unique_ptr<uint8_t[], Deleter> ptr_{nullptr, Deleter{}};
      |                   ^~~~~~~
```


Err3: 

```
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:66:11: error: ‘uint8_t’ does not name a type
   66 | constexpr uint8_t kGatherSlotPrefix = 0x01;
      |           ^~~~~~~
/home/sumantro/pytorch/third_party/gloo/gloo/types.h:31:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’


```
Err4:

```
running develop
/usr/lib/python3.13/site-packages/setuptools/command/develop.py:41: EasyInstallDeprecationWarning: easy_install command is deprecated.
!!

        ********************************************************************************
        Please avoid running `setup.py and easy_install.
        Instead, use pypa/build, pypa/installer or other
        standards-based tools.

        See https://github.com/pypa/setuptools/issues/917 for details.
        ********************************************************************************

!!
  easy_install.initialize_options(self)
/usr/lib/python3.13/site-packages/setuptools/_distutils/cmd.py:66: SetuptoolsDeprecationWarning: setup.py install is deprecated.
!!

        ********************************************************************************
        Please avoid running `setup.py directly.
        Instead, use pypa/build, pypa/installer or other
        standards-based tools.

        See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
        ********************************************************************************

!!
  self.initialize_options()
error: can't create or remove files in install directory

The following error occurred while trying to add or remove files in the
installation directory:

    [Errno 13] Permission denied: '/usr/local/lib64/python3.13'

The installation directory you specified (via --install-dir, --prefix, or
the distutils default setting) was:

    /usr/local/lib64/python3.13/site-packages/

This directory does not currently exist.  Please create it and try again, or
choose a different installation directory (using the -d or --install-dir
option).
```

I've tested the build works as expected in an conda on Fedora 42 on CPU. Following is the final output

python setup.py develop                                                                                                                    1 err  torch py  11:59:04 
Building wheel torch-2.8.0a0+git5616fa4
-- Building version 2.8.0a0+git5616fa4
-- Checkout nccl release tag: v2.26.5-1
cmake --build . --target install --config Release
[1/2] Install the project...
-- Install configuration: "Release"
running develop
/usr/lib/python3.13/site-packages/setuptools/command/develop.py:41: EasyInstallDeprecationWarning: easy_install command is deprecated.
!!

        ********************************************************************************
        Please avoid running ``setup.py`` and ``easy_install``.
        Instead, use pypa/build, pypa/installer or other
        standards-based tools.

        See https://github.com/pypa/setuptools/issues/917 for details.
        ********************************************************************************

!!
  easy_install.initialize_options(self)
/usr/lib/python3.13/site-packages/setuptools/_distutils/cmd.py:66: SetuptoolsDeprecationWarning: setup.py install is deprecated.
!!

        ********************************************************************************
        Please avoid running ``setup.py`` directly.
        Instead, use pypa/build, pypa/installer or other
        standards-based tools.

        See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
        ********************************************************************************

!!
  self.initialize_options()
running egg_info
writing torch.egg-info/PKG-INFO
writing dependency_links to torch.egg-info/dependency_links.txt
writing entry points to torch.egg-info/entry_points.txt
writing requirements to torch.egg-info/requires.txt
writing top-level names to torch.egg-info/top_level.txt
reading manifest file 'torch.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no files found matching '*.*' under directory 'ios'
warning: no files found matching '*.*' under directory 'modules'
warning: no previously-included files matching '*.o' found anywhere in distribution
warning: no previously-included files matching '*.dylib' found anywhere in distribution
warning: no previously-included files matching '*.swp' found anywhere in distribution
adding license file 'LICENSE'
adding license file 'NOTICE'
writing manifest file 'torch.egg-info/SOURCES.txt'
running build_ext
-- Building with NumPy bindings
-- Not using cuDNN
-- Not using CUDA
-- Not using XPU
-- Using MKLDNN
-- Not using Compute Library for the Arm architecture with MKLDNN
-- Not using CBLAS in MKLDNN
-- Not using NCCL
-- Building with distributed package: 
  -- USE_TENSORPIPE=True
  -- USE_GLOO=True
  -- USE_MPI=False
-- Building Executorch
-- Using ITT
Copying functorch._C from functorch/functorch.so to /home/sumantro/pytorch/build/lib.linux-x86_64-cpython-313/functorch/_C.cpython-313-x86_64-linux-gnu.so
copying functorch/functorch.so -> /home/sumantro/pytorch/build/lib.linux-x86_64-cpython-313/functorch/_C.cpython-313-x86_64-linux-gnu.so
building 'torch._C' extension
creating build/temp.linux-x86_64-cpython-313
creating build/temp.linux-x86_64-cpython-313/torch
creating build/temp.linux-x86_64-cpython-313/torch/csrc
gcc -fno-strict-overflow -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -fexceptions -fcf-protection -fexceptions -fcf-protection -fexceptions -fcf-protection -O3 -fPIC -I/usr/include/python3.13 -c torch/csrc/stub.c -o build/temp.linux-x86_64-cpython-313/torch/csrc/stub.o -Wall -Wextra -Wno-strict-overflow -Wno-unused-parameter -Wno-missing-field-initializers -Wno-unknown-pragmas -fno-strict-aliasing
creating build/lib.linux-x86_64-cpython-313/torch
gcc -shared build/temp.linux-x86_64-cpython-313/torch/csrc/stub.o -L/home/sumantro/pytorch/torch/lib -L/usr/lib64 -ltorch_python -o build/lib.linux-x86_64-cpython-313/torch/_C.cpython-313-x86_64-linux-gnu.so -Wl,-rpath,$ORIGIN/lib
copying build/lib.linux-x86_64-cpython-313/torch/_C.cpython-313-x86_64-linux-gnu.so -> torch
Creating /home/sumantro/.local/lib/python3.13/site-packages/torch.egg-link (link to .)
Adding torch 2.8.0a0+git5616fa4 to easy-install.pth file
Installing torchfrtrace script to /home/sumantro/.local/bin
Installing torchrun script to /home/sumantro/.local/bin

Installed /home/sumantro/pytorch
Processing dependencies for torch==2.8.0a0+git5616fa4
Searching for setuptools==74.1.3
Best match: setuptools 74.1.3
Adding setuptools 74.1.3 to easy-install.pth file

Using /usr/lib/python3.13/site-packages
Searching for fsspec==2024.6.1
Best match: fsspec 2024.6.1
Adding fsspec 2024.6.1 to easy-install.pth file

Using /home/sumantro/.local/lib/python3.13/site-packages
Searching for jinja2==3.1.6
Best match: jinja2 3.1.6
Adding jinja2 3.1.6 to easy-install.pth file

Using /usr/lib/python3.13/site-packages
Searching for networkx==3.3
Best match: networkx 3.3
Adding networkx 3.3 to easy-install.pth file

Using /home/sumantro/.local/lib/python3.13/site-packages
Searching for sympy==1.14.0
Best match: sympy 1.14.0
Adding sympy 1.14.0 to easy-install.pth file
Installing isympy script to /home/sumantro/.local/bin

Using /home/sumantro/.local/lib/python3.13/site-packages
Searching for typing-extensions==4.12.2
Best match: typing-extensions 4.12.2
Adding typing-extensions 4.12.2 to easy-install.pth file

Using /usr/lib/python3.13/site-packages/setuptools/_vendor
Searching for filelock==3.15.4
Best match: filelock 3.15.4
Adding filelock 3.15.4 to easy-install.pth file

Using /usr/lib/python3.13/site-packages
Searching for MarkupSafe==3.0.2
Best match: MarkupSafe 3.0.2
Adding MarkupSafe 3.0.2 to easy-install.pth file

Using /usr/lib64/python3.13/site-packages
Searching for mpmath==1.3.0
Best match: mpmath 1.3.0
Adding mpmath 1.3.0 to easy-install.pth file

Using /home/sumantro/.local/lib/python3.13/site-packages
Finished processing dependencies for torch==2.8.0a0+git5616fa4