### PR TITLE
[ROCm] Make rocm-core dependency optional 

### DIFF
--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -80,7 +80,7 @@ if(HIP_FOUND)
   find_package_and_print_version(hip REQUIRED CONFIG)
   # Find ROCM version for checks. UNIX filename is rocm_version.h, Windows is hip_version.h
   if(UNIX)
-    find_package_and_print_version(rocm-core REQUIRED CONFIG)
+    find_package_and_print_version(rocm-core CONFIG)
     find_file(ROCM_VERSION_HEADER_PATH NAMES rocm_version.h
       HINTS ${rocm_core_INCLUDE_DIR}/rocm-core /usr/include)
   else() # Win32

--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -82,7 +82,7 @@ if(HIP_FOUND)
   if(UNIX)
     find_package_and_print_version(rocm-core CONFIG)
     find_file(ROCM_VERSION_HEADER_PATH NAMES rocm_version.h
-      HINTS ${rocm_core_INCLUDE_DIR}/rocm-core /usr/include)
+      HINTS ${rocm_core_INCLUDE_DIR}/rocm-core ${ROCM_PATH}/include /usr/include)
   else() # Win32
     find_file(ROCM_VERSION_HEADER_PATH NAMES hip_version.h
       HINTS ${hip_INCLUDE_DIR}/hip)

--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -82,7 +82,7 @@ if(HIP_FOUND)
   if(UNIX)
     find_package_and_print_version(rocm-core CONFIG)
     find_file(ROCM_VERSION_HEADER_PATH NAMES rocm_version.h
-      HINTS ${rocm_core_INCLUDE_DIR}/rocm-core ${ROCM_PATH}/include /usr/include)
+      HINTS ${rocm_core_INCLUDE_DIR}/rocm-core ${ROCM_PATH}/include/rocm-core /usr/include)
   else() # Win32
     find_file(ROCM_VERSION_HEADER_PATH NAMES hip_version.h
       HINTS ${hip_INCLUDE_DIR}/hip)


### PR DESCRIPTION
rocm-core cmake is not available in ROCm6.2; rocm-core is also not packaged in Debian as per https://github.com/icl-utk-edu/magma/pull/27#issue-2752067707. Hence make it optional.


cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd