### PR TITLE
[ROCm][Inductor][CK] Split ck and ck-tile inductor backend(s)

### DIFF
--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -72,7 +72,7 @@ class TestCKBackend(TestCase):
 
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @unittest.mock.patch.dict(os.environ, {"PATH": _get_path_without_sccache()})
-    @parametrize("max_autotune_gemm_backends", ("CK", "ATen,Triton,CK"))
+    @parametrize("max_autotune_gemm_backends", ("CK", "CKTILE", "ATen,Triton,CK"))
     @parametrize("autotune_in_subproc", (True, False))
     @parametrize("use_aoti", (True, False))
     def test_max_autotune_precompile_matmul(

--- a/torch/_inductor/codegen/rocm/ck_tile_universal_gemm_template.py
+++ b/torch/_inductor/codegen/rocm/ck_tile_universal_gemm_template.py
@@ -216,7 +216,9 @@ def ops():
         for epilogue in ["Default", "CShuffle"]
     ]
 
-    return list(itertools.chain(compute_v3_instances, compute_v4_instances, mem_instances))
+    return list(
+        itertools.chain(compute_v3_instances, compute_v4_instances, mem_instances)
+    )
 
 
 class CKTileGemmTemplate(CKTileTemplate):
@@ -849,8 +851,7 @@ class CKTileGemmTemplate(CKTileTemplate):
             rendered_dispatch=render_dispatch(op.pipeline, op.name()),
             k_batch=self.k_batch,
         )
-    
-    @functools.lru_cache(None)
+
     def gen_ops(self):
         """
         Creates a list of `CKTileGemmOperation` instances that match the GEMM operation this template represents.

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -42,6 +42,7 @@ from ..utils import (
     get_tma_workspace_arg,
     use_aten_gemm_kernels,
     use_ck_gemm_template,
+    use_ck_tile_gemm_template,
     use_cpp_gemm_template,
     use_cutlass_template,
     use_decompose_k_choice,
@@ -724,6 +725,7 @@ def tuned_mm(mat1, mat2, *, layout=None):
 
     if is_nonzero and use_ck_gemm_template(layout, m, n, k):
         CKGemmTemplate.add_ck_gemm_choices(choices, layout, [mat1, mat2])
+    if is_nonzero and use_ck_tile_gemm_template(layout, m, n, k):
         CKTileGemmTemplate.add_choices(choices, layout, [mat1, mat2])
 
     if use_cpp_gemm_template(layout, mat1, mat2):

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1762,6 +1762,16 @@ def use_ck_gemm_template(layout: Layout, m: int, n: int, k: int) -> bool:
     )
 
 
+def use_ck_tile_gemm_template(layout: Layout, m: int, n: int, k: int) -> bool:
+    from .virtualized import V
+
+    return (
+        _use_autotune_backend("CKTILE")
+        and use_ck_template(layout)
+        and V.graph.sizevars.size_hint(m * n * k, fallback=-1) > 0
+    )
+
+
 def use_ck_conv_template(layout: Layout) -> bool:
     return _use_conv_autotune_backend("CK") and use_ck_template(layout)
 


### PR DESCRIPTION
... and fix ck-tile instances not being generated due to incorrect caching

### Testing

Added test cases for CKTILE instances 

```
pytest test/inductor/test_ck_backend.py -k gemm_backends_CKTILE 
```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov  @coconutruben @zjing14 @ThomasNing