### PR TITLE
Use cuda error code instead of error text in get_cuda_error_help

### DIFF
--- a/c10/cuda/CUDAException.cpp
+++ b/c10/cuda/CUDAException.cpp
@@ -30,7 +30,7 @@ void c10_cuda_check_implementation(
   check_message.append("CUDA error: ");
   const char* error_string = cudaGetErrorString(cuda_error);
   check_message.append(error_string);
-  check_message.append(c10::cuda::get_cuda_error_help(error_string));
+  check_message.append(c10::cuda::get_cuda_error_help(cuda_error));
   check_message.append(c10::cuda::get_cuda_check_suffix());
   check_message.append("\n");
   if (include_device_assertions) {

--- a/c10/cuda/CUDAMiscFunctions.cpp
+++ b/c10/cuda/CUDAMiscFunctions.cpp
@@ -1,5 +1,6 @@
 #include <c10/cuda/CUDAMiscFunctions.h>
 #include <c10/util/env.h>
+#include <cuda_runtime.h>
 #include <cstring>
 #include <string>
 
@@ -7,11 +8,19 @@ namespace c10::cuda {
 
 // Explain common CUDA errors
 // NOLINTNEXTLINE(bugprone-exception-escape,-warnings-as-errors)
-std::string get_cuda_error_help(const char* error_string) noexcept {
+std::string get_cuda_error_help(cudaError_t error) noexcept {
   std::string help_text;
-  if (strstr(error_string, "invalid device ordinal")) {
-    help_text.append(
-        "\nGPU device may be out of range, do you have enough GPUs?");
+  switch (error) {
+    case cudaErrorInvalidDevice:
+      help_text.append(
+          "\nGPU device may be out of range, do you have enough GPUs?");
+      break;
+    default:
+      help_text.append("\nSearch for `")
+          .append(cudaGetErrorName(error))
+          .append(
+              "' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html for more information.");
+      break;
   }
   return help_text;
 }

--- a/c10/cuda/CUDAMiscFunctions.h
+++ b/c10/cuda/CUDAMiscFunctions.h
@@ -3,12 +3,13 @@
 // CUDAExceptions.h
 
 #include <c10/cuda/CUDAMacros.h>
+#include <cuda_runtime.h>
 
 #include <mutex>
 #include <string>
 
 namespace c10::cuda {
-C10_CUDA_API std::string get_cuda_error_help(const char*) noexcept;
+C10_CUDA_API std::string get_cuda_error_help(cudaError_t) noexcept;
 C10_CUDA_API const char* get_cuda_check_suffix() noexcept;
 C10_CUDA_API std::mutex* getFreeMutex();
 } // namespace c10::cuda


### PR DESCRIPTION
Use cudaError_t and switch through the enum to prevent impact by upstream changes in wording