### PR TITLE
`SavePlan` cache key per planner instance

### DIFF
--- a/torch/distributed/checkpoint/default_planner.py
+++ b/torch/distributed/checkpoint/default_planner.py
@@ -87,7 +87,7 @@ class DefaultSavePlanner(SavePlanner):
                 "deprecated, and no longer has any effect. Please remove this argument "
                 "from your call."
             )
-        self._cached_plans_key: str = self.__class__.__name__
+        self._cached_plans_key: str = f"{self.__class__.__name__}-{id(self)}"
         self._enable_plan_caching = enable_plan_caching
 
     def set_up_planner(


### PR DESCRIPTION
Right now, different `DefaultSavePlanner` objects use the same cache key. This can result in KeyErrors

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci @saumishr as the author in https://github.com/pytorch/pytorch/pull/147343