### PR TITLE
increment pending_callbacks_counter before initation the pt2 compile callbacks

### DIFF
--- a/torch/_dynamo/callback.py
+++ b/torch/_dynamo/callback.py
@@ -126,9 +126,9 @@ class CompilationCallbackHandler:
         args = CallbackArgs(trigger, compile_id)
         try:
             with self.__pending_callbacks_counter_lock:
-                if self.__pending_callbacks_counter == 0:
-                    self.run_start_callbacks(args)
                 self.__pending_callbacks_counter += 1
+                if self.__pending_callbacks_counter == 1:
+                    self.run_start_callbacks(args)
             yield
         finally:
             with self.__pending_callbacks_counter_lock:


### PR DESCRIPTION
Summary: Since we increment the counter after performing the callback, it leads to the assertion error when callback raises an error and increment never happens. Let's increment first to avoid it.

Test Plan:
tba

Rollback Plan:

Differential Revision: D77475650




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames