### PR TITLE
[BE]Clean up old APIs in AOTI c shim

### DIFF
--- a/torch/csrc/inductor/aoti_torch/c/macros.h
+++ b/torch/csrc/inductor/aoti_torch/c/macros.h
@@ -1,0 +1,63 @@
+#ifndef AOTI_TORCH_MACRO_H
+#define AOTI_TORCH_MACRO_H
+
+#include <stddef.h>
+#include <stdint.h>
+#ifdef __GNUC__
+#define AOTI_TORCH_EXPORT __attribute__((__visibility__("default")))
+#else // !__GNUC__
+#ifdef _WIN32
+// PyTorch2 doesn't currently work on Windows. Exporting these APIs can lead
+// to symbol clashes at link time if libtorch is included in a DLL and binary
+// that depends on the DLL. As a short term fix, we don't export the symbols.
+// In the long term, this will need to be addressed when Windows is supported.
+#ifdef OVRSOURCE
+// Do not export AOTI on Windows for internal builds
+#define AOTI_TORCH_EXPORT
+#else /* OVRSOURCE */
+#ifdef EXPORT_AOTI_FUNCTIONS
+#define AOTI_TORCH_EXPORT __declspec(dllexport)
+#else
+#define AOTI_TORCH_EXPORT __declspec(dllimport)
+#endif
+#endif /* OVRSOURCE */
+#else // !_WIN32
+#define AOTI_TORCH_EXPORT
+#endif // _WIN32
+#endif // __GNUC__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+// AtenTensorHandle represents an abstract notion of Tensor that can be passed
+// between model.so and libtorch.so.  The contents of the structure itself
+// are private; model.so is not allowed to access any fields directly, it must
+// go through functions defined in this ABI.  Under the hood, this is
+// represented as at::Tensor*, but we reserve the right to change this (and in
+// fact, we probably should change it to at::TensorImpl* at least).
+//
+// An AtenTensorHandle can be owning (please check the API reference for exact
+// ownership/borrow semantics).  If you have an owning AtenTensorHandle
+// in model.so, you are obligated to aoti_torch_delete_tensor_object when you
+// are done.  You can use the helper C++ class RAIIAtenTensorHandle
+// (see aot_runtime/model.h) to ensure the deallocator is called in RAII style
+// (note that RAIIAtenTensorHandle is private to model.so, and never crosses
+// the ABI boundary.)
+struct AtenTensorOpaque;
+using AtenTensorHandle = AtenTensorOpaque*;
+
+struct AtenGeneratorOpaque;
+using AtenGeneratorHandle = AtenGeneratorOpaque*;
+
+struct AOTIProxyExecutorOpaque;
+using AOTIProxyExecutorHandle = AOTIProxyExecutorOpaque*;
+
+using AOTITorchError = int32_t;
+#define AOTI_TORCH_SUCCESS 0
+#define AOTI_TORCH_FAILURE 1
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // AOTI_TORCH_MACRO_H

--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -1,8 +1,8 @@
 #ifndef AOTI_TORCH_SHIM
 #define AOTI_TORCH_SHIM
 
-#include <stddef.h>
-#include <stdint.h>
+#include <torch/csrc/inductor/aoti_torch/c/macros.h>
+#include <torch/csrc/inductor/aoti_torch/c/shim_deprecated.h>
 
 // This header defines a stable C API for certain ATen functionality in
 // libtorch. The AOTInductor compiled model.so will only refer to this header
@@ -36,29 +36,6 @@
 // maintain the old and new versions of the APIs until all old model.so
 // go out of use.
 
-#ifdef __GNUC__
-#define AOTI_TORCH_EXPORT __attribute__((__visibility__("default")))
-#else // !__GNUC__
-#ifdef _WIN32
-// PyTorch2 doesn't currently work on Windows. Exporting these APIs can lead
-// to symbol clashes at link time if libtorch is included in a DLL and binary
-// that depends on the DLL. As a short term fix, we don't export the symbols.
-// In the long term, this will need to be addressed when Windows is supported.
-#ifdef OVRSOURCE
-// Do not export AOTI on Windows for internal builds
-#define AOTI_TORCH_EXPORT
-#else /* OVRSOURCE */
-#ifdef EXPORT_AOTI_FUNCTIONS
-#define AOTI_TORCH_EXPORT __declspec(dllexport)
-#else
-#define AOTI_TORCH_EXPORT __declspec(dllimport)
-#endif
-#endif /* OVRSOURCE */
-#else // !_WIN32
-#define AOTI_TORCH_EXPORT
-#endif // _WIN32
-#endif // __GNUC__
-
 // The following files are implemented in a header-only way and are guarded by
 // test/cpp/aoti_abi_check
 #include <c10/util/BFloat16.h>
@@ -68,33 +45,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-// AtenTensorHandle represents an abstract notion of Tensor that can be passed
-// between model.so and libtorch.so.  The contents of the structure itself
-// are private; model.so is not allowed to access any fields directly, it must
-// go through functions defined in this ABI.  Under the hood, this is
-// represented as at::Tensor*, but we reserve the right to change this (and in
-// fact, we probably should change it to at::TensorImpl* at least).
-//
-// An AtenTensorHandle can be owning (please check the API reference for exact
-// ownership/borrow semantics).  If you have an owning AtenTensorHandle
-// in model.so, you are obligated to aoti_torch_delete_tensor_object when you
-// are done.  You can use the helper C++ class RAIIAtenTensorHandle
-// (see aot_runtime/model.h) to ensure the deallocator is called in RAII style
-// (note that RAIIAtenTensorHandle is private to model.so, and never crosses
-// the ABI boundary.)
-struct AtenTensorOpaque;
-using AtenTensorHandle = AtenTensorOpaque*;
-
-struct AtenGeneratorOpaque;
-using AtenGeneratorHandle = AtenGeneratorOpaque*;
-
-struct AOTIProxyExecutorOpaque;
-using AOTIProxyExecutorHandle = AOTIProxyExecutorOpaque*;
-
-using AOTITorchError = int32_t;
-#define AOTI_TORCH_SUCCESS 0
-#define AOTI_TORCH_FAILURE 1
 
 // Getter functions for retrieving various constants from the runtime, that
 // can subsequently be passed to other aoti_* functions.  By hiding these
@@ -349,127 +299,6 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_create_tensor_from_blob_v2(
     const uint8_t* opaque_metadata,
     int64_t opaque_metadata_size);
 
-AOTI_TORCH_EXPORT AOTITorchError aoti_torch__embedding_bag(
-    AtenTensorHandle weight,
-    AtenTensorHandle indices,
-    AtenTensorHandle offsets,
-    int32_t scale_grad_by_freq,
-    int32_t mode,
-    int32_t sparse,
-    AtenTensorHandle per_sample_weights, // optional argument
-    int32_t include_last_offset,
-    int32_t padding_idx,
-    AtenTensorHandle* ret0, // returns new reference
-    AtenTensorHandle* ret1, // returns new reference
-    AtenTensorHandle* ret2, // returns new reference
-    AtenTensorHandle* ret3 // returns new reference
-);
-
-AOTI_TORCH_EXPORT AOTITorchError aoti_torch__fft_c2c(
-    AtenTensorHandle self,
-    const int64_t* dim_ptr,
-    int64_t dim_size,
-    int64_t normalization,
-    int32_t forward,
-    AtenTensorHandle* ret // returns new reference
-);
-
-// This version is deprecated. We will remove it later
-AOTI_TORCH_EXPORT AOTITorchError aoti_torch__scaled_dot_product_flash_attention(
-    AtenTensorHandle query,
-    AtenTensorHandle key,
-    AtenTensorHandle value,
-    double dropout_p,
-    bool is_causal,
-    bool return_debug_mask,
-    double scale,
-    AtenTensorHandle* ret0, // returns new reference
-    AtenTensorHandle* ret1, // returns new reference
-    AtenTensorHandle* ret2, // returns new reference
-    AtenTensorHandle* ret3, // returns new reference
-    int64_t* ret4,
-    int64_t* ret5,
-    AtenTensorHandle* ret6, // returns new reference
-    AtenTensorHandle* ret7, // returns new reference
-    AtenTensorHandle* ret8 // returns new reference
-);
-
-AOTI_TORCH_EXPORT AOTITorchError
-aoti_torch__scaled_dot_product_flash_attention_v2(
-    AtenTensorHandle query,
-    AtenTensorHandle key,
-    AtenTensorHandle value,
-    double dropout_p,
-    int is_causal,
-    int return_debug_mask,
-    double* scale, // optional argument
-    AtenTensorHandle* ret0, // returns new reference
-    AtenTensorHandle* ret1, // returns new reference
-    AtenTensorHandle* ret2, // returns new reference
-    AtenTensorHandle* ret3, // returns new reference
-    int64_t* ret4,
-    int64_t* ret5,
-    AtenTensorHandle* ret6, // returns new reference
-    AtenTensorHandle* ret7, // returns new reference
-    AtenTensorHandle* ret8 // returns new reference
-);
-
-AOTI_TORCH_EXPORT AOTITorchError
-aoti_torch__scaled_dot_product_efficient_attention(
-    AtenTensorHandle query,
-    AtenTensorHandle key,
-    AtenTensorHandle value,
-    AtenTensorHandle attn_bias, // optional argument
-    int compute_log_sumexp,
-    double dropout_p,
-    int is_causal,
-    double* scale, // optional argument
-    AtenTensorHandle* ret0, // returns new reference
-    AtenTensorHandle* ret1, // returns new reference
-    AtenTensorHandle* ret2, // returns new reference
-    AtenTensorHandle* ret3 // returns new reference
-);
-
-AOTI_TORCH_EXPORT AOTITorchError aoti_torch__scaled_mm(
-    AtenTensorHandle self,
-    AtenTensorHandle mat2,
-    AtenTensorHandle bias,
-    int32_t* out_dtype,
-    AtenTensorHandle scale_a,
-    AtenTensorHandle scale_b,
-    AtenTensorHandle scale_result,
-    int8_t use_fast_accum,
-    AtenTensorHandle* ret0,
-    AtenTensorHandle* ret1);
-
-AOTI_TORCH_EXPORT AOTITorchError aoti_torch__scaled_mm_v2(
-    AtenTensorHandle self,
-    AtenTensorHandle mat2,
-    AtenTensorHandle scale_a,
-    AtenTensorHandle scale_b,
-    AtenTensorHandle bias,
-    AtenTensorHandle scale_result,
-    int32_t* out_dtype,
-    int8_t use_fast_accum,
-    AtenTensorHandle* ret0);
-
-AOTI_TORCH_EXPORT AOTITorchError aoti_torch_convolution(
-    AtenTensorHandle input,
-    AtenTensorHandle weight,
-    AtenTensorHandle bias, // optional argument
-    const int64_t* stride_ptr,
-    int64_t stride_size,
-    const int64_t* padding_ptr,
-    int64_t padding_size,
-    const int64_t* dilation_ptr,
-    int64_t dilation_size,
-    int transposed,
-    const int64_t* output_padding_ptr,
-    int64_t output_padding_size,
-    int64_t groups,
-    AtenTensorHandle* ret // returns new reference
-);
-
 // This function will create a new uninitialized tensor object
 // and its pointer is returned through *ret.
 AOTI_TORCH_EXPORT AOTITorchError
@@ -502,28 +331,10 @@ aoti_torch_clone(AtenTensorHandle self, AtenTensorHandle* ret);
 AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_clone_preserve_strides(AtenTensorHandle self, AtenTensorHandle* ret);
 
-AOTI_TORCH_EXPORT AOTITorchError aoti_torch_addmm_out(
-    AtenTensorHandle out,
-    AtenTensorHandle self,
-    AtenTensorHandle mat1,
-    AtenTensorHandle mat2,
-    float beta,
-    float alpha);
-
-AOTI_TORCH_EXPORT AOTITorchError aoti_torch_bmm_out(
-    AtenTensorHandle out,
-    AtenTensorHandle self,
-    AtenTensorHandle mat2);
-
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_copy_(
     AtenTensorHandle self,
     AtenTensorHandle src,
     int32_t non_blocking);
-
-AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mm_out(
-    AtenTensorHandle out,
-    AtenTensorHandle self,
-    AtenTensorHandle mat2);
 
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch__mm_plus_mm_out(
     AtenTensorHandle out,
@@ -571,15 +382,7 @@ aoti_torch_cpu__wrapped_quantized_linear_prepacked(
     int64_t out_channel,
     AtenTensorHandle* out);
 
-AOTI_TORCH_EXPORT AOTITorchError
-aoti_torch_nonzero(AtenTensorHandle self, AtenTensorHandle* out);
-
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_zero_(AtenTensorHandle self);
-
-AOTI_TORCH_EXPORT AOTITorchError aoti_torch_repeat_interleave_Tensor(
-    AtenTensorHandle repeats,
-    int64_t* output_size,
-    AtenTensorHandle* out);
 
 AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_check_inf_and_nan(const char* tensor_name, AtenTensorHandle tensor);
@@ -607,17 +410,6 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_index_put_out(
     const uint32_t num_indices,
     const AtenTensorHandle values,
     bool accumulate);
-
-AOTI_TORCH_EXPORT AOTITorchError aoti_torch_view_as_real(
-    AtenTensorHandle self,
-    AtenTensorHandle* ret // returns new reference
-);
-
-AOTI_TORCH_EXPORT AOTITorchError aoti_torch_view_dtype(
-    AtenTensorHandle self,
-    int32_t dtype,
-    AtenTensorHandle* ret // returns new reference
-);
 
 AOTI_TORCH_EXPORT void aoti_torch_print_tensor_handle(
     AtenTensorHandle self,

--- a/torch/csrc/inductor/aoti_torch/c/shim_deprecated.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim_deprecated.h
@@ -1,0 +1,199 @@
+#ifndef AOTI_TORCH_SHIM_DEPRECATED
+#define AOTI_TORCH_SHIM_DEPRECATED
+
+#include <torch/csrc/inductor/aoti_torch/c/macros.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+[[deprecated(
+    "aoti_torch__embedding_bag is deprecated and will be removed in future versions.")]]
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch__embedding_bag(
+    AtenTensorHandle weight,
+    AtenTensorHandle indices,
+    AtenTensorHandle offsets,
+    int32_t scale_grad_by_freq,
+    int32_t mode,
+    int32_t sparse,
+    AtenTensorHandle per_sample_weights, // optional argument
+    int32_t include_last_offset,
+    int32_t padding_idx,
+    AtenTensorHandle* ret0, // returns new reference
+    AtenTensorHandle* ret1, // returns new reference
+    AtenTensorHandle* ret2, // returns new reference
+    AtenTensorHandle* ret3 // returns new reference
+);
+
+[[deprecated(
+    "aoti_torch__fft_c2c is deprecated and will be removed in future versions.")]]
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch__fft_c2c(
+    AtenTensorHandle self,
+    const int64_t* dim_ptr,
+    int64_t dim_size,
+    int64_t normalization,
+    int32_t forward,
+    AtenTensorHandle* ret // returns new reference
+);
+
+[[deprecated(
+    "aoti_torch__scaled_mm is deprecated and will be removed in future versions.")]]
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch__scaled_mm(
+    AtenTensorHandle self,
+    AtenTensorHandle mat2,
+    AtenTensorHandle bias,
+    int32_t* out_dtype,
+    AtenTensorHandle scale_a,
+    AtenTensorHandle scale_b,
+    AtenTensorHandle scale_result,
+    int8_t use_fast_accum,
+    AtenTensorHandle* ret0,
+    AtenTensorHandle* ret1);
+
+[[deprecated(
+    "aoti_torch__scaled_mm_v2 is deprecated and will be removed in future versions.")]]
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch__scaled_mm_v2(
+    AtenTensorHandle self,
+    AtenTensorHandle mat2,
+    AtenTensorHandle scale_a,
+    AtenTensorHandle scale_b,
+    AtenTensorHandle bias,
+    AtenTensorHandle scale_result,
+    int32_t* out_dtype,
+    int8_t use_fast_accum,
+    AtenTensorHandle* ret0);
+
+[[deprecated(
+    "aoti_torch_addmm_out is deprecated and will be removed in future versions.")]]
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_addmm_out(
+    AtenTensorHandle out,
+    AtenTensorHandle self,
+    AtenTensorHandle mat1,
+    AtenTensorHandle mat2,
+    float beta,
+    float alpha);
+
+[[deprecated(
+    "aoti_torch_bmm is deprecated and will be removed in future versions.")]]
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_bmm_out(
+    AtenTensorHandle out,
+    AtenTensorHandle self,
+    AtenTensorHandle mat2);
+
+[[deprecated(
+    "aoti_torch_convolution is deprecated and will be removed in future versions.")]]
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_convolution(
+    AtenTensorHandle input,
+    AtenTensorHandle weight,
+    AtenTensorHandle bias, // optional argument
+    const int64_t* stride_ptr,
+    int64_t stride_size,
+    const int64_t* padding_ptr,
+    int64_t padding_size,
+    const int64_t* dilation_ptr,
+    int64_t dilation_size,
+    int transposed,
+    const int64_t* output_padding_ptr,
+    int64_t output_padding_size,
+    int64_t groups,
+    AtenTensorHandle* ret // returns new reference
+);
+
+[[deprecated(
+    "aoti_torch_mm_out is deprecated and will be removed in future versions.")]]
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mm_out(
+    AtenTensorHandle out,
+    AtenTensorHandle self,
+    AtenTensorHandle mat2);
+
+[[deprecated(
+    "aoti_torch_nonzero is deprecated and will be removed in future versions.")]]
+AOTI_TORCH_EXPORT AOTITorchError
+aoti_torch_nonzero(AtenTensorHandle self, AtenTensorHandle* out);
+
+[[deprecated(
+    "aoti_torch_repeat_interleave_Tensor is deprecated and will be removed in future versions.")]]
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_repeat_interleave_Tensor(
+    AtenTensorHandle repeats,
+    int64_t* output_size,
+    AtenTensorHandle* out);
+
+[[deprecated(
+    "aoti_torch_view_as_real is deprecated and will be removed in future versions.")]]
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_view_as_real(
+    AtenTensorHandle self,
+    AtenTensorHandle* ret // returns new reference
+);
+
+[[deprecated(
+    "aoti_torch_view_dtype is deprecated and will be removed in future versions.")]]
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_view_dtype(
+    AtenTensorHandle self,
+    int32_t dtype,
+    AtenTensorHandle* ret // returns new reference
+);
+
+[[deprecated(
+    "aoti_torch__scaled_dot_product_flash_attention is deprecated and will be removed in future versions.")]]
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch__scaled_dot_product_flash_attention(
+    AtenTensorHandle query,
+    AtenTensorHandle key,
+    AtenTensorHandle value,
+    double dropout_p,
+    bool is_causal,
+    bool return_debug_mask,
+    double scale,
+    AtenTensorHandle* ret0, // returns new reference
+    AtenTensorHandle* ret1, // returns new reference
+    AtenTensorHandle* ret2, // returns new reference
+    AtenTensorHandle* ret3, // returns new reference
+    int64_t* ret4,
+    int64_t* ret5,
+    AtenTensorHandle* ret6, // returns new reference
+    AtenTensorHandle* ret7, // returns new reference
+    AtenTensorHandle* ret8 // returns new reference
+);
+
+AOTI_TORCH_EXPORT AOTITorchError
+aoti_torch__scaled_dot_product_flash_attention_v2(
+    AtenTensorHandle query,
+    AtenTensorHandle key,
+    AtenTensorHandle value,
+    double dropout_p,
+    int is_causal,
+    int return_debug_mask,
+    double* scale, // optional argument
+    AtenTensorHandle* ret0, // returns new reference
+    AtenTensorHandle* ret1, // returns new reference
+    AtenTensorHandle* ret2, // returns new reference
+    AtenTensorHandle* ret3, // returns new reference
+    int64_t* ret4,
+    int64_t* ret5,
+    AtenTensorHandle* ret6, // returns new reference
+    AtenTensorHandle* ret7, // returns new reference
+    AtenTensorHandle* ret8 // returns new reference
+);
+
+[[deprecated(
+    "aoti_torch__scaled_dot_product_efficient_attention is deprecated and will be removed in future versions.")]]
+AOTI_TORCH_EXPORT AOTITorchError
+aoti_torch__scaled_dot_product_efficient_attention(
+    AtenTensorHandle query,
+    AtenTensorHandle key,
+    AtenTensorHandle value,
+    AtenTensorHandle attn_bias, // optional argument
+    int compute_log_sumexp,
+    double dropout_p,
+    int is_causal,
+    double* scale, // optional argument
+    AtenTensorHandle* ret0, // returns new reference
+    AtenTensorHandle* ret1, // returns new reference
+    AtenTensorHandle* ret2, // returns new reference
+    AtenTensorHandle* ret3 // returns new reference
+);
+
+#ifdef __cplusplus
+} // extern "C"
+
+#endif
+#endif // AOTI_TORCH_SHIM_DEPRECATED


### PR DESCRIPTION
Summary:
The shims for aten ops are now generated by torchgen. But there are some still old APIs in `aoti_torch/c/shim.h`

This diff moves the old to-be-deprecated APIs for aten ops to a separate header file `shim_deprecated.h`

The to-be-deprecated APIs are determined by comparing APIs in `shim.h` and ops in `fallback_ops.py`

Test Plan:
CI

Rollback Plan:

Differential Revision: D78378373


