### PR TITLE
[dist] expose unsafe_get_ptr for dist.ProcessGroupNCCL.NCCLConfig

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -62,6 +62,10 @@
     ignore = dirty
     path = third_party/gemmlowp/gemmlowp
     url = https://github.com/google/gemmlowp.git
+[submodule "third_party/fbgemm"]
+    ignore = dirty
+    path = third_party/fbgemm
+    url = https://github.com/pytorch/fbgemm
 [submodule "android/libs/fbjni"]
     ignore = dirty
     path = android/libs/fbjni
@@ -74,6 +78,10 @@
     ignore = dirty
     path = third_party/fmt
     url = https://github.com/fmtlib/fmt.git
+[submodule "third_party/tensorpipe"]
+    ignore = dirty
+    path = third_party/tensorpipe
+    url = https://github.com/pytorch/tensorpipe.git
 [submodule "third_party/cudnn_frontend"]
 	path = third_party/cudnn_frontend
 	url = https://github.com/NVIDIA/cudnn-frontend.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -62,10 +62,6 @@
     ignore = dirty
     path = third_party/gemmlowp/gemmlowp
     url = https://github.com/google/gemmlowp.git
-[submodule "third_party/fbgemm"]
-    ignore = dirty
-    path = third_party/fbgemm
-    url = https://github.com/pytorch/fbgemm
 [submodule "android/libs/fbjni"]
     ignore = dirty
     path = android/libs/fbjni
@@ -78,10 +74,6 @@
     ignore = dirty
     path = third_party/fmt
     url = https://github.com/fmtlib/fmt.git
-[submodule "third_party/tensorpipe"]
-    ignore = dirty
-    path = third_party/tensorpipe
-    url = https://github.com/pytorch/tensorpipe.git
 [submodule "third_party/cudnn_frontend"]
 	path = third_party/cudnn_frontend
 	url = https://github.com/NVIDIA/cudnn-frontend.git

--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -644,6 +644,7 @@ class ProcessGroupNCCL(Backend):
         cga_cluster_size: int
         min_ctas: int
         max_ctas: int
+        ptr: int
 
     class Options(Backend.Options):
         config: ProcessGroupNCCL.NCCLConfig

--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -644,7 +644,7 @@ class ProcessGroupNCCL(Backend):
         cga_cluster_size: int
         min_ctas: int
         max_ctas: int
-        ptr: int
+        def unsafe_get_ptr(self) -> int: ...
 
     class Options(Backend.Options):
         config: ProcessGroupNCCL.NCCLConfig

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -3401,6 +3401,9 @@ for details.
       .def_readwrite("nvls_ctas", &ncclConfig_t::nvlsCTAs)
 #endif
       .def_property(
+          "ptr"
+          [](const ncclConfig_t& self) { return reinterpret_cast<int64_t>(&self); })
+      .def_property(
           "net_name",
           [](const ncclConfig_t& self) { return self.netName; },
           // Note: NCCL calls free on the netName pointer

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -3400,9 +3400,11 @@ for details.
 #ifdef NCCL_HAS_NVLS_CTAS
       .def_readwrite("nvls_ctas", &ncclConfig_t::nvlsCTAs)
 #endif
-      .def_property(
-          "ptr"
-          [](const ncclConfig_t& self) { return reinterpret_cast<int64_t>(&self); })
+      .def_property_readonly(
+          "ptr",
+          [](const ncclConfig_t& self) {
+            return reinterpret_cast<int64_t>(&self);
+          })
       .def_property(
           "net_name",
           [](const ncclConfig_t& self) { return self.netName; },

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -3400,10 +3400,10 @@ for details.
 #ifdef NCCL_HAS_NVLS_CTAS
       .def_readwrite("nvls_ctas", &ncclConfig_t::nvlsCTAs)
 #endif
-      .def_property_readonly(
-          "ptr",
+      .def(
+          "unsafe_get_ptr",
           [](const ncclConfig_t& self) {
-            return reinterpret_cast<int64_t>(&self);
+            return reinterpret_cast<uintptr_t>(&self);
           })
       .def_property(
           "net_name",


### PR DESCRIPTION
expose the pointer so that we can create the `ncclConfig_t` object from pytorch and use it elsewhere. this is useful to control the nccl communicator parameters for multiple nccl communicators.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta