### PR TITLE
Fix dynamo benchmarks no dtype.__name__

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -2117,7 +2117,7 @@ class BenchmarkRunner:
             except Exception:
                 log.warning(
                     "%s golden ref were not generated for %s. Setting accuracy check to cosine",
-                    ref_dtype.__name__,
+                    str(ref_dtype),
                     name,
                 )
                 self.args.cosine = True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #156505



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames