### PR TITLE
[2/N] cost coverage improvment 

### DIFF
--- a/torch/distributed/tensor/_ops/_random_ops.py
+++ b/torch/distributed/tensor/_ops/_random_ops.py
@@ -31,6 +31,12 @@ def random_op_strategy(op_schema: OpSchema) -> StrategyType:
         if is_tensor_partial(arg_spec):
             # TODO: figure out how inplace random op should behave when it's partial
             raise RuntimeError(f"{op_schema.op} with Partial is not supported yet!")
-        random_strategy.strategies.append(OpSpec(output_specs=arg_spec))
+        random_strategy.strategies.append(
+            OpSpec(
+                output_specs=arg_spec,
+                input_specs=(arg_spec,),
+                redistribute_cost=[[0.0] * len(self_strategy.strategies)],
+            )
+        )
 
     return random_strategy

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -44,6 +44,18 @@ def default_strategy(op_schema: OpSchema) -> StrategyType:
     assert isinstance(select_strategy, OpStrategy)
     # we create new DTensorSpecs even for default strategy to assure that
     # the tensor metas are distinct between the arguments and outputs
+    input_specs = []
+    redistribute_cost = []
+    for i in op_schema.args_schema:
+        input_specs.append(
+            DTensorSpec(
+                mesh=select_strategy.mesh,
+                placements=select_strategy.strategies[0].output_spec.placements,
+                tensor_meta=select_strategy.strategies[0].output_spec.tensor_meta,
+            )
+        )
+        redistribute_cost.append([0.0] * len(select_strategy.strategies))
+
     default_strategy = [
         OpSpec(
             output_specs=DTensorSpec(
@@ -51,14 +63,8 @@ def default_strategy(op_schema: OpSchema) -> StrategyType:
                 placements=strategy.output_spec.placements,
                 tensor_meta=strategy.output_spec.tensor_meta,
             ),
-            input_specs=[
-                DTensorSpec(
-                    mesh=select_strategy.mesh,
-                    placements=strategy.output_spec.placements,
-                    tensor_meta=strategy.output_spec.tensor_meta,
-                )
-            ],
-            redistribute_cost=[[0.0] * len(select_strategy.strategies)],
+            input_specs=input_specs,
+            redistribute_cost=redistribute_cost,
         )
         for strategy in select_strategy.strategies
     ]

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -49,7 +49,16 @@ def default_strategy(op_schema: OpSchema) -> StrategyType:
             output_specs=DTensorSpec(
                 mesh=select_strategy.mesh,
                 placements=strategy.output_spec.placements,
-            )
+                tensor_meta=strategy.output_spec.tensor_meta,
+            ),
+            input_specs=[
+                DTensorSpec(
+                    mesh=select_strategy.mesh,
+                    placements=strategy.output_spec.placements,
+                    tensor_meta=strategy.output_spec.tensor_meta,
+                )
+            ],
+            redistribute_cost=[[0.0] * len(select_strategy.strategies)],
         )
         for strategy in select_strategy.strategies
     ]
@@ -191,7 +200,7 @@ def new_factory_strategy(op_schema: OpSchema) -> StrategyType:
             OpSpec(
                 output_specs=replica_spec,
                 input_specs=(input_spec,),
-                redistribute_cost=[[0.0] * mesh.ndim],
+                redistribute_cost=[[0.0] * len(input_strategy.strategies)],
             )
         )
 
@@ -209,7 +218,7 @@ def new_factory_strategy(op_schema: OpSchema) -> StrategyType:
                     output_specs=input_spec,
                     input_specs=(input_spec,),
                     # encouraging new tensor placement to be the same as input
-                    redistribute_cost=[[-0.1] * mesh.ndim],
+                    redistribute_cost=[[-0.1] * len(input_strategy.strategies)],
                 )
             )
 
@@ -220,14 +229,30 @@ def new_factory_strategy(op_schema: OpSchema) -> StrategyType:
 def gen_bucketize_strategy(op_schema: OpSchema) -> StrategyType:
     """Just propagate input sharding, but expect replicated for boundaries input."""
     mesh = op_schema.get_mesh_from_args()
-    input_strategy = op_schema.args_schema[0]
+    input_strategy, boundaries_strategy = op_schema.args_schema
     bucketize_strategy = OpStrategy([])
     assert isinstance(input_strategy, OpStrategy)
+    assert isinstance(boundaries_strategy, OpStrategy)
     for arg_strategy in input_strategy.strategies:
-        arg_spec = DTensorSpec(mesh, arg_strategy.output_spec.placements)
-        replica_spec = DTensorSpec(mesh, tuple([Replicate()] * mesh.ndim))
+        arg_spec = DTensorSpec(
+            mesh,
+            arg_strategy.output_spec.placements,
+            arg_strategy.output_spec.tensor_meta,
+        )
+        replica_spec = DTensorSpec(
+            mesh,
+            tuple([Replicate()] * mesh.ndim),
+            boundaries_strategy.strategies[0].output_spec.tensor_meta,
+        )
         bucketize_strategy.strategies.append(
-            OpSpec(output_specs=arg_spec, input_specs=(arg_spec, replica_spec))
+            OpSpec(
+                output_specs=arg_spec,
+                input_specs=(arg_spec, replica_spec),
+                redistribute_cost=[
+                    generate_redistribute_costs(input_strategy, arg_spec),
+                    generate_redistribute_costs(boundaries_strategy, replica_spec),
+                ],
+            )
         )
 
     return bucketize_strategy
@@ -667,12 +692,20 @@ def stack_strategy(op_schema: OpSchema) -> StrategyType:
 
     follow_placements = normalize_shard_for_stack(follow_placements, dim)
 
-    op_strategy.strategies.append(
-        OpSpec(
-            output_specs=DTensorSpec(mesh, tuple(follow_placements)),
-            input_specs=input_specs,
+    for strategy in input_tuple_strategy.childs:
+        assert isinstance(strategy, OpStrategy)
+        output_spec = DTensorSpec(mesh, tuple(follow_placements))
+        redistribute_cost = []
+        for input_spec in input_specs:
+            cost = generate_redistribute_costs(strategy, input_spec)
+            redistribute_cost.append(cost)
+        op_strategy.strategies.append(
+            OpSpec(
+                output_specs=output_spec,
+                input_specs=input_specs,
+                redistribute_cost=redistribute_cost,
+            )
         )
-    )
     return op_strategy
 
 

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -741,8 +741,8 @@ def cat_strategy(op_schema: OpSchema) -> StrategyType:
     args_schema = op_schema.args_schema
     input_tuple_strategy = args_schema[0]
     assert isinstance(input_tuple_strategy, TupleStrategy), f"{input_tuple_strategy}"
-    num_input_tensor = len(input_tuple_strategy.childs)
-    first_input_strategy = input_tuple_strategy.childs[0]
+    num_input_tensor = len(input_tuple_strategy.children)
+    first_input_strategy = input_tuple_strategy.children[0]
     assert isinstance(first_input_strategy, OpStrategy), f"{first_input_strategy}"
     common_input_ndim = first_input_strategy.ndim
     dim = cast(int, args_schema[1]) if len(args_schema) > 1 else 0
@@ -754,7 +754,7 @@ def cat_strategy(op_schema: OpSchema) -> StrategyType:
     op_strategy = OpStrategy([])
     # use a set to deduplicate strategies with the same placement
     strategies_placement_pool = set()
-    for this_strategy in input_tuple_strategy.childs:
+    for this_strategy in input_tuple_strategy.children:
         # check strategy of each tensor to be concatenated
         assert isinstance(this_strategy, OpStrategy)
         assert this_strategy.mesh == mesh, (
@@ -782,7 +782,7 @@ def cat_strategy(op_schema: OpSchema) -> StrategyType:
                 input_specs = []
                 for idx in range(num_input_tensor):
                     # extract the strategy for the idx tensors to build the tensor_metadata and redistribute_cost
-                    that_tensor_strategy = input_tuple_strategy.childs[idx]
+                    that_tensor_strategy = input_tuple_strategy.children[idx]
                     assert isinstance(that_tensor_strategy, OpStrategy)
                     input_spec = DTensorSpec(
                         mesh,

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -481,7 +481,9 @@ def gen_slice_scatter_strategy(op_schema: OpSchema) -> StrategyType:
     #   TODO: Ideally we'd like to make sure the output is re-sharded afterwards to keep input sharding.
     mesh = op_schema.get_mesh_from_args()
     input_strategy = op_schema.args_schema[0]
+    src_strategy = op_schema.args_schema[1]
     assert isinstance(input_strategy, OpStrategy)
+    assert isinstance(src_strategy, OpStrategy)
     input_ndim = input_strategy.ndim
     slice_dim = (
         cast(int, op_schema.args_schema[2]) if len(op_schema.args_schema) > 2 else 0
@@ -496,19 +498,38 @@ def gen_slice_scatter_strategy(op_schema: OpSchema) -> StrategyType:
             is_tensor_dim_sharded(arg_spec, dim=slice_dim)
             or is_tensor_partial(arg_spec)
         ):
+            input_spec = DTensorSpec(mesh, arg_spec.placements, arg_spec.tensor_meta)
+            # TODO: need to relax the constraint to src
+            src_spec = DTensorSpec(mesh, arg_spec.placements)
             # only add the strategy if the slice_scatter dim is not sharded or partial
-            slice_scatter_strategy.strategies.append(OpSpec(output_specs=arg_spec))
+            slice_scatter_strategy.strategies.append(
+                OpSpec(
+                    output_specs=arg_spec,
+                    input_specs=(input_spec, src_spec),
+                    redistribute_cost=[
+                        generate_redistribute_costs(input_strategy, input_spec),
+                        generate_redistribute_costs(input_strategy, src_spec),
+                    ],
+                )
+            )
 
     if not slice_scatter_strategy.strategies:
         # if all strategies are filtered out, replicating all specs on slice_scatter dim
         # of the input strategy, and use that as the op strategy
         for arg_strategy in input_strategy.strategies:
             arg_spec = arg_strategy.output_spec
-            replicate_spec = DTensorSpec(
-                mesh, replicate_tensor_dim(arg_spec.placements, dim=slice_dim)
-            )
+            new_placement = replicate_tensor_dim(arg_spec.placements, dim=slice_dim)
+            input_spec = DTensorSpec(mesh, new_placement)
+            src_spec = DTensorSpec(mesh, new_placement)
             slice_scatter_strategy.strategies.append(
-                OpSpec(output_specs=replicate_spec)
+                OpSpec(
+                    output_specs=input_spec,
+                    input_specs=(input_spec, src_spec),
+                    redistribute_cost=[
+                        generate_redistribute_costs(input_strategy, input_spec),
+                        generate_redistribute_costs(input_strategy, src_spec),
+                    ],
+                )
             )
     return slice_scatter_strategy
 
@@ -737,15 +758,21 @@ def cat_strategy(op_schema: OpSchema) -> StrategyType:
 
     # create op strategy base on the follow placements
     op_strategy = OpStrategy([])
+    redistribute_costs = []
+    input_specs = []
+    for _ in range(len(input_tuple_strategy.childs)):
+        assert isinstance(input_tuple_strategy.childs, OpStrategy)
+        input_spec = DTensorSpec(mesh, tuple(follow_placements))
+        input_specs.append(input_spec)
+        redistribute_costs.append(
+            generate_redistribute_costs(input_tuple_strategy.childs, input_spec)
+        )
 
-    input_specs = tuple(
-        DTensorSpec(mesh, tuple(follow_placements))
-        for _ in range(len(input_tuple_strategy.children))
-    )
     op_strategy.strategies.append(
         OpSpec(
             output_specs=DTensorSpec(mesh, tuple(follow_placements)),
-            input_specs=input_specs,
+            input_specs=tuple(input_specs),
+            redistribute_cost=redistribute_costs,
         )
     )
     return op_strategy

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -760,14 +760,14 @@ def cat_strategy(op_schema: OpSchema) -> StrategyType:
         assert this_strategy.mesh == mesh, (
             "cat op doesn't support cross mesh concatenation"
         )
-        for strategy in this_strategy.strategies:
-            # Check each strategy of the tensor, the placement in this strategy
+        for op_spec in this_strategy.strategies:
+            # Check each OpSpec of the tensor, the placement in this OpSpec
             # is used as the exemplar strategy that other tensors and output
             # tensor should follow. We also need to deduplicate the output
             # strategy with the same placement.
-            assert isinstance(strategy, OpSpec)
-            # exemplar strategy to follow
-            exemplar_spec = strategy.output_spec
+            assert isinstance(op_spec, OpSpec)
+            # exemplar OpSpec to follow
+            exemplar_spec = op_spec.output_spec
             # check if the tensor is sharded on the concat dim
             if is_tensor_dim_sharded(exemplar_spec, dim):
                 # if the tensor is sharded on the concat dim, we need to unshard it

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -698,7 +698,7 @@ def stack_strategy(op_schema: OpSchema) -> StrategyType:
 
     follow_placements = normalize_shard_for_stack(follow_placements, dim)
 
-    for strategy in input_tuple_strategy.childs:
+    for strategy in input_tuple_strategy.children:
         assert isinstance(strategy, OpStrategy)
         output_spec = DTensorSpec(mesh, tuple(follow_placements))
         redistribute_cost = []

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -760,12 +760,12 @@ def cat_strategy(op_schema: OpSchema) -> StrategyType:
     op_strategy = OpStrategy([])
     redistribute_costs = []
     input_specs = []
-    for _ in range(len(input_tuple_strategy.childs)):
-        assert isinstance(input_tuple_strategy.childs, OpStrategy)
+    for this_strategy in input_tuple_strategy.childs:
+        assert isinstance(this_strategy, OpStrategy)
         input_spec = DTensorSpec(mesh, tuple(follow_placements))
         input_specs.append(input_spec)
         redistribute_costs.append(
-            generate_redistribute_costs(input_tuple_strategy.childs, input_spec)
+            generate_redistribute_costs(this_strategy, input_spec)
         )
 
     op_strategy.strategies.append(


### PR DESCRIPTION
Part of plan https://github.com/pytorch/pytorch/issues/157495.

Details:
1. Fill in missing redistribute_cost in `cat` and `slice_scatter`;
2. Expand the `cat` strategy based on placement of each input tensor. Previously `cat` only outputs one strategy. Now it output at the level of number_of_input_tensor*number_OpSpec_each_tensor_input_strategy.


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k