### PR TITLE
Fix typo: 'reset_paramteres' → 'reset_parameters' in transformer.cpp

### DIFF
--- a/torch/csrc/api/src/nn/modules/transformer.cpp
+++ b/torch/csrc/api/src/nn/modules/transformer.cpp
@@ -145,7 +145,7 @@ void TransformerDecoderLayerImpl::reset_parameters() {
   multihead_attn->_reset_parameters();
 
   linear1->reset_parameters();
-  // dropout->reset_paramteres();
+  // dropout->reset_parameters();
   linear2->reset_parameters();
 
   norm1->reset_parameters();
@@ -153,7 +153,7 @@ void TransformerDecoderLayerImpl::reset_parameters() {
   norm3->reset_parameters();
   // dropout1->reset_parameters();
   // dropout2->reset_parameters();
-  // dropout3->reset_paramteres();
+  // dropout3->reset_parameters();
 }
 
 /// Pass the inputs (and mask) through the decoder layer.


### PR DESCRIPTION
This PR corrects a typo in `torch/csrc/api/src/nn/modules/transformer.cpp`:
- `reset_paramteres` → `reset_parameters`

Thanks to the reviewers for their time!

