### PR TITLE
Remove unused nonlocal declarations from checkpoint and library helper functions

### DIFF
--- a/torch/library.py
+++ b/torch/library.py
@@ -1388,7 +1388,7 @@ def register_vmap(
         )
 
     def register(func):
-        nonlocal op, lib
+        nonlocal lib
 
         namespace, opname = torch._library.utils.parse_namespace(qualname)
         if lib is None:

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -131,7 +131,6 @@ def _infer_device_type(*args):
     device_types = []
 
     def add_device_types(arg):
-        nonlocal device_types
         if isinstance(arg, torch.Tensor) and not arg.device.type == "cpu":
             device_types.append(arg.device.type)
     tree_map(add_device_types, args)
@@ -167,7 +166,6 @@ def get_device_states(*args) -> Tuple[List[int], List[torch.Tensor]]:
     fwd_device_ids = []
 
     def add_device_ids(arg):
-        nonlocal fwd_device_ids
         if isinstance(arg, torch.Tensor) and arg.device.type not in {"cpu", "meta"}:
             fwd_device_ids.append(arg.get_device())
     tree_map(add_device_ids, args)


### PR DESCRIPTION
**Description**

    Cleans up unused nonlocal declarations in _infer_device_type and get_device_states within torch/utils/checkpoint.py.

    Drops unused nonlocal op in the register function in torch/library.py.

    These changes have no effect on runtime behavior and improve code clarity.

**Testing**

    Verified both files compile with python -m py_compile.

    No logic was altered; only redundant code was removed.

If anything needs more detail, happy to update!
