### PR TITLE
[Quant][CPU] Avoid NaN in fp8 output of qlinear and qconv

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
+++ b/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
@@ -460,4 +460,6 @@ at::Tensor _qconv_prepack_onednn(
     int64_t groups,
     std::optional<torch::List<int64_t>> input_shape=std::nullopt);
 
+#define FP8E4M3_MAX 448.0
+
 #endif // #if AT_MKLDNN_ENABLED()

--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -1484,7 +1484,7 @@ static at::Tensor _fp8_convolution_onednn_ref(
     y_f32.div_(output_scale);
     if (x1.scalar_type() == at::kFloat8_e4m3fn) {
       // Avoid NaN
-      y_f32.clamp_(-448, 448);
+      y_f32.clamp_(-FP8E4M3_MAX, FP8E4M3_MAX);
       // Align with oneDNN: convert fp32 to fp8 by fp32 -> fp16 -> fp8
       y_f32 = y_f32.to(at::kHalf);
     }
@@ -1500,7 +1500,7 @@ static at::Tensor _fp8_convolution_onednn_ref(
   auto out_dtype = output_dtype.has_value() ? output_dtype.value() : at::kFloat8_e4m3fn;
   if (out_dtype == at::kFloat8_e4m3fn) {
     // Avoid NaN
-    y_f32.clamp_(-448, 448);
+    y_f32.clamp_(-FP8E4M3_MAX, FP8E4M3_MAX);
     // Align with oneDNN: convert fp32 to fp8 by fp32 -> fp16 -> fp8
     return y_f32.to(at::kHalf).to(out_dtype);
   }
@@ -1766,7 +1766,7 @@ static at::Tensor _quantized_convolution_onednn(
     // before converting to fp8
     auto post_ops = op_attr.get_post_ops();
     post_ops.append_eltwise(dnnl::algorithm::eltwise_linear, 1.0/output_scale, 0.0);
-    post_ops.append_eltwise(dnnl::algorithm::eltwise_clip, -448.0, 448.0);
+    post_ops.append_eltwise(dnnl::algorithm::eltwise_clip, -FP8E4M3_MAX, FP8E4M3_MAX);
     op_attr.set_post_ops(post_ops);
     output_scale = 1.0f;
   }

--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -1483,6 +1483,8 @@ static at::Tensor _fp8_convolution_onednn_ref(
     }
     y_f32.div_(output_scale);
     if (x1.scalar_type() == at::kFloat8_e4m3fn) {
+      // Avoid NaN
+      y_f32.clamp_(-448, 448);
       // Align with oneDNN: convert fp32 to fp8 by fp32 -> fp16 -> fp8
       y_f32 = y_f32.to(at::kHalf);
     }
@@ -1497,6 +1499,8 @@ static at::Tensor _fp8_convolution_onednn_ref(
   y_f32.div_(output_scale);
   auto out_dtype = output_dtype.has_value() ? output_dtype.value() : at::kFloat8_e4m3fn;
   if (out_dtype == at::kFloat8_e4m3fn) {
+    // Avoid NaN
+    y_f32.clamp_(-448, 448);
     // Align with oneDNN: convert fp32 to fp8 by fp32 -> fp16 -> fp8
     return y_f32.to(at::kHalf).to(out_dtype);
   }
@@ -1730,12 +1734,13 @@ static at::Tensor _quantized_convolution_onednn(
   output_sizes = at::native::conv_output_size(input_size, kernel_size, padding.vec(), stride.vec(), dilation.vec());
   ideep::dims dst_dims = ideep::dims({output_sizes.cbegin(), output_sizes.cend()});
   // Output is not a quantized tensor but data type is uint8
+  auto out_dtype = output_dtype.has_value() ? output_dtype.value() : act_dtype;
   at::Tensor output = has_accum_postop_sum ?
     accum.value() :
     at::empty(
       dst_dims,
       at::device(c10::kCPU)
-          .dtype(fp32_output ? c10::kFloat : (bfloat16_output ? c10::kBFloat16 : act_dtype))
+          .dtype(out_dtype)
           .memory_format(kSpatialDim == 2 ?
               c10::MemoryFormat::ChannelsLast :
               c10::MemoryFormat::ChannelsLast3d)
@@ -1755,6 +1760,16 @@ static at::Tensor _quantized_convolution_onednn(
     unary_scalars,
     unary_algorithm.has_value() ? unary_algorithm.value() : ""
   );
+  // Avoid NaN if output dtype is fp8
+  if (out_dtype == c10::kFloat8_e4m3fn) {
+    // To avoid NaN, we need to clamp the intermediate results (in fp32) to [-488, 488]
+    // before converting to fp8
+    auto post_ops = op_attr.get_post_ops();
+    post_ops.append_eltwise(dnnl::algorithm::eltwise_linear, 1.0/output_scale, 0.0);
+    post_ops.append_eltwise(dnnl::algorithm::eltwise_clip, -448.0, 448.0);
+    op_attr.set_post_ops(post_ops);
+    output_scale = 1.0f;
+  }
 
 #if IDEEP_PREREQ(3, 1, 0, 0)
   // Use oneDNN's APIs instead of prepare/compute from ideep to reduce integration overhead.

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -1012,6 +1012,12 @@ static at::Tensor fp8_qlinear_onednn_ref(
           "onednn qlinear: unsupported unary post op ", unary_post_op, " with binary post op sum");
     }
     y_f32.div_(output_scale);
+    if (x1.scalar_type() == c10::kFloat8_e4m3fn) {
+      // Avoid NaN
+      y_f32.clamp_(-448, 448);
+      // Align with oneDNN: convert fp32 to fp8 by fp32 -> fp16 -> fp8
+      y_f32 = y_f32.to(at::kHalf);
+    }
     x1.copy_(y_f32.to(x1.scalar_type()).view(x1.sizes()));
     return x1;
   } else if (binary_post_op == "add") {
@@ -1038,6 +1044,12 @@ static at::Tensor fp8_qlinear_onednn_ref(
   y_f32.div_(output_scale);
   y_f32 = y_f32.view(output_size);
   auto out_dtype = output_dtype.has_value() ? output_dtype.value() : at::kFloat8_e4m3fn;
+  if (out_dtype == at::kFloat8_e4m3fn) {
+    // Avoid NaN
+    y_f32.clamp_(-448, 448);
+    // Align with oneDNN: convert fp32 to fp8 by fp32 -> fp16 -> fp8
+    return y_f32.to(at::kHalf).to(out_dtype);
+  }
   return y_f32.to(out_dtype);
 }
 
@@ -1118,7 +1130,7 @@ static at::Tensor linear_int8_with_onednn_weight(
 #if defined(__powerpc__)
   if (is_fp8) {
 #else
-  if(is_fp8 && !cpuinfo_has_x86_amx_int8()) {
+  if(is_fp8 && !cpuinfo_has_x86_amx_fp16()) {
 #endif
     // Fall back to ref impl on old platforms because not supported
     // Transpose weight to align with behavior in oneDNN
@@ -1155,12 +1167,13 @@ static at::Tensor linear_int8_with_onednn_weight(
   }
   std::vector<int64_t> src_dims = {M, K};
   std::vector<int64_t> dst_dims = {M, N};
+  auto out_dtype = output_dtype.has_value() ? output_dtype.value() : input.scalar_type();
   at::Tensor output = binary_post_op == "sum" ?
       other.value() :
       at::empty(
         dst_dims,
         at::device(c10::kCPU)
-            .dtype(fp32_output ? c10::kFloat : (bf16_output ? c10::kBFloat16 : input.scalar_type()))
+            .dtype(out_dtype)
       );
   if (output.numel() == 0) {
     return output;
@@ -1195,6 +1208,16 @@ static at::Tensor linear_int8_with_onednn_weight(
     unary_post_op_args,
     unary_post_op_algorithm
   );
+  // Avoid NaN if output dtype is fp8
+  if (out_dtype == c10::kFloat8_e4m3fn) {
+    // To avoid NaN, we need to clamp the intermediate results (in fp32) to [-488, 488]
+    // before converting to fp8
+    auto post_ops = op_attr.get_post_ops();
+    post_ops.append_eltwise(dnnl::algorithm::eltwise_linear, 1.0/output_scale, 0.0);
+    post_ops.append_eltwise(dnnl::algorithm::eltwise_clip, -448, 448.0);
+    op_attr.set_post_ops(post_ops);
+    output_scale = 1.0f;
+  }
   if (input_scale != 1.0f) {
     op_attr.set_scales_mask(DNNL_ARG_SRC, 0);
   }

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -1014,7 +1014,7 @@ static at::Tensor fp8_qlinear_onednn_ref(
     y_f32.div_(output_scale);
     if (x1.scalar_type() == c10::kFloat8_e4m3fn) {
       // Avoid NaN
-      y_f32.clamp_(-448, 448);
+      y_f32.clamp_(-FP8E4M3_MAX, FP8E4M3_MAX);
       // Align with oneDNN: convert fp32 to fp8 by fp32 -> fp16 -> fp8
       y_f32 = y_f32.to(at::kHalf);
     }
@@ -1046,7 +1046,7 @@ static at::Tensor fp8_qlinear_onednn_ref(
   auto out_dtype = output_dtype.has_value() ? output_dtype.value() : at::kFloat8_e4m3fn;
   if (out_dtype == at::kFloat8_e4m3fn) {
     // Avoid NaN
-    y_f32.clamp_(-448, 448);
+    y_f32.clamp_(-FP8E4M3_MAX, FP8E4M3_MAX);
     // Align with oneDNN: convert fp32 to fp8 by fp32 -> fp16 -> fp8
     return y_f32.to(at::kHalf).to(out_dtype);
   }
@@ -1214,7 +1214,7 @@ static at::Tensor linear_int8_with_onednn_weight(
     // before converting to fp8
     auto post_ops = op_attr.get_post_ops();
     post_ops.append_eltwise(dnnl::algorithm::eltwise_linear, 1.0/output_scale, 0.0);
-    post_ops.append_eltwise(dnnl::algorithm::eltwise_clip, -448, 448.0);
+    post_ops.append_eltwise(dnnl::algorithm::eltwise_clip, -FP8E4M3_MAX, FP8E4M3_MAX);
     op_attr.set_post_ops(post_ops);
     output_scale = 1.0f;
   }

--- a/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
@@ -305,7 +305,7 @@ static inline at::Tensor pack_weight_to_onednn_tensor(
 #if defined(__powerpc__)
   if (is_fp8){
 #else
-  if(is_fp8 && !cpuinfo_has_x86_amx_int8()) {
+  if(is_fp8 && !cpuinfo_has_x86_amx_fp16()) {
 #endif
     // oneDNN's fp8 requires AMX support
     // If AMX is not available, fall back to reference implementation

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -166,7 +166,8 @@ def _quantize_fp8e4m3(t: torch.Tensor, channelwise: bool, scale: Optional[torch.
         scale = scale or t.abs().max().reshape([1]) / quant_max
         scale = torch.max(scale, eps) if isinstance(scale, torch.Tensor) else max(scale, eps.item())
         qt = t / scale
-    qt = qt.to(torch.float8_e4m3fn)
+    # Clamp to avoid NaN. Convert in two steps to align with fp32 -> fp16 -> fp8
+    qt = qt.clamp(-448, 448).half().to(torch.float8_e4m3fn)
     return qt, scale
 
 def _dequantize_fp8e4m3(qt: torch.Tensor, scale: torch.Tensor):
@@ -4732,7 +4733,7 @@ class TestQuantizedLinear(TestCase):
         use_bias_list = [True, False]
         weight_quant_per_channel_list = [True, False]
         output_dtype_list = [None, torch.float32, torch.bfloat16]
-        y_scale, y_zp = 0.07, 0
+        y_scale, y_zp = 0.3, 0
         input_dim_list = [2, 3]
         cases = itertools.product(
             in_channels_list, out_channels_list, use_bias_list,
@@ -4830,6 +4831,7 @@ class TestQuantizedLinear(TestCase):
 
                 self.assertEqual(x.dim(), qy.dim())
                 self.assertEqual(y_ref.float(), qy.float())
+                assert not torch.isnan(qy).any()
 
     @unittest.skipIf(IS_FBCODE, "Skip pt2e ops in fbcode")
     @skipIfNoONEDNN
@@ -7883,7 +7885,7 @@ class TestQuantizedConv(TestCase):
         strides=(),
         pads=(),
         dilations=(),
-        Y_scale=0.02,
+        Y_scale=0.002,
         use_bias=True,
         post_op=PointwisePostOp(),
         use_channelwise=True,
@@ -7960,9 +7962,7 @@ class TestQuantizedConv(TestCase):
 
         # Quantize reference results for comparison
         if qconv_output_dtype is None:
-            Y_scale_t = torch.Tensor([Y_scale]).to(device)
-            # Align with oneDNN: convert fp32 to fp8 by fp32 -> fp16 -> fp8
-            result_ref = result_ref.div(Y_scale_t).half().to(torch.float8_e4m3fn)
+            result_ref = _quantize_fp8e4m3(result_ref, False, Y_scale)[0]
         else:
             result_ref = result_ref.to(qconv_output_dtype)
 
@@ -8039,7 +8039,8 @@ class TestQuantizedConv(TestCase):
         if fp32_output or bfloat16_output:
             self.assertTrue(result.dtype == qconv_output_dtype)
 
-        assert torch.allclose(result.float(), result_ref.float(), atol=1e-6)
+        self.assertEqual(result.float(), result_ref.float(), atol=1e-6, rtol=1e-5)
+        assert not torch.isnan(result).any()
 
     def _test_qconv_fp8_helper(self, nd, pointwise_post_op):
         # nd = 1,2,3 -> conv1d/2d/3d
@@ -8154,6 +8155,7 @@ class TestQuantizedConv(TestCase):
     @skipIfNoONEDNN
     def test_qconv3d_fp8(self):
         pointwise_post_op = PointwisePostOp()
+        torch.manual_seed(0)  # For reproducibility in 3D conv tests
         self._test_qconv_fp8_helper(3, pointwise_post_op)
 
 


### PR DESCRIPTION
**Summary**
When output dtype is fp8, oneDNN does not ensure intermediate results in the range of [-448, 448] before converting to fp8. So, we may get NaN in the output, which is a disaster for inference. This PR fixes this issue by clamping the intermediate results by oneDNN's post-op clip.

**Test plan**
```
pytest -sv test/quantization/core/test_quantized_op.py -k "q and fp8"
```

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168