### PR TITLE
[Dynamo][Better Engineering] Type coverage for `torch/_dynamo/utils.py`

### DIFF
--- a/torch/_dynamo/replay_record.py
+++ b/torch/_dynamo/replay_record.py
@@ -15,8 +15,9 @@ and recreate specific program states.
 
 import dataclasses
 from dataclasses import field
+from io import BufferedReader, BufferedWriter
 from types import CellType, CodeType, ModuleType
-from typing import Any, IO
+from typing import Any, IO, Union
 from typing_extensions import Self
 
 from torch.utils._import_utils import import_dill
@@ -51,12 +52,12 @@ class ExecutionRecord:
     builtins: dict[str, Any] = field(default_factory=dict)
     code_options: dict[str, Any] = field(default_factory=dict)
 
-    def dump(self, f: IO[str]) -> None:
+    def dump(self, f: Union[IO[str], BufferedWriter]) -> None:
         assert dill is not None, "replay_record requires `pip install dill`"
         dill.dump(self, f)
 
     @classmethod
-    def load(cls, f: IO[bytes]) -> Self:
+    def load(cls, f: Union[IO[bytes], BufferedReader]) -> Self:
         assert dill is not None, "replay_record requires `pip install dill`"
         return dill.load(f)
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -3907,7 +3907,7 @@ class numpy_operator_wrapper:
         assert not kwargs
 
         args = (
-            np.ndarray(arg) if isinstance(arg, torch.Tensor) else arg for arg in args
+            tnp.ndarray(arg) if isinstance(arg, torch.Tensor) else arg for arg in args
         )
         out = self.op(*args)
         return numpy_to_tensor(out)


### PR DESCRIPTION
As part of better engineering effort, we would like to improve out type support to improve dev experience in dynamo

This PR adds strict typing support to `torch/_dynamo/utils.py`

Running 
```
mypy torch/_dynamo/utils.py --linecount-report /tmp/coverage_log
```

| -------- | Lines Annotated | Lines Total | % lines covered | Funcs Annotated | Funcs Total | % funcs covered |
| -------- | ------- | -------- | ------- | ------- | ------- | ------- |
| Main  |  2163 | 4792 | 45.14% | 121 | 268 | 45.15% |
| This PR | 4818 | 4818 | 100.00% | 268 | 268 | 100.00% |
| Delta    | +2655 | +26 | +54.84% | +147 | 0 | +54.85% |



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames