### PR TITLE
Inductor: dispatch GELU to oneDNN in CPU compile path and re-enable AArch64 fusions

### DIFF
--- a/aten/src/ATen/native/mkldnn/RegisterMkldnnOpContextClass.cpp
+++ b/aten/src/ATen/native/mkldnn/RegisterMkldnnOpContextClass.cpp
@@ -42,6 +42,8 @@ TORCH_LIBRARY(mkldnn, m) {
           });
 
   m.def(TORCH_SELECTIVE_SCHEMA(
+      "mkldnn::_gelu(Tensor X, str algorithm) -> Tensor Y"));
+  m.def(TORCH_SELECTIVE_SCHEMA(
       "mkldnn::_linear_pointwise(Tensor X, Tensor W, Tensor? B, str attr, Scalar?[] scalars, str? algorithm) -> Tensor Y"));
   m.def(TORCH_SELECTIVE_SCHEMA(
       "mkldnn::_linear_pointwise.binary(Tensor X, Tensor other, Tensor W, Tensor? B, str attr) -> Tensor Y"));

--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -1519,21 +1519,30 @@ if torch._C._has_mkldnn:
                         user_node.replace_all_uses_with(node)
                         gm.graph.erase_node(user_node)
 
+    def _register_unary_mkldnn_fusion():
+        # Match any decomposed unary operations that we couldn't perform as part of other
+        # fusions in this file (e.g. Linear+GELU). To ensure the other fusions, which are
+        # done on pass_number=1, take precedence, we perform these fusions on pass_number=2
+
+        # GELU(approximate="none")
+        @register_lowering_pattern(pattern=_gelu_fusion_1(Arg()), pass_number=2)
+        def lower_gelu_none_to_mkldnn(match, *args, **kwargs):
+            assert len(args) == 1, len(args)
+            output = L[mkldnn._gelu](args[0], "none")
+            return output
+
     @functools.cache
     def _mkldnn_fusion_init():
         # TODO: aarch64: enable op fusion for acl once it supports fused operators. Disabling it for now.
         # Otherwise even the matmul or innerproduct can not be accelerated with acl
-        if (
-            torch.backends.mkldnn.enabled
-            and torch.backends.mkldnn.is_available()
-            and not torch.ops.mkldnn._is_mkldnn_acl_supported()
-        ):
+        if torch.backends.mkldnn.enabled and torch.backends.mkldnn.is_available():
             _register_unary_fusion()
             _register_inplace_fusion()
             _register_binary_unary_fusion()
             _register_binary_fusion()
             _register_quantization_lowerings()
             _register_woq_lowerings()
+            _register_unary_mkldnn_fusion()
 
     @functools.cache
     def _mkldnn_weight_pack_init():

--- a/torch/_inductor/mkldnn_lowerings.py
+++ b/torch/_inductor/mkldnn_lowerings.py
@@ -222,6 +222,7 @@ def register_onednn_fusion_ops():
             kernel_creator=mkldnn_ir.QLinearPointwiseBinaryPT2E.create,
         )
         cpu_needs_realized_inputs = [
+            torch.ops.mkldnn._gelu,
             torch.ops.mkldnn._convolution_pointwise,
             torch.ops.mkldnn._convolution_pointwise_,
             torch.ops.mkldnn._convolution_transpose_pointwise,
@@ -229,6 +230,10 @@ def register_onednn_fusion_ops():
             aten.mkldnn_rnn_layer.default,
             torch.ops.onednn.qconv_pointwise,
         ]
+
+        @register_lowering(torch.ops.mkldnn._gelu)
+        def gelu(x: TensorBox, algorithm):
+            return TensorBox.create(mkldnn_ir.Gelu.create(x, algorithm))
 
         @register_lowering(torch.ops.mkldnn._convolution_pointwise)
         def convolution_unary(

--- a/torch/csrc/inductor/aoti_torch/c/shim_cpu.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim_cpu.h
@@ -112,6 +112,11 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu_mkldnn_rnn_layer(
     AtenTensorHandle* ret2,
     AtenTensorHandle* ret3);
 
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu__gelu(
+    AtenTensorHandle X,
+    const char* algorithm,
+    AtenTensorHandle* ret0);
+
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu__linear_pointwise(
     AtenTensorHandle X,
     AtenTensorHandle W,

--- a/torch/csrc/inductor/aoti_torch/shim_cpu.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_cpu.cpp
@@ -255,6 +255,16 @@ AOTITorchError aoti_torch_cpu__linear_pointwise(
   });
 }
 
+AOTITorchError aoti_torch_cpu__gelu(
+    AtenTensorHandle X,
+    const char* algorithm,
+    AtenTensorHandle* ret0) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    auto tmp_result = at::native::mkldnn_gelu(*tensor_handle_to_tensor_pointer(X), algorithm);
+    *ret0 = new_tensor_handle(std::move(tmp_result));
+  });
+}
+
 AOTITorchError aoti_torch_cpu__linear_pointwise_binary(
     AtenTensorHandle X,
     AtenTensorHandle other,


### PR DESCRIPTION
> [!CAUTION]
> **DRAFT RELEASE!**

## Summary

This PR introduces a dedicated `mkldnn::_gelu` operator and ensures `GELU(approximate="none")` subgraphs are lowered to a oneDNN eltwise GELU on CPU. It also re-enables fusions on AArch64 in compile mode.

## Motivation

- On CPU, GELU appears post-decomposition as `mul(x*0.5, add(erf(x*sqrt(0.5)), 1))`, which is later replaced with a codegen-ed `Vectorized` implementation, instead of using faster implementations from oneDNN/ACL when available.
- The fusion logic on AArch64 was disabled due to previous issues with fusions in oneDNN; this is currently being addressed in https://github.com/uxlfoundation/oneDNN/pull/3767#issuecomment-3191330732, allowing arbitrary post-ops (activations) with the ACL `matmul` and `inner_product` primitives.

## Changes

- New op `mkldnn::_gelu(Tensor X, str algorithm)` calling oneDNN eltwise `GELU`; returns dense for dense inputs.
- Adds a new `Gelu` lowering + Inductor IR and AOTI shim `aoti_torch_cpu__gelu(...)`.
- Defines a fusion pattern (in the post-grad step) that recognises the decomposed `GELU` and lowers it to `mkldnn::_gelu` on pass number 2 (0-indexed), to ensure it only occurs after higher-priority linear/conv fusions.
- Re-enables fusions in compile mode on AArch64.

## Remarks
- Uses oneDNN `eltwise_gelu_erf`; only approximate="none" is supported by this path.
- Returns dense for dense inputs so downstream ATen pointwise ops don’t see a `torch._mkldnn` layout unexpectedly.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben