### PR TITLE
[ROCm] Use MI325 (gfx942) runners for binary smoke testing

### DIFF
--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -22,7 +22,7 @@ LABEL_CIFLOW_BINARIES = "ciflow/binaries"
 LABEL_CIFLOW_PERIODIC = "ciflow/periodic"
 LABEL_CIFLOW_BINARIES_LIBTORCH = "ciflow/binaries_libtorch"
 LABEL_CIFLOW_BINARIES_WHEEL = "ciflow/binaries_wheel"
-LABEL_CIFLOW_ROCM = "ciflow/rocm"
+LABEL_CIFLOW_ROCM = "ciflow/rocm-mi300"
 
 
 @dataclass

--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -139,8 +139,6 @@ ROCM_SMOKE_WORKFLOWS = [
         ),
         ciflow_config=CIFlowConfig(
             labels={
-                LABEL_CIFLOW_BINARIES,
-                LABEL_CIFLOW_BINARIES_WHEEL,
                 LABEL_CIFLOW_ROCM,
             },
             isolated_workflow=True,

--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -171,7 +171,7 @@ jobs:
       - name: Teardown XPU
         uses: ./.github/actions/teardown-xpu
     {%- else %}
-    runs-on: linux.rocm.gpu.mi250
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: !{{ common.timeout_minutes }}
     !{{ upload.binary_env(config) }}
     steps:

--- a/.github/workflows/generated-linux-binary-libtorch-nightly.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-nightly.yml
@@ -342,7 +342,7 @@ jobs:
     needs:
       - libtorch-rocm6_3-shared-with-deps-release-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -456,7 +456,7 @@ jobs:
     needs:
       - libtorch-rocm6_4-shared-with-deps-release-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -398,7 +398,7 @@ jobs:
     needs:
       - manywheel-py3_10-rocm6_3-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -509,7 +509,7 @@ jobs:
     needs:
       - manywheel-py3_10-rocm6_4-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -1056,7 +1056,7 @@ jobs:
     needs:
       - manywheel-py3_11-rocm6_3-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -1167,7 +1167,7 @@ jobs:
     needs:
       - manywheel-py3_11-rocm6_4-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -1714,7 +1714,7 @@ jobs:
     needs:
       - manywheel-py3_12-rocm6_3-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -1825,7 +1825,7 @@ jobs:
     needs:
       - manywheel-py3_12-rocm6_4-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -2372,7 +2372,7 @@ jobs:
     needs:
       - manywheel-py3_13-rocm6_3-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -2483,7 +2483,7 @@ jobs:
     needs:
       - manywheel-py3_13-rocm6_4-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -3030,7 +3030,7 @@ jobs:
     needs:
       - manywheel-py3_13t-rocm6_3-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -3141,7 +3141,7 @@ jobs:
     needs:
       - manywheel-py3_13t-rocm6_4-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -3688,7 +3688,7 @@ jobs:
     needs:
       - manywheel-py3_14-rocm6_3-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -3799,7 +3799,7 @@ jobs:
     needs:
       - manywheel-py3_14-rocm6_4-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -4346,7 +4346,7 @@ jobs:
     needs:
       - manywheel-py3_14t-rocm6_3-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -4457,7 +4457,7 @@ jobs:
     needs:
       - manywheel-py3_14t-rocm6_4-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch

--- a/.github/workflows/generated-linux-binary-manywheel-rocm-main.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-rocm-main.yml
@@ -12,7 +12,7 @@ on:
     tags:
       - 'ciflow/binaries/*'
       - 'ciflow/binaries_wheel/*'
-      - 'ciflow/rocm/*'
+      - 'ciflow/rocm-mi300/*'
   workflow_dispatch:
 
 permissions:
@@ -69,7 +69,7 @@ jobs:
     needs:
       - manywheel-py3_9-rocm6_4-build
       - get-label-type
-    runs-on: linux.rocm.gpu.mi250
+    runs-on: linux.rocm.gpu.gfx942.1
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch

--- a/.github/workflows/generated-linux-binary-manywheel-rocm-main.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-rocm-main.yml
@@ -10,8 +10,6 @@ on:
     branches:
       - main
     tags:
-      - 'ciflow/binaries/*'
-      - 'ciflow/binaries_wheel/*'
       - 'ciflow/rocm-mi300/*'
   workflow_dispatch:
 


### PR DESCRIPTION
### Motivation

* MI250 Cirrascale runners are currently having network timeout leading to huge queueing of binary smoke test jobs: 
<img width="483" height="133" alt="image" src="https://github.com/user-attachments/assets/17293002-78ad-4fc9-954f-ddd518bf0a43" />

* MI210 Hollywood runners (with runner names such as `pytorch-rocm-hw-*`) are not suitable for these jobs, because they seem to take much longer to download artifacts: https://github.com/pytorch/pytorch/pull/153287#issuecomment-2918420345 (this is why these jobs were specifically targeting Cirrascale runners). However, it doesn't seem like Cirrascale runners are necessarily doing much better either e.g. [this recent build](https://github.com/pytorch/pytorch/actions/runs/17332256791/job/49231006755).
* Moving to MI325 runners should address the stability part at least, while also reducing load on limited MI2xx runner capacity. 
* However, I'm not sure if the MI325 runners will do any better on the artifact download part (this may need to be investigated more) cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd @amdfaa

* Also removing `ciflow/binaries` and `ciflow/binaries_wheel` label/tag triggers for `generated-linux-binary-manywheel-rocm-main.yml` because we already trigger ROCm binary build/test jobs via these labels/tags in `generated-linux-binary-manywheel-nightly.yml`. And for developers who want to trigger ROCm binary build/test jobs on their PRs, they can use the `ciflow/rocm-mi300` label/tag as per this PR.


### TODOs (cc @amdfaa):
* Check that the workflow runs successfully on the MI325 runners in this PR. Note how long the test jobs take esp. the "Download Build Artifacts" step
* Once this PR is merged, clear the queue of jobs targeting `linux.rocm.gpu.mi250`

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd