### PR TITLE
[a2av] 2D all-to-all-vdev

### DIFF
--- a/test/distributed/test_nvshmem.py
+++ b/test/distributed/test_nvshmem.py
@@ -128,6 +128,80 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinousTest):
         dist.all_to_all_single(expected, inp, out_splits.tolist(), inp_splits.tolist())
         torch.testing.assert_close(out[:out_numel], expected)
 
+    @skipIfRocm
+    def test_nvshmem_all_to_all_vdev_2d(self) -> None:
+        torch.manual_seed(42 + self.rank)
+        self._init_device()
+
+        group_name = dist.group.WORLD.group_name
+        symm_mem.enable_symm_mem_for_group(group_name)
+
+        dtype = torch.float
+        # Number of experts per rank
+        ne = 4
+        nsplits = ne * self.world_size
+        # Number of elements for an expert is random between [0, k)
+        k = 3
+        inp_splits = torch.randint(k, (nsplits,), device=self.device)
+        inp_numel = inp_splits.sum().item()
+        # Exchange input splits to get output splits
+        out_splits = torch.zeros_like(inp_splits)
+        dist.all_to_all_single(out_splits, inp_splits)
+        # We do a .t() here because there is a rank-major to expert-major shuffle
+        out_splits_t = out_splits.reshape(self.world_size, ne).t().reshape(-1)
+
+        # Total number of output elements
+        out_numel = out_splits.sum().item()
+        # Align up to make it bigger
+        align = 16
+        out_numel_max = (out_numel + align - 1) // align * align
+
+        inp = symm_mem.empty(inp_numel, dtype=dtype, device=self.device).fill_(
+            self.rank
+        )
+        out = symm_mem.empty(out_numel_max, dtype=dtype, device=self.device).fill_(-1)
+        in_out_splits = symm_mem.empty(
+            (3, nsplits), dtype=torch.int64, device=self.device
+        ).fill_(-1)
+        # Row 0 is input splits
+        in_out_splits[0].copy_(inp_splits)
+
+        torch.ops.symm_mem.nvshmem_all_to_all_vdev_2d(
+            inp, out, in_out_splits, group_name
+        )
+
+        # Check input splits (row 0) -- should not change
+        torch.testing.assert_close(in_out_splits[0], inp_splits)
+
+        # Check output splits (row 1)
+        torch.testing.assert_close(in_out_splits[1], out_splits_t)
+
+        # Check output offsets (row 2)
+        out_offsets = torch.cumsum(out_splits_t, dim=0)  # inclusive scan
+        # output offsets from `nvshmem_all_to_all_vdev` is exclusive scan
+        self.assertEqual(in_out_splits[2][0], 0)
+        torch.testing.assert_close(in_out_splits[2][1:], out_offsets[:-1])
+
+        # Check data
+        expected = torch.empty(out_numel, dtype=dtype, device=self.device)
+        inp_splits_rank = inp_splits.reshape(self.world_size, ne).sum(1)
+        out_splits_rank = out_splits.reshape(self.world_size, ne).sum(1)
+        dist.all_to_all_single(
+            expected, inp, out_splits_rank.tolist(), inp_splits_rank.tolist()
+        )
+        # We still need to shuffle `expected`
+        out_offsets = torch.cumsum(out_splits, dim=0)  # inclusive scan
+        result_list = []
+        for j in range(ne):
+            for i in range(self.world_size):
+                chunk_id = i * ne + j
+                offset = out_offsets[chunk_id]
+                chunk = expected[offset - out_splits[chunk_id] : offset]
+                result_list.append(chunk)
+
+        final = torch.cat(result_list)
+        torch.testing.assert_close(out[:out_numel], final)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/csrc/distributed/c10d/SymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/SymmetricMemory.cpp
@@ -280,6 +280,8 @@ TORCH_LIBRARY_FRAGMENT(symm_mem, m) {
       "nvshmem_all_to_all(Tensor input, Tensor(a!) out, str group_name) -> Tensor(a!)");
   m.def(
       "nvshmem_all_to_all_vdev(Tensor input, Tensor(a!) out, Tensor(a!) in_out_splits, str group_name) -> Tensor(a!)");
+  m.def(
+      "nvshmem_all_to_all_vdev_2d(Tensor input, Tensor(a!) out, Tensor(a!) in_out_splits, str group_name) -> Tensor(a!)");
 }
 
 TORCH_LIBRARY_IMPL(symm_mem, Meta, m) {

--- a/torch/csrc/distributed/c10d/nvshmem_extension.cuh
+++ b/torch/csrc/distributed/c10d/nvshmem_extension.cuh
@@ -28,4 +28,10 @@ at::Tensor nvshmem_all_to_all_vdev(
     at::Tensor& in_out_splits,
     std::string group_name);
 
+at::Tensor nvshmem_all_to_all_vdev_2d(
+    at::Tensor& input,
+    at::Tensor& out,
+    at::Tensor& in_out_splits,
+    std::string group_name);
+
 } // namespace c10d::nvshmem_extension


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #155172
* __->__ #155058

A 2D AllToAllv shuffle is illustrated below:
(`world_size` = 2, `ne` = 2, where `ne` is number of experts per rank)
```
        Source: |       Rank 0      |       Rank 1      |
                | c0 | c1 | c2 | c3 | d0 | d1 | d2 | d3 |

        Dest  : |       Rank 0      |       Rank 1      |
                | c0 | d0 | c1 | d1 | c2 | d2 | c3 | d3 |
```
where each `c_i` / `d_i` are slices of the `input` tensor, targeting expert `i`, with length indicated by input splits (in `in_out_splits[0]`).  

That is, the 2D AllToAllv shuffle achieves a transpose from rank-major order at input to expert-major order at output.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k