### PR TITLE
Modify ROCm MI2xx-based workflows to run on cron schedule

### DIFF
--- a/.github/workflows/inductor-rocm.yml
+++ b/.github/workflows/inductor-rocm.yml
@@ -3,10 +3,18 @@ name: inductor-rocm
 on:
   push:
     branches:
-      - main
+      #- main
       - release/*
     tags:
       - ciflow/inductor-rocm/*
+  schedule:
+    # We have several schedules so jobs can check github.event.schedule to activate only for a fraction of the runs.
+    # Also run less frequently on weekends.
+    - cron: 45 0,8,16 * * 1-5
+    - cron: 45 4 * * 0,6
+    - cron: 45 4,12,20 * * 1-5
+    - cron: 45 12 * * 0,6
+    - cron: 29 8 * * *  # about 1:29am PDT, for mem leak check and rerun disabled tests
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/rocm.yml
+++ b/.github/workflows/rocm.yml
@@ -2,9 +2,9 @@ name: rocm
 
 on:
   push:
-  #   branches:
+    branches:
   #     - main
-  #     - release/*
+      - release/*
     tags:
       - ciflow/rocm/*
   workflow_dispatch:

--- a/.github/workflows/rocm.yml
+++ b/.github/workflows/rocm.yml
@@ -2,14 +2,20 @@ name: rocm
 
 on:
   push:
-    branches:
-      - main
-      - release/*
+  #   branches:
+  #     - main
+  #     - release/*
     tags:
       - ciflow/rocm/*
   workflow_dispatch:
   schedule:
-    - cron: 29 8 * * *  # about 1:29am PDT
+    # We have several schedules so jobs can check github.event.schedule to activate only for a fraction of the runs.
+    # Also run less frequently on weekends.
+    - cron: 45 0,8,16 * * 1-5
+    - cron: 45 4 * * 0,6
+    - cron: 45 4,12,20 * * 1-5
+    - cron: 45 12 * * 0,6
+    - cron: 29 8 * * *  # about 1:29am PDT, for mem leak check and rerun disabled tests
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}


### PR DESCRIPTION
To mitigate queueing on MI2xx runners since Cirrascale runners are offline. Match cron schedule of periodic.yml


cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd