### PR TITLE
[MPS] Add regression test for memory leak in nn.MaxPool2d

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -390,6 +390,32 @@ class TestMemoryLeak(TestCaseMPS):
         driver_after = torch.mps.driver_allocated_memory()
         self.assertEqual(driver_before, driver_after, f"Detected {driver_after - driver_before} bytes leak of GPU memory")
 
+    @xfailIf(MACOS_VERSION < 15.4)
+    def test_maxpool2d_no_leak(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/125217
+        N, C, H, W = 64, 32, 256, 256
+        iters = 5
+
+        model = torch.nn.Sequential(
+            nn.Conv2d(32, 32, 3),
+            nn.MaxPool2d((2, 2)),
+        ).to('mps')
+        input = torch.rand(N, C, H, W, device='mps')
+
+        # Warm up
+        output = model(input)
+        loss = output.sum()
+        loss.backward()
+
+        # Begin test
+        driver_before = torch.mps.driver_allocated_memory()
+        model(input)
+        for _ in range(iters):
+            output = model(input)
+            loss = output.sum()
+            loss.backward()
+        driver_after = torch.mps.driver_allocated_memory()
+        self.assertEqual(driver_before, driver_after, f"Detected {driver_after - driver_before} bytes leak of GPU memory")
 
 class TestPixelShuffle(TestCaseMPS):
     def test_pixel_shuffle_unshuffle(self):


### PR DESCRIPTION
This PR was previously proposed in #132408 before the fix had landed in MPS. @skotapati confirmed the fix was released in macOS 15.4 in https://github.com/pytorch/pytorch/issues/125217#issuecomment-2963713371.

Fixes #125217