### PR TITLE
[TEST][DO NOT MERGE] test bc-linter with the new config

### DIFF
--- a/.github/workflows/lint-bc.yml
+++ b/.github/workflows/lint-bc.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run BC Lint Action
-        uses: pytorch/test-infra/.github/actions/bc-lint@main
+        uses: pytorch/test-infra/.github/actions/bc-lint@bc-linter-support-config-test
         with:
           repo: ${{ github.event.pull_request.head.repo.full_name }}
           base_sha: ${{ github.event.pull_request.base.sha }}

--- a/tools/test/linter_test_case.py
+++ b/tools/test/linter_test_case.py
@@ -24,7 +24,7 @@ class LinterTestCase(TestCase):
         return replacement
 
     @mock.patch("sys.stdout", new_callable=io.StringIO)
-    def lint_test(self, path, args, mock_stdout):
+    def lint_test(self, path, args, mock_stdout, required_flag):
         return self._lint_test(path, args, mock_stdout)[:2]
 
     @mock.patch("sys.stdout", new_callable=io.StringIO)

--- a/tools/test/test_upload_stats_lib.py
+++ b/tools/test/test_upload_stats_lib.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+# Harmless change in an excluded path to validate that excluded, non-API changes
+# do not produce BC-linter violations.
+
 import gzip
 import inspect
 import json


### PR DESCRIPTION
Testing the new bc-lint config as close to prod as reasonable.

This PR introduces four changes that test the [new bc-linter config ](https://github.com/pytorch/pytorch/pull/161319), testing the permutations of two factors:
* the change is excluded based on the config
* the change is a BC-violation


Changes tests:

- Included + violation: tools/vscode_settings.py
    - Changed deep_update(d, u) → deep_update(d, u, merge_lists) and updated the internal call to pass True.
    - This introduces a new required positional parameter, which should trigger a violation.
    - File: tools/vscode_settings.py
    - File: tools/vscode_settings.py

- Included + no violation: tools/vscode_settings.py
    - Added harmless public helper add_one(x: int) -> int.
    - Additions don’t trigger violations per stronghold’s checks.

- Excluded + “violation”: tools/test/linter_test_case.py
    - Modified method signature lint_test(self, path, args, mock_stdout) → lint_test(self, path, args, mock_stdout, required_flag).
    - This would be a violation if included, but **/test/** is excluded, so bc-linter should ignore it.

- Excluded + no violation: tools/test/test_upload_stats_lib.py
    - Added a top-of-file comment only (no API change).
    - As an excluded path with a harmless diff, bc-linter should report nothing.
    
    
---

The expectation is that only one change triggers BC-linter, namely "Included + violation: tools/vscode_settings.py"