### PR TITLE
Ensure that tensors are contiguous before using no-graph MPS impl

### DIFF
--- a/aten/src/ATen/native/mps/operations/Linear.mm
+++ b/aten/src/ATen/native/mps/operations/Linear.mm
@@ -115,7 +115,10 @@ Tensor _mps_linear(const Tensor& input, const Tensor& weight_arg, const std::opt
     return output;
   }
 
-  if (is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS)) {
+  // No-graph execution causes nonsense if these are non-contiguous.
+  const bool is_contiguous = input.is_contiguous() && weight.is_contiguous() && bias.is_contiguous();
+
+  if (is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS) && is_contiguous) {
     _mps_linear_nograph(input, weight, bias, output);
     // Squeeze last dim of 1D linear
     return weight_arg.dim() != 1 ? output : output.squeeze(-1);

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1244,6 +1244,21 @@ class TestMPS(TestCaseMPS):
             torch.nn.functional.linear(torch.rand(size, device='cpu'),
                                        torch.rand(size, device='mps'))
 
+    def test_linear_non_contiguous(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/161640
+        # Slice tensors to force non-contiguity
+        large_weight = torch.randn(12, 8, device='mps')
+        weight_sliced = large_weight[::2, ::1]
+        weight_contiguous_equiv = weight_sliced.contiguous()
+        input_s = torch.randn(2, 8, device='mps')
+        result_sliced = torch.nn.functional.linear(input_s, weight_sliced)
+        result_contig = torch.nn.functional.linear(input_s, weight_contiguous_equiv)
+        input_cpu = input_s.cpu()
+        weight_sliced_cpu = weight_sliced.cpu()
+        result_sliced_cpu = torch.nn.functional.linear(input_cpu, weight_sliced_cpu)
+        self.assertEqual(result_contig, result_sliced, atol=1e-5, rtol=1e-5)
+        self.assertEqual(result_sliced.to("cpu"), result_sliced_cpu, atol=1e-5, rtol=1e-5)
+
     def _linear_helper(self, in_features, out_features, shape, bias=True, backward_pass=False):
         cpu_linear = torch.nn.Linear(in_features=in_features, out_features=out_features, device="cpu", bias=bias)
         mps_linear = torch.nn.Linear(in_features=in_features, out_features=out_features, device="mps", bias=bias)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1253,11 +1253,7 @@ class TestMPS(TestCaseMPS):
         input_s = torch.randn(2, 8, device='mps')
         result_sliced = torch.nn.functional.linear(input_s, weight_sliced)
         result_contig = torch.nn.functional.linear(input_s, weight_contiguous_equiv)
-        input_cpu = input_s.cpu()
-        weight_sliced_cpu = weight_sliced.cpu()
-        result_sliced_cpu = torch.nn.functional.linear(input_cpu, weight_sliced_cpu)
-        self.assertEqual(result_contig, result_sliced, atol=1e-5, rtol=1e-5)
-        self.assertEqual(result_sliced.to("cpu"), result_sliced_cpu, atol=1e-5, rtol=1e-5)
+        self.assertEqual(result_contig, result_sliced)
 
     def _linear_helper(self, in_features, out_features, shape, bias=True, backward_pass=False):
         cpu_linear = torch.nn.Linear(in_features=in_features, out_features=out_features, device="cpu", bias=bias)


### PR DESCRIPTION
Fixes #161640

Check if tensors are contiguous before using the no-graph implementation. Using the script in the issue above with this change I get expected results.

```
MPS contiguous result sample: tensor([ 1.3600, -2.9516,  1.3207, -3.5132,  1.7061], device='mps:0')
MPS non-contig result sample: tensor([ 1.3600, -2.9516,  1.3207, -3.5132,  1.7061], device='mps:0')
CPU non-contig result sample: tensor([ 1.3600, -2.9516,  1.3207, -3.5132,  1.7061])
```