### PR TITLE
UT/Examples for resharding checkpoint save/loads for distributed tensors with uneven shards.

### DIFF
--- a/test/distributed/checkpoint/test_dtensor_resharding.py
+++ b/test/distributed/checkpoint/test_dtensor_resharding.py
@@ -1,9 +1,24 @@
 # Owner(s): ["oncall: distributed"]
+import logging
+from typing import Any
+
 import torch
+import torch.distributed as dist
 import torch.distributed.checkpoint as dist_cp
 from torch.distributed.checkpoint._extension import ZStandard
+from torch.distributed.checkpoint.metadata import (
+    ChunkStorageMetadata,
+    MetadataIndex,
+    TensorProperties,
+)
+from torch.distributed.checkpoint.planner import (
+    TensorWriteData,
+    WriteItem,
+    WriteItemType,
+)
 from torch.distributed.device_mesh import init_device_mesh
-from torch.distributed.tensor import distribute_tensor, Replicate, Shard, zeros
+from torch.distributed.tensor import distribute_tensor, DTensor, Replicate, Shard, zeros
+from torch.distributed.tensor._shards_wrapper import LocalShardsWrapper
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -20,6 +35,9 @@ from torch.testing._internal.distributed.checkpoint_utils import (
     with_temp_dir,
 )
 
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 CHECKPOINT_DIR = "checkpoint"
 
@@ -279,9 +297,294 @@ class TestDTensorReshardMeshChange(DTensorTestBase):
             storage_reader=dist_cp.FileSystemReader(self.temp_dir),
         )
 
-    # TODO: Add a assertEqual for ref_state_dict["dtensor"].full_tensor()
-    # and state_dict["dtensor"].full_tensor() after we fix the size mismatch
-    # issue for un-even sharding dtensor.
+    @with_comms
+    @with_temp_dir
+    @skip_if_lt_x_gpu(2)
+    def test_dtensor_checkpoint_with_uneven_shards(self) -> None:
+        """
+        Saving a dtensor with uneven shards.
+        rank 0  -> [[0], [1], [2], [3]]
+        rank 1  -> [[4], [5], [6], [7]]
+        rank 2  -> [[8], [9], [10], [11]]
+        rank 3  -> [[12], [13]]
+        """
+        CHECKPOINT_DIR = self.temp_dir
+        mesh_shape = (self.world_size,)
+        mesh_1 = init_device_mesh(self.device_type, mesh_shape)
+        my_rank = dist.get_rank()
+        # Make the last shard uneven
+        if my_rank == self.world_size - 1:
+            local_tensor = torch.arange(
+                start=my_rank * 4, end=(my_rank * 4) + 2, dtype=torch.float
+            ).view(2, 1)
+        else:
+            local_tensor = torch.arange(
+                start=my_rank * 4, end=(my_rank + 1) * 4, dtype=torch.float
+            ).view(4, 1)
+        dtensor = DTensor.from_local(
+            local_tensor,
+            mesh_1,
+            [Shard(0)],
+            run_check=True,
+            shape=torch.Size([14, 1]),
+            stride=torch.Size([1, 1]),
+        )
+
+        state_dict_to_save = {"uneven_sharded_dtensor": dtensor}
+
+        dist_cp.save(
+            state_dict=state_dict_to_save,
+            storage_writer=dist_cp.FileSystemWriter(path=CHECKPOINT_DIR),
+            planner=dist_cp.DefaultSavePlanner(),
+        )
+
+        loading_full_tensor = torch.rand([14, 1], dtype=torch.float, device="cpu")
+        print(f"rank {my_rank} loading_dtensor for load :\n {loading_full_tensor}")
+        state_dict_to_load = {
+            "uneven_sharded_dtensor": loading_full_tensor
+        }  # re-sharding load.
+        dist_cp.load(
+            state_dict=state_dict_to_load,
+            storage_reader=dist_cp.FileSystemReader(self.temp_dir),
+        )
+
+
+class CheckpointableDistTensor(torch.Tensor):
+    """
+    A distributed checkpointable tensor representation. Unlike Dtensor, this representation
+    cannot be used for distributed training.
+
+    Supports distributed tensor save/loads that has uneven shards. (DTensor cannot support the same)
+    """
+
+    _local_tensor: torch.Tensor
+    _shard_offsets: torch.Size
+    _overall_size: torch.Size
+
+    @staticmethod
+    def __new__(
+        cls,
+        fqn: str,
+        local_tensor: torch.Tensor,
+        shard_offsets: list[int],
+        overall_size: list[int],
+    ) -> "CheckpointableDistTensor":
+        r = torch.Tensor._make_wrapper_subclass(
+            cls,
+            overall_size,
+            dtype=local_tensor.dtype,
+            device=local_tensor.device,
+            layout=local_tensor.layout,
+        )
+
+        r._fqn = fqn
+        r._local_tensor = local_tensor
+        r._shard_offsets = torch.Size(shard_offsets)
+        r._overall_size = torch.Size(overall_size)
+
+        return r
+
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+
+    @classmethod
+    def __torch_dispatch__(cls, func, types, args=(), kwargs=None):  # type: ignore[override]
+        raise NotImplementedError(
+            f"{func} is not supported for CheckpointableDistTensor!"
+        )
+
+    def __create_chunk_list__(self):
+        return [
+            ChunkStorageMetadata(
+                offsets=self._shard_offsets, sizes=self._local_tensor.size()
+            )
+        ]
+
+    def __create_write_items__(self, fqn: str, object: Any) -> list[WriteItem]:
+        return [
+            WriteItem(
+                index=MetadataIndex(fqn=self._fqn, offset=self._shard_offsets),
+                type=WriteItemType.SHARD,
+                tensor_data=TensorWriteData(
+                    chunk=ChunkStorageMetadata(
+                        offsets=self._shard_offsets, sizes=self._local_tensor.size()
+                    ),
+                    properties=TensorProperties.create_from_tensor(self._local_tensor),
+                    size=self._overall_size,
+                ),
+            )
+        ]
+
+    def __get_tensor_shard__(self, index: MetadataIndex) -> torch.Tensor:
+        assert self._fqn == index.fqn and self._shard_offsets == index.offset
+        return self._local_tensor
+
+    def __repr__(self):
+        return (
+            f"CheckpointableDistributedTensor("
+            f"fqn={self._fqn}, "
+            f"local_tensor={self._local_tensor}, "
+            f"shard_offset={self._shard_offset}, "
+            f"overall_size={self._overall_size})"
+        )
+
+
+class TestCheckpointableReshard(DTensorTestBase):
+    """
+    Test DCP reshard loads when shard sizes are uneven across the ranks.
+    """
+
+    @with_comms
+    @with_temp_dir
+    def test_uneven_reshard_with_checkpointable_api(self) -> None:
+        """
+        Saves a 1d distributed tensor that has shards with uneven sizes using Checkpointable API.
+        Loads them back with a different shard plan (resharding). By default this UT runs with
+        NUM_DEVICES = 4.
+        """
+        saving_1d_shard_plan = [
+            (0, 4),
+            (4, 3),
+            (7, 4),
+            (11, 5),
+        ]  # offset, length tuples.
+        loading_1d_shard_plan = [(0, 2), (2, 4), (6, 6), (12, 4)]
+        CHECKPOINT_DIR = self.temp_dir
+        my_rank = dist.get_rank()
+        saving_shard_offset, saving_shard_length = saving_1d_shard_plan[my_rank]
+        saving_local_tensor = torch.arange(
+            start=saving_shard_offset,
+            end=saving_shard_offset + saving_shard_length,
+            dtype=torch.float,
+        ).view(saving_shard_length, 1)
+        logger.info(f"[{my_rank}] saving_local_tensor : {saving_local_tensor}")  # noqa: G004
+        saving_cp_dist_tensor = CheckpointableDistTensor(
+            fqn="checkpointable_tensor",
+            local_tensor=saving_local_tensor,
+            shard_offsets=[saving_shard_offset, 0],
+            overall_size=[16, 1],
+        )
+        state_dict_to_save = {"checkpointable_tensor": saving_cp_dist_tensor}
+
+        dist_cp.save(
+            state_dict=state_dict_to_save,
+            storage_writer=dist_cp.FileSystemWriter(path=CHECKPOINT_DIR),
+            planner=dist_cp.DefaultSavePlanner(),
+        )
+
+        loading_shard_offset, loading_shard_length = loading_1d_shard_plan[my_rank]
+        loading_local_tensor = torch.rand([loading_shard_length, 1], dtype=torch.float)
+        logger.info(
+            f"[{my_rank}] loading_local_tensor (initialized with random vals) : {loading_local_tensor}"  # noqa: G004
+        )
+        expected_loaded_local_val_tensor = torch.arange(
+            start=loading_shard_offset,
+            end=loading_shard_offset + loading_shard_length,
+            dtype=torch.float,
+        ).view(loading_shard_length, 1)
+
+        loading_cp_dist_tensor = CheckpointableDistTensor(
+            fqn="checkpointable_tensor",
+            local_tensor=loading_local_tensor,
+            shard_offsets=[loading_shard_offset, 0],
+            overall_size=[16, 1],
+        )
+        state_dict_to_load = {"checkpointable_tensor": loading_cp_dist_tensor}
+        dist_cp.load(
+            state_dict=state_dict_to_load,
+            storage_reader=dist_cp.FileSystemReader(self.temp_dir),
+        )
+        assert torch.equal(loading_local_tensor, expected_loaded_local_val_tensor)
+
+    @with_comms
+    @with_temp_dir
+    def test_uneven_reshard_with_dtensor_shards_wrapper_api(self) -> None:
+        """
+        Saves a 1d distributed tensor that has shards with uneven sizes using Checkpointable API.
+        Loads them back with a different shard plan (resharding). By default this UT runs with
+        NUM_DEVICES = 4.
+        """
+        # NB: saving shardin plan and loading sharding plans are different and their
+        #     shard lengths are uneven.
+        saving_1d_shard_plan = [
+            (0, 4),
+            (4, 3),
+            (7, 4),
+            (11, 5),
+        ]  # offset, length tuples.
+        loading_1d_shard_plan = [(0, 6), (6, 2), (8, 1), (9, 7)]
+        cp_path = self.temp_dir
+        my_rank = dist.get_rank()
+
+        # 1d device mesh on CPU device
+        mesh_shape = (self.world_size,)
+        device_mesh = init_device_mesh("cpu", mesh_shape)
+
+        saving_shard_offset, saving_shard_length = saving_1d_shard_plan[my_rank]
+        saving_local_tensor = torch.arange(
+            start=saving_shard_offset,
+            end=saving_shard_offset + saving_shard_length,
+            dtype=torch.float,
+        ).view(saving_shard_length, 1)
+
+        # In order to support uneven shards we have to wrap the original shards in LocalShardsWrapper.
+        saving_local_shard_wrapper = LocalShardsWrapper(
+            local_shards=[saving_local_tensor], local_offsets=[(saving_shard_offset, 0)]
+        )
+
+        logger.info(
+            f"[{my_rank}] saving_local_shard_warpper : {saving_local_shard_wrapper}"  # noqa: G004
+        )
+
+        saving_cp_dist_tensor = DTensor.from_local(
+            local_tensor=saving_local_shard_wrapper,
+            device_mesh=device_mesh,
+            placements=[Shard(0)],
+            shape=torch.Size([16, 1]),
+            stride=torch.Size([1, 1]),
+        )
+
+        # put the DTensor in a state dict and call DCP save.
+        state_dict_to_save = {"checkpointable_tensor": saving_cp_dist_tensor}
+        dist_cp.save(
+            state_dict=state_dict_to_save,
+            storage_writer=dist_cp.FileSystemWriter(path=cp_path),
+            planner=dist_cp.DefaultSavePlanner(),
+        )
+
+        loading_shard_offset, loading_shard_length = loading_1d_shard_plan[my_rank]
+        loading_local_tensor = torch.rand(
+            [loading_shard_length, 1], dtype=torch.float, device="cpu"
+        )
+        loading_local_shard_wrapper = LocalShardsWrapper(
+            local_shards=[loading_local_tensor],
+            local_offsets=[(loading_shard_offset, 0)],
+        )
+
+        expected_loaded_local_val_tensor = torch.arange(
+            start=loading_shard_offset,
+            end=loading_shard_offset + loading_shard_length,
+            dtype=torch.float,
+        ).view(loading_shard_length, 1)
+
+        loading_cp_dist_tensor = DTensor.from_local(
+            local_tensor=loading_local_shard_wrapper,
+            device_mesh=device_mesh,
+            placements=[Shard(0)],
+            shape=torch.Size([16, 1]),
+            stride=torch.Size([1, 1]),
+        )
+        state_dict_to_load = {"checkpointable_tensor": loading_cp_dist_tensor}
+
+        dist_cp.load(
+            state_dict=state_dict_to_load,
+            storage_reader=dist_cp.FileSystemReader(path=cp_path),
+        )
+        logger.info(
+            f"[{my_rank}] loaded_shards_wrapper : {loading_local_shard_wrapper}"  # noqa: G004
+        )
+        assert torch.equal(loading_local_tensor, expected_loaded_local_val_tensor)
+        dist.barrier()
 
 
 # TODO: Add dtensor resharding test when world size changes.


### PR DESCRIPTION
1\  DTensor abstraction on its own, does not support arbitrary length shards in its distributed tensors representation. It supports a single uneven shard, bit it has to be the last shard in the sharding dimension.

2\ However, DCP supports an API called checkpointable. This API allows you to define your custom shardable tensor structure. I have given a UT example ( look for CheckpointableDistTensor). Therefore, one option is to use CheckpointableDistTensor to save/load uneven shards.

3\ While exploring this path, I also noticed that torch.rec module also encountered a similar problem while working with DTensor. They workaround it by implementing Checkpointable API in DTensor and introducing an auxillary structure called LocalShardsWrapper. This is the second option we can use to unblock data loader resharding work.

In summary;
Use LocalShardWrapper + DTensor as the first option to unblock.
Second preference is to use new implementation of Checkpointable API. ( similar to CheckpointbaleDistTensor I have introduced in this example).

Differential Revision: D80182564




cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci