### PR TITLE
[cc][mkcpp] attempt 1

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -69,8 +69,9 @@ class DeferredTritonCallWrapper:
         """
         prefix = wrapper.prefix
         if self.kernel_name.startswith("multi_kernel_"):
-            # MultiKernel will select one kernel after running the autotune block
-            self.kernel_name = MultiKernelCall.lookup_choice(self.kernel_name)
+            # Generate multi-kernel dispatch system instead of single kernel
+            self._generate_multi_kernel_dispatch(wrapper, prefix)
+            return
         params = CudaKernelParamCache.get(self.kernel_name)
         assert params, f"CudaKernelParamCache not populated for {self.kernel_name}"
         def_args = params["def_args"]
@@ -147,6 +148,296 @@ class DeferredTritonCallWrapper:
             V.graph.wrapper_code.additional_files.append(
                 params[get_cpp_wrapper_cubin_path_name()]
             )
+
+    def _generate_multi_kernel_dispatch(self, wrapper: CppWrapperGpu, prefix: IndentedBuffer):
+        """
+        Generate dispatch system for multi-kernel selection based on symbolic variables.
+        Uses the first symbolic variable to find the closest hint kernel.
+        """
+        from .multi_kernel import MultiKernelCall
+        
+        # Get all kernel choices for this multi-kernel
+        multi_kernel_name = self.kernel_name
+        
+        # Look up the recorded choice to get information about available kernels
+        if hasattr(V.graph, 'multi_kernel_to_choice') and multi_kernel_name in V.graph.multi_kernel_to_choice:
+            chosen_kernel = V.graph.multi_kernel_to_choice[multi_kernel_name]
+        else:
+            # Fallback: try to get kernel information from MultiKernelCall state
+            chosen_kernel = MultiKernelCall.lookup_choice(multi_kernel_name)
+        
+        # Get all available kernel variants for this multi-kernel
+        # This requires looking up the MultiKernelCall state to get all kernel choices
+        kernel_choices = self._get_multi_kernel_choices(multi_kernel_name)
+        
+        if len(kernel_choices) <= 1:
+            # If only one kernel, fall back to regular generation
+            self.kernel_name = chosen_kernel
+            self._generate_single_kernel(wrapper, prefix)
+            return
+            
+        # Generate the dispatch system
+        self._generate_dispatch_header(wrapper, prefix, kernel_choices)
+        self._generate_kernel_entries(wrapper, prefix, kernel_choices)
+        self._generate_dispatch_logic(wrapper, prefix, kernel_choices)
+
+    def _get_multi_kernel_choices(self, multi_kernel_name: str) -> list[str]:
+        """
+        Get all kernel choices for a multi-kernel from the compilation state.
+        """
+        from .multi_kernel import MultiKernelCall
+        
+        # Try to find kernel choices from MultiKernelState
+        if hasattr(V.graph.wrapper_code, 'multi_kernel_state'):
+            state = V.graph.wrapper_code.multi_kernel_state
+            # Look for the kernel names tuple that maps to this multi_kernel_name
+            for kernel_names, mk_name in state.subkernel_to_kernel_name.items():
+                if mk_name == multi_kernel_name:
+                    return list(kernel_names)
+        
+        # Fallback: return just the chosen kernel
+        chosen_kernel = MultiKernelCall.lookup_choice(multi_kernel_name)
+        return [chosen_kernel]
+
+    def _generate_single_kernel(self, wrapper: CppWrapperGpu, prefix: IndentedBuffer):
+        """
+        Generate a single kernel (fallback for when multi-kernel has only one choice).
+        """
+        params = CudaKernelParamCache.get(self.kernel_name)
+        assert params, f"CudaKernelParamCache not populated for {self.kernel_name}"
+        def_args = params["def_args"]
+        arg_types = self.arg_types
+        inductor_meta = params["inductor_meta"]
+
+        if "extra_launcher_args" in inductor_meta and len(def_args) > len(arg_types):
+            assert len(def_args) == len(arg_types) - len(
+                inductor_meta["extra_launcher_args"]
+            )
+            arg_types = arg_types + [SymbolicCallArg] * len(
+                inductor_meta["extra_launcher_args"]
+            )
+
+        if not V.graph.aot_mode:
+            prefix.writeline(
+                maybe_hipify_code_wrapper(
+                    f"static {wrapper.device_codegen.cpp_kernel_type()} {self.kernel_name} = nullptr;"
+                )
+            )
+            kernel_var_name = self.kernel_name
+        else:
+            kernel_var_name = f"kernels_.{self.kernel_name}"
+
+        template_types = [
+            f"typename {name}_type_"
+            for name, arg_type in zip(def_args, arg_types)
+            if isinstance(arg_type, (torch_dtype, UnwrapUnspecArg))
+        ]
+        if V.graph.aot_mode:
+            template_types.append("typename kernels_type_")
+        if template_types:
+            prefix.writeline(f"template <{', '.join(template_types)}>")
+        prefix.writeline(f"static inline void {self.wrapper_name}(")
+        with prefix.indent():
+            assert len(def_args) == len(arg_types), (def_args, arg_types)
+            for name, arg_type in zip(def_args, arg_types):
+                if isinstance(arg_type, (torch_dtype, UnwrapUnspecArg)):
+                    prefix.writeline(f"const {name}_type_& {name},")
+                elif issubclass(arg_type, (SymbolicCallArg, sympy.Expr, int)):
+                    prefix.writeline(f"int64_t {name},")
+                elif arg_type is float:
+                    prefix.writeline(f"float {name},")
+                elif arg_type is bool:
+                    prefix.writeline(f"bool {name},")
+                else:
+                    raise ValueError(f"Unexpected arg type {arg_type}")
+            prefix.writeline(
+                maybe_hipify_code_wrapper(
+                    f"{wrapper.device_codegen.cpp_stream_type()} stream_,"
+                )
+            )
+            if V.graph.aot_mode:
+                prefix.writeline("kernels_type_& kernels_,")
+            prefix.writeline(
+                "const std::optional<std::string>& cubin_dir_ = std::nullopt"
+            )
+        prefix.writeline("){")
+        with prefix.indent():
+            if V.graph.aot_mode:
+                prefix.writeline("/*")
+                prefix.splice(self.kernel_name_to_body[self.kernel_name])
+                prefix.writeline("*/")
+            self.generate_grid(prefix, inductor_meta, params)
+            self.generate_load_kernel(prefix, kernel_var_name, params)
+            self.generate_launch_kernel(prefix, wrapper, kernel_var_name, params)
+        prefix.writeline("}")
+
+        if not config.aot_inductor.embed_kernel_binary:
+            V.graph.wrapper_code.additional_files.append(
+                params[get_cpp_wrapper_cubin_path_name()]
+            )
+
+    def _generate_dispatch_header(self, wrapper: CppWrapperGpu, prefix: IndentedBuffer, kernel_choices: list[str]):
+        """
+        Generate the header and data structures for multi-kernel dispatch.
+        """
+        # Add the dispatch system infrastructure
+        prefix.writeline("")
+        prefix.writeline("using KernelFn = std::function<void(int64_t key)>;")
+        prefix.writeline("")
+        prefix.writeline("struct KernelEntry {")
+        with prefix.indent():
+            prefix.writeline("int64_t shape_key;")
+            prefix.writeline("KernelFn kernel;")
+        prefix.writeline("};")
+        prefix.writeline("")
+        
+        # Generate dispatch function
+        prefix.writeline("static inline void dispatch_to_closest_kernel(")
+        with prefix.indent():
+            prefix.writeline("const std::vector<KernelEntry>& kernels,")
+            prefix.writeline("int64_t key")
+        prefix.writeline(") {")
+        with prefix.indent():
+            prefix.writeline("int64_t best_distance = std::numeric_limits<int64_t>::max();")
+            prefix.writeline("const KernelFn* best_kernel = nullptr;")
+            prefix.writeline("")
+            prefix.writeline("for (const auto& entry : kernels) {")
+            with prefix.indent():
+                prefix.writeline("int64_t distance = std::abs(key - entry.shape_key);")
+                prefix.writeline("if (distance < best_distance) {")
+                with prefix.indent():
+                    prefix.writeline("best_distance = distance;")
+                    prefix.writeline("best_kernel = &entry.kernel;")
+                prefix.writeline("}")
+            prefix.writeline("}")
+            prefix.writeline("")
+            prefix.writeline("if (best_kernel) {")
+            with prefix.indent():
+                prefix.writeline("(*best_kernel)(key);")
+            prefix.writeline("} else {")
+            with prefix.indent():
+                prefix.writeline('throw std::runtime_error("No kernel found for dispatch");')
+            prefix.writeline("}")
+        prefix.writeline("}")
+        prefix.writeline("")
+
+    def _generate_kernel_entries(self, wrapper: CppWrapperGpu, prefix: IndentedBuffer, kernel_choices: list[str]):
+        """
+        Generate individual kernel wrapper functions for each choice.
+        """
+        for i, kernel_name in enumerate(kernel_choices):
+            # Generate individual kernel function
+            individual_wrapper = DeferredTritonCallWrapper(
+                f"call_{kernel_name}",
+                kernel_name,
+                self.kernel_name_to_body,
+                self.arg_types
+            )
+            individual_wrapper._generate_single_kernel(wrapper, prefix)
+
+    def _generate_dispatch_logic(self, wrapper: CppWrapperGpu, prefix: IndentedBuffer, kernel_choices: list[str]):
+        """
+        Generate the main dispatch wrapper that selects kernels based on shape hints.
+        """
+        # Get the first kernel's parameters to understand arguments
+        first_kernel = kernel_choices[0]
+        params = CudaKernelParamCache.get(first_kernel)
+        assert params, f"CudaKernelParamCache not populated for {first_kernel}"
+        def_args = params["def_args"]
+        arg_types = self.arg_types
+        inductor_meta = params["inductor_meta"]
+
+        if "extra_launcher_args" in inductor_meta and len(def_args) > len(arg_types):
+            arg_types = arg_types + [SymbolicCallArg] * len(
+                inductor_meta["extra_launcher_args"]
+            )
+
+        # Find the first symbolic argument for dispatch key
+        dispatch_arg = None
+        for name, arg_type in zip(def_args, arg_types):
+            try:
+                if issubclass(arg_type, (SymbolicCallArg, sympy.Expr, int)):
+                    dispatch_arg = name
+                    break
+            except TypeError:
+                # arg_type might not be a class, check if it's one of the target types
+                if arg_type in (int, float, bool) or arg_type == sympy.Expr:
+                    dispatch_arg = name
+                    break
+
+        if not dispatch_arg:
+            # Fallback to first argument if no symbolic args found
+            dispatch_arg = def_args[0] if def_args else "arg0"
+
+        # Generate template types
+        template_types = [
+            f"typename {name}_type_"
+            for name, arg_type in zip(def_args, arg_types)
+            if isinstance(arg_type, (torch_dtype, UnwrapUnspecArg))
+        ]
+        if V.graph.aot_mode:
+            template_types.append("typename kernels_type_")
+        
+        if template_types:
+            prefix.writeline(f"template <{', '.join(template_types)}>")
+        prefix.writeline(f"static inline void {self.wrapper_name}(")
+        with prefix.indent():
+            for name, arg_type in zip(def_args, arg_types):
+                if isinstance(arg_type, (torch_dtype, UnwrapUnspecArg)):
+                    prefix.writeline(f"const {name}_type_& {name},")
+                elif issubclass(arg_type, (SymbolicCallArg, sympy.Expr, int)):
+                    prefix.writeline(f"int64_t {name},")
+                elif arg_type is float:
+                    prefix.writeline(f"float {name},")
+                elif arg_type is bool:
+                    prefix.writeline(f"bool {name},")
+                else:
+                    raise ValueError(f"Unexpected arg type {arg_type}")
+            prefix.writeline(
+                maybe_hipify_code_wrapper(
+                    f"{wrapper.device_codegen.cpp_stream_type()} stream_,"
+                )
+            )
+            if V.graph.aot_mode:
+                prefix.writeline("kernels_type_& kernels_,")
+            prefix.writeline(
+                "const std::optional<std::string>& cubin_dir_ = std::nullopt"
+            )
+        prefix.writeline("){")
+        with prefix.indent():
+            # Generate kernel table with shape hints
+            prefix.writeline("std::vector<KernelEntry> kernel_table = {")
+            with prefix.indent():
+                # Use config.multi_kernel_hints or default values
+                hints = getattr(config, 'multi_kernel_hints', [64, 4096])
+                if not hints:
+                    hints = [64, 4096]  # Default fallback
+                
+                for i, (kernel_name, hint) in enumerate(zip(kernel_choices, hints)):
+                    prefix.writeline("{")
+                    with prefix.indent():
+                        prefix.writeline(f"{hint},")
+                        prefix.writeline(f"[&](int64_t s) {{")
+                        with prefix.indent():
+                            # Generate call to individual kernel
+                            call_args = []
+                            for name, arg_type in zip(def_args, arg_types):
+                                call_args.append(name)
+                            call_args.append("stream_")
+                            if V.graph.aot_mode:
+                                call_args.append("kernels_")
+                            call_args.append("cubin_dir_")
+                            
+                            prefix.writeline(f"call_{kernel_name}({', '.join(call_args)});")
+                        prefix.writeline("}")
+                    if i < len(kernel_choices) - 1:
+                        prefix.writeline("},")
+                    else:
+                        prefix.writeline("}")
+            prefix.writeline("};")
+            prefix.writeline("")
+            prefix.writeline(f"dispatch_to_closest_kernel(kernel_table, {dispatch_arg});")
+        prefix.writeline("}")
 
     def generate_grid(
         self,

--- a/torch/_inductor/codegen/multi_kernel.py
+++ b/torch/_inductor/codegen/multi_kernel.py
@@ -181,12 +181,11 @@ class MultiKernel:
             V.graph.wrapper_code.generate_workspace_allocation(ws)
 
         if V.graph.cpp_wrapper:
-            # We have already selected the best kernel at compile time
-            # so we only have one set of call args. NB: this currently
-            # doesn't work with MultiTemplateBuffer kernels. bobrenjc93
-            # will add it in a subsequent PR.
+            # For C++ wrapper, generate multi-kernel dispatch system
+            # instead of selecting a single kernel at compile time.
+            # This supports both regular kernels and MultiTemplateBuffer kernels.
             V.graph.wrapper_code.generate_kernel_call(
-                kernel_name, call_args, arg_types=arg_types
+                kernel_name, multi_call_args, arg_types=multi_call_arg_types
             )
         else:
             V.graph.wrapper_code.generate_kernel_call(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #157135
* #156628


```
If you look at the last commit we added support for multi kernel for python codegen but not c++ codegen. for c++ codegen it's a little trickier since we can't do the kernel picking lazily. Instead let's implement a dispatch system that looks like the below where we take the first symbolic variable and use that to find the closest hint kernel:

#include <torch/csrc/inductor/cpp_wrapper/cuda.h>

#define CUDA_DRIVER_CHECK(EXPR)                    \
do {                                               \
    CUresult code = EXPR;                          \
    const char *msg;                               \
    CUresult code_get_error = cuGetErrorString(code, &msg); \
    if (code_get_error != CUDA_SUCCESS) {          \
        throw std::runtime_error(                  \
            std::string("CUDA driver error: ") +   \
            std::string("invalid error code!"));   \
    }                                              \
    if (code != CUDA_SUCCESS) {                    \
        throw std::runtime_error(                  \
            std::string("CUDA driver error: ") +   \
            std::string(msg));                     \
    }                                              \
} while (0);

using KernelFn = std::function<void(int64_t key)>;

struct KernelEntry {
    int64_t shape_key;
    KernelFn kernel;
};

static inline void dispatch_to_closest_kernel(
    const std::vector<KernelEntry>& kernels,
    int64_t key
) {
    int64_t best_distance = std::numeric_limits<int64_t>::max();
    const KernelFn* best_kernel = nullptr;

    for (const auto& entry : kernels) {
        int64_t distance = std::abs(key - entry.shape_key);
        if (distance < best_distance) {
            best_distance = distance;
            best_kernel = &entry.kernel;
        }
    }

    if (best_kernel) {
        (*best_kernel)(key);
    } else {
        throw std::runtime_error("No kernel found for dispatch");
    }
}

static inline CUfunction loadKernel(
        std::string filePath,
        const std::string &funcName,
        uint32_t sharedMemBytes,
        const std::optional<std::string> &cubinDir = std::nullopt) {
    if (cubinDir) {
        std::filesystem::path p1{*cubinDir};
        std::filesystem::path p2{filePath};
        filePath = (p1 / p2.filename()).string();
    }

    CUmodule mod;
    CUfunction func;
    CUDA_DRIVER_CHECK(cuModuleLoad(&mod, filePath.c_str()));
    CUDA_DRIVER_CHECK(cuModuleGetFunction(&func, mod, funcName.c_str()));
    if (sharedMemBytes > 0) {
        CUDA_DRIVER_CHECK(cuFuncSetAttribute(
            func,
            CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
            sharedMemBytes
        ))
    }
    return func;
}

static inline CUfunction loadKernel(const void* start, const std::string &funcName, uint32_t sharedMemBytes) {
    CUmodule mod;
    CUfunction func;
    CUDA_DRIVER_CHECK(cuModuleLoadData(&mod, start));
    CUDA_DRIVER_CHECK(cuModuleGetFunction(&func, mod, funcName.c_str()));
    if (sharedMemBytes > 0) {
        CUDA_DRIVER_CHECK(cuFuncSetAttribute(
            func,
            CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
            sharedMemBytes
        ))
    }
    return func;
}

static inline void launchKernel(
        CUfunction func,
        uint32_t gridX,
        uint32_t gridY,
        uint32_t gridZ,
        uint32_t numWarps,
        uint32_t sharedMemBytes,
        void* args[],
        cudaStream_t stream) {
    CUDA_DRIVER_CHECK(cuLaunchKernel(
        func, gridX, gridY, gridZ, 32*numWarps, 1, 1, sharedMemBytes, stream, args, nullptr
    ));
}
CACHE_TORCH_DTYPE(float32);
CACHE_TORCH_DEVICE(cuda);

static CUfunction triton_tem_fused_mm_relu_0 = nullptr;
template <typename arg_A_type_, typename arg_B_type_, typename out_ptr1_type_>
static inline void call_triton_tem_fused_mm_relu_0(
    const arg_A_type_& arg_A,
    const arg_B_type_& arg_B,
    const out_ptr1_type_& out_ptr1,
    int64_t ks0,
    int64_t _grid_0,
    int64_t _grid_1,
    int64_t _grid_2,
    cudaStream_t stream_,
    const std::optional<std::string>& cubin_dir_ = std::nullopt
){
    uint32_t grid_0 = _grid_0;
    uint32_t grid_1 = _grid_1;
    uint32_t grid_2 = _grid_2;
    if (grid_0 == 0 || grid_1 == 0 || grid_2 == 0) return;
    if (triton_tem_fused_mm_relu_0 == nullptr) {
        triton_tem_fused_mm_relu_0 = loadKernel("/tmp/torchinductor_bobren/tmpqm2ncplr/zx/czxuek3hxz2m4alqaozhhdcdubtcstvs7haqhllkq34tq3r5oaio.cubin", "triton_tem_fused_mm_relu_0", 98304, cubin_dir_);
    }
    CUdeviceptr var_0 = reinterpret_cast<CUdeviceptr>(arg_A.data_ptr());
    CUdeviceptr var_1 = reinterpret_cast<CUdeviceptr>(arg_B.data_ptr());
    CUdeviceptr var_2 = reinterpret_cast<CUdeviceptr>(out_ptr1.data_ptr());
    int32_t var_3 = ks0;
    CUdeviceptr global_scratch_4 = 0;
    void* kernel_args_[] = {&var_0, &var_1, &var_2, &var_3, &global_scratch_4};
    launchKernel(triton_tem_fused_mm_relu_0, grid_0, grid_1, grid_2, 2, 98304, kernel_args_, stream_);
}

static CUfunction triton_tem_fused_mm_relu_1 = nullptr;
template <typename arg_A_type_, typename arg_B_type_, typename out_ptr1_type_>
static inline void call_triton_tem_fused_mm_relu_1(
    const arg_A_type_& arg_A,
    const arg_B_type_& arg_B,
    const out_ptr1_type_& out_ptr1,
    int64_t ks0,
    int64_t _grid_0,
    int64_t _grid_1,
    int64_t _grid_2,
    cudaStream_t stream_,
    const std::optional<std::string>& cubin_dir_ = std::nullopt
){
    uint32_t grid_0 = _grid_0;
    uint32_t grid_1 = _grid_1;
    uint32_t grid_2 = _grid_2;
    if (grid_0 == 0 || grid_1 == 0 || grid_2 == 0) return;
    if (triton_tem_fused_mm_relu_1 == nullptr) {
        triton_tem_fused_mm_relu_1 = loadKernel("/tmp/torchinductor_bobren/tmpqm2ncplr/zx/czxuek3hxz2m4alqaozhhdcdubtcstvs7haqhllkq34tq3r5oaio.cubin", "triton_tem_fused_mm_relu_1", 98304, cubin_dir_);
    }
    CUdeviceptr var_0 = reinterpret_cast<CUdeviceptr>(arg_A.data_ptr());
    CUdeviceptr var_1 = reinterpret_cast<CUdeviceptr>(arg_B.data_ptr());
    CUdeviceptr var_2 = reinterpret_cast<CUdeviceptr>(out_ptr1.data_ptr());
    int32_t var_3 = ks0;
    CUdeviceptr global_scratch_4 = 0;
    void* kernel_args_[] = {&var_0, &var_1, &var_2, &var_3, &global_scratch_4};
    launchKernel(triton_tem_fused_mm_relu_1, grid_0, grid_1, grid_2, 2, 98304, kernel_args_, stream_);
}

void inductor_entry_impl(
    AtenTensorHandle*
        input_handles, // array of input AtenTensorHandle; handles
                        // are stolen; the array itself is borrowed
    AtenTensorHandle*
        output_handles  // array for writing output AtenTensorHandle; handles
                        // will be stolen by the caller; the array itself is
                        // borrowed)
) {
    py::gil_scoped_release release;

    auto inputs = steal_from_raw_handles_to_raii_handles(input_handles, 3);
    int64_t arg0_1;
    AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_item_int64(inputs[0], &arg0_1));
    auto arg1_1 = std::move(inputs[1]);
    auto arg2_1 = std::move(inputs[2]);
    int64_t s77 = arg0_1;
    int64_t _xnumel = 4096L*s77;

    AOTICudaGuard device_guard(3);
    const int64_t int_array_0[] = {s77, 4096L};
    static constexpr int64_t int_array_1[] = {4096L, 1L};
    AtenTensorHandle buf1_handle;
    AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_empty_strided(2, int_array_0, int_array_1, cached_torch_dtype_float32, cached_torch_device_type_cuda,  3, &buf1_handle));
    RAIIAtenTensorHandle buf1(buf1_handle);
    // Topologically Sorted Source Nodes: [matmul, relu], Original ATen: [aten.mm, aten.relu]
    cudaStream_t stream3;
    AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_get_current_cuda_stream(3, (void**)&stream3));

    std::vector<KernelEntry> kernel_table = {
        {
            64,
            [&](int64_t s) {
                call_triton_tem_fused_mm_relu_0(arg1_1, arg2_1, buf1, s77, 128L*(c10::div_floor_integer(static_cast<int64_t>(15L + s77), static_cast<int64_t>(16L))), 1, 1, stream3);
            }
        },
        {
            4096,
            [&](int64_t s) {
                call_triton_tem_fused_mm_relu_1(arg1_1, arg2_1, buf1, s77, 128L*(c10::div_floor_integer(static_cast<int64_t>(15L + s77), static_cast<int64_t>(16L))), 1, 1, stream3);
            }
        }
    };

    dispatch_to_closest_kernel(kernel_table, s77);

    arg1_1.reset();
    arg2_1.reset();
    output_handles[0] = buf1.release();
} // inductor_entry_impl
```

Please add support for c++ codegen aka torch._inductor.config.cpp_wrapper and cpp_wrapper. Use subagents and take as long as you need. 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov