### PR TITLE
Fix redundant move warnings in dim.cpp

### DIFF
--- a/functorch/csrc/dim/dim.cpp
+++ b/functorch/csrc/dim/dim.cpp
@@ -1618,7 +1618,7 @@ static mpy::object create_dim(mpy::object name, mpy::handle size) {
   if (!mpy::is_none(size)) {
     d->set_size(mpy::to_int(size));
   }
-  return std::move(d);
+  return d;
 }
 
 static mpy::object create_dimlist(mpy::object name, mpy::handle size) {
@@ -1634,7 +1634,7 @@ static mpy::object create_dimlist(mpy::object name, mpy::handle size) {
       }
     }
   }
-  return std::move(d);
+  return d;
 }
 
 // Python wrappers that make new reflection primitives available for older


### PR DESCRIPTION
Warnings produced during compilation:

```
DEBUG [2/4] Building CXX object functorch/CMakeFiles/functorch.dir/csrc/dim/dim.cpp.o
DEBUG /home/ubuntu/pytorch/1/functorch/csrc/dim/dim.cpp: In function ‘mpy::object create_dim(mpy::object, mpy::handle)’:
DEBUG /home/ubuntu/pytorch/1/functorch/csrc/dim/dim.cpp:1621:19: warning: redundant move in return statement [-Wredundant-move]
DEBUG  1621 |   return std::move(d);
DEBUG       |          ~~~~~~~~~^~~
DEBUG /home/ubuntu/pytorch/1/functorch/csrc/dim/dim.cpp:1621:19: note: remove ‘std::move’ call
DEBUG /home/ubuntu/pytorch/1/functorch/csrc/dim/dim.cpp: In function ‘mpy::object create_dimlist(mpy::object, mpy::handle)’:
DEBUG /home/ubuntu/pytorch/1/functorch/csrc/dim/dim.cpp:1637:19: warning: redundant move in return statement [-Wredundant-move]
DEBUG  1637 |   return std::move(d);
DEBUG       |          ~~~~~~~~~^~~
DEBUG /home/ubuntu/pytorch/1/functorch/csrc/dim/dim.cpp:1637:19: note: remove ‘std::move’ call
```
