### PR TITLE
[inductor] initial triton static config lookup table

### DIFF
--- a/test/inductor/test_lookup_table.py
+++ b/test/inductor/test_lookup_table.py
@@ -1,0 +1,427 @@
+# Owner(s): ["module: inductor"]
+import json
+import os
+import tempfile
+from unittest.mock import patch
+
+import yaml
+
+import torch
+import torch._inductor.lookup_table
+from torch._inductor import config as inductor_config
+from torch._inductor.test_case import run_tests, TestCase
+
+
+class MockDevice:
+    def __init__(self, device_type="cuda", index=0):
+        self.type = device_type
+        self.index = index
+
+
+class MockInputNode:
+    def __init__(
+        self,
+        device_type="cuda",
+        device_index=0,
+        dtype=torch.float32,
+        size_hint=None,
+        stride_hint=None,
+    ):
+        self.device_type = device_type
+        self.device_index = device_index
+        self.dtype = dtype
+        self.size_hint = size_hint or [128, 128]
+        self.stride_hint = stride_hint or [128, 1]
+
+    def get_device(self):
+        return MockDevice(self.device_type, self.device_index)
+
+    def get_dtype(self):
+        return self.dtype
+
+
+class TestLookupTable(TestCase):
+    def setUp(self):
+        super().setUp()
+        # Reset the global lookup table before each test
+        self.original_table = None
+        self.addCleanup(self._cleanup_patches)
+
+    def _cleanup_patches(self):
+        # Reset any patches after each test
+        pass
+
+    @patch("torch._inductor.lookup_table.gemm_config_lookup_table")
+    @patch("torch._inductor.lookup_table._lookup_key")
+    @patch("torch.cuda.get_device_name")
+    def test_device_name_mismatch(
+        self, mock_get_device_name, mock_lookup_key, mock_lookup_table
+    ):
+        """Test when device name doesn't match any entry in lookup table"""
+        # Setup
+        mock_get_device_name.return_value = "NVIDIA GeForce RTX 3080"
+        mock_lookup_key.return_value = "test_lookup_key"
+
+        # Lookup table has different device name (NVIDIA H100)
+        mock_lookup_table = {
+            "mm": {"NVIDIA H100": {"test_lookup_key": "(128, 128, 64, 2, 2)"}}
+        }
+
+        input_nodes = [
+            MockInputNode(device_type="cuda", device_index=0),
+            MockInputNode(device_type="cuda", device_index=0),
+        ]
+
+        with patch(
+            "torch._inductor.lookup_table.gemm_config_lookup_table", mock_lookup_table
+        ):
+            result = torch._inductor.lookup_table.get_lookup_table(input_nodes, "mm")
+
+        # Should return empty dict when device name doesn't match
+        self.assertEqual(result, {})
+        mock_get_device_name.assert_called_once_with(0)
+        mock_lookup_key.assert_called_once_with(input_nodes)
+
+    @patch("torch._inductor.lookup_table.gemm_config_lookup_table")
+    @patch("torch._inductor.lookup_table._lookup_key")
+    @patch("torch.cuda.get_device_name")
+    def test_lookup_key_mismatch(
+        self, mock_get_device_name, mock_lookup_key, mock_lookup_table
+    ):
+        """Test when lookup key doesn't match any entry in lookup table"""
+        # Setup
+        mock_get_device_name.return_value = "NVIDIA H100"
+        mock_lookup_key.return_value = "non_existent_lookup_key"
+
+        # Lookup table has different lookup key
+        mock_lookup_table = {
+            "mm": {"NVIDIA H100": {"different_lookup_key": "(128, 128, 64, 2, 2)"}}
+        }
+
+        input_nodes = [
+            MockInputNode(device_type="cuda", device_index=0),
+            MockInputNode(device_type="cuda", device_index=0),
+        ]
+
+        with patch(
+            "torch._inductor.lookup_table.gemm_config_lookup_table", mock_lookup_table
+        ):
+            result = torch._inductor.lookup_table.get_lookup_table(input_nodes, "mm")
+
+        # Should return empty dict when lookup key doesn't match
+        self.assertEqual(result, {})
+        mock_get_device_name.assert_called_once_with(0)
+        mock_lookup_key.assert_called_once_with(input_nodes)
+
+    @patch("torch._inductor.lookup_table.gemm_config_lookup_table")
+    @patch("torch._inductor.lookup_table._lookup_key")
+    def test_device_type_mismatch(self, mock_lookup_key, mock_lookup_table):
+        """Test when device type is CPU instead of CUDA"""
+        # Setup
+        mock_lookup_key.return_value = "test_lookup_key"
+
+        # Lookup table has entry for CPU
+        mock_lookup_table = {"mm": {"cpu": {"test_lookup_key": "(128, 128, 64, 2, 2)"}}}
+
+        input_nodes = [
+            MockInputNode(device_type="cpu", device_index=0),
+            MockInputNode(device_type="cpu", device_index=0),
+        ]
+
+        with patch(
+            "torch._inductor.lookup_table.gemm_config_lookup_table", mock_lookup_table
+        ):
+            result = torch._inductor.lookup_table.get_lookup_table(input_nodes, "mm")
+
+        # Should return the lookup string for CPU device
+        expected_result = "(128, 128, 64, 2, 2)"
+        self.assertEqual(result, expected_result)
+        mock_lookup_key.assert_called_once_with(input_nodes)
+
+    @patch("torch._inductor.lookup_table.gemm_config_lookup_table")
+    @patch("torch._inductor.lookup_table._lookup_key")
+    @patch("torch.cuda.get_device_name")
+    def test_lookup_dict_hit(
+        self, mock_get_device_name, mock_lookup_key, mock_lookup_table
+    ):
+        """Test successful lookup that returns a lookup string"""
+        # Setup
+        mock_get_device_name.return_value = "NVIDIA H100"
+        mock_lookup_key.return_value = "test_lookup_key"
+
+        # Lookup table with matching entries
+        expected_lookup_result = "(128, 128, 64, 2, 2)"
+        mock_lookup_table = {
+            "mm": {"NVIDIA H100": {"test_lookup_key": expected_lookup_result}}
+        }
+
+        input_nodes = [
+            MockInputNode(device_type="cuda", device_index=0),
+            MockInputNode(device_type="cuda", device_index=0),
+        ]
+
+        with patch(
+            "torch._inductor.lookup_table.gemm_config_lookup_table", mock_lookup_table
+        ):
+            result = torch._inductor.lookup_table.get_lookup_table(input_nodes, "mm")
+
+        # Should return the exact lookup string
+        self.assertEqual(result, expected_lookup_result)
+        mock_get_device_name.assert_called_once_with(0)
+        mock_lookup_key.assert_called_once_with(input_nodes)
+
+    @patch("torch._inductor.lookup_table.gemm_config_lookup_table", None)
+    @patch("torch._inductor.lookup_table._lookup_key")
+    def test_lookup_table_none(self, mock_lookup_key):
+        """Test when gemm_config_lookup_table is None"""
+        # Setup
+        mock_lookup_key.return_value = "test_lookup_key"
+
+        input_nodes = [
+            MockInputNode(device_type="cuda", device_index=0),
+            MockInputNode(device_type="cuda", device_index=0),
+        ]
+
+        result = torch._inductor.lookup_table.get_lookup_table(input_nodes, "mm")
+
+        # Should return None when lookup table is None
+        self.assertIsNone(result)
+        # Should not call lookup_key when lookup table is None
+        mock_lookup_key.assert_not_called()
+
+    @patch("torch._inductor.lookup_table.gemm_config_lookup_table")
+    @patch("torch._inductor.lookup_table._lookup_key")
+    @patch("torch.cuda.get_device_name")
+    def test_method_mismatch(
+        self, mock_get_device_name, mock_lookup_key, mock_lookup_table
+    ):
+        """Test when method doesn't match any entry in lookup table"""
+        # Setup
+        mock_get_device_name.return_value = "NVIDIA H100"
+        mock_lookup_key.return_value = "test_lookup_key"
+
+        # Lookup table has different method
+        mock_lookup_table = {
+            "bmm": {  # Different method
+                "NVIDIA H100": {"test_lookup_key": "(128, 128, 64, 2, 2)"}
+            }
+        }
+
+        input_nodes = [
+            MockInputNode(device_type="cuda", device_index=0),
+            MockInputNode(device_type="cuda", device_index=0),
+        ]
+
+        with patch(
+            "torch._inductor.lookup_table.gemm_config_lookup_table", mock_lookup_table
+        ):
+            result = torch._inductor.lookup_table.get_lookup_table(
+                input_nodes, "mm"
+            )  # Using "mm" method
+
+        # Should return empty dict when method doesn't match
+        self.assertEqual(result, {})
+        mock_get_device_name.assert_called_once_with(0)
+        mock_lookup_key.assert_called_once_with(input_nodes)
+
+    def test_lookup_key_generation(self):
+        """Test the _lookup_key function with mock input nodes"""
+        # Create mock input nodes with specific properties
+        input_nodes = [
+            MockInputNode(
+                dtype=torch.float32, size_hint=[128, 64], stride_hint=[64, 1]
+            ),
+            MockInputNode(dtype=torch.float16, size_hint=[64, 32], stride_hint=[32, 1]),
+        ]
+
+        # Mock the get_size_hint and get_stride_hint functions
+        with (
+            patch("torch._inductor.lookup_table.get_size_hint") as mock_size_hint,
+            patch("torch._inductor.lookup_table.get_stride_hint") as mock_stride_hint,
+        ):
+            mock_size_hint.side_effect = lambda node: node.size_hint
+            mock_stride_hint.side_effect = lambda node: node.stride_hint
+
+            result = torch._inductor.lookup_table._lookup_key(input_nodes)
+
+            # Verify the result is a string representation of the expected tuple
+            expected = str(
+                tuple(
+                    [
+                        (torch.float32, [128, 64], [64, 1]),
+                        (torch.float16, [64, 32], [32, 1]),
+                    ]
+                )
+            )
+            self.assertEqual(result, expected)
+
+
+class TestLookupTableFileParsing(TestCase):
+    """Test class for file parsing logic in _get_lookup_table()"""
+
+    def setUp(self):
+        super().setUp()
+        # Store original values to restore later
+        self.original_table = torch._inductor.lookup_table.gemm_config_lookup_table
+        self.original_path_config = inductor_config.triton.gemm_config_lookup_table_path
+
+        # Reset global state
+        torch._inductor.lookup_table.gemm_config_lookup_table = None
+        inductor_config.triton.gemm_config_lookup_table_path = None
+
+    def tearDown(self):
+        # Restore original values
+        torch._inductor.lookup_table.gemm_config_lookup_table = self.original_table
+        inductor_config.triton.gemm_config_lookup_table_path = self.original_path_config
+        super().tearDown()
+
+    def test_json_file_parsing(self):
+        """Test that JSON files are parsed correctly"""
+        test_data = {
+            "mm": {"NVIDIA H100": {"test_key": {"triton": "(128, 128, 64, 2, 2)"}}}
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(test_data, f)
+            temp_file_path = f.name
+
+        try:
+            # Configure to use the temp file
+            inductor_config.triton.gemm_config_lookup_table_path = temp_file_path
+
+            # Call the function
+            result = torch._inductor.lookup_table._get_lookup_table()
+
+            # Verify the result
+            self.assertEqual(result, test_data)
+        finally:
+            os.unlink(temp_file_path)
+
+    def test_yaml_file_parsing(self):
+        """Test that YAML files are parsed correctly"""
+        test_data = {
+            "addmm": {"NVIDIA H100": {"test_key": {"triton": "(64, 64, 32, 2, 2)"}}}
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(test_data, f)
+            temp_file_path = f.name
+
+        try:
+            # Configure to use the temp file
+            inductor_config.triton.gemm_config_lookup_table_path = temp_file_path
+
+            # Call the function
+            result = torch._inductor.lookup_table._get_lookup_table()
+
+            # Verify the result
+            self.assertEqual(result, test_data)
+        finally:
+            os.unlink(temp_file_path)
+
+    def test_yml_file_parsing(self):
+        """Test that .yml files are parsed correctly"""
+        test_data = {"bmm": {"cpu": {"test_key": {"triton": "(32, 32, 16, 1, 1)"}}}}
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            yaml.dump(test_data, f)
+            temp_file_path = f.name
+
+        try:
+            # Configure to use the temp file
+            inductor_config.triton.gemm_config_lookup_table_path = temp_file_path
+
+            # Call the function
+            result = torch._inductor.lookup_table._get_lookup_table()
+
+            # Verify the result
+            self.assertEqual(result, test_data)
+        finally:
+            os.unlink(temp_file_path)
+
+    def test_unsupported_file_extension(self):
+        """Test that unsupported file extensions throw an AssertionError"""
+        test_data = {"test": "data"}
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".fakesuffix", delete=False
+        ) as f:
+            json.dump(test_data, f)
+            temp_file_path = f.name
+
+        try:
+            # Configure to use the temp file
+            inductor_config.triton.gemm_config_lookup_table_path = temp_file_path
+
+            # Should raise AssertionError
+            with self.assertRaises(AssertionError) as context:
+                torch._inductor.lookup_table._get_lookup_table()
+
+            self.assertIn("Unsupported file format", str(context.exception))
+            self.assertIn(".fakesuffix", str(context.exception))
+        finally:
+            os.unlink(temp_file_path)
+
+
+class TestLookupTableConfigSettings(TestCase):
+    """Test class for _in_use() method functionality"""
+
+    def setUp(self):
+        super().setUp()
+        # Store original values to restore later
+        self.original_table = torch._inductor.lookup_table.gemm_config_lookup_table
+        self.original_path_config = inductor_config.triton.gemm_config_lookup_table_path
+
+    def tearDown(self):
+        # Restore original values
+        torch._inductor.lookup_table.gemm_config_lookup_table = self.original_table
+        inductor_config.triton.gemm_config_lookup_table_path = self.original_path_config
+
+    def test_in_use_with_path_only(self):
+        """Test: path is set -> _in_use() returns True"""
+        # Setup: table is None, path is set
+        torch._inductor.lookup_table.gemm_config_lookup_table = None
+        inductor_config.triton.gemm_config_lookup_table_path = "/some/path/config.json"
+
+        # Should return True when path is set
+        result = torch._inductor.lookup_table._in_use()
+        self.assertTrue(result)
+
+    def test_in_use_with_table_only(self):
+        """Test: table is set -> _in_use() returns True"""
+        # Setup: path is None, table is set
+        inductor_config.triton.gemm_config_lookup_table_path = None
+        torch._inductor.lookup_table.gemm_config_lookup_table = {"test": "data"}
+
+        # Should return True when table is set
+        result = torch._inductor.lookup_table._in_use()
+        self.assertTrue(result)
+
+    def test_in_use_with_neither(self):
+        """Test: neither path nor table set -> _in_use() returns False"""
+        # Setup: both path and table are None
+        torch._inductor.lookup_table.gemm_config_lookup_table = None
+        inductor_config.triton.gemm_config_lookup_table_path = None
+
+        # Should return False when neither is set
+        result = torch._inductor.lookup_table._in_use()
+        self.assertFalse(result)
+
+    def test_in_use_with_both_table_and_path(self):
+        """Test: both table and path set -> _in_use() returns True, table has precedence"""
+        # Setup: both path and table are set
+        test_table = {"existing": "table_data"}
+        torch._inductor.lookup_table.gemm_config_lookup_table = test_table
+        inductor_config.triton.gemm_config_lookup_table_path = "/some/path/config.json"
+
+        # Should return True when both are set
+        result = torch._inductor.lookup_table._in_use()
+        self.assertTrue(result)
+
+        # Verify table data has precedence and is not overridden by path
+        lookup_result = torch._inductor.lookup_table._get_lookup_table()
+        self.assertEqual(lookup_result, test_table)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_lookup_table_e2e.py
+++ b/test/inductor/test_lookup_table_e2e.py
@@ -1,0 +1,698 @@
+# Owner(s): ["module: inductor"]
+import re
+import unittest
+from functools import partial
+from typing import Any
+
+import torch
+import torch.nn as nn
+from torch._inductor import config
+from torch._inductor.select_algorithm import (
+    add_preprocessing_fn,
+    clear_preprocessing_fns,
+)
+from torch._inductor.test_case import run_tests, TestCase
+from torch._inductor.utils import fresh_cache
+from torch.testing._internal.common_utils import TEST_WITH_ROCM
+from torch.testing._internal.inductor_utils import HAS_CPU, HAS_CUDA, HAS_GPU
+from torch.utils._triton import has_triton_tma_device
+
+
+class MMModel(nn.Module):
+    """Simple model that performs matrix multiplication"""
+
+    def forward(self, a, b):
+        return torch.mm(a, b)
+
+
+class AddMMModel(nn.Module):
+    """Simple model that performs additive matrix multiplication"""
+
+    def forward(self, bias, a, b):
+        return torch.addmm(bias, a, b)
+
+
+class BMMModel(nn.Module):
+    """Simple model that performs batch matrix multiplication"""
+
+    def forward(self, a, b):
+        return torch.bmm(a, b)
+
+
+class MMPlusMMModel(nn.Module):
+    """Simple model that performs two matrix multiplications and adds them"""
+
+    def forward(self, a, b, c, d):
+        return torch.mm(a, b) + torch.mm(c, d)
+
+
+def generate_lookup_key_from_tensors(tensors):
+    """Generate lookup key using the same logic as _lookup_key but from real tensors"""
+    return str(
+        tuple(
+            (tensor.dtype, list(tensor.shape), list(tensor.stride()))
+            for tensor in tensors
+        )
+    )
+
+
+def test_checking_function(
+    choices: list[Any], choice_name_re: str, num_expected_choices: int = 1
+):
+    """Function to register and get feedback
+
+    Args:
+        choices: List of choices that are being autotuned, supplied by select_algorithm
+        choice_name_re: Regex pattern to check all choice names against
+        num_expected_choices: if len(choices) != num_expected_choices, then fail
+    """
+    if len(choices) != num_expected_choices:
+        raise ValueError(f"Expected {num_expected_choices} choices, got {len(choices)}")
+    for choice in choices:
+        if not re.search(choice_name_re, choice.name):
+            raise ValueError(
+                f"Expected choice name to match regex '{choice_name_re}', got {choice.name}"
+            )
+
+    # This is to comply with the interface that expects these to be preprocessing functions
+    return choices
+
+
+@unittest.skipIf(TEST_WITH_ROCM, "ROCm doesn't support lookup table")
+@unittest.skipIf(not HAS_CUDA, "CUDA not available")
+class TestMMLookupTableE2E(TestCase):
+    """Test class for MM method lookup table end-to-end scenarios"""
+
+    def setUp(self):
+        torch._dynamo.reset()
+        clear_preprocessing_fns()
+        self.device = torch.device("cuda")
+        self.device_name = torch.cuda.get_device_name(0)
+
+        # Store original value to restore later
+        self.original_lookup_table = (
+            torch._inductor.lookup_table.gemm_config_lookup_table
+        )
+
+        # Create test tensors for MM (K is 32 * larger than M and N)
+        self.mm_a = torch.randn(64, 2048, device=self.device, dtype=torch.float16)
+        self.mm_b = torch.randn(2048, 64, device=self.device, dtype=torch.float16)
+        self.mm_lookup_key = generate_lookup_key_from_tensors([self.mm_a, self.mm_b])
+
+        # Create model
+        self.model = MMModel().to(self.device)
+
+    def tearDown(self):
+        # Restore original value
+        torch._inductor.lookup_table.gemm_config_lookup_table = (
+            self.original_lookup_table
+        )
+        clear_preprocessing_fns()
+
+    @fresh_cache()
+    def test_mm_no_lookup_table_entry(self):
+        """Test MM when there's no lookup table entry for input_nodes()"""
+        # Setup lookup table with no entry for this specific lookup key
+        torch._inductor.lookup_table.gemm_config_lookup_table = {
+            "mm": {
+                self.device_name: {
+                    "different_lookup_key": {"triton": "(64, 64, 64, 2, 2)"}
+                }
+            }
+        }
+
+        # we expect the ExternChoiceCaller with the default name mm to be chosen here
+        add_preprocessing_fn(
+            partial(test_checking_function, choice_name_re="mm", num_expected_choices=1)
+        )
+
+        # Run the compiled model - should work even without lookup table entry
+        with config.patch(
+            {
+                "max_autotune_gemm": True,
+            }
+        ):
+            compiled_model = torch.compile(self.model, mode="max-autotune")
+            _ = compiled_model(self.mm_a, self.mm_b)
+
+    @fresh_cache()
+    def test_mm_valid_lookup_table_entry(self):
+        """Test MM when there's a valid entry for input_nodes()"""
+        # Setup pruning table with valid triton entry for this lookup key
+        torch._inductor.lookup_table.gemm_config_lookup_table = {
+            "mm": {
+                self.device_name: {self.mm_lookup_key: {"triton": "(64, 64, 32, 2, 2)"}}
+            }
+        }
+        # We expect the TritonTemplateCaller to be chosen here as we have a valid config
+        add_preprocessing_fn(
+            partial(
+                test_checking_function, choice_name_re="triton_", num_expected_choices=1
+            )
+        )
+
+        # Run the compiled model with valid lookup table entry
+        with config.patch(
+            {
+                "max_autotune_gemm": True,
+            }
+        ):
+            compiled_model = torch.compile(self.model, mode="max-autotune")
+            _ = compiled_model(self.mm_a, self.mm_b)
+
+    @fresh_cache()
+    def test_mm_invalid_lookup_table_entry(self):
+        """Test MM when there's an invalid entry that fails to parse"""
+        # Setup pruning table with invalid triton entry for this lookup key
+        torch._inductor.lookup_table.gemm_config_lookup_table = {
+            "mm": {
+                self.device_name: {
+                    self.mm_lookup_key: {"triton": "invalid_config_format"}
+                }
+            }
+        }
+
+        # we expect the ExternChoiceCaller with the default name mm to be chosen here
+        add_preprocessing_fn(
+            partial(test_checking_function, choice_name_re="mm", num_expected_choices=1)
+        )
+
+        # Run the compiled model - should fallback gracefully with invalid config
+        with config.patch(
+            {
+                "max_autotune_gemm": True,
+            }
+        ):
+            compiled_model = torch.compile(self.model, mode="max-autotune")
+            _ = compiled_model(self.mm_a, self.mm_b)
+
+    @unittest.skipIf(
+        not has_triton_tma_device(), "Need device-side TMA support in Triton"
+    )
+    @fresh_cache()
+    def test_mm_valid_tma_lookup_table_entry(self):
+        """Test MM when there's a valid TMA entry for input_nodes()"""
+        # Setup pruning table with valid tma entry for this lookup key
+        torch._inductor.lookup_table.gemm_config_lookup_table = {
+            "mm": {
+                self.device_name: {self.mm_lookup_key: {"tma": "(64, 64, 32, 2, 2)"}}
+            }
+        }
+        # We expect the TritonPersistentTemplateCaller to be chosen here as we have a valid TMA config
+        add_preprocessing_fn(
+            partial(
+                test_checking_function,
+                choice_name_re="triton_mm_persistent_tma_",
+                num_expected_choices=1,
+            )
+        )
+
+        # Run the compiled model with valid TMA lookup table entry
+        with config.patch(
+            {
+                "max_autotune_gemm": True,
+                "triton.enable_persistent_tma_matmul": True,
+            }
+        ):
+            compiled_model = torch.compile(self.model, mode="max-autotune")
+            _ = compiled_model(self.mm_a, self.mm_b)
+
+    @fresh_cache()
+    def test_mm_valid_decompose_k_lookup_table_entry(self):
+        """Test MM when there's a valid decompose_k entry for input_nodes()"""
+        # Setup pruning table with valid decompose_k entry for this lookup key
+        torch._inductor.lookup_table.gemm_config_lookup_table = {
+            "mm": {self.device_name: {self.mm_lookup_key: {"decompose_k": "4"}}}
+        }
+        # we go through bmm for decompose, even though it's not being autotuned
+        add_preprocessing_fn(
+            partial(
+                test_checking_function,
+                choice_name_re="decompose_k|bmm_dtype",
+                num_expected_choices=1,
+            )
+        )
+
+        # Run the compiled model with valid decompose_k lookup table entry
+        with config.patch(
+            {
+                "max_autotune_gemm": True,
+            }
+        ):
+            compiled_model = torch.compile(self.model, mode="max-autotune")
+            _ = compiled_model(self.mm_a, self.mm_b)
+
+
+@unittest.skipIf(TEST_WITH_ROCM, "ROCm doesn't support lookup table")
+@unittest.skipIf(not HAS_CUDA, "CUDA not available")
+class TestAddMMLookupTableE2E(TestCase):
+    """Test class for AddMM method lookup table end-to-end scenarios"""
+
+    def setUp(self):
+        torch._dynamo.reset()
+        clear_preprocessing_fns()
+        self.device = torch.device("cuda")
+        self.device_name = torch.cuda.get_device_name(0)
+
+        # Store original value to restore later
+        self.original_lookup_table = (
+            torch._inductor.lookup_table.gemm_config_lookup_table
+        )
+
+        # Create test tensors for AddMM (bias, a, b)
+        self.addmm_bias = torch.randn(64, 64, device=self.device, dtype=torch.float16)
+        self.addmm_a = torch.randn(64, 32, device=self.device, dtype=torch.float16)
+        self.addmm_b = torch.randn(32, 64, device=self.device, dtype=torch.float16)
+        self.addmm_lookup_key = generate_lookup_key_from_tensors(
+            [self.addmm_bias, self.addmm_a, self.addmm_b]
+        )
+
+        # Create model
+        self.model = AddMMModel().to(self.device)
+
+    def tearDown(self):
+        # Restore original value
+        torch._inductor.lookup_table.gemm_config_lookup_table = (
+            self.original_lookup_table
+        )
+        clear_preprocessing_fns()
+
+    @fresh_cache()
+    def test_addmm_no_lookup_table_entry(self):
+        """Test AddMM when there's no lookup table entry for input_nodes()"""
+        # Setup pruning table with no entry for this specific lookup key
+        torch._inductor.lookup_table.gemm_config_lookup_table = {
+            "addmm": {
+                self.device_name: {
+                    "different_lookup_key": {"triton": "(64, 64, 32, 2, 3)"}
+                }
+            }
+        }
+        # We expect the ExternChoiceCaller with the default name addmm to be chosen here
+        add_preprocessing_fn(
+            partial(
+                test_checking_function, choice_name_re="addmm", num_expected_choices=1
+            )
+        )
+
+        # Run the compiled model - should work even without lookup table entry
+        with config.patch(
+            {
+                "max_autotune_gemm": True,
+            }
+        ):
+            compiled_model = torch.compile(self.model, mode="max-autotune")
+            _ = compiled_model(self.addmm_bias, self.addmm_a, self.addmm_b)
+
+    @fresh_cache()
+    def test_addmm_valid_lookup_table_entry(self):
+        """Test AddMM when there's a valid entry for input_nodes()"""
+        # Setup pruning table with valid triton entry for this lookup key
+        torch._inductor.lookup_table.gemm_config_lookup_table = {
+            "addmm": {
+                self.device_name: {
+                    self.addmm_lookup_key: {"triton": "(64, 64, 32, 2, 2)"}
+                }
+            }
+        }
+
+        # We expect the TritonTemplateCaller to be chosen here as we have a valid config
+        add_preprocessing_fn(
+            partial(
+                test_checking_function, choice_name_re="triton_", num_expected_choices=1
+            )
+        )
+
+        # Run the compiled model with valid lookup table entry
+        with config.patch(
+            {
+                "max_autotune_gemm": True,
+            }
+        ):
+            compiled_model = torch.compile(self.model, mode="max-autotune")
+            _ = compiled_model(self.addmm_bias, self.addmm_a, self.addmm_b)
+
+    @fresh_cache()
+    def test_addmm_invalid_lookup_table_entry(self):
+        """Test AddMM when there's an invalid entry that fails to parse"""
+        # Setup pruning table with invalid triton entry for this lookup key
+        torch._inductor.lookup_table.gemm_config_lookup_table = {
+            "addmm": {
+                self.device_name: {
+                    self.addmm_lookup_key: {"triton": ""}  # Empty string
+                }
+            }
+        }
+
+        # We expect the ExternChoiceCaller with the default name addmm to be chosen here
+        add_preprocessing_fn(
+            partial(
+                test_checking_function, choice_name_re="addmm", num_expected_choices=1
+            )
+        )
+
+        # Run the compiled model - should fallback gracefully with invalid config
+        with config.patch(
+            {
+                "max_autotune_gemm": True,
+            }
+        ):
+            compiled_model = torch.compile(self.model, mode="max-autotune")
+            _ = compiled_model(self.addmm_bias, self.addmm_a, self.addmm_b)
+
+    @fresh_cache()
+    def test_addmm_bias_addmm_lookup_table_entry(self):
+        """Test AddMM when there's a bias_addmm entry in the lookup table"""
+        # Create bias as column vector with stride[0] == 0 for bias_addmm to be eligible
+        bias_unexpanded = torch.randn(64, device=self.device, dtype=torch.float16)
+        bias_expanded = bias_unexpanded.expand(64, 64)
+
+        # Calculate lookup key with expanded bias (stride[0] == 0)
+        bias_addmm_lookup_key = generate_lookup_key_from_tensors(
+            [bias_expanded, self.addmm_a, self.addmm_b]
+        )
+
+        # Setup pruning table with bias_addmm entry for this lookup key
+        torch._inductor.lookup_table.gemm_config_lookup_table = {
+            "addmm": {self.device_name: {bias_addmm_lookup_key: {"bias_addmm": "1"}}}
+        }
+
+        # We expect the ExternChoiceCaller with the bias_addmm name to be chosen here
+        add_preprocessing_fn(
+            partial(
+                test_checking_function,
+                choice_name_re="bias_addmm",
+                num_expected_choices=1,
+            )
+        )
+
+        # Run the compiled model with bias_addmm lookup table entry
+        with config.patch(
+            {
+                "max_autotune_gemm": True,
+                "triton.autotune_cublasLt": True,
+            }
+        ):
+            compiled_model = torch.compile(self.model, mode="max-autotune")
+            # Pass the unexpanded bias to the model
+            _ = compiled_model(bias_unexpanded, self.addmm_a, self.addmm_b)
+
+    @unittest.skipIf(
+        not has_triton_tma_device(), "Need device-side TMA support in Triton"
+    )
+    @fresh_cache()
+    def test_addmm_valid_tma_lookup_table_entry(self):
+        """Test AddMM when there's a valid TMA entry for input_nodes()"""
+        # Setup pruning table with valid tma entry for this lookup key
+        torch._inductor.lookup_table.gemm_config_lookup_table = {
+            "addmm": {
+                self.device_name: {self.addmm_lookup_key: {"tma": "(64, 64, 32, 2, 2)"}}
+            }
+        }
+
+        # We expect the TritonPersistentTemplateCaller to be chosen here as we have a valid TMA config
+        add_preprocessing_fn(
+            partial(
+                test_checking_function,
+                choice_name_re="triton_mm_persistent_tma_",
+                num_expected_choices=1,
+            )
+        )
+
+        # Run the compiled model with valid TMA lookup table entry
+        with config.patch(
+            {
+                "max_autotune_gemm": True,
+                "triton.enable_persistent_tma_matmul": True,
+            }
+        ):
+            compiled_model = torch.compile(self.model, mode="max-autotune")
+            _ = compiled_model(self.addmm_bias, self.addmm_a, self.addmm_b)
+
+
+@unittest.skipIf(TEST_WITH_ROCM, "ROCm doesn't support lookup table")
+@unittest.skipIf(not HAS_CUDA, "CUDA not available")
+class TestBMMLookupTableE2E(TestCase):
+    """Test class for BMM method lookup table end-to-end scenarios"""
+
+    def setUp(self):
+        torch._dynamo.reset()
+        clear_preprocessing_fns()
+        self.device = torch.device("cuda")
+        self.device_name = torch.cuda.get_device_name(0)
+
+        # Store original value to restore later
+        self.original_lookup_table = (
+            torch._inductor.lookup_table.gemm_config_lookup_table
+        )
+
+        # Create test tensors for BMM (batch matrix multiplication)
+        self.bmm_a = torch.randn(8, 128, 64, device=self.device, dtype=torch.float16)
+        self.bmm_b = torch.randn(8, 64, 128, device=self.device, dtype=torch.float16)
+        self.bmm_lookup_key = generate_lookup_key_from_tensors([self.bmm_a, self.bmm_b])
+
+        # Create model
+        self.model = BMMModel().to(self.device)
+
+    def tearDown(self):
+        # Restore original value
+        torch._inductor.lookup_table.gemm_config_lookup_table = (
+            self.original_lookup_table
+        )
+        clear_preprocessing_fns()
+
+    @fresh_cache()
+    def test_bmm_no_lookup_table_entry(self):
+        """Test BMM when there's no lookup table entry for input_nodes()"""
+        # Setup pruning table with no entry for this specific lookup key
+        torch._inductor.lookup_table.gemm_config_lookup_table = {
+            "bmm": {
+                self.device_name: {
+                    "different_lookup_key": {"triton": "(64, 64, 64, 2, 2)"}
+                }
+            }
+        }
+
+        # we expect the ExternChoiceCaller with the default name bmm to be chosen here
+        add_preprocessing_fn(
+            partial(
+                test_checking_function, choice_name_re="bmm", num_expected_choices=1
+            )
+        )
+
+        # Run the compiled model - should work even without lookup table entry
+        with config.patch(
+            {
+                "max_autotune_gemm": True,
+            }
+        ):
+            compiled_model = torch.compile(self.model, mode="max-autotune")
+            _ = compiled_model(self.bmm_a, self.bmm_b)
+
+    @fresh_cache()
+    def test_bmm_valid_lookup_table_entry(self):
+        """Test BMM when there's a valid entry for input_nodes()"""
+        # Setup pruning table with valid triton entry for this lookup key
+        torch._inductor.lookup_table.gemm_config_lookup_table = {
+            "bmm": {
+                self.device_name: {
+                    self.bmm_lookup_key: {"triton": "(64, 64, 64, 2, 2)"}
+                }
+            }
+        }
+
+        # We expect the TritonTemplateCaller to be chosen here as we have a valid config
+        add_preprocessing_fn(
+            partial(
+                test_checking_function, choice_name_re="triton_", num_expected_choices=1
+            )
+        )
+
+        # Run the compiled model with valid lookup table entry
+        with config.patch(
+            {
+                "max_autotune_gemm": True,
+            }
+        ):
+            compiled_model = torch.compile(self.model, mode="max-autotune")
+            _ = compiled_model(self.bmm_a, self.bmm_b)
+
+    @fresh_cache()
+    def test_bmm_invalid_lookup_table_entry(self):
+        """Test BMM when there's an invalid entry that fails to parse"""
+        # Setup pruning table with invalid triton entry for this lookup key
+        torch._inductor.lookup_table.gemm_config_lookup_table = {
+            "bmm": {
+                self.device_name: {
+                    self.bmm_lookup_key: {
+                        "triton": "(256, 256, 128, 1"
+                    }  # Missing closing parenthesis
+                }
+            }
+        }
+
+        # we expect the ExternChoiceCaller with the default name bmm to be chosen here
+        add_preprocessing_fn(
+            partial(
+                test_checking_function, choice_name_re="bmm", num_expected_choices=1
+            )
+        )
+
+        # Run the compiled model - should fallback gracefully with invalid config
+        with config.patch(
+            {
+                "max_autotune_gemm": True,
+            }
+        ):
+            compiled_model = torch.compile(self.model, mode="max-autotune")
+            _ = compiled_model(self.bmm_a, self.bmm_b)
+
+
+@unittest.skipIf(TEST_WITH_ROCM, "ROCm doesn't support lookup table")
+@unittest.skipIf(not HAS_CUDA, "CUDA not available")
+class TestMMPlusMMMLookupTableE2E(TestCase):
+    """Test class for MM_PLUS_MM method lookup table end-to-end scenarios"""
+
+    def setUp(self):
+        torch._dynamo.reset()
+        clear_preprocessing_fns()
+        self.device = torch.device("cuda")
+        self.device_name = torch.cuda.get_device_name(0)
+
+        # Store original value to restore later
+        self.original_lookup_table = (
+            torch._inductor.lookup_table.gemm_config_lookup_table
+        )
+
+        # Create test tensors for MM_PLUS_MM (four matrices for two mm operations)
+        self.mm_plus_mm_a = torch.randn(64, 32, device=self.device, dtype=torch.float16)
+        self.mm_plus_mm_b = torch.randn(32, 64, device=self.device, dtype=torch.float16)
+        self.mm_plus_mm_c = torch.randn(64, 32, device=self.device, dtype=torch.float16)
+        self.mm_plus_mm_d = torch.randn(32, 64, device=self.device, dtype=torch.float16)
+        self.mm_plus_mm_lookup_key = generate_lookup_key_from_tensors(
+            [self.mm_plus_mm_a, self.mm_plus_mm_b, self.mm_plus_mm_c, self.mm_plus_mm_d]
+        )
+
+        # Create model
+        self.model = MMPlusMMModel().to(self.device)
+
+    def tearDown(self):
+        # Restore original value
+        torch._inductor.lookup_table.gemm_config_lookup_table = (
+            self.original_lookup_table
+        )
+        clear_preprocessing_fns()
+
+    @fresh_cache()
+    def test_mm_plus_mm_no_lookup_table_entry(self):
+        """Test MM_PLUS_MM when there's no lookup table entry for input_nodes()"""
+        # Setup pruning table with no entry for this specific lookup key
+        torch._inductor.lookup_table.gemm_config_lookup_table = {
+            "mm_plus_mm": {
+                self.device_name: {
+                    "different_lookup_key": {"triton": "(64, 64, 32, 2, 2)"}
+                }
+            }
+        }
+
+        # we expect the ExternChoiceCaller with the default name mm_plus_mm to be chosen here
+        add_preprocessing_fn(
+            partial(
+                test_checking_function,
+                choice_name_re="_mm_plus_mm",
+                num_expected_choices=1,
+            )
+        )
+
+        # Run the compiled model - should work even without lookup table entry
+        with config.patch(
+            {
+                "max_autotune_gemm": True,
+            }
+        ):
+            compiled_model = torch.compile(self.model, mode="max-autotune")
+            _ = compiled_model(
+                self.mm_plus_mm_a,
+                self.mm_plus_mm_b,
+                self.mm_plus_mm_c,
+                self.mm_plus_mm_d,
+            )
+
+    @fresh_cache()
+    def test_mm_plus_mm_valid_lookup_table_entry(self):
+        """Test MM_PLUS_MM when there's a valid entry for input_nodes()"""
+        # Setup pruning table with valid triton entry for this lookup key
+        torch._inductor.lookup_table.gemm_config_lookup_table = {
+            "mm_plus_mm": {
+                self.device_name: {
+                    # important here that K != 32, as that will make the TritonTemplate not eligible
+                    self.mm_plus_mm_lookup_key: {"triton": "(64, 64, 16, 2, 2)"}
+                }
+            }
+        }
+
+        # We expect the TritonTemplateCaller to be chosen here as we have a valid config
+        add_preprocessing_fn(
+            partial(
+                test_checking_function, choice_name_re="triton_", num_expected_choices=1
+            )
+        )
+
+        # Run the compiled model with valid lookup table entry
+        with config.patch(
+            {
+                "max_autotune_gemm": True,
+            }
+        ):
+            compiled_model = torch.compile(self.model, mode="max-autotune")
+            _ = compiled_model(
+                self.mm_plus_mm_a,
+                self.mm_plus_mm_b,
+                self.mm_plus_mm_c,
+                self.mm_plus_mm_d,
+            )
+
+    @fresh_cache()
+    def test_mm_plus_mm_invalid_lookup_table_entry(self):
+        """Test MM_PLUS_MM when there's an invalid entry that fails to parse"""
+        # Setup pruning table with invalid triton entry for this lookup key
+        torch._inductor.lookup_table.gemm_config_lookup_table = {
+            "mm_plus_mm": {
+                self.device_name: {
+                    self.mm_plus_mm_lookup_key: {
+                        "triton": "(abc, def, ghi, jkl, mno)"
+                    }  # Non-numeric values
+                }
+            }
+        }
+
+        # we expect the ExternChoiceCaller with the default name mm_plus_mm to be chosen here
+        add_preprocessing_fn(
+            partial(
+                test_checking_function,
+                choice_name_re="_mm_plus_mm",
+                num_expected_choices=1,
+            )
+        )
+
+        # Run the compiled model - should fallback gracefully with invalid config
+        with config.patch(
+            {
+                "max_autotune_gemm": True,
+            }
+        ):
+            compiled_model = torch.compile(self.model, mode="max-autotune")
+            _ = compiled_model(
+                self.mm_plus_mm_a,
+                self.mm_plus_mm_b,
+                self.mm_plus_mm_c,
+                self.mm_plus_mm_d,
+            )
+
+
+if __name__ == "__main__":
+    from torch._inductor.utils import is_big_gpu
+
+    # Set env to make it work in CI.
+    if HAS_GPU and HAS_CPU and is_big_gpu():
+        run_tests()

--- a/test/inductor/test_template_heuristics.py
+++ b/test/inductor/test_template_heuristics.py
@@ -1,0 +1,132 @@
+# Owner(s): ["module: inductor"]
+
+from torch._inductor.template_heuristics import _parse_valid_config, GemmConfig
+from torch._inductor.test_case import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+)
+
+
+@instantiate_parametrized_tests
+class TestTemplateHeuristics(TestCase):
+    def test_parse_valid_config_basic_valid(self):
+        """Test _parse_valid_config with basic valid tuple representations."""
+        # Valid 5-parameter tuple
+        result = _parse_valid_config("(64, 64, 32, 2, 4)")
+        expected = [GemmConfig(64, 64, 32, 2, 4)]
+        self.assertEqual(result, expected)
+
+        # Valid 6-parameter tuple
+        result = _parse_valid_config("(32, 32, 16, 1, 2, 8)")
+        expected = [GemmConfig(32, 32, 16, 1, 2, 8)]
+        self.assertEqual(result, expected)
+
+        # Valid tuple with different values
+        result = _parse_valid_config("(128, 128, 64, 3, 8)")
+        expected = [GemmConfig(128, 128, 64, 3, 8)]
+        self.assertEqual(result, expected)
+
+    def test_parse_valid_config_with_spaces(self):
+        """Test _parse_valid_config with spaces in input."""
+        result = _parse_valid_config("( 64 , 64 , 32 , 2 , 4 )")
+        expected = [GemmConfig(64, 64, 32, 2, 4)]
+        self.assertEqual(result, expected)
+
+    def test_parse_valid_config_empty_inputs(self):
+        """Test _parse_valid_config with empty inputs."""
+        # Empty string
+        result = _parse_valid_config("")
+        self.assertEqual(result, [])
+
+        # Empty parentheses
+        result = _parse_valid_config("()")
+        self.assertEqual(result, [])
+
+    @parametrize(
+        "invalid_input",
+        [
+            "garbage",
+            "(not, a, tuple)",
+            "(1, 2, three, 4, 5)",
+            "invalid_format",
+            "(1,2,3,)",  # trailing comma with missing value
+        ],
+    )
+    def test_parse_valid_config_garbage_input(self, invalid_input):
+        """Test _parse_valid_config with invalid garbage input."""
+        with self.assertRaises(ValueError):
+            _parse_valid_config(invalid_input)
+
+    @parametrize(
+        "float_input",
+        [
+            "(64.5, 64, 32, 2, 4)",
+            "(64, 64.0, 32, 2, 4)",
+            "(64, 64, 32.5, 2, 4)",
+            "(64, 64, 32, 2.5, 4)",
+        ],
+    )
+    def test_parse_valid_config_floats_instead_of_ints(self, float_input):
+        """Test _parse_valid_config with floats instead of ints (should fail)."""
+        with self.assertRaises(ValueError):
+            _parse_valid_config(float_input)
+
+    @parametrize(
+        "mixed_input",
+        [
+            "(64, 64, 32, two, 4)",
+            "(64, 64, 32, 2.5, 4)",
+        ],
+    )
+    def test_parse_valid_config_mixed_invalid(self, mixed_input):
+        """Test _parse_valid_config with mixed valid/invalid inputs."""
+        with self.assertRaises(ValueError):
+            _parse_valid_config(mixed_input)
+
+    def test_parse_valid_config_result_validation(self):
+        """Test that _parse_valid_config returns properly structured results."""
+        result = _parse_valid_config("(64, 64, 32, 2, 4)")
+
+        # Check result structure
+        self.assertEqual(len(result), 1)
+        config = result[0]
+        self.assertIsInstance(config, GemmConfig)
+
+        # Verify all attributes are integers
+        self.assertIsInstance(config.block_m, int)
+        self.assertIsInstance(config.block_n, int)
+        self.assertIsInstance(config.block_k, int)
+        self.assertIsInstance(config.num_stages, int)
+        self.assertIsInstance(config.num_warps, int)
+
+    @parametrize(
+        "edge_case_input,expected_exception",
+        [
+            ("(64, 64, 32, 2, 4", ValueError),  # missing closing paren
+            ("64, 64, 32, 2, 4)", ValueError),  # missing opening paren
+            (
+                "(64, 64)",
+                ValueError,
+            ),  # too few values - GemmConfig requires at least 5 args
+        ],
+    )
+    def test_parse_valid_config_edge_cases(self, edge_case_input, expected_exception):
+        """Test edge cases for _parse_valid_config function."""
+        with self.assertRaises(expected_exception):
+            _parse_valid_config(edge_case_input)
+
+    def test_parse_valid_config_large_numbers(self):
+        """Test _parse_valid_config with large numbers."""
+        result = _parse_valid_config("(1024, 2048, 512, 10, 16)")
+        self.assertEqual(len(result), 1)
+        config = result[0]
+        self.assertEqual(config.block_m, 1024)
+        self.assertEqual(config.block_n, 2048)
+        self.assertEqual(config.block_k, 512)
+        self.assertEqual(config.num_stages, 10)
+        self.assertEqual(config.num_warps, 16)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1092,6 +1092,10 @@ class cpp:
 
 # config specific to codegen/triton.py
 class triton:
