### PR TITLE
Support to show the map of truncated function name and full name in profiler table print log

### DIFF
--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -1277,6 +1277,7 @@ def _build_table(
             headers.append(func_full_overload_name)
             add_column(len(func_full_overload_name))
 
+        # "Full Name" must be last column in the table, since it will be long.
         func_full_name = "Full Name"
         headers.append(func_full_name)
         add_column(len(func_full_name))

--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -1479,7 +1479,13 @@ def _build_table(
             f"Self {use_device.upper() if use_device is not None else 'None'} "
             f"time total: {override_time_unit(sum_self_device_time_total, _format_time(sum_self_device_time_total), time_unit)}"
         )
-    return "".join(result)
+
+    res = "".join(result)
+
+    if show_func_name_map:
+        res += show_name.get_map_as_str()
+
+    return res
 
 
 # Collect all events with stack traces and format them canonically

--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -1092,6 +1092,9 @@ class _ShowName:
             return name
 
     def get_map_as_str(self):
+        if len(self.show_name_map) == 0:
+            return ""
+
         item = "Name"
         separation_line = ["-" * self.max_name_column_width, "  ", "-" * 20, "\n"]
 


### PR DESCRIPTION
[Issue]
In profiler function, the long function name will be truncated and shown in log.
And it's possible there are more than one functions have same truncated name.

Like `void __sycl_kernel_at::native::xpu::vectorized_eleme...` in below:

```
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
                                                   Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg      Self XPU    Self XPU %     XPU total  XPU time avg    # of Calls  
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
                                        model_inference         0.45%     322.847us       100.00%      71.641ms      71.641ms       0.000us         0.00%      54.318us      54.318us             1  
                                             my_xpu_ops         0.67%     479.156us        97.94%      70.162ms      70.162ms       0.000us         0.00%      54.318us      54.318us             1  
                                           aten::linear         0.03%      19.116us        19.41%      13.905ms       6.953ms       0.000us         0.00%      21.353us      10.677us             2  
                                            aten::addmm        18.68%      13.381ms        19.32%      13.844ms       6.922ms      21.353us        39.31%      21.353us      10.677us             2  
                                            gemm_kernel         0.00%       0.000us         0.00%       0.000us       0.000us      21.353us        39.31%      21.353us      10.677us             2  
                                              aten::add        43.80%      31.381ms        45.24%      32.411ms       4.051ms      20.206us        37.20%      20.206us       2.526us             8  
void __sycl_kernel_at::native::xpu::vectorized_eleme...         0.00%       0.000us         0.00%       0.000us       0.000us      20.206us        37.20%      20.206us       5.052us             4  
                                             aten::relu         0.03%      20.993us        32.87%      23.550ms      23.550ms       0.000us         0.00%       6.979us       6.979us             1  
                                        aten::clamp_min        32.38%      23.195ms        32.84%      23.529ms      23.529ms       6.979us        12.85%       6.979us       6.979us             1  
void __sycl_kernel_at::native::xpu::vectorized_eleme...         0.00%       0.000us         0.00%       0.000us       0.000us       6.979us        12.85%       6.979us       6.979us             1  
                                               aten::to         0.01%       6.220us         1.33%     949.274us     135.611us       0.000us         0.00%       5.780us       0.826us             7  

``` 

The full name is: 
```
void __sycl_kernel_at::native::xpu::vectorized_elementwise_kernel<4, __sycl_kernel_at::native::xpu::ClampScalarFunctor<float>, __sycl_kernel_at::detail::Array<char*, 2>, TrivialOffsetCalculator<1, unsigned int> >(int, __sycl_kernel_at::native::xpu::ClampScalarFunctor<float>, __sycl_kernel_at::detail::Array<char*, 2>, TrivialOffsetCalculator<1, unsigned int>)

void __sycl_kernel_at::native::xpu::vectorized_elementwise_kernel<4, __sycl_kernel_at::native::xpu::BinaryFunctor<float, float, float, __sycl_kernel_at::native::xpu::AddFunctor<float> >, __sycl_kernel_at::detail::Array<char*, 3>, TrivialOffsetCalculator<2, unsigned int> >(int, __sycl_kernel_at::native::xpu::BinaryFunctor<float, float, float, __sycl_kernel_at::native::xpu::AddFunctor<float> >, __sycl_kernel_at::detail::Array<char*, 3>, TrivialOffsetCalculator<2, unsigned int>)
```


It will lead to two issues:
1. Developer can't find the real name by the truncated name.
2. Some long names would have same truncated name. That will block to find the right full name.

[Solution]
1. Add parameter: `add_full_name_column` in torch.profiler.table() to insert a column right to show the full name of the function whose display name is truncated.
  Add new column name as "Full Name" as last column, to display the full name.

2. The new parameter `add_full_name_column` default value is False to keep legacy behavior as default.
3. Same for "Overload Name" item.

Here is the example of new feature.



```
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ---------  
                                                   Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg      Self XPU    Self XPU %     XPU total  XPU time avg    # of Calls  Full Name  
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ---------  
                                        model_inference         0.29%     204.964us       100.00%      70.362ms      70.362ms       0.000us         0.00%      54.997us      54.997us             1             
                                             my_xpu_ops         0.67%     474.520us        98.53%      69.328ms      69.328ms       0.000us         0.00%      54.997us      54.997us             1             
                                           aten::linear         0.07%      46.537us        20.04%      14.101ms       7.051ms       0.000us         0.00%      21.458us      10.729us             2             
                                            aten::addmm        19.24%      13.539ms        19.91%      14.012ms       7.006ms      21.458us        39.02%      21.458us      10.729us             2             
                                            gemm_kernel         0.00%       0.000us         0.00%       0.000us       0.000us      21.458us        39.02%      21.458us      10.729us             2             
                                              aten::add        42.37%      29.816ms        43.93%      30.910ms       3.864ms      20.832us        37.88%      20.832us       2.604us             8             
void __sycl_kernel_at::native::xpu::vectorized_eleme...         0.00%       0.000us         0.00%       0.000us       0.000us      20.832us        37.88%      20.832us       5.208us             4  void __sycl_kernel_at::native::xpu::vectorized_elementwise_kernel<4, __sycl_kernel_at::native::xpu::BinaryFunctor<float, float, float, __sycl_kernel_at::native::xpu::AddFunctor<float> >, __sycl_kernel_at::detail::Array<char*, 3>, TrivialOffsetCalculator<2, unsigned int> >(int, __sycl_kernel_at::native::xpu::BinaryFunctor<float, float, float, __sycl_kernel_at::native::xpu::AddFunctor<float> >, __sycl_kernel_at::detail::Array<char*, 3>, TrivialOffsetCalculator<2, unsigned int>)  
                                             aten::relu         0.03%      21.979us        33.58%      23.631ms      23.631ms       0.000us         0.00%       7.083us       7.083us             1             
                                        aten::clamp_min        33.08%      23.275ms        33.55%      23.609ms      23.609ms       7.083us        12.88%       7.083us       7.083us             1             
void __sycl_kernel_at::native::xpu::vectorized_eleme...         0.00%       0.000us         0.00%       0.000us       0.000us       7.083us        12.88%       7.083us       7.083us             1  void __sycl_kernel_at::native::xpu::vectorized_elementwise_kernel<4, __sycl_kernel_at::native::xpu::ClampScalarFunctor<float>, __sycl_kernel_at::detail::Array<char*, 2>, TrivialOffsetCalculator<1, unsigned int> >(int, __sycl_kernel_at::native::xpu::ClampScalarFunctor<float>, __sycl_kernel_at::detail::Array<char*, 2>, TrivialOffsetCalculator<1, unsigned int>)  
                                               aten::to         0.01%       6.593us         1.45%       1.021ms     145.805us       0.000us         0.00%       5.624us       0.803us             7             
                                         aten::_to_copy         0.03%      19.568us         1.44%       1.014ms     507.022us       0.000us         0.00%       5.624us       2.812us             2             
                                            aten::copy_         0.23%     163.416us         1.40%     983.650us     491.825us       5.624us        10.23%       5.624us       2.812us             2             
                 Memcpy D2M (DEVICE -> MEMORY(Unknown))         0.00%       0.000us         0.00%       0.000us       0.000us       5.312us         9.66%       5.312us       5.312us             1             
                 Memcpy M2D (MEMORY(Unknown) -> DEVICE)         0.00%       0.000us         0.00%       0.000us       0.000us       0.312us         0.57%       0.312us       0.312us             1             
                                            aten::empty         0.03%      18.404us         0.03%      18.404us       3.067us       0.000us         0.00%       0.000us       0.000us             6             
                                       aten::lift_fresh         0.00%       0.990us         0.00%       0.990us       0.247us       0.000us         0.00%       0.000us       0.000us             4             
                                          aten::detach_         0.00%       2.682us         0.01%       5.602us       1.400us       0.000us         0.00%       0.000us       0.000us             4             
                                                detach_         0.00%       2.920us         0.00%       2.920us       0.730us       0.000us         0.00%       0.000us       0.000us             4             
                                  urEnqueueKernelLaunch         2.67%       1.877ms         2.67%       1.877ms     268.166us       0.000us         0.00%       0.000us       0.000us             7             
                                                aten::t         0.03%      21.170us         0.06%      42.465us      21.232us       0.000us         0.00%       0.000us       0.000us             2             
                                        aten::transpose         0.02%      16.563us         0.03%      21.295us      10.647us       0.000us         0.00%       0.000us       0.000us             2             
                                       aten::as_strided         0.01%       6.601us         0.01%       6.601us       1.650us       0.000us         0.00%       0.000us       0.000us             4             
                                          aten::resize_         0.01%       5.462us         0.01%       5.462us       2.731us       0.000us         0.00%       0.000us       0.000us             2             
                                           aten::expand         0.01%       6.196us         0.01%       8.065us       4.033us       0.000us         0.00%       0.000us       0.000us             2             
                                    aten::empty_strided         0.02%      13.431us         0.02%      13.431us       4.477us       0.000us         0.00%       0.000us       0.000us             3             
                                     urEnqueueUSMMemcpy         1.17%     820.234us         1.17%     820.234us     410.117us       0.000us         0.00%       0.000us       0.000us             2             
                                       aten::empty_like         0.00%       2.188us         0.01%       4.793us       4.793us       0.000us         0.00%       0.000us       0.000us             1             
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ---------
```
