### PR TITLE
Re-enable fusions for AArch64.

### DIFF
--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -1523,11 +1523,7 @@ if torch._C._has_mkldnn:
     def _mkldnn_fusion_init():
         # TODO: aarch64: enable op fusion for acl once it supports fused operators. Disabling it for now.
         # Otherwise even the matmul or innerproduct can not be accelerated with acl
-        if (
-            torch.backends.mkldnn.enabled
-            and torch.backends.mkldnn.is_available()
-            and not torch.ops.mkldnn._is_mkldnn_acl_supported()
-        ):
+        if torch.backends.mkldnn.enabled and torch.backends.mkldnn.is_available():
             _register_unary_fusion()
             _register_inplace_fusion()
             _register_binary_unary_fusion()


### PR DESCRIPTION
> [!CAUTION]
> **DRAFT RELEASE!**

## Summary

This PR re-enables fusions for AArch64 in compile mode.

## Motivation

- The fusion logic on AArch64 was disabled due to previous issues with fusions in oneDNN; this has been addressed in https://github.com/uxlfoundation/oneDNN/pull/3767, allowing arbitrary post-ops (activations) with the ACL `matmul` and `inner_product` primitives.

## Changes

- Re-enables fusions in compile mode on AArch64 by reverting the relevant change in https://github.com/pytorch/pytorch/commit/7faa67f6efd4453befc6822b829a3a79fc31f163.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben