### PR TITLE
dist2: add support for passing custom configs directly to PG

### DIFF
--- a/test/distributed/test_dist2.py
+++ b/test/distributed/test_dist2.py
@@ -28,10 +28,14 @@ class ProcessGroupTest(TestCase):
         os.environ["MASTER_PORT"] = "29500"
 
         pg1 = dist2.new_group(
-            backend="gloo", timeout=timedelta(seconds=60), device="cpu", pg_options=None
+            backend="gloo",
+            timeout=timedelta(seconds=60),
+            device="cpu",
         )
         pg2 = dist2.new_group(
-            backend="gloo", timeout=timedelta(seconds=60), device="cpu", pg_options=None
+            backend="gloo",
+            timeout=timedelta(seconds=60),
+            device="cpu",
         )
 
         self.assertIsNone(dist2.current_process_group())
@@ -216,7 +220,6 @@ class ProcessGroupGlooTest(Dist2MultiProcessTestCase):
             backend="gloo",
             timeout=timedelta(seconds=60),
             device=self.device,
-            pg_options=None,
         )
 
 
@@ -231,15 +234,10 @@ class ProcessGroupNCCLTest(Dist2MultiProcessTestCase):
 
         self.device = torch.device("cuda", self.rank)
 
-        from torch.distributed import ProcessGroupNCCL
-
-        opts = ProcessGroupNCCL.Options()
-
         return dist2.new_group(
             backend="nccl",
             timeout=timedelta(seconds=60),
             device=self.device,
-            pg_options=opts,
         )
 
 


### PR DESCRIPTION
This is intended to make it easier to have backend specific "hints" that can be provided by the user to hint about certain options.

```py
import torch.distributed._dist2 as dist2

pg = dist2.new_group(backend="my_custom_backend", device=..., timeout=..., foo=1234, bar="1234")
pg.allreduce(...)
```

Test plan:

```
pytest test/distributed/test_dist2.py
```

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab