### PR TITLE
use cmake target torch instead of ${TORCH_LIBRARIES} in cpp installation docs

### DIFF
--- a/docs/cpp/source/installing.rst
+++ b/docs/cpp/source/installing.rst
@@ -40,7 +40,7 @@ this:
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
 
   add_executable(example-app example-app.cpp)
-  target_link_libraries(example-app "${TORCH_LIBRARIES}")
+  target_link_libraries(example-app torch)
   set_property(TARGET example-app PROPERTY CXX_STANDARD 17)
 
   # The following code block is suggested to be used on Windows.


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/11682 adds the ability to do `target_link_libraries(my_target torch)` to get  proper includes, libraries and compiler flags added to the target.

Fixes #156434
