### PR TITLE
Add torch._C._log_api_usage_once to datapipes (mapper)

### DIFF
--- a/torch/utils/data/datapipes/iter/callable.py
+++ b/torch/utils/data/datapipes/iter/callable.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+import torch
 import functools
 from collections import namedtuple
 from collections.abc import Iterator, Sized

--- a/torch/utils/data/datapipes/iter/callable.py
+++ b/torch/utils/data/datapipes/iter/callable.py
@@ -74,6 +74,7 @@ class MapperIterDataPipe(IterDataPipe[_T_co]):
         input_col=None,
         output_col=None,
     ) -> None:
+        torch._C._log_api_usage_once("python.data_pipes.map")
         super().__init__()
         self.datapipe = datapipe
 

--- a/torch/utils/data/datapipes/iter/callable.py
+++ b/torch/utils/data/datapipes/iter/callable.py
@@ -1,10 +1,10 @@
 # mypy: allow-untyped-defs
-import torch
 import functools
 from collections import namedtuple
 from collections.abc import Iterator, Sized
 from typing import Any, Callable, Optional, TypeVar, Union
 
+import torch
 from torch.utils.data._utils.collate import default_collate
 from torch.utils.data.datapipes._decorator import functional_datapipe
 from torch.utils.data.datapipes.dataframe import dataframe_wrapper as df_wrapper


### PR DESCRIPTION
This is to get a better understanding of how datapipes is used right now.

