### PR TITLE
[Inductor][Configs] Expose autotune_num_choices_displayed through environment variable

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -428,8 +428,11 @@ max_autotune_pointwise = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_POINTWISE") 
 # enable slow autotuning passes to select gemm algorithms
 max_autotune_gemm = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_GEMM") == "1"
 
-# Modifies the number of autotuning choices displayed, set to None for all
-autotune_num_choices_displayed: Optional[int] = 10
+# Modifies the number of autotuning choices displayed, default is 10
+autotune_num_choices_displayed = int(
+    os.environ.get("TORCHINDUCTOR_AUTOTUNE_NUM_CHOICES_DISPLAYED", 10)
+)
+
 
 # Report the autotune choices and their benchmark results. Default is True.
 max_autotune_report_choices_stats = (


### PR DESCRIPTION
Summary:
Change the number of autotuning results printed via a new environment variable: `TORCHINDUCTOR_AUTOTUNE_NUM_CHOICES_DISPLAYED`. Previously, this value had to be changed manually within `config.py`.

Defaults to 10; set to "ALL" to print all choices.

Test Plan:
Manual testing

Rollback Plan:

Differential Revision: D80047826




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben