### PR TITLE
[CI] Fixes CI for CUDA Version > 12.9

### DIFF
--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -329,9 +329,12 @@ class TestCppExtensionJIT(common.TestCase):
             archflags["Maxwell+Tegra;6.1"] = (["53", "61"], None)
             archflags["Volta"] = (["70"], ["70"]),
             archflags["5.0;6.0+PTX;7.0;7.5"] = (["50", "60", "70", "75"], ["60"])
-        else:
-            archflags["7.5"] = (["50", "60", "70", "75"], ["60"])
-
+        print()
+        print(archflags)
+        print()
+        print()
+        print()
+        print()
         if major < 12:
             # CUDA 12 drops compute capability < 5.0
             archflags["Pascal 3.5"] = (["35", "60", "61"], None)

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -333,6 +333,7 @@ class TestCppExtensionJIT(common.TestCase):
         if major < 12:
             # CUDA 12 drops compute capability < 5.0
             archflags["Pascal 3.5"] = (["35", "60", "61"], None)
+
         for flags, expected in archflags.items():
             try:
                 self._run_jit_cuda_archflags(flags, expected)

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -325,7 +325,8 @@ class TestCppExtensionJIT(common.TestCase):
         }
         archflags["7.5+PTX"] = (["75"], ["75"])
         major, minor = map(int, torch.version.cuda.split('.')[:2])
-        if major < 12 or (major == 12 and minor < 10):
+        if major < 12 or (major == 12 and minor <= 9):
+            # Compute capability <= 7.0 is only supported up to CUDA 12.9
             archflags["Maxwell+Tegra;6.1"] = (["53", "61"], None)
             archflags["Volta"] = (["70"], ["70"]),
             archflags["5.0;6.0+PTX;7.0;7.5"] = (["50", "60", "70", "75"], ["60"])

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -329,12 +329,6 @@ class TestCppExtensionJIT(common.TestCase):
             archflags["Maxwell+Tegra;6.1"] = (["53", "61"], None)
             archflags["Volta"] = (["70"], ["70"]),
             archflags["5.0;6.0+PTX;7.0;7.5"] = (["50", "60", "70", "75"], ["60"])
-        print()
-        print(archflags)
-        print()
-        print()
-        print()
-        print()
         if major < 12:
             # CUDA 12 drops compute capability < 5.0
             archflags["Pascal 3.5"] = (["35", "60", "61"], None)

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -322,15 +322,19 @@ class TestCppExtensionJIT(common.TestCase):
                 [f"{capability[0]}{capability[1]}" for capability in capabilities],
                 None,
             ),
-            "Maxwell+Tegra;6.1": (["53", "61"], None),
-            "Volta": (["70"], ["70"]),
         }
         archflags["7.5+PTX"] = (["75"], ["75"])
-        archflags["5.0;6.0+PTX;7.0;7.5"] = (["50", "60", "70", "75"], ["60"])
-        if int(torch.version.cuda.split(".")[0]) < 12:
+        major, minor = map(int, torch.version.cuda.split('.')[:2])
+        if major < 12 or (major == 12 and minor < 10):
+            archflags["Maxwell+Tegra;6.1"] = (["53", "61"], None)
+            archflags["Volta"] = (["70"], ["70"]),
+            archflags["5.0;6.0+PTX;7.0;7.5"] = (["50", "60", "70", "75"], ["60"])
+        else:
+            archflags["7.5"] = (["50", "60", "70", "75"], ["60"])
+
+        if major < 12:
             # CUDA 12 drops compute capability < 5.0
             archflags["Pascal 3.5"] = (["35", "60", "61"], None)
-
         for flags, expected in archflags.items():
             try:
                 self._run_jit_cuda_archflags(flags, expected)

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -324,11 +324,11 @@ class TestCppExtensionJIT(common.TestCase):
             ),
         }
         archflags["7.5+PTX"] = (["75"], ["75"])
-        major, minor = map(int, torch.version.cuda.split('.')[:2])
+        major, minor = map(int, torch.version.cuda.split(".")[:2])
         if major < 12 or (major == 12 and minor <= 9):
             # Compute capability <= 7.0 is only supported up to CUDA 12.9
             archflags["Maxwell+Tegra;6.1"] = (["53", "61"], None)
-            archflags["Volta"] = (["70"], ["70"]),
+            archflags["Volta"] = ((["70"], ["70"]),)
             archflags["5.0;6.0+PTX;7.0;7.5"] = (["50", "60", "70", "75"], ["60"])
         if major < 12:
             # CUDA 12 drops compute capability < 5.0

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -328,7 +328,7 @@ class TestCppExtensionJIT(common.TestCase):
         if major < 12 or (major == 12 and minor <= 9):
             # Compute capability <= 7.0 is only supported up to CUDA 12.9
             archflags["Maxwell+Tegra;6.1"] = (["53", "61"], None)
-            archflags["Volta"] = ((["70"], ["70"]),)
+            archflags["Volta"] = (["70"], ["70"])
             archflags["5.0;6.0+PTX;7.0;7.5"] = (["50", "60", "70", "75"], ["60"])
         if major < 12:
             # CUDA 12 drops compute capability < 5.0


### PR DESCRIPTION
Compute capabilities older than volta (inclusive) is no longer supported in CUDA Version > 12.9