### PR TITLE
Deprecate DataLoader pin_memory_device param

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -3133,6 +3133,13 @@ class TestDictDataLoader(TestCase):
             self.assertTrue(sample["a_tensor"].is_pinned())
             self.assertTrue(sample["another_dict"]["a_number"].is_pinned())
 
+    @unittest.skipIf(TEST_CUDA, "Test for when CUDA is not available")
+    def test_pin_memory_no_cuda(self):
+        loader = DataLoader(self.dataset, batch_size=2, pin_memory=True)
+        for sample in loader:
+            self.assertFalse(sample["a_tensor"].is_pinned())
+            self.assertFalse(sample["another_dict"]["a_number"].is_pinned())
+
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_pin_memory_device(self):
         loader = DataLoader(

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -36,6 +36,7 @@ from torch.testing._internal.common_utils import (
     skipIfXpu,
     slowTest,
     TEST_CUDA,
+    TEST_MPS,
     TEST_NUMPY,
     TEST_WITH_ASAN,
     TEST_WITH_ROCM,
@@ -3145,6 +3146,15 @@ class TestDictDataLoader(TestCase):
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_pin_memory_with_only_device(self):
         loader = DataLoader(self.dataset, batch_size=2, pin_memory_device="cuda")
+        for sample in loader:
+            self.assertFalse(sample["a_tensor"].is_pinned())
+            self.assertFalse(sample["another_dict"]["a_number"].is_pinned())
+
+    @unittest.skipIf(not TEST_MPS, "MPS unavailable")
+    def test_pin_memory_skip_mps(self):
+        loader = DataLoader(
+            self.dataset, batch_size=2, pin_memory=True, pin_memory_device="mps"
+        )
         for sample in loader:
             self.assertFalse(sample["a_tensor"].is_pinned())
             self.assertFalse(sample["another_dict"]["a_number"].is_pinned())

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -36,7 +36,6 @@ from torch.testing._internal.common_utils import (
     skipIfXpu,
     slowTest,
     TEST_CUDA,
-    TEST_MPS,
     TEST_NUMPY,
     TEST_WITH_ASAN,
     TEST_WITH_ROCM,
@@ -3146,15 +3145,6 @@ class TestDictDataLoader(TestCase):
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_pin_memory_with_only_device(self):
         loader = DataLoader(self.dataset, batch_size=2, pin_memory_device="cuda")
-        for sample in loader:
-            self.assertFalse(sample["a_tensor"].is_pinned())
-            self.assertFalse(sample["another_dict"]["a_number"].is_pinned())
-
-    @unittest.skipIf(not TEST_MPS, "MPS unavailable")
-    def test_pin_memory_skip_mps(self):
-        loader = DataLoader(
-            self.dataset, batch_size=2, pin_memory=True, pin_memory_device="mps"
-        )
         for sample in loader:
             self.assertFalse(sample["a_tensor"].is_pinned())
             self.assertFalse(sample["another_dict"]["a_number"].is_pinned())

--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -33,9 +33,8 @@ def _pin_memory_loop(in_queue, out_queue, device_id, done_event, device):
             try:
                 data = pin_memory(data, device)
             except Exception:
-                current_device_index = torch.accelerator.current_device_index()
                 data = ExceptionWrapper(
-                    where=f"in pin memory thread for device {current_device_index}"
+                    where=f"in pin memory thread for device {device_id}"
                 )
             r = (idx, data)
         while not done_event.is_set():

--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -15,12 +15,13 @@ from torch._utils import ExceptionWrapper
 from . import MP_STATUS_CHECK_INTERVAL
 
 
-def _pin_memory_loop(in_queue, out_queue, done_event, device):
+def _pin_memory_loop(in_queue, out_queue, device_id, done_event, device):
     # This setting is thread local, and prevents the copy in pin_memory from
     # consuming all CPU cores.
     torch.set_num_threads(1)
 
     torch.multiprocessing._set_thread_name("pt_data_pin")
+    torch.accelerator.set_device_index(device_id)
 
     def do_one_step():
         try:

--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -21,7 +21,6 @@ def _pin_memory_loop(in_queue, out_queue, done_event, device):
     torch.set_num_threads(1)
 
     torch.multiprocessing._set_thread_name("pt_data_pin")
-    current_device_index = torch.accelerator.current_device_index()
 
     def do_one_step():
         try:
@@ -33,6 +32,7 @@ def _pin_memory_loop(in_queue, out_queue, done_event, device):
             try:
                 data = pin_memory(data, device)
             except Exception:
+                current_device_index = torch.accelerator.current_device_index()
                 data = ExceptionWrapper(
                     where=f"in pin memory thread for device {current_device_index}"
                 )

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -1175,13 +1175,11 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
 
             # Queue is not type-annotated
             self._data_queue = queue.Queue()  # type: ignore[var-annotated]
-            current_device_index = torch.accelerator.current_device_index()
             pin_memory_thread = threading.Thread(
                 target=_utils.pin_memory._pin_memory_loop,
                 args=(
                     self._worker_result_queue,
                     self._data_queue,
-                    current_device_index,
                     self._pin_memory_thread_done_event,
                     self._pin_memory_device,
                 ),

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -190,9 +190,8 @@ class DataLoader(Generic[_T_co]):
         persistent_workers (bool, optional): If ``True``, the data loader will not shut down
             the worker processes after a dataset has been consumed once. This allows to
             maintain the workers `Dataset` instances alive. (default: ``False``)
-        pin_memory_device (str, optional): the device to :attr:`pin_memory` on if ``pin_memory`` is
-            ``True``. If not given, the current :ref:`accelerator<accelerators>` will be the
-            default. This argument is discouraged and subject to deprecated.
+        pin_memory_device (str, optional): Deprecated, the current :ref:`accelerator<accelerators>`
+            will be used as the device if ``pin_memory=True``.
         in_order (bool, optional): If ``False``, the data loader will not enforce that batches
             are returned in a first-in, first-out order. Only applies when ``num_workers > 0``. (default: ``True``)
 
@@ -234,7 +233,7 @@ class DataLoader(Generic[_T_co]):
     drop_last: bool
     timeout: float
     sampler: Union[Sampler, Iterable]
-    pin_memory_device: str
+    pin_memory_device: Optional[str]
     prefetch_factor: Optional[int]
     _iterator: Optional[_BaseDataLoaderIter]
     __initialized = False
@@ -287,8 +286,37 @@ class DataLoader(Generic[_T_co]):
         self.dataset = dataset
         self.num_workers = num_workers
         self.prefetch_factor = prefetch_factor
-        self.pin_memory = pin_memory
-        self.pin_memory_device = pin_memory_device
+
+        if pin_memory and pin_memory_device:
+            warnings.warn(
+                "pin_memory_device is deprecated, the current accelerator will be used as the device,"
+                f"ignore pin_memory_device='{pin_memory_device}'."
+            )
+
+        self.pin_memory = pin_memory and torch.accelerator.is_available()
+        self.pin_memory_device = (
+            acc.type
+            if self.pin_memory
+            and (acc := torch.accelerator.current_accelerator()) is not None
+            else None
+        )
+
+        # Currently, pin_memory would raise error on the MPS backend (see
+        # https://github.com/pytorch/pytorch/issues/86060), so forcibly
+        # disable pin_memory on MPS. Remove this restriction once pinned
+        # memory allocation for MPS is fixed.
+        if (
+            self.pin_memory
+            and (acc := torch.accelerator.current_accelerator()) is not None
+            and acc.type == "mps"
+        ):
+            self._pin_memory = False
+            warn_msg = (
+                "'pin_memory' argument is set as true but not supported on MPS now, "
+                "then device pinned memory won't be used."
+            )
+            warnings.warn(warn_msg)
+
         self.timeout = timeout
         self.worker_init_fn = worker_init_fn
         self.multiprocessing_context = multiprocessing_context
@@ -654,45 +682,8 @@ class _BaseDataLoaderIter:
         ws, rank = _get_distributed_settings()
         self._world_size = ws
         self._rank = rank
-        # If pin_memory_device not set, default behaviour is current accelerator.
-        # If pin_memory_device is set but pin_memory is not set, the default
-        # behaviour false.
-        if len(loader.pin_memory_device) == 0:
-            if loader.pin_memory and not torch.accelerator.is_available():
-                warn_msg = (
-                    "'pin_memory' argument is set as true but no accelerator is found, "
-                    "then device pinned memory won't be used."
-                )
-                warnings.warn(warn_msg)
-
-            self._pin_memory = loader.pin_memory and torch.accelerator.is_available()
-            self._pin_memory_device = None
-            # Currently, pin_memory would raise error on the MPS backend (see
-            # https://github.com/pytorch/pytorch/issues/86060), so forcibly
-            # disable pin_memory on MPS. Remove this restriction once pinned
-            # memory allocation for MPS is fixed.
-            if (
-                self._pin_memory
-                and (acc := torch.accelerator.current_accelerator()) is not None
-                and acc.type == "mps"
-            ):
-                self._pin_memory = False
-                warn_msg = (
-                    "'pin_memory' argument is set as true but not supported on MPS now, "
-                    "then device pinned memory won't be used."
-                )
-                warnings.warn(warn_msg)
-        else:
-            if not loader.pin_memory:
-                warn_msg = (
-                    "'pin_memory_device' is set but 'pin_memory' argument is not set, "
-                    "then device pinned memory won't be used."
-                    "please set 'pin_memory' to true, if you need to use the device pin memory"
-                )
-                warnings.warn(warn_msg)
-
-            self._pin_memory = loader.pin_memory
-            self._pin_memory_device = loader.pin_memory_device
+        self._pin_memory = loader.pin_memory
+        self._pin_memory_device = loader.pin_memory_device
         self._timeout = loader.timeout
         self._collate_fn = loader.collate_fn
         self._sampler_iter = iter(self._index_sampler)
@@ -1178,24 +1169,13 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
 
             # Queue is not type-annotated
             self._data_queue = queue.Queue()  # type: ignore[var-annotated]
-            current_device = -1
-            if self._pin_memory_device == "cuda":
-                current_device = torch.cuda.current_device()
-            elif self._pin_memory_device == "xpu":
-                current_device = torch.xpu.current_device()
-            elif self._pin_memory_device == torch._C._get_privateuse1_backend_name():
-                custom_device_mod = getattr(
-                    torch, torch._C._get_privateuse1_backend_name()
-                )
-                current_device = custom_device_mod.current_device()
-            elif self._pin_memory_device is None:
-                current_device = torch.accelerator.current_device_index()
+            current_device_index = torch.accelerator.current_device_index()
             pin_memory_thread = threading.Thread(
                 target=_utils.pin_memory._pin_memory_loop,
                 args=(
                     self._worker_result_queue,
                     self._data_queue,
-                    current_device,
+                    current_device_index,
                     self._pin_memory_thread_done_event,
                     self._pin_memory_device,
                 ),

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -1175,11 +1175,13 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
 
             # Queue is not type-annotated
             self._data_queue = queue.Queue()  # type: ignore[var-annotated]
+            current_device = torch.accelerator.current_device_index()
             pin_memory_thread = threading.Thread(
                 target=_utils.pin_memory._pin_memory_loop,
                 args=(
                     self._worker_result_queue,
                     self._data_queue,
+                    current_device,
                     self._pin_memory_thread_done_event,
                     self._pin_memory_device,
                 ),

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -312,9 +312,8 @@ class DataLoader(Generic[_T_co]):
         # disable pin_memory on MPS. Remove this restriction once pinned
         # memory allocation for MPS is fixed.
         if (
-            self.pin_memory
-            and (acc := torch.accelerator.current_accelerator()) is not None
-            and acc.type == "mps"
+            self.pin_memory_device is not None 
+            and self.pin_memory_device == "mps"
         ):
             self._pin_memory = False
             warn_msg = (

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -292,6 +292,12 @@ class DataLoader(Generic[_T_co]):
                 "pin_memory_device is deprecated, the current accelerator will be used as the device,"
                 f"ignore pin_memory_device='{pin_memory_device}'."
             )
+        if pin_memory and not torch.accelerator.is_available():
+            warn_msg = (
+                "'pin_memory' argument is set as true but no accelerator is found, "
+                "then device pinned memory won't be used."
+            )
+            warnings.warn(warn_msg)
 
         self.pin_memory = pin_memory and torch.accelerator.is_available()
         self.pin_memory_device = (

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -16,6 +16,7 @@ import queue
 import threading
 import warnings
 from typing import Any, Callable, Generic, Optional, TYPE_CHECKING, TypeVar, Union
+from typing_extensions import Self
 
 import torch
 import torch.distributed as dist
@@ -35,7 +36,6 @@ from torch.utils.data.sampler import (
     Sampler,
     SequentialSampler,
 )
-from typing_extensions import Self
 
 
 if TYPE_CHECKING:

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -16,7 +16,6 @@ import queue
 import threading
 import warnings
 from typing import Any, Callable, Generic, Optional, TYPE_CHECKING, TypeVar, Union
-from typing_extensions import Self
 
 import torch
 import torch.distributed as dist
@@ -36,6 +35,7 @@ from torch.utils.data.sampler import (
     Sampler,
     SequentialSampler,
 )
+from typing_extensions import Self
 
 
 if TYPE_CHECKING:
@@ -303,9 +303,11 @@ class DataLoader(Generic[_T_co]):
         self.pin_memory_device = (
             acc.type
             if self.pin_memory
+            and torch.accelerator.is_available()
             and (acc := torch.accelerator.current_accelerator()) is not None
             else ""
         )
+        print("self.pin_memory_device = ", self.pin_memory_device)
 
         # Currently, pin_memory would raise error on the MPS backend (see
         # https://github.com/pytorch/pytorch/issues/86060), so forcibly

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -312,7 +312,7 @@ class DataLoader(Generic[_T_co]):
         # disable pin_memory on MPS. Remove this restriction once pinned
         # memory allocation for MPS is fixed.
         if self.pin_memory_device == "mps":
-            self._pin_memory = False
+            self.pin_memory = False
             warn_msg = (
                 "'pin_memory' argument is set as true but not supported on MPS now, "
                 "then device pinned memory won't be used."

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -1175,13 +1175,13 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
 
             # Queue is not type-annotated
             self._data_queue = queue.Queue()  # type: ignore[var-annotated]
-            current_device = torch.accelerator.current_device_index()
+            current_device_id = torch.accelerator.current_device_index()
             pin_memory_thread = threading.Thread(
                 target=_utils.pin_memory._pin_memory_loop,
                 args=(
                     self._worker_result_queue,
                     self._data_queue,
-                    current_device,
+                    current_device_id,
                     self._pin_memory_thread_done_event,
                     self._pin_memory_device,
                 ),


### PR DESCRIPTION
Build on top of https://github.com/pytorch/pytorch/pull/146821

- Moves enabling pin_memory back inside `_BaseDataLoaderIter`
  - This is required for `StatefulDataloader` which leveraged  `_BaseDataLoaderIter` directly and not the `Dataloader` class init
- Add a simple test for CPU only env where setting `pin_memory=True` is a no-op.