### PR TITLE
[dynamo] added additional_info functionality

### DIFF
--- a/tools/dynamo/gb_id_mapping.py
+++ b/tools/dynamo/gb_id_mapping.py
@@ -187,7 +187,7 @@ def cmd_add_new_gb_type(gb_type, file_path, registry_path, additional_info=None)
             "Context": matching_call["context"],
             "Explanation": matching_call["explanation"],
             "Hints": matching_call["hints"] or [],
-            **({"Additional_Info": additional_info} if additional_info else {}),
+            **({"Additional_Info": [additional_info]} if additional_info else {}),
         }
     ]
 
@@ -245,8 +245,17 @@ def cmd_update_gb_type(
         "Context": matching_call["context"],
         "Explanation": matching_call["explanation"],
         "Hints": matching_call["hints"] or [],
-        **({"Additional_Info": additional_info} if additional_info else {}),
     }
+
+    if additional_info:
+        additional_info_list = reg[gb_id][0].get("Additional_Info", [])
+        new_entry["Additional_Info"] = (
+            additional_info_list + [additional_info]
+            if additional_info_list
+            else [additional_info]
+        )
+    elif "Additional_Info" in reg[gb_id][0]:
+        new_entry["Additional_Info"] = reg[gb_id][0]["Additional_Info"]
 
     reg[gb_id].insert(0, new_entry)
 

--- a/tools/dynamo/gb_id_mapping.py
+++ b/tools/dynamo/gb_id_mapping.py
@@ -152,7 +152,7 @@ def find_unimplemented_v2_calls(path):
     return results
 
 
-def cmd_add_new_gb_type(gb_type, file_path, registry_path):
+def cmd_add_new_gb_type(gb_type, file_path, registry_path, additional_info=None):
     """
     Add a new graph break type to the registry.
 
@@ -187,6 +187,7 @@ def cmd_add_new_gb_type(gb_type, file_path, registry_path):
             "Context": matching_call["context"],
             "Explanation": matching_call["explanation"],
             "Hints": matching_call["hints"] or [],
+            **({"Additional_Info": additional_info} if additional_info else {}),
         }
     ]
 
@@ -195,7 +196,9 @@ def cmd_add_new_gb_type(gb_type, file_path, registry_path):
     return True
 
 
-def cmd_update_gb_type(old_gb_type, file_path, registry_path, new_gb_type=None):
+def cmd_update_gb_type(
+    old_gb_type, file_path, registry_path, new_gb_type=None, additional_info=None
+):
     """
     Update an existing graph break type in the registry by adding a new version
     to the version history list.
@@ -242,6 +245,7 @@ def cmd_update_gb_type(old_gb_type, file_path, registry_path, new_gb_type=None):
         "Context": matching_call["context"],
         "Explanation": matching_call["explanation"],
         "Hints": matching_call["hints"] or [],
+        **({"Additional_Info": additional_info} if additional_info else {}),
     }
 
     reg[gb_id].insert(0, new_entry)
@@ -307,6 +311,9 @@ def main():
     add_parser.add_argument(
         "file_path", help="Path to the file containing the unimplemented_v2 call"
     )
+    add_parser.add_argument(
+        "--additional-info", help="Optional additional information to include"
+    )
 
     update_parser = subparsers.add_parser(
         "update", help="Update an existing gb_type in registry"
@@ -318,6 +325,9 @@ def main():
     )
     update_parser.add_argument(
         "--new_gb_type", help="New gb_type name if it has changed", default=None
+    )
+    update_parser.add_argument(
+        "--additional-info", help="Optional additional information to include"
     )
 
     parser.add_argument(
@@ -332,12 +342,18 @@ def main():
     if args.command == "create":
         create_registry(args.dynamo_dir, args.registry_path)
     elif args.command == "add":
-        success = cmd_add_new_gb_type(args.gb_type, args.file_path, args.registry_path)
+        success = cmd_add_new_gb_type(
+            args.gb_type, args.file_path, args.registry_path, args.additional_info
+        )
         if not success:
             sys.exit(1)
     elif args.command == "update":
         success = cmd_update_gb_type(
-            args.gb_type, args.file_path, args.registry_path, args.new_gb_type
+            args.gb_type,
+            args.file_path,
+            args.registry_path,
+            args.new_gb_type,
+            args.additional_info,
         )
         if not success:
             sys.exit(1)


### PR DESCRIPTION
There is now functionality for the developer to add a  --additional-info arg to the add and update dev terminal command to include any additional info the dev might want to remark about the graph break.
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #155526

