### PR TITLE
Fix typo: 'initalized' → 'initialized' in alias analysis test

### DIFF
--- a/test/jit/test_alias_analysis.py
+++ b/test/jit/test_alias_analysis.py
@@ -23,7 +23,7 @@ class TestAliasAnalysis(JitTestCase):
         graph = parse_ir(graph_str)
         alias_db = graph.alias_db()
         split_node = graph.findNode("aten::split")
-        # split input enters wildcard set, list initalized as containing wildcard set
+        # split input enters wildcard set, list initialized as containing wildcard set
         self.assertTrue(
             alias_db.may_contain_alias(next(split_node.inputs()), split_node.output())
         )


### PR DESCRIPTION
This PR corrects a small spelling error in `test/jit/test_alias_analysis.py`.

- "initalized" → "initialized"

This is a minor comment correction and does not affect functionality or logic.

Thank you for maintaining this amazing codebase.


cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel