### PR TITLE
Fix the regression issue caused by non-arrch64 platforms not hitting the MKLDNN path.

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -1770,7 +1770,7 @@ static inline void bmm_out_or_baddbmm_(const Tensor& self_or_result_, const Tens
         (strides[1] == 1 && (sizes[2] == 1 || strides[2] >= sizes[1]));
   };
 #if (defined(__aarch64__) && AT_MKLDNN_ACL_ENABLED()) || !defined(__aarch64__)
-  //For AArch64, disable ACL in bmm_out_or_baddbmm_ and prefer ArmPL; 
+  //For AArch64, disable ACL in bmm_out_or_baddbmm_ and prefer ArmPL;
   //for other devices, fall back to the mkldnn_matmul heuristic.
   bool apply_heur = apply_mkldnn_matmul_heur(batch1.sizes()[1], batch1.sizes()[2], batch2.sizes()[2]);
   if (apply_heur && use_mkldnn_matmul(batch1, batch2, self_or_result)) {

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -1360,7 +1360,7 @@ Tensor outer(const Tensor& self, const Tensor& vec2) {
 #endif
 
 
-#if defined(__aarch64__) && AT_MKLDNN_ACL_ENABLED()
+
 static inline int64_t get_mkldnn_matmul_min_dim() {
   static auto value = [&] {
     const int64_t default_min_dim = [&] {
@@ -1394,7 +1394,19 @@ static inline bool apply_mkldnn_matmul_heur(int64_t m, int64_t k, int64_t n) {
   const int64_t min_size = get_mkldnn_matmul_min_size();
   return at::globalContext().userEnabledMkldnn() && m > min_dim && k > min_dim && n > min_dim && m * k * n > min_size;
 }
-#endif
+static inline void mkldnn_matmul_use(const Tensor& batch1, const Tensor& batch2, const Tensor& self_or_result, const Scalar& beta, const Scalar& alpha){
+  bool apply_heur = apply_mkldnn_matmul_heur(batch1.sizes()[1], batch1.sizes()[2], batch2.sizes()[2]);
+  if (apply_heur && use_mkldnn_matmul(batch1, batch2, self_or_result)) {
+    try {
+      mkldnn_matmul(batch1, batch2, self_or_result, beta.to<float>(), alpha.to<float>());
+  
+      return;
+    } catch (const std::exception& e) {
+      TORCH_WARN("mkldnn_matmul failed, switching to baddbmm:", e.what());
+      at::globalContext().setUserEnabledMkldnn(false);
+    }
+  }
+}
 
 
 static void addmm_impl_cpu_(
@@ -1773,18 +1785,12 @@ static inline void bmm_out_or_baddbmm_(const Tensor& self_or_result_, const Tens
         (strides[1] == 1 && (sizes[2] == 1 || strides[2] >= sizes[1]));
   };
 
-#if defined(__aarch64__) && AT_MKLDNN_ACL_ENABLED()
-  bool apply_heur = apply_mkldnn_matmul_heur(batch1.sizes()[1], batch1.sizes()[2], batch2.sizes()[2]);
-  if (apply_heur && use_mkldnn_matmul(batch1, batch2, self_or_result)) {
-    try {
-      mkldnn_matmul(batch1, batch2, self_or_result, beta.to<float>(), alpha.to<float>());
-      return;
-    } catch (const std::exception& e) {
-      TORCH_WARN("mkldnn_matmul failed, switching to baddbmm:", e.what());
-      at::globalContext().setUserEnabledMkldnn(false);
-    }
-  }
-#endif
+  #if defined(__aarch64__) && AT_MKLDNN_ACL_ENABLED()
+  mkldnn_matmul_use(batch1, batch2, self_or_result, beta, alpha);
+  #elif !defined(__aarch64__)
+  mkldnn_matmul_use(batch1, batch2, self_or_result, beta, alpha);
+  #endif
+
 
   if (contraction_size * res_rows * res_cols < 400) {
     if (is_bmm_out) {

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -1360,7 +1360,8 @@ Tensor outer(const Tensor& self, const Tensor& vec2) {
 #endif
 
 
-
+#if (defined(__aarch64__) && AT_MKLDNN_ACL_ENABLED()) || !defined(__aarch64__)
+//Compile the following code only on (AArch64+ACL) or on non-AArch64 so it's actually used.
 static inline int64_t get_mkldnn_matmul_min_dim() {
   static auto value = [&] {
     const int64_t default_min_dim = [&] {
@@ -1394,6 +1395,7 @@ static inline bool apply_mkldnn_matmul_heur(int64_t m, int64_t k, int64_t n) {
   const int64_t min_size = get_mkldnn_matmul_min_size();
   return at::globalContext().userEnabledMkldnn() && m > min_dim && k > min_dim && n > min_dim && m * k * n > min_size;
 }
+#endif
 static void addmm_impl_cpu_(
     Tensor &result, const Tensor &self, Tensor m1, Tensor m2, const Scalar& beta, const Scalar& alpha) {
   TORCH_INTERNAL_ASSERT(self.dim() == 2 && m1.dim() == 2 && m2.dim() == 2);


### PR DESCRIPTION
This issue was introduced by the commit in issue #161065. Added an extra check to provide a proper path for other platforms.
