### PR TITLE
[TorchGen] Add explicit op level CPU fallback feature via env variables

### DIFF
--- a/aten/src/ATen/core/op_registration/op_registration.h
+++ b/aten/src/ATen/core/op_registration/op_registration.h
@@ -19,6 +19,10 @@
 
 namespace c10 {
 
+
+// Checks PYTORCH_CPU_FALLBACK_OPS if a given op should fallback to CPU.
+bool registerOp(const std::string& opName);
+
 namespace detail {
 // The first argument of the schema might be of type DispatchKeySet, in which case we remove it.
 // We do this because every argument in a function schema is expected to be convertable

--- a/torch/library.h
+++ b/torch/library.h
@@ -952,6 +952,18 @@ class TorchLibraryInit final {
 
 } // namespace detail
 
+// ATenFallbackControlImpl enables backends to explictly control CPU fallback for any op
+// via the PYTORCH_CPU_FALLBACK_OPS environment variable.
+template <typename TorchFuncType>
+void ATenFallbackControlImpl(
+    torch::Library& m,
+    const char* opName,
+    TorchFuncType funcPtr) {
+  if (at::registerOp(opName)) {
+    m.impl(opName, funcPtr);
+  }
+}
+
 } // namespace torch
 
 // NB: The EXACT NAMING of the initializer functions (e.g.,

--- a/torchgen/model.py
+++ b/torchgen/model.py
@@ -345,6 +345,14 @@ def is_xpu_dispatch_key(dk: DispatchKey) -> bool:
     }
 
 
+# Dispatch keys for op level fall back control. Including your backend here will enable users
+# explictly fallback ATen ops to CPU using the PYTORCH_CPU_FALLBACK_OPS env var without un-registering them.
+def is_cpu_fallback_dispatch_key(dk: DispatchKey) -> bool:
+    return dk in {
+        DispatchKey.MTIA,
+    }
+
+
 # Structured kernel generation is only supported for certain key types;
 # otherwise use old-style
 def is_structured_dispatch_key(dk: DispatchKey) -> bool:


### PR DESCRIPTION
Summary:
When implementing new backends, operator/kernel performance/numerical accuracy may regress due to a multitude of factors. In cases where forward fixes may take a few days, such cases require unregistering the op/or adding code to fall it back (all of which are tedious) to prevent blocking of other efforts. This PR introduces a feature where scripts/workflows can easily update fallbacks explicitly by simply setting the `PYTORCH_CPU_FALLBACK_OPS` environment variable, aiming to reduce overhead for teams implementing operations for their new backends.


This feature is **opt in only**, meaning to use this, you must add your backend's dispatch key to the `is_cpu_fallback_dispatch_key` function in model.py. As of now, the only backend using this feature is MTIA.

Differential Revision: D75705343




cc @egienvalue