### PR TITLE
Add `_weight_fp8pack_mm` for A16W8 support

### DIFF
--- a/aten/src/ATen/BlasBackend.h
+++ b/aten/src/ATen/BlasBackend.h
@@ -37,6 +37,7 @@ enum class ScalingType : std::uint8_t {
   BlockWise1x32, // fp8_e8m0fnu scales
   BlockWise1x128, // fp32 scales
   BlockWise128x128, // fp32 scales
+  ChannelWise, // fp32 scales
 };
 
 enum class SwizzleType : std::uint8_t { NO_SWIZZLE = 0, SWIZZLE_32_4_4 = 1 };

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4287,6 +4287,12 @@
     MPS: _weight_int8pack_mm_mps
     XPU: _weight_int8pack_mm_xpu
 
+# Currently, we don't have fp8 pack, but we wish to align the name with int8
+# So that it is easier for the user to understand the API for WoQ case.
+- func: _weight_fp8pack_mm(Tensor self, Tensor mat2, Tensor? scales) -> Tensor
+  dispatch:
+    XPU: _weight_fp8pack_mm_xpu
+
 - func: _sparse_mm(Tensor sparse, Tensor dense) -> Tensor
   python_module: sparse
 

--- a/aten/src/ATen/xpu/XPUScaledBlas.cpp
+++ b/aten/src/ATen/xpu/XPUScaledBlas.cpp
@@ -119,4 +119,62 @@ bool check_rowwise_recipe(
   return true;
 }
 
+/**
+ * A must be fp16/bf16, B must be fp8,
+ * A needs no scale (implicitly 1.0), B needs a single scale {Tensorwise (float)}
+ */
+bool check_a16w8_tensorwise_recipe(
+    c10::ScalarType type_a,
+    c10::ScalarType type_b,
+    std::vector<ScalingType>& recipe_b,
+    ArrayRef<Tensor>& scales_b) {
+  // A must be fp16 or bf16, B must be fp8
+  if ((type_a != ScalarType::Half && type_a != ScalarType::BFloat16) ||
+      !isFloat8Type(type_b)) {
+    return false;
+  }
+
+  // B should have 1 scale {Tensorwise, float}
+  if (scales_b.size() != 1 || recipe_b.size() != 1) {
+    return false;
+  }
+  
+  // B uses Tensorwise with float scale
+  if (recipe_b[0] != ScalingType::TensorWise)
+    return false;
+  if (scales_b[0].scalar_type() != ScalarType::Float)
+    return false;
+
+  return true;
+}
+
+/**
+ * A must be fp16/bf16, B must be fp8,
+ * A needs no scale (implicitly 1.0), B needs a rowwise scale {RowWise (float)}
+ */
+bool check_a16w8_rowwise_recipe(
+    c10::ScalarType type_a,
+    c10::ScalarType type_b,
+    std::vector<ScalingType>& recipe_b,
+    ArrayRef<Tensor>& scales_b) {
+  // A must be fp16 or bf16, B must be fp8
+  if ((type_a != ScalarType::Half && type_a != ScalarType::BFloat16) ||
+      !isFloat8Type(type_b)) {
+    return false;
+  }
+
+  // B should have 1 scale {Rowwise, float}
+  if (scales_b.size() != 1 || recipe_b.size() != 1) {
+    return false;
+  }
+  
+  // B uses Rowwise with float scale
+  if (recipe_b[0] != ScalingType::RowWise)
+    return false;
+  if (scales_b[0].scalar_type() != ScalarType::Float)
+    return false;
+
+  return true;
+}
+
 } // namespace at::native::onednn::scaled

