### PR TITLE
Use to() instead of contiguous() to generate channels last tensor for Intel XPU

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
@@ -602,6 +602,8 @@ std::tuple<Tensor, Tensor, Tensor> convolution_backward_overrideable(
       ? get_cl_tag_by_ndim(input_.ndimension())
       : at::MemoryFormat::Contiguous;
   grad_output_ = grad_output_.to(mfmt);
+  if (!grad_output_.is_contiguous())
+    grad_output_ = grad_output_.contiguous(mfmt);
   weight_ = weight_.contiguous(mfmt);
   input_ = input_.contiguous(mfmt);
 

--- a/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
@@ -601,7 +601,7 @@ std::tuple<Tensor, Tensor, Tensor> convolution_backward_overrideable(
   auto mfmt = is_channels_last_suggested
       ? get_cl_tag_by_ndim(input_.ndimension())
       : at::MemoryFormat::Contiguous;
-  grad_output_ = grad_output_.to(input.suggest_memory_format());
+  grad_output_ = grad_output_.to(mfmt);
   weight_ = weight_.contiguous(mfmt);
   input_ = input_.contiguous(mfmt);
 

--- a/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
@@ -601,7 +601,7 @@ std::tuple<Tensor, Tensor, Tensor> convolution_backward_overrideable(
   auto mfmt = is_channels_last_suggested
       ? get_cl_tag_by_ndim(input_.ndimension())
       : at::MemoryFormat::Contiguous;
-  grad_output_ = grad_output_.contiguous(mfmt);
+  grad_output_ = grad_output_.to(input.suggest_memory_format());
   weight_ = weight_.contiguous(mfmt);
   input_ = input_.contiguous(mfmt);
 

--- a/test/xpu/test_conv.py
+++ b/test/xpu/test_conv.py
@@ -1298,35 +1298,36 @@ class TestConvolutionNNDeviceType(NNTestCase):
         padding = 0
         output_dim = 1
 
-        layer_cpu = nn.Conv2d(input_dim, output_dim, kernel_size,
-                              padding=padding)
+        layer_cpu = nn.Conv2d(input_dim, output_dim, kernel_size, padding=padding)
         layer_cpu.weight.data.fill_(1)
         layer_cpu.bias.data.fill_(1)
 
-        input_data = torch.ones(batch_size, input_dim, input_spatial_dim,
-                                input_spatial_dim)
-        input_data[:, :, :input_spatial_dim // 2, :input_spatial_dim // 2] = -1
+        input_data = torch.ones(
+            batch_size, input_dim, input_spatial_dim, input_spatial_dim
+        )
+        input_data[:, :, : input_spatial_dim // 2, : input_spatial_dim // 2] = -1
 
-        output_grad = torch.ones(batch_size,output_dim, input_spatial_dim,
-                                 input_spatial_dim)
+        output_grad = torch.ones(
+            batch_size, output_dim, input_spatial_dim, input_spatial_dim
+        )
         stride = output_grad.stride()
         abnormal_stride = [stride[0], 1, stride[2], stride[3]]
-        output_grad =output_grad.as_strided(output_grad.size(),
-                                            abnormal_stride)
+        output_grad = output_grad.as_strided(output_grad.size(), abnormal_stride)
 
-        #run on CPU
+        # run on CPU
         input_cpu = input_data.detach().requires_grad_()
         output_cpu = layer_cpu(input_cpu)
         torch.autograd.backward(output_cpu, output_grad)
 
-        #run on XPU
+        # run on XPU
         layer_xpu = copy.deepcopy(layer_cpu).to(device)
         input_xpu = input_data.to(device).detach().requires_grad_()
         output_xpu = layer_xpu(input_xpu)
         torch.autograd.backward(output_xpu, output_grad.to(device))
 
-        self.assertTrue(torch.allclose(layer_cpu.weight.grad,
-                                       layer_xpu.weight.grad.cpu()))
+        self.assertTrue(
+            torch.allclose(layer_cpu.weight.grad, layer_xpu.weight.grad.cpu())
+        )
 
 
 instantiate_device_type_tests(

--- a/test/xpu/test_conv.py
+++ b/test/xpu/test_conv.py
@@ -1289,6 +1289,45 @@ class TestConvolutionNNDeviceType(NNTestCase):
         ):
             self.assertTrue(torch.backends.mkldnn.allow_tf32)
 
+    @onlyXPU
+    def test_conv_backward_with_abnormal_stride(self, device):
+        batch_size = 1
+        input_dim = 6
+        input_spatial_dim = 2
+        kernel_size = 1
+        padding = 0
+        output_dim = 1
+
+        layer_cpu = nn.Conv2d(input_dim, output_dim, kernel_size,
+                              padding=padding)
+        layer_cpu.weight.data.fill_(1)
+        layer_cpu.bias.data.fill_(1)
+
+        input_data = torch.ones(batch_size, input_dim, input_spatial_dim,
+                                input_spatial_dim)
+        input_data[:, :, :input_spatial_dim // 2, :input_spatial_dim // 2] = -1
+
+        output_grad = torch.ones(batch_size,output_dim, input_spatial_dim,
+                                 input_spatial_dim)
+        stride = output_grad.stride()
+        abnormal_stride = [stride[0], 1, stride[2], stride[3]]
+        output_grad =output_grad.as_strided(output_grad.size(),
+                                            abnormal_stride)
+
+        #run on CPU
+        input_cpu = input_data.detach().requires_grad_()
+        output_cpu = layer_cpu(input_cpu)
+        torch.autograd.backward(output_cpu, output_grad)
+
+        #run on XPU
+        layer_xpu = copy.deepcopy(layer_cpu).to(device)
+        input_xpu = input_data.to(device).detach().requires_grad_()
+        output_xpu = layer_xpu(input_xpu)
+        torch.autograd.backward(output_xpu, output_grad.to(device))
+
+        self.assertTrue(torch.allclose(layer_cpu.weight.grad,
+                                       layer_xpu.weight.grad.cpu()))
+
 
 instantiate_device_type_tests(
     TestConvolutionNNDeviceType, globals(), only_for="xpu", allow_xpu=True


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/95693 for Intel XPU case.

In same cases of Conv Backward, the output grad tensor's stride will be abnormal format.
Like output_grad.shape = torch.Size([1, 1, 2, 2]) 
       Normal stride:  [4, 4, 2, 1]
       Abnormal stride: [4, 1, 2, 1]

That will lead to the wrong result of conv backward for Intel XPU.

Solution:
  Refer to the solution of https://github.com/pytorch/pytorch/pull/96791, use to() replace the contiguous() to correct the stride.
  Add unit test case.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @gujinghui @EikanWang @fengyuan14 @guangyey