### PR TITLE
[BE] Use vendored packaging for testing

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -51,7 +51,7 @@ import torch._prims as prims  # noqa: F401
 from torch.utils import _pytree as pytree
 
 
-from packaging import version
+from torch._vendor.packaging import version
 
 from torch.testing._internal.opinfo.core import (  # noqa: F401
     L,


### PR DESCRIPTION
As the rest of the torch uses it, test should rely on it as well
