### PR TITLE
Add ONNX dynamo metadata documentation

### DIFF
--- a/docs/source/onnx_dynamo.md
+++ b/docs/source/onnx_dynamo.md
@@ -159,14 +159,14 @@ The following metadata fields are added to each ONNX node:
 - **pkg.torch.onnx.class_hierarchy**
 
   A list of class names representing the hierarchy of modules leading to this node.
-  
+
   *Example:*
   `['__main__.SimpleAddModel', 'aten.add.Tensor']`
 
 - **pkg.torch.onnx.fx_node**
 
   The string representation of the original FX node, including its name, number of consumers, the targeted torch op, arguments, and keyword arguments.
-  
+
   *Example:*
   `%cat : [num_users=1] = call_function[target=torch.ops.aten.cat.default](args = ([%tensor_x, %input_dict_tensor_x, %input_list_0], 1), kwargs = {})`
 
@@ -223,7 +223,7 @@ Each input value in the ONNX graph may have the following metadata property:
 - **pkg.torch.export.graph_signature.InputSpec.persistent**
 
   Indicates whether the input is persistent (i.e., should be saved as part of the model's state).
-  
+
   *Example values:*
   - "True"
   - "False"
@@ -246,7 +246,7 @@ Each output value in the ONNX graph may have the following metadata property:
 Each initialized value, input, output has the following metadata:
 
 - **pkg.torch.onnx.original_node_name**
-  
+
   The original name of the node in the PyTorch FX graph that produced this value in the case where the value was renamed. This helps trace initializers back to their source in the original model.
 
   *Example:*

--- a/docs/source/onnx_dynamo.md
+++ b/docs/source/onnx_dynamo.md
@@ -165,7 +165,7 @@ The following metadata fields are added to each ONNX node:
 
 - **pkg.torch.onnx.fx_node**
 
-  The string representation of the original FX node, including its name, number of consumers, torch op, arguments, and keyword arguments.
+  The string representation of the original FX node, including its name, number of consumers, the targeted torch op, arguments, and keyword arguments.
   
   *Example:*
   `%sym_size_int_720 : [num_users=1] = call_function[target=torch.ops.aten.sym_size.int](args = (%img, 2), kwargs = {})`
@@ -192,6 +192,19 @@ The following metadata fields are added to each ONNX node:
   `[2]`
 
 These metadata fields are stored in the metadata_props attribute of each ONNX node and can be inspected using Netron or programmatically.
+
+The overall ONNX IR graph has the following metadata props:
+
+- **pkg.torch.export.ExportedProgram.graph_signature**
+
+  This property contains a string representation of the graph_signature from the original PyTorch ExportedProgram. The graph signature describes the structure of the model's inputs and outputs and how they map to the ONNX graph. The inputs are defined as `InputSpec` objects, which include the kind of input (e.g., `InputKind.PARAMETER` for parameters, `InputKind.USER_INPUT` for user-defined inputs), the argument name, the target (which can be a specific node in the model), and whether the input is persistent. The outputs are defined as `OutputSpec` objects, which specify the kind of output (e.g., `OutputKind.USER_OUTPUT`) and the argument name.
+
+- **pkg.torch.export.ExportedProgram.range_constraints**
+
+  This property contains a string representation of any range constraints that were present in the original PyTorch ExportedProgram. Range constraints specify valid ranges for symbolic shapes or values in the model, which can be important for models that use dynamic shapes or symbolic dimensions.
+
+  *Example:*
+  `s0: VR[2, int_oo]`, which indicates that the size of the input tensor must be at least 2.
 
 Each input value in the ONNX graph may have the following metadata property:
 

--- a/docs/source/onnx_dynamo.md
+++ b/docs/source/onnx_dynamo.md
@@ -199,7 +199,7 @@ The overall ONNX IR graph has the following metadata props:
 
   This property contains a string representation of the graph_signature from the original PyTorch ExportedProgram. The graph signature describes the structure of the model's inputs and outputs and how they map to the ONNX graph. The inputs are defined as `InputSpec` objects, which include the kind of input (e.g., `InputKind.PARAMETER` for parameters, `InputKind.USER_INPUT` for user-defined inputs), the argument name, the target (which can be a specific node in the model), and whether the input is persistent. The outputs are defined as `OutputSpec` objects, which specify the kind of output (e.g., `OutputKind.USER_OUTPUT`) and the argument name.
 
-  To read more, please see the {doc}`torch.export <export>` for more information.
+  To read more about the graph signature, please see the {doc}`torch.export <export>` for more information.
 
 - **pkg.torch.export.ExportedProgram.range_constraints**
 
@@ -208,7 +208,7 @@ The overall ONNX IR graph has the following metadata props:
   *Example:*
   `s0: VR[2, int_oo]`, which indicates that the size of the input tensor must be at least 2.
 
-  To read more, please see the {doc}`torch.export <export>` for more information.
+  To read more about range constraints, please see the {doc}`torch.export <export>` for more information.
 
 Each input value in the ONNX graph may have the following metadata property:
 

--- a/docs/source/onnx_dynamo.md
+++ b/docs/source/onnx_dynamo.md
@@ -246,10 +246,6 @@ Each initialized value, input, output has the following metadata:
   `fc1.weight`
 
 
-The `ExportedProgram` class is a representation of a PyTorch model that has been exported to ONNX format. It contains the model's computation graph, which includes the operations performed on the input tensors, their types, and shapes. The `ExportedProgram` class consists of:
-- The `GraphModule` class, a PyTorch module that represents the exported program. It includes a `forward` method that defines the computation graph.
-  - The `forward` method inputs are defined as parameters with specific tensor types and shapes, such as "f32[8, 8]" for a float32 tensor with shape [8, 8].
-  - The operations within the `forward` method are represented as `torch.ops.aten` calls. Each operation is named (e.g., `torch.ops.aten.conv2d.default`) and includes the inputs and outputs with their respective types and shapes. 
   - Each operation in the graph is annotated with its source file and line number, providing context for where the operation was defined in the original code (e.g., `# File: ~/python/site-packages/torch/nn/modules/conv.py:554 in forward, code: return self._conv_forward(input, self.weight, self.bias)`).
 - The `Graph signature`, which defines the input and output specifications of the model. The inputs are defined as `InputSpec` objects, which include the kind of input (e.g., `InputKind.PARAMETER` for parameters, `InputKind.USER_INPUT` for user-defined inputs), the argument name, the target (which can be a specific layer in the model), and whether the input is persistent. The outputs are defined as `OutputSpec` objects, which specify the kind of output (e.g., `OutputKind.USER_OUTPUT`) and the argument name.
 - A `Range constraints` dictionary, which specifies any constraints on the input sizes or shapes, such as `s0: VR[2, int_oo]`, indicating that the size of the input tensor can vary between 2 and infinity.

--- a/docs/source/onnx_dynamo.md
+++ b/docs/source/onnx_dynamo.md
@@ -243,7 +243,7 @@ Each output value in the ONNX graph may have the following metadata property:
   - "USER_INPUT_MUTATION": Indicates a user input was mutated.
   - "TOKEN": A token output.
 
-Each initializer, input, output has the following metadata:
+Each initialized value, input, output has the following metadata:
 
 - **pkg.torch.onnx.original_node_name**
   

--- a/docs/source/onnx_dynamo.md
+++ b/docs/source/onnx_dynamo.md
@@ -135,7 +135,7 @@ You can view the exported model using [Netron](https://netron.app/).
 
 ## When the conversion fails
 
-Function {func}`torch.onnx.export` should called a second time with
+Function {func}`torch.onnx.export` should be called a second time with
 parameter ``report=True``. A markdown report is generated to help the user
 to resolve the issue.
 
@@ -182,7 +182,14 @@ The following metadata fields are added to each ONNX node:
   The stack trace from the original code where this node was created, if available.
 
   *Example:*
-  `File "torch/fx/passes/runtime_assert.py", line 24, in insert_deferred_runtime_asserts`
+  ```
+  File "/opt/conda/envs/ptca/lib/python3.10/site-packages/transformers/models/electra/modeling_electra.py", line 1615, in forward
+    outputs = self.electra(
+  File "/opt/conda/envs/ptca/lib/python3.10/site-packages/transformers/models/electra/modeling_electra.py", line 908, in forward
+    hidden_states = self.embeddings_project(hidden_states)
+  File "/opt/conda/envs/ptca/lib/python3.10/site-packages/torch/nn/modules/linear.py", line 125, in forward
+    return F.linear(input, self.weight, self.bias)
+  ```
 
 These metadata fields are stored in the metadata_props attribute of each ONNX node and can be inspected using Netron or programmatically.
 
@@ -192,12 +199,16 @@ The overall ONNX IR graph has the following metadata props:
 
   This property contains a string representation of the graph_signature from the original PyTorch ExportedProgram. The graph signature describes the structure of the model's inputs and outputs and how they map to the ONNX graph. The inputs are defined as `InputSpec` objects, which include the kind of input (e.g., `InputKind.PARAMETER` for parameters, `InputKind.USER_INPUT` for user-defined inputs), the argument name, the target (which can be a specific node in the model), and whether the input is persistent. The outputs are defined as `OutputSpec` objects, which specify the kind of output (e.g., `OutputKind.USER_OUTPUT`) and the argument name.
 
+  To read more, please see the {doc}`torch.export <export>` for more information.
+
 - **pkg.torch.export.ExportedProgram.range_constraints**
 
   This property contains a string representation of any range constraints that were present in the original PyTorch ExportedProgram. Range constraints specify valid ranges for symbolic shapes or values in the model, which can be important for models that use dynamic shapes or symbolic dimensions.
 
   *Example:*
   `s0: VR[2, int_oo]`, which indicates that the size of the input tensor must be at least 2.
+
+  To read more, please see the {doc}`torch.export <export>` for more information.
 
 Each input value in the ONNX graph may have the following metadata property:
 
@@ -240,12 +251,10 @@ Each initialized value, input, output has the following metadata:
 
 - **pkg.torch.onnx.original_node_name**
   
-  The original name of the node in the PyTorch FX graph that produced this value In the case where the value was renamed. This helps trace initializers back to their source in the original model.
+  The original name of the node in the PyTorch FX graph that produced this value in the case where the value was renamed. This helps trace initializers back to their source in the original model.
 
   *Example:*
   `fc1.weight`
-
-
 
 ## API Reference
 

--- a/docs/source/onnx_dynamo.md
+++ b/docs/source/onnx_dynamo.md
@@ -154,28 +154,28 @@ The following metadata fields are added to each ONNX node:
   A string representing the hierarchical namespace of the node, consisting of a stack trace of modules/methods.
 
   *Example:*
-  `_empty_nn_module_stack_from_metadata_hook: _empty_nn_module_stack_from_metadata_hook/sym_size_int_720: aten.sym_size.int`
+  `__main__.SimpleAddModel/add: aten.add.Tensor`
 
 - **pkg.torch.onnx.class_hierarchy**
 
   A list of class names representing the hierarchy of modules leading to this node.
   
   *Example:*
-  `['_empty_nn_module_stack_from_metadata_hook', 'aten.sym_size.int']`
+  `['__main__.SimpleAddModel', 'aten.add.Tensor']`
 
 - **pkg.torch.onnx.fx_node**
 
   The string representation of the original FX node, including its name, number of consumers, the targeted torch op, arguments, and keyword arguments.
   
   *Example:*
-  `%sym_size_int_720 : [num_users=1] = call_function[target=torch.ops.aten.sym_size.int](args = (%img, 2), kwargs = {})`
+  `%cat : [num_users=1] = call_function[target=torch.ops.aten.cat.default](args = ([%tensor_x, %input_dict_tensor_x, %input_list_0], 1), kwargs = {})`
 
 - **pkg.torch.onnx.name_scopes**
 
   A list of name scopes (methods) representing the path to this node in the PyTorch model.
 
   *Example:*
-  `['_empty_nn_module_stack_from_metadata_hook', 'sym_size_int_720']`
+  `['', 'add']`
 
 - **pkg.torch.onnx.stack_trace**
 
@@ -183,13 +183,6 @@ The following metadata fields are added to each ONNX node:
 
   *Example:*
   `File "torch/fx/passes/runtime_assert.py", line 24, in insert_deferred_runtime_asserts`
-
-- **pkg.torch.onnx.input_names**
-
-  The inputs for a node:
-
-  *Example:*
-  `[2]`
 
 These metadata fields are stored in the metadata_props attribute of each ONNX node and can be inspected using Netron or programmatically.
 

--- a/docs/source/onnx_dynamo.md
+++ b/docs/source/onnx_dynamo.md
@@ -143,16 +143,48 @@ to resolve the issue.
 :hidden:
 onnx_dynamo_memory_usage
 ```
-
 ## Metadata
 
-The `ExportedProgram` class is a representation of a PyTorch model that has been exported to ONNX format. It contains the model's computation graph, which includes the operations performed on the input tensors, their types, and shapes. The `ExportedProgram` class consists of:
-- The `GraphModule` class, a PyTorch module that represents the exported program. It includes a `forward` method that defines the computation graph.
-  - The `forward` method inputs are defined as parameters with specific tensor types and shapes, such as "f32[8, 8]" for a float32 tensor with shape [8, 8].
-  - The operations within the `forward` method are represented as `torch.ops.aten` calls. Each operation is named (e.g., `torch.ops.aten.conv2d.default`) and includes the inputs and outputs with their respective types and shapes. 
-  - Each operation in the graph is annotated with its source file and line number, providing context for where the operation was defined in the original code (e.g., `# File: ~/python/site-packages/torch/nn/modules/conv.py:554 in forward, code: return self._conv_forward(input, self.weight, self.bias)`).
-- The `Graph signature`, which defines the input and output specifications of the model. The inputs are defined as `InputSpec` objects, which include the kind of input (e.g., `InputKind.PARAMETER` for parameters, `InputKind.USER_INPUT` for user-defined inputs), the argument name, the target (which can be a specific layer in the model), and whether the input is persistent. The outputs are defined as `OutputSpec` objects, which specify the kind of output (e.g., `OutputKind.USER_OUTPUT`) and the argument name.
-- A `Range constraints` dictionary, which specifies any constraints on the input sizes or shapes, such as `s0: VR[2, int_oo]`, indicating that the size of the input tensor can vary between 2 and infinity.
+During ONNX export, each ONNX node is annotated with metadata that helps trace its origin and context from the original PyTorch model. This metadata is useful for debugging, model inspection, and understanding the mapping between PyTorch and ONNX graphs.
+
+The following metadata fields are added to each ONNX node:
+
+- **namespace**
+
+  A string representing the hierarchical namespace of the node, consisting of a stack trace of modules/methods.
+
+  *Example:*
+  `_empty_nn_module_stack_from_metadata_hook: _empty_nn_module_stack_from_metadata_hook/sym_size_int_720: aten.sym_size.int`
+
+- **pkg.torch.onnx.class_hierarchy**
+
+  A list of class names representing the hierarchy of modules leading to this node.
+  
+  *Example:*
+  `['_empty_nn_module_stack_from_metadata_hook', 'aten.sym_size.int']`
+
+- **pkg.torch.onnx.fx_node**
+
+  The string representation of the original FX node, including its name, number of consumers, torch op, arguments, and keyword arguments.
+  
+  *Example:*
+  `%sym_size_int_720 : [num_users=1] = call_function[target=torch.ops.aten.sym_size.int](args = (%img, 2), kwargs = {})`
+
+- **pkg.torch.onnx.name_scopes**
+
+  A list of name scopes (methods) representing the path to this node in the PyTorch model.
+
+  *Example:*
+  `['_empty_nn_module_stack_from_metadata_hook', 'sym_size_int_720']`
+
+- **pkg.torch.onnx.stack_trace**
+
+  The stack trace from the original code where this node was created, if available.
+
+  *Example:*
+  `File "torch/fx/passes/runtime_assert.py", line 24, in insert_deferred_runtime_asserts`
+
+These metadata fields are stored in the metadata_props attribute of each ONNX node and can be inspected using Netron or programmatically.
 
 ## API Reference
 

--- a/docs/source/onnx_dynamo.md
+++ b/docs/source/onnx_dynamo.md
@@ -247,7 +247,7 @@ Each initializer, input, output has the following metadata:
 
 - **pkg.torch.onnx.original_node_name**
   
-  The original name of the node in the PyTorch FX graph that produced this initializer. This helps trace initializers back to their source in the original model.
+  The original name of the node in the PyTorch FX graph that produced this value. This helps trace initializers back to their source in the original model.
 
   *Example:*
   `fc1.weight`

--- a/docs/source/onnx_dynamo.md
+++ b/docs/source/onnx_dynamo.md
@@ -240,7 +240,7 @@ Each initialized value, input, output has the following metadata:
 
 - **pkg.torch.onnx.original_node_name**
   
-  The original name of the node in the PyTorch FX graph that produced this value. This helps trace initializers back to their source in the original model.
+  The original name of the node in the PyTorch FX graph that produced this value In the case where the value was renamed. This helps trace initializers back to their source in the original model.
 
   *Example:*
   `fc1.weight`

--- a/docs/source/onnx_dynamo.md
+++ b/docs/source/onnx_dynamo.md
@@ -188,7 +188,7 @@ The following metadata fields are added to each ONNX node:
 
 These metadata fields are stored in the metadata_props attribute of each ONNX node and can be inspected using Netron or programmatically.
 
-The overall ONNX IR graph has the following metadata props:
+The overall ONNX graph has the following `metadata_props`:
 
 - **pkg.torch.export.ExportedProgram.graph_signature**
 

--- a/docs/source/onnx_dynamo.md
+++ b/docs/source/onnx_dynamo.md
@@ -246,9 +246,6 @@ Each initialized value, input, output has the following metadata:
   `fc1.weight`
 
 
-  - Each operation in the graph is annotated with its source file and line number, providing context for where the operation was defined in the original code (e.g., `# File: ~/python/site-packages/torch/nn/modules/conv.py:554 in forward, code: return self._conv_forward(input, self.weight, self.bias)`).
-- The `Graph signature`, which defines the input and output specifications of the model. The inputs are defined as `InputSpec` objects, which include the kind of input (e.g., `InputKind.PARAMETER` for parameters, `InputKind.USER_INPUT` for user-defined inputs), the argument name, the target (which can be a specific layer in the model), and whether the input is persistent. The outputs are defined as `OutputSpec` objects, which specify the kind of output (e.g., `OutputKind.USER_OUTPUT`) and the argument name.
-- A `Range constraints` dictionary, which specifies any constraints on the input sizes or shapes, such as `s0: VR[2, int_oo]`, indicating that the size of the input tensor can vary between 2 and infinity.
 
 ## API Reference
 

--- a/docs/source/onnx_dynamo.md
+++ b/docs/source/onnx_dynamo.md
@@ -183,7 +183,8 @@ The following metadata fields are added to each ONNX node:
 
   *Example:*
   ```
-  File "simpleadd.py", line 7, in forward\n    return torch.add(x, y)
+  File "simpleadd.py", line 7, in forward
+      return torch.add(x, y)
   ```
 
 These metadata fields are stored in the metadata_props attribute of each ONNX node and can be inspected using Netron or programmatically.

--- a/docs/source/onnx_dynamo.md
+++ b/docs/source/onnx_dynamo.md
@@ -183,12 +183,7 @@ The following metadata fields are added to each ONNX node:
 
   *Example:*
   ```
-  File "/opt/conda/envs/ptca/lib/python3.10/site-packages/transformers/models/electra/modeling_electra.py", line 1615, in forward
-    outputs = self.electra(
-  File "/opt/conda/envs/ptca/lib/python3.10/site-packages/transformers/models/electra/modeling_electra.py", line 908, in forward
-    hidden_states = self.embeddings_project(hidden_states)
-  File "/opt/conda/envs/ptca/lib/python3.10/site-packages/torch/nn/modules/linear.py", line 125, in forward
-    return F.linear(input, self.weight, self.bias)
+  File "simpleadd.py", line 7, in forward\n    return torch.add(x, y)
   ```
 
 These metadata fields are stored in the metadata_props attribute of each ONNX node and can be inspected using Netron or programmatically.

--- a/docs/source/onnx_dynamo.md
+++ b/docs/source/onnx_dynamo.md
@@ -184,7 +184,7 @@ The following metadata fields are added to each ONNX node:
   *Example:*
   `File "torch/fx/passes/runtime_assert.py", line 24, in insert_deferred_runtime_asserts`
 
-- **"pkg.torch.onnx.input_names**
+- **pkg.torch.onnx.input_names**
 
   The inputs for a node:
 

--- a/docs/source/onnx_dynamo.md
+++ b/docs/source/onnx_dynamo.md
@@ -184,7 +184,60 @@ The following metadata fields are added to each ONNX node:
   *Example:*
   `File "torch/fx/passes/runtime_assert.py", line 24, in insert_deferred_runtime_asserts`
 
+- **"pkg.torch.onnx.input_names**
+
+  The inputs for a node:
+
+  *Example:*
+  `[2]`
+
 These metadata fields are stored in the metadata_props attribute of each ONNX node and can be inspected using Netron or programmatically.
+
+Each input value in the ONNX graph may have the following metadata property:
+
+- **pkg.torch.export.graph_signature.InputSpec.kind**
+
+  The kind of input, as defined by PyTorch's InputKind enum.
+
+  *Example values:*
+  - "USER_INPUT": A user-provided input to the model.
+  - "PARAMETER": A model parameter (e.g., weight).
+  - "BUFFER": A model buffer (e.g., running mean in BatchNorm).
+  - "CONSTANT_TENSOR": A constant tensor argument.
+  - "CUSTOM_OBJ": A custom object input.
+  - "TOKEN": A token input.
+
+- **pkg.torch.export.graph_signature.InputSpec.persistent**
+
+  Indicates whether the input is persistent (i.e., should be saved as part of the model's state).
+  
+  *Example values:*
+  - "True"
+  - "False"
+
+Each output value in the ONNX graph may have the following metadata property:
+
+- **pkg.torch.export.graph_signature.OutputSpec.kind**
+
+  The kind of input, as defined by PyTorch's OutputKind enum.
+
+  *Example values:*
+  - "USER_OUTPUT": A user-visible output.
+  - "LOSS_OUTPUT": A loss value output.
+  - "BUFFER_MUTATION": Indicates a buffer was mutated.
+  - "GRADIENT_TO_PARAMETER": Gradient output for a parameter.
+  - "GRADIENT_TO_USER_INPUT": Gradient output for a user input.
+  - "USER_INPUT_MUTATION": Indicates a user input was mutated.
+  - "TOKEN": A token output.
+
+Each initializer, input, output has the following metadata:
+
+- **pkg.torch.onnx.original_node_name**
+  
+  The original name of the node in the PyTorch FX graph that produced this initializer. This helps trace initializers back to their source in the original model.
+
+  *Example:*
+  `fc1.weight`
 
 ## API Reference
 

--- a/docs/source/onnx_dynamo.md
+++ b/docs/source/onnx_dynamo.md
@@ -252,7 +252,6 @@ Each initializer, input, output has the following metadata:
   *Example:*
   `fc1.weight`
 
-## Metadata
 
 The `ExportedProgram` class is a representation of a PyTorch model that has been exported to ONNX format. It contains the model's computation graph, which includes the operations performed on the input tensors, their types, and shapes. The `ExportedProgram` class consists of:
 - The `GraphModule` class, a PyTorch module that represents the exported program. It includes a `forward` method that defines the computation graph.

--- a/docs/source/onnx_dynamo.md
+++ b/docs/source/onnx_dynamo.md
@@ -144,6 +144,16 @@ to resolve the issue.
 onnx_dynamo_memory_usage
 ```
 
+## Metadata
+
+The `ExportedProgram` class is a representation of a PyTorch model that has been exported to ONNX format. It contains the model's computation graph, which includes the operations performed on the input tensors, their types, and shapes. The `ExportedProgram` class consists of:
+- The `GraphModule` class, a PyTorch module that represents the exported program. It includes a `forward` method that defines the computation graph.
+  - The `forward` method inputs are defined as parameters with specific tensor types and shapes, such as "f32[8, 8]" for a float32 tensor with shape [8, 8].
+  - The operations within the `forward` method are represented as `torch.ops.aten` calls. Each operation is named (e.g., `torch.ops.aten.conv2d.default`) and includes the inputs and outputs with their respective types and shapes. 
+  - Each operation in the graph is annotated with its source file and line number, providing context for where the operation was defined in the original code (e.g., `# File: ~/python/site-packages/torch/nn/modules/conv.py:554 in forward, code: return self._conv_forward(input, self.weight, self.bias)`).
+- The `Graph signature`, which defines the input and output specifications of the model. The inputs are defined as `InputSpec` objects, which include the kind of input (e.g., `InputKind.PARAMETER` for parameters, `InputKind.USER_INPUT` for user-defined inputs), the argument name, the target (which can be a specific layer in the model), and whether the input is persistent. The outputs are defined as `OutputSpec` objects, which specify the kind of output (e.g., `OutputKind.USER_OUTPUT`) and the argument name.
+- A `Range constraints` dictionary, which specifies any constraints on the input sizes or shapes, such as `s0: VR[2, int_oo]`, indicating that the size of the input tensor can vary between 2 and infinity.
+
 ## API Reference
 
 ```{eval-rst}


### PR DESCRIPTION
Describe auto-generated metadata when calling torch.onnx.export

cc @justinchuby