### PR TITLE
autograd: Add VJP and JVP rules for aten::aminmax #151186

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -11429,6 +11429,53 @@ class TestAutogradDeviceType(TestCase):
 
             gradcheck(fn, (input, 0, idx, src, reduction), check_batched_grad=False)
 
+    def test_aminmax_backprops_to_all_values(self, device):
+        # Tests that gradients are evenly distributed when there are multiple min/max values
+        # Similar to test_min_max_median_backprops_to_all_values but specifically for aminmax
+        x = torch.tensor(
+            [1.0, 0.0, 1.0, 0.0, 1.0, 0.0], device=device, requires_grad=True
+        )
+
+        # Get both min and max values using aminmax
+        with torch.no_grad():
+            min_val, max_val = torch.aminmax(x)
+            min_mask = x == min_val
+            max_mask = x == max_val
+
+        # Test gradient distribution for minimum values
+        x.grad = None
+        min_out = x[min_mask].sum() / min_mask.sum()  # Average of min values
+        min_out.backward(retain_graph=True)
+        self.assertEqual(x.grad[min_mask].sum(), 1.0)
+        self.assertEqual((x.grad[min_mask] == 1.0 / 3.0).all().item(), True)
+        self.assertEqual(x.grad[~min_mask].sum(), 0.0)
+
+        # Test gradient distribution for maximum values
+        x.grad = None
+        max_out = x[max_mask].sum() / max_mask.sum()  # Average of max values
+        max_out.backward()
+        self.assertEqual(x.grad[max_mask].sum(), 1.0)
+        self.assertEqual((x.grad[max_mask] == 1.0 / 3.0).all().item(), True)
+        self.assertEqual(x.grad[~max_mask].sum(), 0.0)
+
+        # Test with NaN values
+        x = torch.tensor(
+            [float("nan"), float("nan"), float("nan")],
+            requires_grad=True,
+            device=device,
+        )
+        min_val, max_val = torch.aminmax(x)
+        min_out = x.sum() / 3.0  # Average of all values for NaN case
+        min_out.backward(retain_graph=True)
+        self.assertEqual(x.grad.sum(), 1.0)
+        self.assertEqual((x.grad == 1.0 / 3.0).all().item(), True)
+
+        x.grad = None
+        max_out = x.sum() / 3.0  # Average of all values for NaN case
+        max_out.backward()
+        self.assertEqual(x.grad.sum(), 1.0)
+        self.assertEqual((x.grad == 1.0 / 3.0).all().item(), True)
+
     def test_scatter_index_reduce_prod_gradgrad_error(self, device):
         # test that double backward raises an error for the case where 2 zeros in src
         # are scattered to the same position in self

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -11414,9 +11414,11 @@ class TestAutogradDeviceType(TestCase):
                 y.backward()
                 self.assertEqual(x.grad.sum(), 1.0)
                 self.assertEqual((x.grad == 1 / 3).sum(), 3)
-        
+
+        # 2) Explicit amin/amax plus the two components of aminmax
+        amin2 = lambda x: torch.aminmax(x)[0]   # min part
         amax2 = lambda x: torch.aminmax(x)[1]
-        for f in [torch.amin, torch.amax, amax2]:
+        for f in [torch.amin, torch.amax, amax2, amin2]:
             x1 = torch.tensor(
                 [1.0, 0.0, 1.0, 0.0, 1.0, 0.0],
                 device=device,
@@ -11445,8 +11447,6 @@ class TestAutogradDeviceType(TestCase):
                 idx = idx.unsqueeze(-1).expand((2, 3))
 
             gradcheck(fn, (input, 0, idx, src, reduction), check_batched_grad=False)
-
-
 
     def test_scatter_index_reduce_prod_gradgrad_error(self, device):
         # test that double backward raises an error for the case where 2 zeros in src

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -11398,7 +11398,8 @@ class TestAutogradForwardMode(TestCase):
 
 # Generic device type autograd tests.
 class TestAutogradDeviceType(TestCase):
-    def test_min_max_median_backprops_to_all_values(self, device):
+    def test_min_max_aminmax_median_backprops_to_all_values(self, device):
+        # 1) Test min/max/median/nanmedian on both a non NaN and all NaN tensor
         for f in [torch.min, torch.max, torch.median, torch.nanmedian]:
             x1 = torch.tensor(
                 [1.0, 0.0, 1.0, 0.0, 1.0, 0.0], device=device, requires_grad=True
@@ -11413,6 +11414,30 @@ class TestAutogradDeviceType(TestCase):
                 y.backward()
                 self.assertEqual(x.grad.sum(), 1.0)
                 self.assertEqual((x.grad == 1 / 3).sum(), 3)
+        
+        # 2) Test torch.amin and torch.amax only on the non NaN input:
+        for f in [torch.amin, torch.amax]:
+            x1 = torch.tensor(
+                [1.0, 0.0, 1.0, 0.0, 1.0, 0.0],
+                device=device,
+                requires_grad=True,
+            )
+            y = f(x1)   # scalar Tensor
+            y.backward()
+            self.assertEqual(x1.grad.sum(), 1.0)
+            self.assertEqual((x1.grad == 1.0 / 3.0).sum(), 3)
+
+        # 3) Test torch.aminmax (component 0 = min, component 1 = max) on non NaN:
+        for component in (0, 1):
+            x1 = torch.tensor(
+                [1.0, 0.0, 1.0, 0.0, 1.0, 0.0],
+                device=device,
+                requires_grad=True,
+            )
+            y = torch.aminmax(x1)[component]  # grab either the "min" or the "max" output
+            y.backward()
+            self.assertEqual(x1.grad.sum(), 1.0)
+            self.assertEqual((x1.grad == 1.0 / 3.0).sum(), 3)
 
     def test_scatter_index_reduce_amin_amax_aminmax_backprops_to_all_values(
         self, device
@@ -11433,32 +11458,7 @@ class TestAutogradDeviceType(TestCase):
 
             gradcheck(fn, (input, 0, idx, src, reduction), check_batched_grad=False)
 
-        # Additional test for torch.aminmax:
-        # Verify that when there are multiple occurrences of the min (or max) value,
-        # the backward distribution is (approximately) as expected.
-        for aminmax_component in (0, 1):
-            # Create an input where 0 is the min and 1 is the max; each repeated three times.
-            x = torch.tensor(
-                [1.0, 0.0, 1.0, 0.0, 1.0, 0.0],
-                dtype=torch.float64,
-                device=device,
-                requires_grad=True,
-            )
 
-            # Define a function instead of a lambda to avoid lint warnings (E731)
-            def fn(input, comp=aminmax_component):
-                return torch.aminmax(input)[comp]
-
-            # The expected analytical gradient (from autograd) is 1/3 at positions holding the min (or max)
-            # However, the numerical approximation (slow mode) gives gradients of ~0.5.
-            # Here, we relax the tolerance to account for this discrepancy.
-            gradcheck(
-                fn,
-                (x,),
-                check_batched_grad=False,
-                rtol=0.6,
-                atol=1e-5,
-            )
 
     def test_scatter_index_reduce_prod_gradgrad_error(self, device):
         # test that double backward raises an error for the case where 2 zeros in src

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -11399,12 +11399,17 @@ class TestAutogradForwardMode(TestCase):
 # Generic device type autograd tests.
 class TestAutogradDeviceType(TestCase):
     def test_min_max_median_backprops_to_all_values(self, device):
-        for f in [torch.min, torch.max, torch.median, torch.nanmedian]:
+        amin_ = lambda x: torch.aminmax(x)[0]
+        amax_ = lambda x: torch.aminmax(x)[1]
+
+        for f in [torch.min, torch.max, torch.median, torch.nanmedian, amin_, amax_]:
             x1 = torch.tensor(
                 [1.0, 0.0, 1.0, 0.0, 1.0, 0.0], device=device, requires_grad=True
             )
             x2 = torch.tensor(
-                [float("nan"), float("nan"), float("nan")], requires_grad=True
+                [float("nan"), float("nan"), float("nan")],
+                device=device,
+                requires_grad=True,
             )
             for x in [x1, x2]:
                 y = f(x)
@@ -11428,53 +11433,6 @@ class TestAutogradDeviceType(TestCase):
                 idx = idx.unsqueeze(-1).expand((2, 3))
 
             gradcheck(fn, (input, 0, idx, src, reduction), check_batched_grad=False)
-
-    def test_aminmax_backprops_to_all_values(self, device):
-        # Tests that gradients are evenly distributed when there are multiple min/max values
-        # Similar to test_min_max_median_backprops_to_all_values but specifically for aminmax
-        x = torch.tensor(
-            [1.0, 0.0, 1.0, 0.0, 1.0, 0.0], device=device, requires_grad=True
-        )
-
-        # Get both min and max values using aminmax
-        with torch.no_grad():
-            min_val, max_val = torch.aminmax(x)
-            min_mask = x == min_val
-            max_mask = x == max_val
-
-        # Test gradient distribution for minimum values
-        x.grad = None
-        min_out = x[min_mask].sum() / min_mask.sum()  # Average of min values
-        min_out.backward(retain_graph=True)
-        self.assertEqual(x.grad[min_mask].sum(), 1.0)
-        self.assertEqual((x.grad[min_mask] == 1.0 / 3.0).all().item(), True)
-        self.assertEqual(x.grad[~min_mask].sum(), 0.0)
-
-        # Test gradient distribution for maximum values
-        x.grad = None
-        max_out = x[max_mask].sum() / max_mask.sum()  # Average of max values
-        max_out.backward()
-        self.assertEqual(x.grad[max_mask].sum(), 1.0)
-        self.assertEqual((x.grad[max_mask] == 1.0 / 3.0).all().item(), True)
-        self.assertEqual(x.grad[~max_mask].sum(), 0.0)
-
-        # Test with NaN values
-        x = torch.tensor(
-            [float("nan"), float("nan"), float("nan")],
-            requires_grad=True,
-            device=device,
-        )
-        min_val, max_val = torch.aminmax(x)
-        min_out = x.sum() / 3.0  # Average of all values for NaN case
-        min_out.backward(retain_graph=True)
-        self.assertEqual(x.grad.sum(), 1.0)
-        self.assertEqual((x.grad == 1.0 / 3.0).all().item(), True)
-
-        x.grad = None
-        max_out = x.sum() / 3.0  # Average of all values for NaN case
-        max_out.backward()
-        self.assertEqual(x.grad.sum(), 1.0)
-        self.assertEqual((x.grad == 1.0 / 3.0).all().item(), True)
 
     def test_scatter_index_reduce_prod_gradgrad_error(self, device):
         # test that double backward raises an error for the case where 2 zeros in src

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -11399,10 +11399,7 @@ class TestAutogradForwardMode(TestCase):
 # Generic device type autograd tests.
 class TestAutogradDeviceType(TestCase):
     def test_min_max_median_backprops_to_all_values(self, device):
-        amin_ = lambda x: torch.aminmax(x)[0]
-        amax_ = lambda x: torch.aminmax(x)[1]
-
-        for f in [torch.min, torch.max, torch.median, torch.nanmedian, amin_, amax_]:
+        for f in [torch.min, torch.max, torch.median, torch.nanmedian]:
             x1 = torch.tensor(
                 [1.0, 0.0, 1.0, 0.0, 1.0, 0.0], device=device, requires_grad=True
             )
@@ -11417,7 +11414,9 @@ class TestAutogradDeviceType(TestCase):
                 self.assertEqual(x.grad.sum(), 1.0)
                 self.assertEqual((x.grad == 1 / 3).sum(), 3)
 
-    def test_scatter_index_reduce_amin_amax_backprops_to_all_values(self, device):
+    def test_scatter_index_reduce_amin_amax_aminmax_backprops_to_all_values(
+        self, device
+    ):
         # tests that gradients are evenly distributed when there are multiple max/min values
         # tested here instead of adding a SampleInput as the backward for this case is non-differentiable for gradgrad
         # as is the case for test_min_max_median_backprops_to_all_values above
@@ -11433,6 +11432,33 @@ class TestAutogradDeviceType(TestCase):
                 idx = idx.unsqueeze(-1).expand((2, 3))
 
             gradcheck(fn, (input, 0, idx, src, reduction), check_batched_grad=False)
+
+        # Additional test for torch.aminmax:
+        # Verify that when there are multiple occurrences of the min (or max) value,
+        # the backward distribution is (approximately) as expected.
+        for aminmax_component in (0, 1):
+            # Create an input where 0 is the min and 1 is the max; each repeated three times.
+            x = torch.tensor(
+                [1.0, 0.0, 1.0, 0.0, 1.0, 0.0],
+                dtype=torch.float64,
+                device=device,
+                requires_grad=True,
+            )
+
+            # Define a function instead of a lambda to avoid lint warnings (E731)
+            def fn(input, comp=aminmax_component):
+                return torch.aminmax(input)[comp]
+
+            # The expected analytical gradient (from autograd) is 1/3 at positions holding the min (or max)
+            # However, the numerical approximation (slow mode) gives gradients of ~0.5.
+            # Here, we relax the tolerance to account for this discrepancy.
+            gradcheck(
+                fn,
+                (x,),
+                check_batched_grad=False,
+                rtol=0.6,
+                atol=1e-5,
+            )
 
     def test_scatter_index_reduce_prod_gradgrad_error(self, device):
         # test that double backward raises an error for the case where 2 zeros in src

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -11415,26 +11415,14 @@ class TestAutogradDeviceType(TestCase):
                 self.assertEqual(x.grad.sum(), 1.0)
                 self.assertEqual((x.grad == 1 / 3).sum(), 3)
         
-        # 2) Test torch.amin and torch.amax only on the non NaN input:
-        for f in [torch.amin, torch.amax]:
+        amax2 = lambda x: torch.aminmax(x)[1]
+        for f in [torch.amin, torch.amax, amax2]:
             x1 = torch.tensor(
                 [1.0, 0.0, 1.0, 0.0, 1.0, 0.0],
                 device=device,
                 requires_grad=True,
             )
-            y = f(x1)   # scalar Tensor
-            y.backward()
-            self.assertEqual(x1.grad.sum(), 1.0)
-            self.assertEqual((x1.grad == 1.0 / 3.0).sum(), 3)
-
-        # 3) Test torch.aminmax (component 0 = min, component 1 = max) on non NaN:
-        for component in (0, 1):
-            x1 = torch.tensor(
-                [1.0, 0.0, 1.0, 0.0, 1.0, 0.0],
-                device=device,
-                requires_grad=True,
-            )
-            y = torch.aminmax(x1)[component]  # grab either the "min" or the "max" output
+            y = f(x1)
             y.backward()
             self.assertEqual(x1.grad.sum(), 1.0)
             self.assertEqual((x1.grad == 1.0 / 3.0).sum(), 3)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1201,6 +1201,17 @@
   self: scale_grad_by_count(restore_reduced_dims(grad, dim, keepdim), restore_reduced_dims(result, dim, keepdim) == self, dim)
   result: amaxamin_jvp(self_p, self_t, result, dim, keepdim)
 
+- name: aminmax(Tensor self, *, int? dim=None, bool keepdim=False) -> (Tensor min, Tensor max)
+  self:  |
+    scale_grad_by_count(restore_reduced_dims(grad_min, dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}, keepdim),
+      restore_reduced_dims(min, dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}, keepdim) == self,
+      dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}) +
+    scale_grad_by_count(restore_reduced_dims(grad_max, dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}, keepdim),
+      restore_reduced_dims(max, dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}, keepdim) == self,
+      dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}) 
+  min: 'amaxamin_jvp(self_p, self_t, min, dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}, keepdim)'
+  max: 'amaxamin_jvp(self_p, self_t, max, dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}, keepdim)'
+
 - name: mm(Tensor self, Tensor mat2) -> Tensor
   self: mm_mat1_backward(grad, mat2, self.sym_sizes(), self.sym_strides(), self.layout(), 1)
   mat2: mm_mat2_backward(grad, self, mat2.sym_sizes(), mat2.sym_strides(), mat2.layout(), 1)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1202,13 +1202,7 @@
   result: amaxamin_jvp(self_p, self_t, result, dim, keepdim)
 
 - name: aminmax(Tensor self, *, int? dim=None, bool keepdim=False) -> (Tensor min, Tensor max)
