### PR TITLE
[xpu][test][1/N] Port distributed shared test files for Intel GPU

### DIFF
--- a/test/distributed/_shard/sharding_spec/test_sharding_spec.py
+++ b/test/distributed/_shard/sharding_spec/test_sharding_spec.py
@@ -24,11 +24,14 @@ from torch.distributed._shard.sharding_spec._internals import (
     get_split_size,
     validate_non_overlapping_shards_metadata,
 )
-from torch.testing._internal.common_cuda import TEST_MULTIGPU
-from torch.testing._internal.common_distributed import requires_accelerator_dist_backend, skip_if_lt_x_gpu
+from torch.testing._internal.common_distributed import (
+    requires_accelerator_dist_backend,
+    skip_if_lt_x_gpu,
+)
 from torch.testing._internal.common_utils import (
     run_tests,
     skip_but_pass_in_sandcastle_if,
+    TEST_MULTIACCELERATOR,
     TestCase,
 )
 from torch.testing._internal.distributed._shard.sharded_tensor import (
@@ -40,80 +43,79 @@ from torch.testing._internal.distributed._shard.sharded_tensor._test_st_common i
 )
 
 
-TEST_MULTIACCELERATOR  = torch.accelerator.device_count() >= 2
+DEVICE_TYPE = (
+    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+)
+BACKEND = torch.distributed.get_default_backend_for_device(DEVICE_TYPE)
+
 
 class TestShardingSpec(TestCase):
-    def setUp(self):
-        super().setUp()
-        # Check the availability of gpu device dynamically
-        if torch.cuda.is_available() and torch.cuda.device_count() >= 2:
-            self.device_type = "cuda"
-        elif hasattr(torch, "xpu") and torch.xpu.is_available() and torch.xpu.device_count() >= 2:
-            self.device_type = "xpu"
-        else:
-            # default to cuda, but the test will be skipped
-            self.device_type = "cuda"
-
-    @skip_but_pass_in_sandcastle_if(not TEST_MULTIACCELERATOR, "2 GPUS (CUDA or XPU) are needed")
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, "2 accelerator devices are needed"
+    )
     def test_device_placement(self):
         # valid devices
-        DevicePlacementSpec(f"{self.device_type}:0")
+        DevicePlacementSpec(f"{DEVICE_TYPE}:0")
         DevicePlacementSpec(torch.device(0))
-        DevicePlacementSpec(torch.device(f"{self.device_type}:0"))
-        DevicePlacementSpec(f"rank:0/{self.device_type}:0")
+        DevicePlacementSpec(torch.device(f"{DEVICE_TYPE}:0"))
+        DevicePlacementSpec(f"rank:0/{DEVICE_TYPE}:0")
         DevicePlacementSpec("rank:0/cpu")
         DevicePlacementSpec("rank:0")
 
-        other_device_type = "xpu" if self.device_type == "cuda" else "cuda"
-        if (other_device_type == "cuda" and torch.cuda.is_available()) or \
-           (other_device_type == "xpu" and hasattr(torch, 'xpu') and torch.xpu.is_available()):
-            DevicePlacementSpec(f"{other_device_type}:0")
-            DevicePlacementSpec(f"rank:0/{other_device_type}:0")
-
         # invalid devices
         with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
-            DevicePlacementSpec(f"{self.device_type}:foo")
+            DevicePlacementSpec("cuda:foo")
         with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
             DevicePlacementSpec("foo:0")
         with self.assertRaisesRegex(RuntimeError, "Invalid device string"):
-            DevicePlacementSpec(f"rank:0/{self.device_type}:foo")
+            DevicePlacementSpec("rank:0/cuda:foo")
         with self.assertRaisesRegex(RuntimeError, "Invalid device string"):
             DevicePlacementSpec("rank:0/cpu2")
 
-    @skip_but_pass_in_sandcastle_if(not TEST_MULTIACCELERATOR, "2 GPUS (CUDA or XPU) are needed")
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, "2 accelerator devices are needed"
+    )
     def test_chunked_sharding_spec(self):
         # Test valid specs.
         ChunkShardingSpec(0, [torch.device(0), torch.device(1)])
-        ChunkShardingSpec(0, [torch.device(f"{self.device_type}:0"), torch.device(f"{self.device_type}:1")])
-        ChunkShardingSpec(-1, [f"{self.device_type}:0", f"{self.device_type}:1"])
-        ChunkShardingSpec(0, [f"rank:0/{self.device_type}:0", f"rank:0/{self.device_type}:1"])
+        ChunkShardingSpec(
+            0,
+            [
+                torch.device(f"{DEVICE_TYPE}:0"),
+                torch.device(f"{DEVICE_TYPE}:1"),
+            ],
+        )
+        ChunkShardingSpec(-1, [f"{DEVICE_TYPE}:0", f"{DEVICE_TYPE}:1"])
+        ChunkShardingSpec(0, [f"rank:0/{DEVICE_TYPE}:0", f"rank:0/{DEVICE_TYPE}:1"])
         ChunkShardingSpec(0, ["rank:0", "rank:1"])
         ChunkShardingSpec(0, ["rank:0/cpu", "rank:1/cpu"])
 
         # Test unimplemented error
         with self.assertRaisesRegex(NotImplementedError, "not support named dimension"):
             # Named dimension.
-            ChunkShardingSpec("N", [f"{self.device_type}:0", f"{self.device_type}:1"])
+            ChunkShardingSpec("N", [f"{DEVICE_TYPE}:0", f"{DEVICE_TYPE}:1"])
 
         # Test invalid specs
         with self.assertRaisesRegex(ValueError, "needs to be an integer"):
-            ChunkShardingSpec(None, [f"{self.device_type}:0", f"{self.device_type}:1"])
+            ChunkShardingSpec(None, [f"{DEVICE_TYPE}:0", f"{DEVICE_TYPE}:1"])
         with self.assertRaisesRegex(ValueError, "needs to be an integer"):
-            ChunkShardingSpec({}, [f"{self.device_type}:0", f"{self.device_type}:1"])
+            ChunkShardingSpec({}, [f"{DEVICE_TYPE}:0", f"{DEVICE_TYPE}:1"])
         with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
-            ChunkShardingSpec(0, ["random:0", f"{self.device_type}:1"])
+            ChunkShardingSpec(0, ["random:0", f"{DEVICE_TYPE}:1"])
         with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
-            ChunkShardingSpec(0, [f"{self.device_type}:foo", f"{self.device_type}:1"])
+            ChunkShardingSpec(0, [f"{DEVICE_TYPE}:foo", f"{DEVICE_TYPE}:1"])
         with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
-            ChunkShardingSpec(0, ["rank:foo", f"{self.device_type}:1"])
+            ChunkShardingSpec(0, ["rank:foo", f"{DEVICE_TYPE}:1"])
         with self.assertRaisesRegex(RuntimeError, "Expected one of"):
-            ChunkShardingSpec(0, ["rank:0/foo", f"{self.device_type}:1"])
+            ChunkShardingSpec(0, ["rank:0/foo", f"{DEVICE_TYPE}:1"])
         with self.assertRaisesRegex(RuntimeError, "Expected one of"):
-            ChunkShardingSpec(0, ["rank:0/random:0", f"{self.device_type}:1"])
+            ChunkShardingSpec(0, ["rank:0/random:0", f"{DEVICE_TYPE}:1"])
         with self.assertRaisesRegex(RuntimeError, "Invalid device string"):
-            ChunkShardingSpec(0, [f"rank:0/{self.device_type}:foo", f"{self.device_type}:1"])
+            ChunkShardingSpec(0, [f"rank:0/{DEVICE_TYPE}:foo", f"{DEVICE_TYPE}:1"])
 
-    @skip_but_pass_in_sandcastle_if(not TEST_MULTIACCELERATOR, "2 GPUS (CUDA or XPU) are needed")
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, "2 accelerator devices are needed"
+    )
     def test_enumerable_sharding_spec(self):
         # test valid specs
 
@@ -123,12 +125,12 @@ class TestShardingSpec(TestCase):
                 ShardMetadata(
                     shard_offsets=[0, 0],
                     shard_sizes=[5, 5],
-                    placement=f"{self.device_type}:0",
+                    placement=f"{DEVICE_TYPE}:0",
                 ),
                 ShardMetadata(
                     shard_offsets=[5, 0],
                     shard_sizes=[5, 5],
-                    placement=f"{self.device_type}:1",
+                    placement=f"{DEVICE_TYPE}:1",
                 ),
             ]
         )
@@ -140,22 +142,22 @@ class TestShardingSpec(TestCase):
                 ShardMetadata(
                     shard_offsets=[0, 0],
                     shard_sizes=[3, 3],
-                    placement=f"{self.device_type}:0",
+                    placement=f"{DEVICE_TYPE}:0",
                 ),
                 ShardMetadata(
                     shard_offsets=[0, 3],
                     shard_sizes=[3, 3],
-                    placement=f"{self.device_type}:1",
+                    placement=f"{DEVICE_TYPE}:1",
                 ),
                 ShardMetadata(
                     shard_offsets=[3, 0],
                     shard_sizes=[3, 3],
-                    placement=f"{self.device_type}:2",
+                    placement=f"{DEVICE_TYPE}:2",
                 ),
                 ShardMetadata(
                     shard_offsets=[3, 3],
                     shard_sizes=[3, 3],
-                    placement=f"{self.device_type}:3",
+                    placement=f"{DEVICE_TYPE}:3",
                 ),
             ]
         )
@@ -167,22 +169,22 @@ class TestShardingSpec(TestCase):
                 ShardMetadata(
                     shard_offsets=[0, 0],
                     shard_sizes=[2, 4],
-                    placement=f"{self.device_type}:0",
+                    placement=f"{DEVICE_TYPE}:0",
                 ),
                 ShardMetadata(
                     shard_offsets=[0, 4],
                     shard_sizes=[4, 2],
-                    placement=f"{self.device_type}:1",
+                    placement=f"{DEVICE_TYPE}:1",
                 ),
                 ShardMetadata(
                     shard_offsets=[2, 0],
                     shard_sizes=[4, 4],
-                    placement=f"{self.device_type}:2",
+                    placement=f"{DEVICE_TYPE}:2",
                 ),
                 ShardMetadata(
                     shard_offsets=[4, 4],
                     shard_sizes=[2, 2],
-                    placement=f"{self.device_type}:3",
+                    placement=f"{DEVICE_TYPE}:3",
                 ),
             ]
         )
@@ -190,16 +192,28 @@ class TestShardingSpec(TestCase):
 
         # test invalid sharding
         with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
-            ShardMetadata(shard_offsets=[0], shard_sizes=[1], placement=f"{self.device_type}:foo")
+            ShardMetadata(
+                shard_offsets=[0], shard_sizes=[1], placement=f"{DEVICE_TYPE}:foo"
+            )
 
         with self.assertRaisesRegex(ValueError, "same number of elements"):
-            ShardMetadata(shard_offsets=[0, 0], shard_sizes=[1], placement=f"{self.device_type}:0")
+            ShardMetadata(
+                shard_offsets=[0, 0], shard_sizes=[1], placement=f"{DEVICE_TYPE}:0"
+            )
 
         with self.assertRaisesRegex(ValueError, "shard_offsets should be >=0"):
-            ShardMetadata(shard_offsets=[-1, 0], shard_sizes=[1, 1], placement=f"{self.device_type}:0")
+            ShardMetadata(
+                shard_offsets=[-1, 0],
+                shard_sizes=[1, 1],
+                placement=f"{DEVICE_TYPE}:0",
+            )
 
         with self.assertRaisesRegex(ValueError, "shard_sizes should be >= 0"):
-            ShardMetadata(shard_offsets=[0, 0], shard_sizes=[-1, 1], placement=f"{self.device_type}:0")
+            ShardMetadata(
+                shard_offsets=[0, 0],
+                shard_sizes=[-1, 1],
+                placement=f"{DEVICE_TYPE}:0",
+            )
 
         with self.assertRaisesRegex(ValueError, "Empty shard list provided"):
             EnumerableShardingSpec([])
@@ -233,12 +247,12 @@ class TestShardingSpec(TestCase):
                 ShardMetadata(
                     shard_offsets=[0, 0],
                     shard_sizes=[5, 5],
-                    placement=f"{self.device_type}:0",
+                    placement=f"{DEVICE_TYPE}:0",
                 ),
                 ShardMetadata(
                     shard_offsets=[5, 0],
                     shard_sizes=[5, 5],
-                    placement=f"{self.device_type}:1",
+                    placement=f"{DEVICE_TYPE}:1",
                 ),
             ]
         )
@@ -251,12 +265,12 @@ class TestShardingSpec(TestCase):
                 ShardMetadata(
                     shard_offsets=[0, 0],
                     shard_sizes=[5, 5],
-                    placement=f"{self.device_type}:0",
+                    placement=f"{DEVICE_TYPE}:0",
                 ),
                 ShardMetadata(
                     shard_offsets=[5, 0],
                     shard_sizes=[5, 5],
-                    placement=f"{self.device_type}:1",
+                    placement=f"{DEVICE_TYPE}:1",
                 ),
             ]
         )
@@ -269,12 +283,12 @@ class TestShardingSpec(TestCase):
                 ShardMetadata(
                     shard_offsets=[0, 0],
                     shard_sizes=[5, 5],
-                    placement=f"{self.device_type}:0",
+                    placement=f"{DEVICE_TYPE}:0",
                 ),
                 ShardMetadata(
                     shard_offsets=[5, 5],
                     shard_sizes=[5, 5],
-                    placement=f"{self.device_type}:1",
+                    placement=f"{DEVICE_TYPE}:1",
                 ),
             ]
         )
@@ -300,10 +314,10 @@ class TestShardingSpec(TestCase):
 
     def test_get_chunk_sharding_params(self):
         ranks = [
-            f"rank:0/{self.device_type}:0",
-            f"rank:1/{self.device_type}:1",
-            f"rank:2/{self.device_type}:2",
-            f"rank:3/{self.device_type}:3",
+            f"rank:0/{DEVICE_TYPE}:0",
+            f"rank:1/{DEVICE_TYPE}:1",
+            f"rank:2/{DEVICE_TYPE}:2",
+            f"rank:3/{DEVICE_TYPE}:3",
         ]
         spec = ChunkShardingSpec(
             dim=0,
@@ -330,12 +344,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement=f"{self.device_type}:0",
+                placement=f"{DEVICE_TYPE}:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 0],
                 shard_sizes=[10, 5],
-                placement=f"{self.device_type}:1",
+                placement=f"{DEVICE_TYPE}:1",
             ),
         ]
         spec = _infer_sharding_spec_from_shards_metadata(shards_metadata)
@@ -346,12 +360,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0],
                 shard_sizes=[16],
-                placement=f"{self.device_type}:0",
+                placement=f"{DEVICE_TYPE}:0",
             ),
             ShardMetadata(
                 shard_offsets=[16],
                 shard_sizes=[9],
-                placement=f"{self.device_type}:0",
+                placement=f"{DEVICE_TYPE}:0",
             ),
         ]
         spec = _infer_sharding_spec_from_shards_metadata(shards_metadata)
@@ -362,22 +376,22 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement=f"rank:0/{self.device_type}:0",
+                placement=f"rank:0/{DEVICE_TYPE}:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 0],
                 shard_sizes=[5, 5],
-                placement=f"rank:1/{self.device_type}:1",
+                placement=f"rank:1/{DEVICE_TYPE}:1",
             ),
             ShardMetadata(
                 shard_offsets=[0, 5],
                 shard_sizes=[5, 5],
-                placement=f"rank:2/{self.device_type}:2",
+                placement=f"rank:2/{DEVICE_TYPE}:2",
             ),
             ShardMetadata(
                 shard_offsets=[5, 5],
                 shard_sizes=[5, 5],
-                placement=f"rank:3/{self.device_type}:3",
+                placement=f"rank:3/{DEVICE_TYPE}:3",
             ),
         ]
         spec = _infer_sharding_spec_from_shards_metadata(shards_metadata)
@@ -424,12 +438,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement=f"{self.device_type}:0",
+                placement=f"{DEVICE_TYPE}:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 0],
                 shard_sizes=[5, 5],
-                placement=f"{self.device_type}:1",
+                placement=f"{DEVICE_TYPE}:1",
             ),
         ]
         validate_non_overlapping_shards_metadata(shards)
@@ -438,12 +452,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement=f"{self.device_type}:0",
+                placement=f"{DEVICE_TYPE}:0",
             ),
             ShardMetadata(
                 shard_offsets=[4, 0],
                 shard_sizes=[5, 5],
-                placement=f"{self.device_type}:1",
+                placement=f"{DEVICE_TYPE}:1",
             ),
         ]
         with self.assertRaisesRegex(ValueError, "overlap"):
@@ -453,12 +467,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement=f"{self.device_type}:0",
+                placement=f"{DEVICE_TYPE}:0",
             ),
             ShardMetadata(
                 shard_offsets=[0, 4],
                 shard_sizes=[5, 5],
-                placement=f"{self.device_type}:1",
+                placement=f"{DEVICE_TYPE}:1",
             ),
         ]
         with self.assertRaisesRegex(ValueError, "overlap"):
@@ -468,12 +482,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[5, 0, 5],
                 shard_sizes=[5, 5, 5],
-                placement=f"{self.device_type}:0",
+                placement=f"{DEVICE_TYPE}:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 5, 5],
                 shard_sizes=[5, 5, 5],
-                placement=f"{self.device_type}:1",
+                placement=f"{DEVICE_TYPE}:1",
             ),
         ]
         validate_non_overlapping_shards_metadata(shards)
@@ -482,12 +496,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[5, 0, 5],
                 shard_sizes=[5, 5, 5],
-                placement=f"{self.device_type}:0",
+                placement=f"{DEVICE_TYPE}:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 4, 5],
                 shard_sizes=[5, 5, 5],
-                placement=f"{self.device_type}:1",
+                placement=f"{DEVICE_TYPE}:1",
             ),
         ]
         with self.assertRaisesRegex(ValueError, "overlap"):
@@ -497,12 +511,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[5, 0, 5],
                 shard_sizes=[5, 5, 5],
-                placement=f"{self.device_type}:0",
+                placement=f"{DEVICE_TYPE}:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 4, 9],
                 shard_sizes=[5, 5, 5],
-                placement=f"{self.device_type}:1",
+                placement=f"{DEVICE_TYPE}:1",
             ),
         ]
         with self.assertRaisesRegex(ValueError, "overlap"):
@@ -630,11 +644,6 @@ class GridShardingSpec(ShardingSpec):
         raise NotImplementedError("GridShardingSpec.shard not implemented yet!")
 
 
-if torch.accelerator.is_available():
-    DEVICE_TYPE = torch.accelerator.current_accelerator().type
-    BACKEND = torch.distributed.get_default_backend_for_device(DEVICE_TYPE)
-
-
 class TestCustomShardingSpec(ShardedTensorTestBase):
     def test_custom_sharding_spec(self):
         ranks = [
@@ -657,7 +666,7 @@ class TestCustomShardingSpec(ShardedTensorTestBase):
         meta = grid_spec.build_metadata(torch.Size((8, 8)), tensor_properties)
         check_tensor(meta.shards_metadata, torch.Size((8, 8)))
 
-    @with_comms(init_rpc=False, backend=BACKEND)
+    @with_comms(backend=BACKEND)
     @skip_if_lt_x_gpu(4)
     @requires_accelerator_dist_backend(["nccl", "xccl"])
     def test_custom_sharding_spec_tensor_ctor(self):
@@ -684,7 +693,7 @@ class TestCustomShardingSpec(ShardedTensorTestBase):
         self.assertEqual((2, 2), local_shard.size())
         self.assertEqual(local_shard, torch.ones(2, 2))
 
-    @with_comms(init_rpc=False, backend=BACKEND)
+    @with_comms(backend=BACKEND)
     @skip_if_lt_x_gpu(4)
     @requires_accelerator_dist_backend(["nccl", "xccl"])
     def test_custom_sharding_spec_shard_tensor(self):

--- a/test/distributed/_shard/sharding_spec/test_sharding_spec.py
+++ b/test/distributed/_shard/sharding_spec/test_sharding_spec.py
@@ -25,7 +25,7 @@ from torch.distributed._shard.sharding_spec._internals import (
     validate_non_overlapping_shards_metadata,
 )
 from torch.testing._internal.common_cuda import TEST_MULTIGPU
-from torch.testing._internal.common_distributed import requires_nccl, skip_if_lt_x_gpu
+from torch.testing._internal.common_distributed import requires_accelerator_dist_backend, skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
     run_tests,
     skip_but_pass_in_sandcastle_if,
@@ -40,61 +40,80 @@ from torch.testing._internal.distributed._shard.sharded_tensor._test_st_common i
 )
 
 
+TEST_MULTIACCELERATOR  = torch.accelerator.device_count() >= 2
+
 class TestShardingSpec(TestCase):
-    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "2 CUDA GPUs are needed")
+    def setUp(self):
+        super().setUp()
+        # Check the availability of gpu device dynamically
+        if torch.cuda.is_available() and torch.cuda.device_count() >= 2:
+            self.device_type = "cuda"
+        elif hasattr(torch, "xpu") and torch.xpu.is_available() and torch.xpu.device_count() >= 2:
+            self.device_type = "xpu"
+        else:
+            # default to cuda, but the test will be skipped
+            self.device_type = "cuda"
+
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIACCELERATOR, "2 GPUS (CUDA or XPU) are needed")
     def test_device_placement(self):
         # valid devices
-        DevicePlacementSpec("cuda:0")
+        DevicePlacementSpec(f"{self.device_type}:0")
         DevicePlacementSpec(torch.device(0))
-        DevicePlacementSpec(torch.device("cuda:0"))
-        DevicePlacementSpec("rank:0/cuda:0")
+        DevicePlacementSpec(torch.device(f"{self.device_type}:0"))
+        DevicePlacementSpec(f"rank:0/{self.device_type}:0")
         DevicePlacementSpec("rank:0/cpu")
         DevicePlacementSpec("rank:0")
 
+        other_device_type = "xpu" if self.device_type == "cuda" else "cuda"
+        if (other_device_type == "cuda" and torch.cuda.is_available()) or \
+           (other_device_type == "xpu" and hasattr(torch, 'xpu') and torch.xpu.is_available()):
+            DevicePlacementSpec(f"{other_device_type}:0")
+            DevicePlacementSpec(f"rank:0/{other_device_type}:0")
+
         # invalid devices
         with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
-            DevicePlacementSpec("cuda:foo")
+            DevicePlacementSpec(f"{self.device_type}:foo")
         with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
             DevicePlacementSpec("foo:0")
         with self.assertRaisesRegex(RuntimeError, "Invalid device string"):
-            DevicePlacementSpec("rank:0/cuda:foo")
+            DevicePlacementSpec(f"rank:0/{self.device_type}:foo")
         with self.assertRaisesRegex(RuntimeError, "Invalid device string"):
             DevicePlacementSpec("rank:0/cpu2")
 
-    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "2 CUDA GPUs are needed")
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIACCELERATOR, "2 GPUS (CUDA or XPU) are needed")
     def test_chunked_sharding_spec(self):
         # Test valid specs.
         ChunkShardingSpec(0, [torch.device(0), torch.device(1)])
-        ChunkShardingSpec(0, [torch.device("cuda:0"), torch.device("cuda:1")])
-        ChunkShardingSpec(-1, ["cuda:0", "cuda:1"])
-        ChunkShardingSpec(0, ["rank:0/cuda:0", "rank:0/cuda:1"])
+        ChunkShardingSpec(0, [torch.device(f"{self.device_type}:0"), torch.device(f"{self.device_type}:1")])
+        ChunkShardingSpec(-1, [f"{self.device_type}:0", f"{self.device_type}:1"])
+        ChunkShardingSpec(0, [f"rank:0/{self.device_type}:0", f"rank:0/{self.device_type}:1"])
         ChunkShardingSpec(0, ["rank:0", "rank:1"])
         ChunkShardingSpec(0, ["rank:0/cpu", "rank:1/cpu"])
 
         # Test unimplemented error
         with self.assertRaisesRegex(NotImplementedError, "not support named dimension"):
             # Named dimension.
-            ChunkShardingSpec("N", ["cuda:0", "cuda:1"])
+            ChunkShardingSpec("N", [f"{self.device_type}:0", f"{self.device_type}:1"])
 
         # Test invalid specs
         with self.assertRaisesRegex(ValueError, "needs to be an integer"):
-            ChunkShardingSpec(None, ["cuda:0", "cuda:1"])
+            ChunkShardingSpec(None, [f"{self.device_type}:0", f"{self.device_type}:1"])
         with self.assertRaisesRegex(ValueError, "needs to be an integer"):
-            ChunkShardingSpec({}, ["cuda:0", "cuda:1"])
+            ChunkShardingSpec({}, [f"{self.device_type}:0", f"{self.device_type}:1"])
         with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
-            ChunkShardingSpec(0, ["random:0", "cuda:1"])
+            ChunkShardingSpec(0, ["random:0", f"{self.device_type}:1"])
         with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
-            ChunkShardingSpec(0, ["cuda:foo", "cuda:1"])
+            ChunkShardingSpec(0, [f"{self.device_type}:foo", f"{self.device_type}:1"])
         with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
-            ChunkShardingSpec(0, ["rank:foo", "cuda:1"])
+            ChunkShardingSpec(0, ["rank:foo", f"{self.device_type}:1"])
         with self.assertRaisesRegex(RuntimeError, "Expected one of"):
-            ChunkShardingSpec(0, ["rank:0/foo", "cuda:1"])
+            ChunkShardingSpec(0, ["rank:0/foo", f"{self.device_type}:1"])
         with self.assertRaisesRegex(RuntimeError, "Expected one of"):
-            ChunkShardingSpec(0, ["rank:0/random:0", "cuda:1"])
+            ChunkShardingSpec(0, ["rank:0/random:0", f"{self.device_type}:1"])
         with self.assertRaisesRegex(RuntimeError, "Invalid device string"):
-            ChunkShardingSpec(0, ["rank:0/cuda:foo", "cuda:1"])
+            ChunkShardingSpec(0, [f"rank:0/{self.device_type}:foo", f"{self.device_type}:1"])
 
-    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "2 CUDA GPUs are needed")
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIACCELERATOR, "2 GPUS (CUDA or XPU) are needed")
     def test_enumerable_sharding_spec(self):
         # test valid specs
 
@@ -104,12 +123,12 @@ class TestShardingSpec(TestCase):
                 ShardMetadata(
                     shard_offsets=[0, 0],
                     shard_sizes=[5, 5],
-                    placement="cuda:0",
+                    placement=f"{self.device_type}:0",
                 ),
                 ShardMetadata(
                     shard_offsets=[5, 0],
                     shard_sizes=[5, 5],
-                    placement="cuda:1",
+                    placement=f"{self.device_type}:1",
                 ),
             ]
         )
@@ -121,22 +140,22 @@ class TestShardingSpec(TestCase):
                 ShardMetadata(
                     shard_offsets=[0, 0],
                     shard_sizes=[3, 3],
-                    placement="cuda:0",
+                    placement=f"{self.device_type}:0",
                 ),
                 ShardMetadata(
                     shard_offsets=[0, 3],
                     shard_sizes=[3, 3],
-                    placement="cuda:1",
+                    placement=f"{self.device_type}:1",
                 ),
                 ShardMetadata(
                     shard_offsets=[3, 0],
                     shard_sizes=[3, 3],
-                    placement="cuda:2",
+                    placement=f"{self.device_type}:2",
                 ),
                 ShardMetadata(
                     shard_offsets=[3, 3],
                     shard_sizes=[3, 3],
-                    placement="cuda:3",
+                    placement=f"{self.device_type}:3",
                 ),
             ]
         )
@@ -148,22 +167,22 @@ class TestShardingSpec(TestCase):
                 ShardMetadata(
                     shard_offsets=[0, 0],
                     shard_sizes=[2, 4],
-                    placement="cuda:0",
+                    placement=f"{self.device_type}:0",
                 ),
                 ShardMetadata(
                     shard_offsets=[0, 4],
                     shard_sizes=[4, 2],
-                    placement="cuda:1",
+                    placement=f"{self.device_type}:1",
                 ),
                 ShardMetadata(
                     shard_offsets=[2, 0],
                     shard_sizes=[4, 4],
-                    placement="cuda:2",
+                    placement=f"{self.device_type}:2",
                 ),
                 ShardMetadata(
                     shard_offsets=[4, 4],
                     shard_sizes=[2, 2],
-                    placement="cuda:3",
+                    placement=f"{self.device_type}:3",
                 ),
             ]
         )
@@ -171,16 +190,16 @@ class TestShardingSpec(TestCase):
 
         # test invalid sharding
         with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
-            ShardMetadata(shard_offsets=[0], shard_sizes=[1], placement="cuda:foo")
+            ShardMetadata(shard_offsets=[0], shard_sizes=[1], placement=f"{self.device_type}:foo")
 
         with self.assertRaisesRegex(ValueError, "same number of elements"):
-            ShardMetadata(shard_offsets=[0, 0], shard_sizes=[1], placement="cuda:0")
+            ShardMetadata(shard_offsets=[0, 0], shard_sizes=[1], placement=f"{self.device_type}:0")
 
         with self.assertRaisesRegex(ValueError, "shard_offsets should be >=0"):
-            ShardMetadata(shard_offsets=[-1, 0], shard_sizes=[1, 1], placement="cuda:0")
+            ShardMetadata(shard_offsets=[-1, 0], shard_sizes=[1, 1], placement=f"{self.device_type}:0")
 
         with self.assertRaisesRegex(ValueError, "shard_sizes should be >= 0"):
-            ShardMetadata(shard_offsets=[0, 0], shard_sizes=[-1, 1], placement="cuda:0")
+            ShardMetadata(shard_offsets=[0, 0], shard_sizes=[-1, 1], placement=f"{self.device_type}:0")
 
         with self.assertRaisesRegex(ValueError, "Empty shard list provided"):
             EnumerableShardingSpec([])
@@ -214,12 +233,12 @@ class TestShardingSpec(TestCase):
                 ShardMetadata(
                     shard_offsets=[0, 0],
                     shard_sizes=[5, 5],
-                    placement="cuda:0",
+                    placement=f"{self.device_type}:0",
                 ),
                 ShardMetadata(
                     shard_offsets=[5, 0],
                     shard_sizes=[5, 5],
-                    placement="cuda:1",
+                    placement=f"{self.device_type}:1",
                 ),
             ]
         )
@@ -232,12 +251,12 @@ class TestShardingSpec(TestCase):
                 ShardMetadata(
                     shard_offsets=[0, 0],
                     shard_sizes=[5, 5],
-                    placement="cuda:0",
+                    placement=f"{self.device_type}:0",
                 ),
                 ShardMetadata(
                     shard_offsets=[5, 0],
                     shard_sizes=[5, 5],
-                    placement="cuda:1",
+                    placement=f"{self.device_type}:1",
                 ),
             ]
         )
@@ -250,12 +269,12 @@ class TestShardingSpec(TestCase):
                 ShardMetadata(
                     shard_offsets=[0, 0],
                     shard_sizes=[5, 5],
-                    placement="cuda:0",
+                    placement=f"{self.device_type}:0",
                 ),
                 ShardMetadata(
                     shard_offsets=[5, 5],
                     shard_sizes=[5, 5],
-                    placement="cuda:1",
+                    placement=f"{self.device_type}:1",
                 ),
             ]
         )
@@ -281,10 +300,10 @@ class TestShardingSpec(TestCase):
 
     def test_get_chunk_sharding_params(self):
         ranks = [
-            "rank:0/cuda:0",
-            "rank:1/cuda:1",
-            "rank:2/cuda:2",
-            "rank:3/cuda:3",
+            f"rank:0/{self.device_type}:0",
+            f"rank:1/{self.device_type}:1",
+            f"rank:2/{self.device_type}:2",
+            f"rank:3/{self.device_type}:3",
         ]
         spec = ChunkShardingSpec(
             dim=0,
@@ -311,12 +330,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement="cuda:0",
+                placement=f"{self.device_type}:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 0],
                 shard_sizes=[10, 5],
-                placement="cuda:1",
+                placement=f"{self.device_type}:1",
             ),
         ]
         spec = _infer_sharding_spec_from_shards_metadata(shards_metadata)
@@ -327,12 +346,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0],
                 shard_sizes=[16],
-                placement="cuda:0",
+                placement=f"{self.device_type}:0",
             ),
             ShardMetadata(
                 shard_offsets=[16],
                 shard_sizes=[9],
-                placement="cuda:1",
+                placement=f"{self.device_type}:0",
             ),
         ]
         spec = _infer_sharding_spec_from_shards_metadata(shards_metadata)
@@ -343,22 +362,22 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement="rank:0/cuda:0",
+                placement=f"rank:0/{self.device_type}:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 0],
                 shard_sizes=[5, 5],
-                placement="rank:1/cuda:1",
+                placement=f"rank:1/{self.device_type}:1",
             ),
             ShardMetadata(
                 shard_offsets=[0, 5],
                 shard_sizes=[5, 5],
-                placement="rank:2/cuda:2",
+                placement=f"rank:2/{self.device_type}:2",
             ),
             ShardMetadata(
                 shard_offsets=[5, 5],
                 shard_sizes=[5, 5],
-                placement="rank:3/cuda:3",
+                placement=f"rank:3/{self.device_type}:3",
             ),
         ]
         spec = _infer_sharding_spec_from_shards_metadata(shards_metadata)
@@ -405,12 +424,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement="cuda:0",
+                placement=f"{self.device_type}:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 0],
                 shard_sizes=[5, 5],
-                placement="cuda:1",
+                placement=f"{self.device_type}:1",
             ),
         ]
         validate_non_overlapping_shards_metadata(shards)
@@ -419,12 +438,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement="cuda:0",
+                placement=f"{self.device_type}:0",
             ),
             ShardMetadata(
                 shard_offsets=[4, 0],
                 shard_sizes=[5, 5],
-                placement="cuda:1",
+                placement=f"{self.device_type}:1",
             ),
         ]
         with self.assertRaisesRegex(ValueError, "overlap"):
@@ -434,12 +453,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement="cuda:0",
+                placement=f"{self.device_type}:0",
             ),
             ShardMetadata(
                 shard_offsets=[0, 4],
                 shard_sizes=[5, 5],
-                placement="cuda:1",
+                placement=f"{self.device_type}:1",
             ),
         ]
         with self.assertRaisesRegex(ValueError, "overlap"):
@@ -449,12 +468,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[5, 0, 5],
                 shard_sizes=[5, 5, 5],
-                placement="cuda:0",
+                placement=f"{self.device_type}:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 5, 5],
                 shard_sizes=[5, 5, 5],
-                placement="cuda:1",
+                placement=f"{self.device_type}:1",
             ),
         ]
         validate_non_overlapping_shards_metadata(shards)
@@ -463,12 +482,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[5, 0, 5],
                 shard_sizes=[5, 5, 5],
-                placement="cuda:0",
+                placement=f"{self.device_type}:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 4, 5],
                 shard_sizes=[5, 5, 5],
-                placement="cuda:1",
+                placement=f"{self.device_type}:1",
             ),
         ]
         with self.assertRaisesRegex(ValueError, "overlap"):
@@ -478,12 +497,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[5, 0, 5],
                 shard_sizes=[5, 5, 5],
-                placement="cuda:0",
+                placement=f"{self.device_type}:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 4, 9],
                 shard_sizes=[5, 5, 5],
-                placement="cuda:1",
+                placement=f"{self.device_type}:1",
             ),
         ]
         with self.assertRaisesRegex(ValueError, "overlap"):
@@ -611,13 +630,18 @@ class GridShardingSpec(ShardingSpec):
         raise NotImplementedError("GridShardingSpec.shard not implemented yet!")
 
 
+if torch.accelerator.is_available():
+    DEVICE_TYPE = torch.accelerator.current_accelerator().type
+    BACKEND = torch.distributed.get_default_backend_for_device(DEVICE_TYPE)
+
+
 class TestCustomShardingSpec(ShardedTensorTestBase):
     def test_custom_sharding_spec(self):
         ranks = [
-            "rank:0/cuda:0",
-            "rank:1/cuda:1",
-            "rank:2/cuda:2",
-            "rank:3/cuda:3",
+            f"rank:0/{DEVICE_TYPE}:0",
+            f"rank:1/{DEVICE_TYPE}:1",
+            f"rank:2/{DEVICE_TYPE}:2",
+            f"rank:3/{DEVICE_TYPE}:3",
         ]
 
         grid_spec = GridShardingSpec(grid_size=4, placements=ranks)
@@ -633,19 +657,19 @@ class TestCustomShardingSpec(ShardedTensorTestBase):
         meta = grid_spec.build_metadata(torch.Size((8, 8)), tensor_properties)
         check_tensor(meta.shards_metadata, torch.Size((8, 8)))
 
-    @with_comms
+    @with_comms(init_rpc=False, backend=BACKEND)
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
+    @requires_accelerator_dist_backend(["nccl", "xccl"])
     def test_custom_sharding_spec_tensor_ctor(self):
         """Test sharded_tensor.ones(...) with the custom
         grid sharding spec.
         """
 
         ranks = [
-            "rank:0/cuda:0",
-            "rank:1/cuda:1",
-            "rank:2/cuda:2",
-            "rank:3/cuda:3",
+            f"rank:0/{DEVICE_TYPE}:0",
+            f"rank:1/{DEVICE_TYPE}:1",
+            f"rank:2/{DEVICE_TYPE}:2",
+            f"rank:3/{DEVICE_TYPE}:3",
         ]
 
         grid_spec = GridShardingSpec(grid_size=2, placements=ranks)
@@ -656,23 +680,23 @@ class TestCustomShardingSpec(ShardedTensorTestBase):
         local_shards = st.local_shards()
         self.assertEqual(1, len(local_shards))
         local_shard = local_shards[0].tensor
-        self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.device)
+        self.assertEqual(torch.device(f"{DEVICE_TYPE}:{self.rank}"), local_shard.device)
         self.assertEqual((2, 2), local_shard.size())
         self.assertEqual(local_shard, torch.ones(2, 2))
 
-    @with_comms
+    @with_comms(init_rpc=False, backend=BACKEND)
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
+    @requires_accelerator_dist_backend(["nccl", "xccl"])
     def test_custom_sharding_spec_shard_tensor(self):
         """Test custom spec can be invoked from the
         _shard_tensor callsite.
         """
 
         ranks = [
-            "rank:0/cuda:0",
-            "rank:1/cuda:1",
-            "rank:2/cuda:2",
-            "rank:3/cuda:3",
+            f"rank:0/{DEVICE_TYPE}:0",
+            f"rank:1/{DEVICE_TYPE}:1",
+            f"rank:2/{DEVICE_TYPE}:2",
+            f"rank:3/{DEVICE_TYPE}:3",
         ]
 
         grid_spec = GridShardingSpec(grid_size=2, placements=ranks)


### PR DESCRIPTION
For https://github.com/pytorch/pytorch/issues/114850, we will port 1 distributed test to Intel GPU.

In this PR we will port 1 distributed shard test files.
We could enable Intel GPU with following methods and try the best to keep the original code styles:

- use "torch.accelerator.current_accelerator()" to determine the accelerator backend
- use "requires_accelerator_dist_backend()" to replace requires_nccl()
- use "torch.accelerator.device_count()" to get the number of accelerator 
- enabled XPU for some test path

cc @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @aditvenk @xmfan @H-Huang @ezyang @gujinghui @EikanWang @fengyuan14 @guangyey