### PR TITLE
Shunt fx_interpreter graphmodule print on error into tlparse

### DIFF
--- a/torch/fx/interpreter.py
+++ b/torch/fx/interpreter.py
@@ -5,8 +5,8 @@ from typing import Any, Optional, TYPE_CHECKING, Union
 
 import torch
 import torch.fx.traceback as fx_traceback
-from torch.hub import tqdm
 from torch._logging import trace_structured
+from torch.hub import tqdm
 
 from . import config
 from ._compatibility import compatibility
@@ -188,10 +188,14 @@ class Interpreter:
                                 "name": "fx_interpreter_error",
                                 "encoding": "string",
                             },
-                            payload_fn=lambda: f"{msg}\nGraphModule: {self.module.print_readable(print_output=False, include_stride=True)}",
+                            payload_fn=lambda: (
+                                f"{msg}\nGraphModule: "
+                                f"{self.module.print_readable(print_output=False, include_stride=True)}"  # type: ignore[operator]
+                            ),
                         )
 
-                    msg += "\nUse TORCH_TRACE / tlparse to see full graph."
+                    msg += "\nUse tlparse to see full graph. "
+                    msg += "(https://github.com/pytorch/tlparse?tab=readme-ov-file#tlparse-parse-structured-pt2-logs)"
                     e.args = (msg,) + e.args[1:]
                     if isinstance(e, KeyError):
                         raise RuntimeError(*e.args) from e

--- a/torch/fx/interpreter.py
+++ b/torch/fx/interpreter.py
@@ -6,6 +6,7 @@ from typing import Any, Optional, TYPE_CHECKING, Union
 import torch
 import torch.fx.traceback as fx_traceback
 from torch.hub import tqdm
+from torch._logging import trace_structured
 
 from . import config
 from ._compatibility import compatibility
@@ -175,13 +176,22 @@ class Interpreter:
                 if self.extra_traceback:
                     msg = f"While executing {node.format_node()}"
                     msg = f"{e.args[0]}\n\n{msg}" if e.args else str(msg)
+                    msg += f"\nOriginal traceback:\n{node.stack_trace}"
                     if (
                         isinstance(self.module, GraphModule)
                         and self.module.graph is not None
                         and isinstance(self.module.graph, torch.fx.Graph)
                     ):
-                        msg += f"\nGraphModule: {self.module.print_readable(print_output=False, include_stride=True)}\n"
-                    msg += f"\nOriginal traceback:\n{node.stack_trace}"
+                        trace_structured(
+                            "artifact",
+                            metadata_fn=lambda: {
+                                "name": "fx_interpreter_error",
+                                "encoding": "string",
+                            },
+                            payload_fn=lambda: f"{msg}\nGraphModule: {self.module.print_readable(print_output=False, include_stride=True)}",
+                        )
+
+                    msg += "\nUse TORCH_TRACE / tlparse to see full graph."
                     e.args = (msg,) + e.args[1:]
                     if isinstance(e, KeyError):
                         raise RuntimeError(*e.args) from e


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #158481
* __->__ #158469

Include both the error stacktrace and the graphmodule in a new
structured trace artifact.  Log the shortened version to the console,
and also log a hint to look at the tlparse for more.

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv