### PR TITLE
[STABLE ABI] Add accessor template method to torch::stable::Tensor

### DIFF
--- a/torch/csrc/stable/tensor_struct.h
+++ b/torch/csrc/stable/tensor_struct.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <ATen/core/TensorAccessor.h>
+
 #include <torch/csrc/inductor/aoti_torch/c/shim.h>
 #include <torch/csrc/inductor/aoti_runtime/mini_array_ref.h>
 #include <torch/headeronly/core/ScalarType.h>
@@ -181,6 +183,19 @@ class Tensor {
     int64_t* ptr;
     TORCH_ERROR_CODE_CHECK(aoti_torch_get_strides(ath_.get(), &ptr));
     return torch::aot_inductor::MiniArrayRef<int64_t>(ptr, dim());
+  }
+
+  template<typename T, size_t N>
+  at::TensorAccessor<T,N> accessor() const& {
+    static_assert(N > 0, "accessor is used for indexing tensor, for scalars use *data_ptr<T>()");
+    STD_TORCH_CHECK(dim() == N, "TensorAccessor expected ", N, " dims but tensor has ", dim());
+    T* ptr = nullptr;
+    if constexpr (std::is_const_v<T>) {
+      ptr = const_data_ptr<T>();
+    } else {
+      ptr = mutable_data_ptr<T>();
+    }
+    return at::TensorAccessor<T,N>(ptr,sizes().data(),strides().data());
   }
 
   bool defined() const {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #161911
* #161897
* #161896
* #161895
* #161894
* __->__ #161893
* #161892
* #161891

