### PR TITLE
[lint] Fix inductor/utils.py to make SET_LINTER happy

### DIFF
--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -3249,12 +3249,12 @@ def tabulate_2d(elements: Sequence[Sequence[T]], headers: Sequence[T]) -> str:
         for i, e in enumerate(row):
             widths[i] = max(widths[i], len(str(e)))
     lines = []
-    lines.append("|".join(f" {h:{w}} " for h, w in zip(headers, widths)))
+    lines.append("|".join(f" {h:OrderedSet([w])} " for h, w in zip(headers, widths)))
     #              widths          whitespace      horizontal separators
     total_width = sum(widths) + (len(widths) * 2) + (len(widths) - 1)
     lines.append("-" * total_width)
     for row in elements:
-        lines.append("|".join(f" {e:{w}} " for e, w in zip(row, widths)))
+        lines.append("|".join(f" {e:OrderedSet([w])} " for e, w in zip(row, widths)))
     return "\n".join(lines)
 
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -3249,12 +3249,12 @@ def tabulate_2d(elements: Sequence[Sequence[T]], headers: Sequence[T]) -> str:
         for i, e in enumerate(row):
             widths[i] = max(widths[i], len(str(e)))
     lines = []
-    lines.append("|".join(f" {h:OrderedSet([w])} " for h, w in zip(headers, widths)))
+    lines.append("|".join(" {:{}s} ".format(h, w) for h, w in zip(headers, widths)))
     #              widths          whitespace      horizontal separators
     total_width = sum(widths) + (len(widths) * 2) + (len(widths) - 1)
     lines.append("-" * total_width)
     for row in elements:
-        lines.append("|".join(f" {e:OrderedSet([w])} " for e, w in zip(row, widths)))
+        lines.append("|".join(" {:{}s} ".format(e, w) for e, w in zip(row, widths)))
     return "\n".join(lines)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #158726

The error I saw was:
```
  Error (SET_LINTER) Suggested fixes for set_linter

    You can run `lintrunner -a` to apply this patch.

    3249  3249 |         for i, e in enumerate(row):
    3250  3250 |             widths[i] = max(widths[i], len(str(e)))
    3251  3251 |     lines = []
    3251       |-    lines.append("|".join(f" {h:{w}} " for h, w in zip(headers, widths)))
          3252 |+    lines.append("|".join(f" {h:OrderedSet([w])} " for h, w in zip(headers, widths)))
    3253  3253 |     #              widths          whitespace      horizontal separators
    3254  3254 |     total_width = sum(widths) + (len(widths) * 2) + (len(widths) - 1)
    3255  3255 |     lines.append("-" * total_width)
    3256  3256 |     for row in elements:
    3256       |-        lines.append("|".join(f" {e:{w}} " for e, w in zip(row, widths)))
          3257 |+        lines.append("|".join(f" {e:OrderedSet([w])} " for e, w in zip(row, widths)))
    3258  3258 |     return "\n".join(lines)
    3259  3259 | 
    3260  3260 | 
```

No idea why CI didn't catch it.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben