### PR TITLE
inductor: Log the specific triton kernel that fails

### DIFF
--- a/test/inductor/test_async_compile.py
+++ b/test/inductor/test_async_compile.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import torch
 from torch._inductor import config
 from torch._inductor.async_compile import AsyncCompile, shutdown_compile_workers
+from torch._inductor.compile_worker.subproc_pool import SubprocException
 from torch._inductor.runtime.triton_compat import Config
 from torch._inductor.runtime.triton_heuristics import (
     generate_lookup_hash_from_source_code,
@@ -40,6 +41,21 @@ class TestAsyncCompile(TestCase):
             with fresh_cache():
                 compiled_fn = torch.compile(fn)
                 self.assertEqual(fn(x, y), compiled_fn(x, y))
+
+    @requires_gpu()
+    @requires_triton()
+    def test_bad_kernel(self):
+        shutdown_compile_workers()
+
+        with config.patch(worker_start_method="subprocess", compile_threads=8):
+            async_compile = AsyncCompile()
+            AsyncCompile.wait_pool_ready()
+            # Working around bug in wait_pool_ready()
+            async_compile._ready_future.result(timeout=120)
+            with self.assertRaises(SubprocException):
+                async_compile.triton(
+                    "fake_kernel_name", source_code="This definitely doesn't exist"
+                ).result()
 
     @requires_gpu()
     @requires_triton()

--- a/test/inductor/test_compile_worker.py
+++ b/test/inductor/test_compile_worker.py
@@ -39,19 +39,6 @@ class TestCompileWorker(TestCase):
             pool.shutdown()
 
     @skipIfWindows(msg="pass_fds not supported on Windows.")
-    def test_exception_with_name(self):
-        pool = SubprocPool(2)
-        try:
-            a = pool.submit(raise_testexc, name="testname")
-            with self.assertRaisesRegex(
-                SubprocException,
-                "testname",
-            ):
-                a.result()
-        finally:
-            pool.shutdown()
-
-    @skipIfWindows(msg="pass_fds not supported on Windows.")
     def test_crash(self):
         pool = SubprocPool(2)
         try:

--- a/test/inductor/test_compile_worker.py
+++ b/test/inductor/test_compile_worker.py
@@ -39,7 +39,7 @@ class TestCompileWorker(TestCase):
             pool.shutdown()
 
     @skipIfWindows(msg="pass_fds not supported on Windows.")
-    def test_exception(self):
+    def test_exception_with_name(self):
         pool = SubprocPool(2)
         try:
             a = pool.submit(raise_testexc, name="testname")

--- a/test/inductor/test_compile_worker.py
+++ b/test/inductor/test_compile_worker.py
@@ -39,6 +39,19 @@ class TestCompileWorker(TestCase):
             pool.shutdown()
 
     @skipIfWindows(msg="pass_fds not supported on Windows.")
+    def test_exception(self):
+        pool = SubprocPool(2)
+        try:
+            a = pool.submit(raise_testexc, name="testname")
+            with self.assertRaisesRegex(
+                SubprocException,
+                "testname",
+            ):
+                a.result()
+        finally:
+            pool.shutdown()
+
+    @skipIfWindows(msg="pass_fds not supported on Windows.")
     def test_crash(self):
         pool = SubprocPool(2)
         try:
@@ -79,7 +92,6 @@ class TestCompileWorker(TestCase):
                 self.assertEqual(os.path.exists(temp_log.name), True)
             finally:
                 pool.shutdown()
-
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/test/inductor/test_compile_worker.py
+++ b/test/inductor/test_compile_worker.py
@@ -93,6 +93,7 @@ class TestCompileWorker(TestCase):
             finally:
                 pool.shutdown()
 
+
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests
 

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -457,7 +457,7 @@ class AsyncCompile:
                 try:
                     kernel, elapsed_us = task.result()
                 except SubprocException as e:
-                    raise e.with_kernel_name(kernel_name) from e
+                    raise e.with_name(kernel_name) from e
 
                 # Now that we've compiled, we should clear the future
                 # so it can't be used again

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -447,7 +447,7 @@ class AsyncCompile:
                 load_kernel,
                 extra_env,
                 extra_config,
-                **({name: kernel_name} if self.process_pool is SubprocPool else {}),
+                **({"name": kernel_name} if self.process_pool is SubprocPool else {}),
             )
 
             def get_result() -> CachingAutotuner:

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -447,7 +447,7 @@ class AsyncCompile:
                 load_kernel,
                 extra_env,
                 extra_config,
-                **({name=kernel_name} if self.process_pool is SubprocPool else {}),
+                **({name: kernel_name} if self.process_pool is SubprocPool else {}),
             )
 
             def get_result() -> CachingAutotuner:

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -38,7 +38,11 @@ from torch._inductor.codecache import (
     StaticAutotunerFuture,
     torch_key,
 )
-from torch._inductor.compile_worker.subproc_pool import AnyPool, SubprocPool
+from torch._inductor.compile_worker.subproc_pool import (
+    AnyPool,
+    SubprocException,
+    SubprocPool,
+)
 from torch._inductor.compile_worker.tracked_process_pool import (
     TrackedProcessPoolExecutor,
 )
@@ -447,11 +451,14 @@ class AsyncCompile:
                 load_kernel,
                 extra_env,
                 extra_config,
-                **({"name": kernel_name} if self.process_pool is SubprocPool else {}),
             )
 
             def get_result() -> CachingAutotuner:
-                kernel, elapsed_us = task.result()
+                try:
+                    kernel, elapsed_us = task.result()
+                except SubprocException as e:
+                    raise e.with_kernel_name(kernel_name) from e
+
                 # Now that we've compiled, we should clear the future
                 # so it can't be used again
                 kernel.set_compile_info(compile_id, is_backward)

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -447,6 +447,7 @@ class AsyncCompile:
                 load_kernel,
                 extra_env,
                 extra_config,
+                name=kernel_name,
             )
 
             def get_result() -> CachingAutotuner:

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -447,7 +447,7 @@ class AsyncCompile:
                 load_kernel,
                 extra_env,
                 extra_config,
-                name=kernel_name,
+                **({name=kernel_name} if self.process_pool is SubprocPool else {}),
             )
 
             def get_result() -> CachingAutotuner:

--- a/torch/_inductor/compile_worker/subproc_pool.py
+++ b/torch/_inductor/compile_worker/subproc_pool.py
@@ -90,8 +90,10 @@ class SubprocException(Exception):
     Thrown when a job in a subprocess raises an Exception.
     """
 
-    def __init__(self, details: str, name:str) -> None:
-        super().__init__(f"An exception occurred in a subprocess:\n\nName={name}\n{details}")
+    def __init__(self, details: str, name: str) -> None:
+        super().__init__(
+            f"An exception occurred in a subprocess:\n\nName={name}\n{details}"
+        )
 
 
 class SubprocPickler:
@@ -127,7 +129,7 @@ class SubprocPool:
         entry = os.path.join(os.path.dirname(__file__), "__main__.py")
         self.pickler = pickler or SubprocPickler()
         self.kind = kind
-        self.names = {}
+        self.names: dict[int, str] = {}
 
         subproc_read_fd, write_fd = os.pipe()
         read_fd, subproc_write_fd = os.pipe()
@@ -189,9 +191,11 @@ class SubprocPool:
         self.read_thread.start()
 
     def submit(
-        self, job_fn: Callable[_P, _T], *args: _P.args,
+        self,
+        job_fn: Callable[_P, _T],
+        *args: _P.args,
         name: str = "",
-        **kwargs: _P.kwargs
+        **kwargs: _P.kwargs,
     ) -> Future[_T]:
         if args or kwargs:
             job_fn = functools.partial(job_fn, *args, **kwargs)

--- a/torch/_inductor/compile_worker/subproc_pool.py
+++ b/torch/_inductor/compile_worker/subproc_pool.py
@@ -91,6 +91,7 @@ class SubprocException(Exception):
     """
 
     def __init__(self, details: str, name: str = "<unknown>") -> None:
+        self.details = details
         super().__init__(
             f"An exception occurred in a subprocess:\n\nName={name}\n{details}"
         )

--- a/torch/_inductor/compile_worker/subproc_pool.py
+++ b/torch/_inductor/compile_worker/subproc_pool.py
@@ -206,14 +206,14 @@ class SubprocPool:
             self.pending_futures[job_id] = future = Future()
         future.set_running_or_notify_cancel()
         self.names[job_id] = name
-        self._send(MsgHeader.JOB, job_id, job_data, job_id)
+        self._send(MsgHeader.JOB, job_id, job_data)
         return future
 
     def _send(self, msg_header: MsgHeader, job_id: int = -1, data: bytes = b"") -> None:
         with self.write_lock:
             if not self.running:
                 raise RuntimeError("Attempting to use a closed pool")
-            _send_msg(self.write_pipe, msg_header, data, job_id)
+            _send_msg(self.write_pipe, msg_header, job_id, data)
 
     def _read_thread(self) -> None:
         while True:

--- a/torch/_inductor/compile_worker/subproc_pool.py
+++ b/torch/_inductor/compile_worker/subproc_pool.py
@@ -96,7 +96,7 @@ class SubprocException(Exception):
             f"An exception occurred in a subprocess:\n\nName={name}\n{details}"
         )
 
-    def with_name(self, name: str):
+    def with_name(self, name: str) -> "SubprocException":
         return SubprocException(self.details, name)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #161561
* __->__ #161452

Added a optional name argument to SubprocPool.submit.

We record this in a dictionary, and when raising exceptions, add the name.
We manage the lifecycle the same as the pending futures.

Added a specific testcase to make sure this logs correctly.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben