### PR TITLE
[Intel GPU] Fix XPU SDPA default priority_order UT fail

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -4269,6 +4269,12 @@ class TestSDPAXpuOnly(NNTestCase):
     def test_default_priority_order(self, device):
         # The default priority order of xpu is overrideable, math, flash, efficient, cudnn
         # For xpu backend, we need to make sure that overrideable > math > flash
+        dtype = torch.bfloat16
+        shape = SdpaShape(1, 1, 1, 1)
+        make_tensor = partial(torch.rand, shape, device=device, dtype=dtype)
+        t = make_tensor()
+        # run sdp_choice to make sure priority_order is set by XPU default priority_order
+        torch._fused_sdp_choice(t, t, t)
         from torch.nn.attention import _cur_sdpa_kernel_backends
         default_priority = _cur_sdpa_kernel_backends(with_priority=True)
         flash_index = default_priority.index(SDPBackend.FLASH_ATTENTION)


### PR DESCRIPTION
Fixes #161483

When the whole `test/test_transformers.py` file is run, the case `test_default_priority_order` can pass because other xpu cases would call SDPA so that the priority order is set by https://github.com/pytorch/pytorch/blob/eec876deb659fe667aac2d97a48d7451c3e88dee/aten/src/ATen/native/mkldnn/xpu/Attention.cpp#L98-L112

However, when the case `test_default_priority_order` is run separately, the priority order is unset so that this case would fail. This PR fix this case.