### PR TITLE
Propagate annotations for custom ops created by @custom_op should get type hints propagated to their OpOverload

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -4171,6 +4171,7 @@ Please use `add.register_fake` to add an fake impl.""",
             )
         )
 
+    # https://github.com/pytorch/pytorch/issues/155385
     def test_annotation_propagation(self):
         # Define a function with specific annotations
         @torch.library.custom_op("test_ns::annotated_func", mutates_args=())

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -4171,7 +4171,6 @@ Please use `add.register_fake` to add an fake impl.""",
             )
         )
 
-    # https://github.com/pytorch/pytorch/issues/155385
     def test_annotation_propagation(self):
         # Define a function with specific annotations
         @torch.library.custom_op("test_ns::annotated_func", mutates_args=())

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -4171,6 +4171,24 @@ Please use `add.register_fake` to add an fake impl.""",
             )
         )
 
+    def test_annotation_propagation(self):
+        # Define a function with specific annotations
+        @torch.library.custom_op("test_ns::annotated_func", mutates_args=())
+        def annotated_func(
+            x: Tensor,
+            y: int,
+        ) -> Tensor:
+            # Simple implementation that returns a tensor
+            return x + y
+
+        # Get the operator annotations
+        init_annotation = annotated_func._init_fn.__annotations__
+        default_annotation = torch.ops.test_ns.annotated_func.default.__call__.__annotations__
+
+        self.assertEqual(
+            init_annotation,
+            default_annotation
+        )
 
 class MiniOpTestOther(CustomOpTestCaseBase):
     test_ns = "mini_op_test"

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -4183,11 +4183,11 @@ Please use `add.register_fake` to add an fake impl.""",
 
         # Get the operator annotations
         init_annotation = annotated_func._init_fn.__annotations__
-        default_annotation = torch.ops.test_ns.annotated_func.default.__call__.__annotations__
+        func_annotation = torch.ops.test_ns.annotated_func.default.__call__.__annotations__
 
         self.assertEqual(
-            init_annotation,
-            default_annotation
+            func_annotation,
+            init_annotation
         )
 
 class MiniOpTestOther(CustomOpTestCaseBase):

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -209,10 +209,10 @@ class CustomOpDef:
         self._autocast_cuda_dtype: Optional[_dtype] = None
         self._autocast_cpu_dtype: Optional[_dtype] = None
 
+        OPDEFS[self._qualname] = self
         self._lib = get_library_allowing_overwrite(self._namespace, self._name)
         self._register_to_dispatcher(self._tags)
         self._disabled_kernel: set = set()
-        OPDEFS[self._qualname] = self
 
     @property
     def _qualname(self) -> str:

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -775,6 +775,10 @@ class OpOverload(OperatorBase):
                 is_write = a.alias_info.is_write or is_write
         self.is_view = is_write is not None and not is_write
 
+        # Propagate annotations if available
+        opdef = torch.library._maybe_get_opdef(self._name)
+        self.__call__.__func__.__annotations__ = opdef._init_fn.__annotations__ if opdef is not None else {}
+
     @property
     def _namespace(self):
         return self._schema.name.split("::")[0]


### PR DESCRIPTION
Fixes #155385

This PR copies the `__annotation__` attribute from the initial function to the `OpOverload.__call__.__func__` (can be accessed directly with `OpOverlaod.__call__.__annotations__`)
```
import torch

@torch.library.custom_op("mylib::sin", mutates_args=())
def sin(x: torch.Tensor) -> torch.Tensor:
    return torch.sin(x)

print(torch.ops.mylib.sin.default.__call__.__annotations__) # {'x': <class 'torch.Tensor'>, 'return': <class 'torch.Tensor'>}

#  They should both have the `__annotations__` field set
def sin(x: torch.Tensor) -> torch.Tensor:
    return torch.sin(x)

print(sin.__annotations__) # {'x': <class 'torch.Tensor'>, 'return': <class 'torch.Tensor'>}
```