### PR TITLE
Stop skipping entire foreach tests, just skip the profiler portion

### DIFF
--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -19,7 +19,6 @@ from torch.testing._internal.common_device_type import (
     onlyCUDA,
     OpDTypes,
     ops,
-    skipCUDAVersionIn,
 )
 from torch.testing._internal.common_dtype import (
     all_types_and_complex_and,
@@ -91,9 +90,11 @@ class ForeachFuncWrapper:
                 torch.cuda.synchronize()
             keys = tuple([e.key for e in p.key_averages()])
             mta_called = any("multi_tensor_apply_kernel" in k for k in keys)
-            assert mta_called == (expect_fastpath and (not zero_size)), (
-                f"{mta_called=}, {expect_fastpath=}, {zero_size=}, {self.func.__name__=}, {keys=}"
-            )
+            # Skip profiler check for CUDA 12.6, 12.8 as the upgrade makes profiler results flaky
+            # https://github.com/pytorch/pytorch/issues/148681
+            # assert mta_called == (expect_fastpath and (not zero_size)), (
+            #     f"{mta_called=}, {expect_fastpath=}, {zero_size=}, {self.func.__name__=}, {keys=}"
+            # )
         else:
             actual = self.func(*inputs, **kwargs)
         if self.is_inplace:
@@ -190,9 +191,6 @@ class TestForeach(TestCase):
                         zero_size=True,
                     )
 
-    # Skip CUDA version 12.8 as the upgrade makes profiler results flaky
-    # https://github.com/pytorch/pytorch/issues/148681
-    @skipCUDAVersionIn([(12, 8)])
     @skipIfRocmVersionLessThan((6, 0))
     @ops(
         foreach_unary_op_db
@@ -305,9 +303,6 @@ class TestForeach(TestCase):
                 else:
                     self.assertEqual(expected, actual)
 
-    # Skip CUDA version 12.8 as the upgrade makes profiler results flaky
-    # https://github.com/pytorch/pytorch/issues/148681
-    @skipCUDAVersionIn([(12, 8)])
     @ops(filter(lambda op: op.supports_scalar_self_arg, foreach_binary_op_db))
     @parametrize("is_fastpath", (True, False))
     def test_binary_op_with_scalar_self_support(self, device, dtype, op, is_fastpath):
@@ -365,9 +360,6 @@ class TestForeach(TestCase):
 
     @ops(foreach_pointwise_op_db)
     @parametrize("is_fastpath", (True, False))
-    # Skip CUDA version 12.8 as the upgrade makes profiler results flaky
-    # https://github.com/pytorch/pytorch/issues/148681
-    @skipCUDAVersionIn([(12, 8)])
     def test_pointwise_op_with_tensor_of_scalarlist_overload(
         self, device, dtype, op, is_fastpath
     ):
@@ -705,9 +697,6 @@ class TestForeach(TestCase):
                 ):
                     foreach_op_([tensor1], [tensor2])
 
-    # Skip CUDA version 12.8 as the upgrade makes profiler results flaky
-    # https://github.com/pytorch/pytorch/issues/148681
-    @skipCUDAVersionIn([(12, 8)])
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not found")
     @ops(
         filter(lambda op: op.supports_out, foreach_binary_op_db),
@@ -823,9 +812,6 @@ class TestForeach(TestCase):
             scalar_self_arg=False,
         )
 
-    # Skip CUDA version 12.8 as the upgrade makes profiler results flaky
-    # https://github.com/pytorch/pytorch/issues/148681
-    @skipCUDAVersionIn([(12, 8)])
     @ops(
         filter(lambda op: op.supports_out, foreach_binary_op_db),
         dtypes=floating_types_and(torch.half, torch.bfloat16),
@@ -1349,9 +1335,6 @@ class TestForeach(TestCase):
                         copy_(t, s, non_blocking)
                     self.assertEqual(ref_input, sample.input)
 
-    # Skip CUDA version 12.8 as the upgrade makes profiler results flaky
-    # https://github.com/pytorch/pytorch/issues/148681
-    @skipCUDAVersionIn([(12, 8)])
     @onlyCUDA
     @ops(filter(lambda op: op.name == "_foreach_copy", foreach_binary_op_db))
     def test_foreach_copy_with_multi_dtypes(self, device, dtype, op):


### PR DESCRIPTION
Instead of skipping the whole test as the CUPTI team figures out what is wrong, let's temporarily skip the profiler check portion. It is high pri to add it back to ensure foreach ops are actually performant.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #156872
* __->__ #156871
* #156876

