### PR TITLE
[PowerPC]: Power11 support in inductor cpp_builder file

### DIFF
--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -632,7 +632,7 @@ def _get_optimization_cflags(
                         with open("/proc/cpuinfo") as f:
                             cpuinfo = f.read()
                     except FileNotFoundError:
-                        # fallback to prtconf (useful for some AIX/Linux distros)
+                        # fallback to prtconf
                         try:
                             cpuinfo = subprocess.check_output(
                                 [


### PR DESCRIPTION

Enable the power11 support in _inductor/cpp_builder.py to support torch inductor to run all the pytest.
With this changes i am able to run the torch coompile test case on power 11 system.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben