### PR TITLE
[PrivateUse1] Optimize privateuse1 backend user experiences

### DIFF
--- a/aten/src/ATen/native/EmbeddingBag.h
+++ b/aten/src/ATen/native/EmbeddingBag.h
@@ -22,7 +22,7 @@ enum class EmbeddingBagMode {
   return !(op1 == op2);
 }
 
-void check_arguments(
+TORCH_API void check_arguments(
     const Tensor& weight,
     const Tensor& indices,
     const Tensor& offsets,
@@ -30,7 +30,7 @@ void check_arguments(
     const std::optional<Tensor>& per_sample_weights,
     bool include_last_offset);
 
-void make_bag_size_out(
+TORCH_API void make_bag_size_out(
     Tensor& bag_size_out,
     const Tensor& offsets,
     const Tensor& indices,
@@ -38,7 +38,7 @@ void make_bag_size_out(
     const bool include_last_offset,
     const bool requires_grad);
 
-void make_max_indices_out(
+TORCH_API void make_max_indices_out(
     Tensor& max_indices_out,
     const Tensor& weight,
     const Tensor& indices,
@@ -47,7 +47,7 @@ void make_max_indices_out(
     const int64_t mode,
     bool include_last_offset);
 
-void make_offset2bag_out(
+TORCH_API void make_offset2bag_out(
     Tensor& offset2bag,
     Tensor& output,
     const Tensor& weight,

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -2078,7 +2078,8 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
            BackendComponent::HIPBit,
            BackendComponent::XPUBit,
            BackendComponent::HPUBit,
-           BackendComponent::MTIABit});
+           BackendComponent::MTIABit,
+           BackendComponent::PrivateUse1});
       constexpr auto dense_k = DispatchKeySet(DispatchKey::Dense);
       return ts.has_any(dense_k) && ts.has_any(dense_backends);
     };

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -2079,7 +2079,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
            BackendComponent::XPUBit,
            BackendComponent::HPUBit,
            BackendComponent::MTIABit,
-           BackendComponent::PrivateUse1});
+           BackendComponent::PrivateUse1Bit});
       constexpr auto dense_k = DispatchKeySet(DispatchKey::Dense);
       return ts.has_any(dense_k) && ts.has_any(dense_backends);
     };

--- a/torchgen/model.py
+++ b/torchgen/model.py
@@ -309,6 +309,7 @@ dispatch_keys = [
     DispatchKey.NestedTensorMeta,
     DispatchKey.ZeroTensor,
     DispatchKey.MTIA,
+    DispatchKey.PrivateUse1,
 ]
 
 


### PR DESCRIPTION
I'm working on a customize backend support for pytorch, and here's what this PR does ( I think other developers that working on `PrivateUse1` backend can be benifit from it:
1. `EmbeddingBag.h`: These utilities functions are very useful when we implementing such operators, but we have to add `TORCH_API` to make it visible from out side of PyTorch project.
2. `TensorImpl.h`: The dense dispatch key set are used for almost every backend, since it has supported MTIABit, well I think adding one Privateuse1 is quite reasonable ( in fact, we do are using it)
3. `model.py`: We can reuse the torchgen to register and implement operators, so the `Privateuse1` key is quite needed.

cc @NmomoN @mengpenghui @fwenguang @cdzhan @1274085042 @PHLens @albanD