### PR TITLE
Remove unnecessary len() call in _correct_storage_aliasing.is_read_only_alias_match

### DIFF
--- a/torch/utils/_python_dispatch.py
+++ b/torch/utils/_python_dispatch.py
@@ -501,7 +501,7 @@ and output of type {type(ret)}. But expected types to match."""
 
     def is_read_only_alias_match(arg, ret):
         shared_aliases = arg.alias_set & ret.alias_set
-        return len(shared_aliases) > 0 and not arg.is_write
+        return shared_aliases and not arg.is_write
 
     num_args = len(func._schema.arguments)
     num_returns = len(func._schema.returns)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #161329
* #161328
* #161317
* #161315
* #161308
* #161304
* #161292
* #161301
* #161300
* #161286
* #161285
* __->__ #161284
* #161240
* #161235
* #161234
* #161231

Containers are truthy iff they're non-empty.