### PR TITLE
Fix torch.searchsorted behavior with inf and nan values (#158738), following up on PR #159403

### DIFF
--- a/aten/src/ATen/native/Bucketization.cpp
+++ b/aten/src/ATen/native/Bucketization.cpp
@@ -57,7 +57,7 @@ int64_t cus_lower_bound(int64_t start, int64_t end, const input_t val, const inp
       start = end; // insert NaN at the end
     } else if (std::isnan(mid_val)) {
       end = mid;  // NaN is greatest, search left
-    } else if (!(mid_val >= val)) {
+    } else if (mid_val < val) {
       start = mid + 1;
     } else {
       end = mid;
@@ -81,7 +81,7 @@ int64_t cus_upper_bound(int64_t start, int64_t end, const input_t val, const inp
       start = end;  // insert NaN at the end
     } else if (std::isnan(mid_val)) {
       end = mid;  // NaN is greatest, search left
-    } else if (!(mid_val > val)) {
+    } else if (mid_val <= val) {
       start = mid + 1;
     } else {
       end = mid;

--- a/aten/src/ATen/native/Bucketization.cpp
+++ b/aten/src/ATen/native/Bucketization.cpp
@@ -53,10 +53,13 @@ int64_t cus_lower_bound(int64_t start, int64_t end, const input_t val, const inp
   while (start < end) {
     const int64_t mid = start + ((end - start) >> 1);
     const input_t mid_val = sort ? bd[sort[mid] + orig_start] : bd[mid];
-    if (!(mid_val >= val)) {
+    if (std::isnan(val)) {
+      start = end; // insert NaN at the end
+    } else if (std::isnan(mid_val)) {
+      end = mid;  // NaN is greatest, search left
+    } else if (!(mid_val >= val)) {
       start = mid + 1;
-    }
-    else {
+    } else {
       end = mid;
     }
   }
@@ -74,10 +77,13 @@ int64_t cus_upper_bound(int64_t start, int64_t end, const input_t val, const inp
   while (start < end) {
     const int64_t mid = start + ((end - start) >> 1);
     const input_t mid_val = sort ? bd[sort[mid] + orig_start] : bd[mid];
-    if (!(mid_val > val)) {
+    if (std::isnan(val)) {
+      start = end;  // insert NaN at the end
+    } else if (std::isnan(mid_val)) {
+      end = mid;  // NaN is greatest, search left
+    } else if (!(mid_val > val)) {
       start = mid + 1;
-    }
-    else {
+    } else {
       end = mid;
     }
   }

--- a/aten/src/ATen/native/cuda/Bucketization.cu
+++ b/aten/src/ATen/native/cuda/Bucketization.cu
@@ -27,14 +27,11 @@ __device__ int64_t lower_bound(const input_t *data_ss, int64_t start, int64_t en
   // sorter gives relative ordering for ND tensors, so we need to save and add the non-updated start as an offset
   // i.e. the second row of a 3x3 tensors starts at element 3 but sorter's second row only contains 0, 1, or 2
   const int64_t orig_start = start;
+  // NumPy-like: for left, NaN query inserts at first NaN in boundaries.
   while (start < end) {
     const int64_t mid = start + ((end - start) >> 1);
     const input_t mid_val = data_sort ? data_ss[orig_start + data_sort[mid]] : data_ss[mid];
-    if (std::isnan(val)) {
-      start = end; // insert NaN at the end
-    } else if (std::isnan(mid_val)) {
-      end = mid;  // NaN is greatest, search left
-    } else if (mid_val < val) {
+    if (!std::isnan(mid_val) && !(mid_val >= val)) {
       start = mid + 1;
     } else {
       end = mid;
@@ -48,19 +45,19 @@ __device__ int64_t upper_bound(const input_t *data_ss, int64_t start, int64_t en
   // sorter gives relative ordering for ND tensors, so we need to save and add the non-updated start as an offset
   // i.e. the second row of a 3x3 tensors starts at element 3 but sorter's second row only contains 0, 1, or 2
   const int64_t orig_start = start;
-  while (start < end) {
-    const int64_t mid = start + ((end - start) >> 1);
-    const input_t mid_val = data_sort ? data_ss[orig_start + data_sort[mid]] : data_ss[mid];
-    if (std::isnan(val)) {
-      start = end; // insert NaN at the end
-    } else if (std::isnan(mid_val)) {
-      end = mid;  // NaN is greatest, search left
-    } else if (mid_val <= val) {
-      start = mid + 1;
-    } else {
-      end = mid;
+  // Numpy-like: for right, NaN query inserts at end (after all NaNs)
+  if (std::isnan(val)) {
+    return end;
+  } else {
+    while (start < end) {
+      const int64_t mid = start + ((end - start) >> 1);
+      const input_t mid_val = data_sort ? data_ss[orig_start + data_sort[mid]] : data_ss[mid];
+      if (!std::isnan(mid_val) && !(mid_val > val)) {
+        start = mid + 1;
+      } else {
+        end = mid;
+      }
     }
-  }
   return start;
 }
 

--- a/aten/src/ATen/native/cuda/Bucketization.cu
+++ b/aten/src/ATen/native/cuda/Bucketization.cu
@@ -34,10 +34,9 @@ __device__ int64_t lower_bound(const input_t *data_ss, int64_t start, int64_t en
       start = end; // insert NaN at the end
     } else if (std::isnan(mid_val)) {
       end = mid;  // NaN is greatest, search left
-    } else if (!(mid_val >= val)) {
+    } else if (mid_val < val) {
       start = mid + 1;
-    }
-    else {
+    } else {
       end = mid;
     }
   }
@@ -56,7 +55,7 @@ __device__ int64_t upper_bound(const input_t *data_ss, int64_t start, int64_t en
       start = end; // insert NaN at the end
     } else if (std::isnan(mid_val)) {
       end = mid;  // NaN is greatest, search left
-    } else if (!(mid_val > val)) {
+    } else if (mid_val <= val) {
       start = mid + 1;
     } else {
       end = mid;

--- a/aten/src/ATen/native/cuda/Bucketization.cu
+++ b/aten/src/ATen/native/cuda/Bucketization.cu
@@ -30,7 +30,11 @@ __device__ int64_t lower_bound(const input_t *data_ss, int64_t start, int64_t en
   while (start < end) {
     const int64_t mid = start + ((end - start) >> 1);
     const input_t mid_val = data_sort ? data_ss[orig_start + data_sort[mid]] : data_ss[mid];
-    if (!(mid_val >= val)) {
+    if (std::isnan(val)) {
+      start = end; // insert NaN at the end
+    } else if (std::isnan(mid_val)) {
+      end = mid;  // NaN is greatest, search left
+    } else if (!(mid_val >= val)) {
       start = mid + 1;
     }
     else {
@@ -48,10 +52,13 @@ __device__ int64_t upper_bound(const input_t *data_ss, int64_t start, int64_t en
   while (start < end) {
     const int64_t mid = start + ((end - start) >> 1);
     const input_t mid_val = data_sort ? data_ss[orig_start + data_sort[mid]] : data_ss[mid];
-    if (!(mid_val > val)) {
+    if (std::isnan(val)) {
+      start = end; // insert NaN at the end
+    } else if (std::isnan(mid_val)) {
+      end = mid;  // NaN is greatest, search left
+    } else if (!(mid_val > val)) {
       start = mid + 1;
-    }
-    else {
+    } else {
       end = mid;
     }
   }


### PR DESCRIPTION
Fixes #158738

_Follows up on PR #159403 — that PR had the correct changes, but they were mistakenly pushed directly to the main branch. This PR moves those changes to a proper feature branch for a clean history and workflow._

**Outcomes:**
- Ensure `inf` values are consistently placed before `nan` values regardless of the `right` parameter.
- Modify custom `lower_bound` and `upper_bound` to treat `NaN` as the largest value, always inserting it at the end.
- Align `searchsorted` behavior with numpy-like semantics when handling special float values.

**Logical Explanation:**  
The original implementation relied on standard `lower_bound` and `upper_bound` semantics, which do not handle special float values like `NaN` and `Inf` correctly. Specifically, the earlier code lacked explicit checks for:

- `if (std::isnan(val))` — to ensure `NaN` is always placed at the end.
- `if (std::isnan(mid_val))` — to treat `NaN` as the largest boundary value, forcing the search to continue leftwards.

By adding these two conditions in the custom `cus_lower_bound` and `cus_upper_bound` functions, we explicitly handle these edge cases. This ensures `NaN` values are always inserted at the end and that `Inf` values are placed before `NaN`, aligning with numpy-like semantics and user expectations.

**Example:**
```
sorted_sequence_inf = torch.tensor([1, 3, torch.inf])
sorted_sequence_nan = torch.tensor([1, 3, torch.nan])
values = torch.tensor([0, 2, 4, torch.inf, torch.nan])

torch.stack([
    torch.searchsorted(sorted_sequence_inf, values),
    torch.searchsorted(sorted_sequence_inf, values, right=True),
    torch.searchsorted(sorted_sequence_nan, values),
    torch.searchsorted(sorted_sequence_nan, values, right=True)
])
```

**Before:**
```
tensor([[0, 1, 2, 2, 3],
        [0, 1, 2, 3, 3],
        [0, 1, 3, 3, 3],
        [0, 1, 3, 3, 3]])
```

**After:**
```
tensor([[0, 1, 2, 2, 3],
        [0, 1, 2, 3, 3],
        [0, 1, 2, 2, 3],
        [0, 1, 2, 2, 3]])
```

cc @eqy @syed-ahmed @soulitzer @zeshengzong @albanD