### PR TITLE
Clarify that attn_mask shape supports head dimension in scaled_dot_product_attention

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5915,7 +5915,7 @@ scaled_dot_product_attention = _add_docstr(
         key (Tensor): Key tensor; shape :math:`(N, ..., H, S, E)`.
         value (Tensor): Value tensor; shape :math:`(N, ..., H, S, Ev)`.
         attn_mask (optional Tensor): Attention mask; shape must be broadcastable to the shape of attention weights,
-            which is :math:`(N,..., L, S)`. Two types of masks are supported.
+            which is :math:`(N,..., L, S)`. For example, this includes masks of shape (N, H, L, S) when using multi-head attention. Two types of masks are supported.
             A boolean mask where a value of True indicates that the element *should* take part in attention.
             A float mask of the same type as query, key, value that is added to the attention score.
         dropout_p (float): Dropout probability; if greater than 0.0, dropout is applied


### PR DESCRIPTION
Fixes #158969 

This PR updates the attn_mask parameter description in the docs for torch.nn.functional.scaled_dot_product_attention to clarify that masks shaped (N, H, L , S) are valid when using multi-head attention. The current behavior supports this but it wasn't clearly stated in the documentation. This small clarification helps avoid confusion for users working with per-head attention masks. 