### PR TITLE
[C10] Add `Scalar::isUnsigned()` method

### DIFF
--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -191,9 +191,15 @@ class C10_API Scalar {
   isIntegral() const {
     return Tag::HAS_i == tag || Tag::HAS_si == tag || Tag::HAS_u == tag;
   }
+
   bool isIntegral(bool includeBool) const {
     return Tag::HAS_i == tag || Tag::HAS_si == tag || Tag::HAS_u == tag ||
         (includeBool && isBoolean());
+  }
+
+  // See Note [Meaning of HAS_u]
+  bool isUnsigned() const {
+    return Tag::HAS_u == tag || (Tag::HAS_i == tag && v.i >= 0);
   }
 
   bool isComplex() const {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #159877

That returns true if Scalar hold unsigned integral value

With the implications of `Tag::HAS_u` semantic.