### PR TITLE
[1/N] Port 6 fsdp distributed test cases to Intel GPU

### DIFF
--- a/test/distributed/fsdp/test_fsdp_pure_fp16.py
+++ b/test/distributed/fsdp/test_fsdp_pure_fp16.py
@@ -152,6 +152,6 @@ class TestPureFP16(FSDPTest):
 
 
 devices = ("cuda", "hpu", "xpu")
-instantiate_device_type_tests(TestPureFP16, globals(), only_for=devices)
+instantiate_device_type_tests(TestPureFP16, globals(), only_for=devices, allow_xpu=True)
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_fsdp_sharded_grad_scaler.py
+++ b/test/distributed/fsdp/test_fsdp_sharded_grad_scaler.py
@@ -35,6 +35,7 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
     TEST_WITH_DEV_DBG_ASAN,
+    TEST_XPU,
     TestCase,
 )
 
@@ -50,6 +51,8 @@ if TEST_WITH_DEV_DBG_ASAN:
         file=sys.stderr,
     )
     sys.exit(0)
+
+device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
 
 
 params = "cpu_offload,sharding_strategy,mixed_precision,use_orig_params"
@@ -76,11 +79,14 @@ subtest_name = functools.partial(subtest_name, test_name_mapping)
 
 class TestShardGradScaler(TestCase):
     @unittest.skipIf(
-        amp_definitely_not_available(), "no supported device (cuda, xla) found"
+        amp_definitely_not_available() and not TEST_XPU,
+        "no supported device (cuda, xla, xpu) found",
     )
     def test_grad_scaling(self):
         pg = DummyProcessGroup(0, 1)
-        scaler = ShardedGradScaler(init_scale=2.0, process_group=pg, enabled=True)
+        scaler = ShardedGradScaler(
+            device=device_type, init_scale=2.0, process_group=pg, enabled=True
+        )
         t0 = torch.full((1,), 4.0, dtype=torch.float32, device="cpu")
         t1 = torch.full((1,), 8.0, dtype=torch.float32, device="cpu")
         outputs = [t1.clone(), (t0.clone(), t1.clone()), [t0.clone(), t1.clone()]]
@@ -92,11 +98,14 @@ class TestShardGradScaler(TestCase):
         self.assertTrue(scaler._scale.device == t1.device)
 
     @unittest.skipIf(
-        amp_definitely_not_available(), "no supported device (cuda, xla) found"
+        amp_definitely_not_available() and not TEST_XPU,
+        "no supported device (cuda, xla, xpu) found",
     )
     def test_scaling_unscaling_sparse(self):
         pg = DummyProcessGroup(0, 1)
-        scaler = ShardedGradScaler(init_scale=2.0, process_group=pg, enabled=True)
+        scaler = ShardedGradScaler(
+            device=device_type, init_scale=2.0, process_group=pg, enabled=True
+        )
         inv_scale = torch.full((1,), 0.5, dtype=torch.float, device="cpu")
         found_inf = torch.full((1,), 0, dtype=torch.float, device="cpu")
 
@@ -137,11 +146,14 @@ class TestShardGradScaler(TestCase):
         self.assertEqual(found_inf, 1.0)
 
     @unittest.skipIf(
-        amp_definitely_not_available(), "no supported device (cuda, xla) found"
+        amp_definitely_not_available() and not TEST_XPU,
+        "no supported device (cuda, xla, xpu) found",
     )
     def test_inf_gradients_skip_optim_step(self):
         pg = DummyProcessGroup(0, 1)
-        scaler = ShardedGradScaler(init_scale=2.0, process_group=pg, enabled=True)
+        scaler = ShardedGradScaler(
+            device=device_type, init_scale=2.0, process_group=pg, enabled=True
+        )
         loss = torch.full((1,), 4.0, dtype=torch.float32, device="cpu")
         t0 = torch.tensor([float("inf")], dtype=torch.float32, device="cpu")
         t0.grad = t0.clone()
@@ -228,8 +240,9 @@ class TestShardedGradScalerParityWithDDP(FSDPTest):
                 {
                     TransformerEncoderLayer,
                     TransformerDecoderLayer,
-                }
+                },
             ),
+            "device_id": self.rank,
         }
         model = FSDP(model, **fsdp_kwargs)
         optim = torch.optim.Adam(model.parameters(), lr=1e-2)
@@ -257,10 +270,10 @@ class TestShardedGradScalerParityWithDDP(FSDPTest):
             cpu_offload=cpu_offload,
             use_orig_params=use_orig_params,
         )
-        grad_scaler = ShardedGradScaler(init_scale=2.0)
-        ref_grad_scaler = torch.amp.GradScaler(device="cuda", init_scale=2.0)
+        grad_scaler = ShardedGradScaler(device=device_type, init_scale=2.0)
+        ref_grad_scaler = torch.amp.GradScaler(device=device_type, init_scale=2.0)
         scaled_losses: list[torch.Tensor] = []
-        device = torch.device("cuda")
+        device = torch.device(device_type)
         torch.manual_seed(42 + self.rank + 1)
 
         for iter in range(10):

--- a/test/distributed/fsdp/test_fsdp_state_dict.py
+++ b/test/distributed/fsdp/test_fsdp_state_dict.py
@@ -97,6 +97,8 @@ STATE_DICT_MAPPING = {
     "sharded_state_dict": StateDictType.SHARDED_STATE_DICT,
 }
 
+device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
+
 
 class Model(Module):
     def __init__(
@@ -155,13 +157,13 @@ class TestDummyModel(torch.nn.Module):
         return self.net3(self.net2(self.net1(x)))
 
     def get_input(self):
-        return torch.rand(8, 8, device="cuda")
+        return torch.rand(8, 8, device=device_type)
 
 
 class TestFSDPStateDict(FSDPTest):
     @property
     def world_size(self):
-        return min(torch.cuda.device_count(), 2)
+        return min(torch.accelerator.device_count(), 2)
 
     def _broadcast_state_dict(self, state_dict):
         return _broadcast_state_dict(self.rank, state_dict)
@@ -196,8 +198,8 @@ class TestFSDPStateDict(FSDPTest):
         self, *fsdp_args, wrap=True, checkpoint_wrap=False, **fsdp_kwargs
     ):
         if wrap:
-            lin1 = nn.Linear(10, 10, bias=False).cuda()
-            lin2 = nn.Linear(10, 10, bias=False).cuda()
+            lin1 = nn.Linear(10, 10, bias=False).to(device_type)
+            lin2 = nn.Linear(10, 10, bias=False).to(device_type)
             if checkpoint_wrap:
                 lin1 = checkpoint_wrapper(lin1)
                 lin2 = checkpoint_wrapper(lin2)
@@ -207,13 +209,13 @@ class TestFSDPStateDict(FSDPTest):
             model = FSDP(seq, *fsdp_args, **fsdp_kwargs)
         else:
             model = nn.Sequential(
-                nn.Linear(10, 10, bias=False).cuda(),
-                nn.Linear(10, 10, bias=False).cuda(),
+                nn.Linear(10, 10, bias=False).to(device_type),
+                nn.Linear(10, 10, bias=False).to(device_type),
             )
         return model
 
     def _get_simple_model(self, *fsdp_args, checkpoint_wrap=False, **fsdp_kwargs):
-        lin = nn.Linear(10, 10, bias=False).cuda()
+        lin = nn.Linear(10, 10, bias=False).to(device_type)
         if checkpoint_wrap:
             lin = checkpoint_wrapper(lin)
         model = FSDP(lin, *fsdp_args, **fsdp_kwargs)
@@ -230,9 +232,9 @@ class TestFSDPStateDict(FSDPTest):
             else None
         )
         if wrap:
-            lin1 = nn.Linear(10, 10, bias=False).cuda()
-            bn1 = nn.BatchNorm1d(10).cuda()
-            lin2 = nn.Linear(10, 10, bias=False).cuda()
+            lin1 = nn.Linear(10, 10, bias=False).to(device_type)
+            bn1 = nn.BatchNorm1d(10).to(device_type)
+            lin2 = nn.Linear(10, 10, bias=False).to(device_type)
             if checkpoint_wrap:
                 lin1 = checkpoint_wrapper(lin1)
                 bn1 = checkpoint_wrapper(bn1)
@@ -247,9 +249,9 @@ class TestFSDPStateDict(FSDPTest):
             model = FSDP(seq, *fsdp_args, **fsdp_kwargs)
         else:
             model = nn.Sequential(
-                nn.Linear(10, 10, bias=False).cuda(),
-                nn.BatchNorm1d(10).cuda(),
-                nn.Linear(10, 10, bias=False).cuda(),
+                nn.Linear(10, 10, bias=False).to(device_type),
+                nn.BatchNorm1d(10).to(device_type),
+                nn.Linear(10, 10, bias=False).to(device_type),
             )
         return model
 
@@ -257,7 +259,7 @@ class TestFSDPStateDict(FSDPTest):
         class FSDPContainer(nn.Module):
             def __init__(self, fsdp_1, fsdp_2):
                 super().__init__()
-                self.non_fsdp_lin = nn.Linear(10, 10, bias=False).cuda()
+                self.non_fsdp_lin = nn.Linear(10, 10, bias=False).to(device_type)
                 self.fsdp_1 = fsdp_1
                 self.fsdp_2 = fsdp_2
 
@@ -505,7 +507,7 @@ class TestFSDPStateDict(FSDPTest):
         # Broadcast the module states from rank 0 with `sync_module_states=True`
         new_fsdp_model = FSDP(
             new_model,
-            device_id=torch.cuda.current_device(),
+            device_id=torch.accelerator.current_device_index(),
             auto_wrap_policy=auto_wrap_policy,
             sync_module_states=True,
         )
@@ -602,7 +604,7 @@ class TestFSDPStateDict(FSDPTest):
 
             model_new = model_call()
             if not cpu_offload.offload_params:
-                model_new = model_new.cuda()
+                model_new = model_new.to(device_type)
             if fp16:
                 model_new.half()
             # Run a forward/backward to compute gradients to test the case
@@ -677,7 +679,7 @@ class TestFSDPStateDict(FSDPTest):
 
         model_new = model_call()
         if not cpu_offload.offload_params:
-            model_new = model_new.cuda()
+            model_new = model_new.to(device_type)
 
         # zero the model to ensure parameters are different.
         _zero_model(model_new, zero_buffers=True)
@@ -704,7 +706,7 @@ class TestFSDPStateDict(FSDPTest):
         """
         if state_dict_rank0_and_offload and state_dict_type != "state_dict":
             return
-        torch.cuda.set_device(self.rank)
+        torch.accelerator.set_device_index(self.rank)
         mixed_precision = (
             MixedPrecision(
                 param_dtype=torch.float16,
@@ -718,7 +720,7 @@ class TestFSDPStateDict(FSDPTest):
         optim = torch.optim.SGD(model.parameters(), lr=0.1)
         initial_params = get_full_params(model)
         for _ in range(6):
-            inp = torch.randn(1, 10, device=torch.cuda.current_device())
+            inp = torch.randn(1, 10, device=torch.accelerator.current_device_index())
             output = model(*inp)
             loss = output.sum()
             expected_dtype = torch.float32 if mixed_precision is None else torch.float16
@@ -768,7 +770,7 @@ class TestFSDPStateDict(FSDPTest):
         # keep everything deterministic for input data
         torch.manual_seed(0)
 
-        model = Model(wrap_fsdp, register_buffers=register_buffers).cuda()
+        model = Model(wrap_fsdp, register_buffers=register_buffers).to(device_type)
         if wrap_fsdp:
             model = FSDP(model)
         elif wrap_ddp:
@@ -804,7 +806,9 @@ class TestFSDPStateDict(FSDPTest):
         model = self._initialize_model(wrap_fsdp)
         optim = SGD(model.parameters(), lr=0.1)
 
-        in_data = torch.rand(64, 4, requires_grad=True, device=torch.device("cuda"))
+        in_data = torch.rand(
+            64, 4, requires_grad=True, device=torch.device(device_type)
+        )
         for _ in range(3):
             out = model(in_data)
             out.sum().backward()
@@ -812,7 +816,7 @@ class TestFSDPStateDict(FSDPTest):
             optim.zero_grad()
 
         if wrap_fsdp:
-            blank_model = FSDP(Model(True).cuda())
+            blank_model = FSDP(Model(True).to(device_type))
             _zero_model(blank_model)
             state_dict = self._state_dict(model, state_dict_type)
             if move_to_cpu:
@@ -884,10 +888,12 @@ class TestFSDPStateDict(FSDPTest):
         optim = SGD(model.parameters(), lr=0.1)
         if not fsdp_root:
             in_data = torch.randn(
-                1, 10, requires_grad=True, device=torch.device("cuda")
+                1, 10, requires_grad=True, device=torch.device(device_type)
             )
         else:
-            in_data = torch.rand(64, 4, requires_grad=True, device=torch.device("cuda"))
+            in_data = torch.rand(
+                64, 4, requires_grad=True, device=torch.device(device_type)
+            )
         for _ in range(3):
             out = model(in_data)
             out.sum().backward()
@@ -943,7 +949,7 @@ class TestFSDPStateDict(FSDPTest):
     @parametrize("state_dict_type", _SUPPORTED_STATE_DICT_IMPLS)
     @parametrize("double_nest", [True])
     def test_state_dict_skip_module(self, state_dict_type, double_nest):
-        torch.cuda.set_device(self.rank)
+        torch.accelerator.set_device_index(self.rank)
 
         def _create_module(wrap_fsdp=True):
             LINEAR_SKIP = "linear_skip"
@@ -968,7 +974,7 @@ class TestFSDPStateDict(FSDPTest):
 
         fsdp, _ = _create_module()
         # Run a forward pass
-        inp = torch.randn((1, 10), device=torch.cuda.current_device())
+        inp = torch.randn((1, 10), device=torch.accelerator.current_device_index())
         loss = fsdp(inp)
         loss.sum().backward()
 
@@ -1016,7 +1022,7 @@ class TestFSDPStateDict(FSDPTest):
 
     @skip_if_lt_x_gpu(2)
     def test_wrong_state_dict_config(self):
-        model = FSDP(Model(wrap_fsdp=True).cuda())
+        model = FSDP(Model(wrap_fsdp=True).to(device_type))
         with self.assertRaisesRegex(RuntimeError, "Expected state_dict_config of type"):
             with model.state_dict_type(
                 model, StateDictType.FULL_STATE_DICT, LocalStateDictConfig()
@@ -1038,7 +1044,7 @@ class TestFSDPStateDict(FSDPTest):
             register_buffers=True,
             ignore_inner=ignore_inner,
             mixed_precision=mixed_precision,
-        ).cuda()
+        ).to(device_type)
         ignored_modules = [model.outer]
         ignored_tensor_to_tensor_name = {
             model.outer.bias: "outer.bias",
@@ -1097,7 +1103,7 @@ class TestFSDPStateDict(FSDPTest):
             self.assertEqual(sd1[prefixed_buffer_name].dtype, torch.float32)
         # Check that the state dict can be loaded into a non-wrapped version of
         # the model
-        nonwrapped_model = Model(wrap_fsdp=False, register_buffers=True).cuda()
+        nonwrapped_model = Model(wrap_fsdp=False, register_buffers=True).to(device_type)
         for param in nonwrapped_model.parameters():
             with torch.no_grad():
                 param.zero_()
@@ -1144,7 +1150,7 @@ class TestFSDPStateDict(FSDPTest):
             def forward(self, x):
                 return self.my_parameter
 
-        model = FSDP(Model().cuda())
+        model = FSDP(Model().to(device_type))
         with FSDP.state_dict_type(model, StateDictType.LOCAL_STATE_DICT):
             out = model(None)
             out.backward()
@@ -1153,7 +1159,7 @@ class TestFSDPStateDict(FSDPTest):
             with torch.no_grad():
                 with FSDP.summon_full_params(model):
                     self.assertEqual(model.my_parameter.item(), 3.1415926)
-                    model.my_parameter.copy_(torch.full((1,), 1.75).cuda())
+                    model.my_parameter.copy_(torch.full((1,), 1.75).to(device_type))
                     self.assertEqual(model.my_parameter.item(), 1.75)
             model.load_state_dict(state_dict)
             with FSDP.summon_full_params(model):
@@ -1161,7 +1167,7 @@ class TestFSDPStateDict(FSDPTest):
 
     @skip_if_lt_x_gpu(2)
     def test_torch_save_load(self):
-        model = Model(wrap_fsdp=True).cuda()
+        model = Model(wrap_fsdp=True).to(device_type)
         with FSDP.state_dict_type(model, StateDictType.LOCAL_STATE_DICT):
             state_dict = model.state_dict()
             checkpoint = io.BytesIO()
@@ -1192,7 +1198,7 @@ class TestFSDPStateDict(FSDPTest):
 
     @skip_if_lt_x_gpu(2)
     def test_shared_module_and_shared_parameter(self):
-        model = FSDP(TestDummyModel().cuda())
+        model = FSDP(TestDummyModel().to(device_type))
         with FSDP.state_dict_type(model, StateDictType.FULL_STATE_DICT):
             state_dict = model.state_dict()
             self.assertEqual(
@@ -1226,7 +1232,8 @@ class TestFSDPStateDict(FSDPTest):
         }
         for load_cpu in [True, False]:
             with self.subTest(load_cpu=load_cpu):
-                pg = dist.new_group(backend="cpu:gloo,cuda:nccl")
+                backend = torch.distributed.get_default_backend_for_device(device_type)
+                pg = dist.new_group(backend=f"cpu:gloo,{device_type}:{backend}")
                 fsdp_model = TransformerWithSharedParams.init(
                     pg,
                     FSDPInitMode.RECURSIVE,
@@ -1272,7 +1279,7 @@ class TestFSDPStateDict(FSDPTest):
 class TestFSDPStateDict4GPUs(FSDPTest):
     @property
     def world_size(self):
-        return torch.cuda.device_count()
+        return torch.accelerator.device_count()
 
     @skip_if_lt_x_gpu(4)
     def test_local_state_dict_reshard(self):
@@ -1282,10 +1289,10 @@ class TestFSDPStateDict4GPUs(FSDPTest):
         local_state_dict, there are still some corner cases that
         using local_state_dict is a better solution.
         """
-        model = FSDP(Model(wrap_fsdp=True)).cuda()
+        model = FSDP(Model(wrap_fsdp=True)).to(device_type)
         optim = torch.optim.SGD(model.parameters(), lr=0.1)
 
-        batch = torch.randn(4, 4, device=torch.cuda.current_device())
+        batch = torch.randn(4, 4, device=torch.accelerator.current_device_index())
         output = model(batch)
         loss = output.sum()
         loss.backward()
@@ -1319,7 +1326,7 @@ class TestFSDPStateDict4GPUs(FSDPTest):
         if rank < 2:
             model2 = FSDP(
                 Model(wrap_fsdp=True, process_group=new_pg), process_group=new_pg
-            ).cuda()
+            ).to(device_type)
             with FSDP.state_dict_type(model2, StateDictType.LOCAL_STATE_DICT):
                 model2.load_state_dict(resharded_state_dict)
 

--- a/test/distributed/fsdp/test_fsdp_traversal.py
+++ b/test/distributed/fsdp/test_fsdp_traversal.py
@@ -29,8 +29,8 @@ if TEST_WITH_DEV_DBG_ASAN:
 class TestTraversal(FSDPTest):
     @property
     def world_size(self):
-        if torch.cuda.is_available():
-            gpu_cnt = torch.cuda.device_count()
+        if torch.torch.accelerator.is_available():
+            gpu_cnt = torch.accelerator.device_count()
             if gpu_cnt < 2:
                 return gpu_cnt
         return 2
@@ -62,6 +62,8 @@ class TestTraversal(FSDPTest):
 
 
 devices = ("cuda", "hpu", "xpu")
-instantiate_device_type_tests(TestTraversal, globals(), only_for=devices)
+instantiate_device_type_tests(
+    TestTraversal, globals(), only_for=devices, allow_xpu=True
+)
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
For https://github.com/pytorch/pytorch/issues/114850, we will port distributed tests to Intel GPU. 
We could enable Intel GPU with following methods and try the best to keep the original code styles:


- Instantiate_device_type_tests()
- Use "torch.accelerator.current_accelerator()" to determine the accelerator backend
- Enabled XPU for some test path
- Added allow_xpu=True for supported test class


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci @gujinghui @EikanWang @fengyuan14 @guangyey @fritzo @neerajprad @alicanb @nikitaved