### PR TITLE
Use `itertools.batched` if available within `new_subgroups`

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -5458,7 +5458,7 @@ def new_subgroups(
         ranks_per_subgroup_list = [
             ranks[i : i + group_size] for i in range(0, len(ranks), group_size)
         ]
-    
+
     return new_subgroups_by_enumeration(
         ranks_per_subgroup_list,
         timeout=timeout,

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -5447,17 +5447,14 @@ def new_subgroups(
             f"The world size ({world_size}) must be divisible by '{group_size=}'"
         )
 
-    # TODO can be dropped once compat for <=cp3.11 is dropped
-    try:
-        from itertools import batched
-        _use_batched = True
-    except ImportError:
-        _use_batched = False
-
     ranks = get_process_group_ranks(group=group)
-    if _use_batched:
-        ranks_per_subgroup_list = list(map(list, batched(ranks, group_size)))
+
+    # TODO can be dropped once compat for <=cp3.11 is dropped
+    if sys.version_info >= (3, 12):
+        # cp3.12<= has itertools.batched
+        ranks_per_subgroup_list = list(map(list, itertools.batched(ranks, group_size)))
     else:
+        # Fallback for older versions
         ranks_per_subgroup_list = [
             ranks[i : i + group_size] for i in range(0, len(ranks), group_size)
         ]

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -5456,7 +5456,7 @@ def new_subgroups(
 
     ranks = get_process_group_ranks(group=group)
     if _use_batched:
-        ranks_per_subgroup_list = [list(chunk) for chunk in batched(ranks, group_size)]
+        ranks_per_subgroup_list = list(map(list, batched(ranks, group_size)))
     else:
         ranks_per_subgroup_list = [
             ranks[i : i + group_size] for i in range(0, len(ranks), group_size)


### PR DESCRIPTION
Uses the new `itertools.batched` (`cp3.12`) functionality if its available instead of list comprehension. Something worth considering is if we should move the try except outside of the function so it doesn't have to check every time `new_subgroups` is called.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci