### PR TITLE
Add user annotation for FX graph cache key

### DIFF
--- a/test/dynamo/test_profiler.py
+++ b/test/dynamo/test_profiler.py
@@ -181,7 +181,7 @@ class DynamoProfilerTests(torch._dynamo.test_case.TestCase):
                 torch.randn(10, 15),
             )
 
-        annotations = [e.name for e in prof.events() if "Compiled" in e.name]
+        annotations = [e.name for e in prof.events() if "Torch-Compiled" in e.name]
         self.assertEqual(
             annotations,
             [

--- a/test/profiler/test_execution_trace.py
+++ b/test/profiler/test_execution_trace.py
@@ -404,6 +404,7 @@ class TestExecutionTrace(TestCase):
 
         nodes = self.get_execution_trace_root(fp.name)
         found_captured_triton_kernel_node = False
+        found_call_compiled_fx_graph = False
         for n in nodes:
             assert "name" in n
             if "triton_" in n["name"]:
@@ -412,7 +413,10 @@ class TestExecutionTrace(TestCase):
                         found_captured_triton_kernel_node = True
                         assert len(n["inputs"]["values"]) > 0
                         assert len(n["outputs"]["values"]) == 0
+            elif "Call CompiledFxGraph" in n["name"]:
+                found_call_compiled_fx_graph = True
         assert found_captured_triton_kernel_node
+        assert found_call_compiled_fx_graph
 
     @unittest.skipIf(IS_WINDOWS, "torch.compile does not support WINDOWS")
     @unittest.skipIf(

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -48,6 +48,7 @@ from torch._inductor.utils import (
     output_node,
     set_tracing_context_output_strides,
 )
+from torch.autograd.profiler import record_function
 from torch.utils._ordered_set import OrderedSet
 
 from . import config
@@ -581,7 +582,10 @@ class CompiledFxGraph(OutputCode):
     def __call__(self, inputs: Sequence[Any]) -> Any:
         assert self.current_callable is not None
         try:
-            return self.current_callable(inputs)
+            with record_function(
+                f"## Call CompiledFxGraph {self._fx_graph_cache_key} ##"
+            ):
+                return self.current_callable(inputs)
         finally:
             get_runtime_metrics_context().finish()
             AutotuneCacheBundler.end_compile()


### PR DESCRIPTION
Summary: AI system co-design team requested to add user annotation for FX graph cache key in PyTorch Kineto trace and Execution trace. With this annotation, they can know the FX graph to which the kernels belong.

Test Plan:
buck2 run mode/opt caffe2/test:test_profiler_cuda -- profiler.test_execution_trace.TestExecutionTraceCUDA

Rollback Plan:

Differential Revision: D79019069




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @Lucaskabela