### PR TITLE
Uninstall brew miniconda while running MacOS testing

### DIFF
--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -88,6 +88,14 @@ jobs:
             pkill "${PROCESS}" || true
           done
 
+      - name: Clean up brew miniconda, if installed
+        continue-on-error: true
+        run: |
+          if brew list miniconda; then
+            brew uninstall miniconda
+            echo "REINSTALL_BREW_MINICONDA=1" >> "${GITHUB_ENV}"
+          fi
+
       - name: Clean up leftover local python3 site-packages on MacOS pet runner
         continue-on-error: true
         run: |
@@ -267,6 +275,14 @@ jobs:
           workflow_run_id: ${{github.run_id}}
           workflow_attempt: ${{github.run_attempt}}
           local_path: usage_log.txt
+
+      - name: Reinstall brew miniconda, if was installed
+        if: always()
+        continue-on-error: true
+        run: |
+          if [[ -n "$REINSTALL_BREW_MINICONDA" ]]; then
+              brew install miniconda
+          fi
 
       - name: Clean up disk space
         if: always()


### PR DESCRIPTION
That results in torch.compile being unable to produce working artifacts
But reinstall it later, when done

Should fix https://github.com/pytorch/pytorch/issues/156833
