### PR TITLE
[ROCm] Add HIPConfig.h to .gitignore like CUDAConfig.h.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ coverage.xml
 aten/build/
 aten/src/ATen/Config.h
 aten/src/ATen/cuda/CUDAConfig.h
+aten/src/ATen/hip/HIPConfig.h
 benchmarks/.data
 caffe2/cpp_test/
 dist/


### PR DESCRIPTION
This file is generated into the source directory by CMake just like `cuda/CUDAConfig.h`, so it seems appropriate to add it to `.gitignore` in the same place: https://github.com/pytorch/pytorch/blob/83ba3f1101789edd5fc01d8b61bf7ab4f840a36a/aten/src/ATen/CMakeLists.txt#L39-L47

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd