### PR TITLE
[Inductor] Support autotuning in the FX backend.

### DIFF
--- a/test/inductor/test_fxir_backend.py
+++ b/test/inductor/test_fxir_backend.py
@@ -424,7 +424,7 @@ class FxirTestCase(InductorTestCase):
         # Compile and check that the tuner was called.
         with unittest.mock.patch.object(
             torch._inductor.runtime.triton_heuristics.CachingAutotuner, "run", run
-        ) as run_mock:
+        ):
             self.assertFalse(called)
             self._compile_and_check(torch.mul, args)
             self.assertTrue(called)

--- a/test/inductor/test_fxir_backend.py
+++ b/test/inductor/test_fxir_backend.py
@@ -427,13 +427,12 @@ class FxirTestCase(InductorTestCase):
 
         args = [torch.randn(8, device=self.device) for _ in range(2)]
 
-        # Compile and check that the tuner was called.
-
         with config.patch(
             "triton.autotune_at_compile_time", enable_tuning
         ), unittest.mock.patch.object(
             torch._inductor.runtime.triton_heuristics.CachingAutotuner, "run", run
         ):
+            # Compile and check that the tuner was called.
             self.assertFalse(called)
             (gm,) = self._compile_and_check(
                 torch.mul, args, compile_kwargs={"dynamic": use_dynamic_shapes}


### PR DESCRIPTION
# Feature 
If `config.triton.autotune_at_compile_time` is set to `True`, autotune Triton kernels during FX conversion. Else, stick with the existing behavior of using the first precompiled config.

# Test plan
Added CI tests verifying that the tuner is called iff this flag is set, with and without dynamic shapes. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov