### PR TITLE
chore: use patchelf from PATH

### DIFF
--- a/.ci/manywheel/build_common.sh
+++ b/.ci/manywheel/build_common.sh
@@ -81,7 +81,8 @@ fi
 
 mkdir -p /tmp/$WHEELHOUSE_DIR
 
-export PATCHELF_BIN=/usr/local/bin/patchelf
+PATCHELF_BIN="$(command -v patchelf)"
+export PATCHELF_BIN
 patchelf_version=$($PATCHELF_BIN --version)
 echo "patchelf version: " $patchelf_version
 if [[ "$patchelf_version" == "patchelf 0.9" ]]; then


### PR DESCRIPTION
    some distrubtions have binaries inside /usr/bin, this commit
    looks for patchelf binary using `command -v` which is a builtin in
    both sh and bash. This way we'll look for patchelf binary inside PATH
    and we'll be able to build torch wheels on other distributions as well
    without patching the code.

    the diff is also compatible with https://www.shellcheck.net/wiki/SC2155

Signed-off-by: kranurag7 <81210977+kranurag7@users.noreply.github.com>
