### PR TITLE
Fix torch.argmax/torch.argmin fail for non-contiguous input on MPS

### DIFF
--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -900,6 +900,9 @@ static void argmax_argmin_out_mps(const Tensor& input_t,
   NSMutableArray<NSNumber*>* apparent_in_shape = nil;
   NSMutableArray<NSNumber*>* apparent_out_shape = nil;
 
+  // https://github.com/pytorch/pytorch/issues/160740
+  Tensor input_for_feed = input_t;
+
   if (dim.has_value()) {
     apparent_out_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
     for (const auto i : c10::irange(num_input_dims)) {
@@ -912,6 +915,9 @@ static void argmax_argmin_out_mps(const Tensor& input_t,
 
     apparent_out_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:1];
     apparent_out_shape[0] = @1;
+
+    // Since input will be flattened, reshape it to 1D tensor
+    input_for_feed = input_t.reshape({num_in_elements}).contiguous();
   }
 
   if (output_t.numel() == 0) {
@@ -958,7 +964,7 @@ static void argmax_argmin_out_mps(const Tensor& input_t,
       newCachedGraph->outputTensor_ = outputClampedTensor;
     });
 
-    auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t, apparent_in_shape);
+    auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_for_feed, apparent_in_shape);
     auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t, apparent_out_shape);
 
     auto feeds = dictionaryFromPlaceholders(inputPlaceholder);

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -4647,6 +4647,20 @@ class TestMPS(TestCaseMPS):
         helper(2, 8, 4, 4, "min", torch.float16)
         helper(2, 8, 4, 4, "min", torch.int64)
 
+    def test_argmin_argmax_non_contiguous(self):
+        # https://github.com/pytorch/pytorch/issues/160740
+        mps_tensor_contiguous = torch.randn(5, 5, device='mps')
+        cpu_tensor_contiguous = mps_tensor_contiguous.detach().clone().cpu()
+        mps_tensor_transposed = mps_tensor_contiguous.t()
+        cpu_tensor_transposed = cpu_tensor_contiguous.t()
+        mps_tensor_strided = mps_tensor_contiguous[::2, ::2]
+        cpu_tensor_strided = cpu_tensor_contiguous[::2, ::2]
+
+        self.assertEqual(torch.argmax(mps_tensor_transposed), torch.argmax(cpu_tensor_transposed))
+        self.assertEqual(torch.argmax(mps_tensor_strided), torch.argmax(cpu_tensor_strided))
+        self.assertEqual(torch.argmin(mps_tensor_transposed), torch.argmin(cpu_tensor_transposed))
+        self.assertEqual(torch.argmin(mps_tensor_strided), torch.argmin(cpu_tensor_strided))
+
     def test_reduction_sum_max_long_val(self):
         x_mps = torch.tensor([sys.maxsize, sys.maxsize - 10, sys.maxsize - 5, sys.maxsize - 18], device="mps")
         x_cpu = x_mps.detach().clone().cpu()


### PR DESCRIPTION
The error occurs when the parameter `dim` is not set while calling `torch.argmax` or `torch.argmin`. On MPS, the input tensor will be flattened when the `dim` has no value. 
https://github.com/pytorch/pytorch/blob/4651aaac47ff855e08a74e2fdbfa605bc53afba8/aten/src/ATen/native/mps/operations/ReduceOps.mm#L903-L915

The error arises from here.
https://github.com/pytorch/pytorch/blob/4651aaac47ff855e08a74e2fdbfa605bc53afba8/aten/src/ATen/native/mps/operations/ReduceOps.mm#L961

The `Placeholder` will call the `view_impl` function, which fails to compute the stride and causes the error.
https://github.com/pytorch/pytorch/blob/1eccfb157ab9855b3f81872a23502fb15f455e0a/aten/src/ATen/native/TensorShape.cpp#L4028-L4037

In this PR, I fix it by copying the input tensor and reshaping it into a continuous 1-D tensor when `dim` has no value to compute the stride correctly. Also, I am adding a testcase for it.
