### PR TITLE
[export] inline jit.scripted function in export

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -634,6 +634,51 @@ graph():
         # instead of the scripted function, so we get x.sin()
         self.assertEqual(res, x.sin())
 
+    def test_inline_script_class_method(self):
+        class M(torch.nn.Module):
+            @staticmethod
+            @torch.jit.script
+            def _forward(x: torch.Tensor):
+                if torch.jit.is_scripting():
+                    return x.cos()
+                return x.sin()
+
+            def forward(self, x: torch.Tensor):
+                return M._forward(x)
+
+        x = torch.randn(3, 4)
+        ep = torch.export.export(M(), (x,))
+        res = ep.module()(x)
+        # We're inlining the original _forward function
+        # instead of the scripted function, so we get x.sin()
+        self.assertEqual(res, x.sin())
+
+    def test_inline_script_method(self):
+        class M(torch.jit.ScriptModule):
+            @torch.jit.script_method
+            def _forward(self, x: torch.Tensor):
+                if torch.jit.is_scripting():
+                    return x.cos()
+                return x.sin()
+
+            def forward(self, x):
+                return self._forward(x)
+
+        class Wrapped(torch.nn.Module):
+            def __init__(self, mod):
+                super().__init__()
+                self.mod = mod
+
+            def forward(self, x):
+                return self.mod(x)
+
+        x = torch.randn(3, 4)
+        ep = torch.export.export(Wrapped(M()), (x,))
+        res = ep.module()(x)
+        # We're inlining the original _forward function
+        # instead of the scripted function, so we get x.sin()
+        self.assertEqual(res, x.sin())
+
     def test_no_tensor_computation_2(self):
         class Module(torch.nn.Module):
             def forward(self, x, y):

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -1490,7 +1490,7 @@ void initJitScriptBindings(PyObject* module) {
                     .attr("compiler")
                     .attr("is_exporting")()
                     .cast<bool>()) {
-              TORCH_CHECK(
+              TORCH_INTERNAL_ASSERT(
                   py::hasattr(args[0], py::str("_torchdynamo_inline")),
                   "During PT2 exporting, we encountered TorchScripted function",
                   strongPtr.function_->name(),

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -1616,16 +1616,14 @@ void initJitScriptBindings(PyObject* module) {
                 // TODO: fix all cases where ScriptMethod doesn't have
                 // __wrapped__, which is the non-scripted original method. E.g.
                 // it seems the top-level script module's scriptMethod doesn't
-                // have __wrapped__ attributes. For example:
+                // have __wrapped__ attributes:
                 //  class M(torch.nn.Module):
                 //    def forward(self, x):
                 //        return x.cos() + x.sin()
                 //  traced_module = torch.jit.trace(M(), example_inputs=inps)
-                // ,where traced_module.forward is a ScriptMethod but doesn't
-                // have __wrapped__
+                // , where traced_module.forward is a ScriptMethod but doesn't
+                // have __wrapped__.
                 py::hasattr(args[0], "__wrapped__")) {
-              // remove the function itself with args[1:]
-              py::slice slice0(1, args.size(), 1);
               return args[0].attr("__wrapped__")(*args, **kwargs);
             } else {
               // see: [pybind11 varargs]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #155381
* __->__ #155180

When we export a scripted function, we inline the original callable stored in "_torchdynamo_inline", this is the same strategy as torch.compile path. 

We do the same thing for script method, where a "\_\_wrapped\_\_" attribute points to the original callable in most cases. There are some corner cases we identified: top-level jit.scripted modules' method doesn't have a \_\_wrapped\_\_. In this case, we fall back to the original scripted approach. Maybe there're more such cases but need verification.

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel