### PR TITLE
Allow setting quantized engine to none

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -738,6 +738,7 @@ const std::vector<at::QEngine>& Context::supportedQEngines() {
   static auto supported_qengines = []() {
     std::vector<at::QEngine> engines = {};
     // Engines are listed in priority order: later one wins
+    engines.push_back(at::kNoQEngine);
     // By default we prefer FBGEMM if we're running on server side
     // QNNPACK on server side has some issue, so we disable it by default.
 #ifdef USE_PYTORCH_QNNPACK

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -9741,7 +9741,7 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
     # FIXME: port to a quantization test suite
     @xfailIfS390X
     def test_qengine(self):
-        qengines = torch.backends.quantized.supported_engines
+        qengines = ['none'] + torch.backends.quantized.supported_engines
         original_qe = torch.backends.quantized.engine
         for qe in qengines:
             torch.backends.quantized.engine = qe


### PR DESCRIPTION
## Summary
- allow `NoQEngine` in `supportedQEngines` so the quantized engine can be reset to `none`
- exercise setting the quantized engine to `none` in `test_qengine`

## Testing
- `python repro_noqengine.py` (fails: quantized engine NoQEngine is not supported)
- `python test/test_torch.py TestTorch.test_qengine` (fails: quantized engine NoQEngine is not supported)


------
https://chatgpt.com/codex/tasks/task_e_6893ceb3a16483238fa4e0e6f02b7d03