### PR TITLE
[do not review][benchmark] test all_gather communication time

### DIFF
--- a/test_comm.py
+++ b/test_comm.py
@@ -1,0 +1,78 @@
+import copy
+import gc
+import os
+from datetime import timedelta
+
+import torch
+import torch.nn as nn
+from torch.distributed import init_process_group
+from torch.distributed.checkpoint.state_dict import (
+    get_model_state_dict,
+    StateDictOptions,
+)
+from torch.distributed.fsdp import fully_shard, MixedPrecisionPolicy
+from torch.testing._internal.common_fsdp import FSDPTest, MLP
+from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    ModelArgs,
+    Transformer,
+    TransformerBlock,
+)
+from torchao.float8.config import CastConfig, Float8LinearConfig, ScalingType
+from torchao.float8.float8_linear_utils import convert_to_float8_training
+
+
+class TestFullyShardMemory(FSDPTest):
+    # @property
+    # def world_size(self) -> int:
+    #    return 8
+    def test_fully_shard_del_memory(self):
+        dim = 1024
+        model = nn.Sequential(*[MLP(dim) for _ in range(3)])
+        ref_model_fp8 = copy.deepcopy(model)
+        ref_model_bf16 = copy.deepcopy(model).to(torch.bfloat16)
+        mp_policy = MixedPrecisionPolicy(param_dtype=torch.bfloat16)
+        model = fully_shard(model, mp_policy=mp_policy)
+        optim = torch.optim.Adam(model.parameters())
+        inp = torch.randn((dim, dim), device=torch.device("cuda"), dtype=torch.bfloat16)
+        enable_fsdp_float8_all_gather = True
+        scaling_type_weight = ScalingType.DYNAMIC
+        float8_linear_config = Float8LinearConfig(
+            enable_fsdp_float8_all_gather=enable_fsdp_float8_all_gather,
+            cast_config_weight=CastConfig(scaling_type=scaling_type_weight),
+        )
+        ref_model_fp8 = convert_to_float8_training(
+            ref_model_fp8,
+            config=float8_linear_config,
+        )
+        ref_model_fp8 = fully_shard(ref_model_fp8)
+        ref_optim_fp8 = torch.optim.Adam(ref_model_fp8.parameters(), lr=1e-2)
+        ref_model_bf16 = fully_shard(ref_model_bf16)
+        ref_optim_bf16 = torch.optim.Adam(ref_model_bf16.parameters(), lr=1e-2)
+        with torch.profiler.profile(
+            activities=[
+                # orch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            record_shapes=True,
+            on_trace_ready=torch.profiler.tensorboard_trace_handler("execution_trace"),
+        ) as prof:
+            for round in range(20):
+                if torch.distributed.get_rank() == 0:
+                    print("dist.all_gather_into_tensor(bf16), with mp_policy(bf16)")
+                optim.zero_grad()
+                loss = model(inp).sum()
+                loss.backward()
+                optim.step()
+
+                if torch.distributed.get_rank() == 0:
+                    print("dist.all_gather_into_tensor(fp8)  ")
+                ref_optim_fp8.zero_grad()
+                ref_loss = ref_model_fp8(inp).sum()
+                ref_loss.backward()
+                ref_optim_fp8.step()
+
+
+if __name__ == "__main__":
+    init_process_group(backend="nccl", timeout=timedelta(hours=24))
+    run_tests()

--- a/test_comm.py
+++ b/test_comm.py
@@ -33,8 +33,8 @@ def rank0_print(*args, **kwargs):
 
 class TestFullyShardAllGatherComm(FSDPTest):
     def test_all_gather_comm(self):
-        dim = 1024
-        model = nn.Sequential(*[MLP(dim) for _ in range(3)])
+        dim = 4096
+        model = nn.Sequential(*[MLP(dim) for _ in range(5)])
         ref_model_fp8 = copy.deepcopy(model)
         mp_policy = MixedPrecisionPolicy(param_dtype=torch.bfloat16)
         model = fully_shard(model, mp_policy=mp_policy)

--- a/test_comm.py
+++ b/test_comm.py
@@ -60,7 +60,7 @@ class TestFullyShardAllGatherComm(FSDPTest):
             schedule=torch.profiler.schedule(wait=10, warmup=10, active=30, repeat=1),
             on_trace_ready=torch.profiler.tensorboard_trace_handler("execution_trace"),
         ) as prof:
-            for _ in range(50):
+            for _ in range(30):
                 inp = torch.randn(
                     (dim, dim), device=torch.device("cuda"), dtype=torch.bfloat16
                 )

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
@@ -86,13 +86,14 @@ class DefaultAllGather(DefaultAllocMixin, AllGather):
         group: dist.ProcessGroup,
         async_op: bool = False,
     ) -> Optional[dist.Work]:
+        from logging import getLogger
+
+        logger = getLogger()
         dist.barrier()
         start_event = torch.cuda.Event(enable_timing=True)
         end_event = torch.cuda.Event(enable_timing=True)
         start_event.record()
         # for fp8 model, the input and output dtupe are torch.uint8
-        if torch.distributed.get_rank() == 0:
-            print("input_tensor length", input_tensor.size(), input_tensor.dtype)
         result = dist.all_gather_into_tensor(
             output_tensor,
             input_tensor,
@@ -103,7 +104,7 @@ class DefaultAllGather(DefaultAllocMixin, AllGather):
         torch.cuda.synchronize()
         all_gather_time = start_event.elapsed_time(end_event)
         if torch.distributed.get_rank() == 0:
-            print(f"all_gather_time: {all_gather_time} ms")
+            logger.info(f"all_gather_time: {all_gather_time} ms")
         dist.barrier()
         return result
 
@@ -509,9 +510,9 @@ def foreach_reduce(
     for i, (fsdp_param, unsharded_grad) in enumerate(zip(fsdp_params, unsharded_grads)):
         if (shard_dim := fsdp_param.fsdp_placement.dim) == 0:
             continue
-        assert unsharded_grad.size(shard_dim) % world_size == 0, (
-            f"Shard({shard_dim}) requires even sharding: {unsharded_grad.size()=} {world_size=}"
-        )
+        assert (
+            unsharded_grad.size(shard_dim) % world_size == 0
+        ), f"Shard({shard_dim}) requires even sharding: {unsharded_grad.size()=} {world_size=}"
         chunks = torch.chunk(unsharded_grad, world_size, dim=shard_dim)
         unsharded_grads[i] = torch.cat(chunks, dim=0)
     padded_unsharded_sizes = tuple(


### PR DESCRIPTION
Build a model in bf16 or fp8, compare the GPU time for dist.all_gather_into_tensor

Average time for bf16: 3.56ms
Average time for fp8:  1.845ms
For gpu trace in ncclDevKernel_AllGather_RING_LL(ncclDevKernelArgsStorage<4096ul>)
bf16 has ~ 3.4ms, fp8 has ~1.7s

Why not use just generating a tensor to run the dist.all_gather_into_tensor directly?
for fp8 tensor, the input tensor for dist.all_gather_into_tensor will be restructured as a uint8 tensor with different size
e.g.
in bf16, the input_tensor has length torch.Size([3147648]) in torch.bfloat16
for fp8, the input_tensor has length torch.Size([3153408]) in torch.uint8


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim