### PR TITLE
Add torch._functorch.config.on_backward_autocast_mismatch

### DIFF
--- a/docs/source/torch.compiler.md
+++ b/docs/source/torch.compiler.md
@@ -97,6 +97,7 @@ Some of the most commonly used backends include:
    torch.compiler_troubleshooting
    torch.compiler_performance_dashboard
    torch.compiler_inductor_provenance
+   torch.compiler_backward_pass_autocast.md
 ```
 
 % _If you want to contribute a developer-level topic

--- a/torch.compiler_backward_pass_autocast.md
+++ b/torch.compiler_backward_pass_autocast.md
@@ -1,0 +1,74 @@
+``torch._functorch.config.backward_pass_autocast``
+--------------------------------------------------
+
+``torch.compile`` traces out a backward graph at the time of the forward pass.
+As so, it assumes something about if the backward pass will be run under an
+ambient autocast context manager. Use ``torch._functorch.config.backward_pass_autocast``
+to control that assumption; an incorrect assumption may lead to silent
+incorrectness.
+
+The options are either:
+
+- `"same_as_forward"`. We assume that the backward of the ``torch.compile``'ed region
+  will be run under the same autocast context manager that the region was run
+  under. Use this if your code looks like the following:
+
+  ```py
+  with torch.amp.autocast(...):
+      y = torch.compile(region)(x)
+      ...
+      # backward pass run under the same autocast context as the compiled region
+      z.backward()
+  ```
+
+- `"off"`. We assume that the backward of the torch.compile'd region will
+  not be run under any autocast context managers.
+  Use this if your code looks like the following:
+
+  ```py
+  with torch.amp.autocast(...):
+      y = torch.compile(region)(x)
+      ...
+  # Backward pass runs under no autocast.
+  z.backward()
+  ```
+
+- There is a third option. If you set ``torch._functorch.config.backward_pass_autocast``
+  to a list of kwargs, we will assume the backward pass runs under an autocast context
+  constructed by those kwargs.
+  
+  For example, if your code looks like the following:
+  ```py
+  y = torch.compile(region)(x)
+  ...
+  # Backward pass runs under special context manager
+  with torch.amp.autocast(**kwargs):
+      z.backward()
+  ```
+  then set ``torch._functorch.config.backward_pass_autocast = kwargs``.
+
+Applying the option
+===================
+
+Use ``patch`` to apply the option to a specific ``torch.compile`` call:
+
+```py
+with torch.amp.autocast(...):
+    with torch._functorch.config.patch(backward_pass_autocast="same_as_forward")
+    y = torch.compile(region)(x)
+    ...
+    # backward pass run under the same autocast context as the compiled region
+    z.backward()
+```
+
+Ignoring safety checks
+======================
+
+If, at runtime of the backward, ``torch.compile`` detects that there is an
+ambient autocast context manager set that is *different* from what
+``torch.compile`` assumed, and it materially would have changed the
+compiled function, then we will either `"do_nothing"`, `"warn"` or `"error"`
+depending on the value of ``torch._functorch.config.on_backward_autocast_mismatch``.
+
+If you think that we're wrong or that the check is too conservative, please set
+this to ``"do_nothing"`` and file an issue.

--- a/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
@@ -120,7 +120,7 @@ def aot_dispatch_export(
         fw_metadata=fw_metadata,
     )
     if needs_autograd and not aot_config.pre_dispatch:
-        graph, _, _ = aot_dispatch_autograd_graph(
+        graph, _, _, _ = aot_dispatch_autograd_graph(
             flat_fn, flat_args, aot_config, fw_metadata=fw_metadata
         )
     else:
@@ -1259,9 +1259,15 @@ def aot_dispatch_autograd(
 
     fw_metadata.deterministic = torch.are_deterministic_algorithms_enabled()
     with dynamo_timed("aot_trace_joint_graph", log_pt2_compile_event=True):
-        fx_g, joint_inputs, maybe_subclass_meta = aot_dispatch_autograd_graph(
+        (
+            fx_g,
+            joint_inputs,
+            maybe_subclass_meta,
+            bwd_autocast_state,
+        ) = aot_dispatch_autograd_graph(
             flat_fn, flat_args, aot_config, fw_metadata=fw_metadata
         )
+    fw_metadata.backward_autocast_state = bwd_autocast_state
 
     # Copied from aot_dispatch_autograd_graph.
     disable_amp = torch._C._is_any_autocast_enabled()

--- a/torch/_functorch/_aot_autograd/schemas.py
+++ b/torch/_functorch/_aot_autograd/schemas.py
@@ -469,6 +469,12 @@ class ViewAndMutationMeta:
 
     graphsafe_rng_state_index: Optional[int] = None
 
+    # If the backward graph was traced underneath any ambient autocast state,
+    # then this field records what that ambient autocast state was.
+    # This field is None if there was no ambient autocast state or if
+    # the ambient autocast state didn't affect the trace.
+    backward_autocast_state: Optional[dict[str, Any]] = None
+
     def __post_init__(self):
         # pre-compute the indices of the inputs that are mutated.
         # When keep_input_mutations is set, we don't need to worry about our epilogue

--- a/torch/_functorch/_aot_autograd/utils.py
+++ b/torch/_functorch/_aot_autograd/utils.py
@@ -85,7 +85,7 @@ def normalize_as_list(x):
     return [x]
 
 
-def _get_autocast_states() -> dict[str, Any]:
+def _get_autocast_states(*, include_cache_state=True) -> dict[str, Any]:
     """Returns a dict representing the current autocast state.
 
     The dict contains:
@@ -94,7 +94,8 @@ def _get_autocast_states() -> dict[str, Any]:
     enabled for autocast.
     """
     states: dict[str, Any] = {}
-    states["autocast_cache"] = torch.is_autocast_cache_enabled()
+    if include_cache_state:
+        states["autocast_cache"] = torch.is_autocast_cache_enabled()
     for device_type in torch._C._autocast_supported_devices():
         if hasattr(torch, device_type) and torch.is_autocast_enabled(device_type):
             states[device_type] = torch.get_autocast_dtype(device_type)

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -263,6 +263,14 @@ fake_tensor_propagate_real_tensors = False
 #       z.backward()
 backward_pass_autocast = "same_as_forward"
 
+# One of "do_nothing", "warn", and "error".
+# AOTDispatcher traces out a backward graph at the time of the forward pass.
+# If, at runtime, there is an autocast context manager that is set
+# that is *different* from what AOTDispatcher traced out in the forward,
+# and this will cause silent incorrectness, then we will either
+# do nothing / warn / error.
+on_backward_autocast_mismatch = "do_nothing"
+
 # This controls whether we collect donated buffer. This flag must be set
 # False if a user wants to retain_graph=True for backward.
 donated_buffer = False if is_fbcode() else True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #156780
* #156779
* #156739
* #156356

If we are able to detect that (1) autocast happened during the backward
pass and (2) the autocast state is different between what we assumed
while compiling the backward pass and runtime of the backward,
then we raise an error, warn, or do nothing depending on this config.

This is "best-effort": if the user specified to us to assume that no
autocast happens during the backward pass, then we are not able to tell
"if autocast happened during the backward pass", so the checks will
never fire.

I also added a doc page around this.

Test Plan:
- new tests