### PR TITLE
[pytorch][dynamo_compile] Log stack_trace to dynamo_compile

### DIFF
--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -350,6 +350,7 @@ class TestDynamoTimed(TestCase):
             e.cuda_version = None
             e.triton_version = None
             e.python_version = None
+            e.stack_trace = None
 
         # First event is for the forward. Formatting makes reading diffs
         # much easier.
@@ -433,6 +434,7 @@ class TestDynamoTimed(TestCase):
  'runtime_triton_autotune_time_us': None,
  'shape_env_guard_count': 0,
  'specialize_float': False,
+ 'stack_trace': None,
  'start_time': 0.0001,
  'start_time_us': 100,
  'structured_logging_overhead_s': 0.0,
@@ -525,6 +527,7 @@ class TestDynamoTimed(TestCase):
  'runtime_triton_autotune_time_us': None,
  'shape_env_guard_count': None,
  'specialize_float': None,
+ 'stack_trace': None,
  'start_time': 0.0001,
  'start_time_us': 100,
  'structured_logging_overhead_s': 0.0,

--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -257,11 +257,16 @@ class TestDynamoTimed(TestCase):
             stack_trace_list.append(e.stack_trace)
 
         self.assertGreater(len(stack_trace_list), 0)
-        result = '\n'.join(item for sublist in stack_trace_list if sublist for item in (sublist if isinstance(sublist, list) else [sublist]))
+        result = '\n'.join(
+            item
+            for sublist in stack_trace_list
+            if sublist
+            for item in (sublist if isinstance(sublist, list) else [sublist])
+        )
         self.assertIn(
             "test_stack_trace",
             result,
-            "Log file does not contain the expected string: 'test_stack_trace'"
+            "Log file does not contain the expected string: 'test_stack_trace'",
         )
 
     @dynamo_config.patch(

--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -243,19 +243,6 @@ class TestDynamoTimed(TestCase):
         utils.reset_frame_count()
         torch._logging._internal.structured_logging_overhead.clear()
 
-    @dynamo_config.patch(
-        {
-            "log_compilation_metrics": True,
-            "inline_inbuilt_nn_modules": False,
-        }
-    )
-    @inductor_config.patch(
-        {
-            "bundle_triton_into_fx_graph_cache": False,
-            "bundled_autotune_remote_cache": False,
-        }
-    )
-
     @dynamo_config.patch({"log_compilation_metrics": True})
     @inductor_config.patch({"force_disable_caches": True})
     def test_stack_trace(self):
@@ -268,9 +255,21 @@ class TestDynamoTimed(TestCase):
         stack_trace_list = []
         for e in compilation_events:
             stack_trace_list.append(e.stack_trace)
+
+        self.assertTrue(len(stack_trace_list) > 0)
         
-        self.assertTrue(len(stack_trace_list)>0)
-        
+    @dynamo_config.patch(
+        {
+            "log_compilation_metrics": True,
+            "inline_inbuilt_nn_modules": False,
+        }
+    )
+    @inductor_config.patch(
+        {
+            "bundle_triton_into_fx_graph_cache": False,
+            "bundled_autotune_remote_cache": False,
+        }
+    )
     # We can't easily test that timing is actually accurate. Mock time to always
     # return the same value; all durations will be zero.
     @mock.patch("time.time", return_value=0.001)

--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -257,7 +257,7 @@ class TestDynamoTimed(TestCase):
             stack_trace_list.append(e.stack_trace)
 
         self.assertGreater(len(stack_trace_list), 0)
-        result = '\n'.join(
+        result = "\n".join(
             item
             for sublist in stack_trace_list
             if sublist

--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -257,7 +257,7 @@ class TestDynamoTimed(TestCase):
             stack_trace_list.append(e.stack_trace)
 
         self.assertTrue(len(stack_trace_list) > 0)
-        
+
     @dynamo_config.patch(
         {
             "log_compilation_metrics": True,

--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -256,7 +256,13 @@ class TestDynamoTimed(TestCase):
         for e in compilation_events:
             stack_trace_list.append(e.stack_trace)
 
-        self.assertTrue(len(stack_trace_list) > 0)
+        self.assertGreater(len(stack_trace_list), 0)
+        result = '\n'.join(item for sublist in stack_trace_list if sublist for item in (sublist if isinstance(sublist, list) else [sublist]))
+        self.assertIn(
+            "test_stack_trace",
+            result,
+            "Log file does not contain the expected string: 'test_stack_trace'"
+        )
 
     @dynamo_config.patch(
         {

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1300,6 +1300,7 @@ def _compile(
                 "dynamo_compile_time_before_restart_us": to_int_us(
                     dynamo_time_before_restart
                 ),
+                "stack_trace": traceback.format_stack(),
             }
             # TODO: replace with CompileEventLogger.compilation_metrics
             # There are some columns here not in PT2 Compile Events

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -225,7 +225,7 @@ def fx_forward_from_src_skip_result(
     return result
 
 
-def log_dynamo_start(code: CodeType, skip: int = 0):
+def log_dynamo_start(code: CodeType, skip: int = 0) -> list[str]:
     convert_frame_intern = structured.intern_string(__file__)
     # Extract and filter the stack
     stack = list(

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -225,29 +225,34 @@ def fx_forward_from_src_skip_result(
     return result
 
 
-def log_dynamo_start(code: CodeType, skip: int = 0) -> None:
+def log_dynamo_start(code: CodeType, skip: int = 0):
     convert_frame_intern = structured.intern_string(__file__)
+    # Extract and filter the stack
+    stack = list(
+        itertools.takewhile(
+            lambda f: f["filename"] != convert_frame_intern,
+            structured.from_traceback(
+                CapturedTraceback.extract(skip=4 + skip).summary()
+            ),
+        )
+    ) + [
+        {
+            "line": code.co_firstlineno,
+            "name": code.co_name,
+            "filename": structured.intern_string(code.co_filename),
+        }
+    ]
     # Initialize the ChromiumEventLogger on start
     torch._logging.trace_structured(
         "dynamo_start",
-        lambda: {
-            "stack": list(
-                itertools.takewhile(
-                    lambda f: f["filename"] != convert_frame_intern,
-                    structured.from_traceback(
-                        CapturedTraceback.extract(skip=4 + skip).summary()
-                    ),
-                )
-            )
-            + [
-                {
-                    "line": code.co_firstlineno,
-                    "name": code.co_name,
-                    "filename": structured.intern_string(code.co_filename),
-                }
-            ]
-        },
+        lambda: {"stack": stack},
     )
+
+    stack_strings = [
+        f"Line: {frame['line']}, Name: {frame['name']}, Filename: {frame['filename']}"
+        for frame in stack
+    ]
+    return stack_strings
 
 
 def preserve_global_state(fn: Callable[_P, _T]) -> Callable[_P, _T]:
@@ -1160,7 +1165,7 @@ def _compile(
         # # 2 extra here
         # torch/_logging/_internal.py:1064 in trace_structured
         # torch/_dynamo/convert_frame.py:780 in <lambda>
-        log_dynamo_start(code, skip)
+        stack_trace = log_dynamo_start(code, skip)
         start_time_ns = time.time_ns()
         fail_type: Optional[str] = None
         fail_reason: Optional[str] = None
@@ -1300,7 +1305,7 @@ def _compile(
                 "dynamo_compile_time_before_restart_us": to_int_us(
                     dynamo_time_before_restart
                 ),
-                "stack_trace": traceback.format_stack(),
+                "stack_trace": stack_trace,
             }
             # TODO: replace with CompileEventLogger.compilation_metrics
             # There are some columns here not in PT2 Compile Events

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1484,7 +1484,6 @@ def add_compilation_metrics_to_chromium(c: CompilationMetrics) -> None:
         fail_reason=c.fail_reason,
         fail_user_frame_filename=c.fail_user_frame_filename,
         fail_user_frame_lineno=c.fail_user_frame_lineno,
-        stack_trace=c.stack_trace,
         # Sets aren't JSON serializable
         non_compliant_ops=(
             list(c.non_compliant_ops) if c.non_compliant_ops is not None else None

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1288,6 +1288,7 @@ class CompilationMetrics:
     compliant_custom_ops: Optional[set[str]] = None
     restart_reasons: Optional[set[str]] = None
     dynamo_time_before_restart_s: Optional[float] = None
+    stack_trace: Optional[list[str]] = None
     # Sometimes, we will finish analyzing a frame but conclude we don't want
     # to install any guarded code.  True means we actually decided to install
     # a compiled frame
@@ -1483,6 +1484,7 @@ def add_compilation_metrics_to_chromium(c: CompilationMetrics) -> None:
         fail_reason=c.fail_reason,
         fail_user_frame_filename=c.fail_user_frame_filename,
         fail_user_frame_lineno=c.fail_user_frame_lineno,
+        stack_trace=c.stack_trace,
         # Sets aren't JSON serializable
         non_compliant_ops=(
             list(c.non_compliant_ops) if c.non_compliant_ops is not None else None


### PR DESCRIPTION
This change logs the stack trace of the code being compiled by Dynamo, improving visibility into what is compiled. It adds a stack_trace field to compilation metrics. This helps with debugging and analysis of Dynamo compilation behavior.
 Ref [D79287964](https://www.internalfb.com/diff/D79287964)

Test Plan: 
$ python -m test_utils
Internal: ref [D79372519](https://www.internalfb.com/diff/D79372519)



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela