### PR TITLE
Forward fix inductor benchmark after #150287

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/cpu_aot_inductor_freezing_timm_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/cpu_aot_inductor_freezing_timm_inference.csv
@@ -42,7 +42,7 @@ cspdarknet53,pass,0
 
 
 
-deit_base_distilled_patch16_224,fail_to_run,0
+deit_base_distilled_patch16_224,pass,0
 
 
 
@@ -114,7 +114,7 @@ lcnet_050,pass,0
 
 
 
-levit_128,fail_to_run,0
+levit_128,pass,0
 
 
 
@@ -238,7 +238,7 @@ vit_base_patch16_224,pass,0
 
 
 
-volo_d1_224,fail_to_run,0
+volo_d1_224,pass,0
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/cpu_aot_inductor_freezing_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/cpu_aot_inductor_freezing_torchbench_inference.csv
@@ -34,7 +34,7 @@ basic_gnn_gin,pass,0
 
 
 
-basic_gnn_sage,fail_to_run,0
+basic_gnn_sage,pass,0
 
 
 


### PR DESCRIPTION
Looks like https://github.com/pytorch/pytorch/pull/150287 stack fixed some inductor tests
HUD: https://hud.pytorch.org/hud/pytorch/pytorch/main/1?per_page=50&name_filter=inductor-periodic%20%2F%20linux-jammy-cpu-py3.9-gcc11-inductor

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames