### PR TITLE
Fix reinplace optimization issue for index_put when self and source alias

### DIFF
--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -491,7 +491,10 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
 
         if get_node_storage(mutated_arg) is None:
             return False
-
+        if isinstance(node.args, (list, tuple)) and len(node.args) >=2:
+            source=node.args[-1]
+            if get_node_storage(source) == get_node_storage(mutated_arg):
+                return False
         shared_view_nodes = storage_to_nodes[get_node_storage(mutated_arg)]
 
         # Only keep tensor that might overlap with mutated_arg.


### PR DESCRIPTION
Fixes #156786 
Fix an issue in inductor's reinplace optimization where torch.index_put is transformed into torch.index_put_ even when self and source refer to the same underlying storage. This causes incorrect results due to read/write aliasing.

The fix adds a condition in reinplace.py to skip transformation when self and source alias.
A test is added to ensure that compiled output matches eager behavior in such cases.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben