### PR TITLE
[testing] test/run_test.py: Only shutdown pool if it was created

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1826,6 +1826,7 @@ def run_tests(
         "If running on CI, add the 'keep-going' label to your PR and rerun your jobs."
     )
 
+    pool = None
     try:
         for test in selected_tests_serial:
             options_clone = copy.deepcopy(options)
@@ -1888,8 +1889,9 @@ def run_tests(
         del os.environ["NUM_PARALLEL_PROCS"]
 
     finally:
-        pool.terminate()
-        pool.join()
+        if pool:
+            pool.terminate()
+            pool.join()
 
     return
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #156333

Summary: I'm seeing errors like this when I introduce a failure that occurs before the pool is created:
```
  File "/var/lib/jenkins/workspace/test/run_test.py", line 1895, in run_tests
    pool.terminate()
    ^^^^
UnboundLocalError: cannot access local variable 'pool' where it is not associated with a value
```
Initializing pool and conditionally shutting down in the finally block just makes the error a little more readable.

Test Plan: CI