### PR TITLE
[DCP] Add support for ShardedTensor to PgTransport

### DIFF
--- a/test/distributed/checkpoint/test_pg_transport.py
+++ b/test/distributed/checkpoint/test_pg_transport.py
@@ -1,13 +1,17 @@
 # Owner(s): ["oncall: distributed"]
 
 import logging
-import os
 from datetime import timedelta
 from typing import Optional
 from unittest.mock import MagicMock, patch
 
 import torch
 import torch.nn as nn
+from torch.distributed._shard.sharded_tensor import (
+    init_from_local_shards,
+    Shard as ShardedTensorShard,
+    ShardMetadata,
+)
 from torch.distributed.checkpoint._pg_transport import (
     _cast_tensor,
     _prepare_state_dict,
@@ -34,9 +38,56 @@ from torch.testing._internal.common_utils import (
 logger = logging.getLogger(__name__)
 
 
+def _create_sharded_tensor_state_dict(
+    rank: int, world_size: int, device: torch.device
+) -> dict:
+    """
+    Create state_dict with ShardedTensor for deterministic testing.
+    Args:
+        rank: Current rank
+        world_size: Total world size
+        device: Device to create tensors on
+    Returns:
+        dict: State dictionary with ShardedTensor
+    """
+    # Create deterministic local shard for this rank
+    global_size = 64
+    shard_size = global_size // world_size
+    start_idx = rank * shard_size
+    end_idx = (rank + 1) * shard_size
+
+    # Create local tensor with deterministic values
+    local_tensor = torch.arange(
+        start_idx * 8, end_idx * 8, dtype=torch.float32, device=device
+    ).reshape(shard_size, 8)
+
+    # Create ShardedTensor using init_from_local_shards
+    sharded_tensor = init_from_local_shards(
+        [
+            ShardedTensorShard(
+                tensor=local_tensor,
+                metadata=ShardMetadata(
+                    shard_offsets=[start_idx, 0],
+                    shard_sizes=[shard_size, 8],
+                    placement=f"rank:{rank}/{device}",
+                ),
+            )
+        ],
+        global_size,
+        8,
+    )
+
+    return {
+        "sharded_tensor": sharded_tensor,
+        "rank_scalar": torch.tensor(float(rank), device=device),
+    }
+
+
 class SimpleModel(nn.Module):
-    def __init__(self):
+    def __init__(self, seed: int = 42):
         super().__init__()
+        # Set seed for deterministic initialization
+        torch.manual_seed(seed)
         self.net1 = nn.Linear(10, 10)
         self.relu = nn.ReLU()
         self.net2 = nn.Linear(10, 10)
@@ -50,6 +101,7 @@ def ring_send_recv_checkpoint(
 ):
     """
     Use the transport to send to rank + 1 and receive from rank - 1.
+    Each rank exchanges its own state_dict with the previous rank.
     """
     next_rank = (rank + 1) % world_size
     prev_rank = (rank - 1) % world_size
@@ -58,15 +110,11 @@ def ring_send_recv_checkpoint(
         received_checkpoint = transport.recv_checkpoint(prev_rank)
     else:
         received_checkpoint = transport.recv_checkpoint(prev_rank)
-        transport.send_checkpoint([next_rank], received_checkpoint)
+        transport.send_checkpoint([next_rank], state_dict)
     return received_checkpoint
 
 
 def _test_pg_transport(self, device) -> None:
-    # python test/distributed/checkpoint/test_pg_transport.py -k test_pg_transport
-    print(f"{self.rank=} pid: {os.getpid()} {device=}")
-    print("in test")
-
     model = SimpleModel().to(device)
     transport = PGTransport(_get_default_group(), timedelta(seconds=10), device)
     original_state_dict = model.state_dict()
@@ -111,6 +159,48 @@ def _test_pg_transport_with_mixed_content(self, device) -> None:
     self.assertEqual(state_dict, received_checkpoint)
 
 
+def _test_pg_transport_with_sharded_tensor(self, device) -> None:
+    # Set current CUDA device for NCCL
+    if device.type == "cuda":
+        torch.cuda.set_device(device)
+
+    state_dict = _create_sharded_tensor_state_dict(self.rank, self.world_size, device)
+    transport = PGTransport(_get_default_group(), timedelta(seconds=10), device)
+    print(state_dict)
+    received_checkpoint = ring_send_recv_checkpoint(
+        transport=transport,
+        state_dict=state_dict,
+        rank=self.rank,
+        world_size=self.world_size,
+    )
+    print("finished comms")
+    print(received_checkpoint)
+
+    # Validate that received checkpoint matches what we expect from rank - 1
+    prev_rank = (self.rank - 1) % self.world_size
+
+    # Compare rank_scalar (should be from previous rank)
+    # Note: PGTransport moves received tensors to CPU when no state_dict callback is provided
+    expected_rank_scalar = torch.tensor(float(prev_rank), device="cpu")
+    received_rank_scalar = received_checkpoint["rank_scalar"]  # type: ignore[index]
+    print(f"{expected_rank_scalar=} {received_rank_scalar=}")
+    torch.testing.assert_close(expected_rank_scalar, received_rank_scalar)
+
+    # For ShardedTensor, validate the local shard data matches what prev_rank would have
+    received_st = received_checkpoint["sharded_tensor"]  # type: ignore[index]
+    global_size = 64
+    shard_size = global_size // self.world_size
+    prev_start_idx = prev_rank * shard_size
+    prev_end_idx = (prev_rank + 1) * shard_size
+    expected_local_tensor = torch.arange(
+        prev_start_idx * 8, prev_end_idx * 8, dtype=torch.float32, device="cpu"
+    ).reshape(shard_size, 8)
+
+    # Compare the actual tensor data
+    received_local_tensor = received_st.local_shards()[0].tensor
+    torch.testing.assert_close(expected_local_tensor, received_local_tensor)
+
+
 class PgTransportCPU(MultiProcContinousTest):
     world_size = 8
     timeout: timedelta = timedelta(seconds=20)
@@ -132,6 +222,9 @@ class PgTransportCPU(MultiProcContinousTest):
 
     def test_pg_transport_with_mixed_content(self) -> None:
         _test_pg_transport_with_mixed_content(self, self.device)
+
+    def test_pg_transport_with_sharded_tensor(self) -> None:
+        _test_pg_transport_with_sharded_tensor(self, self.device)
 
 
 class PgTransportCUDA(MultiProcContinousTest):
@@ -159,6 +252,11 @@ class PgTransportCUDA(MultiProcContinousTest):
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_pg_transport_with_mixed_content(self) -> None:
         _test_pg_transport_with_mixed_content(self, self.device)
+
+    @requires_nccl()
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
+    def test_pg_transport_with_sharded_tensor(self) -> None:
+        _test_pg_transport_with_sharded_tensor(self, self.device)
 
 
 class TestCastTensor(TestCase):
@@ -507,10 +605,6 @@ class TestPGTransportEdgeCases(TestCase):
 
         # Check that wait was called
         self.assertGreaterEqual(self.mock_work.wait.call_count, 4)
-
-
-# import fbvscode
-# fbvscode.attach_debugger()
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/test_pg_transport.py
+++ b/test/distributed/checkpoint/test_pg_transport.py
@@ -606,5 +606,6 @@ class TestPGTransportEdgeCases(TestCase):
         # Check that wait was called
         self.assertGreaterEqual(self.mock_work.wait.call_count, 4)
 
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/checkpoint/_pg_transport.py
+++ b/torch/distributed/checkpoint/_pg_transport.py
@@ -9,6 +9,12 @@ from typing import Callable, cast, Optional, TypeVar, Union
 
 import torch
 from torch.distributed import ProcessGroup, Work
+from torch.distributed._shard.sharded_tensor import (
+    Shard as ShardedTensorShard,
+    ShardedTensor,
+    ShardMetadata,
+)
+from torch.distributed._shard.sharded_tensor.metadata import ShardedTensorMetadata
 from torch.distributed.tensor import _DTensorSpec, DTensor
 from torch.utils._pytree import (
     KeyPath,
@@ -54,6 +60,22 @@ class _DTensorMeta:
 
 
 @dataclass
+class _ShardedTensorMeta:
+    """
+    This is the metadata for a ShardedTensor that is used to transfer checkpoints.
+    It contains the metadata for all local shards and the global tensor metadata.
+
+    This must be pickleable so that it can be sent over the wire.
+    """
+
+    local_shards_meta: list[_TensorMeta]
+    local_shards_shard_metadata: list[
+        ShardMetadata
+    ]  # Original shard metadata for each local shard
+    sharded_tensor_metadata: ShardedTensorMetadata
+
+
+@dataclass
 class _StateDictMeta:
     """
     This is the metadata for a state dict that is used to transfer checkpoints.
@@ -72,7 +94,9 @@ class _StateDictMeta:
 
     treespec: TreeSpec
     paths: list[KeyPath]
-    non_tensor_leaves: list[Union[object, _TensorMeta, _DTensorMeta]]
+    non_tensor_leaves: list[
+        Union[object, _TensorMeta, _DTensorMeta, _ShardedTensorMeta]
+    ]
 
 
 @contextmanager
@@ -104,7 +128,9 @@ def _prepare_state_dict(
     leaves, treespec = tree_flatten_with_path(state_dict)
 
     paths: list[KeyPath] = []
-    non_tensor_leaves: list[Union[object, _TensorMeta, _DTensorMeta]] = []
+    non_tensor_leaves: list[
+        Union[object, _TensorMeta, _DTensorMeta, _ShardedTensorMeta]
+    ] = []
     tensors: list[torch.Tensor] = []
     for key_path, v in leaves:
         paths.append(key_path)
@@ -118,6 +144,26 @@ def _prepare_state_dict(
                 _DTensorMeta(
                     local=tensor_meta,
                     spec=v._spec,
+                )
+            )
+        elif isinstance(v, ShardedTensor):
+            # Handle ShardedTensor by extracting all local shards
+            local_shards = v.local_shards()
+
+            # Prepare metadata for all local shards
+            local_shards_meta = []
+            local_shards_shard_metadata = []
+            for shard in local_shards:
+                tensor, tensor_meta = _prepare_tensor(shard.tensor)
+                tensors.append(tensor)
+                local_shards_meta.append(tensor_meta)
+                local_shards_shard_metadata.append(shard.metadata)
+
+            non_tensor_leaves.append(
+                _ShardedTensorMeta(
+                    local_shards_meta=local_shards_meta,
+                    local_shards_shard_metadata=local_shards_shard_metadata,
+                    sharded_tensor_metadata=v.metadata(),  # Complete metadata
                 )
             )
         elif isinstance(v, torch.Tensor):
@@ -242,7 +288,6 @@ class PGTransport:
         Returns:
             The reconstructed state dictionary with model parameters
         """
-
         state_dict = self._state_dict() if self._state_dict else {}
         state_dict_leaves, _ = tree_flatten_with_path(state_dict)
 
@@ -301,6 +346,37 @@ class PGTransport:
             elif isinstance(v, _DTensorMeta):
                 tensor = recv(path, v.local)
                 values.append(DTensor(tensor, v.spec, requires_grad=False))
+            elif isinstance(v, _ShardedTensorMeta):
+                # Receive all local shards that were sent to us
+                local_shards = []
+                current_rank = self._pg.rank()
+
+                # Receive tensors for each local shard that was sent
+                for j, shard_meta in enumerate(v.local_shards_meta):
+                    tensor = recv(path, shard_meta)
+
+                    # Use the original shard metadata that was stored during preparation
+                    # but update the placement to reflect the current rank/device
+                    original_shard_metadata = v.local_shards_shard_metadata[j]
+                    updated_shard_metadata = ShardMetadata(
+                        shard_offsets=original_shard_metadata.shard_offsets,
+                        shard_sizes=original_shard_metadata.shard_sizes,
+                        placement=f"rank:{current_rank}/{tensor.device.type}",
+                    )
+
+                    local_shard = ShardedTensorShard(
+                        tensor=tensor, metadata=updated_shard_metadata
+                    )
+                    local_shards.append(local_shard)
+
+                # Use complete metadata to reconstruct ShardedTensor
+                sharded_tensor = (
+                    ShardedTensor._init_from_local_shards_and_global_metadata(
+                        local_shards=local_shards,
+                        sharded_tensor_metadata=v.sharded_tensor_metadata,
+                    )
+                )
+                values.append(sharded_tensor)
             else:
                 values.append(v)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #158573

Add support for ShardedTensors in when PGTransport is used for send/recv checkpoints

Test is pulled from https://github.com/pytorch/pytorch/pull/157963

cc @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta