### PR TITLE
Add stride check for attn_mask on non-cpu device

### DIFF
--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -1023,7 +1023,7 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             return attn_weights.matmul(value), key, value
 
         tensor_shape = (4, 2, 16, 32)
-        attn_mask = torch.randn((1, 1, 1, 2), dtype=torch.float, device=self.device)
+        attn_mask = torch.randn((1, 1, 2, 2), dtype=torch.float, device=self.device)
         args = [
             torch.randn(tensor_shape, device=self.device),
             torch.randn(tensor_shape, device=self.device),
@@ -1035,6 +1035,16 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             args1=args,
             has_dropout=False,
             check_train=False,
+        )
+        # test attn_mask with stride of last dim != 1
+        attn_mask_ = attn_mask.transpose(2, 3)
+        args[3] = attn_mask_
+        self._check_common(
+            dot_prod_attention,
+            args1=args,
+            has_dropout=False,
+            check_train=False,
+            contains=self.device == "cpu",
         )
 
     def _test_sdpa_rewriter_23(self):


### PR DESCRIPTION
Add the stride check on last dim for the non-cpu device.

Note: this is a cherry-pick PR for https://github.com/pytorch/pytorch/pull/158424 for inclusion in release 2.8
Fixes https://github.com/pytorch/pytorch/issues/158374

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben