### PR TITLE
[ROCm][SymmetricMemory] Performance improvements for two-shot allreduce

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryOps.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryOps.cu
@@ -402,7 +402,6 @@ at::Tensor multimem_all_gather_out(
 // count to 512 to prevent/alleviate register spill.
 constexpr size_t one_shot_all_reduce_max_num_blocks = 24;
 constexpr size_t one_shot_all_reduce_max_num_threads = 512;
-
 template <typename T, int alignment, int k_world_size>
 static __launch_bounds__(one_shot_all_reduce_max_num_threads) __global__
     void one_shot_all_reduce_kernel(
@@ -561,9 +560,13 @@ at::Tensor one_shot_all_reduce_copy(
       input, local_input, reduce_op, group_name, out);
 }
 
+#if defined(USE_ROCM)
+constexpr size_t two_shot_all_reduce_max_num_blocks = 64;
+constexpr size_t two_shot_all_reduce_max_num_threads = 128;
+#else
 constexpr size_t two_shot_all_reduce_max_num_blocks = 24;
 constexpr size_t two_shot_all_reduce_max_num_threads = 1024;
-
+#endif
 template <
     typename T,
     int alignment,

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryOps.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryOps.cu
@@ -621,6 +621,10 @@ static __launch_bounds__(two_shot_all_reduce_max_num_threads) __global__
     return;
   }
   __syncthreads();
+#if defined (USE_ROCM)
+  //Reducing serialization of ld_vec
+  //Check if numel is met (which it is not most of the time),
+  //this is then not checked inside the loop.
   T* ptr_vec[k_world_size] = {NULL};
 #pragma unroll k_world_size
   for (size_t step = 0; step < k_world_size; ++step) {
@@ -652,6 +656,20 @@ static __launch_bounds__(two_shot_all_reduce_max_num_threads) __global__
       tmp[step] = at::native::memory::ld_vec<alignment>(
           ptr_vec[step] + input_offset + remote_start + i);
     }
+#else
+  for (size_t i = offset; i < numel_per_rank; i += stride) {
+    Vec<alignment> tmp[k_world_size];
+#pragma unroll k_world_size
+    for (size_t step = 0; step < k_world_size; ++step) {
+      size_t remote_rank = (rank + step) % k_world_size;
+      size_t remote_start = numel_per_rank * remote_rank;
+      if (remote_start + i >= numel) {
+        continue;
+      }
+      tmp[step] = at::native::memory::ld_vec<alignment>(
+          input_ptrs[remote_rank] + input_offset + remote_start + i);
+    }
+#endif
 #pragma unroll k_world_size
     for (size_t step = 0; step < k_world_size; ++step) {
       size_t remote_rank = (rank + step) % k_world_size;

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryOps.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryOps.cu
@@ -629,7 +629,7 @@ static __launch_bounds__(two_shot_all_reduce_max_num_threads) __global__
       size_t remote_start = numel_per_rank * remote_rank;
 #if defined (USE_ROCM)
       tmp[step] = at::native::memory::ld_vec<alignment>(
-          input_ptrs[remote_rank] + input_offset + max(remote_start + i, numel-1));
+          input_ptrs[remote_rank] + input_offset + min(remote_start + i, numel-1));
 #else
       if (remote_start + i >= numel) {
         continue;

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryOps.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryOps.cu
@@ -623,24 +623,40 @@ static __launch_bounds__(two_shot_all_reduce_max_num_threads) __global__
   __syncthreads();
   for (size_t i = offset; i < numel_per_rank; i += stride) {
     Vec<alignment> tmp[k_world_size];
+    T* ptrs_vec[k_world_size];
+    bool actv_vec[k_world_size];
+    size_t remote_start[k_world_size];
 #pragma unroll k_world_size
     for (size_t step = 0; step < k_world_size; ++step) {
       size_t remote_rank = (rank + step) % k_world_size;
-      size_t remote_start = numel_per_rank * remote_rank;
-      if (remote_start + i >= numel) {
+//      size_t remote_start = numel_per_rank * remote_rank;
+//      if (remote_start + i >= numel) {
+      remote_start[step] = numel_per_rank * remote_rank;
+      if (remote_start[step] + i >= numel) {
+        actv_vec[step] = false;
         continue;
       }
-      tmp[step] = at::native::memory::ld_vec<alignment>(
-          input_ptrs[remote_rank] + input_offset + remote_start + i);
+//      tmp[step] = at::native::memory::ld_vec<alignment>(
+//          input_ptrs[remote_rank] + input_offset + remote_start + i);
+      actv_vec[step] = true;
+      ptrs_vec[step] = input_ptrs[remote_rank];
     }
 #pragma unroll k_world_size
     for (size_t step = 0; step < k_world_size; ++step) {
-      size_t remote_rank = (rank + step) % k_world_size;
-      size_t remote_start = numel_per_rank * remote_rank;
-      if (remote_start + i >= numel) {
-        continue;
-      }
-      at::native::memory::st_vec<alignment>(output_ptr + remote_start + i, tmp[step]);
+      if (actv_vec[step])
+        tmp[step] = at::native::memory::ld_vec<alignment>(
+          ptrs_vec[step] + input_offset + remote_start[step] + i);
+     }
+#pragma unroll k_world_size
+    for (size_t step = 0; step < k_world_size; ++step) {
+//      size_t remote_rank = (rank + step) % k_world_size;
+//      size_t remote_start = numel_per_rank * remote_rank;
+//      if (remote_start + i >= numel) {
+//        continue;
+//      }
+//      at::native::memory::st_vec<alignment>(output_ptr + remote_start + i, tmp[step]);
+      if (actv_vec[step])
+        at::native::memory::st_vec<alignment>(output_ptr + remote_start[step] + i, tmp[step]);
     }
   }
   // need to make sure all blocks exit simultaneously so that the data


### PR DESCRIPTION
The biggest bottleneck that we found with two-shot allreduce was that the compiler was serializing all the load operations for some reason. To avoid these load delays, we've added de-serialization of loads. Along with this improvement, we also found that on AMD GPUs a different block and thread size gives a nice performance boost. Here are the bandwidth numbers I am getting with this PR:
![image](https://github.com/user-attachments/assets/57005856-4cb5-43cd-8e9c-46869f75ab0b)


The rows that are green are the tensor sizes that we are interested in because two-shot is only used for bigger sizes (one-shot is used for smaller sizes). As we can see, our baseline numbers wrt to fbgemm numbers were consistently underperforming. However, with this deserialize change, most of the tensor sizes have a performance boost (positive %) for the green tensors. There's one tensor with negative performance, but that's within error margin. 

co-authored by: @amd-hhashemi 
https://github.com/pytorch/FBGEMM/issues/4072

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd