### PR TITLE
[PT2]: Allow None for wrapped_fbgemm_linear_fp16_weight

### DIFF
--- a/torch/nativert/kernels/KernelRegistry.cpp
+++ b/torch/nativert/kernels/KernelRegistry.cpp
@@ -1139,7 +1139,7 @@ REGISTER_CPU_KERNEL(
     {
       const auto& in_0 = KernelInput(0).toTensor();
       const auto& weight = KernelInput(1).toTensor();
-      const auto& bias = KernelInput(2).toTensor();
+      auto bias = KernelInput(2).toOptional<at::Tensor>();
 
       if (auto& out_0 = KernelOutput(0); out_0.isNone()) {
         out_0 = create_empty_from(in_0, at::kFloat);
@@ -1148,7 +1148,8 @@ REGISTER_CPU_KERNEL(
       auto& out_0 = KernelOutput(0).toTensor();
       fastResizeToZero(out_0);
 
-      at::native::fbgemm_linear_fp16_weight(in_0, weight, bias, out_0);
+      at::native::fbgemm_linear_fp16_weight(
+          in_0, weight, bias.value_or(at::Tensor()), out_0);
     })
 
 REGISTER_CPU_KERNEL(


### PR DESCRIPTION
Summary: Currently the implementation of [fbgemm_linear_fp16_weight](https://www.internalfb.com/code/fbsource/[ffe8ba561cb6af33fde5b32c27411d6d3f4f2c70]/fbcode/caffe2/aten/src/ATen/native/QuantizedLinear.cpp?lines=477) does not allow None for `bias`, but it's actually a valid case and internally `fbgemm_linear_fp16_weight_fp32_activation` accept None bias as well. For BC reason, we can't directly change the function signature. So wrapping an empty tensor if bias is None to workaround it in Sigmoid.

Test Plan:
P1906210273
```
MODEL_TYPE=dpa_product_first_ctr_model
MODEL_ENTITY_ID=778442870
SNAPSHOT_ID=6
MODULE=user
SUFFIX=.predictor.precompute.remote_request_only

buck2 run mode/opt caffe2/torch/fb/model_transform/fx2trt/packaging:load_net_predictor -- --loadMode=Benchmark --inputNetFile=/data/users/$USER/models/${MODEL_ENTITY_ID}/${SNAPSHOT_ID}/${MODEL_ENTITY_ID}_${SNAPSHOT_ID}${SUFFIX} --moduleName=${MODULE} --submodToDevice="" --benchmarkDontRebatchSamples=true --doNotRandomizeSampleInputs=true --benchmarkNumIterations=10000 &>  ~/logs/${MODEL_TYPE}/load_net_predictor_${MODEL_ENTITY_ID}_${SNAPSHOT_ID}_${MODULE}
```

Rollback Plan:

Reviewed By: henryoier, hl475

Differential Revision: D80382652


