### PR TITLE
torch.zeros bound checks for symint

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -1640,6 +1640,12 @@ Tensor zeros_symint(
     std::optional<Layout> layout,
     std::optional<Device> device,
     std::optional<bool> pin_memory) {
+  
+  for (const auto& dim_size : size) {
+    TORCH_CHECK(dim_size >= 0, 
+        "zeros: Dimension size must be non-negative.");
+  }
+  
   Layout layout_ = layout.value_or(Layout::Strided);
   if (at::sparse_csr::is_sparse_compressed(layout_)) {
     return zeros_sparse_compressed_symint(

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -1640,12 +1640,9 @@ Tensor zeros_symint(
     std::optional<Layout> layout,
     std::optional<Device> device,
     std::optional<bool> pin_memory) {
-  
   for (const auto& dim_size : size) {
-    TORCH_CHECK(dim_size >= 0, 
-        "zeros: Dimension size must be non-negative.");
+    TORCH_CHECK(dim_size >= 0, "zeros: Dimension size must be non-negative.");
   }
-  
   Layout layout_ = layout.value_or(Layout::Strided);
   if (at::sparse_csr::is_sparse_compressed(layout_)) {
     return zeros_sparse_compressed_symint(

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -3260,17 +3260,10 @@ class TestTensorCreation(TestCase):
     def test_refs_tensor(self, device, dtype):
         self.assertEqual(torch._refs.tensor([], device=device, dtype=dtype), torch.tensor([], device=device, dtype=dtype))
 
-
     def test_zeros_bounds_checking(self, device):
-        """Test that zeros function properly validates size parameters and provides clear error messages."""
-        
         # Test negative large integer
-        with self.assertRaisesRegex(RuntimeError, r"zeros\(\.\.\.\): dimension size must be non-negative, got -6744789213055875072"):
+        with self.assertRaisesRegex(RuntimeError, r"zeros: Dimension size must be non-negative."):
             torch.zeros(-6744789213055875072, device=device)
-        
-        # Test extremely large integer
-        with self.assertRaisesRegex(RuntimeError, r"zeros\(\.\.\.\): dimension size too large, got 6409021227853660160"):
-            torch.zeros(6409021227853660160, device=device)
 
 # Class for testing random tensor creation ops, like torch.randint
 class TestRandomTensorCreation(TestCase):

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -2000,6 +2000,11 @@ class TestTensorCreation(TestCase):
         expected = torch.tensor([[0., 0.], [0., 0.]], device=device, dtype=torch.complex32)
         self.assertEqual(complexHalfTensor, expected)
 
+    def test_zeros_bounds_checking(self, device):
+        # Test negative large integer
+        with self.assertRaisesRegex(RuntimeError, r"zeros: Dimension size must be non-negative."):
+            torch.zeros(-6744789213055875072, device=device)
+
     # TODO: this test should be updated
     def test_zeros_out(self, device):
         shape = (3, 4)
@@ -3260,10 +3265,6 @@ class TestTensorCreation(TestCase):
     def test_refs_tensor(self, device, dtype):
         self.assertEqual(torch._refs.tensor([], device=device, dtype=dtype), torch.tensor([], device=device, dtype=dtype))
 
-    def test_zeros_bounds_checking(self, device):
-        # Test negative large integer
-        with self.assertRaisesRegex(RuntimeError, r"zeros: Dimension size must be non-negative."):
-            torch.zeros(-6744789213055875072, device=device)
 
 # Class for testing random tensor creation ops, like torch.randint
 class TestRandomTensorCreation(TestCase):

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -3261,6 +3261,17 @@ class TestTensorCreation(TestCase):
         self.assertEqual(torch._refs.tensor([], device=device, dtype=dtype), torch.tensor([], device=device, dtype=dtype))
 
 
+    def test_zeros_bounds_checking(self, device):
+        """Test that zeros function properly validates size parameters and provides clear error messages."""
+        
+        # Test negative large integer
+        with self.assertRaisesRegex(RuntimeError, r"zeros\(\.\.\.\): dimension size must be non-negative, got -6744789213055875072"):
+            torch.zeros(-6744789213055875072, device=device)
+        
+        # Test extremely large integer
+        with self.assertRaisesRegex(RuntimeError, r"zeros\(\.\.\.\): dimension size too large, got 6409021227853660160"):
+            torch.zeros(6409021227853660160, device=device)
+
 # Class for testing random tensor creation ops, like torch.randint
 class TestRandomTensorCreation(TestCase):
     exact_dtype = True


### PR DESCRIPTION
Fixes #161490

I added a bounds check for negative symints to create a better error message.

cc @albanD