### PR TITLE
Fix a div_mod bug in generic_math.h

### DIFF
--- a/c10/test/util/generic_math_test.cpp
+++ b/c10/test/util/generic_math_test.cpp
@@ -14,4 +14,6 @@ TEST(GenericMathTest, div_floor_test) {
   EXPECT_DOUBLE_EQ(c10::div_floor_floating(5., -2.), -3.);
   EXPECT_EQ(c10::div_floor_integer(5, 2), 2);
   EXPECT_EQ(c10::div_floor_integer(5, -2), -3);
+  EXPECT_EQ(c10::div_mod(-9, -3), 0);
+  EXPECT_EQ(c10::div_mod(-9., -3.), 0.);
 }

--- a/c10/util/generic_math.h
+++ b/c10/util/generic_math.h
@@ -93,7 +93,7 @@ template <
     std::enable_if_t<std::is_integral_v<scalar_t>, int> = 0>
 inline C10_HOST_DEVICE scalar_t div_mod(scalar_t a, scalar_t b) {
   auto mod = a % b;
-  if ((b < 0) != (mod < 0)) {
+  if (mod != 0 && (b < 0) != (mod < 0)) {
     mod += b;
   }
   return mod;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #157383

Summary: There is a bug in integer div_mod that when the remainder is 0 and the divisor is negative, mod operation produces a negative number. Fixed in this PR.