### PR TITLE
[BE] Add pre-push hook for lintrunner to the PyTorch repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,6 @@ repos:
         name: Run Lintrunner in an isolated venv before every push. The first run may be slow...
         entry: python scripts/run_lintrunner.py   # wrapper below
         language: python                          # pre‑commit manages venv for the wrapper
-        skip_install: true                        # ← prevent “pip install .”
         additional_dependencies: []               # wrapper handles lintrunner install
         always_run: true
         stages: [pre-push]                        # fire only on pre‑push

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: local
+    hooks:
+      - id: lintrunner
+        name: Run Lintrunner in an isolated venv before every push. The first run may be slow...
+        entry: python scripts/run_lintrunner.py   # wrapper below
+        language: python                          # pre‑commit manages venv for the wrapper
+        skip_install: true                        # ← prevent “pip install .”
+        additional_dependencies: []               # wrapper handles lintrunner install
+        always_run: true
+        stages: [pre-push]                        # fire only on pre‑push
+        pass_filenames: false                     # Lintrunner gets no per‑file args
+        verbose: true                             # stream output as it is produced...doesn't seem to actually work though

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,4 +10,4 @@ repos:
         always_run: true
         stages: [pre-push]                        # fire only on pre‑push
         pass_filenames: false                     # Lintrunner gets no per‑file args
-        verbose: true                             # stream output as it is produced...doesn't seem to actually work though
+        verbose: true                             # stream output as it is produced...allegedly anyways

--- a/scripts/run_lintrunner.py
+++ b/scripts/run_lintrunner.py
@@ -22,7 +22,7 @@ LINTRUNNER_TOML_PATH = REPO_ROOT / ".lintrunner.toml"
 
 # This is the path to the pre-commit-managed venv
 VENV_ROOT = Path(sys.executable).parent.parent
-# Stores the hash of .lintrunner.toml from the last time we ran `lintrunner init` 
+# Stores the hash of .lintrunner.toml from the last time we ran `lintrunner init`
 INITIALIZED_LINTRUNNER_TOML_HASH_PATH = VENV_ROOT / ".lintrunner_plugins_hash"
 
 

--- a/scripts/run_lintrunner.py
+++ b/scripts/run_lintrunner.py
@@ -32,7 +32,7 @@ def ensure_lintrunner() -> None:
         print("✅ lintrunner is already installed")
         return
     sys.exit(
-        "❌ lintrunner is required but was not found on your PATH. Please install it via `pipx install lintrunner` before running this script."
+        "❌ lintrunner is required but was not found on your PATH. Please run the `python scripts/setup_hooks.py` to install to configure lintrunner before using this script."
     )
 
 

--- a/scripts/run_lintrunner.py
+++ b/scripts/run_lintrunner.py
@@ -4,34 +4,81 @@ Pre‑push hook wrapper for Lintrunner.
 
 ✓ Skips entirely on CI (when $CI is set)
 ✓ Installs Lintrunner once (`pip install lintrunner`) if missing
-✓ Runs Lintrunner and propagates its exit status
+✓ Stores a hash of .lintrunner.toml in the venv
+✓ Re-runs `lintrunner init` if that file's hash changes
 ✓ Pure Python – works on macOS, Linux, Windows
 """
 from __future__ import annotations
+import hashlib
 import os
 import shutil
 import subprocess
 import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOML_PATH = REPO_ROOT / ".lintrunner.toml"
+
+# This is the path to the pre-commit-managed venv
+VENV_ROOT = Path(sys.executable).parent.parent
+MARKER_PATH = VENV_ROOT / ".lintrunner_plugins_hash"
 
 def ensure_lintrunner() -> None:
     """Install Lintrunner globally (user site) if not already on PATH."""
     if shutil.which("lintrunner"):
+        print("✅ lintrunner is already installed")
         return
-    print("Installing lintrunner …", file=sys.stderr)
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "--user", "--quiet", "lintrunner"])
+    print("📦 Installing lintrunner …", file=sys.stderr)
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "lintrunner"])
+
+def compute_file_hash(path: Path) -> str:
+    """Returns SHA256 hash of a file's contents."""
+    hasher = hashlib.sha256()
+    with path.open("rb") as f:
+        while chunk := f.read(8192):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+def read_stored_hash(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    try:
+        return path.read_text().strip()
+    except Exception:
+        return None
+
+def maybe_initialize_lintrunner() -> None:
+    """Runs lintrunner init if .lintrunner.toml changed since last run."""
+    if not TOML_PATH.exists():
+        print("⚠️ No .lintrunner.toml found. Skipping init.")
+        return
+
+    current_hash = compute_file_hash(TOML_PATH)
+    stored_hash = read_stored_hash(MARKER_PATH)
+
+    if current_hash == stored_hash:
+        print("✅ Lintrunner plugins already initialized and up to date.")
+        return
+
+    print("🔁 Running `lintrunner init` …", file=sys.stderr)
     subprocess.check_call(["lintrunner", "init"])
+    MARKER_PATH.write_text(current_hash)
 
 def main() -> None:
-    
-    # 1) Skip the hook entirely on CI runners
+    # 1. Skip in CI
     if os.environ.get("CI"):
+        print("⚙️ CI detected — skipping lintrunner")
         sys.exit(0)
 
-    import sys
-    print("Lintrunner is using Python:", sys.executable, file=sys.stderr)
-    
-    # 2) Ensure lintrunner is available, then run it
+    print(f"🐍 Lintrunner is using Python: {sys.executable}", file=sys.stderr)
+
+    # 2. Ensure lintrunner binary is available
     ensure_lintrunner()
+
+    # 3. Check for plugin updates and re-init if needed
+    maybe_initialize_lintrunner()
+
+    # 4. Run lintrunner and propagate its exit code
     result = subprocess.call(["lintrunner"])
     sys.exit(result)
 

--- a/scripts/run_lintrunner.py
+++ b/scripts/run_lintrunner.py
@@ -35,6 +35,21 @@ def ensure_lintrunner() -> None:
     )
 
 
+def ensure_virtual_environment() -> None:
+    """Fail if not running within a virtual environment."""
+    in_venv = (
+        os.environ.get("VIRTUAL_ENV") is not None
+        or hasattr(sys, "real_prefix")
+        or (hasattr(sys, "base_prefix") and sys.base_prefix != sys.prefix)
+    )
+
+    if not in_venv:
+        sys.exit(
+            "❌ This script must be run from within a virtual environment. "
+            "Please activate your virtual environment before running this script."
+        )
+
+
 def compute_file_hash(path: Path) -> str:
     """Returns SHA256 hash of a file's contents."""
     hasher = hashlib.sha256()
@@ -59,6 +74,9 @@ def initialize_lintrunner_if_needed() -> None:
         print("⚠️ No .lintrunner.toml found. Skipping init.")
         return
 
+    print(
+        f"INITIALIZED_LINTRUNNER_TOML_HASH_PATH = {INITIALIZED_LINTRUNNER_TOML_HASH_PATH}"
+    )
     current_hash = compute_file_hash(LINTRUNNER_TOML_PATH)
     stored_hash = read_stored_hash(INITIALIZED_LINTRUNNER_TOML_HASH_PATH)
 
@@ -72,7 +90,9 @@ def initialize_lintrunner_if_needed() -> None:
 
 
 def main() -> None:
-    print(f"🐍 Lintrunner is using Python: {sys.executable}", file=sys.stderr)
+    # 0. Ensure we're running in a virtual environment
+    ensure_virtual_environment()
+    print(f"🐍 Virtual env being used: {VENV_ROOT}", file=sys.stderr)
 
     # 1. Ensure lintrunner binary is available
     ensure_lintrunner()

--- a/scripts/run_lintrunner.py
+++ b/scripts/run_lintrunner.py
@@ -32,7 +32,9 @@ def ensure_lintrunner() -> None:
     if shutil.which("lintrunner"):
         print("✅ lintrunner is already installed")
         return
-    sys.exit("❌ lintrunner is required but was not found on your PATH. Please install it via `pipx install lintrunner` before running this script.")
+    sys.exit(
+        "❌ lintrunner is required but was not found on your PATH. Please install it via `pipx install lintrunner` before running this script."
+    )
 
 
 def compute_file_hash(path: Path) -> str:

--- a/scripts/run_lintrunner.py
+++ b/scripts/run_lintrunner.py
@@ -8,7 +8,9 @@ Pre‑push hook wrapper for Lintrunner.
 ✓ Re-runs `lintrunner init` if that file's hash changes
 ✓ Pure Python – works on macOS, Linux, Windows
 """
+
 from __future__ import annotations
+
 import hashlib
 import os
 import shutil
@@ -16,12 +18,14 @@ import subprocess
 import sys
 from pathlib import Path
 
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 TOML_PATH = REPO_ROOT / ".lintrunner.toml"
 
 # This is the path to the pre-commit-managed venv
 VENV_ROOT = Path(sys.executable).parent.parent
 MARKER_PATH = VENV_ROOT / ".lintrunner_plugins_hash"
+
 
 def ensure_lintrunner() -> None:
     """Install Lintrunner globally (user site) if not already on PATH."""
@@ -31,6 +35,7 @@ def ensure_lintrunner() -> None:
     print("📦 Installing lintrunner …", file=sys.stderr)
     subprocess.check_call([sys.executable, "-m", "pip", "install", "lintrunner"])
 
+
 def compute_file_hash(path: Path) -> str:
     """Returns SHA256 hash of a file's contents."""
     hasher = hashlib.sha256()
@@ -39,6 +44,7 @@ def compute_file_hash(path: Path) -> str:
             hasher.update(chunk)
     return hasher.hexdigest()
 
+
 def read_stored_hash(path: Path) -> str | None:
     if not path.exists():
         return None
@@ -46,6 +52,7 @@ def read_stored_hash(path: Path) -> str | None:
         return path.read_text().strip()
     except Exception:
         return None
+
 
 def maybe_initialize_lintrunner() -> None:
     """Runs lintrunner init if .lintrunner.toml changed since last run."""
@@ -64,6 +71,7 @@ def maybe_initialize_lintrunner() -> None:
     subprocess.check_call(["lintrunner", "init"])
     MARKER_PATH.write_text(current_hash)
 
+
 def main() -> None:
     # 1. Skip in CI
     if os.environ.get("CI"):
@@ -78,9 +86,11 @@ def main() -> None:
     # 3. Check for plugin updates and re-init if needed
     maybe_initialize_lintrunner()
 
-    # 4. Run lintrunner and propagate its exit code
-    result = subprocess.call(["lintrunner"])
+    # 4. Run lintrunner with any passed arguments and propagate its exit code
+    args = sys.argv[1:]  # Forward all arguments to lintrunner
+    result = subprocess.call(["lintrunner"] + args)
     sys.exit(result)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/run_lintrunner.py
+++ b/scripts/run_lintrunner.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""
+Pre‑push hook wrapper for Lintrunner.
+
+✓ Skips entirely on CI (when $CI is set)
+✓ Installs Lintrunner once (`pip install lintrunner`) if missing
+✓ Runs Lintrunner and propagates its exit status
+✓ Pure Python – works on macOS, Linux, Windows
+"""
+from __future__ import annotations
+import os
+import shutil
+import subprocess
+import sys
+
+def ensure_lintrunner() -> None:
+    """Install Lintrunner globally (user site) if not already on PATH."""
+    if shutil.which("lintrunner"):
+        return
+    print("Installing lintrunner …", file=sys.stderr)
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "--user", "--quiet", "lintrunner"])
+    subprocess.check_call(["lintrunner", "init"])
+
+def main() -> None:
+    
+    # 1) Skip the hook entirely on CI runners
+    if os.environ.get("CI"):
+        sys.exit(0)
+
+    import sys
+    print("Lintrunner is using Python:", sys.executable, file=sys.stderr)
+    
+    # 2) Ensure lintrunner is available, then run it
+    ensure_lintrunner()
+    result = subprocess.call(["lintrunner"])
+    sys.exit(result)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_lintrunner.py
+++ b/scripts/run_lintrunner.py
@@ -4,7 +4,6 @@ Pre‑push hook wrapper for Lintrunner.
 
 ✓ Stores a hash of .lintrunner.toml in the venv
 ✓ Re-runs `lintrunner init` if that file's hash changes
-✓ Pure Python – works on macOS, Linux, and Windows
 """
 
 from __future__ import annotations

--- a/scripts/run_lintrunner.py
+++ b/scripts/run_lintrunner.py
@@ -28,12 +28,11 @@ MARKER_PATH = VENV_ROOT / ".lintrunner_plugins_hash"
 
 
 def ensure_lintrunner() -> None:
-    """Install Lintrunner globally (user site) if not already on PATH."""
+    """Fail if Lintrunner is not on PATH."""
     if shutil.which("lintrunner"):
         print("✅ lintrunner is already installed")
         return
-    print("📦 Installing lintrunner …", file=sys.stderr)
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "lintrunner"])
+    sys.exit("❌ lintrunner is required but was not found on your PATH. Please install it via `pipx install lintrunner` before running this script.")
 
 
 def compute_file_hash(path: Path) -> str:

