### PR TITLE
Fix recently added AllocatorConfig static initializer code.

### DIFF
--- a/c10/cuda/CUDAAllocatorConfig.h
+++ b/c10/cuda/CUDAAllocatorConfig.h
@@ -111,6 +111,19 @@ class C10_CUDA_API CUDAAllocatorConfig {
   }
 
   static const std::unordered_set<std::string>& getKeys() {
+    static std::unordered_set<std::string> keys_ = {
+        "backend",
+        // keep BC for Rocm: `cuda` -> `cud` `a`, to avoid hipify issues
+        // NOLINTBEGIN(bugprone-suspicious-missing-comma,-warnings-as-errors)
+        "release_lock_on_cud"
+        "amalloc",
+        "pinned_use_cud"
+        "a_host_register",
+        // NOLINTEND(bugprone-suspicious-missing-comma,-warnings-as-errors)
+        "release_lock_on_hipmalloc",
+        "pinned_use_hip_host_register",
+        "pinned_num_register_threads",
+    };
     return keys_;
   }
 
@@ -163,18 +176,6 @@ class C10_CUDA_API CUDAAllocatorConfig {
   std::atomic<bool> m_pinned_use_cuda_host_register{false};
   std::atomic<bool> m_use_async_allocator{false};
   std::atomic<bool> m_is_allocator_loaded{false};
-  inline static std::unordered_set<std::string> keys_{
-      "backend",
-      // keep BC for Rocm: `cuda` -> `cud` `a`, to avoid hipify issues
-      // NOLINTBEGIN(bugprone-suspicious-missing-comma,-warnings-as-errors)
-      "release_lock_on_cud"
-      "amalloc",
-      "pinned_use_cud"
-      "a_host_register",
-      // NOLINTEND(bugprone-suspicious-missing-comma,-warnings-as-errors)
-      "release_lock_on_hipmalloc",
-      "pinned_use_hip_host_register",
-      "pinned_num_register_threads"};
 };
 
 // Keep this for backwards compatibility


### PR DESCRIPTION
This fixes DLL load errors detected downstream at https://github.com/ROCm/TheRock/issues/1155 and reported at:
* https://github.com/pytorch/pytorch/pull/150312#issuecomment-3138008463
* https://github.com/pytorch/pytorch/pull/157908#discussion_r2246557897

Static initialization at class scope using a data structure from the STL is not safe (especially in Windows DLLs):

* https://stackoverflow.com/a/5115008
* https://isocpp.org/wiki/faq/ctors#static-init-order
* https://iifx.dev/en/articles/457660146

I'm also fine with other solutions or reverting the changes that introduced these bugs, sending this as one option to consider.