### PR TITLE
Update `is_sparse` doc to mention that it is sparse_coo specific

### DIFF
--- a/torch/_linalg_utils.py
+++ b/torch/_linalg_utils.py
@@ -2,7 +2,6 @@
 """Various linear algebra utility methods for internal use."""
 
 from typing import Optional
-import warnings
 
 import torch
 from torch import Tensor

--- a/torch/_linalg_utils.py
+++ b/torch/_linalg_utils.py
@@ -11,16 +11,7 @@ from torch import Tensor
 def is_sparse(A):
     """Check if tensor A is a sparse COO tensor. All other sparse storage formats (CSR, CSC, etc...) will return False."""
     if isinstance(A, torch.Tensor):
-        layout = A.layout
-
-        if layout == torch.sparse_coo:
-            return True
-
-        if layout in (torch.sparse_csr, torch.sparse_csc, torch.sparse_bsr):
-            warnings.warn(
-                "`is_sparse` will always return False for non-COO sparse tensors.",
-                category=UserWarning
-            )
+        return A.layout == torch.sparse_coo
 
     error_str = "expected Tensor"
     if not torch.jit.is_scripting():

--- a/torch/_linalg_utils.py
+++ b/torch/_linalg_utils.py
@@ -2,6 +2,7 @@
 """Various linear algebra utility methods for internal use."""
 
 from typing import Optional
+import warnings
 
 import torch
 from torch import Tensor
@@ -10,7 +11,16 @@ from torch import Tensor
 def is_sparse(A):
     """Check if tensor A is a sparse tensor"""
     if isinstance(A, torch.Tensor):
-        return A.layout == torch.sparse_coo
+        layout = A.layout
+
+        if layout == torch.sparse_coo:
+            return True
+
+        if layout in (torch.sparse_csr, torch.sparse_csc, torch.sparse_bsr):
+            warnings.warn(
+                "`is_sparse` will always return False for non-COO sparse tensors.",
+                category=UserWarning
+            )
 
     error_str = "expected Tensor"
     if not torch.jit.is_scripting():

--- a/torch/_linalg_utils.py
+++ b/torch/_linalg_utils.py
@@ -9,7 +9,7 @@ from torch import Tensor
 
 
 def is_sparse(A):
-    """Check if tensor A is a sparse tensor"""
+    """Check if tensor A is a sparse COO tensor. All other sparse storage formats (CSR, CSC, etc...) will return False."""
     if isinstance(A, torch.Tensor):
         layout = A.layout
 


### PR DESCRIPTION
## Issue being addressed
`is_sparse` presents itself as determining if a tensor is sparse. HOWEVER, it only does checks against the tensor for `sparse_coo`. This has lead to confusion from developers as when non-coo sparse tensors are provided it return false, despite those tensors being sparse.

## Considered Remedy 
Fixing this is do-able however would result in complexity as existing systems may depend on this behavior remaining consistent, and even inside of pytorch is_sparse is used by `bform` which states that it supports only `sparse_csr and sparse_coo` meaning additional work/thought would have to go into solving for `sparse_csc` and `sparse_bsr`


## Remedy provided in this PR
In lieu of these complications the lowest risk highest gain action was to add clear warning messaging to the function for now to avoid confusion to developers utilizing the function. The rest of the function behavior remains identical

## Issue content
Addresses issue number: #101385
Original issue: https://github.com/pytorch/pytorch/issues/101385
