### PR TITLE
[CUDAGraph] Skip CUDAGraph when only 1 kernel

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -1826,15 +1826,15 @@ class CudaReproTests(TestCase):
     def test_cpu_index(self):
         @torch.compile(fullgraph=True)
         def fn(x):
-            return x[torch.arange(32)]
+            return x[torch.arange(32)] @ x[torch.arange(32)].T
 
         result, (graph,) = run_and_get_graph_lowering(
-            fn, torch.randn(64, device="cuda")
+            fn, torch.randn((64, 2), device="cuda")
         )
         self.assertEqual(graph.disable_cudagraphs_reason, None)
         self.assertEqual(graph.device_types, {"cuda"})
 
-        inp = torch.randn(64, device="cuda", requires_grad=True)
+        inp = torch.randn((64, 2), device="cuda", requires_grad=True)
         result, (graph,) = run_and_get_graph_lowering(fn, inp)
         self.assertEqual(graph.disable_cudagraphs_reason, None)
         self.assertEqual(graph.device_types, {"cuda"})

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1583,6 +1583,16 @@ class _InProcessFxCompile(FxCompile):
                             )
                         )
 
+                    if (
+                        cudagraphs
+                        and not V.graph.disable_cudagraphs_reason
+                        and len(graph.scheduler.nodes) == 1
+                    ):
+                        # no benefits from cudagraph when there is only 1 fused kernel
+                        V.graph.disable_cudagraphs_reason = (
+                            "only one kernel in generated code"
+                        )
+
                     self._compile_stats[type(self)].codegen_and_compile += 1
 
                     return CompiledFxGraph(


### PR DESCRIPTION
When there is only 1 kernel, CUDAGraph does not bring benefits. So we skip cudagraph.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben