### PR TITLE
[refactor][dynamo] make BUILD_TUPLE instruction use inst.arg

### DIFF
--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -2373,7 +2373,7 @@ class InstructionTranslatorBase(
         obj.call_method(self, "__delitem__", [key], {})
 
     def BUILD_TUPLE(self, inst):
-        items = self.popn(inst.argval)
+        items = self.popn(inst.arg)
         self.push(TupleVariable(items))
 
     def BUILD_SLICE(self, inst):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #157161
* #156869
* #157511
* __->__ #157505
* #157159

Before the PR, dynamo symbolic convert BUILD_TUPLE by looking at inst.argval. This is fine for Instructions from original code, which have both arg and argval set to n.  However, all BUILD_TUPLE instructions dynamo created sets arg instead of argval. This PR changes the logic by looking at the arg instead of argval so that the instructions dynamo created can be interpreted by itself.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela