### PR TITLE
[torch] Add MTIA to the list of devices supporting foreach/fused kernels

### DIFF
--- a/torch/utils/_foreach_utils.py
+++ b/torch/utils/_foreach_utils.py
@@ -8,7 +8,7 @@ from torch.autograd.grad_mode import no_grad
 
 def _get_foreach_kernels_supported_devices() -> list[str]:
     r"""Return the device type list that supports foreach kernels."""
-    return ["cuda", "xpu", torch._C._get_privateuse1_backend_name()]
+    return ["cuda", "xpu", "mtia", torch._C._get_privateuse1_backend_name()]
 
 
 def _get_fused_kernels_supported_devices() -> list[str]:
@@ -19,6 +19,7 @@ def _get_fused_kernels_supported_devices() -> list[str]:
         "xpu",
         "hpu",
         "cpu",
+        "mtia",
         torch._C._get_privateuse1_backend_name(),
     ]
 


### PR DESCRIPTION
Summary: We currently have foreach kernel implementations for MTIA, and for when we don't we internally decompose the ops. Anyone using this list for compatibility checks should be sending through the foreach kernels.

Reviewed By: egienvalue, scottxu0730

Differential Revision: D77751248


