### PR TITLE
Working setup with runnable PyTorch on Codex.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,14 @@
 - This is the only AGENTS.md, there are no recursive AGENTS.md
+- When you are working on a bug, first create a standalone file that
+  reproduces the bug and verify it fails in the expected way.  Use this to
+  test if your changes work.  Once the change is passing, find an appropriate
+  test file to add the test to and make sure to follow local conventions on
+  the test file.
+- If you are running the real test suite, DO NOT run the entire test suite.
+  Instead run only a single test case, e.g., 'python test/test_torch.py TestTorch.test_dir'
 - Do NOT run setup.py, you do not have a working build environment
 - Do NOT run pre-commit, it is not setup
-- Do NOT add tests or try to run tests unless the user has given specific
-  instructions on how to do so.
+- To run lint, run 'lintrunner -a' (which will autoapply changes)
 - Do NOT attempt to install dependencies, you do not have Internet access
 - When you are ready to make a PR, do exactly these steps:
   - git stash -u

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,2 +1,11 @@
 - This is the only AGENTS.md, there are no recursive AGENTS.md
 - Do NOT run setup.py, you do not have a working build environment
+- Do NOT run pre-commit, it is not setup
+- Do NOT add tests or try to run tests unless the user has given specific
+  instructions on how to do so.
+- Do NOT attempt to install dependencies, you do not have Internet access
+- When you are ready to make a PR, do exactly these steps:
+  - git stash -u
+  - git reset --hard $(cat /tmp/orig_work.txt) # NB: reset to the LOCAL branch, do NOT fetch
+  - git stash pop
+  - Resolve conflicts if necessary

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,2 @@
 - This is the only AGENTS.md, there are no recursive AGENTS.md
+- Do NOT run setup.py, you do not have a working build environment

--- a/codex_setup.sh
+++ b/codex_setup.sh
@@ -1,13 +1,17 @@
+set -ex
 uv venv
 source .venv/bin/activate
 uv pip install -r requirements.txt
 uv pip install numpy
-NIGHTLY_PATCH=$(curl -s https://github.com/pytorch/pytorch/commit/nightly.patch)
+NIGHTLY_PATCH=$(curl -s https://github.com/pytorch/pytorch/commit/nightly.patch | head -n20)
 COMMIT=$(grep -oE '[0-9a-f]{40}' <<< "$NIGHTLY_PATCH" | head -1)
 COMMIT_DATE=$(echo "$NIGHTLY_PATCH" | grep '^Date:' | sed -E 's/Date: .*, ([0-9]+) ([A-Za-z]+) ([0-9]+) .*/\3 \2 \1/' | awk 'BEGIN{split("Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec", months, " "); for(i=1;i<=12;i++) month[months[i]]=sprintf("%02d",i)} {print $1 month[$2] sprintf("%02d",$3)}')
 VERSION_STRING="2.9.0.dev${COMMIT_DATE}+cpu"
+git rev-parse HEAD > /tmp/orig_work.txt
+cp AGENTS.md /tmp
 git reset --hard $COMMIT
+cp /tmp/AGENTS.md .
 curl https://patch-diff.githubusercontent.com/raw/pytorch/pytorch/pull/159965.diff | patch -p1
 USE_NIGHTLY=$VERSION_STRING python setup.py develop
-git reset --hard HEAD
-echo "source .venv/bin/activate" >> ~/.bashrc
+git commit -asm "Agents patch"
+echo "source $PWD/.venv/bin/activate" >> ~/.bashrc

--- a/codex_setup.sh
+++ b/codex_setup.sh
@@ -3,6 +3,7 @@ uv venv
 source .venv/bin/activate
 uv pip install -r requirements.txt
 uv pip install numpy
+lintrunner init
 NIGHTLY_PATCH=$(curl -s https://github.com/pytorch/pytorch/commit/nightly.patch | head -n20)
 COMMIT=$(grep -oE '[0-9a-f]{40}' <<< "$NIGHTLY_PATCH" | head -1)
 COMMIT_DATE=$(echo "$NIGHTLY_PATCH" | grep '^Date:' | sed -E 's/Date: .*, ([0-9]+) ([A-Za-z]+) ([0-9]+) .*/\3 \2 \1/' | awk 'BEGIN{split("Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec", months, " "); for(i=1;i<=12;i++) month[months[i]]=sprintf("%02d",i)} {print $1 month[$2] sprintf("%02d",$3)}')

--- a/codex_setup.sh
+++ b/codex_setup.sh
@@ -1,0 +1,9 @@
+uv venv
+source .venv/bin/activate
+uv pip install -r requirements.txt
+#COMMIT=$(curl -s https://api.github.com/repos/pytorch/pytorch/branches/nightly | jq ".commit.commit.message" | sed -E 's/.*\(([0-9a-f]{40})\).*/\1/')
+git reset --hard 74a754aae98aabc2aca67e5edb41cc684fae9a82
+curl https://patch-diff.githubusercontent.com/raw/pytorch/pytorch/pull/159965.diff | patch -p1
+USE_NIGHTLY=2.9.0.dev20250806+cpu python setup.py develop
+git reset --hard HEAD
+echo "source .venv/bin/activate" >> ~/.bashrc

--- a/codex_setup.sh
+++ b/codex_setup.sh
@@ -1,9 +1,13 @@
 uv venv
 source .venv/bin/activate
 uv pip install -r requirements.txt
-#COMMIT=$(curl -s https://api.github.com/repos/pytorch/pytorch/branches/nightly | jq ".commit.commit.message" | sed -E 's/.*\(([0-9a-f]{40})\).*/\1/')
-git reset --hard 74a754aae98aabc2aca67e5edb41cc684fae9a82
+uv pip install numpy
+NIGHTLY_PATCH=$(curl -s https://github.com/pytorch/pytorch/commit/nightly.patch)
+COMMIT=$(grep -oE '[0-9a-f]{40}' <<< "$NIGHTLY_PATCH" | head -1)
+COMMIT_DATE=$(echo "$NIGHTLY_PATCH" | grep '^Date:' | sed -E 's/Date: .*, ([0-9]+) ([A-Za-z]+) ([0-9]+) .*/\3 \2 \1/' | awk 'BEGIN{split("Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec", months, " "); for(i=1;i<=12;i++) month[months[i]]=sprintf("%02d",i)} {print $1 month[$2] sprintf("%02d",$3)}')
+VERSION_STRING="2.9.0.dev${COMMIT_DATE}+cpu"
+git reset --hard $COMMIT
 curl https://patch-diff.githubusercontent.com/raw/pytorch/pytorch/pull/159965.diff | patch -p1
-USE_NIGHTLY=2.9.0.dev20250806+cpu python setup.py develop
+USE_NIGHTLY=$VERSION_STRING python setup.py develop
 git reset --hard HEAD
 echo "source .venv/bin/activate" >> ~/.bashrc


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.11.0) (oldest at bottom):
* __->__ #159968

Sample transcript: https://chatgpt.com/s/cd_68938effc1a88191ae78bc82a8cefe94

This makes use of https://github.com/pytorch/pytorch/pull/159965 to bypass doing an actual build and use nightly.

Things to improve:
- Once USE_NIGHTLY is in main can remove the patching
- We should just keep using the latest nightly, instead of a hard coded one

Signed-off-by: Edward Yang <ezyang@meta.com>