### PR TITLE
Move AOTI static linkage header file generation to cpp_wrapper_cpu

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -972,6 +972,33 @@ class CppWrapperCpu(PythonWrapperCodegen):
 
         self.prefix.writeline("}")
 
+    def codegen_static_linkage_model_header(self) -> str:
+        """
+        Generate the header file for each AOTI model. The header file is used in static linkage.
+        """
+        assert config.aot_inductor.compile_standalone
+        with open(
+            os.path.join(
+                os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+                "csrc",
+                "inductor",
+                "aoti_runtime",
+                "model.h",
+            )
+        ) as f:
+            header_code = f.read()
+
+            # we replace like this to avoid replacing
+            # AOTInductorModelBase and AOTInductorModelKernelsBase
+            header_code = (
+                header_code.replace(
+                    "<AOTInductorModel>", f"<{self.aoti_model_class_name}>"
+                )
+                .replace("AOTInductorModel(", f"{self.aoti_model_class_name}(")
+                .replace("AOTInductorModel :", f"{self.aoti_model_class_name} :")
+            )
+            return header_code
+
     def generate(self, is_inference):
         with dynamo_timed("CppWrapperCpu.generate", log_pt2_compile_event=True):
             self.write_wrapper_decl()

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -3299,6 +3299,9 @@ class PythonWrapperCodegen(CodeGen):
     def can_prove_buffer_has_static_shape(buffer):
         return PythonWrapperCodegen.static_shape_for_buffer_or_none(buffer) is not None
 
+    def codegen_static_linkage_model_header(self) -> str:
+        raise NotImplementedError("Unimplemented for PyThonWrapperCodegen")
+
 
 class SubgraphPythonWrapperCodegen(PythonWrapperCodegen):
     """

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1447,6 +1447,12 @@ class _InProcessFxCompile(FxCompile):
                                 output_code_log.debug(
                                     "Output kernel code:\n%s", kernel_code.value
                                 )
+                            header_code = ""
+                            if config.aot_inductor.compile_standalone:
+                                header_code = graph.wrapper_code.codegen_static_linkage_model_header()
+                                output_code_log.debug(
+                                    "Output header code: \n%s", header_code
+                                )
 
                             serialized_extern_kernel_nodes = None
                             if graph.extern_kernel_nodes:
@@ -1470,6 +1476,7 @@ class _InProcessFxCompile(FxCompile):
                                     kernel_code.value,
                                     serialized_extern_kernel_nodes,
                                     device_type=graph.device_type,
+                                    header_code=header_code,
                                     additional_files=[
                                         *dict.fromkeys(
                                             graph.wrapper_code.additional_files


### PR DESCRIPTION
Summary:
We move the header file generation for the following reasons:

1. It's more consistent with how kernel code and wrapper code are generated
2. We will need `device_codegen.cpp_stream_type()` in wrapper to generate the correct device stream type in D77971256

Test Plan:
CI

```
python test/inductor/test_aot_inductor_package.py -k run_static_linkage_model
```

Rollback Plan:

Differential Revision: D78100937




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben