### PR TITLE
Add option for TorchDispatchMode to ignore torch.compile internals

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -279,8 +279,7 @@ class MiscTests(torch._inductor.test_case.TestCase):
             foo(x)
 
         self.assertEqual(len(_checksums), 2)
-        # If you are getting "3" here, then that means the .abs().sum()
-        # are being compiled instead of the contents of g(x).
+        # The correct result here is 1: Dynamo should capture the `g` frame.
         self.assertEqual(counters["frames"]["total"], 1)
         self.assertEqual(counters["frames"]["ok"], 1)
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -229,6 +229,61 @@ class MiscTests(torch._inductor.test_case.TestCase):
         self.assertTrue(same(val4, correct1))
         self.assertEqual(counter.frame_count, 3)
 
+    def test_torch_dispatch_ignore_compile_internals(self):
+        counters.clear()
+        from torch.utils._python_dispatch import TorchDispatchMode
+
+        @torch.library.custom_op("mylib::foo", mutates_args=())
+        def foo(x: torch.Tensor) -> torch.Tensor:
+            return x.clone()
+
+        def checksum(x):
+            return x.abs().sum()
+
+        _checksums = []
+
+        class ChecksumFoo(TorchDispatchMode):
+            @classmethod
+            def ignore_compile_internals(cls):
+                return True
+
+            def __init__(self) -> None:
+                super().__init__()
+
+            def __torch_dispatch__(self, func, types, args, kwargs=None):
+                kwargs = kwargs or {}
+
+                if func is torch.ops.mylib.foo.default:
+                    # Do some compute, smoketest to see if there's a bad interaction
+                    _checksums.append(args[0].abs().sum())
+
+                return func(*args, **kwargs)
+
+        backend_count = 0
+
+        def backend(gm, args):
+            global backend_count
+            backend_count += 1
+            return gm
+
+        # test e2e, with Inductor, as smoketest.
+        @torch.compile(fullgraph=True, backend="inductor")
+        def g(x):
+            return 2 * x.sin().cos()
+
+        x = torch.randn(3)
+
+        with ChecksumFoo():
+            foo(x)
+            g(x)
+            foo(x)
+
+        self.assertEqual(len(_checksums), 2)
+        # If you are getting "3" here, then that means the .abs().sum()
+        # are being compiled instead of the contents of g(x).
+        self.assertEqual(counters["frames"]["total"], 1)
+        self.assertEqual(counters["frames"]["ok"], 1)
+
     @torch._dynamo.config.patch(accumulated_recompile_limit=1)
     def test_dynamo_disabled_in_custom_op_kernels(self):
         counters.clear()

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -73,7 +73,7 @@ from torch.monitor import _WaitCounter
 from torch.nn.parallel.distributed import DistributedDataParallel
 from torch.utils._python_dispatch import (
     _disable_current_modes,
-    _get_current_dispatch_mode_stack,
+    is_in_any_mode_without_ignore_compile_internals,
     is_in_torch_dispatch_mode,
 )
 from torch.utils._traceback import CapturedTraceback, format_traceback_short
@@ -1632,18 +1632,7 @@ class ConvertFrameProtocol(typing.Protocol):
 
 
 def should_skip_due_to_torch_dispatch_mode() -> bool:
-    # fast check
-    if not is_in_torch_dispatch_mode(include_infra_modes=False):
-        return False
-
-    mode_stack = _get_current_dispatch_mode_stack()
-    for mode in mode_stack:
-        if mode.ignore_compile_internals():
-            continue
-        if mode.is_infra_mode():
-            continue
-        return True
-    return False
+    return is_in_any_mode_without_ignore_compile_internals()
 
 
 class CatchErrorsWrapper:

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1683,7 +1683,6 @@ class CatchErrorsWrapper:
                 elif trace_rules.check(frame.f_code):
                     skip_reason = "in skipfiles"
                 elif is_in_torch_dispatch_mode(include_infra_modes=False):
-                    breakpoint()
                     skip_reason = "non-infra torch dispatch mode present, this is not supported today in torch.compile"
                 else:
                     skip_reason = "dynamo tracing is disabled"

--- a/torch/utils/_python_dispatch.py
+++ b/torch/utils/_python_dispatch.py
@@ -155,7 +155,7 @@ class TorchDispatchMode:
             f(x)
 
         The above example will not log anything if
-        ``LoggingMode.ignore_compile_internals`` is True.
+        ``LoggingMode.ignore_compile_internals()`` is True.
         torch.compile will fuse sin() and cos() into a single operation
         and this TorchDispatchMode will not be passed sin and cos.
 

--- a/torch/utils/_python_dispatch.py
+++ b/torch/utils/_python_dispatch.py
@@ -27,6 +27,8 @@ from torch._C import (
 
 _is_in_torch_dispatch_mode = False
 _is_in_non_infra_torch_dispatch_mode = False
+# If inside any mode that has ignore_compile_internals() = False
+_is_in_any_mode_without_ignore_compile_internals = False
 
 
 def is_in_torch_dispatch_mode(include_infra_modes=True) -> bool:
@@ -35,6 +37,10 @@ def is_in_torch_dispatch_mode(include_infra_modes=True) -> bool:
         if include_infra_modes
         else _is_in_non_infra_torch_dispatch_mode
     )
+
+
+def is_in_any_mode_without_ignore_compile_internals() -> bool:
+    return _is_in_any_mode_without_ignore_compile_internals
 
 
 class TorchDispatchMode:
@@ -81,6 +87,9 @@ class TorchDispatchMode:
 
         self.old_dispatch_mode_flags: deque[bool] = deque()
         self.old_non_infra_dispatch_mode_flags: deque[bool] = deque()
+        self.old_without_ignore_compile_internals_dispatch_mode_flags: deque[bool] = (
+            deque()
+        )
 
     def _lazy_init_old_dispatch_mode_flags(self):
         if not hasattr(self, "old_dispatch_mode_flags"):
@@ -89,12 +98,21 @@ class TorchDispatchMode:
         if not hasattr(self, "old_non_infra_dispatch_mode_flags"):
             self.old_non_infra_dispatch_mode_flags: deque[bool] = deque()  # type: ignore[no-redef]
 
+        if not hasattr(
+            self, "old_without_ignore_compile_internals_dispatch_mode_flags"
+        ):
+            self.old_without_ignore_compile_internals_dispatch_mode_flags: deque[  # type: ignore[no-redef]
+                bool
+            ] = deque()
+
     def __torch_dispatch__(self, func, types, args=(), kwargs=None):
         raise NotImplementedError
 
     def __enter__(self):
         global _is_in_torch_dispatch_mode
         global _is_in_non_infra_torch_dispatch_mode
+        global _is_in_any_mode_without_ignore_compile_internals
+
         # Previously, there wasn't any state in this class' constructor
         # super calls were added to existing modes, but for any new modes
         # this will replicate the previous behavior of not strictly needing
@@ -107,6 +125,13 @@ class TorchDispatchMode:
         )
         _is_in_non_infra_torch_dispatch_mode = (
             _is_in_non_infra_torch_dispatch_mode or not self.is_infra_mode()
+        )
+        self.old_without_ignore_compile_internals_dispatch_mode_flags.append(
+            _is_in_any_mode_without_ignore_compile_internals
+        )
+        _is_in_any_mode_without_ignore_compile_internals = (
+            _is_in_any_mode_without_ignore_compile_internals
+            or not self.ignore_compile_internals()
         )
         _push_mode(self)
         return self
@@ -122,6 +147,10 @@ class TorchDispatchMode:
         global _is_in_non_infra_torch_dispatch_mode
         _is_in_non_infra_torch_dispatch_mode = (
             self.old_non_infra_dispatch_mode_flags.pop()
+        )
+        global _is_in_any_mode_without_ignore_compile_internals
+        _is_in_any_mode_without_ignore_compile_internals = (
+            self.old_without_ignore_compile_internals_dispatch_mode_flags.pop()
         )
         _pop_mode(mb_dk_or_mode_key)
 
@@ -165,6 +194,8 @@ class TorchDispatchMode:
         The way this will usually happen is that :func:`torch.compile`
         will just fallback to eager-mode PyTorch.
         """
+        if cls.is_infra_mode():
+            return True
         return False
 
 

--- a/torch/utils/_python_dispatch.py
+++ b/torch/utils/_python_dispatch.py
@@ -137,6 +137,36 @@ class TorchDispatchMode:
     def is_infra_mode(cls):
         return False
 
+    @classmethod
+    def ignore_compile_internals(cls):
+        """Ignore operators that are compiled via torch.compile.
+
+        If ``True``, then this TorchDispatchMode ignores operators that
+        are optimized by :func:`torch.compile`. Mechanically, this involves
+        turning off the TorchDispatchMode throughout the whole compilation process,
+        and turning it back on for the runtime of the compiled artifact(s).
+        For example,
+
+        @torch.compile
+        def f(x):
+            return x.sin().cos()
+
+        with LoggingMode():
+            f(x)
+
+        The above example will not log anything if
+        ``LoggingMode.ignore_compile_internals`` is True.
+        torch.compile will fuse sin() and cos() into a single operation
+        and this TorchDispatchMode will not be passed sin and cos.
+
+        If ``False`` (default), :func:`torch.compile` will respect
+        the eager semantics of passing this TorchDispatchMode all
+        operators that would have run during eager execution.
+        The way this will usually happen is that :func:`torch.compile`
+        will just fallback to eager-mode PyTorch.
+        """
+        return False
+
 
 def _get_current_dispatch_mode():
     stack_len = _len_torch_dispatch_stack()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #161648

If TorchDispatchMode.ignore_compile_internals() is True, then we turn
off the TorchDispatchMode during the compilation process, instead
turning it back on during runtime of the compiled artifact.

Test Plan:
- new test

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela