### PR TITLE
[inductor] add _get_inductor_debug_symbol_cflags for debug symbol control.

### DIFF
--- a/test/inductor/test_compile.py
+++ b/test/inductor/test_compile.py
@@ -171,7 +171,7 @@ int main(){
             self.assertEqual(has_debug_sym, True)
 
         def check_windows_pdb_exist(module_path: str):
-            file_name_no_ext = os.path.splitext(module_path)
+            file_name_no_ext = os.path.splitext(module_path)[0]
             file_name_pdb = f"{file_name_no_ext}.pdb"
             has_pdb_file = os.path.exists(file_name_pdb)
             self.assertEqual(has_pdb_file, True)

--- a/test/inductor/test_compile.py
+++ b/test/inductor/test_compile.py
@@ -16,6 +16,7 @@ from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing._internal.inductor_utils import HAS_CPU
 
 
+_IS_MACOS = sys.platform.startswith("darwin")
 _IS_WINDOWS = sys.platform == "win32"
 
 
@@ -177,6 +178,8 @@ int main(){
 
         if _IS_WINDOWS:
             check_windows_pdb_exist(binary_path)
+        elif _IS_MACOS:
+            pass  # MacOS not sure that if it should be works.
         else:
             check_linux_debug_section(binary_path)
 

--- a/test/inductor/test_compile.py
+++ b/test/inductor/test_compile.py
@@ -156,19 +156,27 @@ int main(){
         )
         cpp_builder.build()
         binary_path = cpp_builder.get_target_file_path()
-        print(os.path.exists(binary_path))
-        switch = os.getenv("TORCHINDUCTOR_DEBUG_SYMBOL")
-        print("switch: ", switch)
+
+        """
+        When we turn on generate debug symbol.
+        On Windows, it should create a [module_name].pdb file. It helps debug by WinDBG.
+        On Linux, it should create some debug sections in binary file.
+        """
 
         def check_linux_debug_section(module_path: str):
             check_cmd = shlex.split(f"readelf -S {module_path}")
             output = safe_command_output(check_cmd)
-            print("output: ", output)
             has_debug_sym = ".debug_info" in output
             self.assertEqual(has_debug_sym, True)
 
+        def check_windows_pdb_exist(module_path: str):
+            file_name_no_ext = os.path.splitext(module_path)
+            file_name_pdb = f"{file_name_no_ext}.pdb"
+            has_pdb_file = os.path.exists(file_name_pdb)
+            self.assertEqual(has_pdb_file, True)
+
         if _IS_WINDOWS:
-            pass
+            check_windows_pdb_exist(binary_path)
         else:
             check_linux_debug_section(binary_path)
 

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -638,7 +638,7 @@ def _get_optimization_cflags(
         return cflags
 
 
-def _get_shared_cflag(do_link: bool) -> list[str]:
+def _get_shared_cflags(do_link: bool) -> list[str]:
     if _IS_WINDOWS:
         """
         MSVC `/MD` using python `ucrtbase.dll` lib as runtime.
@@ -651,6 +651,25 @@ def _get_shared_cflag(do_link: bool) -> list[str]:
         # This causes undefined symbols to behave the same as linux
         return ["shared", "fPIC", "undefined dynamic_lookup"]
     return ["shared", "fPIC"]
+
+
+def _get_inductor_debug_symbol_cflags() -> tuple[list[str], list[str]]:
+    """
+    When we turn on generate debug symbol.
+    On Windows, it should create a [module_name].pdb file. It helps debug by WinDBG.
+    On Linux, it should create some debug sections in binary file.
+    """
+    cflags: list[str] = []
+    ldflags: list[str] = []
+    b_enable_debug_symbol = os.environ.get("TORCHINDUCTOR_DEBUG_SYMBOL", "0") == "1"
+    if b_enable_debug_symbol:
+        if _IS_WINDOWS:
+            cflags = ["Z7", "_DEBUG", "OD"]
+            ldflags = ["DEBUG", "OPT:REF", "OPT:ICF"]
+        else:
+            cflags.append("g")
+
+    return cflags, ldflags
 
 
 def get_cpp_options(
@@ -668,12 +687,15 @@ def get_cpp_options(
     libraries: list[str] = []
     passthrough_args: list[str] = []
 
+    dbg_cflags, dbg_ldflags = _get_inductor_debug_symbol_cflags()
+
     cflags = (
-        _get_shared_cflag(do_link)
+        _get_shared_cflags(do_link)
         + _get_optimization_cflags(cpp_compiler, min_optimize)
         + _get_warning_all_cflag(warning_all)
         + _get_cpp_std_cflag()
         + _get_os_related_cpp_cflags(cpp_compiler)
+        + dbg_cflags
     )
 
     if not _IS_WINDOWS and config.aot_inductor.enable_lto and _is_clang(cpp_compiler):
@@ -686,7 +708,7 @@ def get_cpp_options(
         definitions,
         include_dirs,
         cflags,
-        ldflags,
+        ldflags + dbg_ldflags,
         libraries_dirs,
         libraries,
         passthrough_args,


### PR DESCRIPTION
We need to add inductor debug symbol support for crash case debug. When we turn on generate debug symbol.
On Windows, it should create a [module_name].pdb file. It helps debug by WinDBG.
On Linux, it should create some debug sections in binary file.

I added UT for it also.

It works well on Windows inductor debug.
<img width="1648" height="833" alt="image" src="https://github.com/user-attachments/assets/5282a7de-cef3-4a38-9cd4-a0e63482c8b6" />


cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben