### PR TITLE
[dynamo] propagate tensor metadata on Tensor.__setitem__(tensor)

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -7141,8 +7141,6 @@ def forward(self, s77 : torch.SymInt, s27 : torch.SymInt, L_x_ : torch.Tensor):
         self.assertEqual(out_ref, out_res)
 
     def test_setitem_tensor_prop(self):
-        # https://github.com/pytorch/pytorch/issues/160901
-
         # Using the composite implicit of the forward would be incorrect
         class MyFn(torch.autograd.Function):
             @staticmethod
@@ -7171,7 +7169,7 @@ def forward(self, s77 : torch.SymInt, s27 : torch.SymInt, L_x_ : torch.Tensor):
         torch.compile(fn, backend="eager")(x2, y2).sum().backward()
         self.assertTrue(x2.requires_grad)
 
-        self.assertEqual(x1.grad, x2.grad)
+        self.assertEqual(y1.grad, y2.grad)
 
     def test_nn_parameter_ctor_graph_breaks(self):
         def fn():

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -3047,7 +3047,7 @@ def infer_subclass_type(value):
         return type(value)
 
 
-def specialized_prop(target_cls, tx, example_value, subclass_type):
+def get_specialized_props(target_cls, tx, example_value, subclass_type):
     specialized_props = target_cls.specialize(example_value)
     # TODO: not sure about this fake mode test
     if (
@@ -3084,7 +3084,7 @@ def construct_tensor_variable(
     # when lifting unbacked symbols of input tensors to subgraph inputs.
     # We do it lazily because the tensor may not be used in subgraphs.
     tx.output.current_tracer.track_unbacked_symbols(example_value, proxy)
-    options.update(specialized_prop(target_cls, tx, example_value, subclass_type))
+    options.update(get_specialized_props(target_cls, tx, example_value, subclass_type))
     return target_cls(proxy, **options)
 
 

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -2060,32 +2060,8 @@ class VariableBuilder:
             return self.tx.output.input_source_to_var[source]
 
         options = {}
-        if type(value) in (
-            torch.Tensor,
-            torch.nn.Parameter,
-            torch._subclasses.fake_tensor.FakeTensor,
-            torch._subclasses.functional_tensor.FunctionalTensor,
-        ) or is_traceable_wrapper_subclass(value):
-            # Ordinarily, we would fakeify a tensor so that it can get dynamic
-            # shapes and be computed on without triggering actual operations.
-            # However, how can we fakeify a tensor subclass?  Ordinary
-            # inheritance (nor multiple inheritance) won't work work.
-            #
-            # Instead, our plan is to *manually simulate* the tensor subclass
-            # inheriting from a fake tensor with dynamo.  This means our
-            # data representation for a tensor subclass will be a fake tensor
-            # + tensor subclass type + any extra data the subclass may have
-            # been storing on the tensor.  Because all Python accesses are
-            # mediated through TensorWithTFOverrideVariable, we can ensure
-            # that we dispatch differently, e.g., according to
-            # __torch_function__
-            #
-            # To simplify things for now, the __dict__ tracking bits haven't
-            # been implemented yet, but they can be added into this design at
-            # a later point in time.
-            subclass_type = None
-        else:
-            subclass_type = type(value)
+        subclass_type = infer_subclass_type(value)
+        if subclass_type is not None:
             self.install_guards(GuardBuilder.TYPE_MATCH)
 
         if get_static_address_type(value) == "guarded":
@@ -3042,6 +3018,55 @@ def handle_traced_output(example_value, tx, proxy, options, subclass_type, targe
         )
 
 
+def infer_subclass_type(value):
+    if type(value) in (
+        torch.Tensor,
+        torch.nn.Parameter,
+        torch._subclasses.fake_tensor.FakeTensor,
+        torch._subclasses.functional_tensor.FunctionalTensor,
+    ) or is_traceable_wrapper_subclass(value):
+        # Ordinarily, we would fakeify a tensor so that it can get dynamic
+        # shapes and be computed on without triggering actual operations.
+        # However, how can we fakeify a tensor subclass?  Ordinary
+        # inheritance (nor multiple inheritance) won't work work.
+        #
+        # Instead, our plan is to *manually simulate* the tensor subclass
+        # inheriting from a fake tensor with dynamo.  This means our
+        # data representation for a tensor subclass will be a fake tensor
+        # + tensor subclass type + any extra data the subclass may have
+        # been storing on the tensor.  Because all Python accesses are
+        # mediated through TensorWithTFOverrideVariable, we can ensure
+        # that we dispatch differently, e.g., according to
+        # __torch_function__
+        #
+        # To simplify things for now, the __dict__ tracking bits haven't
+        # been implemented yet, but they can be added into this design at
+        # a later point in time.
+        return None
+    else:
+        return type(value)
+
+
+def specialized_prop(target_cls, tx, example_value, subclass_type):
+    specialized_props = target_cls.specialize(example_value)
+    # TODO: not sure about this fake mode test
+    if (
+        isinstance(example_value, torch._subclasses.fake_tensor.FakeTensor)
+        and example_value.fake_mode is tx.fake_mode
+    ):
+        if subclass_type:
+            tensor_type = subclass_type
+        elif isinstance(example_value, torch.nn.Parameter):
+            tensor_type = torch.nn.Parameter
+        elif isinstance(example_value, torch.nn.Buffer):
+            tensor_type = torch.nn.Buffer
+        else:
+            tensor_type = torch.Tensor
+        specialized_props["class_type"] = tensor_type
+
+    return specialized_props
+
+
 def construct_tensor_variable(
     target_cls, tx, proxy, example_value, subclass_type, options
 ):
@@ -3059,23 +3084,7 @@ def construct_tensor_variable(
     # when lifting unbacked symbols of input tensors to subgraph inputs.
     # We do it lazily because the tensor may not be used in subgraphs.
     tx.output.current_tracer.track_unbacked_symbols(example_value, proxy)
-    specialized_props = target_cls.specialize(example_value)
-    # TODO: not sure about this fake mode test
-    if (
-        isinstance(example_value, torch._subclasses.fake_tensor.FakeTensor)
-        and example_value.fake_mode is tx.fake_mode
-    ):
-        if subclass_type:
-            tensor_type = subclass_type
-        elif isinstance(example_value, torch.nn.Parameter):
-            tensor_type = torch.nn.Parameter
-        elif isinstance(example_value, torch.nn.Buffer):
-            tensor_type = torch.nn.Buffer
-        else:
-            tensor_type = torch.Tensor
-        specialized_props["class_type"] = tensor_type
-
-    options.update(specialized_props)
+    options.update(specialized_prop(target_cls, tx, example_value, subclass_type))
     return target_cls(proxy, **options)
 
 

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -657,13 +657,13 @@ class AutogradFunctionVariable(VariableTracker):
     def call_apply(self, tx: "InstructionTranslator", args, kwargs):
         requires_grad = False
 
-        def visit(node):
+        def visit(vt):
             nonlocal requires_grad
-            if isinstance(node, variables.TensorVariable):
-                if node.requires_grad is not False:
+            if isinstance(vt, variables.TensorVariable):
+                if vt.requires_grad is not False:
                     requires_grad = True
-            if isinstance(node, variables.NNModuleVariable):
-                if node.is_training(tx):
+            if isinstance(vt, variables.NNModuleVariable):
+                if vt.is_training(tx):
                     requires_grad = True
 
         VariableTracker.visit(visit, (args, kwargs))

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1090,19 +1090,19 @@ class TensorVariable(VariableTracker):
             *proxy_args_kwargs([self, key, value], {}),
         )
 
-        # [Note: Tensor.__setitem__ and VariableTracker metadata]
-        # At this point, we proxied a node representing `self[key] = value` into the graph.
-        # When executed, this node will mutate `self`'s tensor metadata, so it's important
-        # even during tracing to propagate. For example:
-        #   value.requires_grad is True => self.requires_grad becomes True
-        #   value.requires_grad is True => self.has_grad_fn becomes True
-
-        # Not sure if __setitem__ can ever save activations, disabling just in case
-        with torch._dynamo.utils._disable_saved_tensors_hooks_during_tracing():
-            get_fake_value(proxy.node, tx, allow_non_graph_fake=False)
-
         target_cls = type(value)
         if isinstance(target_cls, TensorVariable):
+            # [Note: Tensor.__setitem__ and VariableTracker metadata]
+            # At this point, we proxied a node representing `self[key] = value` into the graph.
+            # When executed, this node will mutate `self`'s tensor metadata, so it's important
+            # even during tracing to propagate. For example:
+            #   value.requires_grad is True => self.requires_grad becomes True
+            #   value.requires_grad is True => self.has_grad_fn becomes True
+
+            # Not sure if __setitem__ can ever save activations, disabling just in case
+            with torch._dynamo.utils._disable_saved_tensors_hooks_during_tracing():
+                get_fake_value(proxy.node, tx, allow_non_graph_fake=False)
+
             example_value = self.proxy.node.meta.get("example_value")
             from .builder import get_specialized_props, infer_subclass_type
 

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1090,6 +1090,28 @@ class TensorVariable(VariableTracker):
             *proxy_args_kwargs([self, key, value], {}),
         )
 
+        # [Note: Tensor.__setitem__ and VariableTracker metadata]
+        # At this point, we proxied a node representing `self[key] = value` into the graph.
+        # When executed, this node will mutate `self`'s tensor metadata, so it's important
+        # even during tracing to propagate. For example:
+        #   value.requires_grad is True => self.requires_grad becomes True
+        #   value.requires_grad is True => self.has_grad_fn becomes True
+
+        # Not sure if __setitem__ can ever save activations, disabling just in case
+        with torch._dynamo.utils._disable_saved_tensors_hooks_during_tracing():
+            get_fake_value(proxy.node, tx, allow_non_graph_fake=False)
+
+        target_cls = type(value)
+        if isinstance(target_cls, TensorVariable):
+            example_value = self.proxy.node.meta.get("example_value")
+            from .builder import infer_subclass_type, specialized_prop
+
+            specialized_props = specialized_prop(
+                target_cls, tx, example_value, infer_subclass_type(example_value)
+            )
+            for k, v in specialized_props.items():
+                setattr(self, k, v)
+
         if config.use_graph_deduplication or config.track_nodes_for_deduplication:
             tx.output.region_tracker.add_node_mutation(proxy.node, 0)
 

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1104,9 +1104,9 @@ class TensorVariable(VariableTracker):
         target_cls = type(value)
         if isinstance(target_cls, TensorVariable):
             example_value = self.proxy.node.meta.get("example_value")
-            from .builder import infer_subclass_type, specialized_prop
+            from .builder import get_specialized_props, infer_subclass_type
 
-            specialized_props = specialized_prop(
+            specialized_props = get_specialized_props(
                 target_cls, tx, example_value, infer_subclass_type(example_value)
             )
             for k, v in specialized_props.items():

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1105,6 +1105,9 @@ class TensorVariable(VariableTracker):
             example_value = self.proxy.node.meta.get("example_value")
             from .builder import get_specialized_props, infer_subclass_type
 
+            if isinstance(value, variables.lazy.LazyVariableTracker):
+                value = variables.lazy.LazyVariableTracker.realize_all(value)
+
             specialized_props = get_specialized_props(
                 type(value), tx, example_value, infer_subclass_type(example_value)
             )

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1090,8 +1090,7 @@ class TensorVariable(VariableTracker):
             *proxy_args_kwargs([self, key, value], {}),
         )
 
-        target_cls = type(value)
-        if isinstance(target_cls, TensorVariable):
+        if isinstance(value, TensorVariable):
             # [Note: Tensor.__setitem__ and VariableTracker metadata]
             # At this point, we proxied a node representing `self[key] = value` into the graph.
             # When executed, this node will mutate `self`'s tensor metadata, so it's important
@@ -1107,7 +1106,7 @@ class TensorVariable(VariableTracker):
             from .builder import get_specialized_props, infer_subclass_type
 
             specialized_props = get_specialized_props(
-                target_cls, tx, example_value, infer_subclass_type(example_value)
+                type(value), tx, example_value, infer_subclass_type(example_value)
             )
             for k, v in specialized_props.items():
                 setattr(self, k, v)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #161036

Fixes silent incorrectness for autograd function tracing, where we rely on FakeTensor metadata (requires_grad) to determine whether to HOP or not: https://github.com/pytorch/pytorch/blob/5ee464db5c4293ac09521f9069fa7d2106680a7f/torch/_dynamo/variables/misc.py#L671

Stared at this with @anijain2305 yesterday, `Tensor.__setitem__` can update tensor metadata, and we can just run the fake prop and extract the output metadata from the updated FakeTensor.

FIXES https://github.com/pytorch/pytorch/issues/160901

It should also be the root cause behind the issue in https://github.com/pytorch/torchtitan/pull/1604 @bdhirsh  @ruisizhang123

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela @mlazos