### PR TITLE
[aoti] Add library dir to aot_inductor.custom_op_libs

### DIFF
--- a/test/inductor/test_aot_inductor_custom_ops.py
+++ b/test/inductor/test_aot_inductor_custom_ops.py
@@ -443,7 +443,7 @@ class AOTInductorTestsTemplate:
             ),
             config.patch(
                 "aot_inductor.custom_op_libs",
-                ["aoti_custom_ops"],
+                [(None, "aoti_custom_ops")],
             ),
         ):
             self.check_model(m, args)

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -255,9 +255,9 @@ class CppWrapperCpu(PythonWrapperCodegen):
             )
             self.prefix.splice(
                 f"""
-                extern "C" {{
-                    {declarations}
-                }}
+extern "C" {{
+    {declarations}
+}}
                 """
             )
         if V.graph.aot_mode:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1402,8 +1402,9 @@ class aot_inductor:
 
     # Custom ops that have implemented C shim wrappers, defined as an op to C shim declaration dict
     custom_ops_to_c_shims: dict[torch._ops.OpOverload, list[str]] = {}
-    # custom op libs that have implemented C shim wrappers
-    custom_op_libs: Optional[list[str]] = None
+    # List of custom op libs that have implemented C shim wrappers. Each element
+    # is a tuple containing (path_to_custom_op_lib, name_of_custom_op_lib).
+    custom_op_libs: Optional[list[tuple[str, str]]] = None
 
 
 class cuda:

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -1326,7 +1326,10 @@ def get_cpp_torch_device_options(
                     passthrough_args = ["-Wl,-Bstatic -lcudart_static -Wl,-Bdynamic"]
 
     if config.aot_inductor.custom_op_libs:
-        libraries += config.aot_inductor.custom_op_libs
+        for lib in config.aot_inductor.custom_op_libs:
+            if lib[0] is not None:
+                libraries_dirs.append(lib[0])
+            libraries.append(lib[1])
 
     return (
         definitions,


### PR DESCRIPTION
When I tried adding the cshim for torchao custom ops (https://github.com/pytorch/ao/pull/2485) I found I needed to specify the library directory in order for it to compile correctly.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov