### PR TITLE
[revert] Always set CPU affinity for benchmark jobs

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -601,6 +601,7 @@ test_perf_for_dashboard() {
     elif [[ "${TEST_CONFIG}" == *cpu_aarch64* ]]; then
       device=cpu_aarch64
     fi
+    test_inductor_set_cpu_affinity
   elif [[ "${TEST_CONFIG}" == *cuda_a10g* ]]; then
     device=cuda_a10g
   elif [[ "${TEST_CONFIG}" == *h100* ]]; then
@@ -608,9 +609,6 @@ test_perf_for_dashboard() {
   elif [[ "${TEST_CONFIG}" == *rocm* ]]; then
     device=rocm
   fi
-
-  # Always set CPU affinity because metrics like compilation time requires CPU
-  test_inductor_set_cpu_affinity
 
   for mode in "${modes[@]}"; do
     if [[ "$mode" == "inference" ]]; then


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #155054

Checking if it fixes compile time regression

dashboard job here - https://github.com/pytorch/pytorch/actions/workflows/inductor-perf-test-nightly.yml
