### PR TITLE
[pytorch] bypass the swap enforcement if the device is cpu, to save uncecessary swap.

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -961,7 +961,7 @@ class Module:
             p_should_use_swap_tensors = (
                 should_use_swap_tensors
                 or is_traceable_wrapper_subclass(param_applied)
-                or isinstance(param, FakeTensor)
+                or isinstance(param, FakeTensor) if param.device.type!='cpu' else False
             )
 
             param_grad = param.grad


### PR DESCRIPTION
Summary:
Bypass the enforced FakeTensor swap when device is cpu to reduce unnecessary tensor swaps.

Rollback Plan:

Differential Revision: D78997117

@pytorchbot label "topic: not user facing


