### PR TITLE
[SymmMem] Support rendezvous on view of a tensor

### DIFF
--- a/test/distributed/test_nvshmem.py
+++ b/test/distributed/test_nvshmem.py
@@ -73,8 +73,39 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinousTest):
         symm_mem.enable_symm_mem_for_group(group_name)
 
         x = symm_mem.empty((2, 1024), device=self.device)
-        y = x[1]
-        symm_mem.rendezvous(y, group=group_name)
+        # Directly rendezvousing a slice should not fail
+        hdls = [symm_mem.rendezvous(y, group=group_name) for y in torch.chunk(x, 2)]
+        # Assert that handles are not the same
+        self.assertIsNot(hdls[0], hdls[1])
+
+    @skipIfRocm
+    def test_rendezvous_view(self) -> None:
+        # Rendezvous a view of a tensor
+        self._init_device()
+        group_name = dist.group.WORLD.group_name
+        symm_mem.enable_symm_mem_for_group(group_name)
+
+        x = symm_mem.empty(1024, device=self.device)
+        y = x.view(32, 32)
+        # Directly rendezvousing a view should not fail
+        hdl_y = symm_mem.rendezvous(y, group=group_name)
+
+        # Assert that view's handle is not the same as the original tensor's handle
+        hdl_x = symm_mem.rendezvous(x, group=group_name)
+        self.assertIsNot(hdl_x, hdl_y)
+
+    @skipIfRocm
+    def test_rendezvous_same(self) -> None:
+        # Rendezvous same tensor multiple times
+        self._init_device()
+        group_name = dist.group.WORLD.group_name
+        symm_mem.enable_symm_mem_for_group(group_name)
+
+        x = symm_mem.empty(1024, device=self.device)
+        hdl_0 = symm_mem.rendezvous(x, group=group_name)
+        hdl_1 = symm_mem.rendezvous(x, group=group_name)
+        # The handle should point to the same object
+        self.assertIs(hdl_0, hdl_1)
 
     @skipIfRocm
     def test_nvshmem_put(self) -> None:

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -832,8 +832,12 @@ c10::intrusive_ptr<CUDASymmetricMemory> make_symm_mem(
 } // namespace
 
 c10::intrusive_ptr<SymmetricMemory> CUDASymmetricMemoryAllocator::rendezvous(
-    void* ptr,  // data_ptr() of the tensor
+    const at::Tensor& tensor,
     const std::optional<std::string>& group_name) {
+  // TODO: currently using `storage().data_ptr()` to maintain the same behavior
+  // as before, but we should use `data_ptr()` instead
+  auto ptr = tensor.storage().data_ptr().get();
+
   // Today this would still find the ptr in the map because one allocation
   // matches one tensor. But will break once we enable MemPool.
   // TODO: implement a customized `find` that searches for the allocation that

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.hpp
@@ -115,7 +115,7 @@ class CUDASymmetricMemoryAllocator : public SymmetricMemoryAllocator {
   void free(void* ptr) override;
   size_t get_alloc_size(void* ptr) override;
   c10::intrusive_ptr<SymmetricMemory> rendezvous(
-      void* ptr,
+      const at::Tensor& tensor,
       const std::optional<std::string>& group_name) override;
   bool has_multicast_support(int device_idx) override;
   c10::DeviceType supported_device_type() override;

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
@@ -253,7 +253,7 @@ TORCH_API c10::intrusive_ptr<SymmetricMemory> rendezvous(
     const at::Tensor& tensor,
     const std::optional<std::string>& group_name) {
   auto allocator = get_allocator(tensor.device().type());
-  return allocator->rendezvous(tensor.storage().data_ptr().get(), group_name);
+  return allocator->rendezvous(tensor, group_name);
 }
 
 TORCH_API bool has_multicast_support(

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
@@ -93,7 +93,7 @@ class SymmetricMemoryAllocator : public c10::intrusive_ptr_target {
   virtual void free(void* ptr) = 0;
   virtual size_t get_alloc_size(void* ptr) = 0;
   virtual c10::intrusive_ptr<SymmetricMemory> rendezvous(
-      void* ptr,
+      const at::Tensor& tensor,
       const std::optional<std::string>& group_name) = 0;
   virtual bool has_multicast_support(int device_idx) = 0;
   virtual c10::DeviceType supported_device_type() = 0;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #161008
* __->__ #160925

`tensor.view` share the same `data_ptr()` as the original tensor, thus cannot serve as key to rendezvous' map (we want a 1:1 match between handle and tensor, thus need a unique key).

@ezyang suggests using the raw `TensorImpl*` of a tensor, for which `tensor.view` would have a different value than the original tensor.

But the raw `TensorImpl*` can be stumbled on again when a previous tensor gets deallocated and a new one allocated. For that reason, we'd also need to use a `weak_instrusive_ptr` to distinguish the two tensors, i.e. for the deallocated tensor, `weak_instrusive_ptr::expired()` would return true.

Added `test_rendezvous_view` and `test_rendezvous_same`.

Note: the view support has been added to NVSHMEM backend and NCCL backend. For CUDA backend, I have yet to investigate.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta