### PR TITLE
Fix typo: 'initalizer' → 'initializer' in test_reductions.cpp

### DIFF
--- a/test/cpp/tensorexpr/test_reductions.cpp
+++ b/test/cpp/tensorexpr/test_reductions.cpp
@@ -333,7 +333,7 @@ TEST(Reductions, ReduceMinCustomInitializer) {
   cg.call({in, out, std::numeric_limits<float>::max()});
   ASSERT_EQ(out[0], 10);
 
-  // With an initalizer lower than the min, that's the min.
+  // With an initializer lower than the min, that's the min.
   cg.call({in, out, 5.f});
   ASSERT_EQ(out[0], 5);
 }


### PR DESCRIPTION
Hi team,

This PR fixes a small typographical error in a code comment within `test/cpp/tensorexpr/test_reductions.cpp`, changing 'initalizer' to the correct spelling 'initializer'.

While this is a minor non-functional change, it contributes to the overall clarity and professionalism of the codebase.

I truly appreciate the efforts of all contributors and maintainers keeping PyTorch clean and well-documented. Thank you for your time and for reviewing this!

Warm regards,  
Abhitorch81

