### PR TITLE
[flex attention][triton pin] triton_helpers shim for TMA apis

### DIFF
--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -430,8 +430,8 @@ compute_flex_attention = r"""
         )
 
 
-        tl.extra.cuda.experimental_tensormap_fenceproxy_acquire(desc_q)
-        tl.extra.cuda.experimental_tensormap_fenceproxy_acquire(desc_k)
+        triton_helpers.tensormap_fenceproxy_acquire(desc_q)
+        triton_helpers.tensormap_fenceproxy_acquire(desc_k)
 
 
     # We support two cases for batch dimension. a) (ZKV == ZQ) where off_zkv = off_zq.

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -403,26 +403,29 @@ compute_flex_attention = r"""
         desc_v = workspace_base + TMA_SIZE
         desc_k = workspace_base + 2 * TMA_SIZE
 
-        triton.language.extra.cuda.experimental_device_tensormap_create2d(
+        triton_helpers.make_tensor_descriptor(
+            base_ptr=Q,
+            global_shape=[Q_LEN*HQ*ZQ, QK_HEAD_DIM],
+            strides=[QK_HEAD_DIM, 1],
+            block_shape=[BLOCK_M, QK_HEAD_DIM_ROUNDED],
             desc_ptr=desc_q,
-            global_address=Q,
-            load_size=[BLOCK_M, QK_HEAD_DIM_ROUNDED],
-            global_size=[Q_LEN*HQ*ZQ, QK_HEAD_DIM],
             element_ty=Q.dtype.element_ty,
         )
-        triton.language.extra.cuda.experimental_device_tensormap_create2d(
+        triton_helpers.make_tensor_descriptor(
+            base_ptr=V,
+            global_shape=[KV_LEN*ZKV*HQ, V_HEAD_DIM],
+            strides=[V_HEAD_DIM, 1],
+            block_shape=[BLOCK_N, V_HEAD_DIM_ROUNDED],
             desc_ptr=desc_v,
-            global_address=V,
-            load_size=[BLOCK_N, V_HEAD_DIM_ROUNDED],
-            global_size=[KV_LEN*ZKV*HQ, V_HEAD_DIM],
             element_ty=K.dtype.element_ty,
         )
 
-        triton.language.extra.cuda.experimental_device_tensormap_create2d(
+        triton_helpers.make_tensor_descriptor(
+            base_ptr=K,
+            global_shape=[KV_LEN*ZKV*HQ, QK_HEAD_DIM],
+            strides=[QK_HEAD_DIM, 1],
+            block_shape=[BLOCK_N, QK_HEAD_DIM_ROUNDED],
             desc_ptr=desc_k,
-            global_address=K,
-            load_size=[BLOCK_N, QK_HEAD_DIM_ROUNDED],
-            global_size=[KV_LEN*ZKV*HQ, QK_HEAD_DIM],
             element_ty=K.dtype.element_ty,
         )
 
@@ -484,7 +487,7 @@ compute_flex_attention = r"""
         )
 
     if USE_TMA:
-        q = tl._experimental_descriptor_load(  # load in row major
+        q = triton_helpers.load_tensor_descriptor(  # load in row major
             desc_q,
             [(q_start * BLOCK_M).to(tl.int32), 0],
             [BLOCK_M, QK_HEAD_DIM_ROUNDED],
@@ -710,7 +713,7 @@ def forward_block_mn(
     # -- load k --
     # NB reversed order to since K is transposed
     if USE_TMA:
-       k = tl._experimental_descriptor_load(  # load in row major
+       k = triton_helpers.load_tensor_descriptor(  # load in row major
                 desc_k,
                 [start_n.to(tl.int32) , kv_start],
                 [BLOCK_N, QK_HEAD_DIM_ROUNDED],
@@ -785,7 +788,7 @@ def forward_block_mn(
     # # -- scale and update acc --
     acc = acc * alpha[:, None]
     if USE_TMA:
-        v = tl._experimental_descriptor_load(  # load in row major
+        v = triton_helpers.load_tensor_descriptor(  # load in row major
                     desc_v,
                     [kv_start.to(tl.int32) + start_n.to(tl.int32),0],
                     [BLOCK_N, V_HEAD_DIM_ROUNDED],

--- a/torch/_inductor/runtime/triton_helpers.py
+++ b/torch/_inductor/runtime/triton_helpers.py
@@ -719,7 +719,7 @@ def if_mask(mask: Any, val, *, _builder: object = None) -> tl.constexpr:
     return val
 
 
-HAS_NEW_TMA_API = hasattr(triton.language, "make_tensor_descriptor")
+HAS_NEW_TMA_API = hasattr(tl, "make_tensor_descriptor")
 
 
 """

--- a/torch/_inductor/runtime/triton_helpers.py
+++ b/torch/_inductor/runtime/triton_helpers.py
@@ -717,3 +717,107 @@ def if_mask(mask: Any, val, *, _builder: object = None) -> tl.constexpr:
     if isinstance(mask, tl.constexpr) and mask.value is None:
         return tl.constexpr(None)
     return val
+
+
+HAS_NEW_TMA_API = hasattr(triton.language, "make_tensor_descriptor")
+
+
+"""
+Helper function that dispatches to either `tl.make_tensor_descriptor` or
+`triton.language.extra.cuda.experimental_device_tensormap_create2d` based on `HAS_NEW_TMA_API`.
+
+Parameters:
+- base_ptr: The base pointer to the tensor data (used as `base` or `global_address`)
+- shape: The shape of the tensor (used as `shape` or `global_size`)
+- strides: The strides of the tensor (only used with `make_tensor_descriptor`)
+- block_shape: The block shape (used as `block_shape` or `load_size`)
+- desc_ptr: The descriptor pointer (only used with `experimental_device_tensormap_create2d`)
+- element_ty: The element type (only used with `experimental_device_tensormap_create2d`)
+
+Returns:
+- The tensor descriptor or None depending on the API used
+"""
+if HAS_NEW_TMA_API:
+
+    @triton.jit
+    def make_tensor_descriptor(
+        base_ptr,
+        global_shape,
+        strides,
+        block_shape,
+        desc_ptr,
+        element_ty,
+    ):
+        return tl.make_tensor_descriptor(
+            base=base_ptr,
+            shape=global_shape,
+            strides=strides,
+            block_shape=block_shape,
+        )
+
+    @triton.jit
+    def load_tensor_descriptor(
+        desc,
+        offsets,
+        shape,
+        dtype,
+    ):
+        return tl.load_tensor_descriptor(desc, offsets)
+
+    @triton.jit
+    def store_tensor_descriptor(
+        desc,
+        value,
+        offsets,
+    ):
+        return tl.store_tensor_descriptor(desc, offsets, value)
+
+    @triton.jit
+    def tensormap_fenceproxy_acquire(
+        desc,
+    ):
+        pass
+
+else:
+
+    @triton.jit
+    def make_tensor_descriptor(
+        base_ptr,
+        global_shape,
+        strides,
+        block_shape,
+        desc_ptr,
+        element_ty,
+    ):
+        tl.extra.cuda.experimental_device_tensormap_create2d(
+            desc_ptr=desc_ptr,
+            global_address=base_ptr,
+            load_size=block_shape,
+            global_size=global_shape,
+            element_ty=element_ty,
+        )
+
+        return desc_ptr
+
+    @triton.jit
+    def load_tensor_descriptor(
+        desc,
+        offsets,
+        shape,
+        dtype,
+    ):
+        return tl._experimental_descriptor_load(desc, offsets, shape, dtype)
+
+    @triton.jit
+    def store_tensor_descriptor(
+        desc,
+        value,
+        offsets,
+    ):
+        return tl._experimental_descriptor_store(desc, value, offsets)
+
+    @triton.jit
+    def tensormap_fenceproxy_acquire(
+        desc,
+    ):
+        tl.extra.cuda.experimental_tensormap_fenceproxy_acquire(desc)

--- a/torch/utils/_triton.py
+++ b/torch/utils/_triton.py
@@ -48,11 +48,21 @@ def has_triton_tma_device():
             and torch.cuda.get_device_capability() >= (9, 0)
             and not torch.version.hip
         ):
+            # old API
             try:
                 from triton.language.extra.cuda import (  # noqa: F401
                     experimental_device_tensormap_create1d,
                     experimental_device_tensormap_create2d,
                 )
+
+                return True
+            except ImportError:
+                pass
+
+            # TODO: audit usage of this function to make sure this is the right thing to do
+            # new API
+            try:
+                from triton.languange import make_tensor_descriptor  # noqa: F401
 
                 return True
             except ImportError:

--- a/torch/utils/_triton.py
+++ b/torch/utils/_triton.py
@@ -59,10 +59,9 @@ def has_triton_tma_device():
             except ImportError:
                 pass
 
-            # TODO: audit usage of this function to make sure this is the right thing to do
             # new API
             try:
-                from triton.languange import make_tensor_descriptor  # noqa: F401
+                from triton.language import make_tensor_descriptor  # noqa: F401
 
                 return True
             except ImportError:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #153117
* __->__ #154858

Triton 3.4 will remove the experimental TMA apis: https://github.com/triton-lang/triton/pull/6488

To allow compatibility across different triton versions, we implement a shim layer which calls the new API if available, and otherwise falls back to the experimental API.

Test: `python test/inductor/test_flex_attention.py TestFlexAttentionCUDA.test_GQA_causal_mask_cuda` which previously fails w/ triton-lang/tritoncda4229558c5dca7f7c4734bedd3e596ebcae0b8, but now passes.

Note: we'll need to apply this for other things in inductor, this just does it for flex attention.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov