### PR TITLE
Disable inductor/test_flex_attention.py

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -174,7 +174,7 @@ ROCM_BLOCKLIST = [
     "test_jit_legacy",
     "test_cuda_nvml_based_avail",
     "test_jit_cuda_fuser",
-    "inductor/test_flex_attention"
+    "inductor/test_flex_attention",
 ]
 
 S390X_BLOCKLIST = [

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -174,6 +174,7 @@ ROCM_BLOCKLIST = [
     "test_jit_legacy",
     "test_cuda_nvml_based_avail",
     "test_jit_cuda_fuser",
+    "inductor/test_flex_attention"
 ]
 
 S390X_BLOCKLIST = [


### PR DESCRIPTION
Currently inductor/test_flex_attention.py is causing rocm pytorch mi250 shard 1 to go over the timeout limit. This PR is for disabling that test.