### PR TITLE
[pt][easy] Rename metadata column

### DIFF
--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2200,7 +2200,7 @@ class AlgorithmSelectorCache(PersistentCache):
         def autotune(choices):
             log.debug("Starting autotuning")
 
-            autotune_data = {
+            autotuning_data = {
                 "shape": ", ".join(
                     ["x".join(map(str, n.get_size())) for n in input_nodes]
                 ),
@@ -2213,7 +2213,7 @@ class AlgorithmSelectorCache(PersistentCache):
                 f"{name}_template_autotuning",
                 log_pt2_compile_event=True,
                 dynamo_compile_column_us="compile_time_autotune_time_us",
-                metadata={"autotune_data": autotune_data},
+                metadata={"autotuning_data": autotuning_data},
             ):
                 return make_benchmark_fn()(choices)
 


### PR DESCRIPTION
Summary: Fixing typo: our logging requires autotuning_data instead of autotune_data, making it consistent

Test Plan:
Run benchmark, observe in perfetto trace proper name

Rollback Plan:

Differential Revision: D76159393




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov