### PR TITLE
Update'unit_batch_dynamic_prepacked' tests to use ASSERT_NEAR instead of ASSERT_EQ

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/fully-connected-sparse-operator-tester.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/fully-connected-sparse-operator-tester.h
@@ -579,9 +579,9 @@ class FullyConnectedSparseOperatorTester {
 
           for (size_t i = 0; i < batchSize(); i++) {
             for (size_t c = 0; c < outputChannels(); c++) {
-              ASSERT_FLOAT_EQ(
+              ASSERT_NEAR(
                   output_dynamic[i * outputChannels() + c],
-                  accumulators_float[i * outputChannels() + c])
+                  accumulators_float[i * outputChannels() + c], 1e-3)
                   << "at " << i << ", " << c
                   << ": reference = " <<
                   accumulators_float[i * outputChannels() + c]


### PR DESCRIPTION
Summary:
This test has been flaky for a long time : https://www.internalfb.com/intern/test/844425064175383?ref_report_id=0

 {F1980088390} 

Instead of checking for absolute equality for fp values, use near equality (with epsilon) to assert

Test Plan:
**Before Fix**

✗ Fail: fbsource//xplat/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack:pytorch_qnnpack_testApple - FULLY_CONNECTED_SPARSE_OP_8x1/unit_batch_dynamic_prepacked (0.0s)
'Expected equality of these values:
  output_dynamic[i * outputChannels() + c]
    Which is: 9.9160004
  accumulators_float[i * outputChannels() + c]
    Which is: 9.9159956
at 0, 17: reference = 9.9159955978393555, optimized = 9.9160003662109375
' in file '/xplat/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack/test/fully-connected-sparse-operator-tester.h' at line 584
✗ Fail: fbsource//xplat/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack:pytorch_qnnpack_testApple - FULLY_CONNECTED_SPARSE_OP_1x4/unit_batch_dynamic_prepacked (0.0s)
'Expected equality of these values:
  output_dynamic[i * outputChannels() + c]
    Which is: -11.586517
  accumulators_float[i * outputChannels() + c]
    Which is: -11.586512
at 0, 4: reference = -11.586511611938477, optimized = -11.586517333984375
' in file '/xplat/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack/test/fully-connected-sparse-operator-tester.h' at line 584

Test UI: https://www.internalfb.com/intern/testinfra/testrun/17732923627110328
Network: Up: 60KiB  Down: 62KiB  (reSessionID-f69c66f8-efaa-4368-918f-a526e18ba7f8)
Command: test.                                                                                                                                           
Time elapsed: 26.5s
Test execution completed but the tests failed
Tests finished: Pass 58. Fail 2. Fatal 0. Skip 0. Build failure 0

------------------------------

**After Fix**
buck test @//fbobjc/mode/buck2/ios-tests fbsource//xplat/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack:pytorch_qnnpack_testApple -- --stress-runs 20 --retry 0 --retry-after-run 0 --jobs 18 --return-nonzero-on-failures --no-stress-run-sub-run -- 'unit_batch_dynamic_prepacked'
File changed: fbsource//xplat/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack/test/fully-connected-sparse-operator-tester.h
Buck UI: https://www.internalfb.com/buck2/630110d3-a45a-4d51-a110-6ef7c4f9476f
Test UI: https://www.internalfb.com/intern/testinfra/testrun/11540474139493983
Network: Up: 1.5MiB  Down: 93KiB  (reSessionID-7e51ae25-ead0-4754-86cc-2201aaa2c93d)
Executing actions. Remaining     0/39                                               2.1s exec time total
Command: test.     Finished 3 local                                                                                                                      
Time elapsed: 1:08.4s
Tests finished: Pass 60. Fail 0. Fatal 0. Skip 0. Build failure 0

Rollback Plan:

Differential Revision: D77911682




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168