### PR TITLE
Fix SDPA sharding when `return_debug_mask` is False

### DIFF
--- a/torch/distributed/tensor/_ops/_matrix_ops.py
+++ b/torch/distributed/tensor/_ops/_matrix_ops.py
@@ -312,6 +312,7 @@ def scaled_dot_product_flash_attention_strategy(op_schema: OpSchema) -> OpStrate
     single_mesh_dim_strategies.append(num_heads_dim_sharding)
 
     # Shard on the batch dimension
+    debug_attn_mask_sharding = Shard(0) if return_debug_mask else Replicate()
     single_mesh_dim_strategies.append(
         [
             Shard(0),  # output
@@ -322,7 +323,7 @@ def scaled_dot_product_flash_attention_strategy(op_schema: OpSchema) -> OpStrate
             None,  # max_k
             Replicate(),  # rng_state
             None,  # unused
-            Shard(0),  # debugattn
+            debug_attn_mask_sharding,  # debugattn
             Shard(0),  # q
             Shard(0),  # k
             Shard(0),  # v
@@ -330,6 +331,7 @@ def scaled_dot_product_flash_attention_strategy(op_schema: OpSchema) -> OpStrate
     )
 
     # Context Parallelism: shards on the sequence dim
+    debug_attn_mask_sharding = Shard(2) if return_debug_mask else Replicate()
     single_mesh_dim_strategies.append(
         [
             Shard(2),  # output
@@ -340,7 +342,7 @@ def scaled_dot_product_flash_attention_strategy(op_schema: OpSchema) -> OpStrate
             None,  # max_k
             Replicate(),  # rng_state
             None,  # unused
-            Shard(2),  # debugattn
+            debug_attn_mask_sharding,  # debugattn
             Shard(2),  # q
             Shard(2),  # k
             Shard(2),  # v


### PR DESCRIPTION
If `return_debug_mask` is False (which is the default value for SDPA), the attention tensor returned is an empty tensor (which has 0 dimensions). This means that the shardings for the batch and CP case are that are passed can yield invalid dimensions.

This PR fixes it for `scaled_dot_product_flash_attention_strategy`.  Note that `scaled_dot_product_cudnn_attention_strategy` doen't have this issue

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta