### PR TITLE
force kwarg=copy on .to in proxy_call in export

### DIFF
--- a/torch/_export/non_strict_utils.py
+++ b/torch/_export/non_strict_utils.py
@@ -1060,7 +1060,7 @@ class _NonStrictTorchFunctionHandler(torch.overrides.TorchFunctionMode):
                     frame.f_lineno,
                     frame.f_code.co_name,
                 )
-
+        # could also intercept here, but writing a lot more code needed
         func, args, kwargs = self._override(func, args, kwargs)
         try:
             return func(*args, **kwargs)

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -1673,11 +1673,13 @@ def _export_to_aten_ir_make_fx(
                         k.__getattribute__ = old_getattr  # type: ignore[method-assign, attr-defined]
 
             with ctx, override_getattribute_for_subclasses(flat_args):
+                torch.fx.experimental.proxy_tensor.in_export = True
                 gm = make_fx(
                     wrapped_fn,
                     record_module_stack=True,
                     pre_dispatch=True,
                 )(*flat_args)
+                torch.fx.experimental.proxy_tensor.in_export = False
 
             if non_strict_root is not None:
                 input_names = _graph_input_names(gm)


### PR DESCRIPTION
if we have the following module:

```python
class Module(torch.nn.Module):
    def forward(self, x):
        z = x + 1
        y = z.to("cpu", copy=False)
        z.add_(1)
        return y

t = torch.rand(2, 3)
ep = torch.export.export(Module(), (t,)) # for both strict=True and False
```

the pre-dispatch graph is 

```
    class GraphModule(torch.nn.Module):
        def forward(self, x: "f32[2, 3]"):
             # File: /data/users/shangdiy/test.py:7 in forward, code: z = x + 1
            add: "f32[2, 3]" = torch.ops.aten.add.Tensor(x, 1);  x = None
            
             # File: /data/users/shangdiy/test.py:8 in forward, code: y = z.to("cpu", copy=False)
            _assert_tensor_metadata_default = torch.ops.aten._assert_tensor_metadata.default(add, dtype = torch.float32, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default = None
            to: "f32[2, 3]" = torch.ops.aten.to.dtype_layout(add, dtype = torch.float32, layout = torch.strided, device = device(type='cpu'))
            
             # File: /data/users/shangdiy/test.py:9 in forward, code: z.add_(1)
            add_: "f32[2, 3]" = torch.ops.aten.add_.Tensor(to, 1);  add = add_ = None
            return (to,)
```

**Note that this line is wrong: `add_: "f32[2, 3]" = torch.ops.aten.add_.Tensor(to, 1);`. The add_ should be on `add` instead of `to`. This is because if `z` is in cpu when tracing, the resulting FakeTensor from aten.to() is an alias, so the it is mapped to Proxy `y` instead of `z`.**

We fix this by forcing the FakeTensor to copy when tracing the pre-dispatch graph.


After the fix, the exported graph after is correct:

```
    class GraphModule(torch.nn.Module):
        def forward(self, x: "f32[2, 3]"):
             # File: /data/users/shangdiy/test.py:7 in forward, code: z = x + 1
            add: "f32[2, 3]" = torch.ops.aten.add.Tensor(x, 1);  x = None
            
             # File: /data/users/shangdiy/test.py:8 in forward, code: y = z.to("cpu", copy=False)
            _assert_tensor_metadata_default = torch.ops.aten._assert_tensor_metadata.default(add, dtype = torch.float32, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default = None
            to: "f32[2, 3]" = torch.ops.aten.to.dtype_layout(add, dtype = torch.float32, layout = torch.strided, device = device(type='cpu'))
            
             # File: /data/users/shangdiy/test.py:9 in forward, code: z.add_(1)
            add_: "f32[2, 3]" = torch.ops.aten.add_.Tensor(add, 1);  add = add_ = None
            return (to,)

```

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv