### PR TITLE
[CI] Enable CPU Inductor unit test on Windows

### DIFF
--- a/.ci/pytorch/win-test-helpers/test_inductor_shard.bat
+++ b/.ci/pytorch/win-test-helpers/test_inductor_shard.bat
@@ -1,0 +1,38 @@
+call %SCRIPT_HELPERS_DIR%\setup_pytorch_env.bat
+:: exit the batch once there's an error
+if not errorlevel 0 (
+  echo "setup pytorch env failed"
+  echo %errorlevel%
+  exit /b
+)
+
+pushd test
+
+set TORCHINDUCTOR_WINDOWS_TESTS=1
+set GFLAGS_EXE="C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\gflags.exe"
+if "%SHARD_NUMBER%" == "1" (
+  if exist %GFLAGS_EXE% (
+    echo Some smoke tests
+    %GFLAGS_EXE% /i python.exe +sls
+    python %SCRIPT_HELPERS_DIR%\run_python_nn_smoketests.py
+    if ERRORLEVEL 1 goto fail
+
+    %GFLAGS_EXE% /i python.exe -sls
+    if ERRORLEVEL 1 goto fail
+  )
+)
+
+echo Copying over test times file
+robocopy /E "%PYTORCH_FINAL_PACKAGE_DIR_WIN%\.additional_ci_files" "%PROJECT_DIR_WIN%\.additional_ci_files"
+
+echo Run inductor tests
+python run_test.py --include inductor/test_torchinductor --shard "%SHARD_NUMBER%" "%NUM_TEST_SHARDS%" --verbose
+if ERRORLEVEL 1 goto fail
+
+popd
+
+:eof
+exit /b 0
+
+:fail
+exit /b 1

--- a/.ci/pytorch/win-test.sh
+++ b/.ci/pytorch/win-test.sh
@@ -83,6 +83,14 @@ run_tests() {
     fi
 }
 
-run_tests
+run_inductor_tests(){
+    "$SCRIPT_HELPERS_DIR"/test_inductor_shard.bat
+}
+
+if [[ "${TEST_CONFIG}" == *inductor* ]]; then
+    run_inductor_tests
+else
+    run_tests
+fi
 assert_git_not_dirty
 echo "TEST PASSED"

--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -14,6 +14,7 @@ ciflow_push_tags:
 - ciflow/inductor-micro-benchmark-cpu-x86
 - ciflow/inductor-perf-test-nightly-x86-zen
 - ciflow/inductor-cu126
+- ciflow/inductor-windows
 - ciflow/linux-aarch64
 - ciflow/mps
 - ciflow/nightly

--- a/.github/workflows/inductor-windows.yml
+++ b/.github/workflows/inductor-windows.yml
@@ -1,0 +1,59 @@
+name: inductor-windows
+
+on:
+  push:
+    tags:
+      - ciflow/inductor-windows/*
+  workflow_dispatch:
+  schedule:
+    # Run every 12 hours during the week and every 24 hours on the weekend
+    - cron: 45 0,12 * * 1-5
+    - cron: 45 0 * * 0,6
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  get-default-label-prefix:
+    name: get-default-label-prefix
+    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
+    if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
+    with:
+      triggering_actor: ${{ github.triggering_actor }}
+      issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
+      curr_branch: ${{ github.head_ref || github.ref_name }}
+      curr_ref_type: ${{ github.ref_type }}
+      opt_out_experiments: lf
+
+  win-vs2022-cpu-py3-build:
+    name: win-vs2022-cpu-py3
+    uses: ./.github/workflows/_win-build.yml
+    needs: get-default-label-prefix
+    with:
+      build-environment: win-vs2022-cpu-py3
+      cuda-version: cpu
+      runner: "${{ needs.get-default-label-prefix.outputs.label-type }}windows.4xlarge.nonephemeral"
+      test-matrix: |
+        { include: [
+          { config: "inductor", shard: 1, num_shards: 2, runner: "${{ needs.get-default-label-prefix.outputs.label-type }}windows.4xlarge.nonephemeral" },
+          { config: "inductor", shard: 2, num_shards: 2, runner: "${{ needs.get-default-label-prefix.outputs.label-type }}windows.4xlarge.nonephemeral" },
+        ]}
+    secrets: inherit
+
+  win-vs2022-cpu-py3-inductor-test:
+    name: win-vs2022-cpu-py3
+    uses: ./.github/workflows/_win-test.yml
+    needs:
+      - win-vs2022-cpu-py3-build
+    with:
+      build-environment: win-vs2022-cpu-py3
+      cuda-version: cpu
+      test-matrix: ${{ needs.win-vs2022-cpu-py3-build.outputs.test-matrix }}
+      disable-monitor: false
+    secrets: inherit


### PR DESCRIPTION
It is inital PR to add Windows inductor UTs to `inductor periodic` , as @seemethere and @malfet 's comments: https://github.com/pytorch/pytorch/pull/160161#issuecomment-3175484703

TODO:
1. @xuhancn will add more UTs to list, which in `test/dynamo` and `test/inductor`.
2. @xuhancn will add AOTI UTs, when it is ready.
