### PR TITLE
Improve pin_memory error message clarity

### DIFF
--- a/aten/src/ATen/EmptyTensor.cpp
+++ b/aten/src/ATen/EmptyTensor.cpp
@@ -31,7 +31,7 @@ c10::Allocator* GetCPUAllocatorMaybePinned(bool pin_memory) {
       return at::globalContext().getPinnedMemoryAllocator(opt_device_type);
     } else {
       TORCH_CHECK(
-          false, "Need to provide pin_memory allocator to use pin memory.")
+          false, "pin_memory=True requires CUDA or another accelerator, but none are available.")
     }
   }
 


### PR DESCRIPTION
Replace 'Need to provide pin_memory allocator' error with clearer message explaining that pin_memory requires CUDA or another accelerator backend. Fixes #159740.