### PR TITLE
[ca] Annotate AccumulateGrad branching and add polyfill tests

### DIFF
--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -101,6 +101,16 @@ def reset():
     compiled_autograd.reset()
 
 
+class BaseCustomOp(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x):
+        return x * 2
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        raise NotImplementedError("must override")
+
+
 class TestCompiledAutograd(TestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -4210,6 +4220,515 @@ class CompiledAutograd1(torch.nn.Module):
             self.assertEqual(counters["compiled_autograd"]["captures"], 1)
         finally:
             dist.destroy_process_group()
+
+    # Scenario 1.1: Stealable dense new_grad
+    # if (!GradMode::is_enabled() && !new_grad.is_sparse() &&
+    #     !new_grad.is_sparse_csr() &&
+    #     !(variable.is_sparse_csr() && new_grad.layout() == at::kStrided) &&
+    #     at::caching::adjusted_use_count(new_grad) <= num_expected_refs &&
+    #     (new_grad.is_mkldnn() || utils::obeys_layout_contract(new_grad, variable))) {
+    @unittest.expectedFailure
+    def test_accumulate_grad_polyfill_scenario_1_1(self):
+        def fn():
+            class StealableDenseOp(BaseCustomOp):
+                @staticmethod
+                def backward(ctx, grad_output):
+                    return torch.ones_like(grad_output, requires_grad=False) * 5
+
+            pre_hook_storage_id = None
+
+            def check(grad):
+                nonlocal pre_hook_storage_id
+                assert pre_hook_storage_id is None
+                pre_hook_storage_id = id(grad.untyped_storage())
+
+            var = torch.randn(2, 2, requires_grad=True)
+            var.register_hook(check)
+            output = StealableDenseOp.apply(var)
+            output.backward(torch.ones_like(output))
+
+            assert var.grad is not None, "Grad should be defined"
+            assert torch.equal(
+                var.grad, torch.ones_like(var) * 5
+            ), "Grad content should be as returned by backward"
+            assert (
+                var.grad.requires_grad is False
+            ), "Detached grad should not require grad"
+            assert (
+                id(var.grad.untyped_storage()) == pre_hook_storage_id
+            ), "Should be stolen"
+            yield var.grad
+
+        self.check_output_and_recompiles(
+            fn,
+            compiler_fn=make_compiler_fn(fullgraph=False),
+            count=[1, 2],
+        )
+
+    # Scenario 1.2: Stealable sparse new_grad
+    # } else if (!GradMode::is_enabled() && new_grad.is_sparse() &&
+    #            new_grad._indices().is_contiguous() &&
+    #            new_grad._values().is_contiguous() &&
+    #            new_grad._indices().use_count() <= 1 &&
+    #            new_grad._values().use_count() <= 1 &&
+    #            new_grad.use_count() <= num_expected_refs) {
+    def test_accumulate_grad_polyfill_scenario_1_2(self):
+        def fn():
+            class StealableSparseOp(BaseCustomOp):
+                @staticmethod
+                def backward(ctx, grad_output):
+                    size = grad_output.size()
+                    indices = torch.tensor([[0, 1], [0, 1]], dtype=torch.int64)
+                    values = torch.tensor([5.0, 5.0])
+                    return torch.sparse_coo_tensor(
+                        indices, values, size, requires_grad=False
+                    )
+
+            pre_hook_storages_id = None
+
+            def check(grad):
+                nonlocal pre_hook_storages_id
+                assert pre_hook_storages_id is None
+                pre_hook_storages_id = [
+                    id(grad._indices().untyped_storage()),
+                    id(grad._values().untyped_storage()),
+                ]
+
+            var = torch.randn(2, 2, requires_grad=True)
+            var.register_hook(check)
+            output = StealableSparseOp.apply(var)
+            output.backward(torch.ones_like(output))
+
+            assert var.grad is not None, "Grad should be defined"
+            assert var.grad.is_sparse, "Grad should be sparse"
+            expected_dense_grad = torch.tensor([[5.0, 0.0], [0.0, 5.0]])
+            assert torch.equal(
+                var.grad.to_dense(), expected_dense_grad
+            ), "Content should be equal after shallow copy"
+            assert (
+                var.grad.requires_grad is False
+            ), "Detached grad should not require grad"
+            assert (
+                id(var.grad._indices().untyped_storage()) == pre_hook_storages_id[0]
+            ), "Should be stolen"
+            assert (
+                id(var.grad._values().untyped_storage()) == pre_hook_storages_id[1]
+            ), "Should be stolen"
+            yield var.grad
+
+        self.check_output_and_recompiles(
+            fn,
+            compiler_fn=make_compiler_fn(fullgraph=False),
+            count=[1, 2],
+        )
+
+    # Scenario 1.3: Cloning sparse/nested new_grad
+    # else {
+    #   if (new_grad.is_sparse() || new_grad.is_sparse_csr() ||
+    #       new_grad.is_nested()) {
+    def test_accumulate_grad_polyfill_scenario_1_3(self):
+        def fn():
+            class CloneSparseGradOp(BaseCustomOp):
+                @staticmethod
+                def backward(ctx, grad_output):
+                    size = grad_output.size()
+                    indices = torch.tensor([[0, 1], [0, 1]], dtype=torch.int64)
+                    values = torch.tensor(
+                        [5.0, 5.0], requires_grad=True
+                    )  # Requires grad
+                    return torch.sparse_coo_tensor(
+                        indices, values, size, requires_grad=True
+                    )
+
+            pre_hook_storages_id = None
+
+            def check(grad):
+                nonlocal pre_hook_storages_id
+                assert pre_hook_storages_id is None
+                pre_hook_storages_id = [
+                    id(grad._indices().untyped_storage()),
+                    id(grad._values().untyped_storage()),
+                ]
+
+            var = torch.randn(2, 2, requires_grad=True)
+            var.register_hook(check)
+            output = CloneSparseGradOp.apply(var)
+            output.backward(
+                torch.ones_like(output), create_graph=True
+            )  # grad mode == create_graph
+
+            assert var.grad is not None, "Grad should be defined"
+            assert var.grad.is_sparse, "Grad should be sparse"
+            expected_dense_grad = torch.tensor([[5.0, 0.0], [0.0, 5.0]])
+            assert torch.equal(
+                var.grad.to_dense(), expected_dense_grad
+            ), "Content should be equal after clone"
+            assert (
+                var.grad.requires_grad
+            ), "Grad should require grad for double backward"
+            assert (
+                id(var.grad._indices().untyped_storage()) != pre_hook_storages_id[0]
+            ), "Should be copied"
+            assert (
+                id(var.grad._values().untyped_storage()) != pre_hook_storages_id[1]
+            ), "Should be copied"
+            yield var.grad
+
+        self.check_output_and_recompiles(
+            fn,
+            compiler_fn=make_compiler_fn(fullgraph=False),
+            count=[1, 2],
+        )
+
+    # Scenario 1.5.1: Dense variable gradient layout contract
+    # else { // Covers various deep copy scenarios not covered by specific stealable paths
+    #   ...
+    #   if (new_grad.is_mkldnn()) {
+    #     ...
+    #   } else {
+    #       // Deep copies new_grad according to the "Gradient Layout Contract."
+    #       update_grad(utils::clone_obey_contract(new_grad, variable));
+    #   }
+    # }
+    def test_accumulate_grad_polyfill_scenario_1_5_1(self):
+        def fn():
+            class NotStealableRefsOp(BaseCustomOp):
+                @staticmethod
+                def backward(ctx, grad_output):
+                    return torch.ones_like(grad_output, requires_grad=False) * 10.0
+
+            var = torch.randn(2, 2, requires_grad=True)
+            grad_ref_holder = [None]
+
+            def check(grad):
+                # forces a clone due to refcount
+                grad_ref_holder[0] = grad
+                return grad
+
+            var.register_hook(check)
+            output = NotStealableRefsOp.apply(var)
+            output.backward(torch.ones_like(output))
+
+            assert var.grad is not None, "Grad should be defined"
+            assert torch.equal(
+                var.grad, torch.ones_like(var) * 10.0
+            ), "Grad content should be as returned by backward"
+            assert (
+                grad_ref_holder[0].untyped_storage() is not var.grad.untyped_storage()
+            ), "Should be copied"
+            yield var.grad
+
+        self.check_output_and_recompiles(fn)
+
+    # Scenario 1.5.2: Non-dense variable gradient layout contract
+    # else { // Covers various deep copy scenarios not covered by specific stealable paths
+    #   ...
+    #   if (new_grad.is_mkldnn()) {
+    #     ...
+    #   } else {
+    #       // Deep copies new_grad according to the "Gradient Layout Contract."
+    #       update_grad(utils::clone_obey_contract(new_grad, variable));
+    #   }
+    # }
+    def test_accumulate_grad_polyfill_scenario_1_5_2(self):
+        def fn():
+            class SimpleDenseGradOp(BaseCustomOp):
+                @staticmethod
+                def backward(ctx, grad_output):
+                    return torch.ones_like(grad_output, requires_grad=False) * 7.0
+
+            # Create a non-contiguous variable
+            base_tensor = torch.randn(4, 4)
+            var = base_tensor[::2, ::2]
+            assert (
+                not var.is_contiguous()
+            ), "Variable should be non-contiguous for this test"
+            var.requires_grad_(True)
+
+            grad_ref_holder = [None]
+
+            def check(grad):
+                # forces a clone due to refcount
+                grad_ref_holder[0] = grad
+                return grad
+
+            var.register_hook(check)
+            output = SimpleDenseGradOp.apply(var)
+            output.backward(torch.ones_like(output))
+
+            assert var.grad is not None, "Grad should be defined"
+            # The `clone_obey_contract` branch 2 (`new_grad.clone(at::MemoryFormat::Contiguous)`)
+            # will make the resulting grad contiguous.
+            assert (
+                var.grad.is_contiguous()
+            ), "Resulting grad should be contiguous due to branch 2 of clone_obey_contract"
+            assert torch.equal(
+                var.grad, torch.ones_like(var) * 7.0
+            ), "Grad content should be as returned by backward"
+            assert (
+                grad_ref_holder[0].untyped_storage() is not var.grad.untyped_storage()
+            ), "Should be copied"
+            yield var.grad
+
+        self.check_output_and_recompiles(
+            fn,
+        )
+
+    # Scenario 2.1: Sparse variable_grad + Dense new_grad
+    # } else if (!GradMode::is_enabled()) {
+    #   if (variable_grad.is_sparse() && !new_grad.is_sparse()) {
+    #       auto result = new_grad + variable_grad;
+    def test_accumulate_grad_polyfill_scenario_2_1(self):
+        def fn():
+            class SparseVarGradDenseNewGradOp(BaseCustomOp):
+                @staticmethod
+                def backward(ctx, grad_output):
+                    return torch.ones_like(grad_output) * 3.0
+
+            var = torch.randn(2, 2, requires_grad=True)
+            indices = torch.tensor([[0, 1], [0, 1]], dtype=torch.int64)
+            values = torch.tensor([1.0, 1.0])
+            var.grad = torch.sparse_coo_tensor(
+                indices, values, var.size(), requires_grad=False
+            )
+            initial_grad_ref = var.grad
+            output = SparseVarGradDenseNewGradOp.apply(var)
+
+            expected_sum = (torch.ones_like(var) * 3.0) + initial_grad_ref.to_dense()
+            output.backward(torch.ones_like(output))
+
+            assert var.grad is not None, "Grad should be defined"
+            assert not var.grad.is_sparse, "Resulting grad should be dense"
+            assert torch.equal(var.grad, expected_sum), "Grad content should be the sum"
+            assert (
+                var.grad is not initial_grad_ref
+            ), "Grad object should be replaced (out-of-place)"
+            yield var.grad
+
+        self.check_output_and_recompiles(
+            fn,
+            compiler_fn=lambda gm: gm,  # https://github.com/pytorch/pytorch/issues/154161
+            count=[1, 0],
+        )
+
+    # Scenario 2.3.1: Dense/Dense in-place addition
+    # } else if (!GradMode::is_enabled()) {
+    #   ...
+    # } else {
+    #   variable_grad += new_grad;
+    def test_accumulate_grad_polyfill_scenario_2_3_1(self):
+        def fn():
+            class DenseVarGradDenseNewGradOp(BaseCustomOp):
+                @staticmethod
+                def backward(ctx, grad_output):
+                    return torch.ones_like(grad_output) * 3.0
+
+            var = torch.randn(2, 2, requires_grad=True)
+            var.grad = torch.ones_like(var) * 1.0
+            initial_grad_ref = var.grad
+            output = DenseVarGradDenseNewGradOp.apply(var)
+            expected_sum = initial_grad_ref + (torch.ones_like(var) * 3.0)
+            output.backward(torch.ones_like(output))
+
+            assert var.grad is not None, "Grad should be defined"
+            assert not var.grad.is_sparse, "Resulting grad should be dense"
+            assert torch.equal(var.grad, expected_sum), "Grad content should be the sum"
+            assert (
+                var.grad is initial_grad_ref
+            ), "Grad object should be modified in-place (same object)"
+            yield var.grad
+
+        self.check_output_and_recompiles(fn)
+
+    # Scenario 2.3.2: Sparse/Sparse in-place addition
+    # } else if (!GradMode::is_enabled()) {
+    #   ...
+    # } else {
+    #   variable_grad += new_grad;
+    def test_accumulate_grad_polyfill_scenario_2_3_2(self):
+        def fn():
+            class SparseVarGradSparseNewGradOp(BaseCustomOp):
+                @staticmethod
+                def backward(ctx, grad_output):
+                    size = grad_output.size()
+                    indices = torch.tensor([[0, 1], [0, 1]], dtype=torch.int64)
+                    values = torch.tensor([3.0, 3.0])
+                    return torch.sparse_coo_tensor(
+                        indices, values, size, requires_grad=False
+                    )
+
+            var = torch.randn(2, 2, requires_grad=True)
+            indices_v = torch.tensor([[0, 0], [0, 1]], dtype=torch.int64)
+            values_v = torch.tensor([1.0, 2.0])
+            var.grad = torch.sparse_coo_tensor(
+                indices_v, values_v, var.size(), requires_grad=False
+            )
+            initial_grad_ref = var.grad
+
+            output = SparseVarGradSparseNewGradOp.apply(var)
+
+            new_grad_for_sum = torch.sparse_coo_tensor(
+                torch.tensor([[0, 1], [0, 1]], dtype=torch.int64),
+                torch.tensor([3.0, 3.0]),
+                var.size(),
+            )
+            expected_sum_dense = (
+                initial_grad_ref.to_dense() + new_grad_for_sum.to_dense()
+            )
+
+            output.backward(torch.ones_like(output))
+
+            assert var.grad is not None, "Grad should be defined"
+            assert var.grad.is_sparse, "Resulting grad should remain sparse"
+            assert torch.equal(
+                var.grad.to_dense(), expected_sum_dense
+            ), "Grad content should be the sum of sparse grads"
+            assert (
+                var.grad is initial_grad_ref
+            ), "Grad object should be modified in-place (same object)"
+            yield var.grad
+
+        self.check_output_and_recompiles(
+            fn,
+            compiler_fn=lambda gm: gm,  # https://github.com/pytorch/pytorch/issues/154161
+            count=[1, 0],
+        )
+
+    # Scenario 2.3.3: Dense/Sparse in-place addition
+    # } else if (!GradMode::is_enabled()) {
+    #   ...
+    # } else {
+    #   variable_grad += new_grad;
+    def test_accumulate_grad_polyfill_scenario_2_3_3(self):
+        def fn():
+            class DenseVarGradSparseNewGradOp(BaseCustomOp):
+                @staticmethod
+                def backward(ctx, grad_output):
+                    size = grad_output.size()
+                    indices = torch.tensor([[0, 1], [0, 1]], dtype=torch.int64)
+                    values = torch.tensor([3.0, 3.0])  # New sparse values
+                    return torch.sparse_coo_tensor(
+                        indices, values, size, requires_grad=False
+                    )
+
+            var = torch.randn(2, 2, requires_grad=True)
+            var.grad = torch.ones_like(var) * 1.0  # Initial value
+            initial_grad_ref = var.grad
+            output = DenseVarGradSparseNewGradOp.apply(var)
+
+            new_grad_for_sum = torch.sparse_coo_tensor(
+                torch.tensor([[0, 1], [0, 1]], dtype=torch.int64),
+                torch.tensor([3.0, 3.0]),
+                var.size(),
+            ).to_dense()
+            expected_sum = initial_grad_ref + new_grad_for_sum
+
+            output.backward(torch.ones_like(output))
+
+            assert var.grad is not None, "Grad should be defined"
+            assert not var.grad.is_sparse, "Resulting grad should be dense"
+            assert torch.equal(var.grad, expected_sum), "Grad content should be the sum"
+            assert (
+                var.grad is initial_grad_ref
+            ), "Grad object should be modified in-place (same object)"
+            yield var.grad
+
+        self.check_output_and_recompiles(
+            fn,
+            compiler_fn=make_compiler_fn(fullgraph=False),
+            count=[1, 2],
+        )
+
+    # Scenario 3.1: Sparse variable_grad + Dense new_grad (reorder into Dense + Sparse)
+    # } else { // if GradMode::is_enabled()
+    #   at::Tensor result;
+    #   if (variable_grad.is_sparse() && !new_grad.is_sparse()) {
+    #     result = new_grad + variable_grad;
+    #   }
+    # }
+    def test_accumulate_grad_polyfill_scenario_3_1(self):
+        def fn():
+            class SparseVarGradDenseNewGradDoubleBackwardOp(BaseCustomOp):
+                @staticmethod
+                def backward(ctx, grad_output):
+                    return torch.ones_like(grad_output, requires_grad=True) * 3.0
+
+            var = torch.randn(2, 2, requires_grad=True)
+            indices = torch.tensor([[0, 1], [0, 1]], dtype=torch.int64)
+            values = torch.tensor([1.0, 1.0], requires_grad=True)
+            var.grad = torch.sparse_coo_tensor(
+                indices, values, var.size(), requires_grad=True
+            )
+            initial_grad_ref = var.grad
+
+            output = SparseVarGradDenseNewGradDoubleBackwardOp.apply(var)
+
+            expected_sum = (
+                torch.ones_like(var, requires_grad=True) * 3.0
+            ) + initial_grad_ref.to_dense()
+
+            output.backward(torch.ones_like(output), create_graph=True)
+
+            assert var.grad is not None, "Grad should be defined"
+            assert not var.grad.is_sparse, "Resulting grad should be dense"
+            assert torch.equal(var.grad, expected_sum), "Grad content should be the sum"
+            assert (
+                var.grad is not initial_grad_ref
+            ), "Grad object should be replaced (out-of-place)"
+            assert (
+                var.grad.requires_grad
+            ), "Resulting grad should track history for double backward"
+            yield var.grad
+
+        self.check_output_and_recompiles(
+            fn,
+            compiler_fn=lambda gm: gm,  # https://github.com/pytorch/pytorch/issues/154161
+            count=[1, 0],
+        )
+
+    # Scenario 3.2: variable_grad.defined() & GradMode::is_enabled() - Double backward (dense variable_grad + dense new_grad)
+    # } else { // if GradMode::is_enabled()
+    #   at::Tensor result;
+    #   ...
+    #   } else {
+    #     result = variable_grad + new_grad;
+    #   }
+    # }
+    def test_accumulate_grad_polyfill_scenario_3_2(self):
+        def fn():
+            class DenseVarGradDenseNewGradDoubleBackwardOp(BaseCustomOp):
+                @staticmethod
+                def backward(ctx, grad_output):
+                    return torch.ones_like(grad_output, requires_grad=True) * 3.0
+
+            var = torch.randn(2, 2, requires_grad=True)
+            var.grad = torch.ones_like(var) * 1.0
+            initial_grad_ref = var.grad
+
+            output = DenseVarGradDenseNewGradDoubleBackwardOp.apply(var)
+
+            expected_sum = initial_grad_ref + (
+                torch.ones_like(var, requires_grad=True) * 3.0
+            )
+
+            output.backward(torch.ones_like(output), create_graph=True)
+
+            assert var.grad is not None, "Grad should be defined"
+            assert not var.grad.is_sparse, "Resulting grad should be dense"
+            assert torch.equal(var.grad, expected_sum), "Grad content should be the sum"
+            assert (
+                var.grad is not initial_grad_ref
+            ), "Grad object should be replaced (out-of-place)"
+            assert (
+                var.grad.requires_grad
+            ), "Resulting grad should track history for double backward"
+            yield var.grad
+
+        self.check_output_and_recompiles(
+            fn,
+            compiler_fn=make_compiler_fn(fullgraph=False),
+            count=[1, 3],
+        )
 
 
 def load_test_module(name):

--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -4221,14 +4221,14 @@ class CompiledAutograd1(torch.nn.Module):
         finally:
             dist.destroy_process_group()
 
-    # Scenario 1.1: Stealable dense new_grad
+    # Case 1.1: Stealable dense new_grad
     # if (!GradMode::is_enabled() && !new_grad.is_sparse() &&
     #     !new_grad.is_sparse_csr() &&
     #     !(variable.is_sparse_csr() && new_grad.layout() == at::kStrided) &&
     #     at::caching::adjusted_use_count(new_grad) <= num_expected_refs &&
     #     (new_grad.is_mkldnn() || utils::obeys_layout_contract(new_grad, variable))) {
     @unittest.expectedFailure
-    def test_accumulate_grad_polyfill_scenario_1_1(self):
+    def test_accumulate_grad_polyfill_case_1_1(self):
         def fn():
             class StealableDenseOp(BaseCustomOp):
                 @staticmethod
@@ -4265,14 +4265,14 @@ class CompiledAutograd1(torch.nn.Module):
             count=[1, 2],
         )
 
-    # Scenario 1.2: Stealable sparse new_grad
+    # Case 1.2: Stealable sparse new_grad
     # } else if (!GradMode::is_enabled() && new_grad.is_sparse() &&
     #            new_grad._indices().is_contiguous() &&
     #            new_grad._values().is_contiguous() &&
     #            new_grad._indices().use_count() <= 1 &&
     #            new_grad._values().use_count() <= 1 &&
     #            new_grad.use_count() <= num_expected_refs) {
-    def test_accumulate_grad_polyfill_scenario_1_2(self):
+    def test_accumulate_grad_polyfill_case_1_2(self):
         def fn():
             class StealableSparseOp(BaseCustomOp):
                 @staticmethod
@@ -4322,11 +4322,11 @@ class CompiledAutograd1(torch.nn.Module):
             count=[1, 2],
         )
 
-    # Scenario 1.3: Cloning sparse/nested new_grad
+    # Case 1.3: Cloning sparse/nested new_grad
     # else {
     #   if (new_grad.is_sparse() || new_grad.is_sparse_csr() ||
     #       new_grad.is_nested()) {
-    def test_accumulate_grad_polyfill_scenario_1_3(self):
+    def test_accumulate_grad_polyfill_case_1_3(self):
         def fn():
             class CloneSparseGradOp(BaseCustomOp):
                 @staticmethod
@@ -4380,7 +4380,7 @@ class CompiledAutograd1(torch.nn.Module):
             count=[1, 2],
         )
 
-    # Scenario 1.5.1: Dense variable gradient layout contract
+    # Case 1.5.1: Dense variable gradient layout contract
     # else { // Covers various deep copy scenarios not covered by specific stealable paths
     #   ...
     #   if (new_grad.is_mkldnn()) {
@@ -4390,7 +4390,7 @@ class CompiledAutograd1(torch.nn.Module):
     #       update_grad(utils::clone_obey_contract(new_grad, variable));
     #   }
     # }
-    def test_accumulate_grad_polyfill_scenario_1_5_1(self):
+    def test_accumulate_grad_polyfill_case_1_5_1(self):
         def fn():
             class NotStealableRefsOp(BaseCustomOp):
                 @staticmethod
@@ -4420,7 +4420,7 @@ class CompiledAutograd1(torch.nn.Module):
 
         self.check_output_and_recompiles(fn)
 
-    # Scenario 1.5.2: Non-dense variable gradient layout contract
+    # Case 1.5.2: Non-dense variable gradient layout contract
     # else { // Covers various deep copy scenarios not covered by specific stealable paths
     #   ...
     #   if (new_grad.is_mkldnn()) {
@@ -4430,7 +4430,7 @@ class CompiledAutograd1(torch.nn.Module):
     #       update_grad(utils::clone_obey_contract(new_grad, variable));
     #   }
     # }
-    def test_accumulate_grad_polyfill_scenario_1_5_2(self):
+    def test_accumulate_grad_polyfill_case_1_5_2(self):
         def fn():
             class SimpleDenseGradOp(BaseCustomOp):
                 @staticmethod
@@ -4474,11 +4474,11 @@ class CompiledAutograd1(torch.nn.Module):
             fn,
         )
 
-    # Scenario 2.1: Sparse variable_grad + Dense new_grad
+    # Case 2.1: Sparse variable_grad + Dense new_grad
     # } else if (!GradMode::is_enabled()) {
     #   if (variable_grad.is_sparse() && !new_grad.is_sparse()) {
     #       auto result = new_grad + variable_grad;
-    def test_accumulate_grad_polyfill_scenario_2_1(self):
+    def test_accumulate_grad_polyfill_case_2_1(self):
         def fn():
             class SparseVarGradDenseNewGradOp(BaseCustomOp):
                 @staticmethod
@@ -4511,12 +4511,12 @@ class CompiledAutograd1(torch.nn.Module):
             count=[1, 0],
         )
 
-    # Scenario 2.3.1: Dense/Dense in-place addition
+    # Case 2.3.1: Dense/Dense in-place addition
     # } else if (!GradMode::is_enabled()) {
     #   ...
     # } else {
     #   variable_grad += new_grad;
-    def test_accumulate_grad_polyfill_scenario_2_3_1(self):
+    def test_accumulate_grad_polyfill_case_2_3_1(self):
         def fn():
             class DenseVarGradDenseNewGradOp(BaseCustomOp):
                 @staticmethod
@@ -4540,12 +4540,12 @@ class CompiledAutograd1(torch.nn.Module):
 
         self.check_output_and_recompiles(fn)
 
-    # Scenario 2.3.2: Sparse/Sparse in-place addition
+    # Case 2.3.2: Sparse/Sparse in-place addition
     # } else if (!GradMode::is_enabled()) {
     #   ...
     # } else {
     #   variable_grad += new_grad;
-    def test_accumulate_grad_polyfill_scenario_2_3_2(self):
+    def test_accumulate_grad_polyfill_case_2_3_2(self):
         def fn():
             class SparseVarGradSparseNewGradOp(BaseCustomOp):
                 @staticmethod
@@ -4594,12 +4594,12 @@ class CompiledAutograd1(torch.nn.Module):
             count=[1, 0],
         )
 
-    # Scenario 2.3.3: Dense/Sparse in-place addition
+    # Case 2.3.3: Dense/Sparse in-place addition
     # } else if (!GradMode::is_enabled()) {
     #   ...
     # } else {
     #   variable_grad += new_grad;
-    def test_accumulate_grad_polyfill_scenario_2_3_3(self):
+    def test_accumulate_grad_polyfill_case_2_3_3(self):
         def fn():
             class DenseVarGradSparseNewGradOp(BaseCustomOp):
                 @staticmethod
@@ -4639,14 +4639,14 @@ class CompiledAutograd1(torch.nn.Module):
             count=[1, 2],
         )
 
-    # Scenario 3.1: Sparse variable_grad + Dense new_grad (reorder into Dense + Sparse)
+    # Case 3.1: Sparse variable_grad + Dense new_grad (reorder into Dense + Sparse)
     # } else { // if GradMode::is_enabled()
     #   at::Tensor result;
     #   if (variable_grad.is_sparse() && !new_grad.is_sparse()) {
     #     result = new_grad + variable_grad;
     #   }
     # }
-    def test_accumulate_grad_polyfill_scenario_3_1(self):
+    def test_accumulate_grad_polyfill_case_3_1(self):
         def fn():
             class SparseVarGradDenseNewGradDoubleBackwardOp(BaseCustomOp):
                 @staticmethod
@@ -4686,7 +4686,7 @@ class CompiledAutograd1(torch.nn.Module):
             count=[1, 0],
         )
 
-    # Scenario 3.2: variable_grad.defined() & GradMode::is_enabled() - Double backward (dense variable_grad + dense new_grad)
+    # Case 3.2: variable_grad.defined() & GradMode::is_enabled() - Double backward (dense variable_grad + dense new_grad)
     # } else { // if GradMode::is_enabled()
     #   at::Tensor result;
     #   ...
@@ -4694,7 +4694,7 @@ class CompiledAutograd1(torch.nn.Module):
     #     result = variable_grad + new_grad;
     #   }
     # }
-    def test_accumulate_grad_polyfill_scenario_3_2(self):
+    def test_accumulate_grad_polyfill_case_3_2(self):
         def fn():
             class DenseVarGradDenseNewGradDoubleBackwardOp(BaseCustomOp):
                 @staticmethod

--- a/torch/csrc/autograd/functions/accumulate_grad.h
+++ b/torch/csrc/autograd/functions/accumulate_grad.h
@@ -208,7 +208,7 @@ struct TORCH_API AccumulateGrad : public Node {
       } else {
         if (new_grad.is_sparse() || new_grad.is_sparse_csr() ||
             new_grad.is_nested()) {
-          // Scenario 1.3: Cloning sparse/nested new_grad
+          // Case 1.3: Cloning sparse/nested new_grad
           update_grad(new_grad.clone());
         } else {
           if (new_grad.is_mkldnn()) {

--- a/torch/csrc/autograd/functions/accumulate_grad.h
+++ b/torch/csrc/autograd/functions/accumulate_grad.h
@@ -97,7 +97,6 @@ struct TORCH_API AccumulateGrad : public Node {
   // degraded performance in Reducer.cpp or optimizer kernels, not death by
   // assert or silently bad numerics.
 
-
   // Gradient Accumulation
   // Given a variable with its current grad as variable_grad, accumulates
   // new_grad into variable_grad if in place accumulation is possible.
@@ -119,10 +118,12 @@ struct TORCH_API AccumulateGrad : public Node {
   //     . We only skip clone if indices and values themselves are contiguous
   //       for backward compatibility reasons. Since without this optimization,
   //       earlier we would clone the entire SparseTensor which cloned indices
-  //       and values. For details see https://github.com/pytorch/pytorch/issues/34375.
+  //       and values. For details see
+  //       https://github.com/pytorch/pytorch/issues/34375.
   //   - Case 1.3: Cloning sparse/nested new_grad
   //   - Case 1.4: Cloning MKLDNN new_grad
-  //   - Case 1.5: Deep copies new_grad according to the Gradient Layout Contract.
+  //   - Case 1.5: Deep copies new_grad according to the Gradient Layout
+  //   Contract.
   // - Case 2: Param has existing grad and grad mode is not enabled
   //   - This case is not strictly necessary, but it makes the first-order only
   //     case slightly more efficient.
@@ -135,8 +136,8 @@ struct TORCH_API AccumulateGrad : public Node {
   //   - Case 2.2: Vmap-incompatible
   //     . Ideally we'd perform an in-place operation to avoid changing
   //       the grad tensor. However, if that's impossible because the grads
-  //       are vmap-incompatible (See NOTE: [vmap-incompatible in-place operations]),
-  //       then we just add them out-of-place.
+  //       are vmap-incompatible (See NOTE: [vmap-incompatible in-place
+  //       operations]), then we just add them out-of-place.
   //   - Case 2.3: In-place addition
   //     . In this case we can avoid changing the grad tensor. There are three
   //       scenarios when we'll hit this case:

--- a/torch/csrc/autograd/functions/accumulate_grad.h
+++ b/torch/csrc/autograd/functions/accumulate_grad.h
@@ -58,11 +58,7 @@ struct TORCH_API AccumulateGrad : public Node {
     return impl::post_acc_grad_hooks(variable);
   }
 
-  // Given a variable with its current grad as variable_grad, accumulates
-  // new_grad into variable_grad if in place accumulation is possible.
-  // Otherwise, uses 'update_grad' to update the grad for the variable.
-
-  // "Gradient Layout Contract"
+  // Note: Gradient Layout Contract
   //
   // AccumulateGrad tries to stash strided (non-sparse) grads with memory layout
   // (strides) such that variables and grads interact efficiently in later
@@ -101,6 +97,67 @@ struct TORCH_API AccumulateGrad : public Node {
   // degraded performance in Reducer.cpp or optimizer kernels, not death by
   // assert or silently bad numerics.
 
+
+  // Gradient Accumulation
+  // Given a variable with its current grad as variable_grad, accumulates
+  // new_grad into variable_grad if in place accumulation is possible.
+  // Otherwise, uses 'update_grad' to update the grad for the variable.
+  //
+  // Branch breakdown:
+  // - Case 1: Param has no existing grad
+  //   - Case 1.1: Stealable dense new_grad
+  //     . We aren't setting up for double-backward.
+  //     . No other user-visible tensor references new_grad.
+  //     . new_grad obeys the "Gradient Layout Contract", there has a special
+  //       case, For MKLDNN tensor, which is a opaque tensor, assuming it obeys
+  //       layout_contract.
+  //   - Case 1.2: Stealable sparse new_grad
+  //     . Can't detach sparse tensor (since metadata changes are not allowed
+  //       after detach), so just create a new one for the grad which is a
+  //       shallow copy. We need a shallow copy so that modifying the original
+  //       grad tensor doesn't modify the grad we accumulate.
+  //     . We only skip clone if indices and values themselves are contiguous
+  //       for backward compatibility reasons. Since without this optimization,
+  //       earlier we would clone the entire SparseTensor which cloned indices
+  //       and values. For details see https://github.com/pytorch/pytorch/issues/34375.
+  //   - Case 1.3: Cloning sparse/nested new_grad
+  //   - Case 1.4: Cloning MKLDNN new_grad
+  //   - Case 1.5: Deep copies new_grad according to the Gradient Layout Contract.
+  // - Case 2: Param has existing grad and grad mode is not enabled
+  //   - This case is not strictly necessary, but it makes the first-order only
+  //     case slightly more efficient.
+  //   - Case 2.1: Sparse variable_grad + Dense new_grad
+  //     . If `variable_grad` is sparse and `new_grad` is not sparse, their
+  //       sum is not sparse, and we must change the TensorImpl type of
+  //       `variable_grad` for it to store the result. However, changing the
+  //       TensorImpl type of a tensor requires changing the tensor itself, and
+  //       thus in this case we have to change the grad tensor.
+  //   - Case 2.2: Vmap-incompatible
+  //     . Ideally we'd perform an in-place operation to avoid changing
+  //       the grad tensor. However, if that's impossible because the grads
+  //       are vmap-incompatible (See NOTE: [vmap-incompatible in-place operations]),
+  //       then we just add them out-of-place.
+  //   - Case 2.3: In-place addition
+  //     . In this case we can avoid changing the grad tensor. There are three
+  //       scenarios when we'll hit this case:
+  //       . `variable_grad` is sparse, and `new_grad` is sparse.
+  //       . `variable_grad` is dense, and `new_grad` is sparse.
+  //       . `variable_grad` is dense, and `new_grad` is dense.
+  //       . `variable_grad` is mkldnn, and `new_grad` is mkldnn.
+  //
+  //       In all of these four cases, `variable_grad += new_grad` is a
+  //       valid operation which adds `new_grad` to `variable_grad` in
+  //       place. `variable_grad` is thus still referring to the same tensor
+  //       after the operation.
+  //     . DistributedDataParallel(DDP) package relies on grad being
+  //       mutated in place for saving peak memory usage. DDP will still
+  //       work correctly if it is mutated out of place here, but DDP will
+  //       maintain one extra copy of grad tensors in buffer and thus
+  //       increase peak memory usage.
+  // - Case 3: Param has existing grad and grad mode is enabled
+  //   - Case 3.1: Sparse variable_grad + Dense new_grad
+  //   - Case 3.2: Not Sparse variable_grad + Dense new_grad
+  //
   // variable: the variable whose grad we're accumulating.
   // variable_grad: the current grad for the variable.
   // new_grad: new grad we want to accumulate for the variable.
@@ -125,14 +182,7 @@ struct TORCH_API AccumulateGrad : public Node {
           at::caching::adjusted_use_count(new_grad) <= num_expected_refs &&
           (new_grad.is_mkldnn() ||
            utils::obeys_layout_contract(new_grad, variable))) {
-        // Scenario 1.1: Stealable dense new_grad
-        // we aren't setting up for double-backward
-        // not sparse
-        // no other user-visible tensor references new_grad
-        // new_grad obeys the "Gradient Layout Contract", there has a special
-        // case, For MKLDNN tensor, which is a opaque tensor, assuming it obeys
-        // layout_contract. Under these conditions, we can steal new_grad
-        // without a deep copy.
+        // See Case 1.1: Stealable dense new_grad
         update_grad(new_grad.detach());
       } else if (
           !GradMode::is_enabled() && new_grad.is_sparse() &&
@@ -143,17 +193,7 @@ struct TORCH_API AccumulateGrad : public Node {
           new_grad._indices().use_count() <= 1 &&
           new_grad._values().use_count() <= 1 &&
           new_grad.use_count() <= num_expected_refs) {
-        // Scenario 1.2: Stealable sparse new_grad
-        // Can't detach sparse tensor (since metadata changes are not allowed
-        // after detach), so just create a new one for the grad which is a
-        // shallow copy. We need a shallow copy so that modifying the original
-        // grad tensor doesn't modify the grad we accumulate.
-        // We only skip clone if indices and values themselves are contiguous
-        // for backward compatibility reasons. Since without this optimization,
-        // earlier we would clone the entire SparseTensor which cloned indices
-        // and values.
-        // For details see https://github.com/pytorch/pytorch/issues/34375.
-
+        // Case 1.2: Stealable sparse new_grad
         // No scenario where we expect this to be true currently
         TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
             !at::caching::is_cached_tensor(new_grad._indices()) &&
@@ -172,56 +212,29 @@ struct TORCH_API AccumulateGrad : public Node {
           update_grad(new_grad.clone());
         } else {
           if (new_grad.is_mkldnn()) {
-            // Scenario 1.4: Cloning MKLDNN new_grad
+            // Case 1.4: Cloning MKLDNN new_grad
             update_grad(new_grad.clone());
           } else {
-            // Scenario 1.5: Deep copies new_grad according to the "Gradient
+            // Case 1.5: Deep copies new_grad according to the "Gradient
             // Layout Contract."
             update_grad(utils::clone_obey_contract(new_grad, variable));
           }
         }
       }
     } else if (!GradMode::is_enabled()) {
-      // This case is not strictly necessary, but it makes the first-order only
-      // case slightly more efficient.
+      // Case 2: Param has existing grad and grad mode is not enabled
       if (variable_grad.is_sparse() && !new_grad.is_sparse()) {
-        // Scenario 2.1: Sparse variable_grad + Dense new_grad
-        // If `variable_grad` is sparse and `new_grad` is not sparse, their
-        // sum is not sparse, and we must change the TensorImpl type of
-        // `variable_grad` for it to store the result. However, changing the
-        // TensorImpl type of a tensor requires changing the tensor itself, and
-        // thus in this case we have to change the grad tensor.
+        // Case 2.1: Sparse variable_grad + Dense new_grad
         auto result = new_grad + variable_grad;
         CHECK_RESULT(result, variable);
         update_grad(std::move(result));
       } else if (!at::inplaceIsVmapCompatible(variable_grad, new_grad)) {
-        // Scenario 2.2: Vmap-incompatible
-        // Ideally we'd perform an in-place operation to avoid changing
-        // the grad tensor. However, if that's impossible because the grads
-        // are vmap-incompatible (See NOTE: [vmap-incompatible in-place
-        // operations]), then we just add them out-of-place.
+        // Case 2.2: Vmap-incompatible
         auto result = variable_grad + new_grad;
         CHECK_RESULT(result, variable);
         update_grad(std::move(result));
       } else {
-        // Scenario 2.3: In-place addition
-        // In this case we can avoid changing the grad tensor. There are three
-        // scenarios when we'll hit this case:
-        //
-        // 1. `variable_grad` is sparse, and `new_grad` is sparse.
-        // 2. `variable_grad` is dense, and `new_grad` is sparse.
-        // 3. `variable_grad` is dense, and `new_grad` is dense.
-        // 4. `variable_grad` is mkldnn, and `new_grad` is mkldnn.
-        //
-        // In all of these four cases, `variable_grad += new_grad` is a
-        // valid operation which adds `new_grad` to `variable_grad` in
-        // place. `variable_grad` is thus still referring to the same tensor
-        // after the operation.
-        // Also DistributedDataParallel(DDP) package relies on grad being
-        // mutated in place for saving peak memory usage. DDP will still
-        // work correctly if it is mutated out of place here, but DDP will
-        // maintain one extra copy of grad tensors in buffer and thus
-        // increase peak memory usage.
+        // Case 2.3: In-place addition
         variable_grad += new_grad;
         CHECK_RESULT(variable_grad, variable);
         // ^ We could enforce the contract more aggressively here by writing:
@@ -239,13 +252,15 @@ struct TORCH_API AccumulateGrad : public Node {
         // which may break user code.
       }
     } else {
+      // Case 3: Param has existing grad and grad mode is enabled
       at::Tensor result;
       if (variable_grad.is_sparse() && !new_grad.is_sparse()) {
-        // Scenario 3.1: Sparse variable_grad + Dense new_grad
+        // Case 3.1: Sparse variable_grad + Dense new_grad
         // CPU backend throws an error on sparse + dense, so
         // prefer dense + sparse here.
         result = new_grad + variable_grad;
       } else {
+        // Case 3.2: Not Sparse variable_grad + Dense new_grad
         // Assumes operator+ result typically matches strides of first arg,
         // and hopes variable_grad was originally created obeying layout
         // contract.


### PR DESCRIPTION
Annotates AccumulateGrad and tracks the semantics for AccumulateGrad's polyfill , except for Scenario 1.4: Cloning MKLDNN new_grad and Scenario 2.2: Vmap-incompatible.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #155082
* #155370
* __->__ #155289



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov