### PR TITLE
Enable logging for absolute memory estimation

### DIFF
--- a/test/functorch/test_ac_logging.py
+++ b/test/functorch/test_ac_logging.py
@@ -37,6 +37,7 @@ class TestAcLogging(TestCase):
         self.recomputable_node_idxs: list[int] = []
         self.expected_runtime: int = 100
         self.memories_banned_nodes: list[int] = [50]
+        self.normalized_memories_banned_nodes: list[float] = [0.10344827586206896]
         self.runtimes_banned_nodes: list[int] = [10]
         self.min_cut_saved_values: list[Node] = [self.node1]
 
@@ -93,21 +94,23 @@ class TestAcLogging(TestCase):
             "Expected Runtime": self.expected_runtime,
             "Knapsack Saved Nodes": self.saved_node_idxs,
             "Knapsack Recomputed Nodes": self.recomputable_node_idxs,
-            "Knapsack Input Memories": self.memories_banned_nodes,
+            "Knapsack Input Memories": self.normalized_memories_banned_nodes,
+            "Absolute Memories": self.memories_banned_nodes,
             "Knapsack Input Runtimes": self.runtimes_banned_nodes,
             "Min Cut Solution Saved Values": ["node1"],
         }
         result = create_activation_checkpointing_logging_structure_payload(
-            self.graph,
-            input_joint_graph_node_information,
-            joint_graph_edges,
-            self.all_recomputable_banned_nodes,
-            self.expected_runtime,
-            self.saved_node_idxs,
-            self.recomputable_node_idxs,
-            self.memories_banned_nodes,
-            self.runtimes_banned_nodes,
-            self.min_cut_saved_values,
+            joint_graph=self.graph,
+            joint_graph_node_information=input_joint_graph_node_information,
+            joint_graph_edges=joint_graph_edges,
+            all_recomputable_banned_nodes=self.all_recomputable_banned_nodes,
+            expected_runtime=self.expected_runtime,
+            saved_node_idxs=self.saved_node_idxs,
+            recomputable_node_idxs=self.recomputable_node_idxs,
+            memories_banned_nodes=self.memories_banned_nodes,
+            normalized_memories_banned_nodes=self.normalized_memories_banned_nodes,
+            runtimes_banned_nodes=self.runtimes_banned_nodes,
+            min_cut_saved_values=self.min_cut_saved_values,
         )
         self.assertEqual(result, expected_payload)
 
@@ -119,14 +122,15 @@ class TestAcLogging(TestCase):
         self, mock_json_dumps: MagicMock, mock_trace_structured: MagicMock
     ) -> None:
         create_structured_trace_for_min_cut_info(
-            self.graph,
-            self.all_recomputable_banned_nodes,
-            self.saved_node_idxs,
-            self.recomputable_node_idxs,
-            self.expected_runtime,
-            self.memories_banned_nodes,
-            self.runtimes_banned_nodes,
-            self.min_cut_saved_values,
+            joint_graph=self.graph,
+            all_recomputable_banned_nodes=self.all_recomputable_banned_nodes,
+            saved_node_idxs=self.saved_node_idxs,
+            recomputable_node_idxs=self.recomputable_node_idxs,
+            expected_runtime=self.expected_runtime,
+            memories_banned_nodes=self.memories_banned_nodes,
+            normalized_memories_banned_nodes=self.normalized_memories_banned_nodes,
+            runtimes_banned_nodes=self.runtimes_banned_nodes,
+            min_cut_saved_values=self.min_cut_saved_values,
         )
 
         self.assertEqual(mock_trace_structured.call_count, 1)

--- a/torch/_functorch/_activation_checkpointing/ac_logging_utils.py
+++ b/torch/_functorch/_activation_checkpointing/ac_logging_utils.py
@@ -60,10 +60,32 @@ def create_activation_checkpointing_logging_structure_payload(
     expected_runtime: float,
     saved_node_idxs: list[int],
     recomputable_node_idxs: list[int],
-    memories_banned_nodes: list[float],
+    memories_banned_nodes: list[int],
+    normalized_memories_banned_nodes: list[float],
     runtimes_banned_nodes: list[float],
     min_cut_saved_values: list[Node],
 ) -> dict[str, Any]:
+    """
+    Creates a structured payload for logging activation checkpointing information.
+
+    Args:
+        joint_graph: The computational graph representing operations.
+        joint_graph_node_information: Dictionary containing information about nodes in the joint graph.
+        joint_graph_edges: List of edges in the joint graph represented as tuples of node names.
+        all_recomputable_banned_nodes: List of nodes that are banned from recomputation.
+        expected_runtime: Expected runtime of the computation.
+        saved_node_idxs: Indices of nodes that are saved (not recomputed).
+        recomputable_node_idxs: Indices of nodes that can be recomputed.
+        memories_banned_nodes: Memory usage values (in absolute units) for banned nodes.
+        normalized_memories_banned_nodes: Normalized memory usage values for banned nodes,
+            used as input to the knapsack algorithm.
+        runtimes_banned_nodes: Runtime values for banned nodes, used as input to the
+            knapsack algorithm.
+        min_cut_saved_values: List of nodes saved by the min-cut algorithm.
+
+    Returns:
+        A dictionary containing structured logging information for activation checkpointing.
+    """
     activation_checkpointing_logging_structure_payload: dict[str, Any] = {
         "Joint Graph Size": len(joint_graph.nodes),
         "Joint Graph Edges": {
@@ -77,7 +99,8 @@ def create_activation_checkpointing_logging_structure_payload(
         "Expected Runtime": expected_runtime,
         "Knapsack Saved Nodes": saved_node_idxs,
         "Knapsack Recomputed Nodes": recomputable_node_idxs,
-        "Knapsack Input Memories": memories_banned_nodes,
+        "Absolute Memories": memories_banned_nodes,
+        "Knapsack Input Memories": normalized_memories_banned_nodes,
         "Knapsack Input Runtimes": runtimes_banned_nodes,
         "Min Cut Solution Saved Values": [node.name for node in min_cut_saved_values],
     }
@@ -90,17 +113,37 @@ def create_structured_trace_for_min_cut_info(
     saved_node_idxs: list[int],
     recomputable_node_idxs: list[int],
     expected_runtime: float,
-    memories_banned_nodes: list[float],
+    memories_banned_nodes: list[int],
+    normalized_memories_banned_nodes: list[float],
     runtimes_banned_nodes: list[float],
     min_cut_saved_values: list[Node],
 ) -> None:
+    """
+    Creates a structured trace for minimum cut information in the graph.
+
+    Args:
+        joint_graph: The computational graph representation.
+        all_recomputable_banned_nodes: List of nodes that can be recomputed.
+        saved_node_idxs: Indices of nodes that are saved in memory.
+        recomputable_node_idxs: Indices of nodes that are recomputed.
+        expected_runtime: Expected runtime for the computation.
+        memories_banned_nodes: Memory requirements for each banned node in bytes.
+        normalized_memories_banned_nodes: Normalized memory requirements for each banned node
+            (typically scaled between 0 and 1 for relative comparison).
+        runtimes_banned_nodes: Runtime costs associated with each banned node.
+        min_cut_saved_values: Nodes that are saved as part of the minimum cut solution.
+    """
+    # Create a dictionary to store recomputable node information
     recomputable_node_info: dict[str, int] = {
         node.name: idx for idx, node in enumerate(all_recomputable_banned_nodes)
     }
+
+    # Create joint graph node information
     joint_graph_node_information = create_joint_graph_node_information(
         joint_graph, recomputable_node_info
     )
 
+    # Update node information with recomputable candidate details
     for node_name, node_info in joint_graph_node_information.items():
         if node_info["is_recomputable_candidate"]:
             idx = recomputable_node_info[node_name]
@@ -117,28 +160,30 @@ def create_structured_trace_for_min_cut_info(
                 idx in recomputable_node_idxs
             )
 
+    # Create joint graph edges
     joint_graph_edges = create_joint_graph_edges(joint_graph)
+
+    # Create activation checkpointing logging structure payload
     activation_checkpointing_logging_structure_payload = (
         create_activation_checkpointing_logging_structure_payload(
-            joint_graph,
-            joint_graph_node_information,
-            joint_graph_edges,
-            all_recomputable_banned_nodes,
-            expected_runtime,
-            saved_node_idxs,
-            recomputable_node_idxs,
-            memories_banned_nodes,
-            runtimes_banned_nodes,
-            min_cut_saved_values,
+            joint_graph=joint_graph,
+            joint_graph_node_information=joint_graph_node_information,
+            joint_graph_edges=joint_graph_edges,
+            all_recomputable_banned_nodes=all_recomputable_banned_nodes,
+            expected_runtime=expected_runtime,
+            saved_node_idxs=saved_node_idxs,
+            recomputable_node_idxs=recomputable_node_idxs,
+            memories_banned_nodes=memories_banned_nodes,
+            normalized_memories_banned_nodes=normalized_memories_banned_nodes,
+            runtimes_banned_nodes=runtimes_banned_nodes,
+            min_cut_saved_values=min_cut_saved_values,
         )
     )
 
+    # Create structured trace
     trace_structured(
         "artifact",
-        metadata_fn=lambda: {
-            "name": "min_cut_information",
-            "encoding": "json",
-        },
+        metadata_fn=lambda: {"name": "min_cut_information", "encoding": "json"},
         payload_fn=lambda: json.dumps(
             activation_checkpointing_logging_structure_payload
         ),

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -2433,7 +2433,10 @@ def choose_saved_values_set(
                 saved_node_idxs=saved_node_idxs,
                 recomputable_node_idxs=recomputable_node_idxs,
                 expected_runtime=expected_runtime,
-                memories_banned_nodes=memories_banned_nodes,
+                memories_banned_nodes=[
+                    _size_of(i) for i in all_recomputable_banned_nodes
+                ],
+                normalized_memories_banned_nodes=memories_banned_nodes,
                 runtimes_banned_nodes=runtimes_banned_nodes,
                 min_cut_saved_values=saved_values,
             )


### PR DESCRIPTION
Summary: Update the Auto AC logging so that it also provides the *absolute* memory estimations for each node.

Test Plan:
(aps-gem_omnifm_v2_mwb_dynamic_005_budget-f23a84c3d8): https://fburl.com/ai_infra/0r738h5r


{F1980393481}

* Memory Recorded in bytes


---

```
buck2 test //caffe2/test/functorch:test_ac_logging
```
https://www.internalfb.com/intern/testinfra/testrun/14918173863021573

Rollback Plan:

Differential Revision: D78580107


