### PR TITLE
assume sparse tensor not coalesced_ gsv -> guard_or_false.

### DIFF
--- a/aten/src/ATen/SparseTensorImpl.cpp
+++ b/aten/src/ATen/SparseTensorImpl.cpp
@@ -108,7 +108,7 @@ void SparseTensorImpl::set_indices_and_values_unsafe(const Tensor& indices, cons
   AT_ASSERT(device() == values_.device());
   AT_ASSERT(values_.device() == indices_.device());
 
-  coalesced_ = TORCH_GUARD_SIZE_OBLIVIOUS(sym_nnz().sym_lt(2));
+  coalesced_ = TORCH_GUARD_OR_FALSE(sym_nnz().sym_lt(2));
 }
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #155869

preserve current behavior. Generalize it such that no need for torch._check_is_size to opt into this, 
and make it work for more complex unbacked sizes with ranges [-inf, inf]