### PR TITLE
Add torchao to install_inductor_benchmark_deps cleanup stage

### DIFF
--- a/.ci/docker/common/install_inductor_benchmark_deps.sh
+++ b/.ci/docker/common/install_inductor_benchmark_deps.sh
@@ -48,4 +48,4 @@ install_huggingface
 install_timm
 
 # Clean up
-conda_run pip uninstall -y torch torchvision torchaudio triton
+conda_run pip uninstall -y torch torchvision torchaudio triton torchao


### PR DESCRIPTION
It looks like `torcho` was missed from the cleanup during torchbench setup.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #160191

Fixes #160188 



cc @seemethere @malfet @pytorch/pytorch-dev-infra @snadampal @milpuz01 @aditew01 @nikhil-arm @fadara01