### PR TITLE
Add size_hints to cache key

### DIFF
--- a/test/inductor/test_async_compile.py
+++ b/test/inductor/test_async_compile.py
@@ -79,7 +79,9 @@ def triton_fused_fake_name(in_ptr0, out_ptr0, xnumel, r0_numel, XBLOCK : tl.cons
 
 """
 
-        fn_hash = generate_lookup_hash_from_source_code(func_def)
+        fn_hash = generate_lookup_hash_from_source_code(
+            str({"x": 1024, "r0_": 16384}), func_def
+        )
         block_configs = {
             "XBLOCK": 1,
             "R0_BLOCK": 128,


### PR DESCRIPTION
Differential Revision: D78089705

Previously to support overriding autotune configs for post fusion kernels in Inductor with a lookup table, we only keyed on the source code. However, the same source code could have multiple optimal configs, due to the input sizes. With this, we have many collisions in our lookup table, leading to subpar configs. A way around this is to add the size_hints to the lookup key as well


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov