### PR TITLE
Fix einops x torch.compile interaction

### DIFF
--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -7,15 +7,12 @@ This module provides decorators and utilities for controlling TorchDynamo's beha
 
 import functools
 import inspect
-import sys
 import weakref
 from dataclasses import dataclass
 from typing import Any, Callable, Optional, overload, TYPE_CHECKING, TypeVar, Union
 from typing_extensions import ParamSpec
 
 import torch
-from torch._environment import is_fbcode
-from torch._vendor.packaging.version import Version
 from torch.utils._contextlib import _DecoratorContextManager
 from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 
@@ -742,40 +739,34 @@ def mark_static_address(t, guard=True):
         t._dynamo_static_input_type = "unguarded"  # type: ignore[attr-defined]
 
 
-# Note: this carefully avoids eagerly import einops.
-# TODO: we should delete this whole _allow_in_graph_einops logic by approximately 2024 Q2
+# One day, Dynamo will support tracing into einops directly (no allow_in_graph needed)
+# Note that PyTorch supports multiple versions of einops, so when that day comes,
+# we still need to be really careful about version matches.
 def _allow_in_graph_einops():
-    mod = sys.modules.get("einops")
-    if mod is None:
-        return
-    else:
-        # version > 0.8.1 does allow_in_graph out of tree
-        # for BC we need to keep this in fbcode
-        # internal xref https://fb.workplace.com/groups/1026248852325474/permalink/1107135774236781/
-        if Version(mod.__version__) <= Version("0.8.1") or is_fbcode():
-            import einops
+    import einops
 
-            try:
-                # requires einops > 0.6.1, torch >= 2.0
-                from einops._torch_specific import (  # type: ignore[attr-defined]  # noqa: F401
-                    _ops_were_registered_in_torchdynamo,
-                )
+    try:
+        # requires einops > 0.6.1, torch >= 2.0
+        from einops._torch_specific import (  # type: ignore[attr-defined]  # noqa: F401
+            _ops_were_registered_in_torchdynamo,
+        )
 
-                # einops > 0.6.1 will call the op registration logic as it is imported.
-            except ImportError:
-                # einops <= 0.6.1
-                allow_in_graph(einops.rearrange)
-                allow_in_graph(einops.reduce)
-                if hasattr(einops, "repeat"):
-                    allow_in_graph(einops.repeat)  # available since einops 0.2.0
-                if hasattr(einops, "einsum"):
-                    allow_in_graph(einops.einsum)  # available since einops 0.5.0
-                if hasattr(einops, "pack"):
-                    allow_in_graph(einops.pack)  # available since einops 0.6.0
-                if hasattr(einops, "unpack"):
-                    allow_in_graph(einops.unpack)  # available since einops 0.6.0
+        # einops > 0.6.1 will call the op registration logic as it is imported.
+    except ImportError:
+        # einops <= 0.6.1
+        allow_in_graph(einops.rearrange)
+        allow_in_graph(einops.reduce)
+        if hasattr(einops, "repeat"):
+            allow_in_graph(einops.repeat)  # available since einops 0.2.0
+        if hasattr(einops, "einsum"):
+            allow_in_graph(einops.einsum)  # available since einops 0.5.0
+        if hasattr(einops, "pack"):
+            allow_in_graph(einops.pack)  # available since einops 0.6.0
+        if hasattr(einops, "unpack"):
+            allow_in_graph(einops.unpack)  # available since einops 0.6.0
 
 
+# Note: this carefully avoids eagerly import einops.
 trace_rules.add_module_init_func("einops", _allow_in_graph_einops)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #157600
* #157416

Fixes https://github.com/pytorch/pytorch/issues/157451

If/when einops releases a version greater than 0.8.1, it will just break
(without this patch).

The history is:
- Between 2.6 and 2.7, we tried to delete the einops import (#142847)
- That didn't work so well, so we applied a hotfix in 2.7.1. (#153925)
- The hotfix wasn't completely correct (0.8.1 is the latest version of
  einops, so the condition in the hotfix just always evaluates to True!)
- It turns out we didn't need to delete the einops import. We already
  do not eagerly import einops.
- I reverted the code back to the state it was in in 2.6.
  https://github.com/pytorch/pytorch/blob/release/2.6/torch/_dynamo/decorators.py

Test Plan:
- We have testing in CI for einops 0.6.1, 0.7.0, and 0.8.1. Wait for CI.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames