### PR TITLE
[Autograd Lab]: Enforce 2d inputs

### DIFF
--- a/aten/src/ATen/native/Attention.cpp
+++ b/aten/src/ATen/native/Attention.cpp
@@ -24,6 +24,10 @@ lab_attn_bwd(const Tensor& Q, const Tensor& K, const Tensor& V, const Tensor& a,
 }
 
 std::tuple<Tensor,Tensor> lab_attn(const Tensor& Q, const Tensor& K, const Tensor& V) {
+  TORCH_CHECK(Q.dim() == 2, "Q must have exactly 2 dimensions");
+  TORCH_CHECK(K.dim() == 2, "K must have exactly 2 dimensions");
+  TORCH_CHECK(V.dim() == 2, "V must have exactly 2 dimensions");
+
   auto x = Q.matmul(K.t());
   auto a = x.tanh();
   auto o = a.matmul(V);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #161176
* #161175
* #161174
* #161173
* #161172

Summary:

Throw an error if Q/K/V are not 2d tensors

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: