### PR TITLE
Attempt to fix `torch.backends.cudnn.rnn` import

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -856,6 +856,7 @@ print(t.is_pinned())
             self.assertEqual(torch.backends.cudnn.rnn.fp32_precision, "none")
 
     @recover_orig_fp32_precision
+    @serialTest()
     def test_fp32_precision_with_float32_matmul_precision(self):
         torch.set_float32_matmul_precision("highest")
         self.assertEqual(torch.backends.cuda.matmul.fp32_precision, "ieee")
@@ -865,6 +866,7 @@ print(t.is_pinned())
         self.assertEqual(torch.backends.cuda.matmul.fp32_precision, "tf32")
 
     @recover_orig_fp32_precision
+    @serialTest()
     def test_invalid_status_for_legacy_api(self):
         torch.backends.cudnn.conv.fp32_precision = "none"
         torch.backends.cudnn.rnn.fp32_precision = "tf32"

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -17,6 +17,7 @@ from torch.backends import (
 
 from . import rnn
 
+
 try:
     from torch._C import _cudnn
 except ImportError:

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -15,6 +15,7 @@ from torch.backends import (
     PropModule,
 )
 
+from . import rnn
 
 try:
     from torch._C import _cudnn
@@ -229,7 +230,6 @@ class CudnnModule(PropModule):
         torch._C._get_cudnn_allow_tf32, torch._C._set_cudnn_allow_tf32
     )
     conv = _FP32Precision("cuda", "conv")
-    rnn = _FP32Precision("cuda", "rnn")
     fp32_precision = ContextProp(
         _get_fp32_precision_getter("cuda", "all"),
         _set_fp32_precision_setter("cuda", "all"),

--- a/torch/backends/cudnn/rnn.py
+++ b/torch/backends/cudnn/rnn.py
@@ -67,6 +67,7 @@ class ContextProp:
     def __set__(self, obj, val):
         self.setter(val)
 
+
 def init_dropout_state(dropout, train, dropout_seed, dropout_state):
     dropout_desc_name = "desc_" + str(torch.cuda.current_device())
     dropout_p = dropout if train else 0
@@ -96,7 +97,6 @@ class CudnnRNNModule(PropModule):
         self.m.Unserializable = Unserializable
         self.m.get_cudnn_mode = get_cudnn_mode
         self.m.init_dropout_state = init_dropout_state
-
 
     @staticmethod
     def init_dropout_state(dropout, train, dropout_seed, dropout_state):

--- a/torch/backends/cudnn/rnn.py
+++ b/torch/backends/cudnn/rnn.py
@@ -67,7 +67,6 @@ class ContextProp:
     def __set__(self, obj, val):
         self.setter(val)
 
-
 def init_dropout_state(dropout, train, dropout_seed, dropout_state):
     dropout_desc_name = "desc_" + str(torch.cuda.current_device())
     dropout_p = dropout if train else 0

--- a/torch/backends/cudnn/rnn.py
+++ b/torch/backends/cudnn/rnn.py
@@ -1,6 +1,14 @@
 # mypy: allow-untyped-defs
+import sys
+
+import torch._C
 import torch.cuda
 
+from torch.backends import (
+    _get_fp32_precision_getter,
+    _set_fp32_precision_setter,
+    PropModule,
+)
 
 try:
     from torch._C import _cudnn
@@ -9,8 +17,7 @@ except ImportError:
     # so it's safe to not emit any checks here.
     _cudnn = None  # type: ignore[assignment]
 
-
-def get_cudnn_mode(mode):
+def _get_cudnn_mode(mode):
     if mode == "RNN_RELU":
         # pyrefly: ignore [missing-attribute]
         return int(_cudnn.RNNMode.rnn_relu)
@@ -46,24 +53,53 @@ class Unserializable:
         self.inner = None
 
 
-def init_dropout_state(dropout, train, dropout_seed, dropout_state):
-    dropout_desc_name = "desc_" + str(torch.cuda.current_device())
-    dropout_p = dropout if train else 0
-    if (dropout_desc_name not in dropout_state) or (
-        dropout_state[dropout_desc_name].get() is None
-    ):
-        if dropout_p == 0:
-            dropout_state[dropout_desc_name] = Unserializable(None)
-        else:
-            dropout_state[dropout_desc_name] = Unserializable(
-                torch._cudnn_init_dropout_state(  # type: ignore[call-arg]
-                    dropout_p,
-                    train,
-                    dropout_seed,
-                    # pyrefly: ignore [unexpected-keyword]
-                    self_ty=torch.uint8,
-                    device=torch.device("cuda"),
+# we would like to use ContextProp from backends here but the
+# frozen flags appears to be overzealous
+class ContextProp:
+    def __init__(self, getter, setter):
+        self.getter = getter
+        self.setter = setter
+
+    def __get__(self, obj, objtype):
+        return self.getter()
+
+    def __set__(self, obj, val):
+        self.setter(val)
+ 
+
+class CudnnRNNModule(PropModule):
+    def __init__(self, m, name):
+        super().__init__(m, name)
+        m.Unserializable = Unserializable
+        self.get_cudnn_mode = _get_cudnn_mode
+        self.m.get_cudnn_mode = _get_cudnn_mode
+
+    @staticmethod
+    def init_dropout_state(dropout, train, dropout_seed, dropout_state):
+        dropout_desc_name = "desc_" + str(torch.cuda.current_device())
+        dropout_p = dropout if train else 0
+        if (dropout_desc_name not in dropout_state) or (
+            dropout_state[dropout_desc_name].get() is None
+        ):
+            if dropout_p == 0:
+                dropout_state[dropout_desc_name] = Unserializable(None)
+            else:
+                dropout_state[dropout_desc_name] = Unserializable(
+                    torch._cudnn_init_dropout_state(  # type: ignore[call-arg]
+                        dropout_p,
+                        train,
+                        dropout_seed,
+                        # pyrefly: ignore [unexpected-keyword]
+                        self_ty=torch.uint8,
+                        device=torch.device("cuda"),
+                    )
                 )
-            )
-    dropout_ts = dropout_state[dropout_desc_name].get()
-    return dropout_ts
+        dropout_ts = dropout_state[dropout_desc_name].get()
+        return dropout_ts
+
+    fp32_precision = ContextProp(
+        _get_fp32_precision_getter("cuda", "rnn"),
+        _set_fp32_precision_setter("cuda", "rnn"),
+    )
+
+sys.modules[__name__] = CudnnRNNModule(sys.modules[__name__], __name__)

--- a/torch/backends/cudnn/rnn.py
+++ b/torch/backends/cudnn/rnn.py
@@ -81,6 +81,7 @@ def init_dropout_state(dropout, train, dropout_seed, dropout_state):
                     dropout_p,
                     train,
                     dropout_seed,
+                    # pyrefly: ignore [unexpected-keyword]
                     self_ty=torch.uint8,
                     device=torch.device("cuda"),
                 )

--- a/torch/backends/cudnn/rnn.py
+++ b/torch/backends/cudnn/rnn.py
@@ -3,12 +3,12 @@ import sys
 
 import torch._C
 import torch.cuda
-
 from torch.backends import (
     _get_fp32_precision_getter,
     _set_fp32_precision_setter,
     PropModule,
 )
+
 
 try:
     from torch._C import _cudnn
@@ -17,7 +17,8 @@ except ImportError:
     # so it's safe to not emit any checks here.
     _cudnn = None  # type: ignore[assignment]
 
-def _get_cudnn_mode(mode):
+
+def get_cudnn_mode(mode):
     if mode == "RNN_RELU":
         # pyrefly: ignore [missing-attribute]
         return int(_cudnn.RNNMode.rnn_relu)
@@ -31,7 +32,7 @@ def _get_cudnn_mode(mode):
         # pyrefly: ignore [missing-attribute]
         return int(_cudnn.RNNMode.gru)
     else:
-        raise Exception(f"Unknown mode: {mode}")  # noqa: TRY002
+        raise ValueError(f"Unknown mode: {mode}")  # noqa: TRY002
 
 
 # NB: We don't actually need this class anymore (in fact, we could serialize the
@@ -65,14 +66,37 @@ class ContextProp:
 
     def __set__(self, obj, val):
         self.setter(val)
- 
+
+
+def init_dropout_state(dropout, train, dropout_seed, dropout_state):
+    dropout_desc_name = "desc_" + str(torch.cuda.current_device())
+    dropout_p = dropout if train else 0
+    if (dropout_desc_name not in dropout_state) or (
+        dropout_state[dropout_desc_name].get() is None
+    ):
+        if dropout_p == 0:
+            dropout_state[dropout_desc_name] = Unserializable(None)
+        else:
+            dropout_state[dropout_desc_name] = Unserializable(
+                torch._cudnn_init_dropout_state(  # type: ignore[call-arg]
+                    dropout_p,
+                    train,
+                    dropout_seed,
+                    self_ty=torch.uint8,
+                    device=torch.device("cuda"),
+                )
+            )
+    dropout_ts = dropout_state[dropout_desc_name].get()
+    return dropout_ts
+
 
 class CudnnRNNModule(PropModule):
     def __init__(self, m, name):
         super().__init__(m, name)
-        m.Unserializable = Unserializable
-        self.get_cudnn_mode = _get_cudnn_mode
-        self.m.get_cudnn_mode = _get_cudnn_mode
+        self.m.Unserializable = Unserializable
+        self.m.get_cudnn_mode = get_cudnn_mode
+        self.m.init_dropout_state = init_dropout_state
+
 
     @staticmethod
     def init_dropout_state(dropout, train, dropout_seed, dropout_state):
@@ -101,5 +125,6 @@ class CudnnRNNModule(PropModule):
         _get_fp32_precision_getter("cuda", "rnn"),
         _set_fp32_precision_setter("cuda", "rnn"),
     )
+
 
 sys.modules[__name__] = CudnnRNNModule(sys.modules[__name__], __name__)


### PR DESCRIPTION
#125888 seems to introduce a `PropertyModule` to replace the existing `torch.backends.cudnn` module in order to expose the `.conv.fp32_precision` and `.rnn.fp32_precision` settings. However, it fails to account for the existing `torch.backends.cudnn.rnn` module, which if imported after leaves us in a limbo state where the additional `.rnn.fp32_precision` property is no longer accessible.

This PR is WIP and attempts to remedy this by propagating the hack and replaces the RNN module with a similar `PropertyModule` replacement. There is more than one wart, e.g., a duplicate `ContextProp` definition in `rnn.py` as the original one in `backends` seems to be too strict in its frozen flags check.

CC @guangy10 @zhuhaozhe @albanD 

cc @mikaylagawarecki @zasdfgbnm @ptrblck