### PR TITLE
pt2_remote_cache: Log sample for failures, and log the explicit reason we're faling.

### DIFF
--- a/test/inductor/test_remote_cache.py
+++ b/test/inductor/test_remote_cache.py
@@ -1,0 +1,76 @@
+# Owner(s): ["module: inductor"]
+from dataclasses import dataclass
+
+from torch._inductor.remote_cache import (
+    RemoteCache,
+    RemoteCacheBackend,
+    RemoteCachePassthroughSerde,
+)
+from torch.testing._internal.common_utils import TestCase
+
+
+class FailingBackend(RemoteCacheBackend):
+    def _get(self, key):
+        raise AssertionError("testget")
+
+    def _put(self, key, data):
+        raise AssertionError("testput")
+
+
+class NoopBackend(RemoteCacheBackend):
+    def _get(self, key):
+        return None
+
+    def _put(self, key, data):
+        return None
+
+
+@dataclass
+class TestSample:
+    fail: str = None
+
+
+class FakeCache(RemoteCache):
+    def __init__(self):
+        super().__init__(FailingBackend(), RemoteCachePassthroughSerde())
+
+    def _create_sample(self):
+        return TestSample()
+
+    def _log_sample(self, sample):
+        self.sample = sample
+
+
+class TestRemoteCache(TestCase):
+    def test_normal_logging(
+        self,
+    ) -> None:
+        c = RemoteCache(NoopBackend(), RemoteCachePassthroughSerde())
+        c.put("test", "value")
+        c.get("test")
+
+    def test_failure_no_sample(
+        self,
+    ) -> None:
+        c = RemoteCache(FailingBackend(), RemoteCachePassthroughSerde())
+        with self.assertRaises(AssertionError):
+            c.put("test", "value")
+        with self.assertRaises(AssertionError):
+            c.get("test")
+
+    def test_failure_logging(
+        self,
+    ) -> None:
+        c = FakeCache()
+        with self.assertRaises(AssertionError):
+            c.put("test", "value")
+        self.assertEqual(c.sample.fail_reason, "testput")
+        with self.assertRaises(AssertionError):
+            c.get("test")
+        self.assertEqual(c.sample.fail_reason, "testget")
+
+
+if __name__ == "__main__":
+    from torch._inductor.test_case import run_tests
+
+    run_tests()

--- a/torch/_inductor/remote_cache.py
+++ b/torch/_inductor/remote_cache.py
@@ -170,10 +170,13 @@ class RemoteCache(Generic[_T]):
             try:
                 result = self._get(key, sample)
                 cache_stats.get(type(self).__name__, result)
-            except Exception:
+            except Exception as e:
                 cache_stats.exception(type(self).__name__)
+                if sample:
+                    sample.fail_reason = str(e)
                 raise
-            self._log_sample(sample)
+            finally:
+                self._log_sample(sample)
             return result
 
     # Add `value` to the cache with the key `key`. Note that `None` is not a
@@ -186,10 +189,13 @@ class RemoteCache(Generic[_T]):
             try:
                 self._put(key, value, sample)
                 cache_stats.put(type(self).__name__)
-            except Exception:
+            except Exception as e:
                 cache_stats.exception(type(self).__name__)
+                if sample:
+                    sample.fail_reason = str(e)
                 raise
-            self._log_sample(sample)
+            finally:
+                self._log_sample(sample)
 
     # Used to convert data from the cache into structured data.
     def _decode(self, data: _U, sample: Optional[Sample]) -> _T:  # type: ignore[override]


### PR DESCRIPTION
Summary: This allows us to start alerting on cache failures, based on scuba data

Test Plan:
Added new tests explicitly for the Remote Cache API.

Note that we have existing tests for memcache, but not for manifold AFAICT.

There are two potential wrinkles. One we're adding a new field (and everything uses ScubaData AFAICT, so this should just work).

The other one is the implicit api contract that if the sample is None, then it will be ignored (and not crash). I believe the second one is implemented correctly (and tested). The first one is a little more nebulous, but I think won't cause any breakages.

Also manually ran a compile and made sure it didn't break - P1851504490 as well as forcing it to break and checking we didn't screw up the exception handling - P1851504243

Rollback Plan:

Differential Revision: D77054339




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben