### PR TITLE
[CPUBLAS] add macros for brgemm APIs for versioning

### DIFF
--- a/aten/src/ATen/native/CPUBlas.cpp
+++ b/aten/src/ATen/native/CPUBlas.cpp
@@ -51,7 +51,7 @@ extern "C" void zaxpy_(int *n, void *a, const void *x, int *incx, void *y, int *
 // brgemm_pack_B is changed to transform and the setting of brgemm beta is changed to set_add_C
 #if (IDEEP_VERSION_MAJOR == 3 && IDEEP_VERSION_MINOR == 5)
 #define ONEDNN_UKERNEL_1
-#elif (IDEEP_VERSION_MAJOR >= 3 && IDEEP_VERSION_MINOR >= 6)
+#elif ((IDEEP_VERSION_MAJOR == 3 && IDEEP_VERSION_MINOR >= 6) || (IDEEP_VERSION_MAJOR > 3))
 #define ONEDNN_UKERNEL_2
 #endif
 #if ((defined(ONEDNN_UKERNEL_1) || defined(ONEDNN_UKERNEL_2)) && (defined(__x86_64__) || (defined(_M_X64) && !defined(_M_ARM64EC))))

--- a/aten/src/ATen/native/CPUBlas.h
+++ b/aten/src/ATen/native/CPUBlas.h
@@ -206,6 +206,16 @@ void copy(int64_t n, const c10::complex<float> *x, int64_t incx, c10::complex<fl
 // B Base pointer to a tensor B.
 // C Pointer to a tensor C (accumulation buffer).
 // Note only batch size 1 is used currently
+
+// Define macros for available brgemm APIs
+// so that callers can determine which APIs are available
+#define CPUBLAS_BRGEMM_F16F16F32 // half * half -> float
+#define CPUBLAS_BRGEMM_BF16BF16F32 // bfloat16 * bfloat16 -> float
+#define CPUBLAS_BRGEMM_F32F32F32 // float * float -> float
+#define CPUBLAS_BRGEMM_U8U8I32 // unsigned char * unsigned char -> int32
+#define CPUBLAS_BRGEMM_U8I8I32 // unsigned char * signed char -> int32
+#define CPUBLAS_BRGEMM_I8I8I32 // signed char * signed char -> int32
+
 TORCH_API void brgemm(
     int64_t M,
     int64_t N,


### PR DESCRIPTION
**Summary**
Add macros for brgemm, so that callers (e.g., Torchao's cpp kernels) know which APIs are available. It is useful when callers need to co-work with old versions of PyTorch.