### PR TITLE
Add type validation for alpha and inplace in nn.CELU

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -601,6 +601,12 @@ class CELU(Module):
 
     def __init__(self, alpha: float = 1.0, inplace: bool = False) -> None:
         super().__init__()
+        
+        if not isinstance(alpha, float):
+            raise TypeError(f"alpha must be a float, got {type(alpha).__name__}")
+        if not isinstance(inplace, bool):
+            raise TypeError(f"alpha must be a bool, got {type(alpha).__name__}")
+        
         self.alpha = alpha
         self.inplace = inplace
 


### PR DESCRIPTION
## Summary

Adds explicit type checks for `alpha` and `inplace` in `nn.CELU` constructor to ensure:
- `alpha` is a float
- `inplace` is a bool

This aligns behavior with the documentation, which currently states these types but accepts other ones (e.g., complex, int, str) without errors.

## Motivation

Previously, invalid types like `alpha=True`, `inplace=1.0`, etc., would silently work, despite the docs clearly stating expected types. This change prevents silent misuse and improves API consistency.