### PR TITLE
[ARM] Improve LLM performance & mem usage using int4-bf16 KleidiAI kernels

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -3541,9 +3541,9 @@ Tensor _dyn_quant_matmul_4bit_cpu(
     const int64_t out_features) {
   auto M = inp.size(0);
   TORCH_CHECK(
-      inp.dtype() == kFloat,
+      inp.dtype() == kFloat || (inp.dtype() == kBFloat16 && block_size == in_features),
       __func__,
-      " : expect input to be 32-bit float tensor.");
+      " : expect input to be float32 or bfloat16 tensor.");
   TORCH_CHECK(
       block_size == in_features ||
           (!(block_size % 32) && !(in_features % block_size)),

--- a/aten/src/ATen/native/cpu/int4mm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/int4mm_kernel.cpp
@@ -1267,7 +1267,7 @@ void ref_dyn_quant_matmul_4bit_groupwise_kernel(
  *   - Groupwise kernels expect BF16 scales
  *   - Channelwise kernels expect FP32 scales
  *   - Bias is currently unsupported in fallback path
- */ 
+ */
 void dyn_quant_matmul_4bit_kernel(
     const Tensor& output,
     const Tensor& inp,

--- a/aten/src/ATen/native/cpu/int4mm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/int4mm_kernel.cpp
@@ -8,6 +8,7 @@
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/native/cpu/int_mm_kernel.h>
 #include <ATen/native/cpu/utils.h>
+#include <cmath>
 #include <c10/util/Unroll.h>
 #include <c10/util/irange.h>
 
@@ -861,7 +862,7 @@ static void ref_dyn_quant_matmul_4bit_channelwise_kernel_bf16(
             // quantize
             for (size_t j = 0; j < K; ++j) {
                 float v = cast_bf16_to_f32(row_ptr[j]);
-                int32_t q = static_cast<int32_t>(round(v * scale)) + zp;
+                int32_t q = static_cast<int32_t>(std::round(v * scale)) + zp;
                 q = std::clamp(q, static_cast<int32_t>(INT8_MIN), static_cast<int32_t>(INT8_MAX));
                 *out_ptr++ = static_cast<int8_t>(q);
             }
@@ -1337,7 +1338,7 @@ void dyn_quant_matmul_4bit_kernel(
         TORCH_CHECK(false, "Unsupported output dtype for int4mm kernel");
     }
 
-    constexpr float BF16_MAX = std::ldexp(254.0f, 120);  // ≈ 3.38953139e+38
+    constexpr float BF16_MAX = 3.38953139e+38f;
     constexpr float BF16_MIN = -BF16_MAX;
 
     // Dispatch to reference kernels

--- a/aten/src/ATen/native/cpu/int4mm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/int4mm_kernel.cpp
@@ -936,7 +936,7 @@ void dyn_quant_pack_4bit_weight_kernel(
 #if AT_KLEIDIAI_ENABLED()
   if (can_use_kleidiai(scales_zeros, K, block_size)) {
     const int64_t weight_packed_size =
-        kleidiai::kai_pack_rhs_int4_size(N, K, block_size);
+        kleidiai::kai_pack_rhs_int4_size(N, K, block_size, weights.scalar_type());
     packed_weights.resize_({weight_packed_size});
     kleidiai::kai_pack_int4_rhs(
         packed_weights, weights, scales_zeros, bias, N, K, block_size);

--- a/aten/src/ATen/native/cpu/int4mm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/int4mm_kernel.cpp
@@ -793,6 +793,215 @@ bool can_use_kleidiai(
 }
 #endif
 
+static inline size_t roundup(size_t a, size_t b) {
+    return ((a + b - 1) / b) * b;
+}
+
+static inline float kai_cast_f32_bf16(uint16_t bf16_val) {
+    uint32_t val = ((uint32_t)bf16_val) << 16;
+    float result;
+    std::memcpy(&result, &val, sizeof(result));
+    return result;
+}
+
+static inline uint16_t kai_cast_bf16_f32(float val) {
+    uint32_t bits;
+    std::memcpy(&bits, &val, sizeof(bits));
+    return static_cast<uint16_t>(bits >> 16);
+}
+
+
+static void ref_matmul_mxn_mxk_nxk_bf16_qa8dx_qs4cx(
+    size_t m, size_t n, size_t k, const int8_t* lhs_qa8dx, const uint8_t* rhs_qs4cx, const float* rhs_scales_f32,
+    uint16_t* dst_bf16, float scalar_min, float scalar_max) {
+    const size_t lhs_stride = k * sizeof(int8_t) + sizeof(float) + sizeof(int32_t);
+    const size_t rhs_qs4cx_stride = (roundup(k, 2) / 2);  // Ensure proper rounding
+
+    for (size_t m_idx = 0; m_idx < m; ++m_idx) {
+        const int8_t* lhs_ptr_start = lhs_qa8dx + m_idx * lhs_stride;
+        for (size_t n_idx = 0; n_idx < n; ++n_idx) {
+            // Main f32 accumulator.
+            int32_t iacc = 0;
+
+            const int8_t* lhs_ptr = lhs_ptr_start;
+            const uint8_t* rhs_ptr = rhs_qs4cx + n_idx * rhs_qs4cx_stride;
+
+            // Read LHS quantization parameters stored at the beginning of each row.
+            const float lhs_scale = *(reinterpret_cast<const float*>(lhs_ptr));
+            lhs_ptr += sizeof(float);
+            const int32_t lhs_offset = *(reinterpret_cast<const int32_t*>(lhs_ptr));
+            lhs_ptr += sizeof(int32_t);
+
+            // Compute accumulation over the k dimension.
+            for (size_t k_idx = 0; k_idx < k; ++k_idx) {
+                // Get the LHS values.
+                const int32_t lhs_v0 = static_cast<int32_t>(lhs_ptr[0]);
+
+                // Get the RHS values.
+                const uint8_t rhs_byte = rhs_ptr[0];
+
+                // Unpack the RHS values.
+                int32_t rhs_v0 = 0;
+                if ((k_idx % 2) == 0) {
+                    rhs_v0 = (static_cast<int32_t>(rhs_byte & 0x0F)) - 8;
+                } else {
+                    rhs_v0 = (static_cast<int32_t>(rhs_byte >> 4)) - 8;
+                }
+
+                iacc += lhs_v0 * rhs_v0;
+                iacc += lhs_offset * rhs_v0;
+
+                lhs_ptr += 1;
+                // For this layout the pointer to the RHS only increments after each pair.
+                rhs_ptr += (k_idx % 2);
+            }
+
+            // Get the RHS scale.
+            const float rhs_scale = rhs_scales_f32[n_idx];
+
+            // Compute the final accumulator.
+            float main_acc = static_cast<float>(iacc) * rhs_scale * lhs_scale;
+
+            // Clamp the output.
+            main_acc = std::max(main_acc, scalar_min);
+            main_acc = std::min(main_acc, scalar_max);
+
+            // Convert float32 to bfloat16 and write to destination.
+            *dst_bf16++ = kai_cast_bf16_f32(main_acc);
+        }
+    }
+}
+
+static void ref_quant_qa8dx_bf16(size_t m, size_t k, const uint16_t* lhs_native_mtx_bf16, int8_t* lhs_ref_mtx_qa8dx) {
+    const size_t dst_stride = (k * sizeof(int8_t) + sizeof(float) + sizeof(int32_t));
+
+    // The stride for the input matrix is k elements per row.
+    const size_t lhs_stride = k;
+
+    for (size_t m_idx = 0; m_idx < m; ++m_idx) {
+        // Pointer to the beginning of the current row in the bfloat16 input matrix.
+        const uint16_t* src_ptr = lhs_native_mtx_bf16 + m_idx * lhs_stride;
+
+        // Initialize min/max values.
+        float max0 = -FLT_MAX;
+        float min0 = FLT_MAX;
+
+        // First pass: compute the min and max values for this row.
+        for (size_t k_idx = 0; k_idx < k; ++k_idx) {
+            // Convert bfloat16 to float32
+            float src_val = kai_cast_f32_bf16((src_ptr[k_idx]));
+            max0 = std::max(src_val, max0);
+            min0 = std::min(src_val, min0);
+        }
+
+        // Define the quantization range for int8.
+        const float qmin = static_cast<float>(INT8_MIN);
+        const float qmax = static_cast<float>(INT8_MAX);
+
+        // Adjust the min and max to include zero.
+        const float rmin0 = std::min(0.0f, min0);
+        const float rmax0 = std::max(0.0f, max0);
+
+        // Compute the scaling factor. (If rmin0 == rmax0, scale is set to 1 to avoid division by zero.)
+        const float scale0 = (rmin0 == rmax0) ? 1.f : (qmax - qmin) / (rmax0 - rmin0);
+        // Reciprocal of scale0 for dequantizing (used here for storage in the header).
+        const float recip_scale0 = scale0 ? 1.0f / scale0 : 0.0f;
+
+        // Compute the "descaled" min and max.
+        const float descaled_min0 = rmin0 * scale0;
+        const float descaled_max0 = rmax0 * scale0;
+
+        // Compute errors when aligning the zero point.
+        const float zero_point_from_min_error0 = qmin + descaled_min0;
+        const float zero_point_from_max_error0 = qmax + descaled_max0;
+
+        // Choose the zero point based on which error is smaller.
+        float zero_point0 =
+            (zero_point_from_min_error0 + zero_point_from_max_error0) > 0 ? qmin - descaled_min0 : qmax - descaled_max0;
+
+        // Clamp the zero point to the quantized range.
+        zero_point0 = std::max(zero_point0, qmin);
+        zero_point0 = std::min(zero_point0, qmax);
+
+        // Round the zero point to the nearest integer.
+        const int32_t nudged_zero_point0 = lrintf(zero_point0);
+
+        // Pointer to the current row in the output quantized matrix.
+        int8_t* dst_ptr = lhs_ref_mtx_qa8dx + m_idx * dst_stride;
+
+        // Store the reciprocal of the scale as a float.
+        *((float*)(dst_ptr)) = recip_scale0;
+        dst_ptr += sizeof(float);
+
+        // Store the negative of the nudged zero point as a 32-bit integer.
+        *((int32_t*)(dst_ptr)) = -nudged_zero_point0;
+        dst_ptr += sizeof(int32_t);
+
+        // Second pass: quantize each element.
+        for (size_t k_idx = 0; k_idx < k; ++k_idx) {
+            // Convert from bfloat16 to float32.
+            float src_val = kai_cast_f32_bf16(src_ptr[k_idx]);
+
+            // Scale and round the value.
+            int32_t v0_s32 = static_cast<int32_t>(round(src_val * scale0));
+            v0_s32 = v0_s32 + nudged_zero_point0;
+
+            // Clamp the quantized value to int8 range.
+            v0_s32 = std::max(v0_s32, static_cast<int32_t>(INT8_MIN));
+            v0_s32 = std::min(v0_s32, static_cast<int32_t>(INT8_MAX));
+
+            // Store the quantized int8_t value.
+            dst_ptr[0] = static_cast<int8_t>(v0_s32);
+            dst_ptr += sizeof(int8_t);
+        }
+    }
+}
+
+static void ref_dyn_quant_matmul_4bit_channelwise_kernel_bf16(
+    size_t m, size_t n, size_t k,
+    const uint16_t* lhs_bf16,
+    const uint8_t* rhs_qs4cx,
+    const float* rhs_scales,
+    uint16_t* dst_bf16,
+    float scalar_min,
+    float scalar_max) {
+
+  std::unique_ptr<int8_t[]> lhs_quantized(new int8_t[m * (k + sizeof(float) + sizeof(int32_t))]);
+  ref_quant_qa8dx_bf16(m, k, lhs_bf16, lhs_quantized.get());
+
+  ref_matmul_mxn_mxk_nxk_bf16_qa8dx_qs4cx(
+      m, n, k,
+      lhs_quantized.get(),
+      rhs_qs4cx,
+      rhs_scales,
+      dst_bf16,
+      scalar_min,
+      scalar_max);
+}
+
+static void ref_dyn_quant_matmul_4bit_groupwise_kernel_bf16(
+    size_t m, size_t n, size_t k, size_t block_size,
+    const uint16_t* lhs_bf16,
+    const uint8_t* rhs_qs4cx,
+    const float* rhs_scales,
+    uint16_t* dst_bf16,
+    float scalar_min,
+    float scalar_max) {
+
+  std::unique_ptr<int8_t[]> lhs_quantized(new int8_t[m * (k + sizeof(float) + sizeof(int32_t))]);
+  ref_quant_qa8dx_bf16(m, k, lhs_bf16, lhs_quantized.get());
+
+  ref_matmul_mxn_mxk_nxk_bf16_qa8dx_qs4cx(
+      m, n, k,
+      lhs_quantized.get(),
+      rhs_qs4cx,
+      rhs_scales,
+      dst_bf16,
+      scalar_min,
+      scalar_max);
+}
+
+
 /**
  * The Int4 quantized weights must be represented as a uint8 tensor
  * For matrix multiplication with a weight shape of (N x K)
@@ -1171,60 +1380,64 @@ void dyn_quant_matmul_4bit_kernel(
 #endif
   {
     float* lhs_f32 = reinterpret_cast<float*>(inp.data_ptr());
-    const auto weights_size = N * K / 2;
-    // The weights needs to be in uint8_t data type after quantization
-    auto extracted_weights =
-        (packed_weights.narrow(0, 0, weights_size)).to(kByte);
-    auto float32_scales =
-        (packed_weights.narrow(
-             0, weights_size, packed_weights.size(0) - weights_size))
-            .to(kFloat);
-    uint8_t* rhs_4bit =
-        reinterpret_cast<uint8_t*>(extracted_weights.data_ptr());
-    float* rhs_scales_f32 = reinterpret_cast<float*>(float32_scales.data_ptr());
-    // Ensure tensor is float32 before accessing data_ptr<float>()
-    at::Tensor output_f32;
-    if (output.scalar_type() != at::kFloat) {
-        output_f32 = output.to(at::kFloat);  // creates a new tensor (copy)
-    } else {
-        output_f32 = output;  // alias original
-    }
-// Safe reinterpretation after type guarantee
-float* dst_f32 = output_f32.data_ptr<float>();    if (block_size == K) {
-      ref_dyn_quant_matmul_4bit_channelwise_kernel(
-          M,
-          N,
-          K,
-          lhs_f32,
-          rhs_4bit,
-          rhs_scales_f32,
-          dst_f32,
-          -FLT_MAX,
-          FLT_MAX);
-    } else if (!(block_size % 32) && !(K % block_size)) {
-      ref_dyn_quant_matmul_4bit_groupwise_kernel(
-          M,
-          N,
-          K,
-          block_size,
-          lhs_f32,
-          rhs_4bit,
-          rhs_scales_f32,
-          dst_f32,
-          -FLT_MAX,
-          FLT_MAX);
-    } else {
-      TORCH_CHECK(
-          block_size == K || (!(block_size % 32) && !(K % block_size)),
-          __func__,
-          ": Group size should be multiple 32 or in_features [",
-          K,
-          "]. Provided ",
-          block_size);
-    }
+bool is_bf16 = inp.scalar_type() == at::kBFloat16;
+
+const auto weights_size = N * K / 2;
+auto extracted_weights = (packed_weights.narrow(0, 0, weights_size)).to(kByte);
+auto float32_scales = (packed_weights.narrow(0, weights_size, packed_weights.size(0) - weights_size)).to(kFloat);
+
+uint8_t* rhs_4bit = reinterpret_cast<uint8_t*>(extracted_weights.data_ptr());
+float* rhs_scales_f32 = reinterpret_cast<float*>(float32_scales.data_ptr());
+
+at::Tensor output_f32;
+float* dst_f32 = nullptr;
+
+if (output.scalar_type() != at::kFloat && !is_bf16) {
+    output_f32 = output.to(at::kFloat);
+        dst_f32 = output_f32.data_ptr<float>();
+
+} else {
+    output_f32 = output;
+        dst_f32 = output.data_ptr<float>();
+
+}
+constexpr float BF16_MAX = std::ldexp(254.0f, 120);  // ≈ 3.38953139e+38
+constexpr float BF16_MIN = -BF16_MAX;
+
+if (is_bf16) {
+  uint16_t* lhs_bf16 = reinterpret_cast<uint16_t*>(inp.data_ptr());
+  uint16_t* dst_bf16 = reinterpret_cast<uint16_t*>(output.data_ptr());
+  if (block_size == K) {
+    ref_dyn_quant_matmul_4bit_channelwise_kernel_bf16(
+        M, N, K,
+        lhs_bf16, rhs_4bit, rhs_scales_f32,
+        dst_bf16, BF16_MIN, BF16_MAX);
+  } else if (!(block_size % 32) && !(K % block_size)) {
+    ref_dyn_quant_matmul_4bit_groupwise_kernel_bf16(
+        M, N, K, block_size,
+        lhs_bf16, rhs_4bit, rhs_scales_f32,
+        dst_bf16, BF16_MIN, BF16_MAX);
+  } else {
+    TORCH_CHECK(false, "Unsupported block size for BF16 fallback");
+  }
+} else {
+  if (block_size == K) {
+    ref_dyn_quant_matmul_4bit_channelwise_kernel(
+        M, N, K,
+        lhs_f32, rhs_4bit, rhs_scales_f32,
+        dst_f32, -FLT_MAX, FLT_MAX);
+  } else if (!(block_size % 32) && !(K % block_size)) {
+    ref_dyn_quant_matmul_4bit_groupwise_kernel(
+        M, N, K, block_size,
+        lhs_f32, rhs_4bit, rhs_scales_f32,
+        dst_f32, -FLT_MAX, FLT_MAX);
+  } else {
+    TORCH_CHECK(false, "Unsupported block size for FP32 fallback");
   }
 }
+}
 
+}
 } // anonymous namespace
 
 ALSO_REGISTER_AVX512_DISPATCH(weight_to_int4pack_stub, &weight_to_int4pack_kernel)

--- a/aten/src/ATen/native/kleidiai/kai_kernels.cpp
+++ b/aten/src/ATen/native/kleidiai/kai_kernels.cpp
@@ -1,6 +1,8 @@
 #include <ATen/native/kleidiai/kai_kernels.h>
 #include <ATen/native/kleidiai/kai_pack.h>
 #include <ATen/native/kleidiai/kai_ukernel_interface.h>
+#include <ATen/native/TensorConversions.h>
+#include <kai/kai_common.h>
 
 #include <ATen/Parallel.h>
 
@@ -12,6 +14,19 @@
 #include <cpuinfo.h>
 
 namespace at::native::kleidiai {
+
+at::Tensor kleidi_bf16_to_fp32(const at::Tensor& src) {
+    TORCH_CHECK(src.scalar_type() == at::kBFloat16, "Input must be bfloat16");
+    auto out = at::empty(src.sizes(), src.options().dtype(at::kFloat));
+    auto src_ptr = reinterpret_cast<const uint16_t*>(src.data_ptr<at::BFloat16>());
+    auto out_ptr = out.data_ptr<float>();
+    auto numel = src.numel();
+
+    for (int64_t i = 0; i < numel; ++i) {
+        out_ptr[i] = kai_cast_f32_bf16(src_ptr[i]);
+    }
+    return out;
+}
 
 void kai_pack_int4_rhs(
     const Tensor& weight_packed,
@@ -129,6 +144,7 @@ static void kai_quant_pack_lhs_int4_mm_groupwise(
       kernel_packet.kai_get_lhs_packed_size(m, k, mr, kr, sr);
   auto lhs_packed = std::make_unique<uint8_t[]>(lhs_packed_size);
   uint8_t* dst_act_mtx_f32 = reinterpret_cast<uint8_t*>(output.data_ptr());
+  TORCH_CHECK(input.scalar_type() == at::kFloat, "Input tensor must be float.");
   const uint8_t* lhs_native_mtx_f32 =
       reinterpret_cast<const uint8_t*>(input.data_ptr());
   const uint8_t* rhs_packed_mtx_qs4cx =
@@ -153,6 +169,11 @@ static void kai_quant_pack_lhs_int4_mm_groupwise(
     const int64_t vec_num = (thread_id == num_threads - 1)
         ? (m - vec_per_thread * thread_id)
         : vec_per_thread;
+    size_t offset = kai_get_lhs_packed_offset_lhs_quant_pack_qai8dxp_f32(m_idx, k, mr, kr, sr);
+    size_t write_size = kernel_packet.kai_get_lhs_packed_size(vec_num, k, mr, kr, sr);
+
+    TORCH_CHECK(offset + write_size <= lhs_packed_size,
+      "lhs_packed buffer overflow: offset + write_size > buffer size");
 
     kernel_packet.kai_run_lhs_quant_pack(
         vec_num,
@@ -165,7 +186,6 @@ static void kai_quant_pack_lhs_int4_mm_groupwise(
         lhs_stride,
         lhs_packed_ptr);
   };
-
   at::parallel_for(
       0, num_threads, /*grain_size=*/1, [&](int64_t begin, int64_t end) {
         for (int64_t thread_id = begin; thread_id < end; ++thread_id) {
@@ -217,6 +237,17 @@ static void kai_quant_pack_lhs_int4_mm_channelwise(
     const int64_t m,
     const int64_t n,
     const int64_t k) {
+
+    at::Tensor input_fp32;
+
+    if (input.dtype() == at::kFloat) {
+        input_fp32 = input;
+    } else if (input.dtype() == at::kBFloat16) {
+        at::Tensor temp_fp32_output = at::empty(output.sizes(), output.options().dtype(at::kFloat));
+        at::Tensor input_fp32 = kleidi_bf16_to_fp32(input);
+    } else {
+        TORCH_CHECK(false, "Unsupported input dtype for kai_quant_pack_lhs_int4_mm_channelwise: must be FP32 or BF16");
+    }
   // Kernel IDs for GEMM and GEMV
   constexpr kai_kernel_id gemm_id =
       kai_kernel_id::matmul_clamp_f32_qai8dxp4x8_qsi4cxp8x8_8x8x32_neon_i8mm;
@@ -238,13 +269,17 @@ static void kai_quant_pack_lhs_int4_mm_channelwise(
 
   const size_t lhs_packed_size =
       kernel_packet.kai_get_lhs_packed_size(m, k, mr, kr, sr);
-  auto lhs_packed = std::make_unique<uint8_t[]>(lhs_packed_size);
+  const size_t padding = 128;  // extra bytes
+  auto lhs_packed_tensor = at::empty({(int64_t)(lhs_packed_size + padding)}, at::kByte);
+
+  // auto lhs_packed_tensor = at::empty({(int64_t)lhs_packed_size}, at::kByte);
   uint8_t* dst_act_mtx_f32 = reinterpret_cast<uint8_t*>(output.data_ptr());
-  const uint8_t* lhs_native_mtx_f32 =
-      reinterpret_cast<const uint8_t*>(input.data_ptr());
+  TORCH_CHECK(input_fp32.scalar_type() == at::kFloat, "Input tensor must be float.");
+
+  const float* lhs_native_mtx_f32 = input_fp32.data_ptr<float>();
   const uint8_t* rhs_packed_mtx_qs4cx =
       reinterpret_cast<const uint8_t*>(weight.data_ptr());
-  uint8_t* lhs_packed_base = lhs_packed.get();
+  uint8_t* lhs_packed_base = lhs_packed_tensor.data_ptr<uint8_t>();
 
   const size_t lhs_stride = k * sizeof(float);
   const size_t dst_stride = n * sizeof(float);
@@ -264,7 +299,11 @@ static void kai_quant_pack_lhs_int4_mm_channelwise(
     const int64_t vec_num = (thread_id == num_threads - 1)
         ? (m - vec_per_thread * thread_id)
         : vec_per_thread;
+    size_t offset = kai_get_lhs_packed_offset_lhs_quant_pack_qai8dxp_f32(m_idx, k, mr, kr, sr);
+    size_t write_size = kernel_packet.kai_get_lhs_packed_size(vec_num, k, mr, kr, sr);
 
+    TORCH_CHECK(offset + write_size <= lhs_packed_tensor.numel(),
+      "lhs_packed buffer overflow: offset + write_size > buffer size");
     kernel_packet.kai_run_lhs_quant_pack(
         vec_num,
         k,
@@ -320,22 +359,159 @@ static void kai_quant_pack_lhs_int4_mm_channelwise(
       });
 }
 
-void kai_quant_pack_lhs_int4_mm(
+static void kai_quant_pack_lhs_int4_mm_bf16_channelwise(
     const Tensor& output,
     const Tensor& input,
     const Tensor& weight,
     const int64_t m,
     const int64_t n,
-    const int64_t k,
-    const int64_t bl) {
-  // Prefer Channelwise kernel over Groupwise kernel for conflicting cases
-  if (bl == k) {
-    kleidiai::kai_quant_pack_lhs_int4_mm_channelwise(
-        output, input, weight, m, n, k);
-  } else if (!(bl % 32) && !(k % bl)) {
-    kleidiai::kai_quant_pack_lhs_int4_mm_groupwise(
-        output, input, weight, m, n, k, bl);
+    const int64_t k) {
+  // Kernel IDs for GEMM and GEMV
+  constexpr kai_kernel_id gemm_id =
+      kai_kernel_id::matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm;
+  constexpr kai_kernel_id gemv_id =
+      kai_kernel_id::matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod;
+
+  // Get total threads and select kernel
+  const int64_t total_threads = at::get_num_threads();
+  auto kernel_packet = kai_select_bf16_channelwise_matmul_ukernel(gemv_id);
+  if (cpuinfo_has_arm_i8mm() && m > 1) {
+    kernel_packet = kai_select_bf16_channelwise_matmul_ukernel(gemm_id);
   }
+
+  // Thread blocking parameters
+  const int64_t n_step = kernel_packet.ukernel.get_n_step();
+  const size_t mr = kernel_packet.ukernel.get_mr();
+  const size_t kr = kernel_packet.ukernel.get_kr();
+  const size_t sr = kernel_packet.ukernel.get_sr();
+
+  const size_t lhs_packed_size =
+      kernel_packet.kai_get_lhs_packed_size(m, k, mr, kr, sr);
+  auto lhs_packed = std::make_unique<uint8_t[]>(lhs_packed_size); //
+  uint8_t* dst_act_mtx_f32 = reinterpret_cast<uint8_t*>(output.data_ptr());
+  TORCH_CHECK(input.scalar_type() == at::kBFloat16, "Input tensor must be bfloat16.");
+  const uint8_t* lhs_native_mtx_f32 =
+      reinterpret_cast<const uint8_t*>(input.data_ptr());
+  const uint8_t* rhs_packed_mtx_qs4cx =
+      reinterpret_cast<const uint8_t*>(weight.data_ptr());
+  uint8_t* lhs_packed_base = lhs_packed.get();
+
+  constexpr int32_t element_size = sizeof(uint16_t);
+  const size_t lhs_stride = k * element_size;
+  const size_t dst_stride = n * element_size;
+
+  // LHS quantization packing
+  int64_t vec_per_thread = get_vec_per_thread(m, total_threads, mr);
+  int64_t num_threads = (m + vec_per_thread - 1) / vec_per_thread;
+  const size_t src_stride = vec_per_thread * lhs_stride;
+
+  auto lhs_quant_pack = [=, &kernel_packet](int64_t thread_id) {
+    const auto lhs_src_ptr = lhs_native_mtx_f32 + thread_id * src_stride;
+    const int64_t m_idx = thread_id * vec_per_thread;
+    auto lhs_packed_ptr = lhs_packed_base +
+        kernel_packet.kai_get_lhs_quant_pack_offset(m_idx, k, mr, kr, sr);
+    const int64_t vec_num = (thread_id == num_threads - 1)
+        ? (m - vec_per_thread * thread_id)
+        : vec_per_thread;
+    size_t offset = kernel_packet.kai_get_lhs_quant_pack_offset(m_idx, k, mr, kr, sr);
+    size_t write_size = kernel_packet.kai_get_lhs_packed_size(vec_num, k, mr, kr, sr);
+
+    TORCH_CHECK(offset + write_size <= lhs_packed_size,
+      "lhs_packed buffer overflow: offset + write_size > buffer size");
+
+    kernel_packet.kai_run_lhs_quant_pack(
+        vec_num,
+        k,
+        mr,
+        kr,
+        sr,
+        0,
+        (const uint16_t*)lhs_src_ptr,
+        lhs_stride,
+        lhs_packed_ptr);
+  };
+  at::parallel_for(
+      0, num_threads, /*grain_size=*/1, [&](int64_t begin, int64_t end) {
+        for (int64_t thread_id = begin; thread_id < end; ++thread_id) {
+          lhs_quant_pack(thread_id);
+        }
+      });
+
+  // Matrix multiplication
+  vec_per_thread = get_vec_per_thread(n, total_threads, n_step);
+  num_threads = (n + vec_per_thread - 1) / vec_per_thread;
+
+  auto mm = [=, &kernel_packet](int64_t thread_id) {
+    const auto rhs_packed_ptr = rhs_packed_mtx_qs4cx +
+        kernel_packet.ukernel.get_rhs_packed_offset(
+            thread_id * vec_per_thread, k);
+    auto dst_ptr = dst_act_mtx_f32 +
+        kernel_packet.ukernel.get_dst_offset(
+            0, thread_id * vec_per_thread, dst_stride);
+    const int64_t vec_num = (thread_id == num_threads - 1)
+        ? (n - vec_per_thread * thread_id)
+        : vec_per_thread;
+
+    kernel_packet.ukernel.run_matmul(
+        m,
+        vec_num,
+        k,
+        lhs_packed_base,
+        rhs_packed_ptr,
+        (uint16_t*)dst_ptr,
+        dst_stride,
+        element_size, // dst_stride_col
+        -FLT_MAX,
+        FLT_MAX);
+  };
+
+  at::parallel_for(
+      0, num_threads, /*grain_size=*/1, [&](int64_t begin, int64_t end) {
+        for (int64_t thread_id = begin; thread_id < end; ++thread_id) {
+          mm(thread_id);
+        }
+      });
+}
+void kai_quant_pack_lhs_int4_mm(
+    const at::Tensor& output,
+    const at::Tensor& input,
+    const at::Tensor& weight,
+    const int64_t m,
+    const int64_t n,
+    const int64_t k,
+    const int64_t bl)
+{
+    // Prefer Channelwise kernel over Groupwise kernel for conflicting cases
+    if (bl == k) {
+        const auto input_dtype = input.dtype();
+
+        if (input_dtype == at::kBFloat16) {
+            if (cpuinfo_has_arm_bf16()) {
+                kleidiai::kai_quant_pack_lhs_int4_mm_bf16_channelwise(
+                    output, input, weight, m, n, k);
+            } else {
+                // Fallback to FP32 kernel, output is BF16!
+                TORCH_WARN("CPU does not support BF16. Falling back to FP32 kernel.");
+                at::Tensor input_fp32 = kleidi_bf16_to_fp32(input);
+                // Allocate a temporary FP32 output tensor
+                at::Tensor temp_fp32_output = at::empty(output.sizes(), output.options().dtype(at::kFloat));
+                kleidiai::kai_quant_pack_lhs_int4_mm_channelwise(
+                    temp_fp32_output, input_fp32, weight, m, n, k);
+                // Convert/copy to BF16 output
+                output.copy_(temp_fp32_output.to(at::kBFloat16));
+            }
+        } else if (input_dtype == at::kFloat) {
+            kleidiai::kai_quant_pack_lhs_int4_mm_channelwise(
+                output, input, weight, m, n, k);
+        } else {
+            TORCH_CHECK(
+                false,
+                "Unsupported input data type: Only Bfloat16 and Float inputs are supported for Kleidiai int4 channelwise matrix multiplication");
+        }
+    } else if ((bl % 32 == 0) && (k % bl == 0)) {
+        kleidiai::kai_quant_pack_lhs_int4_mm_groupwise(
+            output, input, weight, m, n, k, bl);
+    }
 }
 } // namespace at::native::kleidiai
 #endif

--- a/aten/src/ATen/native/kleidiai/kai_kernels.cpp
+++ b/aten/src/ATen/native/kleidiai/kai_kernels.cpp
@@ -20,15 +20,11 @@ void kai_pack_int4_rhs(
     const std::optional<Tensor>& bias,
     const int64_t n,
     const int64_t k,
-    const int64_t bl) {
-       size_t expected_size = kai_pack_rhs_int4_size(n, k, bl, scales.scalar_type());
-  TORCH_WARN(
-      ": expected ", expected_size,
-      ", got ", weight_packed.numel()
-  );
+    const int64_t bl)
+{
   if (bl == k) {
     // Channelwise
-    if (scales.scalar_type() == at::kBFloat16) {
+    if (weight.scalar_type() == at::kBFloat16) {
       auto kernel_packet = kai_select_bf16_channelwise_matmul_ukernel(
           kai_kernel_id::matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod);
       auto& params = kernel_packet.rhs_pack_params;

--- a/aten/src/ATen/native/kleidiai/kai_kernels.cpp
+++ b/aten/src/ATen/native/kleidiai/kai_kernels.cpp
@@ -72,11 +72,11 @@ size_t kai_pack_rhs_int4_size(
     const int64_t n,
     const int64_t k,
     const int64_t bl,
-    at::ScalarType scale_dtype)
+    at::ScalarType weight_dtype)
 {
   size_t packed_size = n * k;
   if (bl == k) {
-    if (scale_dtype == at::kBFloat16) {
+    if (weight_dtype == at::kBFloat16) {
       auto kernel_packet = kai_select_bf16_channelwise_matmul_ukernel(
           kai_kernel_id::matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod);
       const auto& ukernel = kernel_packet.ukernel;

--- a/aten/src/ATen/native/kleidiai/kai_kernels.cpp
+++ b/aten/src/ATen/native/kleidiai/kai_kernels.cpp
@@ -485,20 +485,15 @@ void kai_quant_pack_lhs_int4_mm(
     if (bl == k) {
         const auto input_dtype = input.dtype();
 
-        if (input_dtype == at::kBFloat16) {
-            if (cpuinfo_has_arm_bf16()) {
+        if ((input_dtype == at::kBFloat16) )
+        {
+            if (cpuinfo_has_arm_bf16())
+            {
                 kleidiai::kai_quant_pack_lhs_int4_mm_bf16_channelwise(
                     output, input, weight, m, n, k);
             } else {
-                // Fallback to FP32 kernel, output is BF16!
-                TORCH_WARN("CPU does not support BF16. Falling back to FP32 kernel.");
-                at::Tensor input_fp32 = kleidi_bf16_to_fp32(input);
-                // Allocate a temporary FP32 output tensor
-                at::Tensor temp_fp32_output = at::empty(output.sizes(), output.options().dtype(at::kFloat));
-                kleidiai::kai_quant_pack_lhs_int4_mm_channelwise(
-                    temp_fp32_output, input_fp32, weight, m, n, k);
-                // Convert/copy to BF16 output
-                output.copy_(temp_fp32_output.to(at::kBFloat16));
+                TORCH_CHECK(
+                false, "BF16 Unsupported: CPU does not support BF16. Please use a CPU with BF16 support.");
             }
         } else if (input_dtype == at::kFloat) {
             kleidiai::kai_quant_pack_lhs_int4_mm_channelwise(

--- a/aten/src/ATen/native/kleidiai/kai_kernels.cpp
+++ b/aten/src/ATen/native/kleidiai/kai_kernels.cpp
@@ -456,8 +456,7 @@ void kai_quant_pack_lhs_int4_mm(
     if (bl == k) {
         const auto input_dtype = input.dtype();
 
-        if ((input_dtype == at::kBFloat16) )
-        {
+        if (input_dtype == at::kBFloat16) {
             if (cpuinfo_has_arm_bf16()){
                 kleidiai::kai_quant_pack_lhs_int4_mm_bf16_channelwise(
                     output, input, weight, m, n, k);

--- a/aten/src/ATen/native/kleidiai/kai_kernels.h
+++ b/aten/src/ATen/native/kleidiai/kai_kernels.h
@@ -25,7 +25,8 @@ void kai_pack_int4_rhs(
 size_t kai_pack_rhs_int4_size(
     const int64_t n,
     const int64_t k,
-    const int64_t bl);
+    const int64_t bl,
+    at::ScalarType scale_dtype = at::kFloat);
 
 /**
  * @brief Run 2 operations ( Input quantize and pack -> 4 bit Matmul )

--- a/aten/src/ATen/native/kleidiai/kai_kernels.h
+++ b/aten/src/ATen/native/kleidiai/kai_kernels.h
@@ -26,7 +26,7 @@ size_t kai_pack_rhs_int4_size(
     const int64_t n,
     const int64_t k,
     const int64_t bl,
-    at::ScalarType weight_dtype = at::kFloat);
+    at::ScalarType tensor_dtype = at::kFloat);
 
 /**
  * @brief Run 2 operations ( Input quantize and pack -> 4 bit Matmul )

--- a/aten/src/ATen/native/kleidiai/kai_kernels.h
+++ b/aten/src/ATen/native/kleidiai/kai_kernels.h
@@ -5,8 +5,6 @@
 
 namespace at::native::kleidiai {
 
-at::Tensor kleidi_bf16_to_fp32(const at::Tensor& src);
-
 /**
  * @brief Rearranges the quantized weight to support kleidiai inference
  * @param bl Groupsize for quantization should be multiple of 32

--- a/aten/src/ATen/native/kleidiai/kai_kernels.h
+++ b/aten/src/ATen/native/kleidiai/kai_kernels.h
@@ -26,7 +26,7 @@ size_t kai_pack_rhs_int4_size(
     const int64_t n,
     const int64_t k,
     const int64_t bl,
-    at::ScalarType scale_dtype = at::kFloat);
+    at::ScalarType weight_dtype = at::kFloat);
 
 /**
  * @brief Run 2 operations ( Input quantize and pack -> 4 bit Matmul )

--- a/aten/src/ATen/native/kleidiai/kai_kernels.h
+++ b/aten/src/ATen/native/kleidiai/kai_kernels.h
@@ -5,6 +5,8 @@
 
 namespace at::native::kleidiai {
 
+at::Tensor kleidi_bf16_to_fp32(const at::Tensor& src);
+
 /**
  * @brief Rearranges the quantized weight to support kleidiai inference
  * @param bl Groupsize for quantization should be multiple of 32

--- a/aten/src/ATen/native/kleidiai/kai_pack.h
+++ b/aten/src/ATen/native/kleidiai/kai_pack.h
@@ -36,7 +36,7 @@ void kai_pack_rhs_groupwise_int4(
     AT_ERROR("kai_pack_rhs_channelwise_int4: Scales data pointer is null");
   }
 
-  float* bias_ptr = bias.has_value() ? bias.value().data_ptr<float>() : NULL;
+  float* bias_ptr = bias.has_value() ? bias.value().to(kFloat).data_ptr<float>() : NULL;
   auto& params = kernel.rhs_pack_params;
 
   kernel.kai_run_rhs_pack(
@@ -73,7 +73,8 @@ void kai_pack_rhs_channelwise_int4(
   auto weight_packed_data =
       reinterpret_cast<uint8_t*>(weight_packed.data_ptr());
   const auto weight_data = weight.data_ptr<uint8_t>();
-  const auto scales_data = scales.data_ptr<float>();
+
+  const auto scales_data = scales.to(kFloat).data_ptr<float>();
 
   if (weight_data == nullptr) {
     AT_ERROR("kai_pack_rhs_channelwise_int4: Weight data pointer is null");
@@ -83,7 +84,7 @@ void kai_pack_rhs_channelwise_int4(
     AT_ERROR("kai_pack_rhs_channelwise_int4: Scales data pointer is null");
   }
 
-  float* bias_ptr = bias.has_value() ? bias.value().data_ptr<float>() : NULL;
+  float* bias_ptr = bias.has_value() ? bias.value().to(kFloat).data_ptr<float>() : NULL;
   auto& params = kernel.rhs_pack_params;
 
   kernel.kai_run_rhs_pack(

--- a/aten/src/ATen/native/kleidiai/kai_pack.h
+++ b/aten/src/ATen/native/kleidiai/kai_pack.h
@@ -36,7 +36,8 @@ void kai_pack_rhs_groupwise_int4(
     AT_ERROR("kai_pack_rhs_channelwise_int4: Scales data pointer is null");
   }
 
-  float* bias_ptr = bias.has_value() ? bias.value().to(kFloat).data_ptr<float>() : NULL;
+  float* bias_ptr =
+      bias.has_value() ? bias.value().to(kFloat).data_ptr<float>() : NULL;
   auto& params = kernel.rhs_pack_params;
 
   kernel.kai_run_rhs_pack(
@@ -84,7 +85,8 @@ void kai_pack_rhs_channelwise_int4(
     AT_ERROR("kai_pack_rhs_channelwise_int4: Scales data pointer is null");
   }
 
-  float* bias_ptr = bias.has_value() ? bias.value().to(kFloat).data_ptr<float>() : NULL;
+  float* bias_ptr =
+      bias.has_value() ? bias.value().to(kFloat).data_ptr<float>() : NULL;
   auto& params = kernel.rhs_pack_params;
 
   kernel.kai_run_rhs_pack(

--- a/aten/src/ATen/native/kleidiai/kai_ukernel_interface.cpp
+++ b/aten/src/ATen/native/kleidiai/kai_ukernel_interface.cpp
@@ -68,5 +68,37 @@ kai_matmul_ukernel_f32_qa8dxp_qs4cxp kai_select_channelwise_matmul_ukernel(
     const kai_kernel_id id) {
   return channelwise_8bit_4bit_kernels.at(id);
 }
+
+// Kernel Mapping - BF16 Channelwise
+std::unordered_map<kai_kernel_id, kai_matmul_ukernel_bf16_qa8dxp_qs4cxp> bf16_channelwise_8bit_4bit_kernels =
+    {{kai_kernel_id::matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
+      {{kai_get_m_step_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
+        kai_get_n_step_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
+        kai_get_mr_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
+        kai_get_nr_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
+        kai_get_kr_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
+        kai_get_sr_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
+        kai_get_lhs_packed_offset_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
+        kai_get_rhs_packed_offset_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
+        kai_get_dst_offset_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
+        kai_get_dst_size_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
+        kai_run_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod}}},
+     {kai_kernel_id::matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
+      {{kai_get_m_step_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
+        kai_get_n_step_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
+        kai_get_mr_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
+        kai_get_nr_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
+        kai_get_kr_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
+        kai_get_sr_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
+        kai_get_lhs_packed_offset_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
+        kai_get_rhs_packed_offset_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
+        kai_get_dst_offset_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
+        kai_get_dst_size_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
+        kai_run_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm}}}};
+
+kai_matmul_ukernel_bf16_qa8dxp_qs4cxp kai_select_bf16_channelwise_matmul_ukernel(
+    const kai_kernel_id id) {
+  return bf16_channelwise_8bit_4bit_kernels.at(id);
+}
 } // namespace at::native::kleidiai
 #endif

--- a/aten/src/ATen/native/kleidiai/kai_ukernel_interface.cpp
+++ b/aten/src/ATen/native/kleidiai/kai_ukernel_interface.cpp
@@ -70,31 +70,33 @@ kai_matmul_ukernel_f32_qa8dxp_qs4cxp kai_select_channelwise_matmul_ukernel(
 }
 
 // Kernel Mapping - BF16 Channelwise
-std::unordered_map<kai_kernel_id, kai_matmul_ukernel_bf16_qa8dxp_qs4cxp> bf16_channelwise_8bit_4bit_kernels =
-    {{kai_kernel_id::matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
-      {{kai_get_m_step_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
-        kai_get_n_step_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
-        kai_get_mr_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
-        kai_get_nr_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
-        kai_get_kr_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
-        kai_get_sr_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
-        kai_get_lhs_packed_offset_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
-        kai_get_rhs_packed_offset_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
-        kai_get_dst_offset_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
-        kai_get_dst_size_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
-        kai_run_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod}}},
-     {kai_kernel_id::matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
-      {{kai_get_m_step_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
-        kai_get_n_step_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
-        kai_get_mr_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
-        kai_get_nr_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
-        kai_get_kr_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
-        kai_get_sr_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
-        kai_get_lhs_packed_offset_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
-        kai_get_rhs_packed_offset_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
-        kai_get_dst_offset_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
-        kai_get_dst_size_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
-        kai_run_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm}}}};
+std::unordered_map<kai_kernel_id, kai_matmul_ukernel_bf16_qa8dxp_qs4cxp>
+    bf16_channelwise_8bit_4bit_kernels = {
+        {kai_kernel_id::
+             matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
+         {{kai_get_m_step_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
+           kai_get_n_step_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
+           kai_get_mr_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
+           kai_get_nr_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
+           kai_get_kr_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
+           kai_get_sr_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
+           kai_get_lhs_packed_offset_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
+           kai_get_rhs_packed_offset_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
+           kai_get_dst_offset_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
+           kai_get_dst_size_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod,
+           kai_run_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod}}},
+        {kai_kernel_id::matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
+         {{kai_get_m_step_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
+           kai_get_n_step_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
+           kai_get_mr_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
+           kai_get_nr_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
+           kai_get_kr_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
+           kai_get_sr_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
+           kai_get_lhs_packed_offset_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
+           kai_get_rhs_packed_offset_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
+           kai_get_dst_offset_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
+           kai_get_dst_size_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm,
+           kai_run_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm}}}};
 
 kai_matmul_ukernel_bf16_qa8dxp_qs4cxp kai_select_bf16_channelwise_matmul_ukernel(
     const kai_kernel_id id) {

--- a/aten/src/ATen/native/kleidiai/kai_ukernel_interface.h
+++ b/aten/src/ATen/native/kleidiai/kai_ukernel_interface.h
@@ -21,18 +21,21 @@
 namespace at::native::kleidiai {
 
 enum class kai_kernel_id {
+  // FP32 inputs, 4-bit weights, FP32 output
   matmul_clamp_f32_qai8dxp1x8_qsi4c32p8x8_1x8x32_neon_dotprod =
-      0, // Groupwise 4 bit GEMV
+      0, // Groupwise 4-bit GEMV (per-group scales, NEON DOTPROD)
   matmul_clamp_f32_qai8dxp4x8_qsi4c32p4x8_4x8x32_neon_i8mm =
-      1, // Groupwise 4 bit GEMM
+      1, // Groupwise 4-bit GEMM (per-group scales, NEON I8MM)
   matmul_clamp_f32_qai8dxp1x8_qsi4cxp8x8_1x8x32_neon_dotprod =
-      2, // Channelwise 4 bit GEMV
+      2, // Channelwise 4-bit GEMV (per-channel scales, NEON DOTPROD)
   matmul_clamp_f32_qai8dxp4x8_qsi4cxp8x8_8x8x32_neon_i8mm =
-      3, // Channelwise 4 bit GEMM
+      3, // Channelwise 4-bit GEMM (per-channel scales, NEON I8MM)
+
+  // BF16 inputs, 4-bit weights, BF16 output
   matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod =
-      4, // Channelwise 4 bit GEMV
+      4, // Channelwise 4-bit GEMV with BF16 input/output
   matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm =
-      5 // Channelwise 4 bit GEMM
+      5  // Channelwise 4-bit GEMM with BF16 input/output
 };
 
 // Channelwise Kernel mapping

--- a/aten/src/ATen/native/kleidiai/kai_ukernel_interface.h
+++ b/aten/src/ATen/native/kleidiai/kai_ukernel_interface.h
@@ -10,7 +10,11 @@
 #include <kai/ukernels/matmul/matmul_clamp_f32_qai8dxp_qsi4cxp/kai_matmul_clamp_f32_qai8dxp1x8_qsi4cxp8x8_1x8x32_neon_dotprod.h>
 #include <kai/ukernels/matmul/matmul_clamp_f32_qai8dxp_qsi4cxp/kai_matmul_clamp_f32_qai8dxp4x8_qsi4cxp8x8_8x8x32_neon_i8mm.h>
 #include <kai/ukernels/matmul/matmul_clamp_f32_qai8dxp_qsi4cxp/kai_matmul_clamp_f32_qai8dxp_qsi4cxp_interface.h>
+#include <kai/ukernels/matmul/matmul_clamp_bf16_qai8dxp_qsi4cxp/kai_matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod.h>
+#include <kai/ukernels/matmul/matmul_clamp_bf16_qai8dxp_qsi4cxp/kai_matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm.h>
+#include <kai/ukernels/matmul/matmul_clamp_bf16_qai8dxp_qsi4cxp/kai_matmul_clamp_bf16_qai8dxp_qsi4cxp_interface.h>
 #include <kai/ukernels/matmul/pack/kai_lhs_quant_pack_qai8dxp_f32.h>
+#include <kai/ukernels/matmul/pack/kai_lhs_quant_pack_qai8dxp_bf16_neon.h>
 #include <kai/ukernels/matmul/pack/kai_rhs_pack_nxk_qsi4c32p_qsu4c32s1s0.h>
 #include <kai/ukernels/matmul/pack/kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0.h>
 
@@ -24,7 +28,11 @@ enum class kai_kernel_id {
   matmul_clamp_f32_qai8dxp1x8_qsi4cxp8x8_1x8x32_neon_dotprod =
       2, // Channelwise 4 bit GEMV
   matmul_clamp_f32_qai8dxp4x8_qsi4cxp8x8_8x8x32_neon_i8mm =
-      3 // Channelwise 4 bit GEMM
+      3, // Channelwise 4 bit GEMM
+  matmul_clamp_bf16_qai8dxp1x8_qsi4cxp8x8_1x8_neon_dotprod =
+      4, // Channelwise 4 bit GEMV
+  matmul_clamp_bf16_qai8dxp4x8_qsi4cxp8x8_8x8_neon_i8mm =
+      5 // Channelwise 4 bit GEMM
 };
 
 // Channelwise Kernel mapping
@@ -66,6 +74,9 @@ struct kai_matmul_ukernel_f32_qa8dxp_qs4cxp {
       void* rhs_packed,
       size_t extra_bytes,
       const struct kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_params* params);
+   size_t(*kai_get_lhs_quant_pack_offset)(
+        size_t m_idx, size_t k, size_t mr, size_t kr, size_t sr
+    );
 
   kai_matmul_ukernel_f32_qa8dxp_qs4cxp(
       const kai_matmul_clamp_f32_qai8dxp_qsi4cxp_ukernel& kernel)
@@ -75,11 +86,70 @@ struct kai_matmul_ukernel_f32_qa8dxp_qs4cxp {
         kai_get_rhs_packed_size(
             &kai_get_rhs_packed_size_rhs_pack_nxk_qsi4cxp_qs4cxs1s0),
         kai_run_lhs_quant_pack(&kai_run_lhs_quant_pack_qai8dxp_f32),
-        kai_run_rhs_pack(&kai_run_rhs_pack_nxk_qsi4cxp_qs4cxs1s0) {}
+        kai_run_rhs_pack(&kai_run_rhs_pack_nxk_qsi4cxp_qs4cxs1s0),
+        kai_get_lhs_quant_pack_offset(&kai_get_lhs_packed_offset_lhs_quant_pack_qai8dxp_f32){}
 };
 
 struct kai_matmul_ukernel_f32_qa8dxp_qs4cxp
 kai_select_channelwise_matmul_ukernel(const kai_kernel_id id);
+
+// bf16 Channelwise Kernel mapping
+struct kai_matmul_ukernel_bf16_qa8dxp_qs4cxp {
+    struct kai_matmul_clamp_bf16_qai8dxp_qsi4cxp_ukernel ukernel;
+    struct kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_params rhs_pack_params;
+    size_t (*kai_get_lhs_packed_size)(
+        size_t m,
+        size_t k,
+        size_t mr,
+        size_t kr,
+        size_t sr);
+    size_t (*kai_get_rhs_packed_size)(
+        size_t n,
+        size_t k,
+        size_t nr,
+        size_t kr,
+        size_t sr);
+    void (*kai_run_lhs_quant_pack)(
+        size_t m,
+        size_t k,
+        size_t mr,
+        size_t kr,
+        size_t sr,
+        size_t m_idx_start,
+        const void* lhs,
+        size_t lhs_stride,
+        void* lhs_packed);
+    void (*kai_run_rhs_pack)(
+        size_t num_groups,
+        size_t n,
+        size_t k,
+        size_t nr,
+        size_t kr,
+        size_t sr,
+        const uint8_t* rhs,
+        const float* bias,
+        const float* scale,
+        void* rhs_packed,
+        size_t extra_bytes,
+        const struct kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_params* params);
+        size_t(*kai_get_lhs_quant_pack_offset)(
+            size_t m_idx, size_t k, size_t mr, size_t kr, size_t sr
+        );
+
+    kai_matmul_ukernel_bf16_qa8dxp_qs4cxp(
+        const kai_matmul_clamp_bf16_qai8dxp_qsi4cxp_ukernel& kernel)
+        : ukernel(kernel),
+          kai_get_lhs_packed_size(
+              &kai_get_lhs_packed_size_lhs_quant_pack_qai8dxp_bf16_neon),
+          kai_get_rhs_packed_size(
+              &kai_get_rhs_packed_size_rhs_pack_nxk_qsi4cxp_qs4cxs1s0),
+          kai_run_lhs_quant_pack(&kai_run_lhs_quant_pack_qai8dxp_bf16_neon),
+          kai_run_rhs_pack(&kai_run_rhs_pack_nxk_qsi4cxp_qs4cxs1s0),
+          kai_get_lhs_quant_pack_offset(&kai_get_lhs_packed_offset_lhs_quant_pack_qai8dxp_bf16_neon){}
+  };
+
+struct kai_matmul_ukernel_bf16_qa8dxp_qs4cxp
+kai_select_bf16_channelwise_matmul_ukernel(const kai_kernel_id id);
 
 // Groupwise Kernel mapping
 struct kai_matmul_ukernel_f32_qa8dxp_qs4c32p {
@@ -125,6 +195,9 @@ struct kai_matmul_ukernel_f32_qa8dxp_qs4c32p {
       void* rhs_packed,
       size_t extra_bytes,
       const struct kai_rhs_pack_nxk_qsi4c32p_qsu4c32s1s0_params* params);
+      size_t(*kai_get_lhs_quant_pack_offset)(
+        size_t m_idx, size_t k, size_t mr, size_t kr, size_t sr
+    );
 
   kai_matmul_ukernel_f32_qa8dxp_qs4c32p(
       const kai_matmul_clamp_f32_qai8dxp_qsi4c32p_ukernel& kernel)
@@ -134,7 +207,8 @@ struct kai_matmul_ukernel_f32_qa8dxp_qs4c32p {
         kai_get_rhs_packed_size(
             &kai_get_rhs_packed_size_rhs_pack_nxk_qsi4c32p_qsu4c32s1s0),
         kai_run_lhs_quant_pack(&kai_run_lhs_quant_pack_qai8dxp_f32),
-        kai_run_rhs_pack(&kai_run_rhs_pack_nxk_qsi4c32p_qsu4c32s1s0) {}
+        kai_run_rhs_pack(&kai_run_rhs_pack_nxk_qsi4c32p_qsu4c32s1s0),
+        kai_get_lhs_quant_pack_offset(&kai_get_lhs_packed_offset_lhs_quant_pack_qai8dxp_f32) {}
 };
 
 struct kai_matmul_ukernel_f32_qa8dxp_qs4c32p kai_select_groupwise_matmul_ukernel(

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -82,9 +82,6 @@ from torch.testing._internal.common_cuda import (
 from torch.testing._internal.common_device_type import (
     expectedFailureXPU,
     largeTensorTest,
-    onlyNativeDeviceTypes,
-    onlyCUDA,
-    skipMetaIf,
 )
 from torch.testing._internal.common_dtype import all_types, get_all_dtypes
 from torch.testing._internal.common_quantization import (
@@ -108,8 +105,6 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_ASAN,
     TEST_WITH_ROCM,
     xfailIfS390X,
-    runOnRocmArch,
-    MI300_ARCH,
 )
 from torch.testing._internal.logging_utils import logs_to_string
 from torch.utils import _pytree as pytree
@@ -2598,7 +2593,6 @@ class CommonTemplate:
 
         self.common(fn, (a, q_group, in_features, out_features))
 
-
     @xfail_if_mps_unimplemented
     @xfail_if_triton_cpu
     @skipCUDAIf(True, "No _dyn_quant_matmul_4bit implementation on CUDA")
@@ -2618,7 +2612,9 @@ class CommonTemplate:
         a = a.to(torch.bfloat16)
         b = b.to(torch.bfloat16)
         if not self.is_dtype_supported(torch.bfloat16):
-            raise unittest.SkipTest(f"torch.bfloat16 not supported for device {self.device}")
+            raise unittest.SkipTest(
+                f"torch.bfloat16 not supported for device {self.device}"
+            )
 
         def dyn_quant_pack_4bit_weight(b, in_features, out_features):
             b_uint8, b_scales_and_zeros = _group_quantize_tensor_symmetric(

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2598,19 +2598,19 @@ class CommonTemplate:
         m = 32
         k = 128
         n = 128
+        q_group = k
 
         torch.manual_seed(1)
         a = torch.rand((m, k), dtype=torch.bfloat16)
         b = torch.rand((k, n), dtype=torch.bfloat16)
 
+        # codegen_dynamic_shape test fails without explicitly marking these dynamic
         torch._dynamo.mark_dynamic(a, 0)
         torch._dynamo.mark_dynamic(b, 1)
 
         in_features = b.size(0)
         out_features = b.size(1)
-        q_group = in_features
-        a = a.to(torch.bfloat16)
-        b = b.to(torch.bfloat16)
+
         if not self.is_dtype_supported(torch.bfloat16):
             raise unittest.SkipTest(
                 f"torch.bfloat16 not supported for device {self.device}"
@@ -2633,7 +2633,6 @@ class CommonTemplate:
 
         def fn(a, q_group, in_features, out_features):
             b_int4pack, _ = dyn_quant_pack_4bit_weight(b, in_features, out_features)
-            a = a.to(torch.bfloat16)
             res = torch.ops.aten._dyn_quant_matmul_4bit(
                 a,
                 b_int4pack,

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2598,6 +2598,7 @@ class CommonTemplate:
 
         self.common(fn, (a, q_group, in_features, out_features))
 
+    @skipCPUIf(IS_MACOS, "fails on M1, mismatch in bf16 support reporting")
     @xfail_if_mps_unimplemented
     @xfail_if_triton_cpu
     @skipCUDAIf(True, "No _dyn_quant_matmul_4bit implementation on CUDA")

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2476,6 +2476,7 @@ class CommonTemplate:
         b_int8pack, b_scales = convert_weight_to_int8pack(b)
         self.common(fn, (a, b_int8pack, b_scales, c))
 
+    @xfail_if_mps_unimplemented
     @xfail_if_triton_cpu
     @skipCUDAIf(True, "No _dyn_quant_pack_4bit_weight implementation on CUDA")
     @skipIfRocm
@@ -2511,14 +2512,20 @@ class CommonTemplate:
 
         self.common(fn, (b, in_features, out_features))
 
+    @xfail_if_mps_unimplemented
     @xfail_if_triton_cpu
     @skipCUDAIf(True, "No _dyn_quant_pack_4bit_weight implementation on CUDA")
     @skipIfRocm
     @skipIfXpu(msg="No _dyn_quant_pack_4bit_weight implementation on XPU")
     def test__dyn_quant_pack_4bit_weight_bf16(self):
-        q_group = 32
         k = 128
         n = 128
+        q_group = 32
+
+        if not self.is_dtype_supported(torch.bfloat16):
+            raise unittest.SkipTest(
+                f"torch.bfloat16 not supported for device {self.device}"
+            )
 
         torch.manual_seed(1)
         b = torch.rand((k, n), dtype=torch.bfloat16)
@@ -2546,6 +2553,7 @@ class CommonTemplate:
 
         self.common(fn, (b, in_features, out_features))
 
+    @xfail_if_mps_unimplemented
     @xfail_if_triton_cpu
     @skipCUDAIf(True, "No _dyn_quant_matmul_4bit implementation on CUDA")
     @skipIfRocm
@@ -2590,6 +2598,7 @@ class CommonTemplate:
 
         self.common(fn, (a, q_group, in_features, out_features))
 
+    @xfail_if_mps_unimplemented
     @xfail_if_triton_cpu
     @skipCUDAIf(True, "No _dyn_quant_matmul_4bit implementation on CUDA")
     @skipIfRocm
@@ -2599,6 +2608,11 @@ class CommonTemplate:
         k = 128
         n = 128
         q_group = k
+
+        if not self.is_dtype_supported(torch.bfloat16):
+            raise unittest.SkipTest(
+                f"torch.bfloat16 not supported for device {self.device}"
+            )
 
         torch.manual_seed(1)
         a = torch.rand((m, k), dtype=torch.bfloat16)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2517,6 +2517,7 @@ class CommonTemplate:
     @skipCUDAIf(True, "No _dyn_quant_pack_4bit_weight implementation on CUDA")
     @skipIfRocm
     @skipIfXpu(msg="No _dyn_quant_pack_4bit_weight implementation on XPU")
+    @skip_if_halide  # bf16
     def test__dyn_quant_pack_4bit_weight_bf16(self):
         k = 128
         n = 128
@@ -2604,6 +2605,7 @@ class CommonTemplate:
     @skipCUDAIf(True, "No _dyn_quant_matmul_4bit implementation on CUDA")
     @skipIfRocm
     @skipIfXpu(msg="No _dyn_quant_matmul_4bit implementation on XPU")
+    @skip_if_halide  # bf16
     def test__dyn_quant_matmul_4bit_bf16_input(self):
         m = 32
         k = 128

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -7927,7 +7927,6 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
                 in_features,
                 out_features,
             )
-        # === Accuracy checks ===
 
         # Mean relative error check
         expected_mean_err = 0.00952
@@ -7936,15 +7935,6 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
         self.assertTrue(
             abs(mean_err - expected_mean_err) < mean_err_tol,
             f"Mean relative error {mean_err:.6f} deviates from expected {expected_mean_err}"
-        )
-
-        # RMSE check
-        expected_rmse = 0.29
-        rmse_tol = 0.1
-        rmse = torch.sqrt(torch.mean((res - ref) ** 2))
-        self.assertTrue(
-            abs(rmse - expected_rmse) < rmse_tol,
-            f"RMSE {rmse:.6f} not within expected range (~{expected_rmse})"
         )
 
         # Elementwise relative error check
@@ -8082,21 +8072,11 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
             f"Mean relative error {mean_err:.6f} deviates from expected {expected_mean_err}"
         )
 
-        # RMSE check
-        expected_rmse = 0.29
-        rmse_tol = 0.1
-        rmse = torch.sqrt(torch.mean((res - ref) ** 2))
-        self.assertTrue(
-            abs(rmse - expected_rmse) < rmse_tol,
-            f"RMSE {rmse:.6f} not within expected range (~{expected_rmse})"
-        )
-
         # Avoid divide-by-zero with clamp
         denominator = ref.abs().clamp(min=torch.finfo(ref.dtype).eps)
 
         # Compute elementwise relative error — always non-negative
         elementwise_relative_error = (res - ref).abs() / denominator
-        print(elementwise_relative_error.max())
 
         # Check if all elements are within 6% error
         assert torch.all(elementwise_relative_error >= 0), "Relative error should never be negative"

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -7800,7 +7800,7 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
     @parametrize("m", [1, 32])
     @parametrize("k", [64, 128])
     @parametrize("n", [4096, 11008])
-    def test__dyn_quant_matmul_4bit(self, device, m, k, n):
+    def test__dyn_quant_matmul_4bit_fp32(self, device, m, k, n):
         if self.device_type == "cuda":
             self.skipTest("CUDA is unsupported")
 
@@ -7872,7 +7872,96 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
     @parametrize("m", [1, 32])
     @parametrize("k", [64, 128])
     @parametrize("n", [4096, 11008])
-    def test_compile_dyn_quant_matmul_4bit(self, device, m, k, n):
+    def test__dyn_quant_matmul_4bit_bf16(self, device, m, k, n):
+        if self.device_type == "cuda":
+            self.skipTest("CUDA is unsupported")
+
+
+        torch.manual_seed(1)
+        a_bfloat16 = torch.rand((m, k), dtype=torch.bfloat16, device=device)
+        b_bfloat16 = torch.rand((k, n), dtype=torch.bfloat16, device=device)
+        in_features = b_bfloat16.size(0)
+        out_features = b_bfloat16.size(1)
+        q_group = in_features
+
+        def dyn_quant_pack_4bit_weight(b, in_features, out_features):
+            b_uint8, b_scales_and_zeros = _group_quantize_tensor_symmetric(
+                b, n_bit=4, groupsize=q_group
+            )
+
+            if q_group == in_features:
+                b_scales_and_zeros = b_scales_and_zeros.to(torch.float)
+            else:
+                b_scales_and_zeros = b_scales_and_zeros.to(torch.bfloat16)
+            b_int4pack = torch._dyn_quant_pack_4bit_weight(
+                b_uint8, b_scales_and_zeros, None, q_group, in_features, out_features
+            )
+
+            return b_int4pack, b_scales_and_zeros
+
+        def dyn_quant_matmul_4bit(
+            a, b_int4pack, q_group, in_features, out_features
+        ):
+            return torch.ops.aten._dyn_quant_matmul_4bit(
+                a,
+                b_int4pack,
+                q_group,
+                in_features,
+                out_features,
+            )
+
+        b_int4pack, b_scales_and_zeros = dyn_quant_pack_4bit_weight(
+            b_bfloat16, in_features, out_features
+        )
+
+        dtypes = [torch.bfloat16]
+
+        for dtype in dtypes:
+            a = a_bfloat16.to(dtype=dtype)
+            b = b_bfloat16.to(dtype=dtype)
+            ref = torch.mm(a, b)
+            res = dyn_quant_matmul_4bit(
+                a,
+                b_int4pack,
+                q_group,
+                in_features,
+                out_features,
+            )
+        # === Accuracy checks ===
+
+        # Mean relative error check
+        expected_mean_err = 0.00952
+        mean_err_tol = 0.005  # allow small deviation (±0.005)
+        mean_err = ((res - ref).abs() / ref.abs().clamp(min=1e-5)).mean()
+        self.assertTrue(
+            abs(mean_err - expected_mean_err) < mean_err_tol,
+            f"Mean relative error {mean_err:.6f} deviates from expected {expected_mean_err}"
+        )
+
+        # RMSE check
+        expected_rmse = 0.29
+        rmse_tol = 0.1
+        rmse = torch.sqrt(torch.mean((res - ref) ** 2))
+        self.assertTrue(
+            abs(rmse - expected_rmse) < rmse_tol,
+            f"RMSE {rmse:.6f} not within expected range (~{expected_rmse})"
+        )
+
+        # Elementwise relative error check
+        elementwise_diff = (res - ref).abs()
+        elementwise_relative_error = elementwise_diff / ref.abs().clamp(min=torch.finfo(ref.dtype).eps)
+        self.assertTrue(
+            torch.all(elementwise_relative_error < 0.070),
+            "Some elements have relative error >= 7%"
+        )
+
+    @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "cublas runtime error")
+    @unittest.skipIf(TEST_WITH_ROCM and IS_REMOTE_GPU, "ROCM is unsupported")
+    @onlyNativeDeviceTypes
+    @parametrize("m", [1, 32])
+    @parametrize("k", [64, 128])
+    @parametrize("n", [4096, 11008])
+    def test_compile_dyn_quant_matmul_4bit_fp32(self, device, m, k, n):
         if self.device_type == "cuda":
             self.skipTest("CUDA is unsupported")
 
@@ -7930,6 +8019,93 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
         )
 
     @onlyNativeDeviceTypes
+    @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "cublas runtime error")
+    @unittest.skipIf(TEST_WITH_ROCM and IS_REMOTE_GPU, "ROCM is unsupported")
+    @onlyNativeDeviceTypes
+    @parametrize("m", [1, 32])
+    @parametrize("k", [64, 128])
+    @parametrize("n", [4096, 11008])
+    def test_compile_dyn_quant_matmul_4bit_bf16(self, device, m, k, n):
+        if self.device_type == "cuda":
+            self.skipTest("CUDA is unsupported")
+
+
+        torch.manual_seed(1)
+        a_bfloat16 = torch.rand((m, k), dtype=torch.bfloat16, device=device)
+        b_bfloat16 = torch.rand((k, n), dtype=torch.bfloat16, device=device)
+        in_features = b_bfloat16.size(0)
+        out_features = b_bfloat16.size(1)
+        q_group = in_features
+
+        b_uint8, b_scales_and_zeros = _group_quantize_tensor_symmetric(
+            b_bfloat16, n_bit=4, groupsize=q_group
+        )
+
+        if q_group == in_features:
+            b_scales_and_zeros = b_scales_and_zeros.to(dtype=torch.float)
+        else:
+            b_scales_and_zeros = b_scales_and_zeros.to(dtype=torch.bfloat16)
+
+        @torch.compile
+        def dyn_quant_matmul_4bit(
+            a, b_uint8, b_scales_and_zeros, q_group, in_features, out_features
+        ):
+            b_int4pack = torch._dyn_quant_pack_4bit_weight(
+                b_uint8, b_scales_and_zeros, None, q_group, in_features, out_features
+            )
+            return torch._dyn_quant_matmul_4bit(
+                a,
+                b_int4pack,
+                q_group,
+                in_features,
+                out_features,
+            )
+
+        res = dyn_quant_matmul_4bit(
+            a_bfloat16,
+            b_uint8,
+            b_scales_and_zeros,
+            q_group,
+            in_features,
+            out_features,
+        )
+        ref = torch.mm(a_bfloat16, b_bfloat16)
+
+        # === Accuracy checks ===
+
+        # Mean relative error check
+        expected_mean_err = 0.00952
+        mean_err_tol = 0.005  # allow small deviation (±0.005)
+        mean_err = ((res - ref).abs() / ref.abs().clamp(min=1e-5)).mean()
+        self.assertTrue(
+            abs(mean_err - expected_mean_err) < mean_err_tol,
+            f"Mean relative error {mean_err:.6f} deviates from expected {expected_mean_err}"
+        )
+
+        # RMSE check
+        expected_rmse = 0.29
+        rmse_tol = 0.1
+        rmse = torch.sqrt(torch.mean((res - ref) ** 2))
+        self.assertTrue(
+            abs(rmse - expected_rmse) < rmse_tol,
+            f"RMSE {rmse:.6f} not within expected range (~{expected_rmse})"
+        )
+
+            # Avoid divide-by-zero with clamp
+        denominator = ref.abs().clamp(min=torch.finfo(ref.dtype).eps)
+
+        # Compute elementwise relative error — always non-negative
+        elementwise_relative_error = (res - ref).abs() / denominator
+        print(elementwise_relative_error.max())
+
+        # Check if all elements are within 6% error
+        assert torch.all(elementwise_relative_error >= 0), "Relative error should never be negative"
+        self.assertTrue(
+            torch.all(elementwise_relative_error < 0.070),
+            "Some elements have relative error >= 7%"
+        )
+
+    @onlyCPU
     @parametrize("m", [32, 64])
     @parametrize("k", [32, 64])
     @parametrize("n", [48, 64])

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -8091,7 +8091,7 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
             f"RMSE {rmse:.6f} not within expected range (~{expected_rmse})"
         )
 
-            # Avoid divide-by-zero with clamp
+        # Avoid divide-by-zero with clamp
         denominator = ref.abs().clamp(min=torch.finfo(ref.dtype).eps)
 
         # Compute elementwise relative error — always non-negative

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -7800,7 +7800,7 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
     @parametrize("m", [1, 32])
     @parametrize("k", [64, 128])
     @parametrize("n", [4096, 11008])
-    def test__dyn_quant_matmul_4bit_fp32(self, device, m, k, n):
+    def test__dyn_quant_matmul_4bit(self, device, m, k, n):
         if self.device_type == "cuda":
             self.skipTest("CUDA is unsupported")
 
@@ -7872,86 +7872,7 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
     @parametrize("m", [1, 32])
     @parametrize("k", [64, 128])
     @parametrize("n", [4096, 11008])
-    def test__dyn_quant_matmul_4bit_bf16(self, device, m, k, n):
-        if self.device_type == "cuda":
-            self.skipTest("CUDA is unsupported")
-
-
-        torch.manual_seed(1)
-        a_bfloat16 = torch.rand((m, k), dtype=torch.bfloat16, device=device)
-        b_bfloat16 = torch.rand((k, n), dtype=torch.bfloat16, device=device)
-        in_features = b_bfloat16.size(0)
-        out_features = b_bfloat16.size(1)
-        q_group = in_features
-
-        def dyn_quant_pack_4bit_weight(b, in_features, out_features):
-            b_uint8, b_scales_and_zeros = _group_quantize_tensor_symmetric(
-                b, n_bit=4, groupsize=q_group
-            )
-
-            if q_group == in_features:
-                b_scales_and_zeros = b_scales_and_zeros.to(torch.float)
-            else:
-                b_scales_and_zeros = b_scales_and_zeros.to(torch.bfloat16)
-            b_int4pack = torch._dyn_quant_pack_4bit_weight(
-                b_uint8, b_scales_and_zeros, None, q_group, in_features, out_features
-            )
-
-            return b_int4pack, b_scales_and_zeros
-
-        def dyn_quant_matmul_4bit(
-            a, b_int4pack, q_group, in_features, out_features
-        ):
-            return torch.ops.aten._dyn_quant_matmul_4bit(
-                a,
-                b_int4pack,
-                q_group,
-                in_features,
-                out_features,
-            )
-
-        b_int4pack, b_scales_and_zeros = dyn_quant_pack_4bit_weight(
-            b_bfloat16, in_features, out_features
-        )
-
-        dtypes = [torch.bfloat16]
-
-        for dtype in dtypes:
-            a = a_bfloat16.to(dtype=dtype)
-            b = b_bfloat16.to(dtype=dtype)
-            ref = torch.mm(a, b)
-            res = dyn_quant_matmul_4bit(
-                a,
-                b_int4pack,
-                q_group,
-                in_features,
-                out_features,
-            )
-
-        # Mean relative error check
-        expected_mean_err = 0.00952
-        mean_err_tol = 0.005  # allow small deviation (±0.005)
-        mean_err = ((res - ref).abs() / ref.abs().clamp(min=1e-5)).mean()
-        self.assertTrue(
-            abs(mean_err - expected_mean_err) < mean_err_tol,
-            f"Mean relative error {mean_err:.6f} deviates from expected {expected_mean_err}"
-        )
-
-        # Elementwise relative error check
-        elementwise_diff = (res - ref).abs()
-        elementwise_relative_error = elementwise_diff / ref.abs().clamp(min=torch.finfo(ref.dtype).eps)
-        self.assertTrue(
-            torch.all(elementwise_relative_error < 0.070),
-            "Some elements have relative error >= 7%"
-        )
-
-    @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "cublas runtime error")
-    @unittest.skipIf(TEST_WITH_ROCM and IS_REMOTE_GPU, "ROCM is unsupported")
-    @onlyNativeDeviceTypes
-    @parametrize("m", [1, 32])
-    @parametrize("k", [64, 128])
-    @parametrize("n", [4096, 11008])
-    def test_compile_dyn_quant_matmul_4bit_fp32(self, device, m, k, n):
+    def test_compile_dyn_quant_matmul_4bit(self, device, m, k, n):
         if self.device_type == "cuda":
             self.skipTest("CUDA is unsupported")
 
@@ -8009,83 +7930,6 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
         )
 
     @onlyNativeDeviceTypes
-    @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "cublas runtime error")
-    @unittest.skipIf(TEST_WITH_ROCM and IS_REMOTE_GPU, "ROCM is unsupported")
-    @onlyNativeDeviceTypes
-    @parametrize("m", [1, 32])
-    @parametrize("k", [64, 128])
-    @parametrize("n", [4096, 11008])
-    def test_compile_dyn_quant_matmul_4bit_bf16(self, device, m, k, n):
-        if self.device_type == "cuda":
-            self.skipTest("CUDA is unsupported")
-
-
-        torch.manual_seed(1)
-        a_bfloat16 = torch.rand((m, k), dtype=torch.bfloat16, device=device)
-        b_bfloat16 = torch.rand((k, n), dtype=torch.bfloat16, device=device)
-        in_features = b_bfloat16.size(0)
-        out_features = b_bfloat16.size(1)
-        q_group = in_features
-
-        b_uint8, b_scales_and_zeros = _group_quantize_tensor_symmetric(
-            b_bfloat16, n_bit=4, groupsize=q_group
-        )
-
-        if q_group == in_features:
-            b_scales_and_zeros = b_scales_and_zeros.to(dtype=torch.float)
-        else:
-            b_scales_and_zeros = b_scales_and_zeros.to(dtype=torch.bfloat16)
-
-        @torch.compile
-        def dyn_quant_matmul_4bit(
-            a, b_uint8, b_scales_and_zeros, q_group, in_features, out_features
-        ):
-            b_int4pack = torch._dyn_quant_pack_4bit_weight(
-                b_uint8, b_scales_and_zeros, None, q_group, in_features, out_features
-            )
-            return torch._dyn_quant_matmul_4bit(
-                a,
-                b_int4pack,
-                q_group,
-                in_features,
-                out_features,
-            )
-
-        res = dyn_quant_matmul_4bit(
-            a_bfloat16,
-            b_uint8,
-            b_scales_and_zeros,
-            q_group,
-            in_features,
-            out_features,
-        )
-        ref = torch.mm(a_bfloat16, b_bfloat16)
-
-        # === Accuracy checks ===
-
-        # Mean relative error check
-        expected_mean_err = 0.00952
-        mean_err_tol = 0.005  # allow small deviation (±0.005)
-        mean_err = ((res - ref).abs() / ref.abs().clamp(min=1e-5)).mean()
-        self.assertTrue(
-            abs(mean_err - expected_mean_err) < mean_err_tol,
-            f"Mean relative error {mean_err:.6f} deviates from expected {expected_mean_err}"
-        )
-
-        # Avoid divide-by-zero with clamp
-        denominator = ref.abs().clamp(min=torch.finfo(ref.dtype).eps)
-
-        # Compute elementwise relative error — always non-negative
-        elementwise_relative_error = (res - ref).abs() / denominator
-
-        # Check if all elements are within 6% error
-        assert torch.all(elementwise_relative_error >= 0), "Relative error should never be negative"
-        self.assertTrue(
-            torch.all(elementwise_relative_error < 0.070),
-            "Some elements have relative error >= 7%"
-        )
-
-    @onlyCPU
     @parametrize("m", [32, 64])
     @parametrize("k", [32, 64])
     @parametrize("n", [48, 64])

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -3860,8 +3860,12 @@ def meta__dyn_quant_matmul_4bit(
 ):
     torch._check(inp.dim() == 2, lambda: "input must be a 2D tensor")
     torch._check(
-        inp.dtype == torch.float32,
-        lambda: f"expected input to be f32, got {inp.dtype}",
+        (inp.dtype == torch.float32)
+        or (inp.dtype == torch.bfloat16 and block_size == in_features),
+        lambda: (
+            f"expected input to be f32 or bf16 (bf16 requires block_size == in_features), "
+            f"got {inp.dtype} with block_size={block_size} and in_features={in_features}"
+        ),
     )
     M = inp.size(0)
     return inp.new_empty(M, out_features, dtype=inp.dtype)

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -3718,6 +3718,7 @@ def kai_roundup(a: int, b: int) -> int:
 
 def get_kai_packed_weight_size(n_bits, N, K, groupsize):
     if n_bits == 4:
+        # Works for both fp32 and bf16 Kernels
         if groupsize == K:  # channelwise
             # dotprod params only [1x8x32_neon_dotprod]
             kai_nr = 8
@@ -3847,6 +3848,8 @@ def meta__dyn_quant_pack_4bit_weight(
         )
         return weights.new_empty(int(packed_weight_size), dtype=torch.uint8)
     packed_weight_size = weights.numel() + scales_zeros.numel()
+    if bias is not None:
+        packed_weight_size += bias.numel()
     return weights.new_empty(packed_weight_size, dtype=torch.float)
 
 


### PR DESCRIPTION
Co-authored-by: Nikhil Gupta [nikhil.gupta2@arm.com](mailto:nikhil.gupta2@arm.com)

This PR enables the use of KleidiAI INT4 kernels that directly produce BF16 outputs within PyTorch to boost LLM prefill & decode performance

**This change improves decode throughput by ~15% & reduces memory required to inference the model by 50%**

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @snadampal @milpuz01 @nikhil-arm @fadara01 @nWEIdia @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @malfet @davsva01

### Benchmark Setup
```
Model: meta-llama/Llama-3.1-8B
Test Platform: Neoverse V2
```
### Detailed Results

| Metric                           | With `--compile`         | Without `--compile`      |
|----------------------------------|---------------------------|---------------------------|
| Quantization Scheme              | INT4 symmetric channelwise | INT4 symmetric channelwise |
| Input Precision                  | BF16                      | BF16                      |
| Number of Layers Quantized       | 32                        | 32                        |
| Average Compression Ratio        | 87.49%                    | 87.49%                    |
| Total Quantization Time (s)      | 9.62                      | 10.32                     |
| Compile Time (First) (s)         | 134.48                    | 1.69                      |
| Compile Time (Second) (s)        | 80.44                     | 1.60                      |
| Compile Time (Subsequent) (s)    | 0.19                      | 0.22                      |
| Prefill Tokens                   | 54                        | 54                        |
| Decoded Tokens                   | 33                        | 33                        |
| Prefill Time (s)                 | 0.19                      | 0.22                      |
| Decode Time (s)                  | 0.76                      | 1.38                      |
| E2E Generation Time (s)          | 0.95                      | 1.60                      |
| Prefill Throughput (tokens/s)    | 288.13                    | 249.91                    |
| Decode Throughput (tokens/s)     | 43.42                     | 23.83                     |