### PR TITLE
[logs] Change autotune data into separate items

### DIFF
--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2200,20 +2200,24 @@ class AlgorithmSelectorCache(PersistentCache):
         def autotune(choices):
             log.debug("Starting autotuning")
 
-            autotuning_data = {
-                "shape": ", ".join(
-                    ["x".join(map(str, n.get_size())) for n in input_nodes]
-                ),
-                "strides": ", ".join([str(n.get_stride()) for n in input_nodes]),
-                "dtypes": ", ".join([str(n.get_dtype()) for n in input_nodes]),
-                "offset": ", ".join([str(n.get_layout().offset) for n in input_nodes]),
-            }
-
             with dynamo_timed(
                 f"{name}_template_autotuning",
                 log_pt2_compile_event=True,
                 dynamo_compile_column_us="compile_time_autotune_time_us",
-                metadata={"autotuning_data": autotuning_data},
+                metadata={
+                    "autotune_strides": ", ".join(
+                        [str(n.get_stride()) for n in input_nodes]
+                    ),
+                    "autotune_dtypes": ", ".join(
+                        [str(n.get_dtype()) for n in input_nodes]
+                    ),
+                    "autotune_shape": ", ".join(
+                        ["x".join(map(str, n.get_size())) for n in input_nodes]
+                    ),
+                    "autotune_offset": ", ".join(
+                        [str(n.get_layout().offset) for n in input_nodes]
+                    ),
+                },
             ):
                 return make_benchmark_fn()(choices)
 


### PR DESCRIPTION
Summary: Split the autotune data into multiple keys and items : this is better for storage of the data and easier querying.

Test Plan:
```
 TORCHINDUCTOR_MAX_AUTOTUNE=1 tlp buck run (sample)
```

Rollback Plan:

Differential Revision: D76303514




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov