### PR TITLE
Make compiled mode broadcasting use 0 strides

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -789,6 +789,8 @@ class SweepInputs2:
                     getattr(cls.gen, name1)(),
                     getattr(cls.gen, name2)(),
                 ),
+                # needs https://github.com/pytorch/pytorch/pull/144765 for exact_stride
+                # exact_stride=True,
             )
 
         test.__name__ = f"test_{cls.gen.device}_{name1}_{name2}"

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -447,7 +447,10 @@ def _maybe_broadcast(*args, preserve_cpu_scalar_tensors=True):
                 return x
 
             if not utils.same_shape(x.shape, common_shape):
-                return x.expand(common_shape)
+                n_added_dims = len(common_shape) - len(x.shape)
+                new_strides = (0,) * n_added_dims
+                new_strides += x.stride()
+                return x.as_strided(common_shape, new_strides)
 
             return x
         else:

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -447,6 +447,10 @@ def _maybe_broadcast(*args, preserve_cpu_scalar_tensors=True):
                 return x
 
             if not utils.same_shape(x.shape, common_shape):
+                # broadcast_to() and expand() both produce non-zero strides when given a
+                # new dimension of length 1, which confuses the sorting algorithm for
+                # computing output strides (see Note: [Computing output strides]).
+                # Instead, compute the strides directly and use as_strided
                 n_added_dims = len(common_shape) - len(x.shape)
                 new_strides = (0,) * n_added_dims
                 new_strides += x.stride()

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -447,14 +447,8 @@ def _maybe_broadcast(*args, preserve_cpu_scalar_tensors=True):
                 return x
 
             if not utils.same_shape(x.shape, common_shape):
-                # broadcast_to() and expand() both produce non-zero strides when given a
-                # new dimension of length 1, which confuses the sorting algorithm for
-                # computing output strides (see Note: [Computing output strides]).
-                # Instead, compute the strides directly and use as_strided
-                n_added_dims = len(common_shape) - len(x.shape)
-                new_strides = (0,) * n_added_dims
-                new_strides += x.stride()
-                return x.as_strided(common_shape, new_strides)
+                # using broadcast_to to avoid quirks with handling size-1 dimensions
+                return broadcast_to(x, common_shape)
 
             return x
         else:


### PR DESCRIPTION
Currently compiled code uses `expand` for broadcasting, which produces non-zero strides for new dimensions of length one.  This can result in inconsistent strides compared to eager mode - see the below code for an example.

This depends on https://github.com/pytorch/pytorch/pull/144765 for testing

```
def add(x, y):
    z = x + y
    return z

def transpose():
    x = torch.randn(2, 2).T
    y = torch.randn(1, 2, 1)
    out = add(x, y)
    out_comp = torch.compile(add)(x, y)
    print(f"{out=} {out.shape=} {out.stride()=}")
    print(f"{out_comp=} {out_comp.shape=} {out_comp.stride()=}")
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben