### PR TITLE
Fix docstring for `torch.UntypedStorage.from_file`

### DIFF
--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -3205,7 +3205,7 @@ class TestTensorCreation(TestCase):
             self.assertTrue(t_mapped.untyped_storage().filename == expected_filename)
             self.assertEqual(torch.flatten(t), t_mapped)
 
-            s = torch.UntypedStorage.from_file(f.name, shared, t.numel() * dtype.itemsize)
+            s = torch.UntypedStorage.from_file(f.name, shared, nbytes=t.numel() * dtype.itemsize)
             self.assertTrue(s.filename == expected_filename)
 
     @onlyCPU

--- a/torch/_storage_docs.py
+++ b/torch/_storage_docs.py
@@ -20,7 +20,7 @@ def add_docstr_all(method, docstr):
 add_docstr_all(
     "from_file",
     """
-from_file(filename, shared=False, size=0) -> Storage
+from_file(filename, shared=False, nbytes=0) -> Storage
 
 Creates a CPU storage backed by a memory-mapped file.
 
@@ -28,15 +28,15 @@ If ``shared`` is ``True``, then memory is shared between all processes.
 All changes are written to the file. If ``shared`` is ``False``, then the changes on
 the storage do not affect the file.
 
-``size`` is the number of elements in the storage. If ``shared`` is ``False``,
-then the file must contain at least ``size * sizeof(Type)`` bytes
-(``Type`` is the type of storage, in the case of an ``UnTypedStorage`` the file must contain at
-least ``size`` bytes). If ``shared`` is ``True`` the file will be created if needed.
+``nbytes`` is the number of bytes of storage. If ``shared`` is ``False``,
+then the file must contain at least ``nbytes`` bytes. If ``shared`` is
+``True`` the file will be created if needed. (Note that for ``UntypedStorage``
+this argument differs from that of ``TypedStorage.from_file``)
 
 Args:
     filename (str): file name to map
     shared (bool): whether to share memory (whether ``MAP_SHARED`` or ``MAP_PRIVATE`` is passed to the
                     underlying `mmap(2) call <https://man7.org/linux/man-pages/man2/mmap.2.html>`_)
-    size (int): number of elements in the storage
+    nbytes (int): number of bytes of storage
 """,
 )


### PR DESCRIPTION
Fixes #130629

Happy to revert the second commit if we think it's making the test too fragile for the future

cc @svekars @sekyondaMeta @AlannaBurke