### PR TITLE
[NativeRT] Remove device_ member from OpKernel base class

### DIFF
--- a/test/cpp/nativert/test_c10_kernel.cpp
+++ b/test/cpp/nativert/test_c10_kernel.cpp
@@ -27,8 +27,6 @@ return (%x)
   std::advance(it, 1);
   const Node& node = *it;
 
-  c10::Device device = torch::Device(torch::kCPU, 0);
-
   auto a = at::randn({6, 6, 6});
   auto b = at::randn({6, 6, 6});
 
@@ -36,7 +34,7 @@ return (%x)
   frame.setIValue(graph->getValue("a")->id(), a);
   frame.setIValue(graph->getValue("b")->id(), b);
 
-  auto kernel = C10Kernel(&node, device);
+  auto kernel = C10Kernel(&node);
 
   kernel.computeInternal(frame);
 

--- a/torch/nativert/executor/OpKernel.h
+++ b/torch/nativert/executor/OpKernel.h
@@ -98,9 +98,8 @@ class OpKernel {
  public:
   explicit OpKernel(
       const Node* node,
-      std::optional<c10::Device> device = std::nullopt,
       OpKernelKind kind = OpKernelKind::kInterpreterFallbackKernel)
-      : node_(node), device_(device), kind_(kind) {
+      : node_(node), kind_(kind) {
     VLOG(1) << "Initializing kernel for node: " << *node_;
   }
 
@@ -150,7 +149,6 @@ class OpKernel {
   virtual void computeInternal(ExecutionFrame& executionFrame) const = 0;
 
   const Node* node_;
-  std::optional<c10::Device> device_;
   const static bool blockingEnabled_;
   // this should be set in the ctor!
   const OpKernelKind kind_;

--- a/torch/nativert/kernels/C10Kernel.cpp
+++ b/torch/nativert/kernels/C10Kernel.cpp
@@ -13,10 +13,9 @@ namespace torch::nativert {
 
 C10Kernel::C10Kernel(
     const Node* node,
-    c10::Device device,
     OpKernelKind kind,
     AliasingSpec&& aliasingSpec)
-    : OpKernel(node, device, kind),
+    : OpKernel(node, kind),
       op_(getOperatorForTarget(node->target(), node)),
       schema_(op_.schema(), std::move(aliasingSpec), kind_),
       arguments_(prefillStackWithStaticArgs(node, op_.schema())) {}

--- a/torch/nativert/kernels/C10Kernel.h
+++ b/torch/nativert/kernels/C10Kernel.h
@@ -24,10 +24,9 @@ class C10Kernel : public OpKernel {
   C10Kernel() = delete; // deleted default constructor
   C10Kernel(
       const Node* node,
-      c10::Device device,
       OpKernelKind kind = OpKernelKind::kInterpreterFallbackKernel,
       AliasingSpec&& aliasingSpec = {});
-  virtual ~C10Kernel() override = default;
+  ~C10Kernel() override = default;
 
   [[nodiscard]] const c10::IValue& input(
       uint32_t i,
@@ -58,19 +57,19 @@ class C10Kernel : public OpKernel {
 class SymIntOpKernel : public OpKernel {
  public:
   explicit SymIntOpKernel(const Node* node) : OpKernel(node) {}
-  void computeInternal(ExecutionFrame& executionFrame) const override final;
+  void computeInternal(ExecutionFrame& executionFrame) const final;
 };
 
 class SymBoolOpKernel : public OpKernel {
  public:
   explicit SymBoolOpKernel(const Node* node) : OpKernel(node) {}
-  void computeInternal(ExecutionFrame& executionFrame) const override final;
+  void computeInternal(ExecutionFrame& executionFrame) const final;
 };
 
 class SymFloatOpKernel : public OpKernel {
  public:
   explicit SymFloatOpKernel(const Node* node) : OpKernel(node) {}
-  void computeInternal(ExecutionFrame& executionFrame) const override final;
+  void computeInternal(ExecutionFrame& executionFrame) const final;
 };
 
 // ScalarOpKernel does binary arithmetic operations on scalar values.
@@ -79,7 +78,7 @@ class SymFloatOpKernel : public OpKernel {
 class ScalarBinaryOpKernel : public OpKernel {
  public:
   explicit ScalarBinaryOpKernel(const Node* node) : OpKernel(node) {}
-  void computeInternal(ExecutionFrame& executionFrame) const override final;
+  void computeInternal(ExecutionFrame& executionFrame) const final;
 };
 
 } // namespace torch::nativert

--- a/torch/nativert/kernels/KernelFactory.cpp
+++ b/torch/nativert/kernels/KernelFactory.cpp
@@ -242,7 +242,7 @@ ExecutionKernels KernelFactory::initializeNodeKernels(
       nodeKernels.push_back(std::make_unique<HigherOrderKernel>(
           &node, std::move(graphExecutors)));
     } else if (c10::starts_with(node.target(), "torch.ops")) {
-      nodeKernels.push_back(std::make_unique<C10Kernel>(&node, targetDevice));
+      nodeKernels.push_back(std::make_unique<C10Kernel>(&node));
 
       std::string opName = std::string(node.target());
       if (opsWithoutStaticDispatchCount.find(opName) ==

--- a/torch/nativert/kernels/KernelRegistry.cpp
+++ b/torch/nativert/kernels/KernelRegistry.cpp
@@ -244,8 +244,7 @@ namespace torch::nativert {
 C10_DEFINE_REGISTRY(
     StaticallyDispatchedCPUKernelRegistry,
     OpKernel,
-    const Node*,
-    c10::Device)
+    const Node*)
 
 namespace {
 
@@ -1240,10 +1239,9 @@ REGISTER_CPU_KERNEL("torch.ops.aten.stack.default", aten_stack, {
 
 class OpKernel_aten__to_copy : public C10Kernel {
  public:
-  explicit OpKernel_aten__to_copy(const Node* node, c10::Device device)
+  explicit OpKernel_aten__to_copy(const Node* node)
       : C10Kernel(
             node,
-            device,
             torch::nativert::OpKernelKind::kStaticDispatchKernel,
             torch::nativert::AliasingSpec{
                 {/* input_idx = */ 0, /* output_idx = */ 0}}) {

--- a/torch/nativert/kernels/KernelRegistry.h
+++ b/torch/nativert/kernels/KernelRegistry.h
@@ -9,16 +9,14 @@ namespace torch::nativert {
 TORCH_DECLARE_REGISTRY(
     StaticallyDispatchedCPUKernelRegistry,
     OpKernel,
-    const Node*,
-    c10::Device);
+    const Node*);
 
 #define REGISTER_CPU_KERNEL(name, id, ...)                                \
   class OpKernel_##id : public C10Kernel {                                \
    public:                                                                \
-    OpKernel_##id(const Node* node, c10::Device device)                   \
+    OpKernel_##id(const Node* node)                                       \
         : C10Kernel(                                                      \
               node,                                                       \
-              device,                                                     \
               torch::nativert::OpKernelKind::kStaticDispatchKernel) {}    \
     void computeInternal(torch::nativert::ExecutionFrame& executionFrame) \
         const override final {                                            \
@@ -33,10 +31,9 @@ TORCH_DECLARE_REGISTRY(
 #define REGISTER_ALIASING_CPU_KERNEL(name, id, aliasing_spec, ...)        \
   class OpKernel_##id : public C10Kernel {                                \
    public:                                                                \
-    OpKernel_##id(const Node* node, c10::Device device)                   \
+    OpKernel_##id(const Node* node)                                       \
         : C10Kernel(                                                      \
               node,                                                       \
-              device,                                                     \
               torch::nativert::OpKernelKind::kNativeStaticDispatchKernel, \
               aliasing_spec) {}                                           \
     void computeInternal(torch::nativert::ExecutionFrame& executionFrame) \
@@ -50,10 +47,9 @@ TORCH_DECLARE_REGISTRY(
 #define REGISTER_NATIVE_CPU_KERNEL(name, id, ...)                            \
   class OpKernel_##id : public C10Kernel {                                   \
    public:                                                                   \
-    OpKernel_##id(const Node* node, c10::Device device)                      \
+    OpKernel_##id(const Node* node)                                          \
         : C10Kernel(                                                         \
               node,                                                          \
-              device,                                                        \
               torch::nativert::OpKernelKind::kNativeStaticDispatchKernel) {} \
     void computeInternal(torch::nativert::ExecutionFrame& executionFrame)    \
         const override final {                                               \

--- a/torch/nativert/kernels/PrimKernelRegistry.cpp
+++ b/torch/nativert/kernels/PrimKernelRegistry.cpp
@@ -17,7 +17,7 @@ namespace {
 class OpKernel_prim_listpack : public OpKernel {
  public:
   explicit OpKernel_prim_listpack(const Node* node)
-      : OpKernel(node, std::nullopt, OpKernelKind::kPrimKernel) {
+      : OpKernel(node, OpKernelKind::kPrimKernel) {
     auto listType = node->outputs()[0]->type();
     switch (listType.kind()) {
       case Type::Kind::TensorList:
@@ -76,7 +76,7 @@ namespace {
 class OpKernel_variadic_concat : public OpKernel {
  public:
   explicit OpKernel_variadic_concat(const Node* node)
-      : OpKernel(node, std::nullopt, OpKernelKind::kPrimKernel) {
+      : OpKernel(node, OpKernelKind::kPrimKernel) {
     dim_ = node_->attributes().size() > 0
         ? constantToIValue(node_->getAttribute("dim").value).toInt()
         : 0;
@@ -121,7 +121,7 @@ namespace {
 class OpKernel_variadic_stack : public OpKernel {
  public:
   explicit OpKernel_variadic_stack(const Node* node)
-      : OpKernel(node, std::nullopt, OpKernelKind::kPrimKernel) {
+      : OpKernel(node, OpKernelKind::kPrimKernel) {
     dim_ = node_->attributes().size() > 0
         ? constantToIValue(node_->getAttribute("dim").value).toInt()
         : 0;

--- a/torch/nativert/kernels/PrimKernelRegistry.h
+++ b/torch/nativert/kernels/PrimKernelRegistry.h
@@ -11,16 +11,16 @@ namespace torch::nativert {
 
 TORCH_DECLARE_REGISTRY(PrimKernelRegistry, OpKernel, const Node*);
 
-#define REGISTER_PRIM_KERNEL(name, id, ...)                          \
-  class OpKernel_##id : public OpKernel {                            \
-   public:                                                           \
-    OpKernel_##id(const Node* node)                                  \
-        : OpKernel(node, std::nullopt, OpKernelKind::kPrimKernel) {} \
-    void computeInternal(                                            \
-        ExecutionFrame& executionFrame) const override final {       \
-      __VA_ARGS__;                                                   \
-    }                                                                \
-  };                                                                 \
+#define REGISTER_PRIM_KERNEL(name, id, ...)                    \
+  class OpKernel_##id : public OpKernel {                      \
+   public:                                                     \
+    OpKernel_##id(const Node* node)                            \
+        : OpKernel(node, OpKernelKind::kPrimKernel) {}         \
+    void computeInternal(                                      \
+        ExecutionFrame& executionFrame) const override final { \
+      __VA_ARGS__;                                             \
+    }                                                          \
+  };                                                           \
   C10_REGISTER_TYPED_CLASS(PrimKernelRegistry, name, OpKernel_##id)
 
 inline bool checkResizedDataPtr(at::Tensor& t) {


### PR DESCRIPTION
Summary:
In general, device_ is not very useful in OpKernel.  Remove it to avoid misuse. 

Also, the meaning of `device_` is also ambiguous in the OpKernel. 
For StaticDispatch kernels, we always call cpu kernel. 
For C10Kernel, we rely on input tensor's device and dispatcher to determine which device to run on.
For ops involves multiple device, e.g. aten._to_copy(device), the meaning of device is ill-defined.

Test Plan:
CI

Rollback Plan:

Reviewed By: henryoier, dolpm, kqfu, zhxchen17

Differential Revision: D78704840


