### PR TITLE
Allow as_tensor to retain grad info

### DIFF
--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -4171,6 +4171,13 @@ class TestAsArray(TestCase):
             t = torch.asarray(e)
             self.assertEqual(t, original)
 
+    @onlyCPU
+    def test_as_tensor_retains_autograd_history(self):
+        a = torch.tensor(1.0, requires_grad=True)
+        b = torch.tensor(2.0, requires_grad=True)
+        t_as_tensor = torch.as_tensor([a, b])
+        self.assertNotEqual(t_as_tensor.grad_fn, None)
+
     # Dynamo changes numpy scalar to array, thus skips the asserted error.
     @xfailIfTorchDynamo
     @onlyCPU

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -1313,7 +1313,7 @@ Tensor sparse_coo_tensor_ctor(
         inferred_options,
         inferred_scalar_type,
         deviceOptional,
-        r.pyobject(ARG_VALUES),
+        r.pyobject(ARG_VALUES1),
         /*copy_variables=*/false,
         /*copy_numpy=*/true,
         /*type_inference=*/type_inference);
@@ -1322,7 +1322,7 @@ Tensor sparse_coo_tensor_ctor(
         values.options(),
         kLong,
         deviceOptional,
-        r.pyobject(ARG_INDICES),
+        r.pyobject(ARG_INDICES1),
         /*copy_variables=*/false,
         /*copy_numpy=*/true,
         /*type_inference=*/false);

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -301,7 +301,7 @@ std::optional<Tensor> try_create_from_tensor_sequence(
       return std::nullopt;
     }
 
-    tensors.push_back(tensor);
+    tensors.emplace_back(std::move(tensor));
   }
 
   at::Tensor result;
@@ -412,8 +412,9 @@ Tensor internal_new_from_data(
 
   if (PyObject_HasAttrString(data, "__dlpack__")) {
     py::object tensor_o =
-        py::module::import("torch").attr("utils").attr("dlpack").attr(
-            "from_dlpack")(py::handle(data));
+        py::module::import("torch").attr("utils").attr(
+            "dlpack")
+            .attr("from_dlpack")(py::handle(data));
     Tensor tensor = py::cast<Tensor>(tensor_o);
     const auto& inferred_scalar_type =
         type_inference ? tensor.scalar_type() : scalar_type;
@@ -1313,7 +1314,7 @@ Tensor sparse_coo_tensor_ctor(
         inferred_options,
         inferred_scalar_type,
         deviceOptional,
-        r.pyobject(ARG_VALUES1),
+        r.pyobject(ARG_VALUES),
         /*copy_variables=*/false,
         /*copy_numpy=*/true,
         /*type_inference=*/type_inference);
@@ -1322,7 +1323,7 @@ Tensor sparse_coo_tensor_ctor(
         values.options(),
         kLong,
         deviceOptional,
-        r.pyobject(ARG_INDICES1),
+        r.pyobject(ARG_INDICES),
         /*copy_variables=*/false,
         /*copy_numpy=*/true,
         /*type_inference=*/false);

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -9,6 +9,7 @@
 #include <torch/csrc/autograd/variable.h>
 #include <torch/csrc/utils/device_lazy_init.h>
 #include <torch/csrc/utils/numpy_stub.h>
+#include <torch/csrc/utils/object_ptr.h>
 #include <torch/csrc/utils/pybind.h>
 #include <torch/csrc/utils/python_arg_parser.h>
 #include <torch/csrc/utils/python_numbers.h>
@@ -263,6 +264,70 @@ void recursive_store(
   }
 }
 
+// Helper function to detect and handle homogeneous tensor sequences
+// Returns nullopt if the sequence is not homogeneous tensors
+std::optional<Tensor> try_create_from_tensor_sequence(
+    PyObject* data,
+    at::ScalarType scalar_type,
+    std::optional<Device> device_opt,
+    bool type_inference,
+    bool copy_variables) {
+  if (!PySequence_Check(data)) {
+    return std::nullopt;
+  }
+
+  auto length = PySequence_Length(data);
+  if (length <= 0) {
+    return std::nullopt;
+  }
+
+  // Check if all elements are tensors and collect them
+  std::vector<at::Tensor> tensors;
+  tensors.reserve(length);
+
+  for (Py_ssize_t i = 0; i < length; i++) {
+    THPObjectPtr item(PySequence_GetItem(data, i));
+    if (!item) {
+      return std::nullopt;
+    }
+
+    if (!THPVariable_Check(item.get())) {
+      return std::nullopt;
+    }
+
+    auto tensor = THPVariable_Unpack(item.get());
+
+    if (tensor.numel() != 1) {
+      return std::nullopt;
+    }
+
+    tensors.push_back(tensor);
+  }
+
+  at::Tensor result;
+  {
+    pybind11::gil_scoped_release no_gil;
+    result = at::stack(tensors, /*dim=*/0);
+  }
+
+  const auto& target_scalar_type =
+      type_inference ? result.scalar_type() : scalar_type;
+  auto target_device = device_opt.has_value() ? *device_opt : result.device();
+
+  if (target_scalar_type != result.scalar_type() ||
+      target_device != result.device()) {
+    pybind11::gil_scoped_release no_gil;
+    maybe_initialize_device(target_device);
+    result = result.to(
+        target_device,
+        target_scalar_type,
+        /*non_blocking=*/false,
+        /*copy=*/copy_variables);
+  }
+
+  return result;
+}
+
 Tensor internal_new_from_data(
     c10::TensorOptions options,
     at::ScalarType scalar_type,
@@ -360,6 +425,16 @@ Tensor internal_new_from_data(
         inferred_scalar_type,
         /*non_blocking=*/false,
         /*copy=*/copy_variables);
+  }
+
+  // Check for homogeneous tensor sequences to preserve autograd history
+  if (PySequence_Check(data) && !isStorage(data)) {
+    auto tensor_sequence_result = try_create_from_tensor_sequence(
+        data, scalar_type, device_opt, type_inference, copy_variables);
+    if (tensor_sequence_result.has_value()) {
+      return *tensor_sequence_result;
+    }
+    // If not a tensor sequence, fall through to existing scalar processing
   }
 
   auto device = device_opt.has_value() ? *device_opt : options.device();
@@ -1238,7 +1313,7 @@ Tensor sparse_coo_tensor_ctor(
         inferred_options,
         inferred_scalar_type,
         deviceOptional,
-        r.pyobject(ARG_VALUES1),
+        r.pyobject(ARG_VALUES),
         /*copy_variables=*/false,
         /*copy_numpy=*/true,
         /*type_inference=*/type_inference);
@@ -1247,7 +1322,7 @@ Tensor sparse_coo_tensor_ctor(
         values.options(),
         kLong,
         deviceOptional,
-        r.pyobject(ARG_INDICES1),
+        r.pyobject(ARG_INDICES),
         /*copy_variables=*/false,
         /*copy_numpy=*/true,
         /*type_inference=*/false);

--- a/torch/csrc/utils/tensor_new.h
+++ b/torch/csrc/utils/tensor_new.h
@@ -7,6 +7,14 @@
 
 namespace torch::utils {
 
+// Helper function for detecting homogeneous tensor sequences
+std::optional<at::Tensor> try_create_from_tensor_sequence(
+    PyObject* data,
+    at::ScalarType scalar_type,
+    std::optional<c10::Device> device_opt,
+    bool type_inference,
+    bool copy_variables);
+
 // NOTE: [torch.tensor, lift_fresh, and device movement]
 //
 // The `only_lift_cpu_tensors` flag controls what happens on torch.tensor([1, 2,


### PR DESCRIPTION
Fixes #155983

[torch.as_tensor docs](https://docs.pytorch.org/docs/stable/generated/torch.as_tensor.html) state that autograd history should be retained if possible. This issue brings up that if you pass a python list of tensors, it doesn't retain autograd history. This detects when there is a list of tensors and calls stack on them to maintain their grad_fn property. 