### PR TITLE
[BE] Disable CudaGraphTreeTests on rocm

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -40,7 +40,7 @@ from torch.testing._internal.common_utils import (
     skipIfRocm,
     TEST_CUDA_GRAPH,
 )
-from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON
+from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON_NO_ROCM
 from torch.utils._mode_utils import no_dispatch
 from torch.utils._python_dispatch import TorchDispatchMode
 
@@ -122,7 +122,7 @@ class TestCase(InductorTestCase):
         torch._dynamo.reset()
 
 
-if HAS_CUDA_AND_TRITON:
+if HAS_CUDA_AND_TRITON_NO_ROCM:
 
     def get_all_cudagraph_segments():
         segments = torch.cuda.memory_snapshot()
@@ -4351,5 +4351,5 @@ if __name__ == "__main__":
             sys.exit(0)
         raise unittest.SkipTest("cuda graph test is skipped")
 
-    if HAS_CUDA_AND_TRITON:
+    if HAS_CUDA_AND_TRITON_NO_ROCM:
         run_tests(needs="filelock")

--- a/test/inductor/test_cudagraph_trees_expandable_segments.py
+++ b/test/inductor/test_cudagraph_trees_expandable_segments.py
@@ -8,13 +8,13 @@ import sys
 import torch
 from torch.testing._internal.common_cuda import IS_JETSON, IS_WINDOWS
 from torch.testing._internal.common_utils import run_tests
-from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON
+from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON_NO_ROCM
 
 
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(pytorch_test_dir)
 
-if HAS_CUDA_AND_TRITON:
+if HAS_CUDA_AND_TRITON_NO_ROCM:
     try:
         from .test_cudagraph_trees import CudaGraphTreeTests
     except ImportError:
@@ -36,7 +36,7 @@ if __name__ == "__main__":
         torch.cuda.is_available()
         and not IS_JETSON
         and not IS_WINDOWS
-        and HAS_CUDA_AND_TRITON
+        and HAS_CUDA_AND_TRITON_NO_ROCM
     ):
         get_disabled_tests(".")
 

--- a/torch/testing/_internal/inductor_utils.py
+++ b/torch/testing/_internal/inductor_utils.py
@@ -71,6 +71,8 @@ else:
 
 HAS_CUDA_AND_TRITON = torch.cuda.is_available() and HAS_TRITON
 
+HAS_CUDA_AND_TRITON_NO_ROCM = HAS_CUDA_AND_TRITON and torch.version.hip is None
+
 HAS_XPU_AND_TRITON = torch.xpu.is_available() and HAS_TRITON
 
 HAS_MPS = torch.mps.is_available()


### PR DESCRIPTION
Summary: Disables CudaGraphTreeTests on AMD GPUs. These appear to be failing but based on the test contents shouldn't be running.

Test Plan:
Disables tests.

Rollback Plan:

Differential Revision: D80537905




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben