### PR TITLE
Docs/remove setuppy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ source venv/bin/activate  # or `& .\venv\Scripts\Activate.ps1` on Windows
 * If you run into errors when running `python -m pip install -e . -v --no-build-isolation`, here are some debugging steps:
   1. Run `printf '#include <stdio.h>\nint main() { printf("Hello World");}'|clang -x c -; ./a.out` to make sure
   your CMake works and can compile this simple Hello World program without errors.
-  2. Nuke your `build` directory. The `python -m pip install --no-build-isolation -v -e .` build step compiles binaries into the `build` folder and caches many
+  2. Nuke your `build` directory. The build process compiles binaries into the `build` folder and caches many
   details along the way, which saves time the next time you build. If you're running into issues, you can always
   `rm -rf build` from the toplevel `pytorch` directory and start over.
   3. If you have made edits to the PyTorch repo, commit any change you'd like to keep and clean the repo with the
@@ -248,7 +248,7 @@ dependencies as well as the nightly binaries into the repo directory.
   frontend module structure.
   * [csrc](torch/csrc) - C++ files composing the PyTorch library. Files
     in this directory tree are a mix of Python binding code, and C++
-    heavy lifting. Consult `CMakeLists.txt` for the canonical list of Python
+    heavy lifting. Consult `setup.py` or `pyproject.toml` for the canonical list of Python
     binding files; conventionally, they are often prefixed with
     `python_`. [README](torch/csrc/README.md)
     * [jit](torch/csrc/jit) - Compiler and frontend for TorchScript JIT
@@ -1260,7 +1260,7 @@ are Caffe2/PyTorch specific. Here they are:
   `scripts` are Caffe2-specific. Don't put PyTorch code in them without
   extra coordination.
 
-- `mypy*`, `requirements.txt`, `pyproject.toml`, `test`, `tools` are
+- `mypy*`, `requirements.txt`, `setup.py`, `pyproject.toml`, `test`, `tools` are
   PyTorch-specific. Don't put Caffe2 code in them without extra
   coordination.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,7 @@ source venv/bin/activate  # or `& .\venv\Scripts\Activate.ps1` on Windows
   pip uninstall torch
   ```
 
-  Next run `rm -rf build/ torch*.egg-info dist/ && git clean -xfd`. After that, you can install in editable mode again.
+  Next run `rm -rf build/ && git clean -xfd`. After that, you can install in editable mode again.
 
 * If you run into errors when running `python -m pip install -e . -v --no-build-isolation`, here are some debugging steps:
   1. Run `printf '#include <stdio.h>\nint main() { printf("Hello World");}'|clang -x c -; ./a.out` to make sure
@@ -127,7 +127,7 @@ source venv/bin/activate  # or `& .\venv\Scripts\Activate.ps1` on Windows
       ```bash
       git submodule deinit -f .
       git clean -xdf
-      rm -rf build/ torch*.egg-info dist/
+      rm -rf build/ 
       git submodule update --init --recursive
       python -m pip install --group dev
       python -m pip install --no-build-isolation -v -e .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,12 +114,12 @@ source venv/bin/activate  # or `& .\venv\Scripts\Activate.ps1` on Windows
   pip uninstall torch
   ```
 
-  Next run `rm -rf build/ && git clean -xfd`. After that, you can install in editable mode again.
+  Next run `python setup.py clean`. After that, you can install in editable mode again.
 
 * If you run into errors when running `python -m pip install -e . -v --no-build-isolation`, here are some debugging steps:
   1. Run `printf '#include <stdio.h>\nint main() { printf("Hello World");}'|clang -x c -; ./a.out` to make sure
   your CMake works and can compile this simple Hello World program without errors.
-  2. Nuke your `build` directory. The build process compiles binaries into the `build` folder and caches many
+  2. Nuke your `build` directory. The `setup.py` script compiles binaries into the `build` folder and caches many
   details along the way, which saves time the next time you build. If you're running into issues, you can always
   `rm -rf build` from the toplevel `pytorch` directory and start over.
   3. If you have made edits to the PyTorch repo, commit any change you'd like to keep and clean the repo with the
@@ -248,7 +248,7 @@ dependencies as well as the nightly binaries into the repo directory.
   frontend module structure.
   * [csrc](torch/csrc) - C++ files composing the PyTorch library. Files
     in this directory tree are a mix of Python binding code, and C++
-    heavy lifting. Consult `setup.py` or `pyproject.toml` for the canonical list of Python
+    heavy lifting. Consult `setup.py` for the canonical list of Python
     binding files; conventionally, they are often prefixed with
     `python_`. [README](torch/csrc/README.md)
     * [jit](torch/csrc/jit) - Compiler and frontend for TorchScript JIT
@@ -734,7 +734,7 @@ information for the code in `torch/csrc`. More information at:
 By default, cmake will use its Makefile generator to generate your build
 system.  You can get faster builds if you install the ninja build system
 with `pip install ninja`.  If PyTorch was already built, you will need
-to run `rm -rf build/` once after installing ninja for builds to
+to run `python setup.py clean` once after installing ninja for builds to
 succeed.
 
 Note: Make sure to use a machine with a larger number of CPU cores, this will significantly reduce your build times.
@@ -775,7 +775,7 @@ Each of these 3 variables should contain ccache, e.g.
 CMAKE_CXX_COMPILER_LAUNCHER:STRING=/usr/bin/ccache
 ```
 
-If not, you can define these variables on the command line before running `python -m pip install --no-build-isolation -v -e .`.
+If not, you can define these variables on the command line before invoking `setup.py`.
 
 ```bash
 export CMAKE_C_COMPILER_LAUNCHER=ccache
@@ -1260,7 +1260,7 @@ are Caffe2/PyTorch specific. Here they are:
   `scripts` are Caffe2-specific. Don't put PyTorch code in them without
   extra coordination.
 
-- `mypy*`, `requirements.txt`, `setup.py`, `pyproject.toml`, `test`, `tools` are
+- `mypy*`, `requirements.txt`, `setup.py`, `test`, `tools` are
   PyTorch-specific. Don't put Caffe2 code in them without extra
   coordination.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,12 +114,12 @@ source venv/bin/activate  # or `& .\venv\Scripts\Activate.ps1` on Windows
   pip uninstall torch
   ```
 
-  Next run `python setup.py clean`. After that, you can install in editable mode again.
+  Next run `rm -rf build/ torch*.egg-info dist/ && git clean -xfd`. After that, you can install in editable mode again.
 
 * If you run into errors when running `python -m pip install -e . -v --no-build-isolation`, here are some debugging steps:
   1. Run `printf '#include <stdio.h>\nint main() { printf("Hello World");}'|clang -x c -; ./a.out` to make sure
   your CMake works and can compile this simple Hello World program without errors.
-  2. Nuke your `build` directory. The `setup.py` script compiles binaries into the `build` folder and caches many
+  2. Nuke your `build` directory. The `python -m pip install --no-build-isolation -v -e .` build step compiles binaries into the `build` folder and caches many
   details along the way, which saves time the next time you build. If you're running into issues, you can always
   `rm -rf build` from the toplevel `pytorch` directory and start over.
   3. If you have made edits to the PyTorch repo, commit any change you'd like to keep and clean the repo with the
@@ -127,7 +127,7 @@ source venv/bin/activate  # or `& .\venv\Scripts\Activate.ps1` on Windows
       ```bash
       git submodule deinit -f .
       git clean -xdf
-      python setup.py clean
+      rm -rf build/ torch*.egg-info dist/
       git submodule update --init --recursive
       python -m pip install --group dev
       python -m pip install --no-build-isolation -v -e .
@@ -248,7 +248,7 @@ dependencies as well as the nightly binaries into the repo directory.
   frontend module structure.
   * [csrc](torch/csrc) - C++ files composing the PyTorch library. Files
     in this directory tree are a mix of Python binding code, and C++
-    heavy lifting. Consult `setup.py` for the canonical list of Python
+    heavy lifting. Consult `CMakeLists.txt` for the canonical list of Python
     binding files; conventionally, they are often prefixed with
     `python_`. [README](torch/csrc/README.md)
     * [jit](torch/csrc/jit) - Compiler and frontend for TorchScript JIT
@@ -683,7 +683,7 @@ will want to keep in mind:
 
 ### Build only what you need
 
-`python setup.py build` will build everything by default, but sometimes you are
+`python -m pip install --no-build-isolation -v -e .` will build everything by default, but sometimes you are
 only interested in a specific component.
 
 - Working on a test binary? Run `(cd build && ninja bin/test_binary_name)` to
@@ -734,7 +734,7 @@ information for the code in `torch/csrc`. More information at:
 By default, cmake will use its Makefile generator to generate your build
 system.  You can get faster builds if you install the ninja build system
 with `pip install ninja`.  If PyTorch was already built, you will need
-to run `python setup.py clean` once after installing ninja for builds to
+to run `rm -rf build/` once after installing ninja for builds to
 succeed.
 
 Note: Make sure to use a machine with a larger number of CPU cores, this will significantly reduce your build times.
@@ -775,7 +775,7 @@ Each of these 3 variables should contain ccache, e.g.
 CMAKE_CXX_COMPILER_LAUNCHER:STRING=/usr/bin/ccache
 ```
 
-If not, you can define these variables on the command line before invoking `setup.py`.
+If not, you can define these variables on the command line before running `python -m pip install --no-build-isolation -v -e .`.
 
 ```bash
 export CMAKE_C_COMPILER_LAUNCHER=ccache
@@ -1260,7 +1260,7 @@ are Caffe2/PyTorch specific. Here they are:
   `scripts` are Caffe2-specific. Don't put PyTorch code in them without
   extra coordination.
 
-- `mypy*`, `requirements.txt`, `setup.py`, `test`, `tools` are
+- `mypy*`, `requirements.txt`, `pyproject.toml`, `test`, `tools` are
   PyTorch-specific. Don't put Caffe2 code in them without extra
   coordination.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,6 @@ source venv/bin/activate  # or `& .\venv\Scripts\Activate.ps1` on Windows
       ```bash
       git submodule deinit -f .
       git clean -xdf
-      rm -rf build/ 
       git submodule update --init --recursive
       python -m pip install --group dev
       python -m pip install --no-build-isolation -v -e .


### PR DESCRIPTION
Fixes #159234. If you have a substitute for python setup.py clean, I can add in the PR. 
