### PR TITLE
[BE][Testing] Delete some unused code

### DIFF
--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -18,14 +18,8 @@ from torch.serialization import safe_globals
 from torch.testing._internal.common_utils import (
     skipIfTorchDynamo,
     TemporaryFileName,
-    TEST_CUDA,
     TEST_XPU,
 )
-from torch.utils.cpp_extension import CUDA_HOME, ROCM_HOME
-
-
-TEST_CUDA = TEST_CUDA and CUDA_HOME is not None
-TEST_ROCM = TEST_CUDA and torch.version.hip is not None and ROCM_HOME is not None
 
 
 def generate_faked_module():
@@ -35,8 +29,8 @@ def generate_faked_module():
     return _OpenRegMod()
 
 
-@unittest.skipIf(TEST_XPU, "XPU does not support cppextension currently")
-@torch.testing._internal.common_utils.markDynamoStrictTest
+@unittest.skipIf(common.TEST_XPU, "XPU does not support cppextension currently")
+@common.markDynamoStrictTest
 class TestCppExtensionOpenRgistration(common.TestCase):
     """Tests Open Device Registration with C++ extensions."""
 
@@ -60,7 +54,7 @@ class TestCppExtensionOpenRgistration(common.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        torch.testing._internal.common_utils.remove_cpp_extensions_build_root()
+        common.remove_cpp_extensions_build_root()
 
         cls.module = torch.utils.cpp_extension.load(
             name="custom_device_extension",

--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -15,11 +15,7 @@ import torch
 import torch.testing._internal.common_utils as common
 import torch.utils.cpp_extension
 from torch.serialization import safe_globals
-from torch.testing._internal.common_utils import (
-    skipIfTorchDynamo,
-    TemporaryFileName,
-    TEST_XPU,
-)
+from torch.testing._internal.common_utils import TemporaryFileName
 
 
 def generate_faked_module():
@@ -31,7 +27,7 @@ def generate_faked_module():
 
 @unittest.skipIf(common.TEST_XPU, "XPU does not support cppextension currently")
 @common.markDynamoStrictTest
-class TestCppExtensionOpenRgistration(common.TestCase):
+class TestCppExtensionOpenRegistration(common.TestCase):
     """Tests Open Device Registration with C++ extensions."""
 
     module = None
@@ -281,7 +277,7 @@ class TestCppExtensionOpenRgistration(common.TestCase):
         sys.version_info >= (3, 13),
         "Error: Please register PrivateUse1HooksInterface by `RegisterPrivateUse1HooksInterface` first.",
     )
-    @skipIfTorchDynamo("unsupported aten.is_pinned.default")
+    @common.skipIfTorchDynamo("unsupported aten.is_pinned.default")
     def test_open_device_storage_pin_memory(self):
         # Check if the pin_memory is functioning properly on custom device
         cpu_tensor = torch.empty(3)
@@ -419,7 +415,7 @@ class TestCppExtensionOpenRgistration(common.TestCase):
 
     # Not an open registration test - this file is just very convenient
     # for testing torch.compile on custom C++ operators
-    @skipIfTorchDynamo("Temporary disabled due to torch._ops.OpOverloadPacket")
+    @common.skipIfTorchDynamo("Temporary disabled due to torch._ops.OpOverloadPacket")
     def test_compile_autograd_function_aliasing(self):
         x_ref = torch.randn(4, requires_grad=True)
         out_ref = torch.ops._test_funcs.custom_autograd_fn_aliasing(x_ref)
@@ -480,7 +476,7 @@ class TestCppExtensionOpenRgistration(common.TestCase):
         # call _fused_adamw_ with undefined tensor.
         self.module.fallback_with_undefined_tensor()
 
-    @skipIfTorchDynamo()
+    @common.skipIfTorchDynamo()
     @unittest.skipIf(
         np.__version__ < "1.25",
         "versions < 1.25 serialize dtypes differently from how it's serialized in data_legacy_numpy",


### PR DESCRIPTION
- Fix typo in class name `OpenRgistration`->`OpenRegistration`
- Use existing `common` alias of `torch.testing._internal.common_utils`, i.e. `s/torch.testing._internal.common_utils.markDynamoStrictTest/common.markDynamoStrictTest/`
- Remove unused `TEST_CUDA` and `TEST_ROCM` are unused in that file
