### PR TITLE
Fix DataLoader to Pass List to getitems When Using BatchSampler. Fixes Issue_#154810

### DIFF
--- a/torch/utils/data/_utils/fetch.py
+++ b/torch/utils/data/_utils/fetch.py
@@ -47,7 +47,10 @@ class _MapDatasetFetcher(_BaseDatasetFetcher):
     def fetch(self, possibly_batched_index):
         if self.auto_collation:
             if hasattr(self.dataset, "__getitems__") and self.dataset.__getitems__:
-                data = self.dataset.__getitems__(possibly_batched_index)
+                if not isinstance(possibly_batched_index, list):
+                    data = self.dataset.__getitems__([possibly_batched_index])
+                else:
+                    data = self.dataset.__getitems__(possibly_batched_index)
             else:
                 data = [self.dataset[idx] for idx in possibly_batched_index]
         else:


### PR DESCRIPTION
This PR fixes an issue where PyTorch's DataLoader did not always pass a list of indices to custom Datasets implementing __getitems__ when using a BatchSampler. Instead, a single integer could be passed, causing 2D tensor outputs to be incorrectly flattened in the collate function.

Root cause:
In MapDatasetFetcher.fetch, the type of indices (possibly_batched_index) was not checked before being passed to __getitems__. If the indices were not already a list, this led to unexpected results for batch-aware Datasets.

What’s fixed:

    Ensured that DataLoader always passes a list to __getitems__ if a list is expected, by wrapping possibly_batched_index as a list if needed.

Test coverage:

    Added TestDataLoaderBatchSamplerList.test_passes_list_to_getitems in test/test_dataloader.py to verify that, when using a BatchSampler, __getitems__ receives a list and returns correctly shaped batched tensors.

Fixes #154810