### PR TITLE
Fix CN path in load_inline

### DIFF
--- a/.ci/pytorch/win-test.sh
+++ b/.ci/pytorch/win-test.sh
@@ -52,6 +52,9 @@ python -m pip install parameterized==0.8.1
 # Install pulp for testing ilps under torch\distributed\_tools
 python -m pip install pulp==2.9.0
 
+# Minimum version that supports unicode
+python -m pip install ninja=1.11.0
+
 run_tests() {
     # Run nvidia-smi if available
     for path in '/c/Program Files/NVIDIA Corporation/NVSMI/nvidia-smi.exe' /c/Windows/System32/nvidia-smi.exe; do

--- a/.ci/pytorch/win-test.sh
+++ b/.ci/pytorch/win-test.sh
@@ -53,7 +53,7 @@ python -m pip install parameterized==0.8.1
 python -m pip install pulp==2.9.0
 
 # Minimum version that supports unicode
-python -m pip install ninja=1.11.0
+python -m pip install ninja==1.11.0
 
 run_tests() {
     # Run nvidia-smi if available

--- a/.ci/pytorch/win-test.sh
+++ b/.ci/pytorch/win-test.sh
@@ -52,8 +52,8 @@ python -m pip install parameterized==0.8.1
 # Install pulp for testing ilps under torch\distributed\_tools
 python -m pip install pulp==2.9.0
 
-# Minimum version that supports unicode
-python -m pip install ninja==1.11.0
+# Version that supports unicode
+python -m pip install ninja==1.11.1.4
 
 run_tests() {
     # Run nvidia-smi if available

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -752,18 +752,18 @@ class TestCppExtensionJIT(common.TestCase):
             verbose=True,
         )
         self.assertEqual(module.f(), 123)
-
-    @unittest.skipIf(not IS_WINDOWS, "utf-8encoding test only needed on Windows")
+        
     def test_load_with_non_utf8_path(self):
         with tempfile.TemporaryDirectory() as temp_base:
-            chinese_dir = os.path.join(temp_base, "TTS项目", "中文路径") 
-            
+            chinese_dir = os.path.join(temp_base, "TTS项目", "中文路径")
+            os.makedirs(chinese_dir, exist_ok=True)
+
             cpp_source = """
             int chinese_path_test() { 
                 return 12345; 
             }
             """
-            
+
             module = torch.utils.cpp_extension.load_inline(
                 name="chinese_path_extension",
                 cpp_sources=cpp_source,
@@ -771,17 +771,17 @@ class TestCppExtensionJIT(common.TestCase):
                 build_directory=chinese_dir,
                 verbose=True,
             )
-            
+
             self.assertEqual(module.chinese_path_test(), 12345)
-            
+
             build_ninja_path = os.path.join(chinese_dir, "build.ninja")
-            if os.path.exists(build_ninja_path):
-                with open(build_ninja_path, "r", encoding="utf-8") as f:
-                    ninja_content = f.read()
-                
-                self.assertNotIn("", ninja_content)
-                if "项目" in ninja_content:
-                    self.assertIn("中文路径", ninja_content)
+            self.assertTrue(os.path.exists(build_ninja_path))
+
+            with open(build_ninja_path, "r", encoding="utf-8") as f:
+                ninja_content = f.read()
+
+            self.assertIn("TTS项目", ninja_content)
+            self.assertIn("中文路径", ninja_content)
 
     def test_cpp_frontend_module_has_same_output_as_python(self, dtype=torch.double):
         extension = torch.utils.cpp_extension.load(

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -755,11 +755,10 @@ class TestCppExtensionJIT(common.TestCase):
 
     @unittest.skipIf(not IS_WINDOWS, "utf-8encoding test only needed on Windows")
     def test_load_with_non_utf8_path(self):
-        temp_base = tempfile.mkdtemp()
-        chinese_dir = os.path.join(temp_base, "TTS项目", "中文路径") 
-        os.makedirs(chinese_dir, exist_ok=True)
-        
-        try:
+        with tempfile.TemporaryDirectory() as temp_base:
+            chinese_dir = os.path.join(temp_base, "TTS项目", "中文路径") 
+            os.makedirs(chinese_dir, exist_ok=True)
+            
             cpp_source = """
             int chinese_path_test() { 
                 return 12345; 
@@ -781,12 +780,9 @@ class TestCppExtensionJIT(common.TestCase):
                 with open(build_ninja_path, "r", encoding="utf-8") as f:
                     ninja_content = f.read()
                 
-                self.assertNotIn("����", ninja_content)
+                self.assertNotIn("", ninja_content)
                 if "项目" in ninja_content:
                     self.assertIn("中文路径", ninja_content)
-                
-        finally:
-            shutil.rmtree(temp_base)
 
     def test_cpp_frontend_module_has_same_output_as_python(self, dtype=torch.double):
         extension = torch.utils.cpp_extension.load(

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -752,15 +752,15 @@ class TestCppExtensionJIT(common.TestCase):
             verbose=True,
         )
         self.assertEqual(module.f(), 123)
-        
+
     def test_load_with_non_utf8_path(self):
         with tempfile.TemporaryDirectory() as temp_base:
             chinese_dir = os.path.join(temp_base, "TTS项目", "中文路径")
             os.makedirs(chinese_dir, exist_ok=True)
 
             cpp_source = """
-            int chinese_path_test() { 
-                return 12345; 
+            int chinese_path_test() {
+                return 12345;
             }
             """
 
@@ -777,7 +777,7 @@ class TestCppExtensionJIT(common.TestCase):
             build_ninja_path = os.path.join(chinese_dir, "build.ninja")
             self.assertTrue(os.path.exists(build_ninja_path))
 
-            with open(build_ninja_path, "r", encoding="utf-8") as f:
+            with open(build_ninja_path, encoding="utf-8") as f:
                 ninja_content = f.read()
 
             self.assertIn("TTS项目", ninja_content)

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -757,7 +757,6 @@ class TestCppExtensionJIT(common.TestCase):
     def test_load_with_non_utf8_path(self):
         with tempfile.TemporaryDirectory() as temp_base:
             chinese_dir = os.path.join(temp_base, "TTS项目", "中文路径") 
-            os.makedirs(chinese_dir, exist_ok=True)
             
             cpp_source = """
             int chinese_path_test() { 

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -753,6 +753,41 @@ class TestCppExtensionJIT(common.TestCase):
         )
         self.assertEqual(module.f(), 123)
 
+    @unittest.skipIf(not IS_WINDOWS, "utf-8encoding test only needed on Windows")
+    def test_load_with_non_utf8_path(self):
+        temp_base = tempfile.mkdtemp()
+        chinese_dir = os.path.join(temp_base, "TTS项目", "中文路径") 
+        os.makedirs(chinese_dir, exist_ok=True)
+        
+        try:
+            cpp_source = """
+            int chinese_path_test() { 
+                return 12345; 
+            }
+            """
+            
+            module = torch.utils.cpp_extension.load_inline(
+                name="chinese_path_extension",
+                cpp_sources=cpp_source,
+                functions=["chinese_path_test"],
+                build_directory=chinese_dir,
+                verbose=True,
+            )
+            
+            self.assertEqual(module.chinese_path_test(), 12345)
+            
+            build_ninja_path = os.path.join(chinese_dir, "build.ninja")
+            if os.path.exists(build_ninja_path):
+                with open(build_ninja_path, "r", encoding="utf-8") as f:
+                    ninja_content = f.read()
+                
+                self.assertNotIn("����", ninja_content)
+                if "项目" in ninja_content:
+                    self.assertIn("中文路径", ninja_content)
+                
+        finally:
+            shutil.rmtree(temp_base)
+
     def test_cpp_frontend_module_has_same_output_as_python(self, dtype=torch.double):
         extension = torch.utils.cpp_extension.load(
             name="cpp_frontend_extension",

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1796,7 +1796,7 @@ def _check_and_build_extension_h_precompiler_headers(
         if b_exist is False:
             return False
 
-        with open(file_path) as file:
+        with open(file_path, encoding="utf-8") as file:
             # read all content of a file
             content = file.read()
             # check if string present in a file
@@ -1812,7 +1812,7 @@ def _check_and_build_extension_h_precompiler_headers(
 
     def write_pch_signature_to_file(file_path, pch_sign):
         _create_if_not_exist(os.path.dirname(file_path))
-        with open(file_path, "w") as f:
+        with open(file_path, "w", encoding="utf-8") as f:
             f.write(pch_sign)
             f.close()
 
@@ -2203,8 +2203,8 @@ def _write_ninja_file_and_compile_objects(
     if not os.path.exists(build_directory):
         if verbose:
             logger.debug('Creating directory %s...', build_directory)
-        # This is like mkdir -p, i.e. will also create parent directories.
-        os.makedirs(build_directory, exist_ok=True)
+        # This is like mkdir -p but also works on Windows
+        Path(build_directory).mkdir(parents=True, exist_ok=True)
 
     _write_ninja_file(
         path=build_file_path,

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -353,14 +353,14 @@ def _maybe_write(filename, new_content):
     if it already had the right content (to avoid triggering recompile).
     '''
     if os.path.exists(filename):
-        with open(filename) as f:
+        with open(filename, encoding="utf-8") as f:
             content = f.read()
 
         if content == new_content:
             # The file already contains the right thing!
             return
 
-    with open(filename, 'w') as source_file:
+    with open(filename, 'w', encoding="utf-8") as source_file:
         source_file.write(new_content)
 
 def get_default_build_root() -> str:


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/151310

The problem here was testing for paths and nested paths with chinese characters 

This issue won't occur on a dev GPU or local Mac, it seems like it's a unique to Windows issue, tested that it works on my local PC

cc @albanD