### PR TITLE
Fix: Use memory_order_relaxed instead of memory_order_relaxed

### DIFF
--- a/c10/core/DeviceType.cpp
+++ b/c10/core/DeviceType.cpp
@@ -158,7 +158,7 @@ void register_privateuse1_backend(const std::string& backend_name) {
   privateuse1_backend_name = backend_name;
   // Invariant: once this flag is set, privateuse1_backend_name is NEVER written
   // to.
-  privateuse1_backend_name_set.store(true, std::memory_order_relaxed);
+  privateuse1_backend_name_set.store(true, std::memory_order_release);
 }
 
 bool is_privateuse1_backend_registered() {


### PR DESCRIPTION
Addresses #159074 by using `memory_order_release` instead of `memory_order_relaxed` here:

https://github.com/pytorch/pytorch/blob/9c107606629de6383f55e3b48b42e594d23407b1/c10/core/DeviceType.cpp#L161

cc @colesbury, @malfet - please feel free to share any suggestions! 
