### PR TITLE
remove duplicated pybind flag in mps code

### DIFF
--- a/torch/csrc/mps/Module.cpp
+++ b/torch/csrc/mps/Module.cpp
@@ -1,5 +1,3 @@
-#define PYBIND11_DETAILED_ERROR_MESSAGES
-
 #include <ATen/ATen.h>
 #include <pybind11/pytypes.h>
 #include <torch/csrc/Generator.h>


### PR DESCRIPTION
gcc14 (at least) warns that this is already defined