### PR TITLE
[refactor] add helper sizevars function, is_size_one, for size==1 checks

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -2877,9 +2877,7 @@ class ExpandView(BaseView):
             if new_size[i] == -1:
                 assert old_size[i] is not None
                 new_size[i] = old_size[i]
-            elif old_size[i] is None or V.graph.sizevars.shape_env.evaluate_expr(
-                sympy.Eq(old_size[i], 1), fallback_value=False
-            ):
+            elif old_size[i] is None or V.graph.sizevars.is_size_one(old_size[i]):
                 pass
             else:
                 # Sanity check: Expect broadcast compatibility
@@ -2903,11 +2901,7 @@ class ExpandView(BaseView):
             new_stride = [sympy.S.Zero] * skip
             for stride, size in zip(old_layout.stride, old_layout.size):
                 new_stride.append(
-                    stride
-                    if not V.graph.sizevars.shape_env.evaluate_expr(
-                        sympy.Eq(size, 1), fallback_value=False
-                    )
-                    else sympy.S.Zero
+                    stride if not V.graph.sizevars.is_size_one(size) else sympy.S.Zero
                 )
             new_layout = FixedLayout(
                 old_layout.device,

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -2877,7 +2877,9 @@ class ExpandView(BaseView):
             if new_size[i] == -1:
                 assert old_size[i] is not None
                 new_size[i] = old_size[i]
-            elif old_size[i] is None or V.graph.sizevars.is_size_one(old_size[i]):
+            elif old_size[i] is None or V.graph.sizevars.is_size_one_or_false(
+                old_size[i]
+            ):
                 pass
             else:
                 # Sanity check: Expect broadcast compatibility
@@ -2901,7 +2903,9 @@ class ExpandView(BaseView):
             new_stride = [sympy.S.Zero] * skip
             for stride, size in zip(old_layout.stride, old_layout.size):
                 new_stride.append(
-                    stride if not V.graph.sizevars.is_size_one(size) else sympy.S.Zero
+                    stride
+                    if not V.graph.sizevars.is_size_one_or_false(size)
+                    else sympy.S.Zero
                 )
             new_layout = FixedLayout(
                 old_layout.device,

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -946,8 +946,7 @@ def broadcast_tensors(*inputs):
         sizes = x.get_size()
 
         if len(sizes) != len(target) or any(
-            V.graph.sizevars.is_size_one(a)
-            != V.graph.sizevars.is_size_one(b)
+            V.graph.sizevars.is_size_one(a)!= V.graph.sizevars.is_size_one(b))
             for a, b in zip(sizes, target)
         ):
             x = expand(x, target)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -497,9 +497,9 @@ def broadcast_symbolic_shapes(a, b):
     """
     output = []
     for x, y in itertools.zip_longest(reversed(a), reversed(b), fillvalue=sympy.S.One):
-        if V.graph.sizevars.is_size_one(y):
+        if V.graph.sizevars.is_size_one_or_false(y):
             output.append(x)
-        elif V.graph.sizevars.is_size_one(x):
+        elif V.graph.sizevars.is_size_one_or_false(x):
             output.append(y)
         else:
             V.graph.sizevars.check_equals(x, y)
@@ -946,7 +946,8 @@ def broadcast_tensors(*inputs):
         sizes = x.get_size()
 
         if len(sizes) != len(target) or any(
-            V.graph.sizevars.is_size_one(a) != V.graph.sizevars.is_size_one(b)
+            V.graph.sizevars.is_size_one_or_false(a)
+            != V.graph.sizevars.is_size_one_or_false(b)
             for a, b in zip(sizes, target)
         ):
             x = expand(x, target)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -946,7 +946,7 @@ def broadcast_tensors(*inputs):
         sizes = x.get_size()
 
         if len(sizes) != len(target) or any(
-            V.graph.sizevars.is_size_one(a)!= V.graph.sizevars.is_size_one(b)
+            V.graph.sizevars.is_size_one(a) != V.graph.sizevars.is_size_one(b)
             for a, b in zip(sizes, target)
         ):
             x = expand(x, target)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -497,13 +497,9 @@ def broadcast_symbolic_shapes(a, b):
     """
     output = []
     for x, y in itertools.zip_longest(reversed(a), reversed(b), fillvalue=sympy.S.One):
-        if V.graph.sizevars.shape_env.evaluate_expr(
-            sympy.Eq(y, 1), fallback_value=False
-        ):
+        if V.graph.sizevars.is_size_one(y):
             output.append(x)
-        elif V.graph.sizevars.shape_env.evaluate_expr(
-            sympy.Eq(x, 1), fallback_value=False
-        ):
+        elif V.graph.sizevars.is_size_one(x):
             output.append(y)
         else:
             V.graph.sizevars.check_equals(x, y)
@@ -949,13 +945,10 @@ def broadcast_tensors(*inputs):
     for x in inputs:
         sizes = x.get_size()
 
-        def is_length_one(size: sympy.Expr):
-            return V.graph.sizevars.shape_env.evaluate_expr(
-                sympy.Eq(size, 1), fallback_value=False
-            )
-
         if len(sizes) != len(target) or any(
-            is_length_one(a) != is_length_one(b) for a, b in zip(sizes, target)
+            V.graph.sizevars.is_size_one(a)
+            != V.graph.sizevars.is_size_one(b)
+            for a, b in zip(sizes, target)
         ):
             x = expand(x, target)
         outputs.append(x)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -946,7 +946,7 @@ def broadcast_tensors(*inputs):
         sizes = x.get_size()
 
         if len(sizes) != len(target) or any(
-            V.graph.sizevars.is_size_one(a)!= V.graph.sizevars.is_size_one(b))
+            V.graph.sizevars.is_size_one(a)!= V.graph.sizevars.is_size_one(b)
             for a, b in zip(sizes, target)
         ):
             x = expand(x, target)

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -476,7 +476,7 @@ class SizeVarAllocator:
             fallback_value=fallback_value,
         )
 
-    def is_size_one(self, size: Expr) -> bool:
+    def is_size_one_or_false(self, size: Expr) -> bool:
         """Return True if size equals 1.
 
         Unbacked symbolic sizes return False without introducing a guard.

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -476,6 +476,13 @@ class SizeVarAllocator:
             fallback_value=fallback_value,
         )
 
+    def is_size_one(self, size: Expr) -> bool:
+        """Return True if size equals 1.
+
+        Unbacked symbolic sizes return False without introducing a guard.
+        """
+        return self.guard_or_false(sympy.Eq(size, 1))
+
     def evaluate_min(self, left: Expr, right: Expr) -> Expr:
         """return the smaller of left and right, and guard on that choice"""
         if isinstance(left, Expr):


### PR DESCRIPTION
## Summary
- document guard behavior in `SizeVarAllocator.is_size_one`
- use `is_size_one` for broadcast/expand checks.
- This diff is a no-op since we'd use `shape_env.evaluate_expr(... fallback_value=False)`

https://github.com/pytorch/pytorch/blob/a4f9132a178ce8c41b17ff6e89aa382ec1dbe701/torch/_inductor/sizevars.py#L450-L453

------
https://chatgpt.com/codex/tasks/task_e_68b8d0d1f2c48328b2d38c00e738bc8c

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben