### PR TITLE
[cuDNN][CUDA] Allow Flash attention or cuDNN attention as default in fused_sdp_choice test

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -3159,7 +3159,10 @@ class TestSDPACudaOnly(NNTestCase):
         # TODO we are currently disabling this by default, lets assert that this returns
         # FlashAttention, we need to change when we make remove opt-in for cudnn
         if type != "nested" and PLATFORM_SUPPORTS_CUDNN_ATTENTION and SM90OrLater:
-            self.assertEqual(torch._fused_sdp_choice(query, key, value), SDPBackend.FLASH_ATTENTION.value)
+            try:
+                self.assertEqual(torch._fused_sdp_choice(query, key, value), SDPBackend.FLASH_ATTENTION.value)
+            except AssertionError:
+                self.assertEqual(torch._fused_sdp_choice(query, key, value), SDPBackend.CUDNN_ATTENTION.value)
             with sdpa_kernel(backends=[SDPBackend.CUDNN_ATTENTION]):
                 self.assertEqual(torch._fused_sdp_choice(query, key, value), SDPBackend.CUDNN_ATTENTION.value)
         elif PLATFORM_SUPPORTS_FLASH_ATTENTION:


### PR DESCRIPTION
Hopefully we'll be able to flip the default soon...

cc @csarofeen @ptrblck @xwang233 @msaroufim @jerryzh168