### PR TITLE
[inductor] comm reordering: fix memory recalculation

### DIFF
--- a/torch/_inductor/comms.py
+++ b/torch/_inductor/comms.py
@@ -981,7 +981,7 @@ def _sink_waits_iterative_internal(
 
         for n in [candidate, *gns]:
             post_alloc = _post_alloc_update[n]
-            snodes_allocfree[n].size_free += _size_free_delta_update[n]
+            snodes_allocfree[n].size_free += _size_free_delta_update.get(n, 0)
             _curr_memory[n] = (
                 post_alloc,
                 post_alloc - snodes_allocfree[n].size_free,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #161431

_size_free_delta_update is filled only for nodes that change memory_size, but change applied for all nodes in the group.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben