### PR TITLE
Fix doc issue 153531 by adding further explanation of STFT equation

### DIFF
--- a/torch/functional.py
+++ b/torch/functional.py
@@ -652,15 +652,11 @@ def stft(
 
     In the STFT exponent, we use:
 
-    .. math::
-
-        exp\left(- j \frac{2 \pi \cdot \omega k}{\text{n\_fft}}\right)
+    :math:`exp\left(- j \frac{2 \pi \cdot \omega k}{\text{n\_fft}}\right)`
 
     instead of:
 
-    .. math::
-
-        exp\left(- j \frac{2 \pi \cdot \omega k}{\text{win\_length}}\right)
+    :math:`exp\left(- j \frac{2 \pi \cdot \omega k}{\text{win\_length}}\right)`
 
     This choice follows Librosa's STFT function. Librosa's function always
     computes FFT over :math:`\text{n\_fft}` points by zero-padding the

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -650,6 +650,28 @@ def stft(
     :attr:`input`, :math:`N` is the number of frequencies where STFT is applied
     and :math:`T` is the total number of frames used.
 
+<<<<<<< HEAD
+=======
+    In the STFT exponent, we use:
+    :: math::
+
+        exp\left(- j \frac{2 \pi \cdot \omega k}{\text{n\_fft}}\right)
+
+    instead of:
+
+    .. math::
+
+        exp\left(- j \frac{2 \pi \cdot \omega k}{\text{win\_length}}\right)
+
+    This choice follows Librosa's STFT function. Librosa's function always
+    computes FFT over :math:`\text{n\_fft}` points by zero-padding the
+    windowed signal. As a result, the frequency bins and their spacing are
+    based on :math:`\text{n\_fft}` rather than :math:`\text{win\_length}`.
+    Dividing by :math:`\text{n\_fft}` in the STFT exponent ensures the
+    exponent correctly matches the size and frequency resoultion of the FFT.
+
+
+>>>>>>> cd33257d901 (Fix doc issue 153531 by adding further explanation of STFT equation)
     .. warning::
       This function changed signature at version 0.4.1. Calling with the
       previous signature may cause error or return incorrect result.

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -650,8 +650,6 @@ def stft(
     :attr:`input`, :math:`N` is the number of frequencies where STFT is applied
     and :math:`T` is the total number of frames used.
 
-<<<<<<< HEAD
-=======
     In the STFT exponent, we use:
     :: math::
 
@@ -670,8 +668,6 @@ def stft(
     Dividing by :math:`\text{n\_fft}` in the STFT exponent ensures the
     exponent correctly matches the size and frequency resoultion of the FFT.
 
-
->>>>>>> cd33257d901 (Fix doc issue 153531 by adding further explanation of STFT equation)
     .. warning::
       This function changed signature at version 0.4.1. Calling with the
       previous signature may cause error or return incorrect result.

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -651,7 +651,8 @@ def stft(
     and :math:`T` is the total number of frames used.
 
     In the STFT exponent, we use:
-    :: math::
+
+    .. math::
 
         exp\left(- j \frac{2 \pi \cdot \omega k}{\text{n\_fft}}\right)
 


### PR DESCRIPTION
Fixes #153531 
##Summary
This PR fixes doc issue #153531  by adding further explanation of STFT equation in torch/functional.py

##Details 
I added further explanation of why the STFT equation exponent uses n_fft instead of win_length from lines 653 - 674. I did not think the issue required further explanation of the STFT equation as the explanation already present in the torch/functional.py seemed adequate


