### PR TITLE
[pytorch][dynamo_compile] Log graph_node_shape to dynamo_compile

### DIFF
--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -274,7 +274,7 @@ class TestDynamoTimed(TestCase):
 
     @dynamo_config.patch({"log_compilation_metrics": True})
     @inductor_config.patch({"force_disable_caches": True})
-    def test_graph_node_shape(self):
+    def test_graph_node_shapes(self):
         self.warmup()
 
         compilation_events = []
@@ -282,7 +282,10 @@ class TestDynamoTimed(TestCase):
             self.run_forward_backward()
             compilation_events = [arg[0][0] for arg in log_event.call_args_list]
 
-        self.assertEqual(compilation_events[0].graph_node_shape, "{'l_self_modules_linear_parameters_weight_': [1, 3], 'l_self_modules_linear_parameters_bias_': [1], 'l_x_': [3], 'linear': [1]}")
+        self.assertEqual(
+            compilation_events[0].graph_node_shapes,
+            "{'l_self_modules_linear_parameters_weight_': [1, 3], 'l_self_modules_linear_parameters_bias_': [1], 'l_x_': [3], 'linear': [1]}",
+        )
 
     @dynamo_config.patch(
         {
@@ -435,7 +438,7 @@ class TestDynamoTimed(TestCase):
             e.triton_version = None
             e.python_version = None
             e.stack_trace = None
-            e.graph_node_shape = None
+            e.graph_node_shapes = None
 
         # First event is for the forward. Formatting makes reading diffs
         # much easier.
@@ -482,7 +485,7 @@ class TestDynamoTimed(TestCase):
  'gc_time_us': 0,
  'graph_input_count': 1,
  'graph_node_count': 3,
- 'graph_node_shape': None,
+ 'graph_node_shapes': None,
  'graph_op_count': 1,
  'guard_count': 9,
  'has_guarded_code': True,
@@ -565,7 +568,7 @@ class TestDynamoTimed(TestCase):
  'gc_time_us': 0,
  'graph_input_count': 1,
  'graph_node_count': 3,
- 'graph_node_shape': None,
+ 'graph_node_shapes': None,
  'graph_op_count': 1,
  'guard_count': 9,
  'has_guarded_code': True,
@@ -659,7 +662,7 @@ class TestDynamoTimed(TestCase):
  'gc_time_us': None,
  'graph_input_count': None,
  'graph_node_count': None,
- 'graph_node_shape': None,
+ 'graph_node_shapes': None,
  'graph_op_count': None,
  'guard_count': None,
  'has_guarded_code': None,
@@ -742,7 +745,7 @@ class TestDynamoTimed(TestCase):
  'gc_time_us': None,
  'graph_input_count': None,
  'graph_node_count': None,
- 'graph_node_shape': None,
+ 'graph_node_shapes': None,
  'graph_op_count': None,
  'guard_count': None,
  'has_guarded_code': None,

--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -434,7 +434,7 @@ class TestDynamoTimed(TestCase):
             e.cuda_version = None
             e.triton_version = None
             e.python_version = None
-            e.stack_trace = 
+            e.stack_trace = None
             e.graph_node_shape = None
 
         # First event is for the forward. Formatting makes reading diffs

--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -282,10 +282,12 @@ class TestDynamoTimed(TestCase):
             self.run_forward_backward()
             compilation_events = [arg[0][0] for arg in log_event.call_args_list]
 
-        self.assertEqual(
-            compilation_events[0].graph_node_shapes,
-            "{'l_self_modules_linear_parameters_weight_': [1, 3], 'l_self_modules_linear_parameters_bias_': [1], 'l_x_': [3], 'linear': [1]}",
-        )
+    self.assertEqual(
+        compilation_events[0].graph_node_shapes,
+        "{'l_self_modules_linear_parameters_weight_': [1, 3], "
+        "'l_self_modules_linear_parameters_bias_': [1], "
+        "'l_x_': [3], 'linear': [1]}"
+    )
 
     @dynamo_config.patch(
         {

--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -282,12 +282,12 @@ class TestDynamoTimed(TestCase):
             self.run_forward_backward()
             compilation_events = [arg[0][0] for arg in log_event.call_args_list]
 
-    self.assertEqual(
-        compilation_events[0].graph_node_shapes,
-        "{'l_self_modules_linear_parameters_weight_': [1, 3], "
-        "'l_self_modules_linear_parameters_bias_': [1], "
-        "'l_x_': [3], 'linear': [1]}"
-    )
+        self.assertEqual(
+            compilation_events[0].graph_node_shapes,
+            "{'l_self_modules_linear_parameters_weight_': [1, 3], "
+            "'l_self_modules_linear_parameters_bias_': [1], "
+            "'l_x_': [3], 'linear': [1]}",
+        )
 
     @dynamo_config.patch(
         {

--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -272,6 +272,18 @@ class TestDynamoTimed(TestCase):
             "Log file does not contain the expected string: 'test_stack_trace'",
         )
 
+    @dynamo_config.patch({"log_compilation_metrics": True})
+    @inductor_config.patch({"force_disable_caches": True})
+    def test_graph_node_shape(self):
+        self.warmup()
+
+        compilation_events = []
+        with mock.patch("torch._dynamo.utils.log_compilation_event") as log_event:
+            self.run_forward_backward()
+            compilation_events = [arg[0][0] for arg in log_event.call_args_list]
+
+        self.assertEqual(compilation_events[0].graph_node_shape, "{'l_self_modules_linear_parameters_weight_': [1, 3], 'l_self_modules_linear_parameters_bias_': [1], 'l_x_': [3], 'linear': [1]}")
+
     @dynamo_config.patch(
         {
             "log_compilation_metrics": True,
@@ -422,7 +434,8 @@ class TestDynamoTimed(TestCase):
             e.cuda_version = None
             e.triton_version = None
             e.python_version = None
-            e.stack_trace = None
+            e.stack_trace = 
+            e.graph_node_shape = None
 
         # First event is for the forward. Formatting makes reading diffs
         # much easier.
@@ -469,6 +482,7 @@ class TestDynamoTimed(TestCase):
  'gc_time_us': 0,
  'graph_input_count': 1,
  'graph_node_count': 3,
+ 'graph_node_shape': None,
  'graph_op_count': 1,
  'guard_count': 9,
  'has_guarded_code': True,
@@ -551,6 +565,7 @@ class TestDynamoTimed(TestCase):
  'gc_time_us': 0,
  'graph_input_count': 1,
  'graph_node_count': 3,
+ 'graph_node_shape': None,
  'graph_op_count': 1,
  'guard_count': 9,
  'has_guarded_code': True,
@@ -644,6 +659,7 @@ class TestDynamoTimed(TestCase):
  'gc_time_us': None,
  'graph_input_count': None,
  'graph_node_count': None,
+ 'graph_node_shape': None,
  'graph_op_count': None,
  'guard_count': None,
  'has_guarded_code': None,
@@ -726,6 +742,7 @@ class TestDynamoTimed(TestCase):
  'gc_time_us': None,
  'graph_input_count': None,
  'graph_node_count': None,
+ 'graph_node_shape': None,
  'graph_op_count': None,
  'guard_count': None,
  'has_guarded_code': None,

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1261,7 +1261,7 @@ def _compile(
                 shape_env_guard_count = len(output.shape_env.guards)
                 graph_op_count = output.count_calls()
                 graph_node_count = len(output.graph.nodes)
-                graph_node_shape = output.get_graph_sizes_structured()
+                graph_node_shapes = output.get_graph_sizes_structured()
                 graph_input_count = len(output.placeholders)
                 non_compliant_ops = {op.__qualname__ for op in output.non_compliant_ops}
                 compliant_custom_ops = {
@@ -1273,7 +1273,7 @@ def _compile(
                 shape_env_guard_count = None
                 graph_op_count = None
                 graph_node_count = None
-                graph_node_shape = dict({})
+                graph_node_shapes = {}
                 graph_input_count = None
                 non_compliant_ops = set({})
                 compliant_custom_ops = set({})
@@ -1308,7 +1308,7 @@ def _compile(
                     dynamo_time_before_restart
                 ),
                 "stack_trace": stack_trace,
-                "graph_node_shape": str(graph_node_shape),
+                "graph_node_shapes": str(graph_node_shapes),
             }
             # TODO: replace with CompileEventLogger.compilation_metrics
             # There are some columns here not in PT2 Compile Events

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1261,6 +1261,7 @@ def _compile(
                 shape_env_guard_count = len(output.shape_env.guards)
                 graph_op_count = output.count_calls()
                 graph_node_count = len(output.graph.nodes)
+                graph_node_shape = output.get_graph_sizes_structured()
                 graph_input_count = len(output.placeholders)
                 non_compliant_ops = {op.__qualname__ for op in output.non_compliant_ops}
                 compliant_custom_ops = {
@@ -1272,6 +1273,7 @@ def _compile(
                 shape_env_guard_count = None
                 graph_op_count = None
                 graph_node_count = None
+                graph_node_shape = dict({})
                 graph_input_count = None
                 non_compliant_ops = set({})
                 compliant_custom_ops = set({})
@@ -1306,6 +1308,7 @@ def _compile(
                     dynamo_time_before_restart
                 ),
                 "stack_trace": stack_trace,
+                "graph_node_shape": str(graph_node_shape),
             }
             # TODO: replace with CompileEventLogger.compilation_metrics
             # There are some columns here not in PT2 Compile Events

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1289,7 +1289,7 @@ class CompilationMetrics:
     restart_reasons: Optional[set[str]] = None
     dynamo_time_before_restart_s: Optional[float] = None
     stack_trace: Optional[list[str]] = None
-    graph_node_shape: Optional[str] = None
+    graph_node_shapes: Optional[str] = None
     # Sometimes, we will finish analyzing a frame but conclude we don't want
     # to install any guarded code.  True means we actually decided to install
     # a compiled frame

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1289,6 +1289,7 @@ class CompilationMetrics:
     restart_reasons: Optional[set[str]] = None
     dynamo_time_before_restart_s: Optional[float] = None
     stack_trace: Optional[list[str]] = None
+    graph_node_shape: Optional[str] = None
     # Sometimes, we will finish analyzing a frame but conclude we don't want
     # to install any guarded code.  True means we actually decided to install
     # a compiled frame


### PR DESCRIPTION
This PR adds the dynamo graph node shape logging to dynamo compile. Also added unit tests to check if correct graph node shape is being logged.

Test Plan:
$ python -m test_utils
Ran 12 tests in 36.447s
OK

Note: Will merge after D80185628 lands.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela