### PR TITLE
[aot][XPU] switch xpu to use consts cpp build.

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1842,6 +1842,7 @@ class AotCodeCompiler:
             def format_consts_to_cpp(
                 consts: bytes, align_bytes: int, symbol_prefix: str
             ) -> tuple[str, str]:
+                consts_size = len(consts)
                 asan_attr = """#if defined(__clang__) || defined (__GNUC__)\t\n\
 #define ATTRIBUTE_NO_SANITIZE_ADDRESS __attribute__((no_sanitize("address")))\t\n\
 #else\t\n\
@@ -1851,7 +1852,7 @@ class AotCodeCompiler:
 ATTRIBUTE_NO_SANITIZE_ADDRESS\t\n"""
                 const_cpp = asan_attr
                 const_cpp += f"alignas({align_bytes}) extern "
-                const_cpp += f"const unsigned char {symbol_prefix}_binary_constants_bin_start[] = {{\t\n"
+                const_cpp += f"const unsigned char {symbol_prefix}_binary_constants_bin_start[{consts_size}] = {{\t\n"
                 count_bytes = 0
                 for c in consts:
                     const_cpp += f"{c}, "

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1808,7 +1808,7 @@ class AotCodeCompiler:
                 raise RuntimeError(f"Unsupported platform: {platform}")
 
             # Intel compiler failed to compile this manually constructed assembly file.
-            # it is ok to use cpp to compile the .S to a .o and linked with Intel compiler.
+            # Switch XPU to use consts cpp build.
             if device_type == "xpu":
                 use_asm_build = False
 

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1807,6 +1807,11 @@ class AotCodeCompiler:
             else:
                 raise RuntimeError(f"Unsupported platform: {platform}")
 
+            # Intel compiler failed to compile this manually constructed assembly file.
+            # it is ok to use cpp to compile the .S to a .o and linked with Intel compiler.
+            if device_type == "xpu":
+                use_asm_build = False
+
             is_large_consts = len(consts) > 1024
 
             def format_consts_to_asm(
@@ -1873,9 +1878,7 @@ ATTRIBUTE_NO_SANITIZE_ADDRESS\t\n"""
             )
             consts_s = Path(consts_s)
             object_build_options = CppTorchDeviceOptions(
-                # Intel compiler failed to compile this manually constructed assembly file.
-                # it is ok to use gcc to compile the .S to a .o and linked with Intel compiler .
-                device_type=device_type if device_type != "xpu" else "cpu",
+                device_type=device_type,
                 aot_mode=graph.aot_mode,
                 compile_only=True,
                 use_relative_path=use_relative_path,


### PR DESCRIPTION
Intel compiler is not support `format_consts_to_asm`, let's use `format_consts_to_cpp`.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov