### PR TITLE
[ONNX] RMS Norm

### DIFF
--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -763,9 +763,7 @@ class DynamoExporterNewOpsetsTest(common_utils.TestCase, _WithExport):
 
         x = torch.randn(2, 5, 3)
         onnx_program = self.export(RMSNormModel(), (x,), opset_version=23)
-        onnx_testing.assert_onnx_program(
-            onnx_program, backend="reference", rtol=1e-4, atol=1e-4
-        )
+        onnx_testing.assert_onnx_program(onnx_program, backend="reference")
 
         # Test with multi-dimensional normalized_shape
         class RMSNormModel2D(torch.nn.Module):
@@ -773,10 +771,11 @@ class DynamoExporterNewOpsetsTest(common_utils.TestCase, _WithExport):
                 return torch.nn.functional.rms_norm(x, [7, 3])
 
         x = torch.randn(2, 5, 7, 3)
-        onnx_program = self.export(RMSNormModel2D(), (x,), opset_version=23)
-        onnx_testing.assert_onnx_program(
-            onnx_program, backend="reference", rtol=1e-4, atol=1e-4
+        onnx_program = self.export(
+            RMSNormModel2D(), (x,), opset_version=23, report=True
         )
+        onnx_program = self.export(RMSNormModel2D(), (x,), report=True)
+        onnx_testing.assert_onnx_program(onnx_program, backend="reference")
 
     def test_rms_norm_with_weight(self):
         """Test RMS normalization with weight parameter."""
@@ -794,16 +793,14 @@ class DynamoExporterNewOpsetsTest(common_utils.TestCase, _WithExport):
         onnx_program = self.export(RMSNormWithWeight(), (x,), opset_version=23)
 
         # Test with reference evaluator because ORT does not support the op as of version 1.22
-        onnx_testing.assert_onnx_program(
-            onnx_program, backend="reference", rtol=1e-4, atol=1e-4
-        )
+        onnx_testing.assert_onnx_program(onnx_program, backend="reference")
 
     def test_rms_norm_with_eps(self):
         """Test RMS normalization with custom epsilon."""
 
         class RMSNormWithEps(torch.nn.Module):
             def forward(self, x):
-                return torch.nn.functional.rms_norm(x, [3], eps=1e-6)
+                return torch.nn.functional.rms_norm(x, [3], eps=1e-5)
 
         x = torch.randn(2, 5, 3)
 

--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 
 import logging
 
-import onnx.reference as onnx_ref
-
 import onnxruntime
 import pytest
 import transformers
@@ -752,8 +750,9 @@ class DynamoExporterNewOpsetsTest(common_utils.TestCase, _WithExport):
             onnx_testing.assert_onnx_program(onnx_program, atol=1e-2, rtol=1)
         else:
             # Test with reference evaluator because ORT does not support the op as of version 1.22
-            onnx_testing.assert_onnx_program(onnx_program,  atol=1e-2, rtol=1, backend="reference")
-
+            onnx_testing.assert_onnx_program(
+                onnx_program, atol=1e-2, rtol=1, backend="reference"
+            )
 
     def test_graph_accuracy_attention_opset_23(self):
         class Model(torch.nn.Module):
@@ -775,10 +774,13 @@ class DynamoExporterNewOpsetsTest(common_utils.TestCase, _WithExport):
             onnx_testing.assert_onnx_program(onnx_program, atol=1e-2, rtol=1)
         else:
             # Test with reference evaluator because ORT does not support the op as of version 1.22
-            onnx_testing.assert_onnx_program(onnx_program,  atol=1e-2, rtol=1, backend="reference")
+            onnx_testing.assert_onnx_program(
+                onnx_program, atol=1e-2, rtol=1, backend="reference"
+            )
 
     def test_rms_norm(self):
         """Test RMS normalization with various configurations"""
+
         class RMSNormModel(torch.nn.Module):
             def forward(self, x):
                 return torch.nn.functional.rms_norm(x, [10])
@@ -798,6 +800,7 @@ class DynamoExporterNewOpsetsTest(common_utils.TestCase, _WithExport):
 
     def test_rms_norm_with_weight(self):
         """Test RMS normalization with weight parameter"""
+
         class RMSNormWithWeight(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -815,6 +818,7 @@ class DynamoExporterNewOpsetsTest(common_utils.TestCase, _WithExport):
 
     def test_rms_norm_with_eps(self):
         """Test RMS normalization with custom epsilon"""
+
         class RMSNormWithEps(torch.nn.Module):
             def forward(self, x):
                 return torch.nn.functional.rms_norm(x, [10], eps=1e-6)

--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -774,6 +774,60 @@ class DynamoExporterNewOpsetsTest(common_utils.TestCase, _WithExport):
         if has_onnxruntime_opset_23():
             onnx_testing.assert_onnx_program(onnx_program, atol=1e-2, rtol=1)
 
+    def test_rms_norm(self):
+        """Test RMS normalization with various configurations"""
+        class RMSNormModel(torch.nn.Module):
+            def forward(self, x):
+                return torch.nn.functional.rms_norm(x, [10])
+
+        x = torch.randn(20, 5, 10)
+        onnx_program = self.export(RMSNormModel(), (x,))
+        onnx_testing.assert_onnx_program(onnx_program)
+
+        # Test with multi-dimensional normalized_shape
+        class RMSNormModel2D(torch.nn.Module):
+            def forward(self, x):
+                return torch.nn.functional.rms_norm(x, [10, 10])
+
+        x = torch.randn(20, 5, 10, 10)
+        onnx_program = self.export(RMSNormModel2D(), (x,))
+        onnx_testing.assert_onnx_program(onnx_program)
+
+    def test_rms_norm_with_weight(self):
+        """Test RMS normalization with weight parameter"""
+        class RMSNormWithWeight(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.ones(10))
+
+            def forward(self, x):
+                return torch.nn.functional.rms_norm(x, [10], weight=self.weight)
+
+        x = torch.randn(20, 5, 10)
+        expected = RMSNormWithWeight()(x)
+
+        onnx_program = self.export(RMSNormWithWeight(), (x,))
+
+        # Test with reference evaluator for accuracy
+        ref = onnx_ref.ReferenceEvaluator(onnx_program.model_proto)
+        got = ref.run(None, {"x": x.numpy()})[0]
+        torch.testing.assert_close(torch.from_numpy(got), expected, atol=1e-5, rtol=1e-5)
+
+    def test_rms_norm_with_eps(self):
+        """Test RMS normalization with custom epsilon"""
+        class RMSNormWithEps(torch.nn.Module):
+            def forward(self, x):
+                return torch.nn.functional.rms_norm(x, [10], eps=1e-6)
+
+        x = torch.randn(20, 5, 10)
+        expected = RMSNormWithEps()(x)
+
+        onnx_program = self.export(RMSNormWithEps(), (x,))
+
+        # Test with reference evaluator for accuracy
+        ref = onnx_ref.ReferenceEvaluator(onnx_program.model_proto)
+        got = ref.run(None, {"x": x.numpy()})[0]
+        torch.testing.assert_close(torch.from_numpy(got), expected, atol=1e-5, rtol=1e-5)
 
 if __name__ == "__main__":
     common_utils.run_tests()

--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -771,7 +771,7 @@ class DynamoExporterNewOpsetsTest(common_utils.TestCase, _WithExport):
                 return torch.nn.functional.rms_norm(x, [10, 10])
 
         x = torch.randn(20, 5, 10, 10)
-        onnx_program = self.export(RMSNormModel2D(), (x,))
+        onnx_program = self.export(RMSNormModel2D(), (x,), opset_version=23)
         onnx_testing.assert_onnx_program(onnx_program, backend="reference")
 
     def test_rms_norm_with_weight(self):

--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -771,10 +771,7 @@ class DynamoExporterNewOpsetsTest(common_utils.TestCase, _WithExport):
                 return torch.nn.functional.rms_norm(x, [7, 3])
 
         x = torch.randn(2, 5, 7, 3)
-        onnx_program = self.export(
-            RMSNormModel2D(), (x,), opset_version=23, report=True
-        )
-        onnx_program = self.export(RMSNormModel2D(), (x,), report=True)
+        onnx_program = self.export(RMSNormModel2D(), (x,), opset_version=23)
         onnx_testing.assert_onnx_program(onnx_program, backend="reference")
 
     def test_rms_norm_with_weight(self):

--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -725,12 +725,12 @@ class DynamoExporterNewOpsetsTest(common_utils.TestCase, _WithExport):
 
         x = torch.randn(1, 4, 4, 4, dtype=torch.float32)
         onnx_program = self.export(Model(), (x,), opset_version=21)
+        # TODO(after ort support): As of ONNX Runtime 1.22, the operator is not implemented yet.
+        # call assert_onnx_program after ort support
         self.assertIn(
             "GroupNormalization",
             [node.op_type for node in onnx_program.model.graph],
         )
-
-        onnx_testing.assert_onnx_program(onnx_program, backend="reference")
 
     def test_graph_attention_opset_23(self):
         class Model(torch.nn.Module):

--- a/torch/onnx/_internal/exporter/_onnx_program.py
+++ b/torch/onnx/_internal/exporter/_onnx_program.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     import onnxruntime as ort
+    import numpy as np
 
 _LARGE_MODEL_THRESHOLD = 1536 * 1024 * 1024  # 1536MB
 _NP_UNSUPPORTED_DTYPES_8BIT = frozenset(
@@ -115,6 +116,32 @@ def _create_value_mapping(graph: ir.Graph) -> dict[str, ir.Value]:
                 continue
             values[value.name] = value
     return values
+
+
+def _to_numpy_array(input: torch.Tensor | int | float | str | bool) -> np.ndarray:
+    if isinstance(input, (int, float, str, bool)):
+        return ir.tensor(input).numpy()
+
+    from torch.onnx._internal.exporter import _core
+
+    return _core.TorchTensor(input).numpy()
+
+
+def _from_numpy_array(array: np.ndarray) -> torch.Tensor:
+    """Convert a NumPy array to a PyTorch tensor."""
+    import ml_dtypes
+
+    if array.dtype == ml_dtypes.bfloat16:
+        return torch.from_numpy(array.view(np.uint16)).view(torch.bfloat16)
+    if array.dtype == ml_dtypes.float8_e4m3fn:
+        return torch.from_numpy(array.view(np.uint8)).view(torch.float8_e4m3fn)
+    if array.dtype == ml_dtypes.float8_e4m3fnuz:
+        return torch.from_numpy(array.view(np.uint8)).view(torch.float8_e4m3fnuz)
+    if array.dtype == ml_dtypes.float8_e5m2:
+        return torch.from_numpy(array.view(np.uint8)).view(torch.float8_e5m2)
+    if array.dtype == ml_dtypes.float8_e5m2fnuz:
+        return torch.from_numpy(array.view(np.uint8)).view(torch.float8_e5m2fnuz)
+    return torch.from_numpy(array)
 
 
 def _to_ort_value(input: torch.Tensor | int | float | str | bool) -> ort.OrtValue:
@@ -230,6 +257,21 @@ ONNXProgram(
         )
         logger.debug("Inference session run completed.")
         return tuple(_from_ort_value(output) for output in outputs)
+
+    def call_reference(self, *args, **kwargs) -> Sequence[torch.Tensor]:
+        """Run the ONNX model using the reference backend."""
+        import onnx.reference
+
+        evaluator = onnx.reference.ReferenceEvaluator(self.model_proto)
+
+        flatten_args = _process_args(args, kwargs)
+        ref_input = {
+            k.name: _to_numpy_array(v)
+            for k, v in zip(self.model.graph.inputs, flatten_args)
+        }
+        outputs = evaluator.run(None, ref_input)  # type: ignore[arg-type]
+        assert isinstance(outputs, Sequence)
+        return tuple(_from_numpy_array(output) for output in outputs)
 
     def compute_values(
         self, value_names: Sequence[str], args=(), kwargs=None

--- a/torch/onnx/_internal/exporter/_onnx_program.py
+++ b/torch/onnx/_internal/exporter/_onnx_program.py
@@ -13,6 +13,7 @@ import os
 import tempfile
 import textwrap
 import warnings
+from collections.abc import Sequence
 from typing import Any, Callable, TYPE_CHECKING
 
 import torch
@@ -25,10 +26,8 @@ from torch.utils import _pytree
 # because ONNXProgram is exposed to the public API
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-
-    import onnxruntime as ort
     import numpy as np
+    import onnxruntime as ort
 
 _LARGE_MODEL_THRESHOLD = 1536 * 1024 * 1024  # 1536MB
 _NP_UNSUPPORTED_DTYPES_8BIT = frozenset(
@@ -130,6 +129,7 @@ def _to_numpy_array(input: torch.Tensor | int | float | str | bool) -> np.ndarra
 def _from_numpy_array(array: np.ndarray) -> torch.Tensor:
     """Convert a NumPy array to a PyTorch tensor."""
     import ml_dtypes
+    import numpy as np
 
     if array.dtype == ml_dtypes.bfloat16:
         return torch.from_numpy(array.view(np.uint16)).view(torch.bfloat16)

--- a/torch/onnx/_internal/exporter/_testing.py
+++ b/torch/onnx/_internal/exporter/_testing.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 __all__ = ["assert_onnx_program"]
 
-from typing import Any, TYPE_CHECKING, Literal
+from typing import Any, Literal, TYPE_CHECKING
 
 import torch
 from torch.utils import _pytree

--- a/torch/onnx/_internal/exporter/_testing.py
+++ b/torch/onnx/_internal/exporter/_testing.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 __all__ = ["assert_onnx_program"]
 
-from typing import Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, Literal
 
 import torch
 from torch.utils import _pytree
@@ -23,6 +23,7 @@ def assert_onnx_program(
     args: tuple[Any, ...] | None = None,
     kwargs: dict[str, Any] | None = None,
     strategy: str | None = "TorchExportNonStrictStrategy",
+    backend: Literal["onnxruntime", "reference"] = "onnxruntime",
 ) -> None:
     """Assert that the ONNX model produces the same output as the PyTorch ExportedProgram.
 
@@ -37,6 +38,8 @@ def assert_onnx_program(
         strategy: Assert the capture strategy used to export the program. Values can be
             class names like "TorchExportNonStrictStrategy".
             If None, the strategy is not asserted.
+        backend: The backend to use for evaluating the ONNX program.
+            Supported values are "onnxruntime" and "reference".
     """
     if strategy is not None:
         if program._capture_strategy != strategy:
@@ -74,7 +77,17 @@ def assert_onnx_program(
             torch_outputs_adapted.append(torch.view_as_real(output))
         else:
             torch_outputs_adapted.append(output)
-    onnx_outputs = program(*args, **kwargs)
+
+    # Obtain the ONNX outputs using the specified backend
+    if backend == "onnxruntime":
+        onnx_outputs = program(*args, **kwargs)
+    elif backend == "reference":
+        onnx_outputs = program.call_reference(*args, **kwargs)
+    else:
+        raise ValueError(
+            f"Unsupported backend '{backend}'. Supported backends are 'onnxruntime' and 'reference'."
+        )
+
     # TODO(justinchuby): Include output names in the error message
     torch.testing.assert_close(
         tuple(onnx_outputs),

--- a/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
@@ -69,7 +69,7 @@ def aten_rms_norm(
 
     # Default eps value if not provided
     if eps is None:
-        eps = 1e-07  # Observed from decomp
+        eps = torch.finfo(torch.float).eps  # Observed from decomp
 
     # Calculate axis: the first normalization dimension
     # For normalized_shape with D dimensions, normalize over last D dimensions

--- a/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
@@ -58,6 +58,33 @@ def aten_group_norm(
     )
 
 
+@onnx_impl(aten.rms_norm.default, trace_only=True, opset_introduced=23)
+def aten_rms_norm(
+    input: TFloat,
+    normalized_shape: list[int],
+    weight: Optional[TFloat] = None,
+    eps: Optional[float] = None,
+) -> TFloat:
+    """rms_norm(Tensor input, SymInt[] normalized_shape, Tensor? weight=None, float? eps=None) -> Tensor"""
+
+    # Default eps value if not provided
+    if eps is None:
+        eps = 1e-05
+
+    # Calculate axis: the first normalization dimension
+    # For normalized_shape with D dimensions, normalize over last D dimensions
+    # Since ONNX RMSNormalization supports negative axis values, we use -len(normalized_shape)
+    # which correctly maps to the first axis of the normalized dimensions
+    normalized_dims = len(normalized_shape)
+    axis = -normalized_dims
+
+    # Create weight tensor if not provided
+    if weight is None:
+        weight = op23.Constant(value=ir.tensor(1.0, dtype=input.dtype))
+
+    return op23.RMSNormalization(input, weight, axis=axis, epsilon=eps)
+
+
 @onnx_impl(
     aten.scaled_dot_product_attention.default, trace_only=True, opset_introduced=23
 )

--- a/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
@@ -69,7 +69,7 @@ def aten_rms_norm(
 
     # Default eps value if not provided
     if eps is None:
-        eps = 1e-05
+        eps = 1e-07  # Observed from decomp
 
     # Calculate axis: the first normalization dimension
     # For normalized_shape with D dimensions, normalize over last D dimensions


### PR DESCRIPTION
- Implement rms norm using onnx RMSNormalization-23
- Use the correct eps for float32
  https://github.com/pytorch/pytorch/blob/eaadd1282c8e66f37acf54f95668529831c95df7/aten/src/ATen/native/cuda/layer_norm_kernel.cu#L1844-L1866
  <img width="743" height="107" alt="image" src="https://github.com/user-attachments/assets/a6fd45aa-01d9-4667-924d-3012232cfcde" />

- Created facility to run tests with the reference runtime by extending ONNXProgram and assert_onnx_program.

Fix https://github.com/pytorch/pytorch/issues/159257