### PR TITLE
[Autograd Lab] Move lab_attn to explicit grad

### DIFF
--- a/aten/src/ATen/native/Attention.cpp
+++ b/aten/src/ATen/native/Attention.cpp
@@ -10,7 +10,7 @@
 namespace at::native {
 
 std::tuple<Tensor, Tensor, Tensor>
-lab_attn_bwd(const Tensor& Q, const Tensor& K, const Tensor& V, const Tensor& a, const Tensor& grad_o, const Tensor&) {
+lab_attn_bwd(const Tensor& Q, const Tensor& K, const Tensor& V, const Tensor& a, const Tensor& grad_o) {
   auto grad_v = a.t().matmul(grad_o);
   auto grad_a = grad_o.matmul(V.t());
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -15932,9 +15932,9 @@
 # autograd lab fn.
 - func: lab_attn(Tensor Q, Tensor K, Tensor V) -> (Tensor, Tensor)
   variants: function
-    # dispatch:
-    #   CompositeExplicitAutograd: lab_attn
+  dispatch:
+    CompositeExplicitAutograd: lab_attn
 
-- func: lab_attn_bwd(Tensor Q, Tensor K, Tensor V, Tensor a, Tensor grad_o, Tensor ignore) -> (Tensor, Tensor, Tensor)
+- func: lab_attn_bwd(Tensor Q, Tensor K, Tensor V, Tensor a, Tensor grad_o) -> (Tensor, Tensor, Tensor)
   variants: function
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -3247,6 +3247,6 @@
   result: norm_jvp(self_p, self_t, ord, result[i])
 
 # Autograd lab
-# - name: lab_attn(Tensor Q, Tensor K, Tensor V) -> (Tensor, Tensor)
-#   output_differentiability: [True, False]
-#   Q, K, V: lab_attn_bwd(Q, K, V, result1, grads[0], grads[1])
+- name: lab_attn(Tensor Q, Tensor K, Tensor V) -> (Tensor, Tensor)
+  output_differentiability: [True, False]
+  Q, K, V: lab_attn_bwd(Q, K, V, result1, grad)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #161176
* __->__ #161175
* #161174
* #161173
* #161172

Summary:

Move the `lab_attn` op defined previously from implicitly- to
explicitly-defined gradient operator.

Test Plan:
```
python test/test_ops.py -vv -k lab_attn
```
Reviewers:

Subscribers:

Tasks:

Tags: