### PR TITLE
[Native][CPU][TopK] Improve perf by reducing swap operations

### DIFF
--- a/aten/src/ATen/native/TopKImpl.h
+++ b/aten/src/ATen/native/TopKImpl.h
@@ -43,7 +43,7 @@ void topk_impl_loop(
   }
   using elem_t = std::pair<accscalar_t, int64_t>;
 
-  auto use_partial_sort = k * 64 <= dim_size;
+  const auto use_partial_sort = k * 64 <= dim_size;
   std::vector<elem_t> queue(use_partial_sort ? k : dim_size);
   for (const auto i : c10::irange(n)) {
     TensorAccessor<scalar_t, 1> mode_values(

--- a/aten/src/ATen/native/TopKImpl.h
+++ b/aten/src/ATen/native/TopKImpl.h
@@ -1,6 +1,6 @@
 #pragma once
-#include <ATen/core/TensorAccessor.h>
 #include <ATen/NumericUtils.h>
+#include <ATen/core/TensorAccessor.h>
 
 namespace at::native {
 
@@ -20,69 +20,124 @@ void topk_impl_loop(
     const int64_t dim_size,
     const bool largest,
     const bool sorted,
-    char** data, const int64_t* strides, const int64_t n) {
-
+    char** data,
+    const int64_t* strides,
+    const int64_t n) {
   // If k is zero, then output values and indices are empty tensors
   // So iterating over other dims is pointless
   if (k == 0) {
     return;
   }
   using elem_t = std::pair<accscalar_t, int64_t>;
-  std::vector<elem_t> queue(dim_size);
+
+  auto use_partial_sort = k * 64 <= dim_size;
+  std::vector<elem_t> queue(use_partial_sort ? k : dim_size);
   for (const auto i : c10::irange(n)) {
     TensorAccessor<scalar_t, 1> mode_values(
         reinterpret_cast<scalar_t*>(data[0] + i * strides[0]),
-        &k, &mode_values_stride);
+        &k,
+        &mode_values_stride);
     TensorAccessor<int64_t, 1> mode_indices(
         reinterpret_cast<int64_t*>(data[1] + i * strides[1]),
-        &k, &mode_indices_stride);
+        &k,
+        &mode_indices_stride);
     TensorAccessor<const scalar_t, 1> tmp_values(
         reinterpret_cast<scalar_t*>(data[2] + i * strides[2]),
-        &dim_size, &tmp_values_stride);
+        &dim_size,
+        &tmp_values_stride);
 
-    auto n_2 = dim_size;
-    auto use_partial_sort = k * 64 <= n_2;
-
-    for (const auto j : c10::irange(n_2)) {
+    for (const auto j : c10::irange(use_partial_sort ? k : dim_size)) {
       queue[j].first = tmp_values[j];
       queue[j].second = j;
     }
 
     // we want nan to be sorted as top for numpy compatibility
     if (use_partial_sort) {
+      auto queue_begin = queue.begin();
+      auto queue_end = queue.begin() + k;
+      auto& queue_front_ref = queue.front();
+      auto& queue_back_ref = queue.back();
       if (largest) {
-        std::partial_sort(queue.begin(), queue.begin() + k, queue.end(),
-          [](const elem_t& x, const elem_t& y) -> bool {
-            return ((_isnan<accscalar_t>(x.first) && !_isnan<accscalar_t>(y.first)) || (x.first > y.first));
-          });
+        auto comp = [](elem_t const& a, elem_t const& b) {
+          return (_isnan(a.first) && !_isnan(b.first)) || (a.first > b.first);
+        };
+        std::make_heap(queue_begin, queue_end, comp);
+
+        for (auto idx = k; idx < dim_size; ++idx) {
+          elem_t this_val{tmp_values[idx], idx};
+          if (comp(this_val, queue_front_ref)) {
+            std::pop_heap(queue_begin, queue_end, comp);
+            queue_back_ref = this_val;
+            std::push_heap(queue_begin, queue_end, comp);
+          }
+        }
+
+        if (sorted) {
+          std::sort_heap(queue_begin, queue_end, comp);
+        }
       } else {
-        std::partial_sort(queue.begin(), queue.begin() + k, queue.end(),
-          [](const elem_t& x, const elem_t& y) -> bool {
-            return ((!_isnan<accscalar_t>(x.first) && _isnan<accscalar_t>(y.first)) || (x.first < y.first));
-          });
+        auto comp = [](elem_t const& a, elem_t const& b) {
+          return (!_isnan(a.first) && _isnan(b.first)) || (a.first < b.first);
+        };
+        std::make_heap(queue_begin, queue_end, comp);
+
+        for (auto idx = k; idx < dim_size; ++idx) {
+          elem_t this_val{tmp_values[idx], idx};
+          if (comp(this_val, queue_front_ref)) {
+            std::pop_heap(queue_begin, queue_end, comp);
+            queue_back_ref = this_val;
+            std::push_heap(queue_begin, queue_end, comp);
+          }
+        }
+
+        if (sorted) {
+          std::sort_heap(queue_begin, queue_end, comp);
+        }
       }
     } else {
       if (largest) {
-        std::nth_element(queue.begin(), queue.begin() + k - 1, queue.end(),
-          [](const elem_t& x, const elem_t& y) -> bool {
-            return ((_isnan<accscalar_t>(x.first) && !_isnan<accscalar_t>(y.first)) || (x.first > y.first));
-          });
-        if (sorted) {
-          std::sort(queue.begin(), queue.begin() + k - 1,
+        std::nth_element(
+            queue.begin(),
+            queue.begin() + k - 1,
+            queue.end(),
             [](const elem_t& x, const elem_t& y) -> bool {
-              return ((_isnan<accscalar_t>(x.first) && !_isnan<accscalar_t>(y.first)) || (x.first > y.first));
+              return (
+                  (_isnan<accscalar_t>(x.first) &&
+                   !_isnan<accscalar_t>(y.first)) ||
+                  (x.first > y.first));
             });
+        if (sorted) {
+          std::sort(
+              queue.begin(),
+              queue.begin() + k - 1,
+              [](const elem_t& x, const elem_t& y) -> bool {
+                return (
+                    (_isnan<accscalar_t>(x.first) &&
+                     !_isnan<accscalar_t>(y.first)) ||
+                    (x.first > y.first));
+              });
         }
       } else {
-        std::nth_element(queue.begin(), queue.begin() + k -1, queue.end(),
-          [](const elem_t& x, const elem_t& y) -> bool {
-            return ((!_isnan<accscalar_t>(x.first) && _isnan<accscalar_t>(y.first)) || (x.first < y.first));
-          });
-        if (sorted) {
-          std::sort(queue.begin(), queue.begin() + k -1,
+        std::nth_element(
+            queue.begin(),
+            queue.begin() + k - 1,
+            queue.end(),
             [](const elem_t& x, const elem_t& y) -> bool {
-              return ((!_isnan<accscalar_t>(x.first) && _isnan<accscalar_t>(y.first)) || (x.first < y.first));
+              return (
+                  (!_isnan<accscalar_t>(x.first) &&
+                   _isnan<accscalar_t>(y.first)) ||
+                  (x.first < y.first));
             });
+        if (sorted) {
+          std::sort(
+              queue.begin(),
+              queue.begin() + k - 1,
+              [](const elem_t& x, const elem_t& y) -> bool {
+                return (
+                    (!_isnan<accscalar_t>(x.first) &&
+                     _isnan<accscalar_t>(y.first)) ||
+                    (x.first < y.first));
+              });
         }
       }
     }


### PR DESCRIPTION
Current implementation using `std::partial_sort` takes all pairs (keys and values) as its initial states which will lead to heavy memory footprint and access in some problems. This PR uses the first `k`-th data as the initial states in a `k`-length heap and go through all rest data with comparison to heap top and alternative heap push.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168