### PR TITLE
Candidate fix for possible memo disaster upon recurring symint definition

### DIFF
--- a/torch/_export/pass_base.py
+++ b/torch/_export/pass_base.py
@@ -315,7 +315,11 @@ class _ExportPassBaseDeprecatedDoNotUse(PassBase):
         )
         res_proxy.node.meta.update(meta.data)
         if self.fake_tensor_mode and (shape_env := self.fake_tensor_mode.shape_env):
-            if symbol_to_path := compute_unbacked_bindings(shape_env, res_data):
+            # Peek at pending unbacked symbols without clearing, so shared symbols
+            # (e.g. from the same boolean mask) are bound on all nodes.
+            if symbol_to_path := compute_unbacked_bindings(
+                shape_env, res_data, peek=True
+            ):
                 res_proxy.node.meta["unbacked_bindings"] = symbol_to_path
         self.tracer.set_metadata(res_proxy.node, res_data)
         return ProxyValue(res_data, res_proxy)

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -639,10 +639,10 @@ def rebind_unbacked(
                 )
                 continue
 
-            # The old and new could be the same if you improperly hit the memo
-            # while retracing.  Make sure you updated FakeTensorMode.epoch
-            assert raw_u0 != raw_u1, f"{raw_u0} possible memo disaster"
-            # Reuse the OLD symbol name
+            # If fake-tensor memo reuse occurred, raw_u1 == raw_u0; no rebinding needed.
+            if raw_u0 == raw_u1:
+                continue
+            # Otherwise, reuse the OLD symbol name by renaming raw_u1 -> raw_u0
             shape_env._rename_unbacked_to(raw_u1, raw_u0)
 
 


### PR DESCRIPTION
Fixes #154647 

Note that this commit was suggested by an AI assistance tool. It resolves the original problem in the linked issue (and preserves the fact that the two symints generated are indeed the same). I ran a small set of regression tests locally, so now I'd like to run a more through integration here.

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv