### PR TITLE
[Distributed] Force Broadcast in state dict for unsharded case

### DIFF
--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -1058,6 +1058,13 @@ def get_model_state_dict(
             submodules=submodules,
             options=options,
         )
+        if (options is not None and 
+            options.broadcast_from_rank0 and
+            options.full_state_dict
+            ):
+            dist.broadcast_object_list([obj], src=0)
+            model_state_dict = obj["model"]
+            optim_state_dict = obj["optimizer"]
         model_state_dict = _get_model_state_dict(model, info)
         _verify_state_dict(model_state_dict, {}, info)
         return model_state_dict


### PR DESCRIPTION
Soltion to  #157781 
Context: set_state_dict for shard=False (unsharded) case does not call broadcast to share rank 0 contents beforehand causing a hang when manual broadcast is not called before load_model/optim_dict is called. 
This patch adds a broadcast call to ensure the contents of master rank are shared across all ranks to prevent such issues. 

 @atalman @H-Huang @awgu  could you help to take a look ? Thanks


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @LucasLLC @pradeepfn