### PR TITLE
[PT2]: Overriding Tensor device by SubmodNameToDevice

### DIFF
--- a/torch/nativert/graph/Graph.h
+++ b/torch/nativert/graph/Graph.h
@@ -442,6 +442,11 @@ class Graph {
 
   void applyDevicePlacement(const Placement& placement);
 
+  // Override all weights in the graph if matching name is found in the map.
+  void overrideWeightsDevice(
+      const std::unordered_map<std::string, std::optional<c10::Device>>&
+          submodNameToDevice);
+
   std::string getUniqueValueName();
 
   ValueId getNextValueId() {

--- a/torch/nativert/graph/TensorMeta.h
+++ b/torch/nativert/graph/TensorMeta.h
@@ -64,6 +64,11 @@ class TensorMeta {
     return device_;
   }
 
+  // override device according to placement
+  void setDevice(c10::Device device) {
+    device_ = device;
+  }
+
   c10::TensorOptions asTensorOptions() const {
     return c10::TensorOptions().dtype(dtype_).layout(layout_).requires_grad(
         requiresGrad_);


### PR DESCRIPTION
Summary:
A temporarily solution mainly for weights that are not moved to cuda in fake mode during publishing, but runs on cuda in serving.

This has some overlap with placement, but with 2 differences:
1. OverrideWeightsDevice only changes weights, not graph.
2. Placement only handles mapping between non-empty cuda indices, while here we override everything as submodNameToDevice is the ground truth.

Test Plan:
ICE replayer with custom package:
https://www.internalfb.com/intern/unidash/dashboard/ads_infra_cost_estimation/model_infra_cost_estimation/?e[select_ESTIMATION_RUN_ID]=ICE_kevinqfu_1756939411c164_replayeripnext_00

Rollback Plan:

Differential Revision: D81284723


