### PR TITLE
[AOTI] explicit aoti wrapper functions for Windows.

### DIFF
--- a/torch/csrc/inductor/aoti_runtime/interface.h
+++ b/torch/csrc/inductor/aoti_runtime/interface.h
@@ -45,8 +45,7 @@ AOTI_API AOTIRuntimeError AOTInductorModelContainerCreate(
 // "cpu", "cuda", "cuda:0", etc. If the device index is not specified for CUDA
 // device, runtime will use the device index returned by
 // "cudaGetDevice(&device_idx)"
-AOTI_API AOTIRuntimeError
-AOTInductorModelContainerCreateWithDevice(
+AOTI_API AOTIRuntimeError AOTInductorModelContainerCreateWithDevice(
     AOTInductorModelContainerHandle* container_handle,
     size_t num_models,
     const char* device_str,
@@ -71,8 +70,7 @@ AOTI_API AOTIRuntimeError AOTInductorModelContainerRun(
     AOTIProxyExecutorHandle proxy_executor_handle);
 
 // Single-threaded variant of previous.
-AOTI_API AOTIRuntimeError
-AOTInductorModelContainerRunSingleThreaded(
+AOTI_API AOTIRuntimeError AOTInductorModelContainerRunSingleThreaded(
     AOTInductorModelContainerHandle container_handle,
     AtenTensorHandle* input_handles, // array of input AtenTensorHandle; handles
                                      // are stolen; the array itself is borrowed
@@ -86,16 +84,14 @@ AOTInductorModelContainerRunSingleThreaded(
     AOTIProxyExecutorHandle proxy_executor_handle);
 
 // Retrieves the number of constants for the model.
-AOTI_API AOTIRuntimeError
-AOTInductorModelContainerGetNumConstants(
+AOTI_API AOTIRuntimeError AOTInductorModelContainerGetNumConstants(
     AOTInductorModelContainerHandle container_handle,
     size_t* num_constants);
 
 // Retrieves a constant's name.
 // idx is the index of the internal's constants.
 // Need idx < num_constants from AOTInductorModelContainerGetNumConstants
-AOTI_API AOTIRuntimeError
-AOTInductorModelContainerGetConstantName(
+AOTI_API AOTIRuntimeError AOTInductorModelContainerGetConstantName(
     AOTInductorModelContainerHandle container_handle,
     size_t idx,
     const char** name);
@@ -103,8 +99,7 @@ AOTInductorModelContainerGetConstantName(
 // Retrieves a constant's original FQN.
 // idx is the index of the internal's constants.
 // Need idx < num_constants from AOTInductorModelContainerGetNumConstants
-AOTI_API AOTIRuntimeError
-AOTInductorModelContainerGetConstantOriginalFQN(
+AOTI_API AOTIRuntimeError AOTInductorModelContainerGetConstantOriginalFQN(
     AOTInductorModelContainerHandle container_handle,
     size_t idx,
     const char** original_fqn);
@@ -112,8 +107,7 @@ AOTInductorModelContainerGetConstantOriginalFQN(
 // Retrieves whether a constant is from folded.
 // idx is the index of the internal's constants.
 // Need idx < num_constants from AOTInductorModelContainerGetNumConstants
-AOTI_API AOTIRuntimeError
-AOTInductorModelContainerGetConstantFromFolded(
+AOTI_API AOTIRuntimeError AOTInductorModelContainerGetConstantFromFolded(
     AOTInductorModelContainerHandle container_handle,
     size_t idx,
     bool* from_folded);
@@ -121,8 +115,7 @@ AOTInductorModelContainerGetConstantFromFolded(
 // Retrieves the inductor constant type.
 // idx is the index of the internal's constants.
 // Need idx < num_constants from AOTInductorModelContainerGetNumConstants
-AOTI_API AOTIRuntimeError
-AOTInductorModelContainerGetConstantType(
+AOTI_API AOTIRuntimeError AOTInductorModelContainerGetConstantType(
     AOTInductorModelContainerHandle container_handle,
     size_t idx,
     int32_t* type);
@@ -130,8 +123,7 @@ AOTInductorModelContainerGetConstantType(
 // Retrieves a constant's dtype.
 // idx is the index of the internal's constants.
 // Need idx < num_constants from AOTInductorModelContainerGetNumConstants
-AOTI_API AOTIRuntimeError
-AOTInductorModelContainerGetConstantDtype(
+AOTI_API AOTIRuntimeError AOTInductorModelContainerGetConstantDtype(
     AOTInductorModelContainerHandle container_handle,
     size_t idx,
     int32_t* dtype);
@@ -139,15 +131,13 @@ AOTInductorModelContainerGetConstantDtype(
 // Retrieves a constant's data size.
 // idx is the index of the internal's constants.
 // Need idx < num_constants from AOTInductorModelContainerGetNumConstants
-AOTI_API AOTIRuntimeError
-AOTInductorModelContainerGetConstantDataSize(
+AOTI_API AOTIRuntimeError AOTInductorModelContainerGetConstantDataSize(
     AOTInductorModelContainerHandle container_handle,
     size_t idx,
     size_t* data_size);
 
 // Extract the constants that is being used in the container.
-AOTI_API AOTIRuntimeError
-AOTInductorModelContainerExtractConstantsMap(
+AOTI_API AOTIRuntimeError AOTInductorModelContainerExtractConstantsMap(
     AOTInductorModelContainerHandle container_handle,
     AOTInductorConstantMapHandle constant_map_handle,
     bool use_inactive);
@@ -164,8 +154,7 @@ AOTInductorModelContainerUpdateUserManagedConstantBuffer(
 // Setup the constant buffer in model container with provided ConstantMap
 // use_inactive should be set as true if the inactive buffer is to be updated.
 // validate_full_update checks if all constants are included in the ConstantMap
-AOTI_API AOTIRuntimeError
-AOTInductorModelContainerUpdateConstantBuffer(
+AOTI_API AOTIRuntimeError AOTInductorModelContainerUpdateConstantBuffer(
     AOTInductorModelContainerHandle container_handle,
     AOTInductorConstantMapHandle constant_map_handle,
     bool use_inactive,
@@ -173,27 +162,23 @@ AOTInductorModelContainerUpdateConstantBuffer(
 
 // Setup the inactive constant buffer in model container with provided
 // ConstantMap
-AOTI_API AOTIRuntimeError
-AOTInductorModelContainerUpdateInactiveConstantBuffer(
+AOTI_API AOTIRuntimeError AOTInductorModelContainerUpdateInactiveConstantBuffer(
     AOTInductorModelContainerHandle container_handle,
     AOTInductorConstantMapHandle constant_map_handle);
 
 // Free the inactive constant buffer in model container.
-AOTI_API AOTIRuntimeError
-AOTInductorModelContainerFreeInactiveConstantBuffer(
+AOTI_API AOTIRuntimeError AOTInductorModelContainerFreeInactiveConstantBuffer(
     AOTInductorModelContainerHandle container_handle);
 
 // Run constant folding on constant buffer.
-AOTI_API AOTIRuntimeError
-AOTInductorModelContainerRunConstantFolding(
+AOTI_API AOTIRuntimeError AOTInductorModelContainerRunConstantFolding(
     AOTInductorModelContainerHandle container_handle,
     bool use_inactive,
     AOTInductorStreamHandle stream_handle,
     AOTIProxyExecutorHandle proxy_executor_handle);
 
 // Swap the constant buffer being used to the inactive one.
-AOTI_API AOTIRuntimeError
-AOTInductorModelContainerSwapConstantBuffer(
+AOTI_API AOTIRuntimeError AOTInductorModelContainerSwapConstantBuffer(
     AOTInductorModelContainerHandle container_handle);
 
 // Retrieves the number of inputs for the model.

--- a/torch/csrc/inductor/aoti_runtime/interface.h
+++ b/torch/csrc/inductor/aoti_runtime/interface.h
@@ -6,6 +6,17 @@
 // applies to other files under torch/csrc/inductor/aoti_runtime/.
 #include <torch/csrc/inductor/aoti_runtime/utils.h>
 
+#ifdef _WIN32
+/*
+On Windows, we need to explicit declaration for export APIs. And because the
+package loader call these API via GetProcAddress(ldsym on Linux), we can ignore
+the import case.
+*/
+#define AOTI_WRAPPER_INTERFACE __declspec(dllexport)
+#else
+#define AOTI_WRAPPER_INTERFACE __attribute__((__visibility__("default")))
+#endif
+
 extern "C" {
 struct AOTInductorModelOpaque;
 using AOTInductorModelHandle = AOTInductorModelOpaque*;
@@ -21,7 +32,7 @@ using AOTInductorConstantMapHandle = AOTInductorConstantMap*;
 
 // TODO: Deprecate this API. This was kept for BC compatibility.
 // Please use AOTInductorModelContainerCreateWithDevice instead.
-AOTIRuntimeError AOTInductorModelContainerCreate(
+AOTI_WRAPPER_INTERFACE AOTIRuntimeError AOTInductorModelContainerCreate(
     AOTInductorModelContainerHandle* container_handle,
     size_t num_models,
     bool is_cpu,
@@ -34,18 +45,19 @@ AOTIRuntimeError AOTInductorModelContainerCreate(
 // "cpu", "cuda", "cuda:0", etc. If the device index is not specified for CUDA
 // device, runtime will use the device index returned by
 // "cudaGetDevice(&device_idx)"
-AOTIRuntimeError AOTInductorModelContainerCreateWithDevice(
+AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTInductorModelContainerCreateWithDevice(
     AOTInductorModelContainerHandle* container_handle,
     size_t num_models,
     const char* device_str,
     const char* cubin_dir);
 
 // Deletes the AOTInductor model container.
-AOTIRuntimeError AOTInductorModelContainerDelete(
+AOTI_WRAPPER_INTERFACE AOTIRuntimeError AOTInductorModelContainerDelete(
     AOTInductorModelContainerHandle container_handle);
 
 // Runs the inference.
-AOTIRuntimeError AOTInductorModelContainerRun(
+AOTI_WRAPPER_INTERFACE AOTIRuntimeError AOTInductorModelContainerRun(
     AOTInductorModelContainerHandle container_handle,
     AtenTensorHandle* input_handles, // array of input AtenTensorHandle; handles
                                      // are stolen; the array itself is borrowed
@@ -59,7 +71,8 @@ AOTIRuntimeError AOTInductorModelContainerRun(
     AOTIProxyExecutorHandle proxy_executor_handle);
 
 // Single-threaded variant of previous.
-AOTIRuntimeError AOTInductorModelContainerRunSingleThreaded(
+AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTInductorModelContainerRunSingleThreaded(
     AOTInductorModelContainerHandle container_handle,
     AtenTensorHandle* input_handles, // array of input AtenTensorHandle; handles
                                      // are stolen; the array itself is borrowed
@@ -73,14 +86,16 @@ AOTIRuntimeError AOTInductorModelContainerRunSingleThreaded(
     AOTIProxyExecutorHandle proxy_executor_handle);
 
 // Retrieves the number of constants for the model.
-AOTIRuntimeError AOTInductorModelContainerGetNumConstants(
+AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTInductorModelContainerGetNumConstants(
     AOTInductorModelContainerHandle container_handle,
     size_t* num_constants);
 
 // Retrieves a constant's name.
 // idx is the index of the internal's constants.
 // Need idx < num_constants from AOTInductorModelContainerGetNumConstants
-AOTIRuntimeError AOTInductorModelContainerGetConstantName(
+AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTInductorModelContainerGetConstantName(
     AOTInductorModelContainerHandle container_handle,
     size_t idx,
     const char** name);
@@ -88,7 +103,8 @@ AOTIRuntimeError AOTInductorModelContainerGetConstantName(
 // Retrieves a constant's original FQN.
 // idx is the index of the internal's constants.
 // Need idx < num_constants from AOTInductorModelContainerGetNumConstants
-AOTIRuntimeError AOTInductorModelContainerGetConstantOriginalFQN(
+AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTInductorModelContainerGetConstantOriginalFQN(
     AOTInductorModelContainerHandle container_handle,
     size_t idx,
     const char** original_fqn);
@@ -96,7 +112,8 @@ AOTIRuntimeError AOTInductorModelContainerGetConstantOriginalFQN(
 // Retrieves whether a constant is from folded.
 // idx is the index of the internal's constants.
 // Need idx < num_constants from AOTInductorModelContainerGetNumConstants
-AOTIRuntimeError AOTInductorModelContainerGetConstantFromFolded(
+AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTInductorModelContainerGetConstantFromFolded(
     AOTInductorModelContainerHandle container_handle,
     size_t idx,
     bool* from_folded);
@@ -104,7 +121,8 @@ AOTIRuntimeError AOTInductorModelContainerGetConstantFromFolded(
 // Retrieves the inductor constant type.
 // idx is the index of the internal's constants.
 // Need idx < num_constants from AOTInductorModelContainerGetNumConstants
-AOTIRuntimeError AOTInductorModelContainerGetConstantType(
+AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTInductorModelContainerGetConstantType(
     AOTInductorModelContainerHandle container_handle,
     size_t idx,
     int32_t* type);
@@ -112,7 +130,8 @@ AOTIRuntimeError AOTInductorModelContainerGetConstantType(
 // Retrieves a constant's dtype.
 // idx is the index of the internal's constants.
 // Need idx < num_constants from AOTInductorModelContainerGetNumConstants
-AOTIRuntimeError AOTInductorModelContainerGetConstantDtype(
+AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTInductorModelContainerGetConstantDtype(
     AOTInductorModelContainerHandle container_handle,
     size_t idx,
     int32_t* dtype);
@@ -120,20 +139,23 @@ AOTIRuntimeError AOTInductorModelContainerGetConstantDtype(
 // Retrieves a constant's data size.
 // idx is the index of the internal's constants.
 // Need idx < num_constants from AOTInductorModelContainerGetNumConstants
-AOTIRuntimeError AOTInductorModelContainerGetConstantDataSize(
+AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTInductorModelContainerGetConstantDataSize(
     AOTInductorModelContainerHandle container_handle,
     size_t idx,
     size_t* data_size);
 
 // Extract the constants that is being used in the container.
-AOTIRuntimeError AOTInductorModelContainerExtractConstantsMap(
+AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTInductorModelContainerExtractConstantsMap(
     AOTInductorModelContainerHandle container_handle,
     AOTInductorConstantMapHandle constant_map_handle,
     bool use_inactive);
 
 // Setup the constant buffer in model container with provided ConstantMap.
 // The ConstantMap is user managed, and the user would retain ownership.
-AOTIRuntimeError AOTInductorModelContainerUpdateUserManagedConstantBuffer(
+AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTInductorModelContainerUpdateUserManagedConstantBuffer(
     AOTInductorModelContainerHandle container_handle,
     AOTInductorConstantMapHandle constant_map_handle,
     bool use_inactive,
@@ -142,7 +164,8 @@ AOTIRuntimeError AOTInductorModelContainerUpdateUserManagedConstantBuffer(
 // Setup the constant buffer in model container with provided ConstantMap
 // use_inactive should be set as true if the inactive buffer is to be updated.
 // validate_full_update checks if all constants are included in the ConstantMap
-AOTIRuntimeError AOTInductorModelContainerUpdateConstantBuffer(
+AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTInductorModelContainerUpdateConstantBuffer(
     AOTInductorModelContainerHandle container_handle,
     AOTInductorConstantMapHandle constant_map_handle,
     bool use_inactive,
@@ -150,43 +173,47 @@ AOTIRuntimeError AOTInductorModelContainerUpdateConstantBuffer(
 
 // Setup the inactive constant buffer in model container with provided
 // ConstantMap
-AOTIRuntimeError AOTInductorModelContainerUpdateInactiveConstantBuffer(
+AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTInductorModelContainerUpdateInactiveConstantBuffer(
     AOTInductorModelContainerHandle container_handle,
     AOTInductorConstantMapHandle constant_map_handle);
 
 // Free the inactive constant buffer in model container.
-AOTIRuntimeError AOTInductorModelContainerFreeInactiveConstantBuffer(
+AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTInductorModelContainerFreeInactiveConstantBuffer(
     AOTInductorModelContainerHandle container_handle);
 
 // Run constant folding on constant buffer.
-AOTIRuntimeError AOTInductorModelContainerRunConstantFolding(
+AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTInductorModelContainerRunConstantFolding(
     AOTInductorModelContainerHandle container_handle,
     bool use_inactive,
     AOTInductorStreamHandle stream_handle,
     AOTIProxyExecutorHandle proxy_executor_handle);
 
 // Swap the constant buffer being used to the inactive one.
-AOTIRuntimeError AOTInductorModelContainerSwapConstantBuffer(
+AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTInductorModelContainerSwapConstantBuffer(
     AOTInductorModelContainerHandle container_handle);
 
 // Retrieves the number of inputs for the model.
-AOTIRuntimeError AOTInductorModelContainerGetNumInputs(
+AOTI_WRAPPER_INTERFACE AOTIRuntimeError AOTInductorModelContainerGetNumInputs(
     AOTInductorModelContainerHandle container_handle,
     size_t* ret_num_inputs);
 
 // Retrieves the input name at the given index.
-AOTIRuntimeError AOTInductorModelContainerGetInputName(
+AOTI_WRAPPER_INTERFACE AOTIRuntimeError AOTInductorModelContainerGetInputName(
     AOTInductorModelContainerHandle container_handle,
     size_t input_idx,
     const char** ret_input_names);
 
 // Retrieves the number of outputs for the model.
-AOTIRuntimeError AOTInductorModelContainerGetNumOutputs(
+AOTI_WRAPPER_INTERFACE AOTIRuntimeError AOTInductorModelContainerGetNumOutputs(
     AOTInductorModelContainerHandle container_handle,
     size_t* ret_num_outputs);
 
 // Retrieves the output name at the given index.
-AOTIRuntimeError AOTInductorModelContainerGetOutputName(
+AOTI_WRAPPER_INTERFACE AOTIRuntimeError AOTInductorModelContainerGetOutputName(
     AOTInductorModelContainerHandle container_handle,
     size_t output_idx,
     const char** ret_output_names);
@@ -198,31 +225,32 @@ AOTIRuntimeError AOTInductorModelContainerGetOutputName(
 //
 // constant_map_handle is an opaque type to satisfy the C ABI.  It should be a
 // std::unordered_map<std::string, at::Tensor*>*.
-AOTIRuntimeError AOTInductorModelCreate(
+AOTI_WRAPPER_INTERFACE AOTIRuntimeError AOTInductorModelCreate(
     AOTInductorModelHandle* model_handle,
     AOTInductorConstantMapHandle constant_map_handle);
 
 // Run an AOTInductorModel (see AOTInductorModelCreate for when one should use
 // this function versus AOTInductorModelContainerRun).
-AOTIRuntimeError AOTInductorModelRun(
+AOTI_WRAPPER_INTERFACE AOTIRuntimeError AOTInductorModelRun(
     AOTInductorModelHandle model_handle,
     AtenTensorHandle* input_handles,
     AtenTensorHandle* output_handles);
 
 // Replace AOTInductorModel's constant map. Note it doesn't handle concurrency
 // so be sure to handle ordering if AOTInductorModelRun is ran concurrently.
-AOTIRuntimeError AOTInductorModelUpdateConstantsMap(
+AOTI_WRAPPER_INTERFACE AOTIRuntimeError AOTInductorModelUpdateConstantsMap(
     AOTInductorModelHandle model_handle,
     AOTInductorConstantMapHandle constant_map_handle);
 
 // Delete an AOTInductorModel created by AOTInductorModelCreate.
-AOTIRuntimeError AOTInductorModelDelete(AOTInductorModelHandle model_handle);
+AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTInductorModelDelete(AOTInductorModelHandle model_handle);
 
-AOTIRuntimeError AOTInductorModelGetNumOutputs(
+AOTI_WRAPPER_INTERFACE AOTIRuntimeError AOTInductorModelGetNumOutputs(
     AOTInductorModelHandle model_handle,
     size_t* ret_num_outputs);
 
-AOTIRuntimeError AOTInductorModelContainerGetCallSpec(
+AOTI_WRAPPER_INTERFACE AOTIRuntimeError AOTInductorModelContainerGetCallSpec(
     AOTInductorModelContainerHandle container_handle,
     const char** in_spec,
     const char** out_spec);

--- a/torch/csrc/inductor/aoti_runtime/interface.h
+++ b/torch/csrc/inductor/aoti_runtime/interface.h
@@ -12,9 +12,9 @@ On Windows, we need to explicit declaration for export APIs. And because the
 package loader call these API via GetProcAddress(ldsym on Linux), we can ignore
 the import case.
 */
-#define AOTI_WRAPPER_INTERFACE __declspec(dllexport)
+#define AOTI_API __declspec(dllexport)
 #else
-#define AOTI_WRAPPER_INTERFACE __attribute__((__visibility__("default")))
+#define AOTI_API __attribute__((__visibility__("default")))
 #endif
 
 extern "C" {
@@ -32,7 +32,7 @@ using AOTInductorConstantMapHandle = AOTInductorConstantMap*;
 
 // TODO: Deprecate this API. This was kept for BC compatibility.
 // Please use AOTInductorModelContainerCreateWithDevice instead.
-AOTI_WRAPPER_INTERFACE AOTIRuntimeError AOTInductorModelContainerCreate(
+AOTI_API AOTIRuntimeError AOTInductorModelContainerCreate(
     AOTInductorModelContainerHandle* container_handle,
     size_t num_models,
     bool is_cpu,
@@ -45,7 +45,7 @@ AOTI_WRAPPER_INTERFACE AOTIRuntimeError AOTInductorModelContainerCreate(
 // "cpu", "cuda", "cuda:0", etc. If the device index is not specified for CUDA
 // device, runtime will use the device index returned by
 // "cudaGetDevice(&device_idx)"
-AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTI_API AOTIRuntimeError
 AOTInductorModelContainerCreateWithDevice(
     AOTInductorModelContainerHandle* container_handle,
     size_t num_models,
@@ -53,11 +53,11 @@ AOTInductorModelContainerCreateWithDevice(
     const char* cubin_dir);
 
 // Deletes the AOTInductor model container.
-AOTI_WRAPPER_INTERFACE AOTIRuntimeError AOTInductorModelContainerDelete(
+AOTI_API AOTIRuntimeError AOTInductorModelContainerDelete(
     AOTInductorModelContainerHandle container_handle);
 
 // Runs the inference.
-AOTI_WRAPPER_INTERFACE AOTIRuntimeError AOTInductorModelContainerRun(
+AOTI_API AOTIRuntimeError AOTInductorModelContainerRun(
     AOTInductorModelContainerHandle container_handle,
     AtenTensorHandle* input_handles, // array of input AtenTensorHandle; handles
                                      // are stolen; the array itself is borrowed
@@ -71,7 +71,7 @@ AOTI_WRAPPER_INTERFACE AOTIRuntimeError AOTInductorModelContainerRun(
     AOTIProxyExecutorHandle proxy_executor_handle);
 
 // Single-threaded variant of previous.
-AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTI_API AOTIRuntimeError
 AOTInductorModelContainerRunSingleThreaded(
     AOTInductorModelContainerHandle container_handle,
     AtenTensorHandle* input_handles, // array of input AtenTensorHandle; handles
@@ -86,7 +86,7 @@ AOTInductorModelContainerRunSingleThreaded(
     AOTIProxyExecutorHandle proxy_executor_handle);
 
 // Retrieves the number of constants for the model.
-AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTI_API AOTIRuntimeError
 AOTInductorModelContainerGetNumConstants(
     AOTInductorModelContainerHandle container_handle,
     size_t* num_constants);
@@ -94,7 +94,7 @@ AOTInductorModelContainerGetNumConstants(
 // Retrieves a constant's name.
 // idx is the index of the internal's constants.
 // Need idx < num_constants from AOTInductorModelContainerGetNumConstants
-AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTI_API AOTIRuntimeError
 AOTInductorModelContainerGetConstantName(
     AOTInductorModelContainerHandle container_handle,
     size_t idx,
@@ -103,7 +103,7 @@ AOTInductorModelContainerGetConstantName(
 // Retrieves a constant's original FQN.
 // idx is the index of the internal's constants.
 // Need idx < num_constants from AOTInductorModelContainerGetNumConstants
-AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTI_API AOTIRuntimeError
 AOTInductorModelContainerGetConstantOriginalFQN(
     AOTInductorModelContainerHandle container_handle,
     size_t idx,
@@ -112,7 +112,7 @@ AOTInductorModelContainerGetConstantOriginalFQN(
 // Retrieves whether a constant is from folded.
 // idx is the index of the internal's constants.
 // Need idx < num_constants from AOTInductorModelContainerGetNumConstants
-AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTI_API AOTIRuntimeError
 AOTInductorModelContainerGetConstantFromFolded(
     AOTInductorModelContainerHandle container_handle,
     size_t idx,
@@ -121,7 +121,7 @@ AOTInductorModelContainerGetConstantFromFolded(
 // Retrieves the inductor constant type.
 // idx is the index of the internal's constants.
 // Need idx < num_constants from AOTInductorModelContainerGetNumConstants
-AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTI_API AOTIRuntimeError
 AOTInductorModelContainerGetConstantType(
     AOTInductorModelContainerHandle container_handle,
     size_t idx,
@@ -130,7 +130,7 @@ AOTInductorModelContainerGetConstantType(
 // Retrieves a constant's dtype.
 // idx is the index of the internal's constants.
 // Need idx < num_constants from AOTInductorModelContainerGetNumConstants
-AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTI_API AOTIRuntimeError
 AOTInductorModelContainerGetConstantDtype(
     AOTInductorModelContainerHandle container_handle,
     size_t idx,
@@ -139,14 +139,14 @@ AOTInductorModelContainerGetConstantDtype(
 // Retrieves a constant's data size.
 // idx is the index of the internal's constants.
 // Need idx < num_constants from AOTInductorModelContainerGetNumConstants
-AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTI_API AOTIRuntimeError
 AOTInductorModelContainerGetConstantDataSize(
     AOTInductorModelContainerHandle container_handle,
     size_t idx,
     size_t* data_size);
 
 // Extract the constants that is being used in the container.
-AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTI_API AOTIRuntimeError
 AOTInductorModelContainerExtractConstantsMap(
     AOTInductorModelContainerHandle container_handle,
     AOTInductorConstantMapHandle constant_map_handle,
@@ -154,7 +154,7 @@ AOTInductorModelContainerExtractConstantsMap(
 
 // Setup the constant buffer in model container with provided ConstantMap.
 // The ConstantMap is user managed, and the user would retain ownership.
-AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTI_API AOTIRuntimeError
 AOTInductorModelContainerUpdateUserManagedConstantBuffer(
     AOTInductorModelContainerHandle container_handle,
     AOTInductorConstantMapHandle constant_map_handle,
@@ -164,7 +164,7 @@ AOTInductorModelContainerUpdateUserManagedConstantBuffer(
 // Setup the constant buffer in model container with provided ConstantMap
 // use_inactive should be set as true if the inactive buffer is to be updated.
 // validate_full_update checks if all constants are included in the ConstantMap
-AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTI_API AOTIRuntimeError
 AOTInductorModelContainerUpdateConstantBuffer(
     AOTInductorModelContainerHandle container_handle,
     AOTInductorConstantMapHandle constant_map_handle,
@@ -173,18 +173,18 @@ AOTInductorModelContainerUpdateConstantBuffer(
 
 // Setup the inactive constant buffer in model container with provided
 // ConstantMap
-AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTI_API AOTIRuntimeError
 AOTInductorModelContainerUpdateInactiveConstantBuffer(
     AOTInductorModelContainerHandle container_handle,
     AOTInductorConstantMapHandle constant_map_handle);
 
 // Free the inactive constant buffer in model container.
-AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTI_API AOTIRuntimeError
 AOTInductorModelContainerFreeInactiveConstantBuffer(
     AOTInductorModelContainerHandle container_handle);
 
 // Run constant folding on constant buffer.
-AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTI_API AOTIRuntimeError
 AOTInductorModelContainerRunConstantFolding(
     AOTInductorModelContainerHandle container_handle,
     bool use_inactive,
@@ -192,28 +192,28 @@ AOTInductorModelContainerRunConstantFolding(
     AOTIProxyExecutorHandle proxy_executor_handle);
 
 // Swap the constant buffer being used to the inactive one.
-AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTI_API AOTIRuntimeError
 AOTInductorModelContainerSwapConstantBuffer(
     AOTInductorModelContainerHandle container_handle);
 
 // Retrieves the number of inputs for the model.
-AOTI_WRAPPER_INTERFACE AOTIRuntimeError AOTInductorModelContainerGetNumInputs(
+AOTI_API AOTIRuntimeError AOTInductorModelContainerGetNumInputs(
     AOTInductorModelContainerHandle container_handle,
     size_t* ret_num_inputs);
 
 // Retrieves the input name at the given index.
-AOTI_WRAPPER_INTERFACE AOTIRuntimeError AOTInductorModelContainerGetInputName(
+AOTI_API AOTIRuntimeError AOTInductorModelContainerGetInputName(
     AOTInductorModelContainerHandle container_handle,
     size_t input_idx,
     const char** ret_input_names);
 
 // Retrieves the number of outputs for the model.
-AOTI_WRAPPER_INTERFACE AOTIRuntimeError AOTInductorModelContainerGetNumOutputs(
+AOTI_API AOTIRuntimeError AOTInductorModelContainerGetNumOutputs(
     AOTInductorModelContainerHandle container_handle,
     size_t* ret_num_outputs);
 
 // Retrieves the output name at the given index.
-AOTI_WRAPPER_INTERFACE AOTIRuntimeError AOTInductorModelContainerGetOutputName(
+AOTI_API AOTIRuntimeError AOTInductorModelContainerGetOutputName(
     AOTInductorModelContainerHandle container_handle,
     size_t output_idx,
     const char** ret_output_names);
@@ -225,32 +225,32 @@ AOTI_WRAPPER_INTERFACE AOTIRuntimeError AOTInductorModelContainerGetOutputName(
 //
 // constant_map_handle is an opaque type to satisfy the C ABI.  It should be a
 // std::unordered_map<std::string, at::Tensor*>*.
-AOTI_WRAPPER_INTERFACE AOTIRuntimeError AOTInductorModelCreate(
+AOTI_API AOTIRuntimeError AOTInductorModelCreate(
     AOTInductorModelHandle* model_handle,
     AOTInductorConstantMapHandle constant_map_handle);
 
 // Run an AOTInductorModel (see AOTInductorModelCreate for when one should use
 // this function versus AOTInductorModelContainerRun).
-AOTI_WRAPPER_INTERFACE AOTIRuntimeError AOTInductorModelRun(
+AOTI_API AOTIRuntimeError AOTInductorModelRun(
     AOTInductorModelHandle model_handle,
     AtenTensorHandle* input_handles,
     AtenTensorHandle* output_handles);
 
 // Replace AOTInductorModel's constant map. Note it doesn't handle concurrency
 // so be sure to handle ordering if AOTInductorModelRun is ran concurrently.
-AOTI_WRAPPER_INTERFACE AOTIRuntimeError AOTInductorModelUpdateConstantsMap(
+AOTI_API AOTIRuntimeError AOTInductorModelUpdateConstantsMap(
     AOTInductorModelHandle model_handle,
     AOTInductorConstantMapHandle constant_map_handle);
 
 // Delete an AOTInductorModel created by AOTInductorModelCreate.
-AOTI_WRAPPER_INTERFACE AOTIRuntimeError
+AOTI_API AOTIRuntimeError
 AOTInductorModelDelete(AOTInductorModelHandle model_handle);
 
-AOTI_WRAPPER_INTERFACE AOTIRuntimeError AOTInductorModelGetNumOutputs(
+AOTI_API AOTIRuntimeError AOTInductorModelGetNumOutputs(
     AOTInductorModelHandle model_handle,
     size_t* ret_num_outputs);
 
-AOTI_WRAPPER_INTERFACE AOTIRuntimeError AOTInductorModelContainerGetCallSpec(
+AOTI_API AOTIRuntimeError AOTInductorModelContainerGetCallSpec(
     AOTInductorModelContainerHandle container_handle,
     const char** in_spec,
     const char** out_spec);


### PR DESCRIPTION
On Windows, we need to explicit declaration for export APIs. Because the package loader call these API via GetProcAddress.

cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10