### PR TITLE
[CI] Fix check labels permission issue

### DIFF
--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -108,10 +108,6 @@ GH_CHECKSUITES_FRAGMENT = """
 fragment PRCheckSuites on CheckSuiteConnection {
   edges {
     node {
-      app {
-        name
-        databaseId
-      }
       workflowRun {
         workflow {
           name


### PR DESCRIPTION
Example: https://github.com/pytorch/pytorch/actions/runs/16756005929/job/47438675367?pr=159878
```
}
, args {'name': 'pytorch', 'owner': 'pytorch', 'number': 159878} failed: [{'type': 'FORBIDDEN', 'path': ['repository', 'pullRequest', 'commits', 'nodes', 0, 'commit', 'checkSuites', 'edges', 4, 'node', 'app'], 'extensions': {'saml_failure': False}, 'locations': [{'line': 26, 'column': 7}], 'message': 'Resource not accessible by integration'}]
Error: Process completed with exit code 1.
```

My solution is to get rid of this query since I don't think we use the result anywhere