### PR TITLE
Add `is_cpu` method to stable tensor type

### DIFF
--- a/test/cpp_extensions/libtorch_agnostic_extension/libtorch_agnostic/csrc/kernel.cpp
+++ b/test/cpp_extensions/libtorch_agnostic_extension/libtorch_agnostic/csrc/kernel.cpp
@@ -273,13 +273,18 @@ Tensor my_empty_like(Tensor t) {
   return empty_like(t);
 }
 
+void boxed_empty_like(StableIValue* stack, uint64_t num_args, uint64_t num_outputs) {
+  auto res = my_empty_like(to<Tensor>(stack[0]));
+  stack[0] = from(res);
+}
+
 bool my_is_cpu(Tensor t) {
   return t.is_cpu();
 }
 
 
-void boxed_empty_like(StableIValue* stack, uint64_t num_args, uint64_t num_outputs) {
-  auto res = my_empty_like(to<Tensor>(stack[0]));
+void boxed_my_is_cpu(StableIValue* stack, uint64_t num_args, uint64_t num_outputs) {
+  auto res = my_is_cpu(to<Tensor>(stack[0]));
   stack[0] = from(res);
 }
 
@@ -306,6 +311,7 @@ STABLE_TORCH_LIBRARY_IMPL(libtorch_agnostic, CompositeExplicitAutograd, m) {
   m.impl("my_transpose", &boxed_my_transpose);
   m.impl("my_empty_like", &boxed_empty_like);
   m.impl("fill_infinity", &boxed_fill_infinity);
+  m.impl("my_is_cpu", &boxed_my_is_cpu);
 }
 
 
@@ -318,11 +324,6 @@ void boxed_my_zero_(StableIValue* stack, uint64_t num_args, uint64_t num_outputs
   stack[0] = from(res);
 }
 
-void boxed_my_is_cpu(StableIValue* stack, uint64_t num_args, uint64_t num_outputs) {
-  auto res = my_is_cpu(to<Tensor>(stack[0]));
-  stack[0] = from(res);
-}
-
 STABLE_TORCH_LIBRARY_FRAGMENT(libtorch_agnostic, m) {
   m.def("my_zero_(Tensor(a!) t) -> Tensor(a!)");
   m.def("my_is_cpu(Tensor t) -> bool");
@@ -331,9 +332,4 @@ STABLE_TORCH_LIBRARY_FRAGMENT(libtorch_agnostic, m) {
 
 STABLE_TORCH_LIBRARY_IMPL(libtorch_agnostic, CPU, m) {
   m.impl("my_zero_", &boxed_my_zero_);
-  m.impl("my_is_cpu", &boxed_my_is_cpu);
-}
-
-STABLE_TORCH_LIBRARY_IMPL(libtorch_agnostic, CUDA, m) {
-  m.impl("my_is_cpu", &boxed_my_is_cpu);
 }

--- a/test/cpp_extensions/libtorch_agnostic_extension/libtorch_agnostic/csrc/kernel.cpp
+++ b/test/cpp_extensions/libtorch_agnostic_extension/libtorch_agnostic/csrc/kernel.cpp
@@ -325,11 +325,15 @@ void boxed_my_is_cpu(StableIValue* stack, uint64_t num_args, uint64_t num_output
 
 STABLE_TORCH_LIBRARY_FRAGMENT(libtorch_agnostic, m) {
   m.def("my_zero_(Tensor(a!) t) -> Tensor(a!)");
-  m.def("is_cpu(Tensor t) -> bool");
+  m.def("my_is_cpu(Tensor t) -> bool");
 
 }
 
 STABLE_TORCH_LIBRARY_IMPL(libtorch_agnostic, CPU, m) {
   m.impl("my_zero_", &boxed_my_zero_);
+  m.impl("my_is_cpu", &boxed_my_is_cpu);
+}
+
+STABLE_TORCH_LIBRARY_IMPL(libtorch_agnostic, CUDA, m) {
   m.impl("my_is_cpu", &boxed_my_is_cpu);
 }

--- a/test/cpp_extensions/libtorch_agnostic_extension/libtorch_agnostic/csrc/kernel.cpp
+++ b/test/cpp_extensions/libtorch_agnostic_extension/libtorch_agnostic/csrc/kernel.cpp
@@ -273,6 +273,11 @@ Tensor my_empty_like(Tensor t) {
   return empty_like(t);
 }
 
+bool my_is_cpu(Tensor t) {
+  return t.is_cpu();
+}
+
+
 void boxed_empty_like(StableIValue* stack, uint64_t num_args, uint64_t num_outputs) {
   auto res = my_empty_like(to<Tensor>(stack[0]));
   stack[0] = from(res);
@@ -313,10 +318,18 @@ void boxed_my_zero_(StableIValue* stack, uint64_t num_args, uint64_t num_outputs
   stack[0] = from(res);
 }
 
+void boxed_my_is_cpu(StableIValue* stack, uint64_t num_args, uint64_t num_outputs) {
+  auto res = my_is_cpu(to<Tensor>(stack[0]));
+  stack[0] = from(res);
+}
+
 STABLE_TORCH_LIBRARY_FRAGMENT(libtorch_agnostic, m) {
   m.def("my_zero_(Tensor(a!) t) -> Tensor(a!)");
+  m.def("is_cpu(Tensor t) -> bool");
+
 }
 
 STABLE_TORCH_LIBRARY_IMPL(libtorch_agnostic, CPU, m) {
   m.impl("my_zero_", &boxed_my_zero_);
+  m.impl("my_is_cpu", &boxed_my_is_cpu);
 }

--- a/test/cpp_extensions/libtorch_agnostic_extension/libtorch_agnostic/ops.py
+++ b/test/cpp_extensions/libtorch_agnostic_extension/libtorch_agnostic/ops.py
@@ -50,6 +50,17 @@ def my_abs(t) -> Tensor:
     """
     return torch.ops.libtorch_agnostic.my_abs.default(t)
 
+def my_is_cpu(t) -> bool:
+    """
+    Returns is_cpu on the input tensor.
+
+    Args:
+        t: any Tensor
+
+    Returns:
+        a bool
+    """
+    return torch.ops.libtorch_agnostic.my_is_cpu.default(t)
 
 def my_ones_like(tensor, device) -> Tensor:
     """

--- a/test/cpp_extensions/libtorch_agnostic_extension/libtorch_agnostic/ops.py
+++ b/test/cpp_extensions/libtorch_agnostic_extension/libtorch_agnostic/ops.py
@@ -50,6 +50,7 @@ def my_abs(t) -> Tensor:
     """
     return torch.ops.libtorch_agnostic.my_abs.default(t)
 
+
 def my_is_cpu(t) -> bool:
     """
     Returns is_cpu on the input tensor.
@@ -61,6 +62,7 @@ def my_is_cpu(t) -> bool:
         a bool
     """
     return torch.ops.libtorch_agnostic.my_is_cpu.default(t)
+
 
 def my_ones_like(tensor, device) -> Tensor:
     """

--- a/test/cpp_extensions/libtorch_agnostic_extension/test/test_libtorch_agnostic.py
+++ b/test/cpp_extensions/libtorch_agnostic_extension/test/test_libtorch_agnostic.py
@@ -208,6 +208,14 @@ if not IS_WINDOWS:
             self.assertEqual(id(out), id(t))
             self.assertEqual(out, torch.zeros_like(t))
 
+        def test_my_is_cpu(self, device):
+            import libtorch_agnostic
+
+            t = torch.rand(2, 7, device=device)
+            out = libtorch_agnostic.ops.my_is_cpu(t)
+            self.assertEqual(out, t.is_cpu)
+
+
         def test_fill_infinity(self, device):
             import libtorch_agnostic
 

--- a/test/cpp_extensions/libtorch_agnostic_extension/test/test_libtorch_agnostic.py
+++ b/test/cpp_extensions/libtorch_agnostic_extension/test/test_libtorch_agnostic.py
@@ -215,7 +215,6 @@ if not IS_WINDOWS:
             out = libtorch_agnostic.ops.my_is_cpu(t)
             self.assertEqual(out, t.is_cpu)
 
-
         def test_fill_infinity(self, device):
             import libtorch_agnostic
 

--- a/torch/csrc/stable/tensor.h
+++ b/torch/csrc/stable/tensor.h
@@ -111,14 +111,14 @@ class Tensor {
 
   bool is_cpu() const {
     int32_t device_type;
-    AOTI_TORCH_ERROR_CODE_CHECK(
+    TORCH_ERROR_CODE_CHECK(
         aoti_torch_get_device_type(ath_.get(), &device_type));
     return device_type == aoti_torch_device_type_cpu();
   }
 
   int32_t dtype() const {
     int32_t ty;
-    AOTI_TORCH_ERROR_CODE_CHECK(
+    TORCH_ERROR_CODE_CHECK(
         aoti_torch_get_dtype(ath_.get(), &ty));
     return ty;
   }

--- a/torch/csrc/stable/tensor.h
+++ b/torch/csrc/stable/tensor.h
@@ -109,6 +109,20 @@ class Tensor {
     return device_type == aoti_torch_device_type_cuda();
   }
 
+  bool is_cpu() const {
+    int32_t device_type;
+    AOTI_TORCH_ERROR_CODE_CHECK(
+        aoti_torch_get_device_type(ath_.get(), &device_type));
+    return device_type == aoti_torch_device_type_cpu();
+  }
+
+  int32_t dtype() const {
+    int32_t ty;
+    AOTI_TORCH_ERROR_CODE_CHECK(
+        aoti_torch_get_dtype(ath_.get(), &ty));
+    return ty;
+  }
+
   int64_t size(int64_t dim) const {
     int64_t size;
     TORCH_ERROR_CODE_CHECK(aoti_torch_get_size(ath_.get(), dim, &size));

--- a/torch/csrc/stable/tensor.h
+++ b/torch/csrc/stable/tensor.h
@@ -116,13 +116,6 @@ class Tensor {
     return device_type == aoti_torch_device_type_cpu();
   }
 
-  int32_t dtype() const {
-    int32_t ty;
-    TORCH_ERROR_CODE_CHECK(
-        aoti_torch_get_dtype(ath_.get(), &ty));
-    return ty;
-  }
-
   int64_t size(int64_t dim) const {
     int64_t size;
     TORCH_ERROR_CODE_CHECK(aoti_torch_get_size(ath_.get(), dim, &size));


### PR DESCRIPTION
Porting torchaudio to use the stable api requires the `is_cuda` and `dtype` functions. It would be more convenient if these were methods of the stable tensor class rather than utilities one needed to call from the C api. This PR adds them as methods, mirroring how `is_cuda` and `get_device` are already defined. 