### PR TITLE
NamedTuple: Allow side effects for dynamic attributes

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1754,6 +1754,25 @@ utils_device.CURRENT_DEVICE == None""".split("\n"):
         out = f(MyTuple(a, b))
         self.assertTrue(same(a + 1, out))
 
+    def test_namedtuple_subclass_dynamic_attributes(self):
+        class MyNamedTuple(typing.NamedTuple):
+            a: torch.Tensor
+            b: torch.Tensor
+
+        class MyNamedTupleSubclass(MyNamedTuple):
+            pass
+
+        @torch.compile(fullgraph=True, backend="eager")
+        def f(tup):
+            c = torch.tensor(4.0)
+            tup.c = c  # Add dynamic attribute
+            return tup
+
+        extended_tup = MyNamedTupleSubclass(a=torch.tensor([2.0]), b=torch.tensor(1.0))
+        result = f(extended_tup)
+        self.assertTrue(hasattr(result, "c"))
+        self.assertEqual(result.c, torch.tensor(4.0))
+
     def test_structseq1(self):
         def fn(x, y):
             return torch.return_types.max((x, y))

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1787,10 +1787,7 @@ utils_device.CURRENT_DEVICE == None""".split("\n"):
         @torch.compile(backend="eager")
         def f():
             # Create namedtuple inside function (sourceless)
-            tup = MyNamedTupleSubclass(
-                a=torch.tensor([1.0]), 
-                b=torch.tensor(2.0)
-            )
+            tup = MyNamedTupleSubclass(a=torch.tensor([1.0]), b=torch.tensor(2.0))
             # Add dynamic attribute
             tup.c = torch.tensor(3.0)
             return tup

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -707,7 +707,10 @@ class VariableBuilder:
             result = NamedTupleVariable(
                 output, tuple_cls=type(value), source=self.source
             )
-            return result
+            if result.is_structseq() or result.tuple_cls.__bases__ == (tuple,):
+                return result
+
+            return self.tx.output.side_effects.track_object_existing(value, result)
         elif istype(value, (dict, collections.defaultdict, collections.OrderedDict)):
             self.install_guards(GuardBuilder.TYPE_MATCH)
             all_const = all(ConstantVariable.is_literal(k) for k in value.keys())

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -707,9 +707,6 @@ class VariableBuilder:
             result = NamedTupleVariable(
                 output, tuple_cls=type(value), source=self.source
             )
-            if result.tuple_cls.__bases__ == (tuple,):
-                return result
-
             return self.tx.output.side_effects.track_object_existing(value, result)
         elif istype(value, (dict, collections.defaultdict, collections.OrderedDict)):
             self.install_guards(GuardBuilder.TYPE_MATCH)

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -707,7 +707,7 @@ class VariableBuilder:
             result = NamedTupleVariable(
                 output, tuple_cls=type(value), source=self.source
             )
-            if result.is_structseq() or result.tuple_cls.__bases__ == (tuple,):
+            if result.tuple_cls.__bases__ == (tuple,):
                 return result
 
             return self.tx.output.side_effects.track_object_existing(value, result)

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -1129,7 +1129,14 @@ class NamedTupleVariable(TupleVariable):
             ):
                 raise_observed_exception(AttributeError, tx)
             # Subclass of namedtuple type can have dynamic attributes
+            # STEP 1: Ensure proper mutation type for attribute mutations
+            from .base import AttributeMutationExisting
+
+            self.mutation_type = AttributeMutationExisting()
+
             tx.output.side_effects.mutation(self)
+            # STEP 3: Store the attribute mutation (CRITICAL - this was missing!)
+            tx.output.side_effects.store_attr(self, attr, value)
             self.dynamic_attributes[attr] = value
             return ConstantVariable.create(None)
         return super().call_method(tx, name, args, kwargs)

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -1128,6 +1128,7 @@ class NamedTupleVariable(TupleVariable):
                 or attr in self.fields()
             ):
                 raise_observed_exception(AttributeError, tx)
+            # Subclass of namedtuple type can have dynamic attributes
             from .base import AttributeMutationExisting
             self.mutation_type = AttributeMutationExisting()
             tx.output.side_effects.mutation(self)

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -1137,18 +1137,11 @@ class NamedTupleVariable(TupleVariable):
             + create_call_function(1, False)
         )
 
-        # Handle dynamic attributes through store_attr_mutations
-        from torch._dynamo.symbolic_convert import InstructionTranslator
-
-        tx = InstructionTranslator.current_tx()
-        if tx.output.side_effects.has_pending_mutation(self):
-            for name, value in tx.output.side_effects.store_attr_mutations[
-                self
-            ].items():
-                codegen.dup_top()
-                codegen(value)
-                codegen.extend_output(create_rot_n(2))
-                codegen.store_attr(name)
+        for name, value in self.dynamic_attributes.items():
+            codegen.dup_top()
+            codegen(value)
+            codegen.extend_output(create_rot_n(2))
+            codegen.store_attr(name)
 
     def call_method(
         self,

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -1128,14 +1128,9 @@ class NamedTupleVariable(TupleVariable):
                 or attr in self.fields()
             ):
                 raise_observed_exception(AttributeError, tx)
-            # Subclass of namedtuple type can have dynamic attributes
-            # STEP 1: Ensure proper mutation type for attribute mutations
             from .base import AttributeMutationExisting
-
             self.mutation_type = AttributeMutationExisting()
-
             tx.output.side_effects.mutation(self)
-            # STEP 3: Store the attribute mutation (CRITICAL - this was missing!)
             tx.output.side_effects.store_attr(self, attr, value)
             self.dynamic_attributes[attr] = value
             return ConstantVariable.create(None)

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -1147,18 +1147,13 @@ class NamedTupleVariable(TupleVariable):
                 or attr in self.fields()
             ):
                 raise_observed_exception(AttributeError, tx)
-
-                # Handle mutation tracking based on variable type
-            if self.mutation_type is None:
+            # Subclass of namedtuple type can have dynamic attributes
+            if self.source is None:
                 from .base import AttributeMutationNew
 
                 self.mutation_type = AttributeMutationNew()
-
-            # Always call mutation to mark as modified
             tx.output.side_effects.mutation(self)
             tx.output.side_effects.store_attr(self, attr, value)
-
-            # Always update our internal tracking
             self.dynamic_attributes[attr] = value
             return ConstantVariable.create(None)
         return super().call_method(tx, name, args, kwargs)

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -1156,7 +1156,8 @@ class NamedTupleVariable(TupleVariable):
                 raise_observed_exception(AttributeError, tx)
             # Subclass of namedtuple type can have dynamic attributes
             tx.output.side_effects.mutation(self)
-            tx.output.side_effects.store_attr(self, attr, value)
+            if self.source:
+                tx.output.side_effects.store_attr(self, attr, value)
             self.dynamic_attributes[attr] = value
             return ConstantVariable.create(None)
         return super().call_method(tx, name, args, kwargs)

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -1130,6 +1130,7 @@ class NamedTupleVariable(TupleVariable):
                 raise_observed_exception(AttributeError, tx)
             # Subclass of namedtuple type can have dynamic attributes
             from .base import AttributeMutationExisting
+
             self.mutation_type = AttributeMutationExisting()
             tx.output.side_effects.mutation(self)
             tx.output.side_effects.store_attr(self, attr, value)

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -1080,17 +1080,17 @@ class NamedTupleVariable(TupleVariable):
         else:
             # NamedTupleType(*iterable)
             result = self.python_type()(*[x.as_python_constant() for x in self.items])
-        
+
         # Apply dynamic attributes if any were set
         if self.dynamic_attributes:
             for attr_name, attr_value in self.dynamic_attributes.items():
                 # Convert VariableTracker to Python constant if needed
-                if hasattr(attr_value, 'as_python_constant'):
+                if hasattr(attr_value, "as_python_constant"):
                     python_value = attr_value.as_python_constant()
                 else:
                     python_value = attr_value
                 setattr(result, attr_name, python_value)
-        
+
         return result
 
     def as_proxy(self):
@@ -1147,16 +1147,17 @@ class NamedTupleVariable(TupleVariable):
                 or attr in self.fields()
             ):
                 raise_observed_exception(AttributeError, tx)
-            
-                  # Handle mutation tracking based on variable type
+
+                # Handle mutation tracking based on variable type
             if self.mutation_type is None:
                 from .base import AttributeMutationNew
+
                 self.mutation_type = AttributeMutationNew()
-            
+
             # Always call mutation to mark as modified
             tx.output.side_effects.mutation(self)
             tx.output.side_effects.store_attr(self, attr, value)
-            
+
             # Always update our internal tracking
             self.dynamic_attributes[attr] = value
             return ConstantVariable.create(None)

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -716,7 +716,16 @@ class UserDefinedClassVariable(UserDefinedVariable):
 
                 assert all(x is not None for x in items)
 
-            return variables.NamedTupleVariable(items, self.value)
+            # Modify mutability of namedtuple for sourcelesss instantiations.
+            mutation_type = None
+            if self.value.__bases__ != (tuple,):
+                from .base import AttributeMutationNew
+
+                mutation_type = AttributeMutationNew()
+
+            return variables.NamedTupleVariable(
+                items, self.value, mutation_type=mutation_type
+            )
         elif self.value is torch.Size:
             # This simulates `THPSize_pynew`, the C impl for `Size.__new__`.
             tup = variables.BuiltinVariable(tuple).call_function(tx, args, kwargs)

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -718,6 +718,7 @@ class UserDefinedClassVariable(UserDefinedVariable):
 
             # Modify mutability of namedtuple for sourcelesss instantiations.
             from .base import AttributeMutationNew
+
             return variables.NamedTupleVariable(
                 items, self.value, mutation_type=AttributeMutationNew()
             )

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -717,14 +717,9 @@ class UserDefinedClassVariable(UserDefinedVariable):
                 assert all(x is not None for x in items)
 
             # Modify mutability of namedtuple for sourcelesss instantiations.
-            mutation_type = None
-            if self.value.__bases__ != (tuple,):
-                from .base import AttributeMutationNew
-
-                mutation_type = AttributeMutationNew()
-
+            from .base import AttributeMutationNew
             return variables.NamedTupleVariable(
-                items, self.value, mutation_type=mutation_type
+                items, self.value, mutation_type=AttributeMutationNew()
             )
         elif self.value is torch.Size:
             # This simulates `THPSize_pynew`, the C impl for `Size.__new__`.


### PR DESCRIPTION
I confirmed that the tracing was correct i.e. NamedTupleVariable had the correct dynamic attribute added to it.

The problem was that NamedTupleVariable was always marked as immutable. This does not reflect the behavior of namedtuple. 

Subclasses of namedtuple may be mutable, so when a NamedTupleVariable is derived from a subclass that is mutable, I made NamedTupleVariable mutable as well. Then side_effects correctly updates the returned object. 

Fixes #161610


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela