### PR TITLE
Fix torchaudio build when TORCH_CUDA_ARCH_LIST is not set

### DIFF
--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -152,7 +152,9 @@ function get_pinned_commit() {
 function install_torchaudio() {
   local commit
   commit=$(get_pinned_commit audio)
-  if [[ "${BUILD_ENVIRONMENT}" == *cuda* ]] && [[ "${TORCH_CUDA_ARCH_LIST:-}" == "" ]]; then
+  # TODO (huydhn): PyTorch CI docker image set the default TORCH_CUDA_ARCH_LIST
+  # to Maxwell. This default doesn't make sense anymore and should be cleaned up
+  if [[ "${BUILD_ENVIRONMENT}" == *cuda* ]]; then
     TORCH_CUDA_ARCH_LIST=$(nvidia-smi --query-gpu=compute_cap --format=csv | tail -n 1)
     export TORCH_CUDA_ARCH_LIST
   fi

--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -152,6 +152,10 @@ function get_pinned_commit() {
 function install_torchaudio() {
   local commit
   commit=$(get_pinned_commit audio)
+  if [[ "${BUILD_ENVIRONMENT}" == *cuda* ]] && [[ "${TORCH_CUDA_ARCH_LIST:-}" == "" ]]; then
+    TORCH_CUDA_ARCH_LIST=$(nvidia-smi --query-gpu=compute_cap --format=csv | tail -n 1)
+    export TORCH_CUDA_ARCH_LIST
+  fi
   pip_build_and_install "git+https://github.com/pytorch/audio.git@${commit}" dist/audio
 }
 

--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -154,7 +154,7 @@ function install_torchaudio() {
   commit=$(get_pinned_commit audio)
   # TODO (huydhn): PyTorch CI docker image set the default TORCH_CUDA_ARCH_LIST
   # to Maxwell. This default doesn't make sense anymore and should be cleaned up
-  if [[ "${BUILD_ENVIRONMENT}" == *cuda* ]]; then
+  if [[ "${BUILD_ENVIRONMENT}" == *cuda* ]] && command -v nvidia-smi; then
     TORCH_CUDA_ARCH_LIST=$(nvidia-smi --query-gpu=compute_cap --format=csv | tail -n 1)
     export TORCH_CUDA_ARCH_LIST
   fi


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/160988.  The root cause can be found in the same issue.  This fix ensures that when reuse old wheel is on and `torchaudio` wheel is not there, the inductor test job can still rebuild the wheel it needs