### PR TITLE
Use more fine-grained locks in sym mem kernels

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory-inl.h
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory-inl.h
@@ -115,54 +115,44 @@ __device__ __forceinline__ void wait_signal(uint32_t* addr) {
 // Pattern 0: Ensures that all writes to symm_mem buffers from previous
 // kernels across all devices are visible to the current kernel:
 //
-//   sync_remote_blocks<std::memory_order_relaxed>(...);
+//   sync_remote_blocks<false, true>(...);
 //   __syncthreads();
 //
 // Pattern 1: Ensures that all writes to symm_mem buffers from the current
 // block are visible to all remote blocks with matching blockIdx:
 //
 //   __syncthreads();
-//   sync_remote_blocks<std::memory_order_acq_rel>(...);
+//   sync_remote_blocks<true, true>(...);
 //   __syncthreads();
 //
 // Pattern 2: Ensures that symm_mem buffers read by the current kernel are safe
 // for writing by subsequent kernels across all devices.
 //
 //   __syncthreads();
-//   sync_remote_blocks<std::memory_order_relaxed>(...);
-template <std::memory_order Sem>
+//   sync_remote_blocks<true, false>(...);
+template <bool hasPrevMemAccess, bool hasSubsequentMemAccess>
 __device__ __forceinline__ void sync_remote_blocks(
     uint32_t** signal_pads,
     size_t rank,
-    size_t world_size);
-
-template <>
-__device__ __forceinline__ void sync_remote_blocks<std::memory_order_relaxed>(
-    uint32_t** signal_pads,
-    size_t rank,
     size_t world_size) {
   if (threadIdx.x < world_size) {
     auto target_rank = threadIdx.x;
-    put_signal<std::memory_order_relaxed>(
-        signal_pads[target_rank] + blockIdx.x * world_size + rank);
-    wait_signal<std::memory_order_relaxed>(
-        signal_pads[rank] + blockIdx.x * world_size + target_rank);
+    if constexpr (hasPrevMemAccess) {
+      put_signal<std::memory_order_release>(
+          signal_pads[target_rank] + blockIdx.x * world_size + rank);
+    } else {
+      put_signal<std::memory_order_relaxed>(
+          signal_pads[target_rank] + blockIdx.x * world_size + rank);
+    }
+    if constexpr (hasSubsequentMemAccess) {
+      wait_signal<std::memory_order_acquire>(
+          signal_pads[rank] + blockIdx.x * world_size + target_rank);
+    } else {
+      wait_signal<std::memory_order_relaxed>(
+          signal_pads[rank] + blockIdx.x * world_size + target_rank);
+    }
   }
-}
-
-template <>
-__device__ __forceinline__ void sync_remote_blocks<std::memory_order_acq_rel>(
-    uint32_t** signal_pads,
-    size_t rank,
-    size_t world_size) {
-  if (threadIdx.x < world_size) {
-    auto target_rank = threadIdx.x;
-    put_signal<std::memory_order_release>(
-        signal_pads[target_rank] + blockIdx.x * world_size + rank);
-    wait_signal<std::memory_order_acquire>(
-        signal_pads[rank] + blockIdx.x * world_size + target_rank);
-  }
-}
+};
 
 template <typename T>
 struct MultimemLdReduce {


### PR DESCRIPTION
Summary: Use only acq in the beginning of the kernel, and only release in the end

Test Plan:
Existing tests

Rollback Plan:

Differential Revision: D78458020




cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta