### PR TITLE
Fix duplicated kernel name in kernel stack trace tracking

### DIFF
--- a/test/inductor/test_provenance_tracing.py
+++ b/test/inductor/test_provenance_tracing.py
@@ -565,6 +565,7 @@ class TestProvenanceTracingStackTraces(TestCase):
                 "y = torch.addmm(c, d, b)",
             ],
             "extern_kernels.mm": [
+                "x = self.fc1(x)",
                 "y = torch.addmm(c, d, b)",
             ],
         }
@@ -578,9 +579,6 @@ class TestProvenanceTracingStackTraces(TestCase):
                 self.assertEqual(set(data.keys()), set(expected.keys()))
                 for key, expected_lines in expected.items():
                     actual_lines = [self.extract_code_line(s) for s in data[key]]
-                    print(key)
-                    print(actual_lines)
-                    print(expected_lines)
                     self.assertEqual(
                         sorted(actual_lines),
                         sorted(expected_lines),

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -316,7 +316,7 @@ def enable_aot_logging() -> Iterator[None]:
 # They are not stored in DebugContext because they are not set in
 # _inductor_triton_kernel_to_post_grad_node_info's Debug Context
 _inductor_post_to_pre_grad_nodes: dict[str, dict[str, list[str]]] = {}
-_inductor_triton_kernel_to_post_grad_node_info: dict[str, Any] = {}
+_inductor_triton_kernel_to_post_grad_node_info: dict[str, list[str]] = {}
 _pre_grad_graph_id: Optional[int] = None
 _inductor_pre_grad_node_stack_trace: dict[str, str] = {}
 _inductor_kernel_stack_trace: dict[str, list[str]] = {}
@@ -998,6 +998,7 @@ def set_kernel_post_grad_provenance_tracing(
 
         global _inductor_triton_kernel_to_post_grad_node_info
         global _inductor_kernel_stack_trace
+        stack_traces: list[str] = []
         if is_extern:
             assert isinstance(node_schedule, ExternKernelOut)
             curr_node_info = _inductor_triton_kernel_to_post_grad_node_info.setdefault(
@@ -1016,12 +1017,10 @@ def set_kernel_post_grad_provenance_tracing(
                     for origin in node_schedule.origins
                     if origin.name not in curr_node_info
                 )
-            _inductor_kernel_stack_trace[kernel_name] = list(
-                node_schedule.get_stack_traces()
-            )
+            stack_traces = list(node_schedule.get_stack_traces())
         else:
             assert isinstance(node_schedule, list)
-            stack_traces: OrderedSet[str] = OrderedSet()
+            stack_traces_set: OrderedSet[str] = OrderedSet()
             for snode in node_schedule:
                 if snode not in (EnableReduction, DisableReduction):
                     if snode.node is not None:
@@ -1030,13 +1029,14 @@ def set_kernel_post_grad_provenance_tracing(
                                 kernel_name, []
                             )
                         )
-                        stack_traces.update(snode.node.get_stack_traces())
+                        stack_traces_set.update(snode.node.get_stack_traces())
                         curr_node_info.extend(
                             origin.name
                             for origin in snode.node.origins
                             if origin.name not in curr_node_info
                         )
-            _inductor_kernel_stack_trace[kernel_name] = list(stack_traces)
+            stack_traces = list(stack_traces_set)
+        _inductor_kernel_stack_trace.setdefault(kernel_name, []).extend(stack_traces)
     except Exception as e:
         # Since this is just debugging, it should never interfere with regular
         # program execution, so we use this try-except to guard against any error


### PR DESCRIPTION
Summary: as title. When we have two kernels with the same name, the stack traces should be appended, not overwritten.

Test Plan:
```
 buck run mode/opt fbcode//caffe2/test/inductor:provenance_tracing
```

Rollback Plan:

Differential Revision: D80472731




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben