### PR TITLE
don't try to set lazy module loading env var

### DIFF
--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -19,10 +19,6 @@
 #include <c10/cuda/CUDAFunctions.h>
 #include <c10/util/irange.h>
 
-#if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
-#include <c10/cuda/driver_api.h>
-#endif
-
 #if AT_CUDNN_ENABLED()
 #include <ATen/cudnn/cudnn-wrapper.h>
 #endif
@@ -93,29 +89,6 @@ void CUDAHooks::init() const {
   // have a chance to enable vitals.
   at::vitals::VitalsAPI.setVital("CUDA", "used", "true", /* force = */ true);
 
-  // Sets the CUDA_MODULE_LOADING environment variable
-  // if it's not set by the user.
-  // CUDA_MODULE_LOADING="LAZY" is default for all drivers released for CUDA 12.2+.
-  // Check the driver version and only set the env variable if needed.
-  bool set_lazy_module_loading = true;
-  #if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
-  auto driver_api = c10::cuda::DriverAPI::get();
-  // Initialize NVML
-  if (driver_api->nvmlInit_v2_() == NVML_SUCCESS) {
-    // Get the driver version
-    int version = -1;
-    auto res = driver_api->nvmlSystemGetCudaDriverVersion_v2_(&version);
-    if (res == NVML_SUCCESS) {
-      // Check if driver is sufficiently new
-      if (version >= 12020) {
-        set_lazy_module_loading = false;
-      }
-    }
-  }
-  #endif
-  if (set_lazy_module_loading) {
-    c10::utils::set_env("CUDA_MODULE_LOADING", "LAZY", false);
-  }
   const auto num_devices = c10::cuda::device_count_ensure_non_zero();
   c10::cuda::CUDACachingAllocator::init(num_devices);
   at::cuda::detail::init_p2p_access_cache(num_devices);


### PR DESCRIPTION
This is not needed on drivers >=525, and in DriverAPI::get() we are initializing the context anyway, so setting environment variable after that is beside the point
As a result of calling DriverAPI::get on systems that don't have gpus available (e.g. due to CUDA_VISIBLE_DEVICES="") people were getting confusing errors. 
