### PR TITLE
[inductor] use aten `grouped_mm` by default, move template autotuning to max-autotune

### DIFF
--- a/torch/_inductor/kernel/mm_grouped.py
+++ b/torch/_inductor/kernel/mm_grouped.py
@@ -9,6 +9,7 @@ from torch._inductor.runtime.triton_compat import tl
 from torch._inductor.virtualized import V
 from torch.utils._triton import has_triton
 
+from .. import config as inductor_config
 from ..ir import ChoiceCaller, Layout, TensorBox
 from ..lowering import register_lowering
 from ..select_algorithm import (
@@ -481,6 +482,8 @@ def can_use_triton_kernel(
     bias: Optional[TensorBox],
     scale_result: Optional[TensorBox],
 ) -> bool:
+    if not (inductor_config.max_autotune or inductor_config.max_autotune_gemm):
+        return False
     if not (
         torch.cuda.is_available()
         and torch.cuda.get_device_capability() >= (9, 0)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #158045

Seems like the tests were already moved to max-autotune in https://github.com/pytorch/pytorch/pull/150944

Indirectly addresses https://github.com/pytorch/pytorch/issues/158042

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov