### PR TITLE
Display a warning when overwriting `CMAKE_CUDA_ARCHITECTURES`

### DIFF
--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -313,7 +313,13 @@ endif()
 # setting nvcc arch flags
 torch_cuda_get_nvcc_gencode_flag(NVCC_FLAGS_EXTRA)
 # CMake 3.18 adds integrated support for architecture selection, but we can't rely on it
-set(CMAKE_CUDA_ARCHITECTURES OFF)
+if(DEFINED CMAKE_CUDA_ARCHITECTURES)
+  message(WARNING
+          "pytorch is not compatible with `CMAKE_CUDA_ARCHITECTURES` and will ignore its value. "
+          "Please configure `TORCH_CUDA_ARCH_LIST` instead.")
+  set(CMAKE_CUDA_ARCHITECTURES OFF)
+endif ()
+
 list(APPEND CUDA_NVCC_FLAGS ${NVCC_FLAGS_EXTRA})
 message(STATUS "Added CUDA NVCC flags for: ${NVCC_FLAGS_EXTRA}")
 

--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -318,7 +318,7 @@ if(DEFINED CMAKE_CUDA_ARCHITECTURES)
           "pytorch is not compatible with `CMAKE_CUDA_ARCHITECTURES` and will ignore its value. "
           "Please configure `TORCH_CUDA_ARCH_LIST` instead.")
   set(CMAKE_CUDA_ARCHITECTURES OFF)
-endif ()
+endif()
 
 list(APPEND CUDA_NVCC_FLAGS ${NVCC_FLAGS_EXTRA})
 message(STATUS "Added CUDA NVCC flags for: ${NVCC_FLAGS_EXTRA}")


### PR DESCRIPTION
Really, pytorch shoudn't be messing with basic _global_ cmake configuration like this, but without a careful analysis what all depends on this behaviour, I'm not confident to propose a change.
But at least notifying the user that something wonky is going on seems like a good idea.
@drisspg 