### PR TITLE
Preserve current stream in TestCuda::test_stream_compatibility

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1109,6 +1109,7 @@ print(t.is_pinned())
         self.assertTrue(torch.Event in type(cuda_event).mro())
 
     def test_stream_compatibility(self):
+        original_stream = torch.cuda.current_stream()
         s1 = torch.cuda.Stream()
         s2 = torch.cuda.Stream()
         torch.accelerator.set_stream(s1)
@@ -1119,6 +1120,7 @@ print(t.is_pinned())
             RuntimeError, "Device index value .* is out of index range"
         ):
             torch.accelerator.current_stream(torch.accelerator.device_count())
+        torch.accelerator.set_stream(original_stream)
 
     def test_record_stream(self):
         cycles_per_ms = get_cycles_per_ms()


### PR DESCRIPTION
The `test_stream_compatibility` test leaves the current stream set to a user created stream.  The `test_streams` test fails if it runs after this because it expects the current stream to be the default stream.

Fixed by preserving the current stream in `test_stream_compatibility`.

For reference the relevant tests before the changes in this PR:

~~~py
def test_stream_compatibility(self):
    s1 = torch.cuda.Stream()
    s2 = torch.cuda.Stream()
    torch.accelerator.set_stream(s1)
    self.assertEqual(torch.accelerator.current_stream().stream_id, s1.stream_id)
    torch.accelerator.set_stream(s2)
    self.assertEqual(torch.accelerator.current_stream().stream_id, s2.stream_id)
    with self.assertRaisesRegex(
        RuntimeError, "Device index value .* is out of index range"
    ):
        torch.accelerator.current_stream(torch.accelerator.device_count())
~~~

~~~py
@skipCUDANonDefaultStreamIf(True)
def test_streams(self):
    default_stream = torch.cuda.current_stream()
    user_stream = torch.cuda.Stream()
    self.assertEqual(torch.cuda.current_stream(), default_stream)
    self.assertNotEqual(default_stream, user_stream)
    self.assertEqual(default_stream.cuda_stream, 0)
    self.assertNotEqual(user_stream.cuda_stream, 0)
    with torch.cuda.stream(user_stream):
        self.assertEqual(torch.cuda.current_stream(), user_stream)
    self.assertTrue(user_stream.query())
    tensor1 = torch.ByteTensor(5).pin_memory()
    default_stream.synchronize()
    self.assertTrue(default_stream.query())
~~~