### PR TITLE
[ca] cpp tensor pre hooks

### DIFF
--- a/torch/csrc/autograd/cpp_hook.h
+++ b/torch/csrc/autograd/cpp_hook.h
@@ -12,6 +12,9 @@ struct CppFunctionTensorPreHook : public FunctionPreHook {
   CppFunctionTensorPreHook(std::shared_ptr<hooks_list> hooks, size_t value_idx);
   variable_list operator()(const variable_list& values) override;
 
+  void compiled_args(
+      torch::dynamo::autograd::CompiledNodeArgs& args) const override;
+
   std::shared_ptr<hooks_list> hooks_;
   size_t value_idx_;
 };


### PR DESCRIPTION
Support was added for CppFunctionSingleTensorPreHook back in https://github.com/pytorch/pytorch/pull/149987, this extends it to all CppFunctionTensorPreHook.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #155082
* #155370
* #155289

