### PR TITLE
[OpenReg] Disable automatic inclusion of data files

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/setup.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/setup.py
@@ -85,6 +85,7 @@ def main():
         cmdclass={
             "clean": BuildClean,  # type: ignore[misc]
         },
+        include_package_data=False,
     )
 
 


### PR DESCRIPTION
# Background

After I built torch_openreg, I noticed that the wheel package contained the stub.c file under the csrc directory, which was not used in the runtime.

# Motivation

This PR aims to remove the stub.c file and any unused file when running torch_openreg.

**Changes:**

- Setting **include_package_data** keyword to false in the setup function

cc @FFFrog 