### PR TITLE
[AOTI] add zero size consts asm handler

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -6738,9 +6738,11 @@ class AOTInductorLoggingTest(LoggingTestCase):
             "x": {0: Dim.AUTO, 1: Dim.AUTO},
         }
         ep = export(Foo(), inputs, dynamic_shapes=dynamic_shapes, strict=False)
-        with torch.no_grad():
-            with config.patch({"always_keep_tensor_constants": True}):
-                torch._inductor.aot_compile(ep.module(), inputs)
+        with (
+            torch.no_grad(),
+            config.patch({"aot_inductor.use_consts_asm_build": False}),
+        ):
+            torch._inductor.aot_compile(ep.module(), inputs)
         self.assertEqual([r.msg == "create_env" for r in records].count(True), 1)
 
 

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -6726,6 +6726,27 @@ class AOTInductorLoggingTest(LoggingTestCase):
             torch._inductor.aot_compile(ep.module(), inputs)
         self.assertEqual([r.msg == "create_env" for r in records].count(True), 1)
 
+    @make_logging_test(dynamic=logging.DEBUG)
+    def test_shape_env_reuse_zero_consts_use_consts_asm_false(self, records):
+        saved_cfg: bool = torch._inductor.config.aot_inductor.use_consts_asm_build
+        torch._inductor.config.aot_inductor.use_consts_asm_build = False
+
+        # make sure ShapeEnv is only created once and reused afterwards
+        class Foo(torch.nn.Module):
+            def forward(self, x):
+                return x + 2
+
+        inputs = (torch.randn(4, 4),)
+        dynamic_shapes = {
+            "x": {0: Dim.AUTO, 1: Dim.AUTO},
+        }
+        ep = export(Foo(), inputs, dynamic_shapes=dynamic_shapes, strict=False)
+        with torch.no_grad():
+            torch._inductor.aot_compile(ep.module(), inputs)
+        self.assertEqual([r.msg == "create_env" for r in records].count(True), 1)
+
+        torch._inductor.config.aot_inductor.use_consts_asm_build = saved_cfg
+
 
 class TestAOTInductorConfig(TestCase):
     def test_no_compile_standalone(self):

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1939,7 +1939,9 @@ _binary_constants_bin_end:
             )
             consts_o = object_builder.get_target_file_path()
             if use_asm_build is False and len(consts) == 0:
-                RunAsmBuildObject(consts_s, consts_o)
+                src = normalize_path_separator(str(consts_s))
+                asm_cwd = normalize_path_separator(str(consts_s.parent))
+                RunAsmBuildObject(src, consts_o, asm_cwd)
             else:
                 object_builder.build()
 

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1881,12 +1881,17 @@ ATTRIBUTE_NO_SANITIZE_ADDRESS\t\n"""
                 """
                 This function is used to handle zero consts situation. Because cpp standard is not allow zero size array:
                 https://stackoverflow.com/questions/9722632/what-happens-if-i-define-a-0-size-array-in-c-c
-                Such as MSVC will report error C2466:
+                1. On Windows, MSVC will report error C2466:
                 https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2466?view=msvc-170
                 So, we can use assmbely compiler to handle this situation.
+                2. On Windows, why not use Win32 asm to handle all path? Because of ml64 is only support upto align 16, it is
+                not the best performance.
+                3. It function can handle zero size case on both Windows and Linux, as that:
+                    A. On Linux, we added `-pedantic` to disable zero size array on C++ compiler.
+                    B. On Windows, msvc is not support zero size array by default.
                 """
                 if _IS_WINDOWS:
-                    # Windows nasm is max support align to 16, but it is no effect to zero size data.
+                    # Windows ml64 is max support align to 16, but it is no effect to zero size data.
                     asm_code = """
 option casemap:none
 .data

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1823,7 +1823,7 @@ class AotCodeCompiler:
 
             is_large_consts = len(consts) > 1024
 
-            def format_consts_to_asm(
+            def format_consts_to_gnu_asm(
                 consts: bytes,
                 align_bytes: int,
                 symbol_prefix: str,
@@ -1907,7 +1907,7 @@ _binary_constants_bin_end:
                 return asm_code, asm_ext
 
             if use_asm_build:
-                consts_code, code_ext = format_consts_to_asm(
+                consts_code, code_ext = format_consts_to_gnu_asm(
                     consts, ALIGN_BYTES, symbol_prefix, is_large_consts
                 )
             else:

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -75,6 +75,7 @@ from torch._inductor.cpp_builder import (
     get_ld_and_objcopy,
     get_name_and_dir_from_output_file_path,
     normalize_path_separator,
+    RunAsmBuildObject,
 )
 from torch._inductor.cpu_vec_isa import pick_vec_isa
 from torch._inductor.custom_graph_pass import (
@@ -1937,7 +1938,10 @@ _binary_constants_bin_end:
                 BuildOption=object_build_options,
             )
             consts_o = object_builder.get_target_file_path()
-            object_builder.build()
+            if use_asm_build is False and len(consts) == 0:
+                RunAsmBuildObject(consts_s, consts_o)
+            else:
+                object_builder.build()
 
             if is_large_consts and use_asm_build:
                 with open(consts_o, "r+b") as f:

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1823,6 +1823,7 @@ class AotCodeCompiler:
                 use_asm_build = False
 
             is_large_consts = len(consts) > 1024
+            is_zero_size_consts = len(consts) == 0
 
             def format_consts_to_gnu_asm(
                 consts: bytes,
@@ -1915,7 +1916,7 @@ end
                     consts, ALIGN_BYTES, symbol_prefix, is_large_consts
                 )
             else:
-                if len(consts) == 0:
+                if is_zero_size_consts:
                     consts_code, code_ext = get_zero_consts_asm_code(
                         ALIGN_BYTES, symbol_prefix
                     )
@@ -1943,7 +1944,7 @@ end
                 BuildOption=object_build_options,
             )
             consts_o = object_builder.get_target_file_path()
-            if use_asm_build is False and len(consts) == 0:
+            if use_asm_build is False and is_zero_size_consts:
                 src = normalize_path_separator(str(consts_s))
                 asm_cwd = normalize_path_separator(str(consts_s.parent))
                 RunAsmBuildObject(src, consts_o, asm_cwd)

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1886,12 +1886,12 @@ ATTRIBUTE_NO_SANITIZE_ADDRESS\t\n"""
                     asm_code = """
 option casemap:none
 .data
-_binary_constants_bin_start:
+?_binary_constants_bin_start@@3PAEA:
 align 16
-_binary_constants_bin_end:
+?_binary_constants_bin_end@@3PAEA:
 align 16
-public _binary_constants_bin_start
-public _binary_constants_bin_end
+public ?_binary_constants_bin_start@@3PAEA
+public ?_binary_constants_bin_end@@3PAEA
 end
 """
                     asm_ext = "asm"

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -1921,7 +1921,7 @@ def RunAsmBuildObject(src: str, target: str, cwd: str):
         if _IS_WINDOWS:
             # Format reference:
             # https://learn.microsoft.com/en-us/cpp/assembler/masm/ml-and-ml64-command-line-reference?view=msvc-170
-            cmd = f"{asm_cc} {src} /c /Fo {target}"
+            cmd = f"{asm_cc} {src} /c /Fo {target}"  # codespell: ignore /Fo
         else:
             cmd = "{asm_cc} -c {src} -o {target}"
 

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -1905,3 +1905,30 @@ class CppBuilder:
         )
         with open(cmake_path, "a") as f:
             f.write(contents)
+
+
+def RunAsmBuildObject(src: str, target: str):
+    def get_asm_compuler() -> str:
+        if _IS_WINDOWS:
+            ASM_CC = "ml64"
+        else:
+            ASM_CC = get_cpp_compiler()
+            if _is_intel_compiler(ASM_CC):
+                return "gcc"
+        return ASM_CC
+
+    def get_command_line(asm_cc: str, src: str, target: str) -> str:
+        if _IS_WINDOWS:
+            # Format reference:
+            # https://learn.microsoft.com/en-us/cpp/assembler/masm/ml-and-ml64-command-line-reference?view=msvc-170
+            cmd = f"{asm_cc} /Fo {target} /c {src}"
+        else:
+            cmd = "{asm_cc} -c {src} -o {target}"
+
+        return cmd
+
+    asm_cc = get_asm_compuler()
+    _create_if_dir_not_exist(target)
+
+    cmd = get_command_line(asm_cc=asm_cc, src=src, target=target)
+    run_compile_cmd(cmd)

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -1922,9 +1922,9 @@ def RunAsmBuildObject(src: str, target: str, cwd: str) -> None:
         if _IS_WINDOWS:
             # Format reference:
             # https://learn.microsoft.com/en-us/cpp/assembler/masm/ml-and-ml64-command-line-reference?view=msvc-170
-            cmd = f"{asm_cc} {src} /c /Fo {target}"  # codespell: ignore /Fo
+            cmd = f"{asm_cc} {src} /c /Fo {target}"  # codespell:ignore /Fo
         else:
-            cmd = "{asm_cc} -c {src} -o {target}"
+            cmd = f"{asm_cc} -c {src} -o {target}"
 
         return cmd
 

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -1907,7 +1907,7 @@ class CppBuilder:
             f.write(contents)
 
 
-def RunAsmBuildObject(src: str, target: str, cwd: str):
+def RunAsmBuildObject(src: str, target: str, cwd: str) -> None:
     def get_asm_compuler() -> str:
         if _IS_WINDOWS:
             ASM_CC = "ml64"

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -1913,6 +1913,7 @@ def RunAsmBuildObject(src: str, target: str, cwd: str):
             ASM_CC = "ml64"
         else:
             ASM_CC = get_cpp_compiler()
+            # Intel compiler is not support to compile asm, switch to gcc.
             if _is_intel_compiler(ASM_CC):
                 return "gcc"
         return ASM_CC
@@ -1928,7 +1929,5 @@ def RunAsmBuildObject(src: str, target: str, cwd: str):
         return cmd
 
     asm_cc = get_asm_compuler()
-    _create_if_dir_not_exist(target)
-
     cmd = get_command_line(asm_cc=asm_cc, src=src, target=target)
     run_compile_cmd(cmd, cwd=cwd)

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -1907,7 +1907,7 @@ class CppBuilder:
             f.write(contents)
 
 
-def RunAsmBuildObject(src: str, target: str):
+def RunAsmBuildObject(src: str, target: str, cwd: str):
     def get_asm_compuler() -> str:
         if _IS_WINDOWS:
             ASM_CC = "ml64"
@@ -1921,7 +1921,7 @@ def RunAsmBuildObject(src: str, target: str):
         if _IS_WINDOWS:
             # Format reference:
             # https://learn.microsoft.com/en-us/cpp/assembler/masm/ml-and-ml64-command-line-reference?view=msvc-170
-            cmd = f"{asm_cc} /Fo {target} /c {src}"
+            cmd = f"{asm_cc} {src} /c /Fo {target}"
         else:
             cmd = "{asm_cc} -c {src} -o {target}"
 
@@ -1931,4 +1931,4 @@ def RunAsmBuildObject(src: str, target: str):
     _create_if_dir_not_exist(target)
 
     cmd = get_command_line(asm_cc=asm_cc, src=src, target=target)
-    run_compile_cmd(cmd)
+    run_compile_cmd(cmd, cwd=cwd)

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -1907,15 +1907,15 @@ class CppBuilder:
             f.write(contents)
 
 
-def RunAsmBuildObject(src: str, target: str, cwd: str) -> None:
-    def get_asm_compuler() -> str:
+def run_asm_build_object(src: str, target: str, cwd: str) -> None:
+    def get_asm_compiler() -> str:
         if _IS_WINDOWS:
             ASM_CC = "ml64"
         else:
             ASM_CC = get_cpp_compiler()
             # Intel compiler is not support to compile asm, switch to gcc.
             if _is_intel_compiler(ASM_CC):
-                return "gcc"
+                ASM_CC = "gcc"
         return ASM_CC
 
     def get_command_line(asm_cc: str, src: str, target: str) -> str:
@@ -1928,6 +1928,10 @@ def RunAsmBuildObject(src: str, target: str, cwd: str) -> None:
 
         return cmd
 
-    asm_cc = get_asm_compuler()
-    cmd = get_command_line(asm_cc=asm_cc, src=src, target=target)
-    run_compile_cmd(cmd, cwd=cwd)
+    asm_cc = get_asm_compiler()
+    cmd = get_command_line(
+        asm_cc=asm_cc,
+        src=normalize_path_separator(src),
+        target=normalize_path_separator(target),
+    )
+    run_compile_cmd(cmd, cwd=normalize_path_separator(cwd))


### PR DESCRIPTION
Add `get_zero_consts_asm_code` to handle zero size consts to object.
This function is used to handle zero consts situation. Because cpp standard does not allow zero size array:
https://stackoverflow.com/questions/9722632/what-happens-if-i-define-a-0-size-array-in-c-c 
1. On Windows, MSVC will report error C2466:
https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2466?view=msvc-170 
So, we can use assmbely compiler to handle this situation.
2. On Windows, why not use Win32 asm to handle all path? Because ml64 only supports up to align `16`, it is
not aligned to pytorch's `64`. Reference: https://learn.microsoft.com/en-us/cpp/assembler/masm/ml-and-ml64-command-line-reference?view=msvc-170
```
Packs structures on the specified byte boundary. The alignment can be 1, 2, 4, 8, or 16.
```
3. It function can handle zero size case on both Windows and Linux, as that:
    A. On Linux, we added `-pedantic` to disable zero size array on C++ compiler. https://github.com/pytorch/pytorch/blob/8e07c9870d07c5a318ab21bb16b3fa27576851e6/torch/_inductor/cpp_builder.py#L580 
    B. On Windows, msvc is not support zero size array by default.


cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben