### PR TITLE
build: Add fallback commands to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -422,7 +422,10 @@ for i, arg in enumerate(sys.argv):
         EMIT_BUILD_WARNING = True
     if arg == "develop":
         print(
-            "WARNING: Redirecting 'python setup.py develop' to 'pip install -e . -v --no-build-isolation', for more info see https://github.com/pytorch/pytorch/issues/152276",
+            (
+                "WARNING: Redirecting 'python setup.py develop' to 'pip install -e . -v --no-build-isolation',"
+                " for more info see https://github.com/pytorch/pytorch/issues/152276"
+            ),
             file=sys.stderr,
         )
         result = subprocess.run(
@@ -440,7 +443,10 @@ for i, arg in enumerate(sys.argv):
         sys.exit(result.returncode)
     if arg == "install":
         print(
-            "WARNING: Redirecting 'python setup.py install' to 'pip install . -v --no-build-isolation', for more info see https://github.com/pytorch/pytorch/issues/152276",
+            (
+                "WARNING: Redirecting 'python setup.py install' to 'pip install . -v --no-build-isolation',"
+                " for more info see https://github.com/pytorch/pytorch/issues/152276"
+            ),
             file=sys.stderr,
         )
         result = subprocess.run(

--- a/setup.py
+++ b/setup.py
@@ -438,7 +438,8 @@ for i, arg in enumerate(sys.argv):
                 ".",
                 "-v",
                 "--no-build-isolation",
-            ]
+            ],
+            env={**os.environ}
         )
         sys.exit(result.returncode)
     if arg == "install":
@@ -450,7 +451,8 @@ for i, arg in enumerate(sys.argv):
             file=sys.stderr,
         )
         result = subprocess.run(
-            [sys.executable, "-m", "pip", "install", ".", "-v", "--no-build-isolation"]
+            [sys.executable, "-m", "pip", "install", ".", "-v", "--no-build-isolation"],
+            env={**os.environ}
         )
         sys.exit(result.returncode)
     if arg == "--":

--- a/setup.py
+++ b/setup.py
@@ -422,7 +422,7 @@ for i, arg in enumerate(sys.argv):
         EMIT_BUILD_WARNING = True
     if arg == "develop":
         print(
-            "Redirecting 'python setup.py develop' to 'pip install -e . -v --no-build-isolation'",
+            "WARNING: Redirecting 'python setup.py develop' to 'pip install -e . -v --no-build-isolation', for more info see https://github.com/pytorch/pytorch/issues/152276",
             file=sys.stderr,
         )
         result = subprocess.run(
@@ -440,7 +440,7 @@ for i, arg in enumerate(sys.argv):
         sys.exit(result.returncode)
     if arg == "install":
         print(
-            "Redirecting 'python setup.py install' to 'pip install . -v --no-build-isolation'",
+            "WARNING: Redirecting 'python setup.py install' to 'pip install . -v --no-build-isolation', for more info see https://github.com/pytorch/pytorch/issues/152276",
             file=sys.stderr,
         )
         result = subprocess.run(

--- a/setup.py
+++ b/setup.py
@@ -439,7 +439,7 @@ for i, arg in enumerate(sys.argv):
                 "-v",
                 "--no-build-isolation",
             ],
-            env={**os.environ}
+            env={**os.environ},
         )
         sys.exit(result.returncode)
     if arg == "install":
@@ -452,7 +452,7 @@ for i, arg in enumerate(sys.argv):
         )
         result = subprocess.run(
             [sys.executable, "-m", "pip", "install", ".", "-v", "--no-build-isolation"],
-            env={**os.environ}
+            env={**os.environ},
         )
         sys.exit(result.returncode)
     if arg == "--":

--- a/setup.py
+++ b/setup.py
@@ -420,6 +420,33 @@ for i, arg in enumerate(sys.argv):
     if arg == "rebuild" or arg == "build":
         arg = "build"  # rebuild is gone, make it build
         EMIT_BUILD_WARNING = True
+    if arg == "develop":
+        print(
+            "Redirecting 'python setup.py develop' to 'pip install -e . -v --no-build-isolation'",
+            file=sys.stderr,
+        )
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "-e",
+                ".",
+                "-v",
+                "--no-build-isolation",
+            ]
+        )
+        sys.exit(result.returncode)
+    if arg == "install":
+        print(
+            "Redirecting 'python setup.py install' to 'pip install . -v --no-build-isolation'",
+            file=sys.stderr,
+        )
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "install", ".", "-v", "--no-build-isolation"]
+        )
+        sys.exit(result.returncode)
     if arg == "--":
         filtered_args += sys.argv[i:]
         break


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #162010
* __->__ #162009

Adds fallback commands for the following:
* python setup.py install
* python setup.py develop

Ideally these should just work and should provide backwards compat.

Thought process here is that multiple people rely on these commands and just because setuptools wants to drop support for this I don't think a lot of our downstream users who build from source are expecting these to be gone.

This should provide some room for developers to move away from these commands until we have a unified frontend for doing all of these commands that should abstract most of these away.

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>