### PR TITLE
ParamwiseScheduler for different schedulers for specific parameter groups

### DIFF
--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1270,7 +1270,7 @@ class ParamwiseScheduler(LRScheduler):
         >>> scheduler.step()
     """
 
-    def __init__(self, schedulers: Sequence[LRScheduler]):
+    def __init__(self, schedulers: Sequence[LRScheduler]) -> None:
         self._schedulers = schedulers
         self.optimizer = schedulers[0].optimizer  # Assuming all schedulers use the same optimizer
 
@@ -1297,7 +1297,7 @@ class ParamwiseScheduler(LRScheduler):
 
         self._last_lr = [group["lr"] for group in self.optimizer.param_groups]
 
-    def recursive_undo(self, sched=None):
+    def recursive_undo(self, sched=None) -> None:
         """
         Recursively undo any step performed by the initialisation of
         schedulers.
@@ -1310,7 +1310,7 @@ class ParamwiseScheduler(LRScheduler):
         elif hasattr(scheds, "last_epoch"):
             scheds.last_epoch -= 1
 
-    def step(self):  # type: ignore[override]
+    def step(self) -> None:  # type: ignore[override]
         """Perform a step."""
         # Backup learning rates
         lrs = [group["lr"] for group in self.optimizer.param_groups]


### PR DESCRIPTION
Related to suggestion in issue #101082

This new scheduler makes it possible to use a different learning rate scheduler for each parameter group in the optimizer. This way, for example, parts of the network can be artificially frozen (LR = 0.0) while other are trained or warmed up, or different parts can be trained at different speeds.

Example usage:
```python
import torch
from torch import nn

# Dummy model with two parameter groups
class DummyModel(nn.Module):
    def __init__(self):
        super().__init__()
        self.linear1 = nn.Linear(10, 10)
        self.linear2 = nn.Linear(10, 1)
        self.linear3 = nn.Linear(1, 1)

    def forward(self, x):
        x = self.linear1(x)
        x = self.linear2(x)
        return self.linear3(x)

model = DummyModel()
optimizer = torch.optim.SGD([
    {'params': model.linear1.parameters(), 'lr': 0.1},
    {'params': model.linear2.parameters(), 'lr': 0.1},
    {'params': model.linear3.parameters(), 'lr': 0.1},
])

# Two schedulers, one for each param group
scheduler1 = torch.optim.lr_scheduler.StepLR(optimizer, step_size=2, gamma=0.5)
scheduler2 = torch.optim.lr_scheduler.SequentialLR(optimizer, schedulers=[
    torch.optim.lr_scheduler.LinearLR(optimizer, total_iters=3),
    torch.optim.lr_scheduler.ConstantLR(optimizer, factor=0.0, total_iters=2),
    torch.optim.lr_scheduler.StepLR(optimizer, step_size=2, gamma=0.1),
], milestones=[4, 6])

scheduler3 = torch.optim.lr_scheduler.ExponentialLR(optimizer, gamma=0.9)

# Wrap with ParamwiseScheduler
paramwise_scheduler = torch.optim.lr_scheduler.ParamwiseScheduler([scheduler1, scheduler2, scheduler3])

print("Initial LRs:", [group['lr'] for group in optimizer.param_groups])
for epoch in range(10):
    # Dummy training step
    optimizer.zero_grad()
    x = torch.randn(5, 10)
    y = model(x)
    loss = y.sum()
    loss.backward()
    optimizer.step()

    paramwise_scheduler.step()
    print(f"Epoch {epoch+1} LRs:", [group['lr'] for group in optimizer.param_groups])
```

Example output:
```
Initial LRs: [0.1, 0.03333333333333333, 0.1]
Epoch 1 LRs: [0.1, 0.05555555555555556, 0.09000000000000001]
Epoch 2 LRs: [0.05, 0.07777777777777778, 0.08100000000000002]
Epoch 3 LRs: [0.05, 0.0, 0.07290000000000002]
Epoch 4 LRs: [0.025, 0.0, 0.06561000000000002]
Epoch 5 LRs: [0.025, 0.1, 0.05904900000000002]
Epoch 6 LRs: [0.0125, 0.1, 0.05314410000000002]
Epoch 7 LRs: [0.0125, 0.010000000000000002, 0.04782969000000002]
Epoch 8 LRs: [0.00625, 0.010000000000000002, 0.043046721000000024]
Epoch 9 LRs: [0.00625, 0.0010000000000000002, 0.03874204890000002]
Epoch 10 LRs: [0.003125, 0.0010000000000000002, 0.03486784401000002]
```
