### PR TITLE
Add test for user-managed weights with load_state_dict

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -5840,6 +5840,40 @@ class AOTInductorTestsTemplate:
         )
         self.assertEqual(new_expected, new_output)
 
+    def test_user_managed_weights_reflect_load_state_dict(self):
+        class SimpleModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 4)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        model = SimpleModel().eval()
+        input_tensor = torch.randn(2, 4)
+        exported = torch._export.aot_compile(model, (input_tensor,))
+        compiled_model = exported.model
+        weight_tensors = [p for p in model.parameters()]
+        torch._C._aoti.update_constant_buffer(
+            compiled_model,
+            weight_tensors,
+            user_index=0,
+            is_user_random=False,
+            user_managed=True,
+        )
+        output_before = compiled_model(input_tensor)
+        new_state_dict = {
+            "linear.weight": torch.ones_like(model.linear.weight),
+            "linear.bias": torch.zeros_like(model.linear.bias),
+        }
+        model.load_state_dict(new_state_dict)
+        output_after = compiled_model(input_tensor)
+        expected_output = model(input_tensor)
+        torch.testing.assert_close(output_after, expected_output)
+
+        with self.assertRaises(AssertionError):
+            torch.testing.assert_close(output_before, output_after)
+
     def test_cond_share_predicte(self):
         class Model(torch.nn.Module):
             def forward(self, predicate, x):

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -5841,6 +5841,9 @@ class AOTInductorTestsTemplate:
         self.assertEqual(new_expected, new_output)
 
     def test_user_managed_weights_reflect_load_state_dict(self):
+        if self.device != "cuda":
+            raise unittest.SkipTest("requires CUDA")
+
         class SimpleModel(torch.nn.Module):
             def __init__(self):
                 super().__init__()


### PR DESCRIPTION
Summary:
Adds a unit test to verify that when 'user_managed=True' is passed to 'update_constant_buffer', the compiled AOTI model properly shares parameter storage with the eager model.

The test specifically covers the following:
1. Passes model weights to the AOTI model with 'user_managed=True''.
2. Updates the eager model weights using 'load_state_dict()', which performs in-place
3. Asserts that the compiled AOTI model reflects the updated weights, confirming shared memory behavior.

Fixes: #157474


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov