### PR TITLE
[ONNX] Use onnxruntime 1.22 in CI

### DIFF
--- a/.ci/docker/common/install_onnx.sh
+++ b/.ci/docker/common/install_onnx.sh
@@ -19,7 +19,7 @@ pip_install \
   transformers==4.36.2
 
 pip_install coloredlogs packaging
-pip_install onnxruntime==1.18.1
+pip_install onnxruntime==1.22.1
 pip_install onnxscript==0.3.1
 
 # Cache the transformers model to be used later by ONNX tests. We need to run the transformers


### PR DESCRIPTION
Use onnxruntime 1.22 in CI to enable testing of newer opsets and IR versions.


cc @titaiwangms