### PR TITLE
Fix slice op redistribute_cost compute

### DIFF
--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -363,16 +363,22 @@ def gen_slice_strategy(op_schema: OpSchema) -> StrategyType:
         if not is_tensor_dim_sharded(arg_spec, dim=slice_dim) or redundant_slice:
             # only add the strategy if the slice dim is not sharded
             out_spec = DTensorSpec(mesh, arg_spec.placements)
-            slice_strategy.strategies.append(OpSpec(output_specs=out_spec))
+            slice_strategy.strategies.append(
+                OpSpec(output_specs=out_spec, redistribute_cost=[[0.0] * mesh.ndim])
+            )
     if not slice_strategy.strategies:
         # if all strategies are filtered out, unsharding all specs on slice dim
         # of the input strategy, and use that as the op strategy
         for arg_strategy in input_strategy.strategies:
             arg_spec = arg_strategy.output_spec
-            unshard_spec = DTensorSpec(
-                mesh, unshard_tensor_dim(arg_spec.placements, dim=slice_dim)
+            new_placement = unshard_tensor_dim(arg_spec.placements, dim=slice_dim)
+            unshard_spec = DTensorSpec(mesh, new_placement)
+            redistribute_cost = [
+                generate_redistribute_costs(input_strategy, unshard_spec)
+            ]
+            slice_strategy.strategies.append(
+                OpSpec(output_specs=unshard_spec, redistribute_cost=redistribute_cost)
             )
-            slice_strategy.strategies.append(OpSpec(output_specs=unshard_spec))
     return slice_strategy
 
 
@@ -397,8 +403,9 @@ def slice_backward_rules(op_schema: OpSchema) -> OpStrategy:
                 new_placements.append(placement)
         new_spec = DTensorSpec(output_spec.mesh, tuple(new_placements))
         redistribute_cost = [generate_redistribute_costs(input_strategy, new_spec)]
-        placement_strategy.redistribute_cost = redistribute_cost
-        new_strategy = OpSpec(output_specs=new_spec)
+        new_strategy = OpSpec(
+            output_specs=new_spec, redistribute_cost=redistribute_cost
+        )
         output_strategies.append(new_strategy)
     return OpStrategy(output_strategies)
 

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -364,7 +364,10 @@ def gen_slice_strategy(op_schema: OpSchema) -> StrategyType:
             # only add the strategy if the slice dim is not sharded
             out_spec = DTensorSpec(mesh, arg_spec.placements)
             slice_strategy.strategies.append(
-                OpSpec(output_specs=out_spec, redistribute_cost=[[0.0] * mesh.ndim])
+                OpSpec(
+                    output_specs=out_spec,
+                    redistribute_cost=[[0.0] * len(input_strategy.strategies)],
+                )
             )
     if not slice_strategy.strategies:
         # if all strategies are filtered out, unsharding all specs on slice dim

--- a/torch/distributed/tensor/_sharding_prop.py
+++ b/torch/distributed/tensor/_sharding_prop.py
@@ -488,7 +488,6 @@ class ShardingPropagator:
             )
 
     def _select_strategy(self, op_name, strategy: OpStrategy) -> OpSpec:
-        print(f"{op_name}, {strategy.strategies}")
         if len(strategy.strategies) == 1:
             # short cut with only one possible OpSpec
 

--- a/torch/distributed/tensor/_sharding_prop.py
+++ b/torch/distributed/tensor/_sharding_prop.py
@@ -277,6 +277,7 @@ class ShardingPropagator:
             return OutputSharding(None, op_schema)
 
         out_tensor_meta = self._propagate_tensor_meta_non_cached(op_schema)
+
         if op_schema.op in self.op_strategy_funcs:
             # wrap the op_schema with op strategy for sharding strategy propagation
             strategy_schema = self._wrap_with_op_strategy(op_schema)

--- a/torch/distributed/tensor/_sharding_prop.py
+++ b/torch/distributed/tensor/_sharding_prop.py
@@ -277,7 +277,6 @@ class ShardingPropagator:
             return OutputSharding(None, op_schema)
 
         out_tensor_meta = self._propagate_tensor_meta_non_cached(op_schema)
-        op_name = op_schema.op.name()
         if op_schema.op in self.op_strategy_funcs:
             # wrap the op_schema with op strategy for sharding strategy propagation
             strategy_schema = self._wrap_with_op_strategy(op_schema)
@@ -287,7 +286,7 @@ class ShardingPropagator:
 
             if isinstance(op_strategy, OpStrategy):
                 # single Op strategy
-                output_strategy = self._select_strategy(op_name, op_strategy)
+                output_strategy = self._select_strategy(op_strategy)
 
                 # check if we need to redistribute the input
                 needs_redistribute = False
@@ -370,7 +369,7 @@ class ShardingPropagator:
                 out_spec_list: list[DTensorSpec] = []
                 for strategy in op_strategy.childs:
                     assert isinstance(strategy, OpStrategy)
-                    selected_strategy = self._select_strategy(op_name, strategy)
+                    selected_strategy = self._select_strategy(strategy)
                     selected_strategies.append(selected_strategy)
                     out_spec_list.append(selected_strategy.output_spec)
 
@@ -487,22 +486,15 @@ class ShardingPropagator:
                 f"Operator {op_schema.op} does not have a sharding strategy registered."
             )
 
-    def _select_strategy(self, op_name, strategy: OpStrategy) -> OpSpec:
+    def _select_strategy(self, strategy: OpStrategy) -> OpSpec:
         if len(strategy.strategies) == 1:
             # short cut with only one possible OpSpec
-
-            # TODO(zpcore): Enable the following assertion once we specify
-            # redistribute_cost from all DTensor ops.
-
-            # assert strategy.strategies[0].redistribute_cost is not None, (
-            #     f"Op {op_name} must set redistribute cost each OpSpec!"
-            # )
             return strategy.strategies[0]
 
         op_spec_costs: list[float] = []
         for op_spec in strategy.strategies:
             assert op_spec.redistribute_cost is not None, (
-                f"Op {op_name} must set redistribute cost each OpSpec!"
+                "must set redistribute cost each OpSpec!"
             )
             redistribute_cost = sum(chain.from_iterable(op_spec.redistribute_cost))
             op_spec_costs.append(redistribute_cost)


### PR DESCRIPTION
For slice op backward, my understanding is that the `redistribute_cost` attribute is incorrectly assigned to previous placement strategy: https://github.com/pytorch/pytorch/blob/0decd966af9cdcb7ab4410cf475d2fc09f2dea0c/torch/distributed/tensor/_ops/_tensor_ops.py#L399-L400

The mistake is hard to be tested since we didn't enforce the `redistribute_cost` for `strategy.strategies` with size one: https://github.com/pytorch/pytorch/blob/2815ade9a80e1f557370e86500b21cbc465a8ffe/torch/distributed/tensor/_sharding_prop.py#L491-L499


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k