### PR TITLE
[dtensor] refactor PlacementStrategy -> OpSpec, move utils to OpSchema

### DIFF
--- a/test/distributed/tensor/test_op_strategy.py
+++ b/test/distributed/tensor/test_op_strategy.py
@@ -6,7 +6,7 @@ import torch
 from torch.distributed.tensor import DeviceMesh, DTensor, Partial, Replicate, Shard
 from torch.distributed.tensor._collective_utils import redistribute_cost
 from torch.distributed.tensor._dtensor_spec import DTensorSpec, TensorMeta
-from torch.distributed.tensor._op_schema import OpSchema, OpStrategy, PlacementStrategy
+from torch.distributed.tensor._op_schema import OpSchema, OpSpec, OpStrategy
 from torch.distributed.tensor._ops._einsum_strategy import (
     EinsumDims,
     gen_einsum_strategies,
@@ -184,9 +184,9 @@ class TestCostModel(DTensorOpTestBase):
         op_schema = OpSchema(
             torch.ops.aten.addmm.default,
             (
-                OpStrategy([PlacementStrategy(shard0_spec)]),
-                OpStrategy([PlacementStrategy(partial_spec)]),
-                OpStrategy([PlacementStrategy(shard1_spec)]),
+                OpStrategy([OpSpec(shard0_spec)]),
+                OpStrategy([OpSpec(partial_spec)]),
+                OpStrategy([OpSpec(shard1_spec)]),
             ),
             {},
         )
@@ -261,8 +261,8 @@ class TestCostModel(DTensorOpTestBase):
             op_schema = OpSchema(
                 torch.ops.aten.mm.default,
                 (
-                    OpStrategy([PlacementStrategy(lhs_spec)]),
-                    OpStrategy([PlacementStrategy(rhs_spec)]),
+                    OpStrategy([OpSpec(lhs_spec)]),
+                    OpStrategy([OpSpec(rhs_spec)]),
                 ),
                 {},
             )
@@ -308,8 +308,8 @@ class TestCostModel(DTensorOpTestBase):
             op_schema = OpSchema(
                 torch.ops.aten.bmm.default,
                 (
-                    OpStrategy([PlacementStrategy(lhs_spec)]),
-                    OpStrategy([PlacementStrategy(rhs_spec)]),
+                    OpStrategy([OpSpec(lhs_spec)]),
+                    OpStrategy([OpSpec(rhs_spec)]),
                 ),
                 {},
             )

--- a/torch/distributed/tensor/README.md
+++ b/torch/distributed/tensor/README.md
@@ -49,7 +49,7 @@ We offer both a lower level DistributedTensor API and a module level API to crea
 Here are some basic DTensor API examples that showcase:
 1. How to construct a DTensor directly, to represent different types of sharding, replication, sharding + replication strategies.
 2. How to create DTensor from a local `torch.Tensor`.
-3. How to “reshard” an existing DTensor to a different DTensor with modified placement strategy or world size.
+3. How to “reshard” an existing DTensor to a different DTensor with a new DTensor Layout.
 
 ```python
 # torchrun --standalone --nnodes=1 --nproc-per-node=4 dtensor_example.py

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -13,13 +13,7 @@ import torch.distributed.tensor._api as dtensor
 import torch.distributed.tensor._random as random
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor._dtensor_spec import DTensorSpec, TensorMeta
-from torch.distributed.tensor._op_schema import (
-    _is_inplace_op,
-    _is_out_variant_op,
-    OpInfo,
-    OpSchema,
-    OutputSpecType,
-)
+from torch.distributed.tensor._op_schema import OpInfo, OpSchema, OutputSpecType
 from torch.distributed.tensor._random import is_rng_supported_mesh
 from torch.distributed.tensor._redistribute import redistribute_local_tensor
 from torch.distributed.tensor._sharding_prop import ShardingPropagator
@@ -260,13 +254,13 @@ class OpDispatcher:
                 # perform reduce on the collection with AND op
                 local_results = functools.reduce(operator.and_, obj_list, True)
 
-        if _is_inplace_op(op_call):
+        if op_info.schema.is_inplace_op():
             # inplace op should return self instead of re-wrapping
             if output_sharding.output_spec is not None:
                 return args[0]
             else:
                 return None
-        elif _is_out_variant_op(op_call):
+        elif op_info.schema.is_out_variant_op():
             # out variant could possibly have multiple out args (i.e. lu_unpack.out)
             output_specs = (
                 (output_sharding.output_spec,)

--- a/torch/distributed/tensor/_op_schema.py
+++ b/torch/distributed/tensor/_op_schema.py
@@ -44,20 +44,6 @@ def _rebuild_tensor_from_dtensor_meta(arg) -> object:
     )
 
 
-def _is_inplace_op(op: OpOverload):
-    # simple analysis of function schema to determine
-    # if this is an inplace variant, it might not
-    # be entirely correct, but it's good enough for now.
-    return op._schema.name[-1] == "_"
-
-
-def _is_out_variant_op(op: OpOverload):
-    # simple analysis of function schema to determine
-    # if this is an out variant, it might not
-    # be entirely correct, but it's good enough for now.
-    return "out" in op._schema.overload_name
-
-
 def _pretty_print_spec(spec: object) -> str:
     if spec is None:
         return "None"
@@ -70,10 +56,10 @@ def _pretty_print_spec(spec: object) -> str:
 
 
 @dataclass
-class PlacementStrategy:
+class OpSpec:
     """
-    A placement strategy describes acceptable sharding placements of the output
-    and the tensor arguments of an operation.
+    An OpSpec describes an acceptable sharding placements of an operation, with the
+    specified DTensorSpecs for both the output and the inputs.
 
     note: when the op return value is a single DTensor object, output_specs is
     DTensorSpec; when the return value is a tuple of Optional[DTensor],
@@ -83,10 +69,9 @@ class PlacementStrategy:
     output_specs: Union[DTensorSpec, tuple[Optional[DTensorSpec], ...]]
     input_specs: Optional[Sequence[DTensorSpec]] = None
 
-    # redistribute costs for this op placement strategy
-    # we need a nested list to record the cost for each
-    # operand of this operator, and for each operand of
-    # this operator it might have multiple placement strategies
+    # redistribute costs to redistribute the operator input shardings to this OpSpec.
+    # Note that We need a nested list to record the cost for each operand of this
+    # operator, and for each operand of this operator it might have multiple OpSpecs.
     redistribute_cost: Optional[list[list[float]]] = None
 
     @cached_property
@@ -116,7 +101,7 @@ class PlacementStrategy:
             )
 
     def input_spec(self, index: int = 0) -> DTensorSpec:
-        assert self.input_specs is not None, "input_specs of PlacementStrategy is None!"
+        assert self.input_specs is not None, "input_specs of OpSpec is None!"
         assert len(self.input_specs) > index, (
             f"Invalid index {index} for input_specs of length "
             f"{len(self.input_specs)}: {self.input_specs}"
@@ -141,12 +126,13 @@ class StrategyType:
 
 class OpStrategy(StrategyType):
     """
-    OpStrategy that consists of a list of placement strategies associated with the op
+    OpStrategy that consists of a list of sharding strategies associated with the op,
+    where each strategy is an OpSpec that describes the acceptable input/output sharding.
     """
 
-    def __init__(self, strategies: list[PlacementStrategy]) -> None:
+    def __init__(self, strategies: list[OpSpec]) -> None:
         super().__init__()
-        self.strategies: list[PlacementStrategy] = strategies
+        self.strategies: list[OpSpec] = strategies
 
     def __str__(self) -> str:
         strategy_list_str = ", ".join([str(strategy) for strategy in self.strategies])
@@ -155,7 +141,7 @@ class OpStrategy(StrategyType):
 
     def max_num_shards(self) -> int:
         """
-        Returns the max number of shards across all placement strategies
+        Returns the max number of shards across all OpSpecs
         """
         return max(strategy.output_spec.num_shards for strategy in self.strategies)
 
@@ -178,14 +164,14 @@ class OpStrategy(StrategyType):
 
 class TupleStrategy(StrategyType):
     """
-    TupleStrategy represents the output strategy of this op is a tuple
-    of strategy, i.e. If the output of this op is a tuple of tensors or list of tensors
-    with possibly different placement strategies, we should return a TupleStrategy that
-    contains a tuple of OpStrategy, where each child represents the sharding strategy
-    of "each element" of the tuple/list of tensors the op returns.
+    TupleStrategy represents the output strategy of this op is a tuple of OpStrategies,
+    i.e. If the output of this op is a tuple of tensors or list of tensors with possibly
+    different OpStrategies, we should return a TupleStrategy that contains a tuple of
+    OpStrategy, where each child represents the sharding strategy of "each element" of
+    the tuple/list of tensors the op returns.
 
-    NOTE: if the output of the op is a List[Tensor] and they share the same placement
-    strategy, then we should return a single OpStrategy instead of a TupleStrategy
+    NOTE: if the output of the op is a List[Tensor] and they share the same OpStrategy,
+    then we should return a single OpStrategy instead of a TupleStrategy
     """
 
     def __init__(self, childs: Sequence[StrategyType]) -> None:
@@ -229,8 +215,8 @@ class RuntimeSchemaInfo:
 class OpSchema:
     """
     OpSchema is a data class that describes an operator input schemas, it includes
-    DTensorSpecs (instead of DTensor) and non-tensor args/kwargs (positional order
-    preserved). It is mainly used by the DTensor's dispatching logic to perform various
+    DTensorSpecs/OpStrategies (instead of DTensor) and non-tensor args/kwargs (positional
+    order preserved). It is mainly used by the DTensor's dispatching logic to perform various
     actions (i.e. sharding propagation, caching sharding decisions, redistribute, etc.)
 
     NOTE: this should be used as a read only data class
@@ -296,9 +282,9 @@ class OpSchema:
                 args_schema.append(_pretty_print_spec(arg.strategies[0].output_specs))
                 mesh_shape = arg.mesh_shape
             elif isinstance(arg, TupleStrategy):
-                first_op_strtgy = arg.childs[0]
-                assert isinstance(first_op_strtgy, OpStrategy)
-                mesh_shape = first_op_strtgy.mesh_shape
+                first_op_strategy = arg.childs[0]
+                assert isinstance(first_op_strategy, OpStrategy)
+                mesh_shape = first_op_strategy.mesh_shape
                 args_schema.append(str(arg))
             else:
                 args_schema.append(str(arg))
@@ -375,6 +361,18 @@ class OpSchema:
                     )
 
         return mesh
+
+    def is_inplace_op(self) -> bool:
+        # simple analysis of function schema to determine
+        # if this is an inplace variant, it might not
+        # be entirely correct, but it's good enough for now.
+        return self.op._schema.name[-1] == "_"
+
+    def is_out_variant_op(self) -> bool:
+        # simple analysis of function schema to determine
+        # if this is an out variant, it might not
+        # be entirely correct, but it's good enough for now.
+        return "out" in self.op._schema.overload_name
 
     def __hash__(self) -> int:
         # Only hash args and kwargs that op indicates to hash

--- a/torch/distributed/tensor/_ops/_common_rules.py
+++ b/torch/distributed/tensor/_ops/_common_rules.py
@@ -267,7 +267,7 @@ def pointwise_rule(op_schema: OpSchema, linearity: bool = False) -> OutputShardi
 
     enforce_sharding: dict[str, int] = {}
     if op_schema.is_inplace_op():
-        follow_spec = cast(DTensorSpec, op_schema.args_spec[0])
+        follow_spec = op_schema.args_spec[0]
         enforce_sharding.update(zip(out_dimchars, follow_spec.dim_map))
     elif op_schema.is_out_variant_op():
         follow_spec = cast(DTensorSpec, op_schema.kwargs_schema["out"])

--- a/torch/distributed/tensor/_ops/_common_rules.py
+++ b/torch/distributed/tensor/_ops/_common_rules.py
@@ -4,12 +4,7 @@ from typing import cast, Optional
 
 import torch
 from torch.distributed.tensor._dtensor_spec import DTensorSpec, TensorMeta
-from torch.distributed.tensor._op_schema import (
-    _is_inplace_op,
-    _is_out_variant_op,
-    OpSchema,
-    OutputSharding,
-)
+from torch.distributed.tensor._op_schema import OpSchema, OutputSharding
 from torch.distributed.tensor._ops.utils import prod
 from torch.distributed.tensor._utils import compute_local_shape_and_global_offset
 
@@ -271,10 +266,11 @@ def pointwise_rule(op_schema: OpSchema, linearity: bool = False) -> OutputShardi
     fmt = f"{','.join(p for p in dimchars)}->{out_dimchars}"
 
     enforce_sharding: dict[str, int] = {}
-    if _is_inplace_op(op_schema.op):
+    if op_schema.is_inplace_op():
         # inplace op should keep the input sharding it writes to
-        enforce_sharding.update(zip(out_dimchars, input_specs[0].dim_map))
-    elif _is_out_variant_op(op_schema.op):
+        for out_dimchar, mesh_dim in zip(out_dimchars, input_specs[0].dim_map):
+            enforce_sharding[out_dimchar] = mesh_dim
+    elif op_schema.is_out_variant_op():
         out_spec = cast(DTensorSpec, op_schema.kwargs_schema["out"])
         enforce_sharding.update(zip(out_dimchars, out_spec.dim_map))
 

--- a/torch/distributed/tensor/_ops/_einsum_strategy.py
+++ b/torch/distributed/tensor/_ops/_einsum_strategy.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor._dtensor_spec import DTensorSpec
-from torch.distributed.tensor._op_schema import OpStrategy, PlacementStrategy
+from torch.distributed.tensor._op_schema import OpSpec, OpStrategy
 from torch.distributed.tensor.placement_types import (
     Partial,
     Placement,
@@ -167,7 +167,7 @@ def gen_einsum_strategies(
     all_strategies = []
     for strategy_comb in strategy_combs:
         spec_list = [DTensorSpec(mesh, tuple(specs)) for specs in zip(*strategy_comb)]
-        strat = PlacementStrategy(output_specs=spec_list[0], input_specs=spec_list[1:])
+        strat = OpSpec(output_specs=spec_list[0], input_specs=spec_list[1:])
         all_strategies.append(strat)
 
     return OpStrategy(all_strategies)

--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -11,9 +11,9 @@ from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor._dtensor_spec import DTensorSpec
 from torch.distributed.tensor._op_schema import (
     OpSchema,
+    OpSpec,
     OpStrategy,
     PlacementList,
-    PlacementStrategy,
     RuntimeSchemaInfo,
     TupleStrategy,
 )
@@ -267,20 +267,20 @@ def common_reduction_strategy(
     # by default follow reduction input strategy
     reduction_strategy = OpStrategy([])
 
-    for strtg in input_strategy.strategies:
+    for op_spec in input_strategy.strategies:
         if not reduction_linear:
             # input placements for this strategy should clear out pending sum and sharding
             # on the reduction dimension
             input_placements = replicate_reduction_dims(
-                strtg.output_spec.placements, reduce_dims
+                op_spec.output_spec.placements, reduce_dims
             )
         else:
-            input_placements = strtg.output_spec.placements
+            input_placements = op_spec.output_spec.placements
 
         input_spec = DTensorSpec(
             mesh=input_strategy.mesh,
             placements=input_placements,
-            tensor_meta=strtg.output_spec.tensor_meta,
+            tensor_meta=op_spec.output_spec.tensor_meta,
         )
 
         reduce_dims_map = _infer_reduce_dims_map(reduce_dims, input_spec.ndim, keep_dim)
@@ -289,7 +289,7 @@ def common_reduction_strategy(
         )
         redistribute_cost = [generate_redistribute_costs(input_strategy, input_spec)]
         reduction_strategy.strategies.append(
-            PlacementStrategy(
+            OpSpec(
                 output_specs=DTensorSpec(
                     mesh=input_strategy.mesh,
                     placements=out_placements,
@@ -465,7 +465,7 @@ def linalg_replicate_strategy(op_schema: OpSchema) -> OpStrategy:
     assert isinstance(input_strategy, OpStrategy), f"{input_strategy}"
     mesh = input_strategy.mesh
 
-    output_strategies: list[PlacementStrategy] = []
+    output_strategies: list[OpSpec] = []
     for placement_strategy in input_strategy.strategies:
         replicate_placements = tuple(Replicate() for _ in range(mesh.ndim))
         replicate_spec = DTensorSpec(
@@ -476,7 +476,7 @@ def linalg_replicate_strategy(op_schema: OpSchema) -> OpStrategy:
         redistribute_cost = [
             generate_redistribute_costs(input_strategy, replicate_spec)
         ]
-        replicate_strategy = PlacementStrategy(
+        replicate_strategy = OpSpec(
             output_specs=replicate_spec,
             input_specs=(replicate_spec,),
             redistribute_cost=redistribute_cost,
@@ -514,7 +514,7 @@ def softmax_strategy(op_schema: OpSchema) -> OpStrategy:
         )
         output_target_spec = input_target_spec
         output_strategy.strategies.append(
-            PlacementStrategy(
+            OpSpec(
                 output_specs=output_target_spec,
                 input_specs=[input_target_spec],
                 redistribute_cost=redistribute_costs,
@@ -559,7 +559,7 @@ def softmax_backward_strategy(op_schema: OpSchema) -> OpStrategy:
         redist_grad_out_cost = generate_redistribute_costs(grad_out_strategy, tgt_spec)
         redist_out_cost = generate_redistribute_costs(out_strategy, tgt_spec)
         grad_in_strategy.strategies.append(
-            PlacementStrategy(
+            OpSpec(
                 output_specs=tgt_spec,
                 redistribute_cost=[redist_grad_out_cost, redist_out_cost],
             )
@@ -682,7 +682,7 @@ def nll_loss_forward_strategy(op_schema: OpSchema) -> OpStrategy:
             )
 
         output_strategy.strategies.append(
-            PlacementStrategy(
+            OpSpec(
                 output_specs=(output_expected_spec, total_weight_expected_spec),
                 input_specs=op_args_target_specs,
                 redistribute_cost=redistribute_costs,
@@ -797,7 +797,7 @@ def nll_loss_backward_strategy(op_schema: OpSchema) -> OpStrategy:
 
         grad_in_expected_spec = input_expected_spec
         grad_in_strategy.strategies.append(
-            PlacementStrategy(
+            OpSpec(
                 output_specs=grad_in_expected_spec,
                 input_specs=op_args_target_specs,
                 redistribute_cost=redistribute_costs,
@@ -894,7 +894,7 @@ def layer_norm_strategy(op_schema: OpSchema) -> OpStrategy:
         # the output spec is the same as input spec
         output_target_spec = input_target_spec
         output_strategy.strategies.append(
-            PlacementStrategy(
+            OpSpec(
                 output_specs=output_target_spec,
                 input_specs=op_args_target_specs,
                 redistribute_cost=redistribute_costs,
@@ -944,7 +944,7 @@ def layer_norm_bwd_strategy(op_schema: OpSchema) -> OpStrategy:
     # output triple: (d_input, d_weight, d_bias)
     out_tuple_strategy = OpStrategy([])
     for idx, input_placement_strategy in enumerate(input_strategy.strategies):
-        # args for PlacementStrategy
+        # args for OpSpec
         output_specs_list: list[Optional[DTensorSpec]] = []
         input_specs_list: list[DTensorSpec] = []
         redistribute_costs = []
@@ -1052,7 +1052,7 @@ def layer_norm_bwd_strategy(op_schema: OpSchema) -> OpStrategy:
             output_specs_list.append(None)
 
         out_tuple_strategy.strategies.append(
-            PlacementStrategy(
+            OpSpec(
                 output_specs=tuple(output_specs_list),
                 input_specs=input_specs_list,
                 redistribute_cost=redistribute_costs,

--- a/torch/distributed/tensor/_ops/_matrix_ops.py
+++ b/torch/distributed/tensor/_ops/_matrix_ops.py
@@ -9,9 +9,9 @@ from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor._dtensor_spec import DTensorSpec
 from torch.distributed.tensor._op_schema import (
     OpSchema,
+    OpSpec,
     OpStrategy,
     PlacementList,
-    PlacementStrategy,
     RuntimeSchemaInfo,
 )
 from torch.distributed.tensor._ops._einsum_strategy import gen_einsum_strategies
@@ -48,7 +48,7 @@ def transpose_strategy(op_schema: OpSchema) -> OpStrategy:
             Shard(1 - p.dim) if isinstance(p, Shard) else p
             for p in input_spec.placements
         ]
-        transpose_strategy = PlacementStrategy(
+        transpose_strategy = OpSpec(
             output_specs=DTensorSpec(
                 mesh=input_strategy.mesh,
                 placements=tuple(output_placements),
@@ -447,7 +447,7 @@ def constant_pad_nd_strategy(op_schema: OpSchema) -> OpStrategy:
     # TODO(d4l3k); implement a more correct strategy for constant_pad_nd
     return OpStrategy(
         [
-            PlacementStrategy(
+            OpSpec(
                 output_specs=DTensorSpec(mesh, (Replicate(),)),
                 input_specs=(
                     DTensorSpec(mesh, (Replicate(),)),

--- a/torch/distributed/tensor/_ops/_pointwise_ops.py
+++ b/torch/distributed/tensor/_ops/_pointwise_ops.py
@@ -5,11 +5,9 @@ from typing import cast
 import torch
 from torch.distributed.tensor._dtensor_spec import DTensorSpec
 from torch.distributed.tensor._op_schema import (
-    _is_inplace_op,
-    _is_out_variant_op,
     OpSchema,
+    OpSpec,
     OpStrategy,
-    PlacementStrategy,
     RuntimeSchemaInfo,
     StrategyType,
     TupleStrategy,
@@ -424,10 +422,10 @@ def pointwise_strategy(op_schema: OpSchema, linearity: bool = False) -> OpStrate
     max_shards = -1
     max_ndim = -1
 
-    if _is_inplace_op(op_schema.op):
+    if op_schema.is_inplace_op():
         # inplace op should follow the first arg strategy
         followed_strategy = op_schema.args_schema[0]
-    elif _is_out_variant_op(op_schema.op):
+    elif op_schema.is_out_variant_op():
         # out variant op should follow the out kwarg strategy
         followed_strategy = op_schema.kwargs_schema["out"]
     else:
@@ -519,7 +517,7 @@ def common_pointwise_strategy(
                 )
 
         pointwise_strategy.strategies.append(
-            PlacementStrategy(
+            OpSpec(
                 output_specs=DTensorSpec(
                     mesh=followed_strategy.mesh,
                     placements=tuple(out_placements),

--- a/torch/distributed/tensor/_ops/_random_ops.py
+++ b/torch/distributed/tensor/_ops/_random_ops.py
@@ -2,8 +2,8 @@
 import torch
 from torch.distributed.tensor._op_schema import (
     OpSchema,
+    OpSpec,
     OpStrategy,
-    PlacementStrategy,
     StrategyType,
 )
 from torch.distributed.tensor._ops.utils import is_tensor_partial, register_op_strategy
@@ -31,6 +31,6 @@ def random_op_strategy(op_schema: OpSchema) -> StrategyType:
         if is_tensor_partial(arg_spec):
             # TODO: figure out how inplace random op should behave when it's partial
             raise RuntimeError(f"{op_schema.op} with Partial is not supported yet!")
-        random_strategy.strategies.append(PlacementStrategy(output_specs=arg_spec))
+        random_strategy.strategies.append(OpSpec(output_specs=arg_spec))
 
     return random_strategy

--- a/torch/distributed/tensor/_ops/_view_ops.py
+++ b/torch/distributed/tensor/_ops/_view_ops.py
@@ -10,8 +10,8 @@ from torch._prims_common import DimsType
 from torch.distributed.tensor._dtensor_spec import DTensorSpec
 from torch.distributed.tensor._op_schema import (
     OpSchema,
+    OpSpec,
     OpStrategy,
-    PlacementStrategy,
     RuntimeSchemaInfo,
     StrategyType,
 )
@@ -666,7 +666,7 @@ def register_op_strategy_map(
 
             output_spec = DTensorSpec(mesh=mesh, placements=tuple(output_placements))
             output_strategy.strategies.append(
-                PlacementStrategy(
+                OpSpec(
                     output_specs=output_spec,
                     input_specs=(input_tgt_spec,),
                     redistribute_cost=redistribute_costs,

--- a/torch/distributed/tensor/_ops/utils.py
+++ b/torch/distributed/tensor/_ops/utils.py
@@ -14,10 +14,10 @@ from torch.distributed.tensor._collective_utils import redistribute_cost
 from torch.distributed.tensor._dtensor_spec import DTensorSpec
 from torch.distributed.tensor._op_schema import (
     OpSchema,
+    OpSpec,
     OpStrategy,
     OutputSharding,
     PlacementList,
-    PlacementStrategy,
     RuntimeSchemaInfo,
 )
 from torch.distributed.tensor.device_mesh import DeviceMesh
@@ -265,7 +265,7 @@ def expand_to_full_mesh_op_strategy(
         self_spec = input_args_strategy[0].strategies[0].output_spec
 
         if inplace_op and self_spec.placements != input_specs[0].placements:
-            # if it's inplace op, we would only allow the placement strategy to be added when the
+            # if it's inplace op, we would only allow the OpSpec to be added when the
             # input_spec matches the first argument's runtime sharding, otherwise we skip
             continue
 
@@ -288,7 +288,7 @@ def expand_to_full_mesh_op_strategy(
                     output_specs = spec_list[0]  # type: ignore[assignment]
                 else:
                     raise RuntimeError("output spec is None")
-            strategy = PlacementStrategy(
+            strategy = OpSpec(
                 output_specs=output_specs,
                 input_specs=input_specs,
                 redistribute_cost=redistribute_cost,

--- a/torch/distributed/tensor/experimental/_register_sharding.py
+++ b/torch/distributed/tensor/experimental/_register_sharding.py
@@ -8,7 +8,6 @@ import torch
 from torch._ops import OpOverload
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor._op_schema import (
-    _is_inplace_op,
     OpSchema,
     OpStrategy,
     PlacementList,
@@ -101,7 +100,7 @@ def register_sharding(op: Union[OpOverload, list[OpOverload]]):
             op_schema,
             single_mesh_dim_strategies,
             input_index=len(op_schema.op._schema.returns),
-            inplace_op=_is_inplace_op(op_schema.op),
+            inplace_op=op_schema.is_inplace_op(),
         )
 
     def wrapper(custom_sharding_fn):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #155592

as titled. It's sometimes confusing to use PlacementStrategy as a name,
as we also have OpStrategy and TupleStrategy, the latter two contain
the former, so it is better to make the naming clearer.

Renaming PlacementStrategy -> OpSpec as it is an operator spec that
contains output_spec + input_specs.

Also found some utils can be merged to OpSchema so included together in
this PR

cc @H-Huang @awgu @fegin @fduwjj @wz337 @wconstab @d4l3k