### PR TITLE
[inductor] Add get page_size support for Windows.

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -2398,9 +2398,18 @@ end
                     os.remove(o_file)
 
                 if use_mmap_weights:
-                    import resource
 
-                    page_size_ = resource.getpagesize()
+                    def get_page_size():
+                        # Don't use resource.getpagesize(), as it is a Unix specific package
+                        # as seen in https://docs.python.org/2/library/resource.html
+                        import psutil
+
+                        try:
+                            return psutil.virtual_memory().page_size
+                        except:
+                            return 4096  # Default valuevalue
+
+                    page_size_ = get_page_size()
                     page_size = max(16384, page_size_)
 
                     with open(output_so, "a+b") as f_so:

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -2399,15 +2399,12 @@ end
 
                 if use_mmap_weights:
 
-                    def get_page_size():
+                    def get_page_size() -> int:
                         # Don't use resource.getpagesize(), as it is a Unix specific package
                         # as seen in https://docs.python.org/2/library/resource.html
-                        import psutil
+                        page_size = os.sysconf("SC_PAGE_SIZE")
 
-                        try:
-                            return psutil.virtual_memory().page_size
-                        except:
-                            return 4096  # Default valuevalue
+                        return page_size
 
                     page_size_ = get_page_size()
                     page_size = max(16384, page_size_)

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -2403,7 +2403,11 @@ end
                         # Don't use resource.getpagesize() on Windows, as it is a Unix specific package
                         # as seen in https://docs.python.org/2/library/resource.html
                         if _IS_WINDOWS:
-                            from ctypes import byref, Structure, windll
+                            from ctypes import (  # type: ignore[attr-defined]
+                                byref,
+                                Structure,
+                                windll,
+                            )
                             from ctypes.wintypes import DWORD, LPVOID, WORD
 
                             class SYSTEM_INFO(Structure):


### PR DESCRIPTION
`resource` can't work on Windows, as it is a Unix specific package as seen in https://docs.python.org/2/library/resource.html

Use Windows system API to get page_size.

Local tested:
<img width="467" height="433" alt="image" src="https://github.com/user-attachments/assets/47a39060-3aea-46c3-bd8e-35a39413c51f" />


cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben