### PR TITLE
[2/N] support of replication fallback strategy 

### DIFF
--- a/test/distributed/tensor/test_op_strategy.py
+++ b/test/distributed/tensor/test_op_strategy.py
@@ -1,18 +1,61 @@
 # Owner(s): ["oncall: distributed"]
 
+import functools
+import itertools
+import random
+from contextlib import contextmanager
+from copy import deepcopy
 from itertools import chain
+from unittest.mock import patch
+
+import numpy as np
 
 import torch
-from torch.distributed.tensor import DeviceMesh, DTensor, Partial, Replicate, Shard
+from torch.distributed.tensor import (
+    DeviceMesh,
+    distribute_tensor,
+    DTensor,
+    init_device_mesh,
+    Partial,
+    Placement,
+    Replicate,
+    Shard,
+)
 from torch.distributed.tensor._collective_utils import redistribute_cost
 from torch.distributed.tensor._dtensor_spec import DTensorSpec, TensorMeta
-from torch.distributed.tensor._op_schema import OpSchema, OpSpec, OpStrategy
+from torch.distributed.tensor._op_schema import (
+    OpSchema,
+    OpSpec,
+    OpStrategy,
+    RuntimeSchemaInfo,
+    StrategyType,
+)
 from torch.distributed.tensor._ops._einsum_strategy import (
     EinsumDims,
     gen_einsum_strategies,
 )
+from torch.distributed.tensor._ops.utils import (
+    flatten_strategy_args,
+    generate_redistribute_costs,
+    register_op_strategy,
+    replicate_op_strategy,
+)
 from torch.testing._internal.common_utils import run_tests, TestCase
-from torch.testing._internal.distributed._tensor.common_dtensor import DTensorOpTestBase
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    DTensorOpTestBase,
+    DTensorTestBase,
+    with_comms,
+)
+
+
+try:
+    from torch.utils import _cxx_pytree as pytree
+except ImportError:
+    from torch.utils import _pytree as pytree  # type: ignore[no-redef]
+
+
+def extract_tensor_meta(t) -> TensorMeta:
+    return TensorMeta(t.shape, t.stride(), t.dtype)
 
 
 class TestEinsumDims(TestCase):
@@ -131,9 +174,6 @@ class TestEinsumStrategies(DTensorOpTestBase):
 
 
 class TestCostModel(DTensorOpTestBase):
-    def _extract_tensor_meta(self, t) -> TensorMeta:
-        return TensorMeta(t.shape, t.stride(), t.dtype)
-
     @property
     def world_size(self) -> int:
         return 4
@@ -145,7 +185,7 @@ class TestCostModel(DTensorOpTestBase):
         partial_placement = (Partial(),)
 
         global_tensor = torch.randn(10, 10)
-        global_tensor_meta = self._extract_tensor_meta(global_tensor)
+        global_tensor_meta = extract_tensor_meta(global_tensor)
 
         # shard spec
         shard_spec = DTensorSpec(mesh_1d, shard_placement, global_tensor_meta)
@@ -180,9 +220,9 @@ class TestCostModel(DTensorOpTestBase):
         partial_placement = (Partial(),)
         shard1_placement = (Shard(1),)
 
-        shard0_tensor_meta = self._extract_tensor_meta(torch.randn(8))
-        partial_tensor_meta = self._extract_tensor_meta(torch.randn(50, 6))
-        shard1_tensor_meta = self._extract_tensor_meta(torch.randn(6, 8))
+        shard0_tensor_meta = extract_tensor_meta(torch.randn(8))
+        partial_tensor_meta = extract_tensor_meta(torch.randn(50, 6))
+        shard1_tensor_meta = extract_tensor_meta(torch.randn(6, 8))
 
         # shard spec
         shard0_spec = DTensorSpec(mesh, shard0_placement, shard0_tensor_meta)
@@ -226,7 +266,7 @@ class TestCostModel(DTensorOpTestBase):
         partial_placement = (Partial(), Partial())
 
         global_tensor = torch.randn(8, 8)
-        global_tensor_meta = self._extract_tensor_meta(global_tensor)
+        global_tensor_meta = extract_tensor_meta(global_tensor)
 
         # shard spec
         shard_spec = DTensorSpec(mesh_2d, shard_placement, global_tensor_meta)
@@ -255,8 +295,8 @@ class TestCostModel(DTensorOpTestBase):
         mesh = self.build_device_mesh()
         lhs_tensor = torch.randn(6, 8)
         rhs_tensor = torch.randn(8, 12)
-        lhs_tensor_meta = self._extract_tensor_meta(lhs_tensor)
-        rhs_tensor_meta = self._extract_tensor_meta(rhs_tensor)
+        lhs_tensor_meta = extract_tensor_meta(lhs_tensor)
+        rhs_tensor_meta = extract_tensor_meta(rhs_tensor)
 
         mm_combs = (
             (Shard(0), Replicate()),
@@ -301,8 +341,8 @@ class TestCostModel(DTensorOpTestBase):
         mesh = self.build_device_mesh()
         lhs_tensor = torch.randn(8, 6, 8)
         rhs_tensor = torch.randn(8, 8, 12)
-        lhs_tensor_meta = self._extract_tensor_meta(lhs_tensor)
-        rhs_tensor_meta = self._extract_tensor_meta(rhs_tensor)
+        lhs_tensor_meta = extract_tensor_meta(lhs_tensor)
+        rhs_tensor_meta = extract_tensor_meta(rhs_tensor)
 
         bmm_combs = (
             (Shard(0), Shard(0)),
@@ -341,6 +381,285 @@ class TestCostModel(DTensorOpTestBase):
                 op_schema
             )
             self.assertFalse(output_sharding.needs_redistribute)
+
+
+# -------------Test op strategy registration-------------
+# custom op without List[Tensor] as input
+# reference: https://docs.pytorch.org/docs/stable/library.html#torch.library.register_autograd
+@torch.library.custom_op("mylib::numpy_sin", mutates_args=())
+def numpy_sin(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    x_np = x.cpu().numpy()
+    y_np = y.cpu().numpy()
+    out_np = np.sin(x_np) + np.sin(y_np)
+    return torch.from_numpy(out_np).to(device=x.device)
+
+
+def setup_context(ctx, inputs, output):
+    (x, y) = inputs
+    ctx.save_for_backward(x, y)
+
+
+def backward(ctx, grad):
+    (x, y) = ctx.saved_tensors
+    return grad * x.cos(), grad * y.cos()
+
+
+@numpy_sin.register_fake
+def _fw(x, y):
+    return torch.empty_like(x)
+
+
+torch.library.register_autograd(
+    "mylib::numpy_sin", backward, setup_context=setup_context
+)
+
+
+# custom op with List[Tensor] as input
+@torch.library.custom_op("mylib::numpy_tuple_sin", mutates_args=())
+def numpy_tuple_sin(
+    x: torch.Tensor, y: list[torch.Tensor], z: torch.Tensor
+) -> torch.Tensor:
+    x_np = x.cpu().numpy()
+    y_np = [i.cpu().numpy() for i in y]
+    z_np = z.cpu().numpy()
+
+    out_np = np.sin(x_np) + np.sin(z_np) + sum(np.sin(i) for i in y_np)
+    return torch.from_numpy(out_np).to(device=x.device)
+
+
+def setup_tuple_context(ctx, inputs, output):
+    (x, y, z) = inputs
+    ctx.save_for_backward(x, y, z)
+
+
+def tuple_backward(ctx, grad):
+    (x, y, z) = ctx.saved_tensors
+    return grad * x.cos(), [grad * i.cos() for i in y], grad * z.cos()
+
+
+@numpy_tuple_sin.register_fake
+def _fw_tuple(x, y, z):
+    return torch.empty_like(x)
+
+
+torch.library.register_autograd(
+    "mylib::numpy_tuple_sin", tuple_backward, setup_context=setup_tuple_context
+)
+
+
+def manual_strategy(
+    op_schema: OpSchema, output_placement: list[Placement]
+) -> StrategyType:
+    select_strategy_x = op_schema.args_schema[0]
+    select_strategy_y = op_schema.args_schema[1]
+    assert isinstance(select_strategy_x, OpStrategy)
+    assert isinstance(select_strategy_y, OpStrategy)
+    new_placement = output_placement
+    new_input_specs = DTensorSpec(
+        mesh=select_strategy_x.mesh,
+        placements=tuple(new_placement),
+        tensor_meta=select_strategy_x.strategies[0].output_spec.tensor_meta,
+    )
+    output_spec = DTensorSpec(
+        mesh=select_strategy_x.mesh,
+        placements=tuple(new_placement),
+    )
+    output_strategy = OpStrategy([])
+    output_strategy.strategies.append(
+        OpSpec(
+            output_specs=output_spec,
+            input_specs=[new_input_specs, new_input_specs],
+            redistribute_cost=[
+                generate_redistribute_costs(select_strategy_x, new_input_specs),
+                generate_redistribute_costs(select_strategy_y, new_input_specs),
+            ],
+        )
+    )
+    return output_strategy
+
+
+@contextmanager
+def op_strategy_context(op_overload, strategy_func, schema_info=None):
+    """
+    Context manager for setting and clearing op strategies.
+    Args:
+        op_overload: The operator overload to set or clear the strategy for.
+        strategy_func: The strategy function to set for the operator overload.
+        schema_info: Optional schema information for the operator overload.
+    Yields:
+        None
+    """
+    propagator = DTensor._op_dispatcher.sharding_propagator
+    try:
+        # register the op strategy
+        register_op_strategy(op_overload, schema_info=schema_info)(strategy_func)
+        yield
+    finally:
+        # clear this op strategy cache
+        if op_overload in propagator.op_strategy_funcs:
+            del propagator.op_strategy_funcs[op_overload]
+        if op_overload in propagator.op_to_schema_info:
+            del propagator.op_to_schema_info[op_overload]
+        propagator.propagate_op_sharding.cache.cache_clear()
+
+
+def detect_exists_identical_opspec(*args, op, mesh, strategy_function) -> bool:
+    """
+    Given sample input args, detect if identical OpSpecs exists under the same
+    OpStrategy.
+
+    """
+    tree_args, args_spec = pytree.tree_flatten(args)
+    # metadata for each argument
+    arg_tensor_metadata = [extract_tensor_meta(i) for i in args]
+    # possible combination of placements for each arg
+    arg_placement_comb = []
+    for i in tree_args:
+        if isinstance(i, torch.Tensor):
+            # possible placement choice for argument i
+            placement_choices = (Replicate(), *[Shard(i) for i in range(i.ndim)])
+            # expand placement choice into full Placements for argument i
+            arg_placement_comb.append(
+                list(itertools.product(placement_choices, repeat=mesh.ndim))
+            )
+            random.shuffle(arg_placement_comb[-1])
+
+    arg_opspec_list = []
+    for idx, arg_placement in enumerate(arg_placement_comb):
+        arg_opspec_list.append([])
+        for placement in arg_placement:
+            arg_opspec_list[idx].append(
+                OpSpec(
+                    output_specs=DTensorSpec(
+                        mesh, placement, tensor_meta=arg_tensor_metadata[idx]
+                    )
+                )
+            )
+
+    op_schema = OpSchema(
+        op,
+        args_schema=(tuple(OpStrategy(i) for i in arg_opspec_list)),
+        kwargs_schema={},
+    )
+    with op_strategy_context(op, strategy_function):
+        output_strategy = strategy_function(op_schema)
+        # OpSpec doesn't have hashing, convert to str to compare
+        output_strategy_str_list = [
+            str(j)
+            for i in flatten_strategy_args([output_strategy])
+            for j in i.strategies
+        ]
+        return len(output_strategy_str_list) == len(set(output_strategy_str_list))
+
+
+class DistTensorReplicateStrategyRegistrationTest(DTensorTestBase):
+    @with_comms
+    def test_replicate_strategy_placement(self):
+        mesh = init_device_mesh(self.device_type, (2, self.world_size // 2))
+        test_op = torch.ops.mylib.numpy_sin
+        with op_strategy_context(test_op.default, replicate_op_strategy):
+            input_x = torch.randn([8, 16, 32], device=self.device_type)
+            input_y = torch.randn([8, 16, 32], device=self.device_type)
+            output = test_op(input_x, input_y)
+            input_x_dt = distribute_tensor(input_x, mesh, [Shard(0), Shard(1)])
+            input_y_dt = distribute_tensor(input_y, mesh, [Shard(0), Shard(1)])
+            output_dt = test_op(input_x_dt, input_y_dt)
+            self.assertEqual(output_dt.full_tensor(), output)
+            self.assertEqual(output_dt.placements, [Replicate(), Replicate()])
+
+    @with_comms
+    def test_no_identical_strategies(self):
+        # Test if there are any identical OpSpecs in the output strategy.
+        mesh = init_device_mesh(self.device_type, (2, self.world_size // 2))
+        test_op = torch.ops.mylib.numpy_sin
+        x = torch.randn([8, 16, 8], device=self.device_type)
+        y = torch.randn([8, 16, 8], device=self.device_type)
+        self.assertTrue(
+            detect_exists_identical_opspec(
+                x,
+                y,
+                op=test_op.default,
+                mesh=mesh,
+                strategy_function=replicate_op_strategy,
+            )
+        )
+
+    @with_comms
+    @patch(
+        "torch.distributed.tensor._sharding_prop.ShardingPropagator._select_strategy"
+    )
+    def test_replicate_strategy_cost(self, mock_select_strategy):
+        costs_from__select_strategy: list[float] = []
+
+        def mock_select_func(strategy):
+            """function copied from _select_strategy but with cost capturing"""
+            nonlocal costs_from__select_strategy
+            if len(strategy.strategies) == 1:
+                costs_from__select_strategy = strategy.strategies[0].redistribute_cost
+                return strategy.strategies[0]
+
+            op_spec_costs: list[float] = []
+            for op_spec in strategy.strategies:
+                assert op_spec.redistribute_cost is not None, (
+                    "must set redistribute cost each OpSpec!"
+                )
+                costs_from__select_strategy.append(op_spec.redistribute_cost)
+                redistribute_cost = sum(chain.from_iterable(op_spec.redistribute_cost))
+                op_spec_costs.append(redistribute_cost)
+            return strategy.strategies[op_spec_costs.index(min(op_spec_costs))]
+
+        mock_select_strategy.side_effect = mock_select_func
+        mesh = init_device_mesh(self.device_type, (2, self.world_size // 2))
+        test_op = torch.ops.mylib.numpy_sin
+        input_x = torch.randn([8, 16, 8], device=self.device_type)
+        input_y = torch.randn([8, 16, 8], device=self.device_type)
+        # manual write the strategy to force replicate placement
+        manual_replicated_strategy = functools.partial(
+            manual_strategy, output_placement=[Replicate(), Replicate()]
+        )
+        placement_choice_pool = [Replicate(), Shard(0), Shard(1)]
+        for shard_a in placement_choice_pool:
+            for shard_b in placement_choice_pool:
+                input_x_dt = distribute_tensor(input_x, mesh, [shard_a, shard_b])
+                input_y_dt = distribute_tensor(input_y, mesh, [shard_b, shard_a])
+                # generate expected cost from manual strategy:
+                costs_from__select_strategy.clear()
+                with op_strategy_context(test_op.default, manual_replicated_strategy):
+                    expect_output = test_op(input_x_dt, input_y_dt)
+                    expected_cost = deepcopy(costs_from__select_strategy)
+                # generate cost from default fallback strategy:
+                costs_from__select_strategy.clear()
+                with op_strategy_context(test_op.default, replicate_op_strategy):
+                    fallback_output = test_op(input_x_dt, input_y_dt)
+                    fallback_cost = deepcopy(costs_from__select_strategy)
+                self.assertEqual(
+                    expect_output.full_tensor(), fallback_output.full_tensor()
+                )
+                self.assertEqual(expected_cost, fallback_cost)
+
+    @with_comms
+    def test_tuple_replicate_strategy_placement(self):
+        mesh = init_device_mesh(self.device_type, (2, self.world_size // 2))
+        test_op = torch.ops.mylib.numpy_tuple_sin
+        with op_strategy_context(
+            test_op.default,
+            replicate_op_strategy,
+            schema_info=RuntimeSchemaInfo(needs_pytree=True),
+        ):
+            input_x = torch.randn([8, 16, 8], device=self.device_type)
+            input_y = [
+                torch.randn([8, 16, 8], device=self.device_type) for _ in range(3)
+            ]
+            input_z = torch.randn([8, 16, 8], device=self.device_type)
+            output = test_op(input_x, input_y, input_z)
+            input_x_dt = distribute_tensor(input_x, mesh, [Shard(0), Shard(1)])
+            input_y_dt = [
+                distribute_tensor(i, mesh, [Shard(1), Shard(1)]) for i in input_y
+            ]
+            input_z_dt = distribute_tensor(input_z, mesh, [Shard(1), Shard(0)])
+            output_dt = test_op(input_x_dt, input_y_dt, input_z_dt)
+            self.assertEqual(output_dt.full_tensor(), output)
+            self.assertEqual(output_dt.placements, [Replicate(), Replicate()])
 
 
 if __name__ == "__main__":

--- a/torch/distributed/tensor/_op_schema.py
+++ b/torch/distributed/tensor/_op_schema.py
@@ -13,9 +13,15 @@ from torch.distributed.tensor.placement_types import Placement
 
 
 try:
-    from torch.utils._cxx_pytree import tree_leaves, tree_map_only, TreeSpec
+    from torch.utils._cxx_pytree import (
+        register_pytree_node,
+        tree_leaves,
+        tree_map_only,
+        TreeSpec,
+    )
 except ImportError:
     from torch.utils._pytree import (  # type: ignore[no-redef, assignment]
+        register_pytree_node,
         tree_leaves,
         tree_map_only,
         TreeSpec,
@@ -217,6 +223,13 @@ class TupleStrategy(StrategyType):
         return f"TupleStrategy({child_strategies_str})"
 
 
+register_pytree_node(
+    TupleStrategy,
+    lambda node: (node.children, None),
+    lambda children, _: TupleStrategy(tuple(children)),
+)
+
+
 @dataclass
 class RuntimeSchemaInfo:
     """
@@ -282,15 +295,6 @@ class OpSchema:
         # filter out non-relevant values from args schema to get a clean OpStrategy list
         # separate with args_spec for the ease of type annotation
         # TODO: see if we should merge this with args_spec
-
-        # Need to be careful since args_schema can either be DTensorSpecs or
-        # OpStrategies. For now, we only support handling DTensorSpec because
-        # `tree_leaves`` doesn't need support flatten List[StrategyType] to
-        # OpStrategy.
-        if hasattr(self.args_schema, "__getitem__"):
-            assert not isinstance(self.args_schema[0], StrategyType)
-        else:
-            assert not isinstance(self.args_schema, StrategyType)
         args = (
             tree_leaves(self.args_schema)
             if self.schema_info is not None and self.schema_info.needs_pytree

--- a/torch/distributed/tensor/_op_schema.py
+++ b/torch/distributed/tensor/_op_schema.py
@@ -282,6 +282,15 @@ class OpSchema:
         # filter out non-relevant values from args schema to get a clean OpStrategy list
         # separate with args_spec for the ease of type annotation
         # TODO: see if we should merge this with args_spec
+
+        # Need to be careful since args_schema can either be DTensorSpecs or
+        # OpStrategies. For now, we only support handling DTensorSpec because
+        # `tree_leaves`` doesn't need support flatten List[StrategyType] to
+        # OpStrategy.
+        if hasattr(self.args_schema, "__getitem__"):
+            assert not isinstance(self.args_schema[0], StrategyType)
+        else:
+            assert not isinstance(self.args_schema, StrategyType)
         args = (
             tree_leaves(self.args_schema)
             if self.schema_info is not None and self.schema_info.needs_pytree

--- a/torch/distributed/tensor/_ops/utils.py
+++ b/torch/distributed/tensor/_ops/utils.py
@@ -20,7 +20,6 @@ from torch.distributed.tensor._op_schema import (
     PlacementList,
     RuntimeSchemaInfo,
     StrategyType,
-    TupleStrategy,
 )
 from torch.distributed.tensor.device_mesh import DeviceMesh
 from torch.distributed.tensor.placement_types import (
@@ -97,29 +96,11 @@ def register_op_strategy(
     return wrapper
 
 
-# Because TupleStrategy uses `children` attribute to build nested OpStrategy, we
-# use toy code to serve the purpose of tree_flatten.
-def flatten_strategy_args(args_strategy: list[StrategyType]) -> list[OpStrategy]:
-    def dfs(inner_strategy: StrategyType) -> list[OpStrategy]:
-        if isinstance(inner_strategy, OpStrategy):
-            return [inner_strategy]
-        elif isinstance(inner_strategy, TupleStrategy):
-            return list(
-                itertools.chain.from_iterable(dfs(s) for s in inner_strategy.children)
-            )
-        elif isinstance(inner_strategy, DTensorSpec):
-            raise RuntimeError("DTensorSpec should not be used in strategy")
-        else:
-            return []
-
-    return list(itertools.chain.from_iterable(dfs(s) for s in args_strategy))
-
-
 def replicate_op_strategy(op_schema: OpSchema) -> StrategyType:
     """
     Fallback strategy all use Replication()
     """
-    inputs_strategy = op_schema.args_schema
+    inputs_strategy = op_schema.args_strategy
     # TODO(zpcore): handle kwarg_inputs_strategy
     # kwarg_inputs_strategy = op_schema.kwargs_schema
     output_type = [str(ret.type) for ret in op_schema.op._schema.returns]
@@ -135,10 +116,9 @@ def replicate_op_strategy(op_schema: OpSchema) -> StrategyType:
             "because size of the list may depend on the op's input value"
         )
 
-    inputs_strategy_flatten = flatten_strategy_args(inputs_strategy)  # type: ignore[arg-type]
-    mesh = inputs_strategy_flatten[0].mesh
+    mesh = inputs_strategy[0].mesh
 
-    dim_sharding: PlacementList = [Replicate()] * (len(inputs_strategy_flatten) + 1)
+    dim_sharding: PlacementList = [Replicate()] * (len(inputs_strategy) + 1)
     single_dim_placement = [dim_sharding]
     return expand_to_full_mesh_op_strategy(mesh, op_schema, single_dim_placement)
 
@@ -337,9 +317,8 @@ def expand_to_full_mesh_op_strategy(
         input_specs: list[DTensorSpec] = [
             s for s in spec_list[input_index:] if isinstance(s, DTensorSpec)
         ]
-        # do not use op_schema.args_strategy because args_strategy won't be
-        # properly flatten when it contains TupleStrategy.
-        input_args_strategy = flatten_strategy_args(op_schema.args_schema)  # type: ignore[arg-type]
+
+        input_args_strategy = op_schema.args_strategy
         assert len(input_specs) == len(input_args_strategy)
         self_spec = input_args_strategy[0].strategies[0].output_spec
 

--- a/torch/distributed/tensor/_ops/utils.py
+++ b/torch/distributed/tensor/_ops/utils.py
@@ -19,6 +19,8 @@ from torch.distributed.tensor._op_schema import (
     OutputSharding,
     PlacementList,
     RuntimeSchemaInfo,
+    StrategyType,
+    TupleStrategy,
 )
 from torch.distributed.tensor.device_mesh import DeviceMesh
 from torch.distributed.tensor.placement_types import (
@@ -93,6 +95,52 @@ def register_op_strategy(
         return impl
 
     return wrapper
+
+
+# Because TupleStrategy uses `children` attribute to build nested OpStrategy, we
+# use toy code to serve the purpose of tree_flatten.
+def flatten_strategy_args(args_strategy: list[StrategyType]) -> list[OpStrategy]:
+    def dfs(inner_strategy: StrategyType) -> list[OpStrategy]:
+        if isinstance(inner_strategy, OpStrategy):
+            return [inner_strategy]
+        elif isinstance(inner_strategy, TupleStrategy):
+            return list(
+                itertools.chain.from_iterable(dfs(s) for s in inner_strategy.children)
+            )
+        elif isinstance(inner_strategy, DTensorSpec):
+            raise RuntimeError("DTensorSpec should not be used in strategy")
+        else:
+            return []
+
+    return list(itertools.chain.from_iterable(dfs(s) for s in args_strategy))
+
+
+def replicate_op_strategy(op_schema: OpSchema) -> StrategyType:
+    """
+    Fallback strategy all use Replication()
+    """
+    inputs_strategy = op_schema.args_schema
+    # TODO(zpcore): handle kwarg_inputs_strategy
+    # kwarg_inputs_strategy = op_schema.kwargs_schema
+    output_type = [str(ret.type) for ret in op_schema.op._schema.returns]
+    # TODO(zpcore): Confirm if view op can be handle properly or not. Prevent
+    # handling view ops until confirmed.
+    if op_schema.op.is_view:
+        raise RuntimeError(
+            "fallback strategy is unable to handle view ops until confirmed"
+        )
+    if "List[Tensor]" in output_type:
+        raise RuntimeError(
+            "fallback strategy is unable to handle ops with List[Tensor] output "
+            "because size of the list may depend on the op's input value"
+        )
+
+    inputs_strategy_flatten = flatten_strategy_args(inputs_strategy)  # type: ignore[arg-type]
+    mesh = inputs_strategy_flatten[0].mesh
+
+    dim_sharding: PlacementList = [Replicate()] * (len(inputs_strategy_flatten) + 1)
+    single_dim_placement = [dim_sharding]
+    return expand_to_full_mesh_op_strategy(mesh, op_schema, single_dim_placement)
 
 
 def as_list(
@@ -289,8 +337,9 @@ def expand_to_full_mesh_op_strategy(
         input_specs: list[DTensorSpec] = [
             s for s in spec_list[input_index:] if isinstance(s, DTensorSpec)
         ]
-
-        input_args_strategy = op_schema.args_strategy
+        # do not use op_schema.args_strategy because args_strategy won't be
+        # properly flatten when it contains TupleStrategy.
+        input_args_strategy = flatten_strategy_args(op_schema.args_schema)  # type: ignore[arg-type]
         assert len(input_specs) == len(input_args_strategy)
         self_spec = input_args_strategy[0].strategies[0].output_spec
 

--- a/torch/distributed/tensor/_sharding_prop.py
+++ b/torch/distributed/tensor/_sharding_prop.py
@@ -281,6 +281,7 @@ class ShardingPropagator:
         if op_schema.op in self.op_strategy_funcs:
             # wrap the op_schema with op strategy for sharding strategy propagation
             strategy_schema = self._wrap_with_op_strategy(op_schema)
+            strategy_schema.schema_info = op_schema.schema_info
 
             # run sharding strategy propagation/generation
             op_strategy = self.op_strategy_funcs[op_schema.op](strategy_schema)


### PR DESCRIPTION
Support implicit replication strategy registration.

To enable implicit strategy registration, call `implicit_strategy_context()` as below:
1. Use default replication strategy for all missing strategy ops:
```
with implicit_strategy_context():
    ...
```
2. Specify custom strategy as input for centain ops. Those strategies will be registered at runtime. Otherwise, default replication strategy will apply:
```
with implicit_strategy_context(
            [ OpStrategyPack(custom_op_1.default, custom_strategy_1, schema_info=None),
              OpStrategyPack(custom_op_2.default, custom_strategy_2, schema_info=None)
              ...]
        ):
    ...
```

Note for AutoParallel: I also split out the `try_propagate_implicit_strategy()` to help automatic register strategy if missing. We should replace all `torch.distributed.tensor.DTensor._op_dispatcher.sharding_propagator.op_strategy_funcs[op](op_schema)` with `torch.distributed.tensor.DTensor._op_dispatcher.sharding_propagator.try_propagate_implicit_strategy(op, op_schema)` to enable the feature. 

PR stack:
[2/N] support of replication fallback strategy https://github.com/pytorch/pytorch/pull/158476
[1/N] support of replication fallback strategy https://github.com/pytorch/pytorch/pull/158046

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci @fmassa 
