### PR TITLE
[export] support unbacked layer_norm

### DIFF
--- a/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
+++ b/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
@@ -47,6 +47,7 @@ from .schemas import (
     OutputType,
     ViewAndMutationMeta,
 )
+from torch._refs import contiguous
 from .subclass_utils import create_subclass_meta
 from .utils import _get_autocast_states, KNOWN_TYPES, strict_zip
 
@@ -80,7 +81,7 @@ def coerce_tangent_and_suggest_memory_format(x: Tensor):
 
     if memory_format.memory_format is not None:
         was = out
-        out = out.contiguous(memory_format=memory_format.memory_format)
+        out = contiguous(out, memory_format=memory_format.memory_format)
         updated = was is not out
 
     # For subclass we keep memory format of outer strides at the beggining of the list

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -452,7 +452,7 @@ def is_non_overlapping_and_dense(a: Tensor) -> bool:
         return False
 
     # Short-circuits if the tensor is already contiguous or channels-last contiguous
-    if is_contiguous(a) or is_channels_last_contiguous(a):
+    if definitely_contiguous(a) or is_known_channels_last_contiguous(a):
         return True
 
     # The following is equivalent to compute_non_overlapping_and_dense in TensorImpl.cpp

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -12,6 +12,7 @@ import torch._logging
 from torch._dispatch.python import no_python_dispatcher
 from torch._ops import OpOverload
 from torch._prims_common import (
+    definitely_contiguous_for_memory_format,
     elementwise_dtypes,
     ELEMENTWISE_TYPE_PROMOTION_KIND,
     is_boolean_dtype,
@@ -1024,11 +1025,17 @@ def make_fast_binary_impl(
             for op in operands:
                 if not isinstance(op, torch.Tensor):
                     continue
-                is_contiguous = is_contiguous and op.is_contiguous(
-                    memory_format=torch.contiguous_format
+                is_contiguous = (
+                    is_contiguous
+                    and definitely_contiguous_for_memory_format(
+                        op, memory_format=torch.contiguous_format
+                    )
                 )
-                is_channels_last = is_channels_last and op.is_contiguous(
-                    memory_format=torch.channels_last
+                is_channels_last = (
+                    is_channels_last
+                    and definitely_contiguous_for_memory_format(
+                        op, memory_format=torch.channels_last
+                    )
                 )
         if is_contiguous:
             # do contiguous


### PR DESCRIPTION
Summary:
Some example DDE's
```
torch._dynamo.exc.UserError: Could not guard on data-dependent expression Eq((u0//387), 0) (unhinted: Eq((u0//387), 0)).  (Size-like symbols: u0)

Caused by: layer_norm = self.layer_norm(linear)  # caffe2/test/export/test_export.py:4566 in forward (_subclasses/fake_impls.py:1022 in fast_binary_impl)
```
```
  File "./fbcode/caffe2/c10/core/TensorImpl.h", line 825, in torch::autograd::THPVariable_contiguous(_object*, _object*, _object*)
  File "./fbcode/c10/core/SymbolicShapeMeta.h", line 87, in c10::TensorImpl::is_contiguous_default(c10::MemoryFormat) const
  File "./fbcode/caffe2/c10/core/SymbolicShapeMeta.cpp", line 250, in c10::SymbolicShapeMeta::init_is_contiguous() const

torch.fx.experimental.symbolic_shapes.GuardOnDataDependentSymNode: Could not guard on data-dependent expression Eq(128*((u0//387)), 0) (unhinted: Eq(128*((u0//387)), 0)).  (Size-like symbols: u0)

Caused by: (_refs/__init__.py:3302 in native_layer_norm)
```

```
torch.fx.experimental.symbolic_shapes.GuardOnDataDependentSymNode: Could not guard on data-dependent expression Eq(128*((u0//387)), 0) (unhinted: Eq(128*((u0//387)), 0)).  (Size-like symbols: u0)

Caused by: (_functorch/_aot_autograd/collect_metadata_analysis.py:83 in coerce_tangent_and_suggest_memory_format)
```

Differential Revision: D75902204
