### PR TITLE
Update test_schedule_multiproc to use world_size=2

### DIFF
--- a/test/distributed/pipelining/test_schedule_multiproc.py
+++ b/test/distributed/pipelining/test_schedule_multiproc.py
@@ -44,13 +44,13 @@ logger = logging.getLogger(__name__)
 
 d_hid = 512
 batch_size = 256
-
 torch.manual_seed(0)
-
 device_type = "cuda"
 
 
 class ScheduleTest(MultiProcContinousTest):
+    world_size = 2
+
     @classmethod
     def backend_str(cls) -> str:
         # Testing with NCCL backend
@@ -519,9 +519,7 @@ class ScheduleTest(MultiProcContinousTest):
                     raise
 
     @requires_nccl()
-    @skip_but_pass_in_sandcastle_if(
-        not torch.cuda.device_count() == 2, "This test requires exactly 2 GPUs"
-    )
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     @parametrize("ScheduleClass", [ScheduleWithW, ScheduleInterleavedZeroBubble])
     def test_schedule_with_native_zero_bubble(self, ScheduleClass):
         print(ScheduleClass)
@@ -615,9 +613,7 @@ class ScheduleTest(MultiProcContinousTest):
                     raise
 
     @requires_nccl()
-    @skip_but_pass_in_sandcastle_if(
-        not torch.cuda.device_count() == 2, "This test requires exactly 2 GPUs"
-    )
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     @parametrize(
         "ScheduleClass",
         [
@@ -722,9 +718,7 @@ class ScheduleTest(MultiProcContinousTest):
                     raise
 
     @requires_nccl()
-    @skip_but_pass_in_sandcastle_if(
-        not torch.cuda.device_count() == 2, "This test requires exactly 2 GPUs"
-    )
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     @parametrize(
         "schedule_class", [ScheduleVShaped, ScheduleUnbalanced, ScheduleZBVZeroBubble]
     )
@@ -829,9 +823,7 @@ class ScheduleTest(MultiProcContinousTest):
                     raise
 
     @requires_nccl()
-    @skip_but_pass_in_sandcastle_if(
-        not torch.cuda.device_count() == 2, "This test requires exactly 2 GPUs"
-    )
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     @parametrize("ScheduleClass", [ScheduleInterleavedZeroBubble])
     def test_schedule_with_weight_update_mlp_e2e(self, ScheduleClass):
         stages_per_rank = 2


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #155921
* #155920

The multiproc schedule tests previously ran with world_size=2, and PP tests became flakier due to the longer pipeline execution, this is restoring previously behavior. This will fix the tests (https://github.com/pytorch/pytorch/issues/154373, https://github.com/pytorch/pytorch/issues/154391, https://github.com/pytorch/pytorch/issues/154408, https://github.com/pytorch/pytorch/issues/154443, https://github.com/pytorch/pytorch/issues/154481

In follow up PRs I will refactor the tests and move some tests to use large world sizes.

cc @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k