### PR TITLE
[cuda][complex] Use scaling to compute the absolute value of complex number to avoid overflow

### DIFF
--- a/aten/src/ATen/cuda/llvm_complex.cpp
+++ b/aten/src/ATen/cuda/llvm_complex.cpp
@@ -578,7 +578,14 @@ inline
 _Tp
 abs(const complex<_Tp>& __c)
 {
-    return hypot(__c.real(), __c.imag());
+    _Tp result = hypot(__c.real(), __c.imag());
+    if (isinf(result)) {
+        _Tp max_val = max(abs(__c.real()), abs(__c.imag()));
+        _Tp scaled_real = __c.real() / max_val;
+        _Tp scaled_imag = __c.imag() / max_val;
+        return max_val * hypot(scaled_real, scaled_imag));
+    }
+    return result; 
 }
 
 // arg


### PR DESCRIPTION
## Fixes  https://github.com/pytorch/pytorch/issues/158412

## mini repro
* just copy from the issue:
```python
import torch
max_float64 = 1.7976931348623157e+308
real = torch.ones((3, 3), dtype=torch.float64)
imag = torch.full((3, 3), max_float64, dtype=torch.float64)
input = torch.complex(real, imag)
input_gpu = input.cuda()
try:
    out_gpu = torch.absolute(input=input_gpu)
    print(out_gpu) //all inf
except Exception as e:
    print(e)
input_cpu = input.cpu()
try:
    out_cpu = torch.absolute(input=input_cpu)
    print(out_cpu) //all 1.7977e+308
except Exception as e:
    print(e)
```
The output from cpu is  1.7976931348623157e+308 while cuda is inf
## summary
* The absolute op of CUDA implementation cannot manage overflow correctly when the input is very big.
related code:
https://github.com/pytorch/pytorch/blob/d5af0eca8def9a4ae1af69638de3983f3bec778c/aten/src/ATen/cuda/llvm_complex.cpp#L581
## proof procedure
### cuda
* Let us just write a cu program, and use a complex number whose real is 1.0 and imag is max value of double to reproduce the bug
```cuda
#include <complex>
#include <cuda_runtime.h>
#include <cmath>
#include <cuda.h>

template <typename T>
__device__ void abs_kernel(T c) {
    printf("%f\n", hypot(c.real(), c.imag()));
}

__device__ void call_abs_kernel() {
    // 1.7976931348623157e+308 is the max value of double.
    std::complex<double> c(1.0, 1.7976931348623157e+308);
    abs_kernel(c);  
}


__global__ void wrapper_call() {
    call_abs_kernel();
}

int main() {
    const int numBlocks = 2;
    const int numThreadsPerBlock = 4;
    wrapper_call<<<numBlocks, numThreadsPerBlock>>>();
    cudaDeviceSynchronize();

    return 0;
}
```
use nvcc to compile it.
```bash
nvcc -o reproduce_abs_kernel reproduce_abs_kernel.cu --expt-relaxed-constexpr
```
the output is
```bash
inf
inf
inf
inf
inf
inf
inf
inf
```
### c++
I wrote a C++ code that is implemented based on the PyTorch CPU absolute function.
https://github.com/pytorch/pytorch/blob/d5af0eca8def9a4ae1af69638de3983f3bec778c/c10/util/complex.h#L554
```c++
#include <iostream>
#include <complex>
#include <limits>
#include <cmath>

int main() {
    // std::numeric_limits<double>::max() equals 1.7976931348623157e+308
    std::complex<double> myComplex(1.0, std::numeric_limits<double>::max());

    double absValue = std::abs(myComplex);
    std::cout << "The absolute value of the complex number is: " << absValue << std::endl;

    return 0;
```
use g++ to compile it:
```bash
g++ -o complex_cpp complex_cpp.cpp
```
and the output is
```bash
The absolute value of the complex number is: 1.79769e+308
```
### conclusion
* The current absolute operation in CUDA cannot handle overflow correctly, so I used scaling to prevent overflow.