### PR TITLE
[CI][ROCM] Disable rocm build tests

### DIFF
--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -96,7 +96,7 @@ jobs:
 
   {%- if config["gpu_arch_type"] != "cuda-aarch64" %}
   !{{ config["build_name"] }}-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    {% if config["gpu_arch_type"] == "rocm" %}if: false{% else %}if: ${{ github.repository_owner == 'pytorch' }}{% endif %}
     needs:
       - !{{ config["build_name"] }}-build
       - get-label-type

--- a/.github/workflows/generated-linux-binary-libtorch-nightly.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-nightly.yml
@@ -338,7 +338,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   libtorch-rocm6_3-shared-with-deps-release-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - libtorch-rocm6_3-shared-with-deps-release-build
       - get-label-type
@@ -452,7 +452,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   libtorch-rocm6_4-shared-with-deps-release-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - libtorch-rocm6_4-shared-with-deps-release-build
       - get-label-type

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -394,7 +394,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_10-rocm6_3-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_10-rocm6_3-build
       - get-label-type
@@ -505,7 +505,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_10-rocm6_4-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_10-rocm6_4-build
       - get-label-type
@@ -1052,7 +1052,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_11-rocm6_3-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_11-rocm6_3-build
       - get-label-type
@@ -1163,7 +1163,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_11-rocm6_4-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_11-rocm6_4-build
       - get-label-type
@@ -1710,7 +1710,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_12-rocm6_3-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_12-rocm6_3-build
       - get-label-type
@@ -1821,7 +1821,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_12-rocm6_4-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_12-rocm6_4-build
       - get-label-type
@@ -2368,7 +2368,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_13-rocm6_3-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_13-rocm6_3-build
       - get-label-type
@@ -2479,7 +2479,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_13-rocm6_4-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_13-rocm6_4-build
       - get-label-type
@@ -3026,7 +3026,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_13t-rocm6_3-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_13t-rocm6_3-build
       - get-label-type
@@ -3137,7 +3137,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_13t-rocm6_4-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_13t-rocm6_4-build
       - get-label-type
@@ -3684,7 +3684,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_14-rocm6_3-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_14-rocm6_3-build
       - get-label-type
@@ -3795,7 +3795,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_14-rocm6_4-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_14-rocm6_4-build
       - get-label-type
@@ -4342,7 +4342,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_14t-rocm6_3-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_14t-rocm6_3-build
       - get-label-type
@@ -4453,7 +4453,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_14t-rocm6_4-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_14t-rocm6_4-build
       - get-label-type

--- a/.github/workflows/generated-linux-binary-manywheel-rocm-main.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-rocm-main.yml
@@ -63,7 +63,7 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_9-rocm6_4-test:  # Testing
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: false
     needs:
       - manywheel-py3_9-rocm6_4-build
       - get-label-type


### PR DESCRIPTION
There is a queue time of 23 hours for `linux.rocm.gpu.mi250` and 12h for `linux.rocm.gpu.gfx942.1`

With https://github.com/pytorch/pytorch/pull/162044 more jobs will be running on `linux.rocm.gpu.gfx942.1` and this fleet is clearly not capable of handling the load.

So the goal here is to remove smoke tests for builds that uses ROCM in order to reduce the pressure in the fleet and reduce the lag between viable/strict.

Once the fleet is increased we can revert this PR

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd