### PR TITLE
Remove is_arvr_mode() from xnnpack.buck.bzl

### DIFF
--- a/third_party/xnnpack.buck.bzl
+++ b/third_party/xnnpack.buck.bzl
@@ -1,5 +1,4 @@
 load("//tools/build_defs:fb_xplat_cxx_library.bzl", "fb_xplat_cxx_library")
-load("//tools/build_defs:fbsource_utils.bzl", "is_arvr_mode")
 load("//tools/build_defs:glob_defs.bzl", "subdir_glob")
 load("//tools/build_defs:platform_defs.bzl", "ANDROID", "APPLE", "APPLETVOS", "CXX", "IOS", "MACOSX", "WINDOWS")
 load(
@@ -142,9 +141,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_sse",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("sse"),
-            "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("sse"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("sse"),
+                "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("sse"),
+            }),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -160,12 +162,15 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = ([
-            (
-                "x86|x86_64|platform009|platform010",
-                prod_srcs_for_arch_wrapper("sse"),
-            ),
-        ] if not is_arvr_mode() else []),
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "x86|x86_64|platform009|platform010",
+                    prod_srcs_for_arch_wrapper("sse"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -206,9 +211,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_sse2",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("sse2"),
-            "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("sse2"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("sse2"),
+                "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("sse2"),
+            }),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -224,12 +232,15 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = ([
-            (
-                "x86|x86_64|platform009|platform010",
-                prod_srcs_for_arch_wrapper("sse2"),
-            ),
-        ] if not is_arvr_mode() else []),
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "x86|x86_64|platform009|platform010",
+                    prod_srcs_for_arch_wrapper("sse2"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -270,9 +281,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_ssse3",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("ssse3"),
-            "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("ssse3"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("ssse3"),
+                "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("ssse3"),
+            }),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -288,12 +302,15 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = ([
-            (
-                "x86|x86_64|platform009|platform010",
-                prod_srcs_for_arch_wrapper("ssse3"),
-            ),
-        ] if not is_arvr_mode() else []),
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "x86|x86_64|platform009|platform010",
+                    prod_srcs_for_arch_wrapper("ssse3"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -334,9 +351,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_sse41",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("sse41"),
-            "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("sse41"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("sse41"),
+                "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("sse41"),
+            }),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -352,12 +372,15 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = ([
-            (
-                "x86|x86_64|platform009|platform010",
-                prod_srcs_for_arch_wrapper("sse41"),
-            ),
-        ] if not is_arvr_mode() else []),
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "x86|x86_64|platform009|platform010",
+                    prod_srcs_for_arch_wrapper("sse41"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -398,9 +421,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_avx",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx"),
-            "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx"),
+                "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx"),
+            }),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -424,12 +450,15 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = ([
-            (
-                "x86|x86_64|platform009|platform010",
-                prod_srcs_for_arch_wrapper("avx"),
-            ),
-        ] if not is_arvr_mode() else []),
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "x86|x86_64|platform009|platform010",
+                    prod_srcs_for_arch_wrapper("avx"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -471,9 +500,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_avx512vnnigfni",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx512vnnigfni"),
-            "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx512vnnigfni"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx512vnnigfni"),
+                "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx512vnnigfni"),
+            }),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -513,12 +545,15 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = ([
-            (
-                "x86|x86_64|platform009|platform010",
-                prod_srcs_for_arch_wrapper("avx512vnnigfni"),
-            ),
-        ] if not is_arvr_mode() else []),
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "x86|x86_64|platform009|platform010",
+                    prod_srcs_for_arch_wrapper("avx512vnnigfni"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
         visibility = ["PUBLIC"],
@@ -563,9 +598,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_avx512vnni",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx512vnni"),
-            "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx512vnni"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx512vnni"),
+                "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx512vnni"),
+            }),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -604,12 +642,15 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = ([
-            (
-                "x86|x86_64|platform009|platform010",
-                prod_srcs_for_arch_wrapper("avx512vnni"),
-            ),
-        ] if not is_arvr_mode() else []),
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "x86|x86_64|platform009|platform010",
+                    prod_srcs_for_arch_wrapper("avx512vnni"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
         exported_preprocessor_flags = [
@@ -657,7 +698,10 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
 
     fb_xplat_cxx_library(
         name = "ukernels_avxvnni",
-        srcs = prod_srcs_for_arch_wrapper("avxvnni") if is_arvr_mode() else [],
+        srcs = select({
+            "DEFAULT": [],
+            "ovr_config//build_mode:arvr_mode": prod_srcs_for_arch_wrapper("avxvnni"),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -679,12 +723,15 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = ([
-            (
-                "x86|x86_64|platform009|platform010",
-                prod_srcs_for_arch_wrapper("avxvnni"),
-            ),
-        ] if not is_arvr_mode() else []),
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "x86|x86_64|platform009|platform010",
+                    prod_srcs_for_arch_wrapper("avxvnni"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
         visibility = ["PUBLIC"],
@@ -724,9 +771,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_f16c",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("f16c"),
-            "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("f16c"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("f16c"),
+                "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("f16c"),
+            }),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -750,12 +800,15 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = ([
-            (
-                "x86|x86_64|platform009|platform010",
-                prod_srcs_for_arch_wrapper("f16c"),
-            ),
-        ] if not is_arvr_mode() else []),
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "x86|x86_64|platform009|platform010",
+                    prod_srcs_for_arch_wrapper("f16c"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         platforms = (APPLE, ANDROID, CXX, WINDOWS),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -799,9 +852,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_fma3",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("fma3"),
-            "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("fma3"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("fma3"),
+                "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("fma3"),
+            }),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -828,12 +884,15 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = ([
-            (
-                "x86|x86_64|platform009|platform010",
-                prod_srcs_for_arch_wrapper("fma3"),
-            ),
-        ] if not is_arvr_mode() else []),
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "x86|x86_64|platform009|platform010",
+                    prod_srcs_for_arch_wrapper("fma3"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -889,9 +948,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_avx2",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx2"),
-            "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx2"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx2"),
+                "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx2"),
+            }),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -921,12 +983,15 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = ([
-            (
-                "x86|x86_64|platform009|platform010",
-                prod_srcs_for_arch_wrapper("avx2"),
-            ),
-        ] if not is_arvr_mode() else []),
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "x86|x86_64|platform009|platform010",
+                    prod_srcs_for_arch_wrapper("avx2"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -989,9 +1054,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_avx512",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx512f"),
-            "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx512f"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx512f"),
+                "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx512f"),
+            }),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1015,12 +1083,15 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = ([
-            (
-                "x86|x86_64|platform009|platform010",
-                prod_srcs_for_arch_wrapper("avx512f"),
-            ),
-        ] if not is_arvr_mode() else []),
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "x86|x86_64|platform009|platform010",
+                    prod_srcs_for_arch_wrapper("avx512f"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1034,9 +1105,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_avx512vbmi",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx512vbmi"),
-            "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx512vbmi"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx512vbmi"),
+                "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx512vbmi"),
+            }),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1075,12 +1149,15 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = ([
-            (
-                "x86|x86_64|platform009|platform010",
-                prod_srcs_for_arch_wrapper("avx512vbmi"),
-            ),
-        ] if not is_arvr_mode() else []),
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "x86|x86_64|platform009|platform010",
+                    prod_srcs_for_arch_wrapper("avx512vbmi"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1136,9 +1213,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_avx512skx",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx512skx"),
-            "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx512skx"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx512skx"),
+                "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx512skx"),
+            }),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1174,12 +1254,15 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = ([
-            (
-                "x86|x86_64|platform009|platform010",
-                prod_srcs_for_arch_wrapper("avx512skx"),
-            ),
-        ] if not is_arvr_mode() else []),
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "x86|x86_64|platform009|platform010",
+                    prod_srcs_for_arch_wrapper("avx512skx"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1255,8 +1338,11 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_armsimd32",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("armsimd32"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("armsimd32"),
+            }),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1277,12 +1363,15 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(aarch32|arm32|armv7)",
-                prod_srcs_for_arch_wrapper("armsimd32"),
-            ),
-        ] if not is_arvr_mode() else [],
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "(aarch32|arm32|armv7)",
+                    prod_srcs_for_arch_wrapper("armsimd32"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1296,9 +1385,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_neon",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neon"),
-            "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neon"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neon"),
+                "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neon"),
+            }),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1323,16 +1415,19 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(aarch32|arm32|armv7)",
-                prod_srcs_for_arch_wrapper("neon"),
-            ),
-            (
-                "(aarch64|arm64)",
-                prod_srcs_for_arch_wrapper("neon"),
-            ),
-        ] if not is_arvr_mode() else [],
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "(aarch32|arm32|armv7)",
+                    prod_srcs_for_arch_wrapper("neon"),
+                ),
+                (
+                    "(aarch64|arm64)",
+                    prod_srcs_for_arch_wrapper("neon"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1346,20 +1441,26 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_neon_aarch64",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neon_aarch64"), 
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neon_aarch64"),
+            }),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
         compiler_flags = [
             "-O2",
         ],
-        platform_srcs = [
-            (
-                "(aarch64|arm64)",
-                prod_srcs_for_arch_wrapper("neon_aarch64"),
-            ),
-        ] if not is_arvr_mode() else [],
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "(aarch64|arm64)",
+                    prod_srcs_for_arch_wrapper("neon_aarch64"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         labels = labels,
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -1374,8 +1475,11 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_neon_fma",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neonfma"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neonfma"),
+            }),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1407,12 +1511,15 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(aarch32|arm32|armv7)",
-                prod_srcs_for_arch_wrapper("neonfma"),
-            ),
-        ] if not is_arvr_mode() else [],
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "(aarch32|arm32|armv7)",
+                    prod_srcs_for_arch_wrapper("neonfma"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1426,8 +1533,11 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_neonfma_aarch64",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neonfma") + prod_srcs_for_arch_wrapper("neonfma_aarch64"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neonfma") + prod_srcs_for_arch_wrapper("neonfma_aarch64"),
+            }),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1435,12 +1545,15 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "-O2",
         ],
         labels = labels,
-        platform_srcs = [
-            (
-                "(arm64|aarch64)$",
-                prod_srcs_for_arch_wrapper("neonfma") + prod_srcs_for_arch_wrapper("neonfma_aarch64"),
-            ),
-        ] if not is_arvr_mode() else [],
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "(arm64|aarch64)$",
+                    prod_srcs_for_arch_wrapper("neonfma") + prod_srcs_for_arch_wrapper("neonfma_aarch64"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         platforms = (APPLE, ANDROID, CXX, WINDOWS),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -1455,9 +1568,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_fp16arith",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("fp16arith"),
-            "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("fp16arith"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("fp16arith"),
+                "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("fp16arith"),
+            }),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1504,16 +1620,19 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             )
         ],
-        platform_srcs = [
-            (
-                "(aarch32|arm32|armv7)",
-                prod_srcs_for_arch_wrapper("fp16arith"),
-            ),
-            (
-                "(aarch64|arm64)",
-                prod_srcs_for_arch_wrapper("fp16arith") + prod_srcs_for_arch_wrapper("fp16arith_aarch64"),
-            ),
-        ] if not is_arvr_mode() else [],
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "(aarch32|arm32|armv7)",
+                    prod_srcs_for_arch_wrapper("fp16arith"),
+                ),
+                (
+                    "(aarch64|arm64)",
+                    prod_srcs_for_arch_wrapper("fp16arith") + prod_srcs_for_arch_wrapper("fp16arith_aarch64"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1527,9 +1646,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_neon_fp16",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neonfp16"),
-            "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neonfp16"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neonfp16"),
+                "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neonfp16"),
+            }),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1554,16 +1676,19 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(aarch32|arm32|armv7)$",
-                prod_srcs_for_arch_wrapper("neonfp16"),
-            ),
-            (
-                "(arm64|aarch64)",
-                prod_srcs_for_arch_wrapper("neonfp16"),
-            ),
-        ] if not is_arvr_mode() else [],
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "(aarch32|arm32|armv7)$",
+                    prod_srcs_for_arch_wrapper("neonfp16"),
+                ),
+                (
+                    "(arm64|aarch64)",
+                    prod_srcs_for_arch_wrapper("neonfp16"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1577,9 +1702,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_neon_v8",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neonv8"),
-            "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neonv8"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neonv8"),
+                "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neonv8"),
+            }),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1618,16 +1746,19 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(aarch32|arm32|armv7)$",
-                prod_srcs_for_arch_wrapper("neonv8"),
-            ),
-            (
-                "(arm64|aarch64)",
-                prod_srcs_for_arch_wrapper("neonv8"),
-            ),
-        ] if not is_arvr_mode() else [],
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "(aarch32|arm32|armv7)$",
+                    prod_srcs_for_arch_wrapper("neonv8"),
+                ),
+                (
+                    "(arm64|aarch64)",
+                    prod_srcs_for_arch_wrapper("neonv8"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1641,8 +1772,11 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_neon_dot",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neondot"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neondot"),
+            }),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1667,12 +1801,15 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(aarch32|arm32|armv7)",
-                prod_srcs_for_arch_wrapper("neondot"),
-            ),
-        ] if not is_arvr_mode() else [],
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "(aarch32|arm32|armv7)",
+                    prod_srcs_for_arch_wrapper("neondot"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1686,8 +1823,11 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_neon_dot_aarch64",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neondot") + prod_srcs_for_arch_wrapper("neondot_aarch64"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neondot") + prod_srcs_for_arch_wrapper("neondot_aarch64"),
+            }),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1706,12 +1846,15 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(aarch64|arm64)",
-                prod_srcs_for_arch_wrapper("neondot") + prod_srcs_for_arch_wrapper("neondot_aarch64"),
-            ),
-        ] if not is_arvr_mode() else [],
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "(aarch64|arm64)",
+                    prod_srcs_for_arch_wrapper("neondot") + prod_srcs_for_arch_wrapper("neondot_aarch64"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1725,8 +1868,11 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_neon_dot_fp16arith",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neondotfp16arith"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neondotfp16arith"),
+            }),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1750,12 +1896,15 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(aarch32|arm32|armv7)",
-                prod_srcs_for_arch_wrapper("neondotfp16arith"),
-            ),
-        ] if not is_arvr_mode() else [],
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "(aarch32|arm32|armv7)",
+                    prod_srcs_for_arch_wrapper("neondotfp16arith"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         labels = labels,
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -1770,8 +1919,11 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_neon_dot_fp16arith_aarch64",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neondotfp16arith") + prod_srcs_for_arch_wrapper("neondotfp16arith_aarch64"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neondotfp16arith") + prod_srcs_for_arch_wrapper("neondotfp16arith_aarch64"),
+            }),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1791,12 +1943,15 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(aarch64|arm64)",
-                prod_srcs_for_arch_wrapper("neondotfp16arith") + prod_srcs_for_arch_wrapper("neondotfp16arith_aarch64"),
-            ),
-        ] if not is_arvr_mode() else [],
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "(aarch64|arm64)",
+                    prod_srcs_for_arch_wrapper("neondotfp16arith") + prod_srcs_for_arch_wrapper("neondotfp16arith_aarch64"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         labels = labels,
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -1811,8 +1966,11 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_neon_fp16arith",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neonfp16arith"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neonfp16arith"),
+            }),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1837,12 +1995,15 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(aarch32|arm32|armv7)",
-                prod_srcs_for_arch_wrapper("neonfp16arith"),
-            ),
-        ] if not is_arvr_mode() else [],
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "(aarch32|arm32|armv7)",
+                    prod_srcs_for_arch_wrapper("neonfp16arith"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1856,8 +2017,11 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_neon_fp16arith_aarch64",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neonfp16arith") + prod_srcs_for_arch_wrapper("neonfp16arith_aarch64"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neonfp16arith") + prod_srcs_for_arch_wrapper("neonfp16arith_aarch64"),
+            }),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1876,12 +2040,15 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(aarch64|arm64)",
-                prod_srcs_for_arch_wrapper("neonfp16arith") + prod_srcs_for_arch_wrapper("neonfp16arith_aarch64"),
-            ),
-        ] if not is_arvr_mode() else [],
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "(aarch64|arm64)",
+                    prod_srcs_for_arch_wrapper("neonfp16arith") + prod_srcs_for_arch_wrapper("neonfp16arith_aarch64"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1895,9 +2062,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_neonfma_i8mm",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neonfma_i8mm"),
-            "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neonfma_i8mm"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neonfma_i8mm"),
+                "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neonfma_i8mm"),
+            }),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1931,16 +2101,19 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(aarch32|arm32|armv7)$",
-                prod_srcs_for_arch_wrapper("neonfma_i8mm"),
-            ),
-            (
-                "(arm64|aarch64)",
-                prod_srcs_for_arch_wrapper("neonfma_i8mm"),
-            ),
-        ] if not is_arvr_mode() else [],
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "(aarch32|arm32|armv7)$",
+                    prod_srcs_for_arch_wrapper("neonfma_i8mm"),
+                ),
+                (
+                    "(arm64|aarch64)",
+                    prod_srcs_for_arch_wrapper("neonfma_i8mm"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         platforms = (APPLE, ANDROID, CXX, WINDOWS),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -1955,8 +2128,11 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_neoni8mm",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neoni8mm"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neoni8mm"),
+            }),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1977,12 +2153,15 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(arm64|aarch64)",
-                prod_srcs_for_arch_wrapper("neoni8mm"),
-            ),
-        ] if not is_arvr_mode() else [],
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "(arm64|aarch64)",
+                    prod_srcs_for_arch_wrapper("neoni8mm"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         platforms = (APPLE, ANDROID, CXX, WINDOWS),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -1997,8 +2176,11 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_asm_aarch32",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("aarch32"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("aarch32"),
+            }),
+        }),
         headers = subdir_glob([
             ("XNNPACK/src", "xnnpack/assembly.h"),
             ("XNNPACK/src", "**/*.S"),
@@ -2026,12 +2208,15 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(aarch32|arm32|armv7)",
-                prod_srcs_for_arch_wrapper("aarch32"),
-            ),
-        ] if not is_arvr_mode() else [],
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "(aarch32|arm32|armv7)",
+                    prod_srcs_for_arch_wrapper("aarch32"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         platforms = (APPLE, ANDROID, CXX, WINDOWS),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -2046,8 +2231,11 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_asm_aarch64",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("aarch64"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//build_mode:arvr_mode": select({
+                "DEFAULT": [],
+                "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("aarch64"),
+            }),
+        }),
         headers = subdir_glob([
             ("XNNPACK/src", "xnnpack/assembly.h"),
             ("XNNPACK/src", "**/*.S"),
@@ -2071,12 +2259,15 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(aarch64|arm64)",
-                prod_srcs_for_arch_wrapper("aarch64"),
-            ),
-        ] if not is_arvr_mode() else [],
+        platform_srcs = select({
+            "DEFAULT": [
+                (
+                    "(aarch64|arm64)",
+                    prod_srcs_for_arch_wrapper("aarch64"),
+                ),
+            ],
+            "ovr_config//build_mode:arvr_mode": [],
+        }),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,


### PR DESCRIPTION
Summary:
**Changes**
*   Deleted function import from build definition utilities
    *   Removed `load("//tools/build_defs:fbsource_utils.bzl", "is_arvr_mode")`
*   Replaced is_arvr_mode() function calls with direct references to configuration flags
    *  Changed from `is_arvr_mode()` to `"ovr_config//build_mode:arvr_mode"`
*   Changed conditional expressions to Buck `select()` statements

Test Plan:
Check if CI passes

Rollback Plan:

Differential Revision: D78520947


