### PR TITLE
Update gradient behavior note in torch.amin and torch.amax

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -6648,7 +6648,7 @@ dimension(s) :attr:`dim`.
     The difference between ``max``/``min`` and ``amax``/``amin`` is:
         - ``amax``/``amin`` supports reducing on multiple dimensions,
         - ``amax``/``amin`` does not return indices.
-        
+
     Both ``max``/``min`` and ``amax``/``amin`` evenly distribute gradients between equal values
     when there are multiple input elements with the same minimum or maximum value.
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -6648,6 +6648,7 @@ dimension(s) :attr:`dim`.
     The difference between ``max``/``min`` and ``amax``/``amin`` is:
         - ``amax``/``amin`` supports reducing on multiple dimensions,
         - ``amax``/``amin`` does not return indices.
+        
     Both ``max``/``min`` and ``amax``/``amin`` evenly distribute gradients between equal values
     when there are multiple input elements with the same minimum or maximum value.
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -6648,9 +6648,8 @@ dimension(s) :attr:`dim`.
     The difference between ``max``/``min`` and ``amax``/``amin`` is:
         - ``amax``/``amin`` supports reducing on multiple dimensions,
         - ``amax``/``amin`` does not return indices,
-        - ``amax``/``amin`` evenly distributes gradient between equal values,
-          while ``max(dim)``/``min(dim)`` propagates gradient only to a single
-          index in the source tensor.
+        - ``amax``, ``amin``, ``max(dim)``,``min(dim)` evenly distributes gradient between equal values 
+        when there are multiple input elements with the same minimum or maximum value.
 
 {keepdim_details}
 
@@ -7256,9 +7255,8 @@ dimension(s) :attr:`dim`.
     The difference between ``max``/``min`` and ``amax``/``amin`` is:
         - ``amax``/``amin`` supports reducing on multiple dimensions,
         - ``amax``/``amin`` does not return indices,
-        - ``amax``/``amin`` evenly distributes gradient between equal values,
-          while ``max(dim)``/``min(dim)`` propagates gradient only to a single
-          index in the source tensor.
+        - ``amax``, ``amin``, ``max(dim)``,``min(dim)` evenly distributes gradient between equal values 
+        when there are multiple input elements with the same minimum or maximum value.
 
 {keepdim_details}
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -6648,7 +6648,7 @@ dimension(s) :attr:`dim`.
     The difference between ``max``/``min`` and ``amax``/``amin`` is:
         - ``amax``/``amin`` supports reducing on multiple dimensions,
         - ``amax``/``amin`` does not return indices,
-        - ``amax``, ``amin``, ``max(dim)``,``min(dim)` evenly distributes gradient between equal values 
+        - ``amax``, ``amin``, ``max(dim)``, ``min(dim)` evenly distributes gradient between equal values 
         when there are multiple input elements with the same minimum or maximum value.
 
 {keepdim_details}
@@ -7255,7 +7255,7 @@ dimension(s) :attr:`dim`.
     The difference between ``max``/``min`` and ``amax``/``amin`` is:
         - ``amax``/``amin`` supports reducing on multiple dimensions,
         - ``amax``/``amin`` does not return indices,
-        - ``amax``, ``amin``, ``max(dim)``,``min(dim)` evenly distributes gradient between equal values 
+        - ``amax``, ``amin``, ``max(dim)``, ``min(dim)` evenly distributes gradient between equal values 
         when there are multiple input elements with the same minimum or maximum value.
 
 {keepdim_details}

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -6647,9 +6647,10 @@ dimension(s) :attr:`dim`.
 .. note::
     The difference between ``max``/``min`` and ``amax``/``amin`` is:
         - ``amax``/``amin`` supports reducing on multiple dimensions,
-        - ``amax``/``amin`` does not return indices,
-        - ``amax``, ``amin``, ``max(dim)``, ``min(dim)` evenly distributes gradient between equal values 
-        when there are multiple input elements with the same minimum or maximum value.
+        - ``amax``/``amin`` does not return indices.
+
+    Both ``max``/``min`` and ``amax``/``amin`` evenly distribute gradients between equal values
+    when there are multiple input elements with the same minimum or maximum value.
 
 {keepdim_details}
 
@@ -7254,9 +7255,10 @@ dimension(s) :attr:`dim`.
 .. note::
     The difference between ``max``/``min`` and ``amax``/``amin`` is:
         - ``amax``/``amin`` supports reducing on multiple dimensions,
-        - ``amax``/``amin`` does not return indices,
-        - ``amax``, ``amin``, ``max(dim)``, ``min(dim)` evenly distributes gradient between equal values 
-        when there are multiple input elements with the same minimum or maximum value.
+        - ``amax``/``amin`` does not return indices.
+        
+    Both ``max``/``min`` and ``amax``/``amin`` evenly distribute gradients between equal values
+    when there are multiple input elements with the same minimum or maximum value.
 
 {keepdim_details}
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -6648,7 +6648,6 @@ dimension(s) :attr:`dim`.
     The difference between ``max``/``min`` and ``amax``/``amin`` is:
         - ``amax``/``amin`` supports reducing on multiple dimensions,
         - ``amax``/``amin`` does not return indices.
-
     Both ``max``/``min`` and ``amax``/``amin`` evenly distribute gradients between equal values
     when there are multiple input elements with the same minimum or maximum value.
 
@@ -7256,7 +7255,7 @@ dimension(s) :attr:`dim`.
     The difference between ``max``/``min`` and ``amax``/``amin`` is:
         - ``amax``/``amin`` supports reducing on multiple dimensions,
         - ``amax``/``amin`` does not return indices.
-        
+
     Both ``max``/``min`` and ``amax``/``amin`` evenly distribute gradients between equal values
     when there are multiple input elements with the same minimum or maximum value.
 


### PR DESCRIPTION
Fixes #155048

The behavior of `min` and `max` were changed in #43519. The note about gradient behavior in torch.amin and torch.amax docs are updated to reflect this change:

New note:
`amax, amin, max(dim), min(dim) evenly distributes gradient between equal values 
        when there are multiple input elements with the same minimum or maximum value.`


cc - @spzala @svekars @soulitzer @sekyondaMeta @AlannaBurke @ezyang @gqchen @nikitaved @Varal7 @xmfan