### PR TITLE
Fix torch.fused_moving_avg_obs_fake_quant when called with ch_axis = 1

### DIFF
--- a/aten/src/ATen/native/quantized/cuda/FusedObsFakeQuant.cu
+++ b/aten/src/ATen/native/quantized/cuda/FusedObsFakeQuant.cu
@@ -309,7 +309,7 @@ std::tuple<at::Tensor, at::Tensor> fused_moving_avg_obs_fake_quant_cuda(
   if (per_row_fq) {
     if (fake_quant_on.item().toInt()) {
       return at::fake_quantize_per_channel_affine_cachemask(
-          x, scale, zero_point, 0, qmin, qmax);
+          x, scale, zero_point, ch_axis, qmin, qmax);
     } else {
       auto mask = at::ones_like(x, at::kBool, MemoryFormat::Preserve);
       return std::make_tuple(x.clone(), mask);

--- a/test/quantization/core/test_workflow_ops.py
+++ b/test/quantization/core/test_workflow_ops.py
@@ -1148,9 +1148,12 @@ class TestFusedObsFakeQuant(TestCase):
         self.assertEqual(out.shape, output_shape)
 
     @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),
-           symmetric_quant=st.booleans(), use_bool=st.booleans())
+           symmetric_quant=st.booleans(), 
+           use_bool=st.booleans(),
+           axis=[0, 1],
+           )
     @settings(deadline=None)
-    def test_fused_obs_fake_quant_moving_avg_per_channel(self, device, symmetric_quant, use_bool) -> None:
+    def test_fused_obs_fake_quant_moving_avg_per_channel(self, device, symmetric_quant, use_bool, axis) -> None:
         """
         Tests the case where we call the fused_obs_fake_quant op multiple times
         and update the running_min and max of the activation tensors.
@@ -1189,7 +1192,7 @@ class TestFusedObsFakeQuant(TestCase):
                     avg_const,
                     0,
                     255,
-                    0,
+                    axis,
                     True,  # per_channel_enabled
                     symmetric_quant,
                 )
@@ -1210,7 +1213,7 @@ class TestFusedObsFakeQuant(TestCase):
                             preserve_sparsity=symmetric_quant,
                         )
                     x_in = _fake_quantize_per_channel_affine_reference(
-                        x, x_scale, x_zero_point, 0, 0, 255
+                        x, x_scale, x_zero_point, axis, 0, 255
                     )
                     self.assertEqual(scale, x_scale)
                     self.assertEqual(zero_point, x_zero_point)


### PR DESCRIPTION
`torch.fused_moving_avg_obs_fake_quant` works with ch_axis = 1 when `fake_quant_enabled=False` but hit the following error when `fake_quant_enabled=True`:
```
RuntimeError: dimensions of scale and zero-point are not consistent with input tensor
```
The reason is that we always pass in ch_axis=0 when fake_quant_enabled = True. 
