### PR TITLE
[PGNCCLx] Bring split and merge for PGNCCLx

### DIFF
--- a/torch/csrc/distributed/c10d/Backend.hpp
+++ b/torch/csrc/distributed/c10d/Backend.hpp
@@ -392,7 +392,7 @@ class TORCH_API Backend : public torch::CustomClassHolder {
 
   virtual c10::intrusive_ptr<Backend> split(
       const std::vector<int>& ranks,
-      const c10::intrusive_ptr<Options> opts) {
+      const c10::intrusive_ptr<Options>& opts) {
     TORCH_CHECK(
         false,
         "Backend ",
@@ -402,7 +402,7 @@ class TORCH_API Backend : public torch::CustomClassHolder {
 
   virtual c10::intrusive_ptr<Backend> merge(
       const c10::intrusive_ptr<Store>& store,
-      const c10::intrusive_ptr<Options> opts,
+      const c10::intrusive_ptr<Options>& opts,
       const int& rank,
       const int& size) {
     TORCH_CHECK(

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
@@ -699,7 +699,7 @@ const std::vector<uint64_t>& ProcessGroupGloo::groupRanks() const {
 
 c10::intrusive_ptr<Backend> ProcessGroupGloo::split(
     const std::vector<int>& ranks,
-    const c10::intrusive_ptr<Backend::Options> opts) {
+    const c10::intrusive_ptr<Backend::Options>& opts) {
   auto it = std::find(ranks.begin(), ranks.end(), rank_);
   int groupRank;
   if (it == ranks.end()) {
@@ -728,7 +728,7 @@ c10::intrusive_ptr<Backend> ProcessGroupGloo::split(
 
 c10::intrusive_ptr<Backend> ProcessGroupGloo::merge(
     const c10::intrusive_ptr<Store>& store,
-    const c10::intrusive_ptr<Backend::Options> opts,
+    const c10::intrusive_ptr<Backend::Options>& opts,
     const int& rank,
     const int& size) {
   auto glooOpts = c10::dynamic_intrusive_pointer_cast<Options>(opts);

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
@@ -310,11 +310,11 @@ class TORCH_API ProcessGroupGloo : public Backend {
 
   c10::intrusive_ptr<Backend> split(
       const std::vector<int>& ranks,
-      const c10::intrusive_ptr<Backend::Options> opts) override;
+      const c10::intrusive_ptr<Backend::Options>& opts) override;
 
   c10::intrusive_ptr<Backend> merge(
       const c10::intrusive_ptr<Store>& store,
-      const c10::intrusive_ptr<Backend::Options> opts,
+      const c10::intrusive_ptr<Backend::Options>& opts,
       const int& rank,
       const int& size) override;
 

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1256,7 +1256,7 @@ void ProcessGroupNCCL::enableCollectivesTiming() {
 
 c10::intrusive_ptr<Backend> ProcessGroupNCCL::split(
     const std::vector<int>& ranks,
-    const c10::intrusive_ptr<Backend::Options> opts) {
+    const c10::intrusive_ptr<Backend::Options>& opts) {
   auto deviceIdx = guessDeviceId();
   TORCH_CHECK(
       deviceIdx >= 0,
@@ -1295,7 +1295,7 @@ c10::intrusive_ptr<Backend> ProcessGroupNCCL::split(
 
 c10::intrusive_ptr<Backend> ProcessGroupNCCL::merge(
     const c10::intrusive_ptr<Store>& store,
-    const c10::intrusive_ptr<Backend::Options> opts,
+    const c10::intrusive_ptr<Backend::Options>& opts,
     const int& rank,
     const int& size) {
   auto ncclOpts = c10::dynamic_intrusive_pointer_cast<Options>(opts);

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -961,11 +961,11 @@ class TORCH_API ProcessGroupNCCL : public Backend {
 
   c10::intrusive_ptr<Backend> split(
       const std::vector<int>& ranks,
-      const c10::intrusive_ptr<Backend::Options> opts) override;
+      const c10::intrusive_ptr<Backend::Options>& opts) override;
 
   c10::intrusive_ptr<Backend> merge(
       const c10::intrusive_ptr<Store>& store,
-      const c10::intrusive_ptr<Backend::Options> opts,
+      const c10::intrusive_ptr<Backend::Options>& opts,
       const int& rank,
       const int& size) override;
 


### PR DESCRIPTION
Summary: We added group split in D78300794 and remote_group_merge in D78450094. We first want to upstream this change to PGNCCLx as well so that NCCLx can use this new API and we can continue our c10d clean up in https://github.com/pytorch/pytorch/pull/158488.

Test Plan:
CI

```
buck test -c hpc_comms.use_ncclx=stable comms/ncclx/pg/tests:test_c10d_ncclx -- test_group_split_and_merge    
```

Rollback Plan:

Differential Revision: D78521060




cc @H-Huang @awgu @wanchaol @fegin @wz337 @wconstab @d4l3k @pragupta