### PR TITLE
Draft: separate reqs for manywheel build and pin

### DIFF
--- a/.ci/aarch64_linux/aarch64_ci_build.sh
+++ b/.ci/aarch64_linux/aarch64_ci_build.sh
@@ -27,7 +27,7 @@ cd /
 # adding safe directory for git as the permissions will be
 # on the mounted pytorch repo
 git config --global --add safe.directory /pytorch
-pip install -r /pytorch/requirements.txt
+pip install -r /pytorch/.ci/docker/requirements-manywheel.txt
 pip install auditwheel==6.2.0 wheel
 if [ "$DESIRED_CUDA" = "cpu" ]; then
     echo "BASE_CUDA_VERSION is not set. Building cpu wheel."

--- a/.ci/docker/requirements-manywheel.txt
+++ b/.ci/docker/requirements-manywheel.txt
@@ -1,0 +1,10 @@
+# A version of requirements-build.txt pinned to minor versions (to allow for patch releases)
+cmake              ~= 4.0.3
+ninja              ~= 1.11.1
+numpy              ~= 2.0.2
+packaging          ~= 24.2
+PyYAML             ~= 6.0.2
+requests           ~= 2.32.4
+setuptools         ~= 78.1.1 # setuptools develop deprecated on 80.0
+six                ~= 1.17.0
+typing_extensions  ~= 4.14.1


### PR DESCRIPTION
Builds regularly fail due to changes in build packages (most recently https://github.com/pytorch/pytorch/issues/150149), so this pins the manywheel requirements in a similar way to how they are pinned for CI and docs in `requirements-ci.txt` and  `requirements-docs.txt`.

Successor to #150833 