### PR TITLE
[FSDP2] apply dtype casting to list args/kwargs in-place

### DIFF
--- a/test/distributed/fsdp/test_utils.py
+++ b/test/distributed/fsdp/test_utils.py
@@ -87,6 +87,7 @@ class TestUtils(TestCase):
         od = OrderedDict()
         od["k"] = "value"
         data.append(od)
+        data.append([])
 
         total = 0
 
@@ -99,6 +100,12 @@ class TestUtils(TestCase):
         self.assertEqual(total, expected)
         for i, v in enumerate(data):
             self.assertEqual(type(new_data[i]), type(v))
+            if isinstance(v, list):
+                self.assertEqual(
+                    id(new_data[i]),
+                    id(v),
+                    f"expect the same list but got {id(new_data[i])=} and id(data[i])={id(v)}",
+                )
 
     @skip_if_lt_x_gpu(1)
     def test_replace_by_prefix(self):

--- a/torch/distributed/utils.py
+++ b/torch/distributed/utils.py
@@ -242,7 +242,10 @@ def _apply_to_tensors(fn, container):
         elif _is_namedtuple(x):
             res = (apply(el) for el in x)
             return type(x)(*res)
-        elif isinstance(x, (list, tuple, set)):
+        elif isinstance(x, list):
+            x[:] = map(apply, x)
+            return x
+        elif isinstance(x, (tuple, set)):
             return type(x)(apply(el) for el in x)
         else:
             return x


### PR DESCRIPTION
convert to draft for now - on a second thought, dtype casting shouldn't happen in place

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #159439



cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta