### PR TITLE
Add lower bounds for fsspec and networkx dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,11 +16,11 @@ typing-extensions>=4.10.0
 build[uv]  # for building sdist and wheel
 expecttest>=0.3.0
 filelock
-fsspec
+fsspec>=0.8.5
 hypothesis
 jinja2
 lintrunner ; platform_machine != "s390x"
-networkx
+networkx>=2.5.1
 optree>=0.13.0
 psutil
 sympy>=1.13.3

--- a/setup.py
+++ b/setup.py
@@ -1233,9 +1233,9 @@ def main() -> None:
         "typing-extensions>=4.10.0",
         'setuptools ; python_version >= "3.12"',
         "sympy>=1.13.3",
-        "networkx",
+        "networkx>=2.5.1",
         "jinja2",
-        "fsspec",
+        "fsspec>=0.8.5",
     ]
     if BUILD_PYTHON_ONLY:
         install_requires += [f"{LIBTORCH_PKG_NAME}=={TORCH_VERSION}"]


### PR DESCRIPTION
Fixes #156587 

This sets lower bounds for fsspec and networkx in both setup.py and requirements,txt.

- fsspec>= 0.8.5 (released December 15, 2020)
- netowrkx>= 2.5.1 (released April 3, 2021)

These are the first stable versions released after Python 3.9 came out on October 5, 2020. Since Python 3.8 is no longer maintained, setting these minimums helps ensure PyTorch won't be installed alongside unexpectedly old versions of these packages.

Tested with these versions locally to make sure they don't break anything. Adding CI for lower-bound testing could be a follow up later if need.