--- a/aten/src/ATen/xpu/XPUScaledBlas.h
+++ b/aten/src/ATen/xpu/XPUScaledBlas.h
@@ -59,6 +59,8 @@ enum class ScaledGemmImplementation {
   NONE = 0,
   TENSORWISE_TENSORWISE = 1,
   ROWWISE_ROWWISE = 2,
+  A16W8_TENSORWISE = 3,
+  A16W8_ROWWISE = 4,
 };
 
 /**
@@ -88,6 +90,18 @@ bool check_rowwise_recipe(
     c10::ScalarType,
     std::vector<ScalingType>&,
     ArrayRef<Tensor>&,
+    c10::ScalarType,
+    std::vector<ScalingType>&,
+    ArrayRef<Tensor>&);
+
+bool check_a16w8_tensorwise_recipe(
+    c10::ScalarType,
+    c10::ScalarType,
+    std::vector<ScalingType>&,
+    ArrayRef<Tensor>&);
+
+bool check_a16w8_rowwise_recipe(
+    c10::ScalarType,
     c10::ScalarType,
     std::vector<ScalingType>&,
     ArrayRef<Tensor>&);

--- a/aten/src/ATen/xpu/XPUScaledBlas.h
+++ b/aten/src/ATen/xpu/XPUScaledBlas.h
@@ -61,6 +61,7 @@ enum class ScaledGemmImplementation {
   ROWWISE_ROWWISE = 2,
   A16W8_TENSORWISE = 3,
   A16W8_ROWWISE = 4,
+  A16W8_CHANNELWISE = 5,
 };
 
 /**
@@ -101,6 +102,12 @@ bool check_a16w8_tensorwise_recipe(
     ArrayRef<Tensor>&);
 
 bool check_a16w8_rowwise_recipe(
+    c10::ScalarType,
+    c10::ScalarType,
+    std::vector<ScalingType>&,
+    ArrayRef<Tensor>&);
+
+bool check_a16w8_channelwise_recipe(
     c10::ScalarType,
     c10::ScalarType,
     std::vector<ScalingType>&,

--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -656,6 +656,7 @@ aten::_validate_compressed_sparse_indices
 aten::_values
 aten::_values_copy
 aten::_values_copy.out
+aten::_weight_fp8pack_mm
 aten::_weight_int4pack_mm
 aten::_weight_int4pack_mm_for_cpu
 aten::_weight_int4pack_mm_with_scales_and_zeros

--- a/test/xpu/test_gemm.py
+++ b/test/xpu/test_gemm.py
@@ -1494,9 +1494,143 @@ def forward(self, x_1, w_1):
 
         mean_err = ((res - ref).abs() / ref).mean()
         self.assertTrue(mean_err < 0.05)
+# ======== Utilis functions for TestFP8MatMul ========
+# [TODO: stonepia] These functions are ported from the scaled_mm, and they will be removed once
+# scaled_mm PR is merged.
+
+e4m3_type = torch.float8_e4m3fn
+e5m2_type = torch.float8_e5m2
+E4M3_MAX_POS = torch.finfo(torch.float8_e4m3fn).max
+E5M2_MAX_POS = torch.finfo(torch.float8_e5m2).max
+
+# avoid division by zero when calculating scale
+EPS = 1e-12
+
+
+def amax_to_scale(
+    amax: torch.Tensor, float8_dtype: torch.dtype, orig_dtype: torch.dtype
+):
+    """Converts the amax value of a tensor to the fp8 scale.
+    Args:
+        amax: The amax value of the tensor.
+        float8_dtype: the float8 dtype.
+        orig_dtype: The original dtype of the tensor.
+    """
+    scale = torch.empty_like(amax, dtype=torch.float32)
+    if float8_dtype == e4m3_type:
+        res = E4M3_MAX_POS / torch.clamp(amax, min=EPS)
+    elif float8_dtype == e5m2_type:
+        res = E5M2_MAX_POS / torch.clamp(amax, min=EPS)
+    else:
+        raise ValueError(f"Unsupported float8_dtype: {float8_dtype}")
+
+    # Ensure the scale is representable in float16,
+    # this helps when amax is small. We are assuming that we don't need
+    # to care about this for float32/bfloat16
+    if orig_dtype is torch.float16:
+        res = torch.clamp(res, max=torch.finfo(torch.float16).max)
+
+    scale.copy_(res)
+    return scale
+
+
+def tensor_to_scale(x: torch.Tensor, float8_dtype: torch.dtype, dim=None):
+    if dim is None:
+        amax = torch.max(torch.abs(x))
+    else:
+        amax = torch.max(torch.abs(x), dim=dim, keepdim=True).values
+
+    return amax_to_scale(amax, float8_dtype, x.dtype)
+
+
+def weight_float8_mm_emulated(x, y, y_scale) -> torch.Tensor:
+    # naive implementation: dq -> op -> q
+    x_fp32 = x.to(torch.float)
+    y_fp32 = y.to(torch.float) / y_scale
+    out_fp32 = torch.mm(x_fp32, y_fp32)
+
+    return out_fp32.to(x.dtype)
+
+
+def weight_float8_mm(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    b_scale: torch.Tensor,
+) -> torch.Tensor:
+    b_inverse_scale = b_scale.reciprocal()
+    return torch._weight_fp8pack_mm(a, b, b_inverse_scale)
+
+
+def compute_error(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    """Computes the error between two tensors in dB.
+
+    For more details see:
+        https://en.wikipedia.org/wiki/Signal-to-noise_ratio
+
+    Args:
+        x: The original tensor.
+        y: The tensor to compare to the original tensor.
+    """
+    Ps = torch.norm(x)
+    Pn = torch.norm(x - y)
+    return 20 * torch.log10(Ps / Pn)
+
+
+def to_fp8_saturated(x: torch.Tensor, fp8_dtype: torch.dtype):
+    if fp8_dtype == e4m3_type:
+        x = x.clamp(min=-1 * E4M3_MAX_POS, max=E4M3_MAX_POS)
+    elif fp8_dtype == e5m2_type:
+        x = x.clamp(min=-1 * E5M2_MAX_POS, max=E5M2_MAX_POS)
+    else:
+        raise ValueError(f"to_fp8_saturated(): Unsupported fp8_dtype: {fp8_dtype}")
+
+    return x.to(fp8_dtype)
+
+
+class TestFP8MatMul(TestCase):
+    @parametrize("m", [128])
+    @parametrize("k", [512, 1024])
+    @parametrize("n", [512, 1024])
+    @parametrize("a_dtype", [torch.float16, torch.bfloat16])
+    @parametrize("w_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
+    @parametrize("scales", [torch.tensor(1.0)])
+    def test__weight_fp8pack_mm_basics(
+        self, m, k, n, a_dtype, w_dtype, scales, device="xpu"
+    ):
+        torch.manual_seed(1)
+        a = torch.rand((m, k), dtype=a_dtype, device=device)
+        w_ref = torch.rand((k, n), dtype=a_dtype, device=device)
+        w = w_ref.to(w_dtype)
+
+        ref = torch.mm(a, w_ref)
+        scales = scales.to(device)
+        res = torch._weight_fp8pack_mm(a, w, scales)
+
+        mean_err = ((res - ref).abs() / ref).mean()
+        self.assertTrue(mean_err.cpu() < 0.05)
+
+    @parametrize("a_dtype", [torch.float16, torch.bfloat16])
+    @parametrize("w_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
+    def test__weight_fp8pack_mm_vs_emulated(self, a_dtype, w_dtype, device="xpu"):
+        torch.manual_seed(42)
+        a = torch.rand((16, 16), dtype=a_dtype, device=device)
+        w = torch.rand((16, 32), dtype=a_dtype, device=device)
+        scales = tensor_to_scale(w, w_dtype).float()
+
+        w_fp8 = to_fp8_saturated(w * scales, w_dtype)
+        res_actual = weight_float8_mm(a, w_fp8, scales)
+        res_emulated = weight_float8_mm_emulated(a, w_fp8, scales)
+
+        if a_dtype in {torch.bfloat16, torch.float16}:
+            atol, rtol = 7e-2, 7e-2
+        else:
+            atol, rtol = 3e-3, 3e-3
+        torch.testing.assert_close(res_actual, res_emulated, atol=atol, rtol=rtol)
+
 
 
 instantiate_device_type_tests(TestBasicGEMM, globals(), only_for="xpu", allow_xpu=True)
+instantiate_device_type_tests(TestFP8MatMul, globals(), only_for="xpu", allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
This PR adds the `_weight_fp8pack_mm` op for A16W8 matmul, so that supports linear op for woq use case.

For implementation detail, It is based on the API call of `scaled_mm_v2`, it only adds the dispatch logic for the `scaled_mm_v2`.


## Motivation
1. The main purpose is to natively support the A16W8 quantization.

For libraries like torchao, the FP8 WeightOnlyQuantization current implement is not efficient. It requires dequantize the weight first and call `linear()` in FP16/BF16 manner. See [float8_tensor.py linear impl](https://github.com/pytorch/ao/blob/df7bf3780735cc4895136c1b2aef06d50037f186/torchao/quantization/quantize_/workflows/float8/float8_tensor.py#L327-L335) for example.

With this Op added in PyTorch, the FP8 linear op could be directly called in an efficient way.

```diff
- out =  torch.nn.functional.linear(input_tensor, weight_tensor.dequantize())
+ out = torch._weight_fp8_mm(input_tensor, weight_tensor.qdata, weight_tensor.scale)
```

2. Another reason is, PyTorch has quant related API like `int4pack_mm` and `int8pack_mm`. Since FP8 quantization is also a very common use case, we also need to add the related API.
3. Thirdly, we would also want to based on the implementation of `scaled_mm` for more widely mm support. Because the activation doesn't need to be scaled, so the `scaled_mm(a, b, scale_a, scale_b)` could be simplified to a `_weight_fp8pack_mm(a, b, scale_b)`, this will give user more flexibility.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @gujinghui @EikanWang @fengyuan14 @guangyey