### PR TITLE
Revert D77053918: Multisect successfully blamed "D77053918: [logging] dynamo_timed for CachingAutotuner.coordinate_descent_tuning (#156517)" for one test failure

### DIFF
--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1034,19 +1034,6 @@ class CachingAutotuner(KernelInterface):
         Then if coordinate desecnt tuning is run with max-autotune disabled, it will start from C1;
         while if coordinate descent tuning is run with max-autotune enabled, it will start from C3.
         """
-        with dynamo_timed(
-            "CachingAutotuner.coordinate_descent_tuning",
-            log_pt2_compile_event=True,
-            metadata={"kernel_name": self.inductor_meta.get("kernel_name")},
-            dynamo_compile_column_us="runtime_triton_autotune_time_us",
-            compile_id=self.compile_id,
-            is_backward=self.is_backward,
-            log_waitcounter=True,
-            waitcounter_name_override="triton_autotuner",
-        ):
-            return self._coordinate_descent_tuning(launcher, *args, **kwargs)
-
-    def _coordinate_descent_tuning(self, launcher, *args, **kwargs):
         if (
             self.heuristic_type == HeuristicType.TEMPLATE
             or self.heuristic_type == HeuristicType.USER_AUTOTUNE


### PR DESCRIPTION
Summary:
This diff reverts D77053918
D77053918: [logging] dynamo_timed for CachingAutotuner.coordinate_descent_tuning (#156517) by masnesral causes the following test failure:

Tests affected:
- [cogwheel:cogwheel_py_predictor_apps_mgp_background_gen_segmentation_test_v10p#test_outputs_match](https://www.internalfb.com/intern/test/562950115999503/)

Here's the Multisect link:
https://www.internalfb.com/multisect/30047707
Here are the tasks that are relevant to this breakage:
T197066277: 10+ tests, 10+ CI signals failing for mgenai_lon

The backout may land if someone accepts it.

If this diff has been generated in error, you can Commandeer and Abandon it.

Depends on D77053918

Test Plan:
NA

Rollback Plan:

Reviewed By: aorenste

Differential Revision: D77238401




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov