### PR TITLE
Wire in pt2_triton_builds

### DIFF
--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -350,3 +350,7 @@ def get_default_numa_options():
     Must return None or NumaOptions, but not specifying to avoid circular import.
     """
     return None
+
+
+def log_triton_builds(fail: Optional[str]):
+    pass


### PR DESCRIPTION
Summary:
This allows us to start seeing the failure rate on these models (and
potentially alert on it).

Test Plan:
```
FORCE_LOG_TRITON_BUILDS_TO_PROD=1 TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 buck2 run @//mode/opt :compile 2>&1 | tee out
```
P1889607054

Waiting for scuba table to generate, but manual logging show it should show up at https://fburl.com/scuba/pt2_triton_builds_inc_archive/7852kt8h soon.

Rollback Plan:

Reviewed By: masnesral

Differential Revision: D79308333




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben