### PR TITLE
Fix typo: 'tracable' → 'traceable' in torch/_dynamo/variables/torch.py

### DIFF
--- a/torch/_dynamo/create_parameter_op.py
+++ b/torch/_dynamo/create_parameter_op.py
@@ -18,7 +18,7 @@ allowed to compute gradients on).
 """.strip()
 
 
-class TracableCreateParameter(torch.autograd.Function):
+class TraceableCreateParameter(torch.autograd.Function):
     @staticmethod
     def forward(ctx: Any, tensor: Any, placeholder: Any) -> torch.nn.Parameter:
         assert not tensor.requires_grad
@@ -30,11 +30,11 @@ class TracableCreateParameter(torch.autograd.Function):
         return None, grad  # grad flows to placeholder
 
 
-def tracable_create_parameter(
+def traceable_create_parameter(
     tensor: torch.Tensor, placeholder: torch.nn.Parameter
 ) -> torch.nn.Parameter:
     with torch.set_grad_enabled(placeholder.requires_grad):
-        out = TracableCreateParameter.apply(tensor, placeholder)
+        out = TraceableCreateParameter.apply(tensor, placeholder)
     return out
 
 
@@ -55,14 +55,14 @@ _TLS = threading.local()
 
 
 @contextmanager
-def do_not_convert_to_tracable_parameter() -> Generator[bool, None, None]:
-    old_flag = getattr(_TLS, "convert_tracable_parameter", True)
-    _TLS.convert_tracable_parameter = False
+def do_not_convert_to_traceable_parameter() -> Generator[bool, None, None]:
+    old_flag = getattr(_TLS, "convert_traceable_parameter", True)
+    _TLS.convert_traceable_parameter = False
     try:
         yield False
     finally:
-        _TLS.convert_tracable_parameter = old_flag
+        _TLS.convert_traceable_parameter = old_flag
 
 
-def can_convert_to_tracable_parameter() -> bool:
-    return getattr(_TLS, "convert_tracable_parameter", True)
+def can_convert_to_traceable_parameter() -> bool:
+    return getattr(_TLS, "convert_traceable_parameter", True)

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -47,9 +47,9 @@ from torch.utils._python_dispatch import is_traceable_wrapper_subclass_type
 from .. import config, graph_break_hints, polyfills, variables
 from ..codegen import PyCodegen
 from ..create_parameter_op import (
-    can_convert_to_tracable_parameter,
+    can_convert_to_traceable_parameter,
     new_parameter_placeholder,
-    tracable_create_parameter,
+    traceable_create_parameter,
 )
 from ..device_interface import get_registered_device_interfaces
 from ..exc import unimplemented, unimplemented_v2
@@ -1475,7 +1475,7 @@ Either create the tensor outside the compiled region, or do not set the tensor t
         ) or is_traceable_wrapper_subclass_type(data.class_type):
             unimplemented("Parameter constructor with tensor subclass NYI")
 
-        if not can_convert_to_tracable_parameter():
+        if not can_convert_to_traceable_parameter():
             unimplemented("Workaround for issues with nn_parameter construction")
 
         try:
@@ -1497,7 +1497,7 @@ Either create the tensor outside the compiled region, or do not set the tensor t
             tx,
             tx.output.create_proxy(
                 "call_function",
-                tracable_create_parameter,
+                traceable_create_parameter,
                 (data.as_proxy(), placeholder.as_proxy()),
                 {},
             ),
@@ -1509,7 +1509,7 @@ Either create the tensor outside the compiled region, or do not set the tensor t
         result.class_type = torch.nn.Parameter
 
         # TODO(jansel/bdhirsh) - There is some issue with
-        # tracable_create_paramter. It does not seem to use the right
+        # traceable_create_paramter. It does not seem to use the right
         # grad_enabled. Since this is parameter, we can just override the
         # has_grad_fn field to False to workaround the issue.
         result.has_grad_fn = False


### PR DESCRIPTION
Description:

This PR fixes a few minor typographical errors in torch/_dynamo/variables/torch.py:

Corrects occurrences of tracable to the correct spelling traceable in:

Function names

Import statements

Code comments

These changes are purely cosmetic and do not affect functionality. They improve overall code readability and maintain consistency in naming.

Thank you to all PyTorch maintainers and contributors for your incredible work and the opportunity to contribute. Please let me know if any revisions are needed.






