### PR TITLE
[SDPA] Fix `alloc_with_matching_layout` stride sorting

### DIFF
--- a/aten/src/ATen/native/transformers/sdp_utils.h
+++ b/aten/src/ATen/native/transformers/sdp_utils.h
@@ -23,7 +23,7 @@ void alloc_with_matching_layout(
   const auto q_strides = q.strides();
   std::stable_sort(
       fill_order.begin(), fill_order.end(), [&q_strides](int idx1, int idx2) {
-        return q_strides[idx1] < q_strides[idx2];
+        return q_strides[idx1] ? q_strides[idx1] : 1 <  q_strides[idx2] ? q_strides[idx2] : 1;
       });
   std::vector<int64_t> ordered_strides(shape.size());
   int64_t current_stride = 1;


### PR DESCRIPTION
Otherwise dims with "zero" stride get moved before contiguous dims (stride 1).

Need to move the fix from #149282 to here as #154340 moved the original definition from `MHA.cpp`.

cc @ptrblck @msaroufim @jerryzh168