### PR TITLE
[racer] Add unit tests for torch._functorch.partitioners.should_quantize function

### DIFF
--- a/test/functorch/test_partitioners.py
+++ b/test/functorch/test_partitioners.py
@@ -1,0 +1,188 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from torch._functorch.partitioners import (
+    should_quantize,
+    statically_known_false,
+    statically_known_true,
+)
+from torch.fx.experimental.proxy_tensor import make_fx
+
+
+class TestPartitioners(unittest.TestCase):
+    def setUp(self):
+        # Save original config values to restore after tests
+        self.original_config = {}
+        if (
+            hasattr(torch._inductor.config, "post_grad_fusion_options")
+            and "activation_quantization_aten_pass"
+            in torch._inductor.config.post_grad_fusion_options
+        ):
+            self.original_config = dict(
+                torch._inductor.config.post_grad_fusion_options[
+                    "activation_quantization_aten_pass"
+                ]
+            )
+
+    def tearDown(self):
+        # Restore original config values
+        if (
+            hasattr(torch._inductor.config, "post_grad_fusion_options")
+            and "activation_quantization_aten_pass"
+            in torch._inductor.config.post_grad_fusion_options
+        ):
+            torch._inductor.config.post_grad_fusion_options[
+                "activation_quantization_aten_pass"
+            ] = self.original_config
+
+    def _create_test_node(self, shape=(10, 10), dtype=torch.bfloat16):
+        """Helper to create a test node with meta data for testing should_quantize"""
+        tensor = torch.randn(shape, dtype=dtype)
+
+        # Create a dummy function to trace
+        def dummy_fn(x):
+            return x + 1
+
+        # Use make_fx to create a traced function with meta data
+        traced = make_fx(dummy_fn)(tensor)
+
+        # Return the first node with meta data (should be the input node)
+        for node in traced.graph.nodes:
+            if hasattr(node, "meta") and "val" in node.meta:
+                return node
+
+        return None
+
+    def test_should_quantize_basic(self):
+        """Test the basic functionality of should_quantize"""
+        # Setup config for testing
+        if not hasattr(torch._inductor.config, "post_grad_fusion_options"):
+            torch._inductor.config.post_grad_fusion_options = {}
+
+        if (
+            "activation_quantization_aten_pass"
+            not in torch._inductor.config.post_grad_fusion_options
+        ):
+            torch._inductor.config.post_grad_fusion_options[
+                "activation_quantization_aten_pass"
+            ] = {}
+
+        config = torch._inductor.config.post_grad_fusion_options[
+            "activation_quantization_aten_pass"
+        ]
+
+        # Test with size below threshold
+        config["size_in_mb"] = 100
+        node = self._create_test_node(shape=(10, 10))  # Small tensor
+        self.assertFalse(should_quantize(node))
+
+        # Test with size above threshold
+        node = self._create_test_node(shape=(5000, 5000))  # Large tensor
+        self.assertTrue(should_quantize(node))
+
+        # Test with unsupported dtype
+        node = self._create_test_node(dtype=torch.int32)  # Unsupported dtype
+        self.assertFalse(should_quantize(node))
+
+    def test_should_quantize_skip_dynamo_guards(self):
+        """Test the skip_dynamo_guards functionality in should_quantize"""
+        # Setup config for testing
+        if not hasattr(torch._inductor.config, "post_grad_fusion_options"):
+            torch._inductor.config.post_grad_fusion_options = {}
+
+        if (
+            "activation_quantization_aten_pass"
+            not in torch._inductor.config.post_grad_fusion_options
+        ):
+            torch._inductor.config.post_grad_fusion_options[
+                "activation_quantization_aten_pass"
+            ] = {}
+
+        config = torch._inductor.config.post_grad_fusion_options[
+            "activation_quantization_aten_pass"
+        ]
+        config["size_in_mb"] = 100
+
+        # Create a test node
+        node = self._create_test_node(shape=(5000, 5000))  # Large tensor
+
+        # Test with skip_dynamo_guards=False (default behavior)
+        config["skip_dynamo_guards"] = False
+        self.assertTrue(should_quantize(node))
+
+        # Test with skip_dynamo_guards=True, quantize_dynamic_shape=False
+        config["skip_dynamo_guards"] = True
+        config["quantize_dynamic_shape"] = False
+
+        # Mock statically_known_true to return True for our test
+        original_skt = torch.fx.experimental.symbolic_shapes.statically_known_true
+        torch.fx.experimental.symbolic_shapes.statically_known_true = lambda x: True
+
+        self.assertTrue(should_quantize(node))
+
+        # Restore original function
+        torch.fx.experimental.symbolic_shapes.statically_known_true = original_skt
+
+    def test_should_quantize_with_dynamic_shapes(self):
+        """Test should_quantize with dynamic shapes"""
+        # Setup config for testing
+        if not hasattr(torch._inductor.config, "post_grad_fusion_options"):
+            torch._inductor.config.post_grad_fusion_options = {}
+
+        if (
+            "activation_quantization_aten_pass"
+            not in torch._inductor.config.post_grad_fusion_options
+        ):
+            torch._inductor.config.post_grad_fusion_options[
+                "activation_quantization_aten_pass"
+            ] = {}
+
+        config = torch._inductor.config.post_grad_fusion_options[
+            "activation_quantization_aten_pass"
+        ]
+        config["size_in_mb"] = 100
+        config["skip_dynamo_guards"] = True
+
+        # Create a test node
+        node = self._create_test_node(shape=(5000, 5000))  # Large tensor
+
+        # Test case 1: Always quantize tensors with dynamic shapes
+        config["quantize_dynamic_shape"] = True
+
+        # Mock statically_known_true to return False
+        original_skt = torch.fx.experimental.symbolic_shapes.statically_known_true
+        torch.fx.experimental.symbolic_shapes.statically_known_true = lambda x: False
+
+        # Mock statically_known_false to return False
+        original_skf = torch.fx.experimental.symbolic_shapes.statically_known_false
+        torch.fx.experimental.symbolic_shapes.statically_known_false = lambda x: False
+
+        # Should return True because not statically_known_false(size_in_mb >= threshold) is True
+        self.assertTrue(should_quantize(node))
+
+        # Restore original functions
+        torch.fx.experimental.symbolic_shapes.statically_known_true = original_skt
+        torch.fx.experimental.symbolic_shapes.statically_known_false = original_skf
+
+        # Test case 2: Always not quantize tensors with dynamic shapes
+        config["quantize_dynamic_shape"] = False
+
+        # Mock statically_known_true to return False
+        original_skt = torch.fx.experimental.symbolic_shapes.statically_known_true
+        torch.fx.experimental.symbolic_shapes.statically_known_true = lambda x: False
+
+        # Should return False because statically_known_true(size_in_mb >= threshold) is False
+        self.assertFalse(should_quantize(node))
+
+        # Restore original function
+        torch.fx.experimental.symbolic_shapes.statically_known_true = original_skt
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
## Instructions about RACER Diffs:
**This diff was generated by Racer AI agent on behalf of [Yaxuan Zang](https://www.internalfb.com/profile/view/100046492891797) for T225738545. If the quality is poor, consider contact user to add more clear instruction to the task.**

- If you are happy with the changes, commandeer it if minor edits are needed. (**we encourage commandeer to get the diff credit**)
- If you are not happy with the changes, please comment on the diff with clear actions and send it back to the author. Racer will pick it up and re-generate.
- If you really feel the Racer is not helping with this change (alas, some complex changes are hard for AI) feel free to abandon this diff.

For questions or suggestions please post in [RACER Feedback and Q&A](https://fb.workplace.com/groups/2477474979269093) group. 
## Summary:
This diff adds unit tests for the `should_quantize` function in `torch._functorch.partitioners` to address the unit test coverage requirements for the Change Readiness Signal (CRS). The changes in D75248430 added functionality to skip dynamo guards to avoid recompilation, but lacked proper test coverage.

The new tests cover:
1. Basic functionality of `should_quantize`
2. The new `skip_dynamo_guards` functionality
3. Both cases for handling dynamic shapes (always quantize vs. not quantize)

These tests will help ensure the functionality works correctly and meets the 70% coverage requirement.
---
> Generated by [RACER](https://www.internalfb.com/wiki/RACER_(Risk-Aware_Code_Editing_and_Refactoring)/), powered by [Confucius](https://www.internalfb.com/wiki/Confucius/Analect/Shared_Analects/Confucius_Code_Assist_(CCA)/)
[Session](https://www.internalfb.com/confucius?session_id=1d612a0c-519c-11f0-a66a-96babfb60e99&tab=Chat), [Trace](https://www.internalfb.com/confucius?session_id=1d612a0c-519c-11f0-a66a-96babfb60e99&tab=Trace)

Test Plan:
## General Test Instructions:
Racer runs basic linter checks, builds and unit tests (if present). However if this diff requires additional canaries or manual tests, please make sure you run them before land.
## Tests Done:
1. Added a new test file `test_partitioners.py` with comprehensive unit tests for the `should_quantize` function
2. The tests cover all branches of the modified code in D75248430:
   - Testing with skip_dynamo_guards=False (default behavior)
   - Testing with skip_dynamo_guards=True and quantize_dynamic_shape=False
   - Testing with skip_dynamo_guards=True and quantize_dynamic_shape=True
3. Tests restore the original configuration after running to avoid side effects
4. Added the test to the TARGETS file to make it discoverable by the test system
---
> Generated by [RACER](https://www.internalfb.com/wiki/RACER_(Risk-Aware_Code_Editing_and_Refactoring)/), powered by [Confucius](https://www.internalfb.com/wiki/Confucius/Analect/Shared_Analects/Confucius_Code_Assist_(CCA)/)
[Session](https://www.internalfb.com/confucius?session_id=1d612a0c-519c-11f0-a66a-96babfb60e99&tab=Chat), [Trace](https://www.internalfb.com/confucius?session_id=1d612a0c-519c-11f0-a66a-96babfb60e99&tab=Trace)

Rollback Plan:

Differential Revision: D77293391


