### PR TITLE
[PT2]: Add Static Dispatch Kernel for torch.ops.preproc.event_feature_padding.default

### DIFF
--- a/torch/nativert/kernels/KernelRegistry.cpp
+++ b/torch/nativert/kernels/KernelRegistry.cpp
@@ -32,6 +32,7 @@
 #include <c10/util/Enumerate.h>
 #include <c10/util/irange.h>
 
+#include "caffe2/torch/fb/sparsenn/preproc_operators.h"
 #include <torch/csrc/jit/runtime/static/ops.h>
 
 namespace at::native {
@@ -1043,6 +1044,21 @@ REGISTER_CPU_KERNEL("torch.ops.aten.where.self", aten_where, {
   auto& out = KernelOutput(0).toTensor();
   fastResizeToZero(out);
   at::native::where_self_out(cond, self, other, out);
+})
+
+REGISTER_CPU_KERNEL("torch.ops.preproc.event_feature_padding.default", preproc_event_feature_padding, {
+  const auto& in_0 = KernelInput(0).toTensor();
+  const auto& in_1 = KernelInput(1).toTensor();
+  const auto& in_2 = KernelInput(2).toTensor();
+  const auto& in_3 = KernelInput(3).toTensor();
+  const auto& in_4 = KernelInput(4).toTensor();
+  const auto& in_5 = KernelInput(5).toTensor();
+  const auto& in_6 = KernelInput(6).toTensor();
+
+  auto result = facebook::preproc::event_feature_padding(in_0, in_1, in_2, in_3, in_4, in_5, in_6);
+  KernelOutput(0) = std::get<0>(result);
+  KernelOutput(1) = std::get<1>(result);
+  KernelOutput(2) = std::get<2>(result);
 })
 
 REGISTER_CPU_KERNEL("torch.ops.fb.scale_gradient.default", fb_scale_gradient, {


### PR DESCRIPTION
Summary: As title. This is used in user/object net of DSNN models.

Test Plan:
Running BenchmarkAB (with runtime const folding). Result:
mix P1906276014
object P1906275851
 user P1906275689

```
MODEL_TYPE=dpa_product_first_ctr_model
MODEL_ENTITY_ID=778442870
SNAPSHOT_ID=0
OTHER_MODEL_ENTITY_ID=778442870
OTHER_SNAPSHOT_ID=6

MODULES=(mix prepare_float_features object user)
SUFFIXES=(.predictor.local .predictor.precompute.prepare_float_features .predictor.precompute.remote_object_only .predictor.precompute.remote_request_only)

for i in "${!MODULES[@]}"; do 
MODULE=${MODULES[i]}
SUFFIX=${SUFFIXES[i]}
buck2 run mode/opt caffe2/torch/fb/model_transform/fx2trt/packaging:load_net_predictor -- --loadMode=BenchmarkAB --inputNetFile=/data/users/$USER/models/${MODEL_ENTITY_ID}/${SNAPSHOT_ID}/${MODEL_ENTITY_ID}_${SNAPSHOT_ID}${SUFFIX} --otherNetFile=/data/users/$USER/models/${OTHER_MODEL_ENTITY_ID}/${OTHER_SNAPSHOT_ID}/${OTHER_MODEL_ENTITY_ID}_${OTHER_SNAPSHOT_ID}${SUFFIX} --moduleName=${MODULE} --submodToDevice "" --benchmarkDontRebatchSamples=true --doNotRandomizeSampleInputs=true &>  ~/logs/${MODEL_TYPE}/load_net_predictor_${MODEL_ENTITY_ID}_${SNAPSHOT_ID}_${OTHER_MODEL_ENTITY_ID}_${OTHER_SNAPSHOT_ID}_${MODULE}; done
```

Rollback Plan:

Differential Revision: D80385951


