### PR TITLE
Better logging for triton gemm tuning compilation timeouts

### DIFF
--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -3042,8 +3042,7 @@ class AlgorithmSelectorCache(PersistentCache):
 
             try:  # the timeout itself is not captured in future.exceptions so we need this try block to catch it
                 for future in as_completed(
-                    futures,
-                    timeout=precompilation_timeout_seconds
+                    futures, timeout=precompilation_timeout_seconds
                 ):
                     completed_futures.add(future)
                     choice = futures[

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -3043,8 +3043,7 @@ class AlgorithmSelectorCache(PersistentCache):
             try:  # the timeout itself is not captured in future.exceptions so we need this try block to catch it
                 for future in as_completed(
                     futures,
-                    # timeout=precompilation_timeout_seconds,
-                    timeout=30,
+                    timeout=precompilation_timeout_seconds
                 ):
                     completed_futures.add(future)
                     choice = futures[


### PR DESCRIPTION
I've encountered a situtation where, during triton gemm tuning, a triton kernel (pre)compilation timed out.
Pain to debug, but with this PR slightly easier as it informs the user about the actual kernel where the compilation timed out.

When triton kernel compilation(s) time(s) out we get extra logging lines like this:
```bash
E0902 12:42:36.168925 1791674 /root/pytorch-me/torch/_inductor/select_algorithm.py:2816] [0/0] Timeout benchmark choice: TritonTemplateCaller(/tmp/torchinductor_root/rp/crpmahu73qmfbh7fhlwhat2rp2uuh6sfpssagpsrpgmgdg3wbijd.py, ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=256, BLOCK_M=16, BLOCK_N=16, EVEN_K=False, GROUP_M=4, USE_FAST_ACCUM=False, kpack=2, matrix_instr_nonkdim=16, waves_per_eu=8, num_stages=2, num_warps=1) 
E0902 12:42:36.169642 1791674 /root/pytorch-me/torch/_inductor/select_algorithm.py:2816] [0/0] Timeout benchmark choice: TritonTemplateCaller(/tmp/torchinductor_root/5a/c5arb7q5cveo4mwqy4mdgxzjmn6iemt73ue5ggxqrm4wfpzdm5wo.py, ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=256, BLOCK_M=32, BLOCK_N=16, EVEN_K=False, GROUP_M=4, USE_FAST_ACCUM=False, kpack=2, matrix_instr_nonkdim=16, waves_per_eu=0, num_stages=2, num_warps=2) 
E0902 12:42:36.169867 1791674 /root/pytorch-me/torch/_inductor/select_algorithm.py:2816] [0/0] Timeout benchmark choice: TritonTemplateCaller(/tmp/torchinductor_root/tm/ctmk3xqhaatc6quyxhbnemyqz4gyxfz4k36nkc3so2sekgmso6s4.py, ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=16, BLOCK_M=32, BLOCK_N=32, EVEN_K=False, GROUP_M=8, USE_FAST_ACCUM=False, kpack=2, matrix_instr_nonkdim=16, waves_per_eu=2, num_stages=2, num_warps=4) 
E0902 12:42:36.169958 1791674 /root/pytorch-me/torch/_inductor/select_algorithm.py:2816] [0/0] Timeout benchmark choice: TritonTemplateCaller(/tmp/torchinductor_root/i5/ci5pon4lebravl2hzt44gzbjhfb6qwcqdbeuk26u2ryajsewj7h4.py, ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=128, BLOCK_M=32, BLOCK_N=32, EVEN_K=False, GROUP_M=8, USE_FAST_ACCUM=False, kpack=2, matrix_instr_nonkdim=16, waves_per_eu=0, num_stages=2, num_warps=4) 
....
```
that's about it.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @chenyang78