### PR TITLE
[inductor] fix triton bucketize mask propagation

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2720,6 +2720,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             dtype=indexing_dtype,  # type: ignore[attr-defined]
         )
 
+        result.mask_vars = values.mask_vars  # type: ignore[attr-defined]
+
         return result
 
     def reduction_resize(self, value) -> str:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #159930

See https://hud.pytorch.org/pytorch/pytorch/commit/6b414f56a4a133a428af618d8ed1553849341497

Summary:

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben