### PR TITLE
[WIP][Dynamo][vLLM] Support construction of TensorSchema

### DIFF
--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -40,7 +40,7 @@ import warnings
 import weakref
 from typing import TYPE_CHECKING
 from typing_extensions import is_typeddict
-
+from vllm.utils.tensor_schema import TensorSchema
 import torch._dynamo.config
 import torch.nn
 from torch._guards import TracingContext
@@ -151,6 +151,8 @@ def is_cython_function(obj):
         and type(obj).__name__ == "cython_function_or_method"
     )
 
+def is_tensorschema(value) -> bool:
+    return issubclass(value, TensorSchema)
 
 class UserDefinedVariable(VariableTracker):
     value: object
@@ -505,6 +507,9 @@ class UserDefinedClassVariable(UserDefinedVariable):
                         *graph_break_hints.SUPPORTABLE,
                     ],
                 )
+            return variables.BuiltinVariable(dict).call_dict(tx, *args, **kwargs)
+        elif is_tensorschema(self.value):
+            # add check for optional fields
             return variables.BuiltinVariable(dict).call_dict(tx, *args, **kwargs)
         elif self.value is collections.deque:
             maxlen = variables.ConstantVariable.create(None)


### PR DESCRIPTION
Summary:
What: Add support for TensorSchema in user-defined objects for compatibility with Dynamo's tracing system

Why: Observed graph breaks similar to issue with TypedDict - https://github.com/pytorch/pytorch/issues/132629

```
    def test_tensor_schema_llava_pixel_inputs(self):
        class LlavaImagePixelInputs(TensorSchema):
            type: Literal["pixel_values"] = "pixel_values"
            pixel_values: Annotated[
                torch.Tensor,
                TensorShape("bn", 3, "h", "w")
            ]

        def fn(x, y):
            obj = LlavaImagePixelInputs(pixel_values=y)
            return x * obj.pixel_values.sum()

        x, y = torch.randn(4), torch.randn(2, 3, 8, 8)
        ref = fn(x, y)

        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
        res = opt_fn(x, y)

        self.assertEqual(ref, res)
```

```
ERROR: test_tensor_schema_llava_pixel_inputs (caffe2.test.dynamo.test_repros.ReproTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/data/users/benjibeck/fbsource/buck-out/v2/gen/fbcode/95f6e7be6bb24603/caffe2/test/dynamo/__test_repros__/test_repros#link-tree/caffe2/test/dynamo/test_repros.py", line 6544, in test_tensor_schema_llava_pixel_inputs
    res = opt_fn(x, y)
  File "/data/users/benjibeck/fbsource/buck-out/v2/gen/fbcode/95f6e7be6bb24603/caffe2/test/dynamo/__test_repros__/test_repros#link-tree/torch/_dynamo/eval_frame.py", line 813, in compile_wrapper
    raise e.with_traceback(None) from e.__cause__  # User compiler error
torch._dynamo.exc.Unsupported: Observed exception
  Explanation: Dynamo found no exception handler at the top-level compiled function when encountering an exception. Exception will propagate outside the compiled region.
  Hint: Dynamo has detected that tracing the code will result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled.
  Hint: It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues.

  Developer debug context: raised exception TypeError([ConstantVariable(str: "unhashable type: <class 'torch._dynamo.variables.misc.GetAttrVariable'>")])

 For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0088.html

from user code:
   File "/data/users/benjibeck/fbsource/buck-out/v2/gen/fbcode/95f6e7be6bb24603/caffe2/test/dynamo/__test_repros__/test_repros#link-tree/caffe2/test/dynamo/test_repros.py", line 6537, in fn
    obj = LlavaImagePixelInputs(pixel_values=y)

Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you're reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"


----------------------------------------------------------------------
Ran 1 test in 1.662s
```
https://www.internalfb.com/intern/testinfra/testrun/4503599929393926

Test Plan:
```
buck2 test caffe2/test/dynamo:test_repros
```

```
buck2 run fbcode//caffe2/test/dynamo:test_tensor_schema_llava_pixel_inputs_isolated 2>&1 | tee tensor_schema_dynamo.log
```

Full log: P1910537335

Rollback Plan:

Differential Revision: D80549504




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela