### PR TITLE
[SymmMem] Add a helper API to distinguish intra- and inter- node

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -320,6 +320,10 @@ c10::Device CUDASymmetricMemory::get_device() {
   return c10::Device(c10::DeviceType::CUDA, local_device_idx_);
 }
 
+bool CUDASymmetricMemory::world_within_direct_access() {
+  return true;
+}
+
 Block::Block(
     c10::intrusive_ptr<AllocationRef> alloc_ref,
     int device_idx,

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.hpp
@@ -59,6 +59,7 @@ class CUDASymmetricMemory : public SymmetricMemory {
   int get_rank() override;
   int get_world_size() override;
   c10::Device get_device() override;
+  bool world_within_direct_access() override;
 
  private:
   std::vector<c10::intrusive_ptr<AllocationRef>> alloc_refs_;

--- a/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cu
@@ -79,9 +79,16 @@ class NVSHMEMPeerAllocInfo : public c10::intrusive_ptr_target {
     }
     TORCH_INTERNAL_ASSERT(!group_info.rank_to_global_rank.empty());
     rank_to_global_rank_ = group_info.rank_to_global_rank;
+
+    world_within_cuda_p2p_ = true;
     for (int r = 0; r < world_size_; ++r) {
-      buffers_.push_back(nvshmem_ptr(
-          base_ptr_, rank_to_global_rank_[r]));
+      auto peer_ptr = nvshmem_ptr(
+          base_ptr_, rank_to_global_rank_[r]);
+      buffers_.push_back(peer_ptr);
+      // If a peer is over network, `nvshmem_ptr` returns null
+      if (peer_ptr == nullptr) {
+        world_within_cuda_p2p_ = false;
+      }
     }
 
     // TODO: use the same allocation for signal pad
@@ -128,6 +135,8 @@ class NVSHMEMPeerAllocInfo : public c10::intrusive_ptr_target {
   void** signal_pads_dev_;
   std::vector<int> rank_to_global_rank_;
   int* rank_to_global_rank_dev_;
+  // Whether the world is within CUDA P2P only, not network
+  bool world_within_cuda_p2p_;
 
   friend class NVSHMEMSymmetricMemory;
 };
@@ -230,6 +239,10 @@ class NVSHMEMSymmetricMemory : public SymmetricMemory {
   int* get_rank_to_global_rank_dev() override {
     return pai_->rank_to_global_rank_dev_;
   };
+
+  bool world_within_direct_access() {
+    return pai_->world_within_cuda_p2p_;
+  }
 
  private:
   std::shared_ptr<NVSHMEMAllocation> allocation_;

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
@@ -89,6 +89,12 @@ class TORCH_API SymmetricMemory : public c10::intrusive_ptr_target {
   virtual int* get_rank_to_global_rank_dev() {
     TORCH_CHECK(false, "NYI");
   }
+
+  // Returns true if *all* peers within the group are accessible via direct
+  // memory load and store.
+  virtual bool world_within_direct_access() {
+    TORCH_CHECK(false, "NYI");
+  }
 };
 
 class SymmetricMemoryAllocator : public c10::intrusive_ptr_target {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #162003
* __->__ #161984
* #161983

Added a helper API to tell if the world is entirely within a P2P domain or crosses network.
This is mainly for nblocks tuning purpose. (In later PRs)

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim