### PR TITLE
Deprecate c10::string_view

### DIFF
--- a/c10/util/string_view.h
+++ b/c10/util/string_view.h
@@ -592,7 +592,10 @@ constexpr inline void swap(
     basic_string_view<CharT>& rhs) noexcept {
   lhs.swap(rhs);
 }
+
+#if !defined(C10_NODEPRECATED)
 using string_view = std::string_view;
+#endif
 using c10_string_view = basic_string_view<char>;
 
 // NOTE: In C++20, this function should be replaced by string_view.starts_with


### PR DESCRIPTION
Wrap ``c10::string_view`` around `C10_NODEPRECATED`
