### PR TITLE
[ci] fix h100-distributed

### DIFF
--- a/.github/workflows/h100-distributed.yml
+++ b/.github/workflows/h100-distributed.yml
@@ -15,6 +15,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
 
   get-label-type:


### PR DESCRIPTION
This was broken by https://github.com/pytorch/pytorch/pull/157341

This should resolve the permission issue