### PR TITLE
[Inductor] Add DeviceAssert op to enable device-side assertion in torch.compile

### DIFF
--- a/test/inductor/test_device_assert.py
+++ b/test/inductor/test_device_assert.py
@@ -1,0 +1,106 @@
+# Owner(s): ["module: inductor"]
+import torch
+import torch._inductor.config
+from torch._inductor.compiler_bisector import BisectionResult, CompilerBisector
+from torch._inductor.test_case import run_tests, TestCase
+
+
+class TestTorchDeviceAssertTrigger(TestCase):
+    def _run_assert_should_throw(self):
+        def func():
+            a = torch.tensor([1.0, -2.0])
+            result = torch.all(a > 0)
+            assert result, "should throw"
+
+        def test_fn():
+            torch._dynamo.reset()
+            f_c = torch.compile(func)
+
+            try:
+                f_c()
+                return False
+            except Exception:
+                return True
+
+        bisect_result = CompilerBisector.do_bisect(test_fn)
+        # do_bisect return None if all system is passed else return BisectionResult
+        self.assertNotIsInstance(bisect_result, BisectionResult)
+
+    def _run_assert_should_not_throw(self):
+        def func():
+            a = torch.tensor([1.0, 2.0])
+            result = torch.all(a > 0)
+            assert result, "should throw"
+
+        def test_fn():
+            torch._dynamo.reset()
+            f_c = torch.compile(func)
+
+            try:
+                f_c()
+                return True
+            except Exception:
+                return False
+
+        bisect_result = CompilerBisector.do_bisect(test_fn)
+        self.assertNotIsInstance(bisect_result, BisectionResult)
+
+    def _run_assert_inline_expression_should_throw(self):
+        def func():
+            a = torch.tensor([1.0, -2.0])
+            assert torch.all(a > 0), "should throw"
+
+        def test_fn():
+            torch._dynamo.reset()
+            f_c = torch.compile(func)
+
+            try:
+                f_c()
+                return False
+            except Exception:
+                return True
+
+        bisect_result = CompilerBisector.do_bisect(test_fn)
+        self.assertNotIsInstance(bisect_result, BisectionResult)
+
+    def _run_assert_inline_expression_should_not_throw(self):
+        def func():
+            a = torch.tensor([1.0, 2.0])
+            assert torch.all(a > 0), "should throw"
+
+        def test_fn():
+            torch._dynamo.reset()
+            f_c = torch.compile(func)
+
+            try:
+                f_c()
+                return True
+            except Exception:
+                return False
+
+        bisect_result = CompilerBisector.do_bisect(test_fn)
+        self.assertNotIsInstance(bisect_result, BisectionResult)
+
+    @torch._inductor.config.patch(force_disable_caches=True)
+    def test_assert_should_throw(self):
+        self._run_assert_should_throw()
+        self._run_assert_inline_expression_should_throw()
+
+    @torch._inductor.config.patch(force_disable_caches=True)
+    def test_assert_should_not_throw(self):
+        self._run_assert_should_not_throw()
+        self._run_assert_inline_expression_should_not_throw()
+
+    @torch._inductor.config.patch(force_disable_caches=True, cpp_wrapper=True)
+    def test_assert_should_throw_cpp_wrapper(self):
+        self._run_assert_should_throw()
+        self._run_assert_inline_expression_should_throw()
+
+    @torch._inductor.config.patch(force_disable_caches=True, cpp_wrapper=True)
+    def test_assert_should_not_throw_cpp_wrapper(self):
+        self._run_assert_should_not_throw()
+        self._run_assert_inline_expression_should_not_throw()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_device_assert.py
+++ b/test/inductor/test_device_assert.py
@@ -1,14 +1,19 @@
 # Owner(s): ["module: inductor"]
+import os
+import subprocess
+import sys
+
 import torch
 import torch._inductor.config
 from torch._inductor.compiler_bisector import BisectionResult, CompilerBisector
 from torch._inductor.test_case import run_tests, TestCase
+from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON
 
 
 class TestTorchDeviceAssertTrigger(TestCase):
-    def _run_assert_should_throw(self):
+    def _run_assert_should_throw(self, device):
         def func():
-            a = torch.tensor([1.0, -2.0])
+            a = torch.tensor([1.0, -2.0], device=device)
             result = torch.all(a > 0)
             assert result, "should throw"
 
@@ -26,9 +31,9 @@ class TestTorchDeviceAssertTrigger(TestCase):
         # do_bisect return None if all system is passed else return BisectionResult
         self.assertNotIsInstance(bisect_result, BisectionResult)
 
-    def _run_assert_should_not_throw(self):
+    def _run_assert_should_not_throw(self, device):
         def func():
-            a = torch.tensor([1.0, 2.0])
+            a = torch.tensor([1.0, 2.0], device=device)
             result = torch.all(a > 0)
             assert result, "should throw"
 
@@ -45,9 +50,9 @@ class TestTorchDeviceAssertTrigger(TestCase):
         bisect_result = CompilerBisector.do_bisect(test_fn)
         self.assertNotIsInstance(bisect_result, BisectionResult)
 
-    def _run_assert_inline_expression_should_throw(self):
+    def _run_assert_inline_expression_should_throw(self, device):
         def func():
-            a = torch.tensor([1.0, -2.0])
+            a = torch.tensor([1.0, -2.0], device=device)
             assert torch.all(a > 0), "should throw"
 
         def test_fn():
@@ -63,9 +68,9 @@ class TestTorchDeviceAssertTrigger(TestCase):
         bisect_result = CompilerBisector.do_bisect(test_fn)
         self.assertNotIsInstance(bisect_result, BisectionResult)
 
-    def _run_assert_inline_expression_should_not_throw(self):
+    def _run_assert_inline_expression_should_not_throw(self, device):
         def func():
-            a = torch.tensor([1.0, 2.0])
+            a = torch.tensor([1.0, 2.0], device=device)
             assert torch.all(a > 0), "should throw"
 
         def test_fn():
@@ -83,23 +88,95 @@ class TestTorchDeviceAssertTrigger(TestCase):
 
     @torch._inductor.config.patch(force_disable_caches=True)
     def test_assert_should_throw(self):
-        self._run_assert_should_throw()
-        self._run_assert_inline_expression_should_throw()
+        device = "cpu"
+        self._run_assert_should_throw(device)
+        self._run_assert_inline_expression_should_throw(device)
 
     @torch._inductor.config.patch(force_disable_caches=True)
     def test_assert_should_not_throw(self):
-        self._run_assert_should_not_throw()
-        self._run_assert_inline_expression_should_not_throw()
+        device = "cpu"
+        self._run_assert_should_not_throw(device)
+        self._run_assert_inline_expression_should_not_throw(device)
 
     @torch._inductor.config.patch(force_disable_caches=True, cpp_wrapper=True)
     def test_assert_should_throw_cpp_wrapper(self):
-        self._run_assert_should_throw()
-        self._run_assert_inline_expression_should_throw()
+        device = "cpu"
+        self._run_assert_should_throw(device)
+        self._run_assert_inline_expression_should_throw(device)
 
     @torch._inductor.config.patch(force_disable_caches=True, cpp_wrapper=True)
     def test_assert_should_not_throw_cpp_wrapper(self):
-        self._run_assert_should_not_throw()
-        self._run_assert_inline_expression_should_not_throw()
+        device = "cpu"
+        self._run_assert_should_not_throw(device)
+        self._run_assert_inline_expression_should_not_throw(device)
+
+    if HAS_CUDA_AND_TRITON:
+
+        @torch._inductor.config.patch(force_disable_caches=True)
+        def test_run_assert_triton(self):
+            should_throw = """
+import torch
+import torch._dynamo
+
+def func_should_throw():
+    a = torch.tensor([1.0, -2.0], device='cuda')
+    result = torch.all(a > 0)
+    assert result, "should throw"
+
+def test_fn():
+    torch._dynamo.reset()
+    f_c = torch.compile(func_should_throw, backend="inductor")
+
+    try:
+        f_c()
+        torch.cuda.synchronize()
+        return False
+    except Exception as e:
+        return True
+
+result = test_fn()
+print(f"Test result: {result}")
+"""
+
+            should_not_throw = """
+import torch
+import torch._dynamo
+
+def func_should_not_throw():
+    a = torch.tensor([1.0, 2.0], device='cuda')
+    result = torch.all(a > 0)
+    assert result, "should throw"
+
+def test_fn():
+    torch._dynamo.reset()
+    f_c = torch.compile(func_should_not_throw, backend="inductor")
+
+    try:
+        f_c()
+        torch.cuda.synchronize()
+        return True
+    except Exception as e:
+        return False
+
+result = test_fn()
+print(f"Test result: {result}")
+"""
+            for script in [should_not_throw, should_throw]:
+                p = subprocess.run(
+                    [sys.executable, "-c", script],
+                    cwd=os.path.dirname(os.path.realpath(__file__)),
+                    capture_output=True,
+                    text=True,
+                )
+
+                output = p.stdout + "\n" + p.stderr
+
+                self.assertIn("Test result: True", output)
+
+                if p.returncode != 0:
+                    self.fail(
+                        f"Subprocess failed with return code {p.returncode}. Output: {output}"
+                    )
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_device_assert.py
+++ b/test/inductor/test_device_assert.py
@@ -1,13 +1,11 @@
 # Owner(s): ["module: inductor"]
-import os
-import subprocess
-import sys
 
 import torch
 import torch._inductor.config
 from torch._inductor import metrics
 from torch._inductor.compiler_bisector import BisectionResult, CompilerBisector
 from torch._inductor.test_case import run_tests, TestCase
+from torch._inductor.utils import run_and_get_code
 from torch.testing._internal.common_utils import skipIfRocm
 from torch.testing._internal.triton_utils import requires_cuda_and_triton
 
@@ -100,18 +98,6 @@ class TestTorchDeviceAssertTrigger(TestCase):
         self._run_assert_should_not_throw(device)
         self._run_assert_inline_expression_should_not_throw(device)
 
-    @torch._inductor.config.patch(force_disable_caches=True, cpp_wrapper=True)
-    def test_assert_should_throw_cpp_wrapper(self):
-        device = "cpu"
-        self._run_assert_should_throw(device)
-        self._run_assert_inline_expression_should_throw(device)
-
-    @torch._inductor.config.patch(force_disable_caches=True, cpp_wrapper=True)
-    def test_assert_should_not_throw_cpp_wrapper(self):
-        device = "cpu"
-        self._run_assert_should_not_throw(device)
-        self._run_assert_inline_expression_should_not_throw(device)
-
     @requires_cuda_and_triton
     @skipIfRocm
     @torch._inductor.config.patch(force_disable_caches=True)
@@ -135,69 +121,23 @@ class TestTorchDeviceAssertTrigger(TestCase):
     @skipIfRocm
     @torch._inductor.config.patch(force_disable_caches=True)
     def test_run_assert_triton(self):
-        should_throw = """
-import torch
-import torch._dynamo
+        @torch.compile(backend="inductor")
+        def fn():
+            a = torch.tensor([1.0, 2.0], device="cuda")
+            result = torch.all(a > 0)
+            assert result, "should throw"
 
-def func_should_throw():
-    a = torch.tensor([1.0, -2.0], device='cuda')
-    result = torch.all(a > 0)
-    assert result, "should throw"
+        def should_not_throw(fn):
+            try:
+                fn()
+                return True
+            except Exception:
+                return False
 
-def test_fn():
-    torch._dynamo.reset()
-    f_c = torch.compile(func_should_throw, backend="inductor")
+        self.assertEqual(should_not_throw(fn), True)
 
-    try:
-        f_c()
-        torch.cuda.synchronize()
-        return False
-    except Exception as e:
-        return True
-
-result = test_fn()
-print(f"Test result: {result}")
-"""
-
-        should_not_throw = """
-import torch
-import torch._dynamo
-
-def func_should_not_throw():
-    a = torch.tensor([1.0, 2.0], device='cuda')
-    result = torch.all(a > 0)
-    assert result, "should throw"
-
-def test_fn():
-    torch._dynamo.reset()
-    f_c = torch.compile(func_should_not_throw, backend="inductor")
-
-    try:
-        f_c()
-        torch.cuda.synchronize()
-        return True
-    except Exception as e:
-        return False
-
-result = test_fn()
-print(f"Test result: {result}")
-"""
-        for script in [should_not_throw, should_throw]:
-            p = subprocess.run(
-                [sys.executable, "-c", script],
-                cwd=os.path.dirname(os.path.realpath(__file__)),
-                capture_output=True,
-                text=True,
-            )
-
-            output = p.stdout + "\n" + p.stderr
-
-            self.assertIn("Test result: True", output)
-
-            if p.returncode != 0:
-                self.fail(
-                    f"Subprocess failed with return code {p.returncode}. Output: {output}"
-                )
+        _, code = run_and_get_code(fn)
+        self.assertEqual(code[0].count("tl.device_assert"), 1)
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -1119,6 +1119,10 @@ class CppOverrides(OpOverrides):
         code.writeline("()")
         return code
 
+    @staticmethod
+    def device_assert_async(cond, msg):
+        return f'({cond} ? 0 : (throw std::runtime_error("{msg}"), 0))'
+
 
 CppOverrides._initialize_pointwise_overrides("cpp")
 

--- a/torch/_inductor/codegen/halide.py
+++ b/torch/_inductor/codegen/halide.py
@@ -566,6 +566,10 @@ class HalideOverrides(OpOverrides):
     def frexp(x):
         raise NotImplementedError("frexp")
 
+    @staticmethod
+    def device_assert_async(cond, msg):
+        raise NotImplementedError("device_assert_async")
+
 
 HalideOverrides._initialize_pointwise_overrides("halide")
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1578,6 +1578,10 @@ class TritonKernelOverrides(TritonOverrides):
         V.kernel.cse.put(cache_key, (mantissa, exponent))
         return (mantissa, exponent)
 
+    @staticmethod
+    def device_assert_async(cond, msg):
+        return f"tl.device_assert({cond}, {repr(msg)})"
+
 
 class HelperFunctions:
     """An ordered set of helper functions."""

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -158,20 +158,6 @@ def _embedding_dense_backward(
     )
 
 
-# This decomposition is commented out to disable the default
-# python assert decomposition inside Inductor.
-# @register_decomposition([aten._assert_async.msg])
-# def assert_async_msg_decomp(tensor: torch.Tensor, msg: str) -> None:
-#     return
-
-
-# This decomposition is commented out to disable the default
-# python assert decomposition inside Inductor.
-# @register_decomposition([aten._functional_assert_async.msg])
-# def functional_assert_async_msg_decomp(tensor: torch.Tensor, msg: str) -> None:
-#     return
-
-
 @register_decomposition([aten.sym_constrain_range_for_size.default])
 def sym_constrain_range_for_size(
     symbol: torch.SymInt,

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -158,17 +158,18 @@ def _embedding_dense_backward(
     )
 
 
-# TODO: for now, inductor doesn't handle asserts
-# because the condition is symbol -> tensor in the graph.
-@register_decomposition([aten._assert_async.msg])
-def assert_async_msg_decomp(tensor: torch.Tensor, msg: str) -> None:
-    return
+# This decomposition is commented out to disable the default
+# python assert decomposition inside Inductor.
+# @register_decomposition([aten._assert_async.msg])
+# def assert_async_msg_decomp(tensor: torch.Tensor, msg: str) -> None:
+#     return
 
 
-# Following `assert_async_msg_decomp` and implement as non-op.
-@register_decomposition([aten._functional_assert_async.msg])
-def functional_assert_async_msg_decomp(tensor: torch.Tensor, msg: str) -> None:
-    return
+# This decomposition is commented out to disable the default
+# python assert decomposition inside Inductor.
+# @register_decomposition([aten._functional_assert_async.msg])
+# def functional_assert_async_msg_decomp(tensor: torch.Tensor, msg: str) -> None:
+#     return
 
 
 @register_decomposition([aten.sym_constrain_range_for_size.default])

--- a/torch/_inductor/dtype_propagation.py
+++ b/torch/_inductor/dtype_propagation.py
@@ -373,6 +373,10 @@ class DtypePropagationOpsHandler:
             f"{type(self).__name__}: ops.placeholder should not appear here"
         )
 
+    @staticmethod
+    def device_assert(cond: DTypeArg, msg: Optional[str] = None) -> None:
+        return None
+
 
 if TYPE_CHECKING:
 

--- a/torch/_inductor/dtype_propagation.py
+++ b/torch/_inductor/dtype_propagation.py
@@ -373,6 +373,10 @@ class DtypePropagationOpsHandler:
             f"{type(self).__name__}: ops.placeholder should not appear here"
         )
 
+    @staticmethod
+    def device_assert_async(cond, msg: str) -> torch.dtype:
+        return torch.bool
+
 
 if TYPE_CHECKING:
 

--- a/torch/_inductor/dtype_propagation.py
+++ b/torch/_inductor/dtype_propagation.py
@@ -373,10 +373,6 @@ class DtypePropagationOpsHandler:
             f"{type(self).__name__}: ops.placeholder should not appear here"
         )
 
-    @staticmethod
-    def device_assert(cond: DTypeArg, msg: Optional[str] = None) -> None:
-        return None
-
 
 if TYPE_CHECKING:
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -978,7 +978,10 @@ class Loops(IRNode):
     ) -> Union[TensorBox, ShapeAsConstantBuffer]:
         origin_node = kwargs.pop("origin_node", None)
         tb = kwargs.pop("traceback", None)
+        side_effects = kwargs.pop("side_effects", False)
         r = cls(*args, **kwargs)
+        if isinstance(r, Pointwise):
+            r._post_init_setattr("side_effects", side_effects)
         # Need to explicitly set origin_node here to propagate it down.
         # todo(chilli): I think it would be better for IRNode to directly set
         # origin_node
@@ -1073,6 +1076,9 @@ class Pointwise(Loops):
             return partial(nop_loader_fn, dtype=self.dtype)
 
         return self.inner_fn
+
+    def has_side_effects(self) -> bool:
+        return getattr(self, "side_effects", False)
 
     def get_reduction_size(self) -> Sequence[sympy.Expr]:
         return []

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -1094,7 +1094,10 @@ class Pointwise(Loops):
         loader = self.make_loader()
         loader = patch.object(ConstantBuffer, "override_device", device)(loader)
         return Pointwise(
-            device=device, dtype=self.dtype, inner_fn=loader, ranges=self.ranges
+            device=device,
+            dtype=self.dtype,
+            inner_fn=loader,
+            ranges=self.ranges,
         )
 
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -978,10 +978,7 @@ class Loops(IRNode):
     ) -> Union[TensorBox, ShapeAsConstantBuffer]:
         origin_node = kwargs.pop("origin_node", None)
         tb = kwargs.pop("traceback", None)
-        side_effects = kwargs.pop("side_effects", False)
         r = cls(*args, **kwargs)
-        if isinstance(r, Pointwise):
-            r._post_init_setattr("side_effects", side_effects)
         # Need to explicitly set origin_node here to propagate it down.
         # todo(chilli): I think it would be better for IRNode to directly set
         # origin_node
@@ -1076,9 +1073,6 @@ class Pointwise(Loops):
             return partial(nop_loader_fn, dtype=self.dtype)
 
         return self.inner_fn
-
-    def has_side_effects(self) -> bool:
-        return getattr(self, "side_effects", False)
 
     def get_reduction_size(self) -> Sequence[sympy.Expr]:
         return []

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4426,17 +4426,17 @@ class ComputedBuffer(OperationBuffer):
     """
 
     data: Loops
-    _force_load: ClassVar[bool] = False
+    _force_realize: ClassVar[bool] = False
 
     @staticmethod
     @contextlib.contextmanager
-    def force_load() -> Iterator[None]:
-        old_value = ComputedBuffer._force_load
+    def force_realize() -> Iterator[None]:
+        old_value = ComputedBuffer._force_realize
         try:
-            ComputedBuffer._force_load = True
+            ComputedBuffer._force_realize = True
             yield
         finally:
-            ComputedBuffer._force_load = old_value
+            ComputedBuffer._force_realize = old_value
 
     def get_computed_buffer_name(self) -> Optional[str]:
         """
@@ -4511,7 +4511,7 @@ class ComputedBuffer(OperationBuffer):
             not self.get_reduction_type()
             and self.name not in V.graph.mutated_buffers
             and self.num_reads() == 0
-            and not self._force_load
+            and not self._force_realize
         ):
             # inline this op rather than generating ops.load()
             return self.data.make_loader()

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4426,6 +4426,17 @@ class ComputedBuffer(OperationBuffer):
     """
 
     data: Loops
+    _force_load: ClassVar[bool] = False
+
+    @staticmethod
+    @contextlib.contextmanager
+    def force_load() -> Iterator[None]:
+        old_value = ComputedBuffer._force_load
+        try:
+            ComputedBuffer._force_load = True
+            yield
+        finally:
+            ComputedBuffer._force_load = old_value
 
     def get_computed_buffer_name(self) -> Optional[str]:
         """
@@ -4500,6 +4511,7 @@ class ComputedBuffer(OperationBuffer):
             not self.get_reduction_type()
             and self.name not in V.graph.mutated_buffers
             and self.num_reads() == 0
+            and not self._force_load
         ):
             # inline this op rather than generating ops.load()
             return self.data.make_loader()

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6404,39 +6404,6 @@ class RandomSeeds(ExternKernelOut):
         )
 
 
-class DeviceAssert(ExternKernel):
-    def __init__(self, cond: TensorBox, msg: str, device: torch.device) -> None:
-        cond.realize()
-        super().__init__(None, NoneLayout(device=device), [cond])
-        self.msg = msg
-
-    def has_side_effects(self) -> bool:
-        return True
-
-    def is_fusible(self) -> bool:
-        return False
-
-    def codegen(self, wrapper: PythonWrapperCodegen) -> None:
-        assert len(self.inputs) == 1
-        assert isinstance(self.inputs[0], TensorBox)
-        cond_ref = self.inputs[0].codegen_reference()
-        predicate = f"{self.inputs[0].get_name()}_scalar"
-        if V.graph.cpp_wrapper:
-            assert hasattr(wrapper, "codegen_tensor_item")
-            wrapper.codegen_tensor_item(
-                torch.bool,
-                cond_ref,
-                predicate,
-            )
-            wrapper.writeline(
-                f'if (!({predicate})) {{ throw std::runtime_error("{self.msg}"); }}'
-            )
-        else:
-            wrapper.writeline(f"{predicate} = {cond_ref}.item()")
-            wrapper.writeline(f"if not {predicate}:")
-            wrapper.writeline(f"    raise RuntimeError({repr(self.msg)})")
-
-
 class ExternKernelAlloc(ExternKernel):
     def codegen(self, wrapper: PythonWrapperCodegen) -> None:
         wrapper.generate_extern_kernel_alloc(self)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3369,6 +3369,18 @@ def empty_strided(
     return pointwise
 
 
+@register_lowering(torch.ops.aten._assert_async.msg, type_promotion_kind=None)
+def lower_assert_async_msg(cond, msg):
+    V.ops.device_assert(cond, msg)
+
+
+@register_lowering(
+    torch.ops.aten._functional_assert_async.msg, type_promotion_kind=None
+)
+def lower_functional_assert_async_msg(cond, msg):
+    V.ops.device_assert(cond, msg)
+
+
 @register_lowering(aten.new_empty_strided)
 def new_empty_strided(
     x, size, stride, *, dtype=None, layout=None, device=None, pin_memory=None

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1334,7 +1334,11 @@ def _assert_async(cond, msg):
     cond = to_dtype(cond, torch.bool)
 
     def inner_fn(index):
-        with cond.data.data.force_load():
+        if hasattr(cond.data, "data") and hasattr(cond.data.data, "force_load"):
+            with cond.data.data.force_load():
+                cond_loader = cond.make_loader()
+                return ops.device_assert_async(cond_loader(index), msg)
+        else:
             cond_loader = cond.make_loader()
             return ops.device_assert_async(cond_loader(index), msg)
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1341,7 +1341,6 @@ def _assert_async(cond, msg):
         dtype=cond.get_dtype(),
         inner_fn=inner_fn,
         ranges=list(cond.get_size()),
-        side_effects=True,
     )
 
     assertion_op.realize()

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1334,13 +1334,8 @@ def _assert_async(cond, msg):
     cond = to_dtype(cond, torch.bool)
 
     def inner_fn(index):
-        if hasattr(cond.data, "data") and hasattr(cond.data.data, "force_realize"):
-            with cond.data.data.force_realize():
-                cond_loader = cond.make_loader()
-                return ops.device_assert_async(cond_loader(index), msg)
-        else:
-            cond_loader = cond.make_loader()
-            return ops.device_assert_async(cond_loader(index), msg)
+        with ir.ComputedBuffer.force_realize():
+            return ops.device_assert_async(cond.make_loader()(index), msg)
 
     assertion_op = Pointwise.create(
         device=cond.get_device(),

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1334,8 +1334,8 @@ def _assert_async(cond, msg):
     cond = to_dtype(cond, torch.bool)
 
     def inner_fn(index):
-        if hasattr(cond.data, "data") and hasattr(cond.data.data, "force_load"):
-            with cond.data.data.force_load():
+        if hasattr(cond.data, "data") and hasattr(cond.data.data, "force_realize"):
+            with cond.data.data.force_realize():
                 cond_loader = cond.make_loader()
                 return ops.device_assert_async(cond_loader(index), msg)
         else:

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3371,14 +3371,22 @@ def empty_strided(
 
 @register_lowering(torch.ops.aten._assert_async.msg, type_promotion_kind=None)
 def lower_assert_async_msg(cond, msg):
-    V.ops.device_assert(cond, msg)
+    dev = getattr(V.graph, "device", None) or torch.device("cpu")
+    msg = msg or ""
+    device_assert = ir.DeviceAssert(cond, msg, dev)
+    V.graph.register_buffer(device_assert, set_name=True)
+    V.graph.register_operation(device_assert)
 
 
 @register_lowering(
     torch.ops.aten._functional_assert_async.msg, type_promotion_kind=None
 )
 def lower_functional_assert_async_msg(cond, msg):
-    V.ops.device_assert(cond, msg)
+    dev = getattr(V.graph, "device", None) or torch.device("cpu")
+    msg = msg or ""
+    device_assert = ir.DeviceAssert(cond, msg, dev)
+    V.graph.register_buffer(device_assert, set_name=True)
+    V.graph.register_operation(device_assert)
 
 
 @register_lowering(aten.new_empty_strided)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1341,19 +1341,8 @@ def _assert_async(cond, msg):
         dtype=cond.get_dtype(),
         inner_fn=inner_fn,
         ranges=list(cond.get_size()),
+        side_effects=True,
     )
-
-    def has_side_effects():
-        return True
-
-    assert isinstance(assertion_op, TensorBox), (
-        f"assertion_op must be a TensorBox, got {type(assertion_op).__name__}"
-    )
-    assert isinstance(assertion_op.data, ir.StorageBox), (
-        f"assertion_op must be a ir.StorageBox, got {type(assertion_op).__name__}"
-    )
-    pointwise_node = assertion_op.data.data
-    object.__setattr__(pointwise_node, "has_side_effects", has_side_effects)
 
     assertion_op.realize()
     return assertion_op

--- a/torch/_inductor/ops_handler.py
+++ b/torch/_inductor/ops_handler.py
@@ -706,6 +706,9 @@ class OpsHandler(Generic[T]):
         """This is a fake op used in analysis but not codegen"""
         raise NotImplementedError
 
+    def device_assert_async(self, cond: T, msg: str) -> T:
+        raise NotImplementedError
+
 
 _ignore_op_re = re.compile(r"_.*|paren").fullmatch
 
@@ -787,6 +790,9 @@ class DefaultHandler(OpsHandler[Any]):
         for target, impl in ctx.items():
             if target in OP_NAMES:
                 setattr(cls, target, impl)
+
+    def device_assert_async(self, cond, msg):
+        return None
 
 
 DefaultHandler._init_cls()
@@ -933,6 +939,9 @@ class MockHandler(BasicMathOpsMixin, DefaultHandler):
     def indirect_indexing(index_var, size, check=True, wrap_neg=True) -> sympy.Symbol:
         return sympy_index_symbol(str(index_var))
 
+    def device_assert_async(self, cond, msg):
+        return None
+
 
 class KernelFormatterHandler(DefaultHandler):
     def __init__(self, parent_handler: OpsHandler[Any]):
@@ -998,6 +1007,9 @@ class KernelFormatterHandler(DefaultHandler):
     def getvalue(self, result):
         self._output.writeline(f"return {result}")
         return self._output.getvalue()
+
+    def device_assert_async(self, cond, msg: str):
+        return f"ops.device_assert_async({cond}, {msg})"
 
 
 class WrapperHandler(DefaultHandler):

--- a/torch/_inductor/ops_handler.py
+++ b/torch/_inductor/ops_handler.py
@@ -706,9 +706,6 @@ class OpsHandler(Generic[T]):
         """This is a fake op used in analysis but not codegen"""
         raise NotImplementedError
 
-    def device_assert(self, cond: T, msg: Optional[str] = None) -> None:
-        raise NotImplementedError
-
 
 _ignore_op_re = re.compile(r"_.*|paren").fullmatch
 
@@ -935,17 +932,6 @@ class MockHandler(BasicMathOpsMixin, DefaultHandler):
     @staticmethod
     def indirect_indexing(index_var, size, check=True, wrap_neg=True) -> sympy.Symbol:
         return sympy_index_symbol(str(index_var))
-
-    def device_assert(self, cond, msg: Optional[str] = None) -> None:
-        from torch._inductor import ir
-
-        from .virtualized import V
-
-        dev = getattr(V.graph, "device", None) or torch.device("cpu")
-        msg = msg or ""
-        device_assert = ir.DeviceAssert(cond, msg, dev)
-        V.graph.register_buffer(device_assert, set_name=True)
-        V.graph.register_operation(device_assert)
 
 
 class KernelFormatterHandler(DefaultHandler):

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -1276,6 +1276,16 @@ class SchedulerNode(BaseSchedulerNode):
                     )
         return buffers_store_as_atomic_add
 
+    def has_side_effects(self) -> bool:
+        if (
+            self.node is not None
+            and hasattr(self.node, "data")
+            and hasattr(self.node.data, "has_side_effects")
+            and callable(self.node.data.has_side_effects)
+        ):
+            return self.node.data.has_side_effects()
+        return super().has_side_effects()
+
 
 def refresh_group_node_dependencies(
     group_snode: Union[FusedSchedulerNode, GroupedSchedulerNode],

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -1281,7 +1281,6 @@ class SchedulerNode(BaseSchedulerNode):
             self.node is not None
             and hasattr(self.node, "data")
             and hasattr(self.node.data, "has_side_effects")
-            and callable(self.node.data.has_side_effects)
         ):
             return self.node.data.has_side_effects()
         return super().has_side_effects()
@@ -3884,7 +3883,6 @@ class Scheduler:
         Determine if it is possible to combine node1 and node2 into a
         single fused node.
         """
-
         if node1 is node2:
             return False
 
@@ -3988,7 +3986,6 @@ class Scheduler:
         ):
             why("fusion for buffer explicit disabled")
             return False
-
         device = node1.get_device()
         device2 = node2.get_device()
         if device != device2:

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -1277,7 +1277,11 @@ class SchedulerNode(BaseSchedulerNode):
         return buffers_store_as_atomic_add
 
     def has_side_effects(self) -> bool:
-        if self._body.has_op("device_assert_async"):
+        if (
+            self._body is not None
+            and hasattr(self._body, "has_op")
+            and self._body.has_op("device_assert_async")
+        ):
             return True
         return super().has_side_effects()
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -1558,13 +1558,7 @@ class FusedSchedulerNode(BaseSchedulerNode):
     @cache_on_self
     def has_side_effects(self) -> bool:
         if self.snodes is not None:
-            return any(
-                isinstance(node, SchedulerNode)
-                and node._body is not None
-                and hasattr(node._body, "has_op")
-                and node._body.has_op("device_assert_async")
-                for node in self.snodes
-            )
+            return any(node.has_side_effects() for node in self.snodes)
         return super().has_side_effects()
 
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -1277,12 +1277,8 @@ class SchedulerNode(BaseSchedulerNode):
         return buffers_store_as_atomic_add
 
     def has_side_effects(self) -> bool:
-        if (
-            self.node is not None
-            and hasattr(self.node, "data")
-            and hasattr(self.node.data, "has_side_effects")
-        ):
-            return self.node.data.has_side_effects()
+        if self._body.has_op("device_assert_async"):
+            return True
         return super().has_side_effects()
 
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -1278,11 +1278,7 @@ class SchedulerNode(BaseSchedulerNode):
 
     @cache_on_self
     def has_side_effects(self) -> bool:
-        if (
-            self._body is not None
-            and hasattr(self._body, "has_op")
-            and self._body.has_op("device_assert_async")
-        ):
+        if hasattr(self._body, "has_op") and self._body.has_op("device_assert_async"):
             return True
         return super().has_side_effects()
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -1278,7 +1278,8 @@ class SchedulerNode(BaseSchedulerNode):
 
     @cache_on_self
     def has_side_effects(self) -> bool:
-        if hasattr(self._body, "has_op") and self._body.has_op("device_assert_async"):
+        # self._body is None sometimes that's why this check was added
+        if self._body is not None and self._body.has_op("device_assert_async"):
             return True
         return super().has_side_effects()
 

--- a/torch/_inductor/shape_propagation.py
+++ b/torch/_inductor/shape_propagation.py
@@ -139,3 +139,7 @@ class ShapePropagationOpsHandler:
 
     def __getattr__(self, name: str) -> Callable[..., BlockShapeType]:
         return lambda *args, **kwargs: broadcast_shapes_for_args(args)
+
+    @staticmethod
+    def device_assert_async(cond: ShapeArg, msg: str) -> None:
+        return None


### PR DESCRIPTION
This PR introduces a device_assert op to trigger device-side assertions within torch.compile. This implementation is based on the suggestion in [this comment](https://github.com/pytorch/pytorch/issues/147282#issuecomment-2756056084).

Changes Included

- Implemented device_assert op and overrides has_side_effect to return True to avoid removal by dead code elimination.
- Commented out the assert_async_msg_decomp and functional_assert_async_msg_decomp decompositions to disable the default assert decomposition inside Inductor.
- Added lowering for torch.ops.aten._assert_async.msg to convert assert calls into the ops_handler.
- Implemented the codegen method for the device_assert op. This supports generating C++ and Triton code.
- Added test cases to verify both "should throw" and "should not throw" scenarios.

Fixes #147282 


cc @SherlockNoMad @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @mlazos