### PR TITLE
[SymmMem] Allow handle->buffer to point to tensor's data_ptr

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -832,12 +832,11 @@ c10::intrusive_ptr<CUDASymmetricMemory> make_symm_mem(
 } // namespace
 
 c10::intrusive_ptr<SymmetricMemory> CUDASymmetricMemoryAllocator::rendezvous(
-    void* ptr,  // data_ptr() of the tensor
+    const at::Tensor& tensor,
     const std::optional<std::string>& group_name) {
-  // Today this would still find the ptr in the map because one allocation
-  // matches one tensor. But will break once we enable MemPool.
-  // TODO: implement a customized `find` that searches for the allocation that
-  // contains ptr.
+  // CUDA SymmMem backend uses storage ptr as key to find the block
+  auto ptr = tensor.storage().data_ptr().get();
+
   auto block = find_block(ptr);
   if (block == nullptr) {
     return nullptr;

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.hpp
@@ -115,7 +115,7 @@ class CUDASymmetricMemoryAllocator : public SymmetricMemoryAllocator {
   void free(void* ptr) override;
   size_t get_alloc_size(void* ptr) override;
   c10::intrusive_ptr<SymmetricMemory> rendezvous(
-      void* ptr,
+      const at::Tensor& tensor,
       const std::optional<std::string>& group_name) override;
   bool has_multicast_support(int device_idx) override;
   c10::DeviceType supported_device_type() override;

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
@@ -253,7 +253,7 @@ TORCH_API c10::intrusive_ptr<SymmetricMemory> rendezvous(
     const at::Tensor& tensor,
     const std::optional<std::string>& group_name) {
   auto allocator = get_allocator(tensor.device().type());
-  return allocator->rendezvous(tensor.storage().data_ptr().get(), group_name);
+  return allocator->rendezvous(tensor, group_name);
 }
 
 TORCH_API bool has_multicast_support(

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
@@ -93,7 +93,7 @@ class SymmetricMemoryAllocator : public c10::intrusive_ptr_target {
   virtual void free(void* ptr) = 0;
   virtual size_t get_alloc_size(void* ptr) = 0;
   virtual c10::intrusive_ptr<SymmetricMemory> rendezvous(
-      void* ptr,
+      const at::Tensor& tensor,
       const std::optional<std::string>& group_name) = 0;
   virtual bool has_multicast_support(int device_idx) = 0;
   virtual c10::DeviceType supported_device_type() = 0;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #161309

This PR is intended to guard against a case where a user passes `x[1]` to our ops.
If we use storage ptr to search in the `symm_mem` map, `x[1]` would end up with a hit, returning the same handle as `x[0]`. But `handle->buffer` points to `x[0]` address instead of `x[1]`. Since most of our ops today feed these buffer addresses into the kernel, so I think it'd be better for them to be distinctive.

Using `data_ptr` as key would create more entries in the `symm_mem` map (hopefully not by much), but I think that can be compensated by reducing the handle creation cost (later PRs).

(Only changed for NVSHMEM backend.)

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta