### PR TITLE
Remove is_arvr_mode() from /xplat/caffe2/pt_template_srcs.bzl

### DIFF
--- a/pt_template_srcs.bzl
+++ b/pt_template_srcs.bzl
@@ -3,7 +3,6 @@
 # being built
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load("//tools/build_defs:fbsource_utils.bzl", "is_arvr_mode")
 load(":build_variables.bzl", "aten_native_source_list")
 load(
     ":ufunc_defs.bzl",
@@ -135,28 +134,82 @@ def get_generate_code_bin_outs():
         "autograd/generated/ViewFuncs.h": ["autograd/generated/ViewFuncs.h"],
     }
 
-    if is_arvr_mode():
-        outs.update({
-            "autograd/generated/python_enum_tag.cpp": ["autograd/generated/python_enum_tag.cpp"],
-            "autograd/generated/python_fft_functions.cpp": ["autograd/generated/python_fft_functions.cpp"],
-            "autograd/generated/python_functions.h": ["autograd/generated/python_functions.h"],
-            "autograd/generated/python_functions_0.cpp": ["autograd/generated/python_functions_0.cpp"],
-            "autograd/generated/python_functions_1.cpp": ["autograd/generated/python_functions_1.cpp"],
-            "autograd/generated/python_functions_2.cpp": ["autograd/generated/python_functions_2.cpp"],
-            "autograd/generated/python_functions_3.cpp": ["autograd/generated/python_functions_3.cpp"],
-            "autograd/generated/python_functions_4.cpp": ["autograd/generated/python_functions_4.cpp"],
-            "autograd/generated/python_linalg_functions.cpp": ["autograd/generated/python_linalg_functions.cpp"],
-            "autograd/generated/python_nested_functions.cpp": ["autograd/generated/python_nested_functions.cpp"],
-            "autograd/generated/python_nn_functions.cpp": ["autograd/generated/python_nn_functions.cpp"],
-            "autograd/generated/python_return_types.h": ["autograd/generated/python_return_types.h"],
-            "autograd/generated/python_return_types.cpp": ["autograd/generated/python_return_types.cpp"],
-            "autograd/generated/python_sparse_functions.cpp": ["autograd/generated/python_sparse_functions.cpp"],
-            "autograd/generated/python_special_functions.cpp": ["autograd/generated/python_special_functions.cpp"],
-            "autograd/generated/python_torch_functions_0.cpp": ["autograd/generated/python_torch_functions_0.cpp"],
-            "autograd/generated/python_torch_functions_1.cpp": ["autograd/generated/python_torch_functions_1.cpp"],
-            "autograd/generated/python_torch_functions_2.cpp": ["autograd/generated/python_torch_functions_2.cpp"],
-            "autograd/generated/python_variable_methods.cpp": ["autograd/generated/python_variable_methods.cpp"],
-        })
+    outs["autograd/generated/python_enum_tag.cpp"] = select({
+        "ovr_config//build_mode:arvr_mode": ["autograd/generated/python_enum_tag.cpp"],
+        "DEFAULT": [],
+    })
+    outs["autograd/generated/python_fft_functions.cpp"] = select({
+        "ovr_config//build_mode:arvr_mode": ["autograd/generated/python_fft_functions.cpp"],
+        "DEFAULT": [],
+    })
+    outs["autograd/generated/python_functions.h"] = select({
+        "ovr_config//build_mode:arvr_mode": ["autograd/generated/python_functions.h"],
+        "DEFAULT": [],
+    })
+    outs["autograd/generated/python_functions_0.cpp"] = select({
+        "ovr_config//build_mode:arvr_mode": ["autograd/generated/python_functions_0.cpp"],
+        "DEFAULT": [],
+    })
+    outs["autograd/generated/python_functions_1.cpp"] = select({
+        "ovr_config//build_mode:arvr_mode": ["autograd/generated/python_functions_1.cpp"],
+        "DEFAULT": [],
+    })
+    outs["autograd/generated/python_functions_2.cpp"] = select({
+        "ovr_config//build_mode:arvr_mode": ["autograd/generated/python_functions_2.cpp"],
+        "DEFAULT": [],
+    })
+    outs["autograd/generated/python_functions_3.cpp"] = select({
+        "ovr_config//build_mode:arvr_mode": ["autograd/generated/python_functions_3.cpp"],
+        "DEFAULT": [],
+    })
+    outs["autograd/generated/python_functions_4.cpp"] = select({
+        "ovr_config//build_mode:arvr_mode": ["autograd/generated/python_functions_4.cpp"],
+        "DEFAULT": [],
+    })
+    outs["autograd/generated/python_linalg_functions.cpp"] = select({
+        "ovr_config//build_mode:arvr_mode": ["autograd/generated/python_linalg_functions.cpp"],
+        "DEFAULT": [],
+    })
+    outs["autograd/generated/python_nested_functions.cpp"] = select({
+        "ovr_config//build_mode:arvr_mode": ["autograd/generated/python_nested_functions.cpp"],
+        "DEFAULT": [],
+    })
+    outs["autograd/generated/python_nn_functions.cpp"] = select({
+        "ovr_config//build_mode:arvr_mode": ["autograd/generated/python_nn_functions.cpp"],
+        "DEFAULT": [],
+    })
+    outs["autograd/generated/python_return_types.h"] = select({
+        "ovr_config//build_mode:arvr_mode": ["autograd/generated/python_return_types.h"],
+        "DEFAULT": [],
+    })
+    outs["autograd/generated/python_return_types.cpp"] = select({
+        "ovr_config//build_mode:arvr_mode": ["autograd/generated/python_return_types.cpp"],
+        "DEFAULT": [],
+    })
+    outs["autograd/generated/python_sparse_functions.cpp"] = select({
+        "ovr_config//build_mode:arvr_mode": ["autograd/generated/python_sparse_functions.cpp"],
+        "DEFAULT": [],
+    })
+    outs["autograd/generated/python_special_functions.cpp"] = select({
+        "ovr_config//build_mode:arvr_mode": ["autograd/generated/python_special_functions.cpp"],
+        "DEFAULT": [],
+    })
+    outs["autograd/generated/python_torch_functions_0.cpp"] = select({
+        "ovr_config//build_mode:arvr_mode": ["autograd/generated/python_torch_functions_0.cpp"],
+        "DEFAULT": [],
+    })
+    outs["autograd/generated/python_torch_functions_1.cpp"] = select({
+        "ovr_config//build_mode:arvr_mode": ["autograd/generated/python_torch_functions_1.cpp"],
+        "DEFAULT": [],
+    })
+    outs["autograd/generated/python_torch_functions_2.cpp"] = select({
+        "ovr_config//build_mode:arvr_mode": ["autograd/generated/python_torch_functions_2.cpp"],
+        "DEFAULT": [],
+    })
+    outs["autograd/generated/python_variable_methods.cpp"] = select({
+        "ovr_config//build_mode:arvr_mode": ["autograd/generated/python_variable_methods.cpp"],
+        "DEFAULT": [],
+    })
     return outs
 
 def get_template_registration_files_outs(is_oss = False):


### PR DESCRIPTION
Summary:
Replaced is_arvr_mode() with a select on "ovr_config//build_mode:arvr_mode"

Context: This is part of the effort to unify the arvr and xplat target graphs in the citadel orchestrator

Test Plan:
Tested to see if CI passes

Rollback Plan:

Differential Revision: D78749418


