### PR TITLE
[FlexAttn] Fix Paged Attention Accuracy via Upper Mask Mod and Prevent Invalid Memory Access 

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -2384,6 +2384,12 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         self.run_test_with_paged_attention(
             score_mod, dtype=torch.float16, device=device
         )
+        self.run_test_with_paged_attention(
+            score_mod=score_mod,
+            dtype=torch.bfloat16,
+            KV_S=64,
+            device=device,
+        )
 
     @supported_platform
     @skip("TODO: Figure out why this is erroring")

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -659,7 +659,9 @@ class TestFlexAttention(InductorTestCase):
         paged_attention.assign(batch_idx, input_pos, k, v, k_cache, v_cache)
 
         # convert block mask and score mod
-        converted_block_mask = paged_attention.convert_logical_block_mask(block_mask)
+        converted_block_mask = paged_attention.convert_logical_block_mask(
+            block_mask, kv_len=KV_S
+        )
         converted_score_mod = paged_attention.get_score_mod(score_mod)
         return k_cache, v_cache, converted_block_mask, converted_score_mod
 
@@ -5129,7 +5131,9 @@ class TestPagedAttention(InductorTestCase):
         block_mask = create_block_mask(
             causal_mask, max_batch_size, 1, max_seq_len, max_seq_len, device=device
         )
-        new_block_mask = paged_cache.convert_logical_block_mask(block_mask)
+        new_block_mask = paged_cache.convert_logical_block_mask(
+            block_mask, kv_len=max_seq_len
+        )
 
         zeros = [0, 0, 0, 0]
         # Check that the new block mask is correct
@@ -5404,7 +5408,9 @@ class TestPagedAttention(InductorTestCase):
         )
         paged_cache.assign(batch_idx, input_pos, k, v, k_cache, v_cache)
 
-        new_block_mask = paged_cache.convert_logical_block_mask(block_mask)
+        new_block_mask = paged_cache.convert_logical_block_mask(
+            block_mask, kv_len=max_seq_len
+        )
 
         compiled_sdpa = torch.compile(
             create_attention(

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -659,8 +659,9 @@ class TestFlexAttention(InductorTestCase):
         paged_attention.assign(batch_idx, input_pos, k, v, k_cache, v_cache)
 
         # convert block mask and score mod
+        kv_len_tensor = torch.full((KV_B,), KV_S, device=device, dtype=torch.int64)
         converted_block_mask = paged_attention.convert_logical_block_mask(
-            block_mask, kv_len=KV_S
+            block_mask, kv_len=kv_len_tensor
         )
         converted_score_mod = paged_attention.get_score_mod(score_mod)
         return k_cache, v_cache, converted_block_mask, converted_score_mod
@@ -5131,8 +5132,11 @@ class TestPagedAttention(InductorTestCase):
         block_mask = create_block_mask(
             causal_mask, max_batch_size, 1, max_seq_len, max_seq_len, device=device
         )
+        kv_len_tensor = torch.full(
+            (max_batch_size,), max_seq_len, device=device, dtype=torch.int64
+        )
         new_block_mask = paged_cache.convert_logical_block_mask(
-            block_mask, kv_len=max_seq_len
+            block_mask, kv_len=kv_len_tensor
         )
 
         zeros = [0, 0, 0, 0]

--- a/test/inductor/test_flex_decoding.py
+++ b/test/inductor/test_flex_decoding.py
@@ -1545,7 +1545,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
 
     @supported_platform
     @patch.object(torch._inductor.config, "max_autotune", True)
-    def test_ma_autotune_with_captured(self, device):
+    def test_max_autotune_with_captured(self, device):
         head_scale = torch.randn(Hq, device=device)
         batch_scale = torch.randn(B, device=device)
         tok_scale = torch.randn(S, device=device)

--- a/test/inductor/test_flex_decoding.py
+++ b/test/inductor/test_flex_decoding.py
@@ -364,9 +364,9 @@ class TestFlexDecoding(InductorTestCase):
         block_mask: Optional[BlockMask] = None,
         device="cuda",
     ):
-        assert (
-            score_mod is not None or block_mask is not None
-        ), "Must provide score_mod or block_mask"
+        assert score_mod is not None or block_mask is not None, (
+            "Must provide score_mod or block_mask"
+        )
         assert Q_H % KV_H == 0
         if device == "cpu" and dtype is torch.float16:
             dtype = torch.float32
@@ -1524,20 +1524,8 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         def score_mod(score, b, h, m, n):
             return score * 2
 
-        # self.run_test(
-        #     score_mod,
-        #     dtype=torch.bfloat16,
-        #     Q_B=1,
-        #     Q_H=1,
-        #     Q_S=1,
-        #     Q_D=16,
-        #     KV_B=1,
-        #     KV_H=1,
-        #     KV_S=64,
-        #     V_D=16,
-        #     device=device,
-        # )
-        # self.run_test_with_paged_attention(score_mod, device=device)
+        self.run_test(score_mod, device=device)
+        self.run_test_with_paged_attention(score_mod, device=device)
         self.run_test_with_paged_attention(
             score_mod=score_mod,
             dtype=torch.bfloat16,

--- a/test/inductor/test_flex_decoding.py
+++ b/test/inductor/test_flex_decoding.py
@@ -364,9 +364,9 @@ class TestFlexDecoding(InductorTestCase):
         block_mask: Optional[BlockMask] = None,
         device="cuda",
     ):
-        assert score_mod is not None or block_mask is not None, (
-            "Must provide score_mod or block_mask"
-        )
+        assert (
+            score_mod is not None or block_mask is not None
+        ), "Must provide score_mod or block_mask"
         assert Q_H % KV_H == 0
         if device == "cpu" and dtype is torch.float16:
             dtype = torch.float32
@@ -1524,8 +1524,33 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         def score_mod(score, b, h, m, n):
             return score * 2
 
-        self.run_test(score_mod, device=device)
-        self.run_test_with_paged_attention(score_mod, device=device)
+        # self.run_test(
+        #     score_mod,
+        #     dtype=torch.bfloat16,
+        #     Q_B=1,
+        #     Q_H=1,
+        #     Q_S=1,
+        #     Q_D=16,
+        #     KV_B=1,
+        #     KV_H=1,
+        #     KV_S=64,
+        #     V_D=16,
+        #     device=device,
+        # )
+        # # self.run_test_with_paged_attention(score_mod, device=device)
+        self.run_test_with_paged_attention(
+            score_mod=score_mod,
+            dtype=torch.bfloat16,
+            Q_B=1,
+            Q_H=1,
+            Q_S=1,
+            QK_D=16,
+            KV_B=1,
+            KV_H=1,
+            KV_S=64,
+            V_D=16,
+            device=device,
+        )
 
     @supported_platform
     @patch.object(torch._inductor.config, "max_autotune", True)

--- a/test/inductor/test_flex_decoding.py
+++ b/test/inductor/test_flex_decoding.py
@@ -540,7 +540,9 @@ class TestFlexDecoding(InductorTestCase):
         paged_attention.assign(batch_idx, input_pos, k, v, k_cache, v_cache)
 
         # convert block mask and score mod
-        converted_block_mask = paged_attention.convert_logical_block_mask(block_mask)
+        converted_block_mask = paged_attention.convert_logical_block_mask(
+            block_mask, kv_len=KV_S
+        )
         converted_score_mod = paged_attention.get_score_mod(score_mod)
 
         return k_cache, v_cache, converted_block_mask, converted_score_mod
@@ -1529,11 +1531,11 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         self.run_test_with_paged_attention(
             score_mod=score_mod,
             dtype=torch.bfloat16,
-            Q_B=1,
+            Q_B=4,
             Q_H=1,
             Q_S=1,
             QK_D=16,
-            KV_B=1,
+            KV_B=4,
             KV_H=1,
             KV_S=64,
             V_D=16,
@@ -2006,7 +2008,9 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         input_pos = torch.tensor(prefill_length, device=device, dtype=torch.int32).view(
             max_batch_size, 1
         )
-        new_block_mask = paged_cache.convert_logical_block_mask(block_mask)
+        new_block_mask = paged_cache.convert_logical_block_mask(
+            block_mask, kv_len=max_seq_len
+        )
         new_block_mask.seq_lengths = (1, new_block_mask.seq_lengths[1])
         compiled_sdpa = torch.compile(
             create_attention(

--- a/test/inductor/test_flex_decoding.py
+++ b/test/inductor/test_flex_decoding.py
@@ -1537,7 +1537,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         #     V_D=16,
         #     device=device,
         # )
-        # # self.run_test_with_paged_attention(score_mod, device=device)
+        # self.run_test_with_paged_attention(score_mod, device=device)
         self.run_test_with_paged_attention(
             score_mod=score_mod,
             dtype=torch.bfloat16,

--- a/test/inductor/test_flex_decoding.py
+++ b/test/inductor/test_flex_decoding.py
@@ -544,7 +544,9 @@ class TestFlexDecoding(InductorTestCase):
         converted_block_mask = paged_attention.convert_logical_block_mask(
             block_mask, kv_len=kv_len_tensor
         )
-        converted_score_mod = paged_attention.get_score_mod(score_mod)
+        converted_score_mod = paged_attention.get_score_mod(
+            score_mod, kv_len=kv_len_tensor
+        )
 
         return k_cache, v_cache, converted_block_mask, converted_score_mod
 
@@ -2018,7 +2020,9 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         new_block_mask.seq_lengths = (1, new_block_mask.seq_lengths[1])
         compiled_sdpa = torch.compile(
             create_attention(
-                paged_cache.get_score_mod(score_mod), new_block_mask, enable_gqa=False
+                paged_cache.get_score_mod(score_mod, kv_len=kv_len_tensor),
+                new_block_mask,
+                enable_gqa=False,
             )
         )
         paged_out = compiled_sdpa(

--- a/test/inductor/test_flex_decoding.py
+++ b/test/inductor/test_flex_decoding.py
@@ -1545,7 +1545,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
 
     @supported_platform
     @patch.object(torch._inductor.config, "max_autotune", True)
-    def test_max_autotune_with_captured(self, device):
+    def test_ma_autotune_with_captured(self, device):
         head_scale = torch.randn(Hq, device=device)
         batch_scale = torch.randn(B, device=device)
         tok_scale = torch.randn(S, device=device)

--- a/torch/_inductor/codegen/cpp_flex_attention_template.py
+++ b/torch/_inductor/codegen/cpp_flex_attention_template.py
@@ -792,7 +792,7 @@ class CppFlexAttentionTemplate(CppTemplate):
             return ""
 
         if start_offset == -1:
-            start_offset = getattr(self, len_attr)
+            start_offset = self.len_score_other
 
         length = getattr(self, len_attr)
         for i in range(length):
@@ -995,9 +995,9 @@ class CppFlexAttentionTemplate(CppTemplate):
             value=value,
             kv_num_blocks=self.input_nodes[3],
             kv_indices=self.input_nodes[4],
-            full_kv_num_blocks=self.input_nodes[5]
-            if not self.no_full_kv_block
-            else None,
+            full_kv_num_blocks=(
+                self.input_nodes[5] if not self.no_full_kv_block else None
+            ),
             full_kv_indices=self.input_nodes[6] if not self.no_full_kv_block else None,
             score_mod_other_buffers=self.score_mod_other_buffers,
             mask_mod_other_buffers=self.mask_mod_other_buffers,

--- a/torch/_inductor/kernel/flex/flex_decoding.py
+++ b/torch/_inductor/kernel/flex/flex_decoding.py
@@ -215,6 +215,11 @@ def create_flex_decoding_kernel(*args, **kwargs):
     kernel_options.setdefault("SPLIT_KV", get_split_k(B, Hkv, seq_len_kv))
     MAX_SPLIT_KV = kernel_options["SPLIT_KV"]
 
+    # Calculate the maximum valid KV index to prevent invalid memory access
+    # This is based on the actual number of KV blocks available
+    max_kv_blocks = V.graph.sizevars.size_hint(kv_indices.get_size()[-1], fallback=5)
+    kernel_options.setdefault("MAX_VALID_KV_IDX", max_kv_blocks - 1)
+
     # create config dependent intermediate buffers
     buf_ACC_shape = [B, MAX_SPLIT_KV, Hq, seq_len_q, v_head_dim]
     buf_ML_shape = buf_ACC_shape[:-1]

--- a/torch/_inductor/kernel/flex/flex_decoding.py
+++ b/torch/_inductor/kernel/flex/flex_decoding.py
@@ -215,11 +215,6 @@ def create_flex_decoding_kernel(*args, **kwargs):
     kernel_options.setdefault("SPLIT_KV", get_split_k(B, Hkv, seq_len_kv))
     MAX_SPLIT_KV = kernel_options["SPLIT_KV"]
 
-    # Calculate the maximum valid KV index to prevent invalid memory access
-    # This is based on the actual number of KV blocks available
-    max_kv_blocks = V.graph.sizevars.size_hint(kv_indices.get_size()[-1], fallback=5)
-    kernel_options.setdefault("MAX_VALID_KV_IDX", max_kv_blocks - 1)
-
     # create config dependent intermediate buffers
     buf_ACC_shape = [B, MAX_SPLIT_KV, Hq, seq_len_q, v_head_dim]
     buf_ML_shape = buf_ACC_shape[:-1]

--- a/torch/_inductor/kernel/flex/flex_decoding.py
+++ b/torch/_inductor/kernel/flex/flex_decoding.py
@@ -349,6 +349,13 @@ def create_flex_decoding_kernel(*args, **kwargs):
             **cur_kernel_options,
         )
 
+    filtered_score_mod_buffers = [
+        buf for buf in score_mod_other_buffers if not isinstance(buf, sympy.Symbol)
+    ]
+    filtered_mask_mod_buffers = [
+        buf for buf in mask_mod_other_buffers if not isinstance(buf, sympy.Symbol)
+    ]
+
     inputs_for_flex_decoding = (
         [
             query,
@@ -361,8 +368,8 @@ def create_flex_decoding_kernel(*args, **kwargs):
             full_kv_num_blocks,
             full_kv_indices,
         ]
-        + list(score_mod_other_buffers)
-        + list(mask_mod_other_buffers)
+        + filtered_score_mod_buffers
+        + filtered_mask_mod_buffers
     )
 
     input_gen_fns = {

--- a/torch/_inductor/kernel/flex/templates/flex_decode.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/flex_decode.py.jinja
@@ -120,59 +120,11 @@
     kv_indices = KV_IDX + sparse_idx_hz_offset
     kv_num_blocks = tl.load(KV_NUM_BLKS + sparse_block_hz_offset)
     indices_idx = block_n_start // SPARSE_KV_MULTIPLE
-    off_n_block_in_sparse = block_n_start % SPARSE_KV_MULTIPLE
-    off_n = tl.load(kv_indices + indices_idx) * SPARSE_KV_BLOCK_SIZE + off_n_block_in_sparse * BLOCK_N
-    # first kv block we're loading
-
-    # last valid block according to sparse mask
-    block_n_last_valid = tl.minimum(kv_num_blocks * SPARSE_KV_MULTIPLE, tl.maximum(tl.cdiv(KV_LEN, BLOCK_N), 1))
-
-    K_block_ptr = tl.make_block_ptr(
-        base=K + k_offset,
-        shape=(QK_HEAD_DIM, KV_LEN),                # (d, N)
-        strides=(stride_kk, stride_kn),
-        offsets=(0, off_n),
-        block_shape=(QK_HEAD_DIM_ROUNDED, BLOCK_N),
-        order=(0, 1)
-    )
-    V_block_ptr = tl.make_block_ptr(
-        base=V + v_offset,
-        shape=(KV_LEN, V_HEAD_DIM),
-        strides=(stride_vn, stride_vk),
-        offsets=(off_n, 0),
-        block_shape=(BLOCK_N, V_HEAD_DIM_ROUNDED),
-        order=(1, 0)
-    )
-    offs_n = tl.arange(0, BLOCK_N) + off_n
-
-    acc, l_i, m_i = forward_inner(
-        {{gen_argdefs()}},
-        q, K_block_ptr, V_block_ptr, None, None, Q_LEN, KV_LEN,
-        # accumulatd values
-        acc, l_i, m_i,
-        #offsets
-        off_z, offs_hq[:, None], offs_m[:, None], offs_n[None, :],
-        None,
-        #block sparse data
-        kv_indices, kv_num_blocks,
-        block_n_start, block_n_end if block_n_end <= block_n_last_valid else block_n_last_valid,
-        MATMUL_PRECISION,
-        IS_FULL_BLOCKS=False,
-    )
-
-
-    # ~~~~~~~~~~~~~~ "full" blocks ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # We know these blocks are guaranteed to be "full", so we don't need to
-    # apply mask_mod to them - only score_mod
-    if HAS_FULL_BLOCKS:
-        kv_indices = FULL_KV_IDX + sparse_idx_hz_offset
-        kv_num_blocks = tl.load(FULL_KV_NUM_BLKS + sparse_block_hz_offset)
-        # Assign full block in a reverse order for off_t. Prioritize the last CTA.
-        block_n_start = (SPLIT_KV - off_t - 1) * TILE_KV_MULTIPLE
-        block_n_end = block_n_start + TILE_KV_MULTIPLE
-        indices_idx = block_n_start // SPARSE_KV_MULTIPLE
+    # Early exit: skip CTA computation if indices_idx exceeds available KV blocks to prevent invalid memory access
+    if indices_idx <= MAX_VALID_KV_IDX:
         off_n_block_in_sparse = block_n_start % SPARSE_KV_MULTIPLE
         off_n = tl.load(kv_indices + indices_idx) * SPARSE_KV_BLOCK_SIZE + off_n_block_in_sparse * BLOCK_N
+        # first kv block we're loading
 
         # last valid block according to sparse mask
         block_n_last_valid = tl.minimum(kv_num_blocks * SPARSE_KV_MULTIPLE, tl.maximum(tl.cdiv(KV_LEN, BLOCK_N), 1))
@@ -207,8 +159,60 @@
             kv_indices, kv_num_blocks,
             block_n_start, block_n_end if block_n_end <= block_n_last_valid else block_n_last_valid,
             MATMUL_PRECISION,
-            IS_FULL_BLOCKS=True,
+            IS_FULL_BLOCKS=False,
         )
+
+
+    # ~~~~~~~~~~~~~~ "full" blocks ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # We know these blocks are guaranteed to be "full", so we don't need to
+    # apply mask_mod to them - only score_mod
+    if HAS_FULL_BLOCKS:
+        kv_indices = FULL_KV_IDX + sparse_idx_hz_offset
+        kv_num_blocks = tl.load(FULL_KV_NUM_BLKS + sparse_block_hz_offset)
+        # Assign full block in a reverse order for off_t. Prioritize the last CTA.
+        block_n_start = (SPLIT_KV - off_t - 1) * TILE_KV_MULTIPLE
+        block_n_end = block_n_start + TILE_KV_MULTIPLE
+        indices_idx = block_n_start // SPARSE_KV_MULTIPLE
+        # Early exit: skip CTA computation if indices_idx exceeds available KV blocks to prevent invalid memory access
+        if indices_idx <= MAX_VALID_KV_IDX:
+            off_n_block_in_sparse = block_n_start % SPARSE_KV_MULTIPLE
+            off_n = tl.load(kv_indices + indices_idx) * SPARSE_KV_BLOCK_SIZE + off_n_block_in_sparse * BLOCK_N
+
+            # last valid block according to sparse mask
+            block_n_last_valid = tl.minimum(kv_num_blocks * SPARSE_KV_MULTIPLE, tl.maximum(tl.cdiv(KV_LEN, BLOCK_N), 1))
+
+            K_block_ptr = tl.make_block_ptr(
+                base=K + k_offset,
+                shape=(QK_HEAD_DIM, KV_LEN),                # (d, N)
+                strides=(stride_kk, stride_kn),
+                offsets=(0, off_n),
+                block_shape=(QK_HEAD_DIM_ROUNDED, BLOCK_N),
+                order=(0, 1)
+            )
+            V_block_ptr = tl.make_block_ptr(
+                base=V + v_offset,
+                shape=(KV_LEN, V_HEAD_DIM),
+                strides=(stride_vn, stride_vk),
+                offsets=(off_n, 0),
+                block_shape=(BLOCK_N, V_HEAD_DIM_ROUNDED),
+                order=(1, 0)
+            )
+            offs_n = tl.arange(0, BLOCK_N) + off_n
+
+            acc, l_i, m_i = forward_inner(
+                {{gen_argdefs()}},
+                q, K_block_ptr, V_block_ptr, None, None, Q_LEN, KV_LEN,
+                # accumulatd values
+                acc, l_i, m_i,
+                #offsets
+                off_z, offs_hq[:, None], offs_m[:, None], offs_n[None, :],
+                None,
+                #block sparse data
+                kv_indices, kv_num_blocks,
+                block_n_start, block_n_end if block_n_end <= block_n_last_valid else block_n_last_valid,
+                MATMUL_PRECISION,
+                IS_FULL_BLOCKS=True,
+            )
 
     m_offset = off_t * stride_mt + off_z * stride_mz
     l_offset = off_t * stride_lt + off_z * stride_lz

--- a/torch/_inductor/kernel/flex/templates/flex_decode.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/flex_decode.py.jinja
@@ -119,11 +119,8 @@
     # Offset the kv_indices tensor by the correct batch and head
     kv_indices = KV_IDX + sparse_idx_hz_offset
     kv_num_blocks = tl.load(KV_NUM_BLKS + sparse_block_hz_offset)
-    MAX_KV_IDX = {{size("KV_IDX", -1)}} - 1
-    indices_idx = block_n_start // SPARSE_KV_MULTIPLE
-    # Early exit: skip CTA computation if indices_idx exceeds available KV blocks to prevent invalid memory access
-    if indices_idx > MAX_KV_IDX:
-        return
+    MAX_KV_IDX = {{size("KV_IDX", -1)}}
+    indices_idx = (block_n_start // SPARSE_KV_MULTIPLE) % (MAX_KV_IDX)
     off_n_block_in_sparse = block_n_start % SPARSE_KV_MULTIPLE
     off_n = tl.load(kv_indices + indices_idx) * SPARSE_KV_BLOCK_SIZE + off_n_block_in_sparse * BLOCK_N
     # first kv block we're loading
@@ -170,15 +167,12 @@
     # apply mask_mod to them - only score_mod
     if HAS_FULL_BLOCKS:
         kv_indices = FULL_KV_IDX + sparse_idx_hz_offset
-        MAX_KV_IDX = {{size("FULL_KV_IDX", -1)}} - 1
+        MAX_KV_IDX = {{size("FULL_KV_IDX", -1)}}
         kv_num_blocks = tl.load(FULL_KV_NUM_BLKS + sparse_block_hz_offset)
         # Assign full block in a reverse order for off_t. Prioritize the last CTA.
         block_n_start = (SPLIT_KV - off_t - 1) * TILE_KV_MULTIPLE
         block_n_end = block_n_start + TILE_KV_MULTIPLE
-        indices_idx = block_n_start // SPARSE_KV_MULTIPLE
-        # Early exit: skip CTA computation if indices_idx exceeds available KV blocks to prevent invalid memory access
-        if indices_idx > MAX_KV_IDX:
-            return
+        indices_idx = (block_n_start // SPARSE_KV_MULTIPLE) % (MAX_KV_IDX)
         off_n_block_in_sparse = block_n_start % SPARSE_KV_MULTIPLE
         off_n = tl.load(kv_indices + indices_idx) * SPARSE_KV_BLOCK_SIZE + off_n_block_in_sparse * BLOCK_N
 

--- a/torch/_inductor/kernel/flex/templates/flex_decode.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/flex_decode.py.jinja
@@ -181,7 +181,6 @@
             return
         off_n_block_in_sparse = block_n_start % SPARSE_KV_MULTIPLE
         off_n = tl.load(kv_indices + indices_idx) * SPARSE_KV_BLOCK_SIZE + off_n_block_in_sparse * BLOCK_N
-        # first kv block we're loading
 
         # last valid block according to sparse mask
         block_n_last_valid = tl.minimum(kv_num_blocks * SPARSE_KV_MULTIPLE, tl.maximum(tl.cdiv(KV_LEN, BLOCK_N), 1))
@@ -218,7 +217,6 @@
             MATMUL_PRECISION,
             IS_FULL_BLOCKS=True,
         )
-
 
     m_offset = off_t * stride_mt + off_z * stride_mz
     l_offset = off_t * stride_lt + off_z * stride_lz

--- a/torch/_inductor/kernel/flex/templates/flex_decode.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/flex_decode.py.jinja
@@ -119,12 +119,68 @@
     # Offset the kv_indices tensor by the correct batch and head
     kv_indices = KV_IDX + sparse_idx_hz_offset
     kv_num_blocks = tl.load(KV_NUM_BLKS + sparse_block_hz_offset)
+    MAX_KV_IDX = {{size("KV_IDX", -1)}} - 1
     indices_idx = block_n_start // SPARSE_KV_MULTIPLE
     # Early exit: skip CTA computation if indices_idx exceeds available KV blocks to prevent invalid memory access
-    if indices_idx <= MAX_VALID_KV_IDX:
+    if indices_idx > MAX_KV_IDX:
+        return
+    off_n_block_in_sparse = block_n_start % SPARSE_KV_MULTIPLE
+    off_n = tl.load(kv_indices + indices_idx) * SPARSE_KV_BLOCK_SIZE + off_n_block_in_sparse * BLOCK_N
+    # first kv block we're loading
+
+    # last valid block according to sparse mask
+    block_n_last_valid = tl.minimum(kv_num_blocks * SPARSE_KV_MULTIPLE, tl.maximum(tl.cdiv(KV_LEN, BLOCK_N), 1))
+
+    K_block_ptr = tl.make_block_ptr(
+        base=K + k_offset,
+        shape=(QK_HEAD_DIM, KV_LEN),                # (d, N)
+        strides=(stride_kk, stride_kn),
+        offsets=(0, off_n),
+        block_shape=(QK_HEAD_DIM_ROUNDED, BLOCK_N),
+        order=(0, 1)
+    )
+    V_block_ptr = tl.make_block_ptr(
+        base=V + v_offset,
+        shape=(KV_LEN, V_HEAD_DIM),
+        strides=(stride_vn, stride_vk),
+        offsets=(off_n, 0),
+        block_shape=(BLOCK_N, V_HEAD_DIM_ROUNDED),
+        order=(1, 0)
+    )
+    offs_n = tl.arange(0, BLOCK_N) + off_n
+
+    acc, l_i, m_i = forward_inner(
+        {{gen_argdefs()}},
+        q, K_block_ptr, V_block_ptr, None, None, Q_LEN, KV_LEN,
+        # accumulatd values
+        acc, l_i, m_i,
+        #offsets
+        off_z, offs_hq[:, None], offs_m[:, None], offs_n[None, :],
+        None,
+        #block sparse data
+        kv_indices, kv_num_blocks,
+        block_n_start, block_n_end if block_n_end <= block_n_last_valid else block_n_last_valid,
+        MATMUL_PRECISION,
+        IS_FULL_BLOCKS=False,
+    )
+
+
+    # ~~~~~~~~~~~~~~ "full" blocks ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # We know these blocks are guaranteed to be "full", so we don't need to
+    # apply mask_mod to them - only score_mod
+    if HAS_FULL_BLOCKS:
+        kv_indices = FULL_KV_IDX + sparse_idx_hz_offset
+        MAX_KV_IDX = {{size("FULL_KV_IDX", -1)}} - 1
+        kv_num_blocks = tl.load(FULL_KV_NUM_BLKS + sparse_block_hz_offset)
+        # Assign full block in a reverse order for off_t. Prioritize the last CTA.
+        block_n_start = (SPLIT_KV - off_t - 1) * TILE_KV_MULTIPLE
+        block_n_end = block_n_start + TILE_KV_MULTIPLE
+        indices_idx = block_n_start // SPARSE_KV_MULTIPLE
+        # Early exit: skip CTA computation if indices_idx exceeds available KV blocks to prevent invalid memory access
+        if indices_idx > MAX_KV_IDX:
+            return
         off_n_block_in_sparse = block_n_start % SPARSE_KV_MULTIPLE
         off_n = tl.load(kv_indices + indices_idx) * SPARSE_KV_BLOCK_SIZE + off_n_block_in_sparse * BLOCK_N
-        # first kv block we're loading
 
         # last valid block according to sparse mask
         block_n_last_valid = tl.minimum(kv_num_blocks * SPARSE_KV_MULTIPLE, tl.maximum(tl.cdiv(KV_LEN, BLOCK_N), 1))
@@ -159,60 +215,8 @@
             kv_indices, kv_num_blocks,
             block_n_start, block_n_end if block_n_end <= block_n_last_valid else block_n_last_valid,
             MATMUL_PRECISION,
-            IS_FULL_BLOCKS=False,
+            IS_FULL_BLOCKS=True,
         )
-
-
-    # ~~~~~~~~~~~~~~ "full" blocks ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # We know these blocks are guaranteed to be "full", so we don't need to
-    # apply mask_mod to them - only score_mod
-    if HAS_FULL_BLOCKS:
-        kv_indices = FULL_KV_IDX + sparse_idx_hz_offset
-        kv_num_blocks = tl.load(FULL_KV_NUM_BLKS + sparse_block_hz_offset)
-        # Assign full block in a reverse order for off_t. Prioritize the last CTA.
-        block_n_start = (SPLIT_KV - off_t - 1) * TILE_KV_MULTIPLE
-        block_n_end = block_n_start + TILE_KV_MULTIPLE
-        indices_idx = block_n_start // SPARSE_KV_MULTIPLE
-        # Early exit: skip CTA computation if indices_idx exceeds available KV blocks to prevent invalid memory access
-        if indices_idx <= MAX_VALID_KV_IDX:
-            off_n_block_in_sparse = block_n_start % SPARSE_KV_MULTIPLE
-            off_n = tl.load(kv_indices + indices_idx) * SPARSE_KV_BLOCK_SIZE + off_n_block_in_sparse * BLOCK_N
-
-            # last valid block according to sparse mask
-            block_n_last_valid = tl.minimum(kv_num_blocks * SPARSE_KV_MULTIPLE, tl.maximum(tl.cdiv(KV_LEN, BLOCK_N), 1))
-
-            K_block_ptr = tl.make_block_ptr(
-                base=K + k_offset,
-                shape=(QK_HEAD_DIM, KV_LEN),                # (d, N)
-                strides=(stride_kk, stride_kn),
-                offsets=(0, off_n),
-                block_shape=(QK_HEAD_DIM_ROUNDED, BLOCK_N),
-                order=(0, 1)
-            )
-            V_block_ptr = tl.make_block_ptr(
-                base=V + v_offset,
-                shape=(KV_LEN, V_HEAD_DIM),
-                strides=(stride_vn, stride_vk),
-                offsets=(off_n, 0),
-                block_shape=(BLOCK_N, V_HEAD_DIM_ROUNDED),
-                order=(1, 0)
-            )
-            offs_n = tl.arange(0, BLOCK_N) + off_n
-
-            acc, l_i, m_i = forward_inner(
-                {{gen_argdefs()}},
-                q, K_block_ptr, V_block_ptr, None, None, Q_LEN, KV_LEN,
-                # accumulatd values
-                acc, l_i, m_i,
-                #offsets
-                off_z, offs_hq[:, None], offs_m[:, None], offs_n[None, :],
-                None,
-                #block sparse data
-                kv_indices, kv_num_blocks,
-                block_n_start, block_n_end if block_n_end <= block_n_last_valid else block_n_last_valid,
-                MATMUL_PRECISION,
-                IS_FULL_BLOCKS=True,
-            )
 
     m_offset = off_t * stride_mt + off_z * stride_mz
     l_offset = off_t * stride_lt + off_z * stride_lz

--- a/torch/_inductor/kernel/flex/templates/flex_decode.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/flex_decode.py.jinja
@@ -167,7 +167,6 @@
     # apply mask_mod to them - only score_mod
     if HAS_FULL_BLOCKS:
         kv_indices = FULL_KV_IDX + sparse_idx_hz_offset
-        MAX_KV_IDX = {{size("FULL_KV_IDX", -1)}}
         kv_num_blocks = tl.load(FULL_KV_NUM_BLKS + sparse_block_hz_offset)
         # Assign full block in a reverse order for off_t. Prioritize the last CTA.
         block_n_start = (SPLIT_KV - off_t - 1) * TILE_KV_MULTIPLE

--- a/torch/_inductor/kernel/flex/templates/flex_decode.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/flex_decode.py.jinja
@@ -181,6 +181,7 @@
             return
         off_n_block_in_sparse = block_n_start % SPARSE_KV_MULTIPLE
         off_n = tl.load(kv_indices + indices_idx) * SPARSE_KV_BLOCK_SIZE + off_n_block_in_sparse * BLOCK_N
+        # first kv block we're loading
 
         # last valid block according to sparse mask
         block_n_last_valid = tl.minimum(kv_num_blocks * SPARSE_KV_MULTIPLE, tl.maximum(tl.cdiv(KV_LEN, BLOCK_N), 1))
@@ -217,6 +218,7 @@
             MATMUL_PRECISION,
             IS_FULL_BLOCKS=True,
         )
+
 
     m_offset = off_t * stride_mt + off_z * stride_mz
     l_offset = off_t * stride_lt + off_z * stride_lz

--- a/torch/nn/attention/experimental/_paged_attention.py
+++ b/torch/nn/attention/experimental/_paged_attention.py
@@ -181,9 +181,7 @@ class PagedAttention:
         logical_block_offset = input_pos % self.page_size  # [B, S]
         physical_block_idx = torch.gather(
             self.page_table[batch_idx], 1, logical_block_idx.to(torch.int64)
-        ).to(
-            torch.int32
-        )  # [B, S]
+        ).to(torch.int32)  # [B, S]
 
         addr = (physical_block_idx * self.page_size + logical_block_offset).view(
             -1

--- a/torch/nn/attention/experimental/_paged_attention.py
+++ b/torch/nn/attention/experimental/_paged_attention.py
@@ -196,6 +196,7 @@ class PagedAttention:
         self,
         block_mask: BlockMask,
         batch_idx: Optional[torch.Tensor] = None,
+        kv_len: Optional[Union[int, torch.Tensor]] = None,
     ) -> BlockMask:
         """
         Converts a logical block mask by mapping its logical kv indices to the corresponding
@@ -259,7 +260,6 @@ class PagedAttention:
                 .to(torch.int32)
             )
 
-        kv_len = block_mask.seq_lengths[1] if block_mask.seq_lengths else None
         new_mask_mod = self.get_mask_mod(block_mask.mask_mod, kv_len)
 
         seq_lengths = (block_mask.seq_lengths[0], self.n_pages * self.page_size)

--- a/torch/nn/attention/experimental/_paged_attention.py
+++ b/torch/nn/attention/experimental/_paged_attention.py
@@ -137,7 +137,7 @@ class PagedAttention:
     ) -> None:
         """
         Assigns new contents `val` to the storage `cache` at the location
-        `batch_idx` and `input_pos`.`
+        `batch_idx` and `input_pos`.
 
         Args:
             batch_idx (Tensor): batch index; shape :math:`(B)`.

--- a/torch/nn/attention/experimental/_paged_attention.py
+++ b/torch/nn/attention/experimental/_paged_attention.py
@@ -116,6 +116,7 @@ class PagedAttention:
         Args:
             batch_idx (Tensor): batch index to be removed; shape :math:`(1)`.
         """
+
         # find allocated pages
         allocated_page_idx = self.page_table[batch_idx] != -1
         allocated_pages = self.page_table[batch_idx][allocated_page_idx]
@@ -186,6 +187,7 @@ class PagedAttention:
         addr = (physical_block_idx * self.page_size + logical_block_offset).view(
             -1
         )  # [B*S]
+
         k_val = k_val.permute(1, 0, 2, 3).contiguous().view(1, H, B * S, K_D)
         v_val = v_val.permute(1, 0, 2, 3).contiguous().view(1, H, B * S, V_D)
 
@@ -323,7 +325,7 @@ class PagedAttention:
 
         Args:
             score_mod (_score_mod_signature): score_mod based on the logical block index.
-                        kv_len (Optional[torch.Tensor]): actual KV sequence length for upper bound check.
+            `kv_len (Optional[torch.Tensor]): actual KV sequence length for upper bound check.
 
         """
         if score_mod is None:

--- a/torch/nn/attention/experimental/_paged_attention.py
+++ b/torch/nn/attention/experimental/_paged_attention.py
@@ -181,7 +181,9 @@ class PagedAttention:
         logical_block_offset = input_pos % self.page_size  # [B, S]
         physical_block_idx = torch.gather(
             self.page_table[batch_idx], 1, logical_block_idx.to(torch.int64)
-        ).to(torch.int32)  # [B, S]
+        ).to(
+            torch.int32
+        )  # [B, S]
 
         addr = (physical_block_idx * self.page_size + logical_block_offset).view(
             -1


### PR DESCRIPTION
Fixes #159247
Issue 1: Accuracy Problem with Non-Divisible KV Sequences
---------------------------------------------------------

### Background

Paged attention in flex decoding produced inaccurate results when KV sequence length is not divisible by block size. For example, when `KV_S = 64` and `block_size = 128`, the output didn't match standard attention accuracy.

### Root Cause
The current paged attention does not apply upper mask mod when converting from logical to physical mask mod. Instead, it uses a noop_mask by default which makes all the values unmasked, leading to an accuracy mismatch. Adding a upper mask mod according to the origin actual kv_len (64 in this test case) resolves the issue.

### Solution

*   **Applied proper upper bound masking**: Updated all calls to `convert_logical_block_mask` to pass `kv_len` as a tensor with proper shape `[B, KV_S]` to provide information of actual batched KV sequence length. The function now correctly applies upper bound checks using the actual KV sequence lengths for each batch


### Files Modified
*    `torch/nn/attention/experimental/_paged_attention.py`: Added `kv_len` parameter as a tensor to `get_mask_mod` and applied upper mask to the new mask mod.
*   `test/inductor/test_flex_attention.py`: Fixed all related `kv_len` parameter call in the tests
*   `test/inductor/test_flex_decoding.py`: Fixed all related `kv_len` parameter call in the tests

Issue 2: Invalid Memory Access (IMA) in Triton Kernels
------------------------------------------------------

### Background

The Triton kernel for flex attention was experiencing invalid memory access errors when running with compute sanitizers, particularly with short KV sequences and small batch sizes.

### Root Cause

*   Kernel launches CTAs (Cooperative Thread Arrays) proportional to GPU's multi-processor count (108 via `SPLIT_KV`)
*   With small workloads, many CTAs remain idle but still attempt to access `kv_indices` with invalid `indices_idx` values
*   This caused out-of-bounds memory access violations

### Solution

Implemented boundary checks with early exit:

1.  **Added `MAX_VALID_KV_IDX` parameter** in `torch/_inductor/kernel/flex/flex_decoding.py`
    
    *   Calculate maximum valid KV index based on actual `kv_indices` tensor size and pass it to Triton template
2.  **Added early exit logic** in `torch/_inductor/kernel/flex/templates/flex_decode.py.jinja`
    
    *   Boundary checks before accessing `kv_indices` in both normal and full blocks
    *   Idle CTAs with invalid `indices_idx` skip computation entirely
    
This prevents invalid memory access while reducing wasted computation on idle thread blocks.

Testing & Validation
--------------------

### Accuracy Tests

*   Added comprehensive test cases covering KV sequences not divisible by block sizes
*   Verified output matches standard attention for various sequence length combinations

### Sanitizer Results

`========= COMPUTE-SANITIZER Starting standalone test_max_autotune... Running test_max_autotune on device: cuda max_autotune config: True test_max_autotune completed successfully! Test passed! ========= ERROR SUMMARY: 0 errors`

**Before**: More than 13720 invalid memory access errors with sanitizers  
**After**: Clean execution with 0 errors

Both fixes work together to ensure paged attention produces accurate results while running safely without memory access violations.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @mlazos