### PR TITLE
Fix torch.remainder crash when dividing INT_MIN by -1 on CPU

### DIFF
--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -352,7 +352,7 @@ void remainder_kernel(TensorIteratorBase& iter) {
     AT_DISPATCH_INTEGRAL_TYPES(iter.common_dtype(), "remainder_cpu", [&]() {
       cpu_kernel(iter, [](scalar_t a, scalar_t b) -> scalar_t {
         TORCH_CHECK(b != 0, "ZeroDivisionError");
-        // Prevent overflow when computing INT_MIN % -1. For all signed integer types, x % 1 is defined to be 0
+        // Prevent overflow when computing INT_MIN % -1. For all signed integer types, x % (-1) is defined to be 0
         if constexpr (std::is_signed_v<scalar_t>) {
           if (b == scalar_t(-1)) {
             return scalar_t(0);

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -352,6 +352,12 @@ void remainder_kernel(TensorIteratorBase& iter) {
     AT_DISPATCH_INTEGRAL_TYPES(iter.common_dtype(), "remainder_cpu", [&]() {
       cpu_kernel(iter, [](scalar_t a, scalar_t b) -> scalar_t {
         TORCH_CHECK(b != 0, "ZeroDivisionError");
+        // Prevent overflow when computing INT_MIN % -1. For all signed integer types, x % 1 is defined to be 0
+        if constexpr (std::is_signed_v<scalar_t>) {
+          if (b == scalar_t(-1)) {
+            return scalar_t(0);
+          }
+        }
         scalar_t r = a % b;
         if ((r != 0) && (c10::is_negative(r) != c10::is_negative(b))) {
           r += b;


### PR DESCRIPTION
Fixes #153919 

This changes updates the integer CPU kernel for torch.remainder to handle the special case of dividing the minimum representable  signed integer by -1.  Without this check, the operation causes an integer overflow and crashes. The fix returns 0 for this case which matches the definition of x % 1 == 0. I verified locally using the reproduction code from the issue report. 


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168