### PR TITLE
[AOTI] Add missing ops to set of C-shim ops which can have nullptr returns

### DIFF
--- a/torchgen/gen_aoti_c_shim.py
+++ b/torchgen/gen_aoti_c_shim.py
@@ -249,13 +249,19 @@ def gen_returns(schema: FunctionSchema) -> tuple[list[str], list[str]]:
 
     ret_pointer_can_be_null = False
     unambiguous_name = schema.name.unambiguous_name()
-    for name in [
-        "_scaled_dot_product_flash_attention",
-        "_scaled_dot_product_efficient_attention",
+    for name in (
+        "_functional_sym_constrain_range",
         "_scaled_dot_product_cudnn_attention",
+        "_scaled_dot_product_efficient_attention_backward",
+        "_scaled_dot_product_efficient_attention",
+        "_scaled_dot_product_flash_attention",
         "_scaled_dot_product_fused_attention_overrideable",
+        "_thhn_fused_lstm_cell_backward_impl",
         "convolution_backward",
-    ]:
+        "grid_sampler_2d_backward",
+        "grid_sampler_3d_backward",
+        "linear_backward",
+    ):
         if name in unambiguous_name:
             ret_pointer_can_be_null = True
             break


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #155877
* #158075
* #158074
* __->__ #158073

Most added ops are backwards ops, which have not been well-tested previously (thus why they were missed). Necessary ops were identified by manual examination of torch/_meta_registrations.py return values.