### PR TITLE
Register SAC dispatching for triton_kernel_wrapper_mutation

### DIFF
--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -18,6 +18,7 @@ import torch.fx as fx
 import torch.utils._pytree as pytree
 from torch import SymInt, Tensor
 from torch._C import DispatchKey
+from torch._higher_order_ops.utils import redirect_to_mode
 from torch._ops import HigherOrderOperator
 from torch._prims_common import clone_preserve_strides
 from torch._subclasses.fake_tensor import FakeTensorMode
@@ -28,6 +29,7 @@ from torch.fx.experimental.proxy_tensor import (
 )
 from torch.fx.experimental.symbolic_shapes import guard_scalar
 from torch.types import IntLikeType
+from torch.utils.checkpoint import _CachedTorchDispatchMode, _CachingTorchDispatchMode
 
 
 if TYPE_CHECKING:
@@ -1111,6 +1113,10 @@ def _(
     kwargs: dict[str, Any],
 ) -> None:
     return None
+
+# Register dispatches for SAC
+redirect_to_mode(triton_kernel_wrapper_mutation, _CachingTorchDispatchMode)
+redirect_to_mode(triton_kernel_wrapper_mutation, _CachedTorchDispatchMode)
 
 
 def trace_triton_kernel_wrapper(


### PR DESCRIPTION
When using SAC with a Triton kernel and torch.compile, you get:

> NotImplementedError: There was no rule registered for HigherOrderOperator triton_kernel_wrapper_mutation and mode <torch.utils.checkpoint._CachingTorchDispatchMode object at 0x7f3ed1799c90>.Hint: set <torch.utils.checkpoint._CachingTorchDispatchMode object at 0x7f3ed1799c90>'s supports_higher_order_operators to True. This causes all higher order operators to pass through <torch.utils.checkpoint._CachingTorchDispatchMode object at 0x7f3ed1799c90>'s __torch_dispatch__, so handle them accordingly by adding support for HigerOrderOperators (in this case, triton_kernel_wrapper_mutation) in <torch.utils.checkpoint._CachingTorchDispatchMode object at 0x7f3ed1799c90>.__torch_dispatch__ or returning NotImplemented when not supported.

Minimal repro:
```python
import torch
import torch.nn as nn
import triton
import triton.language as tl
from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
    checkpoint_wrapper as ptd_checkpoint_wrapper
)
from torch.utils.checkpoint import (
    CheckpointPolicy,
    create_selective_checkpoint_contexts,
)
from collections import defaultdict


@triton.jit
def simple_add_kernel(
    x_ptr,
    y_ptr,
    output_ptr,
    n_elements,
    BLOCK_SIZE: tl.constexpr,
):
    pid = tl.program_id(axis=0)
    block_start = pid * BLOCK_SIZE
    offsets = block_start + tl.arange(0, BLOCK_SIZE)
    mask = offsets < n_elements
    x = tl.load(x_ptr + offsets, mask=mask)
    y = tl.load(y_ptr + offsets, mask=mask)
    output = x + y
    tl.store(output_ptr + offsets, output, mask=mask)


def triton_add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
    output = torch.empty_like(x)
    n_elements = x.numel()
    grid = lambda meta: (triton.cdiv(n_elements, meta['BLOCK_SIZE']),)
    simple_add_kernel[grid](x, y, output, n_elements, BLOCK_SIZE=1024)
    return output


# Simple model that uses the Triton kernel
class SimpleModel(nn.Module):
    def __init__(self, hidden_size: int = 256):
        super().__init__()
        self.layer1 = nn.Linear(hidden_size, hidden_size)
        self.layer2 = nn.Linear(hidden_size, hidden_size)
        
    def forward(self, x: torch.Tensor) -> torch.Tensor:
        x = self.layer1(x)
        # Use triton kernel here
        x = triton_add(x, x)
        x = self.layer2(x)
        return x

_save_list = {
    torch.ops.aten.mm.default,
    torch.ops.aten.max.default,
}

def apply_selective_ac(module: nn.Module):
    def _get_custom_policy(meta):
        def _custom_policy(ctx, func, *args, **kwargs):
            mode = "recompute" if ctx.is_recompute else "forward"
            mm_count_key = f"{mode}_mm_count"
            if func == torch.ops.aten.mm.default:
                meta[mm_count_key] += 1
            to_save = func in _save_list and not (
                func == torch.ops.aten.mm.default and meta[mm_count_key] % 2 == 0
            )
            return (
                CheckpointPolicy.MUST_SAVE
                if to_save
                else CheckpointPolicy.PREFER_RECOMPUTE
            )
        return _custom_policy

    def selective_checkpointing_context_fn():
        meta = defaultdict(int)
        return create_selective_checkpoint_contexts(_get_custom_policy(meta))

    return ptd_checkpoint_wrapper(
        module,
        context_fn=selective_checkpointing_context_fn,
        preserve_rng_state=False,
    )


def main():
    device = torch.device("cuda")
    hidden_size = 256
    batch_size = 16
    seq_len = 128
    
    model = SimpleModel(hidden_size).to(device)
    
    model = apply_selective_ac(model)
    
    model = torch.compile(model)
    
    x = torch.randn(batch_size, seq_len, hidden_size, device=device)
    
    output = model(x)
    print("Forward pass completed successfully")
    output.sum().backward()
    print("Backward pass completed successfully")

if __name__ == "__main__":
    main()
```

