### PR TITLE
[DO NOT MERGE] ACL Version Upgrade v52.3.0

### DIFF
--- a/.ci/aarch64_linux/aarch64_wheel_ci_build.py
+++ b/.ci/aarch64_linux/aarch64_wheel_ci_build.py
@@ -41,7 +41,7 @@ def build_ArmComputeLibrary() -> None:
                 "clone",
                 "https://github.com/ARM-software/ComputeLibrary.git",
                 "-b",
-                "v25.02",
+                "v52.3.0",
                 "--depth",
                 "1",
                 "--shallow-submodules",

--- a/.ci/aarch64_linux/build_aarch64_wheel.py
+++ b/.ci/aarch64_linux/build_aarch64_wheel.py
@@ -327,7 +327,7 @@ def build_ArmComputeLibrary(host: RemoteHost, git_clone_flags: str = "") -> None
         ]
     )
     host.run_cmd(
-        f"git clone https://github.com/ARM-software/ComputeLibrary.git -b v25.02 {git_clone_flags}"
+        f"git clone https://github.com/ARM-software/ComputeLibrary.git -b v52.3.0 {git_clone_flags}"
     )
 
     host.run_cmd(f"cd ComputeLibrary && scons Werror=1 -j8 {acl_build_flags}")

--- a/.ci/docker/common/install_acl.sh
+++ b/.ci/docker/common/install_acl.sh
@@ -1,6 +1,6 @@
 set -euo pipefail
 
-readonly version=v25.02
+readonly version=v52.3.0
 readonly src_host=https://github.com/ARM-software
 readonly src_repo=ComputeLibrary
 


### PR DESCRIPTION
Upgrades ACL version from v25 to v52 . 
This will be needed for oneDNN upgrade `3.9`
