### PR TITLE
[OOM] Release Reserve Memory after Pass

### DIFF
--- a/torch/fx/passes/pass_manager.py
+++ b/torch/fx/passes/pass_manager.py
@@ -4,6 +4,8 @@ from functools import wraps
 from inspect import unwrap
 from typing import Callable, Optional
 
+import torch
+
 
 logger = logging.getLogger(__name__)
 
@@ -250,4 +252,7 @@ class PassManager:
         out = source
         for _pass in self.passes:
             out = _pass(out)
+            # Release cache is necessary because the pass might perform actions (e.g
+            # accuracy validation) that will take up more and more GPU memory.
+            torch.cuda.empty_cache()
         return out


### PR DESCRIPTION
Summary: Since passes can have side effects due to operations such as inference validation, we need to clear reserve memory for the big models in order to prevent OOM

Test Plan:
Running
```
buck run mode/opt -c python.package_style=inplace -c fbcode.enable_gpu_sections=true -c fbcode.nvcc_arch=h100 //caffe2/torch/fb/model_transform/experimental/benchmark:mts_gpu_benchmark -- --model-snapshot-id=767311113_0 --lower-backend=AOT_INDUCTOR
```
resulted in OOM before this diff, and is fixed after applying.

Rollback Plan:

Differential Revision: D78921238




cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv