### PR TITLE
Use boxed_nop_preserve_node_meta for aot_export_joint_with_descriptors

### DIFF
--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -1131,6 +1131,15 @@ def aot_module_simplified(
     return forward
 
 
+def boxed_nop_preserve_node_meta(fx_g, example_inputs):
+    def run(args):
+        with torch.fx.traceback.preserve_node_meta():
+            return torch.fx.Interpreter(fx_g).boxed_run(args)
+
+    run._boxed_call = True
+    return run
+
+
 def aot_export_joint_with_descriptors(
     stack: contextlib.ExitStack,
     mod: nn.Module,
@@ -1201,8 +1210,6 @@ def aot_export_joint_with_descriptors(
     of the inputs to determine if inputs are parameters and their FQNs.
     """
 
-    from torch._dynamo.backends.debugging import boxed_nop
-
     (
         functional_call,
         _params_buffers_flat,
@@ -1219,8 +1226,8 @@ def aot_export_joint_with_descriptors(
         mod,
         args,
         kwargs,
-        boxed_nop,
-        boxed_nop,
+        boxed_nop_preserve_node_meta,
+        boxed_nop_preserve_node_meta,
         default_partition,
         decompositions,
         keep_inference_input_mutations,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #159546
* __->__ #159545

Signed-off-by: Edward Z. Yang <ezyang@meta.com>