### PR TITLE
Fix argument validation for torch.nn.attention.sdpa_kernel

### DIFF
--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -11,10 +11,13 @@ from torch._dynamo.exc import InternalTorchDynamoError
 from torch._dynamo.testing import EagerAndRecordGraphs, normalize_gm, same
 from torch._dynamo.utils import counters
 from torch.nn import functional as F
+from torch.nn.attention import sdpa_kernel, SDPBackend
+from torch.nn.functional import scaled_dot_product_attention
 from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FLASH_ATTENTION
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
+    subtest,
 )
 
 
@@ -1748,6 +1751,58 @@ class GraphModule(torch.nn.Module):
         res = opt_fn(x)
         self.assertEqual(ref, res)
         self.assertEqual(len(counters["graph_break"]), 1)
+
+    @parametrize(
+        "sdpa_args,sdpa_kwargs",
+        [
+            subtest(([[SDPBackend.CUDNN_ATTENTION, SDPBackend.MATH]], {}), name="1_0"),
+            subtest(
+                ([[SDPBackend.CUDNN_ATTENTION, SDPBackend.MATH], True], {}), name="2_0"
+            ),
+            subtest(
+                (
+                    [[SDPBackend.CUDNN_ATTENTION, SDPBackend.MATH]],
+                    {"set_priority": True},
+                ),
+                name="1_1",
+            ),
+            subtest(
+                ([], {"backends": [SDPBackend.CUDNN_ATTENTION, SDPBackend.MATH]}),
+                name="0_1",
+            ),
+            subtest(
+                (
+                    [],
+                    {
+                        "backends": [SDPBackend.CUDNN_ATTENTION, SDPBackend.MATH],
+                        "set_priority": True,
+                    },
+                ),
+                name="0_2",
+            ),
+        ],
+        name_fn=lambda sdpa_args, sdpa_kwargs: f"{sdpa_args}_{sdpa_kwargs}",
+    )
+    def test_sdpa_kernel_ctx_manager_params(
+        self, sdpa_args: list, sdpa_kwargs: dict
+    ) -> None:
+        """
+        Test the sdpa_kernel context manager with all different legal combinations of arguments.
+        """
+
+        class Model(torch.nn.Module):
+            def forward(self, q, k, v, mask):
+                with sdpa_kernel(*sdpa_args, **sdpa_kwargs):
+                    out = scaled_dot_product_attention(q, k, v, attn_mask=mask)
+                return out
+
+        device = torch.device("cuda")
+        model = Model().to(device)
+
+        q = k = v = torch.randn(2, 4, 16, device=device)
+        m = None
+        model = torch.compile(model, backend="eager")
+        model(q, k, v, m)
 
 
 class ContextlibContextManagerTests(torch._dynamo.test_case.TestCase):

--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -17,7 +17,6 @@ from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FLASH_ATTENTIO
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
-    subtest,
 )
 
 
@@ -1752,47 +1751,17 @@ class GraphModule(torch.nn.Module):
         self.assertEqual(ref, res)
         self.assertEqual(len(counters["graph_break"]), 1)
 
-    @parametrize(
-        "sdpa_args,sdpa_kwargs",
-        [
-            subtest(([[SDPBackend.CUDNN_ATTENTION, SDPBackend.MATH]], {}), name="1_0"),
-            subtest(
-                ([[SDPBackend.CUDNN_ATTENTION, SDPBackend.MATH], True], {}), name="2_0"
-            ),
-            subtest(
-                (
-                    [[SDPBackend.CUDNN_ATTENTION, SDPBackend.MATH]],
-                    {"set_priority": True},
-                ),
-                name="1_1",
-            ),
-            subtest(
-                ([], {"backends": [SDPBackend.CUDNN_ATTENTION, SDPBackend.MATH]}),
-                name="0_1",
-            ),
-            subtest(
-                (
-                    [],
-                    {
-                        "backends": [SDPBackend.CUDNN_ATTENTION, SDPBackend.MATH],
-                        "set_priority": True,
-                    },
-                ),
-                name="0_2",
-            ),
-        ],
-        name_fn=lambda sdpa_args, sdpa_kwargs: f"{sdpa_args}_{sdpa_kwargs}",
-    )
-    def test_sdpa_kernel_ctx_manager_params(
-        self, sdpa_args: list, sdpa_kwargs: dict
-    ) -> None:
+    def test_sdpa_kernel_ctx_manager_params(self) -> None:
         """
-        Test the sdpa_kernel context manager with all different legal combinations of arguments.
+        Test the sdpa_kernel context manager with set_priority=True.
         """
 
         class Model(torch.nn.Module):
             def forward(self, q, k, v, mask):
-                with sdpa_kernel(*sdpa_args, **sdpa_kwargs):
+                with sdpa_kernel(
+                    [SDPBackend.CUDNN_ATTENTION, SDPBackend.MATH],
+                    set_priority=True,
+                ):
                     out = scaled_dot_product_attention(q, k, v, attn_mask=mask)
                 return out
 

--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -1751,6 +1751,7 @@ class GraphModule(torch.nn.Module):
         self.assertEqual(ref, res)
         self.assertEqual(len(counters["graph_break"]), 1)
 
+    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
     def test_sdpa_kernel_ctx_manager_params(self) -> None:
         """
         Test the sdpa_kernel context manager with set_priority=True.

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2124,28 +2124,6 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
         out_compiled = torch.compile(interpolate_chunked)(x)
         self.assertEqual(out_eager, out_compiled)
 
-    def test_sdpa_set_priority(self):
-        from torch.nn.attention import sdpa_kernel, SDPBackend
-        from torch.nn.functional import scaled_dot_product_attention
-
-        class Model(torch.nn.Module):
-            def forward(self, q, k, v, mask):
-                with sdpa_kernel(
-                    backends=[SDPBackend.CUDNN_ATTENTION, SDPBackend.MATH],
-                    set_priority=True,
-                ):
-                    out = scaled_dot_product_attention(q, k, v, m)
-                return out
-
-        device = torch.device("cuda")
-        # device = torch.device('cpu')
-        model = Model().to(device)
-
-        q = k = v = torch.randn(2, 4, 16, device=device)
-        m = None
-        model = torch.compile(model, backend="eager")
-        model(q, k, v, m)
-
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2123,17 +2123,21 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
         out_eager = interpolate_chunked(x)
         out_compiled = torch.compile(interpolate_chunked)(x)
         self.assertEqual(out_eager, out_compiled)
-    
+
     def test_sdpa_set_priority(self):
+        from torch.nn.attention import sdpa_kernel, SDPBackend
         from torch.nn.functional import scaled_dot_product_attention
-        from torch.nn.attention import SDPBackend, sdpa_kernel
+
         class Model(torch.nn.Module):
             def forward(self, q, k, v, mask):
-                with sdpa_kernel(backends=[SDPBackend.CUDNN_ATTENTION, SDPBackend.MATH], set_priority=True):
-                    out = scaled_dot_product_attention(q,k,v,m)
+                with sdpa_kernel(
+                    backends=[SDPBackend.CUDNN_ATTENTION, SDPBackend.MATH],
+                    set_priority=True,
+                ):
+                    out = scaled_dot_product_attention(q, k, v, m)
                 return out
 
-        device = torch.device('cuda')
+        device = torch.device("cuda")
         # device = torch.device('cpu')
         model = Model().to(device)
 

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -408,14 +408,18 @@ class TorchCtxManagerClassVariable(BaseTorchVariable):
                 }
             elif len(args) == 1:
                 assert len(kwargs) == 0 or (
-                    len(kwargs) == 1 and kwargs.keys() == {"backends"}
+                    len(kwargs) == 1 and kwargs.keys() == {"set_priority"}
                 )
             else:
                 assert len(kwargs) == 0
 
             backends = args[0] if len(args) > 0 else kwargs["backends"]
             set_priority = (
-                args[1] if len(args) > 1 else kwargs.get("set_priority", False)
+                args[1]
+                if len(args) > 1
+                else kwargs["set_priority"]
+                if "set_priority" in kwargs
+                else False
             )
 
             return SDPAKernelVariable.create(

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -400,9 +400,24 @@ class TorchCtxManagerClassVariable(BaseTorchVariable):
                 tx, args[0], args[1].as_python_constant()
             )
         elif self.value is torch.nn.attention.sdpa_kernel:
-            assert len(args) == 1 or (len(kwargs) == 1 and "backends" in kwargs)
-            backends = args[0] if len(args) == 1 else kwargs["backends"]
-            set_priority = kwargs["set_priority"] if "set_priority" in kwargs else False
+            assert 0 <= len(args) <= 2
+            if len(args) == 0:
+                assert kwargs.keys() == {"backends"} or kwargs.keys() == {
+                    "backends",
+                    "set_priority",
+                }
+            elif len(args) == 1:
+                assert len(kwargs) == 0 or (
+                    len(kwargs) == 1 and kwargs.keys() == {"backends"}
+                )
+            else:
+                assert len(kwargs) == 0
+
+            backends = args[0] if len(args) > 0 else kwargs["backends"]
+            set_priority = (
+                args[1] if len(args) > 1 else kwargs.get("set_priority", False)
+            )
+
             return SDPAKernelVariable.create(
                 tx, backends.as_python_constant(), set_priority
             )

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -403,13 +403,14 @@ class TorchCtxManagerClassVariable(BaseTorchVariable):
             sig = inspect.signature(torch.nn.attention.sdpa_kernel)
             try:
                 bound_args = sig.bind(*args, **kwargs)
-                bound_args.apply_defaults()
+                if "set_priority" not in bound_args.arguments:
+                    bound_args.arguments["set_priority"] = False
             except TypeError as e:
                 unimplemented_v2(
                     gb_type="Invalid arguments to sdpa_kernel",
                     context="",
                     explanation=str(e),
-                    hints=[*graph_break_hints.FUNDAMENTAL],
+                    hints=[*graph_break_hints.USER_ERROR],
                 )
 
             backends = bound_args.arguments["backends"]

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -408,7 +408,7 @@ class TorchCtxManagerClassVariable(BaseTorchVariable):
                 unimplemented_v2(
                     gb_type="Invalid arguments to sdpa_kernel",
                     context="",
-                    explanation="Invalid arguments to sdpa_kernel",
+                    explanation=str(e),
                     hints=[*graph_break_hints.FUNDAMENTAL],
                 )
 

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -404,7 +404,9 @@ class TorchCtxManagerClassVariable(BaseTorchVariable):
             try:
                 bound_args = sig.bind(*args, **kwargs)
                 if "set_priority" not in bound_args.arguments:
-                    bound_args.arguments["set_priority"] = sig.parameters["set_priority"].default
+                    bound_args.arguments["set_priority"] = sig.parameters[
+                        "set_priority"
+                    ].default
             except TypeError as e:
                 unimplemented_v2(
                     gb_type="Invalid arguments to sdpa_kernel",

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -405,7 +405,12 @@ class TorchCtxManagerClassVariable(BaseTorchVariable):
                 bound_args = sig.bind(*args, **kwargs)
                 bound_args.apply_defaults()
             except TypeError as e:
-                raise AssertionError("Invalid arguments to sdpa_kernel") from e
+                unimplemented_v2(
+                    gb_type="Invalid arguments to sdpa_kernel",
+                    context="",
+                    explanation="Invalid arguments to sdpa_kernel",
+                    hints=[*graph_break_hints.FUNDAMENTAL],
+                )
 
             backends = bound_args.arguments["backends"]
             set_priority = bound_args.arguments["set_priority"]

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -404,7 +404,7 @@ class TorchCtxManagerClassVariable(BaseTorchVariable):
             try:
                 bound_args = sig.bind(*args, **kwargs)
                 if "set_priority" not in bound_args.arguments:
-                    bound_args.arguments["set_priority"] = False
+                    bound_args.arguments["set_priority"] = sig.parameters["set_priority"].default
             except TypeError as e:
                 unimplemented_v2(
                     gb_type="Invalid arguments to sdpa_kernel",


### PR DESCRIPTION
Fixes #155898

[torch.nn.attention.sdpa_kernel](https://github.com/pytorch/pytorch/blob/fdf5d97fa8393f56aea2779877efd8a264ad5811/torch/_dynamo/variables/torch.py#L402-L408)
Parameter validation was too strict. Updated to accept all argument patterns which are legal. 

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @Lucaskabela