### PR TITLE
Fix typo in dcp module

### DIFF
--- a/torch/distributed/checkpoint/storage.py
+++ b/torch/distributed/checkpoint/storage.py
@@ -147,7 +147,7 @@ class StorageWriter(abc.ABC):
     @abc.abstractmethod
     def validate_checkpoint_id(cls, checkpoint_id: Union[str, os.PathLike]) -> bool:
         """
-        Check if the given checkpoint_id is supported by the stroage. This allow
+        Check if the given checkpoint_id is supported by the storage. This allow
         us to enable automatic storage selection.
         """
         ...


### PR DESCRIPTION
Fixed the  docstring in `validate_checkpoint_id`


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k