### PR TITLE
[conv][cuDNN][64-bit indexing] reduce memory usage of depthwise conv 64-bit indexing test

### DIFF
--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -4055,13 +4055,13 @@ class TestConvolutionNNDeviceType(NNTestCase):
     @skipCUDAIfRocm
     @onlyCUDA
     @largeTensorTest("20GB")
-    @largeTensorTest("80GB", "cpu")
+    @largeTensorTest("64GB", "cpu")
     def test_depthwise_conv_64bit_indexing(self, device):
-        x = torch.randn(1, 2, 32800, 32800)
-        c = nn.Conv2d(2, 2, kernel_size=3, stride=1, padding=1, groups=2)
+        x = torch.randn(1, 2, 32800, 32800, dtype=torch.half)
+        c = nn.Conv2d(2, 2, kernel_size=3, stride=1, padding=1, groups=2, dtype=torch.half)
         yref = c(x)
         y = c.to(device=device)(x.to(device=device))
-        self.assertEqual(yref, y)
+        self.assertEqual(yref, y, atol=5e-3, rtol=1e-4)
 
 
 instantiate_device_type_tests(TestConvolutionNNDeviceType, globals(), allow_mps=True)

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -4058,7 +4058,9 @@ class TestConvolutionNNDeviceType(NNTestCase):
     @largeTensorTest("64GB", "cpu")
     def test_depthwise_conv_64bit_indexing(self, device):
         x = torch.randn(1, 2, 32800, 32800, dtype=torch.half)
-        c = nn.Conv2d(2, 2, kernel_size=3, stride=1, padding=1, groups=2, dtype=torch.half)
+        c = nn.Conv2d(
+            2, 2, kernel_size=3, stride=1, padding=1, groups=2, dtype=torch.half
+        )
         yref = c(x)
         y = c.to(device=device)(x.to(device=device))
         self.assertEqual(yref, y, atol=5e-3, rtol=1e-4)


### PR DESCRIPTION
Use half instead for reduced memory usage

cc @csarofeen @ptrblck @xwang233 @msaroufim @jerryzh168