### PR TITLE
[Inductor][CPP] Add the config to set KC_Blocking for GEMM CPP Template

### DIFF
--- a/torch/_inductor/codegen/cpp_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_gemm_template.py
@@ -806,7 +806,7 @@ class CppGemmTemplate(CppTemplate):
                 blockings = [int(i) for i in config.cpp.gemm_cache_blocking.split(",")]
                 assert len(blockings) == 3
                 if blockings[2] != 0:
-                    Kc_blocks = blockings[2]
+                    Kc_blocks = min(blockings[2], Kt_blocks)
 
             if not Kc_blocks:
                 size_cache_B = Kr * Kt_blocks * Nr * num_byte_B


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #156388
* #156387

**Summary**
The CPP GEMM template supports explicitly setting `cache blocking` via the config option `torch._inductor.config.cpp.gemm_cache_blocking = "2,2,2"`. Previously, all three parameters—`Mc_blocks, Nc_blocks, and Kc_blocks`—had to be specified together. When tuning performance for WOQ int4 workloads with small M sizes, we observed that strategy 1 (reusing B by A) becomes ineffective. In such cases, the size of `dequant_B` significantly affects performance.

In this case, we found that tuning `Kc_blocks` alone can yield performance gains. This PR introduces support for setting `Kc_blocks` independently, while allowing `Mc_blocks` and `Nc_blocks` to be determined heuristically. For example, one can now use `torch._inductor.config.cpp.gemm_cache_blocking = "0,0,2"` to achieve this.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov