### PR TITLE
[logging] Add env var to disable stderr logs

### DIFF
--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -44,6 +44,7 @@ trace_log = logging.getLogger("torch.__trace")
 DEFAULT_LOG_LEVEL = logging.WARNING
 LOG_ENV_VAR = "TORCH_LOGS"
 LOG_OUT_ENV_VAR = "TORCH_LOGS_OUT"
+LOG_DISABLE_STREAM_ENV_VAR = "TORCH_LOGS_DISABLE_STREAM"
 LOG_FORMAT_ENV_VAR = "TORCH_LOGS_FORMAT"
 LOG_TRACE_ID_FILTER = "TORCH_LOGS_TRACE_ID_FILTER"
 TRACE_ENV_VAR = "TORCH_TRACE"
@@ -997,6 +998,8 @@ def _init_logs(log_file_name=None) -> None:
     if out is not None:
         log_file_name = out
 
+    log_disable_stream = LOG_DISABLE_STREAM_ENV_VAR not in os.environ
+
     # First, reset all known (registered) loggers to NOTSET, so that they
     # respect their parent log level
     for log_qname in log_registry.get_log_qnames():
@@ -1016,10 +1019,11 @@ def _init_logs(log_file_name=None) -> None:
     # Finally, setup handlers for all registered loggers
     for log_qname in log_registry.get_log_qnames():
         log = logging.getLogger(log_qname)
-        _setup_handlers(
-            logging.StreamHandler,
-            log,
-        )
+        if log_disable_stream:
+            _setup_handlers(
+                logging.StreamHandler,
+                log,
+            )
 
         if log_file_name is not None:
             _setup_handlers(


### PR DESCRIPTION
When using `TORCH_LOGS`, by default, logs will be emitted to `stderr`. This can be disabled with `TORCH_LOGS_DISABLE_STREAM` set to any value.

When combined with `TORCH_LOGS_OUT`, the output will still be available in a file of your choosing.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela