### PR TITLE
[RFC][pt2] Add support for supplying an external worker to compile Triton

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -769,6 +769,10 @@ worker_suppress_logging: bool = Config(
     default=True,
 )
 
+# Supply an override for a standalone compiler worker binary.
+# Intended for internal use.
+worker_path_override = os.environ.get("TORCHINDUCTOR_WORKER_PATH_OVERRIDE")
+
 # Log per-operation runtime estimates for TLParse analysis.
 log_tlparse: bool = Config(
     env_name_force="LOG_TLPARSE",


### PR DESCRIPTION
Summary: If we use the current approach and start the worker using whatever binary started us, we accumulate the memory overhead of that (potentially fat) binary. This adds the inductor changes to allow us to specify an external worker, presumably built against the same rev used to build the torch library.

Test Plan:
New unit test

Rollback Plan:

Differential Revision: D81356325


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben