### PR TITLE
[DTensor] forbid view ops to redistribute when local split is impossible

### DIFF
--- a/torch/distributed/tensor/_ops/_view_ops.py
+++ b/torch/distributed/tensor/_ops/_view_ops.py
@@ -519,45 +519,48 @@ def propagate_shape_and_sharding(
                 return i, placement
         return None, None
 
+    # NOTE: This function has three responsibilities:
+    # 1. determine "theoretically" if an output dimension can be sharded, i.e. fill the shardable_dims map
+    # 2. determine "theoretically" the corresponding input dimension to shard on, via return value
+    # 3. throw an error when strict_view is enabled and we cannot shard an output dimension
+    # 1 and 2 doesn't require the info of whether current input is sharded.
+    # 3 requires that info, to decide whether we can error out. Maybe we can refactor
+    # to make this function purely "theoretical".
     def get_in_dim_to_shard(cmd: DimSpec) -> Optional[InputDim]:
-        # TODO(whc) this helper is pretty hard to understand, at least it should be better documented if not refactored
         if isinstance(cmd, InputDim):
             return cmd
         elif isinstance(cmd, Flatten):
             for i, dim in enumerate(cmd.input_dims):
-                if isinstance(dim, InputDim):
-                    can_shard_dim = True
-                    shard_mesh_dim, shard_placement = (
-                        maybe_get_shard_mesh_dim_and_placement(dim)
-                    )
-                    input_sharded = shard_mesh_dim is not None
-                    if i > 0:
-                        can_shard_dim = False
-                        if strict_view and input_sharded:
-                            raise RuntimeError(
-                                f"Attempted to flatten sharded dimension {i}, ",
-                                "but only the leftmost dim of a Flatten can be sharded.",
-                            )
-                    elif input_sharded:
-                        assert (
-                            shard_placement is not None and shard_mesh_dim is not None
+                # so far all Flatten is always composed of InputDims; revisit this if needed
+                assert isinstance(dim, InputDim)
+                can_shard_dim = True
+                shard_mesh_dim, shard_placement = (
+                    maybe_get_shard_mesh_dim_and_placement(dim)
+                )
+                input_sharded = shard_mesh_dim is not None
+                if i > 0:
+                    can_shard_dim = False
+                    if strict_view and input_sharded:
+                        raise RuntimeError(
+                            f"Attempted to flatten multiple dimensions, with dimension {dim.input_dim} being sharded. ",
+                            "It cannot be performed without redistribution, which is disallowed by the current operator.",
                         )
-                        tensor_dim_size = global_input_shape[shard_placement.dim]
-                        mesh_dim_size = mesh_sizes[shard_mesh_dim]
-                        if tensor_dim_size % mesh_dim_size != 0:
-                            can_shard_dim = False
-                            if strict_view:
-                                raise RuntimeError(
-                                    f"Attempted to flatten unevenly sharded dimension {i}, "
-                                    "which would require resharding the input. "
-                                    "Please explicitly redistribute the tensor instead."
-                                )
+                elif input_sharded:
+                    assert shard_placement is not None and shard_mesh_dim is not None
+                    tensor_dim_size = global_input_shape[shard_placement.dim]
+                    mesh_dim_size = mesh_sizes[shard_mesh_dim]
+                    if tensor_dim_size % mesh_dim_size != 0:
+                        can_shard_dim = False
+                        if strict_view:
+                            raise RuntimeError(
+                                f"Attempted to flatten unevenly sharded dimension {i}, "
+                                "which would require resharding the input. "
+                                "Please explicitly redistribute the tensor instead."
+                            )
+                shardable_dims[dim.input_dim] = [can_shard_dim] * mesh_ndim
 
-                    shardable_dims[dim.input_dim] = [can_shard_dim] * mesh_ndim
-            dim0 = cmd.input_dims[0]
-            # TODO(whc) dim0 can be sharded or not sharded, can't it?
-            # should we only return it if its sharded in the placement?
-            return dim0 if isinstance(dim0, InputDim) else None
+            assert isinstance(cmd.input_dims[0], InputDim)
+            return cmd.input_dims[0]
         elif isinstance(cmd, Split):
             in_dim = get_in_dim_to_shard(cmd.input_dim)
             out_size = cmd.group_shape[cmd.split_id]
@@ -575,6 +578,14 @@ def propagate_shape_and_sharding(
                 shardable_dims[in_dim.input_dim] = [
                     out_size % mesh_dim_size == 0 for mesh_dim_size in mesh_sizes
                 ]
+
+                shard_mesh_dim, _ = maybe_get_shard_mesh_dim_and_placement(in_dim)
+                if strict_view and shard_mesh_dim is not None:
+                    if not shardable_dims[in_dim.input_dim][shard_mesh_dim]:
+                        raise RuntimeError(
+                            f"Attempted to split the sharded dimension {in_dim.input_dim} into multiple subdimensions. ",
+                            "It cannot be performed without redistribution, which is disallowed by the current operator.",
+                        )
 
                 # 2. here we special case things like [Shard(0), Shard(0)]
                 submesh_size = 1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #161950

This PR is a followup to https://github.com/pytorch/pytorch/pull/149764.

In that PR, it only forbids illegal view due to `Flatten`; this PR also forbids illegal view caused by `Split`.

This PR also updates the error message to be less about internal implementation details, which users may find confusing.


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta