### PR TITLE
[Intel GPU PT2E] Infer runtime out dtype based on dequant node in pat…

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/detail/QConv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QConv.cpp
@@ -51,9 +51,10 @@ qconv_get_md(
   wgh_usr_md = dnnl::memory::desc(wgh_tz, wei_data_t, fmt_wgh);
 
   if (bias.has_value()) {
+    auto bias_dt = get_onednn_dtype(bias.value());
     bias_usr_md = dnnl::memory::desc(
         bias.value().sizes().vec(),
-        dnnl::memory::data_type::f32,
+        bias_dt,
         dnnl::memory::format_tag::x);
   }
 

--- a/aten/src/ATen/native/mkldnn/xpu/qconv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/qconv.cpp
@@ -10,13 +10,11 @@ namespace at::native::xpu {
 static inline c10::ScalarType qconv_decide_out_dtype(
     const at::Tensor& act,
     const std::optional<c10::ScalarType> output_dtype) {
-  bool fp32_output = output_dtype.has_value() && (output_dtype == c10::kFloat);
-  bool bfloat16_output =
-      output_dtype.has_value() && (output_dtype == c10::kBFloat16);
-  auto dst_dtype = fp32_output
-      ? c10::kFloat
-      : (bfloat16_output ? c10::kBFloat16 : act.scalar_type());
-  return dst_dtype;
+  if (output_dtype.has_value()) {
+    return output_dtype.value();
+  } else {
+    return act.scalar_type();
+  }
 }
 
 static at::Tensor qconv_prepack_xpu(

--- a/aten/src/ATen/native/mkldnn/xpu/qlinear.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/qlinear.cpp
@@ -10,13 +10,11 @@ namespace at::native::xpu {
 static inline c10::ScalarType qlinear_decide_out_dtype(
     const at::Tensor& act,
     const std::optional<c10::ScalarType> output_dtype) {
-  bool fp32_output = output_dtype.has_value() && (output_dtype == c10::kFloat);
-  bool bfloat16_output =
-      output_dtype.has_value() && (output_dtype == c10::kBFloat16);
-  auto dst_dtype = fp32_output
-      ? c10::kFloat
-      : (bfloat16_output ? c10::kBFloat16 : act.scalar_type());
-  return dst_dtype;
+  if (output_dtype.has_value()) {
+    return output_dtype.value();
+  } else {
+    return act.scalar_type();
+  }
 }
 
 static Tensor q_linear_pointwise(

--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -1570,7 +1570,7 @@ static at::Tensor _quantized_convolution_onednn(
       ),
       "For post op sum, accum tensor must be contiguous."
     );
-    if (fp32_output || bfloat16_output) {
+    if (high_prec_output) {
       TORCH_CHECK(accum_scale == 1.0,  " (ONEDNN): fp32 or bf16 output, accum_scale must be 1.0.");
       TORCH_CHECK(accum_zero_point == 0,  " (ONEDNN): fp32 or bf16 output, accum_zero_point must be 0");
       TORCH_CHECK((accum.value().scalar_type() == c10::kFloat) || (accum.value().scalar_type() == c10::kBFloat16), "The accum tensor should be KFloat or KBFloat.");
@@ -1741,7 +1741,7 @@ static at::Tensor _quantized_convolution_onednn(
     at::empty(
       dst_dims,
       at::device(c10::kCPU)
-          .dtype(out_dtype)
+          .dtype(high_prec_output ? output_dtype.value() : act.scalar_type())
           .memory_format(kSpatialDim == 2 ?
               c10::MemoryFormat::ChannelsLast :
               c10::MemoryFormat::ChannelsLast3d)

--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -1540,9 +1540,10 @@ static at::Tensor _quantized_convolution_onednn(
   // inv_scale = 1.0 / scale will be folded.
   // So, we can only get inv_scale from quant node which is used as
   // output_scale of this op.
-  bool fp32_output = output_dtype.has_value() && (output_dtype.value() == c10::kFloat);
-  bool bfloat16_output = output_dtype.has_value() && (output_dtype.value() == c10::kBFloat16);
-  if (fp32_output || bfloat16_output) {
+  bool is_fp8 = weight.scalar_type() == c10::ScalarType::Float8_e4m3fn;
+  bool high_prec_output = output_dtype.has_value() &&
+     ((output_dtype.value() != c10::ScalarType::Byte) && !is_fp8);
+  if (high_prec_output) {
     // When fp32 or bf16 output, oneDNN expects op_attr doesn't set_scales and set_zero_points.
     // So, we will use default output_scale as 1.0 and output_zero_point as 0, since
     // when output_scale is 1.0, we will skip invoking of op_attr.set_scales in ideep;

--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -1624,7 +1624,6 @@ static at::Tensor _quantized_convolution_onednn(
     dilation.size() == (decltype(dilation.size()))kSpatialDim,
     func_name, ": dilation should contain ", kSpatialDim, " elements for ",
     kSpatialDim, "D convolution.");
-  bool is_fp8 = weight.scalar_type() == c10::ScalarType::Float8_e4m3fn;
   if (is_fp8) {
     TORCH_CHECK(act_dtype == c10::ScalarType::Float8_e4m3fn,
       func_name, ": expect input tensor to have fp8 data type, but got ", act_dtype);

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -1090,9 +1090,9 @@ static at::Tensor linear_int8_with_onednn_weight(
       weight_scales.scalar_type() == c10::ScalarType::Float, "weight scales should be dtype c10::ScalarType::Float.");
   TORCH_CHECK(
       binary_alpha == 1.0f, "onednn qlinear: alpha != 1 for binary post op is not yet supported.");
-  bool fp32_output = output_dtype.has_value() && (output_dtype.value() == c10::kFloat);
-  bool bf16_output = output_dtype.has_value() && (output_dtype.value() == c10::kBFloat16);
-  if (fp32_output || bf16_output) {
+  bool high_prec_output = output_dtype.has_value() &&
+     ((output_dtype.value() != c10::ScalarType::Byte) && !is_fp8);
+  if (high_prec_output) {
     TORCH_CHECK(
         output_scale == 1.0f && output_zero_point == 0, "onednn qlinear: expect scale=1 and zero point=0 for fp32 output");
   }
@@ -1111,7 +1111,7 @@ static at::Tensor linear_int8_with_onednn_weight(
       +-------------------+--------------+---------------+
     */
     TORCH_CHECK(other.has_value(), "onednn qlinear: the extra input is missing for post op ", binary_post_op);
-    if (fp32_output || bf16_output) {
+    if (high_prec_output) {
       TORCH_CHECK(
           other_scale == 1.0f && other_zero_point == 0,
           "onednn qlinear: expect extra input scale = 1.0 and zero point = 0 when output dtype is ", output_dtype.value(),
@@ -1173,7 +1173,7 @@ static at::Tensor linear_int8_with_onednn_weight(
       at::empty(
         dst_dims,
         at::device(c10::kCPU)
-            .dtype(out_dtype)
+            .dtype(high_prec_output ? output_dtype.value() : input.scalar_type())
       );
   if (output.numel() == 0) {
     return output;

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -209,13 +209,8 @@ class TestPatternMatcherBase(TestCase):
             convert_model = _generate_qdq_quantized_model(
                 mod, inputs, is_qat, is_dynamic, quantizer
             )
-            expected = mod(*inputs)
             with torch.no_grad(), maybe_autocast:
-                actual = torch.compile(convert_model)(*inputs)
-                print("actual:", actual[0, 0:2,:,:])
-                print("expected:", expected[0, 0:2, :, :])
-                mean_err = torch.mean((actual - expected).abs())
-                print("mean_err:", mean_err)
+                _ = torch.compile(convert_model)(*inputs)
                 matcher_check_fn()
         else:
             with torch.no_grad(), maybe_autocast:
@@ -1173,21 +1168,15 @@ class TestPatternMatcher(TestPatternMatcherBase):
                 self.softmax = torch.nn.Softmax(dim=1)
 
             def forward(self, x):
-                # [1,3,8,8]
-                # [1,128, 8, 8]
                 x = self.conv(x)
-                # x = self.softmax(x.to(torch.float32)).to(torch.float16)
-                x = self.softmax(x)
-                # x = torch.nn.functional.relu(x)
-                x = self.conv2(x)
-                x = self.conv3(x)
+                x = self.softmax(x.to(torch.float32)).to(torch.float16)
+                x = self.conv3(self.conv2(x))
                 return x
                 # return self.conv3(self.conv2(self.conv(x).to(torch.float32)))
 
-        dtype=torch.float16
-        mod = M().eval().to(device=device, dtype=dtype)
+        mod = M().eval().to(device=device, dtype=torch.float16)
         v = (
-            torch.randn((1, 3, 8, 8), dtype=dtype, requires_grad=False)
+            torch.randn((1, 3, 8, 8), dtype=torch.float16, requires_grad=False)
             .add(1)
             .to(device=device)
         )

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -2370,6 +2370,82 @@ class TestPatternMatcher(TestPatternMatcherBase):
             is_dynamic=is_dynamic,
         )
 
+    def _qlinear_fp16_test_helper(
+        self,
+        inputs,
+        device="cpu",
+        do_permute=False,
+        matcher_check_fn=None,
+        bias=True,
+        is_dynamic=False,
+        is_qat=False,
+    ):
+        class M(torch.nn.Module):
+            def __init__(self, use_bias):
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 3, use_bias)
+                self.linear2 = torch.nn.Linear(3, 4, use_bias)
+                self.softmax = torch.nn.Softmax(dim=1)
+
+            def forward(self, x):
+                x = self.linear(x)
+                x = self.softmax(x.to(torch.float32))
+                x = self.linear2(x.to(torch.float16))
+                return x
+
+        mod = M(bias).eval().to(device=device, dtype=torch.float16)
+        assert isinstance(inputs, tuple)
+
+        def __convert_tensor_to_device(input, device):
+            return input.to(device=device) if isinstance(input, torch.Tensor) else input
+
+        inputs = tuple(__convert_tensor_to_device(input, device) for input in inputs)
+
+        def _default_matcher_check_fn():
+            self.assertEqual(
+                counters["inductor"]["qlinear_weight_prepack_matcher_count"], 2
+            )
+
+        self._test_common(
+            mod,
+            inputs,
+            matcher_check_fn=(
+                matcher_check_fn
+                if matcher_check_fn is not None
+                else _default_matcher_check_fn
+            ),
+            check_quantization=True,
+            is_qat=is_qat,
+            is_dynamic=is_dynamic,
+        )
+
+    @skipIfNoDynamoSupport
+    @skipIfNoONEDNN
+    @skipIfNoXPU
+    def test_qlinear_fp16_xpu(self):
+        r"""
+        This testcase will quantize a single Linear Moduel with fp16 quantization.
+        """
+        for bias in [True, False]:
+            self._qlinear_fp16_test_helper(
+                (torch.randn((2, 4), dtype=torch.float16, device="xpu"),),
+                device="xpu",
+                bias=bias,
+            )
+
+    @skipIfNoDynamoSupport
+    @skipIfNoONEDNN
+    def test_qlinear_fp16_cpu(self):
+        r"""
+        This testcase will quantize a single Linear Moduel with fp16 quantization.
+        """
+        for bias in [True, False]:
+            self._qlinear_fp16_test_helper(
+                (torch.randn((2, 4), dtype=torch.float16, device="cpu"),),
+                device="cpu",
+                bias=bias,
+            )
+
     @skipIfNoDynamoSupport
     @skipIfNoONEDNN
     def test_qlinear_cpu(self):

--- a/torch/_inductor/fx_passes/quantization.py
+++ b/torch/_inductor/fx_passes/quantization.py
@@ -77,6 +77,7 @@ def _get_pattern_output_dtype(match: Match):
         torch.uint8,
         torch.float32,
         torch.bfloat16,
+        torch.float16,
         torch.float8_e4m3fn,
     ]
     return output_dtype
@@ -1930,6 +1931,13 @@ def _register_qlinear_weight_prepack_pass(
         ) = _get_linear_dq_node(
             linear_node, input_index, dtype, input_dim_exceeds_two, input_contiguous
         )
+        # Argument dtype is used for mark whether AMP is enabled or not for
+        # pattern matching. It does not claim the dtype of pattern output.
+        # The real output dtype of pattern is determined by the dequant node instead.
+        dequant_dtype = dequant_node.kwargs.get("out_dtype", dtype)
+        is_amp = dtype == torch.bfloat16
+        if is_amp:
+            dequant_dtype = torch.bfloat16
 
         if input_dim_exceeds_two and not input_contiguous:
             wgt_expand_node = linear_node.args[weight_index]
@@ -1991,7 +1999,7 @@ def _register_qlinear_weight_prepack_pass(
                 bias,
                 1.0,  # output_scale
                 0,  # output_zero_point
-                dtype,  # output_dtype
+                dequant_dtype,  # output_dtype
                 "none",  # post op name
                 [],  # post op args
                 "",  # post op algorithm
@@ -3315,7 +3323,7 @@ def _register_qlinear_unary_fusion():
         _gelu_fusion_2 as _gelu_fusion_tanh,
     )
 
-    for original_pattern_output_dtype in [torch.float32, torch.bfloat16]:
+    for original_pattern_output_dtype in [torch.float32, torch.bfloat16, torch.float16]:
         is_bf16 = original_pattern_output_dtype == torch.bfloat16
         for x_scale_zp_are_tensors in (False, True):
             qlinear_pattern = get_qlinear_pt2e_pattern(x_scale_zp_are_tensors)

--- a/torch/_inductor/fx_passes/quantization.py
+++ b/torch/_inductor/fx_passes/quantization.py
@@ -2886,7 +2886,7 @@ def _register_qconv_post_op_fusion_pass(
             kwargs["groups"],
         )
         output_dtype = _get_pattern_output_dtype(match)
-        assert output_dtype in [torch.int8, torch.uint8, torch.float32, torch.bfloat16]
+        assert output_dtype in [torch.int8, torch.uint8, torch.float32, torch.bfloat16, torch.float16]
         # Output QParams
         o_inv_scale = (
             kwargs["o_inv_scale"]

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1395,7 +1395,7 @@ def quantized_decomposed_quantize_per_tensor_default(
 ) -> Union[TensorBox, ShapeAsConstantBuffer]:
     if input.get_dtype() == torch.bfloat16:
         input = to_dtype(input, torch.float32)
-    assert input.get_dtype() == torch.float32, (
+    assert input.get_dtype() in [torch.float32, torch.float16], (
         f"Expecting input to have dtype torch.float32, but got dtype: {input.get_dtype()}"
     )
 

--- a/torch/_inductor/mkldnn_ir.py
+++ b/torch/_inductor/mkldnn_ir.py
@@ -1023,7 +1023,7 @@ class QLinearPointwisePT2E(ExternKernelAlloc):
         ]
 
         assert output_dtype is not None
-        if output_dtype in [torch.float32, torch.bfloat16]:
+        if output_dtype in [torch.float32, torch.bfloat16, torch.float16]:
             # in _prepare_linear_fusion_create, we use x.dtype (uint8) to create kernel_layout
             # if we set fp32_output, the output buf should be dtype float32 instead of uint8.
             kernel_layout.dtype = output_dtype

--- a/torch/_inductor/mkldnn_ir.py
+++ b/torch/_inductor/mkldnn_ir.py
@@ -664,7 +664,7 @@ class QConvPointWisePT2E(ExternKernelAlloc):
         ]
 
         assert output_dtype is not None
-        if output_dtype in [torch.float32, torch.bfloat16]:
+        if output_dtype in [torch.float32, torch.bfloat16, torch.float16]:
             # in _prepare_convolution_fusion_create, we use x.dtype (uint8) to create kernel_layout
             # if we set output_dtype is not None, the output buf should be output_dtype instead of uint8.
             kernel_layout.dtype = output_dtype

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2622,6 +2622,7 @@ if torch._C._has_mkldnn:
         output_shape[-1] = w.shape[1]
         assert output_dtype in [
             torch.float32,
+            torch.float16,
             torch.bfloat16,
             torch.int8,
             torch.uint8,

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2555,6 +2555,7 @@ if torch._C._has_mkldnn:
             output_dtype = x.dtype
         assert output_dtype in [
             torch.float32,
+            torch.float16,
             torch.bfloat16,
             torch.uint8,
             torch.int8,


### PR DESCRIPTION
# Motivation

Current `qlinear_weight_prepack` fx pass at x86Quantizer and XPUQuantizer cannot guarantee the dtype consistency between matched pattern and the replaced pattern.  For example,
```
          x                           w
          |                           |
    deuqnt(fp16)                 dequant(fp16)
          |                            |
          |                        permute
           \                       /
                 addmm(fp16)
```
Would be replaced by
```
             x                        w
              \                      /   
                 qlinear(...,fp32)
```
The original output node data type info is lost during graph rewriting. 

# Solution

As graph talks itself, the output dtype can be inferred from dequant node directly. The PR uses the data type as qlinear output dtype.

# Verification

```bash
    python test/inductor/test_mkldnn_pattern_matcher.py -v -k test_qlinear_fp16_xpu
   python test/inductor/test_mkldnn_pattern_matcher.py -v -k test_qlinear_fp16_cpu
```

```bash
onednn_verbose,v1,primitive,exec,gpu:0,matmul,jit:gemm:any,undef,src:s8::blocked:ab::f0 wei:s8::blocked:ab::f0 bia:f16::blocked:ab::f0_mask2 dst:f16::blocked:ab::f0,attr-scratchpad:user attr-scales:src0:0:f32+dst:0:f32+wei:2:f32,,1x16384:16384x10,0.167969
onednn_verbose,v1,primitive,exec,gpu:0,matmul,ocl:ref:any,undef,src:f16::blocked:ab::f0 wei:s8::blocked:ab::f0 bia:f16::blocked:ab::f0_mask2 dst:f16::blocked:ab::f0,attr-scratchpad:user attr-scales:src0:0:f32+dst:0:f32+wei:2:f32,,1x10:10x20,0.0810547
```
Fixes #ISSUE_NUMBER


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben