### PR TITLE
[ROCm] TunableOp should use HIP version, not ROCm version

### DIFF
--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -220,19 +220,17 @@ TuningResultsValidator::TuningResultsValidator() {
       []() { return GetPyTorchVersion(); },
       [this](auto&& k) { return ValidatePyTorchVersion(std::forward<decltype(k)>(k)); });
 #ifdef USE_ROCM
-  // rocm
+  // hip
   {
-#ifdef _WIN32
-    std::string rocm_version = HIP_VERSION_BUILD_NAME;
-#else
-    std::string rocm_version = ROCM_BUILD_INFO;
-#endif
+    // HIP version is more accurate than ROCm version.  User's environment could be a stock
+    // ROCm install but with a mix of newer components, making ROCm version meaningless.
+    std::string hip_version = TORCH_HIP_VERSION;
     RegisterValidator(
-       "ROCM_VERSION",
-       [rocm_version]() { return rocm_version; },
-       [rocm_version](auto&& k) {
-        TUNABLE_LOG1("ROCM_VERSION validation: expect ", k, " to match ", rocm_version);
-        return rocm_version == k ? OK : FAIL;
+       "HIP_VERSION",
+       [hip_version]() { return hip_version; },
+       [hip_version](auto&& k) {
+        TUNABLE_LOG1("HIP_VERSION validation: expect ", k, " to match ", hip_version);
+        return hip_version == k ? OK : FAIL;
       });
   }
   // gfx arch

--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -224,7 +224,7 @@ TuningResultsValidator::TuningResultsValidator() {
   {
     // HIP version is more accurate than ROCm version.  User's environment could be a stock
     // ROCm install but with a mix of newer components, making ROCm version meaningless.
-    std::string hip_version = TORCH_HIP_VERSION;
+    std::string hip_version = c10::str(TORCH_HIP_VERSION);
     RegisterValidator(
        "HIP_VERSION",
        [hip_version]() { return hip_version; },


### PR DESCRIPTION
Fixes #160874



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang