### PR TITLE
Documentation Fix: torch.empty_like memory preservation

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -12108,6 +12108,12 @@ Returns an uninitialized tensor with the same size as :attr:`input`.
     Floating point and complex tensors are filled with NaN, and integer tensors
     are filled with the maximum value.
 
+    When ``torch.preserve_format`` is used:
+    If the input tensor is dense (i.e., non-overlapping strided),
+    its memory format (including strides) is retained.
+    Otherwise (e.g., a non-dense view like a stepped slice),
+    the output is converted to the dense (contiguous) format.
+
 Args:
     {input}
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -12112,7 +12112,7 @@ Returns an uninitialized tensor with the same size as :attr:`input`.
     If the input tensor is dense (i.e., non-overlapping strided),
     its memory format (including strides) is retained.
     Otherwise (e.g., a non-dense view like a stepped slice),
-    the output is converted to the dense (contiguous) format.
+    the output is converted to the dense format.
 
 Args:
     {input}


### PR DESCRIPTION
updated docs for torch.empty_like to reflect view and dense memory behavior

Fixes #158022
