### PR TITLE
[Flex attention] Remove extra strides

### DIFF
--- a/torch/_inductor/kernel/flex_decoding.py
+++ b/torch/_inductor/kernel/flex_decoding.py
@@ -138,9 +138,9 @@ flex_decoding_template = TritonTemplate(
     offs_vd = tl.arange(0, V_HEAD_DIM_ROUNDED)
 
     # Get HZ offsets for KV_NUM_BLKS and KV_IDX
-    stride_block_z, stride_block_h, stride_block_row = {{stride("KV_NUM_BLKS")}}
+    stride_block_z, stride_block_h = {{stride("KV_NUM_BLKS")}}
     sparse_block_hz_offset = sparse_idx_z * stride_block_z + sparse_idx_h * stride_block_h
-    stride_kv_z, stride_kv_h, stride_kv_row, stride_kv_col = {{stride("KV_IDX")}}
+    stride_kv_z, stride_kv_h, stride_kv_row = {{stride("KV_IDX")}}
     sparse_idx_hz_offset = sparse_idx_z * stride_kv_z + sparse_idx_h * stride_kv_h
 
     # Calculate KV blocks that belong this CTA.


### PR DESCRIPTION
When running code like:
```Python
import torch
import torch.nn as nn
from torch.nn.attention import flex_attention as fa


batch_size, seq_len, n_heads, head_dim = 1, 3, 16, 32
device, dtype = 'cuda', torch.bfloat16
q = torch.randn(batch_size, n_heads, seq_len, head_dim, device=device, dtype=dtype)
k = v = torch.randn_like(q)
causal_mask = lambda b, h, q_idx, kv_idx: q_idx >= kv_idx
block_mask = fa.create_block_mask(
    causal_mask,
    B=None, H=None,
    Q_LEN=seq_len, KV_LEN=seq_len,
    BLOCK_SIZE=128,
    device=device,
)
input_pos = 3
decode_mask = block_mask[:, :, input_pos // block_mask.BLOCK_SIZE[0]]
decode_mask.mask_mod = lambda b, h, q, kv: causal_mask(b, h, q + input_pos, kv)
decode_mask.seq_lengths = (seq_len, seq_len)
y = torch.compile(fa.flex_attention)(q, k, v, block_mask=decode_mask, enable_gqa=True)

```
Without this PR we get the following error:
```
torch._inductor.exc.InductorError: SubprocException: An exception occurred in a subprocess:

Traceback (most recent call last):
  File "lib/python3.13/site-packages/torch/_inductor/compile_worker/subproc_pool.py", line 340, in do_job
    result = job()
  File "lib/python3.13/site-packages/torch/_inductor/runtime/compile_tasks.py", line 62, in _worker_compile_triton
    kernel.precompile(warm_cache_only=True)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "lib/python3.13/site-packages/torch/_inductor/runtime/triton_heuristics.py", line 398, in precompile
    self._precompile_worker()
    ~~~~~~~~~~~~~~~~~~~~~~~^^
  File "lib/python3.13/site-packages/torch/_inductor/runtime/triton_heuristics.py", line 429, in _precompile_worker
    compile_results.append(self._precompile_config(c))
                           ~~~~~~~~~~~~~~~~~~~~~~~^^^
  File "lib/python3.13/site-packages/torch/_inductor/runtime/triton_heuristics.py", line 712, in _precompile_config
    binary = triton.compile(*compile_args, **compile_kwargs)
  File "lib/python3.13/site-packages/triton/compiler/compiler.py", line 339, in compile
    module = src.make_ir(options, codegen_fns, module_map, context)
  File "lib/python3.13/site-packages/triton/compiler/compiler.py", line 83, in make_ir
    return ast_to_ttir(self.fn, self, context=context, options=options, codegen_fns=codegen_fns,
                       module_map=module_map)
triton.compiler.errors.CompilationError: at 124:4:
    tl.device_assert(BLOCK_M % G == 0)
    BLOCK_M_PER_HQ: tl.constexpr = BLOCK_M // G
    off_g = tl.arange(0, G)                                                 # [G]
    offs_g = tl.ravel(tl.broadcast_to(off_g[:, None], [G, BLOCK_M_PER_HQ])) # [BLOCK_M]
    offs_hq = offs_g + off_hkv * G
    off_m = tl.arange(0, BLOCK_M_PER_HQ)                                    # [BLOCK_M_PER_HQ]
    offs_m = tl.ravel(tl.broadcast_to(off_m[None, :], [G, BLOCK_M_PER_HQ])) # [BLOCK_M]
    offs_d = tl.arange(0, QK_HEAD_DIM_ROUNDED)
    offs_vd = tl.arange(0, V_HEAD_DIM_ROUNDED)

    # Get HZ offsets for KV_NUM_BLKS and KV_IDX
    stride_block_z, stride_block_h, stride_block_row = 1, 1
    ^
IndexError('list index out of range')


Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you're reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @Chillee @drisspg @yanboliang @BoyuanFeng