### PR TITLE
constant_pad_nd: allow zero-sized dims with mixed positive/negative pads; added regression test

### DIFF
--- a/aten/src/ATen/native/PadNd.cpp
+++ b/aten/src/ATen/native/PadNd.cpp
@@ -73,7 +73,7 @@ Tensor constant_pad_nd(const Tensor& self, IntArrayRef pad, const Scalar& value)
     for (const auto i : c10::irange((size_t)l_pad)) {
         auto pad_idx = pad.size() - ((i + 1) * 2);
         auto new_dim = input_sizes[l_diff + i] + pad[pad_idx] + pad[pad_idx + 1];
-        TORCH_CHECK(new_dim > 0, "The input size ", input_sizes[l_diff + i], ", plus negative padding ",
+        TORCH_CHECK(new_dim >= 0, "The input size ", input_sizes[l_diff + i], ", plus negative padding ",
                  pad[pad_idx], " and ", pad[pad_idx + 1], " resulted in a negative output size, "
                  "which is invalid. Check dimension ", l_diff + i, " of your input.");
         new_shape.emplace_back(new_dim);

--- a/test/test_constant_pad_nd.py
+++ b/test/test_constant_pad_nd.py
@@ -29,7 +29,7 @@ class TestConstantPadNd(TestCase):
         assert z.numel() == 0
 
     @onlyNativeDeviceTypes
-    @dtypes(*floating_types)
+    @dtypes(*floating_types())
     def test_constant_pad_nd_devices(self, device, dtype):
         x = torch.ones(5, 3, device=device, dtype=dtype)
         y = torch.ops.aten.constant_pad_nd.default(x, [-1, -2, 1, 1], 0)

--- a/test/test_constant_pad_nd.py
+++ b/test/test_constant_pad_nd.py
@@ -1,0 +1,31 @@
+import pytest
+import torch
+import torch.nn.functional as F
+
+# --- EAGER BEHAVIOR TESTS (most important) ---
+
+def test_constant_pad_nd_mixed_pos_neg_allows_zero_cpu():
+    x = torch.ones(5, 3)
+    y = torch.ops.aten.constant_pad_nd.default(x, [-1, -2, 1, 1], 0)
+    assert tuple(y.shape) == (7, 0)
+    assert y.numel() == 0
+
+def test_constant_pad_nd_negative_size_still_errors_cpu():
+    x = torch.ones(5, 3)
+    # This would make width 3 - 2 - 2 = -1 → must error
+    with pytest.raises(RuntimeError):
+        torch.ops.aten.constant_pad_nd.default(x, [-2, -2], 0)
+
+def test_fpad_matches_constant_pad_nd_cpu():
+    x = torch.ones(5, 3)
+    z = F.pad(x, (-1, -2, 1, 1), mode="constant", value=0)
+    assert tuple(z.shape) == (7, 0)
+    assert z.numel() == 0
+
+# Optional: run on MPS/CUDA if available (kept simple to avoid internal test infra)
+@pytest.mark.parametrize("device", [d for d in ["cpu", "cuda", "mps"] if torch.device(d).type in {"cpu","cuda","mps"} and (d=="cpu" or torch.cuda.is_available() if d=="cuda" else torch.backends.mps.is_available())])
+def test_constant_pad_nd_devices(device):
+    x = torch.ones(5, 3, device=device)
+    y = torch.ops.aten.constant_pad_nd.default(x, [-1, -2, 1, 1], 0)
+    assert tuple(y.shape) == (7, 0)
+    assert y.numel() == 0

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -2956,7 +2956,7 @@ def constant_pad_nd(
         pad_idx = len(pad) - ((i + 1) * 2)
         new_dim = input_sizes[l_diff + i] + pad[pad_idx] + pad[pad_idx + 1]
         torch._check(
-            new_dim > 0,
+            new_dim >= 0, #Allow for zero size output
             lambda: f"The input size {input_sizes[l_diff + i]}, plus negative padding "
             f"{pad[pad_idx]} and {pad[pad_idx + 1]} resulted in a negative output size, "
             f"which is invalid. Check dimension {l_diff + i} of your input.",

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -2956,7 +2956,7 @@ def constant_pad_nd(
         pad_idx = len(pad) - ((i + 1) * 2)
         new_dim = input_sizes[l_diff + i] + pad[pad_idx] + pad[pad_idx + 1]
         torch._check(
-            new_dim >= 0, #Allow for zero size output
+            new_dim >= 0, # Allow for zero size output
             lambda: f"The input size {input_sizes[l_diff + i]}, plus negative padding "
             f"{pad[pad_idx]} and {pad[pad_idx + 1]} resulted in a negative output size, "
             f"which is invalid. Check dimension {l_diff + i} of your input.",


### PR DESCRIPTION
Fixes #161014

### Summary
`aten::constant_pad_nd` incorrectly errors when mixed positive/negative pads
produce a zero-sized dimension (e.g., on a [5, 3] tensor, pads [-1, -2, 1, 1]
should yield shape [7, 0]). Zero-sized dims are valid; only negative sizes should error.

### What changed
- Relax size check from `> 0` to `>= 0`:
  - Python decomposition: torch/_refs/__init__.py
  - Native implementation: aten/src/ATen/native/PadNd.cpp
- Added regression tests: test/test_constant_pad_nd.py

### Test plan
- `pytest -q test/test_constant_pad_nd.py` passes locally.
- Verified:
  - `constant_pad_nd(x, [-1, -2]) -> (5, 0)` still OK
  - `constant_pad_nd(x, [-1, -2, 1, 1]) -> (7, 0)` now OK
  - Truly negative result (e.g., [-2, -2]) still raises.

### Notes
- Behavior aligns eager and decomposition/meta paths.
