### PR TITLE
[Caffe2] Add SVE128 vectorized<T> template layers for unsigned integers

### DIFF
--- a/aten/src/ATen/cpu/vec/vec128/vec128_bfloat16_sve.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_bfloat16_sve.h
@@ -1,0 +1,545 @@
+#pragma once
+
+// DO NOT DEFINE STATIC DATA IN THIS HEADER!
+// See Note [Do not compile initializers with AVX]
+#include <ATen/cpu/vec/sve/sve_helper.h>
+#include <ATen/cpu/vec/vec128/vec128_reduced_precision_common_neon.h>
+#include <c10/util/BFloat16.h>
+#include <c10/util/bit_cast.h>
+#include <c10/util/irange.h>
+
+namespace at::vec {
+// See Note [CPU_CAPABILITY namespace]
+inline namespace CPU_CAPABILITY {
+
+// Following vec128_half_neon.h, we only support aarch64.
+#if !defined(C10_MOBILE) && defined(__aarch64__)
+#ifdef __BIG_ENDIAN__
+#error "Big endian is not supported."
+#endif
+
+template <int index, bool mask_val>
+struct BlendBFloat16Regs {
+  static bfloat16x8_t impl(
+      const bfloat16x8_t& a,
+      const bfloat16x8_t& b,
+      bfloat16x8_t& res);
+};
+
+template <int index>
+struct BlendBFloat16Regs<index, true> {
+  static bfloat16x8_t impl(
+      const bfloat16x8_t& a,
+      const bfloat16x8_t& b,
+      bfloat16x8_t& res) {
+    return vsetq_lane_bf16(vgetq_lane_bf16(b, index), res, index);
+  }
+};
+
+template <int index>
+struct BlendBFloat16Regs<index, false> {
+  static bfloat16x8_t impl(
+      const bfloat16x8_t& a,
+      const bfloat16x8_t& b,
+      bfloat16x8_t& res) {
+    return vsetq_lane_bf16(vgetq_lane_bf16(a, index), res, index);
+  }
+};
+
+template <>
+struct is_vec_specialized_for<c10::BFloat16> : std::bool_constant<true> {};
+
+template <>
+class Vectorized<c10::BFloat16> : public Vectorized16<
+                                      bfloat16x8_t,
+                                      c10::BFloat16,
+                                      BlendBFloat16Regs,
+                                      Vectorized<c10::BFloat16>> {
+  using Base = Vectorized16<
+      bfloat16x8_t,
+      c10::BFloat16,
+      BlendBFloat16Regs,
+      Vectorized<c10::BFloat16>>;
+  friend Base;
+  friend std::tuple<Vectorized<float>, Vectorized<float>> convert_bfloat16_float(
+      const Vectorized<c10::BFloat16>& a);
+  friend Vectorized<c10::BFloat16> convert_float_bfloat16(
+      const Vectorized<float>& a,
+      const Vectorized<float>& b);
+
+ private:
+  Vectorized<c10::BFloat16> map2(
+      const Vectorized<c10::BFloat16>& second,
+      c10::BFloat16 (*const f)(c10::BFloat16, c10::BFloat16)) const {
+    bfloat16x8_t result;
+    result[0] = f(values[0], second[0]);
+    result[1] = f(values[1], second[1]);
+    result[2] = f(values[2], second[2]);
+    result[3] = f(values[3], second[3]);
+    result[4] = f(values[4], second[4]);
+    result[5] = f(values[5], second[5]);
+    result[6] = f(values[6], second[6]);
+    result[7] = f(values[7], second[7]);
+    return result;
+  }
+
+  static float32x4_t convert_f32_bf16(bfloat16x4_t bf16) {
+    return vcvt_f32_bf16(bf16);
+  }
+
+  static bfloat16x4_t convert_bf16_f32(const Vectorized<float>& f32) {
+    return vcvt_bf16_f32(f32);
+  }
+
+  Vectorized<c10::BFloat16> map_with_vec_float_method(
+      Vectorized<float> (Vectorized<float>::*m)() const) const {
+    float32x4_t v00 = convert_f32_bf16(vget_low_bf16(values));
+    float32x4_t v01 = convert_f32_bf16(vget_high_bf16(values));
+    Vectorized<float> mv0 = (Vectorized<float>(v00).*m)();
+    Vectorized<float> mv1 = (Vectorized<float>(v01).*m)();
+    bfloat16x4_t r00 = convert_bf16_f32(mv0);
+    bfloat16x4_t r01 = convert_bf16_f32(mv1);
+    return Vectorized<c10::BFloat16>(vcombine_bf16(r00, r01));
+  }
+
+  Vectorized<c10::BFloat16> map2_with_vec_float_method(
+      const Vectorized<c10::BFloat16>& second,
+      Vectorized<float> (Vectorized<float>::*m)(const Vectorized<float>&)
+          const) const {
+    float32x4_t v00 = convert_f32_bf16(vget_low_bf16(values));
+    float32x4_t v01 = convert_f32_bf16(vget_high_bf16(values));
+    float32x4_t second_v00 = convert_f32_bf16(vget_low_bf16(second.values));
+    float32x4_t second_v01 = convert_f32_bf16(vget_high_bf16(second.values));
+    Vectorized<float> mv0 = (Vectorized<float>(v00).*m)(second_v00);
+    Vectorized<float> mv1 = (Vectorized<float>(v01).*m)(second_v01);
+    bfloat16x4_t r00 = convert_bf16_f32(mv0);
+    bfloat16x4_t r01 = convert_bf16_f32(mv1);
+    return Vectorized<c10::BFloat16>(vcombine_bf16(r00, r01));
+  }
+
+  Vectorized<c10::BFloat16> map2_bitmask_with_vec_float_method(
+      const Vectorized<c10::BFloat16>& second,
+      Vectorized<float> (Vectorized<float>::*m)(const Vectorized<float>&)
+          const) const {
+    float32x4_t v00 = convert_f32_bf16(vget_low_bf16(values));
+    float32x4_t v01 = convert_f32_bf16(vget_high_bf16(values));
+    float32x4_t second_v00 = convert_f32_bf16(vget_low_bf16(second.values));
+    float32x4_t second_v01 = convert_f32_bf16(vget_high_bf16(second.values));
+    Vectorized<float> mv0 = (Vectorized<float>(v00).*m)(second_v00);
+    Vectorized<float> mv1 = (Vectorized<float>(v01).*m)(second_v01);
+    // Assume the operator returns a bitmask, not "real" floats, and
+    // just narrow the bits. All-ones is a NaN and will get mangled by
+    // conversion!
+    bfloat16x4_t r00 =
+        vreinterpret_bf16_u16(vmovn_u32(vreinterpretq_u32_f32(mv0)));
+    bfloat16x4_t r01 =
+        vreinterpret_bf16_u16(vmovn_u32(vreinterpretq_u32_f32(mv1)));
+    return Vectorized<c10::BFloat16>(vcombine_bf16(r00, r01));
+  }
+
+ public:
+  using Vectorized16::Vectorized16;
+
+  Vectorized() = default;
+  Vectorized(svbfloat16_t v) : Vectorized16(svget_neonq(v)) {}
+  Vectorized(c10::BFloat16 val)
+      : Vectorized16(svget_neonq(svdup_n_bf16(c10::bit_cast<bfloat16_t>(val.x)))) {}
+  Vectorized(float val) : Vectorized(c10::BFloat16(val)) {}
+  Vectorized(
+      value_type val0,
+      value_type val1,
+      value_type val2,
+      value_type val3,
+      value_type val4,
+      value_type val5,
+      value_type val6,
+      value_type val7)
+      : Vectorized16(bfloat16x8_t{
+            c10::bit_cast<bfloat16_t>(val0.x),
+            c10::bit_cast<bfloat16_t>(val1.x),
+            c10::bit_cast<bfloat16_t>(val2.x),
+            c10::bit_cast<bfloat16_t>(val3.x),
+            c10::bit_cast<bfloat16_t>(val4.x),
+            c10::bit_cast<bfloat16_t>(val5.x),
+            c10::bit_cast<bfloat16_t>(val6.x),
+            c10::bit_cast<bfloat16_t>(val7.x)}) {}
+  operator svbfloat16_t() const {
+    return svset_neonq(svundef_bf16(), values);
+  }
+  svbfloat16_t valuesAsSve() const {
+    return svset_neonq(svundef_bf16(), values);
+  }
+
+  template <int64_t mask>
+  static Vectorized<c10::BFloat16> blend(
+      const Vectorized<c10::BFloat16>& a,
+      const Vectorized<c10::BFloat16>& b) {
+    // Build an array of flags: each bit of element is 1 if the corresponding bit in
+    // 'mask' is set, 0 otherwise.
+    uint16x8_t maskArray = {
+      (mask &   1ULL) ? 0xFFFF : 0, 
+      (mask &   2ULL) ? 0xFFFF : 0, 
+      (mask &   4ULL) ? 0xFFFF : 0, 
+      (mask &   8ULL) ? 0xFFFF : 0,
+      (mask &  16ULL) ? 0xFFFF : 0, 
+      (mask &  32ULL) ? 0xFFFF : 0, 
+      (mask &  64ULL) ? 0xFFFF : 0, 
+      (mask & 128ULL) ? 0xFFFF : 0};
+    // Use BSL to select elements from b where the mask is 1, else from a
+    return vbslq_f16(maskArray, b.values, a.values);
+  }
+
+  static Vectorized<c10::BFloat16> blendv(
+      const Vectorized<c10::BFloat16>& a,
+      const Vectorized<c10::BFloat16>& b,
+      const Vectorized<c10::BFloat16>& mask) {
+    // NOTE: blendv has the same problems as it does for Half; see comments in
+    // vec128_half_neon.h.
+    Vectorized<c10::BFloat16> vec(mask.values);
+    vec.values = vreinterpretq_bf16_u16(vbslq_u16(
+        vreinterpretq_u16_bf16(vec.values),
+        vreinterpretq_u16_bf16(b.values),
+        vreinterpretq_u16_bf16(a.values)));
+    return vec;
+  }
+  static Vectorized<c10::BFloat16> set(
+      const Vectorized<c10::BFloat16>& a,
+      const Vectorized<c10::BFloat16>& b,
+      int64_t count = size()) {
+    if (count == 0) {
+      return a;
+    } else if (count < size()) {
+      return svsel_bf16(svwhilelt_b16(0ull, count), b, a);
+    }
+    return b;
+  }
+  static Vectorized<c10::BFloat16> loadu(
+      const void* ptr,
+      int64_t count = size()) {
+    if (count == size()) {
+      return vld1q_bf16(reinterpret_cast<const bfloat16_t*>(ptr));
+    }
+    svbool_t pg = svwhilelt_b16(0ull, count);
+    return svld1_bf16(pg, reinterpret_cast<const bfloat16_t*>(ptr));
+  }
+  void store(void* ptr, int64_t count = size()) const {
+    if (count == size()) {
+      vst1q_bf16(reinterpret_cast<bfloat16_t*>(ptr), values);
+      return;
+    } else {
+      svbool_t pg = svwhilelt_b16(0ull, count);
+      svst1_bf16(pg, reinterpret_cast<bfloat16_t*>(ptr), valuesAsSve());
+    }
+  }
+  inline c10::BFloat16 operator[](int idx) const {
+    return values[idx];
+  }
+  inline c10::BFloat16 operator[](int idx) {
+    return values[idx];
+  }
+  bool has_inf_nan() const;
+#define DEFINE_UNARY_ELEMENTWISE_FUNC_VIA_FLOAT_METHOD(name)    \
+  Vectorized name() const {                                     \
+    return map_with_vec_float_method(&Vectorized<float>::name); \
+  }
+
+#define DEFINE_BINARY_COMPARISON_OPERATOR_VIA_FLOAT_METHOD(name) \
+  Vectorized name(const Vectorized& other) const {               \
+    return map2_bitmask_with_vec_float_method(                   \
+        other, &Vectorized<float>::name);                        \
+  }
+
+  DEFINE_UNARY_ELEMENTWISE_FUNC_VIA_FLOAT_METHOD(abs)
+  Vectorized frac() const;
+  DEFINE_UNARY_ELEMENTWISE_FUNC_VIA_FLOAT_METHOD(isnan)
+  DEFINE_UNARY_ELEMENTWISE_FUNC_VIA_FLOAT_METHOD(neg)
+  DEFINE_UNARY_ELEMENTWISE_FUNC_VIA_FLOAT_METHOD(trunc)
+  DEFINE_UNARY_ELEMENTWISE_FUNC_VIA_FLOAT_METHOD(sqrt)
+  DEFINE_UNARY_ELEMENTWISE_FUNC_VIA_FLOAT_METHOD(reciprocal)
+  DEFINE_BINARY_COMPARISON_OPERATOR_VIA_FLOAT_METHOD(operator==)
+  DEFINE_BINARY_COMPARISON_OPERATOR_VIA_FLOAT_METHOD(operator!=)
+  DEFINE_BINARY_COMPARISON_OPERATOR_VIA_FLOAT_METHOD(operator<)
+  DEFINE_BINARY_COMPARISON_OPERATOR_VIA_FLOAT_METHOD(operator<=)
+  DEFINE_BINARY_COMPARISON_OPERATOR_VIA_FLOAT_METHOD(operator>)
+  DEFINE_BINARY_COMPARISON_OPERATOR_VIA_FLOAT_METHOD(operator>=)
+
+#undef DEFINE_UNARY_ELEMENTWISE_FUNC_VIA_FLOAT_METHOD
+#undef DEFINE_BINARY_ELEMENTWISE_FUNC_VIA_FLOAT_METHOD
+
+  Vectorized eq(const Vectorized& other) const;
+  Vectorized ne(const Vectorized& other) const;
+  Vectorized gt(const Vectorized& other) const;
+  Vectorized ge(const Vectorized& other) const;
+  Vectorized lt(const Vectorized& other) const;
+  Vectorized le(const Vectorized& other) const;
+
+  template <typename step_t>
+  static Vectorized<BFloat16> arange(
+      BFloat16 base = 0.f,
+      step_t step = static_cast<step_t>(1)) {
+    bfloat16x8_t result;
+    result[0] = base;
+    result[1] = base + step;
+    result[2] = base + step * 2;
+    result[3] = base + step * 3;
+    result[4] = base + step * 4;
+    result[5] = base + step * 5;
+    result[6] = base + step * 6;
+    result[7] = base + step * 7;
+    return result;
+  }
+
+}; // Vectorized<c10::BFloat16>
+
+inline std::tuple<Vectorized<float>, Vectorized<float>> convert_bfloat16_float(
+    const Vectorized<c10::BFloat16>& a) {
+  static_assert(
+      Vectorized<c10::BFloat16>::size() == 2 * Vectorized<float>::size());
+  bfloat16x8_t x = a;
+  float32x4_t x1 =
+      Vectorized<c10::BFloat16>::convert_f32_bf16(vget_low_bf16(x));
+  float32x4_t x2 =
+      Vectorized<c10::BFloat16>::convert_f32_bf16(vget_high_bf16(x));
+  return {Vectorized<float>(x1), Vectorized<float>(x2)};
+}
+inline Vectorized<c10::BFloat16> convert_float_bfloat16(
+    const Vectorized<float>& a,
+    const Vectorized<float>& b) {
+  static_assert(
+      Vectorized<c10::BFloat16>::size() == 2 * Vectorized<float>::size());
+  bfloat16x4_t x1 = Vectorized<c10::BFloat16>::convert_bf16_f32(a);
+  bfloat16x4_t x2 = Vectorized<c10::BFloat16>::convert_bf16_f32(b);
+  return Vectorized<c10::BFloat16>(vcombine_bf16(x1, x2));
+}
+
+inline void load_fp32_from_bf16(const BFloat16* data, Vectorized<float>& out) {
+  const bfloat16_t* dataPtr = reinterpret_cast<const bfloat16_t*>(data);
+  bfloat16x4_t lowbf16 = vld1_bf16(dataPtr);
+  out = vcvt_f32_bf16(lowbf16);
+}
+
+inline void load_fp32_from_bf16(
+    const BFloat16* data,
+    Vectorized<float>& out1,
+    Vectorized<float>& out2) {
+  Vectorized<BFloat16> bf16_vec = Vectorized<BFloat16>::loadu(data);
+  auto floats = convert_bfloat16_float(bf16_vec);
+  out1 = std::get<0>(floats);
+  out2 = std::get<1>(floats);
+}
+
+bool inline Vectorized<c10::BFloat16>::has_inf_nan() const {
+  auto [v1, v2] = convert_bfloat16_float(values);
+  return v1.has_inf_nan() || v2.has_inf_nan();
+}
+
+template <typename Op>
+Vectorized<c10::BFloat16> binary_operator_via_float(
+    Op op,
+    const Vectorized<c10::BFloat16>& a,
+    const Vectorized<c10::BFloat16>& b) {
+  const auto [a_float_low, a_float_high] = convert_bfloat16_float(a);
+  const auto [b_float_low, b_float_high] = convert_bfloat16_float(b);
+  return convert_float_bfloat16(
+      op(a_float_low, b_float_low), op(a_float_high, b_float_high));
+}
+
+template <>
+Vectorized<c10::BFloat16> inline operator+(
+    const Vectorized<c10::BFloat16>& a,
+    const Vectorized<c10::BFloat16>& b) {
+  return binary_operator_via_float(std::plus<Vectorized<float>>(), a, b);
+}
+
+template <>
+Vectorized<c10::BFloat16> inline operator-(
+    const Vectorized<c10::BFloat16>& a,
+    const Vectorized<c10::BFloat16>& b) {
+  return binary_operator_via_float(std::minus<Vectorized<float>>(), a, b);
+}
+
+template <>
+Vectorized<c10::BFloat16> inline operator*(
+    const Vectorized<c10::BFloat16>& a,
+    const Vectorized<c10::BFloat16>& b) {
+  return binary_operator_via_float(std::multiplies<Vectorized<float>>(), a, b);
+}
+
+template <>
+Vectorized<c10::BFloat16> inline operator/(
+    const Vectorized<c10::BFloat16>& a,
+    const Vectorized<c10::BFloat16>& b) {
+  return binary_operator_via_float(std::divides<Vectorized<float>>(), a, b);
+}
+
+// frac. Implement this here so we can use subtraction
+inline Vectorized<c10::BFloat16> Vectorized<c10::BFloat16>::frac() const {
+  return *this - this->trunc();
+}
+
+template <>
+Vectorized<c10::BFloat16> inline maximum(
+    const Vectorized<c10::BFloat16>& a,
+    const Vectorized<c10::BFloat16>& b) {
+  return binary_operator_via_float(
+      static_cast<Vectorized<float> (*)(
+          const Vectorized<float>&, const Vectorized<float>&)>(&maximum),
+      a,
+      b);
+}
+
+template <>
+Vectorized<c10::BFloat16> inline minimum(
+    const Vectorized<c10::BFloat16>& a,
+    const Vectorized<c10::BFloat16>& b) {
+  return binary_operator_via_float(
+      static_cast<Vectorized<float> (*)(
+          const Vectorized<float>&, const Vectorized<float>&)>(&minimum),
+      a,
+      b);
+}
+
+template <>
+Vectorized<c10::BFloat16> inline clamp(
+    const Vectorized<c10::BFloat16>& a,
+    const Vectorized<c10::BFloat16>& min,
+    const Vectorized<c10::BFloat16>& max) {
+  return minimum(max, maximum(min, a));
+}
+
+template <>
+Vectorized<c10::BFloat16> inline clamp_max(
+    const Vectorized<c10::BFloat16>& a,
+    const Vectorized<c10::BFloat16>& max) {
+  return minimum(max, a);
+}
+
+template <>
+Vectorized<c10::BFloat16> inline clamp_min(
+    const Vectorized<c10::BFloat16>& a,
+    const Vectorized<c10::BFloat16>& min) {
+  return maximum(min, a);
+}
+
+template <>
+Vectorized<c10::BFloat16> inline operator&(
+    const Vectorized<c10::BFloat16>& a,
+    const Vectorized<c10::BFloat16>& b) {
+  return Vectorized<c10::BFloat16>(vreinterpretq_bf16_u16(
+      vandq_u16(vreinterpretq_u16_bf16(a), vreinterpretq_u16_bf16(b))));
+}
+
+template <>
+Vectorized<c10::BFloat16> inline operator|(
+    const Vectorized<c10::BFloat16>& a,
+    const Vectorized<c10::BFloat16>& b) {
+  return Vectorized<c10::BFloat16>(vreinterpretq_bf16_u16(
+      vorrq_u16(vreinterpretq_u16_bf16(a), vreinterpretq_u16_bf16(b))));
+}
+
+template <>
+Vectorized<c10::BFloat16> inline operator^(
+    const Vectorized<c10::BFloat16>& a,
+    const Vectorized<c10::BFloat16>& b) {
+  return Vectorized<c10::BFloat16>(vreinterpretq_bf16_u16(
+      veorq_u16(vreinterpretq_u16_bf16(a), vreinterpretq_u16_bf16(b))));
+}
+
+inline Vectorized<c10::BFloat16> Vectorized<c10::BFloat16>::eq(
+    const Vectorized<c10::BFloat16>& other) const {
+  return svreinterpret_bf16_u16(
+      svand_n_u16_x(ptrue, svreinterpret_u16_bf16(*this == other), 0x3f80));
+}
+
+inline Vectorized<c10::BFloat16> Vectorized<c10::BFloat16>::ne(
+    const Vectorized<c10::BFloat16>& other) const {
+  return svreinterpret_bf16_u16(
+      svand_n_u16_x(ptrue, svreinterpret_u16_bf16(*this != other), 0x3f80));
+}
+
+inline Vectorized<c10::BFloat16> Vectorized<c10::BFloat16>::gt(
+    const Vectorized<c10::BFloat16>& other) const {
+  return svreinterpret_bf16_u16(
+      svand_n_u16_x(ptrue, svreinterpret_u16_bf16(*this > other), 0x3f80));
+}
+
+inline Vectorized<c10::BFloat16> Vectorized<c10::BFloat16>::ge(
+    const Vectorized<c10::BFloat16>& other) const {
+  return svreinterpret_bf16_u16(
+      svand_n_u16_x(ptrue, svreinterpret_u16_bf16(*this >= other), 0x3f80));
+}
+
+inline Vectorized<c10::BFloat16> Vectorized<c10::BFloat16>::lt(
+    const Vectorized<c10::BFloat16>& other) const {
+  return svreinterpret_bf16_u16(
+      svand_n_u16_x(ptrue, svreinterpret_u16_bf16(*this < other), 0x3f80));
+}
+
+inline Vectorized<c10::BFloat16> Vectorized<c10::BFloat16>::le(
+    const Vectorized<c10::BFloat16>& other) const {
+  return svreinterpret_bf16_u16(
+      svand_n_u16_x(ptrue, svreinterpret_u16_bf16(*this <= other), 0x3f80));
+}
+
+template <>
+Vectorized<c10::BFloat16> inline fmadd(
+    const Vectorized<c10::BFloat16>& a,
+    const Vectorized<c10::BFloat16>& b,
+    const Vectorized<c10::BFloat16>& c) {
+  const auto [lowA, highA] = convert_bfloat16_float(a);
+  const auto [lowB, highB] = convert_bfloat16_float(b);
+  const auto [lowC, highC] = convert_bfloat16_float(c);
+  Vectorized<float> resultLow = fmadd(lowA, lowB, lowC);
+  Vectorized<float> resultHigh = fmadd(highA, highB, highC);
+  return convert_float_bfloat16(resultLow, resultHigh);
+}
+
+template <>
+Vectorized<c10::BFloat16> inline fnmadd(
+    const Vectorized<c10::BFloat16>& a,
+    const Vectorized<c10::BFloat16>& b,
+    const Vectorized<c10::BFloat16>& c) {
+  const auto [lowA, highA] = convert_bfloat16_float(a);
+  const auto [lowB, highB] = convert_bfloat16_float(b);
+  const auto [lowC, highC] = convert_bfloat16_float(c);
+  Vectorized<float> resultLow = fnmadd(lowA, lowB, lowC);
+  Vectorized<float> resultHigh = fnmadd(highA, highB, highC);
+  return convert_float_bfloat16(resultLow, resultHigh);
+}
+
+template <>
+Vectorized<c10::BFloat16> inline fmsub(
+    const Vectorized<c10::BFloat16>& a,
+    const Vectorized<c10::BFloat16>& b,
+    const Vectorized<c10::BFloat16>& c) {
+  const auto [lowA, highA] = convert_bfloat16_float(a);
+  const auto [lowB, highB] = convert_bfloat16_float(b);
+  const auto [lowC, highC] = convert_bfloat16_float(c);
+  Vectorized<float> resultLow = fmsub(lowA, lowB, lowC);
+  Vectorized<float> resultHigh = fmsub(highA, highB, highC);
+  return convert_float_bfloat16(resultLow, resultHigh);
+}
+
+template <>
+Vectorized<c10::BFloat16> inline fnmsub(
+    const Vectorized<c10::BFloat16>& a,
+    const Vectorized<c10::BFloat16>& b,
+    const Vectorized<c10::BFloat16>& c) {
+  const auto [lowA, highA] = convert_bfloat16_float(a);
+  const auto [lowB, highB] = convert_bfloat16_float(b);
+  const auto [lowC, highC] = convert_bfloat16_float(c);
+  Vectorized<float> resultLow = fnmsub(lowA, lowB, lowC);
+  Vectorized<float> resultHigh = fnmsub(highA, highB, highC);
+  return convert_float_bfloat16(resultLow, resultHigh);
+}
+
+#else //
+
+CONVERT_NON_VECTORIZED_INIT(BFloat16, bfloat16)
+
+LOAD_FP32_NON_VECTORIZED_INIT(BFloat16, bf16)
+
+#endif // !defined(C10_MOBILE) && defined(__aarch64__)
+
+} // namespace CPU_CAPABILITY
+} // namespace at::vec

--- a/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
@@ -26,7 +26,7 @@ inline namespace CPU_CAPABILITY {
 //    https://github.com/android/ndk/issues/1248
 //    https://bugs.llvm.org/show_bug.cgi?id=45824
 // Most likely we will do aarch32 support with inline asm.
-#if defined(__aarch64__)
+#if defined(__aarch64__) && !defined(CPU_CAPABILITY_SVE128)
 
 #ifdef __BIG_ENDIAN__
 #error "Big endian is not supported."

--- a/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
@@ -5,6 +5,7 @@
 
 #include <ATen/cpu/vec/intrinsics.h>
 #include <ATen/cpu/vec/sve/sve_helper.h>
+#include <ATen/cpu/vec/vec128/vec128_transpose.h>
 #include <ATen/cpu/vec/vec_base.h>
 #include <c10/util/irange.h>
 
@@ -637,6 +638,32 @@ inline Vectorized<float> Vectorized<float>::erf() const {
   auto tmp7 = fmadd(tmp6, r, one_vec);
   return tmp7 ^ sign_mask;
 }
+
+template <>
+inline void transpose_mxn<float>(
+    const float* src,
+    int64_t ld_src,
+    float* dst,
+    int64_t ld_dst,
+    int M,
+    int N) {
+  transpose_float_neon(M, N, src, ld_src, dst, ld_dst);
+}
+
+template <
+    typename T,
+    int M,
+    int N,
+    typename std::enable_if_t<std::is_same_v<T, float>, int> = 0>
+inline void transpose_mxn(
+    const float* src,
+    int64_t ld_src,
+    float* dst,
+    int64_t ld_dst) {
+  transpose_mxn<float>(src, ld_src, dst, ld_dst, M, N);
+}
+
+
 #undef DEFINE_SLEEF_COMPATIBLE_BINARY_ELEMENTWISE_FUNC
 #undef DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC
 #endif /* defined(aarch64) */

--- a/aten/src/ATen/cpu/vec/vec128/vec128_float_sve.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_float_sve.h
@@ -2,6 +2,7 @@
 
 #include <ATen/cpu/vec/intrinsics.h>
 #include <ATen/cpu/vec/sve/sve_helper.h>
+#include <ATen/cpu/vec/vec128/vec128_transpose.h>
 #include <ATen/cpu/vec/vec_base.h>
 #include <c10/util/irange.h>
 #include <cmath>
@@ -738,6 +739,30 @@ inline Vectorized<float> Vectorized<float>::erf() const {
   auto tmp6 = t * tmp5;
   auto tmp7 = fmadd(tmp6, r, one_vec);
   return tmp7 ^ sign_mask;
+}
+
+template <>
+inline void transpose_mxn<float>(
+    const float* src,
+    int64_t ld_src,
+    float* dst,
+    int64_t ld_dst,
+    int M,
+    int N) {
+  transpose_float_neon(M, N, src, ld_src, dst, ld_dst);
+}
+
+template <
+    typename T,
+    int M,
+    int N,
+    typename std::enable_if_t<std::is_same_v<T, float>, int> = 0>
+inline void transpose_mxn(
+    const float* src,
+    int64_t ld_src,
+    float* dst,
+    int64_t ld_dst) {
+  transpose_mxn<float>(src, ld_src, dst, ld_dst, M, N);
 }
 
 } // namespace CPU_CAPABILITY

--- a/aten/src/ATen/cpu/vec/vec128/vec128_float_sve.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_float_sve.h
@@ -1,0 +1,744 @@
+#pragma once
+
+#include <ATen/cpu/vec/intrinsics.h>
+#include <ATen/cpu/vec/sve/sve_helper.h>
+#include <ATen/cpu/vec/vec_base.h>
+#include <c10/util/irange.h>
+#include <cmath>
+
+namespace at::vec {
+// Note [CPU_CAPABILITY namespace]
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// This header, and all of its subheaders, will be compiled with
+// different architecture flags for each supported set of vector
+// intrinsics. So we need to make sure they aren't inadvertently
+// linked together. We do this by declaring objects in an `inline
+// namespace` which changes the name mangling, but can still be
+// accessed as `at::vec`.
+inline namespace CPU_CAPABILITY {
+
+template <>
+struct is_vec_specialized_for<float> : std::bool_constant<true> {};
+
+template <>
+class Vectorized<float> {
+ private:
+  float32x4_t values;
+
+ public:
+  using value_type = float;
+  using size_type = int;
+  static constexpr size_type size() {
+    return 4;
+  }
+  Vectorized() {
+    values = vmovq_n_f32(0);
+  }
+  Vectorized(svfloat32_t v) : values(svget_neonq(v)) {}
+  Vectorized(float32x4_t v) : values(v) {}
+  Vectorized(float val) {
+    values = svget_neonq(svdup_n_f32(val));
+  }
+  Vectorized(float val0, float val1, float val2, float val3)
+      : values{val0, val1, val2, val3} {}
+  Vectorized(float (&arr)[4]) : Vectorized(arr[0], arr[1], arr[2], arr[3]) {}
+  template <
+      typename... Args,
+      typename = std::enable_if_t<(sizeof...(Args) == size())>>
+  Vectorized(Args... vals) {
+    __at_align__ float buffer[size()] = {vals...};
+    values = vld1q_f32(buffer);
+  }
+  operator svfloat32_t() const {
+    return svset_neonq(svundef_f32(), values);
+  }
+  operator float32x4_t() const {
+    return values;
+  }
+  svfloat32_t valuesAsSve() const {
+    return svset_neonq(svundef_f32(), values);
+  }
+  template <int64_t mask>
+  static Vectorized<float> blend(
+      const Vectorized<float>& a,
+      const Vectorized<float>& b) {
+    // Build an array of flags: each bit of element is 1 if the corresponding
+    // bit in 'mask' is set, 0 otherwise.
+    uint32x4_t maskArray = {
+        (mask & 1ULL) ? 0xFFFFFFFF : 0,
+        (mask & 2ULL) ? 0xFFFFFFFF : 0,
+        (mask & 4ULL) ? 0xFFFFFFFF : 0,
+        (mask & 8ULL) ? 0xFFFFFFFF : 0};
+    // Use BSL to select elements from b where the mask is 1, else from a
+    return vbslq_f32(maskArray, b.values, a.values);
+  }
+  static Vectorized<float> blendv(
+      const Vectorized<float>& a,
+      const Vectorized<float>& b,
+      const Vectorized<float>& mask_) {
+    return vbslq_f32(vreinterpretq_u32_f32(mask_.values), b.values, a.values);
+  }
+  template <typename step_t>
+  static Vectorized<float> arange(
+      float base = 0.f,
+      step_t step = static_cast<step_t>(1)) {
+    const Vectorized<float> base_vec(base);
+    const Vectorized<float> step_vec(step);
+    const Vectorized<float> step_sizes(0.0f, 1.0f, 2.0f, 3.0f);
+    return fmadd(step_sizes, step_vec, base_vec);
+  }
+  static Vectorized<float> set(
+      const Vectorized<float>& a,
+      const Vectorized<float>& b,
+      int64_t count = size()) {
+    if (count == 0) {
+      return a;
+    } else if (count < size()) {
+      return svsel_f32(svwhilelt_b32(0ull, count), b, a);
+    }
+    return b;
+  }
+
+  inline svfloat32_t svexp(float32x4_t v) const {
+    // Clamp interval set to prevent denormals!
+    const svfloat32_t max_input = svdup_n_f32(88.722839f);
+    const svfloat32_t min_input = svdup_n_f32(-87.33654f);
+    const svfloat32_t shift = svdup_n_f32(0x1.0000FEp+23f);
+
+    svfloat32_t x = svset_neonq(
+        svundef_f32(),
+        vmaxq_f32(
+            vminq_f32(v, svget_neonq(max_input)), svget_neonq(min_input)));
+
+    svfloat32_t z = svmla_n_f32_x(svptrue_b8(), shift, x, 0x1.715476p+0f);
+    svfloat32_t n = z - shift;
+    svfloat32_t scale = svreinterpret_f32(svreinterpret_u32(z) << 23);
+
+    svfloat32_t r_hi = x - n * 0x1.62E400p-1f;
+    svfloat32_t r = r_hi - n * 0x1.7F7D1Cp-20f;
+    svfloat32_t r2 = r * r;
+
+    svfloat32_t C = 0x1.573E2Ep-5f + r * 0x1.0E4020p-7f;
+    svfloat32_t B = 0x1.FFFDB6p-2f + r * 0x1.555E66p-3f;
+    svfloat32_t A = r * 0x1.FFFFECp-1f;
+
+    svfloat32_t poly = scale + (A + (B + C * r2) * r2) * scale;
+
+    return poly;
+  }
+
+  static Vectorized<float> loadu(const void* ptr, int64_t count = size()) {
+    if (count == size())
+      return vld1q_f32(reinterpret_cast<const float*>(ptr));
+    svbool_t pg = svwhilelt_b32(0ull, count);
+    return svld1_f32(pg, reinterpret_cast<const float*>(ptr));
+  }
+  void store(void* ptr, int64_t count = size()) const {
+    if (count == size()) {
+      vst1q_f32(reinterpret_cast<float*>(ptr), values);
+    } else {
+      svbool_t pg = svwhilelt_b32(0ull, count);
+      svst1_f32(pg, reinterpret_cast<float*>(ptr), valuesAsSve());
+    }
+  }
+  inline float operator[](int idx) const {
+    return values[idx];
+  }
+  inline float operator[](int idx) {
+    return values[idx];
+  }
+  int64_t zero_mask() const {
+    uint32x4_t cmpReg = vceqzq_f32(values);
+    uint16x4_t narrowedCmp = vmovn_u32(cmpReg);
+    uint64x2_t extReg = svget_neonq(svbext_u64(
+        svset_neonq(
+            svundef_u64(),
+            vreinterpretq_u64_u16(vcombine_u16(narrowedCmp, vdup_n_u16(0)))),
+        svreinterpret_u64_u16(svdup_u16(1))));
+    return extReg[0];
+  }
+  Vectorized<float> isnan() const {
+    // NaN check
+    return vreinterpretq_f32_u32(vmvnq_u32(vceqq_f32(values, values)));
+  }
+  bool has_inf_nan() const {
+    return svptest_any(
+        ptrue,
+        svcmpuo_f32(
+            ptrue,
+            svset_neonq(svundef_f32(), vsubq_f32(values, values)),
+            ZERO_F32));
+  }
+  Vectorized<float> map(float (*const f)(float)) const {
+    float32x4_t result;
+    result[0] = f(values[0]);
+    result[1] = f(values[1]);
+    result[2] = f(values[2]);
+    result[3] = f(values[3]);
+    return result;
+  }
+  Vectorized<float> map2(
+      const Vectorized<float>& second,
+      float (*const f)(float, float)) const {
+    float32x4_t result;
+    result[0] = f(values[0], second[0]);
+    result[1] = f(values[1], second[1]);
+    result[2] = f(values[2], second[2]);
+    result[3] = f(values[3], second[3]);
+    return result;
+  }
+  Vectorized<float> abs() const {
+    return Vectorized<float>(vabsq_f32(values));
+  }
+  Vectorized<float> angle() const {
+    auto zero = Vectorized<float>(0);
+    auto pi = Vectorized<float>(c10::pi<float>);
+    auto tmp = blendv(zero, pi, vcltzq_f32(*this));
+    return blendv(tmp, *this, isnan());
+  }
+  Vectorized<float> real() const {
+    return values;
+  }
+  Vectorized<float> imag() const {
+    return Vectorized<float>(0.f);
+  }
+  Vectorized<float> conj() const {
+    return values;
+  }
+#define DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC_WITH_SLEEF_NAME(      \
+    name, sleef_name)                                                        \
+  Vectorized<float> name() const {                                           \
+    return USE_SLEEF(Vectorized<float>(sleef_name(values)), map(std::name)); \
+  }
+
+#define DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(name)      \
+  DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC_WITH_SLEEF_NAME( \
+      name, Sleef_##name##f4_u10)
+
+  DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(acos)
+  DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(acosh)
+  DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(asin)
+  DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(asinh)
+  DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(atan)
+  DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(atanh)
+
+#define DEFINE_SLEEF_COMPATIBLE_BINARY_ELEMENTWISE_FUNC_WITH_SLEEF_NAME( \
+    name, sleef_name)                                                    \
+  Vectorized<float> name(const Vectorized<float>& arg) const {           \
+    return USE_SLEEF(                                                    \
+        Vectorized<float>(sleef_name(values, arg.values)),               \
+        map2(arg, std::name));                                           \
+  }
+
+#define DEFINE_SLEEF_COMPATIBLE_BINARY_ELEMENTWISE_FUNC(name)      \
+  DEFINE_SLEEF_COMPATIBLE_BINARY_ELEMENTWISE_FUNC_WITH_SLEEF_NAME( \
+      name, Sleef_##name##f4_u10)
+
+  DEFINE_SLEEF_COMPATIBLE_BINARY_ELEMENTWISE_FUNC(atan2)
+  DEFINE_SLEEF_COMPATIBLE_BINARY_ELEMENTWISE_FUNC_WITH_SLEEF_NAME(
+      copysign,
+      Sleef_copysignf4)
+
+  Vectorized<float> erf() const;
+
+  DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC_WITH_SLEEF_NAME(
+      erfc,
+      Sleef_erfcf4_u15)
+
+  Vectorized<float> erfinv() const {
+    return map(calc_erfinv);
+  }
+  Vectorized<float> exp() const {
+    return svexp(values);
+  }
+  DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(exp2)
+  DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(expm1)
+  Vectorized<float> exp_u20() const {
+    return exp();
+  }
+  Vectorized<float> fexp_u20() const {
+    return exp();
+  }
+  DEFINE_SLEEF_COMPATIBLE_BINARY_ELEMENTWISE_FUNC_WITH_SLEEF_NAME(
+      fmod,
+      Sleef_fmodf4)
+  DEFINE_SLEEF_COMPATIBLE_BINARY_ELEMENTWISE_FUNC_WITH_SLEEF_NAME(
+      hypot,
+      Sleef_hypotf4_u05)
+  Vectorized<float> i0() const {
+    return map(calc_i0);
+  }
+  Vectorized<float> i0e() const {
+    return map(calc_i0e);
+  }
+  Vectorized<float> digamma() const {
+    return map(calc_digamma);
+  }
+  Vectorized<float> igamma(const Vectorized<float>& x) const {
+    return map2(x, calc_igamma);
+  }
+  Vectorized<float> igammac(const Vectorized<float>& x) const {
+    return map2(x, calc_igammac);
+  }
+
+  DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(log)
+  DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(log10)
+  DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(log1p)
+  DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(log2)
+  DEFINE_SLEEF_COMPATIBLE_BINARY_ELEMENTWISE_FUNC_WITH_SLEEF_NAME(
+      nextafter,
+      Sleef_nextafterf4)
+  Vectorized<float> frac() const;
+  DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(sin)
+  DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(sinh)
+  DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(cos)
+  DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(cosh)
+  Vectorized<float> ceil() const {
+    return vrndpq_f32(values);
+  }
+  Vectorized<float> floor() const {
+    return vrndmq_f32(values);
+  }
+  Vectorized<float> neg() const {
+    return Vectorized<float>(vnegq_f32(values));
+  }
+  Vectorized<float> round() const {
+    return vrndiq_f32(values);
+  }
+  DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(tan)
+  // Implementation is inspired from
+  // https://github.com/ARM-software/ComputeLibrary/blob/v25.01/src/core/NEON/SVEMath.inl#L179
+  Vectorized<float> tanh() const {
+    // Constants used for the tanh calculation.
+    const float32x4_t CONST_2 = svget_neonq(svdup_n_f32(
+        2.f)); // Constant 2.0f for the tanh formula (used in exp(2x)).
+    const float32x4_t CONST_MIN_TANH = svget_neonq(svdup_n_f32(
+        -10.f)); // Minimum threshold for input values to prevent overflow.
+    const float32x4_t CONST_MAX_TANH = svget_neonq(svdup_n_f32(
+        10.f)); // Maximum threshold for input values to prevent overflow.
+
+    // Step 1: Clamp the values within the range [-10, 10] to prevent overflow
+    // during exponentiation. The tanh function approaches ±1 rapidly as the
+    // input grows large, so we limit the input range to avoid numerical
+    // instability. vmaxq_f32 ensures values are greater than -10, and
+    // vminq_f32 ensures they are less than 10.
+    float32x4_t x =
+        vminq_f32(vmaxq_f32(values, CONST_MIN_TANH), CONST_MAX_TANH);
+
+    // Step 2: Calculate exp(2 * x), where x is the clamped value.
+    // svmul_f32_z computes 2 * x, and svexp computes the exponential of
+    // the result.
+    svfloat32_t exp2x = svexp(vmulq_f32(CONST_2, x));
+
+    // Step 3: Calculate the numerator of the tanh function, which is exp(2x)
+    // - 1.
+    float32x4_t num = svget_neonq(svsub_n_f32_x(ptrue, exp2x, 1.f));
+
+    // Step 4: Calculate the denominator of the tanh function, which is exp(2x)
+    // + 1.
+    float32x4_t den = svget_neonq(svadd_n_f32_x(ptrue, exp2x, 1.f));
+
+    // Step 5: Calculate the tanh function as the ratio of the numerator and
+    // denominator: num / den.
+    float32x4_t tanh = vdivq_f32(num, den);
+
+    // Return the calculated tanh values.
+    return tanh;
+  }
+  Vectorized<float> trunc() const {
+    return Vectorized<float>(vrndq_f32(values));
+  }
+  DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(lgamma)
+  Vectorized<float> sqrt() const {
+    return Vectorized<float>(vsqrtq_f32(values));
+  }
+  Vectorized<float> reciprocal() const {
+    float32x4_t recip = vrecpeq_f32(values);
+    recip = vmulq_f32(vrecpsq_f32(values, recip), recip);
+    recip = vmulq_f32(vrecpsq_f32(values, recip), recip);
+    return recip;
+  }
+  Vectorized<float> rsqrt() const {
+    return this->sqrt().reciprocal();
+  }
+
+  DEFINE_SLEEF_COMPATIBLE_BINARY_ELEMENTWISE_FUNC(pow)
+
+  float reduce_add() const {
+    return vaddvq_f32(values);
+  }
+  float reduce_max() const {
+    return vmaxvq_f32(values);
+  }
+
+  // Comparison using the _CMP_**_OQ predicate.
+  //   `O`: get false if an operand is NaN
+  //   `Q`: do not raise if an operand is NaN
+  Vectorized<float> operator==(const Vectorized<float>& other) const {
+    return Vectorized<float>(
+        vreinterpretq_f32_u32(vceqq_f32(values, other.values)));
+  }
+
+  Vectorized<float> operator!=(const Vectorized<float>& other) const {
+    float32x4_t r0 =
+        vreinterpretq_f32_u32(vmvnq_u32(vceqq_f32(values, other.values)));
+    return Vectorized<float>(r0);
+  }
+
+  Vectorized<float> operator<(const Vectorized<float>& other) const {
+    return Vectorized<float>(
+        vreinterpretq_f32_u32(vcltq_f32(values, other.values)));
+  }
+
+  Vectorized<float> operator<=(const Vectorized<float>& other) const {
+    return Vectorized<float>(
+        vreinterpretq_f32_u32(vcleq_f32(values, other.values)));
+  }
+
+  Vectorized<float> operator>(const Vectorized<float>& other) const {
+    return Vectorized<float>(
+        vreinterpretq_f32_u32(vcgtq_f32(values, other.values)));
+  }
+
+  Vectorized<float> operator>=(const Vectorized<float>& other) const {
+    return Vectorized<float>(
+        vreinterpretq_f32_u32(vcgeq_f32(values, other.values)));
+  }
+
+  Vectorized<float> eq(const Vectorized<float>& other) const;
+  Vectorized<float> ne(const Vectorized<float>& other) const;
+  Vectorized<float> gt(const Vectorized<float>& other) const;
+  Vectorized<float> ge(const Vectorized<float>& other) const;
+  Vectorized<float> lt(const Vectorized<float>& other) const;
+  Vectorized<float> le(const Vectorized<float>& other) const;
+};
+
+template <>
+Vectorized<float> inline operator+(
+    const Vectorized<float>& a,
+    const Vectorized<float>& b) {
+  return Vectorized<float>(vaddq_f32(a, b));
+}
+
+template <>
+Vectorized<float> inline operator-(
+    const Vectorized<float>& a,
+    const Vectorized<float>& b) {
+  return Vectorized<float>(vsubq_f32(a, b));
+}
+
+template <>
+Vectorized<float> inline operator*(
+    const Vectorized<float>& a,
+    const Vectorized<float>& b) {
+  return Vectorized<float>(vmulq_f32(a, b));
+}
+
+template <>
+Vectorized<float> inline operator/(
+    const Vectorized<float>& a,
+    const Vectorized<float>& b) {
+  return Vectorized<float>(vdivq_f32(a, b));
+}
+
+// frac. Implement this here so we can use subtraction
+Vectorized<float> inline Vectorized<float>::frac() const {
+  return *this - this->trunc();
+}
+
+// Implements the IEEE 754 201X `maximum` operation, which propagates NaN if
+// either input is a NaN.
+template <>
+Vectorized<float> inline maximum(
+    const Vectorized<float>& a,
+    const Vectorized<float>& b) {
+  return Vectorized<float>(vmaxq_f32(a, b));
+}
+
+// Implements the IEEE 754 201X `minimum` operation, which propagates NaN if
+// either input is a NaN.
+template <>
+Vectorized<float> inline minimum(
+    const Vectorized<float>& a,
+    const Vectorized<float>& b) {
+  return Vectorized<float>(vminq_f32(a, b));
+}
+
+template <>
+Vectorized<float> inline clamp(
+    const Vectorized<float>& a,
+    const Vectorized<float>& min,
+    const Vectorized<float>& max) {
+  return minimum(max, maximum(min, a));
+}
+
+template <>
+Vectorized<float> inline clamp_max(
+    const Vectorized<float>& a,
+    const Vectorized<float>& max) {
+  return minimum(max, a);
+}
+
+template <>
+Vectorized<float> inline clamp_min(
+    const Vectorized<float>& a,
+    const Vectorized<float>& min) {
+  return maximum(min, a);
+}
+
+template <>
+Vectorized<float> inline operator&(
+    const Vectorized<float>& a,
+    const Vectorized<float>& b) {
+  return Vectorized<float>(vreinterpretq_f32_u32(
+      vandq_u32(vreinterpretq_u32_f32(a), vreinterpretq_u32_f32(b))));
+}
+
+template <>
+Vectorized<float> inline operator|(
+    const Vectorized<float>& a,
+    const Vectorized<float>& b) {
+  return Vectorized<float>(vreinterpretq_f32_u32(
+      vorrq_u32(vreinterpretq_u32_f32(a), vreinterpretq_u32_f32(b))));
+}
+
+template <>
+Vectorized<float> inline operator^(
+    const Vectorized<float>& a,
+    const Vectorized<float>& b) {
+  return Vectorized<float>(vreinterpretq_f32_u32(
+      veorq_u32(vreinterpretq_u32_f32(a), vreinterpretq_u32_f32(b))));
+}
+
+Vectorized<float> inline Vectorized<float>::eq(
+    const Vectorized<float>& other) const {
+  return svreinterpret_f32_u32(
+      svand_n_u32_x(ptrue, svreinterpret_u32_f32(*this == other), 0x3f800000));
+}
+
+Vectorized<float> inline Vectorized<float>::ne(
+    const Vectorized<float>& other) const {
+  return svreinterpret_f32_u32(
+      svand_n_u32_x(ptrue, svreinterpret_u32_f32(*this != other), 0x3f800000));
+}
+
+Vectorized<float> inline Vectorized<float>::gt(
+    const Vectorized<float>& other) const {
+  return svreinterpret_f32_u32(
+      svand_n_u32_x(ptrue, svreinterpret_u32_f32(*this > other), 0x3f800000));
+}
+
+Vectorized<float> inline Vectorized<float>::ge(
+    const Vectorized<float>& other) const {
+  return svreinterpret_f32_u32(
+      svand_n_u32_x(ptrue, svreinterpret_u32_f32(*this >= other), 0x3f800000));
+}
+
+Vectorized<float> inline Vectorized<float>::lt(
+    const Vectorized<float>& other) const {
+  return svreinterpret_f32_u32(
+      svand_n_u32_x(ptrue, svreinterpret_u32_f32(*this < other), 0x3f800000));
+}
+
+Vectorized<float> inline Vectorized<float>::le(
+    const Vectorized<float>& other) const {
+  return svreinterpret_f32_u32(
+      svand_n_u32_x(ptrue, svreinterpret_u32_f32(*this <= other), 0x3f800000));
+}
+
+template <>
+inline void convert(const float* src, float* dst, int64_t n) {
+  constexpr uint64_t oneRegElemCount = Vectorized<float>::size();
+  constexpr uint64_t twoRegsElemCount = oneRegElemCount * 2;
+  constexpr uint64_t fourRegsElemCount = twoRegsElemCount * 2;
+  const uint64_t count = static_cast<uint64_t>(n);
+  for (uint64_t iters = count / fourRegsElemCount; iters > 0; --iters) {
+    auto vec1 = vld1q_f32(src);
+    auto vec2 = vld1q_f32(src + oneRegElemCount);
+    auto vec3 = vld1q_f32(src + twoRegsElemCount);
+    auto vec4 = vld1q_f32(src + (twoRegsElemCount + oneRegElemCount));
+    vst1q_f32(dst, vec1);
+    vst1q_f32(dst + oneRegElemCount, vec2);
+    vst1q_f32(dst + twoRegsElemCount, vec3);
+    vst1q_f32(dst + (twoRegsElemCount + oneRegElemCount), vec4);
+    src += fourRegsElemCount;
+    dst += fourRegsElemCount;
+  }
+#pragma clang loop vectorize(disable)
+#pragma clang loop unroll(disable)
+  for (uint64_t remainder = count % fourRegsElemCount; remainder > 0;
+       --remainder) {
+    *dst = *src;
+    src += 1;
+    dst += 1;
+  }
+}
+
+template <>
+inline void convert(const float* src, at::Half* dst, int64_t n) {
+  constexpr uint64_t oneRegElemCount = Vectorized<float>::size();
+  constexpr uint64_t twoRegsElemCount = oneRegElemCount * 2;
+  constexpr uint64_t fourRegsElemCount = twoRegsElemCount * 2;
+  const uint64_t count = static_cast<uint64_t>(n);
+  __fp16* dstPtr = reinterpret_cast<__fp16*>(dst);
+  for (uint64_t iters = count / fourRegsElemCount; iters > 0; --iters) {
+    auto vec1 = vld1q_f32(src);
+    auto vec2 = vld1q_f32(src + oneRegElemCount);
+    auto vec3 = vld1q_f32(src + twoRegsElemCount);
+    auto vec4 = vld1q_f32(src + (twoRegsElemCount + oneRegElemCount));
+    auto convertedVec1 = vcvt_high_f16_f32(vcvt_f16_f32(vec1), vec2);
+    auto convertedVec2 = vcvt_high_f16_f32(vcvt_f16_f32(vec3), vec4);
+    vst1q_f16(dstPtr, convertedVec1);
+    vst1q_f16(dstPtr + twoRegsElemCount, convertedVec2);
+    src += fourRegsElemCount;
+    dstPtr += fourRegsElemCount;
+  }
+#pragma clang loop vectorize(disable)
+#pragma clang loop unroll(disable)
+  for (uint64_t remainder = count % fourRegsElemCount; remainder > 0;
+       --remainder) {
+    *dstPtr = *src;
+    src += 1;
+    dstPtr += 1;
+  }
+}
+
+template <>
+inline void convert(const at::Half* src, float* dst, int64_t n) {
+  constexpr uint64_t oneRegElemCount = Vectorized<float>::size();
+  constexpr uint64_t twoRegsElemCount = oneRegElemCount * 2;
+  constexpr uint64_t fourRegsElemCount = twoRegsElemCount * 2;
+  const uint64_t count = static_cast<uint64_t>(n);
+  const __fp16* srcPtr = reinterpret_cast<const __fp16*>(src);
+  for (uint64_t iters = count / fourRegsElemCount; iters > 0; --iters) {
+    auto vec1 = vld1q_f16(srcPtr);
+    auto vec2 = vld1q_f16(srcPtr + twoRegsElemCount);
+    auto convertedVec1 = vcvt_f32_f16(vget_low_f16(vec1));
+    auto convertedVec3 = vcvt_f32_f16(vget_low_f16(vec2));
+    auto convertedVec2 = vcvt_high_f32_f16(vec1);
+    auto convertedVec4 = vcvt_high_f32_f16(vec2);
+    vst1q_f32(dst, convertedVec1);
+    vst1q_f32(dst + oneRegElemCount, convertedVec2);
+    vst1q_f32(dst + twoRegsElemCount, convertedVec3);
+    vst1q_f32(dst + (twoRegsElemCount + oneRegElemCount), convertedVec4);
+    srcPtr += fourRegsElemCount;
+    dst += fourRegsElemCount;
+  }
+#pragma clang loop vectorize(disable)
+#pragma clang loop unroll(disable)
+  for (uint64_t remainder = count % fourRegsElemCount; remainder > 0;
+       --remainder) {
+    *dst = *srcPtr;
+    srcPtr += 1;
+    dst += 1;
+  }
+}
+
+template <>
+inline void convert(const bool* src, float* dst, int64_t n) {
+  constexpr uint64_t oneRegElemCount = Vectorized<float>::size();
+  constexpr uint64_t twoRegsElemCount = oneRegElemCount * 2;
+  const uint64_t count = static_cast<uint64_t>(n);
+  const uint64_t remainder = count % twoRegsElemCount;
+  const uint8_t* srcPtr = reinterpret_cast<const uint8_t*>(src);
+  for (uint64_t iters = count / twoRegsElemCount; iters > 0; --iters) {
+    auto vec1 = svget_neonq(svld1ub_u32(svptrue_b8(), srcPtr));
+    auto vec2 =
+        svget_neonq(svld1ub_u32(svptrue_b8(), srcPtr + oneRegElemCount));
+    auto vec1Mask = vtstq_u32(vec1, vec1);
+    auto vec2Mask = vtstq_u32(vec2, vec2);
+    vec1Mask = svget_neonq(svand_n_u32_x(
+        svptrue_b8(), svset_neonq(svundef_u32(), vec1Mask), 0x3f800000));
+    vec2Mask = svget_neonq(svand_n_u32_x(
+        svptrue_b8(), svset_neonq(svundef_u32(), vec2Mask), 0x3f800000));
+    vst1q_f32(dst, vreinterpretq_f32_u32(vec1Mask));
+    vst1q_f32(dst + oneRegElemCount, vreinterpretq_f32_u32(vec2Mask));
+    srcPtr += twoRegsElemCount;
+    dst += twoRegsElemCount;
+  }
+  if (remainder > 0) {
+    svbool_t pa = svwhilelt_b32_u64(0, remainder);
+    svbool_t pb = svwhilelt_b32_u64(oneRegElemCount, remainder);
+    auto vec1 = svget_neonq(svld1ub_u32(pa, srcPtr));
+    auto vec2 = svget_neonq(svld1ub_u32(pb, srcPtr + oneRegElemCount));
+    auto vec1Mask = vtstq_u32(vec1, vec1);
+    auto vec2Mask = vtstq_u32(vec2, vec2);
+    vec1Mask = svget_neonq(
+        svand_n_u32_x(pa, svset_neonq(svundef_u32(), vec1Mask), 0x3f800000));
+    vec2Mask = svget_neonq(
+        svand_n_u32_x(pb, svset_neonq(svundef_u32(), vec2Mask), 0x3f800000));
+    svst1_f32(
+        pa, dst, svset_neonq(svundef_f32(), vreinterpretq_f32_u32(vec1Mask)));
+    svst1_f32(
+        pb,
+        dst + oneRegElemCount,
+        svset_neonq(svundef_f32(), vreinterpretq_f32_u32(vec2Mask)));
+  }
+}
+
+template <>
+Vectorized<float> inline fmadd(
+    const Vectorized<float>& a,
+    const Vectorized<float>& b,
+    const Vectorized<float>& c) {
+  return svmad_f32_x(ptrue, a, b, c);
+}
+
+template <>
+Vectorized<float> inline fnmadd(
+    const Vectorized<float>& a,
+    const Vectorized<float>& b,
+    const Vectorized<float>& c) {
+  return svmsb_f32_x(ptrue, a, b, c);
+}
+
+template <>
+Vectorized<float> inline fmsub(
+    const Vectorized<float>& a,
+    const Vectorized<float>& b,
+    const Vectorized<float>& c) {
+  return svnmsb_f32_x(ptrue, a, b, c);
+}
+
+template <>
+Vectorized<float> inline fnmsub(
+    const Vectorized<float>& a,
+    const Vectorized<float>& b,
+    const Vectorized<float>& c) {
+  return svnmad_f32_x(ptrue, a, b, c);
+}
+
+inline Vectorized<float> Vectorized<float>::erf() const {
+  // constants
+  const Vectorized<float> neg_zero_vec(-0.f);
+  const Vectorized<float> one_vec(1.0f);
+  const Vectorized<float> p(0.3275911f);
+  const Vectorized<float> p1(0.254829592f);
+  const Vectorized<float> p2(-0.284496736f);
+  const Vectorized<float> p3(1.421413741f);
+  const Vectorized<float> p4(-1.453152027f);
+  const Vectorized<float> p5(1.061405429f);
+  // sign(x)
+  auto sign_mask = neg_zero_vec & *this;
+  auto abs_vec = this->abs();
+  // t = 1 / (p * abs(x) + 1)
+  auto tmp0 = fmadd(p, abs_vec, one_vec);
+  auto t = one_vec / tmp0;
+  // r = p5 * t ^ 4 + p4 * t ^ 3 + p3 * t ^ 2 + p2 * t + p1
+  auto tmp1 = fmadd(p5, t, p4);
+  auto tmp2 = fmadd(tmp1, t, p3);
+  auto tmp3 = fmadd(tmp2, t, p2);
+  auto r = fmadd(tmp3, t, p1);
+  // - exp(- x * x)
+  auto pow_2 = (*this) * (*this);
+  auto neg_pow_2 = pow_2 ^ neg_zero_vec;
+  auto tmp4 = Vectorized<float>(svexp(neg_pow_2));
+  auto tmp5 = tmp4 ^ neg_zero_vec;
+  // erf(x) = sign(x) * (1 - r * t * exp(- x * x))
+  auto tmp6 = t * tmp5;
+  auto tmp7 = fmadd(tmp6, r, one_vec);
+  return tmp7 ^ sign_mask;
+}
+
+} // namespace CPU_CAPABILITY
+} // namespace at::vec

--- a/aten/src/ATen/cpu/vec/vec128/vec128_half_sve.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_half_sve.h
@@ -4,27 +4,19 @@
 // See Note [Do not compile initializers with AVX]
 
 #include <ATen/cpu/vec/intrinsics.h>
-#include <ATen/cpu/vec/vec128/vec128_float_neon.h>
 #include <ATen/cpu/vec/vec128/vec128_reduced_precision_common_neon.h>
-#include <ATen/cpu/vec/vec_base.h>
 #include <c10/util/Half.h>
 #include <c10/util/irange.h>
+
+#include <arm_neon.h>
+#include <arm_neon_sve_bridge.h>
+#include <arm_sve.h>
 
 namespace at::vec {
 // See Note [CPU_CAPABILITY namespace]
 inline namespace CPU_CAPABILITY {
 
-// Right now contains only aarch64 implementation.
-// Due to follow two reasons aarch32 is not currently supported.
-// 1. Due to difference in ISA been aarch32 and aarch64, intrinsics
-//    that work for aarch64 dont work for aarch32.
-// 2. Android NDK r21 has problems with compiling aarch32.
-//    Clang seg faults.
-//    https://github.com/android/ndk/issues/1248
-//    https://bugs.llvm.org/show_bug.cgi?id=45824
-// Most likely we will do aarch32 support with inline asm.
-#if defined(__aarch64__) && !defined(CPU_CAPABILITY_SVE128)
-#if !defined(C10_MOBILE)
+#if !defined(C10_MOBILE) && defined(__aarch64__)
 
 #ifdef __BIG_ENDIAN__
 #error "Big endian is not supported."
@@ -140,7 +132,7 @@ class Vectorized<c10::Half> : public Vectorized16<
   // A ctor that accepts c10::Half is needed to fit interface with vec_base.h
   // A second constructor that takes float16_t is also included
   Vectorized(c10::Half val) : Vectorized((float16_t)val) {}
-  Vectorized(float16_t val) : Vectorized16(vdupq_n_f16(val)) {}
+  Vectorized(float16_t val) : Vectorized16(svget_neonq(svdup_n_f16(val))) {}
   Vectorized(
       value_type val0,
       value_type val1,
@@ -152,6 +144,40 @@ class Vectorized<c10::Half> : public Vectorized16<
       value_type val7)
       : Vectorized16(
             float16x8_t{val0, val1, val2, val3, val4, val5, val6, val7}) {}
+
+  Vectorized(svfloat16_t v) : Vectorized16(svget_neonq(v)) {}
+  template <
+      typename... Args,
+      typename = std::enable_if_t<(sizeof...(Args) == size())>>
+  Vectorized(Args... vals) {
+    __at_align__ float16_t buffer[size()] = {vals...};
+    values = vld1q_f16(buffer);
+  }
+  operator svfloat16_t() const {
+    return svset_neonq(svundef_f16(), values);
+  }
+  svfloat16_t valuesAsSve() const {
+    return svset_neonq(svundef_f16(), values);
+  }
+
+  template <int64_t mask>
+  static Vectorized<c10::Half> blend(
+      const Vectorized<c10::Half>& a,
+      const Vectorized<c10::Half>& b) {
+    // Build an array of flags: each bit of element is 1 if the corresponding
+    // bit in 'mask' is set, 0 otherwise.
+    constexpr uint16x8_t maskArray = {
+        (mask & 1ULL) ? 0xFFFF : 0,
+        (mask & 2ULL) ? 0xFFFF : 0,
+        (mask & 4ULL) ? 0xFFFF : 0,
+        (mask & 8ULL) ? 0xFFFF : 0,
+        (mask & 16ULL) ? 0xFFFF : 0,
+        (mask & 32ULL) ? 0xFFFF : 0,
+        (mask & 64ULL) ? 0xFFFF : 0,
+        (mask & 128ULL) ? 0xFFFF : 0};
+    // Use BSL to select elements from b where the mask is 1, else from a
+    return vbslq_f16(maskArray, b.values, a.values);
+  }
 
   static Vectorized<c10::Half> blendv(
       const Vectorized<c10::Half>& a,
@@ -166,210 +192,126 @@ class Vectorized<c10::Half> : public Vectorized16<
     // of the mask either all be zeros or all be 1s.
     // We perhaps need some kind of an assert?
     // But that will affect performance.
-
-    // NOTE [vbslq_f16]: vbslq_f16 doesn't work on clang without
-    // __ARM_FEATURE_FP16_VECTOR_ARITHMETIC. vbslq_u16 generates the
-    // same instruction anyway. see https://godbolt.org/z/cY4a55Y7P
-    Vectorized<c10::Half> vec(mask.values);
-    vec.values = vreinterpretq_f16_u16(vbslq_u16(
-        vreinterpretq_u16_f16(vec.values),
-        vreinterpretq_u16_f16(b.values),
-        vreinterpretq_u16_f16(a.values)));
-    return vec;
+    return vbslq_f16(vreinterpretq_u16_f16(mask.values), b.values, a.values);
   }
   static Vectorized<c10::Half> set(
       const Vectorized<c10::Half>& a,
       const Vectorized<c10::Half>& b,
       int64_t count = size()) {
-    uint16_t pre_mask[size()] = {0};
-    for (int i = 0; i < count; i++) {
-      pre_mask[i] = 0xFFFF;
+    if (count == 0) {
+      return a;
+    } else if (count < size()) {
+      return svsel_f16(svwhilelt_b16(0ull, count), b, a);
     }
-    uint16x8_t mask = vld1q_u16(pre_mask);
-
-    // Using blendv is awkward because 0xFFFF is one of many NaN's in FP16
-    // so we directly use vbslq_u16 instead. (See NOTE [vbslq_f16] above.)
-    Vectorized<c10::Half> vec(vreinterpretq_f16_u16(vbslq_u16(
-        mask,
-        vreinterpretq_u16_f16(b.values),
-        vreinterpretq_u16_f16(a.values))));
-
-    return vec;
+    return b;
   }
   static Vectorized<c10::Half> loadu(const void* ptr, int64_t count = size()) {
     if (count == size()) {
       return vld1q_f16(reinterpret_cast<const float16_t*>(ptr));
     }
-    __at_align__ float16_t tmp_values[size()];
-    for (const auto i : c10::irange(size())) {
-      tmp_values[i] = 0;
-    }
-    std::memcpy(
-        tmp_values,
-        reinterpret_cast<const float16_t*>(ptr),
-        count * sizeof(float16_t));
-    return vld1q_f16(reinterpret_cast<const float16_t*>(tmp_values));
+    svbool_t pg = svwhilelt_b16(0ull, count);
+    return svld1_f16(pg, reinterpret_cast<const float16_t*>(ptr));
   }
   void store(void* ptr, int64_t count = size()) const {
     if (count == size()) {
       vst1q_f16(reinterpret_cast<float16_t*>(ptr), values);
       return;
     } else {
-      float16_t tmp_values[size()];
-      vst1q_f16(reinterpret_cast<float16_t*>(tmp_values), values);
-      std::memcpy(ptr, tmp_values, count * sizeof(float16_t));
+      svbool_t pg = svwhilelt_b16(0ull, count);
+      svst1_f16(pg, reinterpret_cast<float16_t*>(ptr), valuesAsSve());
     }
+  }
+  inline c10::Half operator[](int idx) const {
+    return values[idx];
+  }
+  inline c10::Half operator[](int idx) {
+    return values[idx];
   }
   int zero_mask() const {
-#ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
-    uint16x8_t is_zero_vec = vceqzq_f16(values);
-    const int16x8_t shift = vcombine_s16(
-        vcreate_s16(
-            0x0 | (int64_t(0x1) << 16) | (int64_t(0x2) << 32) |
-            (int64_t(0x3) << 48)),
-        vcreate_s16(
-            0x4 | (int64_t(0x5) << 16) | (int64_t(0x6) << 32) |
-            (int64_t(0x7) << 48)));
-    uint16x8_t bits_vec =
-        vshlq_u16(vandq_u16(is_zero_vec, vdupq_n_u16(1)), shift);
-    return vaddvq_u16(bits_vec);
-#else // __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
-    // use known working implmentation.
-    __at_align__ value_type tmp[size()];
-    store(tmp);
-    int mask = 0;
-    for (int i = 0; i < size(); ++i) {
-      if (tmp[i] == 0) {
-        mask |= (1 << i);
-      }
-    }
-    return mask;
-#endif // __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
+    uint16x8_t cmpReg = vceqzq_f16(values);
+    uint8x8_t narrowedCmp = vmovn_u16(cmpReg);
+    uint64x2_t extReg = svget_neonq(svbext_u64(
+        svset_neonq(
+            svundef_u64(),
+            vreinterpretq_u64_u8(vcombine_u8(narrowedCmp, vdup_n_u8(0)))),
+        svreinterpret_u64_u8(svdup_u8(1))));
+    return extReg[0];
   }
   Vectorized<c10::Half> isnan() const {
-#ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
     return vreinterpretq_f16_u16(vmvnq_u16(vceqq_f16(values, values)));
-#else
-    // NOTE: we could make this faster by doing vectorized checks of
-    // exponent/payload bits.
-    __at_align__ c10::Half tmp[size()];
-    __at_align__ c10::Half res[size()];
-    store(tmp);
-    for (const auto i : c10::irange(size())) {
-      if (_isnan(tmp[i])) {
-        std::memset(static_cast<void*>(&res[i]), 0xFF, sizeof(c10::Half));
-      } else {
-        std::memset(static_cast<void*>(&res[i]), 0, sizeof(c10::Half));
-      }
-    }
-    return loadu(res);
-#endif
   }
   bool has_inf_nan() const {
-    __at_align__ c10::Half tmp[size()];
-    store(tmp);
-    for (const auto i : c10::irange(size())) {
-      if (_isnan(tmp[i]) || _isinf(tmp[i])) {
-        return true;
-      }
-    }
-    return false;
+    return svptest_any(
+        ptrue,
+        svcmpuo_f16(
+            ptrue,
+            svset_neonq(svundef_f16(), vsubq_f16(values, values)),
+            ZERO_F16));
+  }
+  Vectorized<c10::Half> ceil() const {
+    return vrndpq_f16(values);
+  }
+  Vectorized<c10::Half> floor() const {
+    return vrndmq_f16(values);
+  }
+  Vectorized<c10::Half> round() const {
+    return vrndiq_f16(values);
   }
   Vectorized<c10::Half> abs() const {
-#ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
     return Vectorized<c10::Half>(vabsq_f16(values));
-#else
-    return map_with_vec_float_method(&Vectorized<float>::abs);
-#endif
   }
   Vectorized<c10::Half> frac() const;
   Vectorized<c10::Half> neg() const {
-#ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
     return Vectorized<c10::Half>(vnegq_f16(values));
-#else
-    return map_with_vec_float_method(&Vectorized<float>::neg);
-#endif
   }
   Vectorized<c10::Half> trunc() const {
-#ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
     return Vectorized<c10::Half>(vrndq_f16(values));
-#else
-    return map_with_vec_float_method(&Vectorized<float>::trunc);
-#endif
   }
   Vectorized<c10::Half> sqrt() const {
-#ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
     return Vectorized<c10::Half>(vsqrtq_f16(values));
-#else
-    return map_with_vec_float_method(&Vectorized<float>::sqrt);
-#endif
   }
   Vectorized<c10::Half> reciprocal() const {
-#ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
-    auto ones = vdupq_n_f16(1.0f);
-    return Vectorized<c10::Half>(vdivq_f16(ones, values));
-#else
-    return map_with_vec_float_method(&Vectorized<float>::reciprocal);
-#endif
+    float16x8_t recip = vrecpeq_f16(values);
+    recip = vmulq_f16(vrecpsq_f16(values, recip), recip);
+    return recip;
+  }
+  Vectorized<c10::Half> rsqrt() const {
+    return this->sqrt().reciprocal();
+  }
+  c10::Half reduce_add() const {
+    return svaddv_f16(ptrue, svset_neonq(svundef_f16(), values));
+  }
+  c10::Half reduce_max() const {
+    return svmaxv_f16(ptrue, svset_neonq(svundef_f16(), values));
   }
   Vectorized<c10::Half> operator==(const Vectorized<c10::Half>& other) const {
-#ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
     return Vectorized<c10::Half>(
         vreinterpretq_f16_u16(vceqq_f16(values, other.values)));
-#else
-    return map2_bitmask_with_vec_float_method(
-        other, &Vectorized<float>::operator==);
-#endif
   }
 
   Vectorized<c10::Half> operator!=(const Vectorized<c10::Half>& other) const {
-#ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
     return Vectorized<c10::Half>(
         vreinterpretq_f16_u16(vmvnq_u16(vceqq_f16(values, other.values))));
-#else
-    return map2_bitmask_with_vec_float_method(
-        other, &Vectorized<float>::operator!=);
-#endif
   }
 
   Vectorized<c10::Half> operator<(const Vectorized<c10::Half>& other) const {
-#ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
     return Vectorized<c10::Half>(
         vreinterpretq_f16_u16(vcltq_f16(values, other.values)));
-#else
-    return map2_bitmask_with_vec_float_method(
-        other, &Vectorized<float>::operator<);
-#endif
   }
 
   Vectorized<c10::Half> operator<=(const Vectorized<c10::Half>& other) const {
-#ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
     return Vectorized<c10::Half>(
         vreinterpretq_f16_u16(vcleq_f16(values, other.values)));
-#else
-    return map2_bitmask_with_vec_float_method(
-        other, &Vectorized<float>::operator<=);
-#endif
   }
 
   Vectorized<c10::Half> operator>(const Vectorized<c10::Half>& other) const {
-#ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
     return Vectorized<c10::Half>(
         vreinterpretq_f16_u16(vcgtq_f16(values, other.values)));
-#else
-    return map2_bitmask_with_vec_float_method(
-        other, &Vectorized<float>::operator>);
-#endif
   }
 
   Vectorized<c10::Half> operator>=(const Vectorized<c10::Half>& other) const {
-#ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
     return Vectorized<c10::Half>(
         vreinterpretq_f16_u16(vcgeq_f16(values, other.values)));
-#else
-    return map2_bitmask_with_vec_float_method(
-        other, &Vectorized<float>::operator>=);
-#endif
   }
 
   Vectorized<c10::Half> eq(const Vectorized<c10::Half>& other) const;
@@ -414,19 +356,13 @@ template <>
 Vectorized<c10::Half> inline operator+(
     const Vectorized<c10::Half>& a,
     const Vectorized<c10::Half>& b) {
-#ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
   return Vectorized<c10::Half>(vaddq_f16(a, b));
-#else
-  return binary_operator_via_float(std::plus<Vectorized<float>>(), a, b);
-#endif
 }
 
 inline void load_fp32_from_fp16(const c10::Half* data, Vectorized<float>& out) {
-  __at_align__ float values[Vectorized<float>::size()];
-  for (const auto k : c10::irange(Vectorized<float>::size())) {
-    values[k] = data[k];
-  }
-  out = Vectorized<float>::loadu(values);
+  const __fp16* dataPtr = reinterpret_cast<const __fp16*>(data);
+  float16x4_t lowf16 = vld1_f16(dataPtr);
+  out = vcvt_f32_f16(lowf16);
 }
 
 inline void load_fp32_from_fp16(
@@ -443,33 +379,21 @@ template <>
 Vectorized<c10::Half> inline operator-(
     const Vectorized<c10::Half>& a,
     const Vectorized<c10::Half>& b) {
-#ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
   return Vectorized<c10::Half>(vsubq_f16(a, b));
-#else
-  return binary_operator_via_float(std::minus<Vectorized<float>>(), a, b);
-#endif
 }
 
 template <>
 Vectorized<c10::Half> inline operator*(
     const Vectorized<c10::Half>& a,
     const Vectorized<c10::Half>& b) {
-#ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
   return Vectorized<c10::Half>(vmulq_f16(a, b));
-#else
-  return binary_operator_via_float(std::multiplies<Vectorized<float>>(), a, b);
-#endif
 }
 
 template <>
 Vectorized<c10::Half> inline operator/(
     const Vectorized<c10::Half>& a,
     const Vectorized<c10::Half>& b) {
-#ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
   return Vectorized<c10::Half>(vdivq_f16(a, b));
-#else
-  return binary_operator_via_float(std::divides<Vectorized<float>>(), a, b);
-#endif
 }
 
 // frac. Implement this here so we can use subtraction
@@ -483,15 +407,7 @@ template <>
 Vectorized<c10::Half> inline maximum(
     const Vectorized<c10::Half>& a,
     const Vectorized<c10::Half>& b) {
-#ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
   return Vectorized<c10::Half>(vmaxq_f16(a, b));
-#else
-  return binary_operator_via_float(
-      static_cast<Vectorized<float> (*)(
-          const Vectorized<float>&, const Vectorized<float>&)>(&maximum),
-      a,
-      b);
-#endif
 }
 
 // Implements the IEEE 754 201X `minimum` operation, which propagates NaN if
@@ -500,15 +416,7 @@ template <>
 Vectorized<c10::Half> inline minimum(
     const Vectorized<c10::Half>& a,
     const Vectorized<c10::Half>& b) {
-#ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
   return Vectorized<c10::Half>(vminq_f16(a, b));
-#else
-  return binary_operator_via_float(
-      static_cast<Vectorized<float> (*)(
-          const Vectorized<float>&, const Vectorized<float>&)>(&minimum),
-      a,
-      b);
-#endif
 }
 
 template <>
@@ -559,84 +467,110 @@ Vectorized<c10::Half> inline operator^(
 
 inline Vectorized<c10::Half> Vectorized<c10::Half>::eq(
     const Vectorized<c10::Half>& other) const {
-  return (*this == other) & Vectorized<c10::Half>(1);
+  return svreinterpret_f16_u16(
+      svand_n_u16_x(ptrue, svreinterpret_u16_f16(*this == other), 0x3C00));
 }
 
 inline Vectorized<c10::Half> Vectorized<c10::Half>::ne(
     const Vectorized<c10::Half>& other) const {
-  return (*this != other) & Vectorized<c10::Half>(1);
+  return svreinterpret_f16_u16(
+      svand_n_u16_x(ptrue, svreinterpret_u16_f16(*this != other), 0x3C00));
 }
 
 inline Vectorized<c10::Half> Vectorized<c10::Half>::gt(
     const Vectorized<c10::Half>& other) const {
-  return (*this > other) & Vectorized<c10::Half>(1);
+  return svreinterpret_f16_u16(
+      svand_n_u16_x(ptrue, svreinterpret_u16_f16(*this > other), 0x3C00));
 }
 
 inline Vectorized<c10::Half> Vectorized<c10::Half>::ge(
     const Vectorized<c10::Half>& other) const {
-  return (*this >= other) & Vectorized<c10::Half>(1);
+  return svreinterpret_f16_u16(
+      svand_n_u16_x(ptrue, svreinterpret_u16_f16(*this >= other), 0x3C00));
 }
 
 inline Vectorized<c10::Half> Vectorized<c10::Half>::lt(
     const Vectorized<c10::Half>& other) const {
-  return (*this < other) & Vectorized<c10::Half>(1);
+  return svreinterpret_f16_u16(
+      svand_n_u16_x(ptrue, svreinterpret_u16_f16(*this < other), 0x3C00));
 }
 
 inline Vectorized<c10::Half> Vectorized<c10::Half>::le(
     const Vectorized<c10::Half>& other) const {
-  return (*this <= other) & Vectorized<c10::Half>(1);
+  return svreinterpret_f16_u16(
+      svand_n_u16_x(ptrue, svreinterpret_u16_f16(*this <= other), 0x3C00));
 }
 
-// These are global functions, so the defaults in vec_base.h should
-// work fine if __ARM_FEATURE_FP16_VECTOR_ARITHMETIC is not available.
-#ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
 template <>
 inline void convert(const float16_t* src, int16_t* dst, int64_t n) {
-  int64_t i;
-#ifndef __msvc_cl__
-#pragma unroll
-#endif
-  for (i = 0; i <= (n - Vectorized<c10::Half>::size());
-       i += Vectorized<c10::Half>::size()) {
-    vst1q_s16(dst + i, vcvtq_s16_f16(vld1q_f16(src + i)));
+  constexpr uint64_t oneRegElemCount = Vectorized<c10::Half>::size();
+  constexpr uint64_t twoRegsElemCount = oneRegElemCount * 2;
+  constexpr uint64_t fourRegsElemCount = twoRegsElemCount * 2;
+  const uint64_t count = static_cast<uint64_t>(n);
+  for (uint64_t iters = count / fourRegsElemCount; iters > 0; --iters) {
+    auto vec1 = vld1q_f16(src);
+    auto vec2 = vld1q_f16(src + oneRegElemCount);
+    auto vec3 = vld1q_f16(src + twoRegsElemCount);
+    auto vec4 = vld1q_f16(src + (twoRegsElemCount + oneRegElemCount));
+    auto convertedVec1 = vcvtq_s16_f16(vec1);
+    auto convertedVec2 = vcvtq_s16_f16(vec2);
+    auto convertedVec3 = vcvtq_s16_f16(vec3);
+    auto convertedVec4 = vcvtq_s16_f16(vec4);
+    vst1q_s16(dst, convertedVec1);
+    vst1q_s16(dst + oneRegElemCount, convertedVec2);
+    vst1q_s16(dst + twoRegsElemCount, convertedVec3);
+    vst1q_s16(dst + (twoRegsElemCount + oneRegElemCount), convertedVec4);
+    src += fourRegsElemCount;
+    dst += fourRegsElemCount;
   }
-#ifndef __msvc_cl__
-#pragma unroll
-#endif
-  for (; i < n; i++) {
-    dst[i] = static_cast<int16_t>(src[i]);
+#pragma clang loop vectorize(disable)
+#pragma clang loop unroll(disable)
+  for (uint64_t remainder = count % fourRegsElemCount; remainder > 0;
+       --remainder) {
+    *dst = *src;
+    src += 1;
+    dst += 1;
   }
 }
 
 template <>
 inline void convert(const int16_t* src, float16_t* dst, int64_t n) {
-  int64_t i;
-#ifndef __msvc_cl__
-#pragma unroll
-#endif
-  for (i = 0; i <= (n - Vectorized<c10::Half>::size());
-       i += Vectorized<c10::Half>::size()) {
-    vst1q_f16(dst + i, vcvtq_f16_s16(vld1q_s16(src + i)));
+  constexpr uint64_t oneRegElemCount = Vectorized<c10::Half>::size();
+  constexpr uint64_t twoRegsElemCount = oneRegElemCount * 2;
+  constexpr uint64_t fourRegsElemCount = twoRegsElemCount * 2;
+  const uint64_t count = static_cast<uint64_t>(n);
+  for (uint64_t iters = count / fourRegsElemCount; iters > 0; --iters) {
+    auto vec1 = vld1q_s16(src);
+    auto vec2 = vld1q_s16(src + oneRegElemCount);
+    auto vec3 = vld1q_s16(src + twoRegsElemCount);
+    auto vec4 = vld1q_s16(src + (twoRegsElemCount + oneRegElemCount));
+    auto convertedVec1 = vcvtq_f16_s16(vec1);
+    auto convertedVec2 = vcvtq_f16_s16(vec2);
+    auto convertedVec3 = vcvtq_f16_s16(vec3);
+    auto convertedVec4 = vcvtq_f16_s16(vec4);
+    vst1q_f16(dst, convertedVec1);
+    vst1q_f16(dst + oneRegElemCount, convertedVec2);
+    vst1q_f16(dst + twoRegsElemCount, convertedVec3);
+    vst1q_f16(dst + (twoRegsElemCount + oneRegElemCount), convertedVec4);
+    src += fourRegsElemCount;
+    dst += fourRegsElemCount;
   }
-#ifndef __msvc_cl__
-#pragma unroll
-#endif
-  for (; i < n; i++) {
-    dst[i] = static_cast<float16_t>(src[i]);
+#pragma clang loop vectorize(disable)
+#pragma clang loop unroll(disable)
+  for (uint64_t remainder = count % fourRegsElemCount; remainder > 0;
+       --remainder) {
+    *dst = *src;
+    src += 1;
+    dst += 1;
   }
 }
-#endif // __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
 
 template <>
 Vectorized<c10::Half> inline fmadd(
     const Vectorized<c10::Half>& a,
     const Vectorized<c10::Half>& b,
     const Vectorized<c10::Half>& c) {
-#ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
-  return Vectorized<c10::Half>(vfmaq_f16(c, a, b));
-#else
-  return a * b + c;
-#endif
+  return Vectorized<c10::Half>(svmad_f16_x(ptrue, a, b, c));
 }
 
 template <>
@@ -644,11 +578,7 @@ Vectorized<c10::Half> inline fnmadd(
     const Vectorized<c10::Half>& a,
     const Vectorized<c10::Half>& b,
     const Vectorized<c10::Half>& c) {
-#ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
-  return Vectorized<c10::Half>(vfmsq_f16(c, a, b));
-#else
-  return -a * b + c;
-#endif
+  return Vectorized<c10::Half>(svmsb_f16_x(ptrue, a, b, c));
 }
 
 template <>
@@ -656,11 +586,7 @@ Vectorized<c10::Half> inline fmsub(
     const Vectorized<c10::Half>& a,
     const Vectorized<c10::Half>& b,
     const Vectorized<c10::Half>& c) {
-#ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
-  return Vectorized<c10::Half>(vnegq_f16(vfmsq_f16(c, a, b)));
-#else
-  return a * b - c;
-#endif
+  return Vectorized<c10::Half>(svnmsb_f16_x(ptrue, a, b, c));
 }
 
 template <>
@@ -668,11 +594,7 @@ Vectorized<c10::Half> inline fnmsub(
     const Vectorized<c10::Half>& a,
     const Vectorized<c10::Half>& b,
     const Vectorized<c10::Half>& c) {
-#ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
-  return Vectorized<c10::Half>(vnegq_f16(vfmaq_f16(c, a, b)));
-#else
-  return -a * b - c;
-#endif
+  return Vectorized<c10::Half>(svnmad_f16_x(ptrue, a, b, c));
 }
 
 #else
@@ -722,7 +644,6 @@ CONVERT_NON_VECTORIZED_INIT(Half, half)
 LOAD_FP32_NON_VECTORIZED_INIT(Half, fp16)
 
 #endif // !defined(C10_MOBILE) && defined(__aarch64__)
-#endif
 
 } // namespace CPU_CAPABILITY
 } // namespace at::vec

--- a/aten/src/ATen/cpu/vec/vec128/vec128_int_sve.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_int_sve.h
@@ -1,0 +1,874 @@
+#pragma once
+
+#include <ATen/cpu/vec/intrinsics.h>
+#include <ATen/cpu/vec/sve/sve_helper.h>
+#include <ATen/cpu/vec/vec_base.h>
+#include <c10/macros/Macros.h>
+#include <c10/util/irange.h>
+
+namespace at::vec {
+// Note [CPU_CAPABILITY namespace]
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// This header, and all of its subheaders, will be compiled with
+// different architecture flags for each supported set of vector
+// intrinsics. So we need to make sure they aren't inadvertently
+// linked together. We do this by declaring objects in an `inline
+// namespace` which changes the name mangling, but can still be
+// accessed as `at::vec`.
+inline namespace CPU_CAPABILITY {
+
+#if defined(CPU_CAPABILITY_SVE)
+
+#define VEC_INT_SVE_TEMPLATE(vl, bit)                                         \
+  template <>                                                                 \
+  struct is_vec_specialized_for<int##bit##_t> : std::bool_constant<true> {};  \
+                                                                              \
+  template <>                                                                 \
+  class Vectorized<int##bit##_t> {                                            \
+   using neon_type = int##bit##x##vl##_t;                                     \
+   private:                                                                   \
+    neon_type values;                                                         \
+                                                                              \
+   public:                                                                    \
+    using value_type = int##bit##_t;                                          \
+    using size_type = int;                                                    \
+    static constexpr size_type size() {                                       \
+      return vl;                                                              \
+    }                                                                         \
+    Vectorized() {                                                            \
+      values = vdupq_n_s##bit(0);                                             \
+    }                                                                         \
+    Vectorized(neon_type v) : values(v) {}                                    \
+    Vectorized(svint##bit##_t v) : values(svget_neonq(v)) {}                  \
+    Vectorized(int##bit##_t val) {                                            \
+      values = svget_neonq(svdup_n_s##bit(val));                              \
+    }                                                                         \
+    template <                                                                \
+        typename... Args,                                                     \
+        typename = std::enable_if_t<(sizeof...(Args) == size())>>             \
+    Vectorized(Args... vals) {                                                \
+      __at_align__ int##bit##_t buffer[size()] = {vals...};                   \
+      values = vld1q_s##bit(buffer);                                          \
+    }                                                                         \
+    operator neon_type() const {                                              \
+      return values;                                                          \
+    }                                                                         \
+    operator svint##bit##_t() const {                                         \
+      return svset_neonq(svundef_s##bit(), values);                           \
+    }                                                                         \
+    template <int64_t mask>                                                   \
+    static Vectorized<int##bit##_t> blend(                                    \
+      const Vectorized<int##bit##_t>& a,                                      \
+      const Vectorized<int##bit##_t>& b);                                     \
+    static Vectorized<int##bit##_t> blendv(                                   \
+        const Vectorized<int##bit##_t>& a,                                    \
+        const Vectorized<int##bit##_t>& b,                                    \
+        const Vectorized<int##bit##_t>& mask_) {                              \
+      return vbslq_s##bit(vreinterpretq_u##bit##_s##bit(mask_.values), b, a); \
+    }                                                                         \
+    template <typename step_t>                                                \
+    static Vectorized<int##bit##_t> arange(                                   \
+        value_type base = 0,                                                  \
+        step_t step = static_cast<step_t>(1));                                \
+    static Vectorized<int##bit##_t> set(                                      \
+        const Vectorized<int##bit##_t>& a,                                    \
+        const Vectorized<int##bit##_t>& b,                                    \
+        int##bit##_t count = size()) {                                        \
+      if (count == 0) {                                                       \
+        return a;                                                             \
+      } else if (count < size()) {                                            \
+        return svsel_s##bit(svwhilelt_b##bit(0ull, count), b, a);             \
+      }                                                                       \
+      return b;                                                               \
+    }                                                                         \
+    static Vectorized<int##bit##_t> loadu(                                    \
+        const void* ptr,                                                      \
+        int64_t count = size()) {                                             \
+      if (count == size())                                                    \
+        return vld1q_s##bit(reinterpret_cast<const int##bit##_t*>(ptr));      \
+      svbool_t pg = svwhilelt_b##bit(0ull, count);                            \
+      return svld1_s##bit(pg, reinterpret_cast<const int##bit##_t*>(ptr));    \
+    }                                                                         \
+    void store(void* ptr, int64_t count = size()) const {                     \
+      if (count == size()) {                                                  \
+        vst1q_s##bit(reinterpret_cast<int##bit##_t*>(ptr), values);           \
+      } else {                                                                \
+        svbool_t pg = svwhilelt_b##bit(0ull, count);                          \
+        auto dstPtr = reinterpret_cast<int##bit##_t*>(ptr);                   \
+        svst1_s##bit(pg, dstPtr, svset_neonq(svundef_s##bit(), values));      \
+      }                                                                       \
+    }                                                                         \
+    const int##bit##_t& operator[](int idx) const = delete;                   \
+    int##bit##_t& operator[](int idx) = delete;                               \
+    Vectorized<int##bit##_t> abs() const {                                    \
+      return vabsq_s##bit(values);                                            \
+    }                                                                         \
+    Vectorized<int##bit##_t> real() const {                                   \
+      return values;                                                          \
+    }                                                                         \
+    Vectorized<int##bit##_t> imag() const {                                   \
+      return svdup_n_s##bit(0);                                               \
+    }                                                                         \
+    Vectorized<int##bit##_t> conj() const {                                   \
+      return values;                                                          \
+    }                                                                         \
+    Vectorized<int##bit##_t> neg() const {                                    \
+      return vnegq_s##bit(values);                                            \
+    }                                                                         \
+    int##bit##_t reduce_add() const {                                         \
+    return vaddvq_s##bit(values);                                             \
+    }                                                                         \
+    int##bit##_t reduce_max() const;                                          \
+    Vectorized<int##bit##_t> operator==(                                      \
+        const Vectorized<int##bit##_t>& other) const {                        \
+      return Vectorized<value_type>(                                          \
+        vreinterpretq_s##bit##_u##bit(vceqq_s##bit(values, other.values)));   \
+    }                                                                         \
+    Vectorized<int##bit##_t> operator!=(                                      \
+        const Vectorized<int##bit##_t>& other) const;                         \
+    Vectorized<int##bit##_t> operator<(                                       \
+        const Vectorized<int##bit##_t>& other) const {                        \
+      return Vectorized<value_type>(                                          \
+        vreinterpretq_s##bit##_u##bit(vcltq_s##bit(values, other.values)));   \
+    }                                                                         \
+    Vectorized<int##bit##_t> operator<=(                                      \
+        const Vectorized<int##bit##_t>& other) const {                        \
+      return Vectorized<value_type>(                                          \
+        vreinterpretq_s##bit##_u##bit(vcleq_s##bit(values, other.values)));   \
+    }                                                                         \
+    Vectorized<int##bit##_t> operator>(                                       \
+        const Vectorized<int##bit##_t>& other) const {                        \
+      return Vectorized<value_type>(                                          \
+        vreinterpretq_s##bit##_u##bit(vcgtq_s##bit(values, other.values)));   \
+    }                                                                         \
+    Vectorized<int##bit##_t> operator>=(                                      \
+        const Vectorized<int##bit##_t>& other) const {                        \
+      return Vectorized<value_type>(                                          \
+        vreinterpretq_s##bit##_u##bit(vcgeq_s##bit(values, other.values)));   \
+    }                                                                         \
+    Vectorized<int##bit##_t> eq(const Vectorized<int##bit##_t>& other) const; \
+    Vectorized<int##bit##_t> ne(const Vectorized<int##bit##_t>& other) const; \
+    Vectorized<int##bit##_t> gt(const Vectorized<int##bit##_t>& other) const; \
+    Vectorized<int##bit##_t> ge(const Vectorized<int##bit##_t>& other) const; \
+    Vectorized<int##bit##_t> lt(const Vectorized<int##bit##_t>& other) const; \
+    Vectorized<int##bit##_t> le(const Vectorized<int##bit##_t>& other) const; \
+  };                                                                          \
+  template <>                                                                 \
+  Vectorized<int##bit##_t> inline operator+(                                  \
+      const Vectorized<int##bit##_t>& a, const Vectorized<int##bit##_t>& b) { \
+    return vaddq_s##bit(a, b);                                                \
+  }                                                                           \
+  template <>                                                                 \
+  Vectorized<int##bit##_t> inline operator-(                                  \
+      const Vectorized<int##bit##_t>& a, const Vectorized<int##bit##_t>& b) { \
+    return vsubq_s##bit(a, b);                                                \
+  }                                                                           \
+  template <>                                                                 \
+  Vectorized<int##bit##_t> inline operator&(                                  \
+      const Vectorized<int##bit##_t>& a, const Vectorized<int##bit##_t>& b) { \
+    return vandq_s##bit(a, b);                                                \
+  }                                                                           \
+  template <>                                                                 \
+  Vectorized<int##bit##_t> inline operator|(                                  \
+      const Vectorized<int##bit##_t>& a, const Vectorized<int##bit##_t>& b) { \
+    return vorrq_s##bit(a, b);                                                \
+  }                                                                           \
+  template <>                                                                 \
+  Vectorized<int##bit##_t> inline operator^(                                  \
+      const Vectorized<int##bit##_t>& a, const Vectorized<int##bit##_t>& b) { \
+    return veorq_s##bit(a, b);                                                \
+  }                                                                           \
+  Vectorized<int##bit##_t> inline Vectorized<int##bit##_t>::eq(               \
+      const Vectorized<int##bit##_t>& other) const {                          \
+    return svand_n_s##bit##_x(ptrue, *this == other, 1);                      \
+  }                                                                           \
+  Vectorized<int##bit##_t> inline Vectorized<int##bit##_t>::ne(               \
+      const Vectorized<int##bit##_t>& other) const {                          \
+    return svand_n_s##bit##_x(ptrue, *this != other, 1);                      \
+  }                                                                           \
+  Vectorized<int##bit##_t> inline Vectorized<int##bit##_t>::gt(               \
+      const Vectorized<int##bit##_t>& other) const {                          \
+    return svand_n_s##bit##_x(ptrue, *this > other, 1);                       \
+  }                                                                           \
+  Vectorized<int##bit##_t> inline Vectorized<int##bit##_t>::ge(               \
+      const Vectorized<int##bit##_t>& other) const {                          \
+    return svand_n_s##bit##_x(ptrue, *this >= other, 1);                      \
+  }                                                                           \
+  Vectorized<int##bit##_t> inline Vectorized<int##bit##_t>::lt(               \
+      const Vectorized<int##bit##_t>& other) const {                          \
+    return svand_n_s##bit##_x(ptrue, *this < other, 1);                       \
+  }                                                                           \
+  Vectorized<int##bit##_t> inline Vectorized<int##bit##_t>::le(               \
+      const Vectorized<int##bit##_t>& other) const {                          \
+    return svand_n_s##bit##_x(ptrue, *this <= other, 1);                      \
+  }
+
+VEC_INT_SVE_TEMPLATE(2, 64)
+VEC_INT_SVE_TEMPLATE(4, 32)
+VEC_INT_SVE_TEMPLATE(8, 16)
+VEC_INT_SVE_TEMPLATE(16, 8)
+
+inline int64_t Vectorized<int64_t>::reduce_max() const {                                         
+  return svmaxv_s64(ptrue, svset_neonq(svundef_s64(), values));                                 
+}
+
+inline int32_t Vectorized<int32_t>::reduce_max() const {                                         
+  return vmaxvq_s32(values);                                 
+}
+
+inline int16_t Vectorized<int16_t>::reduce_max() const {                                         
+  return vmaxvq_s16(values);                                 
+}
+
+inline int8_t Vectorized<int8_t>::reduce_max() const {                                         
+  return vmaxvq_s8(values);                                 
+}                                                                         
+
+template <>                                                                 
+Vectorized<int64_t> inline operator*(                                  
+    const Vectorized<int64_t>& a, const Vectorized<int64_t>& b) { 
+  return svmul_s64_x(ptrue, a, b);                                                
+} 
+
+template <>                                                                 
+Vectorized<int32_t> inline operator*(                                  
+    const Vectorized<int32_t>& a, const Vectorized<int32_t>& b) { 
+  return vmulq_s32(a, b);                                                
+} 
+
+template <>                                                                 
+Vectorized<int16_t> inline operator*(                                  
+    const Vectorized<int16_t>& a, const Vectorized<int16_t>& b) { 
+  return vmulq_s16(a, b);                                                
+} 
+
+template <>                                                                 
+Vectorized<int8_t> inline operator*(                                  
+    const Vectorized<int8_t>& a, const Vectorized<int8_t>& b) { 
+  return vmulq_s8(a, b);                                                
+}  
+
+template <>
+Vectorized<int64_t> inline operator/(
+    const Vectorized<int64_t>& a,
+    const Vectorized<int64_t>& b) {
+  return svdiv_s64_x(ptrue, a, b);
+}
+
+template <>
+Vectorized<int32_t> inline operator/(
+    const Vectorized<int32_t>& a,
+    const Vectorized<int32_t>& b) {
+  return svdiv_s32_x(ptrue, a, b);
+}
+
+template <>
+Vectorized<int16_t> inline operator/(
+    const Vectorized<int16_t>& a,
+    const Vectorized<int16_t>& b) {
+  Vectorized<int32_t> highBitsA = vmovl_high_s16(a);
+  Vectorized<int32_t> highBitsB = vmovl_high_s16(b);
+  Vectorized<int32_t> lowBitsA = vmovl_s16(vget_low_s16(a));
+  Vectorized<int32_t> lowBitsB = vmovl_s16(vget_low_s16(b));
+  int32x4_t highBitsResult = highBitsA / highBitsB;
+  int32x4_t lowBitsResult = lowBitsA / lowBitsB;
+  return vuzp1q_s16(vreinterpretq_s16_s32(lowBitsResult), vreinterpretq_s16_s32(highBitsResult));
+}
+
+template <>
+Vectorized<int8_t> inline operator/(
+    const Vectorized<int8_t>& a,
+    const Vectorized<int8_t>& b) {
+  Vectorized<int16_t> highBitsA = vmovl_high_s8(a);
+  Vectorized<int16_t> highBitsB = vmovl_high_s8(b);
+  Vectorized<int16_t> lowBitsA = vmovl_s8(vget_low_s8(a));
+  Vectorized<int16_t> lowBitsB = vmovl_s8(vget_low_s8(b));
+  int16x8_t highBitsResult = highBitsA / highBitsB;
+  int16x8_t lowBitsResult = lowBitsA / lowBitsB;
+  return vuzp1q_s8(vreinterpretq_s8_s16(lowBitsResult), vreinterpretq_s8_s16(highBitsResult));
+}                                                                           
+
+template <>
+inline Vectorized<int64_t> operator~(                                  
+    const Vectorized<int64_t>& a) {
+  int64x2_t val = a;                                    
+  return ~val;                                                   
+} 
+ 
+template <>
+inline Vectorized<int32_t> operator~(                                  
+    const Vectorized<int32_t>& a) {                                    
+  return vmvnq_s32(a);                                                   
+}
+
+template <>                                                                
+inline Vectorized<int16_t> operator~(                                  
+    const Vectorized<int16_t>& a) {                                    
+  return vmvnq_s16(a);                                                   
+} 
+
+template <>
+inline Vectorized<int8_t> operator~(                                  
+    const Vectorized<int8_t>& a) {                                    
+  return vmvnq_s8(a);                                                   
+}
+
+inline Vectorized<int64_t> Vectorized<int64_t>::operator!=(                                  
+    const Vectorized<int64_t>& other) const {                                    
+  return  ~(*this == other);                                                   
+} 
+                                                                 
+inline Vectorized<int32_t> Vectorized<int32_t>::operator!=(                                  
+    const Vectorized<int32_t>& other) const {                                    
+  return  ~(*this == other);                                                   
+} 
+                                                                
+inline Vectorized<int16_t> Vectorized<int16_t>::operator!=(                                  
+    const Vectorized<int16_t>& other) const {                                    
+  return  ~(*this == other);                                                   
+} 
+                                                              
+inline Vectorized<int8_t> Vectorized<int8_t>::operator!=(                                  
+    const Vectorized<int8_t>& other) const {                                    
+  return  ~(*this == other);                                                   
+}
+
+template <>                                                                 
+Vectorized<int64_t> inline minimum(                                    
+    const Vectorized<int64_t>& a, const Vectorized<int64_t>& b) { 
+  return svmin_s64_x(ptrue, a, b);                                                
+}
+
+template <>                                                                 
+Vectorized<int32_t> inline minimum(                                    
+    const Vectorized<int32_t>& a, const Vectorized<int32_t>& b) { 
+  return vminq_s32(a, b);                                                
+}   
+
+template <>                                                                 
+Vectorized<int16_t> inline minimum(                                    
+    const Vectorized<int16_t>& a, const Vectorized<int16_t>& b) { 
+  return vminq_s16(a, b);                                                
+}   
+
+template <>                                                                 
+Vectorized<int8_t> inline minimum(                                    
+    const Vectorized<int8_t>& a, const Vectorized<int8_t>& b) { 
+  return vminq_s8(a, b);                                                
+}
+
+template <>                                                                 
+Vectorized<int64_t> inline maximum(                                    
+    const Vectorized<int64_t>& a, const Vectorized<int64_t>& b) { 
+  return svmax_s64_x(ptrue, a, b);                                                
+}
+
+template <>                                                                 
+Vectorized<int32_t> inline maximum(                                    
+    const Vectorized<int32_t>& a, const Vectorized<int32_t>& b) { 
+  return vmaxq_s32(a, b);                                                
+}   
+
+template <>                                                                 
+Vectorized<int16_t> inline maximum(                                    
+    const Vectorized<int16_t>& a, const Vectorized<int16_t>& b) { 
+  return vmaxq_s16(a, b);                                                
+}   
+
+template <>                                                                 
+Vectorized<int8_t> inline maximum(                                    
+    const Vectorized<int8_t>& a, const Vectorized<int8_t>& b) { 
+  return vmaxq_s8(a, b);                                                
+}
+
+template <>                                                                 
+Vectorized<int64_t> inline clamp(                                      
+    const Vectorized<int64_t>& a,                                      
+    const Vectorized<int64_t>& min,                                    
+    const Vectorized<int64_t>& max) {                                  
+  return minimum(max, maximum(min, a));                                     
+}
+
+template <>                                                                 
+Vectorized<int32_t> inline clamp(                                      
+    const Vectorized<int32_t>& a,                                      
+    const Vectorized<int32_t>& min,                                    
+    const Vectorized<int32_t>& max) {                                  
+  return minimum(max, maximum(min, a));                                     
+}
+
+template <>                                                                 
+Vectorized<int16_t> inline clamp(                                      
+    const Vectorized<int16_t>& a,                                      
+    const Vectorized<int16_t>& min,                                    
+    const Vectorized<int16_t>& max) {                                  
+  return minimum(max, maximum(min, a));                                     
+}
+
+template <>                                                                 
+Vectorized<int8_t> inline clamp(                                      
+    const Vectorized<int8_t>& a,                                      
+    const Vectorized<int8_t>& min,                                    
+    const Vectorized<int8_t>& max) {                                  
+  return minimum(max, maximum(min, a));                                     
+}
+
+template <>                                                                 
+Vectorized<int64_t> inline clamp_max(                                  
+    const Vectorized<int64_t>& a,                                      
+    const Vectorized<int64_t>& max) {                                  
+  return minimum(max, a);                                                   
+}
+
+template <>                                                                 
+Vectorized<int32_t> inline clamp_max(                                  
+    const Vectorized<int32_t>& a,                                      
+    const Vectorized<int32_t>& max) {                                  
+  return minimum(max, a);                                                   
+}
+
+template <>                                                                 
+Vectorized<int16_t> inline clamp_max(                                  
+    const Vectorized<int16_t>& a,                                      
+    const Vectorized<int16_t>& max) {                                  
+  return minimum(max, a);                                                   
+}
+
+template <>                                                                 
+Vectorized<int8_t> inline clamp_max(                                  
+    const Vectorized<int8_t>& a,                                      
+    const Vectorized<int8_t>& max) {                                  
+  return minimum(max, a);                                                   
+}
+
+template <>                                                                 
+Vectorized<int64_t> inline clamp_min(                                  
+    const Vectorized<int64_t>& a,                                      
+    const Vectorized<int64_t>& min) {                                  
+  return maximum(min, a);                                                   
+} 
+
+template <>                                                                 
+Vectorized<int32_t> inline clamp_min(                                  
+    const Vectorized<int32_t>& a,                                      
+    const Vectorized<int32_t>& min) {                                  
+  return maximum(min, a);                                                   
+} 
+
+template <>                                                                 
+Vectorized<int16_t> inline clamp_min(                                  
+    const Vectorized<int16_t>& a,                                      
+    const Vectorized<int16_t>& min) {                                  
+  return maximum(min, a);                                                   
+} 
+
+template <>                                                                 
+Vectorized<int8_t> inline clamp_min(                                  
+    const Vectorized<int8_t>& a,                                      
+    const Vectorized<int8_t>& min) {                                  
+  return maximum(min, a);                                                   
+}
+
+template <int64_t mask>
+  Vectorized<int64_t> Vectorized<int64_t>::blend(
+      const Vectorized<int64_t>& a,
+      const Vectorized<int64_t>& b) {
+    // Build an array of flags: each bit of element is 1 if the corresponding bit in
+    // 'mask' is set, 0 otherwise.
+    uint64x2_t maskArray = {
+      (mask & 1ULL) ? 0xFFFFFFFFFFFFFFFF : 0, 
+      (mask & 2ULL) ? 0xFFFFFFFFFFFFFFFF : 0};
+    // Use BSL to select elements from b where the mask is 1, else from a
+    return vbslq_s64(maskArray, b.values, a.values);
+}
+
+template <int64_t mask>
+  Vectorized<int32_t> Vectorized<int32_t>::blend(
+      const Vectorized<int32_t>& a,
+      const Vectorized<int32_t>& b) {
+    // Build an array of flags: each bit of element is 1 if the corresponding bit in
+    // 'mask' is set, 0 otherwise.
+    uint32x4_t maskArray = {
+      (mask &     1ULL) ? 0xFFFFFFFF : 0, 
+      (mask &     2ULL) ? 0xFFFFFFFF : 0, 
+      (mask &     4ULL) ? 0xFFFFFFFF : 0, 
+      (mask &     8ULL) ? 0xFFFFFFFF : 0};
+    // Use BSL to select elements from b where the mask is 1, else from a
+    return vbslq_s32(maskArray, b.values, a.values);
+}
+
+template <int64_t mask>
+  Vectorized<int16_t> Vectorized<int16_t>::blend(
+      const Vectorized<int16_t>& a,
+      const Vectorized<int16_t>& b) {
+    // Build an array of flags: each bit of element is 1 if the corresponding bit in
+    // 'mask' is set, 0 otherwise.
+    uint16x8_t maskArray = {
+      (mask &     1ULL) ? 0xFFFF : 0, 
+      (mask &     2ULL) ? 0xFFFF : 0, 
+      (mask &     4ULL) ? 0xFFFF : 0, 
+      (mask &     8ULL) ? 0xFFFF : 0,
+      (mask &    16ULL) ? 0xFFFF : 0, 
+      (mask &    32ULL) ? 0xFFFF : 0, 
+      (mask &    64ULL) ? 0xFFFF : 0, 
+      (mask &   128ULL) ? 0xFFFF : 0};
+    // Use BSL to select elements from b where the mask is 1, else from a
+    return vbslq_s16(maskArray, b.values, a.values);
+}
+
+template <int64_t mask>
+  Vectorized<int8_t> Vectorized<int8_t>::blend(
+      const Vectorized<int8_t>& a,
+      const Vectorized<int8_t>& b) {
+    // Build an array of flags: each bit of element is 1 if the corresponding bit in
+    // 'mask' is set, 0 otherwise.
+    uint8x16_t maskArray = {
+      (mask &     1ULL) ? 0xFF : 0, 
+      (mask &     2ULL) ? 0xFF : 0, 
+      (mask &     4ULL) ? 0xFF : 0, 
+      (mask &     8ULL) ? 0xFF : 0,
+      (mask &    16ULL) ? 0xFF : 0, 
+      (mask &    32ULL) ? 0xFF : 0, 
+      (mask &    64ULL) ? 0xFF : 0, 
+      (mask &   128ULL) ? 0xFF : 0,
+      (mask &   256ULL) ? 0xFF : 0, 
+      (mask &   512ULL) ? 0xFF : 0, 
+      (mask &  1024ULL) ? 0xFF : 0, 
+      (mask &  2048ULL) ? 0xFF : 0,
+      (mask &  4096ULL) ? 0xFF : 0, 
+      (mask &  8192ULL) ? 0xFF : 0, 
+      (mask & 16384ULL) ? 0xFF : 0, 
+      (mask & 32768ULL) ? 0xFF : 0};
+    // Use BSL to select elements from b where the mask is 1, else from a
+    return vbslq_s8(maskArray, b.values, a.values);
+}
+
+template <typename step_t>                                                
+inline Vectorized<int64_t> Vectorized<int64_t>::arange(                                   
+    int64_t base,                                                
+    step_t step) {                               
+      const Vectorized<int64_t> base_vec(base);                        
+      const Vectorized<int64_t> step_vec(step);                        
+      const Vectorized<int64_t> step_sizes = svindex_s64(0, 1);     
+      return svmla_s64_x(ptrue, base_vec, step_sizes, step_vec);                
+}
+
+template <typename step_t>                                                
+inline Vectorized<int32_t> Vectorized<int32_t>::arange(                                   
+    int32_t base,                                                
+    step_t step) {                               
+      const Vectorized<int32_t> base_vec(base);                        
+      const Vectorized<int32_t> step_vec(step);                        
+      const Vectorized<int32_t> step_sizes = svindex_s32(0, 1);     
+      return vmlaq_s32(base_vec, step_sizes, step_vec);                
+}
+
+template <typename step_t>                                                
+inline Vectorized<int16_t> Vectorized<int16_t>::arange(                                   
+    int16_t base,                                                
+    step_t step) {                               
+      const Vectorized<int16_t> base_vec(base);                        
+      const Vectorized<int16_t> step_vec(step);                        
+      const Vectorized<int16_t> step_sizes = svindex_s16(0, 1);     
+      return vmlaq_s16(base_vec, step_sizes, step_vec);                
+} 
+
+template <typename step_t>                                                
+inline Vectorized<int8_t> Vectorized<int8_t>::arange(                                   
+    int8_t base,                                                
+    step_t step) {                               
+      const Vectorized<int8_t> base_vec(base);                        
+      const Vectorized<int8_t> step_vec(step);                        
+      const Vectorized<int8_t> step_sizes = svindex_s8(0, 1);     
+      return vmlaq_s8(base_vec, step_sizes, step_vec);                
+} 
+
+template <>
+inline void convert(const int32_t* src, int64_t* dst, int64_t n) {
+  constexpr uint64_t oneRegElemCount = Vectorized<int64_t>::size();
+  constexpr uint64_t twoRegsElemCount = oneRegElemCount * 2;
+  const uint64_t count = static_cast<uint64_t>(n);
+  const uint64_t remainder = count % twoRegsElemCount;
+  for (uint64_t iters = count / twoRegsElemCount; iters > 0; --iters) {
+    auto vec1 = svget_neonq(svld1sw_s64(svptrue_b8(), src));
+    auto vec2 = svget_neonq(svld1sw_s64(svptrue_b8(), src + oneRegElemCount));
+    vst1q_s64(dst, vec1);
+    vst1q_s64(dst + oneRegElemCount, vec2);
+    src += twoRegsElemCount;
+    dst += twoRegsElemCount;
+  }
+  if (remainder > 0) {
+    svbool_t pa = svwhilelt_b64_u64(0, remainder);
+    svbool_t pb = svwhilelt_b64_u64(oneRegElemCount, remainder);
+    auto vec1 = svld1sw_s64(pa, src);
+    auto vec2 = svld1sw_s64(pb, src + oneRegElemCount);
+    svst1_s64(pa, dst, vec1);
+    svst1_s64(pb, dst + oneRegElemCount, vec2);
+  }
+}
+
+template <>
+inline void convert(const int64_t* src, float* dst, int64_t n) {
+  constexpr uint64_t oneRegElemCount = Vectorized<int64_t>::size();
+  constexpr uint64_t twoRegsElemCount = oneRegElemCount * 2;
+  constexpr uint64_t fourRegsElemCount = twoRegsElemCount * 2;
+  const uint64_t count = static_cast<uint64_t>(n);
+  int32_t* dstPtr = reinterpret_cast<int32_t*>(dst);
+  for (uint64_t iters = count / fourRegsElemCount; iters > 0; --iters) {
+    auto vec1 = vld1q_s64(src);
+    auto vec2 = vld1q_s64(src + oneRegElemCount);
+    auto vec3 = vld1q_s64(src + twoRegsElemCount);
+    auto vec4 = vld1q_s64(src + (twoRegsElemCount + oneRegElemCount));
+    auto convertedVec1 = svcvt_f32_s64_x(ptrue, svset_neonq(svundef_s64(), vec1));
+    auto convertedVec2 = svcvt_f32_s64_x(ptrue, svset_neonq(svundef_s64(), vec2));
+    auto convertedVec3 = svcvt_f32_s64_x(ptrue, svset_neonq(svundef_s64(), vec3));
+    auto convertedVec4 = svcvt_f32_s64_x(ptrue, svset_neonq(svundef_s64(), vec4));
+    svst1w_s64(ptrue, dstPtr, svreinterpret_s64_f32(convertedVec1));
+    svst1w_s64(ptrue, dstPtr + oneRegElemCount, svreinterpret_s64_f32(convertedVec2));
+    svst1w_s64(ptrue, dstPtr + twoRegsElemCount, svreinterpret_s64_f32(convertedVec3));
+    svst1w_s64(ptrue, dstPtr + (twoRegsElemCount + oneRegElemCount), svreinterpret_s64_f32(convertedVec4));
+    src += fourRegsElemCount;
+    dstPtr += fourRegsElemCount;
+  }
+  dst = reinterpret_cast<float*>(dstPtr);
+#pragma clang loop vectorize(disable)
+#pragma clang loop unroll(disable)
+  for (uint64_t remainder = count % fourRegsElemCount; remainder > 0; --remainder) {
+    *dst = *src;
+    src += 1;
+    dst += 1;
+  }
+}
+
+template <>
+inline void convert(const int32_t* src, float* dst, int64_t n) {
+  constexpr uint64_t oneRegElemCount = Vectorized<int32_t>::size();
+  constexpr uint64_t twoRegsElemCount = oneRegElemCount * 2;
+  constexpr uint64_t fourRegsElemCount = twoRegsElemCount * 2;
+  const uint64_t count = static_cast<uint64_t>(n);
+  for (uint64_t iters = count / fourRegsElemCount; iters > 0; --iters) {
+    auto vec1 = vld1q_s32(src);
+    auto vec2 = vld1q_s32(src + oneRegElemCount);
+    auto vec3 = vld1q_s32(src + twoRegsElemCount);
+    auto vec4 = vld1q_s32(src + (twoRegsElemCount + oneRegElemCount));
+    auto convertedVec1 = vcvtq_f32_s32(vec1);
+    auto convertedVec2 = vcvtq_f32_s32(vec2);
+    auto convertedVec3 = vcvtq_f32_s32(vec3);
+    auto convertedVec4 = vcvtq_f32_s32(vec4);
+    vst1q_f32(dst, convertedVec1);
+    vst1q_f32(dst + oneRegElemCount, convertedVec2);
+    vst1q_f32(dst + twoRegsElemCount, convertedVec3);
+    vst1q_f32(dst + (twoRegsElemCount + oneRegElemCount), convertedVec4);
+    src += fourRegsElemCount;
+    dst += fourRegsElemCount;
+  }
+#pragma clang loop vectorize(disable)
+#pragma clang loop unroll(disable)
+  for (uint64_t remainder = count % fourRegsElemCount; remainder > 0; --remainder) {
+    *dst = *src;
+    src += 1;
+    dst += 1;
+  }
+}
+
+template <>
+inline void convert(const int32_t* src, double* dst, int64_t n) {
+  constexpr uint64_t oneRegElemCount = Vectorized<int64_t>::size();
+  constexpr uint64_t twoRegsElemCount = oneRegElemCount * 2;
+  constexpr uint64_t fourRegsElemCount = twoRegsElemCount * 2;
+  const uint64_t count = static_cast<uint64_t>(n);
+  for (uint64_t iters = count / fourRegsElemCount; iters > 0; --iters) {
+    auto vec1 = svld1sw_s64(ptrue, src);
+    auto vec2 = svld1sw_s64(ptrue, src + oneRegElemCount);
+    auto vec3 = svld1sw_s64(ptrue, src + twoRegsElemCount);
+    auto vec4 = svld1sw_s64(ptrue, src + (twoRegsElemCount + oneRegElemCount));
+    auto convertedVec1 = vcvtq_f64_s64(svget_neonq(vec1));
+    auto convertedVec2 = vcvtq_f64_s64(svget_neonq(vec2));
+    auto convertedVec3 = vcvtq_f64_s64(svget_neonq(vec3));
+    auto convertedVec4 = vcvtq_f64_s64(svget_neonq(vec4));
+    vst1q_f64(dst, convertedVec1);
+    vst1q_f64(dst + oneRegElemCount, convertedVec2);
+    vst1q_f64(dst + twoRegsElemCount, convertedVec3);
+    vst1q_f64(dst + (twoRegsElemCount + oneRegElemCount), convertedVec4);
+    src += fourRegsElemCount;
+    dst += fourRegsElemCount;
+  }
+#pragma clang loop vectorize(disable)
+#pragma clang loop unroll(disable)
+  for (uint64_t remainder = count % fourRegsElemCount; remainder > 0; --remainder) {
+    *dst = *src;
+    src += 1;
+    dst += 1;
+  }
+}
+
+template <>
+inline void convert(const bool* src, int64_t* dst, int64_t n) {
+  constexpr uint64_t oneRegElemCount = Vectorized<int64_t>::size();
+  constexpr uint64_t twoRegsElemCount = oneRegElemCount * 2;
+  const uint64_t count = static_cast<uint64_t>(n);
+  const uint64_t remainder = count % twoRegsElemCount;
+  const uint8_t* srcPtr = reinterpret_cast<const uint8_t*>(src);
+  for (uint64_t iters = count / twoRegsElemCount; iters > 0; --iters) {
+    auto vec1 = svget_neonq(svld1ub_s64(svptrue_b8(), srcPtr));
+    auto vec2 = svget_neonq(svld1ub_s64(svptrue_b8(), srcPtr + oneRegElemCount));
+    auto vec1Mask = vtstq_s64(vec1, vec1);
+    auto vec2Mask = vtstq_s64(vec2, vec2);
+    vec1Mask = svget_neonq(svand_n_s64_x(svptrue_b8(), svset_neonq(svundef_s64(), vec1Mask), 1));
+    vec2Mask = svget_neonq(svand_n_s64_x(svptrue_b8(), svset_neonq(svundef_s64(), vec2Mask), 1));
+    vst1q_s64(dst, vec1Mask);
+    vst1q_s64(dst + oneRegElemCount, vec2Mask);
+    srcPtr += twoRegsElemCount;
+    dst += twoRegsElemCount;
+  }
+  if (remainder > 0) {
+    svbool_t pa = svwhilelt_b64_u64(0, remainder);
+    svbool_t pb = svwhilelt_b64_u64(oneRegElemCount, remainder);
+    auto vec1 = svget_neonq(svld1ub_s64(pa, srcPtr));
+    auto vec2 = svget_neonq(svld1ub_s64(pb, srcPtr + oneRegElemCount));
+    auto vec1Mask = vtstq_s64(vec1, vec1);
+    auto vec2Mask = vtstq_s64(vec2, vec2);
+    auto vec1MaskSv = svand_n_s64_x(svptrue_b8(), svset_neonq(svundef_s64(), vec1Mask), 1);
+    auto vec2MaskSv = svand_n_s64_x(svptrue_b8(), svset_neonq(svundef_s64(), vec2Mask), 1);
+    svst1_s64(pa, dst, vec1MaskSv);
+    svst1_s64(pb, dst + oneRegElemCount, vec2MaskSv);
+  }
+}
+
+template <>
+inline void convert(const bool* src, int32_t* dst, int64_t n) {
+  constexpr uint64_t oneRegElemCount = Vectorized<int32_t>::size();
+  constexpr uint64_t twoRegsElemCount = oneRegElemCount * 2;
+  const uint64_t count = static_cast<uint64_t>(n);
+  const uint64_t remainder = count % twoRegsElemCount;
+  const uint8_t* srcPtr = reinterpret_cast<const uint8_t*>(src);
+  for (uint64_t iters = count / twoRegsElemCount; iters > 0; --iters) {
+    auto vec1 = svget_neonq(svld1ub_s32(svptrue_b8(), srcPtr));
+    auto vec2 = svget_neonq(svld1ub_s32(svptrue_b8(), srcPtr + oneRegElemCount));
+    auto vec1Mask = vtstq_s32(vec1, vec1);
+    auto vec2Mask = vtstq_s32(vec2, vec2);
+    vec1Mask = svget_neonq(svand_n_s32_x(svptrue_b8(), svset_neonq(svundef_s32(), vec1Mask), 1));
+    vec2Mask = svget_neonq(svand_n_s32_x(svptrue_b8(), svset_neonq(svundef_s32(), vec2Mask), 1));
+    vst1q_s32(dst, vec1Mask);
+    vst1q_s32(dst + oneRegElemCount, vec2Mask);
+    srcPtr += twoRegsElemCount;
+    dst += twoRegsElemCount;
+  }
+  if (remainder > 0) {
+    svbool_t pa = svwhilelt_b32_u64(0, remainder);
+    svbool_t pb = svwhilelt_b32_u64(oneRegElemCount, remainder);
+    auto vec1 = svget_neonq(svld1ub_s32(pa, srcPtr));
+    auto vec2 = svget_neonq(svld1ub_s32(pb, srcPtr + oneRegElemCount));
+    auto vec1Mask = vtstq_s32(vec1, vec1);
+    auto vec2Mask = vtstq_s32(vec2, vec2);
+    auto vec1MaskSv = svand_n_s32_x(pa, svset_neonq(svundef_s32(), vec1Mask), 1);
+    auto vec2MaskSv = svand_n_s32_x(pb, svset_neonq(svundef_s32(), vec2Mask), 1);
+    svst1_s32(pa, dst, vec1MaskSv);
+    svst1_s32(pb, dst + oneRegElemCount, vec2MaskSv);
+  }
+}
+
+template <>
+inline void convert(const uint8_t* src, bool* dst, int64_t n) {
+  constexpr uint64_t oneRegElemCount = Vectorized<uint8_t>::size();
+  constexpr uint64_t twoRegsElemCount = oneRegElemCount * 2;
+  constexpr uint64_t fourRegsElemCount = twoRegsElemCount * 2;
+  const uint64_t count = static_cast<uint64_t>(n);
+  uint8_t* dstPtr = reinterpret_cast<uint8_t*>(dst);
+  const uint64_t remainder = count % fourRegsElemCount;
+  for (uint64_t iters = count / fourRegsElemCount; iters > 0; --iters) {
+    auto vec1 = vld1q_u8(src);
+    auto vec2 = vld1q_u8(src + oneRegElemCount);
+    auto vec3 = vld1q_u8(src + twoRegsElemCount);
+    auto vec4 = vld1q_u8(src + (twoRegsElemCount + oneRegElemCount));
+    auto vec1Mask = vtstq_u8(vec1, vec1);
+    auto vec2Mask = vtstq_u8(vec2, vec2);
+    auto vec3Mask = vtstq_u8(vec3, vec3);
+    auto vec4Mask = vtstq_u8(vec4, vec4);
+    vst1q_u8(dstPtr, vec1Mask);
+    vst1q_u8(dstPtr + oneRegElemCount, vec2Mask);
+    vst1q_u8(dstPtr + twoRegsElemCount, vec3Mask);
+    vst1q_u8(dstPtr + (twoRegsElemCount + oneRegElemCount), vec4Mask);
+    src += fourRegsElemCount;
+    dstPtr += fourRegsElemCount;
+  }
+  if (remainder > 0) {
+    svbool_t pa = svwhilelt_b8_u64(0, remainder);
+    svbool_t pb = svwhilelt_b8_u64(oneRegElemCount, remainder);
+    svbool_t pc = svwhilelt_b8_u64(twoRegsElemCount, remainder);
+    svbool_t pd = svwhilelt_b8_u64((twoRegsElemCount + oneRegElemCount), remainder);
+    auto vec1 = svget_neonq(svld1_u8(pa, src));
+    auto vec2 = svget_neonq(svld1_u8(pb, src + oneRegElemCount));
+    auto vec3 = svget_neonq(svld1_u8(pc, src + twoRegsElemCount));
+    auto vec4 = svget_neonq(svld1_u8(pd, src + (twoRegsElemCount + oneRegElemCount)));
+    auto vec1Mask = vtstq_u8(vec1, vec1);
+    auto vec2Mask = vtstq_u8(vec2, vec2);
+    auto vec3Mask = vtstq_u8(vec3, vec3);
+    auto vec4Mask = vtstq_u8(vec4, vec4);
+    svst1_u8(pa, dstPtr, svset_neonq(svundef_u8(), vec1Mask));
+    svst1_u8(pb, dstPtr + oneRegElemCount, svset_neonq(svundef_u8(), vec2Mask));
+    svst1_u8(pc, dstPtr + twoRegsElemCount, svset_neonq(svundef_u8(), vec3Mask));
+    svst1_u8(pd, dstPtr + (twoRegsElemCount + oneRegElemCount), svset_neonq(svundef_u8(), vec4Mask));
+  }
+}
+
+template <>
+Vectorized<int64_t> inline operator<<(
+    const Vectorized<int64_t>& a,
+    const Vectorized<int64_t>& b) {
+  return vshlq_s64(a, b);
+}
+
+template <>
+Vectorized<int32_t> inline operator<<(
+    const Vectorized<int32_t>& a,
+    const Vectorized<int32_t>& b) {
+  return vshlq_s32(a, b);
+}
+
+template <>
+Vectorized<int16_t> inline operator<<(
+    const Vectorized<int16_t>& a,
+    const Vectorized<int16_t>& b) {
+  return vshlq_s16(a, b);
+}
+
+template <>
+Vectorized<int8_t> inline operator<<(
+    const Vectorized<int8_t>& a,
+    const Vectorized<int8_t>& b) {
+  return vshlq_s8(a, b);
+}
+
+template <>
+Vectorized<int64_t> inline operator>>(
+    const Vectorized<int64_t>& a,
+    const Vectorized<int64_t>& b) {
+  return svasr_s64_x(ptrue, a, svreinterpret_u64_s64(b));
+}
+
+template <>
+Vectorized<int32_t> inline operator>>(
+    const Vectorized<int32_t>& a,
+    const Vectorized<int32_t>& b) {
+  return svasr_s32_x(ptrue, a, svreinterpret_u32_s32(b));
+}
+
+template <>
+Vectorized<int16_t> inline operator>>(
+    const Vectorized<int16_t>& a,
+    const Vectorized<int16_t>& b) {
+  return svasr_s16_x(ptrue, a, svreinterpret_u16_s16(b));
+}
+
+template <>
+Vectorized<int8_t> inline operator>>(
+    const Vectorized<int8_t>& a,
+    const Vectorized<int8_t>& b) {
+  return svasr_s8_x(ptrue, a, svreinterpret_u8_s8(b));
+}
+
+#endif // defined(CPU_CAPABILITY_SVE)
+
+} // namespace CPU_CAPABILITY
+} // namespace at::vec

--- a/aten/src/ATen/cpu/vec/vec128/vec128_int_sve.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_int_sve.h
@@ -770,7 +770,7 @@ inline void convert(const bool* src, int32_t* dst, int64_t n) {
 
 template <>
 inline void convert(const uint8_t* src, bool* dst, int64_t n) {
-  constexpr uint64_t oneRegElemCount = Vectorized<uint8_t>::size();
+  constexpr uint64_t oneRegElemCount = Vectorized<int8_t>::size();
   constexpr uint64_t twoRegsElemCount = oneRegElemCount * 2;
   constexpr uint64_t fourRegsElemCount = twoRegsElemCount * 2;
   const uint64_t count = static_cast<uint64_t>(n);

--- a/aten/src/ATen/cpu/vec/vec128/vec128_reduced_precision_common_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_reduced_precision_common_neon.h
@@ -92,6 +92,8 @@ struct Vectorized16 {
     return fmadd(step_sizes, step_vec, base_vec);
   }
 
+#ifndef CPU_CAPABILITY_SVE128
+
   // Very slow implementation of indexing.
   // Only required because vec256_qint refers to this.
   // Once we specialize that implementation for ARM
@@ -114,13 +116,14 @@ struct Vectorized16 {
     return mask;
   }
 
+  #endif
+
   Derived map(value_type (*const f)(value_type)) const {
-    __at_align__ value_type tmp[size()];
-    static_cast<const Derived*>(this)->store(tmp);
+    VecT result;
     for (const auto i : c10::irange(size())) {
-      tmp[i] = f(tmp[i]);
+      result[i] = f(values[i]);
     }
-    return Derived::loadu(tmp);
+    return result;
   }
 
   Derived angle() const {

--- a/aten/src/ATen/cpu/vec/vec128/vec128_transpose.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_transpose.h
@@ -1,0 +1,588 @@
+#pragma once
+
+#ifdef __aarch64__
+
+#include <arm_neon.h>
+#include <cstdint>
+
+namespace at::vec {
+inline namespace CPU_CAPABILITY {
+
+static inline void transpose_kernel_8x8_neon(
+    const float* src,
+    int64_t ld_src,
+    float* dst,
+    int64_t ld_dst) {
+  float32x4_t q0 = vld1q_f32(src);
+  float32x4_t q1 = vld1q_f32(src + 4);
+  src += ld_src;
+  float32x4_t q2 = vld1q_f32(src);
+  float32x4_t q3 = vld1q_f32(src + 4);
+  src += ld_src;
+  float32x4_t q4 = vld1q_f32(src);
+  float32x4_t q5 = vld1q_f32(src + 4);
+  src += ld_src;
+  float32x4_t q6 = vld1q_f32(src);
+  float32x4_t q7 = vld1q_f32(src + 4);
+  src += ld_src;
+  float32x4_t q16 = vld1q_f32(src);
+  float32x4_t q17 = vld1q_f32(src + 4);
+  src += ld_src;
+  float32x4_t q18 = vld1q_f32(src);
+  float32x4_t q19 = vld1q_f32(src + 4);
+  src += ld_src;
+  float32x4_t q20 = vld1q_f32(src);
+  float32x4_t q21 = vld1q_f32(src + 4);
+  src += ld_src;
+  float32x4_t q22 = vld1q_f32(src);
+  float32x4_t q23 = vld1q_f32(src + 4);
+
+  float32x4_t v24 = vzip1q_f32(q0, q2);
+  float32x4_t v25 = vzip1q_f32(q4, q6);
+  float32x4_t v26 = vzip1q_f32(q16, q18);
+  float32x4_t v27 = vzip1q_f32(q20, q22);
+
+  float64x2_t v28 = vzip1q_f64(vreinterpretq_f64_f32(v24), vreinterpretq_f64_f32(v25));
+  float64x2_t v29 = vzip1q_f64(vreinterpretq_f64_f32(v26), vreinterpretq_f64_f32(v27));
+
+  vst1q_f32(dst, vreinterpretq_f32_f64(v28));
+  vst1q_f32(dst + 4, vreinterpretq_f32_f64(v29));
+  dst += ld_dst;
+
+  float64x2_t v30 = vzip2q_f64(vreinterpretq_f64_f32(v24), vreinterpretq_f64_f32(v25));
+  float64x2_t v31 = vzip2q_f64(vreinterpretq_f64_f32(v26), vreinterpretq_f64_f32(v27));
+
+  vst1q_f32(dst, vreinterpretq_f32_f64(v30));
+  vst1q_f32(dst + 4, vreinterpretq_f32_f64(v31));
+  dst += ld_dst;
+
+  v24 = vzip2q_f32(q0, q2);
+  v25 = vzip2q_f32(q4, q6);
+  v26 = vzip2q_f32(q16, q18);
+  v27 = vzip2q_f32(q20, q22);
+
+  v28 = vzip1q_f64(vreinterpretq_f64_f32(v24), vreinterpretq_f64_f32(v25));
+  v29 = vzip1q_f64(vreinterpretq_f64_f32(v26), vreinterpretq_f64_f32(v27));
+
+  vst1q_f32(dst, vreinterpretq_f32_f64(v28));
+  vst1q_f32(dst + 4, vreinterpretq_f32_f64(v29));
+  dst += ld_dst;
+
+  v30 = vzip2q_f64(vreinterpretq_f64_f32(v24), vreinterpretq_f64_f32(v25));
+  v31 = vzip2q_f64(vreinterpretq_f64_f32(v26), vreinterpretq_f64_f32(v27));
+
+  vst1q_f32(dst, vreinterpretq_f32_f64(v30));
+  vst1q_f32(dst + 4, vreinterpretq_f32_f64(v31));
+  dst += ld_dst;
+
+  v24 = vzip1q_f32(q1, q3);
+  v25 = vzip1q_f32(q5, q7);
+  v26 = vzip1q_f32(q17, q19);
+  v27 = vzip1q_f32(q21, q23);
+
+  v28 = vzip1q_f64(vreinterpretq_f64_f32(v24), vreinterpretq_f64_f32(v25));
+  v29 = vzip1q_f64(vreinterpretq_f64_f32(v26), vreinterpretq_f64_f32(v27));
+
+  vst1q_f32(dst, vreinterpretq_f32_f64(v28));
+  vst1q_f32(dst + 4, vreinterpretq_f32_f64(v29));
+  dst += ld_dst;
+
+  v30 = vzip2q_f64(vreinterpretq_f64_f32(v24), vreinterpretq_f64_f32(v25));
+  v31 = vzip2q_f64(vreinterpretq_f64_f32(v26), vreinterpretq_f64_f32(v27));
+
+  vst1q_f32(dst, vreinterpretq_f32_f64(v30));
+  vst1q_f32(dst + 4, vreinterpretq_f32_f64(v31));
+  dst += ld_dst;
+
+  v24 = vzip2q_f32(q1, q3);
+  v25 = vzip2q_f32(q5, q7);
+  v26 = vzip2q_f32(q17, q19);
+  v27 = vzip2q_f32(q21, q23);
+
+  v28 = vzip1q_f64(vreinterpretq_f64_f32(v24), vreinterpretq_f64_f32(v25));
+  v29 = vzip1q_f64(vreinterpretq_f64_f32(v26), vreinterpretq_f64_f32(v27));
+
+  vst1q_f32(dst, vreinterpretq_f32_f64(v28));
+  vst1q_f32(dst + 4, vreinterpretq_f32_f64(v29));
+  dst += ld_dst;
+
+  v30 = vzip2q_f64(vreinterpretq_f64_f32(v24), vreinterpretq_f64_f32(v25));
+  v31 = vzip2q_f64(vreinterpretq_f64_f32(v26), vreinterpretq_f64_f32(v27));
+
+  vst1q_f32(dst, vreinterpretq_f32_f64(v30));
+  vst1q_f32(dst + 4, vreinterpretq_f32_f64(v31));
+}
+
+static inline void transpose_kernel_8x4_neon(
+    const float* src,
+    int64_t ld_src,
+    float* dst,
+    int64_t ld_dst) {
+  float32x4_t q0 = vld1q_f32(src);
+  src += ld_src;
+  float32x4_t q1 = vld1q_f32(src);
+  src += ld_src;
+  float32x4_t q2 = vld1q_f32(src);
+  src += ld_src;
+  float32x4_t q3 = vld1q_f32(src);
+  src += ld_src;
+  float32x4_t q4 = vld1q_f32(src);
+  src += ld_src;
+  float32x4_t q5 = vld1q_f32(src);
+  src += ld_src;
+  float32x4_t q6 = vld1q_f32(src);
+  src += ld_src;
+  float32x4_t q7 = vld1q_f32(src);
+
+  float32x4_t v16 = vzip1q_f32(q0, q1);
+  float32x4_t v17 = vzip1q_f32(q2, q3);
+  float32x4_t v18 = vzip1q_f32(q4, q5);
+  float32x4_t v19 = vzip1q_f32(q6, q7);
+
+  float64x2_t v20 = vzip1q_f64(vreinterpretq_f64_f32(v16), vreinterpretq_f64_f32(v17));
+  float64x2_t v21 = vzip1q_f64(vreinterpretq_f64_f32(v18), vreinterpretq_f64_f32(v19));
+
+  vst1q_f32(dst, vreinterpretq_f32_f64(v20));
+  vst1q_f32(dst + 4, vreinterpretq_f32_f64(v21));
+  dst += ld_dst;
+
+  float64x2_t v22 = vzip2q_f64(vreinterpretq_f64_f32(v16), vreinterpretq_f64_f32(v17));
+  float64x2_t v23 = vzip2q_f64(vreinterpretq_f64_f32(v18), vreinterpretq_f64_f32(v19));
+
+  vst1q_f32(dst, vreinterpretq_f32_f64(v22));
+  vst1q_f32(dst + 4, vreinterpretq_f32_f64(v23));
+  dst += ld_dst;
+
+  float32x4_t v24 = vzip2q_f32(q0, q1);
+  float32x4_t v25 = vzip2q_f32(q2, q3);
+  float32x4_t v26 = vzip2q_f32(q4, q5);
+  float32x4_t v27 = vzip2q_f32(q6, q7);
+
+  float64x2_t v28 = vzip1q_f64(vreinterpretq_f64_f32(v24), vreinterpretq_f64_f32(v25));
+  float64x2_t v29 = vzip1q_f64(vreinterpretq_f64_f32(v26), vreinterpretq_f64_f32(v27));
+
+  vst1q_f32(dst, vreinterpretq_f32_f64(v28));
+  vst1q_f32(dst + 4, vreinterpretq_f32_f64(v29));
+  dst += ld_dst;
+
+  float64x2_t v30 = vzip2q_f64(vreinterpretq_f64_f32(v24), vreinterpretq_f64_f32(v25));
+  float64x2_t v31 = vzip2q_f64(vreinterpretq_f64_f32(v26), vreinterpretq_f64_f32(v27));
+
+  vst1q_f32(dst, vreinterpretq_f32_f64(v30));
+  vst1q_f32(dst + 4, vreinterpretq_f32_f64(v31));
+}
+
+static inline void transpose_kernel_8x2_neon(
+    const float* src,
+    int64_t ld_src,
+    float* dst,
+    int64_t ld_dst) {
+  float32x2_t q0 = vld1_f32(src);
+  src += ld_src;
+  float32x2_t q1 = vld1_f32(src);
+  src += ld_src;
+  float32x2_t q2 = vld1_f32(src);
+  src += ld_src;
+  float32x2_t q3 = vld1_f32(src);
+  src += ld_src;
+  float32x2_t q4 = vld1_f32(src);
+  src += ld_src;
+  float32x2_t q5 = vld1_f32(src);
+  src += ld_src;
+  float32x2_t q6 = vld1_f32(src);
+  src += ld_src;
+  float32x2_t q7 = vld1_f32(src);
+
+  float32x2_t v16 = vzip1_f32(q0, q1);
+  float32x2_t v17 = vzip1_f32(q2, q3);
+  float32x2_t v18 = vzip1_f32(q4, q5);
+  float32x2_t v19 = vzip1_f32(q6, q7);
+
+  float32x4_t q16;
+  q16[0] = v16[0];
+  q16[1] = v16[1];
+  float32x4_t q17;
+  q17[0] = v17[0];
+  q17[1] = v17[1];
+  float32x4_t q18;
+  q18[0] = v18[0];
+  q18[1] = v18[1];
+  float32x4_t q19;
+  q19[0] = v19[0];
+  q19[1] = v19[1];
+
+  float64x2_t v20 = vzip1q_f64(vreinterpretq_f64_f32(q16), vreinterpretq_f64_f32(q17));
+  float64x2_t v21 = vzip1q_f64(vreinterpretq_f64_f32(q18), vreinterpretq_f64_f32(q19));
+
+  vst1q_f32(dst, vreinterpretq_f32_f64(v20));
+  vst1q_f32(dst + 4, vreinterpretq_f32_f64(v21));
+  dst += ld_dst;
+
+  float32x2_t v22 = vzip2_f32(q0, q1);
+  float32x2_t v23 = vzip2_f32(q2, q3);
+  float32x2_t v24 = vzip2_f32(q4, q5);
+  float32x2_t v25 = vzip2_f32(q6, q7);
+
+  float32x4_t q22;
+  q22[0] = v22[0];
+  q22[1] = v22[1];
+  float32x4_t q23;
+  q23[0] = v23[0];
+  q23[1] = v23[1];
+  float32x4_t q24;
+  q24[0] = v24[0];
+  q24[1] = v24[1];
+  float32x4_t q25;
+  q25[0] = v25[0];
+  q25[1] = v25[1];
+
+  float64x2_t v26 = vzip1q_f64(vreinterpretq_f64_f32(q22), vreinterpretq_f64_f32(q23));
+  float64x2_t v27 = vzip1q_f64(vreinterpretq_f64_f32(q24), vreinterpretq_f64_f32(q25));
+
+  vst1q_f32(dst, vreinterpretq_f32_f64(v26));
+  vst1q_f32(dst + 4, vreinterpretq_f32_f64(v27));
+}
+
+static inline void transpose_kernel_4x8_neon(
+    const float* src,
+    int64_t ld_src,
+    float* dst,
+    int64_t ld_dst) {
+  float32x4_t q0 = vld1q_f32(src);
+  float32x4_t q1 = vld1q_f32(src + 4);
+  src += ld_src;
+  float32x4_t q2 = vld1q_f32(src);
+  float32x4_t q3 = vld1q_f32(src + 4);
+  src += ld_src;
+  float32x4_t q4 = vld1q_f32(src);
+  float32x4_t q5 = vld1q_f32(src + 4);
+  src += ld_src;
+  float32x4_t q6 = vld1q_f32(src);
+  float32x4_t q7 = vld1q_f32(src + 4);
+
+  float32x4_t v16 = vzip1q_f32(q0, q2);
+  float32x4_t v17 = vzip1q_f32(q4, q6);
+
+  float64x2_t v18 = vzip1q_f64(vreinterpretq_f64_f32(v16), vreinterpretq_f64_f32(v17));
+
+  vst1q_f32(dst, vreinterpretq_f32_f64(v18));
+  dst += ld_dst;
+
+  float64x2_t v19 = vzip2q_f64(vreinterpretq_f64_f32(v16), vreinterpretq_f64_f32(v17));
+
+  vst1q_f32(dst, vreinterpretq_f32_f64(v19));
+  dst += ld_dst;
+
+  float32x4_t v20 = vzip2q_f32(q0, q2);
+  float32x4_t v21 = vzip2q_f32(q4, q6);
+
+  float64x2_t v22 = vzip1q_f64(vreinterpretq_f64_f32(v20), vreinterpretq_f64_f32(v21));
+
+  vst1q_f32(dst, vreinterpretq_f32_f64(v22));
+  dst += ld_dst;
+
+  float64x2_t v23 = vzip2q_f64(vreinterpretq_f64_f32(v20), vreinterpretq_f64_f32(v21));
+
+  vst1q_f32(dst, vreinterpretq_f32_f64(v23));
+  dst += ld_dst;
+
+  float32x4_t v24 = vzip1q_f32(q1, q3);
+  float32x4_t v25 = vzip1q_f32(q5, q7);
+
+  float64x2_t v26 = vzip1q_f64(vreinterpretq_f64_f32(v24), vreinterpretq_f64_f32(v25));
+
+  vst1q_f32(dst, vreinterpretq_f32_f64(v26));
+  dst += ld_dst;
+
+  float64x2_t v27 = vzip2q_f64(vreinterpretq_f64_f32(v24), vreinterpretq_f64_f32(v25));
+
+  vst1q_f32(dst, vreinterpretq_f32_f64(v27));
+  dst += ld_dst;
+
+  float32x4_t v28 = vzip2q_f32(q1, q3);
+  float32x4_t v29 = vzip2q_f32(q5, q7);
+
+  float64x2_t v30 = vzip1q_f64(vreinterpretq_f64_f32(v28), vreinterpretq_f64_f32(v29));
+
+  vst1q_f32(dst, vreinterpretq_f32_f64(v30));
+  dst += ld_dst;
+
+  float64x2_t v31 = vzip2q_f64(vreinterpretq_f64_f32(v28), vreinterpretq_f64_f32(v29));
+
+  vst1q_f32(dst, vreinterpretq_f32_f64(v31));
+}
+
+static inline void transpose_kernel_4x4_neon(
+    const float* src,
+    int64_t ld_src,
+    float* dst,
+    int64_t ld_dst) {
+  float32x4_t q0 = vld1q_f32(src);
+  src += ld_src;
+  float32x4_t q1 = vld1q_f32(src);
+  src += ld_src;
+  float32x4_t q2 = vld1q_f32(src);
+  src += ld_src;
+  float32x4_t q3 = vld1q_f32(src);
+
+  float32x4_t v4 = vzip1q_f32(q0, q1);
+  float32x4_t v5 = vzip1q_f32(q2, q3);
+
+  float64x2_t v6 = vzip1q_f64(vreinterpretq_f64_f32(v4), vreinterpretq_f64_f32(v5));
+
+  vst1q_f32(dst, vreinterpretq_f32_f64(v6));
+  dst += ld_dst;
+
+  float64x2_t v7 = vzip2q_f64(vreinterpretq_f64_f32(v4), vreinterpretq_f64_f32(v5));
+
+  vst1q_f32(dst, vreinterpretq_f32_f64(v7));
+  dst += ld_dst;
+
+  float32x4_t v8 = vzip2q_f32(q0, q1);
+  float32x4_t v9 = vzip2q_f32(q2, q3);
+
+  float64x2_t v10 = vzip1q_f64(vreinterpretq_f64_f32(v8), vreinterpretq_f64_f32(v9));
+
+  vst1q_f32(dst, vreinterpretq_f32_f64(v10));
+  dst += ld_dst;
+
+  float64x2_t v11 = vzip2q_f64(vreinterpretq_f64_f32(v8), vreinterpretq_f64_f32(v9));
+
+  vst1q_f32(dst, vreinterpretq_f32_f64(v11));
+}
+
+static inline void transpose_kernel_4x2_neon(
+    const float* src,
+    int64_t ld_src,
+    float* dst,
+    int64_t ld_dst) {
+  float32x2_t d0 = vld1_f32(src);
+  src += ld_src;
+  float32x2_t d1 = vld1_f32(src);
+  src += ld_src;
+  float32x2_t d2 = vld1_f32(src);
+  src += ld_src;
+  float32x2_t d3 = vld1_f32(src);
+
+  float32x2_t v4 = vzip1_f32(d0, d1);
+  float32x2_t v5 = vzip1_f32(d2, d3);
+
+  float32x4_t q4;
+  q4[0] = v4[0];
+  q4[1] = v4[1];
+  float32x4_t q5;
+  q5[0] = v5[0];
+  q5[1] = v5[1];
+
+  float64x2_t v6 = vzip1q_f64(vreinterpretq_f64_f32(q4), vreinterpretq_f64_f32(q5));
+
+  vst1q_f64(reinterpret_cast<double*>(dst), v6);
+  dst += ld_dst;
+
+  float32x2_t v7 = vzip2_f32(d0, d1);
+  float32x2_t v8 = vzip2_f32(d2, d3);
+
+  float32x4_t q7;
+  q7[0] = v7[0];
+  q7[1] = v7[1];
+  float32x4_t q8;
+  q8[0] = v8[0];
+  q8[1] = v8[1];
+
+  float64x2_t v9 = vzip1q_f64(vreinterpretq_f64_f32(q7), vreinterpretq_f64_f32(q8));
+
+  vst1q_f64(reinterpret_cast<double*>(dst), v9);
+}
+
+static inline void transpose_kernel_2x8_neon(
+    const float* src,
+    int64_t ld_src,
+    float* dst,
+    int64_t ld_dst) {
+  float32x4_t q0 = vld1q_f32(src);
+  float32x4_t q1 = vld1q_f32(src + 4);
+  src += ld_src;
+  float32x4_t q2 = vld1q_f32(src);
+  float32x4_t q3 = vld1q_f32(src + 4);
+
+  float32x4_t v4 = vzip1q_f32(q0, q2);
+
+  vst1q_lane_f64(reinterpret_cast<double*>(dst), vreinterpretq_f64_f32(v4), 0);
+  dst += ld_dst;
+
+  vst1q_lane_f64(reinterpret_cast<double*>(dst), vreinterpretq_f64_f32(v4), 1);
+  dst += ld_dst;
+
+  float32x4_t v5 = vzip2q_f32(q0, q2);
+
+  vst1q_lane_f64(reinterpret_cast<double*>(dst), vreinterpretq_f64_f32(v5), 0);
+  dst += ld_dst;
+
+  vst1q_lane_f64(reinterpret_cast<double*>(dst), vreinterpretq_f64_f32(v5), 1);
+  dst += ld_dst;
+
+  float32x4_t v6 = vzip1q_f32(q1, q3);
+
+  vst1q_lane_f64(reinterpret_cast<double*>(dst), vreinterpretq_f64_f32(v6), 0);
+  dst += ld_dst;
+
+  vst1q_lane_f64(reinterpret_cast<double*>(dst), vreinterpretq_f64_f32(v6), 1);
+  dst += ld_dst;
+
+  float32x4_t v7 = vzip2q_f32(q1, q3);
+
+  vst1q_lane_f64(reinterpret_cast<double*>(dst), vreinterpretq_f64_f32(v7), 0);
+  dst += ld_dst;
+
+  vst1q_lane_f64(reinterpret_cast<double*>(dst), vreinterpretq_f64_f32(v7), 1);
+}
+
+static inline void transpose_kernel_2x4_neon(
+    const float* src,
+    int64_t ld_src,
+    float* dst,
+    int64_t ld_dst) {
+
+  float32x4_t q0 = vld1q_f32(src);
+  src += ld_src;
+  float32x4_t q1 = vld1q_f32(src);
+
+  float32x4_t v3 = vzip1q_f32(q0, q1);
+
+  vst1q_lane_f64(reinterpret_cast<double*>(dst), vreinterpretq_f64_f32(v3), 0);
+  dst += ld_dst;
+
+  vst1q_lane_f64(reinterpret_cast<double*>(dst), vreinterpretq_f64_f32(v3), 1);
+  dst += ld_dst;
+
+  float32x4_t v4 = vzip2q_f32(q0, q1);
+
+  vst1q_lane_f64(reinterpret_cast<double*>(dst), vreinterpretq_f64_f32(v4), 0);
+  dst += ld_dst;
+
+  vst1q_lane_f64(reinterpret_cast<double*>(dst), vreinterpretq_f64_f32(v4), 1);
+}
+
+static inline void transpose_kernel_2x2_neon(
+    const float* src,
+    int64_t ld_src,
+    float* dst,
+    int64_t ld_dst) {
+  float32x2_t d0 = vld1_f32(src);
+  src += ld_src;
+  float32x2_t d1 = vld1_f32(src);
+
+  float32x4_t q0;
+  q0[0] = d0[0];
+  q0[1] = d0[1];
+
+  float32x4_t q1;
+  q1[0] = d1[0];
+  q1[1] = d1[1];
+
+  float32x4_t v3 = vzip1q_f32(q0, q1);
+
+  vst1q_lane_f64(reinterpret_cast<double*>(dst), vreinterpretq_f64_f32(v3), 0);
+  dst += ld_dst;
+
+  vst1q_lane_f64(reinterpret_cast<double*>(dst), vreinterpretq_f64_f32(v3), 1);
+}
+
+static inline void transpose_kernel_mx1(
+    const float* src,
+    int64_t ld_src,
+    float* dst,
+    const int64_t M) {
+  for (int64_t i = 0; i < M; ++i) {
+    dst[i] = src[i * ld_src];
+  }
+}
+
+inline void transpose_float_neon(
+    int64_t M,
+    int64_t N,
+    const float* src,
+    int64_t ld_src,
+    float* dst,
+    int64_t ld_dst) {
+  int64_t jb = 0;
+  while (jb + 7 < M) {
+    int64_t ib = 0;
+    while (ib + 7 < N) {
+      transpose_kernel_8x8_neon(
+          &src[ib + jb * ld_src], ld_src, &dst[jb + ib * ld_dst], ld_dst);
+      ib += 8;
+    }
+    while (ib + 3 < N) {
+      transpose_kernel_8x4_neon(
+          &src[ib + jb * ld_src], ld_src, &dst[jb + ib * ld_dst], ld_dst);
+      ib += 4;
+    }
+    while (ib + 1 < N) {
+      transpose_kernel_8x2_neon(
+          &src[ib + jb * ld_src], ld_src, &dst[jb + ib * ld_dst], ld_dst);
+      ib += 2;
+    }
+    if (ib < N) {
+      transpose_kernel_mx1(
+          &src[ib + jb * ld_src], ld_src, &dst[jb + ib * ld_dst], 8);
+    }
+    jb += 8;
+  }
+  while (jb + 3 < M) {
+    int64_t ib = 0;
+    while (ib + 7 < N) {
+      transpose_kernel_4x8_neon(
+          &src[ib + jb * ld_src], ld_src, &dst[jb + ib * ld_dst], ld_dst);
+      ib += 8;
+    }
+    while (ib + 3 < N) {
+      transpose_kernel_4x4_neon(
+          &src[ib + jb * ld_src], ld_src, &dst[jb + ib * ld_dst], ld_dst);
+      ib += 4;
+    }
+    while (ib + 1 < N) {
+      transpose_kernel_4x2_neon(
+          &src[ib + jb * ld_src], ld_src, &dst[jb + ib * ld_dst], ld_dst);
+      ib += 2;
+    }
+    if (ib < N) {
+      transpose_kernel_mx1(
+          &src[ib + jb * ld_src], ld_src, &dst[jb + ib * ld_dst], 4);
+    }
+    jb += 4;
+  }
+  while (jb + 1 < M) {
+    int64_t ib = 0;
+    while (ib + 7 < N) {
+      transpose_kernel_2x8_neon(
+          &src[ib + jb * ld_src], ld_src, &dst[jb + ib * ld_dst], ld_dst);
+      ib += 8;
+    }
+    while (ib + 3 < N) {
+      transpose_kernel_2x4_neon(
+          &src[ib + jb * ld_src], ld_src, &dst[jb + ib * ld_dst], ld_dst);
+      ib += 4;
+    }
+    while (ib + 1 < N) {
+      transpose_kernel_2x2_neon(
+          &src[ib + jb * ld_src], ld_src, &dst[jb + ib * ld_dst], ld_dst);
+      ib += 2;
+    }
+    if (ib < N) {
+      transpose_kernel_mx1(
+          &src[ib + jb * ld_src], ld_src, &dst[jb + ib * ld_dst], 2);
+    }
+    jb += 2;
+  }
+  if (jb < M) {
+    for (int64_t ib = 0; ib < N; ++ib) {
+      dst[jb + ib * ld_dst] = src[ib + jb * ld_src];
+    }
+  }
+}
+
+} // namespace CPU_CAPABILITY
+} // namespace at::vec
+
+#endif /* __aarch64__ */

--- a/aten/src/ATen/cpu/vec/vec128/vec128_uint_sve.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_uint_sve.h
@@ -1,0 +1,641 @@
+#pragma once
+
+#include <ATen/cpu/vec/intrinsics.h>
+#include <ATen/cpu/vec/sve/sve_helper.h>
+#include <ATen/cpu/vec/vec_base.h>
+#include <c10/macros/Macros.h>
+#include <c10/util/irange.h>
+
+namespace at::vec {
+// Note [CPU_CAPABILITY namespace]
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// This header, and all of its subheaders, will be compiled with
+// different architecture flags for each supported set of vector
+// intrinsics. So we need to make sure they aren't inadvertently
+// linked together. We do this by declaring objects in an `inline
+// namespace` which changes the name mangling, but can still be
+// accessed as `at::vec`.
+inline namespace CPU_CAPABILITY {
+
+#if defined(CPU_CAPABILITY_SVE)
+
+#define VEC_UINT_SVE_TEMPLATE(vl, bit)                                        \
+  template <>                                                                 \
+  struct is_vec_specialized_for<uint##bit##_t> : std::bool_constant<true> {}; \
+                                                                              \
+  template <>                                                                 \
+  class Vectorized<uint##bit##_t> {                                           \
+   using neon_type = uint##bit##x##vl##_t;                                    \
+   private:                                                                   \
+    neon_type values;                                                         \
+                                                                              \
+   public:                                                                    \
+    using value_type = uint##bit##_t;                                         \
+    using size_type = int;                                                    \
+    static constexpr size_type size() {                                       \
+      return vl;                                                              \
+    }                                                                         \
+    Vectorized() {                                                            \
+      values = vdupq_n_u##bit(0);                                             \
+    }                                                                         \
+    Vectorized(neon_type v) : values(v) {}                                    \
+    Vectorized(svuint##bit##_t v) : values(svget_neonq(v)) {}                 \
+    Vectorized(value_type val) {                                              \
+      values = svget_neonq(svdup_n_u##bit(val));                              \
+    }                                                                         \
+    template <                                                                \
+        typename... Args,                                                     \
+        typename = std::enable_if_t<(sizeof...(Args) == size())>>             \
+    Vectorized(Args... vals) {                                                \
+      __at_align__ value_type buffer[size()] = {vals...};                     \
+      values = vld1q_u##bit(buffer);                                          \
+    }                                                                         \
+    operator neon_type() const {                                              \
+      return values;                                                          \
+    }                                                                         \
+    operator svuint##bit##_t() const {                                        \
+      return svset_neonq(svundef_u##bit(), values);                           \
+    }                                                                         \
+    template <int64_t mask>                                                   \
+    static Vectorized<uint##bit##_t> blend(                                   \
+      const Vectorized<uint##bit##_t>& a,                                     \
+      const Vectorized<uint##bit##_t>& b);                                    \
+    static Vectorized<uint##bit##_t> blendv(                                  \
+        const Vectorized<uint##bit##_t>& a,                                   \
+        const Vectorized<uint##bit##_t>& b,                                   \
+        const Vectorized<uint##bit##_t>& mask_) {                             \
+      return vbslq_u##bit(mask_.values, b, a);                                \
+    }                                                                         \
+    template <typename step_t>                                                \
+    static Vectorized<uint##bit##_t> arange(                                  \
+        value_type base = 0,                                                  \
+        step_t step = static_cast<step_t>(1));                                \
+    static Vectorized<uint##bit##_t> set(                                     \
+        const Vectorized<uint##bit##_t>& a,                                   \
+        const Vectorized<uint##bit##_t>& b,                                   \
+        uint##bit##_t count = size()) {                                       \
+      if (count == 0) {                                                       \
+        return a;                                                             \
+      } else if (count < size()) {                                            \
+        return svsel_u##bit(svwhilelt_b##bit(0ull, count), b, a);             \
+      }                                                                       \
+      return b;                                                               \
+    }                                                                         \
+    static Vectorized<uint##bit##_t> loadu(                                   \
+        const void* ptr,                                                      \
+        int64_t count = size()) {                                             \
+      if (count == size())                                                    \
+        return vld1q_u##bit(reinterpret_cast<const uint##bit##_t*>(ptr));     \
+      svbool_t pg = svwhilelt_b##bit(0ull, count);                            \
+      return svld1_u##bit(pg, reinterpret_cast<const uint##bit##_t*>(ptr));   \
+    }                                                                         \
+    void store(void* ptr, int64_t count = size()) const {                     \
+      if (count == size()) {                                                  \
+        vst1q_u##bit(reinterpret_cast<uint##bit##_t*>(ptr), values);          \
+      } else {                                                                \
+        svbool_t pg = svwhilelt_b##bit(0ull, count);                          \
+        auto dstPtr = reinterpret_cast<uint##bit##_t*>(ptr);                  \
+        svst1_u##bit(pg, dstPtr, svset_neonq(svundef_u##bit(), values));      \
+      }                                                                       \
+    }                                                                         \
+    const uint##bit##_t& operator[](int idx) const = delete;                  \
+    uint##bit##_t& operator[](int idx) = delete;                              \
+    Vectorized<uint##bit##_t> abs() const {                                   \
+      return values;                                                          \
+    }                                                                         \
+    Vectorized<uint##bit##_t> real() const {                                  \
+      return values;                                                          \
+    }                                                                         \
+    Vectorized<uint##bit##_t> imag() const {                                  \
+      return vdupq_n_u##bit(0);                                               \
+    }                                                                         \
+    Vectorized<uint##bit##_t> conj() const {                                  \
+      return values;                                                          \
+    }                                                                         \
+    Vectorized<uint##bit##_t> neg() const {                                   \
+      return vreinterpretq_u##bit##_s##bit(                                   \
+        vnegq_s##bit(vreinterpretq_s##bit##_u##bit(values)));                 \
+    }                                                                         \
+    uint##bit##_t reduce_add() const {                                        \
+    return vaddvq_u##bit(values);                                             \
+    }                                                                         \
+    uint##bit##_t reduce_max() const;                                         \
+    Vectorized<uint##bit##_t> operator==(                                     \
+        const Vectorized<uint##bit##_t>& other) const {                       \
+      return Vectorized<value_type>(vceqq_u##bit(values, other.values));      \
+    }                                                                         \
+    Vectorized<uint##bit##_t> operator!=(                                     \
+        const Vectorized<uint##bit##_t>& other) const;                        \
+    Vectorized<uint##bit##_t> operator<(                                      \
+        const Vectorized<uint##bit##_t>& other) const {                       \
+      return Vectorized<value_type>(vcltq_u##bit(values, other.values));      \
+    }                                                                         \
+    Vectorized<uint##bit##_t> operator<=(                                     \
+        const Vectorized<uint##bit##_t>& other) const {                       \
+      return Vectorized<value_type>(vcleq_u##bit(values, other.values));      \
+    }                                                                         \
+    Vectorized<uint##bit##_t> operator>(                                      \
+        const Vectorized<uint##bit##_t>& other) const {                       \
+      return Vectorized<value_type>(vcgtq_u##bit(values, other.values));      \
+    }                                                                         \
+    Vectorized<uint##bit##_t> operator>=(                                     \
+        const Vectorized<uint##bit##_t>& other) const {                       \
+      return Vectorized<value_type>(vcgeq_u##bit(values, other.values));      \
+    }                                                                         \
+    Vectorized<uint##bit##_t> eq(const Vectorized<uint##bit##_t>& other) const; \
+    Vectorized<uint##bit##_t> ne(const Vectorized<uint##bit##_t>& other) const; \
+    Vectorized<uint##bit##_t> gt(const Vectorized<uint##bit##_t>& other) const; \
+    Vectorized<uint##bit##_t> ge(const Vectorized<uint##bit##_t>& other) const; \
+    Vectorized<uint##bit##_t> lt(const Vectorized<uint##bit##_t>& other) const; \
+    Vectorized<uint##bit##_t> le(const Vectorized<uint##bit##_t>& other) const; \
+  };                                                                            \
+  template <>                                                                   \
+  Vectorized<uint##bit##_t> inline operator+(                                   \
+      const Vectorized<uint##bit##_t>& a, const Vectorized<uint##bit##_t>& b) { \
+    return vaddq_u##bit(a, b);                                                  \
+  }                                                                             \
+  template <>                                                                   \
+  Vectorized<uint##bit##_t> inline operator-(                                   \
+      const Vectorized<uint##bit##_t>& a, const Vectorized<uint##bit##_t>& b) { \
+    return vsubq_u##bit(a, b);                                                  \
+  }                                                                             \
+  template <>                                                                   \
+  Vectorized<uint##bit##_t> inline operator&(                                   \
+      const Vectorized<uint##bit##_t>& a, const Vectorized<uint##bit##_t>& b) { \
+    return vandq_u##bit(a, b);                                                  \
+  }                                                                             \
+  template <>                                                                   \
+  Vectorized<uint##bit##_t> inline operator|(                                   \
+      const Vectorized<uint##bit##_t>& a, const Vectorized<uint##bit##_t>& b) { \
+    return vorrq_u##bit(a, b);                                                  \
+  }                                                                             \
+  template <>                                                                   \
+  Vectorized<uint##bit##_t> inline operator^(                                   \
+      const Vectorized<uint##bit##_t>& a, const Vectorized<uint##bit##_t>& b) { \
+    return veorq_u##bit(a, b);                                                  \
+  }                                                                             \
+  Vectorized<uint##bit##_t> inline Vectorized<uint##bit##_t>::eq(               \
+      const Vectorized<uint##bit##_t>& other) const {                           \
+    return svand_n_u##bit##_x(ptrue, *this == other, 1);                        \
+  }                                                                             \
+  Vectorized<uint##bit##_t> inline Vectorized<uint##bit##_t>::ne(               \
+      const Vectorized<uint##bit##_t>& other) const {                           \
+    return svand_n_u##bit##_x(ptrue, *this != other, 1);                        \
+  }                                                                             \
+  Vectorized<uint##bit##_t> inline Vectorized<uint##bit##_t>::gt(               \
+      const Vectorized<uint##bit##_t>& other) const {                           \
+    return svand_n_u##bit##_x(ptrue, *this > other, 1);                         \
+  }                                                                             \
+  Vectorized<uint##bit##_t> inline Vectorized<uint##bit##_t>::ge(               \
+      const Vectorized<uint##bit##_t>& other) const {                           \
+    return svand_n_u##bit##_x(ptrue, *this >= other, 1);                        \
+  }                                                                             \
+  Vectorized<uint##bit##_t> inline Vectorized<uint##bit##_t>::lt(               \
+      const Vectorized<uint##bit##_t>& other) const {                           \
+    return svand_n_u##bit##_x(ptrue, *this < other, 1);                         \
+  }                                                                             \
+  Vectorized<uint##bit##_t> inline Vectorized<uint##bit##_t>::le(               \
+      const Vectorized<uint##bit##_t>& other) const {                           \
+    return svand_n_u##bit##_x(ptrue, *this <= other, 1);                        \
+  }
+
+VEC_UINT_SVE_TEMPLATE(2, 64)
+VEC_UINT_SVE_TEMPLATE(4, 32)
+VEC_UINT_SVE_TEMPLATE(8, 16)
+VEC_UINT_SVE_TEMPLATE(16, 8)
+
+inline uint64_t Vectorized<uint64_t>::reduce_max() const {                                         
+  return svmaxv_u64(ptrue, svset_neonq(svundef_u64(), values));                                 
+}
+
+inline uint32_t Vectorized<uint32_t>::reduce_max() const {                                         
+  return vmaxvq_u32(values);                                 
+}
+
+inline uint16_t Vectorized<uint16_t>::reduce_max() const {                                         
+  return vmaxvq_u16(values);                                 
+}
+
+inline uint8_t Vectorized<uint8_t>::reduce_max() const {                                         
+  return vmaxvq_u8(values);                                 
+}                                                                         
+
+template <>                                                                 
+Vectorized<uint64_t> inline operator*(                                  
+    const Vectorized<uint64_t>& a, const Vectorized<uint64_t>& b) { 
+  return svmul_u64_x(ptrue, a, b);                                                
+} 
+
+template <>                                                                 
+Vectorized<uint32_t> inline operator*(                                  
+    const Vectorized<uint32_t>& a, const Vectorized<uint32_t>& b) { 
+  return vmulq_u32(a, b);                                                
+} 
+
+template <>                                                                 
+Vectorized<uint16_t> inline operator*(                                  
+    const Vectorized<uint16_t>& a, const Vectorized<uint16_t>& b) { 
+  return vmulq_u16(a, b);                                                
+} 
+
+template <>                                                                 
+Vectorized<uint8_t> inline operator*(                                  
+    const Vectorized<uint8_t>& a, const Vectorized<uint8_t>& b) { 
+  return vmulq_u8(a, b);                                                
+}  
+
+template <>
+Vectorized<uint64_t> inline operator/(
+    const Vectorized<uint64_t>& a,
+    const Vectorized<uint64_t>& b) {
+  return svdiv_u64_x(ptrue, a, b);
+}
+
+template <>
+Vectorized<uint32_t> inline operator/(
+    const Vectorized<uint32_t>& a,
+    const Vectorized<uint32_t>& b) {
+  return svdiv_u32_x(ptrue, a, b);
+}
+
+template <>
+Vectorized<uint16_t> inline operator/(
+    const Vectorized<uint16_t>& a,
+    const Vectorized<uint16_t>& b) {
+  Vectorized<uint32_t> highBitsA = vmovl_high_u16(a);
+  Vectorized<uint32_t> highBitsB = vmovl_high_u16(b);
+  Vectorized<uint32_t> lowBitsA = vmovl_u16(vget_low_u16(a));
+  Vectorized<uint32_t> lowBitsB = vmovl_u16(vget_low_u16(b));
+  int32x4_t highBitsResult = highBitsA / highBitsB;
+  int32x4_t lowBitsResult = lowBitsA / lowBitsB;
+  return vuzp1q_u16(vreinterpretq_u16_u32(lowBitsResult), vreinterpretq_u16_u32(highBitsResult));
+}
+
+template <>
+Vectorized<uint8_t> inline operator/(
+    const Vectorized<uint8_t>& a,
+    const Vectorized<uint8_t>& b) {
+  Vectorized<uint16_t> highBitsA = vmovl_high_u8(a);
+  Vectorized<uint16_t> highBitsB = vmovl_high_u8(b);
+  Vectorized<uint16_t> lowBitsA = vmovl_u8(vget_low_u8(a));
+  Vectorized<uint16_t> lowBitsB = vmovl_u8(vget_low_u8(b));
+  int16x8_t highBitsResult = highBitsA / highBitsB;
+  int16x8_t lowBitsResult = lowBitsA / lowBitsB;
+  return vuzp1q_u8(vreinterpretq_u8_u16(lowBitsResult), vreinterpretq_u8_u16(highBitsResult));
+}                                                                           
+
+template <>
+inline Vectorized<uint64_t> operator~(                                  
+    const Vectorized<uint64_t>& a) {
+  uint64x2_t val = a;                                    
+  return ~val;                                                   
+}
+ 
+template <>
+inline Vectorized<uint32_t> operator~(                                  
+    const Vectorized<uint32_t>& a) {                                    
+  return vmvnq_u32(a);                                                   
+}
+
+template <>                                                                
+inline Vectorized<uint16_t> operator~(                                  
+    const Vectorized<uint16_t>& a) {                                    
+  return vmvnq_u16(a);                                                   
+} 
+
+template <>
+inline Vectorized<uint8_t> operator~(                                  
+    const Vectorized<uint8_t>& a) {                                    
+  return vmvnq_u8(a);                                                   
+}
+
+inline Vectorized<uint64_t> Vectorized<uint64_t>::operator!=(                                  
+    const Vectorized<uint64_t>& other) const {                                    
+  return  ~(*this == other);                                                   
+} 
+                                                                 
+inline Vectorized<uint32_t> Vectorized<uint32_t>::operator!=(                                  
+    const Vectorized<uint32_t>& other) const {                                    
+  return  ~(*this == other);                                                   
+} 
+                                                                
+inline Vectorized<uint16_t> Vectorized<uint16_t>::operator!=(                                  
+    const Vectorized<uint16_t>& other) const {                                    
+  return  ~(*this == other);                                                   
+} 
+                                                              
+inline Vectorized<uint8_t> Vectorized<uint8_t>::operator!=(                                  
+    const Vectorized<uint8_t>& other) const {                                    
+  return  ~(*this == other);                                                   
+}
+
+template <>                                                                 
+Vectorized<uint64_t> inline minimum(                                    
+    const Vectorized<uint64_t>& a, const Vectorized<uint64_t>& b) { 
+  return svmin_u64_x(ptrue, a, b);                                                
+}
+
+template <>                                                                 
+Vectorized<uint32_t> inline minimum(                                    
+    const Vectorized<uint32_t>& a, const Vectorized<uint32_t>& b) { 
+  return vminq_u32(a, b);                                                
+}   
+
+template <>                                                                 
+Vectorized<uint16_t> inline minimum(                                    
+    const Vectorized<uint16_t>& a, const Vectorized<uint16_t>& b) { 
+  return vminq_u16(a, b);                                                
+}   
+
+template <>                                                                 
+Vectorized<uint8_t> inline minimum(                                    
+    const Vectorized<uint8_t>& a, const Vectorized<uint8_t>& b) { 
+  return vminq_u8(a, b);                                                
+}
+
+template <>                                                                 
+Vectorized<uint64_t> inline maximum(                                    
+    const Vectorized<uint64_t>& a, const Vectorized<uint64_t>& b) { 
+  return svmax_u64_x(ptrue, a, b);                                                
+}
+
+template <>                                                                 
+Vectorized<uint32_t> inline maximum(                                    
+    const Vectorized<uint32_t>& a, const Vectorized<uint32_t>& b) { 
+  return vmaxq_u32(a, b);                                                
+}   
+
+template <>                                                                 
+Vectorized<uint16_t> inline maximum(                                    
+    const Vectorized<uint16_t>& a, const Vectorized<uint16_t>& b) { 
+  return vmaxq_u16(a, b);                                                
+}   
+
+template <>                                                                 
+Vectorized<uint8_t> inline maximum(                                    
+    const Vectorized<uint8_t>& a, const Vectorized<uint8_t>& b) { 
+  return vmaxq_u8(a, b);                                                
+}
+
+template <>                                                                 
+Vectorized<uint64_t> inline clamp(                                      
+    const Vectorized<uint64_t>& a,                                      
+    const Vectorized<uint64_t>& min,                                    
+    const Vectorized<uint64_t>& max) {                                  
+  return minimum(max, maximum(min, a));                                     
+}
+
+template <>                                                                 
+Vectorized<uint32_t> inline clamp(                                      
+    const Vectorized<uint32_t>& a,                                      
+    const Vectorized<uint32_t>& min,                                    
+    const Vectorized<uint32_t>& max) {                                  
+  return minimum(max, maximum(min, a));                                     
+}
+
+template <>                                                                 
+Vectorized<uint16_t> inline clamp(                                      
+    const Vectorized<uint16_t>& a,                                      
+    const Vectorized<uint16_t>& min,                                    
+    const Vectorized<uint16_t>& max) {                                  
+  return minimum(max, maximum(min, a));                                     
+}
+
+template <>                                                                 
+Vectorized<uint8_t> inline clamp(                                      
+    const Vectorized<uint8_t>& a,                                      
+    const Vectorized<uint8_t>& min,                                    
+    const Vectorized<uint8_t>& max) {                                  
+  return minimum(max, maximum(min, a));                                     
+}
+
+template <>                                                                 
+Vectorized<uint64_t> inline clamp_max(                                  
+    const Vectorized<uint64_t>& a,                                      
+    const Vectorized<uint64_t>& max) {                                  
+  return minimum(max, a);                                                   
+}
+
+template <>                                                                 
+Vectorized<uint32_t> inline clamp_max(                                  
+    const Vectorized<uint32_t>& a,                                      
+    const Vectorized<uint32_t>& max) {                                  
+  return minimum(max, a);                                                   
+}
+
+template <>                                                                 
+Vectorized<uint16_t> inline clamp_max(                                  
+    const Vectorized<uint16_t>& a,                                      
+    const Vectorized<uint16_t>& max) {                                  
+  return minimum(max, a);                                                   
+}
+
+template <>                                                                 
+Vectorized<uint8_t> inline clamp_max(                                  
+    const Vectorized<uint8_t>& a,                                      
+    const Vectorized<uint8_t>& max) {                                  
+  return minimum(max, a);                                                   
+}
+
+template <>                                                                 
+Vectorized<uint64_t> inline clamp_min(                                  
+    const Vectorized<uint64_t>& a,                                      
+    const Vectorized<uint64_t>& min) {                                  
+  return maximum(min, a);                                                   
+} 
+
+template <>                                                                 
+Vectorized<uint32_t> inline clamp_min(                                  
+    const Vectorized<uint32_t>& a,                                      
+    const Vectorized<uint32_t>& min) {                                  
+  return maximum(min, a);                                                   
+} 
+
+template <>                                                                 
+Vectorized<uint16_t> inline clamp_min(                                  
+    const Vectorized<uint16_t>& a,                                      
+    const Vectorized<uint16_t>& min) {                                  
+  return maximum(min, a);                                                   
+} 
+
+template <>                                                                 
+Vectorized<uint8_t> inline clamp_min(                                  
+    const Vectorized<uint8_t>& a,                                      
+    const Vectorized<uint8_t>& min) {                                  
+  return maximum(min, a);                                                   
+}
+
+template <int64_t mask>
+  Vectorized<uint64_t> Vectorized<uint64_t>::blend(
+      const Vectorized<uint64_t>& a,
+      const Vectorized<uint64_t>& b) {
+    // Build an array of flags: each bit of element is 1 if the corresponding bit in
+    // 'mask' is set, 0 otherwise.
+    uint64x2_t maskArray = {
+      (mask & 1ULL) ? 0xFFFFFFFFFFFFFFFF : 0, 
+      (mask & 2ULL) ? 0xFFFFFFFFFFFFFFFF : 0};
+    // Use BSL to select elements from b where the mask is 1, else from a
+    return vbslq_u64(maskArray, b.values, a.values);
+}
+
+template <int64_t mask>
+  Vectorized<uint32_t> Vectorized<uint32_t>::blend(
+      const Vectorized<uint32_t>& a,
+      const Vectorized<uint32_t>& b) {
+    // Build an array of flags: each bit of element is 1 if the corresponding bit in
+    // 'mask' is set, 0 otherwise.
+    uint32x4_t maskArray = {
+      (mask &     1ULL) ? 0xFFFFFFFF : 0, 
+      (mask &     2ULL) ? 0xFFFFFFFF : 0, 
+      (mask &     4ULL) ? 0xFFFFFFFF : 0, 
+      (mask &     8ULL) ? 0xFFFFFFFF : 0};
+    // Use BSL to select elements from b where the mask is 1, else from a
+    return vbslq_u32(maskArray, b.values, a.values);
+}
+
+template <int64_t mask>
+  Vectorized<uint16_t> Vectorized<uint16_t>::blend(
+      const Vectorized<uint16_t>& a,
+      const Vectorized<uint16_t>& b) {
+    // Build an array of flags: each bit of element is 1 if the corresponding bit in
+    // 'mask' is set, 0 otherwise.
+    uint16x8_t maskArray = {
+      (mask &     1ULL) ? 0xFFFF : 0, 
+      (mask &     2ULL) ? 0xFFFF : 0, 
+      (mask &     4ULL) ? 0xFFFF : 0, 
+      (mask &     8ULL) ? 0xFFFF : 0,
+      (mask &    16ULL) ? 0xFFFF : 0, 
+      (mask &    32ULL) ? 0xFFFF : 0, 
+      (mask &    64ULL) ? 0xFFFF : 0, 
+      (mask &   128ULL) ? 0xFFFF : 0};
+    // Use BSL to select elements from b where the mask is 1, else from a
+    return vbslq_u16(maskArray, b.values, a.values);
+}
+
+template <int64_t mask>
+  Vectorized<uint8_t> Vectorized<uint8_t>::blend(
+      const Vectorized<uint8_t>& a,
+      const Vectorized<uint8_t>& b) {
+    // Build an array of flags: each bit of element is 1 if the corresponding bit in
+    // 'mask' is set, 0 otherwise.
+    uint8x16_t maskArray = {
+      (mask &     1ULL) ? 0xFF : 0, 
+      (mask &     2ULL) ? 0xFF : 0, 
+      (mask &     4ULL) ? 0xFF : 0, 
+      (mask &     8ULL) ? 0xFF : 0,
+      (mask &    16ULL) ? 0xFF : 0, 
+      (mask &    32ULL) ? 0xFF : 0, 
+      (mask &    64ULL) ? 0xFF : 0, 
+      (mask &   128ULL) ? 0xFF : 0,
+      (mask &   256ULL) ? 0xFF : 0, 
+      (mask &   512ULL) ? 0xFF : 0, 
+      (mask &  1024ULL) ? 0xFF : 0, 
+      (mask &  2048ULL) ? 0xFF : 0,
+      (mask &  4096ULL) ? 0xFF : 0, 
+      (mask &  8192ULL) ? 0xFF : 0, 
+      (mask & 16384ULL) ? 0xFF : 0, 
+      (mask & 32768ULL) ? 0xFF : 0};
+    // Use BSL to select elements from b where the mask is 1, else from a
+    return vbslq_u8(maskArray, b.values, a.values);
+}
+
+template <typename step_t>                                                
+inline Vectorized<uint64_t> Vectorized<uint64_t>::arange(                                   
+    uint64_t base,                                                
+    step_t step) {                               
+      const Vectorized<uint64_t> base_vec(base);                        
+      const Vectorized<uint64_t> step_vec(step);                        
+      const Vectorized<uint64_t> step_sizes = svindex_u64(0, 1);     
+      return svmla_u64_x(ptrue, base_vec, step_sizes, step_vec);                
+}
+
+template <typename step_t>                                                
+inline Vectorized<uint32_t> Vectorized<uint32_t>::arange(                                   
+    uint32_t base,                                                
+    step_t step) {                               
+      const Vectorized<uint32_t> base_vec(base);                        
+      const Vectorized<uint32_t> step_vec(step);                        
+      const Vectorized<uint32_t> step_sizes = svindex_u32(0, 1);     
+      return vmlaq_u32(base_vec, step_sizes, step_vec);                
+}
+
+template <typename step_t>                                                
+inline Vectorized<uint16_t> Vectorized<uint16_t>::arange(                                   
+    uint16_t base,                                                
+    step_t step) {                               
+      const Vectorized<uint16_t> base_vec(base);                        
+      const Vectorized<uint16_t> step_vec(step);                        
+      const Vectorized<uint16_t> step_sizes = svindex_u16(0, 1);     
+      return vmlaq_u16(base_vec, step_sizes, step_vec);                
+} 
+
+template <typename step_t>                                                
+inline Vectorized<uint8_t> Vectorized<uint8_t>::arange(                                   
+    uint8_t base,                                                
+    step_t step) {                               
+      const Vectorized<uint8_t> base_vec(base);                        
+      const Vectorized<uint8_t> step_vec(step);                        
+      const Vectorized<uint8_t> step_sizes = svindex_u8(0, 1);     
+      return vmlaq_u8(base_vec, step_sizes, step_vec);                
+} 
+
+template <>
+Vectorized<uint64_t> inline operator<<(
+    const Vectorized<uint64_t>& a,
+    const Vectorized<uint64_t>& b) {
+  return vshlq_u64(a, b);
+}
+
+template <>
+Vectorized<uint32_t> inline operator<<(
+    const Vectorized<uint32_t>& a,
+    const Vectorized<uint32_t>& b) {
+  return vshlq_u32(a, b);
+}
+
+template <>
+Vectorized<uint16_t> inline operator<<(
+    const Vectorized<uint16_t>& a,
+    const Vectorized<uint16_t>& b) {
+  return vshlq_u16(a, b);
+}
+
+template <>
+Vectorized<uint8_t> inline operator<<(
+    const Vectorized<uint8_t>& a,
+    const Vectorized<uint8_t>& b) {
+  return vshlq_u8(a, b);
+}
+
+template <>
+Vectorized<uint64_t> inline operator>>(
+    const Vectorized<uint64_t>& a,
+    const Vectorized<uint64_t>& b) {
+  return svlsr_u64_x(ptrue, a, b);
+}
+
+template <>
+Vectorized<uint32_t> inline operator>>(
+    const Vectorized<uint32_t>& a,
+    const Vectorized<uint32_t>& b) {
+  return svlsr_u32_x(ptrue, a, b);
+}
+
+template <>
+Vectorized<uint16_t> inline operator>>(
+    const Vectorized<uint16_t>& a,
+    const Vectorized<uint16_t>& b) {
+  return svlsr_u16_x(ptrue, a, b);
+}
+
+template <>
+Vectorized<uint8_t> inline operator>>(
+    const Vectorized<uint8_t>& a,
+    const Vectorized<uint8_t>& b) {
+  return svlsr_u8_x(ptrue, a, b);
+}
+
+#endif // defined(CPU_CAPABILITY_SVE)
+
+} // namespace CPU_CAPABILITY
+} // namespace at::vec

--- a/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
@@ -1405,7 +1405,12 @@ std::pair<Vectorized<float>, Vectorized<float>> inline convert_int8_to_float(
 
 std::pair<Vectorized<float>, Vectorized<float>> inline convert_int8_to_float(
     at::vec::Vectorized<uint8_t> src) {
+#ifdef CPU_CAPABILITY_SVE
+  svuint8_t x = src;
+  auto u8x8 = vget_low_u8(svget_neonq(x));
+#else
   auto u8x8 = vld1_u8(src.operator const uint8_t*());
+#endif
   auto u16x8 = vmovl_u8(u8x8);
   auto u32x4_hi = vmovl_u16(vget_high_u16(u16x8));
   auto u32x4_lo = vmovl_u16(vget_low_u16(u16x8));
@@ -1434,7 +1439,12 @@ Vectorized<float> inline convert_int8_half_register_to_float(
 
 Vectorized<float> inline convert_int8_half_register_to_float(
     at::vec::Vectorized<uint8_t> src) {
+#ifdef CPU_CAPABILITY_SVE
+  svuint8_t x = src;
+  auto u8x8 = vget_low_u8(svget_neonq(x));
+#else
   auto u8x8 = vld1_u8(src.operator const uint8_t*());
+#endif
   auto u16x8 = vmovl_u8(u8x8);
   auto u32x4_lo = vmovl_u16(vget_low_u16(u16x8));
 

--- a/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
@@ -7,7 +7,9 @@
 #include <ATen/cpu/vec/vec_base.h>
 
 #ifdef __aarch64__
-#if defined(CPU_CAPABILITY_SVE128) || !defined(CPU_CAPABILITY_SVE)
+#ifdef CPU_CAPABILITY_SVE128
+#include <ATen/cpu/vec/vec128/vec128_float_sve.h>
+#elif !defined(CPU_CAPABILITY_SVE)
 #include <ATen/cpu/vec/vec128/vec128_float_neon.h>
 #endif
 #endif

--- a/aten/src/ATen/cpu/vec/vec_common_aarch64.h
+++ b/aten/src/ATen/cpu/vec/vec_common_aarch64.h
@@ -12,9 +12,9 @@
 
 #include <ATen/cpu/vec/vec128/vec128_float_sve.h>
 
-#include <ATen/cpu/vec/vec128/vec128_bfloat16_neon.h>
+#include <ATen/cpu/vec/vec128/vec128_half_sve.h>
 
-#include <ATen/cpu/vec/vec128/vec128_half_neon.h>
+#include <ATen/cpu/vec/vec128/vec128_bfloat16_neon.h>
 
 #include <ATen/cpu/vec/vec128/vec128_convert.h>
 

--- a/aten/src/ATen/cpu/vec/vec_common_aarch64.h
+++ b/aten/src/ATen/cpu/vec/vec_common_aarch64.h
@@ -14,7 +14,11 @@
 
 #include <ATen/cpu/vec/vec128/vec128_half_sve.h>
 
+#ifdef __ARM_FEATURE_BF16
+#include <ATen/cpu/vec/vec128/vec128_bfloat16_sve.h>
+#else
 #include <ATen/cpu/vec/vec128/vec128_bfloat16_neon.h>
+#endif
 
 #include <ATen/cpu/vec/vec128/vec128_convert.h>
 

--- a/aten/src/ATen/cpu/vec/vec_common_aarch64.h
+++ b/aten/src/ATen/cpu/vec/vec_common_aarch64.h
@@ -10,7 +10,7 @@
 
 #ifdef CPU_CAPABILITY_SVE128
 
-#include <ATen/cpu/vec/vec128/vec128_float_neon.h>
+#include <ATen/cpu/vec/vec128/vec128_float_sve.h>
 
 #include <ATen/cpu/vec/vec128/vec128_bfloat16_neon.h>
 

--- a/aten/src/ATen/cpu/vec/vec_common_aarch64.h
+++ b/aten/src/ATen/cpu/vec/vec_common_aarch64.h
@@ -23,6 +23,7 @@
 #include <ATen/cpu/vec/vec128/vec128_convert.h>
 
 #include <ATen/cpu/vec/vec128/vec128_int_sve.h>
+#include <ATen/cpu/vec/vec128/vec128_uint_sve.h>
 
 #include <ATen/cpu/vec/sve/vec_qint.h>
 

--- a/aten/src/ATen/cpu/vec/vec_common_aarch64.h
+++ b/aten/src/ATen/cpu/vec/vec_common_aarch64.h
@@ -22,6 +22,8 @@
 
 #include <ATen/cpu/vec/vec128/vec128_convert.h>
 
+#include <ATen/cpu/vec/vec128/vec128_int_sve.h>
+
 #include <ATen/cpu/vec/sve/vec_qint.h>
 
 #elif defined(CPU_CAPABILITY_SVE)


### PR DESCRIPTION
Summary: Add Vectorized<T> SVE128 specialization for unsigned integer types

Test Plan:
Ads Predictor

Rollback Plan:

Differential Revision: D79949491


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben