### PR TITLE
Add support for tensor stride load and save

### DIFF
--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -382,6 +382,16 @@ def _rebuild_device_tensor_from_cpu_tensor(data, dtype, device, requires_grad):
     return tensor
 
 
+def _rebuild_device_tensor_from_cpu_tensor_with_strides(data, dtype, device, strides, storage_offset, requires_grad):
+    device = _get_restore_location(device)
+    tensor = data.to(dtype=dtype, device=device)
+    tensor.requires_grad = requires_grad
+    try: 
+        tensor.as_strided_(data.size(), strides, storage_offset)
+    except RuntimeError as e:
+        raise RuntimeError(f"Failed to restore strides for tensor {data.size()}") from e
+    return tensor
+
 def _rebuild_device_tensor_from_numpy(data, dtype, device, requires_grad):
     device = _get_restore_location(device)
     tensor = torch.from_numpy(data).to(dtype=dtype, device=device)


### PR DESCRIPTION
Summary:
We add a new path for MTIA tensors that will deserialize tensors with strides preserved. As MTIA Allocator is not exposed externally, we cannot simply let MTIA be handled by the typical CPU/CUDA path. To solve this, we add a variant of _rebuild_device_tensor_from_cpu_tensor, that tries to rebuild the tensor with as_strided to preserve strides from the original tensor.

Uses the tests written from the previous diff to verify strides can be saved and loaded on MTIA.

Reviewed By: egienvalue

Differential Revision: D78512965




cc @egienvalue