### PR TITLE
Fix filename showing up as ints in dynamo_compile stack_trace column.

### DIFF
--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -303,8 +303,6 @@ class TestDynamoTimed(TestCase):
         code = sample_func.__code__
         with mock.patch("torch._logging.trace_structured") as mock_trace:
             stack_strings = convert_frame.log_dynamo_start(code)
-            print("Stack strings:")
-            print(stack_strings)
             last_entry = stack_strings[-1]
             # Check if the last entry is a valid stack trace i.e for the sample_func
             self.assertIn(f"Line: {code.co_firstlineno}", last_entry, "")

--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -296,21 +296,21 @@ class TestDynamoTimed(TestCase):
 
         self.warmup()
         self.run_forward_backward()
+        
         # Dummy code object
         def sample_func():
             pass
 
         code = sample_func.__code__
-        with mock.patch("torch._logging.trace_structured") as mock_trace:
-            stack_strings = convert_frame.log_dynamo_start(code)
-            last_entry = stack_strings[-1]
-            # Check if the last entry is a valid stack trace i.e for the sample_func
-            self.assertIn(f"Line: {code.co_firstlineno}", last_entry, "")
-            self.assertIn(f"Name: {code.co_name}", last_entry, "")
-            self.assertIn(f"Filename: {code.co_filename}", last_entry, "")
-            
-            # Since the remaining logs are env specific, we just check if they are present instead of checking the exact string
-            self.assertGreater(len(stack_strings), 1)
+        stack_strings = convert_frame.log_dynamo_start(code)
+        last_entry = stack_strings[-1]
+        # Check if the last entry is a valid stack trace i.e for the sample_func
+        self.assertIn(f"Line: {code.co_firstlineno}", last_entry, "")
+        self.assertIn(f"Name: {code.co_name}", last_entry, "")
+        self.assertIn(f"Filename: {code.co_filename}", last_entry, "")
+
+        # Since the remaining logs are env specific, we just check if they are present instead of checking the exact string
+        self.assertGreater(len(stack_strings), 1)
 
     @dynamo_config.patch(
         {

--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -289,6 +289,31 @@ class TestDynamoTimed(TestCase):
             "'l_x_': [3], 'linear': [1]}",
         )
 
+    @dynamo_config.patch({"log_compilation_metrics": True})
+    @inductor_config.patch({"force_disable_caches": True})
+    def test_log_dynamo_start(self):
+        import torch._dynamo.convert_frame as convert_frame
+
+        self.warmup()
+        self.run_forward_backward()
+        # Dummy code object
+        def sample_func():
+            pass
+
+        code = sample_func.__code__
+        with mock.patch("torch._logging.trace_structured") as mock_trace:
+            stack_strings = convert_frame.log_dynamo_start(code)
+            print("Stack strings:")
+            print(stack_strings)
+            last_entry = stack_strings[-1]
+            # Check if the last entry is a valid stack trace i.e for the sample_func
+            self.assertIn(f"Line: {code.co_firstlineno}", last_entry, "")
+            self.assertIn(f"Name: {code.co_name}", last_entry, "")
+            self.assertIn(f"Filename: {code.co_filename}", last_entry, "")
+            
+            # Since the remaining logs are env specific, we just check if they are present instead of checking the exact string
+            self.assertGreater(len(stack_strings), 1)
+
     @dynamo_config.patch(
         {
             "log_compilation_metrics": True,

--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -309,7 +309,7 @@ class TestDynamoTimed(TestCase):
         self.assertIn(f"Name: {code.co_name}", last_entry, "Log does not contain a Name")
         self.assertIn(
             "test_utils.py",
-            code.co_filename,
+            last_entry,
             "Log file does not contain the expected Filename: 'test_utils.py'",
         )
 

--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -305,9 +305,13 @@ class TestDynamoTimed(TestCase):
         stack_strings = convert_frame.log_dynamo_start(code)
         last_entry = stack_strings[-1]
         # Check if the last entry is a valid stack trace i.e for the sample_func
-        self.assertIn(f"Line: {code.co_firstlineno}", last_entry, "")
-        self.assertIn(f"Name: {code.co_name}", last_entry, "")
-        self.assertIn(f"Filename: {code.co_filename}", last_entry, "")
+        self.assertIn(f"Line: {code.co_firstlineno}", last_entry, "Log does not contain a Line no.")
+        self.assertIn(f"Name: {code.co_name}", last_entry, "Log does not contain a Name")
+        self.assertIn(
+            "test_utils.py",
+            code.co_filename,
+            "Log file does not contain the expected Filename: 'test_utils.py'",
+        )
 
         # Since the remaining logs are env specific, we just check if they are present instead of checking the exact string
         self.assertGreater(len(stack_strings), 1)

--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -296,7 +296,7 @@ class TestDynamoTimed(TestCase):
 
         self.warmup()
         self.run_forward_backward()
-        
+
         # Dummy code object
         def sample_func():
             pass
@@ -305,8 +305,14 @@ class TestDynamoTimed(TestCase):
         stack_strings = convert_frame.log_dynamo_start(code)
         last_entry = stack_strings[-1]
         # Check if the last entry is a valid stack trace i.e for the sample_func
-        self.assertIn(f"Line: {code.co_firstlineno}", last_entry, "Log does not contain a Line no.")
-        self.assertIn(f"Name: {code.co_name}", last_entry, "Log does not contain a Name")
+        self.assertIn(
+            f"Line: {code.co_firstlineno}",
+            last_entry,
+            "Log does not contain a Line no.",
+        )
+        self.assertIn(
+            f"Name: {code.co_name}", last_entry, "Log does not contain a Name"
+        )
         self.assertIn(
             "test_utils.py",
             last_entry,

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -227,7 +227,7 @@ def fx_forward_from_src_skip_result(
 
 def log_dynamo_start(code: CodeType, skip: int = 0) -> list[str]:
     convert_frame_intern = structured.intern_string(__file__)
-    captured_tb = CapturedTraceback.extract(skip=4 + skip.summary()
+    captured_tb = CapturedTraceback.extract(skip=4 + skip).summary()
     frames_interned = structured.from_traceback(captured_tb)
     # Extract and filter the stack
     stack = list(

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -248,8 +248,9 @@ def log_dynamo_start(code: CodeType, skip: int = 0) -> list[str]:
         lambda: {"stack": stack},
     )
 
+    REVERSE_INTERN_TABLE = {v: k for k, v in structured.INTERN_TABLE.items()}
     stack_strings = [
-        f"Line: {frame['line']}, Name: {frame['name']}, Filename: {frame['filename']}"
+        f"Line: {frame['line']}, Name: {frame['name']}, Filename: {REVERSE_INTERN_TABLE[frame['filename']]}"
         for frame in stack
     ]
     return stack_strings

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -248,7 +248,7 @@ def log_dynamo_start(code: CodeType, skip: int = 0) -> list[str]:
         lambda: {"stack": stack},
     )
 
-    # Capture stack separatly without using from_traceback to get the actual filenames
+    # Capture stack separately without using from_traceback to get the actual filenames
     frames_raw = captured_tb.summary()
     stack_strings = [
         f"Line: {frame.lineno}, Name: {frame.name}, Filename: {frame.filename}"

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -227,8 +227,8 @@ def fx_forward_from_src_skip_result(
 
 def log_dynamo_start(code: CodeType, skip: int = 0) -> list[str]:
     convert_frame_intern = structured.intern_string(__file__)
-    captured_tb = CapturedTraceback.extract(skip=4 + skip)
-    frames_interned = structured.from_traceback(captured_tb.summary())
+    captured_tb = CapturedTraceback.extract(skip=4 + skip.summary()
+    frames_interned = structured.from_traceback(captured_tb)
     # Extract and filter the stack
     stack = list(
         itertools.takewhile(
@@ -249,10 +249,9 @@ def log_dynamo_start(code: CodeType, skip: int = 0) -> list[str]:
     )
 
     # Capture stack separately without using from_traceback to get the actual filenames
-    frames_raw = captured_tb.summary()
     stack_strings = [
         f"Line: {frame.lineno}, Name: {frame.name}, Filename: {frame.filename}"
-        for frame in frames_raw
+        for frame in captured_tb
         if frame.filename != convert_frame_intern
     ] + [
         f"Line: {code.co_firstlineno}, Name: {code.co_name}, Filename: {code.co_filename}"


### PR DESCRIPTION
Test plan:
$ python -m test_utils

Note:
Another way is adding the actual file_name to from_traceback, but since it's referenced in multiple places and may have associated tests this seems safer. Lmk if changes are needed @c00w 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela