### PR TITLE
Only use HIPBLASLT_VEC_EXT for rocm < 7

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -1882,7 +1882,7 @@ void scaled_gemm(
 #if defined(USE_ROCM)
 #if defined(HIPBLASLT_OUTER_VEC)
   // this case is handled later as hipified CUBLASLT_MATMUL_MATRIX_SCALE_OUTER_VEC_32F
-#elif defined(HIPBLASLT_VEC_EXT)
+#elif defined(HIPBLASLT_VEC_EXT) && ROCM_VERSION < 70000
   if (use_rowwise) {
     matmulDescA = HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER_VEC_EXT;
     matmulDescB = HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER_VEC_EXT;

--- a/aten/src/ATen/cuda/tunable/GemmHipblaslt.h
+++ b/aten/src/ATen/cuda/tunable/GemmHipblaslt.h
@@ -489,7 +489,7 @@ class HipblasltGemmOp : public Callable<ParamsT> {
       const void* mat2_scale_ptr = GetBScalePointerFromParams<CT>(params);
       const void* result_scale_ptr = GetDScalePointerFromParams<CT>(params);
       if (mat1_scale_ptr && mat2_scale_ptr) {
-#ifdef HIPBLASLT_VEC_EXT
+#if defined(HIPBLASLT_VEC_EXT) && !(defined(USE_ROCM) && ROCM_VERSION >= 70000)
         if (GetUseRowwiseFromParams<CT>(params)) {
           matmul.setAttribute(HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER_VEC_EXT, mat1_scale_ptr);
           matmul.setAttribute(HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER_VEC_EXT, mat2_scale_ptr);


### PR DESCRIPTION
Summary:
**Problem:** 
Encountered the following error when building with rocm 7
```
buck-out/v2/gen/fbcode/6d722e0195dce538/caffe2/__ATen-hip__/buck-headers/ATen/hip/tunable/GemmHipblaslt.h:495:31: error: expected expression
  495 |           matmul.setAttribute(HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER_VEC_EXT, mat1_scale_ptr);
      |                               ^
fbcode/third-party-buck/platform010/build/rocm/7.0.0/include/hipblaslt/hipblaslt.h:78:5: note: expanded from macro 'HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER_VEC_EXT'
   78 |     static_assert(false, "HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER_VEC_EXT is deprecated and not supported. Please set HIPBLASLT_MATMUL_DESC_A_SCALE_MODE as HIPBLASLT_MATMUL_MATRIX_SCALE_OUTER_VEC_32F instead.")
```

**Changes:**
Gate all uses of HIPBLASLT_MATMUL_DESC_A/B_SCALE_POINTER_VEC_EXT for rocm 7

**Sources:** 
- -DHIPBLASLT_VEC_EXT in https://fburl.com/code/ulyv71nr
- static_assert in https://fburl.com/code/sepu1j9p

Test Plan:
```
Buck UI: https://www.internalfb.com/buck2/38d0a33b-4cda-43b2-9159-005893c1c79b
Network: Up: 109MiB  Down: 1.2GiB  (reSessionID-ce376cb9-ca58-493b-93ac-e91356b63d45)
Analyzing targets. Remaining      0/22623                                                                                    1001530 actions, 1162219 artifacts declared
Executing actions. Remaining      0/132228                                                                                   231:03:48.2s exec time total
Command: run.      Finished 1298 local, 9087 remote, 33194 cache (76% hit)                                                   31:00:18.7s exec time cached (13%)                                   
Time elapsed: 8:06.0s
BUILD SUCCEEDED - starting your binary
```

Rollback Plan:

Differential Revision: D78606589




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd