### PR TITLE
TestForeachCUDA.test_foreach_copy_with_multi_dtypes is a largeTensorTest

### DIFF
--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -16,6 +16,7 @@ from torch.testing._internal.common_cuda import TEST_MULTIGPU
 from torch.testing._internal.common_device_type import (
     dtypes,
     instantiate_device_type_tests,
+    largeTensorTest,
     onlyCUDA,
     OpDTypes,
     ops,
@@ -1353,6 +1354,7 @@ class TestForeach(TestCase):
     # https://github.com/pytorch/pytorch/issues/148681
     @skipCUDAVersionIn([(12, 8)])
     @onlyCUDA
+    @largeTensorTest("75GB", device="cuda")
     @ops(filter(lambda op: op.name == "_foreach_copy", foreach_binary_op_db))
     def test_foreach_copy_with_multi_dtypes(self, device, dtype, op):
         # check (a) multi_tensor_apply is called and (b) numerical parity with for-loop and Tensor.copy_


### PR DESCRIPTION
#156719 causes OOM for AMD ROCm MI200 CI with this message.

torch.OutOfMemoryError: HIP out of memory. Tried to allocate 32.00 GiB. GPU 0 has a total capacity of 63.98 GiB of which 23.74 GiB is free. Of the allocated memory 40.00 GiB is allocated by PyTorch, and 5.78 MiB is reserved by PyTorch but unallocated.

Adding largeTensorTest decorator requiring 75GB (~64GB + ~9GB deficit).