### PR TITLE
[DRAFT] Update CTC Loss gradients to be wrt. raw inputs

### DIFF
--- a/aten/src/ATen/native/LossCTC.cpp
+++ b/aten/src/ATen/native/LossCTC.cpp
@@ -385,7 +385,9 @@ Tensor ctc_loss_backward_cpu_template(const Tensor& grad_out, const Tensor& log_
         for (const auto c : c10::irange(num_labels)) {
           scalar_t& res = grad_a[t][c];
           scalar_t lp = log_probs_a[t][c];
-          res = (std::exp(lp)-std::exp(res + nll - lp)) * gr;
+          //res = (std::exp(lp)-std::exp(res + nll - lp)) * gr;
+          // updates res: upstream and dowstream gradients differ by exp(log_probs).
+          res = (-std::exp(res + nll -lp)) * gr;
         }
       }
 

--- a/aten/src/ATen/native/cuda/LossCTC.cu
+++ b/aten/src/ATen/native/cuda/LossCTC.cu
@@ -558,7 +558,7 @@ ctc_loss_backward_collect_gpu_kernel(scalar_t* __restrict__ gradient_data,
     scalar_t& res = gradient_data[gr_batch_offset + t * gr_input_stride + gr_char_stride * c];
     if (t < input_length && (! zero_infinity || nll != INFINITY)) {
       scalar_t lp = log_probs_data[lp_batch_offset + t * lp_input_stride + lp_char_stride * c];
-      res = (std::exp(lp)-std::exp(res + nll - lp)) * gr;
+      res = (-std::exp(res + nll - lp)) * gr;
     }
     else {
       res = 0.;

--- a/aten/src/ATen/native/cuda/LossCTC.cu
+++ b/aten/src/ATen/native/cuda/LossCTC.cu
@@ -725,7 +725,7 @@ Tensor ctc_loss_backward_gpu_template(const Tensor& grad_out, const Tensor& log_
     // subtract a factor of exp(log_probs) * output_gradient to cancel
     // out effect of log-softmax, so have gradient wrt. raw input.
     // FIXME there's probably a more optimal way to do this.
-    grad._sub(log_probs.exp() * grad_out.view({1, batch_size, 1}));
+    grad.sub_(log_probs.exp() * grad_out.view({1, batch_size, 1}));
   } else { // small problem, use naive algorithm
     // Still no block/grid configuration guru...
     int threads_input = max_threads;

--- a/aten/src/ATen/native/cudnn/LossCTC.cpp
+++ b/aten/src/ATen/native/cudnn/LossCTC.cpp
@@ -249,7 +249,7 @@ std::tuple<Tensor, Tensor> _cudnn_ctc_loss(
       workspace.data_ptr(),
       workspace_size));
   // Subtract exp(log_probs) from the gradient
-  grad.sub_(std::exp(log_probs_t));
+  grad.sub_(log_probs_t.exp());
 
   return std::make_tuple(costs, grad);
 }
@@ -347,6 +347,10 @@ std::tuple<Tensor, Tensor> _cudnn_ctc_loss_tensor(
       workspace.data_ptr()
 
           ));
+
+  // Subtract exp(log_probs) from the gradient
+  grad.sub_(log_probs_t.exp());
+
   return std::make_tuple(costs, grad);
 }
 

--- a/aten/src/ATen/native/cudnn/LossCTC.cpp
+++ b/aten/src/ATen/native/cudnn/LossCTC.cpp
@@ -249,7 +249,7 @@ std::tuple<Tensor, Tensor> _cudnn_ctc_loss(
       workspace.data_ptr(),
       workspace_size));
   // Subtract exp(log_probs) from the gradient
-  grad.sub_(at::exp(log_probs_t));
+  grad.sub_(std::exp(log_probs_t));
 
   return std::make_tuple(costs, grad);
 }

--- a/aten/src/ATen/native/cudnn/LossCTC.cpp
+++ b/aten/src/ATen/native/cudnn/LossCTC.cpp
@@ -213,7 +213,7 @@ std::tuple<Tensor, Tensor> _cudnn_ctc_loss(
   // so the CuDNN gradient semantics have changed between 7.1 and 7.6,
   // this is CuDNN 7.6 only, see PyTorch 1.2 for older CuDNN.
   ctc_loss_desc.setEx(
-      CUDNN_DATA_FLOAT, CUDNN_LOSS_NORMALIZATION_NONE, CUDNN_PROPAGATE_NAN);
+      CUDNN_DATA_FLOAT, CUDNN_LOSS_NORMALIZATION_SOFTMAX, CUDNN_PROPAGATE_NAN);
   TensorDescriptor log_probs_desc{log_probs_t};
   Tensor grad = at::empty_like(log_probs_t, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   TensorDescriptor grad_desc{grad};
@@ -250,7 +250,7 @@ std::tuple<Tensor, Tensor> _cudnn_ctc_loss(
       workspace_size));
   // Subtract exp(log_probs) from the gradient
   grad.sub_(at::exp(log_probs_t));
-  
+
   return std::make_tuple(costs, grad);
 }
 
@@ -312,7 +312,7 @@ std::tuple<Tensor, Tensor> _cudnn_ctc_loss_tensor(
 
   ctc_loss_desc.set_v8_v9(
       CUDNN_DATA_FLOAT,
-      CUDNN_LOSS_NORMALIZATION_NONE,
+      CUDNN_LOSS_NORMALIZATION_SOFTMAX,
       CUDNN_PROPAGATE_NAN,
       255);
   TensorDescriptor log_probs_desc{log_probs_t};

--- a/aten/src/ATen/native/cudnn/LossCTC.cpp
+++ b/aten/src/ATen/native/cudnn/LossCTC.cpp
@@ -213,7 +213,7 @@ std::tuple<Tensor, Tensor> _cudnn_ctc_loss(
   // so the CuDNN gradient semantics have changed between 7.1 and 7.6,
   // this is CuDNN 7.6 only, see PyTorch 1.2 for older CuDNN.
   ctc_loss_desc.setEx(
-      CUDNN_DATA_FLOAT, CUDNN_LOSS_NORMALIZATION_SOFTMAX, CUDNN_PROPAGATE_NAN);
+      CUDNN_DATA_FLOAT, CUDNN_LOSS_NORMALIZATION_NONE, CUDNN_PROPAGATE_NAN);
   TensorDescriptor log_probs_desc{log_probs_t};
   Tensor grad = at::empty_like(log_probs_t, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   TensorDescriptor grad_desc{grad};
@@ -248,6 +248,9 @@ std::tuple<Tensor, Tensor> _cudnn_ctc_loss(
       ctc_loss_desc.desc(),
       workspace.data_ptr(),
       workspace_size));
+  // Subtract exp(log_probs) from the gradient
+  grad.sub_(at::exp(log_probs_t));
+  
   return std::make_tuple(costs, grad);
 }
 
@@ -309,7 +312,7 @@ std::tuple<Tensor, Tensor> _cudnn_ctc_loss_tensor(
 
   ctc_loss_desc.set_v8_v9(
       CUDNN_DATA_FLOAT,
-      CUDNN_LOSS_NORMALIZATION_SOFTMAX,
+      CUDNN_LOSS_NORMALIZATION_NONE,
       CUDNN_PROPAGATE_NAN,
       255);
   TensorDescriptor log_probs_desc{log_probs_t};

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11732,13 +11732,12 @@ class TestNNDeviceType(NNTestCase):
                     for i in idxes:
                         target_lengths[i] = 0
 
-            def ctc_after_softmax(x):
+            def ctc_op(x):
                 x_full = ((x[:, None] * tile_factors[None, :]).view(-1)[:input_length * batch_size * num_labels]
                           .view(input_length, batch_size, num_labels))
-                log_probs = torch.log_softmax(x_full, 2)
-                return torch.nn.functional.ctc_loss(log_probs, targets, input_lengths, target_lengths)
+                return torch.nn.functional.ctc_loss(x_full, targets, input_lengths, target_lengths)
 
-            gradcheck(ctc_after_softmax, [x])
+            gradcheck(ctc_op, [x])
 
     @onlyCUDA
     @skipCUDAIfRocm(msg="skipped Cudnn test on ROCm")
@@ -11749,19 +11748,19 @@ class TestNNDeviceType(NNTestCase):
         target_length = 15
         targets = torch.randint(1, num_labels, (batch_size * target_length,),
                                 device='cuda', dtype=torch.long)
-        log_probs = torch.log_softmax(torch.randn(input_length, batch_size, num_labels, device='cuda', dtype=torch.float), 2)
-        log_probs.requires_grad_()
+        inputs = torch.randn(input_length, batch_size, num_labels, device='cuda', dtype=torch.float)
+        inputs.requires_grad_()
 
         input_lengths = batch_size * [input_length]
         target_lengths = batch_size * [target_length]
         grad_out = torch.randn(batch_size, device='cuda', dtype=torch.float)
         with torch.backends.cudnn.flags(enabled=False):
-            loss_native = torch.nn.functional.ctc_loss(log_probs, targets, input_lengths, target_lengths, reduction='none')
-            grad_native, = torch.autograd.grad(loss_native, log_probs, grad_out)
-        loss_cudnn = torch.nn.functional.ctc_loss(log_probs, targets.to('cpu', torch.int32),
+            loss_native = torch.nn.functional.ctc_loss(inputs, targets, input_lengths, target_lengths, reduction='none')
+            grad_native, = torch.autograd.grad(loss_native, inputs, grad_out)
+        loss_cudnn = torch.nn.functional.ctc_loss(inputs, targets.to('cpu', torch.int32),
                                                   input_lengths, target_lengths, reduction='none')
         self.assertTrue("Cudnn" in str(loss_cudnn.grad_fn))
-        grad_cudnn, = torch.autograd.grad(loss_cudnn, log_probs, grad_out)
+        grad_cudnn, = torch.autograd.grad(loss_cudnn, inputs, grad_out)
         self.assertEqual(grad_cudnn, grad_native, atol=1e-4, rtol=0)
 
     @onlyCUDA
@@ -11773,23 +11772,23 @@ class TestNNDeviceType(NNTestCase):
         target_length = 15
         targets = torch.randint(1, num_labels, (batch_size * target_length,),
                                 device='cuda', dtype=torch.long)
-        log_probs = torch.log_softmax(torch.randn(input_length, batch_size, num_labels, device='cuda', dtype=torch.float), 2)
-        log_probs.requires_grad_()
+        inputs = torch.randn(input_length, batch_size, num_labels, device='cuda', dtype=torch.float)
+        inputs.requires_grad_()
 
         input_lengths = batch_size * [input_length]
         input_lengths = torch.linspace(start=15, end=input_length, steps=batch_size, dtype=torch.long, device='cuda')
         target_lengths = torch.tensor(batch_size * [target_length], dtype=torch.long, device='cuda')
         grad_out = torch.randn(batch_size, device='cuda', dtype=torch.float)
         with torch.backends.cudnn.flags(enabled=False):
-            loss_native = torch.nn.functional.ctc_loss(log_probs, targets, input_lengths, target_lengths, reduction='none')
-            grad_native, = torch.autograd.grad(loss_native, log_probs, grad_out)
-        loss_cudnn = torch.nn.functional.ctc_loss(log_probs,
+            loss_native = torch.nn.functional.ctc_loss(inputs, targets, input_lengths, target_lengths, reduction='none')
+            grad_native, = torch.autograd.grad(loss_native, inputs, grad_out)
+        loss_cudnn = torch.nn.functional.ctc_loss(inputs,
                                                   targets.to('cuda', torch.int32),
                                                   input_lengths.to('cuda', torch.int32),
                                                   target_lengths.to('cuda', torch.int32),
                                                   reduction='none')
         self.assertTrue("Cudnn" in str(loss_cudnn.grad_fn))
-        grad_cudnn, = torch.autograd.grad(loss_cudnn, log_probs, grad_out)
+        grad_cudnn, = torch.autograd.grad(loss_cudnn, inputs, grad_out)
         self.assertEqual(grad_cudnn, grad_native, atol=1e-4, rtol=0)
 
     @onlyCUDA
@@ -11808,14 +11807,14 @@ class TestNNDeviceType(NNTestCase):
         other_device = torch.device("cpu")
         other_dtype = torch.int32
 
-        log_probs = torch.randn(T, N, C).log_softmax(2).to(prob_device)
+        inputs = torch.randn(T, N, C).to(prob_device)
 
         input_lengths = torch.full((N,), T, dtype=other_dtype).to(other_device)
         target_lengths = torch.randint(low=1, high=S, size=(N,), dtype=other_dtype).to(other_device)
         targets = torch.randint(low=0, high=C, size=(sum(target_lengths),), dtype=other_dtype).to(other_device)
 
         ctc_loss = torch.nn.functional.ctc_loss(
-            log_probs=log_probs,
+            log_probs=inputs,
             targets=targets,
             input_lengths=input_lengths,
             target_lengths=target_lengths,
@@ -11824,12 +11823,12 @@ class TestNNDeviceType(NNTestCase):
 
     @expectedFailureMPS
     def test_ctc_loss_error(self, device):
-        log_probs = torch.rand(0, 0, 4, device=device)
+        inputs = torch.rand(0, 0, 4, device=device)
         targets = torch.tensor([], device=device, dtype=torch.long)
         input_lengths = torch.tensor([], device=device, dtype=torch.long)
         target_lengths = torch.tensor([], device=device, dtype=torch.long)
         with self.assertRaisesRegex(RuntimeError, "log_probs tensor must not be empty"):
-            F.ctc_loss(log_probs, targets, input_lengths, target_lengths, reduction='none')
+            F.ctc_loss(inputs, targets, input_lengths, target_lengths, reduction='none')
 
     @expectedFailureMPS  # RuntimeError: LSTM with projections is not currently supported with MPS.
     @dtypesIfCUDA(torch.half, torch.float, torch.double)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11814,7 +11814,7 @@ class TestNNDeviceType(NNTestCase):
         targets = torch.randint(low=0, high=C, size=(sum(target_lengths),), dtype=other_dtype).to(other_device)
 
         ctc_loss = torch.nn.functional.ctc_loss(
-            log_probs=inputs,
+            inputs=inputs,
             targets=targets,
             input_lengths=input_lengths,
             target_lengths=target_lengths,

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3058,9 +3058,8 @@ def ctc_loss(
     """
 
     if has_torch_function_variadic(inputs, targets, input_lengths, target_lengths):
-        raw_ctc = lambda x, *o: ctc_loss(log_softmax(x, -1), *o)  # noqa: E731
         return handle_torch_function(
-            raw_ctc,
+            ctc_loss,
             (inputs, targets, input_lengths, target_lengths),
             inputs,
             targets,
@@ -3071,7 +3070,8 @@ def ctc_loss(
             zero_infinity=zero_infinity,
         )
 
-    raw_ctc = lambda x, *o: torch.ctc_loss(log_softmax(x, -1), *o)  # noqa: E731
+    def raw_ctc(x, *o):
+        return torch.ctc_loss(log_softmax(x, -1), *o)
 
     return raw_ctc(
         inputs,

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3070,10 +3070,7 @@ def ctc_loss(
             zero_infinity=zero_infinity,
         )
 
-    def raw_ctc(x, *o):
-        return torch.ctc_loss(log_softmax(x, -1), *o)
-
-    return raw_ctc(
+    return torch.ctc_loss(
         inputs,
         targets,
         input_lengths,

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3004,7 +3004,7 @@ def local_response_norm(
 
 
 def ctc_loss(
-    log_probs: Tensor,
+    inputs: Tensor,
     targets: Tensor,
     input_lengths: Tensor,
     target_lengths: Tensor,
@@ -3023,9 +3023,9 @@ def ctc_loss(
         {backward_reproducibility_note}
 
     Args:
-        log_probs: :math:`(T, N, C)` or :math:`(T, C)` where `C = number of characters in alphabet including blank`,
+        inputs: :math:`(T, N, C)` or :math:`(T, C)` where `C = number of characters in alphabet including blank`,
             `T = input length`, and `N = batch size`.
-            The logarithmized probabilities of the outputs
+            The unnormalized probabilities of the outputs
             (e.g. obtained with :func:`torch.nn.functional.log_softmax`).
         targets: :math:`(N, S)` or `(sum(target_lengths))`.
                 May be an empty tensor if all entries in `target_lengths` are zero.
@@ -3049,20 +3049,20 @@ def ctc_loss(
 
     Example::
 
-        >>> log_probs = torch.randn(50, 16, 20).log_softmax(2).detach().requires_grad_()
+        >>> inputs = torch.randn(50, 16, 20).detach().requires_grad_()
         >>> targets = torch.randint(1, 20, (16, 30), dtype=torch.long)
         >>> input_lengths = torch.full((16,), 50, dtype=torch.long)
         >>> target_lengths = torch.randint(10, 30, (16,), dtype=torch.long)
-        >>> loss = F.ctc_loss(log_probs, targets, input_lengths, target_lengths)
+        >>> loss = F.ctc_loss(inputs, targets, input_lengths, target_lengths)
         >>> loss.backward()
     """
 
-    if has_torch_function_variadic(log_probs, targets, input_lengths, target_lengths):
+    if has_torch_function_variadic(inputs, targets, input_lengths, target_lengths):
         raw_ctc = lambda x, *o: ctc_loss(log_softmax(x, -1), *o)
         return handle_torch_function(
             raw_ctc,
-            (log_probs, targets, input_lengths, target_lengths),
-            log_probs,
+            (inputs, targets, input_lengths, target_lengths),
+            inputs,
             targets,
             input_lengths,
             target_lengths,
@@ -3074,7 +3074,7 @@ def ctc_loss(
     raw_ctc = lambda x, *o: torch.ctc_loss(log_softmax(x, -1), *o)
 
     return raw_ctc(
-        log_probs,
+        inputs,
         targets,
         input_lengths,
         target_lengths,

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3056,9 +3056,11 @@ def ctc_loss(
         >>> loss = F.ctc_loss(log_probs, targets, input_lengths, target_lengths)
         >>> loss.backward()
     """
+
     if has_torch_function_variadic(log_probs, targets, input_lengths, target_lengths):
+        raw_ctc = lambda x, *o: ctc_loss(log_softmax(x, -1), *o)
         return handle_torch_function(
-            ctc_loss,
+            raw_ctc,
             (log_probs, targets, input_lengths, target_lengths),
             log_probs,
             targets,
@@ -3068,7 +3070,10 @@ def ctc_loss(
             reduction=reduction,
             zero_infinity=zero_infinity,
         )
-    return torch.ctc_loss(
+
+    raw_ctc = lambda x, *o: torch.ctc_loss(log_softmax(x, -1), *o)
+
+    return raw_ctc(
         log_probs,
         targets,
         input_lengths,

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3058,7 +3058,7 @@ def ctc_loss(
     """
 
     if has_torch_function_variadic(inputs, targets, input_lengths, target_lengths):
-        raw_ctc = lambda x, *o: ctc_loss(log_softmax(x, -1), *o)
+        raw_ctc = lambda x, *o: ctc_loss(log_softmax(x, -1), *o)  # noqa: E731
         return handle_torch_function(
             raw_ctc,
             (inputs, targets, input_lengths, target_lengths),
@@ -3071,7 +3071,7 @@ def ctc_loss(
             zero_infinity=zero_infinity,
         )
 
-    raw_ctc = lambda x, *o: torch.ctc_loss(log_softmax(x, -1), *o)
+    raw_ctc = lambda x, *o: torch.ctc_loss(log_softmax(x, -1), *o)  # noqa: E731
 
     return raw_ctc(
         inputs,

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -2049,7 +2049,6 @@ class CTCLoss(_Loss):
         input_lengths: Tensor,
         target_lengths: Tensor,
     ) -> Tensor:
-
         return F.ctc_loss(
             inputs,
             targets,

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -2059,6 +2059,16 @@ class CTCLoss(_Loss):
             self.reduction,
             self.zero_infinity,
         )
+        #
+        # return F.ctc_loss(
+        #     inputs,
+        #     targets,
+        #     input_lengths,
+        #     target_lengths,
+        #     self.blank,
+        #     self.reduction,
+        #     self.zero_infinity,
+        # )
 
 
 # TODO: L1HingeEmbeddingCriterion

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -2049,7 +2049,6 @@ class CTCLoss(_Loss):
         input_lengths: Tensor,
         target_lengths: Tensor,
     ) -> Tensor:
-        """Runs the forward pass."""
 
         return F.ctc_loss(
             inputs,

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -2059,16 +2059,6 @@ class CTCLoss(_Loss):
             self.reduction,
             self.zero_infinity,
         )
-        #
-        # return F.ctc_loss(
-        #     inputs,
-        #     targets,
-        #     input_lengths,
-        #     target_lengths,
-        #     self.blank,
-        #     self.reduction,
-        #     self.zero_infinity,
-        # )
 
 
 # TODO: L1HingeEmbeddingCriterion

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -1904,12 +1904,11 @@ class CTCLoss(_Loss):
             to be aligned to the targets.
 
     Shape:
-        - Log_probs: Tensor of size :math:`(T, N, C)` or :math:`(T, C)`,
+        - Inputs: Tensor of size :math:`(T, N, C)` or :math:`(T, C)`,
           where :math:`T = \text{input length}`,
           :math:`N = \text{batch size}`, and
           :math:`C = \text{number of classes (including blank)}`.
-          The logarithmized probabilities of the outputs (e.g. obtained with
-          :func:`torch.nn.functional.log_softmax`).
+          Probability outputs, need not be normalized.
         - Targets: Tensor of size :math:`(N, S)` or
           :math:`(\operatorname{sum}(\text{target\_lengths}))`,
           where :math:`N = \text{batch size}` and
@@ -1949,7 +1948,7 @@ class CTCLoss(_Loss):
         >>> S_min = 10  # Minimum target length, for demonstration purposes
         >>>
         >>> # Initialize random batch of input vectors, for *size = (T,N,C)
-        >>> input = torch.randn(T, N, C).log_softmax(2).detach().requires_grad_()
+        >>> input = torch.randn(T, N, C).detach().requires_grad_()
         >>>
         >>> # Initialize random batch of targets (0 = blank, 1:C = classes)
         >>> target = torch.randint(low=1, high=C, size=(N, S), dtype=torch.long)
@@ -1972,7 +1971,7 @@ class CTCLoss(_Loss):
         >>> N = 16  # Batch size
         >>>
         >>> # Initialize random batch of input vectors, for *size = (T,N,C)
-        >>> input = torch.randn(T, N, C).log_softmax(2).detach().requires_grad_()
+        >>> input = torch.randn(T, N, C).detach().requires_grad_()
         >>> input_lengths = torch.full(size=(N,), fill_value=T, dtype=torch.long)
         >>>
         >>> # Initialize random batch of targets (0 = blank, 1:C = classes)
@@ -1994,7 +1993,7 @@ class CTCLoss(_Loss):
         >>>
         >>> # Initialize random batch of input vectors, for *size = (T,C)
         >>> # xdoctest: +SKIP("FIXME: error in doctest")
-        >>> input = torch.randn(T, C).log_softmax(1).detach().requires_grad_()
+        >>> input = torch.randn(T, C).detach().requires_grad_()
         >>> input_lengths = torch.tensor(T, dtype=torch.long)
         >>>
         >>> # Initialize random batch of targets (0 = blank, 1:C = classes)

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -2045,14 +2045,15 @@ class CTCLoss(_Loss):
 
     def forward(
         self,
-        log_probs: Tensor,
+        inputs: Tensor,
         targets: Tensor,
         input_lengths: Tensor,
         target_lengths: Tensor,
     ) -> Tensor:
         """Runs the forward pass."""
+
         return F.ctc_loss(
-            log_probs,
+            inputs,
             targets,
             input_lengths,
             target_lengths,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8382,16 +8382,17 @@ def sample_inputs_ctc_loss(op_info, device, dtype, requires_grad, **kwargs):
     num_char = 20
     target_length = 30
 
-    def make_log_probs(s):
-        t = make_tensor(s, device=device, dtype=dtype)
-        log_probs = t.log_softmax(2).to(device=device, dtype=dtype).detach().requires_grad_(requires_grad=requires_grad)
-        return log_probs
+    # Test ctc_loss gradient behavior for the regime in which it is currently accurate and consistent across devices:
+    # normalized inputs and gradients wrt. unnormalized inputs.
+    # See https://github.com/pytorch/pytorch/issues/52241
+    def make_input(s):
+        return make_tensor(s, device=device, dtype=dtype).detach().requires_grad_(requires_grad=requires_grad)
 
     reductions = ('none', 'mean', 'sum')
     zero_inf = (True, False)
     lengths_type = (list, torch.Tensor)
     for r, z, lt in product(reductions, zero_inf, lengths_type):
-        log_probs = make_log_probs((input_length, batch, num_char))
+        log_probs = make_input((input_length, batch, num_char))
         targets = torch.randint(1, num_char, (batch, target_length), dtype=torch.long, device=device)
         input_lengths = torch.full((batch, ), input_length, dtype=torch.long, device=device)
         target_lengths = torch.randint(10, target_length, (batch, ), dtype=torch.long, device=device)
@@ -8404,7 +8405,7 @@ def sample_inputs_ctc_loss(op_info, device, dtype, requires_grad, **kwargs):
             input_lengths = input_lengths.tolist()
             target_lengths = target_lengths.tolist()
 
-        yield SampleInput(log_probs, args=(targets, input_lengths, target_lengths,),
+        yield SampleInput(log_probs, args=(targets, input_lengths, target_lengths),
                           kwargs=dict(reduction=r, zero_infinity=z))
 
 
@@ -21413,7 +21414,8 @@ op_db: list[OpInfo] = [
         dtypes=floating_types(),
         supports_out=False,
         sample_inputs_func=sample_inputs_ctc_loss,
-        # gradcheck_wrapper, see https://github.com/pytorch/pytorch/issues/52241
+        # gradcheck_wrapper to check gradients wrt. unnormalized inputs.
+        # see https://github.com/pytorch/pytorch/issues/52241
         gradcheck_wrapper=gradcheck_wrapper_ctc_loss,
         skips=(
             # RuntimeError: derivative for aten::_ctc_loss_backward is not implemented

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8382,17 +8382,16 @@ def sample_inputs_ctc_loss(op_info, device, dtype, requires_grad, **kwargs):
     num_char = 20
     target_length = 30
 
-    # Test ctc_loss gradient behavior for the regime in which it is currently accurate and consistent across devices:
-    # normalized inputs and gradients wrt. unnormalized inputs.
-    # See https://github.com/pytorch/pytorch/issues/52241
-    def make_input(s):
-        return make_tensor(s, device=device, dtype=dtype).detach().requires_grad_(requires_grad=requires_grad)
+    def make_log_probs(s):
+        t = make_tensor(s, device=device, dtype=dtype)
+        log_probs = t.log_softmax(2).to(device=device, dtype=dtype).detach().requires_grad_(requires_grad=requires_grad)
+        return log_probs
 
     reductions = ('none', 'mean', 'sum')
     zero_inf = (True, False)
     lengths_type = (list, torch.Tensor)
     for r, z, lt in product(reductions, zero_inf, lengths_type):
-        log_probs = make_input((input_length, batch, num_char))
+        log_probs = make_log_probs((input_length, batch, num_char))
         targets = torch.randint(1, num_char, (batch, target_length), dtype=torch.long, device=device)
         input_lengths = torch.full((batch, ), input_length, dtype=torch.long, device=device)
         target_lengths = torch.randint(10, target_length, (batch, ), dtype=torch.long, device=device)
@@ -8405,7 +8404,7 @@ def sample_inputs_ctc_loss(op_info, device, dtype, requires_grad, **kwargs):
             input_lengths = input_lengths.tolist()
             target_lengths = target_lengths.tolist()
 
-        yield SampleInput(log_probs, args=(targets, input_lengths, target_lengths),
+        yield SampleInput(log_probs, args=(targets, input_lengths, target_lengths,),
                           kwargs=dict(reduction=r, zero_infinity=z))
 
 
@@ -21414,8 +21413,7 @@ op_db: list[OpInfo] = [
         dtypes=floating_types(),
         supports_out=False,
         sample_inputs_func=sample_inputs_ctc_loss,
-        # gradcheck_wrapper to check gradients wrt. unnormalized inputs.
-        # see https://github.com/pytorch/pytorch/issues/52241
+        # gradcheck_wrapper, see https://github.com/pytorch/pytorch/issues/52241
         gradcheck_wrapper=gradcheck_wrapper_ctc_loss,
         skips=(
             # RuntimeError: derivative for aten::_ctc_loss_backward is not implemented

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -97,7 +97,6 @@ from torch.testing._internal.opinfo.core import (  # noqa: F401
     sample_inputs_foreach,
     ForeachFuncInfo,
     gradcheck_wrapper_hermitian_input,
-    gradcheck_wrapper_ctc_loss,
     gradcheck_wrapper_triangular_input,
     gradcheck_wrapper_triangular_input_real_positive_diagonal,
     gradcheck_wrapper_masked_operation,
@@ -21414,9 +21413,6 @@ op_db: list[OpInfo] = [
         dtypes=floating_types(),
         supports_out=False,
         sample_inputs_func=sample_inputs_ctc_loss,
-        # gradcheck_wrapper, see https://github.com/pytorch/pytorch/issues/52241
-        # (Update: should not need gradcheck wrapper if/since now using raw inputs)
-        #gradcheck_wrapper=gradcheck_wrapper_ctc_loss,
         skips=(
             # RuntimeError: derivative for aten::_ctc_loss_backward is not implemented
             DecorateInfo(

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8382,16 +8382,17 @@ def sample_inputs_ctc_loss(op_info, device, dtype, requires_grad, **kwargs):
     num_char = 20
     target_length = 30
 
-    def make_log_probs(s):
+    def make_inputs(s):
+        # Use raw unnormalized inputs.
         t = make_tensor(s, device=device, dtype=dtype)
-        log_probs = t.log_softmax(2).to(device=device, dtype=dtype).detach().requires_grad_(requires_grad=requires_grad)
-        return log_probs
+        inputs = t.to(device=device, dtype=dtype).detach().requires_grad_(requires_grad=requires_grad)
+        return inputs
 
     reductions = ('none', 'mean', 'sum')
     zero_inf = (True, False)
     lengths_type = (list, torch.Tensor)
     for r, z, lt in product(reductions, zero_inf, lengths_type):
-        log_probs = make_log_probs((input_length, batch, num_char))
+        inputs = make_inputs((input_length, batch, num_char))
         targets = torch.randint(1, num_char, (batch, target_length), dtype=torch.long, device=device)
         input_lengths = torch.full((batch, ), input_length, dtype=torch.long, device=device)
         target_lengths = torch.randint(10, target_length, (batch, ), dtype=torch.long, device=device)
@@ -8404,7 +8405,7 @@ def sample_inputs_ctc_loss(op_info, device, dtype, requires_grad, **kwargs):
             input_lengths = input_lengths.tolist()
             target_lengths = target_lengths.tolist()
 
-        yield SampleInput(log_probs, args=(targets, input_lengths, target_lengths,),
+        yield SampleInput(inputs, args=(targets, input_lengths, target_lengths,),
                           kwargs=dict(reduction=r, zero_infinity=z))
 
 
@@ -21414,7 +21415,8 @@ op_db: list[OpInfo] = [
         supports_out=False,
         sample_inputs_func=sample_inputs_ctc_loss,
         # gradcheck_wrapper, see https://github.com/pytorch/pytorch/issues/52241
-        gradcheck_wrapper=gradcheck_wrapper_ctc_loss,
+        # (Update: should not need gradcheck wrapper if/since now using raw inputs)
+        #gradcheck_wrapper=gradcheck_wrapper_ctc_loss,
         skips=(
             # RuntimeError: derivative for aten::_ctc_loss_backward is not implemented
             DecorateInfo(

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -3126,8 +3126,7 @@ def gradcheck_wrapper_hermitian_input(op, input, *args, **kwargs):
 
 
 def gradcheck_wrapper_ctc_loss(op, input, *args, **kwargs):
-    """Gradcheck wrapper for ctc loss. This is needed to test the existing restricted cases in which the
-    ctc loss implementation is accurate and consistent across devices."""
+    """Gradcheck wrapper for ctc loss to project onto log-simplex space."""
     # See https://github.com/pytorch/pytorch/issues/52241
     return op(input.log_softmax(dim=2), *args, **kwargs)
 

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -3126,7 +3126,8 @@ def gradcheck_wrapper_hermitian_input(op, input, *args, **kwargs):
 
 
 def gradcheck_wrapper_ctc_loss(op, input, *args, **kwargs):
-    """Gradcheck wrapper for ctc loss to project onto log-simplex space."""
+    """Gradcheck wrapper for ctc loss. This is needed to test the existing restricted cases in which the
+    ctc loss implementation is accurate and consistent across devices."""
     # See https://github.com/pytorch/pytorch/issues/52241
     return op(input.log_softmax(dim=2), *args, **kwargs)
 

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -3125,12 +3125,6 @@ def gradcheck_wrapper_hermitian_input(op, input, *args, **kwargs):
     return op(input + input.mH, *args, **kwargs)
 
 
-def gradcheck_wrapper_ctc_loss(op, input, *args, **kwargs):
-    """Gradcheck wrapper for ctc loss to project onto log-simplex space."""
-    # See https://github.com/pytorch/pytorch/issues/52241
-    return op(input.log_softmax(dim=2), *args, **kwargs)
-
-
 def gradcheck_wrapper_triangular_input(op, *args, upper=False, idx=0, **kwargs):
     """Gradcheck wrapper for functions that take lower or upper triangular matrices as input.
 


### PR DESCRIPTION
(Maybe) Fixes #52241

Draft PR updating CTC loss gradients to be wrt. raw inputs, using the trick that CTC loss gradients wrt before and after `log(softmax(x))` differ by a factor of `exp(log_probs)`.

The CPU changes I built and tested locally, appear to be passing OpInfo tests. The CUDA and CUDNN code I'm less familiar with and don't have an efficient build server, hoping to rely on Pytorch CI to test those changes ( cc @soulitzer ).


