### PR TITLE
[BE] Better uv detection in `pip init`

### DIFF
--- a/tools/linter/adapters/pip_init.py
+++ b/tools/linter/adapters/pip_init.py
@@ -52,7 +52,10 @@ if __name__ == "__main__":
         stream=sys.stderr,
     )
 
-    uv_available = shutil.which("uv") is not None
+    uv_available = (
+        any(prefix in sys.base_prefix for prefix in ["uv/python", "uv\\python"])
+        and shutil.which("uv") is not None
+    )
 
     if uv_available:
         pip_args = ["uv", "pip", "install"]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #155972

If one has some UV and non-UV environments locally, one shoudl call `uv
pip install` only on the UV-enabled ones, which could be detected by
checking if `uv/python` path is present in `sys.base_prefix`

Fixes https://github.com/pytorch/pytorch/issues/152999