### PR TITLE
[pytorch][dynamo_compile] Log stack_trace to dynamo_compile

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1300,6 +1300,7 @@ def _compile(
                 "dynamo_compile_time_before_restart_us": to_int_us(
                     dynamo_time_before_restart
                 ),
+                "stack_trace": traceback.format_stack(),
             }
             # TODO: replace with CompileEventLogger.compilation_metrics
             # There are some columns here not in PT2 Compile Events

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1279,6 +1279,7 @@ class CompilationMetrics:
     compliant_custom_ops: Optional[set[str]] = None
     restart_reasons: Optional[set[str]] = None
     dynamo_time_before_restart_s: Optional[float] = None
+    stack_trace: Optional[list[str]] = None
     # Sometimes, we will finish analyzing a frame but conclude we don't want
     # to install any guarded code.  True means we actually decided to install
     # a compiled frame
@@ -1474,6 +1475,7 @@ def add_compilation_metrics_to_chromium(c: CompilationMetrics) -> None:
         fail_reason=c.fail_reason,
         fail_user_frame_filename=c.fail_user_frame_filename,
         fail_user_frame_lineno=c.fail_user_frame_lineno,
+        stack_trace=c.stack_trace,
         # Sets aren't JSON serializable
         non_compliant_ops=list(c.non_compliant_ops)
         if c.non_compliant_ops is not None


### PR DESCRIPTION
Summary: Logging stack_trace of what we're actually compiling to dynamo_compile. Ref D79287964

Test Plan:
ref D79372519




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela