### PR TITLE
[ROCm] Enable unit tests in test_matmul_cuda.py

### DIFF
--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -63,6 +63,9 @@ if TEST_CUDA:
 # Protects against includes accidentally setting the default dtype
 assert torch.get_default_dtype() is torch.float32
 
+input_dtypes = [torch.float32]
+if not torch.version.hip:
+    input_dtypes += [torch.float16, torch.bfloat16]
 
 @contextlib.contextmanager
 def blas_library_context(backend):
@@ -612,8 +615,7 @@ class TestMatmulCuda(TestCase):
 
 
     @onlyCUDA
-    @skipIfRocm
-    @parametrize("input_dtype", [torch.float32, torch.float16, torch.bfloat16])
+    @parametrize("input_dtype", input_dtypes)
     @parametrize("M", [1, 32, 64])
     @parametrize("N", [1, 32, 64])
     @parametrize("K", [1, 32, 64])
@@ -667,8 +669,7 @@ class TestMatmulCuda(TestCase):
 
 
     @onlyCUDA
-    @skipIfRocm
-    @parametrize("input_dtype", [torch.float32, torch.float16, torch.bfloat16])
+    @parametrize("input_dtype", input_dtypes)
     @parametrize("M", [1, 32, 64])
     @parametrize("N", [1, 32, 64])
     @parametrize("K", [1, 32, 64])


### PR DESCRIPTION
This PR is to enable 162 test_addmm_baddmm_dtype_overload_float32* and 162 test_mm_bmm_dtype_overload_float32* tests on ROCm. 

This enables 324 tests in total.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd