### PR TITLE
[AOTI] split too long string to smaller pieces when its length larger than 16000, fix msvc c2026.

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -35,15 +35,6 @@ from .wrapper import (
 )
 
 
-# MSVC string was longer than the limit of 16380 single-byte characters.
-# https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2026
-MSVC_C2026_MAX_STRING_LENGTH = 16000
-
-
-def truncate_string(s: str, length: int) -> list[str]:
-    return [s[i : i + length] for i in range(0, len(s), length)]
-
-
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -730,6 +721,28 @@ class CppWrapperCpu(PythonWrapperCodegen):
                     )
             self.prefix.writeline("}")
 
+    # MSVC string was longer than the limit of 16380 single-byte characters.
+    # https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2026
+    MSVC_C2026_MAX_STRING_LENGTH = 16000
+
+    def codegen_write_arg_with_large_length_string(
+        self,
+        arg_name: str,
+        arg_str_val: str,
+        max_truncate_length: int = MSVC_C2026_MAX_STRING_LENGTH,
+    ):
+        def truncate_string(s: str, length: int) -> list[str]:
+            return [s[i : i + length] for i in range(0, len(s), length)]
+
+        if len(arg_str_val) > max_truncate_length:
+            serialized_in_spec_strs = truncate_string(arg_str_val, max_truncate_length)
+            self.prefix.writeline(f"{arg_name} =")
+            for truncate_str in serialized_in_spec_strs:
+                self.prefix.writeline(f'R"({truncate_str})"')
+            self.prefix.writeline(";")
+        else:
+            self.prefix.writeline(f'{arg_name} = R"({arg_str_val})";')
+
     def codegen_model_constructor(self):
         """
         // Generated code example
@@ -877,38 +890,17 @@ class CppWrapperCpu(PythonWrapperCodegen):
                     .replace("\t", "\\t")
                 )
 
-            if (
-                len(config.aot_inductor.serialized_in_spec)
-                > MSVC_C2026_MAX_STRING_LENGTH
-            ):
-                serialized_in_spec_strs = truncate_string(
-                    config.aot_inductor.serialized_in_spec, MSVC_C2026_MAX_STRING_LENGTH
-                )
-                self.prefix.writeline("in_spec_ =")
-                for truncate_str in serialized_in_spec_strs:
-                    self.prefix.writeline(f'R"({truncate_str})"')
-                self.prefix.writeline(";")
-            else:
-                self.prefix.writeline(
-                    f'in_spec_ = R"({config.aot_inductor.serialized_in_spec})";'
-                )
-
-            if (
-                len(config.aot_inductor.serialized_out_spec)
-                > MSVC_C2026_MAX_STRING_LENGTH
-            ):
-                serialized_out_spec_strs = truncate_string(
-                    config.aot_inductor.serialized_out_spec,
-                    MSVC_C2026_MAX_STRING_LENGTH,
-                )
-                self.prefix.writeline("out_spec_ =")
-                for truncate_str in serialized_out_spec_strs:
-                    self.prefix.writeline(f'R"({truncate_str})"')
-                self.prefix.writeline(";")
-            else:
-                self.prefix.writeline(
-                    f'out_spec_ = R"({config.aot_inductor.serialized_out_spec})";'
-                )
+            # Origin code: self.prefix.writeline(f'in_spec_ = R"({config.aot_inductor.serialized_in_spec})";')
+            # Fix msvc C2026 error via codegen_write_arg_with_large_length_string
+            self.codegen_write_arg_with_large_length_string(
+                arg_name="in_spec_", arg_str_val=config.aot_inductor.serialized_in_spec
+            )
+            # Origin code: self.prefix.writeline(f'out_spec_ = R"({config.aot_inductor.serialized_out_spec})";')
+            # Fix msvc C2026 error via codegen_write_arg_with_large_length_string
+            self.codegen_write_arg_with_large_length_string(
+                arg_name="out_spec_",
+                arg_str_val=config.aot_inductor.serialized_out_spec,
+            )
 
             for idx, output in enumerate(V.graph.graph_outputs):
                 assert not isinstance(output, sympy.Expr), (

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -735,9 +735,9 @@ class CppWrapperCpu(PythonWrapperCodegen):
             return [s[i : i + length] for i in range(0, len(s), length)]
 
         if len(arg_str_val) > max_truncate_length:
-            serialized_in_spec_strs = truncate_string(arg_str_val, max_truncate_length)
+            truncated_strs = truncate_string(arg_str_val, max_truncate_length)
             self.prefix.writeline(f"{arg_name} =")
-            for truncate_str in serialized_in_spec_strs:
+            for truncate_str in truncated_strs:
                 self.prefix.writeline(f'R"({truncate_str})"')
             self.prefix.writeline(";")
         else:


### PR DESCRIPTION
Split too long string to smaller pieces when its length larger than 16000, fix msvc c2026.

reproducer:
```cmd
pytest test\inductor\test_aot_inductor.py -v -k test_runtime_checks_large_cpu
```

Error message:
<img width="1660" height="174" alt="image" src="https://github.com/user-attachments/assets/56fcd9be-24cb-484b-bfdc-f719ff2650b8" />

For MSVC c2026:
https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2026?view=msvc-170

We can split too long string to smaller pieces, it can fix this issue.

Local validated:
<img width="1122" height="232" alt="image" src="https://github.com/user-attachments/assets/cac54cc9-be51-4a5d-b408-06755a4debd5" />


cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben