### PR TITLE
test without rocblas conv when using cudagraphs

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -3631,11 +3631,11 @@ def run(runner, args, original_dir=None):
 
             if torch.version.hip:
                 # rocm has cudagraph problems with rocblas gemm-based convs
-                os.environ['MIOPEN_DEBUG_CONV_FFT'] = '0'           # N/A?
-                os.environ['MIOPEN_DEBUG_CONV_DIRECT'] = '1'        # PASS  
+                # os.environ['MIOPEN_DEBUG_CONV_FFT'] = '0'           # N/A?
+                # os.environ['MIOPEN_DEBUG_CONV_DIRECT'] = '1'        # PASS  
                 os.environ['MIOPEN_DEBUG_CONV_GEMM'] = '0'          # FAILS: numerical errors between normal run and cudagraph replay
-                os.environ['MIOPEN_DEBUG_CONV_WINOGRAD'] = '0'      # PASS
-                os.environ['MIOPEN_DEBUG_CONV_IMPLICIT_GEMM'] = '0' # N/A?
+                # os.environ['MIOPEN_DEBUG_CONV_WINOGRAD'] = '0'      # PASS
+                # os.environ['MIOPEN_DEBUG_CONV_IMPLICIT_GEMM'] = '0' # N/A?
 
 
     if args.device_index is not None:

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -100,7 +100,6 @@ disable_output = False
 
 MAX_DOWNLOAD_ATTEMPTS = 5
 
-
 class CI(NamedTuple):
     backend: str  # aot_eager or inductor
     training: bool
@@ -3629,6 +3628,15 @@ def run(runner, args, original_dir=None):
                     "cm3leon_generate",
                 }
             )
+
+            if torch.version.hip:
+                # rocm has cudagraph problems with rocblas gemm-based convs
+                os.environ['MIOPEN_DEBUG_CONV_FFT'] = '0'           # N/A?
+                os.environ['MIOPEN_DEBUG_CONV_DIRECT'] = '1'        # PASS  
+                os.environ['MIOPEN_DEBUG_CONV_GEMM'] = '0'          # FAILS: numerical errors between normal run and cudagraph replay
+                os.environ['MIOPEN_DEBUG_CONV_WINOGRAD'] = '0'      # PASS
+                os.environ['MIOPEN_DEBUG_CONV_IMPLICIT_GEMM'] = '0' # N/A?
+
 
     if args.device_index is not None:
         if args.multiprocess:


### PR DESCRIPTION
for testing torchinductor dashboard when disabling blas gemm convolutions



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela