### PR TITLE
[Release Only] Remove nvshmem from list of preload libraries

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -355,7 +355,6 @@ def _load_global_deps() -> None:
             "cusparselt": "libcusparseLt.so.*[0-9]",
             "cusolver": "libcusolver.so.*[0-9]",
             "nccl": "libnccl.so.*[0-9]",
-            "nvshmem": "libnvshmem_host.so.*[0-9]",
         }
         # cufiile is only available on cuda 12+
         # TODO: Remove once CUDA 11.8 binaries are deprecated


### PR DESCRIPTION
Nvshmem integration was reverted in release/2.8, this revert fixes Amazon Linux 2023 issue
Visible Here: https://github.com/pytorch/test-infra/actions/runs/16472470897/job/46565012967#step:15:9590

Success Test (with this fix included):
```
>>> import torch
/usr/local/lib64/python3.9/site-packages/torch/_subclasses/functional_tensor.py:279: UserWarning: Failed to initialize NumPy: No module named 'numpy' (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:81.)
  cpu = _conversion_method_template(device=torch.device("cpu"))
>>> torch.cuda.is_available()
True
>>> torch.cuda.init()
```

Failing Test:
```
import torch
Traceback (most recent call last):
  File "/usr/local/lib64/python3.9/site-packages/torch/__init__.py", line 320, in _load_global_deps
    ctypes.CDLL(global_deps_lib_path, mode=ctypes.RTLD_GLOBAL)
  File "/usr/lib64/python3.9/ctypes/__init__.py", line 374, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: libcudart.so.12: cannot open shared object file: No such file or directory

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib64/python3.9/site-packages/torch/__init__.py", line 416, in <module>
    _load_global_deps()
  File "/usr/local/lib64/python3.9/site-packages/torch/__init__.py", line 374, in _load_global_deps
    _preload_cuda_deps(lib_folder, lib_name)
  File "/usr/local/lib64/python3.9/site-packages/torch/__init__.py", line 304, in _preload_cuda_deps
    raise ValueError(f"{lib_name} not found in the system path {sys.path}")
ValueError: libnvshmem_host.so.*[0-9] not found in the system path ['', '/usr/lib64/python39.zip', '/usr/lib64/python3.9', '/usr/lib64/python3.9/lib-dynload', '/usr/local/lib64/python3.9/site-packages', '/usr/local/lib/python3.9/site-packages', '/usr/lib64/python3.9/site-packages', '/usr/lib/python3.9/site-packages']

```