### PR TITLE
adding parse_to to constant_fold_functions

### DIFF
--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -1934,10 +1934,12 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
             def __init__(self) -> None:
                 super().__init__()
                 self.fc = torch.nn.Linear(16, 16)
+
             def forward(self, x):
                 y = self.fc(x)
                 self.to("cpu")
                 return y
+
         mod = Mod()
         x = torch.rand(2, 16)
         ref = mod(x)

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -1941,13 +1941,11 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
                 return y
 
         mod = Mod()
-        x = torch.rand(2, 16)
+        x = torch.rand(1, 1024)
         ref = mod(x)
-        cnt = torch._dynamo.testing.CompileCounter()
-        opt_mod = torch.compile(mod, backend=cnt, fullgraph=True)
-        res = opt_mod(x)
+        mod.compile(fullgraph=False)
+        res = mod(x)
         self.assertTrue(torch.allclose(ref, res))
-        self.assertEqual(cnt.frame_count, 1)
 
     @torch._dynamo.config.patch(guard_nn_modules=True)
     def test_param_order(self):

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -160,6 +160,7 @@ constant_fold_functions = [
     torch.accelerator.is_available,
     torch.cuda.get_device_properties,
     torch.cuda.is_available,
+    torch._C._nn._parse_to,
     torch.distributed.is_available,
     torch.get_autocast_dtype,
     torch.get_autocast_gpu_dtype,


### PR DESCRIPTION
Fixes #161207

### Summary: 
included torch._C._nn._parse_to in constant_fold_functions in torch/_dynamo/variables/torch.py.

Calls to [nn.Module.to](http://nn.module.to/)(...) parse via _parse_to will be constant-folded



Now, 
```
import torch

class Mod(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.fc = torch.nn.Linear(1024, 1024)

    def forward(self, x):
        res = self.fc(x)
        self.to("cpu")
        return res

mod = Mod()
mod.compile(fullgraph=True)
x = torch.rand(1, 1024)
mod(x)
```

does not produce error 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela @mlazos