### PR TITLE
[dynamo] Refactor convert_frame._compile_inner to return compiled bytecode + output graph. [3/n]

### DIFF
--- a/test/dynamo/test_bytecode_utils.py
+++ b/test/dynamo/test_bytecode_utils.py
@@ -284,7 +284,7 @@ def fn():
         def nothing(*args):
             pass
 
-        code = bytecode_transformation.transform_code_object(fn.__code__, nothing)
+        code, _ = bytecode_transformation.transform_code_object(fn.__code__, nothing)
         self.assertEqual(code.co_exceptiontable, fn.__code__.co_exceptiontable)
 
     @skipIfNotPy311
@@ -300,7 +300,7 @@ def fn():
         def nothing(*args):
             pass
 
-        code = bytecode_transformation.transform_code_object(fn.__code__, nothing)
+        code, _ = bytecode_transformation.transform_code_object(fn.__code__, nothing)
         self.assertEqual(code.co_exceptiontable, fn.__code__.co_exceptiontable)
 
     @skipIfNotPy311

--- a/torch/_dynamo/bytecode_transformation.py
+++ b/torch/_dynamo/bytecode_transformation.py
@@ -1259,7 +1259,7 @@ def debug_bytes(*args: bytes) -> str:
 
 def debug_checks(code: types.CodeType) -> None:
     """Make sure our assembler produces same bytes as we start with"""
-    dode = transform_code_object(code, lambda x, y: None, safe=True)
+    dode, _ = transform_code_object(code, lambda x, y: None, safe=True)
     assert code.co_code == dode.co_code, debug_bytes(code.co_code, dode.co_code)
     assert code.co_lnotab == dode.co_lnotab, debug_bytes(code.co_lnotab, dode.co_lnotab)
 
@@ -1456,7 +1456,7 @@ def transform_code_object(
         [list[Instruction], dict[str, Any]], Optional["DynamoTracerOutput"]
     ],
     safe: bool = False,
-) -> types.CodeType:
+) -> tuple[types.CodeType, Optional["DynamoTracerOutput"]]:
     keys = get_code_keys()
     code_options = {k: getattr(code, k) for k in keys}
     assert len(code_options["co_varnames"]) == code_options["co_nlocals"]
@@ -1465,8 +1465,9 @@ def transform_code_object(
     # propagate line nums again for added instructions
     propagate_line_nums(instructions)
 
-    transformations(instructions, code_options)
-    return clean_and_assemble_instructions(instructions, keys, code_options)[1]
+    tracer_output = transformations(instructions, code_options)
+    _, bytecode = clean_and_assemble_instructions(instructions, keys, code_options)
+    return bytecode, tracer_output
 
 
 def clean_and_assemble_instructions(

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -841,7 +841,7 @@ def compile_frame(
     code: types.CodeType,
     transform: Callable[[list[Instruction], dict[str, Any]], DynamoTracerOutput],
     restart_reasons: set[str],
-):
+) -> DynamoOutput:
     last_attempt_start_time = None
     for attempt in itertools.count():
         CompileContext.get().attempt = attempt
@@ -925,7 +925,7 @@ def _compile(
 
     def transform(
         instructions: list[Instruction], code_options: dict[str, object]
-    ) -> None:
+    ) -> DynamoTracerOutput:
         nonlocal tracer_output
 
         tf_mode_stack: list[torch.overrides.TorchFunctionMode] = (
@@ -954,6 +954,7 @@ def _compile(
             tracer_output = getattr(e, "_torch_dynamo_tracer_output", None)  # type: ignore[attr-defined]
             raise
 
+        assert tracer_output is not None
         return tracer_output
 
     @compile_time_strobelight_meta(phase_name="compile_inner")

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -830,6 +830,65 @@ def trace_frame(
     return tracer_output
 
 
+@dataclass
+class DynamoOutput:
+    tracer_output: DynamoTracerOutput
+    bytecode: types.CodeType
+    last_attempt_start_time: Optional[float]
+
+
+def compile_frame(
+    code: types.CodeType,
+    transform: Callable[[list[Instruction], dict[str, Any]], DynamoTracerOutput],
+    restart_reasons: set[str],
+):
+    last_attempt_start_time = None
+    for attempt in itertools.count():
+        CompileContext.get().attempt = attempt
+
+        try:
+            with dynamo_timed(f"compile_attempt_{attempt}", log_pt2_compile_event=True):
+                bytecode, tracer_output = transform_code_object(code, transform)
+                assert tracer_output is not None
+                return DynamoOutput(
+                    tracer_output=tracer_output,
+                    bytecode=bytecode,
+                    last_attempt_start_time=last_attempt_start_time,
+                )
+        except exc.RestartAnalysis as e:
+            if not isinstance(e, exc.TensorifyScalarRestartAnalysis):
+                TensorifyState.clear()
+            log.info(
+                "Restarting analysis due to %s",
+                LazyString(format_traceback_short, e.__traceback__),
+            )
+            # If restart reason is None just log the type of the exception
+            restart_reasons.add(e.restart_reason or str(type(e)))
+            # We now have a new "last attempt", reset the clock
+            last_attempt_start_time = time.time()
+            if attempt > 100:
+                unimplemented_v2(
+                    gb_type="Excessive RestartAnalysis() calls",
+                    context="",
+                    explanation="Dynamo attempted to trace the same frame 100+ times. "
+                    "Giving up on compiling as the compile time tradeoff is likely not "
+                    "worth the performance gain.",
+                    hints=[],
+                )
+        except exc.SkipFrame as e:
+            if not isinstance(e, exc.TensorifyScalarRestartAnalysis):
+                TensorifyState.clear()
+            log.debug(
+                "Skipping frame %s %s \
+                %s %s",
+                e,
+                code.co_name,
+                code.co_filename,
+                code.co_firstlineno,
+            )
+            raise
+
+
 def _compile(
     code: CodeType,
     globals: dict[str, object],
@@ -895,6 +954,8 @@ def _compile(
             tracer_output = getattr(e, "_torch_dynamo_tracer_output", None)  # type: ignore[attr-defined]
             raise
 
+        return tracer_output
+
     @compile_time_strobelight_meta(phase_name="compile_inner")
     def compile_inner(
         code: CodeType,
@@ -942,50 +1003,14 @@ def _compile(
         )
 
         out_code = None
-        for attempt in itertools.count():
-            CompileContext.get().attempt = attempt
-            try:
-                with dynamo_timed(
-                    f"compile_attempt_{attempt}", log_pt2_compile_event=True
-                ):
-                    out_code = transform_code_object(code, transform)
-                break
-            except exc.RestartAnalysis as e:
-                if not isinstance(e, exc.TensorifyScalarRestartAnalysis):
-                    TensorifyState.clear()
-                log.info(
-                    "Restarting analysis due to %s",
-                    LazyString(format_traceback_short, e.__traceback__),
-                )
-                # If restart reason is None just log the type of the exception
-                restart_reasons.add(e.restart_reason or str(type(e)))
-                # We now have a new "last attempt", reset the clock
-                last_attempt_start_time = time.time()
-                if attempt > 100:
-                    unimplemented_v2(
-                        gb_type="Excessive RestartAnalysis() calls",
-                        context="",
-                        explanation="Dynamo attempted to trace the same frame 100+ times. "
-                        "Giving up on compiling as the compile time tradeoff is likely not "
-                        "worth the performance gain.",
-                        hints=[],
-                    )
-            except exc.SkipFrame as e:
-                if not isinstance(e, exc.TensorifyScalarRestartAnalysis):
-                    TensorifyState.clear()
+        try:
+            out_code = compile_frame(code, transform, restart_reasons).bytecode
+        except exc.SkipFrame:
+            if one_graph or _is_error_on_graph_break(tracer_output):
                 log.debug(
-                    "Skipping frame %s %s \
-                    %s %s",
-                    e,
-                    code.co_name,
-                    code.co_filename,
-                    code.co_firstlineno,
+                    "No graph captured with one_graph=True or error_on_graph_break=True"
                 )
-                if one_graph or _is_error_on_graph_break(tracer_output):
-                    log.debug(
-                        "No graph captured with one_graph=True or error_on_graph_break=True"
-                    )
-                return ConvertFrameReturn()
+            return ConvertFrameReturn()
 
         assert distributed_state is None or distributed_state.all_states is not None, (  # type: ignore[has-type]
             "compiler collective wasn't run before compilation completed"

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1005,7 +1005,7 @@ def _compile(
 
         out_code = None
         try:
-            out_code = compile_frame(code, transform, restart_reasons).bytecode
+            dynamo_output = compile_frame(code, transform, restart_reasons)
         except exc.SkipFrame:
             if one_graph or _is_error_on_graph_break(tracer_output):
                 log.debug(
@@ -1016,6 +1016,9 @@ def _compile(
         assert distributed_state is None or distributed_state.all_states is not None, (  # type: ignore[has-type]
             "compiler collective wasn't run before compilation completed"
         )
+        out_code = dynamo_output.bytecode
+        if dynamo_output.last_attempt_start_time is not None:
+            last_attempt_start_time = dynamo_output.last_attempt_start_time
 
         assert out_code is not None
         log_bytecode(

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -837,7 +837,7 @@ class DynamoOutput:
     last_attempt_start_time: Optional[float]
 
 
-def compile_frame(
+def compile_frame(  # type: ignore[return]
     code: types.CodeType,
     transform: Callable[[list[Instruction], dict[str, Any]], DynamoTracerOutput],
     restart_reasons: set[str],

--- a/torch/_dynamo/resume_execution.py
+++ b/torch/_dynamo/resume_execution.py
@@ -502,7 +502,7 @@ class ContinueExecutionCache:
             # TODO(jansel): add dead code elimination here
             instructions[:] = prefix + instructions
 
-        new_code = transform_code_object(code, update)
+        new_code, _ = transform_code_object(code, update)
         ContinueExecutionCache.generated_code_metadata[new_code] = meta
         return new_code
 

--- a/torch/_dynamo/testing.py
+++ b/torch/_dynamo/testing.py
@@ -200,7 +200,7 @@ def debug_insert_nops(
             return ConvertFrameReturn()
 
         debug_checks(frame.f_code)
-        code = transform_code_object(frame.f_code, insert_nops)
+        code, _ = transform_code_object(frame.f_code, insert_nops)
         graph = OutputGraph(
             code_options={},
             compiler_fn=None,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #160900
* #160899
* __->__ #160855
* #160815
* #160814

We are refactoring dynamo code for convert frame so that we can have modularized pieces sharable between different compiler frontends (e.g. torch.compile, precompile and torch.export).

This PR adds a new helper function compile_frame() which takes a bytecode and a transform function and return compiled bytecode + output graph as DynamoOutput type.

Differential Revision: [D80430802](https://our.internmc.facebook.com/intern/diff/D80430802/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela