### PR TITLE
[Inductor][CUTLASS] Copy cutlass_mock_imports directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1679,6 +1679,8 @@ def main() -> None:
         "_inductor/codegen/*.h",
         "_inductor/codegen/aoti_runtime/*.h",
         "_inductor/codegen/aoti_runtime/*.cpp",
+        "_inductor/codegen/cuda/cutlass_lib_extensions/*.py",
+        "_inductor/codegen/cuda/cutlass_lib_extensions/**/*.py",
         "_inductor/script.ld",
         "_export/serde/*.yaml",
         "_export/serde/*.thrift",

--- a/setup.py
+++ b/setup.py
@@ -1679,8 +1679,6 @@ def main() -> None:
         "_inductor/codegen/*.h",
         "_inductor/codegen/aoti_runtime/*.h",
         "_inductor/codegen/aoti_runtime/*.cpp",
-        "_inductor/codegen/cuda/cutlass_lib_extensions/*.py",
-        "_inductor/codegen/cuda/cutlass_lib_extensions/**/*.py",
         "_inductor/script.ld",
         "_export/serde/*.yaml",
         "_export/serde/*.thrift",

--- a/test/inductor/test_cutlass_backend.py
+++ b/test/inductor/test_cutlass_backend.py
@@ -202,8 +202,8 @@ class TestCutlassBackend(TestCase):
 
     def test_check_paths(self):
         cutlass_mock_imports_path = os.path.join(
-                os.path.dirname(torch.__file__),
-                "_inductor/codegen/cuda/cutlass_lib_extensions/cutlass_mock_imports"
+            os.path.dirname(torch.__file__),
+            "_inductor/codegen/cuda/cutlass_lib_extensions/cutlass_mock_imports",
         )
         cutlass_mock_cuda_path = os.path.join(cutlass_mock_imports_path, "cuda")
         cutlass_mock_pydot_path = os.path.join(cutlass_mock_imports_path, "pydot")

--- a/test/inductor/test_cutlass_backend.py
+++ b/test/inductor/test_cutlass_backend.py
@@ -200,6 +200,19 @@ class TestCutlassBackend(TestCase):
         )
         torch.testing.assert_close(result, ref_result)
 
+    def test_check_paths(self):
+        cutlass_mock_imports_path = os.path.join(
+                os.path.dirname(torch.__file__),
+                "_inductor/codegen/cuda/cutlass_lib_extensions/cutlass_mock_imports"
+        )
+        cutlass_mock_cuda_path = os.path.join(cutlass_mock_imports_path, "cuda")
+        cutlass_mock_pydot_path = os.path.join(cutlass_mock_imports_path, "pydot")
+        cutlass_mock_scipy_path = os.path.join(cutlass_mock_imports_path, "scipy")
+        self.assertTrue(os.path.exists(cutlass_mock_imports_path))
+        self.assertTrue(os.path.exists(cutlass_mock_cuda_path))
+        self.assertTrue(os.path.exists(cutlass_mock_pydot_path))
+        self.assertTrue(os.path.exists(cutlass_mock_scipy_path))
+
     @unittest.skipIf(not SM90OrLater, "need sm_90")
     @mock.patch.dict(os.environ, {"PATH": _get_path_without_sccache()})
     def test_max_autotune_cutlass_threshold(self):


### PR DESCRIPTION
Pip wheels of PyTorch nightly and 2.8 release candidates do not contain `cutlass_mock_imports`.

This is the path to the source code:
```
root@8120d02fd9c5:$ tree ./torch/_inductor/codegen/cuda/cutlass_lib_extensions/ 
./torch/_inductor/codegen/cuda/cutlass_lib_extensions/
├── cutlass_mock_imports
│   ├── cuda
│   │   ├── __init__.py
│   │   ├── cuda.py
│   │   └── cudart.py
│   ├── pydot
│   │   └── __init__.py
│   └── scipy
│       ├── __init__.py
│       └── special.py
├── evt_extensions.py
└── gemm_operation_extensions.py

5 directories, 8 files
```


And this what installed wheel has:
```
root@8120d02fd9c5:$ tree /usr/local/lib/python3.12/dist-packages/torch/_inductor/codegen/cuda/cutlass_lib_extensions/
/usr/local/lib/python3.12/dist-packages/torch/_inductor/codegen/cuda/cutlass_lib_extensions/
├── __init__.py
├── evt_extensions.py
└── gemm_operation_extensions.py

1 directory, 3 files
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben