### PR TITLE
[dcp_poc] Fix parameter order in distributed checkpoint API to use path-first for consistency

### DIFF
--- a/test/distributed/checkpoint/_experimental/test_builder.py
+++ b/test/distributed/checkpoint/_experimental/test_builder.py
@@ -55,7 +55,7 @@ class TestMakeCheckpointer(TestCase):
 
         # Test that it works for sync operations
         checkpoint_path = os.path.join(self.temp_dir, "checkpoint_factory_sync")
-        result = checkpointer.save(self.state_dict, checkpoint_path)
+        result = checkpointer.save(checkpoint_path, self.state_dict)
         self.assertIsNone(result)  # Sync mode returns None
 
         # Verify checkpoint was created
@@ -81,7 +81,7 @@ class TestMakeCheckpointer(TestCase):
         checkpoint_path = os.path.join(
             self.temp_dir, "checkpoint_factory_sync_config_first"
         )
-        result = checkpointer.save(self.state_dict, checkpoint_path)
+        result = checkpointer.save(checkpoint_path, self.state_dict)
         self.assertIsNone(result)  # Sync mode returns None
 
         # Verify checkpoint was created
@@ -105,7 +105,7 @@ class TestMakeCheckpointer(TestCase):
         checkpoint_path = os.path.join(
             self.temp_dir, "checkpoint_factory_sync_custom_config"
         )
-        result = checkpointer.save(self.state_dict, checkpoint_path)
+        result = checkpointer.save(checkpoint_path, self.state_dict)
         self.assertIsNone(result)  # Sync mode returns None
 
         # Verify checkpoint was created
@@ -135,7 +135,7 @@ class TestMakeCheckpointer(TestCase):
             # Test that it works for async operations
             checkpoint_path = os.path.join(self.temp_dir, "checkpoint_factory_async")
             stage_future, write_future = checkpointer.save(
-                self.state_dict, checkpoint_path
+                checkpoint_path, self.state_dict
             )
 
             # Verify futures are returned

--- a/test/distributed/checkpoint/_experimental/test_checkpoint_writer.py
+++ b/test/distributed/checkpoint/_experimental/test_checkpoint_writer.py
@@ -90,7 +90,7 @@ class TestCheckpointWriter(TestCase):
         checkpoint_path = os.path.join(self.temp_dir, "checkpoint")
 
         # Call write
-        self.writer.write(self.state_dict, checkpoint_path)
+        self.writer.write(checkpoint_path, self.state_dict)
 
         # Verify that the checkpoint file exists
         expected_file_path = os.path.join(
@@ -111,7 +111,7 @@ class TestCheckpointWriter(TestCase):
         checkpoint_path = os.path.join(self.temp_dir, "checkpoint")
 
         # Call write
-        self.writer.write(self.state_dict, checkpoint_path)
+        self.writer.write(checkpoint_path, self.state_dict)
 
         # Verify that the barrier was called
         self.mock_barrier.execute_barrier.assert_called_once()
@@ -123,7 +123,7 @@ class TestCheckpointWriter(TestCase):
 
         # Call write with additional kwargs
         kwargs = {"extra": "value"}
-        self.writer.write(self.state_dict, checkpoint_path, **kwargs)
+        self.writer.write(checkpoint_path, self.state_dict, **kwargs)
 
         # Verify that the pre_commit hook was called with the correct parameters
         self.assertTrue(self.mock_hook.pre_commit_called)
@@ -157,7 +157,7 @@ class TestCheckpointWriter(TestCase):
         checkpoint_path = os.path.join(self.temp_dir, "checkpoint_no_barrier")
 
         # Call write
-        writer.write(self.state_dict, checkpoint_path)
+        writer.write(checkpoint_path, self.state_dict)
 
         # Verify that the checkpoint file exists
         expected_file_path = os.path.join(
@@ -179,7 +179,7 @@ class TestCheckpointWriter(TestCase):
         checkpoint_path = os.path.join(self.temp_dir, "checkpoint_no_hook")
 
         # Call write
-        writer.write(self.state_dict, checkpoint_path)
+        writer.write(checkpoint_path, self.state_dict)
 
         # Verify that the checkpoint file exists
         expected_file_path = os.path.join(

--- a/test/distributed/checkpoint/_experimental/test_checkpointer.py
+++ b/test/distributed/checkpoint/_experimental/test_checkpointer.py
@@ -58,7 +58,7 @@ class TestSyncCheckpointer(TestCase):
         checkpoint_path = os.path.join(self.temp_dir, "checkpoint_sync")
 
         # Save the checkpoint synchronously
-        result = self.checkpointer.save(self.state_dict, checkpoint_path)
+        result = self.checkpointer.save(checkpoint_path, self.state_dict)
         self.assertIsNone(result)  # Sync mode returns None
 
         # Verify that the checkpoint file exists
@@ -81,7 +81,7 @@ class TestSyncCheckpointer(TestCase):
         checkpoint_path = os.path.join(self.temp_dir, "checkpoint_map_location")
 
         # Save the checkpoint
-        self.checkpointer.save(self.state_dict, checkpoint_path)
+        self.checkpointer.save(checkpoint_path, self.state_dict)
 
         # Load the checkpoint with map_location='cpu'
         loaded_state_dict = self.checkpointer.load(
@@ -99,7 +99,7 @@ class TestSyncCheckpointer(TestCase):
         checkpoint_path = os.path.join(self.temp_dir, "checkpoint_partial")
 
         # Save the full checkpoint
-        self.checkpointer.save(self.state_dict, checkpoint_path)
+        self.checkpointer.save(checkpoint_path, self.state_dict)
 
         # Create a partial state dictionary with only some keys
         partial_state_dict = {
@@ -142,7 +142,7 @@ class TestSyncCheckpointer(TestCase):
             config=self.writer_config,
             rank_info=self.rank_info,
         )
-        writer.write(nested_state_dict, checkpoint_path)
+        writer.write(checkpoint_path, nested_state_dict)
 
         # Create a partial state dictionary with nested structure
         partial_state_dict = {

--- a/torch/distributed/checkpoint/_experimental/checkpoint_process.py
+++ b/torch/distributed/checkpoint/_experimental/checkpoint_process.py
@@ -185,8 +185,8 @@ class CheckpointProcess:
                     logger.info("Writing checkpoint to %s", path)
 
                     checkpoint_writer.write(
-                        state_dict=request.payload["state_dict"],
                         path=path,
+                        state_dict=request.payload["state_dict"],
                         **request.payload["kwargs"],
                     )
 

--- a/torch/distributed/checkpoint/_experimental/checkpoint_writer.py
+++ b/torch/distributed/checkpoint/_experimental/checkpoint_writer.py
@@ -94,16 +94,16 @@ class CheckpointWriter:
 
     def write(
         self,
-        state_dict: STATE_DICT,
         path: str,
+        state_dict: STATE_DICT,
         **kwargs: dict[str, Any],
     ) -> Optional[Future[None]]:
         """
         Writes the state_dict to storage.
 
         Args:
-            state_dict (STATE_DICT): The state_dict to write.
             path (str): The path to write the checkpoint to.
+            state_dict (STATE_DICT): The state_dict to write.
             **kwargs: Additional keyword arguments passed to hooks.
 
         Returns:

--- a/torch/distributed/checkpoint/_experimental/checkpointer.py
+++ b/torch/distributed/checkpoint/_experimental/checkpointer.py
@@ -35,16 +35,16 @@ class Checkpointer(abc.ABC):
     @abc.abstractmethod
     def save(
         self,
-        state_dict: STATE_DICT,
         path: str,
+        state_dict: STATE_DICT,
         **kwargs: dict[str, Any],
     ) -> Optional[tuple[Future, Future]]:
         """
         Save a state dictionary to storage.
 
         Args:
-            state_dict: The state dictionary to save.
             path: The path where the checkpoint should be saved.
+            state_dict: The state dictionary to save.
             **kwargs: Additional keyword arguments to pass to the writer.
 
         Returns:
@@ -123,26 +123,26 @@ class SyncCheckpointer(Checkpointer):
 
     def save(
         self,
-        state_dict: STATE_DICT,
         path: str,
+        state_dict: STATE_DICT,
         **kwargs: dict[str, Any],
     ) -> Optional[tuple[Future, Future]]:
         """
         Save a state dictionary to storage synchronously.
 
         Args:
-            state_dict: The state dictionary to save.
             path: The path where the checkpoint should be saved.
+            state_dict: The state dictionary to save.
             **kwargs: Additional keyword arguments to pass to the writer.
 
         Returns:
             Always returns None as operations are synchronous.
 
         Example:
-            checkpointer.save(state_dict, "/path/to/checkpoint")
+            checkpointer.save("/path/to/checkpoint", state_dict)
         """
         logger.debug("Saving checkpoint synchronously to %s", path)
-        self._writer.write(state_dict, path, **kwargs)
+        self._writer.write(path, state_dict, **kwargs)
         return None
 
     def load(
@@ -241,23 +241,23 @@ class AsyncCheckpointer(Checkpointer):
 
     def save(
         self,
-        state_dict: STATE_DICT,
         path: str,
+        state_dict: STATE_DICT,
         **kwargs: Any,
     ) -> Optional[tuple[Future, Future]]:
         """
         Save a state dictionary to storage asynchronously.
 
         Args:
-            state_dict: The state dictionary to save.
             path: The path where the checkpoint should be saved.
+            state_dict: The state dictionary to save.
             **kwargs: Additional keyword arguments to pass to the stager and writer.
 
         Returns:
             A tuple of (stage_future, write_future) representing the staging and writing operations.
 
         Example:
-            stage_future, write_future = checkpointer.save(state_dict, "/path/to/checkpoint")
+            stage_future, write_future = checkpointer.save("/path/to/checkpoint", state_dict)
             # ... do other work ...
             write_future.result()  # Wait for completion
         """


### PR DESCRIPTION
Summary: This commit standardizes the parameter order across PyTorch's experimental distributed checkpoint (DCP) API, changing all checkpoint operations from (state_dict, path) to (path, state_dict) for consistency with standard file I/O patterns.

Test Plan:
sandcastle tests

Rollback Plan:

Differential Revision: D80549014




cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta