### PR TITLE
[nativert][ez] Remove unused dist collectives ops.

### DIFF
--- a/test/cpp/nativert/test_execution_frame.cpp
+++ b/test/cpp/nativert/test_execution_frame.cpp
@@ -1,4 +1,6 @@
 #include <gtest/gtest.h>
+
+#include <ATen/ops/tensor.h>
 #include <torch/nativert/executor/ExecutionFrame.h>
 
 namespace torch::nativert {

--- a/test/cpp/nativert/test_op_kernel.cpp
+++ b/test/cpp/nativert/test_op_kernel.cpp
@@ -1,6 +1,6 @@
-#include <ATen/ops/tensor.h>
 #include <ATen/core/dispatch/Dispatcher.h>
 #include <ATen/core/op_registration/op_registration.h>
+#include <ATen/ops/tensor.h>
 #include <gtest/gtest.h>
 #include <torch/nativert/executor/OpKernel.h>
 

--- a/test/cpp/nativert/test_op_kernel.cpp
+++ b/test/cpp/nativert/test_op_kernel.cpp
@@ -1,3 +1,4 @@
+#include <ATen/ops/tensor.h>
 #include <ATen/core/dispatch/Dispatcher.h>
 #include <ATen/core/op_registration/op_registration.h>
 #include <gtest/gtest.h>

--- a/torch/nativert/executor/ExecutionFrame.h
+++ b/torch/nativert/executor/ExecutionFrame.h
@@ -2,7 +2,6 @@
 
 #include <unordered_map>
 
-#include <torch/csrc/distributed/c10d/Work.hpp>
 #include <torch/nativert/executor/ExecutorConfig.h>
 #include <torch/nativert/executor/Weights.h>
 #include <torch/nativert/executor/memory/LayoutManager.h>
@@ -119,18 +118,6 @@ class ExecutionFrame {
     borrowedValueIds_.clear();
   }
 
-  void setWork(int64_t workId, const c10::intrusive_ptr<c10d::Work>& work) {
-    work_[workId] = work;
-  }
-
-  c10::intrusive_ptr<c10d::Work> getWork(int64_t workId) const {
-    TORCH_CHECK(
-        work_.find(workId) != work_.end(),
-        "Couldn't find work with Id: ",
-        workId);
-    return work_.at(workId);
-  }
-
   WeightVersion weightVersion() const {
     return weightVersion_;
   }
@@ -171,8 +158,6 @@ class ExecutionFrame {
   std::vector<c10::IValue> allValues_;
   // a class-local version of getPersistentValueMask
   std::vector<bool> persistent_;
-
-  std::unordered_map<int64_t, c10::intrusive_ptr<c10d::Work>> work_;
 
   std::vector<ValueId> borrowedValueIds_;
 

--- a/torch/nativert/kernels/KernelRegistry.h
+++ b/torch/nativert/kernels/KernelRegistry.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <ATen/ATen.h>
+
 #include <torch/nativert/executor/OpKernel.h>
 #include <torch/nativert/graph/Graph.h>
 #include <torch/nativert/kernels/PrimKernelRegistry.h>

--- a/torch/nativert/kernels/PrimKernelRegistry.h
+++ b/torch/nativert/kernels/PrimKernelRegistry.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <ATen/ATen.h>
+
 #include <torch/nativert/executor/OpKernel.h>
 #include <torch/nativert/graph/Graph.h>
 #include <torch/nativert/kernels/C10Kernel.h>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #159220

Removing dependency to c10d/ in ExecutionFrame.h. We don't need c10d::Work in the frame.

Differential Revision: [D79041618](https://our.internmc.facebook.com/intern/diff/D79041618/)