### PR TITLE
logging exit code for failures to ease debugging

### DIFF
--- a/test/distributed/elastic/agent/server/test/api_test.py
+++ b/test/distributed/elastic/agent/server/test/api_test.py
@@ -1,21 +1,21 @@
 #!/usr/bin/env python3
 # Owner(s): ["oncall: r2p"]
 
+import functools
+
 # Copyright (c) Facebook, Inc. and its affiliates.
 # All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
-
-
-import functools
+# LICENSE file in the root directory  of this source tree.
+import json
 import os
 import signal
 import unittest
 import uuid
 from multiprocessing.pool import ThreadPool
 from typing import Any
-from unittest.mock import call, patch
+from unittest.mock import call, MagicMock, patch
 
 import torch.distributed as dist
 import torch.distributed.elastic.rendezvous.registry as rdzv_registry
@@ -29,6 +29,7 @@ from torch.distributed.elastic.agent.server.api import (
     WorkerSpec,
     WorkerState,
 )
+from torch.distributed.elastic.events import EventSource
 from torch.distributed.elastic.multiprocessing import SignalException
 from torch.distributed.elastic.multiprocessing.errors import ProcessFailure
 from torch.distributed.elastic.rendezvous import RendezvousHandler, RendezvousParameters
@@ -155,6 +156,243 @@ def monres(state: WorkerState):
         return RunResult(state=state, return_values={}, failures={0: pf})
     else:
         return RunResult(state=state)
+
+
+class RecordWorkerEventsTest(unittest.TestCase):
+    def setUp(self):
+        self.spec = MagicMock()
+        self.spec.role = "test_role"
+        self.spec.get_entrypoint_name.return_value = "test_entrypoint"
+        self.spec.rdzv_handler.get_run_id.return_value = "test_run_id"
+        self.spec.rdzv_handler.get_backend.return_value = "test_backend"
+        self.spec.max_restarts = 3
+
+        self.agent = TestAgent(self.spec)
+
+        # Create a mock worker spec and agent
+        self.agent._worker_group = MagicMock()
+        self.agent._worker_group.spec = MagicMock()
+        self.agent._worker_group.spec.event_log_handler = "test_handler"
+
+        # Setup worker group
+        self.worker_group = WorkerGroup(self.spec)
+        self.worker_group.group_world_size = 2
+        self.worker_group.group_rank = 1
+        self.agent._worker_group = self.worker_group
+
+        # Create a test worker
+
+        self.workers = [
+            Worker(
+                local_rank=0,
+                global_rank=0,
+                role_rank=0,
+                world_size=2,
+                role_world_size=2,
+            ),
+            Worker(
+                local_rank=1,
+                global_rank=1,
+                role_rank=1,
+                world_size=2,
+                role_world_size=2,
+            ),
+        ]
+        self.workers[0].id = 0
+        self.workers[1].id = 1
+        self.agent._worker_group.workers = self.workers
+
+    @patch("torch.distributed.elastic.agent.server.api.record")
+    def test_record_worker_events_success(self, mock_record):
+        # Create a RunResult with successful workers
+        result = RunResult(
+            state=WorkerState.SUCCEEDED,
+            return_values={0: "result0", 1: "result1"},
+            failures={},
+        )
+
+        # Call the method under test
+        self.agent._record_worker_events(result)
+
+        # Verify record was called twice (once for each worker)
+        self.assertEqual(mock_record.call_count, 2)
+
+        # Check that both calls were for SUCCEEDED events
+        for call_args in mock_record.call_args_list:
+            event = call_args[0][0]
+
+            self.assertEqual(event.source, EventSource.WORKER)
+            self.assertEqual(event.metadata["state"], "SUCCEEDED")
+            self.assertIsNone(event.metadata["raw_error"])
+            md = json.loads(event.metadata["metadata"])
+            self.assertEqual(md["exit_code"], [None])
+            self.assertEqual(md["worker_pid"], [None])
+
+    @patch("torch.distributed.elastic.agent.server.api.record")
+    def test_record_worker_events_failure(self, mock_record):
+        # Create failures with error data
+        failure0 = ProcessFailure(
+            local_rank=0, pid=1000, exitcode=1, error_file="error0.json"
+        )
+
+        # Create a RunResult with one failed worker and one terminated worker
+        result = RunResult(
+            state=WorkerState.FAILED,
+            return_values={},
+            failures={0: failure0},  # Only worker 0 has a specific failure
+        )
+
+        # Call the method under test
+        self.agent._record_worker_events(result)
+
+        # Verify record was called twice (once for each worker)
+        self.assertEqual(mock_record.call_count, 2)
+
+        # Get the calls
+        calls = mock_record.call_args_list
+
+        # Check first call for the failed worker (global_rank=0)
+        failed_event = calls[0][0][0]
+        self.assertEqual(failed_event.source, EventSource.WORKER)
+        self.assertEqual(failed_event.metadata["state"], "FAILED")
+        self.assertEqual(failed_event.metadata["global_rank"], 0)
+        md = json.loads(failed_event.metadata["metadata"])
+        self.assertEqual(failed_event.metadata["raw_error"], '{"message": "<NONE>"}')
+        self.assertEqual(md["exit_code"], [1])
+        self.assertEqual(md["worker_pid"], [1000])
+
+        # Check second call for the terminated worker (global_rank=1)
+        terminated_event = calls[1][0][0]
+        self.assertEqual(terminated_event.source, EventSource.WORKER)
+        self.assertEqual(terminated_event.metadata["state"], "TERMINATED")
+        self.assertEqual(terminated_event.metadata["global_rank"], 1)
+        self.assertIsNone(terminated_event.metadata["raw_error"])
+        md = json.loads(terminated_event.metadata["metadata"])
+        self.assertEqual(md["exit_code"], [None])
+        self.assertEqual(md["worker_pid"], [None])
+
+
+class ConstructEventTest(unittest.TestCase):
+    def setUp(self):
+        # Create minimal spec and agent for testing
+        self.spec = MagicMock()
+        self.spec.role = "test_role"
+        self.spec.get_entrypoint_name.return_value = "test_entrypoint"
+        self.spec.rdzv_handler.get_run_id.return_value = "test_run_id"
+        self.spec.rdzv_handler.get_backend.return_value = "test_backend"
+        self.spec.max_restarts = 3
+
+        self.agent = TestAgent(self.spec)
+        self.agent._remaining_restarts = 2
+        self.agent._total_execution_time = 42
+
+        # Setup worker group
+        self.worker_group = WorkerGroup(self.spec)
+        self.worker_group.group_world_size = 2
+        self.worker_group.group_rank = 1
+        self.agent._worker_group = self.worker_group
+
+        # Create a test worker
+        self.worker = Worker(
+            local_rank=0, global_rank=5, role_rank=3, world_size=8, role_world_size=4
+        )
+        self.worker.id = 12345
+
+    def test_construct_event_agent_success(self):
+        # Test constructing an agent success event
+        event = self.agent._construct_event(state="SUCCEEDED", source=EventSource.AGENT)
+
+        # Verify basic event properties
+        self.assertEqual(event.name, "torchelastic.worker.status.SUCCEEDED")
+        self.assertEqual(event.source, EventSource.AGENT)
+
+        # Verify metadata
+        metadata = event.metadata
+        self.assertEqual(metadata["run_id"], "test_run_id")
+        self.assertIsNone(metadata["global_rank"])
+        self.assertEqual(metadata["group_rank"], 1)
+        self.assertIsNone(metadata["worker_id"])
+        self.assertEqual(metadata["role"], "test_role")
+        self.assertEqual(metadata["state"], "SUCCEEDED")
+        self.assertEqual(metadata["total_run_time"], 42)
+        self.assertEqual(metadata["rdzv_backend"], "test_backend")
+        self.assertIsNone(metadata["raw_error"])
+        self.assertEqual(
+            metadata["agent_restarts"], 1
+        )  # max_restarts - remaining_restarts
+        self.assertIsNone(metadata["duration_ms"])
+
+        # Verify JSON metadata
+        md_dict = json.loads(metadata["metadata"])
+        self.assertEqual(md_dict["group_world_size"], 2)
+        self.assertEqual(md_dict["entry_point"], "test_entrypoint")
+
+    def test_construct_event_worker_failure(self):
+        # Test constructing a worker failure event with raw error
+        raw_error = json.dumps(
+            {"error_message": "Test error", "traceback": "stack trace"}
+        )
+        event = self.agent._construct_event(
+            state="FAILED",
+            source=EventSource.WORKER,
+            worker=self.worker,
+            raw_error=raw_error,
+            exit_code=1,
+        )
+
+        # Verify basic event properties
+        self.assertEqual(event.name, "torchelastic.worker.status.FAILED")
+        self.assertEqual(event.source, EventSource.WORKER)
+
+        # Verify metadata
+        metadata = event.metadata
+        self.assertEqual(metadata["run_id"], "test_run_id")
+        self.assertEqual(metadata["global_rank"], 5)
+        self.assertEqual(metadata["group_rank"], 1)
+        self.assertEqual(metadata["worker_id"], "12345")
+        self.assertEqual(metadata["role"], "test_role")
+        self.assertEqual(metadata["state"], "FAILED")
+        self.assertEqual(metadata["total_run_time"], 42)
+        self.assertEqual(metadata["rdzv_backend"], "test_backend")
+        self.assertEqual(metadata["raw_error"], raw_error)
+        self.assertEqual(metadata["agent_restarts"], 1)
+
+        # Verify worker-specific metadata
+        md_dict = json.loads(metadata["metadata"])
+        self.assertEqual(md_dict["local_rank"], [0])
+        self.assertEqual(md_dict["role_rank"], [3])
+        self.assertEqual(md_dict["role_world_size"], [4])
+        self.assertEqual(md_dict["exit_code"], [1])
+
+    def test_construct_event_with_duration(self):
+        # Test constructing an event with duration_ms
+        event = self.agent._construct_event(
+            state="RENDEZVOUS", source=EventSource.AGENT, duration_ms=123.45
+        )
+
+        # Verify duration is set correctly
+        self.assertEqual(event.metadata["duration_ms"], 123.45)
+
+    def test_construct_event_worker_no_error(self):
+        # Test constructing a worker event without error info
+        event = self.agent._construct_event(
+            state="HEALTHY", source=EventSource.WORKER, worker=self.worker
+        )
+
+        # Verify error fields are None
+        metadata = event.metadata
+        self.assertIsNone(metadata["raw_error"])
+
+        # Check worker info is set
+        self.assertEqual(metadata["global_rank"], 5)
+        self.assertEqual(metadata["worker_id"], "12345")
+
+        # Check metadata JSON
+        md_dict = json.loads(metadata["metadata"])
+        self.assertEqual(md_dict["local_rank"], [0])
+        self.assertEqual(md_dict["role_rank"], [3])
+        self.assertEqual(md_dict["role_world_size"], [4])
+        self.assertNotIn("exit_code", [None])
 
 
 class SimpleElasticAgentTest(unittest.TestCase):

