### PR TITLE
[Optimus] Support decompose mm with dynamic shapes

### DIFF
--- a/torch/_inductor/fx_passes/decompose_mem_bound_mm.py
+++ b/torch/_inductor/fx_passes/decompose_mem_bound_mm.py
@@ -4,7 +4,10 @@ import logging
 import torch
 from torch import Tensor
 from torch._dynamo.utils import counters, is_node_meta_valid
-from torch.fx.experimental.symbolic_shapes import statically_known_true
+from torch.fx.experimental.symbolic_shapes import (
+    statically_known_false,
+    statically_known_true,
+)
 
 from .. import config
 from ..pattern_matcher import Arg, CallFunction, Match, register_graph_pattern
@@ -82,6 +85,35 @@ def should_decompose_bmm(mat1, mat2) -> bool:
 
 
 def should_decompose_mm(mat1, mat2) -> bool:
+    """
+    Determines whether matrix multiplication (mm) should be decomposed into pointwise operations
+    based on the input matrices' metadata, shapes, device placement, and configuration options.
+    Args:
+        mat1: The first matrix operand. Expected to be an object with a `.meta` attribute containing
+              a "val" key, or a tensor-like object with a `.shape` attribute.
+        mat2: The second matrix operand. Same requirements as `mat1`.
+    Returns:
+        bool: True if the matrix multiplication should be decomposed according to the following logic:
+            - Both inputs must have valid node metadata.
+            - Both matrices must be 2-dimensional.
+            - If the configuration option `skip_dynamic_shape_dim_check` is False:
+                - Decomposition is only considered for statically-shaped matrices.
+                - For CUDA devices: `mat1.shape[0]` must be at least `min_first_dimension_decomposition`,
+                  and both dimensions of `mat2` must be less than `max_other_dimension_decomposition`.
+                - For CPU devices: All relevant dimensions must be less than or equal to their respective
+                  CPU decomposition thresholds.
+            - If `skip_dynamic_shape_dim_check` is True:
+                - Decomposition is considered for dynamic shapes as well, using a combination of
+                  `statically_known_true` and `statically_known_false` checks to handle uncertainty.
+                - The same dimension and device checks apply, but allow for dynamic/static uncertainty.
+            - Returns False if any of the above conditions are not met.
+    Notes:
+        - Relies on helper functions such as `is_node_meta_valid`, `check_device`, `statically_known_true`,
+          and `statically_known_false`, as well as configuration values like
+          `min_first_dimension_decomposition`, `max_other_dimension_decomposition`, etc.
+        - Designed for use in graph optimization or fusion passes where decomposing large or dynamic
+          matrix multiplications can improve performance or memory usage.
+    """
     if is_node_meta_valid(mat1) and is_node_meta_valid(mat2):
         mat1 = mat1.meta["val"]
         mat2 = mat2.meta["val"]
@@ -89,23 +121,80 @@ def should_decompose_mm(mat1, mat2) -> bool:
         return False
     if len(mat1.shape) != 2 or len(mat2.shape) != 2:
         return False
-    return (
-        check_device(mat1, mat2, device="cuda")
-        and statically_known_true(mat1.shape[0] >= min_first_dimension_decomposition)
-        and statically_known_true(mat2.shape[0] < max_other_dimension_decomposition)
-        and statically_known_true(mat2.shape[1] < max_other_dimension_decomposition)
-    ) or (
-        check_device(mat1, mat2, device="cpu")
-        and statically_known_true(
-            mat1.shape[0] <= cpu_max_first_dimension_decomposition
+    # case 1: we skip decompose mm if the input is dynamic shape
+    if not config.post_grad_fusion_options["decompose_mm_pass"].get(
+        "skip_dynamic_shape_dim_check", False
+    ):
+        return (
+            check_device(mat1, mat2, device="cuda")
+            and statically_known_true(
+                mat1.shape[0] >= min_first_dimension_decomposition
+            )
+            and statically_known_true(mat2.shape[0] < max_other_dimension_decomposition)
+            and statically_known_true(mat2.shape[1] < max_other_dimension_decomposition)
+        ) or (
+            check_device(mat1, mat2, device="cpu")
+            and statically_known_true(
+                mat1.shape[0] <= cpu_max_first_dimension_decomposition
+            )
+            and statically_known_true(
+                mat2.shape[0] <= cpu_max_other_dimension_decomposition
+            )
+            and statically_known_true(
+                mat2.shape[1] <= cpu_max_other_dimension_decomposition
+            )
         )
-        and statically_known_true(
-            mat2.shape[0] <= cpu_max_other_dimension_decomposition
+    # case 2: we decompose mm if the input is dynamic shape
+    else:
+        return (
+            check_device(mat1, mat2, device="cuda")
+            and (
+                statically_known_true(
+                    mat1.shape[0] >= min_first_dimension_decomposition
+                )
+                or not statically_known_false(
+                    mat1.shape[0] >= min_first_dimension_decomposition
+                )
+            )
+            and (
+                statically_known_true(mat2.shape[0] < max_other_dimension_decomposition)
+                or not statically_known_false(
+                    mat2.shape[0] < max_other_dimension_decomposition
+                )
+            )
+            and (
+                statically_known_true(mat2.shape[1] < max_other_dimension_decomposition)
+                or not statically_known_false(
+                    mat2.shape[1] < max_other_dimension_decomposition
+                )
+            )
+        ) or (
+            check_device(mat1, mat2, device="cpu")
+            and (
+                statically_known_true(
+                    mat1.shape[0] <= cpu_max_first_dimension_decomposition
+                )
+                or not statically_known_false(
+                    mat1.shape[0] <= cpu_max_first_dimension_decomposition
+                )
+            )
+            and (
+                statically_known_true(
+                    mat2.shape[0] <= cpu_max_other_dimension_decomposition
+                )
+                or not statically_known_false(
+                    mat2.shape[0] <= cpu_max_other_dimension_decomposition
+                )
+            )
+            and (
+                statically_known_true(
+                    mat2.shape[1] <= cpu_max_other_dimension_decomposition
+                )
+                or not statically_known_false(
+                    mat2.shape[1] <= cpu_max_other_dimension_decomposition
+                )
+            )
         )
-        and statically_known_true(
-            mat2.shape[1] <= cpu_max_other_dimension_decomposition
-        )
-    )
 
 
 def print_decompose_pattern(match: Match, inputs: list[torch.fx.Node]):


### PR DESCRIPTION
Summary: The current implementation will not do the decompose for GEMM with dynamic shapes, thus we add one more option for users to enable this feature

Test Plan:
### how to enable

Step 1: Set decompose_mem_bound_mm = false
Step 2:
Add the decompose_mm_pass pattern to the post_grad_fusion_options
json config example:

"post_grad_fusion_options": {
            "decompose_mm_pass": {
              "min_first_dimension_decomposition": 10240, -> default value
              "max_other_dimention_decomposition": 32,  -> default value
             "skip_dynamic_shape_dim_check": true, -> default is false
            }
      },

yaml config example

```
 post_grad_fusion_options:
        decompose_mm_pass:
          skip_dynamic_shape_dim_check: true
```
Note that all these hyper-parameters can be set by the users, if nothing gives, a default value will be used


### unit test

```
buck2 test @mode/dev-nosan //caffe2/test/inductor:decompose_mem_bound_mm -- test_dynamic_shape_decompose_addmm
```

Buck UI: https://www.internalfb.com/buck2/a98eb4b3-da1d-4450-9e49-472ba98b2267
Test UI: https://www.internalfb.com/intern/testinfra/testrun/6473924745731095
Network: Up: 86KiB  Down: 1.3MiB  (reSessionID-96cf35cc-5189-4372-8f25-1fc6a52a3963)
Executing actions. Remaining     0/3                                                       1.4s exec time total
Command: test.     Finished 2 local
Time elapsed: 2:00.6s
Tests finished: Pass 3. Fail 0. Fatal 0. Skip 0. Build failure 0

### E2E

before: aps-DPA_new_v0_amd_20250716-e7927755df
after: aps-DPA_new_v0_amd_20250716_optimus-f2175fc9fb

tlparse:
https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/aps-DPA_new_v0_amd_20250716_optimus-f2175fc9fb/attempt_0/version_0/rank_0/index.html?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=10000

### qps and NE

{F1980635506}
 {F1980635505}
- 12.5% qps improvement with NE neutral

### trace analysis
baseline:https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree%2Ftraces%2Fdynocli%2Faps-DPA_new_v0_amd_20250716-e7927755df%2F0%2Frank-1.Jul_22_22_28_01.4592.pt.trace.json.gz&bucket=aps_traces

{F1980633952}
proposal:https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree%2Ftraces%2Fdynocli%2Faps-DPA_new_v0_amd_20250716_optimus-f2175fc9fb%2F0%2Frank-1.Jul_24_14_37_59.4576.pt.trace.json.gz&bucket=aps_traces

{F1980633966}

```
        unsqueeze_default: "bf16[32*s54, 8, 1][8, 1, 1]cuda:0" = torch.ops.aten.unsqueeze.default(constant_pad_nd_default_2, 2)
        unsqueeze_default_1: "bf16[1, 8, 8][64, 8, 1]cuda:0" = torch.ops.aten.unsqueeze.default(constant_pad_nd_default_3, 0);  constant_pad_nd_default_3 = None
        mul_tensor: "bf16[32*s54, 8, 8][64, 8, 1]cuda:0" = torch.ops.aten.mul.Tensor(unsqueeze_default, unsqueeze_default_1);  unsqueeze_default = unsqueeze_default_1 = None
```


### what have been decomposed
P1880443593

Rollback Plan:

Differential Revision: D78716034




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @mlazos