### PR TITLE
Fixed NLLLoss 1D input crash with torch.compile

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7287,6 +7287,20 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             pickle.loads(pickle.dumps(torch.nn.Linear(10, 10)))
         self.assertEqual(len(w), 0)
 
+    def test_nllloss_1d_input_compile(self):
+        input = torch.log_softmax(torch.randn(32, 1), dim=1).squeeze(1)  # shape: [32]
+        target = torch.zeros(32, dtype=torch.long)  # shape: [32]
+        loss_fn = nn.NLLLoss()
+
+        # Eager mode
+        eager_out = loss_fn(input, target)
+
+        # Compiled mode
+        compiled_fn = torch.compile(lambda x, y: loss_fn(x, y), backend="eager")
+        compiled_out = compiled_fn(input, target)
+
+        torch.testing.assert_close(eager_out, compiled_out, rtol=1e-5, atol=1e-5)
+
 class TestFusionEval(TestCase):
     @set_default_dtype(torch.double)
     @given(X=hu.tensor(shapes=((5, 3, 5, 5),), dtype=np.double),

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -3961,6 +3961,10 @@ def _nll_loss_forward(
     # self can be [N, C] or [C]
     # target can be [N] or []
 
+    # Ensure input is at least 2D to avoid gather errors
+    if self.dim() == 1:
+        self = self.unsqueeze(1)
+
     n_dims = self.dim()
     channel_dim = 1
     if n_dims < 2:


### PR DESCRIPTION
Fixes #155247

Fixes a bug where `nn.NLLLoss` fails with 1D input (shape `[N]`) when using `torch.compile()`, even though eager mode accepts it