### PR TITLE
Don't log pt2 compile event for coordesc tuning

### DIFF
--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1036,7 +1036,7 @@ class CachingAutotuner(KernelInterface):
         """
         with dynamo_timed(
             "CachingAutotuner.coordinate_descent_tuning",
-            log_pt2_compile_event=True,
+            log_pt2_compile_event=False,
             metadata={"kernel_name": self.inductor_meta.get("kernel_name")},
             dynamo_compile_column_us="runtime_triton_autotune_time_us",
             compile_id=self.compile_id,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #156764

This event is slamming our Scuba quota, accounting for ~60% of all events in the last few days. We'll figure out a better way of logging these events to pt2_compile_events, perhaps in a bigger aggregate. For now, let's cut them.

Differential Revision: [D77265794](https://our.internmc.facebook.com/intern/diff/D77265794/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov