### PR TITLE
Add serialized_type_name to torch.return_types.* so we can dump them

### DIFF
--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -1183,6 +1183,21 @@ if "optree" in sys.modules:
         roundtrip_spec = py_pytree.treespec_loads(serialized_spec)
         self.assertEqual(roundtrip_spec, spec)
 
+    def test_pytree_serialize_torch_return_types(self):
+        spec = py_pytree.TreeSpec(
+            torch.return_types.max,
+            None,
+            [
+                py_pytree.LeafSpec(),
+                py_pytree.LeafSpec(),
+            ],
+        )
+
+        serialized_spec = py_pytree.treespec_dumps(spec, 1)
+        self.assertIn("torch.return_types.max", serialized_spec)
+        roundtrip_spec = py_pytree.treespec_loads(serialized_spec)
+        self.assertEqual(roundtrip_spec, spec)
+
     def test_pytree_serialize_register_bad(self):
         class DummyType:
             def __init__(self, x, y):

--- a/torch/return_types.py
+++ b/torch/return_types.py
@@ -27,6 +27,7 @@ def pytree_register_structseq(cls):
         cls,
         structseq_flatten,
         structseq_unflatten,
+        serialized_type_name=f"{cls.__module__}.{cls.__qualname__}",
         flatten_with_keys_fn=structseq_flatten_with_keys,
     )
 


### PR DESCRIPTION
Summary: as title

Test Plan:
```
buck run mode/dev-nosan fbcode//caffe2/test:pytree -- -r test_pytree_serialize_torch_return_types
```

Rollback Plan:

Differential Revision: D76058746


