### PR TITLE
[DTensor] Assert DTensorSpec has valid placements (#158133) (#158133)

### DIFF
--- a/test/distributed/tensor/test_dtensor_compile.py
+++ b/test/distributed/tensor/test_dtensor_compile.py
@@ -343,7 +343,7 @@ def forward(self, b_parametrizations_buffer_original0, x):
         x = torch.randn(64, 32, requires_grad=True)
         spec = DTensorSpec(
             mesh,
-            (Replicate(), Shard(0)),
+            (Replicate(),),
             tensor_meta=TensorMeta(
                 shape=torch.Size([128, 32]), stride=(32, 1), dtype=x.dtype
             ),

--- a/torch/distributed/tensor/_dtensor_spec.py
+++ b/torch/distributed/tensor/_dtensor_spec.py
@@ -32,6 +32,10 @@ class DTensorSpec:
     def __post_init__(self) -> None:
         if not isinstance(self.placements, tuple):
             self.placements = tuple(self.placements)
+        if not len(self.placements) == self.mesh.ndim:
+            raise ValueError(
+                f"DTensorSpec requires one placement per mesh dim (mesh.ndim={self.mesh.ndim}), got {self.placements=}"
+            )
         self._hash: Optional[int] = None
 
     def __setattr__(self, attr: str, value: Any) -> None:


### PR DESCRIPTION
Summary:
This helped identify buggy sharding rules during debugging, why not
check it in.

Approved by: https://github.com/XilunWu, https://github.com/zpcore
ghstack dependencies: #158132

Test Plan:
contbuild & OSS CI, see https://hud.pytorch.org/commit/pytorch/pytorch/1839e8d04b81ee6eda0cff6fbfc218a7a600f6f7

Rollback Plan:

Differential Revision: D78929245




cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @d4l3k @pragupta