### PR TITLE
Remove actionable label from docathon label sync script

### DIFF
--- a/.github/scripts/docathon-label-sync.py
+++ b/.github/scripts/docathon-label-sync.py
@@ -39,7 +39,8 @@ def main() -> None:
     pull_request_label_names = [label.name for label in pull_request_labels]
     issue_label_names = [label.name for label in issue_labels]
     labels_to_add = [
-        label for label in issue_label_names if label not in pull_request_label_names
+        label for label in issue_label_names 
+        if label not in pull_request_label_names and label != "actionable"
     ]
     if not labels_to_add:
         print("The pull request already has the same labels.")

--- a/.github/scripts/docathon-label-sync.py
+++ b/.github/scripts/docathon-label-sync.py
@@ -39,7 +39,8 @@ def main() -> None:
     pull_request_label_names = [label.name for label in pull_request_labels]
     issue_label_names = [label.name for label in issue_labels]
     labels_to_add = [
-        label for label in issue_label_names 
+        label
+        for label in issue_label_names
         if label not in pull_request_label_names and label != "actionable"
     ]
     if not labels_to_add:


### PR DESCRIPTION
Make sure we don't propagate actionable label in docathon sync label script.

cc @sekyondaMeta @AlannaBurke @seemethere @malfet @pytorch/pytorch-dev-infra