### PR TITLE
fold to mm when row dimentions is small

### DIFF
--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -387,6 +387,10 @@ test_failures = {
     # Refinement means we don't actually generate dynamic shapes (but only on
     # cpu apparently?!)
     "test_nonzero_unbacked_refinement_dynamic_shapes": TestFailure(("cpu",)),
+    # For this test, we currently only fold without dynamic shapes
+    "test_folding_bmm_to_mm_dynamic_shapes": TestFailure(
+        ("cpu", "cuda", "xpu"), is_skip=True
+    ),
 }
 
 add_test_failures(test_failures, dynamic_shapes_test_failures)


### PR DESCRIPTION
Summary:
Fix https://github.com/pytorch/pytorch/issues/159346

When we have a matmul like [M, B, K].transpose(0, 1) x [K, N], we should fold when B is small, and M, K, N are large. This could happen when we use MultiheadAttention with batch_first=True.


Folding to mm can speed up`F.linear(x, weight, bias)` by a lot.

Some benchmark numbers (all without max-autotune). If we use max-autotune, I think it'll only give folding to mm more benefits, because bmm triton template is limited to int32 indexing, so we have to fall back to aten bmm when BSxMxNxK is large.

Float16:

| BS |  M   |   N   |   K   | time_fold | time_no_fold | speedup  |
|  4 | 512  | 8192  | 8192  |   1.274   |    41.216    | 32.3516  |
| 64 | 512  | 2048  | 2048  |   1.618   |    1.751     | 1.0822   |
|  4 | 1024 | 2048  | 2048  |   0.576   |    2.253     | 3.9115   |


Float32:

| BS |  M   |   N   |   K   | time_fold | time_no_fold | speedup  |
|  4 | 512  | 8192  | 2048  |   4.059   |    22.967    | 5.6583   |
| 64 | 512  | 2048  | 2048  |  15.763   |    29.486    | 1.8706   |
|  4 | 1024 | 2048  | 2048  |   2.272   |    9.124     | 4.0158   |

You can find more benchmarking results in https://docs.google.com/spreadsheets/d/1d79g3CCE9Tn59JaAbxiNVYfpRxNyVDbYeWGVurqOses/edit?gid=1040716098#gid=1040716098.

In this PR, I set the numbers to be quite conservative, i.e. we only fold to mm if we're sure we can get performance gain from folding. This is to prevent any perf regression. But I think we could be more aggressive in our folding decision based on the benchmarking result.

Another potential work is to enable folding when the batch size is a dynamic symbol. Currently, we only fold when all shape sizes are integers. This means it's hard to take advantage of this when shape size are symints.

```
        # shape_env = s.node.shape_env
        # if shape_env is None:
        #     return False
        # return shape_env.var_to_range[s.node.expr].issubset(ValueRanges(0, 32))
```

Finally, note that in this implementation, we avoid any copy by using transpose. However, this means that the stride of the output after decomposition could be different from the output of the original op.

Test Plan:
```
buck run mode/dev-nosan fbcode//caffe2/test/inductor:test_inductor_cuda -- -r  test_folding_bmm_to_mm
```

Rollback Plan:

Differential Revision: D80385541




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @mlazos