### PR TITLE
[Let's see CI] Remove use of device_guard for TensorIndex kernel

### DIFF
--- a/aten/src/ATen/TensorIndexing.cpp
+++ b/aten/src/ATen/TensorIndexing.cpp
@@ -66,7 +66,6 @@ static inline void set_item(const Tensor& self, ArrayRef<TensorIndex> indices, c
 
 Tensor Tensor::index(ArrayRef<at::indexing::TensorIndex> indices) const {
   TORCH_CHECK(!indices.empty(), "Passing an empty index list to Tensor::index() is not valid syntax");
-  OptionalDeviceGuard device_guard(device_of(*this));
   return at::indexing::get_item(*this, indices);
 }
 Tensor Tensor::index(std::initializer_list<at::indexing::TensorIndex> indices) const {
@@ -75,13 +74,11 @@ Tensor Tensor::index(std::initializer_list<at::indexing::TensorIndex> indices) c
 
 Tensor & Tensor::index_put_(ArrayRef<at::indexing::TensorIndex> indices, Tensor const & rhs) {
   TORCH_CHECK(!indices.empty(), "Passing an empty index list to Tensor::index_put_() is not valid syntax");
-  OptionalDeviceGuard device_guard(device_of(*this));
   at::indexing::set_item(*this, indices, rhs);
   return *this;
 }
 Tensor & Tensor::index_put_(ArrayRef<at::indexing::TensorIndex> indices, const Scalar& v) {
   TORCH_CHECK(!indices.empty(), "Passing an empty index list to Tensor::index_put_() is not valid syntax");
-  OptionalDeviceGuard device_guard(device_of(*this));
   at::indexing::set_item(*this, indices, v);
   return *this;
 }


### PR DESCRIPTION
Summary: Avoid use of device guard to support exporting on fake cuda device.

Test Plan:
CI

Rollback Plan:

Differential Revision: D80040866


