### PR TITLE
[SymmMem] Remove wrappers around nvshmem APIs

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cu
@@ -73,14 +73,6 @@ void initialize_nvshmem_with_store(
   is_initialized = true;
 }
 
-void* nvshmem_malloc(size_t size) {
-  return ::nvshmem_malloc(size);
-}
-
-void* nvshmem_ptr(const void* dest, int pe) {
-  return ::nvshmem_ptr(dest, pe);
-}
-
 // Intializes the device state in CUmodule so that it’s able to perform NVSHMEM
 // operations.
 void nvshmemx_cumodule_init(uintptr_t module) {

--- a/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cuh
+++ b/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cuh
@@ -11,10 +11,6 @@ void initialize_nvshmem_with_store(
     int rank,
     int world_size);
 
-void* nvshmem_malloc(size_t size);
-
-void* nvshmem_ptr(const void* dest, int pe);
-
 // Intializes the device state in CUmodule so that it’s able to perform NVSHMEM
 // operations.
 TORCH_API void nvshmemx_cumodule_init(uintptr_t module);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #155975
* __->__ #155971
* #155968

`NVSHMEMSymmetricMemory.cu` and `nvshmem_extension.cu` are under the same compilation condition now (i.e. only when `USE_NVSHMEM=True`), see https://github.com/pytorch/pytorch/blob/main/caffe2/CMakeLists.txt#L1013-L1018.

Therefore there is no need to build an extra layer to hide dependency.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k