### PR TITLE
Fix typo: 'initalizer' → 'initializer' in test_reductions.cpp

### DIFF
--- a/test/cpp/tensorexpr/test_reductions.cpp
+++ b/test/cpp/tensorexpr/test_reductions.cpp
@@ -333,7 +333,7 @@ TEST(Reductions, ReduceMinCustomInitializer) {
   cg.call({in, out, std::numeric_limits<float>::max()});
   ASSERT_EQ(out[0], 10);
 
-  // With an initalizer lower than the min, that's the min.
+  // With an initializer lower than the min, that's the min.
   cg.call({in, out, 5.f});
   ASSERT_EQ(out[0], 5);
 }


### PR DESCRIPTION
This pull request corrects a minor typographical error in a comment within the file `test/cpp/tensorexpr/test_reductions.cpp`.

###  Change Summary:
- Replaced `initalizer` with the correct spelling `initializer`.

Although this is a non-functional change, fixing such typos contributes to improved readability, and consistency across the codebase.

If there are any additional improvements or changes you'd like me to incorporate, I'd be happy to assist.
Thanks a lot for maintaining such a high class repository.

Thank you very much for your time and consideration!
