### PR TITLE
Move c10/util/Exception.h to torch/standalone

### DIFF
--- a/c10/core/build.bzl
+++ b/c10/core/build.bzl
@@ -80,7 +80,6 @@ def define_targets(rules):
         deps = [
             ":ScalarType",
             "//third_party/cpuinfo",
-            "//:torch_standalone_headers",
             "//c10/macros",
             "//c10/util:TypeCast",
             "//c10/util:base",

--- a/c10/macros/Export.h
+++ b/c10/macros/Export.h
@@ -1,11 +1,95 @@
 #ifndef C10_MACROS_EXPORT_H_
 #define C10_MACROS_EXPORT_H_
 
+/* Header file to define the common scaffolding for exported symbols.
+ *
+ * Export is by itself a quite tricky situation to deal with, and if you are
+ * hitting this file, make sure you start with the background here:
+ * - Linux: https://gcc.gnu.org/wiki/Visibility
+ * - Windows:
+ * https://docs.microsoft.com/en-us/cpp/cpp/dllexport-dllimport?view=vs-2017
+ *
+ * Do NOT include this file directly. Instead, use c10/macros/Macros.h
+ */
+
+// You do not need to edit this part of file unless you are changing the core
+// pytorch export abstractions.
+//
+// This part defines the C10 core export and import macros. This is controlled
+// by whether we are building shared libraries or not, which is determined
+// during build time and codified in c10/core/cmake_macros.h.
+// When the library is built as a shared lib, EXPORT and IMPORT will contain
+// visibility attributes. If it is being built as a static lib, then EXPORT
+// and IMPORT basically have no effect.
+
+// As a rule of thumb, you should almost NEVER mix static and shared builds for
+// libraries that depend on c10. AKA, if c10 is built as a static library, we
+// recommend everything dependent on c10 to be built statically. If c10 is built
+// as a shared library, everything dependent on it should be built as shared. In
+// the PyTorch project, all native libraries shall use the macro
+// C10_BUILD_SHARED_LIB to check whether pytorch is building shared or static
+// libraries.
+
+// For build systems that do not directly depend on CMake and directly build
+// from the source directory (such as Buck), one may not have a cmake_macros.h
+// file at all. In this case, the build system is responsible for providing
+// correct macro definitions corresponding to the cmake_macros.h.in file.
+//
+// In such scenarios, one should define the macro
+//     C10_USING_CUSTOM_GENERATED_MACROS
+// to inform this header that it does not need to include the cmake_macros.h
+// file.
+
 #ifndef C10_USING_CUSTOM_GENERATED_MACROS
 #include <c10/macros/cmake_macros.h>
 #endif // C10_USING_CUSTOM_GENERATED_MACROS
 
-#include <torch/standalone/macros/Export.h>
+#ifdef _WIN32
+#define C10_HIDDEN
+#if defined(C10_BUILD_SHARED_LIBS)
+#define C10_EXPORT __declspec(dllexport)
+#define C10_IMPORT __declspec(dllimport)
+#else
+#define C10_EXPORT
+#define C10_IMPORT
+#endif
+#else // _WIN32
+#if defined(__GNUC__)
+#define C10_EXPORT __attribute__((__visibility__("default")))
+#define C10_HIDDEN __attribute__((__visibility__("hidden")))
+#else // defined(__GNUC__)
+#define C10_EXPORT
+#define C10_HIDDEN
+#endif // defined(__GNUC__)
+#define C10_IMPORT C10_EXPORT
+#endif // _WIN32
+
+#ifdef NO_EXPORT
+#undef C10_EXPORT
+#define C10_EXPORT
+#endif
+
+// Definition of an adaptive XX_API macro, that depends on whether you are
+// building the library itself or not, routes to XX_EXPORT and XX_IMPORT.
+// Basically, you will need to do this for each shared library that you are
+// building, and the instruction is as follows: assuming that you are building
+// a library called libawesome.so. You should:
+// (1) for your cmake target (usually done by "add_library(awesome, ...)"),
+//     define a macro called AWESOME_BUILD_MAIN_LIB using
+//     target_compile_options.
+// (2) define the AWESOME_API macro similar to the one below.
+// And in the source file of your awesome library, use AWESOME_API to
+// annotate public symbols.
+
+// Here, for the C10 library, we will define the macro C10_API for both import
+// and export.
+
+// This one is being used by libc10.so
+#ifdef C10_BUILD_MAIN_LIB
+#define C10_API C10_EXPORT
+#else
+#define C10_API C10_IMPORT
+#endif
 
 // This one is being used by libtorch.so
 #ifdef CAFFE2_BUILD_MAIN_LIB
@@ -75,4 +159,4 @@
 #define C10_API_ENUM
 #endif
 
-#endif // C10_MACROS_EXPORT_H_
+#endif // C10_MACROS_MACROS_H_

--- a/c10/util/build.bzl
+++ b/c10/util/build.bzl
@@ -34,6 +34,7 @@ def define_targets(rules):
         visibility = ["//visibility:public"],
         deps = [
             ":bit_cast",
+            "//:torch_standalone_headers",
             "//c10/macros",
             "@fmt",
             "@moodycamel//:moodycamel",

--- a/test/cpp/aoti_abi_check/test_macros.cpp
+++ b/test/cpp/aoti_abi_check/test_macros.cpp
@@ -1,17 +1,28 @@
 #include <gtest/gtest.h>
 
 #include <torch/standalone/macros/Export.h>
+#include <torch/standalone/util/Exception.h>
 
 namespace torch {
 namespace aot_inductor {
 
-C10_API bool equal(int a, int b) {
+TORCH_STANDALONE_API bool equal(int a, int b) {
   return a == b;
 }
 
-TEST(TestMacros, TestC10API) {
+TEST(TestMacros, TestAPI) {
   EXPECT_TRUE(equal(1, 1));
   EXPECT_FALSE(equal(1, 2));
+}
+
+TEST(TestMacros, TestTorchCheck) {
+  EXPECT_NO_THROW(TORCH_STANDALONE_CHECK(true, "dummy true message"));
+  EXPECT_NO_THROW(TORCH_STANDALONE_CHECK(true, "dummy ", "true ", "message"));
+  EXPECT_THROW(
+      TORCH_STANDALONE_CHECK(false, "dummy false message"), std::runtime_error);
+  EXPECT_THROW(
+      TORCH_STANDALONE_CHECK(false, "dummy ", "false ", "message"),
+      std::runtime_error);
 }
 
 } // namespace aot_inductor

--- a/torch/header_only_apis.txt
+++ b/torch/header_only_apis.txt
@@ -49,4 +49,7 @@ minimum
 size
 
 # torch/standalone/macros/Export.h
-C10_API
+TORCH_STANDALONE_API
+
+# torch/standalone/util/Exception.h
+TORCH_STANDALONE_CHECK

--- a/torch/standalone/macros/Export.h
+++ b/torch/standalone/macros/Export.h
@@ -29,39 +29,29 @@
 // C10_BUILD_SHARED_LIB to check whether pytorch is building shared or static
 // libraries.
 
-// For build systems that do not directly depend on CMake and directly build
-// from the source directory (such as Buck), one may not have a cmake_macros.h
-// file at all. In this case, the build system is responsible for providing
-// correct macro definitions corresponding to the cmake_macros.h.in file.
-//
-// In such scenarios, one should define the macro
-//     C10_USING_CUSTOM_GENERATED_MACROS
-// to inform this header that it does not need to include the cmake_macros.h
-// file.
-
 #ifdef _WIN32
-#define C10_HIDDEN
+#define TORCH_STANDALONE_HIDDEN
 #if defined(C10_BUILD_SHARED_LIBS)
-#define C10_EXPORT __declspec(dllexport)
-#define C10_IMPORT __declspec(dllimport)
+#define TORCH_STANDALONE_EXPORT __declspec(dllexport)
+#define TORCH_STANDALONE_IMPORT __declspec(dllimport)
 #else
-#define C10_EXPORT
-#define C10_IMPORT
+#define TORCH_STANDALONE_EXPORT
+#define TORCH_STANDALONE_IMPORT
 #endif
 #else // _WIN32
 #if defined(__GNUC__)
-#define C10_EXPORT __attribute__((__visibility__("default")))
-#define C10_HIDDEN __attribute__((__visibility__("hidden")))
+#define TORCH_STANDALONE_EXPORT __attribute__((__visibility__("default")))
+#define TORCH_STANDALONE_HIDDEN __attribute__((__visibility__("hidden")))
 #else // defined(__GNUC__)
-#define C10_EXPORT
-#define C10_HIDDEN
+#define TORCH_STANDALONE_EXPORT
+#define TORCH_STANDALONE_HIDDEN
 #endif // defined(__GNUC__)
-#define C10_IMPORT C10_EXPORT
+#define TORCH_STANDALONE_IMPORT TORCH_STANDALONE_EXPORT
 #endif // _WIN32
 
 #ifdef NO_EXPORT
-#undef C10_EXPORT
-#define C10_EXPORT
+#undef TORCH_STANDALONE_EXPORT
+#define TORCH_STANDALONE_EXPORT
 #endif
 
 // Definition of an adaptive XX_API macro, that depends on whether you are
@@ -81,7 +71,7 @@
 
 // This one is being used by libc10.so
 #ifdef C10_BUILD_MAIN_LIB
-#define C10_API C10_EXPORT
+#define TORCH_STANDALONE_API TORCH_STANDALONE_EXPORT
 #else
-#define C10_API C10_IMPORT
+#define TORCH_STANDALONE_API TORCH_STANDALONE_IMPORT
 #endif

--- a/torch/standalone/macros/Macros.h
+++ b/torch/standalone/macros/Macros.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#define TORCH_STANDALONE_CONCATENATE_IMPL(s1, s2) s1##s2
+#define TORCH_STANDALONE_CONCATENATE(s1, s2) \
+  TORCH_STANDALONE_CONCATENATE_IMPL(s1, s2)
+
+#define TORCH_STANDALONE_MACRO_EXPAND(args) args
+
+#define TORCH_STANDALONE_STRINGIZE_IMPL(x) #x
+#define TORCH_STANDALONE_STRINGIZE(x) TORCH_STANDALONE_STRINGIZE_IMPL(x)
+
+// TORCH_STANDALONE_LIKELY/TORCH_STANDALONE_UNLIKELY
+//
+// These macros provide parentheses, so you can use these macros as:
+//
+//    if TORCH_STANDALONE_LIKELY(some_expr) {
+//      ...
+//    }
+//
+// NB: static_cast to boolean is mandatory in C++, because __builtin_expect
+// takes a long argument, which means you may trigger the wrong conversion
+// without it.
+//
+#if defined(__GNUC__) || defined(__ICL) || defined(__clang__)
+#define TORCH_STANDALONE_LIKELY(expr) \
+  (__builtin_expect(static_cast<bool>(expr), 1))
+#define TORCH_STANDALONE_UNLIKELY(expr) \
+  (__builtin_expect(static_cast<bool>(expr), 0))
+#else
+#define TORCH_STANDALONE_LIKELY(expr) (expr)
+#define TORCH_STANDALONE_UNLIKELY(expr) (expr)
+#endif
+
+// On nvcc, TORCH_STANDALONE_UNLIKELY thwarts missing return statement analysis.
+// In cases where the unlikely expression may be a constant, use this macro to
+// ensure return statement analysis keeps working (at the cost of not getting
+// the likely/unlikely annotation on nvcc).
+// https://github.com/pytorch/pytorch/issues/21418
+//
+// Currently, this is only used in the error reporting macros below.  If you
+// want to use it more generally, move me to Macros.h
+//
+// TODO: Brian Vaughan observed that we might be able to get this to work on
+// nvcc by writing some sort of C++ overload that distinguishes constexpr inputs
+// from non-constexpr.  Since there isn't any evidence that losing
+// TORCH_STANDALONE_UNLIKELY in nvcc is causing us perf problems, this is not
+// yet implemented, but this might be an interesting piece of C++ code for an
+// intrepid bootcamper to write.
+#if defined(__CUDACC__)
+#define TORCH_STANDALONE_UNLIKELY_OR_CONST(e) e
+#else
+#define TORCH_STANDALONE_UNLIKELY_OR_CONST(e) TORCH_STANDALONE_UNLIKELY(e)
+#endif

--- a/torch/standalone/util/Exception.h
+++ b/torch/standalone/util/Exception.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#ifdef TORCH_STANDALONE
+#include <torch/standalone/macros/Macros.h>
+
+#include <sstream>
+#include <string>
+
+// In the standalone version, TORCH_STANDALONE_CHECK throws std::runtime_error
+// instead of c10::Error, because c10::Error transitively calls too
+// much code to be implemented as header-only.
+
+#ifdef STRIP_ERROR_MESSAGES
+#define TORCH_STANDALONE_CHECK_MSG(cond, type, ...) \
+  (#cond #type " CHECK FAILED at " TORCH_STANDALONE_STRINGIZE(__FILE__))
+#define TORCH_STANDALONE_CHECK(cond, ...)                \
+  if (TORCH_STANDALONE_UNLIKELY_OR_CONST(!(cond))) {     \
+    throw std::runtime_error(TORCH_STANDALONE_CHECK_MSG( \
+        cond,                                            \
+        "",                                              \
+        __func__,                                        \
+        ", ",                                            \
+        __FILE__,                                        \
+        ":",                                             \
+        __LINE__,                                        \
+        ", ",                                            \
+        __VA_ARGS__));                                   \
+  }
+
+#else // STRIP_ERROR_MESSAGES
+namespace torch::standalone::detail {
+template <typename... Args>
+std::string torchCheckMsgImpl(const char* /*msg*/, const Args&... args) {
+  // This is similar to the one in c10/util/Exception.h, but does
+  // not depend on the more complex c10::str() function. ostringstream
+  // supports less data types than c10::str(), but should be sufficient
+  // in the standalone world.
+  std::ostringstream oss;
+  ((oss << args), ...);
+  return oss.str();
+}
+inline TORCH_STANDALONE_API const char* torchCheckMsgImpl(const char* msg) {
+  return msg;
+}
+// If there is just 1 user-provided C-string argument, use it.
+inline TORCH_STANDALONE_API const char* torchCheckMsgImpl(
+    const char* /*msg*/,
+    const char* args) {
+  return args;
+}
+} // namespace torch::standalone::detail
+
+#define TORCH_STANDALONE_CHECK_MSG(cond, type, ...)        \
+  (::torch::standalone::detail::torchCheckMsgImpl(         \
+      "Expected " #cond                                    \
+      " to be true, but got false.  "                      \
+      "(Could this error message be improved?  If so, "    \
+      "please report an enhancement request to PyTorch.)", \
+      ##__VA_ARGS__))
+#define TORCH_STANDALONE_CHECK(cond, ...)                \
+  if (TORCH_STANDALONE_UNLIKELY_OR_CONST(!(cond))) {     \
+    throw std::runtime_error(TORCH_STANDALONE_CHECK_MSG( \
+        cond,                                            \
+        "",                                              \
+        __func__,                                        \
+        ", ",                                            \
+        __FILE__,                                        \
+        ":",                                             \
+        __LINE__,                                        \
+        ", ",                                            \
+        ##__VA_ARGS__));                                 \
+  }
+
+#endif // STRIP_ERROR_MESSAGES
+
+#else // TORCH_STANDALONE
+#include <c10/util/Exception.h>
+
+#define TORCH_STANDALONE_CHECK(cond, ...) TORCH_CHECK(cond, ##__VA_ARGS__)
+
+#endif // TORCH_STANDALONE


### PR DESCRIPTION
Summary: Move a part of c10/util/Exception.h to torch/standalone, so that TORCH_CHECK can be used there.

Test Plan: CI

Differential Revision: D75785559




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov