### PR TITLE
[NCCL][P2P] Optionally avoid `recordStream`in P2P comms

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -583,8 +583,8 @@ ProcessGroupNCCL::WorkNCCL::~WorkNCCL() {
     TORCH_WARN_ONCE(
         "TORCH_NCCL_AVOID_RECORD_STREAMS=1 is experimental for point-to-point "
         "collectives. To ensure safety, .wait() must be called on all "
-	"returned handles before they fall out of scope, including for isend() "
-	"calls.");
+        "returned handles before they fall out of scope, including for isend() "
+        "calls.");
     this->wait();
   }
 }

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -580,10 +580,11 @@ ProcessGroupNCCL::WorkNCCL::WorkNCCL(const WorkNCCL& w)
 
 ProcessGroupNCCL::WorkNCCL::~WorkNCCL() {
   if (!stashed_for_allocator_safety_->empty() && isP2P_) {
-    TORCH_WARN_ONCE("TORCH_NCCL_AVOID_RECORD_STREAMS=1 is experimental for point-to-point "
-                    "collectives. To ensure safety, .wait() must be called on all "
-	            "returned handles before they fall out of scope, including for isend() "
-	            "calls.")
+    TORCH_WARN_ONCE(
+        "TORCH_NCCL_AVOID_RECORD_STREAMS=1 is experimental for point-to-point "
+        "collectives. To ensure safety, .wait() must be called on all "
+	"returned handles before they fall out of scope, including for isend() "
+	"calls.");
     this->wait();
   }
 }
@@ -4011,8 +4012,9 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::pointToPoint(
   // need stashing anymore
   if (!avoidRecordStreams_ || coalescing_state_) {
     if (avoidRecordStreams_) {
-        TORCH_WARN_ONCE("TORCH_NCCL_AVOID_RECORD_STREAMS=1 is not supported for batch P2P. "
-			"Consider switching to non-batched isend/irecv for better memory usage.");
+      TORCH_WARN_ONCE(
+          "TORCH_NCCL_AVOID_RECORD_STREAMS=1 is not supported for batch P2P. "
+          "Consider switching to non-batched isend/irecv for better memory usage.");
     }
     c10::cuda::CUDACachingAllocator::recordStream(
         tensor.storage().data_ptr(), ncclStream);

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -328,7 +328,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
     // destructs outputs_ tensors who are view tensors in autograd graph.
     WorkNCCL(const WorkNCCL& w);
 
-    ~WorkNCCL();
+    ~WorkNCCL() override;
 
     // Checks if the NCCL kernel has started to execute.
     bool isStarted();

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -328,7 +328,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
     // destructs outputs_ tensors who are view tensors in autograd graph.
     WorkNCCL(const WorkNCCL& w);
 
-    ~WorkNCCL() override = default;
+    ~WorkNCCL();
 
     // Checks if the NCCL kernel has started to execute.
     bool isStarted();


### PR DESCRIPTION
In theory this should also be possible with the Batched/Coalesced case but I don't quite remember the path to that as discussed with @kwen2501 previously

Perhaps the more relevant question is why we cannot use the `currentStream` by default as is done for many other operations---if we remove the need to stash then it would mean batched p2p would also benefit from no `recordStream`s.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta