### PR TITLE
SDPA support gfx950

### DIFF
--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/launch_kernel_pt.hpp
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/launch_kernel_pt.hpp
@@ -14,7 +14,7 @@ __launch_bounds__(MaxThreadPerBlock, MinBlockPerCu)
 #endif
     __global__ void kentry_pt(Args... args)
 {
-#if (defined(__gfx90a__) || defined(__gfx942__))
+#if (defined(__gfx90a__) || defined(__gfx942__) || defined(__gfx950__))
     Kernel{}(args...);
 #else
     CUDA_KERNEL_ASSERT(false && "Fatal! Attempting to call a CK SDPA kernel on unsupported hardware");


### PR DESCRIPTION
Summary: Seems to run, just not the optimal performance. e.g. ck_tile doesn't have those gfx942 optimizations it seems https://github.com/ROCm/composable_kernel/blob/develop/include/ck_tile/ops/fmha/block/variants.hpp#L27

Test Plan:
```
+--------------+-------------------+---------+------------+-------------------+---------------------+------------------+------------------+----------------------+----------------+------------------+---------------+---------------+-------------------+------------------------+-------------------------+-----------------------+---------------------------+----------------------+-------------------+
|   Batch Size |   Sequence Length |   Heads |   Head Dim |   Flash Time (µs) |   Mem Eff Time (µs) |   Math Time (µs) |   Flex Time (µs) |   xformers Time (µs) |   Flash TFlops |   Mem Eff TFlops |   Math TFlops |   Flex TFlops |   xformers TFlops |   Speedup (Flash/Math) |   Speedup (MemEff/Math) |   Speedup (Flex/Math) |   Speedup (xformers/Math) | xformers trace_url   | Flash trace_url   |
+==============+===================+=========+============+===================+=====================+==================+==================+======================+================+==================+===============+===============+===================+========================+=========================+=======================+===========================+======================+===================+
|            1 |              4096 |      16 |         64 |           179.737 |             182.874 |          3106.6  |          359.662 |              205.506 |        382.334 |          375.776 |       22.1205 |       191.067 |           334.392 |                17.2841 |                 16.9877 |               8.63754 |                   15.1169 |                      |                   |
+--------------+-------------------+---------+------------+-------------------+---------------------+------------------+------------------+----------------------+----------------+------------------+---------------+---------------+-------------------+------------------------+-------------------------+-----------------------+---------------------------+----------------------+-------------------+
|            1 |              4096 |      32 |        128 |           617.271 |             623.38  |          7169.73 |          998.961 |              654.534 |        445.312 |          440.947 |       38.3387 |       275.164 |           419.96  |                11.6152 |                 11.5014 |               7.17719 |                   10.9539 |                      |                   |
+--------------+-------------------+---------+------------+-------------------+---------------------+------------------+------------------+----------------------+----------------+------------------+---------------+---------------+-------------------+------------------------+-------------------------+-----------------------+---------------------------+----------------------+-------------------+
|            1 |              8192 |      16 |         64 |           667.032 |             670.118 |         13031.8  |         1383.42  |              768.452 |        412.091 |          410.193 |       21.0928 |       198.694 |           357.703 |                19.5371 |                 19.4471 |               9.42    |                   16.9586 |                      |                   |
+--------------+-------------------+---------+------------+-------------------+---------------------+------------------+------------------+----------------------+----------------+------------------+---------------+---------------+-------------------+------------------------+-------------------------+-----------------------+---------------------------+----------------------+-------------------+
|            1 |              8192 |      32 |        128 |          2074.64  |            2214.81  |         29186.9  |         3916.35  |             2404.29  |        529.978 |          496.437 |       37.6714 |       280.749 |           457.313 |                14.0684 |                 13.1781 |               7.45257 |                   12.1395 |                      |                   |
+--------------+-------------------+---------+------------+-------------------+---------------------+------------------+------------------+----------------------+----------------+------------------+---------------+---------------+-------------------+------------------------+-------------------------+-----------------------+---------------------------+----------------------+-------------------+
|            1 |             16384 |      16 |         64 |          2456.6   |            2472.38  |         51095.8  |         5647.01  |             3008.09  |        447.574 |          444.718 |       21.5186 |       194.707 |           365.518 |                20.7994 |                 20.6666 |               9.0483  |                   16.9861 |                      |                   |
+--------------+-------------------+---------+------------+-------------------+---------------------+------------------+------------------+----------------------+----------------+------------------+---------------+---------------+-------------------+------------------------+-------------------------+-----------------------+---------------------------+----------------------+-------------------+
|            1 |             16384 |      32 |        128 |          8048.8   |            8070.96  |        113478    |        15580.8   |             9768.71  |        546.423 |          544.922 |       38.7569 |       282.274 |           450.218 |                14.0987 |                 14.06   |               7.2832  |                   11.6165 |                      |                   |
+--------------+-------------------+---------+------------+-------------------+---------------------+------------------+------------------+----------------------+----------------+------------------+---------------+---------------+-------------------+------------------------+-------------------------+-----------------------+---------------------------+----------------------+-------------------+
+--------------+-------------------+---------+------------+-------------------+---------------------+------------------+------------------+----------------------+----------------+------------------+---------------+---------------+-------------------+------------------------+-------------------------+-----------------------+---------------------------+----------------------+-------------------+
|   Batch Size |   Sequence Length |   Heads |   Head Dim |   Flash Time (µs) |   Mem Eff Time (µs) |   Math Time (µs) |   Flex Time (µs) |   xformers Time (µs) |   Flash TFlops |   Mem Eff TFlops |   Math TFlops |   Flex TFlops |   xformers TFlops |   Speedup (Flash/Math) |   Speedup (MemEff/Math) |   Speedup (Flex/Math) |   Speedup (xformers/Math) | xformers trace_url   | Flash trace_url   |
+==============+===================+=========+============+===================+=====================+==================+==================+======================+================+==================+===============+===============+===================+========================+=========================+=======================+===========================+======================+===================+
|            1 |              4096 |      16 |         64 |           692.323 |             697.649 |          4241.81 |          1562.26 |              906.441 |        248.148 |          246.254 |       40.5012 |      109.968  |           189.531 |                6.12693 |                 6.08015 |               2.71518 |                   4.67963 |                      |                   |
+--------------+-------------------+---------+------------+-------------------+---------------------+------------------+------------------+----------------------+----------------+------------------+---------------+---------------+-------------------+------------------------+-------------------------+-----------------------+---------------------------+----------------------+-------------------+
|            1 |              4096 |      32 |        128 |          2263.22  |            2267.38  |          9482.64 |          7003.8  |             2765.5   |        303.636 |          303.079 |       72.4687 |       98.1174 |           248.489 |                4.1899  |                 4.18221 |               1.35393 |                   3.42891 |                      |                   |
+--------------+-------------------+---------+------------+-------------------+---------------------+------------------+------------------+----------------------+----------------+------------------+---------------+---------------+-------------------+------------------------+-------------------------+-----------------------+---------------------------+----------------------+-------------------+
|            1 |              8192 |      16 |         64 |          2553.94  |            2572.68  |         15909.8  |          5697.16 |             3284.77  |        269.073 |          267.112 |       43.193  |      120.621  |           209.206 |                6.22953 |                 6.18415 |               2.79259 |                   4.84352 |                      |                   |
+--------------+-------------------+---------+------------+-------------------+---------------------+------------------+------------------+----------------------+----------------+------------------+---------------+---------------+-------------------+------------------------+-------------------------+-----------------------+---------------------------+----------------------+-------------------+
|            1 |              8192 |      32 |        128 |          8187.67  |            8201.71  |         35449.2  |         26424.3  |            10364.5   |        335.722 |          335.147 |       77.5413 |      104.025  |           265.21  |                4.32959 |                 4.32218 |               1.34154 |                   3.42025 |                      |                   |
+--------------+-------------------+---------+------------+-------------------+---------------------+------------------+------------------+----------------------+----------------+------------------+---------------+---------------+-------------------+------------------------+-------------------------+-----------------------+---------------------------+----------------------+-------------------+
|            1 |             16384 |      16 |         64 |          9948.15  |            9815.47  |         62815.1  |         23741.9  |            12710     |        276.31  |          280.046 |       43.7598 |      115.778  |           216.269 |                6.31425 |                 6.39961 |               2.64575 |                   4.94217 |                      |                   |
+--------------+-------------------+---------+------------+-------------------+---------------------+------------------+------------------+----------------------+----------------+------------------+---------------+---------------+-------------------+------------------------+-------------------------+-----------------------+---------------------------+----------------------+-------------------+
|            1 |             16384 |      32 |        128 |         32187.6   |           32035.6   |        137832    |        102075    |            40623.4   |        341.595 |          343.216 |       79.7716 |      107.716  |           270.66  |                4.28216 |                 4.30248 |               1.35031 |                   3.39293 |                      |                   |
+--------------+-------------------+---------+------------+-------------------+---------------------+------------------+------------------+----------------------+----------------+------------------+---------------+---------------+-------------------+------------------------+-------------------------+-----------------------+---------------------------+----------------------+-------------------+

```

Rollback Plan:

Differential Revision: D75934358


