### PR TITLE
[c10d][fr] Add the log of thread name and thread id into fr

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -455,7 +455,6 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
         # This unit test is to test the case when the collective is launched in
         # a side thread and the thread dies before the cache has been fully recycled.
         # More details can be found in this issue: https://github.com/pytorch/pytorch/issues/143470.
-        import threading
 
         # initiate collectives here
         def init_collective_task(t):
@@ -477,6 +476,9 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
         side_thread.start()
         side_thread.join()
         torch.cuda.synchronize()
+
+        # reset ENV
+        os.environ["TORCH_NCCL_CUDA_EVENT_CACHE"] = "0"
 
     CUDA_12_AND_ABOVE = torch.cuda.is_available() and (
         torch.version.cuda is not None and int(torch.version.cuda.split(".")[0]) >= 12
@@ -4276,6 +4278,8 @@ class NCCLTraceTest(NCCLTraceTestBase):
             self.assertEqual(len(t["entries"]), 2)
             t = t["entries"]
             last = t[-1]
+            self.assertEqual(last["thread_id"], str(threading.current_thread().ident))
+            self.assertEqual(last["thread_name"], "fr_test_thread")
             self.assertEqual(last["process_group"], ("0", "default_pg"))
             self.assertEqual(last["state"], "completed")
             s = last["time_discovered_started_ns"]
@@ -4308,6 +4312,23 @@ class NCCLTraceTest(NCCLTraceTestBase):
         else:
             self.assertTrue("entries" not in t)
 
+    # Directly set thread name using threading.current_thread().name does not work
+    # because we use pthread_getname_np to get the thread’s OS-level name in C++
+    def set_thread_name(self, name):
+        import ctypes
+
+        libc = ctypes.cdll.LoadLibrary("libc.so.6")
+        pthread_self = libc.pthread_self
+        pthread_self.restype = ctypes.c_void_p
+        pthread_setname_np = libc.pthread_setname_np
+        pthread_setname_np.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+
+        # Get current pthread handle
+        tid = pthread_self()
+
+        # Set name
+        pthread_setname_np(tid, name.encode())
+
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     @parametrize("timing_enabled", [True, False])
@@ -4319,6 +4340,7 @@ class NCCLTraceTest(NCCLTraceTestBase):
         if timing_enabled:
             pg._enable_collectives_timing()
         device = self.local_device
+        self.set_thread_name("fr_test_thread")
         a = torch.full((3, 4), float(self.rank), device=device)
         for _ in range(2):
             f = pg.allreduce(a)
@@ -4345,6 +4367,7 @@ class NCCLTraceTest(NCCLTraceTestBase):
         if timing_enabled:
             pg._enable_collectives_timing()
         device = self.local_device
+        self.set_thread_name("fr_test_thread")
         a = torch.full((3, 4), float(self.rank), device=device)
         for _ in range(2):
             f = pg.allreduce(a)

--- a/torch/csrc/distributed/c10d/FlightRecorder.hpp
+++ b/torch/csrc/distributed/c10d/FlightRecorder.hpp
@@ -53,6 +53,8 @@ DEFINE_CONSTANT(time_discovered_completed_key, "time_discovered_completed_ns")
 DEFINE_CONSTANT(completed_state, "completed")
 DEFINE_CONSTANT(scheduled_state, "scheduled")
 DEFINE_CONSTANT(started_state, "started")
+DEFINE_CONSTANT(thread_id_key, "thread_id")
+DEFINE_CONSTANT(thread_name_key, "thread_name")
 #undef DEFINE_CONSTANT
 
 // Write NCCL debug info to local disk or any storage users define.
@@ -154,6 +156,8 @@ struct FlightRecorder {
     c10::SmallVector<int64_t, 4> output_dims_;
     std::vector<c10::ScalarType> output_dtypes_;
     c10::SmallVector<int64_t, 8> sizes_; // flattened from inputs, outputs
+    std::thread::id thread_id_;
+    std::string thread_name_;
     bool retired_ = false; // is this work entry no longer in the workMetaList_?
                            // a retired but not completed event has timed out
 

--- a/torch/csrc/distributed/c10d/FlightRecorderDetail.hpp
+++ b/torch/csrc/distributed/c10d/FlightRecorderDetail.hpp
@@ -1,6 +1,7 @@
 #include <nlohmann/json.hpp>
 
 #include <c10/util/WaitCounter.h>
+#include <c10/util/thread_name.h>
 
 #include <torch/csrc/distributed/c10d/FlightRecorder.hpp>
 
@@ -85,6 +86,8 @@ std::optional<size_t> FlightRecorder<EventType>::record(
       {},
       {},
       {},
+      std::this_thread::get_id(),
+      c10::getThreadName(),
       false};
 
   for (const auto& input : inputs) {
@@ -286,6 +289,8 @@ const c10::List<c10::IValue> FlightRecorder<EventType>::getCollectiveTrace(
     dict.insert(record_id_key, int64_t(e.id_));
     dict.insert(pg_id_key, int64_t(e.pg_id_));
     dict.insert(pg_name_key, e.pg_name_);
+    dict.insert(thread_name_key, e.thread_name_);
+    dict.insert(thread_id_key, c10::str(e.thread_id_));
     dict.insert(collective_seq_id_key, int64_t(e.collective_seq_id_));
     dict.insert(p2p_seq_id_key, int64_t(e.p2p_seq_id_));
     dict.insert(op_id_key, int64_t(e.op_id_));
@@ -433,6 +438,8 @@ std::string FlightRecorder<EventType>::dump_json(
       j[record_id_key_str] = int64_t(e.id_);
       j[pg_id_key_str] = int64_t(e.pg_id_);
       j[pg_name_key_str] = e.pg_name_;
+      j[thread_name_key_str] = e.thread_name_;
+      j[thread_id_key_str] = c10::str(e.thread_id_);
       j[collective_seq_id_key_str] = int64_t(e.collective_seq_id_);
       j[p2p_seq_id_key_str] = int64_t(e.p2p_seq_id_);
       j[op_id_key_str] = int64_t(e.op_id_);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #155142

There is an ask from internal head users to have thread id and thread name inside fr. This would be useful to users when it comes to cases when we launches collectives not just on main thread as well.


cc @H-Huang @awgu @wanchaol @fegin @wz337 @wconstab @d4l3k

Differential Revision: [D75973919](https://our.internmc.facebook.com/intern/diff/D75973919)