### PR TITLE
[SymmMem] Use host/nvshmem_api.h for backward compat

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cu
@@ -10,7 +10,13 @@
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/util/error.h>
 
-#include <nvshmem_host.h>
+// Starting from NVSHMEM 3.3.9, nvshmem_host.h exists so that we can cleanly
+// include only the nvshmem host library headers:
+// #include <nvshmem_host.h>
+// It translates into the following two lines:
+#include <host/nvshmem_api.h>
+#include <host/nvshmemx_api.h>
+// For maximum compatibility, we use the "host/" style for now.
 
 namespace c10d {
 namespace symmetric_memory {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #159061

Resolves #159045

`nvshmem_host.h` was introduced in 3.3.9. 
Use `host/nvshmem_api.h` and `host/nvshmemx_api.h` for prior versions.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta