### PR TITLE
[cc][multi-kernel] attempt 4

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -306,6 +306,7 @@ class PersistentCache(CacheBase):
         op: str,
         inputs: str,
         benchmark: Optional[Callable[[Any], dict[ChoiceCaller, float]]],
+        hint_override: Optional[int] = None,
     ) -> dict[ChoiceCaller, float]:
         """
         Check to see if we have benchmarked the given choice callers. For each
@@ -319,11 +320,14 @@ class PersistentCache(CacheBase):
                 b. `max_autotune_gemm=False`: don't benchmark the choice, return nothing.
         """
         precision = torch.get_float32_matmul_precision()
+        cache_key = f"{inputs}_{hint_override}" if hint_override is not None else inputs
 
-        log_stats = partial(log_global_cache_stats, self.system, op, inputs, precision)
-        log_vals = partial(log_global_cache_vals, self.system, op, inputs, precision)
+        log_stats = partial(
+            log_global_cache_stats, self.system, op, cache_key, precision
+        )
+        log_vals = partial(log_global_cache_vals, self.system, op, cache_key, precision)
         log_errors = partial(
-            log_global_cache_errors, self.system, op, inputs, precision
+            log_global_cache_errors, self.system, op, cache_key, precision
         )
         timings = {}
 
@@ -332,9 +336,11 @@ class PersistentCache(CacheBase):
             hit = True
             for choice in choices:
                 choice_hash = choice.hash_key()
-                if choice_hash in cache.get(op, {}).get(inputs, {}).get(precision, {}):
+                if choice_hash in cache.get(op, {}).get(cache_key, {}).get(
+                    precision, {}
+                ):
                     # cache hit
-                    timings[choice] = cache[op][inputs][precision][choice_hash]
+                    timings[choice] = cache[op][cache_key][precision][choice_hash]
                 else:
                     # cache miss
                     hit = False
@@ -359,9 +365,11 @@ class PersistentCache(CacheBase):
                     timings = benchmark(choices)
                     assert all(choice in timings for choice in choices)
                     local_cache.setdefault(op, {})
-                    local_cache[op].setdefault(inputs, {}).setdefault(precision, {})
+                    local_cache[op].setdefault(cache_key, {}).setdefault(precision, {})
                     for choice, timing in timings.items():
-                        local_cache[op][inputs][precision][choice.hash_key()] = timing
+                        local_cache[op][cache_key][precision][choice.hash_key()] = (
+                            timing
+                        )
                 except RuntimeError as e:
                     # catch and log autotuning failures
                     log_errors(e)

--- a/torch/_inductor/codegen/multi_kernel.py
+++ b/torch/_inductor/codegen/multi_kernel.py
@@ -283,6 +283,7 @@ class MultiKernelCall:
             self.load_cache()
 
         self._recorded = False
+        self._shape_cache = {}
 
     def cache_file_path(self):
         key = code_hash(
@@ -343,7 +344,30 @@ class MultiKernelCall:
 
         def wrap_fn(kernel):
             def inner():
+                # Clone args but ensure proper grid size handling
                 args_clone, kwargs_clone = kernel.clone_args(*args, **kwargs)
+
+                # If kernel has a grid_fn, we need to extend args with grid size
+                if hasattr(kernel, "grid_fn") and hasattr(kernel, "call_sizes"):
+                    import sympy
+
+                    from ..select_algorithm import SymbolicGridFn
+
+                    grid_args = ()
+                    if isinstance(kernel.grid_fn, SymbolicGridFn):
+                        grid_args = kernel.grid_fn.sympy_call(
+                            *kernel.call_sizes, kernel.meta
+                        )
+                    elif all(
+                        isinstance(x, (int, sympy.Integer)) for x in kernel.call_sizes
+                    ):
+                        grid_args = kernel.grid_fn(
+                            *map(int, kernel.call_sizes), kernel.meta
+                        )
+
+                    if len(grid_args) == 3:  # Valid grid arguments
+                        args_clone = list(args_clone) + list(grid_args)
+
                 return kernel.run(*args_clone, **kwargs_clone)
 
             return inner
@@ -390,20 +414,45 @@ class MultiKernelCall:
 
     def run(self, *args, **kwargs):
         if self.picked_kernel is None:
-            timings = self.benchmark_sub_kernels(*args, **kwargs)
-            self.picked_kernel = timings.index(min(timings))
-            k0 = self.kernels[0]
-            log.debug(
-                "pick %dth sub-kernel in %s. Size hints %s. Reduction hint %s. Timings %s",
-                self.picked_kernel,
-                [k.inductor_meta.get("kernel_name") for k in self.kernels],
-                k0.size_hints,
-                k0.inductor_meta.get("reduction_hint"),
-                timings,
-            )
-            get_metric_table("persistent_red_perf").add_row(
-                functools.partial(self._metrics_table_row, timings)
-            )
+            cache_key = self._get_multi_kernel_shape_cache_key(*args, **kwargs)
+            cached_choice = self._get_cached_shape_choice(cache_key)
+
+            if cached_choice is not None:
+                self.picked_kernel = cached_choice
+                log.debug(
+                    "using cached shape-specialized choice %dth sub-kernel in %s. Cache key: %s",
+                    self.picked_kernel,
+                    [k.inductor_meta.get("kernel_name") for k in self.kernels],
+                    cache_key,
+                )
+            else:
+                shape_choice = self._select_kernel_by_shape(*args, **kwargs)
+                if shape_choice is not None:
+                    self.picked_kernel = shape_choice
+                    log.debug(
+                        "using shape-based heuristic %dth sub-kernel in %s. Shape choice: %s",
+                        self.picked_kernel,
+                        [k.inductor_meta.get("kernel_name") for k in self.kernels],
+                        shape_choice,
+                    )
+                else:
+                    timings = self.benchmark_sub_kernels(*args, **kwargs)
+                    self.picked_kernel = timings.index(min(timings))
+                    k0 = self.kernels[0]
+                    log.debug(
+                        "pick %dth sub-kernel in %s. Size hints %s. Reduction hint %s. Timings %s",
+                        self.picked_kernel,
+                        [k.inductor_meta.get("kernel_name") for k in self.kernels],
+                        k0.size_hints,
+                        k0.inductor_meta.get("reduction_hint"),
+                        timings,
+                    )
+                    get_metric_table("persistent_red_perf").add_row(
+                        functools.partial(self._metrics_table_row, timings)
+                    )
+
+                self._cache_shape_choice(cache_key, self.picked_kernel)
+
             if not self.disable_cache:
                 self.store_cache()
 
@@ -416,6 +465,70 @@ class MultiKernelCall:
             self.record_choice(self.multi_kernel_name, picked_kernel_name)
         self.run = self.kernels[self.picked_kernel].run  # type: ignore[method-assign]
         self.run(*args, **kwargs)
+
+    def _get_shape_cache_key(self, *args, **kwargs):
+        """
+        Generate a cache key based on tensor shapes for shape-specialized dispatch.
+        """
+        shapes = []
+        for arg in args:
+            if hasattr(arg, "shape"):
+                shapes.append(tuple(arg.shape))
+        return tuple(shapes)
+
+    def _get_multi_kernel_shape_cache_key(self, *args, **kwargs):
+        """
+        Generate a cache key for multi-kernel hint specialized dispatch.
+        Includes both shape information and hint override values.
+        """
+        base_key = self._get_shape_cache_key(*args, **kwargs)
+
+        # Extract hint information from the first kernel's size_hints
+        # We'll use the shape to determine which hint override to use
+        if hasattr(self, "kernels") and self.kernels:
+            k0 = self.kernels[0]
+            if hasattr(k0, "size_hints") and k0.size_hints:
+                # Use the largest tensor dimension to pick the appropriate hint
+                max_dim = 0
+                for arg in args:
+                    if hasattr(arg, "numel"):
+                        max_dim = max(max_dim, arg.numel())
+
+                # Find the best matching hint from config.multi_kernel_hints
+                best_hint = None
+                min_diff = float("inf")
+                for hint in config.multi_kernel_hints:
+                    diff = abs(max_dim - hint)
+                    if diff < min_diff:
+                        min_diff = diff
+                        best_hint = hint
+
+                return (base_key, best_hint)
+
+        return (base_key, None)
+
+    def _get_cached_shape_choice(self, cache_key):
+        """
+        Get cached kernel choice for a specific shape.
+        """
+        return self._shape_cache.get(cache_key)
+
+    def _cache_shape_choice(self, cache_key, kernel_idx):
+        """
+        Cache kernel choice for a specific shape
+        """
+        self._shape_cache[cache_key] = kernel_idx
+
+    def _select_kernel_by_shape(self, *args, **kwargs):
+        """
+        Benchmark kernels for a particular shape and return the
+        best kernel for this shape.
+        """
+        shape_key = self._get_multi_kernel_shape_cache_key(*args, **kwargs)
+        timings = self.benchmark_sub_kernels(*args, **kwargs)
+        best_kernel_idx = timings.index(min(timings))
+        self._cache_shape_choice(shape_key, best_kernel_idx)
+        return best_kernel_idx
 
     def _metrics_table_row(self, timings):
         def get_kernel_path(k):

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -423,6 +423,9 @@ force_same_precision = (
     True if is_fbcode() else os.environ.get("TORCHINDUCTOR_FORCE_SAME_PRECISION") == "1"
 )
 
+# Size hints for multi-kernel dispatch
+multi_kernel_hints: list[int] = [64, 256, 4096]
+
 # Specify candidate backends for gemm autotune.
 # Possible choices are combinations of: ATen, Triton, CUTLASS, CK, CPP.
 # ATen: default Pytorch ATen kernels.

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4748,7 +4748,7 @@ class MultiTemplateBuffer(TritonTemplateBuffer):
         self,
         layout: Layout,
         inputs: list[IRNode],
-        choice_timings: Callable[[], dict[ChoiceCaller, float]],
+        choice_timings_fn: Callable[[Optional[int]], dict[ChoiceCaller, float]],
         unfiltered_choices: list[ChoiceCaller],
         allowed_prologue_inps: OrderedSet[str],
     ) -> None:
@@ -4758,8 +4758,8 @@ class MultiTemplateBuffer(TritonTemplateBuffer):
             make_kernel_render=None,
             allowed_prologue_inps=allowed_prologue_inps,
         )
-        self._choice_timings_fn = choice_timings
-        self._choice_timings: Optional[dict[ChoiceCaller, float]] = None
+        self._choice_timings_fn = choice_timings_fn
+        self._choice_timings: dict[Optional[int], dict[ChoiceCaller, float]] = {}
         self.original_inputs = inputs
         self._output_plannable = all(
             isinstance(choice, TritonTemplateCallerBase)
@@ -4777,11 +4777,12 @@ class MultiTemplateBuffer(TritonTemplateBuffer):
         """
         return self._output_plannable
 
-    @property
-    def choice_timings(self) -> dict[ChoiceCaller, float]:
-        if self._choice_timings is None:
-            self._choice_timings = self._choice_timings_fn()
-        return self._choice_timings
+    def choice_timings(
+        self, hint_override: Optional[int] = None
+    ) -> dict[ChoiceCaller, float]:
+        if hint_override not in self._choice_timings:
+            self._choice_timings[hint_override] = self._choice_timings_fn(hint_override)
+        return self._choice_timings[hint_override]
 
     @contextlib.contextmanager
     def swap_as_triton_caller(self, caller: TritonTemplateCallerBase):  # type: ignore[no-untyped-def]
@@ -4801,9 +4802,25 @@ class MultiTemplateBuffer(TritonTemplateBuffer):
         assert self.get_stride() == caller.layout.stride
         self.make_kernel_render = caller.get_make_kernel_render()
 
-    def get_min_choice(self) -> tuple[ChoiceCaller, float]:
-        min_choice = min(self.choice_timings, key=self.choice_timings.get)  # type: ignore[arg-type]
-        return (min_choice, self.choice_timings[min_choice])
+    def get_min_choice(
+        self, hint_override: Optional[int] = None
+    ) -> tuple[ChoiceCaller, float]:
+        timings = self.choice_timings(hint_override=hint_override)
+        min_choice = min(timings, key=timings.get)  # type: ignore[arg-type]
+        return (min_choice, timings[min_choice])
+
+    def finalize_as_triton_callers(
+        self, callers: dict[Optional[int], TritonTemplateCallerBase]
+    ) -> None:
+        """Finalize with multiple callers for different hint overrides"""
+
+        self._make_kernel_renders: dict[Optional[int], Any] = {}
+
+        for hint_override, caller in callers.items():
+            self._make_kernel_renders[hint_override] = caller.get_make_kernel_render()
+
+        # Set the default to be the one without hint override
+        self.make_kernel_render = self._make_kernel_renders[None]
 
 
 class CUDATemplateBuffer(TemplateBuffer):

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2195,12 +2195,14 @@ class AlgorithmSelectorCache(PersistentCache):
                 return choices[0].output_node()
 
         @functools.cache
-        def make_benchmark_fn():
-            return self.make_benchmark_fn(choices, input_nodes, layout, input_gen_fns)
+        def make_benchmark_fn(hint_override: Optional[int] = None):
+            return self.make_benchmark_fn(
+                choices, input_nodes, layout, input_gen_fns, hint_override=hint_override
+            )
 
         inputs_key = create_inputs_key(input_nodes)
 
-        def autotune(choices):
+        def autotune(choices, hint_override: Optional[int] = None):
             log.debug("Starting autotuning")
 
             with dynamo_timed(
@@ -2222,13 +2224,13 @@ class AlgorithmSelectorCache(PersistentCache):
                     ),
                 },
             ):
-                return make_benchmark_fn()(choices)
+                return make_benchmark_fn(hint_override=hint_override)(choices)
 
         if config.autotune_in_subproc:
             # Initialize the suprocess pool so it will warmup early.
             torch._inductor.autotune_process.get_tuning_process_pool()
 
-        def do_autotuning(choices, precompile_fn):
+        def do_autotuning(choices, precompile_fn, hint_override: Optional[int] = None):
             precompile_start_ts = time.time()
             with dynamo_timed(
                 f"{name}_template_precompiling",
@@ -2244,10 +2246,7 @@ class AlgorithmSelectorCache(PersistentCache):
             if candidates:
                 prescreening_start_ts = time.time()
                 timings = self.lookup(
-                    candidates,
-                    name,
-                    inputs_key,
-                    autotune,
+                    candidates, name, inputs_key, autotune, hint_override=hint_override
                 )
                 choices = self.prune_choices_postscreen(choices, timings)
                 prescreening_elapse = time.time() - prescreening_start_ts
@@ -2255,10 +2254,7 @@ class AlgorithmSelectorCache(PersistentCache):
 
             autotune_start_ts = time.time()
             timings = self.lookup(
-                choices,
-                name,
-                inputs_key,
-                autotune,
+                choices, name, inputs_key, autotune, hint_override=hint_override
             )
 
             autotune_elapse = time.time() - autotune_start_ts
@@ -2320,8 +2316,10 @@ class AlgorithmSelectorCache(PersistentCache):
 
         if return_multi_template and (config.max_autotune or config.max_autotune_gemm):
 
-            def get_timings():
-                timings = do_autotuning(choices, precompile_fn)
+            def get_timings(hint_override: Optional[int] = None):
+                timings = do_autotuning(
+                    choices, precompile_fn, hint_override=hint_override
+                )
                 min_extern_choice = float("inf")
                 for choice, timing in timings.items():
                     if isinstance(choice, ExternKernelCaller):
@@ -2560,6 +2558,7 @@ class AlgorithmSelectorCache(PersistentCache):
         input_nodes: list[ir.IRNode],
         layout: ir.Layout,
         input_gen_fns: Optional[dict[int, Callable[[ir.Buffer], torch.Tensor]]],
+        hint_override: Optional[int] = None,
     ) -> AutotuneArgs:
         """
         Factory method to create AutotuneArgs from a list of ChoiceCallers.
@@ -2568,8 +2567,11 @@ class AlgorithmSelectorCache(PersistentCache):
             input_gen_fns = {}
 
         # de-duplicate args
+        def default_input_gen(node):
+            return cls.benchmark_example_value(node, hint_override)
+
         unique_example_inputs = {
-            x.get_name(): input_gen_fns.get(i, cls.benchmark_example_value)(x)
+            x.get_name(): input_gen_fns.get(i, default_input_gen)(x)
             for i, x in enumerate(input_nodes)
         }
         example_inputs = list(unique_example_inputs.values())
@@ -2582,22 +2584,32 @@ class AlgorithmSelectorCache(PersistentCache):
                     V.graph.sizevars.size_hints(
                         input_node.get_size(),
                         fallback=config.unbacked_symint_fallback,
+                        hint_override=hint_override,
                     ),
                     V.graph.sizevars.size_hints(
                         input_node.get_stride(),
                         fallback=config.unbacked_symint_fallback,
+                        hint_override=hint_override,
                     ),
                     V.graph.sizevars.size_hint(
                         input_node.get_layout().offset,
                         fallback=config.unbacked_symint_fallback,
+                        hint_override=hint_override,
                     ),
                 )
             )
             for input_node in input_nodes
         ]
-        out = cls.benchmark_example_value(layout)
+        out = cls.benchmark_example_value(layout, hint_override)
         out_extern = torch.as_strided(
-            out, out.size(), out.stride(), V.graph.sizevars.size_hint(layout.offset)
+            out,
+            out.size(),
+            out.stride(),
+            V.graph.sizevars.size_hint(
+                layout.offset,
+                fallback=config.unbacked_symint_fallback,
+                hint_override=hint_override,
+            ),
         )
         expected = None
         if VERIFY:
@@ -2704,8 +2716,11 @@ class AlgorithmSelectorCache(PersistentCache):
         input_nodes: list[ir.IRNode],
         layout: ir.Layout,
         input_gen_fns: Optional[dict[int, Callable[[ir.Buffer], torch.Tensor]]],
+        hint_override: Optional[int] = None,
     ) -> dict[ChoiceCaller, float]:
-        inputs = cls.get_inputs(choices, input_nodes, layout, input_gen_fns)
+        inputs = cls.get_inputs(
+            choices, input_nodes, layout, input_gen_fns, hint_override=hint_override
+        )
         return cls.benchmark_choices(choices, inputs)
 
     @classmethod
@@ -2715,6 +2730,7 @@ class AlgorithmSelectorCache(PersistentCache):
         input_nodes: list[ir.IRNode],
         layout: ir.Layout,
         input_gen_fns: Optional[dict[int, Callable[[ir.Buffer], torch.Tensor]]],
+        hint_override: Optional[int] = None,
     ):
         from . import autotune_process
 
@@ -2724,7 +2740,7 @@ class AlgorithmSelectorCache(PersistentCache):
         triton = [c for c in choices if not isinstance(c, ExternKernelCaller)]
 
         timings = cls.benchmark_in_current_process(
-            extern, input_nodes, layout, input_gen_fns
+            extern, input_nodes, layout, input_gen_fns, hint_override=hint_override
         )
         timings.update(autotune_process.benchmark_in_sub_process(triton))  # type: ignore[arg-type]
         return timings
@@ -2736,6 +2752,7 @@ class AlgorithmSelectorCache(PersistentCache):
         input_nodes: list[ir.IRNode],
         layout: ir.Layout,
         input_gen_fns: Optional[dict[int, Callable[[ir.Buffer], torch.Tensor]]],
+        hint_override: Optional[int] = None,
     ):
         if DEBUG:
             print(f"{len(choices)} tuning requests:")
@@ -2746,6 +2763,7 @@ class AlgorithmSelectorCache(PersistentCache):
                 input_nodes=input_nodes,
                 layout=layout,
                 input_gen_fns=input_gen_fns,
+                hint_override=hint_override,
             )
         else:
             return functools.partial(
@@ -2753,6 +2771,7 @@ class AlgorithmSelectorCache(PersistentCache):
                 input_nodes=input_nodes,
                 layout=layout,
                 input_gen_fns=input_gen_fns,
+                hint_override=hint_override,
             )
 
     @staticmethod
@@ -2960,7 +2979,7 @@ class AlgorithmSelectorCache(PersistentCache):
         )
 
     @staticmethod
-    def benchmark_example_value(node):
+    def benchmark_example_value(node, hint_override: Optional[int] = None):
         """
         Convert an ir.Buffer into a concrete torch.Tensor we can use for
         benchmarking.
@@ -2979,10 +2998,12 @@ class AlgorithmSelectorCache(PersistentCache):
             V.graph.sizevars.size_hints(
                 node.get_size(),
                 fallback=config.unbacked_symint_fallback,
+                hint_override=hint_override,
             ),
             V.graph.sizevars.size_hints(
                 node.get_stride(),
                 fallback=config.unbacked_symint_fallback,
+                hint_override=hint_override,
             ),
             node.get_device(),
             node.get_dtype(),
@@ -2990,6 +3011,7 @@ class AlgorithmSelectorCache(PersistentCache):
             V.graph.sizevars.size_hints(
                 V.graph.get_allocation_size(node),
                 fallback=config.unbacked_symint_fallback,
+                hint_override=hint_override,
             ),
         )
 

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -519,8 +519,15 @@ class SizeVarAllocator:
         return sympy_subs(expr, self.var_to_val)
 
     def size_hint(
-        self, expr: Union[Expr, int], *, fallback: Optional[int] = None
+        self,
+        expr: Union[Expr, int],
+        *,
+        fallback: Optional[int] = None,
+        hint_override: Optional[int] = None,
     ) -> int:
+        if hint_override:
+            return hint_override
+
         out = self.symbolic_hint(expr)
         if not isinstance(out, (int, sympy.Integer)) and fallback is not None:
             # Use the provided heuristic fallback hint
@@ -546,8 +553,12 @@ class SizeVarAllocator:
         exprs: Iterable[Union[Expr, int]],
         *,
         fallback: Optional[int] = None,
+        hint_override: Optional[int] = None,
     ) -> tuple[int, ...]:
-        return tuple(self.size_hint(x, fallback=fallback) for x in exprs)
+        return tuple(
+            self.size_hint(x, fallback=fallback, hint_override=hint_override)
+            for x in exprs
+        )
 
     def _lru_cache(self, fn, maxsize=None):
         """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #156452

```
We want to support multi kernel dispatch. Here's the gameplan:

- We want to introduce a new inductor config called multi_kernel_hints: List[int] = [64, 256, 4096] in torch/_inductor/config.py
- Currently we have MultiTemplateBuffer which only generates 20 choices for a given matmul. We want to extend MultiTemplateBuffer so that instead of a single make_kernel_render we want to have len(multi_kernel_hints) + 1 make_kernel_renders. To do this you'll need to do a couple of things:
	- You'll need to update get_min_choice with a hint_override kwarg
	- Instead of accessing self.choice_timings the property,  you'll want to turn it into a method where you can pass in the override
	- You'll need to update _choice_timings_fn to also take in the override
	- You'll need to update `get_timings`, `do_autotuning`, `get_inputs`, `benchmark_in_current_process`, `benchmark_in_sub_process `, `make_benchmark_fn`, `autotune` in torch/_inductor/select_algorithm.py to also take in hint_override
	- You'll need to update PersistentCache.lookup to also take in hint_override and use it in its cache key and benchmarking. In particular you'll want to update cache[op][inputs][precision][choice_hash] to also take in the hint_override.
	- You'll need to update finalize_as_triton_caller so that it finalizes multiple callers, one for each hint.
	- You'll also need to update V.graph.sizevars.size_hints to take in hint_override in torch/_inductor/sizevars.py
- As you can see in speedup_by_fusion in torch/_inductor/scheduler.py, when doing fusion we check to see if fusion is faster than separate and finalize the kernel if so.  You'll want to update `multi_node.finalize_as_triton_caller(ms_fused_choice)` so that instead we do something like `multi_node.finalize_as_triton_callers(ms_fused_choices)` where we still use the hint to determine whether or not to fuse but use also calculate the multi_kernel_hints fusion nodes and pass that in. So in particular we should iterate through multi_kernel_hints and generate one caller for each.
- You'll need to update codegen_template in torch/_inductor/codegen/simd.py to have multiple kernel dispatch similar to codegen_node_schedule
- You'll also need to update torch/_inductor/codegen/multi_kernel.py to support shape specialized dispatch. The basic idea is for every unique shape we will check to see which of the len(multi_kernel_hints) + 1 is best and cache it.
- You'll see that in `call_kernel` in torch/_inductor/select_algorithm.py  we do some arg extension by adding the grid size. The current multi kernel implementation doesn't have support for this, particularly in the `benchmark_sub_kernels` in torch/_inductor/codegen/multi_kernel.py. Make sure we do the proper bookkeeping so we can benchmark the kernels with the right varying grid sizes.
- Instead of using a heuristic such as closest hint value to find the best kernel you should just run a benchmark across all the kernels for a particular shape to pick one
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov