### PR TITLE
[CUDA] Reuse blocks with record_stream during CUDA Graph capture in the CUDACachingAllocator

### DIFF
--- a/c10/cuda/CUDAAllocatorConfig.cpp
+++ b/c10/cuda/CUDAAllocatorConfig.cpp
@@ -373,6 +373,9 @@ void CUDAAllocatorConfig::parseArgs(const std::optional<std::string>& env) {
     } else if (config_item_view == "pinned_use_background_threads") {
       i = parsePinnedUseBackgroundThreads(config, i);
       used_native_specific_option = true;
+    } else if (config_item_view == "reclaim_memory_in_graph_capture") {
+      i = parseReclaimMemoryInGraphCapture(config, i);
+      used_native_specific_option = true;
     } else {
       TORCH_CHECK(
           false, "Unrecognized CachingAllocator option: ", config_item_view);
@@ -403,6 +406,15 @@ size_t CUDAAllocatorConfig::parsePinnedUseCudaHostRegister(
     TORCH_CHECK(
         false, "Error, expecting pinned_use_cuda_host_register value", "");
   }
+  return i;
+}
+
+size_t CUDAAllocatorConfig::parseReclaimMemoryInGraphCapture(
+    const c10::CachingAllocator::ConfigTokenizer& tokenizer,
+    size_t i) {
+  tokenizer.checkToken(++i, ":");
+  m_reclaim_memory_in_graph_capture = tokenizer.toBool(++i);
+
   return i;
 }
 

--- a/c10/cuda/CUDAAllocatorConfig.cpp
+++ b/c10/cuda/CUDAAllocatorConfig.cpp
@@ -373,7 +373,7 @@ void CUDAAllocatorConfig::parseArgs(const std::optional<std::string>& env) {
     } else if (config_item_view == "pinned_use_background_threads") {
       i = parsePinnedUseBackgroundThreads(config, i);
       used_native_specific_option = true;
-    } else if (config_item_view == "reclaim_memory_in_graph_capture") {
+    } else if (config_item_view == "graph_capture_record_stream_reuse") {
       i = parseReclaimMemoryInGraphCapture(config, i);
       used_native_specific_option = true;
     } else {
@@ -413,7 +413,7 @@ size_t CUDAAllocatorConfig::parseReclaimMemoryInGraphCapture(
     const c10::CachingAllocator::ConfigTokenizer& tokenizer,
     size_t i) {
   tokenizer.checkToken(++i, ":");
-  m_reclaim_memory_in_graph_capture = tokenizer.toBool(++i);
+  m_graph_capture_record_stream_reuse = tokenizer.toBool(++i);
 
   return i;
 }

--- a/c10/cuda/CUDAAllocatorConfig.h
+++ b/c10/cuda/CUDAAllocatorConfig.h
@@ -146,8 +146,8 @@ class C10_CUDA_API CUDAAllocatorConfig {
   size_t parsePinnedUseBackgroundThreads(
       const std::vector<std::string>& config,
       size_t i);
-  size_t parseReclaimMemoryInGraphCapture(
-      const c10::CachingAllocator::ConfigTokenizer& tokenizer,
+  size_t parseGraphCaptureRecordStreamReuse(
+      const std::vector<std::string>& config,
       size_t i);
 
   std::atomic<size_t> m_max_split_size;

--- a/c10/cuda/CUDAAllocatorConfig.h
+++ b/c10/cuda/CUDAAllocatorConfig.h
@@ -53,8 +53,8 @@ class C10_CUDA_API CUDAAllocatorConfig {
     return instance().m_release_lock_on_cudamalloc;
   }
 
-  static bool reclaim_memory_in_graph_capture() {
-    return instance().m_reclaim_memory_in_graph_capture;
+  static bool graph_capture_record_stream_reuse() {
+    return instance().m_graph_capture_record_stream_reuse;
   }
 
   /** Pinned memory allocator settings */
@@ -160,7 +160,7 @@ class C10_CUDA_API CUDAAllocatorConfig {
       m_expandable_segments_handle_type;
   std::atomic<bool> m_release_lock_on_cudamalloc;
   std::atomic<bool> m_pinned_use_cuda_host_register;
-  std::atomic<bool> m_reclaim_memory_in_graph_capture;
+  std::atomic<bool> m_graph_capture_record_stream_reuse;
   std::atomic<bool> m_pinned_use_background_threads;
   std::string m_last_allocator_settings;
   std::mutex m_last_allocator_settings_mutex;

--- a/c10/cuda/CUDAAllocatorConfig.h
+++ b/c10/cuda/CUDAAllocatorConfig.h
@@ -53,6 +53,10 @@ class C10_CUDA_API CUDAAllocatorConfig {
     return instance().m_release_lock_on_cudamalloc;
   }
 
+  static bool reclaim_memory_in_graph_capture() {
+    return instance().m_reclaim_memory_in_graph_capture;
+  }
+
   /** Pinned memory allocator settings */
   static bool pinned_use_cuda_host_register() {
     return instance().m_pinned_use_cuda_host_register;
@@ -142,6 +146,9 @@ class C10_CUDA_API CUDAAllocatorConfig {
   size_t parsePinnedUseBackgroundThreads(
       const std::vector<std::string>& config,
       size_t i);
+  size_t parseReclaimMemoryInGraphCapture(
+      const c10::CachingAllocator::ConfigTokenizer& tokenizer,
+      size_t i);
 
   std::atomic<size_t> m_max_split_size;
   std::atomic<size_t> m_max_non_split_rounding_size;
@@ -153,6 +160,7 @@ class C10_CUDA_API CUDAAllocatorConfig {
       m_expandable_segments_handle_type;
   std::atomic<bool> m_release_lock_on_cudamalloc;
   std::atomic<bool> m_pinned_use_cuda_host_register;
+  std::atomic<bool> m_reclaim_memory_in_graph_capture;
   std::atomic<bool> m_pinned_use_background_threads;
   std::string m_last_allocator_settings;
   std::mutex m_last_allocator_settings_mutex;

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1168,7 +1168,9 @@ class DeviceCachingAllocator {
   ska::flat_hash_set<MempoolId_t, MempoolIdHash> use_on_oom_pools;
 
   // See free() for this thing's purpose
-  std::vector<Block*> needs_events_deferred_until_no_capture;
+  // This is a list of empty nodes that are inserted during capture.
+  ska::flat_hash_map<Block*, std::vector<cudaGraphNode_t>> deferred_blocks;
+
   // outstanding cuda events
   ska::flat_hash_map<
       cuda::CUDAStream,
@@ -1329,6 +1331,10 @@ class DeviceCachingAllocator {
       //    capture. Cross-stream memory use is uncommon, so the deferral's
       //    effect on memory use during capture should be small.
       process_events(context);
+    } else {
+      if (CUDAAllocatorConfig::reclaim_memory_in_graph_capture()) {
+        capture_safe_free_blocks(context, stream);
+      }
     }
     size_t size = round_size(orig_size);
     auto& pool = get_pool(size, stream);
@@ -1619,6 +1625,116 @@ class DeviceCachingAllocator {
     return block;
   }
 
+  // An "empty node" in a CUDA graph is a no-op node, used here to represent a
+  // free event within the graph.
+  cudaGraphNode_t insert_empty_node(CUDAStream stream) {
+    cudaStreamCaptureStatus status{};
+    cudaGraph_t currently_capturing_graph{};
+    const cudaGraphNode_t* dependencies{};
+    size_t num_dependencies = 0;
+    C10_CUDA_CHECK(cudaStreamGetCaptureInfo(
+        stream,
+        &status,
+        nullptr,
+        &currently_capturing_graph,
+        &dependencies,
+        &num_dependencies));
+
+    // If the stream is not related to a capturing graph, return nullptr.
+    if (status != cudaStreamCaptureStatusActive) {
+      return nullptr;
+    }
+
+    cudaGraphNode_t new_node{};
+    C10_CUDA_CHECK(cudaGraphAddEmptyNode(
+        &new_node, currently_capturing_graph, dependencies, num_dependencies));
+
+    C10_CUDA_CHECK(cudaStreamUpdateCaptureDependencies(
+        stream, &new_node, 1, cudaStreamSetCaptureDependencies));
+
+    return new_node;
+  }
+
+  // CUDA graphs are modeled as directed acyclic graphs
+  //
+  // Definitions:
+  // - A "joined node" is any node with in-degree >= 2 (i.e., it has multiple
+  // parents).
+  // - A "joined path" is a path that leads to a joined node; equivalently, any
+  // ancestor of a joined node is on a joined path.
+  // - A "joined empty node" is an empty node that lies on at least one joined
+  // path, i.e., it can reach a joined node downstream.
+  //
+  // Note: The provided stream may not be capturing; if it is not, this function
+  // returns an empty set.
+  ska::flat_hash_set<cudaGraphNode_t> get_joined_empty_nodes(
+      cudaStream_t stream) {
+    cudaStreamCaptureStatus status{};
+    cudaGraph_t capturing_graph{};
+    const cudaGraphNode_t* dependencies = nullptr;
+    size_t num_dependencies = 0;
+
+    C10_CUDA_CHECK(cudaStreamGetCaptureInfo(
+        stream,
+        &status,
+        /*pId*/ nullptr,
+        &capturing_graph,
+        &dependencies,
+        &num_dependencies));
+
+    if (status != cudaStreamCaptureStatusActive || num_dependencies == 0) {
+      return {};
+    }
+
+    // Helper to get the parent nodes (dependencies) of a given node.
+    auto get_parents = [](cudaGraphNode_t n) {
+      size_t count = 0;
+      C10_CUDA_CHECK(cudaGraphNodeGetDependencies(
+          n, nullptr, &count)); // parents = dependencies
+      std::vector<cudaGraphNode_t> out(count);
+      if (count) {
+        C10_CUDA_CHECK(cudaGraphNodeGetDependencies(n, out.data(), &count));
+        out.resize(count);
+      }
+      return out;
+    };
+
+    // Helper to check if a node is an empty node.
+    auto is_empty_node = [](cudaGraphNode_t n) {
+      cudaGraphNodeType type{};
+      C10_CUDA_CHECK(cudaGraphNodeGetType(n, &type));
+      return type == cudaGraphNodeTypeEmpty;
+    };
+
+    ska::flat_hash_set<cudaGraphNode_t> visited;
+    ska::flat_hash_set<cudaGraphNode_t> empty_nodes_on_joined_path;
+
+    // The dependencies array contains the frontier nodes of the graph.
+    // We perform a reverse traversal from these frontiers.
+    // If we encounter a joined node (in-degree >= 2), all its ancestors are on
+    // a joined path. If we encounter an empty node on a joined path, it is a
+    // joined empty node.
+    std::function<void(cudaGraphNode_t, bool)> dfs =
+        [&](cudaGraphNode_t node, bool on_the_joined_path) {
+          if (!visited.insert(node).second)
+            return;
+          if (on_the_joined_path && is_empty_node(node)) {
+            empty_nodes_on_joined_path.insert(node);
+          }
+          auto parents = get_parents(node);
+          bool is_joined_node = parents.size() >= 2;
+          for (auto p : parents) {
+            dfs(p, on_the_joined_path || is_joined_node);
+          }
+        };
+
+    for (size_t i = 0; i < num_dependencies; ++i) {
+      dfs(dependencies[i], false);
+    }
+
+    return empty_nodes_on_joined_path;
+  }
+
   void free(Block* block) {
     std::shared_ptr<GatheredContext> context =
         maybeGatherContext(RecordContext::ALL);
@@ -1660,7 +1776,16 @@ class DeviceCachingAllocator {
         // capture. We conservatively defer recording end-of-life events until
         // the next call to process_events() (which won't happen until no
         // captures are underway)
-        needs_events_deferred_until_no_capture.push_back(block);
+        std::vector<cudaGraphNode_t> empty_nodes;
+        if (CUDAAllocatorConfig::reclaim_memory_in_graph_capture()) {
+          for (auto& stream : block->stream_uses) {
+            auto empty_node = insert_empty_node(stream);
+            if (empty_node != nullptr) {
+              empty_nodes.push_back(empty_node);
+            }
+          }
+        }
+        deferred_blocks.emplace(block, std::move(empty_nodes));
       } else {
         insert_events(block);
       }
@@ -3287,8 +3412,8 @@ class DeviceCachingAllocator {
 
   void insert_events_deferred_until_no_capture(
       const std::shared_ptr<GatheredContext>& context) {
-    if (C10_UNLIKELY(!needs_events_deferred_until_no_capture.empty())) {
-      for (auto* block : needs_events_deferred_until_no_capture) {
+    if (C10_UNLIKELY(!deferred_blocks.empty())) {
+      for (auto& [block, inserted_empty_nodes] : deferred_blocks) {
         TORCH_INTERNAL_ASSERT(!block->stream_uses.empty());
         // only streams recorded before cudagraph will be used to insert events
         // since we know all streams recorded during cudagraph must have
@@ -3300,7 +3425,54 @@ class DeviceCachingAllocator {
           free_block(block, context);
         }
       }
-      needs_events_deferred_until_no_capture.clear();
+      deferred_blocks.clear();
+    }
+  }
+
+  // A block is safe to free if all its inserted empty nodes are
+  // on a "joined path" in the graph, meaning they are guaranteed to be
+  // synchronized with all relevant graph execution. This function checks for
+  // such blocks and frees them if possible.
+  void capture_safe_free_blocks(
+      const std::shared_ptr<GatheredContext>& context,
+      cudaStream_t stream) {
+    auto joined_empty_nodes = get_joined_empty_nodes(stream);
+
+    // If the stream is not currently capturing, there are no joined empty
+    // nodes, so nothing to do.
+    if (joined_empty_nodes.empty()) {
+      return;
+    }
+
+    std::vector<Block*> blocks_to_erase;
+
+    for (auto& [block, inserted_empty_nodes] : deferred_blocks) {
+      bool all_nodes_joined = true;
+
+      // Check if all empty nodes associated with this block are on a joined
+      // path.
+      for (const auto& node : inserted_empty_nodes) {
+        if (joined_empty_nodes.find(node) == joined_empty_nodes.end()) {
+          all_nodes_joined = false;
+          break;
+        }
+      }
+
+      // If all empty nodes are joined, the block is safe to free.
+      if (all_nodes_joined) {
+        // Clear stream uses, as the graph guarantees synchronization.
+        // No need to insert events, since event queries are not allowed during
+        // capture.
+        block->stream_uses.clear();
+
+        free_block(block, context);
+        blocks_to_erase.push_back(block);
+      }
+    }
+
+    // Remove freed blocks from the deferred_blocks map.
+    for (auto* block : blocks_to_erase) {
+      deferred_blocks.erase(block);
     }
   }
 
@@ -3731,6 +3903,8 @@ class NativeCachingAllocator : public CUDAAllocator {
     md.pinned_use_host_register =
         CUDAAllocatorConfig::pinned_use_cuda_host_register();
     md.last_allocator_settings = CUDAAllocatorConfig::last_allocator_settings();
+    md.reclaim_memory_in_graph_capture =
+        CUDAAllocatorConfig::reclaim_memory_in_graph_capture();
     md.roundup_power2_divisions =
         CUDAAllocatorConfig::roundup_power2_divisions();
 

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1756,9 +1756,8 @@ class DeviceCachingAllocator {
     auto get_parents =
         [&](cudaGraphNode_t node) -> std::vector<cudaGraphNode_t> {
       size_t count = 0;
-
-      std::vector<cudaGraphNode_t> out(count);
       get_dependencies(node, nullptr, &count);
+      std::vector<cudaGraphNode_t> out(count);
       if (count) {
         get_dependencies(node, out.data(), &count);
         out.resize(count);

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -163,6 +163,7 @@ struct AllocatorConfigInfo {
   bool expandable_segments;
   bool release_lock_on_malloc;
   bool pinned_use_host_register;
+  bool reclaim_memory_in_graph_capture;
   std::string last_allocator_settings;
   std::vector<size_t> roundup_power2_divisions;
 };

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -163,7 +163,7 @@ struct AllocatorConfigInfo {
   bool expandable_segments;
   bool release_lock_on_malloc;
   bool pinned_use_host_register;
-  bool reclaim_memory_in_graph_capture;
+  bool graph_capture_record_stream_reuse;
   std::string last_allocator_settings;
   std::vector<size_t> roundup_power2_divisions;
 };

--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -608,6 +608,13 @@ Available options:
   for processing events. This avoids any slow path associated with querying/processing of
   events in the fast allocation path. This feature is disabled by default.
 
+* ``reclaim_memory_in_graph_capture`` (experimental, default: `False`)
+  If set to `True`, the CUDA caching allocator will attempt to reclaim device memory during
+  CUDA Graph capture by using the graph topology (instead of CUDA events) to determine
+  when a freed block is safe to reuse. This can reduce peak memory during long captures that free
+  and reallocate buffers across multiple streams, especially when the capture DAG frequently
+  reaches joined frontiers.
+
 .. note::
 
     Some stats reported by the

--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -608,7 +608,7 @@ Available options:
   for processing events. This avoids any slow path associated with querying/processing of
   events in the fast allocation path. This feature is disabled by default.
 
-* ``reclaim_memory_in_graph_capture`` (experimental, default: `False`)
+* ``graph_capture_record_stream_reuse`` (experimental, default: `False`)
   If set to `True`, the CUDA caching allocator will attempt to reclaim device memory during
   CUDA Graph capture by using the graph topology (instead of CUDA events) to determine
   when a freed block is safe to reuse. This can reduce peak memory during long captures that free

--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -613,7 +613,8 @@ Available options:
   CUDA Graph capture by using the graph topology (instead of CUDA events) to determine
   when a freed block is safe to reuse. This can reduce peak memory during long captures that free
   and reallocate buffers across multiple streams, especially when the capture DAG frequently
-  reaches joined frontiers.
+  reaches joined frontiers. Note: Enabling this option can significantly increase the time spent
+  capturing the graph.
 
 .. note::
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5613,7 +5613,6 @@ class TestMemPool(TestCase):
             s = p.snapshot()
             self.assertEqual(len(s), 1, "Expected to have a single segment")
 
-    @skipIfRocm(msg="graph_capture_record_stream_reuse is not supported on ROCm")
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )
@@ -5661,7 +5660,6 @@ class TestMemPool(TestCase):
             "graph_capture_record_stream_reuse:False"
         )
 
-    @skipIfRocm(msg="graph_capture_record_stream_reuse is not supported on ROCm")
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5629,7 +5629,9 @@ class TestMemPool(TestCase):
 
         with torch.cuda.stream(s1):
             g.capture_begin()
-            data1 = torch.ones(8, device="cuda")
+            unrelated = torch.rand(8, device="cuda")
+
+            data1 = torch.rand(8, device="cuda")
             data1_ptr = data1.data_ptr()
 
             s2.wait_stream(s1)
@@ -5638,102 +5640,33 @@ class TestMemPool(TestCase):
                 data1.record_stream(s2)
 
             data1.fill_(1.0)
-
-            # data1 is deleted
             del data1
             gc.collect()
 
             s1.wait_stream(s2)
 
-            # The first allocation of data2 occurs before the graph is joined.
-            # The graph will be joined after this allocation.
-            data2 = torch.ones(8, device="cuda")
-            # The second allocation of data2 happens after the graph is joined.
-            # If capture-reclaim is enabled, data2 should reuse the memory from data1.
-            data2 = torch.ones(8, device="cuda")
+            # the graph would be joined after this rand kernel
+            unrelated.fill_(1.0)
+            data2 = torch.rand(8, device="cuda")
             data2_ptr = data2.data_ptr()
 
-            g.capture_end()
-
-        torch.cuda.synchronize()
-        self.assertTrue(data1_ptr == data2_ptr)
-        torch.cuda.memory._set_allocator_settings(
-            "reclaim_memory_in_graph_capture:False"
-        )
-
-    @unittest.skipIf(
-        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
-    )
-    def test_graph_capture_reclaim_4_streams(self):
-        torch.cuda.memory._set_allocator_settings(
-            "reclaim_memory_in_graph_capture:True"
-        )
-        torch.cuda.empty_cache()
-        s1 = torch.cuda.Stream()
-        s2 = torch.cuda.Stream()
-        s3 = torch.cuda.Stream()
-        s4 = torch.cuda.Stream()
-        g = torch.cuda.CUDAGraph(keep_graph=True)
-
-        torch.cuda.synchronize()
-
-        with torch.cuda.stream(s1):
-            g.capture_begin()
-            data1 = torch.ones(8, device="cuda")
-            data2 = torch.ones(8, device="cuda")
-            data1_ptr = data1.data_ptr()
-
             s2.wait_stream(s1)
+
             with torch.cuda.stream(s2):
-                data1.fill_(2.0)
-                data1.record_stream(s2)
+                unrelated.fill_(1.0)
 
-            s3.wait_stream(s1)
-            with torch.cuda.stream(s3):
-                data1.fill_(3.0)
-                data1.record_stream(s3)
-
-            s4.wait_stream(s1)
-            with torch.cuda.stream(s4):
-                data1.fill_(4.0)
-                data1.record_stream(s4)
-
-            data1.fill_(1.0)
-
-            # data1 is deleted
-            del data1
-            gc.collect()
-
-            s1.wait_stream(s2)
-            data2.fill_(1.0)
-
-            s3.wait_stream(s4)
-            with torch.cuda.stream(s3):
-                data2.fill_(3.0)
-                data2.record_stream(s3)
-
-            # First allocation of data3 before the graph is joined.
-            data3 = torch.ones(8, device="cuda")
-            # Second allocation of data3 after the graph is joined.
-            data3 = torch.ones(8, device="cuda")
-            # data3 should not reuse memory from data1, as the freed nodes from data1 are not yet available.
-            # At this point, the graph has two terminal nodes.
+            # data3 should reuse data1 if the capture-reclaim is enabled
+            data3 = torch.rand(8, device="cuda")
             data3_ptr = data3.data_ptr()
 
-            s1.wait_stream(s3)
-
-            # First allocation of data4 before the graph is joined.
-            data4 = torch.ones(8, device="cuda")
-            # Second allocation of data4 after the graph is joined.
-            data4 = torch.ones(8, device="cuda")
-            # data4 should reuse memory from data1.
-            data4_ptr = data4.data_ptr()
+            s1.wait_stream(s2)
 
             g.capture_end()
 
         torch.cuda.synchronize()
-        self.assertTrue(data1_ptr != data3_ptr)
-        self.assertTrue(data1_ptr == data4_ptr)
+        self.assertTrue(data1_ptr != data2_ptr)
+        self.assertTrue(data1_ptr == data3_ptr)
+
         torch.cuda.memory._set_allocator_settings(
             "reclaim_memory_in_graph_capture:False"
         )

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5641,7 +5641,6 @@ class TestMemPool(TestCase):
 
             data1.fill_(1.0)
             del data1
-            gc.collect()
 
             s1.wait_stream(s2)
 
@@ -5702,7 +5701,6 @@ class TestMemPool(TestCase):
 
             data1.fill_(1.0)
             del data1
-            gc.collect()
 
             s1.wait_stream(s2)
             unrelated.fill_(1.0)

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5641,11 +5641,12 @@ class TestMemPool(TestCase):
                 data1.record_stream(s2)
 
             data1.fill_(1.0)
-            del data1; gc.collect()
+            del data1
+            gc.collect()
 
             s1.wait_stream(s2)
 
-            # the graph would be joined after this rand kernel        
+            # the graph would be joined after this kernel
             unrelated.fill_(1.0)
             # this new allocation should reuse data1 if the graph_capture_record_stream_reuse is enabled
             data2 = torch.rand(8, device="cuda")
@@ -5702,7 +5703,8 @@ class TestMemPool(TestCase):
                 data1.record_stream(s4)
 
             data1.fill_(1.0)
-            del data1; gc.collect()
+            del data1
+            gc.collect()
 
             s1.wait_stream(s2)
             unrelated.fill_(1.0)
@@ -5711,7 +5713,7 @@ class TestMemPool(TestCase):
             with torch.cuda.stream(s3):
                 unrelated.fill_(3.0)
                 unrelated.record_stream(s3)
-                
+
             unrelated.fill_(3.0)
             data2 = torch.ones(8, device="cuda")
             data2_ptr = data2.data_ptr()
@@ -5731,7 +5733,6 @@ class TestMemPool(TestCase):
         torch.cuda.memory._set_allocator_settings(
             "graph_capture_record_stream_reuse:False"
         )
-
 
     @skipIfRocm(msg="expandable_segments mode is not supported on ROCm")
     @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Load_inline doesn't work in fbcode")

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -907,7 +907,8 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* arg) {
   py::str release_lock_on_malloc_s = "release_lock_on_cudamalloc";
   py::str pinned_use_host_register_s = "pinned_use_cuda_host_register";
   py::str roundup_power2_divisions_s = "roundup_power2_divisions";
-  py::str reclaim_memory_in_graph_capture_s = "reclaim_memory_in_graph_capture";
+  py::str graph_capture_record_stream_reuse_s =
+      "graph_capture_record_stream_reuse";
 
   allocator_settings[last_allocator_settings_s] =
       snapshot.config_metadata.last_allocator_settings;
@@ -923,8 +924,8 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* arg) {
       snapshot.config_metadata.release_lock_on_malloc;
   allocator_settings[pinned_use_host_register_s] =
       snapshot.config_metadata.pinned_use_host_register;
-  allocator_settings[reclaim_memory_in_graph_capture_s] =
-      snapshot.config_metadata.reclaim_memory_in_graph_capture;
+  allocator_settings[graph_capture_record_stream_reuse_s] =
+      snapshot.config_metadata.graph_capture_record_stream_reuse;
   unsigned int roundup_key = 1;
   py::dict roundup_settings;
   for (const auto& v : snapshot.config_metadata.roundup_power2_divisions) {

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -907,6 +907,7 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* arg) {
   py::str release_lock_on_malloc_s = "release_lock_on_cudamalloc";
   py::str pinned_use_host_register_s = "pinned_use_cuda_host_register";
   py::str roundup_power2_divisions_s = "roundup_power2_divisions";
+  py::str reclaim_memory_in_graph_capture_s = "reclaim_memory_in_graph_capture";
 
   allocator_settings[last_allocator_settings_s] =
       snapshot.config_metadata.last_allocator_settings;
@@ -922,6 +923,8 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* arg) {
       snapshot.config_metadata.release_lock_on_malloc;
   allocator_settings[pinned_use_host_register_s] =
       snapshot.config_metadata.pinned_use_host_register;
+  allocator_settings[reclaim_memory_in_graph_capture_s] =
+      snapshot.config_metadata.reclaim_memory_in_graph_capture;
   unsigned int roundup_key = 1;
   py::dict roundup_settings;
   for (const auto& v : snapshot.config_metadata.roundup_power2_divisions) {

--- a/torch/csrc/cuda/memory_snapshot.cpp
+++ b/torch/csrc/cuda/memory_snapshot.cpp
@@ -458,7 +458,8 @@ std::string _memory_snapshot_pickled() {
   IValue release_lock_on_malloc_s = "release_lock_on_cudamalloc";
   IValue pinned_use_host_register_s = "pinned_use_cuda_host_register";
   IValue roundup_power2_divisions_s = "roundup_power2_divisions";
-  IValue reclaim_memory_in_graph_capture_s = "reclaim_memory_in_graph_capture";
+  IValue graph_capture_record_stream_reuse_s =
+      "graph_capture_record_stream_reuse";
 
   allocator_settings.insert(
       last_allocator_settings_s,
@@ -480,8 +481,8 @@ std::string _memory_snapshot_pickled() {
       pinned_use_host_register_s,
       snapshot.config_metadata.pinned_use_host_register);
   allocator_settings.insert(
-      reclaim_memory_in_graph_capture_s,
-      snapshot.config_metadata.reclaim_memory_in_graph_capture);
+      graph_capture_record_stream_reuse_s,
+      snapshot.config_metadata.graph_capture_record_stream_reuse);
   unsigned int roundup_key = 1;
   auto roundup_settings = new_dict();
   for (const auto& v : snapshot.config_metadata.roundup_power2_divisions) {

--- a/torch/csrc/cuda/memory_snapshot.cpp
+++ b/torch/csrc/cuda/memory_snapshot.cpp
@@ -458,6 +458,7 @@ std::string _memory_snapshot_pickled() {
   IValue release_lock_on_malloc_s = "release_lock_on_cudamalloc";
   IValue pinned_use_host_register_s = "pinned_use_cuda_host_register";
   IValue roundup_power2_divisions_s = "roundup_power2_divisions";
+  IValue reclaim_memory_in_graph_capture_s = "reclaim_memory_in_graph_capture";
 
   allocator_settings.insert(
       last_allocator_settings_s,
@@ -478,6 +479,9 @@ std::string _memory_snapshot_pickled() {
   allocator_settings.insert(
       pinned_use_host_register_s,
       snapshot.config_metadata.pinned_use_host_register);
+  allocator_settings.insert(
+      reclaim_memory_in_graph_capture_s,
+      snapshot.config_metadata.reclaim_memory_in_graph_capture);
   unsigned int roundup_key = 1;
   auto roundup_settings = new_dict();
   for (const auto& v : snapshot.config_metadata.roundup_power2_divisions) {

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -4333,6 +4333,8 @@ CUDA_IDENTIFIER_MAP = collections.OrderedDict(
         ("cudaStreamCaptureModeThreadLocal", ("hipStreamCaptureModeThreadLocal", CONV_TYPE, API_RUNTIME)),
         ("cudaStreamBeginCapture", ("hipStreamBeginCapture", CONV_TYPE, API_RUNTIME)),
         ("cudaStreamEndCapture", ("hipStreamEndCapture", CONV_TYPE, API_RUNTIME)),
+        ("cudaStreamSetCaptureDependencies", ("hipStreamSetCaptureDependencies", CONV_STREAM, API_RUNTIME)),
+        ("cudaStreamUpdateCaptureDependencies", ("hipStreamUpdateCaptureDependencies", CONV_STREAM, API_RUNTIME)),
         ("cudaGraphInstantiate", ("hipGraphInstantiate", CONV_TYPE, API_RUNTIME)),
         ("cudaGraphInstantiateWithFlags", ("hipGraphInstantiateWithFlags", CONV_TYPE, API_RUNTIME)),
         (


### PR DESCRIPTION
## Introduction

During CUDA Graph capture, the CUDA caching allocator currently defers reclaiming blocks until capture ends. This is because CUDA forbids querying events recorded during capture (the CUDA operation is not executed during the capture stage), so the allocator cannot use its normal event-based logic. However, capture records an DAG (we call it **capturing graph**) of work. We can use the capturing graph to determine when a block’s old lifetime is fully before future work, and safely reuse it within the same capture.

This PR adds an experimental flag `graph_capture_record_stream_reuse: True|False (default: False)`. When enabled, the allocator inserts lightweight free markers and uses capture ordering to decide if a freed block is safe to reuse during capture. If the proof cannot be established, we fall back to the existing post-capture path.

## Terms

* **Free marker**: A capture-legal no-op (created with `cudaGraphAddEmptyNode`) inserted after the last captured use of the block on each stream that used it. 
* **Terminal**: The set of the lastest operations of the stream (or the capturing graph). Any newly captured op on that stream will attach after all nodes in this set. For a stream currently capturing, it is the set of nodes returned in `dependencies_out` by `cudaStreamGetCaptureInfo`. 

## When can we reuse a block during capture?

### Strong Rule (Graph-Wide Safety)

This rule provides a universal guarantee that a block is safe for reuse by any stream in the graph.

> A block is safe to reuse if every free marker is a predecessor of every terminal of all active streams in the graph.

Why it's safe:

This rule establishes a strict global ordering. Since any new operation on any stream must be appended after that stream's terminals, this condition guarantees that the block's new lifetime begins only after its old lifetime has completely ended everywhere. This prevents lifetime overlaps when the graph is replayed, ensuring correctness.

### Per-stream Rule (A Practical Optimization)

The strong rule, while safe, is often unnecessarily restrictive. The `DeviceCachingAllocator` introduces a crucial constraint that allows for a simpler check.

In `DeviceCachingAllocator`, `get_free_block` only returns blocks whose `block->stream == p.stream()`. In other words, we never reuse a block on a stream different from the allocation stream. This means we don't need to verify safety across the entire graph. We only need to confirm that the block is safe to reuse from the perspective of its own allocation stream.

> Reuse a block for allocations on stream S if every free marker is a predecessor of every node in the terminal set of S.

In short, a block is considered **reusable** on stream S as long as all marker marking it "free" are guaranteed to complete before any new work that might need it on stream S begins.

## Implementation

* On `free(block)` during capture
  * For each stream in `block->stream_uses` and the allocation stream, insert a free marker (empty node) and make it that stream’s tail.
  * If we cannot place markers for all such streams (for example, a stream is not in capture), defer to the post-capture path.
  * Otherwise, store the marker handles and keep the block in the capture-private structures.
* On `allocate(stream)` during capture (attempt per-stream reclaim)
  * Query the allocation stream S’s terminal via `cudaStreamGetCaptureInfo`.
  * For each deferred block, check whether it is allocated on this stream, and each of its free markers is a predecessor of the terminal.
    * If yes, hand the block to S for immediate reuse within the same capture.
    * If no, keep it deferred; it will be reconsidered as capture progresses and S’s terminal advances.
* On capture end
  * Any still-deferred blocks follow the existing post-capture reclamation (event insertion/polling). External behavior remains unchanged if we cannot prove safety during capture.

## Examples (2 streams)

<img width="641" height="801" alt="pytorch-remove-cudagraph-defer-reclaiming (6)" src="https://github.com/user-attachments/assets/41adc835-d448-483b-99ba-b4341cb7d2a2" />

* Case 0 — Unsafe
The two frees are not ordered with respect to each other. For stream 1, the other stream’s free marker does not precede this stream’s terminal, so the per-stream condition fails.
Counterexample intuition for the unsafe setups: imagine `f2(x)` runs for a long time. If DeviceCachingAllocator reused block `x` on a stream whose terminal is not ordered after the free markers, the new lifetime could overlap the old one on replay, risking use-after-free or data corruption. The per-stream rule prevents exactly this.
* Case 1 — Reusable on stream 1
Stream 1’s terminal is after both frees, so every free marker precedes stream 1’s terminal. The block is reusable for allocations on stream 1.
* Case 2 — Not reusable on stream 2, but this cannot occur in `DeviceCachingAllocator`
This depicts reusing the block on stream 2 while stream 1’s free is not yet ordered before stream 2’s terminal. Though the block is not safe to reuse on stream 2, DeviceCachingAllocator will not choose that block for stream 2 anyway: `get_free_block` rejects blocks whose `stream != p.stream()`. So this case is unreachable.
* Case 3 — Safe (strong rule holds)
In this scenario, the terminal nodes of all streams are positioned after the block's free markers, satisfying the strong rule. This guarantees the block is safe for reuse by any stream in the capturing graph. However, since `DeviceCachingAllocator ` only reuses a block on its original allocation stream, verifying this strong condition is unnecessary. We only need to ensure the per-stream rule is met for the specific stream requesting the block.
* Case 4 — Freeing after a join  
See the note below.

## Edge Case: Freeing after a join 

Our current dependency tracking has a limitation in scenarios where a block is freed after a stream join, see @galv's [comments here](https://github.com/pytorch/pytorch/pull/158352#pullrequestreview-3112565198)).

In the case 4, we have a missed opportunity. Because the block's usage is not explicitly marked, we cannot determine that the block's actual last use may have occurred much earlier, long before the join. Then, we must wait for the subsequent join before the block can be reused.

## Thanks
Thanks to @galv for his great idea around graph parsing and empty nodes.


cc @ptrblck @msaroufim @eqy @jerryzh168 @mcarilli @ezyang @eellison @penguinwu @BoyuanFeng