### PR TITLE
Add a flag "realized" in IRNode to enable tracking origin_nodes

### DIFF
--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1772,6 +1772,13 @@ class GraphLowering(torch.fx.Interpreter):
                     if curr.has_large_inner_fn(threshold=100):
                         result.realize()
 
+        if (
+            isinstance(result, ir.TensorBox)
+            and isinstance(result.data, ir.StorageBox)
+            and isinstance(result.data.data, ir.ExternKernelOut)
+        ):
+            result.data.data.realized = True
+
         # This is not complete, but it doesn't have to be: origin_node
         # tracking is best effort.  The logic here critically relies on direct
         # TensorBox -> StorageBox denoting a non-view; we don't bother trying

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -798,7 +798,9 @@ def gather_origins(
             return is_unrealized_node(n.data)
         if isinstance(n, ir.StorageBox):
             return is_unrealized_node(n.data)
-        return isinstance(n, ir.IRNode) and isinstance(n, ir.Pointwise)
+        if isinstance(n, ir.InputBuffer):
+            return False
+        return isinstance(n, ir.IRNode) and not getattr(n, "realized", False)
 
     kwarg_origins = [val.origins for val in kwargs.values() if is_unrealized_node(val)]
     arg_origins = [arg.origins for arg in args if is_unrealized_node(arg)]


### PR DESCRIPTION
Summary:
This DIFF is to fix the following issue:

In python source code for CompiledFxGraph,the FX graph segment for the Triton kernel is broken. For example, the following function
    def fn(a, b, c):
        x = torch.nn.functional.linear(a, b)
        x = x.sin()
        x = x.t() + c
        return x
Inductor compiled this FX graph into two nodes: the first one is mm, the second one is a triton kernel for sin + transpose + add. The FX graph segment for the triton kernel is like the following:
Graph fragment:
%add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%permute_1, %arg2_1), kwargs = {})
Basically only "add" node in the FX graph.


The root cause is function caffe2/torch/_inductor/utils.py:gather_origins does not detect the realized node correctly. 

To fix this issue, a new flag "realized" is added into IRNode with initial value "False", when self.realized() is called, that flag is set. With this flag, inside function gather_origins, only need to check this flag to determine the node is a realized node or not.

Rollback Plan:

Differential Revision: D77638777




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben