### PR TITLE
fix python_sphinx_theme2 eternal link typo in docs build requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ make -f docker.Makefile
 ### Building the Documentation
 
 To build documentation in various formats, you will need [Sphinx](http://www.sphinx-doc.org)
-and the [pytorch_sphinx_theme](https://pypi.org/project/pytorch-sphinx-theme/).
+and the [pytorch_sphinx_theme2](https://github.com/pytorch/pytorch_sphinx_theme/tree/pytorch_sphinx_theme2).
 
 Before you build the documentation locally, ensure `torch` is
 installed in your environment. For small fixes, you can install the

--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ make -f docker.Makefile
 ### Building the Documentation
 
 To build documentation in various formats, you will need [Sphinx](http://www.sphinx-doc.org)
-and the pytorch_sphinx_theme2.
+and the [pytorch_sphinx_theme](https://pypi.org/project/pytorch-sphinx-theme/).
 
 Before you build the documentation locally, ensure `torch` is
 installed in your environment. For small fixes, you can install the


### PR DESCRIPTION
Fixes a typo in README.md where `pytorch_sphinx_theme2` should be `pytorch_sphinx_theme`.

## Details
- Changed incorrect package name `pytorch_sphinx_theme2` to correct `pytorch_sphinx_theme`
- This may mislead contributors who are trying to set up the documentation build environment
- The correct package exists at: https://pypi.org/project/pytorch-sphinx-theme/

## Test Plan
- [x] Verified the correct package name exists on PyPI
- [x] Confirmed the path is accurate by checking the actual package name
- [x] No functional code changes, only documentation

## Related Issues
Fixes #158201