### PR TITLE
[dynamo] Fix dynamic shapes handling in after_aot repro generation

### DIFF
--- a/test/dynamo/test_fx_graph_runnable.py
+++ b/test/dynamo/test_fx_graph_runnable.py
@@ -27,6 +27,22 @@ class StructuredTracePayloadFormatter(logging.Formatter):
 trace_log = logging.getLogger("torch.__trace")
 
 
+class ToyModel(torch.nn.Module):
+    def __init__(self, input_size=10, hidden_size=20, output_size=5):
+        super().__init__()
+        self.linear1 = torch.nn.Linear(input_size, hidden_size)
+        self.linear2 = torch.nn.Linear(hidden_size, output_size)
+        self.relu = torch.nn.ReLU()
+        self.dropout = torch.nn.Dropout(0.1)
+
+    def forward(self, x):
+        x = self.linear1(x)
+        x = self.relu(x)
+        x = self.dropout(x)
+        x = self.linear2(x)
+        return x
+
+
 class FxGraphRunnableTest(TestCase):
     def setUp(self):
         super().setUp()
@@ -88,6 +104,65 @@ class FxGraphRunnableTest(TestCase):
             return x * 2
 
         torch.compile(f)(torch.randn(5))
+        self._exec_and_verify_payload()
+
+    # testing dynamic shapes
+    def test_dynamic_shapes_run(self):
+        torch._dynamo.reset()
+        torch._dynamo.config.dynamic_shapes = True
+
+        def f(x):
+            return (x @ x.transpose(0, 1)).relu()
+
+        a = torch.randn(10, 12)
+        torch._dynamo.mark_dynamic(a, 0)
+        torch._dynamo.mark_dynamic(a, 1)
+
+        torch.compile(f)(a)
+        self._exec_and_verify_payload()
+
+    def test_broadcast_add_dynamic(self):
+        torch._dynamo.reset()
+        torch._dynamo.config.dynamic_shapes = True
+
+        def f(x, y):
+            return x + y * 2
+
+        x = torch.randn(5, 1)
+        y = torch.randn(1, 8)
+        torch._dynamo.mark_dynamic(x, 0)
+        torch._dynamo.mark_dynamic(y, 1)
+
+        torch.compile(f)(x, y)
+        self._exec_and_verify_payload()
+
+    def test_toy_model_basic(self):
+        model = ToyModel(input_size=8, hidden_size=16, output_size=4)
+        model.eval()  # Set to eval mode to avoid dropout randomness
+
+        x = torch.randn(3, 8)
+        torch.compile(model)(x)
+        self._exec_and_verify_payload()
+
+    def test_toy_model_batch_processing(self):
+        model = ToyModel(input_size=12, hidden_size=24, output_size=6)
+        model.eval()
+
+        x = torch.randn(16, 12)
+        torch.compile(model)(x)
+        self._exec_and_verify_payload()
+
+    def test_toy_model_dynamic_batch(self):
+        torch._dynamo.reset()
+        torch._dynamo.config.dynamic_shapes = True
+
+        model = ToyModel(input_size=10, hidden_size=20, output_size=5)
+        model.eval()
+
+        x = torch.randn(7, 10)
+        torch._dynamo.mark_dynamic(x, 0)
+
+        torch.compile(model)(x)
         self._exec_and_verify_payload()
 
 

--- a/test/dynamo/test_fx_graph_runnable.py
+++ b/test/dynamo/test_fx_graph_runnable.py
@@ -111,6 +111,7 @@ class FxGraphRunnableTest(TestCase):
         self._exec_and_verify_payload()
 
     # testing dynamic shapes
+    @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Skip in fbcode/sandcastle")
     def test_dynamic_shapes_run(self):
         torch._dynamo.reset()
         torch._dynamo.config.dynamic_shapes = True
@@ -125,6 +126,7 @@ class FxGraphRunnableTest(TestCase):
         torch.compile(f)(a)
         self._exec_and_verify_payload()
 
+    @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Skip in fbcode/sandcastle")
     def test_broadcast_add_dynamic(self):
         torch._dynamo.reset()
         torch._dynamo.config.dynamic_shapes = True
@@ -140,6 +142,7 @@ class FxGraphRunnableTest(TestCase):
         torch.compile(f)(x, y)
         self._exec_and_verify_payload()
 
+    @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Skip in fbcode/sandcastle")
     def test_toy_model_basic(self):
         model = ToyModel(input_size=8, hidden_size=16, output_size=4)
         model.eval()  # Set to eval mode to avoid dropout randomness
@@ -148,6 +151,7 @@ class FxGraphRunnableTest(TestCase):
         torch.compile(model)(x)
         self._exec_and_verify_payload()
 
+    @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Skip in fbcode/sandcastle")
     def test_toy_model_batch_processing(self):
         model = ToyModel(input_size=12, hidden_size=24, output_size=6)
         model.eval()
@@ -156,6 +160,7 @@ class FxGraphRunnableTest(TestCase):
         torch.compile(model)(x)
         self._exec_and_verify_payload()
 
+    @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Skip in fbcode/sandcastle")
     def test_toy_model_dynamic_batch(self):
         torch._dynamo.reset()
         torch._dynamo.config.dynamic_shapes = True

--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -301,7 +301,7 @@ isolate_fails_code_str = None
 {extra_imports}
 
 {maybe_fbcode_instructions()}
-        """
+     """
     )
     if not stable_output:
         model_str += f"# torch version: {torch.version.__version__}\n"
@@ -313,25 +313,47 @@ isolate_fails_code_str = None
 
     model_str += NNModuleToString.convert(gm)
 
-    # get hint shape/stride when dynamic shape enabled
-    def hint_if_symint(x):
-        return tuple(i.node.hint if isinstance(i, torch.SymInt) else i for i in x)
-
     writer = InputWriter(save_dir, stable_hash=stable_hash)
     for placeholder, arg in zip(fx_placeholder_targets(gm), args):
         if isinstance(arg, (int, torch.SymInt)):
             writer.symint(placeholder, arg)
         elif isinstance(arg, torch.Tensor):
-            # TODO: improve these names with FQN
             writer.tensor(placeholder, arg)
         elif arg is None:
             writer.const(placeholder)
         else:
-            # It's better to produce a slightly wrong repro string than none
-            # at all
             writer.unsupported(placeholder, arg)
 
-    model_str += "\n".join(writer.lines()) + "\n"
+    # Extract symbolic variables directly from graph module structure
+    used_syms = {}
+
+    # Extract from graph placeholders and their corresponding arguments
+    placeholder_targets = fx_placeholder_targets(gm)
+    for placeholder, arg in zip(placeholder_targets, args):
+        if isinstance(arg, torch.SymInt):
+            sym_name = str(arg.node)
+            if arg.node.hint is not None:
+                used_syms[sym_name] = arg.node.hint
+        elif isinstance(arg, torch.Tensor):
+            # Extract symbolic variables from tensor shapes and strides
+            for dim in arg.shape:
+                if isinstance(dim, torch.SymInt) and dim.node.hint is not None:
+                    used_syms[str(dim.node)] = dim.node.hint
+            for stride in arg.stride():
+                if isinstance(stride, torch.SymInt) and stride.node.hint is not None:
+                    used_syms[str(stride.node)] = stride.node.hint
+
+    # Add symbolic variable definitions to the top of the generated code
+    if used_syms:
+        hint_lines = "\n".join(
+            f"{name} = {hint}" for name, hint in sorted(used_syms.items())
+        )
+        model_str = hint_lines + "\n\n" + model_str
+
+    # Generate the load_args function
+    load_args_lines = writer.lines()
+    load_args_code = "\n".join(load_args_lines)
+    model_str += load_args_code + "\n"
 
     model_str += "mod = Repro()\n"
     return model_str


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #157594
* #157162
* __->__ #157136

Summary:
- Extract symbolic variables directly from graph placeholders and arguments
- Add symbolic variable definitions to generated repro code
- Add unit tests with ToyModel for testing

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames