### PR TITLE
[ez] Save the format as pt for HF saves

### DIFF
--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -444,6 +444,7 @@ def _write_files_from_queue(
                             metadata={
                                 "DCP_SHARDING_INFO": json.dumps(metadata_dict),
                                 "DCP_VERSION": "1.0",
+                                "format": "pt",
                             },
                         )
                     )


### PR DESCRIPTION
Summary: Got a user report that they weren't able to load dcp saved checkpoints with transformers library. Took a quick look and it's because the library is expecting a format to be saved and it throws if not (https://github.com/huggingface/transformers/blob/e61160c5dbd470c4644e6c248d2acb64f763b6d5/src/transformers/modeling_utils.py#L537). This PR adds a format on save.

Test Plan:
ensure existing tests pass

Rollback Plan:

Differential Revision: D76781469


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k