### PR TITLE
[CI] viable strict upgrade: Explicitly name which linux binary wheels should block

### DIFF
--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -18,6 +18,9 @@ jobs:
     runs-on: ubuntu-24.04
     environment: ${{ (github.event_name == 'schedule') && 'mergebot' || '' }}
     steps:
+      - run: echo $AAAA
+        env:
+          AAAA: '[\"pull\", \"trunk\", \"lint\", \"^(?!.*rocm).*linux-binary.*\", \"linux-aarch64\"]'
       - name: Update viable/strict
         uses: pytorch/test-infra/.github/actions/update-viablestrict@main
         id: update_viablestrict

--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -18,9 +18,6 @@ jobs:
     runs-on: ubuntu-24.04
     environment: ${{ (github.event_name == 'schedule') && 'mergebot' || '' }}
     steps:
-      - run: echo $AAAA
-        env:
-          AAAA: '[\"pull\", \"trunk\", \"lint\", \"^(?!.*rocm).*linux-binary.*\", \"linux-aarch64\"]'
       - name: Update viable/strict
         uses: pytorch/test-infra/.github/actions/update-viablestrict@main
         id: update_viablestrict
@@ -28,7 +25,7 @@ jobs:
           repository: pytorch/pytorch
           stable-branch: viable/strict
           requires: '[\"pull\", \"trunk\", \"lint\", \"^(?!.*rocm).*linux-binary.*\", \"linux-aarch64\"]'
-          secret-bot-token: ${{ secrets.MERGEBOT_TOKEN }}
+          secret-bot-token: dummytoken
           clickhouse-url: ${{ secrets.CLICKHOUSE_URL }}
           clickhouse-username: ${{ secrets.CLICKHOUSE_VIABLESTRICT_USERNAME }}
           clickhouse-password: ${{ secrets.CLICKHOUSE_VIABLESTRICT_PASSWORD }}

--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -25,7 +25,7 @@ jobs:
           repository: pytorch/pytorch
           stable-branch: viable/strict
           requires: '[\"pull\", \"trunk\", \"lint\", \"^(?!.*rocm).*linux-binary.*\", \"linux-aarch64\"]'
-          secret-bot-token: dummytoken
+          secret-bot-token: ${{ env.GITHUB_TOKEN }}
           clickhouse-url: ${{ secrets.CLICKHOUSE_URL }}
           clickhouse-username: ${{ secrets.CLICKHOUSE_VIABLESTRICT_USERNAME }}
           clickhouse-password: ${{ secrets.CLICKHOUSE_VIABLESTRICT_PASSWORD }}

--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: 17,47 * * * *
   workflow_dispatch:
-  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}
@@ -25,7 +24,7 @@ jobs:
           repository: pytorch/pytorch
           stable-branch: viable/strict
           requires: '[\"pull\", \"trunk\", \"lint\", \"^(?!.*rocm).*linux-binary.*\", \"linux-aarch64\"]'
-          secret-bot-token: ${{ secrets.GITHUB_TOKEN }}
+          secret-bot-token: ${{ secrets.MERGEBOT_TOKEN }}
           clickhouse-url: ${{ secrets.CLICKHOUSE_URL }}
           clickhouse-username: ${{ secrets.CLICKHOUSE_VIABLESTRICT_USERNAME }}
           clickhouse-password: ${{ secrets.CLICKHOUSE_VIABLESTRICT_PASSWORD }}

--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: 17,47 * * * *
   workflow_dispatch:
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}
@@ -23,8 +24,8 @@ jobs:
         with:
           repository: pytorch/pytorch
           stable-branch: viable/strict
-          requires: '[\"pull\", \"trunk\", \"lint\", \"^(?!.*rocm).*linux-binary.*\", \"linux-aarch64\"]'
-          secret-bot-token: ${{ secrets.MERGEBOT_TOKEN }}
+          requires: '[\"pull\", \"trunk\", \"lint\", \"^linux-binary-manywheel$\", \"^linux-binary-libtorch-release$\", \"linux-aarch64\"]'
+          secret-bot-token: ${{ secrets.GITHUB_TOKEN }}
           clickhouse-url: ${{ secrets.CLICKHOUSE_URL }}
           clickhouse-username: ${{ secrets.CLICKHOUSE_VIABLESTRICT_USERNAME }}
           clickhouse-password: ${{ secrets.CLICKHOUSE_VIABLESTRICT_PASSWORD }}

--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: 17,47 * * * *
   workflow_dispatch:
-  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}
@@ -25,7 +24,7 @@ jobs:
           repository: pytorch/pytorch
           stable-branch: viable/strict
           requires: '[\"pull\", \"trunk\", \"lint\", \"^linux-binary-manywheel$\", \"^linux-binary-libtorch-release$\", \"linux-aarch64\"]'
-          secret-bot-token: ${{ secrets.GITHUB_TOKEN }}
+          secret-bot-token: ${{ secrets.MERGEBOT_TOKEN }}
           clickhouse-url: ${{ secrets.CLICKHOUSE_URL }}
           clickhouse-username: ${{ secrets.CLICKHOUSE_VIABLESTRICT_USERNAME }}
           clickhouse-password: ${{ secrets.CLICKHOUSE_VIABLESTRICT_PASSWORD }}

--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: 17,47 * * * *
   workflow_dispatch:
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}
@@ -23,7 +24,7 @@ jobs:
         with:
           repository: pytorch/pytorch
           stable-branch: viable/strict
-          requires: '[\"pull\", \"trunk\", \"lint\", \"linux-binary\", \"linux-aarch64\"]'
+          requires: '[\"pull\", \"trunk\", \"lint\", \"^(?!.*rocm).*linux-binary.*\", \"linux-aarch64\"]'
           secret-bot-token: ${{ secrets.MERGEBOT_TOKEN }}
           clickhouse-url: ${{ secrets.CLICKHOUSE_URL }}
           clickhouse-username: ${{ secrets.CLICKHOUSE_VIABLESTRICT_USERNAME }}

--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -25,7 +25,7 @@ jobs:
           repository: pytorch/pytorch
           stable-branch: viable/strict
           requires: '[\"pull\", \"trunk\", \"lint\", \"^(?!.*rocm).*linux-binary.*\", \"linux-aarch64\"]'
-          secret-bot-token: ${{ env.GITHUB_TOKEN }}
+          secret-bot-token: ${{ secrets.GITHUB_TOKEN }}
           clickhouse-url: ${{ secrets.CLICKHOUSE_URL }}
           clickhouse-username: ${{ secrets.CLICKHOUSE_VIABLESTRICT_USERNAME }}
           clickhouse-password: ${{ secrets.CLICKHOUSE_VIABLESTRICT_PASSWORD }}


### PR DESCRIPTION
Reason:
rocm binary builds should not block viable strict upgrade.  It is queuing/canceled so viable strict is 1.2 days old

Tested by mangling the workflow file to get to the actual call of the python script `python ../test-infra/tools/scripts/fetch_latest_green_commit.py --required-checks '["pull", "trunk", "lint", "^linux-binary-manywheel$", "^linux-binary-libtorch-release$", "linux-aarch64"]' --viable-strict-branch viable/strict --main-branch master`, which I then ran locally where I have credentials.  It returned d64718503728001a1e78168fd7f2d4ff23e57285 which is green.  Without this change, it returns 5e5870e858f60ff4bf87d03f3592097e934a9580, which is pretty old

The other solution would have been to mark it as unstable I think

Side note, why is it master and how is it working like that




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd