### PR TITLE
fix MPCT destroy_pg call

### DIFF
--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -1542,10 +1542,11 @@ class PipelineScheduleMulti(_PipelineSchedule):
                 _wait_batch_p2p(_batch_p2p(ops))
             except Exception as e:
                 logger.error(
-                    "[Rank %s] pipeline schedule %s caught the following exception \
-                     at time_step %s when running action %s",
+                    "[Rank %s] pipeline schedule %s caught the following exception '%s' \
+at time_step %s when running action %s",
                     self.rank,
                     self.__class__.__name__,
+                    str(e),
                     time_step,
                     action,
                 )

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -1616,6 +1616,7 @@ class MultiProcContinousTest(TestCase):
 
     @classmethod
     def _worker_loop(cls, rank, world_size, rdvz_file, task_queue, completion_queue):
+        raised_exception = False
         # Sub tests are going to access these values, check first
         assert 0 <= rank < world_size
         # set class variables for the test class
@@ -1641,6 +1642,7 @@ class MultiProcContinousTest(TestCase):
                 cls._run_test_given_id(test_id)
                 completion_queue.put(test_id)
             except BaseException as ex:
+                raised_exception = True
                 # Send the exception and stack trace back to the dispatcher
                 exc_info = sys.exc_info()
                 tb_str = "".join(traceback.format_exception(*exc_info))
@@ -1651,7 +1653,12 @@ class MultiProcContinousTest(TestCase):
 
         # Termination
         logger.info("Terminating ...")
-        c10d.destroy_process_group()
+        # Calling destroy_process_group when workers have exceptions
+        # while others are doing collectives will cause a deadlock since
+        # it waits for enqueued collectives to finish.
+        # Only call this on a clean exit path
+        if not raised_exception:
+            c10d.destroy_process_group()
 
     @classmethod
     def _spawn_processes(cls, world_size) -> None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #157795
* __->__ #157952
* #157589

I was seeing hangs / exceptions not raising in some cases. Only call `c10d.destroy_process_group()` for `MultiProcessContinuousTest` in the clean exit case.

cc @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k