### PR TITLE
Update ctc loss docs float32 input required for CuDNN

### DIFF
--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -2062,10 +2062,11 @@ class CTCLoss(_Loss):
         https://www.cs.toronto.edu/~graves/icml_2006.pdf
 
     Note:
-        In order to use CuDNN, the following must be satisfied: :attr:`targets` must be
+        In order to use CuDNN, the following must be satisfied: the :attr:`targets` must be
         in concatenated format, all :attr:`input_lengths` must be `T`.  :math:`blank=0`,
         :attr:`target_lengths` :math:`\leq 256`, the integer arguments must be of
-        dtype :attr:`torch.int32`.
+        dtype :attr:`torch.int32`, and the :attr:`input` itself must be of
+        dtype :attr:`torch.float32`.
 
         The regular implementation uses the (more common in PyTorch) `torch.long` dtype.
 

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -2065,7 +2065,7 @@ class CTCLoss(_Loss):
         In order to use CuDNN, the following must be satisfied: the :attr:`targets` must be
         in concatenated format, all :attr:`input_lengths` must be `T`.  :math:`blank=0`,
         :attr:`target_lengths` :math:`\leq 256`, the integer arguments must be of
-        dtype :attr:`torch.int32`, and the :attr:`input` itself must be of
+        dtype :attr:`torch.int32`, and the :attr:`log_probs` itself must be of
         dtype :attr:`torch.float32`.
 
         The regular implementation uses the (more common in PyTorch) `torch.long` dtype.


### PR DESCRIPTION
Discovered while working on https://github.com/pytorch/pytorch/pull/159106 the non-obvious requirement that inputs must be float32 to use CuDNN (https://github.com/pytorch/pytorch/pull/159106#issuecomment-3189981705), otherwise the native CUDA implementation is called.

Updates the docs.

