### PR TITLE
[Dynamo][Better Engineering] Add typing to bytecode analysis and transform

### DIFF
--- a/torch/_dynamo/bytecode_analysis.py
+++ b/torch/_dynamo/bytecode_analysis.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 """
 This module provides utilities for analyzing and optimizing Python bytecode.
 Key functionality includes:
@@ -18,8 +16,13 @@ import bisect
 import dataclasses
 import dis
 import sys
-from typing import Any, Union
+from typing import Any, TYPE_CHECKING, Union
 
+
+if TYPE_CHECKING:
+    # TODO(lucaskabela): consider moving Instruction into this file
+    # and refactoring in callsite; that way we don't have to guard this import
+    from .bytecode_transformation import Instruction
 
 TERMINAL_OPCODES = {
     dis.opmap["RETURN_VALUE"],
@@ -45,7 +48,7 @@ HASFREE = set(dis.hasfree)
 stack_effect = dis.stack_effect
 
 
-def get_indexof(insts):
+def get_indexof(insts: list["Instruction"]) -> dict["Instruction", int]:
     """
     Get a mapping from instruction memory address to index in instruction list.
     Additionally checks that each instruction only appears once in the list.
@@ -57,12 +60,12 @@ def get_indexof(insts):
     return indexof
 
 
-def remove_dead_code(instructions):
+def remove_dead_code(instructions: list["Instruction"]) -> list["Instruction"]:
     """Dead code elimination"""
     indexof = get_indexof(instructions)
     live_code = set()
 
-    def find_live_code(start):
+    def find_live_code(start: int) -> None:
         for i in range(start, len(instructions)):
             if i in live_code:
                 return
@@ -71,6 +74,7 @@ def remove_dead_code(instructions):
             if inst.exn_tab_entry:
                 find_live_code(indexof[inst.exn_tab_entry.target])
             if inst.opcode in JUMP_OPCODES:
+                assert inst.target is not None
                 find_live_code(indexof[inst.target])
             if inst.opcode in TERMINAL_OPCODES:
                 return
@@ -102,7 +106,7 @@ def remove_dead_code(instructions):
     return [inst for i, inst in enumerate(instructions) if i in live_code]
 
 
-def remove_pointless_jumps(instructions):
+def remove_pointless_jumps(instructions: list["Instruction"]) -> list["Instruction"]:
     """Eliminate jumps to the next instruction"""
     pointless_jumps = {
         id(a)
@@ -112,11 +116,11 @@ def remove_pointless_jumps(instructions):
     return [inst for inst in instructions if id(inst) not in pointless_jumps]
 
 
-def propagate_line_nums(instructions):
+def propagate_line_nums(instructions: list["Instruction"]) -> None:
     """Ensure every instruction has line number set in case some are removed"""
     cur_line_no = None
 
-    def populate_line_num(inst):
+    def populate_line_num(inst: "Instruction") -> None:
         nonlocal cur_line_no
         if inst.starts_line:
             cur_line_no = inst.starts_line
@@ -127,12 +131,12 @@ def propagate_line_nums(instructions):
         populate_line_num(inst)
 
 
-def remove_extra_line_nums(instructions):
+def remove_extra_line_nums(instructions: list["Instruction"]) -> None:
     """Remove extra starts line properties before packing bytecode"""
 
     cur_line_no = None
 
-    def remove_line_num(inst):
+    def remove_line_num(inst: "Instruction") -> None:
         nonlocal cur_line_no
         if inst.starts_line is None:
             return
@@ -152,12 +156,14 @@ class ReadsWrites:
     visited: set[Any]
 
 
-def livevars_analysis(instructions, instruction):
+def livevars_analysis(
+    instructions: list["Instruction"], instruction: "Instruction"
+) -> set[Any]:
     indexof = get_indexof(instructions)
     must = ReadsWrites(set(), set(), set())
     may = ReadsWrites(set(), set(), set())
 
-    def walk(state, start):
+    def walk(state: ReadsWrites, start: int) -> None:
         if start in state.visited:
             return
         state.visited.add(start)
@@ -177,6 +183,7 @@ def livevars_analysis(instructions, instruction):
             if inst.exn_tab_entry:
                 walk(may, indexof[inst.exn_tab_entry.target])
             if inst.opcode in JUMP_OPCODES:
+                assert inst.target is not None
                 walk(may, indexof[inst.target])
                 state = may
             if inst.opcode in TERMINAL_OPCODES:
@@ -197,19 +204,19 @@ class StackSize:
     high: Union[int, float]
     fixed_point: FixedPointBox
 
-    def zero(self):
+    def zero(self) -> None:
         self.low = 0
         self.high = 0
         self.fixed_point.value = False
 
-    def offset_of(self, other, n):
+    def offset_of(self, other: "StackSize", n: int) -> None:
         prior = (self.low, self.high)
         self.low = min(self.low, other.low + n)
         self.high = max(self.high, other.high + n)
         if (self.low, self.high) != prior:
             self.fixed_point.value = False
 
-    def exn_tab_jump(self, depth):
+    def exn_tab_jump(self, depth: int) -> None:
         prior = (self.low, self.high)
         self.low = min(self.low, depth)
         self.high = max(self.high, depth)
@@ -217,7 +224,7 @@ class StackSize:
             self.fixed_point.value = False
 
 
-def stacksize_analysis(instructions) -> Union[int, float]:
+def stacksize_analysis(instructions: list["Instruction"]) -> Union[int, float]:
     assert instructions
     fixed_point = FixedPointBox()
     stack_sizes = {
@@ -238,6 +245,7 @@ def stacksize_analysis(instructions) -> Union[int, float]:
                 eff = stack_effect(inst.opcode, inst.arg, jump=False)
                 stack_sizes[next_inst].offset_of(stack_size, eff)
             if inst.opcode in JUMP_OPCODES:
+                assert inst.target is not None, f"missing target: {inst}"
                 stack_sizes[inst.target].offset_of(
                     stack_size, stack_effect(inst.opcode, inst.arg, jump=True)
                 )
@@ -246,11 +254,6 @@ def stacksize_analysis(instructions) -> Union[int, float]:
                 # on why depth is computed this way.
                 depth = inst.exn_tab_entry.depth + int(inst.exn_tab_entry.lasti) + 1
                 stack_sizes[inst.exn_tab_entry.target].exn_tab_jump(depth)
-
-    if False:
-        for inst in instructions:
-            stack_size = stack_sizes[inst]
-            print(stack_size.low, stack_size.high, inst)
 
     low = min(x.low for x in stack_sizes.values())
     high = max(x.high for x in stack_sizes.values())

--- a/torch/_dynamo/bytecode_transformation.py
+++ b/torch/_dynamo/bytecode_transformation.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 """
 This module provides utilities for analyzing, transforming and manipulating Python bytecode.
 It includes functionality for:
@@ -23,7 +21,7 @@ import itertools
 import sys
 import types
 import uuid
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from typing import Any, Callable, cast, Optional, Union
 
 from ..utils._backport_slots import dataclass_slots
@@ -53,7 +51,9 @@ class InstructionExnTabEntry:
             f"depth={self.depth}, lasti={self.lasti})"
         )
 
-    def __eq__(self, o) -> bool:
+    def __eq__(self, o: object) -> bool:
+        if not isinstance(o, InstructionExnTabEntry):
+            return False
         return (
             self.start is o.start
             and self.end is o.end
@@ -84,7 +84,7 @@ class Instruction:
     def __hash__(self) -> int:
         return id(self)
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: object) -> bool:
         return id(self) == id(other)
 
     def short_inst_repr(self) -> str:
@@ -145,22 +145,26 @@ class _NotProvided:
 
 if sys.version_info >= (3, 12):
 
-    def inst_has_op_bits(name):
+    def inst_has_op_bits(name: str) -> bool:
         return name in ("LOAD_ATTR", "LOAD_GLOBAL", "LOAD_SUPER_ATTR")
 
 elif sys.version_info >= (3, 11):
 
-    def inst_has_op_bits(name):
+    def inst_has_op_bits(name: str) -> bool:
         return name == "LOAD_GLOBAL"
 
 else:
 
-    def inst_has_op_bits(name):
+    def inst_has_op_bits(name: str):
         return False
 
 
 def create_instruction(
-    name, *, arg=None, argval=_NotProvided, target=None
+    name: str,
+    *,
+    arg: Optional[int] = None,
+    argval: Optional[Any] = _NotProvided,
+    target: Optional[Instruction] = None,
 ) -> Instruction:
     """
     At most one of `arg`, `argval`, and `target` can be not None/_NotProvided.
@@ -198,12 +202,12 @@ def create_instruction(
 
 
 # Python 3.11 remaps
-def create_jump_absolute(target) -> Instruction:
+def create_jump_absolute(target: Instruction) -> Instruction:
     inst = "JUMP_FORWARD" if sys.version_info >= (3, 11) else "JUMP_ABSOLUTE"
     return create_instruction(inst, target=target)
 
 
-def create_load_const(val, checked=True) -> Instruction:
+def create_load_const(val: Any, checked: bool = True) -> Instruction:
     """
     In general we should only create `LOAD_CONST` for immutable objects, but
     sometimes it's convenient _and safe_ for Dynamo create `LOAD_CONST` for
@@ -220,7 +224,7 @@ def create_dup_top() -> Instruction:
     return create_instruction("DUP_TOP")
 
 
-def create_rot_n(n) -> list[Instruction]:
+def create_rot_n(n: int) -> list[Instruction]:
     """
     Returns a "simple" sequence of instructions that rotates TOS to the n-th
     position in the stack. For Python < 3.11, returns a single ROT_*
@@ -265,17 +269,18 @@ def add_push_null(
     In this case, instructions WILL be modified.
     """
     if isinstance(inst_or_insts, Instruction):
-        insts = [inst_or_insts]
+        insts: list[Instruction] = [inst_or_insts]
     else:
+        assert isinstance(inst_or_insts, list)
         insts = inst_or_insts
 
-    def inst_has_bit_set(idx):
+    def inst_has_bit_set(idx: int) -> bool:
         assert insts[idx].arg is not None
-        return insts[idx].arg & 1 == 1
+        return insts[idx].arg & 1 == 1  # type: ignore[operator]
 
-    def set_inst_bit(idx):
+    def set_inst_bit(idx: int) -> None:
         assert insts[idx].arg is not None
-        insts[idx].arg |= 1
+        insts[idx].arg |= 1  # type: ignore[operator]
 
     if sys.version_info >= (3, 13):
         # In 3.13, NULL follows the callable
@@ -312,8 +317,9 @@ def add_push_null_call_function_ex(
     is not set, due to an expected CALL_FUNCTION_EX instruction.
     """
     if isinstance(inst_or_insts, Instruction):
-        insts = [inst_or_insts]
+        insts: list[Instruction] = [inst_or_insts]
     else:
+        assert isinstance(inst_or_insts, list)
         insts = inst_or_insts
 
     if sys.version_info < (3, 11):
@@ -334,7 +340,7 @@ def add_push_null_call_function_ex(
     return insts
 
 
-def create_call_function(nargs, push_null) -> list[Instruction]:
+def create_call_function(nargs: int, push_null: bool) -> list[Instruction]:
     """
     Creates a sequence of instructions that makes a function call.
 
@@ -389,7 +395,7 @@ def create_call_function(nargs, push_null) -> list[Instruction]:
     return [create_instruction("CALL_FUNCTION", arg=nargs)]
 
 
-def create_call_method(nargs) -> list[Instruction]:
+def create_call_method(nargs: int) -> list[Instruction]:
     if sys.version_info >= (3, 12):
         return [create_instruction("CALL", arg=nargs)]
     if sys.version_info >= (3, 11):
@@ -400,19 +406,19 @@ def create_call_method(nargs) -> list[Instruction]:
     return [create_instruction("CALL_METHOD", arg=nargs)]
 
 
-def create_load_method(name) -> Instruction:
+def create_load_method(name: str) -> Instruction:
     if sys.version_info >= (3, 12):
         # in 3.12, create a LOAD_ATTR instruction with the low bit set
         return create_instruction("LOAD_ATTR", arg=1, argval=name)
     return create_instruction("LOAD_METHOD", argval=name)
 
 
-def create_setup_with(target) -> Instruction:
+def create_setup_with(target: Instruction) -> Instruction:
     opname = "BEFORE_WITH" if sys.version_info >= (3, 11) else "SETUP_WITH"
     return create_instruction(opname, target=target)
 
 
-def create_swap(n) -> list[Instruction]:
+def create_swap(n: int) -> list[Instruction]:
     if sys.version_info >= (3, 11):
         return [create_instruction("SWAP", arg=n)]
     # in Python < 3.11, SWAP is a macro that expands to multiple instructions
@@ -465,7 +471,7 @@ def lnotab_writer(
     assert sys.version_info < (3, 10)
     lnotab: list[int] = []
 
-    def update(lineno_new, byteno_new):
+    def update(lineno_new: int, byteno_new: int) -> None:
         nonlocal byteno, lineno
         while byteno_new != byteno or lineno_new != lineno:
             byte_offset = max(0, min(byteno_new - byteno, 255))
@@ -478,7 +484,9 @@ def lnotab_writer(
     return lnotab, update
 
 
-def linetable_310_writer(first_lineno):
+def linetable_310_writer(
+    first_lineno: int,
+) -> tuple[list[int], Callable[[int, int], None], Callable[[int], None]]:
     """
     Used to create typing.CodeType.co_linetable
     See https://github.com/python/cpython/blob/main/Objects/lnotab_notes.txt
@@ -490,7 +498,7 @@ def linetable_310_writer(first_lineno):
     lineno_delta = 0
     byteno = 0
 
-    def _update(byteno_delta, lineno_delta):
+    def _update(byteno_delta: int, lineno_delta: int) -> None:
         while byteno_delta != 0 or lineno_delta != 0:
             byte_offset = max(0, min(byteno_delta, 254))
             line_offset = max(-127, min(lineno_delta, 127))
@@ -499,7 +507,7 @@ def linetable_310_writer(first_lineno):
             lineno_delta -= line_offset
             linetable.extend((byte_offset, line_offset & 0xFF))
 
-    def update(lineno_new, byteno_new):
+    def update(lineno_new: int, byteno_new: int) -> None:
         nonlocal lineno, lineno_delta, byteno
         byteno_delta = byteno_new - byteno
         byteno = byteno_new
@@ -507,7 +515,7 @@ def linetable_310_writer(first_lineno):
         lineno_delta = lineno_new - lineno
         lineno = lineno_new
 
-    def end(total_bytes):
+    def end(total_bytes: int) -> None:
         _update(total_bytes - byteno, lineno_delta)
 
     return linetable, update, end
@@ -528,7 +536,9 @@ def encode_varint(n: int) -> list[int]:
     return b
 
 
-def linetable_311_writer(first_lineno: int):
+def linetable_311_writer(
+    first_lineno: int,
+) -> tuple[list[int], Callable[[Optional["dis.Positions"], int], None]]:
     """
     Used to create typing.CodeType.co_linetable
     See https://github.com/python/cpython/blob/3.11/Objects/locations.md
@@ -538,11 +548,11 @@ def linetable_311_writer(first_lineno: int):
     linetable = []
     lineno = first_lineno
 
-    def update(positions: "dis.Positions", inst_size):
+    def update(positions: Optional["dis.Positions"], inst_size: int) -> None:
         nonlocal lineno
         lineno_new = positions.lineno if positions else None
 
-        def _update(delta, size):
+        def _update(delta: int, size: int) -> None:
             assert 0 < size <= 8
             # first byte - use 13 (no column info) is positions is
             # malformed, otherwise use 14 (long form)
@@ -721,7 +731,9 @@ def assemble(instructions: list[Instruction], firstlineno: int) -> tuple[bytes, 
     return bytes(code), bytes(lnotab)
 
 
-def _get_instruction_by_offset(offset_to_inst: dict[int, Instruction], offset: int):
+def _get_instruction_by_offset(
+    offset_to_inst: dict[int, Instruction], offset: int
+) -> Optional[Instruction]:
     """
     Get the instruction located at a given offset, accounting for EXTENDED_ARGs
     """
@@ -731,9 +743,11 @@ def _get_instruction_by_offset(offset_to_inst: dict[int, Instruction], offset: i
     return None
 
 
-def virtualize_jumps(instructions) -> None:
+def virtualize_jumps(instructions: Iterable[Instruction]) -> None:
     """Replace jump targets with pointers to make editing easier"""
-    jump_targets = {inst.offset: inst for inst in instructions}
+    jump_targets = {
+        inst.offset: inst for inst in instructions if inst.offset is not None
+    }
 
     for inst in instructions:
         if inst.opcode in dis.hasjabs or inst.opcode in dis.hasjrel:
@@ -756,7 +770,7 @@ def flip_jump_direction(instruction: Instruction) -> None:
     assert instruction.opcode in _REL_JUMPS
 
 
-def _get_instruction_front(instructions: list[Instruction], idx: int):
+def _get_instruction_front(instructions: list[Instruction], idx: int) -> Instruction:
     """
     i.e. get the first EXTENDED_ARG instruction (if any) when targeting
     instructions[idx] with a jump.
@@ -770,7 +784,7 @@ def _get_instruction_front(instructions: list[Instruction], idx: int):
     return target
 
 
-def devirtualize_jumps(instructions):
+def devirtualize_jumps(instructions: list[Instruction]) -> None:
     """Fill in args for virtualized jump target after instructions may have moved"""
     jumps = set(dis.hasjabs).union(set(dis.hasjrel))
 
@@ -778,6 +792,11 @@ def devirtualize_jumps(instructions):
     for inst in instructions:
         if inst.opcode in jumps:
             if inst.opcode not in dis.hasjabs:
+                assert (
+                    inst.target is not None
+                    and inst.target.offset is not None
+                    and inst.offset is not None
+                )
                 if inst.target.offset < inst.offset:
                     if sys.version_info < (3, 11):
                         raise RuntimeError("Got negative jump offset for Python < 3.11")
@@ -796,6 +815,7 @@ def devirtualize_jumps(instructions):
     # compute jump instruction arg
     for inst in instructions:
         if inst.opcode in jumps:
+            assert inst.target is not None
             target = _get_instruction_front(instructions, indexof[inst.target])
             if inst.opcode in dis.hasjabs:
                 if sys.version_info < (3, 10):
@@ -808,6 +828,7 @@ def devirtualize_jumps(instructions):
                     raise RuntimeError("Python 3.11+ should not have absolute jumps")
             else:  # relative jump
                 # byte offset between target and next instruction
+                assert target.offset is not None and inst.offset is not None
                 inst.arg = abs(
                     int(target.offset - inst.offset - instruction_size(inst))
                 )
@@ -818,7 +839,9 @@ def devirtualize_jumps(instructions):
             inst.argrepr = f"to {target.offset}"
 
 
-def virtualize_exception_table(exn_tab_bytes: bytes, instructions: list[Instruction]):
+def virtualize_exception_table(
+    exn_tab_bytes: bytes, instructions: list[Instruction]
+) -> None:
     """Replace exception table entries with pointers to make editing easier"""
     exn_tab = parse_exception_table(exn_tab_bytes)
     offset_to_inst = {cast(int, inst.offset): inst for inst in instructions}
@@ -827,7 +850,7 @@ def virtualize_exception_table(exn_tab_bytes: bytes, instructions: list[Instruct
     exn_tab_iter = iter(exn_tab)
     try:
 
-        def step():
+        def step() -> tuple[ExceptionTableEntry, InstructionExnTabEntry]:
             nonlocal end_offset_idx
             entry = next(exn_tab_iter)
             # find rightmost offset <= entry.end, since entry.end may not be
@@ -841,9 +864,9 @@ def virtualize_exception_table(exn_tab_bytes: bytes, instructions: list[Instruct
             assert end_offset_idx > 0
             end_offset = offsets[end_offset_idx - 1]
             inst_entry = InstructionExnTabEntry(
-                _get_instruction_by_offset(offset_to_inst, entry.start),
-                _get_instruction_by_offset(offset_to_inst, end_offset),
-                _get_instruction_by_offset(offset_to_inst, entry.target),
+                _get_instruction_by_offset(offset_to_inst, entry.start),  # type: ignore[arg-type]
+                _get_instruction_by_offset(offset_to_inst, end_offset),  # type: ignore[arg-type]
+                _get_instruction_by_offset(offset_to_inst, entry.target),  # type: ignore[arg-type]
                 entry.depth,
                 entry.lasti,
             )
@@ -851,6 +874,7 @@ def virtualize_exception_table(exn_tab_bytes: bytes, instructions: list[Instruct
 
         entry, inst_entry = step()
         for inst in instructions:
+            assert inst.offset is not None
             while inst.offset > entry.end:
                 entry, inst_entry = step()
             if inst.offset >= entry.start:
@@ -872,15 +896,18 @@ def compute_exception_table(
             start = _get_instruction_front(
                 instructions, indexof[inst.exn_tab_entry.start]
             ).offset
+            assert start is not None
             # point to the last 2 bytes of the end instruction
             end = (
                 cast(int, inst.exn_tab_entry.end.offset)
                 + instruction_size(inst.exn_tab_entry.end)
                 - 2
             )
+            assert end is not None
             target = _get_instruction_front(
                 instructions, indexof[inst.exn_tab_entry.target]
             ).offset
+            assert target is not None
             key = (start, end)
             val = (target, inst.exn_tab_entry.depth, inst.exn_tab_entry.lasti)
             if key in exn_dict:
@@ -900,7 +927,7 @@ def compute_exception_table(
     key_stack: list[tuple[int, int]] = []
     exn_tab: list[ExceptionTableEntry] = []
 
-    def pop():
+    def pop() -> None:
         """
         Pop the key_stack and append an exception table entry if possible.
         """
@@ -934,7 +961,7 @@ def compute_exception_table(
 
 
 def check_inst_exn_tab_entries_nested(
-    tab: list[InstructionExnTabEntry], indexof
+    tab: list[InstructionExnTabEntry], indexof: dict[Instruction, int]
 ) -> None:
     """
     Checks `tab` is a properly sorted list of nested InstructionExnTabEntry's,
@@ -979,7 +1006,7 @@ def propagate_inst_exn_table_entries(instructions: list[Instruction]) -> None:
             instructions[i].exn_tab_entry = copy.copy(entry)
 
 
-def check_inst_exn_tab_entries_valid(instructions: list[Instruction]):
+def check_inst_exn_tab_entries_valid(instructions: list[Instruction]) -> None:
     """
     Checks that exn_tab_entries of instructions are valid.
     An entry's start, end, and target must be in instructions.
@@ -1012,7 +1039,9 @@ def strip_extended_args(instructions: list[Instruction]) -> None:
 # instruction, exception table entries, and positions.
 # Returns the modified sequence of instructions (including the modified
 # old instruction!) that can be manipulated elsewhere.
-def overwrite_instruction(old_inst, new_insts):
+def overwrite_instruction(
+    old_inst: Instruction, new_insts: list[Instruction]
+) -> list[Instruction]:
     # update old_inst.exnt_tab_entry.end if necessary
     if (
         old_inst.exn_tab_entry
@@ -1161,7 +1190,7 @@ def fix_extended_args(instructions: list[Instruction]) -> int:
     """Fill in correct argvals for EXTENDED_ARG ops"""
     output: list[Instruction] = []
 
-    def maybe_pop_n(n):
+    def maybe_pop_n(n: int) -> None:
         for _ in range(n):
             if output and output[-1].opcode == dis.EXTENDED_ARG:
                 output.pop()
@@ -1190,7 +1219,7 @@ def fix_extended_args(instructions: list[Instruction]) -> int:
     return added
 
 
-def instruction_size(inst) -> int:
+def instruction_size(inst: Instruction) -> int:
     import torch
 
     if sys.version_info >= (3, 11):
@@ -1198,21 +1227,21 @@ def instruction_size(inst) -> int:
     return 2
 
 
-def check_offsets(instructions) -> None:
+def check_offsets(instructions: Sequence[Instruction]) -> None:
     offset = 0
     for inst in instructions:
         assert inst.offset == offset
         offset += instruction_size(inst)
 
 
-def update_offsets(instructions) -> None:
+def update_offsets(instructions: Sequence[Instruction]) -> None:
     offset = 0
     for inst in instructions:
         inst.offset = offset
         offset += instruction_size(inst)
 
 
-def debug_bytes(*args) -> str:
+def debug_bytes(*args: bytes) -> str:
     index = range(max(map(len, args)))
     result = [
         " ".join(f"{x:03}" for x in arg)
@@ -1224,7 +1253,7 @@ def debug_bytes(*args) -> str:
     return "bytes mismatch\n" + "\n".join(result)
 
 
-def debug_checks(code):
+def debug_checks(code: types.CodeType) -> None:
     """Make sure our assembler produces same bytes as we start with"""
     dode = transform_code_object(code, lambda x, y: None, safe=True)
     assert code.co_code == dode.co_code, debug_bytes(code.co_code, dode.co_code)
@@ -1237,7 +1266,7 @@ HAS_FREE = set(dis.hasfree)
 HAS_CONST = set(dis.hasconst)
 
 
-def get_const_index(code_options, val) -> int:
+def get_const_index(code_options: dict[str, Any], val: Any) -> int:
     for i, v in enumerate(code_options["co_consts"]):
         # NOTE: stronger comparison is required, since we have
         # examples where two values compare equal but have
@@ -1249,11 +1278,15 @@ def get_const_index(code_options, val) -> int:
     return len(code_options["co_consts"]) - 1
 
 
-def fix_vars(instructions: list[Instruction], code_options, varname_from_oparg=None):
+def fix_vars(
+    instructions: list[Instruction],
+    code_options: dict[str, Any],
+    varname_from_oparg: Optional[Callable[..., Any]] = None,
+) -> None:
     # compute instruction arg from argval if arg is not provided
     names = {name: idx for idx, name in enumerate(code_options["co_names"])}
 
-    def get_name_index(name) -> int:
+    def get_name_index(name: str) -> int:
         try:
             idx = names[name]
         except KeyError:
@@ -1288,7 +1321,7 @@ def fix_vars(instructions: list[Instruction], code_options, varname_from_oparg=N
         }
     for i in range(len(instructions)):
 
-        def should_compute_arg():
+        def should_compute_arg() -> bool:
             # argval is prioritized over arg
             return instructions[i].argval is not _NotProvided
 
@@ -1356,7 +1389,7 @@ def fix_vars(instructions: list[Instruction], code_options, varname_from_oparg=N
                 instructions[i].arg = idx
 
 
-def clear_instruction_args(instructions):
+def clear_instruction_args(instructions: list[Instruction]) -> None:
     # Clear the instruction arg for instructions that have argvals.
     # Useful for using dis'd bytecode within generated bytecode.
     for inst in instructions:
@@ -1413,7 +1446,11 @@ def get_code_keys() -> list[str]:
     return keys
 
 
-def transform_code_object(code, transformations, safe=False) -> types.CodeType:
+def transform_code_object(
+    code: types.CodeType,
+    transformations: Callable[[list[Instruction], dict[str, Any]], Any],
+    safe: bool = False,
+) -> types.CodeType:
     keys = get_code_keys()
     code_options = {k: getattr(code, k) for k in keys}
     assert len(code_options["co_varnames"]) == code_options["co_nlocals"]
@@ -1466,7 +1503,7 @@ def clean_and_assemble_instructions(
     return instructions, types.CodeType(*[code_options[k] for k in keys])
 
 
-def populate_kw_names_argval(instructions, consts):
+def populate_kw_names_argval(instructions: Sequence[Instruction], consts: Any) -> None:
     for inst in instructions:
         if inst.opname == "KW_NAMES":
             inst.argval = consts[inst.arg]
@@ -1474,7 +1511,7 @@ def populate_kw_names_argval(instructions, consts):
 
 # If safe=True, we do not make any bytecode modifications.
 # Mainly used for debugging bytecode_transformation (see debug_checks)
-def cleaned_instructions(code, safe=False) -> list[Instruction]:
+def cleaned_instructions(code: types.CodeType, safe: bool = False) -> list[Instruction]:
     instructions = _cached_cleaned_instructions(code, safe)
     # We have a lot of code that implicitly mutates the instruction array. We
     # could do better here by making the copies explicit when necessary.
@@ -1482,7 +1519,7 @@ def cleaned_instructions(code, safe=False) -> list[Instruction]:
 
 
 # Copy an instructions array, making sure to remap the individual instruction targets.
-def _clone_instructions(instructions):
+def _clone_instructions(instructions: Sequence[Instruction]) -> list[Instruction]:
     # This is super hot and this is the fastest way to do this (tried copy.copy
     # and dataclasses.replace).
     copied = [
@@ -1504,10 +1541,10 @@ def _clone_instructions(instructions):
 
     remap = dict(zip(instructions, copied))
     # Handle `None` in the remapper so we don't need an extra `if`.
-    remap[None] = None
+    remap[None] = None  # type: ignore[index, assignment]
 
     for i in copied:
-        i.target = remap[i.target]
+        i.target = remap[i.target]  # type: ignore[index]
         if entry := i.exn_tab_entry:
             i.exn_tab_entry = InstructionExnTabEntry(
                 remap[entry.start],
@@ -1520,7 +1557,9 @@ def _clone_instructions(instructions):
 
 
 @functools.lru_cache
-def _cached_cleaned_instructions(code, safe=False) -> Sequence[Instruction]:
+def _cached_cleaned_instructions(
+    code: types.CodeType, safe: bool = False
+) -> Sequence[Instruction]:
     instructions = list(map(convert_instruction, dis.get_instructions(code)))
     check_offsets(instructions)
     if sys.version_info >= (3, 11):
@@ -1548,7 +1587,7 @@ def _cached_cleaned_instructions(code, safe=False) -> Sequence[Instruction]:
 _unique_id_counter = itertools.count()
 
 
-def unique_id(name, with_uuid=False) -> str:
+def unique_id(name: str, with_uuid: bool = False) -> str:
     ret = f"{name}_{next(_unique_id_counter)}"
     if with_uuid:
         ret += f"_{uuid.uuid4()}".replace("-", "_")
@@ -1560,7 +1599,12 @@ def is_generator(code: types.CodeType) -> bool:
     return (code.co_flags & co_generator) > 0
 
 
-def bytecode_from_template(fn, varname_map=None, noreturn=True, noprefix=True):
+def bytecode_from_template(
+    fn: Callable[..., Any],
+    varname_map: Optional[Mapping[Any, Any]] = None,
+    noreturn: bool = True,
+    noprefix: bool = True,
+) -> list[Instruction]:
     """Generates bytecode from a template function `fn` for use in
     dynamo bytecode generation.
 

--- a/torch/_dynamo/resume_execution.py
+++ b/torch/_dynamo/resume_execution.py
@@ -78,7 +78,7 @@ def _bytecode_from_template_with_split(template, stack_index, varname_map=None):
         ),
         (None, None),
     )
-    assert dummy_idx is not None
+    assert dummy_idx is not None and dummy_inst is not None
 
     # replace LOAD_FAST dummy with first NOP marking exception area
     overwrite_instruction(dummy_inst, [create_instruction("NOP")])

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -943,6 +943,7 @@ def break_graph_if_unsupported(*, push):
                     self.output.add_output_instructions(
                         [create_instruction("KW_NAMES", argval=kw_names)]
                     )
+                assert inst.arg is not None
                 call_insts = create_call_function(inst.arg, False)
                 call_insts[-1].copy_positions(inst)
                 self.output.add_output_instructions(call_insts)


### PR DESCRIPTION
As part of better engineering week, we would like to improve out type support to improve dev experience in dynamo

This PR adds strict typing support to a critical tracing point for dynamo, `bytecode_transformation.py` and by extension, `bytecode_analysis.py`


Running 
```
mypy torch/_dynamo/bytecode_transformation.py torch/_dynamo/bytecode_analysis.py --linecount-report /tmp/coverage_log
```

| -------- | Lines Unannotated | Lines Total | % lines covered | Funcs Unannotated | Funcs Total | % funcs covered |
| -------- | ------- | -------- | ------- | ------- | ------- | ------- |
| Main  |  1422 | 1920 | 74.06% | 73 | 93 | 78.49% |
| This PR | 1968 | 1968 | 100.00% | 93 | 93 | 100.00% |
| Delta    | +546 | +48 | +25.94% | 20 | 0 | +21.51% |


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames