### PR TITLE
feat(cmake): add NCCL version selection based on CUDA version

### DIFF
--- a/cmake/External/nccl.cmake
+++ b/cmake/External/nccl.cmake
@@ -15,6 +15,17 @@ if(NOT __NCCL_INCLUDED)
     # this second replacement is needed when there are multiple archs
     string(REPLACE ";-gencode" " -gencode" NVCC_GENCODE "${NVCC_GENCODE}")
 
+    # Determine NCCL_VERSION based on CUDA_VERSION_STRING
+    # Refer to https://github.com/NVIDIA/nccl/releases for available tags.
+
+    if(CUDA_VERSION_STRING VERSION_LESS "12.0") # For CUDA 11.x
+      set(NCCL_VERSION "v2.21.5-1")
+    else() # For CUDA 12.x and above
+      set(NCCL_VERSION "v2.27.3-1")
+    endif()
+    message(STATUS "NCCL: Using GIT_TAG ${NCCL_VERSION} for CUDA ${CUDA_VERSION_STRING}")
+    
+
     if(DEFINED ENV{MAX_JOBS})
       set(MAX_JOBS "$ENV{MAX_JOBS}")
     else()
@@ -40,6 +51,8 @@ if(NOT __NCCL_INCLUDED)
     set(__NCCL_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/nccl")
     ExternalProject_Add(nccl_external
       SOURCE_DIR ${PROJECT_SOURCE_DIR}/third_party/nccl
+      GIT_REPOSITORY https://github.com/NVIDIA/nccl.git
+      GIT_TAG ${NCCL_VERSION} 
       BUILD_IN_SOURCE 1
       CONFIGURE_COMMAND ""
       BUILD_COMMAND

--- a/cmake/External/nccl.cmake
+++ b/cmake/External/nccl.cmake
@@ -24,7 +24,6 @@ if(NOT __NCCL_INCLUDED)
       set(NCCL_VERSION "v2.27.3-1")
     endif()
     message(STATUS "NCCL: Using GIT_TAG ${NCCL_VERSION} for CUDA ${CUDA_VERSION_STRING}")
-    
 
     if(DEFINED ENV{MAX_JOBS})
       set(MAX_JOBS "$ENV{MAX_JOBS}")

--- a/cmake/External/nccl.cmake
+++ b/cmake/External/nccl.cmake
@@ -52,7 +52,7 @@ if(NOT __NCCL_INCLUDED)
     ExternalProject_Add(nccl_external
       SOURCE_DIR ${PROJECT_SOURCE_DIR}/third_party/nccl
       GIT_REPOSITORY https://github.com/NVIDIA/nccl.git
-      GIT_TAG ${NCCL_VERSION} 
+      GIT_TAG ${NCCL_VERSION}
       BUILD_IN_SOURCE 1
       CONFIGURE_COMMAND ""
       BUILD_COMMAND


### PR DESCRIPTION
resolve: #144768

Adds logic to determine NCCL version dynamically based on the CUDA version string. Uses specific GIT tags for CUDA 11.x and 12.x+, improving compatibility and ensuring proper version selection. Updates the NCCL build configuration to include the GIT repository and selected GIT tag.
