### PR TITLE
[distributed] Enable H100 test for all distributed related changes

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -329,7 +329,8 @@ test_h100_distributed() {
   time python test/run_test.py --include distributed/_composable/fsdp/test_fully_shard_comm.py -k TestFullyShardAllocFromPG $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   # symmetric memory test
   time python test/run_test.py --include distributed/test_symmetric_memory.py  $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
-  time python test/run_test.py --include distributed/test_nvshmem.py $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time TORCH_SYMMMEM=NVSHMEM python test/run_test.py --include distributed/test_nvshmem.py $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time TORCH_SYMMMEM=NCCL python test/run_test.py --include distributed/test_nccl.py $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   assert_git_not_dirty
 }
 

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -329,8 +329,8 @@ test_h100_distributed() {
   time python test/run_test.py --include distributed/_composable/fsdp/test_fully_shard_comm.py -k TestFullyShardAllocFromPG $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   # symmetric memory test
   time python test/run_test.py --include distributed/test_symmetric_memory.py  $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
-  time TORCH_SYMMMEM=NVSHMEM python test/run_test.py --include distributed/test_nvshmem.py $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
-  time TORCH_SYMMMEM=NCCL python test/run_test.py --include distributed/test_nccl.py $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include distributed/test_nvshmem.py $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include distributed/test_nccl.py $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   assert_git_not_dirty
 }
 

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -330,7 +330,6 @@ test_h100_distributed() {
   # symmetric memory test
   time python test/run_test.py --include distributed/test_symmetric_memory.py  $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   time python test/run_test.py --include distributed/test_nvshmem.py $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
-  time python test/run_test.py --include distributed/test_nccl.py $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   assert_git_not_dirty
 }
 

--- a/.github/label_to_label.yml
+++ b/.github/label_to_label.yml
@@ -53,7 +53,7 @@
   - "release notes: distributed (symm_mem)"
   - "release notes: distributed (pipeline)"
   - "release notes: distributed (fsdp)"
-  - "release notes: distributed (fsdp)"
+  - "release notes: distributed (dtensor)"
   - "oncall: distributed"
   then:
   - "ciflow/h100-distributed"

--- a/.github/label_to_label.yml
+++ b/.github/label_to_label.yml
@@ -48,3 +48,12 @@
   - "module: dynamic shapes"
   then:
   - "oncall: pt2"
+- any:
+  - "release notes: distributed (c10d)"
+  - "release notes: distributed (symm_mem)"
+  - "release notes: distributed (pipeline)"
+  - "release notes: distributed (fsdp)"
+  - "release notes: distributed (fsdp)"
+  - "oncall: distributed"
+  then:
+  - "ciflow/h100-distributed"

--- a/.github/workflows/h100-distributed.yml
+++ b/.github/workflows/h100-distributed.yml
@@ -2,8 +2,7 @@ name: Limited CI for distributed tests on H100
 
 on:
   pull_request:
-    paths:
-      - .github/workflows/h100-distributed.yml
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
   push:
     tags:
@@ -16,7 +15,7 @@ concurrency:
 jobs:
 
   get-label-type:
-    if: github.repository_owner == 'pytorch'
+    if: "github.repository_owner == 'pytorch' || contains(join(github.event.pull_request.labels.*.name, ','), 'ciflow/h100-distributed') || contains(github.event.pull_request.labels.*.name, 'oncall: distributed')"
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:

--- a/.github/workflows/h100-distributed.yml
+++ b/.github/workflows/h100-distributed.yml
@@ -1,12 +1,16 @@
 name: Limited CI for distributed tests on H100
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
-  workflow_dispatch:
   push:
+    branches:
+      - main
+      - release/*
+      - landchecks/*
     tags:
       - ciflow/h100-distributed/*
+  workflow_dispatch:
+  schedule:
+    - cron: 46 8 * * *  # about 1:46am PDT
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
@@ -15,7 +19,7 @@ concurrency:
 jobs:
 
   get-label-type:
-    if: "github.repository_owner == 'pytorch' || contains(join(github.event.pull_request.labels.*.name, ','), 'ciflow/h100-distributed') || contains(github.event.pull_request.labels.*.name, 'oncall: distributed')"
+    if: github.repository_owner == 'pytorch'
     name: get-label-type
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:

--- a/.github/workflows/h100-distributed.yml
+++ b/.github/workflows/h100-distributed.yml
@@ -1,14 +1,13 @@
 name: Limited CI for distributed tests on H100
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/h100-distributed.yml
+  workflow_dispatch:
   push:
-    branches:
-      - main
-      - release/*
-      - landchecks/*
     tags:
       - ciflow/h100-distributed/*
-  workflow_dispatch:
   schedule:
     - cron: 46 8 * * *  # about 1:46am PDT
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #156721

We want to run H100 CI for distributed related changes. We already have a labeling of oncall:distributed when touching distributed related code: https://github.com/pytorch/pytorch/blob/4491326fb0c0e67eca1598ae33c41cdfced2cd33/.github/labeler.yml#L94. So we want to leverage that.


cc @H-Huang @awgu @wanchaol @fegin @wz337 @wconstab @d4l3k