### PR TITLE
CUB and compile_kernel composition

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -7029,6 +7029,51 @@ class TestCompileKernel(TestCase):
 
         # Verify results
         self.assertEqual(C_explicit, expected)
+    
+    @unittest.skipIf(TEST_WITH_ROCM, "ROCM does not support nvrtc")
+    @unittest.skipIf(not TEST_CUDA, "No CUDA")
+    def test_compile_kernel_reduction(self):
+        # TODO: Not sure if I should be using ATen/cuda/cub.cuh or cub.cuh
+        # BlockReduce is not exposed in ATen/cuda/cub.cuh
+        kernel_source = """
+        #include <cub/cub.cuh>
+        
+        __global__ void reduction_kernel(const float* input, float* output, int n) {
+            typedef cub::BlockReduce<float, 256> BlockReduce;
+            __shared__ typename BlockReduce::TempStorage temp_storage;
+            
+            int tid = threadIdx.x + blockIdx.x * blockDim.x;
+            float thread_data = (tid < n) ? input[tid] : 0.0f;
+            
+            float aggregate = BlockReduce(temp_storage).Sum(thread_data);
+            
+            if (threadIdx.x == 0) {
+                atomicAdd(output, aggregate);
+            }
+        }
+        """
+        
+        from torch.cuda import _compile_kernel
+        
+        reduction_kernel = _compile_kernel(kernel_source, "reduction_kernel")
+        
+        N = 1024
+        input_data = torch.ones(N, device="cuda")
+        output_data = torch.zeros(1, device="cuda")
+        
+        threads_per_block = 256
+        blocks_per_grid = (N + threads_per_block - 1) // threads_per_block
+        
+        reduction_kernel(
+            grid=(blocks_per_grid, 1, 1),
+            block=(threads_per_block, 1, 1),
+            args=[input_data, output_data, N],
+        )
+        
+        expected = float(N) 
+        actual = output_data.item()
+        
+        self.assertAlmostEqual(actual, expected, places=4)
 
     @unittest.skipIf(not TEST_CUDA, "No CUDA")
     def test_compile_kernel_as_custom_op(self):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -7036,9 +7036,9 @@ class TestCompileKernel(TestCase):
         # TODO: Not sure if I should be using ATen/cuda/cub.cuh or cub.cuh
         # BlockReduce is not exposed in ATen/cuda/cub.cuh
         kernel_source = """
-        #include <cub/cub.cuh>
+        #include <cub/block/block_reduce.cuh>
 
-        __global__ void reduction_kernel(const float* input, float* output, int n) {
+        extern "C" __global__ void reduction_kernel(const float* input, float* output, int n) {
             typedef cub::BlockReduce<float, 256> BlockReduce;
             __shared__ typename BlockReduce::TempStorage temp_storage;
 

--- a/torch/cuda/_utils.py
+++ b/torch/cuda/_utils.py
@@ -173,7 +173,7 @@ def _nvrtc_compile(
 
     from torch.utils.cpp_extension import include_paths
 
-    paths = include_paths(device="cuda")
+    paths = include_paths("cuda")
     for path in paths:
         options.append(f"-I{path}".encode())
 

--- a/torch/cuda/_utils.py
+++ b/torch/cuda/_utils.py
@@ -107,7 +107,10 @@ def _nvrtc_compile(
             raise RuntimeError(f"CUDA error: {error_message}")
 
     # Add 'extern "C"' if not already present to ensure C linkage
-    if not kernel_source.strip().startswith('extern "C"'):
+    if (
+        not kernel_source.strip().startswith('extern "C"')
+        and 'extern "C"' not in kernel_source
+    ):
         kernel_source = f'extern "C" {kernel_source}'
 
     # Combine header code and kernel source
@@ -127,6 +130,8 @@ def _nvrtc_compile(
     # Prepare compilation options
     options = []
     options.append(f"--gpu-architecture=sm_{compute_capability}".encode())
+
+    # options.append(b"--std=c++11")  # Use C++14 standard for better compatibility
 
     # Add custom include directories
     if cuda_include_dirs:

--- a/torch/cuda/_utils.py
+++ b/torch/cuda/_utils.py
@@ -1,5 +1,4 @@
 import ctypes
-import os
 import sys
 from typing import Any, Optional, Union
 
@@ -9,34 +8,32 @@ import torch
 from torch._utils import _get_device_index as _torch_get_device_index
 
 
-def _get_nvrtc_version(cuda_version: int) -> str:
-    # TODO: Expose this from native code
-    # Follows same logic as LazyNVRTC.cpp getLibVersion()
-    major = cuda_version // 1000
-    minor = (cuda_version // 10) % 10
-
+def _get_hip_runtime_library() -> ctypes.CDLL:
     if sys.platform == "win32":
-        if major < 11 or (major == 11 and minor < 3):
-            return f"{major}{minor}"
-        elif major == 11:
-            return "112"
-        else:
-            return f"{major}0"
-    else:
-        if major < 11 or (major == 11 and minor < 3):
-            return f"{major}.{minor}"
-        elif major == 11:
-            return "11.2"
-        else:
-            return str(major)
+        lib = ctypes.CDLL(f"amdhip64_{torch.version.hip[0]}.dll")
+    else:  # Unix-based systems
+        lib = ctypes.CDLL("libamdhip64.so")
+    lib.cuGetErrorString = lib.hipGetErrorString  # type: ignore[attr-defined]
+    lib.cuModuleLoadData = lib.hipModuleLoadData  # type: ignore[attr-defined]
+    lib.cuModuleGetFunction = lib.hipModuleGetFunction  # type: ignore[attr-defined]
+    lib.cuLaunchKernel = lib.hipModuleLaunchKernel  # type: ignore[attr-defined]
+    lib.cuFuncSetAttribute = lib.hipFuncSetAttribute  # type: ignore[attr-defined]
+    return lib
 
 
-# Load CUDA driver and NVRTC
-def _get_cuda_library() -> ctypes.CDLL:
+def _get_cuda_runtime_library() -> ctypes.CDLL:
     if sys.platform == "win32":
         return ctypes.CDLL("nvcuda.dll")
     else:  # Unix-based systems
         return ctypes.CDLL("libcuda.so.1")
+
+
+# Load GPU driver runtime
+def _get_gpu_runtime_library() -> ctypes.CDLL:
+    if torch.version.hip:
+        return _get_hip_runtime_library()
+    else:
+        return _get_cuda_runtime_library()
 
 
 # Helper: check CUDA errors
@@ -44,7 +41,7 @@ def _check_cuda(result: int) -> None:
     if result == 0:
         return
     err_str = ctypes.c_char_p()
-    libcuda = _get_cuda_library()  # Get reference to CUDA library
+    libcuda = _get_gpu_runtime_library()  # Get reference to CUDA library
     libcuda.cuGetErrorString(result, ctypes.byref(err_str))
     error_message = (
         err_str.value.decode() if err_str.value is not None else "Unknown CUDA error"
@@ -52,24 +49,75 @@ def _check_cuda(result: int) -> None:
     raise RuntimeError(f"CUDA error: {error_message}")
 
 
+def _get_hiprtc_library() -> ctypes.CDLL:
+    if sys.platform == "win32":
+        version_str = "".join(["0", torch.version.hip[0], "0", torch.version.hip[2]])
+        lib = ctypes.CDLL(f"hiprtc{version_str}.dll")
+    else:
+        lib = ctypes.CDLL("libhiprtc.so")
+
+    # Provide aliases for HIP RTC functions to match NVRTC API
+    lib.nvrtcGetErrorString = lib.hiprtcGetErrorString  # type: ignore[attr-defined]
+    lib.nvrtcCreateProgram = lib.hiprtcCreateProgram  # type: ignore[attr-defined]
+    lib.nvrtcDestroyProgram = lib.hiprtcDestroyProgram  # type: ignore[attr-defined]
+    lib.nvrtcCompileProgram = lib.hiprtcCompileProgram  # type: ignore[attr-defined]
+    lib.nvrtcGetPTXSize = lib.hiprtcGetCodeSize  # type: ignore[attr-defined]
+    lib.nvrtcGetPTX = lib.hiprtcGetCode  # type: ignore[attr-defined]
+    lib.nvrtcGetProgramLogSize = lib.hiprtcGetProgramLogSize  # type: ignore[attr-defined]
+    lib.nvrtcGetProgramLog = lib.hiprtcGetProgramLog  # type: ignore[attr-defined]
+    lib.nvrtcAddNameExpression = lib.hiprtcAddNameExpression  # type: ignore[attr-defined]
+    lib.nvrtcGetLoweredName = lib.hiprtcGetLoweredName  # type: ignore[attr-defined]
+    return lib
+
+
 def _get_nvrtc_library() -> ctypes.CDLL:
-    # PyTorch packages NVRTC, so we can use it directly
-    # Since PyTorch already loads NVRTC, we can use the system library
-    # which should be compatible with PyTorch's version
     if sys.platform == "win32":
         return ctypes.CDLL("nvrtc64_120_0.dll")
     else:
         return ctypes.CDLL("libnvrtc.so")
 
 
+def _get_gpu_rtc_library() -> ctypes.CDLL:
+    # Since PyTorch already loads the GPU RTC library, we can use the system library
+    # which should be compatible with PyTorch's version
+    if torch.version.hip:
+        return _get_hiprtc_library()
+    else:
+        return _get_nvrtc_library()
+
+
+def _get_gpu_rtc_compatible_flags() -> list[str]:
+    """
+    Get HIPCC/NVCC flags that are compatible with NVRTC compilation.
+
+    Returns:
+        List of HIPCC/NVCC flags that can be safely used with NVRTC.
+    """
+    from torch.utils.cpp_extension import COMMON_HIPCC_FLAGS, COMMON_NVCC_FLAGS
+
+    nvrtc_unsupported_flags = {
+        "--expt-relaxed-constexpr",
+    }
+
+    # Filter out unsupported flags
+    compatible_flags = [
+        flag for flag in COMMON_NVCC_FLAGS if flag not in nvrtc_unsupported_flags
+    ]
+
+    if torch.version.hip:
+        compatible_flags.extend(COMMON_HIPCC_FLAGS)
+
+    return compatible_flags
+
+
 def _nvrtc_compile(
     kernel_source: str,
     kernel_name: str,
     compute_capability: Optional[str] = None,
-    header_code: str = "",
     cuda_include_dirs: Optional[list] = None,
     nvcc_options: Optional[list] = None,
-) -> bytes:
+    auto_pch: bool = False,
+) -> tuple[bytes, str]:
     """
     Compiles a CUDA kernel using NVRTC and returns the PTX code.
 
@@ -78,18 +126,18 @@ def _nvrtc_compile(
         kernel_name (str): The name of the kernel function to compile
         compute_capability (str, None): The compute capability to target (e.g., "86").
                                            If None, will detect from current device.
-        header_code (str, optional): Additional header code to prepend to the kernel source
         cuda_include_dirs (list, None): List of directories containing CUDA headers
         nvcc_options (list, None): Additional options to pass to NVRTC
+        auto_pch (bool): Enable automatic precompiled headers (CUDA 12.8+)
 
     Returns:
-        str: The compiled PTX code
+        Tuple[bytes, str]: The compiled PTX code and mangled kernel name
     """
     # Ensure CUDA is initialized
     import torch.cuda
 
     # Load NVRTC library
-    libnvrtc = _get_nvrtc_library()
+    libnvrtc = _get_gpu_rtc_library()
 
     # NVRTC constants
     NVRTC_SUCCESS = 0
@@ -106,56 +154,49 @@ def _nvrtc_compile(
             )
             raise RuntimeError(f"CUDA error: {error_message}")
 
-    # Add 'extern "C"' if not already present to ensure C linkage
-    if (
-        not kernel_source.strip().startswith('extern "C"')
-        and 'extern "C"' not in kernel_source
-    ):
-        kernel_source = f'extern "C" {kernel_source}'
-
-    # Combine header code and kernel source
-    if header_code:
-        full_source = header_code + "\n" + kernel_source
-    else:
-        full_source = kernel_source
-
     # Convert source to bytes
-    source_bytes = full_source.encode("utf-8")
+    source_bytes = kernel_source.encode("utf-8")
 
     # Get compute capability if not provided
     if compute_capability is None:
         props = torch.cuda.get_device_properties(torch.cuda.current_device())
-        compute_capability = f"{props.major}{props.minor}"
+        if torch.version.hip:
+            compute_capability = f"{props.gcnArchName}"
+        else:
+            compute_capability = f"{props.major}{props.minor}"
 
     # Prepare compilation options
     options = []
-    options.append(f"--gpu-architecture=sm_{compute_capability}".encode())
+    if torch.version.hip:
+        options.append(f"--offload-arch={compute_capability}".encode())
+    else:
+        options.append(f"--gpu-architecture=sm_{compute_capability}".encode())
 
-    # options.append(b"--std=c++11")  # Use C++14 standard for better compatibility
+    # Auto-detect and add CUDA include paths
+    from torch.utils.cpp_extension import include_paths
+
+    cuda_include_paths = include_paths("cuda")
+    for cuda_path in cuda_include_paths:
+        options.append(f"-I{cuda_path}".encode())
 
     # Add custom include directories
     if cuda_include_dirs:
         for directory in cuda_include_dirs:
             options.append(f"-I{directory}".encode())
 
-    from torch.utils.cpp_extension import include_paths
-
-    paths = include_paths("cuda")
-    for path in paths:
-        options.append(f"-I{path}".encode())
+    # Enable automatic precompiled headers (CUDA 12.8+)
+    if auto_pch:
+        assert str(torch.version.cuda) >= "12.8", "PCH requires CUDA 12.8+"
+        if nvcc_options is None:
+            nvcc_options = []
+        nvcc_options.append("--pch")
 
     # Add custom NVCC options
     if nvcc_options:
         for option in nvcc_options:
             options.append(option.encode("utf-8"))
 
-    # TODO: Should we refactor flags into a common place?
-    from torch.utils.cpp_extension import COMMON_NVCC_FLAGS
-
-    # Filter out flags not supported by NVRTC
-    nvrtc_compatible_flags = [
-        flag for flag in COMMON_NVCC_FLAGS if flag != "--expt-relaxed-constexpr"
-    ]
+    nvrtc_compatible_flags = _get_gpu_rtc_compatible_flags()
     options.extend([flag.encode("utf-8") for flag in nvrtc_compatible_flags])
 
     # Convert options to C array
@@ -175,6 +216,10 @@ def _nvrtc_compile(
         )
     )
 
+    # Add kernel name, which can be a template expression
+    c_kernel_name = kernel_name.encode("utf-8")
+    check_nvrtc(libnvrtc.nvrtcAddNameExpression(prog, c_kernel_name))
+
     # Compile program
     res = libnvrtc.nvrtcCompileProgram(prog, num_options, options_array)
 
@@ -192,9 +237,24 @@ def _nvrtc_compile(
     check_nvrtc(libnvrtc.nvrtcGetPTXSize(prog, ctypes.byref(ptx_size)))
     ptx = ctypes.create_string_buffer(ptx_size.value)
     check_nvrtc(libnvrtc.nvrtcGetPTX(prog, ptx))
+
+    # Get mangled name
+    c_mangled_name = ctypes.c_char_p()
+    check_nvrtc(
+        libnvrtc.nvrtcGetLoweredName(prog, c_kernel_name, ctypes.byref(c_mangled_name))
+    )
+    if c_mangled_name.value is not None:
+        mangled_name = c_mangled_name.value.decode()  # make a copy
+    else:
+        mangled_name = ""
+
     libnvrtc.nvrtcDestroyProgram(ctypes.byref(prog))
 
-    return ptx.value
+    # For HIP, hipRTC generates raw CO binaries instead of PTX,
+    # and for some reason, ".value" causes the string to be truncated,
+    # likely due to the presence of '\0' in the string. So we use .raw instead.
+    ptx_bytes = ptx.raw if torch.version.hip else ptx.value
+    return ptx_bytes, mangled_name
 
 
 class _CudaModule:
@@ -207,9 +267,9 @@ class _CudaModule:
             return self._kernels[name]
 
         # Import the CUDA library inside the method
-        from torch.cuda._utils import _get_cuda_library
+        from torch.cuda._utils import _get_gpu_runtime_library
 
-        libcuda = _get_cuda_library()
+        libcuda = _get_gpu_runtime_library()
 
         func = ctypes.c_void_p()
         try:
@@ -234,6 +294,7 @@ class _CudaKernel:
     def __init__(self, func: ctypes.c_void_p, module: ctypes.c_void_p) -> None:
         self.func = func
         self.module = module
+        self._max_shared_mem_bytes = 0
 
     def __call__(
         self,
@@ -256,7 +317,7 @@ class _CudaKernel:
         """
         import torch
 
-        libcuda = torch.cuda._utils._get_cuda_library()
+        libcuda = torch.cuda._utils._get_gpu_runtime_library()
 
         if not args:
             args = []
@@ -280,12 +341,11 @@ class _CudaKernel:
                 c_int = ctypes.c_int(arg)
                 # Store the C int for reference keeping, not in processed_args
                 c_args.append(ctypes.byref(c_int))
-            # TODO: Python floats are actually doubles
             elif isinstance(arg, float):
-                # Convert floats to C float
-                c_float = ctypes.c_float(arg)
-                # Store the C float for reference keeping, not in processed_args
-                c_args.append(ctypes.byref(c_float))
+                # Python floats are doubles - use double by default
+                c_double = ctypes.c_double(arg)
+                # Store the C double for reference keeping, not in processed_args
+                c_args.append(ctypes.byref(c_double))
             else:
                 raise TypeError(f"Unsupported argument type: {type(arg)}")
 
@@ -300,6 +360,22 @@ class _CudaKernel:
             import torch.cuda
 
             stream = torch.cuda.current_stream()
+
+        # Check if kernel requires large shared memory but hasn't been configured
+        if shared_mem >= 48 * 1024 and (
+            self._max_shared_mem_bytes == 0 or shared_mem > self._max_shared_mem_bytes
+        ):
+            configured_msg = (
+                "not configured"
+                if self._max_shared_mem_bytes == 0
+                else f"only {self._max_shared_mem_bytes} bytes configured"
+            )
+            raise RuntimeError(
+                f"Kernel requires {shared_mem} bytes of shared memory (>= 48KB), "
+                f"but {configured_msg}. "
+                "Call kernel.set_shared_memory_config(shared_mem) after compilation "
+                "and before launching the kernel."
+            )
 
         _check_cuda(
             libcuda.cuLaunchKernel(
@@ -316,6 +392,48 @@ class _CudaKernel:
                 None,
             )
         )
+
+    def set_shared_memory_config(self, shared_mem_bytes: int) -> None:
+        if shared_mem_bytes < 48 * 1024:
+            # No configuration needed for <= 48KB, just update the value
+            self._max_shared_mem_bytes = shared_mem_bytes
+            return
+
+        libcuda = _get_gpu_runtime_library()
+
+        # Get device properties to validate against limits
+        device_props = torch.cuda.get_device_properties()
+        # HIP doesn't have shared_memory_per_block_optin in device properties, so we hard-code it here
+        if torch.version.hip:
+            # navi, CDNA1-CDNA3 allows a max of 64KB shared memory
+            # CDNA4 allows a max of 160KB shared memory
+            max_shared_mem = (
+                65536 if device_props.gcnArchName not in ["gfx950"] else 160 * 1024
+            )
+        else:
+            max_shared_mem = getattr(
+                device_props, "shared_memory_per_block_optin", 49152
+            )
+
+        if shared_mem_bytes > max_shared_mem:
+            raise RuntimeError(
+                f"Requested shared memory ({shared_mem_bytes} bytes) exceeds "
+                f"device limit ({max_shared_mem} bytes). "
+                "Consider reducing block size or shared memory usage."
+            )
+
+        # Set the function attribute once
+        # https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html
+        cudaFuncAttributeMaxDynamicSharedMemorySize = 8
+        _check_cuda(
+            libcuda.cuFuncSetAttribute(
+                self.func,
+                cudaFuncAttributeMaxDynamicSharedMemorySize,
+                shared_mem_bytes,
+            )
+        )
+
+        self._max_shared_mem_bytes = shared_mem_bytes
 
 
 def _cuda_load_module(
@@ -337,7 +455,7 @@ def _cuda_load_module(
     import torch.cuda
 
     # Load CUDA driver library
-    libcuda = _get_cuda_library()
+    libcuda = _get_gpu_runtime_library()
 
     # Convert PTX to bytes if it's a string
     if isinstance(ptx, str):

--- a/torch/cuda/_utils.py
+++ b/torch/cuda/_utils.py
@@ -1,4 +1,5 @@
 import ctypes
+import os
 import sys
 from typing import Any, Optional, Union
 
@@ -8,32 +9,34 @@ import torch
 from torch._utils import _get_device_index as _torch_get_device_index
 
 
-def _get_hip_runtime_library() -> ctypes.CDLL:
+def _get_nvrtc_version(cuda_version: int) -> str:
+    # TODO: Expose this from native code
+    # Follows same logic as LazyNVRTC.cpp getLibVersion()
+    major = cuda_version // 1000
+    minor = (cuda_version // 10) % 10
+
     if sys.platform == "win32":
-        lib = ctypes.CDLL(f"amdhip64_{torch.version.hip[0]}.dll")
-    else:  # Unix-based systems
-        lib = ctypes.CDLL("libamdhip64.so")
-    lib.cuGetErrorString = lib.hipGetErrorString  # type: ignore[attr-defined]
-    lib.cuModuleLoadData = lib.hipModuleLoadData  # type: ignore[attr-defined]
-    lib.cuModuleGetFunction = lib.hipModuleGetFunction  # type: ignore[attr-defined]
-    lib.cuLaunchKernel = lib.hipModuleLaunchKernel  # type: ignore[attr-defined]
-    lib.cuFuncSetAttribute = lib.hipFuncSetAttribute  # type: ignore[attr-defined]
-    return lib
+        if major < 11 or (major == 11 and minor < 3):
+            return f"{major}{minor}"
+        elif major == 11:
+            return "112"
+        else:
+            return f"{major}0"
+    else:
+        if major < 11 or (major == 11 and minor < 3):
+            return f"{major}.{minor}"
+        elif major == 11:
+            return "11.2"
+        else:
+            return str(major)
 
 
-def _get_cuda_runtime_library() -> ctypes.CDLL:
+# Load CUDA driver and NVRTC
+def _get_cuda_library() -> ctypes.CDLL:
     if sys.platform == "win32":
         return ctypes.CDLL("nvcuda.dll")
     else:  # Unix-based systems
         return ctypes.CDLL("libcuda.so.1")
-
-
-# Load GPU driver runtime
-def _get_gpu_runtime_library() -> ctypes.CDLL:
-    if torch.version.hip:
-        return _get_hip_runtime_library()
-    else:
-        return _get_cuda_runtime_library()
 
 
 # Helper: check CUDA errors
@@ -41,7 +44,7 @@ def _check_cuda(result: int) -> None:
     if result == 0:
         return
     err_str = ctypes.c_char_p()
-    libcuda = _get_gpu_runtime_library()  # Get reference to CUDA library
+    libcuda = _get_cuda_library()  # Get reference to CUDA library
     libcuda.cuGetErrorString(result, ctypes.byref(err_str))
     error_message = (
         err_str.value.decode() if err_str.value is not None else "Unknown CUDA error"
@@ -49,75 +52,62 @@ def _check_cuda(result: int) -> None:
     raise RuntimeError(f"CUDA error: {error_message}")
 
 
-def _get_hiprtc_library() -> ctypes.CDLL:
-    if sys.platform == "win32":
-        version_str = "".join(["0", torch.version.hip[0], "0", torch.version.hip[2]])
-        lib = ctypes.CDLL(f"hiprtc{version_str}.dll")
-    else:
-        lib = ctypes.CDLL("libhiprtc.so")
-
-    # Provide aliases for HIP RTC functions to match NVRTC API
-    lib.nvrtcGetErrorString = lib.hiprtcGetErrorString  # type: ignore[attr-defined]
-    lib.nvrtcCreateProgram = lib.hiprtcCreateProgram  # type: ignore[attr-defined]
-    lib.nvrtcDestroyProgram = lib.hiprtcDestroyProgram  # type: ignore[attr-defined]
-    lib.nvrtcCompileProgram = lib.hiprtcCompileProgram  # type: ignore[attr-defined]
-    lib.nvrtcGetPTXSize = lib.hiprtcGetCodeSize  # type: ignore[attr-defined]
-    lib.nvrtcGetPTX = lib.hiprtcGetCode  # type: ignore[attr-defined]
-    lib.nvrtcGetProgramLogSize = lib.hiprtcGetProgramLogSize  # type: ignore[attr-defined]
-    lib.nvrtcGetProgramLog = lib.hiprtcGetProgramLog  # type: ignore[attr-defined]
-    lib.nvrtcAddNameExpression = lib.hiprtcAddNameExpression  # type: ignore[attr-defined]
-    lib.nvrtcGetLoweredName = lib.hiprtcGetLoweredName  # type: ignore[attr-defined]
-    return lib
-
-
 def _get_nvrtc_library() -> ctypes.CDLL:
+    # Get NVRTC version based on CUDA runtime version
+    # Use an alternative approach to get the CUDA version
+    # since cudart().getVersion() is failing
+    import torch
+
+    try:
+        import torch.cuda
+
+        cuda_runtime_version = torch.cuda.cudart().getVersion()
+    except (ImportError, AttributeError):
+        # Fallback: if we have CUDA available, get version from device properties
+        if hasattr(torch, "cuda") and torch.cuda.is_available():
+            # Import locally to avoid circular imports
+            import torch.cuda
+
+            props = torch.cuda.get_device_properties(torch.cuda.current_device())
+            cuda_runtime_version = props.major * 1000 + props.minor * 10
+        else:
+            # Hardcode a default CUDA version if all else fails
+            cuda_runtime_version = 12000  # Assume CUDA 12.0 as default
+
+    version = _get_nvrtc_version(cuda_runtime_version)
+
     if sys.platform == "win32":
-        return ctypes.CDLL("nvrtc64_120_0.dll")
+        # Windows handling remains the same
+        lib_name = f"nvrtc64_{version}_0.dll"
+        return ctypes.CDLL(lib_name)
     else:
-        return ctypes.CDLL("libnvrtc.so")
+        lib_paths = [
+            f"libnvrtc.so.{version}",
+            os.path.join(
+                os.environ.get("CUDA_HOME", ""), f"lib64/libnvrtc.so.{version}"
+            ),
+            "/usr/local/cuda/lib64/libnvrtc.so",
+        ]
 
+        for path in lib_paths:
+            try:
+                return ctypes.CDLL(path)
+            except OSError:
+                continue
 
-def _get_gpu_rtc_library() -> ctypes.CDLL:
-    # Since PyTorch already loads the GPU RTC library, we can use the system library
-    # which should be compatible with PyTorch's version
-    if torch.version.hip:
-        return _get_hiprtc_library()
-    else:
-        return _get_nvrtc_library()
-
-
-def _get_gpu_rtc_compatible_flags() -> list[str]:
-    """
-    Get HIPCC/NVCC flags that are compatible with NVRTC compilation.
-
-    Returns:
-        List of HIPCC/NVCC flags that can be safely used with NVRTC.
-    """
-    from torch.utils.cpp_extension import COMMON_HIPCC_FLAGS, COMMON_NVCC_FLAGS
-
-    nvrtc_unsupported_flags = {
-        "--expt-relaxed-constexpr",
-    }
-
-    # Filter out unsupported flags
-    compatible_flags = [
-        flag for flag in COMMON_NVCC_FLAGS if flag not in nvrtc_unsupported_flags
-    ]
-
-    if torch.version.hip:
-        compatible_flags.extend(COMMON_HIPCC_FLAGS)
-
-    return compatible_flags
+        raise RuntimeError(
+            "Could not find libnvrtc.so. Please make sure CUDA is installed."
+        )
 
 
 def _nvrtc_compile(
     kernel_source: str,
     kernel_name: str,
     compute_capability: Optional[str] = None,
+    header_code: str = "",
     cuda_include_dirs: Optional[list] = None,
     nvcc_options: Optional[list] = None,
-    auto_pch: bool = False,
-) -> tuple[bytes, str]:
+) -> bytes:
     """
     Compiles a CUDA kernel using NVRTC and returns the PTX code.
 
@@ -126,18 +116,18 @@ def _nvrtc_compile(
         kernel_name (str): The name of the kernel function to compile
         compute_capability (str, None): The compute capability to target (e.g., "86").
                                            If None, will detect from current device.
+        header_code (str, optional): Additional header code to prepend to the kernel source
         cuda_include_dirs (list, None): List of directories containing CUDA headers
         nvcc_options (list, None): Additional options to pass to NVRTC
-        auto_pch (bool): Enable automatic precompiled headers (CUDA 12.8+)
 
     Returns:
-        Tuple[bytes, str]: The compiled PTX code and mangled kernel name
+        str: The compiled PTX code
     """
     # Ensure CUDA is initialized
     import torch.cuda
 
     # Load NVRTC library
-    libnvrtc = _get_gpu_rtc_library()
+    libnvrtc = _get_nvrtc_library()
 
     # NVRTC constants
     NVRTC_SUCCESS = 0
@@ -154,49 +144,51 @@ def _nvrtc_compile(
             )
             raise RuntimeError(f"CUDA error: {error_message}")
 
+    # Add 'extern "C"' if not already present to ensure C linkage
+    if not kernel_source.strip().startswith('extern "C"'):
+        kernel_source = f'extern "C" {kernel_source}'
+
+    # Combine header code and kernel source
+    if header_code:
+        full_source = header_code + "\n" + kernel_source
+    else:
+        full_source = kernel_source
+
     # Convert source to bytes
-    source_bytes = kernel_source.encode("utf-8")
+    source_bytes = full_source.encode("utf-8")
 
     # Get compute capability if not provided
     if compute_capability is None:
         props = torch.cuda.get_device_properties(torch.cuda.current_device())
-        if torch.version.hip:
-            compute_capability = f"{props.gcnArchName}"
-        else:
-            compute_capability = f"{props.major}{props.minor}"
+        compute_capability = f"{props.major}{props.minor}"
 
     # Prepare compilation options
     options = []
-    if torch.version.hip:
-        options.append(f"--offload-arch={compute_capability}".encode())
-    else:
-        options.append(f"--gpu-architecture=sm_{compute_capability}".encode())
-
-    # Auto-detect and add CUDA include paths
-    from torch.utils.cpp_extension import include_paths
-
-    cuda_include_paths = include_paths("cuda")
-    for cuda_path in cuda_include_paths:
-        options.append(f"-I{cuda_path}".encode())
+    options.append(f"--gpu-architecture=sm_{compute_capability}".encode())
 
     # Add custom include directories
     if cuda_include_dirs:
         for directory in cuda_include_dirs:
             options.append(f"-I{directory}".encode())
 
-    # Enable automatic precompiled headers (CUDA 12.8+)
-    if auto_pch:
-        assert str(torch.version.cuda) >= "12.8", "PCH requires CUDA 12.8+"
-        if nvcc_options is None:
-            nvcc_options = []
-        nvcc_options.append("--pch")
+    from torch.utils.cpp_extension import include_paths
+
+    paths = include_paths(device="cuda")
+    for path in paths:
+        options.append(f"-I{path}".encode())
 
     # Add custom NVCC options
     if nvcc_options:
         for option in nvcc_options:
             options.append(option.encode("utf-8"))
 
-    nvrtc_compatible_flags = _get_gpu_rtc_compatible_flags()
+    # TODO: Should we refactor flags into a common place?
+    from torch.utils.cpp_extension import COMMON_NVCC_FLAGS
+
+    # Filter out flags not supported by NVRTC
+    nvrtc_compatible_flags = [
+        flag for flag in COMMON_NVCC_FLAGS if flag != "--expt-relaxed-constexpr"
+    ]
     options.extend([flag.encode("utf-8") for flag in nvrtc_compatible_flags])
 
     # Convert options to C array
@@ -216,10 +208,6 @@ def _nvrtc_compile(
         )
     )
 
-    # Add kernel name, which can be a template expression
-    c_kernel_name = kernel_name.encode("utf-8")
-    check_nvrtc(libnvrtc.nvrtcAddNameExpression(prog, c_kernel_name))
-
     # Compile program
     res = libnvrtc.nvrtcCompileProgram(prog, num_options, options_array)
 
@@ -237,24 +225,9 @@ def _nvrtc_compile(
     check_nvrtc(libnvrtc.nvrtcGetPTXSize(prog, ctypes.byref(ptx_size)))
     ptx = ctypes.create_string_buffer(ptx_size.value)
     check_nvrtc(libnvrtc.nvrtcGetPTX(prog, ptx))
-
-    # Get mangled name
-    c_mangled_name = ctypes.c_char_p()
-    check_nvrtc(
-        libnvrtc.nvrtcGetLoweredName(prog, c_kernel_name, ctypes.byref(c_mangled_name))
-    )
-    if c_mangled_name.value is not None:
-        mangled_name = c_mangled_name.value.decode()  # make a copy
-    else:
-        mangled_name = ""
-
     libnvrtc.nvrtcDestroyProgram(ctypes.byref(prog))
 
-    # For HIP, hipRTC generates raw CO binaries instead of PTX,
-    # and for some reason, ".value" causes the string to be truncated,
-    # likely due to the presence of '\0' in the string. So we use .raw instead.
-    ptx_bytes = ptx.raw if torch.version.hip else ptx.value
-    return ptx_bytes, mangled_name
+    return ptx.value
 
 
 class _CudaModule:
@@ -267,9 +240,9 @@ class _CudaModule:
             return self._kernels[name]
 
         # Import the CUDA library inside the method
-        from torch.cuda._utils import _get_gpu_runtime_library
+        from torch.cuda._utils import _get_cuda_library
 
-        libcuda = _get_gpu_runtime_library()
+        libcuda = _get_cuda_library()
 
         func = ctypes.c_void_p()
         try:
@@ -294,7 +267,6 @@ class _CudaKernel:
     def __init__(self, func: ctypes.c_void_p, module: ctypes.c_void_p) -> None:
         self.func = func
         self.module = module
-        self._max_shared_mem_bytes = 0
 
     def __call__(
         self,
@@ -317,7 +289,7 @@ class _CudaKernel:
         """
         import torch
 
-        libcuda = torch.cuda._utils._get_gpu_runtime_library()
+        libcuda = torch.cuda._utils._get_cuda_library()
 
         if not args:
             args = []
@@ -341,11 +313,12 @@ class _CudaKernel:
                 c_int = ctypes.c_int(arg)
                 # Store the C int for reference keeping, not in processed_args
                 c_args.append(ctypes.byref(c_int))
+            # TODO: Python floats are actually doubles
             elif isinstance(arg, float):
-                # Python floats are doubles - use double by default
-                c_double = ctypes.c_double(arg)
-                # Store the C double for reference keeping, not in processed_args
-                c_args.append(ctypes.byref(c_double))
+                # Convert floats to C float
+                c_float = ctypes.c_float(arg)
+                # Store the C float for reference keeping, not in processed_args
+                c_args.append(ctypes.byref(c_float))
             else:
                 raise TypeError(f"Unsupported argument type: {type(arg)}")
 
@@ -360,22 +333,6 @@ class _CudaKernel:
             import torch.cuda
 
             stream = torch.cuda.current_stream()
-
-        # Check if kernel requires large shared memory but hasn't been configured
-        if shared_mem >= 48 * 1024 and (
-            self._max_shared_mem_bytes == 0 or shared_mem > self._max_shared_mem_bytes
-        ):
-            configured_msg = (
-                "not configured"
-                if self._max_shared_mem_bytes == 0
-                else f"only {self._max_shared_mem_bytes} bytes configured"
-            )
-            raise RuntimeError(
-                f"Kernel requires {shared_mem} bytes of shared memory (>= 48KB), "
-                f"but {configured_msg}. "
-                "Call kernel.set_shared_memory_config(shared_mem) after compilation "
-                "and before launching the kernel."
-            )
 
         _check_cuda(
             libcuda.cuLaunchKernel(
@@ -392,48 +349,6 @@ class _CudaKernel:
                 None,
             )
         )
-
-    def set_shared_memory_config(self, shared_mem_bytes: int) -> None:
-        if shared_mem_bytes < 48 * 1024:
-            # No configuration needed for <= 48KB, just update the value
-            self._max_shared_mem_bytes = shared_mem_bytes
-            return
-
-        libcuda = _get_gpu_runtime_library()
-
-        # Get device properties to validate against limits
-        device_props = torch.cuda.get_device_properties()
-        # HIP doesn't have shared_memory_per_block_optin in device properties, so we hard-code it here
-        if torch.version.hip:
-            # navi, CDNA1-CDNA3 allows a max of 64KB shared memory
-            # CDNA4 allows a max of 160KB shared memory
-            max_shared_mem = (
-                65536 if device_props.gcnArchName not in ["gfx950"] else 160 * 1024
-            )
-        else:
-            max_shared_mem = getattr(
-                device_props, "shared_memory_per_block_optin", 49152
-            )
-
-        if shared_mem_bytes > max_shared_mem:
-            raise RuntimeError(
-                f"Requested shared memory ({shared_mem_bytes} bytes) exceeds "
-                f"device limit ({max_shared_mem} bytes). "
-                "Consider reducing block size or shared memory usage."
-            )
-
-        # Set the function attribute once
-        # https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html
-        cudaFuncAttributeMaxDynamicSharedMemorySize = 8
-        _check_cuda(
-            libcuda.cuFuncSetAttribute(
-                self.func,
-                cudaFuncAttributeMaxDynamicSharedMemorySize,
-                shared_mem_bytes,
-            )
-        )
-
-        self._max_shared_mem_bytes = shared_mem_bytes
 
 
 def _cuda_load_module(
@@ -455,7 +370,7 @@ def _cuda_load_module(
     import torch.cuda
 
     # Load CUDA driver library
-    libcuda = _get_gpu_runtime_library()
+    libcuda = _get_cuda_library()
 
     # Convert PTX to bytes if it's a string
     if isinstance(ptx, str):


### PR DESCRIPTION
EDIT: It works! Still need to run benchmarks and clean up the PR for review

Another example showing how to use compile_kernel, my homework is to see whether i can get something as fast as using CUB in this way, (probably not but I'll try)

Don't review before benchmarks please

So I chatted offline with @jrhemstad and he tells me that CUB works just fine with NVRTC because they test that utilities like `Block*` and `Warp*` all work - we might just need to still pass CUB headers in

But if the above gets validated then something like the below should get us close to SOL

```cpp
template <int block_size>
__global__ void reduce(cuda::std::span<int const> data, cuda::std::span<int> result) {
  using BlockReduce = cub::BlockReduce<int, block_size>;
  __shared__ typename BlockReduce::TempStorage temp_storage;

  int const index = threadIdx.x + blockIdx.x * blockDim.x;
  int sum = 0;
  if (index < data.size()) {
    sum += data[index];
  }
  sum = BlockReduce(temp_storage).Sum(sum);

  if (threadIdx.x == 0) {
    cuda::atomic_ref<int, cuda::thread_scope_device> atomic_result(result.front());
    atomic_result.fetch_add(sum, cuda::memory_order_relaxed);
  }
}
```

Relevant issue https://github.com/NVIDIA/cccl/issues/5032


Issue I'm debugging now is that including cub is not working but looks like we already package the headers in pytorch directly https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/cuda/cub.cuh

Followup work from #151484 

Update: 

The Problem: CUB (CUDA C++ template library) depends on C++ standard library headers like <cstddef>, <type_traits>, etc. But NVRTC (NVIDIA Runtime Compilation) can't access the full C++ standard library - it's a limited compilation environment.

So I'm creating fake standard library headers and putting them in a temporary directory that we add to NVRTC's include path. When CUB tries to #include <memory>, instead of failing, NVRTC finds our fake memory file. This is probably a terrible idea but I'm curious to see if it can actually work https://gist.github.com/msaroufim/98ad0be6a30ae2595d1a99e56344af0c - EDIT: This is indeed a terrible idea since the volume of libraries to mock is massive

It seems that @malfet's original assesment that CUB won't work well with NVRTC was correct 

EDIT: Actually maybe it wasn't some links would say otherwise

* https://github.com/gevtushenko/cccl/blob/f0cee9b5c3d5f23dcd9f02202e85d3fa679cb319/cub/test/catch2_test_nvrtc.cu
* https://github.com/NVIDIA/jitify
* https://github.com/NVIDIA/cuda-python/discussions/643
* https://github.com/Kernel-Machines/kermac
* https://github.com/pytorch/pytorch/pull/156380