### PR TITLE
ci: Update permissions to include checks + actions

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -35,6 +35,8 @@ jobs:
       pull-requests: write
       checks: read
       actions: read
+      metadata: read
+      repository-projects: read
     name: Check labels
     if: github.repository_owner == 'pytorch'
     runs-on: linux.24_04.4x

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -36,8 +36,7 @@ jobs:
       checks: read
       actions: read
     name: Check labels
-    # Disabling the job until https://github.com/pytorch/pytorch/issues/159825 is resolved
-    if: github.repository_owner == 'pytorch' && false
+    if: github.repository_owner == 'pytorch'
     runs-on: linux.24_04.4x
     steps:
       - name: Checkout PyTorch

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -33,6 +33,8 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      checks: read
+      actions: read
     name: Check labels
     # Disabling the job until https://github.com/pytorch/pytorch/issues/159825 is resolved
     if: github.repository_owner == 'pytorch' && false

--- a/.github/workflows/check_mergeability_ghstack.yml
+++ b/.github/workflows/check_mergeability_ghstack.yml
@@ -12,6 +12,8 @@ jobs:
       pull-requests: read
       checks: read
       actions: read
+      metadata: read
+      repository-projects: read
     if: github.repository_owner == 'pytorch'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/check_mergeability_ghstack.yml
+++ b/.github/workflows/check_mergeability_ghstack.yml
@@ -12,8 +12,7 @@ jobs:
       pull-requests: read
       checks: read
       actions: read
-    # Disabling the job until https://github.com/pytorch/pytorch/issues/159825 is resolved
-    if: github.repository_owner == 'pytorch' && false
+    if: github.repository_owner == 'pytorch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/check_mergeability_ghstack.yml
+++ b/.github/workflows/check_mergeability_ghstack.yml
@@ -7,6 +7,11 @@ on:
 
 jobs:
   ghstack-mergeability-check:
+    permissions:
+      contents: read
+      pull-requests: read
+      checks: read
+      actions: read
     # Disabling the job until https://github.com/pytorch/pytorch/issues/159825 is resolved
     if: github.repository_owner == 'pytorch' && false
     runs-on: ubuntu-latest


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #160118

These workflows were failing since we now need explicit mentions of
these permissions.

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>