### PR TITLE
[CI] Fix decorator logic in common_mps

### DIFF
--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -12,7 +12,7 @@ if torch.backends.mps.is_available():
 
     def mps_ops_modifier(
         ops: Sequence[OpInfo],
-        device_type: Optional[str] = None,
+        device_type: str = "mps",
         xfail_exclusion: Optional[list[str]] = None,
         sparse: bool = False,
     ) -> Sequence[OpInfo]:
@@ -636,10 +636,9 @@ if torch.backends.mps.is_available():
         }
 
         def addDecorator(
-            op: OpInfo, d: DecorateInfo, _device_type: Optional[str] = device_type
-        ) -> None:
-            if _device_type is not None:
-                d.device_type = _device_type
+                op: OpInfo, d: DecorateInfo) -> None:
+            if device_type is not None:
+                d.device_type = device_type
 
             op.decorators = op.decorators + (d,)
 
@@ -654,7 +653,6 @@ if torch.backends.mps.is_available():
                         torch.cdouble,
                     ],
                 ),
-                _device_type="mps",
             )
             if sparse and op.name in SKIPLIST_SPARSE:
                 addDecorator(
@@ -689,7 +687,6 @@ if torch.backends.mps.is_available():
                     addDecorator(
                         op,
                         DecorateInfo(unittest.expectedFailure, dtypes=xfaillist[key]),
-                        _device_type="mps",
                     )
 
             if (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #161814

Always decorate for MPS device. This fixes regressions in sparse testing
that were introduced by https://github.com/pytorch/pytorch/pull/160839