### PR TITLE
Relax unclaimed successes in dtype op tests when running under TEST_WITH_DYNAMO/TEST_WITH_INDUCTOR

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1601,6 +1601,16 @@ class TestCommon(TestCase):
         ) == 0:
             return
 
+        if TEST_WITH_TORCHDYNAMO:
+            # NOTE: Also for TEST_WITH_TORCHINDUCTOR tests
+            # Under compile, some ops may be decomposed into supported ops
+            # So it is okay to have supported_but_unclaimed_*
+            if (
+                len(claimed_but_unsupported_forward)
+                + len(claimed_but_unsupported_backward)
+            ) == 0:
+                return
+
         # Reference operators often support additional dtypes, and that's OK
         if op in python_ref_db:
             if (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #159875
* __->__ #159976

This PR changes the behavior for compile wrapped op tests:
- supported_but_unclaimed_forward
- supported_but_unclaimed_backward

These typically manifest when the op doesn't support inputs of certain dtypes. But under torch.compile, Dynamo/AOTAutograd will trace the graph with FakeTensors, which @ezyang and @eellison tell me need to run decomps before op dispatch. The decomp may map this test to a different op, one that does support the dtype. I suspect all of our failures here are due to decomps, and so I propose to just disable this check for compile.

~~TODO: re-enable all the failed tests.~~ jk there were no failed tests outside of compiled autograd due to this. 