### PR TITLE
Update docs for torch.device

### DIFF
--- a/docs/source/tensor_attributes.rst
+++ b/docs/source/tensor_attributes.rst
@@ -153,7 +153,7 @@ A :class:`torch.device` can be constructed using:
 
   * A device string, which is a string representation of the device type and optionally the device ordinal.
   * A device type and a device ordinal.
-  * A device ordinal, which is treated as the current :ref:`accelerator<accelerators>` type.
+  * A device ordinal, where the current :ref:`accelerator<accelerators>` type will be used.
 
 Via a device string:
 ::
@@ -167,7 +167,7 @@ Via a device string:
     >>> torch.device('mps')
     device(type='mps')
 
-    >>> torch.device('cuda')  # current cuda device index
+    >>> torch.device('cuda')  # implicit index is the "current device index"
     device(type='cuda')
 
 Via a device type and a device ordinal:

--- a/docs/source/tensor_attributes.rst
+++ b/docs/source/tensor_attributes.rst
@@ -150,8 +150,11 @@ the result of :func:`torch.cuda.current_device()`.
 A :class:`torch.Tensor`'s device can be accessed via the :attr:`Tensor.device` property.
 
 A :class:`torch.device` can be constructed using:
+
 1. A device string, which is a string representation of the device type and optionally the device ordinal.
+
 2. A device type and a device ordinal.
+
 3. A device ordinal, which is treated as the current :ref:`accelerator<accelerators>` type.
 
 Via a device string:
@@ -183,6 +186,7 @@ Via a device type and a device ordinal:
     device(type='cpu', index=0)
 
 Via a device ordinal:
+
 .. note::
    This method will raise a RuntimeError if no accelerator is currently detected.
 

--- a/docs/source/tensor_attributes.rst
+++ b/docs/source/tensor_attributes.rst
@@ -184,7 +184,7 @@ Via a device type and a device ordinal:
 
 Via a device ordinal:
 .. note::
-   This will raise a RuntimeError if no accelerator is currently detected.
+   This method will raise a RuntimeError if no accelerator is currently detected.
 
 ::
 
@@ -230,6 +230,14 @@ non-None device argument.  To globally change the default device, see also
 
    >>> # You can substitute the torch.device with a string
    >>> torch.randn((2,3), device='cuda:1')
+
+.. note::
+   Methods which take a device will generally accept a (properly formatted) string
+   or an integer device ordinal, i.e. the following are all equivalent:
+
+   >>> torch.randn((2,3), device=torch.device('cuda:1'))
+   >>> torch.randn((2,3), device='cuda:1')
+   >>> torch.randn((2,3), device=1)  # equivalent to 'cuda:1' if the current accelerator is cuda
 
 .. note::
    Tensors are never moved automatically between devices and require an explicit call from the user. Scalar Tensors (with tensor.dim()==0) are the only exception to this rule and they are automatically transferred from CPU to GPU when needed as this operation can be done "for free".

--- a/docs/source/tensor_attributes.rst
+++ b/docs/source/tensor_attributes.rst
@@ -150,6 +150,7 @@ the result of :func:`torch.cuda.current_device()`.
 A :class:`torch.Tensor`'s device can be accessed via the :attr:`Tensor.device` property.
 
 A :class:`torch.device` can be constructed using:
+
   * A device string, which is a string representation of the device type and optionally the device ordinal.
   * A device type and a device ordinal.
   * A device ordinal, which is treated as the current :ref:`accelerator<accelerators>` type.

--- a/docs/source/tensor_attributes.rst
+++ b/docs/source/tensor_attributes.rst
@@ -150,12 +150,9 @@ the result of :func:`torch.cuda.current_device()`.
 A :class:`torch.Tensor`'s device can be accessed via the :attr:`Tensor.device` property.
 
 A :class:`torch.device` can be constructed using:
-
-1. A device string, which is a string representation of the device type and optionally the device ordinal.
-
-2. A device type and a device ordinal.
-
-3. A device ordinal, which is treated as the current :ref:`accelerator<accelerators>` type.
+  * A device string, which is a string representation of the device type and optionally the device ordinal.
+  * A device type and a device ordinal.
+  * A device ordinal, which is treated as the current :ref:`accelerator<accelerators>` type.
 
 Via a device string:
 ::

--- a/docs/source/tensor_attributes.rst
+++ b/docs/source/tensor_attributes.rst
@@ -149,9 +149,12 @@ the result of :func:`torch.cuda.current_device()`.
 
 A :class:`torch.Tensor`'s device can be accessed via the :attr:`Tensor.device` property.
 
-A :class:`torch.device` can be constructed via a string or via a string and device ordinal
+A :class:`torch.device` can be constructed using:
+1. A device string, which is a string representation of the device type and optionally the device ordinal.
+2. A device type and a device ordinal.
+3. A device ordinal, which is treated as the current :ref:`accelerator<accelerators>` type.
 
-Via a string:
+Via a device string:
 ::
 
     >>> torch.device('cuda:0')
@@ -163,10 +166,10 @@ Via a string:
     >>> torch.device('mps')
     device(type='mps')
 
-    >>> torch.device('cuda')  # current cuda device
+    >>> torch.device('cuda')  # current cuda device index
     device(type='cuda')
 
-Via a string and device ordinal:
+Via a device type and a device ordinal:
 
 ::
 
@@ -178,6 +181,23 @@ Via a string and device ordinal:
 
     >>> torch.device('cpu', 0)
     device(type='cpu', index=0)
+
+Via a device ordinal:
+.. note::
+   This will raise a RuntimeError if no accelerator is currently detected.
+
+::
+
+    >>> torch.device(0)  # the current accelerator is cuda
+    device(type='cuda', index=0)
+
+    >>> torch.device(1)  # the current accelerator is xpu
+    device(type='xpu', index=1)
+
+    >>> torch.device(0)  # no current accelerator detected
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+    RuntimeError: Cannot access accelerator device when none is available.
 
 The device object can also be used as a context manager to change the default
 device tensors are allocated on:
@@ -210,23 +230,6 @@ non-None device argument.  To globally change the default device, see also
 
    >>> # You can substitute the torch.device with a string
    >>> torch.randn((2,3), device='cuda:1')
-
-.. note::
-   For legacy reasons, a device can be constructed via a single device ordinal, which is treated
-   as the current :ref:`accelerator<accelerators>` type.
-   This matches :meth:`Tensor.get_device`, which returns an ordinal for device
-   tensors and is not supported for cpu tensors.
-
-   >>> torch.device(1)
-   device(type='cuda', index=1)
-
-.. note::
-   Methods which take a device will generally accept a (properly formatted) string
-   or (legacy) integer device ordinal, i.e. the following are all equivalent:
-
-   >>> torch.randn((2,3), device=torch.device('cuda:1'))
-   >>> torch.randn((2,3), device='cuda:1')
-   >>> torch.randn((2,3), device=1)  # legacy
 
 .. note::
    Tensors are never moved automatically between devices and require an explicit call from the user. Scalar Tensors (with tensor.dim()==0) are the only exception to this rule and they are automatically transferred from CPU to GPU when needed as this operation can be done "for free".


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #156686

# Motivation
Update the doc, to make `torch.device`'s constructor officially support the following methods:
- A device string, which is a string representation of the device type and optionally the device ordinal.
- A device type and a device ordinal.
- A device ordinal, which is treated as the current accelerator type.

# Additional Context
fix https://github.com/pytorch/pytorch/issues/156519

cc @albanD @EikanWang