### PR TITLE
[tgif] fix getattr_recursive with ModuleList

### DIFF
--- a/torch/fx/passes/split_utils.py
+++ b/torch/fx/passes/split_utils.py
@@ -17,7 +17,12 @@ __all__ = ["getattr_recursive", "setattr_recursive", "Component", "split_by_tags
 @compatibility(is_backward_compatible=False)
 def getattr_recursive(obj, name):
     for layer in name.split("."):
-        if hasattr(obj, layer):
+        if isinstance(obj, torch.nn.ModuleList):
+            if hasattr(obj, "_modules") and layer in obj._modules:
+                obj = obj._modules[layer]
+            else:
+                return None
+        elif hasattr(obj, layer):
             obj = getattr(obj, layer)
         else:
             return None


### PR DESCRIPTION
Summary: This change updates `getattr_recursive`  to handle qualnames with ModuleList that contain digit indices, for example, `op_instances.1.value_model.feature_weights`

Test Plan:
TBA

Rollback Plan:

Reviewed By: jiayisuse

Differential Revision: D80503985




cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv