### PR TITLE
Engine reuse calling thread when only single device detected

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -14839,6 +14839,43 @@ class TestAutogradMultipleDispatch(TestCase):
         self.assertEqual(y.grad, 2 * torch.ones_like(x))
         self.assertEqual(z.grad, torch.ones_like(x))
 
+    @onlyCUDA
+    def test_single_device_threading_optimization(self):
+        class Func(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                return x
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                thread_ids.add(threading.get_ident())
+                return grad_output
+
+        thread_ids = set()
+        x_cuda = torch.randn(10, device="cuda", requires_grad=True)
+        y_cuda = torch.randn(10, device="cuda", requires_grad=True)
+        a = Func.apply(x_cuda)
+        b = Func.apply(y_cuda)
+        c = Func.apply(a + b)
+        d = Func.apply(c * 2)
+        d.sum().backward()
+        # Also include the calling thread
+        thread_ids.add(threading.get_ident())
+        self.assertEqual(len(thread_ids), 1)
+
+        thread_ids = set()
+        x_cpu = torch.randn(10, requires_grad=True)
+        x_cuda = torch.randn(10, device="cuda", requires_grad=True)
+        a_cpu = Func.apply(x_cpu)
+        a_cuda = Func.apply(x_cuda)
+        b_cpu = Func.apply(a_cpu * 2)
+        b_cuda = Func.apply(a_cuda * 3)
+        loss = b_cpu.sum() + b_cuda.cpu().sum()
+        loss.backward()
+        # Also include the calling thread
+        thread_ids.add(threading.get_ident())
+        self.assertEqual(len(thread_ids), 2)
+
 
 # Import test cases from below autograd/ here. These are found
 # implicitly by the loader, so Flake8 thinks they are unused, hence

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -1543,9 +1543,9 @@ auto Engine::ready_queue(
       !c10::AutogradState::get_tls_state().get_multithreading_enabled();
   // Note [ Engine threading optimization when single device ]
   //
-  // If during graph discovery, we find that there is only a single distinct
-  // device, we will reuse the calling thread. This can improve cache locality,
-  // etc.
+  // If during graph traversal, we find that there is only a single distinct
+  // device, we will reuse the calling thread. This can result in a perf win
+  // due to fewer cache misses, TLB misses, context switches, etc.
   //
   // The only situation current_graph_task is not yet set is when
   // execute_with_graph_task enqueues the very first task. We manually check

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -1787,4 +1787,3 @@ void GraphTask::init_to_execute(
 }
 
 } // namespace torch::autograd
- 

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -429,10 +429,11 @@ std::vector<Node*> get_current_graph_task_execution_order() {
     return {};
   }
 
-  // We could potentially check if there is only a single device here
-  // but explicitly require this context doesn't seem bad either
+  // Either the entire graph is on a single device, or multithreading was
+  // explicitly disabled.
   TORCH_CHECK(
-      !c10::AutogradState::get_tls_state().get_multithreading_enabled(),
+      (!c10::AutogradState::get_tls_state().get_multithreading_enabled() ||
+       task->num_distinct_devices_ == 1),
       "get_current_graph_task_execution_order expects the current backward to be "
       "executed with multithreading disabled, e.g. by running:\n\n"
       ">>> with torch.autograd.set_multithreading_enabled(False):\n"

--- a/torch/csrc/autograd/graph_task.h
+++ b/torch/csrc/autograd/graph_task.h
@@ -192,6 +192,9 @@ struct GraphTask : std::enable_shared_from_this<GraphTask> {
 
   uint64_t id_;
 
+  // See Note [ Engine threading optimization when single device ]
+  int num_distinct_devices_{0};
+
   GraphTask(
       bool keep_graph,
       bool grad_mode,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #156188

See internal post https://fb.workplace.com/groups/pytorch.dev/permalink/1800043063907499/

Before:
<img width="802" alt="image" src="https://github.com/user-attachments/assets/f4f0d44c-d29a-48a6-9840-82699dfd052f" />

After:
<img width="1060" alt="image" src="https://github.com/user-attachments/assets/62666ad6-2fd9-4c81-bcdd-d11f9b1ec3c0" />
