### PR TITLE
Reduce scope of s390x CI

### DIFF
--- a/.github/workflows/build-manywheel-images-s390x.yml
+++ b/.github/workflows/build-manywheel-images-s390x.yml
@@ -3,19 +3,9 @@ name: Build manywheel docker images for s390x
 on:
   workflow_dispatch:
   push:
-    branches:
-      - main
-      - release/*
     tags:
-      # NOTE: Binary build pipelines should only get triggered on release candidate or nightly builds
-      # Release candidate tags look like: v1.11.0-rc1
-      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+      - ciflow/s390/*
     paths:
-      - .ci/docker/**
-      - .github/workflows/build-manywheel-images-s390x.yml
-  pull_request:
-    paths:
-      - .ci/docker/**
       - .github/workflows/build-manywheel-images-s390x.yml
 
 

--- a/.github/workflows/s390.yml
+++ b/.github/workflows/s390.yml
@@ -2,8 +2,6 @@ name: s390
 
 on:
   push:
-    branches:
-      - main
     tags:
       - ciflow/s390/*
   workflow_dispatch:

--- a/.github/workflows/s390x-periodic.yml
+++ b/.github/workflows/s390x-periodic.yml
@@ -9,8 +9,6 @@ on:
     tags:
       - ciflow/periodic/*
       - ciflow/s390/*
-    branches:
-      - release/*
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
The purpose of this change is to reduce scope of s390x CI to stop it potentially blocking usual workflows for other users
while still keeping nightly builds and tests for me to look at.