### PR TITLE
Build FBGEMM GenAI as part of PyTorch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,7 @@ torch/lib64
 torch/include/
 torch/share/
 torch/test/
+torch/fbgemm_gpu/
 torch/utils/benchmark/utils/valgrind_wrapper/callgrind.h
 torch/utils/benchmark/utils/valgrind_wrapper/valgrind.h
 torch/version.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,6 +249,7 @@ cmake_dependent_option(USE_CUDSS "Use cuDSS" ON "USE_CUDA" OFF)
 # USE_ROCM is guarded against in Dependencies.cmake because USE_ROCM is not properly defined here
 cmake_dependent_option(USE_CUFILE "Use cuFile" ON "USE_CUDA AND NOT WIN32" OFF)
 option(USE_FBGEMM "Use FBGEMM (quantized 8-bit server operators)" ON)
+option(USE_FBGEMM_GENAI "Use FBGEMM GenAI" OFF)
 option(USE_KINETO "Use Kineto profiling library" ON)
 option(USE_CUPTI_SO "Use CUPTI as a shared library" ON)
 option(USE_FAKELOWP "Use FakeLowp operators" OFF)
@@ -903,6 +904,10 @@ endif(DEBUG_CUDA)
 
 if(USE_FBGEMM)
   string(APPEND CMAKE_CXX_FLAGS " -DUSE_FBGEMM")
+endif()
+
+if(USE_FBGEMM_GENAI)
+  string(APPEND CMAKE_CXX_FLAGS " -DUSE_FBGEMM_GENAI")
 endif()
 
 if(USE_PYTORCH_QNNPACK)

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -986,6 +986,12 @@ elseif(USE_CUDA)
     target_compile_definitions(torch_cuda PRIVATE USE_NCCL)
   endif()
 
+  if(USE_FBGEMM_GENAI)
+    # FBGEMM GenAI is a .so that depends on libtorch_cuda.so so we cannot link FBGEMM GenAI to libtorch_cuda.so.
+    target_link_libraries(torch PRIVATE fbgemm_gpu_gen_ai)
+    install(TARGETS fbgemm_gpu_gen_ai EXPORT Caffe2Targets DESTINATION "${TORCH_INSTALL_LIB_DIR}")
+  endif()
+
   # Compile with NVSHMEM
   # Default value of `USE_NVSHMEM` is set in CMakeLists.txt under root, to ON.
   # If user has specified NVSHMEM_HOME, we use it;

--- a/test/fbgemm/test_fbgemm_genai.py
+++ b/test/fbgemm/test_fbgemm_genai.py
@@ -1,0 +1,25 @@
+import unittest
+
+import torch
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+skipIfFBGEMMGenAINotInstalled = unittest.skipIf(
+    "FBGEMM_GENAI" not in torch.__config__.show(),
+    "Tests that require FBGEMM_GENAI",
+)
+
+
+class TestFBGEMMGenAI(TestCase):
+    @skipIfFBGEMMGenAINotInstalled
+    def test_ops_available(self):
+        M, N, K = 256, 256, 256
+        xq = torch.randn(M, K).to(torch.float8_e4m3fn).cuda()
+        wq = torch.randn(N, K).to(torch.float8_e4m3fn).cuda()
+
+        row_scale = torch.randn(M).cuda()
+        col_scale = torch.randn(N).cuda()
+
+        _ = torch.ops.fbgemm.f8f8bf16_rowwise(xq, wq, row_scale, col_scale)
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
Summary: We are looking to integrate [FBGEMM GenAI](https://github.com/pytorch/FBGEMM/tree/main/fbgemm_gpu/experimental/gen_ai) as a backend to quantized torch ops (e.g. scaled_mm, scaled_grouped_mm). This is to use the FBGEMM quantized GEMM kernels on NV and AMD (e.g. fp8 rowwise, fp8 grouped rowwise).

**The primary benefits of leveraging FBGEMM would be for NV and AMD quantized gemm kernels. Roughly in order of immediate value add (@drisspg  @ngimel  @jwfromm correct me if Im missing anything):**
- FBGEMM has [strong support for AMD](https://github.com/pytorch/FBGEMM/tree/main/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions) that could be leveraged in torch, which I believe is an area that needs more coverage still.
- FBGEMM generally adds support for new hardware and dtypes quickly [(e.g. NVFP4 & MXFP4 support on Blackwell have already been added)](https://github.com/pytorch/FBGEMM/commit/a9c2b70046445e4521898c3e9ce1c4d60e6ee641).
- Exploratory/long term: There is decent amount of duplication for quantized gemm kernels between torch and FBGEMM. We would like to figure out a path to consolidate kernel development efforts, possibly by "graduating" some stable kernels from FBGEMM into torch, and if torch can have a larger reliance on parts of FBGEMM. The value add here would be better competitive baseline performance, by having folks from both fbgemm and torch co-operate on kernel development on the same set of kernels.

**Why bundle FBGEMM with torch instead of a separate user installed library?**
- We want to go after baseline improvements to the ops (scaled_mm/scaled_grouped_mm), having a library installation requires an additional step for the users to get the best performance on AMD/NV for those ops.
- Given the exploratory/long term goal above, it would be harder to achieve it without being bundled in torch.

**Risks to build size/build speed**
- This is a valid concern, I think we could address it by either (1) user installed library approach, or (2) only including specific kernels of fbgemm directly into the torch build as required, instead of all of fbgemm.
- As a datapoint, I tested briefly and compiling with `TORCH_CUDA_ARCH_LIST='9.0a;10.0a;12.0a'` the NV .so is around 29MB. Have not tested with AMD yet. We have some idea of where the bloat is coming from, and it can definitely be reduced if needed.

Reviewers:

Subscribers:

Tasks:

Tags:

Fixes #ISSUE_NUMBER
