### PR TITLE
adding types to nn module init 

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -8,7 +8,7 @@ import weakref
 from collections import namedtuple, OrderedDict
 from collections.abc import Iterator, Mapping
 from typing import Any, Callable, Optional, overload, TypeVar, Union, Dict
-from typing_extensions import Self, TypeVarTuple
+from typing_extensions import Self, TypeVarTuple, Unpack
 import torch
 from torch import device, dtype, Tensor
 from torch._prims_common import DeviceLikeType
@@ -399,6 +399,7 @@ def _forward_unimplemented(self, *input: Any) -> None:
         f'Module [{type(self).__name__}] is missing the required "forward" function'
     )
 
+_Ts = TypeVarTuple("_Ts")
 
 class Module:
     r"""Base class for all neural network modules.
@@ -475,7 +476,7 @@ class Module:
     call_super_init: bool = False
     _compiled_call_impl: Optional[Callable] = None
 
-    def __init__(self, *args: TypeVarTuple, **kwargs: Dict[str, Any]) -> None:
+    def __init__(self, *args: Unpack[_Ts], **kwargs: Dict[str, Any]) -> None:
         """Initialize internal Module state, shared by both nn.Module and ScriptModule."""
         torch._C._log_api_usage_once("python.nn_module")
 

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -7,9 +7,8 @@ import warnings
 import weakref
 from collections import namedtuple, OrderedDict
 from collections.abc import Iterator, Mapping
-from typing import Any, Callable, Optional, overload, TypeVar, Union
-from typing_extensions import Self
-
+from typing import Any, Callable, Optional, overload, TypeVar, Union, Dict
+from typing_extensions import Self, TypeVarTuple
 import torch
 from torch import device, dtype, Tensor
 from torch._prims_common import DeviceLikeType
@@ -476,7 +475,7 @@ class Module:
     call_super_init: bool = False
     _compiled_call_impl: Optional[Callable] = None
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: TypeVarTuple, **kwargs: Dict[str, Any]) -> None:
         """Initialize internal Module state, shared by both nn.Module and ScriptModule."""
         torch._C._log_api_usage_once("python.nn_module")
 

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -521,7 +521,7 @@ class Module:
         super().__setattr__("_modules", {})
 
         if self.call_super_init:
-            super().__init__(*args, **kwargs)
+            super().__init__(*args, **kwargs) # type: ignore[misc]
 
     forward: Callable[..., Any] = _forward_unimplemented
 

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -7,7 +7,7 @@ import warnings
 import weakref
 from collections import namedtuple, OrderedDict
 from collections.abc import Iterator, Mapping
-from typing import Any, Callable, Dict, Optional, overload, TypeVar, Union
+from typing import Any, Callable, Optional, overload, TypeVar, Union
 from typing_extensions import Self, TypeVarTuple, Unpack
 
 import torch
@@ -479,7 +479,7 @@ class Module:
     call_super_init: bool = False
     _compiled_call_impl: Optional[Callable] = None
 
-    def __init__(self, *args: Unpack[_Ts], **kwargs: Dict[str, Any]) -> None:
+    def __init__(self, *args: Unpack[_Ts], **kwargs: dict[str, Any]) -> None:
         """Initialize internal Module state, shared by both nn.Module and ScriptModule."""
         torch._C._log_api_usage_once("python.nn_module")
 

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -7,8 +7,9 @@ import warnings
 import weakref
 from collections import namedtuple, OrderedDict
 from collections.abc import Iterator, Mapping
-from typing import Any, Callable, Optional, overload, TypeVar, Union, Dict
+from typing import Any, Callable, Dict, Optional, overload, TypeVar, Union
 from typing_extensions import Self, TypeVarTuple, Unpack
+
 import torch
 from torch import device, dtype, Tensor
 from torch._prims_common import DeviceLikeType
@@ -399,7 +400,9 @@ def _forward_unimplemented(self, *input: Any) -> None:
         f'Module [{type(self).__name__}] is missing the required "forward" function'
     )
 
+
 _Ts = TypeVarTuple("_Ts")
+
 
 class Module:
     r"""Base class for all neural network modules.


### PR DESCRIPTION
Fixes #156740 

Have added variadic type variable support to nn.Module

```
    def __init__(self, *args, **kwargs) -> None:
```
to
```
    def __init__(self, *args: Unpack[_Ts], **kwargs: dict[str, Any]) -> None:
```
torch/nn/modules/module.py 

raised again because the older PR became stale