### PR TITLE
[dynamo] remove dead object from keepalive

### DIFF
--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -582,9 +582,9 @@ class SideEffects:
         # the .closures field, from which we will see if we need to keep
         # any mutations to cell variables alive.
 
-        self.id_to_variable = {
-            k: v for k, v in self.id_to_variable.items() if is_live(v)
-        }
+        live_obj_ids = {k for k, v in self.id_to_variable.items() if is_live(v)}
+        self.id_to_variable = {k: self.id_to_variable[k] for k in live_obj_ids}
+        self.keepalive = [obj for obj in self.keepalive if id(obj) in live_obj_ids]
         self.store_attr_mutations = {
             k: v for k, v in self.store_attr_mutations.items() if is_live(k)
         }

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -582,9 +582,12 @@ class SideEffects:
         # the .closures field, from which we will see if we need to keep
         # any mutations to cell variables alive.
 
-        live_obj_ids = {k for k, v in self.id_to_variable.items() if is_live(v)}
-        self.id_to_variable = {k: self.id_to_variable[k] for k in live_obj_ids}
-        self.keepalive = [obj for obj in self.keepalive if id(obj) in live_obj_ids]
+        self.id_to_variable = {
+            k: v for k, v in self.id_to_variable.items() if is_live(v)
+        }
+        self.keepalive = [
+            obj for obj in self.keepalive if id(obj) in self.id_to_variable
+        ]
         self.store_attr_mutations = {
             k: v for k, v in self.store_attr_mutations.items() if is_live(k)
         }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #157161
* #156869
* #157511
* #157505
* __->__ #157159

Previously, when we prune dead objects in side effects, we didn't delete the keep_alive objects from the current side effect. These two should be kept in sync (they're in sync most of times except this before this PR). Ideally this should be managed by a single data structure to avoid them being out of sync. But worth a separate refactoring.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela