### PR TITLE
[while_loop] fix constant tensor used as carried inputs

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -36,6 +36,7 @@ from torch._export.utils import (
 from torch._higher_order_ops.associative_scan import associative_scan
 from torch._higher_order_ops.hints_wrap import hints_wrapper
 from torch._higher_order_ops.scan import scan
+from torch._higher_order_ops.while_loop import while_loop
 from torch._inductor.compile_fx import split_const_gm
 from torch._subclasses import FakeTensorMode
 from torch.export import (
@@ -1772,6 +1773,40 @@ class GraphModule(torch.nn.Module):
             "The tensor attributes self.tensors\\[0\\], self.tensors\\[1\\] were assigned during export",
         ):
             export(M(), (torch.randn(2, 3),), strict=False)
+
+    @testing.expectedFailureTrainingIRToRunDecomp  # Could not guard on data-dependent expression -u0 > 16 (unhinted: -u0 > 16)
+    @testing.expectedFailureTrainingIRToRunDecompNonStrict  # Could not guard on data-dependent expression -u0 > 16 (unhinted: -u0 > 16)
+    @testing.expectedFailureRetraceability  # Could not guard on data-dependent expression -u0 > 16 (unhinted: -u0 > 16)
+    @testing.expectedFailureRetraceabilityNonStrict  # Could not guard on data-dependent expression -u0 > 16 (unhinted: -u0 > 16)
+    @torch._dynamo.config.patch(capture_scalar_outputs=True)
+    def test_while_loop_tensor_constant_idx(self):
+        def while_loop_decomp(x, y0):
+            out = torch.zeros_like(x)
+
+            def cond_fn(idx, out, y0):
+                return idx < out.size(0)
+
+            def body_fn(idx, out, y0):
+                i = idx.item()
+                torch._check_is_size(i, max=x.size(0) - 1)
+                y0 = x[i] + y0
+                out = out.clone()
+                out[i] = y0
+                return idx + 1, out, y0
+
+            cnt = torch.tensor(0)
+            _, out, _ = while_loop(cond_fn, body_fn, [cnt, out, y0])
+            return out
+
+        class TestModel(torch.nn.Module):
+            def forward(self, x, y0):
+                return while_loop_decomp(x, y0)
+
+        x, y0 = torch.randn(16, 8), torch.randn(8)
+        # exp_out = TestModel()(x, y0)
+        ep = export(TestModel(), (x, y0))
+        out = ep.module()(x, y0)
+        # self.assertEqual(exp_out, out)
 
     def test_malformed_fqn_from_source_name(self):
         # See https://github.com/pytorch/pytorch/issues/141939

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -1803,10 +1803,10 @@ class GraphModule(torch.nn.Module):
                 return while_loop_decomp(x, y0)
 
         x, y0 = torch.randn(16, 8), torch.randn(8)
-        # exp_out = TestModel()(x, y0)
+        exp_out = TestModel()(x, y0)
         ep = export(TestModel(), (x, y0))
         out = ep.module()(x, y0)
-        # self.assertEqual(exp_out, out)
+        self.assertEqual(exp_out, out)
 
     def test_malformed_fqn_from_source_name(self):
         # See https://github.com/pytorch/pytorch/issues/141939

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -1219,9 +1219,9 @@ class WhileLoopHigherOrderVariable(TorchHigherOrderOperatorVariable):
         additional_inputs_seq = additional_inputs.unpack_var_sequence(tx)
 
         with discard_graph_changes(tx):
-            # See NOTE [unspecialize int carry with unbacked symints]
             # Note: this must be run under discard graph changes.
             def unspecialize_carried_inputs(tx, carry) -> VariableTracker:
+                # See NOTE [unspecialize int carry with unbacked symints]
                 if (
                     isinstance(carry, ConstantVariable) and carry.python_type() is int
                 ) or isinstance(carry, SymNodeVariable):
@@ -1233,6 +1233,7 @@ class WhileLoopHigherOrderVariable(TorchHigherOrderOperatorVariable):
                     )
                     return SymNodeVariable.create(tx, proxy, example_value)
                 else:
+                    # See NOTE [unspecialize constant tensor carry]
                     assert isinstance(carry, TensorVariable)
                     cloned_carry = carry.clone()
                     cloned_carry.proxy.node.meta["example_value"].constant = None

--- a/torch/_higher_order_ops/while_loop.py
+++ b/torch/_higher_order_ops/while_loop.py
@@ -294,9 +294,9 @@ def while_loop_tracing(mode, cond_fn, body_fn, carried_inputs, additional_inputs
                 )
             # Note: [unspecialize constant tensor carry]
             # We need to disable constant specialization for tensor inputs that become loop carries.
-            # Here's the problem: when a user creates a constant tensor e.g. torch.zeros(), PyTorch calls aten.lift_fresh_copy
-            # to create a safe copy (avoiding aliasing issues). This creates a FakeTensor with constant=True.
-            # But when this FakeTensor becomes a loop carry variable, we have a problem:
+            # Here's the problem: when a user creates a constant tensor e.g. torch.tensor(0), PyTorch calls aten.lift_fresh_copy
+            # to create a safe copy (avoiding aliasing issues), which creates a FakeTensor with constant=True.
+            # But when this FakeTensor becomes a loop carry, we have a problem:
             # - Operations like .item() will read the constant value and bake it into the traced code
             # - This is incorrect because carry variables change between loop iterations
             # - The traced code would use the wrong constant value for all iterations


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #158381


Address second part of #158366, where torch.tensor(0), is treated as a constant tensor and its .item() gets specailized to 0 which causes a silent specialization. The fix is to unspecialize the constant carries and make them non-constant.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela