### PR TITLE
[ROCm][inductor] Codegen support for fast_tanhf

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -27,6 +27,7 @@ from torch._dynamo.utils import identity, preserve_rng_state
 from torch._prims_common import is_integer_dtype
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.functions import CeilDiv, FloorDiv, ModularIndexing
+from torch.utils._sympy.value_ranges import bound_sympy
 from torch.utils._triton import has_triton_package, has_triton_stable_tma_api, get_triton_version
 
 from ...utils._sympy.symbol import free_symbol_is_type, prefix_str, symbol_is_type, SymT

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1682,7 +1682,10 @@ class TritonOverrides(OpOverrides):
     @staticmethod
     @maybe_upcast_float32()
     def tanh(x):
-        return f"libdevice.tanh({x})"
+        if torch.version.hip:
+            return f"libdevice.fast_tanhf({x})"
+        else:
+            return f"libdevice.tanh({x})"
 
     @staticmethod
     @maybe_upcast_float32()

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1692,9 +1692,11 @@ class TritonOverrides(OpOverrides):
         else:
             dtype = None
         if (
-            torch.version.hip
+            config.use_fast_math
+            and torch.version.hip
             and get_triton_version() > (3, 5)
             and dtype != torch.float64
+            and dtype is not None
         ):
             # Requires upstream Triton 3.6+ for latest fast_tanhf support
             # https://github.com/triton-lang/triton/pull/8551

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1686,7 +1686,11 @@ class TritonOverrides(OpOverrides):
     @staticmethod
     @maybe_upcast_float32()
     def tanh(x):
-        dtype = V.kernel.cse.varname_map.get(x).dtype
+        cse_var = V.kernel.cse.varname_map.get(x)
+        if cse_var and hasattr(cse_var, "dtype"):
+            dtype = cse_var.dtype
+        else:
+            dtype = None
         if (
             torch.version.hip
             and get_triton_version() > (3, 5)

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -27,9 +27,11 @@ from torch._dynamo.utils import identity, preserve_rng_state
 from torch._prims_common import is_integer_dtype
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.functions import CeilDiv, FloorDiv, ModularIndexing
-from torch.utils._sympy.value_ranges import bound_sympy
-from torch.utils._triton import has_triton_package, has_triton_stable_tma_api, get_triton_version
-
+from torch.utils._triton import (
+    get_triton_version,
+    has_triton_package,
+    has_triton_stable_tma_api,
+)
 from ...utils._sympy.symbol import free_symbol_is_type, prefix_str, symbol_is_type, SymT
 from ...utils._sympy.value_ranges import ValueRanges
 from .. import config, ir, metrics, utils

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1686,13 +1686,10 @@ class TritonOverrides(OpOverrides):
     @staticmethod
     @maybe_upcast_float32()
     def tanh(x):
-        if torch.version.hip:
+        if torch.version.hip and get_triton_version() > (3, 5):
             # Requires upstream Triton 3.6+ for latest fast_tanhf support
             # https://github.com/triton-lang/triton/pull/8551
-            if get_triton_version() > (3, 5):
-                return f"libdevice.fast_tanhf({x})"
-            else:
-                return f"libdevice.tanh({x})"
+            return f"libdevice.fast_tanhf({x})"
         else:
             return f"libdevice.tanh({x})"
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1683,7 +1683,8 @@ class TritonOverrides(OpOverrides):
     @maybe_upcast_float32()
     def tanh(x):
         if (get_triton_version() > (3, 4) and torch.version.hip):
-            return f"libdevice.fast_tanhf({x})"
+            if config.use_fast_math:
+                return f"libdevice.fast_tanhf({x})"
         else:
             return f"libdevice.tanh({x})"
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1683,8 +1683,10 @@ class TritonOverrides(OpOverrides):
     @staticmethod
     @maybe_upcast_float32()
     def tanh(x):
-        if config.use_fast_math and torch.version.hip:
-            if get_triton_version() > (3, 4):
+        if torch.version.hip:
+            # Requires upstream Triton 3.6+ for latest fast_tanhf support
+            # https://github.com/triton-lang/triton/pull/8551
+            if get_triton_version() > (3, 5):
                 return f"libdevice.fast_tanhf({x})"
             else:
                 return f"libdevice.tanh({x})"

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -27,7 +27,7 @@ from torch._dynamo.utils import identity, preserve_rng_state
 from torch._prims_common import is_integer_dtype
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.functions import CeilDiv, FloorDiv, ModularIndexing
-from torch.utils._triton import has_triton_package, has_triton_stable_tma_api
+from torch.utils._triton import has_triton_package, has_triton_stable_tma_api, get_triton_version
 
 from ...utils._sympy.symbol import free_symbol_is_type, prefix_str, symbol_is_type, SymT
 from ...utils._sympy.value_ranges import ValueRanges
@@ -1682,7 +1682,7 @@ class TritonOverrides(OpOverrides):
     @staticmethod
     @maybe_upcast_float32()
     def tanh(x):
-        if torch.version.hip:
+        if (get_triton_version() > (3, 4) and torch.version.hip):
             return f"libdevice.fast_tanhf({x})"
         else:
             return f"libdevice.tanh({x})"

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1686,7 +1686,12 @@ class TritonOverrides(OpOverrides):
     @staticmethod
     @maybe_upcast_float32()
     def tanh(x):
-        if torch.version.hip and get_triton_version() > (3, 5):
+        dtype = V.kernel.cse.varname_map.get(x).dtype
+        if (
+            torch.version.hip
+            and get_triton_version() > (3, 5)
+            and dtype != torch.float64
+        ):
             # Requires upstream Triton 3.6+ for latest fast_tanhf support
             # https://github.com/triton-lang/triton/pull/8551
             return f"libdevice.fast_tanhf({x})"

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1683,9 +1683,11 @@ class TritonOverrides(OpOverrides):
     @staticmethod
     @maybe_upcast_float32()
     def tanh(x):
-        if (get_triton_version() > (3, 4) and torch.version.hip):
-            if config.use_fast_math:
+        if config.use_fast_math and torch.version.hip:
+            if get_triton_version() > (3, 4):
                 return f"libdevice.fast_tanhf({x})"
+            else:
+                return f"libdevice.tanh({x})"
         else:
             return f"libdevice.tanh({x})"
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -32,6 +32,7 @@ from torch.utils._triton import (
     has_triton_package,
     has_triton_stable_tma_api,
 )
+
 from ...utils._sympy.symbol import free_symbol_is_type, prefix_str, symbol_is_type, SymT
 from ...utils._sympy.value_ranges import ValueRanges
 from .. import config, ir, metrics, utils


### PR DESCRIPTION
Improve tanh performance on ROCm when the data type is float32 or lower precision. For float64, retain the current implementation.

Requires commits that will be present in Triton 3.6. 

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @mlazos @dllehr-amd