### PR TITLE
[CUDA] Fix missing `__syncthreads` in MultiMarginLoss backward

### DIFF
--- a/aten/src/ATen/native/cuda/MultiMarginLoss.cu
+++ b/aten/src/ATen/native/cuda/MultiMarginLoss.cu
@@ -121,6 +121,7 @@ __global__ void MultiMarginLoss_backward_kernel(
     gradInput_k[target_k] = static_cast<scalar_t>(gradInput_target_k);
   }
 
+  __syncthreads();
   for (int i=i_start; i<i_end; i+= i_step) {
     gradInput_k[i] *= * gradOutput_k;
   }

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9292,6 +9292,26 @@ class TestNNDeviceType(NNTestCase):
                 mod(x, y)
 
     @onlyCUDA
+    @dtypes(torch.float, torch.double)
+    def test_MarginLoss_race(self, device, dtype):
+        loss = torch.nn.MultiMarginLoss().to(device)
+        batch = 1
+        classes = 128
+        x = torch.randn(batch, classes, requires_grad=True, device=device, dtype=dtype)
+        x.requires_grad = True
+        y = torch.randint(low=0, high=classes, size=(batch,), device=device, dtype=torch.long)
+        x_cpu = x.detach().clone().cpu()
+        y_cpu = y.detach().clone().cpu()
+        out = loss(x, y)
+        out.backward()
+        x_cpu = x.detach().clone().cpu()
+        x_cpu.requires_grad = True
+        y_cpu = y.detach().clone().cpu()
+        out_cpu = loss.cpu()(x_cpu, y_cpu)
+        out_cpu.backward()
+        self.assertEqual(x_cpu.grad, x.grad.cpu())
+
+    @onlyCUDA
     def test_MarginLoss_warnings(self, device):
         model = torch.nn.Linear(128, 22, device=device)
         loss = torch.nn.MultiMarginLoss()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9298,7 +9298,6 @@ class TestNNDeviceType(NNTestCase):
         batch = 1
         classes = 128
         x = torch.randn(batch, classes, requires_grad=True, device=device, dtype=dtype)
-        x.requires_grad = True
         y = torch.randint(low=0, high=classes, size=(batch,), device=device, dtype=torch.long)
         x_cpu = x.detach().clone().cpu()
         y_cpu = y.detach().clone().cpu()


### PR DESCRIPTION
Turns out issue in #158921 is detectable with a simple unit test and adding the missing sync fixes it

cc @ptrblck @msaroufim @jerryzh168