### PR TITLE
[PT2]: Add Static Dispatch Kernel for fmod.Scalar

### DIFF
--- a/torch/nativert/kernels/KernelRegistry.cpp
+++ b/torch/nativert/kernels/KernelRegistry.cpp
@@ -1237,6 +1237,18 @@ REGISTER_CPU_KERNEL("torch.ops.aten.stack.default", aten_stack, {
   at::native::_stack_out_cpu(inputs, dim, out_t);
 })
 
+REGISTER_CPU_KERNEL("torch.ops.aten.fmod.Scalar", aten_fmod_scalar, {
+  const auto& self = KernelInput(0).toTensor();
+  const auto& other = KernelInput(1).toScalar();
+  if (KernelOutput(0).isNone()) {
+    KernelOutput(0) = at::native::fmod(self, other);
+    return;
+  }
+  auto& out = KernelOutput(0).toTensor();
+  fastResizeToZero(out);
+  at::native::fmod_out(self, other, out);
+})
+
 class OpKernel_aten__to_copy : public C10Kernel {
  public:
   explicit OpKernel_aten__to_copy(const Node* node)


### PR DESCRIPTION
Summary: Add static dispatch for torch.ops.aten.fmod.Scalar. Found this missing in user/object nets for DSNN models.

Test Plan:
```
MODEL_TYPE=dpa_product_first_ctr_model
MODEL_ENTITY_ID=892669089
SNAPSHOT_ID=36
MODULE=user
SUFFIX=.predictor.precompute.remote_request_only

buck2 run mode/opt caffe2/torch/fb/model_transform/fx2trt/packaging:load_net_predictor -- --loadMode=BenchmarkByOp --inputNetFile=/data/users/$USER/models/${MODEL_ENTITY_ID}/${SNAPSHOT_ID}/${MODEL_ENTITY_ID}_${SNAPSHOT_ID}${SUFFIX} --moduleName=${MODULE} --submodToDevice="" --benchmarkEnableProfiling=true --benchmarkDontRebatchSamples=true --doNotRandomizeSampleInputs=true --benchmarkNumIterations=1000 
```

Object tower: P1904347784
User tower: P1904348406

Rollback Plan:

Differential Revision: D80238495




cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel