### PR TITLE
Remove mentioning of TorchScript in Export doc

### DIFF
--- a/docs/source/export.ir_spec.md
+++ b/docs/source/export.ir_spec.md
@@ -3,7 +3,7 @@
 # torch.export IR Specification
 
 Export IR is an intermediate representation (IR) for compilers, which bears
-similarities to [MLIR](https://mlir.llvm.org/). It is specifically designed to express the
+similarities to [MLIR](https://mlir.llvm.org/) and TorchScript. It is specifically designed to express the
 semantics of PyTorch programs. Export IR primarily represents computation in a
 streamlined list of operations, with limited support for dynamism such as
 control flows.

--- a/docs/source/export.ir_spec.md
+++ b/docs/source/export.ir_spec.md
@@ -3,7 +3,7 @@
 # torch.export IR Specification
 
 Export IR is an intermediate representation (IR) for compilers, which bears
-similarities to MLIR and TorchScript. It is specifically designed to express the
+similarities to [MLIR](https://mlir.llvm.org/). It is specifically designed to express the
 semantics of PyTorch programs. Export IR primarily represents computation in a
 streamlined list of operations, with limited support for dynamism such as
 control flows.

--- a/docs/source/export.md
+++ b/docs/source/export.md
@@ -129,7 +129,7 @@ programs, and produce lower-level graphs (at the `torch.ops.aten` operator
 level). Note that users can still use {func}`torch.fx.symbolic_trace` as a
 preprocessing step before `torch.export`.
 
-Compared to {func}`torch.jit.trace`, `torch.export` does not capture Python
+Compared to {func}`torch.jit.script`, `torch.export` does not capture Python
 control flow or data structures, but it supports more Python language
 features due to its comprehensive coverage over Python bytecodes.
 The resulting graphs are simpler and only have straight line control

--- a/docs/source/export.md
+++ b/docs/source/export.md
@@ -135,7 +135,7 @@ features due to its comprehensive coverage over Python bytecodes.
 The resulting graphs are simpler and only have straight line control
 flow, except for explicit control flow operators.
 
-Compared to traditional tracing methods, `torch.export` is sound:
+Compared to {func}`torch.jit.trace`, `torch.export` is sound:
 it can trace code that performs integer computation on sizes and records
 all of the side-conditions necessary to ensure that a particular
 trace is valid for other inputs.

--- a/docs/source/export.md
+++ b/docs/source/export.md
@@ -129,16 +129,16 @@ programs, and produce lower-level graphs (at the `torch.ops.aten` operator
 level). Note that users can still use {func}`torch.fx.symbolic_trace` as a
 preprocessing step before `torch.export`.
 
-Compared to {func}`torch.jit.script`, `torch.export` does not capture Python
-control flow or data structures, but it supports more Python language features
-than TorchScript (as it is easier to have comprehensive coverage over Python
-bytecodes). The resulting graphs are simpler and only have straight line control
-flow (except for explicit control flow operators).
+Compared to traditional methods, `torch.export` does not capture Python
+control flow or data structures, but it supports more Python language
+features due to its comprehensive coverage over Python bytecodes.
+The resulting graphs are simpler and only have straight line control
+flow, except for explicit control flow operators.
 
-Compared to {func}`torch.jit.trace`, `torch.export` is sound: it is able to
-trace code that performs integer computation on sizes and records all of the
-side-conditions necessary to show that a particular trace is valid for other
-inputs.
+Compared to traditional tracing methods, `torch.export` is sound:
+it can trace code that performs integer computation on sizes and records 
+all of the side-conditions necessary to ensure that a particular 
+trace is valid for other inputs.
 
 ## Exporting a PyTorch Model
 

--- a/docs/source/export.md
+++ b/docs/source/export.md
@@ -129,7 +129,7 @@ programs, and produce lower-level graphs (at the `torch.ops.aten` operator
 level). Note that users can still use {func}`torch.fx.symbolic_trace` as a
 preprocessing step before `torch.export`.
 
-Compared to traditional methods, `torch.export` does not capture Python
+Compared to {func}`torch.jit.trace`, `torch.export` does not capture Python
 control flow or data structures, but it supports more Python language
 features due to its comprehensive coverage over Python bytecodes.
 The resulting graphs are simpler and only have straight line control

--- a/docs/source/export.md
+++ b/docs/source/export.md
@@ -136,8 +136,8 @@ The resulting graphs are simpler and only have straight line control
 flow, except for explicit control flow operators.
 
 Compared to traditional tracing methods, `torch.export` is sound:
-it can trace code that performs integer computation on sizes and records 
-all of the side-conditions necessary to ensure that a particular 
+it can trace code that performs integer computation on sizes and records
+all of the side-conditions necessary to ensure that a particular
 trace is valid for other inputs.
 
 ## Exporting a PyTorch Model


### PR DESCRIPTION
Remove mentioning of TorchScript

cc @sekyondaMeta @AlannaBurke @avikchaudhuri @gmagogsfm @zhxchen17 @tugsbayasgalan @angelayi @suo @ydwu4 @penguinwu