### PR TITLE
Add master switch for aot_inductor.compile_standalone

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -6531,6 +6531,31 @@ class AOTInductorLoggingTest(LoggingTestCase):
         self.assertEqual([r.msg == "create_env" for r in records].count(True), 1)
 
 
+class TestAOTInductorConfig(TestCase):
+    def test_cpp_package_config(self):
+        self.assertTrue(config.aot_inductor.package_cpp_only is None)
+        self.assertEqual(config.aot_inductor.compile_standalone, False)
+        self.assertEqual(config.aot_inductor_package_cpp_only(), False)
+
+        with config.patch("aot_inductor.compile_standalone", True):
+            self.assertTrue(config.aot_inductor.package_cpp_only is None)
+            self.assertEqual(config.aot_inductor.compile_standalone, True)
+            self.assertEqual(config.aot_inductor_package_cpp_only(), True)
+
+        self.assertTrue(config.aot_inductor.package_cpp_only is None)
+        self.assertEqual(config.aot_inductor.compile_standalone, False)
+        self.assertEqual(config.aot_inductor_package_cpp_only(), False)
+
+        with config.patch("aot_inductor.package_cpp_only", True):
+            self.assertTrue(config.aot_inductor.package_cpp_only is True)
+            self.assertEqual(config.aot_inductor.compile_standalone, False)
+            self.assertEqual(config.aot_inductor_package_cpp_only(), True)
+
+        self.assertTrue(config.aot_inductor.package_cpp_only is None)
+        self.assertEqual(config.aot_inductor.compile_standalone, False)
+        self.assertEqual(config.aot_inductor_package_cpp_only(), False)
+
+
 common_utils.instantiate_parametrized_tests(AOTInductorTestsTemplate)
 
 

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1541,7 +1541,7 @@ class CudaKernelParamCache:
         asm_type: Optional[str] = None,
     ) -> None:
         basename = None
-        if config.aot_inductor.package_cpp_only:
+        if config.aot_inductor_package_cpp_only():
             assert config.triton.unique_kernel_names, (
                 "package_cpp_only requires triton kernel names to be unique"
             )
@@ -1571,7 +1571,7 @@ class CudaKernelParamCache:
         asm_path: str = ""
         if (
             config.aot_inductor.emit_multi_arch_kernel
-            or config.aot_inductor.package_cpp_only
+            or config.aot_inductor_package_cpp_only()
         ):
             assert asm, "Missing kernel assembly code"
             assert asm_type, "Missing kernel assembly type"
@@ -1656,7 +1656,7 @@ class AotCodeCompiler:
         # TODO (benjaminglass1): the CMake packaging path doesn't support linking files
         # built with different flags.  Until that's implemented, append the kernel code
         # to the wrapper and build everything at max optimization.
-        if config.aot_inductor.package_cpp_only:
+        if config.aot_inductor_package_cpp_only():
             wrapper_code = "\n".join((wrapper_code, kernel_code))
             kernel_code = ""
 
@@ -1687,7 +1687,7 @@ class AotCodeCompiler:
 
         if config.aot_inductor.package:
             generated_files.append(wrapper_path)
-            if not config.aot_inductor.package_cpp_only:
+            if not config.aot_inductor_package_cpp_only():
                 generated_files.append(kernel_path)
 
         output_code_log.info("Wrapper code written to: %s", wrapper_path)
@@ -1842,7 +1842,7 @@ class AotCodeCompiler:
 
             if config.aot_inductor.package:
                 generated_files.append(meta_json)
-                if not config.aot_inductor.package_cpp_only:
+                if not config.aot_inductor_package_cpp_only():
                     generated_files.append(kernel_meta_json)
 
             output_so = (
@@ -1926,7 +1926,7 @@ class AotCodeCompiler:
             # If we're packaging via CMake, we build the whole code at max optimization.
             wrapper_build_options = CppTorchDeviceOptions(
                 compile_only=True,
-                min_optimize=not config.aot_inductor.package_cpp_only,
+                min_optimize=not config.aot_inductor_package_cpp_only(),
                 **compile_command,
             )
             kernel_build_options = CppTorchDeviceOptions(
@@ -1942,7 +1942,7 @@ class AotCodeCompiler:
                 wrapper_build_options.precompiled_header = _precompile_header(
                     header_file,
                     cpp_command,
-                    min_optimize=not config.aot_inductor.package_cpp_only,
+                    min_optimize=not config.aot_inductor_package_cpp_only(),
                     **compile_command,
                 )
                 if cpp_prefix := _get_cpp_prefix_header(device_type):
@@ -1972,7 +1972,7 @@ class AotCodeCompiler:
 
             log.debug("aot wrapper compilation command: %s", wrapper_compile_cmd)
             log.debug("aot kernel compilation command: %s", kernel_compile_cmd)
-            if config.aot_inductor.package_cpp_only:
+            if config.aot_inductor_package_cpp_only():
                 # Not doing the actual compilation here
                 compile_flags = str(
                     wrapper_path_operator.with_name(
@@ -2121,7 +2121,7 @@ class AotCodeCompiler:
                 f.write(f"// Compile cmd\n// {kernel_compile_cmd}\n")
                 f.write(f"// Link cmd\n// {link_cmd}\n")
 
-            if config.aot_inductor.package_cpp_only:
+            if config.aot_inductor_package_cpp_only():
                 linker_flags = str(
                     wrapper_path_operator.with_name(
                         f"{wrapper_path_operator.stem}_linker_flags.json"

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1347,7 +1347,6 @@ class aot_inductor:
     force_mmap_weights: bool = False
 
     package: bool = False
-    package_cpp_only: bool = False
 
     # Dictionary of metadata users might want to save to pass to the runtime.
     # TODO: Move this somewhere else, since it's no longer really a config
@@ -1411,6 +1410,23 @@ class aot_inductor:
     custom_ops_to_c_shims: dict[torch._ops.OpOverload, list[str]] = {}
     # custom op libs that have implemented C shim wrappers
     custom_op_libs: Optional[list[str]] = None
+
+    # Emit cpp only code for static linkage
+    package_cpp_only: Optional[bool] = None
+
+    compile_standalone: bool = False
+
+
+# Emit cpp only code
+# If compile_standalone, then emit for static linkage
+# If not compile_standalone, then emit for dynamic linkage
+# By default return the same value as compile_standalone,
+# if package_cpp_only is overriden by user, will return the overriden value.
+# Not intended to be set directly, please set package_cpp_only or compile_standalone instead.
+def aot_inductor_package_cpp_only() -> bool:
+    if aot_inductor.package_cpp_only is not None:
+        return aot_inductor.package_cpp_only
+    return aot_inductor.compile_standalone
 
 
 class cuda:


### PR DESCRIPTION
Summary:

If it's `package_cpp_only` not set, we get it's value from `compile_standalone`.

If it is `package_cpp_only` set, then we return the set value.

Test Plan:
```
buck2 run  mode/dev-nosan caffe2/test/inductor:test_aot_inductor -- -r test_cpp_package_config
```

Rollback Plan:

Differential Revision: D77626944




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov