### PR TITLE
Add dim=None support to torch.logsumexp

### DIFF
--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1533,17 +1533,23 @@ TORCH_IMPL_FUNC(logsumexp_out)
   }
 }
 
-// CompositeExplicitAutograd fallback for backends without dedicated kernels
+// CompositeExplicitAutograd fallback for backends without dedicated kernels.
+// Unlike the structured path (CPU/CUDA), this bypasses the meta function,
+// so we must handle output dtype checking and name propagation explicitly.
 Tensor& logsumexp_out_default(const Tensor& self, IntArrayRef dim, bool keepdim, Tensor& result) {
   TORCH_CHECK(at::isFloatingType(result.scalar_type()) || at::isComplexType(result.scalar_type()),
               "logsumexp(): Expected floating point type for result tensor, but got: ",
               result.scalar_type());
-  if (at::isIntegralType(self.scalar_type(), /*includeBool=*/true)) {
-    auto default_dtype = at::typeMetaToScalarType(c10::get_default_dtype());
-    logsumexp_out_impl(result, self.to(default_dtype), dim, keepdim);
-  } else {
-    logsumexp_out_impl(result, self, dim, keepdim);
+  {
+    NoNamesGuard guard;
+    if (at::isIntegralType(self.scalar_type(), /*includeBool=*/true)) {
+      auto default_dtype = at::typeMetaToScalarType(c10::get_default_dtype());
+      logsumexp_out_impl(result, self.to(default_dtype), dim, keepdim);
+    } else {
+      logsumexp_out_impl(result, self, dim, keepdim);
+    }
   }
+  namedinference::propagate_names_for_reduction(result, self, dim, keepdim);
   return result;
 }
 

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -316,6 +316,23 @@ TORCH_META_FUNC2(mean, dim)
   resize_reduction(*this, self, opt_dim, keepdim, out_dtype);
 }
 
+TORCH_META_FUNC(logsumexp)
+(const Tensor& self, IntArrayRef dim, bool keepdim) {
+  ScalarType out_dtype;
+  if (at::isIntegralType(self.scalar_type(), /*includeBool=*/true)) {
+    out_dtype = at::typeMetaToScalarType(c10::get_default_dtype());
+  } else {
+    out_dtype = self.scalar_type();
+  }
+  const auto& result = maybe_get_output();
+  if (result.defined()) {
+    TORCH_CHECK(at::isFloatingType(result.scalar_type()) || at::isComplexType(result.scalar_type()),
+                "logsumexp(): Expected floating point type for result tensor, but got: ",
+                result.scalar_type());
+  }
+  resize_reduction(*this, self, dim, keepdim, out_dtype);
+}
+
 static ScalarType get_result_or_self_value_dtype(
     const Tensor& self,
     const Tensor& result,
@@ -1505,36 +1522,28 @@ static Tensor& logsumexp_out_impl(Tensor& result, const Tensor& self, IntArrayRe
   return result;
 }
 
-Tensor& logsumexp_out(const Tensor& self, IntArrayRef dims, bool keepdim, Tensor& result) {
-  // Complex type implies floating point type
+TORCH_IMPL_FUNC(logsumexp_out)
+(const Tensor& self, IntArrayRef dim, bool keepdim, const Tensor& result) {
+  if (at::isIntegralType(self.scalar_type(), /*includeBool=*/true)) {
+    auto default_dtype = at::typeMetaToScalarType(c10::get_default_dtype());
+    logsumexp_out_impl(const_cast<Tensor&>(result), self.to(default_dtype), dim, keepdim);
+  } else {
+    logsumexp_out_impl(const_cast<Tensor&>(result), self, dim, keepdim);
+  }
+}
+
+// CompositeExplicitAutograd fallback for backends without dedicated kernels
+Tensor& logsumexp_out_default(const Tensor& self, IntArrayRef dim, bool keepdim, Tensor& result) {
   TORCH_CHECK(at::isFloatingType(result.scalar_type()) || at::isComplexType(result.scalar_type()),
               "logsumexp(): Expected floating point type for result tensor, but got: ",
               result.scalar_type());
-  {
-    NoNamesGuard guard;
-    if (at::isIntegralType(self.scalar_type(), /*includeBool=*/true)) {
-      // for integral inputs, promote input to default floating type.
-      auto default_dtype = at::typeMetaToScalarType(c10::get_default_dtype());
-      logsumexp_out_impl(result, self.to(default_dtype), dims, keepdim);
-    } else {
-      logsumexp_out_impl(result, self, dims, keepdim);
-    }
-  }
-  namedinference::propagate_names_for_reduction(result, self, dims, keepdim);
-  return result;
-}
-
-Tensor logsumexp(const Tensor& self, IntArrayRef dims, bool keepdim) {
-  TensorOptions result_options;
   if (at::isIntegralType(self.scalar_type(), /*includeBool=*/true)) {
-    // even for integral inputs, result is floating dtype
     auto default_dtype = at::typeMetaToScalarType(c10::get_default_dtype());
-    result_options = self.options().dtype(default_dtype);
+    logsumexp_out_impl(result, self.to(default_dtype), dim, keepdim);
   } else {
-    result_options = self.options();
+    logsumexp_out_impl(result, self, dim, keepdim);
   }
-  auto result = at::empty({0}, result_options);
-  return at::logsumexp_outf(self, dims, keepdim, result);
+  return result;
 }
 
 Tensor logsumexp(const Tensor& self, DimnameList dims, bool keepdim) {

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1511,7 +1511,8 @@ static Tensor& logsumexp_out_impl(Tensor& result, const Tensor& self, IntArrayRe
     // For complex numbers, use the real part to calculate the max. Based on
     // https://scicomp.stackexchange.com/questions/34273/log-sum-exp-trick-for-signed-complex-numbers
     auto maxes = at::amax(at::real(self), dims, true);
-    auto maxes_squeezed = (keepdim ? maxes : at::squeeze(maxes, dims));
+    auto maxes_squeezed = keepdim ? maxes
+        : (dims.empty() ? at::squeeze(maxes) : at::squeeze(maxes, dims));
     maxes_squeezed.masked_fill_(maxes_squeezed.abs() == INFINITY, 0);
     at::sum_out(result, (self - maxes).exp_(), dims, keepdim);
     result.log_().add_(maxes_squeezed);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3811,13 +3811,13 @@
 
 - func: logcumsumexp.dimname_out(Tensor self, Dimname dim, *, Tensor(a!) out) -> Tensor(a!)
 
-- func: logsumexp(Tensor self, int[1] dim, bool keepdim=False) -> Tensor
+- func: logsumexp(Tensor self, int[1] dim=[], bool keepdim=False) -> Tensor
   structured_delegate: logsumexp.out
   device_check: NoCheck   # TensorIterator
   variants: function, method
   tags: reduction
 
-- func: logsumexp.out(Tensor self, int[1] dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
+- func: logsumexp.out(Tensor self, int[1] dim=[], bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
   structured: True
   device_check: NoCheck   # TensorIterator
   dispatch:
@@ -13872,11 +13872,11 @@
 - func: special_polygamma.out(int n, Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   python_module: special
 
-- func: special_logsumexp(Tensor self, int[1] dim, bool keepdim=False) -> Tensor
+- func: special_logsumexp(Tensor self, int[1] dim=[], bool keepdim=False) -> Tensor
   python_module: special
   variants: function
 
-- func: special_logsumexp.out(Tensor self, int[1] dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
+- func: special_logsumexp.out(Tensor self, int[1] dim=[], bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
   python_module: special
 
 - func: special_expit(Tensor self) -> Tensor

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3812,17 +3812,17 @@
 - func: logcumsumexp.dimname_out(Tensor self, Dimname dim, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: logsumexp(Tensor self, int[1] dim, bool keepdim=False) -> Tensor
+  structured_delegate: logsumexp.out
   device_check: NoCheck   # TensorIterator
   variants: function, method
-  dispatch:
-    CompositeExplicitAutograd: logsumexp
   tags: reduction
 
 - func: logsumexp.out(Tensor self, int[1] dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
+  structured: True
   device_check: NoCheck   # TensorIterator
   dispatch:
-    # calls squeeze
-    CompositeExplicitAutogradNonFunctional: logsumexp_out
+    CPU, CUDA: logsumexp_out
+    CompositeExplicitAutograd: logsumexp_out_default
   tags: reduction
 
 - func: logsumexp.names(Tensor self, Dimname[1] dim, bool keepdim=False) -> Tensor

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -175,6 +175,7 @@ meta_consistency_out_dtype_mismatch_xfails = {
     xfail("linalg.solve_ex"),
     xfail("linalg.solve_triangular"),
     xfail("logcumsumexp"),
+    xfail("logsumexp"),
     xfail("lu_solve"),
     xfail("lu_unpack"),
     xfail("mode"),

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -526,6 +526,27 @@ class TestReductions(TestCase):
         self.assertEqual(expected, actual)
 
     @skipIfNoSciPy
+    @dtypes(torch.float32, torch.float64)
+    def test_logsumexp_all_dims(self, device, dtype):
+        from scipy.special import logsumexp
+        a = torch.randn(3, 4, device=device, dtype=dtype)
+
+        # No dim argument: reduce over all dimensions
+        actual = torch.logsumexp(a)
+        expected = logsumexp(a.cpu().numpy().flatten())
+        self.assertEqual(expected.shape, actual.shape)
+        self.assertEqual(expected, actual)
+
+        # Equivalent to specifying all dims explicitly
+        actual_explicit = a.logsumexp(list(range(a.ndim)))
+        self.assertEqual(actual, actual_explicit)
+
+        # keepdim=True preserves all dims as size 1
+        actual_keepdim = torch.logsumexp(a, keepdim=True)
+        self.assertEqual(actual_keepdim.shape, torch.Size([1, 1]))
+        self.assertEqual(expected, actual_keepdim.squeeze())
+
+    @skipIfNoSciPy
     @dtypes(torch.complex64, torch.complex128)
     @dtypesIfXPU(torch.complex128)
     # Skip the torch.complex64 for XPU, see https://github.com/intel/torch-xpu-ops/issues/2279 for details

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1040,7 +1040,7 @@
   self: zeros_like(grad)
   result: self_t.zero_()
 
-- name: logsumexp(Tensor self, int[1] dim, bool keepdim=False) -> Tensor
+- name: logsumexp(Tensor self, int[1] dim=[], bool keepdim=False) -> Tensor
   self: logsumexp_backward(grad, self, result, dim, keepdim)
   result: logsumexp_jvp(self_p, self_t, dim, keepdim)
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -905,10 +905,12 @@ def log_softmax(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
 )
 def logsumexp(
-    self: TensorLikeType, dim: DimsType, keepdim: bool = False
+    self: TensorLikeType, dim: DimsType = (), keepdim: bool = False
 ) -> TensorLikeType:
     if not isinstance(dim, Iterable):
         dim = (dim,)
+    if len(dim) == 0:
+        dim = tuple(range(self.ndim))
     if self.numel() == 0:
         return torch.sum(torch.exp(self), dim, keepdim).log()
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -6376,7 +6376,7 @@ Example::
 add_docstr(
     torch.logsumexp,
     r"""
-logsumexp(input, dim, keepdim=False, *, out=None)
+logsumexp(input, dim=(), keepdim=False, *, out=None)
 
 Returns the log of summed exponentials of each row of the :attr:`input`
 tensor in the given dimension :attr:`dim`. The computation is numerically
@@ -6386,6 +6386,9 @@ For summation index :math:`j` given by `dim` and other indices :math:`i`, the re
 
     .. math::
         \text{{logsumexp}}(x)_{{i}} = \log \sum_j \exp(x_{{ij}})
+
+If :attr:`dim` is an empty tuple (the default), the reduction is performed
+over all dimensions, returning a scalar result.
 
 {keepdim_details}
 
@@ -6402,6 +6405,8 @@ Example::
     >>> a = torch.randn(3, 3)
     >>> torch.logsumexp(a, 1)
     tensor([1.4907, 1.0593, 1.5696])
+    >>> torch.logsumexp(a)
+    tensor(2.1762)
     >>> torch.dist(torch.logsumexp(a, 1), torch.log(torch.sum(torch.exp(a), 1)))
     tensor(1.6859e-07)
 """.format(**multi_dim_common),

--- a/torch/csrc/lazy/ts_backend/ts_native_functions.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_native_functions.cpp
@@ -492,7 +492,7 @@ at::Tensor& LazyNativeFunctions::logsumexp_out(
   tls_reenable_functionalize.set_excluded(
       curr_tls.excluded_.remove(c10::DispatchKey::Functionalize));
   c10::impl::ForceDispatchKeyGuard guard_(tls_reenable_functionalize);
-  at::native::logsumexp_out(self_wrapped, dim, keepdim, out_wrapped);
+  at::logsumexp_out(out_wrapped, self_wrapped, dim, keepdim);
   auto out_unwrapped =
       at::functionalization::impl::from_functional_tensor(out_wrapped);
   // propagate mutations back to the inputs (including resizing)

--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -1677,21 +1677,17 @@ def histc_strategy(op_schema: OpSchema) -> OpStrategy:
 def logsumexp_strategy(op_schema: OpSchema) -> OpStrategy:
     """Implements the sharding propagation strategy for logsumexp."""
 
-    # args_schema contains all but the DTensor args (e.g., dim, keepdim).
     args_schema = op_schema.args_schema
-    if not len(args_schema) > 1:
-        raise AssertionError(
-            f"Expected more than 1 arg (input and dim are required), got {len(args_schema)}"
-        )
 
     input_strategy = args_schema[0]
     if not isinstance(input_strategy, OpStrategy):
         raise AssertionError(f"Expected OpStrategy, got {type(input_strategy)}")
 
-    dims_arg = args_schema[1]
+    dims_arg = args_schema[1] if len(args_schema) > 1 else []
     reduce_dims = _infer_reduction_dims(dims_arg, input_strategy.ndim)
-    if reduce_dims is None:
-        raise AssertionError("Expected reduce_dims to not be None")
+    # Empty dim means reduce over all dimensions
+    if reduce_dims is None or len(reduce_dims) == 0:
+        reduce_dims = list(range(input_strategy.ndim))
 
     keep_dim = cast(bool, op_schema.kwargs_schema.get("keepdim", False))
     return common_reduction_strategy(

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -1582,6 +1582,9 @@ def sample_inputs_logsumexp(self, device, dtype, requires_grad, **kwargs):
         ((S, S), (1,), False),
         ((S, S), (-2,), False),
         ((S, S), (0, 1), False),
+        # dim=[] reduces over all dimensions
+        ((S, S), (), False),
+        ((S, S), (), True),
     )
     # Test large inputs to check numerical stability
     lows = (None, 1e3, 1e6) if dtype in (torch.float32, torch.float64, torch.complex64, torch.complex128) else (None,)


### PR DESCRIPTION
Fixes   #156075

Update: Rebased and brought to date. 


In order to support dim=None for `torch.logsumexp`, I followed the pattern used by `torch.sum` and `torch.mean`, as far as possible. 

1. Changed the function signature in `native_functions.yaml` to make dimension argument optional
2. Changes in `ReduceOps.cpp` to modify (1) meta function and (2) impl function for logsumexp variants
3. Update `derivatives.yaml` and `FunctionsManual.c/h` for autograd support
4. Add explicit dim=None argument testing and implicit in test_reductions.py
5. Update documentation 

<del>
There were some changes made to dtype validation and type promotion handling that I following amin/amax for rather than sum and mean, since  the `opt_dtype` parameter is not present in the logsumexp signature.

These changes pass the subset of tests I ran on my cpu-only build `python -m pytest test/test_ops* -k "logsumexp" `, with the exception of 
(1) `test/test_ops.py::TestCommonCPU::test_meta_consistency_out_dtype_mismatch_logsumexp_cpu_float32` and 
(2) `test/test_ops_jit.py::TestJitCPU::test_variant_consistency_jit_logsumexp_cpu_float32`

From what I can tell, the mismatch issue is related to when the dtype consistency checks are made on the device path vs. meta path. The structured kernel dtype validation only runs on real devices, not on meta device. Meta device bypasses the structured kernel infrastructure that performs the dtype consistency checks. 

Running `python -m pytest test/test_reductions.py` passes the new test added. 

I would appreciate any guidance on the dtype consistency check mismatch. Thank you!
</del>




cc @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @aditvenk @weifengpy @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @xmfan @H-Huang @chenyang78