### PR TITLE
Fix XPU failed UT test_pin_memory_no_cuda in CI

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -40,6 +40,7 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_ASAN,
     TEST_WITH_ROCM,
     TEST_WITH_TSAN,
+    TEST_XPU,
     TestCase,
     xfailIfLinux,
 )
@@ -3133,7 +3134,7 @@ class TestDictDataLoader(TestCase):
             self.assertTrue(sample["a_tensor"].is_pinned())
             self.assertTrue(sample["another_dict"]["a_number"].is_pinned())
 
-    @unittest.skipIf(TEST_CUDA, "Test for when CUDA is not available")
+    @unittest.skipIf(TEST_CUDA or TEST_XPU, "Test for when CUDA/XPU is not available")
     def test_pin_memory_no_cuda(self):
         loader = DataLoader(self.dataset, batch_size=2, pin_memory=True)
         for sample in loader:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #159833

# Motivation
https://github.com/pytorch/pytorch/pull/158323 refactor the logic with torch.accelerator API, but it introduces a UT only skips on CUDA. This PR skip it on XPU as well.


cc @gujinghui @EikanWang @fengyuan14