### PR TITLE
[DTensor] Convert embedding mask buffer data back from functional tensor

### DIFF
--- a/test/distributed/tensor/test_embedding_ops.py
+++ b/test/distributed/tensor/test_embedding_ops.py
@@ -79,7 +79,7 @@ class TestEmbeddingOp(DTensorTestBase):
 
         if use_compile:
             sharded_embedding = torch.compile(sharded_embedding, fullgraph=True)
-    
+
         # Run sharded computation
         torch.manual_seed(10)
         inp = torch.randint(
@@ -134,8 +134,12 @@ class TestEmbeddingOp(DTensorTestBase):
             local_embedding.weight,
             **kwargs,
         )
-        maybe_compiled_emb = torch.compile(torch.nn.functional.embedding, fullgraph=True) if use_compile else torch.nn.functional.embedding
-        sharded_output =  maybe_compiled_emb(
+        maybe_compiled_emb = (
+            torch.compile(torch.nn.functional.embedding, fullgraph=True)
+            if use_compile
+            else torch.nn.functional.embedding
+        )
+        sharded_output = maybe_compiled_emb(
             DTensor.from_local(inp, device_mesh, [Replicate()], run_check=False),
             sharded_embedding.weight,
             **kwargs,
@@ -232,12 +236,12 @@ class TestEmbeddingOp(DTensorTestBase):
         # not equal because of different logical_shape, despite of same logical_dim_size
         self.assertNotEqual(partial_placement1, partial_placement3)
 
-
     @with_comms
     def test_embedding_compile(self):
         mesh = self.build_device_mesh()
         self._run_embedding_op_test(mesh, 1, [5, 4], 17, 12)
         self._run_embedding_op_test(mesh, 0, [5, 12], 16, 22, use_compile=True)
-        
+
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -680,6 +680,7 @@ class AOTDispatchSubclassWrapper(CompilerWrapper):
 
         @wraps(compiled_fn)
         def inner_fn(args: list[Any]):
+            # torch.distributed.breakpoint()
             unwrapped_args = runtime_unwrap_tensor_subclasses(
                 args,
                 subclass_metas=runtime_metadata.subclass_inp_meta,
@@ -688,9 +689,10 @@ class AOTDispatchSubclassWrapper(CompilerWrapper):
             args.clear()
             # expectation: runtime_fn is a boxed fn
             unwrapped_outs = compiled_fn(unwrapped_args)
+            torch.distributed.breakpoint()
             wrapped_outs = wrap_tensor_subclasses(
                 unwrapped_outs,
-                subclass_metas=subclass_metas,
+                subclass_metas=subclass_metas,  # where does subclass meta come from, it shouldn't stash a fake tensor
                 num_fw_outs_saved_for_bw=self.num_fw_outs_saved_for_bw,
                 is_runtime=True,
                 included_subclass_symints=True,

--- a/torch/distributed/tensor/_ops/_embedding_ops.py
+++ b/torch/distributed/tensor/_ops/_embedding_ops.py
@@ -55,6 +55,14 @@ class MaskBuffer:
     def apply_mask(self, tensor):
         if self.refcount == 0 or self.data is None:
             raise RuntimeError("MaskBuffer has not been materialized")
+        # NOTE: During tracing, self.data will not be automatically converted back from functional tensor
+        # in run_functionalized_fw_and_collect_metadata since it is not part of `local_tensor`.
+        # We convert it lazily here if needed instead.
+        if (
+            type(self.data) is torch._subclasses.functional_tensor.FunctionalTensor and
+            type(tensor) is not torch._subclasses.functional_tensor.FunctionalTensor
+        ):
+            self.data = torch._functorch._aot_autograd.functional_utils.from_fun(self.data)
 
         # NOTE: _MaskPartial is being used by the embedding op and the gather op.
         # For gather, the mask has the same dimension as the output tensor, whereas

--- a/torch/distributed/tensor/_ops/_embedding_ops.py
+++ b/torch/distributed/tensor/_ops/_embedding_ops.py
@@ -59,10 +59,12 @@ class MaskBuffer:
         # in run_functionalized_fw_and_collect_metadata since it is not part of `local_tensor`.
         # We convert it lazily here if needed instead.
         if (
-            type(self.data) is torch._subclasses.functional_tensor.FunctionalTensor and
-            type(tensor) is not torch._subclasses.functional_tensor.FunctionalTensor
+            type(self.data) is torch._subclasses.functional_tensor.FunctionalTensor
+            and type(tensor) is not torch._subclasses.functional_tensor.FunctionalTensor
         ):
-            self.data = torch._functorch._aot_autograd.functional_utils.from_fun(self.data)
+            self.data = torch._functorch._aot_autograd.functional_utils.from_fun(
+                self.data
+            )
 
         # NOTE: _MaskPartial is being used by the embedding op and the gather op.
         # For gather, the mask has the same dimension as the output tensor, whereas

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -60,7 +60,7 @@ else:
     DEVICE_TYPE = "cpu"
     PG_BACKEND = "gloo"
 
-NUM_DEVICES = 4
+NUM_DEVICES = 1
 
 # We use this as a proxy for "multiple GPUs exist"
 if (TEST_CUDA or TEST_XPU or TEST_HPU) and DEVICE_COUNT > 1:


### PR DESCRIPTION
Fixes #159843

Adds a check for unexpected functional tensors and converts back if needed, which would be required during `run_functionalized_fw_and_collect_metadata`. 

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @tianyu-l @XilunWu @SherlockNoMad