### PR TITLE
[C10D] fix slow init due to repeated dns resolution failure

### DIFF
--- a/torch/csrc/distributed/c10d/socket.cpp
+++ b/torch/csrc/distributed/c10d/socket.cpp
@@ -192,39 +192,51 @@ class SocketImpl {
   const std::optional<std::string> remote_;
 };
 
+// It can be be very slow to repeatedly hit DNS resolution failure, but its very
+// helpful to have DNS names in logs by default. So we try to use DNS but if we
+// hit a transient failure we just disable it for the remainder of the job,
+// logging IP addresses instead.
+// See https://github.com/pytorch/pytorch/issues/159007
+bool DISABLE_getnameinfo = false;
+
 std::string formatSockAddr(const struct ::sockaddr* addr, socklen_t len) {
   char host[NI_MAXHOST], port[NI_MAXSERV]; // NOLINT
 
-  if (int err = ::getnameinfo(
-          addr, len, host, NI_MAXHOST, port, NI_MAXSERV, NI_NUMERICSERV)) {
-    C10D_WARNING(
-        "The hostname of the client socket cannot be retrieved. err={}", err);
-
-    // if we can't resolve the hostname, display the IP address
-    if (addr->sa_family == AF_INET) {
-      struct sockaddr_in* psai = (struct sockaddr_in*)&addr;
-      // NOLINTNEXTLINE(*array*)
-      char ip[INET_ADDRSTRLEN];
-      if (inet_ntop(addr->sa_family, &(psai->sin_addr), ip, INET_ADDRSTRLEN) !=
-          nullptr) {
-        return fmt::format("{}:{}", ip, psai->sin_port);
-      }
-    } else if (addr->sa_family == AF_INET6) {
-      struct sockaddr_in6* psai = (struct sockaddr_in6*)&addr;
-      // NOLINTNEXTLINE(*array*)
-      char ip[INET6_ADDRSTRLEN];
-      if (inet_ntop(
-              addr->sa_family, &(psai->sin6_addr), ip, INET6_ADDRSTRLEN) !=
-          nullptr) {
-        return fmt::format("[{}]:{}", ip, psai->sin6_port);
-      }
+  if (!DISABLE_getnameinfo) {
+    int err = ::getnameinfo(
+        addr, len, host, NI_MAXHOST, port, NI_MAXSERV, NI_NUMERICSERV);
+    if (err != 0) {
+      C10D_WARNING(
+          "The hostname of the client socket cannot be retrieved. err={}", err);
+      DISABLE_getnameinfo = true;
     }
-    return "?UNKNOWN?";
   }
+  // if getnameinfo failed, DISABLE would be set
+  if (!DISABLE_getnameinfo) {
+    if (addr->sa_family == AF_INET) {
+      return fmt::format("{}:{}", host, port);
+    }
+    return fmt::format("[{}]:{}", host, port);
+  }
+  // if we can't resolve the hostname, display the IP address
   if (addr->sa_family == AF_INET) {
-    return fmt::format("{}:{}", host, port);
+    struct sockaddr_in* psai = (struct sockaddr_in*)&addr;
+    // NOLINTNEXTLINE(*array*)
+    char ip[INET_ADDRSTRLEN];
+    if (inet_ntop(addr->sa_family, &(psai->sin_addr), ip, INET_ADDRSTRLEN) !=
+        nullptr) {
+      return fmt::format("{}:{}", ip, psai->sin_port);
+    }
+  } else if (addr->sa_family == AF_INET6) {
+    struct sockaddr_in6* psai = (struct sockaddr_in6*)&addr;
+    // NOLINTNEXTLINE(*array*)
+    char ip[INET6_ADDRSTRLEN];
+    if (inet_ntop(addr->sa_family, &(psai->sin6_addr), ip, INET6_ADDRSTRLEN) !=
+        nullptr) {
+      return fmt::format("[{}]:{}", ip, psai->sin6_port);
+    }
   }
-  return fmt::format("[{}]:{}", host, port);
+  return "?UNKNOWN?";
 }
 } // namespace c10d::detail
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #159812
* __->__ #159596

It can be be very slow to repeatedly hit DNS resolution failure, but
its very helpful to have DNS names in logs by default. So we try to use DNS
but if we hit a transient failure we just disable it for the remainder of the
job, logging IP addresses instead.

Fixes #159007

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @d4l3k @pragupta