### PR TITLE
Remove early torch::is_symint call in is_int_or_symint

### DIFF
--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -872,14 +872,6 @@ static bool is_float_or_complex_list(PyObject* obj) {
 }
 
 static bool is_int_or_symint(PyObject* obj) {
-  // THPUtils_checkIndex may call __index__ or __int__
-  // which may have side effects if obj is a symint node
-  // so we do `is_symint` check first
-  // TODO: maybe we should be using checkLong here?
-  if (torch::is_symint(py::handle(obj))) {
-    return true;
-  }
-
   if (THPUtils_checkIndex(obj)) {
     return true;
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #161635
* #161634
* #161633
* #161622
* #161596
* #161595
* #161591
* #161590
* #161588
* #161586
* #161466
* #161455
* __->__ #161438
* #161433
* #161432
* #161329
* #161328
* #161317
* #161315
* #161308
* #161304
* #161292
* #161301
* #161300
* #161286

If I am reading [THPUtils_checkIndex](https://github.com/pytorch/pytorch/blob/cf94cadbeee31a4d1d46a57f11bce7c9fd1cebc0/torch/csrc/utils.cpp#L28) correctly, it already checks torch::is_symint before hitting __index__ or __int__.