### PR TITLE
[inductor] fix test_save_graph_repro on Windows.

### DIFF
--- a/test/dynamo/test_after_aot.py
+++ b/test/dynamo/test_after_aot.py
@@ -9,6 +9,7 @@ import unittest
 
 import torch._dynamo.test_case
 from torch._dynamo.repro.after_aot import InputReader, InputWriter, save_graph_repro
+from torch._inductor.cpp_builder import normalize_path_separator
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing._internal.common_utils import IS_FBCODE
 from torch.utils._traceback import report_compile_source_on_error
@@ -32,7 +33,7 @@ class TestAfterAot(torch._dynamo.test_case.TestCase):
         gm = make_fx(f)(*args)
         with tempfile.TemporaryDirectory() as d:
             save_graph_repro(buf, gm, args, "inductor_accuracy", save_dir=d)
-            r = buf.getvalue()
+            r = normalize_path_separator(buf.getvalue())
             with report_compile_source_on_error():
                 exec(r, {"__compile_source__": r})
 

--- a/test/dynamo/test_after_aot.py
+++ b/test/dynamo/test_after_aot.py
@@ -9,7 +9,6 @@ import unittest
 
 import torch._dynamo.test_case
 from torch._dynamo.repro.after_aot import InputReader, InputWriter, save_graph_repro
-from torch._inductor.cpp_builder import normalize_path_separator
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing._internal.common_utils import IS_FBCODE
 from torch.utils._traceback import report_compile_source_on_error
@@ -32,7 +31,7 @@ class TestAfterAot(torch._dynamo.test_case.TestCase):
 
         gm = make_fx(f)(*args)
         with tempfile.TemporaryDirectory() as d:
-            save_graph_repro(buf, gm, args, "inductor_accuracy", save_dir=normalize_path_separator(d))
+            save_graph_repro(buf, gm, args, "inductor_accuracy", save_dir=d)
             r = buf.getvalue()
             with report_compile_source_on_error():
                 exec(r, {"__compile_source__": r})

--- a/test/dynamo/test_after_aot.py
+++ b/test/dynamo/test_after_aot.py
@@ -32,8 +32,8 @@ class TestAfterAot(torch._dynamo.test_case.TestCase):
 
         gm = make_fx(f)(*args)
         with tempfile.TemporaryDirectory() as d:
-            save_graph_repro(buf, gm, args, "inductor_accuracy", save_dir=d)
-            r = normalize_path_separator(buf.getvalue())
+            save_graph_repro(buf, gm, args, "inductor_accuracy", save_dir=normalize_path_separator(d))
+            r = buf.getvalue()
             with report_compile_source_on_error():
                 exec(r, {"__compile_source__": r})
 

--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -40,6 +40,7 @@ import torch._prims_common as utils
 import torch._subclasses.meta_utils
 from torch import Tensor
 from torch._dynamo.testing import rand_strided
+from torch._inductor.cpp_builder import normalize_path_separator
 from torch._prims_common import is_float_dtype
 from torch.hub import tqdm
 from torch.multiprocessing.reductions import StorageWeakRef
@@ -292,10 +293,10 @@ def generate_env_vars_string(*, stable_output: bool = False) -> str:
         if filter(key)
     ]
     config_string = "\n".join(config_lines)
-    return f"""\
+    return normalize_path_separator(f"""\
 import os
 {config_string}
-    """
+    """)
 
 
 def generate_config_string(*, stable_output: bool = False) -> str:

--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -58,8 +58,8 @@ from torch._dynamo.debug_utils import (
 )
 from torch._dynamo.utils import clone_inputs, counters, same
 from torch._environment import is_fbcode
-from torch._inductor.output_code import OutputCode
 from torch._inductor.cpp_builder import normalize_path_separator
+from torch._inductor.output_code import OutputCode
 from torch._library.fake_class_registry import FakeScriptObject
 from torch._ops import OpOverload
 from torch.fx.experimental.proxy_tensor import make_fx
@@ -291,7 +291,7 @@ def generate_compiler_repro_string(
     has_distributed_ops: bool = False,
 ) -> str:
     if save_dir is not None:
-        save_dir=normalize_path_separator(save_dir)    
+        save_dir = normalize_path_separator(save_dir)
     # Add distributed imports if needed
     distributed_imports = ""
     if has_distributed_ops:
@@ -399,9 +399,9 @@ def save_graph_repro(
             "Repro is not generated due to existence of BackwardState in graph input"
         )
         return
-    
+
     if save_dir is not None:
-        save_dir=normalize_path_separator(save_dir)
+        save_dir = normalize_path_separator(save_dir)
 
     # Check if the graph contains distributed operations
     has_distributed_ops = any(

--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -304,7 +304,7 @@ from torch.testing._internal.distributed.fake_pg import FakeStore
 
     model_str = textwrap.dedent(
         f"""
-{normalize_path_separator(generate_env_vars_string(stable_output=stable_output))}
+{generate_env_vars_string(stable_output=stable_output)}
 import torch
 from torch import tensor, device
 import torch.fx as fx

--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -59,6 +59,7 @@ from torch._dynamo.debug_utils import (
 from torch._dynamo.utils import clone_inputs, counters, same
 from torch._environment import is_fbcode
 from torch._inductor.output_code import OutputCode
+from torch._inductor.cpp_builder import normalize_path_separator
 from torch._library.fake_class_registry import FakeScriptObject
 from torch._ops import OpOverload
 from torch.fx.experimental.proxy_tensor import make_fx
@@ -289,6 +290,8 @@ def generate_compiler_repro_string(
     stable_hash: bool = False,
     has_distributed_ops: bool = False,
 ) -> str:
+    if save_dir is not None:
+        save_dir=normalize_path_separator(save_dir)    
     # Add distributed imports if needed
     distributed_imports = ""
     if has_distributed_ops:
@@ -301,7 +304,7 @@ from torch.testing._internal.distributed.fake_pg import FakeStore
 
     model_str = textwrap.dedent(
         f"""
-{generate_env_vars_string(stable_output=stable_output)}
+{normalize_path_separator(generate_env_vars_string(stable_output=stable_output))}
 import torch
 from torch import tensor, device
 import torch.fx as fx
@@ -396,6 +399,9 @@ def save_graph_repro(
             "Repro is not generated due to existence of BackwardState in graph input"
         )
         return
+    
+    if save_dir is not None:
+        save_dir=normalize_path_separator(save_dir)
 
     # Check if the graph contains distributed operations
     has_distributed_ops = any(


### PR DESCRIPTION
The issue is caused by Windows path separator work as escape character. Fixed by `normalize_path_separator` in torch front end codegen.

Error message:
<img width="855" height="542" alt="image" src="https://github.com/user-attachments/assets/ad08b521-05e6-4c93-9507-ad19c68ac7b5" />

Fixed:
<img width="855" height="312" alt="image" src="https://github.com/user-attachments/assets/4a0a142a-2dbe-4226-a4cb-8eacfab2c3fc" />

cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela