### PR TITLE
Add comprehensive docblock to torch/_inductor/codegen/cpp.py

### DIFF
--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -1,3 +1,38 @@
+"""
+C++ Code Generation Backend for PyTorch Inductor.
+
+This module implements the C++ code generation backend for PyTorch's Inductor compiler,
+transforming the intermediate representation (IR) into optimized C++ code. It handles
+CPU code generation with support for vectorization, parallelization, and various
+optimization strategies.
+
+Key Components:
+- CppKernel: Base class for C++ kernel code generation
+- CppVecKernel: Vectorized C++ kernel with SIMD optimization support
+- CppTile2DKernel: 2D tiling optimization for matrix operations
+- CppOverrides: C++-specific operation implementations
+- ParallelDepth: OpenMP parallelization strategy management
+
+The C++ backend supports:
+- Automatic vectorization using CPU SIMD instructions (AVX2, AVX512)
+- OpenMP-based parallelization with dynamic thread management
+- Memory access optimization and loop tiling strategies
+- Template-based code generation for common patterns
+- CSE (Common Subexpression Elimination) optimization
+- Integration with external C++ libraries and optimized BLAS routines
+
+Code Generation Features:
+- Efficient loop nest generation with bounds checking
+- Automatic type promotion and casting
+- Memory layout optimization for cache efficiency
+- Support for reduction operations and broadcasting
+- Integration with PyTorch's autograd system
+- Cross-platform compatibility (Linux, Windows, macOS)
+
+This module serves as the primary CPU backend for Inductor, generating
+high-performance C++ code that can be compiled and executed efficiently
+across different CPU architectures and operating systems.
+"""
 # mypy: allow-untyped-defs
 import contextlib
 import dataclasses


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #155418
* #155417
* __->__ #155416
* #155415
* #155414

Enhance the C++ code generation backend module with detailed documentation
explaining the C++ code generation infrastructure, including vectorization,
parallelization, loop optimization, and cross-platform compatibility features.