### PR TITLE
Fix OpSchema equality check

### DIFF
--- a/test/distributed/tensor/test_op_schema.py
+++ b/test/distributed/tensor/test_op_schema.py
@@ -1,0 +1,21 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+# Owner(s): ["oncall: distributed"]
+
+from torch.distributed.tensor._dtensor_spec import DTensorSpec
+from torch.distributed.tensor._op_schema import OpSchema
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestOpSchema(TestCase):
+    def test_equality_checks_lists_of_dtensor_spec(self):
+        """If x == y, then we must have h(x) == h(y)."""
+        dts = DTensorSpec(mesh=None, placements=tuple(), tensor_meta=None)
+        schema1 = OpSchema(op=None, args_schema=[dts, [dts]], kwargs_schema={})
+        schema2 = OpSchema(op=None, args_schema=[dts, [dts, dts]], kwargs_schema={})
+        # This is a regression test; these schemas used to compare equal.
+        self.assertNotEqual(schema1, schema2)
+        self.assertNotEqual(hash(schema1), hash(schema2))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/distributed/tensor/_op_schema.py
+++ b/torch/distributed/tensor/_op_schema.py
@@ -392,8 +392,7 @@ class OpSchema:
                     break
         self.has_symints = has_symints
 
-    def arg_type_tensor_or_tensor_list_like(self, arg_idx: int) -> bool:
-        arg = self.args_schema[arg_idx]
+    def arg_type_tensor_or_tensor_list_like(self, arg: object) -> bool:
         is_tensor = isinstance(arg, DTensorSpec)
         if is_tensor:
             return True
@@ -492,7 +491,7 @@ class OpSchema:
         args_to_hash = tuple(
             tuple(e) if isinstance(e, list) else e
             for i, e in enumerate(self.args_schema)
-            if self.arg_type_tensor_or_tensor_list_like(i) or i >= static_argnum
+            if self.arg_type_tensor_or_tensor_list_like(e) or i >= static_argnum
         )
         if static_kwargkey is not None:
             kwargs_to_hash = tuple(
@@ -524,7 +523,10 @@ class OpSchema:
         for i, (self_arg, other_arg) in enumerate(
             zip(self.args_schema, other.args_schema)
         ):
-            if isinstance(self_arg, DTensorSpec) and self_arg != other_arg:
+            if (
+                self.arg_type_tensor_or_tensor_list_like(self_arg)
+                and self_arg != other_arg
+            ):
                 return False
             elif i >= static_argnum and self_arg != other_arg:
                 return False


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #161329
* #161328
* #161317
* #161315
* #161308
* #161304
* #161292
* #161301
* #161300
* #161286
* #161285
* #161284
* #161240
* #161235
* #161234
* __->__ #161231

`__eq__` didn't compare lists of DTensorSpec, but `__hash__` did (and
it looks like attention was paid to hash, so I made comparison follow
suit).

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta