### PR TITLE
[Typing] Improve typing in PyTorch

### DIFF
--- a/test/test_futures.py
+++ b/test/test_futures.py
@@ -7,7 +7,7 @@ import torch
 import unittest
 from torch.futures import Future
 from torch.testing._internal.common_utils import IS_WINDOWS, TestCase, TemporaryFileName, run_tests
-from typing import TypeVar
+from typing import Any, TypeVar
 
 T = TypeVar("T")
 
@@ -22,7 +22,7 @@ class TestFuture(TestCase):
         error_msg = "Intentional Value Error"
         value_error = ValueError(error_msg)
 
-        f = Future[T]()  # type: ignore[valid-type]
+        f = Future[Any]()
         # Set exception
         f.set_exception(value_error)
         # Exception should throw on wait
@@ -30,7 +30,7 @@ class TestFuture(TestCase):
             f.wait()
 
         # Exception should also throw on value
-        f = Future[T]()  # type: ignore[valid-type]
+        f = Future[Any]()
         f.set_exception(value_error)
         with self.assertRaisesRegex(ValueError, "Intentional"):
             f.value()
@@ -38,7 +38,7 @@ class TestFuture(TestCase):
         def cb(fut):
             fut.value()
 
-        f = Future[T]()  # type: ignore[valid-type]
+        f = Future[Any]()
         f.set_exception(value_error)
 
         with self.assertRaisesRegex(RuntimeError, "Got the following error"):
@@ -55,7 +55,7 @@ class TestFuture(TestCase):
             with self.assertRaisesRegex(ValueError, "Intentional"):
                 f.wait()
 
-        f = Future[T]()  # type: ignore[valid-type]
+        f = Future[Any]()
         t = threading.Thread(target=wait_future, args=(f, ))
         t.start()
         f.set_exception(value_error)
@@ -69,7 +69,7 @@ class TestFuture(TestCase):
             with self.assertRaisesRegex(RuntimeError, "Got the following error"):
                 fut.wait()
 
-        f = Future[T]()  # type: ignore[valid-type]
+        f = Future[Any]()
         t = threading.Thread(target=then_future, args=(f, ))
         t.start()
         f.set_exception(value_error)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -67,7 +67,8 @@ from torch.testing._internal.common_dtype import (
 )
 from torch.testing._internal.two_tensor import TwoTensor
 
-if TEST_WITH_TORCHINDUCTOR:
+from typing import TYPE_CHECKING
+if TEST_WITH_TORCHINDUCTOR or TYPE_CHECKING:
     from torch._inductor.test_case import TestCase
 else:
     from torch.testing._internal.common_utils import TestCase  # type: ignore[assignment]

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -62,9 +62,6 @@ HAS_CUDA = torch.cuda.is_available()
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
-# mypy: disable-error-code="name-defined"
-
-
 class RandomDatasetMock(torch.utils.data.Dataset):
     def __getitem__(self, index):
         return torch.tensor([torch.rand(1).item(), random.uniform(0, 1)])
@@ -856,6 +853,8 @@ class TestHipify(TestCase):
 
 class TestHipifyTrie(TestCase):
     def setUp(self):
+        import torch.utils.hipify.hipify_python
+
         self.trie = torch.utils.hipify.hipify_python.Trie()
 
     def test_add_and_search_trie(self):
@@ -1209,9 +1208,9 @@ def _deprecated_api(x, y=15):
 class TestDeprecate(TestCase):
     def test_deprecated(self):
         with self.assertWarnsRegex(Warning, "is DEPRECATED"):
-            deprecated_api(1, 2)  # noqa: F821
+            deprecated_api(1, 2)  # type: ignore[name-defined] # noqa: F821
         with self.assertWarnsRegex(Warning, "is DEPRECATED"):
-            deprecated_api(1, y=2)  # noqa: F821
+            deprecated_api(1, y=2)  # type: ignore[name-defined] # noqa: F821
         _deprecated_api(1, 2)
         _deprecated_api(1, y=2)
 

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1649,7 +1649,7 @@ def is_warn_always_enabled() -> builtins.bool:
 def _check_with(
     error_type,
     cond: _Union[builtins.bool, SymBool],
-    message: _Callable[[], str],
+    message: _Union[_Callable[[], str], None],
 ):  # noqa: F811
     if not isinstance(cond, (builtins.bool, SymBool)):
         raise TypeError(f"cond must be a bool, but got {type(cond)}")

--- a/torch/_custom_op/impl.py
+++ b/torch/_custom_op/impl.py
@@ -687,9 +687,9 @@ def _find_custom_op(qualname, also_check_torch_library=False):
 
 
 def get_abstract_impl(qualname):
-    if qualname not in torch._custom_op.impl.global_registry:
+    if qualname not in global_registry:
         return None
-    custom_op = torch._custom_op.impl.global_registry[qualname]
+    custom_op = global_registry[qualname]
     if custom_op is None:
         return None
     if not custom_op._has_impl("abstract"):

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -2131,12 +2131,12 @@ def _to_copy(
     if device is not None and device != x_tensor.device:
         # avoid conversions on cpu
         if dtype is not None and device.type == "cpu":
-            x_tensor = torch._prims.convert_element_type(x_tensor, dtype)
+            x_tensor = prims.convert_element_type(x_tensor, dtype)
             dtype_converted = True
-        x_tensor = torch._prims.device_put(x_tensor, device, non_blocking)
+        x_tensor = prims.device_put(x_tensor, device, non_blocking)
 
     if dtype is not None and not dtype_converted:
-        x_tensor = torch._prims.convert_element_type(x_tensor, dtype)
+        x_tensor = prims.convert_element_type(x_tensor, dtype)
         dtype_converted = True
 
     if memory_format is not None:  # no ref/prim for memory format

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -43,6 +43,7 @@ from typing import Any, Callable, NoReturn, Optional, TYPE_CHECKING, Union
 from weakref import ReferenceType
 
 import torch
+import torch._guards
 import torch.overrides
 import torch.utils._device
 from torch._C._dynamo.eval_frame import code_framelocals_names

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -48,6 +48,7 @@ from typing import Any, Callable, cast, NoReturn, Optional, TYPE_CHECKING, Union
 from unittest.mock import patch
 
 import torch
+import torch._guards
 import torch._logging
 from torch._dynamo.exc import TensorifyScalarRestartAnalysis
 from torch._guards import tracing, TracingContext

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -66,6 +66,7 @@ from typing_extensions import Literal, TypeAlias, TypeGuard, TypeIs
 
 import torch
 import torch._functorch.config
+import torch._guards
 import torch.fx.experimental.symbolic_shapes
 import torch.utils._pytree as pytree
 from torch import fx
@@ -1393,7 +1394,7 @@ class CompilationMetrics:
             ),
         }
 
-        all_metrics = {**legacy_metrics, **metrics}
+        all_metrics: dict[str, Any] = {**legacy_metrics, **metrics}
 
         # Processing before logging:
         all_metrics["inductor_fx_remote_cache_hit_keys"] = collection_to_str(

--- a/torch/_export/non_strict_utils.py
+++ b/torch/_export/non_strict_utils.py
@@ -11,6 +11,7 @@ from contextlib import contextmanager
 from typing import Any, Callable, Optional, TYPE_CHECKING, Union
 
 import torch
+import torch._guards
 import torch.utils._pytree as pytree
 from torch._dynamo.source import (
     AttrSource,

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -22,6 +22,7 @@ from typing import Any, Callable, Generic, Optional, TYPE_CHECKING, TypeVar, Uni
 from typing_extensions import override
 
 import torch
+import torch._guards
 from torch._dynamo.precompile_context import PrecompileCacheArtifact, PrecompileContext
 from torch._dynamo.trace_rules import torch_non_c_binding_in_graph_functions
 from torch._dynamo.utils import (

--- a/torch/_functorch/_aot_autograd/input_output_analysis.py
+++ b/torch/_functorch/_aot_autograd/input_output_analysis.py
@@ -15,6 +15,7 @@ import itertools
 from typing import Any, Optional, Union
 
 import torch
+import torch._guards
 import torch.utils._pytree as pytree
 from torch import Tensor
 from torch._C._dynamo.guards import compute_overlapping_tensors

--- a/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
@@ -21,6 +21,7 @@ from contextlib import nullcontext
 from typing import Any, Callable, Optional, TYPE_CHECKING
 
 import torch
+import torch._guards
 import torch.utils._pytree as pytree
 import torch.utils.dlpack
 from torch import Tensor

--- a/torch/_functorch/_aot_autograd/logging_utils.py
+++ b/torch/_functorch/_aot_autograd/logging_utils.py
@@ -8,6 +8,7 @@ import collections
 from contextlib import contextmanager
 
 import torch
+import torch._guards
 import torch.fx.traceback as fx_traceback
 
 

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -19,6 +19,7 @@ from functools import wraps
 from typing import Any, Callable, Optional, TYPE_CHECKING, Union
 
 import torch
+import torch._guards
 import torch.utils.dlpack
 from torch import Tensor
 from torch._dynamo import config as dynamo_config

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -15,6 +15,7 @@ from typing import Any, Callable, Optional, TYPE_CHECKING, Union
 
 import torch
 import torch._inductor.inductor_prims
+import torch._prims.rng_prims
 import torch.distributed
 import torch.fx as fx
 import torch.utils._pytree as pytree

--- a/torch/_higher_order_ops/invoke_subgraph.py
+++ b/torch/_higher_order_ops/invoke_subgraph.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Union
 
 import torch
+import torch._guards
 import torch.utils._pytree as pytree
 from torch._C import DispatchKey
 from torch._dispatch.python import suspend_functionalization

--- a/torch/_higher_order_ops/while_loop.py
+++ b/torch/_higher_order_ops/while_loop.py
@@ -3,6 +3,7 @@ import contextlib
 from typing import Callable, Union
 
 import torch
+import torch._guards
 import torch.utils._pytree as pytree
 from torch._C import DispatchKey
 from torch._higher_order_ops.utils import (

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -16,6 +16,7 @@ from time import time, time_ns
 from typing import Any, Callable, Optional, TYPE_CHECKING
 
 import torch
+import torch._guards
 from torch._dynamo.device_interface import get_registered_device_interfaces
 from torch._dynamo.utils import (
     counters,

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -6,7 +6,9 @@ import dataclasses
 import functools
 import hashlib
 import importlib
+import importlib.machinery
 import importlib.resources
+import importlib.util
 import io
 import itertools
 import json
@@ -46,6 +48,7 @@ from typing import (
 from typing_extensions import override, Self
 
 import torch
+import torch._guards
 import torch.distributed as dist
 from torch import SymInt, Tensor
 from torch._dynamo.exc import SkipFrame

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -19,6 +19,7 @@ import sympy
 from sympy import Expr
 
 import torch
+import torch._guards
 import torch._ops
 import torch.utils._pytree as pytree
 from torch import dtype as torch_dtype

--- a/torch/_inductor/comms.py
+++ b/torch/_inductor/comms.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import heapq
 import importlib
+import importlib.util
 import itertools
 import logging
 import operator

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -22,6 +22,7 @@ from typing import Any, Callable, Optional, TYPE_CHECKING, TypeVar, Union
 from typing_extensions import Never, override, ParamSpec, Protocol, TypedDict, Unpack
 from unittest import mock
 
+import torch._guards
 import torch._inductor.async_compile
 import torch.fx
 import torch.utils._pytree as pytree

--- a/torch/_inductor/compile_fx_ext.py
+++ b/torch/_inductor/compile_fx_ext.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from typing import Any, Optional, TYPE_CHECKING, Union
 from typing_extensions import final, override, Self, TypeGuard
 
+import torch._guards
 import torch._inductor.async_compile  # noqa: F401 required to warm up AsyncCompile pools
 import torch.fx
 from torch._inductor.codecache import BypassFxGraphCache, FxGraphCache

--- a/torch/_inductor/freezing.py
+++ b/torch/_inductor/freezing.py
@@ -7,6 +7,7 @@ import weakref
 from typing import Any, Optional
 
 import torch
+import torch._guards
 import torch.utils._pytree as pytree
 from torch._dynamo.utils import dynamo_timed, lazy_format_graph_code
 from torch._functorch.aot_autograd import MutationType

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -17,7 +17,9 @@ import sympy
 from sympy import Expr
 
 import torch
+import torch._guards
 import torch._logging
+import torch._prims.rng_prims
 import torch.fx
 from torch import device, Tensor
 from torch._decomp import get_decompositions

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -43,6 +43,7 @@ from sympy import Expr, Integer, Symbol
 import torch._export.serde.schema as export_schema
 import torch._library.utils as library_utils
 import torch._logging
+import torch._prims.rng_prims
 import torch.fx
 import torch.utils._pytree as pytree
 from torch._dynamo.utils import identity

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -20,6 +20,7 @@ from unittest.mock import patch
 import sympy
 
 import torch
+import torch._prims.rng_prims
 import torch.ao.quantization.fx._decomposed
 import torch.fx
 import torch.utils._pytree as pytree

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -17,6 +17,8 @@ from collections import Counter, defaultdict
 from typing import Any, Callable, Generic, Optional, TYPE_CHECKING, TypeVar, Union
 from typing_extensions import ParamSpec, TypeAlias
 
+import torch._prims.rng_prims
+
 
 if TYPE_CHECKING:
     from collections.abc import Sequence

--- a/torch/_inductor/standalone_compile.py
+++ b/torch/_inductor/standalone_compile.py
@@ -8,6 +8,7 @@ import shutil
 from contextlib import AbstractContextManager, nullcontext
 from typing import Any, Callable, Literal, Optional, TYPE_CHECKING
 
+import torch._guards
 import torch.fx
 from torch._dynamo.utils import dynamo_timed
 from torch._inductor.cudagraph_utils import BoxedDeviceIndex

--- a/torch/_lobpcg.py
+++ b/torch/_lobpcg.py
@@ -6,6 +6,7 @@
 from typing import Optional
 
 import torch
+import torch._jit_internal
 from torch import _linalg_utils as _utils, Tensor
 from torch.overrides import handle_torch_function, has_torch_function
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -20,6 +20,7 @@ from typing_extensions import Self, TypeGuard
 from weakref import ReferenceType
 
 import torch
+import torch._guards
 import torch._library.utils as library_utils
 from torch import SymBool, SymFloat, SymInt, Tensor
 from torch._C._functorch import is_functorch_wrapped_tensor, is_legacy_batchedtensor

--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -25,6 +25,7 @@ from typing import (
 from typing_extensions import override, TypedDict, TypeGuard, TypeIs, Unpack
 
 import torch
+import torch._guards
 from torch._C._autograd import CreationMeta
 from torch._C._functorch import (
     _add_batch_dim,

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -2,6 +2,7 @@
 import copyreg
 import functools
 import importlib
+import importlib.util
 import logging
 import sys
 import traceback
@@ -12,6 +13,7 @@ from typing import Any, Callable, Generic, Optional, TYPE_CHECKING
 from typing_extensions import deprecated, ParamSpec
 
 import torch
+import torch._guards
 
 
 def _type(self, dtype=None, non_blocking=False, **kwargs):

--- a/torch/amp/autocast_mode.py
+++ b/torch/amp/autocast_mode.py
@@ -5,6 +5,7 @@ import warnings
 from typing import Any, Optional
 
 import torch
+import torch._jit_internal
 from torch.types import _dtype
 
 

--- a/torch/ao/pruning/_experimental/data_sparsifier/lightning/tests/test_callbacks.py
+++ b/torch/ao/pruning/_experimental/data_sparsifier/lightning/tests/test_callbacks.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 import importlib
+import importlib.util
 import math
 import unittest
 import warnings

--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -2,6 +2,7 @@
 from typing import Any, Union
 
 import torch
+import torch._jit_internal
 from torch.utils._contextlib import (
     _DecoratorContextManager,
     _NoParamDecoratorContextManager,

--- a/torch/cpu/amp/autocast_mode.py
+++ b/torch/cpu/amp/autocast_mode.py
@@ -3,6 +3,7 @@ from typing import Any
 from typing_extensions import deprecated
 
 import torch
+import torch._jit_internal
 
 
 __all__ = ["autocast"]

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -12,6 +12,7 @@ It is lazily initialized, so you can always import it, and use
 """
 
 import importlib
+import importlib.util
 import os
 import sys
 import threading

--- a/torch/cuda/amp/autocast_mode.py
+++ b/torch/cuda/amp/autocast_mode.py
@@ -4,6 +4,7 @@ from typing import Any
 from typing_extensions import deprecated
 
 import torch
+import torch._jit_internal
 
 
 __all__ = ["autocast", "custom_fwd", "custom_bwd"]

--- a/torch/distributed/nn/jit/instantiator.py
+++ b/torch/distributed/nn/jit/instantiator.py
@@ -9,6 +9,7 @@ import tempfile
 from typing import Optional
 
 import torch
+import torch._jit_internal
 from torch.distributed.nn.jit.templates.remote_module_template import (
     get_remote_module_template,
 )

--- a/torch/distributed/rpc/__init__.py
+++ b/torch/distributed/rpc/__init__.py
@@ -87,7 +87,7 @@ if is_available():
     rendezvous_iterator: Generator[tuple[Store, int, int], None, None]
 
     __all__ += ["init_rpc", "BackendType", "TensorPipeRpcBackendOptions"]
-    __all__ = __all__ + api.__all__ + backend_registry.__all__  # noqa: PLE0605
+    __all__ = __all__ + api.__all__ + backend_registry.__all__
 
     def init_rpc(
         name,

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -10,6 +10,7 @@ import threading
 from typing import Any, Generic, TYPE_CHECKING, TypeVar
 
 import torch
+import torch._jit_internal
 from torch._C._distributed_rpc import (
     _cleanup_python_rpc_handler,
     _delete_all_user_and_unforked_owner_rrefs,

--- a/torch/fx/_graph_pickler.py
+++ b/torch/fx/_graph_pickler.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, NewType, Optional, TypeVar, Union
 from typing_extensions import override, Self
 
 import torch
+import torch._guards
 import torch.utils._pytree as pytree
 from torch._guards import TracingContext
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode, Tensor

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Literal, NamedTuple, Optional, TYPE_CHECKING
 
 import torch
+import torch._guards
 import torch.utils._pytree as pytree
 from torch._C import _fx_map_arg as map_arg, _NodeIter
 from torch.utils._dtype_abbrs import dtype_abbrs

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from typing import Any
 
 import torch._C
+import torch._jit_internal
 
 # These are imported so users can access them from the `torch.jit` module
 from torch._jit_internal import (

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -292,7 +292,7 @@ def infer_concrete_type_builder(nn_module, share_types=True):
 
     # Constants annotated via `Final[T]` rather than being added to `__constants__`
     for name, ann in class_annotations.items():
-        if torch._jit_internal.is_final(ann):
+        if _jit_internal.is_final(ann):
             constants_set.add(name)
 
     for name in constants_set:
@@ -1021,7 +1021,7 @@ def compile_unbound_method(concrete_type, fn):
     if _jit_internal.is_ignored_fn(fn):
         return None
     stub = make_stub(fn, fn.__name__)
-    with torch._jit_internal._disable_emit_hooks():
+    with _jit_internal._disable_emit_hooks():
         # We don't want to call the hooks here since the graph that is calling
         # this function is not yet complete
         create_methods_and_properties_from_stubs(concrete_type, (stub,), ())
@@ -1058,6 +1058,6 @@ def lazy_bind(concrete_type, unbound_method):
     # make the lazy binding method "look like" the original method
     lazy_binding_method.original_fn = unbound_method  # type: ignore[attr-defined]
     lazy_binding_method.__name__ = unbound_method.__name__
-    torch._jit_internal.copy_torchscript_modifier(unbound_method, lazy_binding_method)
+    _jit_internal.copy_torchscript_modifier(unbound_method, lazy_binding_method)
 
     return lazy_binding_method

--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -21,6 +21,7 @@ from typing import Any, Callable, Optional, TypeVar
 from typing_extensions import ParamSpec
 
 import torch
+import torch._jit_internal
 from torch._jit_internal import (
     _get_model_id,
     _qualified_name,

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -10,6 +10,7 @@ import warnings
 from textwrap import dedent
 
 import torch
+import torch._jit_internal
 from torch._C import (
     _GeneratorType,
     AnyType,

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -8,6 +8,7 @@ from typing import Optional, overload
 from typing_extensions import deprecated
 
 import torch
+import torch._jit_internal
 from torch import _VF, Tensor
 from torch.nn import init
 from torch.nn.parameter import Parameter

--- a/torch/onnx/_internal/_exporter_legacy.py
+++ b/torch/onnx/_internal/_exporter_legacy.py
@@ -20,6 +20,7 @@ from typing import Any, Callable, TYPE_CHECKING
 from typing_extensions import deprecated
 
 import torch
+import torch._guards
 import torch._ops
 from torch.onnx._internal import io_adapter
 from torch.onnx._internal._lazy_import import onnxscript_apis

--- a/torch/onnx/_internal/fx/patcher.py
+++ b/torch/onnx/_internal/fx/patcher.py
@@ -4,6 +4,7 @@ import functools
 from typing import TYPE_CHECKING, Union
 
 import torch
+import torch._guards
 
 
 if TYPE_CHECKING:

--- a/torch/package/package_importer.py
+++ b/torch/package/package_importer.py
@@ -2,6 +2,7 @@
 import builtins
 import importlib
 import importlib.machinery
+import importlib.util
 import inspect
 import io
 import linecache

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -19,6 +19,7 @@ from typing import Any, Callable, cast, Generic, IO, Optional, TypeVar, Union
 from typing_extensions import TypeAlias, TypeIs
 
 import torch
+import torch._guards
 import torch._weights_only_unpickler as _weights_only_unpickler
 from torch._sources import get_source_lines_and_file
 from torch._utils import _import_dotted_name

--- a/torch/utils/_sympy/value_ranges.py
+++ b/torch/utils/_sympy/value_ranges.py
@@ -23,6 +23,7 @@ import sympy
 from sympy.logic.boolalg import Boolean as SympyBoolean, BooleanAtom
 
 import torch
+import torch._guards
 from torch._logging import LazyString
 from torch._prims_common import dtype_to_type
 

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1,4 +1,6 @@
 # mypy: allow-untyped-defs
+import importlib.metadata
+import importlib.util
 import copy
 import glob
 import importlib


### PR DESCRIPTION
Includes various patches such as:

- Add missing imports
- Add missing type annotations and remove line level type ignore comments
- Improve existing type annotations


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @EikanWang @jgong5 @wenzhe-nrv @sanchitintel @mingfeima @XiaobingSuper @ashokei @jingxu10 @jerryzh168 @mcarilli @ptrblck @leslie-fang-intel @ezyang @SherlockNoMad @voznesenskym @penguinwu @Guobing-Chen @zhuhaozhe @blzheng @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov