### PR TITLE
FIxed #156075 Added dim= None for `torch.logsumexp`

### DIFF
--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -824,8 +824,10 @@ def log_softmax(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
 )
 def logsumexp(
-    self: TensorLikeType, dim: DimsType, keepdim: bool = False
+    self: TensorLikeType, dim: DimsType = None, keepdim: bool = False
 ) -> TensorLikeType:
+    if dim is None:
+        dim = tuple(range(self.ndim))
     if not isinstance(dim, Iterable):
         dim = (dim,)
     if self.numel() == 0:


### PR DESCRIPTION
Fixes #156075 
Added dim=None support by making the dim a tuple of all the existing dimension of tensor

cc @albanD 
