### PR TITLE
[AIDIR] Internal util function to insert MLHub debugging insight for dynamic shape

### DIFF
--- a/torch/_dynamo/pgo.py
+++ b/torch/_dynamo/pgo.py
@@ -173,6 +173,7 @@ class CodeState:
 
 _INIT_CODE_STATE: Optional[defaultdict[CodeId, CodeState]] = None
 _CODE_STATE: Optional[defaultdict[CodeId, CodeState]] = None
+_LOGGED_DYNAMIC_ALLOWLIST: bool = False
 
 
 @dataclasses.dataclass(frozen=True)
@@ -616,6 +617,7 @@ def _collect_dynamic_sources(code_state: CodeState) -> OrderedSet[str]:
 
 
 def log_frame_dynamic_whitelist(f_code: types.CodeType) -> None:
+    global _LOGGED_DYNAMIC_ALLOWLIST
     code_id = CodeId.make(f_code)
     frame_state = get_code_state()[code_id]
     frame_whitelist = ",".join(_collect_dynamic_sources(frame_state))
@@ -624,6 +626,15 @@ def log_frame_dynamic_whitelist(f_code: types.CodeType) -> None:
             CompileEventLogger.pt2_compile(
                 name, recompile_dynamic_whitelist=frame_whitelist
             )
+        if not _LOGGED_DYNAMIC_ALLOWLIST:
+            torch._utils_internal.add_mlhub_insight(
+                category="dynamic_shapes_analysis",
+                insight="Dynamic shapes detected",
+                insight_description="PGO detected a recompilation due to dynamic shapes. \
+                Please follow the instruction from the action link to reduce shape recompilations.",
+            )
+            # add mlhub insight only once per job
+            _LOGGED_DYNAMIC_ALLOWLIST = True
 
 
 def render_code_state(cs: defaultdict[CodeId, CodeState]) -> str:

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -117,6 +117,10 @@ def signpost_event(category: str, name: str, parameters: dict[str, Any]):
     log.info("%s %s: %r", category, name, parameters)
 
 
+def add_mlhub_insight(category: str, insight: str, insight_description: str):
+    pass
+
+
 def log_compilation_event(metrics):
     log.info("%s", metrics)
 


### PR DESCRIPTION
Summary:
This feature is Meta internal only
Add a util function to put dynamic shape-related suggestion to MLHubDebugInsightService, which will then be surfaced to users in the MLHub .

The rollout will be controlled by JK.

Test Plan:


MAST job aps-omnifmv3_dev_baseline_test-a34fdccf21 

 {F1980593060}

* If you're not able to see the insight, please add yourself to this gk 'mlhub_debugging_insights_dev_visibility'
* The URL link should route to a new Job Inspector page that will provide details and straight forward instructions of how to config the ds. The page is currently still in development so here we use the general PT2 compile JI page. 
* Test fails because of the export checks. I'll export after addressing all the comments from reviewers.

Rollback Plan:

Reviewed By: pianpwk

Differential Revision: D78526522




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela