### PR TITLE
Add__int__ and __float__ methods to _sympy.functions.Identity

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2165,14 +2165,14 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
         model = MyModel().to("cuda")
         input_tensor = GetInput().to("cuda")
 
-        compile_default = torch.compile(model, mode="default")
+        # compile_default = torch.compile(model, mode="default")
         compile_max_autotune = torch.compile(model, mode="max-autotune")
 
-        with torch.no_grad():
-            default_output = compile_default(input_tensor)
-            max_autotune_output = compile_max_autotune(input_tensor)
+        # with torch.no_grad():
+            # default_output = compile_default(input_tensor)
+        max_autotune_output = compile_max_autotune(input_tensor)
 
-        self.assertEqual(default_output, max_autotune_output)
+        # self.assertEqual(default_output, max_autotune_output)
 
     
 

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2128,13 +2128,14 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
         """
         https://github.com/pytorch/pytorch/issues/155688
         Smallest repro for max-autotune not working with no_grad
-        Before adding __int__ function to torch.utils._sympy.functions.Identity, 
+        Before adding __int__ function to torch.utils._sympy.functions.Identity,
         running the max_autotune mode would raise an error:
         TypeError: Expected a number but got Identity
         """
+
         class ToyModel(torch.nn.Module):
             def __init__(self):
-                super(ToyModel, self).__init__()
+                super().__init__()
 
                 self.linear_layers = nn.ModuleList(
                     [
@@ -2154,7 +2155,6 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
 
                 return x
 
-
         model = ToyModel().to("cuda")
         input_tensor = torch.randn((2, 4)).to("cuda")
 
@@ -2166,8 +2166,6 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
             max_autotune_output = compile_max_autotune(input_tensor)
 
         self.assertEqual(default_output, max_autotune_output)
-
-    
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -9,7 +9,6 @@ import sys
 import unittest
 
 import torch
-import torch.utils.checkpoint as checkpoint
 import torch._dynamo.config as dynamo_config
 import torch.backends.cuda
 import torch.nn.functional as F

--- a/test/test_sympy_utils.py
+++ b/test/test_sympy_utils.py
@@ -37,6 +37,7 @@ from torch.utils._sympy.singleton_int import SingletonInt
 from torch.utils._sympy.solve import INEQUALITY_TYPES, mirror_rel_op, try_solve
 from torch.utils._sympy.value_ranges import ValueRanges
 from torch._inductor.bounds import ValueRangeAnalysis
+from torch._inductor.index_propagation import TypedExpr
 
 
 UNARY_OPS = [
@@ -988,6 +989,11 @@ class TestIdentity(TestCase):
         self.assertRaises(TypeError, int, tup_I)
         self.assertRaises(TypeError, float, tup_I)
 
+class TestTypedExpr(TestCase):
+    def test_typed_expr(self):
+        I = Identity(1)
+        typed_I = TypedExpr(I, torch.int32)
+        self.assertEqual(typed_I.expr, 1)
 
 
 instantiate_parametrized_tests(TestValueRanges)

--- a/test/test_sympy_utils.py
+++ b/test/test_sympy_utils.py
@@ -968,6 +968,22 @@ class TestIdentity(TestCase):
         self.assertEqual(expanded.count(Identity), 0)
         self.assertEqual(expanded, arg)
 
+    def test_cast_identity_int(self):
+        num = 1
+        expr = Identity(num)
+        self.assertEqual(num, int(expr))
+    
+    def test_cast_identity_float(self):
+        num = 1.1
+        expr = Identity(num)
+        self.assertEqual(num, float(expr))
+
+    def test_cast_identity_bool(self):
+        num = True
+        expr = Identity(num)
+        self.assertEqual(num, bool(expr))
+
+
 instantiate_parametrized_tests(TestValueRanges)
 instantiate_parametrized_tests(TestSympyInterp)
 instantiate_parametrized_tests(TestSympySolve)

--- a/test/test_sympy_utils.py
+++ b/test/test_sympy_utils.py
@@ -38,6 +38,7 @@ from torch.utils._sympy.solve import INEQUALITY_TYPES, mirror_rel_op, try_solve
 from torch.utils._sympy.value_ranges import ValueRanges
 from torch._inductor.bounds import ValueRangeAnalysis
 
+
 UNARY_OPS = [
     "reciprocal",
     "square",

--- a/test/test_sympy_utils.py
+++ b/test/test_sympy_utils.py
@@ -38,7 +38,6 @@ from torch.utils._sympy.solve import INEQUALITY_TYPES, mirror_rel_op, try_solve
 from torch.utils._sympy.value_ranges import ValueRanges
 from torch._inductor.bounds import ValueRangeAnalysis
 
-
 UNARY_OPS = [
     "reciprocal",
     "square",
@@ -972,16 +971,22 @@ class TestIdentity(TestCase):
         num = 1
         expr = Identity(num)
         self.assertEqual(num, int(expr))
-    
+
     def test_cast_identity_float(self):
         num = 1.1
         expr = Identity(num)
         self.assertEqual(num, float(expr))
 
-    def test_cast_identity_bool(self):
-        num = True
-        expr = Identity(num)
-        self.assertEqual(num, bool(expr))
+    def test_cast_identity_illegal(self):
+        sym = Identity(sympy.Symbol("x"))
+        self.assertRaises(TypeError, int, sym)
+        self.assertRaises(TypeError, float, sym)
+
+        tup = (0, 1, 2)
+        tup_I = Identity(tup)
+        self.assertRaises(TypeError, int, tup_I)
+        self.assertRaises(TypeError, float, tup_I)
+
 
 
 instantiate_parametrized_tests(TestValueRanges)

--- a/torch/_inductor/index_propagation.py
+++ b/torch/_inductor/index_propagation.py
@@ -31,7 +31,7 @@ import sympy
 
 import torch
 from torch._prims_common import dtype_to_type, is_integer_dtype
-from torch.utils._sympy.functions import FloorDiv, ModularIndexing, Where
+from torch.utils._sympy.functions import FloorDiv, ModularIndexing, Where, Identity
 from torch.utils._sympy.value_ranges import bound_sympy, ValueRanges
 
 from .ops_handler import DefaultHandler
@@ -65,7 +65,11 @@ class TypedExpr:
 
     def __post_init__(self):
         if _is_constant(self.expr):
-            self.expr = dtype_to_type(self.dtype)(self.expr)
+            if isinstance(self.expr, Identity):
+                wrapped_value = self.expr.args[0]
+                self.expr = dtype_to_type(self.dtype)(wrapped_value)
+            else:
+                self.expr = dtype_to_type(self.dtype)(self.expr)
 
 
 class SymPyOps:

--- a/torch/_inductor/index_propagation.py
+++ b/torch/_inductor/index_propagation.py
@@ -31,7 +31,7 @@ import sympy
 
 import torch
 from torch._prims_common import dtype_to_type, is_integer_dtype
-from torch.utils._sympy.functions import FloorDiv, ModularIndexing, Where, Identity
+from torch.utils._sympy.functions import FloorDiv, ModularIndexing, Where
 from torch.utils._sympy.value_ranges import bound_sympy, ValueRanges
 
 from .ops_handler import DefaultHandler
@@ -65,11 +65,7 @@ class TypedExpr:
 
     def __post_init__(self):
         if _is_constant(self.expr):
-            if isinstance(self.expr, Identity):
-                wrapped_value = self.expr.args[0]
-                self.expr = dtype_to_type(self.dtype)(wrapped_value)
-            else:
-                self.expr = dtype_to_type(self.dtype)(self.expr)
+            self.expr = dtype_to_type(self.dtype)(self.expr)
 
 
 class SymPyOps:

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -1300,6 +1300,15 @@ class Identity(sympy.Function):
         # Removes the identity op.
         return self.args[0]
 
+    def __int__(self):
+        return int(self.args[0])
+
+    def __float__(self):
+        return float(self.args[0])
+
+    def __bool__(self):
+        return bool(self.args[0])
+
 
 def make_opaque_unary_fn(name):
     class OpaqueUnaryFn(sympy.Function):

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -1306,9 +1306,6 @@ class Identity(sympy.Function):
     def __float__(self):
         return float(self.args[0])
 
-    def __bool__(self):
-        return bool(self.args[0])
-
 
 def make_opaque_unary_fn(name):
     class OpaqueUnaryFn(sympy.Function):

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -1300,10 +1300,10 @@ class Identity(sympy.Function):
         # Removes the identity op.
         return self.args[0]
 
-    def __int__(self):
+    def __int__(self) -> int:
         return int(self.args[0])
 
-    def __float__(self):
+    def __float__(self) -> float:
         return float(self.args[0])
 
 


### PR DESCRIPTION
Fixes #155688

Root Cause:
in [`torch/_inductor/index_propagation.py`](https://github.com/pytorch/pytorch/blob/f151b201236f959e3874b73dde9bfae5e10dae78/torch/_inductor/index_propagation.py#L57-L68)
When creating a `TypedExpr` from an `Identity` (a `torch.utils._sympy.functions.Identity`, not a `sympy.matrices.expressions.Identity `) and the inner value of the identity, `Identity.args[0]`, is any torch int type, the `TypedExpr.__post_init__` method tries to cast the Identity object to a python `int`.  This is where to `TypeError` from the issue was raised, because Identity does not know how to cast to an `int`.

Fix:
Define `__int__` method for `torch.utils._sympy.functions.Identity`. 
wlog for `float`


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov