### PR TITLE
[MyPy][Refactor] Ban use of dict keyword for dict literals

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,6 @@ ignore = [
     "B023",
     "B028", # No explicit `stacklevel` keyword argument found
     "E402",
-    "C408", # C408 ignored because we like the dict keyword argument syntax
     "E501", # E501 is not flexible enough, we're using B950 instead
     "E721",
     "E741",

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -34,6 +34,8 @@ from typing import (
 )
 from typing_extensions import ParamSpec as _ParamSpec
 
+from . import version
+
 
 if TYPE_CHECKING:
     from .types import Device, IntLikeType

--- a/torch/_inductor/codegen/cpp_micro_gemm.py
+++ b/torch/_inductor/codegen/cpp_micro_gemm.py
@@ -211,12 +211,12 @@ inline void {{kernel_name}}(
     ) -> str:
         buffer_size = " * ".join(map(str, size_args))
         return KernelTemplate._template_from_string(self.ALLOCATE_WEIGHT_BUFFER).render(
-            dict(
-                buffer_name=buffer_name,
-                buffer_dtype=buffer_dtype,
-                buffer_size=buffer_size,
-                is_msvc_compiler=cpp_builder.is_msvc_cl(),
-            )
+            {
+                "buffer_name": buffer_name,
+                "buffer_dtype": buffer_dtype,
+                "buffer_size": buffer_size,
+                "is_msvc_compiler": cpp_builder.is_msvc_cl(),
+            }
         )
 
     def is_woq_int4(self):
@@ -239,9 +239,9 @@ micro_gemm_configs: dict[type[CppMicroGemm], list[CppMicroGemmConfig]] = {}
 
 def register_micro_gemm(*configs):
     def inner(cls):
-        assert cls not in micro_gemm_configs, (
-            f"Duplicate micro_gemm registration for {cls}"
-        )
+        assert (
+            cls not in micro_gemm_configs
+        ), f"Duplicate micro_gemm registration for {cls}"
         assert len(configs) > 0, f"No micro_gemm configs provided for {cls}"
         micro_gemm_configs[cls] = list(configs)
         return cls

--- a/torch/_inductor/codegen/cpp_micro_gemm.py
+++ b/torch/_inductor/codegen/cpp_micro_gemm.py
@@ -239,9 +239,9 @@ micro_gemm_configs: dict[type[CppMicroGemm], list[CppMicroGemmConfig]] = {}
 
 def register_micro_gemm(*configs):
     def inner(cls):
-        assert (
-            cls not in micro_gemm_configs
-        ), f"Duplicate micro_gemm registration for {cls}"
+        assert cls not in micro_gemm_configs, (
+            f"Duplicate micro_gemm registration for {cls}"
+        )
         assert len(configs) > 0, f"No micro_gemm configs provided for {cls}"
         micro_gemm_configs[cls] = list(configs)
         return cls

--- a/torch/_inductor/codegen/cuda/gemm_template.py
+++ b/torch/_inductor/codegen/cuda/gemm_template.py
@@ -1025,9 +1025,9 @@ class CUTLASSGemmTemplate(CUTLASSTemplate, ABC):
         import cutlass_library.gemm_operation as cutlass_gemm_op
         import cutlass_library.library as cutlass_lib
 
-        assert isinstance(
-            op, cutlass_gemm_op.GemmOperation
-        ), "op argument is required and has to be an instance of GemmOperation"
+        assert isinstance(op, cutlass_gemm_op.GemmOperation), (
+            "op argument is required and has to be an instance of GemmOperation"
+        )
 
         if epilogue_nodes and not self._has_tma_epilogue(op):
             raise NotImplementedError(
@@ -1070,9 +1070,9 @@ class CUTLASSGemmTemplate(CUTLASSTemplate, ABC):
             # operand
             op.C.element = op.A.element
 
-            assert (
-                op.C.element == op.D.element
-            ), f"Expect C and D to have the same dtype, found {op.C.element} and {op.D.element}"
+            assert op.C.element == op.D.element, (
+                f"Expect C and D to have the same dtype, found {op.C.element} and {op.D.element}"
+            )
 
         argument_template, epilogue_template = self._get_template_args(op)
         should_swap_xw: bool = False

--- a/torch/_inductor/codegen/cuda/gemm_template.py
+++ b/torch/_inductor/codegen/cuda/gemm_template.py
@@ -1025,9 +1025,9 @@ class CUTLASSGemmTemplate(CUTLASSTemplate, ABC):
         import cutlass_library.gemm_operation as cutlass_gemm_op
         import cutlass_library.library as cutlass_lib
 
-        assert isinstance(op, cutlass_gemm_op.GemmOperation), (
-            "op argument is required and has to be an instance of GemmOperation"
-        )
+        assert isinstance(
+            op, cutlass_gemm_op.GemmOperation
+        ), "op argument is required and has to be an instance of GemmOperation"
 
         if epilogue_nodes and not self._has_tma_epilogue(op):
             raise NotImplementedError(
@@ -1070,9 +1070,9 @@ class CUTLASSGemmTemplate(CUTLASSTemplate, ABC):
             # operand
             op.C.element = op.A.element
 
-            assert op.C.element == op.D.element, (
-                f"Expect C and D to have the same dtype, found {op.C.element} and {op.D.element}"
-            )
+            assert (
+                op.C.element == op.D.element
+            ), f"Expect C and D to have the same dtype, found {op.C.element} and {op.D.element}"
 
         argument_template, epilogue_template = self._get_template_args(op)
         should_swap_xw: bool = False
@@ -1179,27 +1179,27 @@ class CUTLASSGemmTemplate(CUTLASSTemplate, ABC):
 
         instance_definition, instance_type = self._define_gemm_instance(op, evt_name)
 
-        options = dict(
-            alpha=self.alpha,
-            beta=self.beta,
-            X=X,
-            W=W,
-            Y=Y,
-            kernel_call_signature=kernel_call_signature,
-            Bias=Bias,
-            epilogue_template=epilogue_template,
-            argument_template=argument_template,
-            should_swap_xw=should_swap_xw,
-            template=self,
-            kernel=kernel,
-            instance_definition=instance_definition,
-            instance_type=instance_type,
-            input_reorder=self.input_reorder,
-            epilogue_args=evt_args,
-            test_call_statement=test_call_statement,
-            op_conf_name=op.configuration_name(),
-            epilogue_visitor_tree=evt_code,
-        )
+        options = {
+            "alpha": self.alpha,
+            "beta": self.beta,
+            "X": X,
+            "W": W,
+            "Y": Y,
+            "kernel_call_signature": kernel_call_signature,
+            "Bias": Bias,
+            "epilogue_template": epilogue_template,
+            "argument_template": argument_template,
+            "should_swap_xw": should_swap_xw,
+            "template": self,
+            "kernel": kernel,
+            "instance_definition": instance_definition,
+            "instance_type": instance_type,
+            "input_reorder": self.input_reorder,
+            "epilogue_args": evt_args,
+            "test_call_statement": test_call_statement,
+            "op_conf_name": op.configuration_name(),
+            "epilogue_visitor_tree": evt_code,
+        }
         options.update(dict(zip(extra_names, extra_inputs)))
         res = self._template_from_string(self._get_template()).render(**options)
         if inductor_cuda_config.generate_test_runner and not is_dynamic(X, W, Y, Bias):
@@ -1587,19 +1587,19 @@ class CUTLASS3xGemmTemplate(CUTLASSGemmTemplate):
         tensors. This operation also implies the M and N dimensions of Bias and GEMM output to be swapped
         before the function call.
         """
-        options = dict(
-            alpha=alpha,
-            beta=beta,
-            X=X,
-            W=W,
-            Y=Y,
-            Bias=Bias,
-            template=self,
-            kernel=kernel,
-            M="M",
-            N="N",
-            epilogue_args=epilogue_args,
-        )
+        options = {
+            "alpha": alpha,
+            "beta": beta,
+            "X": X,
+            "W": W,
+            "Y": Y,
+            "Bias": Bias,
+            "template": self,
+            "kernel": kernel,
+            "M": "M",
+            "N": "N",
+            "epilogue_args": epilogue_args,
+        }
         assert epilogue_template is not None
 
         if should_swap_xw:
@@ -1878,21 +1878,21 @@ class CUTLASS2xGemmTemplate(CUTLASSGemmTemplate):
         tensors. This operation also implies the M and N dimensions of Bias and GEMM output to be swapped
         before the function call.
         """
-        options = dict(
-            instance_type=instance_type,
-            alpha=alpha,
-            beta=beta,
-            X=X,
-            W=W,
-            Y=Y,
-            Bias=Bias,
-            Meta=Meta,
-            template=self,
-            kernel=kernel,
-            M="M",
-            N="N",
-            epilogue_args=epilogue_args,
-        )
+        options = {
+            "instance_type": instance_type,
+            "alpha": alpha,
+            "beta": beta,
+            "X": X,
+            "W": W,
+            "Y": Y,
+            "Bias": Bias,
+            "Meta": Meta,
+            "template": self,
+            "kernel": kernel,
+            "M": "M",
+            "N": "N",
+            "epilogue_args": epilogue_args,
+        }
 
         if epilogue_template is None:
             arguments = self._template_from_string(argument_template).render(

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -55,7 +55,8 @@ def mm_options(config, sym_m, sym_n, sym_k, layout):
     """
     even_k_symbolic = (
         # it isn't worth guarding on this
-        sympy.gcd(sym_k, config.kwargs["BLOCK_K"]) == config.kwargs["BLOCK_K"]
+        sympy.gcd(sym_k, config.kwargs["BLOCK_K"])
+        == config.kwargs["BLOCK_K"]
     )
     allow_tf32 = torch.backends.cuda.matmul.allow_tf32 and (
         not inductor_config.force_same_precision
@@ -86,12 +87,12 @@ def tma_options() -> dict[str, Any]:
 
 
 def persistent_mm_options(mat1, mat2):
-    res = dict(
-        A_ROW_MAJOR=not mat1.layout.is_transposed(),
-        B_ROW_MAJOR=not mat2.layout.is_transposed(),
-        NUM_SMS=get_num_sms(),
-        TMA_SIZE=TMA_DESCRIPTOR_SIZE,
-    )
+    res = {
+        "A_ROW_MAJOR": not mat1.layout.is_transposed(),
+        "B_ROW_MAJOR": not mat2.layout.is_transposed(),
+        "NUM_SMS": get_num_sms(),
+        "TMA_SIZE": TMA_DESCRIPTOR_SIZE,
+    }
     res.update(tma_options())
     return res
 

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -55,8 +55,7 @@ def mm_options(config, sym_m, sym_n, sym_k, layout):
     """
     even_k_symbolic = (
         # it isn't worth guarding on this
-        sympy.gcd(sym_k, config.kwargs["BLOCK_K"])
-        == config.kwargs["BLOCK_K"]
+        sympy.gcd(sym_k, config.kwargs["BLOCK_K"]) == config.kwargs["BLOCK_K"]
     )
     allow_tf32 = torch.backends.cuda.matmul.allow_tf32 and (
         not inductor_config.force_same_precision

--- a/torch/_inductor/mkldnn_lowerings.py
+++ b/torch/_inductor/mkldnn_lowerings.py
@@ -369,7 +369,11 @@ def register_onednn_fusion_ops():
                         **kwargs,  # type: ignore[arg-type]
                     )
             if len(choices) == 0 or use_aten_gemm_kernels():
-                kwargs = dict(attr=attr, scalars=scalars, algorithm=algorithm)
+                kwargs = {
+                    "attr": attr,
+                    "scalars": scalars,
+                    "algorithm": algorithm,
+                }
                 if b is None:
                     kwargs["B"] = None
                 choices.append(
@@ -432,7 +436,7 @@ def register_onednn_fusion_ops():
                         **kwargs,  # type: ignore[arg-type]
                     )
             if len(choices) == 0 or use_aten_gemm_kernels():
-                kwargs = dict(attr=attr)
+                kwargs = {"attr": attr}
                 if b is None:
                     kwargs["B"] = None
                 choices.append(
@@ -675,9 +679,9 @@ def register_onednn_fusion_ops():
             algorithm,
             layout=None,
         ):
-            assert (
-                packed_weight.get_dtype() is torch.int8
-            ), "Only int8 weights are supported by oneDNN qlinear."
+            assert packed_weight.get_dtype() is torch.int8, (
+                "Only int8 weights are supported by oneDNN qlinear."
+            )
             x_size = x.get_size()
             if len(x_size) > 2:
                 # GEMM template needs 2D input, normalize input shape here
@@ -912,14 +916,14 @@ def register_onednn_fusion_ops():
                         ),
                     )
             if len(choices) == 0 or use_aten_gemm_kernels():
-                kwargs = dict(
-                    output_scale=o_scale,
-                    output_zero_point=o_zero_point,
-                    output_dtype=output_dtype,
-                    post_op_name=attr,
-                    post_op_args=scalars,
-                    post_op_algorithm=algorithm,
-                )
+                kwargs = {
+                    "output_scale": o_scale,
+                    "output_zero_point": o_zero_point,
+                    "output_dtype": output_dtype,
+                    "post_op_name": attr,
+                    "post_op_args": scalars,
+                    "post_op_algorithm": algorithm,
+                }
                 if bias is None:
                     kwargs["bias"] = None
                 choices.append(
@@ -1058,9 +1062,9 @@ def register_onednn_fusion_ops():
                         # we will do accum dtype conversion here.
                         x2 = to_dtype(x2, output_dtype)
                 else:
-                    assert (
-                        x2.get_dtype() == output_dtype
-                    ), "dtype of accum for qlinear post op sum should be the same as output"
+                    assert x2.get_dtype() == output_dtype, (
+                        "dtype of accum for qlinear post op sum should be the same as output"
+                    )
             x2_dtype = x2.get_dtype()
             bias_dtype = bias.get_dtype() if bias is not None else None
             choices: list[ChoiceCaller] = []
@@ -1264,18 +1268,18 @@ def register_onednn_fusion_ops():
                     )
 
             if len(choices) == 0 or use_aten_gemm_kernels():
-                kwargs = dict(
-                    output_scale=o_scale,
-                    output_zero_point=o_zero_point,
-                    output_dtype=output_dtype,
-                    other_scale=x2_scale,
-                    other_zp=x2_zp,
-                    binary_post_op=binary_attr,
-                    binary_alpha=alpha,
-                    unary_post_op=unary_attr,
-                    unary_post_op_args=unary_scalars,
-                    unary_post_op_algorithm=unary_algorithmm,
-                )
+                kwargs = {
+                    "output_scale": o_scale,
+                    "output_zero_point": o_zero_point,
+                    "output_dtype": output_dtype,
+                    "other_scale": x2_scale,
+                    "other_zp": x2_zp,
+                    "binary_post_op": binary_attr,
+                    "binary_alpha": alpha,
+                    "unary_post_op": unary_attr,
+                    "unary_post_op_args": unary_scalars,
+                    "unary_post_op_algorithm": unary_algorithmm,
+                }
                 if bias is None:
                     kwargs["bias"] = None
                 choices.append(

--- a/torch/masked/_ops.py
+++ b/torch/masked/_ops.py
@@ -1,7 +1,6 @@
 # mypy: allow-untyped-defs
 import warnings
 from typing import Any, Callable, Optional, TYPE_CHECKING, TypeVar, Union
-from typing_extensions import ParamSpec, TypeAlias
 
 import torch
 from torch import sym_float, Tensor
@@ -9,6 +8,7 @@ from torch._prims_common import corresponding_real_dtype
 from torch.masked import _docs
 from torch.masked.maskedtensor.core import is_masked_tensor, MaskedTensor
 from torch.masked.maskedtensor.creation import as_masked_tensor
+from typing_extensions import ParamSpec, TypeAlias
 
 
 if TYPE_CHECKING:
@@ -166,123 +166,123 @@ Example::
 """,
     )
 
-    args_and_kwargs = dict(
+    args_and_kwargs = {
         # argument name sufficies separated by double underscore will
         # be removed in the final documentation string.
-        sum=(("dim",), ("keepdim=False", "dtype=None", "mask=None")),
-        prod=(("dim",), ("keepdim=False", "dtype=None", "mask=None")),
-        cumsum=(("dim__as_int",), ("dtype=None", "mask=None")),
-        cumprod=(("dim__as_int",), ("dtype=None", "mask=None")),
-        amin=(("dim",), ("keepdim=False", "dtype=None", "mask=None")),
-        amax=(("dim",), ("keepdim=False", "dtype=None", "mask=None")),
-        argmin=(("dim__as_int",), ("keepdim=False", "dtype=None", "mask=None")),
-        argmax=(("dim__as_int",), ("keepdim=False", "dtype=None", "mask=None")),
-        mean=(("dim",), ("keepdim=False", "dtype=None", "mask=None")),
-        median=(("dim__as_int",), ("keepdim=False", "dtype=None", "mask=None")),
-        norm=(
+        "sum": (("dim",), ("keepdim=False", "dtype=None", "mask=None")),
+        "prod": (("dim",), ("keepdim=False", "dtype=None", "mask=None")),
+        "cumsum": (("dim__as_int",), ("dtype=None", "mask=None")),
+        "cumprod": (("dim__as_int",), ("dtype=None", "mask=None")),
+        "amin": (("dim",), ("keepdim=False", "dtype=None", "mask=None")),
+        "amax": (("dim",), ("keepdim=False", "dtype=None", "mask=None")),
+        "argmin": (("dim__as_int",), ("keepdim=False", "dtype=None", "mask=None")),
+        "argmax": (("dim__as_int",), ("keepdim=False", "dtype=None", "mask=None")),
+        "mean": (("dim",), ("keepdim=False", "dtype=None", "mask=None")),
+        "median": (("dim__as_int",), ("keepdim=False", "dtype=None", "mask=None")),
+        "norm": (
             (
                 "ord",
                 "dim",
             ),
             ("keepdim=False", "dtype=None", "mask=None"),
         ),
-        var=(("dim", "unbiased"), ("keepdim=False", "dtype=None", "mask=None")),
-        std=(("dim", "unbiased"), ("keepdim=False", "dtype=None", "mask=None")),
-        logsumexp=(("dim",), ("keepdim=False", "dtype=None", "mask=None")),
-        softmax=(("dim__as_int",), ("dtype=None", "mask=None")),
-        log_softmax=(("dim__as_int",), ("dtype=None", "mask=None")),
-        softmin=(("dim__as_int",), ("dtype=None", "mask=None")),
-        normalize=(
+        "var": (("dim", "unbiased"), ("keepdim=False", "dtype=None", "mask=None")),
+        "std": (("dim", "unbiased"), ("keepdim=False", "dtype=None", "mask=None")),
+        "logsumexp": (("dim",), ("keepdim=False", "dtype=None", "mask=None")),
+        "softmax": (("dim__as_int",), ("dtype=None", "mask=None")),
+        "log_softmax": (("dim__as_int",), ("dtype=None", "mask=None")),
+        "softmin": (("dim__as_int",), ("dtype=None", "mask=None")),
+        "normalize": (
             (
                 "ord__required",
                 "dim__as_int",
             ),
             ("eps=1e-12", "dtype=None", "mask=None"),
         ),
-    )
+    }
 
-    argument_declarations = dict(
-        dim="""\
-dim (int or tuple of ints, optional): the dimension or dimensions to reduce.
-  Default: None that is equivalent to ``tuple(range(input.ndim))``.""",
-        dim__as_int="""\
-dim (int): the dimension along which {operation name} is computed.""",
-        ord="""\
-ord (int, float, optional): the order of vector norm. Default: 2.
-  See :func:`torch.linalg.vector_norm` for a list of supported norms.""",
-        ord__required="""\
-ord (int, float): the order of vector norm. Default: 2.
-  See :func:`torch.linalg.vector_norm` for a list of supported norms.""",
-        unbiased="""\
-unbiased (bool): when True, use Bessel's correction, otherwise, compute
-  the uncorrected sample variance.""",
-        eps="""\
-eps (float, optional): small value to avoid division by zero. Default: {default}.""",
-        keepdim="""\
-keepdim (bool, optional): whether the output tensor has
-  :attr:`dim` retained or not. Default: {default}.""",
-        dtype="""\
-dtype (:class:`torch.dtype`, optional): the desired data type
-  of returned tensor.  If specified, the input tensor is
-  casted to :attr:`dtype` before the operation is
-  performed. Default: {default}.""",
-        mask="""\
-mask (:class:`torch.Tensor`, optional): the boolean tensor
-  containing the binary mask of validity of input tensor
-  elements.
-  Default: None that is equivalent to ``torch.ones(input.shape, dtype=torch.bool)``.""",
-    )
+    argument_declarations = {
+        "dim": """\
+    dim (int or tuple of ints, optional): the dimension or dimensions to reduce.
+    Default: None that is equivalent to ``tuple(range(input.ndim))``.""",
+        "dim__as_int": """\
+    dim (int): the dimension along which {operation name} is computed.""",
+        "ord": """\
+    ord (int, float, optional): the order of vector norm. Default: 2.
+    See :func:`torch.linalg.vector_norm` for a list of supported norms.""",
+        "ord__required": """\
+    ord (int, float): the order of vector norm. Default: 2.
+    See :func:`torch.linalg.vector_norm` for a list of supported norms.""",
+        "unbiased": """\
+    unbiased (bool): when True, use Bessel's correction, otherwise, compute
+    the uncorrected sample variance.""",
+        "eps": """\
+    eps (float, optional): small value to avoid division by zero. Default: {default}.""",
+        "keepdim": """\
+    keepdim (bool, optional): whether the output tensor has
+    :attr:`dim` retained or not. Default: {default}.""",
+        "dtype": """\
+    dtype (:class:`torch.dtype`, optional): the desired data type
+    of returned tensor.  If specified, the input tensor is
+    casted to :attr:`dtype` before the operation is
+    performed. Default: {default}.""",
+        "mask": """\
+    mask (:class:`torch.Tensor`, optional): the boolean tensor
+    containing the binary mask of validity of input tensor
+    elements.
+    Default: None that is equivalent to ``torch.ones(input.shape, dtype=torch.bool)``.""",
+    }
 
-    definitions = dict(
-        softmax="""\
-Let ``x`` be a sequence of unmasked elements of one-dimensional slice
-of the :attr:`input` tensor. Softmax of i-th element in ``x`` is
-defined as ``exp(x[i])/sum(exp(x))``.""",
-        log_softmax="""\
-Let ``x`` be a sequence of unmasked elements of one-dimensional slice
-of the :attr:`input` tensor. LogSoftmax of i-th element in ``x`` is
-defined as ``log(exp(x[i])/sum(exp(x)))``.""",
-        softmin="""\
-Let ``x`` be a sequence of unmasked elements of one-dimensional slice
-of the :attr:`input` tensor. Softmin of i-th element in ``x`` is
-defined as ``exp(-x[i])/sum(exp(-x))``.""",
-        normalize="""\
-Let ``x`` be a sequence of unmasked elements of one-dimensional slice
-of the :attr:`input` tensor. Normalize of i-th element in ``x`` is
-defined as ``x[i]/max(norm(x, p), eps)``.""",
-        cumsum="""\
-Let ``x`` be a sequence of unmasked elements of one-dimensional slice
-of the :attr:`input` tensor. Cumsum of i-th element in ``x`` is
-defined as ``sum(x[:i])``.""",
-        cumprod="""\
-Let ``x`` be a sequence of unmasked elements of one-dimensional slice
-of the :attr:`input` tensor. Cumsum of i-th element in ``x`` is
-defined as ``prod(x[:i])``.""",
-    )
+    definitions = {
+        "softmax": """\
+    Let ``x`` be a sequence of unmasked elements of one-dimensional slice
+    of the :attr:`input` tensor. Softmax of i-th element in ``x`` is
+    defined as ``exp(x[i])/sum(exp(x))``.""",
+        "log_softmax": """\
+    Let ``x`` be a sequence of unmasked elements of one-dimensional slice
+    of the :attr:`input` tensor. LogSoftmax of i-th element in ``x`` is
+    defined as ``log(exp(x[i])/sum(exp(x)))``.""",
+        "softmin": """\
+    Let ``x`` be a sequence of unmasked elements of one-dimensional slice
+    of the :attr:`input` tensor. Softmin of i-th element in ``x`` is
+    defined as ``exp(-x[i])/sum(exp(-x))``.""",
+        "normalize": """\
+    Let ``x`` be a sequence of unmasked elements of one-dimensional slice
+    of the :attr:`input` tensor. Normalize of i-th element in ``x`` is
+    defined as ``x[i]/max(norm(x, p), eps)``.""",
+        "cumsum": """\
+    Let ``x`` be a sequence of unmasked elements of one-dimensional slice
+    of the :attr:`input` tensor. Cumsum of i-th element in ``x`` is
+    defined as ``sum(x[:i])``.""",
+        "cumprod": """\
+    Let ``x`` be a sequence of unmasked elements of one-dimensional slice
+    of the :attr:`input` tensor. Cumsum of i-th element in ``x`` is
+    defined as ``prod(x[:i])``.""",
+    }
 
-    reduction_names = dict(
-        sum="sum",
-        prod="product",
-        amax="maximum",
-        amin="minimum",
-        argmax="argmax",
-        argmin="argmin",
-        mean="mean",
-        median="median",
-        norm="norm",
-        var="variance",
-        std="standard_deviation",
-        logsumexp="logsumexp",
-    )
+    reduction_names = {
+        "sum": "sum",
+        "prod": "product",
+        "amax": "maximum",
+        "amin": "minimum",
+        "argmax": "argmax",
+        "argmin": "argmin",
+        "mean": "mean",
+        "median": "median",
+        "norm": "norm",
+        "var": "variance",
+        "std": "standard_deviation",
+        "logsumexp": "logsumexp",
+    }
 
-    normalization_names = dict(
-        softmax="softmax",
-        log_softmax="log_softmax",
-        softmin="softmin",
-        normalize="normalize",
-        cumsum="cumulative_sum",
-        cumprod="cumulative_prod",
-    )
+    normalization_names = {
+        "softmax": "softmax",
+        "log_softmax": "log_softmax",
+        "softmin": "softmin",
+        "normalize": "normalize",
+        "cumsum": "cumulative_sum",
+        "cumprod": "cumulative_prod",
+    }
 
     operation_names = {}
     operation_names.update(reduction_names)
@@ -745,9 +745,9 @@ def _sparse_csr_segment_reduction_helper(
 ) -> Tensor:
     # Currently, while sparse CSR is always 2D with no dense dimensions keepdim must be True
     # FIXME: when dense dimensions are implemented for CSR tensors
-    assert keepdim, (
-        "reduction operations on CSR tensors with keepdim=False is unsupported"
-    )
+    assert (
+        keepdim
+    ), "reduction operations on CSR tensors with keepdim=False is unsupported"
     reduce = op.__name__
     valid_reductions = ["sum", "prod", "mean", "amax", "amin"]
     if reduce not in valid_reductions:
@@ -781,9 +781,9 @@ def _sparse_csr_segment_reduction_helper(
             )
             new_shape = [1, mask_input.size(1)]
         else:
-            assert dims[0] == 1, (
-                "Sparse CSR tensors are 2D and only support reduction along dim 0 or 1."
-            )
+            assert (
+                dims[0] == 1
+            ), "Sparse CSR tensors are 2D and only support reduction along dim 0 or 1."
             # all intervals new_crow_indices[i] - new_crow_indices[i-1] are 1
             # except for where crow_indices[i] == crow_indices[i-1] where the interval remains as 0
             new_crow_indices = torch.cat(
@@ -1598,9 +1598,9 @@ def _std_var(
     mask: Optional[Tensor],
     take_sqrt: Optional[bool],
 ) -> Tensor:
-    assert unbiased is None or correction_opt is None, (
-        "Only one of unbiased and correction may be given"
-    )
+    assert (
+        unbiased is None or correction_opt is None
+    ), "Only one of unbiased and correction may be given"
     correction = 1.0
     if unbiased is not None:
         correction = 1.0 if unbiased else 0.0

--- a/torch/masked/_ops.py
+++ b/torch/masked/_ops.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 import warnings
 from typing import Any, Callable, Optional, TYPE_CHECKING, TypeVar, Union
+from typing_extensions import ParamSpec, TypeAlias
 
 import torch
 from torch import sym_float, Tensor
@@ -8,7 +9,6 @@ from torch._prims_common import corresponding_real_dtype
 from torch.masked import _docs
 from torch.masked.maskedtensor.core import is_masked_tensor, MaskedTensor
 from torch.masked.maskedtensor.creation import as_masked_tensor
-from typing_extensions import ParamSpec, TypeAlias
 
 
 if TYPE_CHECKING:
@@ -58,15 +58,15 @@ def _generate_docstring(func):
     """A utility function called from tools/update_masked_docs.py
     script to update the module torch.masked._docs.py
     """
-    docstring_templates = dict(
-        reduction_signature="""\
+    docstring_templates = {
+        "reduction_signature": """\
 {function_name}(input, {operation_args}, *, {operation_kwargs}) -> Tensor""",
-        reduction_descr="""\
+        "reduction_descr": """\
 Returns {operation name} of all the elements in the :attr:`input`
 tensor along the given dimension(s) :attr:`dim` while the :attr:`input`
 elements are masked out according to the boolean tensor
 :attr:`mask`.""",
-        reduction_args="""\
+        "reduction_args": """\
 If :attr:`keepdim` is ``True``, the output tensor is of the same size
 as :attr:`input` except in the dimension(s) :attr:`dim` where it is of
 size 1. Otherwise, :attr:`dim` is squeezed (see
@@ -101,7 +101,7 @@ Args:
 
 Keyword args:
     {kwargs_declarations}""",
-        reduction_example="""\
+        "reduction_example": """\
 Example::
 
     >>> input = {example_input}
@@ -113,21 +113,21 @@ Example::
     >>> {full_function_name}(input, {example_args}, mask=mask)
     {indent_example_output}
 """,
-        reduction_identity="""\
+        "reduction_identity": """\
 The identity value of {operation name} operation, which is used to start the reduction, is ``{identity_int32}``.""",
-        reduction_identity_dtype="""\
+        "reduction_identity_dtype": """\
 The identity value of {operation name} operation, which is used to start the
 reduction, depends on input dtype. For instance, for float32, uint8,
 and int32 dtypes, the identity values are ``{identity_float32}``, ``{identity_uint8}``, and ``{identity_int32}``, respectively.""",
-        normalization_signature="""\
+        "normalization_signature": """\
 {function_name}(input, {operation_args}, *, {operation_kwargs}) -> Tensor""",
-        normalization_descr="""\
+        "normalization_descr": """\
 Returns {operation name} of all the slices in the :attr:`input` tensor
 along :attr:`dim` while the :attr:`input` elements are masked out
 according to the boolean tensor :attr:`mask`.
 
 {definition}""",
-        normalization_args="""\
+        "normalization_args": """\
 The boolean tensor :attr:`mask` defines the "validity" of
 :attr:`input` tensor elements: if :attr:`mask` element is True then
 the corresponding element in :attr:`input` tensor will be included in
@@ -152,7 +152,7 @@ Args:
 
 Keyword args:
     {kwargs_declarations}""",
-        normalization_example="""\
+        "normalization_example": """\
 Example::
 
     >>> input = {example_input}
@@ -164,7 +164,7 @@ Example::
     >>> {full_function_name}(input, {example_args}, mask=mask)
     {indent_example_output}
 """,
-    )
+    }
 
     args_and_kwargs = {
         # argument name sufficies separated by double underscore will
@@ -745,9 +745,9 @@ def _sparse_csr_segment_reduction_helper(
 ) -> Tensor:
     # Currently, while sparse CSR is always 2D with no dense dimensions keepdim must be True
     # FIXME: when dense dimensions are implemented for CSR tensors
-    assert (
-        keepdim
-    ), "reduction operations on CSR tensors with keepdim=False is unsupported"
+    assert keepdim, (
+        "reduction operations on CSR tensors with keepdim=False is unsupported"
+    )
     reduce = op.__name__
     valid_reductions = ["sum", "prod", "mean", "amax", "amin"]
     if reduce not in valid_reductions:
@@ -781,9 +781,9 @@ def _sparse_csr_segment_reduction_helper(
             )
             new_shape = [1, mask_input.size(1)]
         else:
-            assert (
-                dims[0] == 1
-            ), "Sparse CSR tensors are 2D and only support reduction along dim 0 or 1."
+            assert dims[0] == 1, (
+                "Sparse CSR tensors are 2D and only support reduction along dim 0 or 1."
+            )
             # all intervals new_crow_indices[i] - new_crow_indices[i-1] are 1
             # except for where crow_indices[i] == crow_indices[i-1] where the interval remains as 0
             new_crow_indices = torch.cat(
@@ -1598,9 +1598,9 @@ def _std_var(
     mask: Optional[Tensor],
     take_sqrt: Optional[bool],
 ) -> Tensor:
-    assert (
-        unbiased is None or correction_opt is None
-    ), "Only one of unbiased and correction may be given"
+    assert unbiased is None or correction_opt is None, (
+        "Only one of unbiased and correction may be given"
+    )
     correction = 1.0
     if unbiased is not None:
         correction = 1.0 if unbiased else 0.0

--- a/torch/optim/_adafactor.py
+++ b/torch/optim/_adafactor.py
@@ -350,9 +350,9 @@ def _single_tensor_adafactor(
     maximize: bool,
     has_complex: bool,
 ):
-    assert (
-        grad_scale is None and found_inf is None
-    ), "Grad scaling should occur outside of optimizer.step()"
+    assert grad_scale is None and found_inf is None, (
+        "Grad scaling should occur outside of optimizer.step()"
+    )
 
     if torch.jit.is_scripting():
         # this assert is due to JIT being dumb and not realizing that the ops below
@@ -384,9 +384,9 @@ def _single_tensor_adafactor(
             param.mul_(1 - lr * weight_decay)
 
         if grad.dim() > 1:
-            assert (
-                row_var is not None and col_var is not None
-            ), "row_var and col_var should be defined when grad is multidimensional"
+            assert row_var is not None and col_var is not None, (
+                "row_var and col_var should be defined when grad is multidimensional"
+            )
             # same as (g * g).mean(dim=-1) w/o materializing an intermediate size g
             row_mean = (
                 torch.norm(grad, dim=-1, keepdim=True).square_().div_(grad.size(-1))
@@ -400,9 +400,9 @@ def _single_tensor_adafactor(
             var_estimate = row_var @ col_var
             var_estimate.div_(row_var.mean(dim=-2, keepdim=True).clamp_(min=eps1))
         else:
-            assert (
-                variance is not None
-            ), "variance should be defined when grad is a vector"
+            assert variance is not None, (
+                "variance should be defined when grad is a vector"
+            )
             grad_squared = grad * grad
             variance.lerp_(grad_squared, one_minus_beta2_t)
             # avoid writing into variance during update
@@ -475,9 +475,9 @@ def _multi_tensor_adafactor(
     if len(params) == 0:
         return
 
-    assert (
-        grad_scale is None and found_inf is None
-    ), "Grad scaling should occur outside of optimizer.step()"
+    assert grad_scale is None and found_inf is None, (
+        "Grad scaling should occur outside of optimizer.step()"
+    )
 
     lr = _to_scalar(lr)
 
@@ -498,9 +498,9 @@ def _multi_tensor_adafactor(
         device_grads = cast(list[Tensor], device_grads_)
         device_state_steps = cast(list[Tensor], device_state_steps_)
         if eps1 is None:
-            assert (
-                dtype is not None
-            ), "dtype is needed to compute eps1 when eps1 is unset"
+            assert dtype is not None, (
+                "dtype is needed to compute eps1 when eps1 is unset"
+            )
             eps1 = torch.finfo(dtype).eps
 
         if TYPE_CHECKING:
@@ -540,9 +540,9 @@ def _multi_tensor_adafactor(
         if is_multidim:
             device_row_vars = cast(list[Tensor], device_row_vars_)
             device_col_vars = cast(list[Tensor], device_col_vars_)
-            assert (
-                device_row_vars[0] is not None and device_col_vars[0] is not None
-            ), "row_var and col_var should be defined when grad is multidimensional"
+            assert device_row_vars[0] is not None and device_col_vars[0] is not None, (
+                "row_var and col_var should be defined when grad is multidimensional"
+            )
             # same as (g * g).mean(dim=-1) w/o materializing an intermediate size g
             row_means = [
                 torch.norm(grad, dim=-1, keepdim=True) for grad in device_grads
@@ -573,9 +573,9 @@ def _multi_tensor_adafactor(
             del row_var_means
         else:
             device_variances = cast(list[Tensor], device_variances_)
-            assert (
-                device_variances[0] is not None
-            ), "variance should be defined when grad is a vector"
+            assert device_variances[0] is not None, (
+                "variance should be defined when grad is a vector"
+            )
 
             grads_squared = torch._foreach_mul(device_grads, device_grads)
             torch._foreach_lerp_(device_variances, grads_squared, one_minus_beta2_ts)

--- a/torch/optim/_adafactor.py
+++ b/torch/optim/_adafactor.py
@@ -47,15 +47,15 @@ class Adafactor(Optimizer):
             raise ValueError(f"Clipping threshold d should be >= 1 but is: {d}")
         if not 0.0 <= weight_decay:
             raise ValueError(f"weight_decay should be >= 0 but is: {weight_decay}")
-        defaults = dict(
-            lr=lr,
-            beta2_decay=beta2_decay,
-            eps=eps,
-            d=d,
-            weight_decay=weight_decay,
-            foreach=foreach,
-            maximize=maximize,
-        )
+        defaults = {
+            "lr": lr,
+            "beta2_decay": beta2_decay,
+            "eps": eps,
+            "d": d,
+            "weight_decay": weight_decay,
+            "foreach": foreach,
+            "maximize": maximize,
+        }
         super().__init__(params, defaults)
 
     def __setstate__(self, state):
@@ -350,9 +350,9 @@ def _single_tensor_adafactor(
     maximize: bool,
     has_complex: bool,
 ):
-    assert grad_scale is None and found_inf is None, (
-        "Grad scaling should occur outside of optimizer.step()"
-    )
+    assert (
+        grad_scale is None and found_inf is None
+    ), "Grad scaling should occur outside of optimizer.step()"
 
     if torch.jit.is_scripting():
         # this assert is due to JIT being dumb and not realizing that the ops below
@@ -384,9 +384,9 @@ def _single_tensor_adafactor(
             param.mul_(1 - lr * weight_decay)
 
         if grad.dim() > 1:
-            assert row_var is not None and col_var is not None, (
-                "row_var and col_var should be defined when grad is multidimensional"
-            )
+            assert (
+                row_var is not None and col_var is not None
+            ), "row_var and col_var should be defined when grad is multidimensional"
             # same as (g * g).mean(dim=-1) w/o materializing an intermediate size g
             row_mean = (
                 torch.norm(grad, dim=-1, keepdim=True).square_().div_(grad.size(-1))
@@ -400,9 +400,9 @@ def _single_tensor_adafactor(
             var_estimate = row_var @ col_var
             var_estimate.div_(row_var.mean(dim=-2, keepdim=True).clamp_(min=eps1))
         else:
-            assert variance is not None, (
-                "variance should be defined when grad is a vector"
-            )
+            assert (
+                variance is not None
+            ), "variance should be defined when grad is a vector"
             grad_squared = grad * grad
             variance.lerp_(grad_squared, one_minus_beta2_t)
             # avoid writing into variance during update
@@ -475,9 +475,9 @@ def _multi_tensor_adafactor(
     if len(params) == 0:
         return
 
-    assert grad_scale is None and found_inf is None, (
-        "Grad scaling should occur outside of optimizer.step()"
-    )
+    assert (
+        grad_scale is None and found_inf is None
+    ), "Grad scaling should occur outside of optimizer.step()"
 
     lr = _to_scalar(lr)
 
@@ -498,9 +498,9 @@ def _multi_tensor_adafactor(
         device_grads = cast(list[Tensor], device_grads_)
         device_state_steps = cast(list[Tensor], device_state_steps_)
         if eps1 is None:
-            assert dtype is not None, (
-                "dtype is needed to compute eps1 when eps1 is unset"
-            )
+            assert (
+                dtype is not None
+            ), "dtype is needed to compute eps1 when eps1 is unset"
             eps1 = torch.finfo(dtype).eps
 
         if TYPE_CHECKING:
@@ -540,9 +540,9 @@ def _multi_tensor_adafactor(
         if is_multidim:
             device_row_vars = cast(list[Tensor], device_row_vars_)
             device_col_vars = cast(list[Tensor], device_col_vars_)
-            assert device_row_vars[0] is not None and device_col_vars[0] is not None, (
-                "row_var and col_var should be defined when grad is multidimensional"
-            )
+            assert (
+                device_row_vars[0] is not None and device_col_vars[0] is not None
+            ), "row_var and col_var should be defined when grad is multidimensional"
             # same as (g * g).mean(dim=-1) w/o materializing an intermediate size g
             row_means = [
                 torch.norm(grad, dim=-1, keepdim=True) for grad in device_grads
@@ -573,9 +573,9 @@ def _multi_tensor_adafactor(
             del row_var_means
         else:
             device_variances = cast(list[Tensor], device_variances_)
-            assert device_variances[0] is not None, (
-                "variance should be defined when grad is a vector"
-            )
+            assert (
+                device_variances[0] is not None
+            ), "variance should be defined when grad is a vector"
 
             grads_squared = torch._foreach_mul(device_grads, device_grads)
             torch._foreach_lerp_(device_variances, grads_squared, one_minus_beta2_ts)

--- a/torch/optim/adadelta.py
+++ b/torch/optim/adadelta.py
@@ -267,7 +267,9 @@ def _single_tensor_adadelta(
             p.device.type == step.device.type
             and p.device.type in capturable_supported_devices
             for p, step in zip(params, state_steps)
-        ), f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
+        ), (
+            f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
+        )
 
     if not torch.jit.is_scripting():
         lr = _to_scalar(lr)
@@ -326,7 +328,9 @@ def _multi_tensor_adadelta(
             p.device.type == step.device.type
             and p.device.type in capturable_supported_devices
             for p, step in zip(params, state_steps)
-        ), f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
+        ), (
+            f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
+        )
 
     if len(params) == 0:
         return

--- a/torch/optim/adadelta.py
+++ b/torch/optim/adadelta.py
@@ -50,16 +50,16 @@ class Adadelta(Optimizer):
         if not 0.0 <= weight_decay:
             raise ValueError(f"Invalid weight_decay value: {weight_decay}")
 
-        defaults = dict(
-            lr=lr,
-            rho=rho,
-            eps=eps,
-            weight_decay=weight_decay,
-            maximize=maximize,
-            capturable=capturable,
-            foreach=foreach,
-            differentiable=differentiable,
-        )
+        defaults = {
+            "lr": lr,
+            "rho": rho,
+            "eps": eps,
+            "weight_decay": weight_decay,
+            "maximize": maximize,
+            "capturable": capturable,
+            "foreach": foreach,
+            "differentiable": differentiable,
+        }
         super().__init__(params, defaults)
 
     def __setstate__(self, state):
@@ -267,9 +267,7 @@ def _single_tensor_adadelta(
             p.device.type == step.device.type
             and p.device.type in capturable_supported_devices
             for p, step in zip(params, state_steps)
-        ), (
-            f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
-        )
+        ), f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
 
     if not torch.jit.is_scripting():
         lr = _to_scalar(lr)
@@ -328,9 +326,7 @@ def _multi_tensor_adadelta(
             p.device.type == step.device.type
             and p.device.type in capturable_supported_devices
             for p, step in zip(params, state_steps)
-        ), (
-            f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
-        )
+        ), f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
 
     if len(params) == 0:
         return

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -54,17 +54,17 @@ class Adagrad(Optimizer):
         if not 0.0 <= eps:
             raise ValueError(f"Invalid epsilon value: {eps}")
 
-        defaults = dict(
-            lr=lr,
-            lr_decay=lr_decay,
-            eps=eps,
-            weight_decay=weight_decay,
-            initial_accumulator_value=initial_accumulator_value,
-            foreach=foreach,
-            maximize=maximize,
-            differentiable=differentiable,
-            fused=fused,
-        )
+        defaults = {
+            "lr": lr,
+            "lr_decay": lr_decay,
+            "eps": eps,
+            "weight_decay": weight_decay,
+            "initial_accumulator_value": initial_accumulator_value,
+            "foreach": foreach,
+            "maximize": maximize,
+            "differentiable": differentiable,
+            "fused": fused,
+        }
         super().__init__(params, defaults)
 
         if fused:

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -398,7 +398,9 @@ def _single_tensor_adam(
             assert (
                 param.device.type == step_t.device.type
                 and param.device.type in capturable_supported_devices
-            ), f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
+            ), (
+                f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
+            )
 
         # update step
         step_t += 1
@@ -597,7 +599,9 @@ def _multi_tensor_adam(
             p.device.type == step.device.type
             and p.device.type in capturable_supported_devices
             for p, step in zip(params, state_steps)
-        ), f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
+        ), (
+            f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
+        )
 
     assert grad_scale is None and found_inf is None
 

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -85,19 +85,19 @@ class Adam(Optimizer):
             if betas[1].numel() != 1:
                 raise ValueError("Tensor betas[1] must be 1-element")
 
-        defaults = dict(
-            lr=lr,
-            betas=betas,
-            eps=eps,
-            weight_decay=weight_decay,
-            amsgrad=amsgrad,
-            maximize=maximize,
-            foreach=foreach,
-            capturable=capturable,
-            differentiable=differentiable,
-            fused=fused,
-            decoupled_weight_decay=decoupled_weight_decay,
-        )
+        defaults = {
+            "lr": lr,
+            "betas": betas,
+            "eps": eps,
+            "weight_decay": weight_decay,
+            "amsgrad": amsgrad,
+            "maximize": maximize,
+            "foreach": foreach,
+            "capturable": capturable,
+            "differentiable": differentiable,
+            "fused": fused,
+            "decoupled_weight_decay": decoupled_weight_decay,
+        }
         super().__init__(params, defaults)
 
         if fused:
@@ -398,9 +398,7 @@ def _single_tensor_adam(
             assert (
                 param.device.type == step_t.device.type
                 and param.device.type in capturable_supported_devices
-            ), (
-                f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
-            )
+            ), f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
 
         # update step
         step_t += 1
@@ -599,9 +597,7 @@ def _multi_tensor_adam(
             p.device.type == step.device.type
             and p.device.type in capturable_supported_devices
             for p, step in zip(params, state_steps)
-        ), (
-            f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
-        )
+        ), f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
 
     assert grad_scale is None and found_inf is None
 

--- a/torch/optim/adamax.py
+++ b/torch/optim/adamax.py
@@ -256,7 +256,9 @@ def _single_tensor_adamax(
             assert (
                 param.device.type == step_t.device.type
                 and param.device.type in capturable_supported_devices
-            ), f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
+            ), (
+                f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
+            )
 
         # update step
         step_t += 1
@@ -331,7 +333,9 @@ def _multi_tensor_adamax(
             p.device.type == step.device.type
             and p.device.type in capturable_supported_devices
             for p, step in zip(params, state_steps)
-        ), f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
+        ), (
+            f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
+        )
 
     lr = _to_scalar(lr)
 

--- a/torch/optim/adamax.py
+++ b/torch/optim/adamax.py
@@ -53,16 +53,16 @@ class Adamax(Optimizer):
         if not 0.0 <= weight_decay:
             raise ValueError(f"Invalid weight_decay value: {weight_decay}")
 
-        defaults = dict(
-            lr=lr,
-            betas=betas,
-            eps=eps,
-            weight_decay=weight_decay,
-            foreach=foreach,
-            maximize=maximize,
-            differentiable=differentiable,
-            capturable=capturable,
-        )
+        defaults = {
+            "lr": lr,
+            "betas": betas,
+            "eps": eps,
+            "weight_decay": weight_decay,
+            "foreach": foreach,
+            "maximize": maximize,
+            "differentiable": differentiable,
+            "capturable": capturable,
+        }
         super().__init__(params, defaults)
 
     def __setstate__(self, state):
@@ -256,9 +256,7 @@ def _single_tensor_adamax(
             assert (
                 param.device.type == step_t.device.type
                 and param.device.type in capturable_supported_devices
-            ), (
-                f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
-            )
+            ), f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
 
         # update step
         step_t += 1
@@ -333,9 +331,7 @@ def _multi_tensor_adamax(
             p.device.type == step.device.type
             and p.device.type in capturable_supported_devices
             for p, step in zip(params, state_steps)
-        ), (
-            f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
-        )
+        ), f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
 
     lr = _to_scalar(lr)
 

--- a/torch/optim/asgd.py
+++ b/torch/optim/asgd.py
@@ -305,7 +305,9 @@ def _multi_tensor_asgd(
             p.device.type == mu.device.type == eta.device.type == step.device.type
             and p.device.type in capturable_supported_devices
             for p, mu, eta, step in zip(params, mus, etas, state_steps)
-        ), f"If capturable=True, params, mus, etas, and state_steps must be on supported devices: {capturable_supported_devices}."
+        ), (
+            f"If capturable=True, params, mus, etas, and state_steps must be on supported devices: {capturable_supported_devices}."
+        )
 
     lr = _to_scalar(lr)
 

--- a/torch/optim/asgd.py
+++ b/torch/optim/asgd.py
@@ -47,17 +47,17 @@ class ASGD(Optimizer):
         if not 0.0 <= weight_decay:
             raise ValueError(f"Invalid weight_decay value: {weight_decay}")
 
-        defaults = dict(
-            lr=lr,
-            lambd=lambd,
-            alpha=alpha,
-            t0=t0,
-            weight_decay=weight_decay,
-            foreach=foreach,
-            maximize=maximize,
-            differentiable=differentiable,
-            capturable=capturable,
-        )
+        defaults = {
+            "lr": lr,
+            "lambd": lambd,
+            "alpha": alpha,
+            "t0": t0,
+            "weight_decay": weight_decay,
+            "foreach": foreach,
+            "maximize": maximize,
+            "differentiable": differentiable,
+            "capturable": capturable,
+        }
         super().__init__(params, defaults)
 
     def __setstate__(self, state):
@@ -305,9 +305,7 @@ def _multi_tensor_asgd(
             p.device.type == mu.device.type == eta.device.type == step.device.type
             and p.device.type in capturable_supported_devices
             for p, mu, eta, step in zip(params, mus, etas, state_steps)
-        ), (
-            f"If capturable=True, params, mus, etas, and state_steps must be on supported devices: {capturable_supported_devices}."
-        )
+        ), f"If capturable=True, params, mus, etas, and state_steps must be on supported devices: {capturable_supported_devices}."
 
     lr = _to_scalar(lr)
 

--- a/torch/optim/lbfgs.py
+++ b/torch/optim/lbfgs.py
@@ -231,15 +231,15 @@ class LBFGS(Optimizer):
             raise ValueError(f"Invalid learning rate: {lr}")
         if max_eval is None:
             max_eval = max_iter * 5 // 4
-        defaults = dict(
-            lr=lr,
-            max_iter=max_iter,
-            max_eval=max_eval,
-            tolerance_grad=tolerance_grad,
-            tolerance_change=tolerance_change,
-            history_size=history_size,
-            line_search_fn=line_search_fn,
-        )
+        defaults = {
+            "lr": lr,
+            "max_iter": max_iter,
+            "max_eval": max_eval,
+            "tolerance_grad": tolerance_grad,
+            "tolerance_change": tolerance_change,
+            "history_size": history_size,
+            "line_search_fn": line_search_fn,
+        }
         super().__init__(params, defaults)
 
         if len(self.param_groups) != 1:

--- a/torch/optim/nadam.py
+++ b/torch/optim/nadam.py
@@ -59,18 +59,18 @@ class NAdam(Optimizer):  # noqa: D101
             raise ValueError(f"Invalid weight_decay value: {weight_decay}")
         if not 0.0 <= momentum_decay:
             raise ValueError(f"Invalid momentum_decay value: {momentum_decay}")
-        defaults = dict(
-            lr=lr,
-            betas=betas,
-            eps=eps,
-            weight_decay=weight_decay,
-            momentum_decay=momentum_decay,
-            decoupled_weight_decay=decoupled_weight_decay,
-            maximize=maximize,
-            foreach=foreach,
-            capturable=capturable,
-            differentiable=differentiable,
-        )
+        defaults = {
+            "lr": lr,
+            "betas": betas,
+            "eps": eps,
+            "weight_decay": weight_decay,
+            "momentum_decay": momentum_decay,
+            "decoupled_weight_decay": decoupled_weight_decay,
+            "maximize": maximize,
+            "foreach": foreach,
+            "capturable": capturable,
+            "differentiable": differentiable,
+        }
         super().__init__(params, defaults)
 
     def __setstate__(self, state):  # noqa: D105

--- a/torch/optim/radam.py
+++ b/torch/optim/radam.py
@@ -286,7 +286,9 @@ def _single_tensor_radam(
             assert (
                 param.device.type == step_t.device.type
                 and param.device.type in capturable_supported_devices
-            ), f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
+            ), (
+                f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
+            )
 
         if torch.is_complex(param):
             param = torch.view_as_real(param)
@@ -387,7 +389,9 @@ def _multi_tensor_radam(
             p.device.type == step.device.type
             and p.device.type in capturable_supported_devices
             for p, step in zip(params, state_steps)
-        ), f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
+        ), (
+            f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
+        )
 
     lr = _to_scalar(lr)
 

--- a/torch/optim/radam.py
+++ b/torch/optim/radam.py
@@ -56,17 +56,17 @@ class RAdam(Optimizer):  # noqa: D101
         if not 0.0 <= weight_decay:
             raise ValueError(f"Invalid weight_decay value: {weight_decay}")
 
-        defaults = dict(
-            lr=lr,
-            betas=betas,
-            eps=eps,
-            weight_decay=weight_decay,
-            maximize=maximize,
-            foreach=foreach,
-            capturable=capturable,
-            decoupled_weight_decay=decoupled_weight_decay,
-            differentiable=differentiable,
-        )
+        defaults = {
+            "lr": lr,
+            "betas": betas,
+            "eps": eps,
+            "weight_decay": weight_decay,
+            "maximize": maximize,
+            "foreach": foreach,
+            "capturable": capturable,
+            "decoupled_weight_decay": decoupled_weight_decay,
+            "differentiable": differentiable,
+        }
         super().__init__(params, defaults)
 
     def __setstate__(self, state):  # noqa: D105
@@ -286,9 +286,7 @@ def _single_tensor_radam(
             assert (
                 param.device.type == step_t.device.type
                 and param.device.type in capturable_supported_devices
-            ), (
-                f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
-            )
+            ), f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
 
         if torch.is_complex(param):
             param = torch.view_as_real(param)
@@ -389,9 +387,7 @@ def _multi_tensor_radam(
             p.device.type == step.device.type
             and p.device.type in capturable_supported_devices
             for p, step in zip(params, state_steps)
-        ), (
-            f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
-        )
+        ), f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
 
     lr = _to_scalar(lr)
 
@@ -522,15 +518,17 @@ def _multi_tensor_radam(
             del bias_correction1
         else:
             rect = [
-                (  # type: ignore[misc]
-                    (rho_t - 4)  # type: ignore[arg-type]
-                    * (rho_t - 2)
-                    * rho_inf
-                    / ((rho_inf - 4) * (rho_inf - 2) * rho_t)
+                (
+                    (  # type: ignore[misc]
+                        (rho_t - 4)  # type: ignore[arg-type]
+                        * (rho_t - 2)
+                        * rho_inf
+                        / ((rho_inf - 4) * (rho_inf - 2) * rho_t)
+                    )
+                    ** 0.5
+                    if rho_t > 5
+                    else 0
                 )
-                ** 0.5
-                if rho_t > 5
-                else 0
                 for rho_t in rho_t_list
             ]
             unrectified = [0 if rect > 0 else 1.0 for rect in rect]

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -293,7 +293,9 @@ def _single_tensor_rmsprop(
             assert (
                 param.device.type == step.device.type
                 and param.device.type in capturable_supported_devices
-            ), f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
+            ), (
+                f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
+            )
 
         grad = grads[i]
         grad = grad if not maximize else -grad
@@ -367,7 +369,9 @@ def _multi_tensor_rmsprop(
             p.device.type == step.device.type
             and p.device.type in capturable_supported_devices
             for p, step in zip(params, state_steps)
-        ), f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
+        ), (
+            f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
+        )
 
     lr = _to_scalar(lr)
 

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -55,18 +55,18 @@ class RMSprop(Optimizer):  # noqa: D101
         if not 0.0 <= alpha:
             raise ValueError(f"Invalid alpha value: {alpha}")
 
-        defaults = dict(
-            lr=lr,
-            momentum=momentum,
-            alpha=alpha,
-            eps=eps,
-            centered=centered,
-            weight_decay=weight_decay,
-            capturable=capturable,
-            foreach=foreach,
-            maximize=maximize,
-            differentiable=differentiable,
-        )
+        defaults = {
+            "lr": lr,
+            "momentum": momentum,
+            "alpha": alpha,
+            "eps": eps,
+            "centered": centered,
+            "weight_decay": weight_decay,
+            "capturable": capturable,
+            "foreach": foreach,
+            "maximize": maximize,
+            "differentiable": differentiable,
+        }
         super().__init__(params, defaults)
 
     def __setstate__(self, state):  # noqa: D105
@@ -293,9 +293,7 @@ def _single_tensor_rmsprop(
             assert (
                 param.device.type == step.device.type
                 and param.device.type in capturable_supported_devices
-            ), (
-                f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
-            )
+            ), f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
 
         grad = grads[i]
         grad = grad if not maximize else -grad
@@ -369,9 +367,7 @@ def _multi_tensor_rmsprop(
             p.device.type == step.device.type
             and p.device.type in capturable_supported_devices
             for p, step in zip(params, state_steps)
-        ), (
-            f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
-        )
+        ), f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
 
     lr = _to_scalar(lr)
 

--- a/torch/optim/rprop.py
+++ b/torch/optim/rprop.py
@@ -249,7 +249,9 @@ def _single_tensor_rprop(
             assert (
                 param.device.type == step.device.type
                 and param.device.type in capturable_supported_devices
-            ), f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
+            ), (
+                f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
+            )
 
         step += 1
 
@@ -316,7 +318,9 @@ def _multi_tensor_rprop(
             p.device.type == step.device.type
             and p.device.type in capturable_supported_devices
             for p, step in zip(params, state_steps)
-        ), f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
+        ), (
+            f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
+        )
 
     grouped_tensors = Optimizer._group_tensors_by_device_and_dtype(
         [params, grads, prevs, step_sizes, state_steps]  # type: ignore[list-item]

--- a/torch/optim/rprop.py
+++ b/torch/optim/rprop.py
@@ -47,15 +47,15 @@ class Rprop(Optimizer):  # noqa: D101
         if not 0.0 < etas[0] < 1.0 < etas[1]:
             raise ValueError(f"Invalid eta values: {etas[0]}, {etas[1]}")
 
-        defaults = dict(
-            lr=lr,
-            etas=etas,
-            step_sizes=step_sizes,
-            foreach=foreach,
-            maximize=maximize,
-            differentiable=differentiable,
-            capturable=capturable,
-        )
+        defaults = {
+            "lr": lr,
+            "etas": etas,
+            "step_sizes": step_sizes,
+            "foreach": foreach,
+            "maximize": maximize,
+            "differentiable": differentiable,
+            "capturable": capturable,
+        }
         super().__init__(params, defaults)
 
     def __setstate__(self, state):  # noqa: D105
@@ -249,9 +249,7 @@ def _single_tensor_rprop(
             assert (
                 param.device.type == step.device.type
                 and param.device.type in capturable_supported_devices
-            ), (
-                f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
-            )
+            ), f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
 
         step += 1
 
@@ -318,9 +316,7 @@ def _multi_tensor_rprop(
             p.device.type == step.device.type
             and p.device.type in capturable_supported_devices
             for p, step in zip(params, state_steps)
-        ), (
-            f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
-        )
+        ), f"If capturable=True, params and state_steps must be on supported devices: {capturable_supported_devices}."
 
     grouped_tensors = Optimizer._group_tensors_by_device_and_dtype(
         [params, grads, prevs, step_sizes, state_steps]  # type: ignore[list-item]

--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -49,17 +49,17 @@ class SGD(Optimizer):  # noqa: D101
         if weight_decay < 0.0:
             raise ValueError(f"Invalid weight_decay value: {weight_decay}")
 
-        defaults = dict(
-            lr=lr,
-            momentum=momentum,
-            dampening=dampening,
-            weight_decay=weight_decay,
-            nesterov=nesterov,
-            maximize=maximize,
-            foreach=foreach,
-            differentiable=differentiable,
-            fused=fused,
-        )
+        defaults = {
+            "lr": lr,
+            "momentum": momentum,
+            "dampening": dampening,
+            "weight_decay": weight_decay,
+            "nesterov": nesterov,
+            "maximize": maximize,
+            "foreach": foreach,
+            "differentiable": differentiable,
+            "fused": fused,
+        }
         if nesterov and (momentum <= 0 or dampening != 0):
             raise ValueError("Nesterov momentum requires a momentum and zero dampening")
         super().__init__(params, defaults)
@@ -523,9 +523,11 @@ def _fused_sgd(
         torch._fused_sgd_(
             device_params,
             device_grads,
-            []
-            if no_momentum_buffer
-            else cast(list[Tensor], device_momentum_buffer_list),
+            (
+                []
+                if no_momentum_buffer
+                else cast(list[Tensor], device_momentum_buffer_list)
+            ),
             weight_decay=weight_decay,
             momentum=momentum,
             lr=lr,

--- a/torch/optim/sparse_adam.py
+++ b/torch/optim/sparse_adam.py
@@ -31,15 +31,20 @@ class SparseAdam(Optimizer):
         if not 0.0 <= betas[1] < 1.0:
             raise ValueError(f"Invalid beta parameter at index 1: {betas[1]}")
 
-        defaults = dict(lr=lr, betas=betas, eps=eps, maximize=maximize)
+        defaults = {
+            "lr": lr,
+            "betas": betas,
+            "eps": eps,
+            "maximize": maximize,
+        }
         super().__init__(params, defaults)
 
         sparse_params = []
         complex_params = []
         for index, param_group in enumerate(self.param_groups):
-            assert isinstance(param_group, dict), (
-                f"param_groups must be a list of dicts, but got {type(param_group)}"
-            )
+            assert isinstance(
+                param_group, dict
+            ), f"param_groups must be a list of dicts, but got {type(param_group)}"
             # given param group, convert given params to a list first before iterating
             for d_index, d_param in enumerate(param_group["params"]):
                 if d_param.is_sparse:

--- a/torch/optim/sparse_adam.py
+++ b/torch/optim/sparse_adam.py
@@ -42,9 +42,9 @@ class SparseAdam(Optimizer):
         sparse_params = []
         complex_params = []
         for index, param_group in enumerate(self.param_groups):
-            assert isinstance(
-                param_group, dict
-            ), f"param_groups must be a list of dicts, but got {type(param_group)}"
+            assert isinstance(param_group, dict), (
+                f"param_groups must be a list of dicts, but got {type(param_group)}"
+            )
             # given param group, convert given params to a list first before iterating
             for d_index, d_param in enumerate(param_group["params"]):
                 if d_param.is_sparse:

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -16,7 +16,6 @@ import warnings
 from contextlib import closing, contextmanager
 from enum import Enum
 from typing import Any, Callable, cast, Generic, IO, Optional, TypeVar, Union
-from typing_extensions import TypeAlias, TypeIs
 
 import torch
 import torch._weights_only_unpickler as _weights_only_unpickler
@@ -24,6 +23,7 @@ from torch._sources import get_source_lines_and_file
 from torch._utils import _import_dotted_name
 from torch.storage import _get_dtype_from_pickle_storage_type
 from torch.types import FileLike, Storage
+from typing_extensions import TypeAlias, TypeIs
 
 
 __all__ = [
@@ -1109,15 +1109,15 @@ def _legacy_save(obj, f, pickle_module, pickle_protocol) -> None:
             return res
         return None
 
-    sys_info = dict(
-        protocol_version=PROTOCOL_VERSION,
-        little_endian=sys.byteorder == "little",
-        type_sizes=dict(
-            short=SHORT_SIZE,
-            int=INT_SIZE,
-            long=LONG_SIZE,
-        ),
-    )
+    sys_info = {
+        "protocol_version": PROTOCOL_VERSION,
+        "little_endian": sys.byteorder == "little",
+        "type_sizes": {
+            "short": SHORT_SIZE,
+            "int": INT_SIZE,
+            "long": LONG_SIZE,
+        },
+    }
 
     pickle_module.dump(MAGIC_NUMBER, f, protocol=pickle_protocol)
     pickle_module.dump(PROTOCOL_VERSION, f, protocol=pickle_protocol)
@@ -2067,9 +2067,9 @@ def _load(
         typename = _maybe_decode_ascii(saved_id[0])
         data = saved_id[1:]
 
-        assert typename == "storage", (
-            f"Unknown typename for persistent_load, expected 'storage' but got '{typename}'"
-        )
+        assert (
+            typename == "storage"
+        ), f"Unknown typename for persistent_load, expected 'storage' but got '{typename}'"
         storage_type, key, location, numel = data
         if storage_type is torch.UntypedStorage:
             dtype = torch.uint8

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -16,6 +16,7 @@ import warnings
 from contextlib import closing, contextmanager
 from enum import Enum
 from typing import Any, Callable, cast, Generic, IO, Optional, TypeVar, Union
+from typing_extensions import TypeAlias, TypeIs
 
 import torch
 import torch._weights_only_unpickler as _weights_only_unpickler
@@ -23,7 +24,6 @@ from torch._sources import get_source_lines_and_file
 from torch._utils import _import_dotted_name
 from torch.storage import _get_dtype_from_pickle_storage_type
 from torch.types import FileLike, Storage
-from typing_extensions import TypeAlias, TypeIs
 
 
 __all__ = [
@@ -1951,7 +1951,7 @@ def _load(
     data_descripter_size64 = 24
     data_descripter_size32 = 16
     mz_uint32_max = 0xFFFFFFFF
-    offsets: dict[str, int] = dict()
+    offsets: dict[str, int] = {}
 
     def _get_offset(key, name, numel):
         """
@@ -2067,9 +2067,9 @@ def _load(
         typename = _maybe_decode_ascii(saved_id[0])
         data = saved_id[1:]
 
-        assert (
-            typename == "storage"
-        ), f"Unknown typename for persistent_load, expected 'storage' but got '{typename}'"
+        assert typename == "storage", (
+            f"Unknown typename for persistent_load, expected 'storage' but got '{typename}'"
+        )
         storage_type, key, location, numel = data
         if storage_type is torch.UntypedStorage:
             dtype = torch.uint8

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -598,7 +598,10 @@ def as_sparse_gradcheck(gradcheck):
                     and obj.requires_grad
                     and obj.layout in sparse_layouts
                 ):
-                    d = dict(layout=obj.layout, shape=obj.shape)
+                    d = {
+                        "layout": obj.layout,
+                        "shape": obj.shape,
+                    }
                     if not masked:
                         # Materialize unspecified elements with zero values
                         batch_dim = obj.ndim - obj.dense_dim() - obj.sparse_dim()


### PR DESCRIPTION
Following the suggestion in https://github.com/pytorch/pytorch/pull/157735, we ban the use of the dict keyword for literals. 

I also noticed that PYFMT formatted some files when running `lintrunner -a` to ensure that ruff passes, which is why there are formatting changes in this PR. 

Might need to continue to rebase and fix against trunk since we changed a linting rule. 



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov