### PR TITLE
fix(docs): wrong conversion from rst to md in torch.compiler_troubleshooting.md

### DIFF
--- a/docs/source/torch.compiler_troubleshooting.md
+++ b/docs/source/torch.compiler_troubleshooting.md
@@ -296,7 +296,7 @@ or changing some `torch.compile` settings.
 
 We recommend applying `torch.compile` to the highest-level function that doesn't cause excessive problems.
 Typically, it is your train or eval step with the optimizer but without the loop, your top-level `nn.Module`,
-or some sub-``` nn.Module``s. ``torch.compile ``` specifically doesn't handle distributed wrapper modules like
+or some sub- `nn.Module` s. `torch.compile` specifically doesn't handle distributed wrapper modules like
 DDP or FSDP very well, so consider applying `torch.compile` to the inner module passed to the wrapper.
 
 ```py


### PR DESCRIPTION
Due to wrong conversion from rst to md. Introduced in 5df3bf13ec4e436abefe9d3822230727c04c2ab7

Current:
<img width="1764" height="360" alt="image" src="https://github.com/user-attachments/assets/bdae5a6f-9c24-4b94-8dd6-a2b65256a313" />

After fix:
<img width="1266" height="400" alt="image" src="https://github.com/user-attachments/assets/21da6944-a172-4055-b524-6517af94c8c2" />
