### PR TITLE
Add binary size check to validate current limits for binaries released to pypi

### DIFF
--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -106,6 +106,15 @@ if [[ "\$GPU_ARCH_TYPE" != *s390x* && "\$GPU_ARCH_TYPE" != *xpu* && "\$GPU_ARCH_
     # https://github.com/pytorch/pytorch/issues/149422
     python /pytorch/.ci/pytorch/smoke_test/check_gomp.py
   fi
+
+  # Check if package size exceeds the limit
+  if[[ "\$DESIRED_CUDA" == *cu* ]]; then
+    MAX_BIN_SIZE=$(python /pytorch/.github/scripts/get_ci_variable.py --get-bin-size "linux-${DESIRED_CUDA}")
+    if [[ "\$torch_pkg_size" -gt \$MAX_BIN_SIZE ]]; then
+      echo "ERROR: package exceeds the limit of \$MAX_BIN_SIZE bytes"
+      exit 1
+    fi
+  fi
 fi
 
 # Clean temp files

--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -40,6 +40,14 @@ CPU_S390X_ARCH = ["cpu-s390x"]
 
 CUDA_AARCH64_ARCHES = ["12.9-aarch64"]
 
+# current binary limits for each platform released to PyPI
+BINARY_LIMITS = {
+     "linux-cu128": 860000000,
+     "linux-cu129": 1200000000,
+     "windows-cpu": 250000000,
+     "linux-aarch64-cpu": 120000000,
+     "macos": 90000000
+}
 
 PYTORCH_EXTRA_INSTALL_REQUIREMENTS = {
     "12.6": (

--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -42,11 +42,11 @@ CUDA_AARCH64_ARCHES = ["12.9-aarch64"]
 
 # current binary limits for each platform released to PyPI
 BINARY_LIMITS = {
-     "linux-cu128": 860000000,
-     "linux-cu129": 1200000000,
-     "windows-cpu": 250000000,
-     "linux-aarch64-cpu": 120000000,
-     "macos": 90000000
+    "linux-cu128": 860000000,
+    "linux-cu129": 1200000000,
+    "windows-cpu": 250000000,
+    "linux-aarch64-cpu": 120000000,
+    "macos": 90000000,
 }
 
 PYTORCH_EXTRA_INSTALL_REQUIREMENTS = {

--- a/.github/scripts/get_ci_variable.py
+++ b/.github/scripts/get_ci_variable.py
@@ -31,7 +31,7 @@ def main(args: list[str]) -> None:
         return print(generate_binary_build_matrix.CUDA_STABLE)
     if options.min_python_version:
         return print(generate_binary_build_matrix.FULL_PYTHON_VERSIONS[0])
-    if options.get_bin_size !=:
+    if options.get_bin_size != "":
         return print(generate_binary_build_matrix.BINARY_LIMITS[options.get_bin_size])
 
 

--- a/.github/scripts/get_ci_variable.py
+++ b/.github/scripts/get_ci_variable.py
@@ -19,11 +19,20 @@ def main(args: list[str]) -> None:
         action="store_true",
         help="get min supported python version",
     )
+    parser.add_argument(
+        "--get-bin-size",
+        type=str,
+        help="linux-cu128, linux-cu129, linux-aarch64-cpu, windows-cpu, macos",
+        default="",
+    )
+
     options = parser.parse_args(args)
     if options.cuda_stable_version:
         return print(generate_binary_build_matrix.CUDA_STABLE)
     if options.min_python_version:
         return print(generate_binary_build_matrix.FULL_PYTHON_VERSIONS[0])
+    if options.get_bin_size !=:
+        return print(generate_binary_build_matrix.BINARY_LIMITS[options.get_bin_size])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adding check in linux binary validations, trying to mitigate binary size increase for binaries released to pypi:

Reference issues:
2.7.0: https://github.com/pytorch/pytorch/issues/150647
2.8.0: https://github.com/pytorch/pytorch/issues/159515

Trying to mitigate:
https://github.com/pytorch/pytorch/issues/159516