### PR TITLE
[MPS] Optimize cumsum/cumprod metal kernels

### DIFF
--- a/aten/src/ATen/native/mps/kernels/ScanKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ScanKernel.metal
@@ -1,3 +1,4 @@
+#include <metal_simdgroup>
 #include <metal_stdlib>
 using namespace metal;
 
@@ -6,23 +7,103 @@ using namespace metal;
 
 using c10::metal::accum_t;
 
+// This file contains cumsum and cumprod implementations adapted from MLX:
+// https://github.com/ml-explore/mlx/blob/main/mlx/backend/metal/kernels/scan.h
+//
+// The original MLX kernels have been modified to integrate with PyTorch's MPS
+// backend, including support for c10::metal::accum_t in order to perform
+// computations on half/bfloat tensors at higher precision (float).
+//
+// Original work is licensed under MIT License:
+// https://github.com/ml-explore/mlx/blob/main/LICENSE
+
+inline uint64_t simd_shuffle_and_fill_up(
+    uint64_t data,
+    uint64_t filling,
+    uint16_t delta) {
+  return as_type<uint64_t>(metal::simd_shuffle_and_fill_up(
+      as_type<uint2>(data), as_type<uint2>(filling), delta));
+}
+
+inline int64_t simd_shuffle_and_fill_up(
+    int64_t data,
+    int64_t filling,
+    uint16_t delta) {
+  return as_type<int64_t>(metal::simd_shuffle_and_fill_up(
+      as_type<uint2>(data), as_type<uint2>(filling), delta));
+}
+
+inline uint64_t simd_shuffle(uint64_t data, uint16_t lane) {
+  return as_type<uint64_t>(metal::simd_shuffle(as_type<uint2>(data), lane));
+}
+
+inline int64_t simd_shuffle(int64_t data, uint16_t lane) {
+  return as_type<int64_t>(metal::simd_shuffle(as_type<uint2>(data), lane));
+}
+
+#define DEFINE_SIMD_SCAN()                                               \
+  template <typename U, metal::enable_if_t<sizeof(U) < 8, bool> = true>  \
+  U simd_scan(U val) {                                                   \
+    return simd_scan_impl(val);                                          \
+  }                                                                      \
+                                                                         \
+  template <typename U, metal::enable_if_t<sizeof(U) == 8, bool> = true> \
+  U simd_scan(U val) {                                                   \
+    for (int i = 1; i <= 16; i *= 2) {                                   \
+      val = operator()(val, simd_shuffle_and_fill_up(val, init, i));     \
+    }                                                                    \
+    return val;                                                          \
+  }
+
+#define DEFINE_SIMD_EXCLUSIVE_SCAN()                                     \
+  template <typename U, metal::enable_if_t<sizeof(U) < 8, bool> = true>  \
+  U simd_exclusive_scan(U val) {                                         \
+    return simd_exclusive_scan_impl(val);                                \
+  }                                                                      \
+                                                                         \
+  template <typename U, metal::enable_if_t<sizeof(U) == 8, bool> = true> \
+  U simd_exclusive_scan(U val) {                                         \
+    val = simd_scan(val);                                                \
+    return simd_shuffle_and_fill_up(val, init, 1);                       \
+  }
+
 template <typename T, typename acc_t = accum_t<T>>
 struct CumSumOp {
-  static acc_t apply(acc_t a, acc_t b) {
+  DEFINE_SIMD_SCAN()
+  DEFINE_SIMD_EXCLUSIVE_SCAN()
+
+  static constexpr constant acc_t init = static_cast<acc_t>(0);
+
+  acc_t operator()(acc_t a, acc_t b) {
     return a + b;
   }
-  static acc_t identity() {
-    return acc_t(0);
+
+  acc_t simd_scan_impl(acc_t x) {
+    return simd_prefix_inclusive_sum(x);
+  }
+
+  acc_t simd_exclusive_scan_impl(acc_t x) {
+    return simd_prefix_exclusive_sum(x);
   }
 };
 
 template <typename T, typename acc_t = accum_t<T>>
 struct CumProdOp {
-  static acc_t apply(acc_t a, acc_t b) {
+  DEFINE_SIMD_SCAN()
+  DEFINE_SIMD_EXCLUSIVE_SCAN()
+
+  static constexpr constant acc_t init = static_cast<acc_t>(1);
+
+  acc_t operator()(acc_t a, acc_t b) {
     return a * b;
   }
-  static acc_t identity() {
-    return acc_t(1);
+
+  acc_t simd_scan_impl(acc_t x) {
+    return simd_prefix_inclusive_product(x);
+  }
+
+  acc_t simd_exclusive_scan_impl(acc_t x) {
+    return simd_prefix_exclusive_product(x);
   }
 };
 
@@ -50,52 +131,245 @@ struct CumMaxOp {
   }
 };
 
+template <typename T, int N_READS, typename acc_t = accum_t<T>>
+inline void load_unsafe(acc_t values[N_READS], const device T* input) {
+  for (int i = 0; i < N_READS; i++) {
+    values[i] = static_cast<acc_t>(input[i]);
+  }
+}
+
+template <typename T, int N_READS, typename acc_t = accum_t<T>>
+inline void load_safe(
+    acc_t values[N_READS],
+    const device T* input,
+    int start,
+    int total,
+    acc_t init) {
+  for (int i = 0; i < N_READS; i++) {
+    values[i] = (start + i < total) ? static_cast<acc_t>(input[i]) : init;
+  }
+}
+
+template <typename T, int N_READS, typename acc_t = accum_t<T>>
+inline void write_unsafe(acc_t values[N_READS], device T* out) {
+  for (int i = 0; i < N_READS; i++) {
+    out[i] = static_cast<T>(values[i]);
+  }
+}
+
+template <typename T, int N_READS, typename acc_t = accum_t<T>>
+inline void write_safe(
+    acc_t values[N_READS],
+    device T* out,
+    int start,
+    int total) {
+  for (int i = 0; i < N_READS; i++) {
+    if (start + i < total) {
+      out[i] = static_cast<T>(values[i]);
+    }
+  }
+}
+
+// Utility function for ceiling division
+template <typename T, typename U>
+inline T ceildiv(T N, U M) {
+  return (N + M - 1) / M;
+}
+
 // Inclusive scan along innermost dimension for contiguous tensors
-template <typename T, typename Op, typename acc_t = accum_t<T>>
-kernel void scan_contiguous_innermost_dim(
-    constant T* input [[buffer(0)]],
-    device T* output [[buffer(1)]],
-    constant uint& num_rows [[buffer(2)]],
-    constant uint& row_size [[buffer(3)]],
-    uint row [[thread_position_in_grid]]) {
-  if (row >= num_rows)
-    return;
+template <typename T, typename Op, int N_READS, typename acc_t = accum_t<T>>
+kernel void scan_innermost_dim(
+    const device T* in [[buffer(0)]],
+    device T* out [[buffer(1)]],
+    const constant size_t& axis_size [[buffer(2)]],
+    uint3 gid [[threadgroup_position_in_grid]],
+    uint3 gsize [[threadgroups_per_grid]],
+    uint3 lid [[thread_position_in_threadgroup]],
+    uint3 lsize [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr int simd_size = 32;
+  Op op;
 
-  const uint offset = row * row_size;
+  // Position the pointers
+  size_t offset = (gid.y + gsize.y * size_t(gid.z)) * axis_size;
+  in += offset;
+  out += offset;
 
-  acc_t accumulator = Op::identity();
+  // Compute the number of simd_groups
+  uint simd_groups = lsize.x / simd_size;
 
-  for (uint col = 0; col < row_size; col++) {
-    T val = input[offset + col];
-    acc_t accum_val = static_cast<acc_t>(val);
-    accumulator = Op::apply(accumulator, accum_val);
-    output[offset + col] = static_cast<T>(accumulator);
+  // Allocate memory
+  acc_t prefix = Op::init;
+  acc_t values[N_READS];
+  threadgroup acc_t simdgroup_sums[32];
+
+  // Loop over the reduced axis in blocks of size ceildiv(axis_size,
+  // N_READS*lsize)
+  //    Read block
+  //    Compute inclusive scan of the block
+  //      Compute inclusive scan per thread
+  //      Compute exclusive scan of thread sums in simdgroup
+  //      Write simdgroup sums in SM
+  //      Compute exclusive scan of simdgroup sums
+  //      Compute the output by scanning prefix, prev_simdgroup, prev_thread,
+  //      value
+  //    Write block
+
+  for (uint r = 0; r < ceildiv(axis_size, N_READS * lsize.x); r++) {
+    // Compute the block offset
+    uint offset = r * lsize.x * N_READS + lid.x * N_READS;
+
+    // Read the values
+    if ((offset + N_READS) < axis_size) {
+      load_unsafe<T, N_READS>(values, in + offset);
+    } else {
+      load_safe<T, N_READS>(values, in + offset, offset, axis_size, Op::init);
+    }
+
+    // Compute an inclusive scan per thread
+    for (int i = 1; i < N_READS; i++) {
+      values[i] = op(values[i], values[i - 1]);
+    }
+
+    // Compute exclusive scan of thread sums
+    acc_t prev_thread = op.simd_exclusive_scan(values[N_READS - 1]);
+
+    // Write simdgroup_sums to SM
+    if (simd_lane_id == simd_size - 1) {
+      simdgroup_sums[simd_group_id] = op(prev_thread, values[N_READS - 1]);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Compute exclusive scan of simdgroup_sums
+    if (simd_group_id == 0) {
+      acc_t prev_simdgroup =
+          op.simd_exclusive_scan(simdgroup_sums[simd_lane_id]);
+      simdgroup_sums[simd_lane_id] = prev_simdgroup;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Compute the output
+    for (int i = 0; i < N_READS; i++) {
+      values[i] = op(values[i], prefix);
+      values[i] = op(values[i], simdgroup_sums[simd_group_id]);
+      values[i] = op(values[i], prev_thread);
+    }
+
+    // Write the values
+    if ((offset + N_READS) < axis_size) {
+      write_unsafe<T, N_READS>(values, out + offset);
+    } else {
+      write_safe<T, N_READS>(values, out + offset, offset, axis_size);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Share the prefix
+    if (simd_group_id == simd_groups - 1 && simd_lane_id == simd_size - 1) {
+      simdgroup_sums[0] = values[N_READS - 1];
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    prefix = simdgroup_sums[0];
   }
 }
 
 // Inclusive scan along outer dimension for contiguous tensors
-template <typename T, typename Op, typename acc_t = accum_t<T>>
-kernel void scan_contiguous_outer_dim(
-    constant T* input [[buffer(0)]],
-    device T* output [[buffer(1)]],
-    constant uint& num_orows [[buffer(2)]],
-    constant uint& num_irows [[buffer(3)]],
-    constant uint& row_size [[buffer(4)]],
-    uint thread_index [[thread_position_in_grid]]) {
-  const uint orow = thread_index / num_irows;
-  const uint irow = thread_index % num_irows;
+template <typename T, typename Op, int N_READS, typename acc_t = accum_t<T>>
+kernel void scan_outer_dim(
+    const device T* in [[buffer(0)]],
+    device T* out [[buffer(1)]],
+    const constant size_t& axis_size [[buffer(2)]],
+    const constant size_t& stride [[buffer(3)]],
+    const constant size_t& stride_blocks [[buffer(4)]],
+    uint3 gid [[threadgroup_position_in_grid]],
+    uint3 gsize [[threadgroups_per_grid]],
+    uint3 lid [[thread_position_in_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr int simd_size = 32;
+  constexpr int BM = 32;
+  constexpr int BN = 32;
+  constexpr int BN_pad = 32 + 16 / sizeof(T);
+  constexpr int n_simds = BN / N_READS;
+  constexpr int n_scans = BN / n_simds;
+  Op op;
 
-  if (orow >= num_orows)
-    return;
+  threadgroup acc_t read_buffer[BM * BN_pad];
+  acc_t values[n_scans];
+  acc_t prefix[n_scans];
+  for (int i = 0; i < n_scans; i++) {
+    prefix[i] = Op::init;
+  }
 
-  acc_t accumulator = Op::identity();
+  // Compute offsets
+  size_t full_gid = gid.y + gsize.y * size_t(gid.z);
+  size_t offset = full_gid / stride_blocks * axis_size * stride;
+  size_t global_index_x = full_gid % stride_blocks * BN;
+  uint read_offset_y = (lid.x * N_READS) / BN;
+  uint read_offset_x = (lid.x * N_READS) % BN;
+  uint scan_offset_y = simd_lane_id;
+  uint scan_offset_x = simd_group_id * n_scans;
 
-  const uint idx_base = orow * row_size * num_irows + irow;
-  for (uint col = 0, idx = idx_base; col < row_size; col++, idx += num_irows) {
-    T val = input[idx];
-    acc_t accum_val = static_cast<acc_t>(val);
-    accumulator = Op::apply(accumulator, accum_val);
-    output[idx] = static_cast<T>(accumulator);
+  uint stride_limit = stride - global_index_x;
+  in += offset + global_index_x + read_offset_x;
+  out += offset + global_index_x + read_offset_x;
+  threadgroup acc_t* read_into =
+      read_buffer + read_offset_y * BN_pad + read_offset_x;
+  threadgroup acc_t* read_from =
+      read_buffer + scan_offset_y * BN_pad + scan_offset_x;
+
+  for (uint j = 0; j < axis_size; j += BM) {
+    // Calculate the indices for the current thread
+    uint index_y = j + read_offset_y;
+    uint check_index_y = index_y;
+
+    // Read into shared memory with type conversion
+    if (check_index_y < axis_size && (read_offset_x + N_READS) < stride_limit) {
+      for (int i = 0; i < N_READS; i++) {
+        read_into[i] = static_cast<acc_t>(in[index_y * stride + i]);
+      }
+    } else {
+      for (int i = 0; i < N_READS; i++) {
+        if (check_index_y < axis_size && (read_offset_x + i) < stride_limit) {
+          read_into[i] = static_cast<acc_t>(in[index_y * stride + i]);
+        } else {
+          read_into[i] = Op::init;
+        }
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Read strided into registers
+    for (int i = 0; i < n_scans; i++) {
+      values[i] = read_from[i];
+    }
+    simdgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Perform the scan
+    for (int i = 0; i < n_scans; i++) {
+      values[i] = op.simd_scan(values[i]);
+      values[i] = op(values[i], prefix[i]);
+      prefix[i] = simd_shuffle(values[i], simd_size - 1);
+    }
+
+    // Write to shared memory
+    for (int i = 0; i < n_scans; i++) {
+      read_from[i] = values[i];
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Write to device memory with type conversion
+    if (check_index_y < axis_size && (read_offset_x + N_READS) < stride_limit) {
+      for (int i = 0; i < N_READS; i++) {
+        out[index_y * stride + i] = static_cast<T>(read_into[i]);
+      }
+    } else {
+      for (int i = 0; i < N_READS; i++) {
+        if (check_index_y < axis_size && (read_offset_x + i) < stride_limit) {
+          out[index_y * stride + i] = static_cast<T>(read_into[i]);
+        }
+      }
+    }
   }
 }
 
@@ -205,48 +479,6 @@ inline long calculate_base_offset(
   return offset;
 }
 
-// Generic strided scan kernel
-template <typename T, typename Op, typename acc_t = accum_t<T>>
-kernel void scan_strided(
-    constant T* input [[buffer(0)]],
-    device T* output [[buffer(1)]],
-    constant long* sizes [[buffer(2)]],
-    constant long* input_strides [[buffer(3)]],
-    constant long* output_strides [[buffer(4)]],
-    constant uint& ndim [[buffer(5)]],
-    constant uint& scan_dim [[buffer(6)]],
-    uint thread_index [[thread_position_in_grid]]) {
-  const long total_non_scan_elements =
-      calculate_non_scan_elements(sizes, ndim, scan_dim);
-  if (thread_index >= total_non_scan_elements) {
-    return;
-  }
-
-  int pos[c10::metal::max_ndim];
-  thread_index_to_coordinates(thread_index, pos, sizes, ndim, scan_dim);
-
-  const long input_base_offset =
-      calculate_base_offset(pos, input_strides, ndim, scan_dim);
-  const long output_base_offset =
-      calculate_base_offset(pos, output_strides, ndim, scan_dim);
-
-  acc_t accumulator = Op::identity();
-  const long scan_size = sizes[scan_dim];
-  const long input_scan_stride = input_strides[scan_dim];
-  const long output_scan_stride = output_strides[scan_dim];
-
-  for (long scan_idx = 0; scan_idx < scan_size; scan_idx++) {
-    const long input_offset = input_base_offset + scan_idx * input_scan_stride;
-    const long output_offset =
-        output_base_offset + scan_idx * output_scan_stride;
-
-    T val = input[input_offset];
-    acc_t accum_val = static_cast<acc_t>(val);
-    accumulator = Op::apply(accumulator, accum_val);
-    output[output_offset] = static_cast<T>(accumulator);
-  }
-}
-
 // Generic strided scan with indices kernel
 template <typename T, typename Op, typename acc_t = accum_t<T>>
 kernel void scan_with_indices_strided(
@@ -301,34 +533,31 @@ kernel void scan_with_indices_strided(
   }
 }
 
-#define REGISTER_SCAN_OP(OP_NAME, OP_CLASS, DTYPE)                             \
-  template [[host_name(#OP_NAME "_contiguous_innermost_" #DTYPE)]] kernel void \
-  scan_contiguous_innermost_dim<DTYPE, OP_CLASS<DTYPE>>(                       \
-      constant DTYPE * input [[buffer(0)]],                                    \
-      device DTYPE * output [[buffer(1)]],                                     \
-      constant uint & num_rows [[buffer(2)]],                                  \
-      constant uint & row_size [[buffer(3)]],                                  \
-      uint row [[thread_position_in_grid]]);                                   \
-                                                                               \
-  template [[host_name(#OP_NAME "_contiguous_outer_" #DTYPE)]] kernel void     \
-  scan_contiguous_outer_dim<DTYPE, OP_CLASS<DTYPE>>(                           \
-      constant DTYPE * input [[buffer(0)]],                                    \
-      device DTYPE * output [[buffer(1)]],                                     \
-      constant uint & num_orows [[buffer(2)]],                                 \
-      constant uint & num_irows [[buffer(3)]],                                 \
-      constant uint & row_size [[buffer(4)]],                                  \
-      uint thread_index [[thread_position_in_grid]]);                          \
-                                                                               \
-  template [[host_name(#OP_NAME "_strided_" #DTYPE)]] kernel void              \
-  scan_strided<DTYPE, OP_CLASS<DTYPE>>(                                        \
-      constant DTYPE * input [[buffer(0)]],                                    \
-      device DTYPE * output [[buffer(1)]],                                     \
-      constant long* sizes [[buffer(2)]],                                      \
-      constant long* input_strides [[buffer(3)]],                              \
-      constant long* output_strides [[buffer(4)]],                             \
-      constant uint& ndim [[buffer(5)]],                                       \
-      constant uint& scan_dim [[buffer(6)]],                                   \
-      uint thread_index [[thread_position_in_grid]]);
+#define REGISTER_SCAN_OP(OP_NAME, OP_CLASS, DTYPE, NREADS)              \
+  template [[host_name(#OP_NAME "_innermost_" #DTYPE)]] [[kernel]] void \
+  scan_innermost_dim<DTYPE, OP_CLASS<DTYPE>, NREADS>(                   \
+      const device DTYPE* in [[buffer(0)]],                             \
+      device DTYPE* out [[buffer(1)]],                                  \
+      const constant size_t& axis_size [[buffer(2)]],                   \
+      uint3 gid [[threadgroup_position_in_grid]],                       \
+      uint3 gsize [[threadgroups_per_grid]],                            \
+      uint3 lid [[thread_position_in_threadgroup]],                     \
+      uint3 lsize [[threads_per_threadgroup]],                          \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                  \
+      uint simd_group_id [[simdgroup_index_in_threadgroup]]);           \
+                                                                        \
+  template [[host_name(#OP_NAME "_outer_" #DTYPE)]] [[kernel]] void     \
+  scan_outer_dim<DTYPE, OP_CLASS<DTYPE>, NREADS>(                       \
+      const device DTYPE* in [[buffer(0)]],                             \
+      device DTYPE* out [[buffer(1)]],                                  \
+      const constant size_t& axis_size [[buffer(2)]],                   \
+      const constant size_t& stride [[buffer(3)]],                      \
+      const constant size_t& stride_blocks [[buffer(4)]],               \
+      uint3 gid [[threadgroup_position_in_grid]],                       \
+      uint3 gsize [[threadgroups_per_grid]],                            \
+      uint3 lid [[thread_position_in_threadgroup]],                     \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                  \
+      uint simd_group_id [[simdgroup_index_in_threadgroup]])
 
 #define REGISTER_SCAN_WITH_INDICES_OP(OP_NAME, OP_CLASS, DTYPE)                \
   template [[host_name(#OP_NAME "_contiguous_innermost_" #DTYPE)]] kernel void \
@@ -364,21 +593,21 @@ kernel void scan_with_indices_strided(
       uint thread_index [[thread_position_in_grid]]);
 
 // Simple scan operations
-REGISTER_SCAN_OP(cumsum, CumSumOp, float);
-REGISTER_SCAN_OP(cumsum, CumSumOp, half);
-REGISTER_SCAN_OP(cumsum, CumSumOp, long);
-REGISTER_SCAN_OP(cumsum, CumSumOp, int);
-REGISTER_SCAN_OP(cumsum, CumSumOp, short);
-REGISTER_SCAN_OP(cumsum, CumSumOp, char);
-REGISTER_SCAN_OP(cumsum, CumSumOp, uchar);
+REGISTER_SCAN_OP(cumsum, CumSumOp, float, 4);
+REGISTER_SCAN_OP(cumsum, CumSumOp, half, 4);
+REGISTER_SCAN_OP(cumsum, CumSumOp, long, 2);
+REGISTER_SCAN_OP(cumsum, CumSumOp, int, 4);
+REGISTER_SCAN_OP(cumsum, CumSumOp, short, 4);
+REGISTER_SCAN_OP(cumsum, CumSumOp, char, 4);
+REGISTER_SCAN_OP(cumsum, CumSumOp, uchar, 4);
 
-REGISTER_SCAN_OP(cumprod, CumProdOp, float);
-REGISTER_SCAN_OP(cumprod, CumProdOp, half);
-REGISTER_SCAN_OP(cumprod, CumProdOp, long);
-REGISTER_SCAN_OP(cumprod, CumProdOp, int);
-REGISTER_SCAN_OP(cumprod, CumProdOp, short);
-REGISTER_SCAN_OP(cumprod, CumProdOp, char);
-REGISTER_SCAN_OP(cumprod, CumProdOp, uchar);
+REGISTER_SCAN_OP(cumprod, CumProdOp, float, 4);
+REGISTER_SCAN_OP(cumprod, CumProdOp, half, 4);
+REGISTER_SCAN_OP(cumprod, CumProdOp, long, 2);
+REGISTER_SCAN_OP(cumprod, CumProdOp, int, 4);
+REGISTER_SCAN_OP(cumprod, CumProdOp, short, 4);
+REGISTER_SCAN_OP(cumprod, CumProdOp, char, 4);
+REGISTER_SCAN_OP(cumprod, CumProdOp, uchar, 4);
 
 // Scan operations with indices
 REGISTER_SCAN_WITH_INDICES_OP(cummin, CumMinOp, float);
@@ -400,8 +629,8 @@ REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, uchar);
 REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, bool);
 
 #if __METAL_VERSION__ >= 310
-REGISTER_SCAN_OP(cumsum, CumSumOp, bfloat);
-REGISTER_SCAN_OP(cumprod, CumProdOp, bfloat);
+REGISTER_SCAN_OP(cumsum, CumSumOp, bfloat, 4);
+REGISTER_SCAN_OP(cumprod, CumProdOp, bfloat, 4);
 REGISTER_SCAN_WITH_INDICES_OP(cummin, CumMinOp, bfloat);
 REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, bfloat);
 #endif

--- a/aten/src/ATen/native/mps/kernels/ScanKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ScanKernel.metal
@@ -7,7 +7,418 @@ using namespace metal;
 
 using c10::metal::accum_t;
 
-// This file contains cumsum and cumprod implementations adapted from MLX:
+#if __METAL_VERSION__ < 310
+template <typename T, typename acc_t = accum_t<T>>
+struct CumSumOp {
+  static acc_t apply(acc_t a, acc_t b) {
+    return a + b;
+  }
+  static acc_t identity() {
+    return acc_t(0);
+  }
+};
+
+template <typename T, typename acc_t = accum_t<T>>
+struct CumProdOp {
+  static acc_t apply(acc_t a, acc_t b) {
+    return a * b;
+  }
+  static acc_t identity() {
+    return acc_t(1);
+  }
+};
+#endif // __METAL_VERSION__ < 310
+
+template <typename T, typename acc_t = accum_t<T>>
+struct CumMinOp {
+  static acc_t apply(acc_t a, acc_t b) {
+    return metal::min(a, b);
+  }
+  static acc_t identity() {
+    return static_cast<acc_t>(
+        metal::is_floating_point_v<T> ? metal::numeric_limits<T>::infinity()
+                                      : metal::numeric_limits<T>::max());
+  }
+};
+
+template <typename T, typename acc_t = accum_t<T>>
+struct CumMaxOp {
+  static acc_t apply(acc_t a, acc_t b) {
+    return metal::max(a, b);
+  }
+  static acc_t identity() {
+    return static_cast<acc_t>(
+        metal::is_floating_point_v<T> ? -metal::numeric_limits<T>::infinity()
+                                      : metal::numeric_limits<T>::lowest());
+  }
+};
+
+#if __METAL_VERSION__ < 310
+// Inclusive scan along innermost dimension for contiguous tensors
+template <typename T, typename Op, typename acc_t = accum_t<T>>
+kernel void scan_contiguous_innermost_dim(
+    constant T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    constant uint& num_rows [[buffer(2)]],
+    constant uint& row_size [[buffer(3)]],
+    uint row [[thread_position_in_grid]]) {
+  if (row >= num_rows)
+    return;
+
+  const uint offset = row * row_size;
+
+  acc_t accumulator = Op::identity();
+
+  for (uint col = 0; col < row_size; col++) {
+    T val = input[offset + col];
+    acc_t accum_val = static_cast<acc_t>(val);
+    accumulator = Op::apply(accumulator, accum_val);
+    output[offset + col] = static_cast<T>(accumulator);
+  }
+}
+
+// Inclusive scan along outer dimension for contiguous tensors
+template <typename T, typename Op, typename acc_t = accum_t<T>>
+kernel void scan_contiguous_outer_dim(
+    constant T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    constant uint& num_orows [[buffer(2)]],
+    constant uint& num_irows [[buffer(3)]],
+    constant uint& row_size [[buffer(4)]],
+    uint thread_index [[thread_position_in_grid]]) {
+  const uint orow = thread_index / num_irows;
+  const uint irow = thread_index % num_irows;
+
+  if (orow >= num_orows)
+    return;
+
+  acc_t accumulator = Op::identity();
+
+  const uint idx_base = orow * row_size * num_irows + irow;
+  for (uint col = 0, idx = idx_base; col < row_size; col++, idx += num_irows) {
+    T val = input[idx];
+    acc_t accum_val = static_cast<acc_t>(val);
+    accumulator = Op::apply(accumulator, accum_val);
+    output[idx] = static_cast<T>(accumulator);
+  }
+}
+#endif // __METAL_VERSION__ < 310
+
+// Inclusive scan with indices along innermost dimension for contiguous tensors
+template <typename T, typename Op, typename acc_t = accum_t<T>>
+kernel void scan_with_indices_contiguous_innermost_dim(
+    constant T* input [[buffer(0)]],
+    device T* values [[buffer(1)]],
+    device int64_t* indices [[buffer(2)]],
+    constant uint& num_rows [[buffer(3)]],
+    constant uint& row_size [[buffer(4)]],
+    uint row [[thread_position_in_grid]]) {
+  if (row >= num_rows)
+    return;
+
+  const uint offset = row * row_size;
+
+  acc_t accumulator = Op::identity();
+  int64_t best_idx = 0;
+
+  for (uint col = 0; col < row_size; col++) {
+    T val = input[offset + col];
+    acc_t accum_val = static_cast<acc_t>(val);
+    if (col == 0 || Op::apply(accum_val, accumulator) == accum_val) {
+      accumulator = accum_val;
+      best_idx = col;
+    }
+    values[offset + col] = static_cast<T>(accumulator);
+    indices[offset + col] = best_idx;
+  }
+}
+
+// Inclusive scan with indices along outer dimension for contiguous tensors
+template <typename T, typename Op, typename acc_t = accum_t<T>>
+kernel void scan_with_indices_contiguous_outer_dim(
+    constant T* input [[buffer(0)]],
+    device T* values [[buffer(1)]],
+    device int64_t* indices [[buffer(2)]],
+    constant uint& num_orows [[buffer(3)]],
+    constant uint& num_irows [[buffer(4)]],
+    constant uint& row_size [[buffer(5)]],
+    uint thread_index [[thread_position_in_grid]]) {
+  const uint orow = thread_index / num_irows;
+  const uint irow = thread_index % num_irows;
+
+  if (orow >= num_orows)
+    return;
+
+  acc_t accumulator = Op::identity();
+  int64_t best_idx = 0;
+
+  const uint idx_base = orow * row_size * num_irows + irow;
+  for (uint col = 0, idx = idx_base; col < row_size; col++, idx += num_irows) {
+    T val = input[idx];
+    acc_t accum_val = static_cast<acc_t>(val);
+    if (col == 0 || Op::apply(accum_val, accumulator) == accum_val) {
+      accumulator = accum_val;
+      best_idx = col;
+    }
+    values[idx] = static_cast<T>(accumulator);
+    indices[idx] = best_idx;
+  }
+}
+
+// Shared utility functions for strided kernels
+inline long calculate_non_scan_elements(
+    constant long* sizes,
+    uint ndim,
+    uint scan_dim) {
+  long total = 1;
+  for (uint i = 0; i < ndim; ++i) {
+    if (i != scan_dim) {
+      total *= sizes[i];
+    }
+  }
+  return total;
+}
+
+inline void thread_index_to_coordinates(
+    uint index,
+    int pos[c10::metal::max_ndim],
+    constant long* sizes,
+    uint ndim,
+    uint scan_dim) {
+  long remaining_index = index;
+  for (uint i = 0; i < ndim; ++i) {
+    if (i != scan_dim) {
+      pos[i] = remaining_index % sizes[i];
+      remaining_index /= sizes[i];
+    } else {
+      pos[i] = 0;
+    }
+  }
+}
+
+inline long calculate_base_offset(
+    int pos[c10::metal::max_ndim],
+    constant long* strides,
+    uint ndim,
+    uint scan_dim) {
+  long offset = 0;
+  for (uint i = 0; i < ndim; ++i) {
+    if (i != scan_dim) {
+      offset += pos[i] * strides[i];
+    }
+  }
+  return offset;
+}
+
+#if __METAL_VERSION__ < 310
+// Generic strided scan kernel
+template <typename T, typename Op, typename acc_t = accum_t<T>>
+kernel void scan_strided(
+    constant T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    constant long* sizes [[buffer(2)]],
+    constant long* input_strides [[buffer(3)]],
+    constant long* output_strides [[buffer(4)]],
+    constant uint& ndim [[buffer(5)]],
+    constant uint& scan_dim [[buffer(6)]],
+    uint thread_index [[thread_position_in_grid]]) {
+  const long total_non_scan_elements =
+      calculate_non_scan_elements(sizes, ndim, scan_dim);
+  if (thread_index >= total_non_scan_elements) {
+    return;
+  }
+
+  int pos[c10::metal::max_ndim];
+  thread_index_to_coordinates(thread_index, pos, sizes, ndim, scan_dim);
+
+  const long input_base_offset =
+      calculate_base_offset(pos, input_strides, ndim, scan_dim);
+  const long output_base_offset =
+      calculate_base_offset(pos, output_strides, ndim, scan_dim);
+
+  acc_t accumulator = Op::identity();
+  const long scan_size = sizes[scan_dim];
+  const long input_scan_stride = input_strides[scan_dim];
+  const long output_scan_stride = output_strides[scan_dim];
+
+  for (long scan_idx = 0; scan_idx < scan_size; scan_idx++) {
+    const long input_offset = input_base_offset + scan_idx * input_scan_stride;
+    const long output_offset =
+        output_base_offset + scan_idx * output_scan_stride;
+
+    T val = input[input_offset];
+    acc_t accum_val = static_cast<acc_t>(val);
+    accumulator = Op::apply(accumulator, accum_val);
+    output[output_offset] = static_cast<T>(accumulator);
+  }
+}
+#endif // __METAL_VERSION__ < 310
+
+// Generic strided scan with indices kernel
+template <typename T, typename Op, typename acc_t = accum_t<T>>
+kernel void scan_with_indices_strided(
+    constant T* input [[buffer(0)]],
+    device T* values [[buffer(1)]],
+    device int64_t* indices [[buffer(2)]],
+    constant long* sizes [[buffer(3)]],
+    constant long* input_strides [[buffer(4)]],
+    constant long* values_strides [[buffer(5)]],
+    constant long* indices_strides [[buffer(6)]],
+    constant uint& ndim [[buffer(7)]],
+    constant uint& scan_dim [[buffer(8)]],
+    uint thread_index [[thread_position_in_grid]]) {
+  const long total_non_scan_elements =
+      calculate_non_scan_elements(sizes, ndim, scan_dim);
+  if (thread_index >= total_non_scan_elements) {
+    return;
+  }
+
+  int pos[c10::metal::max_ndim];
+  thread_index_to_coordinates(thread_index, pos, sizes, ndim, scan_dim);
+
+  const long input_base_offset =
+      calculate_base_offset(pos, input_strides, ndim, scan_dim);
+  const long values_base_offset =
+      calculate_base_offset(pos, values_strides, ndim, scan_dim);
+  const long indices_base_offset =
+      calculate_base_offset(pos, indices_strides, ndim, scan_dim);
+
+  acc_t accumulator = Op::identity();
+  int64_t best_idx = 0;
+  const long scan_size = sizes[scan_dim];
+  const long input_scan_stride = input_strides[scan_dim];
+  const long values_scan_stride = values_strides[scan_dim];
+  const long indices_scan_stride = indices_strides[scan_dim];
+
+  for (long scan_idx = 0; scan_idx < scan_size; scan_idx++) {
+    const long input_offset = input_base_offset + scan_idx * input_scan_stride;
+    const long values_offset =
+        values_base_offset + scan_idx * values_scan_stride;
+    const long indices_offset =
+        indices_base_offset + scan_idx * indices_scan_stride;
+
+    T val = input[input_offset];
+    acc_t accum_val = static_cast<acc_t>(val);
+    if (scan_idx == 0 || Op::apply(accum_val, accumulator) == accum_val) {
+      accumulator = accum_val;
+      best_idx = scan_idx;
+    }
+    values[values_offset] = static_cast<T>(accumulator);
+    indices[indices_offset] = best_idx;
+  }
+}
+
+#if __METAL_VERSION__ < 310
+#define REGISTER_SCAN_OP(OP_NAME, OP_CLASS, DTYPE)                             \
+  template [[host_name(#OP_NAME "_contiguous_innermost_" #DTYPE)]] kernel void \
+  scan_contiguous_innermost_dim<DTYPE, OP_CLASS<DTYPE>>(                       \
+      constant DTYPE * input [[buffer(0)]],                                    \
+      device DTYPE * output [[buffer(1)]],                                     \
+      constant uint & num_rows [[buffer(2)]],                                  \
+      constant uint & row_size [[buffer(3)]],                                  \
+      uint row [[thread_position_in_grid]]);                                   \
+                                                                               \
+  template [[host_name(#OP_NAME "_contiguous_outer_" #DTYPE)]] kernel void     \
+  scan_contiguous_outer_dim<DTYPE, OP_CLASS<DTYPE>>(                           \
+      constant DTYPE * input [[buffer(0)]],                                    \
+      device DTYPE * output [[buffer(1)]],                                     \
+      constant uint & num_orows [[buffer(2)]],                                 \
+      constant uint & num_irows [[buffer(3)]],                                 \
+      constant uint & row_size [[buffer(4)]],                                  \
+      uint thread_index [[thread_position_in_grid]]);                          \
+                                                                               \
+  template [[host_name(#OP_NAME "_strided_" #DTYPE)]] kernel void              \
+  scan_strided<DTYPE, OP_CLASS<DTYPE>>(                                        \
+      constant DTYPE * input [[buffer(0)]],                                    \
+      device DTYPE * output [[buffer(1)]],                                     \
+      constant long* sizes [[buffer(2)]],                                      \
+      constant long* input_strides [[buffer(3)]],                              \
+      constant long* output_strides [[buffer(4)]],                             \
+      constant uint& ndim [[buffer(5)]],                                       \
+      constant uint& scan_dim [[buffer(6)]],                                   \
+      uint thread_index [[thread_position_in_grid]]);
+#endif // __METAL_VERSION__ < 310
+
+#define REGISTER_SCAN_WITH_INDICES_OP(OP_NAME, OP_CLASS, DTYPE)                \
+  template [[host_name(#OP_NAME "_contiguous_innermost_" #DTYPE)]] kernel void \
+  scan_with_indices_contiguous_innermost_dim<DTYPE, OP_CLASS<DTYPE>>(          \
+      constant DTYPE * input [[buffer(0)]],                                    \
+      device DTYPE * values [[buffer(1)]],                                     \
+      device int64_t* indices [[buffer(2)]],                                   \
+      constant uint& num_rows [[buffer(3)]],                                   \
+      constant uint& row_size [[buffer(4)]],                                   \
+      uint row [[thread_position_in_grid]]);                                   \
+                                                                               \
+  template [[host_name(#OP_NAME "_contiguous_outer_" #DTYPE)]] kernel void     \
+  scan_with_indices_contiguous_outer_dim<DTYPE, OP_CLASS<DTYPE>>(              \
+      constant DTYPE * input [[buffer(0)]],                                    \
+      device DTYPE * values [[buffer(1)]],                                     \
+      device int64_t* indices [[buffer(2)]],                                   \
+      constant uint& num_orows [[buffer(3)]],                                  \
+      constant uint& num_irows [[buffer(4)]],                                  \
+      constant uint& row_size [[buffer(5)]],                                   \
+      uint thread_index [[thread_position_in_grid]]);                          \
+                                                                               \
+  template [[host_name(#OP_NAME "_strided_" #DTYPE)]] kernel void              \
+  scan_with_indices_strided<DTYPE, OP_CLASS<DTYPE>>(                           \
+      constant DTYPE * input [[buffer(0)]],                                    \
+      device DTYPE * values [[buffer(1)]],                                     \
+      device int64_t* indices [[buffer(2)]],                                   \
+      constant long* sizes [[buffer(3)]],                                      \
+      constant long* input_strides [[buffer(4)]],                              \
+      constant long* values_strides [[buffer(5)]],                             \
+      constant long* indices_strides [[buffer(6)]],                            \
+      constant uint& ndim [[buffer(7)]],                                       \
+      constant uint& scan_dim [[buffer(8)]],                                   \
+      uint thread_index [[thread_position_in_grid]]);
+
+#if __METAL_VERSION__ < 310
+// Simple scan operations
+REGISTER_SCAN_OP(cumsum, CumSumOp, float);
+REGISTER_SCAN_OP(cumsum, CumSumOp, half);
+REGISTER_SCAN_OP(cumsum, CumSumOp, long);
+REGISTER_SCAN_OP(cumsum, CumSumOp, int);
+REGISTER_SCAN_OP(cumsum, CumSumOp, short);
+REGISTER_SCAN_OP(cumsum, CumSumOp, char);
+REGISTER_SCAN_OP(cumsum, CumSumOp, uchar);
+
+REGISTER_SCAN_OP(cumprod, CumProdOp, float);
+REGISTER_SCAN_OP(cumprod, CumProdOp, half);
+REGISTER_SCAN_OP(cumprod, CumProdOp, long);
+REGISTER_SCAN_OP(cumprod, CumProdOp, int);
+REGISTER_SCAN_OP(cumprod, CumProdOp, short);
+REGISTER_SCAN_OP(cumprod, CumProdOp, char);
+REGISTER_SCAN_OP(cumprod, CumProdOp, uchar);
+#endif // __METAL_VERSION__ < 310
+
+// Scan operations with indices
+REGISTER_SCAN_WITH_INDICES_OP(cummin, CumMinOp, float);
+REGISTER_SCAN_WITH_INDICES_OP(cummin, CumMinOp, half);
+REGISTER_SCAN_WITH_INDICES_OP(cummin, CumMinOp, long);
+REGISTER_SCAN_WITH_INDICES_OP(cummin, CumMinOp, int);
+REGISTER_SCAN_WITH_INDICES_OP(cummin, CumMinOp, short);
+REGISTER_SCAN_WITH_INDICES_OP(cummin, CumMinOp, char);
+REGISTER_SCAN_WITH_INDICES_OP(cummin, CumMinOp, uchar);
+REGISTER_SCAN_WITH_INDICES_OP(cummin, CumMinOp, bool);
+
+REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, float);
+REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, half);
+REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, long);
+REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, int);
+REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, short);
+REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, char);
+REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, uchar);
+REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, bool);
+
+#if __METAL_VERSION__ >= 310
+REGISTER_SCAN_WITH_INDICES_OP(cummin, CumMinOp, bfloat);
+REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, bfloat);
+#endif // __METAL_VERSION__ >= 310
+
+#if __METAL_VERSION__ >= 310
+
+// The reminder of this file contains cumsum and cumprod implementations adapted
+// from MLX:
 // https://github.com/ml-explore/mlx/blob/main/mlx/backend/metal/kernels/scan.h
 //
 // The original MLX kernels have been modified to integrate with PyTorch's MPS
@@ -104,30 +515,6 @@ struct CumProdOp {
 
   acc_t simd_exclusive_scan_impl(acc_t x) {
     return simd_prefix_exclusive_product(x);
-  }
-};
-
-template <typename T, typename acc_t = accum_t<T>>
-struct CumMinOp {
-  static acc_t apply(acc_t a, acc_t b) {
-    return metal::min(a, b);
-  }
-  static acc_t identity() {
-    return static_cast<acc_t>(
-        metal::is_floating_point_v<T> ? metal::numeric_limits<T>::infinity()
-                                      : metal::numeric_limits<T>::max());
-  }
-};
-
-template <typename T, typename acc_t = accum_t<T>>
-struct CumMaxOp {
-  static acc_t apply(acc_t a, acc_t b) {
-    return metal::max(a, b);
-  }
-  static acc_t identity() {
-    return static_cast<acc_t>(
-        metal::is_floating_point_v<T> ? -metal::numeric_limits<T>::infinity()
-                                      : metal::numeric_limits<T>::lowest());
   }
 };
 
@@ -373,166 +760,6 @@ kernel void scan_outer_dim(
   }
 }
 
-// Inclusive scan with indices along innermost dimension for contiguous tensors
-template <typename T, typename Op, typename acc_t = accum_t<T>>
-kernel void scan_with_indices_contiguous_innermost_dim(
-    constant T* input [[buffer(0)]],
-    device T* values [[buffer(1)]],
-    device int64_t* indices [[buffer(2)]],
-    constant uint& num_rows [[buffer(3)]],
-    constant uint& row_size [[buffer(4)]],
-    uint row [[thread_position_in_grid]]) {
-  if (row >= num_rows)
-    return;
-
-  const uint offset = row * row_size;
-
-  acc_t accumulator = Op::identity();
-  int64_t best_idx = 0;
-
-  for (uint col = 0; col < row_size; col++) {
-    T val = input[offset + col];
-    acc_t accum_val = static_cast<acc_t>(val);
-    if (col == 0 || Op::apply(accum_val, accumulator) == accum_val) {
-      accumulator = accum_val;
-      best_idx = col;
-    }
-    values[offset + col] = static_cast<T>(accumulator);
-    indices[offset + col] = best_idx;
-  }
-}
-
-// Inclusive scan with indices along outer dimension for contiguous tensors
-template <typename T, typename Op, typename acc_t = accum_t<T>>
-kernel void scan_with_indices_contiguous_outer_dim(
-    constant T* input [[buffer(0)]],
-    device T* values [[buffer(1)]],
-    device int64_t* indices [[buffer(2)]],
-    constant uint& num_orows [[buffer(3)]],
-    constant uint& num_irows [[buffer(4)]],
-    constant uint& row_size [[buffer(5)]],
-    uint thread_index [[thread_position_in_grid]]) {
-  const uint orow = thread_index / num_irows;
-  const uint irow = thread_index % num_irows;
-
-  if (orow >= num_orows)
-    return;
-
-  acc_t accumulator = Op::identity();
-  int64_t best_idx = 0;
-
-  const uint idx_base = orow * row_size * num_irows + irow;
-  for (uint col = 0, idx = idx_base; col < row_size; col++, idx += num_irows) {
-    T val = input[idx];
-    acc_t accum_val = static_cast<acc_t>(val);
-    if (col == 0 || Op::apply(accum_val, accumulator) == accum_val) {
-      accumulator = accum_val;
-      best_idx = col;
-    }
-    values[idx] = static_cast<T>(accumulator);
-    indices[idx] = best_idx;
-  }
-}
-
-// Shared utility functions for strided kernels
-inline long calculate_non_scan_elements(
-    constant long* sizes,
-    uint ndim,
-    uint scan_dim) {
-  long total = 1;
-  for (uint i = 0; i < ndim; ++i) {
-    if (i != scan_dim) {
-      total *= sizes[i];
-    }
-  }
-  return total;
-}
-
-inline void thread_index_to_coordinates(
-    uint index,
-    int pos[c10::metal::max_ndim],
-    constant long* sizes,
-    uint ndim,
-    uint scan_dim) {
-  long remaining_index = index;
-  for (uint i = 0; i < ndim; ++i) {
-    if (i != scan_dim) {
-      pos[i] = remaining_index % sizes[i];
-      remaining_index /= sizes[i];
-    } else {
-      pos[i] = 0;
-    }
-  }
-}
-
-inline long calculate_base_offset(
-    int pos[c10::metal::max_ndim],
-    constant long* strides,
-    uint ndim,
-    uint scan_dim) {
-  long offset = 0;
-  for (uint i = 0; i < ndim; ++i) {
-    if (i != scan_dim) {
-      offset += pos[i] * strides[i];
-    }
-  }
-  return offset;
-}
-
-// Generic strided scan with indices kernel
-template <typename T, typename Op, typename acc_t = accum_t<T>>
-kernel void scan_with_indices_strided(
-    constant T* input [[buffer(0)]],
-    device T* values [[buffer(1)]],
-    device int64_t* indices [[buffer(2)]],
-    constant long* sizes [[buffer(3)]],
-    constant long* input_strides [[buffer(4)]],
-    constant long* values_strides [[buffer(5)]],
-    constant long* indices_strides [[buffer(6)]],
-    constant uint& ndim [[buffer(7)]],
-    constant uint& scan_dim [[buffer(8)]],
-    uint thread_index [[thread_position_in_grid]]) {
-  const long total_non_scan_elements =
-      calculate_non_scan_elements(sizes, ndim, scan_dim);
-  if (thread_index >= total_non_scan_elements) {
-    return;
-  }
-
-  int pos[c10::metal::max_ndim];
-  thread_index_to_coordinates(thread_index, pos, sizes, ndim, scan_dim);
-
-  const long input_base_offset =
-      calculate_base_offset(pos, input_strides, ndim, scan_dim);
-  const long values_base_offset =
-      calculate_base_offset(pos, values_strides, ndim, scan_dim);
-  const long indices_base_offset =
-      calculate_base_offset(pos, indices_strides, ndim, scan_dim);
-
-  acc_t accumulator = Op::identity();
-  int64_t best_idx = 0;
-  const long scan_size = sizes[scan_dim];
-  const long input_scan_stride = input_strides[scan_dim];
-  const long values_scan_stride = values_strides[scan_dim];
-  const long indices_scan_stride = indices_strides[scan_dim];
-
-  for (long scan_idx = 0; scan_idx < scan_size; scan_idx++) {
-    const long input_offset = input_base_offset + scan_idx * input_scan_stride;
-    const long values_offset =
-        values_base_offset + scan_idx * values_scan_stride;
-    const long indices_offset =
-        indices_base_offset + scan_idx * indices_scan_stride;
-
-    T val = input[input_offset];
-    acc_t accum_val = static_cast<acc_t>(val);
-    if (scan_idx == 0 || Op::apply(accum_val, accumulator) == accum_val) {
-      accumulator = accum_val;
-      best_idx = scan_idx;
-    }
-    values[values_offset] = static_cast<T>(accumulator);
-    indices[indices_offset] = best_idx;
-  }
-}
-
 #define REGISTER_SCAN_OP(OP_NAME, OP_CLASS, DTYPE, NREADS)              \
   template [[host_name(#OP_NAME "_innermost_" #DTYPE)]] [[kernel]] void \
   scan_innermost_dim<DTYPE, OP_CLASS<DTYPE>, NREADS>(                   \
@@ -595,6 +822,7 @@ kernel void scan_with_indices_strided(
 // Simple scan operations
 REGISTER_SCAN_OP(cumsum, CumSumOp, float, 4);
 REGISTER_SCAN_OP(cumsum, CumSumOp, half, 4);
+REGISTER_SCAN_OP(cumsum, CumSumOp, bfloat, 4);
 REGISTER_SCAN_OP(cumsum, CumSumOp, long, 2);
 REGISTER_SCAN_OP(cumsum, CumSumOp, int, 4);
 REGISTER_SCAN_OP(cumsum, CumSumOp, short, 4);
@@ -603,34 +831,11 @@ REGISTER_SCAN_OP(cumsum, CumSumOp, uchar, 4);
 
 REGISTER_SCAN_OP(cumprod, CumProdOp, float, 4);
 REGISTER_SCAN_OP(cumprod, CumProdOp, half, 4);
+REGISTER_SCAN_OP(cumprod, CumProdOp, bfloat, 4);
 REGISTER_SCAN_OP(cumprod, CumProdOp, long, 2);
 REGISTER_SCAN_OP(cumprod, CumProdOp, int, 4);
 REGISTER_SCAN_OP(cumprod, CumProdOp, short, 4);
 REGISTER_SCAN_OP(cumprod, CumProdOp, char, 4);
 REGISTER_SCAN_OP(cumprod, CumProdOp, uchar, 4);
 
-// Scan operations with indices
-REGISTER_SCAN_WITH_INDICES_OP(cummin, CumMinOp, float);
-REGISTER_SCAN_WITH_INDICES_OP(cummin, CumMinOp, half);
-REGISTER_SCAN_WITH_INDICES_OP(cummin, CumMinOp, long);
-REGISTER_SCAN_WITH_INDICES_OP(cummin, CumMinOp, int);
-REGISTER_SCAN_WITH_INDICES_OP(cummin, CumMinOp, short);
-REGISTER_SCAN_WITH_INDICES_OP(cummin, CumMinOp, char);
-REGISTER_SCAN_WITH_INDICES_OP(cummin, CumMinOp, uchar);
-REGISTER_SCAN_WITH_INDICES_OP(cummin, CumMinOp, bool);
-
-REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, float);
-REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, half);
-REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, long);
-REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, int);
-REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, short);
-REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, char);
-REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, uchar);
-REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, bool);
-
-#if __METAL_VERSION__ >= 310
-REGISTER_SCAN_OP(cumsum, CumSumOp, bfloat, 4);
-REGISTER_SCAN_OP(cumprod, CumProdOp, bfloat, 4);
-REGISTER_SCAN_WITH_INDICES_OP(cummin, CumMinOp, bfloat);
-REGISTER_SCAN_WITH_INDICES_OP(cummax, CumMaxOp, bfloat);
-#endif
+#endif // __METAL_VERSION__ >= 310

--- a/aten/src/ATen/native/mps/operations/ScanKernel.mm
+++ b/aten/src/ATen/native/mps/operations/ScanKernel.mm
@@ -21,11 +21,143 @@ static auto& lib = MetalShaderLibrary::getBundledLibrary();
 #include <ATen/native/mps/ScanKernel_metallib.h>
 #endif
 
+// Utility function to get 2D grid dimensions for dispatch
+static std::pair<uint32_t, uint32_t> get_2d_grid_dims(const IntArrayRef& shape,
+                                                      const IntArrayRef& strides,
+                                                      size_t divisor) {
+  size_t total_elements = 1;
+  for (auto s : shape) {
+    total_elements *= s;
+  }
+
+  size_t grid_size = total_elements / divisor;
+
+  // Simple 2D grid layout
+  uint32_t width = std::min(grid_size, static_cast<size_t>(65535));
+  uint32_t height = (grid_size + width - 1) / width;
+  return std::make_pair(width, height);
+}
+
+static void scan_mps_impl(const Tensor& self, const Tensor& output, int64_t dim, const std::string& op_name) {
+  if (output.numel() == 0) {
+    return;
+  }
+
+  const int64_t ndim = self.dim();
+  const int64_t wrapped_dim = maybe_wrap_dim(dim, ndim);
+  const int64_t axis_size = self.size(wrapped_dim);
+
+  // Preprocess input tensor - ensure it's contiguous for Metal shaders
+  Tensor input_tensor = self;
+  bool input_needs_copy = !self.is_contiguous();
+
+  if (input_needs_copy) {
+    input_tensor = self.contiguous();
+  }
+
+  // Preprocess output tensor - ensure it's contiguous for Metal shaders
+  Tensor output_tensor = output;
+  bool output_needs_copy = !output.is_contiguous();
+  Tensor temp_output;
+
+  if (output_needs_copy) {
+    // Create a temporary contiguous tensor with the same shape and type
+    temp_output = at::empty_like(output, output.options()).contiguous();
+    output_tensor = temp_output;
+  }
+
+  // Determine which kernel to use based on scan dimension position
+  bool is_innermost_scan = (wrapped_dim == ndim - 1);
+
+  MPSStream* mpsStream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
+
+      // Build kernel name based on scan dimension position
+      std::string kernel_name;
+      std::string type_str = scalarToMetalTypeString(input_tensor);
+
+      if (is_innermost_scan) {
+        kernel_name = op_name + "_innermost_" + type_str;
+      } else {
+        kernel_name = op_name + "_outer_" + type_str;
+      }
+
+      id<MTLComputePipelineState> scanPSO = lib.getPipelineStateForFunc(kernel_name);
+
+      // this function call is a no-op if MPS Profiler is not enabled
+      getMPSProfiler().beginProfileKernel(scanPSO, op_name, [&]() {
+        std::vector<Tensor> all_tensors = {input_tensor, output_tensor};
+        return all_tensors;
+      }());
+
+      [computeEncoder setComputePipelineState:scanPSO];
+
+      // Set input and output buffers (both guaranteed contiguous)
+      mtl_setBuffer(computeEncoder, input_tensor, 0);
+      mtl_setBuffer(computeEncoder, output_tensor, 1);
+
+      if (is_innermost_scan) {
+        // Contiguous scan dispatch (scanning innermost dimension)
+        mtl_setBytes(computeEncoder, axis_size, 2);
+
+        int n_reads = (input_tensor.element_size() <= 4) ? 4 : 2;
+        constexpr int simd_size = 32;
+        int elements_per_simd = n_reads * simd_size;
+        int thread_group_size = static_cast<int>(scanPSO.maxTotalThreadsPerThreadgroup);
+
+        if (axis_size <= n_reads * 1024) {
+          thread_group_size = ((axis_size + elements_per_simd - 1) / elements_per_simd) * simd_size;
+        } else if (axis_size <= n_reads * 2048) {
+          thread_group_size = ((axis_size / 2 + elements_per_simd - 1) / elements_per_simd) * simd_size;
+        }
+        thread_group_size = std::min(thread_group_size, static_cast<int>(scanPSO.maxTotalThreadsPerThreadgroup));
+
+        auto tmp_grid_dims = get_2d_grid_dims(input_tensor.sizes(), input_tensor.strides(), axis_size);
+
+        [computeEncoder dispatchThreads:MTLSizeMake(thread_group_size, tmp_grid_dims.first, tmp_grid_dims.second)
+                  threadsPerThreadgroup:MTLSizeMake(thread_group_size, 1, 1)];
+      } else {
+        // Strided scan dispatch (scanning non-innermost dimension)
+        size_t stride = input_tensor.strides()[wrapped_dim];
+        int bn = 32;
+        size_t stride_blocks = (stride + bn - 1) / bn;
+
+        mtl_setBytes(computeEncoder, axis_size, 2);
+        mtl_setBytes(computeEncoder, stride, 3);
+        mtl_setBytes(computeEncoder, stride_blocks, 4);
+
+        int n_reads = (input_tensor.element_size() <= 4) ? 4 : 2;
+        int n_simdgroups = bn / n_reads;
+        int thread_group_size = n_simdgroups * 32;
+
+        auto tmp_grid_dims = get_2d_grid_dims(input_tensor.sizes(), input_tensor.strides(), axis_size * stride);
+        if (tmp_grid_dims.first * stride_blocks <= UINT_MAX) {
+          tmp_grid_dims.first *= stride_blocks;
+        } else {
+          tmp_grid_dims.second *= stride_blocks;
+        }
+
+        [computeEncoder dispatchThreads:MTLSizeMake(thread_group_size, tmp_grid_dims.first, tmp_grid_dims.second)
+                  threadsPerThreadgroup:MTLSizeMake(thread_group_size, 1, 1)];
+      }
+
+      getMPSProfiler().endProfileKernel(scanPSO);
+    }
+  });
+
+  // Post-process: copy result back to original output tensor if needed
+  if (output_needs_copy) {
+    output.copy_(output_tensor);
+  }
+}
+
 // Generic scan implementation that handles both simple scans and scans with indices
-static void scan_mps_impl(const Tensor& self,
-                          const std::vector<Tensor>& outputs,
-                          int64_t dim,
-                          const std::string& op_name) {
+static void scan_mps_impl_generic(const Tensor& self,
+                                  const std::vector<Tensor>& outputs,
+                                  int64_t dim,
+                                  const std::string& op_name) {
   if (outputs[0].numel() == 0) {
     return;
   }
@@ -143,19 +275,19 @@ static void scan_mps_impl(const Tensor& self,
 } // namespace mps
 
 static void cumsum_mps_kernel(const Tensor& result, const Tensor& self, int64_t dim) {
-  mps::scan_mps_impl(self, {result}, dim, "cumsum");
+  mps::scan_mps_impl(self, result, dim, "cumsum");
 }
 
 static void cumprod_mps_kernel(const Tensor& result, const Tensor& self, int64_t dim) {
-  mps::scan_mps_impl(self, {result}, dim, "cumprod");
+  mps::scan_mps_impl(self, result, dim, "cumprod");
 }
 
 void cummax_helper_mps(const Tensor& self, Tensor& values, Tensor& indices, int64_t dim) {
-  mps::scan_mps_impl(self, {values, indices}, dim, "cummax");
+  mps::scan_mps_impl_generic(self, {values, indices}, dim, "cummax");
 }
 
 void cummin_helper_mps(const Tensor& self, Tensor& values, Tensor& indices, int64_t dim) {
-  mps::scan_mps_impl(self, {values, indices}, dim, "cummin");
+  mps::scan_mps_impl_generic(self, {values, indices}, dim, "cummin");
 }
 
 // Register dispatch functions

--- a/aten/src/ATen/native/mps/operations/ScanKernel.mm
+++ b/aten/src/ATen/native/mps/operations/ScanKernel.mm
@@ -306,11 +306,19 @@ static void scan_mps_impl_generic(const Tensor& self,
 } // namespace mps
 
 static void cumsum_mps_kernel(const Tensor& result, const Tensor& self, int64_t dim) {
-  mps::scan_mps_impl(self, result, dim, "cumsum");
+  if (is_macos_13_or_newer(MacOSVersion::MACOS_VER_14_0_PLUS)) {
+    mps::scan_mps_impl(self, result, dim, "cumsum");
+  } else {
+    mps::scan_mps_impl_generic(self, {result}, dim, "cumsum");
+  }
 }
 
 static void cumprod_mps_kernel(const Tensor& result, const Tensor& self, int64_t dim) {
-  mps::scan_mps_impl(self, result, dim, "cumprod");
+  if (is_macos_13_or_newer(MacOSVersion::MACOS_VER_14_0_PLUS)) {
+    mps::scan_mps_impl(self, result, dim, "cumprod");
+  } else {
+    mps::scan_mps_impl_generic(self, {result}, dim, "cumprod");
+  }
 }
 
 void cummax_helper_mps(const Tensor& self, Tensor& values, Tensor& indices, int64_t dim) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #156621
* __->__ #156494

Performance after this change (on M4 Max 64GB)
```
[-------------------------------  -------------------------------]
                                              |  eager  |  compile
1 threads: -------------------------------------------------------
      cumsum-dim0-32x32 (torch.float16)       |  106.9  |   109.7 
      cumsum-dim0-128x128 (torch.float16)     |  110.7  |   127.7 
      cumsum-dim0-512x512 (torch.float16)     |  125.5  |   143.7 
      cumsum-dim0-1024x1024 (torch.float16)   |  145.6  |   164.9 
      cumsum-dim1-32x32 (torch.float16)       |  101.3  |   117.6 
      cumsum-dim1-128x128 (torch.float16)     |   99.8  |   112.7 
      cumsum-dim1-512x512 (torch.float16)     |  102.1  |   118.8 
      cumsum-dim1-1024x1024 (torch.float16)   |  115.4  |   131.9 
      cumsum-1d-100 (torch.float16)           |  100.7  |   118.6 
      cumsum-1d-10000 (torch.float16)         |  101.4  |   117.0 
      cumsum-1d-1000000 (torch.float16)       |  300.8  |   333.9 
      cumsum-dim0-32x32 (torch.float32)       |   90.4  |   103.8 
      cumsum-dim0-128x128 (torch.float32)     |   94.1  |   113.0 
      cumsum-dim0-512x512 (torch.float32)     |  125.1  |   138.6 
      cumsum-dim0-1024x1024 (torch.float32)   |  147.3  |   161.8 
      cumsum-dim1-32x32 (torch.float32)       |  100.7  |   109.3 
      cumsum-dim1-128x128 (torch.float32)     |   99.0  |   113.8 
      cumsum-dim1-512x512 (torch.float32)     |  101.9  |   115.1 
      cumsum-dim1-1024x1024 (torch.float32)   |  114.8  |   131.2 
      cumsum-1d-100 (torch.float32)           |  100.8  |   118.2 
      cumsum-1d-10000 (torch.float32)         |  101.1  |   118.2 
      cumsum-1d-1000000 (torch.float32)       |  360.2  |   409.7 
      cumsum-dim0-32x32 (torch.bfloat16)      |  108.4  |   113.4 
      cumsum-dim0-128x128 (torch.bfloat16)    |  103.6  |   113.8 
      cumsum-dim0-512x512 (torch.bfloat16)    |  122.8  |   139.2 
      cumsum-dim0-1024x1024 (torch.bfloat16)  |  133.6  |   158.9 
      cumsum-dim1-32x32 (torch.bfloat16)      |  100.5  |   112.9 
      cumsum-dim1-128x128 (torch.bfloat16)    |  101.0  |   113.3 
      cumsum-dim1-512x512 (torch.bfloat16)    |   93.8  |   112.8 
      cumsum-dim1-1024x1024 (torch.bfloat16)  |  113.9  |   128.6 
      cumsum-1d-100 (torch.bfloat16)          |  100.7  |   117.7 
      cumsum-1d-10000 (torch.bfloat16)        |  100.1  |   117.8 
      cumsum-1d-1000000 (torch.bfloat16)      |  310.5  |   324.0 

Times are in microseconds (us).
```

Comparison with previous Metal implementation and the original MPSGraph implementation:
```
                                              |  Metal  | MPSGraph | Metal (Previous)
-------------------------------------------------------------------------------------
      cumsum-dim0-32x32 (torch.float16)       |  106.9  |  131.0   |   107.4
      cumsum-dim0-128x128 (torch.float16)     |  110.7  |  116.9   |   134.2
      cumsum-dim0-512x512 (torch.float16)     |  125.5  |  132.5   |   207.3
      cumsum-dim0-1024x1024 (torch.float16)   |  145.6  |  150.0   |   318.9
      cumsum-dim1-32x32 (torch.float16)       |  101.3  |  125.9   |    98.0
      cumsum-dim1-128x128 (torch.float16)     |   99.8  |  116.4   |   110.8
      cumsum-dim1-512x512 (torch.float16)     |  102.1  |  135.9   |   193.0
      cumsum-dim1-1024x1024 (torch.float16)   |  115.4  |  139.5   |   844.7
      cumsum-1d-100 (torch.float16)           |  100.7  |  119.5   |   108.4
      cumsum-1d-10000 (torch.float16)         |  101.4  |  128.9   |   784.7
      cumsum-1d-1000000 (torch.float16)       |  300.8  |  140.6   | 65855.2
      cumsum-dim0-32x32 (torch.float32)       |   90.4  |  115.7   |   114.7
      cumsum-dim0-128x128 (torch.float32)     |   94.1  |  118.0   |   139.0
      cumsum-dim0-512x512 (torch.float32)     |  125.1  |  138.8   |   197.3
      cumsum-dim0-1024x1024 (torch.float32)   |  147.3  |  155.5   |   312.7
      cumsum-dim1-32x32 (torch.float32)       |  100.7  |  127.2   |    92.0
      cumsum-dim1-128x128 (torch.float32)     |   99.0  |  117.7   |   114.2
      cumsum-dim1-512x512 (torch.float32)     |  101.9  |  138.2   |   186.2
      cumsum-dim1-1024x1024 (torch.float32)   |  114.8  |  144.4   |   752.0
      cumsum-1d-100 (torch.float32)           |  100.8  |  118.6   |   112.4
      cumsum-1d-10000 (torch.float32)         |  101.1  |  125.5   |   793.5
      cumsum-1d-1000000 (torch.float32)       |  360.2  |  143.9   | 66431.8
      cumsum-dim0-32x32 (torch.bfloat16)      |  108.4  |  106.6   |   111.6
      cumsum-dim0-128x128 (torch.bfloat16)    |  103.6  |  118.1   |   139.0
      cumsum-dim0-512x512 (torch.bfloat16)    |  122.8  |  140.0   |   217.6
      cumsum-dim0-1024x1024 (torch.bfloat16)  |  133.6  |  153.2   |   305.2
      cumsum-dim1-32x32 (torch.bfloat16)      |  100.5  |  127.9   |   100.5
      cumsum-dim1-128x128 (torch.bfloat16)    |  101.0  |  116.5   |   112.8
      cumsum-dim1-512x512 (torch.bfloat16)    |   93.8  |  136.5   |   187.8
      cumsum-dim1-1024x1024 (torch.bfloat16)  |  113.9  |  139.8   |   790.9
      cumsum-1d-100 (torch.bfloat16)          |  100.7  |  115.7   |   111.6
      cumsum-1d-10000 (torch.bfloat16)        |  100.1  |  125.0   |   778.1
      cumsum-1d-1000000 (torch.bfloat16)      |  310.5  |  127.8   | 64654.3
```