### PR TITLE
[FlexAttention][TF32] Handle uninitialized `torch.backends.cuda.matmul.fp32_precision`

### DIFF
--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -54,6 +54,8 @@ def flex_attention_grid(batch_size, q_heads, num_queries, d_model, meta, *, cdiv
 def get_float32_precision():
     if (
         torch.backends.cuda.matmul.fp32_precision == "ieee"
+        if torch.backends.cuda.matmul.fp32_precision != "none"
+        else torch.get_float32_matmul_precision() == "highest"
         or torch.version.hip
         or torch.mtia.is_available()
     ):


### PR DESCRIPTION
For https://github.com/pytorch/pytorch/issues/161022
The warning says the old API will be deprecated in 2.9+ anyway, leaving it up to the author of #125888 to decide on initialization behavior then

cc @ptrblck @msaroufim @jerryzh168 @zasdfgbnm @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @Chillee @drisspg @yanboliang @BoyuanFeng