### PR TITLE
turn on executon frame clenaup by default

### DIFF
--- a/torch/nativert/executor/ExecutorConfig.h
+++ b/torch/nativert/executor/ExecutorConfig.h
@@ -11,7 +11,7 @@ struct ExecutorConfig {
   bool debugNan = false;
   bool enableStaticCPUKernels = true;
   bool runConstFolding = false;
-  bool doExecutionFrameCleanup = false;
+  bool doExecutionFrameCleanup = true;
   bool tryFreeUnmanagedValuesAfterUse = true;
   // allows up to max number of concurrent threads.
   int64_t maxNumConcurrentThreads = 8;


### PR DESCRIPTION
Summary: Turning execution frame cleanup back on since D78621408 is done

Test Plan:
See D78621408

Rollback Plan:

Differential Revision: D79730674


