### PR TITLE
bmm, topk, cholesky, linalg.norm, max with out variants set causing r…

### DIFF
--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -4353,7 +4353,8 @@ def common_meta_baddbmm_bmm(batch1, batch2, is_bmm, self_baddbmm=None, out_dtype
     return output
 
 
-@register_meta(aten.bmm.default)
+@register_meta([aten.bmm.default, aten.bmm.out])
+@out_wrapper()
 def meta_bmm(self, mat2):
     return common_meta_baddbmm_bmm(self, mat2, True)
 
@@ -6762,7 +6763,8 @@ def scalar_tensor(s, dtype=None, layout=None, device=None, pin_memory=None):
     )
 
 
-@register_meta(aten.topk.default)
+@register_meta([aten.topk.default, aten.topk.values])
+@out_wrapper("values", "indices")
 def topk_meta(self, k, dim=-1, largest=True, sorted=True):
     # From aten/src/ATen/native/Sorting.cpp
     dim = maybe_wrap_dim(dim, self.dim(), wrap_scalar=True)

--- a/torch/_refs/linalg/__init__.py
+++ b/torch/_refs/linalg/__init__.py
@@ -341,3 +341,25 @@ def svdvals(A: TensorLikeType) -> Tensor:
 def vecdot(x: Tensor, y: Tensor, dim: int = -1) -> Tensor:
     check_fp_or_complex(x.dtype, "linalg.vecdot")
     return (x.conj() * y).sum(dim=dim)
+
+
+# CompositeImplicitAutograd - don't register decomp
+@torch._ops.ops.aten.linalg_norm.out.py_impl(torch._C.DispatchKey.CompositeImplicitAutograd)
+@out_wrapper(exact_dtype=True)
+def linalg_norm_out_decomposition(a, *, ord=None, dim=None, keepdim=False, dtype=None):
+    """
+    Leverages the existing functional implementation of linalg.norm to provide
+    a SymInt-aware decomposition for the out= variant.
+    """
+    return torch.linalg.norm(a, ord=ord, dim=dim, keepdim=keepdim, dtype=dtype)
+
+
+# CompositeImplicitAutograd - don't register decomp
+@torch._ops.ops.aten.linalg_cholesky.out.py_impl(torch._C.DispatchKey.CompositeImplicitAutograd)
+@out_wrapper(exact_dtype=True)
+def linalg_cholesky_out_decomposition(a, *, upper=False):
+    """
+    Leverages the existing functional implementation of linalg.cholesky to provide
+    a SymInt-aware decomposition for the out= variant.
+    """
+    return torch.linalg.cholesky(a, upper=upper)


### PR DESCRIPTION
Fixes #135859, following the approach detailed in the [Dynamic Shapes Manual](https://docs.google.com/document/d/1GgvOe7C8_NVOMLOCwDaYV1mXXyHMXY7ExoewHqooxrs/edit?tab=t.0#heading=h.kzbllkiwjdpm).

Adds support for torch.bmm, torch.topk, torch.linalg.cholesky, and torch.linalg.norm.

For bmm.out and topk.out, added an out_wrapper decorator in torch/_meta_registrations.py.

For cholesky and norm, since they are CompositeImplicitAutograd, I used py_impl and out_wrapper with the existing functional implementation. The implementation is added to torch/_refs/linalg/__init__.py, since the two functions are directly the operator is directly exposed in the Python torch.* API.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @chenyang78