### PR TITLE
[Triton] [Inductor] Add Epilogue Subtiling to Blackwell persistent matmul template.

### DIFF
--- a/torch/_inductor/codegen/cuda/cuda_env.py
+++ b/torch/_inductor/codegen/cuda/cuda_env.py
@@ -29,6 +29,16 @@ def get_cuda_arch() -> Optional[str]:
 
 @clear_on_fresh_cache
 @functools.lru_cache(1)
+def is_blackwell_arch() -> Optional[str]:
+    arch = get_cuda_arch()
+    if arch is None:
+        return False
+    arch_number = int(arch)
+    return arch_number >= 100 and arch_number <= 109
+
+
+@clear_on_fresh_cache
+@functools.lru_cache(1)
 def get_cuda_version() -> Optional[str]:
     try:
         cuda_version = config.cuda.version

--- a/torch/_inductor/template_heuristics.py
+++ b/torch/_inductor/template_heuristics.py
@@ -1594,6 +1594,23 @@ class CUDABlackwellPersistentTMATemplateConfigHeuristic(
         # TODO: Tune these for blackwell.
         self.mm_configs = self.persistent_mm_configs
 
+    @staticmethod
+    def _determine_epilogue_subtile(BLOCK_M: int, BLOCK_N: int) -> bool:
+        """
+        Determine the logic for forcing epilogue subtiling based on BLOCK_M
+        and BLOCK_N. This is written as a separate function to enable overwriting
+        it for testing.
+
+        Args:
+            BLOCK_M (int): Size of BLOCK_M
+            BLOCK_N (int): Size of BLOCK_N
+        Returns:
+            (bool): Should we set EPILOGUE_SUBTILE for a config?
+        """
+        # TODO: Tune properly. This is just hard coding to a default based on the assumption
+        # we want to use less shared memory.
+        return (BLOCK_M > 128) or (BLOCK_N > 128)
+
     def get_template_configs(
         self,
         kernel_inputs: KernelInputs,
@@ -1611,6 +1628,11 @@ class CUDABlackwellPersistentTMATemplateConfigHeuristic(
             # TODO: Consider making these tunable.
             template_kwargs["FLATTEN"] = True
             template_kwargs["WARP_SPECIALIZE"] = True
+            # TODO: Tune properly. This is just hard coding to a default based on the assumption
+            # we want to use less shared memory.
+            template_kwargs["EPILOGUE_SUBTILE"] = self._determine_epilogue_subtile(
+                template_kwargs["BLOCK_M"], template_kwargs["BLOCK_N"]
+            )
 
             yield template_kwargs
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1643,7 +1643,9 @@ def use_triton_template(
     )
 
 
-def can_use_tma(*matrices: IRNode, add_guards: bool = False) -> bool:
+def can_use_tma(
+    *matrices: IRNode, output_layout: Optional[Layout] = None, add_guards: bool = False
+) -> bool:
     """
     Return True iff *all* supplied tensors satisfy the CUDA-12.9 TMA constraints
     that Triton relies on today.
@@ -1665,11 +1667,31 @@ def can_use_tma(*matrices: IRNode, add_guards: bool = False) -> bool:
     def _aligned(expr_bytes: Union[int, sympy.Expr]) -> bool:
         return V.graph.sizevars.statically_known_multiple_of(expr_bytes, TMA_ALIGNMENT)
 
-    def _is_tma_compatible(x: IRNode) -> bool:
-        sizes = x.get_size()
-        strides = x.get_stride()
+    def _is_tma_compatible_layout(layout: Optional[Layout]) -> bool:
+        if layout is None:
+            return True
+        sizes = layout.size
+        strides = layout.stride
+        dtype = layout.dtype
+
+        # TODO: Check Base pointer 16-byte aligned for output?
+        return _is_tma_compatible(sizes, strides, dtype)
+
+    def _is_tma_compatible_matrix(m: IRNode) -> bool:
+        sizes = m.get_size()
+        strides = m.get_stride()
+        dtype = m.get_dtype()
+
+        # Base pointer 16-byte aligned
+        if m.get_name() in V.graph.unaligned_buffers:
+            return False
+
+        return _is_tma_compatible(sizes, strides, dtype)
+
+    def _is_tma_compatible(
+        sizes: Sequence[sympy.Expr], strides: Sequence[_IntLike], dtype: torch.dtype
+    ) -> bool:
         rank = len(sizes)
-        dtype = x.get_dtype()
         itemsize = dtype.itemsize
 
         # 2 ≤ rank ≤ 5
@@ -1678,10 +1700,6 @@ def can_use_tma(*matrices: IRNode, add_guards: bool = False) -> bool:
 
         # dtype ∈ {FP16, BF16, FP8-E4M3FN}
         if dtype not in (torch.float16, torch.bfloat16, torch.float8_e4m3fn):
-            return False
-
-        # Base pointer 16-byte aligned
-        if x.get_name() in V.graph.unaligned_buffers:
             return False
 
         if add_guards:
@@ -1725,13 +1743,19 @@ def can_use_tma(*matrices: IRNode, add_guards: bool = False) -> bool:
 
         return True
 
-    return has_triton_tma_device() and all(_is_tma_compatible(m) for m in matrices)
+    return (
+        has_triton_tma_device()
+        and all(_is_tma_compatible_matrix(m) for m in matrices)
+        and _is_tma_compatible_layout(output_layout)
+    )
 
 
-def use_triton_tma_template(*matrices: IRNode, add_guards: bool = False) -> bool:
+def use_triton_tma_template(
+    *matrices: IRNode, output_layout: Optional[Layout], add_guards: bool = False
+) -> bool:
     return (
         all(len(m.get_size()) == 2 for m in matrices)
-        and can_use_tma(*matrices, add_guards=add_guards)
+        and can_use_tma(*matrices, output_layout=output_layout, add_guards=add_guards)
         and config.triton.enable_persistent_tma_matmul
     )
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1760,6 +1760,22 @@ def use_triton_tma_template(
     )
 
 
+def use_triton_blackwell_tma_template(
+    *matrices: IRNode, output_layout: Layout, add_guards: bool = False
+) -> bool:
+    if not use_triton_tma_template(
+        *matrices, output_layout=output_layout, add_guards=add_guards
+    ):
+        return False
+
+    from torch.utils._triton import has_triton_tensor_descriptor_host_tma
+
+    from .codegen.cuda.cuda_env import is_blackwell_arch
+
+    # Blackwell template require the tensor descriptor API, not the experimental API.
+    return has_triton_tensor_descriptor_host_tma() and is_blackwell_arch()
+
+
 def use_cutlass_template(layout: Layout, m: int, n: int, k: int) -> bool:
     from .virtualized import V
 

--- a/torch/utils/_triton.py
+++ b/torch/utils/_triton.py
@@ -94,6 +94,20 @@ def has_triton_tma_device() -> bool:
     return False
 
 
+@functools.cache
+def has_blackwell_tma_device() -> bool:
+    import torch
+
+    if (
+        torch.cuda.is_available()
+        and torch.cuda.get_device_capability() >= (10, 0)
+        and not torch.version.hip
+    ):
+        return has_triton_tma_device() and has_triton_tensor_descriptor_host_tma()
+
+    return False
+
+
 @functools.lru_cache(None)
 def has_triton_stable_tma_api() -> bool:
     if has_triton_package():


### PR DESCRIPTION
Summary: Adds `EPILOGUE_SUBTILE` to the persistent matmul template. By default this is only enabled for the largest block sizes because a followup diff will do the actual tuning.

Test Plan:
Tested on a Blackwell machine with `test_max_autotune.py` and confirmed the updated tests pass.

Example code generated for addmm:

```
triton.jit
def triton_tem_fused_addmm_permute_repeat_3(in_ptr0, arg_A, arg_B, out_ptr0, ks0, ks1, ks2):
    EVEN_K : tl.constexpr = False
    ALLOW_TF32 : tl.constexpr = False
    USE_FAST_ACCUM : tl.constexpr = False
    ACC_TYPE : tl.constexpr = tl.float32
    BLOCK_M : tl.constexpr = 128
    BLOCK_N : tl.constexpr = 128
    BLOCK_K : tl.constexpr = 64
    GROUP_M : tl.constexpr = 8
    A_ROW_MAJOR : tl.constexpr = False
    B_ROW_MAJOR : tl.constexpr = False
    NUM_SMS : tl.constexpr = 148
    TMA_SIZE : tl.constexpr = 128
    TMA_EXPERIMENTAL_API : tl.constexpr = False
    FLATTEN : tl.constexpr = True
    WARP_SPECIALIZE : tl.constexpr = True
    EPILOGUE_SUBTILE : tl.constexpr = False
    A = arg_A
    B = arg_B

    M = 8*ks0
    N = 8*ks1
    K = 8*ks2
    if M * N == 0:
        # early exit due to zero-size input(s)
        return
    start_pid = tl.program_id(0)
    grid_m = tl.cdiv(M, BLOCK_M)
    grid_n = tl.cdiv(N, BLOCK_N)
    k_tiles = tl.cdiv(K, BLOCK_K)
    num_tiles = grid_m * grid_n

    # Note: We require TMA_EXPERIMENTAL_API == False, which
    # we will check before invoking this template.
    stride_am = 1
    stride_ak = 8*ks0
    stride_bk = 1
    stride_bn = 8*ks2
    a_desc = triton.language.make_tensor_descriptor(
        base=A,
        shape=[M, K] if A_ROW_MAJOR else [K, M],
        strides=[stride_am, 1] if A_ROW_MAJOR else [stride_ak, 1],
        block_shape=[BLOCK_M, BLOCK_K] if A_ROW_MAJOR else [BLOCK_K, BLOCK_M],
    )
    b_desc = triton.language.make_tensor_descriptor(
        base=B,
        shape=[K, N] if B_ROW_MAJOR else [N, K],
        strides=[stride_bk, 1] if B_ROW_MAJOR else [stride_bn, 1],
        block_shape=[BLOCK_K, BLOCK_N] if B_ROW_MAJOR else [BLOCK_N, BLOCK_K],
    )
    stride_cm = 8*ks1
    stride_cn = 1
    BLOCK_N_SHAPE: tl.constexpr = BLOCK_N // 2 if EPILOGUE_SUBTILE else BLOCK_N
    _tmp_var0 = triton.language.make_tensor_descriptor(base=out_ptr0, shape=[M, N], strides=[stride_cm, 1], block_shape=[BLOCK_M, BLOCK_N_SHAPE])

    # tile_id_c is used in the epilogue to break the dependency between
    # the prologue and the epilogue
    tile_id_c = start_pid - NUM_SMS
    num_pid_in_group = GROUP_M * grid_n

    for tile_id in tl.range(
        start_pid, num_tiles, NUM_SMS, flatten=FLATTEN, warp_specialize=WARP_SPECIALIZE
    ):
        pid_m, pid_n = _compute_pid(
            tile_id, num_pid_in_group, grid_m, GROUP_M, NUM_SMS
        )
        offs_am = pid_m * BLOCK_M
        offs_bn = pid_n * BLOCK_N

        accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
        for ki in range(k_tiles):
            offs_k = ki * BLOCK_K
            a = tl.load_tensor_descriptor(
                a_desc,
                [offs_am, offs_k] if A_ROW_MAJOR else [offs_k, offs_am],
            )
            b = tl.load_tensor_descriptor(
                b_desc,
                [offs_k, offs_bn] if B_ROW_MAJOR else [offs_bn, offs_k],
            )
            accumulator += tl.dot(
                a if A_ROW_MAJOR else a.T,
                b if B_ROW_MAJOR else b.T,
                allow_tf32=ALLOW_TF32,
            )

        tile_id_c += NUM_SMS
        pid_m, pid_n = _compute_pid(
            tile_id_c, num_pid_in_group, grid_m, GROUP_M, NUM_SMS
        )
        offs_cm = pid_m * BLOCK_M
        offs_cn = pid_n * BLOCK_N
        if EPILOGUE_SUBTILE:
            acc = tl.reshape(accumulator, (BLOCK_M, 2, BLOCK_N // 2))
            acc = tl.permute(acc, (0, 2, 1))
            acc0, acc1 = tl.split(acc)
            _tmp_var1 = offs_cm + tl.arange(0, BLOCK_M)
            _tmp_var2 = _tmp_var1[:, None]
            _tmp_var3 = offs_cn + tl.arange(0, BLOCK_N_SHAPE)
            _tmp_var4 = _tmp_var3[None, :, ]
            _tmp_var5 = (_tmp_var2 < M) & (_tmp_var4 < N)
            tmp0 = tl.load(in_ptr0 + (tl.broadcast_to(_tmp_var4, acc0.shape)), _tmp_var5, eviction_policy='evict_last').to(tl.float32)
            tmp1 = acc0 + tmp0
            triton.language.store_tensor_descriptor(_tmp_var0, [offs_cm, offs_cn], tmp1.to(tl.float16))
            offs_cn2 = offs_cn + BLOCK_N // 2
            _tmp_var6 = offs_cm + tl.arange(0, BLOCK_M)
            _tmp_var7 = _tmp_var6[:, None]
            _tmp_var8 = offs_cn2 + tl.arange(0, BLOCK_N_SHAPE)
            _tmp_var9 = _tmp_var8[None, :, ]
            _tmp_var10 = (_tmp_var7 < M) & (_tmp_var9 < N)
            tmp2 = tl.load(in_ptr0 + (tl.broadcast_to(_tmp_var9, acc1.shape)), _tmp_var10, eviction_policy='evict_last').to(tl.float32)
            tmp3 = acc1 + tmp2
            triton.language.store_tensor_descriptor(_tmp_var0, [offs_cm, offs_cn2], tmp3.to(tl.float16))
        else:
            _tmp_var11 = offs_cm + tl.arange(0, BLOCK_M)
            _tmp_var12 = _tmp_var11[:, None]
            _tmp_var13 = offs_cn + tl.arange(0, BLOCK_N_SHAPE)
            _tmp_var14 = _tmp_var13[None, :, ]
            _tmp_var15 = (_tmp_var12 < M) & (_tmp_var14 < N)
            tmp4 = tl.load(in_ptr0 + (tl.broadcast_to(_tmp_var14, accumulator.shape)), _tmp_var15, eviction_policy='evict_last').to(tl.float32)
            tmp5 = accumulator + tmp4
            triton.language.store_tensor_descriptor(_tmp_var0, [offs_cm, offs_cn], tmp5.to(tl.float16))

triton.jit
def _compute_pid(tile_id, num_pid_in_group, grid_m, GROUP_M: tl.constexpr, NUM_SMS: tl.constexpr):
    group_id = tile_id // num_pid_in_group
    first_pid_m = group_id * GROUP_M
    GROUP_M = min(grid_m - first_pid_m, GROUP_M)
    pid_m = first_pid_m + (tile_id % GROUP_M)
    pid_n = (tile_id % num_pid_in_group) // GROUP_M
    return pid_m, pid_n
''', device_str='cuda')
```

Rollback Plan:

Differential Revision: D80458386




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben