### PR TITLE
[Forward Fix] bring back _running_with_deploy

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -38,6 +38,12 @@ from typing_extensions import ParamSpec as _ParamSpec, TypeIs as _TypeIs
 if TYPE_CHECKING:
     from .types import Device, IntLikeType
 
+
+# multipy/deploy is no longer being used internally so we should be able to delete this  # codespell:ignore multipy
+def _running_with_deploy() -> builtins.bool:
+    False
+
+
 from torch._utils import (
     _functionalize_sync as _sync,
     _import_dotted_name,

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 
 # multipy/deploy is no longer being used internally so we should be able to delete this  # codespell:ignore multipy
 def _running_with_deploy() -> builtins.bool:
-    False
+    return False
 
 
 from torch._utils import (


### PR DESCRIPTION
As we remove all of the cruft we have for torch::deploy, this is still present internally in the codebase to accomodate for deploy, if it can't be removed easily, then we can merge this.