--- a/scripts/run_lintrunner.py
+++ b/scripts/run_lintrunner.py
@@ -2,7 +2,6 @@
 """
 Pre‑push hook wrapper for Lintrunner.
 
-✓ Skips entirely on CI (when $CI is set)
 ✓ Installs Lintrunner once (`pip install lintrunner`) if missing
 ✓ Stores a hash of .lintrunner.toml in the venv
 ✓ Re-runs `lintrunner init` if that file's hash changes
@@ -74,20 +73,15 @@ def maybe_initialize_lintrunner() -> None:
 
 
 def main() -> None:
-    # 1. Skip in CI
-    if os.environ.get("CI"):
-        print("⚙️ CI detected — skipping lintrunner")
-        sys.exit(0)
-
     print(f"🐍 Lintrunner is using Python: {sys.executable}", file=sys.stderr)
 
-    # 2. Ensure lintrunner binary is available
+    # 1. Ensure lintrunner binary is available
     ensure_lintrunner()
 
-    # 3. Check for plugin updates and re-init if needed
+    # 2. Check for plugin updates and re-init if needed
     maybe_initialize_lintrunner()
 
-    # 4. Run lintrunner with any passed arguments and propagate its exit code
+    # 3. Run lintrunner with any passed arguments and propagate its exit code
     args = sys.argv[1:]  # Forward all arguments to lintrunner
     result = subprocess.call(["lintrunner"] + args)
     sys.exit(result)

--- a/scripts/run_lintrunner.py
+++ b/scripts/run_lintrunner.py
@@ -6,7 +6,7 @@ Pre‑push hook wrapper for Lintrunner.
 ✓ Installs Lintrunner once (`pip install lintrunner`) if missing
 ✓ Stores a hash of .lintrunner.toml in the venv
 ✓ Re-runs `lintrunner init` if that file's hash changes
-✓ Pure Python – works on macOS, Linux, Windows
+✓ Pure Python – works on macOS, Linux, and Windows
 """
 
 from __future__ import annotations

--- a/scripts/setup_hooks.py
+++ b/scripts/setup_hooks.py
@@ -37,7 +37,6 @@ def which(cmd: str) -> bool:
 def ensure_pipx() -> None:
     if which("pipx"):
         return
-
     # If we're on a mac
     if sys.platform == "darwin":
         # Try Homebrew installation
@@ -58,24 +57,29 @@ def ensure_pipx() -> None:
             "    Install pipx first (https://pipx.pypa.io/stable/installation/),\n"
             "    then rerun  python scripts/setup_hooks.py\n"
         )
-
     if not which("pipx"):
         sys.exit(
             "\n❌  pipx installation appeared to succeed, but it's still not on PATH.\n"
             "    Restart your terminal or add pipx's bin directory to PATH and retry.\n"
         )
 
+def ensure_tool_installed(tool: str, force_update: bool = True) -> None:
+    if force_update or not which(tool):
+        print(f"Ensuring latest {tool} via pipx …")
+        run(["pipx", "install", "--quiet", "--force", tool])
+        if not which(tool):
+            sys.exit(
+                f"\n❌  {tool} installation appeared to succeed, but it's still not on PATH.\n"
+                "    Restart your terminal or add pipx's bin directory to PATH and retry.\n"
+            )
 
 ensure_pipx()
 
-# ───────────────────────────────────────────
-# 2. Install or upgrade pre‑commit via pipx (one line)
-# ───────────────────────────────────────────
-# pipx results in a globally installed pre-commit tool that
-# can be run from any virtual env
-print("Ensuring latest pre‑commit via pipx …")
-run(["pipx", "install", "--quiet", "--force", "pre-commit"])
-
+# Ensure pre-commit is installed globally via pipx
+ensure_tool_installed("pre-commit", force_update=True)
+# Don't force a lintrunner update b/c it might break folks
+# who already have it installed in a different way 
+ensure_tool_installed("lintrunner") 
 
 # ───────────────────────────────────────────
 # 3. Activate (or refresh) the pre‑push hook

--- a/scripts/setup_hooks.py
+++ b/scripts/setup_hooks.py
@@ -64,14 +64,20 @@ def ensure_pipx() -> None:
         )
 
 
-def ensure_tool_installed(tool: str, force_update: bool = False) -> None:
+def ensure_tool_installed(tool: str, force_update: bool = False) -> bool:
+    """
+    Checks to see if the tool is available and if not (or if force update requested) then
+    it reinstalls it.
+
+    Returns: Whether or not the tool is available on PATH.  If it's not, a new terminal 
+    needs to be opened before git pushes work as expected.
+    """
     if force_update or not which(tool):
         print(f"Ensuring latest {tool} via pipx …")
         run(["pipx", "install", "--quiet", "--force", tool])
         if not which(tool):
-            sys.exit(
-                f"\n❌  {tool} installation appeared to succeed, but it's still not on PATH.\n"
-                "    Restart your terminal or add pipx's bin directory to PATH and retry.\n"
+            print(
+                f"\n⚠️  {tool} installation succeed, but it's not on PATH. Remember to a new terminal.\n"
             )
 
 
@@ -102,10 +108,9 @@ ensure_tool_installed("lintrunner")
 run(["pre-commit", "install", "--hook-type", "pre-push", "--allow-missing-config"])
 
 # ── Pin remote‑hook versions for reproducibility ────────────────────────────
+# (Note: we don't have remote hooks right now, but it future-proofs this script)
 # 1. `autoupdate` bumps every remote hook’s `rev:` in .pre-commit-config.yaml
 #    to the latest commit on its default branch.
-#    (Note: we don't have remote hooks right now, but this future-proofs
-#    this script)
 # 2. `--freeze` immediately rewrites each `rev:` to the exact commit SHA,
 #    ensuring all contributors and CI run identical hook code.
 run(["pre-commit", "autoupdate", "--freeze"])

--- a/scripts/setup_hooks.py
+++ b/scripts/setup_hooks.py
@@ -64,7 +64,7 @@ def ensure_pipx() -> None:
         )
 
 
-def ensure_tool_installed(tool: str, force_update: bool = True) -> None:
+def ensure_tool_installed(tool: str, force_update: bool = False) -> None:
     if force_update or not which(tool):
         print(f"Ensuring latest {tool} via pipx …")
         run(["pipx", "install", "--quiet", "--force", tool])
@@ -85,7 +85,7 @@ run(["pipx", "ensurepath"])
 
 # Ensure pre-commit is installed globally via pipx
 ensure_tool_installed("pre-commit", force_update=True)
-# Don't force a lintrunner update b/c it might break folks
+# Don't force a lintrunner update because it might break folks
 # who already have it installed in a different way
 ensure_tool_installed("lintrunner")
 

--- a/scripts/setup_hooks.py
+++ b/scripts/setup_hooks.py
@@ -95,8 +95,11 @@ ensure_tool_installed("lintrunner")
 # ── Activate (or refresh) the repo’s pre‑push hook ──────────────────────────
 # Creates/overwrites .git/hooks/pre‑push with a tiny shim that will call
 # `pre-commit run --hook-stage pre-push` on every `git push`.
-# This is why we need to install pre-commit globally
-run(["pre-commit", "install", "--hook-type", "pre-push"])
+# This is why we need to install pre-commit globally.
+#
+# The --allow-missing-config flag lets pre-commit succeed if someone changes to 
+# a branch that doesn't have pre-commit installed
+run(["pre-commit", "install", "--hook-type", "pre-push", "--allow-missing-config"])
 
 # ── Pin remote‑hook versions for reproducibility ────────────────────────────
 # 1. `autoupdate` bumps every remote hook’s `rev:` in .pre-commit-config.yaml

--- a/scripts/setup_hooks.py
+++ b/scripts/setup_hooks.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Bootstrap Git pre‑push hook.
+
+✓ Installs pipx automatically (via Homebrew on macOS)
+✓ Installs/updates pre‑commit with pipx  (global, venv‑proof)
+✓ Registers the repo's pre‑push hook and freezes hook versions
+
+Run this from the repo root (inside or outside any project venv):
+
+    python scripts/setup_hooks.py
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+# ───────────────────────────────────────────
+# Helper utilities
+# ───────────────────────────────────────────
+def run(cmd: list[str]) -> None:
+    print(f"$ {' '.join(cmd)}")
+    subprocess.check_call(cmd)
+
+
+def which(cmd: str) -> bool:
+    return shutil.which(cmd) is not None
+
+
+# ───────────────────────────────────────────
+# 1. Ensure pipx exists (install via brew on macOS)
+# ───────────────────────────────────────────
+def ensure_pipx() -> None:
+    if which("pipx"):
+        return
+
+    # If we're on a mac
+    if sys.platform == "darwin":
+        # Try Homebrew installation
+        if which("brew"):
+            print("pipx not found – installing with Homebrew …")
+            run(["brew", "install", "pipx"])
+            run(["pipx", "ensurepath"])
+        else:
+            sys.exit(
+                "\n❌  pipx is required but neither pipx nor Homebrew were found.\n"
+                "    Please install Homebrew (https://brew.sh) or pipx manually:\n"
+                "    https://pipx.pypa.io/stable/installation/\n"
+            )
+    else:
+        # Non‑macOS: ask user to install pipx manually
+        sys.exit(
+            "\n❌  pipx is required but was not found on your PATH.\n"
+            "    Install pipx first (https://pipx.pypa.io/stable/installation/),\n"
+            "    then rerun  python scripts/setup_hooks.py\n"
+        )
+
+    if not which("pipx"):
+        sys.exit(
+            "\n❌  pipx installation appeared to succeed, but it's still not on PATH.\n"
+            "    Restart your terminal or add pipx's bin directory to PATH and retry.\n"
+        )
+
+
+ensure_pipx()
+
+# ───────────────────────────────────────────
+# 2. Install or upgrade pre‑commit via pipx (one line)
+# ───────────────────────────────────────────
+# pipx results in a globally installed pre-commit tool that
+# can be run from any virtual env
+print("Ensuring latest pre‑commit via pipx …")
+run(["pipx", "install", "--quiet", "--force", "pre-commit"])
+
+
+# ───────────────────────────────────────────
+# 3. Activate (or refresh) the pre‑push hook
+# ───────────────────────────────────────────
+# ── Activate (or refresh) the repo’s pre‑push hook ──────────────────────────
+# Creates/overwrites .git/hooks/pre‑push with a tiny shim that will call
+# `pre-commit run --hook-stage pre-push` on every `git push`.
+# This is why we need to install pre-commit globally
+run(["pre-commit", "install", "--hook-type", "pre-push"])
+
+# ── Pin remote‑hook versions for reproducibility ────────────────────────────
+# 1. `autoupdate` bumps every remote hook’s `rev:` in .pre-commit-config.yaml
+#    to the latest commit on its default branch.
+#    (Note: we don't have remote hooks right now, but this future-proofs
+#    this script)
+# 2. `--freeze` immediately rewrites each `rev:` to the exact commit SHA,
+#    ensuring all contributors and CI run identical hook code.
+run(["pre-commit", "autoupdate", "--freeze"])
+
+
+print(
+    "\n✅  pre‑commit is installed globally via pipx and the pre‑push hook is active.\n"
+    "   Lintrunner will now run automatically on every `git push`.\n"
+)

--- a/scripts/setup_hooks.py
+++ b/scripts/setup_hooks.py
@@ -77,7 +77,7 @@ def ensure_tool_installed(tool: str, force_update: bool = True) -> None:
 
 ensure_pipx()
 
-# Ensure the path pipx installs binaies to is part of the system path.
+# Ensure the path pipx installs binaries to is part of the system path.
 # Modifies the shell's configuration files (like ~/.bashrc, ~/.zshrc, etc.)
 #  to include the directory where pipx installs executables in your PATH
 #  variable.

--- a/scripts/setup_hooks.py
+++ b/scripts/setup_hooks.py
@@ -81,6 +81,12 @@ def ensure_tool_installed(tool: str, force_update: bool = False) -> None:
             )
 
 
+if sys.platform.startswith("win"):
+    print(
+        "\n⚠️  Lintrunner is not supported on Windows, so there are no pre-push hooks to add. Exiting setup.\n"
+    )
+    sys.exit(0)
+
 ensure_pipx()
 
 # Ensure the path pipx installs binaries to is part of the system path.

--- a/scripts/setup_hooks.py
+++ b/scripts/setup_hooks.py
@@ -13,7 +13,6 @@ Run this from the repo root (inside or outside any project venv):
 
 from __future__ import annotations
 
-import os
 import shutil
 import subprocess
 import sys

--- a/scripts/setup_hooks.py
+++ b/scripts/setup_hooks.py
@@ -77,6 +77,12 @@ def ensure_tool_installed(tool: str, force_update: bool = True) -> None:
 
 ensure_pipx()
 
+# Ensure the path pipx installs binaies to is part of the system path.
+# Modifies the shell's configuration files (like ~/.bashrc, ~/.zshrc, etc.)
+#  to include the directory where pipx installs executables in your PATH
+#  variable.
+run(["pipx", "ensurepath"])
+
 # Ensure pre-commit is installed globally via pipx
 ensure_tool_installed("pre-commit", force_update=True)
 # Don't force a lintrunner update b/c it might break folks

--- a/scripts/setup_hooks.py
+++ b/scripts/setup_hooks.py
@@ -63,6 +63,7 @@ def ensure_pipx() -> None:
             "    Restart your terminal or add pipx's bin directory to PATH and retry.\n"
         )
 
+
 def ensure_tool_installed(tool: str, force_update: bool = True) -> None:
     if force_update or not which(tool):
         print(f"Ensuring latest {tool} via pipx …")
@@ -73,13 +74,14 @@ def ensure_tool_installed(tool: str, force_update: bool = True) -> None:
                 "    Restart your terminal or add pipx's bin directory to PATH and retry.\n"
             )
 
+
 ensure_pipx()
 
 # Ensure pre-commit is installed globally via pipx
 ensure_tool_installed("pre-commit", force_update=True)
 # Don't force a lintrunner update b/c it might break folks
-# who already have it installed in a different way 
-ensure_tool_installed("lintrunner") 
+# who already have it installed in a different way
+ensure_tool_installed("lintrunner")
 
 # ───────────────────────────────────────────
 # 3. Activate (or refresh) the pre‑push hook

--- a/scripts/setup_hooks.py
+++ b/scripts/setup_hooks.py
@@ -69,7 +69,7 @@ def ensure_tool_installed(tool: str, force_update: bool = False) -> None:
     Checks to see if the tool is available and if not (or if force update requested) then
     it reinstalls it.
 
-    Returns: Whether or not the tool is available on PATH.  If it's not, a new terminal 
+    Returns: Whether or not the tool is available on PATH.  If it's not, a new terminal
     needs to be opened before git pushes work as expected.
     """
     if force_update or not which(tool):
@@ -88,7 +88,7 @@ ensure_pipx()
 #  to include the directory where pipx installs executables in your PATH
 #  variable.
 # Note that further down we run pre-commit through pipx because the path
-#  this command adds may not be in the current shell's PATH.  
+#  this command adds may not be in the current shell's PATH.
 run(["pipx", "ensurepath"])
 
 # Ensure pre-commit is installed globally via pipx
@@ -108,7 +108,17 @@ ensure_tool_installed("lintrunner")
 #
 # The --allow-missing-config flag lets pre-commit succeed if someone changes to
 # a branch that doesn't have pre-commit installed
-run(["pipx", "run", "pre-commit", "install", "--hook-type", "pre-push", "--allow-missing-config"])
+run(
+    [
+        "pipx",
+        "run",
+        "pre-commit",
+        "install",
+        "--hook-type",
+        "pre-push",
+        "--allow-missing-config",
+    ]
+)
 
 # ── Pin remote‑hook versions for reproducibility ────────────────────────────
 # (Note: we don't have remote hooks right now, but it future-proofs this script)

--- a/scripts/setup_hooks.py
+++ b/scripts/setup_hooks.py
@@ -64,7 +64,7 @@ def ensure_pipx() -> None:
         )
 
 
-def ensure_tool_installed(tool: str, force_update: bool = False) -> bool:
+def ensure_tool_installed(tool: str, force_update: bool = False) -> None:
     """
     Checks to see if the tool is available and if not (or if force update requested) then
     it reinstalls it.
@@ -77,7 +77,7 @@ def ensure_tool_installed(tool: str, force_update: bool = False) -> bool:
         run(["pipx", "install", "--quiet", "--force", tool])
         if not which(tool):
             print(
-                f"\n⚠️  {tool} installation succeed, but it's not on PATH. Remember to a new terminal.\n"
+                f"\n⚠️  {tool} installation succeed, but it's not on PATH. Launch a new terminal if your git pushes don't work.\n"
             )
 
 
@@ -87,6 +87,8 @@ ensure_pipx()
 # Modifies the shell's configuration files (like ~/.bashrc, ~/.zshrc, etc.)
 #  to include the directory where pipx installs executables in your PATH
 #  variable.
+# Note that further down we run pre-commit through pipx because the path
+#  this command adds may not be in the current shell's PATH.  
 run(["pipx", "ensurepath"])
 
 # Ensure pre-commit is installed globally via pipx
@@ -98,6 +100,7 @@ ensure_tool_installed("lintrunner")
 # ───────────────────────────────────────────
 # 3. Activate (or refresh) the pre‑push hook
 # ───────────────────────────────────────────
+
 # ── Activate (or refresh) the repo’s pre‑push hook ──────────────────────────
 # Creates/overwrites .git/hooks/pre‑push with a tiny shim that will call
 # `pre-commit run --hook-stage pre-push` on every `git push`.
@@ -105,7 +108,7 @@ ensure_tool_installed("lintrunner")
 #
 # The --allow-missing-config flag lets pre-commit succeed if someone changes to
 # a branch that doesn't have pre-commit installed
-run(["pre-commit", "install", "--hook-type", "pre-push", "--allow-missing-config"])
+run(["pipx", "run", "pre-commit", "install", "--hook-type", "pre-push", "--allow-missing-config"])
 
 # ── Pin remote‑hook versions for reproducibility ────────────────────────────
 # (Note: we don't have remote hooks right now, but it future-proofs this script)
@@ -113,7 +116,7 @@ run(["pre-commit", "install", "--hook-type", "pre-push", "--allow-missing-config
 #    to the latest commit on its default branch.
 # 2. `--freeze` immediately rewrites each `rev:` to the exact commit SHA,
 #    ensuring all contributors and CI run identical hook code.
-run(["pre-commit", "autoupdate", "--freeze"])
+run(["pipx", "run", "pre-commit", "autoupdate", "--freeze"])
 
 
 print(

--- a/scripts/setup_hooks.py
+++ b/scripts/setup_hooks.py
@@ -97,7 +97,7 @@ ensure_tool_installed("lintrunner")
 # `pre-commit run --hook-stage pre-push` on every `git push`.
 # This is why we need to install pre-commit globally.
 #
-# The --allow-missing-config flag lets pre-commit succeed if someone changes to 
+# The --allow-missing-config flag lets pre-commit succeed if someone changes to
 # a branch that doesn't have pre-commit installed
 run(["pre-commit", "install", "--hook-type", "pre-push", "--allow-missing-config"])
 


### PR DESCRIPTION
Adds a pre-commit hook (technically a pre-push hook) to the PyTorch repo.  
**This is currently an opt-in feature**, which one can opt into by running `python scripts/setup_hooks.py` locally.

### Features
- **Run Lintrunner Before Push**: Before every `git push`, automatically runs lintrunner on your changes.  
  - Really need to skip the checks? Run `git push --no-verify`
- **Consistent, Isolated, Lintrunner Environment**: During pre-push, Lintrunner runs in it's own virtual en environment that contain all lintrunner dependencies in a consistent, isolated environment.  No more lintrunner failures because you created a new .venv. (Did you know you needed to run `lintrunner init` every time you make a new .venv?)
- **Dependencies Automatically Updated**: If .lintrunner.toml is updated, this will automatically re-run `lintrunner init` to ensure you install the latest dependencies specified

### Installation
- Run `python scripts/setup_hooks.py`. Now every `git push` will first run lintrunner.

### Additional details
- The lintrunner used by the pre-push hook runs in a special per-repo virtual environment managed by the commit-hook tool located under `$USER/.cache/pre-commit`
- Does not affect your regularly used lintrunner
  - Manual invocations of lintrunner will continue to depend on your local environment instead of the special pre-push one. If there's enough interest, we could explore consolidating them.
- Does not run `lintrunner -a` for you.
  - You still need to manually run that (can be changed later though!)
- Have staged/unstaged changes? No worries
  - This runs `git stash` before running the pre-commit hooks and pops back your changes afterwards, so only the changes actaully being pushed will be tested

### Downsides
- No streaming UI updates
  - While you still get the same output from lintrunner that you're used to, the commit-hook framework doesn't show any output while lintrunner is actually running. Instead, it shows the entire output after linter has completed execution, which could be a few minutes (especially if it has to run `lintrunner init` first)
- `uv` installation is required to run the setup script. The setup script will ask users to install uv if it's not available. 
  - This is required to be able to install the pre-commit package in a safe way that's available no matter what .venv you are running in.

### Opting out
- Disable hook for a single push: Run `git push --no-verify`
- Disable hook permanently: If something goes wrong and you need to wipe your setup:
  - Delete the `$USER/.cache/pre-commit` folder and the `.git/hooks/pre-push` file in your local repo.
  - You can now rerun `python scripts/setup_hooks.py` to setup your git push hook again if you want.

### Potential Future Changes
Things that could be done to make this even better if folks like these ideas:
- Automatic setup
  - Our `CONTRIBUTING.md` file tells devs to run `make setup-env`.  That could be a good entry point to hook the installation into
- Fix the console output streaming
- Make every lintrunner invocation (including manual ones) use the same repo-specific venv that the commit-hook uses.  