### PR TITLE
[SymmMem] Increase signal pad size for NVL72

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryTypes.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryTypes.hpp
@@ -1,8 +1,18 @@
 #pragma once
 
+#include <cstdint>
+
 namespace c10d::symmetric_memory {
 
-constexpr size_t signal_pad_size = 2048;
+// Covers NVL72
+constexpr int max_cuda_p2p_domain_size = 72;
+// Maximum number of channels
+constexpr int symm_max_nblocks = 32;
+
+// Maximally, a rank will need to sync with all other ranks, over all
+// channels. Each signal is 32 bits, which is the minimum unit for atomic cas.
+constexpr size_t signal_pad_size =
+    symm_max_nblocks * max_cuda_p2p_domain_size * sizeof(uint32_t);
 
 #if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
 using HandleType = CUmemGenericAllocationHandle;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #162026

so that the signal calls do not step on each other's foot.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim