### PR TITLE
Guard rocm_smi.h include with a header check

### DIFF
--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -194,6 +194,14 @@ endif()
   if(UNIX)
     find_package_and_print_version(rccl)
     find_package_and_print_version(hsa-runtime64 REQUIRED)
+    find_file(ROCM_SMI_HEADER_PATH
+      NAMES rocm_smi/rocm_smi.h
+      NO_DEFAULT_PATH
+      PATHS ${ROCM_INCLUDE_DIRS}
+    )
+    if(NOT ROCM_SMI_HEADER_PATH)
+      message(FATAL_ERROR "rocm_smi.h not found. Please install the rocm-smi-lib package.")
+    endif()
   endif()
 
   # Optional components.


### PR DESCRIPTION
Fixes #158725 

This PR fixes a build issue when building with USE_ROCM enabled on systems that don't have the rocm_smi.h header installed.

The include of <rocm_smi/rocm_smi.h> in intrad_node_comm.cpp is now conditionally compiled based on a new CMake  check. If the header's found, CMake defines HAS_ROCM_SMI which enables the include. Otherwise the file builds without it.

This makes the build more robust and compatible with different ROCm setups.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @aditvenk @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @jerrymannil @xinyazhang @dllehr-amd