### PR TITLE
symint inputs with cond

### DIFF
--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -8331,9 +8331,6 @@ class GraphModule(torch.nn.Module):
 """,  # noqa: B950
         )
 
-    # unbacked symint inputs are created during non-strict export,
-    # which causes a graph break
-    @unittest.expectedFailure
     def test_cond_unbacked_symint_closure(self):
         from torch.export import Dim
 

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1124,17 +1124,23 @@ class VariableBuilder:
                     # We need to create an unbacked symint to replace the unbacked symbool.
                     new_symint = self.tx.output.shape_env.create_unbacked_symint()
                 else:
+                    assert isinstance(value, torch.SymInt)
+                    new_symint = self.tx.output.shape_env.create_unbacked_symint()
+                    self.tx.output.shape_env.var_to_range[new_symint.node.expr] = (
+                        value.node.shape_env.var_to_range[value.node.expr]
+                    )
+
                     # TODO (yidi): we need to figure out a way to propagate the guards
                     # we accumulated when tracing the subggraph to outer shape_env. For normal symints,
                     # this is automatically done by evaluating the guards once but this
                     # will cause data-dependent error when we evaluate the outer unbacked symints.
                     # The test case that triggers this graph break is test_cond_unbacked_symint_closure
-                    unimplemented_v2(
-                        gb_type="Attempted to wrap unbacked SymInt",
-                        context="",
-                        explanation="Unbacked SymInt input is not supported yet.",
-                        hints=[*graph_break_hints.SUPPORTABLE],
-                    )
+                    # unimplemented_v2(
+                    #     gb_type="Attempted to wrap unbacked SymInt",
+                    #     context="",
+                    #     explanation="Unbacked SymInt input is not supported yet.",
+                    #     hints=[*graph_break_hints.SUPPORTABLE],
+                    # )
 
             sym_node_proxy = self.tx.output.root_tracer.create_graph_input(
                 re.sub(r"[^a-zA-Z0-9]+", "_", self.name),

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -2257,13 +2257,15 @@ class GraphModuleDeserializer(metaclass=Final):
             # shape env to accommodate unbacked symbols in the exported program
             self.unbacked_symbols = set()
             count_unbacked_symfloat, count_unbacked_symint = -1, -1
-            unbacked_symfloat_prefix, unbacked_symint_prefix = (
+            unbacked_prefixes = tuple(
                 prefix_str[t] for t in [SymT.UNBACKED_FLOAT, SymT.UNBACKED_INT]
             )
+            unbacked_symfloat_prefix, unbacked_symint_prefix = unbacked_prefixes
             if symbol_name_to_range:
                 for k, vr in symbol_name_to_range.items():
                     lower = vr.lower
-                    if vr.upper >= 2:  # max is >= 2, not sym bool range
+                    # max is >= 2, not sym bool range and not unbacked sym int/float
+                    if vr.upper >= 2 and k.startswith(unbacked_prefixes):
                         lower = max(2, lower)
                     self.symbol_name_to_range[k] = symbolic_shapes.ValueRanges(
                         _int_to_sympy_int(lower, -int_oo), vr.upper

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -901,6 +901,14 @@ def _name_hoo_subgraph_placeholders(gm: torch.fx.GraphModule) -> None:
             if i < len(hoo_phs):  # placeholder, retain name
                 name_map[node.name] = hoo_phs[i].name
                 node.name = node.target = hoo_phs[i].name
+                # placeholder: retaining names might be OK long term but currently
+                # there's a bug where HOO operands might duplicate closed variables;
+                # therefore need to check for collisions, because placeholders with
+                # duplicates will error at run time
+
+                # node.name = node.target = _rename_without_collisions(
+                #     name_map, node.name, hoo_phs[i].name, is_placeholder=True
+                # )
             else:  # non-placeholder, check for collisions
                 node.name = _rename_without_collisions(name_map, node.name, node.name)
 

--- a/torch/fx/passes/runtime_assert.py
+++ b/torch/fx/passes/runtime_assert.py
@@ -339,8 +339,8 @@ def insert_deferred_runtime_asserts(
             ):
                 if (
                     node.args[0] == True  # noqa: E712
-                    or (assert_expr := _get_sym_val(node.args[0])) in expr_to_proxy
-                    and assert_expr in added_asserts
+                    or (assert_expr := _get_sym_val(node.args[0])) == True  # noqa: E712
+                    or (assert_expr in expr_to_proxy and assert_expr in added_asserts)
                 ):
                     arg = node.args[0]
                     gm.graph.erase_node(node)


### PR DESCRIPTION
Summary:
Before we embark on implementing symint attributes—which would at some point turn them into inputs and interact with cond—this PR adds some tests to see what happens when symint inputs interact with cond.

The tests expose some bugs / limitations around this interaction which the PR fixes.

Test Plan:
added tests

Rollback Plan:

Differential Revision: D78376355


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames