### PR TITLE
Enable XPU for test_autograd_function.py

### DIFF
--- a/test/dynamo/test_autograd_function.py
+++ b/test/dynamo/test_autograd_function.py
@@ -10,11 +10,13 @@ import torch._dynamo.testing
 import torch._dynamo.utils
 from torch.testing._internal.triton_utils import (
     HAS_CUDA_AND_TRITON,
-    requires_cuda_and_triton,
+    requires_gpu,
+    HAS_XPU_AND_TRITON
 )
+from torch.testing._internal.common_fsdp import get_devtype
 
 
-if HAS_CUDA_AND_TRITON:
+if HAS_CUDA_AND_TRITON or HAS_XPU_AND_TRITON:
     import triton
 
     from torch.testing._internal.triton_utils import add_kernel
@@ -507,13 +509,13 @@ class AutogradFunctionTests(torch._dynamo.test_case.TestCase):
 
         class MyMM(torch.autograd.Function):
             @staticmethod
-            @torch.amp.custom_fwd(device_type="cuda")
+            @torch.amp.custom_fwd(device_type=get_devtype())
             def forward(ctx, a, b):
                 ctx.save_for_backward(a, b)
                 return a.mm(b)
 
             @staticmethod
-            @torch.amp.custom_bwd(device_type="cuda")
+            @torch.amp.custom_bwd(device_type=get_devtype())
             def backward(ctx, grad):
                 a, b = ctx.saved_tensors
                 return grad.mm(b.t()), a.t().mm(grad)
@@ -1476,7 +1478,7 @@ class GraphModule(torch.nn.Module):
         self.assertEqual(cnt.frame_count, 1)
         self.assertEqual(cnt.op_count, 1)
 
-    @requires_cuda_and_triton
+    @requires_gpu
     def test_triton_kernel_basic(self):
         class Add(torch.autograd.Function):
             @staticmethod
@@ -1500,14 +1502,14 @@ class GraphModule(torch.nn.Module):
             z = Add.apply(x, y)
             return z
 
-        x = torch.randn(10, device="cuda", requires_grad=True)
-        y = torch.randn(10, device="cuda", requires_grad=True)
+        x = torch.randn(10, device=get_devtype(), requires_grad=True)
+        y = torch.randn(10, device=get_devtype(), requires_grad=True)
         z = f(x, y)
         loss = z.sum()
         loss.backward()
         self.assertEqual(x + y, z)
 
-    @requires_cuda_and_triton
+    @requires_gpu
     def test_triton_kernel_multiple_out(self):
         class Add(torch.autograd.Function):
             @staticmethod
@@ -1535,8 +1537,8 @@ class GraphModule(torch.nn.Module):
             z = Add.apply(x, y)
             return z
 
-        x = torch.randn(10, device="cuda", requires_grad=True)
-        y = torch.randn(10, device="cuda", requires_grad=True)
+        x = torch.randn(10, device=get_devtype(), requires_grad=True)
+        y = torch.randn(10, device=get_devtype(), requires_grad=True)
         z, _ = f(x, y)
         loss = z.sum()
         loss.backward()

--- a/test/dynamo/test_autograd_function.py
+++ b/test/dynamo/test_autograd_function.py
@@ -10,6 +10,7 @@ import torch._dynamo.testing
 import torch._dynamo.utils
 from torch.testing._internal.triton_utils import HAS_GPU, requires_gpu
 
+
 device_type = (
     acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
 )

--- a/test/dynamo/test_autograd_function.py
+++ b/test/dynamo/test_autograd_function.py
@@ -9,15 +9,14 @@ import torch._dynamo.test_case
 import torch._dynamo.testing
 import torch._dynamo.utils
 from torch.testing._internal.triton_utils import (
-    HAS_CUDA_AND_TRITON,
-    requires_gpu,
-    HAS_XPU_AND_TRITON
+    HAS_GPU,
+    requires_gpu
 )
 device_type = (
     acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
 )
 
-if HAS_CUDA_AND_TRITON or HAS_XPU_AND_TRITON:
+if HAS_GPU:
     import triton
 
     from torch.testing._internal.triton_utils import add_kernel

--- a/test/dynamo/test_autograd_function.py
+++ b/test/dynamo/test_autograd_function.py
@@ -8,10 +8,8 @@ import torch
 import torch._dynamo.test_case
 import torch._dynamo.testing
 import torch._dynamo.utils
-from torch.testing._internal.triton_utils import (
-    HAS_GPU,
-    requires_gpu
-)
+from torch.testing._internal.triton_utils import HAS_GPU, requires_gpu
+
 device_type = (
     acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
 )

--- a/torch/testing/_internal/triton_utils.py
+++ b/torch/testing/_internal/triton_utils.py
@@ -2,12 +2,15 @@
 
 import unittest
 
-from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON, HAS_GPU
+from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON, HAS_GPU, HAS_XPU_AND_TRITON
 from torch.utils._triton import has_triton
 
 
 requires_cuda_and_triton = unittest.skipUnless(
     HAS_CUDA_AND_TRITON, "requires cuda and triton"
+)
+requires_xpu_and_triton = unittest.skipUnless(
+    HAS_XPU_AND_TRITON, "requires xpu and triton"
 )
 requires_gpu = unittest.skipUnless(HAS_GPU, "requires gpu")
 

--- a/torch/testing/_internal/triton_utils.py
+++ b/torch/testing/_internal/triton_utils.py
@@ -9,9 +9,6 @@ from torch.utils._triton import has_triton
 requires_cuda_and_triton = unittest.skipUnless(
     HAS_CUDA_AND_TRITON, "requires cuda and triton"
 )
-requires_xpu_and_triton = unittest.skipUnless(
-    HAS_XPU_AND_TRITON, "requires xpu and triton"
-)
 requires_gpu = unittest.skipUnless(HAS_GPU, "requires gpu")
 
 if has_triton():

--- a/torch/testing/_internal/triton_utils.py
+++ b/torch/testing/_internal/triton_utils.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON, HAS_GPU, HAS_XPU_AND_TRITON
+from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON, HAS_GPU
 from torch.utils._triton import has_triton
 
 


### PR DESCRIPTION
# Description
Fixes #114850, we will port dynamo tests to Intel GPU
We could enable Intel GPU with following methods and try the best to keep the original code styles:

# Changes
1. Get device type from accelerator method.
2. Replace the requires_cuda_and_triton with requires_gpu.

# Notify
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @gujinghui @fengyuan14 @guangyey