### PR TITLE
[4/n] Quantization with min & max bounds support - float to 8 bit on X86-64

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag_prepack.h
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag_prepack.h
@@ -3,7 +3,10 @@
 
 namespace at::native {
 
-Tensor& qembeddingbag_byte_prepack_out(Tensor& output, const Tensor& weight);
+Tensor& qembeddingbag_byte_prepack_out(
+    Tensor& output,
+    const Tensor& weight,
+    const std::optional<Tensor>& rowwise_min_max_opt = std::nullopt);
 
 Tensor qembeddingbag_byte_prepack(const Tensor& weight);
 

--- a/aten/src/ATen/native/quantized/library.cpp
+++ b/aten/src/ATen/native/quantized/library.cpp
@@ -121,6 +121,7 @@ TORCH_LIBRARY(quantized, m) {
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::embedding_bag_unpack(__torch__.torch.classes.quantized.EmbeddingPackedParamsBase W_prepack) -> Tensor W_origin"), {at::Tag::pt2_compliant_tag});
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::embedding_bag_byte_prepack(Tensor weight) -> Tensor"), {at::Tag::pt2_compliant_tag});
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::embedding_bag_byte_unpack(Tensor weight) -> Tensor"), {at::Tag::pt2_compliant_tag});
+  m.def(TORCH_SELECTIVE_SCHEMA("quantized::embedding_bag_byte_prepack_with_rowwise_min_max(Tensor weight, Tensor rowwise_min_max) -> Tensor"), {at::Tag::pt2_compliant_tag});
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::embedding_bag_4bit_prepack(Tensor weight, bool optimized_qparams=False, int nbins=200, float ratio=0.16) -> Tensor"), {at::Tag::pt2_compliant_tag});
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::embedding_bag_4bit_unpack(Tensor weight) -> Tensor"), {at::Tag::pt2_compliant_tag});
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::embedding_bag_2bit_prepack(Tensor weight, bool optimized_qparams=False, int nbins=200, float ratio=0.16) -> Tensor"), {at::Tag::pt2_compliant_tag});


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/FBGEMM/pull/4790

X-link: https://github.com/facebookresearch/FBGEMM/pull/1813

At present quantization is performed at whole tensor level where each row's minimum and maximum values are calculated. In order to scale the quantization when tensor's are col-wise sharded, we are introducing these changes.

These changes enable passing the minimum and maximum values of each row of the whole tensor and use it to quantize the col-wise sharded tensors individually.

In this specific change, the support is added for float to 8-bit quantization on X86-64 architecture. In the future changes we will expand the support for other source/target bit rates and architectures.

Test Plan:
## Unit Tests

```
buck test mode/opt deeplearning/fbgemm:QuantUtilsTest
```
https://www.internalfb.com/intern/testinfra/testrun/7881299637204767

```
buck test mode/opt caffe2/torch/fb/model_transform/splitting/tests:split_dispatcher_test
```
https://www.internalfb.com/intern/testinfra/testrun/14636698895328167

## Integration Testing

Please refer to D80905814's test plan.

Rollback Plan:

Reviewed By: excelle08

Differential Revision: D78181177




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168