### PR TITLE
[dynamo] Fix cycle reference problem caused by recursive collect_temp_source in codegen

### DIFF
--- a/torch/_dynamo/codegen.py
+++ b/torch/_dynamo/codegen.py
@@ -590,22 +590,26 @@ class PyCodegen:
         seen_sources: OrderedSet[Source] = OrderedSet()
 
         def collect_temp_source(source):
-            if source in seen_sources:
-                # This source is used atleast twice, so it can be reused
-                self.mark_source_temp(source)
-                # Dont trace source further. This prevents us from marking too
-                # many nodes as temp sources.
-                return
+            stack = collections.deque([source])
+            while stack:
+                source = stack.pop()
 
-            seen_sources.add(source)
+                if source in seen_sources:
+                    # This source is used at least twice, so it can be reused
+                    self.mark_source_temp(source)
+                    # Dont trace source further. This prevents us from marking too
+                    # many nodes as temp sources.
+                    return
 
-            if isinstance(source, ChainedSource):
-                collect_temp_source(source.base)
+                seen_sources.add(source)
 
-            if isinstance(source, DictGetItemSource) and isinstance(
-                source.index, Source
-            ):
-                collect_temp_source(source.index)
+                if isinstance(source, ChainedSource):
+                    stack.append(source.base)
+
+                if isinstance(source, DictGetItemSource) and isinstance(
+                    source.index, Source
+                ):
+                    stack.append(source.index)
 
         # Collect all the sources that are used more than once, so that we can
         # generate tmp variables in the generated pre-graph bytecode. This

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1176,6 +1176,7 @@ def _compile(
 
             if tracer:
                 tracer.output.local_scope = {}
+                tracer.f_locals = {}
 
             from .utils import curr_frame
 

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -210,7 +210,7 @@ class AsPythonConstantNotImplementedError(NotImplementedError):
     vt: "VariableTracker"
 
     def __init__(self, vt: "VariableTracker"):
-        super().__init__(self, f"{vt} is not a constant")
+        super().__init__(f"{vt} is not a constant")
         self.vt = vt
 
 


### PR DESCRIPTION
Recursive function collect_temp_source with closure in PyCodegen caused cycle reference issue when torch.compile is used.
This issue may cause major tensors will not freed timely even there are no user references to these tensors.

We saw OOM issues because of this problem in many cases including training and inference using torch.compile.
The fix is to use iterative function implementation to replace the recursive function implementation.

Fixes #155778

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames