### PR TITLE
Skip compilation when FX graph has no calls and returns empty

### DIFF
--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1648,7 +1648,9 @@ class OutputGraph(OutputGraphGuardsState):
             assert self.should_exit
 
             self.run_compiler_collective()
-
+            if count_calls(self.graph) == 0 and len(rv) == 0:
+                return []
+            
             name = unique_id("__compiled_fn", with_uuid=True)
 
             assert isinstance(rv, list)

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1650,7 +1650,7 @@ class OutputGraph(OutputGraphGuardsState):
             self.run_compiler_collective()
             if count_calls(self.graph) == 0 and len(rv) == 0:
                 return []
-            
+
             name = unique_id("__compiled_fn", with_uuid=True)
 
             assert isinstance(rv, list)


### PR DESCRIPTION
Fixes #160437

Summary: 
This PR avoids compiling empty FX graphs generated during graph breaks. If there are no calls in the graph, we can just return the empty list of instructions. 

More precisely, 
In compile_and_call_fx_graph, if the FX graph contains no calls (count_calls(self.graph) == 0) and the return value list is empty, we now return an empty instruction list immediately

Impact:
module: dynamo

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela