### PR TITLE
[Log] update default msg for recompile reasons and user contexts

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1075,6 +1075,11 @@ def _compile(
             recompile_reason = (
                 "Unable to find recompilation reasons" if not reasons else reasons[0]
             )
+        else:
+            recompile_reason = (
+                f"No reason. is_recompilation:{is_recompilation(cache_size)}, "
+                f"frame is None:{frame is None}"
+            )
         metrics_context.update_outer({"recompile_reason": recompile_reason})
 
         recompile_user_contexts = get_hook_for_recompile_user_context()
@@ -1085,6 +1090,8 @@ def _compile(
                 user_context()[:256] for user_context in recompile_user_contexts
             }
             metrics_context.set("recompile_user_contexts", user_contexts_msg)
+        else:
+            metrics_context.set("recompile_user_contexts", {"Not set"})
 
         exceeded, limit_type = exceeds_recompile_limit(cache_size, compile_id)
         if exceeded:


### PR DESCRIPTION
A user tried to analyze recompile reason/user contexts but found lots of null values, which is confusing. To improve UX, we should set short explanation instead of null values.

<img width="571" height="803" alt="image" src="https://github.com/user-attachments/assets/84acf830-88af-43cf-8821-5488066029f7" />


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela