### PR TITLE
[MPS] Avoid outputing zeros from `exponential_` for MPS

### DIFF
--- a/aten/src/ATen/native/mps/operations/Distributions.mm
+++ b/aten/src/ATen/native/mps/operations/Distributions.mm
@@ -418,8 +418,9 @@ Tensor& exponential_mps_(Tensor& self, double lambda, std::optional<Generator> g
     MPSGraphTensor* logTensor = [mpsGraph logarithmWithTensor:subtractTensor name:nil];
     return [mpsGraph divisionWithPrimaryTensor:logTensor secondaryTensor:minusLambdaTensor name:nil];
   };
+  auto eps = std::numeric_limits<float>::epsilon();
   return mps::random_mps_impl<double>(self,
-                                      0.0,
+                                      eps,
                                       1.0,
                                       std::nullopt,
                                       std::nullopt,

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7722,6 +7722,12 @@ class TestMPS(TestCaseMPS):
         self.assertEqual(Exponential(0.2).sample((1,)).size(), (1,))
         self.assertEqual(Exponential(50.0).sample((1,)).size(), (1,))
 
+    @parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+    def test_exponential_nonzero(self, dtype):
+        for _ in range(100):
+            a = torch.empty(32_000, device="mps", dtype=dtype).exponential_()
+            self.assertTrue((a != 0).all())
+
     # Test add
     def test_add_sub(self):
         def helper(shape, alpha, op_name, inplace):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #159386

Fixes #159103