### PR TITLE
[Inductor Dashboard] Enable deterministic algorithms for all models on ROCm

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -3756,8 +3756,8 @@ def run(runner, args, original_dir=None):
             args.use_eval_mode = True
         inductor_config.fallback_random = True
         if (
-            args.only is not None 
-            and not torch.version.hip 
+            args.only is not None
+            and not torch.version.hip
             and args.only not in {
                 "alexnet",
                 "Background_Matting",

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -3755,32 +3755,36 @@ def run(runner, args, original_dir=None):
             # TODO - Using train mode for timm_models and HF models. Move to train mode for Torchbench as well.
             args.use_eval_mode = True
         inductor_config.fallback_random = True
-        if args.only is not None and args.only not in {
-            "alexnet",
-            "Background_Matting",
-            "pytorch_CycleGAN_and_pix2pix",
-            "pytorch_unet",
-            "Super_SloMo",
-            "vgg16",
-            # https://github.com/pytorch/pytorch/issues/96724
-            "Wav2Vec2ForCTC",
-            "Wav2Vec2ForPreTraining",
-            "sam",
-            "sam_fast",
-            "resnet50_quantized_qat",
-            "mobilenet_v2_quantized_qat",
-            "detectron2_maskrcnn",
-            "detectron2_maskrcnn_r_101_c4",
-            "detectron2_maskrcnn_r_101_fpn",
-            "detectron2_maskrcnn_r_50_c4",
-            "detectron2_maskrcnn_r_50_fpn",
-            "detectron2_fasterrcnn_r_101_c4",
-            "detectron2_fasterrcnn_r_101_dc5",
-            "detectron2_fasterrcnn_r_101_fpn",
-            "detectron2_fasterrcnn_r_50_c4",
-            "detectron2_fasterrcnn_r_50_dc5",
-            "detectron2_fasterrcnn_r_50_fpn",
-        }:
+        if (
+            args.only is not None 
+            and not torch.version.hip 
+            and args.only not in {
+                "alexnet",
+                "Background_Matting",
+                "pytorch_CycleGAN_and_pix2pix",
+                "pytorch_unet",
+                "Super_SloMo",
+                "vgg16",
+                # https://github.com/pytorch/pytorch/issues/96724
+                "Wav2Vec2ForCTC",
+                "Wav2Vec2ForPreTraining",
+                "sam",
+                "sam_fast",
+                "resnet50_quantized_qat",
+                "mobilenet_v2_quantized_qat",
+                "detectron2_maskrcnn",
+                "detectron2_maskrcnn_r_101_c4",
+                "detectron2_maskrcnn_r_101_fpn",
+                "detectron2_maskrcnn_r_50_c4",
+                "detectron2_maskrcnn_r_50_fpn",
+                "detectron2_fasterrcnn_r_101_c4",
+                "detectron2_fasterrcnn_r_101_dc5",
+                "detectron2_fasterrcnn_r_101_fpn",
+                "detectron2_fasterrcnn_r_50_c4",
+                "detectron2_fasterrcnn_r_50_dc5",
+                "detectron2_fasterrcnn_r_50_fpn",
+            }
+        ):
             # some of the models do not support use_deterministic_algorithms
             torch.use_deterministic_algorithms(True)
         if args.devices == ["xpu"]:

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -3758,7 +3758,8 @@ def run(runner, args, original_dir=None):
         if (
             args.only is not None
             and not torch.version.hip
-            and args.only not in {
+            and args.only 
+            not in {
                 "alexnet",
                 "Background_Matting",
                 "pytorch_CycleGAN_and_pix2pix",

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -3758,7 +3758,7 @@ def run(runner, args, original_dir=None):
         if (
             args.only is not None
             and not torch.version.hip
-            and args.only 
+            and args.only
             not in {
                 "alexnet",
                 "Background_Matting",


### PR DESCRIPTION
vgg16 and alexnet fail accuracy tests on ROCm as deterministic algorithms are not enabled. Attempting to re-enable.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @dllehr-amd @chenyang78