### PR TITLE
[SymmMem] Handle should carry tensor data_ptr instead of allocation base address

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -832,8 +832,12 @@ c10::intrusive_ptr<CUDASymmetricMemory> make_symm_mem(
 } // namespace
 
 c10::intrusive_ptr<SymmetricMemory> CUDASymmetricMemoryAllocator::rendezvous(
-    void* ptr,
+    void* ptr,  // data_ptr() of the tensor
     const std::optional<std::string>& group_name) {
+  // Today this would still find the ptr in the map because one allocation
+  // matches one tensor. But will break once we enable MemPool.
+  // TODO: implement a customized `find` that searches for the allocation that
+  // contains ptr.
   auto block = find_block(ptr);
   if (block == nullptr) {
     return nullptr;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #160925
* #160825
* __->__ #160795

Since
- `handle = rendezvous(tensor)`, and
- we pass `handle->buffer_ptrs` to kernels,

`handle` should carry the `data_ptr()` of `tensor` instead of the base address of a memory allocation (today's case).

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta