### PR TITLE
[profiler] update CUDA runtime kernel identification logic

### DIFF
--- a/torch/profiler/_utils.py
+++ b/torch/profiler/_utils.py
@@ -155,12 +155,14 @@ class BasicEvaluation:
 
         def is_cuda_kernel(e):
             """Check if the event is a CUDA runtime kernel."""
+            # Check if the kernel is CUDA
             if e.device_type() != DeviceType.CUDA:
                 return False
 
             name = str(getattr(e, "name", e)).lower()
-            # Exclude launcher and memory events
-            exclude_patterns = ["cudalaunch", "cudamem"]
+
+            # Exclude memory operations
+            exclude_patterns = {"mem", "cpy", "alloc", "free"}
 
             return not any(pattern in name for pattern in exclude_patterns)
 

--- a/torch/profiler/_utils.py
+++ b/torch/profiler/_utils.py
@@ -154,8 +154,15 @@ class BasicEvaluation:
             return any(name.startswith(pattern) for pattern in launch_patterns)
 
         def is_cuda_kernel(e):
-            # TODO: find a better way to identify CUDA Kernel
-            return e.device_type() == DeviceType.CUDA and "mem" not in e.name.lower()
+            """Check if the event is a CUDA runtime kernel."""
+            if e.device_type() != DeviceType.CUDA:
+                return False
+
+            name = str(getattr(e, "name", e)).lower()
+            # Exclude launcher and memory events
+            exclude_patterns = ["cudalaunch", "cudamem"]
+
+            return not any(pattern in name for pattern in exclude_patterns)
 
         cuda_launch_events = sorted(
             (e for e in cuda_event_list if is_cuda_launch_kernel(e)),


### PR DESCRIPTION
Update CUDA kernel detection to exclude memory API calls

References:
- https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY.html
- https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__EXECUTION.html