### PR TITLE
Fix linalg.norm: ensure dtype is respected on CUDA

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -3002,7 +3002,15 @@ Tensor& linalg_matrix_norm_out(
 }
 
 // Numerical or None norms
-Tensor linalg_norm(const Tensor& X, const std::optional<Scalar>& opt_ord, OptionalIntArrayRef opt_dim, bool keepdim, std::optional<ScalarType> opt_dtype) {
+Tensor linalg_norm(const Tensor& X_, const std::optional<Scalar>& opt_ord, OptionalIntArrayRef opt_dim, bool keepdim, std::optional<ScalarType> opt_dtype) {
+  // New dtype handling: align CUDA with CPU by respecting dtype argument
+  Tensor X;
+  if (opt_dtype.has_value()) {
+    X = X_.to(opt_dtype.value());
+  } else {
+    // don’t promote to float64 on CUDA, preserve input dtype
+    X = X_;
+  }
   if (opt_dim.has_value()) {
     TORCH_CHECK(opt_dim->size() == 1 || opt_dim ->size() == 2, "linalg.norm: If ",
               "dim is specified, it must be of length 1 or 2. Got ", *opt_dim);

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -9838,6 +9838,20 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
             a_strided.cpu().numpy() @ b_strided.cpu().numpy()).to(device=device, dtype=dtype)
         self.assertEqual(expect, res)
 
+    def test_norm_dtype_propagation(self):
+        devices = ["cpu", "cuda"]
+        for device in devices:
+            for dtype in (torch.float16, torch.float32):
+                x = torch.randn(4, 5, device=device, dtype=dtype)
+
+                # Without explicit dtype → should match input dtype
+                n = torch.linalg.norm(x)
+                self.assertEqual(n.dtype, dtype)
+
+                # With explicit dtype
+                n_cast = torch.linalg.norm(x, dtype=torch.float64)
+                self.assertEqual(n_cast.dtype, torch.float64)
+
 instantiate_device_type_tests(TestLinalg, globals())
 
 if __name__ == '__main__':


### PR DESCRIPTION
Previously, torch.linalg.norm ignored the dtype argument on CUDA, always promoting
to float64. This PR aligns behavior with torch.norm by honoring dtype.
Added tests for float16/float32 on CPU and CUDA.
