### PR TITLE
[Tests]: disable logspace tests correctly

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -22260,7 +22260,8 @@ python_ref_db = [
                 unittest.expectedFailure, 'TestCommon', 'test_python_ref',
                 dtypes=(
                     torch.float32, torch.float64, torch.float16, torch.complex64,
-                    torch.complex128, torch.bfloat16, torch.int8, torch.uint8
+                    torch.complex128, torch.bfloat16, torch.int8, torch.uint8,
+                    torch.int16, torch.int32, torch.int64
                 ),
                 device_type="cuda"
             ),


### PR DESCRIPTION
These are already disabled directly above this ([code here](https://github.com/pytorch/pytorch/blob/a43446b2fbbd5ce683e7bf70092e982ebe55b1eb/torch/testing/_internal/common_methods_invocations.py#L22248)) because of the "Off-by-one issue when casting floats to ints" problem. But, if the off-by-one issue would be resolved, they still will fail due to the "copy doesn't have prim refs" issue. 


