### PR TITLE
Build domain libraries on the build job

### DIFF
--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -315,10 +315,6 @@ else
         install_torchaudio
       fi
 
-      if [[ "${BUILD_ADDITIONAL_PACKAGES}" == *text* ]]; then
-        install_torchtext
-      fi
-
       if [[ "${BUILD_ADDITIONAL_PACKAGES}" == *torchrec* || "${BUILD_ADDITIONAL_PACKAGES}" == *fbgemm* ]]; then
         install_torchrec_and_fbgemm
       fi

--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -306,6 +306,20 @@ else
     fi
     pip_install_whl "$(echo dist/*.whl)"
 
+    if [[ -n "${BUILD_ADDITIONAL_PACKAGES}" ]]; then
+      if [[ "${BUILD_ADDITIONAL_PACKAGES}" == *vision* ]]; then
+        install_torchvision
+      elif [[ "${BUILD_ADDITIONAL_PACKAGES}" == *audio* ]]; then
+        install_torchaudio
+      elif [[ "${BUILD_ADDITIONAL_PACKAGES}" == *text* ]]; then
+        install_torchtext
+      elif [[ "${BUILD_ADDITIONAL_PACKAGES}" == *torchrec* || "${BUILD_ADDITIONAL_PACKAGES}" == *fbgemm* ]]; then
+        install_torchrec_and_fbgemm
+      elif [[ "${BUILD_ADDITIONAL_PACKAGES}" == *torchao* ]]; then
+        install_torchao
+      fi
+    fi
+
     if [[ "$BUILD_ENVIRONMENT" == *xpu* ]]; then
       echo "Checking that xpu is compiled"
       pushd dist/

--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -309,13 +309,21 @@ else
     if [[ -n "${BUILD_ADDITIONAL_PACKAGES}" ]]; then
       if [[ "${BUILD_ADDITIONAL_PACKAGES}" == *vision* ]]; then
         install_torchvision
-      elif [[ "${BUILD_ADDITIONAL_PACKAGES}" == *audio* ]]; then
+      fi
+
+      if [[ "${BUILD_ADDITIONAL_PACKAGES}" == *audio* ]]; then
         install_torchaudio
-      elif [[ "${BUILD_ADDITIONAL_PACKAGES}" == *text* ]]; then
+      fi
+
+      if [[ "${BUILD_ADDITIONAL_PACKAGES}" == *text* ]]; then
         install_torchtext
-      elif [[ "${BUILD_ADDITIONAL_PACKAGES}" == *torchrec* || "${BUILD_ADDITIONAL_PACKAGES}" == *fbgemm* ]]; then
+      fi
+
+      if [[ "${BUILD_ADDITIONAL_PACKAGES}" == *torchrec* || "${BUILD_ADDITIONAL_PACKAGES}" == *fbgemm* ]]; then
         install_torchrec_and_fbgemm
-      elif [[ "${BUILD_ADDITIONAL_PACKAGES}" == *torchao* ]]; then
+      fi
+
+      if [[ "${BUILD_ADDITIONAL_PACKAGES}" == *torchao* ]]; then
         install_torchao
       fi
     fi

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1660,23 +1660,23 @@ elif [[ "${TEST_CONFIG}" == *timm* ]]; then
   id=$((SHARD_NUMBER-1))
   test_dynamo_benchmark timm_models "$id"
 elif [[ "${TEST_CONFIG}" == cachebench ]]; then
-  install_torchaudio cuda
+  install_torchaudio
   install_torchvision
   checkout_install_torchbench nanogpt BERT_pytorch resnet50 hf_T5 llama moco
   PYTHONPATH=$(pwd)/torchbench test_cachebench
 elif [[ "${TEST_CONFIG}" == verify_cachebench ]]; then
-  install_torchaudio cpu
+  install_torchaudio
   install_torchvision
   checkout_install_torchbench nanogpt
   PYTHONPATH=$(pwd)/torchbench test_verify_cachebench
 elif [[ "${TEST_CONFIG}" == *torchbench* ]]; then
   if [[ "${TEST_CONFIG}" == *cpu* ]]; then
-    install_torchaudio cpu
+    install_torchaudio
   else
-    install_torchaudio cuda
+    install_torchaudio
   fi
   install_torchvision
-  TORCH_CUDA_ARCH_LIST="8.0;8.6" install_torchao
+  install_torchao
   id=$((SHARD_NUMBER-1))
   # https://github.com/opencv/opencv-python/issues/885
   pip_install opencv-python==4.8.0.74

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1670,11 +1670,7 @@ elif [[ "${TEST_CONFIG}" == verify_cachebench ]]; then
   checkout_install_torchbench nanogpt
   PYTHONPATH=$(pwd)/torchbench test_verify_cachebench
 elif [[ "${TEST_CONFIG}" == *torchbench* ]]; then
-  if [[ "${TEST_CONFIG}" == *cpu* ]]; then
-    install_torchaudio
-  else
-    install_torchaudio
-  fi
+  install_torchaudio
   install_torchvision
   install_torchao
   id=$((SHARD_NUMBER-1))

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -89,6 +89,13 @@ on:
         required: false
         type: boolean
         default: true
+      build-additional-packages:
+        description: |
+          If set, the build job will also builds these packages and saves their
+          wheels as artifacts
+        required: false
+        type: string
+        default: ""
 
     secrets:
       HUGGING_FACE_HUB_TOKEN:
@@ -254,6 +261,7 @@ jobs:
           OUR_GITHUB_JOB_ID: ${{ steps.get-job-id.outputs.job-id }}
           HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
           SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
+          BUILD_ADDITIONAL_PACKAGES: ${{ inputs.build-additional-packages }}
         run: |
           START_TIME=$(date +%s)
           if [[ ${BUILD_ENVIRONMENT} == *"s390x"* ]]; then
@@ -299,6 +307,7 @@ jobs:
             -e HUGGING_FACE_HUB_TOKEN \
             -e SCRIBE_GRAPHQL_ACCESS_TOKEN \
             -e USE_SPLIT_BUILD \
+            -e BUILD_ADDITIONAL_PACKAGES \
             --memory="${TOTAL_AVAILABLE_MEMORY_IN_GB%.*}g" \
             --memory-swap="${TOTAL_MEMORY_WITH_SWAP}g" \
             --env-file="/tmp/github_env_${GITHUB_RUN_ID}" \


### PR DESCRIPTION
By setting the name of the domain libraries to build via `BUILD_ADDITIONAL_PACKAGES` environment variable, the build job will build them and make them available as artifacts in the same way as the PyTorch CI wheel. To ensure that this doesn't break CI, the test job will still build them as usual if the wheels are not there.  Building dependencies like FBGEMM on the test job is bad, especially for GPU jobs, because it leave the GPU resource idle

Fixes https://github.com/pytorch/pytorch/issues/152024

Signed-off-by: Huy Do <huydhn@gmail.com>