### PR TITLE
Increase nightly C++ docs build timeout to 6h

### DIFF
--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -70,7 +70,7 @@ jobs:
             runner: ${{ inputs.runner_prefix }}linux.12xlarge
             # TODO: Nightly cpp docs take longer and longer to finish (more than 3h now)
             # Let's try to figure out how this can be improved
-            timeout-minutes: 240
+            timeout-minutes: 360
           - docs_type: python
             runner: ${{ inputs.runner_prefix }}linux.2xlarge
             # It takes less than 30m to finish python docs unless there are issues


### PR DESCRIPTION
This job has been timing out since May https://hud.pytorch.org/hud/pytorch/pytorch/261897734a4d3c0be31eceb20f14e9e1c2cd9644/1?per_page=50&name_filter=build-docs-cpp-true&mergeEphemeralLF=true, maybe it's time to figure out if this makes sense.

Issues https://github.com/pytorch/pytorch/issues/157763

cc @svekars @sekyondaMeta @AlannaBurke