### PR TITLE
ci: Add sccache to manylinux images

### DIFF
--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -2,27 +2,42 @@
 
 set -ex
 
-install_ubuntu() {
-  echo "Preparing to build sccache from source"
+SCCACHE_VERSION="0.10.0"
+
+CARGO_FLAGS=""
+
+install_prereqs_ubuntu() {
   apt-get update
   # libssl-dev will not work as it is upgraded to libssl3 in Ubuntu-22.04.
   # Instead use lib and headers from OpenSSL1.1 installed in `install_openssl.sh``
   apt-get install -y cargo
-  echo "Checking out sccache repo"
-  git clone https://github.com/mozilla/sccache -b v0.10.0
-  cd sccache
-  echo "Building sccache"
-  cargo build --release
-  cp target/release/sccache /opt/cache/bin
-  echo "Cleaning up"
-  cd ..
-  rm -rf sccache
-  apt-get remove -y cargo rustc
-  apt-get autoclean && apt-get clean
+  # cleanup after ourselves
+  trap 'cleanup_ubuntu' EXIT
 
   echo "Downloading old sccache binary from S3 repo for PCH builds"
   curl --retry 3 https://s3.amazonaws.com/ossci-linux/sccache -o /opt/cache/bin/sccache-0.2.14a
   chmod 755 /opt/cache/bin/sccache-0.2.14a
+}
+
+cleanup_ubuntu() {
+  rm -rf sccache
+  apt-get remove -y cargo rustc
+  apt-get autoclean && apt-get clean
+}
+
+install_prereqs_almalinux() {
+  dnf install -y cargo
+  # use vendored openssl, we're not going to use the dist-server anyways
+  CARGO_FEATURES="--bin sccache --features openssl/vendored"
+}
+
+build_and_install_sccache() {
+  # modern version of git don't like openssl1.1
+  wget -q -O sccache.tar.gz "https://github.com/mozilla/sccache/archive/refs/tags/v${SCCACHE_VERSION}.tar.gz"
+  tar xzf sccache.tar.gz
+  pushd "sccache-${SCCACHE_VERSION}"
+  cargo build --release ${CARGO_FEATURES}
+  cp target/release/sccache /opt/cache/bin
 }
 
 install_binary() {
@@ -35,8 +50,21 @@ mkdir -p /opt/cache/lib
 sed -e 's|PATH="\(.*\)"|PATH="/opt/cache/bin:\1"|g' -i /etc/environment
 export PATH="/opt/cache/bin:$PATH"
 
-# Setup compiler cache
-install_ubuntu
+echo "Preparing to build sccache from source"
+DIST_ID=$(. /etc/os-release && echo "$ID")
+case ${DIST_ID} in
+  ubuntu)
+    install_prereqs_ubuntu
+    ;;
+  almalinux)
+    install_prereqs_almalinux
+    ;;
+  *)
+    echo "ERROR: Unknown distribution ${DIST_ID}"
+    exit 1
+    ;;
+esac
+build_and_install_sccache
 chmod a+x /opt/cache/bin/sccache
 
 function write_sccache_stub() {

--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -27,7 +27,7 @@ cleanup_ubuntu() {
 
 install_prereqs_almalinux() {
   dnf install -y cargo
-  # use vendored openssl, we're not going to use the dist-server anyways
+  # disable all features except for local caching
   CARGO_FEATURES="--bin sccache --no-default-features"
 }
 

--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -28,7 +28,7 @@ cleanup_ubuntu() {
 install_prereqs_almalinux() {
   dnf install -y cargo
   # use vendored openssl, we're not going to use the dist-server anyways
-  CARGO_FEATURES="--bin sccache --features openssl/vendored"
+  CARGO_FEATURES="--bin sccache --no-default-features"
 }
 
 build_and_install_sccache() {

--- a/.ci/docker/manywheel/Dockerfile_2_28
+++ b/.ci/docker/manywheel/Dockerfile_2_28
@@ -63,6 +63,11 @@ FROM base as libpng
 ADD ./common/install_libpng.sh install_libpng.sh
 RUN bash ./install_libpng.sh && rm install_libpng.sh
 
+FROM base as cache
+# Install sccache
+ADD ./common/install_cache.sh install_cache.sh
+RUN bash ./install_cache.sh && rm install_cache.sh
+
 FROM ${GPU_IMAGE} as common
 ARG DEVTOOLSET_VERSION=13
 ENV LC_ALL en_US.UTF-8
@@ -115,6 +120,10 @@ COPY --from=libpng             /usr/local/include/libpng*            /usr/local/
 COPY --from=libpng             /usr/local/lib/libpng*                /usr/local/lib/
 COPY --from=libpng             /usr/local/lib/pkgconfig              /usr/local/lib/pkgconfig
 COPY --from=jni                /usr/local/include/jni.h              /usr/local/include/jni.h
+COPY --from=cache              /opt/cache                            /opt/cache
+
+# Ensure sccache is included in the path
+ENV PATH /opt/cache/bin:$PATH
 
 FROM common as cpu_final
 ARG BASE_CUDA_VERSION=12.6

--- a/.ci/docker/manywheel/Dockerfile_2_28_aarch64
+++ b/.ci/docker/manywheel/Dockerfile_2_28_aarch64
@@ -62,6 +62,11 @@ ARG OPENBLAS_VERSION
 ADD ./common/install_openblas.sh install_openblas.sh
 RUN bash ./install_openblas.sh && rm install_openblas.sh
 
+FROM base as cache
+# Install sccache
+ADD ./common/install_cache.sh install_cache.sh
+RUN bash ./install_cache.sh && rm install_cache.sh
+
 FROM base as final
 
 # remove unnecessary python versions
@@ -70,4 +75,8 @@ RUN rm -rf /opt/python/cp26-cp26mu /opt/_internal/cpython-2.6.9-ucs4
 RUN rm -rf /opt/python/cp33-cp33m /opt/_internal/cpython-3.3.6
 RUN rm -rf /opt/python/cp34-cp34m /opt/_internal/cpython-3.4.6
 COPY --from=openblas     /opt/OpenBLAS/  /opt/OpenBLAS/
+COPY --from=cache              /opt/cache                            /opt/cache
+
 ENV LD_LIBRARY_PATH=/opt/OpenBLAS/lib:$LD_LIBRARY_PATH
+# Ensure sccache is included in the path
+ENV PATH /opt/cache/bin:$PATH

--- a/.ci/docker/manywheel/Dockerfile_s390x
+++ b/.ci/docker/manywheel/Dockerfile_s390x
@@ -89,11 +89,20 @@ ADD ./common/install_cpython.sh /build_scripts/install_cpython.sh
 ENV SSL_CERT_FILE=
 RUN bash build_scripts/build.sh && rm -r build_scripts
 
+FROM base as cache
+# Install sccache
+ADD ./common/install_cache.sh install_cache.sh
+RUN bash ./install_cache.sh && rm install_cache.sh
+
 FROM base as final
 COPY --from=python             /opt/python                           /opt/python
 COPY --from=python             /opt/_internal                        /opt/_internal
 COPY --from=python             /opt/python/cp39-cp39/bin/auditwheel  /usr/local/bin/auditwheel
 COPY --from=patchelf           /usr/local/bin/patchelf               /usr/local/bin/patchelf
+COPY --from=cache              /opt/cache                            /opt/cache
+
+# Ensure sccache is included in the path
+ENV PATH /opt/cache/bin:$PATH
 
 RUN alternatives --set python /usr/bin/python3.12
 RUN alternatives --set python3 /usr/bin/python3.12


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #156892
* #156894

Adds sccache to our manylinux images, these are purposefully built
without the scccache-dist binary since we're not expecting to use that.

Another caveat of these builds is that they are built with the vendored
version of openssl.

This is to set the stage for us to be able to build binaries
sequentially.

This is a reland of #148419 

Signed-off-by: Eli Uriegas <github@terriblecode.com>