### PR TITLE
[nativert] Introduce PassRegistrar, use static registration for graph passes

### DIFF
--- a/torch/nativert/graph/passes/pass_manager/GraphPassRegistry.h
+++ b/torch/nativert/graph/passes/pass_manager/GraphPassRegistry.h
@@ -81,4 +81,18 @@ class GraphPassRegistry {
   void operator=(GraphPassRegistry const&) = delete;
 };
 
+// Generic pass registrar template that automatically registers passes during
+// program initialization. Can accept any functor that matches PassSignature.
+template <typename PassFunc>
+class PassRegistrar {
+ public:
+  PassRegistrar(std::string passName, PassFunc func) {
+    GraphPassRegistry::add_pass(std::move(passName), std::move(func));
+  }
+};
+
+#define REGISTER_GRAPH_PASS(pass_name, ...)                         \
+  static torch::nativert::PassRegistrar pass_registrar_##pass_name( \
+      #pass_name, __VA_ARGS__)
+
 } // namespace torch::nativert

--- a/torch/nativert/graph/passes/pass_manager/GraphPasses.cpp
+++ b/torch/nativert/graph/passes/pass_manager/GraphPasses.cpp
@@ -1,92 +1,86 @@
-#include <torch/nativert/graph/passes/pass_manager/GraphPasses.h>
-
 #include <torch/nativert/graph/passes/SubgraphRewriter.h>
 #include <torch/nativert/graph/passes/pass_manager/GraphPassRegistry.h>
 
 namespace torch::nativert {
 
-void register_base_passes() {
-  GraphPassRegistry::add_pass("EmptyPass", [](Graph*) { return false; });
+REGISTER_GRAPH_PASS(EmptyPass, [](Graph*) { return false; });
 
-  GraphPassRegistry::add_pass(
-      "LinearDynamicFp16UnpackedWeight", [](Graph* graph) {
-        std::string p = R"(
+REGISTER_GRAPH_PASS(CleanUpDeadNodes, [](Graph* graph) {
+  return graph->cleanupDeadNodes();
+});
+
+REGISTER_GRAPH_PASS(LinearDynamicFp16UnpackedWeight, [](Graph* graph) {
+  std::string p = R"(
     graph(%i, %w, %b):
     %out_0 = torch.ops.aten.linear.default(input=%i, weight=%w, bias=%b)
     return (%out_0))";
 
-        std::string p_1 = R"(
+  std::string p_1 = R"(
     graph(%i, %w, %b):
     %out_0 = torch.ops.quantized.linear_dynamic_fp16_unpacked_weight.default(X=%i, weight=%w, bias=%b)
     return (%out_0))";
 
-        std::string p_new = R"(
+  std::string p_new = R"(
     graph(%i, %w, %b):
     %pw = torch.ops.quantized.linear_prepack_fp16.default(W=%w, B=%b)
     %out_0 = torch.ops.quantized.linear_dynamic_fp16.default(X=%i, W_prepack=%pw)
     return (%out_0))";
 
-        SubgraphRewriter rewriter("LinearDynamicFp16UnpackedWeight");
-        rewriter.registerRewritePattern(p, p_new);
-        rewriter.registerRewritePattern(p_1, p_new);
-        return rewriter.run(graph);
-      });
+  SubgraphRewriter rewriter("LinearDynamicFp16UnpackedWeight");
+  rewriter.registerRewritePattern(p, p_new);
+  rewriter.registerRewritePattern(p_1, p_new);
+  return rewriter.run(graph);
+});
 
-  GraphPassRegistry::add_pass(
-      "LinearReluDynamicFp16UnpackedWeight", [](Graph* graph) {
-        std::string p = R"(
+REGISTER_GRAPH_PASS(LinearReluDynamicFp16UnpackedWeight, [](Graph* graph) {
+  std::string p = R"(
     graph(%i, %w, %b):
     %out_0 = torch.ops.aten.linear.default(input=%i, weight=%w, bias=%b)
     %out_1 = torch.ops.aten.relu.default(self=%out_0)
     return (%out_1))";
 
-        std::string p_1 = R"(
+  std::string p_1 = R"(
     graph(%i, %w, %b):
     %out_0 = torch.ops.quantized.linear_dynamic_fp16_unpacked_weight.default(X=%i, weight=%w, bias=%b)
     %out_1 = torch.ops.aten.relu.default(self=%out_0)
     return (%out_1))";
 
-        std::string p_new = R"(
+  std::string p_new = R"(
     graph(%i, %w, %b):
     %pw = torch.ops.quantized.linear_prepack_fp16.default(W=%w, B=%b)
     %out_0 = torch.ops.quantized.linear_relu_dynamic_fp16.default(X=%i, W_prepack=%pw)
     return (%out_0))";
 
-        SubgraphRewriter rewriter("LinearReluDynamicFp16UnpackedWeight");
-        rewriter.registerRewritePattern(p, p_new);
-        rewriter.registerRewritePattern(p_1, p_new);
-        return rewriter.run(graph);
-      });
+  SubgraphRewriter rewriter("LinearReluDynamicFp16UnpackedWeight");
+  rewriter.registerRewritePattern(p, p_new);
+  rewriter.registerRewritePattern(p_1, p_new);
+  return rewriter.run(graph);
+});
 
-  GraphPassRegistry::add_pass("CleanUpDeadNodes", [](Graph* graph) {
-    return graph->cleanupDeadNodes();
-  });
+REGISTER_GRAPH_PASS(RemoveDetach, [](Graph* graph) {
+  std::vector<Node*> nodesToDestroy;
 
-  GraphPassRegistry::add_pass("RemoveDetach", [](Graph* graph) {
-    std::vector<Node*> nodesToDestroy;
-
-    for (auto& node : graph->nodes()) {
-      if (node.target() == "torch.ops.aten.detach.default") {
-        nodesToDestroy.push_back(&node);
-        graph->replaceAllUses(node.outputs()[0], node.inputs()[0].value);
-      }
+  for (auto& node : graph->nodes()) {
+    if (node.target() == "torch.ops.aten.detach.default") {
+      nodesToDestroy.push_back(&node);
+      graph->replaceAllUses(node.outputs()[0], node.inputs()[0].value);
     }
+  }
 
-    VLOG(1) << "[GraphPasses] Removed " << nodesToDestroy.size()
-            << " aten.detach nodes";
+  VLOG(1) << "[GraphPasses] Removed " << nodesToDestroy.size()
+          << " aten.detach nodes";
 
-    const bool mutated = !nodesToDestroy.empty();
+  const bool mutated = !nodesToDestroy.empty();
 
-    for (Node* node : nodesToDestroy) {
-      node->destroy();
-    }
+  for (Node* node : nodesToDestroy) {
+    node->destroy();
+  }
 
-    graph->renumberValues();
-    graph->finalize();
-    graph->lint();
+  graph->renumberValues();
+  graph->finalize();
+  graph->lint();
 
-    return mutated;
-  });
-}
+  return mutated;
+});
 
 } // namespace torch::nativert

--- a/torch/nativert/graph/passes/pass_manager/GraphPasses.h
+++ b/torch/nativert/graph/passes/pass_manager/GraphPasses.h
@@ -1,7 +1,0 @@
-#pragma once
-
-namespace torch::nativert {
-
-void register_base_passes();
-
-} // namespace torch::nativert

--- a/torch/nativert/graph/passes/pass_manager/PassManager.cpp
+++ b/torch/nativert/graph/passes/pass_manager/PassManager.cpp
@@ -1,19 +1,13 @@
 #include <torch/nativert/graph/passes/pass_manager/PassManager.h>
 
-#include <c10/util/CallOnce.h>
-
 #include <torch/nativert/graph/Graph.h>
-#include <torch/nativert/graph/passes/pass_manager/GraphPasses.h>
 
 namespace torch::nativert {
 
 GraphPassManager::GraphPassManager(
     GraphPassPipeline pipeline,
     PassManagerOptions opts)
-    : pipeline_(std::move(pipeline)), opts_(opts) {
-  static c10::once_flag flag;
-  c10::call_once(flag, [&]() { register_base_passes(); });
-}
+    : pipeline_(std::move(pipeline)), opts_(opts) {}
 
 bool GraphPassManager::run(Graph* graph) {
   bool changed = false;


### PR DESCRIPTION
Summary:
Introduce PassRegistrar and REGISTER_GRAPH_PASS macro. 
Switch Graph passes to use REGISTER_GRAPH_PASS. 
Remove register_fuse_list_unpack_passes(), register_base_passes(), register_base_passes(), register_variadic_op_passes()

Graph Passes are now registered when program initializes.

Test Plan:
CI

Rollback Plan:

Differential Revision: D80682852


