### PR TITLE
Fix `Tensor.item` within the compile region

### DIFF
--- a/test/dynamo/test_compile.py
+++ b/test/dynamo/test_compile.py
@@ -31,6 +31,17 @@ class InPlaceCompilationTests(TestCase):
         model(x)
         self.assertEqual(cnt.frame_count, 1)
 
+    @torch._dynamo.config.patch(capture_scalar_outputs=True)
+    def test_tensor_item(self):
+        @torch.compile(backend="eager", fullgraph=True)
+        def f():
+            x = torch.tensor([5])
+            torch._check(x.item() == 5)
+            return x
+
+        x = f()
+        self.assertEqual(x.item(), 5)
+
     def test_overwrite_call_impl(self):
         torch._dynamo.reset()
         model = ToyModel()

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -3038,7 +3038,7 @@ def handle_traced_output(example_value, tx, proxy, options, subclass_type, targe
         ]
         or (
             # TODO: this is a little sus, because we didn't check what the self is
-            proxy.node.op == "call_method" and proxy.node.target == "bit_length"
+            proxy.node.op == "call_method" and proxy.node.target in ["bit_length", "item"]
         )
     ):
         set_example_value(proxy.node, example_value)


### PR DESCRIPTION
Fixes #156135 



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @mlazos @chenyang78