### PR TITLE
fix apparent copy-paste bug in log_softmax reduced-precision fp kernel

### DIFF
--- a/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
+++ b/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
@@ -1050,7 +1050,7 @@ _vec_logsoftmax(
           max_fvec0 = fVec::blendv(max_fvec0, data_fvec0, data_fvec0 > max_fvec0);
           max_fvec1 = fVec::blendv(max_fvec1, data_fvec1, data_fvec1 > max_fvec1);
           max_fvec0.store(input_max_data + d1);
-          max_fvec0.store(input_max_data + d1 + fVec::size());
+          max_fvec1.store(input_max_data + d1 + fVec::size());
 
           // cache the 'converted' float input
           data_fvec0.store(input_buffer_ptr + d1);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #156379

This looks like a bug. Check if trying to fix it breaks existing tests; if not, will look into why no test coverage caught it

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168