### PR TITLE
[CI] Move setuptools requirements from conda to pip

### DIFF
--- a/.github/requirements/conda-env-macOS-ARM64
+++ b/.github/requirements/conda-env-macOS-ARM64
@@ -2,5 +2,4 @@
 certifi
 pip=23.2.1
 pkg-config=0.29.2
-setuptools=72.1.0
 wheel=0.37.1

--- a/.github/requirements/pip-requirements-macOS.txt
+++ b/.github/requirements/pip-requirements-macOS.txt
@@ -26,6 +26,7 @@ pytest-xdist==3.3.1
 pytest==7.3.2
 pyyaml==6.0.2
 scipy==1.12.0
+setuptools==72.1.0
 sympy==1.13.3
 tlparse==0.3.30
 tensorboard==2.13.0


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #155698
* __->__ #155697
* #155515

Needed for `import z5` to work without warning, otherwise
`LoggingTests.test_logs_out` will fail