### PR TITLE
use host+device_id to make sure devices are unique in rendezvous request

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -439,6 +439,7 @@ struct RendezvousRequest {
   size_t buffer_size;
   size_t signal_pad_offset;
   bool has_multicast_support;
+  char hostname[HOST_NAME_MAX + 1];
 };
 
 void validate_rendezvous_requests(
@@ -446,13 +447,15 @@ void validate_rendezvous_requests(
     int world_size) {
   TORCH_CHECK(reqs.size() == (size_t)world_size);
 
-  std::unordered_set<int> device_indices;
-  device_indices.reserve(world_size);
+  // For NVL72 systems, multiple hosts can be within a single nvlink domain.
+  // Multiple blocks will have same device_idx but they are on different hosts.
+  // Use (hostname, device_idx) pair to uniquely identify each allocation.
+  std::set<std::pair<std::string, int>> device_host_pairs;
   for (auto req : reqs) {
-    device_indices.insert(req.device_idx);
+    device_host_pairs.insert(std::make_pair(std::string(req.hostname), req.device_idx));
   }
   if (!allow_overlapping_devices() &&
-      device_indices.size() < (size_t)world_size) {
+      device_host_pairs.size() < (size_t)world_size) {
     TORCH_CHECK(
         false,
         "CUDASymmetricMemoryAllocator::rendezvous: ",
@@ -642,6 +645,9 @@ c10::intrusive_ptr<CUDASymmetricMemory> make_symm_mem(
       .buffer_size = block->buffer_size,
       .signal_pad_offset = block->signal_pad_offset,
       .has_multicast_support = device_has_multicast_support(block->device_idx)};
+
+  // Populate hostname field for host identification
+  gethostname(local_req.hostname, sizeof(local_req.hostname));
   auto reqs = storeExchange.all_gather(store, rank, world_size, local_req);
   validate_rendezvous_requests(reqs, world_size);
 


### PR DESCRIPTION
Per title, for NVL72 systems where devices with the same indices on multiple hosts are within the same nvlink domain


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta