### PR TITLE
[cc][multi-kernel] attempt 1

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -306,6 +306,7 @@ class PersistentCache(CacheBase):
         op: str,
         inputs: str,
         benchmark: Optional[Callable[[Any], dict[ChoiceCaller, float]]],
+        hint_override: Optional[int] = None,
     ) -> dict[ChoiceCaller, float]:
         """
         Check to see if we have benchmarked the given choice callers. For each
@@ -319,11 +320,13 @@ class PersistentCache(CacheBase):
                 b. `max_autotune_gemm=False`: don't benchmark the choice, return nothing.
         """
         precision = torch.get_float32_matmul_precision()
+        # Include hint_override in cache key
+        cache_key = f"{inputs}_{hint_override}" if hint_override is not None else inputs
 
-        log_stats = partial(log_global_cache_stats, self.system, op, inputs, precision)
-        log_vals = partial(log_global_cache_vals, self.system, op, inputs, precision)
+        log_stats = partial(log_global_cache_stats, self.system, op, cache_key, precision)
+        log_vals = partial(log_global_cache_vals, self.system, op, cache_key, precision)
         log_errors = partial(
-            log_global_cache_errors, self.system, op, inputs, precision
+            log_global_cache_errors, self.system, op, cache_key, precision
         )
         timings = {}
 
@@ -332,9 +335,9 @@ class PersistentCache(CacheBase):
             hit = True
             for choice in choices:
                 choice_hash = choice.hash_key()
-                if choice_hash in cache.get(op, {}).get(inputs, {}).get(precision, {}):
+                if choice_hash in cache.get(op, {}).get(cache_key, {}).get(precision, {}):
                     # cache hit
-                    timings[choice] = cache[op][inputs][precision][choice_hash]
+                    timings[choice] = cache[op][cache_key][precision][choice_hash]
                 else:
                     # cache miss
                     hit = False
@@ -359,9 +362,9 @@ class PersistentCache(CacheBase):
                     timings = benchmark(choices)
                     assert all(choice in timings for choice in choices)
                     local_cache.setdefault(op, {})
-                    local_cache[op].setdefault(inputs, {}).setdefault(precision, {})
+                    local_cache[op].setdefault(cache_key, {}).setdefault(precision, {})
                     for choice, timing in timings.items():
-                        local_cache[op][inputs][precision][choice.hash_key()] = timing
+                        local_cache[op][cache_key][precision][choice.hash_key()] = timing
                 except RuntimeError as e:
                     # catch and log autotuning failures
                     log_errors(e)

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -412,6 +412,9 @@ disable_decompose_k = os.environ.get("TORCHINDUCTOR_DISABLE_DECOMPOSE_K") == "1"
 # Modifies the number of autotuning choices displayed, set to None for all
 autotune_num_choices_displayed: Optional[int] = 10
 
+# Multi-kernel dispatch hints for creating multiple kernel versions
+multi_kernel_hints: list[int] = [64, 256, 4096]
+
 # enable inductor graph partition to allow multiple inductor graphs for the same dynamo graph
 graph_partition = False
 

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2200,7 +2200,7 @@ class AlgorithmSelectorCache(PersistentCache):
 
         inputs_key = create_inputs_key(input_nodes)
 
-        def autotune(choices):
+        def autotune(choices, hint_override: Optional[int] = None):
             log.debug("Starting autotuning")
 
             with dynamo_timed(
@@ -2222,13 +2222,13 @@ class AlgorithmSelectorCache(PersistentCache):
                     ),
                 },
             ):
-                return make_benchmark_fn()(choices)
+                return make_benchmark_fn(hint_override=hint_override)(choices)
 
         if config.autotune_in_subproc:
             # Initialize the suprocess pool so it will warmup early.
             torch._inductor.autotune_process.get_tuning_process_pool()
 
-        def do_autotuning(choices, precompile_fn):
+        def do_autotuning(choices, precompile_fn, hint_override: Optional[int] = None):
             precompile_start_ts = time.time()
             with dynamo_timed(
                 f"{name}_template_precompiling",
@@ -2248,6 +2248,7 @@ class AlgorithmSelectorCache(PersistentCache):
                     name,
                     inputs_key,
                     autotune,
+                    hint_override,
                 )
                 choices = self.prune_choices_postscreen(choices, timings)
                 prescreening_elapse = time.time() - prescreening_start_ts
@@ -2259,6 +2260,7 @@ class AlgorithmSelectorCache(PersistentCache):
                 name,
                 inputs_key,
                 autotune,
+                hint_override,
             )
 
             autotune_elapse = time.time() - autotune_start_ts
@@ -2320,8 +2322,8 @@ class AlgorithmSelectorCache(PersistentCache):
 
         if return_multi_template and (config.max_autotune or config.max_autotune_gemm):
 
-            def get_timings():
-                timings = do_autotuning(choices, precompile_fn)
+            def get_timings(hint_override: Optional[int] = None):
+                timings = do_autotuning(choices, precompile_fn, hint_override)
                 min_extern_choice = float("inf")
                 for choice, timing in timings.items():
                     if isinstance(choice, ExternKernelCaller):
@@ -2560,6 +2562,7 @@ class AlgorithmSelectorCache(PersistentCache):
         input_nodes: list[ir.IRNode],
         layout: ir.Layout,
         input_gen_fns: Optional[dict[int, Callable[[ir.Buffer], torch.Tensor]]],
+        hint_override: Optional[int] = None,
     ) -> AutotuneArgs:
         """
         Factory method to create AutotuneArgs from a list of ChoiceCallers.
@@ -2704,8 +2707,9 @@ class AlgorithmSelectorCache(PersistentCache):
         input_nodes: list[ir.IRNode],
         layout: ir.Layout,
         input_gen_fns: Optional[dict[int, Callable[[ir.Buffer], torch.Tensor]]],
+        hint_override: Optional[int] = None,
     ) -> dict[ChoiceCaller, float]:
-        inputs = cls.get_inputs(choices, input_nodes, layout, input_gen_fns)
+        inputs = cls.get_inputs(choices, input_nodes, layout, input_gen_fns, hint_override)
         return cls.benchmark_choices(choices, inputs)
 
     @classmethod
@@ -2736,6 +2740,7 @@ class AlgorithmSelectorCache(PersistentCache):
         input_nodes: list[ir.IRNode],
         layout: ir.Layout,
         input_gen_fns: Optional[dict[int, Callable[[ir.Buffer], torch.Tensor]]],
+        hint_override: Optional[int] = None,
     ):
         if DEBUG:
             print(f"{len(choices)} tuning requests:")
@@ -2746,6 +2751,7 @@ class AlgorithmSelectorCache(PersistentCache):
                 input_nodes=input_nodes,
                 layout=layout,
                 input_gen_fns=input_gen_fns,
+                hint_override=hint_override,
             )
         else:
             return functools.partial(
@@ -2753,6 +2759,7 @@ class AlgorithmSelectorCache(PersistentCache):
                 input_nodes=input_nodes,
                 layout=layout,
                 input_gen_fns=input_gen_fns,
+                hint_override=hint_override,
             )
 
     @staticmethod


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

prompt:

```
We want to support multi kernel dispatch. Here's the gameplan:

- We want to introduce a new inductor config called multi_kernel_hints: List[int] = [64, 256, 4096] in torch/_inductor/config.py
- Currently we have MultiTemplateBuffer which only generates 20 choices for a given matmul. We want to extend MultiTemplateBuffer so that instead of a single make_kernel_render we want to have len(multi_kernel_hints) + 1 make_kernel_renders. To do this you'll need to do a couple of things:
	- You'll need to update get_min_choice with a hint_override kwarg
	- Instead of accessing self.choice_timings the property,  you'll want to turn it into a method where you can pass in the override
	- You'll need to update _choice_timings_fn to also take in the override
	- You'll need to update `get_timings`, `do_autotuning`, `get_inputs`, `benchmark_in_current_process`, `make_benchmark_fn`, `autotune` in torch/_inductor/select_algorithm.py to also take in hint_override
	- You'll need to update PersistentCache.lookup to also take in hint_override and use it in its cache key and benchmarking
	- You'll need to update finalize_as_triton_caller so that it finalizes multiple callers, one for each hint.
- As you can see in speedup_by_fusion in torch/_inductor/scheduler.py, when doing fusion we check to see if fusion is faster than separate and finalize the kernel if so.  You'll want to update `multi_node.finalize_as_triton_caller(ms_fused_choice)` so that instead we do something like `multi_node.finalize_as_triton_callers(ms_fused_choices)` where we still use the hint to determine whether or not to fuse but use also calculate the multi_kernel_hints fusion nodes and pass that in
- You'll need to update codegen_template in torch/_inductor/codegen/simd.py to have multiple kernel dispatch similar to codegen_node_schedule
- You'll also need to update torch/_inductor/codegen/multi_kernel.py to support shape specialized dispatch. The basic idea is for every unique shape we will check to see which of the len(multi_kernel_hints) + 1 is best and cache it.
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov