### PR TITLE
Add theme installation to all doc push scripts

### DIFF
--- a/.ci/pytorch/cpp_doc_push_script.sh
+++ b/.ci/pytorch/cpp_doc_push_script.sh
@@ -58,6 +58,7 @@ time python tools/setup_helpers/generate_code.py \
 
 # Build the docs
 pushd docs/cpp
+pip install -e git+https://github.com/pytorch/pytorch_sphinx_theme.git@pytorch_sphinx_theme2#egg=pytorch_sphinx_theme2
 time make VERBOSE=1 html -j
 
 popd

--- a/.ci/pytorch/functorch_doc_push_script.sh
+++ b/.ci/pytorch/functorch_doc_push_script.sh
@@ -12,6 +12,7 @@ echo "version: $version"
 
 # Build functorch docs
 pushd $pt_checkout/functorch/docs
+pip install -e git+https://github.com/pytorch/pytorch_sphinx_theme.git@pytorch_sphinx_theme2#egg=pytorch_sphinx_theme2
 make html
 popd
 

--- a/.ci/pytorch/python_doc_push_script.sh
+++ b/.ci/pytorch/python_doc_push_script.sh
@@ -46,7 +46,7 @@ echo "error: python_doc_push_script.sh: branch (arg3) not specified"
 fi
 
 echo "install_path: $install_path  version: $version"
-
+pip install -e git+https://github.com/pytorch/pytorch_sphinx_theme.git@pytorch_sphinx_theme2#egg=pytorch_sphinx_theme2
 
 build_docs () {
   set +e


### PR DESCRIPTION
This PR ensures the latest PyTorch Sphinx theme is always used when building documentation by adding the theme installation command to all doc push scripts.

The issue with having the theme only in `requirements-docs.txt` is that it's installed once when the Docker image is built, but not updated on subsequent runs. This means the theme version becomes "frozen" until `requirements-docs.txt` is modified, which is inconvenient.

By adding the `pip install` command to all doc push scripts, we ensure the latest theme is always pulled during each documentation build. We're keeping it in `requirements-docs.txt` as well to support local development environments where developers don't use the push scripts but use `make html` instead.

We should remove this when theme is stable.

cc @sekyondaMeta @AlannaBurke