### PR TITLE
Add mast job name from env variable

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -714,6 +714,9 @@ def dynamo_timed(
     if is_backward is not None:
         event_metadata.update({"is_backward": is_backward})
 
+    if "mast_job_name" not in event_metadata:
+        event_metadata["mast_job_name"] = os.environ.get("MAST_HPC_JOB_NAME")
+
     chromium_log: ChromiumEventLogger = get_chromium_event_logger()
     start_ns = time.time_ns()
     chromium_log.log_event_start(


### PR DESCRIPTION
Summary: We see mast job is often empty when reading https://fburl.com/scuba/pt2_compile_events/qiggfzaj. Let's start setting it in with environment variable, per suggestion from romanmeta

Test Plan:
tlp buck run //scripts/sashko:compilation_sample

Rollback Plan:

Differential Revision: D79739051




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela