### PR TITLE
Fix typo: 'initalization' → 'initialization' in profiler test comment

### DIFF
--- a/test/profiler/test_torch_tidy.py
+++ b/test/profiler/test_torch_tidy.py
@@ -427,7 +427,7 @@ class TestTorchTidyProfiler(TestCase):
             self.assertEqual(state[0][0], "momentum_buffer")
             self.assertEqual(state[0][1].id, weight_momenumtum_id)
 
-        # Check that we handle first step (lazy initalization) and steady state.
+        # Check that we handle first step (lazy initialization) and steady state.
         check(cold_start=True)
         check(cold_start=False)
 


### PR DESCRIPTION
This PR fixes a minor typo in the comment inside `test/profiler/test_torch_tidy.py`:

- Corrected `initalization` to `initialization`.

Such small corrections help improve the readability and overall polish of the codebase.

Thank you for maintaining this fantastic project. Please let me know if anything else is needed!

