### PR TITLE
[benchmarks] Set model name early to keep warmup and main model same

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -2425,6 +2425,8 @@ class BenchmarkRunner:
         # Use distributed wrapping as necessary
         model = self.deepcopy_and_maybe_parallelize(model)
 
+        if not hasattr(model, name):
+            model.name = name
         self.init_optimizer(name, current_device, model.parameters())
 
         # The self.autocast context is needed for the model we export with aot_compile,
@@ -2528,8 +2530,6 @@ class BenchmarkRunner:
             result_summary = latency_experiment_summary(
                 self.suite_name, self.args, model, timings, **experiment_kwargs
             )
-            if not hasattr(model, name):
-                model.name = name
             results.append(result_summary)
             return " ".join(map(str, results))
 
@@ -2585,6 +2585,9 @@ class BenchmarkRunner:
 
         # Use distributed wrapping as necessary
         model = self.deepcopy_and_maybe_parallelize(model)
+
+        if not hasattr(model, name):
+            model.name = name
 
         self.init_optimizer(name, current_device, model.parameters())
 
@@ -2699,8 +2702,6 @@ class BenchmarkRunner:
                     f"{ok:3}/{total:3} +{frames_third_pass} frames {compilation_time:3.0f}s"
                 )
 
-            if not hasattr(model, name):
-                model.name = name
             results.append(experiment(model, example_inputs, **experiment_kwargs))
             return " ".join(map(str, results))
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #159186
* #159183
* __->__ #159231
* #159209



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela