### PR TITLE
[ez][CI] Disable failing test_equivalent_template_code on slow grad check

### DIFF
--- a/test/inductor/test_benchmark_fusion.py
+++ b/test/inductor/test_benchmark_fusion.py
@@ -9,7 +9,7 @@ from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.test_operators import realize
 from torch._inductor.utils import fresh_cache, is_big_gpu, run_and_get_code
 from torch.testing import FileCheck
-from torch.testing._internal.common_utils import slowTest
+from torch.testing._internal.common_utils import slowTest, TEST_WITH_SLOW_GRADCHECK
 from torch.testing._internal.inductor_utils import (
     get_func_call,
     HAS_CPU,
@@ -287,6 +287,10 @@ if HAS_CUDA_AND_TRITON:
             self.assertEqual(res, res2, atol=1e-4, rtol=1.1)
             return code, code2
 
+        @unittest.skipIf(
+            TEST_WITH_SLOW_GRADCHECK,
+            "failing on slow gradcheck, seems to have started at 1febab2a89302464f6c7d69cfbef7a24c421ea65",
+        )
         @fresh_cache()
         @config.patch(max_autotune_gemm_backends="TRITON")
         def test_equivalent_template_code(self):


### PR DESCRIPTION
Seems to have started around 2247aa6d1d43e256255f5c74a781c3190a4387b6 https://github.com/pytorch/pytorch/pull/159920
cc @shengfukevin 

Not sure why it only fails slow grad check

```
Traceback (most recent call last):
  File "/var/lib/jenkins/workspace/test/inductor/test_benchmark_fusion.py", line 299, in test_equivalent_template_code
    ).check("" if config.cpp_wrapper else "return").run(out_code[0])
RuntimeError: Expected to find "triton_tem_fused_addmm_relu_0" but did not find it
Searched string:
    with torch.cuda._DeviceGuard(0):
        torch.cuda.set_device(0)
        buf1 = empty_strided_cuda((256, 256), (256, 1), torch.float16)
        # Topologically Sorted Source Nodes: [a, relu], Original ATen: [aten.t, aten.addmm, aten.relu]
        stream0 = get_raw_stream(0)
        triton_tem_fused_addmm_relu_t_0.run(arg2_1, arg0_1, arg1_1, buf1, 8, 1, 1, stream=stream0)
        del arg0_1
        del arg1_1
        del arg2_1
    return (buf1, )


def benchmark_compiled_module(times=10, repeat=10):
    from torch._dynamo.testing import rand_strided
    from torch._inductor.utils import print_performance
    arg0_1 = rand_strided((256, 256), (256, 1), device='cuda:0', dtype=torch.float16)
    arg1_1 = rand_strided((256, ), (1, ), device='cuda:0', dtype=torch.float16)
    arg2_1 = rand_strided((256, 256), (256, 1), device='cuda:0', dtype=torch.float16)
    fn = lambda: call([arg0_1, arg1_1, arg2_1])
    return print_performance(fn, times=times, repeat=repeat)


if __name__ == "__main__":
    from torch._inductor.wrapper_benchmark import compiled_module_main
    compiled_module_main('None', benchmark_compiled_module)
From CHECK: triton_tem_fused_addmm_relu_0


To execute this test, run the following from the base repo dir:
    PYTORCH_TEST_CUDA_MEM_LEAK_CHECK=1 PYTORCH_TEST_WITH_SLOW_GRADCHECK=1 python test/inductor/test_benchmark_fusion.py BenchmarkMultiTemplateFusionCudaTest.test_equivalent_template_code

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben