### PR TITLE
[docs] Decorator to create a deprecation warning

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -20,7 +20,7 @@ import torch.nn as nn
 import torch.utils.cpp_extension
 import torch.utils.data
 from torch._utils import try_import
-from torch._utils_internal import deprecate
+from torch._utils_internal import deprecated
 from torch.autograd._functions.utils import check_onnx_broadcast
 from torch.onnx.symbolic_opset9 import _prepare_onnx_paddings
 from torch.testing._internal.common_cuda import TEST_MULTIGPU
@@ -1201,7 +1201,7 @@ class TestTryImport(TestCase):
         self.assertIsNone(missing_module)
 
 
-@deprecate()
+@deprecated()
 def _deprecated_api(x, y=15):
     return x + y
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -20,6 +20,7 @@ import torch.nn as nn
 import torch.utils.cpp_extension
 import torch.utils.data
 from torch._utils import try_import
+from torch._utils_internal import deprecate
 from torch.autograd._functions.utils import check_onnx_broadcast
 from torch.onnx.symbolic_opset9 import _prepare_onnx_paddings
 from torch.testing._internal.common_cuda import TEST_MULTIGPU
@@ -59,6 +60,9 @@ HAS_CUDA = torch.cuda.is_available()
 
 
 from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+# mypy: disable-error-code="name-defined"
 
 
 class RandomDatasetMock(torch.utils.data.Dataset):
@@ -1195,6 +1199,31 @@ class TestTryImport(TestCase):
     def test_import_missing(self):
         missing_module = try_import("missing_module")
         self.assertIsNone(missing_module)
+
+
+@deprecate("2.0")
+def _deprecated_api(x, y=15):
+    return x + y
+
+
+class TestDeprecate(TestCase):
+    def test_deprecated(self):
+        with self.assertWarnsRegex(
+            DeprecationWarning, "is deprecated and will be removed in version 2.0"
+        ):
+            _deprecated_api(1, 2)
+        with self.assertWarnsRegex(
+            DeprecationWarning, "is deprecated and will be removed in version 2.0"
+        ):
+            _deprecated_api(1, y=2)
+        with self.assertWarnsRegex(
+            DeprecationWarning, "is deprecated and will be removed in version 2.0"
+        ):
+            deprecated_api(1, 2)  # noqa: F821
+        with self.assertWarnsRegex(
+            DeprecationWarning, "is deprecated and will be removed in version 2.0"
+        ):
+            deprecated_api(1, y=2)  # noqa: F821
 
 
 if __name__ == "__main__":

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1201,29 +1201,19 @@ class TestTryImport(TestCase):
         self.assertIsNone(missing_module)
 
 
-@deprecate("2.0")
+@deprecate()
 def _deprecated_api(x, y=15):
     return x + y
 
 
 class TestDeprecate(TestCase):
     def test_deprecated(self):
-        with self.assertWarnsRegex(
-            DeprecationWarning, "is deprecated and will be removed in version 2.0"
-        ):
-            _deprecated_api(1, 2)
-        with self.assertWarnsRegex(
-            DeprecationWarning, "is deprecated and will be removed in version 2.0"
-        ):
-            _deprecated_api(1, y=2)
-        with self.assertWarnsRegex(
-            DeprecationWarning, "is deprecated and will be removed in version 2.0"
-        ):
+        with self.assertWarnsRegex(Warning, "is DEPRECATED"):
             deprecated_api(1, 2)  # noqa: F821
-        with self.assertWarnsRegex(
-            DeprecationWarning, "is deprecated and will be removed in version 2.0"
-        ):
+        with self.assertWarnsRegex(Warning, "is DEPRECATED"):
             deprecated_api(1, y=2)  # noqa: F821
+        _deprecated_api(1, 2)
+        _deprecated_api(1, y=2)
 
 
 if __name__ == "__main__":

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -4,6 +4,7 @@ import logging
 import os
 import sys
 import tempfile
+import warnings
 from typing import Any, Callable, Optional, TypeVar
 from typing_extensions import ParamSpec
 
@@ -282,3 +283,62 @@ def record_chromium_event_internal(
 
 def profiler_allow_cudagraph_cupti_lazy_reinit_cuda12():
     return True
+
+
+def deprecate(version: str):
+    """Decorator that deprecates functions at a specified version.
+
+    Effects:
+    1) Emits a deprecation warning when function is called
+    2) Creates a public alias without the leading underscore
+
+    Args:
+        version: The version when the function will be removed
+    """
+
+    def decorator(func: Callable[_P, _T]) -> Callable[_P, _T]:
+        # Validate naming convention – single leading underscore, not dunder
+        if not (func.__name__.startswith("_")):
+            raise ValueError(
+                "@deprecate must decorate a function whose name "
+                "starts with a single leading underscore (e.g. '_foo') as the api should be considered internal before deprecation."
+            )
+
+        public_name = func.__name__[1:]  # drop exactly one leading underscore
+        module = sys.modules[func.__module__]
+
+        # Don't clobber an existing symbol accidentally.
+        if hasattr(module, public_name):
+            raise RuntimeError(
+                f"Cannot create alias '{public_name}' -> symbol already exists in {module.__name__}. \
+                 Please rename it or consult a pytorch developer on what to do"
+            )
+
+        warning_msg = (
+            f"{func.__name__} is deprecated and will be removed in version {version}. "
+        )
+
+        # public alias
+        @functools.wraps(func)
+        def alias(*args: _P.args, **kwargs: _P.kwargs):  # type: ignore[misc]
+            warnings.warn(warning_msg, DeprecationWarning, stacklevel=2)
+            return func(*args, **kwargs)
+
+        alias.__name__ = public_name
+
+        # Adjust qualname if nested inside a class or another function
+        if "." in func.__qualname__:
+            alias.__qualname__ = func.__qualname__.rsplit(".", 1)[0] + "." + public_name
+        else:
+            alias.__qualname__ = public_name
+
+        setattr(module, public_name, alias)
+
+        @functools.wraps(func)
+        def wrapper(*args: _P.args, **kwargs: _P.kwargs):  # type: ignore[misc]
+            warnings.warn(warning_msg, DeprecationWarning, stacklevel=2)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -6,10 +6,10 @@ import sys
 import tempfile
 import warnings
 from typing import Any, Callable, Optional, TypeVar
-from typing_extensions import ParamSpec
 
 import torch
 from torch._strobelight.compile_time_profiler import StrobelightCompileTimeProfiler
+from typing_extensions import ParamSpec
 
 
 _T = TypeVar("_T")
@@ -285,15 +285,12 @@ def profiler_allow_cudagraph_cupti_lazy_reinit_cuda12():
     return True
 
 
-def deprecate(version: str):
-    """Decorator that deprecates functions at a specified version.
+def deprecate():
+    """Decorator that deprecates functions.
 
     Effects:
     1) Emits a deprecation warning when function is called
     2) Creates a public alias without the leading underscore
-
-    Args:
-        version: The version when the function will be removed
     """
 
     def decorator(func: Callable[_P, _T]) -> Callable[_P, _T]:
@@ -301,7 +298,7 @@ def deprecate(version: str):
         if not (func.__name__.startswith("_")):
             raise ValueError(
                 "@deprecate must decorate a function whose name "
-                "starts with a single leading underscore (e.g. '_foo') as the api should be considered internal before deprecation."
+                "starts with a single leading underscore (e.g. '_foo') as the api should be considered internal for deprecation."
             )
 
         public_name = func.__name__[1:]  # drop exactly one leading underscore
@@ -314,14 +311,12 @@ def deprecate(version: str):
                  Please rename it or consult a pytorch developer on what to do"
             )
 
-        warning_msg = (
-            f"{func.__name__} is deprecated and will be removed in version {version}. "
-        )
+        warning_msg = f"{func.__name__} is DEPRECATED, please consider using an alternative API(s). "
 
-        # public alias
+        # public deprecated alias
         @functools.wraps(func)
         def alias(*args: _P.args, **kwargs: _P.kwargs):  # type: ignore[misc]
-            warnings.warn(warning_msg, DeprecationWarning, stacklevel=2)
+            warnings.warn(warning_msg, UserWarning, stacklevel=2)
             return func(*args, **kwargs)
 
         alias.__name__ = public_name
@@ -336,7 +331,6 @@ def deprecate(version: str):
 
         @functools.wraps(func)
         def wrapper(*args: _P.args, **kwargs: _P.kwargs):  # type: ignore[misc]
-            warnings.warn(warning_msg, DeprecationWarning, stacklevel=2)
             return func(*args, **kwargs)
 
         return wrapper

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -6,10 +6,10 @@ import sys
 import tempfile
 import warnings
 from typing import Any, Callable, Optional, TypeVar
+from typing_extensions import ParamSpec
 
 import torch
 from torch._strobelight.compile_time_profiler import StrobelightCompileTimeProfiler
-from typing_extensions import ParamSpec
 
 
 _T = TypeVar("_T")
@@ -285,7 +285,7 @@ def profiler_allow_cudagraph_cupti_lazy_reinit_cuda12():
     return True
 
 
-def deprecate():
+def deprecated():
     """Decorator that deprecates functions.
 
     Effects:

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -4,7 +4,7 @@ import logging
 import os
 import sys
 import tempfile
-import warnings
+import typing_extensions
 from typing import Any, Callable, Optional, TypeVar
 from typing_extensions import ParamSpec
 
@@ -314,10 +314,9 @@ def deprecated():
         warning_msg = f"{func.__name__} is DEPRECATED, please consider using an alternative API(s). "
 
         # public deprecated alias
-        @functools.wraps(func)
-        def alias(*args: _P.args, **kwargs: _P.kwargs):  # type: ignore[misc]
-            warnings.warn(warning_msg, UserWarning, stacklevel=2)
-            return func(*args, **kwargs)
+        alias = typing_extensions.deprecated(
+            warning_msg, category=UserWarning, stacklevel=2
+        )(func)
 
         alias.__name__ = public_name
 

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -286,10 +286,10 @@ def profiler_allow_cudagraph_cupti_lazy_reinit_cuda12():
 
 
 def deprecated():
-    """Decorator that deprecates functions. When we deprecate a funciton, we make it internal by adding a leading underscore.
+    """When we deprecate a funciton, we make it internal by adding a leading underscore.
     This decorator is used with a private function, and creates a public alias without the leading underscore, but has a deprecation warning.
-    This tells users to use something else without breaking them, however, 
-    if they still really really want to use the deprecated function, they can do so by using the internal function name.
+    This tells users "THIS FUNCTION IS DEPRECATED, please use something else" without breaking them, however, 
+    if they still really really want to use the deprecated function without the warning, they can do so by using the internal function name.
     """
 
     def decorator(func: Callable[_P, _T]) -> Callable[_P, _T]:

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -286,7 +286,7 @@ def profiler_allow_cudagraph_cupti_lazy_reinit_cuda12():
 
 
 def deprecated():
-    """When we deprecate a funciton, we make it internal by adding a leading underscore.
+    """When we deprecate a function that might still be in use, we make it internal by adding a leading underscore.
     This decorator is used with a private function, and creates a public alias without the leading underscore, but has a deprecation warning.
     This tells users "THIS FUNCTION IS DEPRECATED, please use something else" without breaking them, however, 
     if they still really really want to use the deprecated function without the warning, they can do so by using the internal function name.

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -4,12 +4,12 @@ import logging
 import os
 import sys
 import tempfile
-import typing_extensions
 from typing import Any, Callable, Optional, TypeVar
-from typing_extensions import ParamSpec
 
 import torch
+import typing_extensions
 from torch._strobelight.compile_time_profiler import StrobelightCompileTimeProfiler
+from typing_extensions import ParamSpec
 
 
 _T = TypeVar("_T")
@@ -288,7 +288,7 @@ def profiler_allow_cudagraph_cupti_lazy_reinit_cuda12():
 def deprecated():
     """When we deprecate a function that might still be in use, we make it internal by adding a leading underscore.
     This decorator is used with a private function, and creates a public alias without the leading underscore, but has a deprecation warning.
-    This tells users "THIS FUNCTION IS DEPRECATED, please use something else" without breaking them, however, 
+    This tells users "THIS FUNCTION IS DEPRECATED, please use something else" without breaking them, however,
     if they still really really want to use the deprecated function without the warning, they can do so by using the internal function name.
     """
 
@@ -310,11 +310,11 @@ def deprecated():
                  Please rename it or consult a pytorch developer on what to do"
             )
 
-        warning_msg = f"{func.__name__} is DEPRECATED, please consider using an alternative API(s). "
+        warning_msg = f"{func.__name__[1:]} is DEPRECATED, please consider using an alternative API(s). "
 
         # public deprecated alias
         alias = typing_extensions.deprecated(
-            warning_msg, category=UserWarning, stacklevel=2
+            warning_msg, category=UserWarning, stacklevel=1
         )(func)
 
         alias.__name__ = public_name

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -327,10 +327,6 @@ def deprecated():
 
         setattr(module, public_name, alias)
 
-        @functools.wraps(func)
-        def wrapper(*args: _P.args, **kwargs: _P.kwargs):  # type: ignore[misc]
-            return func(*args, **kwargs)
-
-        return wrapper
+        return func
 
     return decorator

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -286,11 +286,10 @@ def profiler_allow_cudagraph_cupti_lazy_reinit_cuda12():
 
 
 def deprecated():
-    """Decorator that deprecates functions.
-
-    Effects:
-    1) Emits a deprecation warning when function is called
-    2) Creates a public alias without the leading underscore
+    """Decorator that deprecates functions. When we deprecate a funciton, we make it internal by adding a leading underscore.
+    This decorator is used with a private function, and creates a public alias without the leading underscore, but has a deprecation warning.
+    This tells users to use something else without breaking them, however, 
+    if they still really really want to use the deprecated function, they can do so by using the internal function name.
     """
 
     def decorator(func: Callable[_P, _T]) -> Callable[_P, _T]:

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -4,12 +4,12 @@ import logging
 import os
 import sys
 import tempfile
+import typing_extensions
 from typing import Any, Callable, Optional, TypeVar
+from typing_extensions import ParamSpec
 
 import torch
-import typing_extensions
 from torch._strobelight.compile_time_profiler import StrobelightCompileTimeProfiler
-from typing_extensions import ParamSpec
 
 
 _T = TypeVar("_T")
@@ -286,10 +286,14 @@ def profiler_allow_cudagraph_cupti_lazy_reinit_cuda12():
 
 
 def deprecated():
-    """When we deprecate a function that might still be in use, we make it internal by adding a leading underscore.
-    This decorator is used with a private function, and creates a public alias without the leading underscore, but has a deprecation warning.
-    This tells users "THIS FUNCTION IS DEPRECATED, please use something else" without breaking them, however,
-    if they still really really want to use the deprecated function without the warning, they can do so by using the internal function name.
+    """
+    When we deprecate a function that might still be in use, we make it internal
+    by adding a leading underscore. This decorator is used with a private function,
+    and creates a public alias without the leading underscore, but has a deprecation
+    warning. This tells users "THIS FUNCTION IS DEPRECATED, please use something else"
+    without breaking them, however, if they still really really want to use the
+    deprecated function without the warning, they can do so by using the internal
+    function name.
     """
 
     def decorator(func: Callable[_P, _T]) -> Callable[_P, _T]:


### PR DESCRIPTION
This PR adds the `@deprecate` decorator for internal functions which we are prepping for deprecation.  Add it on top of an internal function to emit a deprecation warning + allow bc with the non internal version of the function.

Tested with `python test/test_utils.py TestDeprecate.test_deprecated `

Furthermore, testing with a modified version of the tes in the pr gives something like this which is what we want

```
/home/sahanp/repos/pytorch/test/test_utils.py:1239: UserWarning: deprecated_api is DEPRECATED, please consider using an alternative API(s). 
  deprecated_api(1, 2)
  ```