### PR TITLE
Fix weight tensor documentation #134896

### DIFF
--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -1215,7 +1215,7 @@ class CrossEntropyLoss(_WeightedLoss):
 
     Args:
         weight (Tensor, optional): a manual rescaling weight given to each class.
-            If given, has to be a Tensor of size `C` and floating point dtype
+            If given, has to be a Tensor of size `C`.
         size_average (bool, optional): Deprecated (see :attr:`reduction`). By default,
             the losses are averaged over each loss element in the batch. Note that for
             some losses, there are multiple elements per sample. If the field :attr:`size_average`


### PR DESCRIPTION
Fixes #134896


## Description

Remove line about 'weight' tensor needing to be of floating point type. 

cc @svekars @sekyondaMeta @AlannaBurke