### PR TITLE
Support NUMA Binding for Callable Entrypoints, Take 2

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1221,6 +1221,9 @@ coverage_ignore_functions = [
     "reduce_typed_storage_child",
     "storage_from_cache",
     # torch.multiprocessing.spawn
+    # Added docstring for this but I think we need to go through
+    # and add the entire torch.multiprocessing.spawn module to a .rst...
+    "should_use_parallel_start",
     "start_processes",
     # torch.nn.functional
     "adaptive_max_pool1d_with_indices",  # documented as adaptive_max_pool1d

--- a/torch/numa/binding.py
+++ b/torch/numa/binding.py
@@ -1,15 +1,11 @@
 import os
-import shutil
-import stat
-import subprocess
 import traceback
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from enum import Enum
 from logging import getLogger
-from subprocess import run
-from tempfile import mkstemp
 from typing import Callable, Optional, TypeVar
 
 import torch
@@ -18,12 +14,9 @@ from torch._utils_internal import signpost_event
 
 __all__ = [
     "AffinityMode",
-    "maybe_get_temporary_python_executable_with_numa_bindings",
-    "maybe_wrap_command_with_numa_bindings",
+    "maybe_temporarily_apply_numa_binding_to_current_process",
     "NumaOptions",
 ]
-
-_NUMACTL_COMMAND = "numactl"
 
 logger = getLogger(__name__)
 
@@ -54,248 +47,136 @@ class NumaOptions:
     should_fall_back_if_binding_fails: bool = False
 
 
-def maybe_get_temporary_python_executable_with_numa_bindings(
-    *, python_executable_path: str, gpu_index: int, numa_options: Optional[NumaOptions]
-) -> Optional[str]:
+@contextmanager
+def maybe_temporarily_apply_numa_binding_to_current_process(
+    *, gpu_index: int, numa_options: Optional[NumaOptions]
+) -> Iterator[None]:
     """
-    Args:
-        python_executable_path: E.g., "/usr/local/bin/python"
-    Returns:
-        Path to a temporary file. This file can be executed just like the original python
-        executable, except it will first apply NUMA bindings.
+    1. Applies NUMA binding to the current process, suitable for the process
+    which will be interacting with GPU gpu_index.
+    2. Resets to the original CPU affinity before exiting the context manager.
     """
     if numa_options is None:
-        logger.info("Received numa_options=None, not creating numa executable.")
-        return None
+        yield
+        return
 
-    if isinstance(python_executable_path, bytes):
-        python_executable_path = python_executable_path.decode()
-
-    full_numactl_command = maybe_wrap_command_with_numa_bindings(
-        # "$@", i.e. pass through any args the python executable would have
-        # received.
-        command_args=(python_executable_path, '"$@"'),
-        gpu_index=gpu_index,
-        numa_options=numa_options,
+    original_logical_cpu_indices = _get_allowed_cpu_indices_for_current_process()
+    _apply_numa_binding_to_current_process(
+        gpu_index=gpu_index, numa_options=numa_options
+    )
+    yield
+    _bind_current_process_to_logical_cpus(
+        logical_cpu_indices=original_logical_cpu_indices
     )
 
-    if full_numactl_command is None:
-        return None
 
-    executable_path = _get_temporary_executable_for_command(
-        command_args=full_numactl_command
-    )
-    logger.info("Returning python executable with NUMA bindings %s", executable_path)
-
-    return executable_path
-
-
-def maybe_wrap_command_with_numa_bindings(
-    *,
-    command_args: tuple[str, ...],
-    gpu_index: int,
-    numa_options: Optional[NumaOptions],
-) -> Optional[tuple[str, ...]]:
-    """
-    Args:
-        command_args: Full shell command, like ("/usr/local/bin/python", "train.py")
-        gpu_index: The index of the GPU which command_args should bind to
-
-    Returns:
-        command_args, but wrapped so that it runs with NUMA bindings corresponding to
-        gpu_index and numa_options.
-        E.g., ("numactl", "--cpunodebind=0", "/usr/local/bin/python", "train.py")
-    """
-    if not numa_options:
-        logger.info("Received numa_options=None, not applying bindings.")
-        return None
-
+def _apply_numa_binding_to_current_process(
+    *, gpu_index: int, numa_options: NumaOptions
+) -> None:
     kwargs = {
-        "command_args": command_args,
         "gpu_index": gpu_index,
         "numa_options": asdict(numa_options),
     }
-    logger.info("Attempting to wrap command with NUMA bindings, given input %r", kwargs)
+    logger.info("Attempting to apply NUMA binding, given input %r", kwargs)
 
     try:
-        _raise_if_numactl_not_available()
-
-        numactl_options = _get_numactl_cli_options(
-            command_args=command_args, gpu_index=gpu_index, numa_options=numa_options
-        )
-        logger.info("Computed numactl_options=%r", numactl_options)
-
-        _raise_if_numactl_fails_dry_run(numactl_options=numactl_options)
-        logger.info("Validated numactl_options=%r", numactl_options)
-
-        full_numactl_command = _get_assembled_command_from_pieces(
-            command_args=command_args, numactl_options=numactl_options
+        logical_cpu_indices = _get_logical_cpus_to_bind_to(
+            gpu_index=gpu_index, numa_options=numa_options
         )
         logger.info(
-            "Successfully wrapped command with numa_bindings. Returning %r",
-            full_numactl_command,
+            "Computed logical_cpu_indices=%s for NUMA binding",
+            _get_ranges_str_from_ints(logical_cpu_indices),
         )
+
+        _raise_if_logical_cpu_indices_invalid(logical_cpu_indices=logical_cpu_indices)
+        logger.info(
+            "Validated logical_cpu_indices=%s for NUMA binding",
+            _get_ranges_str_from_ints(logical_cpu_indices),
+        )
+
+        _bind_current_process_to_logical_cpus(logical_cpu_indices=logical_cpu_indices)
+        logger.info(
+            "Successfully bound to logical_cpu_indices=%r for NUMA binding",
+            _get_ranges_str_from_ints(logical_cpu_indices),
+        )
+
         signpost_event(
             category="numa_binding",
-            name="wrap_command_success",
-            parameters={**kwargs, "result": full_numactl_command},
+            name="apply_success",
+            parameters={
+                **kwargs,
+                "logical_cpu_indices": _get_ranges_str_from_ints(logical_cpu_indices),
+            },
         )
-        return full_numactl_command
     except Exception:
         signpost_event(
             category="numa_binding",
-            name="wrap_command_exception",
+            name="apply_exception",
             parameters={
                 **kwargs,
                 "traceback": traceback.format_exc(),
             },
         )
-        logger.exception(
-            "Failed to wrap command with NUMA bindings for input = %r", kwargs
-        )
+        logger.exception("Failed to apply NUMA binding for input=%r", kwargs)
         if numa_options.should_fall_back_if_binding_fails:
-            logger.warning("Falling back to original command without NUMA bindings.")
+            logger.warning(
+                "Continuing executing without applying NUMA binding, despite exception %s",
+                traceback.format_exc(),
+            )
             return None
         raise
 
 
-def _get_temporary_executable_for_command(
+def _raise_if_logical_cpu_indices_invalid(*, logical_cpu_indices: set[int]) -> None:
+    if not logical_cpu_indices:
+        raise RuntimeError("Must bind to a non-empty set of CPU indices")
+
+
+def _bind_current_process_to_logical_cpus(*, logical_cpu_indices: set[int]) -> None:
+    # 0 represents the current process
+    os.sched_setaffinity(0, logical_cpu_indices)
+
+
+def _get_logical_cpus_to_bind_to(
     *,
-    command_args: tuple[str, ...],
-) -> str:
-    """
-    Returns:
-        Path to a temporary file which executes the specified command. The executable
-        deletes itself the first time it runs, so do not try to run it multiple times.
-    """
-    fd, path = mkstemp(
-        prefix="pytorch-numa-bind",
-        suffix=".sh",
-    )
-
-    # We do rm first to guarantee the file deletes itself. The rest of the file
-    # will still run as intended.
-    contents = f"""#!/bin/bash
-
-# If this file is more than a few minutes old and still exists on your machine,
-# that is NOT expected. It should have deleted itself. If you are seeing an accumulation of such
-# files, that could suggest a bug in pytorch. See https://github.com/pytorch/pytorch/pull/160163.
-
-rm -- "$0"
-{" ".join(command_args)}
-"""
-
-    with os.fdopen(fd, "w") as file:
-        file.write(contents)
-
-        # Ensure the file is fully synced, in order to avoid race condition
-        # from trying to execute it too early.
-        file.flush()
-        os.fsync(fd)
-
-    # Make the script executable
-    os.chmod(path, stat.S_IRWXU)
-
-    logger.info(
-        "Created temporary executable at path %s, with contents\n%s", path, contents
-    )
-
-    return path
-
-
-def _get_numactl_cli_options(
-    *,
-    command_args: tuple[str, ...],
     gpu_index: int,
     numa_options: NumaOptions,
-) -> tuple[str, ...]:
+) -> set[int]:
     """
     Args:
-        command_args: The args for a command, such as might be input to Popen.
-            Example: ("python", "trainer.py")
-        gpu_index: The index of the GPU that will be used by the subprocess which executes command_args.
+        gpu_index: The index of the GPU that will be used by the subprocess.
             Example: 0
         numa_options: See NumaOptions for details.
 
     Returns:
-        Depending on numa_options, something like
-            ("--cpunodebind=0")
+        Set of logical CPU indices to bind to.
     """
     if numa_options.affinity_mode == AffinityMode.NODE:
-        numactl_command_options = _get_node_numactl_options(gpu_index=gpu_index)
+        logical_cpus = _node_get_logical_cpus_to_bind_to(gpu_index=gpu_index)
     elif numa_options.affinity_mode == AffinityMode.SOCKET:
-        numactl_command_options = _get_socket_numactl_options(gpu_index=gpu_index)
+        logical_cpus = _socket_get_logical_cpus_to_bind_to(gpu_index=gpu_index)
     elif numa_options.affinity_mode == AffinityMode.EXCLUSIVE:
-        numactl_command_options = _get_exclusive_numactl_options(gpu_index=gpu_index)
+        logical_cpus = _exclusive_get_logical_cpus_to_bind_to(gpu_index=gpu_index)
     elif numa_options.affinity_mode == AffinityMode.CORE_COMPLEX:
-        numactl_command_options = _get_core_complex_numactl_options(gpu_index=gpu_index)
+        logical_cpus = _core_complex_get_logical_cpus_to_bind_to(gpu_index=gpu_index)
     else:
         raise ValueError(f"Affinity mode {numa_options.affinity_mode} not supported.")
 
-    return numactl_command_options
+    return logical_cpus
 
 
-def _raise_if_numactl_fails_dry_run(*, numactl_options: tuple[str, ...]) -> None:
-    noop_args = _get_assembled_command_from_pieces(
-        # Execute arbitrary noop
-        command_args=("true",),
-        numactl_options=numactl_options,
-    )
-
-    temporary_executable_path = _get_temporary_executable_for_command(
-        command_args=noop_args
-    )
-
-    try:
-        run(
-            (temporary_executable_path,),
-            stdout=subprocess.DEVNULL,
-            # These allow us to capture the stderr as text
-            stderr=subprocess.PIPE,
-            text=True,
-            # Raise exception if nonzero exit status.
-            check=True,
-        )
-    except subprocess.CalledProcessError as e:
-        raise RuntimeError(
-            f"""Our binding logic inferred to prepend your command with options {noop_args[:-1]}.
-            Before doing that, we did a noop dry run with args {noop_args}, but that command failed.
-            This should NOT happen, and likely suggests a bug in pytorch's numa binding logic.
-
-            The {_NUMACTL_COMMAND} command itself had this stderr:
-
-            {e.stderr}
-            """
-        ) from e
-
-
-def _get_assembled_command_from_pieces(
-    *, command_args: tuple[str, ...], numactl_options: tuple[str, ...]
-) -> tuple[str, ...]:
-    # Syntax for invoking a command but with numactl activated is numactl <args> command <args>
-    return (_NUMACTL_COMMAND, *numactl_options, *command_args)
-
-
-def _raise_if_numactl_not_available() -> None:
-    if not shutil.which(_NUMACTL_COMMAND):
-        raise RuntimeError(
-            f"{_NUMACTL_COMMAND} shell command is required for NUMA bindings."
-        )
-
-
-def _get_node_numactl_options(*, gpu_index: int) -> tuple[str, ...]:
+def _node_get_logical_cpus_to_bind_to(*, gpu_index: int) -> set[int]:
     """
     Core logic of 'node' numa strategy.
-
-    Returns options to be used with numactl. E.g.,
-    ("--cpunodebind=0").
     """
     numa_node_index = _get_numa_node_index_for_gpu_index(gpu_index=gpu_index)
 
-    return (f"--cpunodebind={numa_node_index}",)
+    return _get_allowed_logical_cpu_indices_for_numa_node(
+        numa_node_index=numa_node_index
+    )
 
 
-def _get_socket_numactl_options(*, gpu_index: int) -> tuple[str, ...]:
+def _socket_get_logical_cpus_to_bind_to(*, gpu_index: int) -> set[int]:
     """
     Core logic of 'socket' numa strategy.
     """
@@ -306,12 +187,19 @@ def _get_socket_numactl_options(*, gpu_index: int) -> tuple[str, ...]:
     numa_node_indices = _get_numa_node_indices_for_socket_index(
         socket_index=socket_index
     )
-    numa_node_indices_str = _get_ranges_str_from_ints(numa_node_indices)
 
-    return (f"--cpunodebind={numa_node_indices_str}",)
+    logical_cpus = set()
+    for numa_node_index in numa_node_indices:
+        logical_cpus.update(
+            _get_allowed_logical_cpu_indices_for_numa_node(
+                numa_node_index=numa_node_index
+            )
+        )
+
+    return logical_cpus
 
 
-def _get_exclusive_numactl_options(*, gpu_index: int) -> tuple[str, ...]:
+def _exclusive_get_logical_cpus_to_bind_to(*, gpu_index: int) -> set[int]:
     """
     Core logic of 'exclusive' numa strategy.
     """
@@ -370,20 +258,18 @@ def _get_exclusive_numactl_options(*, gpu_index: int) -> tuple[str, ...]:
     )
 
     # Slice and flatten the logical CPUs from the selected physical cores
-    logical_cpu_indices_for_original_gpu = (
+    logical_cpu_indices_for_original_gpu = {
         logical_cpu_index
         for logical_cpu_indices in list(
             physical_core_to_allowed_logical_cpu_indices.values()
         )[start:end]
         for logical_cpu_index in logical_cpu_indices
-    )
+    }
 
-    return (
-        f"--physcpubind={_get_ranges_str_from_ints(logical_cpu_indices_for_original_gpu)}",
-    )
+    return logical_cpu_indices_for_original_gpu
 
 
-def _get_core_complex_numactl_options(*, gpu_index: int) -> tuple[str, ...]:
+def _core_complex_get_logical_cpus_to_bind_to(*, gpu_index: int) -> set[int]:
     """
     Core logic of 'core-complex' numa strategy.
 
@@ -427,9 +313,7 @@ def _get_core_complex_numactl_options(*, gpu_index: int) -> tuple[str, ...]:
         max_level_cache_to_allowed_logical_cpu_indices.values()
     )[cache_index_for_original_gpu]
 
-    return (
-        f"--physcpubind={_get_ranges_str_from_ints(logical_cpu_indices_for_original_gpu)}",
-    )
+    return logical_cpu_indices_for_original_gpu
 
 
 K = TypeVar("K")


### PR DESCRIPTION
# Context
In #160163, we added support for NUMA binding for `Callable` entrypoints to `elastic_launch`. This requires special consideration, because they go through a different path to spawn subprocesses compared to `str` entrypoints, a path which does not provide a straightforward way to utilize `numactl` CLI. See #160006 for a full description of the challenges.

Although #160163 worked in initial local experiments, we ran into some linker errors in other environments when we tried to call `numactl`. This appeared to be due to interactions with how the `LD_PRELOAD` environment variable was being set.

# This PR
On further thought, the most straightforward, foolproof solution here is to use [the trick that @d4l3k suggested.](https://github.com/pytorch/pytorch/issues/160006#issuecomment-3162018836)

Specifically, for each local rank `i`:
1. The parent process sets its own CPU affinity to what local rank `i`'s should be.
2. Then, the parent spawns the subprocess for local rank `i`.
3. Finally, the parent resets its own CPU affinity to what it was originally.

There were other solutions that would work just for `Callable` entrypoints, but I believe this is the simplest one that can work for *both* `str` and `Callable`, and it's pretty simple.

This required a bit of refactoring:
1. Turn all the `_get_.*_numactl_options` into functions which return a set of logical CPUs to bind to, rather than options like `--cpunodebind=0`.
2. Instead of wrapping commands with `numactl`, use `os.sched_setaffinity` to bind to the CPUs from (1.).
3. Put this all inside a context manager which encapsulates applying and restoring the bindings in the parent process.
4. Use the context manager for both `str` and `Callable` paths

# Test Plan
## Automated
`$ pytest test/test_numa_binding.py`

## Manual
See [doc.](https://docs.google.com/document/d/1vxD-OKYBTT27jbBwtW9iz9g0tNM0u-i0tiTJg_ieQA8/edit?tab=t.0) Meta only, but TLDR tried out every combination of `str`, `Callable`, binding disabled, and binding enabled on the same model and saw 2x SM utilization for binding enabled.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta 