### PR TITLE
docs: fix grammar in profiler_util comment (NFC)

### DIFF
--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -104,7 +104,7 @@ class EventList(list):
         # First we sort the intervals by their start time. Then we iterate over them.
         # Every time we see a new interval we remove several parents from
         # the top until we restore the invariant. Then parent child relationship
-        # if recorded if the stack is not empty.
+        # is recorded if the stack is not empty.
         # Finally we add new interval to the list
         #
         # Algorithm has O(N * log(N)) complexity where N is number of


### PR DESCRIPTION
In the _populate_cpu_children function, corrected the comment that described when the parent–child relationship is recorded.

This change fixes a grammatical error without altering code behavior. Marked as NFC (no functional change).

This is my first contribution to PyTorch. So wanted to get my foot in and start off with a simple update! Looking forward to contribute more deeper and useful changes in the future. 
