### PR TITLE
[Easy] Fix wrong propagation of fallback_ops_dict in gen_aoti_c_shim

### DIFF
--- a/torchgen/gen_aoti_c_shim.py
+++ b/torchgen/gen_aoti_c_shim.py
@@ -744,7 +744,7 @@ https://github.com/pytorch/pytorch/pull/154848 as an example.
             f"c_shim_{device_name}.cpp",
             lambda: gen_aoti_c_shim(
                 fallback_native_functions,
-                inductor_fallback_ops,
+                fallback_ops_dict,
                 structured_func_group_dict,
                 dispatch_key,
                 backend_indices,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #159904

