### PR TITLE
[DTensor] Registers sharding rule for rms_norm

### DIFF
--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -278,7 +278,9 @@ class DistMathOpsTest(DTensorTestBase):
             norm_types.append(torch.nn.RMSNorm)
 
         test_config_list = list(
-            itertools.product(norm_types, shard_dims, norm_shape_idx_list, elementwise_affine_list)
+            itertools.product(
+                norm_types, shard_dims, norm_shape_idx_list, elementwise_affine_list
+            )
         )
 
         # normalized shape is a torch.Size object
@@ -343,7 +345,9 @@ class DistMathOpsTest(DTensorTestBase):
             norm_types.append(torch.nn.RMSNorm)
 
         test_config_list = list(
-            itertools.product(norm_types, shard_dims, norm_shape_idx_list, elementwise_affine_list)
+            itertools.product(
+                norm_types, shard_dims, norm_shape_idx_list, elementwise_affine_list
+            )
         )
 
         # normalized shape is a torch.Size object
@@ -474,8 +478,11 @@ class DistMathOpsTest(DTensorTestBase):
         subtest_cfgs = list(
             filter(
                 valid_filter,
-                [SubTest(norm_type, *cfg) for norm_type in norm_types
-                 for cfg in itertools.product(*(((False, True),) * 5))],
+                [
+                    SubTest(norm_type, *cfg)
+                    for norm_type in norm_types
+                    for cfg in itertools.product(*(((False, True),) * 5))
+                ],
             )
         )
 
@@ -598,7 +605,6 @@ class DistMathOpsTest(DTensorTestBase):
         assert not subtest_fails, (
             f"{len(subtest_fails)}/{len(subtest_cfgs)} subtests failed: {pformat(subtest_fails)}"
         )
-
 
     @with_comms
     def test_topk(self):

--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -271,14 +271,22 @@ class DistMathOpsTest(DTensorTestBase):
         norm_shape_idx_list = list(range(x.ndim))
         shard_dims = [-1, 0, 1, 2]
         elementwise_affine_list = [False, True]
+
+        # Test RMSNorm as well if CUDA
+        norm_types = [torch.nn.LayerNorm]
+        if self.device_type == "cuda" and hasattr(torch.nn, "RMSNorm"):
+            norm_types.append(torch.nn.RMSNorm)
+
         test_config_list = list(
-            itertools.product(shard_dims, norm_shape_idx_list, elementwise_affine_list)
+            itertools.product(
+                norm_types, shard_dims, norm_shape_idx_list, elementwise_affine_list
+            )
         )
 
         # normalized shape is a torch.Size object
-        for shard_dim, norm_idx, elementwise_affine in test_config_list:
+        for norm_type, shard_dim, norm_idx, elementwise_affine in test_config_list:
             normalized_shape = x.shape[norm_idx:]
-            layer_norm = torch.nn.LayerNorm(
+            layer_norm = norm_type(
                 normalized_shape,
                 elementwise_affine=elementwise_affine,
                 device=self.device_type,
@@ -287,6 +295,7 @@ class DistMathOpsTest(DTensorTestBase):
 
             def _replicate_fn(name, module, device_mesh):
                 for name, param in module.named_parameters():
+                    # RMSNorm only has weight, LayerNorm has both weight and bias
                     if name in ["weight", "bias"]:
                         param_dist = torch.nn.Parameter(
                             distribute_tensor(param, device_mesh, [Replicate()])
@@ -307,7 +316,7 @@ class DistMathOpsTest(DTensorTestBase):
             self.assertLessEqual(
                 comm_mode.get_total_counts(),
                 1,  # TODO: This should be 0!
-                f"comm count={comm_mode.get_total_counts()}, "
+                f"comm count={comm_mode.get_total_counts()}, norm_type={norm_type.__name__}, "
                 f"shard_dim={shard_dim}, norm_shape={normalized_shape}, elem_affine={elementwise_affine}",
             )
 
@@ -329,12 +338,20 @@ class DistMathOpsTest(DTensorTestBase):
         norm_shape_idx_list = list(range(3))
         shard_dims = [0, 1, 2]
         elementwise_affine_list = [False, True]
+
+        # Test both LayerNorm and RMSNorm (if CUDA)
+        norm_types = [torch.nn.LayerNorm]
+        if self.device_type == "cuda" and hasattr(torch.nn, "RMSNorm"):
+            norm_types.append(torch.nn.RMSNorm)
+
         test_config_list = list(
-            itertools.product(shard_dims, norm_shape_idx_list, elementwise_affine_list)
+            itertools.product(
+                norm_types, shard_dims, norm_shape_idx_list, elementwise_affine_list
+            )
         )
 
         # normalized shape is a torch.Size object
-        for shard_dim, norm_idx, elementwise_affine in test_config_list:
+        for norm_type, shard_dim, norm_idx, elementwise_affine in test_config_list:
             x = torch.rand(
                 batch,
                 sentence_length,
@@ -343,7 +360,7 @@ class DistMathOpsTest(DTensorTestBase):
                 requires_grad=True,
             )
             normalized_shape = x.shape[norm_idx:]
-            layer_norm = torch.nn.LayerNorm(
+            layer_norm = norm_type(
                 normalized_shape,
                 elementwise_affine=elementwise_affine,
                 device=self.device_type,
@@ -364,9 +381,11 @@ class DistMathOpsTest(DTensorTestBase):
                 self.assertEqual(
                     layer_norm_local.weight, layer_norm_dist.weight.full_tensor()
                 )
-                self.assertEqual(
-                    layer_norm_local.bias, layer_norm_dist.bias.full_tensor()
-                )
+                # RMSNorm doesn't have bias
+                if hasattr(layer_norm_local, "bias"):
+                    self.assertEqual(
+                        layer_norm_local.bias, layer_norm_dist.bias.full_tensor()
+                    )
 
             x_local = x.detach().clone().requires_grad_(True)
             x_dist = distribute_tensor(x, device_mesh, [Shard(shard_dim)])
@@ -384,7 +403,7 @@ class DistMathOpsTest(DTensorTestBase):
             self.assertEqual(
                 sum(comm_mode.comm_module_counts["Global"]["forward"].values()),
                 expected_fwd_comm,
-                f"comm count={comm_mode.get_total_counts()}, "
+                f"comm count={comm_mode.get_total_counts()}, norm_type={norm_type.__name__}, "
                 f"shard_dim={shard_dim}, norm_shape={normalized_shape}, elem_affine={elementwise_affine}",
             )
 
@@ -398,7 +417,7 @@ class DistMathOpsTest(DTensorTestBase):
             self.assertEqual(
                 sum(comm_mode.comm_module_counts["Global"]["backward"].values()),
                 expected_bwd_comm,
-                f"comm count={comm_mode.get_total_counts()}, "
+                f"comm count={comm_mode.get_total_counts()}, norm_type={norm_type.__name__}, "
                 f"shard_dim={shard_dim}, norm_shape={normalized_shape}, elem_affine={elementwise_affine}",
             )
 
@@ -412,18 +431,22 @@ class DistMathOpsTest(DTensorTestBase):
                     is_tensor_partial(layer_norm_dist.weight.grad._spec),
                     needs_reduction,
                 )
-                self.assertEqual(
-                    is_tensor_partial(layer_norm_dist.bias.grad._spec),
-                    needs_reduction,
-                )
+                # RMSNorm doesn't have bias
+                if hasattr(layer_norm_dist, "bias"):
+                    self.assertEqual(
+                        is_tensor_partial(layer_norm_dist.bias.grad._spec),
+                        needs_reduction,
+                    )
                 self.assertEqual(
                     layer_norm_local.weight.grad,
                     layer_norm_dist.weight.grad.full_tensor(),
                 )
-                self.assertEqual(
-                    layer_norm_local.bias.grad,
-                    layer_norm_dist.bias.grad.full_tensor(),
-                )
+                # RMSNorm doesn't have bias
+                if hasattr(layer_norm_local, "bias"):
+                    self.assertEqual(
+                        layer_norm_local.bias.grad,
+                        layer_norm_dist.bias.grad.full_tensor(),
+                    )
 
             self.assertEqual(x_local.grad, x_dist.grad.full_tensor())
 
@@ -432,8 +455,14 @@ class DistMathOpsTest(DTensorTestBase):
         device_mesh = self.build_device_mesh()
         batch, seq_len, embedding_dim, vocab_size = 8, 8, 10, 32
 
+        # Test both LayerNorm and RMSNorm (if CUDA)
+        norm_types = [torch.nn.LayerNorm]
+        if self.device_type == "cuda" and hasattr(torch.nn, "RMSNorm"):
+            norm_types.append(torch.nn.RMSNorm)
+
         # build our subtest configurations and filter out invalid ones
         class SubTest(NamedTuple):
+            norm_type: type
             multidim_norm: bool
             elementwise_affine: bool
             emb_req_grad: bool
@@ -443,19 +472,24 @@ class DistMathOpsTest(DTensorTestBase):
         subtest_fails = {}
         valid_filter = (  # noqa: E731
             lambda cfg: (
-                not (cfg.ln_req_grad and not cfg.elementwise_affine) and any(cfg[2:])
+                not (cfg.ln_req_grad and not cfg.elementwise_affine) and any(cfg[3:])
             )
         )
         subtest_cfgs = list(
             filter(
                 valid_filter,
-                [SubTest(*cfg) for cfg in itertools.product(*(((False, True),) * 5))],
+                [
+                    SubTest(norm_type, *cfg)
+                    for norm_type in norm_types
+                    for cfg in itertools.product(*(((False, True),) * 5))
+                ],
             )
         )
 
         for subtest_cfg in subtest_cfgs:
             try:
                 (
+                    norm_type,
                     multidim_norm,
                     elementwise_affine,
                     emb_req_grad,
@@ -473,7 +507,7 @@ class DistMathOpsTest(DTensorTestBase):
                         self.preln_embeddings = torch.nn.Embedding(
                             vocab_size, embedding_dim
                         )
-                        self.layer_norm = torch.nn.LayerNorm(
+                        self.layer_norm = norm_type(
                             normalized_shape, elementwise_affine=elementwise_affine
                         )
                         self.postln_linear = torch.nn.Linear(
@@ -571,104 +605,6 @@ class DistMathOpsTest(DTensorTestBase):
         assert not subtest_fails, (
             f"{len(subtest_fails)}/{len(subtest_cfgs)} subtests failed: {pformat(subtest_fails)}"
         )
-
-    @with_comms
-    def test_rms_norm_bwd(self):
-        device_mesh = self.build_device_mesh()
-
-        # NLP example from pytorch docs
-        batch, sentence_length, embedding_dim = 20, 5, 10
-        norm_shape_idx_list = list(range(3))
-        shard_dims = [0]  # non-first dimensional sharding is not supported
-        elementwise_affine_list = [False, True]
-        test_config_list = list(
-            itertools.product(shard_dims, norm_shape_idx_list, elementwise_affine_list)
-        )
-
-        # normalized shape is a torch.Size object
-        for shard_dim, norm_idx, elementwise_affine in test_config_list:
-            x = torch.rand(
-                batch,
-                sentence_length,
-                embedding_dim,
-                device=self.device_type,
-                requires_grad=True,
-            )
-            normalized_shape = x.shape[norm_idx:]
-            rms_norm = torch.nn.RMSNorm(
-                normalized_shape,
-                elementwise_affine=elementwise_affine,
-                device=self.device_type,
-            )
-            rms_norm_local = copy.deepcopy(rms_norm).to(self.device_type)
-
-            def _replicate_fn(name, module, device_mesh):
-                for name, param in module.named_parameters():
-                    if name == "weight":
-                        param_dist = torch.nn.Parameter(
-                            distribute_tensor(param, device_mesh, [Replicate()])
-                        )
-                        module.register_parameter(name, param_dist)
-
-            rms_norm_dist = distribute_module(rms_norm, device_mesh, _replicate_fn)
-
-            if elementwise_affine:
-                self.assertEqual(
-                    rms_norm_local.weight, rms_norm_dist.weight.full_tensor()
-                )
-
-            x_local = x.detach().clone().requires_grad_(True)
-            x_dist = distribute_tensor(x, device_mesh, [Shard(shard_dim)])
-            self.assertEqual(x_local, x_dist.full_tensor())
-
-            y_local = rms_norm_local(x_local)
-            # make sure that backward rms norm does not introduce extra collectives
-            comm_mode = CommDebugMode()
-            with comm_mode:
-                y_dist = rms_norm_dist(x_dist)
-                y_dist.sum().backward()
-
-            # TODO: forward pass is sharding strategy is generated from composite, hence 1 more collective than layer_norm
-            # see: https://github.com/pytorch/pytorch/pull/158716#issuecomment-3096012679
-            expected_fwd_comm = 0 if shard_dim < norm_idx else 1
-
-            self.assertEqual(
-                sum(comm_mode.comm_module_counts["Global"]["forward"].values()),
-                expected_fwd_comm,
-                f"comm count={comm_mode.get_total_counts()}, "
-                f"shard_dim={shard_dim}, norm_shape={normalized_shape}, elem_affine={elementwise_affine}",
-            )
-
-            self.assertEqual(y_local, y_dist.full_tensor())
-
-            # backward step
-            y_local.sum().backward()
-
-            expected_bwd_comm = 0 if shard_dim < norm_idx else 1
-
-            self.assertEqual(
-                sum(comm_mode.comm_module_counts["Global"]["backward"].values()),
-                expected_bwd_comm,
-                f"comm count={comm_mode.get_total_counts()}, "
-                f"shard_dim={shard_dim}, norm_shape={normalized_shape}, elem_affine={elementwise_affine}",
-            )
-
-            if elementwise_affine:
-                # if input is sharded on any outer dimension, the gradient of weight
-                # should be Partial
-                dim_map = x_dist._spec.dim_map
-                outer_dims = range(norm_idx)
-                needs_reduction = any(dim_map[d] >= 0 for d in outer_dims)
-                self.assertEqual(
-                    is_tensor_partial(rms_norm_dist.weight.grad._spec),
-                    needs_reduction,
-                )
-                self.assertEqual(
-                    rms_norm_local.weight.grad,
-                    rms_norm_dist.weight.grad.full_tensor(),
-                )
-
-            self.assertEqual(x_local.grad, x_dist.grad.full_tensor())
 
     @with_comms
     def test_topk(self):

--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -455,14 +455,8 @@ class DistMathOpsTest(DTensorTestBase):
         device_mesh = self.build_device_mesh()
         batch, seq_len, embedding_dim, vocab_size = 8, 8, 10, 32
 
-        # Test both LayerNorm and RMSNorm (if CUDA)
-        norm_types = [torch.nn.LayerNorm]
-        if self.device_type == "cuda" and hasattr(torch.nn, "RMSNorm"):
-            norm_types.append(torch.nn.RMSNorm)
-
         # build our subtest configurations and filter out invalid ones
         class SubTest(NamedTuple):
-            norm_type: type
             multidim_norm: bool
             elementwise_affine: bool
             emb_req_grad: bool
@@ -472,24 +466,19 @@ class DistMathOpsTest(DTensorTestBase):
         subtest_fails = {}
         valid_filter = (  # noqa: E731
             lambda cfg: (
-                not (cfg.ln_req_grad and not cfg.elementwise_affine) and any(cfg[3:])
+                not (cfg.ln_req_grad and not cfg.elementwise_affine) and any(cfg[2:])
             )
         )
         subtest_cfgs = list(
             filter(
                 valid_filter,
-                [
-                    SubTest(norm_type, *cfg)
-                    for norm_type in norm_types
-                    for cfg in itertools.product(*(((False, True),) * 5))
-                ],
+                [SubTest(*cfg) for cfg in itertools.product(*(((False, True),) * 5))],
             )
         )
 
         for subtest_cfg in subtest_cfgs:
             try:
                 (
-                    norm_type,
                     multidim_norm,
                     elementwise_affine,
                     emb_req_grad,
@@ -507,7 +496,7 @@ class DistMathOpsTest(DTensorTestBase):
                         self.preln_embeddings = torch.nn.Embedding(
                             vocab_size, embedding_dim
                         )
-                        self.layer_norm = norm_type(
+                        self.layer_norm = torch.nn.LayerNorm(
                             normalized_shape, elementwise_affine=elementwise_affine
                         )
                         self.postln_linear = torch.nn.Linear(
@@ -605,6 +594,162 @@ class DistMathOpsTest(DTensorTestBase):
         assert not subtest_fails, (
             f"{len(subtest_fails)}/{len(subtest_cfgs)} subtests failed: {pformat(subtest_fails)}"
         )
+
+    # @with_comms
+    # def test_layer_norm_bwd_req_grad(self):
+    #     device_mesh = self.build_device_mesh()
+    #     batch, seq_len, embedding_dim, vocab_size = 8, 8, 10, 32
+
+    #     # Test both LayerNorm and RMSNorm (if CUDA)
+    #     norm_types = [torch.nn.LayerNorm]
+    #     if self.device_type == "cuda" and hasattr(torch.nn, "RMSNorm"):
+    #         norm_types.append(torch.nn.RMSNorm)
+
+    #     # build our subtest configurations and filter out invalid ones
+    #     class SubTest(NamedTuple):
+    #         norm_type: type
+    #         multidim_norm: bool
+    #         elementwise_affine: bool
+    #         emb_req_grad: bool
+    #         ln_req_grad: bool
+    #         out_req_grad: bool
+
+    #     subtest_fails = {}
+    #     valid_filter = (  # noqa: E731
+    #         lambda cfg: (
+    #             not (cfg.ln_req_grad and not cfg.elementwise_affine) and any(cfg[3:])
+    #         )
+    #     )
+    #     subtest_cfgs = list(
+    #         filter(
+    #             valid_filter,
+    #             [
+    #                 SubTest(norm_type, *cfg)
+    #                 for norm_type in norm_types
+    #                 for cfg in itertools.product(*(((False, True),) * 5))
+    #             ],
+    #         )
+    #     )
+
+    #     for subtest_cfg in subtest_cfgs:
+    #         try:
+    #             (
+    #                 norm_type,
+    #                 multidim_norm,
+    #                 elementwise_affine,
+    #                 emb_req_grad,
+    #                 ln_req_grad,
+    #                 out_req_grad,
+    #             ) = subtest_cfg
+    #             normalized_shape = (
+    #                 (seq_len, embedding_dim) if multidim_norm else (embedding_dim,)
+    #             )
+
+    #             # configure our local and parallelized models for this subtest
+    #             class LnTpBlock(torch.nn.Module):
+    #                 def __init__(self):
+    #                     super().__init__()
+    #                     self.preln_embeddings = torch.nn.Embedding(
+    #                         vocab_size, embedding_dim
+    #                     )
+    #                     self.layer_norm = norm_type(
+    #                         normalized_shape, elementwise_affine=elementwise_affine
+    #                     )
+    #                     self.postln_linear = torch.nn.Linear(
+    #                         embedding_dim, embedding_dim
+    #                     )
+
+    #                 def forward(self, tokens):
+    #                     h = self.preln_embeddings(tokens)
+    #                     h = self.layer_norm(h)
+    #                     output = self.postln_linear(h)
+    #                     return output
+
+    #             parallel_plan = {
+    #                 "preln_embeddings": RowwiseParallel(
+    #                     input_layouts=Replicate(), output_layouts=Shard(1)
+    #                 ),
+    #                 "layer_norm": SequenceParallel(),
+    #                 "postln_linear": ColwiseParallel(
+    #                     input_layouts=Shard(1),
+    #                     output_layouts=Replicate(),
+    #                 ),
+    #             }
+
+    #             model = LnTpBlock()
+    #             model_local = copy.deepcopy(model).to(device=self.device_type)
+    #             model_dist = parallelize_module(model, device_mesh, parallel_plan)
+    #             req_grad_map = {
+    #                 "preln_embeddings": emb_req_grad,
+    #                 "postln_linear": out_req_grad,
+    #                 "layer_norm": ln_req_grad,
+    #             }
+
+    #             # apply the relevant `requires_grad` mask for this subtest to both models
+    #             for target_model in [model_local, model_dist]:
+    #                 for n, p in target_model.named_parameters():
+    #                     if not req_grad_map.get(n.rpartition(".")[0], False):
+    #                         p.requires_grad_(False)
+    #                         assert not p.requires_grad
+    #                     else:
+    #                         assert p.requires_grad
+
+    #             # forward step for both local and distributed models
+    #             x = torch.randint(vocab_size, (batch, seq_len), device=self.device_type)
+    #             x_local = x.detach().clone()
+    #             output_local = model_local(x_local)
+
+    #             with CommDebugMode() as comm_mode:
+    #                 output_dist = model_dist(x)
+
+    #             self.assertEqual(output_local, output_dist)
+
+    #             # all requires_grad patterns should have the same forward comm counts
+    #             expected_fwd_comm = {
+    #                 funcol.reduce_scatter_tensor: 1,
+    #                 funcol.all_gather_into_tensor: 2,
+    #             }
+    #             self.assertDictEqual(
+    #                 comm_mode.comm_module_counts["Global"]["forward"], expected_fwd_comm
+    #             )
+
+    #             # backward step
+    #             output_local.sum().backward()
+
+    #             with CommDebugMode() as comm_mode:
+    #                 output_dist.sum().backward()
+
+    #             # ensure gradients (and parameters) remain equal between local and distributed models
+    #             self._check_module(model_local, model_dist, check_grad=True)
+
+    #             # different requires_grad patterns will have different bwd comm counts
+    #             if out_req_grad and not any((emb_req_grad, ln_req_grad)):
+    #                 expected_bwd_comm = {}
+    #             elif ln_req_grad and not any((emb_req_grad, multidim_norm)):
+    #                 expected_bwd_comm = {funcol.reduce_scatter_tensor: 1}
+    #             elif multidim_norm:
+    #                 expected_bwd_comm = {funcol.all_reduce: 1}
+    #                 expected_bwd_comm[funcol.all_gather_into_tensor] = (
+    #                     2 if emb_req_grad else 1
+    #                 )
+    #             else:
+    #                 expected_bwd_comm = {
+    #                     funcol.reduce_scatter_tensor: 1,
+    #                     funcol.all_gather_into_tensor: 1,
+    #                 }
+
+    #             self.assertDictEqual(
+    #                 comm_mode.comm_module_counts["Global"]["backward"],
+    #                 expected_bwd_comm,
+    #             )
+    #             self.assertEqual(output_local, output_dist)
+
+    #         except Exception as e:
+    #             subtest_fails[subtest_cfg] = e
+    #     # if any subtest fails, provide the failed subtests and report the overall failure
+    #     assert not subtest_fails, (
+    #         f"{len(subtest_fails)}/{len(subtest_cfgs)} subtests failed: {pformat(subtest_fails)}"
+    #     )
 
     @with_comms
     def test_topk(self):

--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -278,9 +278,7 @@ class DistMathOpsTest(DTensorTestBase):
             norm_types.append(torch.nn.RMSNorm)
 
         test_config_list = list(
-            itertools.product(
-                norm_types, shard_dims, norm_shape_idx_list, elementwise_affine_list
-            )
+            itertools.product(norm_types, shard_dims, norm_shape_idx_list, elementwise_affine_list)
         )
 
         # normalized shape is a torch.Size object
@@ -345,9 +343,7 @@ class DistMathOpsTest(DTensorTestBase):
             norm_types.append(torch.nn.RMSNorm)
 
         test_config_list = list(
-            itertools.product(
-                norm_types, shard_dims, norm_shape_idx_list, elementwise_affine_list
-            )
+            itertools.product(norm_types, shard_dims, norm_shape_idx_list, elementwise_affine_list)
         )
 
         # normalized shape is a torch.Size object
@@ -455,8 +451,14 @@ class DistMathOpsTest(DTensorTestBase):
         device_mesh = self.build_device_mesh()
         batch, seq_len, embedding_dim, vocab_size = 8, 8, 10, 32
 
+        # Test both LayerNorm and RMSNorm (if CUDA)
+        norm_types = [torch.nn.LayerNorm]
+        if self.device_type == "cuda" and hasattr(torch.nn, "RMSNorm"):
+            norm_types.append(torch.nn.RMSNorm)
+
         # build our subtest configurations and filter out invalid ones
         class SubTest(NamedTuple):
+            norm_type: type
             multidim_norm: bool
             elementwise_affine: bool
             emb_req_grad: bool
@@ -466,19 +468,21 @@ class DistMathOpsTest(DTensorTestBase):
         subtest_fails = {}
         valid_filter = (  # noqa: E731
             lambda cfg: (
-                not (cfg.ln_req_grad and not cfg.elementwise_affine) and any(cfg[2:])
+                not (cfg.ln_req_grad and not cfg.elementwise_affine) and any(cfg[3:])
             )
         )
         subtest_cfgs = list(
             filter(
                 valid_filter,
-                [SubTest(*cfg) for cfg in itertools.product(*(((False, True),) * 5))],
+                [SubTest(norm_type, *cfg) for norm_type in norm_types
+                 for cfg in itertools.product(*(((False, True),) * 5))],
             )
         )
 
         for subtest_cfg in subtest_cfgs:
             try:
                 (
+                    norm_type,
                     multidim_norm,
                     elementwise_affine,
                     emb_req_grad,
@@ -496,7 +500,7 @@ class DistMathOpsTest(DTensorTestBase):
                         self.preln_embeddings = torch.nn.Embedding(
                             vocab_size, embedding_dim
                         )
-                        self.layer_norm = torch.nn.LayerNorm(
+                        self.layer_norm = norm_type(
                             normalized_shape, elementwise_affine=elementwise_affine
                         )
                         self.postln_linear = torch.nn.Linear(
@@ -595,161 +599,6 @@ class DistMathOpsTest(DTensorTestBase):
             f"{len(subtest_fails)}/{len(subtest_cfgs)} subtests failed: {pformat(subtest_fails)}"
         )
 
-    # @with_comms
-    # def test_layer_norm_bwd_req_grad(self):
-    #     device_mesh = self.build_device_mesh()
-    #     batch, seq_len, embedding_dim, vocab_size = 8, 8, 10, 32
-
-    #     # Test both LayerNorm and RMSNorm (if CUDA)
-    #     norm_types = [torch.nn.LayerNorm]
-    #     if self.device_type == "cuda" and hasattr(torch.nn, "RMSNorm"):
-    #         norm_types.append(torch.nn.RMSNorm)
-
-    #     # build our subtest configurations and filter out invalid ones
-    #     class SubTest(NamedTuple):
-    #         norm_type: type
-    #         multidim_norm: bool
-    #         elementwise_affine: bool
-    #         emb_req_grad: bool
-    #         ln_req_grad: bool
-    #         out_req_grad: bool
-
-    #     subtest_fails = {}
-    #     valid_filter = (  # noqa: E731
-    #         lambda cfg: (
-    #             not (cfg.ln_req_grad and not cfg.elementwise_affine) and any(cfg[3:])
-    #         )
-    #     )
-    #     subtest_cfgs = list(
-    #         filter(
-    #             valid_filter,
-    #             [
-    #                 SubTest(norm_type, *cfg)
-    #                 for norm_type in norm_types
-    #                 for cfg in itertools.product(*(((False, True),) * 5))
-    #             ],
-    #         )
-    #     )
-
-    #     for subtest_cfg in subtest_cfgs:
-    #         try:
-    #             (
-    #                 norm_type,
-    #                 multidim_norm,
-    #                 elementwise_affine,
-    #                 emb_req_grad,
-    #                 ln_req_grad,
-    #                 out_req_grad,
-    #             ) = subtest_cfg
-    #             normalized_shape = (
-    #                 (seq_len, embedding_dim) if multidim_norm else (embedding_dim,)
-    #             )
-
-    #             # configure our local and parallelized models for this subtest
-    #             class LnTpBlock(torch.nn.Module):
-    #                 def __init__(self):
-    #                     super().__init__()
-    #                     self.preln_embeddings = torch.nn.Embedding(
-    #                         vocab_size, embedding_dim
-    #                     )
-    #                     self.layer_norm = norm_type(
-    #                         normalized_shape, elementwise_affine=elementwise_affine
-    #                     )
-    #                     self.postln_linear = torch.nn.Linear(
-    #                         embedding_dim, embedding_dim
-    #                     )
-
-    #                 def forward(self, tokens):
-    #                     h = self.preln_embeddings(tokens)
-    #                     h = self.layer_norm(h)
-    #                     output = self.postln_linear(h)
-    #                     return output
-
-    #             parallel_plan = {
-    #                 "preln_embeddings": RowwiseParallel(
-    #                     input_layouts=Replicate(), output_layouts=Shard(1)
-    #                 ),
-    #                 "layer_norm": SequenceParallel(),
-    #                 "postln_linear": ColwiseParallel(
-    #                     input_layouts=Shard(1),
-    #                     output_layouts=Replicate(),
-    #                 ),
-    #             }
-
-    #             model = LnTpBlock()
-    #             model_local = copy.deepcopy(model).to(device=self.device_type)
-    #             model_dist = parallelize_module(model, device_mesh, parallel_plan)
-    #             req_grad_map = {
-    #                 "preln_embeddings": emb_req_grad,
-    #                 "postln_linear": out_req_grad,
-    #                 "layer_norm": ln_req_grad,
-    #             }
-
-    #             # apply the relevant `requires_grad` mask for this subtest to both models
-    #             for target_model in [model_local, model_dist]:
-    #                 for n, p in target_model.named_parameters():
-    #                     if not req_grad_map.get(n.rpartition(".")[0], False):
-    #                         p.requires_grad_(False)
-    #                         assert not p.requires_grad
-    #                     else:
-    #                         assert p.requires_grad
-
-    #             # forward step for both local and distributed models
-    #             x = torch.randint(vocab_size, (batch, seq_len), device=self.device_type)
-    #             x_local = x.detach().clone()
-    #             output_local = model_local(x_local)
-
-    #             with CommDebugMode() as comm_mode:
-    #                 output_dist = model_dist(x)
-
-    #             self.assertEqual(output_local, output_dist)
-
-    #             # all requires_grad patterns should have the same forward comm counts
-    #             expected_fwd_comm = {
-    #                 funcol.reduce_scatter_tensor: 1,
-    #                 funcol.all_gather_into_tensor: 2,
-    #             }
-    #             self.assertDictEqual(
-    #                 comm_mode.comm_module_counts["Global"]["forward"], expected_fwd_comm
-    #             )
-
-    #             # backward step
-    #             output_local.sum().backward()
-
-    #             with CommDebugMode() as comm_mode:
-    #                 output_dist.sum().backward()
-
-    #             # ensure gradients (and parameters) remain equal between local and distributed models
-    #             self._check_module(model_local, model_dist, check_grad=True)
-
-    #             # different requires_grad patterns will have different bwd comm counts
-    #             if out_req_grad and not any((emb_req_grad, ln_req_grad)):
-    #                 expected_bwd_comm = {}
-    #             elif ln_req_grad and not any((emb_req_grad, multidim_norm)):
-    #                 expected_bwd_comm = {funcol.reduce_scatter_tensor: 1}
-    #             elif multidim_norm:
-    #                 expected_bwd_comm = {funcol.all_reduce: 1}
-    #                 expected_bwd_comm[funcol.all_gather_into_tensor] = (
-    #                     2 if emb_req_grad else 1
-    #                 )
-    #             else:
-    #                 expected_bwd_comm = {
-    #                     funcol.reduce_scatter_tensor: 1,
-    #                     funcol.all_gather_into_tensor: 1,
-    #                 }
-
-    #             self.assertDictEqual(
-    #                 comm_mode.comm_module_counts["Global"]["backward"],
-    #                 expected_bwd_comm,
-    #             )
-    #             self.assertEqual(output_local, output_dist)
-
-    #         except Exception as e:
-    #             subtest_fails[subtest_cfg] = e
-    #     # if any subtest fails, provide the failed subtests and report the overall failure
-    #     assert not subtest_fails, (
-    #         f"{len(subtest_fails)}/{len(subtest_cfgs)} subtests failed: {pformat(subtest_fails)}"
-    #     )
 
     @with_comms
     def test_topk(self):

--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -630,7 +630,7 @@ class DistMathOpsTest(DTensorTestBase):
 
             # TODO: forward pass is sharding strategy is generated from composite, hence 1 more collective than layer_norm
             # see: https://github.com/pytorch/pytorch/pull/158716#issuecomment-3096012679
-            expected_fwd_comm = 0 if shard_dim < norm_idx else 2
+            expected_fwd_comm = 0 if shard_dim < norm_idx else 1
 
             self.assertEqual(
                 sum(comm_mode.comm_module_counts["Global"]["forward"].values()),


### PR DESCRIPTION
Reduces collective calls in the forward pass from 2 to 1

In #158716 I added the sharding rule for the backward pass but didn't add the forward pass as it didn't get dispatched. After #159324 this should get properly dispatched hence I am adding it now.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta