### PR TITLE
[ONNX] Fix num_heads inference in ONNX Attention-23 exporter

### DIFF
--- a/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
@@ -124,6 +124,8 @@ def aten_scaled_dot_product_attention_23(
             value,
             attn_mask=attn_mask,
             scale=scale,
+            q_num_heads=query.shape[-3],
+            kv_num_heads=key.shape[-3],
             is_causal=is_causal,
         )
         return Y

--- a/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
@@ -101,6 +101,9 @@ def aten_scaled_dot_product_attention_23(
     assert (not is_causal) or (is_causal and attn_mask is None), (
         "is_causal and attn_mask cannot be set at the same time"
     )
+    assert (len(query.shape) == 4 and len(key.shape) == 4 and len(value.shape) == 4), (
+        "only 4D query, key, and value are supported"
+    )
 
     # Attention onnx op can only handle non-training scenarios where dropout is disabled.
     if dropout_p == 0:
@@ -121,8 +124,6 @@ def aten_scaled_dot_product_attention_23(
             value,
             attn_mask=attn_mask,
             scale=scale,
-            q_num_heads=query.shape[3],
-            kv_num_heads=key.shape[3],
             is_causal=is_causal,
         )
         return Y

--- a/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
@@ -101,7 +101,7 @@ def aten_scaled_dot_product_attention_23(
     assert (not is_causal) or (is_causal and attn_mask is None), (
         "is_causal and attn_mask cannot be set at the same time"
     )
-    assert (len(query.shape) == 4 and len(key.shape) == 4 and len(value.shape) == 4), (
+    assert len(query.shape) == 4 and len(key.shape) == 4 and len(value.shape) == 4, (
         "only 4D query, key, and value are supported"
     )
 


### PR DESCRIPTION
Fixes issue in torch-onnx exporter for Attention: https://github.com/pytorch/pytorch/issues/156105

Previously the number of heads attributes inferred by the exporter is incorrect. It should be read from input dimension -3 not dimension 3:

![image](https://github.com/user-attachments/assets/26f10e15-bc98-42ac-807a-2e089a7d996a)

But in fact, [torch sdpa](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html) doesn't support combined num_heads and head_size dimensions like [ONNX](https://onnx.ai/onnx/operators/onnx__Attention.html) does, so this num_heads attribute is not needed.

Extending support to rank>4 can be left as future work if there is use case for that. The translation logic will look like: Reshape(Q,K,V to 4d) -> Attention -> Reshape(Y to original rank).

cc @justinchuby