### PR TITLE
Run WoArm64 CI every 4 hours

### DIFF
--- a/.github/workflows/win-arm64-build-test.yml
+++ b/.github/workflows/win-arm64-build-test.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - ciflow/win-arm64/*
+  schedule:
+    # Every 4 hours starting at 00:00 UTC
+    - cron: '0 */4 * * *'
 
 env:
   GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
Since WoArm64 isn’t part of CI yet, this PR schedules the workflow to increase visibility and insights. It will execute every 4 hours and still support manual runs via the `ciflow/win-arm64` tag.