### PR TITLE
Filter out local timer tests which are unimplemented in Python on AArch64

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1551,6 +1551,7 @@ test_linux_aarch64() {
   python test/run_test.py --include test_modules test_mkldnn test_mkldnn_fusion test_openmp test_torch test_dynamic_shapes \
         test_transformers test_multiprocessing test_numpy_interop test_autograd test_binary_ufuncs test_complex test_spectral_ops \
         test_foreach test_reductions test_unary_ufuncs test_tensor_creation_ops test_ops \
+        distributed/elastic/timer/api_test distributed/elastic/timer/local_timer_example distributed/elastic/timer/local_timer_test \
         --shard "$SHARD_NUMBER" "$NUM_TEST_SHARDS" --verbose
 
   # Dynamo tests

--- a/test/distributed/elastic/timer/file_based_local_timer_test.py
+++ b/test/distributed/elastic/timer/file_based_local_timer_test.py
@@ -15,6 +15,7 @@ import uuid
 
 import torch.distributed.elastic.timer as timer
 from torch.testing._internal.common_utils import (
+    IS_ARM64,
     IS_MACOS,
     IS_WINDOWS,
     run_tests,
@@ -23,8 +24,8 @@ from torch.testing._internal.common_utils import (
 )
 
 
-# timer is not supported on windows or macos
-if not (IS_WINDOWS or IS_MACOS):
+# timer is not supported on these platforms
+if not (IS_WINDOWS or IS_MACOS or IS_ARM64):
     # func2 should time out
     def func2(n, file_path):
         if file_path is not None:

--- a/test/distributed/elastic/timer/local_timer_example.py
+++ b/test/distributed/elastic/timer/local_timer_example.py
@@ -14,6 +14,7 @@ import time
 import torch.distributed.elastic.timer as timer
 import torch.multiprocessing as torch_mp
 from torch.testing._internal.common_utils import (
+    IS_ARM64,
     IS_MACOS,
     IS_WINDOWS,
     run_tests,
@@ -40,8 +41,8 @@ def _stuck_function(rank, mp_queue):
         time.sleep(5)
 
 
-# timer is not supported on macos or windows
-if not (IS_WINDOWS or IS_MACOS):
+# timer is not supported on these platforms
+if not (IS_WINDOWS or IS_MACOS or IS_ARM64):
 
     class LocalTimerExample(TestCase):
         """

--- a/test/distributed/elastic/timer/local_timer_test.py
+++ b/test/distributed/elastic/timer/local_timer_test.py
@@ -15,6 +15,7 @@ import torch.distributed.elastic.timer as timer
 from torch.distributed.elastic.timer.api import TimerRequest
 from torch.distributed.elastic.timer.local_timer import MultiprocessingRequestQueue
 from torch.testing._internal.common_utils import (
+    IS_ARM64,
     IS_MACOS,
     IS_WINDOWS,
     run_tests,
@@ -24,8 +25,10 @@ from torch.testing._internal.common_utils import (
 )
 
 
-# timer is not supported on windows or macos
-if not (IS_WINDOWS or IS_MACOS or TEST_WITH_DEV_DBG_ASAN):
+# timer is not supported on these platforms
+INVALID_PLATFORMS = IS_WINDOWS or IS_MACOS or TEST_WITH_DEV_DBG_ASAN or IS_ARM64
+
+if not INVALID_PLATFORMS:
     # func2 should time out
     def func2(n, mp_queue):
         if mp_queue is not None:
@@ -129,8 +132,7 @@ if not (IS_WINDOWS or IS_MACOS or TEST_WITH_DEV_DBG_ASAN):
             time.sleep(interval)
 
 
-# timer is not supported on windows or macos
-if not (IS_WINDOWS or IS_MACOS or TEST_WITH_DEV_DBG_ASAN):
+if not INVALID_PLATFORMS:
 
     class MultiprocessingRequestQueueTest(TestCase):
         def test_get(self):
@@ -197,8 +199,7 @@ if not (IS_WINDOWS or IS_MACOS or TEST_WITH_DEV_DBG_ASAN):
             self.assertLessEqual(n / 2, len(requests))
 
 
-# timer is not supported on windows or macos
-if not (IS_WINDOWS or IS_MACOS or TEST_WITH_DEV_DBG_ASAN):
+if not INVALID_PLATFORMS:
 
     class LocalTimerServerTest(TestCase):
         def setUp(self):


### PR DESCRIPTION
This stems from using a conda build of Python, which incorrectly detects this as unimplemented:
https://github.com/conda-forge/python-feedstock/issues/804

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci @malfet @snadampal @milpuz01 @aditew01 @nikhil-arm @fadara01 @dzhulgakov