### PR TITLE
wrapper_fxir store triton_meta `extra` field into node.meta

### DIFF
--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -768,7 +768,7 @@ class FxConverter:
             constant_args_idx,
         ) = tracing_triton_hopifier_singleton.store_non_graphable_args(call_kwargs)
 
-        self.gm.graph.call_function(
+        node = self.gm.graph.call_function(
             triton_kernel_wrapper_mutation,
             kwargs={
                 "kernel_idx": kernel.wrapped.kernel_idx,
@@ -778,6 +778,8 @@ class FxConverter:
                 "kwargs": call_kwargs,
             },
         )
+        if extra := triton_meta.get("extra", None):
+            node.meta.setdefault("triton_meta", {})["extra"] = extra
 
     def _generate_extern_kernel_alloc(self, line: WrapperLine) -> None:
         assert isinstance(line, ExternKernelAllocLine)


### PR DESCRIPTION
Summary:
In wrapper_fxir's `_generate_triton_call` function, allow an `extra` metadata field stored in JITFunction's `triton_meta` field to be added to `node.meta`.

use case is: if there are Triton-related configurations in triton_meta that the graph node should be aware of, it can be propagated to the node and accessed down the line. Eg. triton compiler optimization flags associated with this kernel.

Test Plan:
added tests in test_fxir_backend to confirm the lowered graph node has the `["triton_meta"]["extra"]` field when populated.
```
caffe2/test/inductor:fxir_backend -- test_triton_meta_extra
```

Rollback Plan:

Differential Revision: D81604436




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben