### PR TITLE
Add support for error-ing when there is side effect

### DIFF
--- a/torch/_dynamo/source.py
+++ b/torch/_dynamo/source.py
@@ -106,6 +106,13 @@ def is_constant_source(source: Source) -> bool:
     return False
 
 
+def _get_source_debug_name(source: Source) -> str:
+    try:
+        return source.name()
+    except NotImplementedError:
+        return "<unknown source>"
+
+
 @dataclasses.dataclass(frozen=True)
 class LocalSource(Source):
     local_name: str


### PR DESCRIPTION
Summary: Previously in export, we ignored side-effect table from dynamo which can lead to incorrectness as shown in the test case. In this PR, we walk over remaining side effects and suggest where the user can look for.

Test Plan:
CI

Rollback Plan:

Differential Revision: D79607564




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela