### PR TITLE
[indexing] Prevent integer overflow from large step values in C++

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -3127,7 +3127,9 @@ Tensor slice(
   }
   auto storage_offset = self.storage_offset() + start_val * strides[dim];
   auto len = end_val - start_val;
-  sizes[dim] = (len + step - 1) / step; // round-up
+  // NB: (len + step - 1) / step is equivalent implementation,
+  // but len + step could overflow if step or len is very large
+  sizes[dim] = (len == 0) ? 0 : (1 + (len - 1) / step); // safely round up
   strides[dim] *= step;
 
   Tensor result;

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4343,6 +4343,31 @@ class CommonTemplate:
         self.assertEqual(torch.compile(fn)(x1, y), fn(x1, y))
         self.assertEqual(torch.compile(fn)(x2, y), fn(x2, y))
 
+    def test_slice_copy(self):
+        class Model(nn.Module):
+            def __init__(self, start=449, step=(2**63 - 1)):
+                super().__init__()
+                self.start = start
+                self.step = step
+
+            def forward(self, x: torch.Tensor):
+                sliced = torch.slice_copy(
+                    x, dim=0, start=self.start, end=None, step=self.step
+                )
+                return torch.reciprocal(sliced)
+
+        with config.patch({"implicit_fallbacks": True}):
+            # bad case
+            self.common(
+                Model(),
+                (torch.randn(875),),
+            )
+            # normal case
+            self.common(
+                Model(step=10),
+                (torch.randn(875),),
+            )
+
     def test_slice1(self):
         def fn(a):
             return (

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -759,7 +759,7 @@ def slice_forward(
 
     storage_offset = self.storage_offset() + start_val * strides[dim]
     len = end_val - start_val
-    sizes[dim] = (len + step - 1) // step
+    sizes[dim] = -(len // -step)  # round-up, avoiding overflow
     strides[dim] *= step
 
     if self.is_quantized:


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/160868
hmmm, I found an existing fix PR after I've finished this one. For reference, the old PR was
https://github.com/pytorch/pytorch/pull/147433/files. 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos @chenyang78 @leslie-fang-intel 