### PR TITLE
Bump transfomers version

### DIFF
--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -222,9 +222,7 @@ function checkout_install_torchbench() {
     python install.py --continue_on_fail
   fi
 
-  # TODO (huydhn): transformers-4.44.2 added by https://github.com/pytorch/benchmark/pull/2488
-  # is regressing speedup metric. This needs to be investigated further
-  pip install transformers==4.38.1
+  pip install transformers==4.52.4
 
   echo "Print all dependencies after TorchBench is installed"
   python -mpip freeze


### PR DESCRIPTION
I found in local testing that newer transformers versions are way faster on AMD multi-gpu because of a bug fix on flash attention. Waiting on these perf runs to see how it ends up overall:
- https://github.com/pytorch/pytorch/actions/runs/15691135784
- https://github.com/pytorch/pytorch/actions/runs/15691144423