### PR TITLE
[BE][5/X] Phase out usage of use_max_autotune()

### DIFF
--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1472,12 +1472,6 @@ def get_tma_workspace_arg(
     )
 
 
-def use_max_autotune() -> bool:
-    return (
-        config.max_autotune or config.max_autotune_gemm or config.search_autotune_cache
-    )
-
-
 def _use_template_for_gpu(
     layout: Layout, allowed_layout_dtypes: list[torch.dtype]
 ) -> bool:
@@ -1524,7 +1518,7 @@ def use_triton_template(
             )
             or (layout.device.type == "cpu" and layout.dtype in layout_dtypes)
         )
-        and use_max_autotune()
+        and (config.max_autotune or config.max_autotune_gemm)
         and _use_autotune_backend("TRITON")
         and has_backend_feature(layout.device, BackendFeature.TRITON_TEMPLATES)
     )
@@ -1588,7 +1582,7 @@ def use_cutlass_template(layout: Layout, m: int, n: int, k: int) -> bool:
     layout_dtypes = [torch.float16, torch.bfloat16, torch.int32]
     res = (
         _use_template_for_gpu(layout, layout_dtypes)
-        and use_max_autotune()
+        and (config.max_autotune or config.max_autotune_gemm)
         and _use_autotune_backend("CUTLASS")
     )
 
@@ -1728,7 +1722,7 @@ def try_import_ck_lib() -> tuple[
 
 def use_ck_template(layout: Layout) -> bool:
     # config knobs check 1
-    if not use_max_autotune():
+    if not (config.max_autotune or config.max_autotune_gemm):
         return False
     # platform check
     if not torch.version.hip:
@@ -1797,7 +1791,7 @@ def use_ck_conv_template(layout: Layout) -> bool:
 
 
 def _use_template_for_cpu(layout: Layout) -> bool:
-    return use_max_autotune() and layout.device.type == "cpu"
+    return (config.max_autotune or config.max_autotune_gemm) and layout.device.type == "cpu"
 
 
 def use_cpp_bmm_template(
@@ -1877,7 +1871,7 @@ def use_cpp_gemm_template(
 
 
 def use_aten_gemm_kernels() -> bool:
-    return not use_max_autotune() or _use_autotune_backend("ATEN")
+    return not (config.max_autotune or config.max_autotune_gemm) or _use_autotune_backend("ATEN")
 
 
 class DebugDirManager:

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1791,7 +1791,9 @@ def use_ck_conv_template(layout: Layout) -> bool:
 
 
 def _use_template_for_cpu(layout: Layout) -> bool:
-    return (config.max_autotune or config.max_autotune_gemm) and layout.device.type == "cpu"
+    return (
+        config.max_autotune or config.max_autotune_gemm
+    ) and layout.device.type == "cpu"
 
 
 def use_cpp_bmm_template(
@@ -1871,7 +1873,9 @@ def use_cpp_gemm_template(
 
 
 def use_aten_gemm_kernels() -> bool:
-    return not (config.max_autotune or config.max_autotune_gemm) or _use_autotune_backend("ATEN")
+    return not (
+        config.max_autotune or config.max_autotune_gemm
+    ) or _use_autotune_backend("ATEN")
 
 
 class DebugDirManager:


### PR DESCRIPTION
These look to be the last call sites using `use_max_autotune(...)`, so remove those and `use_max_autotune(...)`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov