### PR TITLE
[AOTI] update node name definition for creating get_attr nodes as output node args

### DIFF
--- a/torch/fx/passes/split_utils.py
+++ b/torch/fx/passes/split_utils.py
@@ -245,7 +245,7 @@ def split_by_tags(
             # We don't need components mapping for nodes of type "get_attr"
             # that are consumed by the output. Only need to make sure we create
             # corresponding counterparts in the resulting graph.
-            main_remapping[x] = main_g.get_attr(x.name, type_expr=x.type)
+            main_remapping[x] = main_g.get_attr(x.target, type_expr=x.type)
         else:
             # All component results consumed by the output node should be
             # marked as "used in main".


### PR DESCRIPTION
Summary:
In the original graph, when the forward function is defined as:
def forward(...):
    ...
    _tensor_constant8 = self._tensor_constant8
    _tensor_constant8_1 = self._tensor_constant8
    _tensor_constant8_2 = self._tensor_constant8
    return {
        'multi_class_labels': (..., _tensor_constant8),
        'prediction': (..., _tensor_constant8_1),
        'user_embedding': (..., _tensor_constant8_2)
    }

main_g graph in split_by_tags function will be changed to

def forward(...):
    _tensor_constant8 = self._tensor_constant8
    _tensor_constant8_1 = self._tensor_constant8_1
    _tensor_constant8_2 = self._tensor_constant8_2
    ...

It appears that _tensor_constant8_1 = self._tensor_constant8 was replaced by _tensor_constant8_1 = self._tensor_constant8_1, which causes an exception due to the creation of new weights during lowering. We simply replace the x.name with x.target and the new graph will be created successfully

Test Plan:
TORCH_TRACE=/tmp/yunlai TORCH_LOGS="post_grad_graphs,+inductor,+output_code" buck2 run     @//mode/opt-split-dwarf     -c python.package_style=inplace     -c fbcode.enable_gpu_sections=true     -c fbcode.nvcc_arch=a100,h100     -c fbcode.platform=platform010     //inference_enablement/model_processing/infra/components/lowering/re:re --     -r '{"aot_inductor":{"serialized_inference_model_input_path":"ads_storage_fblearner/tree/user/facebook/fblearner/predictor/894908813/0/gpu_lowering/input.merge.47c49061","serialized_inference_model_output_path":"ads_storage_fblearner/tree/user/facebook/fblearner/predictor/894908813/0/gpu_lowering/output.merge.local_run","submodule_names_to_lower":["merge"],"inductor_lowering_context":{"aot_inductor_lowering_settings":{"use_custom_tracer": true, "max_batch_size":2048,"min_acc_module_size":15,"workdir":"/tmp/local","name":"merge","dll_name":"inductor_engine.so","use_scripting":true,"preset_lowerer":"ifu_cint;disable_new_lowering_weights;disable_dper_passes:passes=fuse_parallel_linear_no_weight_change|fuse_parallel_linear","precision":3,"output_precision":3,"remote_cache_file_path_folder":"","save_remote_cache":false,"aot_inductor_config":"{'\''max_autotune'\'': True, '\''scalar_asserts'\'': False}","disable_dynamic_shapes":false,"remove_unexpected_type_cast":false,"disable_constraint_solver":false,"sample_input_tile_factor":1,"disable_acc_tracer":true,"generate_sample_inputs":false,"tile_sample_input_by_dynamic_shape":false,"node_replacement_dict":"","auto_dynamic_shapes":false,"dynamic_shapes_strategy":73728, "auto_dynamic_shapes_min_size":1,"auto_dynamic_shapes_max_size":1048576,"max_acc_splits":-1,"dynamic_size":-1,"pre_dispatch_export":true,"merge_split_optimization":false,"use_dynamic_dim_hints":false,"allow_refine_dynamic_shapes_on_constants":false}},"model_entity_id":894908813,"model_snapshot_id":0,"add_sample_inputs":false,"hardware_type":0,"platform_arch":2,"dense_in_place_format":2}}' 2>&1 | tee lowering.txt


lowering log: https://www.internalfb.com/intern/everpaste/?handle=GH8_Lx-Yr5F7YSwGADZ-T21Fx1cKbsIXAAAz&phabricator_paste_number=1877917175

Rollback Plan:

Reviewed By: 842974287

Differential Revision: D78770825




cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv