### PR TITLE
Updating build pipeline to use pytorch_sphinx_theme properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ make -f docker.Makefile
 ### Building the Documentation
 
 To build documentation in various formats, you will need [Sphinx](http://www.sphinx-doc.org)
-and the pytorch_sphinx_theme2.
+and the [pytorch_sphinx_theme](https://pypi.org/project/pytorch-sphinx-theme/).
 
 Before you build the documentation locally, ensure `torch` is
 installed in your environment. For small fixes, you can install the


### PR DESCRIPTION
**Description**: The "Building the Documentation" section in README.md lists `pytorch_sphinx_theme2` as a required package, which appears to be a typo. The correct package is `pytorch_sphinx_theme`, available on PyPI.

**Impact**: This could mislead contributors, leading to installation errors or confusion when setting up the documentation build environment.

**Suggested Fix**: Update the line to `and the [pytorch_sphinx_theme](https://pypi.org/project/pytorch-sphinx-theme/).` and verify the path.

**Priority**: Low (documentation issue).

Fixes #158201
