### PR TITLE
[ROCm] No-fence global reduce

### DIFF
--- a/aten/src/ATen/native/cuda/KernelUtils.cuh
+++ b/aten/src/ATen/native/cuda/KernelUtils.cuh
@@ -225,8 +225,8 @@ __device__ __forceinline__ void fastAtomicAdd(
 
 
 #ifdef USE_ROCM
-// This function implements a commited store. 
-// Upon returning, the store is commited to to global memory. 
+// This function implements a commited store.
+// Upon returning, the store is commited to to global memory.
 // This is usefull in avoiding the need for fences.
 template <typename T>
 __device__ inline void cmtdStore(void* address, T value) {

--- a/aten/src/ATen/native/cuda/KernelUtils.cuh
+++ b/aten/src/ATen/native/cuda/KernelUtils.cuh
@@ -223,6 +223,38 @@ __device__ __forceinline__ void fastAtomicAdd(
   }
 }
 
+// This function implements a commited store. 
+// Upon returning, the store is commited to to global memory. 
+// This is usefull in avoiding the need for fences.
+template <typename T>
+__device__ inline void cmtdStore(void* address, T value) {
+      int constexpr num_long_per_val = sizeof(value)/sizeof(long);
+      int constexpr num_int_per_val = sizeof(value)/sizeof(int);
+      int constexpr num_short_per_val = sizeof(value)/sizeof(short);
+      int constexpr num_char_per_val = sizeof(value)/sizeof(char);
+      union pnr { T v;
+                  long l[num_long_per_val];
+                  int i[num_int_per_val];
+                  short s[num_short_per_val];
+                  char c[num_char_per_val]; }
+            _pnr = {.v = value };
+      if constexpr (num_long_per_val*sizeof(long) == sizeof(value))
+        for (int i=0; i<num_long_per_val; i++)
+          __hip_atomic_store(reinterpret_cast<long *>(address)+i, _pnr.l[i], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+      else if constexpr (num_int_per_val*sizeof(int) == sizeof(value))
+        for (int i=0; i<num_int_per_val; i++)
+          __hip_atomic_store(reinterpret_cast<int *>(address)+i, _pnr.i[i], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+      else if constexpr (num_short_per_val*sizeof(short) == sizeof(value))
+        for (int i=0; i<num_short_per_val; i++)
+          __hip_atomic_store(reinterpret_cast<short *>(address)+i, _pnr.s[i], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+      else if constexpr (num_char_per_val*sizeof(char) == sizeof(value))
+        for (int i=0; i<num_char_per_val; i++)
+          __hip_atomic_store(reinterpret_cast<char *>(address)+i, _pnr.c[i], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+      __atomic_signal_fence(__ATOMIC_SEQ_CST);
+      asm volatile("s_waitcnt vmcnt(0)" ::: "memory");
+      __atomic_signal_fence(__ATOMIC_SEQ_CST);
+}
+
 #if (defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__) || defined(__gfx950__))
 // This function implements warp-level opportunistic fastatomics
 // To reduce contention on an atomicAdd, this replaces per-thread atomicAdd with a per-warp atomicAdd.

--- a/aten/src/ATen/native/cuda/KernelUtils.cuh
+++ b/aten/src/ATen/native/cuda/KernelUtils.cuh
@@ -223,6 +223,8 @@ __device__ __forceinline__ void fastAtomicAdd(
   }
 }
 
+
+#ifdef USE_ROCM
 // This function implements a commited store. 
 // Upon returning, the store is commited to to global memory. 
 // This is usefull in avoiding the need for fences.
@@ -254,6 +256,7 @@ __device__ inline void cmtdStore(void* address, T value) {
       asm volatile("s_waitcnt vmcnt(0)" ::: "memory");
       __atomic_signal_fence(__ATOMIC_SEQ_CST);
 }
+#endif
 
 #if (defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__) || defined(__gfx950__))
 // This function implements warp-level opportunistic fastatomics

--- a/aten/src/ATen/native/cuda/KernelUtils.cuh
+++ b/aten/src/ATen/native/cuda/KernelUtils.cuh
@@ -225,9 +225,9 @@ __device__ __forceinline__ void fastAtomicAdd(
 
 
 #ifdef USE_ROCM
-// This function implements a commited store.
-// Upon returning, the store is commited to to global memory.
-// This is usefull in avoiding the need for fences.
+// This function implements a committed store.
+// Upon returning, the store is committed to global memory.
+// This is useful in avoiding the need for fences.
 template <typename T>
 __device__ inline void cmtdStore(void* address, T value) {
       int constexpr num_long_per_val = sizeof(value)/sizeof(long);

--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -806,7 +806,7 @@ struct ReduceOp {
       CUDA_KERNEL_ASSERT(num_int_per_val>=1);
       union pnr { std::array<arg_t, output_vec_size> v; int i[num_int_per_val]; } _pnr = {.v = value };
       for (int i=0; i<num_int_per_val; i++)
-        __builtin_nontemporal_store(0, reinterpret_cast<int *>(&reduce_buffer[offset])+i);
+        reinterpret_cast<int *>(&reduce_buffer[offset])[i] = 0;
       for (int i=0; i<num_int_per_val; i++)
         _pnr.i[i] = atomicAdd(reinterpret_cast<int *>(&reduce_buffer[offset])+i, _pnr.i[i]);
       value = _pnr.v;

--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -806,14 +806,14 @@ struct ReduceOp {
 #endif
     }
 
-#ifndef USE_ROCM // skip fence if store are committed [CMTSTRS] 
+#ifndef USE_ROCM // skip fence if store are committed [CMTSTRS]
     __threadfence(); // make sure writes are globally visible
 #endif
     __syncthreads(); // if multiple warps in this block wrote to staging, make sure they're all done
     bool is_last_block_done = mark_block_finished();
 
     if (is_last_block_done) {
-#ifndef USE_ROCM // skip fence if store are committed [CMTSTRS] 
+#ifndef USE_ROCM // skip fence if store are committed [CMTSTRS]
       __threadfence(); // complete the acquire pattern after atomic
 #endif
       for (auto &v : value) {

--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -802,7 +802,6 @@ struct ReduceOp {
 #else // [CMTSTRS]
       // In architectures with split caches, global fences are costly.
       // Here we preempt need for fences by committing stores to global memory.
-      // We do so by converting the stores to atomics with a return.
       cmtdStore(&reduce_buffer[offset], value);
 #endif
     }

--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -18,6 +18,7 @@
 #include <thrust/pair.h>
 
 #include <ATen/native/cuda/jit_utils.h>
+#include <ATen/native/cuda/KernelUtils.cuh>
 
 namespace at::native {
 
@@ -802,31 +803,7 @@ struct ReduceOp {
       // In architectures with split caches, global fences are costly.
       // Here we preempt need for fences by committing stores to global memory.
       // We do so by converting the stores to atomics with a return.
-      int constexpr num_long_per_val = sizeof(value)/sizeof(long);
-      int constexpr num_int_per_val = sizeof(value)/sizeof(int);
-      int constexpr num_short_per_val = sizeof(value)/sizeof(short);
-      int constexpr num_char_per_val = sizeof(value)/sizeof(char);
-      union pnr { std::array<arg_t, output_vec_size> v;
-                  long l[num_long_per_val];
-                  int i[num_int_per_val];
-                  short s[num_short_per_val];
-                  char c[num_char_per_val]; }
-            _pnr = {.v = value };
-      if constexpr (num_long_per_val*sizeof(long) == sizeof(value))
-        for (int i=0; i<num_long_per_val; i++)
-          __hip_atomic_store(reinterpret_cast<long *>(&reduce_buffer[offset])+i, _pnr.l[i], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      else if constexpr (num_int_per_val*sizeof(int) == sizeof(value))
-        for (int i=0; i<num_int_per_val; i++)
-          __hip_atomic_store(reinterpret_cast<int *>(&reduce_buffer[offset])+i, _pnr.i[i], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      else if constexpr (num_short_per_val*sizeof(short) == sizeof(value))
-        for (int i=0; i<num_short_per_val; i++)
-          __hip_atomic_store(reinterpret_cast<short *>(&reduce_buffer[offset])+i, _pnr.s[i], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      else if constexpr (num_char_per_val*sizeof(char) == sizeof(value))
-        for (int i=0; i<num_char_per_val; i++)
-          __hip_atomic_store(reinterpret_cast<char *>(&reduce_buffer[offset])+i, _pnr.c[i], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      __atomic_signal_fence(__ATOMIC_SEQ_CST);
-      asm volatile("s_waitcnt vmcnt(0)" ::: "memory");
-      __atomic_signal_fence(__ATOMIC_SEQ_CST);
+      cmtdStore(&reduce_buffer[offset], value);
 #endif
     }
 


### PR DESCRIPTION
This change removes need for fences in global_reduce by converting the stores to reduce_buffer[] into atomics+return. This is crucial for perf in architectures with split caches (e.g. MI300), where fences are inherently costly.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd