### PR TITLE
[DTensor] Support in gradient placement for local_map()

### DIFF
--- a/test/distributed/tensor/experimental/test_local_map.py
+++ b/test/distributed/tensor/experimental/test_local_map.py
@@ -5,7 +5,13 @@ from functools import partial
 import torch
 import torch.distributed._functional_collectives as funcol
 from torch.distributed.device_mesh import init_device_mesh
-from torch.distributed.tensor import distribute_tensor, DTensor, Replicate, Shard
+from torch.distributed.tensor import (
+    distribute_tensor,
+    DTensor,
+    Partial,
+    Replicate,
+    Shard,
+)
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.experimental import local_map
 from torch.testing._internal.common_utils import run_tests
@@ -317,6 +323,68 @@ class TestLocalMap(DTensorTestBase):
         )
         with self.assertRaisesRegex(ValueError, "set redistribute_inputs=True"):
             Y_dt = local_mm_allreduce_forward(device_mesh, X_dt, W_dt)
+
+    # check for `in_grad_placements` handling
+    @with_comms()
+    def test_local_map_with_grad_placement(self):
+        """
+        Test the gradient result is correct when we specify the right
+        `in_grad_placements`.
+        """
+        device_mesh = init_device_mesh(
+            device_type=self.device_type, mesh_shape=(self.world_size,)
+        )
+        torch.manual_seed(12)
+
+        # consider X as a batch of 2 on dim 0.
+        X = torch.randn(4, 2, device=self.device_type, requires_grad=True)
+        X1, X2 = torch.chunk(X, 2, dim=0)
+        X1 = X1.detach().requires_grad_()
+        X2 = X2.detach().requires_grad_()
+        W = torch.randn(2, 4, device=self.device_type, requires_grad=True)
+        Y1 = torch.mm(X1, W)
+        Y1.backward(torch.ones_like(Y1))
+        Y2 = torch.mm(X2, W)
+        Y2.backward(torch.ones_like(Y2))
+        in_placement_mismatch_choice = (True, False)
+        for is_in_placement_mismatch in in_placement_mismatch_choice:
+            if is_in_placement_mismatch:
+                # in_placements for local_map() will take effect
+                X_dt = distribute_tensor(X, device_mesh, replicate)
+            else:
+                # in_placements for local_map() will not take effect
+                X_dt = distribute_tensor(X, device_mesh, row_wise)
+            W_dt = distribute_tensor(W, device_mesh, replicate)
+            in_grad_placements = ([Shard(0)], [Partial()])
+
+            local_mm_forward = local_map(
+                mm_forward,
+                out_placements=[Shard(0)],
+                in_placements=(row_wise, replicate),  # simulate DDP
+                in_grad_placements=in_grad_placements,
+                device_mesh=device_mesh,
+                redistribute_inputs=True,
+            )
+            Y_dt = local_mm_forward(X_dt, W_dt)  # Y_dt is shard(0) now
+            self.assertEqual(Y_dt.full_tensor(), torch.cat([Y1, Y2], dim=0))
+
+            # Note: this is a way to simulate how DPP works. In fact, we don't
+            # need to all_gather the loss. Instead, we do all_reduce to each
+            # distributed weight.
+            local_Y = Y_dt.redistribute(placements=replicate)  # all_reduce loss
+            local_Y = local_Y.to_local()
+
+            local_Y.backward(torch.ones_like(local_Y))
+
+            if not is_in_placement_mismatch:
+                self.assertEqual(X_dt.grad.placements, in_grad_placements[0])
+                self.assertEqual(W_dt.grad.placements, in_grad_placements[1])
+            # regardless of is_in_placement_mismatch, grad output should always
+            # match
+            self.assertEqual(
+                X_dt.grad.full_tensor(), torch.cat([X1.grad, X2.grad], dim=0)
+            )
+            self.assertEqual(W_dt.grad.full_tensor(), W.grad)
 
 
 if __name__ == "__main__":

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -486,7 +486,7 @@ class DTensor(torch.Tensor):
     ) -> "DTensor":
         """
         ``redistribute`` performs necessary collective operations that redistribute the current
-        DTensor from its current placements to a new placements, or from is current DeviceMesh
+        DTensor from its current placements to a new placements, or from its current DeviceMesh
         to a new DeviceMesh. i.e. we can turn a Sharded DTensor to a Replicated DTensor by
         specifying a Replicate placement for each dimension of the DeviceMesh.
 

--- a/torch/distributed/tensor/experimental/_func_map.py
+++ b/torch/distributed/tensor/experimental/_func_map.py
@@ -27,6 +27,7 @@ def local_map(
     func: Callable,
     out_placements: OutputPlacements,
     in_placements: Optional[InputPlacements] = None,
+    in_grad_placements: Optional[InputPlacements] = None,
     device_mesh: Optional[DeviceMesh] = None,
     *,
     redistribute_inputs: bool = False,
@@ -66,6 +67,9 @@ def local_map(
             will be skipped and the argument will be directly passed to ``func``.
             If ``in_placements`` is ``None``, no placements examination will be performed.
             Default: None
+        in_grad_placements (Tuple[`PlacementType`, ...], optional):
+            the required placements of the :class:`DTensor` s gradient during back backpropagation.
+            The argument only applies to input of type :class:`DTensor`. Default: None.
         device_mesh (:class:`DeviceMesh`, optional):
             the device mesh that all the :class:`DTensor` s are placed on. If not
             specified, this will be inferred from the input :class:`DTensor` s' device
@@ -177,7 +181,17 @@ def local_map(
                                 "redistribute_inputs=True to local_map."
                             )
 
-                local_arg = arg.to_local()
+                if in_grad_placements is not None:
+                    spec = in_grad_placements[idx]
+                    assert spec is not None, (
+                        f"DTensor input {arg} expects in grad placements but received {spec}!"
+                    )
+                    if not isinstance(spec, tuple):
+                        spec = tuple(spec)
+                    local_arg = arg.to_local(grad_placements=spec)
+                else:
+                    local_arg = arg.to_local()
+
                 if isinstance(local_arg, AsyncCollectiveTensor):
                     local_arg = local_arg.wait()
 

--- a/torch/distributed/tensor/experimental/_func_map.py
+++ b/torch/distributed/tensor/experimental/_func_map.py
@@ -68,8 +68,13 @@ def local_map(
             If ``in_placements`` is ``None``, no placements examination will be performed.
             Default: None
         in_grad_placements (Tuple[`PlacementType`, ...], optional):
-            the required placements of the :class:`DTensor` s gradient during back backpropagation.
-            The argument only applies to input of type :class:`DTensor`. Default: None.
+            the placements hint of the :class:`DTensor` s gradient corresponds
+            to the flattened input DTensor. This argument is the hint that user
+            can give to :meth:`to_local` in case the gradient layout of the
+            local tensor input does not match its :class:`DTensor` input layout.
+            If not specified, we will assume the gradient layout of the local
+            tensor input remains the same as the original :class:`DTensor` input
+            and use that for gradient computation. Default: None.
         device_mesh (:class:`DeviceMesh`, optional):
             the device mesh that all the :class:`DTensor` s are placed on. If not
             specified, this will be inferred from the input :class:`DTensor` s' device


### PR DESCRIPTION
Support `in_grad_placements` argument in torch.distributed.tensor.experimental.local_map().  The argument helps enforce placement of gradient of the input Dtensor.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k