### PR TITLE
Add prefix_kernel_name for gemm template

### DIFF
--- a/torch/_inductor/codegen/cpp_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_gemm_template.py
@@ -193,7 +193,7 @@ extern "C" {{export_declaration}}
 GEMM_TEMPLATE = r"""
 {{ template.codegen_gemm_stub_def() }}
 {
-    {{ kernel.maybe_codegen_profile() }}
+    {{ kernel.maybe_codegen_profile(template.get_kernel_prefix_name()) }}
     {{ template.codegen_blocks(
         num_threads, N, K, micro_gemm, is_dynamic_M, kernel, GemmOut, config, L1_cache_size, L2_cache_size, X, W
     ) }}
@@ -1573,6 +1573,9 @@ class CppGemmTemplate(CppTemplate):
             and X.get_dtype() is torch.bfloat16
             and W.get_dtype() is torch.int8
         )
+
+    def get_kernel_prefix_name(self) -> str:
+        return f"m{self.m}" + f"_n{self.n}" + f"_k{self.k}"
 
     def render(  # type: ignore[override, return]
         self,

--- a/torch/_inductor/codegen/cpp_grouped_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_grouped_gemm_template.py
@@ -40,7 +40,7 @@ GEMM_TEMPLATE = r"""
 extern "C" {{export_declaration}}
 {{kernel.def_kernel(inputs=kernel_args, outputs=Y_list, aliases=aliases)}}
 {
-    {{kernel.maybe_codegen_profile()}}
+    {{kernel.maybe_codegen_profile(template.get_kernel_prefix_name())}}
     {{ template.codegen_blocks(
         num_threads, N, K, micro_gemm, is_dynamic_M, kernel, GemmOuts[0], config, L1_cache_size, L2_cache_size, X_list[0], W_list[0]
     ) }}
@@ -343,6 +343,11 @@ class CppGroupedGemmTemplate(CppGemmTemplate):
         )
         template.maybe_append_choice(choices)
         return template
+
+    def get_kernel_prefix_name(self) -> str:
+        return (
+            f"g{self.gemm_grouped_num}_" + f"m{self.m}" + f"_n{self.n}" + f"_k{self.k}"
+        )
 
     def render(  # type: ignore[override,return,no-untyped-def]
         self,

--- a/torch/_inductor/codegen/cpp_template_kernel.py
+++ b/torch/_inductor/codegen/cpp_template_kernel.py
@@ -186,10 +186,17 @@ class CppTemplateKernel(CppKernel):
         assert isinstance(permuted, ir.ReinterpretView)
         return permuted
 
-    def maybe_codegen_profile(self) -> str:
+    def maybe_codegen_profile(self, prefix_kernel_name: Optional[str] = None) -> str:
         if config.cpp.enable_kernel_profile:
             graph_id = V.graph.graph_id
-            prefix = "graph_" + str(graph_id) + "_" if graph_id is not None else ""
+            if prefix_kernel_name:
+                prefix = (
+                    "graph_" + str(graph_id) + "_" + prefix_kernel_name + "_"
+                    if graph_id is not None
+                    else ""
+                )
+            else:
+                prefix = "graph_" + str(graph_id) + "_" if graph_id is not None else ""
             handle_str = (
                 "torch::aot_inductor::RAIIAtenRecordFunctionHandle "
                 f'record_{prefix}{self.kernel_name}_("{prefix}{self.kernel_name}", nullptr);'


### PR DESCRIPTION
Profiling doesn't distinguish between different template kernels, making analysis difficult:
<img width="577" height="113" alt="image" src="https://github.com/user-attachments/assets/62875981-e02d-463c-b9ae-a9b98d45a938" />

Therefore, adding a kernel prefix name to the gemm template helps distinguish different template kernels.
Python wrapper:
<img width="574" height="109" alt="image" src="https://github.com/user-attachments/assets/b83f5fe4-9879-47ce-b606-ab9235480d9f" />

CPP wrapper:
<img width="614" height="109" alt="image" src="https://github.com/user-attachments/assets/655d58e7-5991-41e3-85d4-8a8c31a9ceb4" />


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @chenyang78