### PR TITLE
[BE] Improve uv detection for venvs 

### DIFF
--- a/tools/linter/adapters/pip_init.py
+++ b/tools/linter/adapters/pip_init.py
@@ -52,11 +52,13 @@ if __name__ == "__main__":
         stream=sys.stderr,
     )
 
-    uv_available = (
-        any(prefix in sys.base_prefix for prefix in ["uv/python", "uv\\python"])
-        and shutil.which("uv") is not None
-    )
+    uv_installed = shutil.which("uv") is not None
+    uv_python = any(prefix in sys.base_prefix for prefix in ["uv/python", "uv\\python"])
 
+    in_conda = os.environ.get("CONDA_PREFIX") is not None
+    in_virtualenv = os.environ.get("VIRTUAL_ENV") is not None
+
+    uv_available = uv_installed and (uv_python or in_virtualenv)
     if uv_available:
         pip_args = ["uv", "pip", "install"]
     elif sys.executable:
@@ -70,8 +72,6 @@ if __name__ == "__main__":
     # However, `pip install --user` interacts poorly with virtualenvs (see:
     # https://bit.ly/3vD4kvl) and conda (see: https://bit.ly/3KG7ZfU). So in
     # these cases perform a regular installation.
-    in_conda = os.environ.get("CONDA_PREFIX") is not None
-    in_virtualenv = os.environ.get("VIRTUAL_ENV") is not None
     if not in_conda and not in_virtualenv:
         pip_args.append("--user")
 

--- a/tools/linter/adapters/pip_init.py
+++ b/tools/linter/adapters/pip_init.py
@@ -73,7 +73,9 @@ if __name__ == "__main__":
     # https://bit.ly/3vD4kvl) and conda (see: https://bit.ly/3KG7ZfU). So in
     # these cases perform a regular installation.
     if not in_conda and not in_virtualenv:
-        pip_args.append("--user")
+        # uv does not support --user
+        if not uv_available:
+            pip_args.append("--user")
 
     pip_args.extend(args.packages)
 


### PR DESCRIPTION
Follow up to https://github.com/pytorch/pytorch/pull/155972 to fix the issue described in https://github.com/pytorch/pytorch/issues/152999#issuecomment-3091251183

Basically, uv can create virtual environments that are based on non-uv python installations. The old version of the code wouldn't leverage uv in those situations, but with this fix it should.

Tested locally to validate that uv environments that used a system python install still had `lintrunner init` use uv to install the packages.