### PR TITLE
Make NestedTensor.lengths() always return valid values

### DIFF
--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -1890,10 +1890,7 @@ def index_put_(func, *args, **kwargs):
     # We can run on the underlying values directly
 
     # Validate indices
-    if inp.lengths() is None:
-        lengths = inp.offsets().diff()
-    else:
-        lengths = inp.lengths()
+    lengths = inp.lengths()
     torch._assert_async(
         torch.all(indices[inp._ragged_idx] < lengths),
         "Some indices in the ragged dimension are out of bounds!",


### PR DESCRIPTION
It seems like we have a pattern of sometimes using `self._lengths` and sometimes using `self._offsets.diff()`. I don't have a strong understanding of this code, but I think it has to do with whether the nested tensor is contiguous or not?

It seems annoying to have to always check the contiguity, so it seems easier to set this once in the `lengths` function.