### PR TITLE
[poc] aot precompile with custom backend api

### DIFF
--- a/test/dynamo/test_aot_compile.py
+++ b/test/dynamo/test_aot_compile.py
@@ -1,0 +1,121 @@
+# Owner(s): ["module: dynamo"]
+
+import os
+import pickle
+
+import torch
+import torch._dynamo.testing
+import torch._inductor.config
+import torch._inductor.test_case
+import torch.onnx.operators
+import torch.utils.cpp_extension
+from torch._dynamo.package import DynamoCache
+from torch._dynamo.precompile_context import PrecompileContext
+from torch._inductor.runtime.runtime_utils import cache_dir
+from torch.fx._graph_pickler import GraphPickler
+from torch.testing._internal.common_utils import instantiate_parametrized_tests
+
+
+class CustomCompiledFunction(torch._dynamo.aot_compile.SerializableCallable):
+    def __init__(self, gm: torch.fx.GraphModule, example_inputs: list[torch.Tensor]):
+        self.gm = gm
+        self.example_inputs = example_inputs
+
+    @classmethod
+    def serialize_compile_artifacts(cls, fn) -> bytes:
+        state = fn.__dict__.copy()
+        state["gm"] = GraphPickler.dumps(state["gm"])
+        return pickle.dumps(state)
+
+    @classmethod
+    def deserialize_compile_artifacts(cls, data: bytes):
+        state = pickle.loads(data)
+        fake_mode = torch._subclasses.FakeTensorMode()
+        state["gm"] = GraphPickler.loads(state["gm"], fake_mode)
+        state["gm"].recompile()
+        return cls(**state)
+
+    def __call__(self, *args, **kwargs):
+        return self.gm(*args, **kwargs)
+
+
+class SimpleLinearModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(3, 3)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+@torch._dynamo.config.patch("enable_aot_compile", True)
+@instantiate_parametrized_tests
+class TestAOTCompile(torch._inductor.test_case.TestCase):
+    def path(self):
+        path = os.path.join(cache_dir(), f"package_{self.id()}")
+        os.makedirs(path, exist_ok=True)
+        return os.path.join(path, "model.pt")
+
+    def setUp(self):
+        super().setUp()
+        torch._dynamo.reset()
+        torch._dynamo.utils.counters.clear()
+        DynamoCache.clear()
+        PrecompileContext.clear()
+
+    def test_aot_compile_basic_fn(self):
+        def fn(x, y):
+            return x + y
+
+        def backend(gm, example_inputs):
+            return CustomCompiledFunction(gm, example_inputs)
+
+        compiled_fn = torch.compile(fn, fullgraph=True, backend=backend).aot_compile(
+            ((torch.randn(3, 4), torch.randn(3, 4)), {})
+        )
+        inputs = (torch.randn(3, 4), torch.randn(3, 4))
+        expected = fn(*inputs)
+        actual = compiled_fn(*inputs)
+        self.assertEqual(expected, actual)
+        compiled_fn.save_compiled_function(self.path())
+        torch._dynamo.reset()
+        with torch.compiler.set_stance("fail_on_recompile"):
+            with open(self.path(), "rb") as f:
+                compiled_fn = torch.compiler.load_compiled_function(f)
+            actual = compiled_fn(*inputs)
+            self.assertEqual(expected, actual)
+
+    def test_aot_compile_basic_forward(self):
+        mod = SimpleLinearModule()
+
+        def backend(gm, example_inputs):
+            return CustomCompiledFunction(gm, example_inputs)
+
+        def guard_filter_fn(guards):
+            return [g.guard_type != "FUNCTION_MATCH" for g in guards]
+
+        compiled_fn = torch.compile(
+            mod,
+            fullgraph=True,
+            backend=backend,
+            options={
+                "guard_filter_fn": torch.compiler.skip_guard_on_globals_unsafe,
+            },
+        ).forward.aot_compile(((torch.randn(3, 3),), {}))
+        inputs = (torch.randn(3, 3),)
+        expected = mod(*inputs)
+        actual = compiled_fn(mod, *inputs)
+        self.assertEqual(expected, actual)
+        compiled_fn.save_compiled_function(self.path())
+        torch._dynamo.reset()
+        with torch.compiler.set_stance("fail_on_recompile"):
+            with open(self.path(), "rb") as f:
+                compiled_fn = torch.compiler.load_compiled_function(f)
+            actual = compiled_fn(mod, *inputs)
+            self.assertEqual(expected, actual)
+
+
+if __name__ == "__main__":
+    from torch._dynamo.test_case import run_tests
+
+    run_tests()

