### PR TITLE
Fix dev container configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -18,8 +18,9 @@ RUN apt-get install --no-install-recommends -y lsb-release wget software-propert
     sudo apt-get clean -y
 
 # Create Python virtual environment
-# RUN python3 -m venv /opt/venv
-# ENV PATH="/opt/venv/bin:$PATH"
+RUN python3 -m venv /opt/venv && \
+    chown -R vscode:vscode /opt/venv
+ENV PATH="/opt/venv/bin:$PATH" VIRTUAL_ENV="/opt/venv"
 RUN pip3 install --upgrade pip
 
 # Install CLANG if version is specified
@@ -41,6 +42,7 @@ RUN if [ -n "$CUDA_VERSION" ]; then \
     CUDA_REPO_VERSION=$(echo ${CUDA_VERSION} | sed 's/\./\-/g'); \
     wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb && \
     dpkg -i cuda-keyring_1.0-1_all.deb && \
+    apt-get update && \
     apt-get install --no-install-recommends -y cuda-toolkit-${CUDA_VERSION} && \
     apt-get clean -y; \
     fi

--- a/.devcontainer/cuda/devcontainer.json
+++ b/.devcontainer/cuda/devcontainer.json
@@ -8,7 +8,7 @@
     "args": {
       "USERNAME": "vscode",
       "BUILDKIT_INLINE_CACHE": "0",
-      "CUDA_VERSION": "12.8.0",
+      "CUDA_VERSION": "12.8",
       "CLANG_VERSION": ""
     }
   },
@@ -19,7 +19,7 @@
   "containerEnv": {
     "PIP_USER": "0" // <‑‑ disable implicit --user
   },
-// Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
 
   // Use 'postCreateCommand' to run commands after the container is created.


### PR DESCRIPTION
Fix the configuration of dev container:
- update version of CUDA to match with NVIDIA repo
- Set working python to venv, set owner of the venv folder to vscode user(now there is an issue that vscode user cannot install build packages to system interpreter)

Tested working with CPU and CUDA environments with a built dev container image from scratch.
