### PR TITLE
Silence a warning by using the newer function

### DIFF
--- a/torch/nested/__init__.py
+++ b/torch/nested/__init__.py
@@ -429,9 +429,9 @@ def nested_tensor_from_jagged(
         >>> torch.equal(c, values[3:5, :])
         True
     """
-    from torch.fx._symbolic_trace import is_fx_tracing
+    from torch.fx._symbolic_trace import is_fx_symbolic_tracing
 
-    if is_fx_tracing():
+    if is_fx_symbolic_tracing():
         raise RuntimeError(
             "torch.nested.nested_tensor_from_jagged does not support tracing with fx.symbolic_trace. "
             "Use fx.wrap to wrap the function that calls nested_tensor_from_jagged."


### PR DESCRIPTION
Currently, this function will unconditionally log a warning with thanks to the code at https://github.com/pytorch/pytorch/blob/1190b7f73e9a94c9280d2baf196fddaa4c3a0374/torch/fx/_symbolic_trace.py#L49-L55

I just followed the instructions in the code and used `is_fx_symbolic_tracing` as the recommended guard here. This is technically a breaking change because it allows `torch.compile` for this function now, but maybe that's ok? I could change this to do an `or` of the two conditions if that is preferred.