### PR TITLE
Add legacy note to autograd.profiler doc.

### DIFF
--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -108,6 +108,10 @@ class _ProfilerStats:
 class profile:
     """Context manager that manages autograd profiler state and holds a summary of results.
 
+    .. note::
+        This is the legacy profiler and will be depreacted.
+        Consider using :mod:`torch.profiler`.
+
     Under the hood it just records events of functions being executed in C++ and
     exposes those events to Python. You can wrap any code into it and it will
     only report runtime of PyTorch functions.

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -109,8 +109,7 @@ class profile:
     """Context manager that manages autograd profiler state and holds a summary of results.
 
     .. note::
-        This is the legacy profiler and will be depreacted.
-        Consider using :mod:`torch.profiler`.
+        This is the backend, most people should use :mod:`torch.profiler` instead.
 
     Under the hood it just records events of functions being executed in C++ and
     exposes those events to Python. You can wrap any code into it and it will


### PR DESCRIPTION
Via google search I got to `torch.autograd.profiler` and implemented my code with it. Only to be taken by surprise finding `torch.profile.profiler`, which has a note saying the autograd one is legacy.

This just adds such note to `autograd.profiler` to avoid this confusion and waste of time to future people in my situation.