### PR TITLE
error message for instantiating CUDA Stream if CUDA not available

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10808,7 +10808,7 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
     def test_no_cuda_monkeypatch(self):
         # Note that this is not in test_cuda.py as this whole file is skipped when cuda
         # is not available.
-        with self.assertRaisesRegex(RuntimeError, "torch.cuda.Stream() requires CUDA support"):
+        with self.assertRaisesRegex(RuntimeError, "torch.cuda.Stream requires CUDA support"):
             torch.cuda.Stream()
 
         with self.assertRaisesRegex(RuntimeError, "Tried to instantiate dummy base class Event"):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10808,7 +10808,7 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
     def test_no_cuda_monkeypatch(self):
         # Note that this is not in test_cuda.py as this whole file is skipped when cuda
         # is not available.
-        with self.assertRaisesRegex(RuntimeError, "Tried to instantiate dummy base class Stream"):
+        with self.assertRaisesRegex(RuntimeError, "torch.cuda.Stream() requires CUDA support"):
             torch.cuda.Stream()
 
         with self.assertRaisesRegex(RuntimeError, "Tried to instantiate dummy base class Event"):

--- a/torch/cuda/streams.py
+++ b/torch/cuda/streams.py
@@ -11,11 +11,6 @@ if not hasattr(torch._C, "_CudaStreamBase"):
     torch._C.__dict__["_CudaEventBase"] = _dummy_type("_CudaEventBase")
 
 
-def _is_compiled() -> bool:
-    r"""Return true if compiled with CUDA support."""
-    return hasattr(torch._C, "_cuda_getDeviceCount")
-
-
 class Stream(torch._C._CudaStreamBase):
     r"""Wrapper around a CUDA stream.
 
@@ -37,9 +32,9 @@ class Stream(torch._C._CudaStreamBase):
     """
 
     def __new__(cls, device=None, priority=0, **kwargs):
-        # Check CUDA availability before attempting to create stream
-        if not _is_compiled():
-            raise RuntimeError("torch.cuda.Stream() requires CUDA support")
+        # Check CUDA availability
+        if not torch.backends.cuda.is_built():
+            raise RuntimeError("torch.cuda.Stream requires CUDA support")
         # setting device manager is expensive, so we avoid it unless necessary
         if device is None or ("stream_id" in kwargs and "device_index" in kwargs):
             return super().__new__(cls, priority=priority, **kwargs)

--- a/torch/cuda/streams.py
+++ b/torch/cuda/streams.py
@@ -39,7 +39,7 @@ class Stream(torch._C._CudaStreamBase):
     def __new__(cls, device=None, priority=0, **kwargs):
         # Check CUDA availability before attempting to create stream
         if not _is_compiled():
-            raise RuntimeError("torch.cuda.Stream() requires CUDA support")
+            raise RuntimeError("torch.cuda.Stream() requires CUDA")
         # setting device manager is expensive, so we avoid it unless necessary
         if device is None or ("stream_id" in kwargs and "device_index" in kwargs):
             return super().__new__(cls, priority=priority, **kwargs)

--- a/torch/cuda/streams.py
+++ b/torch/cuda/streams.py
@@ -39,7 +39,7 @@ class Stream(torch._C._CudaStreamBase):
     def __new__(cls, device=None, priority=0, **kwargs):
         # Check CUDA availability before attempting to create stream
         if not _is_compiled():
-            raise RuntimeError("torch.cuda.Stream() requires CUDA")
+            raise RuntimeError("torch.cuda.Stream() requires CUDA support")
         # setting device manager is expensive, so we avoid it unless necessary
         if device is None or ("stream_id" in kwargs and "device_index" in kwargs):
             return super().__new__(cls, priority=priority, **kwargs)

--- a/torch/cuda/streams.py
+++ b/torch/cuda/streams.py
@@ -11,6 +11,11 @@ if not hasattr(torch._C, "_CudaStreamBase"):
     torch._C.__dict__["_CudaEventBase"] = _dummy_type("_CudaEventBase")
 
 
+def _is_compiled() -> bool:
+    r"""Return true if compiled with CUDA support."""
+    return hasattr(torch._C, "_cuda_getDeviceCount")
+
+
 class Stream(torch._C._CudaStreamBase):
     r"""Wrapper around a CUDA stream.
 
@@ -32,6 +37,9 @@ class Stream(torch._C._CudaStreamBase):
     """
 
     def __new__(cls, device=None, priority=0, **kwargs):
+        # Check CUDA availability before attempting to create stream
+        if not _is_compiled():
+            raise RuntimeError("torch.cuda.Stream() requires CUDA support")
         # setting device manager is expensive, so we avoid it unless necessary
         if device is None or ("stream_id" in kwargs and "device_index" in kwargs):
             return super().__new__(cls, priority=priority, **kwargs)


### PR DESCRIPTION
Fixes #159744 
Summary:
```
import torch

# Generate input data
input_tensor = torch.randn(3, 3)
stream = torch.cuda.Stream()

# Call the API
input_tensor.record_stream(stream)
```

⚠️ will now show an error message
`torch.cuda.Stream requires CUDA support`

cc: @malfet 
