### PR TITLE
Correctly set max_numwarps in coordinate_descent_tuner

### DIFF
--- a/torch/_inductor/runtime/coordinate_descent_tuner.py
+++ b/torch/_inductor/runtime/coordinate_descent_tuner.py
@@ -9,7 +9,7 @@ from torch.utils._ordered_set import OrderedSet
 
 from .hints import TRITON_MAX_BLOCK
 from .runtime_utils import red_text, triton_config_to_hashable
-
+from ..utils import get_max_numwarps
 
 if TYPE_CHECKING:
     from .triton_compat import triton
@@ -57,6 +57,7 @@ class CoordescTuner:
         name="unknown",
         size_hints=None,
         inductor_meta=None,
+        triton_meta=None,
         frozen_fields=None,
     ):
         self.is_mm = is_mm  # we will tune num_stages for mm
@@ -71,6 +72,7 @@ class CoordescTuner:
         self.name = name
         self.size_hints = size_hints
         self.inductor_meta = inductor_meta or {}
+        self.triton_meta = triton_meta
         self.frozen_fields: OrderedSet[str] = (
             OrderedSet(frozen_fields) if frozen_fields is not None else OrderedSet()
         )
@@ -81,9 +83,13 @@ class CoordescTuner:
         return min(max_block, size_hint) if size_hint is not None else max_block
 
     def get_warpsmax(self):
-        # Currently, CUDA has a maximum of 1024 threads, so 32 is the max
-        # number of warps.
-        return 1024 // 32
+        if self.triton_meta:
+            # Avoid querying device directly if triton_meta is populated
+            warp_size = self.triton_meta.get('warp_size')
+            max_threads_per_block = self.triton_meta.get('max_threads_per_block')
+            return max_threads_per_block // warp_size
+        else:
+            return get_max_numwarps()
 
     def cache_benchmark_result(self, config, timing):
         self.cached_benchmark_results[triton_config_to_hashable(config)] = timing

--- a/torch/_inductor/runtime/coordinate_descent_tuner.py
+++ b/torch/_inductor/runtime/coordinate_descent_tuner.py
@@ -57,7 +57,6 @@ class CoordescTuner:
         name="unknown",
         size_hints=None,
         inductor_meta=None,
-        triton_meta=None,
         frozen_fields=None,
     ):
         self.is_mm = is_mm  # we will tune num_stages for mm
@@ -72,7 +71,6 @@ class CoordescTuner:
         self.name = name
         self.size_hints = size_hints
         self.inductor_meta = inductor_meta or {}
-        self.triton_meta = triton_meta
         self.frozen_fields: OrderedSet[str] = (
             OrderedSet(frozen_fields) if frozen_fields is not None else OrderedSet()
         )
@@ -83,10 +81,10 @@ class CoordescTuner:
         return min(max_block, size_hint) if size_hint is not None else max_block
 
     def get_warpsmax(self):
-        if self.triton_meta:
-            # Avoid querying device directly if triton_meta is populated
-            warp_size = self.triton_meta.get('warp_size')
-            max_threads_per_block = self.triton_meta.get('max_threads_per_block')
+        # Avoid querying device directly if device properties are populated in inductor_meta
+        warp_size = self.inductor_meta.get('warp_size')
+        max_threads_per_block = self.inductor_meta.get('max_threads_per_block')
+        if warp_size and max_threads_per_block:
             return max_threads_per_block // warp_size
         else:
             return get_max_numwarps()

--- a/torch/_inductor/runtime/coordinate_descent_tuner.py
+++ b/torch/_inductor/runtime/coordinate_descent_tuner.py
@@ -7,9 +7,10 @@ from typing import TYPE_CHECKING
 
 from torch.utils._ordered_set import OrderedSet
 
+from ..utils import get_max_numwarps
 from .hints import TRITON_MAX_BLOCK
 from .runtime_utils import red_text, triton_config_to_hashable
-from ..utils import get_max_numwarps
+
 
 if TYPE_CHECKING:
     from .triton_compat import triton
@@ -82,8 +83,8 @@ class CoordescTuner:
 
     def get_warpsmax(self):
         # Avoid querying device directly if device properties are populated in inductor_meta
-        warp_size = self.inductor_meta.get('warp_size')
-        max_threads_per_block = self.inductor_meta.get('max_threads_per_block')
+        warp_size = self.inductor_meta.get("warp_size")
+        max_threads_per_block = self.inductor_meta.get("max_threads_per_block")
         if warp_size and max_threads_per_block:
             return max_threads_per_block // warp_size
         else:

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -135,6 +135,7 @@ class DeviceProperties(typing.NamedTuple):
     major: int | None = None
     regs_per_multiprocessor: int | None = None
     max_threads_per_multi_processor: int | None = None
+    max_threads_per_block: int | None = None
     warp_size: int | None = None
 
     @classmethod
@@ -169,6 +170,7 @@ class DeviceProperties(typing.NamedTuple):
             max_threads_per_multi_processor=getattr(
                 props, "max_threads_per_multi_processor", None
             ),
+            max_threads_per_block=getattr(props, "max_threads_per_block", 1024),
             warp_size=getattr(props, "warp_size", 32 if device_type != "cpu" else None),
         )
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -294,10 +294,11 @@ class CachingAutotuner(KernelInterface):
             **triton_meta,
             "device": self.device_props.index,
             "device_type": self.device_props.type,
-            "warp_size": self.device_props.warp_size,
-            "max_threads_per_block": self.device_props.max_threads_per_block, 
         }
         self.inductor_meta = {} if inductor_meta is None else inductor_meta
+        # Add device properties to inductor_meta for use by coordinate descent tuner
+        self.inductor_meta["warp_size"] = self.device_props.warp_size
+        self.inductor_meta["max_threads_per_block"] = self.device_props.max_threads_per_block
         self.deterministic_mode = self.inductor_meta.get("deterministic", False)
 
         self.save_cache_hook = save_cache_hook
@@ -340,7 +341,6 @@ class CachingAutotuner(KernelInterface):
             name=self.fn.__name__,
             size_hints=size_hints,
             inductor_meta=self.inductor_meta,
-            triton_meta=self.triton_meta,
         )
         self.filename = filename
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -298,7 +298,7 @@ class CachingAutotuner(KernelInterface):
         self.inductor_meta = {} if inductor_meta is None else inductor_meta
         # Add device properties to inductor_meta for use by coordinate descent tuner
         self.inductor_meta["warp_size"] = self.device_props.warp_size
-        self.inductor_meta["max_threads_per_block"] =  (
+        self.inductor_meta["max_threads_per_block"] = (
             self.device_props.max_threads_per_block
         )
         self.deterministic_mode = self.inductor_meta.get("deterministic", False)

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -294,6 +294,8 @@ class CachingAutotuner(KernelInterface):
             **triton_meta,
             "device": self.device_props.index,
             "device_type": self.device_props.type,
+            "warp_size": self.device_props.warp_size,
+            "max_threads_per_block": self.device_props.max_threads_per_block, 
         }
         self.inductor_meta = {} if inductor_meta is None else inductor_meta
         self.deterministic_mode = self.inductor_meta.get("deterministic", False)
@@ -338,6 +340,7 @@ class CachingAutotuner(KernelInterface):
             name=self.fn.__name__,
             size_hints=size_hints,
             inductor_meta=self.inductor_meta,
+            triton_meta=self.triton_meta,
         )
         self.filename = filename
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -298,7 +298,9 @@ class CachingAutotuner(KernelInterface):
         self.inductor_meta = {} if inductor_meta is None else inductor_meta
         # Add device properties to inductor_meta for use by coordinate descent tuner
         self.inductor_meta["warp_size"] = self.device_props.warp_size
-        self.inductor_meta["max_threads_per_block"] = self.device_props.max_threads_per_block
+        self.inductor_meta["max_threads_per_block"] =  (
+            self.device_props.max_threads_per_block
+        )
         self.deterministic_mode = self.inductor_meta.get("deterministic", False)
 
         self.save_cache_hook = save_cache_hook

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2696,6 +2696,17 @@ def get_gpu_shared_memory() -> int:
     return driver.active.utils.get_device_properties(0).get("max_shared_mem", 0)
 
 
+def get_max_numwarps() -> int:
+    if torch.cuda.is_available():
+        warp_size = torch.cuda.get_device_properties().warp_size
+        max_threads_per_block = torch.cuda.get_device_properties().max_threads_per_block
+    else:
+        # Defaults
+        warp_size = 32
+        max_threads_per_block = 1024
+    return max_threads_per_block // warp_size
+
+
 def is_welford_reduction(reduction_type: str) -> bool:
     return reduction_type.startswith("welford")
 

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -1062,7 +1062,7 @@ static void registerCudaDeviceProperties(PyObject* module) {
           &cudaDeviceProp::maxThreadsPerMultiProcessor)
       .def_readonly(
           "max_threads_per_block", 
-          &cudaDeviceProp_t::maxThreadsPerBlock)
+          &cudaDeviceProp::maxThreadsPerBlock)
       .def_readonly("warp_size", &cudaDeviceProp::warpSize)
 #ifndef USE_ROCM
       // NVIDIA-only properties

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -1,6 +1,6 @@
 #include <ATen/ATen.h>
 #include <ATen/core/TensorBody.h>
-#include <ATen/hip/HIPConfig.h>
+#include <ATen/cuda/CUDAConfig.h>
 #include <ATen/native/ConvUtils.h>
 #include <c10/core/Device.h>
 #include <c10/core/TensorImpl.h>
@@ -13,18 +13,18 @@
 #if AT_CUDNN_ENABLED()
 
 #endif
-#include <ATen/hip/HIPContext.h>
-#include <ATen/hip/HIPGeneratorImpl.h>
-#include <ATen/hip/CachingHostAllocator.h>
-#include <ATen/hip/Sleep.h>
-#include <ATen/hip/detail/HIPHooks.h>
-#include <ATen/hip/jiterator.h>
-#include <ATen/hip/tunable/Tunable.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/CUDAGeneratorImpl.h>
+#include <ATen/cuda/CachingHostAllocator.h>
+#include <ATen/cuda/Sleep.h>
+#include <ATen/cuda/detail/CUDAHooks.h>
+#include <ATen/cuda/jiterator.h>
+#include <ATen/cuda/tunable/Tunable.h>
 #include <c10/core/AllocatorConfig.h>
 #include <c10/core/StorageImpl.h>
-#include <ATen/hip/impl/HIPCachingAllocatorMasqueradingAsCUDA.h>
-#include <c10/hip/HIPFunctions.h>
-#include <ATen/hip/HIPGraphsUtils.cuh>
+#include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/cuda/CUDAFunctions.h>
+#include <ATen/cuda/CUDAGraphsUtils.cuh>
 
 #ifdef USE_NCCL
 #include <torch/csrc/cuda/python_nccl.h>
@@ -64,7 +64,7 @@ PyObject* THCPModule_setDevice_wrap(PyObject* self, PyObject* arg) {
   auto device = THPUtils_unpackLong(arg);
 
   torch::utils::device_lazy_init(at::kCUDA);
-  c10::hip::set_device(static_cast<c10::DeviceIndex>(device), /*force*/ true);
+  c10::cuda::set_device(static_cast<c10::DeviceIndex>(device), /*force*/ true);
 
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
@@ -79,7 +79,7 @@ PyObject* THCPModule_exchangeDevice(PyObject* self, PyObject* arg) {
   }
 
   torch::utils::device_lazy_init(at::kCUDA);
-  auto current_device = c10::hip::ExchangeDevice(device_index);
+  auto current_device = c10::cuda::ExchangeDevice(device_index);
 
   return THPUtils_packDeviceIndex(current_device);
   END_HANDLE_TH_ERRORS
@@ -94,7 +94,7 @@ PyObject* THCPModule_maybeExchangeDevice(PyObject* self, PyObject* arg) {
   }
 
   torch::utils::device_lazy_init(at::kCUDA);
-  auto current_device = c10::hip::MaybeExchangeDevice(device_index);
+  auto current_device = c10::cuda::MaybeExchangeDevice(device_index);
 
   return THPUtils_packDeviceIndex(current_device);
   END_HANDLE_TH_ERRORS
@@ -104,7 +104,7 @@ PyObject* THCPModule_getDevice_wrap(PyObject* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
   torch::utils::device_lazy_init(at::kCUDA);
   // NOLINTNEXTLINE(bugprone-signed-char-misuse)
-  auto device = static_cast<int32_t>(c10::hip::current_device());
+  auto device = static_cast<int32_t>(c10::cuda::current_device());
   return THPUtils_packInt32(device);
   END_HANDLE_TH_ERRORS
 }
@@ -170,7 +170,7 @@ PyObject* THCPModule_getCurrentStream_wrap(
   TORCH_CHECK(
       THPUtils_checkLong(device_index), "invalid argument to getCurrentStream");
   auto c10_device_index = THPUtils_unpackDeviceIndex(device_index);
-  auto stream = at::hip::getCurrentHIPStreamMasqueradingAsCUDA(c10_device_index);
+  auto stream = at::cuda::getCurrentCUDAStream(c10_device_index);
   PyObject* output_tuple = PyTuple_New(3);
   PyTuple_SetItem(
       output_tuple, 0, THPUtils_packInt64(static_cast<int64_t>(stream.id())));
@@ -192,7 +192,7 @@ PyObject* THCPModule_getCurrentStream_raw(
       THPUtils_checkLong(device_index), "invalid argument to getCurrentStream");
   auto c10_device_index = THPUtils_unpackDeviceIndex(device_index);
   return PyLong_FromVoidPtr(
-      at::hip::getCurrentHIPStreamMasqueradingAsCUDA(c10_device_index).stream());
+      at::cuda::getCurrentCUDAStream(c10_device_index).stream());
   END_HANDLE_TH_ERRORS
 }
 
@@ -203,7 +203,7 @@ PyObject* THCPModule_getDefaultStream_wrap(
   TORCH_CHECK(
       THPUtils_checkLong(device_index), "invalid argument to getDefaultStream");
   auto c10_device_index = THPUtils_unpackDeviceIndex(device_index);
-  auto stream = at::hip::getDefaultHIPStreamMasqueradingAsCUDA(c10_device_index);
+  auto stream = at::cuda::getDefaultCUDAStream(c10_device_index);
   PyObject* output_tuple = PyTuple_New(3);
   PyTuple_SetItem(
       output_tuple, 0, THPUtils_packInt64(static_cast<int64_t>(stream.id())));
@@ -240,16 +240,16 @@ PyObject* THCPModule_setStream_wrap(
           &device_type)) {
   }
 
-  auto stream = at::hip::HIPStreamMasqueradingAsCUDA::unpack3(
+  auto stream = at::cuda::CUDAStream::unpack3(
       stream_id,
       static_cast<c10::DeviceIndex>(device_index),
       static_cast<c10::DeviceType>(device_type));
 
-  auto device = c10::hip::current_device();
+  auto device = c10::cuda::current_device();
   if (device != stream.device_index()) {
-    c10::hip::set_device(stream.device_index());
+    c10::cuda::set_device(stream.device_index());
   }
-  at::hip::setCurrentHIPStreamMasqueradingAsCUDA(stream);
+  at::cuda::setCurrentCUDAStream(stream);
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
@@ -258,7 +258,7 @@ PyObject* THCPModule_getCompiledVersion(PyObject* self, PyObject* noargs) {
 #if defined(USE_ROCM)
   return THPUtils_packInt64((int64_t)ROCM_VERSION);
 #else
-  return THPUtils_packInt64((int64_t)TORCH_HIP_VERSION);
+  return THPUtils_packInt64((int64_t)CUDA_VERSION);
 #endif
 }
 
@@ -285,11 +285,11 @@ PyObject* THCPModule_cudaCachingAllocator_raw_alloc(
     return nullptr;
   }
   auto size = PyLong_AsSsize_t(size_o);
-  hipStream_t stream = static_cast<hipStream_t>(PyLong_AsVoidPtr(stream_o));
+  cudaStream_t stream = static_cast<cudaStream_t>(PyLong_AsVoidPtr(stream_o));
   void* mem = nullptr;
   {
     pybind11::gil_scoped_release no_gil;
-    mem = c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::raw_alloc_with_stream(size, stream);
+    mem = c10::cuda::CUDACachingAllocator::raw_alloc_with_stream(size, stream);
   }
   return PyLong_FromVoidPtr(mem);
   END_HANDLE_TH_ERRORS
@@ -403,7 +403,7 @@ PyObject* THCPModule_cudaCachingAllocator_raw_delete(
   void* mem_ptr = PyLong_AsVoidPtr(obj);
   {
     pybind11::gil_scoped_release no_gil;
-    c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::raw_delete(mem_ptr);
+    c10::cuda::CUDACachingAllocator::raw_delete(mem_ptr);
   }
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
@@ -417,21 +417,21 @@ PyObject* THCPModule_cudaCachingAllocator_enable(
       THPUtils_checkBool(arg),
       "cudaCachingAllocator_enable expects a bool, but got ",
       THPUtils_typename(arg));
-  c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::enable(THPUtils_unpackBool(arg));
+  c10::cuda::CUDACachingAllocator::enable(THPUtils_unpackBool(arg));
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
 
 PyObject* THCPModule_getAllocatorBackend(PyObject* _unused, PyObject* noargs) {
   HANDLE_TH_ERRORS
-  return THPUtils_packString(c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::name());
+  return THPUtils_packString(c10::cuda::CUDACachingAllocator::name());
   END_HANDLE_TH_ERRORS
 }
 
 PyObject* THCPModule_cudaSynchronize(PyObject* _unused, PyObject* noargs) {
   HANDLE_TH_ERRORS {
     pybind11::gil_scoped_release no_gil;
-    c10::hip::device_synchronize();
+    c10::cuda::device_synchronize();
   }
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
@@ -484,7 +484,7 @@ PyObject* THCPModule_cudaClearFlag(PyObject* _unused, PyObject* noargs) {
 static PyGILState_STATE cudaMutexGILState;
 
 PyObject* THCPModule_cudaLockMutex(PyObject* module, PyObject* noargs) {
-  auto mutex = c10::hip::getFreeMutex();
+  auto mutex = c10::cuda::getFreeMutex();
   // This has to be a busy loop because we **absolutely need to** hold the GIL
   // or it's a recipe for a deadlock otherwise (if we let other Python threads
   // run while we have the cudaMutex, but not the GIL, they might try to e.g.
@@ -504,7 +504,7 @@ PyObject* THCPModule_cudaLockMutex(PyObject* module, PyObject* noargs) {
 }
 
 PyObject* THCPModule_cudaUnlockMutex(PyObject* module, PyObject* noargs) {
-  auto mutex = c10::hip::getFreeMutex();
+  auto mutex = c10::cuda::getFreeMutex();
   PyGILState_Release(cudaMutexGILState);
   mutex->unlock();
   Py_RETURN_NONE;
@@ -515,7 +515,7 @@ PyObject* THCPModule_hasPrimaryContext(PyObject* _unused, PyObject* arg) {
   TORCH_CHECK(
       THPUtils_checkLong(arg), "invalid argument to has_primary_context");
   auto device_index = THPUtils_unpackDeviceIndex(arg);
-  if (c10::hip::hasPrimaryContext(device_index)) {
+  if (c10::cuda::hasPrimaryContext(device_index)) {
     Py_RETURN_TRUE;
   } else {
     Py_RETURN_FALSE;
@@ -533,7 +533,7 @@ PyObject* THCPModule_getMemoryFraction(PyObject* _unused, PyObject* args) {
   }
   auto device_index = THPUtils_unpackDeviceIndex(device_o);
   return PyFloat_FromDouble(
-      c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::getMemoryFraction(device_index));
+      c10::cuda::CUDACachingAllocator::getMemoryFraction(device_index));
   END_HANDLE_TH_ERRORS
 }
 
@@ -553,7 +553,7 @@ PyObject* THCPModule_setMemoryFraction(PyObject* _unused, PyObject* args) {
   double fraction = PyFloat_AsDouble(fraction_o);
   auto device_index = THPUtils_unpackDeviceIndex(device_o);
 
-  c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::setMemoryFraction(fraction, device_index);
+  c10::cuda::CUDACachingAllocator::setMemoryFraction(fraction, device_index);
   END_HANDLE_TH_ERRORS
   Py_RETURN_NONE;
 }
@@ -570,7 +570,7 @@ PyObject* THCPModule_hostEmptyCache(PyObject* _unused, PyObject* noargs) {
 PyObject* THCPModule_emptyCache(PyObject* _unused, PyObject* noargs) {
   HANDLE_TH_ERRORS {
     pybind11::gil_scoped_release no_gil;
-    c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::emptyCache();
+    c10::cuda::CUDACachingAllocator::emptyCache();
   }
   END_HANDLE_TH_ERRORS
   Py_RETURN_NONE;
@@ -607,7 +607,7 @@ PyObject* THCPModule_memoryStats(PyObject* _unused, PyObject* arg) {
   };
 
   const DeviceStats stats =
-      c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::getDeviceStats(device_index);
+      c10::cuda::CUDACachingAllocator::getDeviceStats(device_index);
 
   py::dict result;
   result["num_alloc_retries"] = stats.num_alloc_retries;
@@ -640,7 +640,7 @@ PyObject* THCPModule_resetAccumulatedMemoryStats(
       THPUtils_checkLong(arg),
       "invalid argument to reset_accumulated_memory_stats");
   const auto device_index = THPUtils_unpackDeviceIndex(arg);
-  c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::resetAccumulatedStats(device_index);
+  c10::cuda::CUDACachingAllocator::resetAccumulatedStats(device_index);
   END_HANDLE_TH_ERRORS
   Py_RETURN_NONE;
 }
@@ -650,7 +650,7 @@ PyObject* THCPModule_resetPeakMemoryStats(PyObject* _unused, PyObject* arg) {
   TORCH_CHECK(
       THPUtils_checkLong(arg), "invalid argument to reset_peak_memory_stats");
   const auto device_index = THPUtils_unpackDeviceIndex(arg);
-  c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::resetPeakStats(device_index);
+  c10::cuda::CUDACachingAllocator::resetPeakStats(device_index);
   END_HANDLE_TH_ERRORS
   Py_RETURN_NONE;
 }
@@ -731,7 +731,7 @@ CapturedTraceback* getFromContext(
 
 PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
-  c10::hip::MempoolId_t mempool_id = {0, 0};
+  c10::cuda::MempoolId_t mempool_id = {0, 0};
   if (arg && arg != Py_None) {
     TORCH_CHECK(PyTuple_Check(arg), "mempool_id must be a tuple");
     Py_ssize_t size = PyTuple_Size(arg);
@@ -743,12 +743,12 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* arg) {
         THPUtils_checkLong(id1) && THPUtils_checkLong(id2),
         "mempool_id elements must be integers");
 
-    mempool_id = c10::hip::MempoolId_t(
+    mempool_id = c10::cuda::MempoolId_t(
         THPUtils_unpackLong(id1), THPUtils_unpackLong(id2));
   }
 
-  using c10::hip::HIPCachingAllocator::BlockInfo;
-  using c10::hip::HIPCachingAllocator::SegmentInfo;
+  using c10::cuda::CUDACachingAllocator::BlockInfo;
+  using c10::cuda::CUDACachingAllocator::SegmentInfo;
 
   py::str device_s = "device";
   py::str address_s = "address";
@@ -826,7 +826,7 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* arg) {
     return segmentDict;
   };
 
-  auto snapshot = c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::snapshot(mempool_id);
+  auto snapshot = c10::cuda::CUDACachingAllocator::snapshot(mempool_id);
 
   py::list segments;
 
@@ -848,7 +848,7 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* arg) {
   py::str oom_s = "oom";
   py::str device_free_s = "device_free";
 
-  using namespace c10::hip::HIPCachingAllocator;
+  using namespace c10::cuda::CUDACachingAllocator;
 
   auto action_to_str = [&](TraceEntry::Action action) {
     switch (action) {
@@ -915,7 +915,7 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* arg) {
   py::str expandable_segments_s = "expandable_segments";
   py::str pinned_num_register_threads_s = "pinned_num_register_threads";
   py::str release_lock_on_malloc_s = "release_lock_on_cudamalloc";
-  py::str pinned_use_host_register_s = "pinned_use_hip_host_register";
+  py::str pinned_use_host_register_s = "pinned_use_cuda_host_register";
   py::str roundup_power2_divisions_s = "roundup_power2_divisions";
   py::str graph_capture_record_stream_reuse_s =
       "graph_capture_record_stream_reuse";
@@ -979,7 +979,7 @@ PyObject* THCPModule_attachOutOfMemoryObserver(
     Py_XDECREF(result);
   };
   at::globalContext().lazyInitDevice(c10::DeviceType::CUDA);
-  c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::attachOutOfMemoryObserver(std::move(obs));
+  c10::cuda::CUDACachingAllocator::attachOutOfMemoryObserver(std::move(obs));
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
@@ -995,34 +995,34 @@ PyObject* THCPModule_cudaSetSyncDebugMode(PyObject* _unused, PyObject* arg) {
   TORCH_CHECK(
       debug_mode >= 0 && debug_mode <= 2,
       "invalid value of debug_mode, expected one of 0,1,2");
-  c10::hip::SyncDebugMode l = c10::hip::SyncDebugMode::L_DISABLED;
+  c10::cuda::SyncDebugMode l = c10::cuda::SyncDebugMode::L_DISABLED;
   switch (debug_mode) {
     case 0:
-      l = c10::hip::SyncDebugMode::L_DISABLED;
+      l = c10::cuda::SyncDebugMode::L_DISABLED;
       break;
     case 1:
-      l = c10::hip::SyncDebugMode::L_WARN;
+      l = c10::cuda::SyncDebugMode::L_WARN;
       break;
     case 2:
-      l = c10::hip::SyncDebugMode::L_ERROR;
+      l = c10::cuda::SyncDebugMode::L_ERROR;
       break;
     default:
       break; // can't happen
   }
-  c10::hip::warning_state().set_sync_debug_mode(l);
+  c10::cuda::warning_state().set_sync_debug_mode(l);
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
 
 PyObject* THCPModule_cudaGetSyncDebugMode(PyObject* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
-  auto debug_mode = c10::hip::warning_state().get_sync_debug_mode();
+  auto debug_mode = c10::cuda::warning_state().get_sync_debug_mode();
   switch (debug_mode) {
-    case c10::hip::SyncDebugMode::L_DISABLED:
+    case c10::cuda::SyncDebugMode::L_DISABLED:
       return THPUtils_packInt32(0);
-    case c10::hip::SyncDebugMode::L_WARN:
+    case c10::cuda::SyncDebugMode::L_WARN:
       return THPUtils_packInt32(1);
-    case c10::hip::SyncDebugMode::L_ERROR:
+    case c10::cuda::SyncDebugMode::L_ERROR:
       return THPUtils_packInt32(2);
     default:
       return THPUtils_packInt32(-1); // can't happen
@@ -1037,82 +1037,82 @@ PyObject* THCPModule_cudaGetSyncDebugMode(PyObject* self, PyObject* noargs) {
 static void registerCudaDeviceProperties(PyObject* module) {
   // Add _cudaDeviceProperties class to torch._C
   auto m = py::handle(module).cast<py::module>();
-  // hipUUID is defined in either cuda.h or driver_types.h
+  // CUuuid is defined in either cuda.h or driver_types.h
   // hipified to hipUUID which is defined in hip_runtime_api.h
-  py::class_<hipUUID>(m, "_CUuuid")
+  py::class_<CUuuid>(m, "_CUuuid")
       .def_property_readonly(
           "bytes",
-          [](const hipUUID& uuid) {
+          [](const CUuuid& uuid) {
             return std::vector<uint8_t>(uuid.bytes, uuid.bytes + 16);
           })
-      .def("__str__", [](const hipUUID& uuid) {
+      .def("__str__", [](const CUuuid& uuid) {
         return uuid_to_string(uuid.bytes);
       });
-  py::class_<hipDeviceProp_t>(m, "_CudaDeviceProperties")
-      .def_readonly("name", &hipDeviceProp_t::name)
-      .def_readonly("major", &hipDeviceProp_t::major)
-      .def_readonly("minor", &hipDeviceProp_t::minor)
-      .def_readonly("is_multi_gpu_board", &hipDeviceProp_t::isMultiGpuBoard)
-      .def_readonly("is_integrated", &hipDeviceProp_t::integrated)
+  py::class_<cudaDeviceProp>(m, "_CudaDeviceProperties")
+      .def_readonly("name", &cudaDeviceProp::name)
+      .def_readonly("major", &cudaDeviceProp::major)
+      .def_readonly("minor", &cudaDeviceProp::minor)
+      .def_readonly("is_multi_gpu_board", &cudaDeviceProp::isMultiGpuBoard)
+      .def_readonly("is_integrated", &cudaDeviceProp::integrated)
       .def_readonly(
-          "multi_processor_count", &hipDeviceProp_t::multiProcessorCount)
-      .def_readonly("total_memory", &hipDeviceProp_t::totalGlobalMem)
+          "multi_processor_count", &cudaDeviceProp::multiProcessorCount)
+      .def_readonly("total_memory", &cudaDeviceProp::totalGlobalMem)
       .def_readonly(
           "max_threads_per_multi_processor",
-          &hipDeviceProp_t::maxThreadsPerMultiProcessor)
+          &cudaDeviceProp::maxThreadsPerMultiProcessor)
       .def_readonly(
-        "max_threads_per_block", 
-        &hipDeviceProp_t::maxThreadsPerBlock)
-      .def_readonly("warp_size", &hipDeviceProp_t::warpSize)
+          "max_threads_per_block", 
+          &cudaDeviceProp_t::maxThreadsPerBlock)
+      .def_readonly("warp_size", &cudaDeviceProp::warpSize)
 #ifndef USE_ROCM
       // NVIDIA-only properties
       .def_property_readonly(
           "clock_rate",
-          [](const hipDeviceProp_t&) {
+          [](const cudaDeviceProp&) {
             int clk = 0;
-            AT_CUDA_CHECK(hipDeviceGetAttribute(
-                &clk, hipDeviceAttributeClockRate, c10::hip::current_device()));
+            AT_CUDA_CHECK(cudaDeviceGetAttribute(
+                &clk, cudaDevAttrClockRate, c10::cuda::current_device()));
             return clk;
           })
       .def_property_readonly(
           "memory_clock_rate",
-          [](const hipDeviceProp_t&) {
+          [](const cudaDeviceProp&) {
             int mem_clk = 0;
-            AT_CUDA_CHECK(hipDeviceGetAttribute(
+            AT_CUDA_CHECK(cudaDeviceGetAttribute(
                 &mem_clk,
-                hipDeviceAttributeMemoryClockRate,
-                c10::hip::current_device()));
+                cudaDevAttrMemoryClockRate,
+                c10::cuda::current_device()));
             return mem_clk;
           })
-      .def_readonly("memory_bus_width", &hipDeviceProp_t::memoryBusWidth)
+      .def_readonly("memory_bus_width", &cudaDeviceProp::memoryBusWidth)
       .def_readonly(
-          "shared_memory_per_block", &hipDeviceProp_t::sharedMemPerBlock)
+          "shared_memory_per_block", &cudaDeviceProp::sharedMemPerBlock)
       .def_readonly(
           "shared_memory_per_block_optin",
-          &hipDeviceProp_t::sharedMemPerBlockOptin)
+          &cudaDeviceProp::sharedMemPerBlockOptin)
       .def_readonly(
           "shared_memory_per_multiprocessor",
-          &hipDeviceProp_t::sharedMemPerMultiprocessor)
+          &cudaDeviceProp::sharedMemPerMultiprocessor)
 #endif
 #if (defined(USE_ROCM) && ROCM_VERSION >= 60100) || !USE_ROCM
       .def_readonly(
-          "regs_per_multiprocessor", &hipDeviceProp_t::regsPerMultiprocessor)
+          "regs_per_multiprocessor", &cudaDeviceProp::regsPerMultiprocessor)
 #endif
       // HIP-only property; reuse name attribute for CUDA builds
       .def_readonly(
           "gcnArchName",
 #if USE_ROCM
-          &hipDeviceProp_t::gcnArchName
+          &cudaDeviceProp::gcnArchName
 #else
-          &hipDeviceProp_t::name
+          &cudaDeviceProp::name
 #endif // USE_ROCM
           )
-      .def_readonly("uuid", &hipDeviceProp_t::uuid)
-      .def_readonly("pci_bus_id", &hipDeviceProp_t::pciBusID)
-      .def_readonly("pci_device_id", &hipDeviceProp_t::pciDeviceID)
-      .def_readonly("pci_domain_id", &hipDeviceProp_t::pciDomainID)
-      .def_readonly("L2_cache_size", &hipDeviceProp_t::l2CacheSize)
-      .def("__repr__", [](const hipDeviceProp_t& prop) {
+      .def_readonly("uuid", &cudaDeviceProp::uuid)
+      .def_readonly("pci_bus_id", &cudaDeviceProp::pciBusID)
+      .def_readonly("pci_device_id", &cudaDeviceProp::pciDeviceID)
+      .def_readonly("pci_domain_id", &cudaDeviceProp::pciDomainID)
+      .def_readonly("L2_cache_size", &cudaDeviceProp::l2CacheSize)
+      .def("__repr__", [](const cudaDeviceProp& prop) {
         std::ostringstream stream;
         stream << "_CudaDeviceProperties(name='" << prop.name
                << "', major=" << prop.major << ", minor=" << prop.minor
@@ -1147,15 +1147,15 @@ static void registerCudaDeviceProperties(PyObject* module) {
           bool)>(torch::cuda::_record_memory_history));
 
   m.def("_cuda_isHistoryEnabled", []() {
-    return c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::isHistoryEnabled();
+    return c10::cuda::CUDACachingAllocator::isHistoryEnabled();
   });
 
   m.def("_cuda_setMemoryMetadata", [](const std::string& metadata) {
-    c10::hip::HIPCachingAllocator::setUserMetadata(metadata);
+    c10::cuda::CUDACachingAllocator::setUserMetadata(metadata);
   });
 
   m.def("_cuda_getMemoryMetadata", []() {
-    return c10::hip::HIPCachingAllocator::getUserMetadata();
+    return c10::cuda::CUDACachingAllocator::getUserMetadata();
   });
 
   m.def("_cuda_get_conv_benchmark_empty_cache", []() {
@@ -1178,7 +1178,7 @@ void removeStorageDeleterFns(
     auto ptr = stale_storage->data_ptr().get();
     auto allocated_pointer = definitely_stale_pointers.find(ptr);
     TORCH_CHECK(allocated_pointer != definitely_stale_pointers.end());
-    auto t = c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::get();
+    auto t = c10::cuda::CUDACachingAllocator::get();
     bool succeeded = stale_storage->mutable_data_ptr().compare_exchange_deleter(
         t->raw_deleter(), &c10::detail::deleteNothing);
 
@@ -1190,7 +1190,7 @@ void removeStorageDeleterFns(
 
 void addStorageDeleterFns(
     std::vector<c10::StorageImpl*>& storages_to_add_deleters_to,
-    c10::hip::HIPCachingAllocator::CheckpointDelta& delta) {
+    c10::cuda::CUDACachingAllocator::CheckpointDelta& delta) {
   std::unordered_map<void*, c10::StorageImpl*> storages;
   for (auto& storage : storages_to_add_deleters_to) {
     storages[storage->data_ptr().get()] = storage;
@@ -1213,8 +1213,8 @@ static void registerCudaPluggableAllocator(PyObject* module) {
 
   // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<
-      c10::hip::HIPCachingAllocator::HIPAllocator,
-      std::shared_ptr<c10::hip::HIPCachingAllocator::HIPAllocator>>(
+      c10::cuda::CUDACachingAllocator::CUDAAllocator,
+      std::shared_ptr<c10::cuda::CUDACachingAllocator::CUDAAllocator>>(
       m, "_cuda_CUDAAllocator");
   m.def("_cuda_getAllocator", []() {
     return py::cast(torch::cuda::CUDAPluggableAllocator::getCurrentAllocator());
@@ -1222,13 +1222,13 @@ static void registerCudaPluggableAllocator(PyObject* module) {
 
   m.def(
       "_cuda_changeCurrentAllocator",
-      [](const std::shared_ptr<c10::hip::HIPCachingAllocator::HIPAllocator>&
+      [](const std::shared_ptr<c10::cuda::CUDACachingAllocator::CUDAAllocator>&
              allocator) {
         torch::cuda::CUDAPluggableAllocator::changeCurrentAllocator(allocator);
       });
   py::class_<
       torch::cuda::CUDAPluggableAllocator::CUDAPluggableAllocator,
-      c10::hip::HIPCachingAllocator::HIPAllocator,
+      c10::cuda::CUDACachingAllocator::CUDAAllocator,
       std::shared_ptr<
           torch::cuda::CUDAPluggableAllocator::CUDAPluggableAllocator>>(
       m, "_CUDAPluggableAllocator")
@@ -1276,7 +1276,7 @@ static void registerCudaPluggableAllocator(PyObject* module) {
           "set_record_stream_fn",
           [](torch::cuda::CUDAPluggableAllocator::CUDAPluggableAllocator& self,
              uint64_t func_ptr) {
-            using FuncType = void(void*, hipStream_t);
+            using FuncType = void(void*, cudaStream_t);
             std::function<FuncType> func =
                 // NOLINTNEXTLINE(performance-no-int-to-ptr)
                 reinterpret_cast<FuncType*>(func_ptr);
@@ -1287,7 +1287,7 @@ static void registerCudaPluggableAllocator(PyObject* module) {
           [](torch::cuda::CUDAPluggableAllocator::CUDAPluggableAllocator& self,
              uint64_t func_ptr) {
             using FuncType = void(
-                int, c10::hip::MempoolId_t, std::function<bool(hipStream_t)>);
+                int, c10::cuda::MempoolId_t, std::function<bool(cudaStream_t)>);
             std::function<FuncType> func =
                 // NOLINTNEXTLINE(performance-no-int-to-ptr)
                 reinterpret_cast<FuncType*>(func_ptr);
@@ -1297,7 +1297,7 @@ static void registerCudaPluggableAllocator(PyObject* module) {
           "set_end_allocate_to_pool_fn",
           [](torch::cuda::CUDAPluggableAllocator::CUDAPluggableAllocator& self,
              uint64_t func_ptr) {
-            using FuncType = void(int, c10::hip::MempoolId_t);
+            using FuncType = void(int, c10::cuda::MempoolId_t);
             std::function<FuncType> func =
                 // NOLINTNEXTLINE(performance-no-int-to-ptr)
                 reinterpret_cast<FuncType*>(func_ptr);
@@ -1307,15 +1307,15 @@ static void registerCudaPluggableAllocator(PyObject* module) {
           "set_release_pool",
           [](torch::cuda::CUDAPluggableAllocator::CUDAPluggableAllocator& self,
              uint64_t func_ptr) {
-            using FuncType = void(int, c10::hip::MempoolId_t);
+            using FuncType = void(int, c10::cuda::MempoolId_t);
             std::function<FuncType> func =
                 // NOLINTNEXTLINE(performance-no-int-to-ptr)
                 reinterpret_cast<FuncType*>(func_ptr);
             self.set_release_pool(func);
           });
   m.def("_cuda_customAllocator", [](uint64_t malloc_ptr, uint64_t free_ptr) {
-    using MallocFuncType = void*(size_t, int, hipStream_t);
-    using FreeFuncType = void(void*, size_t, int, hipStream_t);
+    using MallocFuncType = void*(size_t, int, cudaStream_t);
+    using FreeFuncType = void(void*, size_t, int, cudaStream_t);
     std::function<MallocFuncType> malloc_fn =
         // NOLINTNEXTLINE(performance-no-int-to-ptr)
         reinterpret_cast<MallocFuncType*>(malloc_ptr);
@@ -1328,25 +1328,25 @@ static void registerCudaPluggableAllocator(PyObject* module) {
 
   // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<
-      c10::hip::HIPCachingAllocator::AllocatorState,
-      std::shared_ptr<c10::hip::HIPCachingAllocator::AllocatorState>>(
+      c10::cuda::CUDACachingAllocator::AllocatorState,
+      std::shared_ptr<c10::cuda::CUDACachingAllocator::AllocatorState>>(
       m, "_cuda_CUDAAllocator_AllocatorState");
 
   m.def(
       "_cuda_getCheckpointState",
-      [](c10::DeviceIndex device, c10::hip::MempoolId_t id) {
-        return c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::getCheckpointState(device, id);
+      [](c10::DeviceIndex device, c10::cuda::MempoolId_t id) {
+        return c10::cuda::CUDACachingAllocator::getCheckpointState(device, id);
       });
 
   m.def("_free_And_Remove_DeleterFn", [](size_t storage_impl_ptr) {
     // NOLINTNEXTLINE(performance-no-int-to-ptr)
     c10::StorageImpl* storage_impl = (c10::StorageImpl*)storage_impl_ptr;
-    auto alloc = c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::get();
+    auto alloc = c10::cuda::CUDACachingAllocator::get();
     auto data_ptr = storage_impl->data_ptr().get();
     bool succeeded = storage_impl->mutable_data_ptr().compare_exchange_deleter(
         alloc->raw_deleter(), c10::detail::deleteNothing);
     TORCH_CHECK(succeeded, "Expected standard deleter");
-    c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::raw_delete(data_ptr);
+    c10::cuda::CUDACachingAllocator::raw_delete(data_ptr);
   });
 
   m.def(
@@ -1366,7 +1366,7 @@ static void registerCudaPluggableAllocator(PyObject* module) {
   m.def("_has_Standard_Deleter", [](size_t storage_impl_ptr) {
     // NOLINTNEXTLINE(performance-no-int-to-ptr)
     c10::StorageImpl* storage_impl = (c10::StorageImpl*)storage_impl_ptr;
-    auto alloc = c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::get();
+    auto alloc = c10::cuda::CUDACachingAllocator::get();
     return (storage_impl->data_ptr().get_deleter() == alloc->raw_deleter());
   });
 
@@ -1404,10 +1404,10 @@ static void registerCudaPluggableAllocator(PyObject* module) {
   m.def(
       "_cuda_beginAllocateCurrentStreamToPool",
       [](c10::DeviceIndex device, at::cuda::MempoolId_t mempool_id) {
-        auto stream = at::hip::getCurrentHIPStreamMasqueradingAsCUDA(device);
+        auto stream = at::cuda::getCurrentCUDAStream(device);
         TORCH_CHECK(stream, "Expected stream capture to be under way");
-        c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::beginAllocateToPool(
-            device, mempool_id, [stream](hipStream_t target) {
+        c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+            device, mempool_id, [stream](cudaStream_t target) {
               return target == stream;
             });
       });
@@ -1415,8 +1415,8 @@ static void registerCudaPluggableAllocator(PyObject* module) {
   m.def(
       "_cuda_beginAllocateToPool",
       [](c10::DeviceIndex device, at::cuda::MempoolId_t mempool_id) {
-        c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::beginAllocateToPool(
-            device, mempool_id, [](hipStream_t) { return true; });
+        c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+            device, mempool_id, [](cudaStream_t) { return true; });
       });
 
   m.def(
@@ -1424,8 +1424,8 @@ static void registerCudaPluggableAllocator(PyObject* module) {
       [](c10::DeviceIndex device, at::cuda::MempoolId_t mempool_id) {
         auto tid = std::this_thread::get_id();
 
-        c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::beginAllocateToPool(
-            device, mempool_id, [=](hipStream_t) {
+        c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+            device, mempool_id, [=](cudaStream_t) {
               auto current_tid = std::this_thread::get_id();
               return current_tid == tid;
             });
@@ -1434,13 +1434,13 @@ static void registerCudaPluggableAllocator(PyObject* module) {
   m.def(
       "_cuda_endAllocateToPool",
       [](c10::DeviceIndex device, at::cuda::MempoolId_t mempool_id) {
-        c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::endAllocateToPool(device, mempool_id);
+        c10::cuda::CUDACachingAllocator::endAllocateToPool(device, mempool_id);
       });
 
   m.def(
       "_cuda_releasePool",
       [](c10::DeviceIndex device, at::cuda::MempoolId_t mempool_id) {
-        c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::releasePool(device, mempool_id);
+        c10::cuda::CUDACachingAllocator::releasePool(device, mempool_id);
       });
 
   m.def(
@@ -1454,14 +1454,14 @@ static void registerCudaPluggableAllocator(PyObject* module) {
           // NOLINTNEXTLINE(performance-no-int-to-ptr)
           allocations.insert(reinterpret_cast<void*>(py::cast<size_t>(elem)));
         }
-        return c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::checkPoolLiveAllocations(
+        return c10::cuda::CUDACachingAllocator::checkPoolLiveAllocations(
             device, mempool_id, allocations);
       });
 
   m.def(
       "_cuda_setCheckpointPoolState",
       [](c10::DeviceIndex device,
-         std::shared_ptr<c10::hip::HIPCachingAllocator::AllocatorState> pps,
+         std::shared_ptr<c10::cuda::CUDACachingAllocator::AllocatorState> pps,
          const std::vector<size_t>& stale_storages_ptr,
          const std::vector<size_t>& storages_to_add_deleters_to_ptr = {}) {
         std::unordered_set<c10::StorageImpl*> ptr_set;
@@ -1475,7 +1475,7 @@ static void registerCudaPluggableAllocator(PyObject* module) {
             ptr_set.insert(ptr);
           }
         }
-        auto delta = c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::setCheckpointPoolState(
+        auto delta = c10::cuda::CUDACachingAllocator::setCheckpointPoolState(
             device, std::move(pps));
         auto& freed_pointers = delta.ptrs_freed;
 
@@ -1518,7 +1518,7 @@ static void bindGetDeviceProperties(PyObject* module) {
   auto m = py::handle(module).cast<py::module>();
   m.def(
       "_get_device_properties",
-      [](c10::DeviceIndex device) -> hipDeviceProp_t* {
+      [](c10::DeviceIndex device) -> cudaDeviceProp* {
         return at::cuda::getDeviceProperties(device);
       },
       py::return_value_policy::reference);
@@ -1550,7 +1550,7 @@ static PyObject* THCPModule_initExtension(PyObject* self, PyObject* noargs) {
     }
   };
 
-  auto num_gpus = c10::hip::device_count();
+  auto num_gpus = c10::cuda::device_count();
   auto default_cuda_generators = PyTuple_New(static_cast<Py_ssize_t>(num_gpus));
   for (const auto i : c10::irange(num_gpus)) {
     auto cast_gen = THPGenerator_initDefaultGenerator(
@@ -1569,7 +1569,7 @@ PyObject* THCPModule_getCurrentBlasHandle_wrap(
     PyObject* self,
     PyObject* noargs) {
   HANDLE_TH_ERRORS
-  hipblasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
   return PyLong_FromVoidPtr(handle);
   END_HANDLE_TH_ERRORS
 }
@@ -1976,11 +1976,11 @@ static void initCudaMethodBindings(PyObject* module) {
   m.def(
       "_cuda_getStreamFromExternal",
       [](uintptr_t data_ptr, c10::DeviceIndex device_index) {
-        hipStream_t ext_stream =
+        cudaStream_t ext_stream =
             // NOLINTNEXTLINE(performance-no-int-to-ptr)
-            reinterpret_cast<hipStream_t>(reinterpret_cast<void*>(data_ptr));
-        at::hip::HIPStreamMasqueradingAsCUDA stream =
-            c10::hip::getStreamFromExternalMasqueradingAsCUDA(ext_stream, device_index);
+            reinterpret_cast<cudaStream_t>(reinterpret_cast<void*>(data_ptr));
+        at::cuda::CUDAStream stream =
+            c10::cuda::getStreamFromExternal(ext_stream, device_index);
         return std::make_tuple(
             stream.id(), stream.device_index(), stream.device_type());
       });

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -1061,8 +1061,7 @@ static void registerCudaDeviceProperties(PyObject* module) {
           "max_threads_per_multi_processor",
           &cudaDeviceProp::maxThreadsPerMultiProcessor)
       .def_readonly(
-          "max_threads_per_block", 
-          &cudaDeviceProp::maxThreadsPerBlock)
+          "max_threads_per_block", &cudaDeviceProp::maxThreadsPerBlock)
       .def_readonly("warp_size", &cudaDeviceProp::warpSize)
 #ifndef USE_ROCM
       // NVIDIA-only properties


### PR DESCRIPTION
Current max_numwarps is incorrect on ROCm as warp_size is not taken into account. This PR resolves this and handles in a none hardcoded way using device props when available.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben