### PR TITLE
Fix docs build

### DIFF
--- a/.ci/docker/requirements-docs.txt
+++ b/.ci/docker/requirements-docs.txt
@@ -58,5 +58,3 @@ sphinx-copybutton==0.5.0
 sphinx-design==0.4.0
 sphinxcontrib-mermaid==1.0.0
 myst-parser==0.18.1
-
-numpy==1.26

--- a/.ci/docker/requirements-docs.txt
+++ b/.ci/docker/requirements-docs.txt
@@ -58,3 +58,5 @@ sphinx-copybutton==0.5.0
 sphinx-design==0.4.0
 sphinxcontrib-mermaid==1.0.0
 myst-parser==0.18.1
+
+numpy==1.26

--- a/torch/nn/attention/bias.py
+++ b/torch/nn/attention/bias.py
@@ -36,14 +36,14 @@ class CausalVariant(IntEnum):
 
     Defines two types of causal biases:
 
-    `UPPER_LEFT`: Represents upper-left triangular bias for standard causal attention.
+    ``UPPER_LEFT``: Represents upper-left triangular bias for standard causal attention.
     The equivalent pytorch code for constructing this bias is:
 
     .. code-block:: python
 
         torch.tril(torch.ones(size, dtype=torch.bool))
 
-    For instance, with `shape=(3,4)`, the materialized bias tensor will be:
+    For instance, with ``shape=(3,4)``, the materialized bias tensor will be:
 
     .. code-block:: text
 
@@ -52,7 +52,7 @@ class CausalVariant(IntEnum):
          [1, 1, 1, 0]]
 
 
-    `LOWER_RIGHT`: Represents lower-right triangular bias, the include values are aligned to the lower
+    ``LOWER_RIGHT``: Represents lower-right triangular bias, the include values are aligned to the lower
     right corner of the matrix.
 
     The equivalent pytorch code for constructing this bias is:
@@ -65,7 +65,7 @@ class CausalVariant(IntEnum):
             diagonal=diagonal_offset,
         )
 
-    For instance, with `shape=(3,4)`, the materialized bias tensor will be:
+    For instance, with ``shape=(3,4)``, the materialized bias tensor will be:
 
     .. code-block:: text
 


### PR DESCRIPTION
Not sure why the online doc build passes but it fails locally with these broken strings...

~Also pinning numpy version even though it is technically optional to ensure users have the right version as most users have numpy in their environment anyways.~