### PR TITLE
[inductor] Follow integer overflow rules in TypedExpr

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6082,7 +6082,7 @@ class CommonTemplate:
         )
 
     def test_unsigned_constant_tensors(self):
-        def foo(x):
+        def fn(x):
             c = torch.tensor(7, dtype=torch.uint8)
             return c + x, torch.neg(c), torch.neg(c) + x
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6081,6 +6081,16 @@ class CommonTemplate:
             (torch.randn([8, 16, 8, 8]),),
         )
 
+    def test_unsigned_constant_tensors(self):
+        def foo(x):
+            c = torch.tensor(7, dtype=torch.uint8)
+            return c + x, torch.neg(c), torch.neg(c) + x
+
+        self.common(
+            fn,
+            (torch.randn([16, 16]),),
+        )
+
     # Disable size_asserts for this test due to https://github.com/pytorch/pytorch/issues/145963
     @config.patch(size_asserts=os.environ.get("TORCHINDUCTOR_SIZE_ASSERTS") == "1")
     @torch._dynamo.config.patch(capture_dynamic_output_shape_ops=True)

--- a/torch/_inductor/index_propagation.py
+++ b/torch/_inductor/index_propagation.py
@@ -74,6 +74,8 @@ class TypedExpr:
                 if self.dtype.is_signed:
                     expr = expr + 2 ** (bits - 1)
                 expr = expr % 2**bits
+                if self.dtype.is_signed:
+                    expr = expr - 2 ** (bits - 1)
             self.expr = expr
 
 

--- a/torch/_inductor/index_propagation.py
+++ b/torch/_inductor/index_propagation.py
@@ -68,7 +68,13 @@ class TypedExpr:
             expr = self.expr
             if isinstance(expr, sympy.Expr):
                 expr = expr.expand(identity=True)
-            self.expr = dtype_to_type(self.dtype)(expr)
+            expr = dtype_to_type(self.dtype)(expr)
+            if is_integer_dtype(self.dtype):
+                bits = torch.iinfo(self.dtype).bits
+                if self.dtype.is_signed:
+                    expr = expr + 2 ** (bits - 1)
+                expr = expr % 2**bits
+            self.expr = expr
 
 
 class SymPyOps:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #161922

Fixes https://github.com/pytorch/pytorch/issues/161763

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @mlazos