### PR TITLE
[nativert] Move OpKernel to PyTorch core

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -600,6 +600,7 @@ libtorch_nativert_sources = [
     "torch/nativert/executor/Placement.cpp",
     "torch/nativert/executor/ExecutionPlanner.cpp",
     "torch/nativert/executor/ExecutionFrame.cpp",
+    "torch/nativert/executor/OpKernel.cpp",
     "torch/nativert/executor/PlacementUtils.cpp",
     "torch/nativert/executor/Weights.cpp",
     "torch/nativert/executor/memory/FunctionSchema.cpp",

--- a/test/cpp/nativert/CMakeLists.txt
+++ b/test/cpp/nativert/CMakeLists.txt
@@ -9,6 +9,7 @@ set(NATIVERT_TEST_SRCS
   ${TORCH_ROOT}/torch/nativert/graph/Graph.cpp
   ${TORCH_ROOT}/torch/nativert/graph/GraphSignature.cpp
   ${TORCH_ROOT}/torch/nativert/graph/Serialization.cpp
+  ${TORCH_ROOT}/torch/nativert/executor/OpKernel.cpp
   ${TORCH_ROOT}/torch/nativert/executor/PlacementUtils.cpp
   ${TORCH_ROOT}/torch/nativert/executor/Weights.cpp
   ${TORCH_ROOT}/torch/nativert/common/FileUtil.cpp

--- a/test/cpp/nativert/test_op_kernel.cpp
+++ b/test/cpp/nativert/test_op_kernel.cpp
@@ -1,0 +1,55 @@
+#include <ATen/core/dispatch/Dispatcher.h>
+#include <ATen/core/op_registration/op_registration.h>
+#include <gtest/gtest.h>
+#include <torch/nativert/executor/OpKernel.h>
+
+namespace torch::nativert {
+
+int64_t increment_kernel(const at::Tensor& tensor, int64_t input) {
+  return input + 1;
+}
+
+TEST(OpKernelTest, GetOperatorForTargetValid) {
+  auto registrar = c10::RegisterOperators().op(
+      "test::foo(Tensor dummy, int input) -> int", &increment_kernel);
+  std::string target = "test.foo.default";
+  EXPECT_NO_THROW({
+    c10::OperatorHandle handle = getOperatorForTarget(target);
+    EXPECT_TRUE(handle.hasSchema());
+    EXPECT_EQ(handle.operator_name().name, "test::foo");
+    EXPECT_EQ(handle.operator_name().overload_name, "");
+  });
+}
+
+TEST(OpKernelTest, GetOperatorForTargetInvalid) {
+  std::string target = "invalid.target";
+  EXPECT_THROW(getOperatorForTarget(target), c10::Error);
+}
+
+TEST(OpKernelTest, GetReadableArgs) {
+  c10::FunctionSchema schema = c10::FunctionSchema(
+      "test_op",
+      "",
+      {c10::Argument("tensor_arg"),
+       c10::Argument("tensor_list_arg"),
+       c10::Argument("int_arg"),
+       c10::Argument("none_arg")},
+      {});
+  std::vector<c10::IValue> stack = {
+      at::tensor({1, 2, 3}),
+      c10::IValue(
+          std::vector<at::Tensor>{at::tensor({1, 2}), at::tensor({3, 4})}),
+      c10::IValue(1),
+      c10::IValue(),
+  };
+  std::string expected =
+      "arg0 tensor_arg: Tensor int[3]cpu\n"
+      "arg1 tensor_list_arg: GenericList [int[2]cpu, int[2]cpu, ]\n"
+      "arg2 int_arg: Int 1\n"
+      "arg3 none_arg: None \n";
+
+  std::string result = readableArgs(schema, stack);
+  EXPECT_EQ(result, expected);
+}
+
+} // namespace torch::nativert

--- a/torch/nativert/executor/OpKernel.cpp
+++ b/torch/nativert/executor/OpKernel.cpp
@@ -1,0 +1,163 @@
+#include <torch/nativert/executor/OpKernel.h>
+
+#include <fmt/ostream.h>
+
+#include <ATen/core/dispatch/Dispatcher.h>
+#include <c10/util/Logging.h>
+
+#include <c10/util/Enumerate.h>
+#include <c10/util/StringUtil.h>
+#include <c10/util/env.h>
+#include <torch/nativert/executor/ExecutionFrame.h>
+
+namespace torch::nativert {
+
+c10::OperatorHandle getOperatorForTarget(
+    std::string_view target,
+    const Node* node) {
+  // target could come as either "torch.ops.aten.add.default" or
+  // "aten.add.default"
+  std::vector<std::string_view> atoms = c10::split(target, '.');
+
+  size_t numAtoms = atoms.size();
+  if (numAtoms < 3) {
+    TORCH_CHECK(false, "Invalid target: ", target);
+  }
+
+  const std::string_view ns = atoms[numAtoms - 3];
+  const std::string_view opName = atoms[numAtoms - 2];
+  const std::string_view overloadName = atoms[numAtoms - 1];
+
+  const auto operatorName = fmt::format("{}::{}", ns, opName);
+  std::string normalizedOverloadName;
+  if (overloadName == "default") {
+    normalizedOverloadName = "";
+  } else {
+    normalizedOverloadName = overloadName;
+  }
+
+  auto handle = c10::Dispatcher::singleton().findSchemaOrThrow(
+      operatorName.c_str(), normalizedOverloadName.c_str());
+
+  return handle;
+}
+
+std::string readableArgs(
+    const c10::FunctionSchema& schema,
+    const std::vector<c10::IValue>& stack) {
+  const auto& schemaArgs = schema.arguments();
+  std::stringstream ss;
+  for (const auto& [i, arg] : c10::enumerate(stack)) {
+    ss << "arg" << i << ' ' << schemaArgs[i].name() << ": " << arg.tagKind()
+       << ' ';
+    if (arg.isTensor()) {
+      auto t = arg.toTensor();
+      ss << t.dtype() << t.sizes() << t.device();
+    } else if (arg.isTensorList()) {
+      auto tl = arg.toTensorVector();
+      ss << '[';
+      for (const auto& t : tl) {
+        ss << t.dtype() << t.sizes() << t.device() << ", ";
+      }
+      ss << ']';
+    } else if (arg.isNone()) {
+      // pass
+    } else {
+      ss << arg;
+    }
+    ss << "\n";
+  }
+  return ss.str();
+}
+
+const bool OpKernel::blockingEnabled_ =
+    c10::utils::get_env("CUDA_LAUNCH_BLOCKING").value_or("0") == "1";
+
+void OpKernel::compute(ExecutionFrame& executionFrame) const {
+  VLOG(2) << "Executing: " << *node_;
+
+  computeInternal(executionFrame);
+
+  VLOG(2) << "Completed: " << *node_;
+}
+
+Arguments prefillStackWithStaticArgs(
+    const Node* node,
+    const c10::FunctionSchema& schema) {
+  std::vector<c10::IValue> stackWithStaticArgs;
+  std::vector<Value*> dynamicArgs;
+  const auto& schemaArgs = schema.arguments();
+  stackWithStaticArgs.resize(schemaArgs.size());
+  dynamicArgs.resize(schemaArgs.size());
+
+  // initialized stackWithStaticArgs_ with static inputs
+  for (const auto& [idx, schemaArg] : c10::enumerate(schemaArgs)) {
+    const auto& argName = schemaArg.name();
+
+    // Check if this is a dynamic input to the op.
+    const auto input = node->tryGetInput(argName);
+    if (input != nullptr) {
+      stackWithStaticArgs.at(idx) = c10::IValue();
+      dynamicArgs.at(idx) = input->value;
+      continue;
+    }
+
+    // Check if this is a statically known input to the op.
+    const auto attribute = node->tryGetAttribute(argName);
+    if (attribute != nullptr) {
+      stackWithStaticArgs.at(idx) = constantToIValue(attribute->value);
+      continue;
+    }
+
+    // Otherwise, it must have a default value
+    auto defaultValueOpt = schemaArg.default_value();
+    if (defaultValueOpt.has_value()) {
+      stackWithStaticArgs.at(idx) = defaultValueOpt.value();
+      continue;
+    }
+
+    TORCH_CHECK(
+        false,
+        "Cannot initialize argument ",
+        argName,
+        " for node ",
+        *node,
+        " with schema ",
+        schema);
+  }
+  return Arguments{std::move(stackWithStaticArgs), std::move(dynamicArgs)};
+}
+
+void fillDynamicInputs(
+    const ExecutionFrame& executionFrame,
+    const Arguments& arguments,
+    std::vector<c10::IValue>& stack) {
+  // fill the stack with dynamic values from execution frame,
+  // including tensor, tensors, symint, symints
+
+  for (auto [idx, value] : arguments.getDynamicArgs()) {
+    TORCH_CHECK(
+        idx < stack.size(),
+        "Invalid index",
+        idx,
+        " for stack size ",
+        stack.size());
+    TORCH_CHECK(stack.at(idx).isNone(), "Encountered None at index ", idx);
+    if (value->type() == Type::Kind::TensorList) {
+      // TODO: This is for passing List<Tensor> as an input to op that takes a
+      // List<Optional<Tensor>>.
+      // Need to cast it to a vector and back to a list, otherwise will get
+      // list covariance problems where List<Tensor> is not a subtype
+      // of List<Optional<Tensor>> when trying to execute aten.index.Tensor.
+      // Our lists should be covariant because they are static,
+      // but IValues don't know that :(
+      stack[idx] = executionFrame.getIValue(value->id()).toTensorList().vec();
+    } else if (value->type() == Type::Kind::None) {
+      stack[idx] = c10::IValue();
+    } else {
+      stack[idx] = executionFrame.getIValue(value->id());
+    }
+  }
+}
+
+} // namespace torch::nativert

--- a/torch/nativert/executor/OpKernel.h
+++ b/torch/nativert/executor/OpKernel.h
@@ -1,0 +1,159 @@
+#pragma once
+
+#include <c10/core/Device.h>
+#include <torch/nativert/executor/ExecutionFrame.h>
+#include <torch/nativert/executor/OpKernelKind.h>
+#include <torch/nativert/graph/Graph.h>
+
+namespace torch::nativert {
+
+c10::OperatorHandle getOperatorForTarget(
+    std::string_view target,
+    const Node* node = nullptr);
+/**
+ * @brief Manages static and dynamic arguments for kernel execution.
+ *
+ * The `Arguments` class encapsulates both static and dynamic arguments
+ * used during the execution of operators in a graph.
+ * Static arguments are the inputs that were specialized to a fixed value
+ * during graph capture phase. For example, scalar inputs and device are
+ * considered static arguments.
+ * Dynamic arguments are the inputs that were not baked in the graph
+ * during graph capture, i.e. all the tensor inputs to operators
+ */
+class Arguments {
+ public:
+  Arguments(
+      std::vector<c10::IValue> stackWithStaticArgs,
+      std::vector<Value*> dynamicArgs)
+      : stackWithStaticArgs_(std::move(stackWithStaticArgs)),
+        dynamicArgs_(std::move(dynamicArgs)) {
+    for (size_t i = 0; i < dynamicArgs_.size(); i++) {
+      if (dynamicArgs_[i]) {
+        indices_.push_back(i);
+      }
+    }
+  }
+
+  // Returns a view of pairs consist of the argument index and
+  // the corresponding Value pointer from the graph.
+  auto getDynamicArgs() const {
+    std::vector<std::pair<size_t, Value*>> ret;
+    ret.reserve(indices_.size());
+    for (auto i : indices_) {
+      ret.emplace_back(i, dynamicArgs_[i]);
+    }
+    return ret;
+  }
+
+  // Argument i means the i-th input to the operator in the argument list.
+  // Will return nullptr if the argument is not dynamic.
+  Value* findDynamic(size_t i) const {
+    DCHECK(i < dynamicArgs_.size()) << "Invalid input index: " << i;
+    return dynamicArgs_[i];
+  }
+
+  // Argument i means the i-th input to the operator in the argument list.
+  // Will return None as IValue if the argument is not static.
+  const c10::IValue& getStatic(size_t i) const {
+    DCHECK(i < stackWithStaticArgs_.size()) << "Invalid input index: " << i;
+    return stackWithStaticArgs_[i];
+  }
+
+  const std::vector<c10::IValue>& getStackWithStaticArgs() const {
+    return stackWithStaticArgs_;
+  }
+
+ private:
+  // stack pre-populated with attributes, aka static arguments
+  const std::vector<c10::IValue> stackWithStaticArgs_;
+
+  // Argument can only be asTensor, asTensors, asSymInt, asSymInts
+  const std::vector<Value*> dynamicArgs_;
+  std::vector<size_t> indices_;
+};
+
+void fillDynamicInputs(
+    const ExecutionFrame& executionFrame,
+    const Arguments& arguments,
+    std::vector<c10::IValue>& stack);
+
+Arguments prefillStackWithStaticArgs(
+    const Node* node,
+    const c10::FunctionSchema& schema);
+
+std::string readableArgs(
+    const c10::FunctionSchema& schema,
+    const std::vector<c10::IValue>& stack);
+
+/**
+ * @brief Abstract interface representing a kernel, which is responsible for
+ * executing a single Node in the graph.
+ *
+ * The OpKernel class is responsible for executing a single Node in the graph.
+ * It provides an interface for accessing node inputs and outputs, determining
+ * the execution kind, and executing the node's computation.
+ */
+class OpKernel {
+ public:
+  explicit OpKernel(
+      const Node* node,
+      std::optional<c10::Device> device = std::nullopt,
+      torch::nativert::OpKernelKind kind =
+          torch::nativert::OpKernelKind::kInterpreterFallbackKernel)
+      : node_(node), device_(device), kind_(kind) {
+    VLOG(1) << "Initializing kernel for node: " << *node_;
+  }
+
+  const Node* node() const {
+    return node_;
+  }
+  void compute(ExecutionFrame& executionFrame) const;
+
+  torch::nativert::OpKernelKind kind() const {
+    return kind_;
+  }
+
+  bool hasPrimKernel() const {
+    return kind() == torch::nativert::OpKernelKind::kPrimKernel;
+  }
+
+  bool hasStaticDispatch() const {
+    return kind() == torch::nativert::OpKernelKind::kStaticDispatchKernel;
+  }
+
+  size_t numInputs() const {
+    return node_->inputs().size();
+  }
+
+  size_t numOutputs() const {
+    return node_->outputs().size();
+  }
+
+  // Input is readonly
+  [[nodiscard]] virtual const c10::IValue& input(
+      uint32_t i,
+      ExecutionFrame& executionFrame) const {
+    TORCH_CHECK(i < numInputs(), "Invalid input index: ", i);
+    return executionFrame.getIValue(node_->inputs()[i].value->id());
+  }
+
+  // Output is read/write
+  c10::IValue& output(uint32_t i, ExecutionFrame& executionFrame) const {
+    TORCH_CHECK(i < numOutputs(), "Invalid output index: ", i);
+    return executionFrame.getIValue(node_->outputs()[i]->id(), true);
+  }
+
+  virtual ~OpKernel() = default;
+
+ protected:
+  virtual void computeInternal(ExecutionFrame& executionFrame) const = 0;
+
+  const Node* node_;
+  std::optional<c10::Device> device_;
+  const static bool blockingEnabled_;
+  // this should be set in the ctor!
+  const torch::nativert::OpKernelKind kind_;
+};
+
+} // namespace torch::nativert


### PR DESCRIPTION
Summary:
Moves OpKernel base class to PyTorch core. It is an abstract interface representing a kernel, which is responsible for executing a single Node in the graph.

Torch Native Runtime RFC: pytorch/rfcs#72

Test Plan:
buck2 run mode/dev-nosan caffe2/test/cpp/nativert:op_kernel_test

Rollback Plan:

Differential Revision: D76525939
