### PR TITLE
[c10d] Disable stack trace call in logging

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -2312,7 +2312,8 @@ void ProcessGroupNCCL::Watchdog::runLoop() {
           data.integers["world_size"] = pg_->size_;
           data.strings["comm_backend"] = "nccl";
           data.strings["comm_backend_version"] = getNcclVersion();
-          data.strings["collective_stack"] = work.getTraceback();
+          // TODO: We see errors for this line, revert it for now.
+          data.strings["collective_stack"] = "";
           data.strings["collective_name"] = opTypeToString(work.opType_);
           logger->log(data);
         }


### PR DESCRIPTION
Summary: We noticed std::future_error: Broken promise errors in logging, so let's disable for now and will investigate more.

Test Plan:
CI

Rollback Plan:

Differential Revision: D76929722


cc @H-Huang @awgu @wanchaol @fegin @wz337 @wconstab @d4l3k