### PR TITLE
Add a way to disable compile for debugging flex-attention

### DIFF
--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -62,7 +62,7 @@ def _warn_once(
 ) -> None:
     """Helper to ensure each warning is shown only once per process."""
     if warning_id not in _WARNINGS_SHOWN:
-        warnings.warn(message, category, stacklevel=3)
+        warnings.warn(message, category, stacklevel=2)
         _WARNINGS_SHOWN.add(warning_id)
 
 
@@ -1580,13 +1580,14 @@ def flex_attention(
 
     if not _FLEX_ATTENTION_DISABLE_COMPILE_DEBUG:
         _warn_once(
-            "flex_attention_performance",
-            "flex_attention called without torch.compile() - this will use an unrolled vmap "
-            "implementation that materializes the full attention matrix instead of generating "
-            "a fused kernels. Use torch.compile(flex_attention)(...). "
-            "If you need to debug your score_mod/mask_mod functions with breakpoints, you can set "
-            "torch.nn.attention.flex_attention._FLEX_ATTENTION_DISABLE_COMPILE_DEBUG=True, but note "
-            "this is not guaranteed to work with all score/mask mods and may produce incorrect results.",
+            warning_id="flex_attention_performance",
+            message=(
+                "flex_attention called without torch.compile() - this will use an unfused implementation that materializes the full scores matrix instead of generating a fused kernel.\n\n"
+                "SOLUTION: Use torch.compile(flex_attention)(...)\n\n"
+                "If you want to debug your score_mod/mask_mod, you can set:\n"
+                "torch.nn.attention.flex_attention._FLEX_ATTENTION_DISABLE_COMPILE_DEBUG = True\n\n"
+                "This will allow you to use print statements or breakpoints. Note: This doesn't work with the backwards pass and may produce incorrect results."
+            ),
         )
 
     if not torch._dynamo.is_dynamo_supported():

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -52,8 +52,18 @@ from torch.utils._pytree import tree_map_only
 #   # Now you can set breakpoints in your score_mod/mask_mod
 #   output = fa.flex_attention(q, k, v, score_mod=my_score_mod)
 #
-# Remember to set this back to False for production use.
 _FLEX_ATTENTION_DISABLE_COMPILE_DEBUG = False
+
+_WARNINGS_SHOWN: set[str] = set()
+
+
+def _warn_once(
+    warning_id: str, message: str, category: type[Warning] = UserWarning
+) -> None:
+    """Helper to ensure each warning is shown only once per process."""
+    if warning_id not in _WARNINGS_SHOWN:
+        warnings.warn(message, category, stacklevel=3)
+        _WARNINGS_SHOWN.add(warning_id)
 
 
 __all__ = [
@@ -1568,6 +1578,17 @@ def flex_attention(
         else:
             return out
 
+    if not _FLEX_ATTENTION_DISABLE_COMPILE_DEBUG:
+        _warn_once(
+            "flex_attention_performance",
+            "flex_attention called without torch.compile() - this will use an unrolled vmap "
+            "implementation that materializes the full attention matrix instead of generating "
+            "a fused kernels. Use torch.compile(flex_attention)(...). "
+            "If you need to debug your score_mod/mask_mod functions with breakpoints, you can set "
+            "torch.nn.attention.flex_attention._FLEX_ATTENTION_DISABLE_COMPILE_DEBUG=True, but note "
+            "this is not guaranteed to work with all score/mask mods and may produce incorrect results.",
+        )
+
     if not torch._dynamo.is_dynamo_supported():
         raise RuntimeError("flex_attention requires dynamo support")
 
@@ -1592,20 +1613,13 @@ def flex_attention(
                         backend = "eager"
 
                     if _FLEX_ATTENTION_DISABLE_COMPILE_DEBUG:
-                        warnings.warn(
-                            "_FLEX_ATTENTION_DISABLE_COMPILE_DEBUG is enabled. This bypasses required "
-                            "compilation and should ONLY be used for debugging. Performance and "
-                            "correctness are not guaranteed. Set this flag to False for production use.",
-                            UserWarning,
-                            stacklevel=2,
-                        )
-                        compiled_fn = _flex_attention_hop_wrapper
+                        flex_fn = _flex_attention_hop_wrapper
                     else:
-                        compiled_fn = torch.compile(
+                        flex_fn = torch.compile(
                             _flex_attention_hop_wrapper, backend=backend, fullgraph=True
                         )
 
-                    out, lse = compiled_fn(
+                    out, lse = flex_fn(
                         query,
                         key,
                         value,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #158617
* __->__ #158534



Finally got around to doing this, this flag lets us do:

```Python


#!/usr/bin/env python3
"""
FlexAttention Debug: Using breakpoints and unwrap
"""

import torch
import torch.nn.attention.flex_attention as fa

unwrap = torch._C._functorch.get_unwrapped

def score_mod(score, batch, head, q_idx, kv_idx):
    # Set breakpoint here to debug
    breakpoint()
    
    # In debugger, unwrap to see actual tensor values:
    # >>> actual_score = unwrap(unwrap(unwrap(unwrap(score))))
    # >>> actual_batch = unwrap(batch)
    # >>> actual_head = unwrap(head)
    # >>> actual_q_idx = unwrap(q_idx)
    # >>> actual_kv_idx = unwrap(kv_idx)
    # >>> print(actual_score)
    # >>> print(f"q_idx: {actual_q_idx}, kv_idx: {actual_kv_idx}")
    
    return torch.where(q_idx >= kv_idx, score, torch.tensor(float('-inf')))

def main():
    # Enable debug mode
    fa._FLEX_ATTENTION_DISABLE_COMPILE_DEBUG = True
    
    # Small example
    B, H, S, D = 1, 2, 4, 8
    q = torch.randn(B, H, S, D)
    k = torch.randn(B, H, S, D)
    v = torch.randn(B, H, S, D)
    
    # Run - will hit breakpoint
    output = fa.flex_attention(q, k, v, score_mod=score_mod)
    
    # Disable debug mode
    fa._FLEX_ATTENTION_DISABLE_COMPILE_DEBUG = False

if __name__ == "__main__":
    main()

```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @Chillee @yanboliang @BoyuanFeng