### PR TITLE
[ONNX] Fix lower opset version support in dynamo=True

### DIFF
--- a/test/onnx/exporter/test_api.py
+++ b/test/onnx/exporter/test_api.py
@@ -29,10 +29,8 @@ class SampleModelTwoInputs(torch.nn.Module):
 
 
 class SampleModelReduction(torch.nn.Module):
-    def forward(self, x, b):
-        y = x + b
-        z = y.sum()
-        return z
+    def forward(self, x):
+        return x.sum()
 
 
 class SampleModelForDynamicShapes(torch.nn.Module):

--- a/test/onnx/exporter/test_api.py
+++ b/test/onnx/exporter/test_api.py
@@ -28,6 +28,13 @@ class SampleModelTwoInputs(torch.nn.Module):
         return (y, z)
 
 
+class SampleModelReduction(torch.nn.Module):
+    def forward(self, x, b):
+        y = x + b
+        z = y.sum()
+        return z
+
+
 class SampleModelForDynamicShapes(torch.nn.Module):
     def forward(self, x, b):
         return x.relu(), b.sigmoid()
@@ -65,12 +72,25 @@ class TestExportAPIDynamo(common_utils.TestCase):
         )
         assert onnx_program is not None
         onnx_testing.assert_onnx_program(onnx_program, strategy=strategy)
+        return onnx_program
 
     def test_args_normalization_with_no_kwargs(self):
         self.assert_export(
             SampleModelTwoInputs(),
             (torch.randn(1, 1, 2), torch.randn(1, 1, 2)),
         )
+
+    def test_lower_opset_support(self):
+        # First test that opset 18 (torchlib opset works)
+        onnx_program = self.assert_export(
+            SampleModelReduction(), (torch.randn(1, 1, 2),), opset_version=18
+        )
+        self.assertEqual(onnx_program.model.opset_imports[""], 18)
+
+        onnx_program = self.assert_export(
+            SampleModelReduction(), (torch.randn(1, 1, 2),), opset_version=16
+        )
+        self.assertEqual(onnx_program.model.opset_imports[""], 16)
 
     def test_symbolic_argument_user_input_is_supported_by_report_and_call(self):
         class constant_plus_tensor_inputs(torch.nn.Module):

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -166,7 +166,10 @@ def export(
         output_names: names to assign to the output nodes of the graph, in order.
         opset_version: The version of the
             `default (ai.onnx) opset <https://github.com/onnx/onnx/blob/master/docs/Operators.md>`_
-            to target. Must be >= 7.
+            to target. You should set ``opset_version`` according to the supported opset versions
+            of the runtime backend or compiler you want to run the exported model with.
+            Leave as default (``None``) to use the recommended version, or refer to
+            the ONNX operators documentation for more information.
         dynamic_axes:
 
             By default the exported model will have the shapes of all input and output tensors

--- a/torch/onnx/_internal/exporter/_compat.py
+++ b/torch/onnx/_internal/exporter/_compat.py
@@ -13,11 +13,11 @@ import torch
 from torch.onnx import _constants as onnx_constants
 from torch.onnx._internal._lazy_import import onnxscript_apis, onnxscript_ir as ir
 from torch.onnx._internal.exporter import (
+    _constants,
     _core,
     _dynamic_shapes,
     _onnx_program,
     _registration,
-    _constants,
 )
 
 

--- a/torch/onnx/_internal/exporter/_compat.py
+++ b/torch/onnx/_internal/exporter/_compat.py
@@ -115,9 +115,11 @@ def export_compat(
             "the requested opset_version %s is a lower version than we have implementations for. "
             "Automatic version conversion will be performed, which may not be successful "
             "at converting to the requested version. If version conversion is unsuccessful, "
-            "the opset version of the exported model will be kept at %s",
+            "the opset version of the exported model will be kept at %s. "
+            "Please consider setting opset_version >=%s to leverage latest ONNX features",
             _constants.TORCHLIB_OPSET,
             opset_version,
+            _constants.TORCHLIB_OPSET,
             _constants.TORCHLIB_OPSET,
         )
         registry_opset_version = _constants.TORCHLIB_OPSET

--- a/torch/onnx/_internal/exporter/_compat.py
+++ b/torch/onnx/_internal/exporter/_compat.py
@@ -110,11 +110,15 @@ def export_compat(
     )
 
     if opset_version < _constants.TORCHLIB_OPSET:
-        logger.info(
-            "Setting torchlib registry to %s to use the torchlib opset version because "
-            "the requested opset_version %s is a lower version. Version conversion will be done after export",
+        logger.warning(
+            "Setting ONNX exporter to use operator set version %s because "
+            "the requested opset_version %s is a lower version than we have implementations for. "
+            "Automatic version conversion will be performed, which may not be successful "
+            "at converting to the requested version. If version conversion is unsuccessful, "
+            "the opset version of the exported model will be kept at %s",
             _constants.TORCHLIB_OPSET,
             opset_version,
+            _constants.TORCHLIB_OPSET,
         )
         registry_opset_version = _constants.TORCHLIB_OPSET
     else:


### PR DESCRIPTION
After we switched to constructing the registry with the specified opset version in dynamo=True, support for opset<18 was broken because there would be no torchlib ops registered for these opsets. I updated the registry creation logic to always use opset 18 if the requested opset is lower, and use the version converter (as designed) to target those opsets.

This requires onnxscript>=0.4 (https://github.com/pytorch/pytorch/pull/161312)

Fixes https://github.com/onnx/onnx/issues/7235

cc @titaiwangms