### PR TITLE
[CUDA][cuBLAS][TF32] Skip checking TF32 options and setting cuBLAS handle TF32 modes for other dtypes

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -586,6 +586,12 @@ void bgemm_internal_cublas<float>(CUDABLAS_BGEMM_ARGTYPES(float)) {
   // See Note [Writing Nondeterministic Operations]
   globalContext().alertCuBLASConfigNotDeterministic();
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  if (!NoTF32Guard::should_disable_tf32() &&
+      at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
+    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
+  } else {
+    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
+  }
   cublasOperation_t opa = _cublasOpFromChar(transa);
   cublasOperation_t opb = _cublasOpFromChar(transb);
   _cublasAdjustLdLevel3(transa, transb, m, n, k, &lda, &ldb, &ldc);
@@ -614,6 +620,12 @@ void bgemm_internal_cublas<c10::complex<float>>(CUDABLAS_BGEMM_ARGTYPES(c10::com
   // See Note [Writing Nondeterministic Operations]
   globalContext().alertCuBLASConfigNotDeterministic();
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  if (!NoTF32Guard::should_disable_tf32() &&
+      at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
+    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
+  } else {
+    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
+  }
   cublasOperation_t opa = _cublasOpFromChar(transa);
   cublasOperation_t opb = _cublasOpFromChar(transb);
   _cublasAdjustLdLevel3(transa, transb, m, n, k, &lda, &ldb, &ldc);
@@ -1043,6 +1055,12 @@ void gemm_internal_cublas<float>(CUDABLAS_GEMM_ARGTYPES(float)) {
   // See Note [Writing Nondeterministic Operations]
   globalContext().alertCuBLASConfigNotDeterministic();
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  if (!NoTF32Guard::should_disable_tf32() &&
+      at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
+    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
+  } else {
+    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
+  }
   cublasOperation_t opa = _cublasOpFromChar(transa);
   cublasOperation_t opb = _cublasOpFromChar(transb);
   _cublasAdjustLdLevel3(transa, transb, m, n, k, &lda, &ldb, &ldc);
@@ -1071,6 +1089,12 @@ void gemm_internal_cublas<c10::complex<float>>(CUDABLAS_GEMM_ARGTYPES(c10::compl
   // See Note [Writing Nondeterministic Operations]
   globalContext().alertCuBLASConfigNotDeterministic();
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  if (!NoTF32Guard::should_disable_tf32() &&
+      at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
+    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
+  } else {
+    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
+  }
   cublasOperation_t opa = _cublasOpFromChar(transa);
   cublasOperation_t opb = _cublasOpFromChar(transb);
   _cublasAdjustLdLevel3(transa, transb, m, n, k, &lda, &ldb, &ldc);
@@ -2435,6 +2459,12 @@ void gemv<c10::complex<float>>(CUDABLAS_GEMV_ARGTYPES(c10::complex<float>)) {
   // See Note [Writing Nondeterministic Operations]
   globalContext().alertCuBLASConfigNotDeterministic();
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  if (!NoTF32Guard::should_disable_tf32() &&
+      at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
+    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
+  } else {
+    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
+  }
   cublasOperation_t op = _cublasOpFromChar(trans);
   _cublasAdjustLdLevel2(m, n, &lda);
   GEMV_CHECK_ARGVALUES(c10::complex<float>);
@@ -2464,6 +2494,12 @@ void gemv<float>(CUDABLAS_GEMV_ARGTYPES(float)) {
   // See Note [Writing Nondeterministic Operations]
   globalContext().alertCuBLASConfigNotDeterministic();
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  if (!NoTF32Guard::should_disable_tf32() &&
+      at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
+    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
+  } else {
+    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
+  }
   cublasOperation_t op = _cublasOpFromChar(trans);
   _cublasAdjustLdLevel2(m, n, &lda);
   GEMV_CHECK_ARGVALUES(float);
@@ -2705,6 +2741,12 @@ template <>
 void getrfBatched<float>(
     int n, float** dA_array, int ldda, int* ipiv_array, int* info_array, int batchsize) {
   auto handle = at::cuda::getCurrentCUDABlasHandle();
+  if (!NoTF32Guard::should_disable_tf32() &&
+      at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
+    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
+  } else {
+    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
+  }
   TORCH_CUDABLAS_CHECK(cublasSgetrfBatched(
       handle, n, dA_array, ldda, ipiv_array, info_array, batchsize));
 }
@@ -2737,6 +2779,12 @@ void getrfBatched<c10::complex<float>>(
     int* info_array,
     int batchsize) {
   auto handle = at::cuda::getCurrentCUDABlasHandle();
+  if (!NoTF32Guard::should_disable_tf32() &&
+      at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
+    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
+  } else {
+    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
+  }
   TORCH_CUDABLAS_CHECK(cublasCgetrfBatched(
       handle,
       n,

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -586,12 +586,7 @@ void bgemm_internal_cublas<float>(CUDABLAS_BGEMM_ARGTYPES(float)) {
   // See Note [Writing Nondeterministic Operations]
   globalContext().alertCuBLASConfigNotDeterministic();
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
-  if (!NoTF32Guard::should_disable_tf32() &&
-      at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
-    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
-  } else {
-    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
-  }
+  at::cuda::maybeSetCUDABlasHandleTF32(at::kFloat, handle);
   cublasOperation_t opa = _cublasOpFromChar(transa);
   cublasOperation_t opb = _cublasOpFromChar(transb);
   _cublasAdjustLdLevel3(transa, transb, m, n, k, &lda, &ldb, &ldc);
@@ -620,12 +615,7 @@ void bgemm_internal_cublas<c10::complex<float>>(CUDABLAS_BGEMM_ARGTYPES(c10::com
   // See Note [Writing Nondeterministic Operations]
   globalContext().alertCuBLASConfigNotDeterministic();
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
-  if (!NoTF32Guard::should_disable_tf32() &&
-      at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
-    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
-  } else {
-    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
-  }
+  at::cuda::maybeSetCUDABlasHandleTF32(at::kComplexFloat, handle);
   cublasOperation_t opa = _cublasOpFromChar(transa);
   cublasOperation_t opb = _cublasOpFromChar(transb);
   _cublasAdjustLdLevel3(transa, transb, m, n, k, &lda, &ldb, &ldc);
@@ -1055,12 +1045,7 @@ void gemm_internal_cublas<float>(CUDABLAS_GEMM_ARGTYPES(float)) {
   // See Note [Writing Nondeterministic Operations]
   globalContext().alertCuBLASConfigNotDeterministic();
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
-  if (!NoTF32Guard::should_disable_tf32() &&
-      at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
-    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
-  } else {
-    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
-  }
+  at::cuda::maybeSetCUDABlasHandleTF32(at::kFloat, handle);
   cublasOperation_t opa = _cublasOpFromChar(transa);
   cublasOperation_t opb = _cublasOpFromChar(transb);
   _cublasAdjustLdLevel3(transa, transb, m, n, k, &lda, &ldb, &ldc);
@@ -1089,12 +1074,7 @@ void gemm_internal_cublas<c10::complex<float>>(CUDABLAS_GEMM_ARGTYPES(c10::compl
   // See Note [Writing Nondeterministic Operations]
   globalContext().alertCuBLASConfigNotDeterministic();
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
-  if (!NoTF32Guard::should_disable_tf32() &&
-      at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
-    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
-  } else {
-    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
-  }
+  at::cuda::maybeSetCUDABlasHandleTF32(at::kComplexFloat, handle);
   cublasOperation_t opa = _cublasOpFromChar(transa);
   cublasOperation_t opb = _cublasOpFromChar(transb);
   _cublasAdjustLdLevel3(transa, transb, m, n, k, &lda, &ldb, &ldc);
@@ -2459,12 +2439,7 @@ void gemv<c10::complex<float>>(CUDABLAS_GEMV_ARGTYPES(c10::complex<float>)) {
   // See Note [Writing Nondeterministic Operations]
   globalContext().alertCuBLASConfigNotDeterministic();
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
-  if (!NoTF32Guard::should_disable_tf32() &&
-      at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
-    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
-  } else {
-    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
-  }
+  at::cuda::maybeSetCUDABlasHandleTF32(at::kComplexFloat, handle);
   cublasOperation_t op = _cublasOpFromChar(trans);
   _cublasAdjustLdLevel2(m, n, &lda);
   GEMV_CHECK_ARGVALUES(c10::complex<float>);
@@ -2494,12 +2469,7 @@ void gemv<float>(CUDABLAS_GEMV_ARGTYPES(float)) {
   // See Note [Writing Nondeterministic Operations]
   globalContext().alertCuBLASConfigNotDeterministic();
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
-  if (!NoTF32Guard::should_disable_tf32() &&
-      at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
-    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
-  } else {
-    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
-  }
+  at::cuda::maybeSetCUDABlasHandleTF32(at::kFloat, handle);
   cublasOperation_t op = _cublasOpFromChar(trans);
   _cublasAdjustLdLevel2(m, n, &lda);
   GEMV_CHECK_ARGVALUES(float);
@@ -2741,12 +2711,7 @@ template <>
 void getrfBatched<float>(
     int n, float** dA_array, int ldda, int* ipiv_array, int* info_array, int batchsize) {
   auto handle = at::cuda::getCurrentCUDABlasHandle();
-  if (!NoTF32Guard::should_disable_tf32() &&
-      at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
-    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
-  } else {
-    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
-  }
+  at::cuda::maybeSetCUDABlasHandleTF32(at::kFloat, handle);
   TORCH_CUDABLAS_CHECK(cublasSgetrfBatched(
       handle, n, dA_array, ldda, ipiv_array, info_array, batchsize));
 }
@@ -2779,12 +2744,7 @@ void getrfBatched<c10::complex<float>>(
     int* info_array,
     int batchsize) {
   auto handle = at::cuda::getCurrentCUDABlasHandle();
-  if (!NoTF32Guard::should_disable_tf32() &&
-      at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
-    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
-  } else {
-    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
-  }
+  at::cuda::maybeSetCUDABlasHandleTF32(at::kComplexFloat, handle);
   TORCH_CUDABLAS_CHECK(cublasCgetrfBatched(
       handle,
       n,

--- a/aten/src/ATen/cuda/CUDAContextLight.h
+++ b/aten/src/ATen/cuda/CUDAContextLight.h
@@ -25,6 +25,7 @@
 #endif
 
 #include <c10/core/Allocator.h>
+#include <c10/core/ScalarType.h>
 #include <c10/cuda/CUDAFunctions.h>
 
 namespace c10 {
@@ -86,6 +87,7 @@ TORCH_CUDA_CPP_API c10::Allocator* getCUDADeviceAllocator();
 TORCH_CUDA_CPP_API cusparseHandle_t getCurrentCUDASparseHandle();
 TORCH_CUDA_CPP_API cublasHandle_t getCurrentCUDABlasHandle();
 TORCH_CUDA_CPP_API cublasLtHandle_t getCurrentCUDABlasLtHandle();
+TORCH_CUDA_CPP_API void maybeSetCUDABlasHandleTF32(c10::ScalarType dtype, cublasHandle_t handle);
 
 TORCH_CUDA_CPP_API void clearCublasWorkspaces();
 TORCH_CUDA_CPP_API std::map<std::tuple<void *, void *>, at::DataPtr>& cublas_handle_stream_to_workspace();

--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -305,17 +305,7 @@ cublasHandle_t getCurrentCUDABlasHandle() {
     workspace_it = cublas_handle_stream_to_workspace().insert(workspace_it, {key, getNewWorkspace()});
   }
   TORCH_CUDABLAS_CHECK(cublasSetWorkspace(handle, workspace_it->second.get(), getChosenWorkspaceSize()));
-#if !defined(USE_ROCM)
-  // On CUDA >= 11, and architecture >= Ampere, cuBLAS can use TF32 to speedup
-  // FP32 data type calculations based on the value of the allow_tf32 flag.
-  // To enable TF32, set the math mode of the handle to CUBLAS_TF32_TENSOR_OP_MATH.
-  if (!NoTF32Guard::should_disable_tf32() &&
-      at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
-    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
-  } else {
-    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
-  }
-#else
+#if defined(USE_ROCM)
   hipblasAtomicsMode_t hipblas_mode;
   if (at::globalContext().deterministicAlgorithms()) {
     hipblas_mode = HIPBLAS_ATOMICS_NOT_ALLOWED;

--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -344,4 +344,14 @@ cublasLtHandle_t getCurrentCUDABlasLtHandle() {
 #endif
 }
 
+void maybeSetCUDABlasHandleTF32(c10::ScalarType dtype, cublasHandle_t handle) {
+  if (dtype == at::kFloat || dtype == at::kComplexFloat) {
+    if (!NoTF32Guard::should_disable_tf32() &&
+        at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
+      TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
+    } else {
+      TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
+    }
+  }
+}
 } // namespace at::cuda

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -886,14 +886,7 @@ return AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
         Tensor result = at::empty({}, self.options());
 
         auto handle = at::cuda::getCurrentCUDABlasHandle();
-	if (self.scalar_type() == at::kFloat || self.scalar_type() == at::kComplexFloat) {
-	  if (!NoTF32Guard::should_disable_tf32() &&
-	      at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
-	    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
-	  } else {
-	    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
-	  }
-	}
+        at::cuda::maybeSetCUDABlasHandleTF32(self.scalar_type(), handle);
         at::cuda::blas::PointerModeGuard pointerModeGuard(handle, CUBLAS_POINTER_MODE_DEVICE);
         at::cuda::blas::dot<scalar_t>(
             handle,
@@ -942,14 +935,7 @@ Tensor vdot_cuda(const Tensor& self, const Tensor& other) {
     Tensor result = at::empty({}, self.options());
 
     auto handle = at::cuda::getCurrentCUDABlasHandle();
-    if (self.scalar_type() == at::kFloat || self.scalar_type() == at::kComplexFloat) {
-      if (!NoTF32Guard::should_disable_tf32() &&
-          at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
-        TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
-      } else {
-        TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
-      }
-    }
+    at::cuda::maybeSetCUDABlasHandleTF32(self.scalar_type(), handle);
 
     at::cuda::blas::PointerModeGuard pointerModeGuard(
         handle, CUBLAS_POINTER_MODE_DEVICE);

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -886,6 +886,14 @@ return AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
         Tensor result = at::empty({}, self.options());
 
         auto handle = at::cuda::getCurrentCUDABlasHandle();
+	if (self.scalar_type() == at::kFloat || self.scalar_type() == at::kComplexFloat) {
+	  if (!NoTF32Guard::should_disable_tf32() &&
+	      at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
+	    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
+	  } else {
+	    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
+	  }
+	}
         at::cuda::blas::PointerModeGuard pointerModeGuard(handle, CUBLAS_POINTER_MODE_DEVICE);
         at::cuda::blas::dot<scalar_t>(
             handle,
@@ -934,6 +942,15 @@ Tensor vdot_cuda(const Tensor& self, const Tensor& other) {
     Tensor result = at::empty({}, self.options());
 
     auto handle = at::cuda::getCurrentCUDABlasHandle();
+    if (self.scalar_type() == at::kFloat || self.scalar_type() == at::kComplexFloat) {
+      if (!NoTF32Guard::should_disable_tf32() &&
+          at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
+        TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
+      } else {
+        TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
+      }
+    }
+
     at::cuda::blas::PointerModeGuard pointerModeGuard(
         handle, CUBLAS_POINTER_MODE_DEVICE);
     at::cuda::blas::vdot<scalar_t>(

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLibBlas.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLibBlas.cpp
@@ -91,14 +91,7 @@ void apply_geqrf_batched(const Tensor& input, const Tensor& tau) {
 
   int info;
   auto handle = at::cuda::getCurrentCUDABlasHandle();
-  if (input.dtype() == at::kFloat || input.dtype() == at::kComplexFloat) {
-    if (!NoTF32Guard::should_disable_tf32() &&
-        at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
-      TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
-    } else {
-      TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
-    }
-  }
+  at::cuda::maybeSetCUDABlasHandleTF32(input.scalar_type(), handle);
   at::cuda::blas::geqrfBatched(handle, m, n, input_ptr_array_data, lda, tau_ptr_array_data, &info, batch_size);
 
   // info only indicates wrong arguments to geqrfBatched call
@@ -154,14 +147,7 @@ static void apply_lu_solve_batched_cublas(const Tensor& LU, const Tensor& pivots
   auto b_ptr_array_data = reinterpret_cast<scalar_t**>(b_ptr_array.data_ptr());
 
   auto handle = at::cuda::getCurrentCUDABlasHandle();
-  if (LU.dtype() == at::kFloat || LU.dtype() == at::kComplexFloat) {
-    if (!NoTF32Guard::should_disable_tf32() &&
-        at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
-      TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
-    } else {
-      TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
-    }
-  }
+  at::cuda::maybeSetCUDABlasHandleTF32(LU.scalar_type(), handle);
   at::cuda::blas::getrsBatched(handle, trans, m, nrhs, const_cast<scalar_t**>(lu_ptr_array_data),
     lda, const_cast<int*>(pivots_data), b_ptr_array_data, lda, &info, batch_size);
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(info == 0);
@@ -197,14 +183,7 @@ static void apply_triangular_solve(const Tensor& A, const Tensor& B, bool left, 
     scalar_t* A_working_ptr = &A_data[i * A_mat_stride];
     scalar_t* B_working_ptr = &B_data[i * B_mat_stride];
     auto handle = at::cuda::getCurrentCUDABlasHandle();
-    if (A.dtype() == at::kFloat || A.dtype() == at::kComplexFloat) {
-      if (!NoTF32Guard::should_disable_tf32() &&
-          at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
-        TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
-      } else {
-        TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
-      }
-    }
+    at::cuda::maybeSetCUDABlasHandleTF32(A.scalar_type(), handle);
     at::cuda::blas::trsm(handle, side, uplo, trans, diag, m, n, &alpha, A_working_ptr, lda, B_working_ptr, ldb);
   }
 }
@@ -238,14 +217,7 @@ static void apply_triangular_solve_batched(const Tensor& A, const Tensor& B, boo
   auto B_ptr_array_data = reinterpret_cast<scalar_t**>(B_ptr_array.data_ptr());
 
   auto handle = at::cuda::getCurrentCUDABlasHandle();
-  if (A.dtype() == at::kFloat || A.dtype() == at::kComplexFloat) {
-    if (!NoTF32Guard::should_disable_tf32() &&
-        at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
-      TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
-    } else {
-      TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
-    }
-  }
+  at::cuda::maybeSetCUDABlasHandleTF32(A.scalar_type(), handle);
 
   at::cuda::blas::trsmBatched(handle, side, uplo, trans, diag, m, n, &alpha, A_ptr_array_data, lda, B_ptr_array_data, ldb, batch_size);
 }
@@ -310,14 +282,7 @@ inline void apply_gels_batched(const Tensor& A, Tensor& B, Tensor& infos) {
 
   auto infos_data = infos.data_ptr<int>();
   auto handle = at::cuda::getCurrentCUDABlasHandle();
-  if (A.dtype() == at::kFloat || A.dtype() == at::kComplexFloat) {
-    if (!NoTF32Guard::should_disable_tf32() &&
-        at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
-      TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
-    } else {
-      TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
-    }
-  }
+  at::cuda::maybeSetCUDABlasHandleTF32(A.scalar_type(), handle);
 
   int info;
 

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLibBlas.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLibBlas.cpp
@@ -91,6 +91,14 @@ void apply_geqrf_batched(const Tensor& input, const Tensor& tau) {
 
   int info;
   auto handle = at::cuda::getCurrentCUDABlasHandle();
+  if (input.dtype() == at::kFloat || input.dtype() == at::kComplexFloat) {
+    if (!NoTF32Guard::should_disable_tf32() &&
+        at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
+      TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
+    } else {
+      TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
+    }
+  }
   at::cuda::blas::geqrfBatched(handle, m, n, input_ptr_array_data, lda, tau_ptr_array_data, &info, batch_size);
 
   // info only indicates wrong arguments to geqrfBatched call
@@ -146,6 +154,14 @@ static void apply_lu_solve_batched_cublas(const Tensor& LU, const Tensor& pivots
   auto b_ptr_array_data = reinterpret_cast<scalar_t**>(b_ptr_array.data_ptr());
 
   auto handle = at::cuda::getCurrentCUDABlasHandle();
+  if (LU.dtype() == at::kFloat || LU.dtype() == at::kComplexFloat) {
+    if (!NoTF32Guard::should_disable_tf32() &&
+        at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
+      TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
+    } else {
+      TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
+    }
+  }
   at::cuda::blas::getrsBatched(handle, trans, m, nrhs, const_cast<scalar_t**>(lu_ptr_array_data),
     lda, const_cast<int*>(pivots_data), b_ptr_array_data, lda, &info, batch_size);
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(info == 0);
@@ -181,6 +197,14 @@ static void apply_triangular_solve(const Tensor& A, const Tensor& B, bool left, 
     scalar_t* A_working_ptr = &A_data[i * A_mat_stride];
     scalar_t* B_working_ptr = &B_data[i * B_mat_stride];
     auto handle = at::cuda::getCurrentCUDABlasHandle();
+    if (A.dtype() == at::kFloat || A.dtype() == at::kComplexFloat) {
+      if (!NoTF32Guard::should_disable_tf32() &&
+          at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
+        TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
+      } else {
+        TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
+      }
+    }
     at::cuda::blas::trsm(handle, side, uplo, trans, diag, m, n, &alpha, A_working_ptr, lda, B_working_ptr, ldb);
   }
 }
@@ -214,6 +238,15 @@ static void apply_triangular_solve_batched(const Tensor& A, const Tensor& B, boo
   auto B_ptr_array_data = reinterpret_cast<scalar_t**>(B_ptr_array.data_ptr());
 
   auto handle = at::cuda::getCurrentCUDABlasHandle();
+  if (A.dtype() == at::kFloat || A.dtype() == at::kComplexFloat) {
+    if (!NoTF32Guard::should_disable_tf32() &&
+        at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
+      TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
+    } else {
+      TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
+    }
+  }
+
   at::cuda::blas::trsmBatched(handle, side, uplo, trans, diag, m, n, &alpha, A_ptr_array_data, lda, B_ptr_array_data, ldb, batch_size);
 }
 
@@ -277,6 +310,15 @@ inline void apply_gels_batched(const Tensor& A, Tensor& B, Tensor& infos) {
 
   auto infos_data = infos.data_ptr<int>();
   auto handle = at::cuda::getCurrentCUDABlasHandle();
+  if (A.dtype() == at::kFloat || A.dtype() == at::kComplexFloat) {
+    if (!NoTF32Guard::should_disable_tf32() &&
+        at::globalContext().float32Precision("cuda", "matmul") == "tf32") {
+      TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
+    } else {
+      TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
+    }
+  }
+
   int info;
 
   at::cuda::blas::gelsBatched<scalar_t>(


### PR DESCRIPTION
For #161822

Basically #125888 appears to introduce measurable CPU overhead due to TF32 precision setting checks. Unfortunately one of the checks is in `getCurrentCUDABlasHandle`, which is called preceding _every_ cuBLAS matmul (and in a few other places such as workspace setup). We don't need to do this for non-`float32` matmuls so this PR is to alleviate the performance hit where it hurts the most (smaller dtypes that have faster matmuls) at the cost of some copypasta.

Some microbenchmark runs with this PR (microseconds):
```
7.812199214640714 
8.07804053692962 
7.865882366786536
7.898942214978888
8.018492849259928
```
and without
```
8.222943563396257
8.129948014357069
8.184711361991504
8.28010104214627
8.266569921033806
```

script:
```
import torch
import time

warmup = 128
iters = 16384

a = torch.zeros(512, 512, device='cuda', dtype=torch.bfloat16)
for _ in range(warmup):
    torch.matmul(a, a)

torch.cuda.synchronize()
t0 = time.perf_counter()
for _ in range(iters):
    torch.matmul(a, a)
torch.cuda.synchronize()
t1 = time.perf_counter()
print(f"{1e6 * (t1 - t0)/iters}")
```

Longer term we'd prefer making `float32Precision` faster (better data structures, less validation, etc.?)

cc @ptrblck @msaroufim @jerryzh168 @csarofeen @xwang233 @zasdfgbnm