### PR TITLE
[inductor] consolidate common GEMM triton param retrieval

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -35,7 +35,10 @@ from torch._inductor.select_algorithm import (
     TritonTemplate,
     TritonTemplateCaller,
 )
-from torch._inductor.template_heuristics import CUDAConfigHeuristic, GemmConfig
+from torch._inductor.template_heuristics import (
+    CUDAMMTemplateConfigHeuristic,
+    GemmConfig,
+)
 from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FP8
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
@@ -1173,7 +1176,7 @@ class TestMaxAutotune(TestCase):
         # Force only decomposeK choice
         with (
             mock.patch(
-                "torch._inductor.kernel.mm.V.choices.get_base_mm_configs"
+                "torch._inductor.kernel.mm.V.choices.get_mm_configs"
             ) as base_mm_mock,
             mock.patch(
                 "torch._inductor.kernel.mm.use_decompose_k_choice"
@@ -1561,9 +1564,9 @@ class TestMaxAutotune(TestCase):
         b = torch.randn(K, N, dtype=torch.float16, device="cuda", requires_grad=True)
 
         with mock.patch(
-            "torch._inductor.kernel.mm.V.choices.get_config_heuristics"
+            "torch._inductor.template_registry.get_template_heuristic"
         ) as config_mock:
-            config_heuristics = CUDAConfigHeuristic()
+            config_heuristics = CUDAMMTemplateConfigHeuristic()
 
             # Traditionally, this would be set of all possible configs
             # We mock out the code path for the sake of the unit test

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -9,6 +9,7 @@ import torch
 
 from . import config
 from .codecache import write_text
+from .kernel_inputs import KernelInputs  # noqa: TC001
 from .metrics import get_metric_table, is_metric_table_enabled
 from .runtime.hints import DeviceProperties, ReductionHint
 from .scheduler import BaseSchedulerNode, Scheduler, WhyNoFuse
@@ -20,6 +21,7 @@ from .template_heuristics import (
     ROCmConfigHeuristic,
     XPUConfigHeuristic,
 )
+from .template_registry import get_template_heuristic
 from .virtualized import V
 
 
@@ -71,58 +73,6 @@ class InductorChoices:
         else:
             return BaseConfigHeuristic()
 
-    # GEMM configs
-    def get_base_mm_configs(
-        self, device_type: Optional[str] = "cuda"
-    ) -> partial[Generator[TritonConfig, None, None]]:
-        mm_heuristics = self.get_config_heuristics(device_type)
-        if config.max_autotune_gemm_search_space != "EXHAUSTIVE":
-            return mm_heuristics.get_mm_configs()
-        else:
-            return mm_heuristics.get_exhaustive_mm_configs()
-
-    def get_extra_mm_configs(
-        self, device_type: Optional[str] = "cuda"
-    ) -> partial[Generator[TritonConfig, None, None]]:
-        mm_heuristics = self.get_config_heuristics(device_type)
-        return mm_heuristics.get_extra_mm_configs()
-
-    def get_int8_mm_configs(
-        self, device_type: Optional[str] = "cuda"
-    ) -> partial[Generator[TritonConfig, None, None]]:
-        mm_heuristics = self.get_config_heuristics(device_type)
-        return mm_heuristics.get_int8_mm_configs()
-
-    def get_mixed_mm_configs(
-        self, device_type: Optional[str] = "cuda"
-    ) -> partial[Generator[TritonConfig, None, None]]:
-        mm_heuristics = self.get_config_heuristics(device_type)
-        return mm_heuristics.get_mixed_mm_configs()
-
-    def get_persistent_mm_configs(
-        self, device_type: Optional[str] = "cuda"
-    ) -> partial[Generator[TritonConfig, None, None]]:
-        mm_heuristics = self.get_config_heuristics(device_type)
-        return mm_heuristics.get_persistent_mm_configs()
-
-    def get_scaled_mm_configs(
-        self, device_type: Optional[str] = "cuda"
-    ) -> partial[Generator[TritonConfig, None, None]]:
-        mm_heuristics = self.get_config_heuristics(device_type)
-        return mm_heuristics.get_scaled_mm_configs()
-
-    def get_scaled_persistent_mm_configs(
-        self, device_type: Optional[str] = "cuda"
-    ) -> partial[Generator[TritonConfig, None, None]]:
-        mm_heuristics = self.get_config_heuristics(device_type)
-        return mm_heuristics.get_scaled_persistent_mm_configs()
-
-    def get_mm_plus_mm_configs(
-        self, device_type: Optional[str] = "cuda"
-    ) -> partial[Generator[TritonConfig, None, None]]:
-        mm_heuristics = self.get_config_heuristics(device_type)
-        return mm_heuristics.get_mm_plus_mm_configs()
-
     # Conv configs
     def get_conv_configs(
         self, device_type: Optional[str] = "cuda"
@@ -131,6 +81,7 @@ class InductorChoices:
         return conv_heuristics.get_conv_configs()
 
     # Flex attention configs
+    # TODO(coconutruben): break out flexattention/decode configs into the new retrieval mechanism
     def get_flex_attention_fwd_configs(
         self, head_dim: int, dtype: torch.dtype, device_type: Optional[str] = "cuda"
     ) -> list[Any]:
@@ -148,6 +99,37 @@ class InductorChoices:
     ) -> list[Any]:
         flex_heuristics = self.get_config_heuristics(device_type)
         return flex_heuristics.get_flex_decode_configs(head_dim, dtype)
+
+    def get_mm_configs(
+        self,
+        kernel_inputs: KernelInputs,
+        layout: Any,
+        template_name: str,
+        op_name: str,
+    ) -> Generator[dict[str, Any], None, None]:
+        """
+        Get generator of template parameters for MM templates using template-specific heuristics.
+
+        Args:
+            kernel_inputs: MMKernelInputs containing input tensor nodes and matrix indices
+            layout: Output layout
+            template_name: Template name (e.g., "bmm", "mm", "mm_persistent_tma")
+            op_name: Operation name (e.g., "bmm", "baddbmm", "addmm", "mm_plus_mm")
+
+        Yields:
+            Template parameter dictionaries ready for maybe_append_choice
+        """
+        input_tensors = kernel_inputs.nodes()
+        if len(input_tensors) < 2:
+            raise ValueError(f"Need at least 2 input tensors, got {len(input_tensors)}")
+
+        # Extract device_type from kernel_inputs
+        device_type = kernel_inputs.device_type
+        assert device_type is not None, "get_mm_configs requires a valid device type"
+        # Get the appropriate template-specific heuristic
+        heuristic = get_template_heuristic(template_name, device_type, op_name)
+
+        yield from heuristic.get_template_configs(kernel_inputs, layout, op_name)
 
     def triton_kernel_kwargs(
         self,

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -6,6 +6,7 @@ from torch._dynamo.utils import counters
 from torch._inductor.codegen.rocm.ck_universal_gemm_template import CKGemmTemplate
 
 from .. import ir, lowering as L
+from ..kernel_inputs import MMKernelInputs
 from ..select_algorithm import (
     autotune_select_algorithm,
     ExternKernelChoice,
@@ -26,8 +27,6 @@ from .mm_common import (
     addmm_epilogue,
     is_batch_stride_largest,
     mm_args,
-    mm_config_kwargs,
-    mm_options,
 )
 
 
@@ -38,13 +37,6 @@ aten = torch.ops.aten
 @SymbolicGridFn
 def bmm_grid(b, m, n, meta, *, cdiv):
     return (cdiv(m, meta["BLOCK_M"]) * cdiv(n, meta["BLOCK_N"]), b, 1)
-
-
-def _is_large_block_for_cpu(m, n, k):
-    # Thresholds are experimentally determined to reduce Triton CPU compile times
-    if m > 128 or n > 128 or k > 128:
-        return True
-    return m * n > 2**12
 
 
 bmm_template = TritonTemplate(
@@ -175,9 +167,14 @@ def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
             meta_mat2 = V.graph.current_node.args[1]
             mat2 = may_require_contiguous(mat2, meta_mat2)
 
+    # TODO(coconutruben): integrate into MMKernelInputs when all callsites use that
     m, n, k, layout, mat1, mat2 = mm_args(
         mat1, mat2, layout=layout, out_dtype=out_dtype
     )
+    name = "bmm"
+
+    # Create MMKernelInputs for BMM at the top
+    kernel_inputs = MMKernelInputs([mat1, mat2])
 
     # below is for getting an overview logging info of inductor mms
     batch_size = mat1.get_size()[0]  # Extract batch dimension
@@ -195,31 +192,27 @@ def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
 
     if out_dtype:
         assert mat1.get_device().type == "cuda", "out_dtype is only supported for CUDA"
-        aten_func = aten_bmm_dtype.bind((mat1, mat2), layout, out_dtype=out_dtype)
+        aten_func = aten_bmm_dtype.bind(
+            kernel_inputs.nodes(), layout, out_dtype=out_dtype
+        )
     else:
-        aten_func = aten_bmm.bind((mat1, mat2), layout)
+        aten_func = aten_bmm.bind(kernel_inputs.nodes(), layout)
 
     # options to tune from
     choices = [aten_func] if use_aten_gemm_kernels() else []
 
-    device_type = ir.get_device_type(mat1)
-    bmm_configs = V.choices.get_base_mm_configs(device_type)
-
-    dtype = mat1.get_dtype()
     if use_triton_template(layout):
         # TODO: add out_dtype support for Triton Template
         assert out_dtype is None, "out_dtype is not supported for Triton"
-        for config in bmm_configs(
-            m,
-            n,
-            k,
-            **mm_config_kwargs(device_type, _is_large_block_for_cpu, dtype.itemsize),
+
+        for kwargs in V.choices.get_mm_configs(
+            kernel_inputs, layout, bmm_template.name, name
         ):
             bmm_template.maybe_append_choice(
                 choices,
-                input_nodes=(mat1, mat2),
+                input_nodes=kernel_inputs.nodes(),
                 layout=layout,
-                **mm_options(config, m, n, k, layout),
+                **kwargs,
             )
     _, is_nonzero = _is_static_problem(layout)
     batch_stride_largest = is_batch_stride_largest(mat1, mat2, layout)
@@ -227,11 +220,13 @@ def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
         batch_stride_largest
         and is_nonzero
         and use_cutlass_template(layout, m, n, k)
-        and _use_cutlass_for_op("bmm")
+        and _use_cutlass_for_op(name)
     ):
         from ..codegen.cuda.gemm_template import CUTLASS3xGemmTemplate
 
-        CUTLASS3xGemmTemplate.add_cutlass_gemm_choices(choices, layout, [mat1, mat2])  # type: ignore[arg-type]
+        CUTLASS3xGemmTemplate.add_cutlass_gemm_choices(
+            choices, layout, kernel_inputs.nodes()
+        )  # type: ignore[arg-type]
 
     if use_cpp_bmm_template(layout, mat1, mat2):
         from ..codegen.cpp_bmm_template import CppBmmTemplate
@@ -239,18 +234,22 @@ def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
         CppBmmTemplate.add_choices(
             choices,
             layout,
-            [mat1, mat2],
+            kernel_inputs.nodes(),
         )
 
     if use_ck_gemm_template(layout, m, n, k):
-        CKGemmTemplate.add_ck_gemm_choices(choices, layout, [mat1, mat2])
+        CKGemmTemplate.add_ck_gemm_choices(choices, layout, kernel_inputs.nodes())
 
-    return autotune_select_algorithm("bmm", choices, [mat1, mat2], layout)
+    return autotune_select_algorithm(name, choices, kernel_inputs.nodes(), layout)
 
 
 @L.register_lowering(aten.baddbmm)
 def tuned_baddbmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
+    # TODO(coconutruben): integrate into MMKernelInputs when all callsites use that
     m, n, k, layout, mat1, mat2, inp = mm_args(mat1, mat2, inp, layout=layout)
+
+    # Create MMKernelInputs for BadDBMM at the top
+    kernel_inputs = MMKernelInputs([inp, mat1, mat2])
 
     # below is for getting an overview logging info of inductor mms
     batch_size = mat1.get_size()[0]
@@ -266,29 +265,26 @@ def tuned_baddbmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
         inp.get_dtype(),
         layout,
     )
-
+    name = "baddbmm"
     # options to tune from
     choices = (
-        [aten_baddbmm.bind((inp, mat1, mat2), layout, alpha=alpha, beta=beta)]
+        [aten_baddbmm.bind(kernel_inputs.nodes(), layout, alpha=alpha, beta=beta)]
         if use_aten_gemm_kernels()
         else []
     )
 
-    device_type = ir.get_device_type(mat1)
-    bmm_configs = V.choices.get_base_mm_configs(device_type)
-
     if use_triton_template(layout):
-        for config in bmm_configs(
-            m, n, k, **mm_config_kwargs(device_type, _is_large_block_for_cpu)
+        for kwargs in V.choices.get_mm_configs(
+            kernel_inputs, layout, bmm_template.name, name
         ):
             bmm_template.maybe_append_choice(
                 choices,
-                input_nodes=(inp, mat1, mat2),
+                input_nodes=kernel_inputs.nodes(),
                 layout=layout,
-                **mm_options(config, m, n, k, layout),
+                **kwargs,
                 prefix_args=1,
                 epilogue_fn=addmm_epilogue(layout.dtype, alpha, beta),
                 epilogue_fn_hash=str(["addmm_epilogue", layout.dtype, alpha, beta]),
             )
 
-    return autotune_select_algorithm("baddbmm", choices, [inp, mat1, mat2], layout)
+    return autotune_select_algorithm(name, choices, kernel_inputs.nodes(), layout)

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -29,7 +29,6 @@ from ..utils import (
     use_triton_template,
 )
 from ..virtualized import V
-from .mm_common import mm_config_kwargs
 
 
 if TYPE_CHECKING:
@@ -59,13 +58,6 @@ def conv3d_grid(n, c, d, h, w, meta, *, cdiv):
         cdiv(c, meta["BLOCK_N"]),
         meta["GROUPS"],
     )
-
-
-def _is_large_block_for_cpu(m, n, k):
-    # Thresholds are experimentally determined to reduce Triton CPU compile times
-    if m > 256 or n > 256 or k > 256:
-        return True
-    return m * n * k > 2**17
 
 
 LOOP_BODY_2D = """
@@ -603,7 +595,6 @@ def convolution(
             sympy_product([x.get_size()[0], *x.get_size()[2:]]),
             out_chan,
             in_chan,
-            **mm_config_kwargs(device_type, _is_large_block_for_cpu),
         ):
             if ndim == 2:
                 conv2d_template.maybe_append_choice(

--- a/torch/_inductor/kernel/mm_plus_mm.py
+++ b/torch/_inductor/kernel/mm_plus_mm.py
@@ -1,8 +1,10 @@
 # mypy: allow-untyped-defs
 
+import logging
+
 import torch
 
-from .. import ir
+from ..kernel_inputs import MMKernelInputs
 from ..lowering import lowerings
 from ..select_algorithm import (
     autotune_select_algorithm,
@@ -11,8 +13,10 @@ from ..select_algorithm import (
 )
 from ..utils import use_aten_gemm_kernels, use_triton_template
 from ..virtualized import V
-from .mm_common import mm_args, mm_grid, mm_options
+from .mm_common import mm_args, mm_grid
 
+
+log = logging.getLogger(__name__)
 
 aten = torch.ops.aten
 
@@ -119,9 +123,9 @@ def tuned_mm_plus_mm(mat1, mat2, mat3, mat4, *, layout=None):
     """
     Computes mm(mat1, mat2) + mm(mat3, mat4)
     """
+    # TODO(coconutruben): integrate into MMKernelInputs when all callsites use that
     m1, n1, k1, layout1, mat1, mat2 = mm_args(mat1, mat2, layout=layout)
     m2, n2, _, layout2, mat3, mat4 = mm_args(mat3, mat4, layout=layout)
-    device_type = ir.get_device_type(mat1)
 
     # Optimization is optional, because we can always just not do the fusion
     if (
@@ -140,27 +144,34 @@ def tuned_mm_plus_mm(mat1, mat2, mat3, mat4, *, layout=None):
             lowerings[aten.mm](mat1, mat2), lowerings[aten.mm](mat3, mat4)
         )
 
+    # Create MMKernelInputs for MM Plus MM (matrices are at indices 0, 1 for first pair)
+    # Note: This is a special case with 4 matrices, but we use the first pair for M, N, K extraction
+    kernel_inputs = MMKernelInputs([mat1, mat2, mat3, mat4], mat1_idx=0, mat2_idx=1)
+
     assert layout1 == layout2
     # options to tune from
     choices = (
-        [aten_mm_plus_mm.bind((mat1, mat2, mat3, mat4), layout1)]
+        [aten_mm_plus_mm.bind(kernel_inputs.nodes(), layout1)]
         if use_aten_gemm_kernels()
         else []
     )
 
-    mm_configs = V.choices.get_mm_plus_mm_configs(device_type)
     if use_triton_template(layout1):
-        for config in mm_configs():
+        # Get template params using the new unified function
+        for kwargs in V.choices.get_mm_configs(
+            kernel_inputs, layout1, mm_plus_mm_template.name, "mm_plus_mm"
+        ):
+            # Apply BLOCK_K constraint specific to mm_plus_mm
             # see https://github.com/triton-lang/triton/issues/1298
             # BLOCK_K = K causes llvm error
-            if V.graph.sizevars.statically_known_lt(config.kwargs["BLOCK_K"], k1):
+            if V.graph.sizevars.statically_known_lt(kwargs.get("BLOCK_K", k1), k1):
                 mm_plus_mm_template.maybe_append_choice(
                     choices,
-                    input_nodes=(mat1, mat2, mat3, mat4),
+                    input_nodes=kernel_inputs.nodes(),
                     layout=layout1,
-                    **mm_options(config, m1, n1, k1, layout1),
+                    **kwargs,
                 )
 
     return autotune_select_algorithm(
-        "mm_plus_mm", choices, [mat1, mat2, mat3, mat4], layout1
+        "mm_plus_mm", choices, kernel_inputs.nodes(), layout1
     )

--- a/torch/_inductor/kernel_inputs.py
+++ b/torch/_inductor/kernel_inputs.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+from typing import Any, Optional, TYPE_CHECKING
+
+import torch
+import torch._inductor.config
+from torch._inductor import ir
+from torch._inductor.virtualized import V
+
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    import sympy
+
+
+class KernelInputs:
+    """
+    Class to store and provide access to input nodes for kernels.
+    This class takes in a tuple of input nodes and provides methods to access
+    information about these nodes, such as their device type and device.
+    """
+
+    def __init__(self, input_nodes: list[Any]):
+        """
+        Initialize with a tuple of input nodes.
+
+        Args:
+            input_nodes: A tuple of input nodes to store
+        """
+        self._input_nodes = input_nodes
+        self._device_name: Optional[str] = None
+        assert len(input_nodes) > 0, "Expected at least one input node"
+
+    def nodes(self, reorder: Optional[Sequence[int]] = None) -> list[Any]:
+        """
+        Return the stored input nodes, optionally reordered.
+
+        Args:
+            reorder: Optional sequence of indices to reorder the nodes.
+                    For example, (2, 0, 1) would return nodes in that order.
+
+        Returns:
+            The tuple of input nodes, optionally reordered
+        """
+        if reorder is None:
+            return self._input_nodes
+        assert len(self._input_nodes) == len(reorder), (
+            f"Reorder length mismatch: {len(self._input_nodes)} vs {len(reorder)}"
+        )
+        return [self._input_nodes[i] for i in reorder]
+
+    @property
+    def device_type(self) -> Optional[str]:
+        """
+        Get the device type of the first node.
+
+        Returns:
+            The device type (e.g., 'cuda', 'cpu')
+        """
+
+        return ir.get_device_type(self._input_nodes[0])
+
+    def device(self) -> torch.device:
+        """
+        Get the device of the first node.
+
+        Returns:
+            The device of the first node
+        """
+        return self._input_nodes[0].get_device()
+
+    def device_name(self) -> Optional[str]:
+        """
+        Get the device name information.
+
+        Returns:
+            A tuple of (gpu_name, vendor, model)
+        """
+        if self._device_name is None:
+            device = self.device()
+            if self.device_type == "cuda":
+                device_properties = torch.cuda.get_device_properties(device)
+                self._device_name = device_properties.gcnArchName
+        return self._device_name
+
+    def shapes_symbolic(self) -> tuple[tuple[Any, ...], ...]:
+        """
+        Get the symbolic shapes of all input nodes.
+
+        Returns:
+            A tuple of shape tuples for each input node
+        """
+        return tuple(node.get_size() for node in self._input_nodes)
+
+    def shapes_hinted(self) -> tuple[tuple[int, ...], ...]:
+        """
+        Get the size hints for shapes of all input nodes.
+
+        Returns:
+            A tuple of shape tuples with integer hints for each input node
+        """
+        return tuple(
+            V.graph.sizevars.size_hints(
+                node.get_size(),
+                fallback=torch._inductor.config.unbacked_symint_fallback,
+            )
+            for node in self._input_nodes
+        )
+
+    def strides_symbolic(self) -> tuple[tuple[sympy.Integer, ...], ...]:
+        """
+        Get the symbolic strides of all input nodes.
+
+        Returns:
+            A tuple of stride tuples for each input node
+        """
+        return tuple(node.get_stride() for node in self._input_nodes)
+
+    def strides_hinted(self) -> tuple[tuple[int, ...], ...]:
+        """
+        Get the size hints for strides of all input nodes.
+
+        Returns:
+            A tuple of stride tuples with integer hints for each input node
+        """
+        return tuple(
+            V.graph.sizevars.size_hints(
+                node.get_stride(),
+                fallback=torch._inductor.config.unbacked_symint_fallback,
+            )
+            for node in self._input_nodes
+        )
+
+    def dtypes(self) -> tuple[torch.dtype, ...]:
+        """
+        Get the dtypes of all input nodes.
+
+        Returns:
+            A tuple of dtypes for each input node
+        """
+        return tuple(node.get_dtype() for node in self._input_nodes)
+
+    def dtype(self, idx: int = 0) -> torch.dtype:
+        """
+        Get the dtype of a specific input node.
+
+        Args:
+            idx: Index of the node to get the dtype from (default: 0)
+
+        Returns:
+            The dtype of the specified input node
+        """
+        return self._input_nodes[idx].get_dtype()
+
+
+class MMKernelInputs(KernelInputs):
+    """
+    Specialized KernelInputs for matrix multiplication operations.
+    Provides additional methods to access M, N, K dimensions.
+    """
+
+    def __init__(self, input_nodes: list[Any], mat1_idx: int = -2, mat2_idx: int = -1):
+        """
+        Initialize with a tuple of input nodes.
+
+        By default, we assume the last 2 input nodes are mat1 and mat2, but
+        the caller can adjust when necessary
+        """
+        super().__init__(input_nodes)
+        # for mm, we need at least 2 nodes, and we need to know which nodes
+        # are the main matrixes e.g. addmm is (bias, mat1, mat2) whereas others
+        # might be (mat1, mat2, scale), etc.
+        assert len(self._input_nodes) >= 2, "Expected at least 2 input nodes"
+
+        # Adjust assertions to handle negative indices
+        m1_idx, m2_idx = mat1_idx, mat2_idx
+        if mat1_idx < 0:
+            m1_idx += len(input_nodes)
+        if mat2_idx < 0:
+            m2_idx += len(input_nodes)
+
+        assert 0 <= m1_idx < len(input_nodes), f"Invalid mat1_idx: {mat1_idx}"
+        assert 0 <= m1_idx < len(input_nodes), f"Invalid mat2_idx: {mat2_idx}"
+
+        self._mat1_idx = mat1_idx
+        self._mat2_idx = mat2_idx
+
+    def mnk_symbolic(
+        self,
+    ) -> tuple[sympy.Integer, sympy.Integer, sympy.Integer]:
+        """
+        Get the symbolic M, N, K dimensions for matrix multiplication.
+        Handles both 2D (MM) and 3D (BMM) tensors.
+
+        M is extracted from the second-to-last dimension of the first operand (mat1).
+        N is extracted from the last dimension of the second operand (mat2).
+        K is extracted from the last dimension of the first operand (mat1).
+
+        Returns:
+            A tuple of (M, N, K) dimensions
+        """
+        mat1 = self.nodes()[self._mat1_idx]
+        mat2 = self.nodes()[self._mat2_idx]
+
+        m = mat1.get_size()[-2]  # M from second-to-last dimension of mat1
+        k = mat1.get_size()[-1]  # K from last dimension of mat1
+        n = mat2.get_size()[-1]  # N from last dimension of mat2
+
+        # Ensure K dimensions match between operands
+        k0 = mat2.get_size()[-2]  # K from second-to-last dimension of mat2
+        V.graph.sizevars.check_equals(k, k0)
+        return (m, n, k)
+
+    def mnk_hinted(self) -> tuple[int, int, int]:
+        """
+        Get the hinted M, N, K dimensions for matrix multiplication.
+        Handles both 2D (MM) and 3D (BMM) tensors.
+
+        Uses shapes_hinted from the base class to get integer hints for dimensions.
+
+        Returns:
+            A tuple of (M, N, K) dimensions as integers
+        """
+        hinted_shapes = self.shapes_hinted()
+        mat1_shape = hinted_shapes[self._mat1_idx]
+        mat2_shape = hinted_shapes[self._mat2_idx]
+
+        m = mat1_shape[-2]  # M from second-to-last dimension of mat1
+        k = mat1_shape[-1]  # K from last dimension of mat1
+        n = mat2_shape[-1]  # N from last dimension of mat2
+
+        # Ensure K dimensions match between operands
+        k_check = mat2_shape[-2]  # K from second-to-last dimension of mat2
+        assert k == k_check, f"K dimensions don't match: {k} vs {k_check}"
+
+        return (m, n, k)

--- a/torch/_inductor/template_heuristics.py
+++ b/torch/_inductor/template_heuristics.py
@@ -7,11 +7,16 @@ from functools import partial
 from threading import Lock
 from typing import Any, Callable, Optional, TYPE_CHECKING
 
+import sympy
+
 import torch
 from torch.utils._ordered_set import OrderedSet
+from torch.utils._triton import has_triton_stable_tma_api
 
-from . import config
-from .utils import get_backend_num_stages
+from . import config, config as inductor_config
+from .kernel_inputs import KernelInputs, MMKernelInputs
+from .template_registry import register_template_heuristic
+from .utils import get_backend_num_stages, get_num_sms, TMA_DESCRIPTOR_SIZE
 from .virtualized import V
 
 
@@ -147,6 +152,9 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
     """
 
     def __init__(self) -> None:
+        # Whether the heuristic is used for int8. Use this when the heuristic is int8 exclusive
+        # but prefer the preprocess_mm_configs argument when it's used for both
+        self.has_int8_tensor: bool = False
         # List of dictionaries to store the kernel configs. Configs that evaluate to true
         # will be utilised on the target platform. The configs are as follows:
         # (BLOCK_M, BLOCK_N, BLOCK_K, num_stages, num_warps)
@@ -467,7 +475,7 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
         configs: list[BaseConfig],
         scale: float,
         has_int8_tensor: bool,
-        exclude: Callable[[int, int, int], bool],
+        exclude: Callable[[sympy.Integer, sympy.Integer, sympy.Integer], bool],
         hint_override: Optional[int] = None,
     ) -> list[BaseConfig]:
         """
@@ -476,7 +484,7 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
         from .runtime.runtime_utils import next_power_of_2
 
         min_block_size = 16
-        min_block_size_k = 32 if has_int8_tensor else 16
+        min_block_size_k = 32 if (has_int8_tensor or self.has_int8_tensor) else 16
 
         scaled_configs = []
         for hint_override in [None] + config.multi_kernel_hints:
@@ -561,6 +569,13 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
 
         return pruned_configs
 
+    def _filter_configs(self, configs: list[BaseConfig]) -> list[BaseConfig]:
+        """
+        Filter configs based on specific requirements.
+        Subclasses can override this to implement custom filtering logic.
+        """
+        return configs
+
     def preprocess_mm_configs(
         self,
         m: int,
@@ -568,14 +583,17 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
         k: int,
         configs: list[BaseConfig],
         has_int8_tensor: bool = False,
-        scale: int = 1,
-        exclude: Callable[[int, int, int], bool] = lambda m, n, k: False,
+        scale: float = 1.0,
+        exclude: Callable[
+            [sympy.Integer, sympy.Integer, sympy.Integer], bool
+        ] = lambda m, n, k: False,
         dtype_size: int = 0,
+        op_name: str = "mm",  # For preprocessing overrides e.g. on CPU
     ) -> Generator[TritonConfig, None, None]:
+        configs = self._filter_configs(configs)
         scaled_configs = self._scale_mm_configs(
             m, n, k, configs, scale, has_int8_tensor, exclude
         )
-
         if config.max_autotune_gemm_search_space == "EXHAUSTIVE":
             assert dtype_size > 0, "dtype_size must be provided for exhaustive search"
             scaled_configs = self._prune_exhaustive_configs(scaled_configs, dtype_size)
@@ -594,48 +612,10 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
     def get_exhaustive_mm_configs(self) -> partial[Generator[TritonConfig, None, None]]:
         return partial(self.preprocess_mm_configs, configs=self.exhaustive_configs)
 
-    def get_extra_mm_configs(self) -> partial[Generator[TritonConfig, None, None]]:
-        return partial(self.preprocess_mm_configs, configs=self.extra_mm_configs)
-
-    def get_int8_mm_configs(self) -> partial[Generator[TritonConfig, None, None]]:
-        return partial(self.preprocess_mm_configs, configs=self.int8_mm_configs)
-
-    def get_mixed_mm_configs(self) -> partial[Generator[TritonConfig, None, None]]:
-        mm_configs = (
-            self.mm_configs + self.mixed_mm_configs
-            if config.max_autotune_gemm_search_space == "EXHAUSTIVE"
-            else self.mm_configs
-        )
-        return partial(self.preprocess_mm_configs, configs=mm_configs)
-
-    def get_persistent_mm_configs(self) -> partial[Generator[TritonConfig, None, None]]:
-        persistent_mm_configs = (
-            self.exhaustive_configs
-            if config.max_autotune_gemm_search_space == "EXHAUSTIVE"
-            else self.persistent_mm_configs
-        )
-
-        # num_warps=2 not safe for TMA
-        persistent_mm_configs = [
-            config for config in persistent_mm_configs if config.num_warps != 2
-        ]
-        return partial(self.preprocess_mm_configs, configs=persistent_mm_configs)
-
-    def get_scaled_mm_configs(self) -> partial[Generator[TritonConfig, None, None]]:
-        return partial(self.preprocess_mm_configs, configs=self.scaled_mm_configs)
-
-    def get_scaled_persistent_mm_configs(
-        self,
-    ) -> partial[Generator[TritonConfig, None, None]]:
-        return partial(
-            self.preprocess_mm_configs, configs=self.scaled_persistent_mm_configs
-        )
-
-    def get_mm_plus_mm_configs(self) -> partial[Generator[TritonConfig, None, None]]:
-        return partial(self._finalize_mm_configs, configs=self.mm_plus_mm_configs)
-
     def get_conv_configs(self) -> partial[Generator[TritonConfig, None, None]]:
-        return partial(self.preprocess_mm_configs, configs=self.conv_configs)
+        return partial(
+            self.preprocess_mm_configs, configs=self.conv_configs, op_name="conv"
+        )
 
     # Flex attn helpers
     def get_flex_attn_fwd_configs(self, head_dim: int, dtype: Any) -> list[FlexConfig]:
@@ -696,7 +676,80 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
 
 
 class CPUConfigHeuristic(BaseConfigHeuristic):
-    pass
+    """
+    CPU-specific config heuristic with CPU-specific optimizations.
+    """
+
+    def _get_cpu_exclude_function(
+        self, method: str = "bmm"
+    ) -> Callable[[sympy.Integer, sympy.Integer, sympy.Integer], bool]:
+        """
+        Get CPU-specific exclude function based on method type.
+        Returns a function that can be used as exclude condition.
+        Moved from mm_common._is_large_block_for_cpu and refactored to return a function.
+        """
+        if method in ("conv"):
+
+            def exclude_conv(
+                m: sympy.Integer, n: sympy.Integer, k: sympy.Integer
+            ) -> bool:
+                # Thresholds are experimentally determined to reduce Triton CPU compile times
+                if m > 256 or n > 256 or k > 256:
+                    return True
+                return m * n * k > 2**17
+
+            return exclude_conv
+        elif method in ("mm", "addmm", "int_mm"):
+
+            def exclude_mm(
+                m: sympy.Integer, n: sympy.Integer, k: sympy.Integer
+            ) -> bool:
+                return m * n > 2**13
+
+            return exclude_mm
+        else:  # Default to bmm implementation for unknown methods
+
+            def exclude_bmm(
+                m: sympy.Integer, n: sympy.Integer, k: sympy.Integer
+            ) -> bool:
+                if m > 128 or n > 128 or k > 128:
+                    return True
+                return m * n > 2**12
+
+            return exclude_bmm
+
+    def preprocess_mm_configs(
+        self,
+        m: int,
+        n: int,
+        k: int,
+        configs: list[BaseConfig],
+        has_int8_tensor: bool = False,
+        scale: float = 1.0,
+        exclude: Callable[
+            [sympy.Integer, sympy.Integer, sympy.Integer], bool
+        ] = lambda m, n, k: False,
+        dtype_size: int = 0,
+        op_name: str = "mm",  # For preprocessing overrides e.g. on CPU
+    ) -> Generator[TritonConfig, None, None]:
+        """
+        CPU-specific preprocessing that applies CPU-specific scaling (0.5) and exclusion logic.
+        """
+        # Get CPU-specific exclude function based on operation type
+        cpu_exclude_fn = self._get_cpu_exclude_function(op_name)
+
+        # Apply CPU-specific scaling (0.5) and exclusion logic
+        return super().preprocess_mm_configs(
+            m,
+            n,
+            k,
+            configs=configs,
+            has_int8_tensor=has_int8_tensor,
+            scale=0.5,
+            exclude=cpu_exclude_fn,
+            dtype_size=dtype_size,
+            op_name=op_name,
+        )
 
 
 class CUDAConfigHeuristic(BaseConfigHeuristic):
@@ -1002,14 +1055,13 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
             for wpeu in [0, int(8 // num_warps)]
         ]
 
-    def _filter_configs(
-        self, configs: list[BaseConfig], new_num_stages: int
-    ) -> list[BaseConfig]:
-        # TODO: _filter_configs can be removed once backend specific configs are added
-        # for all methods
+    def _filter_configs(self, configs: list[BaseConfig]) -> list[BaseConfig]:
+        """
+        ROCm specific filtering
+        """
         for c in configs:
             c.num_stages = self.default_num_stages
-        return configs
+        return super()._filter_configs(configs)
 
     def _finalize_mm_configs(
         self,
@@ -1075,57 +1127,6 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
                 if group_m is not None:
                     kwargs["GROUP_M"] = group_m
                 yield self.triton_config(**kwargs)
-
-    def get_extra_mm_configs(self) -> partial[Generator[TritonConfig, None, None]]:
-        filtered_configs = self._filter_configs(
-            self.extra_mm_configs, self.default_num_stages
-        )
-        return partial(self.preprocess_mm_configs, configs=filtered_configs)
-
-    def get_int8_mm_configs(self) -> partial[Generator[TritonConfig, None, None]]:
-        filtered_configs = self._filter_configs(
-            self.int8_mm_configs, self.default_num_stages
-        )
-        return partial(self.preprocess_mm_configs, configs=filtered_configs)
-
-    def get_mixed_mm_configs(self) -> partial[Generator[TritonConfig, None, None]]:
-        mm_configs = (
-            self.mm_configs + self.mixed_mm_configs
-            if config.max_autotune_gemm_search_space == "EXHAUSTIVE"
-            else self.mm_configs
-        )
-        filtered_configs = self._filter_configs(mm_configs, self.default_num_stages)
-        return partial(self.preprocess_mm_configs, configs=filtered_configs)
-
-    def get_persistent_mm_configs(self) -> partial[Generator[TritonConfig, None, None]]:
-        filtered_configs = self._filter_configs(
-            self.persistent_mm_configs, self.default_num_stages
-        )
-        return partial(self.preprocess_mm_configs, configs=filtered_configs)
-
-    def get_scaled_mm_configs(self) -> partial[Generator[TritonConfig, None, None]]:
-        filtered_configs = self._filter_configs(
-            self.scaled_mm_configs, self.default_num_stages
-        )
-        return partial(self.preprocess_mm_configs, configs=filtered_configs)
-
-    def get_scaled_persistent_mm_configs(
-        self,
-    ) -> partial[Generator[TritonConfig, None, None]]:
-        filtered_configs = self._filter_configs(
-            self.scaled_persistent_mm_configs, self.default_num_stages
-        )
-        return partial(self.preprocess_mm_configs, configs=filtered_configs)
-
-    def get_mm_plus_mm_configs(self) -> partial[Generator[TritonConfig, None, None]]:
-        filtered_configs = self._filter_configs(self.mm_plus_mm_configs, 1)
-        return partial(self._finalize_mm_configs, configs=filtered_configs)
-
-    def get_conv_configs(self) -> partial[Generator[TritonConfig, None, None]]:
-        filtered_configs = self._filter_configs(
-            self.conv_configs, self.default_num_stages
-        )
-        return partial(self.preprocess_mm_configs, configs=filtered_configs)
 
     def get_flex_attn_fwd_configs(self, head_dim: int, dtype: Any) -> list[FlexConfig]:
         flex_attn_fwd_configs: list[FlexConfig] = []
@@ -1207,3 +1208,643 @@ class MTIAConfigHeuristic(BaseConfigHeuristic):
     """
     Placeholder child class for MTIA specific overrides.
     """
+
+
+# Template-specific mixin classes
+
+
+class TemplateConfigHeuristics:
+    def get_template_configs(
+        self,
+        kernel_inputs: KernelInputs,
+        layout: Any,
+        op_name: str,
+    ) -> Generator[dict[str, Any], None, None]:
+        """
+        Get template configs for the given inputs.
+        This is the main entry point for template-specific logic.
+        """
+        # NOTE: not an abstract class, because that clashed below for the mixin
+        # functionality. Can be adjusted, but not a high priority
+        yield from {}
+
+
+class MMTemplateConfigMixin(TemplateConfigHeuristics):
+    """
+    Mixin class that converts config lists to template kwargs.
+    This handles the logic that was previously in choices.get_mm_configs.
+
+    This mixin expects to be used with BaseConfigHeuristic or its subclasses.
+    """
+
+    # Type annotations to ensure the mixin works with BaseConfigHeuristic
+    get_mm_configs: Callable[[], partial[Generator[TritonConfig, None, None]]]
+    get_exhaustive_mm_configs: Callable[
+        [], partial[Generator[TritonConfig, None, None]]
+    ]
+    _filter_configs: Callable[[list[BaseConfig]], list[BaseConfig]]
+
+    def _get_config_generator(
+        self,
+    ) -> partial[Generator[TritonConfig, None, None]]:
+        """
+        Get the appropriate config generator based on search space.
+        Can be overridden by subclasses for template-specific behavior.
+        """
+        # Handle exhaustive search case
+        if config.max_autotune_gemm_search_space == "EXHAUSTIVE":
+            return self.get_exhaustive_mm_configs()
+        else:
+            return self.get_mm_configs()
+
+    def get_template_configs(
+        self,
+        kernel_inputs: KernelInputs,
+        layout: Any,
+        op_name: str,
+    ) -> Generator[dict[str, Any], None, None]:
+        """
+        Convert config lists to template kwargs.
+        This replaces the logic from choices.get_mm_configs and inlines mm_options.
+        """
+        assert isinstance(kernel_inputs, MMKernelInputs), (
+            f"{self.__class__.__name__} requires MMKernelInputs"
+        )
+        input_nodes = kernel_inputs.nodes()
+        if len(input_nodes) < 2:
+            raise ValueError(f"Need at least 2 input tensors, got {len(input_nodes)}")
+
+        # Extract M, N, K from kernel_inputs
+        m, n, k = kernel_inputs.mnk_symbolic()
+
+        # Extract dtype and device_type from kernel_inputs
+        dtype = kernel_inputs.dtype()
+
+        # Get the appropriate config generator
+        configs = self._get_config_generator()
+
+        # Generate and process configs
+        for c in configs(m, n, k, dtype_size=dtype.itemsize, op_name=op_name):
+            template_kwargs = self._convert_config_to_template_kwargs(
+                c, m, n, k, layout
+            )
+            yield template_kwargs
+
+    def _convert_config_to_template_kwargs(
+        self,
+        triton_config: TritonConfig,
+        m: sympy.Integer,
+        n: sympy.Integer,
+        k: sympy.Integer,
+        layout: Any,
+    ) -> dict[str, Any]:
+        """
+        Convert triton config to template kwargs.
+        Moved from mm_common.mm_options.
+        """
+        # Calculate EVEN_K symbolic
+        even_k_symbolic = (
+            # it isn't worth guarding on this
+            sympy.gcd(k, triton_config.kwargs["BLOCK_K"])
+            == triton_config.kwargs["BLOCK_K"]
+        )
+
+        # Calculate allow_tf32
+        allow_tf32 = torch.backends.cuda.matmul.allow_tf32 and (
+            not inductor_config.force_same_precision
+            or ((m % 16) == 0 and (n % 16) == 0 and (k % 8) == 0)
+        )
+
+        # Build options dict
+        options_dict = dict(
+            EVEN_K=even_k_symbolic,
+            ALLOW_TF32=allow_tf32,
+            USE_FAST_ACCUM=False,  # Option for _scaled_mm
+            ACC_TYPE=self._get_acc_type(layout.dtype),
+            num_stages=triton_config.num_stages,
+            num_warps=triton_config.num_warps,
+            **triton_config.kwargs,
+        )
+
+        # If GROUP_M not specified then default to 8
+        if "GROUP_M" not in triton_config.kwargs:
+            group_m = triton_config.kwargs.get("GROUP_M", 8)
+            options_dict["GROUP_M"] = group_m
+
+        return options_dict
+
+    def _get_acc_type(self, dtype: torch.dtype) -> str:
+        """
+        Get accumulator type for the given dtype.
+        Moved from mm_common.acc_type.
+        """
+        if dtype in (torch.float16, torch.bfloat16):
+            return "tl.float32"
+        return f"tl.{dtype}".replace("torch.", "")
+
+
+# INT8 specific mixin to filter correctly
+class INT8MMTemplateConfigMixin(MMTemplateConfigMixin):
+    """
+    Ensure that we feed in has_int8_tensor=True
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.has_int8_tensor = True
+
+
+# TMA-specific mixin for TMA templates
+class TMAConfigMixin(MMTemplateConfigMixin):
+    """
+    TMA-specific mixin that uses persistent configs and adds TMA options.
+    This inherits from MMTemplateConfigMixin and overrides config generation.
+    """
+
+    def _filter_configs(self, configs: list[BaseConfig]) -> list[BaseConfig]:
+        """
+        TMA specific filtering, as num_warps=2 not safe for TMA
+        """
+        configs = [c for c in configs if c.num_warps != 2]
+        return super()._filter_configs(configs)
+
+    def get_template_configs(
+        self,
+        kernel_inputs: KernelInputs,
+        layout: Any,
+        op_name: str,
+    ) -> Generator[dict[str, Any], None, None]:
+        """
+        Generate TMA template configs by calling super and adding TMA-specific options.
+        """
+        # Get base template configs from superclass
+        for template_kwargs in super().get_template_configs(
+            kernel_inputs, layout, op_name
+        ):
+            # Add TMA-specific options (moved from mm_common.persistent_mm_options)
+            input_nodes = kernel_inputs.nodes()
+            self._add_tma_options(template_kwargs, input_nodes)
+            yield template_kwargs
+
+    def _add_tma_options(
+        self, template_kwargs: dict[str, Any], input_nodes: list[Any]
+    ) -> None:
+        """
+        Add TMA-specific options to template kwargs.
+        Moved from mm_common.persistent_mm_options and mm_common.tma_options.
+        """
+        # For TMA templates, we need the actual matrix tensors
+        mat1 = input_nodes[-2]
+        mat2 = input_nodes[-1]
+
+        tma_opts = {
+            "A_ROW_MAJOR": not mat1.layout.is_transposed(),
+            "B_ROW_MAJOR": not mat2.layout.is_transposed(),
+            "NUM_SMS": get_num_sms(),
+            "TMA_SIZE": TMA_DESCRIPTOR_SIZE,
+            "TMA_EXPERIMENTAL_API": not has_triton_stable_tma_api(),
+        }
+        template_kwargs.update(tma_opts)
+
+
+# Scaled MM-specific mixin for scaled MM templates (non-TMA)
+class ScaledMMConfigMixin(MMTemplateConfigMixin):
+    """
+    Scaled MM-specific mixin that uses scaled configs and adds scaled MM options.
+    This is for non-TMA scaled MM templates only.
+    This inherits from MMTemplateConfigMixin and overrides config generation.
+    """
+
+    def get_template_configs(
+        self,
+        kernel_inputs: KernelInputs,
+        layout: Any,
+        op_name: str,
+    ) -> Generator[dict[str, Any], None, None]:
+        """
+        Generate scaled MM template configs with scaled MM-specific options.
+        Handles the remaining logic from mm_common including assertions and SCALING_ROWWISE.
+        """
+        input_nodes = kernel_inputs.nodes()
+
+        # Initial assertion from mm_common.scaled_mm_options
+        assert len(input_nodes) >= 4, (
+            f"scaled_mm requires at least 4 inputs, got {len(input_nodes)}"
+        )
+
+        # Extract scale tensors (typically scale_a and scale_b are input_nodes[2] and input_nodes[3])
+        scale_a = input_nodes[2]
+        scale_b = input_nodes[3]
+
+        # Scale compatibility assertion from mm_common.scaled_mm_options
+        def are_compatible_scales(size_a: Any, size_b: Any) -> bool:
+            # Same sized scales are compatible
+            if len(size_a) == len(size_b):
+                return True
+
+            # Both need to be scalars or len(1) tensors
+            if len(size_a) <= 1 and len(size_b) <= 1:
+                return True
+
+            return False
+
+        size_a, size_b = scale_a.get_size(), scale_b.get_size()
+        assert are_compatible_scales(size_a, size_b), (
+            "Expect scale_a and scale_b to be either both scalars (including single-element tensors) "
+            f"or 1-dimensional tensors with the same size. Got scale_a: {len(size_a)} and scale_b: {len(size_b)}."
+        )
+
+        # Get base template configs from superclass
+        for template_kwargs in super().get_template_configs(
+            kernel_inputs, layout, op_name
+        ):
+            # Add scaled MM-specific options (moved from mm_common.scaled_mm_options)
+            # Override accumulator type for scaled MM
+            template_kwargs["ACC_TYPE"] = "tl.float32"
+            # Add SCALING_ROWWISE attribute based on scale_a tensor shape
+            template_kwargs["SCALING_ROWWISE"] = len(size_a) == 2
+
+            yield template_kwargs
+
+
+# Scaled TMA-specific mixin for scaled MM templates with TMA
+class ScaledTMAConfigMixin(ScaledMMConfigMixin):
+    """
+    Scaled TMA-specific mixin that extends ScaledMMConfigMixin with TMA functionality.
+    This is for scaled MM templates that use device TMA.
+    This inherits from ScaledMMConfigMixin and adds TMA-specific options.
+    """
+
+    def _filter_configs(self, configs: list[BaseConfig]) -> list[BaseConfig]:
+        """
+        TMA specific filtering, as num_warps=2 not safe for TMA
+        """
+        configs = [c for c in configs if c.num_warps != 2]
+        return super()._filter_configs(configs)
+
+    def get_template_configs(
+        self,
+        kernel_inputs: KernelInputs,
+        layout: Any,
+        op_name: str,
+    ) -> Generator[dict[str, Any], None, None]:
+        """
+        Generate scaled TMA template configs with both scaled MM and TMA-specific options.
+        """
+        # Get base scaled MM template configs from superclass
+        for template_kwargs in super().get_template_configs(
+            kernel_inputs, layout, op_name
+        ):
+            # Add TMA-specific options for device TMA scaled MM
+            template_kwargs["TMA_SIZE"] = TMA_DESCRIPTOR_SIZE
+            template_kwargs["NUM_SMS"] = get_num_sms()
+            template_kwargs["TMA_EXPERIMENTAL_API"] = not has_triton_stable_tma_api()
+
+            yield template_kwargs
+
+
+# Template-specific heuristic classes using multiple inheritance
+
+
+# TODO(coconutruben): replace with template.name once templates are importable
+@register_template_heuristic("mm", "cuda", register=torch.version.hip is None)
+# TODO(coconutruben): replace with template.name once templates are importable
+@register_template_heuristic("bmm", "cuda", register=torch.version.hip is None)
+class CUDAMMTemplateConfigHeuristic(MMTemplateConfigMixin, CUDAConfigHeuristic):
+    """Standard MM template heuristic for CUDA"""
+
+
+# TODO(coconutruben): deprecate once autoheuristic is deprecated
+# TODO(coconutruben): replace with template.name once templates are importable
+@register_template_heuristic("mm-ah", "cuda", register=torch.version.hip is None)
+class CUDAMMAHTemplateConfigHeuristic(MMTemplateConfigMixin, CUDAConfigHeuristic):
+    """Standard MM template heuristic for CUDA using the extra mm configs only (for autoheuristic)"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Override mm_configs to use scaled_mm_configs
+        self.mm_configs = self.extra_mm_configs
+        self.exhaustive_configs = self.extra_mm_configs
+
+
+# TODO(coconutruben): replace with template.name once templates are importable
+@register_template_heuristic(
+    "mm_persistent_tma", "cuda", register=torch.version.hip is None
+)
+class CUDAPersistentTMATemplateConfigHeuristic(TMAConfigMixin, CUDAConfigHeuristic):
+    """Persistent TMA template heuristic for CUDA"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Override mm_configs to use persistent_mm_configs
+        self.mm_configs = self.persistent_mm_configs
+
+
+# TODO(coconutruben): replace with template.name once templates are importable
+@register_template_heuristic(
+    "mm", "cuda", register=torch.version.hip is None, op_name="scaled_mm"
+)
+class CUDAScaledMMTemplateConfigHeuristic(ScaledMMConfigMixin, CUDAConfigHeuristic):
+    """Scaled MM template heuristic for CUDA"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Override mm_configs to use scaled_mm_configs
+        self.mm_configs = self.scaled_mm_configs
+        # NOTE: overriding exhaustive configs here to be the same as mm_configs
+        # as we haven't validated exhaustive support here yet
+        # TODO(coconutruben): remove this once we have validated exhaustive support
+        # for scaled_mm
+        self.exhaustive_configs = self.scaled_mm_configs
+
+
+# TODO(coconutruben): replace with template.name once templates are importable
+@register_template_heuristic(
+    "scaled_mm_device_tma", "cuda", register=torch.version.hip is None
+)
+class CUDAScaledTMATemplateConfigHeuristic(ScaledTMAConfigMixin, CUDAConfigHeuristic):
+    """Scaled TMA template heuristic for CUDA"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Override mm_configs to use scaled_persistent_mm_configs for TMA
+        self.mm_configs = self.scaled_persistent_mm_configs
+        # NOTE: overriding exhaustive configs here to be the same as mm_configs
+        # as we haven't validated exhaustive support here yet
+        # TODO(coconutruben): remove this once we have validated exhaustive support
+        # for scaled_mm
+        self.exhaustive_configs = self.scaled_persistent_mm_configs
+
+
+# TODO(coconutruben): replace with template.name once templates are importable
+@register_template_heuristic("mm_plus_mm", "cuda", register=torch.version.hip is None)
+class CUDAMMPlusMMTemplateConfigHeuristic(MMTemplateConfigMixin, CUDAConfigHeuristic):
+    """MM Plus MM template heuristic for CUDA"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Override mm_configs to use mm_plus_mm_configs
+        self.mm_configs = self.mm_plus_mm_configs
+        # NOTE: overriding exhaustive configs here to be the same as mm_configs
+        # as we haven't validated exhaustive support here yet
+        # TODO(coconutruben): remove this once we have validated exhaustive support
+        # for scaled_mm
+        self.exhaustive_configs = self.mm_plus_mm_configs
+
+
+# TODO(coconutruben): replace with template.name once templates are importable
+@register_template_heuristic(
+    "mm", "cuda", register=torch.version.hip is None, op_name="int_mm"
+)
+class CUDAInt8MMTemplateConfigHeuristic(INT8MMTemplateConfigMixin, CUDAConfigHeuristic):
+    """Int8 MM template heuristic for CUDA"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Override mm_configs to use int8_mm_configs
+        self.mm_configs = self.int8_mm_configs
+        # NOTE: overriding exhaustive configs here to be the same as mm_configs
+        # as we haven't validated exhaustive support here yet
+        # TODO(coconutruben): remove this once we have validated exhaustive support
+        # for scaled_mm
+        self.exhaustive_configs = self.int8_mm_configs
+
+
+# ROCm template-specific classes
+
+
+# TODO(coconutruben): replace with template.name once templates are importable
+@register_template_heuristic("mm", "cuda", register=torch.version.hip is not None)
+# TODO(coconutruben): replace with template.name once templates are importable
+@register_template_heuristic("bmm", "cuda", register=torch.version.hip is not None)
+class ROCmMMTemplateConfigHeuristic(MMTemplateConfigMixin, ROCmConfigHeuristic):
+    """Standard MM template heuristic for ROCm"""
+
+
+# TODO(coconutruben): deprecate once autoheuristic is deprecated
+# TODO(coconutruben): replace with template.name once templates are importable
+@register_template_heuristic("mm-ah", "cuda", register=torch.version.hip is not None)
+class ROCmMMAHTemplateConfigHeuristic(MMTemplateConfigMixin, ROCmConfigHeuristic):
+    """Standard MM template heuristic for ROCm using the extra mm configs only (for autoheuristic)"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Override mm_configs to use scaled_mm_configs
+        self.mm_configs = self.extra_mm_configs
+        self.exhaustive_configs = self.extra_mm_configs
+
+
+# TODO(coconutruben): replace with template.name once templates are importable
+@register_template_heuristic(
+    "mm", "cuda", register=torch.version.hip is not None, op_name="scaled_mm"
+)
+class ROCmScaledMMTemplateConfigHeuristic(ScaledMMConfigMixin, ROCmConfigHeuristic):
+    """Scaled MM template heuristic for ROCm (non-TMA)"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Override mm_configs to use scaled_mm_configs
+        self.mm_configs = self.scaled_mm_configs
+        # NOTE: overriding exhaustive configs here to be the same as mm_configs
+        # as we haven't validated exhaustive support here yet
+        # TODO(coconutruben): remove this once we have validated exhaustive support
+        # for scaled_mm
+        self.exhaustive_configs = self.scaled_mm_configs
+
+
+# TODO(coconutruben): replace with template.name once templates are importable
+@register_template_heuristic(
+    "mm", "cuda", register=torch.version.hip is not None, op_name="int_mm"
+)
+class ROCmInt8MMTemplateConfigHeuristic(INT8MMTemplateConfigMixin, ROCmConfigHeuristic):
+    """Int8 MM template heuristic for ROCm"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Override mm_configs to use int8_mm_configs
+        self.mm_configs = self.int8_mm_configs
+        # NOTE: overriding exhaustive configs here to be the same as mm_configs
+        # as we haven't validated exhaustive support here yet
+        # TODO(coconutruben): remove this once we have validated exhaustive support
+        # for scaled_mm
+        self.exhaustive_configs = self.int8_mm_configs
+
+
+# TODO(coconutruben): replace with template.name once templates are importable
+@register_template_heuristic(
+    "mm_plus_mm", "cuda", register=torch.version.hip is not None
+)
+class ROCmMMPlusMMTemplateConfigHeuristic(MMTemplateConfigMixin, ROCmConfigHeuristic):
+    """MM Plus MM template heuristic for ROCm"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Override mm_configs to use mm_plus_mm_configs
+        self.mm_configs = self.mm_plus_mm_configs
+        # NOTE: overriding exhaustive configs here to be the same as mm_configs
+        # as we haven't validated exhaustive support here yet
+        # TODO(coconutruben): remove this once we have validated exhaustive support
+        # for scaled_mm
+        self.exhaustive_configs = self.mm_plus_mm_configs
+
+
+# CPU template-specific classes
+
+
+@register_template_heuristic("mm", "cpu")
+@register_template_heuristic("bmm", "cpu")
+class CPUMMTemplateConfigHeuristic(MMTemplateConfigMixin, CPUConfigHeuristic):
+    """Standard MM template heuristic for CPU"""
+
+
+@register_template_heuristic("mm", "cpu", op_name="scaled_mm")
+class CPUScaledMMTemplateConfigHeuristic(ScaledMMConfigMixin, CPUConfigHeuristic):
+    """Scaled MM template heuristic for CPU (non-TMA)"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Override mm_configs to use scaled_mm_configs
+        self.mm_configs = self.scaled_mm_configs
+        # NOTE: overriding exhaustive configs here to be the same as mm_configs
+        # as we haven't validated exhaustive support here yet
+        # TODO(coconutruben): remove this once we have validated exhaustive support
+        # for scaled_mm
+        self.exhaustive_configs = self.scaled_mm_configs
+
+
+@register_template_heuristic("mm", "cpu", op_name="int_mm")
+class CPUInt8MMTemplateConfigHeuristic(INT8MMTemplateConfigMixin, CPUConfigHeuristic):
+    """Int8 MM template heuristic for CPU"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Override mm_configs to use int8_mm_configs
+        self.mm_configs = self.int8_mm_configs
+        # NOTE: overriding exhaustive configs here to be the same as mm_configs
+        # as we haven't validated exhaustive support here yet
+        # TODO(coconutruben): remove this once we have validated exhaustive support
+        # for scaled_mm
+        self.exhaustive_configs = self.int8_mm_configs
+
+
+@register_template_heuristic("mm_plus_mm", "cpu")
+class CPUMMPlusMMTemplateConfigHeuristic(MMTemplateConfigMixin, CPUConfigHeuristic):
+    """MM Plus MM template heuristic for CPU"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Override mm_configs to use mm_plus_mm_configs
+        self.mm_configs = self.mm_plus_mm_configs
+        # NOTE: overriding exhaustive configs here to be the same as mm_configs
+        # as we haven't validated exhaustive support here yet
+        # TODO(coconutruben): remove this once we have validated exhaustive support
+        # for scaled_mm
+        self.exhaustive_configs = self.mm_plus_mm_configs
+
+
+# XPU template-specific classes
+
+
+@register_template_heuristic("mm", "xpu")
+@register_template_heuristic("bmm", "xpu")
+class XPUMMTemplateConfigHeuristic(MMTemplateConfigMixin, XPUConfigHeuristic):
+    """Standard MM template heuristic for XPU"""
+
+
+@register_template_heuristic("mm", "xpu", op_name="scaled_mm")
+class XPUScaledMMTemplateConfigHeuristic(ScaledMMConfigMixin, XPUConfigHeuristic):
+    """Scaled MM template heuristic for XPU (non-TMA)"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Override mm_configs to use scaled_mm_configs
+        self.mm_configs = self.scaled_mm_configs
+        # NOTE: overriding exhaustive configs here to be the same as mm_configs
+        # as we haven't validated exhaustive support here yet
+        # TODO(coconutruben): remove this once we have validated exhaustive support
+        # for scaled_mm
+        self.exhaustive_configs = self.scaled_mm_configs
+
+
+@register_template_heuristic("mm", "xpu", op_name="int_mm")
+class XPUInt8MMTemplateConfigHeuristic(INT8MMTemplateConfigMixin, XPUConfigHeuristic):
+    """Int8 MM template heuristic for XPU"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Override mm_configs to use int8_mm_configs
+        self.mm_configs = self.int8_mm_configs
+        # NOTE: overriding exhaustive configs here to be the same as mm_configs
+        # as we haven't validated exhaustive support here yet
+        # TODO(coconutruben): remove this once we have validated exhaustive support
+        # for scaled_mm
+        self.exhaustive_configs = self.int8_mm_configs
+
+
+@register_template_heuristic("mm_plus_mm", "xpu")
+class XPUMMPlusMMTemplateConfigHeuristic(MMTemplateConfigMixin, XPUConfigHeuristic):
+    """MM Plus MM template heuristic for XPU"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Override mm_configs to use mm_plus_mm_configs
+        self.mm_configs = self.mm_plus_mm_configs
+        # NOTE: overriding exhaustive configs here to be the same as mm_configs
+        # as we haven't validated exhaustive support here yet
+        # TODO(coconutruben): remove this once we have validated exhaustive support
+        # for scaled_mm
+        self.exhaustive_configs = self.mm_plus_mm_configs
+
+
+# MTIA template-specific classes
+
+
+@register_template_heuristic("mm", "mtia")
+@register_template_heuristic("bmm", "mtia")
+class MTIAMMTemplateConfigHeuristic(MMTemplateConfigMixin, MTIAConfigHeuristic):
+    """Standard MM template heuristic for MTIA"""
+
+
+@register_template_heuristic("mm", "mtia", op_name="scaled_mm")
+class MTIAScaledMMTemplateConfigHeuristic(ScaledMMConfigMixin, MTIAConfigHeuristic):
+    """Scaled MM template heuristic for MTIA (non-TMA)"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Override mm_configs to use scaled_mm_configs
+        self.mm_configs = self.scaled_mm_configs
+        # NOTE: overriding exhaustive configs here to be the same as mm_configs
+        # as we haven't validated exhaustive support here yet
+        # TODO(coconutruben): remove this once we have validated exhaustive support
+        # for scaled_mm
+        self.exhaustive_configs = self.scaled_mm_configs
+
+
+@register_template_heuristic("mm", "mtia", op_name="int_mm")
+class MTIAInt8MMTemplateConfigHeuristic(INT8MMTemplateConfigMixin, MTIAConfigHeuristic):
+    """Int8 MM template heuristic for MTIA"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Override mm_configs to use int8_mm_configs
+        self.mm_configs = self.int8_mm_configs
+        # NOTE: overriding exhaustive configs here to be the same as mm_configs
+        # as we haven't validated exhaustive support here yet
+        # TODO(coconutruben): remove this once we have validated exhaustive support
+        # for scaled_mm
+        self.exhaustive_configs = self.int8_mm_configs
+
+
+@register_template_heuristic("mm_plus_mm", "mtia")
+class MTIAMMPlusMMTemplateConfigHeuristic(MMTemplateConfigMixin, MTIAConfigHeuristic):
+    """MM Plus MM template heuristic for MTIA"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Override mm_configs to use mm_plus_mm_configs
+        self.mm_configs = self.mm_plus_mm_configs
+        # NOTE: overriding exhaustive configs here to be the same as mm_configs
+        # as we haven't validated exhaustive support here yet
+        # TODO(coconutruben): remove this once we have validated exhaustive support
+        # for scaled_mm
+        self.exhaustive_configs = self.mm_plus_mm_configs

--- a/torch/_inductor/template_registry.py
+++ b/torch/_inductor/template_registry.py
@@ -1,0 +1,98 @@
+"""
+Template heuristic registry system for PyTorch Inductor.
+
+This module provides a centralized registration system for template heuristics,
+allowing automatic registration based on device type and conditional registration
+for CUDA vs ROCm based on torch.version.hip.
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import cache
+from typing import Any, Optional, TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from .template_heuristics import TemplateConfigHeuristics
+
+# Module-wide registry for template heuristics
+_TEMPLATE_HEURISTIC_REGISTRY: dict[tuple[str, ...], type[TemplateConfigHeuristics]] = {}
+
+log = logging.getLogger(__name__)
+
+
+def register_template_heuristic(
+    template_name: str,
+    device_type: str,
+    register: bool = True,
+    op_name: Optional[str] = None,
+) -> Any:
+    """
+    Decorator to register template heuristic classes.
+
+    Args:
+        template_name: Name of the template (e.g., "mm", "bmm", "scaled_mm")
+        device_type: Device type ("cuda", "cpu", "xpu")
+        register: Whether to register this heuristic. Caller should pass the condition directly.
+        op_name: Name of the operator (e.g., "mm", "bmm", "scaled_mm"). This is optional
+            and is only used when a template uses different heuristics for different ops
+
+    Returns:
+        Decorator function that registers the class if conditions are met.
+
+    Example:
+        @register_template_heuristic("mm", "cuda", register=torch.version.hip is None)
+        class CUDAMMTemplateConfigHeuristic(MMTemplateConfigMixin, CUDAConfigHeuristic):
+            pass
+    """
+
+    def decorator(
+        cls: type[TemplateConfigHeuristics],
+    ) -> type[TemplateConfigHeuristics]:
+        if register:
+            key: tuple[str, ...] = (device_type, template_name)
+            if op_name is not None:
+                key = (device_type, template_name, op_name)
+            _TEMPLATE_HEURISTIC_REGISTRY[key] = cls
+            log.info(
+                f"Registered template heuristic: {cls.__name__} for '{template_name=}', '{device_type=}', '{op_name=}'"  # noqa: G004
+            )
+        return cls
+
+    return decorator
+
+
+@cache
+def get_template_heuristic(
+    template_name: str, device_type: str, op_name: str
+) -> TemplateConfigHeuristics:
+    """
+    Retrieve a template heuristic instance for the given template and device type.
+
+    Args:
+        template_name: Name of the template (e.g., "mm", "bmm", "scaled_mm")
+        device_type: Device type ("cuda", "cpu", "xpu")
+
+    Returns:
+        Template heuristic instance.
+
+    Raises:
+        ValueError: If no heuristic is found for the given combination.
+    """
+    # First check the more specific key
+    keys = [(device_type, template_name, op_name), (device_type, template_name)]
+
+    # Look up in registry
+    heuristic_class = None
+    for key in keys:
+        if key in _TEMPLATE_HEURISTIC_REGISTRY:
+            heuristic_class = _TEMPLATE_HEURISTIC_REGISTRY[key]
+            break
+    if heuristic_class is None:
+        raise ValueError(
+            f"No template heuristic found for '{template_name=}', "
+            f"'{device_type=}', '{op_name=}'. "
+            f"Available combinations: {list(_TEMPLATE_HEURISTIC_REGISTRY.keys())}"
+        )
+    return heuristic_class()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #158987
* #158091
* #157699
* __->__ #159383

\# Why

- Make loop iteration simpler
- Have a common spot where to make modifications that affect
  all the GEMM Triton templates, avoiding missed spots

\# What

- pull out commong logic of taking the BaseConfig objects
  and turning them into kwargs to feed into maybe_append_choice
  for Triton GEMM templates

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov

Differential Revision: [D79186962](https://our.internmc.facebook.com/intern/diff/D79186962)