### PR TITLE
Optimzie `zero_grad` description

### DIFF
--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -998,16 +998,18 @@ class Optimizer:
         r"""Reset the gradients of all optimized :class:`torch.Tensor` s.
 
         Args:
-            set_to_none (bool): instead of setting to zero, set the grads to None.
+            set_to_none (bool, optional): Instead of setting to zero, set the grads to None. Default: ``True``
+
                 This will in general have lower memory footprint, and can modestly improve performance.
                 However, it changes certain behaviors. For example:
+
                 1. When the user tries to access a gradient and perform manual ops on it,
-                a None attribute or a Tensor full of 0s will behave differently.
+                   a None attribute or a Tensor full of 0s will behave differently.
                 2. If the user requests ``zero_grad(set_to_none=True)`` followed by a backward pass, ``.grad``\ s
-                are guaranteed to be None for params that did not receive a gradient.
+                   are guaranteed to be None for params that did not receive a gradient.
                 3. ``torch.optim`` optimizers have a different behavior if the gradient is 0 or None
-                (in one case it does the step with a gradient of 0 and in the other it skips
-                the step altogether).
+                   (in one case it does the step with a gradient of 0 and in the other it skips
+                   the step altogether).
         """
         foreach = self.defaults.get("foreach", False) or self.defaults.get(
             "fused", False


### PR DESCRIPTION
Optimize [zero_grad doc](https://docs.pytorch.org/docs/stable/generated/torch.optim.Optimizer.zero_grad.html) format and description.

## Test Result

### Before 

<img width="996" height="534" alt="image" src="https://github.com/user-attachments/assets/e1db973c-57e8-4525-90e7-0500cde2263d" />


### After

<img width="890" height="496" alt="image" src="https://github.com/user-attachments/assets/5579c4fb-a857-4030-9303-34770083d1a5" />
