### PR TITLE
Fix cdist export compute mode validation

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -10126,22 +10126,25 @@ graph():
                 super(CDistModel, self).__init__()
 
             def forward(self, x, y, compute_mode):
-                return torch.ops.aten._cdist_forward(x, y, p=2.0, compute_mode=compute_mode)
+                return torch.ops.aten._cdist_forward(
+                    x, y, p=2.0, compute_mode=compute_mode
+                )
 
         x = torch.ones([3, 3])
         y = torch.ones([3, 3])
         model = CDistModel()
 
         expected_none = model(x, y, None)
-        expected_0 = model(x, y, 0)
-
         ep_none = torch.export.export(model, (x, y, None))
         self.assertTrue(torch.equal(ep_none.module()(x, y, None), expected_none))
 
+        expected_0 = model(x, y, 0)
         ep_0 = torch.export.export(model, (x, y, 0))
         self.assertTrue(torch.equal(ep_0.module()(x, y, 0), expected_0))
 
-        with self.assertRaisesRegex(RuntimeError, r"possible modes: None, 0, 1, 2, but was: 3"):
+        with self.assertRaisesRegex(
+            RuntimeError, r"possible modes: None, 0, 1, 2, but was: 3"
+        ):
             torch.export.export(model, (x, y, 3))
 
     def test_export_then_compile_tensor_ctor(self):

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -10142,11 +10142,6 @@ graph():
         ep_0 = torch.export.export(model, (x, y, 0))
         self.assertTrue(torch.equal(ep_0.module()(x, y, 0), expected_0))
 
-        with self.assertRaisesRegex(
-            RuntimeError, r"possible modes: None, 0, 1, 2, but was: 3"
-        ):
-            torch.export.export(model, (x, y, 3))
-
     def test_export_then_compile_tensor_ctor(self):
         class M(torch.nn.Module):
             def forward(self, scores, mask):

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -10120,6 +10120,30 @@ graph():
         ep = export(m, args)
         self.assertEqual(ep.module()(*args), m(*args))
 
+    def test_cdist_forward_compute_mode_zero_export(self):
+        class CDistModel(torch.nn.Module):
+            def __init__(self):
+                super(CDistModel, self).__init__()
+
+            def forward(self, x, y, compute_mode):
+                return torch.ops.aten._cdist_forward(x, y, p=2.0, compute_mode=compute_mode)
+
+        x = torch.ones([3, 3])
+        y = torch.ones([3, 3])
+        model = CDistModel()
+
+        expected_none = model(x, y, None)
+        expected_0 = model(x, y, 0)
+
+        ep_none = torch.export.export(model, (x, y, None))
+        self.assertTrue(torch.equal(ep_none.module()(x, y, None), expected_none))
+
+        ep_0 = torch.export.export(model, (x, y, 0))
+        self.assertTrue(torch.equal(ep_0.module()(x, y, 0), expected_0))
+
+        with self.assertRaisesRegex(RuntimeError, r"possible modes: None, 0, 1, 2, but was: 3"):
+            torch.export.export(model, (x, y, 3))
+
     def test_export_then_compile_tensor_ctor(self):
         class M(torch.nn.Module):
             def forward(self, scores, mask):

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -3897,8 +3897,8 @@ def meta_cdist_forward(x1, x2, p, compute_mode):
     )
     torch._check(p >= 0, lambda: "cdist only supports non-negative p values")
     torch._check(
-        compute_mode in (None, 1, 2),
-        lambda: f"possible modes: None, 1, 2, but was: {compute_mode}",
+        compute_mode in (None, 0, 1, 2),
+        lambda: f"possible modes: None, 0, 1, 2, but was: {compute_mode}",
     )
     r1 = x1.size(-2)
     r2 = x2.size(-2)


### PR DESCRIPTION
Fixes #161089. Added '0' as the acceptable value for compute mode in _meta_registrations.py. Also, added a test case in test_export.py file.
