### PR TITLE
[Testing] Allow MPS for TestCommon in test/test_ops.py

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2836,7 +2836,7 @@ class TestFakeTensor(TestCase):
             self.assertEqual(strided_result.layout, torch.strided)
 
 
-instantiate_device_type_tests(TestCommon, globals())
+instantiate_device_type_tests(TestCommon, globals(), allow_mps=True)
 instantiate_device_type_tests(TestCompositeCompliance, globals())
 instantiate_device_type_tests(TestMathBits, globals())
 instantiate_device_type_tests(TestRefsOpsInfo, globals(), only_for="cpu")


### PR DESCRIPTION
Enables running TestCommon suite in MPS backend
