### PR TITLE
[AOTI] use CudaCachingAllocator for memory allocation

### DIFF
--- a/torch/csrc/inductor/aoti_runtime/model_container.h
+++ b/torch/csrc/inductor/aoti_runtime/model_container.h
@@ -681,7 +681,14 @@ class AOTInductorModelContainer {
   std::shared_mutex model_exec_mutex_;
 
   RAIIDataPtr allocate_constant_blob() {
-#if defined(USE_CUDA) || defined(USE_XPU) || defined(USE_MPS)
+#if defined(USE_CUDA)
+#ifdef AOT_INDUCTOR_USE_CACHING_ALLOCATOR
+    return RAII_gpuMalloc_with_caching_allocator(
+        blob_size_, models_[0]->get_device_idx());
+#else
+    return RAII_gpuMalloc(blob_size_);
+#endif // AOT_INDUCTOR_USE_CACHING_ALLOCATOR
+#elif defined(USE_XPU) || defined(USE_MPS)
     return RAII_gpuMalloc(blob_size_);
 #else
     return RAII_cpuMalloc(blob_size_);


### PR DESCRIPTION
use CUDACachingAllocator for AOTI memory allocation. 

python3 setup.py clean && DEBUG=1 BUILD_AOT_INDUCTOR_TEST=1 USE_CUDA=1 python3 setup.py develop --cmake && LD_LIBRARY_PATH=/data/users/$USER/pytorch/build/lib /home/$USER/local/pytorch/build/bin/test_aoti_inference


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben