### PR TITLE
remove allow-untyped-defs from torch/utils/data/datapipes/iter/fileopener.py

### DIFF
--- a/torch/utils/data/datapipes/iter/fileopener.py
+++ b/torch/utils/data/datapipes/iter/fileopener.py
@@ -1,5 +1,4 @@
-# mypy: allow-untyped-defs
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from io import IOBase
 from typing import Optional
 
@@ -47,7 +46,7 @@ class FileOpenerIterDataPipe(IterDataPipe[tuple[str, IOBase]]):
         mode: str = "r",
         encoding: Optional[str] = None,
         length: int = -1,
-    ):
+    ) -> None:
         super().__init__()
         self.datapipe: Iterable = datapipe
         self.mode: str = mode
@@ -66,12 +65,12 @@ class FileOpenerIterDataPipe(IterDataPipe[tuple[str, IOBase]]):
     # Remove annotation due to 'IOBase' is a general type and true type
     # is determined at runtime based on mode. Some `DataPipe` requiring
     # a subtype would cause mypy error.
-    def __iter__(self):
+    def __iter__(self) -> Iterator[tuple[str, IOBase]]:
         yield from get_file_binaries_from_pathnames(
             self.datapipe, self.mode, self.encoding
         )
 
-    def __len__(self):
+    def __len__(self) -> int:
         if self.length == -1:
             raise TypeError(f"{type(self).__name__} instance doesn't have valid length")
         return self.length


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #155283
* __->__ #155282
* #155281
* #155280
* #155279
* #155278
* #155277
* #155276
* #155275
* #155274

