### PR TITLE
[inductor] Fix descriptor broadcasting for singleton dimensions

### DIFF
--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -81,6 +81,7 @@ TMA_TEST_XFAIL = dict.fromkeys(
         "test_broadcast_prefer_nd_tiling_False_x_size3_y_size3",
         "test_broadcast_prefer_nd_tiling_True_x_size0_y_size0",
         "test_broadcast_prefer_nd_tiling_True_x_size2_y_size2",
+        "test_broadcast_with_singleton_dims",
     ),
     TMA_XFAIL,
 )
@@ -367,13 +368,13 @@ class CommonTemplate:
             return (unsqueeze_6,)
 
         def load_args(reader):
-            buf0 = reader.storage(storage_hash=None, nbytes=512)
+            buf0 = reader.storage(storage_hash=None, nbytes=512, device=self.device)
             reader.tensor(buf0, (1, 4, 2, 32), (128, 1, 0, 4), is_leaf=True)  # expand_4
-            buf1 = reader.storage(storage_hash=None, nbytes=3072)
+            buf1 = reader.storage(storage_hash=None, nbytes=3072, device=self.device)
             reader.tensor(
                 buf1, (1, 3, 4, 64), (768, 64, 192, 1), is_leaf=True
             )  # permute_4
-            buf2 = reader.storage(storage_hash=None, nbytes=3072)
+            buf2 = reader.storage(storage_hash=None, nbytes=3072, device=self.device)
             reader.tensor(buf2, (1, 3, 4, 64), is_leaf=True)  # mul_7
 
         load_args._version = 0

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, Optional, Union
 
 import torch
 import torch.utils._pytree as pytree
+from torch._dynamo.debug_utils import InputReader
 from torch._inductor import config
 from torch._inductor.choices import InductorChoices
 from torch._inductor.codegen.triton import FixedTritonConfig
@@ -324,6 +325,67 @@ class CommonTemplate:
             y,
             expected_num_block_pointers=3,
             config_patches={"triton.prefer_nd_tiling": prefer_nd_tiling},
+        )
+
+    def test_broadcast_with_singleton_dims(self):
+        # This tests the case when the input / output contains both zero strides
+        # and singleton dimensions. In this case the broadcasting dimensions
+        # generated for the descriptor need to ignore dimensions that have zero
+        # strides with size 1
+
+        # This is a minified repro based on HuggingFaceTB/SmolLM2-135M
+        # original issue:
+        # store index=x2 + 192*y0 + 64*y1
+        # matched block params = BlockParameters(
+        #     shape=[3, 4, 1, 1, 64],
+        #     block_shape=[((YBLOCK + 3)//4), Min(4, YBLOCK), 1, 1, XBLOCK],
+        #     strides=[64, 192, 0, 0, 1],
+        #     offsets=[(yoffset//4), ModularIndexing(yoffset, 1, 4), 0, 0, xoffset]
+        # )
+        # broadcasting_dims=[False, False, True, True, False]
+        # broadcast_shape=[((YBLOCK + 3)//4), Min(4, YBLOCK), XBLOCK]
+        # error, len(broadcasting_dims) != broadcast_shape
+        def forward(expand_4, permute_4, mul_7):
+            clone = torch.ops.aten.clone.default(
+                expand_4, memory_format=torch.contiguous_format
+            )
+            expand_4 = None
+            view_4 = torch.ops.aten.view.default(clone, [1, 4, 64])
+            clone = None
+            cos = torch.ops.aten.cos.default(view_4)
+            view_4 = None
+            mul = torch.ops.aten.mul.Tensor(cos, 1.0)
+            cos = None
+            unsqueeze_4 = torch.ops.aten.unsqueeze.default(mul, 1)
+            mul = None
+            mul_6 = torch.ops.aten.mul.Tensor(permute_4, unsqueeze_4)
+            permute_4 = unsqueeze_4 = None
+            add_3 = torch.ops.aten.add.Tensor(mul_6, mul_7)
+            mul_6 = mul_7 = None
+            unsqueeze_6 = torch.ops.aten.unsqueeze.default(add_3, 2)
+            add_3 = None
+            return (unsqueeze_6,)
+
+        def load_args(reader):
+            buf0 = reader.storage(storage_hash=None, nbytes=512)
+            reader.tensor(buf0, (1, 4, 2, 32), (128, 1, 0, 4), is_leaf=True)  # expand_4
+            buf1 = reader.storage(storage_hash=None, nbytes=3072)
+            reader.tensor(
+                buf1, (1, 3, 4, 64), (768, 64, 192, 1), is_leaf=True
+            )  # permute_4
+            buf2 = reader.storage(storage_hash=None, nbytes=3072)
+            reader.tensor(buf2, (1, 3, 4, 64), is_leaf=True)  # mul_7
+
+        load_args._version = 0
+
+        input_reader = InputReader()
+        load_args(input_reader)
+        args = input_reader.args
+
+        self._run_and_compare(
+            forward,
+            *args,
+            expected_num_block_pointers=4,
         )
 
     @parametrize(

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -316,6 +316,14 @@ class BlockDescriptorOptions:
         # Combine all removable dims.
         removable_dims = [any(dims) for dims in zip(singleton_dims, broadcasting_dims)]
 
+        # Remove singleton_dims from broadcasting_dims so that
+        # broadcast_shape and broadcasting_dims have the same length
+        broadcasting_dims = [
+            dim
+            for dim, is_singleton in zip(broadcasting_dims, singleton_dims)
+            if not is_singleton
+        ]
+
         def remove_dims(it):
             """Removes any broadcasting or singleton dims from a given sequence"""
             return [


### PR DESCRIPTION
This fixes the case when an input / output contains both zero strides and singleton dimensions. In this case the broadcasting dimensions generated for the descriptor need to ignore dimensions that have zero strides with size 1, otherwise the determination of which dimensions to broadcast will fail. 

As an example, consider the following store instruction:

```
name=buf1
index=x2 + 192*y0 + 64*y1
valule=TritonCSEVariable('tmp7')
params = BlockParameters(
    shape=[3, 4, 1, 1, 64],
    block_shape=[((YBLOCK + 3)//4), Min(4, YBLOCK), 1, 1, XBLOCK],
    strides=[64, 192, 0, 0, 1],
    offsets=[(yoffset//4), ModularIndexing(yoffset, 1, 4), 0, 0, xoffset]
)
broadcasting_dims=[False, False, True, True, False]
broadcast_shape=[((YBLOCK + 3)//4), Min(4, YBLOCK), XBLOCK]
```
Because `len(self.broadcasting_dims) != self.broadcast_shape)`, dim3 is incorrectly
marked as a broadcast dimension when the pre-broadcast shape is computed in `codegen_broadcast_and_reshape`.

```
9             pre_broadcast_shape = [
280                 sympy.S.One if is_broadcasting else dim
281                 for dim, is_broadcasting in zip(
282  ->                 self.broadcast_shape, self.broadcasting_dims
283                 )
284             ]
```

The pre_broadcast_shape is now wrong: `[((YBLOCK + 3)//4), Min(4, YBLOCK), 1]`

Triton throws the following error: `reshape() cannot change total number of elements in tensor`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben