### PR TITLE
Enable `test/test_numpy_interop.py` config in mypy

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -132,7 +132,7 @@ include_patterns = [
     'test/test_complex.py',
     'test/test_datapipe.py',
     'test/test_futures.py',
-    # 'test/test_numpy_interop.py',
+    'test/test_numpy_interop.py',
     'test/test_torch.py',
     'test/test_type_hints.py',
     'test/test_type_info.py',


### PR DESCRIPTION
## Test Result

```bash
lintrunner --take MYPY test/test_numpy_interop.py 

Warning: Could not find a lintrunner config at: '.lintrunner.private.toml'. Continuing without using configuration file.
ok No lint issues.
```

cc @Skylion007 