### PR TITLE
[PP] Allow larger world_size schedule tests

### DIFF
--- a/test/distributed/pipelining/model_registry.py
+++ b/test/distributed/pipelining/model_registry.py
@@ -211,10 +211,10 @@ class MLPModuleWithDw(torch.nn.Module):
         self.fc2_weight = torch.nn.Parameter(torch.randn(d_hid, d_hid))
         self.fc2_bias = torch.nn.Parameter(torch.randn(d_hid))
 
-        torch.nn.init.uniform_(self.fc1_weight, -0.01, 0.01)
-        torch.nn.init.uniform_(self.fc2_weight, -0.01, 0.01)
-        torch.nn.init.uniform_(self.fc1_bias, -0.01, 0.01)
-        torch.nn.init.uniform_(self.fc2_bias, -0.01, 0.01)
+        torch.nn.init.uniform_(self.fc1_weight, -0.001, 0.001)
+        torch.nn.init.uniform_(self.fc2_weight, -0.001, 0.001)
+        torch.nn.init.uniform_(self.fc1_bias, -0.001, 0.001)
+        torch.nn.init.uniform_(self.fc2_bias, -0.001, 0.001)
 
         self.cached_context = {}
         self.cached_context["fc1"] = []

--- a/test/distributed/pipelining/test_schedule_multiproc.py
+++ b/test/distributed/pipelining/test_schedule_multiproc.py
@@ -46,7 +46,7 @@ from torch.testing._internal.common_utils import (
 logger = logging.getLogger(__name__)
 
 d_hid = 512
-batch_size = 32
+batch_size = 64
 torch.manual_seed(0)
 device_type = "cuda"
 

--- a/test/distributed/pipelining/test_schedule_multiproc.py
+++ b/test/distributed/pipelining/test_schedule_multiproc.py
@@ -3,6 +3,7 @@
 import copy
 import logging
 import tempfile
+from dataclasses import dataclass
 
 from model_registry import ModelWithKwargs, MultiMLP, MultiMLPKwargs, MultiMLPWithDw
 from schedule_registry import (
@@ -27,6 +28,7 @@ from torch.distributed.pipelining import (
     ScheduleZBVZeroBubble,
 )
 from torch.distributed.pipelining.schedules import _PipelineScheduleRuntime
+from torch.nn.modules.loss import MSELoss
 from torch.testing._internal.common_cuda import TEST_MULTIGPU
 from torch.testing._internal.common_distributed import (
     MultiProcContinousTest,
@@ -44,13 +46,161 @@ from torch.testing._internal.common_utils import (
 logger = logging.getLogger(__name__)
 
 d_hid = 512
-batch_size = 64
+batch_size = 32
 torch.manual_seed(0)
 device_type = "cuda"
 
 
+@dataclass
+class PipelineTestConfig:
+    world_size: int
+    device: torch.device
+    rank: int
+
+
+def setup_models_and_data(
+    config: PipelineTestConfig, n_layers=None, model_class=MultiMLP
+):
+    """Setup models, input data, target data, and loss function."""
+    if n_layers is None:
+        n_layers = config.world_size
+
+    full_mod = model_class(d_hid, n_layers=n_layers)
+    full_mod.to(config.device)
+    ref_mod = copy.deepcopy(full_mod)
+
+    x = torch.randn(batch_size, d_hid, device=config.device)
+    with torch.no_grad():
+        y = ref_mod(x)
+        target = y + torch.randn(batch_size, d_hid, device=config.device)
+
+    loss_fn = torch.nn.MSELoss(reduction="sum")
+    return full_mod, ref_mod, x, target, loss_fn
+
+
+def create_single_stage_pipeline(
+    config: PipelineTestConfig, mod, x, chunks, use_tracer=True
+):
+    """Create a single-stage pipeline using either tracer or manual stage creation."""
+    if use_tracer:
+        x_mb = x.chunk(chunks)[0]
+        split_spec = mod.split_spec if hasattr(mod, "split_spec") else None
+        pipe = pipeline(mod, mb_args=(x_mb,), split_spec=split_spec)
+        stage = pipe.build_stage(config.rank, config.device)
+        stage_module = pipe.get_stage_module(config.rank)
+        return stage, stage_module, [stage_module]
+    else:
+        # Manual stage creation
+        submod_name = f"layers.{config.rank}"
+        stage_module = mod.get_submodule(submod_name)
+        stage = PipelineStage(
+            stage_module, config.rank, config.world_size, config.device
+        )
+        return stage, stage_module, [stage_module]
+
+
+def create_multi_stage_pipeline(
+    config: PipelineTestConfig, mod, stages_per_rank, n_stages, stage_indices=None
+):
+    """Create multiple pipeline stages for interleaved schedules."""
+    if stage_indices is None:
+        stage_indices = [
+            config.rank + i * config.world_size for i in range(stages_per_rank)
+        ]
+
+    submod_names = [f"layers.{i}" for i in stage_indices]
+    stage_modules = [mod.get_submodule(submod_name) for submod_name in submod_names]
+    stages = [
+        PipelineStage(stage_module, stage_idx, n_stages, config.device)
+        for stage_module, stage_idx in zip(stage_modules, stage_indices, strict=True)
+    ]
+    return stages, stage_modules, submod_names
+
+
+def run_reference_model(ref_mod, x, target, loss_fn, num_iterations=2, **kwargs):
+    """Run reference model for specified iterations and return final output and loss."""
+    ref_out = None
+    ref_loss = None
+
+    for _ in range(num_iterations):
+        ref_mod.zero_grad()
+        ref_out = ref_mod(x, **kwargs)
+        ref_loss = loss_fn(ref_out, target)
+        ref_loss.backward()
+
+    return ref_out, ref_loss
+
+
+def check_gradients(
+    config: PipelineTestConfig,
+    stage_modules,
+    ref_mod,
+    submod_names=None,
+    rtol=1e-5,
+    atol=4e-5,
+):
+    """Check that gradients match between pipeline stages and reference model using flexible comparison."""
+
+    def grad_check(grad1, grad2, param_name, rtol, atol, tolerance=0.05):
+        if grad1 is None and grad2 is None:
+            return
+        if grad1 is None or grad2 is None:
+            raise AssertionError(
+                f"One gradient is None for {param_name}: {grad1} vs {grad2}"
+            )
+        try:
+            torch.testing.assert_close(grad1, grad2, rtol=rtol, atol=atol)
+        except AssertionError:
+            print(
+                f"Numerical issues detected for {param_name}: param grad {grad1} vs ref grad {grad2}"
+            )
+            raise
+
+    if submod_names is None:
+        # Single stage case - need to detect tracer vs manual pipeline
+        stage_modules = [stage_modules]
+
+        # Try to detect if this is a tracer-based pipeline by checking if parameter exists in ref_mod
+        sample_param_name = next(iter(stage_modules[0].named_parameters()))[0]
+        try:
+            # Try to get parameter directly from reference model (tracer-based)
+            ref_mod.get_parameter(sample_param_name)
+            is_tracer_based = True
+        except AttributeError:
+            # Parameter doesn't exist at root level, must be manual pipeline
+            is_tracer_based = False
+
+        if is_tracer_based:
+            # Tracer-based pipeline: parameter names are full paths from root model
+            for name, p in stage_modules[0].named_parameters():
+                ref_p = ref_mod.get_parameter(name)
+                grad_check(p.grad, ref_p.grad, name, rtol, atol)
+        else:
+            # Manual pipeline: parameter names are local to the submodule
+            submod_name = f"layers.{config.rank}"
+            ref_submod = ref_mod.get_submodule(submod_name)
+            for name, p in stage_modules[0].named_parameters():
+                ref_p = ref_submod.get_parameter(name)
+                grad_check(p.grad, ref_p.grad, f"{submod_name}.{name}", rtol, atol)
+    else:
+        # Multi-stage case - always use submodule approach
+        for stage_module, submod_name in zip(stage_modules, submod_names):
+            ref_submod = ref_mod.get_submodule(submod_name)
+            for name, p in stage_module.named_parameters():
+                ref_p = ref_submod.get_parameter(name)
+                grad_check(p.grad, ref_p.grad, f"{submod_name}.{name}", rtol, atol)
+
+
+def zero_gradients(stage_modules):
+    """Zero gradients for all stage modules."""
+    if not isinstance(stage_modules, list):
+        stage_modules = [stage_modules]
+    for stage_module in stage_modules:
+        stage_module.zero_grad()
+
+
 class ScheduleTest(MultiProcContinousTest):
-    world_size = 2
+    world_size = 4
 
     @classmethod
     def backend_str(cls) -> str:
@@ -61,143 +211,24 @@ class ScheduleTest(MultiProcContinousTest):
     def device(self) -> torch.device:
         return torch.device(device_type, self.rank)
 
-    def _setup_models_and_data(self, n_layers=None, model_class=MultiMLP):
-        """Setup models, input data, target data, and loss function."""
-        if n_layers is None:
-            n_layers = self.world_size
-
-        full_mod = model_class(d_hid, n_layers=n_layers)
-        full_mod.to(self.device)
-        ref_mod = copy.deepcopy(full_mod)
-
-        x = torch.randn(batch_size, d_hid, device=self.device)
-        with torch.no_grad():
-            y = ref_mod(x)
-            target = y + torch.randn(batch_size, d_hid, device=self.device)
-
-        loss_fn = torch.nn.MSELoss(reduction="sum")
-        return full_mod, ref_mod, x, target, loss_fn
-
-    def _create_single_stage_pipeline(self, mod, x, chunks, use_tracer=True):
-        """Create a single-stage pipeline using either tracer or manual stage creation."""
-        if use_tracer:
-            x_mb = x.chunk(chunks)[0]
-            split_spec = mod.split_spec if hasattr(mod, "split_spec") else None
-            pipe = pipeline(mod, mb_args=(x_mb,), split_spec=split_spec)
-            stage = pipe.build_stage(self.rank, self.device)
-            stage_module = pipe.get_stage_module(self.rank)
-            return stage, stage_module, [stage_module]
-        else:
-            # Manual stage creation
-            submod_name = f"layers.{self.rank}"
-            stage_module = mod.get_submodule(submod_name)
-            stage = PipelineStage(stage_module, self.rank, self.world_size, self.device)
-            return stage, stage_module, [stage_module]
-
-    def _create_multi_stage_pipeline(
-        self, mod, stages_per_rank, n_stages, stage_indices=None
-    ):
-        """Create multiple pipeline stages for interleaved schedules."""
-        if stage_indices is None:
-            stage_indices = [
-                self.rank + i * self.world_size for i in range(stages_per_rank)
-            ]
-
-        submod_names = [f"layers.{i}" for i in stage_indices]
-        stage_modules = [mod.get_submodule(submod_name) for submod_name in submod_names]
-        stages = [
-            PipelineStage(stage_module, stage_idx, n_stages, self.device)
-            for stage_module, stage_idx in zip(
-                stage_modules, stage_indices, strict=True
-            )
-        ]
-        return stages, stage_modules, submod_names
-
-    def _run_reference_model(
-        self, ref_mod, x, target, loss_fn, num_iterations=2, **kwargs
-    ):
-        """Run reference model for specified iterations and return final output and loss."""
-        ref_out = None
-        ref_loss = None
-
-        for _ in range(num_iterations):
-            ref_mod.zero_grad()
-            ref_out = ref_mod(x, **kwargs)
-            ref_loss = loss_fn(ref_out, target)
-            ref_loss.backward()
-
-        return ref_out, ref_loss
-
-    def _check_gradients(
-        self, stage_modules, ref_mod, submod_names=None, rtol=1e-5, atol=4e-5
-    ):
-        """Check that gradients match between pipeline stages and reference model using flexible comparison."""
-
-        def grad_check(grad1, grad2, param_name, rtol, atol, tolerance=0.05):
-            if grad1 is None and grad2 is None:
-                return
-            if grad1 is None or grad2 is None:
-                raise AssertionError(
-                    f"One gradient is None for {param_name}: {grad1} vs {grad2}"
-                )
-            try:
-                torch.testing.assert_close(grad1, grad2, rtol=rtol, atol=atol)
-            except AssertionError:
-                print(
-                    f"Numerical issues detected for {param_name}: param grad {grad1} vs ref grad {grad2}"
-                )
-                raise
-
-        if submod_names is None:
-            # Single stage case - need to detect tracer vs manual pipeline
-            stage_modules = [stage_modules]
-
-            # Try to detect if this is a tracer-based pipeline by checking if parameter exists in ref_mod
-            sample_param_name = next(iter(stage_modules[0].named_parameters()))[0]
-            try:
-                # Try to get parameter directly from reference model (tracer-based)
-                ref_mod.get_parameter(sample_param_name)
-                is_tracer_based = True
-            except AttributeError:
-                # Parameter doesn't exist at root level, must be manual pipeline
-                is_tracer_based = False
-
-            if is_tracer_based:
-                # Tracer-based pipeline: parameter names are full paths from root model
-                for name, p in stage_modules[0].named_parameters():
-                    ref_p = ref_mod.get_parameter(name)
-                    grad_check(p.grad, ref_p.grad, name, rtol, atol)
-            else:
-                # Manual pipeline: parameter names are local to the submodule
-                submod_name = f"layers.{self.rank}"
-                ref_submod = ref_mod.get_submodule(submod_name)
-                for name, p in stage_modules[0].named_parameters():
-                    ref_p = ref_submod.get_parameter(name)
-                    grad_check(p.grad, ref_p.grad, f"{submod_name}.{name}", rtol, atol)
-        else:
-            # Multi-stage case - always use submodule approach
-            for stage_module, submod_name in zip(stage_modules, submod_names):
-                ref_submod = ref_mod.get_submodule(submod_name)
-                for name, p in stage_module.named_parameters():
-                    ref_p = ref_submod.get_parameter(name)
-                    grad_check(p.grad, ref_p.grad, f"{submod_name}.{name}", rtol, atol)
-
-    def _zero_gradients(self, stage_modules):
-        """Zero gradients for all stage modules."""
-        if not isinstance(stage_modules, list):
-            stage_modules = [stage_modules]
-        for stage_module in stage_modules:
-            stage_module.zero_grad()
+    @property
+    def config(self) -> PipelineTestConfig:
+        """Lazily create and return the pipeline test configuration."""
+        return PipelineTestConfig(
+            world_size=self.world_size, device=self.device, rank=self.rank
+        )
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     @parametrize("ScheduleClass", [_ScheduleForwardOnly])
     def test_forward_only(self, ScheduleClass):
-        mod, mod_ref, x, _, _ = self._setup_models_and_data()
+        mod, mod_ref, x, _, _ = setup_models_and_data(self.config)
         x_clone = x.clone()
 
         num_microbatches = 2 * self.world_size
-        stage, _, _ = self._create_single_stage_pipeline(mod, x, num_microbatches)
+        stage, _, _ = create_single_stage_pipeline(
+            self.config, mod, x, num_microbatches
+        )
         schedule = ScheduleClass(stage, num_microbatches, scale_grads=False)
 
         # Run forward-only schedule
@@ -241,22 +272,24 @@ class ScheduleTest(MultiProcContinousTest):
             # Multi-stage schedules
             stages_per_rank = 2
             n_stages = stages_per_rank * self.world_size
-            mod, _, x, target, loss_fn = self._setup_models_and_data(n_layers=n_stages)
+            mod, _, x, target, loss_fn = setup_models_and_data(
+                self.config, n_layers=n_stages
+            )
 
             # Create multi-stage pipeline
-            stages, stage_modules, _ = self._create_multi_stage_pipeline(
-                mod, stages_per_rank, n_stages
+            stages, stage_modules, _ = create_multi_stage_pipeline(
+                self.config, mod, stages_per_rank, n_stages
             )
             schedule = ScheduleClass(
                 stages, num_microbatches, loss_fn=loss_fn, scale_grads=False
             )
         else:
             # Single-stage schedules
-            mod, _, x, target, loss_fn = self._setup_models_and_data()
+            mod, _, x, target, loss_fn = setup_models_and_data(self.config)
 
             # Create single-stage pipeline
-            stage, stage_module, _ = self._create_single_stage_pipeline(
-                mod, x, num_microbatches
+            stage, stage_module, _ = create_single_stage_pipeline(
+                self.config, mod, x, num_microbatches
             )
             stage_modules = [stage_module]
             schedule = ScheduleClass(
@@ -264,7 +297,7 @@ class ScheduleTest(MultiProcContinousTest):
             )
 
         # Clear gradients and run eval
-        self._zero_gradients(stage_modules)
+        zero_gradients(stage_modules)
         losses = []
 
         if self.rank == 0:
@@ -296,9 +329,9 @@ class ScheduleTest(MultiProcContinousTest):
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     @parametrize("ScheduleClass", [ScheduleGPipe, Schedule1F1B])
     def test_multi_iter(self, ScheduleClass):
-        mod, _, x, target, loss_fn = self._setup_models_and_data()
+        mod, _, x, target, loss_fn = setup_models_and_data(self.config)
         chunks = 4
-        stage, _, _ = self._create_single_stage_pipeline(mod, x, chunks)
+        stage, _, _ = create_single_stage_pipeline(self.config, mod, x, chunks)
         schedule = ScheduleClass(stage, chunks, loss_fn=loss_fn, scale_grads=False)
 
         # Run
@@ -311,17 +344,13 @@ class ScheduleTest(MultiProcContinousTest):
             else:
                 schedule.step()
 
+        dist.barrier(device_ids=[self.rank])
+
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     @parametrize("ScheduleClass", [ScheduleGPipe, Schedule1F1B])
     def test_kwargs_with_tracer(self, ScheduleClass):
-        # Model has two stages only, thus limiting group size to 2
-        group_size = 2
-        group = dist.new_group(list(range(group_size)))
-        if self.rank >= group_size:
-            return
-
-        mod = ModelWithKwargs(d_hid)
+        mod = ModelWithKwargs(d_hid, splits=self.world_size)
         mod.to(self.device)
 
         x = torch.randn(batch_size, d_hid, device=self.device)
@@ -342,7 +371,6 @@ class ScheduleTest(MultiProcContinousTest):
         stage = pipe.build_stage(
             self.rank,
             self.device,
-            group=group,
         )
 
         # Attach to a schedule
@@ -353,15 +381,15 @@ class ScheduleTest(MultiProcContinousTest):
         losses = []
         if self.rank == 0:
             schedule.step(x, y=y)
-        elif self.rank == group_size - 1:
+        elif self.rank == self.world_size - 1:
             out = schedule.step(target=target, losses=losses)
         else:
             schedule.step()
 
-        # dist.barrier()
+        dist.barrier(device_ids=[self.rank])
 
         # Last rank checks result
-        if self.rank == group_size - 1:
+        if self.rank == self.world_size - 1:
             ref_out = mod(x, y=y)
             ref_loss = loss_fn(ref_out, target)
             pipe_loss = sum(losses)
@@ -372,15 +400,15 @@ class ScheduleTest(MultiProcContinousTest):
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     @parametrize("ScheduleClass", [ScheduleGPipe, Schedule1F1B])
     def test_grad_with_tracer(self, ScheduleClass):
-        mod, ref_mod, x, target, loss_fn = self._setup_models_and_data()
+        mod, ref_mod, x, target, loss_fn = setup_models_and_data(self.config)
 
         # Run reference
-        ref_out, ref_loss = self._run_reference_model(ref_mod, x, target, loss_fn)
+        ref_out, ref_loss = run_reference_model(ref_mod, x, target, loss_fn)
 
         # Create pipeline and schedule
         chunks = 2 * self.world_size
-        stage, stage_module, stage_modules = self._create_single_stage_pipeline(
-            mod, x, chunks
+        stage, stage_module, stage_modules = create_single_stage_pipeline(
+            self.config, mod, x, chunks
         )
         schedule = ScheduleClass(stage, chunks, loss_fn=loss_fn, scale_grads=False)
 
@@ -388,7 +416,7 @@ class ScheduleTest(MultiProcContinousTest):
         out = None
         losses = []
         for _ in range(2):
-            self._zero_gradients(stage_module)
+            zero_gradients(stage_module)
             if self.rank == 0:
                 schedule.step(x)
             elif self.rank == self.world_size - 1:
@@ -396,7 +424,7 @@ class ScheduleTest(MultiProcContinousTest):
             else:
                 schedule.step()
 
-        dist.barrier()
+        dist.barrier(device_ids=[self.rank])
 
         # Last rank checks result
         if self.rank == self.world_size - 1:
@@ -405,22 +433,22 @@ class ScheduleTest(MultiProcContinousTest):
             torch.testing.assert_close(pipe_loss, ref_loss)
 
         # Check gradients using helper method
-        self._check_gradients(stage_module, ref_mod)
+        check_gradients(self.config, stage_module, ref_mod)
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     @parametrize("ScheduleClass", [ScheduleGPipe, Schedule1F1B])
     @parametrize("shape_inference", [True, False])
     def test_grad_with_manual(self, ScheduleClass, shape_inference):
-        mod, ref_mod, x, target, loss_fn = self._setup_models_and_data()
+        mod, ref_mod, x, target, loss_fn = setup_models_and_data(self.config)
 
         # Run reference
-        ref_out, ref_loss = self._run_reference_model(ref_mod, x, target, loss_fn)
+        ref_out, ref_loss = run_reference_model(ref_mod, x, target, loss_fn)
 
         # Create manual pipeline stage
         chunks = 2 * self.world_size
-        stage, stage_module, _ = self._create_single_stage_pipeline(
-            mod, x, chunks, use_tracer=False
+        stage, stage_module, _ = create_single_stage_pipeline(
+            self.config, mod, x, chunks, use_tracer=False
         )
 
         # Handle shape inference
@@ -443,7 +471,7 @@ class ScheduleTest(MultiProcContinousTest):
         out = None
         losses = []
         for _ in range(2):
-            self._zero_gradients(stage_module)
+            zero_gradients(stage_module)
             if self.rank == 0:
                 schedule.step(x)
             elif self.rank == self.world_size - 1:
@@ -451,7 +479,7 @@ class ScheduleTest(MultiProcContinousTest):
             else:
                 schedule.step()
 
-        dist.barrier()
+        dist.barrier(device_ids=[self.rank])
 
         # Last rank checks result
         if self.rank == self.world_size - 1:
@@ -460,7 +488,7 @@ class ScheduleTest(MultiProcContinousTest):
             torch.testing.assert_close(pipe_loss, ref_loss)
 
         # Check gradients using helper method
-        self._check_gradients(stage_module, ref_mod)
+        check_gradients(self.config, stage_module, ref_mod)
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
@@ -476,16 +504,16 @@ class ScheduleTest(MultiProcContinousTest):
     def test_grad_with_manual_interleaved(self, ScheduleClass, use_new_runtime):
         stages_per_rank = 2
         n_stages = stages_per_rank * self.world_size
-        mod, ref_mod, x, target, loss_fn = self._setup_models_and_data(
-            n_layers=n_stages
+        mod, ref_mod, x, target, loss_fn = setup_models_and_data(
+            self.config, n_layers=n_stages
         )
 
         # Run reference
-        ref_out, ref_loss = self._run_reference_model(ref_mod, x, target, loss_fn)
+        ref_out, ref_loss = run_reference_model(ref_mod, x, target, loss_fn)
 
         # Create multi-stage pipeline
-        stages, stage_modules, submod_names = self._create_multi_stage_pipeline(
-            mod, stages_per_rank, n_stages
+        stages, stage_modules, submod_names = create_multi_stage_pipeline(
+            self.config, mod, stages_per_rank, n_stages
         )
         print(f"Rank {self.rank} stages: {[stage.stage_index for stage in stages]}")
 
@@ -545,7 +573,7 @@ class ScheduleTest(MultiProcContinousTest):
         losses = []
         with check_leaked_tensors() as garbage_tensors:
             for _ in range(2):
-                self._zero_gradients(stage_modules)
+                zero_gradients(stage_modules)
                 if self.rank == 0:
                     schedule.step(x)
                 elif self.rank == self.world_size - 1:
@@ -568,239 +596,9 @@ class ScheduleTest(MultiProcContinousTest):
 
         # Check gradients - use relaxed tolerances for interleaved schedules
         # since gradients are small
-        self._check_gradients(
-            stage_modules, ref_mod, submod_names, rtol=5e-3, atol=5e-3
+        check_gradients(
+            self.config, stage_modules, ref_mod, submod_names, rtol=5e-3, atol=5e-3
         )
-
-    @requires_nccl()
-    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    @parametrize("ScheduleClass", [ScheduleWithW, ScheduleInterleavedZeroBubble])
-    def test_schedule_with_native_zero_bubble(self, ScheduleClass):
-        print(ScheduleClass)
-        if ScheduleClass is ScheduleInterleavedZeroBubble:
-            n_stages = 4
-            num_microbatches = 2 * n_stages
-            rank_stages = {0: [0, 2], 1: [1, 3]}
-        else:
-            n_stages = ScheduleClass.n_stages
-            num_microbatches = ScheduleClass.num_microbatches
-            rank_stages = ScheduleClass.rank_stages
-
-        num_steps = 4
-        mod, ref_mod, x, target, loss_fn = self._setup_models_and_data(
-            n_layers=n_stages
-        )
-
-        # Create multi-stage pipeline with custom stage indices
-        stage_indices = rank_stages[self.rank]
-        print(f"Rank {self.rank} stages: {stage_indices}")
-        stages, stage_modules, submod_names = self._create_multi_stage_pipeline(
-            mod, len(stage_indices), n_stages, stage_indices
-        )
-
-        schedule = ScheduleClass(
-            stages, num_microbatches, loss_fn=loss_fn, scale_grads=False
-        )
-
-        # Run reference model
-        ref_x = x.detach().clone().requires_grad_(x.requires_grad)
-        torch.testing.assert_close(x, ref_x)
-        for _ in range(num_steps):
-            ref_out = ref_mod(ref_x)
-            ref_loss = loss_fn(ref_out, target)
-            ref_loss.backward()
-
-        # Run pipeline with tensor leak checking
-        losses = []
-        with check_leaked_tensors() as garbage_tensors:
-            for _ in range(num_steps):
-                if self.rank == 0:
-                    schedule.step(x)
-                elif self.rank == self.world_size - 1:
-                    schedule.step(target=target, losses=losses)
-                else:
-                    schedule.step()
-
-        self.assertEqual(
-            len(garbage_tensors),
-            0,
-            "Found leaked tensors, check logs above for debug info",
-        )
-
-        # Check gradients using helper method
-        self._check_gradients(stage_modules, ref_mod, submod_names)
-
-    @requires_nccl()
-    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    @parametrize("ScheduleClass", [ScheduleWithReorderedB])
-    def test_pipeline_schedule_runtime_custom_sched(self, ScheduleClass):
-        n_stages = 2
-        stages_per_rank = 1
-        mod, ref_mod, x, target, loss_fn = self._setup_models_and_data(
-            n_layers=n_stages
-        )
-
-        # Run reference
-        ref_out, ref_loss = self._run_reference_model(ref_mod, x, target, loss_fn)
-
-        # Create pipeline stages
-        stages, stage_modules, submod_names = self._create_multi_stage_pipeline(
-            mod, stages_per_rank, n_stages
-        )
-        print(f"Rank {self.rank} stages: {[stage.stage_index for stage in stages]}")
-
-        num_microbatches = (
-            ScheduleClass.num_microbatches
-            if hasattr(ScheduleClass, "num_microbatches")
-            else 8
-        )
-
-        schedule = ScheduleClass(
-            stages, num_microbatches, loss_fn=loss_fn, scale_grads=False
-        )
-        assert isinstance(schedule, _PipelineScheduleRuntime)
-
-        # Run pipeline with tensor leak checking
-        with check_leaked_tensors() as garbage_tensors:
-            for _ in range(2):
-                self._zero_gradients(stage_modules)
-                if self.rank == 0:
-                    schedule.step(x)
-                elif self.rank == self.world_size - 1:
-                    losses = []
-                    out = schedule.step(target=target, losses=losses)
-                else:
-                    schedule.step()
-
-        self.assertEqual(
-            len(garbage_tensors),
-            0,
-            "Found leaked tensors, check logs above for debug info",
-        )
-        dist.barrier()
-
-        # Verify results
-        if self.rank == self.world_size - 1:
-            torch.testing.assert_close(out, ref_out)
-            pipe_loss = sum(losses)
-            torch.testing.assert_close(pipe_loss, ref_loss)
-
-        # Check gradients using helper method
-        self._check_gradients(stage_modules, ref_mod, submod_names)
-
-    @requires_nccl()
-    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    @parametrize(
-        "schedule_class",
-        [ScheduleZBVZeroBubble, ScheduleDualPipeV],
-    )
-    @parametrize("use_new_runtime", [False, True])
-    def test_v_shape_schedules(self, schedule_class, use_new_runtime):
-        # n_stages = 8
-        # rank_stages = {0: [0, 7], 1: [1, 6], 2: [2, 5], 3: [3, 4]}
-        n_stages = 4
-        rank_stages = {0: [0, 3], 1: [1, 2]}
-        mod, ref_mod, x, target, loss_fn = self._setup_models_and_data(
-            n_layers=n_stages
-        )
-
-        # Run reference
-        ref_out, ref_loss = self._run_reference_model(ref_mod, x, target, loss_fn)
-
-        # Create multi-stage pipeline with custom stage indices
-        num_microbatches = 8
-        stage_indices = rank_stages[self.rank]
-        stages, stage_modules, submod_names = self._create_multi_stage_pipeline(
-            mod, len(stage_indices), n_stages, stage_indices
-        )
-
-        schedule = schedule_class(
-            stages, num_microbatches, loss_fn=loss_fn, scale_grads=False
-        )
-
-        if schedule_class != ScheduleDualPipeV and use_new_runtime:
-            old_schedule = schedule
-            schedule = _PipelineScheduleRuntime(
-                stages, num_microbatches, loss_fn=loss_fn
-            )
-            schedule._prepare_schedule_with_comms(old_schedule.pipeline_order)
-
-        # Run pipeline - special case where first and last stage are on rank 0
-        out = None
-        losses = []
-        for _ in range(2):
-            self._zero_gradients(stage_modules)
-            if self.rank == 0:
-                out = schedule.step(x, target=target, losses=losses)
-            else:
-                schedule.step()
-
-        # Verify results (rank 0 has both first and last stages)
-        if self.rank == 0:
-            torch.testing.assert_close(out, ref_out)
-            pipe_loss = sum(losses)
-            torch.testing.assert_close(pipe_loss, ref_loss)
-
-        # Check gradients using helper method
-        self._check_gradients(stage_modules, ref_mod, submod_names)
-
-    @requires_nccl()
-    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    @parametrize(
-        "schedule_class",
-        [ScheduleVShaped, ScheduleUnbalanced],
-    )
-    @parametrize("use_new_runtime", [False, True])
-    def test_non_symmetric_stage_ids(self, schedule_class, use_new_runtime):
-        n_stages = schedule_class.n_stages
-        rank_stages = schedule_class.rank_stages
-
-        mod, ref_mod, x, target, loss_fn = self._setup_models_and_data(
-            n_layers=n_stages
-        )
-
-        # Run reference
-        ref_out, ref_loss = self._run_reference_model(ref_mod, x, target, loss_fn)
-
-        # Create multi-stage pipeline with custom stage indices
-        num_microbatches = 1
-        stage_indices = rank_stages[self.rank]
-        print(f"Rank {self.rank} stages: {stage_indices}")
-        stages, stage_modules, submod_names = self._create_multi_stage_pipeline(
-            mod, len(stage_indices), n_stages, stage_indices
-        )
-
-        schedule = schedule_class(
-            stages, num_microbatches, loss_fn=loss_fn, scale_grads=False
-        )
-
-        if use_new_runtime:
-            old_schedule = schedule
-            schedule = _PipelineScheduleRuntime(
-                stages, num_microbatches, loss_fn=loss_fn
-            )
-            schedule._prepare_schedule_with_comms(old_schedule.pipeline_order)
-
-        # Run pipeline - special case where first and last stage are on rank 0
-        out = None
-        losses = []
-        for _ in range(2):
-            self._zero_gradients(stage_modules)
-            if self.rank == 0:
-                out = schedule.step(x, target=target, losses=losses)
-            else:
-                schedule.step()
-
-        dist.barrier()
-
-        # Verify results (rank 0 has both first and last stages)
-        if self.rank == 0:
-            torch.testing.assert_close(out, ref_out)
-            pipe_loss = sum(losses)
-            torch.testing.assert_close(pipe_loss, ref_loss)
-
-        # Check gradients using helper method
-        self._check_gradients(stage_modules, ref_mod, submod_names)
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
@@ -808,17 +606,18 @@ class ScheduleTest(MultiProcContinousTest):
     def test_schedule_with_weight_update_mlp_e2e(self, ScheduleClass):
         stages_per_rank = 2
         n_stages = stages_per_rank * self.world_size
-        full_mod, ref_mod, x, target, loss_fn = self._setup_models_and_data(
-            n_layers=n_stages, model_class=MultiMLPWithDw
+        full_mod, ref_mod, x, target, _ = setup_models_and_data(
+            self.config, n_layers=n_stages, model_class=MultiMLPWithDw
         )
         full_mod.toggle()
+        loss_fn = MSELoss()
 
         # Run reference
-        ref_out, ref_loss = self._run_reference_model(ref_mod, x, target, loss_fn)
+        ref_out, ref_loss = run_reference_model(ref_mod, x, target, loss_fn)
 
         # Create multi-stage pipeline with custom dw_builder
-        stages, stage_modules, submod_names = self._create_multi_stage_pipeline(
-            full_mod, stages_per_rank, n_stages
+        stages, stage_modules, submod_names = create_multi_stage_pipeline(
+            self.config, full_mod, stages_per_rank, n_stages
         )
 
         class CustomState:
@@ -857,13 +656,13 @@ class ScheduleTest(MultiProcContinousTest):
             for stage_module, stage_idx in zip(stage_modules, stage_indices)
         ]
 
-        schedule = ScheduleClass(stages, 2, loss_fn=loss_fn, scale_grads=False)
+        schedule = ScheduleClass(stages, 2, loss_fn=loss_fn)
 
         # Run pipeline
         out = None
         losses = []
         for _ in range(2):
-            self._zero_gradients(stage_modules)
+            zero_gradients(stage_modules)
             if self.rank == 0:
                 schedule.step(x)
             elif self.rank == self.world_size - 1:
@@ -871,16 +670,70 @@ class ScheduleTest(MultiProcContinousTest):
             else:
                 schedule.step()
 
-        dist.barrier()
+        dist.barrier(device_ids=[self.rank])
 
         # Verify results
         if self.rank == self.world_size - 1:
+            torch.testing.assert_close(out, ref_out)
+            pipe_loss = sum(losses) / len(losses)
+            torch.testing.assert_close(pipe_loss, ref_loss)
+
+        # Check gradients using helper method
+        check_gradients(self.config, stage_modules, ref_mod, submod_names)
+
+    @requires_nccl()
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
+    @parametrize(
+        "schedule_class",
+        [ScheduleZBVZeroBubble, ScheduleDualPipeV],
+    )
+    @parametrize("use_new_runtime", [False, True])
+    def test_v_shape_schedules(self, schedule_class, use_new_runtime):
+        n_stages = 8
+        rank_stages = {0: [0, 7], 1: [1, 6], 2: [2, 5], 3: [3, 4]}
+        mod, ref_mod, x, target, loss_fn = setup_models_and_data(
+            self.config, n_layers=n_stages
+        )
+
+        # Run reference
+        ref_out, ref_loss = run_reference_model(ref_mod, x, target, loss_fn)
+
+        # Create multi-stage pipeline with custom stage indices
+        num_microbatches = 8
+        stage_indices = rank_stages[self.rank]
+        stages, stage_modules, submod_names = create_multi_stage_pipeline(
+            self.config, mod, len(stage_indices), n_stages, stage_indices
+        )
+
+        schedule = schedule_class(
+            stages, num_microbatches, loss_fn=loss_fn, scale_grads=False
+        )
+
+        if schedule_class != ScheduleDualPipeV and use_new_runtime:
+            old_schedule = schedule
+            schedule = _PipelineScheduleRuntime(
+                stages, num_microbatches, loss_fn=loss_fn
+            )
+            schedule._prepare_schedule_with_comms(old_schedule.pipeline_order)
+
+        # Run pipeline - special case where first and last stage are on rank 0
+        out = None
+        losses = []
+        for _ in range(2):
+            zero_gradients(stage_modules)
+            if self.rank == 0:
+                out = schedule.step(x, target=target, losses=losses)
+            else:
+                schedule.step()
+
+        # Verify results (rank 0 has both first and last stages)
+        if self.rank == 0:
             torch.testing.assert_close(out, ref_out)
             pipe_loss = sum(losses)
             torch.testing.assert_close(pipe_loss, ref_loss)
 
         # Check gradients using helper method
-        self._check_gradients(stage_modules, ref_mod, submod_names)
+        check_gradients(self.config, stage_modules, ref_mod, submod_names)
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
@@ -891,19 +744,19 @@ class ScheduleTest(MultiProcContinousTest):
     def test_zero_bubble_with_model_kwargs(self, ScheduleClass):
         stages_per_rank = 2
         n_stages = stages_per_rank * self.world_size
-        mod, ref_mod, x, target, loss_fn = self._setup_models_and_data(
-            n_layers=n_stages, model_class=MultiMLPKwargs
+        mod, ref_mod, x, target, loss_fn = setup_models_and_data(
+            self.config, n_layers=n_stages, model_class=MultiMLPKwargs
         )
         unused_kwarg = torch.tensor([1.0], device=self.device)
 
         # Run reference with kwargs
-        ref_out, ref_loss = self._run_reference_model(
+        ref_out, ref_loss = run_reference_model(
             ref_mod, x, target, loss_fn, unused_kwarg=unused_kwarg
         )
 
         # Create multi-stage pipeline
-        stages, stage_modules, submod_names = self._create_multi_stage_pipeline(
-            mod, stages_per_rank, n_stages
+        stages, stage_modules, submod_names = create_multi_stage_pipeline(
+            self.config, mod, stages_per_rank, n_stages
         )
 
         num_microbatches = (
@@ -919,7 +772,7 @@ class ScheduleTest(MultiProcContinousTest):
         out = None
         losses = []
         for _ in range(2):
-            self._zero_gradients(stage_modules)
+            zero_gradients(stage_modules)
             if self.rank == 0:
                 schedule.step(
                     x,
@@ -941,12 +794,209 @@ class ScheduleTest(MultiProcContinousTest):
             torch.testing.assert_close(pipe_loss, ref_loss)
 
         # Check gradients using helper method
-        self._check_gradients(
-            stage_modules, ref_mod, submod_names, rtol=1e-5, atol=5e-3
+        check_gradients(
+            self.config, stage_modules, ref_mod, submod_names, rtol=3e-5, atol=5e-3
         )
 
 
 instantiate_parametrized_tests(ScheduleTest)
+
+
+class CustomSchedulesTest(MultiProcContinousTest):
+    """
+    These schedules are from the ScheduleRegistry and require world_size == 2
+    The schedules test weird and unconventional schedules for edge cases
+    """
+
+    world_size = 2
+
+    @classmethod
+    def backend_str(cls) -> str:
+        # Testing with NCCL backend
+        return "nccl"
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device(device_type, self.rank)
+
+    @property
+    def config(self) -> PipelineTestConfig:
+        """Lazily create and return the pipeline test configuration."""
+        return PipelineTestConfig(
+            world_size=self.world_size, device=self.device, rank=self.rank
+        )
+
+    @requires_nccl()
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
+    @parametrize(
+        "schedule_class",
+        [ScheduleVShaped, ScheduleUnbalanced],
+    )
+    @parametrize("use_new_runtime", [False, True])
+    def test_non_symmetric_stage_ids(self, schedule_class, use_new_runtime):
+        n_stages = schedule_class.n_stages
+        rank_stages = schedule_class.rank_stages
+
+        mod, ref_mod, x, target, loss_fn = setup_models_and_data(
+            self.config, n_layers=n_stages
+        )
+
+        # Run reference
+        ref_out, ref_loss = run_reference_model(ref_mod, x, target, loss_fn)
+
+        # Create multi-stage pipeline with custom stage indices
+        num_microbatches = 1
+        stage_indices = rank_stages[self.rank]
+        print(f"Rank {self.rank} stages: {stage_indices}")
+        stages, stage_modules, submod_names = create_multi_stage_pipeline(
+            self.config, mod, len(stage_indices), n_stages, stage_indices
+        )
+
+        schedule = schedule_class(
+            stages, num_microbatches, loss_fn=loss_fn, scale_grads=False
+        )
+
+        if use_new_runtime:
+            old_schedule = schedule
+            schedule = _PipelineScheduleRuntime(
+                stages, num_microbatches, loss_fn=loss_fn
+            )
+            schedule._prepare_schedule_with_comms(old_schedule.pipeline_order)
+
+        # Run pipeline - special case where first and last stage are on rank 0
+        out = None
+        losses = []
+        for _ in range(2):
+            zero_gradients(stage_modules)
+            if self.rank == 0:
+                out = schedule.step(x, target=target, losses=losses)
+            else:
+                schedule.step()
+
+        dist.barrier()
+
+        # Verify results (rank 0 has both first and last stages)
+        if self.rank == 0:
+            torch.testing.assert_close(out, ref_out)
+            pipe_loss = sum(losses)
+            torch.testing.assert_close(pipe_loss, ref_loss)
+
+        # Check gradients using helper method
+        check_gradients(self.config, stage_modules, ref_mod, submod_names)
+
+    @requires_nccl()
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
+    @parametrize("ScheduleClass", [ScheduleWithReorderedB])
+    def test_pipeline_schedule_runtime_custom_sched(self, ScheduleClass):
+        n_stages = 2
+        stages_per_rank = 1
+        mod, ref_mod, x, target, loss_fn = setup_models_and_data(
+            self.config, n_layers=n_stages
+        )
+
+        # Run reference
+        ref_out, ref_loss = run_reference_model(ref_mod, x, target, loss_fn)
+
+        # Create pipeline stages
+        stages, stage_modules, submod_names = create_multi_stage_pipeline(
+            self.config, mod, stages_per_rank, n_stages
+        )
+        print(f"Rank {self.rank} stages: {[stage.stage_index for stage in stages]}")
+
+        num_microbatches = (
+            ScheduleClass.num_microbatches
+            if hasattr(ScheduleClass, "num_microbatches")
+            else 8
+        )
+
+        schedule = ScheduleClass(
+            stages, num_microbatches, loss_fn=loss_fn, scale_grads=False
+        )
+        assert isinstance(schedule, _PipelineScheduleRuntime)
+
+        # Run pipeline with tensor leak checking
+        with check_leaked_tensors() as garbage_tensors:
+            for _ in range(2):
+                zero_gradients(stage_modules)
+                if self.rank == 0:
+                    schedule.step(x)
+                elif self.rank == self.world_size - 1:
+                    losses = []
+                    out = schedule.step(target=target, losses=losses)
+                else:
+                    schedule.step()
+
+        self.assertEqual(
+            len(garbage_tensors),
+            0,
+            "Found leaked tensors, check logs above for debug info",
+        )
+        dist.barrier()
+
+        # Verify results
+        if self.rank == self.world_size - 1:
+            torch.testing.assert_close(out, ref_out)
+            pipe_loss = sum(losses)
+            torch.testing.assert_close(pipe_loss, ref_loss)
+
+        # Check gradients using helper method
+        check_gradients(self.config, stage_modules, ref_mod, submod_names)
+
+    @requires_nccl()
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
+    @parametrize("ScheduleClass", [ScheduleWithW])
+    def test_schedule_with_native_zero_bubble(self, ScheduleClass):
+        n_stages = ScheduleClass.n_stages
+        num_microbatches = ScheduleClass.num_microbatches
+        rank_stages = ScheduleClass.rank_stages
+
+        num_steps = 4
+        mod, ref_mod, x, target, loss_fn = setup_models_and_data(
+            self.config, n_layers=n_stages
+        )
+
+        # Create multi-stage pipeline with custom stage indices
+        stage_indices = rank_stages[self.rank]
+        print(f"Rank {self.rank} stages: {stage_indices}")
+        stages, stage_modules, submod_names = create_multi_stage_pipeline(
+            self.config, mod, len(stage_indices), n_stages, stage_indices
+        )
+
+        schedule = ScheduleClass(
+            stages, num_microbatches, loss_fn=loss_fn, scale_grads=False
+        )
+
+        # Run reference model
+        ref_x = x.detach().clone().requires_grad_(x.requires_grad)
+        torch.testing.assert_close(x, ref_x)
+        for _ in range(num_steps):
+            ref_out = ref_mod(ref_x)
+            ref_loss = loss_fn(ref_out, target)
+            ref_loss.backward()
+
+        # Run pipeline with tensor leak checking
+        losses = []
+        with check_leaked_tensors() as garbage_tensors:
+            for _ in range(num_steps):
+                if self.rank == 0:
+                    schedule.step(x)
+                elif self.rank == self.world_size - 1:
+                    schedule.step(target=target, losses=losses)
+                else:
+                    schedule.step()
+
+        self.assertEqual(
+            len(garbage_tensors),
+            0,
+            "Found leaked tensors, check logs above for debug info",
+        )
+
+        # Check gradients using helper method
+        check_gradients(self.config, stage_modules, ref_mod, submod_names)
+
+
+instantiate_parametrized_tests(CustomSchedulesTest)
+
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #160474
* __->__ #160559
* #160558

Update schedule tests to use `world_size=4`, changes needed:
- Move some tests that require world_size=2 to new class
- Move helper methods from class level to function level
- Update some initialization to pass assert since gradients were super small.


cc @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta