### PR TITLE
[Autograd lab]: C++ implicit autograd fn

### DIFF
--- a/aten/src/ATen/native/Attention.cpp
+++ b/aten/src/ATen/native/Attention.cpp
@@ -1,0 +1,34 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/core/Tensor.h>
+#include <ATen/TensorUtils.h>
+#include <ATen/NamedTensorUtils.h>
+#include <ATen/native/xnnpack/Engine.h>
+#include <c10/util/Exception.h>
+
+#include <ATen/ops/ones_like_native.h>
+
+namespace at::native {
+
+std::tuple<Tensor, Tensor, Tensor>
+lab_attn_bwd(const Tensor& Q, const Tensor& K, const Tensor& V, const Tensor& a, const Tensor& grad_o, const Tensor&) {
+  auto grad_v = a.t().matmul(grad_o);
+  auto grad_a = grad_o.matmul(V.t());
+
+  auto one = at::native::ones_like(a);
+  auto grad_x = grad_a.mul(one.sub(a.mul(a)));
+
+  auto grad_q = grad_x.matmul(K);
+  auto grad_k = ((Q.t()).matmul(grad_x)).t();
+
+  return std::make_tuple(grad_q, grad_k, grad_v);
+}
+
+std::tuple<Tensor,Tensor> lab_attn(const Tensor& Q, const Tensor& K, const Tensor& V) {
+  auto x = Q.matmul(K.t());
+  auto a = x.tanh();
+  auto o = a.matmul(V);
+
+  return std::make_tuple(o, a);
+}
+
+};  // at::native namespace

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -15928,3 +15928,13 @@
 # This op is ONLY used by pytorch/XLA in functionalization, and should never show up in vanilla eager mode or in any pytorch tracing contexts.
 - func: _propagate_xla_data(Tensor input, Tensor output) -> ()
   variants: function
+
+# autograd lab fn.
+- func: lab_attn(Tensor Q, Tensor K, Tensor V) -> (Tensor, Tensor)
+  variants: function
+    # dispatch:
+    #   CompositeExplicitAutograd: lab_attn
+
+- func: lab_attn_bwd(Tensor Q, Tensor K, Tensor V, Tensor a, Tensor grad_o, Tensor ignore) -> (Tensor, Tensor, Tensor)
+  variants: function
+

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -3245,3 +3245,8 @@
 - name: _foreach_norm.Scalar(Tensor[] self, Scalar ord=2, ScalarType? dtype=None) -> Tensor[]
   self: norm_backward(grads[i], self[i], ord, result[i])
   result: norm_jvp(self_p, self_t, ord, result[i])
+
+# Autograd lab
+# - name: lab_attn(Tensor Q, Tensor K, Tensor V) -> (Tensor, Tensor)
+#   output_differentiability: [True, False]
+#   Q, K, V: lab_attn_bwd(Q, K, V, result1, grads[0], grads[1])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #161176
* #161175
* __->__ #161174
* #161173
* #161172

Summary:

Added a c++ native function called `lab_attn` to `native_functions.yaml`,
with corresponding OpInfo entry in common_methods_invocations.

Some stubs/parts of Step4 (custom formula in derivatives.yaml) are in this
commit, but disabled/non-functional.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: