### PR TITLE
Fix torch.tensor warning in ONNX symbolic_opset10 export 

### DIFF
--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -513,7 +513,9 @@ def _slice(
         if is_none_value(list_or_value) and default_value is not None:
             list_or_value = [default_value]
 
-        if isinstance(list_or_value, (list, torch.Tensor)):
+        if isinstance(list_or_value, torch.Tensor):
+            return g.op("Constant", value_t=list_or_value.clone().detach())
+        elif isinstance(list_or_value, list):
             return g.op("Constant", value_t=torch.tensor(list_or_value))
 
         rank = symbolic_helper._get_tensor_rank(list_or_value)


### PR DESCRIPTION
Fix PyTorch tensor copying warning in ONNX export

## Problem

PyTorch ONNX exporter was generating a warning about incorrect tensor copying method:

```
UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).
```

cc @justinchuby