### PR TITLE
[DTensor] Improve `sort` strategy

### DIFF
--- a/torch/distributed/tensor/_op_schema.py
+++ b/torch/distributed/tensor/_op_schema.py
@@ -267,11 +267,10 @@ class RuntimeSchemaInfo:
     whether to re-run sharding prop or not 2. to determine if we need pytree
     """
 
-    # This static_argnum records static arg "starting index" for ops that have
-    # non-tensor args/kwargs which would affect output or sharding propagation
-    # results. All args starting from this index would be hashed to our sharding
-    # cache. Note that only a few ops need this information, e.g. view,
-    # transpose, var.dim, etc.
+    # This static_argnum records static arg "starting index" for ops that have non-tensor
+    # args/kwargs which would affect sharding propagation results. All args starting from
+    # this index would be hashed to our sharding cache.
+    # Note that only a few ops need this information, e.g. view, transpose, var.dim, etc.
     static_argnum: int = 100
     # This static_kwargkey records static kwarg names which would affect sharding prop
     static_kwargkey: Optional[list[str]] = None

--- a/torch/distributed/tensor/_op_schema.py
+++ b/torch/distributed/tensor/_op_schema.py
@@ -267,10 +267,11 @@ class RuntimeSchemaInfo:
     whether to re-run sharding prop or not 2. to determine if we need pytree
     """
 
-    # This static_argnum records static arg "starting index" for ops that have non-tensor
-    # args/kwargs which would affect sharding propagation results. All args starting from
-    # this index would be hashed to our sharding cache.
-    # Note that only a few ops need this information, e.g. view, transpose, var.dim, etc.
+    # This static_argnum records static arg "starting index" for ops that have
+    # non-tensor args/kwargs which would affect output or sharding propagation
+    # results. All args starting from this index would be hashed to our sharding
+    # cache. Note that only a few ops need this information, e.g. view,
+    # transpose, var.dim, etc.
     static_argnum: int = 100
     # This static_kwargkey records static kwarg names which would affect sharding prop
     static_kwargkey: Optional[list[str]] = None

--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -1176,8 +1176,7 @@ def sort_strategy(op_schema: OpSchema) -> OpStrategy:
 @register_op_strategy(
     [aten.histc.default],
     # strategy choice depends on the value of 'min' and 'max' kwargs, which are position 2 and 3
-    # result depends on the value of 'bins', 'min' and 'max' kwargs, which is from position 1
-    schema_info=RuntimeSchemaInfo(1),
+    schema_info=RuntimeSchemaInfo(2),
 )
 def histc_strategy(op_schema: OpSchema) -> OpStrategy:
     input_strategy = cast(OpStrategy, op_schema.args_schema[0])

--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -1119,7 +1119,6 @@ def fused_rms_norm_bwd_strategy(op_schema: OpSchema) -> OpStrategy:
     schema_info=RuntimeSchemaInfo(2),
 )
 def topk_strategy(op_schema: OpSchema) -> OpStrategy:
-    torch.distributed.breakpoint()
     input_strategy = cast(OpStrategy, op_schema.args_schema[0])
     topk_dim = (
         cast(int, op_schema.args_schema[2]) if len(op_schema.args_schema) > 2 else -1

--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -1147,7 +1147,7 @@ def topk_strategy(op_schema: OpSchema) -> OpStrategy:
 @register_op_strategy(
     [aten.histc.default],
     # strategy choice depends on the value of 'min' and 'max' kwargs, which are position 2 and 3
-    # result depends on the value of 'bins', 'min' and 'max' kwargs, which from position 1
+    # result depends on the value of 'bins', 'min' and 'max' kwargs, which is from position 1
     schema_info=RuntimeSchemaInfo(1),
 )
 def histc_strategy(op_schema: OpSchema) -> OpStrategy:

--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -1147,7 +1147,8 @@ def topk_strategy(op_schema: OpSchema) -> OpStrategy:
 @register_op_strategy(
     [aten.histc.default],
     # strategy choice depends on the value of 'min' and 'max' kwargs, which are position 2 and 3
-    schema_info=RuntimeSchemaInfo(2),
+    # result depends on the value of 'bins', 'min' and 'max' kwargs, which from position 1
+    schema_info=RuntimeSchemaInfo(1),
 )
 def histc_strategy(op_schema: OpSchema) -> OpStrategy:
     input_strategy = cast(OpStrategy, op_schema.args_schema[0])

--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -1114,49 +1114,8 @@ def fused_rms_norm_bwd_strategy(op_schema: OpSchema) -> OpStrategy:
     return _common_norm_backward_strategy(op_schema, rms_norm=True)
 
 
-@register_op_strategy(
-    [aten.topk.default],
-    schema_info=RuntimeSchemaInfo(2),
-)
-def topk_strategy(op_schema: OpSchema) -> OpStrategy:
+def sort_strategy(op_schema: OpSchema, sort_dim: int) -> OpStrategy:
     input_strategy = cast(OpStrategy, op_schema.args_schema[0])
-    topk_dim = (
-        cast(int, op_schema.args_schema[2]) if len(op_schema.args_schema) > 2 else -1
-    )
-    topk_dim = normalize_dim(topk_dim, input_strategy.ndim)
-
-    single_mesh_dim_strategies = []
-
-    # two outputs (values, indices), 1 input
-    # replicate always works
-    all_replicate: PlacementList = [Replicate()] * 3
-    single_mesh_dim_strategies.append(all_replicate)
-
-    # every dim except topk dim should work
-    for dim in range(input_strategy.ndim):
-        if dim != topk_dim:
-            dim_shardings: PlacementList = [Shard(dim)] * 3
-            single_mesh_dim_strategies.append(dim_shardings)
-    # TODO: topk on sharded dim requires non-trival reduction, address it later
-
-    return expand_to_full_mesh_op_strategy(
-        input_strategy.mesh, op_schema, single_mesh_dim_strategies, input_index=2
-    )
-
-
-@register_op_strategy(
-    aten.sort.default,
-    schema_info=RuntimeSchemaInfo(
-        1,
-    ),
-)
-def sort_strategy(op_schema: OpSchema) -> OpStrategy:
-    # mostly copy paste from topk_strategy
-    input_strategy = op_schema.args_schema[0]
-    assert isinstance(input_strategy, OpStrategy)
-    sort_dim = -1
-    if len(op_schema.args_schema) > 1:
-        sort_dim = cast(int, op_schema.args_schema[1])
     sort_dim = normalize_dim(sort_dim, input_strategy.ndim)
     single_mesh_dim_strategies = []
     all_replicate: PlacementList = [Replicate()] * 3
@@ -1168,6 +1127,33 @@ def sort_strategy(op_schema: OpSchema) -> OpStrategy:
     return expand_to_full_mesh_op_strategy(
         input_strategy.mesh, op_schema, single_mesh_dim_strategies, input_index=2
     )
+
+
+@register_op_strategy(
+    [aten.topk.default],
+    schema_info=RuntimeSchemaInfo(2),
+)
+def topk_strategy(op_schema: OpSchema) -> OpStrategy:
+    topk_dim = (
+        cast(int, op_schema.args_schema[2]) if len(op_schema.args_schema) > 2 else -1
+    )
+    return sort_strategy(op_schema, topk_dim)
+
+
+@register_op_strategy(
+    aten.sort.default,
+    schema_info=RuntimeSchemaInfo(
+        1,
+    ),
+)
+def sort_default_strategy(op_schema: OpSchema) -> OpStrategy:
+    # mostly copy paste from topk_strategy
+    input_strategy = op_schema.args_schema[0]
+    assert isinstance(input_strategy, OpStrategy)
+    sort_dim = -1
+    if len(op_schema.args_schema) > 1:
+        sort_dim = cast(int, op_schema.args_schema[1])
+    return sort_strategy(op_schema, sort_dim)
 
 
 @register_op_strategy(
@@ -1184,17 +1170,7 @@ def sort_stable_strategy(op_schema: OpSchema) -> OpStrategy:
     sort_dim = -1
     if "dim" in op_schema.kwargs_schema:
         sort_dim = cast(int, op_schema.kwargs_schema["dim"])
-    sort_dim = normalize_dim(sort_dim, input_strategy.ndim)
-    single_mesh_dim_strategies = []
-    all_replicate: PlacementList = [Replicate()] * 3
-    single_mesh_dim_strategies.append(all_replicate)
-    for dim in range(input_strategy.ndim):
-        if dim != sort_dim:
-            dim_shardings: PlacementList = [Shard(dim)] * 3
-            single_mesh_dim_strategies.append(dim_shardings)
-    return expand_to_full_mesh_op_strategy(
-        input_strategy.mesh, op_schema, single_mesh_dim_strategies, input_index=2
-    )
+    return sort_strategy(op_schema, sort_dim)
 
 
 @register_op_strategy(

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -27,7 +27,6 @@ from torch.distributed.tensor._ops.utils import (
     normalize_dim,
     register_op_strategy,
     register_prop_rule,
-    replicate_op_strategy,
 )
 from torch.distributed.tensor.placement_types import (
     Partial,
@@ -566,10 +565,52 @@ def replica_only_strategy(op_schema: OpSchema) -> StrategyType:
 
 
 @register_op_strategy(
-    [aten.sort.stable, aten.sort.default], schema_info=RuntimeSchemaInfo(1)
+    [aten.sort.stable, aten.sort.default],
+    schema_info=RuntimeSchemaInfo(
+        1,
+        static_kwargkey=["dim", "descending", "stable"],
+    ),
 )
-def sort_strategy(op_schema: OpSchema):
-    return cast(TupleStrategy, replicate_op_strategy(op_schema))
+def sort_strategy(op_schema: OpSchema) -> OpStrategy:
+    self_strategy = op_schema.args_schema[0]
+    assert isinstance(self_strategy, OpStrategy)
+    dim = -1
+    if "dim" in op_schema.kwargs_schema:
+        dim = cast(int, op_schema.kwargs_schema["dim"])
+    elif len(op_schema.args_schema) > 1:
+        dim = cast(int, op_schema.args_schema[1])
+    dim = normalize_dim(dim, self_strategy.ndim)
+    assert isinstance(self_strategy, OpStrategy)
+    output_strategy = OpStrategy([])
+    for op_spec in self_strategy.strategies:
+        placements = op_spec.output_spec.placements
+        # sort dim must be replicated
+        new_placements = []
+        for p in placements:
+            if p.is_shard() and cast(Shard, p).dim != dim:
+                new_placements.append(p)
+            else:
+                new_placements.append(Replicate())
+        new_input_spec = DTensorSpec(
+            mesh=op_spec.output_spec.mesh,
+            placements=tuple(new_placements),
+            tensor_meta=op_spec.output_spec.tensor_meta,
+        )
+        out_spec = DTensorSpec(
+            mesh=op_spec.output_spec.mesh,
+            placements=tuple(new_placements),
+            tensor_meta=op_spec.output_spec.tensor_meta,  # be careful about the newly generated index output
+        )
+        output_strategy.strategies.append(
+            OpSpec(
+                output_specs=(out_spec, out_spec),
+                input_specs=(new_input_spec,),
+                redistribute_cost=[
+                    generate_redistribute_costs(self_strategy, new_input_spec)
+                ],
+            )
+        )
+    return output_strategy
 
 
 @register_op_strategy(


### PR DESCRIPTION
- Sort strategy now supports sharding on non sorted dim.
~~- Fix histc xfail.~~
  - ~~Previously `python test/distributed/tensor/test_dtensor_ops.py TestDTensorOpsCPU.test_dtensor_op_db_histc_cpu_float32` will fail with `PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=18`. However, if we run `PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=18 python test/distributed/tensor/test_dtensor_ops.py TestDTensorOpsCPU.test_dtensor_op_db_histc_cpu_float32`, the test will pass. This kind of error is due to DTensor reuses the strategy schema hashing. It turns out that not only the strategy,  the result correctness also depends on `static_argnum` or the op will reuse the previous args from hashed schema and output wrong results. I updated the document also.~~ (fixed in https://github.com/pytorch/pytorch/pull/159289)


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta