### PR TITLE
Fix typo in parameter name in cpp.py

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -5417,7 +5417,13 @@ class CPUReproTests(TestCase):
 
                 # Verify correctness with explicit samples (should match exactly)
                 torch.testing.assert_close(result, expected, rtol=1e-4, atol=1e-4)
-
+    @config.patch({"emulate_precision_casts": True})
+    def test_to_dtype_use_compute_types(self):
+        x = torch.randn(128, dtype = torch.bfloat16)
+        y = torch.randn(128, dtype = torch.bfloat16)
+        def fn(x, y):
+            return x + y
+        torch.compile(fn)(x, y)
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -15456,14 +15456,7 @@ if RUN_CPU:
                         ret_opt = fn_opt(pytype, dtype)
 
                 self.assertEqual(ret_opt, fn(pytype, dtype))
-def test_to_dtype_use_compute_types():
-    config.emulate_precision_casts=True
-    torch.manual_seed(0)
-    x=torch.randn(128,dtype=torch.bfloat16)
-    y=torch.randn(128,dtype=torch.bfloat16)
-    def fn(x,y):
-        return x+y
-    torch.compile(fn)(x,y)
+
 
 def _strip_tmp_path(code: str) -> str:
     """

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -15456,7 +15456,14 @@ if RUN_CPU:
                         ret_opt = fn_opt(pytype, dtype)
 
                 self.assertEqual(ret_opt, fn(pytype, dtype))
-
+def test_to_dtype_use_compute_types():
+    config.emulate_precision_casts=True
+    torch.manual_seed(0)
+    x=torch.randn(128,dtype=torch.bfloat16)
+    y=torch.randn(128,dtype=torch.bfloat16)
+    def fn(x,y):
+        return x+y
+    torch.compile(fn)(x,y)
 
 def _strip_tmp_path(code: str) -> str:
     """

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -1598,7 +1598,7 @@ class CppVecOverrides(CppOverrides):
         return code
 
     @staticmethod
-    def to_dtype(x, dtype, src_dtype=None, use_compute_dtypes=True):
+    def to_dtype(x, dtype, src_dtype=None, use_compute_types=True):
         assert dtype in [
             torch.bool,
             torch.float64,


### PR DESCRIPTION
Fixes #159239 
This PR fixes a typographical error in "torch/inductor/cpp.py", changing the parameter name from "use_compute_dtypes" to "use_compute_types".
The typo previously caused a runtime error when setting the TORCHINDUCTOR_EMULATE_PRECISION_CASTS=1. This fix ensures the parameter name is correct
This PR includes a unit test to ensure the corrected parameter works properly and prevents regression.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben