### PR TITLE
Add a title to distributed._dist2.md

### DIFF
--- a/docs/source/distributed._dist2.md
+++ b/docs/source/distributed._dist2.md
@@ -1,3 +1,5 @@
+# Experimental Object Oriented Distributed API
+
 ```{eval-rst}
 .. role:: hidden
     :class: hidden-section

--- a/torch/distributed/_dist2.py
+++ b/torch/distributed/_dist2.py
@@ -1,7 +1,4 @@
 """
-Experimental Object Oriented Distributed API - torch.distributed._dist2
-=======================================================================
-
 This is an experimental new API for PyTorch Distributed. This is actively in development and subject to change or deletion entirely.
 
 This is intended as a proving ground for more flexible and object oriented distributed APIs.


### PR DESCRIPTION
Sphinx likes titles and complains about them when they are not there. So adding a title to address this Wartning in the build:
```
WARNING: toctree contains reference to document 'distributed._dist2' that doesn't have a title: no link will be generated
```

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @sekyondaMeta @AlannaBurke