### PR TITLE
Add safetensors to requirements-ci.txt

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -395,3 +395,6 @@ scikit-build==0.18.1
 pyre-extensions==0.0.32
 tabulate==0.9.0
 #Description: These package are needed to build FBGEMM and torchrec on PyTorch CI
+
+safetensors==0.5.3
+#Description: required for testing test_hf_safetensor_e2e.py and test_consolidate_hf_safetensors.py

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -397,4 +397,4 @@ tabulate==0.9.0
 #Description: These package are needed to build FBGEMM and torchrec on PyTorch CI
 
 safetensors==0.5.3
-#Description: required for testing test_hf_safetensor_e2e.py and test_consolidate_hf_safetensors.py
+#Description: required for HF safetensor-based tests


### PR DESCRIPTION
Need to install safetensors in our CI images in order to properly test test_hf_safetensor_e2e.py and test_consolidate_hf_safetensors.py test suites.

Fixes #ISSUE_NUMBER
