### PR TITLE
[inductor] Set num_workers to number of available cpu divided by number of available gpu

### DIFF
--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2064,7 +2064,7 @@ def get_num_workers() -> int:
     )
     assert cpu_count
 
-    # Get the number of GPUs
+    # divide number of cpus by number of gpus for distributed workloads
     num_gpus = torch.cuda.device_count()
     if config.is_fbcode() and num_gpus > 0:
         cpu_count = cpu_count // num_gpus

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2063,6 +2063,12 @@ def get_num_workers() -> int:
         else os.cpu_count()
     )
     assert cpu_count
+
+    # Get the number of GPUs
+    num_gpus = torch.cuda.device_count()
+    if num_gpus > 0:
+        cpu_count = cpu_count // num_gpus
+
     return cpu_count
 
 

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2066,7 +2066,7 @@ def get_num_workers() -> int:
 
     # Get the number of GPUs
     num_gpus = torch.cuda.device_count()
-    if num_gpus > 0:
+    if config.is_fbcode() and num_gpus > 0:
         cpu_count = cpu_count // num_gpus
 
     return cpu_count

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2064,10 +2064,9 @@ def get_num_workers() -> int:
     )
     assert cpu_count
 
-    # divide number of cpus by number of gpus for distributed workloads
-    num_gpus = torch.cuda.device_count()
-    if config.is_fbcode() and num_gpus > 0:
-        cpu_count = cpu_count // num_gpus
+    # Divide the number of CPUs by the number of GPUs for distributed workloads
+    if config.is_fbcode() and torch.cuda.is_available() and torch.cuda.device_count() > 0:
+        cpu_count = cpu_count // torch.cuda.device_count()
 
     return cpu_count
 

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2065,7 +2065,11 @@ def get_num_workers() -> int:
     assert cpu_count
 
     # Divide the number of CPUs by the number of GPUs for distributed workloads
-    if config.is_fbcode() and torch.cuda.is_available() and torch.cuda.device_count() > 0:
+    if (
+        config.is_fbcode()
+        and torch.cuda.is_available()
+        and torch.cuda.device_count() > 0
+    ):
         cpu_count = cpu_count // torch.cuda.device_count()
 
     return cpu_count


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #156201

internal: https://fb.workplace.com/groups/1075192433118967/posts/1689562705015267/?comment_id=1690284241609780&notif_id=1749770611538976&notif_t=work_group_comment&ref=notif

Right now it doesn't have the divided by 2 logic yet. Not sure how to tell if we are on a dev machine.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov