### PR TITLE
[Torch FX] Run ensures on PassResult instead of the input graph_module.

### DIFF
--- a/torch/fx/passes/infra/pass_base.py
+++ b/torch/fx/passes/infra/pass_base.py
@@ -44,7 +44,8 @@ class PassBase(abc.ABC):
 
         self.requires(graph_module)
         res = self.call(graph_module)
-        self.ensures(graph_module)
+        if res:
+            self.ensures(res.graph_module)
         return res
 
     @abc.abstractmethod


### PR DESCRIPTION
Summary: We need to run the ensures on res.graph_module in case a pass creates a new graph_module instead of modifying in place.

Test Plan:
CI

Rollback Plan:

Differential Revision: D81617603




cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv