### PR TITLE
ci: Disable all jobs that require mi250

### DIFF
--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -172,6 +172,7 @@ jobs:
         uses: ./.github/actions/teardown-xpu
     {%- else %}
     runs-on: linux.rocm.gpu.mi250
+    if: false
     timeout-minutes: !{{ common.timeout_minutes }}
     !{{ upload.binary_env(config) }}
     steps:

--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -96,7 +96,7 @@ jobs:
 
   {%- if config["gpu_arch_type"] != "cuda-aarch64" %}
   !{{ config["build_name"] }}-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    {% if config["gpu_arch_type"] == "rocm" %}if: false{% else %}if: ${{ github.repository_owner == 'pytorch' }}{% endif %}
     needs:
       - !{{ config["build_name"] }}-build
       - get-label-type

--- a/.github/workflows/generated-linux-binary-libtorch-nightly.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-nightly.yml
@@ -338,7 +338,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   libtorch-rocm6_3-shared-with-deps-release-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - libtorch-rocm6_3-shared-with-deps-release-build
       - get-label-type
@@ -453,7 +453,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   libtorch-rocm6_4-shared-with-deps-release-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - libtorch-rocm6_4-shared-with-deps-release-build
       - get-label-type

--- a/.github/workflows/generated-linux-binary-libtorch-nightly.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-nightly.yml
@@ -343,6 +343,7 @@ jobs:
       - libtorch-rocm6_3-shared-with-deps-release-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250
+    if: false
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -457,6 +458,7 @@ jobs:
       - libtorch-rocm6_4-shared-with-deps-release-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250
+    if: false
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -394,7 +394,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_10-rocm6_3-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_10-rocm6_3-build
       - get-label-type
@@ -506,7 +506,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_10-rocm6_4-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_10-rocm6_4-build
       - get-label-type
@@ -1054,7 +1054,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_11-rocm6_3-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_11-rocm6_3-build
       - get-label-type
@@ -1166,7 +1166,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_11-rocm6_4-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_11-rocm6_4-build
       - get-label-type
@@ -1714,7 +1714,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_12-rocm6_3-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_12-rocm6_3-build
       - get-label-type
@@ -1826,7 +1826,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_12-rocm6_4-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_12-rocm6_4-build
       - get-label-type
@@ -2374,7 +2374,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_13-rocm6_3-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_13-rocm6_3-build
       - get-label-type
@@ -2486,7 +2486,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_13-rocm6_4-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_13-rocm6_4-build
       - get-label-type
@@ -3034,7 +3034,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_13t-rocm6_3-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_13t-rocm6_3-build
       - get-label-type
@@ -3146,7 +3146,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_13t-rocm6_4-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_13t-rocm6_4-build
       - get-label-type
@@ -3694,7 +3694,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_14-rocm6_3-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_14-rocm6_3-build
       - get-label-type
@@ -3806,7 +3806,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_14-rocm6_4-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_14-rocm6_4-build
       - get-label-type
@@ -4354,7 +4354,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_14t-rocm6_3-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_14t-rocm6_3-build
       - get-label-type
@@ -4466,7 +4466,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_14t-rocm6_4-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_14t-rocm6_4-build
       - get-label-type

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -399,6 +399,7 @@ jobs:
       - manywheel-py3_10-rocm6_3-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250
+    if: false
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -510,6 +511,7 @@ jobs:
       - manywheel-py3_10-rocm6_4-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250
+    if: false
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -1057,6 +1059,7 @@ jobs:
       - manywheel-py3_11-rocm6_3-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250
+    if: false
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -1168,6 +1171,7 @@ jobs:
       - manywheel-py3_11-rocm6_4-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250
+    if: false
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -1715,6 +1719,7 @@ jobs:
       - manywheel-py3_12-rocm6_3-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250
+    if: false
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -1826,6 +1831,7 @@ jobs:
       - manywheel-py3_12-rocm6_4-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250
+    if: false
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -2373,6 +2379,7 @@ jobs:
       - manywheel-py3_13-rocm6_3-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250
+    if: false
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -2484,6 +2491,7 @@ jobs:
       - manywheel-py3_13-rocm6_4-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250
+    if: false
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -3031,6 +3039,7 @@ jobs:
       - manywheel-py3_13t-rocm6_3-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250
+    if: false
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -3142,6 +3151,7 @@ jobs:
       - manywheel-py3_13t-rocm6_4-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250
+    if: false
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -3689,6 +3699,7 @@ jobs:
       - manywheel-py3_14-rocm6_3-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250
+    if: false
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -3800,6 +3811,7 @@ jobs:
       - manywheel-py3_14-rocm6_4-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250
+    if: false
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -4347,6 +4359,7 @@ jobs:
       - manywheel-py3_14t-rocm6_3-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250
+    if: false
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -4458,6 +4471,7 @@ jobs:
       - manywheel-py3_14t-rocm6_4-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250
+    if: false
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch

--- a/.github/workflows/generated-linux-binary-manywheel-rocm-main.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-rocm-main.yml
@@ -65,7 +65,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_9-rocm6_4-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_9-rocm6_4-build
       - get-label-type

--- a/.github/workflows/generated-linux-binary-manywheel-rocm-main.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-rocm-main.yml
@@ -70,6 +70,7 @@ jobs:
       - manywheel-py3_9-rocm6_4-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250
+    if: false
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #162080

We don't have nodes for these right now and this is causing us to queue
forever. If this is still the case after a week then I'm deleting all of
these.

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd