### PR TITLE
[hop] set capture_scalar_outputs=True by default for compiled hops

### DIFF
--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -1409,7 +1409,6 @@ def forward(self, pred_1, x_1):
                 f, (torch.ones(3, 4, 5), torch.ones(4, 4, 5)), torch.ones(5)
             )
 
-    @torch._dynamo.config.patch(capture_scalar_outputs=True)
     def test_map_illegal_outputs(self):
         def f(x, y):
             return x.item()
@@ -7821,7 +7820,6 @@ class GraphModule(torch.nn.Module):
     @skipIfTorchDynamo("Skip because we're testing export")
     @parametrize("strict", [True, False])
     @parametrize("dynamic", [True, False])
-    @torch._dynamo.config.patch(capture_scalar_outputs=True)
     def test_while_loop_op_constant_and_symint_output_export(self, strict, dynamic):
         m, args = WHILE_LOOP_TESTS["const_and_symint_output"]
         dynamic_shapes = {"t": {0: torch.export.Dim("dim_t")}} if dynamic else None
@@ -7894,7 +7892,6 @@ class GraphModule(torch.nn.Module):
     @skipIfTorchDynamo("Graph is not captured correctly when test with dynamo")
     @parametrize("dynamic", [True, False])
     @parametrize("backend", ["eager", "aot_eager"])
-    @torch._dynamo.config.patch(capture_scalar_outputs=True)
     def test_while_loop_op_constant_and_symint_output_compile(self, dynamic, backend):
         m, args = WHILE_LOOP_TESTS["const_and_symint_output"]
         if backend == "eager":
@@ -8034,7 +8031,6 @@ class GraphModule(torch.nn.Module):
     @skipIfTorchDynamo("Graph is not captured correctly when test with dynamo")
     @parametrize("dynamic", [True, False])
     @parametrize("backend", ["eager", "aot_eager"])
-    @torch._dynamo.config.patch(capture_scalar_outputs=True)
     def test_while_loop_op_pytree_int_carry_compile(self, dynamic, backend):
         m, args = WHILE_LOOP_TESTS["pytree_int_carry"]
         if backend == "eager":
@@ -8196,7 +8192,6 @@ class GraphModule(torch.nn.Module):
         return normalize_gm(non_strict_ep.module().print_readable(print_output=False))
 
     @skipIfTorchDynamo("Skip because dynamo cannot trace torch.export.")
-    @torch._dynamo.config.patch(capture_scalar_outputs=True)
     def test_cond_eager_run_with_item(self):
         class M(torch.nn.Module):
             def forward(self, a, b1, b2, c):

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -7820,6 +7820,7 @@ class GraphModule(torch.nn.Module):
     @skipIfTorchDynamo("Skip because we're testing export")
     @parametrize("strict", [True, False])
     @parametrize("dynamic", [True, False])
+    @torch._dynamo.config.patch(capture_scalar_outputs=True)
     def test_while_loop_op_constant_and_symint_output_export(self, strict, dynamic):
         m, args = WHILE_LOOP_TESTS["const_and_symint_output"]
         dynamic_shapes = {"t": {0: torch.export.Dim("dim_t")}} if dynamic else None
@@ -7892,6 +7893,7 @@ class GraphModule(torch.nn.Module):
     @skipIfTorchDynamo("Graph is not captured correctly when test with dynamo")
     @parametrize("dynamic", [True, False])
     @parametrize("backend", ["eager", "aot_eager"])
+    @torch._dynamo.config.patch(capture_scalar_outputs=True)
     def test_while_loop_op_constant_and_symint_output_compile(self, dynamic, backend):
         m, args = WHILE_LOOP_TESTS["const_and_symint_output"]
         if backend == "eager":

--- a/test/inductor/test_control_flow.py
+++ b/test/inductor/test_control_flow.py
@@ -315,7 +315,6 @@ class CondTests(TestCase):
     @requires_gpu
     @parametrize("device", ["cpu", GPU_TYPE])
     @parametrize("dynamic", [False, True])
-    @torch._dynamo.config.patch("capture_scalar_outputs", True)
     def test_cond_unbacked_symint_closure(self, device, dynamic):
         self._run_test(
             model=CondModels.UnbackedSymIntClosure(),
@@ -1203,7 +1202,6 @@ class WhileLoopTests(TestCase):
         with torch._dynamo.config.patch(
             {
                 "capture_dynamic_output_shape_ops": True,
-                "capture_scalar_outputs": True,
             }
         ):
             self._run_test(
@@ -1272,9 +1270,7 @@ class WhileLoopTests(TestCase):
     @requires_gpu
     @parametrize("device", ["cpu", GPU_TYPE])
     @parametrize("dynamic", [True, False])
-    @torch._dynamo.config.patch(
-        {"capture_scalar_outputs": True, "capture_dynamic_output_shape_ops": True}
-    )
+    @torch._dynamo.config.patch({"capture_dynamic_output_shape_ops": True})
     def test_while_loop_with_unbacked_symint_closure(self, device, dynamic):
         self._run_test(
             model=WhileLoopModels.UnbackedSymIntClosure(),
@@ -1318,9 +1314,7 @@ class WhileLoopTests(TestCase):
     @requires_gpu
     @parametrize("device", ["cpu", GPU_TYPE])
     @parametrize("dynamic", [True, False])
-    @torch._dynamo.config.patch(
-        {"capture_scalar_outputs": True, "capture_dynamic_output_shape_ops": True}
-    )
+    @torch._dynamo.config.patch({"capture_dynamic_output_shape_ops": True})
     def test_while_loop_with_sym_expr_cond(self, device, dynamic):
         self._run_test(
             model=WhileLoopModels.SymExprCond(),
@@ -1751,7 +1745,6 @@ class ScanTests(TestCase):
     @parametrize("dynamic", [True, False])
     @parametrize("reverse", [True, False])
     @parametrize("dim", [0, 1, 2])
-    @torch._dynamo.config.patch("capture_scalar_outputs", True)
     def test_scan_pytree_in_out(self, device, dynamic, reverse, dim):
         self._run_test(
             model=ScanModels.SimpleWithPytreeInOuts(reverse=reverse, dim=dim),
@@ -1770,7 +1763,6 @@ class ScanTests(TestCase):
     @parametrize("reverse", [True, False])
     @parametrize("dim", [0, 1, 3])
     @parametrize("scan_length", [1, 5])
-    @torch._dynamo.config.patch("capture_scalar_outputs", True)
     def test_scan_nn_modules(self, device, dynamic, reverse, dim, scan_length):
         init = torch.randn(20, 16, 4, 4)
         xs = torch.randn(scan_length, 20, 16, 4, 4)
@@ -1791,7 +1783,6 @@ class ScanTests(TestCase):
     @parametrize("reverse", [True, False])
     @parametrize("dim", [0, 1, 3])
     @parametrize("scan_length", [1, 5])
-    @torch._dynamo.config.patch("capture_scalar_outputs", True)
     def test_scan_conv(self, device, dynamic, reverse, dim, scan_length):
         init = torch.randn(2, 4, 4, 4, dtype=torch.float64)
         xs = torch.randn(scan_length, 2, 4, 4, 4, dtype=torch.float64)
@@ -1813,7 +1804,6 @@ class ScanTests(TestCase):
     @parametrize("dim", [0, 1, 3])
     @parametrize("pred", [True, False])
     @parametrize("scan_length", [1, 5])
-    @torch._dynamo.config.patch("capture_scalar_outputs", True)
     def test_scan_in_cond(self, device, dynamic, reverse, dim, pred, scan_length):
         init = torch.randn(4, 4, 4)
         xs = torch.randn(scan_length, 4, 4, 4)
@@ -1835,7 +1825,6 @@ class ScanTests(TestCase):
     @parametrize("reverse", [True, False])
     @parametrize("dim", [0, 1, 3])
     @parametrize("scan_length", [1, 5])
-    @torch._dynamo.config.patch("capture_scalar_outputs", True)
     def test_cond_in_scan(self, device, dynamic, reverse, dim, scan_length):
         init = torch.randn(2, 4, 4, 4)
         xs = torch.randn(scan_length, 4, 4, 4)
@@ -1853,7 +1842,6 @@ class ScanTests(TestCase):
     @requires_gpu
     @parametrize("device", ["cpu", GPU_TYPE])
     @parametrize("dynamic", [True, False])
-    @torch._dynamo.config.patch("capture_scalar_outputs", True)
     def test_scan_chunked_ce(self, device, dynamic):
         self._run_test(
             model=ScanModels.ChunkedCE(10),
@@ -1870,7 +1858,6 @@ class ScanTests(TestCase):
     @requires_gpu
     @parametrize("device", ["cpu", GPU_TYPE])
     @parametrize("dynamic", [True, False])
-    @torch._dynamo.config.patch("capture_scalar_outputs", True)
     def test_scan_compare_chunked_ce_with_no_scan(self, device, dynamic):
         for trunk_size, B, T in zip([10, 20], [10, 100], [20, 40]):
             self._compare_result(
@@ -1888,7 +1875,6 @@ class ScanTests(TestCase):
     @requires_gpu
     @parametrize("device", ["cpu", GPU_TYPE])
     @parametrize("dynamic", [True, False])
-    @torch._dynamo.config.patch("capture_scalar_outputs", True)
     def test_scan_with_clamp(self, device, dynamic):
         B = 4
         T = 8
@@ -1993,7 +1979,6 @@ class MapTests(TestCase):
     @requires_gpu
     @parametrize("device", ["cpu", GPU_TYPE])
     @parametrize("dynamic", [True, False])
-    @torch._dynamo.config.patch("capture_scalar_outputs", True)
     def test_map_simple(self, device, dynamic):
         self._run_test(
             model=MapModels.Simple(),
@@ -2005,7 +1990,6 @@ class MapTests(TestCase):
     @requires_gpu
     @parametrize("device", ["cpu", GPU_TYPE])
     @parametrize("dynamic", [True, False])
-    @torch._dynamo.config.patch("capture_scalar_outputs", True)
     def test_map_simple_linear_with_view(self, device, dynamic):
         self._run_test(
             model=MapModels.SimpleWithLinearWithView(),
@@ -2017,7 +2001,6 @@ class MapTests(TestCase):
     @requires_gpu
     @parametrize("device", ["cpu", GPU_TYPE])
     @parametrize("dynamic", [True, False])
-    @torch._dynamo.config.patch("capture_scalar_outputs", True)
     def test_map_pytree_in_out(self, device, dynamic):
         self._run_test(
             model=MapModels.PytreeInOut(),
@@ -2033,7 +2016,6 @@ class MapTests(TestCase):
     @requires_gpu
     @parametrize("device", ["cpu", GPU_TYPE])
     @parametrize("dynamic", [True, False])
-    @torch._dynamo.config.patch("capture_scalar_outputs", True)
     def test_map_nested_with_cond(self, device, dynamic):
         self._run_test(
             model=MapModels.NestedWithCond(),

--- a/test/inductor/test_control_flow.py
+++ b/test/inductor/test_control_flow.py
@@ -315,6 +315,7 @@ class CondTests(TestCase):
     @requires_gpu
     @parametrize("device", ["cpu", GPU_TYPE])
     @parametrize("dynamic", [False, True])
+    @torch._dynamo.config.patch("capture_scalar_outputs", True)
     def test_cond_unbacked_symint_closure(self, device, dynamic):
         self._run_test(
             model=CondModels.UnbackedSymIntClosure(),

--- a/test/inductor/test_control_flow.py
+++ b/test/inductor/test_control_flow.py
@@ -1203,6 +1203,7 @@ class WhileLoopTests(TestCase):
         with torch._dynamo.config.patch(
             {
                 "capture_dynamic_output_shape_ops": True,
+                "capture_scalar_outputs": True,
             }
         ):
             self._run_test(
@@ -1271,7 +1272,9 @@ class WhileLoopTests(TestCase):
     @requires_gpu
     @parametrize("device", ["cpu", GPU_TYPE])
     @parametrize("dynamic", [True, False])
-    @torch._dynamo.config.patch({"capture_dynamic_output_shape_ops": True})
+    @torch._dynamo.config.patch(
+        {"capture_scalar_outputs": True, "capture_dynamic_output_shape_ops": True}
+    )
     def test_while_loop_with_unbacked_symint_closure(self, device, dynamic):
         self._run_test(
             model=WhileLoopModels.UnbackedSymIntClosure(),
@@ -1315,7 +1318,9 @@ class WhileLoopTests(TestCase):
     @requires_gpu
     @parametrize("device", ["cpu", GPU_TYPE])
     @parametrize("dynamic", [True, False])
-    @torch._dynamo.config.patch({"capture_dynamic_output_shape_ops": True})
+    @torch._dynamo.config.patch(
+        {"capture_scalar_outputs": True, "capture_dynamic_output_shape_ops": True}
+    )
     def test_while_loop_with_sym_expr_cond(self, device, dynamic):
         self._run_test(
             model=WhileLoopModels.SymExprCond(),
@@ -1746,6 +1751,7 @@ class ScanTests(TestCase):
     @parametrize("dynamic", [True, False])
     @parametrize("reverse", [True, False])
     @parametrize("dim", [0, 1, 2])
+    @torch._dynamo.config.patch("capture_scalar_outputs", True)
     def test_scan_pytree_in_out(self, device, dynamic, reverse, dim):
         self._run_test(
             model=ScanModels.SimpleWithPytreeInOuts(reverse=reverse, dim=dim),
@@ -1764,6 +1770,7 @@ class ScanTests(TestCase):
     @parametrize("reverse", [True, False])
     @parametrize("dim", [0, 1, 3])
     @parametrize("scan_length", [1, 5])
+    @torch._dynamo.config.patch("capture_scalar_outputs", True)
     def test_scan_nn_modules(self, device, dynamic, reverse, dim, scan_length):
         init = torch.randn(20, 16, 4, 4)
         xs = torch.randn(scan_length, 20, 16, 4, 4)
@@ -1784,6 +1791,7 @@ class ScanTests(TestCase):
     @parametrize("reverse", [True, False])
     @parametrize("dim", [0, 1, 3])
     @parametrize("scan_length", [1, 5])
+    @torch._dynamo.config.patch("capture_scalar_outputs", True)
     def test_scan_conv(self, device, dynamic, reverse, dim, scan_length):
         init = torch.randn(2, 4, 4, 4, dtype=torch.float64)
         xs = torch.randn(scan_length, 2, 4, 4, 4, dtype=torch.float64)
@@ -1805,6 +1813,7 @@ class ScanTests(TestCase):
     @parametrize("dim", [0, 1, 3])
     @parametrize("pred", [True, False])
     @parametrize("scan_length", [1, 5])
+    @torch._dynamo.config.patch("capture_scalar_outputs", True)
     def test_scan_in_cond(self, device, dynamic, reverse, dim, pred, scan_length):
         init = torch.randn(4, 4, 4)
         xs = torch.randn(scan_length, 4, 4, 4)
@@ -1826,6 +1835,7 @@ class ScanTests(TestCase):
     @parametrize("reverse", [True, False])
     @parametrize("dim", [0, 1, 3])
     @parametrize("scan_length", [1, 5])
+    @torch._dynamo.config.patch("capture_scalar_outputs", True)
     def test_cond_in_scan(self, device, dynamic, reverse, dim, scan_length):
         init = torch.randn(2, 4, 4, 4)
         xs = torch.randn(scan_length, 4, 4, 4)
@@ -1843,6 +1853,7 @@ class ScanTests(TestCase):
     @requires_gpu
     @parametrize("device", ["cpu", GPU_TYPE])
     @parametrize("dynamic", [True, False])
+    @torch._dynamo.config.patch("capture_scalar_outputs", True)
     def test_scan_chunked_ce(self, device, dynamic):
         self._run_test(
             model=ScanModels.ChunkedCE(10),
@@ -1859,6 +1870,7 @@ class ScanTests(TestCase):
     @requires_gpu
     @parametrize("device", ["cpu", GPU_TYPE])
     @parametrize("dynamic", [True, False])
+    @torch._dynamo.config.patch("capture_scalar_outputs", True)
     def test_scan_compare_chunked_ce_with_no_scan(self, device, dynamic):
         for trunk_size, B, T in zip([10, 20], [10, 100], [20, 40]):
             self._compare_result(
@@ -1876,6 +1888,7 @@ class ScanTests(TestCase):
     @requires_gpu
     @parametrize("device", ["cpu", GPU_TYPE])
     @parametrize("dynamic", [True, False])
+    @torch._dynamo.config.patch("capture_scalar_outputs", True)
     def test_scan_with_clamp(self, device, dynamic):
         B = 4
         T = 8
@@ -1980,6 +1993,7 @@ class MapTests(TestCase):
     @requires_gpu
     @parametrize("device", ["cpu", GPU_TYPE])
     @parametrize("dynamic", [True, False])
+    @torch._dynamo.config.patch("capture_scalar_outputs", True)
     def test_map_simple(self, device, dynamic):
         self._run_test(
             model=MapModels.Simple(),
@@ -1991,6 +2005,7 @@ class MapTests(TestCase):
     @requires_gpu
     @parametrize("device", ["cpu", GPU_TYPE])
     @parametrize("dynamic", [True, False])
+    @torch._dynamo.config.patch("capture_scalar_outputs", True)
     def test_map_simple_linear_with_view(self, device, dynamic):
         self._run_test(
             model=MapModels.SimpleWithLinearWithView(),
@@ -2002,6 +2017,7 @@ class MapTests(TestCase):
     @requires_gpu
     @parametrize("device", ["cpu", GPU_TYPE])
     @parametrize("dynamic", [True, False])
+    @torch._dynamo.config.patch("capture_scalar_outputs", True)
     def test_map_pytree_in_out(self, device, dynamic):
         self._run_test(
             model=MapModels.PytreeInOut(),
@@ -2017,6 +2033,7 @@ class MapTests(TestCase):
     @requires_gpu
     @parametrize("device", ["cpu", GPU_TYPE])
     @parametrize("dynamic", [True, False])
+    @torch._dynamo.config.patch("capture_scalar_outputs", True)
     def test_map_nested_with_cond(self, device, dynamic):
         self._run_test(
             model=MapModels.NestedWithCond(),

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -236,6 +236,7 @@ def check_meta_consistency(
 def _set_compilation_env():
     _old_is_tracing = torch.fx._symbolic_trace._is_fx_tracing_flag
     _old_allow_empty_graphs = torch._dynamo.config.allow_empty_graphs
+    _old_capture_scalar_outputs = torch._dynamo.config.capture_scalar_outputs
     # The issue is tracked in https://github.com/pytorch/pytorch/issues/144360: when dynamo finds
     # the top-level frame produces no graph, the default behavior is to fallback to eager.
     # Then when it encounters an inner function, it will try to trace that function again, which is unnecessary.
@@ -249,10 +250,12 @@ def _set_compilation_env():
         # once we are confident fx tracing works with dynamo.
         torch.fx._symbolic_trace._is_fx_tracing_flag = False
         torch._dynamo.config.allow_empty_graphs = True
+        torch._dynamo.config.capture_scalar_outputs = True
         yield
     finally:
         torch.fx._symbolic_trace._is_fx_tracing_flag = _old_is_tracing
         torch._dynamo.config.allow_empty_graphs = _old_allow_empty_graphs
+        torch._dynamo.config.capture_scalar_outputs = _old_capture_scalar_outputs
 
 
 # The invariant here is that we always trace the branch with fake tensor


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #158480

We want to do it for two reasons:
1. It's tedious for users to manually turn on capture_scalar_outputs=True when compiling map and scan with inductor, where we decomposing them into while_loop and use the idx tensor.item() to select a slice of output buffer and write into it. This pr turns on the flag by default.
2. a graph break caused by capture_scalar_outputs=False would cause the hop to fail, and we should turn it on by default so that the error message is more meaningful.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben