### PR TITLE
disable execution frame cleanup

### DIFF
--- a/torch/nativert/executor/ExecutorConfig.h
+++ b/torch/nativert/executor/ExecutorConfig.h
@@ -11,7 +11,7 @@ struct ExecutorConfig {
   bool debugNan = false;
   bool enableStaticCPUKernels = false;
   bool runConstFolding = false;
-  bool doExecutionFrameCleanup = true;
+  bool doExecutionFrameCleanup = false;
   bool tryFreeUnmanagedValuesAfterUse = true;
   // allows up to max number of concurrent threads.
   int64_t maxNumConcurrentThreads = 8;


### PR DESCRIPTION
Summary: Want to disable execution frame cleanup until fix in D78621408 is merged

Test Plan:
CI

Rollback Plan:

Differential Revision: D79306602


