### PR TITLE
dist2: cleanup non-option methods on PG (missing, timeouts)

### DIFF
--- a/docs/source/distributed._dist2.md
+++ b/docs/source/distributed._dist2.md
@@ -8,11 +8,5 @@
     :members:
     :undoc-members:
     :show-inheritance:
-```
-
-```{eval-rst}
-.. autoclass:: torch.distributed.ProcessGroup
-    :members:
-    :undoc-members:
-    :show-inheritance:
+    :exclude-members: ReduceOp
 ```

--- a/test/distributed/test_dist2.py
+++ b/test/distributed/test_dist2.py
@@ -1,6 +1,7 @@
 # Owner(s): ["oncall: distributed"]
 
 import os
+import unittest
 from datetime import timedelta
 
 import torch
@@ -12,6 +13,11 @@ from torch.testing._internal.common_distributed import (
     skip_if_lt_x_gpu,
 )
 from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+def synchronize_accelerator():
+    if torch.accelerator.is_available():
+        torch.accelerator.synchronize()
 
 
 class ProcessGroupTest(TestCase):
@@ -41,8 +47,8 @@ class ProcessGroupTest(TestCase):
         self.assertIsNone(dist2.current_process_group())
 
 
-class ProcessGroupGlooTest(MultiProcessTestCase):
-    lazy_init = False
+class Dist2MultiProcessTestCase(MultiProcessTestCase):
+    device: torch.device
 
     @property
     def world_size(self) -> int:
@@ -52,60 +58,189 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         super().setUp()
         self._spawn_processes()
 
+    def new_group(self) -> torch.distributed.ProcessGroup:
+        raise unittest.SkipTest("new_group() must be implemented by subclasses")
+
+    def test_allreduce(self) -> None:
+        pg = self.new_group()
+
+        t = torch.ones(10, device=self.device)
+        pg.allreduce(t, timeout=timedelta(seconds=30)).wait()
+
+        synchronize_accelerator()
+
+        self.assertEqual(t, torch.full_like(t, self.world_size))
+
+        pg.shutdown()
+
+    def test_barrier(self) -> None:
+        pg = self.new_group()
+
+        pg.barrier(timeout=timedelta(seconds=30)).wait()
+
+        synchronize_accelerator()
+
+        pg.shutdown()
+
+    def test_broadcast(self) -> None:
+        pg = self.new_group()
+
+        t = torch.full((10,), self.rank, device=self.device)
+        pg.broadcast(t, root=0, timeout=timedelta(seconds=30)).wait()
+
+        synchronize_accelerator()
+
+        self.assertEqual(t, torch.full_like(t, 0))
+
+        pg.shutdown()
+
+    def test_allgather(self) -> None:
+        pg = self.new_group()
+
+        t = torch.full((10,), self.rank + 1, device=self.device, dtype=torch.float32)
+        out = [torch.zeros(10, device=self.device) for _ in range(self.world_size)]
+        pg.allgather(out, t, timeout=timedelta(seconds=30)).wait()
+
+        synchronize_accelerator()
+
+        for i in range(self.world_size):
+            self.assertEqual(out[i], torch.full_like(t, i + 1))
+
+        pg.shutdown()
+
+    def test_gather(self) -> None:
+        pg = self.new_group()
+
+        inp = torch.full((10,), self.rank + 1, device=self.device, dtype=torch.float32)
+        out = (
+            [torch.zeros(10, device=self.device) for _ in range(self.world_size)]
+            if self.rank == 0
+            else []
+        )
+        pg.gather(out, inp, root=0, timeout=timedelta(seconds=30)).wait()
+
+        synchronize_accelerator()
+
+        if self.rank == 0:
+            for i in range(self.world_size):
+                self.assertEqual(out[i], torch.full_like(inp, i + 1))
+
+        pg.shutdown()
+
+    def test_scatter(self) -> None:
+        pg = self.new_group()
+
+        inp = (
+            [
+                torch.torch.full((10,), i + 1, device=self.device, dtype=torch.float32)
+                for i in range(self.world_size)
+            ]
+            if self.rank == 0
+            else []
+        )
+        out = torch.zeros(10, device=self.device)
+        pg.scatter(out, inp, root=0, timeout=timedelta(seconds=30)).wait()
+
+        synchronize_accelerator()
+
+        self.assertEqual(out, torch.full_like(out, self.rank + 1))
+
+        pg.shutdown()
+
+    def test_reduce(self) -> None:
+        pg = self.new_group()
+
+        t = torch.full((10,), 1, device=self.device, dtype=torch.float32)
+        pg.reduce(
+            t, root=0, op=dist2.ReduceOp.SUM, timeout=timedelta(seconds=30)
+        ).wait()
+
+        synchronize_accelerator()
+
+        if self.rank == 0:
+            self.assertEqual(t, torch.full_like(t, self.world_size))
+
+        pg.shutdown()
+
+    def test_reduce_scatter(self) -> None:
+        pg = self.new_group()
+
+        inp = [
+            torch.full((10,), i + 1, device=self.device, dtype=torch.float32)
+            for i in range(self.world_size)
+        ]
+        out = torch.zeros(10, device=self.device)
+        pg.reduce_scatter(
+            out, inp, op=dist2.ReduceOp.SUM, timeout=timedelta(seconds=30)
+        ).wait()
+
+        synchronize_accelerator()
+
+        self.assertEqual(out, torch.full_like(out, self.world_size * (self.rank + 1)))
+
+        pg.shutdown()
+
+    def test_alltoall_base(self) -> None:
+        pg = self.new_group()
+
+        out = torch.zeros(self.world_size * 10, device=self.device)
+        inp = torch.full(
+            (self.world_size * 10,),
+            self.rank + 1,
+            device=self.device,
+            dtype=torch.float32,
+        )
+        split_sizes = [10 for _ in range(self.world_size)]
+        pg.alltoall_base(
+            out, inp, split_sizes, split_sizes, timeout=timedelta(seconds=30)
+        ).wait()
+
+        synchronize_accelerator()
+
+        for i in range(self.world_size):
+            out_range = out[i * 10 : (i + 1) * 10]
+            self.assertEqual(out_range, torch.full_like(out_range, i + 1))
+
+
+class ProcessGroupGlooTest(Dist2MultiProcessTestCase):
+    device = torch.device("cpu")
+
     @requires_gloo()
-    def test_new_group(self):
+    def new_group(self) -> torch.distributed.ProcessGroup:
         os.environ["RANK"] = str(self.rank)
         os.environ["WORLD_SIZE"] = str(self.world_size)
         os.environ["MASTER_ADDR"] = "127.0.0.1"
         os.environ["MASTER_PORT"] = "29500"
 
-        device = "cpu"
-
-        group = dist2.new_group(
+        return dist2.new_group(
             backend="gloo",
             timeout=timedelta(seconds=60),
-            device=device,
+            device=self.device,
             pg_options=None,
         )
 
-        t = torch.rand(10, device=device)
-        group.allreduce(t).wait()
 
-
-class ProcessGroupNCCLTest(MultiProcessTestCase):
-    lazy_init = False
-
-    @property
-    def world_size(self) -> int:
-        return 2
-
-    def setUp(self):
-        super().setUp()
-        self._spawn_processes()
-
+class ProcessGroupNCCLTest(Dist2MultiProcessTestCase):
     @requires_nccl()
     @skip_if_lt_x_gpu(2)
-    def test_new_group(self):
+    def new_group(self) -> torch.distributed.ProcessGroup:
         os.environ["RANK"] = str(self.rank)
         os.environ["WORLD_SIZE"] = str(self.world_size)
         os.environ["MASTER_ADDR"] = "127.0.0.1"
-        os.environ["MASTER_PORT"] = "29500"
+        os.environ["MASTER_PORT"] = "29501"
 
-        device = torch.device("cuda", self.rank)
+        self.device = torch.device("cuda", self.rank)
 
         from torch.distributed import ProcessGroupNCCL
 
         opts = ProcessGroupNCCL.Options()
 
-        group = dist2.new_group(
+        return dist2.new_group(
             backend="nccl",
             timeout=timedelta(seconds=60),
-            device=device,
+            device=self.device,
             pg_options=opts,
         )
-
-        t = torch.rand(10, device=device)
-        group.allreduce(t).wait()
 
 
 if __name__ == "__main__":

--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -362,6 +362,7 @@ class ProcessGroup:
         self,
         tensor: Tensor,
         root: int,
+        timeout: timedelta | None = None,
     ) -> Work: ...
     @overload
     def allreduce(
@@ -374,12 +375,14 @@ class ProcessGroup:
         self,
         tensors: list[Tensor],
         op=...,
+        timeout: timedelta | None = None,
     ) -> Work: ...
     @overload
     def allreduce(
         self,
         tensor: Tensor,
         op=...,
+        timeout: timedelta | None = None,
     ) -> Work: ...
     def allreduce_coalesced(
         self,
@@ -404,6 +407,7 @@ class ProcessGroup:
         tensor: Tensor,
         root: int,
         op=...,
+        timeout: timedelta | None = None,
     ) -> Work: ...
     @overload
     def allgather(
@@ -417,6 +421,7 @@ class ProcessGroup:
         self,
         output_tensors: list[Tensor],
         input_tensor: Tensor,
+        timeout: timedelta | None = None,
     ) -> Work: ...
     def _allgather_base(
         self,
@@ -449,6 +454,7 @@ class ProcessGroup:
         output_tensors: list[Tensor],
         input_tensor: Tensor,
         root: int,
+        timeout: timedelta | None = None,
     ) -> Work: ...
     @overload
     def scatter(
@@ -463,6 +469,7 @@ class ProcessGroup:
         output_tensor: Tensor,
         input_tensors: list[Tensor],
         root: int,
+        timeout: timedelta | None = None,
     ) -> Work: ...
     @overload
     def reduce_scatter(
@@ -476,6 +483,8 @@ class ProcessGroup:
         self,
         output_tensors: Tensor,
         input_tensor: list[Tensor],
+        op=...,
+        timeout: timedelta | None = None,
     ) -> Work: ...
     def _reduce_scatter_base(
         self,
@@ -499,6 +508,7 @@ class ProcessGroup:
         input: Tensor,
         output_split_sizes: list[int],
         input_split_sizes: list[int],
+        timeout: timedelta | None = None,
     ) -> Work: ...
     @overload
     def alltoall(
@@ -512,6 +522,7 @@ class ProcessGroup:
         self,
         output: list[Tensor],
         input: list[Tensor],
+        timeout: timedelta | None = None,
     ) -> Work: ...
     def send(
         self,
@@ -526,7 +537,10 @@ class ProcessGroup:
         tag: int,
     ) -> Work: ...
     def recv_anysource(self, tensors: list[Tensor], tag: int) -> Work: ...
+    @overload
     def barrier(self, opts=...) -> Work: ...
+    @overload
+    def barrier(self, timeout: timedelta | None = None) -> Work: ...
     def boxed(self) -> ScriptObject: ...
     @staticmethod
     def unbox(obj: ScriptObject) -> ProcessGroup: ...

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -2091,14 +2091,17 @@ communication mechanism.
               "broadcast",
               [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
                  at::Tensor& x,
-                 int rootRank) {
+                 int rootRank,
+                std::optional<std::chrono::milliseconds> timeout) {
                 ::c10d::BroadcastOptions opts;
                 opts.rootRank = rootRank;
+                opts.timeout = timeout.value_or(::c10d::kUnsetTimeout);
                 std::vector<at::Tensor> tensors = {x};
                 return self->broadcast(tensors, opts);
               },
               py::arg("tensor"),
               py::arg("root"),
+              py::arg("timeout") = std::nullopt,
               py::call_guard<py::gil_scoped_release>(),
               R"(Broadcasts the tensor to all processes in the process group.
 
@@ -2116,13 +2119,16 @@ communication mechanism.
               "allreduce",
               [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
                  std::vector<at::Tensor>& xs,
-                 const ::c10d::ReduceOp& op) {
+                 const ::c10d::ReduceOp& op,
+                std::optional<std::chrono::milliseconds> timeout) {
                 ::c10d::AllreduceOptions opts;
                 opts.reduceOp = op;
+                opts.timeout = timeout.value_or(::c10d::kUnsetTimeout);
                 return self->allreduce(xs, opts);
               },
               py::arg("tensors"),
               py::arg("op") = ::c10d::ReduceOp::SUM,
+              py::arg("timeout") = std::nullopt,
               py::call_guard<py::gil_scoped_release>(),
               R"(Allreduces the provided tensors across all processes in the process group.
 
@@ -2132,14 +2138,17 @@ communication mechanism.
               "allreduce",
               [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
                  at::Tensor& x,
-                 const ::c10d::ReduceOp& op) {
+                 const ::c10d::ReduceOp& op,
+                 std::optional<std::chrono::milliseconds> timeout) {
                 ::c10d::AllreduceOptions opts;
                 opts.reduceOp = op;
+                opts.timeout = timeout.value_or(::c10d::kUnsetTimeout);
                 std::vector<at::Tensor> xs = {x};
                 return self->allreduce(xs, opts);
               },
               py::arg("tensor"),
               py::arg("op") = ::c10d::ReduceOp::SUM,
+              py::arg("timeout") = std::nullopt,
               py::call_guard<py::gil_scoped_release>(),
               R"(Allreduces the provided tensors across all processes in the process group.
 
@@ -2169,16 +2178,19 @@ communication mechanism.
               [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
                  at::Tensor& x,
                  int rootRank,
-                 const ::c10d::ReduceOp& op) {
+                 const ::c10d::ReduceOp& op,
+                std::optional<std::chrono::milliseconds> timeout) {
                 ::c10d::ReduceOptions opts;
                 opts.reduceOp = op;
                 opts.rootRank = rootRank;
+                opts.timeout = timeout.value_or(::c10d::kUnsetTimeout);
                 std::vector<at::Tensor> xs = {x};
                 return self->reduce(xs, opts);
               },
               py::arg("tensor"),
               py::arg("root"),
               py::arg("op") = ::c10d::ReduceOp::SUM,
+              py::arg("timeout") = std::nullopt,
               py::call_guard<py::gil_scoped_release>(),
               R"(Reduces the provided tensors across all processes in the process group.
 
@@ -2197,14 +2209,17 @@ communication mechanism.
               "allgather",
               [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
                  std::vector<at::Tensor>& output,
-                 at::Tensor& input) {
+                 at::Tensor& input,
+                 std::optional<std::chrono::milliseconds> timeout) {
                 std::vector<std::vector<at::Tensor>> outputs = {output};
                 std::vector<at::Tensor> inputs = {input};
-                return self->allgather(
-                    outputs, inputs, ::c10d::AllgatherOptions());
+                ::c10d::AllgatherOptions opts;
+                opts.timeout = timeout.value_or(::c10d::kUnsetTimeout);
+                return self->allgather(outputs, inputs, opts);
               },
               py::arg("output_tensors"),
               py::arg("input_tensor"),
+              py::arg("timeout") = std::nullopt,
               py::call_guard<py::gil_scoped_release>(),
               R"(Allgathers the input tensors from all processes across the process group.
 
@@ -2252,16 +2267,22 @@ communication mechanism.
               [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
                  std::vector<at::Tensor>& output,
                  at::Tensor& input,
-                 int rootRank) {
+                 int rootRank,
+                std::optional<std::chrono::milliseconds> timeout) {
                 ::c10d::GatherOptions opts;
                 opts.rootRank = rootRank;
-                std::vector<std::vector<at::Tensor>> outputs = {output};
+                opts.timeout = timeout.value_or(::c10d::kUnsetTimeout);
+                std::vector<std::vector<at::Tensor>> outputs{};
+                if (!output.empty()) {
+                  outputs.push_back(output);
+                }
                 std::vector<at::Tensor> inputs = {input};
                 return self->gather(outputs, inputs, opts);
               },
               py::arg("output_tensors"),
               py::arg("input_tensor"),
               py::arg("root"),
+              py::arg("timeout") = std::nullopt,
               py::call_guard<py::gil_scoped_release>(),
               R"(Gathers the input tensors from all processes across the process group.
 
@@ -2281,16 +2302,22 @@ communication mechanism.
               [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
                  at::Tensor& output,
                  std::vector<at::Tensor>& input,
-                 int rootRank) {
+                 int rootRank,
+                std::optional<std::chrono::milliseconds> timeout) {
                 ::c10d::ScatterOptions opts;
                 opts.rootRank = rootRank;
-                std::vector<std::vector<at::Tensor>> inputs = {input};
+                opts.timeout = timeout.value_or(::c10d::kUnsetTimeout);
+                std::vector<std::vector<at::Tensor>> inputs{};
+                if (!input.empty()) {
+                  inputs.push_back(input);
+                }
                 std::vector<at::Tensor> outputs = {output};
                 return self->scatter(outputs, inputs, opts);
               },
               py::arg("output_tensor"),
               py::arg("input_tensors"),
               py::arg("root"),
+              py::arg("timeout") = std::nullopt,
               py::call_guard<py::gil_scoped_release>(),
               R"(Scatters the input tensors from all processes across the process group.
 
@@ -2310,16 +2337,19 @@ communication mechanism.
               [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
                  at::Tensor& output,
                  std::vector<at::Tensor>& input,
-                 const ::c10d::ReduceOp& op) {
+                 const ::c10d::ReduceOp& op,
+                std::optional<std::chrono::milliseconds> timeout) {
                 std::vector<at::Tensor> outputs = {output};
                 std::vector<std::vector<at::Tensor>> inputs = {input};
                 ::c10d::ReduceScatterOptions opts;
                 opts.reduceOp = op;
+                opts.timeout = timeout.value_or(::c10d::kUnsetTimeout);
                 return self->reduce_scatter(outputs, inputs, opts);
               },
               py::arg("output"),
               py::arg("input"),
               py::arg("op") = ::c10d::ReduceOp::SUM,
+              py::arg("timeout") = std::nullopt,
               py::call_guard<py::gil_scoped_release>(),
               R"(Reduces and scatters the input tensors from all processes across the process group.
 
@@ -2349,6 +2379,27 @@ communication mechanism.
               py::arg("output_split_sizes"),
               py::arg("input_split_sizes"),
               py::arg("opts") = ::c10d::AllToAllOptions(),
+              py::call_guard<py::gil_scoped_release>(),
+              R"(Alltoalls the input tensors from all processes across the process group.
+
+              See :func:`torch.distributed.all_to_all` for more details.)")
+          .def(
+              "alltoall_base",
+              [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+                 at::Tensor& output,
+                 at::Tensor& input,
+                 std::vector<int64_t>& outputSplitSizes,
+                 std::vector<int64_t>& inputSplitSizes,
+                std::optional<std::chrono::milliseconds> timeout) {
+                ::c10d::AllToAllOptions opts;
+                opts.timeout = timeout.value_or(::c10d::kUnsetTimeout);
+                return self->alltoall_base(output, input, outputSplitSizes, inputSplitSizes, opts);
+              },
+              py::arg("output"),
+              py::arg("input"),
+              py::arg("output_split_sizes"),
+              py::arg("input_split_sizes"),
+              py::arg("timeout") = std::nullopt,
               py::call_guard<py::gil_scoped_release>(),
               R"(Alltoalls the input tensors from all processes across the process group.
 
@@ -2400,6 +2451,20 @@ communication mechanism.
 
               See :func:`torch.distributed.barrier` for more details.)")
           .def(
+            "barrier",
+              [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+                std::optional<std::chrono::milliseconds> timeout) {
+                    ::c10d::BarrierOptions opts;
+                    opts.timeout = timeout.value_or(::c10d::kUnsetTimeout);
+                    return self->barrier(opts);
+                },
+                py::arg("timeout") = std::nullopt,
+                py::call_guard<py::gil_scoped_release>(),
+              R"(Blocks until all processes in the group enter the call, and
+              then all leave the call together.
+
+              See :func:`torch.distributed.barrier` for more details.)")
+          .def(
               "_set_sequence_number_for_group",
               &::c10d::ProcessGroup::setSequenceNumberForGroup,
               py::call_guard<py::gil_scoped_release>())
@@ -2410,13 +2475,13 @@ communication mechanism.
           .def(
               "monitored_barrier",
               [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
-                 const std::chrono::milliseconds& timeout,
+                 const std::optional<std::chrono::milliseconds>& timeout,
                  bool waitAllRanks) {
                 ::c10d::BarrierOptions opts;
-                opts.timeout = timeout;
+                opts.timeout = timeout.value_or(::c10d::kUnsetTimeout);
                 return self->monitoredBarrier(opts, waitAllRanks);
               },
-              py::arg("timeout") = ::c10d::kUnsetTimeout,
+              py::arg("timeout") = std::nullopt,
               py::arg("wait_all_ranks") = false,
               py::call_guard<py::gil_scoped_release>(),
               R"(Blocks until all processes in the group enter the call, and
@@ -2626,14 +2691,17 @@ Arguments:
               "broadcast",
               [](const c10::intrusive_ptr<::c10d::Backend>& self,
                  at::Tensor& x,
-                 int rootRank) {
+                 int rootRank,
+                 std::optional<std::chrono::milliseconds> timeout) {
                 ::c10d::BroadcastOptions opts;
                 opts.rootRank = rootRank;
+                opts.timeout = timeout.value_or(::c10d::kUnsetTimeout);
                 std::vector<at::Tensor> xs = {x};
                 return self->broadcast(xs, opts);
               },
               py::arg("tensor"),
               py::arg("root"),
+              py::arg("timeout") = std::nullopt,
               py::call_guard<py::gil_scoped_release>())
           .def(
               "allreduce",
@@ -2645,26 +2713,32 @@ Arguments:
               "allreduce",
               [](const c10::intrusive_ptr<::c10d::Backend>& self,
                  std::vector<at::Tensor>& xs,
-                 const ::c10d::ReduceOp& op) {
+                 const ::c10d::ReduceOp& op,
+                 std::optional<std::chrono::milliseconds> timeout) {
                 ::c10d::AllreduceOptions opts;
                 opts.reduceOp = op;
+                opts.timeout = timeout.value_or(::c10d::kUnsetTimeout);
                 return self->allreduce(xs, opts);
               },
               py::arg("tensors"),
               py::arg("op") = ::c10d::ReduceOp::SUM,
+              py::arg("timeout") = std::nullopt,
               py::call_guard<py::gil_scoped_release>())
           .def(
               "allreduce",
               [](const c10::intrusive_ptr<::c10d::Backend>& self,
                  at::Tensor& x,
-                 const ::c10d::ReduceOp& op) {
+                 const ::c10d::ReduceOp& op,
+                 std::optional<std::chrono::milliseconds> timeout) {
                 ::c10d::AllreduceOptions opts;
                 opts.reduceOp = op;
+                opts.timeout = timeout.value_or(::c10d::kUnsetTimeout);
                 std::vector<at::Tensor> xs = {x};
                 return self->allreduce(xs, opts);
               },
               py::arg("tensor"),
               py::arg("op") = ::c10d::ReduceOp::SUM,
+              py::arg("timeout") = std::nullopt,
               py::call_guard<py::gil_scoped_release>())
           .def(
               "allreduce_coalesced",
@@ -2683,16 +2757,19 @@ Arguments:
               [](const c10::intrusive_ptr<::c10d::Backend>& self,
                  at::Tensor& x,
                  int rootRank,
-                 const ::c10d::ReduceOp& op) {
+                 const ::c10d::ReduceOp& op,
+                 std::chrono::milliseconds timeout) {
                 ::c10d::ReduceOptions opts;
                 opts.reduceOp = op;
                 opts.rootRank = rootRank;
+                opts.timeout = timeout;
                 std::vector<at::Tensor> xs = {x};
                 return self->reduce(xs, opts);
               },
               py::arg("tensor"),
               py::arg("root"),
               py::arg("op") = ::c10d::ReduceOp::SUM,
+              py::arg("timeout") = ::c10d::kUnsetTimeout,
               py::call_guard<py::gil_scoped_release>())
           .def(
               "allgather",
@@ -2712,14 +2789,17 @@ Arguments:
               "allgather",
               [](const c10::intrusive_ptr<::c10d::Backend>& self,
                  std::vector<at::Tensor>& output,
-                 at::Tensor& input) {
+                 at::Tensor& input,
+                 std::chrono::milliseconds timeout) {
                 std::vector<std::vector<at::Tensor>> outputs = {output};
                 std::vector<at::Tensor> inputs = {input};
-                return self->allgather(
-                    outputs, inputs, ::c10d::AllgatherOptions());
+                ::c10d::AllgatherOptions opts;
+                opts.timeout = timeout;
+                return self->allgather(outputs, inputs, opts);
               },
               py::arg("output_tensors"),
               py::arg("input_tensor"),
+              py::arg("timeout") = ::c10d::kUnsetTimeout,
               py::call_guard<py::gil_scoped_release>())
           .def(
               "allgather_coalesced",
@@ -2740,16 +2820,22 @@ Arguments:
               [](const c10::intrusive_ptr<::c10d::Backend>& self,
                  std::vector<at::Tensor>& output,
                  at::Tensor& input,
-                 int rootRank) {
+                 int rootRank,
+                 std::chrono::milliseconds timeout) {
                 ::c10d::GatherOptions opts;
                 opts.rootRank = rootRank;
-                std::vector<std::vector<at::Tensor>> outputs = {output};
+                opts.timeout = timeout;
+                std::vector<std::vector<at::Tensor>> outputs{};
+                if (!output.empty()) {
+                  outputs.push_back(output);
+                }
                 std::vector<at::Tensor> inputs = {input};
                 return self->gather(outputs, inputs, opts);
               },
               py::arg("output_tensors"),
               py::arg("input_tensor"),
               py::arg("root"),
+              py::arg("timeout") = ::c10d::kUnsetTimeout,
               py::call_guard<py::gil_scoped_release>())
           .def(
               "scatter",
@@ -2763,16 +2849,22 @@ Arguments:
               [](const c10::intrusive_ptr<::c10d::Backend>& self,
                  at::Tensor& output,
                  std::vector<at::Tensor>& input,
-                 int rootRank) {
+                 int rootRank,
+                 std::chrono::milliseconds timeout) {
                 ::c10d::ScatterOptions opts;
                 opts.rootRank = rootRank;
-                std::vector<std::vector<at::Tensor>> inputs = {input};
+                opts.timeout = timeout;
+                std::vector<std::vector<at::Tensor>> inputs{};
+                if (!input.empty()) {
+                  inputs.push_back(input);
+                }
                 std::vector<at::Tensor> outputs = {output};
                 return self->scatter(outputs, inputs, opts);
               },
               py::arg("output_tensor"),
               py::arg("input_tensors"),
               py::arg("root"),
+              py::arg("timeout") = ::c10d::kUnsetTimeout,
               py::call_guard<py::gil_scoped_release>())
           .def(
               "reduce_scatter",
@@ -2786,16 +2878,19 @@ Arguments:
               [](const c10::intrusive_ptr<::c10d::Backend>& self,
                  at::Tensor& output,
                  std::vector<at::Tensor>& input,
-                 const ::c10d::ReduceOp& op) {
+                 const ::c10d::ReduceOp& op,
+                 std::chrono::milliseconds timeout) {
                 std::vector<at::Tensor> outputs = {output};
                 std::vector<std::vector<at::Tensor>> inputs = {input};
                 ::c10d::ReduceScatterOptions opts;
                 opts.reduceOp = op;
+                opts.timeout = timeout;
                 return self->reduce_scatter(outputs, inputs, opts);
               },
               py::arg("output_tensors"),
               py::arg("input_tensor"),
               py::arg("op") = ::c10d::ReduceOp::SUM,
+              py::arg("timeout") = ::c10d::kUnsetTimeout,
               py::call_guard<py::gil_scoped_release>())
           .def(
               "_reduce_scatter_base",
@@ -2818,19 +2913,19 @@ Arguments:
               [](::c10d::Backend& self,
                  at::Tensor& output,
                  at::Tensor& input,
-                 std::vector<int64_t> outputSplitSizes,
-                 std::vector<int64_t> inputSplitSizes) {
+                 std::vector<int64_t>& outputSplitSizes,
+                 std::vector<int64_t>& inputSplitSizes,
+                 std::chrono::milliseconds timeout) {
+                ::c10d::AllToAllOptions opts;
+                opts.timeout = timeout;
                 return self.alltoall_base(
-                    output,
-                    input,
-                    outputSplitSizes,
-                    inputSplitSizes,
-                    ::c10d::AllToAllOptions());
+                    output, input, outputSplitSizes, inputSplitSizes, opts);
               },
               py::arg("output"),
               py::arg("input"),
               py::arg("output_split_sizes"),
               py::arg("input_split_sizes"),
+              py::arg("timeout") = ::c10d::kUnsetTimeout,
               py::call_guard<py::gil_scoped_release>())
           .def(
               "alltoall",

--- a/torch/distributed/_dist2.py
+++ b/torch/distributed/_dist2.py
@@ -18,12 +18,23 @@ from torch._C._distributed_c10d import (
     _set_process_group,
     Backend,
     ProcessGroup,
+    ReduceOp,
     Store,
 )
 from torch.distributed.rendezvous import rendezvous
 
 
 _BACKENDS: dict[str, "ProcessGroupFactory"] = {}
+
+__all__ = [
+    "ProcessGroup",
+    "ReduceOp",
+    "ProcessGroupFactory",
+    "register_backend",
+    "new_group",
+    "current_process_group",
+    "process_group",
+]
 
 
 class ProcessGroupFactory(Protocol):


### PR DESCRIPTION
This updates the ProcessGroup.* API to include timeouts on all non-option based overloaded methods. This also adds 2 missing ones `alltoall_base` and `barrier`.

Following design in: https://docs.google.com/document/d/13R-1t_yESTvmAjcCN-wQjQQadIEu0JNIdS65uZawZzY/edit?tab=t.0#heading=h.3ctbqqopzc89

Test plan:

```
pytest test/distributed/test_dist2.py
```

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab