### PR TITLE
Add new parameter for gen_pyi.py to make it more configureable.

### DIFF
--- a/tools/autograd/build.bzl
+++ b/tools/autograd/build.bzl
@@ -12,3 +12,9 @@ def define_targets(rules):
             "//torchgen",
         ],
     )
+
+    rules.filegroup(
+        name = "deprecated_yaml",
+        srcs = ["deprecated.yaml"],
+        visibility = ["//:__subpackages__"],
+    )

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -1832,7 +1832,9 @@ def main() -> None:
         help="path to template directory",
     )
     args = parser.parse_args()
-    fm = FileManager(install_dir=args.out, template_dir=args.template_dir, dry_run=False)
+    fm = FileManager(
+        install_dir=args.out, template_dir=args.template_dir, dry_run=False
+    )
     gen_pyi(
         args.native_functions_path,
         args.tags_path,

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -1826,8 +1826,13 @@ def main() -> None:
         default=".",
         help="path to output directory",
     )
+    parser.add_argument(
+        "--template-dir",
+        default=".",
+        help="path to template directory",
+    )
     args = parser.parse_args()
-    fm = FileManager(install_dir=args.out, template_dir=".", dry_run=False)
+    fm = FileManager(install_dir=args.out, template_dir=args.template_dir, dry_run=False)
     gen_pyi(
         args.native_functions_path,
         args.tags_path,


### PR DESCRIPTION
This is a reposting of PR #128519.
This change is important to how we maintain PyTorch at Google.

From the previous PR:
"
This will make the script more flexible for the directory where it is executed.
...
We plan to use the deprecated_yaml from a blaze genrule that invokes pyi.py. As the input to the pyi.py, genrule requires the input file to be explicitly listed out. When we feed the value of tools/autograd/deprecated.yaml to genrule, it failed to resolve since tools/autograd is a package from blaze perspective. Any file under a blaze package will a proper blaze target to be access.
"

cc @haifeng-jin
