### PR TITLE
use maybe_mark_dynamic instead of mark_dynamic for --dynamic-batch-only option

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -4070,7 +4070,7 @@ def run(runner, args, original_dir=None):
                 nonlocal marked
                 for i, s in enumerate(t.size()):
                     if s == batch_size:
-                        torch._dynamo.mark_dynamic(t, i)
+                        torch._dynamo.maybe_mark_dynamic(t, i)
                         marked = True
                         break
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #157885

When running a Dynamo benchmark with the option "--dynamic-batch-only", I do not think the intention is to fail if we end up specializing, but rather mark things dynamic initially. Specializations generally are not prohibited and can happen sometimes in contiguity checks, for example, if a size appears as a stride (see internal https://fb.workplace.com/groups/1240828337440358/permalink/1266866794836512/).
This feels like the best option here for the benchmarks. We can probably add --dynamic-batch-only-strict; not sure what's the value.
That said, maybe eventually we shall add a mode that either uses backed_size_oblivious as proxy for maximal dynamism or unbacked if the model.
adress https://github.com/pytorch/pytorch/issues/157330


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames