### PR TITLE
Improve All to All Perf for inter-node use-case

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cu
@@ -292,10 +292,10 @@ at::Tensor nvshmem_all_to_all_vdev(
       (input_size < 4 * MiB ? 32 : 64));
 
   // Inter-node: limit the total the number of blocks to 8 which is able to
-  // drive 57 GB/s bandwidth in test, enough to drive a 400 Gb/s NIC.
+  // drive 90 GB/s bandwidth in test, enough to drive a 400 Gb/s NIC.
   // TODO: better intra vs inter detection, currently it is based on world_size
   if (world_size > 8) {
-    num_blocks = std::min(num_blocks, 8);
+    num_blocks = std::min(num_blocks, 16);
   }
 
   // Stride at dim 0 (assuming input is contiguous, TODO)


### PR DESCRIPTION
Summary: For 16 GPU use-case. NVSHMEM can drive only upto 49GB/s with 8 thread blocks per peer for all to all V use-case. Increasing that to 16 threads per block is able to max out the perf.

Test Plan:
Verify on two hosts
Host1:
TORCH_SYMMMEM=NVSHMEM torchrun --nnodes=2 --nproc_per_node=8 --master_addr ${master_ip}  --node_rank=0  comms.py --	master-ip ${master_ip} --b 4 --e 256M --n 500 --f 2 --z 1 --collective all_to_allv --backend nccl --device cuda
Host2:
TORCH_SYMMMEM=NVSHMEM torchrun --nnodes=2 --nproc_per_node=8 --master_addr ${master_ip}  --node_rank=1  comms.py --	master-ip ${master_ip} --b 4 --e 256M --n 100 --f 2 --z 1 --collective all_to_allv --backend nccl --device cuda

Rollback Plan:

Differential Revision: D76937048


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k