### PR TITLE
[MPS] Speedup `argmax`/`argmin`

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -12504,10 +12504,11 @@ class TestMetalLibrary(TestCaseMPS):
         if not dtype.is_floating_point:
             return
 
-        x[5] = torch.nan
+        idx = 25
+        x[idx] = torch.nan
         lib.do_max(z0, z1, x)
-        self.assertTrue(z0.isnan().all().item(), "results are {z0}, but all elements shold have been nan")
-        self.assertTrue((z1 == 5).all().item(), "results are {z1}, but all elements shold have been 5")
+        self.assertTrue(z0.isnan().all().item(), f"results are {z0}, but all elements shold have been nan")
+        self.assertTrue((z1 == idx).all().item(), f"results are {z1}, but all elements shold have been {idx}")
 
     @parametrize("dtype", [torch.float32, torch.float16, torch.int32, torch.bfloat16])
     def test_atomic_add(self, dtype):

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -648,36 +648,29 @@ class MetalKernel(SIMDKernel):
                 dtype=DTYPE_TO_COMPUTATION_DTYPE[dtype],
             )
         if reduction_type in ["argmin", "argmax"]:
-            acc_buf = self._new_idxvar(src_dtype, acc_buf_size)
-            acc_thread_var = f"{acc_buf}[{reduction_idx}]"
+            data_acc_buf = self._new_idxvar(src_dtype, shmem_buf_size)
+            idx_acc_buf = self._new_idxvar(dtype, shmem_buf_size)
             src_metal_type = DTYPE_TO_METAL[src_dtype]
+            cast_value = f"static_cast<{src_metal_type}>({value})"
             if not self.multistage_reduction_entry:
-                self.compute.splice(
-                    f"{acc_thread_var} = static_cast<{src_metal_type}>({value});"
-                )
-                return self.cse.generate(
-                    self.stores,
-                    f"c10::metal::threadgroup_{reduction_type}({acc_buf}, {acc_buf_size})",
-                    dtype=dtype,
-                )
-            lim_fn = "lowest" if reduction_type.endswith("max") else "max"
-            self.indexing_code.writeline(
-                f"{acc_thread_var} = ::metal::numeric_limits<{src_metal_type}>::{lim_fn}();"
-            )
-            idx_var = next(t for t in self.range_tree_nodes.values() if t.is_reduction)
-            idx_acc_buf = self._new_idxvar(torch.long, acc_buf_size)
-            cmp_op = ">" if reduction_type == "argmax" else "<"
-            idx_thread_var = f"{idx_acc_buf}[{reduction_idx}]"
-            self.indexing_code.splice(f"{idx_thread_var} = -1;")
-            self.compute.splice(f"""
-            if ({value} {cmp_op} {acc_thread_var}) {{
-                {acc_thread_var} = {value};
-                {idx_thread_var} = {idx_var.name};
-            }}
-            """)
+                val = cast_value  # type: ignore[assignment]
+                idx_val = f"static_cast<{DTYPE_TO_METAL[dtype]}>({reduction_idx})"
+            else:
+                lim_fn = "lowest" if reduction_type.endswith("max") else "max"
+                limit_val = f"::metal::numeric_limits<{src_metal_type}>::{lim_fn}()"
+                val = self._new_idxvar(src_dtype, default_value=limit_val, is_threadgroup=False)
+                idx_val = self._new_idxvar(dtype, default_value=0, is_threadgroup=False)
+                idx_var = next(t for t in self.range_tree_nodes.values() if t.is_reduction)
+                cmp_op = ">" if reduction_type == "argmax" else "<"
+                self.compute.splice(f"""
+                if ({value} {cmp_op} {val}) {{
+                    {val} = {value};
+                    {idx_val} = {idx_var.name};
+                }}
+                """)
             return self.cse.generate(
                 self.stores,
-                f"{idx_acc_buf}[c10::metal::threadgroup_{reduction_type}({acc_buf}, {acc_buf_size})]",
+                f"c10::metal::threadgroup_{reduction_type}({data_acc_buf}, {idx_acc_buf}, {val}, {idx_val}, {reduction_idx}, {acc_buf_size})",
                 dtype=dtype,
             )
         if reduction_type == "welford_reduce":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #159524

By using efficient `threadgroup_arg[max|min]` primitives. 
- Fixed bug in `simd_argmax` when result of the `simd_ballot` were prematurely cast to `ushort` and adjusted unit test
- Fixed nan handling in compiled argmax, but can't reliably test it as MPS(eager) implementaiton of argmax is buggy

Now according to `bench_mps_ops.py` `max(x, dim=0)` is reliably faster than eager implementaiton:
```
[---------------------------------------------------------------------------------------------  --------------------------------------------------------------------------------------------]
                           |  eager-512x512  |  compile-512x512  |  eager-1024x1024  |  compile-1024x1024  |  eager-2048x2048  |  compile-2048x2048  |  eager-4096x4096  |  compile-4096x4096
1 threads: ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      max (torch.float16)  |      285.8      |       272.2       |       422.3       |        354.5        |       721.6       |        683.5        |       2224.0      |        1979.1     
      max (torch.float32)  |      300.2      |       267.0       |       389.6       |        342.5        |       769.4       |        682.6        |       2995.7      |        2609.8     
      max (torch.int32)    |      299.6      |       275.4       |       390.0       |        361.7        |       758.7       |        686.1        |       3103.4      |        2646.5     
      max (torch.int64)    |      297.5      |       275.5       |       417.0       |        382.1        |       856.1       |        722.6        |       5467.7      |        3156.8     

```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben