### PR TITLE
Back out "Enable output padding when only outermost dim is dynamic"

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3739,8 +3739,10 @@ class Layout(OutputSpec):
         # do for dynamic shape.
         #
         # Skip padding the strides for dynamic shape for now.
-        # If outermost dim is dynamic, stride still can be fully static
-        if not all(isinstance(s, (int, sympy.Integer)) for s in in_strides):
+        if not all(
+            isinstance(s, (int, sympy.Integer))
+            for s in itertools.chain(in_strides, size)
+        ):
             return in_strides
 
         stride_order = get_stride_order(in_strides)
@@ -3755,11 +3757,11 @@ class Layout(OutputSpec):
         for rank, idx in enumerate(fill_order[1:], start=1):
             prev_idx = fill_order[rank - 1]
             stride = new_strides[prev_idx] * size[prev_idx]
-            if isinstance(stride, (int, sympy.Integer)):
-                if stride > config.padding_stride_threshold and stride % align != 0:
-                    stride = ceildiv(stride, align) * align
-                    padded = True
-                new_strides[idx] = stride
+
+            if stride > config.padding_stride_threshold and stride % align != 0:
+                stride = ceildiv(stride, align) * align
+                padded = True
+            new_strides[idx] = stride
 
         if not padded:
             # Consider a tensor with shape [256, 1, 5, 5]


### PR DESCRIPTION
Summary:
Original commit changeset: 9f5a12b7fd0e

Original Phabricator Diff: D79146886

Test Plan:
OOM is gone after back-out with the repro script: P1914070645

Rollback Plan:

Differential Revision: D80812202




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben