### PR TITLE
[NativeRT] Cleanup Weights API

### DIFF
--- a/test/cpp/nativert/test_weights.cpp
+++ b/test/cpp/nativert/test_weights.cpp
@@ -27,8 +27,7 @@ TEST_F(WeightsTest, ConstructEmptyStateDict) {
   std::unordered_map<std::string, c10::IValue> stateDict;
   Weights weights(graph.get(), stateDict, *placement);
   // Check that weights are initialized correctly
-  EXPECT_TRUE(weights.parameters().empty());
-  EXPECT_TRUE(weights.buffers().empty());
+  EXPECT_TRUE(weights.allValues().empty());
   EXPECT_FALSE(weights.contains("non_existent_weight"));
 }
 TEST_F(WeightsTest, SetAndGetValue) {

--- a/torch/nativert/executor/Weights.cpp
+++ b/torch/nativert/executor/Weights.cpp
@@ -231,23 +231,7 @@ Weights::Weights(
   }
 }
 
-std::unordered_map<std::string, at::Tensor> Weights::parameters() const {
-  std::unordered_map<std::string, at::Tensor> result;
-  for (const auto& name : graph_->signature().parameters()) {
-    result.emplace(name, allValues_.at(std::string(name)));
-  }
-  return result;
-}
-
-std::unordered_map<std::string, at::Tensor> Weights::buffers() const {
-  std::unordered_map<std::string, at::Tensor> result;
-  for (const auto& name : graph_->signature().buffers()) {
-    result.emplace(name, allValues_.at(std::string(name)));
-  }
-  return result;
-}
-
-std::unordered_map<std::string, at::Tensor> Weights::attributes() const {
+std::unordered_map<std::string, at::Tensor> Weights::allValues() const {
   return allValues_;
 }
 

--- a/torch/nativert/executor/Weights.h
+++ b/torch/nativert/executor/Weights.h
@@ -56,11 +56,7 @@ class Weights {
   c10::IValue getCustomObj(const std::string& name) const;
   c10::IValue getCustomObjByFileName(const std::string& name) const;
 
-  std::unordered_map<std::string, at::Tensor> parameters() const;
-
-  std::unordered_map<std::string, at::Tensor> buffers() const;
-
-  std::unordered_map<std::string, at::Tensor> attributes() const;
+  std::unordered_map<std::string, at::Tensor> allValues() const;
 
   void loadStateDict(
       const std::unordered_map<std::string, c10::IValue>& stateDict);


### PR DESCRIPTION
Summary:
Clean up Weight class's API
- Remove parameters() and buffers()
- Rename attributes() to allValues()

Test Plan:
CI

Rollback Plan:

Reviewed By: zhxchen17

Differential Revision: D78871314


