### PR TITLE
Fix typo: 'inital_grad' → 'initial_grad' in FSDP test

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_grad_scaler.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_grad_scaler.py
@@ -73,7 +73,7 @@ class TestFullyShardGradientScaler(FSDPTest):
             opt.param_groups[0]["params"][0].grad._local_tensor[0, 0].fill_(
                 float("inf")
             )
-        inital_grad = opt.param_groups[0]["params"][0].grad.to_local().clone()
+        initial_grad = opt.param_groups[0]["params"][0].grad.to_local().clone()
 
         scaler.unscale_(opt)
         for found_inf in scaler._per_optimizer_states[id(opt)][
@@ -85,7 +85,7 @@ class TestFullyShardGradientScaler(FSDPTest):
             OptState.UNSCALED.value,
         )
         unscaled_grad = opt.param_groups[0]["params"][0].grad.to_local().clone()
-        self.assertEqual(unscaled_grad, inital_grad * inv_scale)
+        self.assertEqual(unscaled_grad, initial_grad * inv_scale)
         initial_scale = scaler.get_scale()
         initial_state = copy.copy(opt.state)
 


### PR DESCRIPTION
This PR fixes a minor typo in `test_fully_shard_grad_scaler.py`, changing `inital_grad` to the correct spelling `initial_grad`.

This helps improve code readability and consistency across the test suite.

Thank you for your time and all the efforts maintaining this amazing project!



cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k