### PR TITLE
[PyTorch Core] MTIA supports arbitrary strides

### DIFF
--- a/c10/core/Device.h
+++ b/c10/core/Device.h
@@ -160,7 +160,7 @@ struct C10_API Device final {
   /// Return true if the device supports arbitrary strides.
   bool supports_as_strided() const noexcept {
     return type_ != DeviceType::IPU && type_ != DeviceType::XLA &&
-        type_ != DeviceType::Lazy && type_ != DeviceType::MTIA;
+        type_ != DeviceType::Lazy;
   }
 
   /// Same string as returned from operator<<.


### PR DESCRIPTION
Summary:
Currently, on MTIA the following case will return false

```
options.device().supports_as_strided()
```
As a result, whenever moving a tensor from CPU to MTIA, strides will not be preserved ([see here](https://github.com/pytorch/pytorch/blob/e5edd013ab418b8b3609cb3cb1df3804b69d8eef/aten/src/ATen/native/TensorConversions.cpp#L351)). This is a primary reason why deserializing tensors from .pt files will be contiguous.

Reviewed By: egienvalue, andyanwang

Differential Revision: D77843224




cc @egienvalue