### PR TITLE
[nativert] Expose ModelRunner to public through pmpl type ModelRunnerHandle.

### DIFF
--- a/torch/csrc/api/include/torch/nativert/ModelRunnerHandle.h
+++ b/torch/csrc/api/include/torch/nativert/ModelRunnerHandle.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <ATen/core/ivalue.h>
+#include <c10/macros/Export.h>
+
+namespace torch::nativert {
+
+// We don't want to forward declare in general but including ModelRunner will
+// pollute the public API namespace too much. Therefore, we just use pimpl an
+// incomplete ModelRunner here.
+class ModelRunner;
+
+class TORCH_API ModelRunnerHandle {
+ public:
+  ModelRunnerHandle(
+      const std::string& packagePath,
+      const std::string& modelName);
+
+  ModelRunnerHandle(ModelRunnerHandle&&) = default;
+  ModelRunnerHandle& operator=(ModelRunnerHandle&&) = default;
+  ModelRunnerHandle(const ModelRunnerHandle&) = delete;
+  ModelRunnerHandle& operator=(const ModelRunnerHandle&) = delete;
+  ~ModelRunnerHandle();
+
+  c10::IValue run(
+      const std::vector<c10::IValue>& args,
+      const std::unordered_map<std::string, c10::IValue>& kwargs);
+
+  /**
+   * A low level API which expects user to always pass in flattened inputs.
+   * The ownership of the entire input list must be transferred to the
+   * executor via std::move or in-place construction.
+   */
+  std::vector<c10::IValue> runWithFlatInputsAndOutputs(
+      std::vector<c10::IValue> flatInputs);
+
+ private:
+  std::unique_ptr<ModelRunner> impl_;
+};
+
+} // namespace torch::nativert

--- a/torch/nativert/ModelRunner.cpp
+++ b/torch/nativert/ModelRunner.cpp
@@ -136,4 +136,21 @@ std::vector<c10::IValue> ModelRunner::runWithFlatInputsAndOutputs(
   return executor_->execute(std::move(flatInputs));
 }
 
+ModelRunnerHandle::ModelRunnerHandle(
+    const std::string& packagePath,
+    const std::string& modelName)
+    : impl_(std::make_unique<ModelRunner>(packagePath, modelName)) {}
+ModelRunnerHandle::~ModelRunnerHandle() = default;
+
+c10::IValue ModelRunnerHandle::run(
+    const std::vector<c10::IValue>& args,
+    const std::unordered_map<std::string, c10::IValue>& kwargs) {
+  return impl_->run(args, kwargs);
+}
+
+std::vector<c10::IValue> ModelRunnerHandle::runWithFlatInputsAndOutputs(
+    std::vector<c10::IValue> flatInputs) {
+  return impl_->runWithFlatInputsAndOutputs(std::move(flatInputs));
+}
+
 } // namespace torch::nativert

--- a/torch/nativert/ModelRunner.h
+++ b/torch/nativert/ModelRunner.h
@@ -4,6 +4,7 @@
 
 #include <c10/macros/Export.h>
 #include <torch/csrc/utils/generated_serialization_types.h>
+#include <torch/nativert/ModelRunnerHandle.h>
 #include <torch/nativert/detail/ITree.h>
 #include <torch/nativert/executor/Executor.h>
 #include <torch/nativert/executor/Placement.h>


### PR DESCRIPTION
Summary:
Today users outside of pytorch core cannot `#include <torch/nativert/ModelRunner.h>`.

It turns out that we should place a header inside `torch/csrc/api/include/`. Placing every single nativert header here would pollute the namespace a lot and that's not what we want in general. Therefore here we just create a Handle type which hold a pointer to decouple the actual type from header definition.

Test Plan:
CI

Rollback Plan:

Differential Revision: D79751098
