### PR TITLE
Remove numpy dependency from onnx

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -974,6 +974,8 @@ test_without_numpy() {
   if [[ "${TEST_CONFIG}" == *dynamo_wrapped* ]]; then
     python -c "import sys;sys.path.insert(0, 'fake_numpy');import torch;torch.compile(lambda x:print(x))('Hello World')"
   fi
+  # Regression test for https://github.com/pytorch/pytorch/pull/157734 (torch.onnx should be importable without numpy)
+  python -c "import sys;sys.path.insert(0, 'fake_numpy');import torch; import torch.onnx"
   popd
 }
 

--- a/torch/onnx/_internal/exporter/_onnx_program.py
+++ b/torch/onnx/_internal/exporter/_onnx_program.py
@@ -119,8 +119,8 @@ def _create_value_mapping(graph: ir.Graph) -> dict[str, ir.Value]:
 
 def _to_ort_value(input: torch.Tensor | int | float | str | bool) -> ort.OrtValue:
     """Convert a PyTorch tensor to an ONNX Runtime OrtValue."""
-    import onnxruntime as ort
     import numpy as np
+    import onnxruntime as ort
 
     from torch.onnx._internal.exporter import _core
 

--- a/torch/onnx/_internal/exporter/_onnx_program.py
+++ b/torch/onnx/_internal/exporter/_onnx_program.py
@@ -15,8 +15,6 @@ import textwrap
 import warnings
 from typing import Any, Callable, TYPE_CHECKING
 
-import numpy as np
-
 import torch
 from torch.onnx._internal._lazy_import import onnx, onnxscript_apis, onnxscript_ir as ir
 from torch.onnx._internal.exporter import _dynamic_shapes, _ir_passes
@@ -122,6 +120,7 @@ def _create_value_mapping(graph: ir.Graph) -> dict[str, ir.Value]:
 def _to_ort_value(input: torch.Tensor | int | float | str | bool) -> ort.OrtValue:
     """Convert a PyTorch tensor to an ONNX Runtime OrtValue."""
     import onnxruntime as ort
+    import numpy as np
 
     from torch.onnx._internal.exporter import _core
 


### PR DESCRIPTION
One should not expect numpy to be there during onnx import
Forward fix for : https://github.com/pytorch/pytorch/pull/157734
Added regression test to `test_without_numpy` function

Test plan: Run `python -c "import sys;sys.path.insert(0, 'fake_numpy');import torch; import torch.onnx"` with/without this fix