### PR TITLE
Add _GLIBCXX_USE_CXX11_ABI for TorchConfig.cmake.in

### DIFF
--- a/cmake/TorchConfig.cmake.in
+++ b/cmake/TorchConfig.cmake.in
@@ -147,6 +147,11 @@ if(@USE_XPU@ AND @BUILD_SHARED_LIBS@)
     append_torchlib_if_found(c10_xpu torch_xpu)
 endif()
 
+# When we build libtorch with the old libstdc++ ABI, dependent libraries must too.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  set(TORCH_CXX_FLAGS "-D_GLIBCXX_USE_CXX11_ABI=1")
+endif()
+
 find_library(TORCH_LIBRARY torch PATHS "${TORCH_INSTALL_PREFIX}/lib")
 # the statements below changes target properties on
 # - the imported target from Caffe2Targets.cmake in shared library mode (see the find_package above)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #158105

The `cmake/TorchConfig.cmake` in the official release version of PyTorch defines `TORCH_CXX_FLAGS`,
which includes `_GLIBCXX_USE_CXX11_ABI = 1`, but the community trunk version does not,
I am not sure whether the PyTorch release version has some special processing procedures.