### PR TITLE
[precompile] Support user defined function calls from bytecode.

### DIFF
--- a/test/dynamo/test_package.py
+++ b/test/dynamo/test_package.py
@@ -14,6 +14,7 @@ import torch.onnx.operators
 import torch.utils.cpp_extension
 from torch._dynamo.package import CompilePackage, DiskDynamoStore, DynamoCache
 from torch._dynamo.precompile_context import PrecompileContext
+from torch._dynamo.testing import reduce_to_scalar_loss
 from torch._functorch import config as functorch_config
 from torch._inductor.runtime.runtime_utils import cache_dir
 from torch.testing._internal.common_utils import (
@@ -21,6 +22,10 @@ from torch.testing._internal.common_utils import (
     parametrize,
 )
 from torch.testing._internal.inductor_utils import HAS_CUDA, HAS_XPU
+
+
+def compute_loss_helper(x):
+    return reduce_to_scalar_loss(x)
 
 
 @functorch_config.patch("bundled_autograd_cache", True)
@@ -533,6 +538,30 @@ def add(x, y):
         with torch.compiler.set_stance("fail_on_recompile"):
             expected2 = compiled_fn(arg2)
             expected2.sum().backward()
+
+        self.assertEqual(torch._dynamo.convert_frame.FRAME_COUNTER, total_frames)
+
+    @parametrize("device", ("cpu", "cuda", "xpu"))
+    @torch._dynamo.config.patch(caching_precompile=True)
+    def test_call_function_from_resume(self, device):
+        mod = torch.nn.Linear(2, 3, device=device)
+
+        def foo(x, mod):
+            pred = mod(x)
+            compute_loss_helper(pred).backward()
+            return None
+
+        args = (torch.randn(3, 2, device=device), mod)
+        compiled_fn = torch.compile(foo)
+        compiled_fn(*args)
+        total_frames = torch._dynamo.convert_frame.FRAME_COUNTER
+
+        self._save_and_reload(expected_backends=1, expected_dynamo=1)
+
+        compiled_fn = torch.compile(foo)
+        # Run it again, no recompile needed
+        with torch.compiler.set_stance("fail_on_recompile"):
+            compiled_fn(*args)
 
         self.assertEqual(torch._dynamo.convert_frame.FRAME_COUNTER, total_frames)
 

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -2899,8 +2899,16 @@ class CheckFunctionManager:
                     has_value = False
                     value = MISSING
                 else:
-                    has_value = True
-                    value = builder.get(guard.name)
+                    try:
+                        # Guard evaluation is expected to fail when we guard on
+                        # things like "not hasattr(x, 'foo')". In cases like this,
+                        # we don't have a well defined value because such thing
+                        # doesn't exist.
+                        value = builder.get(guard.name)
+                        has_value = True
+                    except:  # noqa: B001,E722
+                        value = MISSING
+                        has_value = False
                 is_global = get_global_source_name(guard.originating_source) is not None
                 guard_fn = guard.create_fn
                 if isinstance(guard_fn, functools.partial):

--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -9,6 +9,7 @@ from a different process or host.
 """
 
 import abc
+import ast
 import contextlib
 import dataclasses
 import functools
@@ -27,6 +28,7 @@ from typing import Any, Callable, NewType, Optional
 
 import torch
 import torch._inductor.package
+from torch._dynamo.exc import PackageError
 from torch._dynamo.precompile_context import PrecompileCacheArtifact, PrecompileContext
 from torch._inductor.runtime.cache_dir_utils import cache_dir
 from torch.compiler._cache import CacheArtifactFactory
@@ -123,6 +125,10 @@ class _DynamoCodeCacheEntry:
       4. A list of guarded code that eval frame dispatches to.
       5. A list of imported module objects unioned from all compiled branches.
       6. A list of "backends" (compiled fx graph) unioned from all compield branches.
+      7. A string path used to access the original code object users defined.
+         A code object can be accessed by "{python_module}.{function_name}.{code_source}" .
+      8. A boolean flag indicating whether the function is installed to global scope.
+      9. A boolean flag indicating whether the function has a compile id.
     """
 
     python_code: SerializedCode
@@ -131,6 +137,114 @@ class _DynamoCodeCacheEntry:
     guarded_codes: list[_GuardedCodeCacheEntry]
     import_sources: dict[str, str]
     backend_ids: list[_BackendId]
+    code_source: Optional[str]
+    install_to_global: bool
+    has_compile_id: bool = False
+
+
+def _lookup_code(entry: _DynamoCodeCacheEntry) -> types.CodeType:
+    assert len(entry.function_names) == 1
+    fn = sys.modules[entry.python_module]
+    parts = entry.function_names[0].split(".")
+    for part in parts:
+        fn = getattr(fn, part)
+    if entry.code_source:
+        parts = entry.code_source.split(".")
+        for part in parts:
+            if part.endswith("]"):
+                fn = getattr(fn, part[: part.rfind("[")], None)[
+                    ast.literal_eval(part[part.rfind("[") + 1 : -1])
+                ]
+            else:
+                fn = getattr(fn, part)
+    return fn
+
+
+def _raise_resolution_error(code: types.CodeType, scope: Any) -> None:
+    raise PackageError(
+        f"Cannot resolve a fully qualified name for {code}. Lookup scope: {scope}"
+    )
+
+
+def _get_code_source(code: types.CodeType) -> tuple[str, str]:
+    """
+    Given a code object, return a fully qualified name which will be used as
+    a serialized handle to access the code object from the new process.
+    This is normally a straightforward process, but there are some corner cases:
+    1. When a function is defined with decorator, then this function will be captured
+       inside a closure with the wrapper object.
+    2. When a function is defined as a nested function, then the code object will be
+       stored on the co_consts field of the parent code object by Python compiler.
+    This function handles all of the corner cases above.
+    """
+
+    module = inspect.getmodule(code)
+    if module is None:
+        raise PackageError(f"Cannot find module for code {code}")
+
+    toplevel = module
+    if sys.version_info >= (3, 11):
+        parts = code.co_qualname.split(".")
+
+        for part in parts:
+            if not hasattr(toplevel, part):
+                _raise_resolution_error(code, toplevel)
+            toplevel = getattr(toplevel, part)
+            if inspect.isfunction(toplevel):
+                break
+
+    def _find_code_source(obj) -> Optional[str]:
+        nonlocal toplevel
+        if inspect.iscode(obj):
+            if obj is code:
+                return ""
+
+            for i, const in enumerate(obj.co_consts):
+                if (res := _find_code_source(const)) is not None:
+                    return f".co_consts[{i}]{res}"
+
+        if inspect.isfunction(obj):
+            if (res := _find_code_source(obj.__code__)) is not None:
+                toplevel = obj
+                return f".__code__{res}"
+            if obj.__closure__ is not None:
+                for i, cell in enumerate(obj.__closure__):
+                    try:
+                        cell_contents = cell.cell_contents
+                    except ValueError:
+                        continue
+                    if not (
+                        inspect.isfunction(cell_contents)
+                        or inspect.iscode(cell_contents)
+                    ):
+                        continue
+                    if (res := _find_code_source(cell_contents)) is not None:
+                        toplevel = obj
+                        return f".__closure__[{i}].cell_contents{res}"
+
+        if sys.version_info < (3, 11):
+            if inspect.ismodule(obj):
+                for value in obj.__dict__.values():
+                    if not (inspect.isfunction(value) or inspect.isclass(value)):
+                        continue
+                    if (res := _find_code_source(value)) is not None:
+                        return res
+
+            if inspect.isclass(obj):
+                for name, value in obj.__dict__.items():
+                    if not (inspect.isfunction(value) or inspect.isclass(value)):
+                        continue
+                    if (res := _find_code_source(value)) is not None:
+                        if not value.__name__ != name:
+                            _raise_resolution_error(code, toplevel)
+                        return res
+
+        return None
+
+    code_source = _find_code_source(toplevel)
+    if code_source is None:
+        _raise_resolution_error(code, toplevel)
+    return toplevel.__qualname__, code_source.strip(".")
 
 
 @dataclasses.dataclass
@@ -169,6 +283,39 @@ def _get_sourcelines(
 
 def _hash_sourcelines(m: types.ModuleType, firstlineno: int, lastlineno: int) -> str:
     return _hash_source("".join(_get_sourcelines(m, firstlineno, lastlineno)))
+
+
+def _compile_frame_context(code: types.CodeType):
+    from torch._dynamo.convert_frame import get_compile_id
+    from torch._guards import compile_context, CompileContext
+
+    # Each code represents a new compile frame
+    # recompiles on the same frame are all saved
+    # under the same cache entry, so we don't have recompile ids
+    # i.e. If cold start had 0/0, 0/1, 1/0, 1/1, these would be
+    # collapsed into 0/0, 1/0 on warm.
+    @contextlib.contextmanager
+    def _ctx():
+        increment_frame()
+        compile_id = get_compile_id(frame_state={})
+        with (
+            compile_context(CompileContext(compile_id)),
+            dynamo_timed(
+                "_compile.compile_inner",
+                phase_name="entire_frame_compile",
+                dynamo_compile_column_us="dynamo_cumulative_compile_time_us",
+                # TODO: save all relevant compilation metrics
+                metadata={
+                    "frame_key": str(torch._dynamo.utils.curr_frame),
+                    "co_name": code.co_name,
+                    "co_filename": code.co_filename,
+                    "co_firstlineno": code.co_firstlineno,
+                },
+            ),
+        ):
+            yield
+
+    return _ctx()
 
 
 class CompilePackage:
@@ -256,7 +403,9 @@ class CompilePackage:
         self,
         python_code: types.CodeType,
         python_module: str,
-        name: Optional[_FunctionId] = None,
+        function_name: Optional[_FunctionId] = None,
+        code_source: Optional[str] = None,
+        install_to_global: bool = False,
     ) -> None:
         if python_code not in self._codes:
             code = _DynamoCodeCacheEntry(
@@ -266,14 +415,18 @@ class CompilePackage:
                 guarded_codes=[],
                 import_sources={},
                 backend_ids=[],
+                code_source=code_source,
+                install_to_global=install_to_global,
             )
             self._codes[python_code] = code
         else:
             code = self._codes[python_code]
             assert code.python_module == python_module
+            assert code.install_to_global == install_to_global
+            assert code.code_source == code_source
 
-        if name is not None:
-            code.function_names.append(name)
+        if function_name is not None:
+            code.function_names.append(function_name)
 
     @property
     def cached_backends(self) -> dict[_BackendId, Any]:
@@ -284,15 +437,30 @@ class CompilePackage:
         assert self._innermost_fn is not None
         return CompilePackage.source_id_from_fn(self._innermost_fn)
 
+    def _add_user_function(self, code: types.CodeType) -> None:
+        function_name, code_source = _get_code_source(code)
+        self._add_function(
+            code,
+            inspect.getmodule(code).__name__,
+            function_name=_FunctionId(function_name),
+            code_source=code_source,
+        )
+
     @contextlib.contextmanager
     def code_context(self, code: types.CodeType) -> Generator[None, None, None]:
         assert self._current_entry is None
+
+        # Sometimes user code cannot be inlined in dynamo resulting in extra user code
+        # being compiled. We should record these as when they are actually invoked.
+        if code not in self._codes:
+            self._add_user_function(code)
 
         entry = self._codes[code]
         self._current_entry = entry
         try:
             yield
         finally:
+            entry.has_compile_id = True
             self._current_entry = None
 
     def add_guarded_code(
@@ -332,10 +500,13 @@ class CompilePackage:
         self,
         python_code: types.CodeType,
         python_module: str,
-        name: Optional[str],
+        function_name: Optional[str],
     ) -> None:
         self._add_function(
-            python_code, python_module, _FunctionId(name) if name else None
+            python_code,
+            python_module,
+            function_name=_FunctionId(function_name) if function_name else None,
+            install_to_global=True,
         )
         self._resume_codes.add(python_code)
 
@@ -354,6 +525,7 @@ class CompilePackage:
     def validate(self) -> None:
         assert self._current_entry is None
         assert self._innermost_fn is not None
+        assert self._initialized
         assert next(iter(self._codes)) is self._innermost_fn.__code__
 
     def _install_global(self, module: types.ModuleType, name: str, value: Any) -> None:
@@ -380,43 +552,30 @@ class CompilePackage:
           3. Install the precompiled cache entries to ExtraStates on the code object.
         """
         from torch._C._dynamo.eval_frame import _load_precompile_entry
-        from torch._dynamo.convert_frame import get_compile_id
-        from torch._guards import compile_context, CompileContext
 
         from .output_graph import get_builtins_dict
 
         self.uninstall()
         for code, entry in self._codes.items():
-            # Each code represents a new compile frame
-            # recompiles on the same frame are all saved
-            # under the same cache entry, so we don't have recompile ids
-            # i.e. If cold start had 0/0, 0/1, 1/0, 1/1, these would be
-            # collapsed into 0/0, 1/0 on warm.
-            increment_frame()
-            compile_id = get_compile_id(frame_state={})
-            with (
-                compile_context(CompileContext(compile_id)),
-                dynamo_timed(
-                    "_compile.compile_inner",
-                    phase_name="entire_frame_compile",
-                    dynamo_compile_column_us="dynamo_cumulative_compile_time_us",
-                    # TODO: save all relevant compilation metrics
-                    metadata={
-                        "frame_key": str(torch._dynamo.utils.curr_frame),
-                        "co_name": code.co_name,
-                        "co_filename": code.co_filename,
-                        "co_firstlineno": code.co_firstlineno,
-                    },
-                ),
-            ):
+            context = (
+                _compile_frame_context(code)
+                if entry.has_compile_id
+                else contextlib.nullcontext()
+            )
+            with context:
                 module = sys.modules[entry.python_module]
                 for alias, module_name in entry.import_sources.items():
                     self._install_global(
                         module, alias, importlib.import_module(module_name)
                     )
-                for function_name in entry.function_names:
-                    fn = types.FunctionType(code, module.__dict__, function_name)
-                    self._install_global(module, function_name, fn)
+                target_code = code
+                if entry.install_to_global:
+                    for function_name in entry.function_names:
+                        fn = types.FunctionType(code, module.__dict__, function_name)
+                        self._install_global(module, function_name, fn)
+                if entry.code_source:
+                    target_code = _lookup_code(entry)
+
                 for backend_id in entry.backend_ids:
                     if backend_id not in backends:
                         raise RuntimeError(
@@ -431,6 +590,11 @@ class CompilePackage:
                             backend_id,
                             torch._dynamo.disable(backend),
                         )
+
+                if len(entry.guarded_codes) == 0:
+                    # Dynamo generates empty graph for trivial functions, should just skip them
+                    # in these cases.
+                    torch._dynamo.eval_frame.skip_code(target_code)
 
                 for guarded_code in entry.guarded_codes:
                     guards_state = pickle.loads(guarded_code.guards_state)
@@ -450,14 +614,14 @@ class CompilePackage:
                             runtime_global_scope[builtin_dict_name] = builtins_dict
                     assert isinstance(guards_state, torch._dynamo.guards.GuardsState)
                     check_fn_manager = torch._dynamo.guards.CheckFunctionManager(
-                        code,
+                        target_code,
                         guards_state.output_graph,
                         guards_serialization_mode="load",
                         shape_code_parts=guards_state.shape_code_parts,
                         runtime_global_scope=runtime_global_scope,
                     )
                     _load_precompile_entry(
-                        code,
+                        target_code,
                         check_fn_manager.guard_manager,
                         SerializedCode.to_code_object(guarded_code.dynamo_code),
                     )

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -3622,7 +3622,7 @@ class InstructionTranslator(InstructionTranslatorBase):
 
         if self.package is not None:
             self.package.add_resume_function(
-                new_code, self.f_globals["__name__"], package_name
+                new_code, self.f_globals["__name__"], function_name=package_name
             )
 
         cg.extend_output([cg.create_load(k) for k in argnames])


### PR DESCRIPTION
Summary:
Previously precompile was implemented under the assumption that dynamo always inlines the user code and generate resume functions when a graph break is hit. In cases like nanogpt, there exists nontrivial amount of code causing dynamo to fail the speculation and stop inlining certain type of user function. This results in more code objects to be tracked by CompilePackage.

Since these new code objects are user defined, we need to also serialize the location of these code so that we can load the precompile entries to the these code objects in another process.

With this fix, we are able to run nanogpt inference+training with precompile under torchbench.

Test Plan:
buck run mode/opt benchmarks/dynamo:torchbench -- --inference --backend=inductor --only nanogpt --repeat 5 --performance
buck run mode/opt benchmarks/dynamo:torchbench -- --training --backend=inductor --only nanogpt --repeat 5 --performance

Rollback Plan:

Differential Revision: D78691422




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela