### PR TITLE
[BE][Easy] respect `os.environ` in subprocess calls in tools/nightly.py

### DIFF
--- a/tools/nightly.py
+++ b/tools/nightly.py
@@ -436,7 +436,7 @@ class Venv:
             check=check,
             text=True,
             encoding="utf-8",
-            env={**self._env, **env},
+            env={**os.environ, **self._env, **env},
             **popen_kwargs,
         )
 
@@ -481,7 +481,7 @@ class Venv:
             check=check,
             text=True,
             encoding="utf-8",
-            env={**self._env, **env, "UV_PYTHON": str(python)},
+            env={**os.environ, **self._env, **env, "UV_PYTHON": str(python)},
             **popen_kwargs,
         )
 


### PR DESCRIPTION
Respect parent shell's envvars, such as `UV_INDEX_STRATEGY`, `http{,s}_proxy`, etc.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #159572

