### PR TITLE
[Inductor] addmm + activation function fusion

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -3710,6 +3710,7 @@ def run(runner, args, original_dir=None):
             "DebertaForQuestionAnswering",
             "nvidia_deeprecommender",
             "crossvit_9_240",
+            "vision_maskrcnn",
         }:
             # These seem unhappy with numerics of larger cuBLASLt workspace
             torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = False

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -3710,7 +3710,6 @@ def run(runner, args, original_dir=None):
             "DebertaForQuestionAnswering",
             "nvidia_deeprecommender",
             "crossvit_9_240",
-            "vision_maskrcnn",
         }:
             # These seem unhappy with numerics of larger cuBLASLt workspace
             torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = False

--- a/benchmarks/dynamo/torchbench.yaml
+++ b/benchmarks/dynamo/torchbench.yaml
@@ -72,6 +72,7 @@ tolerance:
 require_larger_multiplier_for_smaller_tensor:
   - yolov3
   - timm_efficientnet
+  - vision_maskrcnn
 
 # These benchmarks took >600s on an i9-11900K CPU
 very_slow: &VERY_SLOW_MODELS

--- a/benchmarks/dynamo/torchbench.yaml
+++ b/benchmarks/dynamo/torchbench.yaml
@@ -43,6 +43,7 @@ tolerance:
     - timm_efficientdet
     - timm_efficientnet
     - squeezenet1_1
+    - vision_maskrcnn
 
   higher_fp16:
     - doctr_reco_predictor
@@ -72,7 +73,6 @@ tolerance:
 require_larger_multiplier_for_smaller_tensor:
   - yolov3
   - timm_efficientnet
-  - vision_maskrcnn
 
 # These benchmarks took >600s on an i9-11900K CPU
 very_slow: &VERY_SLOW_MODELS

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -640,13 +640,17 @@ class TestPatternMatcher(TestCase):
             return torch.nn.functional.relu(torch.addmm(input, mat1, mat2))
 
         def fn_addmm_gelu(input, mat1, mat2):
-            return torch.nn.functional.gelu(torch.addmm(input, mat1, mat2), approximate="tanh")
-        
+            return torch.nn.functional.gelu(
+                torch.addmm(input, mat1, mat2), approximate="tanh"
+            )
+
         def fn_add_mm_relu(input, mat1, mat2):
             return torch.nn.functional.relu(torch.add(input, torch.mm(mat1, mat2)))
 
         def fn_add_mm_gelu(input, mat1, mat2):
-            return torch.nn.functional.gelu(torch.add(input, torch.mm(mat1, mat2)), approximate="tanh")
+            return torch.nn.functional.gelu(
+                torch.add(input, torch.mm(mat1, mat2)), approximate="tanh"
+            )
 
         args = [
             torch.randn(20, device="cuda"),
@@ -666,7 +670,9 @@ class TestPatternMatcher(TestCase):
             self.assertTrue("_addmm_activation" in code)
 
         for fn in (fn_addmm_relu, fn_addmm_gelu):
-            actual, (code,) = run_and_get_code(torch.compile(fn, options={"max_autotune_gemm": True}), *args)
+            actual, (code,) = run_and_get_code(
+                torch.compile(fn, options={"max_autotune_gemm": True}), *args
+            )
             self.assertFalse("_addmm_activation" in code)
 
         args_not_replaced = [
@@ -678,7 +684,12 @@ class TestPatternMatcher(TestCase):
         ]
 
         for fn in (fn_addmm_relu, fn_addmm_gelu):
-            actual, (code,) = run_and_get_code(torch.compile(fn,), *args_not_replaced)
+            actual, (code,) = run_and_get_code(
+                torch.compile(
+                    fn,
+                ),
+                *args_not_replaced,
+            )
             self.assertFalse("_addmm_activation" in code)
 
     @inductor_config.patch(

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -635,6 +635,60 @@ class TestPatternMatcher(TestCase):
 
         self.assertEqual(res1, res2)
 
+    def test_addmm_activation(self):
+        def fn_addmm_relu(input, mat1, mat2):
+            return torch.nn.functional.relu(torch.addmm(input, mat1, mat2))
+
+        def fn_addmm_gelu(input, mat1, mat2):
+            return torch.nn.functional.gelu(torch.addmm(input, mat1, mat2))
+        
+        def fn_add_mm_relu(input, mat1, mat2):
+            return torch.nn.functional.relu(torch.add(input, torch.mm(mat1, mat2)))
+
+        def fn_add_mm_gelu(input, mat1, mat2):
+            return torch.nn.functional.gelu(torch.add(input, torch.mm(mat1, mat2)))
+
+        args = [
+            torch.randn(20, device="cuda"),
+            torch.randn(10, 15, device="cuda"),
+            torch.randn(15, 20, device="cuda"),
+        ]
+
+        for fn, atol in (
+            (fn_addmm_relu, 1e-8),
+            (fn_add_mm_relu, 1e-8),
+            (fn_addmm_gelu, 1e-3),
+            (fn_add_mm_gelu, 1e-3),
+        ):
+            expected = fn(*args)
+            actual, (code,) = run_and_get_code(torch.compile(fn), *args)
+            torch.testing.assert_close(actual, expected, atol=atol, rtol=0)
+            self.assertTrue("_addmm_activation" in code)
+
+        for fn in (fn_addmm_relu, fn_addmm_gelu):
+            counters.clear()
+            torch.compile(
+                fn,
+                # replacement disabled on max_autotune_gemm
+                options={"max_autotune_gemm": True},
+            )(*args)
+            self.assertEqual(counters["inductor"]["pattern_matcher_count"], 0)
+            self.assertEqual(counters["inductor"]["pattern_matcher_nodes"], 0)
+
+        args_not_replaced = [
+            # addmm + activation with a rank-2 input
+            # is not fusable, hence not replaced
+            torch.randn(10, 20, device="cuda"),  # input
+            torch.randn(10, 15, device="cuda"),  # mat1
+            torch.randn(15, 20, device="cuda"),  # mat2
+        ]
+
+        for fn in (fn_addmm_relu, fn_addmm_gelu):
+            counters.clear()
+            torch.compile(fn)(*args_not_replaced)
+            self.assertEqual(counters["inductor"]["pattern_matcher_count"], 0)
+            self.assertEqual(counters["inductor"]["pattern_matcher_nodes"], 0)
+
     @inductor_config.patch(
         {
             "max_autotune_gemm_backends": "ATEN",

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -635,6 +635,7 @@ class TestPatternMatcher(TestCase):
 
         self.assertEqual(res1, res2)
 
+    @skipIfRocm
     def test_addmm_activation(self):
         def fn_addmm_relu(input, mat1, mat2):
             return torch.nn.functional.relu(torch.addmm(input, mat1, mat2))
@@ -653,9 +654,9 @@ class TestPatternMatcher(TestCase):
             )
 
         args = [
-            torch.randn(20, device="cuda"),
-            torch.randn(10, 15, device="cuda"),
-            torch.randn(15, 20, device="cuda"),
+            torch.randn(20, device=GPU_TYPE),
+            torch.randn(10, 15, device=GPU_TYPE),
+            torch.randn(15, 20, device=GPU_TYPE),
         ]
 
         for fn, atol in (
@@ -678,9 +679,9 @@ class TestPatternMatcher(TestCase):
         args_not_replaced = [
             # addmm + activation with a rank-2 input
             # is not fusable, hence not replaced
-            torch.randn(10, 20, device="cuda"),  # input
-            torch.randn(10, 15, device="cuda"),  # mat1
-            torch.randn(15, 20, device="cuda"),  # mat2
+            torch.randn(10, 20, device=GPU_TYPE),  # input
+            torch.randn(10, 15, device=GPU_TYPE),  # mat1
+            torch.randn(15, 20, device=GPU_TYPE),  # mat2
         ]
 
         for fn in (fn_addmm_relu, fn_addmm_gelu):

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -660,19 +660,19 @@ def lazy_init():
         extra_check=prepare_softmax_extra_check,
     )
 
-    # for dtype in [torch.bfloat16, torch.float32]:
-    #     register_replacement(
-    #         addmm_gelu_pattern,
-    #         addmm_gelu_replacement,
-    #         [
-    #             torch.empty(5, dtype=dtype),
-    #             torch.empty(3, 4, dtype=dtype),
-    #             torch.empty(4, 5, dtype=dtype),
-    #         ],
-    #         trace_fn=fwd_only,
-    #         pass_dicts=pass_patterns[2],
-    #         extra_check=is_valid_addmm_activation_fusion,
-    #     )
+    for dtype in [torch.bfloat16, torch.float32]:
+        register_replacement(
+            addmm_gelu_pattern,
+            addmm_gelu_replacement,
+            [
+                torch.empty(5, dtype=dtype),
+                torch.empty(3, 4, dtype=dtype),
+                torch.empty(4, 5, dtype=dtype),
+            ],
+            trace_fn=fwd_only,
+            pass_dicts=pass_patterns[2],
+            extra_check=is_valid_addmm_activation_fusion,
+        )
 
     register_replacement(
         addmm_relu_pattern,

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -1547,7 +1547,6 @@ def addmm(match, mat1, mat2, *, inp):
     match.replace_by_example(repl, [inp, mat1, mat2])
 
 
-# two thing to check right now, whether dim = 1 matters and whether contiguous layout matters
 def is_valid_addmm_activation_fusion(match):
     addmm_node = match.kwargs["input"]
 
@@ -1583,6 +1582,21 @@ def addmm_relu_pattern(input, mat1, mat2):
 
 def addmm_relu_replacement(input, mat1, mat2):
     return aten._addmm_activation(input, mat1, mat2, beta=1, alpha=1, use_gelu=False)
+
+
+# @register_graph_pattern(
+#     CallFunction(
+#         aten.relu,
+#         CallFunction(aten.addmm, KeywordArg("input"), Arg(), Arg()),
+#     ),
+#     pass_dict=pass_patterns[2],
+#     extra_check=is_valid_addmm_activation_fusion,
+# )
+# def addmm_relu(match, mat1, mat2, *, input):
+#     def repl(input, mat1, mat2):
+#         return aten._addmm_activation(input, mat1, mat2, beta=1, alpha=1, use_gelu=False)
+
+#     match.replace_by_example(repl, [input, mat1, mat2])
 
 
 def register_partial_reduction_pattern():

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -705,8 +705,8 @@ def is_valid_addmm_activation_fusion(match):
 
 def addmm_gelu_pattern(input, mat1, mat2):
     output = aten.mm(mat1, mat2)
-    output = aten.add()
-    return aten.gelu(output)
+    output = aten.add(output, input)
+    return aten.gelu(output, approximate="tanh")
 
 
 def addmm_gelu_replacement(input, mat1, mat2):

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -661,7 +661,7 @@ def lazy_init():
         extra_check=prepare_softmax_extra_check,
     )
 
-    register_addmm_activation_fusion()
+    # register_addmm_activation_fusion()
 
 
 @functools.cache
@@ -703,18 +703,21 @@ def register_addmm_activation_fusion():
 def is_valid_addmm_activation_fusion(match):
     if config.max_autotune_gemm:
         return False
-    input = match.kwargs["input"].meta["val"]
+    inp = match.kwargs["input"].meta["val"]
     mat1 = match.kwargs["mat1"].meta["val"]
     mat2 = match.kwargs["mat2"].meta["val"]
 
     # match the dispatch logic for cuBLASLT at aten/src/ATen/native/cuda/Blas.cpp
-    if not (input.is_cuda and input.dim() == 1 and input.is_contiguous()):
+    if not (inp.is_cuda and inp.dim() == 1 and inp.is_contiguous()):
         return False
 
     if not (mat1.dim() == 2 and mat2.dim() == 2):
         return False
 
-    if input.size(0) != mat2.size(1):
+    if inp.size(0) != mat2.size(1):
+        return False
+
+    if inp.dtype != mat1.dtype or inp.dtype != mat2.dtype:
         return False
 
     output = match.output_node()

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -699,8 +699,13 @@ def is_valid_addmm_activation_fusion(match):
     
     if not (mat1.dim() == 2 and mat2.dim() == 2):
         return False
+    
+    # bias size must match output width
+    if input.size(0) != mat2.size(1):
+        return False
 
-    return True
+    output = match.output_node()
+    return all(is_pointwise_use(use) for use in output.users)
 
 
 def addmm_gelu_pattern(input, mat1, mat2):

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -687,19 +687,21 @@ def lazy_init():
         extra_check=is_valid_addmm_activation_fusion,
     )
 
+
 def is_valid_addmm_activation_fusion(match):
     if config.max_autotune_gemm:
         return False
+
     input = match.kwargs["input"].meta["val"]
     mat1 = match.kwargs["mat1"].meta["val"]
     mat2 = match.kwargs["mat2"].meta["val"]
 
     if not (input.is_cuda and input.dim() == 1 and input.is_contiguous()):
         return False
-    
+
     if not (mat1.dim() == 2 and mat2.dim() == 2):
         return False
-    
+
     # bias size must match output width
     if input.size(0) != mat2.size(1):
         return False
@@ -1585,7 +1587,6 @@ def addmm(match, mat1, mat2, *, inp):
         return aten.addmm(inp, mat1, mat2)
 
     match.replace_by_example(repl, [inp, mat1, mat2])
-
 
 
 def register_partial_reduction_pattern():

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -661,11 +661,11 @@ def lazy_init():
         extra_check=prepare_softmax_extra_check,
     )
 
-    # register_addmm_activation_fusion()
+    register_addmm_activation_fusion()
 
 
 @functools.cache
-def _addmm_activation_init():
+def register_addmm_activation_fusion():
     shapes = [(5,), (3, 4), (4, 5)]
     args_fp32 = [torch.empty(shape) for shape in shapes]
     args_bf16 = [torch.empty(shape, dtype=torch.bfloat16) for shape in shapes]
@@ -694,10 +694,6 @@ def _addmm_activation_init():
                 pass_dicts=pass_patterns[2],
                 extra_check=is_valid_addmm_activation_fusion,
             )
-
-
-def register_addmm_activation_fusion():
-    _addmm_activation_init()
 
 
 def is_valid_addmm_activation_fusion(match):

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -717,11 +717,6 @@ def register_addmm_activation_fusion():
 
 def is_valid_addmm_activation_fusion(match):
     if config.max_autotune_gemm:
-        print("(╯°□°)╯︵ ┻━┻")
-        print("(╯°□°)╯︵ ┻━┻")
-        print("(╯°□°)╯︵ ┻━┻")
-        print("(╯°□°)╯︵ ┻━┻")
-        print("(╯°□°)╯︵ ┻━┻")
         return False
     input = match.kwargs["input"].meta["val"]
     mat1 = match.kwargs["mat1"].meta["val"]

--- a/torch/_inductor/fx_passes/serialized_patterns/addmm_gelu_pattern.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/addmm_gelu_pattern.py
@@ -1,0 +1,59 @@
+# mypy: ignore-errors
+
+# noqa: F401, E501
+# This is an auto-generated file. Please do not modify it by hand.
+# To re-generate, run:
+# cd ~/pytorch && python torchgen/fuse/gen_patterns.py
+
+import torch
+import torch._inductor
+import operator
+
+aten = torch.ops.aten
+prims = torch.ops.prims
+
+from torch._inductor.pattern_matcher import (
+   Arg,
+   CallFunction,
+   CallFunctionVarArgs,
+   CallMethod,
+   CallMethodVarArgs,
+   CallModule,
+   CallModuleVarArgs,
+   ExclusiveKeywordArg,
+   Ignored,
+   KeywordArg,
+   ListOf,
+   MultiOutputPattern,
+   PatternExpr,
+   RepeatedExpr,
+   _TargetArgsExpr,
+   _TargetExpr,
+   _TargetExprVarArgs,
+)
+mm_default = CallFunction(aten.mm.default, KeywordArg('mat1'), KeywordArg('mat2'))
+add_Tensor = CallFunction(aten.add.Tensor, mm_default, KeywordArg('input'), _users=4)
+mul_Tensor = CallFunction(aten.mul.Tensor, add_Tensor, Ignored())
+mul_Tensor_1 = CallFunction(aten.mul.Tensor, add_Tensor, add_Tensor)
+mul_Tensor_2 = CallFunction(aten.mul.Tensor, mul_Tensor_1, add_Tensor)
+mul_Tensor_3 = CallFunction(aten.mul.Tensor, mul_Tensor_2, Ignored())
+add_Tensor_1 = CallFunction(aten.add.Tensor, add_Tensor, mul_Tensor_3)
+mul_Tensor_4 = CallFunction(aten.mul.Tensor, add_Tensor_1, Ignored())
+tanh_default = CallFunction(aten.tanh.default, mul_Tensor_4)
+add_Tensor_2 = CallFunction(aten.add.Tensor, tanh_default, Ignored())
+addmm_gelu_pattern_fp32 = CallFunction(aten.mul.Tensor, mul_Tensor, add_Tensor_2, _users=0)
+
+
+mm_default = CallFunction(aten.mm.default, KeywordArg('mat1'), KeywordArg('mat2'))
+add_Tensor = CallFunction(aten.add.Tensor, mm_default, KeywordArg('input'))
+convert_element_type_default = CallFunction(prims.convert_element_type.default, add_Tensor, Ignored(), _users=4)
+mul_Tensor = CallFunction(aten.mul.Tensor, convert_element_type_default, Ignored())
+mul_Tensor_1 = CallFunction(aten.mul.Tensor, convert_element_type_default, convert_element_type_default)
+mul_Tensor_2 = CallFunction(aten.mul.Tensor, mul_Tensor_1, convert_element_type_default)
+mul_Tensor_3 = CallFunction(aten.mul.Tensor, mul_Tensor_2, Ignored())
+add_Tensor_1 = CallFunction(aten.add.Tensor, convert_element_type_default, mul_Tensor_3)
+mul_Tensor_4 = CallFunction(aten.mul.Tensor, add_Tensor_1, Ignored())
+tanh_default = CallFunction(aten.tanh.default, mul_Tensor_4)
+add_Tensor_2 = CallFunction(aten.add.Tensor, tanh_default, Ignored())
+mul_Tensor_5 = CallFunction(aten.mul.Tensor, mul_Tensor, add_Tensor_2)
+addmm_gelu_pattern_bf16 = CallFunction(prims.convert_element_type.default, mul_Tensor_5, Ignored(), _users=0)

--- a/torch/_inductor/fx_passes/serialized_patterns/addmm_gelu_pattern_2.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/addmm_gelu_pattern_2.py
@@ -1,0 +1,59 @@
+# mypy: ignore-errors
+
+# noqa: F401, E501
+# This is an auto-generated file. Please do not modify it by hand.
+# To re-generate, run:
+# cd ~/pytorch && python torchgen/fuse/gen_patterns.py
+
+import torch
+import torch._inductor
+import operator
+
+aten = torch.ops.aten
+prims = torch.ops.prims
+
+from torch._inductor.pattern_matcher import (
+   Arg,
+   CallFunction,
+   CallFunctionVarArgs,
+   CallMethod,
+   CallMethodVarArgs,
+   CallModule,
+   CallModuleVarArgs,
+   ExclusiveKeywordArg,
+   Ignored,
+   KeywordArg,
+   ListOf,
+   MultiOutputPattern,
+   PatternExpr,
+   RepeatedExpr,
+   _TargetArgsExpr,
+   _TargetExpr,
+   _TargetExprVarArgs,
+)
+mm_default = CallFunction(aten.mm.default, KeywordArg('mat1'), KeywordArg('mat2'))
+add_Tensor = CallFunction(aten.add.Tensor, KeywordArg('input'), mm_default, _users=4)
+mul_Tensor = CallFunction(aten.mul.Tensor, add_Tensor, Ignored())
+mul_Tensor_1 = CallFunction(aten.mul.Tensor, add_Tensor, add_Tensor)
+mul_Tensor_2 = CallFunction(aten.mul.Tensor, mul_Tensor_1, add_Tensor)
+mul_Tensor_3 = CallFunction(aten.mul.Tensor, mul_Tensor_2, Ignored())
+add_Tensor_1 = CallFunction(aten.add.Tensor, add_Tensor, mul_Tensor_3)
+mul_Tensor_4 = CallFunction(aten.mul.Tensor, add_Tensor_1, Ignored())
+tanh_default = CallFunction(aten.tanh.default, mul_Tensor_4)
+add_Tensor_2 = CallFunction(aten.add.Tensor, tanh_default, Ignored())
+addmm_gelu_pattern_2_fp32 = CallFunction(aten.mul.Tensor, mul_Tensor, add_Tensor_2, _users=0)
+
+
+mm_default = CallFunction(aten.mm.default, KeywordArg('mat1'), KeywordArg('mat2'))
+add_Tensor = CallFunction(aten.add.Tensor, KeywordArg('input'), mm_default)
+convert_element_type_default = CallFunction(prims.convert_element_type.default, add_Tensor, Ignored(), _users=4)
+mul_Tensor = CallFunction(aten.mul.Tensor, convert_element_type_default, Ignored())
+mul_Tensor_1 = CallFunction(aten.mul.Tensor, convert_element_type_default, convert_element_type_default)
+mul_Tensor_2 = CallFunction(aten.mul.Tensor, mul_Tensor_1, convert_element_type_default)
+mul_Tensor_3 = CallFunction(aten.mul.Tensor, mul_Tensor_2, Ignored())
+add_Tensor_1 = CallFunction(aten.add.Tensor, convert_element_type_default, mul_Tensor_3)
+mul_Tensor_4 = CallFunction(aten.mul.Tensor, add_Tensor_1, Ignored())
+tanh_default = CallFunction(aten.tanh.default, mul_Tensor_4)
+add_Tensor_2 = CallFunction(aten.add.Tensor, tanh_default, Ignored())
+mul_Tensor_5 = CallFunction(aten.mul.Tensor, mul_Tensor, add_Tensor_2)
+addmm_gelu_pattern_2_bf16 = CallFunction(prims.convert_element_type.default, mul_Tensor_5, Ignored(), _users=0)

--- a/torch/_inductor/fx_passes/serialized_patterns/addmm_relu_pattern.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/addmm_relu_pattern.py
@@ -1,0 +1,36 @@
+# mypy: ignore-errors
+
+# noqa: F401, E501
+# This is an auto-generated file. Please do not modify it by hand.
+# To re-generate, run:
+# cd ~/pytorch && python torchgen/fuse/gen_patterns.py
+
+import torch
+import torch._inductor
+import operator
+
+aten = torch.ops.aten
+prims = torch.ops.prims
+
+from torch._inductor.pattern_matcher import (
+   Arg,
+   CallFunction,
+   CallFunctionVarArgs,
+   CallMethod,
+   CallMethodVarArgs,
+   CallModule,
+   CallModuleVarArgs,
+   ExclusiveKeywordArg,
+   Ignored,
+   KeywordArg,
+   ListOf,
+   MultiOutputPattern,
+   PatternExpr,
+   RepeatedExpr,
+   _TargetArgsExpr,
+   _TargetExpr,
+   _TargetExprVarArgs,
+)
+mm_default = CallFunction(aten.mm.default, KeywordArg('mat1'), KeywordArg('mat2'))
+add_Tensor = CallFunction(aten.add.Tensor, KeywordArg('input'), mm_default)
+addmm_relu_pattern_fp32 = CallFunction(aten.relu.default, add_Tensor, _users=0)

--- a/torch/_inductor/fx_passes/serialized_patterns/addmm_relu_pattern_2.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/addmm_relu_pattern_2.py
@@ -1,0 +1,36 @@
+# mypy: ignore-errors
+
+# noqa: F401, E501
+# This is an auto-generated file. Please do not modify it by hand.
+# To re-generate, run:
+# cd ~/pytorch && python torchgen/fuse/gen_patterns.py
+
+import torch
+import torch._inductor
+import operator
+
+aten = torch.ops.aten
+prims = torch.ops.prims
+
+from torch._inductor.pattern_matcher import (
+   Arg,
+   CallFunction,
+   CallFunctionVarArgs,
+   CallMethod,
+   CallMethodVarArgs,
+   CallModule,
+   CallModuleVarArgs,
+   ExclusiveKeywordArg,
+   Ignored,
+   KeywordArg,
+   ListOf,
+   MultiOutputPattern,
+   PatternExpr,
+   RepeatedExpr,
+   _TargetArgsExpr,
+   _TargetExpr,
+   _TargetExprVarArgs,
+)
+mm_default = CallFunction(aten.mm.default, KeywordArg('mat1'), KeywordArg('mat2'))
+add_Tensor = CallFunction(aten.add.Tensor, mm_default, KeywordArg('input'))
+addmm_relu_pattern_2_fp32 = CallFunction(aten.relu.default, add_Tensor, _users=0)

--- a/torchgen/fuse/gen_patterns.py
+++ b/torchgen/fuse/gen_patterns.py
@@ -2,8 +2,7 @@
 import os
 
 from torch._inductor import pattern_matcher
-from torch._inductor.fx_passes import joint_graph
-from torch._inductor.fx_passes import post_grad
+from torch._inductor.fx_passes import joint_graph, post_grad
 
 
 if __name__ == "__main__":

--- a/torchgen/fuse/gen_patterns.py
+++ b/torchgen/fuse/gen_patterns.py
@@ -3,6 +3,7 @@ import os
 
 from torch._inductor import pattern_matcher
 from torch._inductor.fx_passes import joint_graph
+from torch._inductor.fx_passes import post_grad
 
 
 if __name__ == "__main__":
@@ -17,3 +18,4 @@ if __name__ == "__main__":
     # to serialize the patterns as it goes.
     os.environ["PYTORCH_GEN_PATTERNS"] = "1"
     joint_graph.lazy_init()
+    post_grad.lazy_init()


### PR DESCRIPTION
PR implements a pass in post_grad to fuse activation(add + mm)

This was previously done similarly here #106912 but was reverted for performance reasons. it was replaced with a pass that unfuses the activation and add from addmm/addmm_activation and let inductor handle the fusion.

however since then cuBLAS team has made a lot of perf improvements on this, will update this post with more benchmarks but preliminary benchmark show good results

perf dash board
<img width="3371" height="1240" alt="Screenshot from 2025-08-07 13-41-35" src="https://github.com/user-attachments/assets/d44d6205-b33a-4a20-9f0f-d9db176b3738" />



Relu works with both training and inference but gelu only works with inference mode due to some fundamental limitations since gelu's derivative depends on input and relu's doesnt. don't think this is fixable with the current addmm_activation API

Graph module before and after this pass

Relu(addmm)
```
graph():
    %primals_1 : [num_users=1] = placeholder[target=primals_1]
    %primals_2 : [num_users=2] = placeholder[target=primals_2]
    %primals_3 : [num_users=2] = placeholder[target=primals_3]
    %addmm : [num_users=1] = call_function[target=torch.ops.aten.addmm.default](args = (%primals_1, %primals_3, %primals_2), kwargs = {})
    %relu : [num_users=2] = call_function[target=torch.ops.aten.relu.default](args = (%addmm,), kwargs = {})
    %le : [num_users=1] = call_function[target=torch.ops.aten.le.Scalar](args = (%relu, 0), kwargs = {})
    %permute_1 : [num_users=1] = call_function[target=torch.ops.aten.permute.default](args = (%primals_3, [1, 0]), kwargs = {})
    return (relu, primals_2, le, permute_1)
graph():
    %primals_1 : [num_users=1] = placeholder[target=primals_1]
    %primals_2 : [num_users=2] = placeholder[target=primals_2]
    %primals_3 : [num_users=2] = placeholder[target=primals_3]
    %_addmm_activation_default : [num_users=2] = call_function[target=torch.ops.aten._addmm_activation.default](args = (%primals_1, %primals_3, %primals_2), kwargs = {})
    %le : [num_users=1] = call_function[target=torch.ops.aten.le.Scalar](args = (%_addmm_activation_default, 0), kwargs = {})
    %permute_1 : [num_users=1] = call_function[target=torch.ops.aten.permute.default](args = (%primals_3, [1, 0]), kwargs = {})
    return (_addmm_activation_default, primals_2, le, permute_1)
```
Gelu (addmm)
```
graph():
    %arg0_1 : [num_users=1] = placeholder[target=arg0_1]
    %arg1_1 : [num_users=1] = placeholder[target=arg1_1]
    %arg2_1 : [num_users=1] = placeholder[target=arg2_1]
    %addmm : [num_users=4] = call_function[target=torch.ops.aten.addmm.default](args = (%arg0_1, %arg2_1, %arg1_1), kwargs = {})
    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%addmm, %addmm), kwargs = {})
    %mul_1 : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%mul, %addmm), kwargs = {})
    %mul_2 : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%mul_1, 0.044715), kwargs = {})
    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%addmm, %mul_2), kwargs = {})
    %mul_3 : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%add, 0.7978845608028654), kwargs = {})
    %mul_4 : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%addmm, 0.5), kwargs = {})
    %tanh : [num_users=1] = call_function[target=torch.ops.aten.tanh.default](args = (%mul_3,), kwargs = {})
    %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%tanh, 1), kwargs = {})
    %mul_5 : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%mul_4, %add_1), kwargs = {})
    return (mul_5,)
graph():
    %arg0_1 : [num_users=1] = placeholder[target=arg0_1]
    %arg1_1 : [num_users=1] = placeholder[target=arg1_1]
    %arg2_1 : [num_users=1] = placeholder[target=arg2_1]
    %_addmm_activation_default : [num_users=1] = call_function[target=torch.ops.aten._addmm_activation.default](args = (%arg0_1, %arg2_1, %arg1_1), kwargs = {use_gelu: True})
    return (_addmm_activation_default,)
```

Benchmark setup:
NGC pytorch 25.06 container
cublas version: 12.9.1.4
torch.compile ran with dynamic = False and max_autotune

H100
```
Testing with M=1024, N=1024, K=1024, dtype=bfloat16
============================================================
Average Time per Iteration (cublas):	 0.0107 ms
Average Time per Iteration (torch compile):	 0.0296 ms

============================================================
Testing with M=2048, N=2048, K=2048, dtype=bfloat16
============================================================
Average Time per Iteration (cublas):	 0.0262 ms
Average Time per Iteration (torch compile):	 0.0327 ms

============================================================
Testing with M=4096, N=4096, K=4096, dtype=bfloat16
============================================================
Average Time per Iteration (cublas):	 0.1763 ms
Average Time per Iteration (torch compile):	 0.2457 ms

============================================================
Testing with M=8192, N=8192, K=8192, dtype=bfloat16
============================================================
Average Time per Iteration (cublas):	 1.5280 ms
Average Time per Iteration (torch compile):	 1.9437 ms
```

A100
```
############################################################
Testing with dtype: float16
############################################################

============================================================
Testing with M=1024, N=1024, K=1024, dtype=float16
============================================================
Average Time per Iteration (cublas):	 0.0313 ms
Average Time per Iteration (torch compile):	 0.0643 ms

============================================================
Testing with M=2048, N=2048, K=2048, dtype=float16
============================================================
Average Time per Iteration (cublas):	 0.1149 ms
Average Time per Iteration (torch compile):	 0.1255 ms

============================================================
Testing with M=4096, N=4096, K=4096, dtype=float16
============================================================
Average Time per Iteration (cublas):	 0.6297 ms
Average Time per Iteration (torch compile):	 0.7547 ms

============================================================
Testing with M=8192, N=8192, K=8192, dtype=float16
============================================================
Average Time per Iteration (cublas):	 4.3821 ms
Average Time per Iteration (torch compile):	 5.0740 ms
```

Script
```py
import torch
torch.manual_seed(0)

warmup, numrun= 10, 100

sizes = [1024, 2048, 4096, 8192]
dtypes = [torch.float16, torch.bfloat16, torch.float32]

device = torch.device("cuda")

for dtype in dtypes:
    dtype_name = str(dtype).split('.')[-1] 
    print(f"\n{'#'*60}")
    print(f"Testing with dtype: {dtype_name}")
    print(f"{'#'*60}")
    
    for size in sizes:
        M, N, K = size, size, size
        print(f"\n{'='*60}")
        print(f"Testing with M={M}, N={N}, K={K}, dtype={dtype_name}")
        print(f"{'='*60}")
        
        A = torch.randn(M, K, device=device, dtype=dtype)
        B = torch.randn(K, N, device=device, dtype=dtype)
        C = torch.randn(M, device=device, dtype=dtype)

        def func1():
            return torch._addmm_activation(C, A, B, use_gelu=True)

        def func2():
            return torch.nn.functional.gelu(torch.add(C, torch.mm(A, B)), approximate="tanh")

        func2_compiled = torch.compile(
            func2,
            dynamic=False, 
            options={
                "force_disable_caches": True,
                "max_autotune": True,
                "max_autotune_gemm": True,
                "max_autotune_gemm_backends": "TRITON",
                "autotune_fallback_to_aten": False,
            }
        )

        for _ in range(warmup): func1()
        torch.cuda.synchronize(device=device)

        start_event = torch.cuda.Event(enable_timing=True)
        end_event = torch.cuda.Event(enable_timing=True)

        total_time_ms = 0.0
        start_event.record()
        for _ in range(numrun): func1()
        end_event.record()
        torch.cuda.synchronize(device=device)
        total_time_ms += start_event.elapsed_time(end_event)
        avg_time_ms = total_time_ms / numrun

        print(f"Average Time per Iteration (cublas):\t {avg_time_ms:.4f} ms")

        for _ in range(warmup): func2_compiled()
        torch.cuda.synchronize(device=device)

        start_event = torch.cuda.Event(enable_timing=True)
        end_event = torch.cuda.Event(enable_timing=True)

        total_time_ms = 0.0
        start_event.record()
        for _ in range(numrun): func2_compiled()
        end_event.record()
        torch.cuda.synchronize(device=device)
        total_time_ms += start_event.elapsed_time(end_event)
        avg_time_ms = total_time_ms / numrun

        print(f"Average Time per Iteration (torch compile):\t {avg_time_ms:.4f} ms")
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @Lucaskabela