### PR TITLE
[CUDA] Add `serialTest` decorator to `largeTensorTest` in `test_cuda.py`

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1503,7 +1503,7 @@ except RuntimeError as e:
         )
 
     @largeTensorTest("20GB", "cuda")
-    @serialTest
+    @serialTest()
     def test_randint_generation_for_large_numel(self) -> None:
         numel = 2**31 + 1
         s = torch.randint(2, (numel,), device="cuda", dtype=torch.int8).sum()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1503,6 +1503,7 @@ except RuntimeError as e:
         )
 
     @largeTensorTest("20GB", "cuda")
+    @serialTest
     def test_randint_generation_for_large_numel(self) -> None:
         numel = 2**31 + 1
         s = torch.randint(2, (numel,), device="cuda", dtype=torch.int8).sum()


### PR DESCRIPTION
Hopefully helps with disabled tests due to OOM such as https://github.com/pytorch/pytorch/issues/159069

cc @ptrblck @msaroufim @jerryzh168