### PR TITLE
Fix torch.clamp CPU overflow with float16 tensors

### DIFF
--- a/c10/util/overflows.h
+++ b/c10/util/overflows.h
@@ -68,6 +68,16 @@ std::enable_if_t<std::is_floating_point_v<From>, bool> overflows(
   if (!limit::has_quiet_NaN && (f != f)) {
     return true;
   }
+  // For floating-point types that support infinity, allow finite values
+  // that exceed the representable range to be converted to infinity.
+  // This ensures consistent behavior between CPU and CUDA for operations
+  // like torch.clamp with float16 tensors.
+  if (limit::has_infinity) {
+    // Only reject NaN for types that don't support it (already handled above)
+    // Finite values outside the range will be converted to infinity by convert<>()
+    return false;
+  }
+  // For types without infinity support, keep strict overflow checking
   return f < limit::lowest() || f > limit::max();
 }
 


### PR DESCRIPTION
Fixes #155671: Allow infinity-supporting types to convert out-of-range values to infinity instead of throwing overflow errors.

This resolves the inconsistency where `torch.clamp()` would fail on CPU but succeed on CUDA when using float16 tensors with values exceeding the float16 maximum (~65504).

## Problem Visualization
![Diagram 1: Function call flow showing CPU/CUDA inconsistency](https://github.com/user-attachments/assets/1083285f-19b7-49b4-9a17-08564deeba25)

## Solution Logic  
![Diagram 2: Detailed fix implementation in c10::util::overflows](https://github.com/user-attachments/assets/530d004d-aa21-4ea4-85cb-bac21150c596)

## Before vs After
![Diagram 3: Side-by-side comparison showing problem resolution](https://github.com/user-attachments/assets/3f921464-43ee-4258-901c-7a5e9026605e)


These diagrams illustrate how my fix resolves the CPU/CUDA inconsistency by allowing infinity-supporting types to convert out-of-range values to infinity.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @malfet