### PR TITLE
[hop] make materialize_as_graph disable pre-existing dispatch modes

### DIFF
--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -1149,6 +1149,12 @@ def materialize_as_graph(
                 )
                 if force_enable_grad:
                     stack.enter_context(torch.enable_grad())
+                # fake_mode is needed because parent tracer's fake_mode might
+                # be None but the associated inputs have fake mode or there
+                # is a global tracing context with fake mode. We nneed to
+                # make sure the fake mode when tracing subgraph is consistent.
+                if fake_mode := detect_fake_mode(unfunc_t):
+                    stack.enter_context(fake_mode)
                 return _maybe_reenter_make_fx(fn)(*unfunc_t)
 
     gm = _materialize_as_graph_inner()

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -148,11 +148,9 @@ def _maybe_reenter_make_fx(fn):
 
                 fake_mode = detect_fake_mode(args)
                 if fake_mode is None:
-                    # we create a fake_mode here to make sure we could
+                    # we creaeta a fake_mode here to make sure we could
                     # trace the graph with data-dependent calls e.g. .item()
-                    return make_fx(
-                        fn, tracing_mode="fake", _allow_non_fake_inputs=True
-                    )(*args)
+                    return make_fx(fn, tracing_mode="fake")(*args)
                 # Tracing with real if all inputs have been fakfied
                 return make_fx(fn)(*args)
 

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -148,9 +148,11 @@ def _maybe_reenter_make_fx(fn):
 
                 fake_mode = detect_fake_mode(args)
                 if fake_mode is None:
-                    # we creaeta a fake_mode here to make sure we could
+                    # we create a fake_mode here to make sure we could
                     # trace the graph with data-dependent calls e.g. .item()
-                    return make_fx(fn, tracing_mode="fake")(*args)
+                    return make_fx(
+                        fn, tracing_mode="fake", _allow_non_fake_inputs=True
+                    )(*args)
                 # Tracing with real if all inputs have been fakfied
                 return make_fx(fn)(*args)
 
@@ -1136,9 +1138,11 @@ def materialize_as_graph(
 
     @torch._dynamo.disable(recursive=True, reason=None)
     def _materialize_as_graph_inner():
-        with suspend_functionalization(), disable_functional_mode():
-            with disable_proxy_modes_tracing():
-                unfunc_t = [_from_fun(arg) for arg in args]
+        with (
+            suspend_functionalization(),
+            torch.utils._python_dispatch._disable_current_modes(),
+        ):
+            unfunc_t = [_from_fun(arg) for arg in args]
             with contextlib.ExitStack() as stack:
                 stack.enter_context(
                     torch._C._ForceDispatchKeyGuard(include_key_set, exclude_key_set),

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -1136,12 +1136,14 @@ def materialize_as_graph(
 
     @torch._dynamo.disable(recursive=True, reason=None)
     def _materialize_as_graph_inner():
-        with (
-            suspend_functionalization(),
-            torch.utils._python_dispatch._disable_current_modes(),
-        ):
-            unfunc_t = [_from_fun(arg) for arg in args]
+        with suspend_functionalization(), disable_functional_mode():
+            with disable_proxy_modes_tracing():
+                unfunc_t = [_from_fun(arg) for arg in args]
+
             with contextlib.ExitStack() as stack:
+                stack.enter_context(
+                    torch.utils._python_dispatch._disable_current_modes()
+                )
                 stack.enter_context(
                     torch._C._ForceDispatchKeyGuard(include_key_set, exclude_key_set),
                 )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #161220

For materializing_as_subgraph, we just want to trace a graph. The handling of different modes should register their own logic. 

