### PR TITLE
weakref const nested args

### DIFF
--- a/test/dynamo/test_nested_const_weight_weakref.py
+++ b/test/dynamo/test_nested_const_weight_weakref.py
@@ -1,0 +1,53 @@
+# Owner(s): ["module: dynamo"]
+import unittest
+
+import torch
+
+
+class TestNestedConstWeightWeakref(unittest.TestCase):
+    def test_nested_const_weight_weakref(self):
+        class DummyModule(torch.nn.Module):
+            def __init__(self):
+                super(DummyModule, self).__init__()
+                self.a = torch.nn.ModuleDict(
+                    {
+                        "b": torch.nn.ModuleDict(
+                            {
+                                "c": torch.nn.ModuleDict(
+                                    {
+                                        "d": torch.nn.ModuleDict(
+                                            {"e": torch.nn.Linear(10, 10, bias=False)}
+                                        )
+                                    }
+                                )
+                            }
+                        )
+                    }
+                )
+
+            def forward(self, x):
+                return self.a.b.c.d.e(x)
+
+        model = DummyModule()
+        opt_model = torch.compile(model)
+        x = torch.randn(10, 10)
+        opt_model(x)
+
+        from torch._dynamo.eval_frame import _debug_get_cache_entry_list
+
+        cache_entries = _debug_get_cache_entry_list(
+            opt_model._torchdynamo_orig_callable.__code__
+        )
+        code = cache_entries[0].code
+
+        from depyf import decompile
+
+        self.assertRegex(
+            decompile(code),
+            r"""__compiled_fn_1_.*\(\n.*L_self_modules_a_modules_b_modules_c_modules_d_modules_e_parameters_weight_.*\n.*\(\), x\)""",
+        )
+        assert torch.allclose(model(x), opt_model(x))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -2187,6 +2187,17 @@ class VariableBuilder:
         if maybe_get_fake_mode(fake_tensor_value) is not self.tx.fake_mode:
             raise InternalTorchDynamoError("Wrapped Tensor must be this graph's fake")
 
+        if is_static_input and isinstance(source, ChainedSource) and not is_dynamic_source(source.name()):
+            from ..source import GlobalWeakRefSource
+            id = re.sub(
+                r"[\[\]'.]", lambda m: "_" if m.group(0) in "[" else "", source.name()
+            )
+            global_name = self.tx.output.install_global_by_id(id, weakref.ref(value))
+            source = GlobalWeakRefSource(global_name)
+            install_guard(
+                source.make_guard(GuardBuilder.WEAKREF_ALIVE)
+            )
+
         grapharg = GraphArg(source, value, False, fake_tensor_value)
         tensor_proxy.node.meta["grapharg"] = grapharg
         return tensor_variable


### PR DESCRIPTION
Summary:
this should get rid of the fetching-by-attributes

Test Plan:
 pytest test/dynamo/test_nested_const_weight_weakref.py

Should fix #141452


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela