### PR TITLE
[ONNX] Fix how shapes are computed for float4

### DIFF
--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -230,8 +230,8 @@ class DynamoExporterTest(common_utils.TestCase, _WithExport):
         onnx_program = self.export(Float4Module(), optimize=False)
         output = onnx_program.model.graph.outputs[0]
         self.assertEqual(output.dtype, ir.DataType.FLOAT4E2M1)
-        # The shape is [*shape, 2] because ONNX stores the shape of the unpacked tensor
-        self.assertEqual(output.shape.dims, [1, 2])
+        # The shape is [*shape[:-1], shape[-1]*2] because ONNX stores the shape of the unpacked tensor
+        self.assertEqual(output.shape.numpy(), [2])
 
     def test_bfloat16_support(self):
         class BfloatModel(torch.nn.Module):

--- a/torch/onnx/_internal/exporter/_type_casting.py
+++ b/torch/onnx/_internal/exporter/_type_casting.py
@@ -25,8 +25,8 @@ def get_float4_shape(tensor: torch.Tensor) -> tuple[int, ...]:
     https://github.com/pytorch/pytorch/issues/146414.
 
     the shell dtype is takes up 1 byte per element and semantically represents
-    two fp4 values packed into 1 byte. Semantically it represents (*tensor.shape, 2)
+    two fp4 values packed into 1 byte. Semantically it represents (*tensor.shape[:-1], tensor.shape[-1]*2)
     fp4 elements.
     """
     assert tensor.dtype == torch.float4_e2m1fn_x2
-    return (*tensor.shape, 2)
+    return (*tensor.shape[:-1], tensor.shape[-1] * 2)


### PR DESCRIPTION
Changed the way we compute shapes for unpacked float4. Previously we always added a last dimension [2] to existing shape, but this doesn't really make sense because it prevents use from being able to represent any shape other than those with a list dim [2]. I updated the logic to be `[*shape[:-1], shape[-1]*2]` which doubles the last dimension. This is more in line with what we see in practice when people are using 4bit types, and it allows us to represent any shape with an even dimension at the end, which is much more reasonable in my opinion.

Also clarified in https://github.com/pytorch/pytorch/pull/148791#discussion_r2155395647