### PR TITLE
[pytorch] Faster and safer lambda expression capture in `has_integral_tensor()`

### DIFF
--- a/aten/src/ATen/native/ForeachUtils.h
+++ b/aten/src/ATen/native/ForeachUtils.h
@@ -22,7 +22,7 @@ namespace {
 // Check if tensor list has either a boolean tensor or a integer tensor
 inline bool has_integral_tensor(TensorList tensors, const bool includeBool) {
   return std::any_of(
-      tensors.begin(), tensors.end(), [&includeBool](const auto& t) {
+      tensors.begin(), tensors.end(), [includeBool](const auto& t) {
         return at::isIntegralType(t.scalar_type(), includeBool);
       });
 }


### PR DESCRIPTION
Summary: Because `includeBool` is already a small value type (i.e., `bool`, 1 byte) that's passed by value to the function. Capturing by reference (4 or 8 bytes depending on the system) is unnecessary and could potentially lead to dangling reference issues if the lambda outlives the original variable. Capturing by value is more efficient for small types and safer.

Test Plan:
OSS CI & tests

Rollback Plan:

Differential Revision: D80595698


