### PR TITLE
[SymmMem] Rename all_to_all_vdev ops

### DIFF
--- a/test/distributed/test_nvshmem.py
+++ b/test/distributed/test_nvshmem.py
@@ -91,7 +91,7 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinousTest):
         torch.testing.assert_close(out, expected)
 
     @skipIfRocm
-    def test_nvshmem_all_to_all_vdev(self) -> None:
+    def test_all_to_all_vdev(self) -> None:
         self._init_device()
 
         group_name = dist.group.WORLD.group_name
@@ -123,7 +123,7 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinousTest):
         # Row 0 is input splits
         in_out_splits[0].copy_(inp_splits)
 
-        torch.ops.symm_mem.nvshmem_all_to_all_vdev(inp, out, in_out_splits, group_name)
+        torch.ops.symm_mem.all_to_all_vdev(inp, out, in_out_splits, group_name)
 
         # Check input splits (row 0) -- should not change
         torch.testing.assert_close(in_out_splits[0], inp_splits)
@@ -133,7 +133,7 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinousTest):
 
         # Check output offsets (row 2)
         out_offsets = torch.cumsum(out_splits, dim=0)  # inclusive scan
-        # output offsets from `nvshmem_all_to_all_vdev` is exclusive scan
+        # output offsets from `all_to_all_vdev` is exclusive scan
         self.assertEqual(in_out_splits[2][0], 0)
         torch.testing.assert_close(in_out_splits[2][1:], out_offsets[:-1])
 
@@ -146,7 +146,7 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinousTest):
 
     @skipIfRocm
     @parametrize("align", [1, 8, 16])  # `major_align` of output
-    def test_nvshmem_all_to_all_vdev_2d(self, align: int) -> None:
+    def test_all_to_all_vdev_2d(self, align: int) -> None:
         torch.manual_seed(42 + self.rank)
         self._init_device()
 
@@ -190,7 +190,7 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinousTest):
         # Row 0 is input splits
         in_out_splits[0].copy_(inp_splits)
 
-        torch.ops.symm_mem.nvshmem_all_to_all_vdev_2d(
+        torch.ops.symm_mem.all_to_all_vdev_2d(
             inp, out, in_out_splits, group_name, major_align=align
         )
         received_out_splits = in_out_splits[1]
@@ -217,7 +217,7 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinousTest):
 
         out_splits_padded = torch.tensor(out_split_list, device=self.device).reshape(-1)
         out_offsets = torch.cumsum(out_splits_padded, dim=0)  # inclusive scan
-        # Make it exclusive scan because that's what `nvshmem_all_to_all_vdev_2d` returns
+        # Make it exclusive scan because that's what `all_to_all_vdev_2d` returns
         out_offsets = torch.cat(
             [torch.zeros(1, device=self.device), out_offsets[:-1]]
         ).to(torch.int64)

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
@@ -280,9 +280,9 @@ TORCH_LIBRARY_FRAGMENT(symm_mem, m) {
   m.def(
       "nvshmem_all_to_all(Tensor input, Tensor(a!) out, str group_name) -> Tensor(a!)");
   m.def(
-      "nvshmem_all_to_all_vdev(Tensor input, Tensor(a!) out, Tensor(a!) in_out_splits, str group_name) -> Tensor(a!)");
+      "all_to_all_vdev(Tensor input, Tensor(a!) out, Tensor(a!) in_out_splits, str group_name) -> Tensor(a!)");
   m.def(
-      "nvshmem_all_to_all_vdev_2d(Tensor input, Tensor(a!) out, Tensor(a!) in_out_splits, str group_name, int? major_align=None) -> Tensor(a!)");
+      "all_to_all_vdev_2d(Tensor input, Tensor(a!) out, Tensor(a!) in_out_splits, str group_name, int? major_align=None) -> Tensor(a!)");
 }
 
 TORCH_LIBRARY_IMPL(symm_mem, Meta, m) {

--- a/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cu
@@ -265,7 +265,7 @@ __global__ void allToAllV(void *send_data, void *recv_data, int64_t* in_out_spli
   }
 }
 
-at::Tensor nvshmem_all_to_all_vdev(
+at::Tensor all_to_all_vdev(
     at::Tensor& input,
     at::Tensor& out,
     at::Tensor& in_out_splits,
@@ -347,9 +347,9 @@ at::Tensor nvshmem_all_to_all_vdev(
   return out;
 }
 
-// Start of `nvshmem_all_to_all_vdev_2d`
+// Start of `all_to_all_vdev_2d`
 // This kernel is used to exchange output splits and source offsets between peers.
-// For meaning of `mype` and `npes`, see the docstring of `nvshmem_all_to_all_vdev_2d`.
+// For meaning of `mype` and `npes`, see the docstring of `all_to_all_vdev_2d`.
 // `in_out_splits` is of size (3, npes * ne) and contains:
 // - input splits (IN)
 // - output splits (OUT) and
@@ -422,7 +422,7 @@ __device__ int64_t prefixSum_warp(int64_t *odata, int64_t *idata, int n) {
 // This kernel is used to do the actual data exchange.
 // `in_out_splits` has the same definition as in `exchangeSplitAndOffset`.
 // `stride` is the stride at dim 0, unit in byte.
-// For meaning of `mype` and `npes`, see the docstring of `nvshmem_all_to_all_vdev_2d`.
+// For meaning of `mype` and `npes`, see the docstring of `all_to_all_vdev_2d`.
 __global__ void allToAllV_2d(void *send_data, void *recv_data, int64_t* in_out_splits, size_t stride, int mype, int npes, int ne, int64_t major_align) {
   int nsplits = npes * ne;
   auto output_splits = in_out_splits + nsplits;
@@ -499,7 +499,7 @@ __global__ void allToAllV_2d(void *send_data, void *recv_data, int64_t* in_out_s
   }
 }
 
-at::Tensor nvshmem_all_to_all_vdev_2d(
+at::Tensor all_to_all_vdev_2d(
     at::Tensor& input,
     at::Tensor& out,
     at::Tensor& in_out_splits,
@@ -635,6 +635,6 @@ at::Tensor nvshmem_all_to_all_vdev_2d(
 TORCH_LIBRARY_IMPL(symm_mem, CUDA, m) {
   m.impl("nvshmem_broadcast", c10d::nvshmem_extension::nvshmem_broadcast);
   m.impl("nvshmem_all_to_all", c10d::nvshmem_extension::nvshmem_all_to_all);
-  m.impl("nvshmem_all_to_all_vdev", c10d::nvshmem_extension::nvshmem_all_to_all_vdev);
-  m.impl("nvshmem_all_to_all_vdev_2d", c10d::nvshmem_extension::nvshmem_all_to_all_vdev_2d);
+  m.impl("all_to_all_vdev", c10d::nvshmem_extension::all_to_all_vdev);
+  m.impl("all_to_all_vdev_2d", c10d::nvshmem_extension::all_to_all_vdev_2d);
 }

--- a/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cuh
+++ b/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cuh
@@ -25,13 +25,13 @@ at::Tensor nvshmem_all_to_all(
     at::Tensor& out,
     std::string group_name);
 
-at::Tensor nvshmem_all_to_all_vdev(
+at::Tensor all_to_all_vdev(
     at::Tensor& input,
     at::Tensor& out,
     at::Tensor& in_out_splits,
     std::string group_name);
 
-at::Tensor nvshmem_all_to_all_vdev_2d(
+at::Tensor all_to_all_vdev_2d(
     at::Tensor& input,
     at::Tensor& out,
     at::Tensor& in_out_splits,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #156582

`all_to_all_vdev` are not binding of NVSHMEM APIs. Removing the `nvshmem_` prefix. 

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k