### PR TITLE
Add framework for explanations for common CUDA errors

### DIFF
--- a/c10/cuda/CUDAException.cpp
+++ b/c10/cuda/CUDAException.cpp
@@ -28,8 +28,9 @@ void c10_cuda_check_implementation(
   std::string check_message;
 #ifndef STRIP_ERROR_MESSAGES
   check_message.append("CUDA error: ");
-  check_message.append(cudaGetErrorString(cuda_error));
-  check_message.append(c10::cuda::get_cuda_check_suffix());
+  const char* error_string = cudaGetErrorString(cuda_error);
+  check_message.append(error_string);
+  check_message.append(c10::cuda::get_cuda_check_suffix(error_string));
   check_message.append("\n");
   if (include_device_assertions) {
     check_message.append(c10_retrieve_device_side_assertion_info());

--- a/c10/cuda/CUDAMiscFunctions.cpp
+++ b/c10/cuda/CUDAMiscFunctions.cpp
@@ -8,7 +8,7 @@ namespace c10::cuda {
 
 // NOLINTNEXTLINE(bugprone-exception-escape,-warnings-as-errors)
 std::string get_cuda_check_suffix(const char* error_string) noexcept {
-  std::string suffix = "";
+  std::string suffix;
 
   // Explain common CUDA errors
   if (strstr(error_string, "invalid device ordinal")) {

--- a/c10/cuda/CUDAMiscFunctions.cpp
+++ b/c10/cuda/CUDAMiscFunctions.cpp
@@ -1,21 +1,31 @@
 #include <c10/cuda/CUDAMiscFunctions.h>
 #include <c10/util/env.h>
+#include <cstring>
+#include <iostream>
+#include <string>
 
 namespace c10::cuda {
 
 // NOLINTNEXTLINE(bugprone-exception-escape,-warnings-as-errors)
-const char* get_cuda_check_suffix() noexcept {
+std::string get_cuda_check_suffix(const char* error_string) noexcept {
+  std::string suffix = "";
+
+  // Explain common CUDA errors
+  if (strstr(error_string, "invalid device ordinal")) {
+    suffix.append("\nGPU device may be out of range, do you have enough GPUs?");
+  }
+
   static auto device_blocking_flag =
       c10::utils::check_env("CUDA_LAUNCH_BLOCKING");
   static bool blocking_enabled =
       (device_blocking_flag.has_value() && device_blocking_flag.value());
-  if (blocking_enabled) {
-    return "";
-  } else {
-    return "\nCUDA kernel errors might be asynchronously reported at some"
-           " other API call, so the stacktrace below might be incorrect."
-           "\nFor debugging consider passing CUDA_LAUNCH_BLOCKING=1";
+  if (!blocking_enabled) {
+    suffix.append(
+        "\nCUDA kernel errors might be asynchronously reported at some"
+        " other API call, so the stacktrace below might be incorrect."
+        "\nFor debugging consider passing CUDA_LAUNCH_BLOCKING=1");
   }
+  return suffix;
 }
 std::mutex* getFreeMutex() {
   static std::mutex cuda_free_mutex;

--- a/c10/cuda/CUDAMiscFunctions.h
+++ b/c10/cuda/CUDAMiscFunctions.h
@@ -5,8 +5,9 @@
 #include <c10/cuda/CUDAMacros.h>
 
 #include <mutex>
+#include <string>
 
 namespace c10::cuda {
-C10_CUDA_API const char* get_cuda_check_suffix() noexcept;
+C10_CUDA_API std::string get_cuda_check_suffix(const char*) noexcept;
 C10_CUDA_API std::mutex* getFreeMutex();
 } // namespace c10::cuda


### PR DESCRIPTION
As popularly requested in user groups.

Test plan:
```
import torch

a = torch.randn(10000)
device = torch.device('cuda:1')
a = a.to(device)
```

Before:
```
Traceback (most recent call last):
  File "/data/users/raymo/pytorch/test/cuda.py", line 6, in <module>
    a = a.to(device)
        ^^^^^^^^^^^^
torch.AcceleratorError: CUDA error: invalid device ordinal
CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1
Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
```

After:
```
Traceback (most recent call last):
  File "/data/users/raymo/pytorch/test/cuda.py", line 6, in <module>
    a = a.to(device)
        ^^^^^^^^^^^^
torch.AcceleratorError: CUDA error: invalid device ordinal
GPU device may be out of range, do you have enough GPUs?
CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1
Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
```

cc @ptrblck @msaroufim @eqy @jerryzh168