### PR TITLE
Enable `file_descriptor` strategy on Darwin

### DIFF
--- a/torch/multiprocessing/__init__.py
+++ b/torch/multiprocessing/__init__.py
@@ -50,7 +50,7 @@ from .spawn import (
 )
 
 
-if sys.platform == "darwin" or sys.platform == "win32":
+if sys.platform == "win32":
     _sharing_strategy = "file_system"
     _all_sharing_strategies = {"file_system"}
 else:


### PR DESCRIPTION
Not sure why it was limited to Linux, as both OSes support file descriptor sharing across processes

Fixes #ISSUE_NUMBER
