### PR TITLE
Use new type statement to fix public API of types

### DIFF
--- a/torch/ao/quantization/__init__.py
+++ b/torch/ao/quantization/__init__.py
@@ -37,7 +37,8 @@ if sys.version_info < (3, 12):
     ObserverOrFakeQuantize = Union[ObserverBase, FakeQuantizeBase]
     ObserverOrFakeQuantize.__module__ = "torch.ao.quantization"
 else:
-    type ObserverOrFakeQuantize = Union[ObserverBase, FakeQuantizeBase]
+    from typing import TypeAliasType
+    ObserverOrFakeQuantize = TypeAliasType(Union[ObserverBase, FakeQuantizeBase])
 
 for _f in [
     compare_results,

--- a/torch/ao/quantization/__init__.py
+++ b/torch/ao/quantization/__init__.py
@@ -38,7 +38,10 @@ if sys.version_info < (3, 12):
     ObserverOrFakeQuantize.__module__ = "torch.ao.quantization"
 else:
     from typing import TypeAliasType
-    ObserverOrFakeQuantize = TypeAliasType("ObserverOrFakeQuantize", Union[ObserverBase, FakeQuantizeBase])
+
+    ObserverOrFakeQuantize = TypeAliasType(
+        "ObserverOrFakeQuantize", Union[ObserverBase, FakeQuantizeBase]
+    )
 
 for _f in [
     compare_results,

--- a/torch/ao/quantization/__init__.py
+++ b/torch/ao/quantization/__init__.py
@@ -33,9 +33,11 @@ from .stubs import *  # noqa: F403
 
 
 # ensure __module__ is set correctly for public APIs
-ObserverOrFakeQuantize = Union[ObserverBase, FakeQuantizeBase]
-if sys.version_info < (3, 14):
+if sys.version_info < (3, 12):
+    ObserverOrFakeQuantize = Union[ObserverBase, FakeQuantizeBase]
     ObserverOrFakeQuantize.__module__ = "torch.ao.quantization"
+else:
+    type ObserverOrFakeQuantize = Union[ObserverBase, FakeQuantizeBase]
 
 for _f in [
     compare_results,

--- a/torch/ao/quantization/__init__.py
+++ b/torch/ao/quantization/__init__.py
@@ -38,7 +38,7 @@ if sys.version_info < (3, 12):
     ObserverOrFakeQuantize.__module__ = "torch.ao.quantization"
 else:
     from typing import TypeAliasType
-    ObserverOrFakeQuantize = TypeAliasType(Union[ObserverBase, FakeQuantizeBase])
+    ObserverOrFakeQuantize = TypeAliasType("ObserverOrFakeQuantize", Union[ObserverBase, FakeQuantizeBase])
 
 for _f in [
     compare_results,

--- a/torch/ao/quantization/qconfig.py
+++ b/torch/ao/quantization/qconfig.py
@@ -573,6 +573,7 @@ if sys.version_info < (3, 12):
     QConfigAny.__module__ = "torch.ao.quantization.qconfig"
 else:
     from typing import TypeAliasType
+
     QConfigAny = TypeAliasType("QConfigAny", Optional[QConfig])
 
 

--- a/torch/ao/quantization/qconfig.py
+++ b/torch/ao/quantization/qconfig.py
@@ -568,9 +568,11 @@ def _assert_valid_qconfig(qconfig: Optional[QConfig], mod: torch.nn.Module) -> N
         )
 
 
-QConfigAny = Optional[QConfig]
-if sys.version_info < (3, 14):
+if sys.version_info < (3, 12):
+    QConfigAny = Optional[QConfig]
     QConfigAny.__module__ = "torch.ao.quantization.qconfig"
+else:
+    type QConfigAny = Optional[QConfig]
 
 
 def _add_module_to_qconfig_obs_ctr(

--- a/torch/ao/quantization/qconfig.py
+++ b/torch/ao/quantization/qconfig.py
@@ -572,7 +572,8 @@ if sys.version_info < (3, 12):
     QConfigAny = Optional[QConfig]
     QConfigAny.__module__ = "torch.ao.quantization.qconfig"
 else:
-    type QConfigAny = Optional[QConfig]
+    from typing import TypeAliasType
+    QConfigAny = TypeAliasType(Optional[QConfig])
 
 
 def _add_module_to_qconfig_obs_ctr(

--- a/torch/ao/quantization/qconfig.py
+++ b/torch/ao/quantization/qconfig.py
@@ -573,7 +573,7 @@ if sys.version_info < (3, 12):
     QConfigAny.__module__ = "torch.ao.quantization.qconfig"
 else:
     from typing import TypeAliasType
-    QConfigAny = TypeAliasType(Optional[QConfig])
+    QConfigAny = TypeAliasType("QConfigAny", Optional[QConfig])
 
 
 def _add_module_to_qconfig_obs_ctr(

--- a/torch/ao/quantization/utils.py
+++ b/torch/ao/quantization/utils.py
@@ -43,7 +43,7 @@ if sys.version_info < (3, 12):
         Callable,
         tuple[Callable, Callable],
         tuple[Callable, tuple[Callable, Callable]],
-        Any
+        Any,
     ]
     Pattern.__module__ = "torch.ao.quantization.utils"
 else:
@@ -55,7 +55,7 @@ else:
             Callable,
             tuple[Callable, Callable],
             tuple[Callable, tuple[Callable, Callable]],
-            Any
+            Any,
         ],
     )
 

--- a/torch/ao/quantization/utils.py
+++ b/torch/ao/quantization/utils.py
@@ -21,9 +21,9 @@ if sys.version_info < (3, 12):
     NodePattern.__module__ = "torch.ao.quantization.utils"
 else:
     from typing import TypeAliasType
+
     NodePattern = TypeAliasType(
-        "NodePattern",
-        Union[tuple[Node, Node], tuple[Node, tuple[Node, Node]], Any]
+        "NodePattern", Union[tuple[Node, Node], tuple[Node, tuple[Node, Node]], Any]
     )
 
 
@@ -40,15 +40,24 @@ QuantizerCls = Any
 
 if sys.version_info < (3, 12):
     Pattern = Union[
-        Callable, tuple[Callable, Callable], tuple[Callable, tuple[Callable, Callable]], Any
+        Callable,
+        tuple[Callable, Callable],
+        tuple[Callable, tuple[Callable, Callable]],
+        Any
     ]
     Pattern.__module__ = "torch.ao.quantization.utils"
 else:
     from typing import TypeAliasType
+
     Pattern = TypeAliasType(
-        "Pattern", Union[
-        Callable, tuple[Callable, Callable], tuple[Callable, tuple[Callable, Callable]], Any
-    ])
+        "Pattern",
+        Union[
+            Callable,
+            tuple[Callable, Callable],
+            tuple[Callable, tuple[Callable, Callable]],
+            Any
+        ],
+    )
 
 
 # TODO: maybe rename this to MatchInputNode

--- a/torch/ao/quantization/utils.py
+++ b/torch/ao/quantization/utils.py
@@ -21,7 +21,7 @@ if sys.version_info < (3, 12):
     NodePattern.__module__ = "torch.ao.quantization.utils"
 else:
     from typing import TypeAliasType
-    NodePattern = TypeAliasType(Union[tuple[Node, Node], tuple[Node, tuple[Node, Node]], Any])
+    NodePattern = TypeAliasType("NodePattern", Union[tuple[Node, Node], tuple[Node, tuple[Node, Node]], Any])
 
 
 # This is the Quantizer class instance from torch/quantization/fx/quantize.py.
@@ -42,7 +42,7 @@ if sys.version_info < (3, 12):
     Pattern.__module__ = "torch.ao.quantization.utils"
 else:
     from typing import TypeAliasType
-    Pattern = TypeAliasType(Union[
+    Pattern = TypeAliasType("Pattern", Union[
         Callable, tuple[Callable, Callable], tuple[Callable, tuple[Callable, Callable]], Any
     ])
 

--- a/torch/ao/quantization/utils.py
+++ b/torch/ao/quantization/utils.py
@@ -20,7 +20,8 @@ if sys.version_info < (3, 12):
     NodePattern = Union[tuple[Node, Node], tuple[Node, tuple[Node, Node]], Any]
     NodePattern.__module__ = "torch.ao.quantization.utils"
 else:
-    type NodePattern = Union[tuple[Node, Node], tuple[Node, tuple[Node, Node]], Any]
+    from typing import TypeAliasType
+    NodePattern = TypeAliasType(Union[tuple[Node, Node], tuple[Node, tuple[Node, Node]], Any])
 
 
 # This is the Quantizer class instance from torch/quantization/fx/quantize.py.
@@ -40,9 +41,10 @@ if sys.version_info < (3, 12):
     ]
     Pattern.__module__ = "torch.ao.quantization.utils"
 else:
-    type Pattern = Union[
+    from typing import TypeAliasType
+    Pattern = TypeAliasType(Union[
         Callable, tuple[Callable, Callable], tuple[Callable, tuple[Callable, Callable]], Any
-    ]
+    ])
 
 
 # TODO: maybe rename this to MatchInputNode

--- a/torch/ao/quantization/utils.py
+++ b/torch/ao/quantization/utils.py
@@ -21,7 +21,10 @@ if sys.version_info < (3, 12):
     NodePattern.__module__ = "torch.ao.quantization.utils"
 else:
     from typing import TypeAliasType
-    NodePattern = TypeAliasType("NodePattern", Union[tuple[Node, Node], tuple[Node, tuple[Node, Node]], Any])
+    NodePattern = TypeAliasType(
+        "NodePattern",
+        Union[tuple[Node, Node], tuple[Node, tuple[Node, Node]], Any]
+    )
 
 
 # This is the Quantizer class instance from torch/quantization/fx/quantize.py.
@@ -42,7 +45,8 @@ if sys.version_info < (3, 12):
     Pattern.__module__ = "torch.ao.quantization.utils"
 else:
     from typing import TypeAliasType
-    Pattern = TypeAliasType("Pattern", Union[
+    Pattern = TypeAliasType(
+        "Pattern", Union[
         Callable, tuple[Callable, Callable], tuple[Callable, tuple[Callable, Callable]], Any
     ])
 

--- a/torch/ao/quantization/utils.py
+++ b/torch/ao/quantization/utils.py
@@ -16,9 +16,12 @@ from torch.fx import Node
 from torch.nn.utils.parametrize import is_parametrized
 
 
-NodePattern = Union[tuple[Node, Node], tuple[Node, tuple[Node, Node]], Any]
-if sys.version_info < (3, 14):
+if sys.version_info < (3, 12):
+    NodePattern = Union[tuple[Node, Node], tuple[Node, tuple[Node, Node]], Any]
     NodePattern.__module__ = "torch.ao.quantization.utils"
+else:
+    type NodePattern = Union[tuple[Node, Node], tuple[Node, tuple[Node, Node]], Any]
+
 
 # This is the Quantizer class instance from torch/quantization/fx/quantize.py.
 # Define separately to prevent circular imports.
@@ -30,11 +33,16 @@ QuantizerCls = Any
 # Type for fusion patterns, it can be more complicated than the following actually,
 # see pattern.md for docs
 # TODO: not sure if typing supports recursive data types
-Pattern = Union[
-    Callable, tuple[Callable, Callable], tuple[Callable, tuple[Callable, Callable]], Any
-]
-if sys.version_info < (3, 14):
+
+if sys.version_info < (3, 12):
+    Pattern = Union[
+        Callable, tuple[Callable, Callable], tuple[Callable, tuple[Callable, Callable]], Any
+    ]
     Pattern.__module__ = "torch.ao.quantization.utils"
+else:
+    type Pattern = Union[
+        Callable, tuple[Callable, Callable], tuple[Callable, tuple[Callable, Callable]], Any
+    ]
 
 
 # TODO: maybe rename this to MatchInputNode


### PR DESCRIPTION
Since type statement breaks older python version, trying to find equivalent behavior without the type mechanics.