### PR TITLE
[CPU] Fix bias dtype issue for FP8 qlinear

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -955,7 +955,12 @@ static at::Tensor fp8_qlinear_onednn_ref(
   std::vector<int64_t> w_scales_new_shape(weight.dim(), 1);
   w_scales_new_shape[0] = -1;
   auto dqw = weight.to(at::kFloat) * weight_scales.reshape(w_scales_new_shape);
-  auto y_f32 = at::linear(dqx, dqw, bias);
+  at::Tensor y_f32;
+  if (bias.has_value()) {
+    y_f32 = at::linear(dqx, dqw, bias.value().to(at::kFloat));
+  } else {
+    y_f32 = at::linear(dqx, dqw);
+  }
   if (binary_post_op == "none") {
     if (unary_post_op == "relu") {
       at::relu_(y_f32);

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -955,11 +955,9 @@ static at::Tensor fp8_qlinear_onednn_ref(
   std::vector<int64_t> w_scales_new_shape(weight.dim(), 1);
   w_scales_new_shape[0] = -1;
   auto dqw = weight.to(at::kFloat) * weight_scales.reshape(w_scales_new_shape);
-  at::Tensor y_f32;
+  auto y_f32 = at::linear(dqx, dqw);
   if (bias.has_value()) {
-    y_f32 = at::linear(dqx, dqw, bias.value().to(at::kFloat));
-  } else {
-    y_f32 = at::linear(dqx, dqw);
+      y_f32 += bias.value().to(at::kFloat);
   }
   if (binary_post_op == "none") {
     if (unary_post_op == "relu") {

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -4754,13 +4754,18 @@ class TestQuantizedLinear(TestCase):
                 qw, w_scales = _quantize_fp8e4m3(w, channelwise=weight_quant_per_channel)
                 if use_bias:
                     b = torch.rand(oc) * 10
+                    if bfloat16_out:
+                        b = b.to(torch.bfloat16)
                 else:
                     b = None
 
                 # compute reference result
                 x_ref = _dequantize_fp8e4m3(qx, x_scale)
                 w_ref = _dequantize_fp8e4m3(qw, w_scales)
-                y_ref = linear_op(x_ref, w_ref, b)
+                if b is not None:
+                    y_ref = linear_op(x_ref, w_ref, b.to(torch.float))
+                else:
+                    y_ref = linear_op(x_ref, w_ref)
 
                 # compute fp8 linear
                 qw_packed = qlinear_prepack(qw, x.shape)


### PR DESCRIPTION
Fixes 
`RuntimeError: self and mat2 must have the same dtype, but got BFloat16 and Float`

With bf16 autocast, bias converted into BFloat16, but fp8_qlinear_onednn_ref not support bf16 bias.
In this pr, convert bias into bf16 on fp8_qlinear_onednn_ref.

Add this case into ut and reproduce: 
`python test/test_quantization.py -k test_qlinear_fp8`

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168