### PR TITLE
Dynamo logger: Issue 156191 logger unknown len

### DIFF
--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -1180,6 +1180,9 @@ class GetAttrVariable(VariableTracker):
             if isinstance(self.obj, variables.NNModuleVariable):
                 # This matches how `setattr` is handled for NNModuleVariable
                 self.obj.convert_to_unspecialized(tx)
+        elif name == "__len__":
+            if isinstance(self.obj, variables.misc.LoggingLoggerVariable):
+                return variables.ConstantVariable(None)
 
         return super().call_method(tx, name, args, kwargs)
 

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -1180,9 +1180,12 @@ class GetAttrVariable(VariableTracker):
             if isinstance(self.obj, variables.NNModuleVariable):
                 # This matches how `setattr` is handled for NNModuleVariable
                 self.obj.convert_to_unspecialized(tx)
-        elif name == "__len__":
-            if isinstance(self.obj, variables.misc.LoggingLoggerVariable):
-                return variables.ConstantVariable(None)
+
+        elif name == "__len__" and isinstance(
+            self.obj, variables.misc.LoggingLoggerVariable
+        ):
+            # Logging should be ignored in trace, so stop it here.
+            return variables.ConstantVariable(None)
 
         return super().call_method(tx, name, args, kwargs)
 


### PR DESCRIPTION
Fixes #156191

The issue is that len(logger.handler) is not implemented on the dynamo tracer. In general, LoggingLoggerVariable is not meant to be traced at least by my interpretation of the source code. Typically using,
torch._dynamo.config.ignore_logger_methods.add(logging.Logger.info) 
prevents graph breaks, but in this issues's case the underlying call is __len__ of a class member of the logger, which is isn't implemented in the tracer and circumvents the ignore flag. 

In order to resolve this issue, I stopped the trace for that call and returned a constant. 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela