### PR TITLE
[2/N] Port 3 fsdp distributed test cases to Intel GPU

### DIFF
--- a/test/distributed/fsdp/test_fsdp_use_orig_params.py
+++ b/test/distributed/fsdp/test_fsdp_use_orig_params.py
@@ -41,6 +41,7 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
     TEST_WITH_DEV_DBG_ASAN,
+    TEST_XPU,
     TestCase,
 )
 from torch.testing._internal.inductor_utils import HAS_GPU
@@ -56,6 +57,8 @@ if TEST_WITH_DEV_DBG_ASAN:
         file=sys.stderr,
     )
     sys.exit(0)
+
+device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
 
 
 class TestFSDPUseOrigParamsMultipleParamGroups(FSDPTest):
@@ -158,7 +161,7 @@ class TestFSDPUseOrigParamsMultipleParamGroups(FSDPTest):
             device_init_mode == DEVICEInitMode.DEVICE_AFTER
             and not fsdp_model.cpu_offload.offload_params
         ):
-            fsdp_model = fsdp_model.cuda()
+            fsdp_model = fsdp_model.to(device=device_type)
         return fsdp_model, fsdp_optim
 
     def _check_train_parity(
@@ -171,7 +174,7 @@ class TestFSDPUseOrigParamsMultipleParamGroups(FSDPTest):
         num_iters: int = 10,
     ):
         """Checks training parity between DDP and FSDP."""
-        device = torch.device("cuda")
+        device = torch.device(device_type)
         for i in range(num_iters):
             iter_losses = []
             for model, optim in ((ddp_model, ddp_optim), (fsdp_model, fsdp_optim)):
@@ -262,7 +265,7 @@ class TestFSDPUseOrigParamsMultipleParamGroups(FSDPTest):
         optim = torch.optim.Adam(model.parameters(), lr=1e-2)
         for _ in range(10):
             losses = []
-            inp = ref_model.get_input(torch.device("cuda"))
+            inp = ref_model.get_input(torch.device(device_type))
             for _model, _optim in ((ref_model, ref_optim), (model, optim)):
                 _optim.zero_grad()
                 loss = _model(*inp).sum()
@@ -470,7 +473,7 @@ class TestFSDPUseOrigParamsMultipleParamGroups(FSDPTest):
         ):
             ddp_optims.append(optim_ctor(ddp_param_group["params"]))
             fsdp_optims.append(optim_ctor(fsdp_param_group["params"]))
-        device = torch.device("cuda")
+        device = torch.device(device_type)
 
         # Check that there exists a `FlatParameter` that has both a weight and
         # a bias in this rank's shard
@@ -643,7 +646,7 @@ class TestFSDPUseOrigParamsUnshardReshard(FSDPTest):
             fsdp_model_orig_params,
             optim_orig_params,
         ) = self._get_fsdp_models_and_optims(sharding_strategy, cpu_offload)
-        device = torch.device("cuda")
+        device = torch.device(device_type)
         for _ in range(3):
             inp1 = fsdp_model.get_input(device)
             _inp2 = fsdp_model.get_input(device)
@@ -701,7 +704,7 @@ class TestFSDPUseOrigParamsUnshardReshard(FSDPTest):
             fsdp_model_orig_params,
             optim_orig_params,
         ) = self._get_fsdp_models_and_optims(sharding_strategy, cpu_offload)
-        device = torch.device("cuda")
+        device = torch.device(device_type)
         for _ in range(3):
             optim.zero_grad()
             optim_orig_params.zero_grad()
@@ -828,9 +831,9 @@ class TestFSDPUseOrigParamsParamAccess(FSDPTest):
                         p1 = p1.flatten()
                 torch.testing.assert_close(p1, p2)
 
-        ddp_model = DDP(Model().cuda(), device_ids=[self.rank])
+        ddp_model = DDP(Model().to(device=device_type), device_ids=[self.rank])
         fsdp_model = FSDP(
-            Model().cuda(),
+            Model().to(device=device_type),
             sharding_strategy=sharding_strategy,
             auto_wrap_policy=always_wrap_policy,
             use_orig_params=True,
@@ -838,7 +841,7 @@ class TestFSDPUseOrigParamsParamAccess(FSDPTest):
         LR = 1e-2
         ddp_optim = torch.optim.Adam(ddp_model.parameters(), lr=LR)
         fsdp_optim = torch.optim.Adam(fsdp_model.parameters(), lr=LR)
-        device = torch.device("cuda")
+        device = torch.device(device_type)
 
         inp = fsdp_model.get_input(device)
         ddp_out = ddp_model(*inp)
@@ -913,11 +916,11 @@ class TestFSDPUseOrigParamsWriteback(FSDPTest):
 
         # Check that the writeback propagates
         ddp_model = DDP(
-            TestFSDPUseOrigParamsWriteback.Model(torch.device("cuda")),
+            TestFSDPUseOrigParamsWriteback.Model(torch.device(device_type)),
             device_ids=[self.rank],
         )
         fsdp_model = FSDP(
-            TestFSDPUseOrigParamsWriteback.Model(torch.device("cuda")),
+            TestFSDPUseOrigParamsWriteback.Model(torch.device(device_type)),
             use_orig_params=True,
         )
         ddp = ddp_model.module  # for brevity
@@ -966,11 +969,11 @@ class TestFSDPUseOrigParamsWriteback(FSDPTest):
             return None if set_to_none else torch.ones_like(param) * 2
 
         ddp_model = DDP(
-            TestFSDPUseOrigParamsWriteback.Model(torch.device("cuda")),
+            TestFSDPUseOrigParamsWriteback.Model(torch.device(device_type)),
             device_ids=[self.rank],
         )
         fsdp_model = FSDP(
-            TestFSDPUseOrigParamsWriteback.Model(torch.device("cuda")),
+            TestFSDPUseOrigParamsWriteback.Model(torch.device(device_type)),
             use_orig_params=True,
         )
         LR = 1e-2
@@ -981,7 +984,7 @@ class TestFSDPUseOrigParamsWriteback(FSDPTest):
         fsdp_optim = torch.optim.Adam(fsdp_model.parameters(), lr=LR)
 
         # Generate an initial gradient
-        inp = fsdp_model.get_input(torch.device("cuda"))
+        inp = fsdp_model.get_input(torch.device(device_type))
         ddp_out = ddp_model(*inp)
         fsdp_out = fsdp_model(*inp)
         ddp_out.sum().backward()
@@ -1011,7 +1014,7 @@ class TestFSDPUseOrigParamsWriteback(FSDPTest):
         self._check_param_parity(ddp_model, fsdp_model)  # triggers a writeback
 
         # Intentionally do not zero the gradient to check writeback
-        inp = fsdp_model.get_input(torch.device("cuda"))
+        inp = fsdp_model.get_input(torch.device(device_type))
         ddp_out = ddp_model(*inp)
         fsdp_out = fsdp_model(*inp)
         ddp_out.sum().backward()
@@ -1023,7 +1026,7 @@ class TestFSDPUseOrigParamsWriteback(FSDPTest):
     @skip_if_lt_x_gpu(2)
     def test_writeback_shape_mismatch(self):
         fsdp_model = FSDP(
-            TestFSDPUseOrigParamsWriteback.Model(torch.device("cuda")),
+            TestFSDPUseOrigParamsWriteback.Model(torch.device(device_type)),
             use_orig_params=True,
         )
         # Check that writing back with mismatched shape errors
@@ -1073,9 +1076,9 @@ class TestFSDPUseOrigParamsWriteback(FSDPTest):
         # Test changing the parameter storage to no longer be a view into the
         # flat parameter
         fsdp_model = fsdp_wrapper(
-            TestFSDPUseOrigParamsWriteback.Model(torch.device("cuda"))
+            TestFSDPUseOrigParamsWriteback.Model(torch.device(device_type))
         )
-        inp = fsdp_model.get_input(torch.device("cuda"))
+        inp = fsdp_model.get_input(torch.device(device_type))
         loss = fsdp_model(*inp).sum()
         fsdp_model.lin1.weight.data = fsdp_model.lin1.weight.clone()
         assert_msg = (
@@ -1086,9 +1089,9 @@ class TestFSDPUseOrigParamsWriteback(FSDPTest):
 
         # Test changing the parameter variable itself
         fsdp_model = fsdp_wrapper(
-            TestFSDPUseOrigParamsWriteback.Model(torch.device("cuda"))
+            TestFSDPUseOrigParamsWriteback.Model(torch.device(device_type))
         )
-        inp = fsdp_model.get_input(torch.device("cuda"))
+        inp = fsdp_model.get_input(torch.device(device_type))
         loss = fsdp_model(*inp).sum()
         fsdp_model.lin1._fsdp_wrapped_module.weight = nn.Parameter(
             fsdp_model.lin1.weight.clone()
@@ -1122,9 +1125,10 @@ class TestFSDPUseOrigParamsWriteback(FSDPTest):
 
         # Train forward -> full-precision unshard -> train forward
         fsdp_model = FSDP(
-            TestFSDPUseOrigParamsWriteback.Model(torch.device("cuda")), **fsdp_kwargs
+            TestFSDPUseOrigParamsWriteback.Model(torch.device(device_type)),
+            **fsdp_kwargs,
         )
-        inp = fsdp_model.get_input(torch.device("cuda"))
+        inp = fsdp_model.get_input(torch.device(device_type))
         fsdp_model(*inp)
         with FSDP.summon_full_params(fsdp_model):
             ...
@@ -1183,13 +1187,13 @@ class TestFSDPUseOrigParamsFQNs(FSDPTest):
                 assert_equal_fn(params[1].shape, param_shapes[1])
                 return self.lin(x)
 
-        model = Model().cuda()
+        model = Model().to(device=device_type)
         # Save the *unsharded* original parameter shapes and check the shapes
         # match in the forward pass
         param_shapes[0] = model.lin.weight.shape
         param_shapes[1] = model.lin.bias.shape
         fsdp_model = FSDP(model, use_orig_params=True)
-        inp = torch.randn((2, 5), device=torch.device("cuda"))
+        inp = torch.randn((2, 5), device=torch.device(device_type))
         fsdp_model(inp)
 
 
@@ -1216,7 +1220,7 @@ class TestFSDPUseOrigParamsNoSync(FSDPTest):
         )
 
     def _test_no_sync_correctness(self, sharding_strategy: ShardingStrategy):
-        model = nn.Linear(7, 1, bias=False, device="cuda")
+        model = nn.Linear(7, 1, bias=False, device=device_type)
         fsdp_kwargs = {
             "sharding_strategy": sharding_strategy,
         }
@@ -1266,8 +1270,8 @@ class TestFSDPUseOrigParamsNoSync(FSDPTest):
                     orig_param.grad,
                 )
 
-        inp = torch.randn((2, 7), device="cuda")
-        grad = torch.randn((2, 1), device="cuda")
+        inp = torch.randn((2, 7), device=device_type)
+        grad = torch.randn((2, 1), device=device_type)
 
         # Compute some reference gradients using one forward/backward
         out_use_flat_params = model_use_flat_params(inp)
@@ -1333,7 +1337,7 @@ class TestFSDPUseOrigParamsNoSync(FSDPTest):
         )
 
     def _test_no_sync_mixed_precision(self, sharding_strategy: ShardingStrategy):
-        model = nn.Linear(3, 3, device="cuda")
+        model = nn.Linear(3, 3, device=device_type)
         mixed_precision = MixedPrecision(
             param_dtype=torch.float16,
             reduce_dtype=torch.float32,
@@ -1344,7 +1348,7 @@ class TestFSDPUseOrigParamsNoSync(FSDPTest):
             "use_orig_params": True,
         }
         fsdp_model = FSDP(model, **fsdp_kwargs)
-        inp = torch.randn((2, 3), device="cuda")
+        inp = torch.randn((2, 3), device=device_type)
         with fsdp_model.no_sync():
             # For each of these `no_sync()` backward passes, check that the
             # gradients are in the low precision parameter dtype (FP16)
@@ -1368,8 +1372,8 @@ class TestFSDPUseOrigParamsInit(FSDPTest):
     @skip_if_lt_x_gpu(2)
     def test_non_uniform_requires_grad(self):
         model = nn.Sequential(
-            nn.Linear(3, 3, device="cuda"),
-            nn.Linear(3, 3, device="cuda"),
+            nn.Linear(3, 3, device=device_type),
+            nn.Linear(3, 3, device=device_type),
         )
         # Freeze biases only and flatten both weights and biases into the same
         # `FlatParameter` to exercise non-uniform `requires_grad`
@@ -1392,10 +1396,10 @@ class TestMultiTensorApply(TestCase):
         # Check that this does not segfault
         torch._foreach_mul_(size0_tensors, 0.1)
 
-    @unittest.skipIf(not TEST_CUDA, "no cuda")
+    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "no cuda and no xpu")
     def test_multi_tensor_apply_size0_tensors_cuda(self):
         size0_tensors = [
-            torch.empty(0, device="cuda") for _ in range(NUM_SIZE0_TENSORS)
+            torch.empty(0, device=device_type) for _ in range(NUM_SIZE0_TENSORS)
         ]
         # Check that this does not segfault
         torch._foreach_mul_(size0_tensors, 0.1)

--- a/test/distributed/fsdp/test_shard_utils.py
+++ b/test/distributed/fsdp/test_shard_utils.py
@@ -15,6 +15,9 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
 )
 
 
+device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
+
+
 class TestShardUtilsDistributed(FSDPTest):
     @property
     def world_size(self):
@@ -23,7 +26,7 @@ class TestShardUtilsDistributed(FSDPTest):
     def _create_tensor(self, *size):
         # Keep everything deterministic.
         torch.manual_seed(0)
-        return torch.rand(*size).cuda()
+        return torch.rand(*size).to(device=device_type)
 
     @skip_if_lt_x_gpu(2)
     def test_create_chunk_sharded_tensor(self):
@@ -34,10 +37,12 @@ class TestShardUtilsDistributed(FSDPTest):
                 tensor,
                 self.rank,
                 self.world_size,
-                torch.cuda.device_count(),
+                torch.accelerator.device_count(),
                 _get_default_group(),
             )
-            output = torch.empty(*size).cuda() if self.rank == 0 else None
+            output = (
+                torch.empty(*size).to(device=device_type) if self.rank == 0 else None
+            )
             sharded_tensor.gather(0, output)
             if self.rank == 0:
                 self.assertEqual(tensor, output)
@@ -51,7 +56,7 @@ class TestShardUtilsDistributedDTensor(DTensorTestBase):
     def _create_tensor(self, *size):
         # Keep everything deterministic.
         torch.manual_seed(0)
-        return torch.rand(*size).cuda()
+        return torch.rand(*size).to(device=device_type)
 
     @with_comms
     @skip_if_lt_x_gpu(2)


### PR DESCRIPTION
For https://github.com/pytorch/pytorch/issues/114850, we will port distributed tests to Intel GPU. This is the second PR for fsdp distributed test cases, the first is https://github.com/pytorch/pytorch/pull/160158.
We could enable Intel GPU with following methods and try the best to keep the original code styles:
- Use "torch.accelerator.current_accelerator()" to determine the accelerator backend
- Enabled XPU for some test path


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci @gujinghui @EikanWang @fengyuan14 @guangyey