### PR TITLE
Define header type directly instead of using DeviceStreamType

### DIFF
--- a/test/inductor/test_static_linkage_utils.py
+++ b/test/inductor/test_static_linkage_utils.py
@@ -1,0 +1,159 @@
+# Owner(s): ["module: inductor"]
+from torch.testing._internal.common_utils import run_tests
+
+
+def get_static_linkage_main_cpp_file(run_single_threaded: bool = False):
+    run_func = "run" if not run_single_threaded else "run_single_threaded"
+
+    return f"""
+#include <dlfcn.h>
+#include <iostream>
+#include <memory>
+#include <torch/torch.h>
+#include <vector>
+
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+// Include the AOTInductor headers
+#include "Minus.wrapper/data/aotinductor/model/Minus.h"
+#include "Plus.wrapper/data/aotinductor/model/Plus.h"
+#include <torch/csrc/inductor/aoti_runtime/model_container.h>
+#include <torch/csrc/inductor/aoti_torch/tensor_converter.h>
+
+using torch::aot_inductor::AOTInductorModelMinus;
+using torch::aot_inductor::AOTInductorModelPlus;
+using torch::aot_inductor::ConstantHandle;
+using torch::aot_inductor::ConstantMap;
+
+
+int main(int argc, char* argv[]) {{
+  if (argc < 2) {{
+    std::cerr
+        << "Usage: ./main <path> <device>"
+        << std::endl;
+    return 1;
+  }}
+  std::string path = argv[1];
+  std::string device_str = argv[2];
+  try {{
+    torch::Device device(device_str);
+
+    // Create two input tensors (10x10)
+    auto tensor1 = torch::ones({{10, 10}}, device);
+    auto tensor2 = torch::ones({{10, 10}}, device);
+    // Create two input tensors (10x10)
+    auto tensor3 = torch::ones({{10, 10}}, device);
+    auto tensor4 = torch::ones({{10, 10}}, device);
+
+    std::vector<at::Tensor> input_tensors = {{tensor1, tensor2}};
+    std::vector<at::Tensor> input_tensors2 = {{tensor3, tensor4}};
+
+    // Create array of input handles
+    auto input_handles1 =
+        torch::aot_inductor::unsafe_alloc_new_handles_from_tensors(
+            input_tensors);
+    auto input_handles2 =
+        torch::aot_inductor::unsafe_alloc_new_handles_from_tensors(
+            input_tensors2);
+
+    // Create array for output handle
+    AtenTensorHandle output_handle1;
+    AtenTensorHandle output_handle2;
+
+    auto constants_map = std::make_shared<ConstantMap>();
+    auto constants_array = std::make_shared<std::vector<ConstantHandle>>();
+    auto model1 = AOTInductorModelPlus::Create(
+        constants_map, constants_array, device_str,
+        path + "Plus.wrapper/data/"
+        "aotinductor/model/");
+    model1->load_constants();
+
+    auto constants_map2 = std::make_shared<ConstantMap>();
+    auto constants_array2 = std::make_shared<std::vector<ConstantHandle>>();
+    auto model2 = AOTInductorModelMinus::Create(
+        constants_map2, constants_array2, device_str,
+        path + "Minus.wrapper/data/"
+        "aotinductor/model/");
+    model2->load_constants();
+
+    // Run the model
+    torch::aot_inductor::DeviceStreamType stream1 = nullptr;
+    torch::aot_inductor::DeviceStreamType stream2 = nullptr;
+    model1->{run_func}(&input_handles1[0], &output_handle1, stream1, nullptr);
+    model2->{run_func}(&input_handles2[0], &output_handle2, stream2, nullptr);
+
+    // Convert output handle to tensor
+    auto output_tensor1 =
+        torch::aot_inductor::alloc_tensors_by_stealing_from_handles(
+            &output_handle1, 1);
+    auto output_tensor2 =
+        torch::aot_inductor::alloc_tensors_by_stealing_from_handles(
+            &output_handle2, 1);
+
+    if (!(torch::all(output_tensor1[0] == 2).item<bool>())){{
+      std::cout << "Wrong Output for Plus Model: " << output_tensor1 << std::endl;
+      throw std::runtime_error("Tensor does not contain only the expected value 2.");
+    }}
+    if (!(torch::all(output_tensor2[0] == 0).item<bool>())){{
+      std::cout << "Wrong Output for Minus Model: " << output_tensor1 << std::endl;
+      throw std::runtime_error("Tensor does not contain only the expected value 0.");
+    }}
+
+    return 0;
+  }} catch (const std::exception &e) {{
+    std::cerr << "Error: " << e.what() << std::endl;
+    return 1;
+  }}
+}}
+
+"""
+
+
+def get_static_linkage_makelist_file_cuda():
+    return """
+cmake_minimum_required(VERSION 3.10)
+project(TestProject)
+
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(Torch REQUIRED)
+find_package(CUDA REQUIRED)
+
+add_subdirectory(Plus.wrapper/data/aotinductor/model/)
+add_subdirectory(Minus.wrapper/data/aotinductor/model/)
+
+# Create executable
+add_executable(main main.cpp)
+
+target_compile_definitions(main PRIVATE USE_CUDA)
+
+target_link_libraries(main PRIVATE torch cuda
+                    ${CUDA_LIBRARIES}
+                    Plus
+                    Minus)
+"""
+
+
+def get_static_linkage_makelist_file_cpu():
+    return """
+cmake_minimum_required(VERSION 3.10)
+project(TestProject)
+
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(Torch REQUIRED)
+
+add_subdirectory(Plus.wrapper/data/aotinductor/model/)
+add_subdirectory(Minus.wrapper/data/aotinductor/model/)
+
+# Create executable
+add_executable(main main.cpp)
+
+target_link_libraries(main PRIVATE torch
+                    Plus
+                    Minus)
+"""
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/codegen/cpu_device_op_overrides.py
+++ b/torch/_inductor/codegen/cpu_device_op_overrides.py
@@ -23,5 +23,7 @@ class CpuDeviceOpOverrides(DeviceOpOverrides):
     def device_guard(self, device_idx: int) -> str:
         return "pass"
 
+    def cpp_stream_type(self) -> str:
+        return "void *"
 
 register_device_op_overrides("cpu", CpuDeviceOpOverrides())

--- a/torch/csrc/inductor/aoti_runtime/device_interface.h
+++ b/torch/csrc/inductor/aoti_runtime/device_interface.h
@@ -1,0 +1,519 @@
+#pragma once
+
+#include <cstring>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+
+// WARNING: Be careful when adding new includes here. This header will be used
+// in model.so, and should not refer to any aten/c10 headers except the stable
+// C ABI defined in torch/csrc/inductor/aoti_torch/c/shim.h. The same rule
+// applies to other files under torch/csrc/inductor/aoti_runtime/.
+#ifdef USE_CUDA
+#include <cuda_runtime.h>
+#endif
+
+#ifdef USE_XPU
+#include <sycl/sycl.hpp>
+#include <torch/csrc/inductor/aoti_runtime/utils_xpu.h>
+#endif
+
+#ifdef USE_MPS
+#include <torch/csrc/inductor/aoti_torch/c/shim_mps.h>
+#endif
+
+#include <torch/csrc/inductor/aoti_runtime/device_utils.h>
+#include <torch/csrc/inductor/aoti_torch/c/shim.h>
+
+namespace torch::aot_inductor {
+
+using RAIIDataPtr = std::unique_ptr<void, std::function<void(void*)>>;
+
+#ifdef USE_CUDA
+
+// NOLINTNEXTLINE(clang-diagnostic-unneeded-internal-declaration,misc-definitions-in-headers)
+RAIIDataPtr RAII_cudaMalloc(size_t num_bytes) {
+  void* data_ptr = nullptr;
+  AOTI_RUNTIME_CUDA_CHECK(cudaMalloc((void**)&data_ptr, num_bytes));
+  auto deleter = [](void* ptr) { AOTI_RUNTIME_CUDA_CHECK(cudaFree(ptr)); };
+  return RAIIDataPtr(data_ptr, deleter);
+}
+#endif // USE_CUDA
+
+#if defined(USE_XPU)
+
+RAIIDataPtr RAII_xpuMalloc(size_t num_bytes) {
+  sycl::queue* queue_ptr = nullptr;
+  aoti_torch_get_current_sycl_queue((void**)&queue_ptr);
+  void* data_ptr = sycl::malloc_device(num_bytes, *queue_ptr);
+  auto deleter = [queue_ptr](void* ptr) { sycl::free(ptr, *queue_ptr); };
+  return RAIIDataPtr(data_ptr, deleter);
+}
+#endif // USE_XPU
+
+#if defined(USE_MPS)
+
+RAIIDataPtr RAII_mpsMalloc(size_t num_bytes) {
+  void* data_ptr = nullptr;
+  aoti_torch_mps_malloc(&data_ptr, num_bytes);
+  auto deleter = [](void* ptr) { aoti_torch_mps_free(ptr); };
+  return RAIIDataPtr(data_ptr, deleter);
+}
+
+#endif // USE_MPS
+
+// NOLINTNEXTLINE(misc-definitions-in-headers)
+inline RAIIDataPtr RAII_cpuMalloc(size_t num_bytes) {
+  void* data_ptr =
+      std::malloc(num_bytes); // NOLINT(cppcoreguidelines-no-malloc)
+  if (!data_ptr) {
+    throw std::bad_alloc();
+  }
+  auto deleter = [](void* ptr) {
+    std::free(ptr); // NOLINT(cppcoreguidelines-no-malloc)
+  };
+  return RAIIDataPtr(data_ptr, deleter);
+}
+
+// Abstract interface for device-specific operations
+class AOTInductorDeviceInterface {
+ public:
+  virtual ~AOTInductorDeviceInterface() = default;
+
+  // Event management
+  virtual void create_event() = 0;
+  virtual void destroy_event() = 0;
+  virtual void record_event(DeviceStreamType stream) = 0;
+  virtual void reset_event() = 0;
+
+  // Memory management
+  virtual RAIIDataPtr allocate_constant_blob(size_t num_bytes) = 0;
+  virtual void copy_to_device(
+      void* dst,
+      const void* src,
+      size_t size,
+      size_t dst_offset = 0) = 0;
+
+  // Copy constants and return the appropriate pointer for tensor creation
+  // This handles device-specific memory layout differences
+  virtual uint8_t* copy_constant_and_get_ptr(
+      uint8_t* internal_ptr,
+      uint8_t* constants_ptr,
+      size_t constant_offset,
+      const uint8_t* src_data,
+      size_t bytes_read,
+      size_t data_size) = 0;
+
+  // Device management
+  virtual void initialize_device(int32_t device_idx) = 0;
+  virtual int32_t get_current_device() = 0;
+  virtual void set_current_device(int32_t device_idx) = 0;
+
+  // Completion status
+  virtual bool is_finished() = 0;
+  virtual void wait_for_completion() = 0;
+};
+
+// CUDA device implementation
+#ifdef USE_CUDA
+class AOTInductorCUDADevice : public AOTInductorDeviceInterface {
+ private:
+  std::optional<cudaEvent_t> event_;
+
+ public:
+  // Delete copy and move constructors/operators since this class manages CUDA
+  // resources
+  AOTInductorCUDADevice(const AOTInductorCUDADevice&) = delete;
+  AOTInductorCUDADevice& operator=(const AOTInductorCUDADevice&) = delete;
+  AOTInductorCUDADevice(AOTInductorCUDADevice&&) = delete;
+  AOTInductorCUDADevice& operator=(AOTInductorCUDADevice&&) = delete;
+
+  AOTInductorCUDADevice() = default;
+
+  void destroy_event_impl() {
+    if (event_) {
+      auto code = cudaEventDestroy(*event_);
+      if (code != cudaSuccess) {
+        std::cerr << "Failed to destroy CUDA event in AOTInductor model: "
+                  << cudaGetErrorString(code) << '\n';
+      }
+      event_.reset();
+    }
+  }
+
+  ~AOTInductorCUDADevice() override {
+    destroy_event_impl();
+  }
+
+  void create_event() override {
+    if (!event_) {
+      cudaEvent_t cuda_event = cudaEvent_t{};
+      AOTI_RUNTIME_CUDA_CHECK(cudaEventCreate(&cuda_event));
+      event_.emplace(cuda_event);
+    }
+  }
+
+  void destroy_event() override {
+    destroy_event_impl();
+  }
+
+  void record_event(DeviceStreamType stream) override {
+    if (event_) {
+      AOTI_RUNTIME_CUDA_CHECK(cudaEventRecord(*event_, stream));
+    }
+  }
+
+  void reset_event() override {
+    // For CUDA, we don't need to reset the event, just ensure it exists
+    if (!event_) {
+      create_event();
+    }
+  }
+
+  RAIIDataPtr allocate_constant_blob(size_t num_bytes) override {
+    return RAII_cudaMalloc(num_bytes);
+  }
+
+  void copy_to_device(
+      void* dst,
+      const void* src,
+      size_t size,
+      size_t dst_offset = 0) override {
+    uint8_t* dst_ptr = static_cast<uint8_t*>(dst) + dst_offset;
+    AOTI_RUNTIME_CUDA_CHECK(
+        cudaMemcpy(dst_ptr, src, size, cudaMemcpyHostToDevice));
+  }
+
+  void initialize_device(int32_t device_idx) override {
+    if (device_idx == -1) {
+      AOTI_RUNTIME_CUDA_CHECK(cudaGetDevice(&device_idx));
+    } else {
+      AOTI_RUNTIME_CUDA_CHECK(cudaSetDevice(device_idx));
+    }
+  }
+
+  int32_t get_current_device() override {
+    int32_t device_idx = 0;
+    AOTI_RUNTIME_CUDA_CHECK(cudaGetDevice(&device_idx));
+    return device_idx;
+  }
+
+  void set_current_device(int32_t device_idx) override {
+    AOTI_RUNTIME_CUDA_CHECK(cudaSetDevice(device_idx));
+  }
+
+  uint8_t* copy_constant_and_get_ptr(
+      uint8_t* internal_ptr,
+      uint8_t* constants_ptr,
+      size_t constant_offset,
+      const uint8_t* src_data,
+      size_t bytes_read,
+      size_t data_size) override {
+    AOTI_RUNTIME_CUDA_CHECK(cudaMemcpy(
+        internal_ptr,
+        src_data + bytes_read,
+        data_size,
+        cudaMemcpyHostToDevice));
+    return internal_ptr;
+  }
+
+  bool is_finished() override {
+    if (!event_) {
+      throw std::runtime_error{"Model CUDA event was not initialized"};
+    }
+    auto event_status = cudaEventQuery(*event_);
+    if (event_status == cudaSuccess) {
+      return true;
+    } else if (event_status == cudaErrorNotReady) {
+      return false;
+    }
+    throw std::runtime_error(
+        std::string("The model did not finish successfully. Error: ") +
+        cudaGetErrorString(cudaGetLastError()));
+  }
+
+  void wait_for_completion() override {
+    if (!event_) {
+      throw std::runtime_error{"Model event was not initialized"};
+    }
+    AOTI_RUNTIME_CUDA_CHECK(cudaEventSynchronize(*event_));
+  }
+};
+#endif // USE_CUDA
+
+// XPU device implementation
+#ifdef USE_XPU
+class AOTInductorXPUDevice : public AOTInductorDeviceInterface {
+ private:
+  std::optional<sycl::event*> event_;
+
+ public:
+  ~AOTInductorXPUDevice() override {
+    destroy_event();
+  }
+
+  void create_event() override {
+    // XPU events are created when needed during record_event
+  }
+
+  void destroy_event() override {
+    if (event_) {
+      (*event_)->wait_and_throw();
+      delete *event_;
+      event_.reset();
+    }
+  }
+
+  void record_event(DeviceStreamType stream) override {
+    event_ = std::make_optional<sycl::event*>(new sycl::event(
+        static_cast<sycl::queue*>(stream)->ext_oneapi_submit_barrier()));
+  }
+
+  void reset_event() override {
+    if (event_) {
+      (*event_)->wait_and_throw();
+      delete *event_;
+      event_.reset();
+    }
+  }
+
+  RAIIDataPtr allocate_constant_blob(size_t num_bytes) override {
+    return RAII_xpuMalloc(num_bytes);
+  }
+
+  void copy_to_device(
+      void* dst,
+      const void* src,
+      size_t size,
+      size_t dst_offset = 0) override {
+    sycl::queue* queue_ptr = nullptr;
+    aoti_torch_get_current_sycl_queue((void**)&queue_ptr);
+    uint8_t* dst_ptr = static_cast<uint8_t*>(dst) + dst_offset;
+    queue_ptr->memcpy(dst_ptr, src, size).wait();
+  }
+
+  void initialize_device(int32_t device_idx) override {
+    if (device_idx == -1) {
+      aoti_torch_get_current_xpu_device(&device_idx);
+    } else {
+      aoti_torch_set_current_xpu_device(device_idx);
+    }
+  }
+
+  int32_t get_current_device() override {
+    int32_t device_idx;
+    aoti_torch_get_current_xpu_device(&device_idx);
+    return device_idx;
+  }
+
+  void set_current_device(int32_t device_idx) override {
+    aoti_torch_set_current_xpu_device(device_idx);
+  }
+
+  uint8_t* copy_constant_and_get_ptr(
+      uint8_t* internal_ptr,
+      uint8_t* constants_ptr,
+      size_t constant_offset,
+      const uint8_t* src_data,
+      size_t bytes_read,
+      size_t data_size) override {
+    sycl::queue* queue_ptr = nullptr;
+    aoti_torch_get_current_sycl_queue((void**)&queue_ptr);
+    queue_ptr->memcpy(internal_ptr, src_data + bytes_read, data_size).wait();
+    return internal_ptr;
+  }
+
+  bool is_finished() override {
+    if (!event_) {
+      throw std::runtime_error{"Model XPU event was not initialized"};
+    }
+    using namespace sycl::info;
+    return (*event_)->get_info<event::command_execution_status>() ==
+        event_command_status::complete;
+  }
+
+  void wait_for_completion() override {
+    if (!event_) {
+      throw std::runtime_error{"Model event was not initialized"};
+    }
+    (*event_)->wait_and_throw();
+  }
+};
+#endif // USE_XPU
+
+// MPS device implementation
+#ifdef USE_MPS
+class AOTInductorMPSDevice : public AOTInductorDeviceInterface {
+ private:
+  bool run_finished_ = false;
+  int32_t device_idx_ = 0;
+
+ public:
+  void create_event() override {
+    // MPS doesn't use events, just track completion with boolean
+  }
+
+  void destroy_event() override {
+    // Nothing to destroy for MPS
+  }
+
+  void record_event(DeviceStreamType stream) override {
+    run_finished_ = true;
+  }
+
+  void reset_event() override {
+    run_finished_ = false;
+  }
+
+  RAIIDataPtr allocate_constant_blob(size_t num_bytes) override {
+    return RAII_mpsMalloc(num_bytes);
+  }
+
+  void copy_to_device(
+      void* dst,
+      const void* src,
+      size_t size,
+      size_t dst_offset = 0) override {
+    // MPS uses a special memcpy function that handles the offset internally
+    aoti_torch_mps_memcpy(
+        static_cast<uint8_t*>(dst),
+        dst_offset,
+        0, // src_offset (always 0 for host source)
+        size,
+        static_cast<const uint8_t*>(src));
+  }
+
+  void initialize_device(int32_t device_idx) override {
+    if (device_idx == -1) {
+      device_idx_ = 0; //
+    } else {
+      device_idx_ = device_idx;
+    }
+  }
+
+  int32_t get_current_device() override {
+    return device_idx_;
+  }
+
+  void set_current_device(int32_t device_idx) override {
+    // MPS doesn't support multiple devices
+  }
+
+  uint8_t* copy_constant_and_get_ptr(
+      uint8_t* internal_ptr,
+      uint8_t* constants_ptr,
+      size_t constant_offset,
+      const uint8_t* src_data,
+      size_t bytes_read,
+      size_t data_size) override {
+    aoti_torch_mps_memcpy(
+        constants_ptr, constant_offset, bytes_read, data_size, src_data);
+    return constants_ptr;
+  }
+
+  bool is_finished() override {
+    return run_finished_;
+  }
+
+  void wait_for_completion() override {
+    // MPS operations are synchronous, nothing to wait for
+  }
+};
+#endif // USE_MPS
+
+// CPU device implementation
+class AOTInductorCPUDevice : public AOTInductorDeviceInterface {
+ private:
+  bool run_finished_ = false;
+
+ public:
+  void create_event() override {
+    // CPU doesn't use events, just track completion with boolean
+  }
+
+  void destroy_event() override {
+    // Nothing to destroy for CPU
+  }
+
+  void record_event(DeviceStreamType stream) override {
+    run_finished_ = true;
+  }
+
+  void reset_event() override {
+    run_finished_ = false;
+  }
+
+  RAIIDataPtr allocate_constant_blob(size_t num_bytes) override {
+    return RAII_cpuMalloc(num_bytes);
+  }
+
+  void copy_to_device(
+      void* dst,
+      const void* src,
+      size_t size,
+      size_t dst_offset = 0) override {
+    uint8_t* dst_ptr = static_cast<uint8_t*>(dst) + dst_offset;
+    memcpy(dst_ptr, src, size);
+  }
+
+  void initialize_device(int32_t device_idx) override {
+    // CPU doesn't need device initialization
+  }
+
+  int32_t get_current_device() override {
+    return 0; // CPU always uses device 0
+  }
+
+  void set_current_device(int32_t device_idx) override {
+    // CPU doesn't support multiple devices
+  }
+
+  uint8_t* copy_constant_and_get_ptr(
+      uint8_t* internal_ptr,
+      uint8_t* constants_ptr,
+      size_t constant_offset,
+      const uint8_t* src_data,
+      size_t bytes_read,
+      size_t data_size) override {
+    memcpy(internal_ptr, src_data + bytes_read, data_size);
+    return internal_ptr;
+  }
+
+  bool is_finished() override {
+    return run_finished_;
+  }
+
+  void wait_for_completion() override {
+    // CPU operations are synchronous, nothing to wait for
+  }
+};
+
+// Factory function to create appropriate device interface
+inline std::unique_ptr<AOTInductorDeviceInterface> create_device_interface(
+    int32_t device_type) {
+#ifdef USE_CUDA
+  if (device_type == aoti_torch_device_type_cuda()) {
+    return std::make_unique<AOTInductorCUDADevice>();
+  }
+#endif
+#ifdef USE_XPU
+  if (device_type == aoti_torch_device_type_xpu()) {
+    return std::make_unique<AOTInductorXPUDevice>();
+  }
+#endif
+#ifdef USE_MPS
+  if (device_type == aoti_torch_device_type_mps()) {
+    return std::make_unique<AOTInductorMPSDevice>();
+  }
+#endif
+  if (device_type == aoti_torch_device_type_cpu()) {
+    return std::make_unique<AOTInductorCPUDevice>();
+  }
+
+  throw std::runtime_error(
+      "Unsupported device type: " + std::to_string(device_type));
+}
+
+} // namespace torch::aot_inductor

--- a/torch/csrc/inductor/aoti_runtime/device_utils.h
+++ b/torch/csrc/inductor/aoti_runtime/device_utils.h
@@ -6,11 +6,6 @@
 // applies to other files under torch/csrc/inductor/aoti_runtime/.
 
 #ifdef USE_CUDA
-
-// FIXME: Currently, CPU and CUDA backend are mutually exclusive.
-// This is a temporary workaround. We need a better way to support
-// multi devices.
-
 #include <cuda.h>
 #include <cuda_runtime_api.h>
 
@@ -23,14 +18,9 @@
           std::string("CUDA error: ") + std::string(msg)); \
     }                                                      \
   } while (0)
+#endif // USE_CUDA
 
-namespace torch::aot_inductor {
-
-using DeviceStreamType = cudaStream_t;
-
-} // namespace torch::aot_inductor
-
-#elif defined(USE_XPU)
+#if defined(USE_XPU)
 #include <level_zero/ze_api.h>
 #include <sycl/sycl.hpp>
 #include <sstream>
@@ -43,14 +33,7 @@ using DeviceStreamType = cudaStream_t;
       throw std::runtime_error(ss.str());                                 \
     }                                                                     \
   } while (0)
-
-namespace torch::aot_inductor {
-
-using DeviceStreamType = sycl::queue*;
-
-} // namespace torch::aot_inductor
-
-#else
+#endif // USE_XPU
 
 #define AOTI_RUNTIME_CPU_CHECK(EXPR)               \
   bool ok = EXPR;                                  \
@@ -60,8 +43,18 @@ using DeviceStreamType = sycl::queue*;
 
 namespace torch::aot_inductor {
 
+#ifdef USE_CUDA
+
+using DeviceStreamType = cudaStream_t;
+
+#elif defined(USE_XPU)
+
+using DeviceStreamType = sycl::queue*;
+
+#else
+
 using DeviceStreamType = void*;
 
-} // namespace torch::aot_inductor
-
 #endif // USE_CUDA
+
+} // namespace torch::aot_inductor


### PR DESCRIPTION
Summary:
- Make header declarations for all device types

- Refactors record_event in AOTInductorDeviceInterface to use a single void*-typed virtual method for stream dispatch, enabling unified handling across CUDA, XPU, and CPU backends. A templated wrapper is used to maintain type safety at the callsite.

TODO: also need to change the generated .h and .cpp code's signature

Test Plan:
```
buck run fbcode//mode/dev-nosan //caffe2/test/inductor:test_aot_inductor -- -r  test_while_loop_simple_cuda
```

Rollback Plan:

Differential Revision: D77971256


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben