### PR TITLE
Suppress dllexport warning on XPU windows build

### DIFF
--- a/cmake/public/xpu.cmake
+++ b/cmake/public/xpu.cmake
@@ -40,6 +40,10 @@ set(TORCH_XPU_ARCH_LIST ${XPU_ARCH_FLAGS})
 # Ensure USE_XPU is enabled.
 string(APPEND XPU_HOST_CXX_FLAGS " -DUSE_XPU")
 string(APPEND XPU_HOST_CXX_FLAGS " -DSYCL_COMPILER_VERSION=${SYCL_COMPILER_VERSION}")
+if(WIN32)
+  # Suppress warnings about dllexport.
+  string(APPEND XPU_HOST_CXX_FLAGS " -Wno-ignored-attributes")
+endif()
 
 if(DEFINED ENV{XPU_ENABLE_KINETO})
   set(XPU_ENABLE_KINETO TRUE)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #161686
# Motivation
Refer to https://github.com/pytorch/pytorch/pull/153986, suppressing the dllexport warning on XPU Windows builds, which will reduce the number of lines in the build log.
```bash
2025-08-27T16:24:34.6542666Z C:\actions-runner\_work\pytorch\pytorch\pytorch\c10\util\Exception.h(475,8): warning: 'dllimport' attribute ignored on inline function [-Wignored-attributes]
2025-08-27T16:24:34.6544084Z   475 | inline C10_API const char* torchCheckMsgImpl(const char* msg) {
```
