### PR TITLE
Fix torch.onnx.export parameter for onnx_shape_inference (#156480)

### DIFF
--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -150,6 +150,7 @@ def export(
     custom_opsets: Mapping[str, int] | None = None,
     export_modules_as_functions: bool | Collection[type[torch.nn.Module]] = False,
     autograd_inlining: bool = True,
+    onnx_shape_inference: bool = True,
 ) -> ONNXProgram | None:
     r"""Exports a model into ONNX format.
 
@@ -428,6 +429,7 @@ def export(
             custom_opsets=custom_opsets,
             export_modules_as_functions=export_modules_as_functions,
             autograd_inlining=autograd_inlining,
+            onnx_shape_inference=onnx_shape_inference,
         )
         return None
 

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -213,6 +213,7 @@ def export(
     custom_opsets: Mapping[str, int] | None = None,
     export_modules_as_functions: bool | Collection[type[torch.nn.Module]] = False,
     autograd_inlining: bool = True,
+    onnx_shape_inference: bool = True,
 ) -> None:
     r"""Exports a model into ONNX format.
 
@@ -536,6 +537,7 @@ def export(
         custom_opsets=custom_opsets,
         export_modules_as_functions=export_modules_as_functions,
         autograd_inlining=autograd_inlining,
+        onnx_shape_inference=onnx_shape_inference,
     )
 
     return None


### PR DESCRIPTION
Controll whether to run the shape type inference while exporting to onnx by parameter onnx_shape_inference in interface torch.onnx.export.

Fixes #156480
