### PR TITLE
[doc] add weifengpy to torch distributed pocs

### DIFF
--- a/docs/source/community/persons_of_interest.rst
+++ b/docs/source/community/persons_of_interest.rst
@@ -132,6 +132,7 @@ Distributed
 -  Chien-Chin Huang (`fegin <https://github.com/fegin>`__)
 -  Tristan Rice (`d4l3k <https://github.com/d4l3k>`__)
 -  Junjie Wang (`fduwjj <https://github.com/fduwjj>`__)
+-  Wei Feng (`weifengpy <https://github.com/weifengpy>`__)
 -  (emeritus) Shen Li (`mrshenli <https://github.com/mrshenli>`__)
 -  (emeritus) Pritam Damania (`pritamdamania87 <https://github.com/pritamdamania87>`__)
 -  (emeritus) Yanli Zhao (`zhaojuanmao <https://github.com/zhaojuanmao>`__)


### PR DESCRIPTION
<img width="415" height="355" alt="Screenshot 2025-07-23 at 16 02 12" src="https://github.com/user-attachments/assets/35b6bb45-d5ed-4d74-8369-e8e66aaa2618" />


Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #158991
* __->__ #158989

