### PR TITLE
[ROCm] Begin introducing Windows CI/dev build scripts

### DIFF
--- a/.ci/pytorch/rocm_sdk-build.sh
+++ b/.ci/pytorch/rocm_sdk-build.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# This script should be sourced to set environment variables specific to
+# building using the ROCm Python wheels.
+# See https://github.com/ROCm/TheRock/blob/main/docs/packaging/python_packaging.md
+# and https://github.com/ROCm/TheRock/blob/main/external-builds/pytorch/build_prod_wheels.py
+
+if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
+  export USE_ROCM=ON
+  # TODO: add rocm[libraries]==ROCM_SDK_VERSION to PYTORCH_EXTRA_INSTALL_REQUIREMENTS?
+  #       (perhaps with ~= or some other looser pin)
+  # TODO: add 'rocmsdk' to PYTORCH_BUILD_VERSION?
+
+  # Look up rocm_sdk paths.
+  # TODO: fail/skip if these do not work
+  ROCM_ROOT_PATH=$(python -m rocm_sdk path --root)
+  ROCM_BIN_PATH=$(python -m rocm_sdk path --bin)
+  ROCM_CMAKE_PATH=$(python -m rocm_sdk path --cmake)
+
+  # Set common build environment variables using those rocm_sdk paths.
+  export CMAKE_PREFIX_PATH=${ROCM_CMAKE_PATH}
+  export ROCM_HOME=${ROCM_ROOT_PATH}
+  export ROCM_PATH=${ROCM_ROOT_PATH}
+  echo "CMAKE_PREFIX_PATH: ${CMAKE_PREFIX_PATH}"
+  echo "ROCM_HOME: ${ROCM_HOME}"
+  echo "ROCM_PATH: ${ROCM_PATH}"
+
+  # TODO: prepend ROCM_BIN_PATH to PATH as needed (venv already does this?)
+  # system_path = str(bin_dir) + os.path.pathsep + os.environ.get("PATH", "")
+
+  if [[ "$BUILD_ENVIRONMENT" == *windows-* ]]; then
+    # Set feature support environment variables (overriding defaults).
+    export DISTUTILS_USE_SDK=1
+    # TODO: enable tests
+    export BUILD_TEST=0
+    # TODO: enable attention (with aotriton)
+    export USE_FLASH_ATTENTION=0
+    export USE_MEM_EFF_ATTENTION=0
+    # TODO: enable Kineto somehow
+    export USE_KINETO=0
+    # TODO: enable GLOO somehow
+    export USE_GLOO=0
+
+    # Use the LLVM toolchain from rocm_sdk (clang-cl, etc.).
+    LLVM_DIR_WIN="${ROCM_ROOT_PATH}\\lib\\llvm\\bin"
+    LLVM_DIR=$(cygpath --unix "${LLVM_DIR_WIN}")
+    export HIP_CLANG_PATH=${LLVM_DIR}
+    export CC="${LLVM_DIR_WIN}\\clang-cl.exe"
+    export CXX="${LLVM_DIR_WIN}\\clang-cl.exe"
+    HIP_DEVICE_LIB_PATH_WIN="${ROCM_ROOT_PATH}\\lib\\llvm\\amdgcn\\bitcode"
+    export HIP_DEVICE_LIB_PATH=${HIP_DEVICE_LIB_PATH_WIN}
+    echo "HIP_CLANG_PATH: ${HIP_CLANG_PATH}"
+    echo "CC: ${CC}"
+    echo "CXX: ${CXX}"
+    echo "HIP_DEVICE_LIB_PATH: ${HIP_DEVICE_LIB_PATH}"
+  fi
+
+  # TODO: Linux-specific settings
+
+  if [[ -n "$CI" && -z "$PYTORCH_ROCM_ARCH" ]]; then
+      # Set ROCM_ARCH to gfx1100 for CI builds, if user doesn't override.
+      echo "Limiting PYTORCH_ROCM_ARCH to gfx1100 for CI builds"
+      export PYTORCH_ROCM_ARCH="gfx1100"
+  fi
+fi

--- a/.ci/pytorch/win-build.sh
+++ b/.ci/pytorch/win-build.sh
@@ -3,6 +3,7 @@
 # If you want to rebuild, run this with REBUILD=1
 # If you want to build with CUDA, run this with USE_CUDA=1
 # If you want to build without CUDA, run this with USE_CUDA=0
+# If you want to build with ROCm, run this with BUILD_ENVIRONMENT=*-rocm-*
 
 if [ ! -f setup.py ]; then
   echo "ERROR: Please run this build script from PyTorch root directory."
@@ -14,6 +15,17 @@ SCRIPT_PARENT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source "$SCRIPT_PARENT_DIR/common.sh"
 # shellcheck source=./common-build.sh
 source "$SCRIPT_PARENT_DIR/common-build.sh"
+
+if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
+  # Note: this assumes that the rocm python packages are already installed.
+
+  # shellcheck source=./rocm_sdk-build.sh
+  source "$SCRIPT_PARENT_DIR/rocm_sdk-build.sh"
+
+  # Prepare sources: hipify then write bootstrap script.
+  python tools/amd_build/build_amd.py
+  python tools/amd_build/write_rocm_init.py
+fi
 
 export TMP_DIR="${PWD}/build/win_tmp"
 TMP_DIR_WIN=$(cygpath -w "${TMP_DIR}")

--- a/tools/README.md
+++ b/tools/README.md
@@ -37,12 +37,8 @@ Developer tools which you might find useful:
 
 Important if you want to run on AMD GPU:
 
-* [amd_build](amd_build) - HIPify scripts, for transpiling CUDA
-  into AMD HIP.  Right now, PyTorch and Caffe2 share logic for how to
-  do this transpilation, but have separate entry-points for transpiling
-  either PyTorch or Caffe2 code.
-  * [build_amd.py](amd_build/build_amd.py) - Top-level entry
-    point for HIPifying our codebase.
+* [amd_build](amd_build) - AMD scripts like HIPify, for transpiling CUDA
+  into AMD HIP, as well as utilities for building using ROCm Python packages.
 
 Tools which are only situationally useful:
 

--- a/tools/amd_build/README.md
+++ b/tools/amd_build/README.md
@@ -1,0 +1,104 @@
+# PyTorch AMD Build
+
+Scripts for building with AMD GPU (ROCm) support.
+
+## Scripts
+
+### build_amd.py
+
+[build_amd.py](build_amd.py) is the top-level entry point for HIPifying our
+codebase. This script runs in-place on the repository, switching source files
+from CUDA APIs to HIP APIs.
+
+Right now, PyTorch and Caffe2 share logic for how to do this transpilation, but
+have separate entry-points for transpiling either PyTorch or Caffe2 code.
+
+Usage:
+
+```bash
+python ./tools/amd_build/build_amd.py
+```
+
+### build_windows.sh
+
+[build_windows.sh](build_windows.sh) is a utility script that helps set
+environment variables for ROCm on Windows builds and then calls
+[.ci/pytorch/win-build.sh](/.ci/pytorch/win-build.sh) to produce pytorch wheels.
+
+### write_rocm_init.py
+
+[write_rocm_init.py](write_rocm_init.py) is a utility for writing the
+`torch/_rocm_init.py` bootstrap module used by [`torch/__init__.py`](/torch/__init__.py).
+
+## Building PyTorch with ROCm support
+
+Source builds in a few configurations are possible:
+
+1. On Linux, PyTorch can be built against a system install of a stable ROCm
+   release, typically installed to `/opt/rocm/`.
+
+   _This build configuration has been supported for the longest time and is
+   generally the most stable._
+2. On Windows, PyTorch can be built against the
+   [AMD HIP SDK for Windows](https://www.amd.com/en/developer/resources/rocm-hub/hip-sdk.html).
+
+   _This build configuration has been tested by a few developers but has not
+   been documented. YMMV_.
+3. On Linux and Windows, PyTorch can be built against the preview ROCm Python
+   packages produced by https://github.com/ROCm/TheRock, typically installed
+   into a Python virtual environment.
+
+   _This build configuration is under active development and is where AMD
+   would like to focus efforts._
+
+See also [Installation From Source - AMD ROCm Support](/README.md#amd-rocm-support).
+
+### Common setup
+
+No matter the build configuration, you will first need to install requirements
+and HIPIFY the codebase:
+
+```bash
+pip install -r requirements.txt
+python tools/amd_build/build_amd.py
+
+# Optionally commit the HIPIFY changes to keep your history clean.
+git checkout -b amd-build
+git add -A
+git commit -m "DO NOT SUBMIT - HIPIFY"
+```
+
+### (Linux) Building with system ROCm
+
+See [Installation From Source - AMD ROCm Support](/README.md#amd-rocm-support).
+
+### (Windows) Building with the HIP SDK
+
+TODO: document (if this continues to be supported, we may focus on the
+ROCm Python packages approach instead)
+
+### (Linux and Windows) Building with ROCm Python packages
+
+> [!WARNING]
+> This method of building and installing is new and may still have feature gaps.
+
+1. Install ROCm Python packages for your GPU (ideally into a venv) by following
+   https://github.com/ROCm/TheRock/blob/main/RELEASES.md#installing-rocm-python-packages:
+
+    ```bash
+    # Make sure to use the index for your GPU family here
+    # TODO: swap to production index URL once available
+    pip install --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx110X-dgpu/ rocm[libraries,devel]
+    ```
+
+2. Write the `_rocm_init.py` file (see https://github.com/ROCm/TheRock/blob/main/docs/packaging/python_packaging.md for details):
+
+    ```bash
+    python tools/amd_build/write_rocm_init.py
+    ```
+
+3. Build (Windows)
+
+    ```bash
+    bash ./tools/amd_build/build_windows.sh
+    ```

--- a/tools/amd_build/build_windows.sh
+++ b/tools/amd_build/build_windows.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Thin wrapper around .ci/pytorch/win-build.sh for testing on a dev machine.
+# This script is hacky... starting with it for bootstrapping then may delete.
+
+set -ex -o pipefail
+
+if [ ! -f setup.py ]; then
+  echo "ERROR: Please run this build script from PyTorch root directory."
+  exit 1
+fi
+
+# TODO: should this be "win-rocm-" or "windows-rocm-"?
+#   .ci/pytorch/common-build.sh looks for "*win-*" when configuring sccache
+#   some workflows use "windows-binary-wheel" or "windows-arm64-binary-wheel"
+#   other workflows use "win-vs2022-cpu-py3", "win=vs2022-cuda12.6-py3", etc.
+export BUILD_ENVIRONMENT=windows-rocm-manywheel
+export PYTORCH_ROCM_ARCH=gfx1100
+
+# To test what CI does (may require software installed at certain paths on your system)
+function ci_build() {
+  bash .ci/pytorch/win-build.sh
+}
+
+# To test without other CI setup.
+function dev_build() {
+  source .ci/pytorch/common.sh
+  source .ci/pytorch/common-build.sh
+  source .ci/pytorch/rocm_sdk-build.sh
+  python tools/amd_build/build_amd.py
+  python tools/amd_build/write_rocm_init.py
+
+  python setup.py bdist_wheel
+}
+
+# Toggle comments here to change script modes
+# TODO: better ergonomics once we figure out CI and dev workflows.
+#       we used a Python build script downstream that could be attractive
+#       here as well:
+#       https://github.com/ROCm/TheRock/blob/main/external-builds/pytorch/build_prod_wheels.py
+
+# ci_build
+dev_build

--- a/tools/amd_build/write_rocm_init.py
+++ b/tools/amd_build/write_rocm_init.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+
+"""This script writes `torch/_rocm_init.py` to initialize with rocm_sdk packages.
+
+That file is loaded by `torch/__init__.py`. See the ROCm packaging documentation
+at https://github.com/ROCm/TheRock/blob/main/docs/packaging/python_packaging.md.
+If the file is not provided, torch will skip initialization with the rocm_sdk
+packages and will rely on its own built in code which may expect a system
+install of ROCm or some other packaging setup.
+
+Usage examples, choosing a rocm Python package version to check for during init:
+
+    * Use installed version if available, else the default "stable" version:
+
+        ```
+        python ./tools/amd_build/write_rocm_init.py
+        ```
+
+    * Use the default "stable" version, ignoring any installed version:
+
+        ```
+        python ./tools/amd_build/write_rocm_init.py --rocm-version stable
+        ```
+
+    * Use a specific version or pattern:
+
+        ```
+        python ./tools/amd_build/write_rocm_init.py --rocm-version 7.0.0rc20250812
+        python ./tools/amd_build/write_rocm_init.py --rocm-version 7.0.0*
+        ```
+
+    * Omit the version, skipping version checks:
+
+        ```
+        python ./tools/amd_build/write_rocm_init.py --rocm-version ""
+        ```
+
+The expectation is that the https://github.com/pytorch/pytorch repo will build
+"PyTorch HEAD on ROCm stable", while https://github.com/ROCm/TheRock downstream
+will build "PyTorch HEAD on ROCm HEAD". However, while the ROCm Python packages
+continue to mature, the "stable" version pinned in this file will be
+periodically updated. Eventually a pattern like `7.1.*` may be preffered here,
+allowing for changes in patch versions but warning about changes to major or
+minor versions.
+
+Available versions can be seen on the index pages at
+https://github.com/ROCm/TheRock/blob/main/RELEASES.md#installing-releases-using-pip.
+Currently (August 2025), only 7.0.0rcYYYYMMDD versions are available, but in the
+future there may be non-rc versions, possibly pushed to PyPI.
+
+The lists of library preloads available are likely to change from ROCm version
+to ROCm version, while the lists of preloads _used directly by PyTorch_ should
+be dependent on code in PyTorch itself. Indirect dependencies like a ROCm
+library taking a dependency on another ROCm library, are possible too and would
+require changes here during a version bump, even with no other PyTorch changes.
+"""
+
+import argparse
+from pathlib import Path
+import platform
+import shlex
+import subprocess
+import sys
+import textwrap
+
+DEFAULT_ROCM_SDK_VERSION = "7.0.0rc20250812"
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+IS_WINDOWS = platform.system() == "Windows"
+
+# List of library preloads for Linux to generate into _rocm_init.py
+LINUX_LIBRARY_PRELOADS = [
+    "amd_comgr",
+    "amdhip64",
+    "rocprofiler-sdk-roctx",  # Linux only for the moment.
+    "roctracer64",  # Linux only for the moment.
+    "roctx64",  # Linux only for the moment.
+    "hiprtc",
+    "hipblas",
+    "hipfft",
+    "hiprand",
+    "hipsparse",
+    "hipsolver",
+    "rccl",  # Linux only for the moment.
+    "hipblaslt",
+    "miopen",
+]
+
+# List of library preloads for Windows to generate into _rocm_init.py
+WINDOWS_LIBRARY_PRELOADS = [
+    "amd_comgr",
+    "amdhip64",
+    "hiprtc",
+    "hipblas",
+    "hipfft",
+    "hiprand",
+    "hipsparse",
+    "hipsolver",
+    "hipblaslt",
+    "miopen",
+]
+
+
+def _capture(args: list[str | Path], cwd: Path) -> str:
+    args = [str(arg) for arg in args]
+    print(f"++ Capture [{cwd}]$ {shlex.join(args)}")
+    try:
+        return subprocess.check_output(
+            args, cwd=str(cwd), stderr=subprocess.STDOUT, text=True
+        ).strip()
+    except subprocess.CalledProcessError as e:
+        print(f"  Error capturing output: {e}")
+        print(f"  Output from the failed command:\n  {e.output}")
+        return ""
+
+
+def get_rocm_sdk_version() -> str:
+    return _capture(
+        [sys.executable, "-m", "rocm_sdk", "version"], cwd=Path.cwd()
+    ).strip()
+
+
+def get_rocm_init_contents(sdk_version: str):
+    """Gets the contents of the _rocm_init.py file to add to the build."""
+    library_preloads = (
+        WINDOWS_LIBRARY_PRELOADS if IS_WINDOWS else LINUX_LIBRARY_PRELOADS
+    )
+    library_preloads_formatted = ", ".join(f"'{s}'" for s in library_preloads)
+
+    # Notes:
+    #   * We could also set `fail_on_version_mismatch=True` here.
+    #   * We could pass a version regex pattern instead of a string too.
+
+    return textwrap.dedent(
+        f"""
+        def initialize():
+            import rocm_sdk
+            rocm_sdk.initialize_process(
+                preload_shortnames=[{library_preloads_formatted}],
+                check_version='{sdk_version}')
+        """
+    )
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser(
+        prog="write_rocm_init.py", formatter_class=argparse.RawTextHelpFormatter
+    )
+    p.add_argument(
+        "--rocm-version",
+        default="auto",
+        help=f"""The rocm version to check for at initialization time. Options are:
+  * 'auto' (the default)
+  * 'stable' (currently {DEFAULT_ROCM_SDK_VERSION})
+  * an explicit version (or pattern) like '7.0.0rc20250812' or '7.0.*'
+The 'auto' option will use the currently installed version or will fallback to 'stable'""",
+    )
+    # TODO: add argument (or other handling) for version regex?
+    # TODO: add argument for explicit list of library preloads?
+
+    args = p.parse_args()
+
+    if args.rocm_version == "auto":
+        print("Requested --rocm-version is 'auto', checking `rocm-sdk version`")
+        rocm_version = get_rocm_sdk_version()
+        if not rocm_version:
+            print("Could not find installed rocm_sdk package, falling back to 'stable'")
+            rocm_version = DEFAULT_ROCM_SDK_VERSION
+    elif args.rocm_version == "stable":
+        rocm_version = DEFAULT_ROCM_SDK_VERSION
+    else:
+        rocm_version = args.rocm_version
+    print(f"Using rocm_version '{rocm_version}'")
+
+    rocm_init_file = REPO_ROOT / "torch" / "_rocm_init.py"
+    rocm_init_contents = get_rocm_init_contents(rocm_version)
+    print(f"Writing to '{rocm_init_file}'")
+    rocm_init_file.write_text(rocm_init_contents)


### PR DESCRIPTION
Progress on https://github.com/pytorch/pytorch/issues/159520.

This begins to set up build scripts and documentation for building PyTorch with ROCm support on Windows, using the (preview) ROCm Python packages published by https://github.com/ROCm/TheRock. The scripts have been adapted from existing downstream scripts at https://github.com/ROCm/TheRock/tree/main/external-builds/pytorch which have been producing torch wheels for about 1 month.

Notes:

* `.ci/pytorch/rocm_sdk-build.sh` and `.ci/pytorch/win-build.sh`
  * I made these changes to be compatible with other scripts in [`.ci/pytorch/`](https://github.com/pytorch/pytorch/tree/main/.ci/pytorch), intending for Windows ROCm builds to slot into existing workflows that call `win-build.sh` here: https://github.com/pytorch/pytorch/blob/fa75ba930390634f708c5a0e1409ad6c4a08e9df/.github/workflows/_win-build.yml#L170-L171
* `tools/amd_build/build_windows.sh`
  * I added this script to have a way to test something _close_ to what a CI runner would do. I can't run [`build_pytorch.bat`](https://github.com/pytorch/pytorch/blob/main/.ci/pytorch/win-test-helpers/build_pytorch.bat) locally (without deeper changes) since it references hardcoded paths on Windows AMI runners.
* `tools/amd_build/write_rocm_init.py`
  * Downstream, we have this as part of [`external-builds/pytorch/build_prod_wheels.py`](https://github.com/ROCm/TheRock/blob/main/external-builds/pytorch/build_prod_wheels.py). I've generalized the file generation here, perhaps too much - we'll see.

I've tested the build scripts locally and sanity checked the wheels produced by a build. I have _not_ tested them on any CI/CD runners yet. I expect I may want to fork an existing workflow and maybe extend [`.github/actions/setup-win/action.yml`](https://github.com/pytorch/pytorch/blob/main/.github/actions/setup-win/action.yml) or [`.github/actions/setup-rocm/action.yml`](https://github.com/pytorch/pytorch/blob/main/.github/actions/setup-rocm/action.yml) to handle installing the ROCm Python wheels. If new workflows will use AMD-provided build/test runners, I'll also need to figure out how to handle any differences in installed software and credentials (e.g. permissions for using cache servers, etc.).

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd