### PR TITLE
[inductor] Unsafe reordering collectives; limit by runtime estimations

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -400,6 +400,9 @@ sink_waits_iterative_debug_limit_to_sink: Optional[int] = (
 reorder_iterative_swapped_gemm_like_limit: Optional[int] = None
 sink_waits_iterative_swapped_gemm_like_limit: Optional[int] = None
 
+reorder_iterative_unsafe_collectives_reorder: bool = False
+sink_waits_iterative_unsafe_collectives_reorder: bool = False
+
 bucket_all_gathers_fx: Literal["none", "all", "only_fsdp"] = "none"
 # By default torch._inductor.fx_passes.bucketing.bucket_size_determinator is used
 bucket_all_gathers_fx_bucket_size_determinator: Optional[Callable[[int], int]] = None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben

Differential Revision: [D80555971](https://our.internmc.facebook.com/intern/diff/D80555971)