### PR TITLE
[dynamic shapes] remove _maybe_guard_rel warnings

### DIFF
--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -6846,11 +6846,8 @@ class ShapeEnv:
             for arg in expr.args:
                 self._maybe_guard_rel(arg)
             return
-        elif not isinstance(expr, sympy.Rel):
-            log.warning(
-                "_maybe_guard_rel() was called on non-relation expression %s", expr
-            )
-            return
+
+        assert isinstance(expr, sympy.Rel)
 
         # A good example of what goes wrong if you don't do this is
         # python test/functorch/test_aotdispatch.py -k
@@ -7639,7 +7636,8 @@ class ShapeEnv:
                 # implement this is to have maybe_guard_rel return a bool
                 # saying if it "subsumed" the guard (and therefore the guard
                 # is no longer necessary)
-                self._maybe_guard_rel(g)
+                if isinstance(g, (sympy.Rel, sympy.And)):
+                    self._maybe_guard_rel(g)
 
                 if not self.allow_complex_guards_as_runtime_asserts:
                     # at this point, we've evaluated the concrete expr value, and have
@@ -7754,7 +7752,8 @@ class ShapeEnv:
                 log.debug("runtime_asserts_frozen but then got %s", expr)
             self._check_frozen(expr, sympy.true)
             # eliminate symbols on equality tests / refine ranges
-            self._maybe_guard_rel(expr)
+            if isinstance(expr, (sympy.Rel, sympy.And)):
+                self._maybe_guard_rel(expr)
 
             # canonicalise to remove equations that are trivially equal
             orig_expr = expr


### PR DESCRIPTION
Fixes #161051

stops warnings arising from `torch._check(sym_or(...))` calls

The issue happens when:
- SDPA calls expand
- expand calls this check, signifying either expand or no-op semantics
https://github.com/pytorch/pytorch/blob/47ecd2042f2f99368cd2d60731d23f4437eecd1d/torch/_refs/__init__.py#L3051-L3052
- The `sym_or` is passed to `_maybe_guard_rel` to process any upper/lower bound implications for axioms we know are True
- `_maybe_guard_rel` was extended to handle `And` expressions as well as relations, so users could write `torch._check(sym_and(a >= 0, a <= N, ...))` easily. For other types, we raised this warning:
https://github.com/pytorch/pytorch/blob/47ecd2042f2f99368cd2d60731d23f4437eecd1d/torch/fx/experimental/symbolic_shapes.py#L6845-L6852

The change only applies `_maybe_guard_rel` to `And` and relation expressions, not calling it for the `sym_or` case

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv