### PR TITLE
[dynamo] Prevent unnecessary recompilation, when using disable inside of compile

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -593,6 +593,14 @@ class ConvertFrameAssert:
         if not has_tensor_in_frame(frame):
             return ConvertFrameReturn()
 
+        # Don't recompile when torch._dynamo.disable decorator is used
+        if (isinstance(code.co_names, tuple)
+            and len(code.co_names) == 3
+            and code.co_names[0] == "torch"
+            and code.co_names[1] == "_dynamo"
+            and code.co_names[2] == "disable"):
+            return ConvertFrameReturn()
+
         # skip tracing non-recursive disabled functions
         # detect if the previous frame (non-convert_frame) is a non-recursive disable wrapper
         prev_frame = sys._getframe()


### PR DESCRIPTION
Fixes #157399 by skipping convert_frame._compile for functions with `code.co_names` equal to `(torch, _dynamo, disable)`

It's my naive first approach and my first PR to PyTorch. I tested it locally on simple tensors and seem to work fine. I'll be grateful for a further guidance with improving the fix and adding unit tests. 

Thanks!

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames