### PR TITLE
[ez][CI] Reuse old whl: turn off on releases, add docs files to ok list

### DIFF
--- a/.github/actions/reuse-old-whl/reuse_old_whl.py
+++ b/.github/actions/reuse-old-whl/reuse_old_whl.py
@@ -114,7 +114,7 @@ def ok_changed_file(file: str) -> bool:
         return True
     if file.startswith("test/") and file.endswith(".py"):
         return True
-    if file.startswith("docs/") and file.endswith(".md", ".rst"):
+    if file.startswith("docs/") and file.endswith((".md", ".rst")):
         return True
     return False
 

--- a/.github/actions/reuse-old-whl/reuse_old_whl.py
+++ b/.github/actions/reuse-old-whl/reuse_old_whl.py
@@ -319,16 +319,16 @@ def can_reuse_whl(args: argparse.Namespace) -> bool:
         print("Release branch, rebuild whl")
         return False
 
+    if not check_changed_files(get_merge_base()):
+        print("Cannot use old whl due to the changed files, rebuild whl")
+        return False
+
     if check_labels_for_pr():
         print(f"Found {FORCE_REBUILD_LABEL} label on PR, rebuild whl")
         return False
 
     if check_issue_open():
         print("Issue #153759 is open, rebuild whl")
-        return False
-
-    if not check_changed_files(get_merge_base()):
-        print("Cannot use old whl due to the changed files, rebuild whl")
         return False
 
     workflow_id = get_workflow_id(args.run_id)

--- a/.github/actions/reuse-old-whl/reuse_old_whl.py
+++ b/.github/actions/reuse-old-whl/reuse_old_whl.py
@@ -114,6 +114,8 @@ def ok_changed_file(file: str) -> bool:
         return True
     if file.startswith("test/") and file.endswith(".py"):
         return True
+    if file.startswith("docs/") and file.endswith(".md", ".rst"):
+        return True
     return False
 
 
@@ -307,15 +309,15 @@ def parse_args() -> argparse.Namespace:
 
 
 def can_reuse_whl(args: argparse.Namespace) -> bool:
-    # if is_main_branch() or (
-    #     args.github_ref
-    #     and any(
-    #         args.github_ref.startswith(x)
-    #         for x in ["refs/heads/release", "refs/tags/v", "refs/heads/main"]
-    #     )
-    # ):
-    #     print("On main branch or release branch, rebuild whl")
-    #     return False
+    if args.github_ref and any(
+        args.github_ref.startswith(x)
+        for x in [
+            "refs/heads/release",
+            "refs/tags/v",
+        ]
+    ):
+        print("Release branch, rebuild whl")
+        return False
 
     if check_labels_for_pr():
         print(f"Found {FORCE_REBUILD_LABEL} label on PR, rebuild whl")

--- a/.github/actions/reuse-old-whl/reuse_old_whl.py
+++ b/.github/actions/reuse-old-whl/reuse_old_whl.py
@@ -314,7 +314,7 @@ def can_reuse_whl(args: argparse.Namespace) -> bool:
         for x in [
             "refs/heads/release",
             "refs/tags/v",
-            "refs/heads/nightly"
+            "refs/heads/nightly",
         ]
     ):
         print("Release branch, rebuild whl")

--- a/.github/actions/reuse-old-whl/reuse_old_whl.py
+++ b/.github/actions/reuse-old-whl/reuse_old_whl.py
@@ -314,6 +314,7 @@ def can_reuse_whl(args: argparse.Namespace) -> bool:
         for x in [
             "refs/heads/release",
             "refs/tags/v",
+            "refs/heads/nightly"
         ]
     ):
         print("Release branch, rebuild whl")


### PR DESCRIPTION
Add docs/**/*.md and docs/**/*.rst to files that are ok to reuse old whls

Prevent using old whls on release branches

Move check for changed files earlier to reduce api usage?