### PR TITLE
forward fix of #152198

### DIFF
--- a/torch/_inductor/shape_propagation.py
+++ b/torch/_inductor/shape_propagation.py
@@ -67,7 +67,7 @@ def broadcast_shapes_for_args(args: Sequence[ShapeArg]) -> BlockShapeType:
         else:
             from torch._inductor.loop_body import LoopBody, LoopBodyBlock
 
-            if isinstance(arg, (LoopBodyBlock, LoopBody)):
+            if isinstance(arg, (LoopBodyBlock, LoopBody, OpsValue)):
                 # TODO: fix me
                 return None
             raise TypeError(f"Unknown type: {type(arg)}")


### PR DESCRIPTION
torch._inductor.virtualized.OpsValue objects instance does not have shape attribute. This breaks the fp8 test on ROCm. Add the OpsValue class in todo list.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben