### PR TITLE
Clarify torch.max and torch.min documentation. Dim doesn't support tuple 

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -6554,7 +6554,7 @@ in the output tensors having 1 fewer dimension than ``input``.
 
 Args:
     {input}
-    {opt_dim_without_none}
+    dim (int or name, optional): The dimension to reduce. Passing a tuple of dimensions is not supported.
     {opt_keepdim}
 
 Keyword args:
@@ -7172,7 +7172,7 @@ the output tensors having 1 fewer dimension than :attr:`input`.
 
 Args:
     {input}
-    {opt_dim_without_none}
+    dim (int or name, optional): The dimension to reduce. Passing a tuple of dimensions is not supported.
     {opt_keepdim}
 
 Keyword args:


### PR DESCRIPTION
Fixes #157948

This PR updates the docstrings for torch.max and torch.min to clarify that the dim argument only accepts a single int or named dimension (not a tuple). Passing a tuple currently raises a TypeError, even though the public docs say dim can  be an int or tuple of ints. 

To fix this I replaced {opt_dim_without_none} with the full line: dim (int or name, optional): The dimension to reduce. Passing a tuple of dimensions is not supported.

I left {input} and {opt_keepdim} untouched since their contents are accurate. I replaced just the dim argument because the shared {opt_dim_without_none} placeholder incorrectly suggests that tuples are supported which isn't true for torch.max or torch.min. 

This change should affect both the in-editor help (help(torch.max) ) and the webiste documentation since the docstring is used to generate the web docs as well.

Please let me know if there's a preferred way to handle this kind of one-off clarification, I'm happy to adjust. 
