### PR TITLE
Change t.is_cuda to t.device.type == 'cuda' in torch/utils/viz

### DIFF
--- a/torch/utils/viz/_cycles.py
+++ b/torch/utils/viz/_cycles.py
@@ -311,7 +311,11 @@ def escape(n):
 
 
 def is_cuda_tensor(obj):
-    return isinstance(obj, torch.Tensor) and obj.is_cuda and not isinstance(obj, torch._subclasses.FakeTensor)
+    return (
+        isinstance(obj, torch.Tensor) and
+        obj.device.type == "cuda" and
+        not isinstance(obj, torch._subclasses.FakeTensor)
+    )
 
 def cuda_allocation_context():
     snapshot = torch.cuda.memory._snapshot()


### PR DESCRIPTION
Fixes #156417

Unlike `.is_cuda` the property `.device` is supported by `ShardedTensor`.