### PR TITLE
[a2av] Test must allocate tensors symmetrically

### DIFF
--- a/test/distributed/test_nvshmem.py
+++ b/test/distributed/test_nvshmem.py
@@ -101,14 +101,17 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinousTest):
         out_splits = torch.zeros_like(inp_splits)
         dist.all_to_all_single(out_splits, inp_splits)
         out_numel = out_splits.sum().item()
-        # Align up to make it bigger
-        align = 16
-        out_numel_max = (out_numel + align - 1) // align * align
 
-        inp = symm_mem.empty(inp_numel, dtype=dtype, device=self.device).fill_(
+        # Max number of input elements (must be a constant across ranks for symmetric memory allocation)
+        max_inp_numel = k * self.world_size
+        # Max number of output elements (must be a constant across ranks for symmetric memory allocation)
+        overflow_factor = self.world_size  # worst case: one rank receives all data
+        max_out_numel = max_inp_numel * overflow_factor
+
+        inp = symm_mem.empty(max_inp_numel, dtype=dtype, device=self.device).fill_(
             self.rank
         )
-        out = symm_mem.empty(out_numel_max, dtype=dtype, device=self.device).fill_(-1)
+        out = symm_mem.empty(max_out_numel, dtype=dtype, device=self.device).fill_(-1)
         in_out_splits = symm_mem.empty(
             (3, self.world_size), dtype=torch.int64, device=self.device
         )
@@ -131,7 +134,9 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinousTest):
 
         # Check data
         expected = torch.empty(out_numel, dtype=dtype, device=self.device)
-        dist.all_to_all_single(expected, inp, out_splits.tolist(), inp_splits.tolist())
+        dist.all_to_all_single(
+            expected, inp[:inp_numel], out_splits.tolist(), inp_splits.tolist()
+        )
         torch.testing.assert_close(out[:out_numel], expected)
 
     @skipIfRocm
@@ -145,27 +150,35 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinousTest):
 
         dtype = torch.float
         # Number of experts per rank
-        ne = 4
+        ne = 8
         nsplits = ne * self.world_size
+
         # Number of elements for an expert is random between [0, k)
-        k = 3
-        inp_splits = torch.randint(k, (nsplits,), device=self.device)
-        inp_numel = inp_splits.sum().item()
+        k = 10
+        inp_splits = torch.randint(k, (nsplits,), dtype=torch.int64, device=self.device)
+
         # Exchange input splits to get output splits
         out_splits = torch.zeros_like(inp_splits)
         dist.all_to_all_single(out_splits, inp_splits)
         # We do a .t() here because there is a rank-major to expert-major shuffle
         out_splits_t = out_splits.reshape(self.world_size, ne).t()
 
-        # Total number of output elements
+        # Actual number of input elements
+        inp_numel = inp_splits.sum().item()
+        # Actual number of output elements
         out_numel = out_splits.sum().item()
-        # Align-up makes it bigger
-        out_numel_max = (out_numel + align * ne) // align * align
+        # Max number of input elements (must be a constant across ranks for symmetric memory allocation)
+        max_inp_numel = k * nsplits
+        # Max number of output elements (must be a constant across ranks for symmetric memory allocation)
+        overflow_factor = self.world_size  # worst case: one rank receives all data
+        max_out_numel = max_inp_numel * overflow_factor
 
-        inp = symm_mem.empty(inp_numel, dtype=dtype, device=self.device).fill_(
+        inp = symm_mem.empty(max_inp_numel, dtype=dtype, device=self.device).fill_(
             self.rank
         )
-        out = symm_mem.empty(out_numel_max, dtype=dtype, device=self.device).fill_(-1)
+        out = symm_mem.empty(max_out_numel, dtype=dtype, device=self.device).fill_(-1)
+        # 3 rows: input splits, output splits, output offsets
+        # Initiallizing all values to -1 to check if they are updated
         in_out_splits = symm_mem.empty(
             (3, nsplits), dtype=torch.int64, device=self.device
         ).fill_(-1)
@@ -210,7 +223,10 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinousTest):
         inp_splits_rank = inp_splits.reshape(self.world_size, ne).sum(1)
         out_splits_rank = out_splits.reshape(self.world_size, ne).sum(1)
         dist.all_to_all_single(
-            expected, inp, out_splits_rank.tolist(), inp_splits_rank.tolist()
+            expected,
+            inp[:inp_numel],
+            out_splits_rank.tolist(),
+            inp_splits_rank.tolist(),
         )
         # We still need to shuffle `expected`
         out_offsets = torch.cumsum(out_splits, dim=0)  # inclusive scan


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #155835

This is a requirement of most SHMEM backends. Otherwise, allocations may misalign across ranks.

In this PR, we make the (total) input size and output size a constant number, even though the split sizes are created random. (Previously we sum the splits up as input size, which creates misalignment in SHMEM heap across ranks).

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k