### PR TITLE
[reland] Add inductor provenance mapping for cpp extern kernel (#161656)

### DIFF
--- a/test/inductor/test_provenance_tracing.py
+++ b/test/inductor/test_provenance_tracing.py
@@ -8,6 +8,7 @@ import os
 import re
 import shutil
 import tempfile
+import unittest
 import zipfile
 from pathlib import Path
 
@@ -23,6 +24,7 @@ from torch._inductor.debug import (
 from torch._inductor.fx_passes.post_grad import post_grad_passes
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.virtualized import V
+from torch.testing._internal.common_utils import IS_MACOS
 from torch.testing._internal.triton_utils import requires_cuda_and_triton
 
 
@@ -532,9 +534,9 @@ class TestProvenanceTracingStackTraces(TestCase):
         finally:
             trace_log.removeHandler(payload_handler)
 
-    def extract_code_line(self, s):
-        # Extract last non-empty line
-        return s.split("\n")[-2].strip()
+    def extract_code_line(self, s, i=-2):
+        # Extract ith line
+        return s.split("\n")[i].strip()
 
     @torch._inductor.config.patch({"trace.provenance_tracking_level": 2})
     @requires_cuda_and_triton
@@ -575,18 +577,18 @@ class TestProvenanceTracingStackTraces(TestCase):
             torch._dynamo.reset()
             reset_inductor_kernel_provenance_debug_handle()
             with self._setup_provenance_capture() as payload_buffer:
+                compiled = torch.compile(model)
                 compiled(*example_inputs)
                 payload_content = payload_buffer.getvalue().strip()
-                if payload_content:
-                    data = json.loads(payload_content)
-                    self.assertEqual(set(data.keys()), set(expected.keys()))
-                    for key, expected_lines in expected.items():
-                        actual_lines = [self.extract_code_line(s) for s in data[key]]
-                        self.assertEqual(
-                            sorted(actual_lines),
-                            sorted(expected_lines),
-                            f"Mismatch for key: {key}",
-                        )
+                data = json.loads(payload_content)
+                self.assertEqual(set(data.keys()), set(expected.keys()))
+                for key, expected_lines in expected.items():
+                    actual_lines = [self.extract_code_line(s) for s in data[key]]
+                    self.assertEqual(
+                        sorted(actual_lines),
+                        sorted(expected_lines),
+                        f"Mismatch for key: {key}",
+                    )
 
     def _check_kernel_information_json(self, kernel_info, expected_kernels):
         """Validate kernel information JSON structure and content."""
@@ -748,6 +750,32 @@ class TestProvenanceTracingStackTraces(TestCase):
         result = create_kernel_information_json()
         self.assertIsInstance(result, dict)
         self.assertEqual(len(result), 0)  # Should be empty with no provenance data
+
+    @unittest.skipIf(
+        IS_MACOS,
+        "MacOS generates different debug handles",
+    )
+    @torch._inductor.config.patch("trace.provenance_tracking_level", 1)
+    def test_cpu_extern_kernel(self):
+        class Foo(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.conv = torch.nn.Conv2d(16, 33, 3)
+
+            def forward(self, x):
+                return self.conv(x)
+
+        model = Foo()
+        x = torch.randn(20, 16, 50, 100)
+        with self._setup_provenance_capture() as payload_buffer:
+            reset_inductor_kernel_provenance_debug_handle()
+            ep = torch.export.export(model, (x,))
+            torch._inductor.aoti_compile_and_package(ep)
+            payload_content = payload_buffer.getvalue().strip()
+            data = json.loads(payload_content)
+
+            keys = [k.split(":")[0] for k in data]
+            self.assertTrue("aoti_torch_cpu_convolution" in keys)
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -34,7 +34,7 @@ from torch.utils._ordered_set import OrderedSet
 from torch.utils._pytree import tree_map
 
 from . import config, ir  # noqa: F811, this is needed
-from .ir import ExternKernelOut
+from .ir import ExternKernel
 from .scheduler import (
     BaseSchedulerNode,
     FusedSchedulerNode,
@@ -1093,7 +1093,7 @@ def create_kernel_information_json() -> dict[str, dict[str, list[str]]]:
 
 
 def set_kernel_post_grad_provenance_tracing(
-    node_schedule: Union[Sequence[BaseSchedulerNode], ExternKernelOut],
+    node_schedule: Union[Sequence[BaseSchedulerNode], ExternKernel],
     kernel_name: str,
     is_extern: bool = False,
 ) -> Optional[int]:
@@ -1114,7 +1114,7 @@ def set_kernel_post_grad_provenance_tracing(
         stack_traces: list[str] = []
         kernel_name = f"{kernel_name}:{_inductor_kernel_provenance_debug_handle}"
         if is_extern:
-            assert isinstance(node_schedule, ExternKernelOut)
+            assert isinstance(node_schedule, ExternKernel)
             curr_node_info = _inductor_triton_kernel_to_post_grad_node_info.setdefault(
                 kernel_name, []
             )


### PR DESCRIPTION
Summary:

Add inductor provenance mapping for cpp extern kernel

Test Plan:
```
buck run fbcode//caffe2/test/inductor:provenance_tracing --  -r test_cpu_extern_kernel
```

Differential Revision: D81598857




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben