### PR TITLE
Raise error from cumulative ops if ndims() - dim > 4

### DIFF
--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -383,6 +383,12 @@ static void cumulative_op_impl(const Tensor& self,
               dim,
               ")");
   TORCH_CHECK(!self.is_complex(), "cumulative ops are not yet supported for complex");
+
+  // issue #154881, raising error to prevent crash within MPSGraph until
+  // workaround is implemented.
+  TORCH_CHECK(nDims - wrapped_dim <= 4,
+              "On-going issue on MPSGraph cumulative ops when ndims() - axis > 4, see issue #154881");
+
   auto input = dtype.has_value() ? self.to(dtype.value()) : self;
 
   // issue #103810551: cumsum / cumprod are broken for int8, int16 and as chances for overflow are pretty high, cast to

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -3774,6 +3774,22 @@ class TestMPS(TestCaseMPS):
             self.assertEqual(e_string, "MPS does not support cumsum_out_mps op with int64 input." +
                              " Support has been added in macOS 13.3")
 
+    def test_cumsum_gt_4d(self):
+        a = torch.ones(1, 2, 3, 4, 5, dtype=torch.float).to('mps')
+        try:
+            t_mps = torch.ops.aten.cumsum(a, dim=0)
+        except Exception as e:
+            e_string = str(e)
+            self.assertEqual(e_string, "On-going issue on MPSGraph cumulative ops when ndims() - axis > 4, see issue #154881")
+
+    def test_cumprod_gt_4d(self):
+        a = torch.ones(1, 2, 3, 4, 5, dtype=torch.float).to('mps')
+        try:
+            t_mps = torch.ops.aten.cumprod(a, dim=0)
+        except Exception as e:
+            e_string = str(e)
+            self.assertEqual(e_string, "On-going issue on MPSGraph cumulative ops when ndims() - axis > 4, see issue #154881")
+
     def test_cumsum_bool(self):
         a = torch.ones(2**16, dtype=torch.bool)
         t_cpu = a.cumsum(0)


### PR DESCRIPTION
Addresses the immediate needs of issue #154881.

Not a real fix, just a more informative error if the issue is hit.