### PR TITLE
[ROCm] Fix Sliding Window Attention in AOTriton integration code

### DIFF
--- a/aten/src/ATen/native/transformers/hip/flash_attn/aot/mha_all_aot.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/aot/mha_all_aot.hip
@@ -275,7 +275,7 @@ mha_fwd_aot(const at::Tensor &q,         // batch_size x seqlen_q x num_heads x 
   auto offset2 = use_philox_state ? philox_state.offset_intragraph_ : 0;
   auto seed_output = mk_philoxtensor(use_philox_state ? seed_t.data_ptr<int64_t>() : nullptr);
   auto offset_output = mk_philoxtensor(use_philox_state ? offset_t.data_ptr<int64_t>() : nullptr);
-  auto persistent_counter = mk_atomictensor(is_causal ? atomic_counter.data_ptr<int32_t>() : nullptr);
+  auto persistent_counter = mk_atomictensor(is_causal || uses_swa ? atomic_counter.data_ptr<int32_t>() : nullptr);
   if (uses_swa) {
 #if V3_API
     using aotriton::v3::flash::CausalType;
@@ -476,7 +476,7 @@ mha_varlen_fwd_aot(const at::Tensor &q,  // total_q x num_heads x head_size, tot
     auto nullscalar = mk_philoxtensor(nullptr);
     auto seed_output = use_philox_state ? mk_philoxtensor(seed_t.data_ptr<int64_t>()) : nullscalar;
     auto offset_output = use_philox_state ? mk_philoxtensor(offset_t.data_ptr<int64_t>()) : nullscalar;
-    auto persistent_counter = is_causal ? mk_philoxtensor(atomic_counter.data_ptr<int64_t>()) : nullscalar;
+    auto persistent_counter = is_causal || uses_swa ? mk_philoxtensor(atomic_counter.data_ptr<int64_t>()) : nullscalar;
     if (uses_swa) {
 #if V3_API
       using aotriton::v3::flash::CausalType;

--- a/aten/src/ATen/native/transformers/hip/flash_attn/aot/mha_all_aot.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/aot/mha_all_aot.hip
@@ -243,12 +243,6 @@ mha_fwd_aot(const at::Tensor &q,         // batch_size x seqlen_q x num_heads x 
   } else {
     softmax_fa_t = at::empty({ 0, 0, 0, 0 }, opts);
   }
-
-  at::Tensor atomic_counter;
-  if (is_causal) {
-    atomic_counter = at::zeros({1}, opts.dtype(at::kInt));
-  }
-
   auto [needs_swa, window_left, window_right] = calculate_swa(window_size_left,
                                                               window_size_right,
                                                               seqlen_q,
@@ -261,6 +255,14 @@ mha_fwd_aot(const at::Tensor &q,         // batch_size x seqlen_q x num_heads x 
   // optimized out (hopefully).
   constexpr bool uses_swa = false;
 #endif
+
+  // SWA in AOTriton Kernels is treated as "Generalized Causal masks"
+  is_causal = is_causal || uses_swa;
+
+  at::Tensor atomic_counter;
+  if (is_causal) {
+    atomic_counter = at::zeros({1}, opts.dtype(at::kInt));
+  }
 
   hipError_t err; // TODO: Error handling
   using aotriton::v2::flash::attn_fwd;
@@ -275,7 +277,7 @@ mha_fwd_aot(const at::Tensor &q,         // batch_size x seqlen_q x num_heads x 
   auto offset2 = use_philox_state ? philox_state.offset_intragraph_ : 0;
   auto seed_output = mk_philoxtensor(use_philox_state ? seed_t.data_ptr<int64_t>() : nullptr);
   auto offset_output = mk_philoxtensor(use_philox_state ? offset_t.data_ptr<int64_t>() : nullptr);
-  auto persistent_counter = mk_atomictensor(is_causal || uses_swa ? atomic_counter.data_ptr<int32_t>() : nullptr);
+  auto persistent_counter = mk_atomictensor(is_causal ? atomic_counter.data_ptr<int32_t>() : nullptr);
   if (uses_swa) {
 #if V3_API
     using aotriton::v3::flash::CausalType;
@@ -455,6 +457,9 @@ mha_varlen_fwd_aot(const at::Tensor &q,  // total_q x num_heads x head_size, tot
   constexpr bool uses_swa = false;
 #endif
 
+  // SWA in AOTriton Kernels is treated as "Generalized Causal masks"
+  is_causal = is_causal || needs_swa;
+
   auto [seed_t, offset_t, philox_state, use_philox_state] =
     prepare_philox_arguments(p_dropout, batch_size * num_heads * 32);
 
@@ -476,7 +481,7 @@ mha_varlen_fwd_aot(const at::Tensor &q,  // total_q x num_heads x head_size, tot
     auto nullscalar = mk_philoxtensor(nullptr);
     auto seed_output = use_philox_state ? mk_philoxtensor(seed_t.data_ptr<int64_t>()) : nullscalar;
     auto offset_output = use_philox_state ? mk_philoxtensor(offset_t.data_ptr<int64_t>()) : nullscalar;
-    auto persistent_counter = is_causal || uses_swa ? mk_philoxtensor(atomic_counter.data_ptr<int64_t>()) : nullscalar;
+    auto persistent_counter = is_causal ? mk_philoxtensor(atomic_counter.data_ptr<int64_t>()) : nullscalar;
     if (uses_swa) {
 #if V3_API
       using aotriton::v3::flash::CausalType;


### PR DESCRIPTION
AOTriton implements Sliding Window Attention (SWA) as a more generalized version of causal masks and also needs an atomic counter for dynamic workload allocation.

Fixes #158308


cc @jbschlosser @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd