### PR TITLE
[ROCm] logsumexp on ROCm needs scaling back to natural base.

### DIFF
--- a/torch/distributed/tensor/experimental/_attention.py
+++ b/torch/distributed/tensor/experimental/_attention.py
@@ -43,15 +43,16 @@ class _RotateMethod(Enum):
 aten = torch.ops.aten
 logger = logging.getLogger(__name__)
 
-_is_hip : bool = hasattr(torch.version, "hip") and torch.version.hip is not None
+_is_hip: bool = hasattr(torch.version, "hip") and torch.version.hip is not None
 if _is_hip:
-    gcn_arch_name = torch.cuda.get_device_properties('cuda').gcnArchName
+    gcn_arch_name = torch.cuda.get_device_properties("cuda").gcnArchName
     _is_ck_supported = False
-    for arch in ['gfx942', 'gfx950']:
+    for arch in ["gfx942", "gfx950"]:
         if arch in gcn_arch_name:
             _is_ck_supported = True
     _preferred_rocm_fa_library = torch.backends.cuda.preferred_rocm_fa_library
-    _CK_BACKEND = torch.backends.cuda._ROCmFABackends['ck']
+    _CK_BACKEND = torch.backends.cuda._ROCmFABackends["ck"]
+
 
 class _DispatchMode(Enum):
     MONKEY_PATCH = auto()
@@ -459,7 +460,8 @@ def _templated_ring_attention(
             need_scaling = True
             # Note: it is possible that CK is seleted but not compiled in the binary.
             if _is_ck_supported and _preferred_rocm_fa_library() == _CK_BACKEND:
-                need_scaling = False  # Unsure about CK's behavior, keep logsumexp untouched
+                # Unsure about CK's behavior, keep logsumexp untouched
+                need_scaling = False
             if need_scaling:
                 logsumexp *= 0.6931471805599453
         sdpa_merger.step(out, logsumexp, partial)

--- a/torch/distributed/tensor/experimental/_attention.py
+++ b/torch/distributed/tensor/experimental/_attention.py
@@ -45,13 +45,16 @@ logger = logging.getLogger(__name__)
 
 _is_hip: bool = hasattr(torch.version, "hip") and torch.version.hip is not None
 if _is_hip:
-    gcn_arch_name = torch.cuda.get_device_properties("cuda").gcnArchName
-    _is_ck_supported = False
-    for arch in ["gfx942", "gfx950"]:
-        if arch in gcn_arch_name:
-            _is_ck_supported = True
-    _preferred_rocm_fa_library = torch.backends.cuda.preferred_rocm_fa_library
-    _CK_BACKEND = torch.backends.cuda._ROCmFABackends["ck"]
+    try:
+        gcn_arch_name = torch.cuda.get_device_properties("cuda").gcnArchName
+        _is_ck_supported = False
+        for arch in ["gfx942", "gfx950"]:
+            if arch in gcn_arch_name:
+                _is_ck_supported = True
+        _preferred_rocm_fa_library = torch.backends.cuda.preferred_rocm_fa_library
+        _CK_BACKEND = torch.backends.cuda._ROCmFABackends["ck"]
+    except Exception:
+        _is_hip = False  # HIP is unavailable at runtime even if compiled
 
 
 class _DispatchMode(Enum):

--- a/torch/distributed/tensor/experimental/_attention.py
+++ b/torch/distributed/tensor/experimental/_attention.py
@@ -43,6 +43,15 @@ class _RotateMethod(Enum):
 aten = torch.ops.aten
 logger = logging.getLogger(__name__)
 
+_is_hip : bool = hasattr(torch.version, "hip") and torch.version.hip is not None
+if _is_hip:
+    gcn_arch_name = torch.cuda.get_device_properties('cuda').gcnArchName
+    _is_ck_supported = False
+    for arch in ['gfx942', 'gfx950']:
+        if arch in gcn_arch_name:
+            _is_ck_supported = True
+    _preferred_rocm_fa_library = torch.backends.cuda.preferred_rocm_fa_library
+    _CK_BACKEND = torch.backends.cuda._ROCmFABackends['ck']
 
 class _DispatchMode(Enum):
     MONKEY_PATCH = auto()
@@ -446,6 +455,13 @@ def _templated_ring_attention(
             is_causal=is_causal_behavior.value,
             **kwargs,
         )
+        if _is_hip:  # See: https://github.com/pytorch/pytorch/issues/156012
+            need_scaling = True
+            # Note: it is possible that CK is seleted but not compiled in the binary.
+            if _is_ck_supported and _preferred_rocm_fa_library() == _CK_BACKEND:
+                need_scaling = False  # Unsure about CK's behavior, keep logsumexp untouched
+            if need_scaling:
+                logsumexp *= 0.6931471805599453
         sdpa_merger.step(out, logsumexp, partial)
 
     return *sdpa_merger.results(), *rest

--- a/torch/distributed/tensor/experimental/_attention.py
+++ b/torch/distributed/tensor/experimental/_attention.py
@@ -44,6 +44,7 @@ aten = torch.ops.aten
 logger = logging.getLogger(__name__)
 
 _is_hip = None
+_CK_BACKEND = None
 
 
 class _DispatchMode(Enum):
@@ -449,6 +450,7 @@ def _templated_ring_attention(
             **kwargs,
         )
         global _is_hip
+        global _CK_BACKEND
         if _is_hip is None:  # Lazy Initialization
             _is_hip = hasattr(torch.version, "hip") and torch.version.hip is not None
             try:
@@ -465,7 +467,7 @@ def _templated_ring_attention(
                 _is_hip = False  # HIP is unavailable at runtime even if compiled
         if _is_hip:  # See: https://github.com/pytorch/pytorch/issues/156012
             need_scaling = True
-            # Note: it is possible that CK is seleted but not compiled in the binary.
+            # Note: it is possible that CK is selected but not compiled in the binary.
             if _is_ck_supported and _preferred_rocm_fa_library() == _CK_BACKEND:
                 # Unsure about CK's behavior, keep logsumexp untouched
                 need_scaling = False

--- a/torch/distributed/tensor/experimental/_attention.py
+++ b/torch/distributed/tensor/experimental/_attention.py
@@ -43,8 +43,8 @@ class _RotateMethod(Enum):
 aten = torch.ops.aten
 logger = logging.getLogger(__name__)
 
-_is_hip = None
-_CK_BACKEND = None
+_is_hip: bool | None = None
+_CK_BACKEND: str | None = None
 
 
 class _DispatchMode(Enum):
@@ -459,6 +459,7 @@ def _templated_ring_attention(
                 for arch in ["gfx942", "gfx950"]:
                     if arch in gcn_arch_name:
                         _is_ck_supported = True
+                # Check the function exists
                 _preferred_rocm_fa_library = (
                     torch.backends.cuda.preferred_rocm_fa_library
                 )
@@ -467,6 +468,7 @@ def _templated_ring_attention(
                 _is_hip = False  # HIP is unavailable at runtime even if compiled
         if _is_hip:  # See: https://github.com/pytorch/pytorch/issues/156012
             need_scaling = True
+            _preferred_rocm_fa_library = torch.backends.cuda.preferred_rocm_fa_library
             # Note: it is possible that CK is selected but not compiled in the binary.
             if _is_ck_supported and _preferred_rocm_fa_library() == _CK_BACKEND:
                 # Unsure about CK's behavior, keep logsumexp untouched

--- a/torch/distributed/tensor/experimental/_attention.py
+++ b/torch/distributed/tensor/experimental/_attention.py
@@ -43,18 +43,7 @@ class _RotateMethod(Enum):
 aten = torch.ops.aten
 logger = logging.getLogger(__name__)
 
-_is_hip: bool = hasattr(torch.version, "hip") and torch.version.hip is not None
-if _is_hip:
-    try:
-        gcn_arch_name = torch.cuda.get_device_properties("cuda").gcnArchName
-        _is_ck_supported = False
-        for arch in ["gfx942", "gfx950"]:
-            if arch in gcn_arch_name:
-                _is_ck_supported = True
-        _preferred_rocm_fa_library = torch.backends.cuda.preferred_rocm_fa_library
-        _CK_BACKEND = torch.backends.cuda._ROCmFABackends["ck"]
-    except Exception:
-        _is_hip = False  # HIP is unavailable at runtime even if compiled
+_is_hip = None
 
 
 class _DispatchMode(Enum):
@@ -459,6 +448,21 @@ def _templated_ring_attention(
             is_causal=is_causal_behavior.value,
             **kwargs,
         )
+        global _is_hip
+        if _is_hip is None:  # Lazy Initialization
+            _is_hip = hasattr(torch.version, "hip") and torch.version.hip is not None
+            try:
+                gcn_arch_name = torch.cuda.get_device_properties("cuda").gcnArchName
+                _is_ck_supported = False
+                for arch in ["gfx942", "gfx950"]:
+                    if arch in gcn_arch_name:
+                        _is_ck_supported = True
+                _preferred_rocm_fa_library = (
+                    torch.backends.cuda.preferred_rocm_fa_library
+                )
+                _CK_BACKEND = torch.backends.cuda._ROCmFABackends["ck"]
+            except Exception:
+                _is_hip = False  # HIP is unavailable at runtime even if compiled
         if _is_hip:  # See: https://github.com/pytorch/pytorch/issues/156012
             need_scaling = True
             # Note: it is possible that CK is seleted but not compiled in the binary.


### PR DESCRIPTION
Fixes #156012

This is a temporary solution that makes context parallelism working before logsumexp behavior changes landed in AOTriton.

After discussion we are not going to release AOTriton 0.10.1 to fix this due to
* Even if the interface is not changed, changing the behavior of returned logsumexp tensor should still be considered as an ABI break. Such changes do not fall into the "ABI compatible" category and should be postponed to next release. 
* AOTriton 0.11 is scheduled to be released before end of July, which is less than five weeks

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd