### PR TITLE
Update custom_class_detail.h

### DIFF
--- a/torch/custom_class_detail.h
+++ b/torch/custom_class_detail.h
@@ -99,6 +99,17 @@ struct WrapMethod<R (CurrClass::*)(Args...) const> {
   R (CurrClass::*m)(Args...) const;
 };
 
+template <typename R, typename CurrClass, typename... Args>
+struct WrapMethod<R (CurrClass::*)(Args...) const noexcept> {
+  WrapMethod(R (CurrClass::*m)(Args...) const noexcept) : m(std::move(m)) {}
+
+  R operator()(c10::intrusive_ptr<CurrClass> cur, Args... args) {
+    return std::invoke(m, *cur, args...);
+  }
+
+  R (CurrClass::*m)(Args...) const;
+};
+
 // Adapter for different callable types
 template <
     typename CurClass,


### PR DESCRIPTION
[quote="pya, post:1, topic:222401"]
Without the above specialization, I ran into the following error using g+±13 with –std=c++17 option:

```
error: invalid use of incomplete type ‘struct torch::detail::WrapMethod<void (MyClass::*)() const noexcept>’
  110 |   return WrapMethod<Func>(std::move(f));
```
[/quote]

Fixes #ISSUE_NUMBER
