### PR TITLE
Rename propagate_tensor_meta to make private again

### DIFF
--- a/torch/distributed/tensor/_sharding_prop.py
+++ b/torch/distributed/tensor/_sharding_prop.py
@@ -301,7 +301,7 @@ class ShardingPropagator:
     ) -> TensorMeta | Sequence[TensorMeta | None] | None:
         """
         Cached version of _propagate_tensor_meta_non_cached
-        Use _propagate_tensor_meta instead to make compile-safe.
+        Use _propagate_tensor_meta instead to handle dynamic shapes.
         """
         return self._propagate_tensor_meta_non_cached(op_schema)
 
@@ -311,7 +311,7 @@ class ShardingPropagator:
         """
         Propagate the tensor metadata, it could either return a TensorMeta
         or a list/tuple of TensorMetas. Uses the cached version if not
-        actively tracing. Use this method if you need caching.
+        actively tracing. Use this method instead of _propagate_tensor_meta_non_cached
         """
         if _are_we_tracing():
             return self._propagate_tensor_meta_non_cached(op_schema)

--- a/torch/distributed/tensor/_sharding_prop.py
+++ b/torch/distributed/tensor/_sharding_prop.py
@@ -301,7 +301,7 @@ class ShardingPropagator:
     ) -> TensorMeta | Sequence[TensorMeta | None] | None:
         """
         Cached version of _propagate_tensor_meta_non_cached
-        Use _propagate_tensor_meta instead to skip if compiling.
+        Use _propagate_tensor_meta instead to make compile-safe.
         """
         return self._propagate_tensor_meta_non_cached(op_schema)
 
@@ -310,8 +310,8 @@ class ShardingPropagator:
     ) -> TensorMeta | Sequence[TensorMeta | None] | None:
         """
         Propagate the tensor metadata, it could either return a TensorMeta
-        or a list/tuple of TensorMetas. Uses the cached version unless
-        if actively tracing.
+        or a list/tuple of TensorMetas. Uses the cached version if not
+        actively tracing. Use this method if you need caching.
         """
         if _are_we_tracing():
             return self._propagate_tensor_meta_non_cached(op_schema)

--- a/torch/distributed/tensor/_sharding_prop.py
+++ b/torch/distributed/tensor/_sharding_prop.py
@@ -296,27 +296,27 @@ class ShardingPropagator:
             return None
 
     @lru_cache  # noqa: B019
-    def _propagate_tensor_meta(
+    def _propagate_tensor_meta_cached(
         self, op_schema: OpSchema
     ) -> TensorMeta | Sequence[TensorMeta | None] | None:
         """
         Cached version of _propagate_tensor_meta_non_cached
-        This is a private API. Use propagate_tensor_meta instead.
+        Use _propagate_tensor_meta instead to skip if compiling.
         """
         return self._propagate_tensor_meta_non_cached(op_schema)
 
-    def propagate_tensor_meta(
+    def _propagate_tensor_meta(
         self, op_schema: OpSchema
     ) -> TensorMeta | Sequence[TensorMeta | None] | None:
         """
         Propagate the tensor metadata, it could either return a TensorMeta
-        or a list/tuple of TensorMetas. This is a public API that should be
-        used if cache should be used.
+        or a list/tuple of TensorMetas. Uses the cached version unless
+        if actively tracing.
         """
         if _are_we_tracing():
             return self._propagate_tensor_meta_non_cached(op_schema)
         else:
-            return self._propagate_tensor_meta(op_schema)
+            return self._propagate_tensor_meta_cached(op_schema)
 
     def _create_output_spec_with_new_tensor_meta(
         self,

--- a/torch/distributed/tensor/parallel/loss.py
+++ b/torch/distributed/tensor/parallel/loss.py
@@ -115,7 +115,7 @@ def _propagate_tensor_meta(
     assert op_info.schema is not None, (
         "op_info.schema should not be None after unwrap_to_op_info"
     )
-    tensor_meta = DTensor._op_dispatcher.sharding_propagator.propagate_tensor_meta(
+    tensor_meta = DTensor._op_dispatcher.sharding_propagator._propagate_tensor_meta(
         op_info.schema
     )
     if isinstance(tensor_meta, TensorMeta):


### PR DESCRIPTION
Rename the wrapper `propagate_tensor_meta` added in #161334 to make it clearly private, and rename the existing LRU function to accommodate.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci