### PR TITLE
docs: link to Nvidia Container Toolkit in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,8 @@ ccmake build  # or cmake-gui build
 
 #### Using pre-built images
 
-You can also pull a pre-built docker image from Docker Hub and run with docker v19.03+
+You can also pull a pre-built docker image from Docker Hub and run with docker v19.03+ 
+(requires the [Nvidia Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) being installed when using Linux distributions).
 
 ```bash
 docker run --gpus all --rm -ti --ipc=host pytorch/pytorch:latest


### PR DESCRIPTION
The Nvidia Container Toolkit is needed on Linux Distributions to properly run Docker images with --gpus flag.

The dependency is OS-level and cannot be pinned from within the container.

Otherwise containers will not run and provide and ambiguous error message

```shell
docker: Error response from daemon: could not select device driver "" with capabilities: [[gpu]].
```

