### PR TITLE
[inductor] Use runtime estimations in comm reordering/sink

### DIFF
--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -1821,6 +1821,8 @@ class TestCollectivesInductor(DynamoDistributedSingleProcTestCase):
                 ],
                 "allow_buffer_reuse": False,
                 "test_configs.track_memory_lifecycle": "error",
+                "reorder_iterative_limit_by_runtime_estimations": False,
+                "sink_waits_iterative_limit_by_runtime_estimations": False,
             }
         ):
             compiled = torch.compile(func, fullgraph=True)

--- a/torch/_inductor/comms.py
+++ b/torch/_inductor/comms.py
@@ -155,10 +155,9 @@ def is_gemm_like(node: Optional[Union[IRNode, Operation]]) -> bool:
     ):
         return True
 
-    if (
-        python_kernel_name := getattr(node, "python_kernel_name", None)
-    ) and "extern_kernels" in python_kernel_name:
-        return True
+    if python_kernel_name := getattr(node, "python_kernel_name", None):
+        if "extern_kernels" in python_kernel_name and "mm" in python_kernel_name:
+            return True
     return False
 
 
@@ -236,6 +235,34 @@ def _initialize_double_linked_list(
     return _prev, _next, _head
 
 
+def is_corresponding_collective_wait(collective_snode, wait_snode):
+    collective_outs = OrderedSet(o.get_name() for o in collective_snode.get_outputs())
+    unmet_deps = OrderedSet(d.name for d in wait_snode.unmet_dependencies)
+    return unmet_deps & collective_outs
+
+
+def _op_runtime_estimate_mult(snode):
+    # Apply multipliers for faster experimentation.
+    # TODO(ivankobzarev): Remove after confirmation that runtime estimations are correct.
+    if contains_collective(snode):
+        return config.reorder_sink_runtime_estimations_comm_mult
+    elif is_gemm_like(snode):
+        return config.reorder_sink_runtime_estimations_mm_mult
+    return 1.0
+
+
+def is_async_collective(snode):
+    if python_kernel_name := getattr(snode.node, "python_kernel_name", None):
+        if "torch.ops._dtensor.shard_dim_alltoall.default" in python_kernel_name:
+            return False
+
+    return True
+
+
+def contains_async_collective(snode):
+    return contains_collective(snode, is_async_collective)
+
+
 def _reorder_communication_preserving_peak_memory_internal(
     snodes: list[BaseSchedulerNode],
 ) -> tuple[list[BaseSchedulerNode], dict[BaseSchedulerNode, ReorderInfo]]:
@@ -266,8 +293,10 @@ def _reorder_communication_preserving_peak_memory_internal(
         buf_to_snode_last_use,
         name_to_freeable_input_buf,
     ) = _initialize_memory_tracking(snodes, graph_inputs, graph_outputs)
+
     runtimes: dict[BaseSchedulerNode, float] = {
-        snode: estimate_op_runtime(snode) for snode in snodes
+        snode: estimate_op_runtime(snode) * _op_runtime_estimate_mult(snode)
+        for snode in snodes
     }
     # debug stats
     stats: dict[BaseSchedulerNode, ReorderInfo] = {}
@@ -276,15 +305,23 @@ def _reorder_communication_preserving_peak_memory_internal(
         collective_snode: BaseSchedulerNode, remaining_snodes: list[BaseSchedulerNode]
     ) -> float:
         # assumes a linear schedule and computes the overlap of the collective with the remaining nodes
-        comm_time = estimate_op_runtime(collective_snode)
+        comm_time = runtimes[collective_snode]
         compute_time = 0.0
+        collective_outs = OrderedSet(
+            o.get_name() for o in collective_snode.get_outputs()
+        )
         for snode in remaining_snodes:
-            if contains_collective(snode):
-                continue
-            if contains_wait(snode):
-                # TODO - if the wait is for a collective that started before this collective or on another stream,
-                # we can ignore it. Otherwise, it's the end of the road for overlap opportunities
+            # We may have some ops without Wait,
+            # e.g. DTensor torch.ops._dtensor.shard_dim_alltoall
+            unmet_deps = OrderedSet(
+                d.name for d in snode.unmet_dependencies if not _is_fake_dep(d)
+            )
+
+            if unmet_deps & collective_outs:
                 break
+
+            if contains_async_collective(snode):
+                continue
 
             def accumulate_time(_snode: BaseSchedulerNode) -> None:
                 nonlocal compute_time
@@ -436,11 +473,12 @@ def _reorder_communication_preserving_peak_memory_internal(
     )
 
     num_processed_collectives: int = 0
-    curr = _head
+    curr: Optional[BaseSchedulerNode] = _head
     debug_iterative_memory_recompute = config.reorder_iterative_debug_memory_recompute
     iterative_recompute_error = False
 
-    while _next[curr] is not None:
+    while curr is not None and _next[curr] is not None:
+        _next_curr = _next[curr]
         if iterative_recompute_error:
             break
         if contains_collective(curr):
@@ -459,8 +497,19 @@ def _reorder_communication_preserving_peak_memory_internal(
             group_head = curr
             group_tail = curr
             group_peak_memory = _curr_memory[curr][0]  # post_alloc memory
+
             while candidate is not None:
-                if contains_collective(candidate):
+                if (
+                    config.reorder_iterative_limit_by_runtime_estimations
+                    and info.final_exposed <= 0
+                ):
+                    info.limiting_factor = "unexposed by runtime estimations"
+                    break
+
+                if (
+                    not config.reorder_iterative_unsafe_collectives_reorder
+                    and contains_collective(candidate)
+                ):
                     info.limiting_factor = "collective ordering"
                     break
 
@@ -494,7 +543,12 @@ def _reorder_communication_preserving_peak_memory_internal(
                         if contains_collective(candidate):
                             return False, "contains_collective"
 
-                        if contains_gemm_like(candidate):
+                        # TODO(ivankobzarev): Replace this heuristic, that
+                        # helps 1D case, but does not help 2D with runtime estimations.
+                        if (
+                            not config.reorder_iterative_group_with_gemm
+                            and contains_gemm_like(candidate)
+                        ):
                             return False, "contains_gemm_like"
                         return True, None
 
@@ -599,7 +653,7 @@ def _reorder_communication_preserving_peak_memory_internal(
                     if iterative_recompute_error:
                         break
                 candidate = _prev[group_head]
-        curr = _next[curr]  # type: ignore[assignment]
+        curr = _next_curr
 
     node_stats = stats
     improvement = {snode: node_stats[snode].improvement for snode in node_stats}
@@ -853,6 +907,12 @@ class SinkWaitInfo:
     moves: int = 0
     moves_info: str = ""
     limiting_factor: str = "None"
+    initial_exposed: float = -1
+    final_exposed: float = -1
+
+    @property
+    def improvement(self):
+        return self.initial_exposed - self.final_exposed
 
 
 def _sink_waits_iterative_internal(
@@ -981,13 +1041,41 @@ def _sink_waits_iterative_internal(
 
         for n in [candidate, *gns]:
             post_alloc = _post_alloc_update[n]
-            snodes_allocfree[n].size_free += _size_free_delta_update[n]
+            snodes_allocfree[n].size_free += _size_free_delta_update.get(n, 0)
             _curr_memory[n] = (
                 post_alloc,
                 post_alloc - snodes_allocfree[n].size_free,
             )
 
-    curr = snodes[-1]
+    runtimes: dict[BaseSchedulerNode, float] = {
+        snode: estimate_op_runtime(snode) * _op_runtime_estimate_mult(snode)
+        for snode in snodes
+    }
+
+    def exposed_communication_time(snodes_to_wait):
+        wait_snode = snodes_to_wait[-1]
+        assert len(snodes_to_wait) > 1
+        idx = len(snodes_to_wait) - 2
+        comm_time = 0.0
+        compute_time = 0.0
+        for i in range(idx, -1, -1):
+            c = snodes_to_wait[i]
+            if contains_collective(c):
+                if is_corresponding_collective_wait(c, wait_snode):
+                    comm_time = runtimes[c]
+                    break
+                else:
+                    continue
+
+            def accumulate_time(_snode: BaseSchedulerNode) -> None:
+                nonlocal compute_time
+                compute_time += runtimes[_snode]
+
+            _temp_group_visit_leaves(c, accumulate_time)
+
+        return max(0, comm_time - compute_time)
+
+    curr: Optional[BaseSchedulerNode] = snodes[-1]
 
     processed_waits = OrderedSet()  # type: ignore[var-annotated]
     debug_iterative_memory_recompute = config.reorder_iterative_debug_memory_recompute
@@ -996,8 +1084,8 @@ def _sink_waits_iterative_internal(
     )
 
     iterative_recompute_error = False
-
-    while _prev[curr] is not None:
+    while curr is not None and _prev[curr] is not None:
+        _prev_curr = _prev[curr]
         if iterative_recompute_error:
             break
         if (
@@ -1009,14 +1097,23 @@ def _sink_waits_iterative_internal(
         if contains_wait(curr) and curr not in processed_waits:
             processed_waits.add(curr)
             info = stats[curr] = SinkWaitInfo()
+            info.initial_exposed = info.final_exposed = exposed_communication_time(
+                _group_nodes(_head, curr)
+            )
             candidate = _next[curr]
             wait_snode = curr
             group_head = curr
             group_tail = curr
             group_peak_memory = _curr_memory[curr][0]
+
             while candidate is not None:
-                if iterative_recompute_error:
+                if (
+                    config.sink_waits_iterative_limit_by_runtime_estimations
+                    and info.final_exposed <= 0
+                ):
+                    info.limiting_factor = "unexposed by runtime estimations"
                     break
+
                 gns: list[BaseSchedulerNode] = _group_nodes(group_head, group_tail)
                 group = GroupedSchedulerNode(
                     wait_snode.scheduler,
@@ -1054,7 +1151,10 @@ def _sink_waits_iterative_internal(
                                 False,
                                 f"candidate contains collective {snode.get_name()}",
                             )
-                        if contains_gemm_like(snode):
+                        if (
+                            not config.sink_iterative_group_with_gemm
+                            and contains_gemm_like(candidate)  # type: ignore[arg-type]
+                        ):
                             return (
                                 False,
                                 f"candidate contains gemm_like {snode.get_name()}",
@@ -1071,21 +1171,38 @@ def _sink_waits_iterative_internal(
                         info.grouped_info = _group_names(gns)
                         candidate = _next[candidate]
                         continue
-                    elif (data_dep is None) and both_contain_comms:
-                        info.limiting_factor = (
-                            f"collective ordering {_group_names(gns)}"
-                            f" with candidate:{candidate.get_name()}"
-                        )
-                        break
+                    elif data_dep is None:
+                        if (
+                            not config.sink_waits_iterative_unsafe_collectives_reorder
+                            and both_contain_comms
+                        ):
+                            info.limiting_factor = (
+                                f"collective ordering {_group_names(gns)}"
+                                f"\n with candidate:{candidate.get_name()}"
+                            )
+                            break
                     else:
                         info.limiting_factor = (
                             f"data dependency {data_dep}(dep_names:{list(data_deps.keys())})"
                             f"\n candidate:{candidate.get_name()}(os:{[candidate.get_buffer_names()]})"
-                            f"dep on {gns}"
+                            f"\n dep on {_group_names(gns)}"
                             f"\n outs:{[o.get_name() for o in group_outs]}"
                             f"\n non_group_reason:{grp_reason}"
                         )
                         break
+
+                # if our group contains some compute and candidate is wait,
+                # reordering will decrease overlap of candidate.
+                # We do not have runtime estimations to estimate
+                # total advantage/disadvantage of the swap.
+                # Conservatively prohibit such swaps.
+                # TODO(ivankobzarev): Use runtime estimations for this decision.
+                if len(gns) > 1 and is_wait(candidate.node):
+                    info.limiting_factor = (
+                        f"candidate is wait, group not only wait({_group_names(gns)})"
+                    )
+                    break
+
                 candidate_allocfree: SNodeMemory = snodes_allocfree[candidate]
                 candidate_delta_mem = (
                     candidate_allocfree.size_alloc - candidate_allocfree.size_free
@@ -1138,6 +1255,10 @@ def _sink_waits_iterative_internal(
 
                 _perform_double_linked_list_swap(candidate, group_head, group_tail)
 
+                info.final_exposed = exposed_communication_time(
+                    _group_nodes(_head, curr)
+                )
+
                 _update_memory_tracking_after_swap(
                     candidate,
                     gns,
@@ -1166,24 +1287,30 @@ def _sink_waits_iterative_internal(
                         break
 
                 candidate = _next[group_tail]
-        curr = _prev[curr]  # type: ignore[assignment]
+        curr = _prev_curr
 
     headers = [
         "Wait node",
+        "initial exposed",
+        "final exposed",
+        "improvement",
+        "limiting factor",
         "grouped",
         "grouped_info",
         "moves",
         "moves_info",
-        "limiting factor",
     ]
     rows = [
         [
             node_summary(snode),
+            info.initial_exposed,
+            info.final_exposed,
+            info.improvement,
+            info.limiting_factor,
             info.grouped,
             info.grouped_info,
             info.moves,
             info.moves_info,
-            info.limiting_factor,
         ]
         for snode, info in stats.items()
     ]
@@ -1218,9 +1345,7 @@ def _sink_waits_iterative_internal(
     return new_snodes, stats
 
 
-def sink_waits_iterative(
-    snodes: list[BaseSchedulerNode],
-) -> list[BaseSchedulerNode]:
+def sink_waits_iterative(snodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
     return _sink_waits_iterative_internal(snodes)[0]
 
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -408,8 +408,8 @@ sink_waits_iterative_limit_by_runtime_estimations: bool = True
 # Debug configurations for experimentations
 reorder_sink_runtime_estimations_mm_mult: float = 1.0
 reorder_sink_runtime_estimations_comm_mult: float = 1.0
-reorder_iterative_group_with_gemm: bool = True
-sink_iterative_group_with_gemm: bool = True
+# Ratio of comm_time to cover deviations of comm_time from estimations
+reorder_sink_extra_comm_comp_overlap: float = 0.1
 
 # Experimental unsafe configuration that allows changing relative collectives order,
 # No guarantees for now that all the rank will do the same order of collectives,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -399,6 +399,24 @@ sink_waits_iterative_debug_limit_to_sink: Optional[int] = (
     None if (env_str := os.getenv("PYTORCH_SINK_WAITS_LIMIT")) is None else int(env_str)
 )
 
+
+# Comparing estimations vs real benchmarks showed big divergence.
+# Exposing extensive config for easier experimentation.
+# TODO:(ivankobzarev) Remove once runtime estimations are reliable.
+reorder_iterative_limit_by_runtime_estimations: bool = True
+sink_waits_iterative_limit_by_runtime_estimations: bool = True
+# Debug configurations for experimentations
+reorder_sink_runtime_estimations_mm_mult: float = 1.0
+reorder_sink_runtime_estimations_comm_mult: float = 1.0
+reorder_iterative_group_with_gemm: bool = True
+sink_iterative_group_with_gemm: bool = True
+
+# Experimental unsafe configuration that allows changing relative collectives order,
+# No guarantees for now that all the rank will do the same order of collectives,
+# which can result in collective hangs.
+reorder_iterative_unsafe_collectives_reorder: bool = False
+sink_waits_iterative_unsafe_collectives_reorder: bool = False
+
 bucket_all_gathers_fx: Literal["none", "all", "only_fsdp"] = "none"
 # By default torch._inductor.fx_passes.bucketing.bucket_size_determinator is used
 bucket_all_gathers_fx_bucket_size_determinator: Optional[Callable[[int], int]] = None

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -402,14 +402,11 @@ sink_waits_iterative_debug_limit_to_sink: Optional[int] = (
 
 # Comparing estimations vs real benchmarks showed big divergence.
 # Exposing extensive config for easier experimentation.
-# TODO:(ivankobzarev) Remove once runtime estimations are reliable.
-reorder_iterative_limit_by_runtime_estimations: bool = True
-sink_waits_iterative_limit_by_runtime_estimations: bool = True
-# Debug configurations for experimentations
-reorder_sink_runtime_estimations_mm_mult: float = 1.0
 reorder_sink_runtime_estimations_comm_mult: float = 1.0
+reorder_sink_runtime_estimations_non_comm_mult: float = 1.0
 # Ratio of comm_time to cover deviations of comm_time from estimations
-reorder_sink_extra_comm_comp_overlap: float = 0.1
+reorder_iterative_extra_comm_comp_overlap: float = 0.1
+sink_iterative_extra_comm_comp_overlap: float = 0.2
 
 # Experimental unsafe configuration that allows changing relative collectives order,
 # No guarantees for now that all the rank will do the same order of collectives,

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2537,13 +2537,16 @@ def is_wait(node: Optional[Union[IRNode, Operation]]) -> bool:
     return type(node) == ir._WaitKernel
 
 
-def contains_collective(snode: BaseSchedulerNode) -> bool:
+def contains_collective(
+    snode: BaseSchedulerNode,
+    filter_fn: Optional[Callable[[BaseSchedulerNode], bool]] = None,
+) -> bool:
     from torch._inductor.scheduler import GroupedSchedulerNode
 
     if isinstance(snode, GroupedSchedulerNode):
         return any(contains_collective(x) for x in snode.snodes)
 
-    return is_collective(snode.node)
+    return is_collective(snode.node) and (filter_fn is None or filter_fn(snode))
 
 
 def contains_wait(snode: BaseSchedulerNode) -> bool:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #161975
* #161499
* __->__ #161406
* #161405



cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben

Differential Revision: [D81152295](https://our.internmc.facebook.com/intern/diff/D81152295)