### PR TITLE
use sym_or instead of any to avoid dde in calc_conv_nd_return_shape

### DIFF
--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2373,9 +2373,10 @@ def calc_conv_nd_return_shape(
             ret_shape.append(
                 _formula(dims[i], padding[i], dilation[i], kernel_size[i], stride[i])
             )
+    from torch.fx.experimental.symbolic_shapes import sym_or
 
     torch._check(
-        any(x > 0 for x in ret_shape[2:]),
+        sym_or(*[x > 0 for x in ret_shape[2:]]),
         lambda: f"Given input size per channel: {list(dims)}. "
         f"Calculated output size per channel: {ret_shape[2:]}. "
         f"Output size is too small",

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2376,7 +2376,7 @@ def calc_conv_nd_return_shape(
     from torch.fx.experimental.symbolic_shapes import sym_or
 
     torch._check(
-        sym_or(*[x > 0 for x in ret_shape[2:]]),
+        sym_or(*(x > 0 for x in ret_shape[2:])),
         lambda: f"Given input size per channel: {list(dims)}. "
         f"Calculated output size per channel: {ret_shape[2:]}. "
         f"Output size is too small",

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2376,7 +2376,7 @@ def calc_conv_nd_return_shape(
     from torch.fx.experimental.symbolic_shapes import sym_or
 
     torch._check(
-        sym_or(*(x > 0 for x in ret_shape[2:])),
+        sym_or(*[x > 0 for x in ret_shape[2:]]),
         lambda: f"Given input size per channel: {list(dims)}. "
         f"Calculated output size per channel: {ret_shape[2:]}. "
         f"Output size is too small",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #162109
* #162099
* __->__ #162084

