### PR TITLE
[c10d] Fix setGroupName and setGroupDesc in `group_split` and `merge_remote_group`

### DIFF
--- a/test/distributed/test_dist2.py
+++ b/test/distributed/test_dist2.py
@@ -208,12 +208,15 @@ class Dist2MultiProcessTestCase(MultiProcessTestCase):
 
     def test_group_split(self) -> None:
         group = self.new_group()
-        subgroup = group.split_group([0], timeout=timedelta(seconds=30))
+        subgroup = group.split_group(
+            [0], timeout=timedelta(seconds=30), group_name="subgroup_1"
+        )
         if self.rank == 0:
             assert subgroup is not None
             self.assertEqual(subgroup.size(), 1)
             backend = subgroup._get_backend(self.device)
             self.assertEqual(backend.options._timeout, timedelta(seconds=30))
+            self.assertEqual(subgroup.group_name, "subgroup_1")
         else:
             self.assertEqual(subgroup, None)
 
@@ -235,6 +238,7 @@ class Dist2MultiProcessTestCase(MultiProcessTestCase):
             self.assertEqual(merged_pg.size(), 2)
             backend = merged_pg._get_backend(self.device)
             self.assertEqual(backend.options._timeout, timedelta(seconds=40))
+            self.assertEqual(merged_pg.group_name, "merged_pg")
         else:
             assert subgroup_2 is not None
             tcp_store = dist.TCPStore(
@@ -249,6 +253,7 @@ class Dist2MultiProcessTestCase(MultiProcessTestCase):
             self.assertEqual(merged_pg.size(), 2)
             backend = merged_pg._get_backend(self.device)
             self.assertEqual(backend.options._timeout, timedelta(seconds=40))
+            self.assertEqual(merged_pg.group_name, "merged_pg")
 
 
 class ProcessGroupGlooTest(Dist2MultiProcessTestCase):

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -2077,10 +2077,10 @@ communication mechanism.
               "merge_remote_group",
               [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
                  const c10::intrusive_ptr<::c10d::Store>& store,
-                 int size,
-                 std::chrono::milliseconds timeout,
-                 std::optional<std::string> groupName,
-                 std::optional<std::string> groupDesc) {
+                 const int& size,
+                 const std::chrono::milliseconds& timeout,
+                 const std::optional<std::string>& groupName,
+                 const std::optional<std::string>& groupDesc) {
                 ::c10d::ProcessGroup::MergeOptions opts;
                 opts.timeout = timeout;
                 opts.group_name = groupName;

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -5105,6 +5105,9 @@ def split_group(
     split_pg.bound_device_id = device_id  # type: ignore[union-attr]
     split_backend_class = split_pg._get_backend(torch.device("cuda"))
     split_backend_class._set_sequence_number_for_group()
+    assert split_pg.group_name == group_name, (
+        f"group name should be set to {group_name} but got {split_pg.group_name}"
+    )
 
     # update global state
     _world.pg_map[split_pg] = (backend, split_pg.get_group_store())


### PR DESCRIPTION
Summary:
We found that we don't really set group_name inside group_split correctly, because we are setting group_name to `deviceTypeToBackend_` which is set after `setBackend`. Same thing as group_desc. I added more unit tests for it.

We need to setGroupName correctly, otherwise, this will break DeviceMesh use case when split_group is used in DeviceMesh

Also ncclx needs to be aware of that its Option is a subclass of BackendOption

Test Plan:
CI

Rollback Plan:

Differential Revision: D79201132




cc @H-Huang @awgu @wanchaol @fegin @wz337 @wconstab @d4l3k @pragupta