### PR TITLE
[inductor] Runtime estimations: add triton's do_bench code

### DIFF
--- a/test/distributed/test_compute_comm_reordering.py
+++ b/test/distributed/test_compute_comm_reordering.py
@@ -266,7 +266,7 @@ class TestComputeCommReorderingMultiProc(DynamoDistributedMultiProcTestCase):
     )
     @patch.object(
         torch._inductor.config,
-        "runtime_estimations_mms_benchmark",
+        "runtime_estimations_comp_benchmark",
         False,
     )
     def test_reorder_compute_for_overlap(self):

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -414,7 +414,8 @@ bucket_reduce_scatters_fx_bucket_size_determinator: Optional[Callable[[int], int
 estimate_op_runtime = "default"
 
 runtime_estimations_use_nccl_lib_estimations: bool = False
-runtime_estimations_comp_benchmark: bool = False
+runtime_estimations_mms_benchmark: bool = False
+runtime_estimations_triton_benchmark: bool = False
 
 # unit: GB/s, uni-directional P2P bandwidth per card
 # default value is NVLink

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -414,7 +414,7 @@ bucket_reduce_scatters_fx_bucket_size_determinator: Optional[Callable[[int], int
 estimate_op_runtime = "default"
 
 runtime_estimations_use_nccl_lib_estimations: bool = False
-runtime_estimations_mms_benchmark: bool = False
+runtime_comp_profile_and_benchmark: bool = False
 
 # unit: GB/s, uni-directional P2P bandwidth per card
 # default value is NVLink

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -414,7 +414,7 @@ bucket_reduce_scatters_fx_bucket_size_determinator: Optional[Callable[[int], int
 estimate_op_runtime = "default"
 
 runtime_estimations_use_nccl_lib_estimations: bool = False
-runtime_comp_profile_and_benchmark: bool = False
+runtime_estimations_comp_benchmark: bool = False
 
 # unit: GB/s, uni-directional P2P bandwidth per card
 # default value is NVLink

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -853,7 +853,7 @@ class BaseSchedulerNode:
             # since it doesn't take extra time to get the result after the collective is completed.
             return 0
 
-        if config.runtime_comp_profile_and_benchmark:
+        if config.runtime_estimations_comp_benchmark:
             ret = estimate_runtime_benchmark(self)
             if ret is not None:
                 return ret
@@ -935,7 +935,7 @@ def estimate_runtime_benchmark(snode: BaseSchedulerNode) -> Optional[float]:
             time, _ = sched.benchmark_codegened_module(module=module, device=device)
         except Exception:
             # if there is dynamic shape in generated triton code, the benchmark will throw errors.
-            # we fall back such case
+            # falling back to 0 for such cases
             time = 0
         return time * 1e3
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2207,7 +2207,8 @@ def override_lowering(
 
 
 def add_scheduler_init_hook(
-    pre_fn: Callable[..., Any], post_fn: Optional[Callable[..., Any]] = None
+    pre_fn: Optional[Callable[..., Any]] = None,
+    post_fn: Optional[Callable[..., Any]] = None,
 ) -> Any:
     """
     Add hook functions to be called at the beginning and end of Scheduler.__init__.
@@ -2218,7 +2219,8 @@ def add_scheduler_init_hook(
     orig_fn = Scheduler.__init__
 
     def wrapper(scheduler: Any, nodes: Any) -> Any:
-        pre_fn(scheduler, nodes)
+        if pre_fn:
+            pre_fn(scheduler, nodes)
         out = orig_fn(scheduler, nodes)
         if post_fn:
             post_fn(scheduler, nodes)


### PR DESCRIPTION
As titled, this PR adds profiling support for BaseScheduleNode and FusedScheduleNode using Triton's do_bench mode.

The changes include:
- Adding estimation for BaseScheduleNode and FusedScheduleNode
- Rename the config name to `runtime_estimations_comp_benchmark` to reflect that we are profiling not only matmuls but also other ops

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #161821
* #161405



cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben