### PR TITLE
fix type documentation for context_parallel no_restore_buffers, to prevent user from passing in the wrong type

### DIFF
--- a/torch/distributed/tensor/experimental/_attention.py
+++ b/torch/distributed/tensor/experimental/_attention.py
@@ -1449,7 +1449,8 @@ def context_parallel(
         no_restore_buffers (Optional[Set[torch.Tensor]]): buffers in these set
             won't be restored after the context exits. This set must be a subset
             of ``buffers``. If the buffers won't be used after the context exits,
-            these buffers can be put in this list to avoid extra restore time.
+            these buffers can be put in this set to avoid extra restore time.
+            Be sure to pass in a Set and not a List.
 
     .. warning::
         `torch.distributed.tensor.experimental.context_parallel` is a


### PR DESCRIPTION
If you pass in a list, such as in the following testcase, you'll receive `RuntimeError: Boolean value of Tensor with more than one value is ambiguous`:

```python
# torchrun --standalone --nnodes=1 --nproc-per-node=1 this_file.py
import os

import torch
import torch.distributed as dist
import torch.nn.functional as F
from torch.distributed.device_mesh import init_device_mesh
from torch.distributed.tensor.experimental import context_parallel
from torch.distributed.tensor.experimental._attention import context_parallel_unshard
from torch.nn.attention import sdpa_kernel, SDPBackend


def context_parallel_sdpa_example(world_size: int, rank: int):
    assert torch.cuda.is_available()
    assert dist.is_nccl_available()
    torch.cuda.set_device(f"cuda:{rank}")
    torch.cuda.manual_seed(0)

    dist.init_process_group(
        backend="nccl",
        init_method="env://",
        world_size=world_size,
        rank=rank,
    )
    device_mesh = init_device_mesh(device_type="cuda", mesh_shape=(world_size,), mesh_dim_names=("cp",))

    batch = 1
    nheads = 1
    qkv_len = 4
    dim = 8
    backend = SDPBackend.FLASH_ATTENTION
    dtype = torch.bfloat16 if backend == SDPBackend.FLASH_ATTENTION or backend == SDPBackend.CUDNN_ATTENTION else torch.float32

    qkv = [
        torch.rand(
            (batch, nheads, qkv_len, dim),
            dtype=dtype,
            requires_grad=True,
            device="cuda",
        )
        for _ in range(3)
    ]
    # specify the SDPBackend to use
    with sdpa_kernel(backend):
        out = F.scaled_dot_product_attention(*qkv, is_causal=True)

    # make a clean copy of QKV for output comparison
    cp_qkv = [t.detach().clone() for t in qkv]
    cp_qkv = tuple(cp_qkv)

    with sdpa_kernel(backend):
        # This `context_parallel()` performs two actions:
        # 1. Shard the tensor objects in `buffers` in-place along the dimension
        #    specified in `buffer_seq_dims`, the tensors in `buffers` and their
        #    sharding dims in `buffer_seq_dims` are organized in the same order.
        # 2. Replace the execution of `F.scaled_dot_product_attention` with a
        #    context-paralleled-enabled Ring Attention.
        with context_parallel(device_mesh, buffers=cp_qkv, buffer_seq_dims=(2, 2, 2), no_restore_buffers=cp_qkv):
            cp_out = F.scaled_dot_product_attention(*cp_qkv, is_causal=True)

        # The output `cp_out` is still sharded in the same way as QKV
        # the `context_parallel_unshard` API allows users to easily
        # unshard to gain the full tensor.
        (cp_out,) = context_parallel_unshard(device_mesh, [cp_out], [2])

    assert torch.allclose(
        cp_out,
        out,
        atol=(1e-08 if dtype == torch.float32 else 1e-03 * world_size),
    )


if __name__ == "__main__":
    rank = int(os.environ["RANK"])
    world_size = int(os.environ["WORLD_SIZE"])

    try:
        context_parallel_sdpa_example(world_size, rank)
    finally:
        dist.barrier()
        dist.destroy_process_group()
```

Changing `no_restore_buffers=cp_qkv` to `no_restore_buffers=set(cp_qkv)` fixes it.

Another viable option is to reject this patch and instead change [`no_restore_buffers = set() if no_restore_buffers is None else no_restore_buffers`](https://github.com/pytorch/pytorch/blob/a7f3bdf550635c796e53442375477efe98fe5447/torch/distributed/tensor/experimental/_attention.py#L1460) to `no_restore_buffers = set() if no_restore_buffers is None else set(no_restore_buffers)`. Other users are likely to make the same mistake of passing in a list.

I assume "b in list" is doing a tensor-wise truth comparison, while "b in set" is somehow not.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci