### PR TITLE
[cutlass backend] Allow bmm use cases when batch stride is 0

### DIFF
--- a/test/inductor/test_cutlass_backend.py
+++ b/test/inductor/test_cutlass_backend.py
@@ -695,6 +695,7 @@ class TestCutlassBackend(TestCase):
     @parametrize("dynamic", (False, True))
     @parametrize("use_aoti", (False, True))
     @parametrize("dtype", (torch.float16, torch.bfloat16))
+    @parametrize("use_expand", (False, True))
     @mock.patch.dict(os.environ, {"PATH": _get_path_without_sccache()})
     def test_max_autotune_cutlass_backend_bmm(
         self,
@@ -702,6 +703,7 @@ class TestCutlassBackend(TestCase):
         use_aoti: bool = False,
         max_autotune_gemm_backends: str = "CUTLASS",
         dtype: torch.dtype = torch.float16,
+        use_expand: bool = False,
     ):
         """
         Main test for bmm.
@@ -719,13 +721,17 @@ class TestCutlassBackend(TestCase):
         ]
         shapes = shapes[0:1] if not dynamic else shapes
 
-        inputs = [
-            (
-                torch.randn(B, M, K).cuda().to(dtype),
-                torch.randn(B, N, K).cuda().to(dtype).permute(0, 2, 1),
-            )
-            for B, M, N, K in shapes
-        ]
+        inputs = []
+        for B, M, N, K in shapes:
+            if use_expand:
+                # Create A using unsqueeze and expand
+                A = torch.randn(M, K).cuda().to(dtype).unsqueeze(0).expand(B, -1, -1)
+            else:
+                # Original method
+                A = torch.randn(B, M, K).cuda().to(dtype)
+
+            B_tensor = torch.randn(B, N, K).cuda().to(dtype).permute(0, 2, 1)
+            inputs.append((A, B_tensor))
         dynamic_shapes = (
             {
                 "a": {0: Dim.DYNAMIC, 1: Dim.DYNAMIC, 2: Dim.DYNAMIC},

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -25,7 +25,7 @@ from ..virtualized import V
 from .mm_common import (
     _is_static_problem,
     addmm_epilogue,
-    is_batch_stride_largest,
+    is_batch_stride_largest_or_zero,
     mm_args,
 )
 
@@ -215,9 +215,9 @@ def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
                 **kwargs,
             )
     _, is_nonzero = _is_static_problem(layout)
-    batch_stride_largest = is_batch_stride_largest(mat1, mat2, layout)
+    batch_stride_largest_or_zero = is_batch_stride_largest_or_zero(mat1, mat2, layout)
     if (
-        batch_stride_largest
+        batch_stride_largest_or_zero
         and is_nonzero
         and use_cutlass_template(layout, m, n, k)
         and _use_cutlass_for_op(name)

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -180,7 +180,7 @@ def check_supported_striding(mat_a: TensorBox, mat_b: TensorBox) -> None:
     )
 
 
-def is_batch_stride_largest(mat1, mat2, layout) -> bool:
+def is_batch_stride_largest_or_zero(mat1, mat2, layout) -> bool:
     """
     Checking if the batch stride is the largest in the stride.
     """
@@ -188,7 +188,7 @@ def is_batch_stride_largest(mat1, mat2, layout) -> bool:
     strides = [mat1.get_stride(), mat2.get_stride(), layout.stride]
     for size, stride in zip(sizes, strides):
         assert len(size) == len(stride) == 3, "Expect 3D tensors"
-        if stride[0] != sympy_product(size[1:]):
+        if stride[0] != 0 and stride[0] != sympy_product(size[1:]):
             return False
 
     return True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #160356

Differential Revision: [D80035771](https://our.internmc.facebook.com/intern/diff/D80035771/)

The motivation and the original change is to reduce the number parameters we pass into the kernel, which was motivated by aesthetic reasons only. 

But seeing the need to use different batch stride, we should just pass in the batch stride. That would be a good long term fix.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben