### PR TITLE
[Lowering] Fix the edge case of empty subgraph split due to dataclass node

### DIFF
--- a/test/fx/test_fx_split.py
+++ b/test/fx/test_fx_split.py
@@ -1,10 +1,26 @@
 # Owner(s): ["module: fx"]
 
+import dataclasses
 from collections import defaultdict
 
 import torch
+import torch.fx.passes.operator_support as op_support
+import torch.fx.passes.splitter_base as splitter_base
 from torch.fx.passes.split_utils import split_by_tags
 from torch.testing._internal.common_utils import TestCase
+
+
+@torch.jit.script
+@dataclasses.dataclass
+class DummyDataClass:
+    a: int
+    b: int
+    c: int
+
+
+@torch.fx.wrap
+def wrapped_add(_dataclass, y):
+    return _dataclass.c + y
 
 
 class TestFXSplit(TestCase):
@@ -37,6 +53,65 @@ class TestFXSplit(TestCase):
             if node.op == "placeholder":
                 self.assertIn("name", node.meta)
                 self.assertEqual(node.meta["name"], node.name)
+
+    def test_dataclass_as_graph_entry(self):
+        """
+        Test that splitting works when the graph entry is a dataclass instance
+        and a wrapped function is called with it, resulting in a call_function
+        node with no input dependencies. This tests the edge case fixed in D81232435
+        where call_function nodes with no dependencies should be handled properly
+        in the starter_nodes() method.
+
+        Graph visualization:
+        y (input)    DummyDataClass(2,3,4) (no input deps, result as a call_function_node)
+            \              /
+             \            /
+              wrapped_add
+                  |
+              z (output)
+        """  # noqa: W605
+
+        class TestModuleWithFunctionEntry(torch.nn.Module):
+            def forward(self, y):
+                # This creates a call_function node with no input dependencies
+                dummy_data_class = DummyDataClass(2, 3, 4)
+                z = wrapped_add(dummy_data_class, y)
+                return z
+
+        mod = TestModuleWithFunctionEntry()
+        gm = torch.fx.symbolic_trace(mod)
+
+        # Create custom operator support to mark wrapped_add as supported
+        class CustomOpSupport(op_support.OperatorSupportBase):
+            def is_node_supported(self, submodules, node) -> bool:
+                return node.target == wrapped_add
+
+        # Create a simple splitter to test the edge case
+        class TestSplitter(splitter_base._SplitterBase):
+            def __init__(self, module, sample_input, operator_support):
+                settings = splitter_base._SplitterSettingBase()
+                super().__init__(module, sample_input, operator_support, settings)
+
+        # Create splitter instance - this tests the fix where call_function nodes
+        # with no input dependencies are properly handled in starter_nodes()
+        splitter = TestSplitter(
+            module=gm,
+            sample_input=[torch.randn(2, 3)],
+            operator_support=CustomOpSupport(),
+        )
+
+        # This should not raise an exception (tests the fix from D81232435)
+        # The fix allows call_function nodes with no dependencies as valid starter nodes
+        split_result = splitter()
+
+        # Verify the splitting worked correctly
+        self.assertIsNotNone(split_result)
+
+        # Test that the split module produces the same result as the original
+        test_input = torch.randn(2, 3)
+        original_result = mod(test_input)
+        split_module_result = split_result(test_input)
+        self.assertTrue(torch.equal(original_result, split_module_result))
 
 
 class TestSplitByTags(TestCase):

--- a/torch/fx/passes/splitter_base.py
+++ b/torch/fx/passes/splitter_base.py
@@ -952,13 +952,22 @@ class _SplitterBase:
         starter_cpu_nodes: NodeSet = set()
         starter_acc_nodes: NodeSet = set()
         for node in self.module.graph.nodes:
+            # edge case, call_function, but with no dependencies
+            if node.op == "call_function" and len(node.all_input_nodes) == 0:
+                if node in self.acc_nodes:
+                    starter_acc_nodes.add(node)
+                else:
+                    starter_cpu_nodes.add(node)
+
             if node.op not in {"placeholder", "get_attr"}:
                 continue
+
             for user in node.users:
                 if user in self.acc_nodes:
                     starter_acc_nodes.add(user)
                 else:
                     starter_cpu_nodes.add(user)
+
         return starter_cpu_nodes, starter_acc_nodes
 
     def put_nodes_into_subgraphs(self) -> list[Subgraph]:


### PR DESCRIPTION
Summary: Fix the edge case by allowing `call_function` nodes with no deps as graph entry (starter_nodes) in the splitter.

Test Plan:
The test shall pass in the current diff (after fix), and fail in the parent diff (before fix)

```
buck test mode/opt //glow/fb/fx/lowering:split_tests -- test_dataclass_as_graph_entry
```

Rollback Plan:

Differential Revision: D81232435




cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv