### PR TITLE
[dynamo] Added back weblink generation

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_compile.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_compile.py
@@ -548,7 +548,8 @@ Unsupported Tensor.backward() call
   Hint: This graph break is fundamental - it is unlikely that Dynamo will ever be able to trace through your code. Consider finding a workaround.
 
   Developer debug context: call_method TensorVariable() backward () {}
-""",  # noqa: B950
+
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0123.html""",  # noqa: B950
                     )
                 else:
                     self.assertGreater(len(counters["graph_break"]), 1)

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -62,6 +62,7 @@ Dynamic shape operator
 
   Developer debug context: aten.nonzero.default
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0036.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -83,6 +84,7 @@ Dynamic shape operator (no meta kernel)
 
   Developer debug context: aten.linalg_lstsq.default
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0037.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -105,6 +107,7 @@ Unsupported Tensor.item() call with capture_scalar_outputs=False
 
   Developer debug context: call_method TensorVariable() item () {}
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0124.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -128,6 +131,7 @@ Data dependent operator
 
   Developer debug context: aten.equal.default
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0033.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -155,6 +159,7 @@ sort with non-constant keys
 
   Developer debug context: TensorVariable()
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0207.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -180,6 +185,7 @@ Unsupported method call
 
   Developer debug context: call_method UserDefinedObjectVariable(zip) __iter__ () {}
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0156.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -208,6 +214,7 @@ Unsupported method call
 
   Developer debug context: call_method UserDefinedObjectVariable(dict_items) __iter__ () {}
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0156.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -231,6 +238,7 @@ Unsupported function call
 
   Developer debug context: call_function UserDefinedObjectVariable(zip) [] {}
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0147.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -254,6 +262,7 @@ Unsupported context manager
 
   Developer debug context: Attempted SETUP_WITH/BEFORE_WITH on ConstantVariable(int: 3)
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0142.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -281,7 +290,10 @@ Backend compiler exception
     Exception:test
     Traceback:
       File "test_error_messages.py", line N, in fn
-        return x + 1""",
+        return x + 1
+
+
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0219.html""",
         )
 
     def test_unsupported_builtin(self):
@@ -300,6 +312,7 @@ Failed to trace builtin operator
 
   Developer debug context: builtin print [<class 'torch._dynamo.variables.constant.ConstantVariable'>] False
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0059.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -325,6 +338,7 @@ Attempted to call function marked as skipped
 
   Developer debug context: module: unittest.case, qualname: skip, skip reason: <missing reason>
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0007.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -346,6 +360,7 @@ Attempted to call function marked as skipped
 
   Developer debug context: module: torch._dynamo.decorators, qualname: disable, skip reason: <missing reason>
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0007.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -374,6 +389,7 @@ Attempted to inline function marked as skipped
 
   Developer debug context: qualname: skip, name: skip, filename: `case.py`, skip reason: skipped according trace_rules.lookup unittest
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0008.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -395,6 +411,7 @@ Call to `torch._dynamo.graph_break()`
 
   Developer debug context: Called `torch._dynamo.graph_break()` with args `[]`, kwargs `{}`
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0025.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -415,6 +432,7 @@ Call to `torch._dynamo.graph_break()`
 
   Developer debug context: Called `torch._dynamo.graph_break()` with args `[]`, kwargs `{'msg': ConstantVariable(str: 'test graph break')}`
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0025.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -436,6 +454,7 @@ Attempted to call function marked as skipped
 
   Developer debug context: module: _warnings, qualname: warn, skip reason: <missing reason>
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0007.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -463,7 +482,8 @@ Attempted to call function marked as skipped
   Hint: Consider using torch.utils._pytree - https://github.com/pytorch/pytorch/blob/main/torch/utils/_pytree.py
 
   Developer debug context: module: optree._C, qualname: PyCapsule.flatten, skip reason: <missing reason>
-""",
+
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0007.html""",
         )
 
     @scoped_load_inline
@@ -509,7 +529,8 @@ Attempted to call function marked as skipped
   Hint: If it is a third-party C/C++ Python extension, please either wrap it into a PyTorch-understood custom operator (see https://pytorch.org/tutorials/advanced/custom_ops_landing_page.html for more details) or, if it is traceable, use `torch.compiler.allow_in_graph`.
 
   Developer debug context: module: mylib, qualname: PyCapsule.foobar, skip reason: <missing reason>
-""",
+
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0007.html""",
         )
 
         cpp_source = """
@@ -561,6 +582,7 @@ Dynamic slicing with Tensor arguments
 
   Developer debug context: SliceVariable start: ConstantVariable(NoneType: None), stop: TensorVariable(), step: ConstantVariable(NoneType: None)
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0038.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -582,6 +604,7 @@ Observed exception
 
   Developer debug context: raised exception ExceptionVariable(<class 'RuntimeError'>)
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0088.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -607,6 +630,7 @@ Uninitialized nn.Module
 
   Developer debug context: Foo
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0119.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -635,6 +659,7 @@ Unsupported nn.Module attribute type
 
   Developer debug context: nn.Module subclass: Foo, name: attr, attribute type: module
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0161.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -664,6 +689,7 @@ Graph break under GenericContextWrappingVariable
 
   Developer debug context: Active generic context managers: [GenericContextWrappingVariable(GenericCtxMgr), GenericContextWrappingVariable(GenericCtxMgr)]
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0066.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -678,7 +704,8 @@ Call to `torch._dynamo.graph_break()`
   Hint: Remove the `torch._dynamo.graph_break()` call.
 
   Developer debug context: Called `torch._dynamo.graph_break()` with args `[]`, kwargs `{}`
-""",
+
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0025.html""",
         )
 
     def test_load_build_class(self):
@@ -699,6 +726,7 @@ LOAD_BUILD_CLASS bytecode not supported
 
   Developer debug context:
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0075.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -731,6 +759,7 @@ Missing bytecode handler
   Hint: It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues.
 
   Developer debug context: GET_AITER with args (<torch._dynamo.symbolic_convert.InstructionTranslator object at 0xmem_addr>, Instruction(GET_AITER)
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0082.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -761,6 +790,7 @@ Reconstruction failure
 
   Developer debug context: UserMethodVariable(<function GraphBreakMessagesTest.test_reconstruction_failure.<locals>.Foo.meth at 0xmem_addr>, UserDefinedObjectVariable(Foo))
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0092.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -796,6 +826,7 @@ Graph Break Reason: Call to `torch._dynamo.graph_break()`
 
   Developer debug context: Called `torch._dynamo.graph_break()` with args `[]`, kwargs `{}`
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0025.html
 User code traceback:
   File "test_error_messages.py", line N, in test_reconstruction_failure_gb
     torch.compile(fn, backend="eager")()
@@ -815,6 +846,7 @@ Reconstruction failure
 
   Developer debug context: UserMethodVariable(<function GraphBreakMessagesTest.test_reconstruction_failure_gb.<locals>.Foo.meth at 0xmem_addr>, UserDefinedObjectVariable(Foo))
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0092.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -843,6 +875,7 @@ NotImplementedError/UnsupportedFakeTensorException when running FX node
 
   Developer debug context:
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0087.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -866,6 +899,7 @@ Data-dependent branching
 
   Developer debug context: attempted to jump with TensorVariable()
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0170.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -932,6 +966,7 @@ Data-dependent assertion failed (cannot compile partial graph)
 
   Developer debug context: value: ConstantVariable(bool: False)
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0034.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -975,6 +1010,7 @@ torch._dynamo.exc.Unsupported: Call to `torch._dynamo.graph_break()`
 
   Developer debug context: Called `torch._dynamo.graph_break()` with args `[]`, kwargs `{}`
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0025.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -1027,6 +1063,7 @@ torch._dynamo.exc.Unsupported: Call to `torch._dynamo.graph_break()`
 
   Developer debug context: Called `torch._dynamo.graph_break()` with args `[]`, kwargs `{}`
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0025.html
 
 from user code:
    File "test_error_messages.py", line N, in fn
@@ -1062,6 +1099,7 @@ Graph Break Reason: Call to `torch._dynamo.graph_break()`
 
   Developer debug context: Called `torch._dynamo.graph_break()` with args `[]`, kwargs `{}`
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0025.html
 User code traceback:
   File "test_error_messages.py", line N, in test_nested_compile_user_frames
     torch.compile(fn, backend="eager")(torch.randn(3))
@@ -1175,6 +1213,7 @@ Graph Break Reason: Call to `torch._dynamo.graph_break()`
 
   Developer debug context: Called `torch._dynamo.graph_break()` with args `[]`, kwargs `{}`
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0025.html
 User code traceback:
   File "test_error_messages.py", line N, in test_graph_break_traceback_collapsed_resume_frames
     f1(torch.randn(3))
@@ -1264,6 +1303,7 @@ Skip calling `torch.compiler.disable()`d function
 
   Developer debug context: <function GraphBreakMessagesTest.test_disable_message.<locals>.f at 0xmem_addr>
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0098.html
 
 from user code:
    File "test_error_messages.py", line N, in outer
@@ -1285,6 +1325,7 @@ Skip calling `torch.compiler.disable()`d function
 
   Developer debug context: <function GraphBreakMessagesTest.test_disable_message.<locals>.g at 0xmem_addr>
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0098.html
 
 from user code:
    File "test_error_messages.py", line N, in outer
@@ -1310,6 +1351,7 @@ Unsupported function call (delayed)
 
   Developer debug context: source: LocalSource(local_name='fn', is_input=True, dynamism=None, is_derefed_cell_contents=False)
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0148.html
 
 from user code:
    File "test_error_messages.py", line N, in outer

--- a/test/dynamo/test_exc.py
+++ b/test/dynamo/test_exc.py
@@ -43,6 +43,7 @@ Call to `torch._dynamo.graph_break()`
 
   Developer debug context: Called `torch._dynamo.graph_break()` with args `[]`, kwargs `{}`
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0025.html
 
 from user code:
    File "test_exc.py", line N, in fn001
@@ -182,6 +183,7 @@ Graph Break Reason: Call to `torch._dynamo.graph_break()`
 
   Developer debug context: Called `torch._dynamo.graph_break()` with args `[]`, kwargs `{}`
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0025.html
 User code traceback:
   File "test_exc.py", line N, in test_graph_break_log
     torch.compile(fn001, backend="eager")(torch.randn(1))

--- a/test/dynamo/test_reorder_logs.py
+++ b/test/dynamo/test_reorder_logs.py
@@ -210,7 +210,8 @@ Unsupported Tensor.item() call with capture_scalar_outputs=False
   Hint: Set `torch._dynamo.config.capture_scalar_outputs = True` or `export TORCHDYNAMO_CAPTURE_SCALAR_OUTPUTS=1` to include these operations in the captured graph.
 
   Developer debug context: call_method TensorVariable() item () {}
-""",  # noqa: B950
+
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0124.html""",  # noqa: B950
         )
 
 

--- a/test/dynamo/test_sets.py
+++ b/test/dynamo/test_sets.py
@@ -174,6 +174,7 @@ Attempted to wrap a set with tensors
 
   Developer debug context: Python set containing torch.Tensor elements
 
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0222.html
 
 from user code:
    File "test_sets.py", line N, in fn

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -1768,7 +1768,8 @@ Dynamic shape operator
   Hint: Enable tracing of dynamic shape operators with `torch._dynamo.config.capture_dynamic_output_shape_ops = True`
 
   Developer debug context: _torch_testing.numpy_nonzero.default
-""",
+
+ For more details about this graph break, please visit: https://pytorch-labs.github.io/compile-graph-break-site/gb/gb0036.html""",
         )
 
     # pre-existing problem: torch.compile(dynamic=True) will, by default,

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -532,7 +532,7 @@ def get_gbid_documentation_link(gb_type: str) -> Optional[str]:
 
     for k, v in registry.items():
         if v and v[0].get("Gb_type") == gb_type:
-            return f"{GRAPH_BREAK_SITE_URL}gb{k}.html"
+            return f"{GRAPH_BREAK_SITE_URL}gb{k.lstrip('GB')}.html"
 
     return None
 

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -26,12 +26,15 @@ Error Formatting:
     - Debugging utilities for error reporting
 """
 
+import json
 import logging
 import os
 import re
 import textwrap
 import typing
 from enum import auto, Enum
+from functools import lru_cache
+from pathlib import Path
 from traceback import extract_stack, format_exc, format_list, StackSummary
 from typing import Any, NoReturn, Optional, TYPE_CHECKING
 
@@ -498,6 +501,42 @@ def format_graph_break_message(
     return msg
 
 
+@lru_cache(maxsize=1)
+def _load_graph_break_registry() -> dict[str, Any]:
+    """
+    Loads the graph break registry from JSON file with caching.
+    """
+    try:
+        script_dir = Path(__file__).resolve().parent
+        registry_path = script_dir / "graph_break_registry.json"
+        with registry_path.open() as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        log.error("Error accessing the registry file: %s", e)
+        return {}
+
+
+def get_gbid_documentation_link(gb_type: str) -> Optional[str]:
+    """
+    Retrieves the GBID documentation link for a given graph break type.
+
+    Args:
+        gb_type: The graph break type to look up.
+
+    Returns:
+        A string containing the documentation URL if found, otherwise None.
+    """
+    GRAPH_BREAK_SITE_URL = "https://pytorch-labs.github.io/compile-graph-break-site/gb/"
+
+    registry = _load_graph_break_registry()
+
+    for k, v in registry.items():
+        if v and v[0].get("Gb_type") == gb_type:
+            return f"{GRAPH_BREAK_SITE_URL}gb{k}.html"
+
+    return None
+
+
 # TODO replace old unimplemented later
 def unimplemented_v2(
     gb_type: str,
@@ -520,10 +559,10 @@ def unimplemented_v2(
 
     msg = format_graph_break_message(gb_type, context, explanation, hints)
 
-    # Temporarily disabling the generation of the weblinks in error message
+    documentation_link = get_gbid_documentation_link(gb_type)
 
-    # documentation_link = get_gbid_documentation_link(gb_type)
-    # msg += f"\n For more details about this graph break, please visit: {documentation_link}"
+    if documentation_link:
+        msg += f"\n For more details about this graph break, please visit: {documentation_link}"
 
     if log_warning:
         log.warning(msg)

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -526,7 +526,9 @@ def get_gbid_documentation_link(gb_type: str) -> Optional[str]:
     Returns:
         A string containing the documentation URL if found, otherwise None.
     """
-    GRAPH_BREAK_SITE_URL = "https://pytorch-labs.github.io/compile-graph-break-site/gb/"
+    GRAPH_BREAK_SITE_URL = (
+        "https://pytorch-labs.github.io/compile-graph-break-site/gb/"  # @lint-ignore
+    )
 
     registry = _load_graph_break_registry()
 


### PR DESCRIPTION
Added back weblink generation for v2.9 development

Note: It is fine to bring the weblink generation back since v2.9 isn't released for a while

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #159011



cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela