### PR TITLE
[inductor] Fix memory layout for concatenation of repeated input

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6130,6 +6130,8 @@ class CommonTemplate:
             fn,
             (torch.randn([1, 3, 3, 16]).to(memory_format=torch.channels_last),),
         )
+        # needs the exact_stride keydword arg from #144765
+        self.common(fn, (torch.randn([1, 2, 2]).transpose(1, 2),))
 
     def test_cat_uint8(self):
         def fn(x):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6136,6 +6136,7 @@ class CommonTemplate:
     def test_cat_strides(self):
         def fn(a):
             return torch.cat([a, a])
+
         self.common(fn, (torch.randn([1, 2, 2]).transpose(1, 2),), exact_stride=True)
 
     def test_cat_uint8(self):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6125,13 +6125,18 @@ class CommonTemplate:
         self.common(
             fn,
             (torch.randn([8, 16]),),
+            exact_stride=True,
         )
         self.common(
             fn,
             (torch.randn([1, 3, 3, 16]).to(memory_format=torch.channels_last),),
+            exact_stride=True,
         )
-        # needs the exact_stride keydword arg from #144765
-        self.common(fn, (torch.randn([1, 2, 2]).transpose(1, 2),))
+
+    def test_cat_strides(self):
+        def fn(a):
+            return torch.cat([a, a])
+        self.common(fn, (torch.randn([1, 2, 2]).transpose(1, 2),), exact_stride=True)
 
     def test_cat_uint8(self):
         def fn(x):

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -438,7 +438,13 @@ def cat(
         shape = list(inp.shape)
         dim = dim + len(inp.shape) if dim < 0 else dim
         shape.insert(dim, len(filtered_tensors))
-        return inp.unsqueeze(dim).expand(*shape).flatten(dim, dim + 1).clone()
+        memory_format = utils.suggest_memory_format(inp)
+        return (
+            inp.unsqueeze(dim)
+            .expand(*shape)
+            .flatten(dim, dim + 1)
+            .clone(memory_format=memory_format)
+        )
 
     # when no 'filtering' has occurred, we raise to prevent infinite recursion (no more decomposition needed)
     return NotImplemented


### PR DESCRIPTION
The optimization to `cat` introduced in https://github.com/pytorch/pytorch/pull/132081 is inconsistent with the behavior of eager mode, which converts non-standard memory layouts to contiguous.  This PR is dependent on https://github.com/pytorch/pytorch/pull/144765 to test for matching strides and will need to be updated once that is merged.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben