### PR TITLE
[ca] Support TorchDispatchMode via pass through

### DIFF
--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -5156,8 +5156,6 @@ xfail_by_backend = {
         "test_reentrant_with_callbacks_depth_1",  # queue_callback
         "test_current_graph_task_execution_order",  # nodes are already freed by the time dynamo traces the lifted hook
         "test_autograd_inplace_views_cross_dtype",  # view_fn not supported by compiled autograd
-        "test_current_node",  # TorchDispatchMode not yet implemented for compiled autograd
-        "test_nested_checkpoint_set_early_stop_no_recompution_needed",  # TorchDispatchMode not yet implemented
         "test_post_accumulate_grad_hook_ordering",  # accuracy error
         "test_current_graph_task_id",  # autograd state already cleared once dynamo is called
         "test_custom_function_forward_mode_forward_is_no_op",  # forward AD
@@ -5250,6 +5248,7 @@ xfail_divergence_from_eager = {
     "test_vjp_call_compiled_backward_fn",  # different functorch error
     "test_vmap_call_compiled_backward_fn",  # different functorch error
     "test_accumulate_grad",  # always out of place add for compiled autograd
+    "test_current_node",  # slightly different dispatched ops
 }
 
 skipped_tests = set()

--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -4868,7 +4868,7 @@ class CompiledAutograd1(torch.nn.Module):
 
         class LoggingTorchFunctionMode(BaseTorchFunctionMode):
             def __torch_function__(self, func, types, args=(), kwargs=None):
-                called_funcs.append(str(func))
+                called_funcs.append(str(func.__name__))
                 return super().__torch_function__(func, types, args, kwargs)
 
         class MyLoss(torch.autograd.Function):
@@ -4901,12 +4901,14 @@ class CompiledAutograd1(torch.nn.Module):
         self.assertExpectedInline(
             "\n".join(called_funcs),
             """\
-<method 'mul' of 'torch._C.TensorBase' objects>
-<method 'mul' of 'torch._C.TensorBase' objects>
-<method 'sum' of 'torch._C.TensorBase' objects>
-<built-in function _set_multithreading_enabled>
-<function Tensor.backward at 0x7f9382fee480>
-<built-in function _set_multithreading_enabled>""",
+Forward
+mul
+mul
+sum
+Backward
+_set_multithreading_enabled
+backward
+_set_multithreading_enabled""",
         )  # noqa: B950
 
     def test_torch_dispatch_mode(self):
@@ -4914,7 +4916,7 @@ class CompiledAutograd1(torch.nn.Module):
 
         class LoggingTorchDispatchMode(TorchDispatchMode):
             def __torch_dispatch__(self, func, types, args=(), kwargs=None):
-                called_funcs.append(str(func))
+                called_funcs.append(str(func.__name__))
                 return func(*args, **kwargs)
 
         class MyLoss(torch.autograd.Function):
@@ -4948,23 +4950,23 @@ class CompiledAutograd1(torch.nn.Module):
             "\n".join(called_funcs),
             """\
 Forward
-aten.mul.Tensor
-aten.mul.Tensor
-aten.sum.default
+mul.Tensor
+mul.Tensor
+sum.default
 Backward
-aten.ones_like.default
-aten.empty.memory_format
-aten.empty.memory_format
-aten.empty.memory_format
-aten.empty.memory_format
-aten.empty.memory_format
-aten.empty.memory_format
-aten.ones_like.default
-aten.mul.Tensor
-aten.mul.Tensor
-aten.mul.Tensor
-aten.new_empty_strided.default
-aten.copy_.default""",
+ones_like.default
+empty.memory_format
+empty.memory_format
+empty.memory_format
+empty.memory_format
+empty.memory_format
+empty.memory_format
+ones_like.default
+mul.Tensor
+mul.Tensor
+mul.Tensor
+new_empty_strided.default
+copy_.default""",
         )  # noqa: B950
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #156550
* __->__ #156516
* #156509
* #156374

The CA initial trace just proxies nodes without dispatching any ops, we should hide it from ambient TorchDispatchModes

In terms of differences with eager autograd engine:
- For function mode, CA additionally disables/re-enables `_set_multithreading_enabled`
- For dispatch mode:
  - accumulate grad doesn't go down the stealing path (inaccurate compile-time refcount) so the grad `detach` ops are `copy_` instead
  - Since we always initial trace with dynamic shapes, and we filter out sizes, there's 1 aten.empty.memory_format for each mark_dynamic'd scalar


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov