### PR TITLE
[DO NOT MERGE][Kineto] Testing not clearing per-thread attribute at all

### DIFF
--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -12,7 +12,7 @@ from numbers import Number
 import torch
 from torch.testing import make_tensor
 from torch.testing._comparison import default_tolerances
-from torch.testing._internal.common_cuda import _get_torch_cuda_version, TEST_MULTIGPU
+from torch.testing._internal.common_cuda import TEST_MULTIGPU
 from torch.testing._internal.common_device_type import (
     dtypes,
     instantiate_device_type_tests,
@@ -80,12 +80,8 @@ class ForeachFuncWrapper:
         actual = None
         zero_size = kwargs.pop("zero_size", False)
 
-        # Skip profiler check for CUDA 12.6, 12.8 as the upgrade makes profiler results flaky
-        # https://github.com/pytorch/pytorch/issues/148681. TODO: ADD IT BACK!!!
-        skip_profiler_check = _get_torch_cuda_version() in [(12, 6), (12, 8)]
         if (
             is_cuda
-            and not skip_profiler_check
             and torch.autograd.kineto_available()
             and torch.profiler.ProfilerActivity.CUDA
             in torch.profiler.supported_activities()


### PR DESCRIPTION
A follow up on #160091. In the previous PR, Kineto clears CUPTI attribute after it flushes activity, which still can be thread-unsafe in cases of parallel tasks. This PR does not clear attribute at all, so even if there are parallel tasks, they will not call a thread-unsafe function.

cc @ptrblck @msaroufim @eqy @jerryzh168 @robieta @chaekit @guotuofeng @guyang3532 @dzhulgakov @davidberard98 @briancoutinho @sraikund16 @sanrise