### PR TITLE
[ez][CI][testing] Set upload artifacts while running to default true if in CI

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1474,7 +1474,7 @@ def parse_args():
     parser.add_argument(
         "--upload-artifacts-while-running",
         action="store_true",
-        default=IS_CI
+        default=IS_CI,
     )
 
     group = parser.add_mutually_exclusive_group()

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1474,6 +1474,7 @@ def parse_args():
     parser.add_argument(
         "--upload-artifacts-while-running",
         action="store_true",
+        default=IS_CI
     )
 
     group = parser.add_mutually_exclusive_group()


### PR DESCRIPTION
I was confused about why the distributed tests weren't showing up quickly on HUD, its because the call of run_tests.py for distributed didn't include upload artifacts while running flag, so set it to default to IS_CI so I don't need to put the flag everywhere