### PR TITLE
[BE] Remove extra semicolon

### DIFF
--- a/torch/nativert/executor/GraphExecutorBase.cpp
+++ b/torch/nativert/executor/GraphExecutorBase.cpp
@@ -13,7 +13,7 @@ GraphExecutorBase::GraphExecutorBase(
     : graph_(graph),
       nodeKernels_(std::move(nodeKernels)),
       executorConfig_(executorConfig),
-      execPlan_(ExecutionPlanner{graph_}.createPlan()) {};
+      execPlan_(ExecutionPlanner{graph_}.createPlan()) {}
 
 void GraphExecutorBase::fillUserInputs(
     ExecutionFrame& frame,


### PR DESCRIPTION
Fixes
```
/Users/nshulga/git/pytorch/pytorch/torch/nativert/executor/GraphExecutorBase.cpp:16:58: warning: extra ';' outside of a function is incompatible with C++98 [-Wc++98-compat-extra-semi]
   16 |       execPlan_(ExecutionPlanner{graph_}.createPlan()) {};
      |                                                          ^
1 warning generated.

```
