### PR TITLE
Remove pin on libuv from instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ conda install pkg-config libuv
 pip install mkl-static mkl-include
 # Add these packages if torch.distributed is needed.
 # Distributed package support on Windows is a prototype feature and is subject to changes.
-conda install -c conda-forge libuv=1.39
+conda install -c conda-forge libuv
 ```
 
 #### Install PyTorch


### PR DESCRIPTION
This package doesn't exist at conda-forge and causes some confusion for users.
see https://anaconda.org/conda-forge/libuv/files?version=1.39.0

libuv is quite stable, so the newer versions should be fine. we build with them anyway at conda-forge.

see: https://github.com/conda-forge/libuv-feedstock/issues/80

cc: @taras-janea @isuruf

Hopefully this can help future users.

Fixes https://github.com/conda-forge/libuv-feedstock/issues/80
