### PR TITLE
c10d inductor tests: do not re initialize dist process group 

### DIFF
--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -775,17 +775,18 @@ class CompileTest(TestCase):
         torch._inductor.config.triton.store_cubin = True
         torch._inductor.config.debug = True
 
-        self.rank = 0
-        self.world_size = 2
         torch.cuda.set_device("cuda:0")
 
-        store = FakeStore()
-        dist.init_process_group(
-            backend="fake",
-            world_size=self.world_size,
-            rank=self.rank,
-            store=store,
-        )
+        if not dist.is_initialized():
+            self.rank = 0
+            self.world_size = 2
+            store = FakeStore()
+            dist.init_process_group(
+                backend="fake",
+                world_size=self.world_size,
+                rank=self.rank,
+                store=store,
+            )
 
     def tearDown(self):
         dist.destroy_process_group()


### PR DESCRIPTION
I don't work on compile or distributed so I have no idea if this is a good idea

In theory this will fix some flaky tests (flaky b/c failed when try to initialize process group twice) like #146806 #147733 #147911?

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k