### PR TITLE
fix fake_tensor for aten._to_copy

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1518,6 +1518,11 @@ class FakeTensorOperatorInvariants(TestCase):
         # it clearly will not work on CPU runner
         if torch._functorch.config.fake_tensor_propagate_real_tensors:
             return
+        
+        cpu_tensor = torch.ones(2, device="cpu")
+        meta_tensor = torch.ones(2, device="meta")
+        linear = torch.nn.Linear(2, 2)
+
         with FakeTensorMode():
             torch.empty(10, device=GPU_TYPE)
             torch.ones(10, device=GPU_TYPE)
@@ -1525,6 +1530,12 @@ class FakeTensorOperatorInvariants(TestCase):
             torch.rand(10, device=GPU_TYPE)
             torch.tensor(3.14, device=GPU_TYPE)
             torch.tensor([[3.14, 2], [1, 2]], device=GPU_TYPE)
+
+            self.assertEqual(cpu_tensor.to(device=GPU_TYPE).device, GPU_TYPE)
+            self.assertEqual(meta_tensor.to(device=GPU_TYPE).device, GPU_TYPE)
+            linear.to(device=GPU_TYPE)
+            for name, param in linear.named_parameters():
+                self.assertEqual(param.device, GPU_TYPE)
 
     @skipIfRocm
     @unittest.skipIf(not RUN_CUDA, "requires cuda")

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -2304,7 +2304,6 @@ class FakeTensorMode(TorchDispatchMode):
         device_conversion_skip_const_prop = (
             func is torch.ops.aten._to_copy.default
             and isinstance(args[0], torch.Tensor)
-            and args[0].device.type == "meta"
         )
 
         # To constant propagate through these functions:

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -930,7 +930,8 @@ class Module:
                 module._apply(fn)
 
         def compute_should_use_set_data(tensor, tensor_applied) -> bool:
-            if torch._has_compatible_shallow_copy_type(tensor, tensor_applied):
+            from torch._subclasses.fake_tensor import FakeTensor 
+            if torch._has_compatible_shallow_copy_type(tensor, tensor_applied) and not isinstance(tensor_applied, FakeTensor):
                 # If the new tensor has compatible tensor type as the existing tensor,
                 # the current behavior is to change the tensor in-place using `.data =`,
                 # and the future behavior is to overwrite the existing tensor. However,
@@ -985,6 +986,7 @@ class Module:
                     ) from e
                 out_param = param
             elif p_should_use_set_data:
+                breakpoint()
                 param.data = param_applied
                 out_param = param
             else:


### PR DESCRIPTION
Summary:
```
with FakeTensorMode(allow_non_fake_inputs=True):
    print(cpu_tensor.to("cuda:0")) # works
    # print(cpu_tensor2.to("cuda")) # crash!
    print(meta_tensor.to("cuda:0")) # works
    module.to("cuda:0") # works
```

Rollback Plan:

Differential Revision: D79690037