--- a/torch/distributed/elastic/agent/server/api.py
+++ b/torch/distributed/elastic/agent/server/api.py
@@ -750,8 +750,17 @@ class SimpleElasticAgent(ElasticAgent):
             failure = result.failures.get(worker.global_rank)
             state: str = self._get_worker_state(worker, result)
             raw_error = json.dumps(failure.error_file_data) if failure else None
+            exit_code = failure.exitcode if failure else None
+            worker_pid = failure.pid if failure else None
             record(
-                self._construct_event(state, EventSource.WORKER, worker, raw_error),
+                self._construct_event(
+                    state=state,
+                    source=EventSource.WORKER,
+                    worker=worker,
+                    raw_error=raw_error,
+                    exit_code=exit_code,
+                    worker_pid=worker_pid,
+                ),
                 self._worker_group.spec.event_log_handler,
             )
 
@@ -787,6 +796,8 @@ class SimpleElasticAgent(ElasticAgent):
         worker: Optional[Worker] = None,
         raw_error: Optional[str] = None,
         duration_ms: Optional[float] = None,
+        exit_code: Optional[int] = None,
+        worker_pid: Optional[int] = None,
     ) -> Event:
         wg = self._worker_group
         spec = wg.spec
@@ -798,6 +809,8 @@ class SimpleElasticAgent(ElasticAgent):
             md["local_rank"] = (worker.local_rank,)
             md["role_rank"] = (worker.role_rank,)
             md["role_world_size"] = (worker.role_world_size,)
+            md["exit_code"] = (exit_code,)
+            md["worker_pid"] = (worker_pid,)
             global_rank = worker.global_rank
             worker_id = str(worker.id)
         else:


### PR DESCRIPTION
Summary:
**Problem**
Some processes are terminated by other processes using signals. These signal terminations often lack stack traces, causing confusion during debugging.

**Solution**
Log exit codes to simplify and improve the debugging process failures.

Test Plan:
unit tests


https://www.internalfb.com/mlhub/pipelines/runs/mast/f773486907-TrainingApplication__13_D79777290?version=0&env=PRODUCTION

Rollback Plan:

Differential Revision: D79777290




cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci