### PR TITLE
[inductor] Windows inductor use intel-openmp.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1639,7 +1639,7 @@ def main() -> None:
 
         skip_iomp = os.getenv("FORCE_SKIP_INTEL_OPENMP_DEPENDENCY", 0)
         if IS_WINDOWS and _is_AMD64_machine() and not skip_iomp:
-            return ["intel-openmp==2025.1.1"]
+            return ["intel-openmp"]
         return []
 
     install_requires += add_iomp_dependency_for_Windows_inductor()

--- a/setup.py
+++ b/setup.py
@@ -1623,7 +1623,7 @@ def main() -> None:
         "networkx>=2.5.1",
         "jinja2",
         "fsspec>=0.8.5",
-        'intel-openmp ;platform_system == "Windows" and platform_machine == "x86_64"',  # for Windows inductor
+        'intel-openmp==2025.1.1 ;platform_system == "Windows" and platform_machine == "x86_64"',  # for Windows inductor
     ]
     if BUILD_PYTHON_ONLY:
         install_requires += [f"{LIBTORCH_PKG_NAME}=={TORCH_VERSION}"]

--- a/setup.py
+++ b/setup.py
@@ -1623,7 +1623,7 @@ def main() -> None:
         "networkx>=2.5.1",
         "jinja2",
         "fsspec>=0.8.5",
-        'intel-openmp==2025.1.1 ;platform_system == "Windows" ',  # for Windows inductor
+        'intel-openmp ;platform_system == "Windows" and platform_machine == "x86_64"',  # for Windows inductor
     ]
     if BUILD_PYTHON_ONLY:
         install_requires += [f"{LIBTORCH_PKG_NAME}=={TORCH_VERSION}"]

--- a/setup.py
+++ b/setup.py
@@ -326,9 +326,6 @@ from tools.setup_helpers.env import (
 from tools.setup_helpers.generate_linker_script import gen_linker_script
 
 
-_IS_X8664 = platform.machine() == "x86_64"
-
-
 def str2bool(value: str | None) -> bool:
     """Convert environment variables to boolean values."""
     if not value:
@@ -1634,8 +1631,14 @@ def main() -> None:
         # for Windows inductor:
         # intel-openmp is requirement for Windows inductor on Windows x64.
         # We can also setup env var to skip the iomp.
+        def _is_AMD64_machine() -> bool:
+            if IS_WINDOWS:
+                return platform.machine() == "AMD64"
+            else:
+                return platform.machine() == "x86_64"
+
         skip_iomp = os.getenv("FORCE_SKIP_INTEL_OPENMP_DEPENDENCY", 0)
-        if IS_WINDOWS and _IS_X8664 and not skip_iomp:
+        if IS_WINDOWS and _is_AMD64_machine() and not skip_iomp:
             return ["intel-openmp==2025.1.1"]
         return []
 

--- a/setup.py
+++ b/setup.py
@@ -1623,6 +1623,7 @@ def main() -> None:
         "networkx>=2.5.1",
         "jinja2",
         "fsspec>=0.8.5",
+        'intel-openmp==2025.1.1 ;platform_system == "Windows" ',  # for Windows inductor
     ]
     if BUILD_PYTHON_ONLY:
         install_requires += [f"{LIBTORCH_PKG_NAME}=={TORCH_VERSION}"]

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -1130,8 +1130,15 @@ def _get_python_related_args() -> tuple[list[str], list[str]]:
             str(
                 (
                     Path(sysconfig.get_path("include", scheme="nt")).parent / "libs"
-                ).absolute()
-            )
+                ).absolute()  # python[ver].lib
+            ),
+            str(
+                (
+                    Path(sysconfig.get_path("include", scheme="nt")).parent
+                    / "Library"
+                    / "lib"
+                ).absolute()  # install python librarys location, such as intel-openmp
+            ),
         ]
     else:
         python_lib_path = [sysconfig.get_config_var("LIBDIR")]

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -67,6 +67,8 @@ _IS_LINUX = sys.platform.startswith("linux")
 _IS_MACOS = sys.platform.startswith("darwin")
 _IS_WINDOWS = sys.platform == "win32"
 
+_IS_X8664 = platform.machine() == "x86_64"
+
 SUBPROCESS_DECODE_ARGS = ("utf-8",) if _IS_WINDOWS else ()
 
 log = logging.getLogger(__name__)
@@ -1306,8 +1308,9 @@ def _get_openmp_args(
         else:
             cflags.append("openmp")
             cflags.append("openmp:experimental")
-            libs.append("libiomp5md")  # intel-openmp
-            ldflags.append("nodefaultlib:vcomp")
+            if _IS_X8664:
+                libs.append("libiomp5md")  # intel-openmp
+                ldflags.append("nodefaultlib:vcomp")
     else:
         if config.is_fbcode():
             include_dir_paths.append(build_paths.openmp_include)

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -1305,7 +1305,7 @@ def _get_openmp_args(
             perload_icx_libomp_win(cpp_compiler)
         else:
             cflags.append("openmp")
-            # cflags.append("openmp:experimental")  # MSVC Openmp, it has some issue for inductor.
+            cflags.append("openmp:experimental")
             libs.append("libiomp5md")  # intel-openmp
             ldflags.append("nodefaultlib:vcomp")
     else:

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -1297,11 +1297,10 @@ def _get_openmp_args(
             libs.append("libiomp5md")
             perload_icx_libomp_win(cpp_compiler)
         else:
-            # /openmp, /openmp:llvm
-            # llvm on Windows, new openmp: https://devblogs.microsoft.com/cppblog/msvc-openmp-update/
-            # msvc openmp: https://learn.microsoft.com/zh-cn/cpp/build/reference/openmp-enable-openmp-2-0-support?view=msvc-170
             cflags.append("openmp")
-            cflags.append("openmp:experimental")  # MSVC CL
+            # cflags.append("openmp:experimental")  # MSVC Openmp, it has some issue for inductor.
+            libs.append("libiomp5md")  # intel-openmp
+            ldflags.append("nodefaultlib:vcomp")
     else:
         if config.is_fbcode():
             include_dir_paths.append(build_paths.openmp_include)

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -67,7 +67,13 @@ _IS_LINUX = sys.platform.startswith("linux")
 _IS_MACOS = sys.platform.startswith("darwin")
 _IS_WINDOWS = sys.platform == "win32"
 
-_IS_X8664 = platform.machine() == "x86_64"
+
+def _is_AMD64_machine() -> bool:
+    if _IS_WINDOWS:
+        return platform.machine() == "AMD64"
+    else:
+        return platform.machine() == "x86_64"
+
 
 SUBPROCESS_DECODE_ARGS = ("utf-8",) if _IS_WINDOWS else ()
 
@@ -1308,9 +1314,9 @@ def _get_openmp_args(
         else:
             cflags.append("openmp")
             cflags.append("openmp:experimental")
-            if _IS_X8664:
-                libs.append("libiomp5md")  # intel-openmp
-                ldflags.append("nodefaultlib:vcomp")
+            if _is_AMD64_machine():
+                libs.append("libiomp5md")  # use intel-openmp
+                ldflags.append("nodefaultlib:vcomp")  # disable msvc openmp
     else:
         if config.is_fbcode():
             include_dir_paths.append(build_paths.openmp_include)


### PR DESCRIPTION
After some debug work, I found PyTorch torch_cpu.dll is using intel-openmp, but not MSVC openmp. 
So, switch Windows inductor to intel-openmp.

It fixed: https://github.com/pytorch/pytorch/blob/c8205cb35435f39d2c26f6c94b45e4adeb6dcb23/test/inductor/test_aot_inductor.py#L2405-L2408
<img width="896" height="230" alt="image" src="https://github.com/user-attachments/assets/273b00f8-7dc1-43c9-9b7f-752e16355a80" />

Change list:
1. On Windows AMD version, Inductor will use `intel-openmp` to fix crashed issue.
2. On Windows AMD version, setup.py will add `intel-openmp` to dependency list explicitly.
3. Add `FORCE_SKIP_INTEL_OPENMP_DEPENDENCY` env var to skip add `intel-openmp` dependency. It is for AMD user @ScottTodd .

Local validated dependency dump:
<img width="853" height="203" alt="image" src="https://github.com/user-attachments/assets/cdc5f164-d745-4f5b-b3a2-5db3f7f79d22" />

cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben 