### PR TITLE
extract shape in _view_has_unbacked_input

### DIFF
--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -514,6 +514,8 @@ def _compute_stride(old_shape, old_stride, new_shape, size_oblivious=False):
 def _view_has_unbacked_input(a, shape):
     from torch.fx.experimental.symbolic_shapes import has_hint
 
+    shape = utils.extract_shape_from_varargs(shape, validate=False)
+
     return (
         any(not has_hint(s) for s in a.size())
         or any(not has_hint(s) for s in a.stride())


### PR DESCRIPTION
Summary: We were getting DDE on reshape still!! i looked deeper and found an issue in _view_has_unbacked_input namely when input is [[,,]] it need to be normalized to [..]

Test Plan:
existing tests.

Rollback Plan:

Differential Revision: D79951119


