### PR TITLE
[ez][CI] Turn off keep-going on main for ROCm

### DIFF
--- a/.github/scripts/filter_test_configs.py
+++ b/.github/scripts/filter_test_configs.py
@@ -26,11 +26,8 @@ logging.basicConfig(level=logging.INFO)
 
 
 def is_rocm_job(job_name: Optional[str]) -> bool:
-    if not job_name:
-        return False
-
     # ROCm jobs are expected to have "rocm" in their name
-    return "rocm" in job_name.lower()
+    return job_name is not None and "rocm" in job_name.lower()
 
 
 def is_cuda_or_rocm_job(job_name: Optional[str]) -> bool:


### PR DESCRIPTION
ROCm machines don't have permission to put objects to S3 so the failures won't show up early on HUD

If people don't care about the failure showing up early, then this doesn't matter and you can close the PR

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd