### PR TITLE
Fix undefined behavior in mul_overflows

### DIFF
--- a/c10/test/util/safe_numerics_test.cpp
+++ b/c10/test/util/safe_numerics_test.cpp
@@ -1,0 +1,109 @@
+#include <c10/util/safe_numerics.h>
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <limits>
+
+template <typename T>
+std::optional<T> mul_overflows(T a, T b) {
+  T result{0};
+  if (c10::mul_overflows(a, b, &result))
+    return std::nullopt;
+  return result;
+}
+
+TEST(MulOverflowsTest, Int64BasicOperations) {
+  ASSERT_EQ(mul_overflows<int64_t>(2, 3), 6);
+  ASSERT_EQ(mul_overflows<int64_t>(-2, 3), -6);
+  ASSERT_EQ(mul_overflows<int64_t>(2, -3), -6);
+  ASSERT_EQ(mul_overflows<int64_t>(-2, -3), 6);
+  ASSERT_EQ(mul_overflows<int64_t>(0, 5), 0);
+  ASSERT_EQ(mul_overflows<int64_t>(5, 0), 0);
+
+  // One cases
+  ASSERT_EQ(mul_overflows<int64_t>(1, 1), 1);
+  ASSERT_EQ(mul_overflows<int64_t>(1, -1), -1);
+  ASSERT_EQ(mul_overflows<int64_t>(-1, 1), -1);
+  ASSERT_EQ(mul_overflows<int64_t>(-1, -1), 1);
+}
+
+TEST(MulOverflowsTest, Int64OverflowCases) {
+  const int64_t max_val = std::numeric_limits<int64_t>::max();
+  const int64_t min_val = std::numeric_limits<int64_t>::min();
+
+  ASSERT_EQ(mul_overflows<int64_t>(max_val, 2), std::nullopt);
+  ASSERT_EQ(mul_overflows<int64_t>(2, max_val), std::nullopt);
+  ASSERT_EQ(mul_overflows<int64_t>(max_val, max_val), std::nullopt);
+
+  ASSERT_EQ(mul_overflows<int64_t>(min_val, 2), std::nullopt);
+  ASSERT_EQ(mul_overflows<int64_t>(2, min_val), std::nullopt);
+  ASSERT_EQ(mul_overflows<int64_t>(min_val, min_val), std::nullopt);
+}
+
+TEST(MulOverflowsTest, Int64LargeNumbersNoOverflow) {
+  const int64_t max_val = std::numeric_limits<int64_t>::max();
+  const int64_t min_val = std::numeric_limits<int64_t>::min();
+
+  ASSERT_EQ(mul_overflows<int64_t>(1L << 30L, 1L << 30L), 1L << 60);
+  ASSERT_EQ(mul_overflows<int64_t>(1L << 32L, 1L << 32L), std::nullopt);
+  ASSERT_EQ(mul_overflows<int64_t>(-(1L << 30L), 1L << 30L), -(1L << 60L));
+  ASSERT_EQ(mul_overflows<int64_t>(1L << 32L, -(1L << 32L)), std::nullopt);
+
+  // max_val is odd, so max_val/2 * 2 = max_val - 1
+  ASSERT_EQ(mul_overflows<int64_t>(max_val / 2, 2), max_val - 1);
+  ASSERT_EQ(mul_overflows<int64_t>(min_val / 2, 2), min_val);
+}
+
+TEST(MulOverflowsTest, Int64BoundaryValues) {
+  const int64_t max_val = std::numeric_limits<int64_t>::max();
+  const int64_t min_val = std::numeric_limits<int64_t>::min();
+
+  ASSERT_EQ(mul_overflows<int64_t>(1, max_val), max_val);
+  ASSERT_EQ(mul_overflows<int64_t>(max_val, 1), max_val);
+  ASSERT_EQ(mul_overflows<int64_t>(1, min_val), min_val);
+  ASSERT_EQ(mul_overflows<int64_t>(min_val, 1), min_val);
+  ASSERT_EQ(mul_overflows<int64_t>(-1, max_val), -max_val);
+  ASSERT_EQ(mul_overflows<int64_t>(max_val, -1), -max_val);
+
+  // result would be -min_val which is > max_val
+  ASSERT_EQ(mul_overflows<int64_t>(min_val, -1L), std::nullopt);
+  ASSERT_EQ(mul_overflows<int64_t>(-1L, min_val), std::nullopt);
+}
+
+TEST(MulOverflowsTest, Uint64BasicOperations) {
+  ASSERT_EQ(mul_overflows<uint64_t>(2u, 3u), 6u);
+  ASSERT_EQ(mul_overflows<uint64_t>(0u, 5u), 0u);
+  ASSERT_EQ(mul_overflows<uint64_t>(5u, 0u), 0u);
+  ASSERT_EQ(mul_overflows<uint64_t>(100u, 200u), 20000u);
+}
+
+TEST(MulOverflowsTest, Uint64OverflowCases) {
+  const uint64_t max_val = std::numeric_limits<uint64_t>::max();
+
+  ASSERT_EQ(mul_overflows<uint64_t>(max_val, 2u), std::nullopt);
+  ASSERT_EQ(mul_overflows<uint64_t>(2ull, max_val), std::nullopt);
+  ASSERT_EQ(mul_overflows<uint64_t>(1ull << 32, 1ull << 32), std::nullopt);
+  ASSERT_EQ(mul_overflows<uint64_t>(max_val, max_val), std::nullopt);
+
+  uint64_t floor_sqrt_max = 4294967295ull;
+  ASSERT_EQ(mul_overflows<uint64_t>(floor_sqrt_max + 1ull, floor_sqrt_max + 1ull), std::nullopt);
+}
+
+TEST(MulOverflowsTest, Uint64LargeNumbersNoOverflow) {
+  const uint64_t max_val = std::numeric_limits<uint64_t>::max();
+
+  // max_val is odd, so max_val/2 * 2 = max_val - 1
+  ASSERT_EQ(mul_overflows<uint64_t>(max_val / 2u, 2u), max_val - 1u);
+  ASSERT_EQ(mul_overflows<uint64_t>(1ull << 31, 1ull << 31), 1ull << 62);
+
+  uint64_t floor_sqrt_max = 4294967295ull;
+  ASSERT_EQ(mul_overflows<uint64_t>(floor_sqrt_max, floor_sqrt_max), 18446744065119617025ull);
+}
+
+TEST(MulOverflowsTest, Uint64BoundaryValues) {
+  const uint64_t max_val = std::numeric_limits<uint64_t>::max();
+
+  ASSERT_EQ(mul_overflows<uint64_t>(1u, max_val), max_val);
+  ASSERT_EQ(mul_overflows<uint64_t>(max_val, 1u), max_val);
+  ASSERT_EQ(mul_overflows<uint64_t>(0u, max_val), 0u);
+  ASSERT_EQ(mul_overflows<uint64_t>(max_val, 0u), 0u);
+}

--- a/c10/test/util/safe_numerics_test.cpp
+++ b/c10/test/util/safe_numerics_test.cpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <limits>
 
+namespace {
 template <typename T>
 std::optional<T> mul_overflows(T a, T b) {
   T result{0};
@@ -10,6 +11,7 @@ std::optional<T> mul_overflows(T a, T b) {
     return std::nullopt;
   return result;
 }
+} // namespace
 
 TEST(MulOverflowsTest, Int64BasicOperations) {
   ASSERT_EQ(mul_overflows<int64_t>(2, 3), 6);
@@ -85,7 +87,9 @@ TEST(MulOverflowsTest, Uint64OverflowCases) {
   ASSERT_EQ(mul_overflows<uint64_t>(max_val, max_val), std::nullopt);
 
   uint64_t floor_sqrt_max = 4294967295ull;
-  ASSERT_EQ(mul_overflows<uint64_t>(floor_sqrt_max + 1ull, floor_sqrt_max + 1ull), std::nullopt);
+  ASSERT_EQ(
+      mul_overflows<uint64_t>(floor_sqrt_max + 1ull, floor_sqrt_max + 1ull),
+      std::nullopt);
 }
 
 TEST(MulOverflowsTest, Uint64LargeNumbersNoOverflow) {
@@ -96,7 +100,9 @@ TEST(MulOverflowsTest, Uint64LargeNumbersNoOverflow) {
   ASSERT_EQ(mul_overflows<uint64_t>(1ull << 31, 1ull << 31), 1ull << 62);
 
   uint64_t floor_sqrt_max = 4294967295ull;
-  ASSERT_EQ(mul_overflows<uint64_t>(floor_sqrt_max, floor_sqrt_max), 18446744065119617025ull);
+  ASSERT_EQ(
+      mul_overflows<uint64_t>(floor_sqrt_max, floor_sqrt_max),
+      18446744065119617025ull);
 }
 
 TEST(MulOverflowsTest, Uint64BoundaryValues) {

--- a/c10/test/util/safe_numerics_test.cpp
+++ b/c10/test/util/safe_numerics_test.cpp
@@ -45,10 +45,10 @@ TEST(MulOverflowsTest, Int64LargeNumbersNoOverflow) {
   const int64_t max_val = std::numeric_limits<int64_t>::max();
   const int64_t min_val = std::numeric_limits<int64_t>::min();
 
-  ASSERT_EQ(mul_overflows<int64_t>(1L << 30L, 1L << 30L), 1L << 60);
-  ASSERT_EQ(mul_overflows<int64_t>(1L << 32L, 1L << 32L), std::nullopt);
-  ASSERT_EQ(mul_overflows<int64_t>(-(1L << 30L), 1L << 30L), -(1L << 60L));
-  ASSERT_EQ(mul_overflows<int64_t>(1L << 32L, -(1L << 32L)), std::nullopt);
+  ASSERT_EQ(mul_overflows<int64_t>(1ull << 30L, 1ull << 30L), 1ull << 60);
+  ASSERT_EQ(mul_overflows<int64_t>(1ull << 32L, 1ull << 32L), std::nullopt);
+  ASSERT_EQ(mul_overflows<int64_t>(-(1ull << 30L), 1ull << 30L), -(1ull << 60L));
+  ASSERT_EQ(mul_overflows<int64_t>(1ull << 32L, -(1ull << 32L)), std::nullopt);
 
   // max_val is odd, so max_val/2 * 2 = max_val - 1
   ASSERT_EQ(mul_overflows<int64_t>(max_val / 2, 2), max_val - 1);

--- a/c10/test/util/safe_numerics_test.cpp
+++ b/c10/test/util/safe_numerics_test.cpp
@@ -47,7 +47,8 @@ TEST(MulOverflowsTest, Int64LargeNumbersNoOverflow) {
 
   ASSERT_EQ(mul_overflows<int64_t>(1ull << 30L, 1ull << 30L), 1ull << 60);
   ASSERT_EQ(mul_overflows<int64_t>(1ull << 32L, 1ull << 32L), std::nullopt);
-  ASSERT_EQ(mul_overflows<int64_t>(-(1ull << 30L), 1ull << 30L), -(1ull << 60L));
+  ASSERT_EQ(
+      mul_overflows<int64_t>(-(1ull << 30L), 1ull << 30L), -(1ull << 60L));
   ASSERT_EQ(mul_overflows<int64_t>(1ull << 32L, -(1ull << 32L)), std::nullopt);
 
   // max_val is odd, so max_val/2 * 2 = max_val - 1

--- a/c10/util/safe_numerics.h
+++ b/c10/util/safe_numerics.h
@@ -34,6 +34,8 @@ C10_ALWAYS_INLINE bool add_overflows(uint64_t a, uint64_t b, uint64_t* out) {
 C10_ALWAYS_INLINE bool mul_overflows(int64_t a, int64_t b, int64_t* out) {
 #if C10_HAS_BUILTIN_OVERFLOW()
   return __builtin_mul_overflow(a, b, out);
+#elif defined(_M_X64) && (_MSC_VER >= 1937)
+  return _mul_overflow_i64(a, b, out);
 #else
   int64_t high{0};
   *out = _mul128(a, b, &high);
@@ -53,6 +55,9 @@ C10_ALWAYS_INLINE bool mul_overflows(int64_t a, int64_t b, int64_t* out) {
 C10_ALWAYS_INLINE bool mul_overflows(uint64_t a, uint64_t b, uint64_t* out) {
 #if C10_HAS_BUILTIN_OVERFLOW()
   return __builtin_mul_overflow(a, b, out);
+#elif defined(_M_X64) && (_MSC_VER >= 1937)
+  uint64_t high{0};
+  return _mul_full_overflow_u64(a, b, out, &high);
 #else
   uint64_t high{0};
   *out = _umul128(a, b, &high);

--- a/c10/util/safe_numerics.h
+++ b/c10/util/safe_numerics.h
@@ -34,8 +34,6 @@ C10_ALWAYS_INLINE bool add_overflows(uint64_t a, uint64_t b, uint64_t* out) {
 C10_ALWAYS_INLINE bool mul_overflows(int64_t a, int64_t b, int64_t* out) {
 #if C10_HAS_BUILTIN_OVERFLOW()
   return __builtin_mul_overflow(a, b, out);
-#elif defined(_M_X64) && (_MSC_VER >= 1937)
-  return _mul_overflow_i64(a, b, out);
 #else
   int64_t high{0};
   *out = _mul128(a, b, &high);
@@ -55,9 +53,6 @@ C10_ALWAYS_INLINE bool mul_overflows(int64_t a, int64_t b, int64_t* out) {
 C10_ALWAYS_INLINE bool mul_overflows(uint64_t a, uint64_t b, uint64_t* out) {
 #if C10_HAS_BUILTIN_OVERFLOW()
   return __builtin_mul_overflow(a, b, out);
-#elif defined(_M_X64) && (_MSC_VER >= 1937)
-  uint64_t high{0};
-  return _mul_full_overflow_u64(a, b, out, &high);
 #else
   uint64_t high{0};
   *out = _umul128(a, b, &high);

--- a/c10/util/safe_numerics.h
+++ b/c10/util/safe_numerics.h
@@ -31,8 +31,7 @@ C10_ALWAYS_INLINE bool add_overflows(uint64_t a, uint64_t b, uint64_t* out) {
 #endif
 }
 
-C10_ALWAYS_INLINE bool mul_overflows(int64_t a, int64_t b, int64_t* out)
-{
+C10_ALWAYS_INLINE bool mul_overflows(int64_t a, int64_t b, int64_t* out) {
 #if C10_HAS_BUILTIN_OVERFLOW()
   return __builtin_mul_overflow(a, b, out);
 #else
@@ -51,8 +50,7 @@ C10_ALWAYS_INLINE bool mul_overflows(int64_t a, int64_t b, int64_t* out)
 #endif
 }
 
-C10_ALWAYS_INLINE bool mul_overflows(uint64_t a, uint64_t b, uint64_t* out)
-{
+C10_ALWAYS_INLINE bool mul_overflows(uint64_t a, uint64_t b, uint64_t* out) {
 #if C10_HAS_BUILTIN_OVERFLOW()
   return __builtin_mul_overflow(a, b, out);
 #else

--- a/c10/util/safe_numerics.h
+++ b/c10/util/safe_numerics.h
@@ -82,8 +82,8 @@ C10_ALWAYS_INLINE bool mul_overflows(int64_t a, int64_t b, int64_t* out) {
     return true;
   }
 
-  bool negative{(a < 0) == (b < 0)};
-  if (!negative) {
+  bool positive{((a < 0) && (b < 0)) || ((a >= 0) && (b >= 0))};
+  if (positive) {
     if (unsigned_result > int64_max) {
       return true;
     }

--- a/c10/util/safe_numerics.h
+++ b/c10/util/safe_numerics.h
@@ -8,8 +8,8 @@
 #if defined(_MSC_VER) && !defined(__SYCL_DEVICE_ONLY__)
 #define C10_HAS_BUILTIN_OVERFLOW() (0)
 #include <intrin.h>
-#include <limits>
 #include <cmath>
+#include <limits>
 #else
 #define C10_HAS_BUILTIN_OVERFLOW() (1)
 #endif

--- a/c10/util/safe_numerics.h
+++ b/c10/util/safe_numerics.h
@@ -82,7 +82,7 @@ C10_ALWAYS_INLINE bool mul_overflows(int64_t a, int64_t b, int64_t* out) {
     return true;
   }
 
-  bool positive{((a < 0) && (b < 0)) || ((a >= 0) && (b >= 0))};
+  bool positive{(a >= 0 && b >= 0) || (a <= 0 && b <= 0)};
   if (positive) {
     if (unsigned_result > int64_max) {
       return true;

--- a/c10/util/safe_numerics.h
+++ b/c10/util/safe_numerics.h
@@ -5,10 +5,11 @@
 #include <cstdint>
 
 // GCC has __builtin_mul_overflow from before it supported __has_builtin
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__SYCL_DEVICE_ONLY__)
 #define C10_HAS_BUILTIN_OVERFLOW() (0)
 #include <intrin.h>
 #include <limits>
+#include <cmath>
 #else
 #define C10_HAS_BUILTIN_OVERFLOW() (1)
 #endif


### PR DESCRIPTION
The implementation of mul_overflows can cause UB when
__builtin_mul_overflow is not available. This happens
because the implementation performs a multiplication
without knowing in advance if the result will overflow.

> (C++17 8/4) If during the evaluation of an expression, the
> result is not mathematically defined or not in the range of
> representable values for its type, the behavior is undefined

A correct implementation of mul_overflows should be able
to determine if the result will overflow without actually
performing the multiplication.

cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex