### PR TITLE
[4/N][SymmMem] Add `get_remote_tensor` + move up `get_buffer` and `get_signal_pad`

### DIFF
--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -806,6 +806,12 @@ class _SymmetricMemory:
         channel: int = 0,
         timeout_ms: int = 0,
     ) -> None: ...
+    def get_remote_tensor(
+        self,
+        peer: int,
+        sizes: torch.types._size,
+        dtype: torch.dtype,
+    ) -> torch.Tensor: ...
     @staticmethod
     def memset32(
         tensor: torch.Tensor, offset: int, val: int, count: int = 1

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1202,6 +1202,12 @@ This class does not support ``__members__`` property.)");
           py::arg("src_rank"),
           py::arg("channel") = 0,
           py::arg("timeout_ms") = 0)
+      .def(
+          "get_remote_tensor",
+          &SymmetricMemory::get_remote_tensor,
+          py::arg("peer"),
+          py::arg("sizes"),
+          py::arg("dtype"))
       // Util functions that are often used together with symmetric memory but
       // not necessarily directly on symmetric memory.
       .def_static(

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -146,78 +146,6 @@ void* CUDASymmetricMemory::get_multicast_ptr() {
   return mc_addr_;
 }
 
-at::Tensor CUDASymmetricMemory::get_buffer(
-    int rank,
-    c10::IntArrayRef sizes,
-    c10::ScalarType dtype,
-    int64_t storage_offset) {
-  const size_t numel = std::accumulate(
-      sizes.begin(),
-      sizes.end(),
-      static_cast<size_t>(1),
-      std::multiplies<size_t>());
-  const auto element_size = c10::elementSize(dtype);
-  const auto req_size = (numel + storage_offset) * element_size;
-  TORCH_CHECK(
-      req_size <= buffer_size_,
-      "CUDASymmetricMemory::get_buffer: the requested size (",
-      req_size,
-      " bytes) exceeds the allocated size (",
-      buffer_size_,
-      " bytes)");
-  auto data_ptr = reinterpret_cast<uint8_t*>(buffers_[rank]) +
-      storage_offset * element_size;
-  auto device = c10::Device(c10::DeviceType::CUDA, local_device_idx_);
-  auto options = at::TensorOptions().dtype(dtype).device(device);
-  return at::for_blob(data_ptr, sizes)
-      .options(options)
-      .target_device(device)
-      .make_tensor();
-}
-
-at::Tensor CUDASymmetricMemory::get_signal_pad(
-    int rank,
-    c10::IntArrayRef sizes,
-    std::optional<c10::ScalarType> dtype,
-    int64_t storage_offset) {
-  // If the dtype is unspecified, default it to UInt32, as it
-  // is the most common type for signaling purposes.
-  if (!dtype.has_value()) {
-    dtype = c10::ScalarType::UInt32;
-  }
-
-  // If the shape is unspecified, treat the signal pad as a 1d tensor.
-  const auto element_size = c10::elementSize(*dtype);
-  std::vector<int64_t> shape;
-  if (!sizes.empty()) {
-    shape = sizes.vec();
-  } else {
-    shape.push_back(signal_pad_size / element_size);
-  }
-
-  const size_t numel = std::accumulate(
-      shape.begin(),
-      shape.end(),
-      static_cast<size_t>(1),
-      std::multiplies<size_t>());
-  const auto req_size = (numel + storage_offset) * element_size;
-  TORCH_CHECK(
-      req_size <= signal_pad_size,
-      "CUDASymmetricMemory::get_signal_pad: the requested size (",
-      req_size,
-      " bytes) exceeds the allocated size (",
-      signal_pad_size,
-      " bytes)");
-  auto data_ptr = reinterpret_cast<uint8_t*>(signal_pads_[rank]) +
-      storage_offset * element_size;
-  auto device = c10::Device(c10::DeviceType::CUDA, local_device_idx_);
-  auto options = at::TensorOptions().dtype(*dtype).device(device);
-  return at::for_blob(data_ptr, shape)
-      .options(options)
-      .target_device(device)
-      .make_tensor();
-}
-
 void check_channel(int channel, int world_size) {
   TORCH_CHECK(
       channel >= 0,
@@ -386,6 +314,10 @@ int CUDASymmetricMemory::get_rank() {
 
 int CUDASymmetricMemory::get_world_size() {
   return world_size_;
+}
+
+c10::Device CUDASymmetricMemory::get_device() {
+  return c10::Device(c10::DeviceType::CUDA, local_device_idx_);
 }
 
 Block::Block(

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.hpp
@@ -52,24 +52,13 @@ class CUDASymmetricMemory : public SymmetricMemory {
   bool has_multicast_support() override;
   void* get_multicast_ptr() override;
 
-  at::Tensor get_buffer(
-      int rank,
-      c10::IntArrayRef sizes,
-      c10::ScalarType dtype,
-      int64_t storage_offset) override;
-
-  at::Tensor get_signal_pad(
-      int rank,
-      c10::IntArrayRef sizes,
-      std::optional<c10::ScalarType> dtype,
-      int64_t storage_offset) override;
-
   void barrier(int channel, size_t timeout_ms) override;
   void put_signal(int dst_rank, int channel, size_t timeout_ms) override;
   void wait_signal(int src_rank, int channel, size_t timeout_ms) override;
 
   int get_rank() override;
   int get_world_size() override;
+  c10::Device get_device() override;
 
  private:
   std::vector<c10::intrusive_ptr<AllocationRef>> alloc_refs_;

--- a/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
@@ -93,82 +93,6 @@ class NCCLSymmetricMemory : public SymmetricMemory {
     return nullptr;
   }
 
-  // TODO: This is up for change.
-  at::Tensor get_buffer(
-      int rank,
-      c10::IntArrayRef sizes,
-      c10::ScalarType dtype,
-      int64_t storage_offset) override {
-    // TODO: deduplicate
-    const size_t numel = std::accumulate(
-        sizes.begin(),
-        sizes.end(),
-        static_cast<size_t>(1),
-        std::multiplies<size_t>());
-    const auto element_size = c10::elementSize(dtype);
-    const auto req_size = (numel + storage_offset) * element_size;
-    TORCH_CHECK(
-        req_size <= buffer_size_,
-        "NCCLSymmetricMemory::get_buffer: the requested size (",
-        req_size,
-        " bytes) exceeds the allocated size (",
-        buffer_size_,
-        " bytes)");
-    auto data_ptr = reinterpret_cast<uint8_t*>(buffers_[rank]) +
-        storage_offset * element_size;
-    auto device = c10::Device(c10::DeviceType::CUDA, device_idx_);
-    auto options = at::TensorOptions().dtype(dtype).device(device);
-    return at::for_blob(data_ptr, sizes)
-        .options(options)
-        .target_device(device)
-        .make_tensor();
-  }
-
-  // TODO: This is up for change.
-  at::Tensor get_signal_pad(
-      int rank,
-      c10::IntArrayRef sizes,
-      std::optional<c10::ScalarType> dtype,
-      int64_t storage_offset) override {
-    // TODO: deduplicate
-    // If the dtype is unspecified, default it to UInt32, as it
-    // is the most common type for signaling purposes.
-    if (!dtype.has_value()) {
-      dtype = c10::ScalarType::UInt32;
-    }
-
-    // If the shape is unspecified, treat the signal pad as a 1d tensor.
-    const auto element_size = c10::elementSize(*dtype);
-    std::vector<int64_t> shape;
-    if (!sizes.empty()) {
-      shape = sizes.vec();
-    } else {
-      shape.push_back(signal_pad_size / element_size);
-    }
-
-    const size_t numel = std::accumulate(
-        shape.begin(),
-        shape.end(),
-        static_cast<size_t>(1),
-        std::multiplies<size_t>());
-    const auto req_size = (numel + storage_offset) * element_size;
-    TORCH_CHECK(
-        req_size <= signal_pad_size,
-        "NCCLSymmetricMemory::get_signal_pad: the requested size (",
-        req_size,
-        " bytes) exceeds the allocated size (",
-        signal_pad_size,
-        " bytes)");
-    auto data_ptr = reinterpret_cast<uint8_t*>(signal_pads_[rank]) +
-        storage_offset * element_size;
-    auto device = c10::Device(c10::DeviceType::CUDA, device_idx_);
-    auto options = at::TensorOptions().dtype(*dtype).device(device);
-    return at::for_blob(data_ptr, shape)
-        .options(options)
-        .target_device(device)
-        .make_tensor();
-  }
-
   void barrier(int channel, size_t timeout_ms) override {
     // TODO
   }
@@ -187,6 +111,10 @@ class NCCLSymmetricMemory : public SymmetricMemory {
 
   int get_world_size() override {
     return world_size_;
+  }
+
+  c10::Device get_device() override {
+    return c10::Device(c10::DeviceType::CUDA, device_idx_);
   }
 
   virtual std::vector<int>& get_rank_to_global_rank() override {

--- a/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cu
@@ -216,16 +216,15 @@ class NVSHMEMSymmetricMemory : public SymmetricMemory {
       c10::ScalarType dtype,
       int64_t storage_offset) override {
     // storage_offset is in element, convert to byte
-    const auto element_size = c10::elementSize(dtype);
-    const auto offset_bytes = storage_offset * element_size;
-    return _get_buffer_at_offset(rank, sizes, dtype, offset_bytes);
+    const auto offset_bytes = storage_offset * c10::elementSize(dtype);
+    return _get_buffer_at_byte_offset(rank, sizes, dtype, offset_bytes);
   }
 
   at::Tensor get_remote_tensor(
       int peer,
       c10::IntArrayRef sizes,
       c10::ScalarType dtype) override {
-    return _get_buffer_at_offset(peer, sizes, dtype, offset_);
+    return _get_buffer_at_byte_offset(peer, sizes, dtype, offset_);
   }
 
   at::Tensor get_signal_pad(
@@ -297,7 +296,7 @@ class NVSHMEMSymmetricMemory : public SymmetricMemory {
   };
 
  private:
-  at::Tensor _get_buffer_at_offset(
+  at::Tensor _get_buffer_at_byte_offset(
       int rank,
       c10::IntArrayRef sizes,
       c10::ScalarType dtype,

--- a/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cu
@@ -297,13 +297,14 @@ class NVSHMEMSymmetricMemory : public SymmetricMemory {
 
  private:
   at::Tensor _get_buffer_at_byte_offset(
-      int rank,
+      int peer,
       c10::IntArrayRef sizes,
       c10::ScalarType dtype,
       size_t offset_bytes) {
-    auto peer_ptr = pai_->buffers_[rank];
+    TORCH_CHECK(peer >= 0 && peer < get_world_size(), "Invalid peer rank: ", peer);
+    auto peer_ptr = pai_->buffers_[peer];
     TORCH_CHECK(peer_ptr != nullptr,
-        "Cannot get buffer across nodes, my rank: ", get_rank(), ", peer: ", rank);
+        "Cannot get buffer across nodes, my rank: ", get_rank(), ", peer: ", peer);
     const size_t tensor_bytes = nbytes_of(sizes, dtype);
     const auto req_size = offset_bytes + tensor_bytes;
     TORCH_CHECK(

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
@@ -288,6 +288,112 @@ std::shared_ptr<c10::Allocator> get_mempool_allocator(c10::Device device) {
   return it->second;
 }
 
+// Helper function:
+// Calculate the number of bytes of a tensor given its shape and dtype
+static inline size_t nbytes_of(c10::IntArrayRef sizes, c10::ScalarType dtype) {
+  const auto numel = std::accumulate(
+      sizes.begin(), sizes.end(), static_cast<size_t>(1), std::multiplies<>());
+  return numel * c10::elementSize(dtype);
+}
+
+// Helper function:
+// Get the buffer pointer for a peer at a given offset
+static at::Tensor get_buffer_at_byte_offset(
+    SymmetricMemory* handle,
+    int peer,
+    c10::IntArrayRef sizes,
+    c10::ScalarType dtype,
+    size_t offset_bytes) {
+  TORCH_CHECK(
+      peer >= 0 && peer < handle->get_world_size(),
+      "Invalid peer rank: ",
+      peer);
+  auto peer_ptr = handle->get_buffer_ptrs()[peer];
+  TORCH_CHECK(
+      peer_ptr != nullptr,
+      "Cannot get buffer across nodes, my rank: ",
+      handle->get_rank(),
+      ", peer: ",
+      peer);
+  const size_t tensor_bytes = nbytes_of(sizes, dtype);
+  const auto req_size = offset_bytes + tensor_bytes;
+  const auto buffer_size = handle->get_buffer_size();
+  TORCH_CHECK(
+      req_size <= buffer_size,
+      "SymmetricMemory::get_buffer: the requested size (",
+      req_size,
+      " bytes) exceeds the allocated size (",
+      buffer_size,
+      " bytes)");
+  auto data_ptr = reinterpret_cast<uint8_t*>(peer_ptr) + offset_bytes;
+  auto device = handle->get_device();
+  auto options = at::TensorOptions().dtype(dtype).device(device);
+  return at::for_blob(data_ptr, sizes)
+      .options(options)
+      .target_device(device)
+      .make_tensor();
+}
+
+// Implementation of SymmetricMemory APIs common to all backends
+
+at::Tensor SymmetricMemory::get_buffer(
+    int rank,
+    c10::IntArrayRef sizes,
+    c10::ScalarType dtype,
+    int64_t storage_offset) {
+  // storage_offset is in element, convert to byte
+  const auto offset_bytes = storage_offset * c10::elementSize(dtype);
+  return get_buffer_at_byte_offset(this, rank, sizes, dtype, offset_bytes);
+}
+
+at::Tensor SymmetricMemory::get_remote_tensor(
+    int peer,
+    c10::IntArrayRef sizes,
+    c10::ScalarType dtype) {
+  return get_buffer_at_byte_offset(this, peer, sizes, dtype, get_offset());
+}
+
+at::Tensor SymmetricMemory::get_signal_pad(
+    int rank,
+    c10::IntArrayRef sizes,
+    std::optional<c10::ScalarType> dtype,
+    int64_t storage_offset) {
+  // If the dtype is unspecified, default it to UInt32, as it
+  // is the most common type for signaling purposes.
+  if (!dtype.has_value()) {
+    dtype = c10::ScalarType::UInt32;
+  }
+
+  // If the shape is unspecified, treat the signal pad as a 1d tensor.
+  const auto element_size = c10::elementSize(*dtype);
+  const auto signal_pad_size = get_signal_pad_size();
+  std::vector<int64_t> shape;
+  if (!sizes.empty()) {
+    shape = sizes.vec();
+  } else {
+    shape.push_back(static_cast<int64_t>(signal_pad_size / element_size));
+  }
+
+  const auto req_pad_bytes = nbytes_of(shape, *dtype);
+  const auto offset_bytes = storage_offset * element_size;
+  const auto req_size = offset_bytes + req_pad_bytes;
+  TORCH_CHECK(
+      req_size <= signal_pad_size,
+      "SymmetricMemory::get_signal_pad: the requested size (",
+      req_size,
+      " bytes) exceeds the allocated size (",
+      signal_pad_size,
+      " bytes)");
+  auto data_ptr =
+      reinterpret_cast<uint8_t*>(get_signal_pad_ptrs()[rank]) + offset_bytes;
+  auto device = get_device();
+  auto options = at::TensorOptions().dtype(dtype).device(device);
+  return at::for_blob(data_ptr, shape)
+      .options(options)
+      .target_device(device)
+      .make_tensor();
+}
+
 } // namespace c10d::symmetric_memory
 
 namespace {

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
@@ -83,6 +83,13 @@ class TORCH_API SymmetricMemory : public c10::intrusive_ptr_target {
   virtual int* get_rank_to_global_rank_dev() {
     TORCH_CHECK(false, "NYI");
   }
+
+  virtual at::Tensor get_remote_tensor(
+      int peer,
+      c10::IntArrayRef sizes,
+      c10::ScalarType dtype) {
+    TORCH_CHECK(false, "NYI");
+  }
 };
 
 class SymmetricMemoryAllocator : public c10::intrusive_ptr_target {

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
@@ -57,17 +57,22 @@ class TORCH_API SymmetricMemory : public c10::intrusive_ptr_target {
   virtual bool has_multicast_support() = 0;
   virtual void* get_multicast_ptr() = 0;
 
-  virtual at::Tensor get_buffer(
+  at::Tensor get_buffer(
       int rank,
       c10::IntArrayRef sizes,
       c10::ScalarType dtype,
-      int64_t storage_offset) = 0;
+      int64_t storage_offset);
 
-  virtual at::Tensor get_signal_pad(
+  at::Tensor get_signal_pad(
       int rank,
       c10::IntArrayRef sizes,
       std::optional<c10::ScalarType> dtype = std::nullopt,
-      int64_t storage_offset = 0) = 0;
+      int64_t storage_offset = 0);
+
+  at::Tensor get_remote_tensor(
+      int peer,
+      c10::IntArrayRef sizes,
+      c10::ScalarType dtype);
 
   virtual void barrier(int channel, size_t timeout_ms) = 0;
   virtual void put_signal(int dst_rank, int channel, size_t timeout_ms) = 0;
@@ -75,19 +80,13 @@ class TORCH_API SymmetricMemory : public c10::intrusive_ptr_target {
 
   virtual int get_rank() = 0;
   virtual int get_world_size() = 0;
+  virtual c10::Device get_device() = 0;
 
   virtual const std::vector<int>& get_rank_to_global_rank() {
     TORCH_CHECK(false, "NYI");
   }
 
   virtual int* get_rank_to_global_rank_dev() {
-    TORCH_CHECK(false, "NYI");
-  }
-
-  virtual at::Tensor get_remote_tensor(
-      int peer,
-      c10::IntArrayRef sizes,
-      c10::ScalarType dtype) {
     TORCH_CHECK(false, "NYI");
   }
 };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):

`get_remote_tensor `: return a symmetric tensor given a peer rank.

The difference between `get_buffer` API and `get_remote_tensor` API:
- the former accepts an offset, whereas the latter doesn't
- the latter returns a symmetric tensor at `hdl.offset` on `peer`.

As a refactorization, this PR also moves the implementation of `get_buffer` and `get_signal_pad` to the `SymmetricMemory` level as their code is common to all backends.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta