### PR TITLE
Add missing <vector> in c10/util/WaitCounter.h

### DIFF
--- a/c10/util/WaitCounter.h
+++ b/c10/util/WaitCounter.h
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <memory>
 #include <string_view>
+#include <vector>
 
 #include <c10/macros/Macros.h>
 #include <c10/util/ScopeExit.h>


### PR DESCRIPTION
It seems that `#include <vector>` is being pulled in indirectly, but it is being used directly, so it is best to explicitly include it.