### PR TITLE
Fix constant_pad_nd_mps bug when pad is empty

### DIFF
--- a/aten/src/ATen/native/mps/operations/Pad.mm
+++ b/aten/src/ATen/native/mps/operations/Pad.mm
@@ -460,6 +460,9 @@ Tensor replication_pad3d_backward_mps(const Tensor& grad_output, const Tensor& i
 
 // backward pass is explicitly handled in autograd by negating the "pad" argument
 Tensor constant_pad_nd_mps(const Tensor& self, IntArrayRef pad, const Scalar& value) {
+  if (pad.empty()) {
+    return self.clone();
+  }
   if (pad.size() > 6) {
     TORCH_WARN_ONCE("MPS: The constant padding of more than 3 dimensions is not currently supported natively. ",
                     "It uses View Ops default implementation to run. This may have performance implications.");


### PR DESCRIPTION
Fixes #161066

There is a size check here, which causes the error. 
https://github.com/pytorch/pytorch/blob/8ce81bcee1da294a34af0a90dc16483055e8c5a4/aten/src/ATen/native/mps/operations/Pad.mm#L39-L40

If the argument `pad` is empty, it will return the cloned tensor on CPU.

https://github.com/pytorch/pytorch/blob/8ce81bcee1da294a34af0a90dc16483055e8c5a4/aten/src/ATen/native/PadNd.cpp#L43-L64

Therefore, this PR fixes the empty padding argument error by checking the size first and returning a cloned tensor immediately if the padding size is 0.
