### PR TITLE
[SymmMem] Replace unnecessary nvshmemx_collective_launch

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cu
@@ -275,7 +275,7 @@ void initialize_nvshmem_with_store(
   maybe_initialize_env_vars();
 
   nvshmemx_uniqueid_t unique_id;
-  NVSHMEM_CHECK(
+  NVSHMEM_CHECK_MSG(
       nvshmemx_get_uniqueid(&unique_id), "nvshmemx_get_uniqueid failed");
 
   // Using an existing store_all_gather due to laziness.
@@ -285,7 +285,7 @@ void initialize_nvshmem_with_store(
   nvshmemx_init_attr_t attr;
   nvshmemx_set_attr_uniqueid_args(rank, world_size, &unique_ids[0], &attr);
 
-  NVSHMEM_CHECK(
+  NVSHMEM_CHECK_MSG(
       nvshmemx_init_attr(NVSHMEMX_INIT_WITH_UNIQUEID, &attr),
       "nvshmemx_init_attr failed");
 

--- a/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cuh
+++ b/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cuh
@@ -3,7 +3,15 @@
 #include <c10/macros/Macros.h>
 #include <ATen/ATen.h>
 
-#define NVSHMEM_CHECK(stmt, msg)                                             \
+#define NVSHMEM_CHECK(stmt)                                             \
+  do {                                                                  \
+    int result = (stmt);                                                \
+    TORCH_CHECK(                                                        \
+        result == 0,                                                    \
+        "NVSHMEM call failed, error code: " + std::to_string(result));  \
+  } while (0)
+
+#define NVSHMEM_CHECK_MSG(stmt, msg)                                         \
   do {                                                                       \
     int result = (stmt);                                                     \
     TORCH_CHECK(                                                             \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #162011

The `nvshmemx_collective_launch` function must be used when the CUDA kernels use NVSHMEM synchronization or collective APIs (e.g., nvshmem_wait, nvshmem_barrier, nvshmem_barrier_all, or any other collective operation). CUDA kernels that do not use synchronizing NVSHMEM APIs are not required to be launched by this API. 

Also added `NVSHMEM_CHECK` or `CUDA_CHECK` around the launch calls.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci