### PR TITLE
Fix empty_like decomposition to preserve strides

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -1326,12 +1326,15 @@ class TestInductorOpInfo(TestCase):
                         adjusted_kwargs.update(kwarg_overrides)
 
                         # Call the appropriate check method based on device type
+                        # TODO: remove when exact_stride=True by default
+                        exact_stride = op_name.endswith("_like")
                         if device_type == GPU_TYPE:
                             self.check_model_gpu(
                                 fn,
                                 args,
                                 kwargs,
                                 **adjusted_kwargs,
+                                exact_stride=exact_stride,
                             )
                         else:
                             self.check_model(
@@ -1339,6 +1342,7 @@ class TestInductorOpInfo(TestCase):
                                 args,
                                 kwargs,
                                 **adjusted_kwargs,
+                                exact_stride=exact_stride,
                             )
 
         except Exception as e:

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -639,7 +639,7 @@ def full_like(
         return result.permute(permutation).clone()
 
 
-def _rand_like(
+def _fn_like(
     rand_fn: Callable[..., torch.Tensor],
     self: torch.Tensor,
     *,
@@ -675,26 +675,31 @@ def _rand_like(
     return result.permute(permutation).clone()
 
 
+@register_decomposition(aten.empty_like)
+def empty_like(self: torch.Tensor, **kwargs: Any) -> torch.Tensor:
+    return _fn_like(torch.empty, self, **kwargs)
+
+
 @register_decomposition(aten.rand_like)
 def rand_like(self: torch.Tensor, **kwargs: Any) -> torch.Tensor:
-    return _rand_like(torch.rand, self, **kwargs)
+    return _fn_like(torch.rand, self, **kwargs)
 
 
 @register_decomposition(aten.randn_like)
 def randn_like(self: torch.Tensor, **kwargs: Any) -> torch.Tensor:
-    return _rand_like(torch.randn, self, **kwargs)
+    return _fn_like(torch.randn, self, **kwargs)
 
 
 @register_decomposition(aten.randint_like.default)
 def randint_like(self: torch.Tensor, high: int, **kwargs: Any) -> torch.Tensor:
-    return _rand_like(functools.partial(aten.randint.low, 0, high), self, **kwargs)
+    return _fn_like(functools.partial(aten.randint.low, 0, high), self, **kwargs)
 
 
 @register_decomposition(aten.randint_like.low_dtype)
 def randint_like_low(
     self: torch.Tensor, low: int, high: int, **kwargs: Any
 ) -> torch.Tensor:
-    return _rand_like(functools.partial(aten.randint.low, low, high), self, **kwargs)
+    return _fn_like(functools.partial(aten.randint.low, low, high), self, **kwargs)
 
 
 @register_decomposition(aten.randint.default)

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -5032,7 +5032,6 @@ def empty_out(
     return out
 
 
-@register_decomposition(aten.empty_like)
 @out_wrapper()
 def empty_like(
     a: TensorLikeType,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #159609
* __->__ #159614

Test Plan: Fails before; succeeds with this diff:
`python test/inductor/test_torchinductor_opinfo.py -k _like_`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben