### PR TITLE
[ROCm] fix CI failures from inductor periodic

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/aot_eager_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/aot_eager_torchbench_training.csv
@@ -154,6 +154,10 @@ maml_omniglot,pass,7
 
 
 
+microbench_unbacked_tolist_sum,pass,8
+
+
+
 mnasnet1_0,pass,7
 
 
@@ -266,11 +270,11 @@ timm_nfnet,pass,0
 
 
 
-timm_regnet,pass,6
+timm_regnet,pass,7
 
 
 
-timm_resnest,pass,7
+timm_resnest,pass,6
 
 
 
@@ -294,7 +298,7 @@ tts_angular,pass,9
 
 
 
-vgg16,pass,6
+vgg16,pass,0
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_aot_eager_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_aot_eager_torchbench_training.csv
@@ -154,6 +154,10 @@ maml_omniglot,pass,7
 
 
 
+microbench_unbacked_tolist_sum,pass,8
+
+
+
 mnasnet1_0,pass,7
 
 
@@ -262,11 +266,11 @@ timm_nfnet,pass,0
 
 
 
-timm_regnet,pass,6
+timm_regnet,pass,7
 
 
 
-timm_resnest,pass,7
+timm_resnest,pass,6
 
 
 
@@ -290,7 +294,7 @@ tts_angular,pass,9
 
 
 
-vgg16,pass,6
+vgg16,pass,0
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_inductor_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_inductor_torchbench_training.csv
@@ -142,6 +142,10 @@ maml_omniglot,pass,7
 
 
 
+microbench_unbacked_tolist_sum,pass,8
+
+
+
 mnasnet1_0,pass,7
 
 
@@ -242,11 +246,11 @@ timm_efficientnet,pass,7
 
 
 
-timm_regnet,pass,6
+timm_regnet,pass,7
 
 
 
-timm_resnest,pass,7
+timm_resnest,pass,6
 
 
 
@@ -270,7 +274,7 @@ tts_angular,pass,9
 
 
 
-vgg16,pass,6
+vgg16,pass,0
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamo_eager_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamo_eager_torchbench_training.csv
@@ -154,6 +154,10 @@ maml_omniglot,pass,7
 
 
 
+microbench_unbacked_tolist_sum,pass,8
+
+
+
 mnasnet1_0,pass,7
 
 
@@ -266,11 +270,11 @@ timm_nfnet,pass,0
 
 
 
-timm_regnet,pass,6
+timm_regnet,pass,7
 
 
 
-timm_resnest,pass,7
+timm_resnest,pass,6
 
 
 
@@ -294,7 +298,7 @@ tts_angular,pass,9
 
 
 
-vgg16,pass,6
+vgg16,pass,0
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/inductor_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/inductor_torchbench_training.csv
@@ -142,6 +142,10 @@ maml_omniglot,pass,7
 
 
 
+microbench_unbacked_tolist_sum,pass,8
+
+
+
 mnasnet1_0,pass,7
 
 
@@ -246,11 +250,11 @@ timm_efficientnet,pass,7
 
 
 
-timm_regnet,pass,6
+timm_regnet,pass,7
 
 
 
-timm_resnest,pass,7
+timm_resnest,pass,6
 
 
 
@@ -274,7 +278,7 @@ tts_angular,pass,9
 
 
 
-vgg16,pass,6
+vgg16,pass,0
 
 
 


### PR DESCRIPTION
Similar idea as https://github.com/pytorch/pytorch/pull/154497, but for ROCm.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames