### PR TITLE
Storage: add_delete_hook for deregistration

### DIFF
--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -346,6 +346,9 @@ class TORCH_API TensorBase {
   const Storage& storage() const {
     return impl_->storage();
   }
+  Storage& mutable_storage() {
+    return impl_->mutable_storage();
+  }
   bool is_alias_of(const at::TensorBase& other) const{
     return impl_->storage().is_alias_of(other.storage());
   }

--- a/c10/core/Storage.h
+++ b/c10/core/Storage.h
@@ -178,6 +178,11 @@ struct C10_API Storage {
         isSharedStorageAlias(*this, other));
   }
 
+  void add_delete_hook(
+      std::function<void(const DataPtr&, const SymInt&)> hook) {
+    storage_impl_->add_delete_hook(std::move(hook));
+  }
+
   void UniqueStorageShareExternalPointer(
       void* src,
       size_t capacity,

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1053,6 +1053,17 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     return storage_;
   }
 
+  /**
+   * Mutable form of storage(). This should only be used with safe operations
+   * such as adding delete hooks.
+   */
+  TENSORIMPL_MAYBE_VIRTUAL Storage& mutable_storage() {
+    if (C10_UNLIKELY(storage_access_should_throw_)) {
+      throw_storage_access_error();
+    }
+    return storage_;
+  }
+
   bool unique_version() const {
     return version_counter_.unique();
   }


### PR DESCRIPTION
This adds a hook that will fire when the Storage object is deleted. This is designed to provide a device agnostic API for cleanup/deregistration of tensors for c10d. We currently depend on `c10::cuda::CUDACachingAllocator::attachAllocatorTraceTracker` in ProcessGroupNCCL to detect freed memory and unregister it form the comms layer.

https://github.com/pytorch/pytorch/blob/364340c7eef72b840eb61fdd1c52166b93820fdf/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp#L1051C5-L1051C65

The CUDACachingAllocator tracker hooks are CUDA specific and can't be used for CPU memory which we also want to be able to register for CPU RDMA operations such as supported in Gloo IB.

Test plan:

```
./build/bin/test_api --gtest_filter="*DeleteHook*"
```