### PR TITLE
Fix AdaptiveMaxPool index error

### DIFF
--- a/aten/src/ATen/native/cpu/AdaptiveMaxPoolKernel.cpp
+++ b/aten/src/ATen/native/cpu/AdaptiveMaxPoolKernel.cpp
@@ -67,7 +67,7 @@ void cpu_adaptive_max_pool2d(
 
           // set output to local max and store location of max
           output_ptr[oh * output_width + ow] = maxval;
-          indices_ptr[oh * output_width + ow] = scalar_t(maxindex);
+          indices_ptr[oh * output_width + ow] = maxindex;
         }
       }
     }
@@ -540,7 +540,7 @@ void cpu_adaptive_max_pool3d(
 
             // set output to local max and store location of max
             output_ptr[od * output_height * output_width + oh * output_width + ow] = maxval;
-            indices_ptr[od * output_height * output_width + oh * output_width + ow] = scalar_t(maxindex);
+            indices_ptr[od * output_height * output_width + oh * output_width + ow] = maxindex;
           }
         }
       }


### PR DESCRIPTION
Fix failure of:
```python
import torch
x = torch.zeros([1, 1, 65536], dtype=torch.float16)
x[0, 0, -1] = 1
_, indices = torch.adaptive_max_pool1d(x, [1])
assert indices == torch.argmax(x.reshape(-1))
```


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01