### PR TITLE
[inductor][decompose k] disable on everything other than cuda

### DIFF
--- a/torch/_inductor/template_heuristics/decompose_k.py
+++ b/torch/_inductor/template_heuristics/decompose_k.py
@@ -20,6 +20,11 @@ if TYPE_CHECKING:
     from ..ir import Layout
 
 
+@register_template_heuristic("decompose_k", None, op_name="mm")
+class EmptyDecomposeKConfigHeuristics(TemplateConfigHeuristics):
+    """empty heuristics to skip decompose k on anything not cuda"""
+
+
 # on CUDA, we don't support hip for decompose_k yet
 @register_template_heuristic(
     "decompose_k", "cuda", register=torch.version.hip is None, op_name="mm"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #161795
* #161767

# why

- untested so far

# what

- add an empty config heuristic for all devices for decompose k
- the cuda heuristic, because it is more specific, will still be picked
  up
- add notes explaining how to enable on other devices

# testing

```
python3 -bb -m pytest test/inductor/test_max_autotune.py -v -k "decompose_k"
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov