### PR TITLE
[DeviceMesh][ez] Make the logic within flatten simpler

### DIFF
--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -171,17 +171,12 @@ else:
             root_mesh = _mesh_resources.get_root_mesh(device_mesh)
 
             flatten_dims_in_root = [
-                not_none(root_mesh.mesh_dim_names).index(flattened_mesh_dim_name)
-                for flattened_mesh_dim_name in not_none(device_mesh.mesh_dim_names)
+                not_none(root_mesh.mesh_dim_names).index(mesh_dim_name)
+                for mesh_dim_name in not_none(device_mesh.mesh_dim_names)
             ]
 
             if not mesh_dim_name:
-                mesh_dim_name = "_".join(
-                    [
-                        not_none(root_mesh.mesh_dim_names)[dim]
-                        for dim in flatten_dims_in_root
-                    ]
-                )
+                mesh_dim_name = "_".join(not_none(device_mesh.mesh_dim_names))
 
             # Check whether the mesh_dim_name for flattened mesh is valid.
             self.flatten_name_to_root_dims.setdefault(root_mesh, {})

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -171,8 +171,8 @@ else:
             root_mesh = _mesh_resources.get_root_mesh(device_mesh)
 
             flatten_dims_in_root = [
-                not_none(root_mesh.mesh_dim_names).index(mesh_dim_name)
-                for mesh_dim_name in not_none(device_mesh.mesh_dim_names)
+                not_none(root_mesh.mesh_dim_names).index(flatten_mesh_dim_name)
+                for flatten_mesh_dim_name in not_none(device_mesh.mesh_dim_names)
             ]
 
             if not mesh_dim_name:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #158999

While looking at the code of device mesh I find that this logic can be simplified. Also the naming needs to be correct. Because this mesh is not "flattened" yet, so we can just call it flatten.



cc @H-Huang @awgu @wanchaol @fegin @wz337 @wconstab @d4l3k @pragupta