### PR TITLE
Redo D75092426: [internal] Expose additional metadata to compilation callbacks

### DIFF
--- a/test/dynamo/test_callback.py
+++ b/test/dynamo/test_callback.py
@@ -1,9 +1,14 @@
 # Owner(s): ["module: dynamo"]
 
+import unittest
 from unittest.mock import Mock
 
-from torch._dynamo.callback import callback_handler
+import torch
+from torch._dynamo.callback import callback_handler, CallbackArgs, CallbackTrigger
 from torch._dynamo.test_case import run_tests, TestCase
+from torch._guards import CompileId
+from torch.testing._internal.common_utils import TEST_WITH_ROCM
+from torch.testing._internal.inductor_utils import HAS_CUDA
 
 
 class CallbackTests(TestCase):
@@ -15,16 +20,22 @@ class CallbackTests(TestCase):
         callback_handler.register_end_callback(self._on_compile_end)
 
     def tearDown(self) -> None:
-        return super().tearDown()
         callback_handler.clear()
+        return super().tearDown()
 
     def test_callbacks_with_duplicate_prevention(self) -> None:
-        with callback_handler.install_callbacks(), callback_handler.install_callbacks():
+        trigger = CallbackTrigger.DYNAMO
+        compile_id = CompileId(0, 0)
+        with callback_handler.install_callbacks(
+            trigger, compile_id
+        ), callback_handler.install_callbacks(trigger, compile_id):
             self._on_compile_start.assert_called_once()
         self._on_compile_end.assert_called_once()
 
     def test_counter(self) -> None:
-        with callback_handler.install_callbacks():
+        trigger = CallbackTrigger.DYNAMO
+        compile_id = CompileId(0, 0)
+        with callback_handler.install_callbacks(trigger, compile_id):
             self.assertEqual(
                 callback_handler._CompilationCallbackHandler__pending_callbacks_counter,
                 1,
@@ -35,18 +46,95 @@ class CallbackTests(TestCase):
 
     def test_counter_assertion(self) -> None:
         callback_handler._CompilationCallbackHandler__pending_callbacks_counter -= 1
-
-        with self.assertRaises(
-            AssertionError
-        ) as e, callback_handler.install_callbacks():
-            pass
-
-        self.assertIn(
-            "Pending callbacks counter cannot become negative.",
-            str(e.exception),
+        with self.assertRaisesRegex(
+            AssertionError, "Pending callbacks counter cannot become negative."
+        ):
+            trigger = CallbackTrigger.DYNAMO
+            compile_id = CompileId(0, 0)
+            with callback_handler.install_callbacks(trigger, str(compile_id)):
+                pass
+        self.assertEqual(
+            callback_handler._CompilationCallbackHandler__pending_callbacks_counter, 0
         )
 
-        callback_handler._CompilationCallbackHandler__pending_callbacks_counter += 1
+    @unittest.skipIf(
+        TEST_WITH_ROCM, "ROCm outputs a different number of autotuning logs"
+    )
+    @unittest.skipIf(not HAS_CUDA, "requires triton")
+    @torch._inductor.config.patch(force_disable_caches=True)
+    def test_triggers(self) -> None:
+        torch._dynamo.reset()
+        order = []
+
+        def on_start(args: CallbackArgs):
+            nonlocal order
+            order.append(f"start={args}")
+
+        def on_end(args: CallbackArgs):
+            nonlocal order
+            order.append(f"end={args}")
+
+        torch._dynamo.callback.on_compile_start(on_start)
+        torch._dynamo.callback.on_compile_start(on_end)
+
+        class TinyModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.fc1 = torch.nn.Linear(10, 10)
+                self.relu = torch.nn.ReLU()
+                self.fc2 = torch.nn.Linear(10, 10)
+
+            def forward(self, x):
+                temp = self.fc1(x)
+                temp = self.relu(temp)
+                torch._dynamo.graph_break()
+                return self.fc2(temp)
+
+        model = TinyModel().to("cuda")
+        compiled_model = torch.compile(model, mode="max-autotune")
+        x = torch.randn(10, 10, device="cuda")
+
+        loss = compiled_model(x).sum()
+        loss.backward()
+        self.assertExpectedInline(
+            "\n".join(order),
+            """\
+start=CallbackArgs(callback_trigger=<CallbackTrigger.DYNAMO: 1>, compile_id='0/0')
+end=CallbackArgs(callback_trigger=<CallbackTrigger.DYNAMO: 1>, compile_id='0/0')
+start=CallbackArgs(callback_trigger=<CallbackTrigger.DYNAMO: 1>, compile_id='1/0')
+end=CallbackArgs(callback_trigger=<CallbackTrigger.DYNAMO: 1>, compile_id='1/0')
+start=CallbackArgs(callback_trigger=<CallbackTrigger.LAZY_BACKWARD: 2>, compile_id='1/0')
+end=CallbackArgs(callback_trigger=<CallbackTrigger.LAZY_BACKWARD: 2>, compile_id='1/0')
+start=CallbackArgs(callback_trigger=<CallbackTrigger.TRITON_AUTOTUNING: 3>, compile_id='1/0')
+end=CallbackArgs(callback_trigger=<CallbackTrigger.TRITON_AUTOTUNING: 3>, compile_id='1/0')
+start=CallbackArgs(callback_trigger=<CallbackTrigger.LAZY_BACKWARD: 2>, compile_id='0/0')
+end=CallbackArgs(callback_trigger=<CallbackTrigger.LAZY_BACKWARD: 2>, compile_id='0/0')
+start=CallbackArgs(callback_trigger=<CallbackTrigger.TRITON_AUTOTUNING: 3>, compile_id='0/0')
+end=CallbackArgs(callback_trigger=<CallbackTrigger.TRITON_AUTOTUNING: 3>, compile_id='0/0')""",  # noqa: B950
+        )
+        order.clear()
+
+        compiled_model.zero_grad()
+        loss = compiled_model(x).sum()
+        loss.backward()
+        self.assertExpectedInline(
+            "\n".join(order),
+            """\
+start=CallbackArgs(callback_trigger=<CallbackTrigger.CUDAGRAPH_RECORDING: 4>, compile_id='0/0')
+end=CallbackArgs(callback_trigger=<CallbackTrigger.CUDAGRAPH_RECORDING: 4>, compile_id='0/0')
+start=CallbackArgs(callback_trigger=<CallbackTrigger.CUDAGRAPH_RECORDING: 4>, compile_id='1/0')
+end=CallbackArgs(callback_trigger=<CallbackTrigger.CUDAGRAPH_RECORDING: 4>, compile_id='1/0')
+start=CallbackArgs(callback_trigger=<CallbackTrigger.CUDAGRAPH_RECORDING: 4>, compile_id='1/0')
+end=CallbackArgs(callback_trigger=<CallbackTrigger.CUDAGRAPH_RECORDING: 4>, compile_id='1/0')
+start=CallbackArgs(callback_trigger=<CallbackTrigger.CUDAGRAPH_RECORDING: 4>, compile_id='0/0')
+end=CallbackArgs(callback_trigger=<CallbackTrigger.CUDAGRAPH_RECORDING: 4>, compile_id='0/0')""",  # noqa: B950
+        )
+        order.clear()
+
+        compiled_model.zero_grad()
+        loss = compiled_model(x).sum()
+        loss.backward()
+        self.assertEqual(len(order), 0)
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_compile.py
+++ b/test/dynamo/test_compile.py
@@ -81,11 +81,11 @@ class InPlaceCompilationTests(TestCase):
         torch._dynamo.reset()
 
         @torch._dynamo.on_compile_start
-        def start_callback():
+        def start_callback(_):
             print("Compilation started.")
 
         @torch._dynamo.on_compile_end
-        def end_callback():
+        def end_callback(_):
             print("Compilation ended.")
 
         mod = ToyModel()
@@ -116,13 +116,13 @@ class InPlaceCompilationTests(TestCase):
         counter = 0
 
         @torch._dynamo.on_compile_start
-        def start_callback():
+        def start_callback(_):
             nonlocal counter
             counter += 1
             print(f"Counter = {counter}")
 
         @torch._dynamo.on_compile_end
-        def end_callback():
+        def end_callback(_):
             nonlocal counter
             counter += 1
             print(f"Counter = {counter}")

--- a/torch/_dynamo/callback.py
+++ b/torch/_dynamo/callback.py
@@ -25,6 +25,7 @@ Example usage:
         print("Compilation complete")
 """
 
+import enum
 import threading
 from collections.abc import Generator
 from contextlib import contextmanager
@@ -32,10 +33,27 @@ from dataclasses import dataclass, field  # noqa: F811
 from typing import Any, Callable
 
 
+class CallbackTrigger(enum.Enum):
+    # most common case, dynamo attempts to trace a new frame
+    DYNAMO = 1
+    # backward compilation can be deferred to runtime
+    LAZY_BACKWARD = 2
+    # some backends autotune at runtime
+    TRITON_AUTOTUNING = 3
+    # cudagraphs record at runtime
+    CUDAGRAPH_RECORDING = 4
+
+
+@dataclass
+class CallbackArgs:
+    callback_trigger: CallbackTrigger
+    compile_id: str
+
+
 @dataclass
 class CompilationCallbackHandler:
-    start_callbacks: list[Callable[[], None]] = field(default_factory=list)
-    end_callbacks: list[Callable[[], None]] = field(default_factory=list)
+    start_callbacks: list[Callable[[CallbackArgs], None]] = field(default_factory=list)
+    end_callbacks: list[Callable[[CallbackArgs], None]] = field(default_factory=list)
 
     __pending_callbacks_counter: int = field(default=0, init=False, repr=False)
     __pending_callbacks_counter_lock: threading.Lock = field(
@@ -43,8 +61,8 @@ class CompilationCallbackHandler:
     )
 
     def register_start_callback(
-        self, callback: Callable[[], None]
-    ) -> Callable[[], None]:
+        self, callback: Callable[[CallbackArgs], None]
+    ) -> Callable[[CallbackArgs], None]:
         """
         Register a callback function to be called when the compilation starts.
 
@@ -54,7 +72,9 @@ class CompilationCallbackHandler:
         self.start_callbacks.append(callback)
         return callback
 
-    def register_end_callback(self, callback: Callable[[], None]) -> Callable[[], None]:
+    def register_end_callback(
+        self, callback: Callable[[CallbackArgs], None]
+    ) -> Callable[[CallbackArgs], None]:
         """
         Register a callback function to be called when the compilation ends.
 
@@ -64,7 +84,7 @@ class CompilationCallbackHandler:
         self.end_callbacks.append(callback)
         return callback
 
-    def remove_start_callback(self, callback: Callable[[], None]) -> None:
+    def remove_start_callback(self, callback: Callable[[CallbackArgs], None]) -> None:
         """
         Remove a registered start callback function.
 
@@ -73,7 +93,7 @@ class CompilationCallbackHandler:
         """
         self.start_callbacks.remove(callback)
 
-    def remove_end_callback(self, callback: Callable[[], None]) -> None:
+    def remove_end_callback(self, callback: Callable[[CallbackArgs], None]) -> None:
         """
         Remove a registered end callback function.
 
@@ -82,29 +102,32 @@ class CompilationCallbackHandler:
         """
         self.end_callbacks.remove(callback)
 
-    def run_start_callbacks(self) -> None:
+    def run_start_callbacks(self, args: CallbackArgs) -> None:
         """
         Execute all registered start callbacks.
         """
         for callback in self.start_callbacks:
-            callback()
+            callback(args)
 
-    def run_end_callbacks(self) -> None:
+    def run_end_callbacks(self, args: CallbackArgs) -> None:
         """
         Execute all registered end callbacks.
         """
         for callback in self.end_callbacks:
-            callback()
+            callback(args)
 
     @contextmanager
-    def install_callbacks(self) -> Generator[None, Any, Any]:
+    def install_callbacks(
+        self, trigger: CallbackTrigger, compile_id: str
+    ) -> Generator[None, Any, Any]:
         """
         Context manager to install the callbacks and run them when the context is exited.
         """
+        args = CallbackArgs(trigger, compile_id)
         try:
             with self.__pending_callbacks_counter_lock:
                 if self.__pending_callbacks_counter == 0:
-                    self.run_start_callbacks()
+                    self.run_start_callbacks(args)
                 self.__pending_callbacks_counter += 1
             yield
         finally:
@@ -113,7 +136,7 @@ class CompilationCallbackHandler:
                     "Pending callbacks counter cannot become negative."
                 )
                 if self.__pending_callbacks_counter == 1:
-                    self.run_end_callbacks()
+                    self.run_end_callbacks(args)
                 self.__pending_callbacks_counter -= 1
 
     def clear(self) -> None:
@@ -122,12 +145,15 @@ class CompilationCallbackHandler:
         """
         self.start_callbacks.clear()
         self.end_callbacks.clear()
+        assert self.__pending_callbacks_counter == 0
 
 
 callback_handler = CompilationCallbackHandler()
 
 
-def on_compile_start(callback: Callable[[], None]) -> Callable[[], None]:
+def on_compile_start(
+    callback: Callable[[CallbackArgs], None],
+) -> Callable[[CallbackArgs], None]:
     """
     Decorator to register a callback function for the start of the compilation.
     """
@@ -135,7 +161,9 @@ def on_compile_start(callback: Callable[[], None]) -> Callable[[], None]:
     return callback
 
 
-def on_compile_end(callback: Callable[[], None]) -> Callable[[], None]:
+def on_compile_end(
+    callback: Callable[[CallbackArgs], None],
+) -> Callable[[CallbackArgs], None]:
     """
     Decorator to register a callback function for the end of the compilation.
     """

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -48,6 +48,7 @@ from weakref import ReferenceType
 import torch
 import torch._logging
 from torch._C._dynamo.guards import GlobalStateGuard
+from torch._dynamo.callback import CallbackTrigger
 from torch._dynamo.distributed import get_compile_pg
 from torch._dynamo.symbolic_convert import TensorifyState
 from torch._guards import compile_context, CompileContext, CompileId, tracing
@@ -774,7 +775,11 @@ def _compile(
         transform: Callable[[list[Instruction], dict[str, Any]], Any],
     ) -> ConvertFrameReturn:
         with contextlib.ExitStack() as stack:
-            stack.enter_context(torch._dynamo.callback_handler.install_callbacks())
+            stack.enter_context(
+                torch._dynamo.callback_handler.install_callbacks(
+                    CallbackTrigger.DYNAMO, str(CompileContext.current_compile_id())
+                )
+            )
             stack.enter_context(CompileTimeInstructionCounter.record())
             return _compile_inner(code, one_graph, hooks, transform)
 

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -20,6 +20,7 @@ from typing import Any, Callable, Optional, TYPE_CHECKING, Union
 import torch
 import torch.utils.dlpack
 from torch import Tensor
+from torch._dynamo.callback import callback_handler, CallbackTrigger
 from torch._dynamo.utils import CompileEventLogger, dynamo_timed, get_metrics_context
 from torch._guards import (
     compile_context,
@@ -2290,6 +2291,9 @@ To fix this, your tensor subclass must implement the dunder method __force_to_sa
                         dynamo_compile_column_us="backward_cumulative_compile_time_us",
                         log_waitcounter=True,
                         waitcounter_name_override="entire_backward_compile",
+                    ), callback_handler.install_callbacks(
+                        CallbackTrigger.LAZY_BACKWARD,
+                        str(CompileContext.current_compile_id()),
                     ):
                         CompileEventLogger.compilation_metric(is_forward=False)
                         # See Note: [Backward graph lazy lowering]

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -346,6 +346,7 @@ class AsyncCompile:
             else:
                 return future.result()
 
+        # Cache miss
         if is_parallel:
             # We want to support changing these env vars after (and while) the
             # process pool is running, so pass them to the subprocess to reset.

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -707,7 +707,6 @@ def compile_fx_inner(
                 dynamo_compile_column_us="inductor_cumulative_compile_time_us",
             )
         )
-        stack.enter_context(torch._dynamo.callback_handler.install_callbacks())
         stack.enter_context(with_fresh_cache_if_config())
         stack.enter_context(DebugContext())
         CompileEventLogger.pt2_compile(

--- a/torch/_inductor/runtime/runtime_utils.py
+++ b/torch/_inductor/runtime/runtime_utils.py
@@ -5,6 +5,9 @@ import operator
 from typing import Any, TYPE_CHECKING
 
 import torch
+
+# NOTE: other files rely on the imports below
+from torch._dynamo import callback as compilation_callback  # noqa: F401
 from torch._inductor.runtime.cache_dir_utils import (  # noqa: F401
     cache_dir,
     default_cache_dir,

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -52,6 +52,7 @@ from .hints import (
 )
 from .runtime_utils import (
     ceildiv,
+    compilation_callback,
     conditional_product,
     create_bandwidth_info_str,
     dynamo_timed,
@@ -914,15 +915,21 @@ class CachingAutotuner(KernelInterface):
         return self.maybe_clone_args(OrderedSet(), *args, **kwargs)
 
     def benchmark_all_configs(self, *args, **kwargs):
-        with dynamo_timed(
-            "CachingAutotuner.benchmark_all_configs",
-            log_pt2_compile_event=True,
-            metadata={"kernel_name": self.inductor_meta.get("kernel_name")},
-            dynamo_compile_column_us="runtime_triton_autotune_time_us",
-            compile_id=self.compile_id,
-            is_backward=self.is_backward,
-            log_waitcounter=True,
-            waitcounter_name_override="triton_autotuner",
+        with (
+            dynamo_timed(
+                "CachingAutotuner.benchmark_all_configs",
+                log_pt2_compile_event=True,
+                metadata={"kernel_name": self.inductor_meta.get("kernel_name")},
+                dynamo_compile_column_us="runtime_triton_autotune_time_us",
+                compile_id=self.compile_id,
+                is_backward=self.is_backward,
+                log_waitcounter=True,
+                waitcounter_name_override="triton_autotuner",
+            ),
+            compilation_callback.callback_handler.install_callbacks(
+                compilation_callback.CallbackTrigger.TRITON_AUTOTUNING,
+                str(self.compile_id),
+            ),
         ):
             timings = {
                 launcher: self.bench(launcher, *args, **kwargs)


### PR DESCRIPTION
Originally https://github.com/pytorch/pytorch/pull/153596
---------------

Summary:
via reverting D75708685

gate the ROCm failure

Test Plan:
Unit tests in OSS, sandcastle

Rollback Plan:

Bifferential Revision: D75894349




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov