### PR TITLE
[texi26] run through an example with MOE.

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -957,11 +957,11 @@ class Module:
 
             from torch._subclasses.fake_tensor import FakeTensor
 
-            # subclasses may have multiple child tensors so we need to use swap_tensors
+            # subclasses may have multiple child tensors so we need to use swap_tensors            
             p_should_use_swap_tensors = (
                 should_use_swap_tensors
                 or is_traceable_wrapper_subclass(param_applied)
-                or isinstance(param, FakeTensor)
+                or isinstance(param, FakeTensor) if param.device.type!='cpu' else False
             )
 
             param_grad = param.grad


### PR DESCRIPTION
Summary:
Run through an example with MOE" implements Mixture of Experts (MoE) functionality in the TEXI model architecture. Key changes include:

1.  Configuration changes:

    *   Switched from standard Transformer to MoETransformer by creating a new config file `vtexi_25b_moe.yaml`
    *   Set number of experts to 4
    *   Enabled soft MoE routing with `is_softMoE: True`
2.  Code modifications:

    *   Updated the `moe_transformer.py` to support soft MoE routing by adding parameters:
        *   `is_softMoE` (default: False)
        *   `softMoE_temperature` (default: 0.01)
    *   Modified the sparse MLP configuration to use these parameters instead of hardcoded values
    *   Updated references in BUCK files and Python code to point to the new MoE configuration
3.  Performance optimization:

    *   Modified tensor handling in `module.py` to exclude CPU tensors from the FakeTensor check, preventing unnecessary tensor swapping

The changes enable the model to use a soft Mixture of Experts approach where routing between experts is done with a softmax function rather than token-initiated routing, avoiding triggering of DDDS.
dynamic-MOE vs soft-MOE
https://docs.google.com/document/d/11snR6YrdQCwahyQCP61hWnww8voaZ8qtw7TFN61eqm8/edit?tab=t.0#bookmark=id.vgyjua5vuj6

Test Plan:
```
make -f ai_codesign/nonprod/xi_mtia_bench/texi25b/Makefile check_warmup

```
P1880892716

Rollback Plan:

Differential Revision: D78957047
