### PR TITLE
Remove non-header-only dep from c10_headers target

### DIFF
--- a/c10/build.bzl
+++ b/c10/build.bzl
@@ -30,7 +30,6 @@ def define_targets(rules):
             "//c10/macros",
             "//c10/util:base_headers",
             "//c10/util:bit_cast",
-            "//c10/util:ssize",
         ],
         visibility = ["//visibility:public"],
     )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #155858

It depends on /c10/util:base which is not header-only.

Differential Revision: [D76552750](https://our.internmc.facebook.com/intern/diff/D76552750/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D76552750/)!