### PR TITLE
Fix torch.classes to use proper module construction via importlib

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2263,8 +2263,8 @@ from torch._ops import ops as ops  # usort: skip
 from torch._classes import classes as classes  # usort: skip
 
 import importlib.util
+import sys
 import types
-
 # Construct a proper module for torch.classes
 _classes_spec = importlib.util.spec_from_loader(f"{__name__}.classes", loader=None)
 torch_classes_module = importlib.util.module_from_spec(_classes_spec)
@@ -2277,7 +2277,7 @@ for attr in dir(classes):
         except Exception:
             pass # In case some dynamic attributes raise
 
-# # Register the module properly in sys.modules
+# Register the module properly in sys.modules
 sys.modules[f"{__name__}.classes"] = torch_classes_module
 
 sys.modules.setdefault(f"{__name__}.ops", ops)


### PR DESCRIPTION
Fixes #ISSUE_NUMBER #158871

### Summary
This patch replaces the manual `sys.modules` assignment for `torch.classes` with a properly constructed module using `importlib.util.module_from_spec`. This ensures that the module meets Python's expectations for introspection, addressing compatibility issues (e.g., Netflix/metaflow#2512).

### Motivation
Modules constructed via `ModuleType()` miss several default attributes (e.g., `__path__`), which can break tools that rely on introspection. Using `module_from_spec()` ensures `torch.classes` behaves like a standard Python module.

### Impact
- Internal quality-of-life fix
- No user-facing changes

### Testing
Tested locally:
```python
import torch
import types

assert isinstance(torch.classes, types.ModuleType)
assert hasattr(torch.classes, "__path__")