### PR TITLE
Run vLLM tests on all trunk commits before 2.9 branch cut

### DIFF
--- a/.github/workflows/vllm.yml
+++ b/.github/workflows/vllm.yml
@@ -2,6 +2,9 @@ name: vllm-test
 
 on:
   push:
+    branches:
+      - main
+      - release/*
     tags:
       - ciflow/vllm/*
   workflow_dispatch:


### PR DESCRIPTION
This makes it easier to bisect issue now given that we don't have lots of time.