### PR TITLE
[Profiler] Fix profile_all_threads in debug build

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -2211,10 +2211,6 @@ assert KinetoStepTracker.current_step() == initial_step + 2 * niters
     @skipIfTorchDynamo("profiler gets ignored if dynamo activated")
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
     @unittest.skipIf(not kineto_available(), "Kineto is required")
-    @unittest.skipIf(
-        "RelWithAssert" in torch.__config__.show(),
-        "failing in debug build, see https://github.com/pytorch/pytorch/pull/150059 for example",
-    )
     def test_profile_all_threads(self):
         profiling_started = threading.Event()
         profiling_ended = threading.Event()

--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -781,7 +781,6 @@ PythonTracer::PythonTracer(torch::profiler::impl::RecordQueue* queue)
 
     std::vector<THPFrameObjectPtr> current_stack;
     auto frame = PyThreadState_GetFrame(thread_state);
-    Py_XINCREF(frame);
 
     size_t depth = 0; // Make sure we can't infinite loop.
     while (frame != nullptr) {

--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -769,7 +769,7 @@ PythonTracer::PythonTracer(torch::profiler::impl::RecordQueue* queue)
     return;
   }
 
-  auto interpreter_threads = interpreterThreads(); 
+  auto interpreter_threads = interpreterThreads();
 
   // Register the tracer in each thread.
   for (const auto thread_state : interpreter_threads) {
@@ -815,10 +815,11 @@ PythonTracer::PythonTracer(torch::profiler::impl::RecordQueue* queue)
 
   for (size_t i = 0; i < interpreter_threads.size(); i++) {
     PyThreadState_Swap(interpreter_threads[i]);
+    auto* ctx = thread_local_results_[i].ctx_;
     // Note:
     //   This profile will not compose with other CPython profilers, and
     //   cannot be round tripped via `sys.settrace(sys.gettrace())`
-    PyEval_SetProfile(PythonTracer::pyProfileFn, (PyObject*)thread_local_results_[i].ctx_);
+    PyEval_SetProfile(PythonTracer::pyProfileFn, (PyObject*)ctx);
   }
 }
 

--- a/torch/csrc/profiler/orchestration/observer.cpp
+++ b/torch/csrc/profiler/orchestration/observer.cpp
@@ -153,7 +153,7 @@ std::shared_ptr<ProfilerStateBase> popTLS() {
 /*static*/ std::shared_ptr<ProfilerStateBase> ProfilerStateBase::pop(
     bool global) {
   auto out = global ? GlobalManager::pop() : popTLS();
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(!out || out->config().global() == global);
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(!out || out->config().global() == global || out->config().experimental_config.profile_all_threads);
   return out;
 }
 

--- a/torch/csrc/profiler/orchestration/observer.cpp
+++ b/torch/csrc/profiler/orchestration/observer.cpp
@@ -153,7 +153,8 @@ std::shared_ptr<ProfilerStateBase> popTLS() {
 /*static*/ std::shared_ptr<ProfilerStateBase> ProfilerStateBase::pop(
     bool global) {
   auto out = global ? GlobalManager::pop() : popTLS();
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(!out || out->config().global() == global || out->config().experimental_config.profile_all_threads);
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(!out || out->config().global() == global || 
+    out->config().experimental_config.profile_all_threads);
   return out;
 }
 


### PR DESCRIPTION
The profile_all_threads option introduced in #143659  is very useful for on-demand profiling. However, I found some issues with this option in debug builds. This PR aims to fix those issues and fix the test `TestProfiler.test_profile_all_threads`.

1. An assertion in `ProfilerStateBase::pop` is incorrect. It does not account for the case when profile_all_threads is enabled. 

2. Sometimes we get coredump here:
```
#0  0x00007f5a75973005 in raise () from /lib64/libc.so.6
#1  0x00007f5a75945894 in abort () from /lib64/libc.so.6
#2  0x00007f5a398b135a in __cxxabiv1::__terminate (handler=<optimized out>) at /opt/conda/conda-bld/gcc-compiler_1654084175708/work/gcc/libstdc++-v3/libsupc++/eh_terminate.cc:48
#3  0x00007f5a398b03b9 in __cxa_call_terminate (ue_header=0x7f59649a5c20) at /opt/conda/conda-bld/gcc-compiler_1654084175708/work/gcc/libstdc++-v3/libsupc++/eh_call.cc:54
#4  0x00007f5a398b0ae7 in __cxxabiv1::__gxx_personality_v0 (version=<optimized out>, actions=6, exception_class=5138137972254386944, ue_header=0x7f59649a5c20, context=<optimized out>)
    at /opt/conda/conda-bld/gcc-compiler_1654084175708/work/gcc/libstdc++-v3/libsupc++/eh_personality.cc:685
#5  0x00007f5a67ad71e4 in _Unwind_RaiseException_Phase2 (exc=0x7f59649a5c20, context=0x7f5969b6a7f0, frames_p=0x7f5969b6a6f8) at /opt/conda/conda-bld/gcc-compiler_1654084175708/work/gcc/libgcc/unwind.inc:64
#6  0x00007f5a67ad7c1e in _Unwind_Resume (exc=0x7f59649a5c20) at /opt/conda/conda-bld/gcc-compiler_1654084175708/work/gcc/libgcc/unwind.inc:241
#7  0x00007f5a6567cf0c in pybind11::handle::dec_ref() const & (this=0x7f5969b6aa48) at /usr/include/c++/10/bits/basic_string.h:525
#8  0x00007f5a6567d15e in pybind11::object::~object (this=0x7f5969b6aa48, __in_chrg=<optimized out>) at /home/yifeng.jyf/projects/pytorch/third_party/pybind11/include/pybind11/pytypes.h:378
#9  0x00007f5a6567edb8 in pybind11::str::~str (this=0x7f5969b6aa48, __in_chrg=<optimized out>) at /home/yifeng.jyf/projects/pytorch/third_party/pybind11/include/pybind11/pytypes.h:1560
#10 0x00007f5a65c34560 in torch::profiler::impl::(anonymous namespace)::ValueCache::store<(torch::profiler::impl::<unnamed>::CallType)2>(const torch::profiler::impl::(anonymous namespace)::PyCCallKey &, torch::profiler::impl::(anonymous namespace)::Config<(torch::profiler::impl::<unnamed>::CallType)2>::ephemeral_t) (this=0x7f59640216b8, key=..., arg=0x7f596b8bf6d0)
    at /home/yifeng.jyf/projects/pytorch/torch/csrc/autograd/profiler_python.cpp:478
#11 0x00007f5a65c3d72f in torch::profiler::impl::(anonymous namespace)::TraceKeyCacheState<(torch::profiler::impl::<unnamed>::CallType)2>::intern(torch::profiler::impl::(anonymous namespace)::Callsite<(torch::profiler::impl::<unnamed>::CallType)2>, torch::profiler::impl::(anonymous namespace)::Config<(torch::profiler::impl::<unnamed>::CallType)2>::ephemeral_t, torch::profiler::impl::(anonymous namespace)::ValueCache &) (this=0x7f59649a2010, callsite=..., ephemeral=0x7f596b8bf6d0, value_cache=...) at /home/yifeng.jyf/projects/pytorch/torch/csrc/autograd/profiler_python.cpp:531
#12 0x00007f5a65c39737 in torch::profiler::impl::(anonymous namespace)::ThreadLocalResults::intern<(torch::profiler::impl::<unnamed>::CallType)2, (torch::profiler::impl::EventType)6, _object*, void*, _frame*>(_object *) (this=0x7f59649a1fd0, ephemeral=0x7f596b8bf6d0) at /home/yifeng.jyf/projects/pytorch/torch/csrc/autograd/profiler_python.cpp:664
#13 0x00007f5a65c36754 in torch::profiler::impl::(anonymous namespace)::PythonTracer::recordCCall (this=0x7f5964021620, tls=..., frame=0x7f596aebc640, arg=0x7f596b8bf6d0, start_frame=true)
    at /home/yifeng.jyf/projects/pytorch/torch/csrc/autograd/profiler_python.cpp:932
#14 0x00007f5a65c3589d in torch::profiler::impl::(anonymous namespace)::PythonTracer::PythonTracer (this=0x7f5964021620, queue=0x7f59649a1720)
    at /home/yifeng.jyf/projects/pytorch/torch/csrc/autograd/profiler_python.cpp:809
```

This can be reproduced with following code:
```python
import torch
from torch import nn
import time
import threading

learning_rate = 1e-3
batch_size = 64

class NeuralNetwork(nn.Module):
    def __init__(self):
        super().__init__()
        self.flatten = nn.Flatten()
        self.linear_relu_stack = nn.Sequential(
            nn.Linear(28*28, 2048),
            nn.ReLU(),
            nn.Linear(2048, 2048),
            nn.ReLU(),
            nn.Linear(2048, 10),
        )

    def forward(self, x):
        x = self.flatten(x)
        logits = self.linear_relu_stack(x)

        return logits

profile_finish = False

def profile_thread_work():
    time.sleep(3)
    experimental_config = torch._C._profiler._ExperimentalConfig(
        profile_all_threads=True,
    )

    with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU,torch.profiler.ProfilerActivity.CUDA], 
        record_shapes=True, profile_memory=True, with_stack=True, with_flops=True, with_modules=True,
        experimental_config=experimental_config
    ):
        time.sleep(1)
    
    global profile_finish
    profile_finish = True


def train_loop(model, optimizer):
    loss_fn = nn.CrossEntropyLoss()
    loss_fn.__call__
    model.train()
    for i in range(100):
        X = torch.randn((64,1,28,28), device="cuda")
        pred = model(X.cuda())
        y = torch.randn((64,10), device="cuda")
        loss = loss_fn(pred, y.cuda())
        loss.backward()
        optimizer.step()
        optimizer.zero_grad()
        loss, current = loss.item(), i * batch_size + len(X)


def main():
    threading.Thread(target=profile_thread_work, daemon=True).start()

    model = NeuralNetwork().cuda()
    optimizer = torch.optim.SGD(model.parameters(), lr=learning_rate)
    while True:
        train_loop(model, optimizer)
        
        if profile_finish:
            break
    
if __name__ == "__main__":
    main()
```


This coredump happens because pybind11 performs GIL checks when doing reference count operations. During the execution of `PythonTracer::PythonTracer`, although the GIL is actually held by current thread, after calling `PyThreadState_Swap`, CPython may mistakenly think that the current thread does not hold the GIL. I suggest splitting the original loop into two parts and only call` PyThreadState_Swap` before calling PyEval_SetProfile.
Also replace `PyEval_GetFrame` with `PyThreadState_GetFrame`, which was introduced in Python 3.9, the minimum Python version currently supported by PyTorch.