### PR TITLE
Use uv run for lintrunner Python deps

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -30,26 +30,11 @@ exclude_patterns = [
     'tools/test/test_selective_build.py',
 ]
 command = [
-    'python3',
+    'uv',
+    'run',
     'tools/linter/adapters/flake8_linter.py',
     '--',
     '@{{PATHSFILE}}'
-]
-init_command = [
-    'python3',
-    'tools/linter/adapters/pip_init.py',
-    '--dry-run={{DRYRUN}}',
-    'flake8==7.3.0',
-    'flake8-bugbear==24.12.12',
-    'flake8-comprehensions==3.16.0',
-    'flake8-executable==2.1.3',
-    'flake8-logging-format==2024.24.12',
-    'flake8-pyi==25.5.0',
-    'flake8-simplify==0.22.0',
-    'mccabe==0.7.0',
-    'pycodestyle==2.14.0',
-    'pyflakes==3.4.0',
-    'torchfix==0.4.0 ; python_version >= "3.9" and python_version < "3.13"',
 ]
 
 
@@ -142,35 +127,12 @@ exclude_patterns = [
     '**/fb/**',
 ]
 command = [
-    'python3',
+    'uv',
+    'run',
     'tools/linter/adapters/mypy_linter.py',
     '--config=mypy.ini',
     '--',
     '@{{PATHSFILE}}'
-]
-init_command = [
-    'python3',
-    'tools/linter/adapters/pip_init.py',
-    '--dry-run={{DRYRUN}}',
-    'numpy==1.26.4 ; python_version >= "3.9" and python_version <= "3.11"',
-    'numpy==2.1.0 ; python_version >= "3.12"',
-    'expecttest==0.3.0',
-    'mypy==1.16.0',
-    'sympy==1.13.3',
-    'types-requests==2.27.25',
-    'types-pyyaml==6.0.2',
-    'types-tabulate==0.8.8',
-    'types-protobuf==5.29.1.20250403',
-    'types-setuptools==79.0.0.20250422',
-    'types-jinja2==2.11.9',
-    'types-colorama==0.4.6',
-    'filelock==3.18.0',
-    'junitparser==2.1.1',
-    'rich==14.1.0',
-    'pyyaml==6.0.2',
-    'optree==0.13.0',
-    'dataclasses-json==0.6.7',
-    'pandas==2.2.3',
 ]
 
 [[linter]]
@@ -374,15 +336,10 @@ command = [
 code = 'NATIVEFUNCTIONS'
 include_patterns=['aten/src/ATen/native/native_functions.yaml']
 command = [
-    'python3',
+    'uv',
+    'run',
     'tools/linter/adapters/nativefunctions_linter.py',
     '--native-functions-yml=aten/src/ATen/native/native_functions.yaml',
-]
-init_command = [
-    'python3',
-    'tools/linter/adapters/pip_init.py',
-    '--dry-run={{DRYRUN}}',
-    'ruamel.yaml==0.18.10',
 ]
 is_formatter = true
 
@@ -390,16 +347,11 @@ is_formatter = true
 code = 'GHA'
 include_patterns=['.github/workflows/**/*.yml']
 command = [
-    'python3',
+    'uv',
+    'run',
     'tools/linter/adapters/gha_linter.py',
     '--',
     '@{{PATHSFILE}}'
-]
-init_command = [
-    'python3',
-    'tools/linter/adapters/pip_init.py',
-    '--dry-run={{DRYRUN}}',
-    'ruamel.yaml==0.18.10',
 ]
 
 [[linter]]
@@ -871,17 +823,12 @@ exclude_patterns = [
     '**/fb/**',
 ]
 command = [
-    'python3',
+    'uv',
+    'run',
     'tools/linter/adapters/cmake_linter.py',
     '--config=.cmakelintrc',
     '--',
     '@{{PATHSFILE}}',
-]
-init_command = [
-    'python3',
-    'tools/linter/adapters/pip_init.py',
-    '--dry-run={{DRYRUN}}',
-    'cmakelint==1.4.1',
 ]
 
 [[linter]]
@@ -893,16 +840,11 @@ exclude_patterns = [
     '**/fb/**',
 ]
 command = [
-    'python3',
+    'uv',
+    'run',
     'tools/linter/adapters/shellcheck_linter.py',
     '--',
     '@{{PATHSFILE}}',
-]
-init_command = [
-    'python3',
-    'tools/linter/adapters/pip_init.py',
-    '--dry-run={{DRYRUN}}',
-    'shellcheck-py==0.7.2.1',
 ]
 
 [[linter]]
@@ -1102,16 +1044,11 @@ include_patterns = [
     '.github/workflows/slow.yml',
 ]
 command = [
-    'python3',
+    'uv',
+    'run',
     'tools/linter/adapters/workflow_consistency_linter.py',
     '--',
     '@{{PATHSFILE}}'
-]
-init_command = [
-    'python3',
-    'tools/linter/adapters/pip_init.py',
-    '--dry-run={{DRYRUN}}',
-    'pyyaml==6.0.2',
 ]
 
 [[linter]]
@@ -1124,22 +1061,18 @@ exclude_patterns = [
     '**/fb/**',
 ]
 command = [
-    'python3',
+    'uv',
+    'run',
     'tools/linter/adapters/no_workflows_on_fork.py',
     '--',
     '@{{PATHSFILE}}',
-]
-init_command = [
-    'python3',
-    'tools/linter/adapters/pip_init.py',
-    '--dry-run={{DRYRUN}}',
-    'pyyaml==6.0.2',
 ]
 
 [[linter]]
 code = 'CODESPELL'
 command = [
-    'python3',
+    'uv',
+    'run',
     'tools/linter/adapters/codespell_linter.py',
     '--',
     '@{{PATHSFILE}}'
@@ -1166,12 +1099,6 @@ exclude_patterns = [
     'aten/src/ATen/[a-mA-M]*/**',
     'test/**',
 ]
-init_command = [
-    'python3',
-    'tools/linter/adapters/pip_init.py',
-    '--dry-run={{DRYRUN}}',
-    'codespell[toml]==2.4.1',
-]
 is_formatter = true
 
 # usort + ruff-format
@@ -1182,7 +1109,8 @@ include_patterns = [
     '**/*.pyi',
 ]
 command = [
-    'python3',
+    'uv',
+    'run',
     'tools/linter/adapters/pyfmt_linter.py',
     '--',
     '@{{PATHSFILE}}'
@@ -1448,22 +1376,13 @@ exclude_patterns = [
     'torch/utils/viz/__init__.py',
     'torch/utils/viz/_cycles.py',
 ]
-init_command = [
-    'python3',
-    'tools/linter/adapters/pip_init.py',
-    '--dry-run={{DRYRUN}}',
-    '--no-black-binary',
-    'black==23.12.1',
-    'usort==1.0.8.post1',
-    'isort==6.0.1',
-    'ruff==0.12.2',  # sync with RUFF
-]
 is_formatter = true
 
 [[linter]]
 code = 'PYPROJECT'
 command = [
-    'python3',
+    'uv',
+    'run',
     'tools/linter/adapters/pyproject_linter.py',
     '--',
     '@{{PATHSFILE}}'
@@ -1471,18 +1390,12 @@ command = [
 include_patterns = [
     "**/pyproject.toml",
 ]
-init_command = [
-    'python3',
-    'tools/linter/adapters/pip_init.py',
-    '--dry-run={{DRYRUN}}',
-    'packaging==25.0',
-    'tomli==2.2.1 ; python_version < "3.11"',
-]
 
 [[linter]]
 code = 'CMAKE_MINIMUM_REQUIRED'
 command = [
-    'python3',
+    'uv',
+    'run',
     'tools/linter/adapters/cmake_minimum_required_linter.py',
     '--',
     '@{{PATHSFILE}}'
@@ -1495,13 +1408,6 @@ include_patterns = [
     "**/*.cmake.in",
     "**/*requirements*.txt",
     "**/*requirements*.in",
-]
-init_command = [
-    'python3',
-    'tools/linter/adapters/pip_init.py',
-    '--dry-run={{DRYRUN}}',
-    'packaging==25.0',
-    'tomli==2.2.1 ; python_version < "3.11"',
 ]
 
 [[linter]]
@@ -1580,18 +1486,13 @@ exclude_patterns = [
     '**/fb/**',
 ]
 command = [
-    'python3',
+    'uv',
+    'run',
     'tools/linter/adapters/ruff_linter.py',
     '--config=pyproject.toml',
     '--show-disable',
     '--',
     '@{{PATHSFILE}}'
-]
-init_command = [
-    'python3',
-    'tools/linter/adapters/pip_init.py',
-    '--dry-run={{DRYRUN}}',
-    'ruff==0.12.2',  # sync with PYFMT
 ]
 is_formatter = true
 

--- a/tools/linter/adapters/cmake_linter.py
+++ b/tools/linter/adapters/cmake_linter.py
@@ -1,3 +1,9 @@
+# /// script
+# dependencies = [
+#   "cmakelint==1.4.1",
+# ]
+# ///
+
 from __future__ import annotations
 
 import argparse

--- a/tools/linter/adapters/cmake_minimum_required_linter.py
+++ b/tools/linter/adapters/cmake_minimum_required_linter.py
@@ -1,3 +1,10 @@
+# /// script
+# dependencies = [
+#   "packaging==25.0",
+#   "tomli==2.2.1 ; python_version < '3.11'",
+# ]
+# ///
+
 from __future__ import annotations
 
 import argparse

--- a/tools/linter/adapters/codespell_linter.py
+++ b/tools/linter/adapters/codespell_linter.py
@@ -1,3 +1,9 @@
+ # /// script
+# dependencies = [
+#   "codespell[toml]==2.4.1",
+# ]
+# ///
+
 from __future__ import annotations
 
 import argparse

--- a/tools/linter/adapters/flake8_linter.py
+++ b/tools/linter/adapters/flake8_linter.py
@@ -1,4 +1,18 @@
-from __future__ import annotations
+ # /// script
+# dependencies = [
+#   "flake8==7.3.0",
+#   "flake8-bugbear==24.12.12",
+#   "flake8-comprehensions==3.16.0",
+#   "flake8-executable==2.1.3",
+#   "flake8-logging-format==2024.24.12",
+#   "flake8-pyi==25.5.0",
+#   "flake8-simplify==0.22.0",
+#   "mccabe==0.7.0",
+#   "pycodestyle==2.14.0",
+#   "pyflakes==3.4.0",
+#   "torchfix==0.4.0 ; python_version >= '3.9' and python_version < '3.13'",
+# ]
+# ///
 
 import argparse
 import json

--- a/tools/linter/adapters/gha_linter.py
+++ b/tools/linter/adapters/gha_linter.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+# /// script
+# dependencies = [
+#   "ruamel.yaml==0.18.10",
+# ]
+# ///
 """
 TODO
 """

--- a/tools/linter/adapters/lintrunner_version_linter.py
+++ b/tools/linter/adapters/lintrunner_version_linter.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
             name="command-failed",
             original=None,
             replacement=None,
-            description="Lintrunner is not installed, did you forget to run `make setup-lint && make lint`?",
+            description="Lintrunner is not installed; try `uv run lintrunner`.",
         )
         sys.exit(0)
 

--- a/tools/linter/adapters/mypy_linter.py
+++ b/tools/linter/adapters/mypy_linter.py
@@ -1,3 +1,27 @@
+# /// script
+# dependencies = [
+#   "numpy==1.26.4 ; python_version >= '3.9' and python_version <= '3.11'",
+#   "numpy==2.1.0 ; python_version >= '3.12'",
+#   "expecttest==0.3.0",
+#   "mypy==1.16.0",
+#   "sympy==1.13.3",
+#   "types-requests==2.27.25",
+#   "types-pyyaml==6.0.2",
+#   "types-tabulate==0.8.8",
+#   "types-protobuf==5.29.1.20250403",
+#   "types-setuptools==79.0.0.20250422",
+#   "types-jinja2==2.11.9",
+#   "types-colorama==0.4.6",
+#   "filelock==3.18.0",
+#   "junitparser==2.1.1",
+#   "rich==14.1.0",
+#   "pyyaml==6.0.2",
+#   "optree==0.13.0",
+#   "dataclasses-json==0.6.7",
+#   "pandas==2.2.3",
+# ]
+# ///
+
 from __future__ import annotations
 
 import argparse

--- a/tools/linter/adapters/nativefunctions_linter.py
+++ b/tools/linter/adapters/nativefunctions_linter.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+# /// script
+# dependencies = [
+#   "ruamel.yaml==0.18.10",
+# ]
+# ///
 """
 Verify that it is possible to round-trip native_functions.yaml via ruamel under some
 configuration.  Keeping native_functions.yaml consistent in this way allows us to

--- a/tools/linter/adapters/no_workflows_on_fork.py
+++ b/tools/linter/adapters/no_workflows_on_fork.py
@@ -1,3 +1,10 @@
+# /// script
+# dependencies = [
+#   "pyyaml==6.0.2",
+#   "types-PyYAML==6.0.2",
+# ]
+# ///
+
 """
 This a linter that ensures that jobs that can be triggered by push,
 pull_request, or schedule will check if the repository owner is 'pytorch'.  This
@@ -24,7 +31,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, NamedTuple, Optional
 
-from yaml import load
+import yaml  # type: ignore[import-untyped]
 
 
 # Safely load fast C Yaml loader/dumper if they are available
@@ -55,7 +62,7 @@ class LintMessage(NamedTuple):
 
 def load_yaml(path: Path) -> Any:
     with open(path) as f:
-        return load(f, Loader)
+        return yaml.load(f, Loader)
 
 
 def gen_lint_message(

--- a/tools/linter/adapters/pyfmt_linter.py
+++ b/tools/linter/adapters/pyfmt_linter.py
@@ -1,3 +1,12 @@
+# /// script
+# dependencies = [
+#   "black==23.12.1",
+#   "usort==1.0.8.post1",
+#   "isort==6.0.1",
+#   "ruff==0.12.2",
+# ]
+# ///
+
 from __future__ import annotations
 
 import argparse
@@ -11,7 +20,7 @@ import subprocess
 import sys
 from enum import Enum
 from pathlib import Path
-from typing import NamedTuple
+from typing import NamedTuple, cast
 
 import black
 import isort
@@ -114,8 +123,7 @@ def run_isort(content: str, path: Path) -> str:
 
 def run_usort(content: str, path: Path) -> str:
     usort_config = usort.Config.find(path)
-
-    return usort.usort_string(content, path=path, config=usort_config)
+    return cast(str, usort.usort_string(content, path=path, config=usort_config))
 
 
 def run_black(content: str, path: Path) -> str:

--- a/tools/linter/adapters/pyproject_linter.py
+++ b/tools/linter/adapters/pyproject_linter.py
@@ -1,3 +1,10 @@
+# /// script
+# dependencies = [
+#   "packaging==25.0",
+#   "tomli==2.2.1 ; python_version < '3.11'",
+# ]
+# ///
+
 from __future__ import annotations
 
 import argparse

--- a/tools/linter/adapters/ruff_linter.py
+++ b/tools/linter/adapters/ruff_linter.py
@@ -1,5 +1,11 @@
 """Adapter for https://github.com/charliermarsh/ruff."""
 
+# /// script
+# dependencies = [
+#   "ruff==0.12.2",
+# ]
+# ///
+
 from __future__ import annotations
 
 import argparse

--- a/tools/linter/adapters/shellcheck_linter.py
+++ b/tools/linter/adapters/shellcheck_linter.py
@@ -1,3 +1,9 @@
+# /// script
+# dependencies = [
+#   "shellcheck-py==0.7.2.1",
+# ]
+# ///
+
 from __future__ import annotations
 
 import argparse
@@ -108,7 +114,7 @@ if __name__ == "__main__":
             name="command-failed",
             original=None,
             replacement=None,
-            description="shellcheck is not installed, did you forget to run `lintrunner init`?",
+            description="shellcheck is not installed; try `uv run tools/linter/adapters/shellcheck_linter.py`",
         )
         print(json.dumps(err_msg._asdict()), flush=True)
         sys.exit(0)

--- a/tools/linter/adapters/workflow_consistency_linter.py
+++ b/tools/linter/adapters/workflow_consistency_linter.py
@@ -1,3 +1,10 @@
+# /// script
+# dependencies = [
+#   "pyyaml==6.0.2",
+#   "types-PyYAML==6.0.2",
+# ]
+# ///
+
 """Checks for consistency of jobs between different GitHub workflows.
 
 Any job with a specific `sync-tag` must match all other jobs with the same `sync-tag`.
@@ -13,7 +20,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, NamedTuple, TYPE_CHECKING
 
-from yaml import dump, load
+import yaml  # type: ignore[import-untyped]
 
 
 if TYPE_CHECKING:
@@ -52,7 +59,7 @@ def glob_yamls(path: Path) -> Iterable[Path]:
 
 def load_yaml(path: Path) -> Any:
     with open(path) as f:
-        return load(f, Loader)
+        return yaml.load(f, Loader)
 
 
 def is_workflow(yaml: Any) -> bool:
@@ -119,12 +126,12 @@ if __name__ == "__main__":
     # For each sync tag, check that all the jobs have the same code.
     for sync_tag, path_and_jobs in tag_to_jobs.items():
         baseline_path, baseline_dict = path_and_jobs.pop()
-        baseline_str = dump(baseline_dict)
+        baseline_str = yaml.dump(baseline_dict)
 
         printed_baseline = False
 
         for path, job_dict in path_and_jobs:
-            job_str = dump(job_dict)
+            job_str = yaml.dump(job_dict)
             if baseline_str != job_str:
                 print_lint_message(path, job_dict, sync_tag)
 


### PR DESCRIPTION
I asked Codex to whip up the proof of concept. The idea is to make use of uv's anonymous venvs instead of forcing everything to be installed in the current venv, which is helpful when you are working on multiple projects which have different pins for various formatting tools (hi autoparallel). If people like the idea I'll clean it up and land it.

## Summary
- use `uv run` in lintrunner config to invoke Python linters without a prior `lintrunner init`
- declare per-script dependencies via inline metadata so `uv` installs them on demand
- clean up ShellCheck adapter message now that `lintrunner init` is not required
- mention `uv run` in fallback messages when lintrunner or shellcheck are missing

## Testing
- `lintrunner tools/linter/adapters/no_workflows_on_fork.py tools/linter/adapters/workflow_consistency_linter.py` *(fails: Failed to fetch `https://pypi.org/simple/ruff/`)*

------
https://chatgpt.com/codex/tasks/task_e_688f81faeae48323a3aa0c7ac1cd452c