### PR TITLE
[ci] Increase shards for linux-jammy-py3.10-clang18-asan on pull.yml to 7

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -132,16 +132,16 @@ jobs:
       docker-image-name: ci-image:pytorch-linux-jammy-py3-clang18-asan
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 6, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
-          { config: "default", shard: 2, num_shards: 6, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
-          { config: "default", shard: 3, num_shards: 6, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
-          { config: "default", shard: 4, num_shards: 6, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
-          { config: "default", shard: 5, num_shards: 6, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
-          { config: "default", shard: 6, num_shards: 6, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default", shard: 1, num_shards: 7, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default", shard: 2, num_shards: 7, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default", shard: 3, num_shards: 7, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default", shard: 4, num_shards: 7, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default", shard: 5, num_shards: 7, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default", shard: 6, num_shards: 7, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default", shard: 7, num_shards: 7, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
         ]}
       sync-tag: asan-build
     secrets: inherit
-
 
   linux-jammy-py3_10-clang18-asan-test:
     name: linux-jammy-py3.10-clang18-asan


### PR DESCRIPTION
Tests for `linux-jammy-py3.10-clang18-asan` in pull are intermittently failing due to time out.

EX:
* https://github.com/pytorch/pytorch/actions/runs/17393738817/job/49372960082
* https://github.com/pytorch/pytorch/actions/runs/17391190505/job/49366171245
* https://github.com/pytorch/pytorch/actions/runs/17390925896/job/49365066945
* https://github.com/pytorch/pytorch/actions/runs/17390344774/job/49363637395

Instead of increasing the time out, I believe it is more reasonable to increase the shards count for the tests, the total cost for CI might not be that significant as we pay per instances * hours, so the total additional should be only the startup+teardown of a single extra shard. 

The other option, increasing timeout, could solve the problem, but this approach if applied repeatedly would consistently increase the human hours cost of developers. Plus the extra CI waiting times and potential conflicts that those might bring.


cc @seemethere @malfet @pytorch/pytorch-dev-infra