### PR TITLE
[autograd] torch._C._set_view_replay_enabled state leaking into other tests

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -109,6 +109,10 @@ def graph_desc(fn):
 
 
 class TestAutograd(TestCase):
+    def tearDown(self):
+        torch.autograd._force_original_view_tracking(False)
+        super().tearDown()
+
     def test_copy_slices_graph_task_updates(self):
         def f1(x, y):
             out = x.clone().view(-1)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -111,7 +111,7 @@ def graph_desc(fn):
 class TestAutograd(TestCase):
     def tearDown(self):
         torch.autograd._force_original_view_tracking(False)
-        super().tearDown()
+        super(TestCase, self).tearDown()
 
     def test_copy_slices_graph_task_updates(self):
         def f1(x, y):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #159875
* __->__ #159840

This was causing view_fns to pop up in tests that ran after `TestAutograd.test_view_replay_enabled` where it isn't used as a context manager. It is unclear to me why we would want `_force_original_view_tracking` to mutate global state on __init__ rather than on __enter__, that could be an alternative fix.

FIXES https://github.com/pytorch/pytorch/issues/156306 https://github.com/pytorch/pytorch/issues/156289 https://github.com/pytorch/pytorch/issues/156265 https://github.com/pytorch/pytorch/issues/156209 