### PR TITLE
[test][do not merge] Upgrade oneDNN to v3.9.2

### DIFF
--- a/third_party/mkl-dnn.BUILD
+++ b/third_party/mkl-dnn.BUILD
@@ -85,7 +85,7 @@ template_rule(
     name = "include_dnnl_version_hash",
     src = "include/oneapi/dnnl/dnnl_version_hash.h.in",
     out = "include/oneapi/dnnl/dnnl_version_hash.h",
-    substitutions = {"@DNNL_VERSION_HASH@": "78e781f6bbec4cf622a23426830ae4b531432295",}
+    substitutions = {"@DNNL_VERSION_HASH@": "74f23b48e0779e5e39ea14ebdb80eca9afdb92aa",}
 )
 
 cc_library(

--- a/third_party/mkl-dnn.BUILD
+++ b/third_party/mkl-dnn.BUILD
@@ -85,7 +85,7 @@ template_rule(
     name = "include_dnnl_version_hash",
     src = "include/oneapi/dnnl/dnnl_version_hash.h.in",
     out = "include/oneapi/dnnl/dnnl_version_hash.h",
-    substitutions = {"@DNNL_VERSION_HASH@": "fef486592e40c9e907e615e747118620b4611e04",}
+    substitutions = {"@DNNL_VERSION_HASH@": "420879fd083d77772f7a496920ac2b97cdc7a970",}
 )
 
 cc_library(

--- a/third_party/mkl-dnn.BUILD
+++ b/third_party/mkl-dnn.BUILD
@@ -70,7 +70,7 @@ template_rule(
     substitutions = {
         "@DNNL_VERSION_MAJOR@": "3",
         "@DNNL_VERSION_MINOR@": "9",
-        "@DNNL_VERSION_PATCH@": "1",
+        "@DNNL_VERSION_PATCH@": "2",
     },
 )
 
@@ -85,7 +85,7 @@ template_rule(
     name = "include_dnnl_version_hash",
     src = "include/oneapi/dnnl/dnnl_version_hash.h.in",
     out = "include/oneapi/dnnl/dnnl_version_hash.h",
-    substitutions = {"@DNNL_VERSION_HASH@": "74f23b48e0779e5e39ea14ebdb80eca9afdb92aa",}
+    substitutions = {"@DNNL_VERSION_HASH@": "fef486592e40c9e907e615e747118620b4611e04",}
 )
 
 cc_library(

--- a/third_party/mkl-dnn.BUILD
+++ b/third_party/mkl-dnn.BUILD
@@ -15,9 +15,10 @@ _DNNL_RUNTIME_OMP = {
     "#cmakedefine DNNL_ENABLE_STACK_CHECKER": "#undef DNNL_ENABLE_STACK_CHECKER",
     "#cmakedefine DNNL_EXPERIMENTAL_UKERNEL": "/* undef DNNL_EXPERIMENTAL_UKERNEL */",
     "#cmakedefine DNNL_EXPERIMENTAL": "#undef DNNL_EXPERIMENTAL",
-    "#cmakedefine DNNL_EXPERIMENTAL_SPARSE": "#undef DNNL_EXPERIMENTAL_SPARSE",
     "#cmakedefine ONEDNN_BUILD_GRAPH": "#undef ONEDNN_BUILD_GRAPH",
     "#cmakedefine DNNL_EXPERIMENTAL_PROFILING": "#undef DNNL_EXPERIMENTAL_PROFILING",
+    "#cmakedefine DNNL_EXPERIMENTAL_LOGGING": "#undef DNNL_EXPERIMENTAL_LOGGING",
+    "#cmakedefine DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER": "#undef DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER",
     "#cmakedefine DNNL_DISABLE_GPU_REF_KERNELS": "#undef DNNL_DISABLE_GPU_REF_KERNELS",
     "#cmakedefine01 BUILD_TRAINING": "#define BUILD_TRAINING 1",
     "#cmakedefine01 BUILD_INFERENCE": "#define BUILD_INFERENCE 0",
@@ -49,8 +50,6 @@ _DNNL_RUNTIME_OMP = {
     "#cmakedefine01 BUILD_AVX512": "#define BUILD_AVX512 0",
     "#cmakedefine01 BUILD_AMX": "#define BUILD_AMX 0",
     "#cmakedefine01 BUILD_PRIMITIVE_GPU_ISA_ALL": "#define BUILD_PRIMITIVE_GPU_ISA_ALL 1",
-    "#cmakedefine01 BUILD_GEN9": "#define BUILD_GEN9 0",
-    "#cmakedefine01 BUILD_GEN11": "#define BUILD_GEN11 0",
     "#cmakedefine01 BUILD_XELP": "#define BUILD_XELP 0",
     "#cmakedefine01 BUILD_XEHPG": "#define BUILD_XEHPG 0",
     "#cmakedefine01 BUILD_XEHPC": "#define BUILD_XEHPC 0",
@@ -70,7 +69,7 @@ template_rule(
     out = "include/oneapi/dnnl/dnnl_version.h",
     substitutions = {
         "@DNNL_VERSION_MAJOR@": "3",
-        "@DNNL_VERSION_MINOR@": "7",
+        "@DNNL_VERSION_MINOR@": "9",
         "@DNNL_VERSION_PATCH@": "1",
     },
 )
@@ -86,7 +85,7 @@ template_rule(
     name = "include_dnnl_version_hash",
     src = "include/oneapi/dnnl/dnnl_version_hash.h.in",
     out = "include/oneapi/dnnl/dnnl_version_hash.h",
-    substitutions = {"@DNNL_VERSION_HASH@": "8d263e693366ef8db40acc569cc7d8edf644556d",}
+    substitutions = {"@DNNL_VERSION_HASH@": "78e781f6bbec4cf622a23426830ae4b531432295",}
 )
 
 cc_library(
@@ -99,6 +98,7 @@ cc_library(
         "src/cpu/aarch64/**/*.cpp",
         "src/cpu/rv64/**/*.cpp",
         "src/cpu/sycl/**/*.cpp",
+        "src/cpu/ppc64/**/*.cpp",
     ]),
     hdrs = glob([
         "include/oneapi/dnnl/*.h",
@@ -110,13 +110,16 @@ cc_library(
         "src/cpu/**/**/*.h",
         "src/common/*.hpp",
         "src/common/**/**/*.h",
-        "src/common/ittnotify/jitprofiling.h",
+        "third_party/xbyak/*.h",
+        "third_party/ittnotify/jitprofiling.h",
+        "third_party/spdlog/**/*.h",
     ], exclude=[
         "src/cpu/aarch64/**/*.hpp",
         "src/cpu/aarch64/**/*.h",
         "src/cpu/rv64/**/*.hpp",
         "src/cpu/rv64/**/*.h",
         "src/cpu/sycl/**/*.hpp",
+        "src/cpu/ppc64/**/*.hpp",
     ]) + [
         "include/oneapi/dnnl/dnnl_config.h",
         "include/oneapi/dnnl/dnnl_version.h",
@@ -141,7 +144,7 @@ cc_library(
         "src/",
         "src/common/",
         "src/cpu/",
-        "src/cpu/x64/xbyak/",
+        "third_party/",
     ],
     visibility = ["//visibility:public"],
     linkopts = [


### PR DESCRIPTION
- [x] Add [this commit](https://github.com/pytorch/pytorch/commit/9dd627081ffd40d78331f4bcbbbf2c32db112b99) inside this PR
- [x] Rebase to the latest main to fix XPU failures.

This PR is to upgrade oneDNN to v3.9.2.

### Validation results on CPU

1. NLP models accuracy/inference/training
<img width="1541" height="352" alt="image" src="https://github.com/user-attachments/assets/f0efb41e-c6a3-473a-95a3-bc81de0c6de7" />

2. Torchbench cpu userbenchmark inference & training and inductor quantization
<img width="1212" height="596" alt="image" src="https://github.com/user-attachments/assets/e71c6264-eed4-49d9-8fdc-cad6d5e0fe5a" />

3. Dynamo benchmarks
<img width="967" height="335" alt="image" src="https://github.com/user-attachments/assets/f75406b7-8553-4aac-81ca-bb28139886d0" />

4. Torch AO CPU tests
<img width="1726" height="632" alt="image" src="https://github.com/user-attachments/assets/d69b22f1-136b-49ee-9147-96f55c8d7d9b" />


cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @Guobing-Chen @Xia-Weiwen @snadampal @milpuz01 @aditew01 @nikhil-arm @fadara01 @nWEIdia @malfet