### PR TITLE
Fix autograd assertion error in CUDA backend when privateuse1 is registered

### DIFF
--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -244,13 +244,10 @@ struct TORCH_API Node : std::enable_shared_from_this<Node> {
    * they may have different streams.
    */
   std::optional<c10::Stream> stream() {
-    auto opt_device_type = at::getAccelerator();
-    if (!opt_device_type.has_value()) {
-      return std::nullopt;
-    }
     for (const auto& metadata : input_metadata_) {
-      if (metadata.device().type() == opt_device_type.value())
+      if (at::isAccelerator(metadata.device().type())) {
         return metadata.stream();
+      }
     }
 
     return std::nullopt;


### PR DESCRIPTION
Fixes #161129 .

When a PrivateUse1 backend is registered, the `at::isAccelerator()` and `at::getAccelerator()` functions will always return the PrivateUse1 accelerator even if the underlying tensors and models are using the existing CUDA backend. This results in the autograd assertion error in the issue above.

This PR addresses the issue by using the streams associated with the inputs (in part, reverting to the behavior of PyTorch 2.7.1) instead of the `isAccelerator()` and `getAccelerator` functions which can return the wrong backend and consequently the wrong stream.

