### PR TITLE
[Triton] [Inductor] Generalize index broadcasting to handle torch.utils._sympy.functions.Identity

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -26,6 +26,7 @@ from torch._dynamo.utils import identity, preserve_rng_state
 from torch._prims_common import is_integer_dtype
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.functions import CeilDiv, FloorDiv, ModularIndexing
+from torch.utils._sympy.utils import is_integer_scalar_expr
 from torch.utils._triton import has_triton_package
 
 from ...utils._sympy.symbol import free_symbol_is_type, prefix_str, symbol_is_type, SymT
@@ -2300,7 +2301,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
         expand_str = None
         index_str = self.index_to_str(index)
-        if isinstance(index, sympy.Integer):
+        if is_integer_scalar_expr(index):
             expand_str = f"{copy_shape}.shape" if copy_shape else self.dense_size_str()
             index_str = f"tl.full({expand_str}, {index_str}, tl.int32)"
             if self.fixed_config and not self._has_constant_xmask():

--- a/torch/utils/_sympy/utils.py
+++ b/torch/utils/_sympy/utils.py
@@ -1,0 +1,18 @@
+import sympy
+
+
+def is_integer_scalar_expr(expr: sympy.Expr) -> bool:
+    """
+    Returns True if the expression is a scalar integer expression
+    that can be used as a scalar index. This is meant to differentiate
+    between value like 3 and Add(Identity(3), Identity(0)), which would
+    both be "scalar" from a variable like xindex.
+    """
+    stack = [expr]
+    while stack:
+        current = stack.pop()
+        if current.args:
+            stack.extend(current.args)
+        elif not isinstance(current, sympy.Integer):
+            return False
+    return True


### PR DESCRIPTION
Summary:
When investigating S546308, we encountered an inductor lowering issue associated with dynamic shapes. The core of the issue is that a provided "index" value is wrapped in an `Identity` value and therefore selects the Tensor codepath (e.g. tl.broadcast_to) instead of the scalar codepath (tl.full).

This updates the code to take the tensore codepath whenever the `sympy.Expr` is operating entirely on scalars.

Test Plan:
Reproducing comand is found via re.

Rollback Plan:

Differential Revision: D79865498




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben