### PR TITLE
[Inductor][CPP backend] Optimize parallel depth algorithm [Don't merge]

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -964,7 +964,7 @@ class cpp:
     dynamic_threads = os.environ.get("TORCHINDUCTOR_CPP_DYNAMIC_THREADS", "0") == "1"
 
     simdlen: Optional[int] = None
-    min_chunk_size = int(os.environ.get("TORCHINDUCTOR_CPP_MIN_CHUNK_SIZE", "4096"))
+    min_chunk_size = int(os.environ.get("TORCHINDUCTOR_CPP_MIN_CHUNK_SIZE", "4"))
 
     cxx: tuple[Literal[None], str] = (
         None,  # download gcc12 from conda-forge if conda is installed


### PR DESCRIPTION
Optimize `decide_parallel_depth` by 
1. concerning vectorization's loop steps 
2. rewrite parallel depth computation. The original algorithm can't handle small worksize because `seq // threads` assume all cores are used. 
```
seq = self.size_hint()
par = 1
depth = 0
for expr in ranges:
    hint = V.graph.sizevars.size_hint(expr, fallback=8192)
    if par >= 2 * threads or par == threads:
        break
    if seq // threads < config.cpp.min_chunk_size:
        # not enough work
        break
    depth += 1
    par *= hint
    seq /= hint
```
However, if there is a `LoopNest` which has worksize < threads. It can't fully use the CPU cores. For example, a loop with worksize==5x5x2=50 while CPU has 56 cores. The parallel depth will be 1 and it will use only 5 cores because `seq//threads` is always smaller than 1`. Even tuning chunk size can't handle this case. However, this case should use fifty cores ideally. Hence, I rewrote the parallel depth computation.
```
for (i=0; i<5; i+=1)
  for(j=0; j<5; j+=1)
    for(k=0; k<2; k+=1)
```

On my host machine with Intel SPR CPU, torchbench gets significant speedup.  
| benchmark   | datatype | dynamicshape | geomean speedup |
|-------------|----------|--------------|-----------------|
| torchbench  | amp_fp16 | no           | 107.0%          |
| timms       | amp_fp16 | no           | 99.7%           |
| huggingface | amp_fp16 | no           | 98.8%           |
| torchbench  | fp32     | yes          | 113.4%          |
| timms       | fp32     | yes          | 98.1%           |
| huggingface | fp32     | yes          | 99.9%           |
| torchbench  | amp_bf16 | yes          | 116.2%          |



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov