### PR TITLE
[AOTI][experiment] Provide an option to cross-compile for Windows

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1489,6 +1489,9 @@ class aot_inductor:
 
     compile_standalone: bool = False
 
+    # If set to "windows", we will compile from WSL and generate a C++ project file for Windows
+    cross_target_platform: Optional[str] = None
+
     # Whether to enable link-time-optimization
     enable_lto = os.environ.get("AOT_INDUCTOR_ENABLE_LTO", "0") == "1"
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #159804
* __->__ #159794

Summary: Because PT2 doesn't run on native Windows due to the missing Triton support, we take a cross-compilation path for AOTInductor. Concretely, we can run AOTI on WSL, specifying package_cpp_only to generate a C++ project with cpp files for the main wrapper and weights and generate ptx files for kernels. Then we take the C++ project files to native Windows and compile it with native Windows toolchain. This PR adds a cross-compilation config so that WSL export can work. Next PR in this stack will update AOTI runner code so that they can work with this flow.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben