### PR TITLE
Add docblock to torch/_functorch/partitioners.py

### DIFF
--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -1,3 +1,33 @@
+"""
+Graph partitioning utilities for AOT (Ahead-of-Time) compilation in PyTorch functorch.
+
+This module provides comprehensive graph partitioning capabilities for PyTorch's AOT compilation
+system, enabling efficient compilation and execution of forward and backward passes. The primary
+focus is on optimizing computation graphs through strategic partitioning, activation checkpointing,
+and memory management.
+
+Key Components:
+- Graph partitioning algorithms for forward/backward pass separation
+- Activation checkpointing strategies using min-cut and knapsack algorithms  
+- Memory optimization through selective recomputation
+- Operator classification and fusion optimization
+- Symbolic computation handling for dynamic shapes
+
+Core Classes:
+- OpTypes: Categorizes operators (fusible, compute-intensive, random, view, recomputable)
+- NodeInfo: Tracks node relationships and execution order in forward/backward graphs
+- MinCutOptions: Configuration for min-cut partitioning algorithms
+- Various partitioner implementations for different optimization strategies
+
+Main Functions:
+- extract_graph_with_inputs_outputs: Extracts subgraphs with specified inputs/outputs
+- Partitioning functions for forward/backward graph separation
+- Min-cut algorithms for optimal activation checkpointing
+- Memory usage analysis and optimization utilities
+
+This module is central to PyTorch's compilation infrastructure, handling the complex task of
+graph partitioning while maintaining correctness and optimizing for memory and compute efficiency.
+"""
 # mypy: allow-untyped-defs
 import copy
 import functools

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -8,7 +8,7 @@ and memory management.
 
 Key Components:
 - Graph partitioning algorithms for forward/backward pass separation
-- Activation checkpointing strategies using min-cut and knapsack algorithms  
+- Activation checkpointing strategies using min-cut and knapsack algorithms
 - Memory optimization through selective recomputation
 - Operator classification and fusion optimization
 - Symbolic computation handling for dynamic shapes


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #155410
* #155409
* #155408
* #155407
* #155406
* __->__ #155405

Added module documentation covering graph partitioning utilities for AOT compilation,
including key components, classes, and functions for optimization strategies and memory management.

Originally generated by claude but reviewed and edited by me.