--- a/torch/_dynamo/__init__.py
+++ b/torch/_dynamo/__init__.py
@@ -10,7 +10,7 @@ seamlessly optimize PyTorch programs, including those using modern Python featur
 
 import torch
 
-from . import config, convert_frame, eval_frame, resume_execution
+from . import aot_compile, config, convert_frame, eval_frame, resume_execution
 from .backends.registry import list_backends, lookup_backend, register_backend
 from .callback import callback_handler, on_compile_end, on_compile_start
 from .code_context import code_context

--- a/torch/_dynamo/aot_compile.py
+++ b/torch/_dynamo/aot_compile.py
@@ -1,0 +1,158 @@
+import abc
+import builtins
+import importlib
+import inspect
+import pickle
+import types
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import torch
+import torch.fx
+
+from . import convert_frame
+from .hooks import Hooks
+
+
+class SerializableCallable(abc.ABC):
+    @classmethod
+    @abc.abstractmethod
+    def serialize_compile_artifacts(cls, fn: Any) -> bytes:
+        pass
+
+    @classmethod
+    @abc.abstractmethod
+    def deserialize_compile_artifacts(cls, data: bytes) -> Any:
+        pass
+
+
+def bind_locals(signature, *args, **kwargs):
+    bound_arguments = signature.bind(*args, **kwargs)
+    bound_arguments.apply_defaults()
+    return bound_arguments.arguments
+
+
+@dataclass
+class CompileArtifacts:
+    signature: inspect.Signature
+    bytecode: types.CodeType
+    guard_manager: Optional[torch._dynamo.guards.GuardManagerWrapper]
+    guards_state: bytes
+    import_sources: dict[str, str]
+    backend_id: str
+    compiled_fn: SerializableCallable
+    original_code: types.CodeType
+
+    def compiled_function(self) -> Any:
+        import_sources = {
+            alias: importlib.import_module(module_name)
+            for alias, module_name in self.import_sources.items()
+        }
+        f_globals = {**import_sources, self.backend_id: self.compiled_fn}
+        core = types.FunctionType(self.bytecode, f_globals)
+
+        def optimized_call(*args, **kwargs):
+            f_locals = bind_locals(self.signature, *args, **kwargs)
+            if not self.guard_manager.check(f_locals):
+                reason = str(self.guard_manager.check_verbose(f_locals))
+                raise RuntimeError(f"GuardManager check failed, reason: {reason}")
+            return core(*args, **kwargs)
+
+        if self.guard_manager is None:
+            guards_state = pickle.loads(self.guards_state)
+            self.guard_manager = torch._dynamo.guards.CheckFunctionManager(
+                self.original_code,
+                guards_state.output_graph,
+                shape_code_parts=guards_state.shape_code_parts,
+                runtime_global_scope=f_globals,
+            ).guard_manager
+
+        def save_compiled_function(path: str):
+            with open(path, "wb") as f:
+                f.write(type(self).serialize(self))
+
+        optimized_call.save_compiled_function = save_compiled_function
+        return optimized_call
+
+    @classmethod
+    def serialize(cls, artifacts: "CompileArtifacts") -> bytes:
+        from torch._dynamo.package import SerializedCode
+
+        state = artifacts.__dict__.copy()
+        state["guard_manager"] = None
+        state["bytecode"] = SerializedCode.from_code_object(state["bytecode"])
+        compiled_fn = state["compiled_fn"]
+        state["compiled_fn"] = (
+            type(compiled_fn).deserialize_compile_artifacts,
+            type(compiled_fn).serialize_compile_artifacts(compiled_fn),
+        )
+        state["original_code"] = SerializedCode.from_code_object(state["original_code"])
+        return pickle.dumps(state)
+
+    @classmethod
+    def deserialize(cls, data: bytes) -> "CompileArtifacts":
+        from torch._dynamo.package import SerializedCode
+
+        state = pickle.loads(data)
+        state["bytecode"] = SerializedCode.to_code_object(state["bytecode"])
+        deserializer, compiled_fn_state = state["compiled_fn"]
+        state["compiled_fn"] = deserializer(compiled_fn_state)
+        state["original_code"] = SerializedCode.to_code_object(state["original_code"])
+        return cls(**state)
+
+
+def aot_compile_fullgraph(
+    model,
+    example_inputs,
+    hooks: Hooks,
+    backend,
+):
+    from torch._dynamo.utils import dynamo_timed, get_metrics_context
+    from torch._guards import compile_context, CompileContext, TracingContext
+
+    args, kwargs = example_inputs
+    if hasattr(model, "__self__"):
+        fn = model.__func__
+        args = (model.__self__,) + args
+    elif inspect.isfunction(model):
+        fn = model
+    else:
+        raise RuntimeError(f"Unsupported model code type {model}")
+
+    signature = inspect.signature(fn)
+    f_locals = bind_locals(signature, *args, **kwargs)
+    with (
+        compile_context(CompileContext(convert_frame.get_compile_id({}))),
+        get_metrics_context(),
+        dynamo_timed("fullgraph_capture"),
+    ):
+        capture_output = convert_frame.fullgraph_capture(
+            convert_frame.FrameInfo(
+                fn.__code__,
+                fn.__globals__,
+                f_locals,
+                builtins,
+                closure=(),
+            )
+        )
+        dynamo_output = capture_output.dynamo_output
+        check_fn = dynamo_output.build_guards(fn.__code__, hooks=hooks, save=True)
+
+    backend_input = capture_output.backend_input
+    import_sources = dynamo_output.tracer_output.output_graph.import_sources
+    with torch._guards.tracing(TracingContext(backend_input.fake_mode)):
+        compiled_fn = backend(backend_input.graph_module, backend_input.example_inputs)
+
+    if not isinstance(compiled_fn, SerializableCallable):
+        raise RuntimeError(f"Backend {backend} did not return a SerializableCallable.")
+    compile_artifacts = CompileArtifacts(
+        signature=signature,
+        bytecode=dynamo_output.bytecode,
+        guard_manager=check_fn.guard_manager,
+        guards_state=check_fn.guards_state,
+        import_sources=import_sources,
+        backend_id=backend_input.backend_id,
+        compiled_fn=compiled_fn,
+        original_code=fn.__code__,
+    )
+    return compile_artifacts.compiled_function()

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -667,6 +667,8 @@ wrap_top_frame = False
 # and AOTAutograd runtime wrapper.
 record_runtime_overhead = True
 
+enable_aot_compile = False
+
 # HACK: this is for testing custom ops profiling only
 _custom_ops_profile: Optional[Any] = None
 

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -602,6 +602,7 @@ class _TorchDynamoContext:
         dynamic: Optional[bool] = None,
         compiler_config: Optional[Any] = None,
         package: Optional[CompilePackage] = None,
+        hooks: Optional[Hooks] = None,
     ) -> None:
         super().__init__()
         assert callable(callback) or callback is False or callback is None
@@ -616,6 +617,7 @@ class _TorchDynamoContext:
         self.cleanup_fns: list[Callable[[], Any]] = []
         self.enter_exit_hooks = []
         self._package = package
+        self._hooks = hooks
         patch_fn()
 
         # Save the backends so that we can reset them during torch._dynamo.reset
@@ -698,6 +700,23 @@ class _TorchDynamoContext:
                         self._package.initialize(fn, None, ignore_inlined_sources=False)
 
         fn = innermost_fn(fn)
+
+        def aot_compile(example_inputs: tuple[tuple[Any, ...], dict[str, Any]]) -> Any:
+            from torch._dynamo.aot_compile import aot_compile_fullgraph
+
+            if not self.error_on_graph_break:
+                raise RuntimeError(
+                    "Graph breaks are not supported with aot compile. Please use torch.compile(fullgraph=True)."
+                )
+
+            return aot_compile_fullgraph(
+                fn,
+                example_inputs,
+                hooks=self._hooks,
+                backend=innermost_fn(
+                    self.callback, unaltered_fn_attr="_torchdynamo_orig_backend"
+                ),
+            )
 
         # add context containing GraphModule to any GraphModule forward functions
         if isinstance(fn, GraphModule):
@@ -843,6 +862,8 @@ class _TorchDynamoContext:
         # provide public api _fn.get_compiler_config()
         assert not hasattr(compile_wrapper, "get_compiler_config")
         compile_wrapper.get_compiler_config = get_compiler_config  # type: ignore[attr-defined]
+        if torch._dynamo.config.enable_aot_compile:
+            compile_wrapper.aot_compile = aot_compile
 
         # If the function is called using torch._dynamo.optimize decorator, we
         # should prevent any type of skipping.
@@ -901,6 +922,7 @@ class OptimizeContext(_TorchDynamoContext):
             Callable[[], Union[OptimizeContext, _NullDecorator]]
         ] = None,
         package: Optional[CompilePackage] = None,
+        hooks: Optional[Hooks] = None,
     ) -> None:
         def on_enter() -> None:
             install_generation_tagging_init()
@@ -916,6 +938,7 @@ class OptimizeContext(_TorchDynamoContext):
             dynamic=dynamic,
             compiler_config=compiler_config,
             package=package,
+            hooks=hooks,
         )
 
         if config.compiled_autograd:
@@ -1052,6 +1075,7 @@ def _optimize_catch_errors(
         compiler_config=compiler_config,
         rebuild_ctx=rebuild_ctx,
         package=package,
+        hooks=hooks,
     )
 
 

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+import io
 from typing import Any, Callable, Optional, TYPE_CHECKING, TypeVar, Union
 from typing_extensions import ParamSpec
 
@@ -639,3 +640,10 @@ def nested_compile_region(fn=None):
     )
 
     return _mark_compile_region(fn)
+
+
+def load_compiled_function(file: io.IOBase):
+    from torch._dynamo.aot_compile import CompileArtifacts
+
+    data = file.read()
+    return CompileArtifacts.deserialize(data).compiled_function()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #161382
* #160900

Adding a new feature to torch.compile(fullgraph=True) which "aot_compile" a function with given example inputs.

On user side it should look like:

```
def foo(x, y):
    return x + y

compiled_fn = torch.compile(fullgraph=True).aot_compile(((torch.randn(3, 4), torch.randn(3, 4)), {}))
```

This is different from the traditional `torch.compile` workflow where compiled object will be a drop-in replacement for the original eager model:
```
tensor input -> torch.compile() -> tensor output
```
`aot_compile` will instead return a compiled function as result:
```
tensor input -> aot_compile() -> compiled function
```
The aot compiled function will be savable and loadable on disk as well:
```
torch.compile(fullgraph=True).aot_compile(...).save_compiled_function('my/path')
compiled_fn = torch.compiler.load_compiled_function("my/path")
```

Right now we treat compiler backend as a blackbox and it needs to implement the following interface to make compile artifacts serialzable:
```
class SerializableCallable:
    def save_compile_artifacts(): ....
    def load_compile_artifacts(): ....
```
We haven't implemented this for inductor yet, but this shouldn't be an issue since we gate this feature through `torch._dynamo.config.aot_compile` (which defaults to False), and this will be left as follow up PR to the current PR.

Differential Revision: [D80914270](https://our.internmc.facebook.com/intern/diff/D80914270/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela