### PR TITLE
hacky fix on dictionary changed size during iteration

### DIFF
--- a/torch/_inductor/codegen/cuda/gemm_template.py
+++ b/torch/_inductor/codegen/cuda/gemm_template.py
@@ -1495,7 +1495,8 @@ class CUTLASS3xGemmTemplate(CUTLASSGemmTemplate):
 
         name_to_buffer = V.graph.name_to_buffer | V.graph.graph_inputs
 
-        for name in V.graph.constants.keys():
+        constant_keys = set(V.graph.constants.keys())
+        for name in constant_keys:
             name_to_buffer[name] = V.graph.add_tensor_constant(
                 V.graph.constants[name], name
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #160783

Differential Revision: [D80370731](https://our.internmc.facebook.com/intern/diff/D80370731/)

problem: "torch._inductor.exc.LoweringException: RuntimeError: dictionary changed size during iteration"
previous fix https://github.com/pytorch/pytorch/pull/160552 would result in an infinite loop
trying this.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben