### PR TITLE
[torch elastic] support pid in log prefix template

### DIFF
--- a/torch/distributed/elastic/multiprocessing/__init__.py
+++ b/torch/distributed/elastic/multiprocessing/__init__.py
@@ -63,9 +63,12 @@ was launched a :class:`api.SubprocessContext` is returned. Both are specific
 implementations of the parent :class:`api.PContext` class.
 """
 
-from typing import Callable, Optional, Union
+from __future__ import annotations
+
+from typing import Callable, Optional
 
 from torch.distributed.elastic.multiprocessing.api import (  # noqa: F401
+    _LogPrefixContext,
     _validate_full_rank,
     DefaultLogsSpecs,
     LogsDest,
@@ -101,11 +104,12 @@ __all__ = [
 
 def start_processes(
     name: str,
-    entrypoint: Union[Callable, str],
+    entrypoint: Callable | str,
     args: dict[int, tuple],
     envs: dict[int, dict[str, str]],
     logs_specs: LogsSpecs,
-    log_line_prefixes: Optional[dict[int, str]] = None,
+    log_prefix_template: str | None = None,
+    per_rank_log_prefix_context: list[_LogPrefixContext] | None = None,
     start_method: str = "spawn",
     numa_options: Optional[NumaOptions] = None,
 ) -> PContext:
@@ -195,6 +199,9 @@ def start_processes(
         args: arguments to each replica
         envs: env vars to each replica
         log_dir: directory used to write log files
+        log_prefix_template: the template used to format the log line prefix.
+        log_prefix_context: the context used to format the log line prefix.
+                            must be present if log_line_prefix_template is set.
         start_method: multiprocessing start method (spawn, fork, forkserver)
                       ignored for binaries
         redirects: which std streams to redirect to a log file
@@ -215,7 +222,8 @@ def start_processes(
             args=args,
             envs=envs,
             logs_specs=logs_specs,
-            log_line_prefixes=log_line_prefixes,
+            log_prefix_template=log_prefix_template,
+            per_rank_log_prefix_context=per_rank_log_prefix_context,
             numa_options=numa_options,
         )
     else:
@@ -224,7 +232,8 @@ def start_processes(
             entrypoint=entrypoint,
             args=args,
             envs=envs,
-            log_line_prefixes=log_line_prefixes,
+            log_prefix_template=log_prefix_template,
+            per_rank_log_prefix_context=per_rank_log_prefix_context,
             start_method=start_method,
             logs_specs=logs_specs,
             numa_options=numa_options,

--- a/torch/distributed/launcher/api.py
+++ b/torch/distributed/launcher/api.py
@@ -6,6 +6,7 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+import os
 import sys
 import uuid
 from dataclasses import dataclass, field
@@ -63,6 +64,10 @@ class LaunchConfig:
                         as a period of monitoring workers.
         start_method: The method is used by the elastic agent to start the
                     workers (spawn, fork, forkserver).
+        log_line_prefix_template: The template used to format the log line prefix.
+                                  If this is not set, the environment variable
+                                  `TORCHELASTIC_LOG_LINE_PREFIX_TEMPLATE` will be used.
+                                  See ``LocalElasticAgent`` for more details.
         metrics_cfg: configuration to initialize metrics.
         local_addr: address of the local node if any. If not set, a lookup on the local
                 machine's FQDN will be performed.
@@ -102,6 +107,9 @@ class LaunchConfig:
             self.rdzv_configs["timeout"] = self.rdzv_timeout
         elif "timeout" not in self.rdzv_configs:
             self.rdzv_configs["timeout"] = default_timeout
+
+        if self.log_line_prefix_template is None:
+            self.log_line_prefix_template = os.getenv("TORCHELASTIC_LOG_LINE_PREFIX_TEMPLATE")
 
         # Post-processing to enable refactoring to introduce logs_specs due to non-torchrun API usage
         if self.logs_specs is None:
@@ -211,20 +219,21 @@ def launch_agent(
 
     logger.info(
         "Starting elastic_operator with launch configs:\n"
-        "  entrypoint         : %(entrypoint)s\n"
-        "  min_nodes          : %(min_nodes)s\n"
-        "  max_nodes          : %(max_nodes)s\n"
-        "  nproc_per_node     : %(nproc_per_node)s\n"
-        "  run_id             : %(run_id)s\n"
-        "  rdzv_backend       : %(rdzv_backend)s\n"
-        "  rdzv_endpoint      : %(rdzv_endpoint)s\n"
-        "  rdzv_configs       : %(rdzv_configs)s\n"
-        "  max_restarts       : %(max_restarts)s\n"
-        "  monitor_interval   : %(monitor_interval)s\n"
-        "  log_dir            : %(log_dir)s\n"
-        "  metrics_cfg        : %(metrics_cfg)s\n"
-        "  event_log_handler  : %(event_log_handler)s\n"
-        "  numa_options       : %(numa_options)s\n",
+        "  entrypoint               : %(entrypoint)s\n"
+        "  min_nodes                : %(min_nodes)s\n"
+        "  max_nodes                : %(max_nodes)s\n"
+        "  nproc_per_node           : %(nproc_per_node)s\n"
+        "  run_id                   : %(run_id)s\n"
+        "  rdzv_backend             : %(rdzv_backend)s\n"
+        "  rdzv_endpoint            : %(rdzv_endpoint)s\n"
+        "  rdzv_configs             : %(rdzv_configs)s\n"
+        "  max_restarts             : %(max_restarts)s\n"
+        "  monitor_interval         : %(monitor_interval)s\n"
+        "  log_dir                  : %(log_dir)s\n"
+        "  log_line_prefix_template : %(log_line_prefix_template)s\n"
+        "  metrics_cfg              : %(metrics_cfg)s\n"
+        "  event_log_handler        : %(event_log_handler)s\n"
+        "  numa_options             : %(numa_options)s\n",
         {
             "entrypoint": entrypoint_name,
             "min_nodes": config.min_nodes,
@@ -236,7 +245,8 @@ def launch_agent(
             "rdzv_configs": config.rdzv_configs,
             "max_restarts": config.max_restarts,
             "monitor_interval": config.monitor_interval,
-            "log_dir": config.logs_specs.root_log_dir,  # type: ignore[union-attr]
+            "log_dir": config.logs_specs.root_log_dir,
+            "log_line_prefix_template": config.log_line_prefix_template,
             "metrics_cfg": config.metrics_cfg,
             "event_log_handler": config.event_log_handler,
             "numa_options": config.numa_options,

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -812,8 +812,6 @@ def config_from_args(args) -> tuple[LaunchConfig, Union[Callable, str], list[str
         # This env variable will be passed down to the subprocesses
         os.environ["OMP_NUM_THREADS"] = str(omp_num_threads)
 
-    log_line_prefix_template = os.getenv("TORCHELASTIC_LOG_LINE_PREFIX_TEMPLATE")
-
     rdzv_configs = _parse_rendezvous_config(args.rdzv_conf)
 
     if args.rdzv_backend == "static":
@@ -856,7 +854,6 @@ def config_from_args(args) -> tuple[LaunchConfig, Union[Callable, str], list[str
         max_restarts=args.max_restarts,
         monitor_interval=args.monitor_interval,
         start_method=args.start_method,
-        log_line_prefix_template=log_line_prefix_template,
         local_addr=args.local_addr,
         logs_specs=logs_specs,
         event_log_handler=args.event_log_handler,


### PR DESCRIPTION
Summary:
## Before

pid was not supported and required logger to dump them individually
This led to challenge matching the pids as not all loggers would dump them.

## After

`${pid}` is supported as a placeholder in `TORCHELASTIC_LOG_LINE_PREFIX_TEMPLATE`.

To do that, this changeset:
- Pushed down template materialization from agent to `multiprocessing.PContext` as that's where it gets the `pid`.
- Shifted the docstrings as needed.
- Default `LaunchConfig.log_line_prefix_template` to following env var if persists to consolidate the logic

Test Plan:
CI

Run job

Differential Revision: D81177345




cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci