### PR TITLE
[PowerPC]: Fixed build issue that occur because of datatype f8 enablement for onednn in qlinear and prepack

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -1113,7 +1113,11 @@ static at::Tensor linear_int8_with_onednn_weight(
       );
     }
   }
-  if (is_fp8 && !cpuinfo_has_x86_amx_int8()) {
+#if defined(__powerpc__)
+  if (is_fp8) {
+#else
+  if(is_fp8 && !cpuinfo_has_x86_amx_int8()) {
+#endif
     // Fall back to ref impl on old platforms because not supported
     return fp8_qlinear_onednn_ref(
         input, input_scale, onednn_weight, weight_scales, bias,

--- a/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
@@ -302,7 +302,11 @@ static inline at::Tensor pack_weight_to_onednn_tensor(
     weigh_dtype == at::kChar || weigh_dtype == at::kFloat8_e4m3fn,
     "Weight should be of type int8 or float8_e4m3fn");
   bool is_fp8 = weigh_dtype == at::kFloat8_e4m3fn;
-  if (is_fp8 && !cpuinfo_has_x86_amx_int8()) {
+#if defined(__powerpc__)
+  if (is_fp8){
+#else
+    if(is_fp8 && !cpuinfo_has_x86_amx_int8()) {
+#endif
     // oneDNN's fp8 requires AMX support
     // If AMX is not available, fall back to reference implementation
     return weight;


### PR DESCRIPTION
Getting the build issue because of enablement of data type fp8 for onednn in qlinear and qlinear_prepack file after this commit c2185dc4a5626848df37cad214b73d5ae7dd4f17

Currrently cpuinfo is disable for power system because of that  it is giving below error. 

**Error:**
 ‘cpuinfo_has_x86_amx_int8’ was not declared in this scope
 
Made a required changes and now build issue got fixed.



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168