### PR TITLE
[MTIA ATen Backend] In-Tree mul.Scalar_out / mul.out

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4269,7 +4269,7 @@
   structured: True
   structured_inherits: TensorIteratorBase
   dispatch:
-    CPU, CUDA, MPS: mul_out
+    CPU, CUDA, MPS, MTIA: mul_out
     SparseCPU: mul_out_sparse_cpu
     SparseCUDA: mul_out_sparse_cuda
     SparseCsrCPU, SparseCsrCUDA, SparseCsrMeta: mul_out_sparse_csr


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #156941
* #156940
* #156939
* #156938
* __->__ #156937
* #156936
* #156935
* #156934
* #156933

Migrate mul.Scalar_out / mul.out in tree

Differential Revision: [D77011801](https://our.internmc.facebook.com/intern/diff/D77011801/)