### PR TITLE
Register hpu device to fake backend

### DIFF
--- a/torch/testing/_internal/distributed/fake_pg.py
+++ b/torch/testing/_internal/distributed/fake_pg.py
@@ -25,4 +25,4 @@ def _create_fake_pg(prefix_store, rank, world_size, timeout):
     return FakeProcessGroup(rank, world_size)
 
 
-dist.Backend.register_backend("fake", _create_fake_pg, devices=["cpu", "cuda"])
+dist.Backend.register_backend("fake", _create_fake_pg, devices=["cpu", "cuda", "hpu"])


### PR DESCRIPTION
## MOTIVATION

This PR intends to add hpu ( Intel Gaudi) also to the list of devices that will be supported by the "fake" distributed backend and the process group that will be created. 

## CHANGES
- Add "hpu" to the list of devices

@ankurneog, @EikanWang 


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k