### PR TITLE
[WIP][xpu][test] Migrate 6 UT test suites for Intel GPU

### DIFF
--- a/test/distributed/fsdp/test_fsdp_mixed_precision.py
+++ b/test/distributed/fsdp/test_fsdp_mixed_precision.py
@@ -379,7 +379,7 @@ class TestFSDPMixedPrecision(FSDPTest):
         sharding_strategy,
         enable_sharded_grad_scaler,
     ):
-        torch.get_device_module(device_type).set_device(self.rank)
+        torch.accelerator.set_device_index(self.rank)
         fsdp_models = [
             self._get_simple_model(
                 param_dtype=full_precision_param_dtype,

--- a/test/distributed/fsdp/test_fsdp_mixed_precision.py
+++ b/test/distributed/fsdp/test_fsdp_mixed_precision.py
@@ -978,7 +978,7 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
             model,
             sharding_strategy=sharding_strategy,
             mixed_precision=mixed_precision,
-            device_id=torch.accelerator.current_device(),
+            device_id=torch.accelerator.current_device_index(),
             use_orig_params=use_orig_params,
         )
         # Use an input with dtype not equal to the mixed precision
@@ -1125,7 +1125,7 @@ class TestFSDPMixedPrecisionIgnoredModules(FSDPTest):
             mixed_precision=float16,
         )
 
-        x = torch.ones(2, 100, device=torch.get_device_module(device_type).current_device())
+        x = torch.ones(2, 100, device=device_type)
 
         with self.assertRaisesRegex(RuntimeError, "must have the same dtype"):
             model(x).sum().backward()

--- a/test/distributed/fsdp/test_fsdp_mixed_precision.py
+++ b/test/distributed/fsdp/test_fsdp_mixed_precision.py
@@ -33,6 +33,7 @@ from torch.testing._internal.common_fsdp import (
     FSDPInitMode,
     FSDPTest,
     subtest_name,
+    get_devtype,
     TransformerWithSharedParams,
 )
 from torch.testing._internal.common_utils import (
@@ -43,6 +44,7 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_DEV_DBG_ASAN,
 )
 
+device_type = torch.device(get_devtype())
 
 try:
     import torchvision
@@ -249,13 +251,13 @@ class TestFSDPMixedPrecision(FSDPTest):
                 FSDP(
                     LinearMixedPrecision(
                         param_dtype, buffer_name="buffer0", run_checks=run_checks
-                    ).cuda(),
+                    ).to(device_type),
                     *fsdp_args,
                     **fsdp_kwargs,
                 ),
                 LinearMixedPrecision(
                     param_dtype, buffer_name="buffer1", run_checks=run_checks
-                ).cuda(),
+                ).to(device_type),
             ),
             *fsdp_args,
             **fsdp_kwargs,
@@ -264,7 +266,7 @@ class TestFSDPMixedPrecision(FSDPTest):
 
     def _get_simple_model(self, param_dtype, *fsdp_args, **fsdp_kwargs):
         model = FSDP(
-            LinearMixedPrecision(param_dtype).cuda(), *fsdp_args, **fsdp_kwargs
+            LinearMixedPrecision(param_dtype).to(device_type), *fsdp_args, **fsdp_kwargs
         )
         return model
 
@@ -344,7 +346,7 @@ class TestFSDPMixedPrecision(FSDPTest):
             def forward(self, x):
                 return self.lin2(self.lin1(x))
 
-        m = MyModel().cuda()
+        m = MyModel().to(device_type)
         mp = MixedPrecision(
             param_dtype=torch.float16,
             reduce_dtype=torch.float16,
@@ -377,7 +379,7 @@ class TestFSDPMixedPrecision(FSDPTest):
         sharding_strategy,
         enable_sharded_grad_scaler,
     ):
-        torch.cuda.set_device(self.rank)
+        torch.get_device_module(device_type).set_device(self.rank)
         fsdp_models = [
             self._get_simple_model(
                 param_dtype=full_precision_param_dtype,
@@ -399,7 +401,7 @@ class TestFSDPMixedPrecision(FSDPTest):
         ]
         for model in fsdp_models:
             if not cpu_offload.offload_params:
-                model.cuda()
+                model.to(device_type)
 
             # Patch reduce_scatter to add validation for mixed precision types.
             orig_reduce_scatter = dist.reduce_scatter_tensor
@@ -415,7 +417,7 @@ class TestFSDPMixedPrecision(FSDPTest):
 
                 for _ in range(3):
                     inp = torch.randn(
-                        3, 10, device="cuda", dtype=full_precision_param_dtype
+                        3, 10, device=device_type, dtype=full_precision_param_dtype
                     )
                     # Forward pass of LinearMixedPrecision check casting of
                     # inputs, params, buffers.
@@ -590,11 +592,11 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
             fsdp_model = FSDP(model, mixed_precision=mp_config)
             optim = torch.optim.SGD(fsdp_model.parameters(), lr=0.1)
             for _ in range(6):
-                inp = fsdp_model.module.get_input(torch.device("cuda"))
+                inp = fsdp_model.module.get_input(torch.device(device_type))
                 # This would fail if we casted integer module inputs such as for
                 # embedding tables.
                 output = fsdp_model(*inp)
-                loss = fsdp_model.module.get_loss(inp, output).cuda()
+                loss = fsdp_model.module.get_loss(inp, output).to(device_type)
                 self.assertEqual(loss.dtype, param_dtype)
                 fsdp_model.module.run_backward(loss)
                 optim.step()
@@ -641,14 +643,14 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
         End to end test to ensure mixed precision + auto_wrap works
         for ResNet model.
         """
-        resnet_model = torchvision.models.resnet50().cuda()
+        resnet_model = torchvision.models.resnet50().to(device_type)
         resnet_model = nn.SyncBatchNorm.convert_sync_batchnorm(
             resnet_model, process_group=dist.distributed_c10d._get_default_group()
         )
         n_bn = sum(
             1 if isinstance(x, _BatchNorm) else 0 for x in resnet_model.modules()
         )
-        inp = torch.ones(1, 3, 1000, 1000, device="cuda")
+        inp = torch.ones(1, 3, 1000, 1000, device=device_type)
         mp_config = MixedPrecision(
             param_dtype=torch.float16,
             reduce_dtype=torch.float16,
@@ -707,7 +709,7 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
         def never_wrap_policy(*args, **kwargs):
             return False
 
-        net = BatchNormNet().cuda()
+        net = BatchNormNet().to(device_type)
         if convert_sync_bn:
             net = nn.SyncBatchNorm.convert_sync_batchnorm(net)
         # FSDP detects that mixed precision + batchnorm will cause issues
@@ -740,7 +742,7 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
         # Overall mixed precision is still enabled
         self.assertEqual(mp_config, model.mixed_precision)
 
-        inp = torch.randn((1, 2), device="cuda")
+        inp = torch.randn((1, 2), device=device_type)
         # Without FSDP BN mixed precision fix, this would result in
         # RuntimeError: Expected counts to have type Half but got Float
         # for syncBN
@@ -781,7 +783,7 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
             os.environ["FSDP_USE_FULL_PREC_IN_EVAL"] = (
                 "1" if use_full_prec_in_eval else "0"
             )
-            m = MyModel().cuda()
+            m = MyModel().to(device_type)
             m.a = FSDP(m.a, mixed_precision=mp_config)
             model = FSDP(m, mixed_precision=mp_config)
             model.eval()
@@ -812,9 +814,9 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
                 DEVICEInitMode.DEVICE_BEFORE,
                 {"mixed_precision": mp_config},
             )
-            inp = model.get_input(torch.device("cuda"))
+            inp = model.get_input(torch.device(device_type))
             output = model(*inp)
-            loss = model.get_loss(inp, output).cuda()
+            loss = model.get_loss(inp, output).to(device_type)
             # Loss should be in fp16
             self.assertEqual(torch.float16, loss.dtype)
             model.run_backward(loss)
@@ -825,9 +827,9 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
 
             # Now in eval mode, loss should be fp32 if use_full_prec_in_eval is set.
             model.eval()
-            inp = model.get_input(torch.device("cuda"))
+            inp = model.get_input(torch.device(device_type))
             output = model(*inp)
-            loss = model.get_loss(inp, output).cuda()
+            loss = model.get_loss(inp, output).to(device_type)
             expected_dtype = torch.float32 if use_full_prec_in_eval else torch.float16
             self.assertEqual(expected_dtype, loss.dtype)
 
@@ -857,7 +859,7 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
                 mixed_precision=mp_config,
             )
 
-            inp = torch.randn(3, 10, device="cuda")
+            inp = torch.randn(3, 10, device=device_type)
             fsdp_model((inp, self, fsdp_model, mp_config, torch.float32))
             for buf in fsdp_model.buffers():
                 self.assertEqual(torch.float16, buf.dtype)
@@ -937,9 +939,9 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
             )
             model.eval()
             with patch_reduce_scatter(test_reduce_scatter, torch.float32):
-                inp = model.get_input(torch.device("cuda"))
+                inp = model.get_input(torch.device(device_type))
                 output = model(*inp)
-                loss = model.get_loss(inp, output).cuda()
+                loss = model.get_loss(inp, output).to(device_type)
                 model.run_backward(loss)
 
     @skip_if_lt_x_gpu(2)
@@ -976,14 +978,14 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
             model,
             sharding_strategy=sharding_strategy,
             mixed_precision=mixed_precision,
-            device_id=torch.cuda.current_device(),
+            device_id=torch.accelerator.current_device(),
             use_orig_params=use_orig_params,
         )
         # Use an input with dtype not equal to the mixed precision
         # `param_dtype` so that it gets cast
         x_float = torch.randn(
             (32, 1024),
-            device="cuda",
+            device=device_type,
             dtype=torch.float32,
             requires_grad=True,
         )
@@ -1018,7 +1020,7 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
             nn.Sequential(NonLearnableConv((1, 2, 2, 1), 64)),
             nn.Sequential(nn.Conv2d(64, 3, 3, padding=1)),
             nn.Sequential(NonLearnableConv((1, 2, 2, 1), 3)),
-        ).cuda()
+        ).to(device_type)
 
         dtype = torch.float16
         model = FSDP(
@@ -1035,7 +1037,7 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
         )
 
         # Check that we can run forward/backward without dtype errors
-        x = torch.randn(2, 3, 128, 128, device="cuda")
+        x = torch.randn(2, 3, 128, 128, device=device_type)
         out = model(x)
         out.mean().backward()
 
@@ -1115,7 +1117,7 @@ class TestFSDPMixedPrecisionIgnoredModules(FSDPTest):
 
     @skip_if_lt_x_gpu(1)
     def test_mixed_precision_with_ignored_module(self):
-        model = ModelWithIgnoredModule().cuda()
+        model = ModelWithIgnoredModule().to(device_type)
         float16 = MixedPrecision(param_dtype=torch.float16)
         model = FSDP(
             model,
@@ -1123,7 +1125,7 @@ class TestFSDPMixedPrecisionIgnoredModules(FSDPTest):
             mixed_precision=float16,
         )
 
-        x = torch.ones(2, 100, device=torch.cuda.current_device())
+        x = torch.ones(2, 100, device=torch.get_device_module(device_type).current_device())
 
         with self.assertRaisesRegex(RuntimeError, "must have the same dtype"):
             model(x).sum().backward()
@@ -1142,9 +1144,9 @@ class TestFSDPDifferentSubmodulePrecision(FSDPTest):
         model = SaveForwardInputsModel(
             forward_inputs,
             cast_forward_inputs=False,
-        ).cuda()
+        ).to(device_type)
         c1, c2 = model.c1, model.c2
-        x = torch.zeros(2, 100, device="cuda")
+        x = torch.zeros(2, 100, device=device_type)
 
         # float16 on one submodule and float32 on everything else
         model.c2 = FSDP(model.c2, mixed_precision=float16)
@@ -1163,9 +1165,9 @@ class TestFSDPDifferentSubmodulePrecision(FSDPTest):
 
         model = SaveForwardInputsModel(
             forward_inputs=forward_inputs, cast_forward_inputs=True
-        ).cuda()
+        ).to(device_type)
         c1, c2 = model.c1, model.c2
-        x = torch.zeros(2, 100, device="cuda")
+        x = torch.zeros(2, 100, device=device_type)
 
         # float16 on one submodule and float32 on everything else
         model.c2 = FSDP(model.c2, mixed_precision=float16)
@@ -1184,8 +1186,8 @@ class TestFSDPDifferentSubmodulePrecision(FSDPTest):
 
         model = SaveForwardInputsModel(
             forward_inputs=forward_inputs, cast_forward_inputs=False
-        ).cuda()
-        x = torch.zeros(2, 100, device="cuda")
+        ).to(device_type)
+        x = torch.zeros(2, 100, device=device_type)
 
         # float16 on one submodule and float32 on everything else
         model.c2 = FSDP(model.c2, mixed_precision=float16)
@@ -1204,8 +1206,8 @@ class TestFSDPDifferentSubmodulePrecision(FSDPTest):
 
         model = SaveForwardInputsModel(
             forward_inputs=forward_inputs, cast_forward_inputs=False
-        ).cuda()
-        x = torch.zeros(2, 100, device="cuda")
+        ).to(device_type)
+        x = torch.zeros(2, 100, device=device_type)
 
         # For submodules with different precisions, right now current design
         # does not support the case when the root FSDP instance wraps a submodule
@@ -1228,9 +1230,9 @@ class TestFSDPDifferentSubmodulePrecision(FSDPTest):
 
         model = SaveForwardInputsModel(
             forward_inputs=forward_inputs, cast_forward_inputs=False
-        ).cuda()
+        ).to(device_type)
         c1, c2 = model.c1, model.c2
-        x = torch.zeros(2, 100, device="cuda")
+        x = torch.zeros(2, 100, device=device_type)
 
         model.c2 = FSDP(model.c2, mixed_precision=float16)
         fsdp = FSDP(model, mixed_precision=float32)
@@ -1263,14 +1265,14 @@ class TestFSDPDifferentSubmodulePrecision(FSDPTest):
 
             def forward(self, x: torch.Tensor) -> torch.Tensor:
                 self.forward_inputs["model_input_x"] = x
-                y = torch.ones(2, 100, device="cuda", dtype=torch.float32)
+                y = torch.ones(2, 100, device=device_type, dtype=torch.float32)
                 return self.l2(self.l1(x), y)
 
         forward_inputs: dict[str, torch.Tensor] = {}
 
         float16 = MixedPrecision(param_dtype=torch.float16)
-        model = ToyModel(forward_inputs).cuda()
-        x = torch.zeros(2, 100, device="cuda", dtype=torch.float32)
+        model = ToyModel(forward_inputs).to(device_type)
+        x = torch.zeros(2, 100, device=device_type, dtype=torch.float32)
         model.l2 = FSDP(model.l2, mixed_precision=float16)
         fsdp = FSDP(model, mixed_precision=float16)
 
@@ -1325,7 +1327,7 @@ class TestFSDPTrainEval(FSDPTest):
                     return self.module(*args, **kwargs)
                 return self.ema_module(*args, **kwargs)
 
-        device = torch.device("cuda")
+        device = torch.device(device_type)
         model = TransformerWithEMA(device=device)
         policy = ModuleWrapPolicy(
             {nn.Transformer, nn.TransformerEncoderLayer, nn.TransformerDecoderLayer}

--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -16,7 +16,11 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
 )
+from torch.testing._internal.inductor_utils import HAS_GPU
 
+device_type = (
+    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+)
 
 try:
     from . import test_functions
@@ -208,22 +212,22 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertTrue(same(ref, res))
         self.assertEqual(cnts.frame_count, 2)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_stream_context_manager1(self):
+    @unittest.skipIf(not HAS_GPU, "requires GPU")
+    def test_gpu_stream_context_manager1(self):
         def fn(x):
-            s = torch.cuda.Stream()
+            s = torch.Stream()
             x = torch.mul(x, 5)
             x = torch.add(x, 2)
-            current_stream = torch.cuda.current_stream()
+            current_stream = torch.accelerator.current_stream()
             s.wait_stream(current_stream)
-            with torch.cuda.stream(s):
+            with s:
                 x = torch.relu(x)
             current_stream.wait_stream(s)
             x = torch.add(x, 1)
             x = torch.cos(x)
             return x
 
-        x = torch.randn((2, 2), device="cuda")
+        x = torch.randn((2, 2), device=device_type)
         ref = fn(x)
         cnts = torch._dynamo.testing.CompileCounter()
         opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
@@ -233,17 +237,17 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnts.op_count, 12)
 
     @unittest.expectedFailure  # https://github.com/pytorch/pytorch/issues/118204
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_stream_across_graph_break(self):
+    @unittest.skipIf(not HAS_GPU, "requires GPU")
+    def test_gpu_stream_across_graph_break(self):
         def fn(x):
-            s = torch.cuda.Stream()
+            s = torch.Stream()
             x = torch.mul(x, 5)
             x = torch.add(x, 2)
 
             print("foo")
 
-            tcs = torch.cuda.stream(s)
-            current_stream = torch.cuda.current_stream()
+            tcs = s
+            current_stream = torch.accelerator.current_stream()
             s.wait_stream(current_stream)
 
             with tcs:
@@ -254,7 +258,7 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
             x = torch.cos(x)
             return x
 
-        x = torch.randn((2, 2), device="cuda")
+        x = torch.randn((2, 2), device=device_type)
         ref = fn(x)
         cnts = torch._dynamo.testing.CompileCounter()
         opt_fn = torch.compile(fn, backend=cnts)
@@ -264,25 +268,25 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnts.op_count, 9)
 
     @unittest.expectedFailure  # https://github.com/pytorch/pytorch/issues/118204
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_stream_context_manager2(self):
+    @unittest.skipIf(not HAS_GPU, "requires GPU")
+    def test_gpu_stream_context_manager2(self):
         def fn(x, s):
             x = torch.mul(x, 5)
             x = torch.add(x, 2)
 
-            current_stream = torch.cuda.current_stream()
+            current_stream = torch.accelerator.current_stream()
             s.wait_stream(current_stream)
 
-            with torch.cuda.stream(s):
+            with s:
                 x = torch.relu(x)
 
             current_stream.wait_stream(s)
-            with torch.cuda.stream(current_stream):
+            with current_stream:
                 x = torch.relu(x)
 
-            s2 = torch.cuda.Stream()
+            s2 = torch.Stream()
             s2.wait_stream(current_stream)
-            with torch.cuda.stream(s2):
+            with s2:
                 x = torch.relu(x)
 
             current_stream.wait_stream(s2)
@@ -290,8 +294,8 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
             x = torch.cos(x)
             return x
 
-        x = torch.randn((2, 2), device="cuda")
-        s = torch.cuda.Stream()
+        x = torch.randn((2, 2), device=device_type)
+        s = torch.Stream()
         ref = fn(x, s)
         cnts = torch._dynamo.testing.CompileCounter()
         opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
@@ -300,17 +304,17 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnts.frame_count, 1)
         self.assertEqual(cnts.op_count, 18)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_stream_method(self):
+    @unittest.skipIf(not HAS_GPU, "requires GPU")
+    def test_gpu_stream_method(self):
         def fn(x):
             x = torch.mul(x, 1)
             x = torch.add(x, 2)
 
-            new_stream = torch.cuda.Stream()
-            cur_stream = torch.cuda.current_stream()
+            new_stream = torch.Stream()
+            cur_stream = torch.accelerator.current_stream()
             new_stream.wait_stream(cur_stream)
 
-            with torch.cuda.stream(new_stream):
+            with new_stream:
                 x = torch.sin(x)
                 x = torch.add(x, 3)
 
@@ -320,7 +324,7 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
             cur_stream.query()
             cur_stream.synchronize()
 
-            with torch.cuda.stream(new_stream):
+            with new_stream:
                 x = torch.add(x, 5)
             new_stream.synchronize()
 
@@ -328,7 +332,7 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
             x = torch.cos(x)
             return x
 
-        x = torch.randn((2, 2), device="cuda")
+        x = torch.randn((2, 2), device=device_type)
         ref = fn(x)
         cnts = torch._dynamo.testing.CompileCounter()
         opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
@@ -337,13 +341,13 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnts.frame_count, 1)
         self.assertEqual(cnts.op_count, 21)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_stream_compared_with_constant(self):
+    @unittest.skipIf(not HAS_GPU, "requires GPU")
+    def test_gpu_stream_compared_with_constant(self):
         def fn(x):
             x = torch.mul(x, 1)
             x = torch.add(x, 2)
 
-            cur_stream = torch.cuda.current_stream()
+            cur_stream = torch.accelerator.current_stream()
             if cur_stream is not None:
                 return x + 1
             return x - 1
@@ -352,12 +356,12 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
             x = torch.mul(x, 1)
             x = torch.add(x, 2)
 
-            cur_stream = torch.cuda.current_stream()
+            cur_stream = torch.accelerator.current_stream()
             if cur_stream != "const_str":
                 return x + 1
             return x - 1
 
-        x = torch.randn((2, 2), device="cuda")
+        x = torch.randn((2, 2), device=device_type)
         ref = fn(x)
         cnts = torch._dynamo.testing.CompileCounter()
         opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
@@ -367,16 +371,16 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(ref, res)
         self.assertEqual(ref, res2)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_stream_compared_with_stream(self):
+    @unittest.skipIf(not HAS_GPU, "requires GPU")
+    def test_gpu_stream_compared_with_stream(self):
         def fn(x, s0, s1):
             if s0 == s1:
                 return x + 1
             else:
                 return x - 1
 
-        s0 = torch.cuda.Stream()
-        s1 = torch.cuda.Stream()
+        s0 = torch.Stream()
+        s1 = torch.Stream()
         x = torch.randn(2, 2)
         cnts = torch._dynamo.testing.CompileCounter()
         opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
@@ -407,15 +411,15 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnts.frame_count, 2)
         self.assertEqual(ref0, res0)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_event_reconstruct(self):
+    @unittest.skipIf(not HAS_GPU, "requires GPU")
+    def test_gpu_event_reconstruct(self):
         def fn(x):
-            e = torch.cuda.Event()
+            e = torch.Event()
             x = torch.mul(x, 5)
             x = torch.add(x, 2)
             return x, e
 
-        x = torch.randn((2, 2), device="cuda")
+        x = torch.randn((2, 2), device=device_type)
         ref = fn(x)
         cnts = torch._dynamo.testing.CompileCounter()
         opt_fn = torch.compile(fn, backend=cnts)
@@ -424,22 +428,22 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnts.frame_count, 1)
         self.assertEqual(cnts.op_count, 3)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_event_across_graph_break(self):
+    @unittest.skipIf(not HAS_GPU, "requires GPU")
+    def test_gpu_event_across_graph_break(self):
         def fn(x):
-            e = torch.cuda.Event()
+            e = torch.Event()
             e.record()
             x = torch.mul(x, 5)
             x = torch.add(x, 2)
 
             print("foo")
 
-            torch.cuda.current_stream().wait_event(e)
+            torch.accelerator.current_stream().wait_event(e)
             x = torch.add(x, 1)
             x = torch.cos(x)
             return x, e
 
-        x = torch.randn((2, 2), device="cuda")
+        x = torch.randn((2, 2), device=device_type)
         ref = fn(x)
         cnts = torch._dynamo.testing.CompileCounter()
         opt_fn = torch.compile(fn, backend=cnts)
@@ -448,30 +452,30 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnts.frame_count, 2)
         self.assertEqual(cnts.op_count, 9)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_event_created_outside_of_graph(self):
-        user_stream = torch.cuda.Stream()
-        event = torch.cuda.Event()
-        foo = torch.empty((2, 2), device="cuda")
+    @unittest.skipIf(not HAS_GPU, "requires GPU")
+    def test_gpu_event_created_outside_of_graph(self):
+        user_stream = torch.Stream()
+        event = torch.Event()
+        foo = torch.empty((2, 2), device=device_type)
 
         def func(foo):
             event.wait()
             return foo + 1, event
 
-        x = torch.randn((1024, 1024), device="cuda")
+        x = torch.randn((1024, 1024), device=device_type)
         cnts = torch._dynamo.testing.CompileCounter()
 
         def run_iters(fn, compile=False):
             if compile:
                 fn = torch.compile(fn, backend=cnts)
             for _ in range(10):
-                with torch.cuda.stream(user_stream):
+                with user_stream:
                     torch.mm(x, x, out=foo)
                     event.record()
                 out = fn(foo)
                 # let `fn` finish reading `foo` before writing to it in the next
                 # iteration or `run_iters` call.
-                torch.cuda.current_stream().synchronize()
+                torch.accelerator.current_stream().synchronize()
             return out
 
         ref = run_iters(func, compile=False)
@@ -480,8 +484,8 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnts.frame_count, 1)
         self.assertEqual(cnts.op_count, 3)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_event_method_create_stream_outside_of_compile(self):
+    @unittest.skipIf(not HAS_GPU, "requires GPU")
+    def test_gpu_event_method_create_stream_outside_of_compile(self):
         def fn(x, cur_stream, new_stream):
             x = torch.mul(x, 1)
             x = torch.add(x, 2)
@@ -492,10 +496,10 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
             event.query()
 
             new_stream.wait_event(event)
-            with torch.cuda.stream(new_stream):
+            with new_stream:
                 x = torch.add(x, 4)
 
-            new_event = torch.cuda.Event()
+            new_event = torch.Event()
             new_event.record(new_stream)
 
             new_event.wait(cur_stream)
@@ -508,9 +512,9 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
             x = torch.cos(x)
             return x
 
-        x = torch.randn((2, 2), device="cuda")
-        cur_stream = torch.cuda.current_stream()
-        new_stream = torch.cuda.Stream()
+        x = torch.randn((2, 2), device=device_type)
+        cur_stream = torch.accelerator.current_stream()
+        new_stream = torch.Stream()
         ref = fn(x, cur_stream, new_stream)
         cnts = torch._dynamo.testing.CompileCounter()
         opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
@@ -519,14 +523,14 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnts.frame_count, 1)
         self.assertEqual(cnts.op_count, 19)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_event_method(self):
+    @unittest.skipIf(not HAS_GPU, "requires GPU")
+    def test_gpu_event_method(self):
         def fn(x):
             x = torch.mul(x, 1)
             x = torch.add(x, 2)
 
-            cur_stream = torch.cuda.current_stream()
-            new_stream = torch.cuda.Stream()
+            cur_stream = torch.accelerator.current_stream()
+            new_stream = torch.Stream()
 
             x = torch.add(x, 3)
 
@@ -534,10 +538,10 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
             event.query()
 
             new_stream.wait_event(event)
-            with torch.cuda.stream(new_stream):
+            with new_stream:
                 x = torch.add(x, 4)
 
-            new_event = torch.cuda.Event()
+            new_event = torch.Event()
             new_event.record(new_stream)
 
             new_event.wait(cur_stream)
@@ -550,7 +554,7 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
             x = torch.cos(x)
             return x
 
-        x = torch.randn((2, 2), device="cuda")
+        x = torch.randn((2, 2), device=device_type)
         ref = fn(x)
         cnts = torch._dynamo.testing.CompileCounter()
         opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
@@ -559,14 +563,14 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnts.frame_count, 1)
         self.assertEqual(cnts.op_count, 19)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_device(self):
+    @unittest.skipIf(not HAS_GPU, "requires GPU")
+    def test_gpu_device(self):
         def fn(x):
-            with torch.cuda.device(x.device.index - 1):
+            with torch.accelerator.device_index(x.device.index - 1):
                 x = torch.sin(x + 1)
             return x
 
-        x = torch.randn((2, 2), device="cuda")
+        x = torch.randn((2, 2), device=device_type)
         ref = fn(x)
         opt_fn = torch.compile(backend="eager", fullgraph=True)(fn)
         res = opt_fn(x)
@@ -596,18 +600,18 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
             res = opt_fn(x)
             self.assertTrue(same(ref, res))
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
+    @unittest.skipIf(not HAS_GPU, "requires GPU")
     def test_autocast(self):
-        if not torch.cuda.is_bf16_supported():
+        if not torch.get_device_module(device_type).is_bf16_supported():
             raise unittest.SkipTest("requires bf16")
 
         class MyModule(torch.nn.Module):
             def forward(self, x):
-                a_float32 = torch.rand((8, 8), device="cuda")
-                b_float32 = torch.rand((8, 8), device="cuda")
-                d_float32 = torch.rand((8, 8), device="cuda")
+                a_float32 = torch.rand((8, 8), device=device_type)
+                b_float32 = torch.rand((8, 8), device=device_type)
+                d_float32 = torch.rand((8, 8), device=device_type)
 
-                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                with torch.autocast(device_type=device_type, dtype=torch.bfloat16):
                     e_float16 = torch.mm(a_float32, b_float32)
                     f_float16 = torch.mm(d_float32, e_float16)
                 return f_float16
@@ -622,18 +626,18 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(exported.device, real_device)
         self.assertEqual(exported.dtype, real_dtype)
 
-        self.assertEqual(exported.device.type, "cuda")
+        self.assertEqual(exported.device.type, device_type)
         self.assertEqual(exported.device.index, 0)
         self.assertEqual(exported.dtype, torch.bfloat16)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_amp_autocast(self):
+    @unittest.skipIf(not HAS_GPU, "requires GPU")
+    def test_gpu_amp_autocast(self):
         class MyModule(torch.nn.Module):
             def forward(self, x):
-                a_float32 = torch.rand((8, 8), device="cuda")
-                b_float32 = torch.rand((8, 8), device="cuda")
+                a_float32 = torch.rand((8, 8), device=device_type)
+                b_float32 = torch.rand((8, 8), device=device_type)
 
-                with torch.autocast(device_type="cuda", dtype=torch.float64):
+                with torch.autocast(device_type=device_type, dtype=torch.float64):
                     c_float64 = torch.mm(a_float32, b_float32)
                 return c_float64
 
@@ -647,7 +651,7 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(exported.device, real_device)
         self.assertEqual(exported.dtype, real_dtype)
 
-        self.assertEqual(exported.device.type, "cuda")
+        self.assertEqual(exported.device.type, device_type)
         self.assertEqual(exported.device.index, 0)
         self.assertEqual(exported.dtype, torch.float64)
 
@@ -674,7 +678,7 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         class MyModule(torch.nn.Module):
             def forward(self, query, key, value):
                 with torch.autocast("cpu"):
-                    with torch.autocast("cuda", dtype=torch.float32):
+                    with torch.autocast(device_type, dtype=torch.float32):
                         out = F.scaled_dot_product_attention(
                             query, key, value, None, 0.0, True
                         )
@@ -685,13 +689,13 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         seq_len_k = 1
         head_dim = 8
         query = torch.ones(
-            1, 8, seq_len_q, head_dim, device="cuda", dtype=dtype, requires_grad=True
+            1, 8, seq_len_q, head_dim, device=device_type, dtype=dtype, requires_grad=True
         )
         key = torch.ones(
-            1, 8, seq_len_k, head_dim, device="cuda", dtype=dtype, requires_grad=True
+            1, 8, seq_len_k, head_dim, device=device_type, dtype=dtype, requires_grad=True
         )
         value = torch.ones(
-            1, 8, seq_len_k, head_dim, device="cuda", dtype=dtype, requires_grad=True
+            1, 8, seq_len_k, head_dim, device=device_type, dtype=dtype, requires_grad=True
         )
 
         module = MyModule()
@@ -705,7 +709,7 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(compiled.device, real_device)
         self.assertEqual(compiled.dtype, real_dtype)
 
-        self.assertEqual(compiled.device.type, "cuda")
+        self.assertEqual(compiled.device.type, device_type)
         self.assertEqual(compiled.device.index, 0)
         self.assertEqual(compiled.dtype, torch.float32)
 
@@ -882,15 +886,15 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(out_32.device.type, "cpu")
         self.assertEqual(out_32.dtype, torch.float32)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
+    @unittest.skipIf(not HAS_GPU, "requires GPU")
     def test_autocast_float64(self):
         class MyModule(torch.nn.Module):
             def forward(self, x):
-                a_float32 = torch.rand((8, 8), device="cuda")
-                b_float32 = torch.rand((8, 8), device="cuda")
-                d_float32 = torch.rand((8, 8), device="cuda")
+                a_float32 = torch.rand((8, 8), device=device_type)
+                b_float32 = torch.rand((8, 8), device=device_type)
+                d_float32 = torch.rand((8, 8), device=device_type)
 
-                with torch.autocast(device_type="cuda", dtype=torch.float64):
+                with torch.autocast(device_type=device_type, dtype=torch.float64):
                     e_float64 = torch.mm(a_float32, b_float32)
                     f_float64 = torch.mm(d_float32, e_float64)
                 return f_float64
@@ -908,15 +912,15 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(exported.device.index, 0)
         self.assertEqual(exported.dtype, torch.float64)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
+    @unittest.skipIf(not HAS_GPU, "requires GPU")
     def test_autocast_device(self):
         class MyModule(torch.nn.Module):
             def forward(self, x):
-                a_float32 = torch.rand((8, 8), device="cuda")
-                b_float32 = torch.rand((8, 8), device="cuda")
-                d_float32 = torch.rand((8, 8), device="cuda")
+                a_float32 = torch.rand((8, 8), device=device_type)
+                b_float32 = torch.rand((8, 8), device=device_type)
+                d_float32 = torch.rand((8, 8), device=device_type)
 
-                with torch.autocast("cuda"):
+                with torch.autocast(device_type):
                     e_float64 = torch.mm(a_float32, b_float32)
                     f_float64 = torch.mm(d_float32, e_float64)
                 return f_float64
@@ -934,10 +938,10 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(exported.device.index, 0)
         self.assertEqual(exported.dtype, torch.float16)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
+    @unittest.skipIf(not HAS_GPU, "requires GPU")
     def test_autocast_arguments_binding(self):
         def f1(x):
-            with torch.autocast(device_type="cuda", enabled=False):
+            with torch.autocast(device_type=device_type, enabled=False):
                 x = torch.sin(x + 1)
             return x
 
@@ -956,17 +960,17 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertTrue(same(ref1, res1))
         self.assertTrue(same(ref2, res2))
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
+    @unittest.skipIf(not HAS_GPU, "requires GPU")
     def test_autocast_decorator(self):
         def autocast_func(orig_func):
-            @torch.amp.autocast(device_type="cuda", dtype=torch.float16)
+            @torch.amp.autocast(device_type=device_type, dtype=torch.float16)
             def new_fwd(*args, **kwargs):
                 return orig_func(*args, **kwargs)
 
             return new_fwd
 
-        def autocast_func_cuda(orig_func):
-            @torch.autocast(device_type="cuda", dtype=torch.float16)
+        def autocast_func_gpu(orig_func):
+            @torch.autocast(device_type=device_type, dtype=torch.float16)
             def new_fwd(*args, **kwargs):
                 return orig_func(*args, **kwargs)
 
@@ -983,14 +987,14 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
             return torch.mm(a, b)
 
         mm_float16 = autocast_func(mm)
-        mm_float16_cuda = autocast_func_cuda(mm)
+        mm_float16_gpu = autocast_func_gpu(mm)
         mm_float16_cpu = autocast_func_cpu(mm)
 
         def fn(a, b):
-            return mm_float16(a, b), mm_float16_cuda(a, b), mm_float16_cpu(a, b)
+            return mm_float16(a, b), mm_float16_gpu(a, b), mm_float16_cpu(a, b)
 
-        a_float32 = torch.rand((8, 8), device="cuda")
-        b_float32 = torch.rand((8, 8), device="cuda")
+        a_float32 = torch.rand((8, 8), device=device_type)
+        b_float32 = torch.rand((8, 8), device=device_type)
 
         ref = fn(a_float32, b_float32)
         opt_fn = torch.compile(backend="eager", fullgraph=True)(fn)
@@ -1239,9 +1243,13 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(ref, res)
 
     def test_graph_break_inlining_autocast(self):
-        for device in ["cuda", "cpu"]:
+        for device in ["cuda", "cpu", "xpu"]:
             if device == "cuda" and not (
                 torch.cuda.is_available() and torch.cuda.is_bf16_supported()
+            ):
+                continue
+            elif device == "xpu" and not (
+                torch.xpu.is_available() and torch.xpu.is_bf16_supported()
             ):
                 continue
             self._graph_break_inlining_autocast_test_helper(device)

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -4084,7 +4084,7 @@ class GraphModule(torch.nn.Module):
 
         f5()
         new_device = (
-            "cpu" if torch._C._get_accelerator() in (torch.device("cuda"), torch.device("xpu")) else "cuda, xpu"
+            "cpu" if torch._C._get_accelerator() == torch.device(device_type) else device_type
         )
 
         old_get_device_module = torch.get_device_module
@@ -4098,7 +4098,7 @@ class GraphModule(torch.nn.Module):
         # torch.get_device_module
         with patch("torch.get_device_module", new_get_device_module):
             print(torch.get_device_module())
-            self.assertTrue(f5() in getattr(torch, new_device))
+            self.assertEqual(f5(), getattr(torch, new_device))
 
         # synchronize causes a graph break, so no fullgraph=True
         @torch.compile(backend="eager")

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -4084,7 +4084,7 @@ class GraphModule(torch.nn.Module):
 
         f5()
         new_device = (
-            ("cpu",) if torch._C._get_accelerator() in (torch.device("cuda"), torch.device("xpu")) else ("cuda", "xpu")
+            "cpu" if torch._C._get_accelerator() in (torch.device("cuda"), torch.device("xpu")) else "cuda, xpu"
         )
 
         old_get_device_module = torch.get_device_module

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -4083,10 +4083,10 @@ class GraphModule(torch.nn.Module):
             return torch.get_device_module()
 
         f5()
-        new_device = (
-            "cpu" if torch._C._get_accelerator() == torch.device("cuda") else "cuda"
-        )
-
+        if torch._C._get_accelerator() == torch.device("cuda"):
+            new_device = "cuda"
+        else:
+            new_device = "cpu"
         old_get_device_module = torch.get_device_module
 
         def new_get_device_module(device=None):
@@ -4733,12 +4733,12 @@ class DefaultsTests(torch._dynamo.test_case.TestCase):
             opt_fn(x, ys, zs[:1])
 
     @unittest.skipIf(not TEST_MULTIGPU, "detected only one GPU")
-    def test_gpu_current_device(self):
+    def test_cuda_current_device(self):
         def fn(x):
             y = torch.empty(
-                (2, 3),
-                dtype=torch.float32,
-                device=torch.accelerator.current_device_index(),
+                (2, 3), 
+                dtype=torch.float32, 
+                device=torch.cuda.current_device(),
             )
             y.copy_(x)
             return torch.sin(y + y.device.index)

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -4091,14 +4091,14 @@ class GraphModule(torch.nn.Module):
 
         def new_get_device_module(device=None):
             if device:
-                return (old_get_device_module(device),)
+                return old_get_device_module(device)
             return getattr(torch, new_device)
 
         # NOTE: torch.get_device_module.__wrapped__ is guarded on, but not
         # torch.get_device_module
         with patch("torch.get_device_module", new_get_device_module):
             print(torch.get_device_module())
-            self.assertTrue(f5() in getattr(torch, new_get_device_module))
+            self.assertTrue(f5() in getattr(torch, new_device))
 
         # synchronize causes a graph break, so no fullgraph=True
         @torch.compile(backend="eager")

--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -39,7 +39,12 @@ from torch.testing._internal.common_utils import (
 )
 from torch.testing._internal.hop_db import hop_db
 from torch.testing._internal.logging_utils import LoggingTestCase, make_logging_test
-from torch.testing._internal.triton_utils import requires_cuda_and_triton
+from torch.testing._internal.triton_utils import requires_gpu
+
+
+device_type = (
+    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+)
 
 
 def count_ops(gm, args, freq, op):
@@ -6834,7 +6839,7 @@ class ActivationCheckpointingTests(torch._dynamo.test_case.TestCase):
             for arg, cloned_arg in zip(args, cloned_args):
                 self.assertEqual(arg.grad, cloned_arg.grad)
 
-    @requires_cuda_and_triton
+    @requires_gpu
     @torch._functorch.config.patch(functionalize_rng_ops=True)
     def test_function(self):
         def gn(x, y):
@@ -6853,7 +6858,7 @@ class ActivationCheckpointingTests(torch._dynamo.test_case.TestCase):
         backend = aot_autograd(fw_compiler=fw_compiler, bw_compiler=bw_compiler)
         self._validate(fn, backend, x, y)
 
-    @requires_cuda_and_triton
+    @requires_gpu
     @torch._functorch.config.patch(functionalize_rng_ops=True)
     def test_function_with_kwargs(self):
         def gn(x, y):
@@ -6876,7 +6881,7 @@ class ActivationCheckpointingTests(torch._dynamo.test_case.TestCase):
         backend = aot_autograd(fw_compiler=fw_compiler, bw_compiler=bw_compiler)
         self._validate(fn, backend, x, y)
 
-    @requires_cuda_and_triton
+    @requires_gpu
     @torch._functorch.config.patch(functionalize_rng_ops=True)
     def test_dropout(self):
         def gn(x, y):
@@ -6887,8 +6892,8 @@ class ActivationCheckpointingTests(torch._dynamo.test_case.TestCase):
                 gn, torch.sin(x), y, use_reentrant=True
             )
 
-        x = torch.randn(4, 4, device="cuda", requires_grad=True)
-        y = torch.randn(4, 4, device="cuda", requires_grad=True)
+        x = torch.randn(4, 4, device=device_type, requires_grad=True)
+        y = torch.randn(4, 4, device=device_type, requires_grad=True)
 
         fw_compiler = functools.partial(
             count_ops, freq=1, op=torch.ops.rngprims.philox_rand.default
@@ -6902,7 +6907,7 @@ class ActivationCheckpointingTests(torch._dynamo.test_case.TestCase):
             fn, backend, x, y, skip_check=True
         )  # dropout decomp is known to diverge with eager
 
-    @requires_cuda_and_triton
+    @requires_gpu
     @torch._functorch.config.patch(functionalize_rng_ops=True)
     def test_dropout_inductor(self):
         def gn(x, y):
@@ -6913,15 +6918,15 @@ class ActivationCheckpointingTests(torch._dynamo.test_case.TestCase):
                 gn, torch.sin(x), y, use_reentrant=True
             )
 
-        x = torch.randn(4, 4, device="cuda", requires_grad=True)
-        y = torch.randn(4, 4, device="cuda", requires_grad=True)
+        x = torch.randn(4, 4, device=device_type, requires_grad=True)
+        y = torch.randn(4, 4, device=device_type, requires_grad=True)
 
         backend = "inductor"
         self._validate(
             fn, backend, x, y, skip_check=True
         )  # dropout decomp is known to diverge with eager
 
-    @requires_cuda_and_triton
+    @requires_gpu
     @torch._functorch.config.patch(functionalize_rng_ops=True)
     def test_fallback(self):
         def gn(x, y):
@@ -6952,7 +6957,7 @@ class ActivationCheckpointingTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnt.op_count, 2)
         self.assertEqual(len(backend.graphs), 2)
 
-    @requires_cuda_and_triton
+    @requires_gpu
     @torch._functorch.config.patch(functionalize_rng_ops=True)
     def test_module(self):
         class MockModule(torch.nn.Module):
@@ -7206,7 +7211,7 @@ xfail_hops_compile = {
 
 
 class TestHigherOrderOpsOpInfo(torch._dynamo.test_case.TestCase):
-    @requires_cuda_and_triton
+    @requires_gpu
     @parametrize("backend", ("aot_eager", "inductor"))
     @ops(
         list(filter(lambda op: op.name not in xfail_hops_compile, hop_db)),
@@ -7240,7 +7245,7 @@ class TestHigherOrderOpsOpInfo(torch._dynamo.test_case.TestCase):
             self.assertEqual(eager_out, compiled_out)
 
 
-instantiate_device_type_tests(TestHigherOrderOpsOpInfo, globals(), only_for=("cuda",))
+instantiate_device_type_tests(TestHigherOrderOpsOpInfo, globals(), only_for=("cuda", "xpu"), allow_xpu=True)
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -59,7 +59,6 @@ from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FP8,
     SM70OrLater,
     TEST_CUDA,
-    TEST_XPU,
 )
 from torch.testing._internal.common_device_type import (
     E4M3_MAX_POS,
@@ -73,6 +72,7 @@ from torch.testing._internal.common_utils import (
     skipIfHpu,
     skipIfWindows,
     TEST_WITH_ROCM,
+    TEST_XPU,
 )
 from torch.testing._internal.logging_utils import LoggingTestCase, make_logging_test
 from torch.testing._internal.two_tensor import TwoTensor


### PR DESCRIPTION
# Description
Fixes #114850, we will port dynamo, fsdp tests to Intel GPU
We could enable Intel GPU with following methods and try the best to keep the original code styles:

# Changes
1. Get device type with from accelerator and get_devtype helper method
2. Replace the requires cuda statement with requires_gpu.
3. Replace the cuda() with to(device_type).
4. Add is_xpu check into the test logic. 


# Notify
cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @ezyang @chenyang78 @mingfeima @sanchitintel @ashokei @jingxu10 @jerryzh168 @ipiszy @muchulee8 @aakhundov @coconutruben @gujinghui @fengyuan14 @guangyey