### PR TITLE
ci: increase timeout for binary builds

### DIFF
--- a/.github/workflows/_binary-build-linux.yml
+++ b/.github/workflows/_binary-build-linux.yml
@@ -23,7 +23,7 @@ on:
         description: Hardware to run this "build" job on, linux.12xlarge or linux.arm64.2xlarge.
       timeout-minutes:
         required: false
-        default: 240
+        default: 480
         type: number
         description: timeout for the job
       use_split_build:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #159827
* __->__ #160588
* #159821
* #160055
* #159895

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>