### PR TITLE
[inductor] Improve GEMM logging to display batch size for batched operations

### DIFF
--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -993,16 +993,15 @@ def _compile_fx_inner(
         mm_table_data = []
         for key, value in counters["aten_mm_info"].items():
             parts = key.split("_")
-            
             if len(parts) < 3:
                 # Unexpected format, show as-is
                 mm_table_data.append([key, "-", "?", "?", "?", value])
                 continue
-            
+
             # Determine if this is a batched operation by checking the operation name
             name = "_".join(parts[:-4]) if len(parts) >= 4 else "_".join(parts[:-3])
-            is_batched = name.endswith(('bmm', 'baddbmm'))
-            
+            is_batched = name.endswith(("bmm", "baddbmm"))
+
             if is_batched and len(parts) >= 4:
                 # Batched operation: last 4 parts are batch, m, n, k
                 batch, m, n, k = parts[-4:]
@@ -1013,7 +1012,7 @@ def _compile_fx_inner(
                 m, n, k = parts[-3:]
                 name = "_".join(parts[:-3])
                 mm_table_data.append([name, "-", m, n, k, value])
-                
+
         log.info("Overview info of inductor aten mms: ")
         log.info(
             "{:<30} | {:<20} | {:<20} | {:<20} | {:<20} | {:<20}".format(  # noqa: G001

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -992,19 +992,61 @@ def _compile_fx_inner(
     if log.isEnabledFor(logging.INFO):
         mm_table_data = []
         for key, value in counters["aten_mm_info"].items():
-            m, n, k = key.split("_")[-3:]
-            name = "_".join(key.split("_")[:-3])
-            mm_table_data.append([name, m, n, k, value])
+            # Handle different key formats:
+            # 1. New format with batch: "aten.bmm_b{batch}_m{m}_n{n}_k{k}" or "aten.baddbmm_b{batch}_m{m}_n{n}_k{k}"
+            # 2. Old format without batch: "aten.mm_m{m}_n{n}_k{k}" or "aten.addmm_m{m}_n{n}_k{k}"
+            # 3. Legacy format: "aten.mm_{m}_{n}_{k}" (fallback for compatibility)
+            
+            parts = key.split("_")
+            batch = None
+            m = n = k = None
+            name_parts = []
+            
+            # Try to parse new format first (with prefixed values like b10, m1024, etc.)
+            for part in parts:
+                if part.startswith('b') and len(part) > 1 and part[1:].isdigit():
+                    batch = part[1:]
+                elif part.startswith('m') and len(part) > 1 and part[1:].isdigit():
+                    m = part[1:]
+                elif part.startswith('n') and len(part) > 1 and part[1:].isdigit():
+                    n = part[1:]
+                elif part.startswith('k') and len(part) > 1 and part[1:].isdigit():
+                    k = part[1:]
+                else:
+                    name_parts.append(part)
+            
+            # If we couldn't parse the new format, fall back to legacy format
+            if m is None or n is None or k is None:
+                if len(parts) >= 3:
+                    # Legacy format: last 3 parts are M, N, K
+                    m, n, k = parts[-3:]
+                    name_parts = parts[:-3]
+                    batch = None
+                else:
+                    # Unexpected format, show as-is
+                    mm_table_data.append([key, "?", "?", "?", "?", value])
+                    continue
+            
+            name = "_".join(name_parts)
+            
+            # Format the display name to include batch size if present
+            if batch is not None:
+                display_name = f"{name} (B={batch})"
+            else:
+                display_name = name
+                
+            mm_table_data.append([display_name, m, n, k, value])
+        
         log.info("Overview info of inductor aten mms: ")
         log.info(
-            "{:<20} | {:<20} | {:<20} | {:<20} | {:<20}".format(  # noqa: G001
+            "{:<30} | {:<20} | {:<20} | {:<20} | {:<20}".format(  # noqa: G001
                 "Name", "M", "N", "K", "Count"
             )
         )
-        log.info("-" * 100)
+        log.info("-" * 130)
         for row in mm_table_data:
-            log.info("{:<20} | {:<20} | {:<20} | {:<20} | {:<20}".format(*row))  # noqa: G001
-            log.info("-" * 100)
+            log.info("{:<30} | {:<20} | {:<20} | {:<20} | {:<20}".format(*row))  # noqa: G001
+            log.info("-" * 130)
 
     # Not strictly necessary, but good to clean up straggling futures
     # that are unused to reclaim memory.

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -179,9 +179,11 @@ def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
     )
 
     # below is for getting an overview logging info of inductor mms
-    counters["aten_mm_info"][f"aten.bmm_{m}_{n}_{k}"] += 1
+    batch_size = mat1.get_size()[0]  # Extract batch dimension
+    counters["aten_mm_info"][f"aten.bmm_b{batch_size}_m{m}_n{n}_k{k}"] += 1
     log.info(
-        "Tuned aten.bmm: m=%s, n=%s, k=%s, mat1_dtype=%s, mat2_dtype=%s, output_layout=%s",
+        "Tuned aten.bmm: batch=%s, m=%s, n=%s, k=%s, mat1_dtype=%s, mat2_dtype=%s, output_layout=%s",
+        batch_size,
         m,
         n,
         k,
@@ -241,9 +243,11 @@ def tuned_baddbmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
     m, n, k, layout, mat1, mat2, inp = mm_args(mat1, mat2, inp, layout=layout)
 
     # below is for getting an overview logging info of inductor mms
-    counters["aten_mm_info"][f"aten.baddbmm_{m}_{n}_{k}"] += 1
+    batch_size = mat1.get_size()[0]
+    counters["aten_mm_info"][f"aten.baddbmm_b{batch_size}_m{m}_n{n}_k{k}"] += 1
     log.info(
-        "Tuned aten.baddbmm: m=%s, n=%s, k=%s, mat1_dtype=%s, mat2_dtype=%s, inp=%s, output_layout=%s",
+        "Tuned aten.baddbmm: batch_size=%s, m=%s, n=%s, k=%s, mat1_dtype=%s, mat2_dtype=%s, inp=%s, output_layout=%s",
+        batch_size,
         m,
         n,
         k,

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -180,7 +180,7 @@ def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
 
     # below is for getting an overview logging info of inductor mms
     batch_size = mat1.get_size()[0]  # Extract batch dimension
-    counters["aten_mm_info"][f"aten.bmm_b{batch_size}_m{m}_n{n}_k{k}"] += 1
+    counters["aten_mm_info"][f"aten.bmm_{batch_size}_{m}_{n}_{k}"] += 1
     log.info(
         "Tuned aten.bmm: batch=%s, m=%s, n=%s, k=%s, mat1_dtype=%s, mat2_dtype=%s, output_layout=%s",
         batch_size,
@@ -244,7 +244,7 @@ def tuned_baddbmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
 
     # below is for getting an overview logging info of inductor mms
     batch_size = mat1.get_size()[0]
-    counters["aten_mm_info"][f"aten.baddbmm_b{batch_size}_m{m}_n{n}_k{k}"] += 1
+    counters["aten_mm_info"][f"aten.baddbmm_{batch_size}_{m}_{n}_{k}"] += 1
     log.info(
         "Tuned aten.baddbmm: batch_size=%s, m=%s, n=%s, k=%s, mat1_dtype=%s, mat2_dtype=%s, inp=%s, output_layout=%s",
         batch_size,

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -617,7 +617,7 @@ def tuned_mm(mat1, mat2, *, layout=None):
     name = "mm"
 
     # below is for getting an overview logging info of inductor mms
-    counters["aten_mm_info"][f"aten.mm_m{m}_n{n}_k{k}"] += 1
+    counters["aten_mm_info"][f"aten.mm_{m}_{n}_{k}"] += 1
     log.info(
         "Tuned aten.mm: m=%s, n=%s, k=%s, mat1_dtype=%s, mat2_dtype=%s, output_layout=%s",
         m,
@@ -793,7 +793,7 @@ def tuned_int_mm(mat1, mat2, *, layout=None):
     )
 
     # below is for getting an overview logging info of inductor mms
-    counters["aten_mm_info"][f"aten._int_mm_m{m}_n{n}_k{k}"] += 1
+    counters["aten_mm_info"][f"aten._int_mm_{m}_{n}_{k}"] += 1
     log.info(
         "Tuned aten._int_mm: m=%s, n=%s, k=%s, mat1_dtype=%s, mat2_dtype=%s, output_layout=%s",
         m,
@@ -841,7 +841,7 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
     static_shape, is_nonzero = _is_static_problem(layout)
 
     # below is for getting an overview logging info of inductor mms
-    counters["aten_mm_info"][f"aten.addmm_m{m}_n{n}_k{k}"] += 1
+    counters["aten_mm_info"][f"aten.addmm_{m}_{n}_{k}"] += 1
     log.info(
         "Tuned aten.addmm: m=%s, n=%s, k=%s, mat1_dtype=%s, mat2_dtype=%s, output_layout=%s",
         m,
@@ -1036,7 +1036,7 @@ def tuned_scaled_mm(
         mat_a, mat_b, layout=layout, out_dtype=out_dtype
     )
     # below is for getting an overview logging info of inductor mms
-    counters["aten_mm_info"][f"aten._scaled_mm.default_m{m}_n{n}_k{k}"] += 1
+    counters["aten_mm_info"][f"aten._scaled_mm.default_{m}_{n}_{k}"] += 1
     log.info(
         "Tuned aten._scaled_mm.default: m=%s, n=%s, k=%s, mat1_dtype=%s, mat2_dtype=%s, output_layout=%s",
         m,

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -617,7 +617,7 @@ def tuned_mm(mat1, mat2, *, layout=None):
     name = "mm"
 
     # below is for getting an overview logging info of inductor mms
-    counters["aten_mm_info"][f"aten.mm_{m}_{n}_{k}"] += 1
+    counters["aten_mm_info"][f"aten.mm_m{m}_n{n}_k{k}"] += 1
     log.info(
         "Tuned aten.mm: m=%s, n=%s, k=%s, mat1_dtype=%s, mat2_dtype=%s, output_layout=%s",
         m,
@@ -793,7 +793,7 @@ def tuned_int_mm(mat1, mat2, *, layout=None):
     )
 
     # below is for getting an overview logging info of inductor mms
-    counters["aten_mm_info"][f"aten._int_mm_{m}_{n}_{k}"] += 1
+    counters["aten_mm_info"][f"aten._int_mm_m{m}_n{n}_k{k}"] += 1
     log.info(
         "Tuned aten._int_mm: m=%s, n=%s, k=%s, mat1_dtype=%s, mat2_dtype=%s, output_layout=%s",
         m,
@@ -841,7 +841,7 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
     static_shape, is_nonzero = _is_static_problem(layout)
 
     # below is for getting an overview logging info of inductor mms
-    counters["aten_mm_info"][f"aten.addmm_{m}_{n}_{k}"] += 1
+    counters["aten_mm_info"][f"aten.addmm_m{m}_n{n}_k{k}"] += 1
     log.info(
         "Tuned aten.addmm: m=%s, n=%s, k=%s, mat1_dtype=%s, mat2_dtype=%s, output_layout=%s",
         m,
@@ -1036,7 +1036,7 @@ def tuned_scaled_mm(
         mat_a, mat_b, layout=layout, out_dtype=out_dtype
     )
     # below is for getting an overview logging info of inductor mms
-    counters["aten_mm_info"][f"aten._scaled_mm.default_{m}_{n}_{k}"] += 1
+    counters["aten_mm_info"][f"aten._scaled_mm.default_m{m}_n{n}_k{k}"] += 1
     log.info(
         "Tuned aten._scaled_mm.default: m=%s, n=%s, k=%s, mat1_dtype=%s, mat2_dtype=%s, output_layout=%s",
         m,


### PR DESCRIPTION
Improves the GEMM overview logging in PyTorch Inductor to properly display batch size information for batched matrix operations like `torch.bmm` and `torch.baddbmm`.

**Fixes #155307**

```python
# Repro
import os
os.environ["TORCH_LOGS"] = "inductor"
import torch

M, N, K = 1024, 1024, 1024
dtype = torch.bfloat16
A = torch.randn(10, M, K, device="cuda", dtype=dtype)
B = torch.randn(10, K, N, device="cuda", dtype=dtype)

compiled_model = torch.compile(torch.bmm, fullgraph=True)
_ = compiled_model(A, B)
```

**Before:**
```
Name                 | M                    | N                    | K                    | Count               
----------------------------------------------------------------------------------------------------
aten.bmm             | 1024                 | 1024                 | 1024                 | 1                   
----------------------------------------------------------------------------------------------------
```

The batch size (10) is missing from the logs, making it unclear what the actual operation dimensions were.

**After:**
```
Name                 | B                    | M                    | N                    | K                    | Count               
---------------------------------------------------------------------------------------------------------------------------
aten.bmm             | 10                   | 1024                 | 1024                 | 1024                 | 1                   
---------------------------------------------------------------------------------------------------------------------------
```

## Changes Made

- **compile_fx.py**:
  - Detects batched operations by checking if operation name ends with `'bmm'` or `'baddbmm'`
  - For batched operations: takes last 4 parts as `batch, m, n, k`
  - For non-batched operations: takes last 3 parts as `m, n, k`
  - Added separate column for batch size
  - Shows batch size for batched operations, shows "-" for non-batched operations

- **bmm.py**: 
  - Extract batch size from `mat1.get_size()[0]` for both `tuned_bmm` and `tuned_baddbmm`
  - Use positional counter keys: `aten.bmm_{batch_size}_{m}_{n}_{k}`
  - Enhanced log messages to include batch size information

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @henrylhtsang