### PR TITLE
Clarify torch.library backend registration support in extending.rst

### DIFF
--- a/docs/source/notes/extending.rst
+++ b/docs/source/notes/extending.rst
@@ -923,7 +923,7 @@ In a similar way where ``__torch_function__`` is able to interpose on all of tor
 Most of these functions are defined in ``native_functions.yaml`` which specifies the properties of these functions as well as their backend implementation. Their implementation alongside specified features are then automatically registered via codegen.
 Some more exotic functions or features are also registered in other places in the C++ codebase or in user-defined C++ extensions.
 
-It is also possible to add `new` native functions using :mod:`torch.library`. This Python feature allows defining and/or adding new implementations to native functions. This can be used to add missing kernels, replace existing ones or define brand new native functions.
+It is also possible to add `new` native functions using :mod:`torch.library`, which supports applying multiple decorators to register different definitions for different backends (e.g CPU and CUDA). This Python feature allows defining and/or adding new implementations to native functions. This can be used to add missing kernels, replace existing ones or define brand new native functions.
 
 You can find many examples of ``__torch_dispatch__``-based subclasses in the `subclass zoo <https://github.com/albanD/subclass_zoo>`_ repo.
 


### PR DESCRIPTION
Improved the description of `torch.library` to highlight that it supports multiple decorators for backend-specific registrations (e.g., CPU, CUDA). This clarification helps users better understand how to define or extend
native functions in PyTorch for multiple backends.