+    """
+    config settings specific to triton templates
+    """
+
     # Use cudagraphs on output code
     cudagraphs = os.environ.get("TORCHINDUCTOR_CUDAGRAPHS") == "1"
 
@@ -1278,6 +1282,14 @@ class triton:
     # with a version of triton new enough to support TMA
     enable_persistent_tma_matmul = (
         os.environ.get("ENABLE_PERSISTENT_TMA_MATMUL", "0") == "1"
+    )
+
+    # Path to the gemm config lookup table file (JSON or YAML format).
+    # If this path is set OR if the gemm_config_lookup_table global in lookup_table.py
+    # is set, then the lookup table will be used to override max-autotune-gemm
+    # autotune configs with the ones from the lookup table.
+    gemm_config_lookup_table_path: Optional[str] = os.environ.get(
+        "TORCHINDUCTOR_GEMM_CONFIG_LOOKUP_TABLE_PATH", None
     )
     # Skip L1 cache for buffers that are used only once.  Disabled by default
     skip_l1_cache = os.environ.get("TORCHINDUCTOR_SKIP_L1", "0") == "1"

--- a/torch/_inductor/lookup_table.py
+++ b/torch/_inductor/lookup_table.py
@@ -1,0 +1,169 @@
+import json
+import logging
+from functools import lru_cache
+from typing import Any, Optional
+
+import torch
+from torch._inductor.virtualized import V
+
+from . import config as inductor_config
+
+
+log = logging.getLogger(__name__)
+
+
+def _in_use() -> bool:
+    """
+    Determine if the gemm config lookup table should be used.
+    Returns True if either:
+    1. The gemm_config_lookup_table_path is set, OR
+    2. The gemm_config_lookup_table global has been set
+    """
+    return (
+        inductor_config.triton.gemm_config_lookup_table_path is not None
+        or gemm_config_lookup_table is not None
+    )
+
+
+@lru_cache(0)
+def _read_lookup_table(
+    path: str,
+) -> Optional[dict[str, dict[str, dict[str, dict[str, str]]]]]:
+    """
+    Handle actual file reading, so this can be cached depending on the input path
+    """
+    if not _in_use():
+        return None
+    # Assert supported file extensions
+    if path.endswith(".json"):
+        with open(path) as f:
+            table = json.load(f)
+    elif path.endswith(".yaml") or path.endswith(".yml"):
+        try:
+            import yaml
+        except ImportError:
+            raise ImportError(
+                "PyYAML is required to load YAML files. Install with: pip install PyYAML, or convert your file to JSON format instead."
+            )
+        with open(path) as f:
+            table = yaml.safe_load(f)
+    else:
+        raise AssertionError(
+            f"Unsupported file format. Only .json and .yaml/.yml files are supported. Got: {path}"
+        )
+    return table
+
+
+def _get_lookup_table() -> Optional[dict[str, dict[str, dict[str, dict[str, str]]]]]:
+    """
+    Load and return the gemm config lookup table from file if configured.
+
+    If the table is already defined, this takes precedence over the file path
+    """
+    if not _in_use():
+        return None
+
+    # If table is directly defined, use that
+    if gemm_config_lookup_table is not None:
+        # Log warning if both table and path are defined
+        if inductor_config.triton.gemm_config_lookup_table_path is not None:
+            log.warning(
+                "Both gemm_config_lookup_table and gemm_config_lookup_table_path are defined. "
+                "Ignoring the path because a table is already defined."
+            )
+        return gemm_config_lookup_table
+
+    # Otherwise use the path if it's defined
+    if inductor_config.triton.gemm_config_lookup_table_path is not None:
+        return _read_lookup_table(inductor_config.triton.gemm_config_lookup_table_path)
+
+    return None
+
+
+# A static lookup table for triton configurations for GEMMs.
+# This is a lookup table in the form of
+# [op][device name][input_nodes_key][backend_key] = "(128, 128, 64, 2, 2)"
+# where the value is a string representation of a string of a GemmConfig for
+# `triton` backend key
+gemm_config_lookup_table: Optional[dict[str, dict[str, dict[str, dict[str, str]]]]] = (
+    None
+)
+
+
+def _lookup_key(input_nodes: list[Any]) -> str:
+    return str(
+        tuple(
+            # List here, because we want a standard encoding e.g. [] instead of ()
+            (node.get_dtype(), list(get_size_hint(node)), list(get_stride_hint(node)))
+            for node in input_nodes
+        )
+    )
+
+
+def get_lookup_table(input_nodes: list[Any], method: str) -> Optional[dict[str, str]]:
+    lookup_dict = None
+    lookup_table = _get_lookup_table()
+    if _in_use() and lookup_table is not None:
+        # Assume the first input parameter is used to determine the device
+        device = input_nodes[0].get_device()
+        device_name = (
+            torch.cuda.get_device_name(device.index) if device.type == "cuda" else "cpu"
+        )
+
+        # Generate lookup table key
+        lookup_key = _lookup_key(input_nodes)
+        log.debug(f"lookup_key: {lookup_key}")
+        # Retrieve the lookup dictionary
+        lookup_dict = (
+            lookup_table.get(method, {}).get(device_name, {}).get(lookup_key, {})
+        )
+    log.debug(f"lookup_dict for {method}: {lookup_dict}")
+    return lookup_dict
+
+
+def lookup_template_dict(
+    lookup_dict: Optional[dict[str, str]], key: str
+) -> Optional[str]:
+    if not _in_use():
+        return None
+    # This function needs to return "" if the key is not found or
+    # if the lookup_dict is None.
+    # This is because we treat the case of the dict being empty
+    # as the user not providing a lookup table for that input
+    # and therefore falling back to using no Triton configs
+    return lookup_dict.get(key, "") if lookup_dict is not None else ""
+
+
+def lookup_table_extract_choice(choices: list[Any]) -> tuple[list[Any], bool]:
+    """
+    If there are multiple choices, this means we want the last choice as
+    the lookup table produces at most one choice. The first choice is ATEN
+    and the choice we fall back to when the lookup table has no match
+    """
+    if not _in_use():
+        return choices, False
+    if len(choices) > 1:
+        return [choices[-1]], False
+    # indicate to the caller that we're using the ATEN choice
+    # as they might use this information to modify the layout
+    return choices, True
+
+
+def get_size_hint(mat: Any) -> list[int]:
+    size = mat.get_size()
+    if not all(isinstance(dim, int) for dim in size):
+        size = V.graph.sizevars.size_hints(
+            size,
+            fallback=torch._inductor.config.unbacked_symint_fallback,
+        )
+    return size
+
+
+def get_stride_hint(mat: Any) -> list[int]:
+    stride = mat.get_stride()
+    if not all(isinstance(dim, int) for dim in stride):
+        stride = V.graph.sizevars.size_hints(
+            stride,
+            fallback=torch._inductor.config.unbacked_symint_fallback,
+        )
+    return stride


### PR DESCRIPTION
Summary:
# Why

- enable initial feature set to see wider internal benchmarking and adoption
- introduce expected behavior testing that subsequent expansions (more backends, functions, etc) can rely on

# What

- First version of a static lookup table for Triton configs across mm, addmm, bmm, mm_plus_mm
- supports triton, tma, decompose_k, and bias_addmm in configs
- configuration inside lookup_table.py for now, with knob to turn on/off in inductor_config.triton

Test Plan:
```
buck2 test mode/opt fbcode//caffe2/test/inductor:lookup_table_cpu
buck2 test mode/opt fbcode//caffe2/test/inductor:template_heuristics_cpu
buck2 test mode/opt fbcode//caffe2/test/inductor:lookup_table_e2e
```

Rollback Plan:

Differential Revision: D76945358




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov