### PR TITLE
[aot] add format_consts_to_cpp function for further development.

### DIFF
--- a/test/cpp/aoti_inference/test.py
+++ b/test/cpp/aoti_inference/test.py
@@ -1,4 +1,5 @@
 import torch
+import torch._inductor.config
 from torch._export import aot_compile
 from torch.export import Dim
 
@@ -85,6 +86,18 @@ def generate_basic_tests():
             )
 
 
+def generate_basic_tests_consts_cpp():
+    backup_consts_asm_cfg: bool = (
+        torch._inductor.config.aot_inductor.use_consts_asm_build
+    )
+    torch._inductor.config.aot_inductor.use_consts_asm_build = False
+
+    # Test consts cpp build again.
+    generate_basic_tests()
+
+    torch._inductor.config.aot_inductor.use_consts_asm_build = backup_consts_asm_cfg
+
+
 def generate_large_tests():
     device = "cuda"
     model = Net(device, size=4096).to(device=device)
@@ -157,6 +170,7 @@ def generate_test_with_additional_tensors():
 
 
 generate_basic_tests()
+generate_basic_tests_consts_cpp()
 generate_large_tests()
 generate_test_with_additional_tensors()
 

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -441,7 +441,11 @@ class AOTInductorTestsTemplate:
 
         ep = torch.export.export(model, input1, dynamic_shapes=None, strict=False)
         torch._inductor.aoti_compile_and_package(
-            ep, inductor_configs={"aot_inductor.use_consts_asm_build": False}
+            ep,
+            inductor_configs={
+                "aot_inductor.use_runtime_constant_folding": True,
+                "aot_inductor.use_consts_asm_build": False,
+            },
         )
 
     @common_utils.parametrize("dynamic", [False, True])

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -423,7 +423,7 @@ class AOTInductorTestsTemplate:
         class Model(torch.nn.Module):
             def __init__(self, device) -> None:
                 super().__init__()
-                self.x = torch.randn(2048, 2048, dtype=torch.float16, device=device)
+                self.x = torch.randn(256, 256, dtype=torch.float16, device=device)
 
             def _quantize(self, input):
                 return torch.abs(input)
@@ -434,7 +434,7 @@ class AOTInductorTestsTemplate:
 
                 return abs_weight, abs_y
 
-        input1 = (torch.rand(2048, 2048, dtype=torch.float16, device=self.device),)
+        input1 = (torch.rand(256, 256, dtype=torch.float16, device=self.device),)
         model = Model(self.device).to(self.device)
 
         _ = model(*input1)

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1774,7 +1774,7 @@ class AotCodeCompiler:
             def format_consts_to_cpp(
                 consts: bytes, align_bytes: int, symbol_prefix: str
             ) -> tuple[str, str]:
-                const_cpp = f"extern alignas({align_bytes}) "
+                const_cpp = f"alignas({align_bytes}) extern "
                 const_cpp += f"const unsigned char {symbol_prefix}_binary_constants_bin_start[] = {{\t\n"
                 count_bytes = 0
                 for c in consts:

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1722,7 +1722,8 @@ class AotCodeCompiler:
         cmake_path = str(Path(specified_sub_dir) / "CMakeLists.txt")
 
         def _compile_consts(consts: bytes, platform: str) -> str:
-            use_asm_build: bool = True
+            # Load from aot_inductor, and update the value on demand.
+            use_asm_build: bool = config.aot_inductor.use_consts_asm_build
 
             if platform == "linux":
                 if graph.mutated_buffers & OrderedSet(graph.constants.keys()):

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1817,7 +1817,7 @@ class AotCodeCompiler:
             consts_o = object_builder.get_target_file_path()
             object_builder.build()
 
-            if is_large_consts and use_asm_build:
+            if is_large_consts:
                 with open(consts_o, "r+b") as f:
                     f.seek(0)
                     hdr = f.read(1024)

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1817,7 +1817,7 @@ class AotCodeCompiler:
             consts_o = object_builder.get_target_file_path()
             object_builder.build()
 
-            if is_large_consts:
+            if is_large_consts and use_asm_build:
                 with open(consts_o, "r+b") as f:
                     f.seek(0)
                     hdr = f.read(1024)

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1783,6 +1783,7 @@ class AotCodeCompiler:
                     if count_bytes % 16 == 0:
                         const_cpp += "\t\n"
                 const_cpp += "};\t\n"
+                const_cpp += "alignas({align_bytes}) extern const unsigned char * {symbol_prefix}_binary_constants_bin_end;\t\n"
                 return const_cpp, "cpp"
 
             if use_asm_build:

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1783,7 +1783,7 @@ class AotCodeCompiler:
                     if count_bytes % 16 == 0:
                         const_cpp += "\t\n"
                 const_cpp += "};\t\n"
-                const_cpp += "alignas({align_bytes}) extern const unsigned char * {symbol_prefix}_binary_constants_bin_end;\t\n"
+                const_cpp += f"alignas({align_bytes}) extern const unsigned char * {symbol_prefix}_binary_constants_bin_end;\t\n"
                 return const_cpp, "cpp"
 
             if use_asm_build:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1346,6 +1346,10 @@ class aot_inductor:
     # rather than embedded into the data section. Needed to support 1B+ parameter models
     force_mmap_weights: bool = False
 
+    # Default value of use_consts_asm_build is True, it will build by assembly language.
+    # When the value is False, it will build by c++ language.
+    use_consts_asm_build = True
+
     package: bool = False
     package_cpp_only: bool = False
 


### PR DESCRIPTION
Changes:
1. Split `format_consts_to_asm` function, which is current way to convert consts to object.
2. Add `format_consts_to_cpp` function, which would support for more compiler support, such as `msvc` and `icx`.
3. Add `config.aot_inductor.use_consts_asm_build` for `format_consts_to_asm` and `format_consts_to_cpp` control.
4. Add UT for `format_consts_to_cpp`.

For `format_consts_to_cpp`, I have local tested it:
Case: https://docs.pytorch.org/docs/main/torch.compiler_aot_inductor.html
Run it and `cat` cpp code:
<img width="674" alt="image" src="https://github.com/user-attachments/assets/d47ccf84-06d2-47f5-8a0d-9a43a9020aa3" />



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov 