### PR TITLE
 Add regression test for UnicodeDecodeError in torch.compile with extreme values

### DIFF
--- a/test/test_extreme_values.py
+++ b/test/test_extreme_values.py
@@ -1,0 +1,25 @@
+import torch
+import torch.nn as nn
+import random
+
+def test_unicode_error_on_extreme_values():
+    class BuggyModel(nn.Module):
+        def forward(self, x):
+            if self.training:
+                mask = torch.rand_like(x) < 0.1
+                extreme_vals = torch.empty_like(x[mask])
+                for i in range(extreme_vals.numel()):
+                    extreme_vals[i] = random.choice([
+                        float("nan"), float("inf"), float("-inf")
+                    ])
+                x[mask] = extreme_vals
+            return x
+
+    model = BuggyModel().train()
+    x = torch.randn(1, 1, 32, 32)
+
+    try:
+        compiled = torch.compile(model)
+        _ = compiled(x)
+    except UnicodeDecodeError as e:
+        assert False, f"torch.compile raised UnicodeDecodeError: {e}"


### PR DESCRIPTION
## Summary

This PR adds a **regression test** for `torch.compile` that triggers a `UnicodeDecodeError` when compiling models with extreme tensor values.

📌 **Note**: This PR **does not fix** the issue — it adds a test to reproduce and track it.

## Related Issue

Partial support for [#156451](https://github.com/pytorch/pytorch/issues/156451)

## Changes

✅ Added test: `test/test_extreme_values.py`  
❌ No changes to PyTorch internals yet

## Next Steps

- A separate PR will propose the actual fix for the UnicodeDecodeError.
- This test will help us validate that the fix works and catch future regressions.

