### PR TITLE
Add check `requires_grad` in `zeroTensorFallback`

### DIFF
--- a/aten/src/ATen/ZeroTensorFallback.cpp
+++ b/aten/src/ATen/ZeroTensorFallback.cpp
@@ -58,6 +58,7 @@ namespace at {
       if (ivalue.isTensor()) {
         auto tensor = std::move(ivalue).toTensor();
         if (tensor._is_zerotensor()) {
+          TORCH_CHECK(!tensor.requires_grad(), "ZeroTensor `requires_grad` must be False, but got: ", tensor.requires_grad());
           TORCH_CHECK(!mut_arg, "ZeroTensors are immutable. Please use the materialized zero tensor ",
                     "obtained using .clone() if you want a mutable tensor.");
           tensor = at::zeros({}, tensor.options()).expand(tensor.sizes());
@@ -68,7 +69,7 @@ namespace at {
         for(const auto j : c10::irange(tensors.size())) {
           const Tensor& tensor = tensors[j];
           if (tensor._is_zerotensor()) {
-            // TODO: assert requires_grad=False
+            TORCH_CHECK(!tensor.requires_grad(), "ZeroTensor `requires_grad` must be False, but got: ", tensor.requires_grad());
             //_like should not propagate zerotensor dispatch key
             TORCH_CHECK(!mut_arg, "ZeroTensors are immutable. Please use the materialized zero tensor ",
                     "obtained using .clone() if you want a mutable tensor.");

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10997,6 +10997,17 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
 
             self.assertEqual(len(w), 0)
 
+    def test_zerotensor_errors(self):
+        a = torch._efficientzerotensor(3)
+        b = torch._efficientzerotensor(3)
+        a.requires_grad = True
+        with self.assertRaisesRegex(RuntimeError, "ZeroTensor `requires_grad` must be False"):
+            a.mul(b)
+
+        a.requires_grad = False
+        b.requires_grad = True
+        with self.assertRaisesRegex(RuntimeError, "ZeroTensor `requires_grad` must be False"):
+            a.mul(b)
 
 # The following block extends TestTorch with negative dim wrapping tests
 # FIXME: replace these with OpInfo sample inputs or systemic OpInfo tests


### PR DESCRIPTION
Fixes TODO in `ZeroTensorFallback.cpp`, add check `requires_grad` in `zeroTensorFallback`

## Test Result

```bash
pytest test/test_torch.py

.............................ssssssssssss.............................................s...........................ssss.s...................ss              [100%]
============= 1771 passed, 117 skipped in 683.44s (0:11:23) ========
```