### PR TITLE
Remove torchaudio from smoke testing

### DIFF
--- a/.ci/pytorch/smoke_test/smoke_test.py
+++ b/.ci/pytorch/smoke_test/smoke_test.py
@@ -35,14 +35,7 @@ MODULES = [
         "smoke_test": "./vision/test/smoke_test.py",
         "extension": "extension",
         "repo_name": "vision",
-    },
-    {
-        "name": "torchaudio",
-        "repo": "https://github.com/pytorch/audio.git",
-        "smoke_test": "./audio/test/smoke_test/smoke_test.py --no-ffmpeg",
-        "extension": "_extension",
-        "repo_name": "audio",
-    },
+    }
 ]
 
 

--- a/.ci/pytorch/smoke_test/smoke_test.py
+++ b/.ci/pytorch/smoke_test/smoke_test.py
@@ -35,7 +35,7 @@ MODULES = [
         "smoke_test": "./vision/test/smoke_test.py",
         "extension": "extension",
         "repo_name": "vision",
-    }
+    },
 ]
 
 


### PR DESCRIPTION
torchaudo is transitioning maintenance mode: https://github.com/pytorch/audio
Hence turn off smoke testing for now. These should not be part of nightly/release validation.
