### PR TITLE
Update the heuristic for AArch64 bgemm

### DIFF
--- a/.ci/docker/common/install_openblas.sh
+++ b/.ci/docker/common/install_openblas.sh
@@ -4,7 +4,7 @@
 set -ex
 
 cd /
-git clone https://github.com/Mousius/OpenBLAS.git -b "bgemm-optimisation" --depth 1 --shallow-submodules
+git clone https://github.com/OpenMathLib/OpenBLAS.git -b "${OPENBLAS_VERSION:-v0.3.30}" --depth 1 --shallow-submodules
 
 OPENBLAS_CHECKOUT_DIR="OpenBLAS"
 OPENBLAS_BUILD_FLAGS="

--- a/.ci/docker/common/install_openblas.sh
+++ b/.ci/docker/common/install_openblas.sh
@@ -4,9 +4,10 @@
 set -ex
 
 cd /
-git clone https://github.com/OpenMathLib/OpenBLAS.git -b "${OPENBLAS_VERSION:-v0.3.30}" --depth 1 --shallow-submodules
+git clone https://github.com/OpenMathLib/OpenBLAS.git
 
 OPENBLAS_CHECKOUT_DIR="OpenBLAS"
+git -C "${OPENBLAS_CHECKOUT_DIR}" checkout 5e43ba948c3cb35864c7b0953b8dd02374dd3967
 OPENBLAS_BUILD_FLAGS="
 NUM_THREADS=128
 USE_OPENMP=1

--- a/.ci/docker/common/install_openblas.sh
+++ b/.ci/docker/common/install_openblas.sh
@@ -4,7 +4,7 @@
 set -ex
 
 cd /
-git clone https://github.com/OpenMathLib/OpenBLAS.git -b "${OPENBLAS_VERSION:-v0.3.30}" --depth 1 --shallow-submodules
+git clone https://github.com/Mousius/OpenBLAS.git -b "bgemm-optimisation" --depth 1 --shallow-submodules
 
 OPENBLAS_CHECKOUT_DIR="OpenBLAS"
 OPENBLAS_BUILD_FLAGS="

--- a/aten/src/ATen/native/CPUBlas.cpp
+++ b/aten/src/ATen/native/CPUBlas.cpp
@@ -20,6 +20,14 @@ extern "C" void dgemm_(char *transa, char *transb, int *m, int *n, int *k, doubl
 extern "C" void sgemm_(char *transa, char *transb, int *m, int *n, int *k, float *alpha, const float *a, int *lda, const float *b, int *ldb, float *beta, float *c, int *ldc);
 extern "C" void cgemm_(char *transa, char *transb, int *m, int *n, int *k, void *alpha, const void *a, int *lda, const void *b, int *ldb, void *beta, void *c, int *ldc);
 extern "C" void zgemm_(char *transa, char *transb, int *m, int *n, int *k, void *alpha, const void *a, int *lda, const void *b, int *ldb, void *beta, void *c, int *ldc);
+#ifdef BLAS_HAS_BGEMM
+extern "C" void bgemm_(char *transa, char *transb, int *m, int *n, int *k,
+                const at::BFloat16 *alpha,
+                const at::BFloat16 *a, int *lda,
+                const at::BFloat16 *b, int *ldb,
+                const at::BFloat16 *beta,
+                at::BFloat16 *c, int *ldc);
+#endif  // BLAS_HAS_BGEMM
 #ifdef BLAS_HAS_SBGEMM
 extern "C" void sbgemm_(char *transa, char *transb, int *m, int *n, int *k,
                 float *alpha,
@@ -339,7 +347,7 @@ void gemm(
 #ifdef __aarch64__
    // MKLDNN also supports ARM for bf16, and the bypass is only
    // currently intended for x86/x86_64.
-   const bool use_bf16_gemv_trans = false;
+   const bool use_bf16_gemv_trans = (m == 1 || n == 1);
 #elif defined(__powerpc__)
    const bool use_bf16_gemv_trans = false;
 #else
@@ -353,19 +361,30 @@ void gemm(
      return;
    }
 #endif
-#if AT_BUILD_WITH_BLAS() && defined(BLAS_HAS_SBGEMM)
+#if AT_BUILD_WITH_BLAS() && (defined(BLAS_HAS_SBGEMM) || defined(BLAS_HAS_BGEMM))
    if (use_blas_gemm(transa, transb, m, n, k, lda, ldb, ldc)) {
       int m_ = m, n_ = n, k_ = k, lda_ = lda, ldb_ = ldb, ldc_ = ldc;
       char transa_ = to_blas(transa), transb_ = to_blas(transb);
-      float alpha_ = alpha, beta_ = beta;
-      int c_size = n_ * m_;
+#if defined(BLAS_HAS_BGEMM)
+      at::BFloat16 alpha_ = c10::convert<at::BFloat16>(alpha);
+      at::BFloat16 beta_ = c10::convert<at::BFloat16>(beta);
+      bgemm_(&transa_, &transb_,
+             &m_, &n_, &k_,
+             &alpha_,
+             a, &lda_,
+             b, &ldb_,
+             &beta_,
+             c, &ldc_);
+#else
       // C matrix in OpenBLAS sbgemm are of type "float" so we have to convert, copy and copy back.
+      int c_size = n_ * m_;
       std::vector<float> float_v(c_size, 0.0f);
       for (const auto j : c10::irange(n)) {
         for (const auto i : c10::irange(m)) {
           float_v[j * m_ + i] = c10::convert<float>(c[j * ldc_ + i]);
         }
       }
+      float alpha_ = alpha, beta_ = beta;
       sbgemm_(&transa_, &transb_,
               &m_, &n_, &k_,
               &alpha_,
@@ -378,6 +397,7 @@ void gemm(
           c[j * ldc_ + i] = c10::convert<at::BFloat16>(float_v[j * m_ + i]);
         }
       }
+#endif // end of defined(BLAS_HAS_BGEMM)
       return;
    }
 #endif

--- a/aten/src/ATen/native/mkldnn/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/Matmul.cpp
@@ -157,7 +157,7 @@ mkldnn_gemm(
   bool bf32_usable = std::is_same_v<scalar_t, float> && use_mkldnn_bf32_matmul();
   bool tf32_usable = std::is_same_v<scalar_t, float> && use_mkldnn_tf32_matmul();
   if ( !(bf16_usable || fp16_usable || bf32_usable || tf32_usable) ||
-      ((m >= 16 && k >= 16) || (k <= 8 && n * m < 16384) || (m <= 8 && n <= 1024)) || (alpha == 0.0f)) {
+      ((n * m <= 16384) && (n * k >= 4 * 2048 / m)) || (m * n * k <= 16 * 16 * 16) || (alpha == 0.0f)) {
     return false;
   }
 

--- a/aten/src/ATen/native/mkldnn/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/Matmul.cpp
@@ -157,7 +157,7 @@ mkldnn_gemm(
   bool bf32_usable = std::is_same_v<scalar_t, float> && use_mkldnn_bf32_matmul();
   bool tf32_usable = std::is_same_v<scalar_t, float> && use_mkldnn_tf32_matmul();
   if ( !(bf16_usable || fp16_usable || bf32_usable || tf32_usable) ||
-      ((n * m <= 16384) && (n * k >= 4 * 2048 / m)) || (m * n * k <= 16 * 16 * 16) || (alpha == 0.0f)) {
+      ((n * m <= 2048 * 256) && !(m <= 512 && n * k * m >= 4096 * 1024 * 128)) || (alpha == 0.0f)) {
     return false;
   }
 

--- a/aten/src/ATen/native/mkldnn/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/Matmul.cpp
@@ -157,7 +157,7 @@ mkldnn_gemm(
   bool bf32_usable = std::is_same_v<scalar_t, float> && use_mkldnn_bf32_matmul();
   bool tf32_usable = std::is_same_v<scalar_t, float> && use_mkldnn_tf32_matmul();
   if ( !(bf16_usable || fp16_usable || bf32_usable || tf32_usable) ||
-      (m * n * k <= 16 * 16 * 16) || (alpha == 0.0f)) {
+      ((m >= 16 && k >= 16) || (k <= 8 && n * m < 16384) || (m <= 8 && n <= 1024)) || (alpha == 0.0f)) {
     return false;
   }
 

--- a/cmake/Modules/FindBLAS.cmake
+++ b/cmake/Modules/FindBLAS.cmake
@@ -336,13 +336,18 @@ ENDIF(NOT BLAS_FIND_QUIETLY)
 # Do nothing is BLAS was found before
 ENDIF(NOT BLAS_FOUND)
 
+
 # Blas has bfloat16 support?
 IF(BLAS_LIBRARIES)
   INCLUDE(CheckFunctionExists)
-  SET(CMAKE_REQUIRED_LIBRARIES ${BLAS_LIBRARIES})
+  set(CMAKE_REQUIRED_LIBRARIES ${BLAS_LIBRARIES})
+  check_function_exists("bgemm_" BLAS_HAS_BGEMM)
+  IF(BLAS_HAS_BGEMM)
+    add_compile_options(-DBLAS_HAS_BGEMM)
+  ENDIF(BLAS_HAS_BGEMM)
   check_function_exists("sbgemm_" BLAS_HAS_SBGEMM)
-  set(CMAKE_REQUIRED_LIBRARIES)
   IF(BLAS_HAS_SBGEMM)
     add_compile_options(-DBLAS_HAS_SBGEMM)
   ENDIF(BLAS_HAS_SBGEMM)
+  set(CMAKE_REQUIRED_LIBRARIES)
 ENDIF(BLAS_LIBRARIES)


### PR DESCRIPTION
Updates heuristic for bgmm. Based on [these changes](https://github.com/pytorch/pytorch/compare/main...Mousius:pytorch:bgemm?expand=1)

```
import torch
import time

# Set below to True to use cases selected by only one of the hueristics.
USE_ONLY_DIVERGENT_TEST_CASES = True   
BATCH_SIZES  = [ 1, 8, 32 ]
M_DIMS       = [ 4, 8, 16, 32, 64, 256, 512, 1024, 2048 ]
N_DIMS       = [ 4, 8, 16, 32, 64, 256, 512, 1024, 2048 ]
K_DIMS       = [ 4, 8, 16, 32, 64, 256, 512, 1024, 2048 ]
ITERS        = 40
DTYPE        = torch.bfloat16

def old_heuristic(m, n, k):
    is_above_min_dims = m > 8 and n > 8 and k > 8
    is_above_min_size = m * n * k <= 16 * 16 * 16
    return is_above_min_dims and is_above_min_size

def new_heuristic(m, n, k):
    is_above_min_dims = m >= 8 and n >= 8 and k >= 8
    heuristic = m <= 8 or k <= 8 or n >= 1024
    return heuristic and is_above_min_dims

def generate_test_cases():
   test_cases = []
   for b in BATCH_SIZES:
       for m in M_DIMS:
           for n in N_DIMS:
                   for k in K_DIMS:
                       if USE_ONLY_DIVERGENT_TEST_CASES:
                           if old_heuristic(m, n, k) != new_heuristic(m, n, k):
                               test_cases.append([b, m, n, k])
                       else:
                           test_cases.append([b, m, n, k])
   return test_cases

def test(x, y):
   for _ in range(5):
       torch.bmm(x, y)
   perf = 0.0
   for _ in range(ITERS):
       start = time.time()
       torch.bmm(x, y)
       end = time.time()
       perf += (end - start) / ITERS
   return perf

def main():
    device = torch.device("cpu")

    print(f"{'b':<10}{'m':<10}{'n':<10}{'k':<10}{'time (s)':10}")
    cumulative_mean_time = 0.0
    last_b = None

    for b, m, n, k in generate_test_cases():
        x = torch.randn((b, m, n), dtype=DTYPE, device=device)
        y = torch.randn((b, n, k), dtype=DTYPE, device=device)
        mean_time = test(x, y)
        cumulative_mean_time += mean_time
        print(f"{b:<10}{m:<10}{n:<10}{k:<10}{mean_time:10.3e}")
    print(f"Cumulative mean time = {cumulative_mean_time:.4f} s")


if __name__ == "__main__":
   main()
```

From the script we see that cumulative mean time from all test cases (at 16 threads) is:

2.0007 s for the old heuristic
0.7480 s for the new heuristic

@aditew01 

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01