### PR TITLE
[EZ][BE] Delete redundant header

### DIFF
--- a/aten/src/ATen/native/mps/operations/Indexing.h
+++ b/aten/src/ATen/native/mps/operations/Indexing.h
@@ -1,8 +1,0 @@
-//  Copyright © 2022 Apple Inc.
-#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
-#include <ATen/native/mps/OperationUtils.h>
-#include <ATen/native/mps/TensorFactory.h>
-#include <c10/core/ScalarType.h>
-#include <unordered_map>
-
-using namespace at::mps;

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -18,8 +18,6 @@
 #include <ATen/native/Resize.h>
 #include <ATen/native/TensorAdvancedIndexing.h>
 #include <ATen/native/mps/MPSGraphVenturaOps.h>
-#include <ATen/native/mps/operations/Indexing.h>
-#include <c10/core/QScheme.h>
 #include <c10/util/SmallVector.h>
 #include <c10/util/irange.h>
 #include <fmt/format.h>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #158064
* __->__ #157966

Not sure why it was there in the first place. And why `Indexing.m`` needed to include QScheme.h is also unclear