### PR TITLE
Remove some no-effect lintrules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,7 +168,6 @@ select = [
     "PLW0406", # import self
     "PLW0711", # binary op exception
     "PLW1501", # bad open mode
-    "PLW1507", # shallow copy os.environ
     "PLW1509", # preexec_fn not safe with threads
     "PLW2101", # useless lock statement
     "PLW3301", # nested min max
@@ -195,8 +194,6 @@ select = [
     "RUF026", # default factory kwarg
     "RUF030", # No print statement in assert
     "RUF033", # default values __post_init__ dataclass
-    "RUF041", # simplify nested Literal
-    "RUF048", # properly parse `__version__`
     "RUF200", # validate pyproject.toml
     "S324", # for hashlib FIPS compliance
     "SLOT",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #156445
* #156466

Everytime I run lintunner I get these error messages at the top. If they
aren't doing anything, we might as well just remove the rules?

```
--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -1,3 +1,6 @@
+warning: Selection `PLW1507` has no effect because preview is not enabled.
+warning: Selection `RUF041` has no effect because preview is not enabled.
+warning: Selection `RUF048` has no effect because preview is not enabled.
```