### PR TITLE
[CUDA] fix nansum in non-JIT build

### DIFF
--- a/aten/src/ATen/native/cuda/ReduceSumProdKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceSumProdKernel.cu
@@ -87,7 +87,7 @@ struct nansum_functor_complex {
 #else
   void operator()(TensorIterator& iter) {
     using acc_t = at::opmath_type<scalar_t>;
-    gpu_reduce_kernel<scalar_t, acc_t>(
+    gpu_reduce_kernel<scalar_t, scalar_t>(
         iter, NanSumOps<acc_t, acc_t>{});
   }
 #endif


### PR DESCRIPTION
This change fix crash of
```
import torch
a = torch.tensor([[1, 2]], dtype=torch.complex32).to('cuda')
b = torch.nansum(a, dim=0)
print(b)
```
