### PR TITLE
fixed a tiny typo in torch.compiler.md

### DIFF
--- a/docs/source/torch.compiler.md
+++ b/docs/source/torch.compiler.md
@@ -36,7 +36,7 @@ TorchDynamo requires a backend that converts the captured graphs into a fast
 machine code. Different backends can result in various optimization gains.
 The default backend is called TorchInductor, also known as *inductor*,
 TorchDynamo has a list of supported backends developed by our partners,
-which can be see by running `torch.compiler.list_backends()` each of which
+which can be seen by running `torch.compiler.list_backends()` each of which
 with its optional dependencies.
 
 Some of the most commonly used backends include:


### PR DESCRIPTION
Fixes #157444

there was a typo in [docs/source/torch.compiler.md](https://github.com/pytorch/pytorch/blob/main/docs/source/torch.compiler.md) : see -> seen