### PR TITLE
[PP] Initialize P2P communicators on first step

### DIFF
--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -556,10 +556,10 @@ or equal to the number of stages ({self._num_stages})."
     def _initialize_stage(self, args, kwargs):
         # Prepare the communication needed for the pipeline schedule execution
         # This is needed because during execution we always perform a series of batch P2P ops
-        # The first call of the batched P2P needs to involve the entire pipeline group
-        ops = []
-        self._stage._init_p2p_neighbors(ops)
-        _wait_batch_p2p(_batch_p2p(ops))
+        # The first call of the batched P2P needs to involve the global group
+        all_ops: list[dist.P2POp] = []
+        all_ops.extend(self._stage._get_init_p2p_neighbors_ops())
+        _wait_batch_p2p(_batch_p2p(all_ops))
 
         self._stage._prepare_forward_infra(self._n_microbatches, args, kwargs)
         if self._has_backward:
@@ -1437,11 +1437,11 @@ class PipelineScheduleMulti(_PipelineSchedule):
     def _initialize_stages(self, args: tuple[Any, ...], kwargs):
         # Prepare the communication needed for the pipeline schedule execution
         # This is needed because during execution we always perform a series of batch P2P ops
-        # The first call of the batched P2P needs to involve the entire pipeline group
-        ops = []
+        # The first call of the batched P2P needs to involve the global group
+        all_ops: list[dist.P2POp] = []
         for stage in self._stages:
-            stage._init_p2p_neighbors(ops)
-        _wait_batch_p2p(_batch_p2p(ops))
+            all_ops.extend(stage._get_init_p2p_neighbors_ops())
+        _wait_batch_p2p(_batch_p2p(all_ops))
 
         # may be 'none' value (if this stage sends its output shapes to the next stage via P2P)
         # or real value (if this stage and next stage are on the same device)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #160342
* __->__ #160210

Was hitting hangs in multi-node settings and initializing the NCCL communicators needed for batch p2p ops ahead of time fixes this.

This change adds extra communication since it communicates a dummy tensor to next and previous stage ranks. However, this is only paid on the first step so it is negligible.

Debug history: https://docs.google.com/document/d/1EKVJYmW2hj_VsvDvnSggXhZzJyvMu9dA0iDJWOZAtjY/edit?tab=t.0

cc @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta