### PR TITLE
Updates to safetensors checkpoint consolidation script to be faster

### DIFF
--- a/torch/distributed/checkpoint/_consolidate_hf_safetensors.py
+++ b/torch/distributed/checkpoint/_consolidate_hf_safetensors.py
@@ -4,6 +4,7 @@ import concurrent.futures
 import json
 import logging
 import math
+import mmap
 import os
 import struct
 import time
@@ -12,6 +13,7 @@ from typing import Any, Optional
 
 import fsspec  # type: ignore[import-untyped]
 from fsspec.core import url_to_fs  # type: ignore[import-untyped]
+from fsspec.implementations.local import LocalFileSystem  # type: ignore[import-untyped]
 
 import torch
 from torch.distributed.checkpoint._hf_utils import (
@@ -199,6 +201,41 @@ def _write_metadata(
             output_data.metadata_size = f.tell()
 
 
+def _read_tensor_data_mmap(
+    input_fs: fsspec.AbstractFileSystem,
+    file_path: str,
+    start_offset: int,
+    end_offset: int,
+    metadata_size: int,
+) -> bytes:
+    """
+    Read tensor data from a safetensors file using memory mapping for efficiency.
+
+    Args:
+        input_fs: Filesystem interface for input file operations
+        file_path: Path to the safetensors file
+        start_offset: Start offset of tensor data within the data section
+        end_offset: End offset of tensor data within the data section
+        metadata_size: Size of the metadata header
+
+    Returns:
+        Raw tensor data as bytes
+    """
+    # For local files, use mmap for efficient access
+    if isinstance(input_fs, LocalFileSystem):
+        # Local file - use mmap
+        with open(file_path, "rb") as f:
+            with mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ) as mm:
+                absolute_start = metadata_size + start_offset
+                absolute_end = metadata_size + end_offset
+                return bytes(mm[absolute_start:absolute_end])
+    else:
+        # Remote file - fall back to regular read
+        with input_fs.open(file_path, "rb") as f:
+            f.seek(metadata_size + start_offset)
+            return f.read(end_offset - start_offset)
+
+
 def _process_output_file(
     input_fs: fsspec.AbstractFileSystem,
     output_fs: fsspec.AbstractFileSystem,
@@ -207,7 +244,7 @@ def _process_output_file(
     input_files_data: dict[str, _InputFileData],
 ) -> None:
     """
-    Process a single output file by writing tensor data from input files.
+    Process a single output file by writing tensor data from input files using memory mapping.
 
     This function is designed to be run in parallel for different output files.
 
@@ -216,47 +253,51 @@ def _process_output_file(
         output_fs: Filesystem interface for output file operations
         output_file: Path to the output file
         output_data: Metadata for the output file
-        input_safetensors_files: List of input safetensors file paths
-        input_metadatas: Dictionary mapping input file paths to their metadata
+        input_files_data: Dictionary mapping input file paths to their metadata
     """
     # Process each input safetensors file
     for safetensors_file in input_files_data.keys():
-        with input_fs.open(safetensors_file, "rb") as f:
-            file_metadata = input_files_data[safetensors_file].metadata
-            input_metadata_size = input_files_data[safetensors_file].metadata_size
-            for fqn, metadata in file_metadata.items():
-                if fqn == DEFAULT_EXTRA_METADATA_KEY:
-                    continue
+        file_metadata = input_files_data[safetensors_file].metadata
+        input_metadata_size = input_files_data[safetensors_file].metadata_size
 
-                # Skip if this tensor doesn't belong in this output file
-                if fqn not in output_data.fqn_data:
-                    continue
+        for fqn, metadata in file_metadata.items():
+            if fqn == DEFAULT_EXTRA_METADATA_KEY:
+                continue
 
-                data_offsets = metadata[DATA_OFFSETS_KEY]
-                # Get the tensor data as bytes
-                f.seek(input_metadata_size + data_offsets[0])
-                data_to_write = f.read(data_offsets[1])
+            # Skip if this tensor doesn't belong in this output file
+            if fqn not in output_data.fqn_data:
+                continue
 
-                # Get the offsets of this tensor shard within the full tensor
-                offsets_of_tensor_being_read = _get_dcp_custom_metadata(file_metadata)[
-                    fqn
-                ][SAVED_OFFSETS_KEY]  # type: ignore[index]
+            data_offsets = metadata[DATA_OFFSETS_KEY]
 
-                # Get metadata for this tensor in the output file
-                fqn_data = output_data.fqn_data[fqn]
+            # Use memory mapping to read tensor data efficiently
+            data_to_write = _read_tensor_data_mmap(
+                input_fs,
+                safetensors_file,
+                data_offsets[0],
+                data_offsets[1],
+                input_metadata_size,
+            )
 
-                # Write this tensor shard to the appropriate position in the output file
-                _write_sub_tensor_to_file(
-                    output_fs,
-                    data_to_write,
-                    fqn_data.dtype_size,  # Size of each element in bytes
-                    fqn_data.shape_in_file,  # Full tensor shape
-                    offsets_of_tensor_being_read,  # Where this shard belongs in the full tensor
-                    metadata[SHAPE_KEY],  # Shape of this shard
-                    output_file,
-                    # Calculate the exact byte position where this tensor data should start
-                    output_data.metadata_size + fqn_data.offset_in_file,
-                )
+            # Get the offsets of this tensor shard within the full tensor
+            custom_metadata = _get_dcp_custom_metadata(file_metadata)
+            offsets_of_tensor_being_read = custom_metadata[fqn][SAVED_OFFSETS_KEY]  # type: ignore[index]
+
+            # Get metadata for this tensor in the output file
+            fqn_data = output_data.fqn_data[fqn]
+
+            # Write this tensor shard to the appropriate position in the output file
+            _write_sub_tensor_to_file_optimized(
+                output_fs,
+                data_to_write,
+                fqn_data.dtype_size,  # Size of each element in bytes
+                fqn_data.shape_in_file,  # Full tensor shape
+                offsets_of_tensor_being_read,  # Where this shard belongs in the full tensor
+                metadata[SHAPE_KEY],  # Shape of this shard
+                output_file,
+                # Calculate the exact byte position where this tensor data should start
+                output_data.metadata_size + fqn_data.offset_in_file,
+            )
 
 
 def _write_data(
@@ -267,7 +308,7 @@ def _write_data(
     num_threads: int = 1,
 ) -> None:
     """
-    Write tensor data from input files to the output files.
+    Write tensor data from input files to the output files using memory mapping.
 
     This function reads tensor data from each input file and writes it to the appropriate
     position in the output files based on the tensor's offsets. When num_threads > 1,
@@ -497,6 +538,137 @@ def _write_element_by_element(
             out_f.write(element_data)
 
 
+def _write_sub_tensor_to_file_optimized(
+    fs: fsspec.AbstractFileSystem,
+    sub_tensor_bytes: bytes,
+    element_size: int,
+    tensor_shape: list[int],
+    sub_tensor_offsets: list[int],
+    sub_tensor_shape: list[int],
+    output_file_path: str,
+    output_start_byte: int,
+) -> None:
+    """
+    Optimized version of _write_sub_tensor_to_file with enhanced sharding pattern detection.
+
+    Uses advanced pattern detection to optimize common sharding patterns:
+    - Row-wise sharding with memory-efficient bulk copying
+    - Contiguous chunk detection for direct memory operations
+    - General fallback for arbitrary patterns
+
+    Args:
+        fs: Filesystem interface for file operations
+        sub_tensor_bytes: Raw tensor data as bytes
+        element_size: Size of each element in bytes
+        tensor_shape: Shape of the full tensor
+        sub_tensor_offsets: Starting offsets of the sub-tensor within the full tensor
+        sub_tensor_shape: Shape of the sub-tensor
+        output_file_path: Path to the output file
+        output_start_byte: Starting byte position of the tensor in the file
+    """
+    # Handle empty tensors
+    if not tensor_shape or not sub_tensor_shape:
+        return
+
+    # Enhanced row-wise sharding detection
+    if len(tensor_shape) >= 2 and len(sub_tensor_shape) >= 2:
+        # Check if this is a row-wise chunk (all dims except first are complete)
+        is_row_wise = all(
+            sub_tensor_shape[i] == tensor_shape[i] and sub_tensor_offsets[i] == 0
+            for i in range(1, len(tensor_shape))
+        )
+
+        if is_row_wise:
+            # Optimized row-wise copy using bulk memory operations
+            _write_row_wise_tensor_optimized(
+                fs,
+                sub_tensor_bytes,
+                element_size,
+                tensor_shape,
+                sub_tensor_offsets,
+                sub_tensor_shape,
+                output_file_path,
+                output_start_byte,
+            )
+            return
+
+    # Check for fully contiguous chunk
+    expected_chunk_size = math.prod(sub_tensor_shape) * element_size
+
+    if len(sub_tensor_bytes) == expected_chunk_size:
+        # Calculate if the chunk maps to a contiguous region in the tensor
+        tensor_strides = [1]
+        for i in range(len(tensor_shape) - 1, 0, -1):
+            tensor_strides.insert(0, tensor_strides[0] * tensor_shape[i])
+
+        # Check if chunk represents a contiguous slice
+        chunk_start_pos = sum(
+            offset * stride
+            for offset, stride in zip(sub_tensor_offsets, tensor_strides)
+        )
+
+        # For simple contiguous cases, use direct copy
+        if all(
+            offset + size <= dim
+            for offset, size, dim in zip(
+                sub_tensor_offsets, sub_tensor_shape, tensor_shape
+            )
+        ):
+            tensor_start_byte = output_start_byte + chunk_start_pos * element_size
+
+            with fs.open(output_file_path, "r+b") as out_f:
+                out_f.seek(tensor_start_byte)
+                out_f.write(sub_tensor_bytes)
+            return
+
+    # Fall back to the original implementation for complex patterns
+    _write_sub_tensor_to_file(
+        fs,
+        bytearray(sub_tensor_bytes),
+        element_size,
+        tensor_shape,
+        sub_tensor_offsets,
+        sub_tensor_shape,
+        output_file_path,
+        output_start_byte,
+    )
+
+
+def _write_row_wise_tensor_optimized(
+    fs: fsspec.AbstractFileSystem,
+    sub_tensor_bytes: bytes,
+    element_size: int,
+    tensor_shape: list[int],
+    sub_tensor_offsets: list[int],
+    sub_tensor_shape: list[int],
+    output_file_path: str,
+    output_start_byte: int,
+) -> None:
+    """
+    Optimized row-wise tensor writing using bulk memory operations.
+
+    This function an optimization strategy:
+    - Direct memory copy for contiguous rows
+    - Minimal file seeking operations
+    - Bulk data transfer instead of element-by-element
+    """
+    with fs.open(output_file_path, "r+b") as out_f:
+        # Optimized row-wise copy
+        elements_per_row = math.prod(tensor_shape[1:])
+        bytes_per_row = elements_per_row * element_size
+
+        start_row = sub_tensor_offsets[0]
+        num_rows = sub_tensor_shape[0]
+
+        # Calculate byte positions
+        tensor_start_byte = output_start_byte + start_row * bytes_per_row
+        chunk_size_bytes = num_rows * bytes_per_row
+
+        # Direct memory copy for contiguous rows
+        out_f.seek(tensor_start_byte)
+        out_f.write(sub_tensor_bytes[:chunk_size_bytes])
+
+
 def _write_sub_tensor_to_file(
     fs: fsspec.AbstractFileSystem,
     sub_tensor_bytes: bytearray,
@@ -508,7 +680,7 @@ def _write_sub_tensor_to_file(
     output_start_byte: int,
 ) -> None:
     """
-    Writes a sub-tensor from a byte array into a file representing the full tensor at specified offsets.
+    Original implementation - writes a sub-tensor from a byte array into a file representing the full tensor at specified offsets.
 
     This function handles the complex task of placing a tensor shard (sub-tensor) at the correct
     position within the consolidated tensor file. It works by calculating the exact byte offsets
@@ -519,6 +691,7 @@ def _write_sub_tensor_to_file(
     - Any other arbitrary sharding pattern (general element-by-element approach)
 
     Args:
+        fs: Filesystem interface for file operations
         sub_tensor_bytes: Byte array containing the sub-tensor data
         element_size: The size of each element in bytes
         tensor_shape: The shape of the overall tensor (list)


### PR DESCRIPTION
Summary:
- adding mmap-ing
- more efficient writing in larger chunks

latency from ~150s to ~6s for simple row-wise consolidation of a 7gb model sharded across 4 ranks

Test Plan:
ran consolidation with the following code:

```
from torch.distributed.checkpoint._consolidate_hf_safetensors import consolidate_safetensors_files
import time

start_time = time.time()
consolidate_safetensors_files(base_path, consolidated_path)
end_time = time.time()
print(f"Time taken: {end_time - start_time} seconds")
```

With the old code this was taking a couple minutes and this is now down to ~6s.
Internal users can find the tensor shards in the manifold path: manifold://ankita_test_bucket/tree/safetensors

Rollback Plan:

Differential Revision: D77960054




cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k