### PR TITLE
Add MTIA to floor_divide op

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2765,7 +2765,7 @@
   device_check: NoCheck   # TensorIterator
   variants: function, method
   dispatch:
-    CPU, CUDA, MPS: floor_divide
+    CPU, CUDA, MPS, MTIA: floor_divide
     SparseCPU, SparseCUDA: floor_divide_sparse
 
 - func: floor_divide_.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)


### PR DESCRIPTION
Summary: Missed file in op registration resulting in fallback during test

Reviewed By: andyanwang, srsuryadev

Differential Revision: D81085615




cc @egienvalue