### PR TITLE
Fix excess refcounting in ObjLoaderFunc

### DIFF
--- a/torch/csrc/jit/serialization/import.cpp
+++ b/torch/csrc/jit/serialization/import.cpp
@@ -71,15 +71,15 @@ static void postSetStateValidate(const IValue& v) {
 c10::intrusive_ptr<c10::ivalue::Object> ObjLoaderFunc(
     const at::StrongTypePtr& type,
     IValue input) {
-  auto cls = type.type_->expect<at::ClassType>();
-  auto qn = cls->name();
-  size_t n = cls->numAttributes();
+  const auto& cls = type.type_->expectRef<at::ClassType>();
+  auto qn = cls.name();
+  size_t n = cls.numAttributes();
   if (checkHasValidSetGetState(cls)) {
     auto obj = c10::ivalue::Object::create(type, n);
     // XXX: Do not optimize __setstate__, so that we don't try to
     // specialize the class before it is initialized.
     GraphOptimizerEnabledGuard guard(false);
-    Function& set_state = cls->getMethod("__setstate__");
+    Function& set_state = cls.getMethod("__setstate__");
     // since we are in the middle of unpickling we might still have lists and
     // dicts that do not have accurate tags (e.g. they report they are
     // List[Any]). But we need to run __setstate__ which will check the input
@@ -96,7 +96,7 @@ c10::intrusive_ptr<c10::ivalue::Object> ObjLoaderFunc(
     auto dict = std::move(input).toGenericDict();
     auto obj = c10::ivalue::Object::create(type, n);
     for (const auto i : c10::irange(n)) {
-      obj->setSlot(i, dict.at(cls->getAttributeName(i)));
+      obj->setSlot(i, dict.at(cls.getAttributeName(i)));
     }
     return obj;
   }

--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -110,7 +110,7 @@ void Pickler::pushIValueImpl(const IValue& ivalue) {
     pushGlobal(type_name.prefix(), type_name.name());
     push<PickleOpCode>(PickleOpCode::EMPTY_TUPLE);
     push<PickleOpCode>(PickleOpCode::NEWOBJ);
-    if (checkHasValidSetGetState(type)) {
+    if (checkHasValidSetGetState(*type)) {
       Function& getstate = type->getMethod("__getstate__");
       pushIValue(getstate({obj}));
     } else {

--- a/torch/csrc/jit/serialization/pickler_helper.cpp
+++ b/torch/csrc/jit/serialization/pickler_helper.cpp
@@ -34,9 +34,9 @@ WriteableTensorData getWriteableTensorData(
   return result;
 }
 
-bool checkHasValidSetGetState(const std::shared_ptr<c10::ClassType>& cls) {
+bool checkHasValidSetGetState(const c10::ClassType& cls) {
   // Check that the schemas for __getstate__ and __setstate__ are correct
-  auto getstate = cls->findMethod("__getstate__");
+  auto getstate = cls.findMethod("__getstate__");
   if (getstate == nullptr) {
     return false;
   }
@@ -56,7 +56,7 @@ bool checkHasValidSetGetState(const std::shared_ptr<c10::ClassType>& cls) {
 
   // Check __setstate__ if the method exists
   //   __setstate__ is expected to be (self, T) -> None
-  auto setstate = cls->findMethod("__setstate__");
+  auto setstate = cls.findMethod("__setstate__");
   if (!setstate) {
     return false;
   }

--- a/torch/csrc/jit/serialization/pickler_helper.h
+++ b/torch/csrc/jit/serialization/pickler_helper.h
@@ -112,7 +112,7 @@ getWriteableTensorData(const at::Tensor& tensor, bool to_cpu = true);
 // if the cls has __getstate__/__setstate__
 // assert they have the right schema and return true,
 // otherwise return false
-bool checkHasValidSetGetState(const std::shared_ptr<c10::ClassType>& cls);
+bool checkHasValidSetGetState(const c10::ClassType& cls);
 
 // Declare BackendMeta serialization and deserialization function pointer types.
 using BackendMetaPtr = std::function<


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #161528

expectRef is preferred over expect because it doesn't copy a std::shared_ptr.

Differential Revision: [D81053710](https://our.internmc.facebook.com/intern/diff/D81053710/)

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel