### PR TITLE
Use to() instead of contiguous() to generate channels last tensor for Intel XPU

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
@@ -601,7 +601,10 @@ std::tuple<Tensor, Tensor, Tensor> convolution_backward_overrideable(
   auto mfmt = is_channels_last_suggested
       ? get_cl_tag_by_ndim(input_.ndimension())
       : at::MemoryFormat::Contiguous;
-  grad_output_ = grad_output_.contiguous(mfmt);
+  grad_output_ = grad_output_.to(mfmt);
+  if (!grad_output_.is_contiguous())
+    grad_output_ = grad_output_.contiguous(mfmt);
+
   weight_ = weight_.contiguous(mfmt);
   input_ = input_.contiguous(mfmt);
 

--- a/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
@@ -536,6 +536,19 @@ Tensor convolution_overrideable(
       Attr());
 }
 
+bool is_stride_decrease_order(Tensor &tensor) {
+  std::vector<int64_t> strides = tensor.strides().vec();
+  if (strides.size() < 2)
+    return true;
+
+  for (size_t i = 0; i < strides.size() - 1; ++i) {
+    if (strides[i] < strides[i + 1])
+      return false;
+  }
+
+  return true;
+}
+
 std::tuple<Tensor, Tensor, Tensor> convolution_backward_overrideable(
     const Tensor& grad_output,
     const Tensor& input,
@@ -601,7 +614,11 @@ std::tuple<Tensor, Tensor, Tensor> convolution_backward_overrideable(
   auto mfmt = is_channels_last_suggested
       ? get_cl_tag_by_ndim(input_.ndimension())
       : at::MemoryFormat::Contiguous;
-  grad_output_ = grad_output_.to(mfmt);
+
+
+  if (!is_stride_decrease_order(grad_output_))
+    grad_output_ = grad_output_.to(mfmt);
+
   if (!grad_output_.is_contiguous())
     grad_output_ = grad_output_.contiguous(mfmt);
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/95693 for Intel XPU case.

In same cases of Conv Backward, the output grad tensor's stride will be abnormal format.
Like output_grad.shape = torch.Size([1, 1, 2, 2])
Normal stride: [4, 4, 2, 1]
Abnormal stride: [4, 1, 2, 1]

That will lead to the wrong result of conv backward for Intel XPU.

Solution:
- Refer to the solution of https://github.com/pytorch/pytorch/pull/96791, use to() to correct the stride for channel last case.
Note: to() can't replace the contiguous() to make the tensor weights are contiguous. Refer to https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/cudnn/ConvShared.cpp#L772
 
- Add unit test case.

This PR is rebased on old PR https://github.com/pytorch/pytorch/pull/160606 with more review comments.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @gujinghui @EikanWang @fengyuan14 @guangyey