### PR TITLE
[dynamo, easy] add comment on skipping sys.monitoring frames

### DIFF
--- a/torch/csrc/dynamo/eval_frame_cpp.cpp
+++ b/torch/csrc/dynamo/eval_frame_cpp.cpp
@@ -140,6 +140,8 @@ PyObject* dynamo__custom_eval_frame(
   auto fail = [&]() { clear_old_frame_if_python_312_plus(tstate, frame); };
 
 #if IS_PYTHON_3_12_PLUS
+  // skip tracing the frame if CPython is in a tracing state (e.g.
+  // sys.monitoring call)
   if (tstate->tracing > 0) {
     eval_default();
     return eval_result;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #159493
* #159369

Add a comment so we know why we're doing this code (followup to https://github.com/pytorch/pytorch/pull/159369)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela