### PR TITLE
[cc][multi-kernel] attempt 2

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -412,6 +412,9 @@ disable_decompose_k = os.environ.get("TORCHINDUCTOR_DISABLE_DECOMPOSE_K") == "1"
 # Modifies the number of autotuning choices displayed, set to None for all
 autotune_num_choices_displayed: Optional[int] = 10
 
+# Size hints for multi-kernel dispatch optimization
+multi_kernel_hints: list[int] = [64, 256, 4096]
+
 # enable inductor graph partition to allow multiple inductor graphs for the same dynamo graph
 graph_partition = False
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4748,7 +4748,7 @@ class MultiTemplateBuffer(TritonTemplateBuffer):
         self,
         layout: Layout,
         inputs: list[IRNode],
-        choice_timings: Callable[[], dict[ChoiceCaller, float]],
+        choice_timings: Callable[[Optional[int]], dict[ChoiceCaller, float]],
         unfiltered_choices: list[ChoiceCaller],
         allowed_prologue_inps: OrderedSet[str],
     ) -> None:
@@ -4759,7 +4759,7 @@ class MultiTemplateBuffer(TritonTemplateBuffer):
             allowed_prologue_inps=allowed_prologue_inps,
         )
         self._choice_timings_fn = choice_timings
-        self._choice_timings: Optional[dict[ChoiceCaller, float]] = None
+        self._choice_timings_cache: dict[Optional[int], dict[ChoiceCaller, float]] = {}
         self.original_inputs = inputs
         self._output_plannable = all(
             isinstance(choice, TritonTemplateCallerBase)
@@ -4777,11 +4777,10 @@ class MultiTemplateBuffer(TritonTemplateBuffer):
         """
         return self._output_plannable
 
-    @property
-    def choice_timings(self) -> dict[ChoiceCaller, float]:
-        if self._choice_timings is None:
-            self._choice_timings = self._choice_timings_fn()
-        return self._choice_timings
+    def choice_timings(self, hint_override: Optional[int] = None) -> dict[ChoiceCaller, float]:
+        if hint_override not in self._choice_timings_cache:
+            self._choice_timings_cache[hint_override] = self._choice_timings_fn(hint_override)
+        return self._choice_timings_cache[hint_override]
 
     @contextlib.contextmanager
     def swap_as_triton_caller(self, caller: TritonTemplateCallerBase):  # type: ignore[no-untyped-def]
@@ -4801,9 +4800,30 @@ class MultiTemplateBuffer(TritonTemplateBuffer):
         assert self.get_stride() == caller.layout.stride
         self.make_kernel_render = caller.get_make_kernel_render()
 
-    def get_min_choice(self) -> tuple[ChoiceCaller, float]:
-        min_choice = min(self.choice_timings, key=self.choice_timings.get)  # type: ignore[arg-type]
-        return (min_choice, self.choice_timings[min_choice])
+    def finalize_as_triton_callers(self, callers: dict[Optional[int], TritonTemplateCallerBase]) -> None:
+        """Finalize with multiple callers for different hint overrides"""
+        from . import config
+        
+        # Store all the kernel renders for different hints
+        self._make_kernel_renders: dict[Optional[int], Any] = {}
+        
+        for hint_override, caller in callers.items():
+            assert isinstance(caller, torch._inductor.select_algorithm.TritonTemplateCaller)
+            assert self.get_size() == caller.layout.size
+            assert self.get_stride() == caller.layout.stride
+            self._make_kernel_renders[hint_override] = caller.get_make_kernel_render()
+        
+        # Set the default make_kernel_render to the one without hint override
+        self.make_kernel_render = self._make_kernel_renders.get(None)
+        
+        # If no default, use the first available
+        if self.make_kernel_render is None and self._make_kernel_renders:
+            self.make_kernel_render = next(iter(self._make_kernel_renders.values()))
+
+    def get_min_choice(self, hint_override: Optional[int] = None) -> tuple[ChoiceCaller, float]:
+        timings = self.choice_timings(hint_override)
+        min_choice = min(timings, key=timings.get)  # type: ignore[arg-type]
+        return (min_choice, timings[min_choice])
 
 
 class CUDATemplateBuffer(TemplateBuffer):

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -2944,6 +2944,7 @@ class Scheduler:
             def benchmark_when_ready() -> bool:
                 min_ms_fused = float("inf")
                 ms_fused_choice = None
+                ms_fused_choices = []
 
                 new_timings = {}
                 # Benchmark each choice after compilation completes
@@ -2967,14 +2968,15 @@ class Scheduler:
                             mod_fused, device
                         )
                         new_timings[choice] = ms_fused
+                        ms_fused_choices.append(choice)
                         if ms_fused < min_ms_fused:
                             min_ms_fused = ms_fused
                             ms_fused_choice = choice
 
                 log_fusion(min_ms_fused, ms1, ms2)
 
-                if min_ms_fused < (ms1 + ms2) and ms_fused_choice is not None:
-                    multi_node.finalize_as_triton_caller(ms_fused_choice)
+                if min_ms_fused < (ms1 + ms2) and ms_fused_choices:
+                    multi_node.finalize_as_triton_callers(ms_fused_choices)
                     multi_node._choice_timings = new_timings
                     return True
                 else:

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2560,6 +2560,7 @@ class AlgorithmSelectorCache(PersistentCache):
         input_nodes: list[ir.IRNode],
         layout: ir.Layout,
         input_gen_fns: Optional[dict[int, Callable[[ir.Buffer], torch.Tensor]]],
+        hint_override: Optional[int] = None,
     ) -> AutotuneArgs:
         """
         Factory method to create AutotuneArgs from a list of ChoiceCallers.
@@ -2704,8 +2705,9 @@ class AlgorithmSelectorCache(PersistentCache):
         input_nodes: list[ir.IRNode],
         layout: ir.Layout,
         input_gen_fns: Optional[dict[int, Callable[[ir.Buffer], torch.Tensor]]],
+        hint_override: Optional[int] = None,
     ) -> dict[ChoiceCaller, float]:
-        inputs = cls.get_inputs(choices, input_nodes, layout, input_gen_fns)
+        inputs = cls.get_inputs(choices, input_nodes, layout, input_gen_fns, hint_override=hint_override)
         return cls.benchmark_choices(choices, inputs)
 
     @classmethod
@@ -2715,6 +2717,7 @@ class AlgorithmSelectorCache(PersistentCache):
         input_nodes: list[ir.IRNode],
         layout: ir.Layout,
         input_gen_fns: Optional[dict[int, Callable[[ir.Buffer], torch.Tensor]]],
+        hint_override: Optional[int] = None,
     ):
         from . import autotune_process
 
@@ -2724,7 +2727,7 @@ class AlgorithmSelectorCache(PersistentCache):
         triton = [c for c in choices if not isinstance(c, ExternKernelCaller)]
 
         timings = cls.benchmark_in_current_process(
-            extern, input_nodes, layout, input_gen_fns
+            extern, input_nodes, layout, input_gen_fns, hint_override=hint_override
         )
         timings.update(autotune_process.benchmark_in_sub_process(triton))  # type: ignore[arg-type]
         return timings
@@ -2736,6 +2739,7 @@ class AlgorithmSelectorCache(PersistentCache):
         input_nodes: list[ir.IRNode],
         layout: ir.Layout,
         input_gen_fns: Optional[dict[int, Callable[[ir.Buffer], torch.Tensor]]],
+        hint_override: Optional[int] = None,
     ):
         if DEBUG:
             print(f"{len(choices)} tuning requests:")
@@ -2746,6 +2750,7 @@ class AlgorithmSelectorCache(PersistentCache):
                 input_nodes=input_nodes,
                 layout=layout,
                 input_gen_fns=input_gen_fns,
+                hint_override=hint_override,
             )
         else:
             return functools.partial(
@@ -2753,6 +2758,7 @@ class AlgorithmSelectorCache(PersistentCache):
                 input_nodes=input_nodes,
                 layout=layout,
                 input_gen_fns=input_gen_fns,
+                hint_override=hint_override,
             )
 
     @staticmethod

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -546,8 +546,18 @@ class SizeVarAllocator:
         exprs: Iterable[Union[Expr, int]],
         *,
         fallback: Optional[int] = None,
+        hint_override: Optional[dict[Union[Expr, int], int]] = None,
     ) -> tuple[int, ...]:
-        return tuple(self.size_hint(x, fallback=fallback) for x in exprs)
+        if hint_override is None:
+            return tuple(self.size_hint(x, fallback=fallback) for x in exprs)
+        
+        result = []
+        for x in exprs:
+            if x in hint_override:
+                result.append(hint_override[x])
+            else:
+                result.append(self.size_hint(x, fallback=fallback))
+        return tuple(result)
 
     def _lru_cache(self, fn, maxsize=None):
         """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #156427

```
We want to support multi kernel dispatch. Here's the gameplan:

- We want to introduce a new inductor config called multi_kernel_hints: List[int] = [64, 256, 4096] in torch/_inductor/config.py
- Currently we have MultiTemplateBuffer which only generates 20 choices for a given matmul. We want to extend MultiTemplateBuffer so that instead of a single make_kernel_render we want to have len(multi_kernel_hints) + 1 make_kernel_renders. To do this you'll need to do a couple of things:
	- You'll need to update get_min_choice with a hint_override kwarg
	- Instead of accessing self.choice_timings the property,  you'll want to turn it into a method where you can pass in the override
	- You'll need to update _choice_timings_fn to also take in the override
	- You'll need to update `get_timings`, `do_autotuning`, `get_inputs`, `benchmark_in_current_process`, `benchmark_in_sub_process `, `make_benchmark_fn`, `autotune` in torch/_inductor/select_algorithm.py to also take in hint_override
	- You'll need to update PersistentCache.lookup to also take in hint_override and use it in its cache key and benchmarking. In particular you'll want to update cache[op][inputs][precision][choice_hash] to also take in the hint_override.
	- You'll need to update finalize_as_triton_caller so that it finalizes multiple callers, one for each hint.
	- You'll also need to update V.graph.sizevars.size_hints to take in hint_override in torch/_inductor/sizevars.py
- As you can see in speedup_by_fusion in torch/_inductor/scheduler.py, when doing fusion we check to see if fusion is faster than separate and finalize the kernel if so.  You'll want to update `multi_node.finalize_as_triton_caller(ms_fused_choice)` so that instead we do something like `multi_node.finalize_as_triton_callers(ms_fused_choices)` where we still use the hint to determine whether or not to fuse but use also calculate the multi_kernel_hints fusion nodes and pass that in
- You'll need to update codegen_template in torch/_inductor/codegen/simd.py to have multiple kernel dispatch similar to codegen_node_schedule
- You'll also need to update torch/_inductor/codegen/multi_kernel.py to support shape specialized dispatch. The basic idea is for every unique shape we will check to see which of the len(multi_kernel_hints) + 1 is best and cache it.
- You'll see that in `call_kernel` in torch/_inductor/select_algorithm.py  we do some arg extension by adding the grid size. The current multi kernel implementation doesn't have support for this, particularly in the `benchmark_sub_kernels` in torch/_inductor/codegen/multi_kernel.py. Make sure we do the proper bookkeeping so we can benchmark the kernels with the right varying grid sizes.
- Instead of using a heuristic such as closest hint value to find the best kernel you should just run a benchmark across all the kernels for a particular shape to pick one
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov