### PR TITLE
ELU: compute ELU(0) with the cheaper definition

### DIFF
--- a/aten/src/ATen/native/cpu/Elu.h
+++ b/aten/src/ATen/native/cpu/Elu.h
@@ -24,7 +24,7 @@ auto get_scalar_elu_elementwise_func(MathT alpha, MathT scale, MathT input_scale
   const auto poscoef = scale;
   const auto negiptcoef = input_scale;
   return [negcoef, negiptcoef, poscoef](ParamT a) -> ParamT {
-    return MathT(a) <= MathT(0)
+    return MathT(a) < MathT(0)
       ? std::expm1(MathT(a) * negiptcoef) * negcoef
       : MathT(a) * poscoef;
   };
@@ -42,7 +42,7 @@ auto get_vectorized_elu_elementwise_func(T alpha, T scale, T input_scale) {
   const vec::Vectorized<T> negiptcoef_vec(input_scale);
   const vec::Vectorized<T> zero_vec(static_cast<T>(0));
   return [negcoef_vec, poscoef_vec, negiptcoef_vec, zero_vec](vec::Vectorized<T> a) -> vec::Vectorized<T> {
-    const auto cmp = a > zero_vec;
+    const auto cmp = a >= zero_vec;
     if (!cmp.zero_mask()) {
       return a * poscoef_vec;
     } else {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #155766
* __->__ #155765

Both halves of the ELU definition yield 0 when evaluated at 0. Let's choose the half that doesn't require expm1. (I have no particular evidence that the input is often 0 in any case, but this seems like a free win.)

Differential Revision: [D76481038](https://our.internmc.facebook.com/intern/diff/D76481038/)

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168