### PR TITLE
[cuDNN] cuDNN frontend for LayerNorm RMSNorm

### DIFF
--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -1128,9 +1128,8 @@ void LayerNormKernelImplInternal(
 }
 
 inline bool use_cudnn_layernorm(bool gamma, bool beta) {
-  // static bool enabled = (c10::utils::check_env("TORCH_CUDNN_LAYERNORM_ENABLED") == true);
-  // bool ok = enabled && gamma && beta;
-  bool ok = gamma && beta;
+  static bool enabled = (c10::utils::check_env("TORCH_CUDNN_LAYERNORM_ENABLED") == true);
+  bool ok = enabled && gamma && beta;
   if (ok) {
     TORCH_WARN_ONCE("USING EXPERIMENTAL CUDNN LAYERNORM");
   }
@@ -1165,9 +1164,8 @@ void LayerNormKernelImpl(
 }
 
 inline bool use_cudnn_rmsnorm(bool gamma) {
-  // static bool enabled = (c10::utils::check_env("TORCH_CUDNN_RMSNORM_ENABLED") == true);
-  // bool ok = enabled && gamma;
-  bool ok = gamma;
+  static bool enabled = (c10::utils::check_env("TORCH_CUDNN_RMSNORM_ENABLED") == true);
+  bool ok = enabled && gamma;
   if (ok) {
     TORCH_WARN_ONCE("USING EXPERIMENTAL CUDNN RMSNORM");
   }

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -1712,15 +1712,21 @@ void LayerNormBackwardKernelImpl(
     Tensor* dX,
     Tensor* dgamma,
     Tensor* dbeta) {
-  AT_DISPATCH_FLOATING_TYPES_AND2(
-      at::ScalarType::Half,
-      at::ScalarType::BFloat16,
-      X.scalar_type(),
-      "LayerNormBackwardKernelImpl",
-      [&]() {
-        LayerNormBackwardKernelImplInternal<scalar_t>(
-            dY.contiguous(), X, mean, rstd, gamma, M, N, dX, dgamma, dbeta);
-      });
+  if (use_cudnn_layernorm(gamma.numel(), dbeta->numel(), X.scalar_type())) {
+#ifndef USE_ROCM
+    at::native::raw_cudnn_layernorm_backward_out(dY, X, mean, rstd, gamma, M, N, dX, dgamma, dbeta);
+#endif
+  } else {
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        at::ScalarType::Half,
+        at::ScalarType::BFloat16,
+        X.scalar_type(),
+        "LayerNormBackwardKernelImpl",
+        [&]() {
+          LayerNormBackwardKernelImplInternal<scalar_t>(
+              dY.contiguous(), X, mean, rstd, gamma, M, N, dX, dgamma, dbeta);
+        });
+  }
 }
 
 void RMSNormBackwardKernelImpl(
@@ -1732,15 +1738,21 @@ void RMSNormBackwardKernelImpl(
     int64_t N,
     Tensor* dX,
     Tensor* dgamma) {
-  AT_DISPATCH_FLOATING_TYPES_AND2(
-      at::ScalarType::Half,
-      at::ScalarType::BFloat16,
-      X.scalar_type(),
-      "LayerNormBackwardKernelImpl",
-      [&]() {
-        LayerNormBackwardKernelImplInternal<scalar_t, true>(
-            dY.contiguous(), X, rstd, rstd, gamma, M, N, dX, dgamma, dgamma);
-      });
+  if (use_cudnn_rmsnorm(gamma.numel(), X.scalar_type())) {
+#ifndef USE_ROCM
+    at::native::raw_cudnn_rmsnorm_backward_out(dY, X, rstd, gamma, M, N, dX, dgamma);
+#endif
+  } else {
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        at::ScalarType::Half,
+        at::ScalarType::BFloat16,
+        X.scalar_type(),
+        "LayerNormBackwardKernelImpl",
+        [&]() {
+          LayerNormBackwardKernelImplInternal<scalar_t, true>(
+              dY.contiguous(), X, rstd, rstd, gamma, M, N, dX, dgamma, dgamma);
+        });
+  }
 }
 
 } // namespace

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -1128,8 +1128,9 @@ void LayerNormKernelImplInternal(
 }
 
 inline bool use_cudnn_layernorm(bool gamma, bool beta) {
-  static bool enabled = (c10::utils::check_env("TORCH_CUDNN_LAYERNORM_ENABLED") == true);
-  bool ok = enabled && gamma && beta;
+  // static bool enabled = (c10::utils::check_env("TORCH_CUDNN_LAYERNORM_ENABLED") == true);
+  // bool ok = enabled && gamma && beta;
+  bool ok = gamma && beta;
   if (ok) {
     TORCH_WARN_ONCE("USING EXPERIMENTAL CUDNN LAYERNORM");
   }
@@ -1164,8 +1165,9 @@ void LayerNormKernelImpl(
 }
 
 inline bool use_cudnn_rmsnorm(bool gamma) {
-  static bool enabled = (c10::utils::check_env("TORCH_CUDNN_RMSNORM_ENABLED") == true);
-  bool ok = enabled && gamma;
+  // static bool enabled = (c10::utils::check_env("TORCH_CUDNN_RMSNORM_ENABLED") == true);
+  // bool ok = enabled && gamma;
+  bool ok = gamma;
   if (ok) {
     TORCH_WARN_ONCE("USING EXPERIMENTAL CUDNN RMSNORM");
   }

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -1128,11 +1128,15 @@ void LayerNormKernelImplInternal(
 }
 
 inline bool use_cudnn_layernorm(bool gamma, bool beta, at::ScalarType dtype) {
+#ifndef USE_ROCM
   static bool enabled = (c10::utils::check_env("TORCH_CUDNN_LAYERNORM_ENABLED") == true);
   // cuDNN only supports bf16, fp16, and fp32
   bool dtype_supported = dtype != at::ScalarType::Double;
   bool ok = enabled && gamma && beta && dtype_supported;
   return ok;
+#else
+  return false;
+#endif
 }
 
 void LayerNormKernelImpl(
@@ -1163,11 +1167,15 @@ void LayerNormKernelImpl(
 }
 
 inline bool use_cudnn_rmsnorm(bool gamma, at::ScalarType dtype) {
+#ifndef USE_ROCM
   static bool enabled = (c10::utils::check_env("TORCH_CUDNN_RMSNORM_ENABLED") == true);
   // cuDNN only supports bf16, fp16, and fp32
   bool dtype_supported = dtype != at::ScalarType::Double;
   bool ok = enabled && gamma && dtype_supported;
   return ok;
+#else
+  return false;
+#endif
 }
 
 void RmsNormKernelImpl(

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -24,8 +24,10 @@
 #include <ATen/ops/zeros_like_native.h>
 #endif
 
+#ifndef USE_ROCM
 #include <ATen/native/cudnn/LayerNorm_v8.h>
 #include <ATen/native/cudnn/RMSNorm_v8.h>
+#endif
 
 #include <c10/cuda/CUDAMathCompat.h>
 #include <c10/util/env.h>

--- a/aten/src/ATen/native/cudnn/LayerNorm_v8.cpp
+++ b/aten/src/ATen/native/cudnn/LayerNorm_v8.cpp
@@ -214,7 +214,7 @@ void raw_cudnn_layernorm_forward_out(
     TORCH_INTERNAL_ASSERT(
         layernorm_graph->build_operation_graph(handle).is_good());
     TORCH_INTERNAL_ASSERT(
-        layernorm_graph->create_execution_plans({fe::HeurMode_t::FALLBACK})
+        layernorm_graph->create_execution_plans({fe::HeurMode_t::A, fe::HeurMode_t::FALLBACK})
             .is_good());
     TORCH_INTERNAL_ASSERT(
         layernorm_graph->check_support(handle).is_good(),
@@ -344,7 +344,7 @@ void raw_cudnn_layernorm_backward_out(
     TORCH_INTERNAL_ASSERT(
         layernorm_graph->build_operation_graph(handle).is_good());
     TORCH_INTERNAL_ASSERT(
-        layernorm_graph->create_execution_plans({fe::HeurMode_t::FALLBACK})
+        layernorm_graph->create_execution_plans({fe::HeurMode_t::A, fe::HeurMode_t::FALLBACK})
             .is_good());
     TORCH_INTERNAL_ASSERT(
         layernorm_graph->check_support(handle).is_good(),
@@ -387,3 +387,4 @@ void raw_cudnn_layernorm_backward_out(
 } // namespace at
 
 #endif // AT_CUDNN_ENABLED
+

--- a/aten/src/ATen/native/cudnn/LayerNorm_v8.cpp
+++ b/aten/src/ATen/native/cudnn/LayerNorm_v8.cpp
@@ -92,7 +92,7 @@ void setLayerNormParams(
     const Tensor& X,
     int64_t M,
     int64_t N) {
-  memset(&params, 0, sizeof(params));
+  std::memset(&params, 0, sizeof(params));
   params.device_id = at::cuda::current_device();
   params.dataType = get_fe_dtype(X);
   params.M = M;

--- a/aten/src/ATen/native/cudnn/LayerNorm_v8.cpp
+++ b/aten/src/ATen/native/cudnn/LayerNorm_v8.cpp
@@ -1,6 +1,6 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 
-#include <ATen/cuda/CUDAConfig.h>  // for the definition of AT_CUDNN_ENABLED
+#include <ATen/cuda/CUDAConfig.h> // for the definition of AT_CUDNN_ENABLED
 
 #if AT_CUDNN_ENABLED()
 
@@ -12,22 +12,21 @@ C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wsuggest-override")
 #include <cudnn_frontend.h>
 C10_DIAGNOSTIC_POP()
 
-#include <cudnn_frontend_find_plan.h>
-#include <cudnn_frontend_get_plan.h>
-#include <ATen/core/Tensor.h>
 #include <ATen/TensorUtils.h>
+#include <ATen/core/Tensor.h>
 #include <ATen/cuda/Exceptions.h>
+#include <ATen/cudnn/Handle.h>
 #include <ATen/native/cudnn/LayerNorm_v8.h>
 #include <ATen/native/utils/ParamsHash.h>
-#include <ATen/cudnn/Handle.h>
-#include <ATen/TensorUtils.h>
+#include <cudnn_frontend_find_plan.h>
+#include <cudnn_frontend_get_plan.h>
 
-#include <c10/util/env.h>
-#include <c10/cuda/CUDAException.h>
 #include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/cuda/CUDAException.h>
+#include <c10/util/env.h>
 
-#include <unordered_map>
 #include <list>
+#include <unordered_map>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -41,9 +40,8 @@ C10_DIAGNOSTIC_POP()
 
 #include <cudnn_frontend.h>
 
-namespace at { namespace native {
-
-
+namespace at {
+namespace native {
 
 auto get_fe_dtype(const Tensor& t) {
   namespace fe = cudnn_frontend;
@@ -59,37 +57,41 @@ auto get_fe_dtype(const Tensor& t) {
   return fe_dtype;
 }
 
- namespace { 
- namespace fe = cudnn_frontend;
+namespace {
+namespace fe = cudnn_frontend;
 using graph_and_tensors_forward = std::tuple<
-                                    std::shared_ptr<fe::graph::Graph>,
-                                    std::shared_ptr<fe::graph::Tensor_attributes>, // X,
-                                    std::shared_ptr<fe::graph::Tensor_attributes>, // mean,
-                                    std::shared_ptr<fe::graph::Tensor_attributes>, // inv_var,
-                                    std::shared_ptr<fe::graph::Tensor_attributes>, // scale,
-                                    std::shared_ptr<fe::graph::Tensor_attributes>, // bias,
-                                    std::shared_ptr<fe::graph::Tensor_attributes> // Y
-                        >;
+    std::shared_ptr<fe::graph::Graph>,
+    std::shared_ptr<fe::graph::Tensor_attributes>, // X,
+    std::shared_ptr<fe::graph::Tensor_attributes>, // mean,
+    std::shared_ptr<fe::graph::Tensor_attributes>, // inv_var,
+    std::shared_ptr<fe::graph::Tensor_attributes>, // scale,
+    std::shared_ptr<fe::graph::Tensor_attributes>, // bias,
+    std::shared_ptr<fe::graph::Tensor_attributes> // Y
+    >;
 using graph_and_tensors_backward = std::tuple<
-                                    std::shared_ptr<fe::graph::Graph>,
-                                    std::shared_ptr<fe::graph::Tensor_attributes>, // X,
-                                    std::shared_ptr<fe::graph::Tensor_attributes>, // DY,
-                                    std::shared_ptr<fe::graph::Tensor_attributes>, // mean,
-                                    std::shared_ptr<fe::graph::Tensor_attributes>, // inv_variance,
-                                    std::shared_ptr<fe::graph::Tensor_attributes>, // scale,
-                                    std::shared_ptr<fe::graph::Tensor_attributes>, // dscale,
-                                    std::shared_ptr<fe::graph::Tensor_attributes>, // dbias,
-                                    std::shared_ptr<fe::graph::Tensor_attributes> // DX
-                        >;
+    std::shared_ptr<fe::graph::Graph>,
+    std::shared_ptr<fe::graph::Tensor_attributes>, // X,
+    std::shared_ptr<fe::graph::Tensor_attributes>, // DY,
+    std::shared_ptr<fe::graph::Tensor_attributes>, // mean,
+    std::shared_ptr<fe::graph::Tensor_attributes>, // inv_variance,
+    std::shared_ptr<fe::graph::Tensor_attributes>, // scale,
+    std::shared_ptr<fe::graph::Tensor_attributes>, // dscale,
+    std::shared_ptr<fe::graph::Tensor_attributes>, // dbias,
+    std::shared_ptr<fe::graph::Tensor_attributes> // DX
+    >;
 
 struct LayerNormParams {
   c10::DeviceIndex device_id;
   fe::DataType_t dataType;
   int64_t M;
-  int64_t N; 
+  int64_t N;
 };
 
-void setLayerNormParams(LayerNormParams& params, const Tensor& X, int64_t M, int64_t N) {
+void setLayerNormParams(
+    LayerNormParams& params,
+    const Tensor& X,
+    int64_t M,
+    int64_t N) {
   memset(&params, 0, sizeof(params));
   params.device_id = at::cuda::current_device();
   params.dataType = get_fe_dtype(X);
@@ -103,192 +105,285 @@ struct LayerNormCacheKeyWrapper : ParamsWrapper<LayerNormParams> {
   }
 };
 
- template <typename T, typename KeyType>
+template <typename T, typename KeyType>
 struct LayerNormGraphCache {
-std::unordered_map<KeyType, T, ParamsWrapperHash<KeyType>> engine_cache;
+  std::unordered_map<KeyType, T, ParamsWrapperHash<KeyType>> engine_cache;
 
-// no mutexes here as caches are now thread local for v8, can also return a pointer
-// to the Execution Plan if we know it will not be invalidated by another thread
-T* find(const KeyType& key) {
-  auto it = engine_cache.find(key);
-  if (it == engine_cache.end()) {
-    return nullptr;
+  // no mutexes here as caches are now thread local for v8, can also return a
+  // pointer to the Execution Plan if we know it will not be invalidated by
+  // another thread
+  T* find(const KeyType& key) {
+    auto it = engine_cache.find(key);
+    if (it == engine_cache.end()) {
+      return nullptr;
+    }
+    return &(it->second);
   }
-  return &(it->second);
-}
 
-void update(const KeyType& key, T& results) {
-  engine_cache.erase(key);
-  engine_cache.emplace(key, std::move(results));
-}
-
+  void update(const KeyType& key, T& results) {
+    engine_cache.erase(key);
+    engine_cache.emplace(key, std::move(results));
+  }
 };
 
-// @eqy: use thread local caches as cuDNN Execution Plans are not guaranteed to be thread safe across all engines
-// see Limitations in https://docs.nvidia.com/deeplearning/cudnn/release-notes/index.html
-thread_local LayerNormGraphCache<graph_and_tensors_forward, LayerNormCacheKeyWrapper> layernorm_forward_graph_cache;
-thread_local LayerNormGraphCache<graph_and_tensors_backward, LayerNormCacheKeyWrapper> layernorm_backward_graph_cache;
+// @eqy: use thread local caches as cuDNN Execution Plans are not guaranteed to
+// be thread safe across all engines see Limitations in
+// https://docs.nvidia.com/deeplearning/cudnn/release-notes/index.html
+thread_local LayerNormGraphCache<
+    graph_and_tensors_forward,
+    LayerNormCacheKeyWrapper>
+    layernorm_forward_graph_cache;
+thread_local LayerNormGraphCache<
+    graph_and_tensors_backward,
+    LayerNormCacheKeyWrapper>
+    layernorm_backward_graph_cache;
 
- }
+} // namespace
 
-void raw_cudnn_layernorm_forward_out(const Tensor& X, const Tensor& scale, const Tensor& bias, float epsilon, Tensor* mean, Tensor* rstd, Tensor* Y, int64_t M, int64_t N) {
+void raw_cudnn_layernorm_forward_out(
+    const Tensor& X,
+    const Tensor& scale,
+    const Tensor& bias,
+    float epsilon,
+    Tensor* mean,
+    Tensor* rstd,
+    Tensor* Y,
+    int64_t M,
+    int64_t N) {
   namespace fe = cudnn_frontend;
   auto key = LayerNormCacheKeyWrapper(X, M, N);
   auto graph_and_tensors_forward_ptr = layernorm_forward_graph_cache.find(key);
   auto layernorm_graph = std::make_shared<fe::graph::Graph>();
   graph_and_tensors_forward graph_and_tensors_forward_values;
-  std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*> variant_pack;
+  std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*>
+      variant_pack;
   if (graph_and_tensors_forward_ptr) {
-    auto [graph, X_fe, mean_fe, inv_variance_fe, scale_fe, bias_fe, Y_fe] = *graph_and_tensors_forward_ptr;
-    std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*> variant_pack_ = {
-      {X_fe, X.data_ptr()},
-      {mean_fe, mean->data_ptr()},
-      {inv_variance_fe, rstd->data_ptr()},
-      {scale_fe, scale.data_ptr()},
-      {bias_fe, bias.data_ptr()},
-      {Y_fe, Y->data_ptr()}};
+    auto [graph, X_fe, mean_fe, inv_variance_fe, scale_fe, bias_fe, Y_fe] =
+        *graph_and_tensors_forward_ptr;
+    std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*>
+        variant_pack_ = {
+            {X_fe, X.data_ptr()},
+            {mean_fe, mean->data_ptr()},
+            {inv_variance_fe, rstd->data_ptr()},
+            {scale_fe, scale.data_ptr()},
+            {bias_fe, bias.data_ptr()},
+            {Y_fe, Y->data_ptr()}};
     variant_pack = std::move(variant_pack_);
     layernorm_graph = std::move(graph);
   } else {
     layernorm_graph->set_io_data_type(get_fe_dtype(X))
         .set_intermediate_data_type(fe::DataType_t::FLOAT)
         .set_compute_data_type(fe::DataType_t::FLOAT);
-    // cuDNN only seems to care about non-normalized and normalized dimensions, and we can only have one non-normalized-dimension, so...
-    // we reshape to
-    // N, M, 1, 1 because cuDNN also has the restruction that everything must be in 4-D
+    // cuDNN only seems to care about non-normalized and normalized dimensions,
+    // and we can only have one non-normalized-dimension, so... we reshape to N,
+    // M, 1, 1 because cuDNN also has the restruction that everything must be in
+    // 4-D
     auto X_reshaped = X.reshape({M, N, 1, 1});
-    auto X_fe = layernorm_graph->tensor(fe::graph::Tensor_attributes()
-                             .set_name("X")
-                             .set_dim(std::vector<int64_t>(X_reshaped.sizes().begin(), X_reshaped.sizes().end()))
-                             .set_stride(std::vector<int64_t>(X_reshaped.strides().begin(), X_reshaped.strides().end())));
-    auto scale_fe = layernorm_graph->tensor(fe::graph::Tensor_attributes()
-                                  .set_name("scale")
-                                  .set_dim({1, N, 1, 1})
-                                  .set_stride({N, 1, N, N})
-                                  .set_data_type(get_fe_dtype(scale)));
-    auto bias_fe  = layernorm_graph->tensor(fe::graph::Tensor_attributes()
-                                 .set_name("bias")
-                                 .set_dim({1, N, 1, 1})
-                                 .set_stride({N, 1, N, N})
-                                 .set_data_type(get_fe_dtype(bias)));
+    auto X_fe = layernorm_graph->tensor(
+        fe::graph::Tensor_attributes()
+            .set_name("X")
+            .set_dim(std::vector<int64_t>(
+                X_reshaped.sizes().begin(), X_reshaped.sizes().end()))
+            .set_stride(std::vector<int64_t>(
+                X_reshaped.strides().begin(), X_reshaped.strides().end())));
+    auto scale_fe =
+        layernorm_graph->tensor(fe::graph::Tensor_attributes()
+                                    .set_name("scale")
+                                    .set_dim({1, N, 1, 1})
+                                    .set_stride({N, 1, N, N})
+                                    .set_data_type(get_fe_dtype(scale)));
+    auto bias_fe =
+        layernorm_graph->tensor(fe::graph::Tensor_attributes()
+                                    .set_name("bias")
+                                    .set_dim({1, N, 1, 1})
+                                    .set_stride({N, 1, N, N})
+                                    .set_data_type(get_fe_dtype(bias)));
     auto epsilon_fe = layernorm_graph->tensor(epsilon);
     auto layernorm_options =
-        fe::graph::Layernorm_attributes().set_forward_phase(fe::NormFwdPhase_t::TRAINING).set_epsilon(epsilon_fe);
-    auto [Y_fe, mean_fe, inv_variance_fe] = layernorm_graph->layernorm(X_fe, scale_fe, bias_fe, layernorm_options);
+        fe::graph::Layernorm_attributes()
+            .set_forward_phase(fe::NormFwdPhase_t::TRAINING)
+            .set_epsilon(epsilon_fe);
+    auto [Y_fe, mean_fe, inv_variance_fe] =
+        layernorm_graph->layernorm(X_fe, scale_fe, bias_fe, layernorm_options);
     mean_fe->set_output(true).set_data_type(get_fe_dtype(*mean));
     inv_variance_fe->set_output(true).set_data_type(get_fe_dtype(*rstd));
     Y_fe->set_output(true);
 
     cudnnHandle_t handle = getCudnnHandle();
     TORCH_INTERNAL_ASSERT(layernorm_graph->validate().is_good());
-    TORCH_INTERNAL_ASSERT(layernorm_graph->build_operation_graph(handle).is_good());
-    TORCH_INTERNAL_ASSERT(layernorm_graph->create_execution_plans({fe::HeurMode_t::FALLBACK}).is_good());
-    TORCH_INTERNAL_ASSERT(layernorm_graph->check_support(handle).is_good(), layernorm_graph->check_support(handle).get_message());
+    TORCH_INTERNAL_ASSERT(
+        layernorm_graph->build_operation_graph(handle).is_good());
+    TORCH_INTERNAL_ASSERT(
+        layernorm_graph->create_execution_plans({fe::HeurMode_t::FALLBACK})
+            .is_good());
+    TORCH_INTERNAL_ASSERT(
+        layernorm_graph->check_support(handle).is_good(),
+        layernorm_graph->check_support(handle).get_message());
     TORCH_INTERNAL_ASSERT(layernorm_graph->build_plans(handle).is_good());
-    std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*> variant_pack_ = {
-      {X_fe, X.data_ptr()},
-      {mean_fe, mean->data_ptr()},
-      {inv_variance_fe, rstd->data_ptr()},
-      {scale_fe, scale.data_ptr()},
-      {bias_fe, bias.data_ptr()},
-      {Y_fe, Y->data_ptr()}};
+    std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*>
+        variant_pack_ = {
+            {X_fe, X.data_ptr()},
+            {mean_fe, mean->data_ptr()},
+            {inv_variance_fe, rstd->data_ptr()},
+            {scale_fe, scale.data_ptr()},
+            {bias_fe, bias.data_ptr()},
+            {Y_fe, Y->data_ptr()}};
     variant_pack = std::move(variant_pack_);
-    auto result = std::make_tuple(layernorm_graph, X_fe, mean_fe, inv_variance_fe, scale_fe, bias_fe, Y_fe);
+    auto result = std::make_tuple(
+        layernorm_graph,
+        X_fe,
+        mean_fe,
+        inv_variance_fe,
+        scale_fe,
+        bias_fe,
+        Y_fe);
     layernorm_forward_graph_cache.update(key, result);
   }
   cudnnHandle_t handle = getCudnnHandle();
   size_t workspace_size = layernorm_graph->get_workspace_size();
-  auto workspace_ptr = c10::cuda::CUDACachingAllocator::get()->allocate(workspace_size);
+  auto workspace_ptr =
+      c10::cuda::CUDACachingAllocator::get()->allocate(workspace_size);
   TORCH_INTERNAL_ASSERT(!workspace_size || workspace_ptr);
-  TORCH_INTERNAL_ASSERT(layernorm_graph->execute(handle, variant_pack, workspace_ptr.get()).is_good());
+  TORCH_INTERNAL_ASSERT(
+      layernorm_graph->execute(handle, variant_pack, workspace_ptr.get())
+          .is_good());
 }
 
-void raw_cudnn_layernorm_backward_out(const Tensor& dY, const Tensor& X, const Tensor& mean, const Tensor& rstd, const Tensor& gamma, int64_t M, int64_t N, Tensor* dX,  Tensor* dgamma, Tensor* dbeta) {
+void raw_cudnn_layernorm_backward_out(
+    const Tensor& dY,
+    const Tensor& X,
+    const Tensor& mean,
+    const Tensor& rstd,
+    const Tensor& gamma,
+    int64_t M,
+    int64_t N,
+    Tensor* dX,
+    Tensor* dgamma,
+    Tensor* dbeta) {
   namespace fe = cudnn_frontend;
   auto key = LayerNormCacheKeyWrapper(X, M, N);
-  auto graph_and_tensors_backward_ptr = layernorm_backward_graph_cache.find(key);
+  auto graph_and_tensors_backward_ptr =
+      layernorm_backward_graph_cache.find(key);
   auto layernorm_graph = std::make_shared<fe::graph::Graph>();
   graph_and_tensors_backward graph_and_tensors_backward_values;
-  std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*> variant_pack;
+  std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*>
+      variant_pack;
   if (graph_and_tensors_backward_ptr) {
-    auto [graph, X_fe, DY_fe, mean_fe, inv_variance_fe, scale_fe, dscale_fe, dbias_fe, DX_fe] = *graph_and_tensors_backward_ptr;
-    std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*> variant_pack_ = {
-      {X_fe, X.data_ptr()},
-      {DY_fe, dY.data_ptr()},
-      {mean_fe, mean.data_ptr()},
-      {inv_variance_fe, rstd.data_ptr()},
-      {scale_fe, gamma.data_ptr()},
-      {dscale_fe, dgamma->data_ptr()},
-      {dbias_fe, dbeta->data_ptr()},
-      {DX_fe, dX->data_ptr()}};
+    auto
+        [graph,
+         X_fe,
+         DY_fe,
+         mean_fe,
+         inv_variance_fe,
+         scale_fe,
+         dscale_fe,
+         dbias_fe,
+         DX_fe] = *graph_and_tensors_backward_ptr;
+    std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*>
+        variant_pack_ = {
+            {X_fe, X.data_ptr()},
+            {DY_fe, dY.data_ptr()},
+            {mean_fe, mean.data_ptr()},
+            {inv_variance_fe, rstd.data_ptr()},
+            {scale_fe, gamma.data_ptr()},
+            {dscale_fe, dgamma->data_ptr()},
+            {dbias_fe, dbeta->data_ptr()},
+            {DX_fe, dX->data_ptr()}};
     variant_pack = std::move(variant_pack_);
     layernorm_graph = std::move(graph);
   } else {
     layernorm_graph->set_io_data_type(get_fe_dtype(X))
         .set_intermediate_data_type(fe::DataType_t::FLOAT)
         .set_compute_data_type(fe::DataType_t::FLOAT);
-    // cuDNN only seems to care about non-normalized and normalized dimensions, and we can only have one non-normalized-dimension, so...
-    // we reshape to
-    // N, M, 1, 1 because cuDNN also has the restruction that everything must be in 4-D
+    // cuDNN only seems to care about non-normalized and normalized dimensions,
+    // and we can only have one non-normalized-dimension, so... we reshape to N,
+    // M, 1, 1 because cuDNN also has the restruction that everything must be in
+    // 4-D
     auto X_reshaped = X.reshape({M, N, 1, 1});
     auto DY_reshaped = dY.reshape({M, N, 1, 1});
-    auto X_fe = layernorm_graph->tensor(fe::graph::Tensor_attributes()
-                             .set_name("X")
-                             .set_dim(std::vector<int64_t>(X_reshaped.sizes().begin(), X_reshaped.sizes().end()))
-                             .set_stride({N, 1, N, N}));
-    auto DY_fe = layernorm_graph->tensor(fe::graph::Tensor_attributes()
-                             .set_name("DY")
-                             .set_dim(std::vector<int64_t>(DY_reshaped.sizes().begin(), DY_reshaped.sizes().end()))
-                             .set_stride({N, 1, N, N}));
-    auto scale_fe = layernorm_graph->tensor(fe::graph::Tensor_attributes()
-                                  .set_name("scale")
-                                  .set_dim({1, N, 1, 1})
-                                  .set_stride({N, 1, N, N})
-                                  .set_data_type(get_fe_dtype(gamma)));
-    auto mean_fe = layernorm_graph->tensor(fe::graph::Tensor_attributes()
-                                  .set_name("mean")
-                                  .set_dim({M, 1, 1, 1})
-                                  .set_stride({1, 1, 1, 1})
-                                  .set_data_type(get_fe_dtype(mean)));
-    auto inv_variance_fe  = layernorm_graph->tensor(fe::graph::Tensor_attributes()
-                                 .set_name("inv_variance")
-                                 .set_dim({M, 1, 1, 1})
-                                 .set_stride({1, 1, 1, 1})
-                                 .set_data_type(get_fe_dtype(rstd)));
+    auto X_fe = layernorm_graph->tensor(
+        fe::graph::Tensor_attributes()
+            .set_name("X")
+            .set_dim(std::vector<int64_t>(
+                X_reshaped.sizes().begin(), X_reshaped.sizes().end()))
+            .set_stride({N, 1, N, N}));
+    auto DY_fe = layernorm_graph->tensor(
+        fe::graph::Tensor_attributes()
+            .set_name("DY")
+            .set_dim(std::vector<int64_t>(
+                DY_reshaped.sizes().begin(), DY_reshaped.sizes().end()))
+            .set_stride({N, 1, N, N}));
+    auto scale_fe =
+        layernorm_graph->tensor(fe::graph::Tensor_attributes()
+                                    .set_name("scale")
+                                    .set_dim({1, N, 1, 1})
+                                    .set_stride({N, 1, N, N})
+                                    .set_data_type(get_fe_dtype(gamma)));
+    auto mean_fe =
+        layernorm_graph->tensor(fe::graph::Tensor_attributes()
+                                    .set_name("mean")
+                                    .set_dim({M, 1, 1, 1})
+                                    .set_stride({1, 1, 1, 1})
+                                    .set_data_type(get_fe_dtype(mean)));
+    auto inv_variance_fe =
+        layernorm_graph->tensor(fe::graph::Tensor_attributes()
+                                    .set_name("inv_variance")
+                                    .set_dim({M, 1, 1, 1})
+                                    .set_stride({1, 1, 1, 1})
+                                    .set_data_type(get_fe_dtype(rstd)));
     auto layernorm_options =
-        fe::graph::Layernorm_backward_attributes().set_saved_mean_and_inv_variance(mean_fe, inv_variance_fe);
-    auto [DX_fe, dscale_fe, dbias_fe] = layernorm_graph->layernorm_backward(DY_fe, X_fe, scale_fe, layernorm_options);
+        fe::graph::Layernorm_backward_attributes()
+            .set_saved_mean_and_inv_variance(mean_fe, inv_variance_fe);
+    auto [DX_fe, dscale_fe, dbias_fe] = layernorm_graph->layernorm_backward(
+        DY_fe, X_fe, scale_fe, layernorm_options);
     DX_fe->set_output(true);
     dscale_fe->set_output(true).set_data_type(get_fe_dtype(*dgamma));
     dbias_fe->set_output(true).set_data_type(get_fe_dtype(*dbeta));
     cudnnHandle_t handle = getCudnnHandle();
     TORCH_INTERNAL_ASSERT(layernorm_graph->validate().is_good());
-    TORCH_INTERNAL_ASSERT(layernorm_graph->build_operation_graph(handle).is_good());
-    TORCH_INTERNAL_ASSERT(layernorm_graph->create_execution_plans({fe::HeurMode_t::FALLBACK}).is_good());
-    TORCH_INTERNAL_ASSERT(layernorm_graph->check_support(handle).is_good(), layernorm_graph->check_support(handle).get_message());
+    TORCH_INTERNAL_ASSERT(
+        layernorm_graph->build_operation_graph(handle).is_good());
+    TORCH_INTERNAL_ASSERT(
+        layernorm_graph->create_execution_plans({fe::HeurMode_t::FALLBACK})
+            .is_good());
+    TORCH_INTERNAL_ASSERT(
+        layernorm_graph->check_support(handle).is_good(),
+        layernorm_graph->check_support(handle).get_message());
     TORCH_INTERNAL_ASSERT(layernorm_graph->build_plans(handle).is_good());
-    std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*> variant_pack_ = {
-      {X_fe, X.data_ptr()},
-      {DY_fe, dY.data_ptr()},
-      {mean_fe, mean.data_ptr()},
-      {inv_variance_fe, rstd.data_ptr()},
-      {scale_fe, gamma.data_ptr()},
-      {dscale_fe, dgamma->data_ptr()},
-      {dbias_fe, dbeta->data_ptr()},
-      {DX_fe, dX->data_ptr()}};
+    std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*>
+        variant_pack_ = {
+            {X_fe, X.data_ptr()},
+            {DY_fe, dY.data_ptr()},
+            {mean_fe, mean.data_ptr()},
+            {inv_variance_fe, rstd.data_ptr()},
+            {scale_fe, gamma.data_ptr()},
+            {dscale_fe, dgamma->data_ptr()},
+            {dbias_fe, dbeta->data_ptr()},
+            {DX_fe, dX->data_ptr()}};
     variant_pack = std::move(variant_pack_);
-    auto result = std::make_tuple(layernorm_graph, X_fe, DY_fe, mean_fe, inv_variance_fe, scale_fe, dscale_fe, dbias_fe, DX_fe);
+    auto result = std::make_tuple(
+        layernorm_graph,
+        X_fe,
+        DY_fe,
+        mean_fe,
+        inv_variance_fe,
+        scale_fe,
+        dscale_fe,
+        dbias_fe,
+        DX_fe);
     layernorm_backward_graph_cache.update(key, result);
   }
   cudnnHandle_t handle = getCudnnHandle();
   size_t workspace_size = layernorm_graph->get_workspace_size();
-  auto workspace_ptr = c10::cuda::CUDACachingAllocator::get()->allocate(workspace_size);
+  auto workspace_ptr =
+      c10::cuda::CUDACachingAllocator::get()->allocate(workspace_size);
   TORCH_INTERNAL_ASSERT(!workspace_size || workspace_ptr);
-  TORCH_INTERNAL_ASSERT(layernorm_graph->execute(handle, variant_pack, workspace_ptr.get()).is_good());
+  TORCH_INTERNAL_ASSERT(
+      layernorm_graph->execute(handle, variant_pack, workspace_ptr.get())
+          .is_good());
 }
 
+} // namespace native
+} // namespace at
 
-
-}} // at::native
-
-#endif  // AT_CUDNN_ENABLED
+#endif // AT_CUDNN_ENABLED

--- a/aten/src/ATen/native/cudnn/LayerNorm_v8.cpp
+++ b/aten/src/ATen/native/cudnn/LayerNorm_v8.cpp
@@ -1,0 +1,301 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+
+#include <ATen/cuda/CUDAConfig.h>  // for the definition of AT_CUDNN_ENABLED
+
+#if AT_CUDNN_ENABLED()
+
+#include <ATen/cudnn/cudnn-wrapper.h>
+
+#include <c10/macros/Macros.h>
+
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wsuggest-override")
+#include <cudnn_frontend.h>
+C10_DIAGNOSTIC_POP()
+
+#include <cudnn_frontend_find_plan.h>
+#include <cudnn_frontend_get_plan.h>
+#include <ATen/core/Tensor.h>
+#include <ATen/TensorUtils.h>
+#include <ATen/cuda/Exceptions.h>
+#include <ATen/native/cudnn/LayerNorm_v8.h>
+#include <ATen/native/utils/ParamsHash.h>
+#include <ATen/cudnn/Handle.h>
+#include <ATen/TensorUtils.h>
+
+#include <c10/util/env.h>
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDACachingAllocator.h>
+
+#include <unordered_map>
+#include <list>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#else
+#include <ATen/ops/empty.h>
+#endif
+
+#ifdef __linux__
+#include <dlfcn.h>
+#endif
+
+#include <cudnn_frontend.h>
+
+namespace at { namespace native {
+
+ 
+
+auto get_fe_dtype(const Tensor& t) {
+  namespace fe = cudnn_frontend;
+  auto dtype = t.scalar_type();
+  auto fe_dtype = fe::DataType_t::FLOAT;
+  if (dtype == at::ScalarType::Half) {
+    fe_dtype = fe::DataType_t::HALF;
+  } else if (dtype == at::ScalarType::BFloat16) {
+    fe_dtype = fe::DataType_t::BFLOAT16;
+  } else {
+    TORCH_INTERNAL_ASSERT("cuDNN layernorm got unsupported dtype", dtype);
+  }
+  return fe_dtype;
+}
+
+ namespace { 
+ namespace fe = cudnn_frontend;
+using graph_and_tensors_forward = std::tuple<
+                                    std::shared_ptr<fe::graph::Graph>,
+                                    std::shared_ptr<fe::graph::Tensor_attributes>, // X,
+                                    std::shared_ptr<fe::graph::Tensor_attributes>, // mean,
+                                    std::shared_ptr<fe::graph::Tensor_attributes>, // inv_var,
+                                    std::shared_ptr<fe::graph::Tensor_attributes>, // scale,
+                                    std::shared_ptr<fe::graph::Tensor_attributes>, // bias,
+                                    std::shared_ptr<fe::graph::Tensor_attributes>, // epsilon,
+                                    std::shared_ptr<fe::graph::Tensor_attributes> // Y
+                        >;
+using graph_and_tensors_backward = std::tuple<
+                                    std::shared_ptr<fe::graph::Graph>,
+                                    std::shared_ptr<fe::graph::Tensor_attributes>, // X,
+                                    std::shared_ptr<fe::graph::Tensor_attributes>, // DY,
+                                    std::shared_ptr<fe::graph::Tensor_attributes>, // mean,
+                                    std::shared_ptr<fe::graph::Tensor_attributes>, // inv_variance,
+                                    std::shared_ptr<fe::graph::Tensor_attributes>, // scale,
+                                    std::shared_ptr<fe::graph::Tensor_attributes>, // dscale,
+                                    std::shared_ptr<fe::graph::Tensor_attributes>, // dbias,
+                                    std::shared_ptr<fe::graph::Tensor_attributes> // DX
+                        >;
+
+struct LayerNormParams {
+  c10::DeviceIndex device_id;
+  fe::DataType_t dataType;
+  int64_t M;
+  int64_t N; 
+};
+
+void setLayerNormParams(LayerNormParams& params, const Tensor& X, int64_t M, int64_t N) {
+  memset(&params, 0, sizeof(params));
+  params.device_id = at::cuda::current_device();
+  params.dataType = get_fe_dtype(X);
+  params.M = M;
+  params.N = N;
+}
+
+struct LayerNormCacheKeyWrapper : ParamsWrapper<LayerNormParams> {
+  LayerNormCacheKeyWrapper(const Tensor& X, int64_t M, int64_t N) {
+    setLayerNormParams(this->pod, X, M, N);
+  }
+};
+
+ template <typename T, typename KeyType>
+struct LayerNormGraphCache {
+std::unordered_map<KeyType, T, ParamsWrapperHash<KeyType>> engine_cache;
+
+// no mutexes here as caches are now thread local for v8, can also return a pointer
+// to the Execution Plan if we know it will not be invalidated by another thread
+T* find(const KeyType& key) {
+  auto it = engine_cache.find(key);
+  if (it == engine_cache.end()) {
+    return nullptr;
+  }
+  return &(it->second);
+}
+
+void update(const KeyType& key, T& results) {
+  engine_cache.erase(key);
+  engine_cache.emplace(key, std::move(results));
+}
+
+};
+
+// @eqy: use thread local caches as cuDNN Execution Plans are not guaranteed to be thread safe across all engines
+// see Limitations in https://docs.nvidia.com/deeplearning/cudnn/release-notes/index.html
+thread_local LayerNormGraphCache<graph_and_tensors_forward, LayerNormCacheKeyWrapper> layernorm_forward_graph_cache;
+thread_local LayerNormGraphCache<graph_and_tensors_backward, LayerNormCacheKeyWrapper> layernorm_backward_graph_cache;
+
+ }
+
+void raw_cudnn_layernorm_forward_out(const Tensor& X, const Tensor& scale, const Tensor& bias, float epsilon, Tensor* mean, Tensor* rstd, Tensor* Y, int64_t M, int64_t N) {
+  namespace fe = cudnn_frontend;
+  auto key = LayerNormCacheKeyWrapper(X, M, N);
+  auto graph_and_tensors_forward_ptr = layernorm_forward_graph_cache.find(key);
+  auto layernorm_graph = std::make_shared<fe::graph::Graph>();
+  graph_and_tensors_forward graph_and_tensors_forward_values;
+  std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*> variant_pack;
+  if (graph_and_tensors_forward_ptr) {
+    auto [graph, X_fe, mean_fe, inv_variance_fe, scale_fe, bias_fe, epsilon_fe, Y_fe] = *graph_and_tensors_forward_ptr;
+    std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*> variant_pack_ = {
+      {X_fe, X.data_ptr()},
+      {mean_fe, mean->data_ptr()},
+      {inv_variance_fe, rstd->data_ptr()},
+      {scale_fe, scale.data_ptr()},
+      {bias_fe, bias.data_ptr()},
+      {epsilon_fe, &epsilon},
+      {Y_fe, Y->data_ptr()}};
+    variant_pack = std::move(variant_pack_);
+    layernorm_graph = std::move(graph);
+  } else {
+    layernorm_graph->set_io_data_type(get_fe_dtype(X))
+        .set_intermediate_data_type(fe::DataType_t::FLOAT)
+        .set_compute_data_type(fe::DataType_t::FLOAT);
+    // cuDNN only seems to care about non-normalized and normalized dimensions, and we can only have one non-normalized-dimension, so...
+    // we reshape to
+    // N, M, 1, 1 because cuDNN also has the restruction that everything must be in 4-D
+    auto X_reshaped = X.reshape({M, N, 1, 1});
+    auto X_fe = layernorm_graph->tensor(fe::graph::Tensor_attributes()
+                             .set_name("X")
+                             .set_dim(std::vector<int64_t>(X_reshaped.sizes().begin(), X_reshaped.sizes().end()))
+                             .set_stride(std::vector<int64_t>(X_reshaped.strides().begin(), X_reshaped.strides().end())));
+    auto scale_fe = layernorm_graph->tensor(fe::graph::Tensor_attributes()
+                                  .set_name("scale")
+                                  .set_dim({1, N, 1, 1})
+                                  .set_stride({N, 1, N, N})
+                                  .set_data_type(get_fe_dtype(scale)));
+    auto bias_fe  = layernorm_graph->tensor(fe::graph::Tensor_attributes()
+                                 .set_name("bias")
+                                 .set_dim({1, N, 1, 1})
+                                 .set_stride({N, 1, N, N})
+                                 .set_data_type(get_fe_dtype(bias)));
+    auto epsilon_fe = layernorm_graph->tensor(fe::graph::Tensor_attributes()
+                                    .set_name("epsilon")
+                                    .set_dim({1, 1, 1, 1})
+                                    .set_stride({1, 1, 1, 1})
+                                    .set_data_type(fe::DataType_t::FLOAT));
+    auto layernorm_options =
+        fe::graph::Layernorm_attributes().set_forward_phase(fe::NormFwdPhase_t::TRAINING).set_epsilon(epsilon_fe);
+    auto [Y_fe, mean_fe, inv_variance_fe] = layernorm_graph->layernorm(X_fe, scale_fe, bias_fe, layernorm_options);
+    mean_fe->set_output(true).set_data_type(get_fe_dtype(*mean));
+    inv_variance_fe->set_output(true).set_data_type(get_fe_dtype(*rstd));
+    Y_fe->set_output(true);
+
+    cudnnHandle_t handle = getCudnnHandle();
+    TORCH_INTERNAL_ASSERT(layernorm_graph->validate().is_good());
+    TORCH_INTERNAL_ASSERT(layernorm_graph->build_operation_graph(handle).is_good());
+    TORCH_INTERNAL_ASSERT(layernorm_graph->create_execution_plans({fe::HeurMode_t::FALLBACK}).is_good());
+    TORCH_INTERNAL_ASSERT(layernorm_graph->check_support(handle).is_good(), layernorm_graph->check_support(handle).get_message());
+    TORCH_INTERNAL_ASSERT(layernorm_graph->build_plans(handle).is_good());
+    std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*> variant_pack_ = {
+      {X_fe, X.data_ptr()},
+      {mean_fe, mean->data_ptr()},
+      {inv_variance_fe, rstd->data_ptr()},
+      {scale_fe, scale.data_ptr()},
+      {bias_fe, bias.data_ptr()},
+      {epsilon_fe, &epsilon},
+      {Y_fe, Y->data_ptr()}};
+    variant_pack = std::move(variant_pack_);
+    auto result = std::make_tuple(layernorm_graph, X_fe, mean_fe, inv_variance_fe, scale_fe, bias_fe, epsilon_fe, Y_fe);
+    layernorm_forward_graph_cache.update(key, result);
+  }
+  cudnnHandle_t handle = getCudnnHandle();
+  size_t workspace_size = layernorm_graph->get_workspace_size();
+  auto workspace_ptr = c10::cuda::CUDACachingAllocator::get()->allocate(workspace_size);
+  TORCH_INTERNAL_ASSERT(!workspace_size || workspace_ptr);
+  TORCH_INTERNAL_ASSERT(layernorm_graph->execute(handle, variant_pack, workspace_ptr.get()).is_good());
+}
+
+void raw_cudnn_layernorm_backward_out(const Tensor& dY, const Tensor& X, const Tensor& mean, const Tensor& rstd, const Tensor& gamma, int64_t M, int64_t N, Tensor* dX,  Tensor* dgamma, Tensor* dbeta) {
+  namespace fe = cudnn_frontend;
+  auto key = LayerNormCacheKeyWrapper(X, M, N);
+  auto graph_and_tensors_backward_ptr = layernorm_backward_graph_cache.find(key);
+  auto layernorm_graph = std::make_shared<fe::graph::Graph>();
+  graph_and_tensors_backward graph_and_tensors_backward_values;
+  std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*> variant_pack;
+  if (graph_and_tensors_backward_ptr) {
+    auto [graph, X_fe, DY_fe, mean_fe, inv_variance_fe, scale_fe, dscale_fe, dbias_fe, DX_fe] = *graph_and_tensors_backward_ptr;
+    std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*> variant_pack_ = {
+      {X_fe, X.data_ptr()},
+      {DY_fe, dY.data_ptr()},
+      {mean_fe, mean.data_ptr()},
+      {inv_variance_fe, rstd.data_ptr()},
+      {scale_fe, gamma.data_ptr()},
+      {dscale_fe, dgamma->data_ptr()},
+      {dbias_fe, dbeta->data_ptr()},
+      {DX_fe, dX->data_ptr()}};
+    variant_pack = std::move(variant_pack_);
+    layernorm_graph = std::move(graph);
+  } else {
+    layernorm_graph->set_io_data_type(get_fe_dtype(X))
+        .set_intermediate_data_type(fe::DataType_t::FLOAT)
+        .set_compute_data_type(fe::DataType_t::FLOAT);
+    // cuDNN only seems to care about non-normalized and normalized dimensions, and we can only have one non-normalized-dimension, so...
+    // we reshape to
+    // N, M, 1, 1 because cuDNN also has the restruction that everything must be in 4-D
+    auto X_reshaped = X.reshape({M, N, 1, 1});
+    auto DY_reshaped = dY.reshape({M, N, 1, 1});
+    auto X_fe = layernorm_graph->tensor(fe::graph::Tensor_attributes()
+                             .set_name("X")
+                             .set_dim(std::vector<int64_t>(X_reshaped.sizes().begin(), X_reshaped.sizes().end()))
+                             .set_stride({N, 1, N, N}));
+    auto DY_fe = layernorm_graph->tensor(fe::graph::Tensor_attributes()
+                             .set_name("DY")
+                             .set_dim(std::vector<int64_t>(DY_reshaped.sizes().begin(), DY_reshaped.sizes().end()))
+                             .set_stride({N, 1, N, N}));
+    auto scale_fe = layernorm_graph->tensor(fe::graph::Tensor_attributes()
+                                  .set_name("scale")
+                                  .set_dim({1, N, 1, 1})
+                                  .set_stride({N, 1, N, N})
+                                  .set_data_type(get_fe_dtype(gamma)));
+    auto mean_fe = layernorm_graph->tensor(fe::graph::Tensor_attributes()
+                                  .set_name("mean")
+                                  .set_dim({M, 1, 1, 1})
+                                  .set_stride({1, 1, 1, 1})
+                                  .set_data_type(get_fe_dtype(mean)));
+    auto inv_variance_fe  = layernorm_graph->tensor(fe::graph::Tensor_attributes()
+                                 .set_name("inv_variance")
+                                 .set_dim({M, 1, 1, 1})
+                                 .set_stride({1, 1, 1, 1})
+                                 .set_data_type(get_fe_dtype(rstd)));
+    auto layernorm_options =
+        fe::graph::Layernorm_backward_attributes().set_saved_mean_and_inv_variance(mean_fe, inv_variance_fe);
+    auto [DX_fe, dscale_fe, dbias_fe] = layernorm_graph->layernorm_backward(DY_fe, X_fe, scale_fe, layernorm_options);
+    DX_fe->set_output(true);
+    dscale_fe->set_output(true).set_data_type(get_fe_dtype(*dgamma));
+    dbias_fe->set_output(true).set_data_type(get_fe_dtype(*dbeta));
+    cudnnHandle_t handle = getCudnnHandle();
+    TORCH_INTERNAL_ASSERT(layernorm_graph->validate().is_good());
+    TORCH_INTERNAL_ASSERT(layernorm_graph->build_operation_graph(handle).is_good());
+    TORCH_INTERNAL_ASSERT(layernorm_graph->create_execution_plans({fe::HeurMode_t::FALLBACK}).is_good());
+    TORCH_INTERNAL_ASSERT(layernorm_graph->check_support(handle).is_good(), layernorm_graph->check_support(handle).get_message());
+    TORCH_INTERNAL_ASSERT(layernorm_graph->build_plans(handle).is_good());
+    std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*> variant_pack_ = {
+      {X_fe, X.data_ptr()},
+      {DY_fe, dY.data_ptr()},
+      {mean_fe, mean.data_ptr()},
+      {inv_variance_fe, rstd.data_ptr()},
+      {scale_fe, gamma.data_ptr()},
+      {dscale_fe, dgamma->data_ptr()},
+      {dbias_fe, dbeta->data_ptr()},
+      {DX_fe, dX->data_ptr()}};
+    variant_pack = std::move(variant_pack_);
+    auto result = std::make_tuple(layernorm_graph, X_fe, DY_fe, mean_fe, inv_variance_fe, scale_fe, dscale_fe, dbias_fe, DX_fe);
+    layernorm_backward_graph_cache.update(key, result);
+  }
+  cudnnHandle_t handle = getCudnnHandle();
+  size_t workspace_size = layernorm_graph->get_workspace_size();
+  auto workspace_ptr = c10::cuda::CUDACachingAllocator::get()->allocate(workspace_size);
+  TORCH_INTERNAL_ASSERT(!workspace_size || workspace_ptr);
+  TORCH_INTERNAL_ASSERT(layernorm_graph->execute(handle, variant_pack, workspace_ptr.get()).is_good());
+}
+
+
+
+}} // at::native
+
+#endif  // AT_CUDNN_ENABLED

--- a/aten/src/ATen/native/cudnn/LayerNorm_v8.cpp
+++ b/aten/src/ATen/native/cudnn/LayerNorm_v8.cpp
@@ -213,9 +213,10 @@ void raw_cudnn_layernorm_forward_out(
     TORCH_INTERNAL_ASSERT(layernorm_graph->validate().is_good());
     TORCH_INTERNAL_ASSERT(
         layernorm_graph->build_operation_graph(handle).is_good());
-    TORCH_INTERNAL_ASSERT(
-        layernorm_graph->create_execution_plans({fe::HeurMode_t::A, fe::HeurMode_t::FALLBACK})
-            .is_good());
+    TORCH_INTERNAL_ASSERT(layernorm_graph
+                              ->create_execution_plans(
+                                  {fe::HeurMode_t::A, fe::HeurMode_t::FALLBACK})
+                              .is_good());
     TORCH_INTERNAL_ASSERT(
         layernorm_graph->check_support(handle).is_good(),
         layernorm_graph->check_support(handle).get_message());
@@ -343,9 +344,10 @@ void raw_cudnn_layernorm_backward_out(
     TORCH_INTERNAL_ASSERT(layernorm_graph->validate().is_good());
     TORCH_INTERNAL_ASSERT(
         layernorm_graph->build_operation_graph(handle).is_good());
-    TORCH_INTERNAL_ASSERT(
-        layernorm_graph->create_execution_plans({fe::HeurMode_t::A, fe::HeurMode_t::FALLBACK})
-            .is_good());
+    TORCH_INTERNAL_ASSERT(layernorm_graph
+                              ->create_execution_plans(
+                                  {fe::HeurMode_t::A, fe::HeurMode_t::FALLBACK})
+                              .is_good());
     TORCH_INTERNAL_ASSERT(
         layernorm_graph->check_support(handle).is_good(),
         layernorm_graph->check_support(handle).get_message());
@@ -387,4 +389,3 @@ void raw_cudnn_layernorm_backward_out(
 } // namespace at
 
 #endif // AT_CUDNN_ENABLED
-

--- a/aten/src/ATen/native/cudnn/LayerNorm_v8.cpp
+++ b/aten/src/ATen/native/cudnn/LayerNorm_v8.cpp
@@ -129,7 +129,7 @@ struct LayerNormGraphCache {
 
 // @eqy: use thread local caches as cuDNN Execution Plans are not guaranteed to
 // be thread safe across all engines see Limitations in
-// https://docs.nvidia.com/deeplearning/cudnn/release-notes/index.html
+// https://docs.nvidia.com/deeplearning/cudnn/backend/latest/release-notes.html
 thread_local LayerNormGraphCache<
     graph_and_tensors_forward,
     LayerNormCacheKeyWrapper>

--- a/aten/src/ATen/native/cudnn/LayerNorm_v8.cpp
+++ b/aten/src/ATen/native/cudnn/LayerNorm_v8.cpp
@@ -43,7 +43,7 @@ C10_DIAGNOSTIC_POP()
 
 namespace at { namespace native {
 
- 
+
 
 auto get_fe_dtype(const Tensor& t) {
   namespace fe = cudnn_frontend;

--- a/aten/src/ATen/native/cudnn/LayerNorm_v8.cpp
+++ b/aten/src/ATen/native/cudnn/LayerNorm_v8.cpp
@@ -120,9 +120,10 @@ struct LayerNormGraphCache {
     return &(it->second);
   }
 
-  void update(const KeyType& key, T& results) {
+  template <typename U>
+  void update(const KeyType& key, U&& results) {
     engine_cache.erase(key);
-    engine_cache.emplace(key, std::move(results));
+    engine_cache.emplace(key, std::forward<U>(results));
   }
 };
 
@@ -238,7 +239,7 @@ void raw_cudnn_layernorm_forward_out(
         scale_fe,
         bias_fe,
         Y_fe);
-    layernorm_forward_graph_cache.update(key, result);
+    layernorm_forward_graph_cache.update(key, std::move(result));
   }
   cudnnHandle_t handle = getCudnnHandle();
   size_t workspace_size = layernorm_graph->get_workspace_size();
@@ -373,7 +374,7 @@ void raw_cudnn_layernorm_backward_out(
         dscale_fe,
         dbias_fe,
         DX_fe);
-    layernorm_backward_graph_cache.update(key, result);
+    layernorm_backward_graph_cache.update(key, std::move(result));
   }
   cudnnHandle_t handle = getCudnnHandle();
   size_t workspace_size = layernorm_graph->get_workspace_size();

--- a/aten/src/ATen/native/cudnn/LayerNorm_v8.h
+++ b/aten/src/ATen/native/cudnn/LayerNorm_v8.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <ATen/core/Tensor.h>
+
+#include <ATen/cuda/CUDAConfig.h>  // for the definition of AT_CUDNN_ENABLED
+
+#include <ATen/cudnn/cudnn-wrapper.h>
+#include <ATen/cudnn/Descriptors.h>
+#include <ATen/cudnn/Types.h>
+
+namespace at { namespace native {
+
+
+#if AT_CUDNN_ENABLED()
+
+void raw_cudnn_layernorm_forward_out(const Tensor& X, const Tensor& scale, const Tensor& bias, float epsilon,  Tensor* mean,  Tensor* rstd, Tensor* Y, int64_t M, int64_t N);
+void raw_cudnn_layernorm_backward_out(const Tensor& dY, const Tensor& X, const Tensor& mean, const Tensor& rstd, const Tensor& gamma, int64_t M, int64_t N, Tensor* dX,  Tensor* dgamma, Tensor* dbeta);
+
+#endif
+}}

--- a/aten/src/ATen/native/cudnn/LayerNorm_v8.h
+++ b/aten/src/ATen/native/cudnn/LayerNorm_v8.h
@@ -1,19 +1,39 @@
 #pragma once
 #include <ATen/core/Tensor.h>
 
-#include <ATen/cuda/CUDAConfig.h>  // for the definition of AT_CUDNN_ENABLED
+#include <ATen/cuda/CUDAConfig.h> // for the definition of AT_CUDNN_ENABLED
 
-#include <ATen/cudnn/cudnn-wrapper.h>
 #include <ATen/cudnn/Descriptors.h>
 #include <ATen/cudnn/Types.h>
+#include <ATen/cudnn/cudnn-wrapper.h>
 
-namespace at { namespace native {
-
+namespace at {
+namespace native {
 
 #if AT_CUDNN_ENABLED()
 
-void raw_cudnn_layernorm_forward_out(const Tensor& X, const Tensor& scale, const Tensor& bias, float epsilon,  Tensor* mean,  Tensor* rstd, Tensor* Y, int64_t M, int64_t N);
-void raw_cudnn_layernorm_backward_out(const Tensor& dY, const Tensor& X, const Tensor& mean, const Tensor& rstd, const Tensor& gamma, int64_t M, int64_t N, Tensor* dX,  Tensor* dgamma, Tensor* dbeta);
+void raw_cudnn_layernorm_forward_out(
+    const Tensor& X,
+    const Tensor& scale,
+    const Tensor& bias,
+    float epsilon,
+    Tensor* mean,
+    Tensor* rstd,
+    Tensor* Y,
+    int64_t M,
+    int64_t N);
+void raw_cudnn_layernorm_backward_out(
+    const Tensor& dY,
+    const Tensor& X,
+    const Tensor& mean,
+    const Tensor& rstd,
+    const Tensor& gamma,
+    int64_t M,
+    int64_t N,
+    Tensor* dX,
+    Tensor* dgamma,
+    Tensor* dbeta);
 
 #endif
-}}
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/cudnn/RMSNorm_v8.cpp
+++ b/aten/src/ATen/native/cudnn/RMSNorm_v8.cpp
@@ -116,9 +116,10 @@ struct RMSNormGraphCache {
     return &(it->second);
   }
 
-  void update(const KeyType& key, T& results) {
+  template <typename U>
+  void update(const KeyType& key, U&& results) {
     engine_cache.erase(key);
-    engine_cache.emplace(key, std::move(results));
+    engine_cache.emplace(key, std::forward<U>(results));
   }
 };
 
@@ -215,7 +216,7 @@ void raw_cudnn_rmsnorm_forward_out(
     variant_pack = std::move(variant_pack_);
     auto result =
         std::make_tuple(rmsnorm_graph, X_fe, inv_variance_fe, scale_fe, Y_fe);
-    rmsnorm_forward_graph_cache.update(key, result);
+    rmsnorm_forward_graph_cache.update(key, std::move(result));
   }
   cudnnHandle_t handle = getCudnnHandle();
   size_t workspace_size = rmsnorm_graph->get_workspace_size();
@@ -329,7 +330,7 @@ void raw_cudnn_rmsnorm_backward_out(
         scale_fe,
         dscale_fe,
         DX_fe);
-    rmsnorm_backward_graph_cache.update(key, result);
+    rmsnorm_backward_graph_cache.update(key, std::move(result));
   }
   cudnnHandle_t handle = getCudnnHandle();
   size_t workspace_size = rmsnorm_graph->get_workspace_size();

--- a/aten/src/ATen/native/cudnn/RMSNorm_v8.cpp
+++ b/aten/src/ATen/native/cudnn/RMSNorm_v8.cpp
@@ -198,9 +198,10 @@ void raw_cudnn_rmsnorm_forward_out(
     TORCH_INTERNAL_ASSERT(rmsnorm_graph->validate().is_good());
     TORCH_INTERNAL_ASSERT(
         rmsnorm_graph->build_operation_graph(handle).is_good());
-    TORCH_INTERNAL_ASSERT(
-        rmsnorm_graph->create_execution_plans({fe::HeurMode_t::A, fe::HeurMode_t::FALLBACK})
-            .is_good());
+    TORCH_INTERNAL_ASSERT(rmsnorm_graph
+                              ->create_execution_plans(
+                                  {fe::HeurMode_t::A, fe::HeurMode_t::FALLBACK})
+                              .is_good());
     TORCH_INTERNAL_ASSERT(
         rmsnorm_graph->check_support(handle).is_good(),
         rmsnorm_graph->check_support(handle).get_message());
@@ -303,9 +304,10 @@ void raw_cudnn_rmsnorm_backward_out(
     TORCH_INTERNAL_ASSERT(rmsnorm_graph->validate().is_good());
     TORCH_INTERNAL_ASSERT(
         rmsnorm_graph->build_operation_graph(handle).is_good());
-    TORCH_INTERNAL_ASSERT(
-        rmsnorm_graph->create_execution_plans({fe::HeurMode_t::A, fe::HeurMode_t::FALLBACK})
-            .is_good());
+    TORCH_INTERNAL_ASSERT(rmsnorm_graph
+                              ->create_execution_plans(
+                                  {fe::HeurMode_t::A, fe::HeurMode_t::FALLBACK})
+                              .is_good());
     TORCH_INTERNAL_ASSERT(
         rmsnorm_graph->check_support(handle).is_good(),
         rmsnorm_graph->check_support(handle).get_message());

--- a/aten/src/ATen/native/cudnn/RMSNorm_v8.cpp
+++ b/aten/src/ATen/native/cudnn/RMSNorm_v8.cpp
@@ -199,7 +199,7 @@ void raw_cudnn_rmsnorm_forward_out(
     TORCH_INTERNAL_ASSERT(
         rmsnorm_graph->build_operation_graph(handle).is_good());
     TORCH_INTERNAL_ASSERT(
-        rmsnorm_graph->create_execution_plans({fe::HeurMode_t::FALLBACK})
+        rmsnorm_graph->create_execution_plans({fe::HeurMode_t::A, fe::HeurMode_t::FALLBACK})
             .is_good());
     TORCH_INTERNAL_ASSERT(
         rmsnorm_graph->check_support(handle).is_good(),
@@ -304,7 +304,7 @@ void raw_cudnn_rmsnorm_backward_out(
     TORCH_INTERNAL_ASSERT(
         rmsnorm_graph->build_operation_graph(handle).is_good());
     TORCH_INTERNAL_ASSERT(
-        rmsnorm_graph->create_execution_plans({fe::HeurMode_t::FALLBACK})
+        rmsnorm_graph->create_execution_plans({fe::HeurMode_t::A, fe::HeurMode_t::FALLBACK})
             .is_good());
     TORCH_INTERNAL_ASSERT(
         rmsnorm_graph->check_support(handle).is_good(),

--- a/aten/src/ATen/native/cudnn/RMSNorm_v8.cpp
+++ b/aten/src/ATen/native/cudnn/RMSNorm_v8.cpp
@@ -125,7 +125,7 @@ struct RMSNormGraphCache {
 
 // @eqy: use thread local caches as cuDNN Execution Plans are not guaranteed to
 // be thread safe across all engines see Limitations in
-// https://docs.nvidia.com/deeplearning/cudnn/release-notes/index.html
+// https://docs.nvidia.com/deeplearning/cudnn/backend/latest/release-notes.html
 thread_local RMSNormGraphCache<
     graph_and_tensors_forward,
     RMSNormCacheKeyWrapper>

--- a/aten/src/ATen/native/cudnn/RMSNorm_v8.cpp
+++ b/aten/src/ATen/native/cudnn/RMSNorm_v8.cpp
@@ -88,7 +88,7 @@ void setRMSNormParams(
     const Tensor& X,
     int64_t M,
     int64_t N) {
-  memset(&params, 0, sizeof(params));
+  std::memset(&params, 0, sizeof(params));
   params.device_id = at::cuda::current_device();
   params.dataType = get_fe_dtype_rmsnorm(X);
   params.M = M;

--- a/aten/src/ATen/native/cudnn/RMSNorm_v8.cpp
+++ b/aten/src/ATen/native/cudnn/RMSNorm_v8.cpp
@@ -1,0 +1,306 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+
+#include <ATen/cuda/CUDAConfig.h>  // for the definition of AT_CUDNN_ENABLED
+
+#if AT_CUDNN_ENABLED()
+
+#include <ATen/cudnn/cudnn-wrapper.h>
+
+#include <c10/macros/Macros.h>
+
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wsuggest-override")
+#include <cudnn_frontend.h>
+C10_DIAGNOSTIC_POP()
+
+#include <cudnn_frontend_find_plan.h>
+#include <cudnn_frontend_get_plan.h>
+#include <ATen/core/Tensor.h>
+#include <ATen/TensorUtils.h>
+#include <ATen/cuda/Exceptions.h>
+#include <ATen/native/cudnn/RMSNorm_v8.h>
+#include <ATen/native/utils/ParamsHash.h>
+#include <ATen/cudnn/Handle.h>
+#include <ATen/TensorUtils.h>
+
+#include <c10/util/env.h>
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDACachingAllocator.h>
+
+#include <unordered_map>
+#include <list>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#else
+#include <ATen/ops/empty.h>
+#endif
+
+#ifdef __linux__
+#include <dlfcn.h>
+#endif
+
+#include <cudnn_frontend.h>
+
+namespace at { namespace native {
+
+
+auto get_fe_dtype_rmsnorm(const Tensor& t) {
+  namespace fe = cudnn_frontend;
+  auto dtype = t.scalar_type();
+  auto fe_dtype = fe::DataType_t::FLOAT;
+  if (dtype == at::ScalarType::Half) {
+    fe_dtype = fe::DataType_t::HALF;
+  } else if (dtype == at::ScalarType::BFloat16) {
+    fe_dtype = fe::DataType_t::BFLOAT16;
+  } else {
+    TORCH_INTERNAL_ASSERT("cuDNN layernorm got unsupported dtype", dtype);
+  }
+  return fe_dtype;
+}
+
+namespace fe = cudnn_frontend;
+
+ namespace { 
+ namespace fe = cudnn_frontend; 
+using graph_and_tensors_forward = std::tuple<
+                                    std::shared_ptr<cudnn_frontend::graph::Graph>,
+                                    std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>, // X,
+                                    std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>, // inv_var (rstd),
+                                    std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>, // scale,
+                                    std::shared_ptr<cudnn_frontend::graph::Tensor_attributes> // Y
+                        >;
+using graph_and_tensors_backward = std::tuple<
+                                    std::shared_ptr<cudnn_frontend::graph::Graph>,
+                                    std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>, // X,
+                                    std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>, // DY,
+                                    std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>, // inv_variance (rstd),
+                                    std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>, // scale,
+                                    std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>, // dscale,
+                                    std::shared_ptr<cudnn_frontend::graph::Tensor_attributes> // DX
+                        >;
+
+struct RMSNormParams {
+  c10::DeviceIndex device_id;
+  cudnn_frontend::DataType_t dataType;
+  int64_t M;
+  int64_t N; 
+};
+
+void setRMSNormParams(RMSNormParams& params, const Tensor& X, int64_t M, int64_t N) {
+  memset(&params, 0, sizeof(params));
+  params.device_id = at::cuda::current_device();
+  params.dataType = get_fe_dtype_rmsnorm(X);
+  params.M = M;
+  params.N = N;
+}
+
+struct RMSNormCacheKeyWrapper : ParamsWrapper<RMSNormParams> {
+  RMSNormCacheKeyWrapper(const Tensor& X, int64_t M, int64_t N) {
+    setRMSNormParams(this->pod, X, M, N);
+  }
+};
+
+ template <typename T, typename KeyType>
+struct RMSNormGraphCache {
+std::unordered_map<KeyType, T, ParamsWrapperHash<KeyType>> engine_cache;
+
+// no mutexes here as caches are now thread local for v8, can also return a pointer
+// to the Execution Plan if we know it will not be invalidated by another thread
+T* find(const KeyType& key) {
+  auto it = engine_cache.find(key);
+  if (it == engine_cache.end()) {
+    return nullptr;
+  }
+  return &(it->second);
+}
+
+void update(const KeyType& key, T& results) {
+  engine_cache.erase(key);
+  engine_cache.emplace(key, std::move(results));
+}
+
+};
+
+// @eqy: use thread local caches as cuDNN Execution Plans are not guaranteed to be thread safe across all engines
+// see Limitations in https://docs.nvidia.com/deeplearning/cudnn/release-notes/index.html
+thread_local RMSNormGraphCache<graph_and_tensors_forward, RMSNormCacheKeyWrapper> rmsnorm_forward_graph_cache;
+thread_local RMSNormGraphCache<graph_and_tensors_backward, RMSNormCacheKeyWrapper> rmsnorm_backward_graph_cache;
+
+ }
+
+void raw_cudnn_rmsnorm_forward_out(const Tensor& X, const Tensor& scale, float epsilon, Tensor* rstd, Tensor* Y, int64_t M, int64_t N) {
+  namespace fe = cudnn_frontend;
+  auto key = RMSNormCacheKeyWrapper(X, M, N);
+  auto graph_and_tensors_forward_ptr = rmsnorm_forward_graph_cache.find(key);
+  auto rmsnorm_graph = std::make_shared<cudnn_frontend::graph::Graph>();
+  graph_and_tensors_forward graph_and_tensors_forward_values;
+  std::unordered_map<std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>, void*> variant_pack;
+  if (graph_and_tensors_forward_ptr) {
+    auto [graph, X_fe, inv_variance_fe, scale_fe, Y_fe] = *graph_and_tensors_forward_ptr;
+    std::unordered_map<std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>, void*> variant_pack_ = {
+      {X_fe, X.data_ptr()},
+      {inv_variance_fe, rstd->data_ptr()},
+      {scale_fe, scale.data_ptr()},
+      {Y_fe, Y->data_ptr()}};
+    variant_pack = std::move(variant_pack_);
+    rmsnorm_graph = std::move(graph);
+  } else {
+    rmsnorm_graph->set_io_data_type(get_fe_dtype_rmsnorm(X))
+        .set_intermediate_data_type(cudnn_frontend::DataType_t::FLOAT)
+        .set_compute_data_type(cudnn_frontend::DataType_t::FLOAT);
+    // cuDNN only seems to care about non-normalized and normalized dimensions, and we can only have one non-normalized-dimension, so...
+    // we reshape to
+    // N, M, 1, 1 because cuDNN also has the restriction that everything must be in 4-D
+    auto X_reshaped = X.reshape({M, N, 1, 1});
+    auto X_fe = rmsnorm_graph->tensor(cudnn_frontend::graph::Tensor_attributes()
+                             .set_name("X")
+                             .set_dim(std::vector<int64_t>(X_reshaped.sizes().begin(), X_reshaped.sizes().end()))
+                             .set_stride(std::vector<int64_t>(X_reshaped.strides().begin(), X_reshaped.strides().end())));
+    auto scale_fe = rmsnorm_graph->tensor(cudnn_frontend::graph::Tensor_attributes()
+                                  .set_name("scale")
+                                  .set_dim({1, N, 1, 1})
+                                  .set_stride({N, 1, N, N})
+                                  .set_data_type(get_fe_dtype_rmsnorm(scale)));
+    
+    // For RMSNorm, we use LayerNorm without bias and without centering (mean=0)
+    // We create a zero bias tensor for the layernorm operation
+    auto zero_bias = rmsnorm_graph->tensor(cudnn_frontend::graph::Tensor_attributes()
+                                 .set_name("zero_bias")
+                                 .set_dim({1, N, 1, 1})
+                                 .set_stride({N, 1, N, N})
+                                 .set_is_virtual(true)
+                                 .set_data_type(get_fe_dtype_rmsnorm(scale)));
+    
+    auto epsilon_fe = rmsnorm_graph->tensor(epsilon);
+    
+    // Use LayerNorm with special configuration for RMSNorm
+    // RMSNorm is essentially LayerNorm without centering (mean subtraction)
+    // cuDNN doesn't have a direct RMSNorm API yet, so we use LayerNorm
+    auto layernorm_options =
+        cudnn_frontend::graph::Layernorm_attributes()
+        .set_forward_phase(cudnn_frontend::NormFwdPhase_t::TRAINING)
+        .set_epsilon(epsilon_fe);
+    
+    auto [Y_fe, mean_fe, inv_variance_fe] = rmsnorm_graph->layernorm(X_fe, scale_fe, zero_bias, layernorm_options);
+    
+    // For RMSNorm, we only output inv_variance (rstd) and Y
+    // mean is not used in RMSNorm
+    inv_variance_fe->set_output(true).set_data_type(get_fe_dtype_rmsnorm(*rstd));
+    Y_fe->set_output(true);
+
+    cudnnHandle_t handle = getCudnnHandle();
+    TORCH_INTERNAL_ASSERT(rmsnorm_graph->validate().is_good());
+    TORCH_INTERNAL_ASSERT(rmsnorm_graph->build_operation_graph(handle).is_good());
+    TORCH_INTERNAL_ASSERT(rmsnorm_graph->create_execution_plans({cudnn_frontend::HeurMode_t::FALLBACK}).is_good());
+    TORCH_INTERNAL_ASSERT(rmsnorm_graph->check_support(handle).is_good(), rmsnorm_graph->check_support(handle).get_message());
+    TORCH_INTERNAL_ASSERT(rmsnorm_graph->build_plans(handle).is_good());
+    std::unordered_map<std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>, void*> variant_pack_ = {
+      {X_fe, X.data_ptr()},
+      {inv_variance_fe, rstd->data_ptr()},
+      {scale_fe, scale.data_ptr()},
+      {Y_fe, Y->data_ptr()}};
+    variant_pack = std::move(variant_pack_);
+    auto result = std::make_tuple(rmsnorm_graph, X_fe, inv_variance_fe, scale_fe, Y_fe);
+    rmsnorm_forward_graph_cache.update(key, result);
+  }
+  cudnnHandle_t handle = getCudnnHandle();
+  size_t workspace_size = rmsnorm_graph->get_workspace_size();
+  auto workspace_ptr = c10::cuda::CUDACachingAllocator::get()->allocate(workspace_size);
+  TORCH_INTERNAL_ASSERT(!workspace_size || workspace_ptr);
+  TORCH_INTERNAL_ASSERT(rmsnorm_graph->execute(handle, variant_pack, workspace_ptr.get()).is_good());
+}
+
+void raw_cudnn_rmsnorm_backward_out(const Tensor& dY, const Tensor& X, const Tensor& rstd, const Tensor& gamma, int64_t M, int64_t N, Tensor* dX, Tensor* dgamma) {
+  namespace fe = cudnn_frontend;
+  auto key = RMSNormCacheKeyWrapper(X, M, N);
+  auto graph_and_tensors_backward_ptr = rmsnorm_backward_graph_cache.find(key);
+  auto rmsnorm_graph = std::make_shared<cudnn_frontend::graph::Graph>();
+  graph_and_tensors_backward graph_and_tensors_backward_values;
+  std::unordered_map<std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>, void*> variant_pack;
+  if (graph_and_tensors_backward_ptr) {
+    auto [graph, X_fe, DY_fe, inv_variance_fe, scale_fe, dscale_fe, DX_fe] = *graph_and_tensors_backward_ptr;
+    std::unordered_map<std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>, void*> variant_pack_ = {
+      {X_fe, X.data_ptr()},
+      {DY_fe, dY.data_ptr()},
+      {inv_variance_fe, rstd.data_ptr()},
+      {scale_fe, gamma.data_ptr()},
+      {dscale_fe, dgamma->data_ptr()},
+      {DX_fe, dX->data_ptr()}};
+    variant_pack = std::move(variant_pack_);
+    rmsnorm_graph = std::move(graph);
+  } else {
+    rmsnorm_graph->set_io_data_type(get_fe_dtype_rmsnorm(X))
+        .set_intermediate_data_type(cudnn_frontend::DataType_t::FLOAT)
+        .set_compute_data_type(cudnn_frontend::DataType_t::FLOAT);
+    // cuDNN only seems to care about non-normalized and normalized dimensions, and we can only have one non-normalized-dimension, so...
+    // we reshape to
+    // N, M, 1, 1 because cuDNN also has the restriction that everything must be in 4-D
+    auto X_reshaped = X.reshape({M, N, 1, 1});
+    auto DY_reshaped = dY.reshape({M, N, 1, 1});
+    auto X_fe = rmsnorm_graph->tensor(cudnn_frontend::graph::Tensor_attributes()
+                             .set_name("X")
+                             .set_dim(std::vector<int64_t>(X_reshaped.sizes().begin(), X_reshaped.sizes().end()))
+                             .set_stride({N, 1, N, N}));
+    auto DY_fe = rmsnorm_graph->tensor(cudnn_frontend::graph::Tensor_attributes()
+                             .set_name("DY")
+                             .set_dim(std::vector<int64_t>(DY_reshaped.sizes().begin(), DY_reshaped.sizes().end()))
+                             .set_stride({N, 1, N, N}));
+    auto scale_fe = rmsnorm_graph->tensor(cudnn_frontend::graph::Tensor_attributes()
+                                  .set_name("scale")
+                                  .set_dim({1, N, 1, 1})
+                                  .set_stride({N, 1, N, N})
+                                  .set_data_type(get_fe_dtype_rmsnorm(gamma)));
+    auto inv_variance_fe  = rmsnorm_graph->tensor(cudnn_frontend::graph::Tensor_attributes()
+                                 .set_name("inv_variance")
+                                 .set_dim({M, 1, 1, 1})
+                                 .set_stride({1, 1, 1, 1})
+                                 .set_data_type(get_fe_dtype_rmsnorm(rstd)));
+    
+    // For RMSNorm backward, we create zero mean for layernorm_backward
+    auto zero_mean = rmsnorm_graph->tensor(cudnn_frontend::graph::Tensor_attributes()
+                                 .set_name("zero_mean")
+                                 .set_dim({M, 1, 1, 1})
+                                 .set_stride({1, 1, 1, 1})
+                                 .set_is_virtual(true)
+                                 .set_data_type(get_fe_dtype_rmsnorm(rstd)));
+    
+    auto layernorm_options =
+        cudnn_frontend::graph::Layernorm_backward_attributes()
+        .set_saved_mean_and_inv_variance(zero_mean, inv_variance_fe);
+    
+    auto [DX_fe, dscale_fe, dbias_fe] = rmsnorm_graph->layernorm_backward(DY_fe, X_fe, scale_fe, layernorm_options);
+    
+    // For RMSNorm, we only output DX and dscale (dgamma)
+    // dbias is not used in RMSNorm
+    DX_fe->set_output(true);
+    dscale_fe->set_output(true).set_data_type(get_fe_dtype_rmsnorm(*dgamma));
+    
+    cudnnHandle_t handle = getCudnnHandle();
+    TORCH_INTERNAL_ASSERT(rmsnorm_graph->validate().is_good());
+    TORCH_INTERNAL_ASSERT(rmsnorm_graph->build_operation_graph(handle).is_good());
+    TORCH_INTERNAL_ASSERT(rmsnorm_graph->create_execution_plans({cudnn_frontend::HeurMode_t::FALLBACK}).is_good());
+    TORCH_INTERNAL_ASSERT(rmsnorm_graph->check_support(handle).is_good(), rmsnorm_graph->check_support(handle).get_message());
+    TORCH_INTERNAL_ASSERT(rmsnorm_graph->build_plans(handle).is_good());
+    std::unordered_map<std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>, void*> variant_pack_ = {
+      {X_fe, X.data_ptr()},
+      {DY_fe, dY.data_ptr()},
+      {inv_variance_fe, rstd.data_ptr()},
+      {scale_fe, gamma.data_ptr()},
+      {dscale_fe, dgamma->data_ptr()},
+      {DX_fe, dX->data_ptr()}};
+    variant_pack = std::move(variant_pack_);
+    auto result = std::make_tuple(rmsnorm_graph, X_fe, DY_fe, inv_variance_fe, scale_fe, dscale_fe, DX_fe);
+    rmsnorm_backward_graph_cache.update(key, result);
+  }
+  cudnnHandle_t handle = getCudnnHandle();
+  size_t workspace_size = rmsnorm_graph->get_workspace_size();
+  auto workspace_ptr = c10::cuda::CUDACachingAllocator::get()->allocate(workspace_size);
+  TORCH_INTERNAL_ASSERT(!workspace_size || workspace_ptr);
+  TORCH_INTERNAL_ASSERT(rmsnorm_graph->execute(handle, variant_pack, workspace_ptr.get()).is_good());
+}
+
+
+
+}} // at::native
+
+#endif  // AT_CUDNN_ENABLED

--- a/aten/src/ATen/native/cudnn/RMSNorm_v8.cpp
+++ b/aten/src/ATen/native/cudnn/RMSNorm_v8.cpp
@@ -1,6 +1,6 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 
-#include <ATen/cuda/CUDAConfig.h>  // for the definition of AT_CUDNN_ENABLED
+#include <ATen/cuda/CUDAConfig.h> // for the definition of AT_CUDNN_ENABLED
 
 #if AT_CUDNN_ENABLED()
 
@@ -12,22 +12,21 @@ C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wsuggest-override")
 #include <cudnn_frontend.h>
 C10_DIAGNOSTIC_POP()
 
-#include <cudnn_frontend_find_plan.h>
-#include <cudnn_frontend_get_plan.h>
-#include <ATen/core/Tensor.h>
 #include <ATen/TensorUtils.h>
+#include <ATen/core/Tensor.h>
 #include <ATen/cuda/Exceptions.h>
+#include <ATen/cudnn/Handle.h>
 #include <ATen/native/cudnn/RMSNorm_v8.h>
 #include <ATen/native/utils/ParamsHash.h>
-#include <ATen/cudnn/Handle.h>
-#include <ATen/TensorUtils.h>
+#include <cudnn_frontend_find_plan.h>
+#include <cudnn_frontend_get_plan.h>
 
-#include <c10/util/env.h>
-#include <c10/cuda/CUDAException.h>
 #include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/cuda/CUDAException.h>
+#include <c10/util/env.h>
 
-#include <unordered_map>
 #include <list>
+#include <unordered_map>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -41,9 +40,8 @@ C10_DIAGNOSTIC_POP()
 
 #include <cudnn_frontend.h>
 
-namespace at { namespace native {
-
-
+namespace at {
+namespace native {
 
 auto get_fe_dtype_rmsnorm(const Tensor& t) {
   namespace fe = cudnn_frontend;
@@ -59,33 +57,37 @@ auto get_fe_dtype_rmsnorm(const Tensor& t) {
   return fe_dtype;
 }
 
- namespace { 
- namespace fe = cudnn_frontend;
+namespace {
+namespace fe = cudnn_frontend;
 using graph_and_tensors_forward = std::tuple<
-                                    std::shared_ptr<fe::graph::Graph>,
-                                    std::shared_ptr<fe::graph::Tensor_attributes>, // X,
-                                    std::shared_ptr<fe::graph::Tensor_attributes>, // inv_var,
-                                    std::shared_ptr<fe::graph::Tensor_attributes>, // scale,
-                                    std::shared_ptr<fe::graph::Tensor_attributes> // Y
-                        >;
+    std::shared_ptr<fe::graph::Graph>,
+    std::shared_ptr<fe::graph::Tensor_attributes>, // X,
+    std::shared_ptr<fe::graph::Tensor_attributes>, // inv_var,
+    std::shared_ptr<fe::graph::Tensor_attributes>, // scale,
+    std::shared_ptr<fe::graph::Tensor_attributes> // Y
+    >;
 using graph_and_tensors_backward = std::tuple<
-                                    std::shared_ptr<fe::graph::Graph>,
-                                    std::shared_ptr<fe::graph::Tensor_attributes>, // X,
-                                    std::shared_ptr<fe::graph::Tensor_attributes>, // DY,
-                                    std::shared_ptr<fe::graph::Tensor_attributes>, // inv_variance,
-                                    std::shared_ptr<fe::graph::Tensor_attributes>, // scale,
-                                    std::shared_ptr<fe::graph::Tensor_attributes>, // dscale,
-                                    std::shared_ptr<fe::graph::Tensor_attributes> // DX
-                        >;
+    std::shared_ptr<fe::graph::Graph>,
+    std::shared_ptr<fe::graph::Tensor_attributes>, // X,
+    std::shared_ptr<fe::graph::Tensor_attributes>, // DY,
+    std::shared_ptr<fe::graph::Tensor_attributes>, // inv_variance,
+    std::shared_ptr<fe::graph::Tensor_attributes>, // scale,
+    std::shared_ptr<fe::graph::Tensor_attributes>, // dscale,
+    std::shared_ptr<fe::graph::Tensor_attributes> // DX
+    >;
 
 struct RMSNormParams {
   c10::DeviceIndex device_id;
   fe::DataType_t dataType;
   int64_t M;
-  int64_t N; 
+  int64_t N;
 };
 
-void setRMSNormParams(RMSNormParams& params, const Tensor& X, int64_t M, int64_t N) {
+void setRMSNormParams(
+    RMSNormParams& params,
+    const Tensor& X,
+    int64_t M,
+    int64_t N) {
   memset(&params, 0, sizeof(params));
   params.device_id = at::cuda::current_device();
   params.dataType = get_fe_dtype_rmsnorm(X);
@@ -99,175 +101,245 @@ struct RMSNormCacheKeyWrapper : ParamsWrapper<RMSNormParams> {
   }
 };
 
- template <typename T, typename KeyType>
+template <typename T, typename KeyType>
 struct RMSNormGraphCache {
-std::unordered_map<KeyType, T, ParamsWrapperHash<KeyType>> engine_cache;
+  std::unordered_map<KeyType, T, ParamsWrapperHash<KeyType>> engine_cache;
 
-// no mutexes here as caches are now thread local for v8, can also return a pointer
-// to the Execution Plan if we know it will not be invalidated by another thread
-T* find(const KeyType& key) {
-  auto it = engine_cache.find(key);
-  if (it == engine_cache.end()) {
-    return nullptr;
+  // no mutexes here as caches are now thread local for v8, can also return a
+  // pointer to the Execution Plan if we know it will not be invalidated by
+  // another thread
+  T* find(const KeyType& key) {
+    auto it = engine_cache.find(key);
+    if (it == engine_cache.end()) {
+      return nullptr;
+    }
+    return &(it->second);
   }
-  return &(it->second);
-}
 
-void update(const KeyType& key, T& results) {
-  engine_cache.erase(key);
-  engine_cache.emplace(key, std::move(results));
-}
-
+  void update(const KeyType& key, T& results) {
+    engine_cache.erase(key);
+    engine_cache.emplace(key, std::move(results));
+  }
 };
 
-// @eqy: use thread local caches as cuDNN Execution Plans are not guaranteed to be thread safe across all engines
-// see Limitations in https://docs.nvidia.com/deeplearning/cudnn/release-notes/index.html
-thread_local RMSNormGraphCache<graph_and_tensors_forward, RMSNormCacheKeyWrapper> rmsnorm_forward_graph_cache;
-thread_local RMSNormGraphCache<graph_and_tensors_backward, RMSNormCacheKeyWrapper> rmsnorm_backward_graph_cache;
+// @eqy: use thread local caches as cuDNN Execution Plans are not guaranteed to
+// be thread safe across all engines see Limitations in
+// https://docs.nvidia.com/deeplearning/cudnn/release-notes/index.html
+thread_local RMSNormGraphCache<
+    graph_and_tensors_forward,
+    RMSNormCacheKeyWrapper>
+    rmsnorm_forward_graph_cache;
+thread_local RMSNormGraphCache<
+    graph_and_tensors_backward,
+    RMSNormCacheKeyWrapper>
+    rmsnorm_backward_graph_cache;
 
- }
+} // namespace
 
-void raw_cudnn_rmsnorm_forward_out(const Tensor& X, const Tensor& scale, float epsilon, Tensor* rstd, Tensor* Y, int64_t M, int64_t N) {
+void raw_cudnn_rmsnorm_forward_out(
+    const Tensor& X,
+    const Tensor& scale,
+    float epsilon,
+    Tensor* rstd,
+    Tensor* Y,
+    int64_t M,
+    int64_t N) {
   namespace fe = cudnn_frontend;
   auto key = RMSNormCacheKeyWrapper(X, M, N);
   auto graph_and_tensors_forward_ptr = rmsnorm_forward_graph_cache.find(key);
   auto rmsnorm_graph = std::make_shared<fe::graph::Graph>();
   graph_and_tensors_forward graph_and_tensors_forward_values;
-  std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*> variant_pack;
+  std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*>
+      variant_pack;
   if (graph_and_tensors_forward_ptr) {
-    auto [graph, X_fe, inv_variance_fe, scale_fe, Y_fe] = *graph_and_tensors_forward_ptr;
-    std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*> variant_pack_ = {
-      {X_fe, X.data_ptr()},
-      {inv_variance_fe, rstd->data_ptr()},
-      {scale_fe, scale.data_ptr()},
-      {Y_fe, Y->data_ptr()}};
+    auto [graph, X_fe, inv_variance_fe, scale_fe, Y_fe] =
+        *graph_and_tensors_forward_ptr;
+    std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*>
+        variant_pack_ = {
+            {X_fe, X.data_ptr()},
+            {inv_variance_fe, rstd->data_ptr()},
+            {scale_fe, scale.data_ptr()},
+            {Y_fe, Y->data_ptr()}};
     variant_pack = std::move(variant_pack_);
     rmsnorm_graph = std::move(graph);
   } else {
     rmsnorm_graph->set_io_data_type(get_fe_dtype_rmsnorm(X))
         .set_intermediate_data_type(fe::DataType_t::FLOAT)
         .set_compute_data_type(fe::DataType_t::FLOAT);
-    // cuDNN only seems to care about non-normalized and normalized dimensions, and we can only have one non-normalized-dimension, so...
-    // we reshape to
-    // M, N, 1, 1 because cuDNN also has the restriction that everything must be in 4-D
+    // cuDNN only seems to care about non-normalized and normalized dimensions,
+    // and we can only have one non-normalized-dimension, so... we reshape to M,
+    // N, 1, 1 because cuDNN also has the restriction that everything must be in
+    // 4-D
     auto X_reshaped = X.reshape({M, N, 1, 1});
-    auto X_fe = rmsnorm_graph->tensor(fe::graph::Tensor_attributes()
-                             .set_name("X")
-                             .set_dim(std::vector<int64_t>(X_reshaped.sizes().begin(), X_reshaped.sizes().end()))
-                             .set_stride(std::vector<int64_t>(X_reshaped.strides().begin(), X_reshaped.strides().end())));
-    auto scale_fe = rmsnorm_graph->tensor(fe::graph::Tensor_attributes()
+    auto X_fe = rmsnorm_graph->tensor(
+        fe::graph::Tensor_attributes()
+            .set_name("X")
+            .set_dim(std::vector<int64_t>(
+                X_reshaped.sizes().begin(), X_reshaped.sizes().end()))
+            .set_stride(std::vector<int64_t>(
+                X_reshaped.strides().begin(), X_reshaped.strides().end())));
+    auto scale_fe =
+        rmsnorm_graph->tensor(fe::graph::Tensor_attributes()
                                   .set_name("scale")
                                   .set_dim({1, N, 1, 1})
                                   .set_stride({N, 1, N, N})
                                   .set_data_type(get_fe_dtype_rmsnorm(scale)));
     auto epsilon_fe = rmsnorm_graph->tensor(epsilon);
-    auto rmsnorm_options =
-        fe::graph::Rmsnorm_attributes().set_forward_phase(fe::NormFwdPhase_t::TRAINING).set_epsilon(epsilon_fe);
-    auto [Y_fe, inv_variance_fe] = rmsnorm_graph->rmsnorm(X_fe, scale_fe, rmsnorm_options);
-    inv_variance_fe->set_output(true).set_data_type(get_fe_dtype_rmsnorm(*rstd));
+    auto rmsnorm_options = fe::graph::Rmsnorm_attributes()
+                               .set_forward_phase(fe::NormFwdPhase_t::TRAINING)
+                               .set_epsilon(epsilon_fe);
+    auto [Y_fe, inv_variance_fe] =
+        rmsnorm_graph->rmsnorm(X_fe, scale_fe, rmsnorm_options);
+    inv_variance_fe->set_output(true).set_data_type(
+        get_fe_dtype_rmsnorm(*rstd));
     Y_fe->set_output(true);
 
     cudnnHandle_t handle = getCudnnHandle();
     TORCH_INTERNAL_ASSERT(rmsnorm_graph->validate().is_good());
-    TORCH_INTERNAL_ASSERT(rmsnorm_graph->build_operation_graph(handle).is_good());
-    TORCH_INTERNAL_ASSERT(rmsnorm_graph->create_execution_plans({fe::HeurMode_t::FALLBACK}).is_good());
-    TORCH_INTERNAL_ASSERT(rmsnorm_graph->check_support(handle).is_good(), rmsnorm_graph->check_support(handle).get_message());
+    TORCH_INTERNAL_ASSERT(
+        rmsnorm_graph->build_operation_graph(handle).is_good());
+    TORCH_INTERNAL_ASSERT(
+        rmsnorm_graph->create_execution_plans({fe::HeurMode_t::FALLBACK})
+            .is_good());
+    TORCH_INTERNAL_ASSERT(
+        rmsnorm_graph->check_support(handle).is_good(),
+        rmsnorm_graph->check_support(handle).get_message());
     TORCH_INTERNAL_ASSERT(rmsnorm_graph->build_plans(handle).is_good());
-    std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*> variant_pack_ = {
-      {X_fe, X.data_ptr()},
-      {inv_variance_fe, rstd->data_ptr()},
-      {scale_fe, scale.data_ptr()},
-      {Y_fe, Y->data_ptr()}};
+    std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*>
+        variant_pack_ = {
+            {X_fe, X.data_ptr()},
+            {inv_variance_fe, rstd->data_ptr()},
+            {scale_fe, scale.data_ptr()},
+            {Y_fe, Y->data_ptr()}};
     variant_pack = std::move(variant_pack_);
-    auto result = std::make_tuple(rmsnorm_graph, X_fe, inv_variance_fe, scale_fe, Y_fe);
+    auto result =
+        std::make_tuple(rmsnorm_graph, X_fe, inv_variance_fe, scale_fe, Y_fe);
     rmsnorm_forward_graph_cache.update(key, result);
   }
   cudnnHandle_t handle = getCudnnHandle();
   size_t workspace_size = rmsnorm_graph->get_workspace_size();
-  auto workspace_ptr = c10::cuda::CUDACachingAllocator::get()->allocate(workspace_size);
+  auto workspace_ptr =
+      c10::cuda::CUDACachingAllocator::get()->allocate(workspace_size);
   TORCH_INTERNAL_ASSERT(!workspace_size || workspace_ptr);
-  TORCH_INTERNAL_ASSERT(rmsnorm_graph->execute(handle, variant_pack, workspace_ptr.get()).is_good());
+  TORCH_INTERNAL_ASSERT(
+      rmsnorm_graph->execute(handle, variant_pack, workspace_ptr.get())
+          .is_good());
 }
 
-void raw_cudnn_rmsnorm_backward_out(const Tensor& dY, const Tensor& X, const Tensor& rstd, const Tensor& gamma, int64_t M, int64_t N, Tensor* dX,  Tensor* dgamma) {
+void raw_cudnn_rmsnorm_backward_out(
+    const Tensor& dY,
+    const Tensor& X,
+    const Tensor& rstd,
+    const Tensor& gamma,
+    int64_t M,
+    int64_t N,
+    Tensor* dX,
+    Tensor* dgamma) {
   namespace fe = cudnn_frontend;
   auto key = RMSNormCacheKeyWrapper(X, M, N);
   auto graph_and_tensors_backward_ptr = rmsnorm_backward_graph_cache.find(key);
   auto rmsnorm_graph = std::make_shared<fe::graph::Graph>();
   graph_and_tensors_backward graph_and_tensors_backward_values;
-  std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*> variant_pack;
+  std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*>
+      variant_pack;
   if (graph_and_tensors_backward_ptr) {
-    auto [graph, X_fe, DY_fe, inv_variance_fe, scale_fe, dscale_fe, DX_fe] = *graph_and_tensors_backward_ptr;
-    std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*> variant_pack_ = {
-      {X_fe, X.data_ptr()},
-      {DY_fe, dY.data_ptr()},
-      {inv_variance_fe, rstd.data_ptr()},
-      {scale_fe, gamma.data_ptr()},
-      {dscale_fe, dgamma->data_ptr()},
-      {DX_fe, dX->data_ptr()}};
+    auto [graph, X_fe, DY_fe, inv_variance_fe, scale_fe, dscale_fe, DX_fe] =
+        *graph_and_tensors_backward_ptr;
+    std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*>
+        variant_pack_ = {
+            {X_fe, X.data_ptr()},
+            {DY_fe, dY.data_ptr()},
+            {inv_variance_fe, rstd.data_ptr()},
+            {scale_fe, gamma.data_ptr()},
+            {dscale_fe, dgamma->data_ptr()},
+            {DX_fe, dX->data_ptr()}};
     variant_pack = std::move(variant_pack_);
     rmsnorm_graph = std::move(graph);
   } else {
     rmsnorm_graph->set_io_data_type(get_fe_dtype_rmsnorm(X))
         .set_intermediate_data_type(fe::DataType_t::FLOAT)
         .set_compute_data_type(fe::DataType_t::FLOAT);
-    // cuDNN only seems to care about non-normalized and normalized dimensions, and we can only have one non-normalized-dimension, so...
-    // we reshape to
-    // M, N, 1, 1 because cuDNN also has the restriction that everything must be in 4-D
+    // cuDNN only seems to care about non-normalized and normalized dimensions,
+    // and we can only have one non-normalized-dimension, so... we reshape to M,
+    // N, 1, 1 because cuDNN also has the restriction that everything must be in
+    // 4-D
     auto X_reshaped = X.reshape({M, N, 1, 1});
     auto DY_reshaped = dY.reshape({M, N, 1, 1});
-    auto X_fe = rmsnorm_graph->tensor(fe::graph::Tensor_attributes()
-                             .set_name("X")
-                             .set_dim(std::vector<int64_t>(X_reshaped.sizes().begin(), X_reshaped.sizes().end()))
-                             .set_stride({N, 1, N, N}));
-    auto DY_fe = rmsnorm_graph->tensor(fe::graph::Tensor_attributes()
-                             .set_name("DY")
-                             .set_dim(std::vector<int64_t>(DY_reshaped.sizes().begin(), DY_reshaped.sizes().end()))
-                             .set_stride({N, 1, N, N}));
-    auto scale_fe = rmsnorm_graph->tensor(fe::graph::Tensor_attributes()
+    auto X_fe = rmsnorm_graph->tensor(
+        fe::graph::Tensor_attributes()
+            .set_name("X")
+            .set_dim(std::vector<int64_t>(
+                X_reshaped.sizes().begin(), X_reshaped.sizes().end()))
+            .set_stride({N, 1, N, N}));
+    auto DY_fe = rmsnorm_graph->tensor(
+        fe::graph::Tensor_attributes()
+            .set_name("DY")
+            .set_dim(std::vector<int64_t>(
+                DY_reshaped.sizes().begin(), DY_reshaped.sizes().end()))
+            .set_stride({N, 1, N, N}));
+    auto scale_fe =
+        rmsnorm_graph->tensor(fe::graph::Tensor_attributes()
                                   .set_name("scale")
                                   .set_dim({1, N, 1, 1})
                                   .set_stride({N, 1, N, N})
                                   .set_data_type(get_fe_dtype_rmsnorm(gamma)));
-    auto inv_variance_fe  = rmsnorm_graph->tensor(fe::graph::Tensor_attributes()
-                                 .set_name("inv_variance")
-                                 .set_dim({M, 1, 1, 1})
-                                 .set_stride({1, 1, 1, 1})
-                                 .set_data_type(get_fe_dtype_rmsnorm(rstd)));
+    auto inv_variance_fe =
+        rmsnorm_graph->tensor(fe::graph::Tensor_attributes()
+                                  .set_name("inv_variance")
+                                  .set_dim({M, 1, 1, 1})
+                                  .set_stride({1, 1, 1, 1})
+                                  .set_data_type(get_fe_dtype_rmsnorm(rstd)));
     auto rmsnorm_options =
         fe::graph::Rmsnorm_backward_attributes().has_dbias(false);
-    auto [DX_fe, dscale_fe, dbias_fe] = rmsnorm_graph->rmsnorm_backward(DY_fe, X_fe, scale_fe, inv_variance_fe, rmsnorm_options);
+    auto [DX_fe, dscale_fe, dbias_fe] = rmsnorm_graph->rmsnorm_backward(
+        DY_fe, X_fe, scale_fe, inv_variance_fe, rmsnorm_options);
     DX_fe->set_output(true);
     dscale_fe->set_output(true).set_data_type(get_fe_dtype_rmsnorm(*dgamma));
     // dbias_fe should be nullptr for RMSNorm
-    TORCH_INTERNAL_ASSERT(dbias_fe == nullptr, "RMSNorm backward should not have dbias");
-    
+    TORCH_INTERNAL_ASSERT(
+        dbias_fe == nullptr, "RMSNorm backward should not have dbias");
+
     cudnnHandle_t handle = getCudnnHandle();
     TORCH_INTERNAL_ASSERT(rmsnorm_graph->validate().is_good());
-    TORCH_INTERNAL_ASSERT(rmsnorm_graph->build_operation_graph(handle).is_good());
-    TORCH_INTERNAL_ASSERT(rmsnorm_graph->create_execution_plans({fe::HeurMode_t::FALLBACK}).is_good());
-    TORCH_INTERNAL_ASSERT(rmsnorm_graph->check_support(handle).is_good(), rmsnorm_graph->check_support(handle).get_message());
+    TORCH_INTERNAL_ASSERT(
+        rmsnorm_graph->build_operation_graph(handle).is_good());
+    TORCH_INTERNAL_ASSERT(
+        rmsnorm_graph->create_execution_plans({fe::HeurMode_t::FALLBACK})
+            .is_good());
+    TORCH_INTERNAL_ASSERT(
+        rmsnorm_graph->check_support(handle).is_good(),
+        rmsnorm_graph->check_support(handle).get_message());
     TORCH_INTERNAL_ASSERT(rmsnorm_graph->build_plans(handle).is_good());
-    std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*> variant_pack_ = {
-      {X_fe, X.data_ptr()},
-      {DY_fe, dY.data_ptr()},
-      {inv_variance_fe, rstd.data_ptr()},
-      {scale_fe, gamma.data_ptr()},
-      {dscale_fe, dgamma->data_ptr()},
-      {DX_fe, dX->data_ptr()}};
+    std::unordered_map<std::shared_ptr<fe::graph::Tensor_attributes>, void*>
+        variant_pack_ = {
+            {X_fe, X.data_ptr()},
+            {DY_fe, dY.data_ptr()},
+            {inv_variance_fe, rstd.data_ptr()},
+            {scale_fe, gamma.data_ptr()},
+            {dscale_fe, dgamma->data_ptr()},
+            {DX_fe, dX->data_ptr()}};
     variant_pack = std::move(variant_pack_);
-    auto result = std::make_tuple(rmsnorm_graph, X_fe, DY_fe, inv_variance_fe, scale_fe, dscale_fe, DX_fe);
+    auto result = std::make_tuple(
+        rmsnorm_graph,
+        X_fe,
+        DY_fe,
+        inv_variance_fe,
+        scale_fe,
+        dscale_fe,
+        DX_fe);
     rmsnorm_backward_graph_cache.update(key, result);
   }
   cudnnHandle_t handle = getCudnnHandle();
   size_t workspace_size = rmsnorm_graph->get_workspace_size();
-  auto workspace_ptr = c10::cuda::CUDACachingAllocator::get()->allocate(workspace_size);
+  auto workspace_ptr =
+      c10::cuda::CUDACachingAllocator::get()->allocate(workspace_size);
   TORCH_INTERNAL_ASSERT(!workspace_size || workspace_ptr);
-  TORCH_INTERNAL_ASSERT(rmsnorm_graph->execute(handle, variant_pack, workspace_ptr.get()).is_good());
+  TORCH_INTERNAL_ASSERT(
+      rmsnorm_graph->execute(handle, variant_pack, workspace_ptr.get())
+          .is_good());
 }
 
+} // namespace native
+} // namespace at
 
-
-}} // at::native
-
-#endif  // AT_CUDNN_ENABLED
+#endif // AT_CUDNN_ENABLED

--- a/aten/src/ATen/native/cudnn/RMSNorm_v8.h
+++ b/aten/src/ATen/native/cudnn/RMSNorm_v8.h
@@ -1,19 +1,35 @@
 #pragma once
 #include <ATen/core/Tensor.h>
 
-#include <ATen/cuda/CUDAConfig.h>  // for the definition of AT_CUDNN_ENABLED
+#include <ATen/cuda/CUDAConfig.h> // for the definition of AT_CUDNN_ENABLED
 
-#include <ATen/cudnn/cudnn-wrapper.h>
 #include <ATen/cudnn/Descriptors.h>
 #include <ATen/cudnn/Types.h>
+#include <ATen/cudnn/cudnn-wrapper.h>
 
-namespace at { namespace native {
-
+namespace at {
+namespace native {
 
 #if AT_CUDNN_ENABLED()
 
-void raw_cudnn_rmsnorm_forward_out(const Tensor& X, const Tensor& scale, float epsilon, Tensor* rstd, Tensor* Y, int64_t M, int64_t N);
-void raw_cudnn_rmsnorm_backward_out(const Tensor& dY, const Tensor& X, const Tensor& rstd, const Tensor& gamma, int64_t M, int64_t N, Tensor* dX,  Tensor* dgamma);
+void raw_cudnn_rmsnorm_forward_out(
+    const Tensor& X,
+    const Tensor& scale,
+    float epsilon,
+    Tensor* rstd,
+    Tensor* Y,
+    int64_t M,
+    int64_t N);
+void raw_cudnn_rmsnorm_backward_out(
+    const Tensor& dY,
+    const Tensor& X,
+    const Tensor& rstd,
+    const Tensor& gamma,
+    int64_t M,
+    int64_t N,
+    Tensor* dX,
+    Tensor* dgamma);
 
 #endif
-}}
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/cudnn/RMSNorm_v8.h
+++ b/aten/src/ATen/native/cudnn/RMSNorm_v8.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <ATen/core/Tensor.h>
+
+#include <ATen/cuda/CUDAConfig.h>  // for the definition of AT_CUDNN_ENABLED
+
+#include <ATen/cudnn/cudnn-wrapper.h>
+#include <ATen/cudnn/Descriptors.h>
+#include <ATen/cudnn/Types.h>
+
+namespace at { namespace native {
+
+
+#if AT_CUDNN_ENABLED()
+
+void raw_cudnn_rmsnorm_forward_out(const Tensor& X, const Tensor& scale, float epsilon, Tensor* rstd, Tensor* Y, int64_t M, int64_t N);
+void raw_cudnn_rmsnorm_backward_out(const Tensor& dY, const Tensor& X, const Tensor& rstd, const Tensor& gamma, int64_t M, int64_t N, Tensor* dX,  Tensor* dgamma);
+
+#endif
+}}


### PR DESCRIPTION
~~cuDNN performance as of 9.10 is still not great~~

~~if it ever becomes good, this PR could streamline process of adding experimental cudnn backend for layernorm and rmsnorm~~

Implementation follows examples at: https://github.com/NVIDIA/cudnn-frontend/tree/main/samples/cpp/norm

After some changes and discussion with cudnn team, it appears that cudnn performnace is great on the newer versions of cudnn. For forward pass, cuDNN 9.11 has good performance, and for the backward pass, a soon to be released version of cuDNN will have good performance. 

Backend gated behind environmental variables for both layer norm and rms norm
- TORCH_CUDNN_LAYERNORM_ENABLED=1
- TORCH_CUDNN_RMSNORM_ENABLED=1

cuDNN 9.11

Forward
Layernorm H100 fp16
```
Problem Size   Default Eager            Throughput     Compiled (default)       Throughput     cuDNN Eager              Throughput     Best Mode
------------------------------------------------------------------------------------------------------------------------
16384x1024     0.000042                 3195.660       0.000073                 1838.599       0.000030                 4473.924       cudnn_eager (1.40x)
16384x2048     0.000064                 4194.304       0.000074                 3627.506       0.000051                 5263.440       cudnn_eager (1.25x)
16384x4096     0.000116                 4628.198       0.000103                 5212.339       0.000099                 5422.939       cudnn_eager (1.17x)
32768x1024     0.000078                 3441.480       0.000072                 3728.270       0.000051                 5263.440       cudnn_eager (1.53x)
32768x2048     0.000120                 4473.924       0.000142                 3780.781       0.000099                 5422.939       cudnn_eager (1.21x)
32768x4096     0.000233                 4608.334       0.000202                 5315.554       0.000192                 5592.405       cudnn_eager (1.21x)
65536x1024     0.000152                 3532.045       0.000112                 4793.490       0.000104                 5162.220       cudnn_eager (1.46x)
65536x2048     0.000232                 4628.198       0.000278                 3862.381       0.000192                 5592.405       cudnn_eager (1.21x)
65536x4096     0.000517                 4153.740       0.000398                 5395.688       0.000376                 5711.393       cudnn_eager (1.38x)
```
B200 layer norm on fp16
```
COMPREHENSIVE PERFORMANCE MATRIX
================================================================================
Problem Size   Default Eager       Default Compiled    cuDNN Eager         Best Mode
--------------------------------------------------------------------------------
16384x1024     0.000042            0.000119            0.000043            default_eager (1.00x)
16384x2048     0.000062            0.000119            0.000041            cudnn_eager (1.51x)
16384x4096     0.000101            0.000118            0.000047            cudnn_eager (2.15x)
32768x1024     0.000083            0.000120            0.000040            cudnn_eager (2.07x)
32768x2048     0.000118            0.000124            0.000048            cudnn_eager (2.46x)
32768x4096     0.000192            0.000152            0.000093            cudnn_eager (2.06x)
65536x1024     0.000160            0.000126            0.000051            cudnn_eager (3.14x)
65536x2048     0.000228            0.000234            0.000092            cudnn_eager (2.48x)
65536x4096     0.000374            0.000297            0.000182            cudnn_eager (2.05x)
```

B200 layer norm on fp32
```
COMPREHENSIVE PERFORMANCE MATRIX
==============================================================================
Problem Size   Default Eager       Compiled (def)    cuDNN Eager         Best Mode
------------------------------------------------------------------------------
16384x1024     0.000042            0.000116          0.000040            cudnn_eager (1.05x)
16384x2048     0.000062            0.000124          0.000038            cudnn_eager (1.63x)
16384x4096     0.000102            0.000125          0.000044            cudnn_eager (2.32x)
32768x1024     0.000083            0.000132          0.000051            cudnn_eager (1.63x)
32768x2048     0.000118            0.000122          0.000050            cudnn_eager (2.36x)
32768x4096     0.000193            0.000152          0.000083            cudnn_eager (2.33x)
65536x1024     0.000161            0.000125          0.000047            cudnn_eager (3.43x)
65536x2048     0.000228            0.000234          0.000094            cudnn_eager (2.43x)
65536x4096     0.000374            0.000298          0.000161            cudnn_eager (2.32x)
```


B200 rmsnorm on fp16
```
COMPREHENSIVE PERFORMANCE MATRIX
================================================================================
Problem Size   Default Eager       Compiled (def)      cuDNN Eager         Best Mode
--------------------------------------------------------------------------------
16384x1024     0.000032            0.000106            0.000046            default_eager (1.00x)
16384x2048     0.000031            0.000114            0.000047            default_eager (1.00x)
16384x4096     0.000048            0.000110            0.000047            cudnn_eager (1.02x)
32768x1024     0.000052            0.000121            0.000051            cudnn_eager (1.02x)
32768x2048     0.000054            0.000104            0.000045            cudnn_eager (1.20x)
32768x4096     0.000088            0.000107            0.000086            cudnn_eager (1.02x)
65536x1024     0.000097            0.000111            0.000048            cudnn_eager (2.02x)
65536x2048     0.000101            0.000153            0.000083            cudnn_eager (1.22x)
65536x4096     0.000167            0.000204            0.000158            cudnn_eager (1.06x)
```

Backward Results (9.11)

Layernorm H100 fp16
```
Problem Size   Default Eager            Throughput     Compiled (default)       Throughput     cuDNN Eager              Throughput     Best Mode
------------------------------------------------------------------------------------------------------------------------
16384x1024     0.000184                 91.181         0.000291                 57.654         0.000140                 119.837        cudnn_eager (1.31x)
16384x2048     0.000255                 131.586        0.000576                 58.254         0.000286                 117.323        default_eager (1.00x)
16384x4096     0.000458                 146.526        0.000467                 143.702        0.000563                 119.199        default_eager (1.00x)
32768x1024     0.000295                 113.744        0.000367                 91.429         0.000152                 220.753        cudnn_eager (1.94x)
32768x2048     0.000443                 151.487        0.000456                 147.169        0.000537                 124.970        default_eager (1.00x)
32768x4096     0.000903                 148.635        0.000877                 153.042        0.001092                 122.910        default_compiled_default (1.03x)
65536x1024     0.000572                 117.323        0.000454                 147.817        0.000290                 231.410        cudnn_eager (1.97x)
65536x2048     0.000864                 155.345        0.000875                 153.392        0.001060                 126.620        default_eager (1.00x)
65536x4096     0.001807                 148.553        0.001710                 156.980        0.002137                 125.613        default_compiled_default (1.06x)
```

RMSNorm H100 fp16
```
Problem Size   Default Eager            Throughput     Compiled (default)       Throughput     cuDNN Eager              Throughput     Best Mode
------------------------------------------------------------------------------------------------------------------------
16384x1024     0.000168                 99.864         0.000325                 51.622         0.000154                 108.943        cudnn_eager (1.09x)
16384x2048     0.000253                 132.626        0.000412                 81.443         0.000288                 116.508        default_eager (1.00x)
16384x4096     0.000460                 145.889        0.000514                 130.562        0.000568                 118.149        default_eager (1.00x)
32768x1024     0.000298                 112.599        0.000377                 89.004         0.000175                 191.740        cudnn_eager (1.70x)
32768x2048     0.000443                 151.487        0.000467                 143.702        0.000539                 124.506        default_eager (1.00x)
32768x4096     0.000903                 148.635        0.000873                 153.743        0.001090                 123.136        default_compiled_default (1.03x)
65536x1024     0.000571                 117.529        0.000472                 142.180        0.000289                 232.211        cudnn_eager (1.98x)
65536x2048     0.000863                 155.525        0.000875                 153.392        0.001063                 126.263        default_eager (1.00x)
65536x4096     0.001807                 148.553        0.001710                 156.980        0.002135                 125.731        default_compiled_default (1.06x)
```

Backward results (internal cuDNN version, soon to be released)
Layernorm H100 fp16
```
Problem Size   Default Eager            Throughput     Compiled (default)       Throughput     cuDNN Eager              Throughput     Best Mode
------------------------------------------------------------------------------------------------------------------------
16384x1024     0.000235                 571.139        0.000242                 554.619        0.000092                 1458.888       cudnn_eager (2.55x)
16384x2048     0.000268                 1001.625       0.000256                 1048.576       0.000170                 1579.032       cudnn_eager (1.58x)
16384x4096     0.000459                 1169.653       0.000461                 1164.579       0.000283                 1897.070       cudnn_eager (1.62x)
32768x1024     0.000305                 880.116        0.000245                 1095.655       0.000303                 885.926        default_compiled_default (1.24x)
32768x2048     0.000443                 1211.898       0.000459                 1169.653       0.000283                 1897.070       cudnn_eager (1.57x)
32768x4096     0.000904                 1187.768       0.000877                 1224.335       0.000584                 1838.599       cudnn_eager (1.55x)
65536x1024     0.000572                 938.586        0.000464                 1157.049       0.000298                 1801.580       cudnn_eager (1.92x)
65536x2048     0.000864                 1242.757       0.000876                 1225.733       0.000545                 1970.168       cudnn_eager (1.59x)
65536x4096     0.001807                 1188.425       0.001712                 1254.371       0.001143                 1878.813       cudnn_eager (1.58x)
```
rmsnorm H100 fp16
```
Problem Size   Default Eager            Throughput     Compiled (default)       Throughput     cuDNN Eager              Throughput     Best Mode
------------------------------------------------------------------------------------------------------------------------
16384x1024     0.000177                 758.292        0.000180                 745.654        0.000097                 1383.688       cudnn_eager (1.82x)
16384x2048     0.000283                 948.535        0.000233                 1152.084       0.000209                 1284.380       cudnn_eager (1.35x)
16384x4096     0.000433                 1239.887       0.000449                 1195.704       0.000285                 1883.758       cudnn_eager (1.52x)
32768x1024     0.000310                 865.921        0.000208                 1290.555       0.000186                 1443.201       cudnn_eager (1.67x)
32768x2048     0.000419                 1281.315       0.000451                 1190.401       0.000289                 1857.685       cudnn_eager (1.45x)
32768x4096     0.000878                 1222.941       0.000857                 1252.908       0.000535                 2006.994       cudnn_eager (1.64x)
65536x1024     0.000510                 1052.688       0.000450                 1193.046       0.000282                 1903.798       cudnn_eager (1.81x)
65536x2048     0.000820                 1309.441       0.000869                 1235.606       0.000536                 2003.250       cudnn_eager (1.53x)
65536x4096     0.001764                 1217.394       0.001683                 1275.986       0.001060                 2025.928       cudnn_eager (1.66x)
```


cc @csarofeen @ptrblck @xwang233 @eqy @nWEIdia @msaroufim @jerryzh168 @tinglvv