### PR TITLE
Use common generate binary build matrix script for keeping cuda arch lists across Linux and Windows systems

### DIFF
--- a/.ci/manywheel/build_cuda.sh
+++ b/.ci/manywheel/build_cuda.sh
@@ -53,21 +53,23 @@ fi
 cuda_version_nodot=$(echo $CUDA_VERSION | tr -d '.')
 EXTRA_CAFFE2_CMAKE_FLAGS+=("-DATEN_NO_TEST=ON")
 
+TORCH_CUDA_ARCH_LIST=$(python .github\scripts\get_ci_variable.py --cuda-arch-list ${CUDA_VERSION})
+
 case ${CUDA_VERSION} in
     #removing sm_50-sm_60 as these architectures are deprecated in CUDA 12.8/9 and will be removed in future releases
     #however we would like to keep sm_70 architecture see: https://github.com/pytorch/pytorch/issues/157517
-    12.8)
-        TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;9.0;10.0;12.0"
-        ;;
     12.9)
-        TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;9.0;10.0;12.0+PTX"
+        TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}+PTX"
         # WAR to resolve the ld error in libtorch build with CUDA 12.9
         if [[ "$PACKAGE_TYPE" == "libtorch" ]]; then
             TORCH_CUDA_ARCH_LIST="7.5;8.0;9.0;10.0;12.0+PTX"
         fi
         ;;
     12.6)
-        TORCH_CUDA_ARCH_LIST="5.0;6.0;7.0;7.5;8.0;8.6;9.0"
+        #default version
+        ;;
+    12.8)
+        #default version
         ;;
     *)
         echo "unknown cuda version $CUDA_VERSION"

--- a/.ci/pytorch/windows/cuda126.bat
+++ b/.ci/pytorch/windows/cuda126.bat
@@ -36,12 +36,8 @@ IF "%CUDA_PATH_V126%"=="" (
     )
 )
 
-IF "%BUILD_VISION%" == "" (
-    set TORCH_CUDA_ARCH_LIST=5.0;6.0;6.1;7.0;7.5;8.0;8.6;9.0
-    set TORCH_NVCC_FLAGS=-Xfatbin -compress-all
-) ELSE (
-    set NVCC_FLAGS=-D__CUDA_NO_HALF_OPERATORS__ --expt-relaxed-constexpr -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_75,code=sm_75 -gencode=arch=compute_80,code=compute_80 -gencode=arch=compute_86,code=compute_86 -gencode=arch=compute_90,code=compute_90
-)
+for /f "tokens=*" %%i in ('python .github\scripts\get_ci_variable.py --cuda-arch-list 12.6') do set TORCH_CUDA_ARCH_LIST=%%i
+set TORCH_NVCC_FLAGS=-Xfatbin -compress-all
 
 set "CUDA_PATH=%CUDA_PATH_V126%"
 set "PATH=%CUDA_PATH_V126%\bin;%PATH%"

--- a/.ci/pytorch/windows/cuda128.bat
+++ b/.ci/pytorch/windows/cuda128.bat
@@ -36,12 +36,8 @@ IF "%CUDA_PATH_V128%"=="" (
     )
 )
 
-IF "%BUILD_VISION%" == "" (
-    set TORCH_CUDA_ARCH_LIST=6.1;7.0;7.5;8.0;8.6;9.0;10.0;12.0
-    set TORCH_NVCC_FLAGS=-Xfatbin -compress-all
-) ELSE (
-    set NVCC_FLAGS=-D__CUDA_NO_HALF_OPERATORS__ --expt-relaxed-constexpr -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_75,code=sm_75 -gencode=arch=compute_80,code=compute_80 -gencode=arch=compute_86,code=compute_86 -gencode=arch=compute_90,code=compute_90 -gencode=arch=compute_100,code=compute_100 -gencode=arch=compute_120,code=compute_120
-)
+for /f "tokens=*" %%i in ('python .github\scripts\get_ci_variable.py --cuda-arch-list 12.8') do set TORCH_CUDA_ARCH_LIST=%%i
+set TORCH_NVCC_FLAGS=-Xfatbin -compress-all
 
 set "CUDA_PATH=%CUDA_PATH_V128%"
 set "PATH=%CUDA_PATH_V128%\bin;%PATH%"

--- a/.ci/pytorch/windows/cuda129.bat
+++ b/.ci/pytorch/windows/cuda129.bat
@@ -36,12 +36,8 @@ IF "%CUDA_PATH_V129%"=="" (
     )
 )
 
-IF "%BUILD_VISION%" == "" (
-    set TORCH_CUDA_ARCH_LIST=7.0;7.5;8.0;8.6;9.0;10.0;12.0
-    set TORCH_NVCC_FLAGS=-Xfatbin -compress-all
-) ELSE (
-    set NVCC_FLAGS=-D__CUDA_NO_HALF_OPERATORS__ --expt-relaxed-constexpr -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_75,code=sm_75 -gencode=arch=compute_80,code=compute_80 -gencode=arch=compute_86,code=compute_86 -gencode=arch=compute_90,code=compute_90 -gencode=arch=compute_100,code=compute_100 -gencode=arch=compute_120,code=compute_120
-)
+for /f "tokens=*" %%i in ('python .github\scripts\get_ci_variable.py --cuda-arch-list 12.9') do set TORCH_CUDA_ARCH_LIST=%%i
+set TORCH_NVCC_FLAGS=-Xfatbin -compress-all
 
 set "CUDA_PATH=%CUDA_PATH_V129%"
 set "PATH=%CUDA_PATH_V129%\bin;%PATH%"

--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -29,6 +29,13 @@ CUDA_ARCHES_CUDNN_VERSION = {
     "12.9": "9",
 }
 
+# default torch CUDA arch list
+CUDA_ARCHES_LIST = {
+    "12.6": "5.0;6.0;6.1;7.0;7.5;8.0;8.6;9.0",
+    "12.8": "7.0;7.5;8.0;8.6;9.0;10.0;12.0",
+    "12.9": "7.0;7.5;8.0;8.6;9.0;10.0;12.0",
+}
+
 # NOTE: Please also update the ROCm sources in `PIP_SOURCES` in tools/nightly.py when changing this
 ROCM_ARCHES = ["6.3", "6.4"]
 

--- a/.github/scripts/get_ci_variable.py
+++ b/.github/scripts/get_ci_variable.py
@@ -19,11 +19,20 @@ def main(args: list[str]) -> None:
         action="store_true",
         help="get min supported python version",
     )
+    parser.add_argument(
+        "--cuda-arch-list",
+        help="get cuda arch list",
+        type=str,
+        default="",
+    )
+
     options = parser.parse_args(args)
     if options.cuda_stable_version:
         return print(generate_binary_build_matrix.CUDA_STABLE)
     if options.min_python_version:
         return print(generate_binary_build_matrix.FULL_PYTHON_VERSIONS[0])
+    if options.cuda_arch_list != "":
+        return print(generate_binary_build_matrix.CUDA_ARCHES_LIST[options.cuda_arch_list])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/160575

Will iterate over it and perhaps replace cuda12*.bat files by bash shell scripts and consolidate them into 1 file