### PR TITLE
[Fix] Rework CUDA error explanation framework to be less destructive …

### DIFF
--- a/c10/cuda/CUDAException.cpp
+++ b/c10/cuda/CUDAException.cpp
@@ -30,7 +30,8 @@ void c10_cuda_check_implementation(
   check_message.append("CUDA error: ");
   const char* error_string = cudaGetErrorString(cuda_error);
   check_message.append(error_string);
-  check_message.append(c10::cuda::get_cuda_check_suffix(error_string));
+  check_message.append(c10::cuda::get_cuda_error_help(error_string));
+  check_message.append(c10::cuda::get_cuda_check_suffix());
   check_message.append("\n");
   if (include_device_assertions) {
     check_message.append(c10_retrieve_device_side_assertion_info());

--- a/c10/cuda/CUDAMiscFunctions.cpp
+++ b/c10/cuda/CUDAMiscFunctions.cpp
@@ -1,31 +1,34 @@
 #include <c10/cuda/CUDAMiscFunctions.h>
 #include <c10/util/env.h>
 #include <cstring>
-#include <iostream>
 #include <string>
 
 namespace c10::cuda {
 
+// Explain common CUDA errors
 // NOLINTNEXTLINE(bugprone-exception-escape,-warnings-as-errors)
-std::string get_cuda_check_suffix(const char* error_string) noexcept {
-  std::string suffix;
-
-  // Explain common CUDA errors
+std::string get_cuda_error_help(const char* error_string) noexcept {
+  std::string help_text;
   if (strstr(error_string, "invalid device ordinal")) {
-    suffix.append("\nGPU device may be out of range, do you have enough GPUs?");
+    help_text.append(
+        "\nGPU device may be out of range, do you have enough GPUs?");
   }
+  return help_text;
+}
 
+// NOLINTNEXTLINE(bugprone-exception-escape,-warnings-as-errors)
+const char* get_cuda_check_suffix() noexcept {
   static auto device_blocking_flag =
       c10::utils::check_env("CUDA_LAUNCH_BLOCKING");
   static bool blocking_enabled =
       (device_blocking_flag.has_value() && device_blocking_flag.value());
-  if (!blocking_enabled) {
-    suffix.append(
-        "\nCUDA kernel errors might be asynchronously reported at some"
-        " other API call, so the stacktrace below might be incorrect."
-        "\nFor debugging consider passing CUDA_LAUNCH_BLOCKING=1");
+  if (blocking_enabled) {
+    return "";
+  } else {
+    return "\nCUDA kernel errors might be asynchronously reported at some"
+           " other API call, so the stacktrace below might be incorrect."
+           "\nFor debugging consider passing CUDA_LAUNCH_BLOCKING=1";
   }
-  return suffix;
 }
 std::mutex* getFreeMutex() {
   static std::mutex cuda_free_mutex;

--- a/c10/cuda/CUDAMiscFunctions.h
+++ b/c10/cuda/CUDAMiscFunctions.h
@@ -8,6 +8,7 @@
 #include <string>
 
 namespace c10::cuda {
-C10_CUDA_API std::string get_cuda_check_suffix(const char*) noexcept;
+C10_CUDA_API std::string get_cuda_error_help(const char*) noexcept;
+C10_CUDA_API const char* get_cuda_check_suffix() noexcept;
 C10_CUDA_API std::mutex* getFreeMutex();
 } // namespace c10::cuda


### PR DESCRIPTION
…in fbsource

Fix-forward for #158395

Added `std::string c10::cuda::get_cuda_error_help(const char* error_string)` to provide a framework for appending clarifying messages to CUDA errors.

cc @ptrblck @msaroufim @eqy @jerryzh168