### PR TITLE
[c10d][nvshmem] modify is_nvshmem_available runtime check to work with static-linked library (#159558)

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cu
@@ -28,12 +28,20 @@ namespace c10d::nvshmem_extension {
 
 constexpr int MiB = 1024 * 1024;
 
+extern "C" void nvshmem_init() __attribute__((weak));
+
 // Check if NVSHMEM is available
 bool is_nvshmem_available() {
   // Runtime check
   static std::mutex mutex;
   static int is_available = -2;
   std::lock_guard<std::mutex> lock(mutex);
+
+  // Checked if the symbol is statically linked
+  if(is_available == -2 && nvshmem_init) {
+    is_available = 1;
+  }
+
   if (is_available == -2) {
     void* handle{};
     // Open the shared library, RTLD_LAZY defers symbol resolution until needed


### PR DESCRIPTION
Summary:

Currently this function rely on the logic that we load `libnvshmem_device.a` statically and load `libnvshmem_host.so` at runtime. For loading `libnvshmem.a` (the combine 2 thing together) statically this will fail. Add a section to check if the symbol from host API exist at runtime to check if nvshmem is loaded statically

Test Plan:
CI + sample run

Rollback Plan:

Differential Revision: D79177525




cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta