### PR TITLE
Added Emscripten __assert_fail declaration to Macros.h

### DIFF
--- a/torch/headeronly/macros/Macros.h
+++ b/torch/headeronly/macros/Macros.h
@@ -412,6 +412,13 @@ extern SYCL_EXTERNAL void __assert_fail(
     const char* file,
     unsigned int line,
     const char* func);
+#elif (defined(__EMSCRIPTEN__))
+// As defined in assert.h in the Emscripten stdlib
+_Noreturn void __assert_fail(
+    const char* expr,
+    const char* file,
+    int line,
+    const char* func);
 #else // __SYCL_DEVICE_ONLY__
 #if (defined(__CUDA_ARCH__) && !(defined(__clang__) && defined(__CUDA__)))
 // CUDA supports __assert_fail function which are common for both device


### PR DESCRIPTION
Summary: __assert_fail is declared slightly differently in the Emscripten stdlib. This may cause errors when compiling with Emscripten.

Test Plan:
N/A

Rollback Plan:

Differential Revision: D78500790


