### PR TITLE
Support NUMA Binding for Callable Entrypoints

### DIFF
--- a/docs/source/elastic/numa.rst
+++ b/docs/source/elastic/numa.rst
@@ -3,8 +3,8 @@
 NUMA Binding Utilities
 ======================
 
-.. automodule:: torch.distributed.numa
+.. automodule:: torch.numa
    :members:
 
-.. automodule:: torch.distributed.numa.binding
+.. automodule:: torch.numa.binding
    :members:

--- a/test/test_numa_binding.py
+++ b/test/test_numa_binding.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
+import multiprocessing.spawn as spawn
+import os
 import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass
 from typing import Any, Optional
-from unittest import skipIf, skipUnless
+from unittest import skipUnless
 from unittest.mock import mock_open, patch
 
 import torch
 from torch.distributed.elastic.multiprocessing import DefaultLogsSpecs, start_processes
-from torch.distributed.numa.binding import (
+from torch.numa.binding import (
     _get_ranges_str_from_ints,
     _get_set_of_int_from_ranges_str,
     AffinityMode,
@@ -35,12 +38,10 @@ class MockDeviceProperties:
 
 
 _real_open = open
+_real_mkstemp = tempfile.mkstemp
 
 
-@skipIf(
-    sys.platform == "win32",
-    "Windows is missing various os module attributes like sched_getaffinity",
-)
+@skipUnless(sys.platform == "linux", "Only linux currently supported")
 @skipUnless(
     torch.distributed.is_available(), "Need access to some distributed submodules"
 )
@@ -53,25 +54,43 @@ class NumaBindingTest(TestCase):
         self._mock_num_logical_cpus = 0
         self._mock_num_numa_nodes = 0
         self._mock_num_sockets = 0
+        self._temp_file_paths = []
 
         self._context_managers_to_apply_to_all_tests = [
             patch("torch.cuda.device_count", self._mock_device_count),
             patch("torch.cuda.get_device_properties", self._mock_get_device_properties),
             patch("torch.cuda.is_available", self._mock_is_available),
+            # Implicitly used by dynamo
+            patch("torch.cuda.get_rng_state"),
             patch("builtins.open", new=self._mock_open),
             patch("os.listdir", new=self._mock_listdir),
             patch("os.sched_getaffinity", new=self._mock_sched_getaffinity),
             patch("shutil.which", return_value="/usr/bin/numactl"),
-            patch("subprocess.run"),
+            patch("torch.numa.binding.run"),
+            patch("torch.numa.binding.mkstemp", self._mock_mkstemp),
         ]
 
         for context_manager in self._context_managers_to_apply_to_all_tests:
             context_manager.__enter__()
 
     def tearDown(self) -> None:
+        # Clean up temporary files
+        for temp_file_path in self._temp_file_paths:
+            try:
+                os.unlink(temp_file_path)
+            except FileNotFoundError:
+                # File may have already been deleted or doesn't exist
+                pass
+
         for context_manager in self._context_managers_to_apply_to_all_tests:
             context_manager.__exit__(None, None, None)
         super().tearDown()
+
+    def _mock_mkstemp(self, *args, **kwargs):
+        # Just keep track of temp files so we can delete them
+        fd, path = _real_mkstemp(*args, **kwargs)
+        self._temp_file_paths.append(path)
+        return fd, path
 
     def _add_mock_hardware(
         self,
@@ -204,7 +223,7 @@ class NumaBindingTest(TestCase):
     def _mock_open(self, path: str, *args, **kwargs) -> Any:
         if path in self._mock_file_path_to_contents:
             return mock_open(read_data=self._mock_file_path_to_contents[path])()
-        if path.startswith("/sys/"):
+        if isinstance(path, str) and path.startswith("/sys/"):
             raise FileNotFoundError(f"File {path} was not mocked.")
         # Looks like CI is calling open and intending to open an actual file in some places.
         # Need this to make the CI pass.
@@ -222,8 +241,8 @@ class NumaBindingTest(TestCase):
     def _mock_sched_getaffinity(self, pid: int) -> set[int]:
         return set(range(self._mock_num_logical_cpus))
 
-    def _start_test_processes_and_get_command_args_for_local_rank(
-        self, *, numa_options: Optional[NumaOptions], local_rank: int
+    def _start_processes_for_str_entrypoint_and_get_Popen_args(
+        self, *, numa_options: Optional[NumaOptions], target_local_rank: int
     ) -> tuple[str, ...]:
         """
         Calls start_processes like elastic_launch ultimately would
@@ -250,9 +269,57 @@ class NumaBindingTest(TestCase):
             call_args = next(
                 call_args
                 for call_args in mock_popen.call_args_list
-                if call_args.kwargs.get("env", {}).get("LOCAL_RANK") == str(local_rank)
+                if call_args.kwargs.get("env", {}).get("LOCAL_RANK")
+                == str(target_local_rank)
             )
             return call_args.kwargs["args"]
+
+    def _start_processes_for_callable_entrypoint_and_get_executable_contents(
+        self, *, numa_options: Optional[NumaOptions], target_local_rank: int
+    ) -> str:
+        active_local_rank = None
+        executable_path = None
+
+        def _mock_process_start(self: Any) -> None:
+            nonlocal active_local_rank
+            active_local_rank = self._args[1]
+            spawn.get_command_line()
+            self._target(*self._args)
+
+        original_get_command_line = spawn.get_command_line
+
+        def _mock_get_command_line(*args, **kwargs) -> list[str]:
+            nonlocal executable_path
+            result = original_get_command_line(*args, **kwargs)
+            if active_local_rank == target_local_rank:
+                executable_path = result[0]
+
+            return result
+
+        with (
+            patch("multiprocessing.context.SpawnProcess.start", _mock_process_start),
+            patch("multiprocessing.spawn.get_command_line", _mock_get_command_line),
+            patch("multiprocessing.process.BaseProcess.sentinel", 1),
+            # Prevent hanging
+            patch(
+                "multiprocessing.synchronize.Event.wait",
+                lambda self, timeout=None: None,
+            ),
+        ):
+            start_processes(
+                name="test_process",
+                entrypoint=lambda x: x,
+                args=dict.fromkeys(range(self._mock_device_count()), (0,)),
+                envs={
+                    i: {"LOCAL_RANK": str(i)} for i in range(self._mock_device_count())
+                },
+                logs_specs=DefaultLogsSpecs(),
+                numa_options=numa_options,
+            )
+
+        assert executable_path is not None
+        with open(executable_path) as executable_file:
+            return executable_file.read()
 
     def test_node_numa_binding(self) -> None:
         self._add_mock_hardware(
@@ -263,8 +330,9 @@ class NumaBindingTest(TestCase):
             num_physical_core_per_l3_cache=2,
         )
 
-        command_args = self._start_test_processes_and_get_command_args_for_local_rank(
-            numa_options=NumaOptions(affinity_mode=AffinityMode.NODE), local_rank=11
+        command_args = self._start_processes_for_str_entrypoint_and_get_Popen_args(
+            numa_options=NumaOptions(affinity_mode=AffinityMode.NODE),
+            target_local_rank=11,
         )
         self.assertEqual(
             command_args,
@@ -273,7 +341,6 @@ class NumaBindingTest(TestCase):
             (
                 "numactl",
                 "--cpunodebind=5",
-                "--preferred=5",
                 "echo",
                 "Hello, world!",
             ),
@@ -288,8 +355,8 @@ class NumaBindingTest(TestCase):
             num_physical_core_per_l3_cache=2,
         )
 
-        command_args = self._start_test_processes_and_get_command_args_for_local_rank(
-            numa_options=None, local_rank=11
+        command_args = self._start_processes_for_str_entrypoint_and_get_Popen_args(
+            numa_options=None, target_local_rank=11
         )
         self.assertEqual(
             command_args,
@@ -340,20 +407,18 @@ class NumaBindingTest(TestCase):
         )
 
         with (
-            patch("torch.distributed.numa.binding.signpost_event") as signpost_patch,
+            patch("torch.numa.binding.signpost_event") as signpost_patch,
             patch(
-                "subprocess.run",
+                "torch.numa.binding.run",
                 side_effect=subprocess.CalledProcessError(1, "numactl"),
             ),
         ):
-            command_args = (
-                self._start_test_processes_and_get_command_args_for_local_rank(
-                    numa_options=NumaOptions(
-                        affinity_mode=AffinityMode.NODE,
-                        should_fall_back_if_binding_fails=True,
-                    ),
-                    local_rank=0,
-                )
+            command_args = self._start_processes_for_str_entrypoint_and_get_Popen_args(
+                numa_options=NumaOptions(
+                    affinity_mode=AffinityMode.NODE,
+                    should_fall_back_if_binding_fails=True,
+                ),
+                target_local_rank=0,
             )
         self.assertIn(
             "subprocess.CalledProcessError",
@@ -387,6 +452,25 @@ class NumaBindingTest(TestCase):
             NumaOptions(affinity_mode=AffinityMode.EXCLUSIVE),
         )
 
+    def test_fork_start_method_does_not_call_get_default_numa_options(self) -> None:
+        # Inner import to avoid crashing if not torch.distributed.is_available()
+        from torch.distributed.launcher.api import LaunchConfig
+
+        with patch(
+            "torch.distributed.launcher.api.get_default_numa_options"
+        ) as mock_get_default_numa_options:
+            launch_config = LaunchConfig(
+                min_nodes=1,
+                max_nodes=1,
+                nproc_per_node=1,
+                start_method="fork",
+                # Don't provide numa_options
+            )
+            # Verify get_default_numa_options was not called
+            mock_get_default_numa_options.assert_not_called()
+            # Verify numa_options is None when start_method is fork
+            self.assertIsNone(launch_config.numa_options)
+
     def test_socket_numa_binding_with_multiple_numa_per_socket(self) -> None:
         self._add_mock_hardware(
             num_sockets=4,
@@ -396,15 +480,15 @@ class NumaBindingTest(TestCase):
             num_physical_core_per_l3_cache=2,
         )
 
-        command_args = self._start_test_processes_and_get_command_args_for_local_rank(
-            numa_options=NumaOptions(affinity_mode=AffinityMode.SOCKET), local_rank=15
+        command_args = self._start_processes_for_str_entrypoint_and_get_Popen_args(
+            numa_options=NumaOptions(affinity_mode=AffinityMode.SOCKET),
+            target_local_rank=15,
         )
         self.assertEqual(
             command_args,
             (
                 "numactl",
                 "--cpunodebind=6-7",
-                "--preferred-many=6-7",
                 "echo",
                 "Hello, world!",
             ),
@@ -419,15 +503,15 @@ class NumaBindingTest(TestCase):
             num_physical_core_per_l3_cache=2,
         )
 
-        command_args = self._start_test_processes_and_get_command_args_for_local_rank(
-            numa_options=NumaOptions(affinity_mode=AffinityMode.SOCKET), local_rank=7
+        command_args = self._start_processes_for_str_entrypoint_and_get_Popen_args(
+            numa_options=NumaOptions(affinity_mode=AffinityMode.SOCKET),
+            target_local_rank=7,
         )
         self.assertEqual(
             command_args,
             (
                 "numactl",
                 "--cpunodebind=3",
-                "--preferred=3",
                 "echo",
                 "Hello, world!",
             ),
@@ -442,8 +526,9 @@ class NumaBindingTest(TestCase):
             num_physical_core_per_l3_cache=3,
         )
 
-        command_args_0 = self._start_test_processes_and_get_command_args_for_local_rank(
-            numa_options=NumaOptions(affinity_mode=AffinityMode.EXCLUSIVE), local_rank=0
+        command_args_0 = self._start_processes_for_str_entrypoint_and_get_Popen_args(
+            numa_options=NumaOptions(affinity_mode=AffinityMode.EXCLUSIVE),
+            target_local_rank=0,
         )
         self.assertEqual(
             command_args_0,
@@ -451,14 +536,14 @@ class NumaBindingTest(TestCase):
                 "numactl",
                 # Gets an extra physical core due to odd number of physical cores on numa node
                 "--physcpubind=0-3",
-                "--preferred=0",
                 "echo",
                 "Hello, world!",
             ),
         )
 
-        command_args_1 = self._start_test_processes_and_get_command_args_for_local_rank(
-            numa_options=NumaOptions(affinity_mode=AffinityMode.EXCLUSIVE), local_rank=1
+        command_args_1 = self._start_processes_for_str_entrypoint_and_get_Popen_args(
+            numa_options=NumaOptions(affinity_mode=AffinityMode.EXCLUSIVE),
+            target_local_rank=1,
         )
         self.assertEqual(
             command_args_1,
@@ -466,7 +551,6 @@ class NumaBindingTest(TestCase):
                 "numactl",
                 # Does not get an extra physical core, since the 1st GPU already took the extra.
                 "--physcpubind=4-5",
-                "--preferred=0",
                 "echo",
                 "Hello, world!",
             ),
@@ -485,9 +569,9 @@ class NumaBindingTest(TestCase):
             RuntimeError,
             "There are only 1 physical cores on numa_node_index=0, but there are 2 GPUs associated with this NUMA node.",
         ):
-            self._start_test_processes_and_get_command_args_for_local_rank(
+            self._start_processes_for_str_entrypoint_and_get_Popen_args(
                 numa_options=NumaOptions(affinity_mode=AffinityMode.EXCLUSIVE),
-                local_rank=1,
+                target_local_rank=1,
             )
 
     def test_core_complex_numa_binding_with_extra_l3(self) -> None:
@@ -499,9 +583,9 @@ class NumaBindingTest(TestCase):
             num_physical_core_per_l3_cache=3,
         )
 
-        command_args = self._start_test_processes_and_get_command_args_for_local_rank(
+        command_args = self._start_processes_for_str_entrypoint_and_get_Popen_args(
             numa_options=NumaOptions(affinity_mode=AffinityMode.CORE_COMPLEX),
-            local_rank=3,
+            target_local_rank=3,
         )
         self.assertEqual(
             command_args,
@@ -509,7 +593,6 @@ class NumaBindingTest(TestCase):
                 "numactl",
                 # The second L3 on the second numa node
                 "--physcpubind=24-29",
-                "--preferred=1",
                 "echo",
                 "Hello, world!",
             ),
@@ -524,9 +607,9 @@ class NumaBindingTest(TestCase):
             num_physical_core_per_l3_cache=3,
         )
 
-        command_args = self._start_test_processes_and_get_command_args_for_local_rank(
+        command_args = self._start_processes_for_str_entrypoint_and_get_Popen_args(
             numa_options=NumaOptions(affinity_mode=AffinityMode.CORE_COMPLEX),
-            local_rank=3,
+            target_local_rank=3,
         )
         self.assertEqual(
             command_args,
@@ -535,7 +618,6 @@ class NumaBindingTest(TestCase):
                 # There are only 2 L3 caches, so the 4th GPU shares the same
                 # cores as the 3rd GPU.
                 "--physcpubind=6-11",
-                "--preferred=1",
                 "echo",
                 "Hello, world!",
             ),
@@ -552,11 +634,9 @@ class NumaBindingTest(TestCase):
 
         # Only some subset of the CPUs are available this time.
         with patch("os.sched_getaffinity", return_value={0, 4, 6, 7, 9}):
-            command_args = (
-                self._start_test_processes_and_get_command_args_for_local_rank(
-                    numa_options=NumaOptions(affinity_mode=AffinityMode.CORE_COMPLEX),
-                    local_rank=0,
-                )
+            command_args = self._start_processes_for_str_entrypoint_and_get_Popen_args(
+                numa_options=NumaOptions(affinity_mode=AffinityMode.CORE_COMPLEX),
+                target_local_rank=0,
             )
 
         self.assertEqual(
@@ -565,7 +645,6 @@ class NumaBindingTest(TestCase):
                 "numactl",
                 # Binds to the second L3 because it has the most available CPUs
                 "--physcpubind=6-7,9",
-                "--preferred=0",
                 "echo",
                 "Hello, world!",
             ),
@@ -584,41 +663,19 @@ class NumaBindingTest(TestCase):
             num_physical_core_per_l3_cache=1,
         )
 
-        command_args = self._start_test_processes_and_get_command_args_for_local_rank(
+        command_args = self._start_processes_for_str_entrypoint_and_get_Popen_args(
             numa_options=NumaOptions(affinity_mode=AffinityMode.CORE_COMPLEX),
-            local_rank=0,
+            target_local_rank=0,
         )
         self.assertEqual(
             command_args,
             (
                 "numactl",
                 "--physcpubind=0-1",
-                "--preferred=0",
                 "echo",
                 "Hello, world!",
             ),
         )
-
-    def test_raises_error_if_numa_options_provided_for_callable_entrypoint(
-        self,
-    ) -> None:
-        # Inner import to avoid crashing if not torch.distributed.is_available()
-        from torch.distributed.elastic.agent.server.api import WorkerSpec
-
-        def mock_entrypoint() -> None:
-            pass
-
-        with self.assertRaisesRegex(ValueError, r".*numa_options.*"):
-            # not relevant to test, just pass in an arbitrary value
-            mock_rdzv_handler: Any = 0
-            WorkerSpec(
-                role="trainer",
-                # Only str entrypoint (e.g. "echo") is currently supported
-                entrypoint=mock_entrypoint,
-                local_world_size=8,
-                rdzv_handler=mock_rdzv_handler,
-                numa_options=NumaOptions(affinity_mode=AffinityMode.NODE),
-            )
 
     def test_raises_error_if_numactl_unavailable(self) -> None:
         self._add_mock_hardware(
@@ -632,8 +689,9 @@ class NumaBindingTest(TestCase):
             patch("shutil.which", return_value=None),
             self.assertRaisesRegex(RuntimeError, r".*numactl.*"),
         ):
-            self._start_test_processes_and_get_command_args_for_local_rank(
-                numa_options=NumaOptions(affinity_mode=AffinityMode.NODE), local_rank=0
+            self._start_processes_for_str_entrypoint_and_get_Popen_args(
+                numa_options=NumaOptions(affinity_mode=AffinityMode.NODE),
+                target_local_rank=0,
             )
 
     def test_binds_to_node_0_if_node_stored_as_minus_one(self) -> None:
@@ -654,18 +712,48 @@ class NumaBindingTest(TestCase):
             contents="-1",
         )
 
-        command_args = self._start_test_processes_and_get_command_args_for_local_rank(
-            numa_options=NumaOptions(affinity_mode=AffinityMode.NODE), local_rank=0
+        command_args = self._start_processes_for_str_entrypoint_and_get_Popen_args(
+            numa_options=NumaOptions(affinity_mode=AffinityMode.NODE),
+            target_local_rank=0,
         )
         self.assertEqual(
             command_args,
             (
                 "numactl",
                 "--cpunodebind=0",
-                "--preferred=0",
                 "echo",
                 "Hello, world!",
             ),
+        )
+
+    def test_callable_entrypoint_basic(self) -> None:
+        self._add_mock_hardware(
+            num_sockets=4,
+            num_numa_nodes_per_socket=2,
+            num_gpus_per_numa_node=2,
+            num_l3_caches_per_numa_node=4,
+            num_physical_core_per_l3_cache=2,
+        )
+
+        executable_contents = (
+            self._start_processes_for_callable_entrypoint_and_get_executable_contents(
+                numa_options=NumaOptions(affinity_mode=AffinityMode.NODE),
+                target_local_rank=11,
+            )
+        )
+        self.assertEqual(
+            executable_contents,
+            # There are 8 numa nodes and 2 GPUs per numa node, so GPU 11 would be
+            # on numa node 11 // 2 = 5.
+            f"""#!/bin/bash
+
+# If this file is more than a few minutes old and still exists on your machine,
+# that is NOT expected. It should have deleted itself. If you are seeing an accumulation of such
+# files, that could suggest a bug in pytorch. See https://github.com/pytorch/pytorch/pull/160163.
+
+rm -- "$0"
+numactl --cpunodebind=5 {sys.executable} "$@"
+""",
         )
 
     def test_get_set_of_int_from_ranges_str(self) -> None:

--- a/torch/distributed/elastic/agent/server/api.py
+++ b/torch/distributed/elastic/agent/server/api.py
@@ -27,7 +27,7 @@ from torch.distributed.elastic.metrics import prof, put_metric
 from torch.distributed.elastic.multiprocessing import ProcessFailure, SignalException
 from torch.distributed.elastic.rendezvous import RendezvousGracefulExitError
 from torch.distributed.elastic.utils.logging import get_logger
-from torch.distributed.numa.binding import NumaOptions
+from torch.numa.binding import NumaOptions
 
 
 __all__ = [
@@ -103,13 +103,6 @@ class WorkerSpec:
             )
             self.entrypoint = self.fn
         assert self.entrypoint
-
-        if (
-            self.numa_options is not None
-            and not self.numa_options.should_fall_back_if_binding_fails
-            and not isinstance(self.entrypoint, str)
-        ):
-            raise ValueError("numa_options is only supported for str entrypoints.")
 
     def get_entrypoint_name(self):
         """Get the entry point name.

--- a/torch/distributed/elastic/multiprocessing/__init__.py
+++ b/torch/distributed/elastic/multiprocessing/__init__.py
@@ -80,7 +80,7 @@ from torch.distributed.elastic.multiprocessing.api import (  # noqa: F401
     to_map,
 )
 from torch.distributed.elastic.utils.logging import get_logger
-from torch.distributed.numa.binding import NumaOptions
+from torch.numa.binding import NumaOptions
 
 
 __all__ = [
@@ -227,6 +227,7 @@ def start_processes(
             log_line_prefixes=log_line_prefixes,
             start_method=start_method,
             logs_specs=logs_specs,
+            numa_options=numa_options,
         )
 
     try:

--- a/torch/distributed/elastic/multiprocessing/api.py
+++ b/torch/distributed/elastic/multiprocessing/api.py
@@ -37,7 +37,7 @@ from torch.distributed.elastic.multiprocessing.subprocess_handler import (
     SubprocessHandler,
 )
 from torch.distributed.elastic.multiprocessing.tail_log import TailLog
-from torch.distributed.numa.binding import maybe_wrap_with_numa_bindings, NumaOptions
+from torch.numa.binding import NumaOptions
 
 
 IS_WINDOWS = sys.platform == "win32"
@@ -631,6 +631,7 @@ class MultiprocessContext(PContext):
         start_method: str,
         logs_specs: LogsSpecs,
         log_line_prefixes: Optional[dict[int, str]] = None,
+        numa_options: Optional[NumaOptions] = None,
     ):
         super().__init__(
             name,
@@ -655,6 +656,8 @@ class MultiprocessContext(PContext):
         # successfully. If any process died on event.wait() calling set() method will deadlock.
         self._worker_finished_event = mp.get_context(self.start_method).Event()
 
+        self._numa_options: Optional[NumaOptions] = numa_options
+
     def _start(self):
         if self._pc:
             raise ValueError(
@@ -676,6 +679,7 @@ class MultiprocessContext(PContext):
             join=False,
             daemon=False,
             start_method=self.start_method,
+            numa_options=self._numa_options,
         )
 
     def _is_done(self) -> bool:
@@ -814,10 +818,6 @@ class SubprocessContext(PContext):
         log_line_prefixes: Optional[dict[int, str]] = None,
         numa_options: Optional[NumaOptions] = None,
     ):
-        entrypoint, args = maybe_wrap_with_numa_bindings(
-            entrypoint=entrypoint, local_rank_to_args=args, numa_options=numa_options
-        )
-
         super().__init__(
             name,
             entrypoint,
@@ -831,6 +831,7 @@ class SubprocessContext(PContext):
         self._running_local_ranks: set[int] = set(range(self.nprocs))
         self._failures: dict[int, ProcessFailure] = {}
         self.subprocess_handlers: dict[int, SubprocessHandler] = {}
+        self._numa_options: Optional[NumaOptions] = numa_options
 
     def _start(self):
         if self.subprocess_handlers:
@@ -845,6 +846,7 @@ class SubprocessContext(PContext):
                 stdout=self.stdouts[local_rank],
                 stderr=self.stderrs[local_rank],
                 local_rank_id=local_rank,
+                numa_options=self._numa_options,
             )
             for local_rank in range(self.nprocs)
         }

--- a/torch/distributed/elastic/multiprocessing/subprocess_handler/handlers.py
+++ b/torch/distributed/elastic/multiprocessing/subprocess_handler/handlers.py
@@ -3,10 +3,12 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+from typing import Optional
 
 from torch.distributed.elastic.multiprocessing.subprocess_handler.subprocess_handler import (
     SubprocessHandler,
 )
+from torch.numa.binding import NumaOptions
 
 
 __all__ = ["get_subprocess_handler"]
@@ -19,6 +21,7 @@ def get_subprocess_handler(
     stdout: str,
     stderr: str,
     local_rank_id: int,
+    numa_options: Optional[NumaOptions] = None,
 ) -> SubprocessHandler:
     return SubprocessHandler(
         entrypoint=entrypoint,
@@ -27,4 +30,5 @@ def get_subprocess_handler(
         stdout=stdout,
         stderr=stderr,
         local_rank_id=local_rank_id,
+        numa_options=numa_options,
     )

--- a/torch/distributed/launcher/api.py
+++ b/torch/distributed/launcher/api.py
@@ -26,7 +26,7 @@ from torch.distributed.elastic.multiprocessing.errors import ChildFailedError
 from torch.distributed.elastic.rendezvous import RendezvousParameters
 from torch.distributed.elastic.rendezvous.utils import parse_rendezvous_endpoint
 from torch.distributed.elastic.utils.logging import get_logger
-from torch.distributed.numa.binding import NumaOptions
+from torch.numa.binding import NumaOptions
 
 
 __all__ = ["LaunchConfig", "elastic_launch", "launch_agent"]
@@ -107,7 +107,13 @@ class LaunchConfig:
         if self.logs_specs is None:
             self.logs_specs = DefaultLogsSpecs()
 
-        if self.numa_options is None and torch.cuda.is_available():
+        if (
+            self.numa_options is None
+            # NOTE: This filter isn't relevant for str entrypoints,
+            # but it's the default anyway.
+            and self.start_method == "spawn"
+            and torch.cuda.is_available()
+        ):
             self.numa_options = get_default_numa_options()
             logger.info("Using default numa options = %r", self.numa_options)
 

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -382,7 +382,7 @@ from torch.distributed.elastic.rendezvous.utils import _parse_rendezvous_config
 from torch.distributed.elastic.utils import macros
 from torch.distributed.elastic.utils.logging import get_logger
 from torch.distributed.launcher.api import elastic_launch, LaunchConfig
-from torch.distributed.numa.binding import (
+from torch.numa.binding import (
     AffinityMode as _AffinityMode,  # Signify as private with _
     NumaOptions as _NumaOptions,
 )


### PR DESCRIPTION
**NOTE:** This implementation has been replaced with #161183 to fix some crashes.

# Context
This is an extension of #149334.

# This PR
Add support for NUMA bindings with Callable entrypoints, such as `do_train` instead of `/usr/local/bin/python`.

Most notably, we utilize a hack in order to force `Process.start()` to use custom NUMA bindings for each subprocess. Please search for `HACK:` in the code to see a description of the implementation we chose, and #160006 for discussion of alternatives and why this is necessary.

Other changes:
* Remove unnecessary `--preferred` option from all binding strategies. By default, Linux already allocates memory to the NUMA node local to the CPU which triggered the allocation. (See [MPOL_LOCAL](https://man7.org/linux/man-pages/man2/set_mempolicy.2.html).)
* Refactor so that the main API is `maybe_wrap_command_with_numa_bindings`, which computes bindings for a single rank at a time, rather than `maybe_wrap_with_numa_bindings` which computed bindings for all ranks at once. This allowed for more code sharing between `Callable` and `str` entrypoints.

# Test Plan
## Automated
`$ pytest test/test_numa_binding.py`

## Manual
Using [this benchmark,](https://gist.github.com/pdesupinski/bbe01ade455d86e989794f2c612e2d91), ran

```
$ PYTHONUNBUFFERED=1 LOGLEVEL=INFO perf stat -e ls_dmnd_fills_from_sys.dram_io_far,ls_dmnd_fills_from_sys.dram_io_near -- python -m torch.distributed.run --standalone --nproc-per-node=8 --numa-binding=node --run-path mlp_train.py 2>&1 | tee node_callable.txt && PYTHONUNBUFFERED=1 LOGLEVEL=INFO perf stat -e ls_dmnd_fills_from_sys.dram_io_far,ls_dmnd_fills_from_sys.dram_io_near -- python -u -m torch.distributed.run --standalone --nproc-per-node=8 --run-path mlp_train.py 2>&1 | tee none_callable.txt
```

and observed 
* 6.6% remote memory accesses with 'node' bindings
* 11.6% remote without bindings

I also ran similar with `str` entrypoints as before just to be sure it's still working.

NOTE: [--run-path triggers the code to be run inside a `Callable`.](https://github.com/pytorch/pytorch/blob/017259f9c65b6fad55fb9597d7077e2543eaae46/torch/distributed/run.py#L870)



cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @raghavhrishi