### PR TITLE
Add STD_TORCH_CHECK to torch::standalone

### DIFF
--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -23,6 +23,7 @@
 #endif // C10_USING_CUSTOM_GENERATED_MACROS
 
 #include <c10/macros/Export.h>
+#include <torch/standalone/macros/Macros.h>
 
 #if defined(__clang__)
 #define __ubsan_ignore_float_divide_by_zero__ \
@@ -96,9 +97,6 @@
 #define C10_CONCATENATE(s1, s2) C10_CONCATENATE_IMPL(s1, s2)
 
 #define C10_MACRO_EXPAND(args) args
-
-#define C10_STRINGIZE_IMPL(x) #x
-#define C10_STRINGIZE(x) C10_STRINGIZE_IMPL(x)
 
 /**
  * C10_ANONYMOUS_VARIABLE(str) introduces a new identifier which starts with
@@ -175,26 +173,6 @@ using namespace c10::hip;
 namespace at::xpu {
 using namespace c10::xpu;
 } // namespace at::xpu
-
-// C10_LIKELY/C10_UNLIKELY
-//
-// These macros provide parentheses, so you can use these macros as:
-//
-//    if C10_LIKELY(some_expr) {
-//      ...
-//    }
-//
-// NB: static_cast to boolean is mandatory in C++, because __builtin_expect
-// takes a long argument, which means you may trigger the wrong conversion
-// without it.
-//
-#if defined(__GNUC__) || defined(__ICL) || defined(__clang__)
-#define C10_LIKELY(expr) (__builtin_expect(static_cast<bool>(expr), 1))
-#define C10_UNLIKELY(expr) (__builtin_expect(static_cast<bool>(expr), 0))
-#else
-#define C10_LIKELY(expr) (expr)
-#define C10_UNLIKELY(expr) (expr)
-#endif
 
 /// C10_NOINLINE - Functions whose declaration is annotated with this will not
 /// be inlined.

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -1,6 +1,8 @@
 #ifndef C10_UTIL_EXCEPTION_H_
 #define C10_UTIL_EXCEPTION_H_
 
+#include <torch/standalone/util/Exception.h>
+
 #include <c10/macros/Export.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/Backtrace.h>
@@ -364,27 +366,6 @@ C10_API std::string GetExceptionString(const std::exception& e);
 // invocations involving __VA_ARGS__.  See
 // https://stackoverflow.com/questions/5134523/msvc-doesnt-expand-va-args-correctly
 #define C10_EXPAND_MSVC_WORKAROUND(x) x
-
-// On nvcc, C10_UNLIKELY thwarts missing return statement analysis.  In cases
-// where the unlikely expression may be a constant, use this macro to ensure
-// return statement analysis keeps working (at the cost of not getting the
-// likely/unlikely annotation on nvcc).
-// https://github.com/pytorch/pytorch/issues/21418
-//
-// Currently, this is only used in the error reporting macros below.  If you
-// want to use it more generally, move me to Macros.h
-//
-// TODO: Brian Vaughan observed that we might be able to get this to work on
-// nvcc by writing some sort of C++ overload that distinguishes constexpr inputs
-// from non-constexpr.  Since there isn't any evidence that losing C10_UNLIKELY
-// in nvcc is causing us perf problems, this is not yet implemented, but this
-// might be an interesting piece of C++ code for an intrepid bootcamper to
-// write.
-#if defined(__CUDACC__)
-#define C10_UNLIKELY_OR_CONST(e) e
-#else
-#define C10_UNLIKELY_OR_CONST(e) C10_UNLIKELY(e)
-#endif
 
 // ----------------------------------------------------------------------------
 // Error reporting macros

--- a/test/cpp/aoti_abi_check/test_exception.cpp
+++ b/test/cpp/aoti_abi_check/test_exception.cpp
@@ -1,0 +1,19 @@
+#include <gtest/gtest.h>
+
+#include <torch/standalone/util/Exception.h>
+
+namespace torch {
+namespace aot_inductor {
+
+TEST(TestExceptions, TestStdTorchCheck) {
+  EXPECT_NO_THROW(STD_TORCH_CHECK(true, "dummy true message"));
+  EXPECT_NO_THROW(STD_TORCH_CHECK(true, "dummy ", "true ", "message"));
+  EXPECT_THROW(
+      STD_TORCH_CHECK(false, "dummy false message"), std::runtime_error);
+  EXPECT_THROW(
+      STD_TORCH_CHECK(false, "dummy ", "false ", "message"),
+      std::runtime_error);
+}
+
+} // namespace aot_inductor
+} // namespace torch

--- a/test/cpp/aoti_abi_check/test_macros.cpp
+++ b/test/cpp/aoti_abi_check/test_macros.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <torch/standalone/macros/Export.h>
+#include <torch/standalone/macros/Macros.h>
 
 namespace torch {
 namespace aot_inductor {
@@ -12,6 +13,12 @@ C10_API bool equal(int a, int b) {
 TEST(TestMacros, TestC10API) {
   EXPECT_TRUE(equal(1, 1));
   EXPECT_FALSE(equal(1, 2));
+}
+
+TEST(TestMacros, TestC10Macros) {
+  EXPECT_TRUE(C10_STRINGIZE("whatever") == "whatever");
+  EXPECT_TRUE(C10_LIKELY(true));
+  EXPECT_TRUE(C10_UNLIKELY(false));
 }
 
 } // namespace aot_inductor

--- a/test/cpp_extensions/libtorch_agnostic_extension/libtorch_agnostic/csrc/kernel.cpp
+++ b/test/cpp_extensions/libtorch_agnostic_extension/libtorch_agnostic/csrc/kernel.cpp
@@ -1,6 +1,7 @@
 #include <torch/csrc/inductor/aoti_torch/c/shim.h>
 #include <torch/csrc/inductor/aoti_runtime/utils.h>
 #include <torch/csrc/stable/library.h>
+#include <torch/standalone/util/Exception.h>
 
 #include <optional>
 
@@ -36,6 +37,7 @@ RAIIATH sgd_out_of_place(
 
   int64_t param_dim;
   aoti_torch_get_dim(param.get(), &param_dim);
+  STD_TORCH_CHECK(param_dim == 1, "param must be 1D");
 
   int64_t *param_sizes;
   int64_t *param_strides;

--- a/torch/header_only_apis.txt
+++ b/torch/header_only_apis.txt
@@ -50,3 +50,11 @@ size
 
 # torch/standalone/macros/Export.h
 C10_API
+
+# torch/standalone/macros/Macros.h
+C10_STRINGIZE
+C10_LIKELY
+C10_UNLIKELY
+
+# torch/standalone/util/Exception.h
+STD_TORCH_CHECK

--- a/torch/standalone/macros/Macros.h
+++ b/torch/standalone/macros/Macros.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#define C10_STRINGIZE_IMPL(x) #x
+#define C10_STRINGIZE(x) C10_STRINGIZE_IMPL(x)
+
+// C10_LIKELY/C10_UNLIKELY
+//
+// These macros provide parentheses, so you can use these macros as:
+//
+//    if C10_LIKELY(some_expr) {
+//      ...
+//    }
+//
+// NB: static_cast to boolean is mandatory in C++, because __builtin_expect
+// takes a long argument, which means you may trigger the wrong conversion
+// without it.
+//
+#if defined(__GNUC__) || defined(__ICL) || defined(__clang__)
+#define C10_LIKELY(expr) (__builtin_expect(static_cast<bool>(expr), 1))
+#define C10_UNLIKELY(expr) (__builtin_expect(static_cast<bool>(expr), 0))
+#else
+#define C10_LIKELY(expr) (expr)
+#define C10_UNLIKELY(expr) (expr)
+#endif

--- a/torch/standalone/util/Exception.h
+++ b/torch/standalone/util/Exception.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <torch/standalone/macros/Export.h>
+#include <torch/standalone/macros/Macros.h>
+
+#include <sstream>
+#include <string>
+
+namespace c10 {
+// On nvcc, C10_UNLIKELY thwarts missing return statement analysis.  In cases
+// where the unlikely expression may be a constant, use this macro to ensure
+// return statement analysis keeps working (at the cost of not getting the
+// likely/unlikely annotation on nvcc).
+// https://github.com/pytorch/pytorch/issues/21418
+//
+// Currently, this is only used in the error reporting macros below.  If you
+// want to use it more generally, move me to Macros.h
+//
+// TODO: Brian Vaughan observed that we might be able to get this to work on
+// nvcc by writing some sort of C++ overload that distinguishes constexpr inputs
+// from non-constexpr.  Since there isn't any evidence that losing C10_UNLIKELY
+// in nvcc is causing us perf problems, this is not yet implemented, but this
+// might be an interesting piece of C++ code for an intrepid bootcamper to
+// write.
+#if defined(__CUDACC__)
+#define C10_UNLIKELY_OR_CONST(e) e
+#else
+#define C10_UNLIKELY_OR_CONST(e) C10_UNLIKELY(e)
+#endif
+
+} // namespace c10
+
+// STD_TORCH_CHECK throws std::runtime_error instead of c10::Error which is
+// useful when certain headers are used in a libtorch-independent way,
+// e.g. when Vectorized<T> is used in AOTInductor generated code, or
+// for custom ops to have an ABI stable dependency on libtorch.
+#ifdef STRIP_ERROR_MESSAGES
+#define STD_TORCH_CHECK_MSG(cond, type, ...) \
+  (#cond #type " CHECK FAILED at " C10_STRINGIZE(__FILE__))
+#define STD_TORCH_CHECK(cond, ...)                \
+  if (C10_UNLIKELY_OR_CONST(!(cond))) {           \
+    throw std::runtime_error(STD_TORCH_CHECK_MSG( \
+        cond,                                     \
+        "",                                       \
+        __func__,                                 \
+        ", ",                                     \
+        __FILE__,                                 \
+        ":",                                      \
+        __LINE__,                                 \
+        ", ",                                     \
+        __VA_ARGS__));                            \
+  }
+#else // so STRIP_ERROR_MESSAGES is not defined
+
+namespace torch::standalone::detail {
+template <typename... Args>
+std::string stdTorchCheckMsgImpl(const char* /*msg*/, const Args&... args) {
+  // This is similar to the one in c10/util/Exception.h, but does
+  // not depend on the more complex c10::str() function. ostringstream
+  // supports fewer data types than c10::str(), but should be sufficient
+  // in the standalone world.
+  std::ostringstream oss;
+  ((oss << args), ...);
+  return oss.str();
+}
+
+inline const char* stdTorchCheckMsgImpl(const char* msg) {
+  return msg;
+}
+// If there is just 1 user-provided C-string argument, use it.
+inline const char* stdTorchCheckMsgImpl(const char* /*msg*/, const char* args) {
+  return args;
+}
+} // namespace torch::standalone::detail
+
+#define STD_TORCH_CHECK_MSG(cond, type, ...)               \
+  (torch::standalone::detail::stdTorchCheckMsgImpl(        \
+      "Expected " #cond                                    \
+      " to be true, but got false.  "                      \
+      "(Could this error message be improved?  If so, "    \
+      "please report an enhancement request to PyTorch.)", \
+      ##__VA_ARGS__))
+#define STD_TORCH_CHECK(cond, ...)                \
+  if (C10_UNLIKELY_OR_CONST(!(cond))) {           \
+    throw std::runtime_error(STD_TORCH_CHECK_MSG( \
+        cond,                                     \
+        "",                                       \
+        __func__,                                 \
+        ", ",                                     \
+        __FILE__,                                 \
+        ":",                                      \
+        __LINE__,                                 \
+        ", ",                                     \
+        ##__VA_ARGS__));                          \
+  }
+#endif // STRIP_ERROR_MESSAGES


### PR DESCRIPTION
Moved the following APIs to header only:
```
# torch/standalone/macros/Macros.h
C10_STRINGIZE
C10_LIKELY
C10_UNLIKELY

# torch/standalone/util/Exception.h
STD_TORCH_CHECK
```

Big thanks to @desertfire as the `STD_TORCH_CHECK_MSG` implementation pieces are copied from #[154998](https://github.com/pytorch/pytorch/pull/154998)

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #155253

