### PR TITLE
[BE] Clarify comment to not revert when command has been edited

### DIFF
--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1891,7 +1891,9 @@ def validate_revert(
         else pr.get_comment_by_id(comment_id)
     )
     if comment.editor_login is not None:
-        raise PostCommentError("Don't want to revert based on edited command")
+        raise PostCommentError(
+            "Halting the revert as the revert command has been edited."
+        )
     author_association = comment.author_association
     author_login = comment.author_login
     allowed_reverters = ["COLLABORATOR", "MEMBER", "OWNER"]

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1892,7 +1892,7 @@ def validate_revert(
     )
     if comment.editor_login is not None:
         raise PostCommentError(
-            "Halting the revert as the revert command has been edited."
+            "Halting the revert as the revert comment has been edited."
         )
     author_association = comment.author_association
     author_login = comment.author_login


### PR DESCRIPTION
This is mostly a nit. I was a bit confused when I saw 
<img width="1032" height="183" alt="image" src="https://github.com/user-attachments/assets/7a18f167-78c1-4c33-ba6f-3588914c642e" />
in https://github.com/pytorch/pytorch/pull/159172

So I decided I should clean up this message a bit.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #159495

