### PR TITLE
[PT2]: Skip AOTI Weight Loading during Init

### DIFF
--- a/torch/nativert/executor/DelegateExecutor.h
+++ b/torch/nativert/executor/DelegateExecutor.h
@@ -46,6 +46,8 @@ class DelegateExecutor {
   // This call activate the processed weights.
   virtual void commitWeights() = 0;
 
+  virtual void initWeights(std::shared_ptr<Weights> weights) = 0;
+
   virtual std::vector<at::Tensor> run(std::vector<at::Tensor>& inputs) = 0;
 };
 

--- a/torch/nativert/executor/Executor.h
+++ b/torch/nativert/executor/Executor.h
@@ -177,6 +177,8 @@ class Executor {
   // Helper method to get current timestamp in seconds
   int64_t getCurrentTimestampSeconds() const;
 
+  void initWeights(const std::shared_ptr<Weights>& weights);
+
   std::unique_ptr<GraphExecutorBase> graphExecutor_;
 
   const Placement placement_;


### PR DESCRIPTION
Summary: AOTI already has weights embedded in .so file. So for the initial load, no need to load the weights again. This allows lowered modules can have different set of weights on different hardwares.

Test Plan:
```
MODEL_TYPE=ads_mtml_offsite_cvr_oba_optout_dedicated_model
MODEL_ENTITY_ID=895279202
SNAPSHOT_ID=0
MODULE=merge

buck2 run mode/dev-nosan -c fbcode.nvcc_arch=a100,h100 -c fbcode.enable_gpu_sections=true fbcode//caffe2/torch/fb/model_transform/fx2trt/packaging:load_net_predictor -- --loadMode=Benchmark --inputNetFile=/data/users/$USER/models/${MODEL_ENTITY_ID}/${SNAPSHOT_ID}/${MODEL_ENTITY_ID}_${SNAPSHOT_ID}.predictor.disagg.gpu.${MODULE} --moduleName ${MODULE} --predictor-hardware-type 1 --submodToDevice ""  --benchmarkDontRebatchSamples=true --benchmarkNumIterations 1000
```

Rollback Plan:

Differential Revision: D78383881


