### PR TITLE
forward fix #161102

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -174,7 +174,6 @@ ROCM_BLOCKLIST = [
     "test_jit_legacy",
     "test_cuda_nvml_based_avail",
     "test_jit_cuda_fuser",
-    "inductor/test_flex_attention",
 ]
 
 S390X_BLOCKLIST = [

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -174,6 +174,7 @@ ROCM_BLOCKLIST = [
     "test_jit_legacy",
     "test_cuda_nvml_based_avail",
     "test_jit_cuda_fuser",
+    "inductor/test_flex_attention",
 ]
 
 S390X_BLOCKLIST = [

--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -53,9 +53,11 @@ def flex_attention_grid(batch_size, q_heads, num_queries, d_model, meta, *, cdiv
 
 def get_float32_precision():
     if (
-        (torch.backends.cuda.matmul.fp32_precision == "ieee"
-        if torch.backends.cuda.matmul.fp32_precision != "none"
-        else torch.get_float32_matmul_precision() == "highest")
+        (
+            torch.backends.cuda.matmul.fp32_precision == "ieee"
+            if torch.backends.cuda.matmul.fp32_precision != "none"
+            else torch.get_float32_matmul_precision() == "highest"
+        )
         or torch.version.hip
         or torch.mtia.is_available()
     ):

--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -53,9 +53,9 @@ def flex_attention_grid(batch_size, q_heads, num_queries, d_model, meta, *, cdiv
 
 def get_float32_precision():
     if (
-        torch.backends.cuda.matmul.fp32_precision == "ieee"
+        (torch.backends.cuda.matmul.fp32_precision == "ieee"
         if torch.backends.cuda.matmul.fp32_precision != "none"
-        else torch.get_float32_matmul_precision() == "highest"
+        else torch.get_float32_matmul_precision() == "highest")
         or torch.version.hip
         or torch.mtia.is_available()
     ):


### PR DESCRIPTION
PR #161102 caused tf32 to be the default precision for flex attention.  This PR forward-fixes the broken logic and restores ROCm MI200 CI flex attention test.


cc @eqy  @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben