### PR TITLE
[caffe][executorch] rename to avoid shadow in irange

### DIFF
--- a/c10/util/irange.h
+++ b/c10/util/irange.h
@@ -24,7 +24,7 @@ struct integer_iterator {
   using pointer = I*;
   using reference = I&;
 
-  explicit constexpr integer_iterator(I value) : value(value) {}
+  explicit constexpr integer_iterator(I val) : value(val) {}
 
   constexpr I operator*() const {
     return value;


### PR DESCRIPTION
Summary:
D76832520 switched Executorch to use the caffe c10 headers. This copy contains a shadow, which is treated as an error for certain embedded compile flows.

Simple rename to avoid.

Test Plan:
CI

Rollback Plan:

Differential Revision: D77446104


