### PR TITLE
[FSDP2] cast `unsharded_param_grad` to correct reduce dtype

### DIFF
--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -524,7 +524,9 @@ class FSDPParamGroup:
                     fsdp_param.unsharded_accumulated_grad = None
                 elif fsdp_param.unsharded_param.grad is not None:
                     fsdp_params_with_grad.append(fsdp_param)
-                    unsharded_grads.append(fsdp_param.unsharded_grad_data.to(fsdp_param.reduce_dtype))
+                    unsharded_grads.append(
+                        fsdp_param.unsharded_grad_data.to(fsdp_param.reduce_dtype)
+                    )
                     fsdp_param.unsharded_param.grad = None
             if self.reshard_after_backward:
                 self.reshard()

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -524,7 +524,7 @@ class FSDPParamGroup:
                     fsdp_param.unsharded_accumulated_grad = None
                 elif fsdp_param.unsharded_param.grad is not None:
                     fsdp_params_with_grad.append(fsdp_param)
-                    unsharded_grads.append(fsdp_param.unsharded_grad_data)
+                    unsharded_grads.append(fsdp_param.unsharded_grad_data.to(fsdp_param.reduce_dtype))
                     fsdp_param.unsharded_param.grad = None
             if self.reshard_after_backward:
                 self.reshard()


### PR DESCRIPTION
This is an edge case when using gradient accumulation with FSDP2. 

If a parameter within a parameter group doesnt have gradients for all but the final backwards pass, the grad is not casted to the reduce dtype resulting in inconsistent dtype between gradients for `reduce_scatter`.

Specifically, if using a MixedPrecisionPolicy with `param_dtype=torch.bfloat16` and `reduce_dtype=torch.float32`, parameters that had grads for both steps will have gradients of dtype torch.float32, but those that have a gradient _only_ on the final pass will have gradients of dtype torch.bfloat16. This raises:

```
AssertionError: FSDP reduce-scatter expects uniform gradient dtype but got {torch.bfloat16, torch.float32}
```

This pr explicitly casts the grad to the correct dtype for the given case.


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @aditvenk