### PR TITLE
Fix Triton GEMM templates with k=1

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -1550,6 +1550,12 @@ class TestMaxAutotune(TestCase):
                 if "benchmark_gpu" in counter:
                     self.assertEqual(counters["inductor"][counter], 2)
 
+    @config.patch(
+        {
+            "max_autotune": True,
+            "max_autotune_gemm_backends": "TRITON",
+        }
+    )
     def test_mm_k_1(self):
         def mm(x, y):
             return x @ y
@@ -1561,9 +1567,6 @@ class TestMaxAutotune(TestCase):
             compiled_f = torch.compile(mm)
 
             out, code = run_and_get_code(compiled_f, a, b)
-            FileCheck().check("@triton_heuristics.template").check(
-                "triton_tem_fused_mm"
-            ).run(code[0])
             torch.testing.assert_close(out, mm(a, b), atol=1e-2, rtol=1e-2)
 
 

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -1551,18 +1551,20 @@ class TestMaxAutotune(TestCase):
                     self.assertEqual(counters["inductor"][counter], 2)
 
     def test_mm_k_1(self):
+        def mm(x, y):
+            return x @ y
+
         for i in range(90, 100):
             torch._dynamo.reset()
             a = torch.randn((i, 1), device="cuda", dtype=torch.float32)
             b = torch.randn((1, i), device="cuda", dtype=torch.float32)
-            f = lambda x, y: x @ y
-            compiled_f = torch.compile(f)
+            compiled_f = torch.compile(mm)
 
             out, code = run_and_get_code(compiled_f, a, b)
             FileCheck().check("@triton_heuristics.template").check(
                 "triton_tem_fused_mm"
             ).run(code[0])
-            torch.testing.assert_close(out, f(a, b), atol=1e-2, rtol=1e-2)
+            torch.testing.assert_close(out, mm(a, b), atol=1e-2, rtol=1e-2)
 
 
 class TestMaxAutotunePrecompile(TestCase):

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -112,10 +112,8 @@ mm_template = TritonTemplate(
     n_idx = pid_n * BLOCK_N
     rm = m_idx + tl.arange(0, BLOCK_M)
     rn = n_idx + tl.arange(0, BLOCK_N)
-    v_m = ((stride_am == 1 and stride_ak == M) or (stride_am == K and stride_ak == 1)) and m_idx + BLOCK_M <= M
-    v_n = ((stride_bk == 1 and stride_bn == K) or (stride_bk == N and stride_bn == 1)) and n_idx + BLOCK_N <= N
-    offs_a_m = tl.where(v_m, tl.max_contiguous(tl.multiple_of(rm % M, BLOCK_M), BLOCK_M), rm % M)
-    offs_b_n = tl.where(v_n, tl.max_contiguous(tl.multiple_of(rn % N, BLOCK_N), BLOCK_N), rn % N)
+    offs_a_m = rm % M
+    offs_b_n = rn % N
 
     offs_k = tl.arange(0, BLOCK_K)
     acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_TYPE)

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -108,13 +108,16 @@ mm_template = TritonTemplate(
     tl.assume(pid_m >= 0)
     tl.assume(pid_n >= 0)
 
-    m_idx = pid_m * BLOCK_M
-    n_idx = pid_n * BLOCK_N
-    rm = m_idx + tl.arange(0, BLOCK_M)
-    rn = n_idx + tl.arange(0, BLOCK_N)
-    offs_a_m = rm % M
-    offs_b_n = rn % N
-
+    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    if ((stride_am == 1 and stride_ak == M) or (stride_am == K and stride_ak == 1)) and (M >= BLOCK_M and K > 1):
+        offs_a_m = tl.max_contiguous(tl.multiple_of(rm % M, BLOCK_M), BLOCK_M)
+    else:
+        offs_a_m = rm % M
+    if ((stride_bk == 1 and stride_bn == K) or (stride_bk == N and stride_bn == 1)) and (N >= BLOCK_N and K > 1):
+        offs_b_n = tl.max_contiguous(tl.multiple_of(rn % N, BLOCK_N), BLOCK_N)
+    else:
+        offs_b_n = rn % N
     offs_k = tl.arange(0, BLOCK_K)
     acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_TYPE)
 

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -108,16 +108,15 @@ mm_template = TritonTemplate(
     tl.assume(pid_m >= 0)
     tl.assume(pid_n >= 0)
 
-    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
-    rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
-    if ((stride_am == 1 and stride_ak == M) or (stride_am == K and stride_ak == 1)) and M >= BLOCK_M:
-        offs_a_m = tl.max_contiguous(tl.multiple_of(rm % M, BLOCK_M), BLOCK_M)
-    else:
-        offs_a_m = rm % M
-    if ((stride_bk == 1 and stride_bn == K) or (stride_bk == N and stride_bn == 1)) and N >= BLOCK_N:
-        offs_b_n = tl.max_contiguous(tl.multiple_of(rn % N, BLOCK_N), BLOCK_N)
-    else:
-        offs_b_n = rn % N
+    m_idx = pid_m * BLOCK_M
+    n_idx = pid_n * BLOCK_N
+    rm = m_idx + tl.arange(0, BLOCK_M)
+    rn = n_idx + tl.arange(0, BLOCK_N)
+    v_m = ((stride_am == 1 and stride_ak == M) or (stride_am == K and stride_ak == 1)) and m_idx + BLOCK_M <= M
+    v_n = ((stride_bk == 1 and stride_bn == K) or (stride_bk == N and stride_bn == 1)) and n_idx + BLOCK_N <= N
+    offs_a_m = tl.where(v_m, tl.max_contiguous(tl.multiple_of(rm % M, BLOCK_M), BLOCK_M), rm % M)
+    offs_b_n = tl.where(v_n, tl.max_contiguous(tl.multiple_of(rn % N, BLOCK_N), BLOCK_N), rn % N)
+
     offs_k = tl.arange(0, BLOCK_K)
     acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_TYPE)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #158650

Thanks to @davidberard98 for much of the analysis here. For GEMMs of K=1, the hints, `tl.multiple_of` and `tl.max_contiguous` apply completely, as the indices to the loads are only dependent on `offs_m` and `offs_n`. For shapes like `(97x1), (1x97)`, this results in misaligned address errors, due to the fact that for all BLOCK_M and BLOCK_N sizes, the last tile is not a contiguous load. With K > 1 case, the hint is not as strict given the dependency on the k indices for the load as well. In the K=1 case, only `offs_m` and `offs_n` are used and broadcasted to the index shape.

One can say these hints are "wrong", but in various cases in the hints being wrong, such as with the shape `9999x4, 4x9999`, there is a substantial performance improvement with the hint.

For nice shapes with K=1, where M, N are a multiple 8 to where these hints are fine and there is no misaligned address, there is no performance regression observed on H100:
<img width="547" height="402" alt="Screenshot 2025-07-18 at 5 05 47 PM" src="https://github.com/user-attachments/assets/fee2bbaa-784c-422e-bb8c-43c6c2607ad2" />

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben