### PR TITLE
Remove unnecessary MPSStream initialization

### DIFF
--- a/aten/src/ATen/mps/MPSGuardImpl.mm
+++ b/aten/src/ATen/mps/MPSGuardImpl.mm
@@ -34,13 +34,12 @@ void MPSGuardImpl::record(void** event,
     mps_event_id = at::mps::getMPSEventPool()->acquireEvent(flag == EventFlag::BACKEND_DEFAULT);
     *event = (__bridge void*)(intptr_t)(mps_event_id);
   }
-  MPSStream mps_stream{stream};
+  
   at::mps::getMPSEventPool()->recordEvent(mps_event_id, true);
 }
 
 void MPSGuardImpl::block(void* event, const Stream& stream) const {
   auto mps_event_id = (__bridge id_t)(intptr_t)(event);
-  MPSStream mps_stream{stream};
 
   at::mps::getMPSEventPool()->waitForEvent(mps_event_id, false);
 }

--- a/aten/src/ATen/mps/MPSGuardImpl.mm
+++ b/aten/src/ATen/mps/MPSGuardImpl.mm
@@ -34,7 +34,7 @@ void MPSGuardImpl::record(void** event,
     mps_event_id = at::mps::getMPSEventPool()->acquireEvent(flag == EventFlag::BACKEND_DEFAULT);
     *event = (__bridge void*)(intptr_t)(mps_event_id);
   }
-  
+
   at::mps::getMPSEventPool()->recordEvent(mps_event_id, true);
 }
 


### PR DESCRIPTION
Uncovered a small memory leak as part of the investigation into https://github.com/pytorch/pytorch/issues/154329.

The call to MPSStream was orphaned by https://github.com/pytorch/pytorch/pull/85817/files#diff-6ca28430ea5963cd324d8fb17f3052ae0cb8c5a96369965491cb69bab08ab0beL38. Removing it as it's now unnecessary  and was causing memory leaks

This resolves about 30% of the remaining memory growth from the linked issue