### PR TITLE
torch.distributed: add initial _dist2 prototype API

### DIFF
--- a/docs/source/distributed._dist2.md
+++ b/docs/source/distributed._dist2.md
@@ -1,0 +1,18 @@
+```{eval-rst}
+.. role:: hidden
+    :class: hidden-section
+```
+
+```{eval-rst}
+.. automodule:: torch.distributed._dist2
+    :members:
+    :undoc-members:
+    :show-inheritance:
+```
+
+```{eval-rst}
+.. autoclass:: torch.distributed.ProcessGroup
+    :members:
+    :undoc-members:
+    :show-inheritance:
+```

--- a/docs/source/distributed.md
+++ b/docs/source/distributed.md
@@ -1471,3 +1471,9 @@ If you are running single node training, it may be convenient to interactively b
 ```{eval-rst}
 .. py:module:: torch.distributed.checkpoint.state_dict
 ```
+
+```{toctree}
+:hidden:
+
+distributed._dist2
+```

--- a/test/distributed/test_dist2.py
+++ b/test/distributed/test_dist2.py
@@ -1,0 +1,89 @@
+# Owner(s): ["oncall: distributed"]
+
+import os
+from datetime import timedelta
+
+import torch
+import torch.distributed._dist2 as dist2
+from torch.testing._internal.common_distributed import (
+    MultiProcessTestCase,
+    requires_gloo,
+    requires_nccl,
+    skip_if_lt_x_gpu,
+)
+from torch.testing._internal.common_utils import run_tests
+
+
+class ProcessGroupGlooTest(MultiProcessTestCase):
+    lazy_init = False
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    def setUp(self):
+        super().setUp()
+        self._spawn_processes()
+
+    @requires_gloo()
+    def test_new_group(self):
+        os.environ["RANK"] = str(self.rank)
+        os.environ["WORLD_SIZE"] = str(self.world_size)
+        os.environ["MASTER_ADDR"] = "127.0.0.1"
+        os.environ["MASTER_PORT"] = "29500"
+
+        device = "cpu"
+
+        group = dist2.new_group(
+            backend="gloo",
+            timeout=timedelta(seconds=60),
+            device=device,
+            pg_options=None,
+        )
+
+        t = torch.rand(10, device=device)
+        group.allreduce(t).wait()
+
+
+class ProcessGroupNCCLTest(MultiProcessTestCase):
+    lazy_init = False
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    def setUp(self):
+        super().setUp()
+        self._spawn_processes()
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_new_group(self):
+        os.environ["RANK"] = str(self.rank)
+        os.environ["WORLD_SIZE"] = str(self.world_size)
+        os.environ["MASTER_ADDR"] = "127.0.0.1"
+        os.environ["MASTER_PORT"] = "29500"
+
+        device = torch.device("cuda", self.rank)
+
+        from torch.distributed import ProcessGroupNCCL
+
+        opts = ProcessGroupNCCL.Options()
+
+        group = dist2.new_group(
+            backend="nccl",
+            timeout=timedelta(seconds=60),
+            device=device,
+            pg_options=opts,
+        )
+
+        t = torch.rand(10, device=device)
+        group.allreduce(t).wait()
+
+
+if __name__ == "__main__":
+    assert not torch.cuda._initialized, (
+        "test_distributed must not have initialized CUDA context on main process"
+    )
+
+    run_tests()

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -2086,7 +2086,7 @@ communication mechanism.
               py::call_guard<py::gil_scoped_release>(),
               R"(Broadcasts the tensor to all processes in the process group.
 
-              See :func:`torch.distributed.broadcast for more details.)")
+              See :func:`torch.distributed.broadcast` for more details.)")
           .def(
               "broadcast",
               [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
@@ -2208,7 +2208,7 @@ communication mechanism.
               py::call_guard<py::gil_scoped_release>(),
               R"(Allgathers the input tensors from all processes across the process group.
 
-              See :func:`torch.distributed.all_gather: for more details.)")
+              See :func:`torch.distributed.all_gather` for more details.)")
           .def(
               "_allgather_base",
               &::c10d::ProcessGroup::_allgather_base,
@@ -2352,7 +2352,7 @@ communication mechanism.
               py::call_guard<py::gil_scoped_release>(),
               R"(Alltoalls the input tensors from all processes across the process group.
 
-              See :func:`torch.distributed.all_to_all for more details.)")
+              See :func:`torch.distributed.all_to_all` for more details.)")
           .def(
               "alltoall",
               &::c10d::ProcessGroup::alltoall,

--- a/torch/distributed/_dist2.py
+++ b/torch/distributed/_dist2.py
@@ -1,0 +1,136 @@
+"""
+Experimental Object Oriented Distributed API - torch.distributed._dist2
+=======================================================================
+
+This is an experimental new API for PyTorch Distributed. This is actively in development and subject to change or deletion entirely.
+
+This is intended as a proving ground for more flexible and object oriented distributed APIs.
+"""
+
+from datetime import timedelta
+from typing import Protocol, Union
+
+import torch
+from torch._C._distributed_c10d import Backend, ProcessGroup, Store
+from torch.distributed.rendezvous import rendezvous
+
+
+_BACKENDS: dict[str, "ProcessGroupFactory"] = {}
+
+
+class ProcessGroupFactory(Protocol):
+    """Protocol for process group factories."""
+
+    def __call__(
+        self,
+        store: Store,
+        rank: int,
+        world_size: int,
+        timeout: timedelta,
+        device: torch.device,
+        pg_options: Backend.Options,
+    ) -> ProcessGroup: ...
+
+
+def register_backend(name: str, func: ProcessGroupFactory) -> None:
+    """
+    Register a new process group backend.
+
+    Args:
+        name: The name of the backend.
+        func: The function to create the process group.
+    """
+    if name in _BACKENDS:
+        raise ValueError(f"Backend {name} already registered")
+
+    _BACKENDS[name] = func
+
+
+def _gloo_factory(
+    store: Store,
+    rank: int,
+    world_size: int,
+    timeout: timedelta,
+    device: torch.device,
+    pg_options: Backend.Options,
+) -> ProcessGroup:
+    from torch.distributed import ProcessGroupGloo
+
+    assert pg_options is None, "Gloo backend does not support options"
+
+    backend_class = ProcessGroupGloo(store, rank, world_size, timeout)
+    backend_class._set_sequence_number_for_group()
+
+    pg = ProcessGroup(store, rank, world_size)
+    pg._set_default_backend(ProcessGroup.BackendType.GLOO)
+
+    # register devices
+    pg._register_backend(device, ProcessGroup.BackendType.GLOO, backend_class)
+    pg._register_backend(
+        torch.device("cpu"), ProcessGroup.BackendType.GLOO, backend_class
+    )
+    if torch.cuda.is_available():
+        pg._register_backend(
+            torch.device("cuda"), ProcessGroup.BackendType.GLOO, backend_class
+        )
+    return pg
+
+
+def _nccl_factory(
+    store: Store,
+    rank: int,
+    world_size: int,
+    timeout: timedelta,
+    device: torch.device,
+    pg_options: Backend.Options,
+) -> ProcessGroup:
+    from torch.distributed import ProcessGroupNCCL
+
+    assert isinstance(pg_options, ProcessGroupNCCL.Options)
+
+    pg_options._timeout = timeout
+
+    backend_class = ProcessGroupNCCL(store, rank, world_size, pg_options)
+    backend_class._set_sequence_number_for_group()
+    backend_class.eager_connect_single_device(device)
+
+    pg = ProcessGroup(store, rank, world_size)
+    pg._set_default_backend(ProcessGroup.BackendType.NCCL)
+    pg._register_backend(device, ProcessGroup.BackendType.NCCL, backend_class)
+
+    return pg
+
+
+register_backend("gloo", _gloo_factory)
+register_backend("nccl", _nccl_factory)
+
+
+def new_group(
+    backend: str,
+    timeout: timedelta,
+    device: Union[str, torch.device],
+    pg_options: Backend.Options,
+) -> ProcessGroup:
+    """
+    Create a new process group with the given backend and options. This group is
+    independent and will not be globally registered and thus not usable via the
+    standard torch.distributed.* APIs.
+
+    Args:
+        backend: The backend to use for the process group.
+        timeout: The timeout for collective operations.
+        device: The device to use for the process group.
+        pg_options: The options to use for the process group.
+
+    Returns:
+        A new process group.
+    """
+    if backend not in _BACKENDS:
+        raise ValueError(f"Backend {backend} not registered")
+
+    device = torch.device(device)
+
+    store, rank, world_size = next(iter(rendezvous("env://")))
+    store.set_timeout(timeout)
+
+    return _BACKENDS[backend](store, rank, world_size, timeout, device, pg_options)


### PR DESCRIPTION
This adds the initial dist2 API as proposed in https://docs.google.com/document/d/13R-1t_yESTvmAjcCN-wQjQQadIEu0JNIdS65uZawZzY/edit?tab=t.0#heading=h.3ctbqqopzc89

This is a WIP experimental API and is a sandbox for a number of new features and quality of life improvements/changes to c10d.

Test plan:

```
pytest test/distributed/test_dist2.py
```

Docs

```
cd docs
make html
```

![Screenshot 2025-07-08 at 13-39-23 Object Oriented Distributed API - torch distributed _dist2 — PyTorch main documentation](https://github.com/user-attachments/assets/9c03a7ec-09e5-42b9-8478-1ec28bc2b6bd)


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab