### PR TITLE
Preserve Enum types during torch.export serialization and deserialization

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -12,7 +12,6 @@ import unittest
 import warnings
 from contextlib import contextmanager
 from dataclasses import dataclass
-from enum import auto, Enum
 from re import escape
 from typing import Dict, List, Union
 from unittest.mock import MagicMock, patch
@@ -201,11 +200,6 @@ class Inp2:
 class Inp3:
     f: torch.Tensor
     p: torch.Tensor
-
-
-class TestEnumColor(Enum):
-    RED = auto()
-    GREEN = auto()
 
 
 NON_STRICT_SUFFIX = "_nonstrict"
@@ -14473,37 +14467,6 @@ def forward(self, args_0):
     abs_1 = torch.ops.aten.abs.default(args_0);  args_0 = None
     return (abs_1,)""",
         )
-
-    def test_enum_serialization_round_trip(self):
-        import json
-        import os
-
-        import torch
-
-        # Define a model that accepts a dict with Enum as key
-        class M(torch.nn.Module):
-            def forward(self, x):
-                return x[TestEnumColor.RED] + 1
-
-        # Export the model with the Enum input
-        model = M()
-        ep = torch.export.export(model, ({TestEnumColor.RED: torch.tensor(5)},))
-
-        # Save and load
-        file_name = "tmp_enum.pt"
-        torch.export.save(ep, file_name)
-        ep2 = torch.export.load(file_name)
-
-        # Ensure that the Enum type is preserved in in_spec
-        self.assertEqual(
-            ep.module()._in_spec,
-            ep2.module()._in_spec,
-            "Enum type not preserved after save/load round-trip",
-        )
-
-        # Cleanup the temporary file
-        if os.path.exists(file_name):
-            os.remove(file_name)
 
 
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -12,6 +12,7 @@ import unittest
 import warnings
 from contextlib import contextmanager
 from dataclasses import dataclass
+from enum import auto, Enum
 from re import escape
 from typing import Dict, List, Union
 from unittest.mock import MagicMock, patch
@@ -200,6 +201,11 @@ class Inp2:
 class Inp3:
     f: torch.Tensor
     p: torch.Tensor
+
+
+class TestEnumColor(Enum):
+    RED = auto()
+    GREEN = auto()
 
 
 NON_STRICT_SUFFIX = "_nonstrict"
@@ -14467,6 +14473,37 @@ def forward(self, args_0):
     abs_1 = torch.ops.aten.abs.default(args_0);  args_0 = None
     return (abs_1,)""",
         )
+
+    def test_enum_serialization_round_trip(self):
+        import json
+        import os
+
+        import torch
+
+        # Define a model that accepts a dict with Enum as key
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return x[TestEnumColor.RED] + 1
+
+        # Export the model with the Enum input
+        model = M()
+        ep = torch.export.export(model, ({TestEnumColor.RED: torch.tensor(5)},))
+
+        # Save and load
+        file_name = "tmp_enum.pt"
+        torch.export.save(ep, file_name)
+        ep2 = torch.export.load(file_name)
+
+        # Ensure that the Enum type is preserved in in_spec
+        self.assertEqual(
+            ep.module()._in_spec,
+            ep2.module()._in_spec,
+            "Enum type not preserved after save/load round-trip",
+        )
+
+        # Cleanup the temporary file
+        if os.path.exists(file_name):
+            os.remove(file_name)
 
 
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -1096,6 +1096,14 @@ if "optree" in sys.modules:
         serialized_spec = py_pytree.treespec_dumps(spec)
         self.assertIsInstance(serialized_spec, str)
 
+    def test_enum_treespec_roundtrip(self):
+        data = {TestEnum.A: 5}
+        spec = py_pytree.tree_structure(data)
+
+        serialized = py_pytree.treespec_dumps(spec)
+        deserialized_spec = py_pytree.treespec_loads(serialized)
+        self.assertEqual(spec, deserialized_spec)
+
     def test_pytree_serialize_namedtuple(self):
         Point1 = namedtuple("Point1", ["x", "y"])
         py_pytree._register_namedtuple(

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -859,6 +859,21 @@ class TestGenericPytree(TestCase):
                 self.assertFalse(pytree.is_namedtuple(cls))
                 self.assertFalse(pytree.is_namedtuple_class(cls))
 
+    @parametrize(
+        "pytree",
+        [
+            subtest(py_pytree, name="py"),
+            subtest(cxx_pytree, name="cxx"),
+        ],
+    )
+    def test_enum_treespec_roundtrip(self, pytree):
+        data = {TestEnum.A: 5}
+        spec = pytree.tree_structure(data)
+
+        serialized = pytree.treespec_dumps(spec)
+        deserialized_spec = pytree.treespec_loads(serialized)
+        self.assertEqual(spec, deserialized_spec)
+
 
 class TestPythonPytree(TestCase):
     def test_deprecated_register_pytree_node(self):
@@ -1095,14 +1110,6 @@ if "optree" in sys.modules:
 
         serialized_spec = py_pytree.treespec_dumps(spec)
         self.assertIsInstance(serialized_spec, str)
-
-    def test_enum_treespec_roundtrip(self):
-        data = {TestEnum.A: 5}
-        spec = py_pytree.tree_structure(data)
-
-        serialized = py_pytree.treespec_dumps(spec)
-        deserialized_spec = py_pytree.treespec_loads(serialized)
-        self.assertEqual(spec, deserialized_spec)
 
     def test_pytree_serialize_namedtuple(self):
         Point1 = namedtuple("Point1", ["x", "y"])

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -113,14 +113,14 @@ class KeyEntry(Protocol):
 
 
 class EnumEncoder(json.JSONEncoder):
-    def default(self, obj: object) -> object:
+    def default(self, obj: object) -> Union[str, dict[str, Any]]:
         if isinstance(obj, Enum):
             return {
                 "__enum__": True,
                 "fqn": f"{obj.__class__.__module__}:{obj.__class__.__qualname__}",
                 "name": obj.name,
             }
-        return super().default(obj)
+        return cast(str, super().default(obj))
 
 
 Context = Any
@@ -1840,7 +1840,7 @@ def _treespec_to_json(treespec: TreeSpec) -> _TreeSpecSchema:
     return _TreeSpecSchema(serialized_type_name, serialized_context, child_schemas)
 
 
-def enum_object_hook(obj: dict[str, Any]) -> Any:
+def enum_object_hook(obj: dict[str, Any]) -> Union[Enum, dict[str, Any]]:
     if "__enum__" in obj:
         modname, _, classname = obj["fqn"].partition(":")
         mod = importlib.import_module(modname)


### PR DESCRIPTION
Fixes #154674 

Addresses an issue where `torch.export` does not correctly preserve Python `Enum` types during the save/load round-trip. Previously, Enum inputs were serialized by value only, causing their type to be lost after deserialization.
