### PR TITLE
Fix comment on broadcasting example to clarify dimension mismatch

### DIFF
--- a/docs/source/notes/broadcasting.rst
+++ b/docs/source/notes/broadcasting.rst
@@ -13,7 +13,6 @@ General semantics
 -----------------
 Two tensors are "broadcastable" if the following rules hold:
 
-- Each tensor has at least one dimension.
 - When iterating over the dimension sizes, starting at the trailing dimension,
   the dimension sizes must either be equal, one of them is 1, or one of them
   does not exist.
@@ -26,7 +25,8 @@ For Example::
 
     >>> x=torch.empty((0,))
     >>> y=torch.empty(2,2)
-    # x and y are not broadcastable, because x does not have at least 1 dimension
+    # x and y are not broadcastable, because the 0-sized dimension of x
+    # does not match the 2-sized dimension of y.
 
     # can line up trailing dimensions
     >>> x=torch.empty(5,3,4,1)


### PR DESCRIPTION
Fixes #162116 

Updated the comment in the broadcasting example to clarify that tensors with mismatched dimension sizes (0 vs 2) are not broadcastable. Removed incorrect reference to missing dimensions.
