### PR TITLE
[ROCm][CK][Inductor] enable gfx950 for max autotune with CK

### DIFF
--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -5,6 +5,8 @@ import os
 import unittest
 
 from torch.testing._internal.common_cuda import tf32_off
+
+
 try:
     from .test_aot_inductor_utils import AOTIRunnerUtil
 except ImportError:
@@ -93,17 +95,20 @@ class TestCKBackend(TestCase):
 
         assert "rocm" in dir(config)
 
-        with config.patch(
-            {
-                "max_autotune": True,
-                "autotune_in_subproc": autotune_in_subproc,
-                "max_autotune_gemm_backends": max_autotune_gemm_backends,
-                "compile_threads": 16,
-                "rocm.ck_max_profiling_configs": 8,
-                "rocm.ck_tile_max_profiling_configs": 8,
-                "rocm.ck_dir": self.ck_dir,
-            }
-        ), tf32_off():
+        with (
+            config.patch(
+                {
+                    "max_autotune": True,
+                    "autotune_in_subproc": autotune_in_subproc,
+                    "max_autotune_gemm_backends": max_autotune_gemm_backends,
+                    "compile_threads": 16,
+                    "rocm.ck_max_profiling_configs": 8,
+                    "rocm.ck_tile_max_profiling_configs": 8,
+                    "rocm.ck_dir": self.ck_dir,
+                }
+            ),
+            tf32_off(),
+        ):
             if use_aoti:
                 Y_compiled = AOTIRunnerUtil.run(
                     model=mm,
@@ -140,17 +145,20 @@ class TestCKBackend(TestCase):
 
         assert "rocm" in dir(config)
 
-        with config.patch(
-            {
-                "max_autotune": True,
-                "autotune_in_subproc": autotune_in_subproc,
-                "max_autotune_gemm_backends": max_autotune_gemm_backends,
-                "compile_threads": 16,
-                "rocm.ck_max_profiling_configs": 8,
-                "rocm.ck_tile_max_profiling_configs": 8,
-                "rocm.ck_dir": self.ck_dir,
-            }
-        ), tf32_off():
+        with (
+            config.patch(
+                {
+                    "max_autotune": True,
+                    "autotune_in_subproc": autotune_in_subproc,
+                    "max_autotune_gemm_backends": max_autotune_gemm_backends,
+                    "compile_threads": 16,
+                    "rocm.ck_max_profiling_configs": 8,
+                    "rocm.ck_tile_max_profiling_configs": 8,
+                    "rocm.ck_dir": self.ck_dir,
+                }
+            ),
+            tf32_off(),
+        ):
 
             @torch.compile(dynamic=True)
             def compiled_mm(a, b):
@@ -183,16 +191,19 @@ class TestCKBackend(TestCase):
 
         assert "rocm" in dir(config)
 
-        with config.patch(
-            {
-                "max_autotune": True,
-                "autotune_in_subproc": True,
-                "max_autotune_gemm_backends": max_autotune_gemm_backends,
-                "compile_threads": 12,
-                "rocm.ck_dir": self.ck_dir,
-                "rocm.use_preselected_instances": True,
-            }
-        ), tf32_off():
+        with (
+            config.patch(
+                {
+                    "max_autotune": True,
+                    "autotune_in_subproc": True,
+                    "max_autotune_gemm_backends": max_autotune_gemm_backends,
+                    "compile_threads": 12,
+                    "rocm.ck_dir": self.ck_dir,
+                    "rocm.use_preselected_instances": True,
+                }
+            ),
+            tf32_off(),
+        ):
             Y_compiled = torch.compile(mm, dynamic=False)(a, b)
             Y = mm(a, b)
             torch.testing.assert_close(Y_compiled, Y)
@@ -212,17 +223,20 @@ class TestCKBackend(TestCase):
 
         assert "rocm" in dir(config)
 
-        with config.patch(
-            {
-                "max_autotune": True,
-                "autotune_in_subproc": True,
-                "max_autotune_gemm_backends": max_autotune_gemm_backends,
-                "compile_threads": 16,
-                "rocm.ck_dir": self.ck_dir,
-                "rocm.ck_max_profiling_configs": 8,
-                "rocm.ck_tile_max_profiling_configs": 8,
-            }
-        ), tf32_off():
+        with (
+            config.patch(
+                {
+                    "max_autotune": True,
+                    "autotune_in_subproc": True,
+                    "max_autotune_gemm_backends": max_autotune_gemm_backends,
+                    "compile_threads": 16,
+                    "rocm.ck_dir": self.ck_dir,
+                    "rocm.ck_max_profiling_configs": 8,
+                    "rocm.ck_tile_max_profiling_configs": 8,
+                }
+            ),
+            tf32_off(),
+        ):
 
             @torch.compile(dynamic=False)
             def mm(a, b):
@@ -237,7 +251,6 @@ class TestCKBackend(TestCase):
     @parametrize("max_autotune_gemm_backends", ("CK", "ATen,Triton,CK"))
     @parametrize("x_shape", ([4096, 2048], [2048], [4096, 1]))
     def test_max_autotune_addmm(self, max_autotune_gemm_backends, x_shape):
-
         m, k, n = 4096, 224, 2048
         alpha, beta = 1.0, 1.0
 
@@ -248,16 +261,19 @@ class TestCKBackend(TestCase):
 
         assert "rocm" in dir(config)
 
-        with config.patch(
-            {
-                "max_autotune": True,
-                "autotune_in_subproc": True,
-                "max_autotune_gemm_backends": max_autotune_gemm_backends,
-                "compile_threads": 2,
-                "rocm.ck_dir": self.ck_dir,
-                "rocm.ck_max_profiling_configs": 2,
-            }
-        ), tf32_off():
+        with (
+            config.patch(
+                {
+                    "max_autotune": True,
+                    "autotune_in_subproc": True,
+                    "max_autotune_gemm_backends": max_autotune_gemm_backends,
+                    "compile_threads": 2,
+                    "rocm.ck_dir": self.ck_dir,
+                    "rocm.ck_max_profiling_configs": 2,
+                }
+            ),
+            tf32_off(),
+        ):
 
             @torch.compile(dynamic=False)
             def addmm(x, a, b, alpha, beta):
@@ -378,7 +394,6 @@ class TestCKBackend(TestCase):
     )
     @parametrize("max_autotune_conv_backends", ("CK", "ATEN,CK,TRITON"))
     def test_max_autotune_conv2d(self, max_autotune_conv_backends):
-
         tensor_options = {"device": "cuda", "dtype": torch.float32}
 
         x = torch.randn(1, 8, 224, 224, **tensor_options)
@@ -388,16 +403,19 @@ class TestCKBackend(TestCase):
 
         assert "rocm" in dir(config)
 
-        with config.patch(
-            {
-                "max_autotune": True,
-                "autotune_in_subproc": False,
-                "max_autotune_conv_backends": max_autotune_conv_backends,
-                "compile_threads": 4,
-                "rocm.ck_dir": self.ck_dir,
-                "rocm.ck_max_profiling_configs": 4,
-            }
-        ), tf32_off():
+        with (
+            config.patch(
+                {
+                    "max_autotune": True,
+                    "autotune_in_subproc": False,
+                    "max_autotune_conv_backends": max_autotune_conv_backends,
+                    "compile_threads": 4,
+                    "rocm.ck_dir": self.ck_dir,
+                    "rocm.ck_max_profiling_configs": 4,
+                }
+            ),
+            tf32_off(),
+        ):
 
             @torch.compile(dynamic=False)
             def conv2d(x, w):
@@ -429,15 +447,18 @@ class TestCKBackend(TestCase):
 
         assert "rocm" in dir(config)
 
-        with config.patch(
-            {
-                "max_autotune": True,
-                "max_autotune_gemm_backends": max_autotune_gemm_backends,
-                "compile_threads": 2,
-                "rocm.ck_max_profiling_configs": 2,
-                "rocm.ck_dir": self.ck_dir,
-            }
-        ), tf32_off():
+        with (
+            config.patch(
+                {
+                    "max_autotune": True,
+                    "max_autotune_gemm_backends": max_autotune_gemm_backends,
+                    "compile_threads": 2,
+                    "rocm.ck_max_profiling_configs": 2,
+                    "rocm.ck_dir": self.ck_dir,
+                }
+            ),
+            tf32_off(),
+        ):
 
             @torch.compile(dynamic=False)
             def compiled_bmm(x, w):

--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -345,27 +345,13 @@ class TestCKBackend(TestCase):
             )
             return y
 
-        if quantize_type == "tensorwise":
-            y_eager = linear(
-                x_fp8,
-                x_inverse_scale,
-                w_t_fp8,
-                w_inverse_scale_t,
-                bias,
-            )
-        else:
-            # FIXME when rowwise quantize is supported by pt eager on ROCm
-            w_fp8_tw, w_inverse_scale_tw = _quantize_tensorwise(w, dtype_float8)
-            w_fp8_tw_t = w_fp8_tw.t()
-            w_inverse_scale_tw_t = w_inverse_scale_tw.t()
-            x_fp8_tw, x_inverse_scale_tw = _quantize_tensorwise(x, dtype_float8)
-            y_eager = linear(
-                x_fp8_tw,
-                x_inverse_scale_tw,
-                w_fp8_tw_t,
-                w_inverse_scale_tw_t,
-                bias,
-            )
+        y_eager = linear(
+            x_fp8,
+            x_inverse_scale,
+            w_t_fp8,
+            w_inverse_scale_t,
+            bias,
+        )
 
         with config.patch(
             {

--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -279,13 +279,17 @@ class TestCKBackend(TestCase):
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @unittest.mock.patch.dict(os.environ, {"PATH": _get_path_without_sccache()})
     @parametrize("max_autotune_gemm_backends", ("CK", "ATen,Triton,CK"))
-    @parametrize("dtype", (torch.bfloat16,))
-    @parametrize("use_fast_accum", (True,))
     @parametrize("quantize_type", ("tensorwise", "rowwise"))
     @parametrize("has_bias", (True, False))
     def test_max_autotune_scaled_mm(
-        self, max_autotune_gemm_backends, dtype, use_fast_accum, quantize_type, has_bias
+        self, max_autotune_gemm_backends, quantize_type, has_bias
     ):
+        use_fast_accum = False
+        runtime_arch = torch.cuda.get_device_properties(0).gcnArchName
+        if "gfx94" not in runtime_arch and "gfx95" not in runtime_arch:
+            self.skipTest(f"Unsupported arch {runtime_arch}")
+        # output dtype
+        dtype = torch.bfloat16
         tensor_options = {"device": "cuda", "dtype": dtype}
 
         M = 2240
@@ -299,7 +303,9 @@ class TestCKBackend(TestCase):
         if has_bias:
             bias = torch.randn(N, **tensor_options)
 
-        dtype_float8 = torch.float8_e4m3fnuz
+        dtype_float8 = (
+            torch.float8_e4m3fnuz if "gfx94" in runtime_arch else torch.float8_e4m3fn
+        )
 
         f_quantize = (
             _quantize_tensorwise if quantize_type == "tensorwise" else _quantize_rowwise

--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -199,10 +199,10 @@ class TestCKBackend(TestCase):
 
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @unittest.mock.patch.dict(os.environ, {"PATH": _get_path_without_sccache()})
-    @parametrize("max_autotune_gemm_backends", ("CK", "ATen,Triton,CK"))
+    @parametrize("max_autotune_gemm_backends", ("ATen,Triton,CK"))
     def test_max_autotune_precompile_non_contiguous(self, max_autotune_gemm_backends):
         """
-        Make sure the ck template can work with non-contiguous inputs
+        Make sure the matmul with non-contiguous inputs can fallback
         """
 
         tensor_options = {"device": "cuda", "dtype": torch.float16}

--- a/torch/_inductor/codegen/rocm/ck_conv_template.py
+++ b/torch/_inductor/codegen/rocm/ck_conv_template.py
@@ -2,8 +2,12 @@
 import copy
 import logging
 import random
+from typing import Any
+from typing_extensions import override
 
 from torch._inductor.virtualized import V
+
+from .rocm_template import ArgInfo
 
 
 try:
@@ -282,6 +286,8 @@ class CKGroupedConvFwdTemplate(CKTemplate):
                 using BlockGemmPipelineVersion = ck::BlockGemmPipelineVersion;
 
                 using ConvolutionForwardSpecialization = ck::tensor_operation::device::ConvolutionForwardSpecialization;
+
+                using OutElementOp = PassThrough;
 
                 namespace ck {
                 namespace utils {
@@ -606,3 +612,14 @@ class CKGroupedConvFwdTemplate(CKTemplate):
             right_pads_0,
             right_pads_1,
         )
+
+    @override
+    def get_runtime_arg_info(self) -> list[ArgInfo]:
+        return []
+
+    @override
+    def get_runtime_arg_values(self, **kwargs: Any) -> list[Any]:
+        """
+        Helper method to retrieve runtime args from generate kwargs
+        """
+        return []

--- a/torch/_inductor/codegen/rocm/ck_template.py
+++ b/torch/_inductor/codegen/rocm/ck_template.py
@@ -50,11 +50,6 @@ class CKTemplate(ROCmTemplate):
                 #include "ck/library/utility/host_tensor.hpp"
                 #include "ck/library/utility/host_tensor_generator.hpp"
                 #include "ck/library/utility/literals.hpp"
-
-                namespace at
-                {
-                  using Float8_e4m3fn = void;
-                }
             """
         )
         return res

--- a/torch/_inductor/codegen/rocm/ck_template.py
+++ b/torch/_inductor/codegen/rocm/ck_template.py
@@ -21,8 +21,10 @@ class CKTemplate(ROCmTemplate):
         torch.bfloat16: "BF16",
         torch.int32: "I32",
         torch.int8: "I8",
-        torch.float8_e4m3fnuz: "F8",
-        torch.float8_e5m2fnuz: "BF8",
+        torch.float8_e4m3fnuz: "F8",  # gfx94
+        torch.float8_e4m3fn: "F8",  # gfx95
+        torch.float8_e5m2fnuz: "BF8",  # gfx94
+        torch.float8_e5m2: "BF8",  # gfx95
     }
 
     def header(self) -> IndentedBuffer:
@@ -48,6 +50,11 @@ class CKTemplate(ROCmTemplate):
                 #include "ck/library/utility/host_tensor.hpp"
                 #include "ck/library/utility/host_tensor_generator.hpp"
                 #include "ck/library/utility/literals.hpp"
+
+                namespace at
+                {
+                  using Float8_e4m3fn = void;
+                }
             """
         )
         return res

--- a/torch/_inductor/codegen/rocm/ck_tile_template.py
+++ b/torch/_inductor/codegen/rocm/ck_tile_template.py
@@ -16,8 +16,10 @@ class CKTileTemplate(ROCmTemplate):
         torch.bfloat16: "BF16",
         torch.int32: "I32",
         torch.int8: "I8",
-        torch.float8_e4m3fnuz: "F8",
-        torch.float8_e5m2fnuz: "BF8",
+        torch.float8_e4m3fnuz: "F8",  # gfx94
+        torch.float8_e4m3fn: "F8",  # gfx95
+        torch.float8_e5m2fnuz: "BF8",  # gfx94
+        torch.float8_e5m2: "BF8",  # gfx95
     }
 
     ck_dtype_to_size = {

--- a/torch/_inductor/codegen/rocm/ck_tile_universal_gemm_template.py
+++ b/torch/_inductor/codegen/rocm/ck_tile_universal_gemm_template.py
@@ -245,16 +245,16 @@ class CKTileGemmTemplate(CKTileTemplate):
         const auto BiasTerms = std::array<const void*, 0> ();
         const auto BiasStrides = std::array<int32_t, 0> ();
 
-        auto kargs = ck_tile::GemmKernelArgs<0> {
-           X,
-           W,
+        auto kargs = ck_tile::UniversalGemmKernelArgs<> {
+           {X},
+           {W},
            BiasTerms,
            Y,
            M,
            N,
            K,
-           LDA,
-           LDB,
+           {LDA},
+           {LDB},
            BiasStrides,
            LDC,
            kBatch

--- a/torch/_inductor/codegen/rocm/rocm_utils.py
+++ b/torch/_inductor/codegen/rocm/rocm_utils.py
@@ -11,5 +11,7 @@ DTYPE_TO_ROCM_TYPE = {
     torch.float16: "uint16_t",
     torch.float8_e4m3fnuz: "uint8_t",
     torch.float8_e5m2fnuz: "uint8_t",
+    torch.float8_e4m3fn: "uint8_t",
+    torch.float8_e5m2: "uint8_t",
     torch.bfloat16: "uint16_t",
 }

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1629,7 +1629,11 @@ class rocm:
 
     # Enable the CK backend for CDNA2 and CDNA3 only (for now)
     # Processor name reference: https://llvm.org/docs/AMDGPUUsage.html#processors
-    ck_supported_arch: list[str] = ["gfx90a", "gfx942"]
+    ck_supported_arch: list[Literal["gfx90a", "gfx942", "gfx950"]] = [
+        "gfx90a",
+        "gfx942",
+        "gfx950",
+    ]
 
     # Optimization level, use to balance compilation speed and runtime performance.
     # The type will not necessarily be comprehensive and won't be enforced at runtime.

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -449,11 +449,12 @@ force_same_precision: bool = Config(
 multi_kernel_hints: list[int] = []
 
 # Specify candidate backends for gemm autotune.
-# Possible choices are combinations of: ATen, Triton, CUTLASS, CK, CPP.
+# Possible choices are combinations of: ATen, Triton, CUTLASS, CK, CKTILE, CPP.
 # ATen: default Pytorch ATen kernels.
 # Triton: Triton templates defined in torch inductor (AMD and NVidia GPUs).
 # CUTLASS: Cutlass templates and kernels (NVidia GPUs only).
 # CK: Composable Kernel templates and kernels (AMD Instinct GPUs only).
+# CKTILE: Composable Kernel templates and kernels, new API (AMD Instinct GPUs only).
 # CPP: CPP templates and kernels for CPU.
 max_autotune_gemm_backends = os.environ.get(
     "TORCHINDUCTOR_MAX_AUTOTUNE_GEMM_BACKENDS", "ATEN,TRITON,CPP"


### PR DESCRIPTION
+ update inductor config for new gfx arch
+ fixes in codegen for conv2d and ck-tile matmul
+ use appropriate fp8 dtypes
+ test cleanup


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @mlazos