### PR TITLE
[MPS] Speedup torch.full for 1-byte types

### DIFF
--- a/aten/src/ATen/native/mps/operations/ConstantOps.mm
+++ b/aten/src/ATen/native/mps/operations/ConstantOps.mm
@@ -62,15 +62,12 @@ static Tensor& fill_scalar_mps_impl(Tensor& self, const Scalar& value) {
   return self;
 }
 
-// returns false if tensor cannot be filled with fillBuffer()
-static bool fill_mps_tensor_(Tensor& self, uint8_t value) {
-  if (self.is_contiguous()) {
-    MPSStream* stream = getCurrentMPSStream();
-    auto storage_byte_offset = self.storage_offset() * self.itemsize();
-    stream->fill(mps::getMTLBufferStorage(self), value, self.nbytes(), storage_byte_offset);
-    return true;
-  }
-  return false;
+static Tensor& fill_mps_tensor_(Tensor& self, uint8_t value) {
+  TORCH_INTERNAL_ASSERT(self.is_contiguous());
+  const auto stream = getCurrentMPSStream();
+  auto storage_byte_offset = self.storage_offset() * self.itemsize();
+  stream->fill(mps::getMTLBufferStorage(self), value, self.nbytes(), storage_byte_offset);
+  return self;
 }
 
 Tensor& fill_scalar_mps(Tensor& self, const Scalar& value) {
@@ -89,13 +86,19 @@ Tensor& fill_scalar_mps(Tensor& self, const Scalar& value) {
     return self;
   }
   // check if it's possible to use fillBuffer() to fill the Tensor's storage
-  if (value.toDouble() == 0.0 && fill_mps_tensor_(self, 0) == true) {
-    return self;
-    // Special handling for bool, as one can full bool tesnros with infs
-  } else if (self.scalar_type() == kBool && fill_mps_tensor_(self, value.toBool())) {
-    return self;
-  } else if (c10::elementSize(self.scalar_type()) == 1 && fill_mps_tensor_(self, value.toByte())) {
-    return self;
+  if (self.is_contiguous()) {
+    if (value.toDouble() == 0.0) {
+      return fill_mps_tensor_(self, 0);
+    }
+    if (self.scalar_type() == kBool) {
+      return fill_mps_tensor_(self, value.toBool());
+    }
+    if (self.scalar_type() == kByte) {
+      return fill_mps_tensor_(self, value.toByte());
+    }
+    if (self.scalar_type() == kChar) {
+      return fill_mps_tensor_(self, value.toChar());
+    }
   }
 
   return fill_scalar_mps_impl(self, value);
@@ -107,8 +110,6 @@ Tensor& fill_tensor_mps_(Tensor& self, const Tensor& value) {
               value.dim(),
               " dimensions.");
   Scalar scalar_value = value.item();
-  if (scalar_value.toDouble() == 0.0 && fill_mps_tensor_(self, 0) == true)
-    return self;
   return fill_scalar_mps(self, scalar_value);
 }
 

--- a/aten/src/ATen/native/mps/operations/ConstantOps.mm
+++ b/aten/src/ATen/native/mps/operations/ConstantOps.mm
@@ -91,8 +91,10 @@ Tensor& fill_scalar_mps(Tensor& self, const Scalar& value) {
   // check if it's possible to use fillBuffer() to fill the Tensor's storage
   if (value.toDouble() == 0.0 && fill_mps_tensor_(self, 0) == true) {
     return self;
-  }
-  if (c10::elementSize(self.scalar_type()) == 1 && fill_mps_tensor_(self, value.toByte())) {
+    // Special handling for bool, as one can full bool tesnros with infs
+  } else if (self.scalar_type() == kBool && fill_mps_tensor_(self, value.toBool())) {
+    return self;
+  } else if (c10::elementSize(self.scalar_type()) == 1 && fill_mps_tensor_(self, value.toByte())) {
     return self;
   }
 

--- a/aten/src/ATen/native/mps/operations/ConstantOps.mm
+++ b/aten/src/ATen/native/mps/operations/ConstantOps.mm
@@ -89,8 +89,12 @@ Tensor& fill_scalar_mps(Tensor& self, const Scalar& value) {
     return self;
   }
   // check if it's possible to use fillBuffer() to fill the Tensor's storage
-  if (value.toDouble() == 0.0 && fill_mps_tensor_(self, 0) == true)
+  if (value.toDouble() == 0.0 && fill_mps_tensor_(self, 0) == true) {
     return self;
+  }
+  if (c10::elementSize(self.scalar_type()) && fill_mps_tensor_(self, value.toByte())) {
+    return self;
+  }
 
   return fill_scalar_mps_impl(self, value);
 }

--- a/aten/src/ATen/native/mps/operations/ConstantOps.mm
+++ b/aten/src/ATen/native/mps/operations/ConstantOps.mm
@@ -92,7 +92,7 @@ Tensor& fill_scalar_mps(Tensor& self, const Scalar& value) {
   if (value.toDouble() == 0.0 && fill_mps_tensor_(self, 0) == true) {
     return self;
   }
-  if (c10::elementSize(self.scalar_type()) && fill_mps_tensor_(self, value.toByte())) {
+  if (c10::elementSize(self.scalar_type()) == 1 && fill_mps_tensor_(self, value.toByte())) {
     return self;
   }
 

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -998,8 +998,8 @@ class TestIndexing(TestCase):
     )
     @serialTest(TEST_CUDA)
     def test_index_put_accumulate_large_tensor(self, device):
-        if device.startswith("mps"):
-            raise unittest.SkipTest("Crash with max number of dimentions")
+        # if device.startswith("mps"):
+        #     raise unittest.SkipTest("Crash with max number of dimentions")
         # This test is for tensors with number of elements >= INT_MAX (2^31 - 1).
         N = (1 << 31) + 5
         dt = torch.int8

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -998,8 +998,6 @@ class TestIndexing(TestCase):
     )
     @serialTest(TEST_CUDA)
     def test_index_put_accumulate_large_tensor(self, device):
-        # if device.startswith("mps"):
-        #     raise unittest.SkipTest("Crash with max number of dimentions")
         # This test is for tensors with number of elements >= INT_MAX (2^31 - 1).
         N = (1 << 31) + 5
         dt = torch.int8


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #158888
* __->__ #158874

By using [`fillBuffer:range:value:`](https://developer.apple.com/documentation/metal/mtlblitcommandencoder/fillbuffer:range:value:?language=objc) rather than MPSGraph op, which should be faster and also does not have INT_MAX limit

Which in turn fixes `test_index_put_accumulate_large_tensor_mps` test