### PR TITLE
Avoid making node a successor/predecessor of itself

### DIFF
--- a/torch/_inductor/memory.py
+++ b/torch/_inductor/memory.py
@@ -281,6 +281,7 @@ def assign_memory_planning_info_for_scheduler_nodes(
         succ_nodes = node_to_succ_nodes[node]
         pred_nodes = node_to_pred_nodes[node]
 
+        # make sure we do not make node a successor or predecessor of itself
         succ_nodes.discard(node)
         pred_nodes.discard(node)
 
@@ -288,7 +289,6 @@ def assign_memory_planning_info_for_scheduler_nodes(
             index=index,
             size=size_alloc,
             pred_buffers=node_to_pred_buffers[node],
-            # make sure we do not make node a successor or predecessor of itslef
             pred_nodes=node_to_pred_nodes[node],
             succ_nodes=succ_nodes,
         )

--- a/torch/_inductor/memory.py
+++ b/torch/_inductor/memory.py
@@ -279,11 +279,16 @@ def assign_memory_planning_info_for_scheduler_nodes(
     for index, node in enumerate(nodes):
         size_alloc = sum(buffer.mpi_buffer.size_alloc for buffer in node.get_outputs())
         succ_nodes = node_to_succ_nodes[node]
+        pred_nodes = node_to_pred_nodes[node]
+
+        succ_nodes.discard(node)
+        pred_nodes.discard(node)
 
         node.mpi_node = MemoryPlanningInfoForNode(
             index=index,
             size=size_alloc,
             pred_buffers=node_to_pred_buffers[node],
+            # make sure we do not make node a successor or predecessor of itslef
             pred_nodes=node_to_pred_nodes[node],
             succ_nodes=succ_nodes,
         )
@@ -677,6 +682,7 @@ def validate_graph_acyclic(nodes: list[BaseSchedulerNode]) -> None:
         path.append(node)
 
         for pred_node in node.mpi_node.pred_nodes:
+            assert pred_node != node
             dfs_visit(pred_node)
 
         path.pop()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #161205

This fixes an assertion we were running into in the memory planning about not having an acyclic graph. The repro is very long so hard to make local test of, but fixes repro I am looking at.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben