### PR TITLE
[dynamo][3/N] Make `OptimizedModule.__dir__` behave like a wrapper module

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -456,12 +456,6 @@ class OptimizedModule(torch.nn.Module):
             self._orig_mod._infer_parameters(self._orig_mod, args, kwargs)
         return self._forward(*args, **kwargs)
 
-    def __dir__(self):
-        orig_mod_attrs = self._orig_mod.__dir__()
-        return orig_mod_attrs + [
-            attr for attr in super().__dir__() if attr not in orig_mod_attrs
-        ]
-
 
 def remove_from_cache(f):
     """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

TODO: investigate, this might break BC for #94478, although we can ask
the user to use `model.compile()` now.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela