### PR TITLE
Disable background threads for XPU host allocator

### DIFF
--- a/aten/src/ATen/xpu/CachingHostAllocator.cpp
+++ b/aten/src/ATen/xpu/CachingHostAllocator.cpp
@@ -32,8 +32,8 @@ struct XPUCachingHostAllocatorImpl
   }
 
   bool pinned_use_background_threads() override {
-    // Background threads for XPU currently hang on Windows.
-    // This will be enabled once the underlying issue is fixed.
+    // Using background threads for XPU causes a hang on Windows during program
+    // exit. Will be enabled once the issue is resolved.
     return false;
   }
 };

--- a/aten/src/ATen/xpu/CachingHostAllocator.cpp
+++ b/aten/src/ATen/xpu/CachingHostAllocator.cpp
@@ -30,6 +30,12 @@ struct XPUCachingHostAllocatorImpl
   bool query_event(XPUEvent& event) override {
     return event.query();
   }
+
+  bool pinned_use_background_threads() override {
+    // Background threads for XPU currently hang on Windows.
+    // This will be enabled once the underlying issue is fixed.
+    return false;
+  }
 };
 
 DECLARE_HOST_ALLOCATOR(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #161242

# Motivation
https://github.com/pytorch/pytorch/pull/160505 enables background threads for XPU host allocator. However, it will hang on Windows during program exit. Now disable it until we narrow down the issue.
