### PR TITLE
[MPS] Fix bug in 3d coords calculation

### DIFF
--- a/aten/src/ATen/native/mps/kernels/UpSample.metal
+++ b/aten/src/ATen/native/mps/kernels/UpSample.metal
@@ -168,10 +168,10 @@ inline linear_return_t<T> linear_interp(T v0, T v1, float x) {
 inline uint3 coords_from_threadidx(
     constant UpsampleParams<5>& params,
     uint thread_index) {
-  const auto size_y = static_cast<uint>(params.output_sizes[3]);
-  const auto size_xy = static_cast<uint>(params.output_sizes[4]) * size_y;
+  const auto size_x = static_cast<uint>(params.output_sizes[4]);
+  const auto size_xy = static_cast<uint>(params.output_sizes[3]) * size_x;
   auto output_xy = thread_index % size_xy;
-  return uint3(output_xy % size_y, output_xy / size_y, thread_index / size_xy);
+  return uint3(output_xy % size_x, output_xy / size_x, thread_index / size_xy);
 }
 
 inline float3 coords_to_real_coords(

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -7204,7 +7204,6 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
 
         self.common(fn, (torch.randn([2, 4, 37, 38]),))
 
-    @xfail_if_mps_unimplemented
     def test_upsample_nearest3d(self):
         def fn(a):
             return (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #156373
* __->__ #156375

Which was not caught by CI beforehand, as all 3D examples right now are symmetric, so add an uneven shape to `sample_inputs_interpolate`

Though it's indirectly tested by `test_upsample_nearest3d` inductor test

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov