### PR TITLE
Optimize grad_mode Self typing

### DIFF
--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 from typing import Any, Union
+from typing_extensions import Self
 
 import torch
 from torch.utils._contextlib import (
@@ -196,7 +197,7 @@ class set_grad_enabled(_DecoratorContextManager):
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         torch._C._set_grad_enabled(self.prev)
 
-    def clone(self) -> "set_grad_enabled":
+    def clone(self) -> Self:
         r"""
         Create a copy of this class
         """
@@ -273,7 +274,7 @@ class inference_mode(_DecoratorContextManager):
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         self._inference_mode_context.__exit__(exc_type, exc_value, traceback)
 
-    def clone(self) -> "inference_mode":
+    def clone(self) -> Self:
         r"""
         Create a copy of this class
         """
@@ -319,7 +320,7 @@ class set_multithreading_enabled(_DecoratorContextManager):
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         torch._C._set_multithreading_enabled(self.prev)
 
-    def clone(self) -> "set_multithreading_enabled":
+    def clone(self) -> Self:
         r"""
         Create a copy of this class
         """
@@ -359,7 +360,7 @@ class _force_original_view_tracking(_DecoratorContextManager):
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         torch._C._set_view_replay_enabled(self.prev)
 
-    def clone(self):
+    def clone(self) -> Self:
         return self.__class__(self.mode)
 
 


### PR DESCRIPTION
## Test Result

```bash
$ lintrunner
Warning: Could not find a lintrunner config at: '.lintrunner.private.toml'. Continuing without using configuration file.
WARNING: The init commands have changed since you last ran lintrunner. You may need to run `lintrunner init`.
  CLANGFORMAT success!
  MYPY success!
  MYPYSTRICT success!
  CLANGTIDY success!
  FLAKE8 success!
  TYPEIGNORE success!
  TYPENOSKIP success!
  NOQA success!
  GHA success!
  NATIVEFUNCTIONS success!
  SPACES success!
  NEWLINE success!
  TABS success!
  C10_UNUSED success!
  INCLUDE success!
  C10_NODISCARD success!
  PYBIND11_INCLUDE success!
  ERROR_PRONE_ISINSTANCE success!
  PYBIND11_SPECIALIZATION success!
  PYPIDEP success!
  EXEC success!
  CUBINCLUDE success!
  RAWCUDA success!
  RAWCUDADEVICE success!
  DEPLOY_DETECTION success!
  ROOT_LOGGING success!
  CMAKE success!
  SHELLCHECK success!
  ACTIONLINT success!
  CONTEXT_DECORATOR success!
  CALL_ONCE success!
  TESTOWNERS success!
  TEST_HAS_MAIN success!
  NO_WORKFLOWS_ON_FORK success!
  COPYRIGHT success!
  ONCE_FLAG success!
  BAZEL_LINTER success!
  WORKFLOWSYNC success!
  MERGE_CONFLICTLESS_CSV success!
  LINTRUNNER_VERSION success!
  PYFMT success!
  RUFF success!
  META_NO_CREATE_UNBACKED success!
  SET_LINTER success!
  ATEN_CPU_GPU_AGNOSTIC success!
  DOCSTRING_LINTER success!
  TEST_DEVICE_BIAS success!
  IMPORT_LINTER success!
  HEADER_ONLY_LINTER success!
ok No lint issues.

```
