### PR TITLE
Clarrifying input output angle unit in the docs for trigonometric fun…

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -3135,7 +3135,7 @@ add_docstr(
     r"""
 cos(input, *, out=None) -> Tensor
 
-Returns a new tensor with the cosine of the elements in the :attr:`input` tensor where each value is in radians.
+Returns a new tensor with the cosine of the elements in the :attr:`input` tensor where each value in this input tensor is in radians.
 
 .. math::
     \text{out}_{i} = \cos(\text{input}_{i})
@@ -9942,7 +9942,7 @@ add_docstr(
     r"""
 sin(input, *, out=None) -> Tensor
 
-Returns a new tensor with the sine of the elements in the :attr:`input` tensor where each value is in radians.
+Returns a new tensor with the sine of the elements in the :attr:`input` tensor where each value in this input tensor is in radians.
 
 .. math::
     \text{out}_{i} = \sin(\text{input}_{i})
@@ -11359,7 +11359,7 @@ add_docstr(
     r"""
 tan(input, *, out=None) -> Tensor
 
-Returns a new tensor with the tangent of the elements in the :attr:`input` tensor where each value is in radians.
+Returns a new tensor with the tangent of the elements in the :attr:`input` tensor where each value in this input tensor is in radians.
 
 .. math::
     \text{out}_{i} = \tan(\text{input}_{i})

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -253,7 +253,7 @@ add_docstr(
     r"""
 acos(input: Tensor, *, out: Optional[Tensor]) -> Tensor
 
-Returns a new tensor with the arccosine of the elements (in radians) in the :attr:`input` tensor.
+Returns a new tensor with the arccosine (in radians) of each element in :attr:`input`.
 
 .. math::
     \text{out}_{i} = \cos^{-1}(\text{input}_{i})

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -253,7 +253,7 @@ add_docstr(
     r"""
 acos(input: Tensor, *, out: Optional[Tensor]) -> Tensor
 
-Computes the inverse cosine of each element in :attr:`input`.
+Returns a new tensor with the arccosine of the elements (in radians) in the :attr:`input` tensor.
 
 .. math::
     \text{out}_{i} = \cos^{-1}(\text{input}_{i})
@@ -1047,7 +1047,7 @@ add_docstr(
     r"""
 asin(input: Tensor, *, out: Optional[Tensor]) -> Tensor
 
-Returns a new tensor with the arcsine of the elements of :attr:`input`.
+Returns a new tensor with the arcsine of the elements (in radians) in the :attr:`input` tensor.
 
 .. math::
     \text{out}_{i} = \sin^{-1}(\text{input}_{i})
@@ -1119,7 +1119,7 @@ add_docstr(
     r"""
 atan(input: Tensor, *, out: Optional[Tensor]) -> Tensor
 
-Returns a new tensor with the arctangent of the elements of :attr:`input`.
+Returns a new tensor with the arctangent of the elements (in radians) in the :attr:`input` tensor.
 
 .. math::
     \text{out}_{i} = \tan^{-1}(\text{input}_{i})
@@ -3135,7 +3135,7 @@ add_docstr(
     r"""
 cos(input, *, out=None) -> Tensor
 
-Returns a new tensor with the cosine  of the elements of :attr:`input`.
+Returns a new tensor with the cosine of the elements in the :attr:`input` tensor where each value is in radians.
 
 .. math::
     \text{out}_{i} = \cos(\text{input}_{i})
@@ -9942,7 +9942,7 @@ add_docstr(
     r"""
 sin(input, *, out=None) -> Tensor
 
-Returns a new tensor with the sine of the elements of :attr:`input`.
+Returns a new tensor with the sine of the elements in the :attr:`input` tensor where each value is in radians.
 
 .. math::
     \text{out}_{i} = \sin(\text{input}_{i})
@@ -11359,7 +11359,7 @@ add_docstr(
     r"""
 tan(input, *, out=None) -> Tensor
 
-Returns a new tensor with the tangent of the elements of :attr:`input`.
+Returns a new tensor with the tangent of the elements in the :attr:`input` tensor where each value is in radians.
 
 .. math::
     \text{out}_{i} = \tan(\text{input}_{i})

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -3135,7 +3135,7 @@ add_docstr(
     r"""
 cos(input, *, out=None) -> Tensor
 
-Returns a new tensor with the cosine of the elements in the :attr:`input` tensor where each value in this input tensor is in radians.
+Returns a new tensor with the cosine of the elements of :attr:`input` given in radians.
 
 .. math::
     \text{out}_{i} = \cos(\text{input}_{i})

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -9942,7 +9942,8 @@ add_docstr(
     r"""
 sin(input, *, out=None) -> Tensor
 
-Returns a new tensor with the sine of the elements in the :attr:`input` tensor where each value in this input tensor is in radians.
+Returns a new tensor with the sine of the elements in the :attr:`input` tensor,
+where each value in this input tensor is in radians.
 
 .. math::
     \text{out}_{i} = \sin(\text{input}_{i})
@@ -11359,7 +11360,8 @@ add_docstr(
     r"""
 tan(input, *, out=None) -> Tensor
 
-Returns a new tensor with the tangent of the elements in the :attr:`input` tensor where each value in this input tensor is in radians.
+Returns a new tensor with the tangent of the elements in the :attr:`input` tensor,
+where each value in this input tensor is in radians.
 
 .. math::
     \text{out}_{i} = \tan(\text{input}_{i})


### PR DESCRIPTION
…ctions

Fixes #[160995](https://github.com/pytorch/pytorch/issues/160995)

Modified the docs to clarify that input tensor  values for torch.sin, torch.cos and torch.tan should be in radians and the output tensor  values for torch.acos, torch.asin and torch.atan is in radians.