### PR TITLE
[C10D] Add check_rng_sync util

### DIFF
--- a/test/distributed/test_collective_utils.py
+++ b/test/distributed/test_collective_utils.py
@@ -131,6 +131,8 @@ class TestCollectiveUtils(MultiProcessTestCase):
         self,
         device,
     ) -> None:
+        if device == "cuda" and not torch.cuda.is_available():
+            self.skipTest("Cuda is not available")
         store = c10d.FileStore(self.file_name, self.world_size)
         c10d.init_process_group(
             backend="gloo", store=store, rank=self.rank, world_size=self.world_size

--- a/torch/distributed/collective_utils.py
+++ b/torch/distributed/collective_utils.py
@@ -22,6 +22,13 @@ import torch
 import torch.distributed as dist
 
 
+__all__: list[str] = [
+    "SyncPayload",
+    "broadcast",
+    "all_gather",
+    "all_gather_object_enforce_type",
+]
+
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")

--- a/torch/distributed/collective_utils.py
+++ b/torch/distributed/collective_utils.py
@@ -279,10 +279,10 @@ def _check_cpu_rng_sync(
     torch.distributed.all_gather(all_state_tensors, state_tensor)
     state_ranks = defaultdict(set)
     for rank, state_tensor in enumerate(all_state_tensors):
-        # Hacky way to summarize the state vector of the CPU rng. Is there a better way to do this?
+        # Summarize the state vector of the CPU rng.
         # The properties that matter most are (1) its different if there is a state difference, (2) its printable
         # (see desync table- not viable to print whole state vector of size 5k)
-        state_ranks[hash(tuple(state_tensor.tolist()))].add(rank)
+        state_ranks[torch.hash_tensor(state_tensor).item()].add(rank)
     return state_ranks, "Generator state hash"
 
 

--- a/torch/distributed/collective_utils.py
+++ b/torch/distributed/collective_utils.py
@@ -9,11 +9,20 @@ Each should also handle single rank scenario.
 
 from __future__ import annotations
 
+import logging
+from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any, Callable, cast, Generic, Optional, TypeVar, Union
+from typing import Any, Callable, cast, Generic, Optional, TYPE_CHECKING, TypeVar, Union
 
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+import torch
 import torch.distributed as dist
 
+
+logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
@@ -215,3 +224,87 @@ def all_gather_object_enforce_type(
                 f"Object type at index {i} is {type(object_list[i])}, "
                 f"while first object type is {type(first_obj)}"
             )
+
+
+def summarize_ranks(numbers: Iterable[int]) -> str:
+    numbers = sorted(numbers)
+    result = []
+    current_range_start = numbers[0]
+    for i in range(1, len(numbers)):
+        if numbers[i] == numbers[i - 1] + 1:
+            pass
+        else:
+            if current_range_start == numbers[i - 1]:
+                result.append(str(current_range_start))
+            else:
+                result.append(f"{current_range_start}-{numbers[i - 1]}")
+            current_range_start = numbers[i]
+    if current_range_start == numbers[-1]:
+        result.append(str(current_range_start))
+    else:
+        result.append(f"{current_range_start}-{numbers[-1]}")
+    return ", ".join(result)
+
+
+def _check_philox_rng_sync(
+    generator: torch.Generator, group: dist.ProcessGroup
+) -> tuple[dict[Any, set], str]:
+    local_state = generator.get_state()
+    all_states = [torch.empty_like(local_state) for _ in range(group.size())]
+    torch.distributed.all_gather(all_states, local_state)
+    seeds_offsets = [
+        (state[:8].view(torch.uint64).item(), state[8:].view(torch.uint64).item())
+        for state in all_states
+    ]
+    seed_offset_ranks = defaultdict(set)
+    for rank, (seed, offset) in enumerate(seeds_offsets):
+        seed_offset_ranks[(seed, offset)].add(rank)
+    return seed_offset_ranks, "(Seed, Offset)"
+
+
+def _check_cpu_rng_sync(
+    generator: torch.Generator, group: dist.ProcessGroup
+) -> tuple[dict[Any, set], str]:
+    # seed is returned as uint64_t from C impl, so may not fit in torch int64 tensor directly.
+    state_tensor = generator.get_state()
+    all_state_tensors = [torch.empty_like(state_tensor) for _ in range(group.size())]
+    torch.distributed.all_gather(all_state_tensors, state_tensor)
+    state_ranks = defaultdict(set)
+    for rank, state_tensor in enumerate(all_state_tensors):
+        # Hacky way to summarize the state vector of the CPU rng. Is there a better way to do this?
+        # The properties that matter most are (1) its different if there is a state difference, (2) its printable
+        # (see desync table- not viable to print whole state vector of size 5k)
+        state_ranks[hash(tuple(state_tensor.tolist()))].add(rank)
+    return state_ranks, "Generator state hash"
+
+
+def _check_rng_sync(
+    generator: torch.Generator, group: dist.ProcessGroup
+) -> tuple[dict[Any, set], str]:
+    if generator.device.type == "cuda":
+        return _check_philox_rng_sync(generator, group)
+    elif generator.device.type == "cpu":
+        return _check_cpu_rng_sync(generator, group)
+    else:
+        raise NotImplementedError(
+            f"Unsupported generator device: {generator.device.type}"
+        )
+
+
+def _desync_table_str(tag: str, value_ranks: dict[Any, set[int]]) -> str:
+    headers = ["Ranks", f"{tag} values"]
+    rank_values = [
+        [summarize_ranks(ranks), str(value)] for value, ranks in value_ranks.items()
+    ]
+    from tabulate import tabulate
+
+    return tabulate(rank_values, headers=headers)
+
+
+def check_rng_sync(generator: torch.Generator, group: dist.ProcessGroup) -> None:
+    value_ranks, value_header = _check_rng_sync(generator, group)
+    if len(value_ranks) > 1:
+        logger.error(
+            "Generator desync detected:\n%s",
+            _desync_table_str(value_header, value_ranks),
+        )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #160283

Debugs RNG desync by checking the current state on each rank in the group and summarizing the differences if any are detected.

Notes:
- used allgather instead of gather since its simpler to do this SPMD rather than add conditional behavior, though I could be convinced we only want to log on rank0.

Usage:
`check_rng_sync(generator, group)`

Prints something like this:

(cuda):
```
[rank0]:E0808 ] Generator desync detected:
[rank0]:E0808 ] Ranks    (Seed, Offset) values
[rank0]:E0808 ] -------  -----------------------
[rank0]:E0808 ] 0        (456, 0)
[rank0]:E0808 ] 1        (123, 4)
[rank0]:E0808 ] 2-3      (123, 0)
```

(cpu):
```
[rank2]:E0810 ] Generator desync detected:
[rank2]:E0810 ] Ranks      Generator State Hash values
[rank2]:E0810 ] -------  -----------------------------
[rank2]:E0810 ] 0                  7633364531954955665
[rank2]:E0810 ] 1                  8807615394212033278
[rank2]:E0810 ] 2-3               -6150027303226666531
```

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @d4l3k @pragupta