### PR TITLE
[Multiprocesing] Fix `_release_ipc_counter` missing in rebuilding cuda ipc tensor with UntypedStorage

### DIFF
--- a/torch/storage.py
+++ b/torch/storage.py
@@ -155,6 +155,10 @@ class _StorageBase:
         raise NotImplementedError
 
     @classmethod
+    def _release_ipc_counter(cls, *args, device=None, **kwargs):
+        return cls._release_ipc_counter_cuda(*args, **kwargs)
+
+    @classmethod
     def _release_ipc_counter_cuda(cls, *args, **kwargs) -> Self:
         raise NotImplementedError
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/155311

To avoid `torch.multiprocessing.reductions::rebuild_cuda_tensor` failed on untyped storage, this FIX PR adds the `_release_ipc_counter` into UntypedStorage like the previous legacy typed storage.

https://github.com/pytorch/pytorch/blob/e2d141dbde55c2a4370fac5165b0561b6af4798b/torch/storage.py#L1466-L1469
