### PR TITLE
Enable target-determination (TD) for ROCm CI

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1405,9 +1405,7 @@ def parse_args():
         and not IS_MACOS
         and "xpu" not in BUILD_ENVIRONMENT
         and "onnx" not in BUILD_ENVIRONMENT
-        and (
-            os.environ.get("GITHUB_WORKFLOW", "slow") in ("trunk", "pull", "rocm", "rocm-mi300")
-        ),
+        and os.environ.get("GITHUB_WORKFLOW", "slow") in ("trunk", "pull", "rocm", "rocm-mi300")
     )
     parser.add_argument(
         "--shard",

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1405,8 +1405,10 @@ def parse_args():
         and not IS_MACOS
         and "xpu" not in BUILD_ENVIRONMENT
         and "onnx" not in BUILD_ENVIRONMENT
-        and (os.environ.get("GITHUB_WORKFLOW", "slow") in ("trunk", "pull")
-             or "rocm" in os.environ.get("GITHUB_WORKFLOW", "slow")),
+        and (
+            os.environ.get("GITHUB_WORKFLOW", "slow") in ("trunk", "pull")
+            or "rocm" in os.environ.get("GITHUB_WORKFLOW", "slow")
+        ),
     )
     parser.add_argument(
         "--shard",

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1406,8 +1406,7 @@ def parse_args():
         and "xpu" not in BUILD_ENVIRONMENT
         and "onnx" not in BUILD_ENVIRONMENT
         and (
-            os.environ.get("GITHUB_WORKFLOW", "slow") in ("trunk", "pull")
-            or "rocm" in os.environ.get("GITHUB_WORKFLOW", "slow")
+            os.environ.get("GITHUB_WORKFLOW", "slow") in ("trunk", "pull", "rocm", "rocm-mi300")
         ),
     )
     parser.add_argument(

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1406,7 +1406,7 @@ def parse_args():
         and "xpu" not in BUILD_ENVIRONMENT
         and "onnx" not in BUILD_ENVIRONMENT
         and os.environ.get("GITHUB_WORKFLOW", "slow")
-        in ("trunk", "pull", "rocm", "rocm-mi300")
+        in ("trunk", "pull", "rocm", "rocm-mi300"),
     )
     parser.add_argument(
         "--shard",

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1405,7 +1405,8 @@ def parse_args():
         and not IS_MACOS
         and "xpu" not in BUILD_ENVIRONMENT
         and "onnx" not in BUILD_ENVIRONMENT
-        and os.environ.get("GITHUB_WORKFLOW", "slow") in ("trunk", "pull", "rocm", "rocm-mi300")
+        and os.environ.get("GITHUB_WORKFLOW", "slow")
+        in ("trunk", "pull", "rocm", "rocm-mi300")
     )
     parser.add_argument(
         "--shard",

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1402,7 +1402,6 @@ def parse_args():
         )
         and get_pr_number() is not None
         and not strtobool(os.environ.get("NO_TD", "False"))
-        and not TEST_WITH_ROCM
         and not IS_MACOS
         and "xpu" not in BUILD_ENVIRONMENT
         and "onnx" not in BUILD_ENVIRONMENT

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1405,7 +1405,8 @@ def parse_args():
         and not IS_MACOS
         and "xpu" not in BUILD_ENVIRONMENT
         and "onnx" not in BUILD_ENVIRONMENT
-        and os.environ.get("GITHUB_WORKFLOW", "slow") in ("trunk", "pull"),
+        and (os.environ.get("GITHUB_WORKFLOW", "slow") in ("trunk", "pull")
+             or "rocm" in os.environ.get("GITHUB_WORKFLOW", "slow")),
     )
     parser.add_argument(
         "--shard",


### PR DESCRIPTION
Target determination sorts the tests in a PR CI run based on heuristics about which tests are more relevant to the PR's changes. This can help provide faster CI signal as well as help alleviate capacity concerns as job durations should decrease due to catching failures earlier.


cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd