### PR TITLE
unskipped flaky conv2d, rmatmul, and matmul as these now pass

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1562,7 +1562,7 @@ test_linux_aarch64() {
   #functorch tests
   python test/run_test.py --include functorch/test_aotdispatch.py \
        --shard "$SHARD_NUMBER" "$NUM_TEST_SHARDS" --verbose
- 
+
   # Dynamo tests
   python test/run_test.py --include dynamo/test_compile dynamo/test_backends dynamo/test_comptime dynamo/test_config \
        dynamo/test_functions dynamo/test_fx_passes_pre_grad dynamo/test_interop dynamo/test_model_output dynamo/test_modules \

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1559,6 +1559,10 @@ test_linux_aarch64() {
         test_foreach test_reductions test_unary_ufuncs test_tensor_creation_ops test_ops test_cpp_extensions_open_device_registration \
         --shard "$SHARD_NUMBER" "$NUM_TEST_SHARDS" --verbose
 
+  #functorch tests
+  python test/run_test.py --include functorch/test_aotdispatch.py \
+       --shard "$SHARD_NUMBER" "$NUM_TEST_SHARDS" --verbose
+ 
   # Dynamo tests
   python test/run_test.py --include dynamo/test_compile dynamo/test_backends dynamo/test_comptime dynamo/test_config \
        dynamo/test_functions dynamo/test_fx_passes_pre_grad dynamo/test_interop dynamo/test_model_output dynamo/test_modules \

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -7574,6 +7574,12 @@ if not TEST_MKL:
                     {torch.float32: tol(atol=6e-05, rtol=4e-06)}
                 ),
             ),
+            decorate(
+                "nn.functional.conv2d",
+                decorator=toleranceOverride(
+                    {torch.float32: tol(atol=6e-05, rtol=4e-06)}
+                ),
+            ),
         }
     )
 

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -77,7 +77,6 @@ from torch.testing._internal.common_modules import module_db, modules
 from torch.testing._internal.common_utils import (
     compare_equal_outs_and_grads,
     instantiate_parametrized_tests,
-    IS_ARM64,
     IS_MACOS,
     IS_WINDOWS,
     IS_X86,
@@ -7558,8 +7557,6 @@ aot_autograd_failures = {
         "bicubic",
         decorator=toleranceOverride({torch.float32: tol(atol=1e-04, rtol=1e-05)}),
     ),
-
- 
 }
 
 if not TEST_MKL:

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -2371,7 +2371,7 @@ def forward(self, arg0_1, arg1_1):
             return a.mul(3), b.mul(4)
 
         inp = [
-            # First inp doesnt require grad, but we switch it on
+            # First inp doesn't require grad, but we switch it on
             torch.ones(3, 3, requires_grad=False),
             torch.ones(3, 3, requires_grad=True),
         ]
@@ -5669,7 +5669,7 @@ def forward(self, primals_1, tangents_1):
         _, fw_graph_out_nodes = get_ins_outs(fw_graph)
         self.assertEqual(
             # fw outputs include b.size() which expands to 2 symints,
-            # then 4 tensors (transposes of matricies used for mm) are saved
+            # then 4 tensors (transposes of matrices used for mm) are saved
             # finally 3 symints are saved
             [False, True, True, False, False] + [False] * 4 + [True] * 3,
             [is_sym_node(n) for n in fw_graph_out_nodes],
@@ -5999,7 +5999,7 @@ metadata incorrectly.
         self.assertEqual(b_test.a, b_ref.a)
         self.assertEqual(b_test.b, b_ref.b)
 
-        # NOTE: we need to use b in our gradient compute. Otherwise we will need to recompile teh backward.
+        # NOTE: we need to use b in our gradient compute. Otherwise we will need to recompile the backward.
         (b_ref * out_ref).sum().backward()
         (b_test * out_test).sum().backward()
         # Both grad_inputs are TwoTensor

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -2372,7 +2372,7 @@ def forward(self, arg0_1, arg1_1):
             return a.mul(3), b.mul(4)
 
         inp = [
-            # First inp doesn't require grad, but we switch it on
+            # First inp doesnt require grad, but we switch it on
             torch.ones(3, 3, requires_grad=False),
             torch.ones(3, 3, requires_grad=True),
         ]
@@ -5670,7 +5670,7 @@ def forward(self, primals_1, tangents_1):
         _, fw_graph_out_nodes = get_ins_outs(fw_graph)
         self.assertEqual(
             # fw outputs include b.size() which expands to 2 symints,
-            # then 4 tensors (transposes of matrices used for mm) are saved
+            # then 4 tensors (transposes of matricies used for mm) are saved
             # finally 3 symints are saved
             [False, True, True, False, False] + [False] * 4 + [True] * 3,
             [is_sym_node(n) for n in fw_graph_out_nodes],
@@ -6000,7 +6000,7 @@ metadata incorrectly.
         self.assertEqual(b_test.a, b_ref.a)
         self.assertEqual(b_test.b, b_ref.b)
 
-        # NOTE: we need to use b in our gradient compute. Otherwise we will need to recompile the backward.
+        # NOTE: we need to use b in our gradient compute. Otherwise we will need to recompile teh backward.
         (b_ref * out_ref).sum().backward()
         (b_test * out_test).sum().backward()
         # Both grad_inputs are TwoTensor
@@ -7539,8 +7539,6 @@ aot_autograd_failures = {
     skip("nn.functional.binary_cross_entropy_with_logits"),  # seems to fail sometimes?
     skip("nn.functional.margin_ranking_loss"),  # seems flaky
     skip("linalg.lu_solve"),  # flaky
-    decorate("matmul", decorator=unittest.skipIf(IS_ARM64, "flaky")),
-    decorate("__rmatmul__", decorator=unittest.skipIf(IS_ARM64, "flaky")),
     # overrides atol=1e-4, rtol=1e-5 would do as well
     decorate(
         "svd_lowrank",
@@ -7560,8 +7558,8 @@ aot_autograd_failures = {
         "bicubic",
         decorator=toleranceOverride({torch.float32: tol(atol=1e-04, rtol=1e-05)}),
     ),
-    # conv2d sometimes nondeterministic in this config?
-    decorate("nn.functional.conv2d", decorator=unittest.skipIf(IS_ARM64, "flaky")),
+
+ 
 }
 
 if not TEST_MKL:


### PR DESCRIPTION
These tests were flaky, they now pass on aarch64 after 100 runs. Logs are attached.
[aotdispatch_test_detailed_flakyonly.log](https://github.com/user-attachments/files/21315442/aotdispatch_test_detailed_flakyonly.log)
[aotdispatch_test_detailed_flakyonly2.log](https://github.com/user-attachments/files/21315443/aotdispatch_test_detailed_flakyonly2.log)
[aotdispatch_test_summary_flakyonly.log](https://github.com/user-attachments/files/21315444/aotdispatch_test_summary_flakyonly.log)
[aotdispatch_test_summary_flakyonly2.log](https://github.com/user-attachments/files/21315445/aotdispatch_test_summary_flakyonly2.log)


cc @malfet @snadampal @milpuz01 @aditew01 @nikhil-arm @fadara01