### PR TITLE
[AOTI] Use format_consts_to_cpp on Windows.

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1804,6 +1804,10 @@ class AotCodeCompiler:
             elif platform == "darwin":
                 section_attr = "__DATA,__data"
                 symbol_prefix = "_"
+            elif platform == "win32":
+                symbol_prefix = ""
+                # ASM build is not supported on Windows, force use CPP build.
+                use_asm_build = False
             else:
                 raise RuntimeError(f"Unsupported platform: {platform}")
 


### PR DESCRIPTION
`format_consts_to_asm` is not supported on Windows, force use `format_consts_to_cpp` on Windows.


cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov