### PR TITLE
port 2 distributed pipeline test files for Intel GPU

### DIFF
--- a/test/distributed/pipelining/test_backward.py
+++ b/test/distributed/pipelining/test_backward.py
@@ -10,7 +10,7 @@ from torch.distributed.pipelining._backward import (
     stage_backward_input,
     stage_backward_weight,
 )
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_device_type import instantiate_device_type_tests, skipXPUIf
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 

--- a/test/distributed/pipelining/test_backward.py
+++ b/test/distributed/pipelining/test_backward.py
@@ -19,6 +19,7 @@ batch_size = 256
 
 
 class StageBackwardTests(TestCase):
+    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/1682")
     def test_stage_backward(self, device):
         # MLP as a stage module
         mod = MLPModule(d_hid).to(device)
@@ -49,18 +50,11 @@ class StageBackwardTests(TestCase):
 
         torch.testing.assert_close(grad_inputs[0], ref_x.grad)
 
-        rtol, atol = None, None
-        if self.device_type == "xpu":
-            rtol, atol = (
-                torch.testing._comparison.default_tolerances(torch.float32)[0],
-                1e-4,
-            )
-
         # Every rank checks gradients
         for name, p in mod.named_parameters():
             ref_p = ref_mod.get_parameter(name)
             try:
-                torch.testing.assert_close(p.grad, ref_p.grad, rtol=rtol, atol=atol)
+                torch.testing.assert_close(p.grad, ref_p.grad)
             except AssertionError:
                 print(f"Gradient test failed for {name}: {p.grad} vs {ref_p.grad}")
                 raise
@@ -100,6 +94,7 @@ class StageBackwardTests(TestCase):
             # Check that the weight gradients were not updated
             self.assertEqual(p.grad, None)
 
+    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/1682")
     def test_stage_backward_weight(self, device):
         # MLP as a stage module
         mod = MLPModule(d_hid).to(device)
@@ -131,22 +126,16 @@ class StageBackwardTests(TestCase):
         ref_loss = loss_fn(ref_out, ref_target)
         ref_loss.backward()
 
-        rtol, atol = None, None
-        if self.device_type == "xpu":
-            rtol, atol = (
-                torch.testing._comparison.default_tolerances(torch.float32)[0],
-                1e-4,
-            )
-
         # Every rank checks gradients
         for name, p in mod.named_parameters():
             ref_p = ref_mod.get_parameter(name)
             try:
-                torch.testing.assert_close(p.grad, ref_p.grad, rtol=rtol, atol=atol)
+                torch.testing.assert_close(p.grad, ref_p.grad)
             except AssertionError:
                 print(f"Gradient test failed for {name}: {p.grad} vs {ref_p.grad}")
                 raise
 
+    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/1682")
     def test_stage_backward_weight_multiple_iters(self, device):
         # MLP as a stage module
         mod = MLPModule(d_hid).to(device)
@@ -188,18 +177,11 @@ class StageBackwardTests(TestCase):
             ref_loss = loss_fn(ref_out, ref_target)
             ref_loss.backward()
 
-        rtol, atol = None, None
-        if self.device_type == "xpu":
-            rtol, atol = (
-                torch.testing._comparison.default_tolerances(torch.float32)[0],
-                1e-4,
-            )
-
         # Every rank checks gradients
         for name, p in mod.named_parameters():
             ref_p = ref_mod.get_parameter(name)
             try:
-                torch.testing.assert_close(p.grad, ref_p.grad, rtol=rtol, atol=atol)
+                torch.testing.assert_close(p.grad, ref_p.grad)
             except AssertionError:
                 print(f"Gradient test failed for {name}: {p.grad} vs {ref_p.grad}")
                 raise

--- a/test/distributed/pipelining/test_backward.py
+++ b/test/distributed/pipelining/test_backward.py
@@ -10,7 +10,10 @@ from torch.distributed.pipelining._backward import (
     stage_backward_input,
     stage_backward_weight,
 )
-from torch.testing._internal.common_device_type import instantiate_device_type_tests, skipXPUIf
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    skipXPUIf,
+)
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 

--- a/test/distributed/pipelining/test_backward.py
+++ b/test/distributed/pipelining/test_backward.py
@@ -49,11 +49,18 @@ class StageBackwardTests(TestCase):
 
         torch.testing.assert_close(grad_inputs[0], ref_x.grad)
 
+        rtol, atol = None, None
+        if self.device_type == "xpu":
+            rtol, atol = (
+                torch.testing._comparison.default_tolerances(torch.float32)[0],
+                1e-4,
+            )
+
         # Every rank checks gradients
         for name, p in mod.named_parameters():
             ref_p = ref_mod.get_parameter(name)
             try:
-                torch.testing.assert_close(p.grad, ref_p.grad)
+                torch.testing.assert_close(p.grad, ref_p.grad, rtol=rtol, atol=atol)
             except AssertionError:
                 print(f"Gradient test failed for {name}: {p.grad} vs {ref_p.grad}")
                 raise
@@ -124,11 +131,18 @@ class StageBackwardTests(TestCase):
         ref_loss = loss_fn(ref_out, ref_target)
         ref_loss.backward()
 
+        rtol, atol = None, None
+        if self.device_type == "xpu":
+            rtol, atol = (
+                torch.testing._comparison.default_tolerances(torch.float32)[0],
+                1e-4,
+            )
+
         # Every rank checks gradients
         for name, p in mod.named_parameters():
             ref_p = ref_mod.get_parameter(name)
             try:
-                torch.testing.assert_close(p.grad, ref_p.grad)
+                torch.testing.assert_close(p.grad, ref_p.grad, rtol=rtol, atol=atol)
             except AssertionError:
                 print(f"Gradient test failed for {name}: {p.grad} vs {ref_p.grad}")
                 raise
@@ -174,11 +188,18 @@ class StageBackwardTests(TestCase):
             ref_loss = loss_fn(ref_out, ref_target)
             ref_loss.backward()
 
+        rtol, atol = None, None
+        if self.device_type == "xpu":
+            rtol, atol = (
+                torch.testing._comparison.default_tolerances(torch.float32)[0],
+                1e-4,
+            )
+
         # Every rank checks gradients
         for name, p in mod.named_parameters():
             ref_p = ref_mod.get_parameter(name)
             try:
-                torch.testing.assert_close(p.grad, ref_p.grad)
+                torch.testing.assert_close(p.grad, ref_p.grad, rtol=rtol, atol=atol)
             except AssertionError:
                 print(f"Gradient test failed for {name}: {p.grad} vs {ref_p.grad}")
                 raise
@@ -223,7 +244,9 @@ class StageBackwardTests(TestCase):
 
 
 devices = ["cpu", "cuda", "hpu", "xpu"]
-instantiate_device_type_tests(StageBackwardTests, globals(), only_for=devices)
+instantiate_device_type_tests(
+    StageBackwardTests, globals(), only_for=devices, allow_xpu=True
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/pipelining/test_microbatch.py
+++ b/test/distributed/pipelining/test_microbatch.py
@@ -56,6 +56,7 @@ class MicrobatchTests(TestCase):
         torch.testing.assert_close(merged_kwargs, kwargs)
         print("Microbatch test passed")
 
+    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/1682")
     def test_chunk_spec(self, device):
         mod = ModelWithKwargs().to(device)
         batch_size = ModelWithKwargs.DEFAULT_BATCH_SIZE
@@ -85,11 +86,7 @@ class MicrobatchTests(TestCase):
         ref = mod(x, y)
         out = pipe(x, y)[0]
 
-        rtol, atol = None, None
-        if self.device_type == "xpu":
-            rtol, atol = 1e-4, 1e-4
-
-        torch.testing.assert_close(out, ref, rtol=rtol, atol=atol)
+        torch.testing.assert_close(out, ref)
         print(f"equivalence test passed {torch.sum(out)} ref {torch.sum(ref)}")
 
 

--- a/test/distributed/pipelining/test_microbatch.py
+++ b/test/distributed/pipelining/test_microbatch.py
@@ -9,7 +9,7 @@ from torch.distributed.pipelining.microbatch import (
     split_args_kwargs_into_chunks,
     TensorChunkSpec,
 )
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_device_type import instantiate_device_type_tests, skipXPUIf
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 

--- a/test/distributed/pipelining/test_microbatch.py
+++ b/test/distributed/pipelining/test_microbatch.py
@@ -9,7 +9,10 @@ from torch.distributed.pipelining.microbatch import (
     split_args_kwargs_into_chunks,
     TensorChunkSpec,
 )
-from torch.testing._internal.common_device_type import instantiate_device_type_tests, skipXPUIf
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    skipXPUIf,
+)
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 

--- a/test/distributed/pipelining/test_microbatch.py
+++ b/test/distributed/pipelining/test_microbatch.py
@@ -84,12 +84,19 @@ class MicrobatchTests(TestCase):
 
         ref = mod(x, y)
         out = pipe(x, y)[0]
-        torch.testing.assert_close(out, ref)
+
+        rtol, atol = None, None
+        if self.device_type == "xpu":
+            rtol, atol = 1e-4, 1e-4
+
+        torch.testing.assert_close(out, ref, rtol=rtol, atol=atol)
         print(f"equivalence test passed {torch.sum(out)} ref {torch.sum(ref)}")
 
 
 devices = ["cpu", "cuda", "hpu", "xpu"]
-instantiate_device_type_tests(MicrobatchTests, globals(), only_for=devices)
+instantiate_device_type_tests(
+    MicrobatchTests, globals(), only_for=devices, allow_xpu=True
+)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
it's another pr to port distributed pipeline test for Intel GPU, while the other pr is https://github.com/pytorch/pytorch/pull/159033. 
In this pr, we port two test files for Intel GPU
We could enable Intel GPU with following methods and try the best to keep the original code styles:

1. instantiate_device_type_tests()
2. skip the case at xpu due to accuracy gap introduced by oneDNN non-deterministic


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @gujinghui @EikanWang @fengyuan14 @guangyey