### PR TITLE
[Inductor] Expose decomposeK knobs as envvars

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -1501,9 +1501,10 @@ class TestMaxAutotune(TestCase):
         max_autotune=True,
         max_autotune_gemm_backends="TRITON",
         autotune_fallback_to_aten=False,
-        disable_decompose_k=True,
     )
-    def test_max_autotune_disable_decompose_K(self):
+    @parametrize("num_decompose_k_splits", (0, 5, 20))
+    @parametrize("decompose_k_threshold", (1, 8, 16))
+    def test_max_autotune_decompose_k_envvars(self):
         M, N, K = (32, 32, 32768)
 
         a = torch.randn(M, K, dtype=torch.float16, device="cuda", requires_grad=True)
@@ -1511,9 +1512,7 @@ class TestMaxAutotune(TestCase):
 
         compiled_func = torch.compile(lambda a, b: a @ b)
         out, code = run_and_get_code(compiled_func, a, b)
-
-        for codegen in code:
-            FileCheck().check_not("decompose_k").run(codegen)
+        import pdb; pdb.set_trace()
 
     @skipIfXpu
     @unittest.skipIf(

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -1544,7 +1544,6 @@ class TestMaxAutotune(TestCase):
                     self.assertTrue(decompose_count > 0)
                     self.assertTrue(decompose_count <= num_decompose_k_splits)
 
-
     @skipIfXpu
     @unittest.skipIf(
         TEST_WITH_ROCM, "exhaustive currently only thoroughly tested on NVIDIA"

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -50,7 +50,7 @@ from torch.utils._triton import has_triton_tma_device
 aten = torch.ops.aten
 from torch._inductor.mock_cache import global_stats, PatchCaches, Stats
 from torch._inductor.test_case import run_tests, TestCase
-from torch._inductor.utils import fresh_cache, run_and_get_code
+from torch._inductor.utils import fresh_cache, get_k_splits, run_and_get_code, use_decompose_k_choice
 from torch._inductor.virtualized import V
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing import FileCheck
@@ -1493,6 +1493,7 @@ class TestMaxAutotune(TestCase):
             self.assertEqual(hits(), 4)
             self.assertEqual(misses(), 4)
 
+    @fresh_cache()
     @skipIfXpu
     @unittest.skipIf(
         config.cpp_wrapper, "decompose_k not supported for cpp_wrapper yet"
@@ -1503,16 +1504,34 @@ class TestMaxAutotune(TestCase):
         autotune_fallback_to_aten=False,
     )
     @parametrize("num_decompose_k_splits", (0, 5, 20))
-    @parametrize("decompose_k_threshold", (1, 8, 16))
-    def test_max_autotune_decompose_k_envvars(self):
-        M, N, K = (32, 32, 32768)
+    @parametrize("decompose_k_threshold", (8, 16))
+    def test_max_autotune_decompose_k_envvars(self, num_decompose_k_splits, decompose_k_threshold):
+        shapes = [(32, 32, 32768), (32, 32, 256)]
+        for M, N, K in shapes:
+            get_k_splits.cache_clear()
+            use_decompose_k_choice.cache_clear()
+            a = torch.randn(M, K, dtype=torch.float16, device="cuda", requires_grad=True)
+            b = torch.randn(K, N, dtype=torch.float16, device="cuda", requires_grad=True)
 
-        a = torch.randn(M, K, dtype=torch.float16, device="cuda", requires_grad=True)
-        b = torch.randn(K, N, dtype=torch.float16, device="cuda", requires_grad=True)
+            with config.patch(
+                {
+                    "triton.num_decompose_k_splits": num_decompose_k_splits,
+                    "triton.decompose_k_threshold": decompose_k_threshold,
+                }
+            ):
+                compiled_func = torch.compile(lambda a, b: a @ b)
+                _, code = run_and_get_code(compiled_func, a, b)
 
-        compiled_func = torch.compile(lambda a, b: a @ b)
-        out, code = run_and_get_code(compiled_func, a, b)
-        import pdb; pdb.set_trace()
+                decompose_count = 0
+                for codegen in code:
+                    if "benchmark_decompose_k_mm" in codegen:
+                        decompose_count += 1
+
+                if K // M < decompose_k_threshold or K // N < decompose_k_threshold or num_decompose_k_splits == 0:
+                    self.assertEqual(decompose_count, 0)
+                else:
+                    self.assertTrue(decompose_count > 0 and decompose_count <= num_decompose_k_splits)
+
 
     @skipIfXpu
     @unittest.skipIf(

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -1500,6 +1500,7 @@ class TestMaxAutotune(TestCase):
 
     @fresh_cache()
     @skipIfXpu
+    @unittest.skipIf(TEST_WITH_ROCM, "decompose_k not supported on ROCm")
     @unittest.skipIf(
         config.cpp_wrapper, "decompose_k not supported for cpp_wrapper yet"
     )

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1340,11 +1340,15 @@ class triton:
     disallow_failing_autotune_kernels_TESTING_ONLY = False
 
     # specify number of splits to autotune on for decompose_k. 0 disables decompose_k
-    num_decompose_k_splits = int(os.environ.get("TORCHINDUCTOR_NUM_DECOMPOSE_K_SPLITS", "10"))
+    num_decompose_k_splits = int(
+        os.environ.get("TORCHINDUCTOR_NUM_DECOMPOSE_K_SPLITS", "10")
+    )
 
     # specify minimum ratio of K to M AND N in order to autotune on decompose_k. 0 enables
     # it as an autotuning choice for all matmuls
-    decompose_k_threshold = int(os.environ.get("TORCHINDUCTOR_DECOMPOSE_K_THRESHOLD", "32"))
+    decompose_k_threshold = int(
+        os.environ.get("TORCHINDUCTOR_DECOMPOSE_K_THRESHOLD", "32")
+    )
 
 
 class aot_inductor:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -425,13 +425,6 @@ max_autotune_pointwise = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_POINTWISE") 
 # enable slow autotuning passes to select gemm algorithms
 max_autotune_gemm = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_GEMM") == "1"
 
-# specify number of splits to autotune on for decompose_k. 0 disables decompose_k
-num_decompose_k_splits = int(os.environ.get("TORCHINDUCTOR_NUM_DECOMPOSE_K_SPLITS", "0"))
-
-# specify minimum ratio of K to M AND N in order to autotune on decompose_k. 0 enables
-# it as an autotuning choice for all matmuls
-decompose_k_threshold = int(os.environ.get("TORCHINDUCTOR_DECOMPOSE_K_THRESHOLD", "32"))
-
 # Modifies the number of autotuning choices displayed, set to None for all
 autotune_num_choices_displayed: Optional[int] = 10
 
@@ -1345,6 +1338,13 @@ class triton:
     # For testing it's helpful to be able to assert that none of the configs fail.
     # Note: it may also need to be used with config.compile_threads = 1
     disallow_failing_autotune_kernels_TESTING_ONLY = False
+
+    # specify number of splits to autotune on for decompose_k. 0 disables decompose_k
+    num_decompose_k_splits = int(os.environ.get("TORCHINDUCTOR_NUM_DECOMPOSE_K_SPLITS", "10"))
+
+    # specify minimum ratio of K to M AND N in order to autotune on decompose_k. 0 enables
+    # it as an autotuning choice for all matmuls
+    decompose_k_threshold = int(os.environ.get("TORCHINDUCTOR_DECOMPOSE_K_THRESHOLD", "32"))
 
 
 class aot_inductor:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -425,8 +425,12 @@ max_autotune_pointwise = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_POINTWISE") 
 # enable slow autotuning passes to select gemm algorithms
 max_autotune_gemm = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_GEMM") == "1"
 
-# disable decomposek autotune choice for gemm
-disable_decompose_k = os.environ.get("TORCHINDUCTOR_DISABLE_DECOMPOSE_K") == "1"
+# specify number of splits to autotune on for decompose_k. 0 disables decompose_k
+num_decompose_k_splits = int(os.environ.get("TORCHINDUCTOR_NUM_DECOMPOSE_K_SPLITS", "0"))
+
+# specify minimum ratio of K to M AND N in order to autotune on decompose_k. 0 enables
+# it as an autotuning choice for all matmuls
+decompose_k_threshold = int(os.environ.get("TORCHINDUCTOR_DECOMPOSE_K_THRESHOLD", "32"))
 
 # Modifies the number of autotuning choices displayed, set to None for all
 autotune_num_choices_displayed: Optional[int] = 10

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2015,7 +2015,6 @@ def get_code(fn: Callable[P, _T], *args: P.args, **kwargs: P.kwargs) -> list[str
             self.codegen_with_cpp_wrapper() if self.cpp_wrapper else self.codegen()
         )
         # Skip all the actual compiling.
-        nonlocal save_output_code
         save_output_code(wrapper_code.value)
         if kernel_code:
             save_output_code(kernel_code.value)

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1666,6 +1666,7 @@ def _use_cutlass_for_op(op_name: str) -> bool:
 
 _IntLike: TypeAlias = Union[int, sympy.Expr]
 
+
 @functools.cache
 def use_decompose_k_choice(m: _IntLike, n: _IntLike, k: _IntLike) -> bool:
     from torch._inductor.virtualized import V


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #158745

Fix up decomposeK autotuning, by removing condition to return more than `k_splits_limit` and setting default to 10 instead of 5. Allow `k_splits_limit` to be configurable to the user via `TORCHINDUCTOR_NUM_DECOMPOSE_K_SPLITS` and also allow user to configure threshold in which to use decompose_k via `TORCHINDUCTOR_DECOMPOSE_K_THRESHOLD`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben