### PR TITLE
[1/N] cost coverage improvment

### DIFF
--- a/torch/distributed/tensor/_ops/_random_ops.py
+++ b/torch/distributed/tensor/_ops/_random_ops.py
@@ -31,6 +31,12 @@ def random_op_strategy(op_schema: OpSchema) -> StrategyType:
         if is_tensor_partial(arg_spec):
             # TODO: figure out how inplace random op should behave when it's partial
             raise RuntimeError(f"{op_schema.op} with Partial is not supported yet!")
-        random_strategy.strategies.append(OpSpec(output_specs=arg_spec))
+        random_strategy.strategies.append(
+            OpSpec(
+                output_specs=arg_spec,
+                input_specs=(arg_spec,),
+                redistribute_cost=[[0.0] * len(self_strategy.strategies)],
+            )
+        )
 
     return random_strategy

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -44,6 +44,18 @@ def default_strategy(op_schema: OpSchema) -> StrategyType:
     assert isinstance(select_strategy, OpStrategy)
     # we create new DTensorSpecs even for default strategy to assure that
     # the tensor metas are distinct between the arguments and outputs
+    input_specs = []
+    redistribute_cost = []
+    for i in op_schema.args_schema:
+        input_specs.append(
+            DTensorSpec(
+                mesh=select_strategy.mesh,
+                placements=select_strategy.strategies[0].output_spec.placements,
+                tensor_meta=select_strategy.strategies[0].output_spec.tensor_meta,
+            )
+        )
+        redistribute_cost.append([0.0] * len(select_strategy.strategies))
+
     default_strategy = [
         OpSpec(
             output_specs=DTensorSpec(
@@ -51,14 +63,8 @@ def default_strategy(op_schema: OpSchema) -> StrategyType:
                 placements=strategy.output_spec.placements,
                 tensor_meta=strategy.output_spec.tensor_meta,
             ),
-            input_specs=[
-                DTensorSpec(
-                    mesh=select_strategy.mesh,
-                    placements=strategy.output_spec.placements,
-                    tensor_meta=strategy.output_spec.tensor_meta,
-                )
-            ],
-            redistribute_cost=[[0.0] * len(select_strategy.strategies)],
+            input_specs=input_specs,
+            redistribute_cost=redistribute_cost,
         )
         for strategy in select_strategy.strategies
     ]

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -49,7 +49,16 @@ def default_strategy(op_schema: OpSchema) -> StrategyType:
             output_specs=DTensorSpec(
                 mesh=select_strategy.mesh,
                 placements=strategy.output_spec.placements,
-            )
+                tensor_meta=strategy.output_spec.tensor_meta,
+            ),
+            input_specs=[
+                DTensorSpec(
+                    mesh=select_strategy.mesh,
+                    placements=strategy.output_spec.placements,
+                    tensor_meta=strategy.output_spec.tensor_meta,
+                )
+            ],
+            redistribute_cost=[[0.0] * len(select_strategy.strategies)],
         )
         for strategy in select_strategy.strategies
     ]
@@ -191,7 +200,7 @@ def new_factory_strategy(op_schema: OpSchema) -> StrategyType:
             OpSpec(
                 output_specs=replica_spec,
                 input_specs=(input_spec,),
-                redistribute_cost=[[0.0] * mesh.ndim],
+                redistribute_cost=[[0.0] * len(input_strategy.strategies)],
             )
         )
 
@@ -209,7 +218,7 @@ def new_factory_strategy(op_schema: OpSchema) -> StrategyType:
                     output_specs=input_spec,
                     input_specs=(input_spec,),
                     # encouraging new tensor placement to be the same as input
-                    redistribute_cost=[[-0.1] * mesh.ndim],
+                    redistribute_cost=[[-0.1] * len(input_strategy.strategies)],
                 )
             )
 
@@ -220,14 +229,30 @@ def new_factory_strategy(op_schema: OpSchema) -> StrategyType:
 def gen_bucketize_strategy(op_schema: OpSchema) -> StrategyType:
     """Just propagate input sharding, but expect replicated for boundaries input."""
     mesh = op_schema.get_mesh_from_args()
-    input_strategy = op_schema.args_schema[0]
+    input_strategy, boundaries_strategy = op_schema.args_schema
     bucketize_strategy = OpStrategy([])
     assert isinstance(input_strategy, OpStrategy)
+    assert isinstance(boundaries_strategy, OpStrategy)
     for arg_strategy in input_strategy.strategies:
-        arg_spec = DTensorSpec(mesh, arg_strategy.output_spec.placements)
-        replica_spec = DTensorSpec(mesh, tuple([Replicate()] * mesh.ndim))
+        arg_spec = DTensorSpec(
+            mesh,
+            arg_strategy.output_spec.placements,
+            arg_strategy.output_spec.tensor_meta,
+        )
+        replica_spec = DTensorSpec(
+            mesh,
+            tuple([Replicate()] * mesh.ndim),
+            boundaries_strategy.strategies[0].output_spec.tensor_meta,
+        )
         bucketize_strategy.strategies.append(
-            OpSpec(output_specs=arg_spec, input_specs=(arg_spec, replica_spec))
+            OpSpec(
+                output_specs=arg_spec,
+                input_specs=(arg_spec, replica_spec),
+                redistribute_cost=[
+                    generate_redistribute_costs(input_strategy, arg_spec),
+                    generate_redistribute_costs(boundaries_strategy, replica_spec),
+                ],
+            )
         )
 
     return bucketize_strategy
@@ -667,12 +692,20 @@ def stack_strategy(op_schema: OpSchema) -> StrategyType:
 
     follow_placements = normalize_shard_for_stack(follow_placements, dim)
 
-    op_strategy.strategies.append(
-        OpSpec(
-            output_specs=DTensorSpec(mesh, tuple(follow_placements)),
-            input_specs=input_specs,
+    for strategy in input_tuple_strategy.childs:
+        assert isinstance(strategy, OpStrategy)
+        output_spec = DTensorSpec(mesh, tuple(follow_placements))
+        redistribute_cost = []
+        for input_spec in input_specs:
+            cost = generate_redistribute_costs(strategy, input_spec)
+            redistribute_cost.append(cost)
+        op_strategy.strategies.append(
+            OpSpec(
+                output_specs=output_spec,
+                input_specs=input_specs,
+                redistribute_cost=redistribute_cost,
+            )
         )
-    )
     return op_strategy
 
 

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -698,7 +698,7 @@ def stack_strategy(op_schema: OpSchema) -> StrategyType:
 
     follow_placements = normalize_shard_for_stack(follow_placements, dim)
 
-    for strategy in input_tuple_strategy.childs:
+    for strategy in input_tuple_strategy.children:
         assert isinstance(strategy, OpStrategy)
         output_spec = DTensorSpec(mesh, tuple(follow_placements))
         redistribute_cost = []


### PR DESCRIPTION
Part of plan https://github.com/pytorch/pytorch/issues/157495.

Details:
1. Fill missing redistribute_cost for ops like `aten::detach`, `aten::bernoulli `, `aten::_to_copy`, `aten::bucketize.Tensor`, `aten::stack`, `aten::clone`, `aten::copy_`, `aten::zero_ `. 
2.  Fix redistribute_cost error in new_factory_strategy.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k