### PR TITLE
Simplify the base classes of `_PyFutureMeta`

### DIFF
--- a/torch/futures/__init__.py
+++ b/torch/futures/__init__.py
@@ -13,11 +13,7 @@ T = TypeVar("T")
 S = TypeVar("S")
 
 
-class _PyFutureMeta(type(torch._C.Future), type(Generic)):  # type: ignore[misc, no-redef]
-    pass
-
-
-class Future(torch._C.Future, Generic[T], metaclass=_PyFutureMeta):
+class Future(torch._C.Future, Generic[T]):
     r"""
     Wrapper around a ``torch._C.Future`` which encapsulates an asynchronous
     execution of a callable, e.g. :meth:`~torch.distributed.rpc.rpc_async`. It


### PR DESCRIPTION
Summary:

I'm fairly sure the use of a custom metaclass is a holdover from pre-3.7 where Generic used a custom metaclass so we had to use multiple inheritance to avoid import-time failures.

At this point, `type(Generic)` is just `type` so it isn't needed, and we will get the least metaclass from our base classes, which means the `type(torch._C.Future)` isn't needed either, it will happen automatically just by inheritance.

Test Plan:

I'm fairly confident from local testing that this should be a no-op.

But also, Pytorch CI should give us pretty strong signal that this change doesn't break anything in case there's some edge case I missed.


cc @ezyang @malfet @xuzhao9 @gramster