### PR TITLE
[nativert] Move Pytree

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -601,6 +601,7 @@ libtorch_nativert_sources = [
     "torch/nativert/executor/Weights.cpp",
     "torch/nativert/executor/memory/FunctionSchema.cpp",
     "torch/nativert/common/FileUtil.cpp",
+    "torch/nativert/detail/ITree.cpp",
 ]
 
 torch_mobile_tracer_sources = [

--- a/test/cpp/nativert/CMakeLists.txt
+++ b/test/cpp/nativert/CMakeLists.txt
@@ -14,6 +14,7 @@ set(NATIVERT_TEST_SRCS
   ${TORCH_ROOT}/torch/nativert/common/FileUtil.cpp
   ${TORCH_ROOT}/torch/nativert/executor/memory/FunctionSchema.cpp
   ${TORCH_ROOT}/torch/nativert/executor/ExecutionPlanner.cpp
+  ${TORCH_ROOT}/torch/nativert/detail/ITree.cpp
 )
 
 add_executable(test_nativert

--- a/test/cpp/nativert/test_itree.cpp
+++ b/test/cpp/nativert/test_itree.cpp
@@ -1,0 +1,1150 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <fmt/format.h>
+
+#include <c10/util/Enumerate.h>
+#include <torch/nativert/detail/ITree.h>
+
+namespace torch::nativert::detail {
+
+using torch::nativert::Graph;
+using torch::nativert::stringToGraph;
+using torch::nativert::Type;
+using torch::nativert::Value;
+
+std::pair<std::unique_ptr<Graph>, std::vector<const Value*>> makeValues(
+    int count) {
+  auto graph = Graph::createGraph();
+  std::vector<const Value*> values;
+
+  for (int i = 0; i < count; i++) {
+    std::string name = fmt::format("v{}", i);
+    Value* value = graph->addValue(name, Type::Kind::None, nullptr);
+    values.push_back(value);
+  }
+
+  return std::make_pair(std::move(graph), values);
+}
+
+TEST(ITreeTest, Unflatten) {
+  // Original data: [(0, 1), 2, {"4": 7, "5": 8, "6": 9}, (10,), {"11": 12}]
+  auto jsonSpec = R"(
+[
+  1,
+  {
+    "type": "builtins.list",
+    "context": "null",
+    "children_spec": [
+      {
+        "type": "builtins.tuple",
+        "context": "null",
+        "children_spec": [
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          }
+        ]
+      },
+      {
+        "type": null,
+        "context": null,
+        "children_spec": []
+      },
+      {
+        "type": "builtins.dict",
+        "context": "[\"4\", \"5\", \"6\"]",
+        "children_spec": [
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          }
+        ]
+      },
+      {
+        "type": "torch.fx.immutable_collections.immutable_list",
+        "context": "null",
+        "children_spec": [
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          }
+        ]
+      },
+      {
+        "type": "torch.fx.immutable_collections.immutable_dict",
+        "context": "[\"11\"]",
+        "children_spec": [
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          }
+        ]
+      }
+    ]
+  }
+]
+  )";
+
+  auto [graph, valuePtrs] = makeValues(8);
+
+  const auto spec = itreeSpecLoads(jsonSpec, valuePtrs);
+  std::vector<c10::IValue> flats = {
+      c10::IValue(0),
+      c10::IValue(1),
+      c10::IValue(2),
+      c10::IValue(7),
+      c10::IValue(8),
+      c10::IValue(9),
+      c10::IValue(10),
+      c10::IValue(12),
+  };
+  auto itree = itreeUnflatten(flats, spec);
+  EXPECT_TRUE(itree.isList());
+  EXPECT_EQ(itree.toListRef().size(), 5);
+
+  EXPECT_TRUE(itree.toListRef().at(0).isTuple());
+  EXPECT_EQ(itree.toListRef().at(0).toTupleRef().elements()[0], c10::IValue(0));
+  EXPECT_EQ(itree.toListRef().at(0).toTupleRef().elements()[1], c10::IValue(1));
+
+  EXPECT_TRUE(itree.toListRef().at(1).isInt());
+  EXPECT_EQ(itree.toListRef().at(1), c10::IValue(2));
+
+  EXPECT_TRUE(itree.toListRef().at(2).isGenericDict());
+  EXPECT_EQ(itree.toListRef().at(2).toGenericDict().at("4"), c10::IValue(7));
+  EXPECT_EQ(itree.toListRef().at(2).toGenericDict().at("5"), c10::IValue(8));
+  EXPECT_EQ(itree.toListRef().at(2).toGenericDict().at("6"), c10::IValue(9));
+
+  EXPECT_TRUE(itree.toListRef().at(3).isList());
+  EXPECT_EQ(itree.toListRef().at(3).toListRef().at(0), c10::IValue(10));
+
+  EXPECT_TRUE(itree.toListRef().at(4).isGenericDict());
+  EXPECT_EQ(itree.toListRef().at(4).toGenericDict().at("11"), c10::IValue(12));
+
+  const auto flattened = itreeFlatten(itree, spec);
+  EXPECT_EQ(flattened.size(), flats.size());
+  for (size_t i = 0; i < flattened.size(); i++) {
+    EXPECT_EQ(flattened[i], flats[i]);
+  }
+}
+
+TEST(ITreeTest, NoVersion) {
+  auto jsonSpec = R"(
+  {
+    "type": "builtins.list",
+    "context": "null",
+    "children_spec": [
+      {
+        "type": "builtins.tuple",
+        "context": "null",
+        "children_spec": [
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          }
+        ]
+      }
+    ]
+  }
+  )";
+
+  auto [graph, valuePtrs] = makeValues(2);
+  EXPECT_THROW({ itreeSpecLoads(jsonSpec, valuePtrs); }, std::exception);
+}
+
+TEST(ITreeTest, NoField) {
+  auto jsonSpec = R"(
+[
+  1,
+  {
+    "type": "builtins.list",
+    "context": "null",
+    "children_spec": [
+      {
+        "children_spec": []
+      },
+      {
+        "type": "builtins.dict",
+        "context": "[\"4\", \"5\", \"6\"]",
+        "children_spec": [
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          }
+        ]
+      }
+    ]
+  }
+]
+  )";
+
+  auto [graph, valuePtrs] = makeValues(3);
+  EXPECT_THROW(itreeSpecLoads(jsonSpec, valuePtrs), std::exception);
+}
+
+TEST(ITreeTest, NoContext) {
+  auto jsonSpec = R"(
+[
+  1,
+  {
+    "type": "builtins.list",
+    "context": "null",
+    "children_spec": [
+      {
+        "type": "builtins.dict",
+        "context": "[]",
+        "children_spec": [
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          }
+        ]
+      }
+    ]
+  }
+]
+  )";
+  auto [graph, valuePtrs] = makeValues(3);
+  auto spec = itreeSpecLoads(jsonSpec, valuePtrs);
+
+  std::vector<c10::IValue> flats = {
+      c10::IValue(7),
+      c10::IValue(8),
+      c10::IValue(9),
+  };
+  ASSERT_DEATH({ itreeUnflatten(flats, spec); }, "Check failed");
+}
+
+TEST(ITreeTest, TooManyContext) {
+  auto jsonSpec = R"(
+[
+  1,
+  {
+    "type": "builtins.list",
+    "context": "null",
+    "children_spec": [
+      {
+        "type": "builtins.dict",
+        "context": "[\"4\", \"5\", \"6\", \"10\"]",
+        "children_spec": [
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          }
+        ]
+      }
+    ]
+  }
+]
+  )";
+
+  auto [graph, valuePtrs] = makeValues(3);
+  auto spec = itreeSpecLoads(jsonSpec, valuePtrs);
+
+  std::vector<c10::IValue> flats = {
+      c10::IValue(7),
+      c10::IValue(8),
+      c10::IValue(9),
+  };
+  ASSERT_DEATH({ itreeUnflatten(flats, spec); }, "Check failed");
+}
+
+TEST(ITreeTest, DoubleRegister) {
+  EXPECT_THROW(
+      { registerPytreeNode("builtins.dict", NodeDef{}); }, std::exception);
+}
+
+TEST(ITreeTest, NotEnoughUnflatten) {
+  // Original data: [(0, 1), 2, {"4": 7, "5": 8, "6": 9}]
+  auto jsonSpec = R"(
+[
+  1,
+  {
+    "type": "builtins.list",
+    "context": "null",
+    "children_spec": [
+      {
+        "type": "builtins.tuple",
+        "context": "null",
+        "children_spec": [
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          }
+        ]
+      },
+      {
+        "type": null,
+        "context": null,
+        "children_spec": []
+      },
+      {
+        "type": "builtins.dict",
+        "context": "[\"4\", \"5\", \"6\"]",
+        "children_spec": [
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          }
+        ]
+      }
+    ]
+  }
+]
+  )";
+  auto [graph, valuePtrs] = makeValues(6);
+  const auto spec = itreeSpecLoads(jsonSpec, valuePtrs);
+  std::vector<c10::IValue> flats = {
+      c10::IValue(0),
+      c10::IValue(1),
+      c10::IValue(2),
+      c10::IValue(7),
+  };
+  ASSERT_DEATH({ itreeUnflatten(flats, spec); }, "Check failed");
+}
+
+TEST(ITreeTest, TooManyUnflatten) {
+  // Original data: [(0, 1), 2, {"4": 7, "5": 8, "6": 9}]
+  auto jsonSpec = R"(
+[
+  1,
+  {
+    "type": "builtins.list",
+    "context": "null",
+    "children_spec": [
+      {
+        "type": "builtins.tuple",
+        "context": "null",
+        "children_spec": [
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          }
+        ]
+      },
+      {
+        "type": null,
+        "context": null,
+        "children_spec": []
+      },
+      {
+        "type": "builtins.dict",
+        "context": "[\"4\", \"5\", \"6\"]",
+        "children_spec": [
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          }
+        ]
+      }
+    ]
+  }
+]
+  )";
+  auto [graph, valuePtrs] = makeValues(6);
+  const auto spec = itreeSpecLoads(jsonSpec, valuePtrs);
+  std::vector<c10::IValue> flats = {
+      c10::IValue(0),
+      c10::IValue(1),
+      c10::IValue(2),
+      c10::IValue(7),
+      c10::IValue(0),
+      c10::IValue(1),
+      c10::IValue(2),
+      c10::IValue(7),
+      c10::IValue(0),
+      c10::IValue(1),
+      c10::IValue(2),
+      c10::IValue(7),
+  };
+  ASSERT_DEATH({ itreeUnflatten(flats, spec); }, "Check failed");
+}
+
+TEST(ITreeTest, Flatten) {
+  // Original data: [(0, 1), 2, {"4": 7, "5": 8, "6": 9}, (10,), {"11": 12}]
+  auto jsonSpec = R"(
+[
+  1,
+  {
+    "type": "builtins.list",
+    "context": "null",
+    "children_spec": [
+      {
+        "type": "builtins.tuple",
+        "context": "null",
+        "children_spec": [
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          }
+        ]
+      },
+      {
+        "type": null,
+        "context": null,
+        "children_spec": []
+      },
+      {
+        "type": "builtins.dict",
+        "context": "[\"4\", \"5\", \"6\"]",
+        "children_spec": [
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          }
+        ]
+      },
+      {
+        "type": "torch.fx.immutable_collections.immutable_list",
+        "context": "null",
+        "children_spec": [
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          }
+        ]
+      },
+      {
+        "type": "torch.fx.immutable_collections.immutable_dict",
+        "context": "[\"11\"]",
+        "children_spec": [
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          }
+        ]
+      }
+    ]
+  }
+]
+  )";
+  auto [graph, valuePtrs] = makeValues(8);
+  const auto spec = itreeSpecLoads(jsonSpec, valuePtrs);
+  auto tup = c10::ivalue::Tuple::create({c10::IValue(0), c10::IValue(1)});
+  c10::Dict<c10::IValue, c10::IValue> dict(
+      c10::StringType::get(), c10::AnyType::get());
+  dict.insert("4", c10::IValue(7));
+  dict.insert("5", c10::IValue(8));
+  dict.insert("6", c10::IValue(9));
+  c10::List<c10::IValue> ilist(c10::AnyType::get());
+  ilist.push_back(c10::IValue(10));
+  c10::Dict<c10::IValue, c10::IValue> idict(
+      c10::StringType::get(), c10::AnyType::get());
+  idict.insert("11", c10::IValue(12));
+  c10::List<c10::IValue> list(c10::AnyType::get());
+  list.push_back(std::move(tup));
+  list.push_back(c10::IValue(2));
+  list.push_back(std::move(dict));
+  list.push_back(std::move(ilist));
+  list.push_back(std::move(idict));
+  auto flats = itreeFlatten(c10::IValue{list}, spec);
+  std::vector<c10::IValue> expected = {
+      c10::IValue(0),
+      c10::IValue(1),
+      c10::IValue(2),
+      c10::IValue(7),
+      c10::IValue(8),
+      c10::IValue(9),
+      c10::IValue(10),
+      c10::IValue(12),
+  };
+  for (const auto& [i, flat] : c10::enumerate(flats)) {
+    EXPECT_EQ(flat, expected.at(i));
+  }
+}
+
+TEST(ITreeTest, IValueApplyFromArgs) {
+  // inputSpec for testing is generated from E2ETestModelWithNestedDictInput
+  /*
+      args = (
+        {
+            "a": (
+                torch.rand(4, 4),
+                {
+                    123: (torch.rand(4, 4), torch.rand(4, 4)),
+                    234: (torch.rand(4, 4), torch.rand(4, 4)),
+                },
+            ),
+            "b": (
+                torch.rand(4, 4),
+                {
+                    345: (torch.rand(4, 4), torch.rand(4, 4)),
+                    456: (torch.rand(4, 4), torch.rand(4, 4)),
+                },
+            ),
+        },
+    )*/
+  auto jsonSpec = R"(
+[
+    1,
+    {
+        "type": "builtins.tuple",
+        "context": "null",
+        "children_spec": [
+            {
+                "type": "builtins.tuple",
+                "context": "null",
+                "children_spec": [
+                    {
+                        "type": "builtins.dict",
+                        "context": "[\"a\", \"b\"]",
+                        "children_spec": [
+                            {
+                                "type": "builtins.tuple",
+                                "context": "null",
+                                "children_spec": [
+                                    {
+                                        "type": null,
+                                        "context": null,
+                                        "children_spec": []
+                                    },
+                                    {
+                                        "type": "builtins.dict",
+                                        "context": "[123, 234]",
+                                        "children_spec": [
+                                            {
+                                                "type": "builtins.tuple",
+                                                "context": "null",
+                                                "children_spec": [
+                                                    {
+                                                        "type": null,
+                                                        "context": null,
+                                                        "children_spec": []
+                                                    },
+                                                    {
+                                                        "type": null,
+                                                        "context": null,
+                                                        "children_spec": []
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "type": "builtins.tuple",
+                                                "context": "null",
+                                                "children_spec": [
+                                                    {
+                                                        "type": null,
+                                                        "context": null,
+                                                        "children_spec": []
+                                                    },
+                                                    {
+                                                        "type": null,
+                                                        "context": null,
+                                                        "children_spec": []
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "builtins.tuple",
+                                "context": "null",
+                                "children_spec": [
+                                    {
+                                        "type": null,
+                                        "context": null,
+                                        "children_spec": []
+                                    },
+                                    {
+                                        "type": "builtins.dict",
+                                        "context": "[345, 456]",
+                                        "children_spec": [
+                                            {
+                                                "type": "builtins.tuple",
+                                                "context": "null",
+                                                "children_spec": [
+                                                    {
+                                                        "type": null,
+                                                        "context": null,
+                                                        "children_spec": []
+                                                    },
+                                                    {
+                                                        "type": null,
+                                                        "context": null,
+                                                        "children_spec": []
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "type": "builtins.tuple",
+                                                "context": "null",
+                                                "children_spec": [
+                                                    {
+                                                        "type": null,
+                                                        "context": null,
+                                                        "children_spec": []
+                                                    },
+                                                    {
+                                                        "type": null,
+                                                        "context": null,
+                                                        "children_spec": []
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "type": "builtins.dict",
+                "context": "[]",
+                "children_spec": []
+            }
+        ]
+    }
+]
+  )";
+
+  auto tup_a1_123 =
+      c10::ivalue::Tuple::create({c10::IValue(1), c10::IValue(2)});
+  auto tup_a1_234 =
+      c10::ivalue::Tuple::create({c10::IValue(3), c10::IValue(4)});
+  c10::Dict<c10::IValue, c10::IValue> dict_a1(
+      c10::StringType::get(), c10::AnyType::get());
+  dict_a1.insert(123, tup_a1_123);
+  dict_a1.insert(234, tup_a1_234);
+  auto tup_a =
+      c10::ivalue::Tuple::create({c10::IValue(0), c10::IValue(dict_a1)});
+
+  auto tup_b1_345 =
+      c10::ivalue::Tuple::create({c10::IValue(6), c10::IValue(7)});
+  auto tup_b1_456 =
+      c10::ivalue::Tuple::create({c10::IValue(8), c10::IValue(9)});
+  c10::Dict<c10::IValue, c10::IValue> dict_b1(
+      c10::StringType::get(), c10::AnyType::get());
+  dict_b1.insert(345, tup_b1_345);
+  dict_b1.insert(456, tup_b1_456);
+  auto tup_b =
+      c10::ivalue::Tuple::create({c10::IValue(5), c10::IValue(dict_b1)});
+
+  c10::Dict<c10::IValue, c10::IValue> dict(
+      c10::StringType::get(), c10::AnyType::get());
+  dict.insert("a", tup_a);
+  dict.insert("b", tup_b);
+  std::vector<c10::IValue> args = {c10::IValue(dict)};
+
+  for (int usedIdx = 0; usedIdx < 10; usedIdx++) {
+    std::vector<bool> isUsed(10, false);
+    isUsed[usedIdx] = true;
+    std::stringstream ss;
+    for (int i = 0; i < 10; ++i) {
+      if (isUsed[i]) {
+        ss << fmt::format("%o1 = aten.foo(a=%a{})\n", i);
+      }
+    }
+    std::string source = fmt::format(
+        R"(graph(%a0, %a1, %a2, %a3, %a4, %a5, %a6, %a7, %a8, %a9):
+{}
+return(%o1)
+)",
+        ss.str());
+
+    auto graph = stringToGraph(source);
+    std::vector<const Value*> userInputs(
+        graph->userInputs().begin(), graph->userInputs().end());
+
+    const auto spec = itreeSpecLoads(jsonSpec, userInputs);
+
+    std::vector<int> visited;
+    auto fn = [&](const c10::IValue& leaf, const Value* value) {
+      visited.push_back(value->id());
+    };
+    ivalueApplyFromArgs(fn, args, {}, spec);
+
+    EXPECT_EQ(visited.size(), 1);
+    EXPECT_EQ(visited[0], usedIdx);
+  }
+}
+
+TEST(ITreeTest, UnmatchedFlattenType) {
+  // Original data: [(0, 1), 2, {"4": 7, "5": 8, "6": 9}]
+  auto jsonSpec = R"(
+[
+  1,
+  {
+    "type": "builtins.list",
+    "context": "null",
+    "children_spec": [
+      {
+        "type": "builtins.tuple",
+        "context": "null",
+        "children_spec": [
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          }
+        ]
+      },
+      {
+        "type": null,
+        "context": null,
+        "children_spec": []
+      },
+      {
+        "type": "builtins.dict",
+        "context": "[\"4\", \"5\", \"6\"]",
+        "children_spec": [
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          }
+        ]
+      }
+    ]
+  }
+]
+  )";
+  auto [graph, valuePtrs] = makeValues(6);
+  const auto spec = itreeSpecLoads(jsonSpec, valuePtrs);
+  auto tup = c10::ivalue::Tuple::create({c10::IValue(0), c10::IValue(1)});
+  c10::Dict<c10::IValue, c10::IValue> dict(
+      c10::StringType::get(), c10::AnyType::get());
+  dict.insert("4", c10::IValue(7));
+  dict.insert("5", c10::IValue(8));
+  dict.insert("6", c10::IValue(9));
+  EXPECT_THROW(
+      { itreeFlatten(c10::IValue{std::move(dict)}, spec); }, std::exception);
+}
+
+TEST(ITreeTest, UnmatchedDictFlatten) {
+  // Original data: [(0, 1), 2, {"4": 7, "5": 8, "6": 9}]
+  auto jsonSpec = R"(
+[
+  1,
+  {
+    "type": "builtins.list",
+    "context": "null",
+    "children_spec": [
+      {
+        "type": "builtins.tuple",
+        "context": "null",
+        "children_spec": [
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          }
+        ]
+      },
+      {
+        "type": null,
+        "context": null,
+        "children_spec": []
+      },
+      {
+        "type": "builtins.dict",
+        "context": "[\"4\", \"5\", \"6\"]",
+        "children_spec": [
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          }
+        ]
+      }
+    ]
+  }
+]
+  )";
+  auto [graph, valuePtrs] = makeValues(6);
+  const auto spec = itreeSpecLoads(jsonSpec, valuePtrs);
+  auto tup = c10::ivalue::Tuple::create({c10::IValue(0), c10::IValue(1)});
+  c10::Dict<c10::IValue, c10::IValue> dict(
+      c10::StringType::get(), c10::AnyType::get());
+  dict.insert("4", c10::IValue(7));
+  dict.insert("5", c10::IValue(8));
+  dict.insert("100", c10::IValue(8));
+  dict.insert("101", c10::IValue(8));
+  c10::List<c10::IValue> list(c10::AnyType::get());
+  list.push_back(std::move(tup));
+  list.push_back(c10::IValue(2));
+  list.push_back(std::move(dict));
+  ASSERT_DEATH(
+      { itreeFlatten(c10::IValue{std::move(list)}, spec); }, "Check failed");
+}
+
+TEST(ITreeTest, DictFlattenTest) {
+  auto jsonSpec = R"(
+[
+  1,
+  {
+    "type": "builtins.list",
+    "context": "null",
+    "children_spec": [
+      {
+        "type": "builtins.dict",
+        "context": "[\"4\", \"5\", \"6\"]",
+        "children_spec": [
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          }
+        ]
+      }
+    ]
+  }
+]
+  )";
+  auto [graph, valuePtrs] = makeValues(3);
+  const auto spec = itreeSpecLoads(jsonSpec, valuePtrs);
+  c10::Dict<c10::IValue, c10::IValue> dict(
+      c10::StringType::get(), c10::AnyType::get());
+  // allow dict.size < context
+  // test dict.size=2 , context,size=3,
+  dict.insert("4", c10::IValue(7));
+  dict.insert("5", c10::IValue(8));
+  c10::List<c10::IValue> list(c10::AnyType::get());
+  list.push_back(std::move(dict));
+  itreeFlatten(c10::IValue{std::move(list)}, spec);
+}
+
+TEST(ITreeTest, UnmatchedTupleFlatten) {
+  // Original data: [(0, 1), 2, {"4": 7, "5": 8, "6": 9}]
+  auto jsonSpec = R"(
+[
+  1,
+  {
+    "type": "builtins.list",
+    "context": "null",
+    "children_spec": [
+      {
+        "type": "builtins.tuple",
+        "context": "null",
+        "children_spec": [
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          }
+        ]
+      },
+      {
+        "type": null,
+        "context": null,
+        "children_spec": []
+      },
+      {
+        "type": "builtins.dict",
+        "context": "[\"4\", \"5\", \"6\"]",
+        "children_spec": [
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          }
+        ]
+      }
+    ]
+  }
+]
+  )";
+  auto [graph, valuePtrs] = makeValues(6);
+  const auto spec = itreeSpecLoads(jsonSpec, valuePtrs);
+  auto tup = c10::ivalue::Tuple::create({c10::IValue(0)});
+  c10::Dict<c10::IValue, c10::IValue> dict(
+      c10::StringType::get(), c10::AnyType::get());
+  dict.insert("4", c10::IValue(7));
+  dict.insert("5", c10::IValue(8));
+  dict.insert("6", c10::IValue(8));
+  c10::List<c10::IValue> list(c10::AnyType::get());
+  list.push_back(std::move(tup));
+  list.push_back(c10::IValue(2));
+  list.push_back(std::move(dict));
+  ASSERT_DEATH(
+      { itreeFlatten(c10::IValue{std::move(list)}, spec); }, "Check failed");
+}
+
+TEST(ITreeTest, ToAtenType) {
+  // Original data: ((0, 1), 2, {"4": 7, "5": 8}, [10], {6: 9})
+  auto jsonSpec = R"(
+[
+  1,
+  {
+    "type": "builtins.tuple",
+    "context": "null",
+    "children_spec": [
+      {
+        "type": "builtins.tuple",
+        "context": "null",
+        "children_spec": [
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          }
+        ]
+      },
+      {
+        "type": null,
+        "context": null,
+        "children_spec": []
+      },
+      {
+        "type": "builtins.dict",
+        "context": "[\"4\", \"5\"]",
+        "children_spec": [
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          },
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          }
+        ]
+      },
+      {
+        "type": "builtins.list",
+        "context": "null",
+        "children_spec": [
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          }
+        ]
+      },
+      {
+        "type": "builtins.dict",
+        "context": "[6]",
+        "children_spec": [
+          {
+            "type": null,
+            "context": null,
+            "children_spec": []
+          }
+        ]
+      }
+    ]
+  }
+]
+  )";
+  auto [graph, valuePtrs] = makeValues(7);
+  const auto spec = itreeSpecLoads(jsonSpec, valuePtrs);
+  auto atenType = spec.toAtenType();
+
+  // Root level is tuple.
+  EXPECT_EQ(atenType->kind(), c10::TypeKind::TupleType);
+  const c10::TupleType& rootType = atenType->expectRef<c10::TupleType>();
+  EXPECT_EQ(rootType.elements().size(), 5);
+
+  at::TypePtr elementType = rootType.elements()[0];
+  EXPECT_EQ(elementType->kind(), c10::TypeKind::TupleType);
+  EXPECT_EQ(
+      elementType->expectRef<c10::TupleType>().elements()[0]->kind(),
+      c10::TypeKind::AnyType);
+  EXPECT_EQ(
+      elementType->expectRef<c10::TupleType>().elements()[1]->kind(),
+      c10::TypeKind::AnyType);
+
+  elementType = rootType.elements()[1];
+  EXPECT_EQ(elementType->kind(), c10::TypeKind::AnyType);
+
+  elementType = rootType.elements()[2];
+  EXPECT_EQ(elementType->kind(), c10::TypeKind::DictType);
+  EXPECT_EQ(
+      elementType->expectRef<c10::DictType>().getKeyType()->kind(),
+      c10::TypeKind::StringType);
+  EXPECT_EQ(
+      elementType->expectRef<c10::DictType>().getValueType()->kind(),
+      c10::TypeKind::AnyType);
+
+  elementType = rootType.elements()[3];
+  EXPECT_EQ(elementType->kind(), c10::TypeKind::ListType);
+  EXPECT_EQ(
+      elementType->expectRef<c10::ListType>().getElementType()->kind(),
+      c10::TypeKind::AnyType);
+
+  elementType = rootType.elements()[4];
+  EXPECT_EQ(elementType->kind(), c10::TypeKind::DictType);
+  EXPECT_EQ(
+      elementType->expectRef<c10::DictType>().getKeyType()->kind(),
+      c10::TypeKind::IntType);
+  EXPECT_EQ(
+      elementType->expectRef<c10::DictType>().getValueType()->kind(),
+      c10::TypeKind::AnyType);
+}
+
+} // namespace torch::nativert::detail

--- a/torch/nativert/detail/ITree.cpp
+++ b/torch/nativert/detail/ITree.cpp
@@ -1,0 +1,485 @@
+#include <ATen/record_function.h>
+#include <torch/nativert/detail/ITree.h>
+
+#include <iterator>
+#include <string_view>
+
+#include <ATen/core/ivalue.h>
+#include <c10/util/Synchronized.h>
+#include <nlohmann/json.hpp>
+
+namespace torch::nativert::detail {
+
+namespace {
+inline constexpr int kDefaultTreeSpecSerializationProtocol = 1;
+
+c10::IValue dynamicToIValue(const nlohmann::json& obj) {
+  if (obj.is_string()) {
+    return obj.get<std::string>();
+  } else if (obj.is_number_integer()) {
+    return obj.get<int64_t>();
+  } else {
+    TORCH_CHECK(false, "Unsupported dynamic type: ", obj);
+  }
+}
+
+void itreeFlatten(
+    const c10::IValue& nested,
+    const ITreeSpec& spec,
+    std::vector<c10::IValue>& ivalues) {
+  if (spec.isIValue()) {
+    ivalues.push_back(nested);
+    return;
+  }
+  auto flattenFn = spec.nodeDefCache().flattenFn;
+  flattenFn(nested, spec, ivalues);
+}
+
+class PytreeNodeRegistry {
+ public:
+  PytreeNodeRegistry() {
+    // Add some law of physics here.
+    registerNode(
+        "builtins.tuple",
+        NodeDef{
+            [](const c10::IValue& nested,
+               const ITreeSpec& spec,
+               std::vector<c10::IValue>& ivalues) {
+              const auto& tuple = nested.toTupleRef().elements();
+              TORCH_CHECK_EQ(tuple.size(), spec.children().size());
+              for (size_t i = 0; i < tuple.size(); i++) {
+                itreeFlatten(tuple[i], spec.children(i), ivalues);
+              }
+            },
+            [](std::vector<c10::IValue> flats,
+               const nlohmann::json& obj) -> c10::IValue {
+              TORCH_INTERNAL_ASSERT_DEBUG_ONLY(obj.is_null());
+              return c10::ivalue::Tuple::create(std::move(flats));
+            },
+            [](ITreeMapNoReturnFn fn,
+               const c10::IValue& nested,
+               const ITreeSpec& spec) {
+              const auto& tuple = nested.toTupleRef().elements();
+              TORCH_CHECK_EQ(tuple.size(), spec.children().size());
+              for (size_t i = 0; i < tuple.size(); i++) {
+                ivalueApply(fn, tuple[i], spec.children(i));
+              }
+            }});
+    const auto& tupleNodeDef = getNodeDef("builtins.tuple");
+    registerNode(
+        "collections.namedtuple",
+        NodeDef{
+            tupleNodeDef.flattenFn,
+            [](std::vector<c10::IValue> flats,
+               const nlohmann::json& obj) -> c10::IValue {
+              TORCH_INTERNAL_ASSERT_DEBUG_ONLY(!obj.is_null());
+              return c10::ivalue::Tuple::create(std::move(flats));
+            },
+            tupleNodeDef.ivalueApplyFn,
+            [](std::string_view context) { return nlohmann::json{context}; }});
+    registerNode(
+        "builtins.list",
+        NodeDef{
+            [](const c10::IValue& nested,
+               const ITreeSpec& spec,
+               std::vector<c10::IValue>& ivalues) {
+              auto list = nested.toListRef();
+              for (size_t i = 0; i < list.size(); i++) {
+                itreeFlatten(list[i], spec.children(i), ivalues);
+              }
+            },
+            [](std::vector<c10::IValue> flats,
+               const nlohmann::json& obj) -> c10::IValue {
+              TORCH_INTERNAL_ASSERT_DEBUG_ONLY(obj.is_null());
+              c10::List<c10::IValue> list(c10::AnyType::get());
+              list.reserve(flats.size());
+              for (auto& flat : flats) {
+                list.push_back(std::move(flat));
+              }
+              return list;
+            },
+            [](ITreeMapNoReturnFn fn,
+               const c10::IValue& nested,
+               const ITreeSpec& spec) {
+              auto list = nested.toListRef();
+              for (size_t i = 0; i < list.size(); i++) {
+                ivalueApply(fn, list[i], spec.children(i));
+              }
+            }});
+    registerNode(
+        "torch.fx.immutable_collections.immutable_list",
+        getNodeDef("builtins.list"));
+    registerNode(
+        "builtins.dict",
+        NodeDef{
+            [](const c10::IValue& nested,
+               const ITreeSpec& spec,
+               std::vector<c10::IValue>& ivalues) {
+              auto dict = nested.toGenericDict();
+              const auto& contextKeys = spec.contextKeys();
+              // allow the dict size less than the spec, missing key will be
+              // filled with empty tensor
+              TORCH_CHECK_LE(dict.size(), contextKeys.size());
+              size_t i = 0;
+              for (const auto& key : contextKeys) {
+                auto it = dict.find(key);
+
+                if (it != dict.end()) {
+                  itreeFlatten(it->value(), spec.children(i), ivalues);
+                } else {
+                  // when we have a dict with missing keys, we fill the missing
+                  // ivalues with an empty tensor which is required for
+                  // validation
+                  for (size_t j = 0; j < spec.children(i).numIValues(); ++j) {
+                    at::Tensor empty_tensor;
+                    ivalues.emplace_back(std::move(empty_tensor));
+                  }
+                }
+                i++;
+              }
+            },
+            [](std::vector<c10::IValue> flats,
+               const nlohmann::json& obj) -> c10::IValue {
+              c10::Dict<c10::IValue, c10::IValue> dict(
+                  c10::AnyType::get(), c10::AnyType::get());
+              TORCH_CHECK(obj.is_array());
+              TORCH_CHECK_EQ(obj.size(), flats.size());
+              dict.reserve(flats.size());
+              for (size_t i = 0; i < flats.size(); i++) {
+                dict.insert(dynamicToIValue(obj[i]), std::move(flats[i]));
+              }
+              return dict;
+            },
+            [](ITreeMapNoReturnFn fn,
+               const c10::IValue& nested,
+               const ITreeSpec& spec) {
+              auto dict = nested.toGenericDict();
+              const auto& contextKeys = spec.contextKeys();
+
+              size_t i = 0;
+              for (const auto& key : contextKeys) {
+                if (spec.children(i).isUsed()) {
+                  auto it = dict.find(key);
+                  if (it != dict.end()) {
+                    ivalueApply(fn, it->value(), spec.children(i));
+                  } else {
+                    TORCH_CHECK(false, "input arg is missing key ", key);
+                  }
+                }
+                i++;
+              }
+            }});
+    registerNode(
+        "torch.fx.immutable_collections.immutable_dict",
+        getNodeDef("builtins.dict"));
+  }
+  bool hasNodeDef(std::string_view typeName) const {
+    return registry_.find(std::string{typeName}) != registry_.end();
+  }
+  const NodeDef& getNodeDef(std::string_view typeName) const {
+    return registry_.at(std::string{typeName});
+  }
+  void registerNode(std::string_view typeName, NodeDef nodeDef) {
+    TORCH_CHECK(!hasNodeDef(typeName));
+    registry_.emplace(typeName, nodeDef);
+  }
+
+ private:
+  std::unordered_map<std::string, NodeDef> registry_;
+};
+
+c10::Synchronized<PytreeNodeRegistry>& getPytreeNodeRegistry() {
+  static auto* registry = new c10::Synchronized<PytreeNodeRegistry>();
+  return *registry;
+}
+
+ITreeSpec makeITreeSpec(
+    const nlohmann::json& obj,
+    const std::vector<const Value*>& values,
+    int start) {
+  TORCH_CHECK(obj.is_object());
+  TORCH_CHECK(obj.find("type") != obj.end());
+  if (obj["type"].is_null()) {
+    TORCH_CHECK_EQ(obj["children_spec"].size(), 0);
+    TORCH_CHECK(obj["context"].is_null());
+
+    const Value* value = values[start];
+    if (value) {
+      bool isUsed = !value->users().empty();
+      return ITreeSpec(value, isUsed);
+    } else {
+      return ITreeSpec(value, false);
+    }
+  }
+  const auto& name = obj["type"].get<std::string>();
+  NodeDef nodeDefCache;
+  getPytreeNodeRegistry().withLock([&](auto& registry) {
+    TORCH_CHECK(registry.hasNodeDef(name), "Unknown pytree node type: ", name);
+    nodeDefCache = registry.getNodeDef(name);
+  });
+  auto context = nodeDefCache.contextLoadFn(obj["context"].get<std::string>());
+  const auto& childrenSpec = obj["children_spec"];
+  TORCH_CHECK(childrenSpec.is_array());
+  std::vector<ITreeSpec> children;
+  int offset = 0;
+  for (const auto& child : childrenSpec) {
+    children.push_back(makeITreeSpec(child, values, start + offset));
+    // NOLINTNEXTLINE(*-narrowing-conversions)
+    offset += children.back().numIValues();
+  }
+
+  return ITreeSpec(name, context, std::move(children), nodeDefCache);
+}
+
+} // namespace
+
+void registerPytreeNode(std::string_view typeName, NodeDef nodeDef) {
+  getPytreeNodeRegistry().withLock([&](auto& registry) {
+    registry.registerNode(typeName, std::move(nodeDef));
+  });
+}
+
+ITreeSpec itreeSpecLoads(
+    std::string_view json,
+    const std::vector<const Value*>& values) {
+  const auto obj = nlohmann::json::parse(json);
+  TORCH_CHECK(obj.is_array());
+  TORCH_CHECK_EQ(obj.size(), 2);
+  TORCH_CHECK_EQ(obj[0].get<int64_t>(), kDefaultTreeSpecSerializationProtocol);
+  auto result = makeITreeSpec(obj[1], values, 0);
+
+  TORCH_CHECK_EQ(result.numIValues(), values.size());
+  return result;
+}
+
+c10::IValue itreeUnflatten(
+    std::vector<c10::IValue> ivalues,
+    const ITreeSpec& spec) {
+  RECORD_USER_SCOPE("nativert::itreeUnflatten");
+  TORCH_CHECK_EQ(ivalues.size(), spec.numIValues());
+  if (spec.isIValue()) {
+    return std::move(ivalues[0]);
+  }
+  auto unflattenFn = spec.nodeDefCache().unflattenFn;
+  if (spec.allIValues()) {
+    return unflattenFn(std::move(ivalues), spec.context());
+  }
+  size_t start = 0;
+  std::vector<c10::IValue> childrenPytrees;
+  for (const auto& child : spec.children()) {
+    if (child.isIValue()) {
+      childrenPytrees.push_back(std::move(ivalues[start]));
+      start++;
+      continue;
+    }
+    size_t numIValues = child.numIValues();
+    std::vector<c10::IValue> slice(
+        // NOLINTNEXTLINE(*-narrowing-conversions)
+        std::make_move_iterator(ivalues.begin() + start),
+        // NOLINTNEXTLINE(*-narrowing-conversions)
+        std::make_move_iterator(ivalues.begin() + start + numIValues));
+    childrenPytrees.push_back(itreeUnflatten(std::move(slice), child));
+    start += numIValues;
+  }
+  return unflattenFn(std::move(childrenPytrees), spec.context());
+}
+
+std::vector<c10::IValue> itreeFlatten(
+    const c10::IValue& nested,
+    const ITreeSpec& spec) {
+  std::vector<c10::IValue> ivalues;
+  ivalues.reserve(spec.numIValues());
+  itreeFlatten(nested, spec, ivalues);
+  return ivalues;
+}
+
+std::vector<c10::IValue> itreeFlattenFromArgs(
+    const std::vector<c10::IValue>& args,
+    const std::unordered_map<std::string, c10::IValue>& kwargs,
+    const ITreeSpec& spec) {
+  RECORD_USER_SCOPE("nativert::itreeFlattenFromArgs");
+  TORCH_CHECK(!spec.isIValue());
+  TORCH_CHECK_EQ(spec.children().size(), 2);
+
+  std::vector<c10::IValue> ivalues;
+  ivalues.reserve(spec.numIValues());
+  const auto& specArgs = spec.children(0);
+  TORCH_CHECK(!specArgs.isIValue());
+  TORCH_CHECK_EQ(specArgs.children().size(), args.size());
+  for (size_t i = 0; i < args.size(); i++) {
+    itreeFlatten(args[i], specArgs.children(i), ivalues);
+  }
+
+  const auto& specKwargs = spec.children(1);
+  TORCH_CHECK(!specKwargs.isIValue());
+  TORCH_CHECK_EQ(specKwargs.context().size(), kwargs.size());
+  for (size_t i = 0; i < specKwargs.context().size(); i++) {
+    itreeFlatten(
+        kwargs.at(specKwargs.context()[i].get_ref<const std::string&>()),
+        specKwargs.children(i),
+        ivalues);
+  }
+  return ivalues;
+}
+
+void ivalueApplyFromArgs(
+    ITreeMapNoReturnFn fn,
+    const std::vector<c10::IValue>& args,
+    const std::unordered_map<std::string, c10::IValue>& kwargs,
+    const ITreeSpec& spec) {
+  RECORD_USER_SCOPE("nativert::ivalueApplyFromArgs");
+  TORCH_CHECK(!spec.isIValue());
+  TORCH_CHECK_EQ(spec.children().size(), 2);
+
+  const auto& specArgs = spec.children(0);
+  TORCH_CHECK(!specArgs.isIValue());
+  TORCH_CHECK_EQ(specArgs.children().size(), args.size());
+  for (size_t i = 0; i < args.size(); i++) {
+    ivalueApply(fn, args[i], specArgs.children(i));
+  }
+
+  const auto& specKwargs = spec.children(1);
+  TORCH_CHECK(!specKwargs.isIValue());
+
+  const auto& ctx = specKwargs.context();
+  TORCH_CHECK_EQ(ctx.size(), kwargs.size());
+
+  for (size_t i = 0; i < ctx.size(); i++) {
+    ivalueApply(
+        fn,
+        kwargs.at(ctx[i].get_ref<const std::string&>()),
+        specKwargs.children(i));
+  }
+}
+
+std::vector<at::Tensor> itreeFlattenToTensorList(
+    const c10::IValue& nested,
+    const ITreeSpec& spec) {
+  auto flats = itreeFlatten(nested, spec);
+  std::vector<at::Tensor> tensors;
+  tensors.reserve(flats.size());
+  for (const auto& flat : flats) {
+    tensors.push_back(flat.toTensor());
+  }
+  return tensors;
+}
+
+c10::IValue itreeMap(
+    ITreeMapFn f,
+    const c10::IValue& nested,
+    const ITreeSpec& spec) {
+  const auto flats = itreeFlatten(nested, spec);
+  std::vector<c10::IValue> mapped;
+  mapped.reserve(flats.size());
+  for (const auto& flat : flats) {
+    mapped.push_back(f(flat));
+  }
+  return itreeUnflatten(std::move(mapped), spec);
+}
+
+c10::IValue argsToIValue(
+    const std::vector<c10::IValue>& args,
+    const std::unordered_map<std::string, c10::IValue>& kwargs) {
+  c10::Dict<c10::IValue, c10::IValue> dict(
+      c10::StringType::get(), c10::AnyType::get());
+  for (const auto& [key, arg] : kwargs) {
+    dict.insert(key, arg);
+  }
+  return c10::ivalue::Tuple::create({c10::ivalue::Tuple::create(args), dict});
+}
+
+std::
+    pair<std::vector<c10::IValue>, std::unordered_map<std::string, c10::IValue>>
+    itreeMapArgs(
+        ITreeMapFn f,
+        const std::vector<c10::IValue>& args,
+        const std::unordered_map<std::string, c10::IValue>& kwargs,
+        const ITreeSpec& spec) {
+  const auto val = argsToIValue(args, kwargs);
+  const auto mapVal = itreeMap(f, val, spec);
+  auto mapArgs =
+      mapVal.toTupleRef().elements()[0].toTupleRef().elements().vec();
+  std::unordered_map<std::string, c10::IValue> mapKwargs;
+  for (const auto& entry : mapVal.toTupleRef().elements()[1].toGenericDict()) {
+    mapKwargs.emplace(entry.key().toStringRef(), entry.value());
+  }
+  return {std::move(mapArgs), std::move(mapKwargs)};
+}
+
+void ivalueApply(
+    ITreeMapNoReturnFn fn,
+    const c10::IValue& nested,
+    const ITreeSpec& spec) {
+  if (spec.isIValue()) {
+    if (spec.isUsed()) {
+      fn(nested, spec.value());
+    }
+    return;
+  }
+  auto ivalueApplyFn = spec.nodeDefCache().ivalueApplyFn;
+  ivalueApplyFn(fn, nested, spec);
+}
+
+nlohmann::json defaultContextLoadFn(std::string_view context) {
+  return nlohmann::json::parse(context);
+}
+
+ITreeSpec::ITreeSpec(
+    std::string_view uniformName,
+    nlohmann::json context,
+    std::vector<ITreeSpec> children,
+    NodeDef nodeDefCache)
+    : uniformName_(uniformName),
+      context_(std::move(context)),
+      children_(std::move(children)),
+      nodeDefCache_(nodeDefCache),
+      numIValues_(0),
+      value_(nullptr),
+      isUsed_(false) {
+  for (auto& child : children_) {
+    numIValues_ += child.numIValues();
+    allIValues_ &= child.isIValue();
+    isUsed_ |= child.isUsed();
+  }
+
+  if (uniformName_ == "builtins.dict" ||
+      uniformName_ == "torch.fx.immutable_collections.immutable_dict") {
+    for (const auto& keyObj : context_) {
+      contextKeys_.push_back(dynamicToIValue(keyObj));
+    }
+  }
+}
+
+c10::TypePtr ITreeSpec::toAtenType() const {
+  if (isIValue()) {
+    return c10::AnyType::get();
+  } else if (uniformName_ == "builtins.tuple") {
+    std::vector<c10::TypePtr> childrenType;
+    childrenType.reserve(children_.size());
+    for (const auto& childrenSpec : children_) {
+      childrenType.emplace_back(childrenSpec.toAtenType());
+    }
+    return c10::TupleType::create(std::move(childrenType));
+  } else if (
+      uniformName_ == "builtins.list" ||
+      uniformName_ == "torch.fx.immutable_collections.immutable_list") {
+    if (children_.empty()) {
+      return c10::ListType::create(c10::AnyType::get());
+    } else {
+      return c10::ListType::create(children_[0].toAtenType());
+    }
+  } else if (
+      uniformName_ == "builtins.dict" ||
+      uniformName_ == "torch.fx.immutable_collections.immutable_dict") {
+    if (children_.empty()) {
+      return c10::DictType::create(c10::AnyType::get(), c10::AnyType::get());
+    } else {
+      return c10::DictType::create(
+          dynamicToIValue(context_[0]).type(), children_[0].toAtenType());
+    }
+  } else {
+    TORCH_CHECK(false, "Unsupported uniform name: ", uniformName());
+  }
+}
+
+} // namespace torch::nativert::detail

--- a/torch/nativert/detail/ITree.h
+++ b/torch/nativert/detail/ITree.h
@@ -1,0 +1,178 @@
+/*
+ * A C++ extension bridge with the Python pytree
+ * serialization/unserialization format for torch.export.
+ */
+
+#pragma once
+
+#include <optional>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include <ATen/core/ivalue.h>
+#include <nlohmann/json.hpp>
+#include <torch/nativert/graph/Graph.h>
+
+namespace torch::nativert::detail {
+
+using torch::nativert::Value;
+
+class ITreeSpec;
+
+using ITreeFlattenFn =
+    void (*)(const c10::IValue&, const ITreeSpec&, std::vector<c10::IValue>&);
+using ITreeUnflattenFn =
+    c10::IValue (*)(std::vector<c10::IValue>, const nlohmann::json&);
+
+using ContextLoadFn = nlohmann::json (*)(std::string_view);
+
+using ITreeMapFn = c10::function_ref<c10::IValue(const c10::IValue&)>;
+using ITreeMapNoReturnFn =
+    c10::function_ref<void(const c10::IValue&, const Value*)>;
+
+using IValueApplyFn =
+    void (*)(ITreeMapNoReturnFn, const c10::IValue&, const ITreeSpec&);
+
+nlohmann::json defaultContextLoadFn(std::string_view);
+
+struct NodeDef {
+  ITreeFlattenFn flattenFn;
+  ITreeUnflattenFn unflattenFn;
+  IValueApplyFn ivalueApplyFn;
+
+  ContextLoadFn contextLoadFn = defaultContextLoadFn;
+};
+
+class ITreeSpec {
+ public:
+  // Leaf node.
+  ITreeSpec(const Value* value = nullptr, bool isUsed = true)
+      : numIValues_(1), value_(value), isUsed_(isUsed) {}
+
+  // Non leaf node.
+  ITreeSpec(
+      std::string_view uniformName,
+      nlohmann::json context,
+      std::vector<ITreeSpec> children,
+      NodeDef nodeDefCache);
+
+  bool isIValue() const {
+    return !uniformName_;
+  }
+
+  std::string_view uniformName() const {
+    TORCH_CHECK(uniformName_);
+    return uniformName_.value();
+  }
+
+  const nlohmann::json& context() const {
+    return context_;
+  }
+
+  const std::vector<c10::IValue>& contextKeys() const {
+    return contextKeys_;
+  }
+
+  const auto& children() const {
+    return children_;
+  }
+
+  const ITreeSpec& children(size_t i) const {
+    return children_[i];
+  }
+
+  const NodeDef& nodeDefCache() const {
+    return nodeDefCache_;
+  }
+
+  size_t numIValues() const {
+    return numIValues_;
+  }
+
+  bool allIValues() const {
+    return allIValues_;
+  }
+
+  c10::TypePtr toAtenType() const;
+
+  bool isUsed() const {
+    return isUsed_;
+  }
+
+  const Value* value() const {
+    return value_;
+  }
+
+ private:
+  // Only non leaf nodes have names.
+  // Examples of uniform name: "builtins.tuple", "builtins.dict".
+  std::optional<std::string> uniformName_;
+  nlohmann::json context_;
+  std::vector<ITreeSpec> children_;
+
+  std::vector<c10::IValue> contextKeys_;
+
+  // Cached fields.
+  NodeDef nodeDefCache_;
+  size_t numIValues_;
+  bool allIValues_ = true;
+
+  const Value* value_;
+  bool isUsed_;
+};
+
+void registerPytreeNode(std::string_view typeName, NodeDef nodeDef);
+
+// Serialized json tree spec should be dumped from treespec_dumps() in
+// torch.utils._pytree directly .
+ITreeSpec itreeSpecLoads(
+    std::string_view json,
+    const std::vector<const Value*>& values);
+
+c10::IValue itreeUnflatten(
+    std::vector<c10::IValue> ivalues,
+    const ITreeSpec& spec);
+
+std::vector<c10::IValue> itreeFlatten(
+    const c10::IValue& nested,
+    const ITreeSpec& spec);
+
+std::vector<c10::IValue> itreeFlattenFromArgs(
+    const std::vector<c10::IValue>& args,
+    const std::unordered_map<std::string, c10::IValue>& kwargs,
+    const ITreeSpec& spec);
+
+std::vector<at::Tensor> itreeFlattenToTensorList(
+    const c10::IValue& nested,
+    const ITreeSpec& spec);
+
+c10::IValue itreeMap(
+    ITreeMapFn f,
+    const c10::IValue& nested,
+    const ITreeSpec& spec);
+
+c10::IValue TORCH_API argsToIValue(
+    const std::vector<c10::IValue>& args,
+    const std::unordered_map<std::string, c10::IValue>& kwargs);
+
+std::
+    pair<std::vector<c10::IValue>, std::unordered_map<std::string, c10::IValue>>
+    itreeMapArgs(
+        ITreeMapFn f,
+        const std::vector<c10::IValue>& args,
+        const std::unordered_map<std::string, c10::IValue>& kwargs,
+        const ITreeSpec& spec);
+
+void ivalueApply(
+    ITreeMapNoReturnFn f,
+    const c10::IValue& nested,
+    const ITreeSpec& spec);
+
+void ivalueApplyFromArgs(
+    ITreeMapNoReturnFn fn,
+    const std::vector<c10::IValue>& args,
+    const std::unordered_map<std::string, c10::IValue>& kwargs,
+    const ITreeSpec& spec);
+
+} // namespace torch::nativert::detail


### PR DESCRIPTION
Summary: fbcode/sigmoid/core/common -> fbcode/caffe2/torch/nativert/common

Torch Native Runtime RFC: https://github.com/pytorch/rfcs/pull/72

Test Plan:
```
buck run fbcode//mode/dev-nosan  //caffe2/test/cpp/nativert:pytree_test
```

OSS CI

Rollback Plan:

Differential Revision: D75965059
