### PR TITLE
replace cuda-memcheck with compute-sanitizer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -975,7 +975,7 @@ If you are working on the CUDA code, here are some useful CUDA debugging tips:
 1. `CUDA_DEVICE_DEBUG=1` will enable CUDA device function debug symbols (`-g -G`).
     This will be particularly helpful in debugging device code. However, it will
     slow down the build process for about 50% (compared to only `DEBUG=1`), so use wisely.
-2. `cuda-gdb` and `cuda-memcheck` are your best CUDA debugging friends. Unlike`gdb`,
+2. `cuda-gdb` and `compute-sanitizer` are your best CUDA debugging friends. Unlike`gdb`,
    `cuda-gdb` can display actual values in a CUDA tensor (rather than all zeros).
 3. CUDA supports a lot of C++11/14 features such as, `std::numeric_limits`, `std::nextafter`,
    `std::tuple` etc. in device code. Many of such features are possible because of the

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -3415,7 +3415,7 @@ class DeviceCachingAllocator {
 
 // Returns whether to force all allocations to bypass the caching allocator and
 // go straight to cudaMalloc.  This setting is useful when debugging GPU memory
-// errors, since the caching allocator foils cuda-memcheck.
+// errors, since the caching allocator foils compute-sanitizer.
 static bool forceUncachedAllocator() {
   // Allow either CUDA or HIP name for env var for maximum user comfort
   // the CUDA env var avoids being hipified in cuda_to_hip_mappings.py

--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -492,7 +492,7 @@ Optimizing memory usage  with ``PYTORCH_CUDA_ALLOC_CONF``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Use of a caching allocator can interfere with memory checking tools such as
-``cuda-memcheck``.  To debug memory errors using ``cuda-memcheck``, set
+``compute-sanitizer``.  To debug memory errors using ``compute-sanitizer``, set
 ``PYTORCH_NO_CUDA_MEMORY_CACHING=1`` in your environment to disable caching.
 
 The behavior of the caching allocator can be controlled via the environment variable


### PR DESCRIPTION
`cuda-memcheck` is deprecated and replaced by `compute-sanitizer`, which was introduced in CUDA 11.0. 
This PR updates the docs first. We should revisit the `test/scripts/run_cuda_memcheck.py` next making sure these are still valid. 

CC @atalman 