### PR TITLE
[dynamo] Refactor convert_frame to remove usage of nonlocal tracer output return. [4/n]

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -921,38 +921,31 @@ def _compile(
     # Only nonlocal defs here please!
     # Time spent compiling this frame before restarting or failing analysis
     dynamo_time_before_restart: float = 0.0
-    tracer_output: Optional[DynamoTracerOutput] = None
 
     def transform(
         instructions: list[Instruction], code_options: dict[str, object]
     ) -> DynamoTracerOutput:
-        nonlocal tracer_output
-
         tf_mode_stack: list[torch.overrides.TorchFunctionMode] = (
             torch.overrides._get_current_function_mode_stack()
         )
-        try:
-            tracer_output = trace_frame(
-                code,
-                globals,
-                locals,
-                builtins,
-                closure,
-                compiler_fn,
-                tf_mode_stack,
-                one_graph,
-                speculation_log,
-                instructions,
-                code_options,
-                export=export,
-                export_constraints=export_constraints,
-                frame_state=frame_state,
-                distributed_state=distributed_state,
-                package=package,
-            )
-        except Exception as e:
-            tracer_output = getattr(e, "_torch_dynamo_tracer_output", None)  # type: ignore[attr-defined]
-            raise
+        tracer_output = trace_frame(
+            code,
+            globals,
+            locals,
+            builtins,
+            closure,
+            compiler_fn,
+            tf_mode_stack,
+            one_graph,
+            speculation_log,
+            instructions,
+            code_options,
+            export=export,
+            export_constraints=export_constraints,
+            frame_state=frame_state,
+            distributed_state=distributed_state,
+            package=package,
+        )
 
         assert tracer_output is not None
         return tracer_output
@@ -963,7 +956,7 @@ def _compile(
         one_graph: bool,
         hooks: Hooks,
         transform: Callable[[list[Instruction], dict[str, Any]], Any],
-    ) -> ConvertFrameReturn:
+    ) -> tuple[ConvertFrameReturn, Optional[DynamoTracerOutput]]:
         with contextlib.ExitStack() as stack:
             stack.enter_context(
                 torch._dynamo.callback_handler.install_callbacks(
@@ -974,7 +967,8 @@ def _compile(
             return _compile_inner(code, one_graph, hooks, transform)
 
         return (
-            ConvertFrameReturn()
+            ConvertFrameReturn(),
+            None,
         )  # dead, but see https://github.com/python/mypy/issues/7577
 
     @maybe_cprofile
@@ -983,7 +977,7 @@ def _compile(
         one_graph: bool,
         hooks: Hooks,
         transform: Callable[[list[Instruction], dict[str, Any]], Any],
-    ) -> ConvertFrameReturn:
+    ) -> tuple[ConvertFrameReturn, DynamoTracerOutput]:
         nonlocal dynamo_time_before_restart
         last_attempt_start_time = start_time = time.time()
 
@@ -1006,8 +1000,8 @@ def _compile(
         out_code = None
         try:
             dynamo_output = compile_frame(code, transform, restart_reasons)
-        except exc.SkipFrame:
-            if one_graph or _is_error_on_graph_break(tracer_output):
+        except exc.SkipFrame as e:
+            if one_graph or _is_error_on_graph_break(e._torch_dynamo_tracer_output):
                 log.debug(
                     "No graph captured with one_graph=True or error_on_graph_break=True"
                 )
@@ -1017,6 +1011,7 @@ def _compile(
             "compiler collective wasn't run before compilation completed"
         )
         out_code = dynamo_output.bytecode
+        tracer_output = dynamo_output.tracer_output
         if dynamo_output.last_attempt_start_time is not None:
             last_attempt_start_time = dynamo_output.last_attempt_start_time
 
@@ -1038,7 +1033,7 @@ def _compile(
         orig_code_map[out_code] = code
         output_codes.add(out_code)
         dynamo_time_before_restart = last_attempt_start_time - start_time
-        assert tracer_output is not None and tracer_output.output_graph is not None
+        assert tracer_output.output_graph is not None
         output = tracer_output.output_graph
 
         # Tests for new code objects.
@@ -1122,7 +1117,7 @@ def _compile(
             # they are benign and do not generate any new graphs.
             hooks.guard_export_fn(output.guards)
 
-        return wrap_guarded_code(guarded_code)
+        return wrap_guarded_code(guarded_code), tracer_output
 
     metrics_context = get_metrics_context()
     code_context = (
@@ -1218,7 +1213,7 @@ def _compile(
                 raise FailOnRecompileLimitHit(
                     f"{limit_type} reached, because fail_on_recompile_limit_hit = True this is a HARD failure"
                 )
-            elif one_graph or _is_error_on_graph_break(tracer_output):
+            elif one_graph or _get_error_on_graph_break():
                 raise FailOnRecompileLimitHit(
                     f"{limit_type} reached with one_graph=True or error_on_graph_break=True. "
                     "Excessive recompilations can degrade "
@@ -1277,7 +1272,9 @@ def _compile(
         torch._dynamo.utils.ReinplaceCounters.clear()
         guarded_code = None
         try:
-            guarded_code = compile_inner(code, one_graph, hooks, transform)
+            guarded_code, tracer_output = compile_inner(
+                code, one_graph, hooks, transform
+            )
 
             # NB: We only put_code_state in success case.  Success case here
             # does include graph breaks; specifically, if a graph break still
@@ -1311,6 +1308,7 @@ def _compile(
             fail_user_frame_filename, fail_user_frame_lineno = exc.get_exc_message(
                 e, compile_id
             )
+            tracer_output = getattr(e, "_torch_dynamo_tracer_output", None)
             if tracer_output and tracer_output.is_tracing_resume_prologue:
                 # Do not allow any errors to be suppressed if tracer is currently tracing
                 # through resume function.
@@ -1352,9 +1350,7 @@ def _compile(
                     log.info("run_gc_after_compile: running gc")
                     gc.collect(1)
 
-            output = None
-            if tracer_output:
-                output = tracer_output.output_graph
+            output = tracer_output.output_graph
             if output:
                 output.local_scope = {}
                 # tracer should already be None, keep an extra check here just in case.

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1005,7 +1005,7 @@ def _compile(
                 log.debug(
                     "No graph captured with one_graph=True or error_on_graph_break=True"
                 )
-            return ConvertFrameReturn(), tracer_output
+            return ConvertFrameReturn(), e._torch_dynamo_tracer_output
 
         assert distributed_state is None or distributed_state.all_states is not None, (  # type: ignore[has-type]
             "compiler collective wasn't run before compilation completed"
@@ -1350,6 +1350,7 @@ def _compile(
                     log.info("run_gc_after_compile: running gc")
                     gc.collect(1)
 
+            assert tracer_output is not None
             output = tracer_output.output_graph
             if output:
                 output.local_scope = {}

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1005,7 +1005,7 @@ def _compile(
                 log.debug(
                     "No graph captured with one_graph=True or error_on_graph_break=True"
                 )
-            return ConvertFrameReturn()
+            return ConvertFrameReturn(), tracer_output
 
         assert distributed_state is None or distributed_state.all_states is not None, (  # type: ignore[has-type]
             "compiler collective wasn't run before compilation completed"
@@ -1080,7 +1080,7 @@ def _compile(
         # are extra graphs now.
 
         if output.export and output.is_empty_graph():
-            return ConvertFrameReturn()
+            return ConvertFrameReturn(), tracer_output
 
         assert output.guards is not None
         CleanupManager.instance[out_code] = output.cleanups

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -66,7 +66,9 @@ graph_breaks_log = torch._logging.getArtifactLogger(__name__, "graph_breaks")
 
 
 class TorchDynamoException(RuntimeError):
-    pass
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._torch_dynamo_tracer_output = None
 
 
 class InternalTorchDynamoError(TorchDynamoException):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #160900
* __->__ #160899
* #160855
* #160815
* #160814

Today convert_frame is implemented like the following:
```
def _compile():
    tracer_output = None
    def transform():
        nonlocal tracer_output
        ...
    def _compile_inner():
         transform(...)


     compile_inner(...)
```

The code is using unconventional nonlocal variable as the return value. This is not ideal for 2 reasons:
1. Reasoning about the code, especially together with error handling code becomes harder.
2. more importantly, this makes it harder to extract out common code pieces into a shared library because everything must depend on a central global state.

In this diff we remove the usage of nonlocal return and just use the conventional function return to output the compilation data.

Differential Revision: [D80461258](https://our.internmc.facebook.com/intern/diff/D80461258/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela