### PR TITLE
[cherry-pick] temporarily disabling generation of weblinks for torch v2.8 & removing string literals for weblink generation

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_compile.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_compile.py
@@ -548,8 +548,7 @@ Unsupported Tensor.backward() call
   Hint: This graph break is fundamental - it is unlikely that Dynamo will ever be able to trace through your code. Consider finding a workaround.
 
   Developer debug context: call_method TensorVariable() backward () {}
-
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0123""",  # noqa: B950
+""",  # noqa: B950
                     )
                 else:
                     self.assertGreater(len(counters["graph_break"]), 1)

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -61,7 +61,6 @@ Dynamic shape operator
 
   Developer debug context: aten.nonzero.default
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0036
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -83,7 +82,6 @@ Dynamic shape operator (no meta kernel)
 
   Developer debug context: aten.linalg_lstsq.default
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0037
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -106,7 +104,6 @@ Unsupported Tensor.item() call with capture_scalar_outputs=False
 
   Developer debug context: call_method TensorVariable() item () {}
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0124
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -130,7 +127,6 @@ Data dependent operator
 
   Developer debug context: aten.equal.default
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0033
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -158,7 +154,6 @@ sort with non-constant keys
 
   Developer debug context: TensorVariable()
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0207
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -183,7 +178,6 @@ Unsupported method call
 
   Developer debug context: call_method UserDefinedObjectVariable(zip) __iter__ () {}
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0156
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -211,7 +205,6 @@ Unsupported method call
 
   Developer debug context: call_method UserDefinedObjectVariable(dict_items) __iter__ () {}
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0156
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -235,7 +228,6 @@ Unsupported function call
 
   Developer debug context: call_function UserDefinedObjectVariable(zip) [] {}
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0147
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -259,7 +251,6 @@ Unsupported context manager
 
   Developer debug context: Attempted SETUP_WITH/BEFORE_WITH on ConstantVariable(int: 3)
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0142
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -287,10 +278,7 @@ Backend compiler exception
     Exception:test
     Traceback:
       File "test_error_messages.py", line N, in fn
-        return x + 1
-
-
- For more details about this graph break, please visit: None""",
+        return x + 1""",
         )
 
     def test_unsupported_builtin(self):
@@ -309,7 +297,6 @@ Failed to trace builtin operator
 
   Developer debug context: builtin print [<class 'torch._dynamo.variables.constant.ConstantVariable'>] False
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0059
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -335,7 +322,6 @@ Attempted to call function marked as skipped
 
   Developer debug context: module: unittest.case, qualname: skip, skip reason: <missing reason>
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0007
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -357,7 +343,6 @@ Attempted to call function marked as skipped
 
   Developer debug context: module: torch._dynamo.decorators, qualname: disable, skip reason: <missing reason>
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0007
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -386,7 +371,6 @@ Attempted to inline function marked as skipped
 
   Developer debug context: qualname: skip, name: skip, filename: `case.py`, skip reason: skipped according trace_rules.lookup unittest
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0008
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -408,7 +392,6 @@ Call to `torch._dynamo.graph_break()`
 
   Developer debug context: Called `torch._dynamo.graph_break()` with args `[]`, kwargs `{}`
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0025
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -429,7 +412,6 @@ Call to `torch._dynamo.graph_break()`
 
   Developer debug context: Called `torch._dynamo.graph_break()` with args `[]`, kwargs `{'msg': ConstantVariable(str: 'test graph break')}`
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0025
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -451,7 +433,6 @@ Attempted to call function marked as skipped
 
   Developer debug context: module: _warnings, qualname: warn, skip reason: <missing reason>
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0007
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -479,8 +460,7 @@ Attempted to call function marked as skipped
   Hint: Consider using torch.utils._pytree - https://github.com/pytorch/pytorch/blob/main/torch/utils/_pytree.py
 
   Developer debug context: module: optree._C, qualname: PyCapsule.flatten, skip reason: <missing reason>
-
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0007""",
+""",
         )
 
     @scoped_load_inline
@@ -526,8 +506,7 @@ Attempted to call function marked as skipped
   Hint: If it is a third-party C/C++ Python extension, please either wrap it into a PyTorch-understood custom operator (see https://pytorch.org/tutorials/advanced/custom_ops_landing_page.html for more details) or, if it is traceable, use `torch.compiler.allow_in_graph`.
 
   Developer debug context: module: mylib, qualname: PyCapsule.foobar, skip reason: <missing reason>
-
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0007""",
+""",
         )
 
         cpp_source = """
@@ -579,7 +558,6 @@ Dynamic slicing with Tensor arguments
 
   Developer debug context: SliceVariable start: ConstantVariable(NoneType: None), stop: TensorVariable(), step: ConstantVariable(NoneType: None)
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0038
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -601,7 +579,6 @@ Observed exception
 
   Developer debug context: raised exception ExceptionVariable(<class 'RuntimeError'>)
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0088
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -627,7 +604,6 @@ Uninitialized nn.Module
 
   Developer debug context: Foo
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0119
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -656,7 +632,6 @@ Unsupported nn.Module attribute type
 
   Developer debug context: nn.Module subclass: Foo, name: attr, attribute type: module
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0161
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -686,7 +661,6 @@ Graph break under GenericContextWrappingVariable
 
   Developer debug context: Active generic context managers: [GenericContextWrappingVariable(GenericCtxMgr), GenericContextWrappingVariable(GenericCtxMgr)]
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0066
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -701,8 +675,7 @@ Call to `torch._dynamo.graph_break()`
   Hint: Remove the `torch._dynamo.graph_break()` call.
 
   Developer debug context: Called `torch._dynamo.graph_break()` with args `[]`, kwargs `{}`
-
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0025""",
+""",
         )
 
     def test_load_build_class(self):
@@ -723,7 +696,6 @@ LOAD_BUILD_CLASS bytecode not supported
 
   Developer debug context:
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0075
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -756,7 +728,6 @@ Missing bytecode handler
   Hint: It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues.
 
   Developer debug context: GET_AITER with args (<torch._dynamo.symbolic_convert.InstructionTranslator object at 0xmem_addr>, Instruction(GET_AITER)
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0082
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -787,7 +758,6 @@ Reconstruction failure
 
   Developer debug context: UserMethodVariable(<function GraphBreakMessagesTest.test_reconstruction_failure.<locals>.Foo.meth at 0xmem_addr>, UserDefinedObjectVariable(Foo))
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0092
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -823,7 +793,6 @@ Graph Break Reason: Call to `torch._dynamo.graph_break()`
 
   Developer debug context: Called `torch._dynamo.graph_break()` with args `[]`, kwargs `{}`
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0025
 User code traceback:
   File "test_error_messages.py", line N, in test_reconstruction_failure_gb
     torch.compile(fn, backend="eager")()
@@ -843,7 +812,6 @@ Reconstruction failure
 
   Developer debug context: UserMethodVariable(<function GraphBreakMessagesTest.test_reconstruction_failure_gb.<locals>.Foo.meth at 0xmem_addr>, UserDefinedObjectVariable(Foo))
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0092
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -872,7 +840,6 @@ NotImplementedError/UnsupportedFakeTensorException when running FX node
 
   Developer debug context:
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0087
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -896,7 +863,6 @@ Data-dependent branching
 
   Developer debug context: attempted to jump with TensorVariable()
 
- For more details about this graph break, please visit: None
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -963,7 +929,6 @@ Data-dependent assertion failed (cannot compile partial graph)
 
   Developer debug context: value: ConstantVariable(bool: False)
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0034
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -1007,7 +972,6 @@ torch._dynamo.exc.Unsupported: Call to `torch._dynamo.graph_break()`
 
   Developer debug context: Called `torch._dynamo.graph_break()` with args `[]`, kwargs `{}`
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0025
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -1060,7 +1024,6 @@ torch._dynamo.exc.Unsupported: Call to `torch._dynamo.graph_break()`
 
   Developer debug context: Called `torch._dynamo.graph_break()` with args `[]`, kwargs `{}`
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0025
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -1096,7 +1059,6 @@ Graph Break Reason: Call to `torch._dynamo.graph_break()`
 
   Developer debug context: Called `torch._dynamo.graph_break()` with args `[]`, kwargs `{}`
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0025
 User code traceback:
   File "test_error_messages.py", line N, in test_nested_compile_user_frames
     torch.compile(fn, backend="eager")(torch.randn(3))
@@ -1210,7 +1172,6 @@ Graph Break Reason: Call to `torch._dynamo.graph_break()`
 
   Developer debug context: Called `torch._dynamo.graph_break()` with args `[]`, kwargs `{}`
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0025
 User code traceback:
   File "test_error_messages.py", line N, in test_graph_break_traceback_collapsed_resume_frames
     f1(torch.randn(3))
@@ -1300,7 +1261,6 @@ Skip calling `torch.compiler.disable()`d function
 
   Developer debug context: <function GraphBreakMessagesTest.test_disable_message.<locals>.f at 0xmem_addr>
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0098
 
 from user code:
    File "test_error_messages.py", line N, in outer
@@ -1322,7 +1282,6 @@ Skip calling `torch.compiler.disable()`d function
 
   Developer debug context: <function GraphBreakMessagesTest.test_disable_message.<locals>.g at 0xmem_addr>
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0098
 
 from user code:
    File "test_error_messages.py", line N, in outer
@@ -1348,7 +1307,6 @@ Unsupported function call (delayed)
 
   Developer debug context: source: LocalSource(local_name='fn', is_input=True, dynamism=None, is_derefed_cell_contents=False)
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0148
 
 from user code:
    File "test_error_messages.py", line N, in outer

--- a/test/dynamo/test_exc.py
+++ b/test/dynamo/test_exc.py
@@ -43,7 +43,6 @@ Call to `torch._dynamo.graph_break()`
 
   Developer debug context: Called `torch._dynamo.graph_break()` with args `[]`, kwargs `{}`
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0025
 
 from user code:
    File "test_exc.py", line N, in fn001
@@ -183,7 +182,6 @@ Graph Break Reason: Call to `torch._dynamo.graph_break()`
 
   Developer debug context: Called `torch._dynamo.graph_break()` with args `[]`, kwargs `{}`
 
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0025
 User code traceback:
   File "test_exc.py", line N, in test_graph_break_log
     torch.compile(fn001, backend="eager")(torch.randn(1))

--- a/test/dynamo/test_reorder_logs.py
+++ b/test/dynamo/test_reorder_logs.py
@@ -210,8 +210,7 @@ Unsupported Tensor.item() call with capture_scalar_outputs=False
   Hint: Set `torch._dynamo.config.capture_scalar_outputs = True` or `export TORCHDYNAMO_CAPTURE_SCALAR_OUTPUTS=1` to include these operations in the captured graph.
 
   Developer debug context: call_method TensorVariable() item () {}
-
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0124""",  # noqa: B950
+""",  # noqa: B950
         )
 
 

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -1817,8 +1817,7 @@ Dynamic shape operator
   Hint: Enable tracing of dynamic shape operators with `torch._dynamo.config.capture_dynamic_output_shape_ops = True`
 
   Developer debug context: _torch_testing.numpy_nonzero.default
-
- For more details about this graph break, please visit: https://compile-graph-break-site.vercel.app/gb/GB0036""",
+""",
         )
 
     # pre-existing problem: torch.compile(dynamic=True) will, by default,

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -494,46 +494,6 @@ def format_graph_break_message(
     return msg
 
 
-'''
-@lru_cache(maxsize=1)
-def _load_graph_break_registry() -> dict[str, Any]:
-    """
-    Loads the graph break registry from JSON file with caching.
-    """
-    try:
-        script_dir = Path(__file__).resolve().parent
-        registry_path = script_dir / "graph_break_registry.json"
-        with registry_path.open() as f:
-            return json.load(f)
-    except (FileNotFoundError, json.JSONDecodeError) as e:
-        log.error("Error accessing the registry file: %s", e)
-        return {}
-
-'''
-
-'''
-def get_gbid_documentation_link(gb_type: str) -> Optional[str]:
-    """
-    Retrieves the GBID documentation link for a given graph break type.
-
-    Args:
-        gb_type: The graph break type to look up.
-
-    Returns:
-        A string containing the documentation URL if found, otherwise None.
-    """
-    GRAPH_BREAK_SITE_URL = "https://compile-graph-break-site.vercel.app/gb/"
-
-    registry = _load_graph_break_registry()
-
-    for k, v in registry.items():
-        if v and v[0].get("Gb_type") == gb_type:
-            return f"{GRAPH_BREAK_SITE_URL}{k}"
-
-    return "None"
-'''
-
-
 # TODO replace old unimplemented later
 def unimplemented_v2(
     gb_type: str,

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -26,15 +26,12 @@ Error Formatting:
     - Debugging utilities for error reporting
 """
 
-import json
 import logging
 import os
 import re
 import textwrap
 import typing
 from enum import auto, Enum
-from functools import lru_cache
-from pathlib import Path
 from traceback import extract_stack, format_exc, format_list, StackSummary
 from typing import Any, NoReturn, Optional, TYPE_CHECKING
 
@@ -497,6 +494,7 @@ def format_graph_break_message(
     return msg
 
 
+'''
 @lru_cache(maxsize=1)
 def _load_graph_break_registry() -> dict[str, Any]:
     """
@@ -511,7 +509,9 @@ def _load_graph_break_registry() -> dict[str, Any]:
         log.error("Error accessing the registry file: %s", e)
         return {}
 
+'''
 
+'''
 def get_gbid_documentation_link(gb_type: str) -> Optional[str]:
     """
     Retrieves the GBID documentation link for a given graph break type.
@@ -531,6 +531,7 @@ def get_gbid_documentation_link(gb_type: str) -> Optional[str]:
             return f"{GRAPH_BREAK_SITE_URL}{k}"
 
     return "None"
+'''
 
 
 # TODO replace old unimplemented later
@@ -555,8 +556,10 @@ def unimplemented_v2(
 
     msg = format_graph_break_message(gb_type, context, explanation, hints)
 
-    documentation_link = get_gbid_documentation_link(gb_type)
-    msg += f"\n For more details about this graph break, please visit: {documentation_link}"
+    # Temporarily disabling the generation of the weblinks in error message
+
+    # documentation_link = get_gbid_documentation_link(gb_type)
+    # msg += f"\n For more details about this graph break, please visit: {documentation_link}"
 
     if log_warning:
         log.warning(msg)


### PR DESCRIPTION
Cherry Picked trunk commits: https://github.com/pytorch/pytorch/pull/157299 and https://github.com/pytorch/pytorch/pull/157820 onto release/2.8 branch to remove generation of weblinks and string literals.


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames