### PR TITLE
[caffe2] Improve auto vectorized code

### DIFF
--- a/aten/src/ATen/cpu/vec/vec_base.h
+++ b/aten/src/ATen/cpu/vec/vec_base.h
@@ -57,7 +57,10 @@ Windows llvm will not have this definition.
 #endif
 
 // These macros helped us unify vec_base.h
-#ifdef CPU_CAPABILITY_AVX512
+#if defined(__aarch64__) && !defined(CPU_CAPABILITY_SVE256) // NEON
+#define VECTOR_WIDTH 16
+#define __at_align__ __attribute__((aligned(16)))
+#elif defined(CPU_CAPABILITY_AVX512)
 #if defined(__GNUC__)
 #define __at_align__ __attribute__((aligned(64)))
 #elif defined(_WIN32)


### PR DESCRIPTION
Summary:
We are currently relying on the auto-vectorized routines implemented in Loops.h

Having VECTOR_WIDTH set to 16 facilitates the compiler using NEON registers

Test Plan:
Canary

Rollback Plan:

Differential Revision: D78684713




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168