### PR TITLE
[MPS][BE] Fix unused vars in GridSampler

### DIFF
--- a/aten/src/ATen/native/mps/kernels/GridSampler.metal
+++ b/aten/src/ATen/native/mps/kernels/GridSampler.metal
@@ -19,9 +19,7 @@ struct GridSamplerOffsets {
 static GridSamplerOffsets find_grid_sampler_offsets(
     constant int32_t* output_sizes,
     constant int32_t* output_strides,
-    constant int32_t* input_sizes,
     constant int32_t* input_strides,
-    constant int32_t* grid_sizes,
     constant int32_t* grid_strides,
     int32_t sampler_dims,
     uint tid) {
@@ -278,16 +276,13 @@ kernel void grid_sampler(
   auto output_strides = params.output_strides.data();
   auto input_sizes = params.input_sizes.data();
   auto input_strides = params.input_strides.data();
-  auto grid_sizes = params.grid_sizes.data();
   auto grid_strides = params.grid_strides.data();
   auto sampler_dims = params.sampler_dims;
 
   auto offsets = find_grid_sampler_offsets(
       output_sizes,
       output_strides,
-      input_sizes,
       input_strides,
-      grid_sizes,
       grid_strides,
       sampler_dims,
       tid);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #160889
* __->__ #160850

This fixes following warnings during the compilation of GridSampler.metal
```
/Users/malfet/git/pytorch/pytorch/aten/src/ATen/native/mps/kernels/GridSampler.metal:22:23: warning: unused parameter 'input_sizes' [-Wunused-parameter]
    constant int32_t* input_sizes,
                      ^
/Users/malfet/git/pytorch/pytorch/aten/src/ATen/native/mps/kernels/GridSampler.metal:24:23: warning: unused parameter 'grid_sizes' [-Wunused-parameter]
    constant int32_t* grid_sizes,
                      ^
2 warnings generated.
```

Introduced by https://github.com/pytorch/pytorch/pull/160541