### PR TITLE
[dtensor] Rework partial propagation in pointwise op and support mul

### DIFF
--- a/test/distributed/tensor/test_pointwise_ops.py
+++ b/test/distributed/tensor/test_pointwise_ops.py
@@ -17,6 +17,7 @@ from torch.distributed.tensor import (
     Replicate,
     Shard,
 )
+from torch.distributed.tensor.debug import CommDebugMode
 from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorOpTestBase,
@@ -147,14 +148,6 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         d_3 = d_1 + d_2
         self.assertTrue(d_3._spec.placements[0].is_partial())
 
-    def test_partial_mul(self):
-        device_mesh = self.build_device_mesh()
-        d_1 = DTensor.from_local(torch.ones(2, 2), device_mesh, [Partial()])
-        d_2 = DTensor.from_local(torch.ones(2, 2), device_mesh, [Partial()])
-        d_3 = d_1 * d_2
-        self.assertTrue(d_3._spec.placements[0].is_replicate())
-        self.assertEqual(d_3.to_local(), torch.ones(2, 2) * (self.world_size**2))
-
     def test_activations(self):
         device_mesh = self.build_device_mesh()
         self._run_sharded_elementwise_ops(
@@ -281,6 +274,54 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         expected = torch.mul(input_tensor, other_tensor, out=output_tensor)
         self.assertEqual(input_tensor, dtensor.to_local())
         self.assertEqual(expected, dt.to_local())
+
+    def test_mul_partial(self):
+        # we only test the partial behavior for mul op as other placement
+        # behaviors should be well tested in test_dtensor_ops.py
+        device_mesh = self.build_device_mesh()
+        comm_mode = CommDebugMode()
+        # 1. simple test for partial * partial
+        d_1 = DTensor.from_local(torch.ones(2, 2), device_mesh, [Partial()])
+        d_2 = DTensor.from_local(torch.ones(2, 2), device_mesh, [Partial()])
+        with comm_mode:
+            d_3 = d_1 * d_2
+        comm_counts = comm_mode.get_total_counts()
+        self.assertEqual(comm_counts, 1)
+        self.assertTrue(isinstance(d_3, DTensor))
+        self.assertEqual(d_3.placements, (Partial(),))
+        self.assertEqual(d_3.to_local(), torch.ones(2, 2) * (self.world_size))
+
+        # 2. test the partial input DTensor * scalar/replicate input
+        input = torch.full((8, 8), 1.0, device=self.device_type)
+
+        # test for different types of other inputs
+        other_inps = (
+            2.0,  # scalar
+            torch.tensor(2.0, device=self.device_type),  # scalar tensor
+            torch.full((8, 8), 2.0, device=self.device_type),  # tensor
+        )
+
+        for partial_op in ["sum", "avg"]:
+            expected_p_out = (
+                input * self.world_size * 2.0 if partial_op == "sum" else input * 2.0
+            )
+
+            d_input = DTensor.from_local(input, device_mesh, [Partial(partial_op)])
+
+            for other_inp in other_inps:
+                if isinstance(other_inp, Tensor) and other_inp.numel() > 1:
+                    d_other = distribute_tensor(other_inp, device_mesh, [Replicate()])
+                else:
+                    d_other = other_inp
+
+                with comm_mode:
+                    z = d_input * d_other
+
+                comm_counts = comm_mode.get_total_counts()
+                self.assertEqual(comm_counts, 0)
+                self.assertTrue(isinstance(z, DTensor))
+                self.assertEqual(z.placements, (Partial(partial_op),))
+                self.assertEqual(z.full_tensor(), expected_p_out)
 
 
 if __name__ == "__main__":

--- a/test/distributed/tensor/test_pointwise_ops.py
+++ b/test/distributed/tensor/test_pointwise_ops.py
@@ -323,6 +323,14 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
                 self.assertEqual(z.placements, (Partial(partial_op),))
                 self.assertEqual(z.full_tensor(), expected_p_out)
 
+        # test other partial to assert the partial not getting propagated
+        d_input = DTensor.from_local(input, device_mesh, [Partial("max")])
+        d_other = distribute_tensor(torch.ones(8, 8), device_mesh, [Replicate()])
+
+        z = d_input * d_other
+        self.assertEqual(z.placements, (Replicate(),))
+        self.assertEqual(z.to_local(), input)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/tensor/_ops/_pointwise_ops.py
+++ b/torch/distributed/tensor/_ops/_pointwise_ops.py
@@ -519,7 +519,7 @@ def common_pointwise_strategy(
     pointwise_strategy = OpStrategy([])
 
     for op_spec in followed_strategy.strategies:
-        spec_to_follow = op_spec.output_specs
+        spec_to_follow = op_spec.output_spec
 
         out_placements: list[Placement] = []
         for placement in spec_to_follow.placements:

--- a/torch/distributed/tensor/_ops/_pointwise_ops.py
+++ b/torch/distributed/tensor/_ops/_pointwise_ops.py
@@ -45,15 +45,6 @@ aten = torch.ops.aten
 # ]
 
 
-linear_pointwise_ops = [
-    aten.div.Scalar,  # this op is linear on the first argument, and the second argument is scalar, so it fits as a linear op.
-    aten.div_.Scalar,  # this op is linear on the first argument, and the second argument is scalar, so it fits as a linear op.
-    aten.to.dtype,
-    aten.add.Tensor,
-    aten.add_.Tensor,
-]
-
-
 pointwise_ops = [
     # please keep the entries below alphabetically sorted
     aten.__ilshift__.Scalar,
@@ -297,11 +288,7 @@ pointwise_ops = [
     aten.maximum.out,
     aten.minimum.default,
     aten.minimum.out,
-    aten.mul.Scalar,
-    aten.mul.Tensor,
     aten.mul.out,
-    aten.mul_.Scalar,
-    aten.mul_.Tensor,
     aten.mvlgamma.default,
     aten.mvlgamma.out,
     aten.mvlgamma_.default,
@@ -416,18 +403,49 @@ pointwise_ops = [
     aten.threshold_backward.default,
 ]
 
+# linear_pointwise_ops = [
+#     aten.div.Scalar,  # this op is linear on the first argument, and the second argument is scalar, so it fits as a linear op.
+#     aten.div_.Scalar,  # this op is linear on the first argument, and the second argument is scalar, so it fits as a linear op.
+#     aten.to.dtype,
+#     aten.add.Tensor,
+#     aten.add_.Tensor,
+#     aten.mul.Scalar,
+#     aten.mul_.Scalar,
+#     aten.mul.Tensor,
+#     aten.mul_.Tensor,
+#     aten.mul.out,
+# ]
 
-def pointwise_strategy(op_schema: OpSchema, linearity: bool = False) -> OpStrategy:
-    max_shards_strategy_index = -1
+# the linear pointwise ops map, key is op, value is the type of linearity
+linear_pointwise_ops = {
+    aten.to.dtype: 0,
+    aten.div.Scalar: 1,
+    aten.div_.Scalar: 1,
+    aten.add.Tensor: 1,
+    aten.add_.Tensor: 1,
+    aten.mul.Scalar: 0,
+    aten.mul_.Scalar: 0,
+    aten.mul.Tensor: 2,
+    aten.mul_.Tensor: 2,
+}
+
+
+def pointwise_strategy(op_schema: OpSchema, linearity: int = -1) -> OpStrategy:
+    followed_strategy_index = -1
     max_shards = -1
     max_ndim = -1
 
     if op_schema.is_inplace_op():
         # inplace op should follow the first arg strategy
         followed_strategy = op_schema.args_schema[0]
+        followed_strategy_index = 0
     elif op_schema.is_out_variant_op():
         # out variant op should follow the out kwarg strategy
         followed_strategy = op_schema.kwargs_schema["out"]
+        # out variant is technically a kwarg for the strategy to follow so it does not
+        # have an "index", we set it to a reasonably large number just to indicate it's
+        # not a valid index
+        followed_strategy_index = 100
     else:
         # normal pointwise op, we choose to follow the arg with
         # the max shards in case operands needs reshard
@@ -442,33 +460,67 @@ def pointwise_strategy(op_schema: OpSchema, linearity: bool = False) -> OpStrate
             if (arg_max_shards > max_shards) or (
                 arg_max_shards == max_shards and arg_max_ndim > max_ndim
             ):
-                max_shards_strategy_index = idx
+                followed_strategy_index = idx
                 max_shards = arg_max_shards
                 max_ndim = arg_max_ndim
 
-        followed_strategy = op_schema.args_schema[max_shards_strategy_index]
+        followed_strategy = op_schema.args_schema[followed_strategy_index]
 
     assert isinstance(followed_strategy, OpStrategy), (
         f"no strategy to follow for {op_schema}!"
     )
     return common_pointwise_strategy(
-        op_schema.args_schema, followed_strategy, linearity
+        op_schema.args_schema,
+        followed_strategy,
+        followed_strategy_index,
+        linearity,
     )
+
+
+def linear_pointwise_strategy(op_schema: OpSchema) -> StrategyType:
+    """
+    Linear pointwise operators can propagate pending reductions.
+    For example, c = add(a, b); if a is pending sum, then c will be
+    pending sum as well without any communication overhead.
+
+    Note that there're multiple types of linearity, refer to the
+    doc of common_pointwise_strategy for more details.
+    """
+    linearity_type = linear_pointwise_ops.get(op_schema.op, -1)
+    return pointwise_strategy(op_schema, linearity=linearity_type)
 
 
 def common_pointwise_strategy(
     args_schema: Sequence[object],
     followed_strategy: OpStrategy,
-    linearity: bool,
+    followed_strategy_index: int,
+    linearity: int = -1,
 ) -> OpStrategy:
+    """
+    Common strategy for pointwise operations.
+
+    Args:
+        args_schema: Input arguments schema
+        followed_strategy: Strategy to follow for output placement
+        followed_strategy_index: Index of the strategy being followed
+        linearity: depending on the operator, we support different types of linearity
+            -1: the operation does not support linearity
+            0: the unary operation that supports linearity, output propagates partial.
+            1: the binary operation supports add linearity, where it requires every operand
+                to be partial, output propagates partial.
+            2: the binary operation supports multiplicative linearity, where it requires
+                the primary operand to be partial, and the other operands to be replicate,
+                output propagates partial.
+    """
     # handle broadcasting
     common_shape = torch.broadcast_shapes(
         *[arg.shape for arg in args_schema if isinstance(arg, OpStrategy)]
     )
     pointwise_strategy = OpStrategy([])
 
-    for placement_strategy in followed_strategy.strategies:
-        spec_to_follow = placement_strategy.output_spec
+    for op_spec in followed_strategy.strategies:
+        spec_to_follow = op_spec.output_specs
+
         out_placements: list[Placement] = []
         for placement in spec_to_follow.placements:
             if isinstance(placement, Shard):
@@ -476,17 +528,25 @@ def common_pointwise_strategy(
                 common_ndim = len(common_shape)
                 new_shard_dim = common_ndim - len(spec_to_follow.shape) + shard_dim
                 out_placements.append(Shard(new_shard_dim))
-            elif isinstance(placement, Partial) and not linearity:
-                # clear the partial placemnet if op does not support linearity
-                # by default we just replicate the partial, need to see if this
-                # is optimal for all cases
-                out_placements.append(Replicate())
+            elif isinstance(placement, Partial):
+                # note that only partial-sum and partial-avg are supported for linearity
+                partial_supports_linearity = placement.is_partial(
+                    "sum"
+                ) or placement.is_partial("avg")
+                if linearity > 0 and partial_supports_linearity:
+                    # propagate the partial placement
+                    out_placements.append(placement)
+                else:
+                    # clear the partial placement if op does not support linearity
+                    # by default we just replicate the partial, need to see if this
+                    # is optimal for all cases
+                    out_placements.append(Replicate())
             else:
                 out_placements.append(placement)
 
         input_specs: list[DTensorSpec] = []
         redistribute_costs: list[list[float]] = []
-        for arg_idx, input_arg in enumerate(args_schema):
+        for input_idx, input_arg in enumerate(args_schema):
             if isinstance(input_arg, OpStrategy):
                 # sanity check that all args that follow the same strategy
                 # are on the same DeviceMesh
@@ -501,11 +561,21 @@ def common_pointwise_strategy(
                 input_arg_dims_map = infer_broadcast_dims_map(
                     common_shape, input_arg_spec.shape
                 )
+
+                # Determine if this input should convert Partial to Replicate base on linearity
+                should_convert_partial = (
+                    linearity == 2
+                    and input_idx
+                    != followed_strategy_index  # Don't convert the "followed" strategy
+                )
+
                 input_target_placements = map_placements_after_broadcast(
                     tuple(out_placements),
                     common_shape,
                     input_arg_dims_map,
+                    partial_to_replicate=should_convert_partial,
                 )
+
                 input_arg_target_spec = DTensorSpec(
                     mesh=followed_strategy.mesh,
                     placements=input_target_placements,
@@ -529,16 +599,7 @@ def common_pointwise_strategy(
     return pointwise_strategy
 
 
-def linear_pointwise_strategy(op_schema: OpSchema) -> StrategyType:
-    """
-    Linear pointwise operators can propagate pending reductions.
-    For example, c = add(a, b); if a is pending sum, then c will be
-    pending sum as well without any communication overhead.
-    """
-    return pointwise_strategy(op_schema, linearity=True)
-
-
-for op in linear_pointwise_ops:
+for op in linear_pointwise_ops.keys():
     register_op_strategy(op, schema_info=RuntimeSchemaInfo(static_kwargkey=["out"]))(
         linear_pointwise_strategy
     )

--- a/torch/distributed/tensor/_ops/_pointwise_ops.py
+++ b/torch/distributed/tensor/_ops/_pointwise_ops.py
@@ -403,26 +403,13 @@ pointwise_ops = [
     aten.threshold_backward.default,
 ]
 
-# linear_pointwise_ops = [
-#     aten.div.Scalar,  # this op is linear on the first argument, and the second argument is scalar, so it fits as a linear op.
-#     aten.div_.Scalar,  # this op is linear on the first argument, and the second argument is scalar, so it fits as a linear op.
-#     aten.to.dtype,
-#     aten.add.Tensor,
-#     aten.add_.Tensor,
-#     aten.mul.Scalar,
-#     aten.mul_.Scalar,
-#     aten.mul.Tensor,
-#     aten.mul_.Tensor,
-#     aten.mul.out,
-# ]
-
 # the linear pointwise ops map, key is op, value is the type of linearity
 linear_pointwise_ops = {
     aten.to.dtype: 0,
-    aten.div.Scalar: 1,
-    aten.div_.Scalar: 1,
     aten.add.Tensor: 1,
     aten.add_.Tensor: 1,
+    aten.div.Scalar: 0,
+    aten.div_.Scalar: 0,
     aten.mul.Scalar: 0,
     aten.mul_.Scalar: 0,
     aten.mul.Tensor: 2,
@@ -483,8 +470,11 @@ def linear_pointwise_strategy(op_schema: OpSchema) -> StrategyType:
     For example, c = add(a, b); if a is pending sum, then c will be
     pending sum as well without any communication overhead.
 
-    Note that there're multiple types of linearity, refer to the
-    doc of common_pointwise_strategy for more details.
+    Note that:
+    1. Only unary and binary operations are supported, out variant
+      ops are not supported.
+    2. There're multiple types of linearity, refer to the doc of
+      common_pointwise_strategy for more details.
     """
     linearity_type = linear_pointwise_ops.get(op_schema.op, -1)
     return pointwise_strategy(op_schema, linearity=linearity_type)

--- a/torch/distributed/tensor/_ops/utils.py
+++ b/torch/distributed/tensor/_ops/utils.py
@@ -196,11 +196,18 @@ def map_placements_after_broadcast(
     placements: tuple[Placement, ...],
     shape: torch.Size,
     broadcast_dims_map: list[int],
+    partial_to_replicate: bool = False,
 ) -> tuple[Placement, ...]:
     """Map each placement based on the output shape after broadcast."""
     new_placements: list[Placement] = []
     for placement in placements:
-        if isinstance(placement, (Replicate, Partial)):
+        if isinstance(placement, Partial):
+            if partial_to_replicate:
+                # map the partial placement to replicate
+                new_placements.append(Replicate())
+            else:
+                new_placements.append(placement)
+        elif isinstance(placement, Replicate):
             new_placements.append(placement)
         else:
             assert isinstance(placement, Shard)

--- a/torch/distributed/tensor/placement_types.py
+++ b/torch/distributed/tensor/placement_types.py
@@ -41,8 +41,10 @@ class Placement:
     def is_replicate(self) -> bool:
         return isinstance(self, Replicate)
 
-    def is_partial(self) -> bool:
-        return isinstance(self, Partial)
+    def is_partial(self, reduce_op: Optional[str] = None) -> bool:
+        if reduce_op is None:
+            return isinstance(self, Partial)
+        return isinstance(self, Partial) and self.reduce_op == reduce_op
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
I am trying to see if I can easily add the linearity support for aten.mul to allow Partial placement to propagate through. But it turns out that I have to completely rework the current linearity propagation.

In short, before this PR, linearity mainly support aten.add and some trival ops. It is done by allowing input Partial to propagate, and in the meanwhile, redistribute Replicate inputs to Partial to preserve the single device semantic, i.e suppose we want to execute `aten.add(lhs, rhs)` on 2 ranks:
* `lhs` is partial, value on rank 0: `r0`, lhs value on rank 1: `r1`
* `rhs` is replicate, value: `a`

Then in order to preserve single device semantic (which should produce the value of `a + r0 + r1`), we do `rhs/world_size` first, then add `rhs` to `lhs`. This means every operand would first need be partial, then we can add them together.

But this become non-true for multiplicative operations, like `aten.mul`, for `aten.mul`, assuming the same `aten.mul(lhs, rhs)` and value, we don't need to divide lhs by world_size to preserve single device semantic, b.c. `a* (r0+r1) = a* r0 + a* r1`

So to accomodate the difference of add/mul, in this PR I:
* change linearity to be a int to support different linearity types, add linearity and multiplicative are separate
* add checks to ensure only a subset of partial types can support linearity (namely partial-sum/avg)
* handle the linearity type plumbing through the pointwise ops.
* add `mul.Tensor/Scalar` to be the multiplicative linearity
* added the tests to show that the partial placements can be propagated with `aten.mul`

Fixes #ISSUE_NUMBER


cc @H-Huang @awgu @fegin @fduwjj @wz337 @wconstab @d4l3k