### PR TITLE
[aot precompile] Handle closure variables.

### DIFF
--- a/torch/_dynamo/aot_compile.py
+++ b/torch/_dynamo/aot_compile.py
@@ -44,6 +44,7 @@ class CompileArtifacts:
     backend_id: str
     compiled_fn: SerializableCallable
     original_code: types.CodeType
+    closure: Optional[tuple[Any, ...]]
 
     def compiled_function(self) -> Any:
         import_sources = {
@@ -51,7 +52,7 @@ class CompileArtifacts:
             for alias, module_name in self.import_sources.items()
         }
         f_globals = {**import_sources, self.backend_id: self.compiled_fn}
-        core = types.FunctionType(self.bytecode, f_globals)
+        core = types.FunctionType(self.bytecode, f_globals, closure=self.closure)
 
         def optimized_call(*args: Any, **kwargs: Any) -> Any:
             f_locals = bind_locals(self.signature, *args, **kwargs)
@@ -124,6 +125,15 @@ def aot_compile_fullgraph(
 
     signature = inspect.signature(fn)
     f_locals = bind_locals(signature, *args, **kwargs)
+    if fn.__code__.co_freevars or fn.__closure__:
+        assert len(fn.__closure__) == len(fn.__code__.co_freevars)
+        f_locals.update(
+            {
+                name: cell.cell_contents
+                for name, cell in zip(fn.__code__.co_freevars, fn.__closure__)
+            }
+        )
+
     with (
         compile_context(CompileContext(convert_frame.get_compile_id({}))),
         get_metrics_context(),
@@ -135,11 +145,13 @@ def aot_compile_fullgraph(
                 fn.__globals__,
                 f_locals,
                 builtins.__dict__,
-                closure=(),  # type: ignore[arg-type]
+                closure=fn.__closure__,
             )
         )
         dynamo_output = capture_output.dynamo_output
-        check_fn = dynamo_output.build_guards(fn.__code__, hooks=hooks, save=True)
+        check_fn = dynamo_output.build_guards(
+            fn.__code__, hooks=hooks, save=True, strict_error=True
+        )
         assert check_fn.guards_state is not None
 
     backend_input = capture_output.backend_input
@@ -167,5 +179,6 @@ def aot_compile_fullgraph(
         backend_id=backend_input.backend_id,
         compiled_fn=compiled_fn,
         original_code=fn.__code__,
+        closure=fn.__closure__,
     )
     return compile_artifacts.compiled_function()

--- a/torch/_dynamo/aot_compile.py
+++ b/torch/_dynamo/aot_compile.py
@@ -145,7 +145,7 @@ def aot_compile_fullgraph(
                 fn.__globals__,
                 f_locals,
                 builtins.__dict__,
-                closure=fn.__closure__,
+                closure=fn.__closure__ or (),  # type: ignore[arg-type]
             )
         )
         dynamo_output = capture_output.dynamo_output

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -856,6 +856,7 @@ class DynamoOutput:
         hooks: Optional[Hooks] = None,
         save: bool = False,
         cache_entry: Optional[CacheEntry] = None,
+        strict_error: bool = False,
     ) -> CheckFunctionManager:
         assert self.tracer_output.output_graph is not None
         return CheckFunctionManager(
@@ -865,6 +866,7 @@ class DynamoOutput:
             hooks.guard_fail_fn if hooks else None,
             hooks.guard_filter_fn if hooks else None,
             save_guards=save,
+            strict_error=strict_error,
         )
 
 

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -3274,6 +3274,7 @@ class CheckFunctionManager:
         shape_code_parts: Optional[ShapeCodeParts] = None,
         runtime_global_scope: Optional[dict[str, Any]] = None,
         save_guards: bool = False,
+        strict_error: bool = False,
     ):
         guards = output_graph.guards if output_graph else None
         self._weakrefs: dict[int, ReferenceType[object]] = {}
@@ -3447,7 +3448,7 @@ class CheckFunctionManager:
                     builder, sorted_guards, self.output_graph
                 )
             except exc.PackageError as e:
-                if torch._dynamo.config.strict_precompile:
+                if torch._dynamo.config.strict_precompile or strict_error:
                     raise e
                 self.output_graph.bypass_package(
                     f"Guard evaluation failed: {str(e)}",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #161990

We previously assume aot precompile should only work on non closures. This is hard to enforce in practice because we will see a lot of cases with decorater (e.g. hugging face models)
```
def check_inputs(fn):
    def _fn(self, *args, **kwargs):
        for arg in args:
            assert arg.shape[0] > 1

        return fn(*args, **kwargs)
    return _fn


@check_inputs
def foo(x, y):
    a = x + x
    b = y + y
    c = a + b
    return c
```
It doesn't make sense to not support these cases since they are straightfowrad to do.

This PR adds the logic to handle closure and make sure they can be precompiled properly.

Differential Revision: [D81509535](https://our.internmc.facebook.com/intern/diff/D81509535/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela