### PR TITLE
FXConverter handling of generic output in inductor fallback kernel (#159002)

### DIFF
--- a/test/inductor/test_fxir_backend.py
+++ b/test/inductor/test_fxir_backend.py
@@ -156,15 +156,15 @@ class FxirTestCase(InductorTestCase):
 
     def test_fallback(self):
         """
-        Test a program that calls an aten fallback.
+        Test a program that calls aten fallbacks.
         """
 
-        length = 8
-
         def foo(x):
-            return x + torch.randn(1, device=self.device)
+            batch1 = torch.randn(2, 3, 5, device=self.device)
+            batch2 = torch.randn(2, 5, 4, device=self.device)
+            return torch.addbmm(x, batch1, batch2)
 
-        args = (torch.randn(length, device=self.device),)
+        args = (torch.randn(3, 4, device=self.device),)
 
         # Since the program has a random output, just check metadata.
         # Don't check for an exact value.
@@ -173,8 +173,10 @@ class FxirTestCase(InductorTestCase):
         )
 
         # Check for the fallback kernel.
-        num_fallback = self._count_ops(gm, torch.ops.aten.randint.low_out)
-        self.assertEqual(num_fallback, 1)
+        num_fallback = self._count_ops(
+            gm, torch.ops.aten.randint.low_out
+        ) + self._count_ops(gm, torch.ops.aten.addbmm.default)
+        self.assertEqual(num_fallback, 2)
 
     def test_cat_inputs(self):
         """

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -485,12 +485,19 @@ class FxConverter:
     def _generate_multi_output(self, line: WrapperLine) -> None:
         assert isinstance(line, MultiOutputLine)
 
+        arg_node = self.buffer_to_node[line.arg_name]
+
+        # For non-tuple / non-list outputs, map the
+        # output to the same node as the input.
+        if len(line.indices) == 0:
+            self.buffer_to_node[line.result_name] = arg_node
+            return
+
         # Extract the index for tuple access.
         inds = line.indices[0][1:]
         assert len(inds) == 1, f"Cannot convert {inds} to an index."
         idx = inds[0]
 
-        arg_node = self.buffer_to_node[line.arg_name]
         node = self.gm.graph.call_function(operator.getitem, args=(arg_node, idx))
         node.meta["val"] = arg_node.meta["val"][idx]
         node.name = line.result_name


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #159297

Summary:

A fallback kernel's output may be a non-list/tuple but a `MultiOutput` with empty indices. Allow the `FXConverter` to handle such case.

Test Plan:
Modified the fxir test for fallbacks, then ran `buck2 test mode/dev-nosan caffe2/test/inductor:fxir_backend -- test_fallback`.

Before this diff the modified test would fail with
```
File "/re_cwd/buck-out/v2/gen/fbcode/e2105f7329ead90a/caffe2/test/inductor/__fxir_backend__/fxir_backend#link-tree/torch/_inductor/codegen/wrapper_fxir.py", line 341, in generate
    line.codegen_fx(self)(line)
  File "/re_cwd/buck-out/v2/gen/fbcode/e2105f7329ead90a/caffe2/test/inductor/__fxir_backend__/fxir_backend#link-tree/torch/_inductor/codegen/wrapper_fxir.py", line 489, in _generate_multi_output
    inds = line.indices[0][1:]
torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
IndexError: list index out of range
```
 (Full error paste in P1878839403)

With this diff the error is no longer present.

Rollback Plan:

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben

Differential Revision: [D79126619](https://our.internmc.facebook.com/intern/diff/D79126619)