### PR TITLE
[c10d] fix torch.compile issue with all_to_all_single_autograd

### DIFF
--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -797,6 +797,7 @@ def _resolve_group_name(group: RANK_TYPES, tag: str = "") -> str:
         raise ValueError(f"Unsupported group type: {type(group)}, {group}")
 
 
+@torch.compiler.allow_in_graph
 class _FromTorchTensor(torch.autograd.Function):
     """
     _FromTorchTensor allows autograd to propagate from a normal Tensor to an


### PR DESCRIPTION
The following warnings emerged without the `torch.compiler.allow_in_graph` decorator to `_FromTorchTensor`.

```
[rank0]:/usr/local/lib/python3.12/dist-packages/torch/autograd/graph.py:829: UserWarning: _c10d_functional::wait_tensor: an autograd kernel was not registered to the Autograd key(s) but we are trying to bac
kprop through it. This may lead to silently incorrect behavior. This behavior is deprecated and will be removed in a future version of PyTorch. If your operator is differentiable, please ensure you have reg
istered an autograd kernel to the correct Autograd key (e.g. DispatchKey::Autograd, DispatchKey::CompositeImplicitAutograd). If your operator is not differentiable, or to squash this warning and use the pre
vious behavior, please register torch::CppFunction::makeFallthrough() to DispatchKey::Autograd. (Triggered internally at /pytorch/torch/csrc/autograd/autograd_not_implemented_fallback.cpp:62.)
[rank0]:  return Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
```

The training loss is also a little bit higher without this decorator.

* torch.compile w/ allow_in_graph
```
[rank0]:2025-07-23 07:50:17,850 - INFO - step:  1  loss: 12.2657  memory:  6.27GiB(3.27%)  tps: 266  tflops: 0.51  mfu: 0.04%
[rank0]:[titan] 2025-07-23 07:50:17,850 - root - INFO - step:  1  loss: 12.2657  memory:  6.27GiB(3.27%)  tps: 266  tflops: 0.51  mfu: 0.04%
[rank0]:2025-07-23 07:50:17,850 - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:[titan] 2025-07-23 07:50:17,850 - root - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:2025-07-23 07:50:17,901 - INFO - step:  2  loss: 12.0711  memory:  8.23GiB(4.29%)  tps: 80,184  tflops: 154.76  mfu: 11.90%
[rank0]:[titan] 2025-07-23 07:50:17,901 - root - INFO - step:  2  loss: 12.0711  memory:  8.23GiB(4.29%)  tps: 80,184  tflops: 154.76  mfu: 11.90%
[rank0]:2025-07-23 07:50:17,953 - INFO - step:  3  loss:  9.7752  memory:  8.23GiB(4.29%)  tps: 80,536  tflops: 155.44  mfu: 11.96%
[rank0]:[titan] 2025-07-23 07:50:17,953 - root - INFO - step:  3  loss:  9.7752  memory:  8.23GiB(4.29%)  tps: 80,536  tflops: 155.44  mfu: 11.96%
[rank0]:2025-07-23 07:50:18,001 - INFO - step:  4  loss:  9.5899  memory:  8.23GiB(4.29%)  tps: 85,464  tflops: 164.95  mfu: 12.69%
[rank0]:[titan] 2025-07-23 07:50:18,001 - root - INFO - step:  4  loss:  9.5899  memory:  8.23GiB(4.29%)  tps: 85,464  tflops: 164.95  mfu: 12.69%
[rank0]:2025-07-23 07:50:18,051 - INFO - step:  5  loss: 10.0028  memory:  8.23GiB(4.29%)  tps: 82,887  tflops: 159.98  mfu: 12.31%
[rank0]:[titan] 2025-07-23 07:50:18,051 - root - INFO - step:  5  loss: 10.0028  memory:  8.23GiB(4.29%)  tps: 82,887  tflops: 159.98  mfu: 12.31%
[rank0]:2025-07-23 07:50:18,101 - INFO - step:  6  loss:  9.0393  memory:  8.23GiB(4.29%)  tps: 81,623  tflops: 157.54  mfu: 12.12%
[rank0]:[titan] 2025-07-23 07:50:18,101 - root - INFO - step:  6  loss:  9.0393  memory:  8.23GiB(4.29%)  tps: 81,623  tflops: 157.54  mfu: 12.12%
[rank0]:2025-07-23 07:50:18,152 - INFO - step:  7  loss:  8.9024  memory:  8.23GiB(4.29%)  tps: 81,732  tflops: 157.75  mfu: 12.13%
[rank0]:[titan] 2025-07-23 07:50:18,152 - root - INFO - step:  7  loss:  8.9024  memory:  8.23GiB(4.29%)  tps: 81,732  tflops: 157.75  mfu: 12.13%
[rank0]:2025-07-23 07:50:18,199 - INFO - step:  8  loss:  8.6312  memory:  8.23GiB(4.29%)  tps: 88,232  tflops: 170.29  mfu: 13.10%
[rank0]:[titan] 2025-07-23 07:50:18,199 - root - INFO - step:  8  loss:  8.6312  memory:  8.23GiB(4.29%)  tps: 88,232  tflops: 170.29  mfu: 13.10%
[rank0]:2025-07-23 07:50:18,247 - INFO - step:  9  loss:  8.3782  memory:  8.23GiB(4.29%)  tps: 85,637  tflops: 165.28  mfu: 12.71%
[rank0]:[titan] 2025-07-23 07:50:18,247 - root - INFO - step:  9  loss:  8.3782  memory:  8.23GiB(4.29%)  tps: 85,637  tflops: 165.28  mfu: 12.71%
[rank0]:2025-07-23 07:50:18,298 - INFO - step: 10  loss:  8.3246  memory:  8.23GiB(4.29%)  tps: 80,791  tflops: 155.93  mfu: 11.99%
[rank0]:[titan] 2025-07-23 07:50:18,298 - root - INFO - step: 10  loss:  8.3246  memory:  8.23GiB(4.29%)  tps: 80,791  tflops: 155.93  mfu: 11.99%
```

* torch.compile w/o allow_in_graph
```
[rank0]:2025-07-23 08:11:46,329 - INFO - step:  1  loss: 12.2657  memory:  6.42GiB(3.35%)  tps: 269  tflops: 0.52  mfu: 0.04%
[rank0]:[titan] 2025-07-23 08:11:46,329 - root - INFO - step:  1  loss: 12.2657  memory:  6.42GiB(3.35%)  tps: 269  tflops: 0.52  mfu: 0.04%
[rank0]:2025-07-23 08:11:46,329 - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:[titan] 2025-07-23 08:11:46,329 - root - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:2025-07-23 08:11:46,379 - INFO - step:  2  loss: 11.9649  memory:  8.38GiB(4.37%)  tps: 81,467  tflops: 157.24  mfu: 12.10%
[rank0]:[titan] 2025-07-23 08:11:46,379 - root - INFO - step:  2  loss: 11.9649  memory:  8.38GiB(4.37%)  tps: 81,467  tflops: 157.24  mfu: 12.10%
[rank0]:2025-07-23 08:11:46,429 - INFO - step:  3  loss: 12.4308  memory:  8.38GiB(4.37%)  tps: 83,762  tflops: 161.67  mfu: 12.44%
[rank0]:[titan] 2025-07-23 08:11:46,429 - root - INFO - step:  3  loss: 12.4308  memory:  8.38GiB(4.37%)  tps: 83,762  tflops: 161.67  mfu: 12.44%
[rank0]:2025-07-23 08:11:46,475 - INFO - step:  4  loss: 10.0933  memory:  8.38GiB(4.37%)  tps: 90,209  tflops: 174.11  mfu: 13.39%
[rank0]:[titan] 2025-07-23 08:11:46,475 - root - INFO - step:  4  loss: 10.0933  memory:  8.38GiB(4.37%)  tps: 90,209  tflops: 174.11  mfu: 13.39%
[rank0]:2025-07-23 08:11:46,522 - INFO - step:  5  loss: 10.8865  memory:  8.38GiB(4.37%)  tps: 87,016  tflops: 167.95  mfu: 12.92%
[rank0]:[titan] 2025-07-23 08:11:46,522 - root - INFO - step:  5  loss: 10.8865  memory:  8.38GiB(4.37%)  tps: 87,016  tflops: 167.95  mfu: 12.92%
[rank0]:2025-07-23 08:11:46,570 - INFO - step:  6  loss: 10.0978  memory:  8.38GiB(4.37%)  tps: 86,433  tflops: 166.82  mfu: 12.83%
[rank0]:[titan] 2025-07-23 08:11:46,570 - root - INFO - step:  6  loss: 10.0978  memory:  8.38GiB(4.37%)  tps: 86,433  tflops: 166.82  mfu: 12.83%
[rank0]:2025-07-23 08:11:46,620 - INFO - step:  7  loss: 10.5796  memory:  8.38GiB(4.37%)  tps: 82,259  tflops: 158.77  mfu: 12.21%
[rank0]:[titan] 2025-07-23 08:11:46,620 - root - INFO - step:  7  loss: 10.5796  memory:  8.38GiB(4.37%)  tps: 82,259  tflops: 158.77  mfu: 12.21%
[rank0]:2025-07-23 08:11:46,668 - INFO - step:  8  loss: 10.2391  memory:  8.38GiB(4.37%)  tps: 85,785  tflops: 165.57  mfu: 12.74%
[rank0]:[titan] 2025-07-23 08:11:46,668 - root - INFO - step:  8  loss: 10.2391  memory:  8.38GiB(4.37%)  tps: 85,785  tflops: 165.57  mfu: 12.74%
[rank0]:2025-07-23 08:11:46,718 - INFO - step:  9  loss:  9.7691  memory:  8.38GiB(4.37%)  tps: 83,120  tflops: 160.43  mfu: 12.34%
[rank0]:[titan] 2025-07-23 08:11:46,718 - root - INFO - step:  9  loss:  9.7691  memory:  8.38GiB(4.37%)  tps: 83,120  tflops: 160.43  mfu: 12.34%
[rank0]:2025-07-23 08:11:46,769 - INFO - step: 10  loss:  9.5386  memory:  8.38GiB(4.37%)  tps: 80,909  tflops: 156.16  mfu: 12.01%
[rank0]:[titan] 2025-07-23 08:11:46,769 - root - INFO - step: 10  loss:  9.5386  memory:  8.38GiB(4.37%)  tps: 80,909  tflops: 156.16  mfu: 12.01%
```

* w/o torch.compile
```
[rank0]:2025-07-23 08:13:20,702 - INFO - step:  1  loss: 12.2652  memory: 10.30GiB(5.37%)  tps: 551  tflops: 1.06  mfu: 0.08%
[rank0]:[titan] 2025-07-23 08:13:20,702 - root - INFO - step:  1  loss: 12.2652  memory: 10.30GiB(5.37%)  tps: 551  tflops: 1.06  mfu: 0.08%
[rank0]:2025-07-23 08:13:20,702 - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:[titan] 2025-07-23 08:13:20,702 - root - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:2025-07-23 08:13:20,766 - INFO - step:  2  loss: 12.0628  memory: 12.26GiB(6.39%)  tps: 64,286  tflops: 124.08  mfu: 9.54%
[rank0]:[titan] 2025-07-23 08:13:20,766 - root - INFO - step:  2  loss: 12.0628  memory: 12.26GiB(6.39%)  tps: 64,286  tflops: 124.08  mfu: 9.54%
[rank0]:2025-07-23 08:13:20,828 - INFO - step:  3  loss:  9.5921  memory: 12.26GiB(6.39%)  tps: 66,332  tflops: 128.03  mfu: 9.85%
[rank0]:[titan] 2025-07-23 08:13:20,828 - root - INFO - step:  3  loss:  9.5921  memory: 12.26GiB(6.39%)  tps: 66,332  tflops: 128.03  mfu: 9.85%
[rank0]:2025-07-23 08:13:20,888 - INFO - step:  4  loss:  9.4609  memory: 12.26GiB(6.39%)  tps: 68,750  tflops: 132.69  mfu: 10.21%
[rank0]:[titan] 2025-07-23 08:13:20,888 - root - INFO - step:  4  loss:  9.4609  memory: 12.26GiB(6.39%)  tps: 68,750  tflops: 132.69  mfu: 10.21%
[rank0]:2025-07-23 08:13:20,950 - INFO - step:  5  loss:  9.9488  memory: 12.26GiB(6.39%)  tps: 66,421  tflops: 128.20  mfu: 9.86%
[rank0]:[titan] 2025-07-23 08:13:20,950 - root - INFO - step:  5  loss:  9.9488  memory: 12.26GiB(6.39%)  tps: 66,421  tflops: 128.20  mfu: 9.86%
[rank0]:2025-07-23 08:13:21,013 - INFO - step:  6  loss:  9.1012  memory: 12.26GiB(6.39%)  tps: 65,233  tflops: 125.90  mfu: 9.68%
[rank0]:[titan] 2025-07-23 08:13:21,013 - root - INFO - step:  6  loss:  9.1012  memory: 12.26GiB(6.39%)  tps: 65,233  tflops: 125.90  mfu: 9.68%
[rank0]:2025-07-23 08:13:21,077 - INFO - step:  7  loss:  9.0418  memory: 12.26GiB(6.39%)  tps: 65,388  tflops: 126.20  mfu: 9.71%
[rank0]:[titan] 2025-07-23 08:13:21,077 - root - INFO - step:  7  loss:  9.0418  memory: 12.26GiB(6.39%)  tps: 65,388  tflops: 126.20  mfu: 9.71%
[rank0]:2025-07-23 08:13:21,135 - INFO - step:  8  loss:  8.7260  memory: 12.26GiB(6.39%)  tps: 70,151  tflops: 135.40  mfu: 10.42%
[rank0]:[titan] 2025-07-23 08:13:21,135 - root - INFO - step:  8  loss:  8.7260  memory: 12.26GiB(6.39%)  tps: 70,151  tflops: 135.40  mfu: 10.42%
[rank0]:2025-07-23 08:13:21,198 - INFO - step:  9  loss:  8.4993  memory: 12.26GiB(6.39%)  tps: 66,263  tflops: 127.89  mfu: 9.84%
[rank0]:[titan] 2025-07-23 08:13:21,198 - root - INFO - step:  9  loss:  8.4993  memory: 12.26GiB(6.39%)  tps: 66,263  tflops: 127.89  mfu: 9.84%
[rank0]:2025-07-23 08:13:21,259 - INFO - step: 10  loss:  8.3969  memory: 12.26GiB(6.39%)  tps: 67,673  tflops: 130.61  mfu: 10.05%
[rank0]:[titan] 2025-07-23 08:13:21,259 - root - INFO - step: 10  loss:  8.3969  memory: 12.26GiB(6.39%)  tps: 67,673  tflops: 130.61  mfu: 10.05%
```

@d4l3k


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci