### PR TITLE
[ATen][CUDA][cuFFT] Guard against deprecated error codes

### DIFF
--- a/aten/src/ATen/native/cuda/CuFFTUtils.h
+++ b/aten/src/ATen/native/cuda/CuFFTUtils.h
@@ -38,16 +38,20 @@ static inline std::string _cudaGetErrorEnum(cufftResult error)
       return "CUFFT_INVALID_SIZE";
     case CUFFT_UNALIGNED_DATA:
       return "CUFFT_UNALIGNED_DATA";
-    case CUFFT_INCOMPLETE_PARAMETER_LIST:
-      return "CUFFT_INCOMPLETE_PARAMETER_LIST";
     case CUFFT_INVALID_DEVICE:
       return "CUFFT_INVALID_DEVICE";
-    case CUFFT_PARSE_ERROR:
-      return "CUFFT_PARSE_ERROR";
     case CUFFT_NO_WORKSPACE:
       return "CUFFT_NO_WORKSPACE";
     case CUFFT_NOT_IMPLEMENTED:
       return "CUFFT_NOT_IMPLEMENTED";
+#if CUDA_VERSION <= 12090
+    case CUFFT_INCOMPLETE_PARAMETER_LIST:
+      return "CUFFT_INCOMPLETE_PARAMETER_LIST";
+    case CUFFT_PARSE_ERROR:
+      return "CUFFT_PARSE_ERROR";
+    case CUFFT_LICENSE_ERROR:
+      return "CUFFT_LICENSE_ERROR";
+#endif
 #if !defined(USE_ROCM)
     case CUFFT_LICENSE_ERROR:
       return "CUFFT_LICENSE_ERROR";

--- a/aten/src/ATen/native/cuda/CuFFTUtils.h
+++ b/aten/src/ATen/native/cuda/CuFFTUtils.h
@@ -49,10 +49,8 @@ static inline std::string _cudaGetErrorEnum(cufftResult error)
       return "CUFFT_INCOMPLETE_PARAMETER_LIST";
     case CUFFT_PARSE_ERROR:
       return "CUFFT_PARSE_ERROR";
-    case CUFFT_LICENSE_ERROR:
-      return "CUFFT_LICENSE_ERROR";
 #endif
-#if !defined(USE_ROCM)
+#if !defined(USE_ROCM) && CUDA_VERSION <= 12090
     case CUFFT_LICENSE_ERROR:
       return "CUFFT_LICENSE_ERROR";
 #endif


### PR DESCRIPTION
This PR adds a guard based on CUDA version, per latest cuFFT [documentation](https://docs.nvidia.com/cuda/cufft/index.html#return-value-cufftresult):
>The following error codes are deprecated and will be removed in a future release: `CUFFT_INCOMPLETE_PARAMETER_LIST`, `CUFFT_PARSE_ERROR`, `CUFFT_LICENSE_ERROR`.

cc @ptrblck @msaroufim @eqy @jerryzh168 @mruberry @manuelcandales @SherlockNoMad @angelayi