### PR TITLE
[dynamo] [2/3] added add_new_gb_type functionality

### DIFF
--- a/tools/dynamo/gb_id_mapping.py
+++ b/tools/dynamo/gb_id_mapping.py
@@ -26,7 +26,7 @@ def save_registry(reg, path):
 
 def next_gb_id(reg):
     ids = [int(x[2:]) for x in reg if x.startswith("GB") and x[2:].isdigit()]
-    return f"GB{(max(ids,default=0)+1):04d}"
+    return f"GB{(max(ids, default=0) + 1):04d}"
 
 
 """
@@ -165,14 +165,18 @@ def cmd_add_new_gb_type(gb_type, file_path, registry_path):
 
     existing_gb_types = {entry["Gb_type"] for entry in reg.values()}
     if gb_type in existing_gb_types:
-        print(f"Error: gb_type '{gb_type}' already exists in registry. Please rename the gb_type so it can be unique.")
+        print(
+            f"Error: gb_type '{gb_type}' already exists in registry. Please rename the gb_type so it can be unique."
+        )
         return False
 
     calls = find_unimplemented_v2_calls(Path(file_path))
     matching_call = next((call for call in calls if call["gb_type"] == gb_type), None)
 
     if not matching_call:
-        print(f"Error: Could not find unimplemented_v2 call with gb_type '{gb_type}' in {file_path}")
+        print(
+            f"Error: Could not find unimplemented_v2 call with gb_type '{gb_type}' in {file_path}"
+        )
         return False
 
     gb_id = next_gb_id(reg)


### PR DESCRIPTION
The user can now use the terminal to update the registry whenever they create a new unimplemented_v2() callsite.
Terminal command template: python [path to gb_id_mapping.py] add "new_gb_type" [path to file where user added callsite]
Before the user added a new gb_type:
<img width="619" alt="Screenshot 2025-06-02 at 1 33 54 PM" src="https://github.com/user-attachments/assets/7258cab1-a184-4200-9d56-7b21d243d6d8" />
After the user added a new gb_type:
<img width="366" alt="Screenshot 2025-06-02 at 1 34 47 PM" src="https://github.com/user-attachments/assets/5c383e94-268c-4f6d-9111-7b18c856222e" />


Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #154886
* #154738

