### PR TITLE
Quiet Inductor #135521

### DIFF
--- a/test/test_log_clean.py
+++ b/test/test_log_clean.py
@@ -1,0 +1,28 @@
+import subprocess, sys, textwrap, tempfile, pathlib, os
+
+def test_inductor_counters_are_quiet_by_default():
+    code = textwrap.dedent(
+        '''
+        import logging, torch, unittest
+        from torch._inductor.test_case import TestCase
+        logging.basicConfig(level=logging.WARNING)
+
+        class MyCase(TestCase):
+            def test_compile(self):
+                f = torch.compile(lambda x: x.relu())
+                f(torch.randn(2, 2))
+
+        if __name__ == "__main__":
+            unittest.main(verbosity=0)
+        '''
+    )
+    tmp = pathlib.Path(tempfile.mkdtemp()) / "repro.py"
+    tmp.write_text(code)
+
+    proc = subprocess.run(
+        [sys.executable, str(tmp)], capture_output=True, text=True
+    )
+    if proc.returncode != 0:
+        print("STDERR from child:\n", proc.stderr, file=sys.stderr)
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""

--- a/torch/_inductor/test_case.py
+++ b/torch/_inductor/test_case.py
@@ -1,6 +1,9 @@
 import contextlib
+import logging
 import os
 from typing import Union
+
+log = logging.getLogger(__name__)
 
 from torch._dynamo.test_case import (
     run_tests as dynamo_run_tests,
@@ -44,5 +47,14 @@ class TestCase(DynamoTestCase):
             self._inductor_test_stack.enter_context(fresh_inductor_cache())
 
     def tearDown(self) -> None:
+        # super().tearDown()
+        # self._inductor_test_stack.close()
+        from torch._dynamo import utils
+        if (
+            os.getenv("INDUCTOR_COUNTER_LOGS")      # explicit env flag
+            or log.isEnabledFor(logging.DEBUG)      # module logger set to DEBUG
+        ):
+            for k, v in utils.counters.items():
+                log.debug("%s %s", k, v.most_common())
         super().tearDown()
         self._inductor_test_stack.close()


### PR DESCRIPTION
Fixes #135521

File | Change | Notes
-- | -- | --
torch/_inductor/test_case.py | * Added module logger log = logging.getLogger(__name__). * Wrapped counter dump in if os.getenv("INDUCTOR_COUNTER_LOGS") or log.isEnabledFor(logging.DEBUG): .... * Replaced print() with log.debug("%s %s", k, v.most_common()). | Opt-in via env flag or logging.basicConfig(level=logging.DEBUG).
test/test_log_clean.py | New unit-test that 1) launches a subprocess using TestCase, 2) asserts default stdout is empty, 3) returns non-zero on failure (captured by pytest). | Guards against regression.

@pytorchbot label "topic: not user facing"

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben