### PR TITLE
[ez] Make NUMA signpost parameters JSON serializable

### DIFF
--- a/torch/numa/binding.py
+++ b/torch/numa/binding.py
@@ -5,7 +5,7 @@ import subprocess
 import traceback
 from collections import defaultdict
 from collections.abc import Iterable
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from enum import Enum
 from logging import getLogger
 from subprocess import run
@@ -113,7 +113,7 @@ def maybe_wrap_command_with_numa_bindings(
     kwargs = {
         "command_args": command_args,
         "gpu_index": gpu_index,
-        "numa_options": numa_options,
+        "numa_options": asdict(numa_options),
     }
     logger.info("Attempting to wrap command with NUMA bindings, given input %r", kwargs)
 


### PR DESCRIPTION
# Context
Broader context in #160163.

In order for the _utils_internal version of signpost_event to do proper logging, its parameters argument needs to be json serializable.

# This PR
Convert `NumaOptions` to serializable form before inputting to `signpost_event`.

# Test Plan
## Automated
Added tests `$ pytest test/test_numa_binding.py`.

## Manual
See [D80317206](https://www.internalfb.com/diff/D80317206).
