### PR TITLE
[AOTI] use CudaCachingAllocator for memory allocation

### DIFF
--- a/test/cpp/aoti_inference/test.cpp
+++ b/test/cpp/aoti_inference/test.cpp
@@ -884,12 +884,24 @@ void test_cuda_alloc_test() {
   size_t initTorchActive = stats.active_bytes[0].current;
   auto runner = std::make_unique<torch::inductor::AOTIModelContainerRunnerCuda>(
       model_so_path);
-  size_t torchActive = stats.active_bytes[0].current;
-
-  ASSERT_EQ(initTorchActive + DATASIZE, torchActive);
 
   auto actual_output_tensors =
       runner->run(data_loader.attr(inputs_attr.c_str()).toTensorList().vec());
+
+  stats = c10::cuda::CUDACachingAllocator::getDeviceStats(device_idx);
+  size_t torchActive = stats.active_bytes[0].current;
+
+  // CUDACachingAllocator may round up allocations to larger block sizes
+  // We should see at least DATASIZE increase, but it might be more due to
+  // rounding
+  size_t actualIncrease = torchActive - initTorchActive;
+  ASSERT_GE(actualIncrease, DATASIZE)
+      << "Expected at least " << DATASIZE << " bytes increase, got "
+      << actualIncrease;
+  ASSERT_LE(actualIncrease, DATASIZE * 2)
+      << "Expected at most " << (DATASIZE * 2) << " bytes increase, got "
+      << actualIncrease;
+
   ASSERT_TRUE(torch::allclose(ref_output_tensors[0], actual_output_tensors[0]));
 }
 #endif
@@ -1113,8 +1125,7 @@ TEST(AotInductorTest, MultiStreamTestCuda) {
   test_multi_cuda_streams("cuda");
 }
 
-// TODO: ENABLE CUDACachingAllocator Test
-TEST(DISABLED_AotInductorTest, CudaAllocTestCuda) {
+TEST(AotInductorTest, CudaAllocTestCuda) {
   test_cuda_alloc_test();
 }
 #endif

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -1094,6 +1094,15 @@ def get_mmap_self_macro(use_mmap_weights: bool) -> list[str]:
     return macros
 
 
+def get_caching_allocator_macro() -> list[str]:
+    from torch._inductor import config
+
+    macros = []
+    if config.aot_inductor.weight_use_caching_allocator:
+        macros.append(" AOT_INDUCTOR_USE_CACHING_ALLOCATOR")
+    return macros
+
+
 def get_cpp_torch_options(
     cpp_compiler: str,
     vec_isa: VecISA,
@@ -1150,6 +1159,7 @@ def get_cpp_torch_options(
     fb_macro_passthrough_args = _use_fb_internal_macros()
 
     mmap_self_macros = get_mmap_self_macro(use_mmap_weights)
+    caching_allocator_macros = get_caching_allocator_macro()
 
     definitions = (
         torch_cpp_wrapper_definitions
@@ -1157,6 +1167,7 @@ def get_cpp_torch_options(
         + isa_macros
         + fb_macro_passthrough_args
         + mmap_self_macros
+        + caching_allocator_macros
     )
     include_dirs = (
         sys_libs_include_dirs

--- a/torch/csrc/inductor/aoti_runtime/model_container.h
+++ b/torch/csrc/inductor/aoti_runtime/model_container.h
@@ -681,7 +681,14 @@ class AOTInductorModelContainer {
   std::shared_mutex model_exec_mutex_;
 
   RAIIDataPtr allocate_constant_blob() {
-#if defined(USE_CUDA) || defined(USE_XPU) || defined(USE_MPS)
+#if defined(USE_CUDA)
+#ifdef AOT_INDUCTOR_USE_CACHING_ALLOCATOR
+    return RAII_gpuMalloc_with_caching_allocator(
+        blob_size_, models_[0]->get_device_idx());
+#else
+    return RAII_gpuMalloc(blob_size_);
+#endif // AOT_INDUCTOR_USE_CACHING_ALLOCATOR
+#elif defined(USE_XPU) || defined(USE_MPS)
     return RAII_gpuMalloc(blob_size_);
 #else
     return RAII_cpuMalloc(blob_size_);


### PR DESCRIPTION
use CUDACachingAllocator for AOTI memory allocation. 

python3 setup.py clean && DEBUG=1 BUILD_AOT_INDUCTOR_TEST=1 USE_CUDA=1 python3 setup.py develop --cmake && LD_LIBRARY_PATH=/data/users/$USER/pytorch/build/lib /home/$USER/local/pytorch/build/bin/test_aoti_inference


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben