### PR TITLE
[Dynamo][Better Engineering] Add type coverage to decorators

### DIFF
--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -1,6 +1,3 @@
-# mypy: allow-untyped-defs
-# ruff: noqa: TCH004
-
 """
 This module provides decorators and utilities for controlling TorchDynamo's behavior during compilation.
 """
@@ -9,10 +6,12 @@ import functools
 import inspect
 import weakref
 from dataclasses import dataclass
+from types import TracebackType
 from typing import Any, Callable, Optional, overload, TYPE_CHECKING, TypeVar, Union
 from typing_extensions import ParamSpec
 
 import torch
+from torch.compiler import is_compiling
 from torch.utils._contextlib import _DecoratorContextManager
 from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 
@@ -29,7 +28,6 @@ from .eval_frame import (
 from .exc import IncorrectUsage
 from .external_utils import (
     get_nonrecursive_disable_wrapper,
-    is_compiling,
     wrap_dunder_call_ctx_manager,
 )
 from .utils import _get_error_on_graph_break, _set_error_on_graph_break, is_function
@@ -56,9 +54,11 @@ else:
 
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
+FuncType = Callable[..., Any]
+F = TypeVar("F", bound=FuncType)
 
 
-def run(fn=None):
+def run(fn: Optional[Callable[_P, _R]] = None) -> Any:
     """Don't do any dynamic compiles, just use prior optimizations"""
     if fn is not None:
         fn = innermost_fn(fn)
@@ -67,7 +67,7 @@ def run(fn=None):
     return RunOnlyContext()
 
 
-def disable(fn=None, recursive=True, *, reason=None, wrapping=True):
+def disable(fn=None, recursive=True, *, reason=None, wrapping=True):  # type: ignore[no-untyped-def]
     """
     Decorator to disable TorchDynamo
 
@@ -87,7 +87,7 @@ def disable(fn=None, recursive=True, *, reason=None, wrapping=True):
         return DisableContext(msg=reason, wrapping=wrapping)
     else:
 
-        def wrap(fn):
+        def wrap(fn: Callable[_P, _R]) -> Callable[_P, _R]:
             fn = innermost_fn(fn)
             assert callable(fn)
 
@@ -106,7 +106,7 @@ _nonrecursive_disable_wrapper_code = disable(lambda: None, recursive=False).__co
 skip_code(_nonrecursive_disable_wrapper_code)
 
 
-def skip(fn=None):
+def skip(fn: Optional[Callable[_P, _R]] = None) -> Callable[..., Any]:
     """
     Skip frames associated with the function code, but still process recursively
     invoked frames
@@ -134,7 +134,7 @@ class set_stance(_DecoratorContextManager):
         stance: str = "default",
         *,
         skip_guard_eval_unsafe: bool = False,
-        force_backend=None,
+        force_backend: Union[str, Callable[..., Any], None] = None,
     ) -> None:
         if force_backend is not None and stance != "default":
             raise RuntimeError("non-default stance cannot have force_backend set")
@@ -142,29 +142,34 @@ class set_stance(_DecoratorContextManager):
         self.stance = DynamoStance(stance, skip_guard_eval_unsafe, force_backend)
         self.prev = _set_stance(self.stance)
 
-    def __call__(self, fn):
+    def __call__(self, fn: F) -> F:
         _set_stance(self.prev)
         wrapper = super().__call__(fn)
         # forbid wrapper in graph
         wrapper._dynamo_forbidden = True  # type: ignore[attr-defined]
         return wrapper
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         _set_stance(self.stance)
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
         _set_stance(self.prev)
 
-    def clone(self):
+    def clone(self) -> "set_stance":
         return self.__class__(self.stance.stance, force_backend=self.stance.backend)
 
 
-def assume_constant_result(fn):
-    fn._dynamo_marked_constant = True
+def assume_constant_result(fn):  # type: ignore[no-untyped-def]
+    fn._dynamo_marked_constant = True  # type: ignore[attr-defined]
     return fn
 
 
-def allow_in_graph(fn):
+def allow_in_graph(fn):  # type: ignore[no-untyped-def]
     """
     Tells the compiler frontend (Dynamo) to skip symbolic introspection of the function
     and instead directly write it to the graph when encountered.
@@ -182,14 +187,14 @@ def allow_in_graph(fn):
         trace_rules._allowed_callable_ids.add(fn_id)
 
         # Avoid id reuse which creates subtle bugs.
-        def deregister():
+        def deregister() -> None:
             trace_rules._allowed_callable_ids.remove(fn_id)
 
         weakref.finalize(fn, deregister)
     return fn
 
 
-def nonstrict_trace(traceable_fn):
+def nonstrict_trace(traceable_fn: Callable[_P, _R]) -> Callable[_P, _R]:
     # Like `allow_in_graph`, but with the following enhancements/differences:
     #
     # 1. Supports user-defined class as inputs, as long as the class has been
@@ -210,7 +215,7 @@ def nonstrict_trace(traceable_fn):
     assert callable(traceable_fn), "nonstrict_trace expects a callable"
 
     @functools.wraps(traceable_fn)
-    def wrapped(*args, **kwargs):
+    def wrapped(*args: _P.args, **kwargs: _P.kwargs) -> _R:
         return traceable_fn(*args, **kwargs)
 
     wrapped_id = id(wrapped)
@@ -222,7 +227,7 @@ def nonstrict_trace(traceable_fn):
     trace_rules._nonstrict_trace_callable_ids.add(wrapped_id)
 
     # Avoid id reuse which creates subtle bugs.
-    def deregister():
+    def deregister() -> None:
         trace_rules._allowed_callable_ids.remove(wrapped_id)
         trace_rules._nonstrict_trace_callable_ids.remove(wrapped_id)
 
@@ -231,8 +236,8 @@ def nonstrict_trace(traceable_fn):
     return wrapped
 
 
-def _disallow_in_graph_helper(throw_if_not_allowed):
-    def inner(fn):
+def _disallow_in_graph_helper(throw_if_not_allowed: bool) -> Callable[..., Any]:
+    def inner(fn: Any) -> Any:
         if isinstance(fn, (list, tuple)):
             return [disallow_in_graph(x) for x in fn]
         assert callable(fn), "disallow_in_graph expects a callable"
@@ -254,7 +259,7 @@ def _disallow_in_graph_helper(throw_if_not_allowed):
     return inner
 
 
-def disallow_in_graph(fn):
+def disallow_in_graph(fn: Callable[..., Any]) -> Any:
     """
     Customize which functions TorchDynamo will exclude in the generated
     graph and force a graph break on.
@@ -280,17 +285,17 @@ def disallow_in_graph(fn):
 
 
 @_disallow_in_graph_helper(throw_if_not_allowed=False)
-def graph_break(msg=""):
+def graph_break(msg: str = "") -> None:
     """Force a graph break"""
 
 
 # NOTE: primarily used for internal debugging purposes!
 @_disallow_in_graph_helper(throw_if_not_allowed=False)
-def skip_frame(msg=""):
+def skip_frame(msg: str = "") -> None:
     """Force a skipped frame"""
 
 
-def forbid_in_graph(fn):
+def forbid_in_graph(fn: Any) -> Any:
     """
     Customize which functions TorchDynamo will assert are not present while tracing.
 
@@ -392,7 +397,9 @@ def substitute_in_graph(
             else:
                 traceable_sig = inspect.signature(traceable_fn)
 
-                def sig_ident(sig):
+                def sig_ident(
+                    sig: inspect.Signature,
+                ) -> tuple[tuple[str, ...], set[str], dict[str, Any]]:
                     # Ignore annotations for parameters and return type
                     return (
                         tuple(
@@ -472,7 +479,9 @@ def substitute_in_graph(
         def wrapped(*args: _P.args, **kwargs: _P.kwargs) -> _R:
             return original_fn(*args, **kwargs)
 
-        def dispatch_fn(self, value: Callable[_P, _R]) -> PolyfilledFunctionVariable:
+        def dispatch_fn(
+            self: VariableBuilder, value: Callable[_P, _R]
+        ) -> PolyfilledFunctionVariable:
             return PolyfilledFunctionVariable(
                 value,
                 source=self.source,
@@ -497,7 +506,9 @@ def substitute_in_graph(
 # Helper function to flatten a tensor subclass and apply a function to
 # all inner tensors that match the outer dim. Used to reduce duplication
 # across the various marking APIs.
-def _apply_func_to_inner_tensors_of_same_dim(func, t, *args, **kwargs):
+def _apply_func_to_inner_tensors_of_same_dim(
+    func: Callable[..., Any], t: object, *args: Any, **kwargs: Any
+) -> None:
     assert is_traceable_wrapper_subclass(t)
 
     attrs, _ctx = t.__tensor_flatten__()
@@ -522,7 +533,12 @@ class _DimRange:
 
 
 @forbid_in_graph
-def mark_unbacked(t, index, strict=False, specialize_on=None):
+def mark_unbacked(
+    t: Any,
+    index: Union[int, list[Any], tuple[Any]],
+    strict: bool = False,
+    specialize_on: Optional[list[Any]] = None,
+) -> None:
     """
     Mark a tensor as having an unbacked dim.  This changes the semantics of operations,
     we will always report the size does not equal zero/one, we will turn asserts
@@ -565,7 +581,14 @@ def mark_unbacked(t, index, strict=False, specialize_on=None):
 
 
 @forbid_in_graph
-def mark_dynamic(t, index, *, min=None, max=None, specialize_on=None):
+def mark_dynamic(
+    t: Any,
+    index: Union[int, list[Any], tuple[Any]],
+    *,
+    min: Optional[int] = None,
+    max: Optional[int] = None,
+    specialize_on: Optional[list[Any]] = None,
+) -> None:
     """
     Mark a tensor as having a dynamic dim and set corresponding min and max range for the dim.
 
@@ -620,7 +643,7 @@ def mark_dynamic(t, index, *, min=None, max=None, specialize_on=None):
 
         # TODO(voz): Should we bounds check?
         t._dynamo_dynamic_indices.add(index)
-        t._dynamo_dynamic_range.add(_DimRange(index, min, max))
+        t._dynamo_dynamic_range.add(_DimRange(index, min, max))  # type: ignore[arg-type]
 
         # FX tracers don't respect @forbid_in_graph and choke on the following error since it passes in proxies:
         # TypeError: 'Attribute' object does not support item assignment
@@ -636,7 +659,7 @@ def mark_dynamic(t, index, *, min=None, max=None, specialize_on=None):
 
 
 @forbid_in_graph
-def maybe_mark_dynamic(t, index):
+def maybe_mark_dynamic(t: Any, index: Union[int, list[Any], tuple[Any]]) -> None:
     """
     Mark a tensor as having a dynamic dim, but don't enforce it (i.e., if this
     dimension ends up getting specialized, don't error).
@@ -658,7 +681,9 @@ def maybe_mark_dynamic(t, index):
         maybe_mark_dynamic(t, i)
 
 
-def mark_static(t, index=None):
+def mark_static(
+    t: Any, index: Optional[Union[int, list[Any], tuple[Any]]] = None
+) -> None:
     """
     Mark a tensor as having a static dim or mark a nn module class as static.
 
@@ -723,7 +748,7 @@ def mark_static(t, index=None):
 
 
 @forbid_in_graph
-def mark_static_address(t, guard=True):
+def mark_static_address(t: Any, guard: bool = True) -> None:
     """
     Marks an input tensor whose data_ptr will not change across multiple calls
     to a dynamo-compiled function. This indicates to cudagraphs that an extra allocation
@@ -742,7 +767,7 @@ def mark_static_address(t, guard=True):
 # One day, Dynamo will support tracing into einops directly (no allow_in_graph needed)
 # Note that PyTorch supports multiple versions of einops, so when that day comes,
 # we still need to be really careful about version matches.
-def _allow_in_graph_einops():
+def _allow_in_graph_einops() -> None:
     import einops
 
     try:
@@ -773,21 +798,26 @@ trace_rules.add_module_init_func("einops", _allow_in_graph_einops)
 # Proxy class for torch._dynamo.config patching - so dynamo can identify context managers/decorators
 # created by patch_dynamo_config, compared to ones created by a raw torch._dynamo.config.patch.
 class DynamoConfigPatchProxy:
-    def __init__(self, config_patch):
+    def __init__(self, config_patch: Any) -> None:
         self.config_patch = config_patch
 
     @property
-    def changes(self):
+    def changes(self) -> dict[str, Any]:
         return self.config_patch.changes
 
     # Decorator implementation that simply sets up `self` as a context manager.
     # Placed in external_utils so that we can trace through it.
     __call__ = wrap_dunder_call_ctx_manager
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         return self.config_patch.__enter__()
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
         return self.config_patch.__exit__(exc_type, exc_val, exc_tb)
 
 
@@ -819,7 +849,7 @@ for name in _allowed_config_patches:
 del config
 
 
-def _patch_dynamo_config_check(changes: dict[str, Any]):
+def _patch_dynamo_config_check(changes: dict[str, Any]) -> None:
     for k, v in changes.items():
         if k not in _allowed_config_patches:
             raise ValueError(
@@ -871,7 +901,7 @@ def dont_skip_tracing(fn: None = None) -> DynamoConfigPatchProxy: ...
 def dont_skip_tracing(fn: Callable[_P, _R]) -> Callable[_P, _R]: ...
 
 
-def dont_skip_tracing(fn=None):
+def dont_skip_tracing(fn: Optional[Any] = None) -> Any:
     """
     Context manager/decorator to trace into functions intentionally marked by developers to be skipped
     when tracing.
@@ -885,16 +915,21 @@ def dont_skip_tracing(fn=None):
 
 
 class SetFullgraphDecoratorContextManager:
-    def __init__(self, fullgraph):
+    def __init__(self, fullgraph: bool) -> None:
         self.fullgraph = fullgraph
 
     __call__ = wrap_dunder_call_ctx_manager
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         self.prev_fullgraph = _get_error_on_graph_break()
         _set_error_on_graph_break(self.fullgraph)
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
         _set_error_on_graph_break(self.prev_fullgraph)
 
 

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -1,5 +1,5 @@
 # mypy: allow-untyped-defs
-from typing import Any, Callable, Optional, TYPE_CHECKING, TypeVar
+from typing import Any, Callable, Optional, TYPE_CHECKING, TypeVar, Union
 from typing_extensions import ParamSpec
 
 import torch
@@ -39,6 +39,8 @@ __all__ = [
 
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
+FuncType = Callable[..., Any]
+F = TypeVar("F", bound=FuncType)
 
 
 def compile(*args, **kwargs):
@@ -252,7 +254,10 @@ def disable(fn=None, recursive=True, *, reason=None):
 
 
 def set_stance(
-    stance: str = "default", *, skip_guard_eval_unsafe=False, force_backend=None
+    stance: str = "default",
+    *,
+    skip_guard_eval_unsafe: bool = False,
+    force_backend: Union[str, Callable[..., Any], None] = None,
 ):
     """
     Set the current stance of the compiler.


### PR DESCRIPTION
As part of better engineering week, we would like to improve out type support to improve dev experience in dynamo

This PR adds strict typing support to an important file in dynamo, `decorators.py`

NOTE: Untyped fns are because there is a conflict with `__init__.py` in compiler so we can't type these at this time

Running 
```
mypy torch/_dynamo/decorators.py --linecount-report /tmp/coverage_log
```

| -------- | Lines Unannotated | Lines Total | % lines covered | Funcs Unannotated | Funcs Total | % funcs covered |
| -------- | ------- | -------- | ------- | ------- | ------- | ------- |
| Main  |  209 | 908 | 23.02% | 9 | 39 | 23.08% |
| This PR | 870 | 943 | 100.00% | 36 | 39 | 100.00% |
| Delta    | +661 | +35 | +76.98% | +27 | 0 | +76.92% |




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames