### PR TITLE
skip XPU for dataloader CPU only unit test

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -3133,6 +3133,8 @@ class TestDictDataLoader(TestCase):
             self.assertTrue(sample["a_tensor"].is_pinned())
             self.assertTrue(sample["another_dict"]["a_number"].is_pinned())
 
+    @skipIfXpu
+    @skipIfRocm
     @unittest.skipIf(TEST_CUDA, "Test for when CUDA is not available")
     def test_pin_memory_no_cuda(self):
         loader = DataLoader(self.dataset, batch_size=2, pin_memory=True)


### PR DESCRIPTION
Fixes [#159802](https://github.com/pytorch/pytorch/issues/159802)
