### PR TITLE
Tidy code in torch/csrc/jit

### DIFF
--- a/torch/csrc/jit/api/object.cpp
+++ b/torch/csrc/jit/api/object.cpp
@@ -26,7 +26,7 @@ std::optional<Method> Object::find_method(const std::string& basename) const {
 void Object::define(const std::string& src, const ResolverPtr& resolver) {
   const auto self = SimpleSelf(type());
   _ivalue()->compilation_unit()->define(
-      *type()->name(), src, resolver ? resolver : nativeResolver(), &self);
+      type()->name(), src, resolver ? resolver : nativeResolver(), &self);
 }
 
 Object Object::copy() const {

--- a/torch/csrc/jit/backends/backend_detail.cpp
+++ b/torch/csrc/jit/backends/backend_detail.cpp
@@ -296,7 +296,7 @@ Module codegen_backend_module(
         continue;
       }
 
-      auto default_value = arg.default_value();
+      const auto& default_value = arg.default_value();
 
       if (arg.kwarg_only()) {
         // If this is a kwarg, it needs to be emitted as keyword=value

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -1370,7 +1370,7 @@ struct to_ir {
           union_type_hint->containedTypes().begin(),
           union_type_hint->containedTypes().end(),
           std::back_inserter(candidate_types),
-          [&](TypePtr type_ptr) { return type_match(type_ptr); });
+          [&](const TypePtr& type_ptr) { return type_match(type_ptr); });
 
       if (!is_dict_constructor && candidate_types.empty()) {
         throw(
@@ -1516,7 +1516,7 @@ struct to_ir {
   }
 
   Value* emitListComprehension(const ListComp& lc, const TypePtr& type_hint) {
-    const auto loc = lc.range();
+    const auto& loc = lc.range();
     const auto targets_list = List<Expr>::create(lc.range(), {lc.target()});
     const auto itrs = List<Expr>::create(lc.range(), {lc.iter()});
 
@@ -1642,7 +1642,7 @@ struct to_ir {
   }
 
   Value* emitDictComprehension(const DictComp& dc, const TypePtr& type_hint) {
-    const auto loc = dc.range();
+    const auto& loc = dc.range();
     const auto targets_list = List<Expr>::create(dc.range(), {dc.target()});
     const auto itrs = List<Expr>::create(dc.range(), {dc.iter()});
 
@@ -5244,9 +5244,9 @@ struct to_ir {
       const std::vector<std::optional<NamedValue>>& tuple_args) {
     auto tuple_type = tuple_val.value(*graph)->type()->expect<TupleType>();
     auto tuple_len = tuple_type->elements().size();
-    auto beg_val = tuple_args[0];
-    auto end_val = tuple_args[1];
-    auto step = tuple_args[2];
+    const auto& beg_val = tuple_args[0];
+    const auto& end_val = tuple_args[1];
+    const auto& step = tuple_args[2];
 
     int64_t step_size = 1;
     if (step) {

--- a/torch/csrc/jit/frontend/lexer.h
+++ b/torch/csrc/jit/frontend/lexer.h
@@ -412,11 +412,7 @@ struct Token {
 
 struct Lexer {
   explicit Lexer(std::shared_ptr<Source> source)
-      : source(std::move(source)),
-
-        indent_stack(),
-        next_tokens(),
-        shared(sharedParserData()) {
+      : source(std::move(source)), shared(sharedParserData()) {
     auto first_indent = lexRaw(true);
     indent_stack.push_back(first_indent.range.size());
     lex();

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -817,7 +817,6 @@ void initJITBindings(PyObject* module) {
           })
       .def(
           "_jit_nvfuser_set_comparison_callback",
-          // NOLINTNEXTLINE(performance-unnecessary-value-param)
           [](bool, py::function) {
             TORCH_WARN(
                 "nvfuser is no longer supported in torch script, use _jit_nvfuser_set_comparison_callback is deprecated and a no-op");

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -178,6 +178,7 @@ void initJITBindings(PyObject* module) {
   static py::handle exc =
       py::exception<JITException>(m, "JITException").release();
 
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
   py::register_exception_translator([](std::exception_ptr p) {
     try {
       if (p) {
@@ -816,6 +817,7 @@ void initJITBindings(PyObject* module) {
           })
       .def(
           "_jit_nvfuser_set_comparison_callback",
+          // NOLINTNEXTLINE(performance-unnecessary-value-param)
           [](bool, py::function) {
             TORCH_WARN(
                 "nvfuser is no longer supported in torch script, use _jit_nvfuser_set_comparison_callback is deprecated and a no-op");
@@ -2141,10 +2143,9 @@ void initJITBindings(PyObject* module) {
       .def(
           "_set_unwrap_func",
           // Intentionally not releasing GIL as this just does an assign
-          [](PythonFutureWrapper& self, py::function unwrapFunc) {
+          [](PythonFutureWrapper& self, const py::function& unwrapFunc) {
             auto functionGuard =
-                std::make_shared<torch::jit::PythonFunctionGuard>(
-                    std::move(unwrapFunc));
+                std::make_shared<torch::jit::PythonFunctionGuard>(unwrapFunc);
 
             std::function<void(py::object)> pf =
                 [functionGuard(std::move(functionGuard))](
@@ -2340,9 +2341,9 @@ void initJITBindings(PyObject* module) {
       },
       py::call_guard<py::gil_scoped_release>());
 
-  m.def("_jit_assert_is_instance", [](py::object obj, const TypePtr& type) {
-    toIValue(std::move(obj), type);
-  });
+  m.def(
+      "_jit_assert_is_instance",
+      [](const py::object& obj, const TypePtr& type) { toIValue(obj, type); });
 
 #if defined(C10_SUPPORTS_FATAL_SIGNAL_HANDLERS)
   m.def("_set_print_stack_traces_on_fatal_signal", [](bool print) {

--- a/torch/csrc/jit/python/python_custom_class.cpp
+++ b/torch/csrc/jit/python/python_custom_class.cpp
@@ -44,7 +44,7 @@ void initPythonCustomClassBindings(PyObject* module) {
 
   py::class_<ScriptClassFunctionPtr>(
       m, "ScriptClassFunction", py::dynamic_attr())
-      .def("__call__", [](py::args args, const py::kwargs& kwargs) {
+      .def("__call__", [](const py::args& args, const py::kwargs& kwargs) {
         auto strongPtr = py::cast<ScriptClassFunctionPtr>(args[0]);
         Function& callee = *strongPtr.function_;
         py::object result = invokeScriptFunctionFromPython(

--- a/torch/csrc/jit/python/python_list.cpp
+++ b/torch/csrc/jit/python/python_list.cpp
@@ -60,7 +60,7 @@ void initScriptListBindings(PyObject* module) {
       .def("__iter__", [](ScriptListIterator& iter) { return iter; });
 
   py::class_<ScriptList, std::shared_ptr<ScriptList>>(m, "ScriptList")
-      .def(py::init([](py::list list) {
+      .def(py::init([](const py::list& list) {
         TypePtr type = nullptr;
 
         if (!list.empty()) {
@@ -100,7 +100,7 @@ void initScriptListBindings(PyObject* module) {
           })
       .def(
           "__contains__",
-          [](const std::shared_ptr<ScriptList>& self, py::object elem) {
+          [](const std::shared_ptr<ScriptList>& self, const py::object& elem) {
             try {
               return toPyObject(self->contains(
                   toIValue(std::move(elem), self->type()->getElementType())));
@@ -146,7 +146,7 @@ void initScriptListBindings(PyObject* module) {
           "__setitem__",
           [](const std::shared_ptr<ScriptList>& self,
              ScriptList::diff_type idx,
-             py::object value) {
+             const py::object& value) {
             try {
               self->setItem(
                   idx,
@@ -202,7 +202,7 @@ void initScriptListBindings(PyObject* module) {
                                   // long as the iterator
       .def(
           "count",
-          [](const std::shared_ptr<ScriptList>& self, py::object value) {
+          [](const std::shared_ptr<ScriptList>& self, const py::object& value) {
             try {
               return self->count(
                   toIValue(std::move(value), self->type()->getElementType()));
@@ -213,7 +213,7 @@ void initScriptListBindings(PyObject* module) {
           })
       .def(
           "remove",
-          [](const std::shared_ptr<ScriptList>& self, py::object value) {
+          [](const std::shared_ptr<ScriptList>& self, const py::object& value) {
             try {
               return self->remove(
                   toIValue(std::move(value), self->type()->getElementType()));
@@ -223,7 +223,7 @@ void initScriptListBindings(PyObject* module) {
           })
       .def(
           "append",
-          [](const std::shared_ptr<ScriptList>& self, py::object value) {
+          [](const std::shared_ptr<ScriptList>& self, const py::object& value) {
             try {
               return self->append(
                   toIValue(std::move(value), self->type()->getElementType()));
@@ -236,7 +236,7 @@ void initScriptListBindings(PyObject* module) {
           [](const std::shared_ptr<ScriptList>& self) { self->clear(); })
       .def(
           "extend",
-          [](const std::shared_ptr<ScriptList>& self, py::list list) {
+          [](const std::shared_ptr<ScriptList>& self, const py::list& list) {
             try {
               self->extend(toIValue(std::move(list), self->type()));
             } catch (const py::cast_error& e) {
@@ -274,7 +274,7 @@ void initScriptListBindings(PyObject* module) {
           "insert",
           [](const std::shared_ptr<ScriptList>& self,
              ScriptList::diff_type idx,
-             py::object obj) {
+             const py::object& obj) {
             try {
               self->insert(
                   toIValue(std::move(obj), self->type()->getElementType()),
@@ -287,7 +287,7 @@ void initScriptListBindings(PyObject* module) {
           [](const ScriptList& data) { // __getstate__
             return scriptListToPyList(data);
           },
-          [](py::list list) { // __setstate__
+          [](const py::list& list) { // __setstate__
             TypePtr type = nullptr;
 
             if (!list.empty()) {

--- a/torch/csrc/jit/python/python_list.cpp
+++ b/torch/csrc/jit/python/python_list.cpp
@@ -100,7 +100,7 @@ void initScriptListBindings(PyObject* module) {
           })
       .def(
           "__contains__",
-          [](const std::shared_ptr<ScriptList>& self, const py::object& elem) {
+          [](const std::shared_ptr<ScriptList>& self, py::object elem) {
             try {
               return toPyObject(self->contains(
                   toIValue(std::move(elem), self->type()->getElementType())));

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -180,8 +180,8 @@ std::shared_ptr<PythonResolver> pythonResolver(const ResolutionCallback& rcb) {
 }
 std::shared_ptr<PythonResolver> pythonResolver(
     const ResolutionCallback& rcb,
-    std::string classname,
-    ClassTypePtr classType) {
+    const std::string& classname,
+    const ClassTypePtr& classType) {
   return std::make_shared<PythonResolver>(
       rcb, std::move(classname), std::move(classType));
 }
@@ -581,7 +581,7 @@ struct slot_dict_impl {
     return result;
   }
 
-  void setattr(const std::string& name, py::object value) {
+  void setattr(const std::string& name, const py::object& value) {
     const TypePtr& type = module_->type()->getAttribute(name);
     Module(module_).setattr(name, toIValue(std::move(value), type));
   }
@@ -758,7 +758,9 @@ void initJitScriptBindings(PyObject* module) {
               py::keep_alive<0, 1>())
           .def(
               "setattr",
-              [](Object& self, const std::string& name, py::object value) {
+              [](Object& self,
+                 const std::string& name,
+                 const py::object& value) {
                 if (self.type()->hasConstant(name)) {
                   TORCH_CHECK(
                       false,
@@ -1413,7 +1415,8 @@ void initJitScriptBindings(PyObject* module) {
 
       .def(
           "find_function",
-          [](std::shared_ptr<CompilationUnit> self, const std::string& name) {
+          [](const std::shared_ptr<CompilationUnit>& self,
+             const std::string& name) {
             auto fn = self->find_function(QualifiedName(name));
             if (fn) {
               return std::optional<StrongFunctionPtr>(
@@ -1424,7 +1427,8 @@ void initJitScriptBindings(PyObject* module) {
           })
       .def(
           "__getattr__",
-          [](std::shared_ptr<CompilationUnit> self, const std::string& name) {
+          [](const std::shared_ptr<CompilationUnit>& self,
+             const std::string& name) {
             auto fn = self->find_function(QualifiedName(name));
             if (fn) {
               return StrongFunctionPtr(std::move(self), fn);
@@ -1457,7 +1461,7 @@ void initJitScriptBindings(PyObject* module) {
           "create_function",
           [](std::shared_ptr<CompilationUnit>& self,
              const std::string& qualified_name,
-             std::shared_ptr<Graph> graph,
+             const std::shared_ptr<Graph>& graph,
              bool should_mangle) {
             Function* fn = self->create_function(
                 qualified_name, std::move(graph), should_mangle);
@@ -1483,7 +1487,7 @@ void initJitScriptBindings(PyObject* module) {
   py::class_<StrongFunctionPtr>(m, "ScriptFunction", py::dynamic_attr())
       .def(
           "__call__",
-          [](py::args args, const py::kwargs& kwargs) {
+          [](const py::args& args, const py::kwargs& kwargs) {
             HANDLE_TH_ERRORS
             auto strongPtr = py::cast<StrongFunctionPtr>(args[0]);
             if (py::module::import("torch")
@@ -1607,7 +1611,7 @@ void initJitScriptBindings(PyObject* module) {
   py::class_<Method>(m, "ScriptMethod", py::dynamic_attr())
       .def(
           "__call__",
-          [](py::args args, const py::kwargs& kwargs) {
+          [](const py::args& args, const py::kwargs& kwargs) {
             HANDLE_TH_ERRORS
             if (py::module::import("torch")
                     .attr("compiler")
@@ -1923,7 +1927,7 @@ void initJitScriptBindings(PyObject* module) {
   m.def("_test_only_remove_entry_to_op_version_map", &test_only_remove_entry);
   m.def(
       "import_ir_module",
-      [](std::shared_ptr<CompilationUnit> cu,
+      [](const std::shared_ptr<CompilationUnit>& cu,
          const std::string& filename,
          py::object map_location,
          const py::dict& extra_files,
@@ -1947,7 +1951,7 @@ void initJitScriptBindings(PyObject* module) {
       });
   m.def(
       "_import_ir_module_from_package",
-      [](std::shared_ptr<CompilationUnit> cu,
+      [](const std::shared_ptr<CompilationUnit>& cu,
          std::shared_ptr<caffe2::serialize::PyTorchStreamReader> reader,
          std::shared_ptr<torch::jit::DeserializationStorageContext>
              storage_context,
@@ -1968,7 +1972,7 @@ void initJitScriptBindings(PyObject* module) {
       });
   m.def(
       "import_ir_module_from_buffer",
-      [](std::shared_ptr<CompilationUnit> cu,
+      [](const std::shared_ptr<CompilationUnit>& cu,
          const std::string& buffer,
          py::object map_location,
          const py::dict& extra_files,
@@ -2125,7 +2129,7 @@ void initJitScriptBindings(PyObject* module) {
       "Retrieve the optimized graph that was run the last time the graph executor ran on this thread");
   m.def(
       "_create_function_from_graph",
-      [](const std::string& qualname, std::shared_ptr<Graph> graph) {
+      [](const std::string& qualname, const std::shared_ptr<Graph>& graph) {
         // TODO this should go in the global Python CU
         auto cu = std::make_shared<CompilationUnit>();
         c10::QualifiedName name(qualname);
@@ -2133,7 +2137,7 @@ void initJitScriptBindings(PyObject* module) {
         return StrongFunctionPtr(std::move(cu), fn);
       });
   m.def("_ivalue_tags_match", ivalue_tags_match);
-  m.def("_ivalue_debug_python_object", [](py::object py_obj) {
+  m.def("_ivalue_debug_python_object", [](const py::object& py_obj) {
     // convert to IValue first, IValue will incref via py::object
     IValue pyobj_ivalue = toIValue(std::move(py_obj), PyObjectType::get());
     // convert back to PyObject by borrowing the reference, which also
@@ -2231,8 +2235,8 @@ void initJitScriptBindings(PyObject* module) {
       .def(
           "add_constant",
           [](ConcreteModuleTypeBuilder& self,
-             std::string name,
-             py::object value) {
+             const std::string& name,
+             const py::object& value) {
             self.addConstant(std::move(name), std::move(value));
           })
       .def("add_attribute", &ConcreteModuleTypeBuilder::addAttribute)

--- a/torch/csrc/jit/runtime/decomposition_registry.cpp
+++ b/torch/csrc/jit/runtime/decomposition_registry.cpp
@@ -53,7 +53,6 @@ void loadDecompositionFunctions() {
   }
 
   auto src = std::make_shared<Source>(GetSerializedDecompositions());
-  std::stringstream ss;
   std::vector<at::IValue> constantTable;
   auto resolver = std::make_shared<SourceImporterImpl>(
       compilation_unit,

--- a/torch/csrc/jit/runtime/graph_executor.cpp
+++ b/torch/csrc/jit/runtime/graph_executor.cpp
@@ -64,6 +64,7 @@ EnableProfilingGuard::EnableProfilingGuard() {
   auto& executor_mode = getExecutorMode();
   old_executor_mode = executor_mode;
   executor_mode = true;
+  // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
   old_get_optimize = getGraphExecutorOptimize();
   setGraphExecutorOptimize(true);
 }
@@ -522,7 +523,9 @@ struct DifferentiableGraphOp {
   Gradient grad;
   GraphExecutor grad_executor;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   const size_t num_inputs;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   const size_t num_outputs;
 };
 

--- a/torch/csrc/jit/runtime/interpreter.cpp
+++ b/torch/csrc/jit/runtime/interpreter.cpp
@@ -40,7 +40,6 @@ using torch::distributed::autograd::DistAutogradContainer;
 #include <mutex>
 #include <ostream>
 #include <stdexcept>
-#include <typeinfo>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -236,6 +235,7 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
       (void)instX_;
       (void)initialSize_;
     }
+    ~StackSizeDidntChangeGuard() = default;
 
     void callAssert() const {
 #ifndef NDEBUG

--- a/torch/csrc/jit/runtime/jit_trace.cpp
+++ b/torch/csrc/jit/runtime/jit_trace.cpp
@@ -253,7 +253,7 @@ void insertTracingNodes(Block* block, ProfilingRecord* pr, TracingData& td) {
       for (size_t j = 0; j < outputs_size; j++) {
         auto& iiv = iivs[j];
         if (iiv.isTensor()) {
-          auto t = iiv.toTensor();
+          const auto& t = iiv.toTensor();
           auto type = t.defined() ? tensorTypeInCurrentExecutionContext(t)
                                   : TensorType::get();
           tracer->outputs().at(j)->setType(type);

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -640,7 +640,7 @@ const ExecutionPlan& ProfilingGraphExecutorImpl::getOptimizedPlanFor(
   // object in interpreter.
   if (!remaining_bailout_depth_.has_value() || !tensorExprFuserEnabled()) {
     if (remaining_bailout_depth.has_value()) {
-      remaining_bailout_depth_ = *remaining_bailout_depth;
+      remaining_bailout_depth_ = remaining_bailout_depth;
     } else {
       remaining_bailout_depth_ = getInstantiatedBailoutDepth();
     }

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -1045,7 +1045,7 @@ void BlockRunner::set_inputs(IValueList&& args, const KeywordArgs& kwargs) {
     const auto& schema_arg = schema_args[i_arg];
 
     if (i_arg - 1 < args.size()) {
-      check_type(schema_arg, std::forward<IValueList>(args)[i_arg - 1]);
+      check_type(schema_arg, args[i_arg - 1]);
       set_arg(i_arg - 1, std::forward<IValueList>(args));
       continue;
     }

--- a/torch/csrc/jit/runtime/static/memory_planner.cpp
+++ b/torch/csrc/jit/runtime/static/memory_planner.cpp
@@ -5,7 +5,6 @@
 #include <torch/csrc/jit/ir/alias_analysis.h>
 #include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/runtime/static/impl.h>
-#include <iterator>
 
 namespace torch::jit {
 

--- a/torch/csrc/jit/runtime/static/ops.h
+++ b/torch/csrc/jit/runtime/static/ops.h
@@ -172,8 +172,8 @@ inline bool sr_schema_check(torch::jit::Node*) {
 template <typename Schema, typename... Schemas>
 bool sr_schema_check(
     torch::jit::Node* node,
-    Schema&& first,
-    Schemas&&... rest) {
+    const Schema& first,
+    const Schemas&... rest) {
   auto is_match = node->matches(first) || sr_schema_check(node, rest...);
   if (!is_match) {
     torch::jit::LogAndDumpSchema(node);

--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -1287,7 +1287,7 @@ void UseSplitAndSqueeze(std::shared_ptr<Graph>& graph) {
     if (!axis_opt) {
       continue;
     }
-    auto axis = *axis_opt;
+    const auto& axis = *axis_opt;
     auto* split_node_output = node->output();
     auto* list_unpack_node =
         maybeUserWithKind(split_node_output, prim::ListUnpack);

--- a/torch/csrc/jit/runtime/symbolic_shape_registry.cpp
+++ b/torch/csrc/jit/runtime/symbolic_shape_registry.cpp
@@ -357,7 +357,6 @@ void loadFunctions() {
         GetSerializedShapeFunctions() + _xnnpack_shape_compute_functions;
 
     auto src = std::make_shared<Source>(shape_compute_functions);
-    std::stringstream ss;
     std::vector<at::IValue> constantTable;
     auto resolver = std::make_shared<SourceImporterImpl>(
         compilation_unit,

--- a/torch/csrc/jit/tensorexpr/bounds_inference.cpp
+++ b/torch/csrc/jit/tensorexpr/bounds_inference.cpp
@@ -325,8 +325,8 @@ static bool hasConflictingOverlap(
     auto bTABIs = bIt->second;
     for (size_t i = 0; i < aTABIs.size(); ++i) {
       for (size_t j = 0; j < bTABIs.size(); ++j) {
-        auto aTABI = aTABIs[i];
-        auto bTABI = bTABIs[j];
+        const auto& aTABI = aTABIs[i];
+        const auto& bTABI = bTABIs[j];
         if (aTABI.kind == kLoad && bTABI.kind == kLoad) {
           continue;
         }

--- a/torch/csrc/jit/tensorexpr/eval.cpp
+++ b/torch/csrc/jit/tensorexpr/eval.cpp
@@ -169,8 +169,8 @@ class SimpleIREvaluatorImpl : public IRVisitor {
       const InterpValue& lhs,
       const InterpValue& rhs,
       IRNodeType op_type) {
-    std::vector<T> lhs_v = lhs.as_vec<T>();
-    std::vector<T> rhs_v = rhs.as_vec<T>();
+    const std::vector<T>& lhs_v = lhs.as_vec<T>();
+    const std::vector<T>& rhs_v = rhs.as_vec<T>();
     std::vector<T> result_v(lhs_v.size());
     for (const auto i : c10::irange(lhs_v.size())) {
       switch (op_type) {
@@ -208,8 +208,8 @@ class SimpleIREvaluatorImpl : public IRVisitor {
       const InterpValue& lhs,
       const InterpValue& rhs,
       IRNodeType op_type) {
-    std::vector<T> lhs_v = lhs.as_vec<T>();
-    std::vector<T> rhs_v = rhs.as_vec<T>();
+    const std::vector<T>& lhs_v = lhs.as_vec<T>();
+    const std::vector<T>& rhs_v = rhs.as_vec<T>();
     std::vector<T> result_v(lhs_v.size());
     for (const auto i : c10::irange(lhs_v.size())) {
       switch (op_type) {
@@ -235,8 +235,8 @@ class SimpleIREvaluatorImpl : public IRVisitor {
       const InterpValue& lhs,
       const InterpValue& rhs,
       IRNodeType op_type) {
-    std::vector<T> lhs_v = lhs.as_vec<T>();
-    std::vector<T> rhs_v = rhs.as_vec<T>();
+    const std::vector<T>& lhs_v = lhs.as_vec<T>();
+    const std::vector<T>& rhs_v = rhs.as_vec<T>();
     std::vector<T> result_v(lhs_v.size());
     for (const auto i : c10::irange(lhs_v.size())) {
       switch (op_type) {
@@ -263,8 +263,8 @@ class SimpleIREvaluatorImpl : public IRVisitor {
       const InterpValue& retval1,
       const InterpValue& retval2,
       CompareSelectOperation cmp_op) {
-    std::vector<T> lhs_v = lhs.as_vec<T>();
-    std::vector<T> rhs_v = rhs.as_vec<T>();
+    const std::vector<T>& lhs_v = lhs.as_vec<T>();
+    const std::vector<T>& rhs_v = rhs.as_vec<T>();
     std::vector<R> ret_val1_v = retval1.as_vec<R>();
     std::vector<R> ret_val2_v = retval2.as_vec<R>();
     std::vector<R> result_v(lhs_v.size());
@@ -301,7 +301,7 @@ class SimpleIREvaluatorImpl : public IRVisitor {
       std::enable_if_t<std::is_same_v<
           decltype(detail::bin_op_deducer(std::declval<D>())),
           void>>* = nullptr>
-  void visit_binary_op(NodePtr<D> v, bool option = false) {
+  void visit_binary_op(const NodePtr<D>& v, bool option = false) {
     v->lhs()->accept(this);
     InterpValue lhs_v = value_;
     v->rhs()->accept(this);

--- a/torch/csrc/jit/tensorexpr/external_functions.cpp
+++ b/torch/csrc/jit/tensorexpr/external_functions.cpp
@@ -981,7 +981,7 @@ void nnc_aten_upsample_nearest2d_out(
       buf_dtypes,
       qdata,
       bufs_out_num);
-  auto x = tensors[1];
+  const auto& x = tensors[1];
 
   int64_t output_size_h = extra_args[3];
   int64_t output_size_w = extra_args[4];
@@ -1013,7 +1013,7 @@ void nnc_aten_quantize_per_tensor(
   auto tensors = constructTensors(
       bufs_num, buf_data, buf_ranks, buf_dims, buf_strides, buf_dtypes);
   // NOLINTNEXTLINE(facebook-hte-LocalUncheckedArrayBounds)
-  at::Tensor x = tensors[1];
+  const at::Tensor& x = tensors[1];
   const double qscale = ((double*)extra_args)[0];
   const int64_t qzero = extra_args[1];
   const c10::ScalarType qdtype = static_cast<c10::ScalarType>(extra_args[2]);

--- a/torch/csrc/jit/tensorexpr/graph_opt.cpp
+++ b/torch/csrc/jit/tensorexpr/graph_opt.cpp
@@ -189,7 +189,7 @@ void annotateInputShapes(
       graph->inputs().size() == example_inputs.size(),
       buildErrorMessage("Given inputs do not match the fuser graph inputs."));
   for (size_t idx = 0; idx < example_inputs.size(); idx++) {
-    if (auto t = example_inputs[idx]) {
+    if (const auto& t = example_inputs[idx]) {
       auto concrete_tensor_type = tensorTypeInCurrentExecutionContext(*t);
       graph->inputs().at(idx)->setType(concrete_tensor_type);
     }

--- a/torch/csrc/jit/tensorexpr/ir_cloner.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_cloner.cpp
@@ -14,7 +14,7 @@ template <
         decltype(detail::bin_op_deducer(std::declval<Op>())),
         void>>* = nullptr>
 static ExprPtr mutate_binary_op(
-    NodePtr<Op> v,
+    const NodePtr<Op>& v,
     IRCloner* cloner,
     bool option = false) {
   ExprPtr lhs_new = v->lhs()->accept_mutator(cloner);

--- a/torch/csrc/jit/tensorexpr/ir_printer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_printer.cpp
@@ -61,7 +61,7 @@ template <
         decltype(detail::bin_op_deducer(std::declval<Op>())),
         void>>* = nullptr>
 static void visitBinaryOp(
-    NodePtr<Op> v,
+    const NodePtr<Op>& v,
     const std::string& op_str,
     IRPrinter* printer,
     bool parens = true) {

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -48,7 +48,7 @@ template <
         decltype(detail::bin_op_deducer(std::declval<Op>())),
         void>>* = nullptr>
 static ExprPtr mutateBinaryOp(
-    NodePtr<Op> v,
+    const NodePtr<Op>& v,
     IRMutator* mutator,
     bool option = false) {
   ExprPtr lhs = v->lhs();
@@ -1211,8 +1211,8 @@ namespace {
 // second type refers to the corresponding term, as in MinTerm or MaxTerm.
 template <class Op, class OpTerm>
 ExprPtr combineMinMaxTerms(
-    ExprPtr lhs,
-    ExprPtr rhs,
+    const ExprPtr& lhs,
+    const ExprPtr& rhs,
     bool propagate_nans,
     HashProvider& hasher) {
   auto combine_scalars = [&](ExprPtr c1, ExprPtr c2) -> ExprPtr {
@@ -1225,7 +1225,8 @@ ExprPtr combineMinMaxTerms(
     return c2;
   };
 
-  auto combine_opterms = [&](NodePtr<OpTerm> m1, NodePtr<OpTerm> m2) {
+  auto combine_opterms = [&](const NodePtr<OpTerm>& m1,
+                             const NodePtr<OpTerm>& m2) {
     ExprPtr scalar = combine_scalars(m1->scalar(), m2->scalar());
     std::vector<ExprPtr> variables;
     for (const auto& v : m1->variables()) {
@@ -1237,7 +1238,8 @@ ExprPtr combineMinMaxTerms(
     return alloc<OpTerm>(hasher, scalar, propagate_nans, std::move(variables));
   };
 
-  auto add_expr_to_opterm = [&](ExprPtr expr, NodePtr<OpTerm> opterm) {
+  auto add_expr_to_opterm = [&](const ExprPtr& expr,
+                                const NodePtr<OpTerm>& opterm) {
     ExprPtr scalar = nullptr;
     std::vector<ExprPtr> variables;
     if (opterm) {
@@ -1275,7 +1277,7 @@ ExprPtr combineMinMaxTerms(
 // the other op of opterm in other_op.
 template <class OpTerm>
 bool isOperandInMinMaxTerm(
-    NodePtr<OpTerm> opterm,
+    const NodePtr<OpTerm>& opterm,
     ExprPtr op,
     HashProvider& hasher,
     ExprPtr* other_op) {
@@ -1308,8 +1310,8 @@ bool isOperandInMinMaxTerm(
 // type corresponding to the expected inner op (e.g. MinTerm).
 template <class OpTerm, class OtherOpTerm>
 bool simplifyNestedMinMax(
-    ExprPtr lhs,
-    ExprPtr rhs,
+    const ExprPtr& lhs,
+    const ExprPtr& rhs,
     bool propagate_nans,
     HashProvider& hasher,
     ExprPtr* new_op) {

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -1228,11 +1228,14 @@ ExprPtr combineMinMaxTerms(
   auto combine_opterms = [&](const NodePtr<OpTerm>& m1,
                              const NodePtr<OpTerm>& m2) {
     ExprPtr scalar = combine_scalars(m1->scalar(), m2->scalar());
+    auto const& m1_variables = m1->variables();
+    auto const& m2_variables = m2->variables();
     std::vector<ExprPtr> variables;
-    for (const auto& v : m1->variables()) {
+    variables.reserve(m1_variables.size() + m2_variables.size());
+    for (const auto& v : m1_variables) {
       variables.push_back(v);
     }
-    for (const auto& v : m2->variables()) {
+    for (const auto& v : m2_variables) {
       variables.push_back(v);
     }
     return alloc<OpTerm>(hasher, scalar, propagate_nans, std::move(variables));

--- a/torch/csrc/jit/tensorexpr/ir_verifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_verifier.cpp
@@ -19,7 +19,7 @@ template <
     std::enable_if_t<
         std::is_same_v<decltype(detail::deducer(std::declval<D>())), void>>* =
         nullptr>
-static void verifyBitwiseOp(NodePtr<D> v, IRVerifier* verifier) {
+static void verifyBitwiseOp(const NodePtr<D>& v, IRVerifier* verifier) {
   if (!v->lhs()->dtype().is_integral()) {
     throw unsupported_dtype();
   }

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -681,7 +681,7 @@ class FunctionInliner : public IRMutator {
     }
     for (const auto i : c10::irange(buf->ndim())) {
       VarPtr func_callee_arg = producer_index_vars_.at(i);
-      ExprPtr func_caller_param = dims.at(i);
+      const ExprPtr& func_caller_param = dims.at(i);
       if (func_callee_arg == nullptr) {
         continue;
       }
@@ -1328,7 +1328,7 @@ bool LoopNest::optimizeConditionals() {
       continue;
     }
 
-    auto for_to_split = fors.back();
+    const auto& for_to_split = fors.back();
     if (!LoopNest::isNormalized(for_to_split)) {
       // Do not optimize this conditional since the condition variable
       // refers to a loop that is not normalized.
@@ -1360,7 +1360,7 @@ bool LoopNest::optimizeConditionals() {
     // Remove all the if-then-else expressions from this store and create
     // one loop per sub-expression.
     std::vector<StmtPtr> split_loops;
-    auto cond_to_replace = ifthenelse_exprs.front();
+    const auto& cond_to_replace = ifthenelse_exprs.front();
     for (size_t i = 0; i < sub_exprs.size(); ++i) {
       IfThenElseReplacer ifthenelseReplacer(cond_to_replace, sub_exprs[i]);
       auto new_store = store->accept_mutator(&ifthenelseReplacer);
@@ -2435,7 +2435,7 @@ bool LoopNest::flatten(const std::vector<ForPtr>& loops, ForPtr* flattened) {
   ExprPtr stop = immLike(flat_var, 1);
   for (size_t i = 0; i < normalized_loops.size(); ++i) {
     size_t idx = normalized_loops.size() - i - 1;
-    auto curr_loop = normalized_loops[idx];
+    const auto& curr_loop = normalized_loops[idx];
     ExprPtr div = alloc<Div>(flat_var, stop);
     ExprPtr sub_expr = idx == 0 ? div : alloc<Mod>(div, curr_loop->stop());
     var_mapping.emplace_back(curr_loop->var(), sub_expr);
@@ -2878,6 +2878,7 @@ LoopNest::AccessResult LoopNest::cacheAccesses(
   // determine the offsets for calls into the cache based off the loop start of
   // each axis.
   std::vector<ExprPtr> tmp_params;
+  tmp_params.reserve(new_loop_vars.size());
   for (size_t i = 0; i < new_loop_vars.size(); ++i) {
     tmp_params.push_back(alloc<Add>(new_loop_vars[i], info.start[i]));
   }

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -1360,6 +1360,7 @@ bool LoopNest::optimizeConditionals() {
     // Remove all the if-then-else expressions from this store and create
     // one loop per sub-expression.
     std::vector<StmtPtr> split_loops;
+    split_loops.reserve(sub_exprs.size());
     const auto& cond_to_replace = ifthenelse_exprs.front();
     for (size_t i = 0; i < sub_exprs.size(); ++i) {
       IfThenElseReplacer ifthenelseReplacer(cond_to_replace, sub_exprs[i]);

--- a/torch/csrc/jit/tensorexpr/loopnest_randomization.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest_randomization.cpp
@@ -44,7 +44,7 @@ static std::vector<std::vector<ForPtr>> GetAllPerfectlyNestedLoopNests(
   nested_loops.push_back(loops[0]);
   for (size_t i = 1; i < loops.size(); i++) {
     auto last_loop = nested_loops.back();
-    auto next_loop = loops[i];
+    const auto& next_loop = loops[i];
     if (last_loop->body()->nstmts() == 1 &&
         last_loop->body()->front() == next_loop) {
       nested_loops.push_back(next_loop);
@@ -100,7 +100,7 @@ static void printHistory(int index, std::string message) {
 }
 
 template <typename T>
-static std::string join(std::vector<T> indices, char sep = ',') {
+static std::string join(const std::vector<T>& indices, char sep = ',') {
   std::string s;
   for (const auto& index : indices) {
     s += std::to_string(index) + sep;
@@ -255,7 +255,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
             break;
           }
           int loop_n = std::rand() % (int)loops.size();
-          auto loop = loops[loop_n];
+          const auto& loop = loops[loop_n];
           int factor = (std::rand() % 20) + 1;
           message = "splitWithTail(loops[" + std::to_string(loop_n) + "], " +
               std::to_string(factor) + ");\n";
@@ -269,7 +269,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
             break;
           }
           int loop_n = std::rand() % (int)loops.size();
-          auto loop = loops[loop_n];
+          const auto& loop = loops[loop_n];
           int factor = (std::rand() % 20) + 1;
           message = "splitWithMask(loops[" + std::to_string(loop_n) + "], " +
               std::to_string(factor) + ")\n";
@@ -283,7 +283,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
             break;
           }
           int loop_n = std::rand() % (int)loops.size();
-          auto loop = loops[loop_n];
+          const auto& loop = loops[loop_n];
           std::vector<StmtPtr> stmts(
               loop->body()->begin(), loop->body()->end());
           if (stmts.empty()) {
@@ -308,7 +308,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
             break;
           }
           int loop_n = std::rand() % (int)loops.size();
-          auto loop = loops[loop_n];
+          const auto& loop = loops[loop_n];
 
           message = "distributeLoop(loops[" + std::to_string(loop_n) + "])\n";
           randomization_helper::printHistory(n_transform, message);
@@ -322,7 +322,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
             break;
           }
           int loop_n = std::rand() % (int)loops.size();
-          auto loop = loops[loop_n];
+          const auto& loop = loops[loop_n];
 
           message = "distributeLoopAndParents(loops[" + std::to_string(loop_n) +
               "])\n";
@@ -337,7 +337,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
             break;
           }
           int loop_n = std::rand() % (int)loops.size();
-          auto loop = loops[loop_n];
+          const auto& loop = loops[loop_n];
 
           message = "distributeLoopOverInnerLoops(loops[" +
               std::to_string(loop_n) + "])\n";
@@ -352,7 +352,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
             break;
           }
           int loop_n = std::rand() % (int)loops.size();
-          auto loop = loops[loop_n];
+          const auto& loop = loops[loop_n];
 
           message = "distributeLoopAndParentsOverInnerLoops(loops[" +
               std::to_string(loop_n) + "])\n";
@@ -516,7 +516,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
             break;
           }
           int loop_n = std::rand() % (int)loops.size();
-          auto loop = loops[loop_n];
+          const auto& loop = loops[loop_n];
 
           message = "fullUnroll(loops[" + std::to_string(loop_n) + "]);\n";
           randomization_helper::printHistory(n_transform, message);
@@ -530,7 +530,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
             break;
           }
           int loop_n = std::rand() % (int)loops.size();
-          auto loop = loops[loop_n];
+          const auto& loop = loops[loop_n];
 
           message = "normalize(loops[" + std::to_string(loop_n) + "]);\n";
           randomization_helper::printHistory(n_transform, message);
@@ -573,7 +573,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
         case COMPRESS_BUFFER: {
           auto buffers = NodeFinder<Buf>::find(l.root_stmt());
           int buffer_n = std::rand() % (int)buffers.size();
-          auto buffer = buffers[buffer_n];
+          const auto& buffer = buffers[buffer_n];
 
           message = "compressBuffer(buffers[" + std::to_string(buffer_n) +
               "], l.root_stmt());\n";
@@ -596,7 +596,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
             break;
           }
           int loop_n = std::rand() % (int)loops.size();
-          auto loop = loops[loop_n];
+          const auto& loop = loops[loop_n];
 
           int factor = randomization_helper::find_factor(loop);
           if (factor == -1) {
@@ -615,7 +615,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
             break;
           }
           int loop_n = std::rand() % (int)loops.size();
-          auto loop = loops[loop_n];
+          const auto& loop = loops[loop_n];
 
           int factor = randomization_helper::find_factor(loop);
           if (factor == -1) {

--- a/torch/csrc/jit/tensorexpr/operators/conv2d.cpp
+++ b/torch/csrc/jit/tensorexpr/operators/conv2d.cpp
@@ -5,6 +5,8 @@
 #include <torch/csrc/jit/tensorexpr/operators/misc.h>
 #include <torch/csrc/jit/tensorexpr/tensor.h>
 
+#include <utility>
+
 namespace torch::jit::tensorexpr {
 
 namespace {
@@ -100,16 +102,16 @@ Tensor conv2d_depthwise_dynamic(
     BufHandle weight,
     const InitFunc& init_func,
     ExprHandle N,
-    ExprHandle C,
+    const ExprHandle& C,
     ExprHandle H,
     ExprHandle W,
     ExprHandle K,
-    ExprHandle CperG,
-    ExprHandle R,
-    ExprHandle S,
+    const ExprHandle& CperG,
+    const ExprHandle& R,
+    const ExprHandle& S,
     ExprHandle stride,
     ExprHandle pad,
-    ExprHandle groups) {
+    const ExprHandle& groups) {
   TORCH_INTERNAL_ASSERT(input.ndim() == 4);
   TORCH_INTERNAL_ASSERT(weight.ndim() == 4);
 
@@ -118,7 +120,7 @@ Tensor conv2d_depthwise_dynamic(
 
   return Reduce(
       "conv2d_depthwise",
-      {N, K, OH, OW},
+      {std::move(N), std::move(K), OH, OW},
       std::nullopt, // TODO
       Sum(),
       [&](const std::vector<VarHandle>& v) { return init_func(v); },
@@ -146,8 +148,8 @@ Tensor conv2d_depthwise_dynamic(
 } // namespace
 
 Tensor conv2d_depthwise(
-    BufHandle input,
-    BufHandle weight,
+    const BufHandle& input,
+    const BufHandle& weight,
     BufHandle bias,
     int stride,
     int pad,
@@ -160,8 +162,8 @@ Tensor conv2d_depthwise(
 }
 
 Tensor conv2d_depthwise(
-    BufHandle input,
-    BufHandle weight,
+    const BufHandle& input,
+    const BufHandle& weight,
     int stride,
     int pad,
     int groups) {
@@ -191,20 +193,20 @@ Tensor conv2d_depthwise(
     return bias.load(v[1]);
   };
   return conv2d_depthwise_dynamic(
-      input,
-      weight,
+      std::move(input),
+      std::move(weight),
       init_func,
-      N,
-      C,
-      H,
-      W,
-      K,
-      CperG,
-      R,
-      S,
-      stride,
-      pad,
-      groups);
+      std::move(N),
+      std::move(C),
+      std::move(H),
+      std::move(W),
+      std::move(K),
+      std::move(CperG),
+      std::move(R),
+      std::move(S),
+      std::move(stride),
+      std::move(pad),
+      std::move(groups));
 }
 
 Tensor conv2d_depthwise(
@@ -225,20 +227,20 @@ Tensor conv2d_depthwise(
     return ExprHandle(Sum().initializer());
   };
   return conv2d_depthwise_dynamic(
-      input,
-      weight,
+      std::move(input),
+      std::move(weight),
       init_func,
-      N,
-      C,
-      H,
-      W,
-      K,
-      CperG,
-      R,
-      S,
-      stride,
-      pad,
-      groups);
+      std::move(N),
+      std::move(C),
+      std::move(H),
+      std::move(W),
+      std::move(K),
+      std::move(CperG),
+      std::move(R),
+      std::move(S),
+      std::move(stride),
+      std::move(pad),
+      std::move(groups));
 }
 
 static std::vector<int64_t> _pair_int(ArgValue v) {

--- a/torch/csrc/jit/tensorexpr/operators/conv2d.h
+++ b/torch/csrc/jit/tensorexpr/operators/conv2d.h
@@ -7,8 +7,8 @@ namespace torch::jit::tensorexpr {
 
 // An API to compute 2D depthwise convolutions with bias.
 TORCH_API Tensor conv2d_depthwise(
-    BufHandle input,
-    BufHandle weight,
+    const BufHandle& input,
+    const BufHandle& weight,
     BufHandle bias,
     int stride,
     int pad,
@@ -16,8 +16,8 @@ TORCH_API Tensor conv2d_depthwise(
 
 // An API to compute 2D depthwise convolutions without bias.
 TORCH_API Tensor conv2d_depthwise(
-    BufHandle input,
-    BufHandle weight,
+    const BufHandle& input,
+    const BufHandle& weight,
     int stride,
     int pad,
     int groups);

--- a/torch/csrc/jit/tensorexpr/operators/pointwise.cpp
+++ b/torch/csrc/jit/tensorexpr/operators/pointwise.cpp
@@ -14,7 +14,7 @@ Tensor computeSign(
         std::vector<ExprHandle> indices(axes.begin(), axes.end());
         std::vector<ExprHandle> inputs = {
             tensorOrConstant(inputValues[0], indices)};
-        auto inp = inputs[0];
+        const auto& inp = inputs[0];
         auto zero = ExprHandle(immLike(inp, 0.0f));
         auto res = (zero < inp) - (inp < zero);
         return promoteToDtype(res, inp.dtype().scalar_type());

--- a/torch/csrc/jit/tensorexpr/registerizer.cpp
+++ b/torch/csrc/jit/tensorexpr/registerizer.cpp
@@ -165,7 +165,7 @@ void Scope::filterClosed() {
       std::remove_if(
           closedAccesses_.begin(),
           closedAccesses_.end(),
-          [](auto info) {
+          [](const auto& info) {
             return info->store_cost()->isConstant() &&
                 immediateAs<int>(info->store_cost()) <= 1 &&
                 info->load_cost()->isConstant() &&
@@ -645,7 +645,9 @@ std::vector<std::shared_ptr<AccessInfo>> RegisterizerAnalysis::getCandidates() {
   std::sort(
       currentScope_->closedAccesses().begin(),
       currentScope_->closedAccesses().end(),
-      [](auto i1, auto i2) { return i1->accessOrder() < i2->accessOrder(); });
+      [](const auto& i1, const auto& i2) {
+        return i1->accessOrder() < i2->accessOrder();
+      });
   return currentScope_->closedAccesses();
 }
 


### PR DESCRIPTION
Apply clang-tidy to C++ code in torch/csrc/jit, most fixes are about performance warnings. JIT code should be maintained for a long time so that we aim to finally enable clang-tidy checking on them.

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel