### PR TITLE
[DTensor] Fix aten.all strategy with min instead of sum as the reduce_op

### DIFF
--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -56,9 +56,8 @@ class DistMathOpsTest(DTensorTestBase):
         shard_spec = [Shard(0)]
 
         tensor = torch.randn(12, 8, 8)
-        # TODO: check `all` correctness and test `all` on a bool tensor
-        if op_str in ("any"):
-            # test out a bool tensor for any
+        if op_str in ("any", "all"):
+            # test out a bool tensor for any and all
             tensor = tensor < 0
         dtensor = distribute_tensor(tensor, device_mesh, shard_spec)
 

--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -303,8 +303,8 @@ def common_reduction_strategy(
 
 
 LINEAR_REDUCTION_OP_MAP = {
-    aten.all.default: "sum",
-    aten.all.dim: "sum",
+    aten.all.default: "min",
+    aten.all.dim: "min",
     aten.sum.default: "sum",
     aten.sum.dim_IntList: "sum",
     aten.prod.default: "product",


### PR DESCRIPTION
For `aten.all`, when all_reduce with `min`, if one rank returns torch.Tensor([False]), the reduction result will be torch.Tensor([False]). Only when all ranks return torch.Tensor([True]) will return torch.Tensor([True]). the behavior matches the aten.all.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta