### PR TITLE
Fix cuda 12.9 aarch64 GPU builds. Update CUDA_STABLE variable. 

### DIFF
--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -75,10 +75,8 @@ TRITON_VERSION=$(cat $PYTORCH_ROOT/.ci/docker/triton_version.txt)
 # Here PYTORCH_EXTRA_INSTALL_REQUIREMENTS is already set for the all the wheel builds hence append TRITON_CONSTRAINT
 TRITON_CONSTRAINT="platform_system == 'Linux' and platform_machine == 'x86_64'"
 
-AARCH64_CUDA_VERSION=$(python $PYTORCH_ROOT/.github/scripts/get_ci_variable.py --cuda-aarch64-version)
-AARCH64_CUDA_VERSION_NODOT=$(echo ${AARCH64_CUDA_VERSION} | tr -d '.')
 # CUDA 12.9 builds have triton for Linux and Linux aarch64 binaries.
-if [[ "$DESIRED_CUDA" == "cu${AARCH64_CUDA_VERSION_NODOT}" ]]; then
+if [[ "$DESIRED_CUDA" == "cu129" ]]; then
   TRITON_CONSTRAINT="platform_system == 'Linux'"
 fi
 

--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -75,8 +75,10 @@ TRITON_VERSION=$(cat $PYTORCH_ROOT/.ci/docker/triton_version.txt)
 # Here PYTORCH_EXTRA_INSTALL_REQUIREMENTS is already set for the all the wheel builds hence append TRITON_CONSTRAINT
 TRITON_CONSTRAINT="platform_system == 'Linux' and platform_machine == 'x86_64'"
 
+AARCH64_CUDA_VERSION=$(python3 $PYTORCH_ROOT/.github/scripts/get_ci_variable.py --cuda-aarch64-version)
+AARCH64_CUDA_VERSION_NODOT=$(echo ${STABLE_CUDA_VERSION} | tr -d '.')
 # CUDA 12.9 builds have triton for Linux and Linux aarch64 binaries.
-if [[ "$DESIRED_CUDA" == cu129 ]]; then
+if [[ "$DESIRED_CUDA" == "cu${AARCH64_CUDA_VERSION_NODOT}" ]]; then
   TRITON_CONSTRAINT="platform_system == 'Linux'"
 fi
 

--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -76,7 +76,7 @@ TRITON_VERSION=$(cat $PYTORCH_ROOT/.ci/docker/triton_version.txt)
 TRITON_CONSTRAINT="platform_system == 'Linux' and platform_machine == 'x86_64'"
 
 AARCH64_CUDA_VERSION=$(python3 $PYTORCH_ROOT/.github/scripts/get_ci_variable.py --cuda-aarch64-version)
-AARCH64_CUDA_VERSION_NODOT=$(echo ${STABLE_CUDA_VERSION} | tr -d '.')
+AARCH64_CUDA_VERSION_NODOT=$(echo ${AARCH64_CUDA_VERSION} | tr -d '.')
 # CUDA 12.9 builds have triton for Linux and Linux aarch64 binaries.
 if [[ "$DESIRED_CUDA" == "cu${AARCH64_CUDA_VERSION_NODOT}" ]]; then
   TRITON_CONSTRAINT="platform_system == 'Linux'"

--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -75,8 +75,8 @@ TRITON_VERSION=$(cat $PYTORCH_ROOT/.ci/docker/triton_version.txt)
 # Here PYTORCH_EXTRA_INSTALL_REQUIREMENTS is already set for the all the wheel builds hence append TRITON_CONSTRAINT
 TRITON_CONSTRAINT="platform_system == 'Linux' and platform_machine == 'x86_64'"
 
-# CUDA 12.8 builds have triton for Linux and Linux aarch64 binaries.
-if [[ "$DESIRED_CUDA" == cu128 ]]; then
+# CUDA 12.9 builds have triton for Linux and Linux aarch64 binaries.
+if [[ "$DESIRED_CUDA" == cu129 ]]; then
   TRITON_CONSTRAINT="platform_system == 'Linux'"
 fi
 

--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -75,7 +75,7 @@ TRITON_VERSION=$(cat $PYTORCH_ROOT/.ci/docker/triton_version.txt)
 # Here PYTORCH_EXTRA_INSTALL_REQUIREMENTS is already set for the all the wheel builds hence append TRITON_CONSTRAINT
 TRITON_CONSTRAINT="platform_system == 'Linux' and platform_machine == 'x86_64'"
 
-AARCH64_CUDA_VERSION=$(python3 $PYTORCH_ROOT/.github/scripts/get_ci_variable.py --cuda-aarch64-version)
+AARCH64_CUDA_VERSION=$(python $PYTORCH_ROOT/.github/scripts/get_ci_variable.py --cuda-aarch64-version)
 AARCH64_CUDA_VERSION_NODOT=$(echo ${AARCH64_CUDA_VERSION} | tr -d '.')
 # CUDA 12.9 builds have triton for Linux and Linux aarch64 binaries.
 if [[ "$DESIRED_CUDA" == "cu${AARCH64_CUDA_VERSION_NODOT}" ]]; then

--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -17,7 +17,7 @@ from typing import Optional
 
 # NOTE: Please also update the CUDA sources in `PIP_SOURCES` in tools/nightly.py when changing this
 CUDA_ARCHES = ["12.6", "12.8", "12.9"]
-CUDA_STABLE = "12.6"
+CUDA_STABLE = "12.8"
 CUDA_ARCHES_FULL_VERSION = {
     "12.6": "12.6.3",
     "12.8": "12.8.1",

--- a/.github/scripts/get_ci_variable.py
+++ b/.github/scripts/get_ci_variable.py
@@ -15,11 +15,6 @@ def main(args: list[str]) -> None:
         help="get cuda stable version",
     )
     parser.add_argument(
-        "--cuda-aarch64-version",
-        action="store_true",
-        help="get cuda aarch64 version",
-    )
-    parser.add_argument(
         "--min-python-version",
         action="store_true",
         help="get min supported python version",
@@ -27,8 +22,6 @@ def main(args: list[str]) -> None:
     options = parser.parse_args(args)
     if options.cuda_stable_version:
         return print(generate_binary_build_matrix.CUDA_STABLE)
-    if options.cuda_aarch64_version:
-        return print(generate_binary_build_matrix.CUDA_AARCH64_ARCHES[0].removesuffix("-aarch64"))
     if options.min_python_version:
         return print(generate_binary_build_matrix.FULL_PYTHON_VERSIONS[0])
 

--- a/.github/scripts/get_ci_variable.py
+++ b/.github/scripts/get_ci_variable.py
@@ -28,7 +28,7 @@ def main(args: list[str]) -> None:
     if options.cuda_stable_version:
         return print(generate_binary_build_matrix.CUDA_STABLE)
     if options.cuda_aarch64_version:
-        return print(generate_binary_build_matrix.CUDA_AARCH64_ARCHES.removesuffix("-aarch64"))
+        return print(generate_binary_build_matrix.CUDA_AARCH64_ARCHES[0].removesuffix("-aarch64"))
     if options.min_python_version:
         return print(generate_binary_build_matrix.FULL_PYTHON_VERSIONS[0])
 

--- a/.github/scripts/get_ci_variable.py
+++ b/.github/scripts/get_ci_variable.py
@@ -15,6 +15,11 @@ def main(args: list[str]) -> None:
         help="get cuda stable version",
     )
     parser.add_argument(
+        "--cuda-aarch64-version",
+        action="store_true",
+        help="get cuda aarch64 version",
+    )
+    parser.add_argument(
         "--min-python-version",
         action="store_true",
         help="get min supported python version",
@@ -22,6 +27,8 @@ def main(args: list[str]) -> None:
     options = parser.parse_args(args)
     if options.cuda_stable_version:
         return print(generate_binary_build_matrix.CUDA_STABLE)
+    if options.cuda_aarch64_version:
+        return print(generate_binary_build_matrix.CUDA_AARCH64_ARCHES.removesuffix("-aarch64"))
     if options.min_python_version:
         return print(generate_binary_build_matrix.FULL_PYTHON_VERSIONS[0])
 

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -1407,74 +1407,6 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
     uses: ./.github/workflows/_binary-upload.yml
 
-  manywheel-py3_11-cuda12_6-full-build:
-    if: ${{ github.repository_owner == 'pytorch' }}
-    uses: ./.github/workflows/_binary-build-linux.yml
-    needs: get-label-type
-    with:
-      PYTORCH_ROOT: /pytorch
-      PACKAGE_TYPE: manywheel
-      # TODO: This is a legacy variable that we eventually want to get rid of in
-      #       favor of GPU_ARCH_VERSION
-      DESIRED_CUDA: cu126
-      GPU_ARCH_VERSION: 12.6
-      GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: manylinux2_28-builder
-      DOCKER_IMAGE_TAG_PREFIX: cuda12.6
-      use_split_build: False
-      DESIRED_PYTHON: "3.11"
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build_name: manywheel-py3_11-cuda12_6-full
-      build_environment: linux-binary-manywheel
-    secrets:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
-  manywheel-py3_11-cuda12_6-full-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
-    needs:
-      - manywheel-py3_11-cuda12_6-full-build
-      - get-label-type
-    uses: ./.github/workflows/_binary-test-linux.yml
-    with:
-      PYTORCH_ROOT: /pytorch
-      PACKAGE_TYPE: manywheel
-      # TODO: This is a legacy variable that we eventually want to get rid of in
-      #       favor of GPU_ARCH_VERSION
-      DESIRED_CUDA: cu126
-      GPU_ARCH_VERSION: 12.6
-      GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: manylinux2_28-builder
-      DOCKER_IMAGE_TAG_PREFIX: cuda12.6
-      use_split_build: False
-      DESIRED_PYTHON: "3.11"
-      build_name: manywheel-py3_11-cuda12_6-full
-      build_environment: linux-binary-manywheel
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      runs_on: linux.4xlarge.nvidia.gpu # for other cuda versions, we use 4xlarge runner
-    secrets:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
-  manywheel-py3_11-cuda12_6-full-upload:  # Uploading
-    if: ${{ github.repository_owner == 'pytorch' }}
-    permissions:
-      id-token: write
-      contents: read
-    needs: manywheel-py3_11-cuda12_6-full-test
-    with:
-      PYTORCH_ROOT: /pytorch
-      PACKAGE_TYPE: manywheel
-      # TODO: This is a legacy variable that we eventually want to get rid of in
-      #       favor of GPU_ARCH_VERSION
-      DESIRED_CUDA: cu126
-      GPU_ARCH_VERSION: 12.6
-      GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: manylinux2_28-builder
-      DOCKER_IMAGE_TAG_PREFIX: cuda12.6
-      use_split_build: False
-      DESIRED_PYTHON: "3.11"
-      build_name: manywheel-py3_11-cuda12_6-full
-    secrets:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
-    uses: ./.github/workflows/_binary-upload.yml
-
   manywheel-py3_11-cuda12_8-build:
     if: ${{ github.repository_owner == 'pytorch' }}
     uses: ./.github/workflows/_binary-build-linux.yml
@@ -1540,6 +1472,74 @@ jobs:
       use_split_build: False
       DESIRED_PYTHON: "3.11"
       build_name: manywheel-py3_11-cuda12_8
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/_binary-upload.yml
+
+  manywheel-py3_11-cuda12_8-full-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
+    uses: ./.github/workflows/_binary-build-linux.yml
+    needs: get-label-type
+    with:
+      PYTORCH_ROOT: /pytorch
+      PACKAGE_TYPE: manywheel
+      # TODO: This is a legacy variable that we eventually want to get rid of in
+      #       favor of GPU_ARCH_VERSION
+      DESIRED_CUDA: cu128
+      GPU_ARCH_VERSION: 12.8
+      GPU_ARCH_TYPE: cuda
+      DOCKER_IMAGE: manylinux2_28-builder
+      DOCKER_IMAGE_TAG_PREFIX: cuda12.8
+      use_split_build: False
+      DESIRED_PYTHON: "3.11"
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      build_name: manywheel-py3_11-cuda12_8-full
+      build_environment: linux-binary-manywheel
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+  manywheel-py3_11-cuda12_8-full-test:  # Testing
+    if: ${{ github.repository_owner == 'pytorch' }}
+    needs:
+      - manywheel-py3_11-cuda12_8-full-build
+      - get-label-type
+    uses: ./.github/workflows/_binary-test-linux.yml
+    with:
+      PYTORCH_ROOT: /pytorch
+      PACKAGE_TYPE: manywheel
+      # TODO: This is a legacy variable that we eventually want to get rid of in
+      #       favor of GPU_ARCH_VERSION
+      DESIRED_CUDA: cu128
+      GPU_ARCH_VERSION: 12.8
+      GPU_ARCH_TYPE: cuda
+      DOCKER_IMAGE: manylinux2_28-builder
+      DOCKER_IMAGE_TAG_PREFIX: cuda12.8
+      use_split_build: False
+      DESIRED_PYTHON: "3.11"
+      build_name: manywheel-py3_11-cuda12_8-full
+      build_environment: linux-binary-manywheel
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      runs_on: linux.g4dn.4xlarge.nvidia.gpu  # 12.8 and 12.9 build need sm_70+ runner
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+  manywheel-py3_11-cuda12_8-full-upload:  # Uploading
+    if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      id-token: write
+      contents: read
+    needs: manywheel-py3_11-cuda12_8-full-test
+    with:
+      PYTORCH_ROOT: /pytorch
+      PACKAGE_TYPE: manywheel
+      # TODO: This is a legacy variable that we eventually want to get rid of in
+      #       favor of GPU_ARCH_VERSION
+      DESIRED_CUDA: cu128
+      GPU_ARCH_VERSION: 12.8
+      GPU_ARCH_TYPE: cuda
+      DOCKER_IMAGE: manylinux2_28-builder
+      DOCKER_IMAGE_TAG_PREFIX: cuda12.8
+      use_split_build: False
+      DESIRED_PYTHON: "3.11"
+      build_name: manywheel-py3_11-cuda12_8-full
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
     uses: ./.github/workflows/_binary-upload.yml


### PR DESCRIPTION
This contains 2 fixes that required in main and will need to be cherry-picked to Release 2.8 branch:
1. The PR https://github.com/pytorch/pytorch/pull/155819 missed to include triton change. 
2. CUDA STABLE variable needs to be set to 12.8. Updating CUDA stable updates full static build

