### PR TITLE
Fix redundant H2D/D2H memcpy in cpp_wrapper by creating scalar tensors on CPU

### DIFF
--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -65,6 +65,7 @@ class TestGpuWrapper(InductorTestCase):
     def test_non_tensor_args_wrapped_on_cpu(self):
         def test_fn(x, s):
             return (x + s).sum()
+
         compiled = torch.compile(options={"cpp_wrapper": True})(test_fn)
         x = torch.randn(4, device=self.device)
         with torch.utils._device.DeviceContext(self.device):

--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -63,6 +63,12 @@ class TestGpuWrapper(InductorTestCase):
         comp()
 
     def test_non_tensor_args_wrapped_on_cpu(self):
+        if not RUN_GPU:
+            self.skipTest("GPU not available")
+
+        if GPU_TYPE != "cuda":
+            self.skipTest("Test only runs on CUDA")
+
         def test_fn(x, s):
             return (x + s).sum()
 

--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -66,9 +66,6 @@ class TestGpuWrapper(InductorTestCase):
         if not RUN_GPU:
             self.skipTest("GPU not available")
 
-        if GPU_TYPE != "cuda":
-            self.skipTest("Test only runs on CUDA")
-
         def test_fn(x, s):
             return (x + s).sum()
 

--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -62,6 +62,15 @@ class TestGpuWrapper(InductorTestCase):
         )(test_fn)
         comp()
 
+    def test_non_tensor_args_wrapped_on_cpu(self):
+        def test_fn(x, s):
+            return (x + s).sum()
+        compiled = torch.compile(options={"cpp_wrapper": True})(test_fn)
+        x = torch.randn(4, device=self.device)
+        with torch.utils._device.DeviceContext(self.device):
+            _, code = test_torchinductor.run_and_get_cpp_code(compiled, x, 3)
+        self.assertIn("torch.tensor(arg, device='cpu')", code)
+
 
 class DynamicShapesGpuWrapperGpuTests(InductorTestCase):
     device = GPU_TYPE

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -1169,7 +1169,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
             """
         )
 
-        wrapper_body = "input_tensors = [arg if isinstance(arg, torch.Tensor) else torch.tensor(arg) for arg in args]"
+        wrapper_body = "input_tensors = [arg if isinstance(arg, torch.Tensor) else torch.tensor(arg, device='cpu') for arg in args]"
         if V.graph.constants:
             # Append constants to the input args for cpp wrapper.
             # Python wrapper directly gets the value inside the wrapper call


### PR DESCRIPTION
Fixes #160520 

Summary: 
When running Inductor with cpp_wrapper under a DeviceContext, non-tensor arguments were being wrapped with torch.tensor(arg) without specifying the device. 

creating the tensor on the current active device (like CUDA), and later fetching it back to CPU via .item(), causing unnecessary host-device-host memory transfers. 

PR fixes issue by explicitly creating scalar tensors on the CPU: 

```
input_tensors = [
    arg if isinstance(arg, torch.Tensor) else torch.tensor(arg, device='cpu')
    for arg in args
]
```

impact: inductor, codegen

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben