### PR TITLE
flip the list-as-tuple behavior for short lists

### DIFF
--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -894,12 +894,9 @@ class TestIndexing(TestCase):
         # Generate a list of lists, containing overlapping window indices
         indices = [range(i, i + W) for i in range(0, N - W)]
 
-        for i in [len(indices), 100, 32]:
+        for i in [len(indices), 100, 32, 31]:
             windowed_data = t[indices[:i]]
             self.assertEqual(windowed_data.shape, (i, W))
-
-        with self.assertRaisesRegex(IndexError, "too many indices"):
-            windowed_data = t[indices[:31]]
 
     def test_bool_indices_accumulate(self, device):
         mask = torch.zeros(size=(10,), dtype=torch.bool, device=device)

--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -2124,16 +2124,6 @@ $0: f32[] = torch._ops.aten.empty.memory_format([], device=device(type='cpu'), p
             t = DimImplementedTensor(torch.randn(3, 3), use_wrapper_subclass)
             self.assertEqual(t.dim(), 2)
 
-    def test_maybe_tuple_bug(self):
-        class T(torch.Tensor):
-            @classmethod
-            def __torch_function__(cls, *args, **kwargs):
-                pass
-
-        a = torch.rand(3)
-
-        a[[T(), T()]]
-
     def test_standard_is_not_subclass(self):
         # https://github.com/pytorch/pytorch/issues/79079
         self.assertFalse(torch._C._dispatch_isTensorSubclassLike(torch.empty(0)))

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -262,76 +262,9 @@ static Variable applySlicing(
   return result;
 }
 
-static bool treatSequenceAsTuple(PyObject* index) {
-  if (PyTuple_Check(index)) {
-    return true;
-  }
-  if (THPVariable_Check(index)) {
-    return false;
-  }
-  //  Allow indexing with ndarray if numpy compilation is enabled. An ndarray
-  //  index should not be treated as a tuple since the indexing has a different
-  //  syntax.
-#ifdef USE_NUMPY
-  if (::torch::utils::is_numpy_available() && PyArray_CheckExact(index)) {
-    return false;
-  }
-#endif
-  if (!PySequence_Check(index)) {
-    return false;
-  }
-  // This uses a heuristics from NumPy for determining whether to treat
-  // non-tuple sequences as if they were a tuple. From the NumPy code comments:
-  //
-  // "At this point, we're left with a non-tuple, non-array, sequence:
-  //  typically, a list. We use some somewhat-arbitrary heuristics from here
-  //  onwards to decided whether to treat that list as a single index, or a
-  //  list of indices. Backwards compatibility only takes effect for short
-  //  sequences - otherwise we treat it like any other scalar."
-  auto n = PySequence_Size(index);
-  if (n < 0) {
-    // Negative size indicates a Python error in the PySequence_Size call.
-    PyErr_Clear();
-    return false;
-  }
-  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-  if (n >= 32) {
-    return false;
-  }
-  for (Py_ssize_t i = 0; i < n; i++) {
-    auto obj = THPObjectPtr{PySequence_GetItem(index, i)};
-    if (!obj.get()) {
-      PyErr_Clear();
-      return false;
-    }
-    if (THPVariable_Check(obj.get()) || PySequence_Check(obj.get()) ||
-        PySlice_Check(obj.get())) {
-      TORCH_WARN(
-          "Using a non-tuple sequence for "
-          "multidimensional indexing is deprecated and will be changed in "
-          "pytorch 2.9; use x[tuple(seq)] instead of "
-          "x[seq]. In pytorch 2.9 this will be interpreted as tensor index, "
-          "x[torch.tensor(seq)], which will result either in an error or a "
-          "different result");
-      return true;
-    }
-    if (obj.get() == Py_Ellipsis || obj.get() == Py_None) {
-      TORCH_WARN(
-          "Using a non-tuple sequence for "
-          "multidimensional indexing is deprecated and will be changed in "
-          "pytorch 2.9; use x[tuple(seq)] instead of "
-          "x[seq]. In pytorch 2.9 this will be interpreted as tensor index, "
-          "x[torch.tensor(seq)], which will result either in an error or a "
-          "different result");
-      return true;
-    }
-  }
-  return false;
-}
-
 static THPObjectPtr wrapTuple(PyObject* index) {
   THPObjectPtr res;
-  if (treatSequenceAsTuple(index)) {
+  if (PyTuple_Check(index)) {
     res = PySequence_Tuple(index);
   } else {
     res = PyTuple_Pack(1, index);


### PR DESCRIPTION
Per title, previously we started throwing noisy warnings, but given how popular this pattern was in our test suite decided to leave it as warning, not as silent behavior change for one release. 
Now `treatSequenceAsTuple` would return `true` in the only case where the sequence was indeed a tuple, so no need for a special function anymore. 