### PR TITLE
Expand on autotune support for persistent reduction kernels

### DIFF
--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2915,7 +2915,7 @@ def _persistent_reduction_configs(
             triton_config_reduction(size_hints, xblock, rnumel, register_intensive=True)
             for xblock in xblock_vals
             if xblock == 1
-            or (xblock <= xnumel and rnumel * xblock <= MAX_PERSISTENT_BLOCK_NUMEL)
+            or (rnumel * xblock <= MAX_PERSISTENT_BLOCK_NUMEL and xblock <= xnumel)
         ]
     else:
         configs = []

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2912,7 +2912,7 @@ def _persistent_reduction_configs(
             for xblock in (1, 8, 32, 128)
             if xblock == 1
             or (max_autotune_enabled or rnumel * xblock <= MAX_PERSISTENT_BLOCK_NUMEL)
-            and xblock <= xnumel)
+            and xblock <= xnumel
         ]
     else:
         configs = []
@@ -2936,12 +2936,12 @@ def _persistent_reduction_configs(
         pass
     # TODO(jansel): we should be able to improve these heuristics
     if not max_autotune_enabled:  # Do not filter configs when tuning
-        elif reduction_hint == ReductionHint.INNER and rnumel >= 256:
+        if reduction_hint == ReductionHint.INNER and rnumel >= 256:
             configs = configs[:1]
         elif reduction_hint == ReductionHint.OUTER:
             configs = configs[-1:]
     
-    tiny_config = [
+    tiny_configs = [
         triton_config_reduction(
             size_hints,
             2 * (256 // rnumel) if rnumel <= 256 else 1,
@@ -2954,7 +2954,7 @@ def _persistent_reduction_configs(
             if conf not in configs:
                 configs.append(conf)
     elif reduction_hint == ReductionHint.OUTER_TINY:
-        configs = tiny_config
+        configs = tiny_configs
 
     for c in configs:
         # we don't need Rn_BLOCK for persistent reduction

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2911,7 +2911,7 @@ def _persistent_reduction_configs(
             triton_config_reduction(size_hints, xblock, rnumel, register_intensive=True)
             for xblock in (1, 8, 32, 128)
             if xblock == 1
-            or (max_autotune_enabled or rnumel * xblock <= MAX_PERSISTENT_BLOCK_NUMEL)
+            or rnumel * xblock <= MAX_PERSISTENT_BLOCK_NUMEL
             and xblock <= xnumel
         ]
     else:

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2911,8 +2911,7 @@ def _persistent_reduction_configs(
             triton_config_reduction(size_hints, xblock, rnumel, register_intensive=True)
             for xblock in (1, 8, 32, 128)
             if xblock == 1
-            or (max_autotune_enabled or rnumel * xblock <= MAX_PERSISTENT_BLOCK_NUMEL)
-            and xblock <= xnumel
+            or (xblock <= xnumel and rnumel * xblock <= MAX_PERSISTENT_BLOCK_NUMEL)
         ]
     else:
         configs = []

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2906,9 +2906,9 @@ def _persistent_reduction_configs(
     )
 
     if torch.version.hip:
-        xblock_vals = (1, 4, 8, 16, 32, 64, 128, 256)
+        xblock_vals = [1, 4, 8, 16, 32, 64, 128, 256]
     else:
-        xblock_vals = (1, 8, 32, 128)
+        xblock_vals = [1, 8, 32, 128]
 
     if "y" not in size_hints:
         configs = [

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2938,7 +2938,7 @@ def _persistent_reduction_configs(
             rnumel,
         )
     ]
-        
+
     # defer to more autotuning, initially
     if "y" in size_hints:
         pass

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2911,7 +2911,7 @@ def _persistent_reduction_configs(
             triton_config_reduction(size_hints, xblock, rnumel, register_intensive=True)
             for xblock in (1, 8, 32, 128)
             if xblock == 1
-            or rnumel * xblock <= MAX_PERSISTENT_BLOCK_NUMEL
+            or (max_autotune_enabled or rnumel * xblock <= MAX_PERSISTENT_BLOCK_NUMEL)
             and xblock <= xnumel
         ]
     else:


### PR DESCRIPTION
After the removal of want_no_x_dim for persistent reduction kernels, we can improve the autotuning setup for persistent reduction kernels.

Currently even with tuning enable, filtering will only try a single config in many cases. Avoid filtering with autotune mode, and override MAX_BLOCK limit. Also we always include tiny_config when autotuning is enabled.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @mlazos