### PR TITLE
Dispatch GELU to oneDNN in compile mode.

### DIFF
--- a/aten/src/ATen/native/mkldnn/RegisterMkldnnOpContextClass.cpp
+++ b/aten/src/ATen/native/mkldnn/RegisterMkldnnOpContextClass.cpp
@@ -42,6 +42,8 @@ TORCH_LIBRARY(mkldnn, m) {
           });
 
   m.def(TORCH_SELECTIVE_SCHEMA(
+      "mkldnn::_gelu(Tensor X, str algorithm) -> Tensor Y"));
+  m.def(TORCH_SELECTIVE_SCHEMA(
       "mkldnn::_linear_pointwise(Tensor X, Tensor W, Tensor? B, str attr, Scalar?[] scalars, str? algorithm) -> Tensor Y"));
   m.def(TORCH_SELECTIVE_SCHEMA(
       "mkldnn::_linear_pointwise.binary(Tensor X, Tensor other, Tensor W, Tensor? B, str attr) -> Tensor Y"));

--- a/torch/_inductor/mkldnn_lowerings.py
+++ b/torch/_inductor/mkldnn_lowerings.py
@@ -222,6 +222,7 @@ def register_onednn_fusion_ops():
             kernel_creator=mkldnn_ir.QLinearPointwiseBinaryPT2E.create,
         )
         cpu_needs_realized_inputs = [
+            torch.ops.mkldnn._gelu,
             torch.ops.mkldnn._convolution_pointwise,
             torch.ops.mkldnn._convolution_pointwise_,
             torch.ops.mkldnn._convolution_transpose_pointwise,
@@ -229,6 +230,10 @@ def register_onednn_fusion_ops():
             aten.mkldnn_rnn_layer.default,
             torch.ops.onednn.qconv_pointwise,
         ]
+
+        @register_lowering(torch.ops.mkldnn._gelu)
+        def gelu(x: TensorBox, algorithm):
+            return TensorBox.create(mkldnn_ir.Gelu.create(x, algorithm))
 
         @register_lowering(torch.ops.mkldnn._convolution_pointwise)
         def convolution_unary(

--- a/torch/csrc/inductor/aoti_torch/c/shim_cpu.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim_cpu.h
@@ -112,6 +112,11 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu_mkldnn_rnn_layer(
     AtenTensorHandle* ret2,
     AtenTensorHandle* ret3);
 
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu__gelu(
+    AtenTensorHandle X,
+    const char* algorithm,
+    AtenTensorHandle* ret0);
+
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu__linear_pointwise(
     AtenTensorHandle X,
     AtenTensorHandle W,

--- a/torch/csrc/inductor/aoti_torch/shim_cpu.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_cpu.cpp
@@ -255,6 +255,16 @@ AOTITorchError aoti_torch_cpu__linear_pointwise(
   });
 }
 
+AOTITorchError aoti_torch_cpu__gelu(
+    AtenTensorHandle X,
+    const char* algorithm,
+    AtenTensorHandle* ret0) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    auto tmp_result = at::native::mkldnn_gelu(*tensor_handle_to_tensor_pointer(X), algorithm);
+    *ret0 = new_tensor_handle(std::move(tmp_result));
+  });
+}
+
 AOTITorchError aoti_torch_cpu__linear_pointwise_binary(
     AtenTensorHandle X,
     AtenTensorHandle other,


### PR DESCRIPTION
> [!CAUTION]
> **DRAFT RELEASE!**

## Summary

This PR introduces a dedicated `mkldnn::_gelu` operator and ensures `GELU(approximate="none")` subgraphs are lowered to a oneDNN eltwise GELU on CPU.

## Motivation

- On CPU, GELU appears post-decomposition as `mul(x*0.5, add(erf(x*sqrt(0.5)), 1))`, which is later replaced with a codegen-ed `Vectorized` implementation, instead of using faster implementations from oneDNN/ACL when available.

## Changes

- New op `mkldnn::_gelu(Tensor X, str algorithm)` calling oneDNN eltwise GELU; returns dense for dense inputs.
- Adds a new `Gelu` lowering + Inductor IR and AOTI shim `aoti_torch_cpu__gelu(...)`.
- Defines a fusion pattern (in the post-grad step) that recognises the decomposed GELU subgraph and lowers it to `mkldnn::_gelu` on pass number 2 (0-indexed), to ensure it only occurs after higher-priority linear/conv fusions.

## Remarks
- Uses oneDNN `eltwise_gelu_erf`; only approximate="none" is supported by this path.
- Returns dense for dense inputs so downstream ATen pointwise ops don't see a `torch._mkldnn` layout unexpectedly.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @malfet @snadampal @milpuz01 @aditew01 @nikhil-arm @fadara01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben