### PR TITLE
[BE] Add missing type for storage dict

### DIFF
--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -1147,7 +1147,7 @@ def _save(
     pickle_protocol,
     _disable_byteorder_record,
 ):
-    serialized_storages = {}
+    serialized_storages: dict[str, torch.storage.UntypedStorage] = {}
     id_map: dict[int, str] = {}
 
     # Since loading storages that view the same data with different dtypes is


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.11.0) (oldest at bottom):
* #156836
* __->__ #156831
* #156830

For some reason, this one always bleats when I run mypy on OSX, so shut it up.

Signed-off-by: Edward Yang <ezyang@meta.com>