### PR TITLE
Enhance APoT quantizer

### DIFF
--- a/test/quantization/core/experimental/test_nonuniform_observer.py
+++ b/test/quantization/core/experimental/test_nonuniform_observer.py
@@ -16,7 +16,7 @@ class TestNonUniformObserver(unittest.TestCase):
         obs.max_val = torch.tensor([0.0])
 
         with self.assertRaises(AssertionError):
-            alpha, gamma, quantization_levels, level_indices = obs.calculate_qparams(signed=False)
+            alpha, gamma, quantization_levels, level_indices, quantization_partitions = obs.calculate_qparams(signed=False)
 
     """
         Test case 2: calculate_qparams
@@ -32,7 +32,7 @@ class TestNonUniformObserver(unittest.TestCase):
 
         obs.min_val = torch.tensor([0.0])
         obs.max_val = torch.tensor([1.0])
-        alpha, gamma, quantization_levels, level_indices = obs.calculate_qparams(signed=False)
+        alpha, gamma, quantization_levels, level_indices, quantization_partitions = obs.calculate_qparams(signed=False)
 
         alpha_test = torch.max(-obs.min_val, obs.max_val)
 
@@ -74,7 +74,7 @@ class TestNonUniformObserver(unittest.TestCase):
 
         obs.min_val = torch.tensor([0.0])
         obs.max_val = torch.tensor([1.0])
-        alpha, gamma, quantization_levels, level_indices = obs.calculate_qparams(signed=False)
+        alpha, gamma, quantization_levels, level_indices, quantization_partitions = obs.calculate_qparams(signed=False)
 
         alpha_test = torch.max(-obs.min_val, obs.max_val)
 
@@ -118,7 +118,7 @@ class TestNonUniformObserver(unittest.TestCase):
 
         obs.min_val = torch.tensor([0.0])
         obs.max_val = torch.tensor([1.0])
-        alpha, gamma, quantization_levels, level_indices = obs.calculate_qparams(signed=True)
+        alpha, gamma, quantization_levels, level_indices, quantization_partitions = obs.calculate_qparams(signed=True)
         alpha_test = torch.max(-obs.min_val, obs.max_val)
 
         # check alpha value
@@ -168,7 +168,7 @@ class TestNonUniformObserver(unittest.TestCase):
         obs.min_val = torch.tensor([0.0])
         obs.max_val = torch.tensor([1.0])
 
-        alpha, gamma, quantization_levels, level_indices = obs.calculate_qparams(signed=False)
+        alpha, gamma, quantization_levels, level_indices, quantization_partitions = obs.calculate_qparams(signed=False)
 
         # calculate expected gamma value
         gamma_test = 0
@@ -205,7 +205,7 @@ class TestNonUniformObserver(unittest.TestCase):
 
         X = obs.forward(X)
 
-        alpha, gamma, quantization_levels, level_indices = obs.calculate_qparams(signed=True)
+        alpha, gamma, quantization_levels, level_indices, quantization_partitions = obs.calculate_qparams(signed=True)
 
         min_val = torch.min(X)
         max_val = torch.max(X)

--- a/test/quantization/core/experimental/test_quantized_tensor.py
+++ b/test/quantization/core/experimental/test_quantized_tensor.py
@@ -24,7 +24,8 @@ class TestQuantizedTensor(unittest.TestCase):
                                 alpha=qparams[0],
                                 gamma=qparams[1],
                                 quantization_levels=qparams[2],
-                                level_indices=qparams[3])
+                                level_indices=qparams[3],
+                                quantization_partitions=qparams[4])
 
         qtensor_data = qtensor.int_repr().int()
 

--- a/test/quantization/core/experimental/test_quantizer.py
+++ b/test/quantization/core/experimental/test_quantizer.py
@@ -26,14 +26,15 @@ class TestQuantizer(unittest.TestCase):
 
         apot_observer = APoTObserver(b=8, k=1)
         apot_observer(tensor2quantize)
-        alpha, gamma, quantization_levels, level_indices = apot_observer.calculate_qparams(signed=False)
+        alpha, gamma, quantization_levels, level_indices, quantization_partititons = apot_observer.calculate_qparams(signed=False)
 
         # get apot quantized tensor result
         qtensor = quantize_APoT(tensor2quantize=tensor2quantize,
                                 alpha=alpha,
                                 gamma=gamma,
                                 quantization_levels=quantization_levels,
-                                level_indices=level_indices)
+                                level_indices=level_indices,
+                                quantization_partitions=quantization_partititons)
 
         # get uniform quantization quantized tensor result
         uniform_observer = MinMaxObserver()
@@ -74,14 +75,15 @@ class TestQuantizer(unittest.TestCase):
 
         observer = APoTObserver(b=4, k=2)
         observer.forward(tensor2quantize)
-        alpha, gamma, quantization_levels, level_indices = observer.calculate_qparams(signed=False)
+        alpha, gamma, quantization_levels, level_indices, quantization_partitions = observer.calculate_qparams(signed=False)
 
         # get apot quantized tensor result
         qtensor = quantize_APoT(tensor2quantize=tensor2quantize,
                                 alpha=alpha,
                                 gamma=gamma,
                                 quantization_levels=quantization_levels,
-                                level_indices=level_indices)
+                                level_indices=level_indices,
+                                quantization_partitions=quantization_partitions)
 
         qtensor_data = qtensor.data.int()
 
@@ -114,14 +116,15 @@ class TestQuantizer(unittest.TestCase):
 
         observer.forward(tensor2quantize)
 
-        alpha, gamma, quantization_levels, level_indices = observer.calculate_qparams(signed=False)
+        alpha, gamma, quantization_levels, level_indices, quantization_partitions = observer.calculate_qparams(signed=False)
 
         # make mock apot_tensor
         original_apot = quantize_APoT(tensor2quantize=tensor2quantize,
                                       alpha=alpha,
                                       gamma=gamma,
                                       quantization_levels=quantization_levels,
-                                      level_indices=level_indices)
+                                      level_indices=level_indices,
+                                      quantization_partitions=quantization_partitions)
 
         original_input = torch.clone(original_apot.data).int()
 
@@ -133,7 +136,8 @@ class TestQuantizer(unittest.TestCase):
                                    alpha=alpha,
                                    gamma=gamma,
                                    quantization_levels=quantization_levels,
-                                   level_indices=level_indices)
+                                   level_indices=level_indices,
+                                   quantization_partitions=quantization_partitions)
 
         result = final_apot.data.int()
 
@@ -159,14 +163,15 @@ class TestQuantizer(unittest.TestCase):
 
         observer.forward(tensor2quantize)
 
-        alpha, gamma, quantization_levels, level_indices = observer.calculate_qparams(signed=False)
+        alpha, gamma, quantization_levels, level_indices, quantization_partitions = observer.calculate_qparams(signed=False)
 
         # make mock apot_tensor
         original_apot = quantize_APoT(tensor2quantize=tensor2quantize,
                                       alpha=alpha,
                                       gamma=gamma,
                                       quantization_levels=quantization_levels,
-                                      level_indices=level_indices)
+                                      level_indices=level_indices,
+                                      quantization_partitions=quantization_partitions)
 
         original_input = torch.clone(original_apot.data).int()
 
@@ -178,7 +183,8 @@ class TestQuantizer(unittest.TestCase):
                                    alpha=alpha,
                                    gamma=gamma,
                                    quantization_levels=quantization_levels,
-                                   level_indices=level_indices)
+                                   level_indices=level_indices,
+                                   quantization_partitions=quantization_partitions)
 
         result = final_apot.data.int()
 
@@ -207,14 +213,15 @@ class TestQuantizer(unittest.TestCase):
 
         observer.forward(tensor2quantize)
 
-        alpha, gamma, quantization_levels, level_indices = observer.calculate_qparams(signed=False)
+        alpha, gamma, quantization_levels, level_indices, quantization_partitions = observer.calculate_qparams(signed=False)
 
         # make mock apot_tensor
         original_apot = quantize_APoT(tensor2quantize=tensor2quantize,
                                       alpha=alpha,
                                       gamma=gamma,
                                       quantization_levels=quantization_levels,
-                                      level_indices=level_indices)
+                                      level_indices=level_indices,
+                                      quantization_partitions=quantization_partitions)
 
         # dequantize apot_tensor
         dequantize_result = dequantize_APoT(apot_tensor=original_apot)

--- a/torch/ao/quantization/experimental/apot_utils.py
+++ b/torch/ao/quantization/experimental/apot_utils.py
@@ -4,34 +4,26 @@ This file contains utility functions to convert values
 using APoT nonuniform quantization methods.
 """
 
-import math
+import torch
 
 
 r"""Converts floating point input into APoT number
     based on quantization levels
 """
 
+def float_to_apot_tensor(x, levels, indices, quantization_partitions, alpha):
+    x.clamp_(min=-alpha, max=alpha)
 
-def float_to_apot(x, levels, indices, alpha):
-    # clip values based on alpha
-    if x < -alpha:
-        return -alpha
-    elif x > alpha:
-        return alpha
+    grid = levels.to(x.device)
+    indices = indices.to(x.device)
+    part = quantization_partitions.to(x.device)
 
-    levels_lst = list(levels)
-    indices_lst = list(indices)
+    xhard = torch.searchsorted(part, x, right=False)
+    xhard = torch.clamp(xhard, min=0, max=grid.shape[0]-1)
+    xhard[xhard >= grid.size(0)] = 0
+    xhard = indices[xhard]
 
-    min_delta = math.inf
-    best_idx = 0
-
-    for level, idx in zip(levels_lst, indices_lst):
-        cur_delta = abs(level - x)
-        if cur_delta < min_delta:
-            min_delta = cur_delta
-            best_idx = idx
-
-    return best_idx
+    return xhard
 
 
 r"""Converts floating point input into
@@ -39,25 +31,31 @@ r"""Converts floating point input into
     based on quantization levels
 """
 
+def quant_dequant_tensor(x, levels, indices, quantization_partitions):
+    grid = levels.to(x.device)
+    indices = indices.to(x.device)
+    part = quantization_partitions.to(x.device)
 
-def quant_dequant_util(x, levels, indices):
-    min_delta = math.inf
-    best_fp = 0.0
+    xhard = torch.searchsorted(part, x, right=False)
+    xhard = torch.clamp(xhard, min=0, max=grid.shape[0]-1)
+    xhard[xhard >= grid.size(0)] = 0
+    xhard = grid[xhard]
 
-    for level in levels:
-        cur_delta = abs(level - x)
-        if cur_delta < min_delta:
-            min_delta = cur_delta
-            best_fp = level
-
-    return best_fp
+    return xhard
 
 
 r"""Converts APoT input into floating point number
 based on quantization levels
 """
 
+def apot_to_float_tensor(x_apot, levels, indices):
+    levels = levels.to(x_apot.device)
+    indices = indices.to(x_apot.device)
 
-def apot_to_float(x_apot, levels, indices):
-    idx = list(indices).index(x_apot)
-    return levels[idx]
+    reverse_lookup_map = torch.empty(indices.max().item() + 1, dtype=indices.dtype).to(x_apot.device)
+    reverse_lookup_map[indices] = torch.arange(len(indices), dtype=indices.dtype).to(x_apot.device)
+    idx = reverse_lookup_map[x_apot]
+
+    mapped_values = levels[idx]
+
+    return mapped_values

--- a/torch/ao/quantization/experimental/fake_quantize.py
+++ b/torch/ao/quantization/experimental/fake_quantize.py
@@ -14,6 +14,7 @@ class APoTFakeQuantize(FakeQuantizeBase):
     gamma: Tensor
     quantization_levels: Tensor
     level_indices: Tensor
+    quantization_partitions: Tensor
 
     def __init__(self, observer: Callable = APoTObserver, **observer_kwargs: Any):
         super().__init__()
@@ -22,7 +23,7 @@ class APoTFakeQuantize(FakeQuantizeBase):
 
     def calculate_qparams(  # type: ignore[override]
         self, signed: bool = False
-    ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
         return self.activation_post_process.calculate_qparams(signed=signed)
 
     def forward(self, X: torch.Tensor) -> Tensor:  # type: ignore[override]
@@ -33,6 +34,7 @@ class APoTFakeQuantize(FakeQuantizeBase):
             self.gamma = result[1]
             self.quantization_levels = result[2]
             self.level_indices = result[3]
+            self.quantization_partitions = result[4]
 
         if self.fake_quant_enabled[0] == 1:
             assert (
@@ -40,10 +42,11 @@ class APoTFakeQuantize(FakeQuantizeBase):
                 and self.gamma is not None
                 and self.quantization_levels is not None
                 and self.level_indices is not None
+                and self.quantization_partitions is not None
             ), "Must set qparams for fake quant"
 
             X = fake_quantize_function.apply(
-                X, self.alpha, self.gamma, self.quantization_levels, self.level_indices
+                X, self.alpha, self.gamma, self.quantization_levels, self.level_indices, self.quantization_partitions
             )
 
         return X

--- a/torch/ao/quantization/experimental/linear.py
+++ b/torch/ao/quantization/experimental/linear.py
@@ -46,6 +46,7 @@ class LinearAPoT(WeightedQuantizedModule):
             self.gamma,
             self.quantization_levels,
             self.level_indices,
+            self.quantization_partitions,
         ) = observer.calculate_qparams(signed=False)
 
         quantized_weight = quantize_APoT(
@@ -54,6 +55,7 @@ class LinearAPoT(WeightedQuantizedModule):
             self.gamma,
             self.quantization_levels,
             self.level_indices,
+            self.quantization_partitions,
         )
         self.weight = quantized_weight.data
         self.weight_transposed = torch.transpose(self.weight, 0, 1)
@@ -168,5 +170,6 @@ class LinearAPoT(WeightedQuantizedModule):
         gamma: torch.Tensor,
         quantization_levels: torch.Tensor,
         level_indices: torch.Tensor,
+        quantization_partitions: torch.Tensor,
     ):
         raise NotImplementedError


### PR DESCRIPTION
This is an enhancement to the APoT quantizers.

---

Fixes:
  * Use torch functions (no lambdas), now runs on 'cuda'
  * Update, repair and pass changes with all related tests
  * Massive speed enhancement (previous was 'cpu' only compatible)

Cc: @asl3
