### PR TITLE
[ROCm][TunableOp] Unit test to verify that there is only one kernel launch per PyTorch API invocation.

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5947,8 +5947,7 @@ class TestLinalg(TestCase):
             batch_C = torch.bmm(batch_A, batch_A)
 
             kernel_count = 0
-            with profile(
-                activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
+            with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
                 C = torch.mm(A, A)
                 Y = torch.nn.functional.linear(X, A, bias)
                 batch_C = torch.bmm(batch_A, batch_A)


### PR DESCRIPTION
TunableOp UT covers breakage that was fixed in this PR: https://github.com/pytorch/pytorch/pull/153764

After tuning is complete, verify that there is only one kernel launch. for each PyTorch API invocation 

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang