### PR TITLE
Avoid writing temporary modules to disk

### DIFF
--- a/test/distributed/nn/jit/test_instantiator.py
+++ b/test/distributed/nn/jit/test_instantiator.py
@@ -45,52 +45,18 @@ class TestInstantiator(TestCase):
         self.assertEqual(return_type_str, "Tuple[Tensor, int, str]")
 
     def test_instantiate_scripted_remote_module_template(self):
-        dir_path = Path(instantiator.INSTANTIATED_TEMPLATE_DIR_PATH)
-
-        # Cleanup.
-        file_paths = dir_path.glob(f"{instantiator._FILE_PREFIX}*.py")
-        for file_path in file_paths:
-            file_path.unlink()
-
-        # Check before run.
-        file_paths = dir_path.glob(f"{instantiator._FILE_PREFIX}*.py")
-        num_files_before = len(list(file_paths))
-        self.assertEqual(num_files_before, 0)
-
         generated_module = instantiator.instantiate_scriptable_remote_module_template(
             MyModuleInterface
         )
         self.assertTrue(hasattr(generated_module, "_remote_forward"))
         self.assertTrue(hasattr(generated_module, "_generated_methods"))
 
-        # Check after run.
-        file_paths = dir_path.glob(f"{instantiator._FILE_PREFIX}*.py")
-        num_files_after = len(list(file_paths))
-        self.assertEqual(num_files_after, 1)
-
     def test_instantiate_non_scripted_remote_module_template(self):
-        dir_path = Path(instantiator.INSTANTIATED_TEMPLATE_DIR_PATH)
-
-        # Cleanup.
-        file_paths = dir_path.glob(f"{instantiator._FILE_PREFIX}*.py")
-        for file_path in file_paths:
-            file_path.unlink()
-
-        # Check before run.
-        file_paths = dir_path.glob(f"{instantiator._FILE_PREFIX}*.py")
-        num_files_before = len(list(file_paths))
-        self.assertEqual(num_files_before, 0)
-
         generated_module = (
             instantiator.instantiate_non_scriptable_remote_module_template()
         )
         self.assertTrue(hasattr(generated_module, "_remote_forward"))
         self.assertTrue(hasattr(generated_module, "_generated_methods"))
-
-        # Check after run.
-        file_paths = dir_path.glob(f"{instantiator._FILE_PREFIX}*.py")
-        num_files_after = len(list(file_paths))
-        self.assertEqual(num_files_after, 1)
 
 
 if __name__ == "__main__":

--- a/test/distributed/nn/jit/test_instantiator.py
+++ b/test/distributed/nn/jit/test_instantiator.py
@@ -2,7 +2,6 @@
 # Owner(s): ["oncall: distributed"]
 
 import sys
-from pathlib import Path
 
 import torch
 import torch.distributed as dist

--- a/torch/distributed/nn/jit/instantiator.py
+++ b/torch/distributed/nn/jit/instantiator.py
@@ -1,11 +1,8 @@
 #!/usr/bin/python3
 # mypy: allow-untyped-defs
-import atexit
 import importlib
-import logging
-import os
+import importlib.util
 import sys
-import tempfile
 from typing import Optional
 
 import torch
@@ -14,15 +11,7 @@ from torch.distributed.nn.jit.templates.remote_module_template import (
 )
 
 
-logger = logging.getLogger(__name__)
-
-
 _FILE_PREFIX = "_remote_module_"
-_TEMP_DIR = tempfile.TemporaryDirectory()
-INSTANTIATED_TEMPLATE_DIR_PATH = _TEMP_DIR.name
-atexit.register(_TEMP_DIR.cleanup)
-logger.info("Created a temporary directory at %s", INSTANTIATED_TEMPLATE_DIR_PATH)
-sys.path.append(INSTANTIATED_TEMPLATE_DIR_PATH)
 
 
 def get_arg_return_types_from_interface(module_interface):
@@ -63,40 +52,35 @@ def get_arg_return_types_from_interface(module_interface):
     return args_str, arg_types_str, return_type_str
 
 
-def _write(out_path, text):
-    old_text: Optional[str]
-    try:
-        with open(out_path) as f:
-            old_text = f.read()
-    except OSError:
-        old_text = None
-    if old_text != text:
-        with open(out_path, "w") as f:
-            logger.info("Writing %s", out_path)
-            f.write(text)
-    else:
-        logger.info("Skipped writing %s", out_path)
+class StringLoader(importlib.abc.SourceLoader):
+    def __init__(self, data):
+        self.data = data
+
+    def get_source(self, fullname):
+        return self.data
+    
+    def get_data(self, path):
+        return self.data.encode("utf-8")
+    
+    def get_filename(self, fullname):
+        return fullname
 
 
 def _do_instantiate_remote_module_template(
     generated_module_name, str_dict, enable_moving_cpu_tensors_to_cuda
 ):
-    generated_code_text = get_remote_module_template(
-        enable_moving_cpu_tensors_to_cuda
-    ).format(**str_dict)
-    out_path = os.path.join(
-        INSTANTIATED_TEMPLATE_DIR_PATH, f"{generated_module_name}.py"
-    )
-    _write(out_path, generated_code_text)
+    if generated_module_name in sys.modules:
+        return sys.modules[generated_module_name]
 
-    # From importlib doc,
-    # > If you are dynamically importing a module that was created since
-    # the interpreter began execution (e.g., created a Python source file),
-    # you may need to call invalidate_caches() in order for the new module
-    # to be noticed by the import system.
-    importlib.invalidate_caches()
-    generated_module = importlib.import_module(f"{generated_module_name}")
-    return generated_module
+    spec = importlib.util.spec_from_loader(
+        generated_module_name,
+        StringLoader(get_remote_module_template(enable_moving_cpu_tensors_to_cuda).format(**str_dict)),
+        origin='torch-jit',
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[generated_module_name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def instantiate_scriptable_remote_module_template(

--- a/torch/distributed/nn/jit/instantiator.py
+++ b/torch/distributed/nn/jit/instantiator.py
@@ -71,8 +71,12 @@ def _do_instantiate_remote_module_template(
     if generated_module_name in sys.modules:
         return sys.modules[generated_module_name]
 
-    loader = _StringLoader(get_remote_module_template(enable_moving_cpu_tensors_to_cuda).format(**str_dict))
-    spec = importlib.util.spec_from_loader(generated_module_name, loader, origin='torch-git')
+    loader = _StringLoader(
+        get_remote_module_template(enable_moving_cpu_tensors_to_cuda).format(**str_dict)
+    )
+    spec = importlib.util.spec_from_loader(
+        generated_module_name, loader, origin="torch-git"
+    )
     assert spec is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[generated_module_name] = module


### PR DESCRIPTION
In some cases the warning from #147744 still gets emitted because [atexit hooks aren't called](https://github.com/python/cpython/pull/114279).

Even in those cases, if the atexit hooks _were_ called you could end up with issues due to the directory being deleted in one process, but still being used elsewhere.

It's better all round to load these modules entirely in-memory.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci @EikanWang @jgong5 @wenzhe-nrv @sanchitintel