### PR TITLE
[MPS][BE] Extend torch.special. to integer dtypes

### DIFF
--- a/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
@@ -76,12 +76,12 @@ struct zeta_functor {
 };
 
 struct xlog1py_functor {
-  template <typename T>
-  inline enable_if_t<is_floating_point_v<T>, T> operator()(const T a, const T b) {
+  template <typename T, enable_if_t<is_floating_point_v<T>, bool> = true>
+  inline T operator()(const T a, const T b) {
     return static_cast<T>(c10::metal::xlog1py(a, b));
   }
-  template <typename T>
-  inline enable_if_t<!is_floating_point_v<T>, float> operator()(const T a, const T b) {
+  template <typename T, enable_if_t<is_integral_v<T>, bool> = true>
+  inline float operator()(const T a, const T b) {
     return c10::metal::xlog1py(float(a), float(b));
   }
 };

--- a/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
@@ -77,8 +77,12 @@ struct zeta_functor {
 
 struct xlog1py_functor {
   template <typename T>
-  inline T operator()(const T a, const T b) {
+  inline enable_if_t<is_floating_point_v<T>, T> operator()(const T a, const T b) {
     return static_cast<T>(c10::metal::xlog1py(a, b));
+  }
+  template <typename T>
+  inline enable_if_t<!is_floating_point_v<T>, float> operator()(const T a, const T b) {
+    return c10::metal::xlog1py(float(a), float(b));
   }
 };
 
@@ -300,6 +304,7 @@ REGISTER_FLOAT_BINARY_OP(fmin);
 REGISTER_FLOAT_BINARY_OP(nextafter);
 REGISTER_FLOAT_BINARY_OP(zeta);
 REGISTER_FLOAT_BINARY_OP(xlog1py);
+REGISTER_INT2FLOAT_BINARY_OP(xlog1py);
 REGISTER_FLOAT_BINARY_OP(chebyshev_polynomial_t);
 REGISTER_FLOAT_BINARY_OP(chebyshev_polynomial_u);
 REGISTER_FLOAT_BINARY_OP(chebyshev_polynomial_v);

--- a/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
@@ -69,9 +69,13 @@ struct copysign_functor {
 };
 
 struct zeta_functor {
-  template <typename T>
+  template <typename T, enable_if_t<is_floating_point_v<T>, bool> = true>
   inline T operator()(const T a, const T b) {
     return static_cast<T>(c10::metal::zeta(a, b));
+  }
+  template <typename T, enable_if_t<is_integral_v<T>, bool> = true>
+  inline float operator()(const T a, const T b) {
+    return c10::metal::zeta(float(a), float(b));
   }
 };
 
@@ -87,44 +91,68 @@ struct xlog1py_functor {
 };
 
 struct chebyshev_polynomial_t_functor {
-  template <typename T>
+  template <typename T, enable_if_t<is_floating_point_v<T>, bool> = true>
   inline T operator()(const T a, const T b) {
     return static_cast<T>(c10::metal::chebyshev_polynomial_t_forward(a, b));
+  }
+  template <typename T, enable_if_t<is_integral_v<T>, bool> = true>
+  inline float operator()(const T a, const T b) {
+    return c10::metal::chebyshev_polynomial_t_forward(float(a), float(b));
   }
 };
 
 struct chebyshev_polynomial_u_functor {
-  template <typename T>
+  template <typename T, enable_if_t<is_floating_point_v<T>, bool> = true>
   inline T operator()(const T a, const T b) {
     return static_cast<T>(c10::metal::chebyshev_polynomial_u_forward(a, b));
+  }
+  template <typename T, enable_if_t<is_integral_v<T>, bool> = true>
+  inline float operator()(const T a, const T b) {
+    return c10::metal::chebyshev_polynomial_u_forward(float(a), float(b));
   }
 };
 
 struct chebyshev_polynomial_v_functor {
-  template <typename T>
+  template <typename T, enable_if_t<is_floating_point_v<T>, bool> = true>
   inline T operator()(const T a, const T b) {
     return static_cast<T>(c10::metal::chebyshev_polynomial_v_forward(a, b));
+  }
+  template <typename T, enable_if_t<is_integral_v<T>, bool> = true>
+  inline float operator()(const T a, const T b) {
+    return c10::metal::chebyshev_polynomial_v_forward(float(a), float(b));
   }
 };
 
 struct chebyshev_polynomial_w_functor {
-  template <typename T>
+  template <typename T, enable_if_t<is_floating_point_v<T>, bool> = true>
   inline T operator()(const T a, const T b) {
     return static_cast<T>(c10::metal::chebyshev_polynomial_w_forward(a, b));
+  }
+  template <typename T, enable_if_t<is_integral_v<T>, bool> = true>
+  inline float operator()(const T a, const T b) {
+    return c10::metal::chebyshev_polynomial_w_forward(float(a), float(b));
   }
 };
 
 struct hermite_polynomial_h_functor {
-  template <typename T>
+  template <typename T, enable_if_t<is_floating_point_v<T>, bool> = true>
   inline T operator()(const T a, const T b) {
     return static_cast<T>(c10::metal::hermite_polynomial_h_forward(a, b));
+  }
+  template <typename T, enable_if_t<is_integral_v<T>, bool> = true>
+  inline float operator()(const T a, const T b) {
+    return c10::metal::hermite_polynomial_h_forward(float(a), float(b));
   }
 };
 
 struct hermite_polynomial_he_functor {
-  template <typename T>
+  template <typename T, enable_if_t<is_floating_point_v<T>, bool> = true>
   inline T operator()(const T a, const T b) {
     return static_cast<T>(c10::metal::hermite_polynomial_he_forward(a, b));
+  }
+  template <typename T, enable_if_t<is_integral_v<T>, bool> = true>
+  inline float operator()(const T a, const T b) {
+    return c10::metal::hermite_polynomial_he_forward(float(a), float(b));
   }
 };
 
@@ -303,14 +331,21 @@ REGISTER_FLOAT_BINARY_OP(fmax);
 REGISTER_FLOAT_BINARY_OP(fmin);
 REGISTER_FLOAT_BINARY_OP(nextafter);
 REGISTER_FLOAT_BINARY_OP(zeta);
+REGISTER_INT2FLOAT_BINARY_OP(zeta);
 REGISTER_FLOAT_BINARY_OP(xlog1py);
 REGISTER_INT2FLOAT_BINARY_OP(xlog1py);
 REGISTER_FLOAT_BINARY_OP(chebyshev_polynomial_t);
+REGISTER_INT2FLOAT_BINARY_OP(chebyshev_polynomial_t);
 REGISTER_FLOAT_BINARY_OP(chebyshev_polynomial_u);
+REGISTER_INT2FLOAT_BINARY_OP(chebyshev_polynomial_u);
 REGISTER_FLOAT_BINARY_OP(chebyshev_polynomial_v);
+REGISTER_INT2FLOAT_BINARY_OP(chebyshev_polynomial_w);
 REGISTER_FLOAT_BINARY_OP(chebyshev_polynomial_w);
+REGISTER_INT2FLOAT_BINARY_OP(chebyshev_polynomial_v);
 REGISTER_FLOAT_BINARY_OP(hermite_polynomial_h);
+REGISTER_INT2FLOAT_BINARY_OP(hermite_polynomial_h);
 REGISTER_FLOAT_BINARY_OP(hermite_polynomial_he);
+REGISTER_INT2FLOAT_BINARY_OP(hermite_polynomial_he);
 REGISTER_FLOAT_BINARY_OP(add);
 REGISTER_INTEGER_BINARY_OP(add);
 REGISTER_OPMATH_FLOAT_BINARY_OP(mul);

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -512,14 +512,6 @@ if torch.backends.mps.is_available():
             "histc": [torch.float16, torch.bfloat16],
             "index_add": [torch.int64],
             # Operations not supported for integral types
-            "special.xlog1py": [
-                torch.bool,
-                torch.int16,
-                torch.int32,
-                torch.int64,
-                torch.uint8,
-                torch.int8,
-            ],
             "special.zeta": [
                 torch.bool,
                 torch.int16,

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -511,47 +511,6 @@ if torch.backends.mps.is_available():
             "dot": [torch.int64] if MACOS_VERSION < 14.0 else [],
             "histc": [torch.float16, torch.bfloat16],
             "index_add": [torch.int64],
-            # Operations not supported for integral types
-            "special.zeta": [
-                torch.bool,
-                torch.int16,
-                torch.int32,
-                torch.int64,
-                torch.uint8,
-                torch.int8,
-            ],
-            "special.chebyshev_polynomial_t": [
-                torch.bool,
-                torch.int16,
-                torch.int32,
-                torch.int64,
-                torch.uint8,
-                torch.int8,
-            ],
-            "special.chebyshev_polynomial_u": [
-                torch.bool,
-                torch.int16,
-                torch.int32,
-                torch.int64,
-                torch.uint8,
-                torch.int8,
-            ],
-            "special.hermite_polynomial_h": [
-                torch.bool,
-                torch.int16,
-                torch.int32,
-                torch.int64,
-                torch.uint8,
-                torch.int8,
-            ],
-            "special.hermite_polynomial_he": [
-                torch.bool,
-                torch.int16,
-                torch.int32,
-                torch.int64,
-                torch.uint8,
-                torch.int8,
-            ],
             # GEMM on MPS is not supported for integral types
             "nn.functional.linear": [
                 torch.int16,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #155002

By changing the functor to looks as follows
```metal
struct xlog1py_functor {
  template <typename T, enable_if_t<is_floating_point_v<T>, bool> = true>
  inline T operator()(const T a, const T b) {
    return static_cast<T>(c10::metal::xlog1py(a, b));
  }
  template <typename T, enable_if_t<is_integral_v<T>, bool> = true>
  inline float operator()(const T a, const T b) {
    return c10::metal::xlog1py(float(a), float(b));
  }
};
```

Repeat the same for `zeta`, `chebyshev_polynomial_[tuvw]_functor` and `hermite_polynomial_h[e]_functor`