### PR TITLE
Expose opt_einsum in torch.backends

### DIFF
--- a/torch/backends/__init__.py
+++ b/torch/backends/__init__.py
@@ -136,5 +136,6 @@ from torch.backends import (
     mps as mps,
     nnpack as nnpack,
     openmp as openmp,
+    opt_einsum as opt_einsum,
     quantized as quantized,
 )


### PR DESCRIPTION
Fixes the following issue:
```
:/tmp# python -c "import torch; print(torch.__version__)"
2.7.1+cu126
:/tmp# python -c "import torch; print(torch.backends.opt_einsum.is_available())"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
AttributeError: module 'torch.backends' has no attribute 'opt_einsum'
```

