### PR TITLE
[dm][mk] attempt 2

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -295,6 +295,7 @@ class PersistentCache(CacheBase):
         op: str,
         inputs: str,
         benchmark: Optional[Callable[[Any], dict[ChoiceCaller, float]]],
+        hint_override: Optional[int] = None,
     ) -> dict[ChoiceCaller, float]:
         """
         Check to see if we have benchmarked the given choice callers. For each

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1652,6 +1652,9 @@ _cache_config_ignore_prefix: list[str] = [
 # External callable for matmul tuning candidates
 external_matmul: list[Callable[[torch.Tensor, torch.Tensor, torch.Tensor], None]] = []
 
+# Multi-kernel dispatch hints for different kernel sizes
+multi_kernel_hints: list[int] = [64, 256, 4096]
+
 
 class test_configs:
     force_extern_kernel_in_multi_template: bool = False

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2184,7 +2184,7 @@ class AlgorithmSelectorCache(PersistentCache):
             # Initialize the suprocess pool so it will warmup early.
             torch._inductor.autotune_process.get_tuning_process_pool()
 
-        def do_autotuning(choices, precompile_fn):
+        def do_autotuning(choices, precompile_fn, hint_override: Optional[int] = None):
             precompile_start_ts = time.time()
             with dynamo_timed(
                 f"{name}_template_precompiling",
@@ -2203,6 +2203,7 @@ class AlgorithmSelectorCache(PersistentCache):
                     name,
                     inputs_key,
                     autotune,
+                    hint_override=hint_override,
                 )
                 choices = self.prune_choices_postscreen(choices, timings)
                 prescreening_elapse = time.time() - prescreening_start_ts
@@ -2214,6 +2215,7 @@ class AlgorithmSelectorCache(PersistentCache):
                 name,
                 inputs_key,
                 autotune,
+                hint_override=hint_override,
             )
 
             autotune_elapse = time.time() - autotune_start_ts
@@ -2250,8 +2252,8 @@ class AlgorithmSelectorCache(PersistentCache):
 
         if return_multi_template and (config.max_autotune or config.max_autotune_gemm):
 
-            def get_timings():
-                timings = do_autotuning(choices, precompile_fn)
+            def get_timings(hint_override: Optional[int] = None):
+                timings = do_autotuning(choices, precompile_fn, hint_override)
                 min_extern_choice = float("inf")
                 for choice, timing in timings.items():
                     if isinstance(choice, ExternKernelCaller):

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -568,7 +568,10 @@ class SizeVarAllocator:
         exprs: Iterable[Expr],
         *,
         fallback: Optional[int] = None,
+        hint_override: Optional[int] = None,
     ) -> tuple[int, ...]:
+        if hint_override is not None:
+            return tuple(hint_override for _ in exprs)
         return tuple(self.size_hint(x, fallback=fallback) for x in exprs)
 
     def _lru_cache(self, fn, maxsize=None):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #156423

```
We want to support multi kernel dispatch. Here's the gameplan:

- We want to introduce a new inductor config called multi_kernel_hints: List[int] = [64, 256, 4096] in torch/_inductor/config.py
- Currently we have MultiTemplateBuffer which only generates 20 choices for a given matmul. We want to extend MultiTemplateBuffer so that instead of a single make_kernel_render we want to have len(multi_kernel_hints) + 1 make_kernel_renders. To do this you'll need to do a couple of things:
	- You'll need to update get_min_choice with a hint_override kwarg
	- Instead of accessing self.choice_timings the property,  you'll want to turn it into a method where you can pass in the override
	- You'll need to update _choice_timings_fn to also take in the override
	- You'll need to update `get_timings`, `do_autotuning`, `get_inputs`, `benchmark_in_current_process`, `make_benchmark_fn`, `autotune` in torch/_inductor/select_algorithm.py to also take in hint_override
	- You'll need to update PersistentCache.lookup to also take in hint_override and use it in its cache key and benchmarking
	- You'll need to update finalize_as_triton_caller so that it finalizes multiple callers, one for each hint.
	- You'll also need to update V.graph.sizevars.size_hints to take in hint_override in torch/_inductor/sizevars.py
- As you can see in speedup_by_fusion in torch/_inductor/scheduler.py, when doing fusion we check to see if fusion is faster than separate and finalize the kernel if so.  You'll want to update `multi_node.finalize_as_triton_caller(ms_fused_choice)` so that instead we do something like `multi_node.finalize_as_triton_callers(ms_fused_choices)` where we still use the hint to determine whether or not to fuse but use also calculate the multi_kernel_hints fusion nodes and pass that in
- You'll need to update codegen_template in torch/_inductor/codegen/simd.py to have multiple kernel dispatch similar to codegen_node_schedule
- You'll also need to update torch/_inductor/codegen/multi_kernel.py to support shape specialized dispatch. The basic idea is for every unique shape we will check to see which of the len(multi_kernel_hints) + 1 is best and cache it.
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov