### PR TITLE
Add profiler analysis flag to combine multiple profiles into one

### DIFF
--- a/test/inductor/test_analysis.py
+++ b/test/inductor/test_analysis.py
@@ -1,11 +1,13 @@
 # Owner(s): ["module: inductor"]
 
 import json
+import sys
 import tempfile
 import unittest
 import uuid
 from io import StringIO
 from unittest.mock import patch
+import os
 
 import torch
 import torch.nn.functional as F
@@ -542,6 +544,97 @@ class TestAnalysis(TestCase):
         for event in out_profile["traceEvents"]:
             if event["name"] == "triton_poi_fused_add_randn_sin_0":
                 event["args"]["kernel_num_gb"] = 0.002097168
+
+    @skipIf(not SM80OrLater, "Requires SM80")
+    @dtypes(torch.float, torch.float16)
+    def test_combine_profiles(self, device, dtype):
+        """
+        Test combining multiple profiles into a single profile.
+        """
+        if device == "cpu" or torch.version.hip is not None:
+            return
+
+        # Create three different models to generate different traces
+        om1 = _test_model(device, dtype, addmm=True, bmm=False)
+        om2 = _test_model(device, dtype, addmm=False, bmm=True)  
+        om3 = _pointwise_test_model(device, dtype)
+
+        # Generate three separate traces
+        trace1, trace2 = trace_files()
+        trace3 = f"{TMP_DIR}/trace3-{uuid.uuid4()}.json"
+        combined_trace = f"{TMP_DIR}/combined-{uuid.uuid4()}.json"
+
+        # Generate first trace
+        torch._dynamo.reset()
+        with fresh_inductor_cache():
+            with torch.profiler.profile(record_shapes=True) as p1:
+                om1()
+        p1.export_chrome_trace(trace1)
+
+        # Generate second trace  
+        torch._dynamo.reset()
+        with fresh_inductor_cache():
+            with torch.profiler.profile(record_shapes=True) as p2:
+                om2()
+        p2.export_chrome_trace(trace2)
+
+        # Generate third trace
+        torch._dynamo.reset()
+        with fresh_inductor_cache():
+            with torch.profiler.profile(record_shapes=True) as p3:
+                om3()
+        p3.export_chrome_trace(trace3)
+
+        # Combine the three traces
+        with patch(
+            "sys.argv",
+            [
+                *prefix,
+                "--combine",
+                trace1,
+                trace2, 
+                trace3,
+                combined_trace,
+            ],
+        ):
+            main()
+
+        # Verify the combined trace exists and contains expected data
+        with open(combined_trace) as f:
+            combined_profile = json.load(f)
+
+        # Load original traces for comparison
+        with open(trace1) as f:
+            profile1 = json.load(f)
+        with open(trace2) as f:
+            profile2 = json.load(f)
+        with open(trace3) as f:
+            profile3 = json.load(f)
+
+        # Verify trace events are combined
+        expected_event_count = (
+            len(profile1["traceEvents"]) + 
+            len(profile2["traceEvents"]) + 
+            len(profile3["traceEvents"])
+        )
+        self.assertEqual(len(combined_profile["traceEvents"]), expected_event_count)
+
+        # Verify device properties are present
+        self.assertIn("deviceProperties", combined_profile)
+        self.assertGreater(len(combined_profile["deviceProperties"]), 0)
+
+        # Verify some trace events from each original profile are present
+        combined_event_names = {event["name"] for event in combined_profile["traceEvents"]}
+        
+        # Check that we have events from each original profile
+        profile1_event_names = {event["name"] for event in profile1["traceEvents"]}
+        profile2_event_names = {event["name"] for event in profile2["traceEvents"]}
+        profile3_event_names = {event["name"] for event in profile3["traceEvents"]}
+        
+        # At least some events from each profile should be in the combined profile
+        self.assertTrue(profile1_event_names.intersection(combined_event_names))
+        self.assertTrue(profile2_event_names.intersection(combined_event_names))
+        self.assertTrue(profile3_event_names.intersection(combined_event_names))
 
 
 instantiate_device_type_tests(TestAnalysis, globals())

--- a/test/inductor/test_analysis.py
+++ b/test/inductor/test_analysis.py
@@ -1,13 +1,11 @@
 # Owner(s): ["module: inductor"]
 
 import json
-import sys
 import tempfile
 import unittest
 import uuid
 from io import StringIO
 from unittest.mock import patch
-import os
 
 import torch
 import torch.nn.functional as F
@@ -556,7 +554,7 @@ class TestAnalysis(TestCase):
 
         # Create three different models to generate different traces
         om1 = _test_model(device, dtype, addmm=True, bmm=False)
-        om2 = _test_model(device, dtype, addmm=False, bmm=True)  
+        om2 = _test_model(device, dtype, addmm=False, bmm=True)
         om3 = _pointwise_test_model(device, dtype)
 
         # Generate three separate traces
@@ -571,7 +569,7 @@ class TestAnalysis(TestCase):
                 om1()
         p1.export_chrome_trace(trace1)
 
-        # Generate second trace  
+        # Generate second trace
         torch._dynamo.reset()
         with fresh_inductor_cache():
             with torch.profiler.profile(record_shapes=True) as p2:
@@ -592,7 +590,7 @@ class TestAnalysis(TestCase):
                 *prefix,
                 "--combine",
                 trace1,
-                trace2, 
+                trace2,
                 trace3,
                 combined_trace,
             ],
@@ -613,9 +611,9 @@ class TestAnalysis(TestCase):
 
         # Verify trace events are combined
         expected_event_count = (
-            len(profile1["traceEvents"]) + 
-            len(profile2["traceEvents"]) + 
-            len(profile3["traceEvents"])
+            len(profile1["traceEvents"])
+            + len(profile2["traceEvents"])
+            + len(profile3["traceEvents"])
         )
         self.assertEqual(len(combined_profile["traceEvents"]), expected_event_count)
 
@@ -624,13 +622,15 @@ class TestAnalysis(TestCase):
         self.assertGreater(len(combined_profile["deviceProperties"]), 0)
 
         # Verify some trace events from each original profile are present
-        combined_event_names = {event["name"] for event in combined_profile["traceEvents"]}
-        
+        combined_event_names = {
+            event["name"] for event in combined_profile["traceEvents"]
+        }
+
         # Check that we have events from each original profile
         profile1_event_names = {event["name"] for event in profile1["traceEvents"]}
         profile2_event_names = {event["name"] for event in profile2["traceEvents"]}
         profile3_event_names = {event["name"] for event in profile3["traceEvents"]}
-        
+
         # At least some events from each profile should be in the combined profile
         self.assertTrue(profile1_event_names.intersection(combined_event_names))
         self.assertTrue(profile2_event_names.intersection(combined_event_names))

--- a/torch/_inductor/analysis/profile_analysis.py
+++ b/torch/_inductor/analysis/profile_analysis.py
@@ -683,7 +683,9 @@ class JsonProfile:
 
         # Merge device properties, avoiding duplicates
         other_device_props = other.data.get("deviceProperties", [])
-        existing_device_ids = {dev["id"] for dev in combined_data["deviceProperties"]}
+        existing_device_ids = OrderedSet(
+            [dev["id"] for dev in combined_data["deviceProperties"]]
+        )
 
         for device_prop in other_device_props:
             if device_prop["id"] not in existing_device_ids:
@@ -724,7 +726,7 @@ class ParseException(RuntimeError):
 
 def main() -> None:
     """
-    main function
+    Main function for the profile analysis script.
     """
     import argparse
 

--- a/torch/_inductor/analysis/profile_analysis.py
+++ b/torch/_inductor/analysis/profile_analysis.py
@@ -723,6 +723,9 @@ class ParseException(RuntimeError):
 
 
 def main() -> None:
+    """
+    main function
+    """
     import argparse
 
     parser = argparse.ArgumentParser()
@@ -760,7 +763,9 @@ def main() -> None:
         "--combine",
         nargs="+",
         metavar=("input_files", "output_file"),
-        help="Combine multiple profiles into a single profile by merging trace events. Specify as <input_file1> <input_file2> [input_file3 ...] <output_file>. The last argument is the output file, all preceding arguments are input files to combine.",
+        help="Combine multiple profiles into a single profile by merging trace events. Specify as <input_file1> \
+<input_file2> [input_file3 ...] <output_file>. The last argument is the output file, all preceding arguments are \
+input files to combine.",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
Combine multiple profiles into one:
```
python profile_analysis.py --combine <file1> <file2> ... <out>
```
This only works well if they have different pids, like from different programs in a distributed run.

<img width="1521" height="465" alt="combining_multiple_profiles" src="https://github.com/user-attachments/assets/aba7112b-e9a9-4075-b82b-a4e4408384da" />


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @mlazos