### PR TITLE
Organize BUCK for torch/standalone

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -672,14 +672,6 @@ flatbuffer_cc_library(
 )
 
 cc_library(
-    name = "torch_standalone_headers",
-    hdrs = glob([
-        "torch/standalone/**/*.h"
-    ]),
-    visibility = ["//visibility:public"],
-)
-
-cc_library(
     name = "torch_headers",
     hdrs = if_cuda(
         torch_cuda_headers,

--- a/c10/core/build.bzl
+++ b/c10/core/build.bzl
@@ -80,7 +80,6 @@ def define_targets(rules):
         deps = [
             ":ScalarType",
             "//third_party/cpuinfo",
-            "//:torch_standalone_headers",
             "//c10/macros",
             "//c10/util:TypeCast",
             "//c10/util:base",

--- a/c10/macros/build.bzl
+++ b/c10/macros/build.bzl
@@ -13,7 +13,7 @@ def define_targets(rules):
         local_defines = ["C10_BUILD_MAIN_LIB"],
         visibility = ["//visibility:public"],
         deps = [
-            "//:torch_standalone_headers",
+            "//torch/standalone:torch_standalone_headers",
         ],
     )
 

--- a/c10/ovrsource_defs.bzl
+++ b/c10/ovrsource_defs.bzl
@@ -74,7 +74,7 @@ def define_c10_ovrsource(name, is_mobile):
             ],
         }),
         exported_deps = [
-            "//xplat/caffe2:torch_standalone_headers",
+            "//xplat/caffe2/torch/standalone:torch_standalone_headers",
             ":ovrsource_c10_cmake_macros.h",
             "//arvr/third-party/gflags:gflags",
             "//third-party/cpuinfo:cpuinfo",

--- a/c10/util/build.bzl
+++ b/c10/util/build.bzl
@@ -34,7 +34,7 @@ def define_targets(rules):
         visibility = ["//visibility:public"],
         deps = [
             ":bit_cast",
-            "//:torch_standalone_headers",
+            "//torch/standalone:torch_standalone_headers",
             "//c10/macros",
             "@fmt",
             "@moodycamel//:moodycamel",
@@ -92,7 +92,7 @@ def define_targets(rules):
             ],
         ),
         deps = [
-            "//:torch_standalone_headers",
+            "//torch/standalone:torch_standalone_headers",
         ],
         visibility = ["//visibility:public"],
     )

--- a/torch/standalone/BUILD.bazel
+++ b/torch/standalone/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "torch_standalone_headers",
+    hdrs = glob([
+        "**/*.h"
+    ]),
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Summary: Undo highlevel BUCKification in favor of something more organized by moving it to the dir itself

Test Plan:
CI

Rollback Plan:

Reviewed By: swolchok

Differential Revision: D76920013


