### PR TITLE
[Intel GPU PT2E] Infer runtime out dtype based on dequant node in pattern

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/qlinear.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/qlinear.cpp
@@ -13,9 +13,11 @@ static inline c10::ScalarType qlinear_decide_out_dtype(
   bool fp32_output = output_dtype.has_value() && (output_dtype == c10::kFloat);
   bool bfloat16_output =
       output_dtype.has_value() && (output_dtype == c10::kBFloat16);
+  bool fp16_output = output_dtype.has_value() && (output_dtype == c10::kHalf);
   auto dst_dtype = fp32_output
       ? c10::kFloat
-      : (bfloat16_output ? c10::kBFloat16 : act.scalar_type());
+      : (bfloat16_output ? c10::kBFloat16
+                         : (fp16_output ? c10::kHalf : act.scalar_type()));
   return dst_dtype;
 }
 

--- a/aten/src/ATen/native/mkldnn/xpu/qlinear.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/qlinear.cpp
@@ -10,15 +10,11 @@ namespace at::native::xpu {
 static inline c10::ScalarType qlinear_decide_out_dtype(
     const at::Tensor& act,
     const std::optional<c10::ScalarType> output_dtype) {
-  bool fp32_output = output_dtype.has_value() && (output_dtype == c10::kFloat);
-  bool bfloat16_output =
-      output_dtype.has_value() && (output_dtype == c10::kBFloat16);
-  bool fp16_output = output_dtype.has_value() && (output_dtype == c10::kHalf);
-  auto dst_dtype = fp32_output
-      ? c10::kFloat
-      : (bfloat16_output ? c10::kBFloat16
-                         : (fp16_output ? c10::kHalf : act.scalar_type()));
-  return dst_dtype;
+  if (output_dtype.has_value()) {
+    return output_dtype.value();
+  } else {
+    return act.scalar_type();
+  }
 }
 
 static Tensor q_linear_pointwise(

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -2338,7 +2338,6 @@ class TestPatternMatcher(TestPatternMatcherBase):
         self,
         inputs,
         device="cpu",
-        int8_mixed_bf16=False,
         do_permute=False,
         matcher_check_fn=None,
         bias=True,
@@ -2357,8 +2356,6 @@ class TestPatternMatcher(TestPatternMatcherBase):
                 x = self.softmax(x.to(torch.float32))
                 x = self.linear2(x.to(torch.float16))
                 return x
-
-            #    return  self.linear2(self.softmax(self.linear(x).to(torch.float32)).to(torch.float16))
 
         mod = M(bias).eval().to(device=device, dtype=torch.float16)
         assert isinstance(inputs, tuple)
@@ -2381,7 +2378,6 @@ class TestPatternMatcher(TestPatternMatcherBase):
                 if matcher_check_fn is not None
                 else _default_matcher_check_fn
             ),
-            check_autocast=torch.bfloat16 if int8_mixed_bf16 else torch.float,
             check_quantization=True,
             is_qat=is_qat,
             is_dynamic=is_dynamic,

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1401,7 +1401,7 @@ def quantized_decomposed_quantize_per_tensor_default(
 ) -> Union[TensorBox, ShapeAsConstantBuffer]:
     if input.get_dtype() == torch.bfloat16:
         input = to_dtype(input, torch.float32)
-    assert input.get_dtype() == torch.float32, (
+    assert input.get_dtype() in [torch.float32, torch.float16], (
         f"Expecting input to have dtype torch.float32, but got dtype: {input.get_dtype()}"
     )
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2775,7 +2775,13 @@ if torch._C._has_mkldnn:
         output_shape = list(x.shape)
         # The weight has been transposed during the qlinear weight prepack process.
         output_shape[-1] = w.shape[1]
-        assert output_dtype in [torch.float32, torch.bfloat16, torch.int8, torch.uint8]
+        assert output_dtype in [
+            torch.float32,
+            torch.bfloat16,
+            torch.int8,
+            torch.uint8,
+            torch.float16,
+        ]
         out = x.new_empty(output_shape, dtype=output_dtype)
         return out
 


### PR DESCRIPTION
# Motivation

Current `qlinear_weight_prepack` fx pass at x86Quantizer and XPUQuantizer cannot guarantee the dtype consistency between matched pattern and the replaced pattern.  For example,
```
          x                           w
          |                           |
    deuqnt(fp16)                 dequant(fp16)
          |                            |
          |                        permute
           \                       /
                 addmm(fp16)
```
Would be replaced by
```
             x                        w
              \                      /   
                 qlinear(...,fp32)
```
The original output node data type info is lost during graph rewriting. 

# Solution

As graph talks itself, the output dtype can be inferred from dequant node directly. The PR uses the data type as qlinear output dtype.

# Verification

```bash
    python test/inductor/test_mkldnn_pattern_matcher.py -v -k test_qlinear_fp16_xpu
   python test/inductor/test_mkldnn_pattern_matcher.py -v -k test_qlinear_fp16_cpu
```

```bash
onednn_verbose,v1,primitive,exec,gpu:0,matmul,jit:gemm:any,undef,src:s8::blocked:ab::f0 wei:s8::blocked:ab::f0 bia:f16::blocked:ab::f0_mask2 dst:f16::blocked:ab::f0,attr-scratchpad:user attr-scales:src0:0:f32+dst:0:f32+wei:2:f32,,1x16384:16384x10,0.167969
onednn_verbose,v1,primitive,exec,gpu:0,matmul,ocl:ref:any,undef,src:f16::blocked:ab::f0 wei:s8::blocked:ab::f0 bia:f16::blocked:ab::f0_mask2 dst:f16::blocked:ab::f0,attr-scratchpad:user attr-scales:src0:0:f32+dst:0:f32+wei:2:f32,,1x10:10x20,0.0810547
```


Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #159941



cc @liangan1 @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben 