### PR TITLE
[DRAFT] Remove dynamo export output frgile handling

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -406,6 +406,24 @@ def forward(self, x, y):
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
+    def test_fallthrough(self):
+        def func(x):
+            y = x + 1
+            return x, y
+
+        inp = torch.tensor([0.1, 0.1])
+        opt_func = torch.compile(func, backend="eager", fullgraph=True, dynamic=True)
+        real_result = opt_func(inp)
+
+        torch._dynamo.reset()
+
+        exported = torch._dynamo.export(func)(inp)
+        out_graph = exported[0]
+
+        dynamo_result = out_graph(inp)
+
+        self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
+        
     def test_dupes_2(self):
         inp = torch.tensor([0.1, 0.1])
 

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -309,7 +309,7 @@ def forward(self, x):
                 # Along with tensor output, return Nonetype
                 # and constant. Although these outputs aren't
                 # very useful, they do show up in graphs.
-                return x + 1, None, 1024
+                return None, x + 1, 1024
 
         # Check that module can be roundtripped, thereby confirming proper deserialization.
         inp = (torch.ones(10),)

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1397,7 +1397,8 @@ class FlattenInputOutputSignature(torch.fx.Transformer):
                     assert isinstance(self.flat_results[i], tuple(common_constant_types))
                     new_results_flat.append(self.flat_results[i])
             return super().output(target, (new_results_flat,), {})
-
+        
+        breakpoint()
         assert self.graph_output_metadata["num_leaves"] == len(self.flat_results)
         new_results_flat = [None for i in range(len(self.flat_results))]
 

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1466,12 +1466,10 @@ class OutputGraph(OutputGraphGuardsState):
                 tempvars=tempvars,
                 overridden_sources=overridden_sources,
             )
-            self.codegen_suffix(tx, pre_stack_values_flat, pass2)
             if root_stack_values:
-                pass2.record_return_map = True
-                pass2._leaf_idx = 0
-                self.codegen_suffix(tx, root_stack_values, pass2)
-                pass2.record_return_map = False
+                self.codegen_suffix(tx, pre_stack_values_flat + root_stack_values, pass2, return_vt=root_stack_values[0])
+            else:
+                self.codegen_suffix(tx, pre_stack_values_flat + root_stack_values, pass2)
 
             return_map = {
                 "num_leaves": pass2._leaf_idx,
@@ -1549,10 +1547,11 @@ class OutputGraph(OutputGraphGuardsState):
         tx: "InstructionTranslatorBase",
         stack_values: list[VariableTracker],
         cg: PyCodegen,
+        return_vt: Optional[VariableTracker] = None
     ) -> None:
         # NOTE: `codegen_save_tempvars` must run first to update `source` fields
         # for variables with `AttributeMutationNew`, as they don't implement
-        # `reconstruct` themselves.
+        # `reconstruct` themselves
         self.side_effects.codegen_save_tempvars(cg)
         if self.backward_state:
             assert not self.export
@@ -1561,7 +1560,8 @@ class OutputGraph(OutputGraphGuardsState):
                 assert self.backward_state_var is not None
                 cg.append_output(cg.create_load(self.backward_state_var))
                 cg.store_attr(name)
-        self.side_effects.codegen_hooks(cg)
+        with cg.disable_record_return_leaves():
+            self.side_effects.codegen_hooks(cg)
 
         # Return variables used for logging at the end
         for debug_var, args in tx.debug_locals:
@@ -1571,8 +1571,9 @@ class OutputGraph(OutputGraphGuardsState):
             cg.extend_output(create_call_function(len(args), False))
             cg.extend_output([create_instruction("POP_TOP")])
 
-        cg.restore_stack(stack_values, value_from_source=not tx.export)
-        self.side_effects.codegen_update_mutated(cg)
+        cg.restore_stack(stack_values, value_from_source=not tx.export, return_vt=return_vt)
+        with cg.disable_record_return_leaves():
+            self.side_effects.codegen_update_mutated(cg)
 
     def cleanup_graph(self) -> None:
         """

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1210,6 +1210,8 @@ class OutputGraph(OutputGraphGuardsState):
             variables.LazyVariableTracker.realize_all(value)
             # ignore top `stack_pops` values on the stack
             if len(tx.stack) - i <= stack_pops:
+                if "UserFunction" in str(value):
+                    breakpoint()
                 stack_values.append(value)
                 continue
             if isinstance(value, NullVariable):
@@ -1263,6 +1265,7 @@ class OutputGraph(OutputGraphGuardsState):
                 val_to_names[v] = []
             val_to_names[v].append(k)
         for v in val_to_names.keys():
+            print("VVV", v)
             restore_vars.extend(val_to_names[v])
             stack_values.extend([v] * len(val_to_names[v]))
 
@@ -1470,6 +1473,23 @@ class OutputGraph(OutputGraphGuardsState):
                 self.codegen_suffix(tx, pre_stack_values_flat + root_stack_values, pass2, return_vt=root_stack_values[0])
             else:
                 self.codegen_suffix(tx, pre_stack_values_flat + root_stack_values, pass2)
+
+            breakpoint()
+
+            # assert len(root_stack_values) == 1
+            # fx_graph_outputs = pass2.graph_outputs
+            # breakpoint()
+            # proxy_ids = list(fx_graph_outputs.keys())
+            # for idx, out_vt in enumerate(root_stack_values[0].items):
+            #     if out_vt.source is not None:
+            #         # Must be an input
+            #         print("-----> Output", idx, out_vt.source.name())
+            #     elif isinstance(out_vt, variables.TensorVariable) and id(out_vt.proxy) in proxy_ids:
+            #         print("-----> Output", idx, proxy_ids.index(id(out_vt.proxy)))
+            #     elif isinstance(out_vt, variables.ConstantVariable):
+            #         print("-----> Output", idx, " constant value", out_vt.value)
+            #     else:
+            #         raise NotImplementedError("Where is this output coming from?")
 
             return_map = {
                 "num_leaves": pass2._leaf_idx,

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1462,6 +1462,8 @@ class InstructionTranslatorBase(
         assert val is None or isinstance(val, VariableTracker), (
             f"push expects VariableTracker, got {typestr(val)}"
         )
+        if "UserFunction" in str(val):
+            breakpoint()
         self.stack.append(val)  # type: ignore[arg-type]
 
     def push_many(self, vals: list[VariableTracker]) -> None:

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -3397,6 +3397,7 @@ MOD_INLINELIST = [
     "torch._dynamo.compiled_autograd",
     "torch._dynamo.comptime",
     "torch._dynamo.polyfills",
+    "torch._export.utils",
     "torch._functorch._aot_autograd.subclass_parametrization",
     "torch._functorch.autograd_function",
     "torch._functorch.eager_transforms",

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -316,7 +316,9 @@ class ConstDictVariable(VariableTracker):
             # We can safely call realize() here as it won't introduce any new guards
             item = self.original_items.get(key.vt)
             if self.is_new_item(item, value) or self.should_reconstruct_all:
-                with codegen.suppress_return_leaves():
+                # When we reconstruct return values to dict, key is always the context 
+                # so it is never returned. But we do need to codegen it.
+                with codegen.disable_record_return_leaves():
                     codegen(key.vt)
                 codegen(value)
                 num_args += 1

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -316,7 +316,8 @@ class ConstDictVariable(VariableTracker):
             # We can safely call realize() here as it won't introduce any new guards
             item = self.original_items.get(key.vt)
             if self.is_new_item(item, value) or self.should_reconstruct_all:
-                codegen(key.vt)
+                with codegen.suppress_return_leaves():
+                    codegen(key.vt)
                 codegen(value)
                 num_args += 1
         codegen.append_output(create_instruction("BUILD_MAP", arg=num_args))

--- a/torch/_functorch/predispatch.py
+++ b/torch/_functorch/predispatch.py
@@ -1,0 +1,158 @@
+# mypy: ignore-errors
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+This module contains pre-dispatch wrappers for functorch operations
+that enable proper tracing in PT2 non-strict export/compile fx graph.
+"""
+
+import torch
+from torch._C._functorch import (
+    _add_batch_dim as _add_batch_dim_impl,
+    _remove_batch_dim as _remove_batch_dim_impl,
+    _vmap_decrement_nesting as _vmap_decrement_nesting_impl,
+    _vmap_increment_nesting as _vmap_increment_nesting_impl,
+)
+
+
+def _add_batch_dim(self, batch_dim, level):
+    """
+    Thin wrapper around torch._C._add_batch_dim that is used to proxy in
+    PT2 export/compile fx graph
+    """
+    from torch._export.utils import _maybe_find_pre_dispatch_tf_mode_for_export
+
+    mode = _maybe_find_pre_dispatch_tf_mode_for_export()
+
+    if mode:
+        return torch.overrides.handle_torch_function(
+            _add_batch_dim, (self,), self, batch_dim, level
+        )
+
+    res = _add_batch_dim_impl(self, batch_dim, level)
+    return res
+
+
+def _remove_batch_dim(self, level, batch_size, out_dim):
+    """
+    Thin wrapper around torch._C._remove_batch_dim that is used to proxy in
+    PT2 export/compile fx graph
+    """
+    from torch._export.utils import _maybe_find_pre_dispatch_tf_mode_for_export
+
+    mode = _maybe_find_pre_dispatch_tf_mode_for_export()
+
+    if mode:
+        return torch.overrides.handle_torch_function(
+            _remove_batch_dim, (self,), self, level, batch_size, out_dim
+        )
+
+    res = _remove_batch_dim_impl(self, level, batch_size, out_dim)
+    return res
+
+
+def _vmap_increment_nesting(batch_size, randomness):
+    """
+    Thin wrapper around torch._C._vmap_increment_nesting that is used
+    to proxy in export/compile graph
+    """
+    from torch._export.utils import _maybe_find_pre_dispatch_tf_mode_for_export
+
+    mode = _maybe_find_pre_dispatch_tf_mode_for_export()
+
+    if mode:
+        return torch.overrides.handle_torch_function(
+            _vmap_increment_nesting, (batch_size,), batch_size, randomness
+        )
+    res = _vmap_increment_nesting_impl(batch_size, randomness)
+    return res
+
+
+def _vmap_decrement_nesting():
+    """
+    Thin wrapper around torch._C._vmap_increment_nesting that is used
+    to proxy in export/compile graph
+    """
+    from torch._export.utils import _maybe_find_pre_dispatch_tf_mode_for_export
+
+    mode = _maybe_find_pre_dispatch_tf_mode_for_export()
+
+    if mode:
+        return torch.overrides.handle_torch_function(
+            _vmap_decrement_nesting,
+            (),
+        )
+    return _vmap_decrement_nesting_impl()
+
+
+# Global variables for lazy_load_decompositions
+DECOMPOSITIONS_LOADED = False
+DECOMPOSITIONS_LOCK = None  # Will be initialized when needed
+VMAP_DECOMPOSITIONS_LIB = None
+
+
+def lazy_load_decompositions():
+    """
+    Lazy loading of vmap decompositions with pre-dispatch support.
+    """
+    from torch._export.utils import _maybe_find_pre_dispatch_tf_mode_for_export
+
+    mode = _maybe_find_pre_dispatch_tf_mode_for_export()
+
+    if mode:
+        return torch.overrides.handle_torch_function(lazy_load_decompositions, ())
+
+    global DECOMPOSITIONS_LOADED, DECOMPOSITIONS_LOCK, VMAP_DECOMPOSITIONS_LIB
+
+    if DECOMPOSITIONS_LOADED:
+        return
+
+    # Initialize lock if needed
+    if DECOMPOSITIONS_LOCK is None:
+        import threading
+
+        DECOMPOSITIONS_LOCK = threading.Lock()
+
+    with DECOMPOSITIONS_LOCK:
+        if DECOMPOSITIONS_LOADED:
+            return
+
+        import os
+
+        if not (os.environ.get("PYTORCH_JIT", "1") == "1" and __debug__):
+            DECOMPOSITIONS_LOADED = True
+            return
+
+        # use an alternate way to register an operator into the decomposition table
+        # _register_jit_decomposition doesn't work for some operators, e.g. addr,
+        #  because the Tensor types generated cannot be unioned by torchscript
+        # decomp should be type OpOverload
+        VMAP_DECOMPOSITIONS_LIB = torch.library.Library(
+            "aten", "IMPL", "FuncTorchBatched"
+        )
+
+        from torch._decomp import decomposition_table
+
+        def _register_python_decomposition_vmap(decomp):
+            if decomp in decomposition_table:
+                VMAP_DECOMPOSITIONS_LIB.impl(decomp, decomposition_table[decomp])
+            else:
+                raise RuntimeError(f"could not find decomposition for {decomp}")
+
+        _register_python_decomposition_vmap(torch.ops.aten.mse_loss_backward.default)
+        _register_python_decomposition_vmap(
+            torch.ops.aten.smooth_l1_loss_backward.default
+        )
+        _register_python_decomposition_vmap(torch.ops.aten.huber_loss_backward.default)
+        _register_python_decomposition_vmap(torch.ops.aten.nll_loss_forward.default)
+        _register_python_decomposition_vmap(torch.ops.aten.nll_loss2d_forward.default)
+        _register_python_decomposition_vmap(torch.ops.aten.nll_loss_backward.default)
+        _register_python_decomposition_vmap(torch.ops.aten.nll_loss2d_backward.default)
+        _register_python_decomposition_vmap(torch.ops.aten.addr.default)
+
+        DECOMPOSITIONS_LOADED = True

--- a/torch/export/_leakage_detection_utils.py
+++ b/torch/export/_leakage_detection_utils.py
@@ -1,0 +1,84 @@
+import gc
+import types
+import typing
+import weakref
+
+import torch
+
+
+# Things we never want to flag as leaks
+_SKIP_TYPES = (
+    types.FrameType,
+    types.GeneratorType,
+    types.FunctionType,
+    types.MethodType,
+    types.CodeType,
+    types.ModuleType,
+)
+
+
+def _is_tracked_fake(obj: typing.Any) -> bool:
+    return isinstance(obj, torch.fx.experimental.symbolic_shapes.TrackedFake)
+
+
+def _is_gm_meta_like_dict(d: dict) -> bool:
+    # Hope gm.meta was a custom dict we can assert on
+    return "val" in d
+
+
+def _dict_is_attr_of_tracked_fake(d: dict) -> bool:
+    """
+    Python 3.10 quirk: sometimes the referrer is obj.__dict__ instead of obj.
+    Check if this dict is exactly the __dict__ of a TrackedFake.
+    """
+    for parent in gc.get_referrers(d):
+        if (
+            hasattr(parent, "__dict__")
+            and parent.__dict__ is d
+            and _is_tracked_fake(parent)
+        ):
+            return True
+    return False
+
+
+def find_legit_leaks_from_referrers(active_fakes: weakref.WeakSet) -> weakref.WeakSet:
+    legit_leak: weakref.WeakSet = weakref.WeakSet()
+
+    for act in active_fakes:
+        # Track by id to avoid processing duplicate referrers
+        seen = set()
+        # Assume it's a leak unless we find only ignorable referrers
+        flagged = False
+
+        for r in gc.get_referrers(act):
+            rid = id(r)
+            if rid in seen:
+                continue
+            seen.add(rid)
+
+            # Fast-path: skip obvious non-owners
+            if r is globals() or r is locals():
+                continue
+            if isinstance(r, _SKIP_TYPES):
+                continue
+            if _is_tracked_fake(r):
+                # TrackedFake should be ignored
+                continue
+
+            # Handle dicts carefully (Python 3.10 sometimes shows __dict__)
+            if isinstance(r, dict):
+                if _is_gm_meta_like_dict(r):
+                    continue
+                if _dict_is_attr_of_tracked_fake(r):
+                    continue
+                flagged = True
+                break
+
+            # Any other referrer we don't explicitly whitelist counts as a leak
+            flagged = True
+            break
+
+        if flagged:
+            legit_leak.add(act)
+
+    return legit_leak


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #161100
* #161032

As part of consolidating compile and export, we try to remove legacy output matcher by directly relying dynamo sources to map graph outputs to user output. There are four parts we need to consider:
1) graph input being directly returned. (this doesn't show up in the graph so we need to rely on outer sources) 
2) constants are being returned (this doesn't show up in the graph so we need to rely on outer sources) 
3) duplicates 
4) graph outputs 

We handle this by carefully attaching `record_return_map` on top of stack (return value) and during codegen process, we log the resulting locations along with some metadata (whether it is input or graph putput or constant) 

Why can't we just directly analyze final VariableTracker? 
This is because dynamo doesn't have support for "flatten"-ing the VariableTracker to constituent variable trackers, so only way to do this during codegen-ing. I am all ears for better approach tho in case I missed something. 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela

Differential Revision: [D80774271](https://our.internmc.facebook.com/intern/diff/D80774271)