### PR TITLE
correctly import torch.version

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -34,6 +34,8 @@ from typing import (
 )
 from typing_extensions import ParamSpec as _ParamSpec
 
+from . import version
+
 
 if TYPE_CHECKING:
     from .types import Device, IntLikeType


### PR DESCRIPTION
The structure is 

```
torch/
  __init__.py
  version.py
```


When we import torch, only `torch/__init__.py` is executed by default.

The submodules like `version.py` are not automatically imported or attached to the torch module.

So without anything in `__init__.py`, `torch.version` may not be found. So in this PR, we make the import explicit. 