### PR TITLE
[CUDA][BUILD] Add back the capability to use env TORCH_CUDA_ARCH_LIST

### DIFF
--- a/cmake/public/utils.cmake
+++ b/cmake/public/utils.cmake
@@ -324,6 +324,10 @@ endmacro()
 #
 macro(torch_cuda_get_nvcc_gencode_flag store_var)
   # setting nvcc arch flags
+  # We need to support the explicitly and conveniently defined TORCH_CUDA_ARCH_LIST
+  if((NOT DEFINED TORCH_CUDA_ARCH_LIST) AND (DEFINED ENV{TORCH_CUDA_ARCH_LIST}))
+    set(TORCH_CUDA_ARCH_LIST $ENV{TORCH_CUDA_ARCH_LIST})
+  endif()
   if(DEFINED CUDA_ARCH_NAME)
     message(WARNING
         "CUDA_ARCH_NAME is no longer used. Use TORCH_CUDA_ARCH_LIST instead. "


### PR DESCRIPTION
Add back the capability to use env TORCH_CUDA_ARCH_LIST to control how downstream projects (which uses find_package (torch)) build.  

Follow up to: https://github.com/pytorch/pytorch/pull/152715 

Before this PR, 
On a CPU only machine, building a downstream project would ignore the TORCH_CUDA_ARCH_LIST setting (if set) and go straight to the auto GPU detection mode, in which case there would be no GPU detected and an excessive list of cuda architectures may be used. This also means that there is no way to build a binary that would be targeting a different SM on the current machine a developer is using. 

After this PR, 
TORCH_CUDA_ARCH_LIST is effective for developers to control explicitly which SM architectures to build. 

p.s. I think this PR might have been the original intent of https://github.com/pytorch/pytorch/pull/152715  

cc @atalman @malfet @janeyx99 @ptrblck @eqy @tinglvv 