### PR TITLE
[dtensor] relax device_mesh argument constraint in local_map

### DIFF
--- a/test/distributed/tensor/experimental/test_local_map.py
+++ b/test/distributed/tensor/experimental/test_local_map.py
@@ -14,12 +14,12 @@ from torch.distributed.tensor import (
 )
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.experimental import local_map
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     with_comms,
 )
-from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 
 
 funcol_py = torch.ops.c10d_functional
@@ -393,8 +393,6 @@ class TestLocalMap(DTensorTestBase):
         Test the function can be applied to accept DTensors that lives
         on different device meshes.
         """
-        import os
-        os.environ["NCCL_DEBUG"] = "WARN"
         mesh_full = init_device_mesh(
             device_type=self.device_type, mesh_shape=(self.world_size,)
         )

--- a/test/distributed/tensor/experimental/test_local_map.py
+++ b/test/distributed/tensor/experimental/test_local_map.py
@@ -19,6 +19,7 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     with_comms,
 )
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 
 
 funcol_py = torch.ops.c10d_functional
@@ -384,6 +385,50 @@ class TestLocalMap(DTensorTestBase):
                 X_dt.grad.full_tensor(), torch.cat([X1.grad, X2.grad], dim=0)
             )
             self.assertEqual(W_dt.grad.full_tensor(), W.grad)
+
+    @skip_if_lt_x_gpu(4)
+    @with_comms
+    def test_multi_mesh_inputs(self):
+        """
+        Test the function can be applied to accept DTensors that lives
+        on different device meshes.
+        """
+        import os
+        os.environ["NCCL_DEBUG"] = "WARN"
+        mesh_full = init_device_mesh(
+            device_type=self.device_type, mesh_shape=(self.world_size,)
+        )
+        mesh_2d = init_device_mesh(
+            device_type=self.device_type, mesh_shape=(self.world_size // 2, 2)
+        )
+        comm_mode = CommDebugMode()
+
+        X = torch.randn(8, 32, device=self.device_type, requires_grad=False)
+        x_placements = [Shard(1)]
+        W = torch.randn(16, 8, device=self.device_type, requires_grad=False)
+        w_placements = [Shard(0), Shard(1)]
+
+        X_dt = distribute_tensor(X, mesh_full, x_placements)
+        W_dt = distribute_tensor(W, mesh_2d, w_placements)
+
+        # local output shape should be (8, 4)
+        output_placements = [Replicate(), Shard(1)]
+
+        local_mm_forward = local_map(
+            mm_forward,
+            out_placements=output_placements,
+            in_placements=(x_placements, w_placements),
+            device_mesh=mesh_2d,
+        )
+
+        with comm_mode:
+            Y_dt = local_mm_forward(X_dt, W_dt)
+
+        self.assertEqual(comm_mode.get_total_counts(), 0)
+        # output local shape should be (8, 4)
+        self.assertEqual(Y_dt.to_local().shape, (8, 4))
+        # output lives in mesh_2d
+        self.assertEqual(Y_dt.device_mesh, mesh_2d)
 
 
 if __name__ == "__main__":

--- a/torch/distributed/tensor/experimental/_func_map.py
+++ b/torch/distributed/tensor/experimental/_func_map.py
@@ -76,10 +76,11 @@ def local_map(
             tensor input remains the same as the original :class:`DTensor` input
             and use that for gradient computation. Default: None.
         device_mesh (:class:`DeviceMesh`, optional):
-            the device mesh that all the :class:`DTensor` s are placed on. If not
-            specified, this will be inferred from the input :class:`DTensor` s' device
-            mesh. `local_map` requires every :class:`DTensor` s to be placed on the same
-            device mesh. Default: None.
+            the device mesh that the output :class:`DTensor` s are placed on. If not
+            specified, this will be inferred from the first input :class:`DTensor`'s device
+            mesh. Default: None.
+
+    Keyword Args:
         redistribute_inputs (bool, optional):
             the bool value indicating whether to reshard the input :class:`DTensor` s when
             their placements are different from the required input placements. If this
@@ -91,10 +92,6 @@ def local_map(
         and returns a :class:`DTensor` constructed from the return value of ``func``.
 
     Raises:
-        AssertionError: If the input :class:`DTensor` is not placed on the same device
-            mesh, or if they are placed on a different device mesh than the ``device_mesh``
-            argument passed in.
-
         AssertionError: For any non-DTensor output, we require its corresponding
             output placement in ``out_placements`` be None. An AssertionError will be raised
             if this is not the case.
@@ -159,11 +156,6 @@ def local_map(
                 # this function is applied to at least one DTensor argument
                 seen_dtensor_arg = True
 
-                assert arg.device_mesh == device_mesh, (
-                    f"arg {arg} in local_map has a mismatched device mesh: "
-                    f"{arg} has device mesh {arg.device_mesh} while "
-                    f"the expected device mesh is {device_mesh}!"
-                )
                 if in_placements is not None:
                     spec = in_placements[idx]
                     assert spec is not None, (
@@ -176,7 +168,7 @@ def local_map(
                     if arg.placements != spec:
                         if redistribute_inputs:
                             # redistribute to input placements
-                            arg = arg.redistribute(device_mesh, spec)
+                            arg = arg.redistribute(placements=spec)
                         else:
                             raise ValueError(
                                 f"arg {arg} in local_map has a mismatched placements: "
@@ -217,7 +209,7 @@ def local_map(
         out = func(*local_args, **kwargs)
 
         if seen_dtensor_arg:
-            # process output
+            # process output to be DTensor if we've seen DTensor inputs
             flat_out, out_spec = pytree.tree_flatten(out)
 
             flat_dist_out = []


### PR DESCRIPTION
This PR relaxes the device_mesh argument constraint in the local_map API. The current restriction is too strict, i.e. all the input arguments must have the same device mesh if they are DTensors. But many times user might want to pass in DTensors to this function that lives on different device mesh, i.e. weight and activation could live in different device mesh.

When using the local_map, we are extracting the local tensors from DTensors, and as long as the placements user specified match with the actual DTensor placements, user knows clearly that the inputs are intended to live in different mesh. So this PR removes the same mesh check and update doc to clearly document the behavior.

The `device_mesh` argument now serves for a main purpose, allow user to specify the device_mesh for the output DTensor reconstruction

Fixes #ISSUE_NUMBER


cc @H-Huang @awgu @fegin @fduwjj @wz337 @wconstab @d4l3k