### PR TITLE
[NativeRT] Remove normalizeDevice

### DIFF
--- a/test/cpp/nativert/test_placement.cpp
+++ b/test/cpp/nativert/test_placement.cpp
@@ -8,23 +8,6 @@
 using namespace ::testing;
 
 namespace torch::nativert {
-TEST(PlacementTest, NormalizeDevice) {
-  c10::Device cpuDevice = c10::Device(c10::DeviceType::CPU);
-  c10::Device cpuDevice1 = c10::Device(c10::DeviceType::CPU);
-  cpuDevice1.set_index(1);
-
-  EXPECT_EQ(normalizeDevice(cpuDevice), cpuDevice);
-  EXPECT_NE(normalizeDevice(cpuDevice1), cpuDevice1);
-
-  c10::Device cudaDevice = c10::Device(c10::DeviceType::CUDA);
-  c10::Device cudaDevice1 = c10::Device(c10::DeviceType::CUDA, 1);
-  EXPECT_EQ(normalizeDevice(cudaDevice), c10::Device(c10::DeviceType::CUDA, 0));
-  EXPECT_EQ(
-      normalizeDevice(cudaDevice1), c10::Device(c10::DeviceType::CUDA, 1));
-
-  EXPECT_NE(
-      normalizeDevice(cudaDevice1), c10::Device(c10::DeviceType::CUDA, 0));
-}
 
 TEST(PlacementTest, IsSameDevice) {
   c10::Device cpuDevice = c10::Device(c10::DeviceType::CPU);
@@ -90,11 +73,11 @@ TEST(PlacementTest, Placement) {
       {c10::Device("cuda:0"), c10::Device("cuda:1")}};
   Placement p1(deviceMap1);
   EXPECT_EQ(p1.getMappedDevice(c10::Device("cpu")), c10::Device("cpu"));
-  EXPECT_EQ(p1.getMappedDevice(c10::Device("cuda")), c10::Device("cuda:1"));
+  EXPECT_EQ(p1.getMappedDevice(c10::Device("cuda")), c10::Device("cuda"));
   EXPECT_EQ(p1.getMappedDevice(c10::Device("cuda:0")), c10::Device("cuda:1"));
 
   std::unordered_map<c10::Device, c10::Device> deviceMap2 = {
-      {c10::Device("cpu"), c10::Device("cuda")}};
+      {c10::Device("cpu"), c10::Device("cuda:0")}};
   Placement p2(deviceMap2);
   EXPECT_EQ(p2.getMappedDevice(c10::Device("cpu")), c10::Device("cuda:0"));
   EXPECT_EQ(p2.getMappedDevice(c10::Device("cuda:0")), c10::Device("cuda:0"));

--- a/torch/nativert/executor/Placement.h
+++ b/torch/nativert/executor/Placement.h
@@ -9,21 +9,6 @@
 namespace torch::nativert {
 
 /**
- * This function returns a normalized version of the input device:
- * - For CPU devices, the returned device will have no index (i.e., the default
- * CPU device).
- * - For CUDA devices, if no index is specified, index 0 is assumed.
- * - For other device types, the function will raise an error.
- *
- * @param device The input c10::Device to normalize.
- * @return A normalized c10::Device with standardized indexing.
- *
- * @throws c10::Error If the device type is not CPU or CUDA.
- */
-
-c10::Device normalizeDevice(const c10::Device& device);
-
-/**
  * Returns true if the two devices are the same and has the same device index
  * (if cuda).
  */

--- a/torch/nativert/executor/PlacementUtils.cpp
+++ b/torch/nativert/executor/PlacementUtils.cpp
@@ -4,20 +4,6 @@
 
 namespace torch::nativert {
 
-c10::Device normalizeDevice(const c10::Device& device) {
-  // cpu device doesn't have index
-  // cuda device index must have a index
-  if (device.is_cpu()) {
-    return c10::Device(c10::DeviceType::CPU);
-  } else if (device.is_cuda()) {
-    return c10::Device(
-        c10::DeviceType::CUDA,
-        device.has_index() ? device.index() : static_cast<c10::DeviceIndex>(0));
-  } else {
-    TORCH_CHECK(false, "Unsupported device type", device);
-  }
-}
-
 bool isSameDevice(const c10::Device& a, const c10::Device& b) {
   if (a.is_cpu()) {
     return b.is_cpu();


### PR DESCRIPTION
Summary:
In pytorch, tensor.to("cuda") behaves differently from tensor.to("cuda:0). 

tensor.to("cuda") will read from thread local DeviceGuard, aka cuda::current_device(), to infer the device index. 

TBEPermute is relying on this behavior to route output tensor to a device specified by current thread. 

For this reason, we remove the normalizeDevice(), and disallow index-less cuda device in Placement. 

Device-to-device mapping must be done between concrete device!

Test Plan:
CI

Rollback Plan:

Differential Revision: D78443109


