### PR TITLE
[ONNX] Set the name of the producing node using the value name

### DIFF
--- a/torch/onnx/_internal/exporter/_core.py
+++ b/torch/onnx/_internal/exporter/_core.py
@@ -619,10 +619,17 @@ def _handle_call_function_node_with_lowering(
         node_name_to_values[node.name] = outputs
         for i, output in enumerate(outputs):
             output.name = f"{node.name}__{i}"
+            # Set the name of the producing node using the value name for correspondence
+            producer = output.producer()
+            assert producer is not None
+            producer.name = f"node_{output.name}"
     else:
         _set_shape_type(outputs, node.meta["val"], complex_to_float=True)
         node_name_to_values[node.name] = outputs
         outputs.name = node.name
+        producer = output.producer()
+        assert producer is not None
+        producer.name = f"node_{output.name}"
 
     for ir_node in onnx_nodes:
         ir_node.meta["node"] = node

--- a/torch/onnx/_internal/exporter/_core.py
+++ b/torch/onnx/_internal/exporter/_core.py
@@ -621,15 +621,15 @@ def _handle_call_function_node_with_lowering(
             output.name = f"{node.name}__{i}"
             # Set the name of the producing node using the value name for correspondence
             producer = output.producer()
-            assert producer is not None
-            producer.name = f"node_{output.name}"
+            if producer is not None:
+                producer.name = f"node_{output.name}"
     else:
         _set_shape_type(outputs, node.meta["val"], complex_to_float=True)
         node_name_to_values[node.name] = outputs
         outputs.name = node.name
         producer = outputs.producer()
-        assert producer is not None
-        producer.name = f"node_{outputs.name}"
+        if producer is not None:
+            producer.name = f"node_{outputs.name}"
 
     for ir_node in onnx_nodes:
         ir_node.meta["node"] = node

--- a/torch/onnx/_internal/exporter/_core.py
+++ b/torch/onnx/_internal/exporter/_core.py
@@ -627,9 +627,9 @@ def _handle_call_function_node_with_lowering(
         _set_shape_type(outputs, node.meta["val"], complex_to_float=True)
         node_name_to_values[node.name] = outputs
         outputs.name = node.name
-        producer = output.producer()
+        producer = outputs.producer()
         assert producer is not None
-        producer.name = f"node_{output.name}"
+        producer.name = f"node_{outputs.name}"
 
     for ir_node in onnx_nodes:
         ir_node.meta["node"] = node


### PR DESCRIPTION
When comparing two graphs exported using different opset versions, even though the value names are the same in both graphs, the node names did not match, causing model-explorer to not be able to sync the two graphs. This change updates the names of the nodes that directly produce the output values, for better correspondence across exported graphs.

![image](https://github.com/user-attachments/assets/3c00ca18-221f-4add-8429-4bcf12069036)
