### PR TITLE
Add regression test for Conv2d 1x1 vs Linear equivalence (#156154)

### DIFF
--- a/test/test_nn/test_conv1x1_linear_mismatch.py
+++ b/test/test_nn/test_conv1x1_linear_mismatch.py
@@ -1,0 +1,22 @@
+import torch
+import torch.nn as nn
+
+def test_conv1x1_linear_mismatch():
+    print("✅ Test file is running...")
+
+    conv = nn.Conv2d(4, 5, 1)
+    linear = nn.Linear(4, 5)
+
+    linear.weight.data = conv.weight.data.view(5, 4)
+    linear.bias.data = conv.bias.data
+
+    x = torch.randn(2, 4, 1, 1)
+
+    out_conv = conv(x).view(2, 5)
+    out_linear = linear(x.view(2, 4))
+
+    print("Conv output:\n", out_conv)
+    print("Linear output:\n", out_linear)
+
+    torch.testing.assert_close(out_conv, out_linear, rtol=1e-5, atol=1e-7)
+


### PR DESCRIPTION
Fixes #156154
This PR adds a regression test for issue [#156154](https://github.com/pytorch/pytorch/issues/156154).

---

###  Summary

Conv2d with `kernel_size=1` and Linear layers should behave identically when initialized with the same weights and biases. The issue reports divergence when `batch_size > 1`.

---

### What this PR adds

- A unit test under `test/test_nn/` that compares `nn.Conv2d(4, 5, 1)` and `nn.Linear(4, 5)` with matched parameters.
- Uses `torch.testing.assert_close()` to check output equivalence.
- Helps guard against backend or layout regressions.

---

### Notes

- This test passes on CPU in my local setup.
- May expose backend-specific or dispatch inconsistencies.

cc @pytorch/pytorch-maintainers @albanD
