### PR TITLE
[AMD] adjust wavefront size for fixed size sort

### DIFF
--- a/aten/src/ATen/native/cuda/Sort.cu
+++ b/aten/src/ATen/native/cuda/Sort.cu
@@ -205,8 +205,10 @@ struct MediumRadixSort {
     TORCH_INTERNAL_ASSERT(ceilPowerOf2 <= 4096);
 #ifdef USE_ROCM
     constexpr int default_ipt = 8;
+    constexpr int small_ipt = 2;
 #else
     constexpr int default_ipt = 32;
+    constexpr int small_ipt = 4;
 #endif
     switch (ceilPowerOf2) {
       case 4096:
@@ -223,7 +225,7 @@ struct MediumRadixSort {
       case 128:
       case 64:
 #if !HAS_WARP_MERGE_SORT()
-        HANDLE_CASE(128, 4);
+        HANDLE_CASE(128, small_ipt);
         break;
 #endif
       case 32:


### PR DESCRIPTION
Summary:
On MI350, i'm failing in an assert in rocprim: 
https://github.com/ROCm/rocPRIM/blob/develop_deprecated/rocprim/include/rocprim/block/block_radix_sort.hpp#L167

So it appears that HANDLE_CASE(128, 4) makes a blocksize of 32 and for MI350 the ::rocprim::arch::wavefront::size() is 64 which triggers this. I don't know why MI300 works because in theory it should be 64 too?

Test Plan:
argsort a 100 elelment tensor will cause this proboem. Need to add some UT

Rollback Plan:

Reviewed By: danzimm

Differential Revision: D76112190


