### PR TITLE
[Draft][CUDA] Upgrade torch._scaled_grouped_mm to SM100+

### DIFF
--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -1564,44 +1564,99 @@ namespace {
     }
   }
 
-  void check_scale(const Tensor& mat, const Tensor& scale, const int dim, const int arg_idx, const int scale_multiplier=1) {
-    if (mat.dim() == 2) {
+  void check_input_and_scale_size(const Tensor& mat_a, const Tensor& mat_b, const Tensor& scale_a, const Tensor& scale_b, const std::optional<at::Tensor>& offs) {
+    cuda::detail::GroupCountInfo info = at::cuda::detail::get_group_count(mat_a, mat_b, offs);
+    auto dprops = at::cuda::getCurrentDeviceProperties();
+    if (dprops->major == 9) {
+        TORCH_CHECK(
+          mat_a.size(-1) % 16 == 0,
+          "Expected trailing dimension of mat_a to be divisible by 16 ",
+          "but got mat1 shape: (",
+          mat_a.sizes(),
+          ").");
+        TORCH_CHECK(mat_b.size(-2) % 16 == 0 && mat_b.size(-1) % 16 == 0,
+          "Expected mat_b shape to be divisible by 16 ",
+          "but got mat_b shape: (",
+          mat_b.sizes(),
+          ").");
+
+      auto check_scale_for_mat = [&](const Tensor& mat, const Tensor& scale, const int dim, const int arg_idx) {
+        if (mat.dim() == 2) {
+          TORCH_CHECK(
+              scale.dim() == 1, "scale must be a 1D tensor, but got ", scale.dim(), "D, arg ", arg_idx);
+          TORCH_CHECK(
+              scale.is_contiguous(), "scale must be contiguous for arg ", arg_idx);
+          TORCH_CHECK(
+              scale.size(0) == mat.size(dim) * ( (info.input_matrix_type == at::cuda::detail::GroupMMInputMatrixType::GroupMMInputMatrixType_MatrixA_2D_MatrixB_2D) ? info.group_count : 1), "scale must have the same length as mat for arg ", arg_idx);
+        } else {
+          TORCH_CHECK(
+              scale.dim() == 2,
+              "scale must be a 2D tensor, but got ", scale.dim(), "D for arg ", arg_idx);
+          TORCH_CHECK(
+              scale.stride(1) == 1,
+              "scale must be contiguous in the last dimension for arg ", arg_idx);
+          TORCH_CHECK(
+              scale.size(0) == mat.size(0),
+              "scale must have the same batch dimension as mat for arg ", arg_idx);
+          TORCH_CHECK(
+              scale.size(1) == mat.size(1 + dim),
+              "scale must have the same first dimension as mat for arg ", arg_idx);
+        }
+      };
+
+      check_scale_for_mat(mat_a, scale_a, 0, 0);
+      check_scale_for_mat(mat_b, scale_b, 1, 1);
+    } else if (dprops->major >= 10) {
+
       TORCH_CHECK(
-          scale.dim() == 1,
-          "scale must be a 1D tensor, but got ",
-          scale.dim(),
-          "D, arg ",
-          arg_idx);
+        mat_a.size(-1) % 128 == 0,
+        "Expected trailing dimension of mat_a (K) to be divisible by 128 ",
+        "but got mat1 shape: (",
+        mat_a.sizes(),
+        ").");
+      TORCH_CHECK(mat_b.size(-2) % 128 == 0 && mat_b.size(-1) % 128 == 0,
+        "Expected mat_b shape (N, K) to be divisible by 128 ",
+        "but got mat_b shape: (",
+        mat_b.sizes(),
+        ").");
+
+      const int m_scale_group_size = 1;
+      const int n_scale_group_size = 128;
+      const int k_scale_group_size = 128;
+
       TORCH_CHECK(
-          scale.is_contiguous(), "scale must be contiguous for arg ", arg_idx);
+          scale_a.dim() == 3,
+          "scale_a must be a 3D tensor, but got ", scale_a.dim(), "D");
       TORCH_CHECK(
-          scale.size(0) == mat.size(dim) * scale_multiplier,
-          "scale must have the same length as mat for arg ",
-          arg_idx);
+          scale_a.size(0) == info.group_count,
+          "scale_a must describe the group count");
+      TORCH_CHECK(
+          scale_a.size(1) == info.M / m_scale_group_size,
+          "scale_a.size(1) must be the size ", info.M , " / " , m_scale_group_size, " = ", info.M / m_scale_group_size);
+      TORCH_CHECK(
+          scale_a.size(2) == info.K / k_scale_group_size,
+          "scale_a.size(2) must be the size ", info.K , " / " , k_scale_group_size, " = ", info.K / k_scale_group_size);
+
+      TORCH_CHECK(
+          scale_b.dim() == 3,
+          "scale_b must be a 3D tensor, but got ", scale_b.dim(), "D");
+      TORCH_CHECK(
+          scale_b.size(0) == info.group_count,
+          "scale_b must describe the group count");
+      TORCH_CHECK(
+          scale_b.size(1) == info.N / n_scale_group_size,
+          "scale_b.size(1) must be the size ", info.N , " / " , n_scale_group_size, " = ", info.N / n_scale_group_size);
+      TORCH_CHECK(
+          scale_b.size(2) == info.K / k_scale_group_size,
+          "scale_b.size(2) must be the size ", info.K , " / " , k_scale_group_size, " = ", info.K / k_scale_group_size);
+
     } else {
-      TORCH_CHECK(
-          scale.dim() == 2,
-          "scale must be a 2D tensor, but got ",
-          scale.dim(),
-          "D for arg ",
-          arg_idx);
-      TORCH_CHECK(
-          scale.stride(1) == 1,
-          "scale must be contiguous in the last dimension for arg ",
-          arg_idx);
-      TORCH_CHECK(
-          scale.size(0) == mat.size(0),
-          "scale must have the same batch dimension as mat for arg ",
-          arg_idx);
-      TORCH_CHECK(
-          scale.size(1) == mat.size(1 + dim),
-          "scale must have the same first dimension as mat for arg ",
-          arg_idx);
+      TORCH_CHECK(false, "torch._scaled_grouped_mm is only supported on CUDA devices with compute capability >= 9.0");
     }
-}
 
+  }
 
-}
+} // anonymous namespace
 
 Tensor
 _scaled_mm_cuda(const Tensor& mat_a, const Tensor& mat_b,
@@ -1664,9 +1719,7 @@ bool use_fast_accum) {
       scale_a.scalar_type() == kFloat && scale_b.scalar_type() == kFloat,
       "Both scale_a and scale_b must be float (fp32) tensors.");
 
-  const int scale_multiplier = (mat_a.dim() == 2 && mat_b.dim() == 2) ? offs->size(0) : 1;
-  check_scale(mat_a, scale_a, 0 ,0, scale_multiplier);
-  check_scale(mat_b, scale_b, 1, 1, scale_multiplier);
+  check_input_and_scale_size(mat_a, mat_b, scale_a, scale_b, offs);
 
   Tensor out = create_grouped_gemm_output_tensor(mat_a, mat_b, offs, out_dtype);
 

--- a/aten/src/ATen/native/cuda/GroupMM.cu
+++ b/aten/src/ATen/native/cuda/GroupMM.cu
@@ -248,6 +248,8 @@ void bf16bf16_grouped_gemm_impl_sm90_sm100(
       tensor_StrideA,
       tensor_StrideB,
       tensor_StrideOutput,
+      tensor_ShapeA,
+      tensor_ShapeB,
       scaling_format,
       a_row_major,
       b_row_major);

--- a/aten/src/ATen/native/cuda/GroupMM.cu
+++ b/aten/src/ATen/native/cuda/GroupMM.cu
@@ -174,26 +174,9 @@ void bf16bf16_grouped_gemm_impl_sm90_sm100(
   using StrideA = typename Gemm::GemmKernel::InternalStrideA;
   using StrideB = typename Gemm::GemmKernel::InternalStrideB;
   using StrideOutput = typename Gemm::GemmKernel::InternalStrideD;
-  int32_t M, N, K, group_count;
 
-  M = mat_a.size(-2);
-  K = mat_a.size(-1);
-  N = mat_b.size(-1);
-
-  if (mat_a.dim() == 2 && mat_b.dim() == 2) {
-    // if both inputs are ragged, K is dynamic, M and N come from inputs
-    group_count = offs->size(0);
-    K = -1;
-  } else if (mat_a.dim() == 2) {
-    group_count = mat_b.size(0);
-    M = -1;
-  } else if (mat_b.dim() == 2) {
-    group_count = mat_a.size(0);
-    N = -1;
-  } else {
-    // regular bmm
-    group_count = mat_a.size(0);
-  }
+  auto group_count_info = at::cuda::detail::get_group_count(mat_a, mat_b, offs);
+  int32_t group_count = group_count_info.group_count;
 
   TORCH_CHECK(group_count < 1024, "Can't process more than 1024 groups");
   const int64_t problem_shape_size =
@@ -260,9 +243,7 @@ void bf16bf16_grouped_gemm_impl_sm90_sm100(
       stride_B,
       stride_output,
       offs.has_value() ? offs->const_data_ptr<int32_t>() : nullptr,
-      M,
-      N,
-      K,
+      group_count_info,
       tensor_StrideA,
       tensor_StrideB,
       tensor_StrideOutput,
@@ -322,24 +303,8 @@ void dispatch_bf16_grouped_kernel_on_tile_size(
     std::optional<at::Tensor> offs,
     std::optional<at::Tensor> bias, // BF16
     at::Tensor& out) {
-  int32_t M, N, K, group_count;
 
-  M = mat_a.size(-2);
-  K = mat_a.size(-1);
-  N = mat_b.size(-1);
-
-  // below we assume that gemms are approx same size
-  if (mat_a.dim() == 2 && mat_b.dim() == 2) {
-    // if both inputs are ragged, K is dynamic, M and N come from inputs
-    group_count = offs->size(0);
-    K = K / group_count;
-  } else if (mat_a.dim() == 2) {
-    group_count = mat_b.size(0);
-    M = M / group_count;
-  } else if (mat_b.dim() == 2) {
-    group_count = mat_a.size(0);
-    N = N / group_count;
-  }
+  auto [M, N, K, group_count, type] = at::cuda::detail::get_group_count(mat_a, mat_b, offs);
   //   bool large =
   //       ((M >= 2048 && K >= 2048) || (M >= 2048 && N >= 2048) ||
   //        (K >= 2048 && N >= 2048));

--- a/aten/src/ATen/native/cuda/GroupMMCommon.cuh
+++ b/aten/src/ATen/native/cuda/GroupMMCommon.cuh
@@ -1,5 +1,6 @@
 #pragma once
 #include <cutlass/util/packed_stride.hpp>
+#include <ATen/native/cuda/ScaledGroupMM.h>
 
 namespace at::cuda::detail {
 
@@ -31,9 +32,7 @@ __global__ void prepare_grouped_gemm_data(
     StrideB* stride_B,
     StrideOutput* stride_output,
     const int32_t* offs,
-    int32_t M,
-    int32_t N,
-    int32_t K,
+    GroupCountInfo group_count_info,
     // Original strides of the input tensors
     Strides tensor_StrideA,
     Strides tensor_StrideB,
@@ -44,6 +43,10 @@ __global__ void prepare_grouped_gemm_data(
     int64_t b_scale_stride,
     bool a_row_major = true,
     bool b_row_major = false) {
+  int32_t M = group_count_info.M;
+  int32_t N = group_count_info.N;
+  int32_t K = group_count_info.K;
+
   int32_t tid = threadIdx.x;
   int32_t delta = 0;
   int32_t offset = 0;
@@ -84,7 +87,7 @@ __global__ void prepare_grouped_gemm_data(
     }
   }
   int64_t lda, ldb, ldoutput;
-  if (M < 0) {
+  if (group_count_info.input_matrix_type == GroupMMInputMatrixType::GroupMMInputMatrixType_MatrixA_2D_MatrixB_3D) {
     // A and output is 2d
     CUDA_KERNEL_ASSERT(offset <= tensor_ShapeA[0] && "expected offset to be less than tensor size\n");
     M = delta;
@@ -98,7 +101,7 @@ __global__ void prepare_grouped_gemm_data(
     }
     output_ptrs[tid] = tid == 0 ? output : output + offs[tid - 1] * ldoutput;
     B_ptrs[tid] = B + tid * tensor_StrideB[0];
-  } else if (N < 0) {
+  } else if (group_count_info.input_matrix_type == GroupMMInputMatrixType::GroupMMInputMatrixType_MatrixA_3D_MatrixB_2D) {
     CUDA_KERNEL_ASSERT(offset <= tensor_ShapeB[1] && "expected offset to be less than tensor size\n");
     N = delta;
     lda = a_row_major ? tensor_StrideA[1] : tensor_StrideA[2];
@@ -111,7 +114,7 @@ __global__ void prepare_grouped_gemm_data(
       inputA_scale_ptrs[tid] = scale_A + tid * a_scale_stride;
       inputB_scale_ptrs[tid] = tid == 0 ? scale_B : scale_B + offs[tid - 1];
     }
-  } else if (K < 0) {
+  } else if (group_count_info.input_matrix_type == GroupMMInputMatrixType::GroupMMInputMatrixType_MatrixA_2D_MatrixB_2D) {
     CUDA_KERNEL_ASSERT(offset <= tensor_ShapeA[1] && offset <= tensor_ShapeB[0] && "expected offset to be less than tensor size\n");
     // A, B is 2d, output is 3d
     K = delta;
@@ -152,5 +155,174 @@ __global__ void prepare_grouped_gemm_data(
   stride_B[tid] = cutlass::make_cute_packed_stride(StrideB{}, {ldb, ldb, 1});
   stride_output[tid] =
       cutlass::make_cute_packed_stride(StrideOutput{}, {M, ldoutput, 1});
+}
+
+template <
+    typename DtypeA,
+    typename DtypeB,
+    typename DtypeOutput,
+    typename DtypeScale,
+    typename ProblemShape,
+    typename StrideA,
+    typename StrideB,
+    typename StrideOutput,
+    typename LayoutSFA,
+    typename LayoutSFB,
+    typename ScaleConfig>
+__global__ void prepare_grouped_gemm_data_sm100(
+    DtypeA* A,
+    DtypeB* B,
+    DtypeOutput* output,
+    DtypeScale* scale_A,
+    DtypeScale* scale_B,
+    DtypeA** A_ptrs,
+    DtypeB** B_ptrs,
+    DtypeOutput** output_ptrs,
+    DtypeScale** inputA_scale_ptrs,
+    DtypeScale** inputB_scale_ptrs,
+    ProblemShape* problem_sizes,
+    // Strides for cutlass, cute::Stride
+    StrideA* stride_A,
+    StrideB* stride_B,
+    StrideOutput* stride_output,
+    const int32_t* offs,
+    GroupCountInfo group_count_info,
+    // Original strides of the input tensors
+    Strides tensor_StrideA,
+    Strides tensor_StrideB,
+    Strides tensor_StrideOutput,
+    Strides tensor_StrideSFA,
+    Strides tensor_StrideSFB,
+    LayoutSFA* layout_sfa_base_as_int,
+    LayoutSFB* layout_sfb_base_as_int,
+    bool transpose = false,
+    bool a_row_major = true,
+    bool b_row_major = false) {
+
+  int32_t M = group_count_info.M;
+  int32_t N = group_count_info.N;
+  int32_t K = group_count_info.K;
+
+  int32_t tid = threadIdx.x;
+  int32_t delta = 0;
+  if (offs != nullptr) {
+    int32_t start = tid == 0 ? 0 : offs[tid - 1];
+    delta = offs[tid] - start;
+    if (K < 0) {
+      if (!a_row_major && b_row_major) {
+        CUDA_KERNEL_ASSERT(delta >=0 && "expected ofsets to be greater or equal 0\n");
+      } else  {
+        // CUTLASS cannot handle delta=0 here.
+        CUDA_KERNEL_ASSERT(delta >0 && "expected ofsets to be greater than 0\n");
+      }
+    }
+
+    // TMA transfers require global memory tensor addresses to be
+    // aligned to 16 bytes.
+    if (tid < blockDim.x - 1) {
+      // Check this requirement for input tensors, in case group
+      // addresses are increased along the dynamic dimension.
+      if ((K < 0 && a_row_major) ||       // 2D/2D: check along K dimension
+          (M < 0 && !a_row_major)) {      // 3D/2D: check along N dimension
+        int align = 128 / cutlass::sizeof_bits<DtypeA>::value;
+        CUDA_KERNEL_ASSERT(
+                           delta % align == 0 &&
+                           "expected input tensor dynamic dimension byte size to be non-negative multiple of 16\n");
+      }
+      if ((K < 0 && !b_row_major) ||      // 2D/2D: check along K dimension
+          (N < 0 && b_row_major)) {       // 3D/2D: check along N dimension
+        int align = 128 / cutlass::sizeof_bits<DtypeB>::value;
+        CUDA_KERNEL_ASSERT(
+                           delta % align == 0 &&
+                           "expected input tensor dynamic dimension byte size to be non-negative multiple of 16\n");
+      }
+
+      // Check the same requirement for output tensor (that is always
+      // contiguous, and in row-major layout).
+      if (N < 0) {
+        int align = 128 / cutlass::sizeof_bits<DtypeOutput>::value;
+        CUDA_KERNEL_ASSERT(
+                           delta % align == 0 &&
+                           "expected output tensor dynamic dimension byte size to be non-negative multiple of 16\n");
+      }
+    }
+  }
+  int64_t lda, ldb, ldoutput;
+
+  if (group_count_info.input_matrix_type == GroupMMInputMatrixType::GroupMMInputMatrixType_MatrixA_2D_MatrixB_3D) {
+    // A and output is 2d
+    M = delta;
+    lda = a_row_major ? tensor_StrideA[0] : tensor_StrideA[1];
+    ldb = b_row_major ? tensor_StrideB[1] : tensor_StrideB[2];
+    ldoutput = tensor_StrideOutput[0];
+    A_ptrs[tid] = tid == 0 ? A : A + offs[tid - 1] * tensor_StrideA[0];
+    B_ptrs[tid] = B + tid * tensor_StrideB[0];
+    output_ptrs[tid] = tid == 0 ? output : output + offs[tid - 1] * ldoutput;
+  } else if (group_count_info.input_matrix_type == GroupMMInputMatrixType::GroupMMInputMatrixType_MatrixA_3D_MatrixB_2D) {
+    N = delta;
+    lda = a_row_major ? tensor_StrideA[1] : tensor_StrideA[2];
+    ldb =
+        b_row_major ? tensor_StrideB[0] : tensor_StrideB[1]; // B is transposed
+    ldoutput = tensor_StrideOutput[0];
+    A_ptrs[tid] = A + tid * tensor_StrideA[0];
+    B_ptrs[tid] = tid == 0 ? B : B + offs[tid - 1] * tensor_StrideB[1];
+    output_ptrs[tid] = tid == 0 ? output : output + offs[tid - 1];
+  } else if (group_count_info.input_matrix_type == GroupMMInputMatrixType::GroupMMInputMatrixType_MatrixA_2D_MatrixB_2D) {
+    // A, B is 2d, output is 3d
+    K = delta;
+    lda = a_row_major ? tensor_StrideA[0] : tensor_StrideA[1];
+    ldb = b_row_major ? tensor_StrideB[0] : tensor_StrideB[1];
+    ldoutput = tensor_StrideOutput[1];
+    A_ptrs[tid] = tid == 0 ? A : A + offs[tid - 1] * tensor_StrideA[1];
+    B_ptrs[tid] = tid == 0 ? B : B + offs[tid - 1] * tensor_StrideB[0];
+    output_ptrs[tid] = output + tid * tensor_StrideOutput[0];
+  } else {
+    // A, B, output are 3D
+    lda = a_row_major ? tensor_StrideA[1] : tensor_StrideA[2];
+    ldb = b_row_major ? tensor_StrideB[1] : tensor_StrideB[2];
+    ldoutput = tensor_StrideOutput[1];
+    A_ptrs[tid] = A + tid * tensor_StrideA[0];
+    B_ptrs[tid] = B + tid * tensor_StrideB[0];
+    output_ptrs[tid] = output + tid * tensor_StrideOutput[0];
+  }
+
+  if (scale_A != nullptr) {
+    // We support only scale_A and scale_B are 3D tensors now.
+    inputA_scale_ptrs[tid] = scale_A + tid * tensor_StrideSFA[0];
+    inputB_scale_ptrs[tid] = scale_B + tid * tensor_StrideSFB[0];
+  }
+  // make_cute_packed_stride only replaces one of the stride elements with
+  // one the provided values in the shape arguments
+  // the indices of the src/dst depend on whether A/B are row-major
+  // so constructing shape argument with two similar lda values
+  // while it looks non-sensical (and it is a nonsensical shape)
+  // is fine for these stride construction purposes - the one that will be used
+  // for replacement is correct, the other one is ignored, and we don't have to
+  // branch on whether A/B are row-major
+  stride_A[tid] = cutlass::make_cute_packed_stride(StrideA{}, {lda, lda, 1});
+  stride_B[tid] = cutlass::make_cute_packed_stride(StrideB{}, {ldb, ldb, 1});
+  stride_output[tid] =
+      cutlass::make_cute_packed_stride(StrideOutput{}, {M, ldoutput, 1});
+
+  if (transpose) {
+    problem_sizes[tid] = ProblemShape(N, M, K);
+  } else {
+    problem_sizes[tid] = ProblemShape(M, N, K);
+  }
+
+  LayoutSFA* layout_sfa_ptr = layout_sfa_base_as_int + tid;
+  LayoutSFB* layout_sfb_ptr = layout_sfb_base_as_int + tid;
+
+  if (!transpose) {
+    *layout_sfa_ptr =
+        ScaleConfig::tile_atom_to_shape_SFA(cute::make_shape(M, N, K, 1));
+    *layout_sfb_ptr =
+        ScaleConfig::tile_atom_to_shape_SFB(cute::make_shape(M, N, K, 1));
+  } else {
+    *layout_sfa_ptr =
+        ScaleConfig::tile_atom_to_shape_SFA(cute::make_shape(N, M, K, 1));
+    *layout_sfb_ptr =
+        ScaleConfig::tile_atom_to_shape_SFB(cute::make_shape(N, M, K, 1));
+  }
 }
 } // namespace at::cuda::detail

--- a/aten/src/ATen/native/cuda/GroupMMCommon.cuh
+++ b/aten/src/ATen/native/cuda/GroupMMCommon.cuh
@@ -1,10 +1,64 @@
 #pragma once
-#include <cutlass/util/packed_stride.hpp>
 #include <ATen/native/cuda/ScaledGroupMM.h>
+#include <cutlass/util/packed_stride.hpp>
 
 namespace at::cuda::detail {
 
 using Strides = std::array<int64_t, 3>;
+
+struct Sm90ScalingFormat {
+  int64_t a_scale_stride = 0;
+  int64_t b_scale_stride = 0;
+
+  template <bool is_a, bool is_2D = true>
+  __device__ __forceinline__ size_t
+  get_input_scale_ptr_offset(int32_t tid, const int32_t* offs) {
+    auto stride = is_a ? a_scale_stride : b_scale_stride;
+    if constexpr (is_2D) {
+      return tid == 0 ? 0 : offs[tid - 1];
+    } else {
+      return tid * stride;
+    }
+  }
+
+  __device__ __forceinline__ void setup_layout(
+      int32_t tid,
+      const int32_t* offs,
+      int32_t M,
+      int32_t N,
+      int32_t K) {}
+};
+
+template <typename LayoutSFA, typename LayoutSFB, typename ScaleConfig>
+struct Sm100ScalingFormat {
+  Strides tensor_StrideSFA = {};
+  Strides tensor_StrideSFB = {};
+  LayoutSFA* layout_sfa_ptr = nullptr;
+  LayoutSFB* layout_sfb_ptr = nullptr;
+
+  template <bool is_a, bool use_offset = true>
+  __device__ __forceinline__ size_t
+  get_input_scale_ptr_offset(int32_t tid, const int32_t* offs) {
+    auto stride = is_a ? tensor_StrideSFA[0] : tensor_StrideSFB[0];
+    if constexpr (use_offset) {
+      return tid == 0 ? 0 : offs[tid - 1] * stride;
+    } else {
+      return tid * stride;
+    }
+  }
+
+  __device__ __forceinline__ void setup_layout(
+      int32_t tid,
+      const int32_t* offs,
+      int32_t M,
+      int32_t N,
+      int32_t K) {
+    layout_sfa_ptr[tid] =
+        ScaleConfig::tile_atom_to_shape_SFA(cute::make_shape(M, N, K, 1));
+    layout_sfb_ptr[tid] =
+        ScaleConfig::tile_atom_to_shape_SFB(cute::make_shape(M, N, K, 1));
+  }
+};
 
 template <
     typename DtypeA,
@@ -14,7 +68,8 @@ template <
     typename ProblemShape,
     typename StrideA,
     typename StrideB,
-    typename StrideOutput>
+    typename StrideOutput,
+    typename ScalingFormat>
 __global__ void prepare_grouped_gemm_data(
     DtypeA* A,
     DtypeB* B,
@@ -37,57 +92,65 @@ __global__ void prepare_grouped_gemm_data(
     Strides tensor_StrideA,
     Strides tensor_StrideB,
     Strides tensor_StrideOutput,
-    Strides tensor_ShapeA,
-    Strides tensor_ShapeB,
-    int64_t a_scale_stride,
-    int64_t b_scale_stride,
+    ScalingFormat scaling_format,
     bool a_row_major = true,
     bool b_row_major = false) {
+
+  // The M, N, K may need to be recalculated from the offs tensor
   int32_t M = group_count_info.M;
   int32_t N = group_count_info.N;
   int32_t K = group_count_info.K;
 
+  auto input_type = group_count_info.input_matrix_type;
   int32_t tid = threadIdx.x;
   int32_t delta = 0;
-  int32_t offset = 0;
+
   if (offs != nullptr) {
     int32_t start = tid == 0 ? 0 : offs[tid - 1];
-    offset = offs[tid];
-    delta = offset - start;
-    CUDA_KERNEL_ASSERT(delta >=0 && "expected gemm dimension to be greater or equal 0\n");
+    delta = offs[tid] - start;
+    if (input_type == GroupMMInputMatrixType::MatrixA_2D_MatrixB_2D) {
+      CUDA_KERNEL_ASSERT(
+          delta >= 0 && "expected ofsets to be greater or equal 0\n");
+    }
 
     // TMA transfers require global memory tensor addresses to be
     // aligned to 16 bytes.
     if (tid < blockDim.x - 1) {
       // Check this requirement for input tensors, in case group
       // addresses are increased along the dynamic dimension.
-      if ((K < 0 && a_row_major) ||       // 2D/2D: check along K dimension
-          (M < 0 && !a_row_major)) {      // 3D/2D: check along N dimension
+      if ((input_type == GroupMMInputMatrixType::MatrixA_2D_MatrixB_2D &&
+           a_row_major) || // 2D/2D: check along K dimension
+          (input_type == GroupMMInputMatrixType::MatrixA_2D_MatrixB_3D &&
+           !a_row_major)) { // 3D/2D: check along M dimension
         int align = 128 / cutlass::sizeof_bits<DtypeA>::value;
         CUDA_KERNEL_ASSERT(
-                           delta % align == 0 &&
-                           "expected input tensor dynamic dimension byte size to be non-negative multiple of 16\n");
+            delta % align == 0 &&
+            "expected input tensor dynamic dimension byte size to be non-negative multiple of 16\n");
       }
-      if ((K < 0 && !b_row_major) ||      // 2D/2D: check along K dimension
-          (N < 0 && b_row_major)) {       // 3D/2D: check along N dimension
+      if ((input_type == GroupMMInputMatrixType::MatrixA_2D_MatrixB_2D &&
+           !b_row_major) || // 2D/2D: check along K dimension
+          (input_type == GroupMMInputMatrixType::MatrixA_3D_MatrixB_2D &&
+           b_row_major)) { // 3D/2D: check along N dimension
         int align = 128 / cutlass::sizeof_bits<DtypeB>::value;
         CUDA_KERNEL_ASSERT(
-                           delta % align == 0 &&
-                           "expected input tensor dynamic dimension byte size to be non-negative multiple of 16\n");
+            delta % align == 0 &&
+            "expected input tensor dynamic dimension byte size to be non-negative multiple of 16\n");
       }
 
       // Check the same requirement for output tensor (that is always
       // contiguous, and in row-major layout).
-      if (N < 0) {
+      if (input_type == GroupMMInputMatrixType::MatrixA_3D_MatrixB_2D) {
         int align = 128 / cutlass::sizeof_bits<DtypeOutput>::value;
         CUDA_KERNEL_ASSERT(
-                           delta % align == 0 &&
-                           "expected output tensor dynamic dimension byte size to be non-negative multiple of 16\n");
+            delta % align == 0 &&
+            "expected output tensor dynamic dimension byte size to be non-negative multiple of 16\n");
       }
     }
   }
-  int64_t lda, ldb, ldoutput;
-  if (group_count_info.input_matrix_type == GroupMMInputMatrixType::GroupMMInputMatrixType_MatrixA_2D_MatrixB_3D) {
+
+  int64_t lda{}, ldb{}, ldoutput{};
+
+  if (input_type == GroupMMInputMatrixType::MatrixA_2D_MatrixB_3D) {
     // A and output is 2d
     CUDA_KERNEL_ASSERT(offset <= tensor_ShapeA[0] && "expected offset to be less than tensor size\n");
     M = delta;
@@ -96,13 +159,14 @@ __global__ void prepare_grouped_gemm_data(
     ldoutput = tensor_StrideOutput[0];
     A_ptrs[tid] = tid == 0 ? A : A + offs[tid - 1] * tensor_StrideA[0];
     if (scale_A != nullptr) {
-      inputA_scale_ptrs[tid] = tid == 0 ? scale_A : scale_A + offs[tid - 1];
-      inputB_scale_ptrs[tid] = scale_B + tid * b_scale_stride;
+      inputA_scale_ptrs[tid] = scale_A +
+          scaling_format.template get_input_scale_ptr_offset<true, true>(tid, offs);
+      inputB_scale_ptrs[tid] = scale_B +
+          scaling_format.template get_input_scale_ptr_offset<false, false>(tid, offs);
     }
     output_ptrs[tid] = tid == 0 ? output : output + offs[tid - 1] * ldoutput;
     B_ptrs[tid] = B + tid * tensor_StrideB[0];
-  } else if (group_count_info.input_matrix_type == GroupMMInputMatrixType::GroupMMInputMatrixType_MatrixA_3D_MatrixB_2D) {
-    CUDA_KERNEL_ASSERT(offset <= tensor_ShapeB[1] && "expected offset to be less than tensor size\n");
+  } else if (input_type == GroupMMInputMatrixType::MatrixA_3D_MatrixB_2D) {
     N = delta;
     lda = a_row_major ? tensor_StrideA[1] : tensor_StrideA[2];
     ldb = b_row_major ? tensor_StrideB[0] : tensor_StrideB[1]; // B is transposed
@@ -111,11 +175,12 @@ __global__ void prepare_grouped_gemm_data(
     output_ptrs[tid] = tid == 0 ? output : output + offs[tid - 1];
     B_ptrs[tid] = tid == 0 ? B : B + offs[tid - 1] * tensor_StrideB[1];
     if (scale_A != nullptr) {
-      inputA_scale_ptrs[tid] = scale_A + tid * a_scale_stride;
-      inputB_scale_ptrs[tid] = tid == 0 ? scale_B : scale_B + offs[tid - 1];
+      inputA_scale_ptrs[tid] = scale_A +
+          scaling_format.template get_input_scale_ptr_offset<true, false>(tid, offs);
+      inputB_scale_ptrs[tid] = scale_B +
+          scaling_format.template get_input_scale_ptr_offset<false, true>(tid, offs);
     }
-  } else if (group_count_info.input_matrix_type == GroupMMInputMatrixType::GroupMMInputMatrixType_MatrixA_2D_MatrixB_2D) {
-    CUDA_KERNEL_ASSERT(offset <= tensor_ShapeA[1] && offset <= tensor_ShapeB[0] && "expected offset to be less than tensor size\n");
+  } else if (input_type == GroupMMInputMatrixType::MatrixA_2D_MatrixB_2D) {
     // A, B is 2d, output is 3d
     K = delta;
     lda = a_row_major ? tensor_StrideA[0] : tensor_StrideA[1];
@@ -125,11 +190,14 @@ __global__ void prepare_grouped_gemm_data(
     B_ptrs[tid] = tid == 0 ? B : B + offs[tid - 1] * tensor_StrideB[0];
     output_ptrs[tid] = output + tid * tensor_StrideOutput[0];
     if (scale_A != nullptr) {
-      inputA_scale_ptrs[tid] = scale_A + tid * M;
-      inputB_scale_ptrs[tid] = scale_B + tid * N;
+      // for scale 2D/2D, we shift the pointer by M/N
+      inputA_scale_ptrs[tid] = scale_A +
+          scaling_format.template get_input_scale_ptr_offset<true, false>(tid, offs);
+      inputB_scale_ptrs[tid] = scale_B +
+          scaling_format.template get_input_scale_ptr_offset<false, false>(tid, offs);
     }
   } else {
-    // A, B, output are 3D
+    // A, B, output is 3D
     lda = a_row_major ? tensor_StrideA[1] : tensor_StrideA[2];
     ldb = b_row_major ? tensor_StrideB[1] : tensor_StrideB[2];
     ldoutput = tensor_StrideOutput[1];
@@ -137,8 +205,10 @@ __global__ void prepare_grouped_gemm_data(
     B_ptrs[tid] = B + tid * tensor_StrideB[0];
     output_ptrs[tid] = output + tid * tensor_StrideOutput[0];
     if (scale_A != nullptr) {
-      inputA_scale_ptrs[tid] = scale_A + tid * a_scale_stride;
-      inputB_scale_ptrs[tid] = scale_B + tid * b_scale_stride;
+      inputA_scale_ptrs[tid] = scale_A +
+          scaling_format.template get_input_scale_ptr_offset<true, false>(tid, offs);
+      inputB_scale_ptrs[tid] = scale_B +
+          scaling_format.template get_input_scale_ptr_offset<false, false>(tid, offs);
     }
   }
   problem_sizes[tid] = ProblemShape(M, N, K);
@@ -155,174 +225,8 @@ __global__ void prepare_grouped_gemm_data(
   stride_B[tid] = cutlass::make_cute_packed_stride(StrideB{}, {ldb, ldb, 1});
   stride_output[tid] =
       cutlass::make_cute_packed_stride(StrideOutput{}, {M, ldoutput, 1});
+
+  scaling_format.setup_layout(tid, offs, M, N, K);
 }
 
-template <
-    typename DtypeA,
-    typename DtypeB,
-    typename DtypeOutput,
-    typename DtypeScale,
-    typename ProblemShape,
-    typename StrideA,
-    typename StrideB,
-    typename StrideOutput,
-    typename LayoutSFA,
-    typename LayoutSFB,
-    typename ScaleConfig>
-__global__ void prepare_grouped_gemm_data_sm100(
-    DtypeA* A,
-    DtypeB* B,
-    DtypeOutput* output,
-    DtypeScale* scale_A,
-    DtypeScale* scale_B,
-    DtypeA** A_ptrs,
-    DtypeB** B_ptrs,
-    DtypeOutput** output_ptrs,
-    DtypeScale** inputA_scale_ptrs,
-    DtypeScale** inputB_scale_ptrs,
-    ProblemShape* problem_sizes,
-    // Strides for cutlass, cute::Stride
-    StrideA* stride_A,
-    StrideB* stride_B,
-    StrideOutput* stride_output,
-    const int32_t* offs,
-    GroupCountInfo group_count_info,
-    // Original strides of the input tensors
-    Strides tensor_StrideA,
-    Strides tensor_StrideB,
-    Strides tensor_StrideOutput,
-    Strides tensor_StrideSFA,
-    Strides tensor_StrideSFB,
-    LayoutSFA* layout_sfa_base_as_int,
-    LayoutSFB* layout_sfb_base_as_int,
-    bool transpose = false,
-    bool a_row_major = true,
-    bool b_row_major = false) {
-
-  int32_t M = group_count_info.M;
-  int32_t N = group_count_info.N;
-  int32_t K = group_count_info.K;
-
-  int32_t tid = threadIdx.x;
-  int32_t delta = 0;
-  if (offs != nullptr) {
-    int32_t start = tid == 0 ? 0 : offs[tid - 1];
-    delta = offs[tid] - start;
-    if (K < 0) {
-      if (!a_row_major && b_row_major) {
-        CUDA_KERNEL_ASSERT(delta >=0 && "expected ofsets to be greater or equal 0\n");
-      } else  {
-        // CUTLASS cannot handle delta=0 here.
-        CUDA_KERNEL_ASSERT(delta >0 && "expected ofsets to be greater than 0\n");
-      }
-    }
-
-    // TMA transfers require global memory tensor addresses to be
-    // aligned to 16 bytes.
-    if (tid < blockDim.x - 1) {
-      // Check this requirement for input tensors, in case group
-      // addresses are increased along the dynamic dimension.
-      if ((K < 0 && a_row_major) ||       // 2D/2D: check along K dimension
-          (M < 0 && !a_row_major)) {      // 3D/2D: check along N dimension
-        int align = 128 / cutlass::sizeof_bits<DtypeA>::value;
-        CUDA_KERNEL_ASSERT(
-                           delta % align == 0 &&
-                           "expected input tensor dynamic dimension byte size to be non-negative multiple of 16\n");
-      }
-      if ((K < 0 && !b_row_major) ||      // 2D/2D: check along K dimension
-          (N < 0 && b_row_major)) {       // 3D/2D: check along N dimension
-        int align = 128 / cutlass::sizeof_bits<DtypeB>::value;
-        CUDA_KERNEL_ASSERT(
-                           delta % align == 0 &&
-                           "expected input tensor dynamic dimension byte size to be non-negative multiple of 16\n");
-      }
-
-      // Check the same requirement for output tensor (that is always
-      // contiguous, and in row-major layout).
-      if (N < 0) {
-        int align = 128 / cutlass::sizeof_bits<DtypeOutput>::value;
-        CUDA_KERNEL_ASSERT(
-                           delta % align == 0 &&
-                           "expected output tensor dynamic dimension byte size to be non-negative multiple of 16\n");
-      }
-    }
-  }
-  int64_t lda, ldb, ldoutput;
-
-  if (group_count_info.input_matrix_type == GroupMMInputMatrixType::GroupMMInputMatrixType_MatrixA_2D_MatrixB_3D) {
-    // A and output is 2d
-    M = delta;
-    lda = a_row_major ? tensor_StrideA[0] : tensor_StrideA[1];
-    ldb = b_row_major ? tensor_StrideB[1] : tensor_StrideB[2];
-    ldoutput = tensor_StrideOutput[0];
-    A_ptrs[tid] = tid == 0 ? A : A + offs[tid - 1] * tensor_StrideA[0];
-    B_ptrs[tid] = B + tid * tensor_StrideB[0];
-    output_ptrs[tid] = tid == 0 ? output : output + offs[tid - 1] * ldoutput;
-  } else if (group_count_info.input_matrix_type == GroupMMInputMatrixType::GroupMMInputMatrixType_MatrixA_3D_MatrixB_2D) {
-    N = delta;
-    lda = a_row_major ? tensor_StrideA[1] : tensor_StrideA[2];
-    ldb =
-        b_row_major ? tensor_StrideB[0] : tensor_StrideB[1]; // B is transposed
-    ldoutput = tensor_StrideOutput[0];
-    A_ptrs[tid] = A + tid * tensor_StrideA[0];
-    B_ptrs[tid] = tid == 0 ? B : B + offs[tid - 1] * tensor_StrideB[1];
-    output_ptrs[tid] = tid == 0 ? output : output + offs[tid - 1];
-  } else if (group_count_info.input_matrix_type == GroupMMInputMatrixType::GroupMMInputMatrixType_MatrixA_2D_MatrixB_2D) {
-    // A, B is 2d, output is 3d
-    K = delta;
-    lda = a_row_major ? tensor_StrideA[0] : tensor_StrideA[1];
-    ldb = b_row_major ? tensor_StrideB[0] : tensor_StrideB[1];
-    ldoutput = tensor_StrideOutput[1];
-    A_ptrs[tid] = tid == 0 ? A : A + offs[tid - 1] * tensor_StrideA[1];
-    B_ptrs[tid] = tid == 0 ? B : B + offs[tid - 1] * tensor_StrideB[0];
-    output_ptrs[tid] = output + tid * tensor_StrideOutput[0];
-  } else {
-    // A, B, output are 3D
-    lda = a_row_major ? tensor_StrideA[1] : tensor_StrideA[2];
-    ldb = b_row_major ? tensor_StrideB[1] : tensor_StrideB[2];
-    ldoutput = tensor_StrideOutput[1];
-    A_ptrs[tid] = A + tid * tensor_StrideA[0];
-    B_ptrs[tid] = B + tid * tensor_StrideB[0];
-    output_ptrs[tid] = output + tid * tensor_StrideOutput[0];
-  }
-
-  if (scale_A != nullptr) {
-    // We support only scale_A and scale_B are 3D tensors now.
-    inputA_scale_ptrs[tid] = scale_A + tid * tensor_StrideSFA[0];
-    inputB_scale_ptrs[tid] = scale_B + tid * tensor_StrideSFB[0];
-  }
-  // make_cute_packed_stride only replaces one of the stride elements with
-  // one the provided values in the shape arguments
-  // the indices of the src/dst depend on whether A/B are row-major
-  // so constructing shape argument with two similar lda values
-  // while it looks non-sensical (and it is a nonsensical shape)
-  // is fine for these stride construction purposes - the one that will be used
-  // for replacement is correct, the other one is ignored, and we don't have to
-  // branch on whether A/B are row-major
-  stride_A[tid] = cutlass::make_cute_packed_stride(StrideA{}, {lda, lda, 1});
-  stride_B[tid] = cutlass::make_cute_packed_stride(StrideB{}, {ldb, ldb, 1});
-  stride_output[tid] =
-      cutlass::make_cute_packed_stride(StrideOutput{}, {M, ldoutput, 1});
-
-  if (transpose) {
-    problem_sizes[tid] = ProblemShape(N, M, K);
-  } else {
-    problem_sizes[tid] = ProblemShape(M, N, K);
-  }
-
-  LayoutSFA* layout_sfa_ptr = layout_sfa_base_as_int + tid;
-  LayoutSFB* layout_sfb_ptr = layout_sfb_base_as_int + tid;
-
-  if (!transpose) {
-    *layout_sfa_ptr =
-        ScaleConfig::tile_atom_to_shape_SFA(cute::make_shape(M, N, K, 1));
-    *layout_sfb_ptr =
-        ScaleConfig::tile_atom_to_shape_SFB(cute::make_shape(M, N, K, 1));
-  } else {
-    *layout_sfa_ptr =
-        ScaleConfig::tile_atom_to_shape_SFA(cute::make_shape(N, M, K, 1));
-    *layout_sfb_ptr =
-        ScaleConfig::tile_atom_to_shape_SFB(cute::make_shape(N, M, K, 1));
-  }
-}
 } // namespace at::cuda::detail

--- a/aten/src/ATen/native/cuda/ScaledGroupMM.cu
+++ b/aten/src/ATen/native/cuda/ScaledGroupMM.cu
@@ -85,6 +85,7 @@ GroupCountInfo get_group_info(
     group_count = offs->size(0);
     type = GroupMMInputMatrixType::MatrixA_2D_MatrixB_2D;
     // stack on the K dimension
+    // Note: K here does not represent the actual size for each group; it is used solely for sizing heuristics.
     K = K / group_count;
   } else if (mat_a.dim() == 2) {
     group_count = mat_b.size(0);
@@ -374,6 +375,8 @@ void f8f8bf16_grouped_gemm_impl_sm90(
       tensor_StrideA,
       tensor_StrideB,
       tensor_StrideOutput,
+      tensor_ShapeA,
+      tensor_ShapeB,
       scaling_format,
       true,  // a_row_major
       false  // b_col_major
@@ -654,6 +657,8 @@ void launch_gemm_sm100(at::Tensor mat_a,   // FP8
   Strides tensor_StrideOutput = make_strides(out.strides());
   Strides tensor_StrideSFA = make_strides(scale_a.strides());
   Strides tensor_StrideSFB = make_strides(scale_b.strides());
+  Strides tensor_ShapeA = make_strides(mat_a.sizes());
+  Strides tensor_ShapeB = make_strides(mat_b.sizes());
 
   at::cuda::detail::Sm100ScalingFormat<typename Config::LayoutSFA, typename Config::LayoutSFB, typename Config::ScaleConfig> scaling_format{
     tensor_StrideSFA,
@@ -684,6 +689,8 @@ void launch_gemm_sm100(at::Tensor mat_a,   // FP8
       tensor_StrideA,
       tensor_StrideB,
       tensor_StrideOutput,
+      tensor_ShapeA,
+      tensor_ShapeB,
       scaling_format,
       true,  // a_row_major
       false  // b_col_major

--- a/aten/src/ATen/native/cuda/ScaledGroupMM.cu
+++ b/aten/src/ATen/native/cuda/ScaledGroupMM.cu
@@ -23,9 +23,11 @@ C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wunused-but-set-variable")
 
 #if defined(BUILD_ROWWISE_FP8_KERNEL)
 
+#include <ATen/ops/empty.h>
 #include <ATen/native/cuda/GroupMMCommon.cuh>
 
 #include <cute/tensor.hpp>
+#include <cutlass/arch/arch.h>
 #include <cutlass/core_io.h>
 #include <cutlass/cutlass.h>
 #include <cutlass/gemm/device/gemm.h>
@@ -42,8 +44,16 @@ C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wunused-but-set-variable")
 
 #include <cute/atom/mma_atom.hpp>
 #include <cutlass/gemm/dispatch_policy.hpp>
+#include <cutlass/gemm/group_array_problem_shape.hpp>
 #include <cutlass/gemm/kernel/gemm_universal.hpp>
 #include <cutlass/util/packed_stride.hpp>
+
+// Added for SM100 support
+#include <cutlass/epilogue/collective/default_epilogue.hpp>
+#include <cutlass/epilogue/thread/activation.h>
+#include <cutlass/epilogue/thread/linear_combination.h>
+#include <cutlass/gemm/kernel/tile_scheduler_params.h>
+#include <cutlass/tensor_ref.h>
 
 C10_DIAGNOSTIC_POP()
 C10_DIAGNOSTIC_POP()
@@ -118,6 +128,12 @@ int ceildiv(int a, int b) {
 int round_up_to_nearest_multiple(int a, int b) {
   return ceildiv(a, b) * b;
 }
+
+Strides make_strides(at::IntArrayRef strides) {
+  Strides out;
+  std::copy(strides.begin(), strides.end(), out.begin());
+  return out;
+};
 
 template <
     typename FastAccum,
@@ -289,12 +305,6 @@ void f8f8bf16_grouped_gemm_impl_sm90(
 
   auto stream = at::cuda::getCurrentCUDAStream().stream();
 
-  auto make_strides = [](at::IntArrayRef strides) -> Strides {
-    Strides out;
-    std::copy(strides.begin(), strides.end(), out.begin());
-    return out;
-  };
-
   Strides tensor_StrideA = make_strides(mat_a.strides());
   Strides tensor_StrideB = make_strides(mat_b.strides());
   Strides tensor_StrideOutput = make_strides(out.strides());
@@ -334,54 +344,6 @@ void f8f8bf16_grouped_gemm_impl_sm90(
       b_scale_stride);
 
   C10_CUDA_KERNEL_LAUNCH_CHECK();
-
-  //   auto buf_cpu = mat_a.new_empty(
-  //       input_args_size,
-  //       at::TensorOptions().dtype(at::kByte).device(at::kCPU));
-  //   AT_CUDA_CHECK(cudaMemcpy(
-  //       (char*)buf_cpu.data_ptr(),
-  //       buf_ptr,
-  //       input_args_size,
-  //       cudaMemcpyDeviceToHost));
-  //   char* buf_ptr_cpu = (char*)buf_cpu.data_ptr();
-  //   DtypeA** inputA_ptrs_h = reinterpret_cast<DtypeA**>(buf_ptr_cpu);
-  //   DtypeB** inputB_ptrs_h =
-  //       reinterpret_cast<DtypeB**>(inputA_ptrs_h + aligned_group_count);
-  //   DtypeOutput** output_ptrs_h =
-  //       reinterpret_cast<DtypeOutput**>(inputB_ptrs_h + aligned_group_count);
-  //   DtypeScale** inputA_scale_ptrs_h =
-  //       reinterpret_cast<DtypeScale**>(output_ptrs_h + aligned_group_count);
-  //   DtypeScale** inputB_scale_ptrs_h =
-  //       reinterpret_cast<DtypeScale**>(inputA_scale_ptrs_h +
-  //       aligned_group_count);
-  //   StrideA* stride_A_h =
-  //       reinterpret_cast<StrideA*>(inputB_scale_ptrs_h +
-  //       aligned_group_count);
-  //   StrideB* stride_B_h = reinterpret_cast<StrideB*>(stride_A_h +
-  //   group_count); StrideOutput* stride_output_h =
-  //       reinterpret_cast<StrideOutput*>(stride_B_h + group_count);
-  //   ProblemShape::UnderlyingProblemShape* problem_sizes_h =
-  //       reinterpret_cast<ProblemShape::UnderlyingProblemShape*>(
-  //           stride_output_h + group_count);
-
-  //   std::cout << "PTRS " << mat_a.data_ptr() << " " << mat_b.data_ptr() << "
-  //   "
-  //             << out.data_ptr() << " " << scale_a.data_ptr() << " "
-  //             << scale_b.data_ptr() << "\n";
-  //   for (int i = 0; i < group_count; i++) {
-  //     std::cout << "A " << (void*)inputA_ptrs_h[i] << "\n";
-  //     std::cout << "B " << (void*)inputB_ptrs_h[i] << "\n";
-  //     std::cout << "O " << (void*)output_ptrs_h[i] << "\n";
-  //     std::cout << "A_scale " << (void*)inputA_scale_ptrs_h[i] << "\n";
-  //     std::cout << "B_scale " << (void*)inputB_scale_ptrs_h[i] << "\n";
-  //     std::cout << "sizes " << problem_sizes_h[i] << "\n";
-  //     std::cout << "strideA" << stride_A_h[i] << "\n";
-  //     std::cout << "strideB" << stride_B_h[i] << "\n";
-  //     std::cout << "stride_output" << stride_output_h[i] << "\n";
-  //   }
-  //   int device_id = 0;
-  //   cutlass::KernelHardwareInfo kernel_hw_info =
-  //   cutlass::KernelHardwareInfo::make_kernel_hardware_info<Gemm::GemmKernel>(device_id);
 
   typename Gemm::Arguments arguments{
       cutlass::gemm::GemmUniversalMode::kGrouped,
@@ -528,9 +490,465 @@ void dispatch_fp8_grouped_gemm_on_bias_dtype(
   }
 }
 
+#if (defined(CUDA_VERSION) && CUDA_VERSION >= 12080) && \
+    (defined(CUTLASS_ARCH_MMA_SM100A_SUPPORTED) ||      \
+     defined(CUTLASS_ARCH_MMA_SM100_SUPPORTED))
+
+// The following section is adapted from fp8_blockwise_moe_kernel.cu to add
+// SM100+ support. Note: Bias is not yet supported in this path.
+
+using ProblemShapeSm100 =
+    cutlass::gemm::GroupProblemShape<cute::Shape<int, int, int>>;
+template <typename OutType, typename ScheduleConfig, typename LayoutD>
+void launch_f8f8bf16_grouped_gemm_sm100(
+    at::Tensor& out_ptrs,
+    const at::Tensor& a_ptrs,
+    const at::Tensor& b_ptrs,
+    const at::Tensor& a_scales_ptrs,
+    const at::Tensor& b_scales_ptrs,
+    const at::Tensor& stride_a,
+    const at::Tensor& stride_b,
+    const at::Tensor& stride_c,
+    const at::Tensor& layout_sfa,
+    const at::Tensor& layout_sfb,
+    const at::Tensor& problem_sizes,
+    int group_count) {
+  using ElementA = cutlass::float_e4m3_t;
+  using ElementB = cutlass::float_e4m3_t;
+  using ElementC = OutType;
+  using ElementD = ElementC;
+  using ElementAccumulator = float;
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::ColumnMajor;
+  using LayoutC = LayoutD;
+
+  static constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementA>::value;
+  static constexpr int AlignmentB = 128 / cutlass::sizeof_bits<ElementB>::value;
+  static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+
+  using ArchTag = cutlass::arch::Sm100;
+  using OperatorClass = cutlass::arch::OpClassTensorOp;
+  using CollectiveEpilogue =
+      typename cutlass::epilogue::collective::CollectiveBuilder<
+          ArchTag,
+          OperatorClass,
+          typename ScheduleConfig::MmaTileShape,
+          typename ScheduleConfig::ClusterShape,
+          cutlass::epilogue::collective::EpilogueTileAuto,
+          ElementAccumulator,
+          ElementAccumulator,
+          void, // ElementCompute
+          LayoutC*,
+          AlignmentC,
+          ElementD,
+          LayoutC*,
+          AlignmentC,
+          typename ScheduleConfig::EpilogueSchedule>::CollectiveOp;
+
+  using CollectiveMainloop =
+      typename cutlass::gemm::collective::CollectiveBuilder<
+          ArchTag,
+          OperatorClass,
+          ElementA,
+          cute::tuple<LayoutA*, typename ScheduleConfig::LayoutSFA*>,
+          AlignmentA,
+          ElementB,
+          cute::tuple<LayoutB*, typename ScheduleConfig::LayoutSFB*>,
+          AlignmentB,
+          ElementAccumulator,
+          typename ScheduleConfig::MmaTileShape,
+          typename ScheduleConfig::ClusterShape,
+          cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+              sizeof(typename CollectiveEpilogue::SharedStorage))>,
+          typename ScheduleConfig::KernelSchedule>::CollectiveOp;
+
+  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+      ProblemShapeSm100,
+      CollectiveMainloop,
+      CollectiveEpilogue,
+      void>;
+
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using UnderlyingProblemShape =
+      typename ProblemShapeSm100::UnderlyingProblemShape;
+  using StrideA = typename Gemm::GemmKernel::InternalStrideA;
+  using StrideB = typename Gemm::GemmKernel::InternalStrideB;
+  using StrideC = typename Gemm::GemmKernel::InternalStrideC;
+  using StrideD = typename Gemm::GemmKernel::InternalStrideD;
+
+  Gemm gemm_op;
+
+  typename GemmKernel::MainloopArguments mainloop_args{
+      static_cast<const ElementA**>(a_ptrs.data_ptr()),
+      static_cast<StrideA*>(stride_a.data_ptr()),
+      static_cast<const ElementB**>(b_ptrs.data_ptr()),
+      static_cast<StrideB*>(stride_b.data_ptr()),
+      static_cast<const ElementAccumulator**>(a_scales_ptrs.data_ptr()),
+      reinterpret_cast<typename ScheduleConfig::LayoutSFA*>(
+          layout_sfa.data_ptr()),
+      static_cast<const ElementAccumulator**>(b_scales_ptrs.data_ptr()),
+      reinterpret_cast<typename ScheduleConfig::LayoutSFB*>(
+          layout_sfb.data_ptr())};
+
+  cutlass::KernelHardwareInfo hw_info;
+  hw_info.device_id = 0;
+  hw_info.sm_count = at::cuda::getDeviceProperties(a_ptrs.device().index())
+                         ->multiProcessorCount;
+
+  typename GemmKernel::EpilogueArguments epilogue_args{
+      {},
+      nullptr, // bias ptr
+      static_cast<StrideC*>(stride_c.data_ptr()),
+      static_cast<ElementD**>(out_ptrs.data_ptr()),
+      static_cast<StrideC*>(stride_c.data_ptr())};
+
+  UnderlyingProblemShape* problem_sizes_as_shapes =
+      static_cast<UnderlyingProblemShape*>(problem_sizes.data_ptr());
+  typename GemmKernel::Arguments args{
+      cutlass::gemm::GemmUniversalMode::kGrouped,
+      {group_count, problem_sizes_as_shapes, nullptr},
+      mainloop_args,
+      epilogue_args,
+      hw_info};
+
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+
+  auto can_implement_status = gemm_op.can_implement(args);
+  TORCH_CHECK(
+      can_implement_status == cutlass::Status::kSuccess,
+      "Failed to implement GEMM");
+
+  auto& allocator = *c10::cuda::CUDACachingAllocator::get();
+  size_t workspace_size = Gemm::get_workspace_size(args);
+  auto workspace = allocator.allocate(workspace_size);
+
+  auto status = gemm_op.initialize(args, workspace.get(), stream);
+  TORCH_CHECK(status == cutlass::Status::kSuccess, "Failed to initialize GEMM");
+
+  status = gemm_op.run(stream);
+  TORCH_CHECK(status == cutlass::Status::kSuccess, "Failed to run GEMM");
+}
+
+template <
+    typename DtypeA,
+    typename DtypeB,
+    typename DtypeOut,
+    typename DtypeScale,
+    typename ProblemShape,
+    typename LayoutSFA,
+    typename LayoutSFB,
+    typename ScaleConfig>
+__global__ void prepare_grouped_gemm_data_sm100_kernel(
+    DtypeA* mat_a_ptr,
+    DtypeB* mat_b_ptr,
+    DtypeOut* out_ptr,
+    DtypeScale* scale_a_ptr,
+    DtypeScale* scale_b_ptr,
+    DtypeA** inputA_ptrs,
+    DtypeB** inputB_ptrs,
+    DtypeOut** output_ptrs,
+    DtypeScale** inputA_scale_ptrs,
+    DtypeScale** inputB_scale_ptrs,
+    ProblemShape* problem_sizes,
+    int64_t* stride_a,
+    int64_t* stride_b,
+    int64_t* stride_c,
+    LayoutSFA* layout_sfa_ptr,
+    LayoutSFB* layout_sfb_ptr,
+    const int32_t* offs,
+    int32_t M,
+    int32_t N,
+    int32_t K,
+    Strides tensor_StrideA,
+    Strides tensor_StrideB,
+    Strides tensor_StrideOut,
+    int64_t a_scale_stride,
+    int64_t b_scale_stride) {
+  int group_idx = blockIdx.x;
+
+  int64_t stride_a_batch = tensor_StrideA[0];
+  int64_t stride_b_batch = tensor_StrideB[0];
+  int64_t stride_out_batch = tensor_StrideOut[0];
+
+  int32_t M_i = M;
+  int32_t N_i = N;
+  int32_t K_i = K;
+
+  if (offs) {
+    if (K < 0) { // Both A and B are ragged
+      const int32_t start_row = (group_idx == 0) ? 0 : offs[group_idx - 1];
+      const int32_t end_row = offs[group_idx];
+      M_i = end_row - start_row;
+      K_i = tensor_StrideA[0] / M_i;
+      inputA_ptrs[group_idx] = mat_a_ptr + start_row;
+      inputB_ptrs[group_idx] = mat_b_ptr + (group_idx * N * K_i); // N is fixed
+      inputA_scale_ptrs[group_idx] = scale_a_ptr + start_row;
+    } else if (M < 0) { // Only A is ragged
+      const int32_t start_row = (group_idx == 0) ? 0 : offs[group_idx - 1];
+      const int32_t end_row = offs[group_idx];
+      M_i = end_row - start_row;
+      inputA_ptrs[group_idx] = mat_a_ptr + start_row * K_i;
+      inputB_ptrs[group_idx] = mat_b_ptr + group_idx * stride_b_batch;
+      inputA_scale_ptrs[group_idx] = scale_a_ptr + start_row;
+    } else { // Only B is ragged
+      const int32_t start_col = (group_idx == 0) ? 0 : offs[group_idx - 1];
+      const int32_t end_col = offs[group_idx];
+      N_i = end_col - start_col;
+      inputA_ptrs[group_idx] = mat_a_ptr + group_idx * stride_a_batch;
+      inputB_ptrs[group_idx] = mat_b_ptr + start_col * K_i;
+      inputB_scale_ptrs[group_idx] = scale_b_ptr + start_col;
+    }
+    output_ptrs[group_idx] = out_ptr + (group_idx * N_i);
+  } else { // Neither is ragged (standard BMM)
+    inputA_ptrs[group_idx] = mat_a_ptr + group_idx * stride_a_batch;
+    inputB_ptrs[group_idx] = mat_b_ptr + group_idx * stride_b_batch;
+    output_ptrs[group_idx] = out_ptr + group_idx * stride_out_batch;
+    inputA_scale_ptrs[group_idx] = scale_a_ptr + group_idx * a_scale_stride;
+    inputB_scale_ptrs[group_idx] = scale_b_ptr + group_idx * b_scale_stride;
+  }
+
+  problem_sizes[group_idx] = {M_i, N_i, K_i};
+
+  stride_a[group_idx] = tensor_StrideA[0];
+  stride_b[group_idx] = tensor_StrideB[0];
+  stride_c[group_idx] = tensor_StrideOut[0];
+
+  layout_sfa_ptr[group_idx] =
+      ScaleConfig::tile_atom_to_shape_SFA(cute::make_shape(M_i, N_i, K_i, 1));
+  layout_sfb_ptr[group_idx] =
+      ScaleConfig::tile_atom_to_shape_SFB(cute::make_shape(M_i, N_i, K_i, 1));
+}
+
+template <typename OutType>
+void f8f8bf16_grouped_gemm_impl_sm100(
+    at::Tensor mat_a, // FP8
+    at::Tensor mat_b, // FP8
+    at::Tensor scale_a, // FP32
+    at::Tensor scale_b, // FP32
+    std::optional<at::Tensor> offs,
+    std::optional<at::Tensor> bias, // BF16
+    bool use_fast_accum,
+    at::Tensor& out) {
+  // SM100 path does not support bias yet
+  TORCH_CHECK(
+      !bias.has_value(), "Bias is not supported for SM100 grouped GEMM yet.");
+
+  using DtypeA = cutlass::float_e4m3_t;
+  using DtypeB = cutlass::float_e4m3_t;
+  using DtypeOut = OutType;
+  using DtypeScale = float;
+
+  // Dispatch logic based on matrix sizes from fp8_blockwise_moe_kernel.cu
+  struct MmaConfig1 {
+    using MmaTileShape = cute::Shape<cute::_256, cute::_32, cute::_128>;
+    using ClusterShape = cute::Shape<cute::_2, cute::_1, cute::_1>;
+    using KernelSchedule =
+        cutlass::gemm::KernelPtrArrayTmaWarpSpecializedBlockwise2SmSm100;
+    using EpilogueSchedule = cutlass::epilogue::PtrArrayTmaWarpSpecialized2Sm;
+    using ScaleConfig = cutlass::detail::Sm100BlockwiseScaleConfig<
+        128,
+        1,
+        128,
+        cute::UMMA::Major::K,
+        cute::UMMA::Major::K>;
+    using LayoutSFA = decltype(ScaleConfig::deduce_layoutSFA());
+    using LayoutSFB = decltype(ScaleConfig::deduce_layoutSFB());
+  };
+  struct MmaConfig2 {
+    using MmaTileShape = cute::Shape<cute::_128, cute::_128, cute::_128>;
+    using ClusterShape = cute::Shape<cute::_1, cute::_1, cute::_1>;
+    using KernelSchedule =
+        cutlass::gemm::KernelPtrArrayTmaWarpSpecializedBlockwise1SmSm100;
+    using EpilogueSchedule = cutlass::epilogue::PtrArrayTmaWarpSpecialized1Sm;
+    using ScaleConfig = cutlass::detail::Sm100BlockwiseScaleConfig<
+        1,
+        128,
+        128,
+        cute::UMMA::Major::K,
+        cute::UMMA::Major::K>;
+    using LayoutSFA = decltype(ScaleConfig::deduce_layoutSFA());
+    using LayoutSFB = decltype(ScaleConfig::deduce_layoutSFB());
+  };
+  struct MmaConfig3 {
+    using MmaTileShape = cute::Shape<cute::_64, cute::_128, cute::_128>;
+    using ClusterShape = cute::Shape<cute::_1, cute::_1, cute::_1>;
+    using KernelSchedule =
+        cutlass::gemm::KernelPtrArrayTmaWarpSpecializedBlockwise1SmSm100;
+    using EpilogueSchedule = cutlass::epilogue::PtrArrayTmaWarpSpecialized1Sm;
+    using ScaleConfig = cutlass::detail::Sm100BlockwiseScaleConfig<
+        1,
+        128,
+        128,
+        cute::UMMA::Major::K,
+        cute::UMMA::Major::K>;
+    using LayoutSFA = decltype(ScaleConfig::deduce_layoutSFA());
+    using LayoutSFB = decltype(ScaleConfig::deduce_layoutSFB());
+  };
+
+  int32_t M_val, N_val, K_val, group_count;
+  M_val = mat_a.size(-2);
+  K_val = mat_a.size(-1);
+  N_val = mat_b.size(-1);
+  const bool ragged_a = mat_a.dim() == 2;
+  const bool ragged_b = mat_b.dim() == 2;
+  const bool transpose_inputs = (M_val <= 2048 && K_val >= 2048);
+
+  // Use transposed inputs for certain shapes for performance
+  at::Tensor mat_a_final = transpose_inputs ? mat_a.t() : mat_a;
+  at::Tensor mat_b_final = transpose_inputs ? mat_b.transpose(1, 2) : mat_b;
+  at::Tensor out_final = transpose_inputs ? out.t() : out;
+  at::Tensor scale_a_final = transpose_inputs ? scale_b : scale_a;
+  at::Tensor scale_b_final = transpose_inputs ? scale_a : scale_b;
+
+  if (ragged_a && ragged_b) {
+    group_count = offs->size(0);
+    K_val = -1;
+    M_val = -1;
+    N_val = -1;
+  } else if (ragged_a) {
+    group_count = mat_b_final.size(0);
+    M_val = -1;
+  } else if (ragged_b) {
+    group_count = mat_a_final.size(0);
+    N_val = -1;
+  } else {
+    group_count = mat_a_final.size(0);
+  }
+
+  auto& allocator = *c10::cuda::CUDACachingAllocator::get();
+
+  const int group_alignment = 16 / sizeof(void*);
+  const int aligned_group_count =
+      round_up_to_nearest_multiple(group_count, group_alignment);
+  at::TensorOptions ptr_options =
+      at::TensorOptions().device(mat_a.device()).dtype(at::kLong);
+  at::TensorOptions int32_options =
+      at::TensorOptions().device(mat_a.device()).dtype(at::kInt);
+  at::TensorOptions int64_options =
+      at::TensorOptions().device(mat_a.device()).dtype(at::kLong);
+
+  at::Tensor a_ptrs = at::empty({aligned_group_count}, ptr_options);
+  at::Tensor b_ptrs = at::empty({aligned_group_count}, ptr_options);
+  at::Tensor out_ptrs = at::empty({aligned_group_count}, ptr_options);
+  at::Tensor a_scales_ptrs = at::empty({aligned_group_count}, ptr_options);
+  at::Tensor b_scales_ptrs = at::empty({aligned_group_count}, ptr_options);
+
+  at::Tensor stride_a = at::empty({group_count}, int64_options);
+  at::Tensor stride_b = at::empty({group_count}, int64_options);
+  at::Tensor stride_c = at::empty({group_count}, int64_options);
+  at::Tensor problem_sizes = at::empty({group_count, 3}, int32_options);
+
+  at::Tensor layout_sfa = at::empty({group_count}, int32_options);
+  at::Tensor layout_sfb = at::empty({group_count}, int32_options);
+
+  // Prepare data on GPU
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+
+  auto launch_prep_kernel = [&](auto scale_config) {
+    using ScaleConfig = decltype(scale_config);
+    using LayoutSFA = typename ScaleConfig::LayoutSFA;
+    using LayoutSFB = typename ScaleConfig::LayoutSFB;
+    prepare_grouped_gemm_data_sm100_kernel<
+        DtypeA,
+        DtypeB,
+        DtypeOut,
+        DtypeScale,
+        typename ProblemShapeSm100::UnderlyingProblemShape,
+        LayoutSFA,
+        LayoutSFB,
+        ScaleConfig><<<group_count, 1, 0, stream>>>(
+        (DtypeA*)mat_a_final.data_ptr(),
+        (DtypeB*)mat_b_final.data_ptr(),
+        (DtypeOut*)out_final.data_ptr(),
+        scale_a_final.data_ptr<DtypeScale>(),
+        scale_b_final.data_ptr<DtypeScale>(),
+        (DtypeA**)a_ptrs.data_ptr(),
+        (DtypeB**)b_ptrs.data_ptr(),
+        (DtypeOut**)out_ptrs.data_ptr(),
+        (DtypeScale**)a_scales_ptrs.data_ptr(),
+        (DtypeScale**)b_scales_ptrs.data_ptr(),
+        (typename ProblemShapeSm100::UnderlyingProblemShape*)
+            problem_sizes.data_ptr(),
+        (int64_t*)stride_a.data_ptr(),
+        (int64_t*)stride_b.data_ptr(),
+        (int64_t*)stride_c.data_ptr(),
+        reinterpret_cast<LayoutSFA*>(layout_sfa.data_ptr()),
+        reinterpret_cast<LayoutSFB*>(layout_sfb.data_ptr()),
+        offs.has_value() ? offs->const_data_ptr<int32_t>() : nullptr,
+        M_val,
+        N_val,
+        K_val,
+        make_strides(mat_a_final.strides()),
+        make_strides(mat_b_final.strides()),
+        make_strides(out_final.strides()),
+        scale_a_final.stride(0),
+        scale_b_final.stride(0));
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  };
+
+  // Pick config and launch
+  if (transpose_inputs) {
+    launch_prep_kernel(typename MmaConfig1::ScaleConfig{});
+    launch_f8f8bf16_grouped_gemm_sm100<
+        OutType,
+        MmaConfig1,
+        cutlass::layout::ColumnMajor>(
+        out_ptrs,
+        a_ptrs,
+        b_ptrs,
+        a_scales_ptrs,
+        b_scales_ptrs,
+        stride_a,
+        stride_b,
+        stride_c,
+        layout_sfa,
+        layout_sfb,
+        problem_sizes,
+        group_count);
+    out = out_final.t();
+  } else if (M_val > 2048 && K_val >= 2048) {
+    launch_prep_kernel(typename MmaConfig2::ScaleConfig{});
+    launch_f8f8bf16_grouped_gemm_sm100<
+        OutType,
+        MmaConfig2,
+        cutlass::layout::RowMajor>(
+        out_ptrs,
+        a_ptrs,
+        b_ptrs,
+        a_scales_ptrs,
+        b_scales_ptrs,
+        stride_a,
+        stride_b,
+        stride_c,
+        layout_sfa,
+        layout_sfb,
+        problem_sizes,
+        group_count);
+  } else {
+    launch_prep_kernel(typename MmaConfig3::ScaleConfig{});
+    launch_f8f8bf16_grouped_gemm_sm100<
+        OutType,
+        MmaConfig3,
+        cutlass::layout::RowMajor>(
+        out_ptrs,
+        a_ptrs,
+        b_ptrs,
+        a_scales_ptrs,
+        b_scales_ptrs,
+        stride_a,
+        stride_b,
+        stride_c,
+        layout_sfa,
+        layout_sfb,
+        problem_sizes,
+        group_count);
+  }
+}
+#endif // SM100 support guard
+
 } // namespace
 
-#endif
+#endif // BUILD_ROWWISE_FP8_KERNEL guard
 
 namespace at::cuda::detail {
 void f8f8bf16_grouped_mm(
@@ -543,8 +961,27 @@ void f8f8bf16_grouped_mm(
     bool use_fast_accum,
     at::Tensor& out) {
 #if defined(BUILD_ROWWISE_FP8_KERNEL)
-  dispatch_fp8_grouped_gemm_on_bias_dtype(
-      mat_a, mat_b, scale_a, scale_b, offs, bias, use_fast_accum, out);
+  auto dprops = at::cuda::getCurrentDeviceProperties();
+
+  if (dprops->major >= 10) {
+#if (defined(CUDA_VERSION) && CUDA_VERSION >= 12080) && \
+    (defined(CUTLASS_ARCH_MMA_SM100A_SUPPORTED) ||      \
+     defined(CUTLASS_ARCH_MMA_SM100_SUPPORTED))
+    f8f8bf16_grouped_gemm_impl_sm100<cutlass::bfloat16_t>(
+        mat_a, mat_b, scale_a, scale_b, offs, bias, use_fast_accum, out);
+#else
+    TORCH_CHECK(
+        false,
+        "Grouped MM for SM100+ requires supported device. Your build does not meet these requirements.");
+#endif
+  } else if (dprops->major >= 9) {
+    dispatch_fp8_grouped_gemm_on_bias_dtype(
+        mat_a, mat_b, scale_a, scale_b, offs, bias, use_fast_accum, out);
+  } else {
+    TORCH_CHECK(
+        false,
+        "Grouped MM is only supported on SM90 and SM100+ architectures.");
+  }
 #else
   TORCH_CHECK(false, "grouped mm is not supported on your system");
 #endif

--- a/aten/src/ATen/native/cuda/ScaledGroupMM.h
+++ b/aten/src/ATen/native/cuda/ScaledGroupMM.h
@@ -3,6 +3,28 @@
 #include <optional>
 
 namespace at::cuda::detail {
+
+enum class GroupMMInputMatrixType {
+  GroupMMInputMatrixType_MatrixA_2D_MatrixB_2D,
+  GroupMMInputMatrixType_MatrixA_2D_MatrixB_3D,
+  GroupMMInputMatrixType_MatrixA_3D_MatrixB_2D,
+  GroupMMInputMatrixType_MatrixA_3D_MatrixB_3D,
+};
+
+struct GroupCountInfo {
+  // This is the M,N,K of the real 2D tensor, not the stacked tensor
+  int M;
+  int N;
+  int K;
+  int group_count;
+  GroupMMInputMatrixType input_matrix_type;
+};
+
+GroupCountInfo get_group_count(
+    at::Tensor mat_a,
+    at::Tensor mat_b,
+    std::optional<at::Tensor> offs);
+
 TORCH_API void f8f8bf16_grouped_mm(
     at::Tensor mat_a, // FP8
     at::Tensor mat_b, // FP8
@@ -12,4 +34,5 @@ TORCH_API void f8f8bf16_grouped_mm(
     std::optional<at::Tensor> bias, // BF16
     bool use_fast_accum,
     at::Tensor& out);
+
 } // namespace at::cuda::detail

--- a/aten/src/ATen/native/cuda/ScaledGroupMM.h
+++ b/aten/src/ATen/native/cuda/ScaledGroupMM.h
@@ -5,14 +5,14 @@
 namespace at::cuda::detail {
 
 enum class GroupMMInputMatrixType {
-  GroupMMInputMatrixType_MatrixA_2D_MatrixB_2D,
-  GroupMMInputMatrixType_MatrixA_2D_MatrixB_3D,
-  GroupMMInputMatrixType_MatrixA_3D_MatrixB_2D,
-  GroupMMInputMatrixType_MatrixA_3D_MatrixB_3D,
+  MatrixA_2D_MatrixB_2D,
+  MatrixA_2D_MatrixB_3D,
+  MatrixA_3D_MatrixB_2D,
+  MatrixA_3D_MatrixB_3D,
 };
 
+// Dimensions of individual 2D matrices within the grouped operation
 struct GroupCountInfo {
-  // This is the M,N,K of the real 2D tensor, not the stacked tensor
   int M;
   int N;
   int K;
@@ -20,7 +20,16 @@ struct GroupCountInfo {
   GroupMMInputMatrixType input_matrix_type;
 };
 
-GroupCountInfo get_group_count(
+// Extract group information from input tensors (maybe 2D or 3D) for grouped matrix multiplication
+//
+// For 3D tensors: group_count is derived from the first dimension (size(0))
+// For 2D tensors: group_count is determined from the offsets tensor length
+//
+// Returns M, N, K dimensions representing the individual 2D matrix sizes within each group,
+// not the dimensions of the stacked input tensors
+//
+// Notice: If the input tensors are 2D, the M, N, K may need to be recalculated from the offs tensor
+GroupCountInfo get_group_info(
     at::Tensor mat_a,
     at::Tensor mat_b,
     std::optional<at::Tensor> offs);

--- a/aten/src/ATen/native/cuda/ScaledGroupMM.h
+++ b/aten/src/ATen/native/cuda/ScaledGroupMM.h
@@ -29,6 +29,7 @@ struct GroupCountInfo {
 // not the dimensions of the stacked input tensors
 //
 // Notice: If the input tensors are 2D, the M, N, K may need to be recalculated from the offs tensor
+// Then the dimension does not represent the actual size for each group; it is used solely for sizing heuristics.
 GroupCountInfo get_group_info(
     at::Tensor mat_a,
     at::Tensor mat_b,

--- a/cmake/Codegen.cmake
+++ b/cmake/Codegen.cmake
@@ -125,7 +125,7 @@ if(INTERN_BUILD_ATEN_OPS)
       "89;90a;100a;120a")
     _BUILD_FOR_ADDITIONAL_ARCHS(
       "${CMAKE_CURRENT_LIST_DIR}/../aten/src/ATen/native/cuda/ScaledGroupMM.cu"
-      "90a")
+      "90a;100a")
     _BUILD_FOR_ADDITIONAL_ARCHS(
       "${CMAKE_CURRENT_LIST_DIR}/../aten/src/ATen/native/cuda/GroupMM.cu"
       "90a;100a")

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -23,6 +23,7 @@ from torch.testing._internal.common_cuda import (
     SM53OrLater,
     SM89OrLater,
     SM90OrLater,
+    SM100OrLater,
     xfailIfSM100OrLater,
     xfailIfSM120OrLater,
     _get_torch_cuda_version,
@@ -1837,6 +1838,27 @@ class TestFP8Matmul(TestCase):
                 out_dtype=torch.bfloat16,
             )
 
+
+    def create_scaled_grouped_gemm_scale_tensors(self, m, n, k, n_groups, is_a_3d, is_b_3d):
+        device = "cuda"
+
+        m_scale_group_size = 1
+        n_scale_group_size = 128
+        k_scale_group_size = 128
+
+        if SM100OrLater:
+            scale_a = torch.rand(n_groups, m // m_scale_group_size, k // k_scale_group_size, device=device, dtype=torch.float32)
+            scale_b = torch.rand(n_groups, n // n_scale_group_size, k // k_scale_group_size, device=device, dtype=torch.float32)
+        else:
+            scale_a = torch.rand(m * n_groups, device=device, dtype=torch.float32)
+            scale_b = torch.rand(n * n_groups, device=device, dtype=torch.float32)
+            if is_a_3d:
+                scale_a = scale_a.view(n_groups, m)
+            if is_b_3d:
+                scale_b = scale_b.view(n_groups, n)
+
+        return scale_a, scale_b
+
     def scaled_grouped_mm_helper(self, alist, blist, ascalelist, bscalelist, outlist, use_fast_accum):
         for a, b, ascale, bscale, out in zip(alist, blist, ascalelist, bscalelist, outlist):
             out_ref = torch._scaled_mm(a, b.t(), ascale.view(-1, 1), bscale.view(1, -1),
@@ -1970,6 +1992,126 @@ class TestFP8Matmul(TestCase):
                 outlist.append(out[:, start:offs_cpu[i]])
                 start = offs_cpu[i]
                 self.scaled_grouped_mm_helper(a, blist, scale_a, bscalelist, outlist, fast_accum)
+
+
+
+    # @unittest.skipIf(TEST_WITH_ROCM, "ROCm doesn't support CUTLASS")
+    # @unittest.skipIf(not SM90OrLater, "Grouped gemm supported on SM90")
+    # @parametrize("fast_accum", [False, True])
+    # @parametrize("strided", [False, True])
+    # def test_scaled_grouped_gemm_2d_2d(self, fast_accum, strided):
+    #     device = "cuda"
+    #     m, n, k, n_groups = 128, 384, 512, 4
+    #     a = torch.randn(m, k * n_groups + k * int(strided), device=device).to(torch.float8_e4m3fn)[:, :k * n_groups]
+    #     b = torch.randn(n, k * n_groups + k * int(strided), device=device).to(torch.float8_e4m3fn)[:, :k * n_groups]
+    #     scale_a, scale_b = self.create_scaled_grouped_gemm_scale_tensors(m, n, k, n_groups, False, False)
+    #     offs = torch.arange(k, n_groups * k + 1, k, device=device, dtype=torch.int32)
+    #     f = torch._scaled_grouped_mm
+    #     out = f(a, b.t(), scale_a, scale_b, offs=offs,
+    #             out_dtype=torch.bfloat16, use_fast_accum=fast_accum)
+    #     offs_cpu = offs.cpu()
+    #     alist, blist, ascalelist, bscalelist = [], [], [], []
+    #     start = 0
+    #     for i in range(n_groups):
+    #         alist.append(a[:, start:offs_cpu[i]])
+    #         blist.append(b[:, start:offs_cpu[i]])
+    #         ascalelist.append(scale_a[i * m : (i + 1) * m])
+    #         bscalelist.append(scale_b[i * n : (i + 1) * n])
+    #         start = offs_cpu[i]
+    #     self.scaled_grouped_mm_helper(alist, blist, ascalelist, bscalelist, out, fast_accum)
+
+
+    # @unittest.skipIf(TEST_WITH_ROCM, "ROCm doesn't support CUTLASS")
+    # @unittest.skipIf(not SM90OrLater, "Grouped gemm supported on SM90")
+    # @parametrize("fast_accum", [False, True])
+    # @parametrize("strided", [False, True])
+    # def test_scaled_grouped_gemm_2d_3d(self, fast_accum, strided):
+    #     device = "cuda"
+    #     m, n, k, n_groups = 128, 384, 512, 4
+    #     s_int = int(strided)
+    #     a = torch.randn(m * n_groups, k * (1 + s_int), device=device).to(torch.float8_e4m3fn)[:, :k]
+    #     b = torch.randn(n_groups * (1 + s_int), n, k * (1 + s_int), device=device).to(torch.float8_e4m3fn)[::(1 + s_int), :, :k]
+    #     self.assertTrue(a.is_contiguous() is not strided)
+    #     self.assertTrue(b.is_contiguous() is not strided)
+    #     for check_zero_size in (True, False):
+    #         if check_zero_size and n_groups <= 1:
+    #             continue
+
+    #         offs = torch.arange(m, n_groups * m + 1, m, device="cuda", dtype=torch.int32)
+    #         if check_zero_size:
+    #             offs[0] = offs[1]
+    #         scale_a, scale_b = self.create_scaled_grouped_gemm_scale_tensors(m, n, k, n_groups, False, True)
+
+    #         f = torch._scaled_grouped_mm
+    #         out = f(a, b.transpose(-2, -1), scale_a, scale_b, offs=offs,
+    #                 out_dtype=torch.bfloat16, use_fast_accum=fast_accum)
+
+    #         offs_cpu = offs.cpu()
+    #         alist, ascalelist, outlist = [], [], []
+    #         start = 0
+    #         for i in range(n_groups):
+    #             alist.append(a[start:offs_cpu[i]])
+    #             ascalelist.append(scale_a[start:offs_cpu[i]])
+    #             outlist.append(out[start:offs_cpu[i]])
+    #             start = offs_cpu[i]
+    #             self.scaled_grouped_mm_helper(alist, b, ascalelist, scale_b, outlist, fast_accum)
+
+
+    # @unittest.skipIf(TEST_WITH_ROCM, "ROCm doesn't support CUTLASS")
+    # @xfailIfSM100OrLater
+    # @unittest.skipIf(not SM90OrLater, "Grouped gemm supported on SM90")
+    # @parametrize("fast_accum", [False, True])
+    # @parametrize("strided", [False, True])
+    # def test_scaled_grouped_gemm_3d_3d(self, fast_accum, strided):
+    #     device = "cuda"
+    #     m, n, k, n_groups = 128, 384, 512, 4
+    #     s_int = int(strided)
+    #     a = torch.randn(n_groups * (1 + s_int), m, k * (1 + s_int), device=device).to(torch.float8_e4m3fn)[::(1 + s_int), :, :k]
+    #     b = torch.randn(n_groups * (1 + s_int), n, k * (1 + s_int), device=device).to(torch.float8_e4m3fn)[::(1 + s_int), :, :k]
+    #     self.assertTrue(a.is_contiguous() is not strided)
+    #     self.assertTrue(b.is_contiguous() is not strided)
+    #     scale_a, scale_b = self.create_scaled_grouped_gemm_scale_tensors(m, n, k, n_groups, True, True)
+
+    #     f = torch._scaled_grouped_mm
+    #     out = f(a, b.transpose(-2, -1), scale_a, scale_b,
+    #             out_dtype=torch.bfloat16, use_fast_accum=fast_accum)
+
+    #     self.scaled_grouped_mm_helper(a, b, scale_a, scale_b, out, fast_accum)
+
+
+    # @unittest.skipIf(TEST_WITH_ROCM, "ROCm doesn't support CUTLASS")
+    # @unittest.skipIf(not SM90OrLater, "Grouped gemm supported on SM90")
+    # @parametrize("fast_accum", [False, True])
+    # @parametrize("strided", [False, True])
+    # def test_scaled_grouped_gemm_3d_2d(self, fast_accum, strided):
+    #     device = "cuda"
+    #     m, n, k, n_groups = 128, 384, 512, 4
+    #     s_int = int(strided)
+    #     a = torch.randn(n_groups * (1 + s_int), m, k * (1 + s_int), device=device).to(torch.float8_e4m3fn)[::(1 + s_int), :, :k]
+    #     b = torch.randn(n * n_groups, k * (1 + s_int), device=device).to(torch.float8_e4m3fn)[:, :k]
+    #     self.assertTrue(a.is_contiguous() is not strided)
+    #     self.assertTrue(b.is_contiguous() is not strided)
+    #     scale_a, scale_b = self.create_scaled_grouped_gemm_scale_tensors(m, n, k, n_groups, True, False)
+    #     for check_zero_size in (True, False):
+    #         if check_zero_size and n_groups <= 1:
+    #             continue
+
+    #         offs = torch.arange(n, n_groups * n + 1, n, device="cuda", dtype=torch.int32)
+    #         if check_zero_size:
+    #             offs[0] = offs[1]
+
+    #         f = torch._scaled_grouped_mm
+    #         out = f(a, b.transpose(-2, -1), scale_a, scale_b, offs=offs,
+    #                 out_dtype=torch.bfloat16, use_fast_accum=fast_accum)
+    #         offs_cpu = offs.cpu()
+    #         blist, bscalelist, outlist = [], [], []
+    #         start = 0
+    #         for i in range(n_groups):
+    #             blist.append(b[start:offs_cpu[i]])
+    #             bscalelist.append(scale_b[start:offs_cpu[i]])
+    #             outlist.append(out[:, start:offs_cpu[i]])
+    #             start = offs_cpu[i]
+    #             self.scaled_grouped_mm_helper(a, blist, scale_a, bscalelist, outlist, fast_accum)
 
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM, mx_skip_msg)

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -1853,10 +1853,15 @@ class TestFP8Matmul(TestCase):
 
     def scaled_grouped_mm_helper(self, alist, blist, ascalelist, bscalelist, outlist, use_fast_accum):
         for a, b, ascale, bscale, out in zip(alist, blist, ascalelist, bscalelist, outlist):
-            out_ref = torch._scaled_mm(a, b.t(), ascale.view(-1, 1), bscale.view(1, -1),
-                                    out_dtype=torch.bfloat16, use_fast_accum=use_fast_accum)
+            out_ref = torch._scaled_mm(
+                a,
+                b.t(),
+                ascale.view(-1, 1),
+                bscale.view(1, -1),
+                out_dtype=torch.bfloat16,
+                use_fast_accum=use_fast_accum,
+            )
             self.assertEqual(out.float(), out_ref.float(), atol=5e-2, rtol=5e-4)
-
 
     @unittest.skipIf(TEST_WITH_ROCM, "ROCm doesn't support CUTLASS")
     @unittest.skipIf(not SM100OrLater, "Grouped gemm supported on SM100")
@@ -1866,8 +1871,18 @@ class TestFP8Matmul(TestCase):
 
         a_2d_list, b_2d_list, a_scale_list, b_scale_list = [], [], [], []
         for _ in range(n_groups):
-            a_2d, a_scale = tensor_to_scale_block(torch.randn(m, k, device=device, dtype=torch.float32).pow(3), torch.float8_e4m3fn, 1, 128)
-            b_2d, b_scale = tensor_to_scale_block(torch.randn(n, k, device=device, dtype=torch.float32).pow(3), torch.float8_e4m3fn, 128, 128)
+            a_2d, a_scale = tensor_to_scale_block(
+                torch.randn(m, k, device=device, dtype=torch.float32).pow(3),
+                torch.float8_e4m3fn,
+                1,
+                128,
+            )
+            b_2d, b_scale = tensor_to_scale_block(
+                torch.randn(n, k, device=device, dtype=torch.float32).pow(3),
+                torch.float8_e4m3fn,
+                128,
+                128,
+            )
             a_2d_list.append(a_2d)
             b_2d_list.append(b_2d)
             a_scale_list.append(a_scale)
@@ -1877,15 +1892,32 @@ class TestFP8Matmul(TestCase):
         b = torch.stack(b_2d_list, dim=0)
         a_scale = torch.stack(a_scale_list, dim=0)
         b_scale = torch.stack(b_scale_list, dim=0)
-        a_scale = a_scale.transpose(1, 2).contiguous().transpose(1, 2) # scale a needs to be outer-dim-major
+        #  scale a needs to be outer-dim-major
+        a_scale = a_scale.transpose(1, 2).contiguous().transpose(1, 2)
 
         f = torch._scaled_grouped_mm
-        out = f(a, b.transpose(-2, -1), a_scale, b_scale.transpose(-2, -1), out_dtype=torch.bfloat16)
+        out = f(
+            a,
+            b.transpose(-2, -1),
+            a_scale,
+            b_scale.transpose(-2, -1),
+            out_dtype=torch.bfloat16,
+        )
 
         # _scaled_mm is not currently supported on SM100, we use emulated implementation instead
         for a_2d, b_2d, a_scale_2d, b_scale_2d, out_2d in zip(a, b, a_scale, b_scale, out):
-            out_ref_2d = mm_float8_emulated_block(a_2d, a_scale_2d.reciprocal(), b_2d.t(), b_scale_2d.reciprocal().t(), torch.bfloat16)
-            cosine_sim = torch.nn.functional.cosine_similarity(out_2d.flatten().float(), out_ref_2d.flatten().float(), dim=0)
+            out_ref_2d = mm_float8_emulated_block(
+                a_2d,
+                a_scale_2d.reciprocal(),
+                b_2d.t(),
+                b_scale_2d.reciprocal().t(),
+                torch.bfloat16,
+            )
+            cosine_sim = torch.nn.functional.cosine_similarity(
+                out_2d.flatten().float(),
+                out_ref_2d.flatten().float(),
+                dim=0,
+            )
             self.assertGreaterEqual(float(cosine_sim), 0.999)
             self.assertEqual(out_2d.float(), out_ref_2d.float(), atol=6e-1, rtol=7e-2)
 


### PR DESCRIPTION

This PR adds support for the Blackwell-specific scaling factor layouts, following the Scaling Factor Types outlined in issues #157950 and #158037. The operator now supports the following configurations:

| Operation | API | Input A | Input B | Scaling Factor A | Scaling Factor B | Hardware | Limitations |
| :---- | :---- | :---- | :---- | :---- | :---- | :---- | :---- |
| Hopper Grouped GEMM (FP8) | \_scaled\_grouped\_mm | 2D/3D Layout: RowMajor | 2D/3D Layout: ColMajor | shape: \[M, 1\] Layout: Per-row only | shape: \[1, N\] Layout: Per-row only | 90 | FP8\_E4M3 only, no bias/scale\_result |
| **Blackwell Grouped GEMM (FP8)** | \_scaled\_grouped\_mm | 2D/3D Layout: RowMajor | 2D/3D Layout:ColMajor | shape: \[M, K//128\] Layout: BlockWise1x128 Outer-dim-major | shape: \[K//128, N//128\] Layout: BlockWise128x128 near-inner-dim-major | 100+ | FP8\_E4M3 only, no bias/scale\_result |


* **GroupMMInputMatrixType** and a helper function **get\_group\_info** have been introduced to generalize the logic for handling various input tensor combinations (2D/3D, representing batched or ragged inputs). This abstracts away the complexity of determining matrix dimensions (M, N, K) and group counts for different scenarios.

  * **Note**: When inputs are 2D (ragged), the returned M, N, and K dimensions are derived from the total tensor size and group count. These values are used for heuristics and may not represent the actual dimensions of each individual matrix in the group. See [dispatch_fp8_grouped_gemm_on_tile_size](https://github.com/pytorch/pytorch/blob/v2.8.0-rc8/aten/src/ATen/native/cuda/ScaledGroupMM.cu#L436)

* The refactoring supports ragged inputs (as introduced in PR #148531). For the initial Blackwell implementation with ragged tensors, the scaling factors are expected to be 3D tensors with shapes like \[n\_groups, M, K//128\] for scale\_A and \[n\_groups, K//128, N//128\] for scale\_B.  
* As discussed in issue #156238, we are going to support more flexible input layouts in the future.  
* \_scaled\_mm is not yet available for SM100, the tests use a block-wise emulated reference implementation for comparison.



cc @ptrblck @msaroufim @eqy @jerryzh168