### PR TITLE
[MPS] Implement scan metal kernels

### DIFF
--- a/aten/src/ATen/native/mps/kernels/ScanKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ScanKernel.metal
@@ -103,9 +103,6 @@ kernel void scan_contiguous_outer_dim(
   const uint orow = thread_index / num_irows;
   const uint irow = thread_index % num_irows;
 
-  if (orow >= num_orows || irow >= num_irows)
-    return;
-
   acc_t accumulator = Op::identity();
 
   const uint idx_base = orow * row_size * num_irows + irow;
@@ -158,9 +155,6 @@ kernel void scan_with_indices_contiguous_outer_dim(
     uint thread_index [[thread_position_in_grid]]) {
   const uint orow = thread_index / num_irows;
   const uint irow = thread_index % num_irows;
-
-  if (orow >= num_orows || irow >= num_irows)
-    return;
 
   acc_t accumulator = Op::identity();
   int64_t best_idx = 0;

--- a/aten/src/ATen/native/mps/kernels/ScanKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ScanKernel.metal
@@ -103,6 +103,9 @@ kernel void scan_contiguous_outer_dim(
   const uint orow = thread_index / num_irows;
   const uint irow = thread_index % num_irows;
 
+  if (orow >= num_orows)
+    return;
+
   acc_t accumulator = Op::identity();
 
   const uint idx_base = orow * row_size * num_irows + irow;
@@ -155,6 +158,9 @@ kernel void scan_with_indices_contiguous_outer_dim(
     uint thread_index [[thread_position_in_grid]]) {
   const uint orow = thread_index / num_irows;
   const uint irow = thread_index % num_irows;
+
+  if (orow >= num_orows)
+    return;
 
   acc_t accumulator = Op::identity();
   int64_t best_idx = 0;

--- a/aten/src/ATen/native/mps/kernels/ScanKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ScanKernel.metal
@@ -1,0 +1,443 @@
+#include <metal_stdlib>
+using namespace metal;
+
+#include <c10/metal/common.h>
+#include <c10/metal/utils.h>
+
+using c10::metal::detail::AccumulationType;
+
+template <typename T>
+struct CumSumOp {
+  using AccumType = typename AccumulationType<T>::type;
+
+  static AccumType apply(AccumType a, AccumType b) {
+    return a + b;
+  }
+  static T identity() {
+    return T(0);
+  }
+};
+
+template <typename T>
+struct CumProdOp {
+  using AccumType = typename AccumulationType<T>::type;
+
+  static AccumType apply(AccumType a, AccumType b) {
+    return a * b;
+  }
+  static T identity() {
+    return T(1);
+  }
+};
+
+template <typename T>
+struct CumMinOp {
+  using AccumType = typename AccumulationType<T>::type;
+
+  static AccumType apply(AccumType a, AccumType b) {
+    return metal::min(a, b);
+  }
+  static T identity() {
+    return metal::is_floating_point_v<T> ? metal::numeric_limits<T>::infinity()
+                                         : metal::numeric_limits<T>::max();
+  }
+};
+
+template <typename T>
+struct CumMaxOp {
+  using AccumType = typename AccumulationType<T>::type;
+
+  static AccumType apply(AccumType a, AccumType b) {
+    return metal::max(a, b);
+  }
+  static T identity() {
+    return metal::is_floating_point_v<T> ? -metal::numeric_limits<T>::infinity()
+                                         : metal::numeric_limits<T>::lowest();
+  }
+};
+
+template <typename T>
+struct LogCumSumExpOp {
+  using AccumType = typename AccumulationType<T>::type;
+
+  static AccumType apply(AccumType a, AccumType b) {
+    if (metal::isinf(a) && a < 0) {
+      return b;
+    }
+    if (metal::isinf(b) && b < 0) {
+      return a;
+    }
+    AccumType max_val = metal::max(a, b);
+    AccumType min_val = metal::min(a, b);
+    return max_val + c10::metal::log1p(metal::exp(min_val - max_val));
+  }
+  static T identity() {
+    return -metal::numeric_limits<T>::infinity();
+  }
+};
+
+// Inclusive scan along innermost dimension for contiguous tensors
+template <typename T, typename Op>
+kernel void scan_contiguous_innermost_dim(
+    constant T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    constant uint& num_rows [[buffer(2)]],
+    constant uint& row_size [[buffer(3)]],
+    uint row [[thread_position_in_grid]]) {
+  if (row >= num_rows)
+    return;
+
+  const uint offset = row * row_size;
+
+  using AccumType = typename AccumulationType<T>::type;
+  AccumType accumulator = AccumulationType<T>::to_accum(Op::identity());
+
+  for (uint col = 0; col < row_size; col++) {
+    T val = input[offset + col];
+    AccumType accum_val = AccumulationType<T>::to_accum(val);
+    accumulator = Op::apply(accumulator, accum_val);
+    output[offset + col] = AccumulationType<T>::from_accum(accumulator);
+  }
+}
+
+// Inclusive scan along outer dimension for contiguous tensors
+template <typename T, typename Op>
+kernel void scan_contiguous_outer_dim(
+    constant T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    constant uint& num_orows [[buffer(2)]],
+    constant uint& num_irows [[buffer(3)]],
+    constant uint& row_size [[buffer(4)]],
+    uint thread_index [[thread_position_in_grid]]) {
+  const uint orow = thread_index / num_irows;
+  const uint irow = thread_index % num_irows;
+
+  if (orow >= num_orows || irow >= num_irows)
+    return;
+
+  using AccumType = typename AccumulationType<T>::type;
+  AccumType accumulator = AccumulationType<T>::to_accum(Op::identity());
+
+  const uint idx_base = orow * row_size * num_irows + irow;
+  for (uint col = 0, idx = idx_base; col < row_size; col++, idx += num_irows) {
+    T val = input[idx];
+    AccumType accum_val = AccumulationType<T>::to_accum(val);
+    accumulator = Op::apply(accumulator, accum_val);
+    output[idx] = AccumulationType<T>::from_accum(accumulator);
+  }
+}
+
+// Inclusive scan with indices along innermost dimension for contiguous tensors
+template <typename T, typename Op>
+kernel void scan_with_indices_contiguous_innermost_dim(
+    constant T* input [[buffer(0)]],
+    device T* values [[buffer(1)]],
+    device int64_t* indices [[buffer(2)]],
+    constant uint& num_rows [[buffer(3)]],
+    constant uint& row_size [[buffer(4)]],
+    uint row [[thread_position_in_grid]]) {
+  if (row >= num_rows)
+    return;
+
+  const uint offset = row * row_size;
+
+  using AccumType = typename AccumulationType<T>::type;
+  AccumType accumulator = AccumulationType<T>::to_accum(Op::identity());
+  int64_t best_idx = 0;
+
+  for (uint col = 0; col < row_size; col++) {
+    T val = input[offset + col];
+    AccumType accum_val = AccumulationType<T>::to_accum(val);
+    if (col == 0 || Op::apply(accum_val, accumulator) == accum_val) {
+      accumulator = accum_val;
+      best_idx = col;
+    }
+    values[offset + col] = AccumulationType<T>::from_accum(accumulator);
+    indices[offset + col] = best_idx;
+  }
+}
+
+// Inclusive scan with indices along outer dimension for contiguous tensors
+template <typename T, typename Op>
+kernel void scan_with_indices_contiguous_outer_dim(
+    constant T* input [[buffer(0)]],
+    device T* values [[buffer(1)]],
+    device int64_t* indices [[buffer(2)]],
+    constant uint& num_orows [[buffer(3)]],
+    constant uint& num_irows [[buffer(4)]],
+    constant uint& row_size [[buffer(5)]],
+    uint thread_index [[thread_position_in_grid]]) {
+  const uint orow = thread_index / num_irows;
+  const uint irow = thread_index % num_irows;
+
+  if (orow >= num_orows || irow >= num_irows)
+    return;
+
+  using AccumType = typename AccumulationType<T>::type;
+  AccumType accumulator = AccumulationType<T>::to_accum(Op::identity());
+  int64_t best_idx = 0;
+
+  const uint idx_base = orow * row_size * num_irows + irow;
+  for (uint col = 0, idx = idx_base; col < row_size; col++, idx += num_irows) {
+    T val = input[idx];
+    AccumType accum_val = AccumulationType<T>::to_accum(val);
+    if (col == 0 || Op::apply(accum_val, accumulator) == accum_val) {
+      accumulator = accum_val;
+      best_idx = col;
+    }
+    values[idx] = AccumulationType<T>::from_accum(accumulator);
+    indices[idx] = best_idx;
+  }
+}
+
+// Shared utility functions for strided kernels
+inline long calculate_non_scan_elements(
+    constant long* sizes,
+    uint ndim,
+    uint scan_dim) {
+  long total = 1;
+  for (uint i = 0; i < ndim; ++i) {
+    if (i != scan_dim) {
+      total *= sizes[i];
+    }
+  }
+  return total;
+}
+
+inline void thread_index_to_coordinates(
+    uint index,
+    int pos[c10::metal::max_ndim],
+    constant long* sizes,
+    uint ndim,
+    uint scan_dim) {
+  long remaining_index = index;
+  for (uint i = 0; i < ndim; ++i) {
+    if (i != scan_dim) {
+      pos[i] = remaining_index % sizes[i];
+      remaining_index /= sizes[i];
+    } else {
+      pos[i] = 0;
+    }
+  }
+}
+
+inline long calculate_base_offset(
+    int pos[c10::metal::max_ndim],
+    constant long* strides,
+    uint ndim,
+    uint scan_dim) {
+  long offset = 0;
+  for (uint i = 0; i < ndim; ++i) {
+    if (i != scan_dim) {
+      offset += pos[i] * strides[i];
+    }
+  }
+  return offset;
+}
+
+// Generic strided scan kernel
+template <typename T, typename Op>
+kernel void scan_strided(
+    constant T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    constant long* sizes [[buffer(2)]],
+    constant long* input_strides [[buffer(3)]],
+    constant long* output_strides [[buffer(4)]],
+    constant uint& ndim [[buffer(5)]],
+    constant uint& scan_dim [[buffer(6)]],
+    uint thread_index [[thread_position_in_grid]]) {
+  const long total_non_scan_elements =
+      calculate_non_scan_elements(sizes, ndim, scan_dim);
+  if (thread_index >= total_non_scan_elements) {
+    return;
+  }
+
+  int pos[c10::metal::max_ndim];
+  thread_index_to_coordinates(thread_index, pos, sizes, ndim, scan_dim);
+
+  const long input_base_offset =
+      calculate_base_offset(pos, input_strides, ndim, scan_dim);
+  const long output_base_offset =
+      calculate_base_offset(pos, output_strides, ndim, scan_dim);
+
+  using AccumType = typename AccumulationType<T>::type;
+  AccumType accumulator = AccumulationType<T>::to_accum(Op::identity());
+  const long scan_size = sizes[scan_dim];
+  const long input_scan_stride = input_strides[scan_dim];
+  const long output_scan_stride = output_strides[scan_dim];
+
+  for (long scan_idx = 0; scan_idx < scan_size; scan_idx++) {
+    const long input_offset = input_base_offset + scan_idx * input_scan_stride;
+    const long output_offset =
+        output_base_offset + scan_idx * output_scan_stride;
+
+    T val = input[input_offset];
+    AccumType accum_val = AccumulationType<T>::to_accum(val);
+    accumulator = Op::apply(accumulator, accum_val);
+    output[output_offset] = AccumulationType<T>::from_accum(accumulator);
+  }
+}
+
+// Generic strided scan with indices kernel
+template <typename T, typename Op>
+kernel void scan_with_indices_strided(
+    constant T* input [[buffer(0)]],
+    device T* values [[buffer(1)]],
+    device int64_t* indices [[buffer(2)]],
+    constant long* sizes [[buffer(3)]],
+    constant long* input_strides [[buffer(4)]],
+    constant long* values_strides [[buffer(5)]],
+    constant long* indices_strides [[buffer(6)]],
+    constant uint& ndim [[buffer(7)]],
+    constant uint& scan_dim [[buffer(8)]],
+    uint thread_index [[thread_position_in_grid]]) {
+  const long total_non_scan_elements =
+      calculate_non_scan_elements(sizes, ndim, scan_dim);
+  if (thread_index >= total_non_scan_elements) {
+    return;
+  }
+
+  int pos[c10::metal::max_ndim];
+  thread_index_to_coordinates(thread_index, pos, sizes, ndim, scan_dim);
+
+  const long input_base_offset =
+      calculate_base_offset(pos, input_strides, ndim, scan_dim);
+  const long values_base_offset =
+      calculate_base_offset(pos, values_strides, ndim, scan_dim);
+  const long indices_base_offset =
+      calculate_base_offset(pos, indices_strides, ndim, scan_dim);
+
+  using AccumType = typename AccumulationType<T>::type;
+  AccumType accumulator = AccumulationType<T>::to_accum(Op::identity());
+  int64_t best_idx = 0;
+  const long scan_size = sizes[scan_dim];
+  const long input_scan_stride = input_strides[scan_dim];
+  const long values_scan_stride = values_strides[scan_dim];
+  const long indices_scan_stride = indices_strides[scan_dim];
+
+  for (long scan_idx = 0; scan_idx < scan_size; scan_idx++) {
+    const long input_offset = input_base_offset + scan_idx * input_scan_stride;
+    const long values_offset =
+        values_base_offset + scan_idx * values_scan_stride;
+    const long indices_offset =
+        indices_base_offset + scan_idx * indices_scan_stride;
+
+    T val = input[input_offset];
+    AccumType accum_val = AccumulationType<T>::to_accum(val);
+    if (scan_idx == 0 || Op::apply(accum_val, accumulator) == accum_val) {
+      accumulator = accum_val;
+      best_idx = scan_idx;
+    }
+    values[values_offset] = AccumulationType<T>::from_accum(accumulator);
+    indices[indices_offset] = best_idx;
+  }
+}
+
+#define REGISTER_SCAN_OP(OP_NAME, OP_CLASS, DTYPE)                             \
+  template [[host_name(#OP_NAME "_contiguous_innermost_" #DTYPE)]] kernel void \
+  scan_contiguous_innermost_dim<DTYPE, OP_CLASS<DTYPE>>(                       \
+      constant DTYPE * input [[buffer(0)]],                                    \
+      device DTYPE * output [[buffer(1)]],                                     \
+      constant uint & num_rows [[buffer(2)]],                                  \
+      constant uint & row_size [[buffer(3)]],                                  \
+      uint row [[thread_position_in_grid]]);                                   \
+                                                                               \
+  template [[host_name(#OP_NAME "_contiguous_outer_" #DTYPE)]] kernel void     \
+  scan_contiguous_outer_dim<DTYPE, OP_CLASS<DTYPE>>(                           \
+      constant DTYPE * input [[buffer(0)]],                                    \
+      device DTYPE * output [[buffer(1)]],                                     \
+      constant uint & num_orows [[buffer(2)]],                                 \
+      constant uint & num_irows [[buffer(3)]],                                 \
+      constant uint & row_size [[buffer(4)]],                                  \
+      uint thread_index [[thread_position_in_grid]]);                          \
+                                                                               \
+  template [[host_name(#OP_NAME "_strided_" #DTYPE)]] kernel void              \
+  scan_strided<DTYPE, OP_CLASS<DTYPE>>(                                        \
+      constant DTYPE * input [[buffer(0)]],                                    \
+      device DTYPE * output [[buffer(1)]],                                     \
+      constant long* sizes [[buffer(2)]],                                      \
+      constant long* input_strides [[buffer(3)]],                              \
+      constant long* output_strides [[buffer(4)]],                             \
+      constant uint& ndim [[buffer(5)]],                                       \
+      constant uint& scan_dim [[buffer(6)]],                                   \
+      uint thread_index [[thread_position_in_grid]]);
+
+#define REGISTER_SCAN_WITH_INDICES_OP(OP_NAME, OP_CLASS, DTYPE)                \
+  template [[host_name(#OP_NAME "_contiguous_innermost_" #DTYPE)]] kernel void \
+  scan_with_indices_contiguous_innermost_dim<DTYPE, OP_CLASS<DTYPE>>(          \
+      constant DTYPE * input [[buffer(0)]],                                    \
+      device DTYPE * values [[buffer(1)]],                                     \
+      device int64_t* indices [[buffer(2)]],                                   \
+      constant uint& num_rows [[buffer(3)]],                                   \
+      constant uint& row_size [[buffer(4)]],                                   \
+      uint row [[thread_position_in_grid]]);                                   \
+                                                                               \
+  template [[host_name(#OP_NAME "_contiguous_outer_" #DTYPE)]] kernel void     \
+  scan_with_indices_contiguous_outer_dim<DTYPE, OP_CLASS<DTYPE>>(              \
+      constant DTYPE * input [[buffer(0)]],                                    \
+      device DTYPE * values [[buffer(1)]],                                     \
+      device int64_t* indices [[buffer(2)]],                                   \
+      constant uint& num_orows [[buffer(3)]],                                  \
+      constant uint& num_irows [[buffer(4)]],                                  \
+      constant uint& row_size [[buffer(5)]],                                   \
+      uint thread_index [[thread_position_in_grid]]);                          \
+                                                                               \
+  template [[host_name(#OP_NAME "_strided_" #DTYPE)]] kernel void              \
+  scan_with_indices_strided<DTYPE, OP_CLASS<DTYPE>>(                           \
+      constant DTYPE * input [[buffer(0)]],                                    \
+      device DTYPE * values [[buffer(1)]],                                     \
+      device int64_t* indices [[buffer(2)]],                                   \
+      constant long* sizes [[buffer(3)]],                                      \
+      constant long* input_strides [[buffer(4)]],                              \
+      constant long* values_strides [[buffer(5)]],                             \
+      constant long* indices_strides [[buffer(6)]],                            \
+      constant uint& ndim [[buffer(7)]],                                       \
+      constant uint& scan_dim [[buffer(8)]],                                   \
+      uint thread_index [[thread_position_in_grid]]);
+
+// Simple scan operations
+REGISTER_SCAN_OP(cumsum, CumSumOp, float);
+REGISTER_SCAN_OP(cumsum, CumSumOp, half);
+REGISTER_SCAN_OP(cumsum, CumSumOp, long);
+REGISTER_SCAN_OP(cumsum, CumSumOp, int);
+REGISTER_SCAN_OP(cumsum, CumSumOp, short);
+REGISTER_SCAN_OP(cumsum, CumSumOp, char);
+REGISTER_SCAN_OP(cumsum, CumSumOp, uchar);
+
+REGISTER_SCAN_OP(cumprod, CumProdOp, float);
+REGISTER_SCAN_OP(cumprod, CumProdOp, half);
+REGISTER_SCAN_OP(cumprod, CumProdOp, long);
+REGISTER_SCAN_OP(cumprod, CumProdOp, int);
+REGISTER_SCAN_OP(cumprod, CumProdOp, short);
+REGISTER_SCAN_OP(cumprod, CumProdOp, char);
+REGISTER_SCAN_OP(cumprod, CumProdOp, uchar);
+
+REGISTER_SCAN_OP(logcumsumexp, LogCumSumExpOp, float);
+REGISTER_SCAN_OP(logcumsumexp, LogCumSumExpOp, half);
+
+// Scan operations with indices
+REGISTER_SCAN_WITH_INDICES_OP(cummin, CumMinOp, float);
+REGISTER_SCAN_WITH_INDICES_OP(cummin, CumMinOp, half);
+REGISTER_SCAN_WITH_INDICES_OP(cummin, CumMinOp, long);
+REGISTER_SCAN_WITH_INDICES_OP(cummin, CumMinOp, int);
+REGISTER_SCAN_WITH_INDICES_OP(cummin, CumMinOp, short);
+REGISTER_SCAN_WITH_INDICES_OP(cummin, CumMinOp, char);
+REGISTER_SCAN_WITH_INDICES_OP(cummin, CumMinOp, uchar);
+REGISTER_SCAN_WITH_INDICES_OP(cummin, CumMinOp, bool);
+
+REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, float);
+REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, half);
+REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, long);
+REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, int);
+REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, short);
+REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, char);
+REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, uchar);
+REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, bool);
+
+#if __METAL_VERSION__ >= 310
+REGISTER_SCAN_OP(cumsum, CumSumOp, bfloat);
+REGISTER_SCAN_OP(cumprod, CumProdOp, bfloat);
+REGISTER_SCAN_OP(logcumsumexp, LogCumSumExpOp, bfloat);
+REGISTER_SCAN_WITH_INDICES_OP(cummin, CumMinOp, bfloat);
+REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, bfloat);
+#endif

--- a/aten/src/ATen/native/mps/operations/ScanKernel.mm
+++ b/aten/src/ATen/native/mps/operations/ScanKernel.mm
@@ -1,0 +1,217 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/Dispatch.h>
+#include <ATen/mps/MPSProfiler.h>
+#include <ATen/native/ReduceOps.h>
+#include <ATen/native/mps/OperationUtils.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/_cummax_helper_native.h>
+#include <ATen/ops/_cummin_helper_native.h>
+#include <ATen/ops/_logcumsumexp_native.h>
+#endif
+
+namespace at::native {
+namespace mps {
+
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& lib = MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/ScanKernel_metallib.h>
+#endif
+
+// Generic scan implementation that handles both simple scans and scans with indices
+template <typename scalar_t>
+void scan_mps_impl_generic(const Tensor& self,
+                           const std::vector<Tensor>& outputs,
+                           int64_t dim,
+                           const std::string& op_name) {
+  if (outputs[0].numel() == 0) {
+    return;
+  }
+
+  const int64_t ndim = self.dim();
+  const int64_t wrapped_dim = maybe_wrap_dim(dim, ndim);
+
+  // Calculate dimensions for scan operation
+  int64_t row_size = self.size(wrapped_dim);
+  auto sizes = self.sizes();
+
+  bool is_innermost = (wrapped_dim == ndim - 1);
+
+  // Check if all tensors are contiguous
+  bool is_contiguous = self.is_contiguous();
+  for (const auto& output : outputs) {
+    is_contiguous = is_contiguous && output.is_contiguous();
+  }
+
+  uint32_t num_rows, num_orows, num_irows, num_threads;
+
+  if (is_innermost) {
+    // Treat all outer dimensions as a single dimension
+    num_rows = self.numel() / row_size;
+    num_threads = num_rows;
+  } else {
+    // Treat all outer dimensions (i.e. dim_ < dim) as one
+    num_orows = c10::multiply_integers(sizes.begin(), sizes.begin() + wrapped_dim);
+    // Treat all inner dimensions (i.e. dim > dimension) as one
+    num_irows = c10::multiply_integers(sizes.begin() + wrapped_dim + 1, sizes.end());
+    num_threads = num_orows * num_irows;
+  }
+
+  MPSStream* mpsStream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
+
+      // Choose kernel based on contiguity and dimension
+      std::string kernel_name;
+      if (is_contiguous) {
+        kernel_name =
+            op_name + "_contiguous_" + (is_innermost ? "innermost_" : "outer_") + scalarToMetalTypeString(self);
+      } else {
+        kernel_name = op_name + "_strided_" + scalarToMetalTypeString(self);
+      }
+
+      id<MTLComputePipelineState> scanPSO = lib.getPipelineStateForFunc(kernel_name);
+
+      // this function call is a no-op if MPS Profiler is not enabled
+      getMPSProfiler().beginProfileKernel(scanPSO, op_name, [&]() {
+        std::vector<Tensor> all_tensors = {self};
+        all_tensors.insert(all_tensors.end(), outputs.begin(), outputs.end());
+        return all_tensors;
+      }());
+
+      [computeEncoder setComputePipelineState:scanPSO];
+
+      // Set input tensor
+      mtl_setBuffer(computeEncoder, self, 0);
+
+      // Set output tensors
+      for (size_t i = 0; i < outputs.size(); ++i) {
+        mtl_setBuffer(computeEncoder, outputs[i], i + 1);
+      }
+
+      if (is_contiguous) {
+        // Contiguous kernels
+        if (is_innermost) {
+          if (outputs.size() == 1) {
+            // Simple scan (cumsum, cumprod, logcumsumexp)
+            mtl_setArgs<2>(computeEncoder, num_rows, static_cast<uint32_t>(row_size));
+          } else {
+            // Scan with indices (cummin, cummax)
+            mtl_setArgs<3>(computeEncoder, num_rows, static_cast<uint32_t>(row_size));
+          }
+        } else {
+          if (outputs.size() == 1) {
+            // Simple scan (cumsum, cumprod, logcumsumexp)
+            mtl_setArgs<2>(computeEncoder, num_orows, num_irows, static_cast<uint32_t>(row_size));
+          } else {
+            // Scan with indices (cummin, cummax)
+            mtl_setArgs<3>(computeEncoder, num_orows, num_irows, static_cast<uint32_t>(row_size));
+          }
+        }
+      } else {
+        // Strided kernels - pass full tensor information
+        if (outputs.size() == 1) {
+          // Simple scan (cumsum, cumprod, logcumsumexp)
+          mtl_setArgs<2>(computeEncoder,
+                         self.sizes(),
+                         self.strides(),
+                         outputs[0].strides(),
+                         static_cast<uint32_t>(self.ndimension()),
+                         static_cast<uint32_t>(wrapped_dim));
+        } else {
+          // Scan with indices (cummin, cummax)
+          mtl_setArgs<3>(computeEncoder,
+                         self.sizes(),
+                         self.strides(),
+                         outputs[0].strides(),
+                         outputs[1].strides(),
+                         static_cast<uint32_t>(self.ndimension()),
+                         static_cast<uint32_t>(wrapped_dim));
+        }
+      }
+
+      mtl_dispatch1DJob(computeEncoder, scanPSO, num_threads);
+
+      getMPSProfiler().endProfileKernel(scanPSO);
+    }
+  });
+}
+
+// Convenience wrapper for simple scans (cumsum, cumprod, logcumsumexp)
+template <typename scalar_t>
+void scan_mps_impl(const Tensor& self, const Tensor& result, int64_t dim, const std::string& op_name) {
+  scan_mps_impl_generic<scalar_t>(self, {result}, dim, op_name);
+}
+
+// Convenience wrapper for scans with indices (cummin, cummax)
+template <typename scalar_t>
+void scan_with_indices_mps_impl(const Tensor& self,
+                                const Tensor& values,
+                                const Tensor& indices,
+                                int64_t dim,
+                                const std::string& op_name) {
+  scan_mps_impl_generic<scalar_t>(self, {values, indices}, dim, op_name);
+}
+
+} // namespace mps
+
+static void cumsum_mps_kernel(const Tensor& result, const Tensor& self, int64_t dim) {
+  AT_DISPATCH_ALL_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16, self.scalar_type(), "cumsum_mps", [&]() {
+    mps::scan_mps_impl<scalar_t>(self, result, dim, "cumsum");
+  });
+}
+
+static void cumprod_mps_kernel(const Tensor& result, const Tensor& self, int64_t dim) {
+  AT_DISPATCH_ALL_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16, self.scalar_type(), "cumprod_mps", [&]() {
+    mps::scan_mps_impl<scalar_t>(self, result, dim, "cumprod");
+  });
+}
+
+Tensor& _logcumsumexp_out_mps(const Tensor& self, int64_t dim, Tensor& result) {
+  const auto wrap_dim = maybe_wrap_dim(dim, self.dim());
+  result.resize_(self.sizes());
+  if (self.dim() == 0) {
+    result.fill_(self);
+    return result;
+  }
+  if (self.numel() == 0) {
+    result.zero_();
+    return result;
+  }
+
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      ScalarType::Half, ScalarType::BFloat16, self.scalar_type(), "logcumsumexp_mps", [&]() {
+        mps::scan_mps_impl<scalar_t>(self, result, wrap_dim, "logcumsumexp");
+      });
+  return result;
+}
+
+Tensor _logcumsumexp_mps(const Tensor& self, int64_t dim) {
+  Tensor result = at::empty_like(self, MemoryFormat::Contiguous);
+  return _logcumsumexp_out_mps(self, dim, result);
+}
+
+void cummax_helper_mps(const Tensor& self, Tensor& values, Tensor& indices, int64_t dim) {
+  AT_DISPATCH_ALL_TYPES_AND3(
+      at::ScalarType::Bool, at::ScalarType::Half, at::ScalarType::BFloat16, self.scalar_type(), "cummax_mps", [&]() {
+        mps::scan_with_indices_mps_impl<scalar_t>(self, values, indices, dim, "cummax");
+      });
+}
+
+void cummin_helper_mps(const Tensor& self, Tensor& values, Tensor& indices, int64_t dim) {
+  AT_DISPATCH_ALL_TYPES_AND3(
+      at::ScalarType::Bool, at::ScalarType::Half, at::ScalarType::BFloat16, self.scalar_type(), "cummin_mps", [&]() {
+        mps::scan_with_indices_mps_impl<scalar_t>(self, values, indices, dim, "cummin");
+      });
+}
+
+// Register dispatch functions
+REGISTER_DISPATCH(cumsum_stub, &cumsum_mps_kernel)
+REGISTER_DISPATCH(cumprod_stub, &cumprod_mps_kernel)
+
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -22,8 +22,6 @@
 #include <ATen/ops/conj_physical_native.h>
 #include <ATen/ops/cos_native.h>
 #include <ATen/ops/cosh_native.h>
-#include <ATen/ops/cumprod_native.h>
-#include <ATen/ops/cumsum_native.h>
 #include <ATen/ops/erf_native.h>
 #include <ATen/ops/exp2_native.h>
 #include <ATen/ops/frac_native.h>
@@ -49,11 +47,6 @@
 #endif
 
 namespace at::native {
-
-enum class MPSCumulativeOpType : uint8_t {
-  CUMSUM = 0,
-  CUMPROD = 1,
-};
 
 namespace mps {
 
@@ -354,64 +347,6 @@ TORCH_IMPL_FUNC(logit_backward_out_mps)
     auto feeds = dictionaryFromPlaceholders(gradOutputPlaceholder, inputPlaceholder);
     runMPSGraph(stream, cachedGraph->graph(), feeds, gradInputPlaceholder);
   }
-}
-
-static void cumulative_op_impl(const Tensor& self,
-                               int64_t dim,
-                               std::optional<ScalarType> dtype,
-                               const Tensor& result,
-                               MPSCumulativeOpType cumulativeOpType,
-                               const std::string& op_name) {
-  bool macOS13_3_plus = is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_3_PLUS);
-  auto nDims = self.dim();
-  auto wrapped_dim = maybe_wrap_dim(dim, nDims);
-  TORCH_CHECK(wrapped_dim >= 0 && wrapped_dim < std::max(1LL, self.ndimension()),
-              "Expected wrapped dim to be between 0 and ",
-              self.ndimension(),
-              " but got ",
-              wrapped_dim,
-              "(original dim is ",
-              dim,
-              ")");
-  TORCH_CHECK(!self.is_complex(), "cumulative ops are not yet supported for complex");
-  auto input = dtype.has_value() ? self.to(dtype.value()) : self;
-
-  // issue #103810551: cumsum / cumprod are broken for int8, int16 and as chances for overflow are pretty high, cast to
-  // int32 fixed in macOS 13.3
-  bool castInputData = (isIntegralType(input.scalar_type(), true) && input.scalar_type() != ScalarType::Int &&
-                        input.scalar_type() != ScalarType::Long);
-
-  TORCH_CHECK(macOS13_3_plus || input.scalar_type() != ScalarType::Long,
-              "MPS does not support ",
-              op_name,
-              " op with int64 input. Support has been added in macOS 13.3");
-
-  mps::unary_op(
-      input, result, op_name + std::to_string(dim), ^MPSGraphTensor*(MPSGraph* mpsGraph, MPSGraphTensor* inputTensor) {
-        if (castInputData) {
-          inputTensor = mps::castMPSTensor(mpsGraph, inputTensor, ScalarType::Int);
-        }
-        MPSGraphTensor* rc;
-        if (cumulativeOpType == MPSCumulativeOpType::CUMSUM) {
-          rc = [mpsGraph cumulativeSumWithTensor:inputTensor axis:dim name:nil];
-        } else if (cumulativeOpType == MPSCumulativeOpType::CUMPROD) {
-          rc = [mpsGraph cumulativeProductWithTensor:inputTensor axis:dim name:nil];
-        }
-        if ((mps::getMPSDataType(result) != [rc dataType]) || castInputData) {
-          return mps::castMPSTensor(mpsGraph, rc, result.scalar_type());
-        }
-        return rc;
-      });
-}
-
-TORCH_IMPL_FUNC(cumsum_out_mps)
-(const Tensor& self, int64_t dim, std::optional<ScalarType> dtype, const Tensor& result) {
-  return cumulative_op_impl(self, dim, dtype, result, MPSCumulativeOpType::CUMSUM, "cumsum_out_mps");
-}
-
-TORCH_IMPL_FUNC(cumprod_out_mps)
-(const Tensor& self, int64_t dim, std::optional<ScalarType> dtype, const Tensor& result) {
-  return cumulative_op_impl(self, dim, dtype, result, MPSCumulativeOpType::CUMPROD, "cumprod_out_mps");
 }
 
 TORCH_IMPL_FUNC(sgn_out_mps)(const Tensor& self, const Tensor& output) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3736,13 +3736,11 @@
   dispatch:
     CPU: _logcumsumexp_cpu
     CUDA: _logcumsumexp_cuda
-    MPS: _logcumsumexp_mps
 
 - func: _logcumsumexp.out(Tensor self, int dim, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _logcumsumexp_out_cpu
     CUDA: _logcumsumexp_out_cuda
-    MPS: _logcumsumexp_out_mps
 
 - func: logcumsumexp(Tensor self, int dim) -> Tensor
   variants: function, method

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1962,6 +1962,7 @@
   dispatch:
     CPU: cummax_helper_cpu
     CUDA: cummax_helper_cuda
+    MPS: cummax_helper_mps
 
 - func: cummin(Tensor self, int dim) -> (Tensor values, Tensor indices)
   device_check: NoCheck   # TensorIterator
@@ -1986,6 +1987,7 @@
   dispatch:
     CPU: cummin_helper_cpu
     CUDA: cummin_helper_cuda
+    MPS: cummin_helper_mps
 
 - func: cummaxmin_backward(Tensor grad, Tensor input, Tensor indices, int dim) -> Tensor
   variants: function
@@ -2005,8 +2007,7 @@
   structured: True
   device_check: NoCheck   # TensorIterator
   dispatch:
-    CPU, CUDA: cumprod_out
-    MPS: cumprod_out_mps
+    CPU, CUDA, MPS: cumprod_out
 
 - func: cumprod.dimname(Tensor self, Dimname dim, *, ScalarType? dtype=None) -> Tensor
   device_check: NoCheck   # TensorIterator
@@ -2037,8 +2038,7 @@
   structured: True
   device_check: NoCheck   # TensorIterator
   dispatch:
-    CPU, CUDA: cumsum_out
-    MPS: cumsum_out_mps
+    CPU, CUDA, MPS: cumsum_out
 
 - func: cumsum.dimname(Tensor self, Dimname dim, *, ScalarType? dtype=None) -> Tensor
   device_check: NoCheck   # TensorIterator
@@ -3736,11 +3736,13 @@
   dispatch:
     CPU: _logcumsumexp_cpu
     CUDA: _logcumsumexp_cuda
+    MPS: _logcumsumexp_mps
 
 - func: _logcumsumexp.out(Tensor self, int dim, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _logcumsumexp_out_cpu
     CUDA: _logcumsumexp_out_cuda
+    MPS: _logcumsumexp_out_mps
 
 - func: logcumsumexp(Tensor self, int dim) -> Tensor
   variants: function, method

--- a/c10/metal/utils.h
+++ b/c10/metal/utils.h
@@ -90,24 +90,12 @@ struct OpMathType<bfloat> {
 template <typename T>
 struct AccumulationType {
   using type = T;
-  static type to_accum(T val) {
-    return val;
-  }
-  static T from_accum(type val) {
-    return val;
-  }
 };
 
 // Specialization for half - promote to float for accumulation
 template <>
 struct AccumulationType<half> {
   using type = float;
-  static type to_accum(half val) {
-    return static_cast<float>(val);
-  }
-  static half from_accum(type val) {
-    return static_cast<half>(val);
-  }
 };
 
 #if __METAL_VERSION__ >= 310
@@ -115,12 +103,6 @@ struct AccumulationType<half> {
 template <>
 struct AccumulationType<bfloat> {
   using type = float;
-  static type to_accum(bfloat val) {
-    return static_cast<float>(val);
-  }
-  static bfloat from_accum(type val) {
-    return static_cast<bfloat>(val);
-  }
 };
 #endif
 
@@ -170,6 +152,9 @@ using vec4type_t = typename detail::vectypes<T>::type4;
 
 template <typename T>
 using opmath_t = typename detail::OpMathType<T>::type;
+
+template <typename T>
+using accum_t = typename detail::AccumulationType<T>::type;
 
 // TODO: Move it to type_traits header may be
 template <typename F, typename... Args>

--- a/c10/metal/utils.h
+++ b/c10/metal/utils.h
@@ -85,6 +85,45 @@ struct OpMathType<bfloat> {
   using type = float;
 };
 #endif
+
+// Type promotion structure for higher precision accumulation
+template <typename T>
+struct AccumulationType {
+  using type = T;
+  static type to_accum(T val) {
+    return val;
+  }
+  static T from_accum(type val) {
+    return val;
+  }
+};
+
+// Specialization for half - promote to float for accumulation
+template <>
+struct AccumulationType<half> {
+  using type = float;
+  static type to_accum(half val) {
+    return static_cast<float>(val);
+  }
+  static half from_accum(type val) {
+    return static_cast<half>(val);
+  }
+};
+
+#if __METAL_VERSION__ >= 310
+// Specialization for bfloat - promote to float for accumulation
+template <>
+struct AccumulationType<bfloat> {
+  using type = float;
+  static type to_accum(bfloat val) {
+    return static_cast<float>(val);
+  }
+  static bfloat from_accum(type val) {
+    return static_cast<bfloat>(val);
+  }
+};
+#endif
+
 } // namespace detail
 
 template <typename T>

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2652,6 +2652,7 @@ class CommonTemplate:
                 inp = torch.full((2, n), float("inf"), device=self.device, dtype=_dtype)
                 self.assertEqual(cfn(inp), fn(inp))
 
+    @xfail_if_mps_unimplemented
     @xfail_if_triton_cpu
     def test_logcumsumexp(self):
         def fn(x):
@@ -2678,6 +2679,7 @@ class CommonTemplate:
             rtol=1e-5,
         )
 
+    @xfail_if_mps_unimplemented
     def test_logcumsumexp_zero_dim(self):
         def fn(x):
             return x.logcumsumexp(0), x.logcumsumexp(-1)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2566,7 +2566,6 @@ class CommonTemplate:
         self.common(fn, (torch.ones(32, 32) * 70,))
 
     @skip_if_halide
-    @xfail_if_mps_unimplemented  # aten::_cummin_helper is not implemented for MPS
     def test_cummin(self):
         def fn(x):
             return x.cummin(0)
@@ -2653,7 +2652,6 @@ class CommonTemplate:
                 inp = torch.full((2, n), float("inf"), device=self.device, dtype=_dtype)
                 self.assertEqual(cfn(inp), fn(inp))
 
-    @xfail_if_mps_unimplemented
     @xfail_if_triton_cpu
     def test_logcumsumexp(self):
         def fn(x):
@@ -2680,7 +2678,6 @@ class CommonTemplate:
             rtol=1e-5,
         )
 
-    @xfail_if_mps_unimplemented
     def test_logcumsumexp_zero_dim(self):
         def fn(x):
             return x.logcumsumexp(0), x.logcumsumexp(-1)

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -416,6 +416,7 @@ if torch.backends.mps.is_available():
             "linalg.qr": None,
             "linalg.svdvals": None,
             "linalg.vecdot": None,
+            "logcumsumexp": None,
             "lu_solve": None,
             "masked.median": None,
             "matrix_exp": None,
@@ -1001,6 +1002,8 @@ if torch.backends.mps.is_available():
             "aminmax",
             # memory overlapping checks
             "index_select",
+            # unimplemented
+            "logcumsumexp",
         }
 
         def addDecorator(op: OpInfo, d: DecorateInfo) -> None:

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -313,11 +313,6 @@ if torch.backends.mps.is_available():
             # but in case of the returned indices this results in undefined behaviour.
             "sort": [torch.int8, torch.uint8, torch.bool, torch.float16],
             # Unsupported dtypes
-            "cumsum": [torch.int64],
-            "cumprod": [torch.int64],
-            "cumulative_trapezoid": [torch.int64],
-            "masked.cumsum": [torch.int64],
-            "masked.cumprod": [torch.int64],
             "linalg.vander": [torch.int64],
             # Fail with `Expected 1.0 but got nan.` for empty tensors
             # Caused by sample input at index 23: SampleInput(

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -386,8 +386,6 @@ if torch.backends.mps.is_available():
             "cauchy": None,
             "cholesky_inverse": None,
             "cholesky_solve": None,
-            "cummax": None,
-            "cummin": None,
             "frexp": None,
             "gcd": None,
             "geqrf": None,
@@ -418,7 +416,6 @@ if torch.backends.mps.is_available():
             "linalg.qr": None,
             "linalg.svdvals": None,
             "linalg.vecdot": None,
-            "logcumsumexp": None,
             "lu_solve": None,
             "masked.median": None,
             "matrix_exp": None,
@@ -1004,8 +1001,6 @@ if torch.backends.mps.is_available():
             "aminmax",
             # memory overlapping checks
             "index_select",
-            # unimplemented
-            "logcumsumexp",
         }
 
         def addDecorator(op: OpInfo, d: DecorateInfo) -> None:

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -312,8 +312,6 @@ if torch.backends.mps.is_available():
             # The values of the sorted tensor match the CPU,
             # but in case of the returned indices this results in undefined behaviour.
             "sort": [torch.int8, torch.uint8, torch.bool, torch.float16],
-            # Unsupported dtypes
-            "linalg.vander": [torch.int64],
             # Fail with `Expected 1.0 but got nan.` for empty tensors
             # Caused by sample input at index 23: SampleInput(
             #     input=Tensor[size=(), device="mps:0", dtype=torch.float32],


### PR DESCRIPTION
Implements metal kernels for scan operations:
- Migrates cumsum and cumprod from MPSGraph implementation to Metal.
- Fixes #154881 
- Adds MPS backend support for cummin and cummax


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov