### PR TITLE
[BE] Remove CUDA 11.8 artifacts

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -367,14 +367,8 @@ def _load_global_deps() -> None:
             "nccl": "libnccl.so.*[0-9]",
             "nvtx": "libnvToolsExt.so.*[0-9]",
             "nvshmem": "libnvshmem_host.so.*[0-9]",
+            "cufile": "libcufile.so.*[0-9]",
         }
-        # cufiile is only available on cuda 12+
-        # TODO: Remove once CUDA 11.8 binaries are deprecated
-        if cuda_version is not None:
-            t_version = cuda_version.split(".")
-            t_major = int(t_version[0])  # type: ignore[operator]
-            if t_major >= 12:
-                cuda_libs["cufile"] = "libcufile.so.*[0-9]"
 
         is_cuda_lib_err = [
             lib for lib in cuda_libs.values() if lib.split(".")[0] in err.args[0]


### PR DESCRIPTION
We are including cufile by default in all CUDA 12+ builds. Since CUDA 11.8 is removed we can safely remove this code
