### PR TITLE
Allow parallel start NUMA binding

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1221,9 +1221,6 @@ coverage_ignore_functions = [
     "reduce_typed_storage_child",
     "storage_from_cache",
     # torch.multiprocessing.spawn
-    # Added docstring for this but I think we need to go through
-    # and add the entire torch.multiprocessing.spawn module to a .rst...
-    "should_use_parallel_start",
     "start_processes",
     # torch.nn.functional
     "adaptive_max_pool1d_with_indices",  # documented as adaptive_max_pool1d

--- a/test/test_numa_binding.py
+++ b/test/test_numa_binding.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 import sys
 from dataclasses import dataclass
 from multiprocessing.context import SpawnProcess
@@ -459,31 +458,6 @@ class NumaBindingTest(TestCase):
             launch_config.numa_options,
             NumaOptions(affinity_mode=AffinityMode.EXCLUSIVE),
         )
-
-    def test_parallel_start_does_not_call_get_default_numa_options(self) -> None:
-        # Inner import to avoid crashing if not torch.distributed.is_available()
-        from torch.distributed.launcher.api import LaunchConfig
-
-        self._add_mock_hardware(
-            num_sockets=1,
-            num_numa_nodes_per_socket=1,
-            num_gpus_per_numa_node=2,
-            num_l3_caches_per_numa_node=1,
-            num_physical_core_per_l3_cache=1,
-        )
-
-        with patch(
-            "torch.distributed.launcher.api.get_default_numa_options"
-        ) as mock_get_default_numa_options:
-            os.environ["TORCH_MP_PARALLEL_START"] = "1"
-            launch_config = LaunchConfig(
-                min_nodes=1,
-                max_nodes=1,
-                nproc_per_node=2,
-                start_method="forkserver",
-            )
-            mock_get_default_numa_options.assert_not_called()
-            self.assertIsNone(launch_config.numa_options)
 
     def test_nproc_must_equal_cuda_device_count_to_use_default_numa_options(
         self,

--- a/torch/distributed/elastic/multiprocessing/subprocess_handler/subprocess_handler.py
+++ b/torch/distributed/elastic/multiprocessing/subprocess_handler/subprocess_handler.py
@@ -12,7 +12,7 @@ from subprocess import Popen
 from typing import Any, Optional
 
 from torch.numa.binding import (
-    maybe_temporarily_apply_numa_binding_to_current_process,
+    maybe_temporarily_apply_numa_binding_to_current_thread,
     NumaOptions,
 )
 
@@ -57,7 +57,7 @@ class SubprocessHandler:
         self.local_rank_id = local_rank_id
 
         # See HACK [NUMA inheritance] in spawn.py for context.
-        with maybe_temporarily_apply_numa_binding_to_current_process(
+        with maybe_temporarily_apply_numa_binding_to_current_thread(
             gpu_index=local_rank_id, numa_options=numa_options
         ):
             self.proc: Popen = self._popen(args_str, env_vars)

--- a/torch/distributed/launcher/api.py
+++ b/torch/distributed/launcher/api.py
@@ -26,7 +26,6 @@ from torch.distributed.elastic.multiprocessing.errors import ChildFailedError
 from torch.distributed.elastic.rendezvous import RendezvousParameters
 from torch.distributed.elastic.rendezvous.utils import parse_rendezvous_endpoint
 from torch.distributed.elastic.utils.logging import get_logger
-from torch.multiprocessing.spawn import should_use_parallel_start
 from torch.numa.binding import NumaOptions
 
 
@@ -110,11 +109,6 @@ class LaunchConfig:
 
         if (
             self.numa_options is None
-            # The way we apply NUMA bindings currently depends
-            # on the processes being started sequentially.
-            # Technically, this filter does not matter for str entrypoints,
-            # but we ignore that nuance for now.
-            and not should_use_parallel_start(self.start_method)
             and torch.cuda.is_available()
             # We assume local_rank n uses cuda device n.
             and torch.cuda.device_count() == self.nproc_per_node

--- a/torch/multiprocessing/spawn.py
+++ b/torch/multiprocessing/spawn.py
@@ -226,17 +226,6 @@ class SpawnContext(ProcessContext):
         super().__init__(processes, error_files)
 
 
-def should_use_parallel_start(start_method: str) -> bool:
-    """
-    Returns:
-        Whether we will start subprocesses in parallel.
-    """
-    return (
-        start_method == "forkserver"
-        and os.environ.get(ENV_VAR_PARALLEL_START, "0") == "1"
-    )
-
-
 # Note: [start_processes]
 # mp.start_processes handles both start_method='spawn' and 'fork'. It's supposed to be a
 # more generalized API than mp.spawn. Currently we only document mp.spawn as it's the
@@ -258,7 +247,10 @@ def start_processes(
     # this func will start processes in parallel if start_method is 'forkserver'.
     # Please opt in to this perf optimization by setting env var (TORCH_MP_PARALLEL_START) to 1.
     # todo: investigate why spawn does not work with threadpool and raises SIGINT
-    if should_use_parallel_start(start_method):
+    if (
+        start_method == "forkserver"
+        and os.environ.get(ENV_VAR_PARALLEL_START, "0") == "1"
+    ):
         log.info("Starting processes in parallel.")
         start_parallel = True
     else:

--- a/torch/multiprocessing/spawn.py
+++ b/torch/multiprocessing/spawn.py
@@ -29,7 +29,6 @@ __all__ = [
     "ProcessException",
     "ProcessExitedException",
     "ProcessRaisedException",
-    "should_use_parallel_start",
     "spawn",
     "SpawnContext",
     "start_processes",
@@ -265,9 +264,6 @@ def start_processes(
     else:
         # Set env var TORCH_MP_PARALLEL_START to 0 to disable parallel start
         start_parallel = False
-
-    if numa_options is not None and start_parallel:
-        raise ValueError("NUMA binding is not compatible with parallel start")
 
     mp = multiprocessing.get_context(start_method)
     error_files = [None] * nprocs

--- a/torch/multiprocessing/spawn.py
+++ b/torch/multiprocessing/spawn.py
@@ -13,7 +13,7 @@ from concurrent.futures import as_completed, ThreadPoolExecutor
 from typing import Optional
 
 from torch.numa.binding import (
-    maybe_temporarily_apply_numa_binding_to_current_process,
+    maybe_temporarily_apply_numa_binding_to_current_thread,
     NumaOptions,
 )
 
@@ -288,8 +288,8 @@ def start_processes(
             daemon=daemon,
         )
 
-        # HACK [NUMA inheritance]: Subprocesses inherit the parent process's CPU
-        # affinity. So, we temporarily apply the bindings to the current process,
+        # HACK [NUMA inheritance]: Subprocesses inherit the parent thread's CPU
+        # affinity. So, we temporarily apply the bindings to the current thread,
         # and then immediately undo them.
         # This is necessary because the alternatives would be to
         # either
@@ -301,7 +301,7 @@ def start_processes(
         # can result in worse memory locality, because torch and CUDA
         # initialization would occur before applying the bindings, thus
         # allowing some memory to be allocated on the wrong NUMA nodes.
-        with maybe_temporarily_apply_numa_binding_to_current_process(
+        with maybe_temporarily_apply_numa_binding_to_current_thread(
             gpu_index=i, numa_options=numa_options
         ):
             process.start()


### PR DESCRIPTION
# Context
In #161183, we added NUMA-binding support for `Callable` entrypoints to `elastic_launch`.

However, we would raise an exception if the subprocesses would be spawned in parallel via `ThreadPoolExecutor`, which is an option configurable via the `TORCH_MP_PARALLEL_START` environment variable (see diff).

The logic here was that `os.sched_setaffinity`, which we used to set CPU affinities, is [per process](https://docs.python.org/3/library/os.html#os.sched_setaffinity), so there could be a race condition during a parallel start:

> Restrict the process with PID pid (or the current process if zero) to a set of CPUs. mask is an iterable of integers representing the set of CPUs to which the process should be restricted.

But on further reading, the Linux docs say [`sched_setaffinity` is per *thread*.](https://man7.org/linux/man-pages/man2/sched_setaffinity.2.html) As it turns out, the Python doc is a misnomer.

I [verified that `sched_setaffinity` only affects the calling thread, not the entire calling process.](https://gist.github.com/pdesupinski/7e2de3cbe5bb48d489f257b83ccddf07)

The upshot is that we actually *can* safely use the inheritance trick from #161183 even with parallel start, since the setting will be inherited from the calling thread, and `os.sched_setaffinity` only affects the calling thread.

# This PR
Remove restrictions against parallel start for NUMA binding.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @Lucaskabela