### PR TITLE
[Easy][Profiler] Fix pattern matcher of profiler

### DIFF
--- a/torch/profiler/_pattern_matcher.py
+++ b/torch/profiler/_pattern_matcher.py
@@ -310,7 +310,7 @@ class FP32MatMulPattern(Pattern):
             has_tf32 = False
         else:
             # Anything less than sm_80 is not Ampere which doesn't support TF32
-            has_tf32 = all(int(arch[3:]) >= 80 for arch in torch.cuda.get_arch_list())
+            has_tf32 = all(int(re.sub("sm_|compute_", "", arch)) >= 80 for arch in torch.cuda.get_arch_list())
         return has_tf32 is False or super().skip or not self.prof.record_shapes
 
     def match(self, event: _ProfilerEvent):

--- a/torch/profiler/_pattern_matcher.py
+++ b/torch/profiler/_pattern_matcher.py
@@ -310,7 +310,10 @@ class FP32MatMulPattern(Pattern):
             has_tf32 = False
         else:
             # Anything less than sm_80 is not Ampere which doesn't support TF32
-            has_tf32 = all(int(re.sub("sm_|compute_", "", arch)) >= 80 for arch in torch.cuda.get_arch_list())
+            has_tf32 = all(
+                int(re.sub("sm_|compute_", "", arch)) >= 80
+                for arch in torch.cuda.get_arch_list()
+            )
         return has_tf32 is False or super().skip or not self.prof.record_shapes
 
     def match(self, event: _ProfilerEvent):


### PR DESCRIPTION
Per title, as it fails with the following error if "+PTX" was used in `TORCH_CUDA_ARCH_LIST`:
```
  File "/usr/local/lib/python3.12/dist-packages/torch/profiler/_pattern_matcher.py", line 313, in skip
    has_tf32 = all(int(arch[3:]) >= 80 for arch in torch.cuda.get_arch_list())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/profiler/_pattern_matcher.py", line 313, in <genexpr>
    has_tf32 = all(int(arch[3:]) >= 80 for arch in torch.cuda.get_arch_list())
                   ^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: 'pute_120'
```
Because slicing `arch[3:]` will not end up on having only digits for `compute_120` element of `torch.cuda.get_arch_list()`:
```python
>>> torch.cuda.get_arch_list()
['sm_75', 'sm_80', 'sm_86', 'sm_90', 'sm_100', 'sm_120', 'compute_120'] 
```

cc @ptrblck @msaroufim @eqy @jerryzh168 @robieta @chaekit @guotuofeng @guyang3532 @dzhulgakov @davidberard98 @briancoutinho @sraikund16 @sanrise