### PR TITLE
[c10d] Remove multicast support check in supportsTensorAlloc

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -5723,11 +5723,7 @@ bool ProcessGroupNCCL::supportsTensorAlloc(c10::DeviceIndex deviceIdx) {
     return false;
   }
 
-  // We do an extra check to see if CUDA driver supports multicast.  If not, we
-  // will return false. Although `ncclMemAlloc` will fall back to regular
-  // `cudaMalloc` and hence not error out, we may still want to avoid creating a
-  // separate memory pool for NCCL.
-  return c10d::cuda::deviceSupportsMulticast(deviceIdx);
+  return true;
 }
 
 at::Tensor ProcessGroupNCCL::allocateTensor(


### PR DESCRIPTION
Summary:
The context of this change is there are legit use cases, e.g., mempool based zero
copy, to use ncclMemAlloc to allocate the memory pool, which is unrelated to
multicast.

Test Plan:
We tested the change in a private pytorch branch: Integrated with XLF mempool allocation and tested the mem allocation function is adopted as expected

Rollback Plan:

Differential Revision: D79395717




cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci