### PR TITLE
[EXPERIMENTAL][dynamo] Avoid potential graph breaks by relaxing `handle_traced_output` checks

### DIFF
--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -2888,18 +2888,7 @@ def handle_traced_output(example_value, tx, proxy, options, subclass_type, targe
 
         set_example_value(proxy.node, example_value)
         return SDPAParamsVariable(proxy, **options)
-    elif isinstance(example_value, bool) and (
-        proxy.node.target
-        in [
-            torch._C._are_functorch_transforms_active,
-            torch._C._functorch.is_batchedtensor,
-            torch.backends.cuda.is_flash_attention_available,
-            torch.backends.cuda.can_use_flash_attention,
-            torch.backends.cuda.can_use_efficient_attention,
-            "is_integer",
-        ]
-        + list(supported_const_comparison_op_values.keys())
-    ):
+    elif isinstance(example_value, bool):
         set_example_value(proxy.node, example_value)
         return ConstantVariable.create(example_value, **options)
     elif (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #157500
* #157499
* __->__ #157013

My hunch is that we don't need to check these because if Dynamo gets to
`handle_traced_output`, that means the underlying op is already allowed
to be in the fx graph.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames