### PR TITLE
[DTensor] Support user-supplied Generator for random ops

### DIFF
--- a/test/distributed/tensor/test_random_ops.py
+++ b/test/distributed/tensor/test_random_ops.py
@@ -94,13 +94,12 @@ class DistTensorRandomInitTest(DTensorTestBase):
         torch.manual_seed(42)
         rng = torch.Generator(device="cuda").manual_seed(42)
         t1 = torch.distributed.tensor.empty(
-            (2, 3), device_mesh=device_mesh, placements=[Shard(0)]
+            (8, 3), device_mesh=device_mesh, placements=[Shard(0)]
         )
         t2 = torch.distributed.tensor.empty(
-            (2, 3), device_mesh=device_mesh, placements=[Shard(0)]
+            (8, 3), device_mesh=device_mesh, placements=[Shard(0)]
         )
         for i in range(2):
-            print(f"{i=}")
             # run a second time, to make sure that `rng`'s offset-state is advancing on the second usage
             torch.nn.init.uniform_(t1, 0.0, 1.0)
             torch.nn.init.uniform_(t2, 0.0, 1.0, rng)

--- a/test/distributed/tensor/test_random_ops.py
+++ b/test/distributed/tensor/test_random_ops.py
@@ -88,17 +88,37 @@ class DistTensorRandomInitTest(DTensorTestBase):
             self._run_init_op(torch.randint_like, low=0, high=100, dtype=dtype)
 
     @with_comms
+    @skip_if_lt_x_gpu(4)
     def test_init_with_user_generator(self):
         device_mesh = self.build_device_mesh()
         torch.manual_seed(42)
+        rng = torch.Generator(device="cuda").manual_seed(42)
         t1 = torch.distributed.tensor.empty(
             (2, 3), device_mesh=device_mesh, placements=[Shard(0)]
         )
-        torch.nn.init.uniform_(t1, 0.0, 1.0)
-        rng = torch.Generator(device="cuda").manual_seed(42)
         t2 = torch.distributed.tensor.empty(
             (2, 3), device_mesh=device_mesh, placements=[Shard(0)]
         )
+        for i in range(2):
+            print(f"{i=}")
+            # run a second time, to make sure that `rng`'s offset-state is advancing on the second usage
+            torch.nn.init.uniform_(t1, 0.0, 1.0)
+            torch.nn.init.uniform_(t2, 0.0, 1.0, rng)
+            self.assertEqual(t1.full_tensor(), t2.full_tensor(), f"Failed at {i=}")
+
+        # ensure that we do not cache the 'seed' of `rng` from the first time we see it in DTensor
+        # TODO: we have a semantics decision to make
+        # There is a discontinuity between how the default RNG and a user-supplied RNG behaves with DTensor:
+        # (a) if the user calls `torch.manual_seed` after already using the default RNG with DTensor,
+        #     they may be surprised that it has no effect on DTensor.  They must instead call this private API
+        #     (`torch.distributed.tensor._random._rng_tracker._manual_seed`)
+        # (b) If we try to match the semantics of (a) with a user-supplied RNG, they may be very surprised to find that
+        #     their RNG object never advances its state after using it with DTensor.
+        torch.distributed.tensor._random._rng_tracker._manual_seed(55)
+        # torch.manual_seed(55)
+        rng.manual_seed(55)
+
+        torch.nn.init.uniform_(t1, 0.0, 1.0)
         torch.nn.init.uniform_(t2, 0.0, 1.0, rng)
         self.assertEqual(t1.full_tensor(), t2.full_tensor())
 

--- a/test/distributed/tensor/test_random_ops.py
+++ b/test/distributed/tensor/test_random_ops.py
@@ -114,13 +114,11 @@ class DistTensorRandomInitTest(DTensorTestBase):
         #     (`torch.distributed.tensor._random._rng_tracker._manual_seed`)
         # (b) If we try to match the semantics of (a) with a user-supplied RNG, they may be very surprised to find that
         #     their RNG object never advances its state after using it with DTensor.
-        torch.distributed.tensor._random._rng_tracker._manual_seed(55)
-        # torch.manual_seed(55)
-        rng.manual_seed(55)
-
-        torch.nn.init.uniform_(t1, 0.0, 1.0)
-        torch.nn.init.uniform_(t2, 0.0, 1.0, rng)
-        self.assertEqual(t1.full_tensor(), t2.full_tensor())
+        # torch.distributed.tensor._random._rng_tracker._manual_seed(55)
+        # rng.manual_seed(55)
+        # torch.nn.init.uniform_(t1, 0.0, 1.0)
+        # torch.nn.init.uniform_(t2, 0.0, 1.0, rng)
+        # self.assertEqual(t1.full_tensor(), t2.full_tensor())
 
     @with_comms
     @skip_if_lt_x_gpu(4)

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -138,7 +138,6 @@ class OpDispatcher:
         (2) registered sharding strategy, then rule
         (3) composite implicit autograd decomposition
         """
-
         if op_call in self._custom_op_handlers:
             return self._custom_op_handlers[op_call](op_call, args, kwargs)  # type: ignore[operator]
 

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -197,8 +197,19 @@ class OpDispatcher:
                     cast(dtensor.DTensor, args[0]),
                     cast(torch.Tensor, local_tensor_args[0]),
                 )
+
+                # If the user provided a generator, we hook it up to our RNG manager, but we also pop it from kwargs
+                # so the op_call does not directly use it (we want op_call to fall back to the 'default' which is
+                # our RNG manager)
+                maybe_user_generator = op_info.local_kwargs.pop("generator", None)
+                assert maybe_user_generator is None or isinstance(
+                    maybe_user_generator, torch.Generator
+                )
+                # maybe_user_generator = None
                 rng_context = (
-                    random._rng_tracker._distribute_region(first_arg._spec)
+                    random._rng_tracker._distribute_region(
+                        first_arg._spec, generator=maybe_user_generator
+                    )
                     if random._rng_tracker and not first_local_arg.is_meta
                     else contextlib.nullcontext()
                 )

--- a/torch/distributed/tensor/_random.py
+++ b/torch/distributed/tensor/_random.py
@@ -146,7 +146,9 @@ class _RNGStateTracker:
         )
         self.rng_states[name] = torch.cat([seed_tensor, offset_tensor])
 
-    def _distribute_region(self, spec: DTensorSpec):
+    def _distribute_region(
+        self, spec: DTensorSpec, generator: Optional[torch.Generator]
+    ):
         pass
 
     def _manual_seed(self, parallel_seed: int) -> None:
@@ -191,7 +193,17 @@ class OffsetBasedRNGTracker(_RNGStateTracker):
         self.set_seed("parallel-rng", parallel_seed)
 
     @contextlib.contextmanager
-    def _distribute_region(self, spec: DTensorSpec):
+    def _distribute_region(
+        self, spec: DTensorSpec, generator: Optional[torch.Generator] = None
+    ):
+        g_name = "parallel-rng"
+        if generator is not None:
+            # This is a little hacky, but for any user-passed generator, we store its state under a unique key,
+            # not because we need to keep a copy of it but because its the easiest way to make it work with the
+            # existing set/get APIs
+            g_name = str(id(generator))
+            if g_name not in self.rng_states:
+                self.rng_states[g_name] = generator.get_state()
         # check if the parallel rng state has been synchronized or not
         if not self.rng_state_is_sync("parallel-rng"):
             raise RuntimeError(
@@ -202,18 +214,18 @@ class OffsetBasedRNGTracker(_RNGStateTracker):
         if self.distribute_region_enabled:
             if self._device.type == "hpu":
                 self._device_handle.set_rng_ctx("philox")
-            old_offset = self.get_offset("parallel-rng")
-            self._set_pre_op_offset(spec)
+            old_offset = self.get_offset(g_name)
+            self._set_pre_op_offset(g_name, spec)
             with torch.random.fork_rng(
                 devices=[self._device], device_type=self._device.type
             ):
                 assert self._device_handle is not None
-                self._device_handle.set_rng_state(self.rng_states["parallel-rng"])
+                self._device_handle.set_rng_state(self.rng_states[g_name])
                 try:
                     yield  # execute the region code
                 finally:
                     # update offset to synchronize among ranks
-                    self._set_post_op_offset(spec, old_offset)
+                    self._set_post_op_offset(g_name, spec, old_offset)
             if self._device.type == "hpu":
                 self._device_handle.unset_rng_ctx("philox")
         else:
@@ -240,7 +252,7 @@ class OffsetBasedRNGTracker(_RNGStateTracker):
         )
         self.rng_states[name] = torch.cat([seed_tensor, offset_tensor])
 
-    def _set_pre_op_offset(self, spec: DTensorSpec) -> None:
+    def _set_pre_op_offset(self, name: str, spec: DTensorSpec) -> None:
         """Set the starting RNG offset for current device's local shard before actual
         op execution. The pre_op_offset value should start from the current RNG offset
         and increment by the size of local shard until it reaches the size of the whole
@@ -248,6 +260,7 @@ class OffsetBasedRNGTracker(_RNGStateTracker):
         will be the same.
 
         Args:
+            name (str): The name of the generator to use (should be a key in self.rng_states)
             spec (:class:`DTensorSpec`): the spec of the DTensor object on which
                 we prepare the offset for running random ops.
 
@@ -350,20 +363,23 @@ class OffsetBasedRNGTracker(_RNGStateTracker):
         local_size = prod(local_size_on_rank_0)
 
         # get current RNG offset
-        current_offset = self.get_offset("parallel-rng")
+        current_offset = self.get_offset(name)
 
         # pytorch: offset must be multiple of 4
         # source: aten/src/ATen/cuda/CUDAGeneratorImpl.cpp
         offset_incr = (shard_linear_idx * local_size + 3) // 4 * 4
-        self.set_offset("parallel-rng", current_offset + offset_incr)
+        self.set_offset(name, current_offset + offset_incr)
 
-    def _set_post_op_offset(self, spec: DTensorSpec, old_offset: int) -> None:
+    def _set_post_op_offset(
+        self, name: str, spec: DTensorSpec, old_offset: int
+    ) -> None:
         """Sets the RNG to a synchronized state after running the local random op. Every
         rank should set its RNG offset to `old_offset + DTensor.numel()` where old_offset is
         the offset before calling `set_pre_op_offset` i.e. the offset before running DTensor
         random ops.
 
         Args:
+            name (str): The name of the generator to use (should be a key in self.rng_states)
             spec (:class:`DTensorSpec`): the spec of the DTensor object on which
                 we post-process the offset for running random ops.
 
@@ -378,7 +394,7 @@ class OffsetBasedRNGTracker(_RNGStateTracker):
         # pytorch: offset must be multiple of 4
         # source: aten/src/ATen/cuda/CUDAGeneratorImpl.cpp
         numel = (numel + 3) // 4 * 4
-        self.set_offset("parallel-rng", old_offset + numel)
+        self.set_offset(name, old_offset + numel)
 
     def _calc_shard_linear_idx(
         self, shard_coord: list[int], shard_size: list[int]

--- a/torch/distributed/tensor/_random.py
+++ b/torch/distributed/tensor/_random.py
@@ -238,7 +238,10 @@ class OffsetBasedRNGTracker(_RNGStateTracker):
             # ensure we (a) propagate the state advancement back to the user's RNG so its visible and impacts any future
             # usage of that RNG (dtensor or non-dtensor), (b) drop it from our own cache so that if the user updates
             # the seed value in their rng and uses it with DTensor again, we always use the latest value
-            generator.set_state(self.rng_states.pop(g_name))
+            # TODO: we don't actually do this yet, because it deviates the semantics of user-supplied RNG from the
+            # semantics of default RNG.
+            # generator.set_state(self.rng_states.pop(g_name))
+            pass
 
     def get_offset(self, name: str) -> int:
         if name not in self.rng_states:

--- a/torch/distributed/tensor/_random.py
+++ b/torch/distributed/tensor/_random.py
@@ -201,12 +201,9 @@ class OffsetBasedRNGTracker(_RNGStateTracker):
             # This is a little hacky, but for any user-passed generator, we store its state under a unique key,
             # not because we need to keep a copy of it but because its the easiest way to make it work with the
             # existing set/get APIs. We also ensure we remove it from rng_states after each _distribute_region.
-            g_name = str(id(generator))
+            g_name = "user-passed-generator"
             assert g_name not in self.rng_states
             self.rng_states[g_name] = generator.get_state()
-            print(
-                f"using latest generator state: {g_name=}, {self.rng_states[g_name]=}"
-            )
         # check if the parallel rng state has been synchronized or not
         if not self.rng_state_is_sync("parallel-rng"):
             raise RuntimeError(
@@ -238,10 +235,7 @@ class OffsetBasedRNGTracker(_RNGStateTracker):
             # ensure we (a) propagate the state advancement back to the user's RNG so its visible and impacts any future
             # usage of that RNG (dtensor or non-dtensor), (b) drop it from our own cache so that if the user updates
             # the seed value in their rng and uses it with DTensor again, we always use the latest value
-            # TODO: we don't actually do this yet, because it deviates the semantics of user-supplied RNG from the
-            # semantics of default RNG.
-            # generator.set_state(self.rng_states.pop(g_name))
-            pass
+            generator.set_state(self.rng_states.pop(g_name))
 
     def get_offset(self, name: str) -> int:
         if name not in self.rng_states:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #159933

If the user provides a generator kwarg to a random op (e.g.
nn.init.uniform_(..., generator=my_generator)), we can still advance
that generator's state in a SPMD-global way so that each local-tensor
gets appropriate values and the generator advances to the same state as
if it had operated on the full tensor.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @d4l3k @pragupta