### PR TITLE
[docs][typing] Document and type support for dim=None in torch.amin and torch.amax

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4052,12 +4052,12 @@
 - func: min.names_dim_min(Tensor self, Dimname dim, bool keepdim=False, *, Tensor(a!) min, Tensor(b!) min_indices) -> (Tensor(a!) values, Tensor(b!) indices)
   device_check: NoCheck   # TensorIterator
 
-- func: amin(Tensor self, int[1] dim=[], bool keepdim=False) -> Tensor
+- func: amin(Tensor self, int[]? dim=None, bool keepdim=False) -> Tensor
   variants: function, method
   structured_delegate: amin.out
   tags: core
 
-- func: amin.out(Tensor self, int[1] dim=[], bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
+- func: amin.out(Tensor self, int[]? dim=None, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
   structured: True
   dispatch:
     CPU, CUDA: amin_out

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -6642,7 +6642,7 @@ add_docstr(
 amax(input, dim, keepdim=False, *, out=None) -> Tensor
 
 Returns the maximum value of each slice of the :attr:`input` tensor in the given
-dimension(s) :attr:`dim`.
+dimension(s) :attr:`dim`. If 'dim' is None, the maximum of all elements in the 'input' tensor is returned.
 
 .. note::
     The difference between ``max``/``min`` and ``amax``/``amin`` is:
@@ -7250,7 +7250,7 @@ add_docstr(
 amin(input, dim, keepdim=False, *, out=None) -> Tensor
 
 Returns the minimum value of each slice of the :attr:`input` tensor in the given
-dimension(s) :attr:`dim`.
+dimension(s) :attr:`dim`. If 'dim' is None, the minimum of all elements in the 'input' tensor is returned.
 
 .. note::
     The difference between ``max``/``min`` and ``amax``/``amin`` is:


### PR DESCRIPTION
This PR updates the documentation and type hints for 'torch.amin' and 'torch.amax' to reflect that 'dim=None' is valid and supported at runtime.

**Changes:**
- Updated 'torch/_torch_docs.py' to document 'dim =None'
-  Updated 'native_functions.yaml' to allow 'dim=None' in the function schema

Fixes #156072 