### PR TITLE
Remove accidental host synchronization in autograd cpu offload

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1231,6 +1231,7 @@ CUSTOM_HANDLERS = {
     "test_cuda_primary_ctx": run_test_with_subprocess,
     "test_cuda_nvml_based_avail": run_test_with_subprocess,
     "test_cuda_trace": run_test_with_subprocess,
+    "test_cuda_sync_guard": run_test_with_subprocess,
     "test_cpp_extensions_aot_no_ninja": test_cpp_extensions_aot_no_ninja,
     "test_cpp_extensions_aot_ninja": test_cpp_extensions_aot_ninja,
     "distributed/test_distributed_spawn": test_distributed,

--- a/test/test_cuda_sync_guard.py
+++ b/test/test_cuda_sync_guard.py
@@ -1,0 +1,42 @@
+# Owner(s): ["module: cuda"]
+
+import sys
+import unittest
+
+import torch
+from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_utils import (
+    CudaSyncGuard,
+    NoTest,
+    run_tests,
+    TestCase,
+)
+
+
+# NOTE: this needs to be run in a brand new process
+
+if not TEST_CUDA:
+    print("CUDA not available, skipping tests", file=sys.stderr)
+    TestCase = NoTest  # noqa: F811
+
+
+@unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
+class Test(TestCase):
+    def test_autograd_save_on_cpu_does_not_synchronize(self):
+        a = torch.randn(5, requires_grad=True, device="cuda")
+        b = torch.randn(5, requires_grad=True, device="cuda")
+        c = torch.randn(5, requires_grad=True, device="cuda")
+
+        def f(a, b, c):
+            prod_1 = a * b
+            prod_2 = prod_1 * c
+            y = prod_2 * a
+            return y
+
+        with CudaSyncGuard("error"), torch.autograd.graph.save_on_cpu(pin_memory=True):
+            y = f(a, b, c)
+            y.sum().backward()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -366,13 +366,14 @@ class save_on_cpu(saved_tensors_hooks):
         def pack_to_cpu(tensor: torch.Tensor) -> tuple[torch.device, torch.Tensor]:
             if not pin_memory:
                 return (tensor.device, tensor.cpu())
+            actually_pin_memory = device_module.is_available() and not tensor.is_sparse
             packed = torch.empty(
                 tensor.size(),
                 dtype=tensor.dtype,
                 layout=tensor.layout,
-                pin_memory=(device_module.is_available() and not tensor.is_sparse),
+                pin_memory=actually_pin_memory,
             )
-            packed.copy_(tensor)
+            packed.copy_(tensor, non_blocking=actually_pin_memory)
             return (tensor.device, packed)
 
         def unpack_from_cpu(packed: tuple[torch.device, torch.Tensor]) -> torch.Tensor:


### PR DESCRIPTION
A coworker noticed while working with my draft PR #146924 that `torch.autograd.graph.save_on_cpu` will currently do a device-to-host synchronization after the memcpy after every time you save a tensor to CPU memory in the forward pass. This is obviously a mistake.

Unfortunately, testing is a bit difficult. We can't test for a host synchronization directly via doing cuda graph capture, since cuda stream capture currently does not support pin_memory() calls (my coworker @tingyangk hit this issue becuase he is working on #146924 ), so instead I use CudaSyncGuard. This itself is not perfect because it has a global effect. In order to prevent concurrent test cases that synchronize from crashing, I run this test in its own process.

@Varal7 originally added this in 9beb279d848e9b141027a0f3e395b8329bf1733e, but that was several years ago, and I am not sure that he is active any more and able to review this. I don't think this is very actively used code anyway, but I figured it was worthwhile to provide a fix.

cc @ezyang @albanD @gqchen @nikitaved @soulitzer @Varal7 @xmfan @ptrblck @msaroufim @eqy @jerryzh168