### PR TITLE
[MPS] Add support for log_normal_ 

### DIFF
--- a/aten/src/ATen/native/mps/operations/Distributions.mm
+++ b/aten/src/ATen/native/mps/operations/Distributions.mm
@@ -343,6 +343,14 @@ Tensor& bernoulli_mps_(Tensor& self, const Tensor& p_, std::optional<Generator> 
   return mps::bernoulli_mps_impl(self, p_, gen, __func__);
 }
 
+Tensor& log_normal_mps_(Tensor& self, double mean, double std, std::optional<Generator> gen) {
+  TORCH_CHECK(std > 0.0, "log_normal_ expects std > 0.0, but found std=", std);
+  // generate normal samples then exponentiate
+  mps::normal_mps_impl(self, mean, std, std::nullopt, std::nullopt, gen, "normal");
+  self.exp_();
+  return self;
+}
+
 // random_.from
 Tensor& random_mps_(Tensor& self, int64_t from, std::optional<int64_t> to_opt, std::optional<Generator> gen) {
   auto input_dtype = self.scalar_type();

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10543,7 +10543,7 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
     def test_no_cuda_monkeypatch(self):
         # Note that this is not in test_cuda.py as this whole file is skipped when cuda
         # is not available.
-        with self.assertRaisesRegex(RuntimeError, "torch.cuda.Stream requires CUDA support"):
+        with self.assertRaisesRegex(RuntimeError, "Tried to instantiate dummy base class Event"):
             torch.cuda.Stream()
 
         with self.assertRaisesRegex(RuntimeError, "Tried to instantiate dummy base class Event"):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10543,7 +10543,7 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
     def test_no_cuda_monkeypatch(self):
         # Note that this is not in test_cuda.py as this whole file is skipped when cuda
         # is not available.
-        with self.assertRaisesRegex(RuntimeError, "Tried to instantiate dummy base class Event"):
+        with self.assertRaisesRegex(RuntimeError, "Tried to instantiate dummy base class Stream"):
             torch.cuda.Stream()
 
         with self.assertRaisesRegex(RuntimeError, "Tried to instantiate dummy base class Event"):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2107,7 +2107,6 @@ class TestTorchDeviceType(TestCase):
 
 
     @dtypes(*floating_types_and(torch.half, torch.bfloat16))
-    @skipIfMPS
     def test_log_normal(self, device, dtype):
         a = torch.tensor([10], dtype=dtype, device=device).log_normal_()
         self.assertEqual(a.dtype, dtype)


### PR DESCRIPTION
We have this op in list of most requested ops in MPS backend

```
import torch
torch.manual_seed(42)
x = torch.tensor([0.0, 0.3, -0.5, 0.7], dtype=torch.float32, device='mps')
print(x.log_normal_(1, 1))
```
output:
```
tensor([6.7172, 3.3963, 3.1457, 5.6748], device='mps:0')
```

cc @alexsamardzic @nikitaved @pearu @cpuhrsch @amjames @bhosmer @jcaip @kulinseth @albanD @malfet @DenisVieriu97 @jhavukainen