### PR TITLE
[NativeRT] Remove makeProxyExecutor from ModelRunner interface

### DIFF
--- a/torch/nativert/executor/Executor.cpp
+++ b/torch/nativert/executor/Executor.cpp
@@ -22,8 +22,7 @@ Executor::Executor(
     const std::shared_ptr<Weights>& weights,
     Placement placement,
     const std::shared_ptr<caffe2::serialize::PyTorchStreamReader>&
-        pytorchStreamReader,
-    MakeProxyExecutorFn makeProxyExecutorFunc)
+        pytorchStreamReader)
     : executorConfig_(std::move(executorConfig)),
       graph_(std::move(graph)),
       placement_(std::move(placement)),
@@ -31,7 +30,6 @@ Executor::Executor(
           executorConfig_.runConstFolding
               ? std::optional<ConstantFolder>(*graph_)
               : std::nullopt),
-      makeProxyExecutorFunc_(std::move(makeProxyExecutorFunc)),
       executionFrames_(executorConfig_.maxNumConcurrentThreads),
       clearedExecutionFrames_(executorConfig_.maxNumConcurrentThreads),
       numExecutionFrames_(0),
@@ -48,12 +46,7 @@ void Executor::initialize(
   auto start = std::chrono::high_resolution_clock::now();
 
   auto executionKernels = KernelFactory().initializeNodeKernels(
-      *graph_,
-      weights,
-      executorConfig_,
-      placement_,
-      pytorchStreamReader,
-      makeProxyExecutorFunc_);
+      *graph_, weights, executorConfig_, placement_, pytorchStreamReader);
 
   if (constantFolder_.has_value()) {
     constantFolder_->unlinkConstants(executionKernels.nodeKernels);

--- a/torch/nativert/executor/Executor.h
+++ b/torch/nativert/executor/Executor.h
@@ -82,8 +82,7 @@ class Executor {
       const std::shared_ptr<Weights>& weights,
       Placement placement = Placement(),
       const std::shared_ptr<caffe2::serialize::PyTorchStreamReader>&
-          pytorchStreamReader = nullptr,
-      MakeProxyExecutorFn makeProxyExecutorFunc = nullptr);
+          pytorchStreamReader = nullptr);
 
   std::shared_ptr<Weights> getWeights() {
     std::shared_ptr<Weights> ret;
@@ -189,8 +188,6 @@ class Executor {
   std::vector<ConstFoldingExecution> constFoldingExecutions_;
 
   std::optional<ConstantFolder> constantFolder_;
-
-  MakeProxyExecutorFn makeProxyExecutorFunc_;
 
   c10::Semaphore sem_;
   torch::nativert::detail::MPMCQueue<std::unique_ptr<ExecutionFrame>>

--- a/torch/nativert/kernels/KernelFactory.cpp
+++ b/torch/nativert/kernels/KernelFactory.cpp
@@ -128,8 +128,7 @@ ExecutionKernels KernelFactory::initializeNodeKernels(
     const torch::nativert::ExecutorConfig& executorConfig,
     const Placement& placement,
     const std::shared_ptr<caffe2::serialize::PyTorchStreamReader>&
-        pytorchStreamReader,
-    const MakeProxyExecutorFn& makeProxyExecutorFunc) {
+        pytorchStreamReader) {
   std::vector<std::unique_ptr<OpKernel>> nodeKernels;
   std::vector<std::unique_ptr<DelegateExecutor>> delegateExecutors;
   std::vector<ConstFoldingExecution> constFoldingExecutions;

--- a/torch/nativert/kernels/KernelFactory.h
+++ b/torch/nativert/kernels/KernelFactory.h
@@ -70,7 +70,7 @@ class KernelFactoryHandler {
 
 class KernelFactory {
  public:
-  explicit KernelFactory() {}
+  KernelFactory() = default;
 
   ExecutionKernels initializeNodeKernels(
       const Graph& graph,
@@ -78,8 +78,7 @@ class KernelFactory {
       const torch::nativert::ExecutorConfig& executorConfig,
       const Placement& placement,
       const std::shared_ptr<caffe2::serialize::PyTorchStreamReader>&
-          pytorchStreamReader = nullptr,
-      const MakeProxyExecutorFn& makeProxyExecutorFunc = nullptr);
+          pytorchStreamReader = nullptr);
 
   static void registerHandler(
       const std::string& name,


### PR DESCRIPTION
Summary: makeProxyExecutor shouldn't be exposed to ModelRunner Interface.

Test Plan:
CI

Rollback Plan:

Differential Revision: D78501011


