### PR TITLE
[CI] Set PATH during build to include location of sccache wrapped nvcc

### DIFF
--- a/.ci/docker/ubuntu/Dockerfile
+++ b/.ci/docker/ubuntu/Dockerfile
@@ -151,7 +151,6 @@ ENV INSTALLED_ACL ${ACL}
 ARG SKIP_SCCACHE_INSTALL
 COPY ./common/install_cache.sh install_cache.sh
 ENV PATH /opt/cache/bin:$PATH
-ENV CMAKE_CUDA_COMPILER_LAUNCHER=/opt/cache/bin/sccache
 RUN if [ -z "${SKIP_SCCACHE_INSTALL}" ]; then bash ./install_cache.sh; fi
 RUN rm install_cache.sh
 

--- a/.ci/docker/ubuntu/Dockerfile
+++ b/.ci/docker/ubuntu/Dockerfile
@@ -151,6 +151,7 @@ ENV INSTALLED_ACL ${ACL}
 ARG SKIP_SCCACHE_INSTALL
 COPY ./common/install_cache.sh install_cache.sh
 ENV PATH /opt/cache/bin:$PATH
+ENV CMAKE_CUDA_COMPILER_LAUNCHER=/opt/cache/bin/sccache
 RUN if [ -z "${SKIP_SCCACHE_INSTALL}" ]; then bash ./install_cache.sh; fi
 RUN rm install_cache.sh
 

--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -27,7 +27,7 @@ cmake --version
 echo "Environment variables:"
 env
 
-export CMAKE_CUDA_COMPILER_LAUNCHER=sccache
+export PATH="/opt/cache/lib:$PATH"
 
 if [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then
   # Use jemalloc during compilation to mitigate https://github.com/pytorch/pytorch/issues/116289

--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -27,6 +27,8 @@ cmake --version
 echo "Environment variables:"
 env
 
+# sccache nvcc wrapper gets put in /opt/cache/lib since there are some issues if
+# it is always wrapped, so we need to add it to PATH during CI builds
 export PATH="/opt/cache/lib:$PATH"
 
 if [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then

--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -27,8 +27,9 @@ cmake --version
 echo "Environment variables:"
 env
 
-# sccache nvcc wrapper gets put in /opt/cache/lib since there are some issues if
-# it is always wrapped, so we need to add it to PATH during CI builds
+# The sccache wrapped version of nvcc gets put in /opt/cache/lib in docker since
+# there are some issues if it is always wrapped, so we need to add it to PATH
+# during CI builds
 export PATH="/opt/cache/lib:$PATH"
 
 if [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then

--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -29,7 +29,8 @@ env
 
 # The sccache wrapped version of nvcc gets put in /opt/cache/lib in docker since
 # there are some issues if it is always wrapped, so we need to add it to PATH
-# during CI builds
+# during CI builds.
+# https://github.com/pytorch/pytorch/blob/0b6c0898e6c352c8ea93daec854e704b41485375/.ci/docker/common/install_cache.sh#L97
 export PATH="/opt/cache/lib:$PATH"
 
 if [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then

--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -27,6 +27,8 @@ cmake --version
 echo "Environment variables:"
 env
 
+export CMAKE_CUDA_COMPILER_LAUNCHER=sccache
+
 if [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then
   # Use jemalloc during compilation to mitigate https://github.com/pytorch/pytorch/issues/116289
   export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2


### PR DESCRIPTION
Sccache wasn't working for nvcc on jammy, so manually set the path to include where nvcc is

I had problems with always making nvcc a wrapper in some inductor tests where I got
```
sccache: encountered fatal error
sccache: error: PCH not supported by nvcc
sccache: caused by: PCH not supported by nvcc
```
and I also got an error (only on clang) when trying to set CMAKE_CUDA_COMPILER_LAUNCHER to /opt/cache/bin/sccache or sccache
```
ccache: error: failed to execute compile
    sccache: caused by: Compiler not supported: "nvcc warning : Support for offline compilation for architectures prior to \'<compute/sm/lto>_75\' will be removed in a future release (Use -Wno-deprecated-gpu-targets to suppress warning).\nnvcc fatal   : Failed to preprocess host compiler properties.\n"
```

Non jammy cuda jobs' docker images used a different dockerfile, which set CMAKE_CUDA_COMPILER_LAUNCHER https://github.com/pytorch/pytorch/blob/e895e9689c625cbcd8f46880115e0d093713fa37/.ci/docker/ubuntu-cuda/Dockerfile#L110

Alt solution:
Given that I only get the error on clang, I could set CMAKE_CUDA_COMPILER_LAUNCHER=sccache only when not using clang

Setting CUDA_NVCC_EXECUTABLE doesn't fail but also doesn't result in cache hits/misses

