### PR TITLE
Add build support for RISCV

### DIFF
--- a/aten/src/ATen/cpu/Utils.cpp
+++ b/aten/src/ATen/cpu/Utils.cpp
@@ -1,6 +1,6 @@
 #include <cassert>
 #include <ATen/cpu/Utils.h>
-#if !defined(__s390x__ ) && !defined(__powerpc__)
+#if !defined(__s390x__ ) && !defined(__powerpc__) && !defined(__riscv)
 #include <cpuinfo.h>
 #endif
 #if defined(__linux__)
@@ -10,7 +10,7 @@
 
 namespace at::cpu {
 bool is_avx2_supported() {
-#if !defined(__s390x__) && !defined(__powerpc__)
+#if !defined(__s390x__) && !defined(__powerpc__) && !defined(__riscv)
   return cpuinfo_initialize() && cpuinfo_has_x86_avx2();
 #else
   return false;
@@ -18,7 +18,7 @@ bool is_avx2_supported() {
 }
 
 bool is_avx512_supported() {
-#if !defined(__s390x__) && !defined(__powerpc__)
+#if !defined(__s390x__) && !defined(__powerpc__) && !defined(__riscv)
   return cpuinfo_initialize() && cpuinfo_has_x86_avx512f() && cpuinfo_has_x86_avx512vl() && cpuinfo_has_x86_avx512bw() && cpuinfo_has_x86_avx512dq();
 #else
   return false;
@@ -26,7 +26,7 @@ bool is_avx512_supported() {
 }
 
 bool is_avx512_vnni_supported() {
-#if !defined(__s390x__) && !defined(__powerpc__)
+#if !defined(__s390x__) && !defined(__powerpc__) && !defined(__riscv)
   return cpuinfo_initialize() && cpuinfo_has_x86_avx512vnni();
 #else
   return false;
@@ -34,7 +34,7 @@ bool is_avx512_vnni_supported() {
 }
 
 bool is_avx512_bf16_supported() {
-#if !defined(__s390x__) && !defined(__powerpc__)
+#if !defined(__s390x__) && !defined(__powerpc__) && !defined(__riscv)
   return cpuinfo_initialize() && cpuinfo_has_x86_avx512bf16();
 #else
   return false;
@@ -42,7 +42,7 @@ bool is_avx512_bf16_supported() {
 }
 
 bool is_amx_tile_supported() {
-#if !defined(__s390x__) && !defined(__powerpc__)
+#if !defined(__s390x__) && !defined(__powerpc__) && !defined(__riscv)
   return cpuinfo_initialize() && cpuinfo_has_x86_amx_tile();
 #else
   return false;
@@ -50,7 +50,7 @@ bool is_amx_tile_supported() {
 }
 
 bool is_amx_fp16_supported() {
-#if !defined(__s390x__) && !defined(__powerpc__)
+#if !defined(__s390x__) && !defined(__powerpc__) && !defined(__riscv)
   return is_amx_tile_supported() && cpuinfo_has_x86_amx_fp16();
 #else
   return false;
@@ -93,7 +93,7 @@ bool init_amx() {
 }
 
 static uint32_t get_cache_size(int level) {
-#if !defined(__s390x__) && !defined(__powerpc__)
+#if !defined(__s390x__) && !defined(__powerpc__) && !defined(__riscv)
   if (!cpuinfo_initialize()) {
     return 0;
   }

--- a/aten/src/ATen/cpu/Utils.cpp
+++ b/aten/src/ATen/cpu/Utils.cpp
@@ -1,6 +1,6 @@
 #include <cassert>
 #include <ATen/cpu/Utils.h>
-#if !defined(__s390x__ ) && !defined(__powerpc__) && !defined(__riscv)
+#if !defined(__s390x__ ) && !defined(__powerpc__)
 #include <cpuinfo.h>
 #endif
 #if defined(__linux__)
@@ -10,7 +10,7 @@
 
 namespace at::cpu {
 bool is_avx2_supported() {
-#if !defined(__s390x__) && !defined(__powerpc__) && !defined(__riscv)
+#if !defined(__s390x__) && !defined(__powerpc__)
   return cpuinfo_initialize() && cpuinfo_has_x86_avx2();
 #else
   return false;
@@ -18,7 +18,7 @@ bool is_avx2_supported() {
 }
 
 bool is_avx512_supported() {
-#if !defined(__s390x__) && !defined(__powerpc__) && !defined(__riscv)
+#if !defined(__s390x__) && !defined(__powerpc__)
   return cpuinfo_initialize() && cpuinfo_has_x86_avx512f() && cpuinfo_has_x86_avx512vl() && cpuinfo_has_x86_avx512bw() && cpuinfo_has_x86_avx512dq();
 #else
   return false;
@@ -26,7 +26,7 @@ bool is_avx512_supported() {
 }
 
 bool is_avx512_vnni_supported() {
-#if !defined(__s390x__) && !defined(__powerpc__) && !defined(__riscv)
+#if !defined(__s390x__) && !defined(__powerpc__)
   return cpuinfo_initialize() && cpuinfo_has_x86_avx512vnni();
 #else
   return false;
@@ -34,7 +34,7 @@ bool is_avx512_vnni_supported() {
 }
 
 bool is_avx512_bf16_supported() {
-#if !defined(__s390x__) && !defined(__powerpc__) && !defined(__riscv)
+#if !defined(__s390x__) && !defined(__powerpc__)
   return cpuinfo_initialize() && cpuinfo_has_x86_avx512bf16();
 #else
   return false;
@@ -42,7 +42,7 @@ bool is_avx512_bf16_supported() {
 }
 
 bool is_amx_tile_supported() {
-#if !defined(__s390x__) && !defined(__powerpc__) && !defined(__riscv)
+#if !defined(__s390x__) && !defined(__powerpc__)
   return cpuinfo_initialize() && cpuinfo_has_x86_amx_tile();
 #else
   return false;
@@ -50,7 +50,7 @@ bool is_amx_tile_supported() {
 }
 
 bool is_amx_fp16_supported() {
-#if !defined(__s390x__) && !defined(__powerpc__) && !defined(__riscv)
+#if !defined(__s390x__) && !defined(__powerpc__)
   return is_amx_tile_supported() && cpuinfo_has_x86_amx_fp16();
 #else
   return false;
@@ -93,7 +93,7 @@ bool init_amx() {
 }
 
 static uint32_t get_cache_size(int level) {
-#if !defined(__s390x__) && !defined(__powerpc__) && !defined(__riscv)
+#if !defined(__s390x__) && !defined(__powerpc__)
   if (!cpuinfo_initialize()) {
     return 0;
   }

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ filelock
 fsspec>=0.8.5
 hypothesis
 jinja2
-lintrunner ; platform_machine != "s390x"
+lintrunner ; platform_machine != "s390x" and platform_machine != "riscv64"
 networkx>=2.5.1
 optree>=0.13.0
 psutil


### PR DESCRIPTION
In requirements.txt, do not install lintrunner on riscv64

Fixes #160170 

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168