### PR TITLE
[MyPy][Typing] ban use of dict(..) for literal dictionaries

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,7 +7,7 @@ max-line-length = 120
 # C408 ignored because we like the dict keyword argument syntax
 # E501 is not flexible enough, we're using B950 instead
 ignore =
-    E203,E305,E402,E501,E704,E721,E741,F405,F841,F999,W503,W504,C408,E302,W291,E303,
+    E203,E305,E402,E501,E704,E721,E741,F405,F841,F999,W503,W504,E302,W291,E303,
     # shebang has extra meaning in fbcode lints, so I think it's not worth trying
     # to line this up with executable bit
     EXE001,

--- a/benchmarks/fastrnns/profile.py
+++ b/benchmarks/fastrnns/profile.py
@@ -41,15 +41,15 @@ def run_rnn(
         torch.cuda.synchronize()
 
     assert device == "cuda"
-    creator_args = dict(
-        seqLength=seqLength,
-        numLayers=numLayers,
-        inputSize=inputSize,
-        hiddenSize=hiddenSize,
-        miniBatch=miniBatch,
-        device=device,
-        seed=seed,
-    )
+    creator_args = {
+        "seqLength": seqLength,
+        "numLayers": numLayers,
+        "inputSize": inputSize,
+        "hiddenSize": hiddenSize,
+        "miniBatch": miniBatch,
+        "device": device,
+        "seed": seed,
+    }
     modeldef = rnn_creator(**creator_args)
 
     [run_iter(modeldef) for _ in range(nloops)]
@@ -68,15 +68,15 @@ def profile(
     device="cuda",
     seed=None,
 ):
-    params = dict(
-        seqLength=seqLength,
-        numLayers=numLayers,
-        inputSize=inputSize,
-        hiddenSize=hiddenSize,
-        miniBatch=miniBatch,
-        device=device,
-        seed=seed,
-    )
+    params = {
+        "seqLength": seqLength,
+        "numLayers": numLayers,
+        "inputSize": inputSize,
+        "hiddenSize": hiddenSize,
+        "miniBatch": miniBatch,
+        "device": device,
+        "seed": seed,
+    }
     for name, creator, context in get_nn_runners(*rnns):
         with context():
             run_rnn(name, creator, nloops, **params)

--- a/benchmarks/fastrnns/test.py
+++ b/benchmarks/fastrnns/test.py
@@ -39,15 +39,15 @@ def test_rnns(
     device="cuda",
     seed=17,
 ):
-    creator_args = dict(
-        seqLength=seqLength,
-        numLayers=numLayers,
-        inputSize=inputSize,
-        hiddenSize=hiddenSize,
-        miniBatch=miniBatch,
-        device=device,
-        seed=seed,
-    )
+    creator_args = {
+        "seqLength": seqLength,
+        "numLayers": numLayers,
+        "inputSize": inputSize,
+        "hiddenSize": hiddenSize,
+        "miniBatch": miniBatch,
+        "device": device,
+        "seed": seed,
+    }
 
     print("Setting up...")
     control = control_creator(**creator_args)

--- a/benchmarks/functional_autograd_benchmark/audio_text_models.py
+++ b/benchmarks/functional_autograd_benchmark/audio_text_models.py
@@ -34,9 +34,12 @@ def get_deepspeech(device: torch.device) -> GetterReturnType:
     sample_rate = 16000
     window_size = 0.02
     window = "hamming"
-    audio_conf = dict(
-        sample_rate=sample_rate, window_size=window_size, window=window, noise_dir=None
-    )
+    audio_conf = {
+        "sample_rate": sample_rate,
+        "window_size": window_size,
+        "window": window,
+        "noise_dir": None,
+    }
 
     N = 10
     num_classes = 10

--- a/benchmarks/gpt_fast/mixtral_moe_model.py
+++ b/benchmarks/gpt_fast/mixtral_moe_model.py
@@ -53,17 +53,17 @@ class ModelArgs:
 
 
 transformer_configs = {
-    "Mixtral-8x7B-v0.1": dict(
-        block_size=32768,
-        n_layer=16,
-        n_head=32,
-        n_local_heads=8,
-        dim=4096,
-        intermediate_size=14336,
-        rope_base=1000000.0,
-        num_experts=8,
-        num_activated_experts=2,
-    ),
+    "Mixtral-8x7B-v0.1": {
+        "block_size": 32768,
+        "n_layer": 16,
+        "n_head": 32,
+        "n_local_heads": 8,
+        "dim": 4096,
+        "intermediate_size": 14336,
+        "rope_base": 1000000.0,
+        "num_experts": 8,
+        "num_activated_experts": 2,
+    },
 }
 
 

--- a/benchmarks/gpt_fast/model.py
+++ b/benchmarks/gpt_fast/model.py
@@ -59,32 +59,40 @@ class ModelArgs:
 
 
 transformer_configs = {
-    "CodeLlama-7b-Python-hf": dict(
-        block_size=16384, vocab_size=32000, n_layer=32, dim=4096, rope_base=1000000
-    ),
-    "7B": dict(n_layer=32, n_head=32, dim=4096),
-    "13B": dict(n_layer=40, n_head=40, dim=5120),
-    "30B": dict(n_layer=60, n_head=52, dim=6656),
-    "34B": dict(
-        n_layer=48,
-        n_head=64,
-        dim=8192,
-        vocab_size=32000,
-        n_local_heads=8,
-        intermediate_size=22016,
-        rope_base=1000000,
-    ),  # CodeLlama-34B-Python-hf
-    "70B": dict(
-        n_layer=80, n_head=64, dim=8192, n_local_heads=8, intermediate_size=28672
-    ),
-    "Mistral-7B": dict(
-        n_layer=32,
-        n_head=32,
-        n_local_heads=8,
-        dim=4096,
-        intermediate_size=14336,
-        vocab_size=32000,
-    ),
+    "CodeLlama-7b-Python-hf": {
+        "block_size": 16384,
+        "vocab_size": 32000,
+        "n_layer": 32,
+        "dim": 4096,
+        "rope_base": 1000000,
+    },
+    "7B": {"n_layer": 32, "n_head": 32, "dim": 4096},
+    "13B": {"n_layer": 40, "n_head": 40, "dim": 5120},
+    "30B": {"n_layer": 60, "n_head": 52, "dim": 6656},
+    "34B": {
+        "n_layer": 48,
+        "n_head": 64,
+        "dim": 8192,
+        "vocab_size": 32000,
+        "n_local_heads": 8,
+        "intermediate_size": 22016,
+        "rope_base": 1000000,
+    },  # CodeLlama-34B-Python-hf
+    "70B": {
+        "n_layer": 80,
+        "n_head": 64,
+        "dim": 8192,
+        "n_local_heads": 8,
+        "intermediate_size": 28672,
+    },
+    "Mistral-7B": {
+        "n_layer": 32,
+        "n_head": 32,
+        "n_local_heads": 8,
+        "dim": 4096,
+        "intermediate_size": 14336,
+        "vocab_size": 32000,
+    },
 }
 
 

--- a/benchmarks/operator_benchmark/pt/batchnorm_test.py
+++ b/benchmarks/operator_benchmark/pt/batchnorm_test.py
@@ -14,14 +14,14 @@ if torch.backends.cudnn.is_available:
         for config in configs:
             is_cuda = any("cuda" in attr.values() for attr in config)
             if is_cuda:
-                result.append((*config, dict(cudnn=True)))
-            result.append((*config, dict(cudnn=False)))
+                result.append((*config, {"cudnn": True}))
+            result.append((*config, {"cudnn": False}))
         return result
 
 else:
 
     def cudnn_benchmark_configs(configs):
-        return [(*config, dict(cudnn=False)) for config in configs]
+        return [(*config, {"cudnn": False}) for config in configs]
 
 
 batchnorm_configs_short = cudnn_benchmark_configs(

--- a/benchmarks/sparse/triton_ops.py
+++ b/benchmarks/sparse/triton_ops.py
@@ -53,7 +53,7 @@ def test_bsr_dense_mm(x, y, **meta):
 
     def test_func(x=x, y=y):
         return bsr_dense_mm(
-            x, y, meta=dict(GROUP_SIZE_ROW=4, num_stages=1, num_warps=4)
+            x, y, meta={"GROUP_SIZE_ROW": 4, "num_stages": 1, "num_warps": 4}
         )
 
     return _test_worker(test_func)
@@ -350,21 +350,21 @@ if __name__ == "__main__":
                     # Skip invalid parameter combinations
                     continue
                 test_func = globals()["test_" + op]
-                meta = dict(
-                    bsr_scatter_mm6=dict(
-                        SPLIT_N=split_n,
-                        TILE_M=tile_m,
-                        TILE_N=tile_n,
-                        GROUP_SIZE=group_size,
-                        num_stages=num_stages,
-                        num_warps=num_warps,
-                    ),
-                    bsr_dense_mm_with_meta=dict(
-                        GROUP_SIZE_ROW=group_size,
-                        num_stages=num_stages,
-                        num_warps=num_warps,
-                    ),
-                ).get(op, {})
+                meta = {
+                    "bsr_scatter_mm6": {
+                        "SPLIT_N": split_n,
+                        "TILE_M": tile_m,
+                        "TILE_N": tile_n,
+                        "GROUP_SIZE": group_size,
+                        "num_stages": num_stages,
+                        "num_warps": num_warps,
+                    },
+                    "bsr_dense_mm_with_meta": {
+                        "GROUP_SIZE_ROW": group_size,
+                        "num_stages": num_stages,
+                        "num_warps": num_warps,
+                    },
+                }.get(op, {})
 
                 meta_str = ";".join(
                     f"{k}={v}" for k, v in meta.items() if v is not None

--- a/benchmarks/transformer/score_mod.py
+++ b/benchmarks/transformer/score_mod.py
@@ -690,7 +690,7 @@ def generate_block_mask(attn_type: str, shape: tuple[int]):
     if attn_type == "document_mask":
         random.seed(0)
         lengths = generate_random_lengths(N * B, B)
-        mask_mod_kwargs = dict(offsets=length_to_offsets(lengths, "cuda"))
+        mask_mod_kwargs = {"offsets": length_to_offsets(lengths, "cuda")}
 
     mask_mod_dict = {
         "noop": None,
@@ -848,7 +848,7 @@ def generate_FA_callable(
     if attn_type == "alibi":
         h = torch.arange(Hq, dtype=torch.float32, device="cuda")
         alibi_slopes = torch.exp2(-((h + 1) * 8.0 / Hq))
-        FA_kwargs = dict(alibi_slopes=alibi_slopes)
+        FA_kwargs = {"alibi_slopes": alibi_slopes}
     elif attn_type == "document_mask":
         FA_kwargs["cu_seqlens_q"] = kwargs["offsets"].to(torch.int32)
         FA_kwargs["cu_seqlens_k"] = kwargs["offsets"].to(torch.int32)
@@ -905,7 +905,7 @@ def generate_FD_callable(
     if attn_type == "alibi":
         h = torch.arange(Hq, dtype=torch.float32, device="cuda")
         alibi_slopes = torch.exp2(-((h + 1) * 8.0 / Hq))
-        FA_kwargs = dict(alibi_slopes=alibi_slopes)
+        FA_kwargs = {"alibi_slopes": alibi_slopes}
 
     FD_dict = {
         "noop": partial(flash_attn_with_kvcache_renamed, causal=False),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,6 @@ ignore = [
     "B023",
     "B028", # No explicit `stacklevel` keyword argument found
     "E402",
-    "C408", # C408 ignored because we like the dict keyword argument syntax
     "E501", # E501 is not flexible enough, we're using B950 instead
     "E721",
     "E741",

--- a/test/cpp_api_parity/sample_functional.py
+++ b/test/cpp_api_parity/sample_functional.py
@@ -45,28 +45,28 @@ Tensor sample_functional(Tensor x, SampleFunctionalFuncOptions options) {
 """
 
 functional_tests = [
-    dict(
-        constructor=wrap_functional(F.sample_functional, has_parity=True),
-        cpp_options_args="F::SampleFunctionalFuncOptions(true)",
-        input_size=(1, 2, 3),
-        fullname="sample_functional_has_parity",
-        has_parity=True,
-    ),
-    dict(
-        constructor=wrap_functional(F.sample_functional, has_parity=False),
-        cpp_options_args="F::SampleFunctionalFuncOptions(false)",
-        input_size=(1, 2, 3),
-        fullname="sample_functional_no_parity",
-        has_parity=False,
-    ),
+    {
+        "constructor": wrap_functional(F.sample_functional, has_parity=True),
+        "cpp_options_args": "F::SampleFunctionalFuncOptions(true)",
+        "input_size": (1, 2, 3),
+        "fullname": "sample_functional_has_parity",
+        "has_parity": True,
+    },
+    {
+        "constructor": wrap_functional(F.sample_functional, has_parity=False),
+        "cpp_options_args": "F::SampleFunctionalFuncOptions(false)",
+        "input_size": (1, 2, 3),
+        "fullname": "sample_functional_no_parity",
+        "has_parity": False,
+    },
     # This is to test that setting the `test_cpp_api_parity=False` flag skips
     # the C++ API parity test accordingly (otherwise this test would run and
     # throw a parity error).
-    dict(
-        constructor=wrap_functional(F.sample_functional, has_parity=False),
-        cpp_options_args="F::SampleFunctionalFuncOptions(false)",
-        input_size=(1, 2, 3),
-        fullname="sample_functional_THIS_TEST_SHOULD_BE_SKIPPED",
-        test_cpp_api_parity=False,
-    ),
+    {
+        "constructor": wrap_functional(F.sample_functional, has_parity=False),
+        "cpp_options_args": "F::SampleFunctionalFuncOptions(false)",
+        "input_size": (1, 2, 3),
+        "fullname": "sample_functional_THIS_TEST_SHOULD_BE_SKIPPED",
+        "test_cpp_api_parity": False,
+    },
 ]

--- a/test/cpp_api_parity/sample_module.py
+++ b/test/cpp_api_parity/sample_module.py
@@ -77,32 +77,32 @@ TORCH_MODULE(SampleModule);
 """
 
 module_tests = [
-    dict(
-        module_name="SampleModule",
-        desc="has_parity",
-        constructor_args=(True, True),
-        cpp_constructor_args="torch::nn::SampleModuleOptions(true, true)",
-        input_size=(3, 4),
-        cpp_input_args=["torch::randn({3, 4})"],
-        has_parity=True,
-    ),
-    dict(
-        fullname="SampleModule_no_parity",
-        constructor=lambda: SampleModule(has_parity=False, has_submodule=True),
-        cpp_constructor_args="torch::nn::SampleModuleOptions(false, true)",
-        input_size=(3, 4),
-        cpp_input_args=["torch::randn({3, 4})"],
-        has_parity=False,
-    ),
+    {
+        "module_name": "SampleModule",
+        "desc": "has_parity",
+        "constructor_args": (True, True),
+        "cpp_constructor_args": "torch::nn::SampleModuleOptions(true, true)",
+        "input_size": (3, 4),
+        "cpp_input_args": ["torch::randn({3, 4})"],
+        "has_parity": True,
+    },
+    {
+        "fullname": "SampleModule_no_parity",
+        "constructor": lambda: SampleModule(has_parity=False, has_submodule=True),
+        "cpp_constructor_args": "torch::nn::SampleModuleOptions(false, true)",
+        "input_size": (3, 4),
+        "cpp_input_args": ["torch::randn({3, 4})"],
+        "has_parity": False,
+    },
     # This is to test that setting the `test_cpp_api_parity=False` flag skips
     # the C++ API parity test accordingly (otherwise this test would run and
     # throw a parity error).
-    dict(
-        fullname="SampleModule_THIS_TEST_SHOULD_BE_SKIPPED",
-        constructor=lambda: SampleModule(False, True),
-        cpp_constructor_args="torch::nn::SampleModuleOptions(false, true)",
-        input_size=(3, 4),
-        cpp_input_args=["torch::randn({3, 4})"],
-        test_cpp_api_parity=False,
-    ),
+    {
+        "fullname": "SampleModule_THIS_TEST_SHOULD_BE_SKIPPED",
+        "constructor": lambda: SampleModule(False, True),
+        "cpp_constructor_args": "torch::nn::SampleModuleOptions(false, true)",
+        "input_size": (3, 4),
+        "cpp_input_args": ["torch::randn({3, 4})"],
+        "test_cpp_api_parity": False,
+    },
 ]

--- a/test/distributed/_composable/fsdp/test_fully_shard_compile.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_compile.py
@@ -783,32 +783,34 @@ Unsupported Tensor.backward() call
                     f"def call({extra_str_from_graph_partition}args):"
                 )
                 for fwd_ag_block_info in [
-                    dict(overlapped_compute_op_str=None),
-                    dict(
-                        overlapped_compute_op_str="extern_kernels.mm(",
-                    ),
-                    dict(
-                        overlapped_compute_op_str="extern_kernels.mm(",
-                    ),
-                    dict(
-                        overlapped_compute_op_str="extern_kernels.mm(",
-                    ),
-                    dict(
-                        overlapped_compute_op_str="extern_kernels.mm(",
-                    ),
-                    dict(
-                        overlapped_compute_op_str="extern_kernels.mm(",
-                    ),
-                    dict(
-                        overlapped_compute_op_str="extern_kernels.mm(",
-                    ),
-                    dict(
-                        overlapped_compute_op_str="extern_kernels.mm(",
-                    ),
-                    dict(
-                        overlapped_compute_op_str="extern_kernels.mm(",
-                        last_all_gather=True,
-                    ),
+                    {
+                        "overlapped_compute_op_str": None,
+                    },
+                    {
+                        "overlapped_compute_op_str": "extern_kernels.mm(",
+                    },
+                    {
+                        "overlapped_compute_op_str": "extern_kernels.mm(",
+                    },
+                    {
+                        "overlapped_compute_op_str": "extern_kernels.mm(",
+                    },
+                    {
+                        "overlapped_compute_op_str": "extern_kernels.mm(",
+                    },
+                    {
+                        "overlapped_compute_op_str": "extern_kernels.mm(",
+                    },
+                    {
+                        "overlapped_compute_op_str": "extern_kernels.mm(",
+                    },
+                    {
+                        "overlapped_compute_op_str": "extern_kernels.mm(",
+                    },
+                    {
+                        "overlapped_compute_op_str": "extern_kernels.mm(",
+                        "last_all_gather": True,
+                    },
                 ]:
                     # file_check = self.inductor_code_check_fsdp_all_gather(
                     #     file_check, **fwd_ag_block_info
@@ -821,25 +823,31 @@ Unsupported Tensor.backward() call
                     f"def call({extra_str_from_graph_partition}args):"
                 )
                 for bwd_ag_block_info in [
-                    dict(overlapped_compute_op_str=None),
-                    dict(
-                        overlapped_compute_op_str="extern_kernels.mm(",
-                    ),
-                    dict(
-                        overlapped_compute_op_str="extern_kernels.mm(",
-                        last_all_gather=True,
-                    ),
+                    {
+                        "overlapped_compute_op_str": None,
+                    },
+                    {
+                        "overlapped_compute_op_str": "extern_kernels.mm(",
+                    },
+                    {
+                        "overlapped_compute_op_str": "extern_kernels.mm(",
+                        "last_all_gather": True,
+                    },
                 ]:
                     # file_check = self.inductor_code_check_fsdp_all_gather(
                     #     file_check, **bwd_ag_block_info
                     # )
                     pass
                 for bwd_rs_block_info in [
-                    dict(overlapped_compute_op_str="extern_kernels.addmm("),
-                    dict(
-                        overlapped_compute_op_str=None
-                    ),  # TODO: improve compute/comm overlap, so that `overlapped_compute_op_str` is not None
-                    dict(overlapped_compute_op_str=None),
+                    {
+                        "overlapped_compute_op_str": "extern_kernels.addmm(",
+                    },
+                    {
+                        "overlapped_compute_op_str": None,
+                    },  # TODO: improve compute/comm overlap, so that `overlapped_compute_op_str` is not None
+                    {
+                        "overlapped_compute_op_str": None,
+                    },
                 ]:
                     # file_check = self.inductor_code_check_fsdp_reduce_scatter(
                     #     file_check, **bwd_rs_block_info
@@ -1029,21 +1037,21 @@ Unsupported Tensor.backward() call
                     f"def call({extra_str_from_graph_partition}args):"
                 )
                 for fwd_ag_block_info in [
-                    dict(
-                        overlapped_compute_op_str=(
+                    {
+                        "overlapped_compute_op_str": (
                             "triton_" if all_requires_grad else None
                         ),
-                    ),
-                    dict(
-                        overlapped_compute_op_str="aten.native_dropout.",
-                    ),
-                    dict(
-                        overlapped_compute_op_str="aten._scaled_dot_product_efficient_attention.",
-                    ),
-                    dict(
-                        overlapped_compute_op_str="aten._scaled_dot_product_efficient_attention.",
-                        last_all_gather=True,
-                    ),
+                    },
+                    {
+                        "overlapped_compute_op_str": "aten.native_dropout.",
+                    },
+                    {
+                        "overlapped_compute_op_str": "aten._scaled_dot_product_efficient_attention.",
+                    },
+                    {
+                        "overlapped_compute_op_str": "aten._scaled_dot_product_efficient_attention.",
+                        "last_all_gather": True,
+                    },
                 ]:
                     # file_check = self.inductor_code_check_fsdp_all_gather(
                     #     file_check, **fwd_ag_block_info
@@ -1056,16 +1064,16 @@ Unsupported Tensor.backward() call
                     f"def call({extra_str_from_graph_partition}args):"
                 )
                 for bwd_ag_block_info in [
-                    dict(
-                        overlapped_compute_op_str="extern_kernels.mm(",
-                    ),
-                    dict(
-                        overlapped_compute_op_str="aten._scaled_dot_product_efficient_attention_backward.",
-                    ),
-                    dict(
-                        overlapped_compute_op_str="aten._scaled_dot_product_efficient_attention_backward.",
-                        last_all_gather=True,
-                    ),
+                    {
+                        "overlapped_compute_op_str": "extern_kernels.mm(",
+                    },
+                    {
+                        "overlapped_compute_op_str": "aten._scaled_dot_product_efficient_attention_backward.",
+                    },
+                    {
+                        "overlapped_compute_op_str": "aten._scaled_dot_product_efficient_attention_backward.",
+                        "last_all_gather": True,
+                    },
                 ]:
                     # if bwd_ag_block_info is not None:
                     #     file_check = self.inductor_code_check_fsdp_all_gather(
@@ -1074,15 +1082,25 @@ Unsupported Tensor.backward() call
                     pass
                 for bwd_rs_block_info in [
                     (
-                        dict(overlapped_compute_op_str="extern_kernels.mm(")
+                        {
+                            "overlapped_compute_op_str": "extern_kernels.mm(",
+                        }
                         if all_requires_grad
                         else None
                     ),
-                    dict(
-                        overlapped_compute_op_str=None
-                    ),  # TODO: improve compute/comm overlap, so that `overlapped_compute_op_str` is not None
-                    dict(overlapped_compute_op_str=None),
-                    dict(overlapped_compute_op_str=None) if all_requires_grad else None,
+                    {
+                        "overlapped_compute_op_str": None,
+                    },  # TODO: improve compute/comm overlap, so that `overlapped_compute_op_str` is not None
+                    {
+                        "overlapped_compute_op_str": None,
+                    },
+                    (
+                        {
+                            "overlapped_compute_op_str": None,
+                        }
+                        if all_requires_grad
+                        else None
+                    ),
                 ]:
                     # if bwd_rs_block_info is not None:
                     #     file_check = self.inductor_code_check_fsdp_reduce_scatter(

--- a/test/distributed/tensor/test_pointwise_ops.py
+++ b/test/distributed/tensor/test_pointwise_ops.py
@@ -240,11 +240,11 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
             device_mesh=device_mesh,
             placements=placements,
             op=torch.ops.aten.native_dropout_backward,
-            kwargs=dict(
-                grad_output=grad_output,
-                mask=mask,
-                scale=0.3,
-            ),
+            kwargs={
+                "grad_output": grad_output,
+                "mask": mask,
+                "scale": 0.3,
+            },
         )
 
     def test_dropout_errors(self):

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -860,9 +860,12 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
         # used by the other PG's.  There are specific edge cases for nccl that need to be tested.
 
         store = c10d.FileStore(self.file_name, self.world_size)
-        base_opts = dict(
-            backend="nccl", store=store, rank=self.rank, world_size=self.world_size
-        )
+        base_opts = {
+            "backend": "nccl",
+            "store": store,
+            "rank": self.rank,
+            "world_size": self.world_size,
+        }
 
         # test the default value coming from the `init_process_group` kwarg default
         dist.init_process_group(**base_opts)
@@ -902,13 +905,13 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
     @parametrize("backend", [None, "nccl"])
     def test_set_nccl_pg_timeout(self, backend):
         store = c10d.FileStore(self.file_name, self.world_size)
-        opts = dict(
-            backend=backend,
-            store=store,
-            rank=self.rank,
-            world_size=self.world_size,
-            timeout=timedelta(seconds=123),
-        )
+        opts = {
+            "backend": backend,
+            "store": store,
+            "rank": self.rank,
+            "world_size": self.world_size,
+            "timeout": timedelta(seconds=123),
+        }
         dist.init_process_group(**opts)
         pg = dist.distributed_c10d._get_default_group()
         pg.allreduce(torch.rand(10).cuda(self.rank))
@@ -927,13 +930,13 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
     def test_extend_nccl_pg_timeout(self, backend):
         torch.cuda.set_device(self.rank)
         store = c10d.FileStore(self.file_name, self.world_size)
-        opts = dict(
-            backend=backend,
-            store=store,
-            rank=self.rank,
-            world_size=self.world_size,
-            timeout=timedelta(seconds=123),
-        )
+        opts = {
+            "backend": backend,
+            "store": store,
+            "rank": self.rank,
+            "world_size": self.world_size,
+            "timeout": timedelta(seconds=123),
+        }
         dist.init_process_group(**opts)
         pg = dist.distributed_c10d._get_default_group()
         bankend = pg._get_backend(torch.device(f"cuda:{self.rank}"))

--- a/test/dynamo/cpython/3_13/test_contextlib.py
+++ b/test/dynamo/cpython/3_13/test_contextlib.py
@@ -750,10 +750,10 @@ class _TestBaseExitStack:
             ((), {}),
             ((1,), {}),
             ((1,2), {}),
-            ((), dict(example=1)),
-            ((1,), dict(example=1)),
-            ((1,2), dict(example=1)),
-            ((1,2), dict(self=3, callback=4)),
+            ((), {'example': 1, }),
+            ((1,), {'example': 1, }),
+            ((1,2), {'example': 1, }),
+            ((1,2), {'self': 3, 'callback': 4, }),
         ]
         result = []
         def _exit(*args, **kwds):

--- a/test/dynamo/cpython/3_13/test_dict.py
+++ b/test/dynamo/cpython/3_13/test_dict.py
@@ -78,8 +78,8 @@ class DictTest(__TestCase):
 
     def test_constructor(self):
         # calling built-in types without argument must return empty
-        self.assertEqual(dict(), {})
-        self.assertIsNot(dict(), {})
+        self.assertEqual({}, {})
+        self.assertIsNot({}, {})
 
     def test_literal_constructor(self):
         # check literal constructor for different sized dicts
@@ -141,7 +141,7 @@ class DictTest(__TestCase):
         self.assertIn('a', d)
         self.assertIn('b', d)
         self.assertRaises(TypeError, d.keys, None)
-        self.assertEqual(repr(dict(a=1).keys()), "dict_keys(['a'])")
+        self.assertEqual(repr({'a': 1, }.keys()), "dict_keys(['a'])")
 
     def test_values(self):
         d = {}
@@ -149,7 +149,7 @@ class DictTest(__TestCase):
         d = {1:2}
         self.assertEqual(set(d.values()), {2})
         self.assertRaises(TypeError, d.values, None)
-        self.assertEqual(repr(dict(a=1).values()), "dict_values([1])")
+        self.assertEqual(repr({'a': 1, }.values()), "dict_values([1])")
 
     def test_items(self):
         d = {}
@@ -158,7 +158,7 @@ class DictTest(__TestCase):
         d = {1:2}
         self.assertEqual(set(d.items()), {(1, 2)})
         self.assertRaises(TypeError, d.items, None)
-        self.assertEqual(repr(dict(a=1).items()), "dict_items([('a', 1)])")
+        self.assertEqual(repr({'a': 1, }.items()), "dict_items([('a', 1)])")
 
     def test_views_mapping(self):
         mappingproxy = type(type.__dict__)
@@ -697,8 +697,8 @@ class DictTest(__TestCase):
     def helper_keys_contained(self, fn):
         # Test rich comparisons against dict key views, which should behave the
         # same as sets.
-        empty = fn(dict())
-        empty2 = fn(dict())
+        empty = fn({})
+        empty2 = fn({})
         smaller = fn({1:1, 2:2})
         larger = fn({1:1, 2:2, 3:3})
         larger2 = fn({1:1, 2:2, 3:3})
@@ -997,7 +997,7 @@ class DictTest(__TestCase):
             pass
         x, y, z, w, o = 1.5, "a", (1, object()), [], MyObject()
 
-        d = dict()
+        d = {}
         self._not_tracked(d)
         d[1] = "a"
         self._not_tracked(d)
@@ -1015,8 +1015,8 @@ class DictTest(__TestCase):
 
         # dd isn't tracked right now, but it may mutate and therefore d
         # which contains it must be tracked.
-        d = dict()
-        dd = dict()
+        d = {}
+        dd = {}
         d[1] = dd
         self._not_tracked(dd)
         self._tracked(d)
@@ -1025,20 +1025,20 @@ class DictTest(__TestCase):
 
         d = dict.fromkeys([x, y, z])
         self._not_tracked(d)
-        dd = dict()
+        dd = {}
         dd.update(d)
         self._not_tracked(dd)
         d = dict.fromkeys([x, y, z, o])
         self._tracked(d)
-        dd = dict()
+        dd = {}
         dd.update(d)
         self._tracked(dd)
 
-        d = dict(x=x, y=y, z=z)
+        d = {'x': x, 'y': y, 'z': z, }
         self._not_tracked(d)
-        d = dict(x=x, y=y, z=z, w=w)
+        d = {'x': x, 'y': y, 'z': z, 'w': w, }
         self._tracked(d)
-        d = dict()
+        d = {}
         d.update(x=x, y=y, z=z)
         self._not_tracked(d)
         d.update(w=w)
@@ -1048,7 +1048,7 @@ class DictTest(__TestCase):
         self._not_tracked(d)
         d = dict([(x, y), (z, w)])
         self._tracked(d)
-        d = dict()
+        d = {}
         d.update([(x, y), (z, 1)])
         self._not_tracked(d)
         d.update([(x, y), (z, w)])
@@ -1482,10 +1482,10 @@ class DictTest(__TestCase):
         self.assertEqual(list(reversed({}.keys())), [])
 
         # dict() and {} don't trigger the same code path
-        self.assertEqual(list(reversed(dict())), [])
-        self.assertEqual(list(reversed(dict().items())), [])
-        self.assertEqual(list(reversed(dict().values())), [])
-        self.assertEqual(list(reversed(dict().keys())), [])
+        self.assertEqual(list(reversed({})), [])
+        self.assertEqual(list(reversed({}.items())), [])
+        self.assertEqual(list(reversed({}.values())), [])
+        self.assertEqual(list(reversed({}.keys())), [])
 
     def test_reverse_iterator_for_shared_shared_dicts(self):
         class A:

--- a/test/dynamo/cpython/3_13/test_exceptions.py
+++ b/test/dynamo/cpython/3_13/test_exceptions.py
@@ -573,8 +573,8 @@ class ExceptionTests(__TestCase):
                 {'args': ('foo',), 'x': 'foo'}),
             (SlottedNaiveException, ('foo',), {},
                 {'args': ('foo',), 'x': 'foo'}),
-            (AttributeError, ('foo',), dict(name='name', obj='obj'),
-                dict(args=('foo',), name='name', obj='obj')),
+            (AttributeError, ('foo',), {'name': 'name', 'obj': 'obj', },
+                {'args': ('foo',), 'name': 'name', 'obj': 'obj', }),
         ]
         try:
             # More tests are in test_WindowsError
@@ -2048,10 +2048,10 @@ class ImportErrorTests(__TestCase):
             self.assertEqual(str(arg), str(exc))
 
     def test_copy_pickle(self):
-        for kwargs in (dict(),
-                       dict(name='somename'),
-                       dict(path='somepath'),
-                       dict(name='somename', path='somepath')):
+        for kwargs in ({},
+                       {'name': 'somename', },
+                       {'path': 'somepath', },
+                       {'name': 'somename', 'path': 'somepath', }):
             orig = ImportError('test', **kwargs)
             for proto in range(pickle.HIGHEST_PROTOCOL + 1):
                 exc = pickle.loads(pickle.dumps(orig, proto))

--- a/test/dynamo/cpython/3_13/test_ordered_dict.py
+++ b/test/dynamo/cpython/3_13/test_ordered_dict.py
@@ -523,7 +523,7 @@ class OrderedDictTests:
     def test_sizeof(self):
         OrderedDict = self.OrderedDict
         # Wimpy test: Just verify the reported size is larger than a regular dict
-        d = dict(a=1)
+        d = {'a': 1, }
         od = OrderedDict(**d)
         self.assertGreater(sys.getsizeof(od), sys.getsizeof(d))
 

--- a/test/dynamo/test_dicts.py
+++ b/test/dynamo/test_dicts.py
@@ -66,7 +66,7 @@ class DictTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(fn(x), opt_fn(x))
 
     def test_dict_contains(self):
-        sd = dict()
+        sd = {}
         sd[2] = 5
         sd[4] = 10
 

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -895,7 +895,10 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
 
     @make_test
     def test_dict_kwargs(x):
-        z = dict(text_embed=x + 1, other=x + 2)
+        z = {
+            "text_embed": x + 1,
+            "other": x + 2,
+        }
         return z
 
     @make_test
@@ -1477,11 +1480,11 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         self._test_default_dict_helper(set)
 
     def test_default_dict_lambda(self):
-        self._test_default_dict_helper(lambda: dict())  # noqa: C408
+        self._test_default_dict_helper(dict)  # noqa: C408
 
     def test_default_dict_closure(self):
         def factory():
-            return dict()  # noqa: C408
+            return {}  # noqa: C408
 
         self._test_default_dict_helper(factory)
 
@@ -1508,7 +1511,7 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         param = torch.nn.Parameter(torch.ones([2, 2]))
 
         def fn(x):
-            dd = collections.defaultdict(lambda: dict())  # noqa: C408
+            dd = collections.defaultdict(dict)  # noqa: C408
             dd["a"] = x + 1
             dd[param] = 123
             dd["c"] = x * 2
@@ -1547,7 +1550,7 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
 
     @make_test
     def test_call_dict1(x):
-        d1 = dict()  # noqa: C408
+        d1 = {}  # noqa: C408
         d1["x"] = x + 1
         d2 = collections.OrderedDict()
         d2["x"] = x + 2
@@ -1555,7 +1558,7 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
 
     @make_test
     def test_call_dict2(x):
-        d1 = dict()  # noqa: C408
+        d1 = {}  # noqa: C408
         d1["x"] = x
         d2 = collections.OrderedDict(d1)
         if isinstance(d2, collections.OrderedDict):
@@ -1926,7 +1929,9 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
 
         opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
 
-        x = dict(a=torch.randn(3))
+        x = {
+            "a": torch.randn(3),
+        }
         self.assertEqual(fn(x), opt_fn(x))
 
         x = torch.randn(4)

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -7648,7 +7648,7 @@ utils_device.CURRENT_DEVICE == None""".split("\n"):
         od = collections.OrderedDict
 
         def fn():
-            d1 = dict()  # noqa: C408
+            d1 = {}  # noqa: C408
             d1["a"] = 1
             d2 = od(d1)
             d2["b"] = 2

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -3439,8 +3439,12 @@ class ReproTests(torch._dynamo.test_case.TestCase):
 
         @torch.compile(backend="eager", fullgraph=True)
         def fn(x):
-            d1 = dict(other1=5)
-            d2 = dict(other2=4)
+            d1 = {
+                "other1": 5,
+            }
+            d2 = {
+                "other2": 4,
+            }
             text_cond = {**d1, **d2}
             return forward_with_cond_scale(x, 1, cond_scale=2, self_cond=3, **text_cond)
 

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -5397,7 +5397,14 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
         bbox_pred = torch.tensor([[0.2, 0.3], [0.4, 0.7], [0.1, 0.1], [0.5, 0.1]])
         score_thr = 0.15
         nms_pre = torch.tensor(4)
-        inputs = (score, score_thr, nms_pre, dict(bbox_pred=bbox_pred))
+        inputs = (
+            score,
+            score_thr,
+            nms_pre,
+            {
+                "bbox_pred": bbox_pred,
+            },
+        )
 
         ep = export(M(), inputs)
         orig_res = M()(*inputs)

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -711,7 +711,7 @@ class TestDeserialize(TestCase):
         def _deepcopy_inputs(inputs):
             # copy.deepcopy(deepcopy) can fail if tensor inputs have attribute (i.e. __dict__).
             # we remove __dict__ when deepcopying.
-            dict_mapping = dict()
+            dict_mapping = {}
             inputs_clone = ()
             for idx, i in enumerate(inputs):
                 if isinstance(i, torch.Tensor) and hasattr(inputs[0], "__dict__"):

--- a/test/functorch/functorch_additional_op_db.py
+++ b/test/functorch/functorch_additional_op_db.py
@@ -439,7 +439,9 @@ def sample_inputs_index_put(op_info, device, dtype, requires_grad, **kwargs):
             SampleInput(
                 make_arg((S, S)),
                 args=((make_idx((2,), low=0, high=4),), make_arg((2, S))),
-                kwargs=dict(accumulate=accumulate),
+                kwargs={
+                    "accumulate": accumulate,
+                },
             )
         )
 
@@ -448,7 +450,9 @@ def sample_inputs_index_put(op_info, device, dtype, requires_grad, **kwargs):
             SampleInput(
                 make_arg((S, S, 2)),
                 args=((make_idx((3,), low=0, high=4),), make_arg((3, S, 2))),
-                kwargs=dict(accumulate=accumulate),
+                kwargs={
+                    "accumulate": accumulate,
+                },
             )
         )
 
@@ -457,7 +461,9 @@ def sample_inputs_index_put(op_info, device, dtype, requires_grad, **kwargs):
             SampleInput(
                 make_arg((S, 0)),
                 args=((make_idx((3,), low=0, high=4),), make_arg((3, 0))),
-                kwargs=dict(accumulate=accumulate),
+                kwargs={
+                    "accumulate": accumulate,
+                },
             )
         )
 
@@ -466,7 +472,9 @@ def sample_inputs_index_put(op_info, device, dtype, requires_grad, **kwargs):
             SampleInput(
                 make_arg((S,)),
                 args=((make_idx((), low=0, high=S),), make_arg(())),
-                kwargs=dict(accumulate=accumulate),
+                kwargs={
+                    "accumulate": accumulate,
+                },
             )
         )
 
@@ -478,7 +486,9 @@ def sample_inputs_index_put(op_info, device, dtype, requires_grad, **kwargs):
                 SampleInput(
                     make_arg((S, S)),
                     args=((make_idx((2,), low=0, high=S),), make_arg((S,))),
-                    kwargs=dict(accumulate=accumulate),
+                    kwargs={
+                        "accumulate": accumulate,
+                    },
                 )
             )
 
@@ -565,7 +575,9 @@ def sample_inputs_new_zeros_with_same_feature_meta(
             SampleInput(
                 tangent,
                 args=(base,),
-                kwargs=dict(self_num_batch_dims=num_tangent_bdims),
+                kwargs={
+                    "self_num_batch_dims": num_tangent_bdims,
+                },
             )
         )
     return results

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -3276,7 +3276,12 @@ class TestVmapOperators(Namespace.TestVmapBase):
                 4, 8, kernel_size=3, groups=2, stride=3, padding=1, dilation=2
             )
             arg_values = [torch.randn(inp_shape), mod2.weight, mod2.bias]
-            kwarg_values = dict(groups=2, stride=3, padding=1, dilation=2)
+            kwarg_values = {
+                "groups": 2,
+                "stride": 3,
+                "padding": 1,
+                "dilation": 2,
+            }
             for loop_out, batched_out in get_fallback_and_vmap_exhaustive(
                 conv_fn, arg_values, kwarg_values
             ):

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -4752,7 +4752,11 @@ class AOTInductorTestsTemplate:
             torch.randint(0, 128, (16, 10), device=self.device),
         )
         self.check_model(
-            Model(), example_inputs, options=dict(max_autotune=max_autotune)
+            Model(),
+            example_inputs,
+            options={
+                "max_autotune": max_autotune,
+            },
         )
 
     @skip_if_no_torchvision

--- a/test/inductor/test_cpu_select_algorithm.py
+++ b/test/inductor/test_cpu_select_algorithm.py
@@ -72,7 +72,14 @@ def patches(fn):
             epilogue_fusion=True,
             max_autotune_gemm_backends="CPP,ATEN",
         ),
-        patch.object(select_algorithm, "VERIFY", dict(atol=1e-4, rtol=1e-4)),
+        patch.object(
+            select_algorithm,
+            "VERIFY",
+            {
+                "atol": 1e-4,
+                "rtol": 1e-4,
+            },
+        ),
         patch.object(select_algorithm.AlgorithmSelectorCache, "lookup", skip_cache),
     ]:
         fn = patcher(fn)
@@ -94,7 +101,14 @@ def verify(dtype):
     atol, rtol = 1e-4, 1e-4
     if dtype == torch.half or dtype == torch.bfloat16:
         atol, rtol = 1e-2, 1e-2
-    with patch.object(select_algorithm, "VERIFY", dict(atol=atol, rtol=rtol)):
+    with patch.object(
+        select_algorithm,
+        "VERIFY",
+        {
+            "atol": atol,
+            "rtol": rtol,
+        },
+    ):
         yield atol, rtol
 
 
@@ -1355,7 +1369,14 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
             atol, rtol = 5e-2, 5e-2
 
         with (
-            patch.object(select_algorithm, "VERIFY", dict(atol=atol, rtol=rtol)),
+            patch.object(
+                select_algorithm,
+                "VERIFY",
+                {
+                    "atol": atol,
+                    "rtol": rtol,
+                },
+            ),
             torch.no_grad(),
             torch.autocast("cpu", enabled=(dtype == torch.bfloat16), dtype=dtype),
         ):
@@ -1990,7 +2011,14 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
         )
         atol, rtol = 5e-2, 5e-2
         with (
-            patch.object(select_algorithm, "VERIFY", dict(atol=atol, rtol=rtol)),
+            patch.object(
+                select_algorithm,
+                "VERIFY",
+                {
+                    "atol": atol,
+                    "rtol": rtol,
+                },
+            ),
             torch.no_grad(),
             torch.autocast("cpu", enabled=int8_mixed_bf16, dtype=torch.bfloat16),
         ):
@@ -2038,7 +2066,14 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
             (v,),
         )
         atol, rtol = 1e-2, 1e-2
-        with patch.object(select_algorithm, "VERIFY", dict(atol=atol, rtol=rtol)):
+        with patch.object(
+            select_algorithm,
+            "VERIFY",
+            {
+                "atol": atol,
+                "rtol": rtol,
+            },
+        ):
             self.common(ref_quantized_mod, (v,), atol=atol, rtol=rtol)
         self.assertEqual(counters["inductor"]["cpp_templated_kernel_counter"], 1)
         vec_amx = VecAMX()

--- a/test/inductor/test_cutlass_evt.py
+++ b/test/inductor/test_cutlass_evt.py
@@ -111,9 +111,9 @@ class MockGraphHandler(GraphLowering):
 
         self.sizevars = torch._inductor.sizevars.SizeVarAllocator()
         self.name_to_buffer = name_to_buffer
-        self.graph_inputs = dict()
+        self.graph_inputs = {}
         self.mutated_buffers = OrderedSet()
-        self.constants = dict()
+        self.constants = {}
 
 
 class TestCutlassEVT(TestCase):

--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -28,7 +28,14 @@ def patches(fn):
     for patcher in [
         dynamo_config.patch(verbose=True),
         inductor_config.patch(debug=True, max_autotune=True, epilogue_fusion=True),
-        patch.object(select_algorithm, "VERIFY", dict(atol=1e-4, rtol=1e-4)),
+        patch.object(
+            select_algorithm,
+            "VERIFY",
+            {
+                "atol": 1e-4,
+                "rtol": 1e-4,
+            },
+        ),
         patch.object(select_algorithm.AlgorithmSelectorCache, "lookup", skip_cache),
         torch.backends.cudnn.flags(allow_tf32=False),
     ]:
@@ -116,7 +123,14 @@ class TestSelectAlgorithm(TestCase):
         # The preprocessing function should have been called
         self.assertTrue(func_called[0])
 
-    @patch.object(select_algorithm, "VERIFY", dict(atol=5e-2, rtol=5e-2))
+    @patch.object(
+        select_algorithm,
+        "VERIFY",
+        {
+            "atol": 5e-2,
+            "rtol": 5e-2,
+        },
+    )
     @patches
     def test_addmm_fp16(self):
         @torch.compile
@@ -316,7 +330,12 @@ class TestSelectAlgorithm(TestCase):
 
         if GPU_TYPE == "xpu":
             patcher = patch.object(
-                select_algorithm, "VERIFY", dict(atol=1e-3, rtol=1e-3)
+                select_algorithm,
+                "VERIFY",
+                {
+                    "atol": 1e-3,
+                    "rtol": 1e-3,
+                },
             )
             fn = patcher(fn)
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -14861,14 +14861,14 @@ if RUN_GPU:
                     self.config = config
 
                     self.transformer = nn.ModuleDict(
-                        dict(
-                            wte=nn.Embedding(config.vocab_size, config.n_embd),
-                            wpe=nn.Embedding(config.block_size, config.n_embd),
-                            h=nn.ModuleList(
+                        {
+                            "wte": nn.Embedding(config.vocab_size, config.n_embd),
+                            "wpe": nn.Embedding(config.block_size, config.n_embd),
+                            "h": nn.ModuleList(
                                 [Block(config) for _ in range(config.n_layer)]
                             ),
-                            ln_f=nn.LayerNorm(config.n_embd),
-                        )
+                            "ln_f": nn.LayerNorm(config.n_embd),
+                        }
                     )
                     self.lm_head = nn.Linear(
                         config.n_embd, config.vocab_size, bias=False

--- a/test/jit/test_list_dict.py
+++ b/test/jit/test_list_dict.py
@@ -268,19 +268,19 @@ class TestList(JitTestCase):
 
     def test_dict_keyword_with_kwargs(self):
         def fn():
-            return dict(foo=1, bar=2, baz=3)
+            return dict(foo=1, bar=2, baz=3)  # noqa: C408
 
         self.checkScript(fn, ())
 
     def test_dict_keyword_with_kwargs_using_container_values(self):
         def fn():
-            return dict(foo=[1, 2, 3], bar=[4, 5, 6], baz=[7, 8, 9])
+            return dict(foo=[1, 2, 3], bar=[4, 5, 6], baz=[7, 8, 9])  # noqa: C408
 
         self.checkScript(fn, ())
 
     def test_dict_keyword_with_iterable(self):
         def fn():
-            return dict([("foo", 1), ("bar", 2), ("baz", 3)])  # noqa: C406
+            return dict([("foo", 1), ("bar", 2), ("baz", 3)])  # noqa: C406, C408
 
         self.checkScript(fn, ())
 
@@ -343,14 +343,14 @@ class TestList(JitTestCase):
 
             @torch.jit.script
             def fn():
-                x: Dict[int, str] = dict(  # noqa: C406
+                x: Dict[int, str] = dict(  # noqa: C406, C408
                     [("foo", 1), ("bar", 2), ("baz", 3)]
                 )
                 return x
 
     def test_dict_keyword_with_nested_call(self):
         def fn():
-            return dict(dict(foo=1, bar=2, baz=3))
+            return dict(dict(foo=1, bar=2, baz=3))  # noqa: C408
 
         self.checkScript(fn, ())
 

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -1289,15 +1289,15 @@ class TestEmbeddingNNDeviceType(NNTestCase):
     @dtypes(*itertools.product((torch.int, torch.long), (torch.float, torch.double)))
     def test_EmbeddingBag_per_sample_weights_and_no_offsets(self, device, dtypes):
         def run_tests(mode, sparse, trainable_per_sample_weights):
-            kwargs = dict(
-                test_per_sample_weights=True,
-                device=device,
-                mode=mode,
-                wdtype=dtypes[1],
-                dtype=dtypes[0],
-                sparse=sparse,
-                trainable_per_sample_weights=trainable_per_sample_weights,
-            )
+            kwargs = {
+                "test_per_sample_weights": True,
+                "device": device,
+                "mode": mode,
+                "wdtype": dtypes[1],
+                "dtype": dtypes[0],
+                "sparse": sparse,
+                "trainable_per_sample_weights": trainable_per_sample_weights,
+            }
 
             # Simple case
             self._test_EmbeddingBag_vs_Embedding(2, 3, 5, 7, **kwargs)
@@ -1436,14 +1436,14 @@ class TestEmbeddingNNDeviceType(NNTestCase):
             random.randint(1, 50),
             random.randint(1, 50),
         )
-        kwargs = dict(
-            mode=mode,
-            sparse=sparse,
-            device=device,
-            wdtype=wdtype,
-            dtype=dtype,
-            test_backward=test_backward,
-        )
+        kwargs = {
+            "mode": mode,
+            "sparse": sparse,
+            "device": device,
+            "wdtype": wdtype,
+            "dtype": dtype,
+            "test_backward": test_backward,
+        }
         self._test_EmbeddingBag_vs_Embedding(N, D, B, L, **kwargs)
         for max_norm in (None, 3):
             for p in itertools.product([1, 2], repeat=4):

--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -751,7 +751,12 @@ class DynamoExporterNewOpsetsTest(common_utils.TestCase, _WithExport):
 
         ref = onnx_ref.ReferenceEvaluator(onnx_program.model_proto)
         got = ref.run(
-            None, dict(query=query.numpy(), key=key.numpy(), value=value.numpy())
+            None,
+            {
+                "query": query.numpy(),
+                "key": key.numpy(),
+                "value": value.numpy(),
+            },
         )[0]
         torch.testing.assert_close(torch.from_numpy(got), expected, atol=1e-2, rtol=1)
 

--- a/test/onnx/ops/test_ops.py
+++ b/test/onnx/ops/test_ops.py
@@ -16,76 +16,76 @@ class SchemaTest(common_utils.TestCase):
         torch.library.opcheck(
             _symbolic_impl._symbolic,
             ([torch.tensor(1)], "CustomOp", 1),
-            dict(
-                shape=[
+            {
+                "shape": [
                     1,
                 ],
-                attr_keys=["key"],
-                attr_types=["i"],
-                attr_pos=[(0, 1)],
-                attr_ints=[1],
-                attr_floats=[1.0],
-                attr_strs=["attr"],
-                metadata_props_keys=["meta_key"],
-                metadata_props_values=["meta_value"],
-                domain="custom_domain",
-                version=42,
-            ),
+                "attr_keys": ["key"],
+                "attr_types": ["i"],
+                "attr_pos": [(0, 1)],
+                "attr_ints": [1],
+                "attr_floats": [1.0],
+                "attr_strs": ["attr"],
+                "metadata_props_keys": ["meta_key"],
+                "metadata_props_values": ["meta_value"],
+                "domain": "custom_domain",
+                "version": 42,
+            },
         )
 
         # Empty inputs
         torch.library.opcheck(
             _symbolic_impl._symbolic,
             ([], "CustomOp", 1),
-            dict(
-                shape=[
+            {
+                "shape": [
                     1,
                 ],
-                attr_keys=[],
-                attr_types=[],
-                attr_pos=[],
-                attr_ints=[],
-                attr_floats=[],
-                attr_strs=[],
-                metadata_props_keys=[],
-                metadata_props_values=[],
-            ),
+                "attr_keys": [],
+                "attr_types": [],
+                "attr_pos": [],
+                "attr_ints": [],
+                "attr_floats": [],
+                "attr_strs": [],
+                "metadata_props_keys": [],
+                "metadata_props_values": [],
+            },
         )
 
     def test_symbolic_multi_out_has_correct_schema(self):
         torch.library.opcheck(
             _symbolic_impl._symbolic_multi_out,
             ([torch.tensor(1)], "CustomMultiOutOp", [1, 2, 10]),
-            dict(
-                shapes=[[1, 2], [42], []],
-                attr_keys=["key"],
-                attr_types=["i"],
-                attr_pos=[(0, 1)],
-                attr_ints=[1],
-                attr_floats=[1.0],
-                attr_strs=["attr"],
-                metadata_props_keys=["meta_key"],
-                metadata_props_values=["meta_value"],
-                domain="",
-                version=1,
-            ),
+            {
+                "shapes": [[1, 2], [42], []],
+                "attr_keys": ["key"],
+                "attr_types": ["i"],
+                "attr_pos": [(0, 1)],
+                "attr_ints": [1],
+                "attr_floats": [1.0],
+                "attr_strs": ["attr"],
+                "metadata_props_keys": ["meta_key"],
+                "metadata_props_values": ["meta_value"],
+                "domain": "",
+                "version": 1,
+            },
         )
 
         # Empty inputs
         torch.library.opcheck(
             _symbolic_impl._symbolic_multi_out,
             ([], "CustomMultiOutOp", []),
-            dict(
-                shapes=[],
-                attr_keys=[],
-                attr_types=[],
-                attr_pos=[],
-                attr_ints=[],
-                attr_floats=[],
-                attr_strs=[],
-                metadata_props_keys=[],
-                metadata_props_values=[],
-            ),
+            {
+                "shapes": [],
+                "attr_keys": [],
+                "attr_types": [],
+                "attr_pos": [],
+                "attr_ints": [],
+                "attr_floats": [],
+                "attr_strs": [],
+                "metadata_props_keys": [],
+                "metadata_props_values": [],
+            },
         )
 
 
@@ -94,16 +94,16 @@ class SymbolicOpsTest(common_utils.TestCase):
         output = torch.onnx.ops.symbolic(
             "custom_domain::CustomOp",
             (torch.tensor(1),),
-            dict(
-                int_key=1,
-                float_key=1.0,
-                str_key="attr",
-                bool_key=True,
-                list_int_key=[1, 2],
-                list_float_key=[1.0, 2.0],
-                list_str_key=["attr1", "attr2"],
-                list_bool_key=[True, False],
-            ),
+            {
+                "int_key": 1,
+                "float_key": 1.0,
+                "str_key": "attr",
+                "bool_key": True,
+                "list_int_key": [1, 2],
+                "list_float_key": [1.0, 2.0],
+                "list_str_key": ["attr1", "attr2"],
+                "list_bool_key": [True, False],
+            },
             dtype=torch.float32,
             shape=[1, 2, 3],
             version=1,
@@ -147,16 +147,16 @@ class SymbolicOpsTest(common_utils.TestCase):
                 return torch.onnx.ops.symbolic(
                     "custom_domain::CustomOp",
                     (x, None),
-                    dict(
-                        int_key=1,
-                        float_key=1.0,
-                        str_key="attr",
-                        bool_key=True,
-                        list_int_key=[1, 2],
-                        list_float_key=[1.0, 2.0],
-                        list_str_key=["attr1", "attr2"],
-                        list_bool_key=[True, False],
-                    ),
+                    {
+                        "int_key": 1,
+                        "float_key": 1.0,
+                        "str_key": "attr",
+                        "bool_key": True,
+                        "list_int_key": [1, 2],
+                        "list_float_key": [1.0, 2.0],
+                        "list_str_key": ["attr1", "attr2"],
+                        "list_bool_key": [True, False],
+                    },
                     dtype=x.dtype,
                     shape=[1, 2, 3],
                     version=1,
@@ -173,16 +173,16 @@ class SymbolicOpsTest(common_utils.TestCase):
         attributes = node.attributes
         self.assertEqual(
             attributes,
-            dict(
-                int_key=ir.AttrInt64("int_key", 1),
-                float_key=ir.AttrFloat32("float_key", 1.0),
-                str_key=ir.AttrString("str_key", "attr"),
-                bool_key=ir.AttrInt64("bool_key", 1),
-                list_int_key=ir.AttrInt64s("list_int_key", [1, 2]),
-                list_float_key=ir.AttrFloat32s("list_float_key", [1.0, 2.0]),
-                list_str_key=ir.AttrStrings("list_str_key", ["attr1", "attr2"]),
-                list_bool_key=ir.AttrInt64s("list_bool_key", [1, 0]),
-            ),
+            {
+                "int_key": ir.AttrInt64("int_key", 1),
+                "float_key": ir.AttrFloat32("float_key", 1.0),
+                "str_key": ir.AttrString("str_key", "attr"),
+                "bool_key": ir.AttrInt64("bool_key", 1),
+                "list_int_key": ir.AttrInt64s("list_int_key", [1, 2]),
+                "list_float_key": ir.AttrFloat32s("list_float_key", [1.0, 2.0]),
+                "list_str_key": ir.AttrStrings("list_str_key", ["attr1", "attr2"]),
+                "list_bool_key": ir.AttrInt64s("list_bool_key", [1, 0]),
+            },
         )
         self.assertEqual(node.metadata_props["meta_key"], "meta_value")
         outputs = node.outputs
@@ -227,16 +227,16 @@ class SymbolicOpsTest(common_utils.TestCase):
         outputs = torch.onnx.ops.symbolic_multi_out(
             "custom_domain::CustomMultiOutOp",
             (torch.tensor(1),),
-            dict(
-                int_key=1,
-                float_key=1.0,
-                str_key="attr",
-                bool_key=True,
-                list_int_key=[1, 2],
-                list_float_key=[1.0, 2.0],
-                list_str_key=["attr1", "attr2"],
-                list_bool_key=[True, False],
-            ),
+            {
+                "int_key": 1,
+                "float_key": 1.0,
+                "str_key": "attr",
+                "bool_key": True,
+                "list_int_key": [1, 2],
+                "list_float_key": [1.0, 2.0],
+                "list_str_key": ["attr1", "attr2"],
+                "list_bool_key": [True, False],
+            },
             dtypes=(
                 1,  # 1 is float32 in ONNX
                 torch.int32,
@@ -291,16 +291,16 @@ class SymbolicOpsTest(common_utils.TestCase):
                 return torch.onnx.ops.symbolic_multi_out(
                     "custom_domain::CustomOp",
                     (x, None),
-                    dict(
-                        int_key=1,
-                        float_key=1.0,
-                        str_key="attr",
-                        bool_key=True,
-                        list_int_key=[1, 2],
-                        list_float_key=[1.0, 2.0],
-                        list_str_key=["attr1", "attr2"],
-                        list_bool_key=[True, False],
-                    ),
+                    {
+                        "int_key": 1,
+                        "float_key": 1.0,
+                        "str_key": "attr",
+                        "bool_key": True,
+                        "list_int_key": [1, 2],
+                        "list_float_key": [1.0, 2.0],
+                        "list_str_key": ["attr1", "attr2"],
+                        "list_bool_key": [True, False],
+                    },
                     dtypes=(torch.float32, torch.int32, torch.float8_e4m3fn),
                     shapes=([1, 2], [42], []),
                     version=1,
@@ -317,16 +317,16 @@ class SymbolicOpsTest(common_utils.TestCase):
         attributes = node.attributes
         self.assertEqual(
             attributes,
-            dict(
-                int_key=ir.AttrInt64("int_key", 1),
-                float_key=ir.AttrFloat32("float_key", 1.0),
-                str_key=ir.AttrString("str_key", "attr"),
-                bool_key=ir.AttrInt64("bool_key", 1),
-                list_int_key=ir.AttrInt64s("list_int_key", [1, 2]),
-                list_float_key=ir.AttrFloat32s("list_float_key", [1.0, 2.0]),
-                list_str_key=ir.AttrStrings("list_str_key", ["attr1", "attr2"]),
-                list_bool_key=ir.AttrInt64s("list_bool_key", [1, 0]),
-            ),
+            {
+                "int_key": ir.AttrInt64("int_key", 1),
+                "float_key": ir.AttrFloat32("float_key", 1.0),
+                "str_key": ir.AttrString("str_key", "attr"),
+                "bool_key": ir.AttrInt64("bool_key", 1),
+                "list_int_key": ir.AttrInt64s("list_int_key", [1, 2]),
+                "list_float_key": ir.AttrFloat32s("list_float_key", [1.0, 2.0]),
+                "list_str_key": ir.AttrStrings("list_str_key", ["attr1", "attr2"]),
+                "list_bool_key": ir.AttrInt64s("list_bool_key", [1, 0]),
+            },
         )
         self.assertEqual(node.metadata_props["meta_key"], "meta_value")
         outputs = node.outputs
@@ -378,16 +378,16 @@ class SymbolicOpsTest(common_utils.TestCase):
             torch.onnx.ops.symbolic_multi_out(
                 "custom_domain::CustomMultiOutOp",
                 (torch.tensor(1),),
-                dict(
-                    int_key=1,
-                    float_key=1.0,
-                    str_key="attr",
-                    bool_key=True,
-                    list_int_key=[1, 2],
-                    list_float_key=[1.0, 2.0],
-                    list_str_key=["attr1", "attr2"],
-                    list_bool_key=[True, False],
-                ),
+                {
+                    "int_key": 1,
+                    "float_key": 1.0,
+                    "str_key": "attr",
+                    "bool_key": True,
+                    "list_int_key": [1, 2],
+                    "list_float_key": [1.0, 2.0],
+                    "list_str_key": ["attr1", "attr2"],
+                    "list_bool_key": [True, False],
+                },
                 dtypes=(torch.float32, torch.int32),
                 shapes=([1, 2], [42], []),
                 version=1,
@@ -398,16 +398,16 @@ class SymbolicOpsTest(common_utils.TestCase):
             torch.onnx.ops.symbolic_multi_out(
                 "custom_domain::CustomMultiOutOp",
                 (torch.tensor(1),),
-                dict(
-                    int_key=1,
-                    float_key=1.0,
-                    str_key="attr",
-                    bool_key=True,
-                    list_int_key=[1, 2],
-                    list_float_key=[1.0, 2.0],
-                    list_str_key=["attr1", "attr2"],
-                    list_bool_key=[True, False],
-                ),
+                {
+                    "int_key": 1,
+                    "float_key": 1.0,
+                    "str_key": "attr",
+                    "bool_key": True,
+                    "list_int_key": [1, 2],
+                    "list_float_key": [1.0, 2.0],
+                    "list_str_key": ["attr1", "attr2"],
+                    "list_bool_key": [True, False],
+                },
                 dtypes=(torch.float32,),
                 shapes=([1, 2], [42]),
                 version=1,
@@ -562,7 +562,10 @@ class NativeOnnxOpsTest(common_utils.TestCase):
         torch.library.opcheck(
             _impl.attention_23,
             (Q, K, V),
-            dict(q_num_heads=q_num_heads, kv_num_heads=kv_num_heads),
+            {
+                "q_num_heads": q_num_heads,
+                "kv_num_heads": kv_num_heads,
+            },
         )
         output, present_key, present_value, qk_output = torch.onnx.ops.attention(
             Q, K, V, q_num_heads=q_num_heads, kv_num_heads=kv_num_heads
@@ -633,12 +636,24 @@ class NativeOnnxOpsTest(common_utils.TestCase):
 
         # Test with boolean mask
         bool_mask = torch.randint(0, 2, (q_seq_len, kv_seq_len), dtype=torch.bool)
-        torch.library.opcheck(_impl.attention_23, (Q, K, V), dict(attn_mask=bool_mask))
+        torch.library.opcheck(
+            _impl.attention_23,
+            (Q, K, V),
+            {
+                "attn_mask": bool_mask,
+            },
+        )
         output_bool, _, _, _ = torch.onnx.ops.attention(Q, K, V, attn_mask=bool_mask)
 
         # Test with float mask
         float_mask = torch.randn(q_seq_len, kv_seq_len)
-        torch.library.opcheck(_impl.attention_23, (Q, K, V), dict(attn_mask=float_mask))
+        torch.library.opcheck(
+            _impl.attention_23,
+            (Q, K, V),
+            {
+                "attn_mask": float_mask,
+            },
+        )
         output_float, _, _, _ = torch.onnx.ops.attention(Q, K, V, attn_mask=float_mask)
 
         self.assertEqual(
@@ -662,12 +677,24 @@ class NativeOnnxOpsTest(common_utils.TestCase):
         bool_mask = torch.randint(
             0, 2, (batch_size, q_num_heads, q_seq_len, kv_seq_len), dtype=torch.bool
         )
-        torch.library.opcheck(_impl.attention_23, (Q, K, V), dict(attn_mask=bool_mask))
+        torch.library.opcheck(
+            _impl.attention_23,
+            (Q, K, V),
+            {
+                "attn_mask": bool_mask,
+            },
+        )
         output_bool, _, _, _ = torch.onnx.ops.attention(Q, K, V, attn_mask=bool_mask)
 
         # Test with float mask
         float_mask = torch.randn(batch_size, q_num_heads, q_seq_len, kv_seq_len)
-        torch.library.opcheck(_impl.attention_23, (Q, K, V), dict(attn_mask=float_mask))
+        torch.library.opcheck(
+            _impl.attention_23,
+            (Q, K, V),
+            {
+                "attn_mask": float_mask,
+            },
+        )
         output_float, _, _, _ = torch.onnx.ops.attention(Q, K, V, attn_mask=float_mask)
 
         self.assertEqual(
@@ -688,7 +715,13 @@ class NativeOnnxOpsTest(common_utils.TestCase):
         V = torch.rand(batch_size, kv_num_heads, kv_seq_len, head_size)
 
         zero_mask = torch.zeros(q_seq_len, kv_seq_len)
-        torch.library.opcheck(_impl.attention_23, (Q, K, V), dict(attn_mask=zero_mask))
+        torch.library.opcheck(
+            _impl.attention_23,
+            (Q, K, V),
+            {
+                "attn_mask": zero_mask,
+            },
+        )
         output, _, _, _ = torch.onnx.ops.attention(Q, K, V, attn_mask=zero_mask)
 
         self.assertEqual(output.shape, (batch_size, q_num_heads, q_seq_len, head_size))
@@ -706,7 +739,11 @@ class NativeOnnxOpsTest(common_utils.TestCase):
         # Create a lower triangular causal mask
         causal_mask = torch.tril(torch.ones(q_seq_len, kv_seq_len, dtype=torch.bool))
         torch.library.opcheck(
-            _impl.attention_23, (Q, K, V), dict(attn_mask=causal_mask)
+            _impl.attention_23,
+            (Q, K, V),
+            {
+                "attn_mask": causal_mask,
+            },
         )
         output, _, _, _ = torch.onnx.ops.attention(Q, K, V, attn_mask=causal_mask)
 
@@ -724,14 +761,26 @@ class NativeOnnxOpsTest(common_utils.TestCase):
 
         # Test 2D mask with GQA
         mask_2d = torch.randint(0, 2, (q_seq_len, kv_seq_len), dtype=torch.bool)
-        torch.library.opcheck(_impl.attention_23, (Q, K, V), dict(attn_mask=mask_2d))
+        torch.library.opcheck(
+            _impl.attention_23,
+            (Q, K, V),
+            {
+                "attn_mask": mask_2d,
+            },
+        )
         output_2d, _, _, _ = torch.onnx.ops.attention(Q, K, V, attn_mask=mask_2d)
 
         # Test 4D mask with GQA (note: using q_num_heads for mask heads)
         mask_4d = torch.randint(
             0, 2, (batch_size, q_num_heads, q_seq_len, kv_seq_len), dtype=torch.bool
         )
-        torch.library.opcheck(_impl.attention_23, (Q, K, V), dict(attn_mask=mask_4d))
+        torch.library.opcheck(
+            _impl.attention_23,
+            (Q, K, V),
+            {
+                "attn_mask": mask_4d,
+            },
+        )
         output_4d, _, _, _ = torch.onnx.ops.attention(Q, K, V, attn_mask=mask_4d)
 
         self.assertEqual(
@@ -756,7 +805,13 @@ class NativeOnnxOpsTest(common_utils.TestCase):
         # Allow some positions
         float_mask[:, :3] = 0.0
 
-        torch.library.opcheck(_impl.attention_23, (Q, K, V), dict(attn_mask=float_mask))
+        torch.library.opcheck(
+            _impl.attention_23,
+            (Q, K, V),
+            {
+                "attn_mask": float_mask,
+            },
+        )
         output, _, _, _ = torch.onnx.ops.attention(Q, K, V, attn_mask=float_mask)
 
         self.assertEqual(output.shape, (batch_size, q_num_heads, q_seq_len, head_size))
@@ -771,7 +826,13 @@ class NativeOnnxOpsTest(common_utils.TestCase):
         K = torch.rand(batch_size, kv_num_heads, kv_seq_len, head_size)
         V = torch.rand(batch_size, kv_num_heads, kv_seq_len, head_size)
 
-        torch.library.opcheck(_impl.attention_23, (Q, K, V), dict(is_causal=True))
+        torch.library.opcheck(
+            _impl.attention_23,
+            (Q, K, V),
+            {
+                "is_causal": True,
+            },
+        )
         output, _, _, _ = torch.onnx.ops.attention(Q, K, V, is_causal=True)
 
         self.assertEqual(output.shape, (batch_size, q_num_heads, q_seq_len, head_size))
@@ -791,7 +852,10 @@ class NativeOnnxOpsTest(common_utils.TestCase):
         torch.library.opcheck(
             _impl.attention_23,
             (Q, K, V),
-            dict(past_key=past_key, past_value=past_value),
+            {
+                "past_key": past_key,
+                "past_value": past_value,
+            },
         )
         output, present_key, present_value, _ = torch.onnx.ops.attention(
             Q, K, V, past_key=past_key, past_value=past_value
@@ -818,7 +882,13 @@ class NativeOnnxOpsTest(common_utils.TestCase):
         K = torch.rand(batch_size, kv_num_heads, kv_seq_len, head_size)
         V = torch.rand(batch_size, kv_num_heads, kv_seq_len, head_size)
 
-        torch.library.opcheck(_impl.attention_23, (Q, K, V), dict(softcap=30.0))
+        torch.library.opcheck(
+            _impl.attention_23,
+            (Q, K, V),
+            {
+                "softcap": 30.0,
+            },
+        )
         output, _, _, _ = torch.onnx.ops.attention(Q, K, V, softcap=30.0)
 
         self.assertEqual(output.shape, (batch_size, q_num_heads, q_seq_len, head_size))
@@ -837,7 +907,9 @@ class NativeOnnxOpsTest(common_utils.TestCase):
             torch.library.opcheck(
                 _impl.attention_23,
                 (Q, K, V),
-                dict(qk_matmul_output_mode=mode),
+                {
+                    "qk_matmul_output_mode": mode,
+                },
             )
             output, _, _, qk_output = torch.onnx.ops.attention(
                 Q, K, V, qk_matmul_output_mode=mode
@@ -861,7 +933,13 @@ class NativeOnnxOpsTest(common_utils.TestCase):
         V = torch.rand(batch_size, kv_num_heads, kv_seq_len, head_size)
 
         custom_scale = 0.25
-        torch.library.opcheck(_impl.attention_23, (Q, K, V), dict(scale=custom_scale))
+        torch.library.opcheck(
+            _impl.attention_23,
+            (Q, K, V),
+            {
+                "scale": custom_scale,
+            },
+        )
         output, _, _, _ = torch.onnx.ops.attention(Q, K, V, scale=custom_scale)
 
         self.assertEqual(output.shape, (batch_size, q_num_heads, q_seq_len, head_size))

--- a/test/onnx/test_models_onnxruntime.py
+++ b/test/onnx/test_models_onnxruntime.py
@@ -137,8 +137,14 @@ def _init_test_rpn():
     rpn_bg_iou_thresh = 0.3
     rpn_batch_size_per_image = 256
     rpn_positive_fraction = 0.5
-    rpn_pre_nms_top_n = dict(training=2000, testing=1000)
-    rpn_post_nms_top_n = dict(training=2000, testing=1000)
+    rpn_pre_nms_top_n = {
+        "training": 2000,
+        "testing": 1000,
+    }
+    rpn_post_nms_top_n = {
+        "training": 2000,
+        "testing": 1000,
+    }
     rpn_nms_thresh = 0.7
     rpn_score_thresh = 0.0
 

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -71,8 +71,14 @@ def _init_test_rpn():
     rpn_bg_iou_thresh = 0.3
     rpn_batch_size_per_image = 256
     rpn_positive_fraction = 0.5
-    rpn_pre_nms_top_n = dict(training=2000, testing=1000)
-    rpn_post_nms_top_n = dict(training=2000, testing=1000)
+    rpn_pre_nms_top_n = {
+        "training": 2000,
+        "testing": 1000,
+    }
+    rpn_post_nms_top_n = {
+        "training": 2000,
+        "testing": 1000,
+    }
     rpn_nms_thresh = 0.7
     rpn_score_thresh = 0.0
 

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -1020,7 +1020,13 @@ class TestBinaryUfuncs(TestCase):
 
         for mode, np_ref in ((None, np.true_divide), ("floor", np.floor_divide)):
             expect = np_ref(an, bn)
-            kwargs = dict(rounding_mode=mode) if mode is not None else {}
+            kwargs = (
+                {
+                    "rounding_mode": mode,
+                }
+                if mode is not None
+                else {}
+            )
             with set_default_dtype(torch.double):
                 actual = torch.divide(a, b, **kwargs)
             self.assertEqual(
@@ -1098,7 +1104,13 @@ class TestBinaryUfuncs(TestCase):
         ):
             expect = torch.from_numpy(np_ref(an, bn))
 
-            kwargs = dict(rounding_mode=mode) if mode is not None else {}
+            kwargs = (
+                {
+                    "rounding_mode": mode,
+                }
+                if mode is not None
+                else {}
+            )
             # Contiguous (likely vectorized)
             with set_default_dtype(torch.double):
                 actual = torch.divide(a, b, **kwargs)

--- a/test/test_bundled_inputs.py
+++ b/test/test_bundled_inputs.py
@@ -339,18 +339,18 @@ class TestBundledInputs(TestCase):
                 else:
                     return arg1["a"] + arg1["b"] + arg2[0]
 
-        small_sample = dict(
-            a=torch.zeros([10, 20]),
-            b=torch.zeros([1, 1]),
-            c=torch.zeros([10, 20]),
-        )
+        small_sample = {
+            "a": torch.zeros([10, 20]),
+            "b": torch.zeros([1, 1]),
+            "c": torch.zeros([10, 20]),
+        }
         small_list = [torch.zeros([10, 20])]
 
-        big_sample = dict(
-            a=torch.zeros([1 << 5, 1 << 8, 1 << 10]),
-            b=torch.zeros([1 << 5, 1 << 8, 1 << 10]),
-            c=torch.zeros([1 << 5, 1 << 8, 1 << 10]),
-        )
+        big_sample = {
+            "a": torch.zeros([1 << 5, 1 << 8, 1 << 10]),
+            "b": torch.zeros([1 << 5, 1 << 8, 1 << 10]),
+            "c": torch.zeros([1 << 5, 1 << 8, 1 << 10]),
+        }
         big_list = [torch.zeros([1 << 5, 1 << 8, 1 << 10])]
 
         def condensed(t):

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1874,7 +1874,11 @@ except RuntimeError as e:
             torch.arange(9, 11),
         ]
         counting_ds_n = 11
-        dl_common_args = dict(num_workers=3, batch_size=3, pin_memory=(not TEST_CUDA))
+        dl_common_args = {
+            "num_workers": 3,
+            "batch_size": 3,
+            "pin_memory": (not TEST_CUDA),
+        }
         for ctx in supported_multiprocessing_contexts:
             # windows and jetson devices don't support sharing cuda tensor; ROCm does not yet fully support IPC
             if (
@@ -1926,9 +1930,12 @@ except RuntimeError as e:
             else datapipe.filter(filter_len)
         )
 
-        dl_common_args = dict(
-            num_workers=2, batch_size=2, shuffle=True, pin_memory=(not TEST_CUDA)
-        )
+        dl_common_args = {
+            "num_workers": 2,
+            "batch_size": 2,
+            "shuffle": True,
+            "pin_memory": (not TEST_CUDA),
+        }
         for ctx in supported_multiprocessing_contexts:
             self.assertEqual(
                 reference,

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -4965,7 +4965,7 @@ class TestVisionTracing(JitTestCase):
                 if k in ["inception_v3"]
                 else torch.rand(1, 3, 224, 224)
             )
-            kwargs = dict(num_classes=50)
+            kwargs = {'num_classes': 50, }
             model_test = cls.generate_test_fn(k, x, kwargs)
             setattr(cls, test_name, model_test)
 
@@ -4974,7 +4974,7 @@ class TestVisionTracing(JitTestCase):
         for k in torchvision_models.list_models(module=torchvision_models.segmentation):
             test_name = "test_torchvision_models_segmentation_" + k
             x = torch.rand(1, 3, 32, 32)
-            kwargs = dict(num_classes=10, pretrained_backbone=False)
+            kwargs = {'num_classes': 10, 'pretrained_backbone': False, }
             model_test = cls.generate_test_fn(k, x, kwargs)
             setattr(cls, test_name, model_test)
 
@@ -4983,7 +4983,7 @@ class TestVisionTracing(JitTestCase):
         for k in torchvision_models.list_models(module=torchvision_models.detection):
             test_name = "test_torchvision_models_detection_" + k
             x = [torch.rand(3, 300, 300)]
-            kwargs = dict(num_classes=10, pretrained_backbone=False)
+            kwargs = {'num_classes': 10, 'pretrained_backbone': False, }
             model_test = cls.generate_test_fn(k, x, kwargs)
             setattr(cls, test_name, model_test)
 
@@ -4996,7 +4996,7 @@ class TestVisionTracing(JitTestCase):
                 if k not in {"mvit_v1_b", "mvit_v2_s", "s3d"}
                 else torch.rand(1, 3, 16, 224, 224)
             )
-            kwargs = dict(num_classes=50)
+            kwargs = {'num_classes': 50, }
             model_test = cls.generate_test_fn(k, x, kwargs)
             setattr(cls, test_name, model_test)
 

--- a/test/test_masked.py
+++ b/test/test_masked.py
@@ -4,19 +4,27 @@
 """
 
 import itertools
-import torch
-from typing import Any
-from functools import wraps
 import unittest
-from torch.testing._internal.common_utils import skipIfTorchDynamo
+from functools import wraps
+from typing import Any
 
+import torch
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyNativeDeviceTypes,
+    ops,
+    precisionOverride,
+)
+from torch.testing._internal.common_methods_invocations import op_db, SampleInput
 
-from torch.testing._internal.common_utils import \
-    (TestCase, parametrize, suppress_warnings, _TestParametrizer, run_tests)
-from torch.testing._internal.common_methods_invocations import \
-    (op_db, SampleInput)
-from torch.testing._internal.common_device_type import \
-    (instantiate_device_type_tests, ops, onlyNativeDeviceTypes, precisionOverride)
+from torch.testing._internal.common_utils import (
+    _TestParametrizer,
+    parametrize,
+    run_tests,
+    skipIfTorchDynamo,
+    suppress_warnings,
+    TestCase,
+)
 
 
 def apply_masked_reduction_along_dim(op, input, *args, **kwargs):
@@ -74,27 +82,27 @@ def apply_masked_reduction_along_dim(op, input, *args, **kwargs):
       of masked operations.
     """
     # eliminate mask and dim_position keyword arguments:
-    mask = kwargs.pop('mask', None)
-    dim_pos = kwargs.pop('dim_position', 0)
+    mask = kwargs.pop("mask", None)
+    dim_pos = kwargs.pop("dim_position", 0)
 
-    dtype = kwargs.get('dtype', input.dtype)
+    dtype = kwargs.get("dtype", input.dtype)
     if input.ndim == 0:
         # scalar input is an elementary slice
         return op(input, *args, **kwargs).to(dtype=dtype)
 
     # eliminate keepdim keyword argument if specified:
-    keepdim = kwargs.pop('keepdim', False)
+    keepdim = kwargs.pop("keepdim", False)
 
     # eliminate dim argument that may appear both as args or kwargs
     # element:
     if dim_pos < len(args):
         # dim is specified in args
-        assert 'dim' not in kwargs, (args, kwargs)
+        assert "dim" not in kwargs, (args, kwargs)
         dim = args[dim_pos]
-        args0 = args[:dim_pos] + (None,) + args[dim_pos + 1:]
+        args0 = args[:dim_pos] + (None,) + args[dim_pos + 1 :]
     else:
         # dim may be specified in kwargs
-        dim = kwargs.pop('dim', None)
+        dim = kwargs.pop("dim", None)
         args0 = args
 
     # dimensions along which the reduction operation is applied:
@@ -112,7 +120,9 @@ def apply_masked_reduction_along_dim(op, input, *args, **kwargs):
             shape.append(input.shape[i])
 
     # keepdim=True version of the output, filled with nan or 0:
-    output = input.new_full(shape, float('nan') if dtype.is_floating_point else 0, dtype=dtype)
+    output = input.new_full(
+        shape, float("nan") if dtype.is_floating_point else 0, dtype=dtype
+    )
 
     # apply op to all elementary slices:
     if mask is None:
@@ -139,13 +149,13 @@ def apply_masked_normalization_along_dim(op, input, *args, **kwargs):
     """Applies normalization op along given dimension to strided x
     elements that are valid according to mask tensor.
     """
-    mask = kwargs.pop('mask', None)
-    dim_pos = kwargs.pop('dim_position', 0)
+    mask = kwargs.pop("mask", None)
+    dim_pos = kwargs.pop("dim_position", 0)
     if input.ndim == 0:  # scalar input
         return op(input, *args, **kwargs)
-    dtype = kwargs.get('dtype', input.dtype)
+    dtype = kwargs.get("dtype", input.dtype)
     dim = args[dim_pos]
-    args0 = args[:dim_pos] + (0,) + args[dim_pos + 1:]
+    args0 = args[:dim_pos] + (0,) + args[dim_pos + 1 :]
     output = torch.zeros_like(input, dtype=dtype)
     if mask is None:
         inpmask = input.new_ones([], dtype=torch.bool).expand(input.shape)
@@ -153,27 +163,44 @@ def apply_masked_normalization_along_dim(op, input, *args, **kwargs):
         inpmask = torch.masked._input_mask(input, mask=mask)
     dim_ = dim % input.ndim
     left_ranges = tuple(map(range, input.shape[:dim_]))
-    right_ranges = tuple(map(range, input.shape[dim_ + 1:]))
+    right_ranges = tuple(map(range, input.shape[dim_ + 1 :]))
     for s in itertools.product(*(left_ranges + ((slice(None),),) + right_ranges)):
         indices = inpmask[s].argwhere()
         output[s][indices] = op(input[s][indices], *args0, **kwargs)
     return output
 
 
-reference_functions = dict(
-    norm=lambda *args, **kwargs: apply_masked_reduction_along_dim(torch.linalg.vector_norm, *args, **dict(kwargs, dim_position=1)),
-    var=lambda *args, **kwargs: apply_masked_reduction_along_dim(torch.var, *args, **dict(kwargs, dim_position=0)),
-    std=lambda *args, **kwargs: apply_masked_reduction_along_dim(torch.std, *args, **dict(kwargs, dim_position=0)),
-    softmax=lambda *args, **kwargs: apply_masked_normalization_along_dim(torch.softmax, *args, **kwargs),
-    log_softmax=lambda *args, **kwargs: apply_masked_normalization_along_dim(torch.log_softmax, *args, **kwargs),
-    softmin=lambda *args, **kwargs: apply_masked_normalization_along_dim(torch.nn.functional.softmin, *args, **kwargs),
-    normalize=lambda *args, **kwargs: apply_masked_normalization_along_dim(
-        torch.nn.functional.normalize, *args, **dict(kwargs, dim_position=1)),
-)
+reference_functions = {
+    "norm": lambda *args, **kwargs: apply_masked_reduction_along_dim(
+        torch.linalg.vector_norm, *args, **dict(kwargs, dim_position=1)
+    ),
+    "var": lambda *args, **kwargs: apply_masked_reduction_along_dim(
+        torch.var, *args, **dict(kwargs, dim_position=0)
+    ),
+    "std": lambda *args, **kwargs: apply_masked_reduction_along_dim(
+        torch.std, *args, **dict(kwargs, dim_position=0)
+    ),
+    "softmax": lambda *args, **kwargs: apply_masked_normalization_along_dim(
+        torch.softmax, *args, **kwargs
+    ),
+    "log_softmax": lambda *args, **kwargs: apply_masked_normalization_along_dim(
+        torch.log_softmax, *args, **kwargs
+    ),
+    "softmin": lambda *args, **kwargs: apply_masked_normalization_along_dim(
+        torch.nn.functional.softmin, *args, **kwargs
+    ),
+    "normalize": lambda *args, **kwargs: apply_masked_normalization_along_dim(
+        torch.nn.functional.normalize, *args, **dict(kwargs, dim_position=1)
+    ),
+}
 
-masked_ops = [op for op in op_db if op.name.startswith('masked.')]
-masked_ops_with_references = [op for op in masked_ops if op.name.rsplit('.', 1)[-1] in reference_functions]
-masked_ops_with_non_strided_support = [op for op in masked_ops if op.supports_sparse or op.supports_sparse_csr]
+masked_ops = [op for op in op_db if op.name.startswith("masked.")]
+masked_ops_with_references = [
+    op for op in masked_ops if op.name.rsplit(".", 1)[-1] in reference_functions
+]
+masked_ops_with_non_strided_support = [
+    op for op in masked_ops if op.supports_sparse or op.supports_sparse_csr
+]
 
 
 def _tensor_to_strided(obj):
@@ -187,20 +214,17 @@ def _tensor_to_strided(obj):
 
 
 def to_strided(obj):
-    """Convert the tensor content of object to strided tensor content.
-    """
+    """Convert the tensor content of object to strided tensor content."""
     return torch.utils._pytree.tree_map(_tensor_to_strided, obj)
 
 
 def to_sparse_coo(obj):
-    """Convert the tensor content of object to sparse coo tensor content.
-    """
+    """Convert the tensor content of object to sparse coo tensor content."""
     return torch.utils._pytree.tree_map(torch.Tensor.to_sparse, obj)
 
 
 def to_sparse_csr(obj):
-    """Convert the tensor content of object to sparse csr tensor content.
-    """
+    """Convert the tensor content of object to sparse csr tensor content."""
     return torch.utils._pytree.tree_map(torch.Tensor.to_sparse_csr, obj)
 
 
@@ -210,28 +234,33 @@ class mask_layouts(_TestParametrizer):
     The sample_inputs generator provides samples with all supported
     layouts for the mask argument.
     """
+
     def _parametrize_test(self, test, generic_cls, device_cls):
 
         @wraps(test)
         def wrap(self, layout, device, dtype, op):
-            layout_name = str(layout).lstrip('torch.')
+            layout_name = str(layout).lstrip("torch.")
             if layout == torch.strided:
                 # strided layouts are always supported
                 sample_inputs_func = op.sample_inputs
             elif layout == torch.sparse_coo:
                 if not op.supports_sparse:
-                    raise unittest.SkipTest(f"{op.name} does not support inputs with {layout_name} layout")
+                    raise unittest.SkipTest(
+                        f"{op.name} does not support inputs with {layout_name} layout"
+                    )
                 sample_inputs_func = op.sample_inputs_sparse_coo
             elif layout == torch.sparse_csr:
                 if not op.supports_sparse_csr:
-                    raise unittest.SkipTest(f"{op.name} does not support inputs with {layout_name} layout")
+                    raise unittest.SkipTest(
+                        f"{op.name} does not support inputs with {layout_name} layout"
+                    )
                 sample_inputs_func = op.sample_inputs_sparse_csr
             else:
-                raise NotImplementedError(f'{layout}')
+                raise NotImplementedError(f"{layout}")
 
             def sample_inputs_generator():
                 for sample_input in sample_inputs_func(device, dtype):
-                    mask = sample_input.kwargs.get('mask')
+                    mask = sample_input.kwargs.get("mask")
                     if mask is None:
                         yield sample_input
                     else:
@@ -240,26 +269,36 @@ class mask_layouts(_TestParametrizer):
                         if layout != torch.strided:
                             sample_input_kwargs = sample_input.kwargs.copy()
                             sample_input_kwargs.update(mask=mask.to_dense())
-                            yield SampleInput(sample_input.input.clone(),
-                                              args=sample_input.args,
-                                              kwargs=sample_input_kwargs)
+                            yield SampleInput(
+                                sample_input.input.clone(),
+                                args=sample_input.args,
+                                kwargs=sample_input_kwargs,
+                            )
                         if layout != torch.sparse_coo and op.supports_sparse:
                             sample_input_kwargs = sample_input.kwargs.copy()
                             sample_input_kwargs.update(mask=mask.to_sparse())
-                            yield SampleInput(sample_input.input.clone(),
-                                              args=sample_input.args,
-                                              kwargs=sample_input_kwargs)
-                        if layout != torch.sparse_csr and op.supports_sparse_csr and sample_input.input.ndim == 2:
+                            yield SampleInput(
+                                sample_input.input.clone(),
+                                args=sample_input.args,
+                                kwargs=sample_input_kwargs,
+                            )
+                        if (
+                            layout != torch.sparse_csr
+                            and op.supports_sparse_csr
+                            and sample_input.input.ndim == 2
+                        ):
                             sample_input_kwargs = sample_input.kwargs.copy()
                             sample_input_kwargs.update(mask=mask.to_sparse_csr())
-                            yield SampleInput(sample_input.input.clone(),
-                                              args=sample_input.args,
-                                              kwargs=sample_input_kwargs)
+                            yield SampleInput(
+                                sample_input.input.clone(),
+                                args=sample_input.args,
+                                kwargs=sample_input_kwargs,
+                            )
 
             test(self, layout, device, dtype, op, sample_inputs_generator())
 
         for layout in (torch.strided, torch.sparse_coo, torch.sparse_csr):
-            yield (wrap, str(layout).lstrip('torch.'), {'layout': layout}, lambda _: [])
+            yield (wrap, str(layout).lstrip("torch."), {"layout": layout}, lambda _: [])
 
 
 class TestMasked(TestCase):
@@ -276,17 +315,23 @@ class TestMasked(TestCase):
     @ops(masked_ops_with_references)
     @precisionOverride({torch.bfloat16: 5e-4, torch.float16: 5e-4})
     def test_reference_masked(self, device, dtype, op):
-        op_name = op.name.rsplit('.', 1)[-1]
+        op_name = op.name.rsplit(".", 1)[-1]
         ref_op = reference_functions[op_name]
         sample_inputs = op.sample_inputs(device, dtype)
         for sample_input in sample_inputs:
-            t_inp, t_args, t_kwargs = sample_input.input, sample_input.args, sample_input.kwargs
-            if op_name in {'var', 'std'} and not (t_inp.dtype.is_floating_point or t_inp.dtype.is_complex):
+            t_inp, t_args, t_kwargs = (
+                sample_input.input,
+                sample_input.args,
+                sample_input.kwargs,
+            )
+            if op_name in {"var", "std"} and not (
+                t_inp.dtype.is_floating_point or t_inp.dtype.is_complex
+            ):
                 # torch.var/torch.std does not support integer inputs
                 continue
             actual = op.op(t_inp, *t_args, **t_kwargs)
             expected = ref_op(t_inp, *t_args, **t_kwargs)
-            if t_kwargs.get('mask') is None:
+            if t_kwargs.get("mask") is None:
                 outmask = None
             else:
                 outmask = torch.masked._output_mask(op.op, t_inp, *t_args, **t_kwargs)
@@ -308,7 +353,7 @@ class TestMasked(TestCase):
             #  op(inp, mask).to_dense() == op(inp.to_dense(), mask.to_dense()) at outmask
             #
             r_inp, r_args, r_kwargs = to_strided((t_inp, t_args, t_kwargs))
-            if r_kwargs.get('mask') is None:
+            if r_kwargs.get("mask") is None:
                 outmask = None
             else:
                 outmask = torch.masked._output_mask(op.op, r_inp, *r_args, **r_kwargs)
@@ -316,14 +361,22 @@ class TestMasked(TestCase):
             self.assertEqualMasked(actual, expected, outmask)
 
     @skipIfTorchDynamo("https://github.com/pytorch/torchdynamo/issues/1992")
-    @parametrize("sparse_kind,fill_value", [('coo', 0), ('hybrid_coo', 0),
-                                            ('coo', 123), ('hybrid_coo', 123),
-                                            ('csr', 0), ('csr', 123)],
-                 name_fn=lambda sparse_kind, fill_value: f'{sparse_kind}_fill_value_{fill_value}')
+    @parametrize(
+        "sparse_kind,fill_value",
+        [
+            ("coo", 0),
+            ("hybrid_coo", 0),
+            ("coo", 123),
+            ("hybrid_coo", 123),
+            ("csr", 0),
+            ("csr", 123),
+        ],
+        name_fn=lambda sparse_kind, fill_value: f"{sparse_kind}_fill_value_{fill_value}",
+    )
     def test_where(self, sparse_kind, fill_value):
 
         is_hybrid = False
-        if sparse_kind == 'coo':
+        if sparse_kind == "coo":
 
             def to_sparse(dense):
                 return dense.to_sparse(2)
@@ -331,7 +384,7 @@ class TestMasked(TestCase):
             def set_values(sparse, index, value):
                 sparse._values()[index] = value
 
-        elif sparse_kind == 'hybrid_coo':
+        elif sparse_kind == "hybrid_coo":
             is_hybrid = True
 
             def to_sparse(dense):
@@ -340,7 +393,7 @@ class TestMasked(TestCase):
             def set_values(sparse, index, value):
                 sparse._values()[index] = value
 
-        elif sparse_kind == 'csr':
+        elif sparse_kind == "csr":
 
             def to_sparse(dense):
                 return dense.to_sparse_csr()
@@ -351,12 +404,16 @@ class TestMasked(TestCase):
         else:
             assert 0, sparse_kind
 
-        mask = torch.tensor([[1, 0, 1, 0, 0],
-                             [1, 1, 1, 1, 0],
-                             [0, 1, 0, 1, 0],
-                             [0, 0, 0, 0, 0],
-                             [0, 0, 1, 1, 0],
-                             [1, 1, 0, 0, 0]]).to(dtype=bool)
+        mask = torch.tensor(
+            [
+                [1, 0, 1, 0, 0],
+                [1, 1, 1, 1, 0],
+                [0, 1, 0, 1, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 1, 1, 0],
+                [1, 1, 0, 0, 0],
+            ]
+        ).to(dtype=bool)
         mask = to_sparse(mask)
         # make some specified mask elements as explicit masked-out masks:
         if is_hybrid:
@@ -366,12 +423,16 @@ class TestMasked(TestCase):
             set_values(mask, 3, False)
             set_values(mask, -3, False)
 
-        input = torch.tensor([[1, 0, 0, 0, -1],
-                              [2, 3, 0, 0, -2],
-                              [0, 4, 5, 0, -3],
-                              [0, 0, 6, 7, 0],
-                              [0, 8, 9, 0, -3],
-                              [10, 11, 0, 0, -5]])
+        input = torch.tensor(
+            [
+                [1, 0, 0, 0, -1],
+                [2, 3, 0, 0, -2],
+                [0, 4, 5, 0, -3],
+                [0, 0, 6, 7, 0],
+                [0, 8, 9, 0, -3],
+                [10, 11, 0, 0, -5],
+            ]
+        )
         input = to_sparse(input)
         # make specified input elements have zero values:
         if is_hybrid:
@@ -387,35 +448,52 @@ class TestMasked(TestCase):
         Z = 99
         # Z value corresponds to masked-in elements that are not
         # specified in the input and it will be replaced with a zero
-        tmp = torch.tensor([[1, F, Z, F, F],
-                            [2, F, Z, Z, F],
-                            [F, 4, F, Z, F],
-                            [0, 0, 0, 0, 0],
-                            [F, F, 9, F, F],
-                            [Z, 11, F, F, F]])
+        tmp = torch.tensor(
+            [
+                [1, F, Z, F, F],
+                [2, F, Z, Z, F],
+                [F, 4, F, Z, F],
+                [0, 0, 0, 0, 0],
+                [F, F, 9, F, F],
+                [Z, 11, F, F, F],
+            ]
+        )
         tmp = to_sparse(tmp)
 
-
-        sparse = torch.masked._where(mask, input,
-                                     torch.tensor(fill_value, dtype=input.dtype, device=input.device))
+        sparse = torch.masked._where(
+            mask,
+            input,
+            torch.tensor(fill_value, dtype=input.dtype, device=input.device),
+        )
 
         if tmp.layout == torch.sparse_coo:
             expected_sparse = torch.sparse_coo_tensor(
                 tmp.indices(),
-                torch.where(tmp.values() != Z, tmp.values(), tmp.values().new_full([], 0)),
-                input.shape)
-            outmask = torch.sparse_coo_tensor(sparse.indices(),
-                                              sparse.values().new_full(sparse.values().shape, 1).to(dtype=bool),
-                                              sparse.shape)._coalesced_(True)
+                torch.where(
+                    tmp.values() != Z, tmp.values(), tmp.values().new_full([], 0)
+                ),
+                input.shape,
+            )
+            outmask = torch.sparse_coo_tensor(
+                sparse.indices(),
+                sparse.values().new_full(sparse.values().shape, 1).to(dtype=bool),
+                sparse.shape,
+            )._coalesced_(True)
         elif tmp.layout == torch.sparse_csr:
             expected_sparse = torch.sparse_csr_tensor(
                 tmp.crow_indices(),
                 tmp.col_indices(),
-                torch.where(tmp.values() != Z, tmp.values(), tmp.values().new_full([], 0)),
-                input.shape)
-            outmask = torch.sparse_csr_tensor(sparse.crow_indices(), sparse.col_indices(),
-                                              sparse.values().new_full(sparse.values().shape, 1).to(dtype=bool),
-                                              sparse.shape)
+                torch.where(
+                    tmp.values() != Z, tmp.values(), tmp.values().new_full([], 0)
+                ),
+                input.shape,
+            )
+            outmask = torch.sparse_csr_tensor(
+                sparse.crow_indices(),
+                sparse.col_indices(),
+                sparse.values().new_full(sparse.values().shape, 1).to(dtype=bool),
+                sparse.shape,
+            )
         else:
             assert 0
 
@@ -424,12 +502,16 @@ class TestMasked(TestCase):
         # check invariance:
         #  torch.where(mask.to_dense(), input.to_dense(), fill_value)
         #    == where(mask, input, fill_value).to_dense(fill_value)
-        expected = torch.where(mask.to_dense(), input.to_dense(), torch.full(input.shape, F))
-        dense = torch.where(outmask.to_dense(), sparse.to_dense(), torch.full(sparse.shape, F))
+        expected = torch.where(
+            mask.to_dense(), input.to_dense(), torch.full(input.shape, F)
+        )
+        dense = torch.where(
+            outmask.to_dense(), sparse.to_dense(), torch.full(sparse.shape, F)
+        )
         self.assertEqual(dense, expected)
 
 
-instantiate_device_type_tests(TestMasked, globals(), except_for='meta')
+instantiate_device_type_tests(TestMasked, globals(), except_for="meta")
 
 if __name__ == "__main__":
     run_tests()

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -11728,9 +11728,9 @@ class TestRNNMPS(TestCaseMPS):
 
         if backward:
             grad_cases = [
-                dict(output_grad_presented=True, states_grad_presented=True),
-                dict(output_grad_presented=False, states_grad_presented=True),
-                dict(output_grad_presented=True, states_grad_presented=False),
+                {'output_grad_presented': True, 'states_grad_presented': True, },
+                {'output_grad_presented': False, 'states_grad_presented': True, },
+                {'output_grad_presented': True, 'states_grad_presented': False, },
             ]
 
             for grad_case in grad_cases:
@@ -11749,13 +11749,13 @@ class TestRNNMPS(TestCaseMPS):
 
     LSTM_TEST_CASES = [
         {},  # default
-        dict(batch_first=True),
-        dict(bias=False),
-        dict(bidirectional=True),
-        dict(batch_first=True, bias=False),
-        dict(bidirectional=True, bias=False),
-        dict(bidirectional=True, batch_first=True),
-        dict(bidirectional=True, batch_first=True, bias=False)
+        {'batch_first': True, },
+        {'bias': False, },
+        {'bidirectional': True, },
+        {'batch_first': True, 'bias': False, },
+        {'bidirectional': True, 'bias': False, },
+        {'bidirectional': True, 'batch_first': True, },
+        {'bidirectional': True, 'batch_first': True, 'bias': False, }
     ]
 
     def test_lstm_forward(self, device="mps", dtype=torch.float32):

--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -540,10 +540,10 @@ class TestMultiprocessing(TestCase):
     def test_cuda_ipc_deadlock(self):
         ctx = mp.get_context("spawn")
         queue = ctx.Queue(1)
-        processes = dict(
-            a=ctx.Process(target=_test_cuda_ipc_deadlock_actor, args=(queue, 100)),
-            l=ctx.Process(target=_test_cuda_ipc_deadlock_learner, args=(queue, 100)),
-        )
+        processes = {
+            "a": ctx.Process(target=_test_cuda_ipc_deadlock_actor, args=(queue, 100)),
+            "l": ctx.Process(target=_test_cuda_ipc_deadlock_learner, args=(queue, 100)),
+        }
 
         for p in processes.values():
             p.start()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6598,9 +6598,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
     def test_upsamplingLinear1d(self):
         for align_corners in [True, False]:
             for recompute_scale_factor in [True, False]:
-                kwargs = dict(
-                    mode='linear', align_corners=align_corners, recompute_scale_factor=recompute_scale_factor
-                )
+                kwargs = {'mode': 'linear', 'align_corners': align_corners, 'recompute_scale_factor': recompute_scale_factor, }
                 # test float scale factor up & downsampling
                 for scale_factor in [0.5, 1.5, 2]:
                     m = nn.Upsample(scale_factor=scale_factor, **kwargs)
@@ -6660,7 +6658,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             device_list.append('cuda')
 
         for align_corners in [True, False]:
-            kwargs = dict(mode='bicubic', align_corners=align_corners)
+            kwargs = {'mode': 'bicubic', 'align_corners': align_corners, }
             # test float scale factor up & downsampling
             for device in device_list:
                 for scale_factor in [0.6, 1.6, 2.3]:
@@ -6867,27 +6865,27 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         for device in device_list:
             for scale_factor in [0.5, 1.5, 2]:
                 for mode in ['nearest', 'area']:
-                    kwargs = dict(mode=mode)
+                    kwargs = {'mode': mode, }
                     m = nn.Upsample(scale_factor=scale_factor, **kwargs).to(device)
                     for input in [_make_input(1, device), _make_input(2, device), _make_input(3, device)]:
                         _test_interpolate_helper(input, scale_factor, m)
 
                 for align_corners in [True, False]:
-                    kwargs = dict(mode='linear', align_corners=align_corners)
+                    kwargs = {'mode': 'linear', 'align_corners': align_corners, }
                     m = nn.Upsample(scale_factor=scale_factor, **kwargs).to(device)
                     _test_interpolate_helper(_make_input(1, device), scale_factor, m)
 
-                    kwargs = dict(mode='bilinear', align_corners=align_corners)
+                    kwargs = {'mode': 'bilinear', 'align_corners': align_corners, }
                     m = nn.Upsample(scale_factor=scale_factor, **kwargs).to(device)
                     _test_interpolate_helper(_make_input(2, device), scale_factor, m)
 
-                    kwargs = dict(mode='bicubic', align_corners=align_corners)
+                    kwargs = {'mode': 'bicubic', 'align_corners': align_corners, }
 
                     def m(t):
                         return F.interpolate(t, scale_factor=scale_factor, **kwargs).to(device)
                     _test_interpolate_helper(_make_input(2, device), scale_factor, m)
 
-                    kwargs = dict(mode='trilinear', align_corners=align_corners)
+                    kwargs = {'mode': 'trilinear', 'align_corners': align_corners, }
                     m = nn.Upsample(scale_factor=scale_factor, **kwargs).to(device)
                     _test_interpolate_helper(_make_input(3, device), scale_factor, m)
 
@@ -10025,7 +10023,7 @@ class TestNNDeviceType(NNTestCase):
         # Forward AD does not support XLA because XLA tensors don't have storage
         check_forward_ad = torch.device(device).type != 'xla'
 
-        kwargs = dict(mode=mode, align_corners=align_corners, antialias=antialias)
+        kwargs = {'mode': mode, 'align_corners': align_corners, 'antialias': antialias, }
         # test float scale factor up & downsampling
         for scale_factor in [0.5, 1.5, 2]:
             in_t = torch.ones(
@@ -10275,7 +10273,7 @@ class TestNNDeviceType(NNTestCase):
     @parametrize_test("align_corners", [True, False])
     @parametrize_test("memory_format", [torch.contiguous_format, torch.channels_last_3d])
     def test_upsamplingTrilinear3d(self, device, align_corners, memory_format):
-        kwargs = dict(mode='trilinear', align_corners=align_corners)
+        kwargs = {'mode': 'trilinear', 'align_corners': align_corners, }
 
         # test float scale factor up & downsampling
         for scale_factor in [0.5, 1.5, 2]:

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1274,7 +1274,9 @@ class TestOptimRenewed(TestCase):
             optimizer = optim_cls(
                 [
                     dict(params=[weight, bias], **optim_input.kwargs),
-                    dict(params=[irrelevant]),
+                    {
+                        "params": [irrelevant],
+                    },
                 ],
                 **outer_kwargs,
             )

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -2839,7 +2839,7 @@ class TestReductions(TestCase):
         array = tensor.cpu().numpy()
 
         for dim, correction, keepdim in test_args:
-            numpy_kwargs = dict(axis=dim, ddof=correction, keepdims=keepdim)
+            numpy_kwargs = {'axis': dim, 'ddof': correction, 'keepdims': keepdim, }
             if correction is None:
                 # NumPy default is not compatible with torch.std (gh-50010)
                 numpy_kwargs['ddof'] = 1
@@ -2873,7 +2873,7 @@ class TestReductions(TestCase):
         array = tensor.cpu().numpy()
 
         for dim, correction, keepdim in test_args:
-            numpy_kwargs = dict(axis=dim, ddof=correction, keepdims=keepdim)
+            numpy_kwargs = {'axis': dim, 'ddof': correction, 'keepdims': keepdim, }
             if correction is None:
                 # NumPy default is incompatible with torch.std (gh-50010)
                 numpy_kwargs['ddof'] = 1
@@ -2906,7 +2906,7 @@ class TestReductions(TestCase):
         tensor = make_tensor(_size, device=device, dtype=dtype)
 
         for dim, correction, keepdim in test_args:
-            kwargs = dict(dim=dim, correction=correction, keepdim=keepdim)
+            kwargs = {'dim': dim, 'correction': correction, 'keepdim': keepdim, }
             std1 = torch.std(tensor, **kwargs)
             if dim is not None:
                 mean1 = torch.mean(tensor, dim=dim, keepdim=keepdim)
@@ -2937,7 +2937,7 @@ class TestReductions(TestCase):
         tensor = make_tensor(_size, device=device, dtype=dtype)
 
         for dim, correction, keepdim in test_args:
-            kwargs = dict(dim=dim, correction=correction, keepdim=keepdim)
+            kwargs = {'dim': dim, 'correction': correction, 'keepdim': keepdim, }
             var1 = torch.var(tensor, **kwargs)
             if dim is not None:
                 mean1 = torch.mean(tensor, dim=dim, keepdim=keepdim)

--- a/test/test_segment_reductions.py
+++ b/test/test_segment_reductions.py
@@ -67,10 +67,7 @@ class TestSegmentReductions(TestCase):
         expected_result = torch.tensor(expected_arr, device=device, dtype=dtype)
         expected_grad = torch.tensor(expected_grad_arr, device=device, dtype=dtype)
         for mode in ['lengths', 'offsets']:
-            segment_reduce_kwargs = dict(
-                axis=axis,
-                unsafe=unsafe,
-                initial=initial_value)
+            segment_reduce_kwargs = {'axis': axis, 'unsafe': unsafe, 'initial': initial_value, }
             if (mode == 'lengths'):
                 segment_reduce_kwargs['lengths'] = lengths
             else:
@@ -472,7 +469,7 @@ class TestSegmentReductions(TestCase):
                     elif reduce == 'max':
                         initial = -1000
                     segment_reduce_args = {x, reduce}
-                    segment_reduce_kwargs = dict(axis=dim, unsafe=True, initial=initial)
+                    segment_reduce_kwargs = {'axis': dim, 'unsafe': True, 'initial': initial, }
                     if mode == 'lengths':
                         segment_reduce_kwargs[mode] = lengths
                     elif mode == 'offsets':

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -1228,10 +1228,7 @@ class TestSerialization(TestCase, SerializationMixin):
     def test_serialization_nested_class(self) -> None:
         with tempfile.NamedTemporaryFile() as checkpoint:
             torch.save(
-                dict(
-                    a_nested=ClassAMock.Nested(),
-                    b_nested=ClassBMock.Nested(),
-                ),
+                {'a_nested': ClassAMock.Nested(), 'b_nested': ClassBMock.Nested(), },
                 checkpoint
             )
             checkpoint.seek(0)
@@ -4580,7 +4577,7 @@ class TestSerialization(TestCase, SerializationMixin):
             f.seek(0)
             try:
                 old_get_allowed_globals = torch._weights_only_unpickler._get_allowed_globals
-                torch._weights_only_unpickler._get_allowed_globals = lambda: dict()  # noqa: PIE807
+                torch._weights_only_unpickler._get_allowed_globals = lambda: {}  # noqa: PIE807
                 unsafe_all_globals = torch.serialization.get_unsafe_globals_in_checkpoint(f)
                 self.assertEqual(set(unsafe_all_globals), expected_all_global_strs)
             finally:

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -5067,25 +5067,40 @@ class TestSparseAny(TestCase):
             blocksize=(1, 1) if layout in {torch.sparse_bsr, torch.sparse_bsc} else None)
         assert inp.layout is layout
 
-        expected_behaviour = dict(
-            # <mth name> = (<supported layouts>, <exception message on other layouts>)
-            is_coalesced=({torch.sparse_coo},
-                          "is_coalesced expected sparse coordinate tensor layout but got (Sparse(Csr|Csc|Bsr|Bsc)|Strided)"),
-            coalesce=({torch.sparse_coo},
-                      "coalesce expected sparse coordinate tensor layout but got (Sparse(Csr|Csc|Bsr|Bsc)|Strided)"),
-            indices=({torch.sparse_coo},
-                     "indices expected sparse coordinate tensor layout but got (Sparse(Csr|Csc|Bsr|Bsc)|Strided)"),
-            values=({torch.sparse_coo, torch.sparse_csr, torch.sparse_csc, torch.sparse_bsr, torch.sparse_bsc},
-                    "values expected sparse tensor layout but got Strided"),
-            crow_indices=({torch.sparse_csr, torch.sparse_bsr},
-                          "crow_indices expected sparse row compressed tensor layout but got (Sparse(Csc|Bsc|)|Strided)"),
-            col_indices=({torch.sparse_csr, torch.sparse_bsr},
-                         "col_indices expected sparse row compressed tensor layout but got (Sparse(Csc|Bsc|)|Strided)"),
-            ccol_indices=({torch.sparse_csc, torch.sparse_bsc},
-                          "ccol_indices expected sparse column compressed tensor layout but got (Sparse(Csr|Bsr|)|Strided)"),
-            row_indices=({torch.sparse_csc, torch.sparse_bsc},
-                         "row_indices expected sparse column compressed tensor layout but got (Sparse(Csr|Bsr|)|Strided)"),
-        )[mth.__name__]
+        expected_behaviour = {
+            'is_coalesced': (
+                {torch.sparse_coo},
+                "is_coalesced expected sparse coordinate tensor layout but got (Sparse(Csr|Csc|Bsr|Bsc)|Strided)"
+            ),
+            'coalesce': (
+                {torch.sparse_coo},
+                "coalesce expected sparse coordinate tensor layout but got (Sparse(Csr|Csc|Bsr|Bsc)|Strided)"
+            ),
+            'indices': (
+                {torch.sparse_coo},
+                "indices expected sparse coordinate tensor layout but got (Sparse(Csr|Csc|Bsr|Bsc)|Strided)"
+            ),
+            'values': (
+                {torch.sparse_coo, torch.sparse_csr, torch.sparse_csc, torch.sparse_bsr, torch.sparse_bsc},
+                "values expected sparse tensor layout but got Strided"
+            ),
+            'crow_indices': (
+                {torch.sparse_csr, torch.sparse_bsr},
+                "crow_indices expected sparse row compressed tensor layout but got (Sparse(Csc|Bsc|)|Strided)"
+            ),
+            'col_indices': (
+                {torch.sparse_csr, torch.sparse_bsr},
+                "col_indices expected sparse row compressed tensor layout but got (Sparse(Csc|Bsc|)|Strided)"
+            ),
+            'ccol_indices': (
+                {torch.sparse_csc, torch.sparse_bsc},
+                "ccol_indices expected sparse column compressed tensor layout but got (Sparse(Csr|Bsr|)|Strided)"
+            ),
+            'row_indices': (
+                {torch.sparse_csc, torch.sparse_bsc},
+                "row_indices expected sparse column compressed tensor layout but got (Sparse(Csr|Bsr|)|Strided)"
+            ),
+        }[mth.__name__]
 
         if layout in expected_behaviour[0]:
             mth(inp)

--- a/test/test_sparse_semi_structured.py
+++ b/test/test_sparse_semi_structured.py
@@ -43,7 +43,7 @@ from torch.testing._internal.inductor_utils import HAS_GPU
 
 import pytest
 
-SEMI_STRUCTURED_SUPPORTED_BACKENDS = dict()
+SEMI_STRUCTURED_SUPPORTED_BACKENDS = {}
 
 _IS_SM8X = False
 _IS_SM9X = False

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -1644,7 +1644,7 @@ def generate_doc_test(doc_test):
 
     setattr(TestFFTDocExamples, 'test_' + doc_test.name, skipCPUIfNoFFT(test))
 
-for doc_test in FFTDocTestFinder().find(torch.fft, globs=dict(torch=torch)):
+for doc_test in FFTDocTestFinder().find(torch.fft, globs={'torch': torch, }):
     generate_doc_test(doc_test)
 
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -830,7 +830,7 @@ class TestAssertClose(TestCase):
     def test_docstring_examples(self):
         finder = doctest.DocTestFinder(verbose=False)
         runner = doctest.DocTestRunner(verbose=False, optionflags=doctest.NORMALIZE_WHITESPACE)
-        globs = dict(torch=torch)
+        globs = {'torch': torch, }
         doctests = finder.find(torch.testing.assert_close, globs=globs)[0]
         failures = []
         runner.run(doctests, out=lambda report: failures.append(report))
@@ -2448,26 +2448,26 @@ class TestOpInfos(TestCase):
         s = SampleInput(a, b, c, d=d, e=e)
         assert s.input is a
         assert s.args == (b, c)
-        assert s.kwargs == dict(d=d, e=e)
+        assert s.kwargs == {'d': d, 'e': e, }
 
         # Construction with explicit args and kwargs
-        s = SampleInput(a, args=(b,), kwargs=dict(c=c, d=d, e=e))
+        s = SampleInput(a, args=(b,), kwargs={'c': c, 'd': d, 'e': e, })
         assert s.input is a
         assert s.args == (b,)
-        assert s.kwargs == dict(c=c, d=d, e=e)
+        assert s.kwargs == {'c': c, 'd': d, 'e': e, }
 
         # Construction with a mixed form will error
         with self.assertRaises(AssertionError):
             s = SampleInput(a, b, c, args=(d, e))
 
         with self.assertRaises(AssertionError):
-            s = SampleInput(a, b, c, kwargs=dict(d=d, e=e))
+            s = SampleInput(a, b, c, kwargs={'d': d, 'e': e, })
 
         with self.assertRaises(AssertionError):
             s = SampleInput(a, args=(b, c), d=d, e=e)
 
         with self.assertRaises(AssertionError):
-            s = SampleInput(a, b, c=c, kwargs=dict(d=d, e=e))
+            s = SampleInput(a, b, c=c, kwargs={'d': d, 'e': e, })
 
         # Mixing metadata into "natural" construction will error
         with self.assertRaises(AssertionError):

--- a/test/torch_np/numpy_tests/core/test_multiarray.py
+++ b/test/torch_np/numpy_tests/core/test_multiarray.py
@@ -5920,7 +5920,10 @@ class TestPEP3118Dtype(TestCase):
         def aligned(n):
             return align * (1 + (n - 1) // align)
 
-        base = dict(formats=["i"], names=["f0"])
+        base = {
+            "formats": ["i"],
+            "names": ["f0"],
+        }
 
         self._check("ix", dict(itemsize=aligned(size + 1), **base))
         self._check("ixx", dict(itemsize=aligned(size + 2), **base))
@@ -5974,9 +5977,12 @@ class TestPEP3118Dtype(TestCase):
         self._check(
             "(3)T{ix}",
             (
-                dict(
-                    names=["f0"], formats=["i"], offsets=[0], itemsize=aligned(size + 1)
-                ),
+                {
+                    "names": ["f0"],
+                    "formats": ["i"],
+                    "offsets": [0],
+                    "itemsize": aligned(size + 1),
+                },
                 (3,),
             ),
         )

--- a/test/torch_np/numpy_tests/core/test_numeric.py
+++ b/test/torch_np/numpy_tests/core/test_numeric.py
@@ -616,7 +616,13 @@ class TestSeterr(TestCase):
     def test_default(self):
         err = np.geterr()
         assert_equal(
-            err, dict(divide="warn", invalid="warn", over="warn", under="ignore")
+            err,
+            {
+                "divide": "warn",
+                "invalid": "warn",
+                "over": "warn",
+                "under": "ignore",
+            },
         )
 
     def test_set(self):

--- a/test/torch_np/test_random.py
+++ b/test/torch_np/test_random.py
@@ -111,7 +111,11 @@ class TestShuffle(TestCase):
 class TestChoice(TestCase):
     @parametrize("use_numpy", [True, False])
     def test_choice(self, use_numpy):
-        kwds = dict(size=3, replace=False, p=[0.1, 0, 0.3, 0.6, 0])
+        kwds = {
+            "size": 3,
+            "replace": False,
+            "p": [0.1, 0, 0.3, 0.6, 0],
+        }
         with control_stream(use_numpy):
             tnp.random.seed(12345)
             x = tnp.random.choice(5, **kwds)

--- a/torch/_inductor/mkldnn_lowerings.py
+++ b/torch/_inductor/mkldnn_lowerings.py
@@ -369,7 +369,11 @@ def register_onednn_fusion_ops():
                         **kwargs,  # type: ignore[arg-type]
                     )
             if len(choices) == 0 or use_aten_gemm_kernels():
-                kwargs = dict(attr=attr, scalars=scalars, algorithm=algorithm)
+                kwargs = {
+                    "attr": attr,
+                    "scalars": scalars,
+                    "algorithm": algorithm,
+                }
                 if b is None:
                     kwargs["B"] = None
                 choices.append(
@@ -432,7 +436,7 @@ def register_onednn_fusion_ops():
                         **kwargs,  # type: ignore[arg-type]
                     )
             if len(choices) == 0 or use_aten_gemm_kernels():
-                kwargs = dict(attr=attr)
+                kwargs = {"attr": attr}
                 if b is None:
                     kwargs["B"] = None
                 choices.append(
@@ -908,14 +912,14 @@ def register_onednn_fusion_ops():
                         else [6, 0, 3, 1, 2, 4, 5],
                     )
             if len(choices) == 0 or use_aten_gemm_kernels():
-                kwargs = dict(
-                    output_scale=o_scale,
-                    output_zero_point=o_zero_point,
-                    output_dtype=output_dtype,
-                    post_op_name=attr,
-                    post_op_args=scalars,
-                    post_op_algorithm=algorithm,
-                )
+                kwargs = {
+                    "output_scale": o_scale,
+                    "output_zero_point": o_zero_point,
+                    "output_dtype": output_dtype,
+                    "post_op_name": attr,
+                    "post_op_args": scalars,
+                    "post_op_algorithm": algorithm,
+                }
                 if bias is None:
                     kwargs["bias"] = None
                 choices.append(
@@ -1243,18 +1247,18 @@ def register_onednn_fusion_ops():
                     )
 
             if len(choices) == 0 or use_aten_gemm_kernels():
-                kwargs = dict(
-                    output_scale=o_scale,
-                    output_zero_point=o_zero_point,
-                    output_dtype=output_dtype,
-                    other_scale=x2_scale,
-                    other_zp=x2_zp,
-                    binary_post_op=binary_attr,
-                    binary_alpha=alpha,
-                    unary_post_op=unary_attr,
-                    unary_post_op_args=unary_scalars,
-                    unary_post_op_algorithm=unary_algorithmm,
-                )
+                kwargs = {
+                    "output_scale": o_scale,
+                    "output_zero_point": o_zero_point,
+                    "output_dtype": output_dtype,
+                    "other_scale": x2_scale,
+                    "other_zp": x2_zp,
+                    "binary_post_op": binary_attr,
+                    "binary_alpha": alpha,
+                    "unary_post_op": unary_attr,
+                    "unary_post_op_args": unary_scalars,
+                    "unary_post_op_algorithm": unary_algorithmm,
+                }
                 if bias is None:
                     kwargs["bias"] = None
                 choices.append(

--- a/torch/masked/_ops.py
+++ b/torch/masked/_ops.py
@@ -58,15 +58,15 @@ def _generate_docstring(func):
     """A utility function called from tools/update_masked_docs.py
     script to update the module torch.masked._docs.py
     """
-    docstring_templates = dict(
-        reduction_signature="""\
+    docstring_templates = {
+        "reduction_signature": """\
 {function_name}(input, {operation_args}, *, {operation_kwargs}) -> Tensor""",
-        reduction_descr="""\
+        "reduction_descr": """\
 Returns {operation name} of all the elements in the :attr:`input`
 tensor along the given dimension(s) :attr:`dim` while the :attr:`input`
 elements are masked out according to the boolean tensor
 :attr:`mask`.""",
-        reduction_args="""\
+        "reduction_args": """\
 If :attr:`keepdim` is ``True``, the output tensor is of the same size
 as :attr:`input` except in the dimension(s) :attr:`dim` where it is of
 size 1. Otherwise, :attr:`dim` is squeezed (see
@@ -101,7 +101,7 @@ Args:
 
 Keyword args:
     {kwargs_declarations}""",
-        reduction_example="""\
+        "reduction_example": """\
 Example::
 
     >>> input = {example_input}
@@ -113,21 +113,21 @@ Example::
     >>> {full_function_name}(input, {example_args}, mask=mask)
     {indent_example_output}
 """,
-        reduction_identity="""\
+        "reduction_identity": """\
 The identity value of {operation name} operation, which is used to start the reduction, is ``{identity_int32}``.""",
-        reduction_identity_dtype="""\
+        "reduction_identity_dtype": """\
 The identity value of {operation name} operation, which is used to start the
 reduction, depends on input dtype. For instance, for float32, uint8,
 and int32 dtypes, the identity values are ``{identity_float32}``, ``{identity_uint8}``, and ``{identity_int32}``, respectively.""",
-        normalization_signature="""\
+        "normalization_signature": """\
 {function_name}(input, {operation_args}, *, {operation_kwargs}) -> Tensor""",
-        normalization_descr="""\
+        "normalization_descr": """\
 Returns {operation name} of all the slices in the :attr:`input` tensor
 along :attr:`dim` while the :attr:`input` elements are masked out
 according to the boolean tensor :attr:`mask`.
 
 {definition}""",
-        normalization_args="""\
+        "normalization_args": """\
 The boolean tensor :attr:`mask` defines the "validity" of
 :attr:`input` tensor elements: if :attr:`mask` element is True then
 the corresponding element in :attr:`input` tensor will be included in
@@ -152,7 +152,7 @@ Args:
 
 Keyword args:
     {kwargs_declarations}""",
-        normalization_example="""\
+        "normalization_example": """\
 Example::
 
     >>> input = {example_input}
@@ -164,7 +164,7 @@ Example::
     >>> {full_function_name}(input, {example_args}, mask=mask)
     {indent_example_output}
 """,
-    )
+    }
 
     args_and_kwargs = {
         # argument name sufficies separated by double underscore will

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -1951,7 +1951,7 @@ def _load(
     data_descripter_size64 = 24
     data_descripter_size32 = 16
     mz_uint32_max = 0xFFFFFFFF
-    offsets: dict[str, int] = dict()
+    offsets: dict[str, int] = {}
 
     def _get_offset(key, name, numel):
         """


### PR DESCRIPTION
Following the suggestion in https://github.com/pytorch/pytorch/pull/157735 by @Skylion007 and @ezyang, we ban the use of the dict keyword for literals.

I might need to continue to rebase and fix against trunk since we changed a linting rule.

The main changes are in test and benchmark. I just converted the usages to avoid dict(..).


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov