### PR TITLE
[cutlass backend] delete pip cutlass path since nvidia stops supporting nvidia-cutlass

### DIFF
--- a/torch/_inductor/codegen/cuda/cutlass_utils.py
+++ b/torch/_inductor/codegen/cuda/cutlass_utils.py
@@ -79,34 +79,6 @@ def try_import_cutlass() -> bool:
 
         return True
 
-    try:
-        import cutlass  # type: ignore[import-not-found]  # noqa: F811
-        import cutlass_library  # type: ignore[import-not-found]  # noqa: F811
-
-        cutlass_minor_vesion = int(cutlass.__version__.split(".")[1])
-        if cutlass_minor_vesion < 7:
-            log.warning("CUTLASS version < 3.7 is not recommended.")
-
-        log.debug(
-            "Found cutlass_library in python search path, overriding config.cuda.cutlass_dir"
-        )
-        cutlass_library_dir = os.path.dirname(cutlass_library.__file__)
-        assert os.path.isdir(cutlass_library_dir), (
-            f"{cutlass_library_dir} is not a directory"
-        )
-        config.cuda.cutlass_dir = os.path.abspath(
-            os.path.join(
-                cutlass_library_dir,
-                "source",
-            )
-        )
-
-        return True
-    except ModuleNotFoundError:
-        log.debug(
-            "cutlass_library not found in sys.path, trying to import from config.cuda.cutlass_dir"
-        )
-
     # Copy CUTLASS python scripts to a temp dir and add the temp dir to Python search path.
     # This is a temporary hack to avoid CUTLASS module naming conflicts.
     # TODO(ipiszy): remove this hack when CUTLASS solves Python scripts packaging structure issues.

--- a/torch/_inductor/codegen/cuda/cutlass_utils.py
+++ b/torch/_inductor/codegen/cuda/cutlass_utils.py
@@ -146,7 +146,7 @@ def try_import_cutlass() -> bool:
                 )
 
         try:
-            import cutlass  # noqa: F401
+            import cutlass  # noqa: F401, F811
             import cutlass_library.generator  # noqa: F401
             import cutlass_library.library  # noqa: F401
             import cutlass_library.manifest  # noqa: F401


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #156655
* #156654
* __->__ #156651

Differential Revision: [D77186982](https://our.internmc.facebook.com/intern/diff/D77186982/)

source: https://pypi.org/project/nvidia-cutlass/

If users want to use it, they can install pytorch through wheel, git clone cutlass, and specify cutlass path via TORCHINDUCTOR_CUTLASS_DIR

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov