### PR TITLE
[inductor][static launcher] Skip correctness test for test_floats

### DIFF
--- a/test/inductor/test_static_cuda_launcher.py
+++ b/test/inductor/test_static_cuda_launcher.py
@@ -2,7 +2,7 @@
 import os
 import random
 import tempfile
-from unittest import mock, expectedFailure
+from unittest import expectedFailure, mock
 
 import torch
 from torch._dynamo.device_interface import get_interface_for_device
@@ -153,7 +153,9 @@ class TestStaticCudaLauncher(TestCase):
     # despite type annotations.
     # There's also not really a good way for me to make a float16 in python...
     @skipIfRocm
-    @expectedFailureIf(TorchVersion(triton.__version__) >= "3.4.0")  # https://github.com/triton-lang/triton/issues/6176
+    @expectedFailureIf(
+        TorchVersion(triton.__version__) >= "3.4.0"
+    )  # https://github.com/triton-lang/triton/issues/6176
     def test_floats(self):
         @triton.jit
         def floats(arg0, arg1: tl.float16, arg2: tl.float32, arg3: tl.float64):
@@ -170,9 +172,7 @@ class TestStaticCudaLauncher(TestCase):
         # TODO: in Pytorch's pinned version of triton, arg3 is typed as regular float
         # but in triton 3.3.0, this is fixed and it's 0ffd. We'll need to update later.
         self.assertEqual(launcher.arg_tys, "Offf")
-        self.assertEqual(
-            arg0, torch.tensor([3.0], dtype=torch.float64, device="cuda")
-        )
+        self.assertEqual(arg0, torch.tensor([3.0], dtype=torch.float64, device="cuda"))
         new_arg0 = torch.zeros(1, dtype=torch.float64, device="cuda")
         device_interface = get_interface_for_device("cuda")
         stream = device_interface.get_raw_stream(device_interface.current_device())

--- a/test/inductor/test_static_cuda_launcher.py
+++ b/test/inductor/test_static_cuda_launcher.py
@@ -2,7 +2,7 @@
 import os
 import random
 import tempfile
-from unittest import mock
+from unittest import mock, expectedFailure
 
 import torch
 from torch._dynamo.device_interface import get_interface_for_device
@@ -15,6 +15,15 @@ from torch._inductor.test_case import TestCase
 from torch.testing._internal.common_utils import skipIfRocm
 from torch.testing._internal.triton_utils import requires_cuda
 from torch.torch_version import TorchVersion
+
+
+def expectedFailureIf(condition):
+    def decorator(fn):
+        if condition:
+            return expectedFailure(fn)
+        return fn
+
+    return decorator
 
 
 @requires_cuda
@@ -144,6 +153,7 @@ class TestStaticCudaLauncher(TestCase):
     # despite type annotations.
     # There's also not really a good way for me to make a float16 in python...
     @skipIfRocm
+    @expectedFailureIf(TorchVersion(triton.__version__) >= "3.4.0")  # https://github.com/triton-lang/triton/issues/6176
     def test_floats(self):
         @triton.jit
         def floats(arg0, arg1: tl.float16, arg2: tl.float32, arg3: tl.float64):
@@ -156,22 +166,18 @@ class TestStaticCudaLauncher(TestCase):
         args = (arg0, 1.0, 1.0, 1.0)
 
         compiled_kernel = floats[1,](*args)
-        if TorchVersion(triton.__version__) >= "3.4.0":
-            with self.assertRaisesRegex(NotImplementedError, "fp64 scalars"):
-                self._make_launcher(compiled_kernel)
-        else:
-            launcher = self._make_launcher(compiled_kernel)
-            # TODO: in Pytorch's pinned version of triton, arg3 is typed as regular float
-            # but in triton 3.3.0, this is fixed and it's 0ffd. We'll need to update later.
-            self.assertEqual(launcher.arg_tys, "Offf")
-            self.assertEqual(
-                arg0, torch.tensor([3.0], dtype=torch.float64, device="cuda")
-            )
-            new_arg0 = torch.zeros(1, dtype=torch.float64, device="cuda")
-            device_interface = get_interface_for_device("cuda")
-            stream = device_interface.get_raw_stream(device_interface.current_device())
-            launcher.run(1, 1, 1, stream, new_arg0, 1.0, 1.0, 1.0)
-            self.assertEqual(new_arg0, arg0)
+        launcher = self._make_launcher(compiled_kernel)
+        # TODO: in Pytorch's pinned version of triton, arg3 is typed as regular float
+        # but in triton 3.3.0, this is fixed and it's 0ffd. We'll need to update later.
+        self.assertEqual(launcher.arg_tys, "Offf")
+        self.assertEqual(
+            arg0, torch.tensor([3.0], dtype=torch.float64, device="cuda")
+        )
+        new_arg0 = torch.zeros(1, dtype=torch.float64, device="cuda")
+        device_interface = get_interface_for_device("cuda")
+        stream = device_interface.get_raw_stream(device_interface.current_device())
+        launcher.run(1, 1, 1, stream, new_arg0, 1.0, 1.0, 1.0)
+        self.assertEqual(new_arg0, arg0)
 
     @skipIfRocm
     def test_basic_1arg(self):

--- a/test/inductor/test_static_cuda_launcher.py
+++ b/test/inductor/test_static_cuda_launcher.py
@@ -14,6 +14,7 @@ from torch._inductor.runtime.triton_helpers import libdevice
 from torch._inductor.test_case import TestCase
 from torch.testing._internal.common_utils import skipIfRocm
 from torch.testing._internal.triton_utils import requires_cuda
+from torch.torch_version import TorchVersion
 
 
 @requires_cuda
@@ -155,8 +156,22 @@ class TestStaticCudaLauncher(TestCase):
         args = (arg0, 1.0, 1.0, 1.0)
 
         compiled_kernel = floats[1,](*args)
-        with self.assertRaisesRegex(NotImplementedError, "fp64 scalars"):
-            self._make_launcher(compiled_kernel)
+        if TorchVersion(triton.__version__) >= "3.4.0":
+            with self.assertRaisesRegex(NotImplementedError, "fp64 scalars"):
+                self._make_launcher(compiled_kernel)
+        else:
+            launcher = self._make_launcher(compiled_kernel)
+            # TODO: in Pytorch's pinned version of triton, arg3 is typed as regular float
+            # but in triton 3.3.0, this is fixed and it's 0ffd. We'll need to update later.
+            self.assertEqual(launcher.arg_tys, "Offf")
+            self.assertEqual(
+                arg0, torch.tensor([3.0], dtype=torch.float64, device="cuda")
+            )
+            new_arg0 = torch.zeros(1, dtype=torch.float64, device="cuda")
+            device_interface = get_interface_for_device("cuda")
+            stream = device_interface.get_raw_stream(device_interface.current_device())
+            launcher.run(1, 1, 1, stream, new_arg0, 1.0, 1.0, 1.0)
+            self.assertEqual(new_arg0, arg0)
 
     @skipIfRocm
     def test_basic_1arg(self):

--- a/test/inductor/test_static_cuda_launcher.py
+++ b/test/inductor/test_static_cuda_launcher.py
@@ -155,16 +155,8 @@ class TestStaticCudaLauncher(TestCase):
         args = (arg0, 1.0, 1.0, 1.0)
 
         compiled_kernel = floats[1,](*args)
-        launcher = self._make_launcher(compiled_kernel)
-        # TODO: in Pytorch's pinned version of triton, arg3 is typed as regular float
-        # but in triton 3.3.0, this is fixed and it's 0ffd. We'll need to update later.
-        self.assertEqual(launcher.arg_tys, "Offf")
-        self.assertEqual(arg0, torch.tensor([3.0], dtype=torch.float64, device="cuda"))
-        new_arg0 = torch.zeros(1, dtype=torch.float64, device="cuda")
-        device_interface = get_interface_for_device("cuda")
-        stream = device_interface.get_raw_stream(device_interface.current_device())
-        launcher.run(1, 1, 1, stream, new_arg0, 1.0, 1.0, 1.0)
-        self.assertEqual(new_arg0, arg0)
+        with self.assertRaisesRegex(NotImplementedError, "fp64 scalars"):
+            self._make_launcher(compiled_kernel)
 
     @skipIfRocm
     def test_basic_1arg(self):

--- a/torch/_inductor/runtime/static_cuda_launcher.py
+++ b/torch/_inductor/runtime/static_cuda_launcher.py
@@ -150,13 +150,7 @@ class StaticallyLaunchedCudaKernel:
             return "O"
         elif ty == "nvTmaDesc":
             raise NotImplementedError("nvTmaDesc kernels are not yet supported")
-        ret = StaticallyLaunchedCudaKernel.type_mappings()[ty]
-        if ret == "d":
-            # https://github.com/triton-lang/triton/issues/6176
-            raise NotImplementedError(
-                "fp64 scalars have a known issue in Triton (#6176)"
-            )
-        return ret
+        return StaticallyLaunchedCudaKernel.type_mappings()[ty]
 
     def arg_ty_from_signature(self, src: ASTSource) -> str:
         def index_key(i: Any) -> int:

--- a/torch/_inductor/runtime/static_cuda_launcher.py
+++ b/torch/_inductor/runtime/static_cuda_launcher.py
@@ -150,7 +150,13 @@ class StaticallyLaunchedCudaKernel:
             return "O"
         elif ty == "nvTmaDesc":
             raise NotImplementedError("nvTmaDesc kernels are not yet supported")
-        return StaticallyLaunchedCudaKernel.type_mappings()[ty]
+        ret = StaticallyLaunchedCudaKernel.type_mappings()[ty]
+        if ret == "d":
+            # https://github.com/triton-lang/triton/issues/6176
+            raise NotImplementedError(
+                "fp64 scalars have a known issue in Triton (#6176)"
+            )
+        return ret
 
     def arg_ty_from_signature(self, src: ASTSource) -> str:
         def index_key(i: Any) -> int:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #157023

https://github.com/triton-lang/triton/issues/6176 causes kernels that take fp64 scalar inputs to generate wrong results. Until we get around to fixing this, just skip the accuracy check (it'll fail on Triton's launcher anyway).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov

Differential Revision: [D77407307](https://our.internmc.facebook.com/intern/diff/D77407307)