### PR TITLE
[CUDA 13] CMake/Dependencies: no need to call find_package(CUB)

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1143,7 +1143,7 @@ if(USE_UCC)
 endif()
 
 # ---[ CUB
-if(USE_CUDA)
+if(USE_CUDA AND CUDA_VERSION VERSION_LESS 13.0)
   find_package(CUB)
   if(NOT CUB_FOUND)
     message(FATAL_ERROR "Cannot find CUB.")


### PR DESCRIPTION
CUB library is the part of CCCL of the CUDA Toolkit 13. If CUDA Found, CUB is found as well.