### PR TITLE
[Optimus][decompose_mm] Fix BooleanAtom corner case

### DIFF
--- a/torch/_inductor/fx_passes/decompose_mem_bound_mm.py
+++ b/torch/_inductor/fx_passes/decompose_mem_bound_mm.py
@@ -70,9 +70,13 @@ def should_decompose_bmm(mat1, mat2) -> bool:
         if mat1.shape[0] < min_first_dimension_decomposition:
             return False
         # 2 of m, n, k must be <= MAX_OTHER_DIMENSION_DECOMPOSITION
-        if (mat1.shape[1] < max_other_dimension_decomposition) + (
-            mat1.shape[2] < max_other_dimension_decomposition
-        ) + (mat2.shape[2] < max_other_dimension_decomposition) < 2:
+        # use bool() to deal with BooleanAtom type
+        if (
+            bool(mat1.shape[1] < max_other_dimension_decomposition)
+            + bool(mat1.shape[2] < max_other_dimension_decomposition)
+            + bool(mat2.shape[2] < max_other_dimension_decomposition)
+            < 2
+        ):
             return False
         return True
     elif check_device(mat1, mat2, device="cpu"):


### PR DESCRIPTION
Summary:
We observe a case where the BooleanAtom does not support regular sum op for bool exp, thus we fix it by using bool()

Rollback Plan:

Differential Revision: D80550876




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @mlazos