### PR TITLE
[dynamo] do not issue lru_cache warning for functions in the top-level torch namespace

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -956,6 +956,7 @@ class LRUCacheWarningTests(LoggingTestCase):
 
         @torch.compile(backend="eager")
         def f(x):
+            torch.get_device_module()
             x = x.cos().sin()
             return x
 

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -34,12 +34,12 @@ import types
 from collections.abc import Sequence
 from types import FunctionType
 from typing import Any, Callable, Optional, TYPE_CHECKING, TypeVar
-from typing_extensions import Never
 from unittest.mock import patch
 from weakref import WeakKeyDictionary
 
 import torch
 from torch._dynamo.exc import get_stack_above_dynamo
+from typing_extensions import Never
 
 from .. import config, graph_break_hints, polyfills, variables
 from ..bytecode_transformation import create_call_function, create_rot_n, is_generator
@@ -1583,7 +1583,7 @@ class WrapperUserFunctionVariable(VariableTracker):
             target_fn = getattr(self.wrapper_obj, self.attr_to_trace, None)
             module_name = getattr(target_fn, "__module__", "") or ""
 
-            if not module_name.startswith("torch"):
+            if not module_name.split(".", maxsplit=1)[0] == "torch":
                 msg = (
                     "Dynamo detected a call to a `functools.lru_cache`-wrapped "
                     "function. Dynamo ignores the cache wrapper and directly "

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -34,12 +34,12 @@ import types
 from collections.abc import Sequence
 from types import FunctionType
 from typing import Any, Callable, Optional, TYPE_CHECKING, TypeVar
+from typing_extensions import Never
 from unittest.mock import patch
 from weakref import WeakKeyDictionary
 
 import torch
 from torch._dynamo.exc import get_stack_above_dynamo
-from typing_extensions import Never
 
 from .. import config, graph_break_hints, polyfills, variables
 from ..bytecode_transformation import create_call_function, create_rot_n, is_generator
@@ -1583,7 +1583,7 @@ class WrapperUserFunctionVariable(VariableTracker):
             target_fn = getattr(self.wrapper_obj, self.attr_to_trace, None)
             module_name = getattr(target_fn, "__module__", "") or ""
 
-            if not module_name.split(".", maxsplit=1)[0] == "torch":
+            if module_name.split(".", maxsplit=1)[0] != "torch":
                 msg = (
                     "Dynamo detected a call to a `functools.lru_cache`-wrapped "
                     "function. Dynamo ignores the cache wrapper and directly "

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -1583,7 +1583,7 @@ class WrapperUserFunctionVariable(VariableTracker):
             target_fn = getattr(self.wrapper_obj, self.attr_to_trace, None)
             module_name = getattr(target_fn, "__module__", "") or ""
 
-            if not module_name.startswith("torch."):
+            if not module_name.startswith("torch"):
                 msg = (
                     "Dynamo detected a call to a `functools.lru_cache`-wrapped "
                     "function. Dynamo ignores the cache wrapper and directly "


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #157598

`lru_cache` usage warning was being raised for `torch.get_device_module()`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames