### PR TITLE
Check for Index before Tensors in is_int_or_symint

### DIFF
--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -880,6 +880,10 @@ static bool is_int_or_symint(PyObject* obj) {
     return true;
   }
 
+  if (THPUtils_checkIndex(obj)) {
+    return true;
+  }
+
   // FakeTensor(..., size=()) is qualified for SymInt param,
   // but we can't go via __index__ (below) as we would normally
   // do for regular tensors, because __index__ first forces a
@@ -893,10 +897,6 @@ static bool is_int_or_symint(PyObject* obj) {
         at::isIntegralType(var.dtype().toScalarType(), /*include_bool*/ true)) {
       return true;
     }
-  }
-
-  if (THPUtils_checkIndex(obj)) {
-    return true;
   }
 
   return false;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #161635
* #161634
* #161633
* #161622
* #161596
* #161595
* #161591
* #161590
* #161588
* #161586
* #161466
* #161455
* #161438
* __->__ #161433
* #161432
* #161329
* #161328
* #161317
* #161315
* #161308
* #161304
* #161292
* #161301
* #161300
* #161286

Cheaper (and cheap in an absolute sense) check should come first.