### PR TITLE
[CI] Reuse old whl: loosen check for deleted files, do not handle renames

### DIFF
--- a/.github/actions/reuse-old-whl/reuse_old_whl.py
+++ b/.github/actions/reuse-old-whl/reuse_old_whl.py
@@ -132,7 +132,7 @@ def check_changed_files(sha: str) -> bool:
     # Return true if all the changed files are in the list of allowed files to
     # be changed to reuse the old whl
 
-    # Removing files in the torch folder is not allowed since rysnc will not
+    # Removing files in the torch folder is not allowed since rsync will not
     # remove files
     removed_files = (
         subprocess.check_output(

--- a/.github/actions/reuse-old-whl/reuse_old_whl.py
+++ b/.github/actions/reuse-old-whl/reuse_old_whl.py
@@ -132,17 +132,26 @@ def check_changed_files(sha: str) -> bool:
     # Return true if all the changed files are in the list of allowed files to
     # be changed to reuse the old whl
 
-    # Removing any files is not allowed since rsync will not remove files
+    # Removing files in the torch folder is not allowed since rysnc will not
+    # remove files
     removed_files = (
         subprocess.check_output(
-            ["git", "diff", "--name-only", sha, "HEAD", "--diff-filter=D"],
+            [
+                "git",
+                "diff",
+                "--name-only",
+                sha,
+                "HEAD",
+                "--diff-filter=D",
+                "--no-renames",
+            ],
             text=True,
             stderr=subprocess.DEVNULL,
         )
         .strip()
         .split()
     )
-    if removed_files:
+    if any(file.startswith("torch/") for file in removed_files):
         print(
             f"Removed files between {sha} and HEAD: {removed_files}, cannot reuse old whl"
         )
@@ -150,7 +159,7 @@ def check_changed_files(sha: str) -> bool:
 
     changed_files = (
         subprocess.check_output(
-            ["git", "diff", "--name-only", sha, "HEAD"],
+            ["git", "diff", "--name-only", sha, "HEAD", "--no-renames"],
             text=True,
             stderr=subprocess.DEVNULL,
         )


### PR DESCRIPTION
Make the check for deleted files only be for files in the torch folder since docs only changes could not get through this
Use `--no-renames` to make both the old name and the old name show up in the diff.  Without it I think only the new name shows up in git diff