### PR TITLE
Remove the dead code in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1194,16 +1194,6 @@ class build_ext(setuptools.command.build_ext.build_ext):
         else:
             report("-- Not using ITT")
 
-        # Do not use clang to compile extensions if `-fstack-clash-protection` is defined
-        # in system CFLAGS
-        c_flags = os.getenv("CFLAGS", "")
-        if (
-            IS_LINUX
-            and "-fstack-clash-protection" in c_flags
-            and "clang" in os.getenv("CC", "")
-        ):
-            os.environ["CC"] = str(os.environ["CC"])
-
         super().run()
 
         if IS_DARWIN:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #160515

The following line has no effect.

https://github.com/pytorch/pytorch/blob/34ec5ed275f8aa875c80daa97b3e82af0b06f673/setup.py#L1205

This code was originally introduced in this PR: https://github.com/pytorch/pytorch/commit/dd7cec680cc439af1fd5933b763ab2b963a3f643,
and clang11 and later now support `-fstack-clash-protection`. Can we remove this line?

@malfet