### PR TITLE
[ROCm][SymmetricMemory] Avoid bf16 to float conversion during reduce

### DIFF
--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -974,7 +974,7 @@ class SymmMemCollectiveTest(MultiProcContinousTest):
                 gathered_res[i],
                 sum_inps[..., i * slice_width : (i + 1) * slice_width],
                 rtol=1e-01,
-                atol=1e-01,
+                atol=1.1e-01,
             )
 
     @skip_if_lt_x_gpu(4)

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory-inl.h
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory-inl.h
@@ -260,6 +260,17 @@ __device__ __inline__ T add_bf16x2(T a, T b) {
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800))
   CUDA_KERNEL_ASSERT(false);
   return T{};
+#elif defined(USE_ROCM)
+  union bf2f { float f; __hip_bfloat16 bf[2]; } _bf2f_a = { .f = 0 }, _bf2f_b = { .f = 0 } ;
+  _bf2f_a.bf[1] = reinterpret_cast<__hip_bfloat162*>(&a)->x;
+  _bf2f_b.bf[1] = reinterpret_cast<__hip_bfloat162*>(&b)->x;
+  union f2bf { float f; __hip_bfloat16 bf[2]; } _f2bf_res0, _f2bf_res1;
+  _f2bf_res0.f = _bf2f_a.f + _bf2f_b.f;
+  _bf2f_a.bf[1] = reinterpret_cast<__hip_bfloat162*>(&a)->y;
+  _bf2f_b.bf[1] = reinterpret_cast<__hip_bfloat162*>(&b)->y;
+  _f2bf_res1.f = _bf2f_a.f + _bf2f_b.f;
+  __hip_bfloat162 rtn(_f2bf_res0.bf[1], _f2bf_res1.bf[1]);
+  return *reinterpret_cast<T*>(&rtn);
 #else
   auto res = __hadd2(
       *reinterpret_cast<__nv_bfloat162*>(&a),

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory-inl.h
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory-inl.h
@@ -261,10 +261,16 @@ __device__ __inline__ T add_bf16x2(T a, T b) {
   CUDA_KERNEL_ASSERT(false);
   return T{};
 #elif defined(USE_ROCM)
-  union bf2f { float f; __hip_bfloat16 bf[2]; } _bf2f_a = { .f = 0 }, _bf2f_b = { .f = 0 } ;
+  union bf2f {
+    float f;
+    __hip_bfloat16 bf[2];
+  } _bf2f_a = {.f = 0}, _bf2f_b = {.f = 0};
   _bf2f_a.bf[1] = reinterpret_cast<__hip_bfloat162*>(&a)->x;
   _bf2f_b.bf[1] = reinterpret_cast<__hip_bfloat162*>(&b)->x;
-  union f2bf { float f; __hip_bfloat16 bf[2]; } _f2bf_res0, _f2bf_res1;
+  union f2bf {
+    float f;
+    __hip_bfloat16 bf[2];
+  } _f2bf_res0, _f2bf_res1;
   _f2bf_res0.f = _bf2f_a.f + _bf2f_b.f;
   _bf2f_a.bf[1] = reinterpret_cast<__hip_bfloat162*>(&a)->y;
   _bf2f_b.bf[1] = reinterpret_cast<__hip_bfloat162*>(&b)->y;

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory-inl.h
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory-inl.h
@@ -265,6 +265,10 @@ __device__ __inline__ T add_bf16x2(T a, T b) {
     float f;
     __hip_bfloat16 bf[2];
   } _bf2f_a = {.f = 0}, _bf2f_b = {.f = 0};
+
+  //__hip_bfloat162 is a struct wtih two __hip_bfloat16 elements called x and y
+  // This typecasts input a and b as bfloat16 and maps to low bits of a float
+  // and does the addition in float
   _bf2f_a.bf[1] = reinterpret_cast<__hip_bfloat162*>(&a)->x;
   _bf2f_b.bf[1] = reinterpret_cast<__hip_bfloat162*>(&b)->x;
   union f2bf {
@@ -272,9 +276,13 @@ __device__ __inline__ T add_bf16x2(T a, T b) {
     __hip_bfloat16 bf[2];
   } _f2bf_res0, _f2bf_res1;
   _f2bf_res0.f = _bf2f_a.f + _bf2f_b.f;
+
+  // Same thing for y elements of __hip_bfloat162
   _bf2f_a.bf[1] = reinterpret_cast<__hip_bfloat162*>(&a)->y;
   _bf2f_b.bf[1] = reinterpret_cast<__hip_bfloat162*>(&b)->y;
   _f2bf_res1.f = _bf2f_a.f + _bf2f_b.f;
+
+  // Put the two results together
   __hip_bfloat162 rtn(_f2bf_res0.bf[1], _f2bf_res1.bf[1]);
   return *reinterpret_cast<T*>(&rtn);
 #else


### PR DESCRIPTION
This PR helps improve the performance of one-shot and two-shot allreduce as reported here: https://github.com/pytorch/FBGEMM/issues/4072

One-Shot:
![image](https://github.com/user-attachments/assets/69fe0d53-6636-42e1-90e0-e5efb989f59f)
As shown in the numbers presented above, symmetric memory performance prior to the PR (baseline) was on average about 26% less than fbgemm's number reported in the issue above. After this PR, we are seeing 16% improvement on average as compared to fbgemm and 59% as compared to our baseline numbers.

Two-Shot:
![image](https://github.com/user-attachments/assets/e5c8a288-303e-4d50-814b-4348e589e1fc)
Similarly, in two-shot, we were originally underperforming by 12%. We have improved by 22% after this PR as compared to symmetric memory performance prior to this PR. However, two-shot performance is still about 23% lower than fbgemm. This work is still in progress and will be pushing those changes through a separate PR.


Fixes #ISSUE_NUMBER


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd