### PR TITLE
Migrate pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc11 -> pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc13

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -102,11 +102,11 @@ case "$tag" in
     UCC_COMMIT=${_UCC_COMMIT}
     TRITON=yes
     ;;
-  pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc11)
+  pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc13)
     CUDA_VERSION=12.8.1
     CUDNN_VERSION=9
     ANACONDA_PYTHON_VERSION=3.10
-    GCC_VERSION=11
+    GCC_VERSION=13
     VISION=yes
     KATEX=yes
     UCX_COMMIT=${_UCX_COMMIT}

--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -509,10 +509,12 @@ HAS_TRITON=$(drun python -c "import triton" > /dev/null 2>&1 && echo "yes" || ec
 if [[ -n "$TRITON" || -n "$TRITON_CPU" ]]; then
   if [ "$HAS_TRITON" = "no" ]; then
     echo "expecting triton to be installed, but it is not"
+    drun python -c "import triton"
     exit 1
   fi
 elif [ "$HAS_TRITON" = "yes" ]; then
   echo "expecting triton to not be installed, but it is"
+  drun python -c "import triton"
   exit 1
 fi
 

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -49,7 +49,7 @@ jobs:
       matrix:
         runner: [linux.12xlarge]
         docker-image-name: [
-          pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc11,
+          pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc13,
           pytorch-linux-jammy-cuda12.6-cudnn9-py3-gcc9-inductor-benchmarks,
           pytorch-linux-jammy-cuda12.6-cudnn9-py3.12-gcc9-inductor-benchmarks,
           pytorch-linux-jammy-cuda12.6-cudnn9-py3.13-gcc9-inductor-benchmarks,

--- a/.github/workflows/h100-distributed.yml
+++ b/.github/workflows/h100-distributed.yml
@@ -31,7 +31,7 @@ jobs:
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
 
-  linux-jammy-cuda12.8-py3_10-gcc13-sm90-build-dist:
+  linux-jammy-cuda12_8-py3_10-gcc13-sm90-build-dist:
     name: linux-jammy-cuda12.8-py3.10-gcc13-sm90-dist
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
@@ -51,9 +51,9 @@ jobs:
     name: linux-jammy-cuda12.8-py3.10-gcc13-sm90-dist
     uses: ./.github/workflows/_linux-test.yml
     needs:
-      - linux-jammy-cuda12.8-py3_10-gcc13-sm90-build-dist
+      - linux-jammy-cuda12_8-py3_10-gcc13-sm90-build-dist
     with:
       build-environment: linux-jammy-cuda12.8-py3.10-gcc13-sm90-dist
-      docker-image: ${{ needs.linux-jammy-cuda12.8-py3_10-gcc13-sm90-build-dist.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-cuda12.8-py3_10-gcc13-sm90-build-dist.outputs.test-matrix }}
+      docker-image: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc13-sm90-build-dist.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc13-sm90-build-dist.outputs.test-matrix }}
     secrets: inherit

--- a/.github/workflows/h100-distributed.yml
+++ b/.github/workflows/h100-distributed.yml
@@ -31,7 +31,7 @@ jobs:
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
 
-  linux-jammy-cuda12.8-py3.10-gcc13-sm90-build-dist:
+  linux-jammy-cuda12.8-py3_10-gcc13-sm90-build-dist:
     name: linux-jammy-cuda12.8-py3.10-gcc13-sm90-dist
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
@@ -47,13 +47,13 @@ jobs:
         ]}
     secrets: inherit
 
-  linux-jammy-cuda12.8-py3.10-gcc13-sm90-test:
+  linux-jammy-cuda12_8-py3_10-gcc13-sm90-test:
     name: linux-jammy-cuda12.8-py3.10-gcc13-sm90-dist
     uses: ./.github/workflows/_linux-test.yml
     needs:
-      - linux-jammy-cuda12.8-py3.10-gcc13-sm90-build-dist
+      - linux-jammy-cuda12.8-py3_10-gcc13-sm90-build-dist
     with:
       build-environment: linux-jammy-cuda12.8-py3.10-gcc13-sm90-dist
-      docker-image: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-sm90-build-dist.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-sm90-build-dist.outputs.test-matrix }}
+      docker-image: ${{ needs.linux-jammy-cuda12.8-py3_10-gcc13-sm90-build-dist.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-cuda12.8-py3_10-gcc13-sm90-build-dist.outputs.test-matrix }}
     secrets: inherit

--- a/.github/workflows/h100-distributed.yml
+++ b/.github/workflows/h100-distributed.yml
@@ -39,7 +39,7 @@ jobs:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       runner: "linux.12xlarge"
       build-environment: linux-jammy-cuda12.8-py3.10-gcc11-sm90-dist
-      docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc11
+      docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc13
       cuda-arch-list: '9.0'
       test-matrix: |
         { include: [

--- a/.github/workflows/h100-distributed.yml
+++ b/.github/workflows/h100-distributed.yml
@@ -31,14 +31,14 @@ jobs:
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
 
-  linux-jammy-cuda12_8-py3_10-gcc11-sm90-build-dist:
-    name: linux-jammy-cuda12.8-py3.10-gcc11-sm90-dist
+  linux-jammy-cuda12.8-py3.10-gcc13-sm90-build-dist:
+    name: linux-jammy-cuda12.8-py3.10-gcc13-sm90-dist
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       runner: "linux.12xlarge"
-      build-environment: linux-jammy-cuda12.8-py3.10-gcc11-sm90-dist
+      build-environment: linux-jammy-cuda12.8-py3.10-gcc13-sm90-dist
       docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc13
       cuda-arch-list: '9.0'
       test-matrix: |
@@ -47,13 +47,13 @@ jobs:
         ]}
     secrets: inherit
 
-  linux-jammy-cuda12_8-py3_10-gcc11-sm90-test:
-    name: linux-jammy-cuda12.8-py3.10-gcc11-sm90-dist
+  linux-jammy-cuda12.8-py3.10-gcc13-sm90-test:
+    name: linux-jammy-cuda12.8-py3.10-gcc13-sm90-dist
     uses: ./.github/workflows/_linux-test.yml
     needs:
-      - linux-jammy-cuda12_8-py3_10-gcc11-sm90-build-dist
+      - linux-jammy-cuda12.8-py3.10-gcc13-sm90-build-dist
     with:
-      build-environment: linux-jammy-cuda12.8-py3.10-gcc11-sm90-dist
-      docker-image: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc11-sm90-build-dist.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc11-sm90-build-dist.outputs.test-matrix }}
+      build-environment: linux-jammy-cuda12.8-py3.10-gcc13-sm90-dist
+      docker-image: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-sm90-build-dist.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-sm90-build-dist.outputs.test-matrix }}
     secrets: inherit

--- a/.github/workflows/h100-symm-mem.yml
+++ b/.github/workflows/h100-symm-mem.yml
@@ -46,7 +46,7 @@ jobs:
         ]}
     secrets: inherit
 
-  linux-jammy-cuda12.8-py3.10-gcc13-sm90-test:
+  linux-jammy-cuda12_8-py3_10-gcc13-sm90-test:
     name: linux-jammy-cuda12.8-py3.10-gcc13-sm90-symm
     uses: ./.github/workflows/_linux-test.yml
     needs:

--- a/.github/workflows/h100-symm-mem.yml
+++ b/.github/workflows/h100-symm-mem.yml
@@ -31,7 +31,7 @@ jobs:
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
 
-  linux-jammy-cuda12.8-py3.10-gcc13-sm90-build-symm:
+  linux-jammy-cuda12_8-py3_10-gcc13-sm90-build-symm:
     name: linux-jammy-cuda12.8-py3.10-gcc13-sm90-symm
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
@@ -50,9 +50,9 @@ jobs:
     name: linux-jammy-cuda12.8-py3.10-gcc13-sm90-symm
     uses: ./.github/workflows/_linux-test.yml
     needs:
-      - linux-jammy-cuda12.8-py3.10-gcc13-sm90-build-symm
+      - linux-jammy-cuda12_8-py3_10-gcc13-sm90-build-symm
     with:
       build-environment: linux-jammy-cuda12.8-py3.10-gcc13-sm90-symm
-      docker-image: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-sm90-build-symm.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-sm90-build-symm.outputs.test-matrix }}
+      docker-image: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc13-sm90-build-symm.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc13-sm90-build-symm.outputs.test-matrix }}
     secrets: inherit

--- a/.github/workflows/h100-symm-mem.yml
+++ b/.github/workflows/h100-symm-mem.yml
@@ -38,7 +38,7 @@ jobs:
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build-environment: linux-jammy-cuda12.8-py3.10-gcc11-sm90-symm
-      docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc11
+      docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc13
       cuda-arch-list: '9.0'
       test-matrix: |
         { include: [

--- a/.github/workflows/h100-symm-mem.yml
+++ b/.github/workflows/h100-symm-mem.yml
@@ -31,13 +31,13 @@ jobs:
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
 
-  linux-jammy-cuda12_8-py3_10-gcc11-sm90-build-symm:
-    name: linux-jammy-cuda12.8-py3.10-gcc11-sm90-symm
+  linux-jammy-cuda12.8-py3.10-gcc13-sm90-build-symm:
+    name: linux-jammy-cuda12.8-py3.10-gcc13-sm90-symm
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-jammy-cuda12.8-py3.10-gcc11-sm90-symm
+      build-environment: linux-jammy-cuda12.8-py3.10-gcc13-sm90-symm
       docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc13
       cuda-arch-list: '9.0'
       test-matrix: |
@@ -46,13 +46,13 @@ jobs:
         ]}
     secrets: inherit
 
-  linux-jammy-cuda12_8-py3_10-gcc11-sm90-test:
-    name: linux-jammy-cuda12.8-py3.10-gcc11-sm90-symm
+  linux-jammy-cuda12.8-py3.10-gcc13-sm90-test:
+    name: linux-jammy-cuda12.8-py3.10-gcc13-sm90-symm
     uses: ./.github/workflows/_linux-test.yml
     needs:
-      - linux-jammy-cuda12_8-py3_10-gcc11-sm90-build-symm
+      - linux-jammy-cuda12.8-py3.10-gcc13-sm90-build-symm
     with:
-      build-environment: linux-jammy-cuda12.8-py3.10-gcc11-sm90-symm
-      docker-image: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc11-sm90-build-symm.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc11-sm90-build-symm.outputs.test-matrix }}
+      build-environment: linux-jammy-cuda12.8-py3.10-gcc13-sm90-symm
+      docker-image: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-sm90-build-symm.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-sm90-build-symm.outputs.test-matrix }}
     secrets: inherit

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -112,7 +112,7 @@ jobs:
       test-matrix: ${{ needs.linux-jammy-cuda12_4-py3_10-gcc11-build.outputs.test-matrix }}
     secrets: inherit
 
-  linux-jammy-cuda12.8-py3.10-gcc13-build:
+  linux-jammy-cuda12_8-py3_10-gcc13-build:
     name: linux-jammy-cuda12.8-py3.10-gcc13
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
@@ -131,16 +131,16 @@ jobs:
         ]}
     secrets: inherit
 
-  linux-jammy-cuda12.8-py3.10-gcc13-test:
+  linux-jammy-cuda12_8-py3_10-gcc13-test:
     name: linux-jammy-cuda12.8-py3.10-gcc13
     uses: ./.github/workflows/_linux-test.yml
     needs:
-      - linux-jammy-cuda12.8-py3.10-gcc13-build
+      - linux-jammy-cuda12_8-py3_10-gcc13-build
       - target-determination
     with:
       build-environment: linux-jammy-cuda12.8-py3.10-gcc13
-      docker-image: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-build.outputs.test-matrix }}
+      docker-image: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc13-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc13-build.outputs.test-matrix }}
     secrets: inherit
 
   linux-jammy-cuda12_8-py3_9-gcc9-build:

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -112,13 +112,13 @@ jobs:
       test-matrix: ${{ needs.linux-jammy-cuda12_4-py3_10-gcc11-build.outputs.test-matrix }}
     secrets: inherit
 
-  linux-jammy-cuda12_8-py3_10-gcc11-build:
-    name: linux-jammy-cuda12.8-py3.10-gcc11
+  linux-jammy-cuda12.8-py3.10-gcc13-build:
+    name: linux-jammy-cuda12.8-py3.10-gcc13
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-jammy-cuda12.8-py3.10-gcc11
+      build-environment: linux-jammy-cuda12.8-py3.10-gcc13
       docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc13
       test-matrix: |
         { include: [
@@ -131,16 +131,16 @@ jobs:
         ]}
     secrets: inherit
 
-  linux-jammy-cuda12_8-py3_10-gcc11-test:
-    name: linux-jammy-cuda12.8-py3.10-gcc11
+  linux-jammy-cuda12.8-py3.10-gcc13-test:
+    name: linux-jammy-cuda12.8-py3.10-gcc13
     uses: ./.github/workflows/_linux-test.yml
     needs:
-      - linux-jammy-cuda12_8-py3_10-gcc11-build
+      - linux-jammy-cuda12.8-py3.10-gcc13-build
       - target-determination
     with:
-      build-environment: linux-jammy-cuda12.8-py3.10-gcc11
-      docker-image: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc11-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc11-build.outputs.test-matrix }}
+      build-environment: linux-jammy-cuda12.8-py3.10-gcc13
+      docker-image: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-build.outputs.test-matrix }}
     secrets: inherit
 
   linux-jammy-cuda12_8-py3_9-gcc9-build:

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -119,7 +119,7 @@ jobs:
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build-environment: linux-jammy-cuda12.8-py3.10-gcc11
-      docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc11
+      docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc13
       test-matrix: |
         { include: [
           { config: "nogpu_AVX512", shard: 1, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
@@ -241,7 +241,7 @@ jobs:
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build-environment: linux-jammy-cuda12.8-py3-gcc11-slow-gradcheck
-      docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc11
+      docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc13
       cuda-arch-list: 8.6
       test-matrix: |
         { include: [

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -254,13 +254,13 @@ jobs:
       timeout-minutes: 600
     secrets: inherit
 
-  linux-jammy-cuda12_8-py3_10-gcc11-build-distributed:
-    name: linux-jammy-cuda12.8-py3.10-gcc11-build-distributed
+  linux-jammy-cuda12.8-py3.10-gcc13-build-distributed:
+    name: linux-jammy-cuda12.8-py3.10-gcc13-build-distributed
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-jammy-cuda12.8-py3.10-gcc11-distributed
+      build-environment: linux-jammy-cuda12.8-py3.10-gcc13-distributed
       docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc13
       cuda-arch-list: '7.5'
       test-matrix: |
@@ -271,26 +271,26 @@ jobs:
         ]}
     secrets: inherit
 
-  linux-jammy-cuda12_8-py3_10-gcc11-test-distributed:
-    name: linux-jammy-cuda12.8-py3.10-gcc11-test
+  linux-jammy-cuda12.8-py3.10-gcc13-test-distributed:
+    name: linux-jammy-cuda12.8-py3.10-gcc13-test
     uses: ./.github/workflows/_linux-test.yml
     needs:
-      - linux-jammy-cuda12_8-py3_10-gcc11-build-distributed
+      - linux-jammy-cuda12.8-py3.10-gcc13-build-distributed
       - target-determination
     with:
       timeout-minutes: 360
-      build-environment: linux-jammy-cuda12.8-py3.10-gcc11-distributed
-      docker-image: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc11-build-distributed.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc11-build-distributed.outputs.test-matrix }}
+      build-environment: linux-jammy-cuda12.8-py3.10-gcc13-distributed
+      docker-image: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-build-distributed.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-build-distributed.outputs.test-matrix }}
     secrets: inherit
 
-  linux-jammy-cuda12_8-py3_10-gcc11-build:
-    name: linux-jammy-cuda12.8-py3.10-gcc11
+  linux-jammy-cuda12.8-py3.10-gcc13-build:
+    name: linux-jammy-cuda12.8-py3.10-gcc13
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-jammy-cuda12.8-py3.10-gcc11
+      build-environment: linux-jammy-cuda12.8-py3.10-gcc13
       docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc13
       test-matrix: |
         { include: [
@@ -302,17 +302,17 @@ jobs:
         ]}
     secrets: inherit
 
-  linux-jammy-cuda12_8-py3_10-gcc11-test:
-    name: linux-jammy-cuda12.8-py3.10-gcc11
+  linux-jammy-cuda12.8-py3.10-gcc13-test:
+    name: linux-jammy-cuda12.8-py3.10-gcc13
     uses: ./.github/workflows/_linux-test.yml
     needs:
-      - linux-jammy-cuda12_8-py3_10-gcc11-build
+      - linux-jammy-cuda12.8-py3.10-gcc13-build
       - target-determination
     with:
       timeout-minutes: 360
-      build-environment: linux-jammy-cuda12.8-py3.10-gcc11
-      docker-image: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc11-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc11-build.outputs.test-matrix }}
+      build-environment: linux-jammy-cuda12.8-py3.10-gcc13
+      docker-image: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-build.outputs.test-matrix }}
     secrets: inherit
 
   linux-jammy-py3-clang18-mobile-build:
@@ -374,7 +374,7 @@ jobs:
     needs: get-label-type
     with:
       runner: "${{ needs.get-label-type.outputs.label-type }}linux.large"
-      build-environment: linux-jammy-cuda12.8-py3.10-gcc11-bazel-test
+      build-environment: linux-jammy-cuda12.8-py3.10-gcc13-bazel-test
       docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc13
       cuda-version: cpu
       test-matrix: |
@@ -417,13 +417,13 @@ jobs:
         ]}
     secrets: inherit
 
-  linux-jammy-cuda12_8-py3_10-gcc11-sm89-build:
-    name: linux-jammy-cuda12.8-py3.10-gcc11-sm89
+  linux-jammy-cuda12.8-py3.10-gcc13-sm89-build:
+    name: linux-jammy-cuda12.8-py3.10-gcc13-sm89
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-jammy-cuda12.8-py3.10-gcc11-sm89
+      build-environment: linux-jammy-cuda12.8-py3.10-gcc13-sm89
       docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc13
       cuda-arch-list: 8.9
       test-matrix: |
@@ -436,16 +436,16 @@ jobs:
         ]}
     secrets: inherit
 
-  linux-jammy-cuda12_8-py3_10-gcc11-sm89-test:
-    name: linux-jammy-cuda12.8-py3.10-gcc11-sm89
+  linux-jammy-cuda12.8-py3.10-gcc13-sm89-test:
+    name: linux-jammy-cuda12.8-py3.10-gcc13-sm89
     uses: ./.github/workflows/_linux-test.yml
     needs:
-      - linux-jammy-cuda12_8-py3_10-gcc11-sm89-build
+      - linux-jammy-cuda12.8-py3.10-gcc13-sm89-build
       - target-determination
     with:
-      build-environment: linux-jammy-cuda12.8-py3.10-gcc11-sm89
-      docker-image: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc11-sm89-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc11-sm89-build.outputs.test-matrix }}
+      build-environment: linux-jammy-cuda12.8-py3.10-gcc13-sm89
+      docker-image: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-sm89-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-sm89-build.outputs.test-matrix }}
     secrets: inherit
 
   linux-jammy-py3-clang12-executorch-build:

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -254,7 +254,7 @@ jobs:
       timeout-minutes: 600
     secrets: inherit
 
-  linux-jammy-cuda12.8-py3.10-gcc13-build-distributed:
+  linux-jammy-cuda12_8-py3_10-gcc13-build-distributed:
     name: linux-jammy-cuda12.8-py3.10-gcc13-build-distributed
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
@@ -271,20 +271,20 @@ jobs:
         ]}
     secrets: inherit
 
-  linux-jammy-cuda12.8-py3.10-gcc13-test-distributed:
+  linux-jammy-cuda12_8-py3_10-gcc13-test-distributed:
     name: linux-jammy-cuda12.8-py3.10-gcc13-test
     uses: ./.github/workflows/_linux-test.yml
     needs:
-      - linux-jammy-cuda12.8-py3.10-gcc13-build-distributed
+      - linux-jammy-cuda12_8-py3_10-gcc13-build-distributed
       - target-determination
     with:
       timeout-minutes: 360
       build-environment: linux-jammy-cuda12.8-py3.10-gcc13-distributed
-      docker-image: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-build-distributed.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-build-distributed.outputs.test-matrix }}
+      docker-image: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc13-build-distributed.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc13-build-distributed.outputs.test-matrix }}
     secrets: inherit
 
-  linux-jammy-cuda12.8-py3.10-gcc13-build:
+  linux-jammy-cuda12_8-py3_10-gcc13-build:
     name: linux-jammy-cuda12.8-py3.10-gcc13
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
@@ -302,11 +302,11 @@ jobs:
         ]}
     secrets: inherit
 
-  linux-jammy-cuda12.8-py3.10-gcc13-test:
+  linux-jammy-cuda12_8-py3_10-gcc13-test:
     name: linux-jammy-cuda12.8-py3.10-gcc13
     uses: ./.github/workflows/_linux-test.yml
     needs:
-      - linux-jammy-cuda12.8-py3.10-gcc13-build
+      - linux-jammy-cuda12.8-py3_10-gcc13-build
       - target-determination
     with:
       timeout-minutes: 360

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -261,7 +261,7 @@ jobs:
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build-environment: linux-jammy-cuda12.8-py3.10-gcc11-distributed
-      docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc11
+      docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc13
       cuda-arch-list: '7.5'
       test-matrix: |
         { include: [
@@ -291,7 +291,7 @@ jobs:
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build-environment: linux-jammy-cuda12.8-py3.10-gcc11
-      docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc11
+      docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc13
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge.nvidia.gpu" },
@@ -375,7 +375,7 @@ jobs:
     with:
       runner: "${{ needs.get-label-type.outputs.label-type }}linux.large"
       build-environment: linux-jammy-cuda12.8-py3.10-gcc11-bazel-test
-      docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc11
+      docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc13
       cuda-version: cpu
       test-matrix: |
         { include: [
@@ -424,7 +424,7 @@ jobs:
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build-environment: linux-jammy-cuda12.8-py3.10-gcc11-sm89
-      docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc11
+      docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc13
       cuda-arch-list: 8.9
       test-matrix: |
         { include: [

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -306,13 +306,13 @@ jobs:
     name: linux-jammy-cuda12.8-py3.10-gcc13
     uses: ./.github/workflows/_linux-test.yml
     needs:
-      - linux-jammy-cuda12.8-py3_10-gcc13-build
+      - linux-jammy-cuda12_8-py3_10-gcc13-build
       - target-determination
     with:
       timeout-minutes: 360
       build-environment: linux-jammy-cuda12.8-py3.10-gcc13
-      docker-image: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-build.outputs.test-matrix }}
+      docker-image: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc13-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc13-build.outputs.test-matrix }}
     secrets: inherit
 
   linux-jammy-py3-clang18-mobile-build:
@@ -417,7 +417,7 @@ jobs:
         ]}
     secrets: inherit
 
-  linux-jammy-cuda12.8-py3.10-gcc13-sm89-build:
+  linux-jammy-cuda12_8-py3_10-gcc13-sm89-build:
     name: linux-jammy-cuda12.8-py3.10-gcc13-sm89
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
@@ -436,16 +436,16 @@ jobs:
         ]}
     secrets: inherit
 
-  linux-jammy-cuda12.8-py3.10-gcc13-sm89-test:
+  linux-jammy-cuda12_8-py3_10-gcc13-sm89-test:
     name: linux-jammy-cuda12.8-py3.10-gcc13-sm89
     uses: ./.github/workflows/_linux-test.yml
     needs:
-      - linux-jammy-cuda12.8-py3.10-gcc13-sm89-build
+      - linux-jammy-cuda12_8-py3_10-gcc13-sm89-build
       - target-determination
     with:
       build-environment: linux-jammy-cuda12.8-py3.10-gcc13-sm89
-      docker-image: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-sm89-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-sm89-build.outputs.test-matrix }}
+      docker-image: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc13-sm89-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc13-sm89-build.outputs.test-matrix }}
     secrets: inherit
 
   linux-jammy-py3-clang12-executorch-build:

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -56,7 +56,7 @@ jobs:
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build-environment: linux-jammy-cuda12.8-py3.10-gcc11-sm86
-      docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc11
+      docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc13
       cuda-arch-list: 8.6
       test-matrix: |
         { include: [

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -49,13 +49,13 @@ jobs:
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
 
-  linux-jammy-cuda12_8-py3_10-gcc11-sm86-build:
-    name: linux-jammy-cuda12.8-py3.10-gcc11-sm86
+  linux-jammy-cuda12.8-py3.10-gcc13-sm86-build:
+    name: linux-jammy-cuda12.8-py3.10-gcc13-sm86
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-jammy-cuda12.8-py3.10-gcc11-sm86
+      build-environment: linux-jammy-cuda12.8-py3.10-gcc13-sm86
       docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc13
       cuda-arch-list: 8.6
       test-matrix: |
@@ -66,16 +66,16 @@ jobs:
         ]}
     secrets: inherit
 
-  linux-jammy-cuda12_8-py3_10-gcc11-sm86-test:
-    name: linux-jammy-cuda12.8-py3.10-gcc11-sm86
+  linux-jammy-cuda12.8-py3.10-gcc13-sm86-test:
+    name: linux-jammy-cuda12.8-py3.10-gcc13-sm86
     uses: ./.github/workflows/_linux-test.yml
     needs:
-      - linux-jammy-cuda12_8-py3_10-gcc11-sm86-build
+      - linux-jammy-cuda12.8-py3.10-gcc13-sm86-build
       - target-determination
     with:
-      build-environment: linux-jammy-cuda12.8-py3.10-gcc11-sm86
-      docker-image: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc11-sm86-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc11-sm86-build.outputs.test-matrix }}
+      build-environment: linux-jammy-cuda12.8-py3.10-gcc13-sm86
+      docker-image: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-sm86-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-sm86-build.outputs.test-matrix }}
     secrets: inherit
 
   linux-jammy-py3_9-clang12-build:

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -49,7 +49,7 @@ jobs:
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
 
-  linux-jammy-cuda12.8-py3.10-gcc13-sm86-build:
+  linux-jammy-cuda12_8-py3_10-gcc13-sm86-build:
     name: linux-jammy-cuda12.8-py3.10-gcc13-sm86
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
@@ -66,16 +66,16 @@ jobs:
         ]}
     secrets: inherit
 
-  linux-jammy-cuda12.8-py3.10-gcc13-sm86-test:
+  linux-jammy-cuda12_8-py3_10-gcc13-sm86-test:
     name: linux-jammy-cuda12.8-py3.10-gcc13-sm86
     uses: ./.github/workflows/_linux-test.yml
     needs:
-      - linux-jammy-cuda12.8-py3.10-gcc13-sm86-build
+      - linux-jammy-cuda12_8-py3_10-gcc13-sm86-build
       - target-determination
     with:
       build-environment: linux-jammy-cuda12.8-py3.10-gcc13-sm86
-      docker-image: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-sm86-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-sm86-build.outputs.test-matrix }}
+      docker-image: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc13-sm86-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc13-sm86-build.outputs.test-matrix }}
     secrets: inherit
 
   linux-jammy-py3_9-clang12-build:

--- a/.github/workflows/target-determination-indexer.yml
+++ b/.github/workflows/target-determination-indexer.yml
@@ -37,7 +37,7 @@ jobs:
         id: calculate-docker-image
         uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
         with:
-          docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc11
+          docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc13
           working-directory: pytorch
 
       - name: Use following to pull public copy of the image

--- a/.github/workflows/test-h100.yml
+++ b/.github/workflows/test-h100.yml
@@ -31,14 +31,14 @@ jobs:
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
 
-  linux-jammy-cuda12_8-py3_10-gcc11-sm90-build:
-    name: linux-jammy-cuda12.8-py3.10-gcc11-sm90
+  linux-jammy-cuda12.8-py3.10-gcc13-sm90-build:
+    name: linux-jammy-cuda12.8-py3.10-gcc13-sm90
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       runner: "linux.12xlarge"
-      build-environment: linux-jammy-cuda12.8-py3.10-gcc11-sm90
+      build-environment: linux-jammy-cuda12.8-py3.10-gcc13-sm90
       docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc13
       cuda-arch-list: '9.0'
       test-matrix: |
@@ -47,13 +47,13 @@ jobs:
         ]}
     secrets: inherit
 
-  linux-jammy-cuda12_8-py3_10-gcc11-sm90-test:
-    name: linux-jammy-cuda12.8-py3.10-gcc11-sm90
+  linux-jammy-cuda12.8-py3.10-gcc13-sm90-test:
+    name: linux-jammy-cuda12.8-py3.10-gcc13-sm90
     uses: ./.github/workflows/_linux-test.yml
     needs:
-      - linux-jammy-cuda12_8-py3_10-gcc11-sm90-build
+      - linux-jammy-cuda12.8-py3.10-gcc13-sm90-build
     with:
-      build-environment: linux-jammy-cuda12.8-py3.10-gcc11-sm90
-      docker-image: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc11-sm90-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc11-sm90-build.outputs.test-matrix }}
+      build-environment: linux-jammy-cuda12.8-py3.10-gcc13-sm90
+      docker-image: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-sm90-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-sm90-build.outputs.test-matrix }}
     secrets: inherit

--- a/.github/workflows/test-h100.yml
+++ b/.github/workflows/test-h100.yml
@@ -39,7 +39,7 @@ jobs:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       runner: "linux.12xlarge"
       build-environment: linux-jammy-cuda12.8-py3.10-gcc11-sm90
-      docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc11
+      docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc13
       cuda-arch-list: '9.0'
       test-matrix: |
         { include: [

--- a/.github/workflows/test-h100.yml
+++ b/.github/workflows/test-h100.yml
@@ -47,7 +47,7 @@ jobs:
         ]}
     secrets: inherit
 
-  linux-jammy-cuda12.8-py3.10-gcc13-sm90-test:
+  linux-jammy-cuda12_8-py3_10-gcc13-sm90-test:
     name: linux-jammy-cuda12.8-py3.10-gcc13-sm90
     uses: ./.github/workflows/_linux-test.yml
     needs:

--- a/.github/workflows/test-h100.yml
+++ b/.github/workflows/test-h100.yml
@@ -31,7 +31,7 @@ jobs:
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
 
-  linux-jammy-cuda12.8-py3.10-gcc13-sm90-build:
+  linux-jammy-cuda12_8-py3_10-gcc13-sm90-build:
     name: linux-jammy-cuda12.8-py3.10-gcc13-sm90
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
@@ -51,9 +51,9 @@ jobs:
     name: linux-jammy-cuda12.8-py3.10-gcc13-sm90
     uses: ./.github/workflows/_linux-test.yml
     needs:
-      - linux-jammy-cuda12.8-py3.10-gcc13-sm90-build
+      - linux-jammy-cuda12_8-py3_10-gcc13-sm90-build
     with:
       build-environment: linux-jammy-cuda12.8-py3.10-gcc13-sm90
-      docker-image: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-sm90-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-cuda12.8-py3.10-gcc13-sm90-build.outputs.test-matrix }}
+      docker-image: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc13-sm90-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc13-sm90-build.outputs.test-matrix }}
     secrets: inherit

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -53,7 +53,7 @@ jobs:
     needs: get-label-type
     with:
       build-environment: libtorch-linux-jammy-cuda12.8-py3.10-gcc11
-      docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc11
+      docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc13
       build-generates-artifacts: false
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       runner: "linux.4xlarge"
@@ -71,7 +71,7 @@ jobs:
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build-environment: linux-jammy-cuda12.8-py3.10-gcc11-no-ops
-      docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc11
+      docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc13
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 1 },

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -47,7 +47,7 @@ jobs:
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
 
-  libtorch-linux-jammy-cuda12.8-py3.10-gcc13-debug-build:
+  libtorch-linux-jammy-cuda12_8-py3_10-gcc13-debug-build:
     name: libtorch-linux-jammy-cuda12.8-py3.10-gcc13-debug
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
@@ -64,7 +64,7 @@ jobs:
     secrets: inherit
 
   # no-ops builds test USE_PER_OPERATOR_HEADERS=0 where ATen/ops is not generated
-  linux-jammy-cuda12.8-py3.10-gcc13-no-ops-build:
+  linux-jammy-cuda12_8-py3_10-gcc13-no-ops-build:
     name: linux-jammy-cuda12.8-py3.10-gcc13-no-ops
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -47,12 +47,12 @@ jobs:
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
 
-  libtorch-linux-jammy-cuda12_8-py3_10-gcc11-debug-build:
-    name: libtorch-linux-jammy-cuda12.8-py3.10-gcc11-debug
+  libtorch-linux-jammy-cuda12.8-py3.10-gcc13-debug-build:
+    name: libtorch-linux-jammy-cuda12.8-py3.10-gcc13-debug
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
-      build-environment: libtorch-linux-jammy-cuda12.8-py3.10-gcc11
+      build-environment: libtorch-linux-jammy-cuda12.8-py3.10-gcc13
       docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc13
       build-generates-artifacts: false
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
@@ -64,13 +64,13 @@ jobs:
     secrets: inherit
 
   # no-ops builds test USE_PER_OPERATOR_HEADERS=0 where ATen/ops is not generated
-  linux-jammy-cuda12_8-py3_10-gcc11-no-ops-build:
-    name: linux-jammy-cuda12.8-py3.10-gcc11-no-ops
+  linux-jammy-cuda12.8-py3.10-gcc13-no-ops-build:
+    name: linux-jammy-cuda12.8-py3.10-gcc13-no-ops
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-jammy-cuda12.8-py3.10-gcc11-no-ops
+      build-environment: linux-jammy-cuda12.8-py3.10-gcc13-no-ops
       docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc13
       test-matrix: |
         { include: [


### PR DESCRIPTION
Binary builds where migrated to gcc13 a while ago: https://github.com/pytorch/pytorch/pull/152825
This migrates pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc11 jobs to pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc13. Make sure we have a coverage for GCC13 in CI

Reference issue, users seeing regression with gcc13: https://github.com/pytorch/pytorch/issues/157626