### PR TITLE
load inline user overridable gencode

### DIFF
--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -349,41 +349,7 @@ class TestCppExtensionJIT(common.TestCase):
                 pass
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not found")
-    def test_cuda_arch_flags_fix(self):
-        """Test that user-provided CUDA arch flags prevent default generation"""
-        user_arch_flags = ["-gencode=arch=compute_86,code=sm_86"]
-        result = _get_cuda_arch_flags(user_arch_flags)
-
-        self.assertEqual(
-            len(result),
-            0,
-            f"User arch flags should prevent default generation. "
-            f"Expected: [], Got: {result}",
-        )
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not found")
-    def test_cuda_arch_flags_backward_compatibility(self):
-        default_flags = _get_cuda_arch_flags()
-        self.assertGreater(
-            len(default_flags), 0, "No args should generate default flags"
-        )
-
-        non_arch_flags = _get_cuda_arch_flags(["-O2", "--use-fast-math"])
-        self.assertGreater(
-            len(non_arch_flags), 0, "Non-arch flags should still generate defaults"
-        )
-
-        empty_flags = _get_cuda_arch_flags([])
-        self.assertGreater(
-            len(empty_flags), 0, "Empty list should generate default flags"
-        )
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not found")
     def test_cuda_arch_flags_compilation_with_user_flags(self):
-        """Test compilation with user-provided arch flags"""
-        if not torch.cuda.is_available():
-            self.skipTest("CUDA not available")
-
         from torch.utils.cpp_extension import load_inline
 
         cuda_code = "__global__ void dummy() {}"
@@ -396,7 +362,7 @@ class TestCppExtensionJIT(common.TestCase):
         arch_flag = f"-gencode=arch=compute_{capability[0]}{capability[1]},code=sm_{capability[0]}{capability[1]}"
 
         module = load_inline(
-            name="test_cuda_arch_fix",
+            name="test_cuda_arch_flags_compilation_with_user_flags",
             cpp_sources=[cpp_code],
             cuda_sources=[cuda_code],
             extra_cuda_cflags=[arch_flag],

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -21,7 +21,6 @@ import torch.utils.cpp_extension
 from torch.testing._internal.common_cuda import TEST_CUDA, TEST_CUDNN
 from torch.testing._internal.common_utils import gradcheck, TEST_XPU
 from torch.utils.cpp_extension import (
-    _get_cuda_arch_flags,
     _TORCH_PATH,
     check_compiler_is_gcc,
     CUDA_HOME,

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -349,7 +349,6 @@ class TestCppExtensionJIT(common.TestCase):
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not found")
     def test_cuda_arch_flags_default_gencode(self):
-
         def run_compilation_test(extra_cuda_cflags, test_name):
             script_content = f'''
 import sys

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -349,9 +349,6 @@ class TestCppExtensionJIT(common.TestCase):
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not found")
     def test_cuda_arch_flags_compilation_with_user_flags(self):
-        """Test compilation with user-provided arch flags"""
-        if not torch.cuda.is_available():
-            self.skipTest("CUDA not available")
 
         import tempfile
 

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -349,7 +349,7 @@ class TestCppExtensionJIT(common.TestCase):
                 pass
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not found")
-    def test_cuda_arch_flags_override_default_gencode(self):
+    def test_cuda_arch_flags_non_default_gencode(self):
         user_arch_flags = ["-gencode=arch=compute_86,code=sm_86"]
         result = _get_cuda_arch_flags(user_arch_flags)
 

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -349,7 +349,6 @@ class TestCppExtensionJIT(common.TestCase):
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not found")
     def test_cuda_arch_flags_compilation_with_user_flags(self):
-
         import tempfile
 
         from torch.utils.cpp_extension import load_inline

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -364,17 +364,17 @@ class TestCppExtensionJIT(common.TestCase):
         capability = torch.cuda.get_device_capability()
         user_arch_flag = f"-gencode=arch=compute_{capability[0]}{capability[1]},code=sm_{capability[0]}{capability[1]}"
 
-        stdout_capture = io.StringIO()
-        with contextlib.redirect_stdout(stdout_capture):
+        stderr_capture = io.StringIO()
+        with contextlib.redirect_stderr(stderr_capture):
             module = load_inline(
-                name="test_cuda_arch_fix_verbose",
+                name="test_cuda_arch_flags_compilation_with_user_flags",
                 cpp_sources=[cpp_code],
                 cuda_sources=[cuda_code],
                 extra_cuda_cflags=[user_arch_flag],
                 verbose=True,
             )
 
-        compilation_output = stdout_capture.getvalue()
+        compilation_output = stderr_capture.getvalue()
 
         self.assertIsNotNone(module)
 

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -353,7 +353,6 @@ class TestCppExtensionJIT(common.TestCase):
             script_content = f'''
 import sys
 import os
-sys.path.insert(0, "{os.path.dirname(os.path.abspath(__file__))}")
 import torch
 from torch.utils.cpp_extension import load_inline
 

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -2698,7 +2698,7 @@ def _write_ninja_file_to_build_library(path,
         cuda_flags += _get_rocm_arch_flags(cuda_flags)
         cuda_flags += extra_cuda_cflags
     elif with_cuda:
-        cuda_flags = common_cflags + COMMON_NVCC_FLAGS + _get_cuda_arch_flags()
+        cuda_flags = common_cflags + COMMON_NVCC_FLAGS + _get_cuda_arch_flags(extra_cuda_cflags)
         if IS_WINDOWS:
             for flag in COMMON_MSVC_FLAGS:
                 cuda_flags = ['-Xcompiler', flag] + cuda_flags


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/156815

As far as testing goes
* I tried to use cuobjdump but that was kinda goofy https://github.com/pytorch/pytorch/pull/156850/commits/bccd9393a5f3acfdda88d64e1244f5093b42fd09 the problem was that the name of the cubin will have a single gencode always
* Another idea was to read stderr and check that the right amount of gencodes is there https://github.com/pytorch/pytorch/pull/156850/commits/0beadc01b31fce66eebe3067774f678ed79de2c7 this helped a lot to convince me locally that this test works, the test passed on my dev gpu but was failing in CI and I suspect it's because of a bad interaction with subprocesses
* Last approach was to have a simpler unit test to check which flags get added by default, this is not as comprehensive as the previous ideas but it works and is fast so will opt for this since I'm convinced testing is working per my own experiments and customers
