### PR TITLE
Pass by const ref instead of by value in StableIValue from

### DIFF
--- a/torch/csrc/stable/library.h
+++ b/torch/csrc/stable/library.h
@@ -31,7 +31,7 @@ namespace detail {
 // Specialization for general copyable types (catch-all) => StableIValue
 template <typename T>
 struct FromImpl {
-  static StableIValue call(T val) {
+  static StableIValue call(const T& val) {
     static_assert(
         sizeof(T) <= sizeof(StableIValue),
         "StableLibrary stack does not support parameter types larger than 64 bits.");
@@ -44,7 +44,7 @@ struct FromImpl {
     // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107361) We have a
     // static_assert above that T is trivially copyable, which should be
     // enough.
-    std::memcpy(&result, reinterpret_cast<void*>(&val), sizeof(val));
+    std::memcpy(&result, reinterpret_cast<const void*>(&val), sizeof(val));
     return result;
   }
 };
@@ -52,7 +52,7 @@ struct FromImpl {
 // Specialization for std::nullopt_t => StableIValue
 template <>
 struct FromImpl<std::nullopt_t> {
-  static StableIValue call(std::nullopt_t val) {
+  static StableIValue call(const std::nullopt_t& val) {
     return from(nullptr);
   }
 };
@@ -88,7 +88,7 @@ struct FromImpl<std::nullopt_t> {
 // std::optional<T> or a std::nullopt.
 template <typename T>
 struct FromImpl<std::optional<T>> {
-  static StableIValue call(std::optional<T> val) {
+  static StableIValue call(const std::optional<T>& val) {
     if (!val.has_value()) {
       return from(std::nullopt);
     }
@@ -101,7 +101,7 @@ struct FromImpl<std::optional<T>> {
 // Returns a new owning reference of the underlying Tensor.
 template <>
 struct FromImpl<torch::stable::Tensor> {
-  static StableIValue call(torch::stable::Tensor val) {
+  static StableIValue call(const torch::stable::Tensor& val) {
     AtenTensorHandle new_ath;
     aoti_torch_new_tensor_handle(val.get(), &new_ath);
     return from(new_ath);

--- a/torch/csrc/stable/library.h
+++ b/torch/csrc/stable/library.h
@@ -186,6 +186,7 @@ StableIValue from(const std::optional<T>& val) {
 }
 
 // The below overload is used! See https://godbolt.org/z/859cshxrW
+// We are suppressing the warning for versions clang12- and gcc11-
 [[maybe_unused]] StableIValue from(const torch::stable::Tensor& val) {
   return detail::FromImpl<torch::stable::Tensor>::call(val);
 }

--- a/torch/csrc/stable/library.h
+++ b/torch/csrc/stable/library.h
@@ -181,6 +181,15 @@ StableIValue from(T val) {
 }
 
 template <typename T>
+StableIValue from(const std::optional<T>& val) {
+  return detail::FromImpl<std::optional<T>>::call(val);
+}
+
+StableIValue from(const torch::stable::Tensor& val) {
+  return detail::FromImpl<torch::stable::Tensor>::call(val);
+}
+
+template <typename T>
 T to(StableIValue val) {
   return detail::ToImpl<T>::call(val);
 }

--- a/torch/csrc/stable/library.h
+++ b/torch/csrc/stable/library.h
@@ -185,7 +185,8 @@ StableIValue from(const std::optional<T>& val) {
   return detail::FromImpl<std::optional<T>>::call(val);
 }
 
-StableIValue from(const torch::stable::Tensor& val) {
+// The below overload is used! See https://godbolt.org/z/859cshxrW
+[[maybe_unused]] StableIValue from(const torch::stable::Tensor& val) {
   return detail::FromImpl<torch::stable::Tensor>::call(val);
 }
 

--- a/torch/csrc/stable/library.h
+++ b/torch/csrc/stable/library.h
@@ -31,7 +31,7 @@ namespace detail {
 // Specialization for general copyable types (catch-all) => StableIValue
 template <typename T>
 struct FromImpl {
-  static StableIValue call(const T& val) {
+  static StableIValue call(T val) {
     static_assert(
         sizeof(T) <= sizeof(StableIValue),
         "StableLibrary stack does not support parameter types larger than 64 bits.");
@@ -52,7 +52,7 @@ struct FromImpl {
 // Specialization for std::nullopt_t => StableIValue
 template <>
 struct FromImpl<std::nullopt_t> {
-  static StableIValue call(const std::nullopt_t& val) {
+  static StableIValue call(std::nullopt_t val) {
     return from(nullptr);
   }
 };


### PR DESCRIPTION
I realize I was passing stable::Tensors by value (thus making a copy every time) which is not what I want from the `from` function that converts Ts to StableIValues. `from` should not mutate the input and should be read-only.

I asked an LLM whether this is API BC breaking (with an intuition that it shouldn't be), and it said no, cuz:
1. "Passing by const reference is more permissive than passing by value. e.g., if T is a type that has a deleted or inaccessible copy constructor (e.g., std::unique_ptr), the original code would have been invalid, while the new code would be valid." Nice. We are good with additive.
2. We didn't modify the original input before (cuz we took a copy) and we don't now (cuz we promise const).

Update: The LLM failed to mention primitives, with which we should not pass references around, so we are only changing the signatures of std::optional<T> and stable::Tensor

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #156126
* #155977
* #155367

