### PR TITLE
Add deprecation warning

### DIFF
--- a/torch/export/__init__.py
+++ b/torch/export/__init__.py
@@ -10,6 +10,7 @@ import zipfile
 from collections.abc import Iterator
 from enum import auto, Enum
 from typing import Any, Callable, Optional, TYPE_CHECKING, Union
+from typing_extensions import deprecated
 
 import torch
 import torch.utils._pytree as pytree
@@ -73,6 +74,11 @@ from .unflatten import FlatArgsAdapter, unflatten, UnflattenedModule
 PassType = Callable[[torch.fx.GraphModule], Optional[PassResult]]
 
 
+@deprecated(
+    "`torch.export.export_for_training` is deprecated and will be removed in PyTorch 2.10. "
+    "Please use `torch.export.export` instead, which is functionally equivalent.",
+    category=FutureWarning,
+)
 def export_for_training(
     mod: torch.nn.Module,
     args: tuple[Any, ...],


### PR DESCRIPTION
Summary: export_for_training exist because we couldn't migrate internal usages of export to the final IR. Now that we have completed the migration, we should deprecate and delete this API.

Test Plan:
CI

Rollback Plan:

Differential Revision: D78240836


