### PR TITLE
Support complex numbers in DTensor redistribute

### DIFF
--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -15,7 +15,13 @@ from torch.distributed.tensor import (
 )
 from torch.distributed.tensor._collective_utils import shard_dim_alltoall
 from torch.distributed.tensor.debug import CommDebugMode
-from torch.testing._internal.common_utils import run_tests, TEST_CUDA, TEST_HPU
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TEST_CUDA,
+    TEST_HPU,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     with_comms,
@@ -31,7 +37,8 @@ class RedistributeTest(DTensorTestBase):
         return 4
 
     @with_comms
-    def test_shard_to_replicate_forward_backward(self):
+    @parametrize("dtype", [torch.float32, torch.cfloat])
+    def test_shard_to_replicate_forward_backward(self, dtype):
         # 1) test shard -> replicate forward
         device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
         replica_spec = [Replicate()]
@@ -49,7 +56,7 @@ class RedistributeTest(DTensorTestBase):
         for input_size, shard_dim in input_sizes_and_shard_dim:
             shard_spec = [Shard(shard_dim)]
             expected_tensor = torch.randn(
-                input_size, device=self.device_type, requires_grad=True
+                input_size, device=self.device_type, requires_grad=True, dtype=dtype
             )
             dtensor = distribute_tensor(expected_tensor, device_mesh, shard_spec)
             with comm_mode:
@@ -68,7 +75,8 @@ class RedistributeTest(DTensorTestBase):
             grad_input = dtensor.grad
             self.assertEqual(grad_input.placements, shard_spec)
             self.assertEqual(
-                grad_input.to_local(), torch.ones(dtensor.to_local().size())
+                grad_input.to_local(),
+                torch.ones(dtensor.to_local().size(), dtype=dtype),
             )
             self.assertEqual(comm_mode.get_total_counts(), 0)
 
@@ -101,10 +109,13 @@ class RedistributeTest(DTensorTestBase):
         self.assertEqual(comm_mode.get_total_counts(), 0)
 
     @with_comms
-    def test_replicate_to_local_partial_grad(self):
+    @parametrize("dtype", [torch.float32, torch.cfloat])
+    def test_replicate_to_local_partial_grad(self, dtype):
         device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
         replica_spec = [Replicate()]
-        local_tensor = torch.randn(12, 3, device=self.device_type, requires_grad=True)
+        local_tensor = torch.randn(
+            12, 3, device=self.device_type, requires_grad=True, dtype=dtype
+        )
 
         replica_tensor = distribute_tensor(local_tensor, device_mesh, replica_spec)
 
@@ -116,6 +127,8 @@ class RedistributeTest(DTensorTestBase):
             )
             out.backward(torch.ones_like(out))
 
+        # TODO(whc) it appears complex-allreduce is already being supported becuase this test passes,
+        # but I did not see where the support is
         self.assertEqual(comm_mode.get_total_counts(), 1)
         self.assertEqual(comm_mode.get_comm_counts()[funcol.all_reduce], 1)
 
@@ -168,13 +181,14 @@ class RedistributeTest(DTensorTestBase):
             )
 
     @with_comms
-    def test_partial_to_replicate_forward_backward(self):
+    @parametrize("dtype", [torch.float32, torch.cfloat])
+    def test_partial_to_replicate_forward_backward(self, dtype):
         # Although we don't allow user to reshard to produce a partial
         # placement (i.e. user can't reshard to partial), we do allow
         # replicate to partial internally, and also partial to replicate
         # backward should work as expected
         device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
-        partial_local = torch.ones(12, 3, device=self.device_type, requires_grad=True)
+        partial_local = torch.ones(12, 3, device=self.device_type, requires_grad=True, dtype=dtype)
         partial_spec = [Partial()]
         replica_spec = [Replicate()]
 
@@ -199,7 +213,7 @@ class RedistributeTest(DTensorTestBase):
             global_partial_tensor.backward(torch.ones_like(global_partial_tensor))
         self.assertIsNotNone(partial_local.grad)
         self.assertEqual(partial_local.grad.size(), partial_local.size())
-        self.assertEqual(partial_local.grad, torch.ones_like(partial_local))
+        self.assertEqual(partial_local.grad, torch.ones_like(partial_local, dtype=dtype))
         self.assertEqual(comm_mode.get_total_counts(), 0)
 
     @with_comms
@@ -380,7 +394,8 @@ class RedistributeTest(DTensorTestBase):
         self.assertEqual(comm_mode.get_total_counts(), 0)
 
     @with_comms
-    def test_partial_to_shard(self):
+    @parametrize("dtype", [torch.float32, torch.cfloat])
+    def test_partial_to_shard(self, dtype):
         device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
         partial_spec = [Partial()]
         my_rank = device_mesh.get_rank()
@@ -399,7 +414,7 @@ class RedistributeTest(DTensorTestBase):
         for input_size, shard_dim in input_sizes_and_shard_dim:
             shard_spec = [Shard(shard_dim)]
 
-            partial_local = torch.ones(input_size, device=self.device_type)
+            partial_local = torch.ones(input_size, device=self.device_type, dtype=dtype)
             partial_tensor = DTensor.from_local(
                 partial_local, device_mesh, partial_spec, run_check=False
             )
@@ -428,7 +443,7 @@ class RedistributeTest(DTensorTestBase):
             self.assertEqual(scatter_shard_tensor.placements, shard_spec)
             self.assertEqual(
                 scatter_shard_tensor.to_local(),
-                torch.ones(local_shape) * self.world_size,
+                torch.ones(local_shape, dtype=dtype) * self.world_size,
             )
             self.assertEqual(
                 comm_mode.get_comm_counts()[funcol.reduce_scatter_tensor], 1
@@ -471,20 +486,21 @@ class RedistributeTest(DTensorTestBase):
                 self.assertEqual(dt_full_tensor, input_tensor)
 
     @with_comms
-    def test_redistribute_shard_dim_change(self):
+    @parametrize("dtype", [torch.float32, torch.cfloat])
+    def test_redistribute_shard_dim_change(self, dtype):
         # test 1d device mesh
         mesh_1d = DeviceMesh(self.device_type, torch.arange(self.world_size))
         data_to_test = [
             # evenly sharded case
-            torch.randn((8, 8), device=self.device_type),
+            torch.randn((8, 8), device=self.device_type, dtype=dtype),
             # 3d or more dims
-            torch.randn((8, 8, 8), device=self.device_type),
+            torch.randn((8, 8, 8), device=self.device_type, dtype=dtype),
             # uneven case 1
-            torch.randn((8, 5), device=self.device_type),
+            torch.randn((8, 5), device=self.device_type, dtype=dtype),
             # uneven case 2
-            torch.randn((5, 8), device=self.device_type),
+            torch.randn((5, 8), device=self.device_type, dtype=dtype),
             # uneven case 3
-            torch.randn((5, 5), device=self.device_type),
+            torch.randn((5, 5), device=self.device_type, dtype=dtype),
         ]
 
         sharding_src_dst_pairs = [([Shard(0)], [Shard(1)]), ([Shard(1)], [Shard(0)])]
@@ -520,15 +536,15 @@ class RedistributeTest(DTensorTestBase):
         )
         data_to_test_2d = [
             # evenly sharded case
-            torch.randn((8, 8), device=self.device_type),
+            torch.randn((8, 8), device=self.device_type, dtype=dtype),
             # 3d or more dims
-            torch.randn((8, 8, 8), device=self.device_type),
+            torch.randn((8, 8, 8), device=self.device_type, dtype=dtype),
             # uneven case 1
-            torch.randn((8, 5), device=self.device_type),
+            torch.randn((8, 5), device=self.device_type, dtype=dtype),
             # uneven case 2
-            torch.randn((5, 8), device=self.device_type),
+            torch.randn((5, 8), device=self.device_type, dtype=dtype),
             # uneven case 3
-            torch.randn((5, 5), device=self.device_type),
+            torch.randn((5, 5), device=self.device_type, dtype=dtype),
         ]
         sharding_src_dst_pairs_2d = [
             ([Shard(0), Shard(1)], [Shard(0), Shard(0)]),
@@ -568,10 +584,11 @@ class RedistributeTest(DTensorTestBase):
                 self.assertEqual(local_out_dt, local_expected_dt)
 
     @with_comms
-    def test_shard_dim_alltoall(self):
+    @parametrize("dtype", [torch.float32, torch.cfloat])
+    def test_shard_dim_alltoall(self, dtype):
         # init 2d mesh here so we can test when group_rank != global_rank
         mesh = init_device_mesh(self.device_type, (2, 2))
-        tensor = torch.randn(12, self.world_size, device=self.device_type)
+        tensor = torch.randn(12, self.world_size, device=self.device_type, dtype=dtype)
         new_tensor = shard_dim_alltoall(tensor, 0, 1, mesh, 0)
 
         meta_tensor = torch.randn(12, self.world_size, device="meta")
@@ -579,6 +596,9 @@ class RedistributeTest(DTensorTestBase):
 
         self.assertEqual(new_tensor.shape, new_meta_tensor.shape)
         self.assertEqual(new_tensor.stride(), new_meta_tensor.stride())
+
+
+instantiate_parametrized_tests(RedistributeTest)
 
 
 class MultiDimRedistributeTest(DTensorTestBase):

--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -188,7 +188,9 @@ class RedistributeTest(DTensorTestBase):
         # replicate to partial internally, and also partial to replicate
         # backward should work as expected
         device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
-        partial_local = torch.ones(12, 3, device=self.device_type, requires_grad=True, dtype=dtype)
+        partial_local = torch.ones(
+            12, 3, device=self.device_type, requires_grad=True, dtype=dtype
+        )
         partial_spec = [Partial()]
         replica_spec = [Replicate()]
 
@@ -213,7 +215,9 @@ class RedistributeTest(DTensorTestBase):
             global_partial_tensor.backward(torch.ones_like(global_partial_tensor))
         self.assertIsNotNone(partial_local.grad)
         self.assertEqual(partial_local.grad.size(), partial_local.size())
-        self.assertEqual(partial_local.grad, torch.ones_like(partial_local, dtype=dtype))
+        self.assertEqual(
+            partial_local.grad, torch.ones_like(partial_local, dtype=dtype)
+        )
         self.assertEqual(comm_mode.get_total_counts(), 0)
 
     @with_comms

--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -127,8 +127,6 @@ class RedistributeTest(DTensorTestBase):
             )
             out.backward(torch.ones_like(out))
 
-        # TODO(whc) it appears complex-allreduce is already being supported becuase this test passes,
-        # but I did not see where the support is
         self.assertEqual(comm_mode.get_total_counts(), 1)
         self.assertEqual(comm_mode.get_comm_counts()[funcol.all_reduce], 1)
 

--- a/torch/csrc/distributed/c10d/Functional.cpp
+++ b/torch/csrc/distributed/c10d/Functional.cpp
@@ -81,8 +81,11 @@ at::Tensor all_reduce(
     const at::Tensor& input,
     std::string reduce_op,
     std::string group_name) {
-  auto output = input.clone(at::MemoryFormat::Contiguous);
-  return all_reduce_(output, std::move(reduce_op), std::move(group_name));
+  auto input_real = input.is_complex() ? at::view_as_real(input) : input;
+  auto output = input_real.clone(at::MemoryFormat::Contiguous);
+  auto output_ret =
+      all_reduce_(output, std::move(reduce_op), std::move(group_name));
+  return input.is_complex() ? at::view_as_complex(output_ret) : output_ret;
 }
 
 std::vector<at::Tensor> all_reduce_coalesced_(

--- a/torch/csrc/distributed/c10d/Functional.cpp
+++ b/torch/csrc/distributed/c10d/Functional.cpp
@@ -141,15 +141,11 @@ at::Tensor all_gather_into_tensor(
     int64_t group_size,
     std::string group_name) {
   TORCH_CHECK(input.is_contiguous());
-  if (input.is_complex()) {
-    auto real_input = at::view_as_real(input);
-    std::vector<at::Tensor> inputs{real_input};
-    return at::view_as_complex(all_gather_into_tensor_coalesced(
-        inputs, group_size, std::move(group_name))[0]);
-  }
-  std::vector<at::Tensor> inputs{input};
-  return all_gather_into_tensor_coalesced(
+  auto real_input = input.is_complex() ? at::view_as_real(input) : input;
+  std::vector<at::Tensor> inputs{real_input};
+  auto output = all_gather_into_tensor_coalesced(
       inputs, group_size, std::move(group_name))[0];
+  return input.is_complex() ? at::view_as_complex(output) : output;
 }
 
 at::Tensor& all_gather_into_tensor_out(

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2819,6 +2819,8 @@ def broadcast(
     opts.rootRank = group_src
     opts.rootTensor = 0
     opts.asyncOp = async_op
+    if tensor.is_complex():
+        tensor = torch.view_as_real(tensor)
     work = group.broadcast([tensor], opts)
     if async_op:
         return work


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #157329

Add complex number unwrapping in functional collectives used by DTensor.

Complex tensors are not directly supported by underlying comm kernels
(e.g. nccl) but complex tensors can be viewed as real tensors of a
higher rank (added size-2 tensor dim represents real vs im component).
Collective output is then viewed as complex to restore the
original/expected shape and dtype.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @d4l3k
