### PR TITLE
Revert : Remove is_arvr_mode() from xnnpack.buck.bzl

### DIFF
--- a/third_party/xnnpack.buck.bzl
+++ b/third_party/xnnpack.buck.bzl
@@ -1,4 +1,5 @@
 load("//tools/build_defs:fb_xplat_cxx_library.bzl", "fb_xplat_cxx_library")
+load("//tools/build_defs:fbsource_utils.bzl", "is_arvr_mode")
 load("//tools/build_defs:glob_defs.bzl", "subdir_glob")
 load("//tools/build_defs:platform_defs.bzl", "ANDROID", "APPLE", "APPLETVOS", "CXX", "IOS", "MACOSX", "WINDOWS")
 load(
@@ -141,12 +142,9 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_sse",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("sse"),
-                "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("sse"),
-            }),
-        }),
+            "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("sse"),
+            "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("sse"),
+        }) if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -162,15 +160,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "x86|x86_64|platform009|platform010",
-                    prod_srcs_for_arch_wrapper("sse"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = ([
+            (
+                "x86|x86_64|platform009|platform010",
+                prod_srcs_for_arch_wrapper("sse"),
+            ),
+        ] if not is_arvr_mode() else []),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -211,12 +206,9 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_sse2",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("sse2"),
-                "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("sse2"),
-            }),
-        }),
+            "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("sse2"),
+            "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("sse2"),
+        }) if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -232,15 +224,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "x86|x86_64|platform009|platform010",
-                    prod_srcs_for_arch_wrapper("sse2"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = ([
+            (
+                "x86|x86_64|platform009|platform010",
+                prod_srcs_for_arch_wrapper("sse2"),
+            ),
+        ] if not is_arvr_mode() else []),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -281,12 +270,9 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_ssse3",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("ssse3"),
-                "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("ssse3"),
-            }),
-        }),
+            "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("ssse3"),
+            "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("ssse3"),
+        }) if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -302,15 +288,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "x86|x86_64|platform009|platform010",
-                    prod_srcs_for_arch_wrapper("ssse3"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = ([
+            (
+                "x86|x86_64|platform009|platform010",
+                prod_srcs_for_arch_wrapper("ssse3"),
+            ),
+        ] if not is_arvr_mode() else []),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -351,12 +334,9 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_sse41",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("sse41"),
-                "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("sse41"),
-            }),
-        }),
+            "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("sse41"),
+            "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("sse41"),
+        }) if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -372,15 +352,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "x86|x86_64|platform009|platform010",
-                    prod_srcs_for_arch_wrapper("sse41"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = ([
+            (
+                "x86|x86_64|platform009|platform010",
+                prod_srcs_for_arch_wrapper("sse41"),
+            ),
+        ] if not is_arvr_mode() else []),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -421,12 +398,9 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_avx",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx"),
-                "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx"),
-            }),
-        }),
+            "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx"),
+            "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx"),
+        }) if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -450,15 +424,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "x86|x86_64|platform009|platform010",
-                    prod_srcs_for_arch_wrapper("avx"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = ([
+            (
+                "x86|x86_64|platform009|platform010",
+                prod_srcs_for_arch_wrapper("avx"),
+            ),
+        ] if not is_arvr_mode() else []),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -500,12 +471,9 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_avx512vnnigfni",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx512vnnigfni"),
-                "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx512vnnigfni"),
-            }),
-        }),
+            "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx512vnnigfni"),
+            "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx512vnnigfni"),
+        }) if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -545,15 +513,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "x86|x86_64|platform009|platform010",
-                    prod_srcs_for_arch_wrapper("avx512vnnigfni"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = ([
+            (
+                "x86|x86_64|platform009|platform010",
+                prod_srcs_for_arch_wrapper("avx512vnnigfni"),
+            ),
+        ] if not is_arvr_mode() else []),
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
         visibility = ["PUBLIC"],
@@ -598,12 +563,9 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_avx512vnni",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx512vnni"),
-                "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx512vnni"),
-            }),
-        }),
+            "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx512vnni"),
+            "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx512vnni"),
+        }) if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -642,15 +604,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "x86|x86_64|platform009|platform010",
-                    prod_srcs_for_arch_wrapper("avx512vnni"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = ([
+            (
+                "x86|x86_64|platform009|platform010",
+                prod_srcs_for_arch_wrapper("avx512vnni"),
+            ),
+        ] if not is_arvr_mode() else []),
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
         exported_preprocessor_flags = [
@@ -698,10 +657,7 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
 
     fb_xplat_cxx_library(
         name = "ukernels_avxvnni",
-        srcs = select({
-            "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": prod_srcs_for_arch_wrapper("avxvnni"),
-        }),
+        srcs = prod_srcs_for_arch_wrapper("avxvnni") if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -723,15 +679,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "x86|x86_64|platform009|platform010",
-                    prod_srcs_for_arch_wrapper("avxvnni"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = ([
+            (
+                "x86|x86_64|platform009|platform010",
+                prod_srcs_for_arch_wrapper("avxvnni"),
+            ),
+        ] if not is_arvr_mode() else []),
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
         visibility = ["PUBLIC"],
@@ -771,12 +724,9 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_f16c",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("f16c"),
-                "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("f16c"),
-            }),
-        }),
+            "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("f16c"),
+            "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("f16c"),
+        }) if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -800,15 +750,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "x86|x86_64|platform009|platform010",
-                    prod_srcs_for_arch_wrapper("f16c"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = ([
+            (
+                "x86|x86_64|platform009|platform010",
+                prod_srcs_for_arch_wrapper("f16c"),
+            ),
+        ] if not is_arvr_mode() else []),
         platforms = (APPLE, ANDROID, CXX, WINDOWS),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -852,12 +799,9 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_fma3",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("fma3"),
-                "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("fma3"),
-            }),
-        }),
+            "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("fma3"),
+            "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("fma3"),
+        }) if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -884,15 +828,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "x86|x86_64|platform009|platform010",
-                    prod_srcs_for_arch_wrapper("fma3"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = ([
+            (
+                "x86|x86_64|platform009|platform010",
+                prod_srcs_for_arch_wrapper("fma3"),
+            ),
+        ] if not is_arvr_mode() else []),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -948,12 +889,9 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_avx2",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx2"),
-                "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx2"),
-            }),
-        }),
+            "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx2"),
+            "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx2"),
+        }) if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -983,15 +921,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "x86|x86_64|platform009|platform010",
-                    prod_srcs_for_arch_wrapper("avx2"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = ([
+            (
+                "x86|x86_64|platform009|platform010",
+                prod_srcs_for_arch_wrapper("avx2"),
+            ),
+        ] if not is_arvr_mode() else []),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1054,12 +989,9 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_avx512",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx512f"),
-                "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx512f"),
-            }),
-        }),
+            "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx512f"),
+            "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx512f"),
+        }) if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1083,15 +1015,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "x86|x86_64|platform009|platform010",
-                    prod_srcs_for_arch_wrapper("avx512f"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = ([
+            (
+                "x86|x86_64|platform009|platform010",
+                prod_srcs_for_arch_wrapper("avx512f"),
+            ),
+        ] if not is_arvr_mode() else []),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1105,12 +1034,9 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_avx512vbmi",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx512vbmi"),
-                "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx512vbmi"),
-            }),
-        }),
+            "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx512vbmi"),
+            "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx512vbmi"),
+        }) if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1149,15 +1075,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "x86|x86_64|platform009|platform010",
-                    prod_srcs_for_arch_wrapper("avx512vbmi"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = ([
+            (
+                "x86|x86_64|platform009|platform010",
+                prod_srcs_for_arch_wrapper("avx512vbmi"),
+            ),
+        ] if not is_arvr_mode() else []),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1213,12 +1136,9 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_avx512skx",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx512skx"),
-                "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx512skx"),
-            }),
-        }),
+            "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx512skx"),
+            "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx512skx"),
+        }) if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1254,15 +1174,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "x86|x86_64|platform009|platform010",
-                    prod_srcs_for_arch_wrapper("avx512skx"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = ([
+            (
+                "x86|x86_64|platform009|platform010",
+                prod_srcs_for_arch_wrapper("avx512skx"),
+            ),
+        ] if not is_arvr_mode() else []),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1338,11 +1255,8 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_armsimd32",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("armsimd32"),
-            }),
-        }),
+            "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("armsimd32"),
+        }) if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1363,15 +1277,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "(aarch32|arm32|armv7)",
-                    prod_srcs_for_arch_wrapper("armsimd32"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = [
+            (
+                "(aarch32|arm32|armv7)",
+                prod_srcs_for_arch_wrapper("armsimd32"),
+            ),
+        ] if not is_arvr_mode() else [],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1385,12 +1296,9 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_neon",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neon"),
-                "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neon"),
-            }),
-        }),
+            "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neon"),
+            "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neon"),
+        }) if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1415,19 +1323,16 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "(aarch32|arm32|armv7)",
-                    prod_srcs_for_arch_wrapper("neon"),
-                ),
-                (
-                    "(aarch64|arm64)",
-                    prod_srcs_for_arch_wrapper("neon"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = [
+            (
+                "(aarch32|arm32|armv7)",
+                prod_srcs_for_arch_wrapper("neon"),
+            ),
+            (
+                "(aarch64|arm64)",
+                prod_srcs_for_arch_wrapper("neon"),
+            ),
+        ] if not is_arvr_mode() else [],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1441,26 +1346,20 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_neon_aarch64",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neon_aarch64"),
-            }),
-        }),
+            "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neon_aarch64"), 
+        }) if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
         compiler_flags = [
             "-O2",
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "(aarch64|arm64)",
-                    prod_srcs_for_arch_wrapper("neon_aarch64"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = [
+            (
+                "(aarch64|arm64)",
+                prod_srcs_for_arch_wrapper("neon_aarch64"),
+            ),
+        ] if not is_arvr_mode() else [],
         labels = labels,
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -1475,11 +1374,8 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_neon_fma",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neonfma"),
-            }),
-        }),
+            "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neonfma"),
+        }) if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1511,15 +1407,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "(aarch32|arm32|armv7)",
-                    prod_srcs_for_arch_wrapper("neonfma"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = [
+            (
+                "(aarch32|arm32|armv7)",
+                prod_srcs_for_arch_wrapper("neonfma"),
+            ),
+        ] if not is_arvr_mode() else [],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1533,11 +1426,8 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_neonfma_aarch64",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neonfma") + prod_srcs_for_arch_wrapper("neonfma_aarch64"),
-            }),
-        }),
+            "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neonfma") + prod_srcs_for_arch_wrapper("neonfma_aarch64"),
+        }) if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1545,15 +1435,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "-O2",
         ],
         labels = labels,
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "(arm64|aarch64)$",
-                    prod_srcs_for_arch_wrapper("neonfma") + prod_srcs_for_arch_wrapper("neonfma_aarch64"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = [
+            (
+                "(arm64|aarch64)$",
+                prod_srcs_for_arch_wrapper("neonfma") + prod_srcs_for_arch_wrapper("neonfma_aarch64"),
+            ),
+        ] if not is_arvr_mode() else [],
         platforms = (APPLE, ANDROID, CXX, WINDOWS),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -1568,12 +1455,9 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_fp16arith",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("fp16arith"),
-                "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("fp16arith"),
-            }),
-        }),
+            "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("fp16arith"),
+            "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("fp16arith"),
+        }) if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1620,19 +1504,16 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             )
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "(aarch32|arm32|armv7)",
-                    prod_srcs_for_arch_wrapper("fp16arith"),
-                ),
-                (
-                    "(aarch64|arm64)",
-                    prod_srcs_for_arch_wrapper("fp16arith") + prod_srcs_for_arch_wrapper("fp16arith_aarch64"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = [
+            (
+                "(aarch32|arm32|armv7)",
+                prod_srcs_for_arch_wrapper("fp16arith"),
+            ),
+            (
+                "(aarch64|arm64)",
+                prod_srcs_for_arch_wrapper("fp16arith") + prod_srcs_for_arch_wrapper("fp16arith_aarch64"),
+            ),
+        ] if not is_arvr_mode() else [],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1646,12 +1527,9 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_neon_fp16",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neonfp16"),
-                "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neonfp16"),
-            }),
-        }),
+            "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neonfp16"),
+            "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neonfp16"),
+        }) if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1676,19 +1554,16 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "(aarch32|arm32|armv7)$",
-                    prod_srcs_for_arch_wrapper("neonfp16"),
-                ),
-                (
-                    "(arm64|aarch64)",
-                    prod_srcs_for_arch_wrapper("neonfp16"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = [
+            (
+                "(aarch32|arm32|armv7)$",
+                prod_srcs_for_arch_wrapper("neonfp16"),
+            ),
+            (
+                "(arm64|aarch64)",
+                prod_srcs_for_arch_wrapper("neonfp16"),
+            ),
+        ] if not is_arvr_mode() else [],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1702,12 +1577,9 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_neon_v8",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neonv8"),
-                "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neonv8"),
-            }),
-        }),
+            "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neonv8"),
+            "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neonv8"),
+        }) if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1746,19 +1618,16 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "(aarch32|arm32|armv7)$",
-                    prod_srcs_for_arch_wrapper("neonv8"),
-                ),
-                (
-                    "(arm64|aarch64)",
-                    prod_srcs_for_arch_wrapper("neonv8"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = [
+            (
+                "(aarch32|arm32|armv7)$",
+                prod_srcs_for_arch_wrapper("neonv8"),
+            ),
+            (
+                "(arm64|aarch64)",
+                prod_srcs_for_arch_wrapper("neonv8"),
+            ),
+        ] if not is_arvr_mode() else [],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1772,11 +1641,8 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_neon_dot",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neondot"),
-            }),
-        }),
+            "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neondot"),
+        }) if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1801,15 +1667,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "(aarch32|arm32|armv7)",
-                    prod_srcs_for_arch_wrapper("neondot"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = [
+            (
+                "(aarch32|arm32|armv7)",
+                prod_srcs_for_arch_wrapper("neondot"),
+            ),
+        ] if not is_arvr_mode() else [],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1823,11 +1686,8 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_neon_dot_aarch64",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neondot") + prod_srcs_for_arch_wrapper("neondot_aarch64"),
-            }),
-        }),
+            "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neondot") + prod_srcs_for_arch_wrapper("neondot_aarch64"),
+        }) if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1846,15 +1706,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "(aarch64|arm64)",
-                    prod_srcs_for_arch_wrapper("neondot") + prod_srcs_for_arch_wrapper("neondot_aarch64"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = [
+            (
+                "(aarch64|arm64)",
+                prod_srcs_for_arch_wrapper("neondot") + prod_srcs_for_arch_wrapper("neondot_aarch64"),
+            ),
+        ] if not is_arvr_mode() else [],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1868,11 +1725,8 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_neon_dot_fp16arith",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neondotfp16arith"),
-            }),
-        }),
+            "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neondotfp16arith"),
+        }) if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1896,15 +1750,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "(aarch32|arm32|armv7)",
-                    prod_srcs_for_arch_wrapper("neondotfp16arith"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = [
+            (
+                "(aarch32|arm32|armv7)",
+                prod_srcs_for_arch_wrapper("neondotfp16arith"),
+            ),
+        ] if not is_arvr_mode() else [],
         labels = labels,
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -1919,11 +1770,8 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_neon_dot_fp16arith_aarch64",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neondotfp16arith") + prod_srcs_for_arch_wrapper("neondotfp16arith_aarch64"),
-            }),
-        }),
+            "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neondotfp16arith") + prod_srcs_for_arch_wrapper("neondotfp16arith_aarch64"),
+        }) if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1943,15 +1791,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "(aarch64|arm64)",
-                    prod_srcs_for_arch_wrapper("neondotfp16arith") + prod_srcs_for_arch_wrapper("neondotfp16arith_aarch64"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = [
+            (
+                "(aarch64|arm64)",
+                prod_srcs_for_arch_wrapper("neondotfp16arith") + prod_srcs_for_arch_wrapper("neondotfp16arith_aarch64"),
+            ),
+        ] if not is_arvr_mode() else [],
         labels = labels,
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -1966,11 +1811,8 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_neon_fp16arith",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neonfp16arith"),
-            }),
-        }),
+            "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neonfp16arith"),
+        }) if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -1995,15 +1837,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "(aarch32|arm32|armv7)",
-                    prod_srcs_for_arch_wrapper("neonfp16arith"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = [
+            (
+                "(aarch32|arm32|armv7)",
+                prod_srcs_for_arch_wrapper("neonfp16arith"),
+            ),
+        ] if not is_arvr_mode() else [],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -2017,11 +1856,8 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_neon_fp16arith_aarch64",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neonfp16arith") + prod_srcs_for_arch_wrapper("neonfp16arith_aarch64"),
-            }),
-        }),
+            "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neonfp16arith") + prod_srcs_for_arch_wrapper("neonfp16arith_aarch64"),
+        }) if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -2040,15 +1876,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "(aarch64|arm64)",
-                    prod_srcs_for_arch_wrapper("neonfp16arith") + prod_srcs_for_arch_wrapper("neonfp16arith_aarch64"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = [
+            (
+                "(aarch64|arm64)",
+                prod_srcs_for_arch_wrapper("neonfp16arith") + prod_srcs_for_arch_wrapper("neonfp16arith_aarch64"),
+            ),
+        ] if not is_arvr_mode() else [],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -2062,12 +1895,9 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_neonfma_i8mm",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neonfma_i8mm"),
-                "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neonfma_i8mm"),
-            }),
-        }),
+            "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neonfma_i8mm"),
+            "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neonfma_i8mm"),
+        }) if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -2101,19 +1931,16 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "(aarch32|arm32|armv7)$",
-                    prod_srcs_for_arch_wrapper("neonfma_i8mm"),
-                ),
-                (
-                    "(arm64|aarch64)",
-                    prod_srcs_for_arch_wrapper("neonfma_i8mm"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = [
+            (
+                "(aarch32|arm32|armv7)$",
+                prod_srcs_for_arch_wrapper("neonfma_i8mm"),
+            ),
+            (
+                "(arm64|aarch64)",
+                prod_srcs_for_arch_wrapper("neonfma_i8mm"),
+            ),
+        ] if not is_arvr_mode() else [],
         platforms = (APPLE, ANDROID, CXX, WINDOWS),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -2128,11 +1955,8 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_neoni8mm",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neoni8mm"),
-            }),
-        }),
+            "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neoni8mm"),
+        }) if is_arvr_mode() else [],
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX, APPLETVOS),
@@ -2153,15 +1977,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "(arm64|aarch64)",
-                    prod_srcs_for_arch_wrapper("neoni8mm"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = [
+            (
+                "(arm64|aarch64)",
+                prod_srcs_for_arch_wrapper("neoni8mm"),
+            ),
+        ] if not is_arvr_mode() else [],
         platforms = (APPLE, ANDROID, CXX, WINDOWS),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -2176,11 +1997,8 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_asm_aarch32",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("aarch32"),
-            }),
-        }),
+            "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("aarch32"),
+        }) if is_arvr_mode() else [],
         headers = subdir_glob([
             ("XNNPACK/src", "xnnpack/assembly.h"),
             ("XNNPACK/src", "**/*.S"),
@@ -2208,15 +2026,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "(aarch32|arm32|armv7)",
-                    prod_srcs_for_arch_wrapper("aarch32"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = [
+            (
+                "(aarch32|arm32|armv7)",
+                prod_srcs_for_arch_wrapper("aarch32"),
+            ),
+        ] if not is_arvr_mode() else [],
         platforms = (APPLE, ANDROID, CXX, WINDOWS),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -2231,11 +2046,8 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_asm_aarch64",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//build_mode:arvr_mode": select({
-                "DEFAULT": [],
-                "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("aarch64"),
-            }),
-        }),
+            "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("aarch64"),
+        }) if is_arvr_mode() else [],
         headers = subdir_glob([
             ("XNNPACK/src", "xnnpack/assembly.h"),
             ("XNNPACK/src", "**/*.S"),
@@ -2259,15 +2071,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = select({
-            "DEFAULT": [
-                (
-                    "(aarch64|arm64)",
-                    prod_srcs_for_arch_wrapper("aarch64"),
-                ),
-            ],
-            "ovr_config//build_mode:arvr_mode": [],
-        }),
+        platform_srcs = [
+            (
+                "(aarch64|arm64)",
+                prod_srcs_for_arch_wrapper("aarch64"),
+            ),
+        ] if not is_arvr_mode() else [],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,


### PR DESCRIPTION
Summary:
This diff reverts D78520947
This diff broke some tests. Here is the task - T231858523

Depends on D78520947

Test Plan:
NA

Rollback Plan:

Differential Revision: D78712371


