### PR TITLE
Add ciflow/vllm to vLLM commit hash update PR(s)

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -41,6 +41,9 @@
 - test/inductor/**
 - test/dynamo/**
 
+"ciflow/vllm":
+- .github/ci_commit_pins/vllm.txt
+
 "module: cpu":
 - aten/src/ATen/cpu/**
 - aten/src/ATen/native/cpu/**


### PR DESCRIPTION
As it should be, otherwise, PR(s) like https://github.com/pytorch/pytorch/pull/161121 were merged without the signals it needed.