### PR TITLE
[TorchScript] ProfilingExecutor - RemoveProfileNodesAndSpecializeTypes None handling

### DIFF
--- a/test/cpp/jit/CMakeLists.txt
+++ b/test/cpp/jit/CMakeLists.txt
@@ -88,6 +88,7 @@ set(JIT_TEST_SRCS
   ${JIT_TEST_ROOT}/test_subgraph_matcher.cpp
   ${JIT_TEST_ROOT}/test_subgraph_rewriter.cpp
   ${JIT_TEST_ROOT}/test_subgraph_utils.cpp
+  ${JIT_TEST_ROOT}/test_te.cpp
   ${JIT_TEST_ROOT}/test_union.cpp
   ${JIT_TEST_ROOT}/test_utils.cpp
   ${JIT_TEST_ROOT}/test_script_profile.cpp

--- a/test/cpp/jit/test_te.cpp
+++ b/test/cpp/jit/test_te.cpp
@@ -1,0 +1,41 @@
+#include <gtest/gtest.h>
+
+#include <test/cpp/jit/test_utils.h>
+#include <torch/csrc/jit/ir/irparser.h>
+#include <torch/csrc/jit/passes/tensorexpr_fuser.h>
+
+#include <iostream>
+
+namespace torch {
+namespace jit {
+
+TEST(TETest, RemoveProfiling) {
+  auto g = std::make_shared<Graph>();
+  const auto graph_string = R"IR(
+    graph(%a : Tensor,
+          %b : bool):
+      %1 : None = prim::Constant()
+      %2 : Tensor? = prim::If(%b)
+        block0():
+          %3 : Tensor? = prim::profile[profiled_type=Tensor, seen_none=0](%1)
+          -> (%3)
+        block1():
+          %4 : Tensor = prim::profile[profiled_type=Tensor, seen_none=0](%a)
+          -> (%4)
+      return (%2))IR";
+  torch::jit::parseIR(graph_string, g.get());
+
+  g->lint();
+  RemoveProfileNodesAndSpecializeTypes(g);
+  g->lint();
+
+  testing::FileCheck()
+      .check("prim::Constant")
+      ->check("prim::If")
+      ->check("block")
+      ->check("block")
+      ->check("return")
+      ->run(*g);
+}
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -196,11 +196,20 @@ static void removeProfileNodesAndSpecializeTypes(Block* b) {
       if (it->input()->type()->kind() == c10::TypeKind::TensorType) {
         input_tensor_type = it->input()->type()->expect<TensorType>();
       } else {
-        input_tensor_type = it->input()
-                                ->type()
-                                ->expectRef<OptionalType>()
-                                .getElementType()
-                                ->expect<TensorType>();
+        auto element_type = it->input()
+                              ->type();
+        if (element_type->cast<OptionalType>()) {
+          input_tensor_type = element_type->expectRef<OptionalType>()
+                                          .getElementType()
+                                          ->expect<TensorType>();
+        } else {
+          // This handles the following scenario:
+          // 1. profiling nodes are inserted
+          // 2. optimizations simplify a Tensor? -> None type
+          // 3. Now the input to the prim::profile() is actually a None type.
+          element_type->expect<NoneType>();
+        }
+
         input_is_optional = true;
       }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #161538

ProfilingGraphExecutor works like this:
1. do some unrelated JIT optimizations
2. Add profiling nodes to collect JIT information like tensor dtypes and shapes
3. Do some more unrelated JIT optimizations
4. Remove the profiling nodes and extract the tensor info, and then use the JIT tensor info to do optimizations.

This PR is intended to fix a bug in Step 4, where the profiling nodes were removed. It was previously assumed that all the things that were profiled were either Tensors or Optional[Tensor]s - otherwise, step 2 would not have introduced a profiling node.

However, we saw a case where step 3 would remove replace Optional[Tensor] inputs with `None` inputs (e.g. if a conditional that returned a Tensor or a None could be statically known to only follow the `None` branch).

To fix this, we essentially just modify the RemoveProfileNodesAndSpecializeTypes assert so that it accepts Tensors, Optional[Tensor]s, or None (the new part).

Note that this issue is probably somewhat uncommon (maybe why we didn't see it for the first 4 years that this code existed). I expect that, typically, any time that step 3 would convert `Optional[Tensor] -> None`, step 1 would have already done that. So it's difficult to reproduce in an end-to-end TorchScript workload.

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel

Differential Revision: [D81068172](https://our.internmc.facebook.com/intern/diff/D81068172)