### PR TITLE
[Profiler] Fix lost C call events problem in Python 3.12.0-3.12.4

### DIFF
--- a/test/profiler/test_python_tracer.py
+++ b/test/profiler/test_python_tracer.py
@@ -1,28 +1,34 @@
-from torch.profiler import profile, ProfilerActivity
-from torch.testing._internal.common_utils import run_tests, skipIfPythonVersionMismatch, TestCase, TemporaryFileName
+# Owner(s): ["oncall: profiler"]
 
 import json
 import sys
 import time
 
+from torch.profiler import profile, ProfilerActivity
+from torch.testing._internal.common_utils import (
+    run_tests,
+    skipIfPythonVersionMismatch,
+    TemporaryFileName,
+    TestCase,
+)
+
 
 class TestPythonTracer(TestCase):
-
     @skipIfPythonVersionMismatch(lambda major, minor, micro: major == 3 and minor == 12)
     def test_method_with_c_function(self):
-        micro = sys.version_info.micro
-
         class A:
             method_with_c_function = classmethod(repr)
 
         def get_key(x):
             A().method_with_c_function()
-            time.sleep(1)
+            time.sleep(1.2)
             return len(x)
 
         names = ["Alice", "Bob"]
 
-        with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA], with_stack=True) as prof:
+        with profile(
+            activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA], with_stack=True
+        )as prof:
             sorted(names, key=get_key)
 
         with TemporaryFileName(mode="w+") as fname:
@@ -31,19 +37,23 @@ class TestPythonTracer(TestCase):
                 events = json.load(f)["traceEvents"]
                 found = False
                 for event in events:
-                    if event.get("cat", "") == "python_function" and event.get("name", "") == "<built-in function sorted>":
+                    if (
+                        event.get("cat", "") == "python_function"
+                        and event.get("name", "") == "<built-in function sorted>"
+                    ):
                         duration = event.get("dur", 0)
-                        if (duration >= 2000000):
+                        if duration >= 2000000:
                             found = True
                             break
                 self.assertTrue(found)
 
     @skipIfPythonVersionMismatch(lambda major, minor, micro: major == 3 and minor == 12)
     def test_monitoring_callback(self):
-        from torch._vendor.packaging import version
         vi = sys.version_info
         from sys import monitoring
-        with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA], with_stack=True) as prof:
+        with profile(
+            activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA], with_stack=True
+        ):
             name = monitoring.get_tool(2)
             if vi.micro < 5:
                 self.assertEqual(name, "PyTorch Profiler")

--- a/test/profiler/test_python_tracer.py
+++ b/test/profiler/test_python_tracer.py
@@ -38,6 +38,20 @@ class TestPythonTracer(TestCase):
                             break
                 self.assertTrue(found)
 
+    @skipIfPythonVersionMismatch(lambda major, minor, micro: major == 3 and minor == 12)
+    def test_monitoring_callback(self):
+        from torch._vendor.packaging import version
+        vi = sys.version_info
+        from sys import monitoring
+        with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA], with_stack=True) as prof:
+            name = monitoring.get_tool(2)
+            if vi.micro < 5:
+                self.assertEqual(name, "PyTorch Profiler")
+            else:
+                self.assertEqual(name, None)
+        name = monitoring.get_tool(2)
+        self.assertEqual(name, None)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/profiler/test_python_tracer.py
+++ b/test/profiler/test_python_tracer.py
@@ -28,7 +28,7 @@ class TestPythonTracer(TestCase):
 
         with profile(
             activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA], with_stack=True
-        )as prof:
+        ) as prof:
             sorted(names, key=get_key)
 
         with TemporaryFileName(mode="w+") as fname:
@@ -51,6 +51,7 @@ class TestPythonTracer(TestCase):
     def test_monitoring_callback(self):
         vi = sys.version_info
         from sys import monitoring
+
         with profile(
             activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA], with_stack=True
         ):

--- a/test/profiler/test_python_tracer.py
+++ b/test/profiler/test_python_tracer.py
@@ -1,0 +1,43 @@
+from torch.profiler import profile, ProfilerActivity
+from torch.testing._internal.common_utils import run_tests, skipIfPythonVersionNotIn, TestCase, TemporaryFileName
+
+import json
+import sys
+import time
+
+
+class TestPythonTracer(TestCase):
+
+    @skipIfPythonVersionNotIn("3.12", "3.13")
+    def test_method_with_c_function(self):
+        micro = sys.version_info.micro
+
+        class A:
+            method_with_c_function = classmethod(repr)
+
+        def get_key(x):
+            A().method_with_c_function()
+            time.sleep(1)
+            return len(x)
+
+        names = ["Alice", "Bob"]
+
+        with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA], with_stack=True) as prof:
+            sorted(names, key=get_key)
+
+        with TemporaryFileName(mode="w+") as fname:
+            prof.export_chrome_trace(fname)
+            with open(fname) as f:
+                events = json.load(f)["traceEvents"]
+                found = False
+                for event in events:
+                    if event.get("cat", "") == "python_function" and event.get("name", "") == "<built-in function sorted>":
+                        duration = event.get("dur", 0)
+                        if (duration >= 2000000):
+                            found = True
+                            break
+                self.assertTrue(found)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/profiler/test_python_tracer.py
+++ b/test/profiler/test_python_tracer.py
@@ -1,5 +1,5 @@
 from torch.profiler import profile, ProfilerActivity
-from torch.testing._internal.common_utils import run_tests, skipIfPythonVersionNotIn, TestCase, TemporaryFileName
+from torch.testing._internal.common_utils import run_tests, skipIfPythonVersionMismatch, TestCase, TemporaryFileName
 
 import json
 import sys
@@ -8,7 +8,7 @@ import time
 
 class TestPythonTracer(TestCase):
 
-    @skipIfPythonVersionNotIn("3.12", "3.13")
+    @skipIfPythonVersionMismatch(lambda major, minor, micro: major == 3 and minor == 12)
     def test_method_with_c_function(self):
         micro = sys.version_info.micro
 

--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -749,7 +749,7 @@ class PythonTracer final : public python_tracer::PythonTracerBase {
 #define PROFILER_ID 2
 #define PY_MONITORING_EVENT_CALL 4
 
-static bool should_compensate_c_call_event() {
+static bool should_compensate_c_call_events() {
   static const bool result = []() {
     const char* version = Py_GetVersion();
     const char micro = version[5];
@@ -810,7 +810,7 @@ static PyObject* c_call_callback(
 }
 
 static void registerMonitoringCallback() {
-  if (!should_compensate_c_call_event()) {
+  if (!should_compensate_c_call_events()) {
     return;
   }
 
@@ -862,7 +862,7 @@ static void registerMonitoringCallback() {
 }
 
 static void unregisterMonitoringCallback() {
-  if (!should_compensate_c_call_event()) {
+  if (!should_compensate_c_call_events()) {
     return;
   }
 

--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -837,7 +837,7 @@ static void registerMonitoringCallback() {
   auto monitoring =
       THPObjectPtr(PyObject_GetAttrString(sys_module, "monitoring"));
   if (!monitoring) {
-    TORCH_WARN("Failed to get monitoring from sys moudle.");
+    TORCH_WARN("Failed to get monitoring from sys module.");
     PyErr_Clear();
     return;
   }
@@ -895,7 +895,7 @@ static void unregisterMonitoringCallback() {
   auto monitoring =
       THPObjectPtr(PyObject_GetAttrString(sys_module, "monitoring"));
   if (!monitoring) {
-    TORCH_WARN("Failed to get monitoring from sys moudle.");
+    TORCH_WARN("Failed to get monitoring from sys module.");
     PyErr_Clear();
     return;
   }

--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -765,7 +765,6 @@ static bool should_compensate_c_call_events() {
 struct _PyEventHandler {
   PyObject_HEAD
   vectorcallfunc vectorcall;
-  PythonTracer* tracer;
 };
 
 static PyTypeObject _PyEventHandler_Type = {

--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -797,7 +797,8 @@ static PyObject* c_call_callback(
   PyObject* callable = args[2];
   if (Py_TYPE(callable) == &PyMethod_Type) {
     // The call event of a method with c function is missing on 3.12.0-3.12.4.
-    // See https://github.com/python/cpython/commit/257c413cd16ddabcedde413288d0bb93bf872da7
+    // See
+    // https://github.com/python/cpython/commit/257c413cd16ddabcedde413288d0bb93bf872da7
     // Other cases have already be handled by the legacy_tracing, so we only
     // need to handle this case.
     // The exception branches keep the same behavior as CPython.

--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -679,6 +679,13 @@ struct ThreadLocalResults {
 // ============================================================================
 // == Tracing implementation ==================================================
 // ============================================================================
+#define IS_PYTHON_3_12 (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION == 12)
+#if IS_PYTHON_3_12
+// forward declarations
+struct _PyEventHandler;
+static PyObject* c_call_callback(_PyEventHandler* self, PyObject* const* args, size_t nargsf, PyObject* kwnames);
+#endif
+
 class PythonTracer final : public python_tracer::PythonTracerBase {
  public:
   PythonTracer(torch::profiler::impl::RecordQueue* queue);
@@ -717,8 +724,6 @@ class PythonTracer final : public python_tracer::PythonTracerBase {
 
   const std::vector<PyThreadState*> interpreterThreads() const;
 
-  PyObject* get_callable_from_frame(PyFrameObject* frame);
-
   std::atomic<bool> active_lock_{false};
   bool active_{false};
 
@@ -730,7 +735,180 @@ class PythonTracer final : public python_tracer::PythonTracerBase {
   std::vector<StartFrame> start_frames_;
   std::deque<ThreadLocalResults> thread_local_results_;
   ValueCache value_cache_;
+
+#if IS_PYTHON_3_12
+  friend PyObject* c_call_callback(
+      _PyEventHandler* self,
+      PyObject* const* args,
+      size_t nargsf,
+      PyObject* kwnames);
+#endif
 };
+
+#if IS_PYTHON_3_12
+#define PROFILER_ID 2
+#define PY_MONITORING_EVENT_CALL 4
+
+static bool should_compensate_c_call_event() {
+  static const bool result = []() {
+    const char* version = Py_GetVersion();
+    const char micro = version[5];
+    return micro == '0' || (micro <= '4' && version[6] == ' ');
+  }();
+  return result;
+}
+
+struct _PyEventHandler {
+  PyObject_HEAD
+  vectorcallfunc vectorcall;
+  PythonTracer* tracer;
+};
+
+static PyTypeObject _PyEventHandler_Type = {
+    PyVarObject_HEAD_INIT(&PyType_Type, 0)
+    "torch.profiler.python_tracer_event_handler",
+    sizeof(_PyEventHandler),
+    .tp_dealloc = (destructor)PyObject_Free,
+    .tp_vectorcall_offset = offsetof(_PyEventHandler, vectorcall),
+    .tp_call = PyVectorcall_Call,
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |
+        Py_TPFLAGS_HAVE_VECTORCALL | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+};
+
+static PyObject* c_call_callback(
+    _PyEventHandler* self,
+    PyObject* const* args,
+    size_t nargsf,
+    PyObject* kwnames) {
+  PyThreadState* tstate = PyThreadState_GET();
+  if (tstate->c_profilefunc != PythonTracer::pyProfileFn) {
+    Py_RETURN_NONE;
+  }
+
+  PyObject* callable = args[2];
+  if (Py_TYPE(callable) == &PyMethod_Type) {
+    PyObject* func = PyMethod_GET_FUNCTION(callable);
+    if (!func) {
+      return NULL;
+    }
+    if (PyCFunction_Check(func)) {
+      PyFrameObject* frame = PyEval_GetFrame();
+      if (!frame) {
+        PyErr_SetString(
+            PyExc_SystemError, "Missing frame when calling profile function.");
+        return NULL;
+      }
+      Py_INCREF(frame);
+      auto& local_results =
+          *reinterpret_cast<TraceContext*>(tstate->c_profileobj)
+               ->thread_local_results_;
+      local_results.active_tracer_->recordCCall(local_results, frame, func);
+      Py_DECREF(frame);
+    }
+  }
+  Py_RETURN_NONE;
+}
+
+static void registerMonitoringCallback() {
+  if (!should_compensate_c_call_event()) {
+    return;
+  }
+
+  auto sys_module = THPObjectPtr(PyImport_ImportModule("sys"));
+  if (!sys_module) {
+    TORCH_WARN("Failed to import sys module.");
+    return;
+  }
+  auto monitoring =
+      THPObjectPtr(PyObject_GetAttrString(sys_module, "monitoring"));
+  if (!monitoring) {
+    TORCH_WARN("Failed to get monitoring from sys moudle.");
+    return;
+  }
+  auto result = THPObjectPtr(PyObject_CallMethod(
+      monitoring, "use_tool_id", "is", PROFILER_ID, "PyTorch Profiler"));
+  if (!result) {
+    TORCH_WARN("Failed to call sys.monitoring.use_tool_id");
+    return;
+  }
+  auto handler = THPObjectPtr(PyObject_NEW(PyObject, &_PyEventHandler_Type));
+  if (!handler) {
+    TORCH_WARN("Failed to create _PyEventHandler object.");
+    return;
+  }
+  reinterpret_cast<_PyEventHandler*>(handler.get())->vectorcall =
+      (vectorcallfunc)c_call_callback;
+  result = THPObjectPtr(PyObject_CallMethod(
+      monitoring,
+      "register_callback",
+      "iiO",
+      PROFILER_ID,
+      1 << PY_MONITORING_EVENT_CALL,
+      handler.get()));
+  if (!result) {
+    TORCH_WARN("Failed to call sys.monitoring.register_callback.");
+    return;
+  }
+  result = THPObjectPtr(PyObject_CallMethod(
+      monitoring,
+      "set_events",
+      "ii",
+      PROFILER_ID,
+      1 << PY_MONITORING_EVENT_CALL));
+  if (!result) {
+    TORCH_WARN("Failed to call sys.monitoring.set_events.");
+    return;
+  }
+}
+
+static void unregisterMonitoringCallback() {
+  if (!should_compensate_c_call_event()) {
+    return;
+  }
+
+  auto sys_module = THPObjectPtr(PyImport_ImportModule("sys"));
+  if (!sys_module) {
+    TORCH_WARN("Failed to import sys module.");
+    return;
+  }
+  auto monitoring =
+      THPObjectPtr(PyObject_GetAttrString(sys_module, "monitoring"));
+  if (!monitoring) {
+    TORCH_WARN("Failed to get monitoring from sys moudle.");
+    return;
+  }
+  auto tool_name = THPObjectPtr(
+      PyObject_CallMethod(monitoring, "get_tool", "i", PROFILER_ID));
+  if (!tool_name) {
+    TORCH_WARN("Failed to call sys.monitoring.use_tool_id");
+    return;
+  }
+  if (THPUtils_checkString(tool_name)) {
+    const char* str = THPUtils_unpackStringView(tool_name).data();
+    if (strcmp(str, "PyTorch Profiler") == 0) {
+      auto none = THPObjectPtr(Py_None);
+      Py_INCREF(Py_None);
+      auto result = THPObjectPtr(PyObject_CallMethod(
+          monitoring,
+          "register_callback",
+          "iiO",
+          PROFILER_ID,
+          1 << PY_MONITORING_EVENT_CALL,
+          none.get()));
+      if (!result) {
+        TORCH_WARN("Failed to call sys.monitoring.register_callback.");
+        return;
+      }
+      result = THPObjectPtr(
+          PyObject_CallMethod(monitoring, "set_events", "ii", PROFILER_ID, 0));
+      if (!result) {
+        TORCH_WARN("Failed to call sys.monitoring.set_events.");
+        return;
+      }
+    }
+  }
+}
+#endif
 
 const std::vector<PyThreadState*> PythonTracer::interpreterThreads() const {
   pybind11::gil_scoped_acquire gil;
@@ -797,16 +975,6 @@ PythonTracer::PythonTracer(torch::profiler::impl::RecordQueue* queue)
 
     for (auto it = current_stack.rbegin(); it != current_stack.rend(); it++) {
       recordPyCall(thread_local_results_.back(), it->get(), true);
-      PyFrameObject* frame = it->get();
-      PyObject* callable = get_callable_from_frame(frame);
-      if (callable) {
-        // If the frame has a callable, record it as a C call since
-        // PyEval_GetFrame only gets the python frame. We need to record this C
-        // call so that when exiting the profiler we don't have a mismatched C
-        // call.
-        recordCCall(thread_local_results_.back(), it->get(), callable, true);
-      }
-
       auto frame_refcount = Py_REFCNT(it->get());
 
       // We hold one reference in `current_stack`, and the interpreter holds
@@ -819,6 +987,9 @@ PythonTracer::PythonTracer(torch::profiler::impl::RecordQueue* queue)
     //   cannot be round tripped via `sys.settrace(sys.gettrace())`
     PyEval_SetProfile(PythonTracer::pyProfileFn, (PyObject*)ctx);
   }
+#if IS_PYTHON_3_12
+  registerMonitoringCallback();
+#endif
 }
 
 void PythonTracer::stop() {
@@ -830,6 +1001,10 @@ void PythonTracer::stop() {
         PyEval_SetProfile(nullptr, nullptr);
       }
     }
+
+#if IS_PYTHON_3_12
+    unregisterMonitoringCallback();
+#endif
 
     auto lock_returned = active_lock_.compare_exchange_strong(active_, false);
     active_ = false;
@@ -854,6 +1029,9 @@ void PythonTracer::restart() {
       PyEval_SetProfile(PythonTracer::pyProfileFn, (PyObject*)ctx);
     }
   }
+#if IS_PYTHON_3_12
+  registerMonitoringCallback();
+#endif
 }
 
 // NOLINTNEXTLINE(bugprone-exception-escape)
@@ -937,25 +1115,6 @@ void PythonTracer::recordCCall(
   queue_->getSubqueue()->emplace_py_call(key, c10::getApproximateTime());
 }
 
-PyObject* PythonTracer::get_callable_from_frame(PyFrameObject* frame) {
-  if (frame == nullptr) {
-    return nullptr;
-  }
-  // Get the code object associated with the frame
-  auto code = THPCodeObjectPtr(PyFrame_GetCode(frame));
-  if (code == nullptr) {
-    return nullptr;
-  }
-  // Get the function name (if needed)
-  auto name = THPUtils_unpackStringView(code->co_name).data();
-  // To get the function object, you will need to look in the globals or the
-  // frame's f_globals
-  PyObject* func = PyDict_GetItemString(PyFrame_GetGlobals(frame), name);
-  if (func) {
-    Py_INCREF(func); // Make sure the returned function has a reference
-  }
-  return func; // Returns a PyObject* (the function)
-}
 
 // ============================================================================
 // == Post processing =========================================================
@@ -1058,9 +1217,7 @@ class PostProcess {
                state.exits_.top().t_ < enter.enter_t_) {
           auto& exit = state.exits_.top();
           auto& tstack = stacks[exit.python_tid_];
-          if (!tstack.empty()) {
-            pop(tstack, exit.t_);
-          }
+          pop(tstack, exit.t_);
           state.exits_.pop();
         }
         out.push_back(Result::create(

--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -768,14 +768,26 @@ struct _PyEventHandler {
 };
 
 static PyTypeObject _PyEventHandler_Type = {
-    .ob_base = PyVarObject_HEAD_INIT(&PyType_Type, 0)
-    .tp_name = "torch.profiler.python_tracer_event_handler",
-    .tp_basicsize = sizeof(_PyEventHandler),
-    .tp_dealloc = (destructor)PyObject_Free,
-    .tp_vectorcall_offset = offsetof(_PyEventHandler, vectorcall),
-    .tp_call = PyVectorcall_Call,
-    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |
-        Py_TPFLAGS_HAVE_VECTORCALL | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    PyVarObject_HEAD_INIT(&PyType_Type, 0) /* ob_base */
+    "torch.profiler.python_tracer_event_handler", /* tp_name */
+    sizeof(_PyEventHandler), /* tp_basicsize */
+    0, /* tp_itemsize */
+    (destructor)PyObject_Free, /* tp_dealloc */
+    offsetof(_PyEventHandler, vectorcall), /* tp_vectorcall_offset */
+    nullptr, /* tp_getattr */
+    nullptr, /* tp_setattr */
+    nullptr, /* tp_reserved */
+    nullptr, /* tp_repr */
+    nullptr, /* tp_as_number */
+    nullptr, /* tp_as_sequence */
+    nullptr, /* tp_as_mapping */
+    nullptr, /* tp_hash */
+    PyVectorcall_Call, /* tp_call */
+    nullptr, /* tp_str */
+    nullptr, /* tp_getattro */
+    nullptr, /* tp_setattro */
+    nullptr, /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_VECTORCALL | Py_TPFLAGS_DISALLOW_INSTANTIATION, /* tp_flags */
 };
 
 static PyObject* c_call_callback(

--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -787,7 +787,8 @@ static PyTypeObject _PyEventHandler_Type = {
     nullptr, /* tp_getattro */
     nullptr, /* tp_setattro */
     nullptr, /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_VECTORCALL | Py_TPFLAGS_DISALLOW_INSTANTIATION, /* tp_flags */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_VECTORCALL |
+        Py_TPFLAGS_DISALLOW_INSTANTIATION, /* tp_flags */
 };
 
 static PyObject* c_call_callback(

--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -768,9 +768,9 @@ struct _PyEventHandler {
 };
 
 static PyTypeObject _PyEventHandler_Type = {
-    PyVarObject_HEAD_INIT(&PyType_Type, 0)
-    "torch.profiler.python_tracer_event_handler",
-    sizeof(_PyEventHandler),
+    .ob_base = PyVarObject_HEAD_INIT(&PyType_Type, 0)
+    .tp_name = "torch.profiler.python_tracer_event_handler",
+    .tp_basicsize = sizeof(_PyEventHandler),
     .tp_dealloc = (destructor)PyObject_Free,
     .tp_vectorcall_offset = offsetof(_PyEventHandler, vectorcall),
     .tp_call = PyVectorcall_Call,

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -5764,3 +5764,18 @@ def recover_orig_fp32_precision(fn):
             torch.backends.cuda.matmul.fp32_precision = old_cuda_matmul_p
 
     return recover()(fn)
+
+# Skips a test if the Python version is not in the specified range.
+def skipIfPythonVersionNotIn(version_from, version_to):
+    from torch._vendor.packaging import version
+    vi = sys.version_info
+    v = version.parse(f"{vi.major}.{vi.minor}.{vi.micro}")
+    def dec_fn(fn):
+        @wraps(fn)
+        def wrap_fn(self, *args, **kwargs):
+            if v >= version.parse(version_from) and v < version.parse(version_to):
+                return fn(self, *args, **kwargs)
+            else:
+                raise unittest.SkipTest(f"Python version {v} not in range [{version_from} - {version_to})")
+        return wrap_fn
+    return dec_fn

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -5767,8 +5767,8 @@ def recover_orig_fp32_precision(fn):
 
 # Skips a test if the Python version is not in the specified range.
 def skipIfPythonVersionMismatch(predicate):
-    from torch._vendor.packaging import version
     vi = sys.version_info
+
     def dec_fn(fn):
         @wraps(fn)
         def wrap_fn(self, *args, **kwargs):

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -5765,7 +5765,6 @@ def recover_orig_fp32_precision(fn):
 
     return recover()(fn)
 
-# Skips a test if the Python version is not in the specified range.
 def skipIfPythonVersionMismatch(predicate):
     vi = sys.version_info
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -5766,16 +5766,15 @@ def recover_orig_fp32_precision(fn):
     return recover()(fn)
 
 # Skips a test if the Python version is not in the specified range.
-def skipIfPythonVersionNotIn(version_from, version_to):
+def skipIfPythonVersionMismatch(predicate):
     from torch._vendor.packaging import version
     vi = sys.version_info
-    v = version.parse(f"{vi.major}.{vi.minor}.{vi.micro}")
     def dec_fn(fn):
         @wraps(fn)
         def wrap_fn(self, *args, **kwargs):
-            if v >= version.parse(version_from) and v < version.parse(version_to):
+            if predicate(vi.major, vi.minor, vi.micro):
                 return fn(self, *args, **kwargs)
             else:
-                raise unittest.SkipTest(f"Python version {v} not in range [{version_from} - {version_to})")
+                raise unittest.SkipTest("Python version mismatch")
         return wrap_fn
     return dec_fn


### PR DESCRIPTION
Hi team,

Please help review this patch.

This PR https://github.com/pytorch/pytorch/pull/150370 tried to fix the "Empty C Call Queue" problem on Python 3.12. It added C calls for each starting Python event with a callable.

I found the root cause is not that we cannot get C function frames by `PyFrame_GetBack` when PythonTracer is filling start frames, but the c call event loss problem bug on Python 3.12.0-3.12.4. And that problem was fixed by https://github.com/python/cpython/commit/257c413cd16ddabcedde413288d0bb93bf872da7 on 3.12.5.

So I think the https://github.com/pytorch/pytorch/pull/150370 cannot fix the problem, this patch reverts the change of it.

There are solutions to fix the problem correctly, such as we can add a new monitoring callback to compensate call events of methods with C function or we can override the callback registered by `PyEval_SetProfile`.  These solutions may make the code hard to maintain.

~~Since upgrading the micro version of Python is not difficult for users, we can just ignore C functions and suggest user upgrade.~~