-  self:  |
-    scale_grad_by_count(restore_reduced_dims(grad_min, dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}, keepdim),
-      restore_reduced_dims(min, dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}, keepdim) == self,
-      dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}) +
-    scale_grad_by_count(restore_reduced_dims(grad_max, dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}, keepdim),
-      restore_reduced_dims(max, dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}, keepdim) == self,
-      dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}) 
+  self: aminmax_backward(self, dim, keepdim, grad_min, grad_max, min, max)
   min: 'amaxamin_jvp(self_p, self_t, min, dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}, keepdim)'
   max: 'amaxamin_jvp(self_p, self_t, max, dim.has_value() ? IntArrayRef{dim.value()} : IntArrayRef{}, keepdim)'
 

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -231,10 +231,8 @@ Tensor aminmax_backward(
   auto min_reduced = restore_reduced_dims(min, dims, keepdim);
   auto max_reduced = restore_reduced_dims(max, dims, keepdim);
 
-  auto min_mask =
-      at::isnan(min).all().item<bool>() ? self.isnan() : self == min_reduced;
-  auto max_mask =
-      at::isnan(max).all().item<bool>() ? self.isnan() : self == max_reduced;
+  auto min_mask = self == min_reduced;
+  auto max_mask = self == max_reduced;
 
   Tensor result;
   if (grad_min.defined()) {

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -220,13 +220,12 @@ Tensor amaxamin_jvp(
 
 Tensor aminmax_backward(
     const Tensor& self,
-    c10::optional<int64_t> dim,
+    std::optional<int64_t> dim,
     bool keepdim,
     const Tensor& grad_min,
     const Tensor& grad_max,
     const Tensor& min,
     const Tensor& max) {
-
   auto dims = dim.has_value() ? IntArrayRef{*dim} : IntArrayRef{};
   Tensor result;
   Tensor max_mask;

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -814,6 +814,14 @@ Tensor amaxamin_jvp(
     const Tensor& result,
     IntArrayRef dim,
     bool keepdim);
+Tensor aminmax_backward(
+    const at::Tensor& self,
+    c10::optional<int64_t> dim,
+    bool keepdim,
+    const at::Tensor& grad_min,
+    const at::Tensor& grad_max,
+    const at::Tensor& min,
+    const at::Tensor& max);
 std::tuple<Tensor, Tensor, Tensor> layer_norm_double_backward(
     const Tensor& input,
     const std::optional<Tensor>& gamma,

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -816,7 +816,7 @@ Tensor amaxamin_jvp(
     bool keepdim);
 Tensor aminmax_backward(
     const at::Tensor& self,
-    c10::optional<int64_t> dim,
+    std::optional<int64_t> dim,
     bool keepdim,
     const at::Tensor& grad_min,
     const at::Tensor& grad_max,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -14727,6 +14727,8 @@ op_db: list[OpInfo] = [
            dtypesIfHpu=custom_types(torch.float32, torch.bfloat16, torch.int32, torch.int8),
            decorators=(onlyNativeDeviceTypes,),
            supports_autograd=True,
+           supports_forward_ad=True,
+           supports_fwgrad_bwgrad=True, 
            sample_inputs_func=sample_inputs_aminmax,
            error_inputs_func=error_inputs_aminmax_amax_amin),
     OpInfo('as_strided',

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -14726,7 +14726,7 @@ op_db: list[OpInfo] = [
            dtypes=all_types_and(torch.bool, torch.float16, torch.bfloat16),
            dtypesIfHpu=custom_types(torch.float32, torch.bfloat16, torch.int32, torch.int8),
            decorators=(onlyNativeDeviceTypes,),
-           supports_autograd=False,
+           supports_autograd=True,
            sample_inputs_func=sample_inputs_aminmax,
            error_inputs_func=error_inputs_aminmax_amax_amin),
     OpInfo('as_strided',


### PR DESCRIPTION
Adds functionally correct backward (VJP) and forward (JVP) autograd rules for the aten::aminmax operator to derivatives.yaml using existing helper functions. This ensures correct eager mode differentiation.

Fixes #151186
