### PR TITLE
Back out "[Inductor] Fix epilogue fusion decision with 1 Triton caller as choice"

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -10,7 +10,6 @@ import random
 import re
 import tempfile
 import unittest
-from functools import partial
 from typing import Callable, Optional
 from unittest import mock
 from unittest.mock import MagicMock
@@ -36,11 +35,7 @@ from torch._inductor.select_algorithm import (
     TritonTemplate,
     TritonTemplateCaller,
 )
-from torch._inductor.template_heuristics import (
-    BaseConfigHeuristic,
-    CUDAConfigHeuristic,
-    GemmConfig,
-)
+from torch._inductor.template_heuristics import CUDAConfigHeuristic, GemmConfig
 from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FP8
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
@@ -1554,61 +1549,6 @@ class TestMaxAutotune(TestCase):
             for counter in counters["inductor"]:
                 if "benchmark_gpu" in counter:
                     self.assertEqual(counters["inductor"][counter], 2)
-
-    @unittest.skipIf(
-        not has_triton_tma_device(), "Need device-side TMA support in Triton"
-    )
-    @config.patch(
-        max_autotune=True,
-        max_autotune_gemm_backends="TRITON",
-        autotune_fallback_to_aten=False,
-    )
-    def test_one_triton_choice_epilogue_fusion(self):
-        """
-        Here we test the fusion case with only 1 Triton choice for mm lowering.
-        The hardcoded config itself is valid, but when fused with the torch.float32
-        case, the shared memory requirements is higher than the amount available on H100.
-
-        This test checks that the fusion does not occur in this edge case. This is important
-        for future work on lookup table for autotuned gemm configs.
-        """
-
-        def f(a, b):
-            return (a @ b).to(torch.float32)
-
-        a = torch.randn(512, 1152, device="cuda", dtype=torch.bfloat16)
-        b = torch.randn(1152, 7680, device="cuda", dtype=torch.bfloat16)
-
-        config_heuristic = BaseConfigHeuristic()
-        with config.patch(
-            {
-                "triton.enable_persistent_tma_matmul": "1",
-            }
-        ):
-            with (
-                mock.patch(
-                    "torch._inductor.kernel.mm.V.choices.get_base_mm_configs"
-                ) as base_mm_mock,
-                mock.patch(
-                    "torch._inductor.kernel.mm.V.choices.get_persistent_mm_configs"
-                ) as persistent_mm_mock,
-            ):
-                base_mm_mock.return_value = partial(
-                    config_heuristic.preprocess_mm_configs, configs=[]
-                )
-                persistent_mm_mock.return_value = partial(
-                    config_heuristic.preprocess_mm_configs,
-                    configs=[GemmConfig(256, 128, 64, 4, 8, 8)],
-                )
-
-                compiled_f = torch.compile(f)
-                out, code = run_and_get_code(compiled_f, a, b)
-
-                FileCheck().check("triton_tem_fused_mm").check(
-                    "triton_poi_fused__to_copy"
-                ).run(code[0])
-
-                torch.testing.assert_close(out, f(a, b), atol=1e-2, rtol=1e-2)
 
 
 class TestMaxAutotunePrecompile(TestCase):


### PR DESCRIPTION
Summary:
Original commit changeset: efe1b678bc43

Original Phabricator Diff: D76904773

Rollback Plan:

Differential Revision: D77980552

Here we backout of this PR [https://github.com/pytorch/pytorch/pull/156500](https://l.facebook.com/l.php?u=https%3A%2F%2Fgithub.com%2Fpytorch%2Fpytorch%2Fpull%2F156500&h=AT2T1ypjbz7JNI2eK_e_HjwcXAZTPxf9AkGAlKPSA-DVQ3S-g7KVodYu41ot1n2I1zZQFzruIUYFspGdreSGu3NxfwMGtgrdIvtgIi4n2BlS_YQEr_QRPy-ku5BXFmOPTmTCNParCadNHgtHlAHDXl1MdGI), which was created to benchmark fusions if there was only one Triton choice for a MultiTemplateBuffer, such as in the case of the GEMM config lookup table.

The PR was originally landed to always ensure fusion safety on upcasts, in which shared memory usage could exceed the hardware limit. However, given the GEMM config lookup table's goal of reducing compile time of max-autotune down to 0, this approach does not work given it adds significant autotune time. We will revert back to automatically trying to fuse epilogues onto Triton GEMMs, and it is up to the user currently to ensure that hardcoded GEMM configs are fusible. An actual solution here is to be able to determine shared memory usage ahead-of-time, and there are other fusions, not just upcasts, that can lead to more shared memory usage for Triton.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov