### PR TITLE
Optimize scatter/gather kernel for ARM.

### DIFF
--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -132,10 +132,6 @@
 #include <ATen/ops/zeros_like.h>
 #endif
 
-#ifdef USE_FBGEMM
-#include <fbgemm/Utils.h>
-#endif
-
 #include <c10/util/Unroll.h>
 #include <c10/util/irange.h>
 
@@ -1999,6 +1995,14 @@ Tensor index_fill(
   return self.clone(at::MemoryFormat::Preserve).index_fill_(dim, index, source);
 }
 
+bool is_radix_sort_accelerated_with_openmp() {
+  #ifdef _OPENMP
+    return true;
+  #else
+    return false;
+  #endif
+}
+
 // fast paths for GNN usage
 static bool can_use_expanded_index_path(
     const Tensor& self,
@@ -2006,13 +2010,6 @@ static bool can_use_expanded_index_path(
     const Tensor& index,
     const Tensor& src,
     bool is_scatter_like) {
-#ifdef USE_FBGEMM
-  if (!fbgemm::is_radix_sort_accelerated_with_openmp()) {
-    return false;
-  }
-#else
-  return false;
-#endif
 
   if (!self.device().is_cpu()) {
     return false;

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -2011,10 +2011,10 @@ static bool can_use_expanded_index_path(
     return false;
   }
 #elif defined(__aarch64__)
-  // On ARM, only allow fast path if OpenMP is available
-  #ifndef _OPENMP
-    return false;
-  #endif
+// On ARM, only allow fast path if OpenMP is available
+#ifndef _OPENMP
+  return false;
+#endif
 #else
   return false;
 #endif

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -132,6 +132,10 @@
 #include <ATen/ops/zeros_like.h>
 #endif
 
+#ifdef USE_FBGEMM
+#include <fbgemm/Utils.h>
+#endif
+
 #include <c10/util/Unroll.h>
 #include <c10/util/irange.h>
 
@@ -1995,14 +1999,6 @@ Tensor index_fill(
   return self.clone(at::MemoryFormat::Preserve).index_fill_(dim, index, source);
 }
 
-bool is_radix_sort_accelerated_with_openmp() {
-  #ifdef _OPENMP
-    return true;
-  #else
-    return false;
-  #endif
-}
-
 // fast paths for GNN usage
 static bool can_use_expanded_index_path(
     const Tensor& self,
@@ -2010,6 +2006,18 @@ static bool can_use_expanded_index_path(
     const Tensor& index,
     const Tensor& src,
     bool is_scatter_like) {
+#ifdef USE_FBGEMM
+  if (!fbgemm::is_radix_sort_accelerated_with_openmp()) {
+    return false;
+  }
+#elif defined(__aarch64__)
+  // On ARM, only allow fast path if OpenMP is available
+  #ifndef _OPENMP
+    return false;
+  #endif
+#else
+  return false;
+#endif
 
   if (!self.device().is_cpu()) {
     return false;

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -2010,13 +2010,11 @@ static bool can_use_expanded_index_path(
   if (!fbgemm::is_radix_sort_accelerated_with_openmp()) {
     return false;
   }
-#elif defined(__aarch64__)
-// On ARM, only allow fast path if OpenMP is available
+#else
+// On non-FBGEMM platforms, allow fast path only if OpenMP is available
 #ifndef _OPENMP
   return false;
 #endif
-#else
-  return false;
 #endif
 
   if (!self.device().is_cpu()) {

--- a/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
+++ b/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
@@ -695,7 +695,7 @@ void update_prefsum_and_offset_in_range(
   }
 }
 
-static void combine_prefix_sum(
+static inline void combine_prefix_sum(
     const int nthreads,
     const int64_t elements_count,
     const int64_t* const histogram,
@@ -710,7 +710,7 @@ static void combine_prefix_sum(
   (void)elements_count;
 }
 
-static void combine_prefix_sum_for_msb(
+static inline void combine_prefix_sum_for_msb(
     const int nthreads,
     const int64_t elements_count,
     const int64_t* const histogram,

--- a/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
+++ b/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
@@ -832,8 +832,8 @@ std::pair<K*, V*> radix_sort_parallel(
 
   const auto maxthreads = omp_get_max_threads();
 
-  alignas(64) int64_t histogram[RDX_HIST_SIZE * maxthreads];
-  alignas(64) int64_t histogram_ps[RDX_HIST_SIZE * maxthreads];
+  std::vector<int64_t> histogram(RDX_HIST_SIZE * maxthreads, 0);
+  std::vector<int64_t> histogram_ps(RDX_HIST_SIZE * maxthreads, 0);
 
   // If negative values are present, we want to perform all passes
   // up to a sign bit
@@ -858,8 +858,8 @@ std::pair<K*, V*> radix_sort_parallel(
           output_keys,
           output_values,
           elements_count,
-          histogram,
-          histogram_ps,
+          histogram.data(),
+          histogram_ps.data(),
           pass,
           maybe_with_neg_vals && pass == num_passes - 1);
 

--- a/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
+++ b/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
@@ -697,7 +697,7 @@ void update_prefsum_and_offset_in_range(
 
 static inline void combine_prefix_sum(
     const int nthreads,
-    const int64_t elements_count,
+    [[maybe_unused]] const int64_t elements_count,
     const int64_t* const histogram,
     int64_t* const histogram_ps) {
   int64_t offset = 0;
@@ -706,13 +706,11 @@ static inline void combine_prefix_sum(
   // TODO(DamianSzwichtenberg): Is assert sufficient? In most cases, it will
   // work only in debug build.
   assert(offset == elements_count);
-  // Suppress unused variable warning
-  (void)elements_count;
 }
 
 static inline void combine_prefix_sum_for_msb(
     const int nthreads,
-    const int64_t elements_count,
+    [[maybe_unused]] const int64_t elements_count,
     const int64_t* const histogram,
     int64_t* const histogram_ps) {
   int64_t offset = 0;
@@ -723,8 +721,6 @@ static inline void combine_prefix_sum_for_msb(
   // TODO(DamianSzwichtenberg): Is assert sufficient? In most cases, it will
   // work only in debug build.
   assert(offset == elements_count);
-  // Suppress unused variable warning
-  (void)elements_count;
 }
 
 template <typename K, typename V>

--- a/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
+++ b/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
@@ -695,7 +695,7 @@ void update_prefsum_and_offset_in_range(
   }
 }
 
-void combine_prefix_sum(
+static void combine_prefix_sum(
     const int nthreads,
     const int64_t elements_count,
     const int64_t* const histogram,
@@ -710,7 +710,7 @@ void combine_prefix_sum(
   (void)elements_count;
 }
 
-void combine_prefix_sum_for_msb(
+static void combine_prefix_sum_for_msb(
     const int nthreads,
     const int64_t elements_count,
     const int64_t* const histogram,

--- a/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
+++ b/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
@@ -677,8 +677,10 @@ std::pair<K*, V*> radix_sort_parallel(
 
 // implementation taken from FBGEMM/src/Utils.cc
 namespace {
-// histogram size per thread
-constexpr int RDX_HIST_SIZE = 256;
+// In radix sort, we extract one byte (8 bits) per pass from each key,
+// which yields 256 (2^8) distinct values. Therefore, we use 256 histogram bins
+// to count the frequency of each byte value during a pass.
+constexpr int RDX_HIST_SIZE = 256; // histogram size per thread
 
 void update_prefsum_and_offset_in_range(
     int64_t& offset,

--- a/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
+++ b/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
@@ -930,6 +930,10 @@ void cpu_scatter_reduce_expanded_index(const Tensor& self, const Tensor& index, 
   int64_t* sorted_col_index_keys = nullptr;
   int64_t* sorted_col_index_values = nullptr;
 
+// We maintain the FBGEMM path for x86 platforms to leverage potential
+// architecture-specific assembly/intrinsic optimizations in that library.
+// For ARM and other non-x86 platforms, we use the in-tree radix_sort_parallel
+// implementation to ensure parity in performance.
 #if defined(USE_FBGEMM)
   std::tie(sorted_col_index_keys, sorted_col_index_values) = fbgemm::radix_sort_parallel(
       keys.get(),


### PR DESCRIPTION
**Optimize scatter/gather kernel for ARM.**

*Retain FBGEMM kernel for x86.
*Unlocking expanded-index fast path and major speedup on ARM CPU's.

**Performance Evaluation:**
**Hardware used:** Graviton 3 - 32 core
 **Package versions:**
  torch              v2.7.0
  torch_geometric    v2.4.0

**Testing:**
Benchmarked the optimized scatter/gather kernel implementation on an ARM-based 
Graviton3 server using a graph neural network inference workload with PyTorch Geometric. 
Loaded 100 real-world graph samples and performed multiple warmup and timed inference 
passes using a pre-trained model. Profiling was enabled via torch.profiler (CPU-only) 
to capture per-op performance metrics. The profiler traces and MSE accuracy 
confirmed both functional correctness and significant speedup for 
scatter/gather-heavy workloads on ARM.




**Total Evaluation Time:**

| **OMP\_NUM\_THREADS / Cores** | **Original (v2.7.0) Time** | **fbgemm-patched (v2.7.0 + patch) Time** |
| ----------------------------- | -------------------------- | ---------------------------------------- |
| 16 / 32                       | 169.58s                    | 144.23s                                  |
| 32 / 32                       | 165.42s                    | 138.70s                                |

**Summary:**
With the fbgemm patch, total evaluation time decreased from 169.58s to 144.23s (a 15% reduction) with 16 threads, and from 165.42s to 138.70s (a 16% reduction) with 32 threads.
This highlights a consistent end-to-end inference speedup across thread counts on ARM.
____________________________________________________________________________________________________________________________

**PyTorch profiler Data:**
| Version                   | OMP\_NUM\_THREADS | Self CPU % | Self CPU Time (ms) |
| ------------------------- | ----------------- | ---------- | ------------------ |
| **Official v2.7.0**       | 16                | 21.15%     | 365.06             |
| **Official v2.7.0**       | 32                | 21.03%     | 353.87             |
| **v2.7.0 + fbgemm patch** | 16                | 10.32%     | 153.30             |
| **v2.7.0 + fbgemm patch** | 32                | 5.70%      | 79.31              |


__________________________________________________________________________________________________________________________________

**Total time taken by the kernel (In ms):**
| OMP\_NUM\_THREADS | Official Time (ms) | Patched Time (ms) | Speedup (×) | Time Reduction (%) |
| ----------------- | ------------------ | ----------------- | ----------- | ------------------ |
| 16                | 365.06             | 153.30            | **2.38×**   | **57.99%**         |
| 32                | 353.87             | 79.31             | **4.46×**   | **77.59%**         |

**Summary:**
With OMP_NUM_THREADS=16, the fbgemm patch reduced scatter_add_ CPU time by ~58% (2.38× faster).

With OMP_NUM_THREADS=32, the patch reduced scatter_add_ CPU time by ~78% (4.46× faster).

The patch also reduced the relative CPU usage of scatter kernels (Self CPU %) substantially.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @snadampal @milpuz01 @nikhil-arm @fadara01 @robert-hardwick @nWEIdia @malfet