### PR TITLE
Fix typo: 'reset_paramteres' → 'reset_parameters' in transformer module comments

### DIFF
--- a/torch/csrc/api/src/nn/modules/transformer.cpp
+++ b/torch/csrc/api/src/nn/modules/transformer.cpp
@@ -145,7 +145,7 @@ void TransformerDecoderLayerImpl::reset_parameters() {
   multihead_attn->_reset_parameters();
 
   linear1->reset_parameters();
-  // dropout->reset_paramteres();
+  // dropout->reset_parameters();
   linear2->reset_parameters();
 
   norm1->reset_parameters();
@@ -153,7 +153,7 @@ void TransformerDecoderLayerImpl::reset_parameters() {
   norm3->reset_parameters();
   // dropout1->reset_parameters();
   // dropout2->reset_parameters();
-  // dropout3->reset_paramteres();
+  // dropout3->reset_parameters();
 }
 
 /// Pass the inputs (and mask) through the decoder layer.


### PR DESCRIPTION
Hello,

This pull request addresses a small typographical error in the comments of `torch/csrc/api/src/nn/modules/transformer.cpp`. Specifically, it corrects the word `reset_paramteres` to the proper spelling `reset_parameters`.

Although minor, such improvements help enhance code readability and maintain a consistent level of professionalism throughout the codebase. I hope this contributes positively to the overall developer experience.

Thank you very much for your time and consideration. Please let me know if any changes are needed.

Warm regards,  
Abhishek Nandy

