### PR TITLE
[ROCm] OffsetCalc Unroll Optimization

### DIFF
--- a/aten/src/ATen/cuda/detail/OffsetCalculator.cuh
+++ b/aten/src/ATen/cuda/detail/OffsetCalculator.cuh
@@ -47,7 +47,7 @@ struct OffsetCalculator {
     offset_type offsets;
 
 #if defined(USE_ROCM)
-    if (dims <= 3) {
+    if ((dims > 0) && (dims <= 3)) {
       auto divmod = sizes_[0].divmod(linear_idx);
 #pragma unroll
       for (int arg = 0; arg < NARGS; arg++)

--- a/aten/src/ATen/cuda/detail/OffsetCalculator.cuh
+++ b/aten/src/ATen/cuda/detail/OffsetCalculator.cuh
@@ -45,6 +45,30 @@ struct OffsetCalculator {
 
   C10_HOST_DEVICE offset_type get(index_t linear_idx) const {
     offset_type offsets;
+
+#if defined(USE_ROCM)
+    if (dims <= 3) {
+      auto divmod = sizes_[0].divmod(linear_idx);
+#pragma unroll
+      for (int arg = 0; arg < NARGS; arg++)
+        offsets[arg] = divmod.mod * strides_[0][arg];
+      if (dims >= 2) {
+        divmod = sizes_[1].divmod(divmod.div);
+#pragma unroll
+        for (int arg = 0; arg < NARGS; arg++)
+          offsets[arg] += divmod.mod * strides_[1][arg];
+      }
+      if (dims >= 3) {
+        divmod = sizes_[2].divmod(divmod.div);
+#pragma unroll
+        for (int arg = 0; arg < NARGS; arg++)
+          offsets[arg] += divmod.mod * strides_[2][arg];
+      }
+      // [...]
+      return offsets;
+    }
+#endif
+
     #pragma unroll
     for (int arg = 0; arg < NARGS; arg++) {
       offsets[arg] = 0;

--- a/aten/src/ATen/cuda/detail/OffsetCalculator.cuh
+++ b/aten/src/ATen/cuda/detail/OffsetCalculator.cuh
@@ -47,7 +47,7 @@ struct OffsetCalculator {
     offset_type offsets;
 
 #if defined(USE_ROCM)
-    if ((dims > 0) && (dims <= 3)) {
+    if ((dims > 0) && (dims <= 2)) {
       auto divmod = sizes_[0].divmod(linear_idx);
 #pragma unroll
       for (int arg = 0; arg < NARGS; arg++)
@@ -57,12 +57,6 @@ struct OffsetCalculator {
 #pragma unroll
         for (int arg = 0; arg < NARGS; arg++)
           offsets[arg] += divmod.mod * strides_[1][arg];
-      }
-      if (dims >= 3) {
-        divmod = sizes_[2].divmod(divmod.div);
-#pragma unroll
-        for (int arg = 0; arg < NARGS; arg++)
-          offsets[arg] += divmod.mod * strides_[2][arg];
       }
       // [...]
       return offsets;


### PR DESCRIPTION
Our compiler is generating inefficient code for the offsetCalc in certain situations.
The root-cause for this needs to be identified. For now specialized unrolling based on 'dims' notably helps perf.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd