### PR TITLE
[Dynamo][Better Engineering] Add typing support for _dynamo/repro and debug_utils

### DIFF
--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -1,6 +1,3 @@
-# mypy: allow-untyped-defs
-# mypy: disable-error-code="method-assign"
-
 """
 Debug utilities for TorchDynamo compilation and execution.
 
@@ -34,6 +31,7 @@ import sys
 import tempfile
 import textwrap
 from collections import Counter
+from collections.abc import Sequence
 from importlib import import_module
 from typing import Any, Callable, Optional, TypeVar
 
@@ -43,7 +41,9 @@ import torch._subclasses.meta_utils
 from torch import Tensor
 from torch._dynamo.testing import rand_strided
 from torch._prims_common import is_float_dtype
+from torch.hub import tqdm
 from torch.multiprocessing.reductions import StorageWeakRef
+from torch.storage import UntypedStorage
 from torch.utils._content_store import ContentStoreReader, ContentStoreWriter
 
 from . import config
@@ -64,6 +64,7 @@ if use_buck:
 
 extra_deps = []
 extra_imports = ""
+cur_target = ""
 if use_buck:
     extra_deps = [
         "//caffe2/torch/fb/sparsenn:sparsenn_operators_gpu",
@@ -79,7 +80,7 @@ BUCK_CMD_PREFIX = ["buck2", "run", "@mode/dev-nosan"]
 
 
 class BuckTargetWriter:
-    def __init__(self, filename):
+    def __init__(self, filename: str) -> None:
         self.subdir, self.py_file = os.path.split(os.path.abspath(filename))
         self.target = self.py_file.replace(".py", "")
 
@@ -93,7 +94,7 @@ class BuckTargetWriter:
         tmp = tmp[tmp.find("fbcode/") :][7:]
         self.cmd_line_path = f"//{tmp}:{self.target}"
 
-    def build(self):
+    def build(self) -> str:
         extra_cpp_deps = "\n".join([f'        "{x}",' for x in extra_deps])
         return textwrap.dedent(
             f"""
@@ -119,7 +120,7 @@ python_binary(
 """
         )
 
-    def write(self, print_msg=True):
+    def write(self, print_msg: bool = True) -> list[str]:
         target_file = os.path.join(self.subdir, "TARGETS")
         with open(target_file, "w") as fd:
             fd.write(self.build())
@@ -133,7 +134,7 @@ python_binary(
         return cmd_split
 
 
-def minifier_dir():
+def minifier_dir() -> str:
     path = os.path.join(get_debug_dir(), "minifier")
     if path is None:
         path = f"{tempfile.gettempdir()}/minifier_{getpass.getuser()}"
@@ -171,7 +172,7 @@ class NNModuleToString:
     ]
 
     @staticmethod
-    def can_convert_to_string(gm):
+    def can_convert_to_string(gm: torch.fx.GraphModule) -> bool:
         cant_convert = set()
         for _, module in gm.named_children():
             if type(module) not in NNModuleToString.safe_reprs:
@@ -183,7 +184,7 @@ class NNModuleToString:
         return True
 
     @staticmethod
-    def convert(gm):
+    def convert(gm: torch.fx.GraphModule) -> str:
         from torch.nn.modules.module import _addindent
 
         tab = " " * 4
@@ -248,7 +249,7 @@ class NNModuleToString:
 
 
 @functools.cache  # subprocess is expensive
-def _cuda_system_info_comment():
+def _cuda_system_info_comment() -> str:
     if not torch.cuda.is_available():
         return "# torch.cuda.is_available()==False, no GPU info collected\n"
 
@@ -272,7 +273,7 @@ def _cuda_system_info_comment():
     return model_str
 
 
-def generate_env_vars_string(*, stable_output=False):
+def generate_env_vars_string(*, stable_output: bool = False) -> str:
     """
     Generate a string configuration for environment variables related to Dynamo, Inductor, and Triton.
     """
@@ -282,7 +283,7 @@ def generate_env_vars_string(*, stable_output=False):
     allow_list = ["TORCH", "DYNAMO", "INDUCTOR", "TRITON"]
     skip_list = ["TRITON_LIBDEVICE_PATH", "TRITON_PTXAS_PATH", "TRITON_LIBCUDA_PATH"]
 
-    def filter(key):
+    def filter(key: str) -> bool:
         return any(string in key for string in allow_list) and key not in skip_list
 
     config_lines = [
@@ -297,7 +298,7 @@ import os
     """
 
 
-def generate_config_string(*, stable_output=False):
+def generate_config_string(*, stable_output: bool = False) -> str:
     import torch._functorch.config
     import torch._inductor.config
 
@@ -317,11 +318,11 @@ import torch.fx.experimental._config
 """
 
 
-def get_minifier_repro_path():
+def get_minifier_repro_path() -> str:
     return os.path.join(minifier_dir(), "minifier_launcher.py")
 
 
-def helper_for_dump_minify(contents):
+def helper_for_dump_minify(contents: str) -> None:
     minified_repro_path = get_minifier_repro_path()
     log.warning("Writing minified repro to:\n%s", minified_repro_path)
 
@@ -340,7 +341,7 @@ class AccuracyError(Exception):
     pass
 
 
-def clone_inputs_retaining_gradness(example_inputs):
+def clone_inputs_retaining_gradness(example_inputs: Sequence[Any]) -> list[Any]:
     """
     This clone inputs is different from utils clone_input. In case of minifier,
     all the tensors are leaf tensors while creating a new graph. So, we set the
@@ -350,10 +351,15 @@ def clone_inputs_retaining_gradness(example_inputs):
     for idx in range(len(example_inputs)):
         if isinstance(cloned_inputs[idx], torch.Tensor):
             cloned_inputs[idx].requires_grad_(example_inputs[idx].requires_grad)
-    return cloned_inputs
+    return cloned_inputs  # type: ignore[return-value]
 
 
-def run_fwd_maybe_bwd(gm, args, only_fwd=False, disable_clone=False):
+def run_fwd_maybe_bwd(
+    gm: torch.fx.GraphModule,
+    args: Sequence[Any],
+    only_fwd: bool = False,
+    disable_clone: bool = False,
+) -> Any:
     """
     Runs a forward and possibly backward iteration for a given mod and args.
 
@@ -381,14 +387,14 @@ def run_fwd_maybe_bwd(gm, args, only_fwd=False, disable_clone=False):
 
 
 def same_two_models(
-    gm,
-    opt_gm,
-    example_inputs,
-    only_fwd=False,
+    gm: torch.fx.GraphModule,
+    opt_gm: torch.fx.GraphModule,
+    example_inputs: Sequence[Any],
+    only_fwd: bool = False,
     *,
-    require_fp64=False,
-    ignore_non_fp=False,
-):
+    require_fp64: bool = False,
+    ignore_non_fp: bool = False,
+) -> bool:
     """
     Check two models have same accuracy.
 
@@ -438,7 +444,7 @@ def same_two_models(
     return passing
 
 
-def cast_dtype_args_to_fp64(model):
+def cast_dtype_args_to_fp64(model: torch.fx.GraphModule) -> torch.fx.GraphModule:
     for node in model.graph.nodes:
         if (
             node.op == "call_function"
@@ -459,7 +465,9 @@ def cast_dtype_args_to_fp64(model):
     return model
 
 
-def cast_to(dtype, model, inputs):
+def cast_to(
+    dtype: torch.dtype, model: torch.fx.GraphModule, inputs: list[Any]
+) -> tuple[torch.fx.GraphModule, list[Any]]:
     from torch.utils._pytree import tree_map
 
     model = model.to(dtype)
@@ -477,19 +485,21 @@ def cast_to(dtype, model, inputs):
     return model, inputs
 
 
-def cast_to_fp64(model, inputs):
+def cast_to_fp64(
+    model: torch.fx.GraphModule, inputs: list[Any]
+) -> tuple[torch.fx.GraphModule, list[Any]]:
     return cast_to(torch.float64, model, inputs)
 
 
 def backend_accuracy_fails(
-    gm,
-    example_inputs,
-    compiler_fn,
-    only_fwd=False,
+    gm: torch.fx.GraphModule,
+    example_inputs: Sequence[Any],
+    compiler_fn: Callable[[torch.fx.GraphModule, list[Any]], torch.fx.GraphModule],
+    only_fwd: bool = False,
     *,
-    require_fp64=False,
-    ignore_non_fp=False,
-):
+    require_fp64: bool = False,
+    ignore_non_fp: bool = False,
+) -> bool:
     try:
         compiled_gm = compiler_fn(
             copy.deepcopy(gm), clone_inputs_retaining_gradness(example_inputs)
@@ -545,20 +555,27 @@ class NopInputReader:
     def __init__(self) -> None:
         self.total = 0
 
-    def storage(self, storage_hash, nbytes, *, device=None, dtype_hint=None):
+    def storage(
+        self,
+        storage_hash: Optional[str],
+        nbytes: int,
+        *,
+        device: Optional["torch._prims_common.DeviceLikeType"] = None,
+        dtype_hint: Optional[torch.dtype] = None,
+    ) -> None:
         self.total += 1
 
-    def tensor(self, *args, **kwargs):
+    def tensor(self, *args: Any, **kwargs: Any) -> Optional[torch.Tensor]:
         pass
 
-    def symint(self, *args, **kwargs):
+    def symint(self, *args: Any, **kwargs: Any) -> Optional[int]:
         pass
 
 
 # TODO: Support bundling the entire repro into a zip file for ease of
 # transferring around
 class InputReader:
-    def __init__(self, save_dir=None, *, pbar=None):
+    def __init__(self, save_dir: Optional[str] = None, *, pbar: Optional[tqdm] = None):
         # If None, we will generate random data instead.  It's important
         # to natively support this use case as it will allow people to
         # share repros without including the real data, if the problem
@@ -566,13 +583,20 @@ class InputReader:
         if save_dir is None:
             log.warning("no save_dir specified, will generate random data")
         self.store = ContentStoreReader(save_dir) if save_dir is not None else None
-        self.args = []
+        self.args: list[Any] = []
         self.pbar = pbar
 
-    def storage(self, storage_hash, nbytes, *, device=None, dtype_hint=None):
+    def storage(
+        self,
+        storage_hash: Optional[str],
+        nbytes: int,
+        *,
+        device: Optional["torch._prims_common.DeviceLikeType"] = None,
+        dtype_hint: Optional[torch.dtype] = None,
+    ) -> UntypedStorage:
         if self.pbar is not None:
             self.pbar.update(1)
-        device = _device_or_default(device)
+        device = _device_or_default(device)  # type: ignore[arg-type]
         dtype_hint = _dtype_or_default(dtype_hint)
         if self.store is not None and storage_hash is not None:
             try:
@@ -593,16 +617,16 @@ class InputReader:
 
     def tensor(
         self,
-        storage,
-        shape,
-        stride=None,
+        storage: UntypedStorage,
+        shape: "torch._prims_common.ShapeType",
+        stride: Optional["torch._prims_common.StrideType"] = None,
         *,
-        storage_offset=None,
-        dtype=None,
-        requires_grad=None,
-        is_leaf=None,
-        **metadata,
-    ):
+        storage_offset: Optional[int] = None,
+        dtype: Optional[torch.dtype] = None,
+        requires_grad: Optional[bool] = None,
+        is_leaf: Optional[bool] = None,
+        **metadata: Any,
+    ) -> torch.Tensor:
         stride = _stride_or_default(stride, shape=shape)
         storage_offset = _storage_offset_or_default(storage_offset)
         dtype = _dtype_or_default(dtype)
@@ -624,7 +648,7 @@ class InputReader:
         self.args.append(t)
         return t  # for BC
 
-    def symint(self, val):
+    def symint(self, val: Any) -> Any:
         self.args.append(val)
         return val  # for BC
 
@@ -642,8 +666,8 @@ class InputReader:
 
 
 class InputWriter:
-    def __init__(self, save_dir, *, stable_hash=False):
-        self._lines = []
+    def __init__(self, save_dir: Optional[str], *, stable_hash: bool = False) -> None:
+        self._lines: list[str] = []
         # TODO: consider ensuring tensor and storage counters line up?
         self.storage_counter = itertools.count()
         self.save_dir = save_dir
@@ -652,9 +676,9 @@ class InputWriter:
             if save_dir is not None
             else None
         )
-        self.seen_storages = {}
+        self.seen_storages: dict[StorageWeakRef, str] = {}
 
-    def lines(self):
+    def lines(self) -> list[str]:
         r = [
             "def load_args(reader):",
         ]
@@ -669,7 +693,13 @@ class InputWriter:
     # of initialization may be appropriate
     #
     # If we had a FakeTensor, device_hint tells us what device should be
-    def storage(self, untyped_storage, *, dtype_hint=None, device_hint=None) -> str:
+    def storage(
+        self,
+        untyped_storage: UntypedStorage,
+        *,
+        device_hint: Optional["torch._prims_common.DeviceLikeType"] = None,
+        dtype_hint: Optional[torch.dtype] = None,
+    ) -> str:
         ws = StorageWeakRef(untyped_storage)
         v = self.seen_storages.get(ws)
         if v is not None:
@@ -684,7 +714,7 @@ class InputWriter:
         device = untyped_storage.device
         if device.type == "meta":
             assert device_hint is not None
-            device = device_hint
+            device = device_hint  # type: ignore[assignment]
         if _device_or_default(None) != device:
             maybe_device = f", device={device!r}"
         nbytes = untyped_storage.nbytes()
@@ -697,7 +727,7 @@ class InputWriter:
         self.seen_storages[ws] = v
         return v
 
-    def tensor(self, name, t) -> None:
+    def tensor(self, name: str, t: torch.Tensor) -> None:
         from torch.fx.experimental.symbolic_shapes import statically_known_true, sym_eq
 
         storage = self.storage(
@@ -729,7 +759,7 @@ class InputWriter:
             + f")  # {name}"
         )
 
-    def unsupported(self, name, arg):
+    def unsupported(self, name: str, arg: Any) -> None:
         # NB: Try hard not to /print/ a tensor, that will be very slow
         self._lines.append(f"# {name} was unsupported type for dumping: {type(arg)}")
         # Best effort dump as much useful stuff we can lol, in case you want
@@ -747,13 +777,13 @@ class InputWriter:
             self._lines.append('"""')
 
     # write out that the arg was filtered out as it is constant
-    def const(self, name) -> None:
+    def const(self, name: str) -> None:
         self._lines.append(
             f"reader.const({name!r})  # {name}, filtered out during compilation"
         )
 
     # TODO: this doesn't actually symint atm
-    def symint(self, name, val) -> None:
+    def symint(self, name: str, val: Any) -> None:
         if isinstance(val, torch.SymInt):
             val = val.node.hint
         self._lines.append(f"reader.symint({val!r})  # {name}")
@@ -782,8 +812,10 @@ def aot_graph_input_parser(
 
     from torch.utils._dtype_abbrs import dtype_abbrs
 
-    dtype_map = {value: key for key, value in dtype_abbrs.items()}
-    dtype_pattern = "|".join(dtype_abbrs.values())
+    dtype_map: dict[str, torch.dtype] = {
+        value: key for key, value in dtype_abbrs.items()
+    }
+    dtype_pattern: str = "|".join(dtype_abbrs.values())
 
     # Extracting the source code from the function
     source = inspect.getsource(func)
@@ -799,21 +831,23 @@ def aot_graph_input_parser(
     # Dictionary for tensors from annotations
     kwargs: dict[str, Any] = {}
 
-    sym_shapes = sym_shapes or {}
+    sym_shapes_dict: dict[str, int] = sym_shapes or {}
 
-    def get_sym_int(symint):
+    def get_sym_int(symint: str) -> int:
         torch._check(
-            symint in sym_shapes or default_sym_shape is not None,
+            symint in sym_shapes_dict or default_sym_shape is not None,
             lambda: f"{symint} not in symbolic_shapes and default sym shape not passed in",
         )
-        return sym_shapes.get(symint, default_sym_shape)
+        return sym_shapes_dict.get(symint, default_sym_shape)  # type: ignore[return-value]
 
-    def gen_tensor(shape, dtype) -> Tensor:
+    def gen_tensor(
+        shape: "torch._prims_common.ShapeType", dtype: torch.dtype
+    ) -> Tensor:
         # Resolve symbolic shapes to concrete values
         resolved_shape = []
         dynamic_dims = []
         for i, dim in enumerate(shape):
-            dim = dim.strip()
+            dim = dim.strip()  # type: ignore[attr-defined]
             if "s" in dim:
                 s = get_sym_int(dim)
                 resolved_shape.append(s)
@@ -868,9 +902,9 @@ def profile_to_file(filename: str) -> Callable[[T], T]:
     prof = cProfile.Profile()
     filename = os.path.abspath(os.path.expanduser(filename))
 
-    def decorator(fn):
+    def decorator(fn: Any) -> Any:
         @functools.wraps(fn)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
             prof.enable()
             try:
                 return fn(*args, **kwargs)
@@ -879,7 +913,7 @@ def profile_to_file(filename: str) -> Callable[[T], T]:
 
         return wrapper
 
-    def save_it():
+    def save_it() -> None:
         prof.dump_stats(filename)
         sys.stderr.write(
             textwrap.dedent(

--- a/torch/_dynamo/repro/after_dynamo.py
+++ b/torch/_dynamo/repro/after_dynamo.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 """
 Utilities for reproducing and debugging issues in Dynamo after graph capture.
 
@@ -26,12 +24,12 @@ import os
 import shutil
 import sys
 import textwrap
+from collections.abc import Sequence
 from importlib import import_module
-from typing import Optional, Union
+from typing import Any, Callable, Optional, Union
 
 import torch
 import torch.fx as fx
-from torch._dynamo.backends.registry import CompiledFn
 from torch._dynamo.debug_utils import (
     AccuracyError,
     backend_accuracy_fails,
@@ -53,7 +51,7 @@ from torch.fx.experimental.symbolic_shapes import fx_placeholder_targets
 from torch.hub import tqdm
 
 from .. import config
-from ..backends.registry import lookup_backend, register_debug_backend
+from ..backends.registry import CompilerFn, lookup_backend, register_debug_backend
 from ..debug_utils import clone_inputs_retaining_gradness
 
 
@@ -68,7 +66,11 @@ use_buck = inductor_config.is_fbcode()
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
 
-def _accuracy_fails(gm, example_inputs, compiler_fn):
+def _accuracy_fails(
+    gm: torch.fx.GraphModule,
+    example_inputs: Sequence[Any],
+    compiler_fn: Callable[[torch.fx.GraphModule, list[Any]], torch.fx.GraphModule],
+) -> bool:
     return backend_accuracy_fails(
         gm,
         example_inputs,
@@ -79,29 +81,33 @@ def _accuracy_fails(gm, example_inputs, compiler_fn):
 
 
 class WrapBackendDebug:
-    def __init__(self, unconfigured_compiler_fn, compiler_name: Optional[str]) -> None:
+    def __init__(
+        self, unconfigured_compiler_fn: CompilerFn, compiler_name: Optional[str]
+    ) -> None:
         functools.wraps(unconfigured_compiler_fn)(self)
-        self._torchdynamo_orig_backend = unconfigured_compiler_fn  # type: ignore[attr-defined]
+        self._torchdynamo_orig_backend = unconfigured_compiler_fn
         self._compiler_name = compiler_name
         if hasattr(unconfigured_compiler_fn, "__name__"):
             self.__name__ = unconfigured_compiler_fn.__name__
         if hasattr(unconfigured_compiler_fn, "compiler_name"):
-            self.__name__ = unconfigured_compiler_fn.compiler_name
+            self.__name__ = unconfigured_compiler_fn.compiler_name  # type: ignore[attr-defined]
         if hasattr(unconfigured_compiler_fn, "get_compiler_config"):
             self.get_compiler_config = unconfigured_compiler_fn.get_compiler_config  # type: ignore[attr-defined]
 
-    def __call__(self, gm, example_inputs, **kwargs):
+    def __call__(
+        self, gm: torch.fx.GraphModule, example_inputs: list[Any], **kwargs: Any
+    ) -> torch.fx.GraphModule:
         compiler_fn = functools.partial(self._torchdynamo_orig_backend, **kwargs)
         assert config.repro_after in ("dynamo", "aot", None)
 
         if config.repro_after == "dynamo":
 
-            def add_paths(exc):
-                exc.minifier_path = os.path.join(minifier_dir(), "minifier_launcher.py")
+            def add_paths(exc: Exception) -> None:
+                exc.minifier_path = os.path.join(minifier_dir(), "minifier_launcher.py")  # type: ignore[attr-defined]
                 if use_buck:
-                    exc.buck_command = " ".join(
+                    exc.buck_command = " ".join(  # type: ignore[attr-defined]
                         BUCK_CMD_PREFIX
-                        + [BuckTargetWriter(exc.minifier_path).cmd_line_path]
+                        + [BuckTargetWriter(exc.minifier_path).cmd_line_path]  # type: ignore[attr-defined]
                     )
 
             if config.repro_level == 3:
@@ -111,7 +117,7 @@ class WrapBackendDebug:
             if config.repro_level == 4:
                 # Check Accuracy
                 compiled_gm = compiler_fn(copy.deepcopy(gm), example_inputs)
-                if _accuracy_fails(gm, example_inputs, compiler_fn):
+                if _accuracy_fails(gm, example_inputs, compiler_fn):  # type: ignore[arg-type]
                     log.warning(
                         "Accuracy failed for the TorchDynamo produced graph. Creating script to minify the error."
                     )
@@ -126,7 +132,7 @@ class WrapBackendDebug:
             else:
                 try:
                     compiled_gm = compiler_fn(copy.deepcopy(gm), example_inputs)
-                    run_fwd_maybe_bwd(compiled_gm, example_inputs)
+                    run_fwd_maybe_bwd(compiled_gm, example_inputs)  # type: ignore[arg-type]
                 except Exception as exc:
                     log.warning(
                         "Compiled Fx GraphModule failed. Creating script to minify the error."
@@ -149,10 +155,12 @@ class WrapBackendDebug:
         else:
             compiled_gm = compiler_fn(gm, example_inputs)
 
-        return compiled_gm
+        return compiled_gm  # type: ignore[return-value]
 
 
-def wrap_backend_debug(unconfigured_compiler_fn, compiler_name: Optional[str]):
+def wrap_backend_debug(
+    unconfigured_compiler_fn: CompilerFn, compiler_name: Optional[str]
+) -> WrapBackendDebug:
     """
     A minifier decorator that wraps the TorchDynamo produced Fx graph modules.
     As opposed to wrap_compiler_debug, this wrapper intercepts at the
@@ -170,15 +178,15 @@ def wrap_backend_debug(unconfigured_compiler_fn, compiler_name: Optional[str]):
 
 
 def generate_dynamo_fx_repro_string(
-    gm,
-    args,
-    compiler_name,
-    check_accuracy=False,
+    gm: torch.fx.GraphModule,
+    args: Sequence[Any],
+    compiler_name: Optional[str],
+    check_accuracy: bool = False,
     *,
-    stable_output=False,
-    save_dir=None,
-    command="run",
-):
+    stable_output: bool = False,
+    save_dir: Optional[str] = None,
+    command: str = "run",
+) -> str:
     """
     Generate a repro string for backend-agnostic minified version.
     """
@@ -225,7 +233,12 @@ if __name__ == '__main__':
     )
 
 
-def dump_backend_repro_as_file(gm, args, compiler_name, check_accuracy=False):
+def dump_backend_repro_as_file(
+    gm: torch.fx.GraphModule,
+    args: Sequence[Any],
+    compiler_name: Optional[str],
+    check_accuracy: bool = False,
+) -> None:
     """
     Saves the repro to a repro.py file
     """
@@ -253,7 +266,12 @@ def dump_backend_repro_as_file(gm, args, compiler_name, check_accuracy=False):
     shutil.copyfile(file_name, latest_repro)
 
 
-def dump_backend_state(gm, args, compiler_name, check_accuracy=False):
+def dump_backend_state(
+    gm: torch.fx.GraphModule,
+    args: Sequence[Any],
+    compiler_name: Optional[str],
+    check_accuracy: bool = False,
+) -> None:
     """
     Dumps the dynamo graph to repro the issue.
     1) It tries to convert Fx GraphModule to a string. If we can, it writes to a
@@ -271,7 +289,9 @@ def dump_backend_state(gm, args, compiler_name, check_accuracy=False):
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
 
-def dump_to_minify_after_dynamo(gm, args, compiler_name):
+def dump_to_minify_after_dynamo(
+    gm: torch.fx.GraphModule, args: Sequence[Any], compiler_name: Optional[str]
+) -> None:
     # TODO: factor this out
     subdir = os.path.join(minifier_dir(), "checkpoints")
     if not os.path.exists(subdir):
@@ -295,8 +315,8 @@ def dump_to_minify_after_dynamo(gm, args, compiler_name):
 
 @register_debug_backend  # type: ignore[arg-type]
 def dynamo_minifier_backend(
-    gm: fx.GraphModule, example_inputs, compiler_name: CompiledFn
-):
+    gm: fx.GraphModule, example_inputs: Sequence[Any], compiler_name: Optional[str]
+) -> fx.GraphModule:
     from functorch.compile import minifier
 
     compiler_fn = lookup_backend(compiler_name)
@@ -336,7 +356,9 @@ def dynamo_minifier_backend(
 
 
 @register_debug_backend  # type: ignore[arg-type]
-def dynamo_accuracy_minifier_backend(gm, example_inputs, compiler_name):
+def dynamo_accuracy_minifier_backend(
+    gm: fx.GraphModule, example_inputs: Sequence[Any], compiler_name: Optional[str]
+) -> fx.GraphModule:
     from functorch.compile import minifier
 
     compiler_fn = lookup_backend(compiler_name)
@@ -366,7 +388,12 @@ def dynamo_accuracy_minifier_backend(gm, example_inputs, compiler_name):
     return gm
 
 
-def backend_fails(gm, example_inputs, compiler_fn, orig_failure):
+def backend_fails(
+    gm: fx.GraphModule,
+    example_inputs: Sequence[Any],
+    compiler_fn: CompilerFn,
+    orig_failure: Sequence[Any],
+) -> bool:
     """
     Minifier uses this function to identify if the minified graph module fails
     with the same error.
@@ -383,8 +410,8 @@ def backend_fails(gm, example_inputs, compiler_fn, orig_failure):
     try:
         # Run the original gm to check eager validity
         run_fwd_maybe_bwd(gm, clone_inputs_retaining_gradness(example_inputs))
-        compiled_gm = compiler_fn(gm, example_inputs)
-        run_fwd_maybe_bwd(compiled_gm, clone_inputs_retaining_gradness(example_inputs))
+        compiled_gm = compiler_fn(gm, example_inputs)  # type: ignore[arg-type]
+        run_fwd_maybe_bwd(compiled_gm, clone_inputs_retaining_gradness(example_inputs))  # type: ignore[arg-type]
     except Exception as e:
         new_failure = str(e)
         if SequenceMatcher(None, orig_failure, new_failure).ratio() > 0.5:
@@ -397,7 +424,7 @@ def backend_fails(gm, example_inputs, compiler_fn, orig_failure):
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
 
-def run_load_args(options, mod, load_args):
+def run_load_args(options: Any, mod: torch.nn.Module, load_args: Any) -> list[Any]:
     if not hasattr(load_args, "_version"):
         log.warning(
             "load_args does not have a _version attribute, please file a bug to PyTorch "
@@ -423,7 +450,7 @@ def run_load_args(options, mod, load_args):
     return args
 
 
-def repro_minify(options, mod, load_args):
+def repro_minify(options: Any, mod: torch.nn.Module, load_args: Any) -> None:
     args = run_load_args(options, mod, load_args)
 
     # Setup debug minifier compiler
@@ -450,7 +477,7 @@ def repro_minify(options, mod, load_args):
         opt_mod(*args)
 
 
-def repro_run(options, mod, load_args):
+def repro_run(options: Any, mod: torch.nn.Module, load_args: Any) -> None:
     opt_mod = torch._dynamo.optimize(options.backend)(mod)
 
     if options.accuracy != "":
@@ -460,10 +487,10 @@ def repro_run(options, mod, load_args):
         with torch.amp.autocast("cuda", enabled=options.autocast):
             # TODO: disable clone
             args = run_load_args(options, mod, load_args)
-            assert same_two_models(mod, mod, args), "Eager itself failed"
+            assert same_two_models(mod, mod, args), "Eager itself failed"  # type: ignore[arg-type]
             if not same_two_models(
-                mod,
-                opt_mod,
+                mod,  # type: ignore[arg-type]
+                opt_mod,  # type: ignore[arg-type]
                 args,
                 only_fwd=config.repro_forward_only,
                 ignore_non_fp=config.repro_ignore_non_fp,
@@ -472,26 +499,29 @@ def repro_run(options, mod, load_args):
     else:
         with torch.amp.autocast("cuda", enabled=options.autocast):
             args = run_load_args(options, mod, load_args)
-            run_fwd_maybe_bwd(mod, args, only_fwd=options.only_fwd, disable_clone=True)
+            run_fwd_maybe_bwd(mod, args, only_fwd=options.only_fwd, disable_clone=True)  # type: ignore[arg-type]
             del args
 
             args = run_load_args(options, mod, load_args)
             run_fwd_maybe_bwd(
-                opt_mod, args, only_fwd=options.only_fwd, disable_clone=True
+                opt_mod,  # type: ignore[arg-type]
+                args,
+                only_fwd=options.only_fwd,
+                disable_clone=True,  # type: ignore[arg-type]
             )
 
 
 def run_repro(
-    mod,
-    load_args,
+    mod: torch.nn.Module,
+    load_args: Any,
     *,
-    command="run",
+    command: str = "run",
     accuracy: Union[bool, str] = "",
-    save_dir=None,
-    autocast=False,
-    backend="inductor",
-    **kwargs,
-):
+    save_dir: Optional[str] = None,
+    autocast: bool = False,
+    backend: str = "inductor",
+    **kwargs: Any,
+) -> None:
     for k in kwargs:
         log.warning(
             "Unrecognized kwarg %s; perhaps this repro was made on a newer version of PyTorch",
@@ -517,7 +547,7 @@ default settings on this script:
         formatter_class=argparse.RawTextHelpFormatter,
     )
 
-    def common_flags(parser):
+    def common_flags(parser: argparse.ArgumentParser) -> None:
         accuracy_group = parser.add_mutually_exclusive_group()
         accuracy_group.add_argument(
             "--no-accuracy",


### PR DESCRIPTION
As part of better engineering week, we would like to improve out type support to improve dev experience in dynamo

This PR adds strict typing support to an important set of utilities in dynamo, `repro/` and the base `debug_utils.py`

Running 
```
mypy torch/_dynamo/repro/ torch/_dynamo/debug_utils.py --linecount-report /tmp/coverage_log
```

| -------- | Lines Unannotated | Lines Total | % lines covered | Funcs Unannotated | Funcs Total | % funcs covered |
| -------- | ------- | -------- | ------- | ------- | ------- | ------- |
| Main  |  905 | 3268 | 27.69% | 22 | 81 | 27.16% |
| This PR | 3368 | 3368 | 100.00% | 81 | 81 | 100.00% |
| Delta    | +2463 | +100 | +72.31% | +59 | 0 | +72.84% |

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames