### PR TITLE
[aot] fix greater_than_max build fail on Windows.

### DIFF
--- a/c10/util/TypeSafeSignMath.h
+++ b/c10/util/TypeSafeSignMath.h
@@ -79,11 +79,7 @@ template <typename Limit, typename T>
 inline constexpr bool greater_than_max(const T& x) {
   constexpr bool can_overflow =
       std::numeric_limits<T>::digits > std::numeric_limits<Limit>::digits;
-#ifdef _WIN32
-  return can_overflow && x > std::numeric_limits<Limit>::max;
-#else
-  return can_overflow && x > std::numeric_limits<Limit>::max();
-#endif
+  return can_overflow && x > (std::numeric_limits<Limit>::max)();
 }
 
 #ifdef __GNUC__

--- a/c10/util/TypeSafeSignMath.h
+++ b/c10/util/TypeSafeSignMath.h
@@ -79,7 +79,11 @@ template <typename Limit, typename T>
 inline constexpr bool greater_than_max(const T& x) {
   constexpr bool can_overflow =
       std::numeric_limits<T>::digits > std::numeric_limits<Limit>::digits;
+#ifdef _WIN32
+  return can_overflow && x > std::numeric_limits<Limit>::max;
+#else
   return can_overflow && x > std::numeric_limits<Limit>::max();
+#endif
 }
 
 #ifdef __GNUC__


### PR DESCRIPTION
Error snapshot:
<img width="937" height="110" alt="image" src="https://github.com/user-attachments/assets/10195f84-83c4-42db-af3c-76f875a6a983" />

Reason:
`std::numeric_limits::max` is confilct to windef.h:`max(a, b)`

Fix code:
<img width="488" height="269" alt="image" src="https://github.com/user-attachments/assets/3328c37b-7c89-435e-944c-4ca7c9b6c5b6" />




cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10