### PR TITLE
[Memory Snapshot] Add Flag to Toggle Global and Local Callbacks for Annotations

### DIFF
--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -1125,7 +1125,7 @@ static void registerCudaDeviceProperties(PyObject* module) {
 
   m.def(
       "_cuda_record_memory_history_legacy",
-      static_cast<void (*)(bool, bool, int64_t, bool, bool, bool, bool)>(
+      static_cast<void (*)(bool, bool, int64_t, bool, bool, bool, bool, bool)>(
           torch::cuda::_record_memory_history));
 
   m.def(
@@ -1135,6 +1135,7 @@ static void registerCudaDeviceProperties(PyObject* module) {
           std::optional<std::string>,
           const std::string&,
           size_t,
+          bool,
           bool,
           bool)>(torch::cuda::_record_memory_history));
 

--- a/torch/csrc/cuda/memory_snapshot.h
+++ b/torch/csrc/cuda/memory_snapshot.h
@@ -16,7 +16,8 @@ TORCH_CUDA_CU_API void _record_memory_history(
     bool trace_alloc_record_context = false,
     bool record_cpp_context = false,
     bool clearHistory = false,
-    bool compileContext = false);
+    bool compileContext = false,
+    bool globalRecordAllocations = false);
 
 TORCH_CUDA_CU_API void _record_memory_history(
     std::optional<std::string> enabled = "all",
@@ -24,7 +25,8 @@ TORCH_CUDA_CU_API void _record_memory_history(
     const std::string& stacks = "all",
     size_t max_entries = SIZE_MAX,
     bool clearHistory = false,
-    bool compileContext = false);
+    bool compileContext = false,
+    bool globalRecordAllocations = false);
 
 TORCH_CUDA_CU_API std::string _memory_snapshot_pickled();
 

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -847,6 +847,7 @@ def _record_memory_history_legacy(
     record_context_cpp=False,
     clear_history=False,
     compile_context=False,
+    global_record_annotations=False,
 ):
     _C._cuda_record_memory_history_legacy(  # type: ignore[call-arg]
         enabled,
@@ -856,6 +857,7 @@ def _record_memory_history_legacy(
         record_context_cpp,
         clear_history,
         compile_context,
+        global_record_annotations,
     )
 
 
@@ -912,9 +914,16 @@ def _record_memory_history_impl(
     device: "Device" = None,
     clear_history: bool = False,
     compile_context: bool = False,
+    global_record_annotations: bool = False,
 ):
     _C._cuda_record_memory_history(  # type: ignore[call-arg]
-        enabled, context, stacks, max_entries, clear_history, compile_context
+        enabled,
+        context,
+        stacks,
+        max_entries,
+        clear_history,
+        compile_context,
+        global_record_annotations,
     )
 
 


### PR DESCRIPTION
Summary:
There are some cases where we want only local annotations for memory snapshot such as executing inside the cudastream callback, which cannot execute CUDA operators. Thus the cuda errors happen: Exception in RecordFunction callback: CUDA error: operation not permitted

However, we need to have an option to turn on the globally so that on-demand snapshot can get annotations. Additionally, there may be some cases in which auto-trace will also want annotations using record functions so we expose the flag to the auto-trace as well.

Test Plan:
Run MVAI executable and see that the errors go away

Rollback Plan:

Differential Revision: D75831687


