### PR TITLE
add `__annotations__` attribute to `OpOverload`

### DIFF
--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -777,6 +777,7 @@ class OpOverload(OperatorBase):
         # Logic replicated from aten/src/ATen/native/MathBitsFallback.h
         is_write = None
         for a in self._schema.arguments:
+            self.__annotations__[a.name] = a.type
             if a.alias_info is None:
                 continue
             if is_write is None:
@@ -785,7 +786,6 @@ class OpOverload(OperatorBase):
                 # We will conservatively call mixed mutable/non-mutable
                 # aliased inputs as NOT a view
                 is_write = a.alias_info.is_write or is_write
-            self.__annotations__[a.name] = a.type
         return_types = (
             tuple(a.type for a in self._schema.returns)
             if self._schema.returns

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -785,6 +785,18 @@ class OpOverload(OperatorBase):
                 # We will conservatively call mixed mutable/non-mutable
                 # aliased inputs as NOT a view
                 is_write = a.alias_info.is_write or is_write
+            self.__annotations__[a.name] = a.type
+        return_types = (
+            tuple(a.type for a in self._schema.returns)
+            if self._schema.returns
+            else None
+        )
+        if return_types is None:
+            self.__annotations__["return"] = None
+        else:
+            self.__annotations__["return"] = (
+                return_types if len(return_types) > 1 else return_types[0]
+            )
         self.is_view = is_write is not None and not is_write
 
     @property


### PR DESCRIPTION
Currently I build the `__annotations__` dict for `OpOverload` in its `__init__`. I'm not sure whether this way complies with the demands in #155386.

Fixes #155386
