### PR TITLE
remove co_lnotab in favor of co_linetable

### DIFF
--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -145,7 +145,7 @@ def _patch_function(fn: FunctionType, nargs: int) -> FunctionType:
             co.co_name,
             co.co_qualname,  # type: ignore[attr-defined]
             co.co_firstlineno,
-            co.co_lnotab,
+            co.co_linetable,
             co.co_exceptiontable,  # type: ignore[attr-defined]
             co.co_freevars,
             co.co_cellvars,


### PR DESCRIPTION
Fixes #158833
DeprecationWarning: remove co_lnotab in favor of co_linetable


cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv