### PR TITLE
[BE] Raise better exception in `torch.[con]cat[enate]`

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -774,7 +774,7 @@ Tensor cat(TensorList tensors, Dimname dim) {
 
 // torch.concat, alias for torch.cat
 Tensor& concat_out(TensorList tensors, Dimname dim, Tensor& result) {
-  return at::cat_out(tensors, dim, result);
+  return cat_out(tensors, dim, result);
 }
 
 Tensor concat(TensorList tensors, Dimname dim) {
@@ -791,7 +791,7 @@ Tensor concat(TensorList tensors, int64_t dim) {
 
 // torch.concatenate, alias for torch.cat
 Tensor& concatenate_out(TensorList tensors, Dimname dim, Tensor& result) {
-  return at::cat_out(tensors, dim, result);
+  return cat_out(tensors, dim, result);
 }
 
 Tensor concatenate(TensorList tensors, Dimname dim) {
@@ -799,7 +799,7 @@ Tensor concatenate(TensorList tensors, Dimname dim) {
 }
 
 Tensor& concatenate_out(TensorList tensors, int64_t dim, Tensor& result) {
-  return at::cat_out(tensors, dim, result);
+  return at::cat_out(result, tensors, dim);
 }
 
 Tensor concatenate(TensorList tensors, int64_t dim) {

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -799,7 +799,7 @@ Tensor concatenate(TensorList tensors, Dimname dim) {
 }
 
 Tensor& concatenate_out(TensorList tensors, int64_t dim, Tensor& result) {
-  return at::cat_out(result, tensors, dim);
+  return at::cat_out(tensors, dim, result);
 }
 
 Tensor concatenate(TensorList tensors, int64_t dim) {

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -763,24 +763,22 @@ TORCH_IMPL_FUNC(cat_out_cpu)
 }
 
 Tensor& cat_out(TensorList tensors, Dimname dim, Tensor& result) {
-  TORCH_CHECK(!tensors.empty(), "expected a non-empty list of Tensors");
+  TORCH_CHECK_VALUE(!tensors.empty(), "expected a non-empty list of Tensors");
   return at::cat_out(result, tensors, dimname_to_position(tensors[0], dim));
 }
 
 Tensor cat(TensorList tensors, Dimname dim) {
-  TORCH_CHECK(!tensors.empty(), "expected a non-empty list of Tensors");
+  TORCH_CHECK_VALUE(!tensors.empty(), "expected a non-empty list of Tensors");
   return at::cat(tensors, dimname_to_position(tensors[0], dim));
 }
 
 // torch.concat, alias for torch.cat
 Tensor& concat_out(TensorList tensors, Dimname dim, Tensor& result) {
-  TORCH_CHECK(!tensors.empty(), "expected a non-empty list of Tensors");
-  return at::cat_out(result, tensors, dimname_to_position(tensors[0], dim));
+  return at::cat_out(tensors, dim, result);
 }
 
 Tensor concat(TensorList tensors, Dimname dim) {
-  TORCH_CHECK(!tensors.empty(), "expected a non-empty list of Tensors");
-  return at::cat(tensors, dimname_to_position(tensors[0], dim));
+  return at::cat(tensors, dim);
 }
 
 Tensor& concat_out(TensorList tensors, int64_t dim, Tensor& result) {
@@ -793,13 +791,11 @@ Tensor concat(TensorList tensors, int64_t dim) {
 
 // torch.concatenate, alias for torch.cat
 Tensor& concatenate_out(TensorList tensors, Dimname dim, Tensor& result) {
-  TORCH_CHECK(!tensors.empty(), "expected a non-empty list of Tensors");
-  return at::cat_out(result, tensors, dimname_to_position(tensors[0], dim));
+  return at::cat_out(tensors, dim, result);
 }
 
 Tensor concatenate(TensorList tensors, Dimname dim) {
-  TORCH_CHECK(!tensors.empty(), "expected a non-empty list of Tensors");
-  return at::cat(tensors, dimname_to_position(tensors[0], dim));
+  return at::cat(tensors, dim);
 }
 
 Tensor& concatenate_out(TensorList tensors, int64_t dim, Tensor& result) {

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -536,9 +536,9 @@ class TestTensorCreation(TestCase):
     def test_concat_empty_list_error(self, device):
         # Regression test for https://github.com/pytorch/pytorch/issues/155306
         msg = "expected a non-empty list of Tensors"
-        with self.assertRaisesRegex(RuntimeError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             torch.concat([], dim='N')
-        with self.assertRaisesRegex(RuntimeError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             torch.concatenate([], dim='N')
 
     def test_cat_out(self, device):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #155460

By replacing `TORCH_CHECK` with `TORCH_CHECK_VALUE`

Also make redispatching from aliases an even simpler, by just calling
respective original class

Addresses feedback raised in https://github.com/pytorch/pytorch/pull/155383/files#r2133952368

cc @albanD