### PR TITLE
[export] Add runnable code to export docs

### DIFF
--- a/.ci/docker/requirements-docs.txt
+++ b/.ci/docker/requirements-docs.txt
@@ -59,3 +59,4 @@ sphinx-copybutton==0.5.0
 sphinx-design==0.4.0
 sphinxcontrib-mermaid==1.0.0
 myst-parser==0.18.1
+myst-nb

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -62,7 +62,7 @@ extensions = [
     "sphinxcontrib.katex",
     "sphinx_copybutton",
     "sphinx_design",
-    "myst_parser",
+    "myst_nb",
     "sphinx.ext.linkcode",
     "sphinxcontrib.mermaid",
     "sphinx_sitemap",

--- a/docs/source/export/api_reference.md
+++ b/docs/source/export/api_reference.md
@@ -1,0 +1,69 @@
+(export.api_reference)=
+
+# torch.export API Reference
+
+```{eval-rst}
+.. automodule:: torch.export
+
+.. autofunction:: torch.export.export
+
+.. autoclass:: torch.export.ExportedProgram
+   :members:
+   :exclude-members: __init__
+
+.. automodule:: torch.export.dynamic_shapes
+   :members: Dim, ShapesCollection, AdditionalInputs, refine_dynamic_shapes_from_suggested_fixes
+
+.. autofunction:: torch.export.save
+
+.. autofunction:: torch.export.load
+
+.. autofunction:: torch.export.pt2_archive._package.package_pt2
+
+.. autofunction:: torch.export.pt2_archive._package.load_pt2
+
+.. autofunction:: torch.export.draft_export
+
+.. automodule:: torch.export.unflatten
+    :members:
+
+.. autofunction:: torch.export.register_dataclass
+
+.. automodule:: torch.export.decomp_utils
+   :members:
+   :ignore-module-all:
+   :undoc-members:
+
+.. automodule:: torch.export.experimental
+   :members:
+   :ignore-module-all:
+
+.. automodule:: torch.export.passes
+   :members:
+
+.. automodule:: torch.export.pt2_archive
+   :members:
+   :ignore-module-all:
+
+.. automodule:: torch.export.pt2_archive.constants
+   :members:
+   :ignore-module-all:
+
+.. automodule:: torch.export.exported_program
+   :members:
+   :ignore-module-all:
+   :exclude-members: ExportedProgram
+
+.. automodule:: torch.export.custom_ops
+   :members:
+   :ignore-module-all:
+
+.. automodule:: torch.export.custom_obj
+   :members:
+   :ignore-module-all:
+
+.. automodule:: torch.export.graph_signature
+   :members:
+   :ignore-module-all:
+   :undoc-members:
+```


### PR DESCRIPTION
Preview: https://docs-preview.pytorch.org/pytorch/pytorch/158506/export.html

Yay I can add runnable code to export docs now
Also moved export API reference to a different file. 

With these changes, we can start to consolidate the [export tutorial](https://docs.pytorch.org/tutorials/intermediate/torch_export_tutorial.html) with the docs on pytorch docs. We just need to move the section on DDE and 0/1 specialization, and then I think we can delete the export tutorial.

cc @svekars @sekyondaMeta @AlannaBurke