### PR TITLE
handling special case for pow(3) for GPU

### DIFF
--- a/aten/src/ATen/native/cuda/ForeachFunctors.cuh
+++ b/aten/src/ATen/native/cuda/ForeachFunctors.cuh
@@ -723,6 +723,9 @@ struct TernaryOpScalarListFunctor {
 template <typename T>
 struct power_functor {
   C10_DEVICE T operator()(const T& a, const T& b) const {
+    if (b == static_cast<T>(3)) {
+      return a * a * a;
+    }
     return at::native::pow_(a, b);
   }
 };

--- a/aten/src/ATen/native/cuda/PowKernel.cu
+++ b/aten/src/ATen/native/cuda/PowKernel.cu
@@ -191,6 +191,12 @@ void pow_tensor_scalar_kernel(TensorIteratorBase& iter, const Scalar& exp_scalar
         });
         return;
       }
+      if (exp_scalar.equal(3.0)) {
+        gpu_kernel(iter, [=]GPU_LAMBDA(scalar_t base) -> scalar_t {
+          return base * base * base;
+        });
+        return;
+      }
       const auto exp = exp_scalar.to<scalar_t>();
       gpu_kernel(iter, [=]GPU_LAMBDA(scalar_t base) -> scalar_t {
         return pow_(base, exp);

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -1694,12 +1694,10 @@ class TestBinaryUfuncs(TestCase):
         cuda_out1 = t.pow(2)
         cpu_out1 = t.cpu().pow(2)
         self.assertEqual(cpu_out1, cuda_out1)
-
         # Test pow(3)
         cuda_out2 = t.pow(3)
         cpu_out2 = t.cpu().pow(3)
         self.assertEqual(cpu_out2, cuda_out2)
-
 
     @skipIfTorchDynamo()
     @onlyNativeDeviceTypes

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -1690,9 +1690,12 @@ class TestBinaryUfuncs(TestCase):
     @dtypes(torch.complex64, torch.complex128)
     def test_pow_cuda_complex_extremal_passing(self, device, dtype):
         t = torch.tensor(complex(-1.0, float("inf")), dtype=dtype, device=device)
-        cuda_out = t.pow(2)
-        cpu_out = t.cpu().pow(2)
-        self.assertEqual(cpu_out, cuda_out)
+
+        # Test pow(2) and pow(3)
+        for i in [2, 3]:
+            cuda_out = t.pow(i)
+            cpu_out = t.cpu().pow(i)
+            self.assertEqual(cpu_out, cuda_out)
 
     @skipIfTorchDynamo()
     @onlyNativeDeviceTypes

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -1689,12 +1689,17 @@ class TestBinaryUfuncs(TestCase):
     @onlyCUDA
     @dtypes(torch.complex64, torch.complex128)
     def test_pow_cuda_complex_extremal_passing(self, device, dtype):
-        # Test pow(2) and pow(3)
-        for i in [2, 3]:
-            t = torch.tensor(complex(-1.0, float("inf")), dtype=dtype, device=device)
-            cuda_out = t.pow(i)
-            cpu_out = t.cpu().pow(i)
-            self.assertEqual(cpu_out, cuda_out)
+        t = torch.tensor(complex(-1.0, float("inf")), dtype=dtype, device=device)
+        # Test pow(2)
+        cuda_out1 = t.pow(2)
+        cpu_out1 = t.cpu().pow(2)
+        self.assertEqual(cpu_out1, cuda_out1)
+
+        # Test pow(3)
+        cuda_out2 = t.pow(3)
+        cpu_out2 = t.cpu().pow(3)
+        self.assertEqual(cpu_out2, cuda_out2)
+
 
     @skipIfTorchDynamo()
     @onlyNativeDeviceTypes

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -1689,10 +1689,9 @@ class TestBinaryUfuncs(TestCase):
     @onlyCUDA
     @dtypes(torch.complex64, torch.complex128)
     def test_pow_cuda_complex_extremal_passing(self, device, dtype):
-        t = torch.tensor(complex(-1.0, float("inf")), dtype=dtype, device=device)
-
         # Test pow(2) and pow(3)
         for i in [2, 3]:
+            t = torch.tensor(complex(-1.0, float("inf")), dtype=dtype, device=device)
             cuda_out = t.pow(i)
             cpu_out = t.cpu().pow(i)
             self.assertEqual(cpu_out, cuda_out)


### PR DESCRIPTION
follows #152373 

Special case for pow(3):
Similar to the [CPU kernel](https://github.com/pytorch/pytorch/blob/d27d36136ce35d5d6dc3faa818ba840ba61d4357/aten/src/ATen/native/cpu/PowKernel.cpp#L64), added corresponding GPU code for numerical stability.

issue #150951