### PR TITLE
[cutlass backend][forward fix] use _cuda_compiler path to check if nvcc exists

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -159,7 +159,7 @@ def use_re_build() -> bool:
     """
     Use for CUTLASS compilation only right now.
     """
-    if config.is_fbcode() and not cuda_env.nvcc_exist():
+    if config.is_fbcode() and not cuda_env.nvcc_exist(_cuda_compiler()):
         from triton.fb.re_build_helper import should_build_locally
 
         return not should_build_locally()


### PR DESCRIPTION
Differential Revision: D76571828


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov