### PR TITLE
Use linux.2xlarge runner

### DIFF
--- a/.github/workflows/build-magma-rocm-linux.yml
+++ b/.github/workflows/build-magma-rocm-linux.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   build-linux-magma-rocm:
     if: github.repository_owner == 'pytorch'
-    runs-on: linux.12xlarge
+    runs-on: linux.2xlarge
     permissions:
       id-token: write
     strategy:


### PR DESCRIPTION
The cuda version of this job uses a linux.2xlarge here so matching that to see if this job really needs a 12xlarge system or not.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd