### PR TITLE
Remove background thread UT on XPU to fix CI

### DIFF
--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -607,17 +607,6 @@ if __name__ == "__main__":
             z[0] = z[0] + 1.0
             self.assertEqual(z, x)
 
-    def test_background_thread_for_pin_memory(self):
-        # Just ensure no crash
-        torch._C._accelerator_setAllocatorSettings("pinned_use_background_threads:True")
-        cpu_tensor = torch.randn(100)
-        pin_tensor = cpu_tensor.pin_memory()
-        xpu_tensor = pin_tensor.to(device="xpu", non_blocking=True)
-        torch.xpu.synchronize()
-        del pin_tensor
-        gc.collect()
-        self.assertEqual(xpu_tensor.cpu(), cpu_tensor)
-
 
 instantiate_device_type_tests(TestXpu, globals(), only_for="xpu", allow_xpu=True)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #161844

# Motivation
Because we revert `torch._C._set_allocator_settings` in https://github.com/pytorch/pytorch/pull/161626, this UT becomes invalid.
Fix https://github.com/pytorch/pytorch/issues/161697
