### PR TITLE
Refine autotune choices stats logging

### DIFF
--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -3446,45 +3446,48 @@ def _log_autotune_choices_stats(
     event_name: str, timings: dict[ChoiceCaller, float]
 ) -> None:
     """Helper function to extract autotune metadata from benchmark results."""
-    if not timings:
-        return None
 
-    metadata: dict[str, Union[int, float, str]] = {
-        "num_choices": len(timings),
-        "num_triton_choices": len(
-            [c for c in timings if isinstance(c, TritonTemplateCaller)]
-        ),
-    }
+    try:
+        metadata: dict[str, Union[int, float, str]] = {
+            "num_choices": len(timings),
+            "num_triton_choices": len(
+                [c for c in timings if isinstance(c, TritonTemplateCaller)]
+            ),
+        }
 
-    sorted_choices = sorted(timings, key=timings.__getitem__)
-    best_choice = sorted_choices[0]
-    metadata["best_kernel"] = best_choice.name
-    if best_choice.description:
-        metadata["best_kernel_desc"] = best_choice.description
-    metadata["best_time"] = timings[best_choice]
+        sorted_choices = sorted(timings, key=timings.__getitem__)
+        best_choice = sorted_choices[0]
+        metadata["best_kernel"] = best_choice.name
+        if best_choice.description:
+            metadata["best_kernel_desc"] = best_choice.description
+        metadata["best_time"] = timings[best_choice]
 
-    best_triton_pos = next(
-        (
-            i
-            for i, choice in enumerate(sorted_choices)
-            if isinstance(choice, TritonTemplateCaller)
-        ),
-        None,
-    )
-    if best_triton_pos is not None:
-        metadata["best_triton_pos"] = best_triton_pos
-        best_triton_kernel = sorted_choices[best_triton_pos]
-        if best_triton_pos != 0:
-            metadata["best_triton_time"] = timings[best_triton_kernel]
-            metadata["best_triton_kernel"] = best_triton_kernel.name
-            if best_triton_kernel.description:
-                metadata["best_triton_kernel_desc"] = best_triton_kernel.description
+        best_triton_pos = next(
+            (
+                i
+                for i, choice in enumerate(sorted_choices)
+                if isinstance(choice, TritonTemplateCaller)
+            ),
+            None,
+        )
+        if best_triton_pos is not None:
+            metadata["best_triton_pos"] = best_triton_pos
+            best_triton_kernel = sorted_choices[best_triton_pos]
+            if best_triton_pos != 0:
+                metadata["best_triton_time"] = timings[best_triton_kernel]
+                metadata["best_triton_kernel"] = best_triton_kernel.name
+                if best_triton_kernel.description:
+                    metadata["best_triton_kernel_desc"] = best_triton_kernel.description
 
-    payload = json.dumps(metadata)
-    get_chromium_event_logger().add_event_data(
-        event_name, autotune_choices_stats=payload
-    )
-    sys.stderr.write(f"Autotune Choices Stats:\n{payload}\n")
+        payload = json.dumps(metadata)
+        get_chromium_event_logger().add_event_data(
+            event_name, autotune_choices_stats=payload
+        )
+        sys.stderr.write(f"Autotune Choices Stats:\n{payload}\n")
+    except Exception as exc:
+        get_chromium_event_logger().try_add_event_data(
+            event_name, metadata={"error": str(exc)}
+        )
 
 
 def _log_autotune_exceptions(


### PR DESCRIPTION
Summary:
We're seeing a data discrepancy between autotune_metadata and autotune_choice_stats. Ideally, autotuning events should have both. However, we only see about 10% of autotuning events containing both.

There are two unlikely but possible reasons:
1. There are actually no choices.
2. Exceptions were thrown.

This change adds a try-catch block to capture these exceptions and avoid interrupting the normal training flow.

Test Plan:
```
TORCHINDUCTOR_MAX_AUTOTUNE_REPORT_CHOICES_STATS=1 pytest test/inductor/test_max_autotune.py
```

Fixes #ISSUE_NUMBER


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben