### PR TITLE
Fix torch==2.6 broke nn.Module.dtype typing

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -190,6 +190,47 @@ class TestNN(NNTestCase):
         MyModuleWithMixinBefore.call_super_init = False
         MyModuleWithMixinAfter.call_super_init = False
 
+    def test_module_device_dtype_properties(self):
+        """Test that modules have device and dtype properties that return correct types.
+        
+        This test addresses the issue where module.device and module.dtype were
+        returning Union[Tensor, Module] instead of torch.device and torch.dtype,
+        causing mypy type errors when used with torch.autocast.
+        """
+        # Test module with parameters
+        linear = nn.Linear(3, 5)
+        self.assertIsInstance(linear.device, torch.device)
+        self.assertIsInstance(linear.dtype, torch.dtype)
+        
+        # Test that device and dtype match the first parameter
+        first_param = next(linear.parameters())
+        self.assertEqual(linear.device, first_param.device)
+        self.assertEqual(linear.dtype, first_param.dtype)
+        
+        # Test module with only buffers
+        class BufferOnlyModule(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer('buf', torch.randn(3, 4))
+        
+        buffer_module = BufferOnlyModule()
+        self.assertIsInstance(buffer_module.device, torch.device)
+        self.assertIsInstance(buffer_module.dtype, torch.dtype)
+        self.assertEqual(buffer_module.device, buffer_module.buf.device)
+        self.assertEqual(buffer_module.dtype, buffer_module.buf.dtype)
+        
+        # Test empty module (should raise RuntimeError)
+        empty_module = nn.Module()
+        with self.assertRaises(RuntimeError):
+            _ = empty_module.device
+        with self.assertRaises(RuntimeError):
+            _ = empty_module.dtype
+        
+        # Test the original issue: using module.device.type and module.dtype with autocast
+        # This should work without type errors after our fix
+        with torch.autocast(device_type=linear.device.type, dtype=linear.dtype):
+            pass  # Should not raise any errors
+
     def test_share_memory(self):
         class Net(nn.Module):
             def __init__(self) -> None:

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1943,6 +1943,52 @@ class Module:
         if "_backward_pre_hooks" not in self.__dict__:
             self._backward_pre_hooks = OrderedDict()
 
+    @property
+    def device(self) -> device:
+        r"""Return the device of the module.
+
+        Returns the device of the first parameter if the module has parameters,
+        otherwise returns the device of the first buffer if the module has buffers.
+
+        Returns:
+            torch.device: The device of the module.
+
+        Raises:
+            RuntimeError: If the module has no parameters or buffers.
+        """
+        try:
+            return next(self.parameters()).device
+        except StopIteration:
+            try:
+                return next(self.buffers()).device
+            except StopIteration:
+                raise RuntimeError(
+                    f"Cannot determine device: {type(self).__name__} module has no parameters or buffers"
+                )
+
+    @property
+    def dtype(self) -> dtype:
+        r"""Return the dtype of the module.
+
+        Returns the dtype of the first parameter if the module has parameters,
+        otherwise returns the dtype of the first buffer if the module has buffers.
+
+        Returns:
+            torch.dtype: The dtype of the module.
+
+        Raises:
+            RuntimeError: If the module has no parameters or buffers.
+        """
+        try:
+            return next(self.parameters()).dtype
+        except StopIteration:
+            try:
+                return next(self.buffers()).dtype
+            except StopIteration:
+                raise RuntimeError(
+                    f"Cannot determine dtype: {type(self).__name__} module has no parameters or buffers"
+                )
+
     # It is crucial that the return type is not annotated as `Any`, otherwise type checking
     # on `torch.nn.Module` and all its subclasses is largely disabled as a result. See:
     # https://github.com/pytorch/pytorch/pull/115074


### PR DESCRIPTION
This PR addresses the typing issue with nn.Module.dtype and nn.Module.device that was broken in torch==2.6.

PyTorch's `nn.Module` class didn't have explicit `device` and `dtype` properties. When users accessed `module.device` or `module.dtype`, it fell back to the `__getattr__` method which returns `Union[Tensor, "Module"]` before 2.6 i guess. 
causing mypy to interpret these properties as having the wrong type. I am assuming the earlier fallback did something automatic to fall back to the correct but after the more stricter type change in 2.6 we started to see this issue

I tried to add these properties to the base class but on further ispection it might not seem like the best path forward since most of the codebase does not make use of it in this way, It seems like an anitpattern and the best way would be to either use the input tensors device  or something like this maybe. I looked up these examples on google. 

```
 with torch.autocast(device_type=input.device.type, dtype=input.dtype):

 param = next(module.parameters())
 with torch.autocast(device_type=param.device.type, dtype=param.dtype):
```

Let me know what others think of this and if yes we can close the parent issue with this comment. 

Fixes #152292