### PR TITLE
Multi-threaded concurrent fetching in Dataloader for high-latency storage.

### DIFF
--- a/torch/utils/data/_utils/fetch.py
+++ b/torch/utils/data/_utils/fetch.py
@@ -51,7 +51,7 @@ class _BaseDatasetFetcher:
             while not result_queue.empty():
                 idx, value = await result_queue.get()
                 results[idx] = value
-            return [results[i] for i in indices if i in results]
+            return [results[i] for i in indices]
 
         return self._loop.run_until_complete(_run(indices))
 

--- a/torch/utils/data/_utils/fetch.py
+++ b/torch/utils/data/_utils/fetch.py
@@ -46,8 +46,8 @@ class _BaseDatasetFetcher:
         async def _run(indices):
             task_queue = asyncio.Queue()
             result_queue = asyncio.Queue()
-            for idx in indices:
-                await task_queue.put(idx)
+            for index in indices:
+                await task_queue.put(index)
 
             workers = [
                 asyncio.create_task(_worker(task_queue, result_queue))
@@ -57,9 +57,9 @@ class _BaseDatasetFetcher:
 
             results = {}
             while not result_queue.empty():
-                idx, value = await result_queue.get()
-                results[idx] = value
-            return [results[i] for i in indices]
+                index, value = await result_queue.get()
+                results[index] = value
+            return [results[index] for index in indices]
 
         return self._loop.run_until_complete(_run(indices))
 
@@ -101,8 +101,8 @@ class _IterableDatasetFetcher(_BaseDatasetFetcher):
 
 
 class _MapDatasetFetcher(_BaseDatasetFetcher):
-    def _fetch_one(self, idx):
-        return self.dataset[idx]
+    def _fetch_one(self, index):
+        return self.dataset[index]
 
     def fetch(self, possibly_batched_index):
         if self.auto_collation:
@@ -111,7 +111,7 @@ class _MapDatasetFetcher(_BaseDatasetFetcher):
             elif self.num_threads > 1:
                 data = self._run_async(possibly_batched_index, self._fetch_one)
             else:
-                data = [self.dataset[idx] for idx in possibly_batched_index]
+                data = [self.dataset[index] for index in possibly_batched_index]
         else:
             data = self.dataset[possibly_batched_index]
         return self.collate_fn(data)

--- a/torch/utils/data/_utils/fetch.py
+++ b/torch/utils/data/_utils/fetch.py
@@ -5,7 +5,11 @@ This logic is shared in both single- and multi-processing data loading.
 """
 
 import asyncio
+import logging
 from concurrent.futures import ThreadPoolExecutor
+
+# Set up logger for this module
+logger = logging.getLogger(__name__)
 
 
 class _BaseDatasetFetcher:
@@ -31,7 +35,11 @@ class _BaseDatasetFetcher:
                     )
                     await result_queue.put((index, result))
                 except Exception as e:
-                    print(f"Exception during fetch: {e}")
+                    logger.error(
+                        "Exception during fetch for index %s: %s (%s)", 
+                        index, str(e), type(e).__name__,
+                        exc_info=True
+                    )
                 finally:
                     task_queue.task_done()
 

--- a/torch/utils/data/_utils/fetch.py
+++ b/torch/utils/data/_utils/fetch.py
@@ -4,16 +4,56 @@ r"""Contains definitions of the methods used by the _BaseDataLoaderIter to fetch
 This logic is shared in both single- and multi-processing data loading.
 """
 
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+
 
 class _BaseDatasetFetcher:
-    def __init__(self, dataset, auto_collation, collate_fn, drop_last):
+    def __init__(self, dataset, auto_collation, collate_fn, drop_last, num_threads=1):
         self.dataset = dataset
         self.auto_collation = auto_collation
         self.collate_fn = collate_fn
         self.drop_last = drop_last
+        self.num_threads = num_threads
 
-    def fetch(self, possibly_batched_index):
-        raise NotImplementedError
+        if self.num_threads > 1:
+            self._executor = ThreadPoolExecutor(self.num_threads)
+            self._loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self._loop)
+
+    def _run_async(self, indices, fetch_fn):
+        async def _worker(task_queue, result_queue):
+            while not task_queue.empty():
+                index = await task_queue.get()
+                try:
+                    result = await self._loop.run_in_executor(
+                        self._executor, fetch_fn, index
+                    )
+                    await result_queue.put((index, result))
+                except Exception as e:
+                    print(f"Exception during fetch: {e}")
+                finally:
+                    task_queue.task_done()
+
+        async def _run(indices):
+            task_queue = asyncio.Queue()
+            result_queue = asyncio.Queue()
+            for idx in indices:
+                await task_queue.put(idx)
+
+            workers = [
+                asyncio.create_task(_worker(task_queue, result_queue))
+                for _ in range(self.num_threads)
+            ]
+            await asyncio.gather(*workers)
+
+            results = {}
+            while not result_queue.empty():
+                idx, value = await result_queue.get()
+                results[idx] = value
+            return [results[i] for i in indices if i in results]
+
+        return self._loop.run_until_complete(_run(indices))
 
 
 class _IterableDatasetFetcher(_BaseDatasetFetcher):
@@ -22,18 +62,27 @@ class _IterableDatasetFetcher(_BaseDatasetFetcher):
         self.dataset_iter = iter(dataset)
         self.ended = False
 
+    def _fetch_one(self, _):
+        return next(self.dataset_iter)
+
     def fetch(self, possibly_batched_index):
         if self.ended:
             raise StopIteration
 
         if self.auto_collation:
             data = []
-            for _ in possibly_batched_index:
+            if self.num_threads > 1:
                 try:
-                    data.append(next(self.dataset_iter))
+                    data = self._run_async(possibly_batched_index, self._fetch_one)
                 except StopIteration:
                     self.ended = True
-                    break
+            else:
+                for _ in possibly_batched_index:
+                    try:
+                        data.append(next(self.dataset_iter))
+                    except StopIteration:
+                        self.ended = True
+                        break
             if len(data) == 0 or (
                 self.drop_last and len(data) < len(possibly_batched_index)
             ):
@@ -44,10 +93,15 @@ class _IterableDatasetFetcher(_BaseDatasetFetcher):
 
 
 class _MapDatasetFetcher(_BaseDatasetFetcher):
+    def _fetch_one(self, idx):
+        return self.dataset[idx]
+
     def fetch(self, possibly_batched_index):
         if self.auto_collation:
             if hasattr(self.dataset, "__getitems__") and self.dataset.__getitems__:
                 data = self.dataset.__getitems__(possibly_batched_index)
+            elif self.num_threads > 1:
+                data = self._run_async(possibly_batched_index, self._fetch_one)
             else:
                 data = [self.dataset[idx] for idx in possibly_batched_index]
         else:

--- a/torch/utils/data/_utils/worker.py
+++ b/torch/utils/data/_utils/worker.py
@@ -240,6 +240,7 @@ def _worker_loop(
     num_workers,
     persistent_workers,
     shared_seed,
+    num_threads=1,
 ):
     # See NOTE [ Data Loader Multiprocessing Shutdown Logic ] for details on the
     # logic of this function.
@@ -287,7 +288,7 @@ def _worker_loop(
                 init_fn(worker_id)
 
             fetcher = _DatasetKind.create_fetcher(
-                dataset_kind, dataset, auto_collation, collate_fn, drop_last
+                dataset_kind, dataset, auto_collation, collate_fn, drop_last, num_threads
             )
         except Exception:
             init_exception = ExceptionWrapper(
@@ -327,7 +328,7 @@ def _worker_loop(
 
                 # Recreate the fetcher for worker-reuse policy
                 fetcher = _DatasetKind.create_fetcher(
-                    dataset_kind, dataset, auto_collation, collate_fn, drop_last
+                    dataset_kind, dataset, auto_collation, collate_fn, drop_last, num_threads
                 )
                 continue
             elif r is None:

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -77,14 +77,14 @@ class _DatasetKind:
     Iterable = 1
 
     @staticmethod
-    def create_fetcher(kind, dataset, auto_collation, collate_fn, drop_last):
+    def create_fetcher(kind, dataset, auto_collation, collate_fn, drop_last, num_threads=1):
         if kind == _DatasetKind.Map:
             return _utils.fetch._MapDatasetFetcher(
-                dataset, auto_collation, collate_fn, drop_last
+                dataset, auto_collation, collate_fn, drop_last, num_threads
             )
         else:
             return _utils.fetch._IterableDatasetFetcher(
-                dataset, auto_collation, collate_fn, drop_last
+                dataset, auto_collation, collate_fn, drop_last, num_threads
             )
 
 
@@ -195,7 +195,7 @@ class DataLoader(Generic[_T_co]):
             default. This argument is discouraged and subject to deprecated.
         in_order (bool, optional): If ``False``, the data loader will not enforce that batches
             are returned in a first-in, first-out order. Only applies when ``num_workers > 0``. (default: ``True``)
-
+        num_threads (int, optional): Number of threads per worker to use for data loading. (default: ``1``)
 
     .. warning:: If the ``spawn`` start method is used, :attr:`worker_init_fn`
                  cannot be an unpicklable object, e.g., a lambda function. See
@@ -238,6 +238,7 @@ class DataLoader(Generic[_T_co]):
     prefetch_factor: Optional[int]
     _iterator: Optional[_BaseDataLoaderIter]
     __initialized = False
+    num_threads: int = 1
 
     def __init__(
         self,
@@ -259,6 +260,7 @@ class DataLoader(Generic[_T_co]):
         persistent_workers: bool = False,
         pin_memory_device: str = "",
         in_order: bool = True,
+        num_threads: int = 1,
     ) -> None:
         torch._C._log_api_usage_once("python.data_loader")
 
@@ -286,6 +288,7 @@ class DataLoader(Generic[_T_co]):
 
         self.dataset = dataset
         self.num_workers = num_workers
+        self.num_threads = num_threads
         self.prefetch_factor = prefetch_factor
         self.pin_memory = pin_memory
         self.pin_memory_device = pin_memory_device
@@ -783,6 +786,7 @@ class _SingleProcessDataLoaderIter(_BaseDataLoaderIter):
             self._auto_collation,
             self._collate_fn,
             self._drop_last,
+            self.num_threads,
         )
 
     def _next_data(self):
@@ -1160,6 +1164,7 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
                     self._num_workers,
                     self._persistent_workers,
                     self._shared_seed,
+                    self.num_threads,
                 ),
             )
             w.daemon = True

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -654,6 +654,7 @@ class _BaseDataLoaderIter:
         self._drop_last = loader.drop_last
         self._index_sampler = loader._index_sampler
         self._num_workers = loader.num_workers
+        self._num_threads = loader.num_threads
         ws, rank = _get_distributed_settings()
         self._world_size = ws
         self._rank = rank
@@ -786,7 +787,7 @@ class _SingleProcessDataLoaderIter(_BaseDataLoaderIter):
             self._auto_collation,
             self._collate_fn,
             self._drop_last,
-            self.num_threads,
+            self._num_threads,
         )
 
     def _next_data(self):
@@ -1164,7 +1165,7 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
                     self._num_workers,
                     self._persistent_workers,
                     self._shared_seed,
-                    self.num_threads,
+                    self._num_threads,
                 ),
             )
             w.daemon = True


### PR DESCRIPTION
Currently, each worker spawned by the DataLoader runs as a separate Python process, but the workload within each worker is single-threaded. In some cases — especially when streaming from high-lantecy storage like S3 or NFS — using multiple threads within each worker can significantly improve throughput, as now fetching a single data item takes quite a while compared with low-latency storage like SSD. 

This PR enables multi-threading inside each worker. It exposes the `num_threads` option in the `DataLoader` class's instantiation function, allowing users to easily tweak the concurrency setup. By default, we use `num_threads=1` for backward compatibility. 

To demonstrate the effectiveness of this threaded dataloader, I wrote a simple script to loop over a S3-based dataloader with a `fake training fwd/bwd time being 1s`. On my AWS machine, I got the following results:

Setup 1: `python simple_data_loop.py --num_threads=1` leads to `per_iter_time: 2.317s`, indicating a data streaming latency of 1.3s.

Setup 2: `python simple_data_loop.py --num_threads=32` leads to `per_iter_time: 1.021s`, indicating a data streaming latency of 0.021s.
 
We can see multi-threading hides the data streaming latency almost completely. 
 
`simple_data_loop.py`:
```
import numpy as np
import torch
import torch.utils.data as torch_data


import logging
import os
import random
import time
from io import BytesIO

import boto3
import pandas as pd

from boto3.s3.transfer import TransferConfig
from botocore import UNSIGNED
from botocore.config import Config
from PIL import Image
from tqdm import tqdm


logger = logging.getLogger(__name__)


class S3ImgDataset(torch_data.Dataset):
    def __init__(self, s3_img_path_list: list[str]):
        super().__init__()

        # https://github.com/pytorch/pytorch/issues/13246#issuecomment-905703662
        self.s3_img_path_list = pd.array(s3_img_path_list, dtype="string")

        self.s3_transfer_config = TransferConfig(multipart_threshold=5 * 1024**3)
        self.s3_client = boto3.client(
            "s3",
            aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
            aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
            aws_session_token=os.getenv("AWS_SESSION_TOKEN"),
            config=Config(
                region_name=os.getenv("AWS_REGION", "us-west-2"),
                signature_version=UNSIGNED,
            ),
        )

    def __len__(self):
        return len(self.s3_img_path_list)

    def __getitem__(self, idx):
        # each path is like s3://<bucket>/<prefix>
        try:
            s3_img_path = self.s3_img_path_list[idx]
            bucket, prefix = s3_img_path.replace("s3://", "").split("/", 1)

            bytesio = BytesIO()
            self.s3_client.download_fileobj(
                bucket, prefix, bytesio, Config=self.s3_transfer_config
            )
            bytesio.seek(0)

            img = torch.from_numpy(np.array(Image.open(bytesio)))
        except Exception as e:
            logger.error(f"Error loading image {s3_img_path}: {e}")
            return self.__getitem__(random.randint(0, len(self) - 1))

        return img


def benchmark(
    s3_img_path_list: list[str],
    fake_training_time,
    batch_size,
    num_workers,
    num_threads,
    prefetch_factor,
):
    dataset = S3ImgDataset(s3_img_path_list)
    dataloader = torch_data.DataLoader(
        dataset,
        batch_size=batch_size,
        shuffle=True,
        num_workers=num_workers,
        num_threads=num_threads,
        prefetch_factor=prefetch_factor,
        persistent_workers=True,
        pin_memory=True,
        drop_last=True,  # Ensure consistent batch sizes
    )

    num_warmup_batches, num_test_batches = 20, 100

    for batch_idx, batch in tqdm(enumerate(dataloader)):
        if batch_idx == num_warmup_batches:
            tic = time.time()

        # fake training
        time.sleep(fake_training_time)


        if batch_idx > num_test_batches + num_warmup_batches:
            break

    per_iter_time = (time.time() - tic) / num_test_batches
    return per_iter_time


if __name__ == "__main__":
    import argparse

    parser = argparse.ArgumentParser()
    parser.add_argument(
        "--fake_training_time",
        type=float,
        default=1.0,
        help="fake training time in seconds",
    )
    parser.add_argument(
        "--batch_size", type=int, default=256, help="how many objects to load per batch"
    )
    parser.add_argument(
        "--num_workers", type=int, default=8, help="how many workers to use"
    )
    parser.add_argument(
        "--num_threads", type=int, default=32, help="how many threads to use"
    )
    parser.add_argument(
        "--prefetch_factor", type=int, default=16, help="how many batches to prefetch"
    )

    args = parser.parse_args()

    with open("s3_img_path_list.txt", "r") as f:
        s3_img_path_list = [line.strip() for line in f.readlines() if line.strip()]

    # repeat s3_img_path_list 1000 times
    s3_img_path_list = s3_img_path_list * 1000

    per_iter_time = benchmark(
        s3_img_path_list,
        args.fake_training_time,
        args.batch_size,
        args.num_workers,
        args.num_threads,
        args.prefetch_factor,
    )
    print(f"args: {args}")
    print(f"per_iter_time: {per_iter_time:.3f}s")
```