### PR TITLE
Add size_hints_or_throw

### DIFF
--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -176,7 +176,9 @@ class InductorChoices:
         if cooperative_reduction:
             # The RSPLIT of cooperative reductions means each thread block is operating on fewer elements
             try:
-                threshold *= 32 // min(V.graph.sizevars.size_hint(features.numel), 32)
+                threshold *= 32 // min(
+                    V.graph.sizevars.size_hint_or_throw(features.numel), 32
+                )
             except ValueError:
                 pass  # unbacked symint
 

--- a/torch/_inductor/codegen/halide.py
+++ b/torch/_inductor/codegen/halide.py
@@ -643,8 +643,8 @@ def eq(left, right):
     if V.graph.sizevars.statically_known_equals(left, right):
         return True
     try:
-        a = V.graph.sizevars.size_hint(left)
-        b = V.graph.sizevars.size_hint(right)
+        a = V.graph.sizevars.size_hint_or_throw(left)
+        b = V.graph.sizevars.size_hint_or_throw(right)
     except TypeError:  # unbacked symints
         return False
     if a == b:
@@ -656,8 +656,8 @@ def lt(left, right):
     if V.graph.sizevars.statically_known_lt(left, right):
         return True
     try:
-        a = V.graph.sizevars.size_hint(left)
-        b = V.graph.sizevars.size_hint(right)
+        a = V.graph.sizevars.size_hint_or_throw(left)
+        b = V.graph.sizevars.size_hint_or_throw(right)
     except TypeError:  # unbacked symints
         gcd = sympy.gcd(left, right)
         if gcd == left:

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -611,9 +611,7 @@ class DebugFormatter:
                     static_layout = FixedLayout(
                         layout.device,
                         dtype=layout.dtype,
-                        size=list(
-                            V.graph.sizevars.size_hints_or_throw(layout.size)
-                        ),
+                        size=list(V.graph.sizevars.size_hints_or_throw(layout.size)),
                         stride=list(
                             V.graph.sizevars.size_hints_or_throw(layout.stride)
                         ),

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -611,8 +611,12 @@ class DebugFormatter:
                     static_layout = FixedLayout(
                         layout.device,
                         dtype=layout.dtype,
-                        size=[*V.graph.sizevars.size_hints(layout.size)],
-                        stride=[*V.graph.sizevars.size_hints(layout.stride)],
+                        size=list(
+                            V.graph.sizevars.size_hints_or_throw(layout.size)
+                        ),
+                        stride=list(
+                            V.graph.sizevars.size_hints_or_throw(layout.stride)
+                        ),
                         offset=offset,
                     )
                     node_info["layout"] = str(static_layout)
@@ -630,16 +634,20 @@ class DebugFormatter:
                 pass
             try:
                 node_info["stride"] = str(
-                    V.graph.sizevars.size_hints(node.get_stride())
+                    V.graph.sizevars.size_hints_or_throw(node.get_stride())
                 )
             except Exception:
                 pass
             try:
-                node_info["size"] = str(V.graph.sizevars.size_hints(node.get_size()))  # type: ignore[arg-type]
+                node_info["size"] = str(
+                    V.graph.sizevars.size_hints_or_throw(node.get_size())
+                )  # type: ignore[arg-type]
             except Exception:
                 pass
             try:
-                node_info["numel"] = str(V.graph.sizevars.size_hint(node.get_numel()))
+                node_info["numel"] = str(
+                    V.graph.sizevars.size_hint_or_throw(node.get_numel())
+                )
             except Exception:
                 pass
             if hasattr(node, "data") and isinstance(node.data, ir.IRNode):

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -591,6 +591,11 @@ class SizeVarAllocator:
     ) -> tuple[int, ...]:
         return tuple(self.size_hint(x, fallback=fallback) for x in exprs)
 
+    def size_hints_or_throw(
+        self, exprs: Iterable[Union[Expr, int]]
+    ) -> tuple[int, ...]:
+        return tuple(self.size_hint_or_throw(x) for x in exprs)
+
     def _lru_cache(self, fn, maxsize=None):
         """
         Wrapper around functools.lru_cache that clears when replacements

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -591,9 +591,7 @@ class SizeVarAllocator:
     ) -> tuple[int, ...]:
         return tuple(self.size_hint(x, fallback=fallback) for x in exprs)
 
-    def size_hints_or_throw(
-        self, exprs: Iterable[Union[Expr, int]]
-    ) -> tuple[int, ...]:
+    def size_hints_or_throw(self, exprs: Iterable[Union[Expr, int]]) -> tuple[int, ...]:
         return tuple(self.size_hint_or_throw(x) for x in exprs)
 
     def _lru_cache(self, fn, maxsize=None):


### PR DESCRIPTION
## Summary
- revert default fallback change for `size_hint` utilities
- keep `size_hint_or_throw` in heuristics and debug routines where exceptions were expected
- add `size_hints_or_throw` and tighten debug logic

## Testing
- `python -m py_compile torch/_inductor/sizevars.py torch/_inductor/debug.py torch/_inductor/choices.py torch/_inductor/codegen/halide.py`

------
https://chatgpt.com/codex/tasks/task_e_684cbdd7bc7883288450351889854157

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov