### PR TITLE
[ROCm] delete un-needed workaround for tensor.item()

### DIFF
--- a/aten/src/ATen/native/cuda/CUDAScalar.cu
+++ b/aten/src/ATen/native/cuda/CUDAScalar.cu
@@ -11,25 +11,11 @@
 
 #include <ATen/cuda/CUDAContext.h>
 
-#if defined(USE_ROCM)
-// TODO(lufang): Tensor.item() on AMD HIP is not synced in the Recsys models.
-// This is just a short term workaround. Issue is tracked as FBA-388 on the AMD side.
-namespace {
-  bool use_sync_mode() {
-    static const bool sync_mode = c10::utils::check_env("HIP_DOUBLE_SYNC_ON_LOCAL_SCALE_DENSE") == true;
-    return sync_mode;
-  }
-}
-#endif
-
 namespace at::native {
 
 Scalar _local_scalar_dense_cuda(const Tensor& self) {
   Scalar r;
   TORCH_CHECK(self.numel() > 0, "_local_scalar_dense: Empty tensor not supported");
-#if defined(USE_ROCM)
-  if (!use_sync_mode()){
-#endif
     AT_DISPATCH_V2(
       self.scalar_type(), "_local_scalar_dense_cuda", AT_WRAP([&] {
           // Create pinned memory for the scalar value to avoid implicit
@@ -46,15 +32,6 @@ Scalar _local_scalar_dense_cuda(const Tensor& self) {
           at::cuda::memcpy_and_sync((void *)value.const_data_ptr<scalar_t>(), self.const_data_ptr<scalar_t>(), sizeof(scalar_t), cudaMemcpyDeviceToHost, stream);
           r = Scalar(*value.const_data_ptr<scalar_t>());
         }), AT_EXPAND(AT_ALL_TYPES_AND_COMPLEX), kComplexHalf, kHalf, kBool, kBFloat16, AT_EXPAND(AT_FLOAT8_TYPES), AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES));
-#if defined(USE_ROCM)
-  } else {
-    auto cpu_self = self.cpu();
-    AT_DISPATCH_V2(
-      self.scalar_type(), "_local_scalar_dense_hip", AT_WRAP([&] {
-          r = Scalar(*cpu_self.const_data_ptr<scalar_t>());
-        }), AT_EXPAND(AT_ALL_TYPES_AND_COMPLEX), kComplexHalf, kHalf, kBool, kBFloat16, AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES));
-  }
-#endif
   return r;
 }
 


### PR DESCRIPTION
Deleting unused workaround per discussion here:
https://github.com/pytorch/pytorch/pull/158165#discussion_r2207968880



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang