### PR TITLE
[Dynamo] Fix weakref.proxy error when `torch.compile`

### DIFF
--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -2912,7 +2912,9 @@ class GuardBuilder(GuardBuilderBase):
             getattr(guarded_object.__class__, "__weakrefoffset__", 0) != 0
         )
         # See D64140537 for why we are checking for tuple.
-        if supports_weakref and not isinstance(guarded_object, (enum.Enum, tuple)):
+        if supports_weakref and not isinstance(
+            guarded_object, (enum.Enum, tuple, weakref.ProxyTypes)
+        ):
             obj_ref = weakref.ref(guarded_object)
 
         guard.set_export_info(


### PR DESCRIPTION
Fixes #159258

The error occurs when we attempt to create a weak reference from a weak reference proxy.
https://github.com/pytorch/pytorch/blob/e9d42b3880dcdbd823bbdc9370c8b0b3af0ba2e3/torch/_dynamo/guards.py#L2910-L2915

In fact, we shouldn't create a weak reference from another reference or proxy, as it would check in CPython.
https://github.com/python/cpython/blob/f60f8225ed146a8f9b5fbf1eeed3474782127ea8/Objects/weakrefobject.c#L410-L418

However, `__weakrefoffset__` is not equal to **0** when the `guarded_object` is in `weakref.ProxyTypes`, and it will wrongly create a weak reference for the `weakref.ProxyTypes`. I think this could be a bug from CPython, but we can prevent it by adding more weakref type checks (`weakref.ProxyTypes` contains `weakref.ProxyType` and `weakref.CallableProxyType`) here.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela