### PR TITLE
Fix HUD benchmark cold start: disable all caches

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -3520,6 +3520,8 @@ def run(runner, args, original_dir=None):
             torch._dynamo.config.assume_static_by_default = False
     if args.compiled_autograd:
         torch._dynamo.config.compiled_autograd = True
+    if args.cold_start_latency:
+        torch._inductor.config.force_disable_caches = True
     if args.propagate_real_tensors:
         # TODO: Separate flag for data dependent
         torch._dynamo.config.capture_scalar_outputs = True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #156124

https://ossci-raw-job-status.s3.amazonaws.com/log/43655332838

From adhoc nightly runs with the compiled autograd configuration, I see that at least AOTAutograd cache is turned on in the benchmark:
```python
2025-06-07T04:41:08.1329432Z   File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/torch/_dynamo/compiled_autograd.py", line 1354, in set_node_origin
2025-06-07T04:41:08.1330022Z     raise RuntimeError(
2025-06-07T04:41:08.1330639Z RuntimeError: This compiled backward function was saved by AOTAutogradCache, which does not support
2025-06-07T04:41:08.1331301Z                     compiled autograd. Please turn off AOTAutogradCache using `TORCHINDUCTOR_AUTOGRAD_CACHE=0`.
```

When we use the --cold-start-latency (all the performance tests) configuration, we should be disabling all caches. We can keep the cache for the warm start, which is used for accuracy tests.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames