### PR TITLE
Try running test_foreach sequentially

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -468,6 +468,7 @@ jobs:
       build-environment: linux-jammy-cuda12.6-py3.10-gcc11-sm89
       docker-image: ${{ needs.linux-jammy-cuda12_6-py3_10-gcc11-sm89-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda12_6-py3_10-gcc11-sm89-build.outputs.test-matrix }}
+      disable-monitor: true
     secrets: inherit
 
   linux-jammy-py3-clang12-executorch-build:

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -311,6 +311,7 @@ CI_SERIAL_LIST = [
     "inductor/test_max_autotune",
     "inductor/test_cutlass_backend",  # slow due to many nvcc compilation steps,
     "inductor/test_flex_attention",  # OOM
+    "test_foreach",  # Flaky https://github.com/pytorch/pytorch/issues/151228
 ]
 # A subset of onnx tests that cannot run in parallel due to high memory usage.
 ONNX_SERIAL_LIST = [

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -311,7 +311,6 @@ CI_SERIAL_LIST = [
     "inductor/test_max_autotune",
     "inductor/test_cutlass_backend",  # slow due to many nvcc compilation steps,
     "inductor/test_flex_attention",  # OOM
-    "test_foreach",  # Flaky https://github.com/pytorch/pytorch/issues/151228
 ]
 # A subset of onnx tests that cannot run in parallel due to high memory usage.
 ONNX_SERIAL_LIST = [


### PR DESCRIPTION
`test_foreach.py::TestForeachCUDA::test_parity` starts failing consistently in trunk, but I couldn't reproduce the issue locally or on CI (ssh into the runner) https://hud.pytorch.org/hud/pytorch/pytorch/main/1?per_page=50&name_filter=g6

~So, I suspect that running tests in parallel has a side effect here~.  Disable utilization monitoring to see if it fixs the issue. The other CI change I know is jammy upgrade https://github.com/pytorch/pytorch/pull/154437

Fixes https://github.com/pytorch/pytorch/issues/151228 (I disabled this test and another test_parity failure shows up)