### PR TITLE
Add missing `inline namespace CPU_CAPABILITY` to Gelu/Elu.h

### DIFF
--- a/aten/src/ATen/native/cpu/Elu.h
+++ b/aten/src/ATen/native/cpu/Elu.h
@@ -11,6 +11,7 @@
 #include <c10/util/BFloat16.h> // For c10::is_reduced_floating_point_v.
 
 namespace at::native {
+inline namespace CPU_CAPABILITY {
 /**
  * Return a function object that calculates ELU with the given
  * parameters on its input element.  ParamT is the type of the input
@@ -69,4 +70,5 @@ auto get_vectorized_elu_elementwise_func(float alpha, float scale, float input_s
     return vec::convert_from_float<T>(res0, res1);
   };
 }
+} // namespace CPU_CAPABILITY
 } // namespace at::native

--- a/aten/src/ATen/native/cpu/Gelu.h
+++ b/aten/src/ATen/native/cpu/Gelu.h
@@ -12,6 +12,7 @@
 #include <c10/util/BFloat16.h> // For c10::is_reduced_floating_point_v.
 
 namespace at::native {
+inline namespace CPU_CAPABILITY {
 constexpr double kGeluBeta = M_SQRT2 * M_2_SQRTPI * 0.5;
 constexpr double kGeluKappa = 0.044715;
 
@@ -78,5 +79,5 @@ vec::Vectorized<T> vectorized_gelu(vec::Vectorized<T> x) {
   return at::vec::convert_from_float<T>(vectorized_gelu(x0), vectorized_gelu(x1));
 }
 
-
-} // namespace
+} // namespace CPU_CAPABILITY
+} // namespace at::native


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #156512

As I recently learned the hard way (#156243), it is necessary to put kernel code that uses Vectorized in headers in this namespace.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168