### PR TITLE
Skip const folding with symbolic expression

### DIFF
--- a/torch/fx/experimental/const_fold.py
+++ b/torch/fx/experimental/const_fold.py
@@ -164,6 +164,9 @@ def split_const_subgraphs(
     attributes on the module prior to running the non-constant portion of the
     graph.
     """
+
+    import sympy
+
     if not isinstance(module, torch.fx.GraphModule):
         mod_traced = torch.fx.symbolic_trace(module)
     else:
@@ -192,6 +195,10 @@ def split_const_subgraphs(
 
         # Skip folding side-effectful functions
         if node.is_impure():
+            continue
+
+        # Skip folding nodes that have symbolic fill_value
+        if isinstance(node.kwargs.get("fill_value", None), sympy.Expr):
             continue
 
         # Must be a constant foldable node at this point.


### PR DESCRIPTION
Summary: When performing constant folding, we must skip over operators that have symbolic `fill_value`.

Test Plan:
CI

Rollback Plan:

Reviewed By: kalpit-meta-1

Differential Revision: D80965936




cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv