### PR TITLE
Fix torch._numpy to match NumPy when empty ellipsis causes advanced indexing separation

### DIFF
--- a/test/torch_np/test_indexing.py
+++ b/test/torch_np/test_indexing.py
@@ -412,6 +412,77 @@ class TestAdvancedIndexing(TestCase):
 
         self._test_cases(cases + numpy_torch_cases, "Special index types")
 
+    def test_ellipsis(self):
+        """Tests containing ellipsis."""
+        cases = [
+            # Ellipsis + Basic indexing
+            {
+                "shape": (3, 4, 5),
+                "index": (slice(None), 0, ..., slice(None)),
+                "name": "empty ellipsis without advanced indexing",
+            },
+            {
+                "shape": (3, 4, 5),
+                "index": (slice(None), ..., 0),
+                "name": "non-empty ellipsis without advanced indexing",
+            },
+            # Ellipsis + Advanced indexing without separation
+            {
+                "shape": (3, 4, 5),
+                "index": (slice(None), ..., slice(None), (0, 1)),
+                "name": "empty ellipsis without separation",
+            },
+            {
+                "shape": (3, 4, 5),
+                "index": (slice(None), ..., (0, 1)),
+                "name": "non-empty ellipsis without separation",
+            },
+            # Ellipsis + Advanced indexing with separation
+            {
+                "shape": (3, 4, 5),
+                "index": (slice(None), (0, 1), ..., (0, 1)),
+                "name": "empty ellipsis separation",
+            },
+            {
+                "shape": (1, 3, 4, 5),
+                "index": (slice(None), (0, 1), ..., (0, 1)),
+                "name": "non-empty ellipsis separation",
+            },
+            {
+                "shape": (4, 3, 5),
+                "index": (slice(None), ((0,), (1,)), ..., (0, 1)),
+                "name": "empty ellipsis separation with 2-depth int sequence",
+            },
+            {
+                "shape": (4, 3, 5, 6),
+                "index": (slice(None), ((0,), (1,)), ..., (0, 1), slice(None)),
+                "name": "empty ellipsis separation with 2-depth int sequence and end slice",
+            },
+            {
+                "shape": (4, 3, 5, 6),
+                "index": (slice(None), ((0,), (1,)), ..., (0, 1), (((0, 1), (1, 2)),)),
+                "name": "empty ellipsis separation with 2 and 3-depth int sequence",
+            },
+            # Ellipsis + Boolean masks in advanced indexing with separation
+            {
+                "shape": (3, 4, 5),
+                "index": (slice(None), True, True, True, ..., 0, 0),
+                "name": "empty ellipsis separation with 0-dim boolean masks",
+            },
+            {
+                "shape": (4, 3, 5),
+                "index": (slice(None), (True, True, False), ..., (0, 1)),
+                "name": "empty ellipsis separation with 1-dim boolean masks",
+            },
+            # TODO(manuelcandales) Fix issue #71673 and enable this case
+            # {
+            #     "shape": (1, 2, 2, 4, 5),
+            #     "index": (slice(None), ((True, False), (True, True)), (0, 1, 2), ..., (0,)),
+            #     "name": "empty ellipsis separation with 2-dim boolean masks",
+            # },
+        ]
+        self._test_cases(cases, "Ellipsis and advanced indexing separation")
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/_numpy/_ndarray.py
+++ b/torch/_numpy/_ndarray.py
@@ -244,12 +244,12 @@ def _numpy_empty_ellipsis_patch(index, tensor_ndim):
             ellipsis_pos = i
             break
 
-    maybe_sequeeze = lambda x: x
+    maybe_squeeze = lambda x: x
     maybe_unsqueeze = lambda x: x
 
     # If no ellipsis, no patch needed
     if ellipsis_pos is None:
-        return index, maybe_sequeeze, maybe_unsqueeze
+        return index, maybe_squeeze, maybe_unsqueeze
 
     # Count non-ellipsis dimensions consumed by the index
     consumed_dims = 0
@@ -278,16 +278,16 @@ def _numpy_empty_ellipsis_patch(index, tensor_ndim):
             end_ndims = 1 + sum(
                 1 for idx in index[ellipsis_pos + 1 :] if isinstance(idx, slice)
             )
-            maybe_sequeeze = lambda x: x.squeeze(-end_ndims)
+            maybe_squeeze = lambda x: x.squeeze(-end_ndims)
 
             def maybe_unsqueeze(x):
                 if isinstance(x, torch.Tensor) and x.ndim >= end_ndims:
                     return x.unsqueeze(-end_ndims)
                 return x
 
-            return new_index, maybe_sequeeze, maybe_unsqueeze
+            return new_index, maybe_squeeze, maybe_unsqueeze
 
-    return index, maybe_sequeeze, maybe_unsqueeze
+    return index, maybe_squeeze, maybe_unsqueeze
 
 
 # Used to indicate that a parameter is unspecified (as opposed to explicitly


### PR DESCRIPTION
Fixes #141563 

In NumPy, an ellipsis always acts as a separator between advanced indices, even when the ellipsis doesn't actually match any dimensions. In PyTorch an empty ellipsis doesn't cause a separation. This leads to differing behavior between Numpy and PyTorch in this edge case.

This difference in behavior leads to a bug when using torch.compile:
```python
>>> import numpy as np
>>> f = lambda x: x[:,(0,1),...,(0,1)].shape
>>> a = np.ones((3, 4, 5))
>>> f(a)
(2, 3)
>>> torch.compile(f)(a)
(3, 2)
```

Similarly to #157676, this PR doesn't change PyTorch's behavior, but it fixes the translation layer, ensuring torch._numpy compatibility with NumPy. I am marking this PR as fixing #141563, even though PyTorch behavior isn't modified.

Notice that there are still some other bugs in PyTorch's advanced indexing, that need to be fixed (mainly regarding proper accounting of dimensions when multidimensional boolean masks are present). But those need to be fixed at the ATen operator level. Examples:
- #71673
- #107699 
- #158125

cc @mruberry @rgommers