### PR TITLE
Limit intel-openmp install to non-ARM64 Windows builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1588,7 +1588,7 @@ def main() -> None:
         "networkx>=2.5.1",
         "jinja2",
         "fsspec>=0.8.5",
-        'intel-openmp==2025.1.1 ;platform_system == "Windows" and platform_machine != "arm64" ',  # for Windows x64 inductor
+        'intel-openmp==2025.1.1 ;platform_system == "Windows" and (platform_machine == "ARM64" or platform_machine == "arm64") ',  # for Windows x64 inductor
     ]
     if BUILD_PYTHON_ONLY:
         install_requires += [f"{LIBTORCH_PKG_NAME}=={TORCH_VERSION}"]

--- a/setup.py
+++ b/setup.py
@@ -1588,7 +1588,7 @@ def main() -> None:
         "networkx>=2.5.1",
         "jinja2",
         "fsspec>=0.8.5",
-        'intel-openmp==2025.1.1 ;platform_system == "Windows" ',  # for Windows inductor
+        'intel-openmp==2025.1.1 ;platform_system == "Windows" and platform_machine != "arm64" ',  # for Windows x64 inductor
     ]
     if BUILD_PYTHON_ONLY:
         install_requires += [f"{LIBTORCH_PKG_NAME}=={TORCH_VERSION}"]


### PR DESCRIPTION
Nightly wheel tests on Windows ARM64 began failing after #160258 added intel-openmp to the Windows dependency list. Because intel-openmp isn’t available on Windows ARM64, this PR scopes its installation to non-ARM64 Windows builds only, preventing the ARM64 failures.

Fixes #160898 


cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @Blackhex