### PR TITLE
Fix stride comparison max(512 - s, 1) vs. (512 - s)

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -474,6 +474,10 @@ def try_match_insignificant_strides(
 
     if all(
         V.graph.sizevars.statically_known_equals(s1, s2)
+        or (
+            V.graph.sizevars.statically_known_true(sympy.Ne(s1, 0))
+            and V.graph.sizevars.statically_known_equals(sympy.Max(1, s1), s2)
+        )
         for s1, s2 in zip(strides, tensor.get_stride())
     ):
         return tensor  # type: ignore[arg-type]


### PR DESCRIPTION
Summary: The stride comparison: [512 - s16, 1] vs . [Max(1, 512 - s16), 1] is not considered as equal so that a new buffer is created that later causes a inductor failure. When forcing this comparison to be equal, everything works.

Test Plan:
CI

Rollback Plan:

Differential Revision: D76108791


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben