### PR TITLE
[DDP][FSDP2] Add unit test for DDP mixed precision with FSDP2 ignored params

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_ignore_params.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_ignore_params.py
@@ -320,7 +320,7 @@ class TestFullyShardIgnoreParams(FSDPTest):
             "reduce_dtype": torch.float16,
             "buffer_dtype": torch.float16,
         }
-    
+
     @skip_if_lt_x_gpu(2)
     def test_ddp_mixed_precision_with_fsdp_ignore_params(self):
         """Test DDP mixed precision combined with FSDP2 ignore_params"""
@@ -335,7 +335,7 @@ class TestFullyShardIgnoreParams(FSDPTest):
         ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-2)
 
         test_model, test_inp = _generate_model_and_input()
-        
+
         test_name_to_param_map, _ = _find_name_param_mappings(test_model, "")
 
         ignored_path = "module_b.module_c"
@@ -403,7 +403,7 @@ class TestFullyShardIgnoreParams(FSDPTest):
             ref_loss = ref_model(ref_inp)
             test_loss = test_model(test_inp)
 
-            # Assert loss equality
+            # Assert loss equality check
             self.assertTrue(
                 torch.allclose(ref_loss, test_loss, rtol=1e-3, atol=1e-5),
                 f"ref_loss={ref_loss.item()} and test_loss={test_loss.item()} should match at iteration {iteration}",

--- a/test/distributed/_composable/fsdp/test_fully_shard_ignore_params.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_ignore_params.py
@@ -1,11 +1,11 @@
 # Owner(s): ["oncall: distributed"]
 
+import itertools
 import sys
 
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-import itertools
 from torch.distributed._composable.fsdp import fully_shard
 from torch.distributed._composable.fsdp.fully_shard import FSDPModule as FSDP2
 from torch.distributed.device_mesh import init_device_mesh
@@ -313,6 +313,7 @@ class TestFullyShardIgnoreParams(FSDPTest):
                 self.compare_ref_test_params(
                     ref_name_to_param_map, test_name_to_param_map
                 )
+
     @skip_if_lt_x_gpu(2)
     def test_ddp_mixed_precision_with_fsdp_ignore_params(self):
         """Test DDP mixed precision combined with FSDP2 ignore_params"""
@@ -325,7 +326,6 @@ class TestFullyShardIgnoreParams(FSDPTest):
         ref_model = DDP(ref_model, mixed_precision=mp_config, process_group=default_pg)
         ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-2)
         ref_name_to_param_map, _ = _find_name_param_mappings(ref_model, "")
-
 
         test_model, test_inp = _generate_model_and_input()
         test_name_to_param_map, _ = _find_name_param_mappings(test_model, "")
@@ -342,7 +342,6 @@ class TestFullyShardIgnoreParams(FSDPTest):
             ignored_params=fsdp_ignored_params,
         )
 
-
         fsdped_modules = _find_all_fsdped_modules(test_model, "")
         self.assertEqual(fsdped_modules, {"module_b", "module_b.lin_b"})
 
@@ -356,20 +355,30 @@ class TestFullyShardIgnoreParams(FSDPTest):
             params_and_buffers_to_ignore=modified_ddp_ignored_param_names,
         )
 
-
         test_model = DDP(test_model, mixed_precision=mp_config, broadcast_buffers=False)
         test_optim = torch.optim.Adam(test_model.parameters(), lr=1e-2)
 
-
-        for n, p in itertools.chain(test_model.named_parameters(), test_model.named_buffers()):
-            if any(ignored_name in n for ignored_name in modified_ddp_ignored_param_names):
+        for n, p in itertools.chain(
+            test_model.named_parameters(), test_model.named_buffers()
+        ):
+            if any(
+                ignored_name in n for ignored_name in modified_ddp_ignored_param_names
+            ):
                 # These params are ignored by DDP, so no mixed precision
-                self.assertFalse(hasattr(p, "_mp_param"), f"Parameter {n} should not have _mp_param")
-                self.assertFalse(hasattr(p, "_fp_param"), f"Parameter {n} should not have _fp_param")
+                self.assertFalse(
+                    hasattr(p, "_mp_param"), f"Parameter {n} should not have _mp_param"
+                )
+                self.assertFalse(
+                    hasattr(p, "_fp_param"), f"Parameter {n} should not have _fp_param"
+                )
             else:
                 # These params should have mixed precision from DDP
-                self.assertTrue(hasattr(p, "_mp_param"), f"Parameter {n} should have _mp_param")
-                self.assertTrue(hasattr(p, "_fp_param"), f"Parameter {n} should have _fp_param")
+                self.assertTrue(
+                    hasattr(p, "_mp_param"), f"Parameter {n} should have _mp_param"
+                )
+                self.assertTrue(
+                    hasattr(p, "_fp_param"), f"Parameter {n} should have _fp_param"
+                )
                 self.assertEqual(mp_config.param_dtype, p._mp_param.dtype)
                 self.assertEqual(torch.float32, p._fp_param.dtype)
 
@@ -384,14 +393,18 @@ class TestFullyShardIgnoreParams(FSDPTest):
 
             for n, param in test_model.named_parameters():
                 if param.grad is not None:
-                    self.assertEqual(param.grad.dtype, torch.float32,
-                                f"Gradient for {n} should be fp32 at iteration {iteration}")
+                    self.assertEqual(
+                        param.grad.dtype,
+                        torch.float32,
+                        f"Gradient for {n} should be fp32 at iteration {iteration}",
+                    )
 
             with implicit_replication():
                 ref_optim.step()
                 ref_optim.zero_grad()
                 test_optim.step()
                 test_optim.zero_grad()
+
 
 instantiate_parametrized_tests(TestFullyShardIgnoreParams)
 

--- a/test/distributed/_composable/fsdp/test_fully_shard_ignore_params.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_ignore_params.py
@@ -9,7 +9,7 @@ import torch.nn as nn
 from torch.distributed._composable.fsdp import fully_shard
 from torch.distributed._composable.fsdp.fully_shard import FSDPModule as FSDP2
 from torch.distributed.device_mesh import init_device_mesh
-from torch.distributed.fsdp import MixedPrecisionConfig
+from torch.distributed.fsdp import MixedPrecision
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.experimental import implicit_replication
 from torch.nn.parallel import DistributedDataParallel as DDP
@@ -316,7 +316,7 @@ class TestFullyShardIgnoreParams(FSDPTest):
                 )
 
     def _get_fp16_config(self):
-        return MixedPrecisionConfig(
+        return MixedPrecision(
             param_dtype=torch.float16,
             reduce_dtype=torch.float16,
             buffer_dtype=torch.float16,

--- a/test/distributed/_composable/fsdp/test_fully_shard_ignore_params.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_ignore_params.py
@@ -9,6 +9,7 @@ import torch.nn as nn
 from torch.distributed._composable.fsdp import fully_shard
 from torch.distributed._composable.fsdp.fully_shard import FSDPModule as FSDP2
 from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.fsdp import MixedPrecisionConfig
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.experimental import implicit_replication
 from torch.nn.parallel import DistributedDataParallel as DDP
@@ -315,11 +316,11 @@ class TestFullyShardIgnoreParams(FSDPTest):
                 )
 
     def _get_fp16_config(self):
-        return {
-            "param_dtype": torch.float16,
-            "reduce_dtype": torch.float16,
-            "buffer_dtype": torch.float16,
-        }
+        return MixedPrecisionConfig(
+            param_dtype=torch.float16,
+            reduce_dtype=torch.float16,
+            buffer_dtype=torch.float16,
+        )
 
     @skip_if_lt_x_gpu(2)
     def test_ddp_mixed_precision_with_fsdp_ignore_params(self):


### PR DESCRIPTION
This PR adds a unit test to showcase DDP mixed precision working with FSDP2 ignored parameters, addressing issue #156130.

## Summary
- Enhanced `test_fully_shard_ignore_params.py` to include a test case that demonstrates DDP mixed precision functionality with FSDP2's `ignore_params` feature
- The test validates that DDP's native mixed precision (introduced in #92882) works correctly when combined with FSDP2's parameter ignoring capability

## Motivation
DDP has mixed precision support and FSDP2 has `ignore_params` functionality via `fully_shard(ignore_params=)`. However, there was no test coverage ensuring these two features work together correctly. This test fills that gap and provides a reference implementation.

## Test Details
The new test case demonstrates:
- Setting up DDP with mixed precision enabled
- Configuring FSDP2 with ignored parameters
- Verifying the interaction between both features works as expected

Fixes #156130


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci