### PR TITLE
Export torch.optim.optimizer.ParamsT

### DIFF
--- a/torch/optim/__init__.py
+++ b/torch/optim/__init__.py
@@ -16,7 +16,7 @@ from torch.optim.adamw import AdamW as AdamW
 from torch.optim.asgd import ASGD as ASGD
 from torch.optim.lbfgs import LBFGS as LBFGS
 from torch.optim.nadam import NAdam as NAdam
-from torch.optim.optimizer import Optimizer as Optimizer
+from torch.optim.optimizer import Optimizer as Optimizer, ParamsT as ParamsT
 from torch.optim.radam import RAdam as RAdam
 from torch.optim.rmsprop import RMSprop as RMSprop
 from torch.optim.rprop import Rprop as Rprop
@@ -54,6 +54,7 @@ __all__ = [
     "lr_scheduler",
     "NAdam",
     "Optimizer",
+    "ParamsT",
     "RAdam",
     "RMSprop",
     "Rprop",


### PR DESCRIPTION
`ParamsT` is very useful for typing in third-party sub-classes of `torch.optim.Optimizer`.  The type is also stable enough to be exported.