### PR TITLE
Update pyrefly config for better codenav

### DIFF
--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -93,7 +93,7 @@ errors.implicit-import = false
 # and mypy.ini specifies `check_untyped_defs = False` for this file.
 # If you check even the unannotated stuff mypy produces 322 errors.
 # "test/test_torch.py",
-# Uncomment this file to check 
+# Uncomment this file to check
 # [[tool.pyrefly.sub-config]]
 # matches = "test/test_torch.py"
 # untyped-def-behavior = "skip-and-infer-return-any"

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -93,9 +93,7 @@ errors.implicit-import = false
 # and mypy.ini specifies `check_untyped_defs = False` for this file.
 # If you check even the unannotated stuff mypy produces 322 errors.
 # "test/test_torch.py",
-
 # Uncomment this file to check 
 # [[tool.pyrefly.sub-config]]
 # matches = "test/test_torch.py"
-
 # untyped-def-behavior = "skip-and-infer-return-any"

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -86,10 +86,15 @@ ignore-missing-imports = [
 
 untyped_def_behavior = "check-and-infer-return-any"
 
+# Shut off noisey errors
+errors.implicit-import = false
+
 # We exclude test_torch.py because it is full of errors, but most functions lack type signatures,
 # and mypy.ini specifies `check_untyped_defs = False` for this file.
 # If you check even the unannotated stuff mypy produces 322 errors.
 # "test/test_torch.py",
+
+# Uncomment this file to check 
 # [[tool.pyrefly.sub-config]]
 # matches = "test/test_torch.py"
 

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -86,7 +86,7 @@ ignore-missing-imports = [
 
 untyped_def_behavior = "check-and-infer-return-any"
 
-# Shut off noisey errors
+# Shut off noisy errors
 errors.implicit-import = false
 
 # We exclude test_torch.py because it is full of errors, but most functions lack type signatures,

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -1,4 +1,4 @@
-project_includes = [
+project-includes = [
     "torch",
     "caffe2",
     "test/test_bundled_images.py",
@@ -7,12 +7,11 @@ project_includes = [
     "test/test_datapipe.py",
     "test/test_futures.py",
     "test/test_numpy_interop.py",
-    "test/test_torch.py",
     "test/test_type_hints.py",
     "test/test_type_info.py",
     "test/test_utils.py",
 ]
-project_excludes = [
+project-excludes = [
   "torch/include/**",
   "torch/csrc/**",
   "torch/distributed/elastic/agent/server/api.py",
@@ -27,7 +26,7 @@ project_excludes = [
   "*/__pycache__/**",
   "*/.*",
 ]
-replace_imports_with_any = [
+ignore-missing-imports = [
     "torch._C._jit_tree_views.*",
     "torch.for_onnx.onnx.*",
     "torch.ao.quantization.experimental.apot_utils.*",
@@ -86,3 +85,12 @@ replace_imports_with_any = [
 ]
 
 untyped_def_behavior = "check-and-infer-return-any"
+
+# We exclude test_torch.py because it is full of errors, but most functions lack type signatures,
+# and mypy.ini specifies `check_untyped_defs = False` for this file.
+# If you check even the unannotated stuff mypy produces 322 errors.
+# "test/test_torch.py",
+# [[tool.pyrefly.sub-config]]
+# matches = "test/test_torch.py"
+
+# untyped-def-behavior = "skip-and-infer-return-any"


### PR DESCRIPTION
This fixes behavior in codenav by switching from `replace_imports_with_any` to `ignore-missing-imports`
