### PR TITLE
[OpenReg] Implement device autoload mechanism

### DIFF
--- a/docs/source/accelerator/autoload.md
+++ b/docs/source/accelerator/autoload.md
@@ -1,0 +1,57 @@
+## Autoload
+
+The **Autoload** mechanism in PyTorch simplifies the integration of custom backends by enabling automatic discovery and initialization at runtime. This eliminates the need for explicit imports or manual initialization, allowing developers to seamlessly integrate new accelerators or backends into PyTorch.
+
+This tutorial will guide you through the steps to enable and use the Autoload mechanism for a custom backend.
+
+### Step 1
+
+The first step is to define an initialization hook for your backend. This hook will be automatically invoked by PyTorch during startup.
+
+::::{tab-set}
+
+:::{tab-item} Python
+
+```{eval-rst}
+.. literalinclude:: ../../../test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/__init__.py
+    :language: python
+    :start-after: LITERALINCLUDE START: AUTOLOAD
+    :end-before: LITERALINCLUDE END: AUTOLOAD
+    :linenos:
+```
+
+:::
+
+::::
+
+### Step 2
+
+To enable Autoload, you need to register the `_autoload` function as an entry point in your `setup.py` file.
+
+The first step is to define an initialization hook for your backend. This hook will be automatically invoked by PyTorch during startup.
+
+::::{tab-set}
+
+:::{tab-item} Python
+
+```{eval-rst}
+.. literalinclude:: ../../../test/cpp_extensions/open_registration_extension/torch_openreg/setup.py
+    :language: python
+    :start-after: LITERALINCLUDE START: SETUP
+    :end-before: LITERALINCLUDE END: SETUP
+    :linenos:
+```
+
+:::
+
+::::
+
+### Step 2
+
+After defining the initialization hook and registering the entry point, build and install your backend. Now, we can use the new accelerators without explicitly importing it.
+
+    ```Python
+    >>> import torch
+    >>> torch.tensor(1, device="openreg")
+    tensor(1, device='openreg:0')
+    ```

--- a/docs/source/accelerator/autoload.md
+++ b/docs/source/accelerator/autoload.md
@@ -4,7 +4,7 @@ The **Autoload** mechanism in PyTorch simplifies the integration of custom backe
 
 This tutorial will guide you through the steps to enable and use the Autoload mechanism for a custom backend.
 
-### Step 1
+### Hook Initialization
 
 The first step is to define an initialization hook for your backend. This hook will be automatically invoked by PyTorch during startup.
 
@@ -24,7 +24,7 @@ The first step is to define an initialization hook for your backend. This hook w
 
 ::::
 
-### Step 2
+### Backend Registrition
 
 To enable Autoload, you need to register the `_autoload` function as an entry point in your `setup.py` file.
 
@@ -46,7 +46,7 @@ The first step is to define an initialization hook for your backend. This hook w
 
 ::::
 
-### Step 2
+### Using Backend with Autoload
 
 After defining the initialization hook and registering the entry point, build and install your backend. Now, we can use the new accelerators without explicitly importing it.
 

--- a/docs/source/accelerator/autoload.md
+++ b/docs/source/accelerator/autoload.md
@@ -3,7 +3,21 @@
 The **Autoload** mechanism in PyTorch simplifies the integration of custom backends by enabling automatic discovery and initialization at runtime. This eliminates the need for explicit imports or manual initialization, allowing developers to seamlessly integrate new accelerators or backends into PyTorch.
 
 This tutorial will guide you through the steps to enable and use the Autoload mechanism for a custom backend.
+# Autoload Mechanism
 
+## Background
+
+## Design
+
+## Implementation
+
+### Entry Point Setup 
+
+### Backend Setup
+
+## result
+
+Please use `sphinx_design cards` to display the before-and-after differences. For more information, see this [link](https://studynotes.readthedocs.io/zh/main/struct/extend/design/design-index.html).
 ### Hook Initialization
 
 The first step is to define an initialization hook for your backend. This hook will be automatically invoked by PyTorch during startup.

--- a/docs/source/accelerator/autoload.md
+++ b/docs/source/accelerator/autoload.md
@@ -1,44 +1,28 @@
-# Autoload
-
-The **Autoload** mechanism in PyTorch simplifies the integration of custom backends by enabling automatic discovery and initialization at runtime. This eliminates the need for explicit imports or manual initialization, allowing developers to seamlessly integrate new accelerators or backends into PyTorch.
-
-This tutorial will guide you through the steps to enable and use the Autoload mechanism for a custom backend.
 # Autoload Mechanism
+
+The **Autoload** mechanism in PyTorch simplifies the integration of a custom backend by enabling automatic discovery and initialization at runtime. This eliminates the need for explicit imports or manual initialization, allowing developers to seamlessly integrate a new accelerator or backend into PyTorch.
 
 ## Background
 
+The **Autoload Device Extension** proposal in PyTorch is centered on improving support for various hardware backend devices, especially those implemented as out-of-the-tree extensions (not part of PyTorch’s main codebase). Currently, users must manually import or load these device-specific extensions to use them, which complicates the experience and increases cognitive overhead.
+
+In contrast, in-tree devices (devices officially supported within PyTorch) are seamlessly integrated—users don’t need extra imports or steps. The goal of autoloading is to make out-of-the-tree devices just as easy to use, so users can follow the standard PyTorch device programming model without explicit loading or code changes. This would allow existing PyTorch applications to run on new devices without any modification, making hardware support more user-friendly and reducing barriers to adoption.
+
+For more information about the background of **Autoload**, please refer to its [RFC](https://github.com/pytorch/pytorch/issues/122468).
+
 ## Design
+
+The core idea of **Autoload** is to Use Python’s plugin discovery (entry points) so PyTorch automatically loads out-of-tree device extensions when torch is imported—no explicit user import needed.
+
+For more instructions of the design of **Autoload**, please refer to [**How it works**](https://docs.pytorch.org/tutorials/unstable/python_extension_autoload.html#how-it-works).
 
 ## Implementation
 
-### Entry Point Setup 
+This tutorial will take **OpenReg** as a new out-of-the-tree device and guide you through the steps to enable and use the **Autoload** mechanism.
 
-### Backend Setup
+### Entry Point Setup
 
-## result
-
-Please use `sphinx_design cards` to display the before-and-after differences. For more information, see this [link](https://studynotes.readthedocs.io/zh/main/struct/extend/design/design-index.html).
-### Hook Initialization
-
-The first step is to define an initialization hook for your backend. This hook will be automatically invoked by PyTorch during startup.
-
-::::{tab-set-code}
-```{eval-rst}
-.. literalinclude:: ../../../test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/__init__.py
-    :language: python
-    :start-after: LITERALINCLUDE START: AUTOLOAD
-    :end-before: LITERALINCLUDE END: AUTOLOAD
-    :linenos:
-```
-
-
-::::
-
-### Backend Registrition
-
-To enable Autoload, you need to register the `_autoload` function as an entry point in your `setup.py` file.
-
-The first step is to define an initialization hook for your backend. This hook will be automatically invoked by PyTorch during startup.
+To enable **Autoload**, register the `_autoload` function as an entry point in `setup.py` file.
 
 ::::{tab-set}
 
@@ -50,18 +34,53 @@ The first step is to define an initialization hook for your backend. This hook w
     :start-after: LITERALINCLUDE START: SETUP
     :end-before: LITERALINCLUDE END: SETUP
     :linenos:
+    :emphasize-lines: 9-13
 ```
 
 :::
 
 ::::
 
-### Using Backend with Autoload
+### Backend Setup
 
-After defining the initialization hook and registering the entry point, build and install your backend. Now, we can use the new accelerators without explicitly importing it.
+Define the initialization hook `_autoload` for backend initialization. This hook will be automatically invoked by PyTorch during startup.
 
-    ```Python
-    >>> import torch
-    >>> torch.tensor(1, device="openreg")
-    tensor(1, device='openreg:0')
-    ```
+::::{tab-set-code}
+```{eval-rst}
+.. literalinclude:: ../../../test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/__init__.py
+    :language: python
+    :start-after: LITERALINCLUDE START: AUTOLOAD
+    :end-before: LITERALINCLUDE END: AUTOLOAD
+    :linenos:
+    :emphasize-lines: 10-12
+```
+
+
+::::
+
+## Result
+
+After setting up the entry point and backend, build and install your backend. Now, we can use the new accelerator without explicitly importing it.
+
+```{eval-rst}
+.. grid:: 2
+
+    .. grid-item-card:: :octicon:`terminal;1em;` Without Autoload
+       :class-card: card-prerequisites
+
+       ::
+
+           >>> import torch
+           >>> import torch_openreg
+           >>> torch.tensor(1, device="openreg")
+           tensor(1, device='openreg:0')
+
+    .. grid-item-card:: :octicon:`terminal;1em;` With Autoload
+       :class-card: card-prerequisites
+
+       ::
+
+           >>> import torch # Automatically import torch_openreg
+           >>> torch.tensor(1, device="openreg")
+           tensor(1, device='openreg:0')
+```

--- a/docs/source/accelerator/autoload.md
+++ b/docs/source/accelerator/autoload.md
@@ -8,10 +8,7 @@ This tutorial will guide you through the steps to enable and use the Autoload me
 
 The first step is to define an initialization hook for your backend. This hook will be automatically invoked by PyTorch during startup.
 
-::::{tab-set}
-
-:::{tab-item} Python
-
+::::{tab-set-code}
 ```{eval-rst}
 .. literalinclude:: ../../../test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/__init__.py
     :language: python

--- a/docs/source/accelerator/autoload.md
+++ b/docs/source/accelerator/autoload.md
@@ -17,7 +17,6 @@ The first step is to define an initialization hook for your backend. This hook w
     :linenos:
 ```
 
-:::
 
 ::::
 

--- a/docs/source/accelerator/autoload.md
+++ b/docs/source/accelerator/autoload.md
@@ -1,4 +1,4 @@
-## Autoload
+# Autoload
 
 The **Autoload** mechanism in PyTorch simplifies the integration of custom backends by enabling automatic discovery and initialization at runtime. This eliminates the need for explicit imports or manual initialization, allowing developers to seamlessly integrate new accelerators or backends into PyTorch.
 

--- a/docs/source/accelerator/index.md
+++ b/docs/source/accelerator/index.md
@@ -46,6 +46,7 @@ This guide is a work in progress. For more details, please refer to the [roadmap
 :glob:
 :maxdepth: 1
 
+autoload
 operators
 ```
 

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/README.md
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/README.md
@@ -128,7 +128,7 @@ There are 4 DSOs in torch_openreg, and the dependencies between them are as foll
 
 - Autoload Machanism
 
-When `import torch`, installed plugin backends (such as `torch_openreg`) will be automatically loaded, achieving the same experience as the built-in backends.
+    When `import torch`, installed accelerators (such as `torch_openreg`) will be automatically loaded, achieving the same experience as the built-in backends.
 
   - Registering the backend with Python `entry points`: See `setup` in `setup.py`
   - Adding a callable function for backend initialization: See `_autoload` in `torch_openreg/__init__.py`

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/README.md
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/README.md
@@ -124,6 +124,14 @@ There are 4 DSOs in torch_openreg, and the dependencies between them are as foll
     - Per-operator Fallback: See `sub.Tensor`
     - Global Fallback: See `wrapper_cpu_fallback`
 
+### Autoload
+
+- Autoload Backend Machanism
+
+  - Registering the backend with Python entry points: See `setup`
+  - Adding an invoked function for the backend initialization: See `_autoload`
+  - Dynamically loading the backend without explicit imports: See [Usage Example](#usage-example)
+
 ## Installation and Usage
 
 ### Installation
@@ -139,7 +147,7 @@ After installation, you can use the `openreg` device in Python just like any oth
 
 ```python
 import torch
-import torch_openreg
+# import torch_openreg <- No need to import this because it is automatically loaded
 
 if not torch.openreg.is_available():
     print("OpenReg backend is not available in this build.")

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/README.md
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/README.md
@@ -128,8 +128,10 @@ There are 4 DSOs in torch_openreg, and the dependencies between them are as foll
 
 - Autoload Backend Machanism
 
-  - Registering the backend with Python entry points: See `setup`
-  - Adding an invoked function for the backend initialization: See `_autoload`
+When `import torch`, installed plugin backends (such as `torch_openreg`) will be automatically loaded, achieving the same experience as the built-in backends.
+
+  - Registering the backend with Python `entry points`: See `setup` in `setup.py`
+  - Adding a callable function for backend initialization: See `_autoload` in `torch_openreg/__init__.py`
   - Dynamically loading the backend without explicit imports: See [Usage Example](#usage-example)
 
 ## Installation and Usage
@@ -147,7 +149,6 @@ After installation, you can use the `openreg` device in Python just like any oth
 
 ```python
 import torch
-# import torch_openreg <- No need to import this because it is automatically loaded
 
 if not torch.openreg.is_available():
     print("OpenReg backend is not available in this build.")

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/README.md
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/README.md
@@ -126,7 +126,7 @@ There are 4 DSOs in torch_openreg, and the dependencies between them are as foll
 
 ### Autoload
 
-- Autoload Backend Machanism
+- Autoload Machanism
 
 When `import torch`, installed plugin backends (such as `torch_openreg`) will be automatically loaded, achieving the same experience as the built-in backends.
 

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/setup.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/setup.py
@@ -146,7 +146,7 @@ def main():
             ],
         },
     )
-    # LITERALINCLUDE START: SETUP
+    # LITERALINCLUDE END: SETUP
 
 
 if __name__ == "__main__":

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/setup.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/setup.py
@@ -28,6 +28,10 @@ def make_relative_rpath_args(path):
 
 
 def get_pytorch_dir():
+    # Disable autoload of device backends.
+    # This is necessary to avoid issues with the backend being loaded
+    # before the extension is built.
+    os.environ["TORCH_DEVICE_BACKEND_AUTOLOAD"] = "0"
     import torch
 
     return os.path.dirname(os.path.realpath(torch.__file__))
@@ -127,6 +131,7 @@ def main():
         ]
     }
 
+    # LITERALINCLUDE START: SETUP
     setup(
         packages=find_packages(),
         package_data=package_data,
@@ -135,7 +140,13 @@ def main():
             "clean": BuildClean,  # type: ignore[misc]
         },
         include_package_data=False,
+        entry_points={
+            "torch.backends": [
+                "torch_openreg = torch_openreg:_autoload",
+            ],
+        },
     )
+    # LITERALINCLUDE START: SETUP
 
 
 if __name__ == "__main__":

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/setup.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/setup.py
@@ -28,9 +28,11 @@ def make_relative_rpath_args(path):
 
 
 def get_pytorch_dir():
-    # Disable autoload of device backends.
-    # This is necessary to avoid issues with the backend being loaded
-    # before the extension is built.
+    # Disable autoload of the accelerator
+
+    # We must do this for two reasons:
+    # We only need to get the PyTorch installation directory, so whether the accelerator is loaded or not is irrelevant
+    # If the accelerator has been previously built and not uninstalled, importing torch will cause a circular import error
     os.environ["TORCH_DEVICE_BACKEND_AUTOLOAD"] = "0"
     import torch
 

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/__init__.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/__init__.py
@@ -17,3 +17,8 @@ import torch_openreg.openreg
 torch.utils.rename_privateuse1_backend("openreg")
 torch._register_device_module("openreg", torch_openreg.openreg)
 torch.utils.generate_methods_for_privateuse1_backend(for_storage=True)
+
+# LITERALINCLUDE START: AUTOLOAD
+def _autoload():
+    pass
+# LITERALINCLUDE START: AUTOLOAD

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/__init__.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/__init__.py
@@ -9,7 +9,7 @@ if sys.platform == "win32":
     _load_dll_libraries()
     del _load_dll_libraries
 
-
+# LITERALINCLUDE START: AUTOLOAD
 import torch_openreg._C  # type: ignore[misc]
 import torch_openreg.openreg
 
@@ -19,8 +19,8 @@ torch._register_device_module("openreg", torch_openreg.openreg)
 torch.utils.generate_methods_for_privateuse1_backend(for_storage=True)
 
 
-# LITERALINCLUDE START: AUTOLOAD
 def _autoload():
+    # It is a placeholder function here to be registered as an entry point.
     pass
 
 

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/__init__.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/__init__.py
@@ -18,7 +18,10 @@ torch.utils.rename_privateuse1_backend("openreg")
 torch._register_device_module("openreg", torch_openreg.openreg)
 torch.utils.generate_methods_for_privateuse1_backend(for_storage=True)
 
+
 # LITERALINCLUDE START: AUTOLOAD
 def _autoload():
     pass
-# LITERALINCLUDE START: AUTOLOAD
+
+
+# LITERALINCLUDE END: AUTOLOAD

--- a/test/test_openreg.py
+++ b/test/test_openreg.py
@@ -10,7 +10,6 @@ from unittest.mock import patch
 
 import numpy as np
 import psutil
-import torch_openreg  # noqa: F401
 
 import torch
 from torch.serialization import safe_globals

--- a/test/test_transformers_privateuse1.py
+++ b/test/test_transformers_privateuse1.py
@@ -4,8 +4,6 @@ import unittest
 from collections import namedtuple
 from functools import partial
 
-import torch_openreg  # noqa: F401
-
 import torch
 from torch.nn.attention import SDPBackend
 from torch.testing._internal.common_nn import NNTestCase


### PR DESCRIPTION
# Implement OpenReg device autoload mechanism

## Overview
The **Autoload** mechanism in PyTorch simplifies the integration of third-party device backends by enabling automatic discovery and initialization at runtime. Traditionally, integrating a new backend required explicit imports or manual initialization, which could be cumbersome and error-prone. With Autoload, PyTorch dynamically detects and initializes device backends, providing a seamless user experience.

This mechanism leverages Python entry points (e.g., `torch.backends`) and dynamic module loading. When PyTorch starts, it scans for registered entry points and invokes their initialization hooks, ensuring that all available backends are ready for use without requiring explicit imports.

## Motivation

This PR aims to apply [device autoload mechanism](https://github.com/pytorch/pytorch/issues/122468) to the OpenReg module with some simple changes.

## Change
### Before
```python
import torch
import torch_openreg

x = torch.tensor([1, 2, 3], device="openreg")
print(x)
```
### After
```python
import torch

# No need to import torch_openreg manually!
x = torch.tensor([1, 2, 3], device="openreg")
print(x)
```

cc @FFFrog @albanD 
