### PR TITLE
Update docstring in scaled_dot_product_attention to remote outdated logical_not example

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5831,7 +5831,7 @@ scaled_dot_product_attention = _add_docstr(
 
             if attn_mask is not None:
                 if attn_mask.dtype == torch.bool:
-                    attn_bias.masked_fill_(attn_mask.logical_not(), float("-inf"))
+                    attn_bias.masked_fill_(attn_mask, float("-inf"))
                 else:
                     attn_bias = attn_mask + attn_bias
 


### PR DESCRIPTION
Fixes #158451 

This PR updates the docstring for scaled_dot_product_attention to correct how boolean masks are described. The previous version showed a .logical_not() being used before masked_fill_ which isn't part of the current implementation. 

I removed that outdated example so that the documentation matches what the code actually does, which is that positions where the masks is True are filled with -inf and excluded from attention while False values are left untouched. No changes were made to the function's behavior. This is just a doc fix to avoid confusion.

