### PR TITLE
fix tests caused by has_triton

### DIFF
--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -94,14 +94,6 @@ from .schema import (  # type: ignore[attr-defined]
 from .union import _Union
 
 
-if has_triton():
-    from triton.runtime.autotuner import Autotuner
-else:
-
-    class Autotuner:  # type: ignore[no-redef]
-        pass
-
-
 __all__ = [
     "serialize",
     "GraphModuleSerializer",
@@ -684,6 +676,7 @@ class GraphModuleSerializer(metaclass=Final):
                 is torch._higher_order_ops.triton_kernel_wrap.triton_kernel_wrapper_functional
             ):
                 assert has_triton(), "triton required to serialize triton kernels"
+                from triton.runtime.autotuner import Autotuner
 
                 meta_val = node.meta["val"]
                 assert isinstance(meta_val, dict)


### PR DESCRIPTION
Summary: this will only cause it in the event that we are serializing a triton hop. there are a few tests that do weird mocking stuff that this function doesn't like, so this will prevent it from being called there.

Test Plan:
att

Rollback Plan:

Differential Revision: D81261486


