### PR TITLE
dynamo: Write a structured trace for supressed exceptions.

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1435,6 +1435,15 @@ class ConvertFrame:
             else:
                 log.warning(error_msg, exc_info=True)
 
+            torch._logging.trace_structured(
+                "artifact",
+                metadata_fn=lambda: {
+                    "name": "dynamo_exception",
+                    "encoding": "string",
+                },
+                payload_fn=lambda: error_msg,
+            )
+
             if isinstance(e, SkipCodeRecursiveException):
                 return ConvertFrameReturn(
                     frame_exec_strategy=FrameExecStrategy(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #160151
* #159691

Trying to understand a supressed exception when nothing shows up in TLParse is
relatively confusing. Logging this explicitly to make it elss confusing.

This also needs a TLParse diff to finish it.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela