### PR TITLE
Set proper device type before create tensor in distributed environment

### DIFF
--- a/torch/distributed/tensor/_utils.py
+++ b/torch/distributed/tensor/_utils.py
@@ -284,7 +284,7 @@ def compute_global_tensor_shape(
     if isinstance(placements[0], Replicate):
         return shape
     elif isinstance(placements[0], Shard):
-        local_shape = torch.tensor(list(shape))
+        local_shape = torch.tensor(list(shape), device=mesh.device_type)
         gathered_shaped_tensors = [
             torch.empty_like(local_shape, device=local_shape.device)
             for _ in range(mesh.size())


### PR DESCRIPTION
Distributed mesh device type must use to create tensor, this resolve create tensor on cpu instead create hardware/mesh device

Fixes #161154 


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @tianyu-l @XilunWu