### PR TITLE
[inductor] Fix removal of constexpr args from the launcher signature

### DIFF
--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -1281,8 +1281,8 @@ def forward(self, x_1, output_1):
         self.assertEqual(compiled_out, eager_out)
 
     @requires_gpu
-    @common_utils.parametrize("dump_launch_params", [False, True])
-    @common_utils.parametrize("dynamic", ["0", "1"])
+    @common_utils.parametrize("dump_launch_params", ["0", "1"])
+    @common_utils.parametrize("dynamic", [False, True])
     def test_triton_kernel_equal_to_1_arg(self, dynamic, dump_launch_params):
         os.environ["TORCHINDUCTOR_DUMP_LAUNCH_PARAMS"] = dump_launch_params
 

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -4,6 +4,7 @@
 # Skip do not assign a lambda expression, use a def
 import functools
 import logging
+import os
 
 import torch
 import torch._dynamo.testing
@@ -1280,8 +1281,11 @@ def forward(self, x_1, output_1):
         self.assertEqual(compiled_out, eager_out)
 
     @requires_gpu
-    @common_utils.parametrize("dynamic", [False, True])
-    def test_triton_kernel_equal_to_1_arg(self, dynamic):
+    @common_utils.parametrize("dump_launch_params", [False, True])
+    @common_utils.parametrize("dynamic", ["0", "1"])
+    def test_triton_kernel_equal_to_1_arg(self, dynamic, dump_launch_params):
+        os.environ["TORCHINDUCTOR_DUMP_LAUNCH_PARAMS"] = dump_launch_params
+
         @triton.jit
         def add_kernel_half_n_elements(
             in_ptr0,

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6767,6 +6767,13 @@ class UserDefinedTritonKernel(ExternKernel):
                 args.append(arg.codegen_reference())
                 arg_types.append(arg.get_dtype())
             elif isinstance(arg, (int, float, bool, sympy.Expr)):
+                # See #160000 and #145515, equals-to-1 args are treated as constexpr
+                if (
+                    name in named_args
+                    and V.graph.sizevars.statically_known_equals(arg, 1)
+                    and triton_version_uses_attrs_dict()
+                ):
+                    continue
                 args.append(arg)
                 arg_types.append(type(arg))
             elif name in constexpr_names:

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6767,13 +6767,6 @@ class UserDefinedTritonKernel(ExternKernel):
                 args.append(arg.codegen_reference())
                 arg_types.append(arg.get_dtype())
             elif isinstance(arg, (int, float, bool, sympy.Expr)):
-                # See #160000 and #145515, equals-to-1 args are treated as constexpr
-                if (
-                    name in named_args
-                    and V.graph.sizevars.statically_known_equals(arg, 1)
-                    and triton_version_uses_attrs_dict()
-                ):
-                    continue
                 args.append(arg)
                 arg_types.append(type(arg))
             elif name in constexpr_names:

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1313,11 +1313,8 @@ class CachingAutotuner(KernelInterface):
                 # constexprs are not passed in as args
                 return [
                     x
-                    for x in self.triton_meta["signature"].keys()
-                    # Also include constants that are None or equal to 1 as these
-                    # are marked as constexpr
-                    if x not in cfg.kwargs.keys()
-                    and x not in self.triton_meta["constants"]
+                    for i, x in enumerate(self.triton_meta["signature"].keys())
+                    if x not in cfg.kwargs.keys() and i not in self.fn.constexprs
                 ]
         else:
 
@@ -1427,23 +1424,12 @@ class CompileResult(Generic[_T]):
         if triton_version_uses_attrs_dict():
             call_args = arg_names
             def_args = arg_names
-            equals_to_1 = OrderedSet(
-                [
-                    c
-                    for c in compile_meta["constants"]
-                    if compile_meta["constants"][c] == 1
-                ]
-            )
-            implicit_constants = (
-                OrderedSet(
-                    (
-                        "num_warps",
-                        "num_stages",
-                    )
+            implicit_constants = OrderedSet(
+                (
+                    "num_warps",
+                    "num_stages",
                 )
-                .union(OrderedSet(k for k in known_constants))
-                .union(equals_to_1)
-            )
+            ).union(OrderedSet(k for k in known_constants))
             if implicit_constants := implicit_constants & OrderedSet(
                 compile_meta["constants"].keys()
             ):

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1314,7 +1314,7 @@ class CachingAutotuner(KernelInterface):
                 return [
                     x
                     for i, x in enumerate(self.triton_meta["signature"].keys())
-                    if x not in cfg.kwargs.keys() and i not in self.fn.constexprs
+                    if i not in self.fn.constexprs
                 ]
         else:
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1311,11 +1311,23 @@ class CachingAutotuner(KernelInterface):
 
             def filtered_signature() -> list[str]:
                 # constexprs are not passed in as args
-                return [
-                    x
-                    for i, x in enumerate(self.triton_meta["signature"].keys())
-                    if i not in self.fn.constexprs
-                ]
+                new_signature: list[str] = []
+                from triton.runtime.interpreter import InterpretedFunction
+
+                for i, x in enumerate(self.triton_meta["signature"].keys()):
+                    if isinstance(self.fn, InterpretedFunction):
+                        # These are torch compiled triton kernels that definitely
+                        # have block size configs. Dynamo does not currently
+                        # trace user defined triton kernels when TRITON_INTERPRET=1
+                        if x not in cfg.kwargs.keys():
+                            new_signature.append(x)
+                    elif i not in self.fn.constexprs:
+                        # use constexprs rather than just configs since user
+                        # defined triton kernels may not have any configs
+                        new_signature.append(x)
+
+                return new_signature
+
         else:
 
             def filtered_signature() -> list[str]:


### PR DESCRIPTION
Fixes the case described below which occurs when:
- A user `torch.compile`s a function that uses a triton kernel.
- `TORCHINDUCTOR_DUMP_LAUNCH_PARAMS=1` .

Problem:

If the user defined triton kernel is not autotuned:

```python
import os
os.environ["TORCHINDUCTOR_DUMP_LAUNCH_PARAMS"] = "1"
@triton.jit
def kernel(..., BLOCK_SIZE: tl.constexpr):
    ...
@torch.compile
def fn(..)
    kernel[..](..., 128)

fn(..)
```

Then In `triton_heuristics. _interpret_args_grid`, `filter_signature` function:

```python
        def filtered_signature() -> list[str]:
                # constexprs are not passed in as args
                return [
                    x
                    for x in self.triton_meta["signature"].keys()
                    if x not in cfg.kwargs.keys()
                ]
```

because `triton.autotune` is not used on the the `triton.jit` function, `cfg` above will be empty, and so `BLOCK_SIZE` will not be removed from the signature even though it is constexpr, even though it is removed from the arguments that are passed in to `interpret_args_grid`. This results in a mismatch between the number of parameters in the signature and the number of arguments, which leads to the error `NameError: name '_grid_2' is not defined`. 

Fix:

Use the triton jit kernel `constexprs` for args to remove.  Not sure if this is a good fix so suggestions are welcome.

Test plan: 

Added a parameter to an existing triton kernel to test for this edge case


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben