### PR TITLE
Improve safetensors consolidation script

### DIFF
--- a/test/distributed/checkpoint/test_consolidate_hf_safetensors.py
+++ b/test/distributed/checkpoint/test_consolidate_hf_safetensors.py
@@ -112,7 +112,7 @@ class TestConsolidateHFSafeTensors(DTensorTestBase):
             
         if self.rank == 0:
             fqn_to_index_mapping = {"dtensor": 1, "dtensor_col": 2}
-            consolidate_safetensors_files(checkpoint_dir, output_dir, fqn_to_index_mapping)
+            consolidate_safetensors_files(checkpoint_dir, output_dir, fqn_to_index_mapping=fqn_to_index_mapping)
             
             file1_path = os.path.join(output_dir, "model-00001-of-00002.safetensors")
             file2_path = os.path.join(output_dir, "model-00002-of-00002.safetensors")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #155707
* __->__ #155706
* #154743
* #154519
* #154518

This improves the safetensor consolidation script by adding the ability to multi thread so that we can write to multiple files concurrently and speed up the consolidation process. It also can take in a safetensors metadata file for the mapping of fqns to what files they should be part of which will help with parallelization. It also changes the full deserialization, to only read tensor by tensor. Finally, there is an upload method so that users can upload the output files to remote storage from the script

Differential Revision: [D75790351](https://our.internmc.facebook.com/intern/diff/D75790351/)

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k