### PR TITLE
Fix the description of `alpha` in `torch.sub`

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -10748,9 +10748,9 @@ Args:
 
 Keyword args:
     alpha (Number): the multiplier for :attr:`other`. Note that the type of :attr:`alpha`
-                    should meet with the dtype of :attr:`input`. Specially, for floating
-                    point input tensors, argument :attr:`alpha` could be either a floating
-                    point number or an integer.
+                    should be type-promotable with the dtype of :attr:`input`. See
+                    `here <https://docs.pytorch.org/docs/stable/tensor_attributes.html#type-promotion-doc>`_
+                    for more details.
     {out}
 
 Example::

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -10747,7 +10747,10 @@ Args:
     other (Tensor or Number): the tensor or number to subtract from :attr:`input`.
 
 Keyword args:
-    alpha (Number): the multiplier for :attr:`other`.
+    alpha (Number): the multiplier for :attr:`other`. Note that the type of :attr:`alpha`
+                    should meet with the dtype of :attr:`input`. Specially, for floating
+                    point input tensors, argument :attr:`alpha` could be either a floating
+                    point number or an integer.
     {out}
 
 Example::


### PR DESCRIPTION
Fixes #159637 
