### PR TITLE
[Optimus] Replace torch rms norm with quack rms norm kernel

### DIFF
--- a/test/inductor/test_kernel_optimization.py
+++ b/test/inductor/test_kernel_optimization.py
@@ -4,6 +4,7 @@ import torch
 import torch._inductor
 from torch._dynamo.utils import counters
 from torch._inductor.test_case import run_tests, TestCase
+from torch.testing._internal.common_device_type import skipIf
 from torch.testing._internal.common_utils import serialTest
 from torch.testing._internal.inductor_utils import GPU_TYPE, requires_gpu
 
@@ -26,6 +27,19 @@ class TestEinsumtoPointwise(torch.nn.Module):
         output2 = torch.functional.einsum("bni, bnio -> bno", input2, weights2)
         add2 = output2 + bias2
         return add1 + add2
+
+
+class TestRMSNorm(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+
+    def forward(
+        self,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+    ) -> torch.Tensor:
+        normalized_shape = [input.shape[-1]]
+        return torch.nn.functional.rms_norm(input, normalized_shape, weight=weight)
 
 
 class TestKernelOptimization(TestCase):
@@ -85,6 +99,41 @@ class TestKernelOptimization(TestCase):
         self.compare_gradients(module, traced)
         self.assertEqual(
             counters["inductor"]["einsum_to_pointwise_pass"],
+            1,
+        )
+        counters.clear()
+
+    @requires_gpu()
+    @skipIf(
+        torch.cuda.get_device_capability()[0] < 9,
+        "need at least B200 GPU",
+    )
+    @torch._inductor.config.patch(
+        pre_grad_fusion_options={
+            "use_custom_rmsnorm_kernel_pass": {"quack": True},
+        },
+        post_grad_fusion_options={},
+    )
+    def test_replace_rms_norm_with_quack(self):
+        counters.clear()
+        module = TestRMSNorm().to(GPU_TYPE)
+        dtype = torch.bfloat16
+        input = [
+            torch.randn(585936, 384, device=GPU_TYPE, requires_grad=True, dtype=dtype),
+            torch.randn(384, device=GPU_TYPE, requires_grad=True, dtype=dtype),
+        ]
+        traced = torch.compile(module)
+        ref = module(*input)
+        res = traced(*input)
+        # Create upstream gradients
+        dy = torch.randn_like(ref)
+        torch.autograd.grad(ref, input, grad_outputs=dy, retain_graph=True)
+        torch.autograd.grad(res, input, grad_outputs=dy, retain_graph=True)
+        self.compare_pred(module, traced, input, rtol=0.1, atol=0.1)
+        self.compare_parameters(module, traced, rtol=0.1, atol=0.1)
+        self.compare_gradients(module, traced, rtol=0.1, atol=0.1)
+        self.assertEqual(
+            counters["inductor"]["use_custom_rmsnorm_kernel_pass"],
             1,
         )
         counters.clear()

--- a/torch/_inductor/fx_passes/kernel_optimization.py
+++ b/torch/_inductor/fx_passes/kernel_optimization.py
@@ -1,0 +1,82 @@
+# mypy: allow-untyped-defs
+import logging
+from typing import Optional
+
+import torch
+from torch._dynamo.utils import counters, is_node_meta_valid
+
+from .. import config
+HAS_CUTLASS = True
+try:
+    from ..kernel.quack.quack_rmsnorm import rmsnorm as quack_rmsnorm
+except ImportError:
+    HAS_CUTLASS = False
+
+from ..pattern_matcher import (
+    CallFunctionVarArgs,
+    Match,
+    MULTIPLE,
+    register_graph_pattern,
+)
+from .split_cat import construct_pattern_matcher_pass
+
+
+log = logging.getLogger(__name__)
+
+
+def check_device(inputs: list[torch.Tensor], device="cuda") -> bool:
+    return all(input.device.type == device for input in inputs)
+
+
+def should_replace_norm(inputs: list[Optional[torch.fx.Node]]) -> bool:
+    inputs = [input for input in inputs if input is not None]
+
+    if not all(is_node_meta_valid(input) for input in inputs):
+        return False
+
+    return check_device([input.meta["example_value"] for input in inputs])
+
+
+def print_norm_pattern(match: Match, inputs: list[Optional[torch.fx.Node]]):
+    node = match.nodes[-1]
+    log.debug(
+        "replace layer_norm %s with input shape: %s",
+        node.target,
+        ", ".join(
+            str(input.meta["example_value"].shape) if input is not None else "None"
+            for input in inputs
+        ),
+    )
+
+
+@register_graph_pattern(
+    CallFunctionVarArgs([torch.nn.functional.rms_norm, torch.rms_norm], users=MULTIPLE),
+    pass_dict=construct_pattern_matcher_pass("use_custom_rmsnorm_kernel_pass"),
+)
+def rms_norm_replacement(
+    match: Match,
+    input: torch.fx.Node,
+    normalized_shape: list[int],
+    weight: Optional[torch.fx.Node] = None,
+    eps: Optional[float] = None,
+):
+    def repl(input, weight, eps):
+        if config.pre_grad_fusion_options["use_custom_rmsnorm_kernel_pass"].get(
+            "quack", False
+        ):
+            out, _ = quack_rmsnorm(input, weight, eps=eps)
+            return out
+
+    if weight is None:
+        # quack rmsnorm does not support weight is None
+        return False
+    
+    if not HAS_CUTLASS:
+        return False
+
+    if should_replace_norm([input, weight]):
+        counters["inductor"]["use_custom_rmsnorm_kernel_pass"] += 1
+        if eps is None:
+            eps = torch.finfo(input.meta["example_value"].dtype).eps
+        match.replace_by_example(repl, [input, weight, eps])
+        print_norm_pattern(match, [input, weight])

--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -160,6 +160,11 @@ def use_matmul_fuse_lce_replace_first_LCE(graph):
 def lazy_init():
     from . import efficient_conv_bn_eval, split_cat  # noqa: F401
 
+    try:
+        from . import kernel_optimization  # noqa: F401
+    except ImportError:
+        pass  # kernel_optimization requires CUTLASS, skip if not available
+
     if config.is_fbcode():
         from . import fb  # type: ignore[attr-defined]  # noqa: F401
 

--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -64,6 +64,7 @@ pre_grad_pass_names = [
     "unbind_stack_to_slices_pass",
     "move_reshape_out_of_split_stack_pass",
     "einsum_to_pointwise_pass",
+    "use_custom_rmsnorm_kernel_pass",
 ]
 
 post_grad_pass_names = [

--- a/torch/_inductor/kernel/quack/__init__.py
+++ b/torch/_inductor/kernel/quack/__init__.py
@@ -1,0 +1,3 @@
+__version__ = "0.1.7"
+
+from . import quack_rmsnorm

--- a/torch/_inductor/kernel/quack/quack_rmsnorm.py
+++ b/torch/_inductor/kernel/quack/quack_rmsnorm.py
@@ -1,0 +1,982 @@
+# Copyright (c) 2025, Wentao Guo, Ted Zadouri, Tri Dao.
+
+# pyre-ignore-all-errors
+from typing import Optional, Union
+
+HAS_CUTLASS = True
+
+try:
+    import cuda.bindings.driver as cuda
+    import cutlass
+    import cutlass.cute as cute
+    from cutlass import Float32, Int32
+    from cutlass.cute.runtime import from_dlpack
+except ImportError:
+    HAS_CUTLASS = False
+
+import torch
+
+if HAS_CUTLASS:
+    from torch._inductor.kernel.quack import utils
+
+    from .reduction_base import ReductionBase, torch2cute_dtype_map
+
+
+    # import from: https://github.com/Dao-AILab/quack/blob/main/quack/rmsnorm.py
+
+
+    class RMSNorm(ReductionBase):
+        """RMSNorm (Root Mean Square Layer Normalization) implementation using CUTLASS.
+        
+        This class implements the forward pass of RMSNorm, which normalizes the input
+        by the root mean square of the elements along the last dimension.
+        
+        Args:
+            dtype: The CUTLASS numeric type for computations
+            N: The size of the last dimension to normalize over
+        """
+        def __init__(self, dtype: cutlass.Numeric, N: int):
+            super().__init__(dtype, N, stage=1)
+            self.reload_from = None if N <= 16384 else "smem"
+            self.delay_w_load = False
+
+        def _calculate_threads_per_row(self) -> int:
+            """Calculate the number of threads per row for the RMSNorm kernel."""
+            N = self.N
+            if N <= 64:
+                return 8
+            elif N <= 128:
+                return 16
+            elif N <= 3072:
+                return 32
+            elif N <= 6144:
+                return 64
+            elif N <= 16384:
+                return 128
+            else:
+                return 256
+
+        def _set_cluster_n(self) -> None:
+            """
+            Set the number of clusters for the RMSNorm kernel.
+            Stored in self.cluster_n.
+            """
+            N = self.N
+
+            # cluster_n = 4 is faster and cluster_n = 2 for N=64k for some reason
+            # Similarly cluster_n = 8 is faster for N=128k
+            if cutlass.const_expr(self.dtype.width == 16):
+                # 16-bit types (fp16, bf16)
+                if N <= 16 * 1024:
+                    cluster_n = 1
+                elif N <= 32 * 1024:
+                    cluster_n = 2
+                elif N <= 64 * 1024:
+                    cluster_n = 4
+                elif N <= 128 * 1024:
+                    cluster_n = 8
+                else:
+                    cluster_n = 16
+            else:
+                # 32-bit types (fp32)
+                if N <= 32 * 1024:
+                    cluster_n = 1
+                elif N <= 64 * 1024:
+                    cluster_n = 2
+                elif N <= 128 * 1024:
+                    cluster_n = 4
+                elif N <= 256 * 1024:
+                    cluster_n = 8
+                else:
+                    cluster_n = 16
+
+            self.cluster_n = cluster_n
+
+        @cute.jit
+        def __call__(
+            self,
+            mX: cute.Tensor,
+            mW: cute.Tensor,
+            mO: cute.Tensor,
+            mRstd: Optional[cute.Tensor],
+            stream: cuda.CUstream,
+            eps: Float32 = 1e-6,
+        ) -> None:
+            semistatic_shape = (
+                *mX.shape[:-1],
+                self.N,
+            )  # Set last dimension to be statically N
+            def new_stride(t: cute.Tensor) -> tuple[Int32, Int32]:
+                return (
+                    cute.assume(t.stride[0], divby=128 // t.element_type.width),
+                    t.stride[1],
+                )
+            mX, mO = [
+                cute.make_tensor(
+                    t.iterator, cute.make_layout(semistatic_shape, stride=new_stride(t))
+                )
+                for t in (mX, mO)
+            ]
+            assert mX.element_type == self.dtype
+            assert mO.element_type == self.dtype
+            self._set_cluster_n()
+            tiler_mn, tv_layout = self._get_tv_layout()
+            num_threads = cute.size(tv_layout, mode=[0])
+            num_warps = num_threads // cute.arch.WARP_SIZE
+            mW_expanded_layout = cute.prepend(
+                mW.layout, cute.make_layout((tiler_mn[0],), stride=(0,))
+            )
+            mW = cute.make_tensor(mW.iterator, mW_expanded_layout)
+            if cutlass.const_expr(mRstd is not None):
+                mRstd_expanded_layout = cute.append(
+                    mRstd.layout, cute.make_layout((self.N,), stride=(0,))  # type: ignore[union-attr]
+                )
+                mRstd = cute.make_tensor(mRstd.iterator, mRstd_expanded_layout)  # type: ignore[union-attr]
+            self.kernel(
+                mX, mW, mO, mRstd, eps, tv_layout, tiler_mn, self.reload_from
+            ).launch(
+                grid=[cute.ceil_div(mX.shape[0], tiler_mn[0]), self.cluster_n, 1],
+                block=[num_threads, 1, 1],
+                cluster=(
+                    [1, self.cluster_n, 1]
+                    if cutlass.const_expr(self.cluster_n > 1)
+                    else None
+                ),
+                smem=self._smem_size_in_bytes(tiler_mn, num_warps),
+                stream=stream,
+            )
+
+        @cute.kernel
+        def kernel(
+            self,
+            mX: cute.Tensor,
+            mW: cute.Tensor,
+            mO: cute.Tensor,
+            mRstd: Optional[cute.Tensor],
+            eps: cute.Float32,
+            tv_layout: cute.Layout,
+            tiler_mn: cute.Shape,
+            reload_from: cutlass.Constexpr = None,
+            delay_w_load: cutlass.Constexpr = False,
+        ) -> None:
+            tidx, _, _ = cute.arch.thread_idx()
+            bidx, _, _ = cute.arch.block_idx()
+            if cutlass.const_expr(self.cluster_n > 1):
+                cluster_y = cute.arch.block_idx()[1]
+            else:
+                cluster_y = cutlass.const_expr(0)
+
+            smem = cutlass.utils.SmemAllocator()
+            sX = smem.allocate_tensor(
+                mX.element_type,
+                cute.make_ordered_layout(tiler_mn, order=(1, 0)),
+                byte_alignment=16,
+            )
+            reduction_buffer, mbar_ptr = self._allocate_reduction_buffer_and_mbar(
+                smem, tv_layout
+            )
+
+            shape = mX.shape
+            idX = cute.make_identity_tensor(shape)
+            # slice for CTAs
+            # We use domain_offset_i64 to deal with tensors larger than 2^31 elements
+            mX, mO = [
+                utils.domain_offset_i64((bidx * tiler_mn[0], 0), mT) for mT in (mX, mO)
+            ]
+            gX, gO = [cute.local_tile(mT, tiler_mn, (0, cluster_y)) for mT in (mX, mO)]
+            cX = cute.local_tile(idX, tiler_mn, (bidx, cluster_y))
+            gW = cute.local_tile(mW, tiler_mn, (0, cluster_y))
+            gRstd = (
+                cute.local_tile(mRstd, tiler_mn, (bidx, cluster_y))
+                if cutlass.const_expr(mRstd is not None)
+                else None
+            )
+
+            # declare the atoms which will be used later for memory copy
+            copy_atom_load_X = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(), mX.element_type, num_bits_per_copy=128
+            )
+            copy_atom_load_X_async = cute.make_copy_atom(
+                cute.nvgpu.cpasync.CopyG2SOp(), mX.element_type, num_bits_per_copy=128
+            )
+            num_bits_per_copy_W = cutlass.const_expr(
+                min(128, 128 // mX.element_type.width * mW.element_type.width)
+            )
+            copy_atom_load_W = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(),
+                mW.element_type,
+                num_bits_per_copy=num_bits_per_copy_W,
+            )
+            num_bits_per_copy_O = cutlass.const_expr(
+                min(128, 128 // mX.element_type.width * mO.element_type.width)
+            )
+            copy_atom_store_O = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(),
+                mO.element_type,
+                num_bits_per_copy=num_bits_per_copy_O,
+            )
+
+            thr_copy_X = cute.make_tiled_copy(
+                copy_atom_load_X_async, tv_layout, tiler_mn
+            ).get_slice(tidx)
+
+            tXgW = thr_copy_X.partition_S(gW)
+            tXgX = thr_copy_X.partition_S(gX)
+            tXsX = thr_copy_X.partition_D(sX)
+            tXgO = thr_copy_X.partition_D(gO)
+            tXrRstd = (
+                thr_copy_X.partition_D(gRstd)
+                if cutlass.const_expr(mRstd is not None)
+                else None
+            )
+            tXcX = thr_copy_X.partition_S(cX)[(0, None), None, None]
+
+            # allocate fragments for gmem->rmem
+            tXrW = cute.make_fragment_like(tXgW)
+            tXrW.fill(0.0)
+            tXrX, tXrO = [cute.make_fragment_like(thr) for thr in (tXgX, tXgO)]
+
+            num_warps = cute.size(tv_layout, mode=[0]) // cute.arch.WARP_SIZE
+            self._initialize_cluster(tidx, mbar_ptr, num_warps)
+
+            tXpX = utils.predicate_k(thr_copy_X.partition_S(cX), limit=shape[1])
+            row = tXcX[0][0]
+            if row < shape[0]:
+                cute.copy(copy_atom_load_X_async, tXgX, tXsX, pred=tXpX)
+            cute.arch.cp_async_commit_group()
+
+            tXpW = utils.predicate_k(thr_copy_X.partition_S(cX), limit=shape[1])
+            if cutlass.const_expr(not delay_w_load):
+                cute.copy(copy_atom_load_W, tXgW, tXrW, pred=tXpW)
+
+            cute.arch.cp_async_wait_group(0)
+            cute.autovec_copy(tXsX, tXrX)
+            x = tXrX.load().to(cute.Float32)
+            threads_per_row = tv_layout.shape[0][0]
+            sum_sq_x = utils.row_reduce(
+                x * x,
+                cute.ReductionOp.ADD,
+                threads_per_row,
+                reduction_buffer[None, None, 0],
+                mbar_ptr,
+                init_val=0.0,
+                hook_fn=(
+                    cute.arch.cluster_wait
+                    if cutlass.const_expr(self.cluster_n > 1)
+                    else None
+                ),
+            )
+            rstd = utils.rsqrt(sum_sq_x / shape[1] + eps)
+            if cutlass.const_expr(mRstd is not None):
+                # Only the thread corresponding to column 0 writes out the rstd to gmem
+                if (
+                    tXcX[0][1] == 0
+                    and row < shape[0]
+                    and (self.cluster_n == 1 or cute.arch.block_idx_in_cluster() == 0)
+                ):
+                    tXrRstd[0] = rstd  # type: ignore[index]
+            if cutlass.const_expr(delay_w_load):
+                cute.copy(copy_atom_load_W, tXgW, tXrW, pred=tXpW)
+            if cutlass.const_expr(reload_from == "smem"):
+                cute.autovec_copy(tXsX, tXrX)
+                x = tXrX.load().to(cute.Float32)
+            elif cutlass.const_expr(reload_from == "gmem"):
+                cute.copy(copy_atom_load_X, tXgX, tXrX, pred=tXpX)
+                x = tXrX.load().to(cute.Float32)
+            x_hat = x * rstd
+            w = tXrW.load().to(cute.Float32)
+            y = x_hat * w
+            tXrO.store(y.to(tXrO.element_type))
+            tXpO = utils.predicate_k(thr_copy_X.partition_S(cX), limit=shape[1])
+            if row < shape[0]:
+                cute.copy(copy_atom_store_O, tXrO, tXgO, pred=tXpO)
+
+
+    def _rmsnorm_fwd(
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        eps: float = 1e-6,
+        return_rstd: bool = False,
+    ) -> Union[tuple[torch.Tensor, Optional[torch.Tensor]], torch.Tensor]:
+        """RMSNorm forward pass.
+        Args:
+            x: Input tensor of shape (M, N)
+            weight: Weight tensor of shape (N,)
+            eps: Small value for numerical stability
+            return_rstd: Whether to return the reciprocal standard deviation
+        Returns:
+            Normalized output tensor of same shape as x
+            If return_rstd is True, also returns rstd tensor of shape (M,)
+        """
+        assert x.dim() == 2, "Input must be 2D"
+        assert weight.dim() == 1, "Weight must be 1D"
+        assert x.shape[-1] == weight.shape[0], (
+            "Last dimension of input must match weight dimension"
+        )
+        assert x.is_cuda and weight.is_cuda, "Tensors must be on CUDA device"
+        assert x.dtype in [
+            torch.float16,
+            torch.bfloat16,
+            torch.float32,
+        ], "Unsupported dtype"
+
+        assert weight.dtype in [
+            torch.float32,
+            torch.bfloat16,
+            torch.float16,
+        ], "Weight must be float32, float16 or bfloat16"
+
+        M, N = x.shape
+        device = x.device
+        out = torch.empty_like(x)
+        rstd = torch.empty(M, device=device, dtype=torch.float32) if return_rstd else None
+        dtype = torch2cute_dtype_map[x.dtype]
+
+        def convert_from_dlpack(x: torch.Tensor) -> cute.Tensor:
+            return from_dlpack(x.detach(), assumed_align=16).mark_layout_dynamic(leading_dim=1)
+        x_tensor, out_tensor = [convert_from_dlpack(t) for t in (x, out)]
+        # handle weight divisibility based on weight dtype
+        weight_dtype = torch2cute_dtype_map[weight.dtype]
+        weight_tensor = utils.convert_from_dlpack(
+            weight.detach(), leading_dim=0, divisibility=128 // weight_dtype.width
+        )
+        rstd_tensor = (
+            from_dlpack(rstd.detach(), assumed_align=4).mark_layout_dynamic(leading_dim=0)
+            if rstd is not None
+            else None
+        )
+        current_stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+        compile_key = (dtype, N, rstd is not None, weight.dtype)
+        if compile_key not in _rmsnorm_fwd.compile_cache:  # type: ignore[attr-defined]
+            rmsnorm_op = RMSNorm(dtype, N)
+            _rmsnorm_fwd.compile_cache[compile_key] = cute.compile(  # type: ignore[attr-defined]
+                rmsnorm_op, x_tensor, weight_tensor, out_tensor, rstd_tensor, current_stream
+            )
+        _rmsnorm_fwd.compile_cache[compile_key](  # type: ignore[attr-defined]
+            x_tensor, weight_tensor, out_tensor, rstd_tensor, current_stream, eps
+        )
+        return (out, rstd) if return_rstd else out
+
+
+    _rmsnorm_fwd.compile_cache = {} # type: ignore[attr-defined]
+
+
+    def rmsnorm_ref(x: torch.Tensor, w: torch.Tensor, eps: float=1e-6) -> torch.Tensor:
+        x_f32 = x.float()
+        return (
+            x_f32 / (torch.sqrt(torch.mean(x_f32.square(), dim=-1, keepdim=True) + eps)) * w
+        ).to(x.dtype)
+
+
+    def rstd_ref(x: torch.Tensor, eps: float=1e-6) -> torch.Tensor:
+        x_f32 = x.float()
+        return 1.0 / torch.sqrt(torch.mean(x_f32 * x_f32, dim=-1) + eps)
+
+
+    def rmsnorm_bwd_ref(
+        x: torch.Tensor, w: torch.Tensor, dout: torch.Tensor, rstd: torch.Tensor, eps:float=1e-6
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Reference implementation for RMSNorm backward pass."""
+        x_f32 = x.float()
+        x_hat = x_f32 * rstd.unsqueeze(1)
+        wdy = dout * w
+        c1 = (x_hat * wdy).mean(dim=-1, keepdim=True)
+        dx = (wdy - x_hat * c1) * rstd.unsqueeze(1)
+
+        # dL/dW
+        dw = (dout * x_hat).sum(dim=0)
+        return dx.to(x.dtype), dw.to(w.dtype)
+
+
+    class RMSNormBackward(ReductionBase):
+        """RMSNorm backward pass implementation using CUTLASS.
+        
+        This class implements the backward pass of RMSNorm, computing gradients
+        with respect to both the input and the weight parameters.
+        
+        Args:
+            dtype: The CUTLASS numeric type for computations
+            N: The size of the last dimension to normalize over
+        """
+        def __init__(self, dtype: cutlass.Numeric, N: int):
+            # 2 stages for double buffering when computing mean of x_hat * wdy
+            super().__init__(dtype, N, stage=2, reduction_dtype=Float32)
+            self.reload_wdy = None if N <= 16 * 1024 else "smem"
+            if self.N > 128 * 1024 and self.dtype.width >= 32:
+                # Not enough smem
+                raise ValueError(
+                    "RMSNormBackward does not support N > 128k with dtype >= 32 bits"
+                )
+
+        def _get_num_threads(self) -> int:
+            return 128 if self.N <= 4096 else 256
+
+        def _calculate_threads_per_row(self) -> int:
+            N = self.N
+            return (
+                8
+                if N <= 64
+                else (
+                    16
+                    if N <= 128
+                    else (
+                        32
+                        if N <= 256
+                        else (64 if N <= 512 else (128 if N <= 4096 else 256))
+                    )
+                )
+            )
+
+        def _set_cluster_n(self) -> None:
+            N = self.N
+            cluster_n = (
+                1
+                if N <= 8 * 1024
+                else (
+                    2
+                    if N <= 16 * 1024
+                    else (4 if N <= 32 * 1024 else (8 if N <= 64 * 1024 else 16))
+                )
+            )
+            self.cluster_n = cluster_n
+
+        def _smem_size_in_bytes(self, tiler_mn: int, num_warps: int) -> int:
+            return (
+                # Multiply by 2 since we need space for X and dOut,
+                # and multiply by another 2 due to double buffering
+                cute.size_in_bytes(self.dtype, cute.make_layout(tiler_mn)) * 2 * 2
+                + self.stage
+                * num_warps
+                * self.cluster_n
+                * (self.reduction_dtype.width // 8)
+                + self.stage
+                * (cutlass.Int64.width // 8)
+                * 2  # mult 2 as we need 2 mbar per stage
+            )
+
+        @cute.jit
+        def __call__(
+            self,
+            mX: cute.Tensor,
+            mW: cute.Tensor,
+            mdOut: cute.Tensor,
+            mRstd: cute.Tensor,
+            mdX: cute.Tensor,
+            mdW: cute.Tensor,
+            sm_count: Int32,
+            stream: cuda.CUstream,
+        ) -> None:
+            semistatic_shape = (
+                *mX.shape[:-1],
+                self.N,
+            )  # Set last dimension to be statically N
+            def new_stride(t: cute.Tensor) -> cute.Tensor:
+                return (
+                    cute.assume(t.stride[0], divby=128 // t.element_type.width),
+                    t.stride[1],
+                )
+            mX, mdOut, mdX = [
+                cute.make_tensor(
+                    t.iterator, cute.make_layout(semistatic_shape, stride=new_stride(t))
+                )
+                for t in (mX, mdOut, mdX)
+            ]
+            self._set_cluster_n()
+            tiler_mn, tv_layout = self._get_tv_layout()
+            num_threads = cute.size(tv_layout, mode=[0])
+            num_warps = num_threads // cute.arch.WARP_SIZE
+
+            mW_expanded_layout = cute.prepend(
+                mW.layout, cute.make_layout((tiler_mn[0],), stride=(0,))
+            )
+            mW = cute.make_tensor(mW.iterator, mW_expanded_layout)
+
+            num_blocks = sm_count
+            self.kernel(mX, mW, mdOut, mRstd, mdX, mdW, tv_layout, tiler_mn).launch(
+                grid=[num_blocks, self.cluster_n, 1],
+                block=[num_threads, 1, 1],
+                cluster=[1, self.cluster_n, 1] if self.cluster_n > 1 else None,
+                smem=self._smem_size_in_bytes(tiler_mn, num_warps),
+                stream=stream,
+            )
+
+        @cute.kernel
+        def kernel(
+            self,
+            mX: cute.Tensor,
+            mW: cute.Tensor,
+            mdOut: cute.Tensor,
+            mRstd: cute.Tensor,
+            mdX: cute.Tensor,
+            mdW: cute.Tensor,
+            tv_layout: cute.Layout,
+            tiler_mn: cute.Shape,
+        ) -> None:
+            tidx, _, _ = cute.arch.thread_idx()
+            bidx_start, _, _ = cute.arch.block_idx()
+            gdim, _, _ = cute.arch.grid_dim()
+            if cutlass.const_expr(self.cluster_n > 1):
+                cluster_y = cute.arch.block_idx()[1]
+            else:
+                cluster_y = cutlass.const_expr(0)
+
+            shape = mX.shape
+            M, _ = shape[0], shape[1]
+            is_even_N = cutlass.const_expr(shape[1] == tiler_mn[1] * self.cluster_n)
+
+            idX = cute.make_identity_tensor(shape)
+
+            smem = cutlass.utils.SmemAllocator()
+            smem_layout = cute.make_ordered_layout(
+                (tiler_mn[0], tiler_mn[1], 2), order=(1, 0, 2)
+            )
+            sX = smem.allocate_tensor(mX.element_type, smem_layout, byte_alignment=16)
+            sdOut = smem.allocate_tensor(mdOut.element_type, smem_layout, byte_alignment=16)
+            reduction_buffer, mbar_ptr = self._allocate_reduction_buffer_and_mbar(
+                smem, tv_layout, is_persistent=True
+            )
+            if cutlass.const_expr(mbar_ptr is not None):
+                mbar_full_ptr, mbar_empty_ptr = mbar_ptr, mbar_ptr + 2
+            else:
+                mbar_full_ptr, mbar_empty_ptr = None, None
+
+            copy_atom_load_X = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(), mX.element_type, num_bits_per_copy=128
+            )
+            copy_atom_load_X_async = cute.make_copy_atom(
+                cute.nvgpu.cpasync.CopyG2SOp(), mX.element_type, num_bits_per_copy=128
+            )
+            num_bits_per_copy_W = cutlass.const_expr(
+                min(128, 128 // mX.element_type.width * mW.element_type.width)
+            )
+            copy_atom_load_W = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(),
+                mW.element_type,
+                num_bits_per_copy=num_bits_per_copy_W,
+            )
+            num_bits_per_copy_dX = cutlass.const_expr(
+                min(128, 128 // mX.element_type.width * mdX.element_type.width)
+            )
+            copy_atom_store_dX = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(),
+                mdX.element_type,
+                num_bits_per_copy=num_bits_per_copy_dX,
+            )
+            num_bits_per_copy_dW = cutlass.const_expr(
+                min(128, 128 // mX.element_type.width * mdW.element_type.width)
+            )
+            copy_atom_store_dW = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(),
+                mdW.element_type,
+                num_bits_per_copy=num_bits_per_copy_dW,
+            )
+
+            thr_copy_X = cute.make_tiled_copy(
+                copy_atom_load_X, tv_layout, tiler_mn
+            ).get_slice(tidx)
+
+            gW = cute.local_tile(mW, tiler_mn, (0, cluster_y))
+            tXgW = thr_copy_X.partition_S(gW)
+            tXrW = cute.make_fragment_like(tXgW)
+            # Need this, otherwise rW can have arbitrary values that changes the reduction
+            if not is_even_N:
+                tXrW.fill(0.0)
+
+            gW_coord = cute.local_tile(idX, tiler_mn, (0, cluster_y))
+            tXpW = (
+                utils.predicate_k(thr_copy_X.partition_S(gW_coord), limit=shape[1])
+                if not is_even_N
+                else None
+            )
+            cute.copy(copy_atom_load_W, tXgW, tXrW, pred=tXpW)
+            weight = tXrW.load().to(cute.Float32)
+
+            num_warps = cute.size(tv_layout, mode=[0]) // cute.arch.WARP_SIZE
+
+            self._initialize_cluster(tidx, mbar_ptr, num_warps, is_persistent=True)
+
+            dw_coord = cute.local_tile(idX, tiler_mn, (0, cluster_y))
+            tXpdW = (
+                utils.predicate_k(thr_copy_X.partition_S(dw_coord), limit=shape[1])
+                if not is_even_N
+                else None
+            )
+
+            gdW = cute.local_tile(mdW, (1, tiler_mn[1]), (bidx_start, cluster_y))
+            tXgdW = thr_copy_X.partition_S(gdW)
+            # Always compute partial weight gradients in fp32
+            tXrdW = cute.make_fragment_like(tXgdW, Float32)
+
+            gX = cute.local_tile(mX, tiler_mn, (None, cluster_y))
+            gdOut = cute.local_tile(mdOut, tiler_mn, (None, cluster_y))
+            gdX = cute.local_tile(mdX, tiler_mn, (None, cluster_y))
+            cX = cute.local_tile(idX, tiler_mn, (None, cluster_y))
+            tXgX = thr_copy_X.partition_S(gX)
+            tXsX = thr_copy_X.partition_D(sX)
+            tXgdOut = thr_copy_X.partition_S(gdOut)
+            tXsdOut = thr_copy_X.partition_D(sdOut)
+            tXgdX = thr_copy_X.partition_D(gdX)
+            tXcX = thr_copy_X.partition_S(cX)[(0, None), None, None, None]
+            # This doesn't change across iterations
+            tXpX = (
+                utils.predicate_k(thr_copy_X.partition_S(cX[None, None, 0]), limit=shape[1])
+                if not is_even_N
+                else None
+            )
+
+            tXrX, tXrdOut, tXrdX = [
+                cute.make_fragment_like(thr[None, None, None, 0])
+                for thr in (tXgX, tXgdOut, tXgdX)
+            ]
+
+            # Prefetch the first batch
+            row = tXcX[None, None, None, bidx_start][0][0]
+            if row < M:
+                tXgX_cur = utils.coord_offset_i64(bidx_start, tXgX, dim=3)[
+                    None, None, None, 0
+                ]
+                tXgdOut_cur = utils.coord_offset_i64(bidx_start, tXgdOut, dim=3)[
+                    None, None, None, 0
+                ]
+                cute.copy(
+                    copy_atom_load_X_async,
+                    tXgX_cur,
+                    tXsX[None, None, None, 0],
+                    pred=tXpX,
+                )
+                cute.copy(
+                    copy_atom_load_X_async,
+                    tXgdOut_cur,
+                    tXsdOut[None, None, None, 0],
+                    pred=tXpX,
+                )
+            elif tiler_mn[0] > 1:
+                # Fill with zero, otherwise smem will be uninitialized, and we could read this back
+                # later into registers, causing wrong dW.
+                utils.fill_oob(
+                    tXsX[None, None, None, 0], None, fill_value=mX.element_type.zero
+                )
+                utils.fill_oob(
+                    tXsdOut[None, None, None, 0], None, fill_value=mdOut.element_type.zero
+                )
+            cute.arch.cp_async_commit_group()
+
+            if cutlass.const_expr(self.cluster_n > 1):
+                cute.arch.cluster_wait()
+
+            threads_per_row = tv_layout.shape[0][0]
+            tXrdW.fill(0.0)
+            stage = Int32(0)
+            producer_phase = Int32(1)
+            consumer_phase = Int32(0)
+            for bidx in cutlass.range(bidx_start, cute.ceil_div(M, tiler_mn[0]), gdim):
+                row = tXcX[None, None, None, bidx][0][0]
+                rstd = cutlass.Float.zero
+                if row + gdim * tiler_mn[0] < M:  # Prefetch the next batch
+                    tXgX_cur = utils.coord_offset_i64(bidx + gdim, tXgX, dim=3)[
+                        None, None, None, 0
+                    ]
+                    tXgdOut_cur = utils.coord_offset_i64(bidx + gdim, tXgdOut, dim=3)[
+                        None, None, None, 0
+                    ]
+                    cute.copy(
+                        copy_atom_load_X_async,
+                        tXgX_cur,
+                        tXsX[None, None, None, stage ^ 1],
+                        pred=tXpX,
+                    )
+                    cute.copy(
+                        copy_atom_load_X_async,
+                        tXgdOut_cur,
+                        tXsdOut[None, None, None, stage ^ 1],
+                        pred=tXpX,
+                    )
+                elif tiler_mn[0] > 1:
+                    utils.fill_oob(
+                        tXsX[None, None, None, stage ^ 1],
+                        None,
+                        fill_value=mX.element_type.zero,
+                    )
+                    utils.fill_oob(
+                        tXsdOut[None, None, None, stage ^ 1],
+                        None,
+                        fill_value=mdOut.element_type.zero,
+                    )
+                cute.arch.cp_async_commit_group()
+                if row < M or tiler_mn[0] == 1:
+                    rstd = mRstd[row]
+                cute.arch.cp_async_wait_group(1)
+                cute.autovec_copy(tXsX[None, None, None, stage], tXrX)
+                x = tXrX.load().to(cute.Float32)
+                cute.autovec_copy(tXsdOut[None, None, None, stage], tXrdOut)
+                dout = tXrdOut.load().to(cute.Float32)
+                x_hat = x * rstd
+                wdy = dout * weight
+                if cutlass.const_expr(self.cluster_n > 1):
+                    cute.arch.mbarrier_wait(mbar_empty_ptr + stage, producer_phase)
+                mean_xhat_wdy = (
+                    utils.row_reduce(
+                        x_hat * wdy,
+                        cute.ReductionOp.ADD,
+                        threads_per_row,
+                        reduction_buffer[None, None, stage],
+                        (
+                            mbar_full_ptr + stage
+                            if cutlass.const_expr(self.cluster_n > 1)
+                            else None
+                        ),
+                        phase=consumer_phase,
+                        init_val=0.0,
+                    )
+                    / shape[1]
+                )
+
+                if cutlass.const_expr(self.cluster_n > 1):
+                    # It's faster to have 1 lane per warp to signal the mbar, rather than all lanes
+                    # Requires adjusting the thread_count when initializing the mbar
+                    cute.arch.sync_warp()
+                    lane_idx = cute.arch.lane_idx()
+                    if lane_idx < self.cluster_n:
+                        cute.arch.mbarrier_arrive(
+                            mbar_empty_ptr + stage, peer_cta_rank_in_cluster=lane_idx
+                        )
+
+                if cutlass.const_expr(self.reload_wdy == "smem"):
+                    cute.autovec_copy(tXsdOut[None, None, None, stage], tXrdOut)
+                    dout = tXrdOut.load().to(cute.Float32)
+                    wdy = dout * weight
+
+                dx = (wdy - x_hat * mean_xhat_wdy) * rstd
+                tXrdX.store(dx.to(tXrdOut.element_type))
+                if row < M or tiler_mn[0] == 1:
+                    tXgdX_cur = utils.coord_offset_i64(bidx, tXgdX, dim=3)[
+                        None, None, None, 0
+                    ]
+                    cute.copy(copy_atom_store_dX, tXrdX, tXgdX_cur, pred=tXpX)
+                # Accumulate weight gradients in fp32
+                tXrdW.store(tXrdW.load() + dout * x_hat)
+
+                stage ^= 1
+                if stage == 0:
+                    consumer_phase ^= 1
+                    producer_phase ^= 1
+
+            if cutlass.const_expr(self.cluster_n > 1):  # Prevent cluster from exiting early
+                cute.arch.mbarrier_wait(mbar_empty_ptr + stage, producer_phase)
+
+            if cutlass.const_expr(tiler_mn[0] > 1):
+                # reduction of dw_partial within the same threadblock
+                sdW = cute.make_tensor(
+                    cute.recast_ptr(sX.iterator, dtype=cute.Float32),
+                    cute.make_ordered_layout(tiler_mn, order=(1, 0)),
+                )
+                tXsdW = thr_copy_X.partition_D(sdW)
+                cute.arch.barrier()
+                row = tXcX[None, None, None, 0][0][0]
+                if row > 0:
+                    cute.autovec_copy(tXrdW, tXsdW)
+                cute.arch.barrier()
+                if row == 0:
+                    for i in cutlass.range_constexpr(1, cutlass.const_expr(tiler_mn[0])):
+                        tXrdW_other = cute.make_fragment_like(tXrdW)
+                        tXsdW_other = cute.make_tensor(
+                            tXsdW.iterator + i * sdW.stride[0], tXsdW.layout
+                        )
+                        cute.autovec_copy(tXsdW_other, tXrdW_other)
+                        tXrdW.store(tXrdW.load() + tXrdW_other.load())
+                    cute.copy(copy_atom_store_dW, tXrdW, tXgdW, pred=tXpdW)
+            else:
+                # dw is already in fp32, so we can directly copy to global memory
+                cute.copy(copy_atom_store_dW, tXrdW, tXgdW, pred=tXpdW)
+
+
+    def _rmsnorm_backward(
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        dout: torch.Tensor,
+        rstd: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """RMSNorm backward pass.
+        Args:
+            x: Input tensor of shape (M, N)
+            weight: Weight tensor of shape (N,)
+            dout: Upstream gradients tensor of shape (M, N)
+            rstd: Reciprocal standard deviation tensor of shape (M,)
+        Returns:
+            Tuple of (dx, dw) where:
+            - dx: Input gradients tensor of same shape as x
+            - dw: Weight gradients tensor of same shape as weight
+        """
+        assert x.dim() == 2, "Input must be 2D"
+        assert weight.dim() == 1, "Weight must be 1D"
+        assert x.shape[-1] == weight.shape[0], (
+            "Last dimension of input must match weight dimension"
+        )
+        assert x.is_cuda and weight.is_cuda, "Tensors must be on CUDA device"
+        assert x.dtype in [
+            torch.float16,
+            torch.bfloat16,
+            torch.float32,
+        ], "Unsupported dtype"
+
+        assert weight.dtype in [
+            torch.float32,
+            torch.bfloat16,
+            torch.float16,
+        ], "Weight must be float32, float16 or bfloat16"
+
+        M, N = x.shape
+        dx = torch.empty_like(x)
+
+        device = x.device
+
+        # This should be tuned on how many CTAs can be launched on each SM
+        sm_count_multiple = (
+            16
+            if N <= 256
+            else (8 if N <= 1024 else (4 if N <= 2048 else (2 if N <= 4096 else 1)))
+        )
+        sm_count = torch.cuda.get_device_properties(device).multi_processor_count
+        # By right, if we're using cluster, this should be cluster_count not sm_count.
+        # But for cluster >= 4, due to quantization we would need to query active max cluster.
+        # Instead we just do sm_count * 2, which is reasonably larger than active_cluster_count to
+        # avoid wave quantization.
+        sm_count = (
+            sm_count * sm_count_multiple
+            if N <= 8192
+            else sm_count // 2
+            if N <= 16384
+            else sm_count * 2
+        )
+
+        # Always store partial gradients in fp32 for numerical accuracy
+        dw_partial = torch.empty(sm_count, N, device=device, dtype=torch.float32)
+
+        dtype = torch2cute_dtype_map[x.dtype]
+
+        def convert_from_dlpack(x: torch.Tensor) -> cute.Tensor:
+            return from_dlpack(x.detach(), assumed_align=16).mark_layout_dynamic(leading_dim=1)
+        x_tensor, dout_tensor, dx_tensor = [
+            convert_from_dlpack(tensor) for tensor in (x, dout, dx)
+        ]
+
+        # Handle weight div based on weight dtype
+        weight_dtype = torch2cute_dtype_map[weight.dtype]
+        weight_tensor = utils.convert_from_dlpack(
+            weight.detach(), leading_dim=0, divisibility=128 // weight_dtype.width
+        )
+
+        dw_partial_tensor = from_dlpack(
+            dw_partial, assumed_align=16
+        ).mark_compact_shape_dynamic(mode=0)
+        rstd_tensor = from_dlpack(rstd.detach(), assumed_align=4).mark_layout_dynamic(
+            leading_dim=0
+        )
+
+        current_stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+        compile_key = (dtype, N, weight.dtype)
+        if compile_key not in _rmsnorm_backward.compile_cache:
+            rmsnorm_backward_op = RMSNormBackward(dtype, N)
+            _rmsnorm_backward.compile_cache[compile_key] = cute.compile(
+                rmsnorm_backward_op,
+                x_tensor,
+                weight_tensor,
+                dout_tensor,
+                rstd_tensor,
+                dx_tensor,
+                dw_partial_tensor,
+                sm_count,
+                current_stream,
+            )
+
+        _rmsnorm_backward.compile_cache[compile_key](
+            x_tensor,
+            weight_tensor,
+            dout_tensor,
+            rstd_tensor,
+            dx_tensor,
+            dw_partial_tensor,
+            sm_count,
+            current_stream,
+        )
+        # we have summed the partial gradients in fp32, now we convert back to the weight dtype
+        dw = dw_partial.sum(dim=0).to(weight.dtype)
+        return dx, dw
+
+
+    _rmsnorm_backward.compile_cache = {}
+
+
+    class RMSNormFunction(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, x, weight, eps):
+            x_shape_start = x.shape
+
+            # Flatten input
+            x = x.view(-1, x.shape[-1])
+
+            out, rstd = _rmsnorm_fwd(x, weight, eps, return_rstd=True)
+            ctx.save_for_backward(x, weight, rstd)
+            ctx.eps = eps
+            ctx.x_shape_start = x_shape_start
+
+            return out.reshape(x_shape_start)
+
+        @staticmethod
+        def backward(ctx, dout):
+            x, weight, rstd = ctx.saved_tensors
+            x_shape_start = ctx.x_shape_start
+            # Reshape dout to match the flattened shape used in forward
+            dout = dout.view(-1, dout.shape[-1])
+            dx, dw = _rmsnorm_backward(x, weight, dout, rstd)
+            dx = dx.view(x_shape_start)
+            # dx is returned for input gradient,
+            # dw is returned for weight gradient,
+            # None for eps gradient
+            return dx, dw, None
+
+
+    @torch.library.custom_op("ads_mkl::quack_rmsnorm", mutates_args=())
+    def rmsnorm(
+        x: torch.Tensor, weight: torch.Tensor, eps: float
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return _rmsnorm_fwd(x, weight, eps, return_rstd=True)
+
+
+    @rmsnorm.register_fake
+    def _(x: torch.Tensor, weight: torch.Tensor, eps: float=1e-5) -> tuple[torch.Tensor, torch.Tensor]:
+        rms = torch.sqrt(eps + torch.sum(x * x, dim=1) / x.shape[1])
+        rstd = 1 / rms
+        return (x * rstd[:, None] * weight[None, :]).to(torch.bfloat16), rstd
+
+
+    @torch.library.custom_op("ads_mkl::quack_rmsnorm_backward", mutates_args=())
+    def wrapped_rmsnorm_backward(
+        x: torch.Tensor, weight: torch.Tensor, dout: torch.Tensor, rstd: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return _rmsnorm_backward(x, weight, dout, rstd)
+
+
+    @wrapped_rmsnorm_backward.register_fake
+    def _(
+        x: torch.Tensor, weight: torch.Tensor, dout: torch.Tensor, rstd: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return dout.clone().detach(), weight.clone().detach()
+
+
+    def rmsnorm_backward(ctx, dout, _) -> tuple[torch.Tensor, torch.Tensor, None]:
+        x, weight, rstd = ctx.saved_tensors
+        dx, dw = wrapped_rmsnorm_backward(x, weight, dout, rstd)
+        # dw is returned for weight gradient, None for eps gradient
+        return dx, dw, None
+
+
+    def setup_context(ctx, inputs, output) -> None:
+        x, weight, eps = inputs
+        out, rstd = output
+        ctx.save_for_backward(x, weight, rstd)
+        ctx.eps = eps
+
+
+    rmsnorm.register_autograd(rmsnorm_backward, setup_context=setup_context)

--- a/torch/_inductor/kernel/quack/reduction_base.py
+++ b/torch/_inductor/kernel/quack/reduction_base.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2025, Wentao Guo, Ted Zadouri, Tri Dao.
+
+# pyre-ignore-all-errors
+from typing import Optional
+
+import cutlass
+import cutlass.cute as cute
+
+import torch
+
+
+# import from https://github.com/Dao-AILab/quack/blob/main/quack/reduction_base.py
+
+torch2cute_dtype_map = {
+    torch.float16: cutlass.Float16,
+    torch.bfloat16: cutlass.BFloat16,
+    torch.float32: cutlass.Float32,
+}
+
+
+class ReductionBase:
+    """Base class for reduction operations using CUTLASS.
+    
+    This class provides common functionality for implementing reduction kernels
+    such as RMSNorm, LayerNorm, and other normalization operations. It handles
+    thread layout calculations, shared memory management, cluster synchronization,
+    and provides a framework for multi-stage reductions.
+    
+    Args:
+        dtype: The CUTLASS numeric type for input/output data
+        N: The size of the reduction dimension
+        stage: Number of stages for multi-buffering (typically 1 or 2)
+        reduction_dtype: The numeric type used for reduction computations (default: Float32)
+    """
+    def __init__(
+        self,
+        dtype: type[cutlass.Numeric],
+        N: int,
+        stage: int,
+        reduction_dtype=cutlass.Float32,
+    ):
+        self.dtype = dtype
+        self.N = N
+        self.stage = stage
+        self.reduction_dtype = reduction_dtype
+
+    def _calculate_threads_per_row(self):
+        raise NotImplementedError
+
+    def _set_cluster_n(self):
+        self.cluster_n = 1
+
+    def _get_num_threads(self):
+        return 128 if self.N <= 16384 else 256
+
+    def _get_tv_layout(self):
+        copy_bits = 128
+        vecsize = copy_bits // self.dtype.width
+        assert self.N % vecsize == 0, (
+            f"Input N {self.N} is not divisible by vector size {vecsize}"
+        )
+        num_threads = self._get_num_threads()
+        assert num_threads % cute.arch.WARP_SIZE == 0
+
+        threads_per_row = self._calculate_threads_per_row()
+        num_blocks_N = cute.ceil_div(
+            self.N // vecsize, threads_per_row * self.cluster_n
+        )
+        cols_per_block = num_threads // threads_per_row
+        tiler_mn = (cols_per_block, vecsize * num_blocks_N * threads_per_row)
+        tv_layout = cute.make_layout(
+            ((threads_per_row, cols_per_block), (vecsize, num_blocks_N)),
+            stride=(
+                (vecsize * cols_per_block, 1),
+                (cols_per_block, cols_per_block * vecsize * threads_per_row),
+            ),
+        )
+        return tiler_mn, tv_layout
+
+    def _smem_size_in_bytes(self, tiler_mn, num_warps):
+        return (
+            cute.size_in_bytes(self.dtype, cute.make_layout(tiler_mn))
+            + self.stage
+            * num_warps
+            * self.cluster_n
+            * (self.reduction_dtype.width // 8)
+            + self.stage * (cutlass.Int64.width // 8)
+        )
+
+    def _get_reduction_buffer_layout(self, tv_layout: cute.Layout, cluster_n: int):
+        num_warps = cute.size(tv_layout, mode=[0]) // cute.arch.WARP_SIZE
+        warps_per_row = max(tv_layout.shape[0][0] // cute.arch.WARP_SIZE, 1)
+        return cute.make_ordered_layout(
+            (num_warps // warps_per_row, (warps_per_row, cluster_n), self.stage),
+            order=(1, 0, 2),
+        )
+
+    def _allocate_reduction_buffer_and_mbar(
+        self,
+        smem: cutlass.utils.SmemAllocator,
+        tv_layout: cute.Layout,
+        is_persistent: bool = False,
+    ) -> tuple[cute.Tensor, Optional[cute.Pointer]]:
+        reduction_buffer = smem.allocate_tensor(
+            self.reduction_dtype,
+            self._get_reduction_buffer_layout(tv_layout, self.cluster_n),
+            byte_alignment=4,
+        )
+        if cutlass.const_expr(self.cluster_n > 1):
+            mbar_ptr = smem.allocate_array(
+                cutlass.Int64,
+                num_elems=self.stage if not is_persistent else self.stage * 2,
+            )
+        else:
+            mbar_ptr = None
+        return reduction_buffer, mbar_ptr
+
+    @cute.jit
+    def _initialize_cluster(
+        self,
+        tidx: cutlass.Int32,
+        mbar_ptr: cute.Pointer,
+        num_warps: int,
+        is_persistent: bool = False,
+    ):
+        if cutlass.const_expr(self.cluster_n > 1):
+            if tidx < self.stage:  # Initialize full barrier
+                cute.arch.mbarrier_init(mbar_ptr + tidx, 1)
+                if cutlass.const_expr(is_persistent):  # Initialize empty barrier
+                    cute.arch.mbarrier_init(
+                        mbar_ptr + self.stage + tidx, num_warps * self.cluster_n
+                    )
+            cute.arch.mbarrier_init_fence()
+            # Cluster arrive after barrier init
+            cute.arch.cluster_arrive_relaxed()

--- a/torch/_inductor/kernel/quack/utils.py
+++ b/torch/_inductor/kernel/quack/utils.py
@@ -1,0 +1,721 @@
+# Copyright (c) 2025, Wentao Guo, Ted Zadouri, Tri Dao.
+
+# pyre-ignore-all-errors
+import math
+import operator
+from typing import Callable, Optional, Union
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Float32, Int32
+from cutlass._mlir.dialects import llvm, nvvm, vector
+from cutlass.cute.runtime import from_dlpack
+from cutlass.cutlass_dsl import dsl_user_op, T
+
+
+# import from https://github.com/Dao-AILab/quack/blob/main/quack/utils.py
+def convert_from_dlpack(x, leading_dim, alignment=16, divisibility=1) -> cute.Tensor:
+    return (
+        from_dlpack(x, assumed_align=alignment)
+        .mark_layout_dynamic(leading_dim=leading_dim)
+        .mark_compact_shape_dynamic(
+            mode=leading_dim, stride_order=x.dim_order(), divisibility=divisibility
+        )
+    )
+
+
+@cute.jit
+def warp_reduce(
+    val: cute.TensorSSA | cute.Numeric,
+    op: Callable,
+    width: cutlass.Constexpr[int] = cute.arch.WARP_SIZE,
+) -> cute.TensorSSA | cute.Numeric:
+    if cutlass.const_expr(isinstance(val, cute.TensorSSA)):
+        res = cute.make_fragment(val.shape, val.dtype)
+        res.store(val)
+        for i in cutlass.range_constexpr(cute.size(val.shape)):
+            res[i] = warp_reduce(res[i], op, width)
+        return res.load()
+    else:
+        for i in cutlass.range_constexpr(int(math.log2(width))):
+            val = op(val, cute.arch.shuffle_sync_bfly(val, offset=1 << i))
+    return val
+
+
+@cute.jit
+def block_reduce(
+    val: cute.Numeric,
+    op: Callable,
+    reduction_buffer: cute.Tensor,
+    init_val: cute.Numeric = 0.0,
+) -> cute.Numeric:
+    """reduction_buffer has shape (num_warps / warp_per_row, warps_per_row)"""
+    lane_idx, warp_idx = cute.arch.lane_idx(), cute.arch.warp_idx()
+    warps_per_row = cute.size(reduction_buffer.shape[1])
+    row_idx, col_idx = warp_idx // warps_per_row, warp_idx % warps_per_row
+    if lane_idx == 0:
+        reduction_buffer[row_idx, col_idx] = val
+    cute.arch.barrier()
+    block_reduce_val = init_val
+    if lane_idx < warps_per_row:
+        block_reduce_val = reduction_buffer[row_idx, lane_idx]
+    return warp_reduce(block_reduce_val, op)
+
+
+@dsl_user_op
+def elem_pointer(
+    x: cute.Tensor, coord: cute.Coord, *, loc=None, ip=None
+) -> cute.Pointer:
+    return x.iterator + cute.crd2idx(coord, x.layout, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def set_block_rank(
+    smem_ptr: cute.Pointer, peer_cta_rank_in_cluster: cute.Int32, *, loc=None, ip=None
+) -> cutlass.Int32:
+    """Map the given smem pointer to the address at another CTA rank in the cluster."""
+    smem_ptr_i32 = smem_ptr.toint(loc=loc, ip=ip).ir_value()
+    return cutlass.Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [smem_ptr_i32, peer_cta_rank_in_cluster.ir_value()],
+            "mapa.shared::cluster.u32 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def store_shared_remote(
+    val: float | Float32 | cutlass.Int64,
+    smem_ptr: cute.Pointer,
+    mbar_ptr: cute.Pointer,
+    peer_cta_rank_in_cluster: cute.typing.Int,
+    *,
+    loc=None,
+    ip=None,
+) -> None:
+    remote_smem_ptr_i32 = set_block_rank(
+        smem_ptr, peer_cta_rank_in_cluster, loc=loc, ip=ip
+    ).ir_value()
+    remote_mbar_ptr_i32 = set_block_rank(
+        mbar_ptr, peer_cta_rank_in_cluster, loc=loc, ip=ip
+    ).ir_value()
+    if cutlass.const_expr(isinstance(val, float)):
+        val = Float32(val)
+    assert isinstance(val, (Float32, cutlass.Int64)), "val must be Float32 or Int64"
+    suffix = "f32" if cutlass.const_expr(isinstance(val, Float32)) else "s64"
+    llvm.inline_asm(
+        None,
+        [remote_smem_ptr_i32, val.ir_value(loc=loc, ip=ip), remote_mbar_ptr_i32],
+        f"st.async.shared::cluster.mbarrier::complete_tx::bytes.{suffix} [$0], $1, [$2];",
+        f"r,{'f' if cutlass.const_expr(isinstance(val, Float32)) else 'l'},r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@cute.jit
+def cluster_reduce(
+    val: cute.Numeric,
+    op: Callable,
+    reduction_buffer: cute.Tensor,
+    mbar_ptr: cute.Pointer,
+    init_val: cute.Numeric = 0.0,
+    phase: Optional[cutlass.Int32] = None,
+) -> cute.Numeric:
+    """reduction_buffer has shape (num_warps / warps_per_row, (warps_per_row, cluster_n))"""
+    cta_rank_in_cluster = cute.arch.block_idx_in_cluster()
+    lane_idx, warp_idx = cute.arch.lane_idx(), cute.arch.warp_idx()
+    rows_per_block, (warps_per_row, cluster_n) = reduction_buffer.shape
+    row_idx, col_idx = warp_idx // warps_per_row, warp_idx % warps_per_row
+    if warp_idx == 0:
+        with cute.arch.elect_one():
+            num_warps = rows_per_block * warps_per_row
+            cute.arch.mbarrier_arrive_and_expect_tx(
+                mbar_ptr,
+                num_warps * cluster_n * reduction_buffer.element_type.width // 8,
+            )
+    if lane_idx < cluster_n:
+        store_shared_remote(
+            val,
+            elem_pointer(reduction_buffer, (row_idx, (col_idx, cta_rank_in_cluster))),
+            mbar_ptr,
+            peer_cta_rank_in_cluster=lane_idx,
+        )
+    cute.arch.mbarrier_wait(mbar_ptr, phase=phase if phase is not None else 0)
+    block_reduce_val = init_val
+    num_iter = cute.ceil_div(warps_per_row * cluster_n, cute.arch.WARP_SIZE)
+    for i in cutlass.range_constexpr(num_iter):
+        idx = lane_idx + i * cute.arch.WARP_SIZE
+        if idx < cute.size(reduction_buffer, mode=[1]):
+            block_reduce_val = op(block_reduce_val, reduction_buffer[row_idx, idx])
+    return warp_reduce(block_reduce_val, op)
+
+
+@cute.jit
+def block_or_cluster_reduce(
+    val: cute.Numeric,
+    op: Callable,
+    reduction_buffer: cute.Tensor,
+    mbar_ptr: Optional[cute.Pointer],
+    phase: Optional[cutlass.Int32] = None,
+    init_val: cute.Numeric = 0.0,
+) -> cute.Numeric:
+    """Perform either block or cluster reduction based on whether mbar_ptr is provided."""
+    if cutlass.const_expr(mbar_ptr is None):
+        return block_reduce(val, op, reduction_buffer, init_val=init_val)
+    else:
+        return cluster_reduce(
+            val, op, reduction_buffer, mbar_ptr, phase=phase, init_val=init_val
+        )
+
+
+@cute.jit
+def row_reduce(
+    x: cute.TensorSSA | cute.Numeric,
+    op: cute.ReductionOp,
+    threads_per_row: cutlass.Constexpr[int],
+    reduction_buffer: Optional[cute.Tensor] = None,
+    mbar_ptr: Optional[cute.Pointer] = None,
+    phase: Optional[cutlass.Int32] = None,
+    init_val: cute.Numeric = 0.0,
+    hook_fn: Optional[Callable] = None,
+) -> cute.Numeric:
+    """reduction_buffer must have shape (num_warps / warps_per_row, (warps_per_row, cluster_n))"""
+    if cutlass.const_expr(isinstance(x, cute.TensorSSA)):
+        val = x.reduce(op, init_val=init_val, reduction_profile=0)
+    else:
+        val = x
+    warp_op = {
+        cute.ReductionOp.ADD: operator.add,
+        cute.ReductionOp.MAX: cute.arch.fmax
+        if cutlass.const_expr(x.dtype == Float32)
+        else max,
+        cute.ReductionOp.MIN: min,
+        cute.ReductionOp.MUL: operator.mul,
+    }[op]
+    val = warp_reduce(
+        val,
+        warp_op,
+        width=min(threads_per_row, cute.arch.WARP_SIZE),
+    )
+    if cutlass.const_expr(hook_fn is not None):
+        hook_fn()
+    if cutlass.const_expr(reduction_buffer is not None):
+        warps_per_row, cluster_n = reduction_buffer.shape[1]
+        assert cluster_n == 1 or mbar_ptr is not None, (
+            "mbar_ptr must be provided for cluster reduction"
+        )
+        if cutlass.const_expr(warps_per_row > 1 or cluster_n > 1):
+            val = block_or_cluster_reduce(
+                val, warp_op, reduction_buffer, mbar_ptr, phase=phase, init_val=init_val
+            )
+    return val
+
+
+@cute.jit
+def online_softmax_reduce(
+    x: cute.TensorSSA,
+    threads_per_row: cutlass.Constexpr[int],
+    reduction_buffer: Optional[cute.Tensor] = None,
+    mbar_ptr: Optional[cute.Pointer] = None,
+    hook_fn: Optional[Callable] = None,
+    phase: Optional[cutlass.Int32] = None,
+    return_exp_x: bool = False,
+) -> [Float32, Float32, Optional[cute.TensorSSA]]:
+    """Online softmax reduction implementation using CUTLASS.
+    
+    Performs numerically stable softmax reduction by computing max and sum of exponentials
+    in a single pass, supporting both block-level and cluster-level reductions.
+    
+    Args:
+        x: Input tensor of type Float32
+        threads_per_row: Number of threads per row for reduction
+        reduction_buffer: Optional buffer for multi-warp/cluster reductions.
+                         Must have shape (num_warps / warps_per_row, (warps_per_row, cluster_n), 2)
+        mbar_ptr: Optional memory barrier pointer for cluster synchronization
+        hook_fn: Optional hook function to call during reduction
+        phase: Optional phase for memory barrier synchronization
+        return_exp_x: Whether to return the exponential values
+        
+    Returns:
+        Tuple of (max_x, sum_exp_x, exp_x) where:
+        - max_x: Maximum value across the reduction
+        - sum_exp_x: Sum of exponentials
+        - exp_x: Exponential values (only if return_exp_x is True, otherwise None)
+    """
+    assert x.dtype == Float32, "x must be of type Float32"
+    max_x = warp_reduce(
+        x.reduce(cute.ReductionOp.MAX, init_val=-Float32.inf, reduction_profile=0),
+        cute.arch.fmax,
+        width=min(threads_per_row, cute.arch.WARP_SIZE),
+    )
+    log2_e = math.log2(math.e)
+    exp_x = exp2f(x * log2_e - (max_x * log2_e))
+    # exp_x = exp2f((x - max_x) * log2_e)
+    sum_exp_x = warp_reduce(
+        exp_x.reduce(cute.ReductionOp.ADD, init_val=0.0, reduction_profile=0),
+        operator.add,
+        width=min(threads_per_row, cute.arch.WARP_SIZE),
+    )
+    if cutlass.const_expr(hook_fn is not None):
+        hook_fn()
+    if cutlass.const_expr(reduction_buffer is not None):
+        rows_per_block, (warps_per_row, cluster_n) = reduction_buffer.shape
+        assert cluster_n == 1 or mbar_ptr is not None, (
+            "mbar_ptr must be provided for cluster reduction"
+        )
+        if cutlass.const_expr(warps_per_row > 1 or cluster_n > 1):
+            assert reduction_buffer.element_type == cutlass.Int64, (
+                "reduction_buffer must be of type cute.Int64"
+            )
+            lane_idx, warp_idx = cute.arch.lane_idx(), cute.arch.warp_idx()
+            row_idx, col_idx = warp_idx // warps_per_row, warp_idx % warps_per_row
+            if cutlass.const_expr(mbar_ptr is None):
+                if lane_idx == 0:
+                    reduction_buffer[row_idx, col_idx] = f32x2_to_i64(max_x, sum_exp_x)
+                cute.arch.barrier()
+                max_x_single_warp = -Float32.inf
+                sum_exp_x = 0.0
+                if lane_idx < warps_per_row:
+                    max_x_single_warp, sum_exp_x = i64_to_f32x2(
+                        reduction_buffer[row_idx, lane_idx]
+                    )
+                max_x_final = warp_reduce(max_x_single_warp, cute.arch.fmax)
+                sum_exp_x *= exp2f((max_x_single_warp - max_x_final) * log2_e)
+                sum_exp_x = warp_reduce(sum_exp_x, operator.add)
+                if cutlass.const_expr(return_exp_x):
+                    exp_x *= exp2f((max_x - max_x_final) * log2_e)
+                max_x = max_x_final
+            else:
+                cta_rank_in_cluster = cute.arch.block_idx_in_cluster()
+                if warp_idx == 0:
+                    with cute.arch.elect_one():
+                        num_warps = rows_per_block * warps_per_row
+                        cute.arch.mbarrier_arrive_and_expect_tx(
+                            mbar_ptr,
+                            num_warps
+                            * cluster_n
+                            * reduction_buffer.element_type.width
+                            // 8,
+                        )
+                if lane_idx < cluster_n:
+                    store_shared_remote(
+                        f32x2_to_i64(max_x, sum_exp_x),
+                        elem_pointer(
+                            reduction_buffer, (row_idx, (col_idx, cta_rank_in_cluster))
+                        ),
+                        mbar_ptr,
+                        peer_cta_rank_in_cluster=lane_idx,
+                    )
+                cute.arch.mbarrier_wait(
+                    mbar_ptr, phase=phase if phase is not None else 0
+                )
+                num_iter = cute.ceil_div(warps_per_row * cluster_n, cute.arch.WARP_SIZE)
+                max_x_single_warp = cute.make_fragment(num_iter, Float32)
+                max_x_single_warp.fill(-Float32.inf)
+                sum_exp_x_single_warp = cute.make_fragment(num_iter, Float32)
+                sum_exp_x_single_warp.fill(0.0)
+                for i in cutlass.range_constexpr(num_iter):
+                    idx = lane_idx + i * cute.arch.WARP_SIZE
+                    if idx < cute.size(reduction_buffer, mode=[1]):
+                        max_x_single_warp[i], sum_exp_x_single_warp[i] = i64_to_f32x2(
+                            reduction_buffer[row_idx, idx]
+                        )
+                max_x_final = max_x_single_warp.load().reduce(
+                    cute.ReductionOp.MAX, init_val=-Float32.inf, reduction_profile=0
+                )
+                max_x_final = warp_reduce(max_x_final, cute.arch.fmax)
+                sum_exp_x = 0.0
+                for i in cutlass.range_constexpr(num_iter):
+                    sum_exp_x += sum_exp_x_single_warp[i] * exp2f(
+                        (max_x_single_warp[i] - max_x_final) * log2_e
+                    )
+                sum_exp_x = warp_reduce(sum_exp_x, operator.add)
+                if cutlass.const_expr(return_exp_x):
+                    exp_x *= exp2f((max_x - max_x_final) * log2_e)
+                max_x = max_x_final
+    return max_x, sum_exp_x, (exp_x if cutlass.const_expr(return_exp_x) else None)
+
+
+@dsl_user_op
+def fmin(
+    a: Union[float, Float32], b: Union[float, Float32], *, loc=None, ip=None
+) -> Float32:
+    return Float32(
+        nvvm.fmin(
+            T.f32(),
+            Float32(a).ir_value(loc=loc, ip=ip),
+            Float32(b).ir_value(loc=loc, ip=ip),
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@cute.jit
+def exp2f(x: cute.TensorSSA | Float32) -> cute.TensorSSA | Float32:
+    """exp2f calculation for both vector and scalar.
+    :param x: input value
+    :type x: cute.TensorSSA or Float32
+    :return: exp2 value
+    :rtype: cute.TensorSSA or Float32
+    """
+    if cutlass.const_expr(isinstance(x, cute.TensorSSA)):
+        res = cute.make_fragment(x.shape, Float32)
+        res.store(x)
+        for i in cutlass.range(cute.size(x.shape), unroll_full=True):
+            res[i] = cute.arch.exp2(res[i])
+        return res.load()
+    else:
+        return cute.arch.exp2(x)
+
+
+@dsl_user_op
+def log2f(a: float | Float32, *, loc=None, ip=None) -> Float32:
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Float32(a).ir_value(loc=loc, ip=ip)],
+            "lg2.approx.ftz.f32 $0, $1;",
+            "=f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def sqrt(a: float | Float32, *, loc=None, ip=None) -> Float32:
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Float32(a).ir_value(loc=loc, ip=ip)],
+            "sqrt.approx.ftz.f32 $0, $1;",
+            "=f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def rsqrt(a: float | Float32, *, loc=None, ip=None) -> Float32:
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Float32(a).ir_value(loc=loc, ip=ip)],
+            "rsqrt.approx.ftz.f32 $0, $1;",
+            "=f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def tanh(a: float | Float32, *, loc=None, ip=None) -> Float32:
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Float32(a).ir_value(loc=loc, ip=ip)],
+            "tanh.approx.f32 $0, $1;",
+            "=f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def ceil(a: float | Float32, *, loc=None, ip=None) -> Int32:
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [Float32(a).ir_value(loc=loc, ip=ip)],
+            "cvt.rpi.ftz.s32.f32 $0, $1;",
+            "=r,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def silu(a: float | Float32, *, loc=None, ip=None) -> Float32:
+    """
+    silu(a) = a * sigmoid(a) = a * (1 + tanh(a / 2)) / 2 = (0.5 * a) * tanh(0.5 * a) + (0.5 * a)
+    This compiles down to 3 SASS instructions: FMUL to get 0.5 * a, MUFU.TANH, and FFMA.
+    """
+    a_half = 0.5 * a
+    return a_half * tanh(a_half) + a_half
+
+
+@dsl_user_op
+def prmt(a: int | Int32, b: int | Int32, c: int | Int32, *, loc=None, ip=None) -> Int32:
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Int32(a).ir_value(loc=loc, ip=ip),
+                Int32(b).ir_value(loc=loc, ip=ip),
+                Int32(c).ir_value(loc=loc, ip=ip),
+            ],
+            "prmt.b32 $0, $1, $2, $3;",
+            "=r,r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@cute.jit
+def permute_gated_Cregs_b16(t: cute.Tensor) -> None:
+    assert t.element_type.width == 16
+    assert cute.size(t.shape) % 4 == 0, (
+        "Tensor size must be a multiple of 4 for b16 permutation"
+    )
+    t_u32 = cute.recast_tensor(t, Int32)
+
+    quad_idx = cute.arch.lane_idx() % 4
+    lane_03 = quad_idx == 0 or quad_idx == 3
+    selector_upper = Int32(0x5410) if lane_03 else Int32(0x1054)
+    selector_lower = Int32(0x7632) if lane_03 else Int32(0x3276)
+    # upper_map = [0, 3, 1, 2]
+    # lower_map = [1, 2, 0, 3]
+    # upper_idx = upper_map[quad_idx]
+    # indexing isn't supported so we have to do arithmetic
+    upper_idx = quad_idx // 2 if quad_idx % 2 == 0 else 3 - quad_idx // 2
+    lower_idx = upper_idx ^ 1
+
+    # 1 -> 0b11111, 2 -> 0b11110, 4 -> 0b11100, 8 -> 0b11000, 16 -> 0b10000, 32 -> 0b00000
+    width = 4
+    mask = cute.arch.WARP_SIZE - width
+    clamp = cute.arch.WARP_SIZE - 1
+    mask_and_clamp = mask << 8 | clamp
+
+    for i in cutlass.range(cute.size(t_u32.shape) // 2, unroll_full=True):
+        upper, lower = t_u32[i * 2 + 0], t_u32[i * 2 + 1]
+        upper0 = upper if lane_03 else lower
+        lower0 = lower if lane_03 else upper
+        upper0 = cute.arch.shuffle_sync(
+            upper0, offset=upper_idx, mask_and_clamp=mask_and_clamp
+        )
+        lower0 = cute.arch.shuffle_sync(
+            lower0, offset=lower_idx, mask_and_clamp=mask_and_clamp
+        )
+        t_u32[i * 2 + 0] = prmt(upper0, lower0, selector_upper)
+        t_u32[i * 2 + 1] = prmt(upper0, lower0, selector_lower)
+
+
+@cute.jit
+def predicate_k(tAcA: cute.Tensor, limit: cutlass.Int32) -> cute.Tensor:
+    # Only compute predicates for the "k" dimension. For the mn dimension, we will use "if"
+    tApA = cute.make_fragment(
+        cute.make_layout(
+            (
+                cute.size(tAcA, mode=[0, 1]),
+                cute.size(tAcA, mode=[1]),
+                cute.size(tAcA, mode=[2]),
+            ),
+            stride=(cute.size(tAcA, mode=[2]), 0, 1),
+        ),
+        cutlass.Boolean,
+    )
+    for rest_v in cutlass.range_constexpr(tApA.shape[0]):
+        for rest_k in cutlass.range_constexpr(tApA.shape[2]):
+            tApA[rest_v, 0, rest_k] = cute.elem_less(
+                tAcA[(0, rest_v), 0, rest_k][1], limit
+            )
+    return tApA
+
+
+@cute.jit
+def fill_oob(
+    tXsX: cute.Tensor, tXpX: Optional[cute.Tensor], fill_value: cute.Numeric
+) -> None:
+    """Fill out-of-bounds values in shared memory tensor.
+
+    Args:
+        tXsX: Shared memory tensor to fill
+        tXpX: Predicate tensor indicating valid elements
+        fill_value: Value to fill OOB locations with
+    """
+    tXrX_fill = cute.make_fragment_like(tXsX[(None, 0), 0, 0])
+    tXrX_fill.fill(fill_value)
+    for rest_v in cutlass.range_constexpr(tXsX.shape[0][1]):
+        for rest_k in cutlass.range_constexpr(tXsX.shape[2]):
+            if cutlass.const_expr(tXpX is not None):
+                if not tXpX[rest_v, 0, rest_k]:
+                    cute.autovec_copy(tXrX_fill, tXsX[(None, rest_v), None, rest_k])
+            else:
+                cute.autovec_copy(tXrX_fill, tXsX[(None, rest_v), None, rest_k])
+
+
+@dsl_user_op
+def f32x2_to_i64(a: Float32, b: Float32, *, loc=None, ip=None) -> cutlass.Int64:
+    vec_f32x2 = vector.from_elements(
+        T.vector(2, T.f32()), (a.ir_value(), b.ir_value()), loc=loc, ip=ip
+    )
+    vec_i64x1 = vector.bitcast(T.vector(1, T.i64()), vec_f32x2)
+    res = cutlass.Int64(
+        vector.extract(
+            vec_i64x1, dynamic_position=[], static_position=[0], loc=loc, ip=ip
+        )
+    )
+    return res
+
+
+@dsl_user_op
+def i64_to_f32x2(c: cutlass.Int64, *, loc=None, ip=None) -> tuple[Float32, Float32]:
+    vec_i64x1 = vector.from_elements(
+        T.vector(1, T.i64()), (c.ir_value(),), loc=loc, ip=ip
+    )
+    vec_f32x2 = vector.bitcast(T.vector(2, T.f32()), vec_i64x1)
+    res0 = Float32(
+        vector.extract(
+            vec_f32x2, dynamic_position=[], static_position=[0], loc=loc, ip=ip
+        )
+    )
+    res1 = Float32(
+        vector.extract(
+            vec_f32x2, dynamic_position=[], static_position=[1], loc=loc, ip=ip
+        )
+    )
+    return res0, res1
+
+
+@dsl_user_op
+def domain_offset_i64(
+    coord: cute.Coord, tensor: cute.Tensor, *, loc=None, ip=None
+) -> cute.Tensor:
+    flat_coord_i64 = tuple(cutlass.Int64(c) for c in cute.flatten(coord))
+    flat_stride = cute.flatten_to_tuple(tensor.stride)
+    assert len(flat_coord_i64) == len(flat_stride), (
+        "Coordinate and stride must have the same length"
+    )
+    offset = sum(c * s for c, s in zip(flat_coord_i64, flat_stride))
+    assert isinstance(tensor.iterator, cute.Pointer)
+    # HACK: we assume that applying the offset does not change the pointer alignment
+    new_ptr = cute.make_ptr(
+        tensor.element_type,
+        tensor.iterator.toint() + offset * tensor.element_type.width // 8,
+        tensor.memspace,
+        assumed_align=tensor.iterator.max_alignment,
+    )
+    return cute.make_tensor(new_ptr, tensor.layout)
+
+
+@dsl_user_op
+def coord_offset_i64(
+    idx: cute.typing.Int, tensor: cute.Tensor, dim: int, *, loc=None, ip=None
+) -> cute.Tensor:
+    offset = cutlass.Int64(idx) * cute.size(tensor.stride[dim])
+    assert isinstance(tensor.iterator, cute.Pointer)
+    # HACK: we assume that applying the offset does not change the pointer alignment
+    new_ptr = cute.make_ptr(
+        tensor.element_type,
+        tensor.iterator.toint() + offset * tensor.element_type.width // 8,
+        tensor.memspace,
+        assumed_align=tensor.iterator.max_alignment,
+    )
+    return cute.make_tensor(new_ptr, tensor.layout)
+
+
+@cute.jit
+def warp_prefix_sum(
+    val: cutlass.Int32, lane: Optional[cutlass.Int32] = None
+) -> cutlass.Int32:
+    if cutlass.const_expr(lane is None):
+        lane = cute.arch.lane_idx()
+    for i in cutlass.range_constexpr(int(math.log2(cute.arch.WARP_SIZE))):
+        offset = 1 << i
+        # Very important that we set mask_and_clamp to 0
+        partial_sum = cute.arch.shuffle_sync_up(val, offset=offset, mask_and_clamp=0)
+        if lane >= offset:
+            val += partial_sum
+    return val
+
+
+def convert_layout_acc_mn(acc_layout: cute.Layout) -> cute.Layout:
+    """
+    For Sm80, convert ((2, 2), MMA_M, MMA_N, ...) to ((2, MMA_M), (2, MMA_N), ...).
+    For Sm90, convert ((2, 2, V), MMA_M, MMA_N, ...) to ((2, MMA_M), (2, V, MMA_N), ...).
+    """
+    acc_layout_col_major = cute.make_layout(acc_layout.shape)
+    acc_layout_mn = cute.make_layout(
+        (
+            (acc_layout_col_major.shape[0][1], acc_layout_col_major.shape[1]),  # MMA_M
+            (
+                acc_layout_col_major.shape[0][0],
+                *acc_layout_col_major.shape[0][2:],
+                acc_layout_col_major.shape[2],
+            ),  # MMA_N
+            *acc_layout_col_major.shape[3:],
+        ),
+        stride=(
+            (
+                acc_layout_col_major.stride[0][1],
+                acc_layout_col_major.stride[1],
+            ),  # MMA_M
+            (
+                acc_layout_col_major.stride[0][0],
+                *acc_layout_col_major.stride[0][2:],
+                acc_layout_col_major.stride[2],
+            ),  # MMA_N
+            *acc_layout_col_major.stride[3:],
+        ),
+    )
+    return cute.composition(acc_layout, acc_layout_mn)
+
+
+def make_acc_tensor_mn_view(acc: cute.Tensor) -> cute.Tensor:
+    return cute.make_tensor(acc.iterator, convert_layout_acc_mn(acc.layout))
+
+
+@dsl_user_op
+def sm90_get_smem_load_op(
+    layout_c: cutlass.utils.LayoutEnum,
+    elem_ty_c: type[cutlass.Numeric],
+    *,
+    loc=None,
+    ip=None,
+) -> cute.CopyAtom:
+    """
+    Selects the largest vectorized smem load atom available subject to constraint of gmem layout.
+
+    Parameters:
+    -----------
+    layout_c : LayoutEnum
+        The layout enum of the output tensor D.
+
+    elem_ty_c : Type[Numeric]
+        The element type for output tensor D.
+
+    Returns:
+    --------
+    Either SmemLoadMatrix or SimtSyncCopy, based on the input parameters.
+    """
+
+    if not isinstance(elem_ty_c, cutlass.cutlass_dsl.NumericMeta):
+        raise TypeError(f"elem_ty_c must be a Numeric, but got {elem_ty_c}")
+    is_m_major = layout_c.is_m_major_c()
+    if elem_ty_c.width == 16:
+        return cute.make_copy_atom(
+            cute.nvgpu.warp.LdMatrix8x8x16bOp(is_m_major, 4), elem_ty_c, loc=loc, ip=ip
+        )
+    else:
+        return cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(), elem_ty_c, loc=loc, ip=ip
+        )


### PR DESCRIPTION
Summary: We observe significant perf gain to replace torch rms norm with the quack rms norm kernel (D80317390). We do this inside compiler, thus it can be reused across models with at least B200 GPUs

Test Plan:
### unit test

```
buck2 test mode/opt  -c fbcode.nvcc_arch=b200a -c fbcode.enable_gpu_sections=true -c fbcode.platform010_cuda_version=12.8 -m "ovr_config//third-party/pypi/nvidia-cutlass-dsl/constraints:4.1.0" //caffe2/test/inductor:kernel_optimization -- test_replace_rms_norm_with_quack
```

Buck UI: https://www.internalfb.com/buck2/c29f2d25-b674-44c5-b504-a475b209384c
Test UI: https://www.internalfb.com/intern/testinfra/testrun/12666374058307987
Network: Up: 38KiB  Down: 12MiB  (reSessionID-0cbaccbb-7f2c-4651-9fc2-c13760f0e8f7)
Analyzing targets. Remaining     0/287
Executing actions. Remaining     0/21254                                                                      11.9s exec time total
Command: test.     Finished 5 local, 1 cache (17% hit)                                                        7.2s exec time cached (60%)
Time elapsed: 24.5s
Tests finished: Pass 1. Fail 0. Fatal 0. Skip 0. Build failure 0

### EMS

Enable the following flag
```
        torch._inductor.config.pre_grad_fusion_options = {
            "use_custom_rmsnorm_kernel_pass": {"quack": True}
        }
```

```
buck2 run mode/opt -c fbcode.platform010_cuda_version=12.8 aps_models/ads/ecosystem/tooling/tools/efficient_module_suite/benchmark:omnifm_perf_benchmark -- benchmark-with-prod-model --prod_config mast_omnifm_v3_B200_1kgpu --prod_config_override prod_config_override_jointarch --batch_size 1152 --enable_pt2 True --mfu_profile_module uniarch_layers.0.seq_interaction_layer --enable_ac True
```


without quack kernel

```
| Metric                | Value        |
|:----------------------|:-------------|
| Batch size            | 1152         |
| GPU type              | B200         |
| Latency               | 74.57 ms     |
| Model size            | 1.44 GB      |
| Flops                 | 14431.98 G   |
| Flops/example         | 12.53 G      |
| TFLOPS/sec            | 193.53       |
| MFU                   | 16.54%       |
| Activation/example    | 12.27 MB     |
| CPU time total        | 224.09 ms    |
| GPU time total        | 262.45 ms    |
| Estimated avg BW      | 2534.11 GB/s |
| Estimated avg BW util | 40.87%       |
Trace link: https://our.intern.facebook.com/intern/perfdoctor/trace_view?filepath=tree/traces/efficient_module_suite/uniarch.uniarch_layers.0.seq_interaction_layer.Aug_07_22_26_33_trace.json.gz&bucket=pyper_traces
Perfetto link: https://interncache-all.fbcdn.net/manifold/perfetto-artifacts/tree/ui/index.html#!/?url=https://interncache-all.fbcdn.net/manifold/pyper_traces/tree/traces/efficient_module_suite/uniarch.uniarch_layers.0.seq_interaction_layer.Aug_07_22_26_33_trace.json.gz
Snapshot link: https://www.internalfb.com/pytorch_memory_visualizer/ai_efficiency/tree/gpu_snapshot/uniarch.uniarch_layers.0.seq_interaction_layer.Aug_07_22_26_33.snapshot.pickle
```

with quack kernel

```
| Metric             | Value      |
|:-------------------|:-----------|
| Batch size         | 1152       |
| GPU type           | B200       |
| Latency            | 71.72 ms   |
| Model size         | 1.44 GB    |
| Flops              | 14431.98 G |
| Flops/example      | 12.53 G    |
| TFLOPS/sec         | 201.22     |
| MFU                | 17.20%     |
| Activation/example | 12.28 MB   |
| CPU time total     | 197.22 ms  |
| GPU time total     | 237.44 ms  |
Trace link: https://our.intern.facebook.com/intern/perfdoctor/trace_view?filepath=tree/traces/efficient_module_suite/uniarch_layers.0.seq_interaction_layer.Aug_26_17_07_41_trace.json.gz&bucket=pyper_traces
Perfetto link: https://interncache-all.fbcdn.net/manifold/perfetto-artifacts/tree/ui/index.html#!/?url=https://interncache-all.fbcdn.net/manifold/pyper_traces/tree/traces/efficient_module_suite/uniarch_layers.0.seq_interaction_layer.Aug_26_17_07_41_trace.json.gz
Snapshot link: https://www.internalfb.com/pytorch_memory_visualizer/ai_efficiency/tree/gpu_snapshot/uniarch_layers.0.seq_interaction_layer.Aug_26_17_07_41.snapshot.pickle
```

Rollback Plan:

Differential Revision: D80492377




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @mlazos