### PR TITLE
[DeviceMesh] Make the repr shorter when debug ENV not set

### DIFF
--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -643,10 +643,13 @@ else:
             _mesh_resources.mesh_stack.pop()
 
         def __repr__(self) -> str:
+            mesh_repr = f"DeviceMesh('{self.device_type}', shape: {self.mesh.shape}, stride: {self.mesh.stride()}"
+            if os.environ.get("TORCH_DISTRIBUTED_DEBUG", "") == "DETAIL":
+                mesh_repr += f", Mesh: {self.mesh.tolist()}"
             device_mesh_repr = (
-                f"DeviceMesh('{self.device_type}', {self.mesh.tolist()})"
+                f"{mesh_repr})"
                 if not self.mesh_dim_names
-                else f"DeviceMesh('{self.device_type}', {self.mesh.tolist()}, mesh_dim_names={self.mesh_dim_names})"
+                else f"{mesh_repr}, mesh_dim_names={self.mesh_dim_names})"
             )
             return device_mesh_repr
 

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -643,15 +643,16 @@ else:
             _mesh_resources.mesh_stack.pop()
 
         def __repr__(self) -> str:
-            mesh_repr = f"DeviceMesh('{self.device_type}', shape: {self.mesh.shape}, stride: {self.mesh.stride()}"
-            if os.environ.get("TORCH_DISTRIBUTED_DEBUG", "") == "DETAIL":
-                mesh_repr += f", Mesh: {self.mesh.tolist()}"
             device_mesh_repr = (
-                f"{mesh_repr})"
-                if not self.mesh_dim_names
-                else f"{mesh_repr}, mesh_dim_names={self.mesh_dim_names})"
+                f"({', '.join(f'{k}={v}' for k, v in zip(self.mesh_dim_names, self.mesh.shape))})"
+                if self.mesh_dim_names
+                else f"{tuple(self.mesh.shape)}"
             )
-            return device_mesh_repr
+            device_mesh_repr = f"DeviceMesh({device_mesh_repr}, device: '{self.device_type}', stride: {self.mesh.stride()}"
+            # We only print the mesh tensor if the debug mode is turned on.
+            if os.environ.get("TORCH_DISTRIBUTED_DEBUG", "") == "DETAIL":
+                device_mesh_repr += f", Mesh: {self.mesh.tolist()}"
+            return f"{device_mesh_repr})"
 
         def __hash__(self):
             # lazily compute hash


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #158822

Users want a shorter repr so this PR is trying to address that when TORCH_DISTRIBUTED_DEBUG is not set to DETAIL. Feedback and discussion is welcomed. Somehow I found that torch.set_printoptions is global, so I am hesitated to use it.

Now the print is like 

<img width="435" height="79" alt="image" src="https://github.com/user-attachments/assets/8f173287-7138-4fbe-a4a3-8483523b21e4" />

or 

<img width="485" height="104" alt="image" src="https://github.com/user-attachments/assets/21e34db9-56b5-47e2-9767-750d6105a273" />

or

<img width="675" height="97" alt="image" src="https://github.com/user-attachments/assets/53aa763e-7edd-4622-9cdb-37e2af8ec11f" />


cc @H-Huang @awgu @wanchaol @fegin @wz337 @wconstab @d4l3k @pragupta