### PR TITLE
[AOTI] package loader normalize path separator

### DIFF
--- a/torch/csrc/inductor/aoti_package/model_package_loader.cpp
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.cpp
@@ -41,6 +41,18 @@ namespace {
 const std::string k_separator = "/";
 
 std::string normalize_path_separator(const std::string& orig_path) {
+  /*
+  On Windows and Linux have different separator:
+  On Windows use "\", and the path like: C:\Users\Test\file.txt
+  On Linux use "/", and the path like: /home/user/file.txt
+
+  In order to simplify the path operation, we can use this function to
+  normalize path separator. It will convert Windows separator to Linux
+  separator, and re-use the common code to handle both Windows and Linux
+  path.
+  On Windows, when we input: "C:\Users\Test\file.txt", the output should be:
+  "C:/Users/Test/file.txt". And then, we can process the output like on Linux.
+  */
 #ifdef _WIN32
   const bool _IS_WINDOWS = true;
 #else

--- a/torch/csrc/inductor/aoti_package/model_package_loader.cpp
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.cpp
@@ -48,22 +48,18 @@ std::string normalize_path_separator(const std::string& orig_path) {
 
   In order to simplify the path operation, we can use this function to
   normalize path separator. It will convert Windows separator to Linux
-  separator, and re-use the common code to handle both Windows and Linux
+  separator, and reuse the common code to handle both Windows and Linux
   path.
   On Windows, when we input: "C:\Users\Test\file.txt", the output should be:
   "C:/Users/Test/file.txt". And then, we can process the output like on Linux.
   */
 #ifdef _WIN32
-  const bool _IS_WINDOWS = true;
+  std::string normalized_path = orig_path;
+  std::replace(normalized_path.begin(), normalized_path.end(), '\\', '/');
+  return normalized_path;
 #else
-  const bool _IS_WINDOWS = false;
-#endif
-  if (_IS_WINDOWS) {
-    std::string normalized_path = orig_path;
-    std::replace(normalized_path.begin(), normalized_path.end(), '\\', '/');
-    return normalized_path;
-  }
   return orig_path;
+#endif
 }
 
 bool file_exists(const std::string& path) {


### PR DESCRIPTION
Add `normalize_path_separator` to handle Windows path simplify.

This solution is working well on `torch/_inductor/cpp_builder.py`: https://github.com/pytorch/pytorch/blob/a00cd8cf252a0b061f2eef6b5b42ae967acf5f64/torch/_inductor/cpp_builder.py#L406-L409

Let's copy it to package loader.


cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10