### PR TITLE
[ROCm] disallow creation of HIP Device

### DIFF
--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -58,7 +58,7 @@ class TORCH_API Context {
     if (!opt_device_type.has_value()) {
       opt_device_type = at::getAccelerator(true);
     }
-    if (opt_device_type == at::kCUDA) {
+    if (opt_device_type == at::kCUDA || opt_device_type == at::kHIP) {
       return at::detail::getCUDAHooks();
     } else if (opt_device_type == at::kXPU) {
       return at::detail::getXPUHooks();
@@ -68,8 +68,6 @@ class TORCH_API Context {
       return at::detail::getPrivateUse1Hooks();
     } else if (opt_device_type == at::kMTIA) {
       return at::detail::getMTIAHooks();
-    } else if (opt_device_type == at::kHIP) {
-      return at::detail::getHIPHooks();
     } else if (opt_device_type == at::kHPU) {
       return at::detail::getHPUHooks();
     } else {

--- a/aten/src/ATen/hip/impl/HIPStreamMasqueradingAsCUDA.h
+++ b/aten/src/ATen/hip/impl/HIPStreamMasqueradingAsCUDA.h
@@ -25,7 +25,7 @@ public:
         HIPStream(
           Stream(
             Stream::UNSAFE,
-            Device(c10::DeviceType::HIP, stream.device_index()),
+            Device(c10::DeviceType::CUDA, stream.device_index()),
             stream.id())
         )
       ) {}

--- a/aten/src/ATen/native/Copy.cpp
+++ b/aten/src/ATen/native/Copy.cpp
@@ -283,10 +283,8 @@ static Tensor & copy_impl(Tensor & self, const Tensor & src, bool non_blocking) 
   }
 
   DeviceType device_type = iter.device_type(0);
-  if (iter.device_type(1) == kCUDA) {
+  if (iter.device_type(1) == kCUDA || iter.device_type(1) == kHIP) {
     device_type = kCUDA;
-  } else if (iter.device_type(1) == kHIP) {
-    device_type = kHIP;
   } else if (iter.device_type(1) == kMPS) {
     device_type = kMPS;
   } else if (iter.device_type(1) == kXPU){

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -340,7 +340,7 @@ class TORCH_API Tensor: public TensorBase {
   }
 
   Tensor hip() const {
-    return to(options().device(c10::DeviceType::HIP), /*non_blocking*/ false, /*copy*/ false);
+    return to(options().device(c10::DeviceType::CUDA), /*non_blocking*/ false, /*copy*/ false);
   }
 
   Tensor ve() const {

--- a/c10/core/Backend.h
+++ b/c10/core/Backend.h
@@ -241,10 +241,11 @@ inline DeviceType backendToDeviceType(Backend b) {
     case Backend::SparseCsrCUDA:
     case Backend::HIP:
     case Backend::SparseHIP:
-    //case Backend::QuantizedHIP:
     case Backend::SparseCsrHIP:
       return DeviceType::CUDA;
     case Backend::VE:
+    case Backend::SparseVE:
+    case Backend::SparseCsrVE:
       return DeviceType::VE;
     case Backend::FPGA:
       return DeviceType::FPGA;
@@ -254,10 +255,6 @@ inline DeviceType backendToDeviceType(Backend b) {
       return DeviceType::XLA;
     case Backend::Lazy:
       return DeviceType::Lazy;
-    case Backend::SparseVE:
-      return DeviceType::VE;
-    case Backend::SparseCsrVE:
-      return DeviceType::VE;
     case Backend::IPU:
       return DeviceType::IPU;
     case Backend::XPU:

--- a/c10/core/Backend.h
+++ b/c10/core/Backend.h
@@ -239,9 +239,11 @@ inline DeviceType backendToDeviceType(Backend b) {
     case Backend::SparseCUDA:
     case Backend::QuantizedCUDA:
     case Backend::SparseCsrCUDA:
-      return DeviceType::CUDA;
     case Backend::HIP:
-      return DeviceType::HIP;
+    case Backend::SparseHIP:
+    //case Backend::QuantizedHIP:
+    case Backend::SparseCsrHIP:
+      return DeviceType::CUDA;
     case Backend::VE:
       return DeviceType::VE;
     case Backend::FPGA:
@@ -252,12 +254,8 @@ inline DeviceType backendToDeviceType(Backend b) {
       return DeviceType::XLA;
     case Backend::Lazy:
       return DeviceType::Lazy;
-    case Backend::SparseHIP:
-      return DeviceType::HIP;
     case Backend::SparseVE:
       return DeviceType::VE;
-    case Backend::SparseCsrHIP:
-      return DeviceType::HIP;
     case Backend::SparseCsrVE:
       return DeviceType::VE;
     case Backend::IPU:

--- a/c10/core/Device.h
+++ b/c10/core/Device.h
@@ -35,6 +35,10 @@ struct C10_API Device final {
   /// index.
   /* implicit */ Device(DeviceType type, DeviceIndex index = -1)
       : type_(type), index_(index) {
+    if (is_hip()) {
+        // Do not allow HIP devices as they always alias as CUDA.
+        type_ = DeviceType::CUDA;
+    }
     validate();
   }
 

--- a/c10/core/Device.h
+++ b/c10/core/Device.h
@@ -36,8 +36,8 @@ struct C10_API Device final {
   /* implicit */ Device(DeviceType type, DeviceIndex index = -1)
       : type_(type), index_(index) {
     if (is_hip()) {
-        // Do not allow HIP devices as they always alias as CUDA.
-        type_ = DeviceType::CUDA;
+      // Do not allow HIP devices as they always alias as CUDA.
+      type_ = DeviceType::CUDA;
     }
     validate();
   }

--- a/c10/core/impl/InlineDeviceGuard.h
+++ b/c10/core/impl/InlineDeviceGuard.h
@@ -118,9 +118,7 @@ class InlineDeviceGuard {
       typename U = T,
       typename std::enable_if_t<!std::is_same_v<U, VirtualGuardImpl>, int> = 0>
   void set_device(at::Device device) {
-    AT_ASSERT(
-        (U::static_type == DeviceType::HIP && device.is_cuda()) ||
-        device.type() == U::static_type);
+    AT_ASSERT(device.type() == U::static_type);
     auto index = device.index();
     if (index == -1)
       return;

--- a/torch/csrc/autograd/profiler_legacy.h
+++ b/torch/csrc/autograd/profiler_legacy.h
@@ -21,6 +21,8 @@ enum class C10_API_ENUM EventKind : uint16_t {
   MemoryAlloc,
 };
 
+// NOLINTBEGIN(clang-analyzer-optin.performance.Padding)
+
 // To be deprecated, once we switch to Kineto profiling
 struct TORCH_API LegacyEvent {
   LegacyEvent(
@@ -271,6 +273,8 @@ struct TORCH_API LegacyEvent {
   uint64_t flops_ = 0;
 };
 
+// NOLINTEND(clang-analyzer-optin.performance.Padding)
+
 // a linked-list of fixed sized vectors, to avoid
 // a std::vector resize from taking a large amount of time inside
 // a profiling  event
@@ -361,6 +365,8 @@ struct TORCH_API RecordProfile {
   void processEvents(const std::vector<LegacyEvent*>& events);
 };
 
+// NOLINTBEGIN(cppcoreguidelines-special-member-functions)
+
 // A guard that enables the legacy profiler, taking in an optional callback to
 // process the results Usage:
 // {
@@ -397,5 +403,7 @@ struct TORCH_API TLSLegacyProfilerGuard {
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   const std::optional<ProfilerDisableOptions> profilerDisableOptions_;
 };
+
+// NOLINTEND(cppcoreguidelines-special-member-functions)
 
 } // namespace torch::autograd::profiler

--- a/torch/csrc/autograd/profiler_legacy.h
+++ b/torch/csrc/autograd/profiler_legacy.h
@@ -139,7 +139,7 @@ struct TORCH_API LegacyEvent {
   }
 
   void updateMemoryStats(int64_t alloc_size, c10::Device device) {
-    if (device.is_cuda() || device.type() == c10::DeviceType::HIP) {
+    if (device.is_cuda() || device.is_hip()) {
       cuda_memory_usage_ = alloc_size;
     } else if (
         device.is_cpu() || device.type() == c10::DeviceType::MKLDNN ||

--- a/torch/library.h
+++ b/torch/library.h
@@ -372,7 +372,7 @@ inline CppFunction dispatch(c10::DeviceType type, Func&& raw_f) {
       case c10::DeviceType::Meta:
         return c10::DispatchKey::Meta;
       case c10::DeviceType::HIP:
-        return c10::DispatchKey::HIP;
+        return c10::DispatchKey::CUDA;
       case c10::DeviceType::MAIA:
         return c10::DispatchKey::MAIA;
       case c10::DeviceType::HPU:


### PR DESCRIPTION
Today hip already aliases as cuda. to("hip") doesn't work. This PR keeps the at::kHIP DeviceType, but the Device constructor will now replace HIP with CUDA.

This fixes some strange issues where a hip:0 device was getting created when using torch.compile(backend='cudagraphs').

caffe was the only code that could create HIP devices, and it's gone.



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang