### PR TITLE
remove duplicate import for defaultdict

### DIFF
--- a/functorch/op_analysis/gen_data.py
+++ b/functorch/op_analysis/gen_data.py
@@ -33,7 +33,6 @@ def gen_data(special_op_lists, analysis_name):
     annotated_ops = {
         a.strip(): b.strip() for a, b in list(csv.reader(open("annotated_ops")))
     }
-    from collections import defaultdict
 
     uniq_ops = []
     uniq_names = set()


### PR DESCRIPTION
Fixes #160518

This PR aims to remove the duplicate import of defaultdict in the following file:

https://github.com/pytorch/pytorch/blob/ecde76c764752540edf9ef62a97936c86d984b17/functorch/op_analysis/gen_data.py#L36


