### PR TITLE
[dynamo] fix infinite loop in computing all stack meta

### DIFF
--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1314,7 +1314,7 @@ class OutputGraph(OutputGraphGuardsState):
             all_stack_locals_metas.append(meta)
             if cur_tx is self.root_tx:
                 break
-            cur_tx = tx.parent
+            cur_tx = cur_tx.parent
 
         # Use nn.Module "proxies" in the constructed GraphModule so that
         # the resulting GM does not hold additional strong references to the original modules.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #157161
* #156869
* __->__ #157160
* #157159

Fix a typo that could cause infinite loop.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames