### PR TITLE
Fix typo: 'intialized' → 'initialized' in test_modules.py

### DIFF
--- a/test/jit/test_modules.py
+++ b/test/jit/test_modules.py
@@ -21,7 +21,7 @@ class TestModules(JitTestCase):
         """
 
         # torch.nn.Linear has a __constants__ attribute defined
-        # and intialized to a list.
+        # and initialized to a list.
         class Net(torch.nn.Linear):
             x: torch.jit.Final[int]
 


### PR DESCRIPTION
This PR fixes a minor typo in `test/jit/test_modules.py`:

- Before: `intialized`
- After:  `initialized`

There are no functional code changes — this is a comment-only fix to improve clarity and consistency.

Thank you to the PyTorch team for maintaining this outstanding project.  
Please let me know if anything else is needed.

With appreciation,  
Abhishek Nandy  
[@abhitorch81](https://github.com/abhitorch81)





cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel