### PR TITLE
[MPS] Add device guard for MPS dispatch key

### DIFF
--- a/torchgen/gen.py
+++ b/torchgen/gen.py
@@ -61,6 +61,7 @@ from torchgen.model import (
     FunctionSchema,
     is_cuda_dispatch_key,
     is_generic_dispatch_key,
+    is_mps_dispatch_key,
     is_ufunc_dispatch_key,
     is_xpu_dispatch_key,
     Location,
@@ -210,7 +211,11 @@ def parse_native_yaml_struct(
             use_out_as_primary=True,
             external=False,
             # Only cuda-like devices in tree require device guards
-            device_guard=is_cuda_dispatch_key(k) or is_xpu_dispatch_key(k),
+            device_guard=(
+                is_cuda_dispatch_key(k)
+                or is_xpu_dispatch_key(k)
+                or is_mps_dispatch_key(k)
+            ),
             index=v,
         )
     return ParsedYaml(rs, indices)

--- a/torchgen/model.py
+++ b/torchgen/model.py
@@ -345,6 +345,13 @@ def is_xpu_dispatch_key(dk: DispatchKey) -> bool:
     }
 
 
+# MPS specific dispatch keys
+def is_mps_dispatch_key(dk: DispatchKey) -> bool:
+    return dk in {
+        DispatchKey.MPS,
+    }
+
+
 # Structured kernel generation is only supported for certain key types;
 # otherwise use old-style
 def is_structured_dispatch_key(dk: DispatchKey) -> bool:
@@ -356,7 +363,11 @@ def is_ufunc_dispatch_key(dk: DispatchKey) -> bool:
     return dk in UFUNC_DISPATCH_KEYS
 
 
-dispatch_device_map = {is_cuda_dispatch_key: "cuda", is_xpu_dispatch_key: "xpu"}
+dispatch_device_map = {
+    is_cuda_dispatch_key: "cuda",
+    is_xpu_dispatch_key: "xpu",
+    is_mps_dispatch_key: "mps",
+}
 
 
 # This is oddly named ScalarType and not DType for symmetry with C++


### PR DESCRIPTION
- Add `is_mps_dispatch_key()` function to identify MPS dispatch keys
- Include MPS in device guard generation alongside CUDA and XPU
- Add MPS to `dispatch_device_map` for consistency

This prevents crashes when operations like `solve_triangular` are called with tensors on
different devices (e.g., CPU and MPS). Without device guards, MPS operations could crash
with segmentation faults when mixing CPU and MPS tensors.

Fixes #142048

Test Plan:
- Relying on CI to verify the fix works correctly
- The fix follows the same pattern as existing CUDA and XPU device guards
- Example test case that should pass after this fix:
  ```python
  # This would previously crash with SIGSEGV
  A_mps = torch.randn(3, 3, device='mps').triu()
  B_cpu = torch.randn(3, 2, device='cpu')
  
  # Should now raise: RuntimeError: Expected all tensors to be on the same device
  with pytest.raises(RuntimeError, match="Expected all tensors to be on the same device"):
      torch.linalg.solve_triangular(A_mps, B_cpu, upper=True)
  
  # Same device should work correctly
  B_mps = B_cpu.to('mps')
  result = torch.linalg.solve_triangular(A_mps, B_mps, upper=True)
  assert result.device.type == 'mps'
  ```