### PR TITLE
[inductor] Quiesce Triton compile worker pool by default in OSS

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -786,7 +786,7 @@ compile_threads: Optional[int] = None if is_fbcode() else decide_compile_threads
 quiesce_async_compile_pool: bool = Config(
     justknob="pytorch/inductor:quiesce_async_compile_pool",
     env_name_force="TORCHINDUCTOR_QUIESCE_ASYNC_COMPILE_POOL",
-    default=is_fbcode(),
+    default=True,
 )
 
 # Whether or not to enable statically launching CUDA kernels


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #156330
* #156187



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov