### PR TITLE
[DRAFT] Support raw inputs in CTC Loss Python API

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3060,9 +3060,11 @@ def ctc_loss(
         >>> loss = F.ctc_loss(log_probs, targets, input_lengths, target_lengths)
         >>> loss.backward()
     """
+
     if has_torch_function_variadic(log_probs, targets, input_lengths, target_lengths):
+        raw_ctc = lambda x, *o: ctc_loss(log_softmax(x, -1), *o)
         return handle_torch_function(
-            ctc_loss,
+            raw_ctc,
             (log_probs, targets, input_lengths, target_lengths),
             log_probs,
             targets,
@@ -3072,7 +3074,10 @@ def ctc_loss(
             reduction=reduction,
             zero_infinity=zero_infinity,
         )
-    return torch.ctc_loss(
+
+    raw_ctc = lambda x, *o: torch.ctc_loss(log_softmax(x, -1), *o)
+
+    return raw_ctc(
         log_probs,
         targets,
         input_lengths,

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3062,9 +3062,8 @@ def ctc_loss(
     """
 
     if has_torch_function_variadic(inputs, targets, input_lengths, target_lengths):
-        raw_ctc = lambda x, *o: ctc_loss(log_softmax(x, -1), *o)  # noqa: E731
         return handle_torch_function(
-            raw_ctc,
+            ctc_loss,
             (inputs, targets, input_lengths, target_lengths),
             inputs,
             targets,
@@ -3075,7 +3074,8 @@ def ctc_loss(
             zero_infinity=zero_infinity,
         )
 
-    raw_ctc = lambda x, *o: torch.ctc_loss(log_softmax(x, -1), *o)  # noqa: E731
+    def raw_ctc(x, *o):
+        return torch.ctc_loss(log_softmax(x, -1), *o)
 
     return raw_ctc(
         inputs,

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3062,7 +3062,7 @@ def ctc_loss(
     """
 
     if has_torch_function_variadic(inputs, targets, input_lengths, target_lengths):
-        raw_ctc = lambda x, *o: ctc_loss(log_softmax(x, -1), *o)
+        raw_ctc = lambda x, *o: ctc_loss(log_softmax(x, -1), *o)  # noqa: E731
         return handle_torch_function(
             raw_ctc,
             (inputs, targets, input_lengths, target_lengths),
@@ -3075,7 +3075,7 @@ def ctc_loss(
             zero_infinity=zero_infinity,
         )
 
-    raw_ctc = lambda x, *o: torch.ctc_loss(log_softmax(x, -1), *o)
+    raw_ctc = lambda x, *o: torch.ctc_loss(log_softmax(x, -1), *o)  # noqa: E731
 
     return raw_ctc(
         inputs,

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -1870,12 +1870,11 @@ class CTCLoss(_Loss):
             to be aligned to the targets.
 
     Shape:
-        - Log_probs: Tensor of size :math:`(T, N, C)` or :math:`(T, C)`,
+        - Inputs: Tensor of size :math:`(T, N, C)` or :math:`(T, C)`,
           where :math:`T = \text{input length}`,
           :math:`N = \text{batch size}`, and
           :math:`C = \text{number of classes (including blank)}`.
-          The logarithmized probabilities of the outputs (e.g. obtained with
-          :func:`torch.nn.functional.log_softmax`).
+          Probability outputs, need not be normalized.
         - Targets: Tensor of size :math:`(N, S)` or
           :math:`(\operatorname{sum}(\text{target\_lengths}))`,
           where :math:`N = \text{batch size}` and
@@ -1915,7 +1914,7 @@ class CTCLoss(_Loss):
         >>> S_min = 10  # Minimum target length, for demonstration purposes
         >>>
         >>> # Initialize random batch of input vectors, for *size = (T,N,C)
-        >>> input = torch.randn(T, N, C).log_softmax(2).detach().requires_grad_()
+        >>> input = torch.randn(T, N, C).detach().requires_grad_()
         >>>
         >>> # Initialize random batch of targets (0 = blank, 1:C = classes)
         >>> target = torch.randint(low=1, high=C, size=(N, S), dtype=torch.long)
@@ -1938,7 +1937,7 @@ class CTCLoss(_Loss):
         >>> N = 16  # Batch size
         >>>
         >>> # Initialize random batch of input vectors, for *size = (T,N,C)
-        >>> input = torch.randn(T, N, C).log_softmax(2).detach().requires_grad_()
+        >>> input = torch.randn(T, N, C).detach().requires_grad_()
         >>> input_lengths = torch.full(size=(N,), fill_value=T, dtype=torch.long)
         >>>
         >>> # Initialize random batch of targets (0 = blank, 1:C = classes)
@@ -1960,7 +1959,7 @@ class CTCLoss(_Loss):
         >>>
         >>> # Initialize random batch of input vectors, for *size = (T,C)
         >>> # xdoctest: +SKIP("FIXME: error in doctest")
-        >>> input = torch.randn(T, C).log_softmax(1).detach().requires_grad_()
+        >>> input = torch.randn(T, C).detach().requires_grad_()
         >>> input_lengths = torch.tensor(T, dtype=torch.long)
         >>>
         >>> # Initialize random batch of targets (0 = blank, 1:C = classes)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8382,16 +8382,17 @@ def sample_inputs_ctc_loss(op_info, device, dtype, requires_grad, **kwargs):
     num_char = 20
     target_length = 30
 
-    def make_log_probs(s):
-        t = make_tensor(s, device=device, dtype=dtype)
-        log_probs = t.log_softmax(2).to(device=device, dtype=dtype).detach().requires_grad_(requires_grad=requires_grad)
-        return log_probs
+    # Test ctc_loss gradient behavior for the regime in which it is currently accurate and consistent across devices:
+    # normalized inputs and gradients wrt. unnormalized inputs.
+    # See https://github.com/pytorch/pytorch/issues/52241
+    def make_input(s):
+        return make_tensor(s, device=device, dtype=dtype).detach().requires_grad_(requires_grad=requires_grad)
 
     reductions = ('none', 'mean', 'sum')
     zero_inf = (True, False)
     lengths_type = (list, torch.Tensor)
     for r, z, lt in product(reductions, zero_inf, lengths_type):
-        log_probs = make_log_probs((input_length, batch, num_char))
+        log_probs = make_input((input_length, batch, num_char))
         targets = torch.randint(1, num_char, (batch, target_length), dtype=torch.long, device=device)
         input_lengths = torch.full((batch, ), input_length, dtype=torch.long, device=device)
         target_lengths = torch.randint(10, target_length, (batch, ), dtype=torch.long, device=device)
@@ -8404,7 +8405,7 @@ def sample_inputs_ctc_loss(op_info, device, dtype, requires_grad, **kwargs):
             input_lengths = input_lengths.tolist()
             target_lengths = target_lengths.tolist()
 
-        yield SampleInput(log_probs, args=(targets, input_lengths, target_lengths,),
+        yield SampleInput(log_probs, args=(targets, input_lengths, target_lengths),
                           kwargs=dict(reduction=r, zero_infinity=z))
 
 
@@ -21367,7 +21368,8 @@ op_db: list[OpInfo] = [
         dtypes=floating_types(),
         supports_out=False,
         sample_inputs_func=sample_inputs_ctc_loss,
-        # gradcheck_wrapper, see https://github.com/pytorch/pytorch/issues/52241
+        # gradcheck_wrapper to check gradients wrt. unnormalized inputs.
+        # see https://github.com/pytorch/pytorch/issues/52241
         gradcheck_wrapper=gradcheck_wrapper_ctc_loss,
         skips=(
             # RuntimeError: derivative for aten::_ctc_loss_backward is not implemented

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -97,7 +97,6 @@ from torch.testing._internal.opinfo.core import (  # noqa: F401
     sample_inputs_foreach,
     ForeachFuncInfo,
     gradcheck_wrapper_hermitian_input,
-    gradcheck_wrapper_ctc_loss,
     gradcheck_wrapper_triangular_input,
     gradcheck_wrapper_triangular_input_real_positive_diagonal,
     gradcheck_wrapper_masked_operation,
@@ -21368,9 +21367,6 @@ op_db: list[OpInfo] = [
         dtypes=floating_types(),
         supports_out=False,
         sample_inputs_func=sample_inputs_ctc_loss,
-        # gradcheck_wrapper, see https://github.com/pytorch/pytorch/issues/52241
-        # (Update: should not need gradcheck wrapper if/since now using raw inputs)
-        #gradcheck_wrapper=gradcheck_wrapper_ctc_loss,
         skips=(
             # RuntimeError: derivative for aten::_ctc_loss_backward is not implemented
             DecorateInfo(

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8382,17 +8382,16 @@ def sample_inputs_ctc_loss(op_info, device, dtype, requires_grad, **kwargs):
     num_char = 20
     target_length = 30
 
-    # Test ctc_loss gradient behavior for the regime in which it is currently accurate and consistent across devices:
-    # normalized inputs and gradients wrt. unnormalized inputs.
-    # See https://github.com/pytorch/pytorch/issues/52241
-    def make_input(s):
-        return make_tensor(s, device=device, dtype=dtype).detach().requires_grad_(requires_grad=requires_grad)
+    def make_log_probs(s):
+        t = make_tensor(s, device=device, dtype=dtype)
+        log_probs = t.log_softmax(2).to(device=device, dtype=dtype).detach().requires_grad_(requires_grad=requires_grad)
+        return log_probs
 
     reductions = ('none', 'mean', 'sum')
     zero_inf = (True, False)
     lengths_type = (list, torch.Tensor)
     for r, z, lt in product(reductions, zero_inf, lengths_type):
-        log_probs = make_input((input_length, batch, num_char))
+        log_probs = make_log_probs((input_length, batch, num_char))
         targets = torch.randint(1, num_char, (batch, target_length), dtype=torch.long, device=device)
         input_lengths = torch.full((batch, ), input_length, dtype=torch.long, device=device)
         target_lengths = torch.randint(10, target_length, (batch, ), dtype=torch.long, device=device)
@@ -8405,7 +8404,7 @@ def sample_inputs_ctc_loss(op_info, device, dtype, requires_grad, **kwargs):
             input_lengths = input_lengths.tolist()
             target_lengths = target_lengths.tolist()
 
-        yield SampleInput(log_probs, args=(targets, input_lengths, target_lengths),
+        yield SampleInput(log_probs, args=(targets, input_lengths, target_lengths,),
                           kwargs=dict(reduction=r, zero_infinity=z))
 
 
@@ -21368,8 +21367,7 @@ op_db: list[OpInfo] = [
         dtypes=floating_types(),
         supports_out=False,
         sample_inputs_func=sample_inputs_ctc_loss,
-        # gradcheck_wrapper to check gradients wrt. unnormalized inputs.
-        # see https://github.com/pytorch/pytorch/issues/52241
+        # gradcheck_wrapper, see https://github.com/pytorch/pytorch/issues/52241
         gradcheck_wrapper=gradcheck_wrapper_ctc_loss,
         skips=(
             # RuntimeError: derivative for aten::_ctc_loss_backward is not implemented

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8382,16 +8382,17 @@ def sample_inputs_ctc_loss(op_info, device, dtype, requires_grad, **kwargs):
     num_char = 20
     target_length = 30
 
-    def make_log_probs(s):
+    def make_inputs(s):
+        # Use raw unnormalized inputs.
         t = make_tensor(s, device=device, dtype=dtype)
-        log_probs = t.log_softmax(2).to(device=device, dtype=dtype).detach().requires_grad_(requires_grad=requires_grad)
-        return log_probs
+        inputs = t.to(device=device, dtype=dtype).detach().requires_grad_(requires_grad=requires_grad)
+        return inputs
 
     reductions = ('none', 'mean', 'sum')
     zero_inf = (True, False)
     lengths_type = (list, torch.Tensor)
     for r, z, lt in product(reductions, zero_inf, lengths_type):
-        log_probs = make_log_probs((input_length, batch, num_char))
+        inputs = make_inputs((input_length, batch, num_char))
         targets = torch.randint(1, num_char, (batch, target_length), dtype=torch.long, device=device)
         input_lengths = torch.full((batch, ), input_length, dtype=torch.long, device=device)
         target_lengths = torch.randint(10, target_length, (batch, ), dtype=torch.long, device=device)
@@ -8404,7 +8405,7 @@ def sample_inputs_ctc_loss(op_info, device, dtype, requires_grad, **kwargs):
             input_lengths = input_lengths.tolist()
             target_lengths = target_lengths.tolist()
 
-        yield SampleInput(log_probs, args=(targets, input_lengths, target_lengths,),
+        yield SampleInput(inputs, args=(targets, input_lengths, target_lengths,),
                           kwargs=dict(reduction=r, zero_infinity=z))
 
 
@@ -21368,7 +21369,8 @@ op_db: list[OpInfo] = [
         supports_out=False,
         sample_inputs_func=sample_inputs_ctc_loss,
         # gradcheck_wrapper, see https://github.com/pytorch/pytorch/issues/52241
-        gradcheck_wrapper=gradcheck_wrapper_ctc_loss,
+        # (Update: should not need gradcheck wrapper if/since now using raw inputs)
+        #gradcheck_wrapper=gradcheck_wrapper_ctc_loss,
         skips=(
             # RuntimeError: derivative for aten::_ctc_loss_backward is not implemented
             DecorateInfo(

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -3126,8 +3126,7 @@ def gradcheck_wrapper_hermitian_input(op, input, *args, **kwargs):
 
 
 def gradcheck_wrapper_ctc_loss(op, input, *args, **kwargs):
-    """Gradcheck wrapper for ctc loss. This is needed to test the existing restricted cases in which the
-    ctc loss implementation is accurate and consistent across devices."""
+    """Gradcheck wrapper for ctc loss to project onto log-simplex space."""
     # See https://github.com/pytorch/pytorch/issues/52241
     return op(input.log_softmax(dim=2), *args, **kwargs)
 

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -3126,7 +3126,8 @@ def gradcheck_wrapper_hermitian_input(op, input, *args, **kwargs):
 
 
 def gradcheck_wrapper_ctc_loss(op, input, *args, **kwargs):
-    """Gradcheck wrapper for ctc loss to project onto log-simplex space."""
+    """Gradcheck wrapper for ctc loss. This is needed to test the existing restricted cases in which the
+    ctc loss implementation is accurate and consistent across devices."""
     # See https://github.com/pytorch/pytorch/issues/52241
     return op(input.log_softmax(dim=2), *args, **kwargs)
 

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -3125,12 +3125,6 @@ def gradcheck_wrapper_hermitian_input(op, input, *args, **kwargs):
     return op(input + input.mH, *args, **kwargs)
 
 
-def gradcheck_wrapper_ctc_loss(op, input, *args, **kwargs):
-    """Gradcheck wrapper for ctc loss to project onto log-simplex space."""
-    # See https://github.com/pytorch/pytorch/issues/52241
-    return op(input.log_softmax(dim=2), *args, **kwargs)
-
-
 def gradcheck_wrapper_triangular_input(op, *args, upper=False, idx=0, **kwargs):
     """Gradcheck wrapper for functions that take lower or upper triangular matrices as input.
 


### PR DESCRIPTION
(Maybe) Fixes #52241 

Adds support for unnormalized inputs to the Python API(s) for CTC loss.

Draft PR: would appreciate permission for a CI run to check tests pass (cc @soulitzer) (CTC loss OpInfo and forward pass tests pass locally) and feedback on this approach from a maintainer and original implementation author (cc @soulitzer and @t-vi, this follows up on your comment https://github.com/pytorch/pytorch/issues/52241#issuecomment-778724613) on this approach. 


This should be backwards-compatible- as log_softmax is idempotent, behavior on the currently supported log-simplex space is preserved, and simply extended to include raw inputs. (See https://github.com/pytorch/pytorch/issues/52241#issuecomment-2973324675 for reference.)



