### PR TITLE
[SymmMem] Feed tensor.data_ptr instead of handle.buffer_ptr into kernels

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cu
@@ -110,7 +110,7 @@ at::Tensor nvshmem_broadcast(at::Tensor& input, const int64_t root, const std::s
   auto input_hdl = c10d::symmetric_memory::rendezvous(input, group_name);
   int rank = input_hdl->get_rank();
   auto team = group_to_team(group_name, input_hdl->get_rank_to_global_rank());
-  void* buffer_ptr = input.data_ptr();
+  void* buffer_ptr = input.mutable_data_ptr();
   auto buffer_size = input.numel() * input.element_size();
   int team_size = nvshmem_team_n_pes(team);
   TORCH_CHECK(root < team_size, "root must be smaller than group size");
@@ -149,7 +149,7 @@ void nvshmem_get(at::Tensor& tensor, const int64_t peer) {
 
   c10::cuda::CUDAGuard guard(tensor.device());
   auto stream = at::cuda::getCurrentCUDAStream();
-  nvshmemx_getmem_on_stream(tensor.data_ptr(), buffer_ptr, buffer_size, peer, stream);
+  nvshmemx_getmem_on_stream(tensor.mutable_data_ptr(), buffer_ptr, buffer_size, peer, stream);
 }
 
 at::Tensor nvshmem_all_to_all(
@@ -163,7 +163,7 @@ at::Tensor nvshmem_all_to_all(
   auto team = group_to_team(group_name, input_hdl->get_rank_to_global_rank());
 
   void* input_ptr = input.data_ptr();
-  void* output_ptr = out.data_ptr();
+  void* output_ptr = out.mutable_data_ptr();
   TORCH_CHECK(input.is_contiguous() && out.is_contiguous());
   TORCH_CHECK_EQ(input.numel(), out.numel());
   TORCH_CHECK_EQ(input.dtype(), out.dtype());
@@ -301,8 +301,8 @@ at::Tensor all_to_all_vdev(
   int world_size = input_hdl->get_world_size();
 
   void* input_ptr = input.data_ptr();
-  void* output_ptr = out.data_ptr();
-  int64_t* splits_ptr = (int64_t*)(in_out_splits.data_ptr());
+  void* output_ptr = out.mutable_data_ptr();
+  int64_t* splits_ptr = (int64_t*)(in_out_splits.mutable_data_ptr());
 
   auto stream = at::cuda::getCurrentCUDAStream(input.device().index());
 
@@ -625,9 +625,9 @@ void all_to_all_vdev_2d(
   TORCH_CHECK(major_align_val > 0, "major_align must be positive");
 
   void* input_ptr = input.data_ptr();
-  void* output_ptr = out.data_ptr();
+  void* output_ptr = out.mutable_data_ptr();
   int64_t* in_splits_ptr = (int64_t*)(in_splits.data_ptr());
-  int64_t* out_splits_offsets_ptr = (int64_t*)(out_splits_offsets.data_ptr());
+  int64_t* out_splits_offsets_ptr = (int64_t*)(out_splits_offsets.mutable_data_ptr());
 
   // Shape checks
   TORCH_CHECK(in_splits.is_contiguous()
@@ -759,8 +759,8 @@ void all_to_all_vdev_2d_offset(
   int64_t major_align_val = 0;
 
   void* input_ptr = input.data_ptr();
-  void* output_ptr = out.data_ptr();
-  int64_t* out_splits_offsets_ptr = (int64_t*)(out_splits_offsets.data_ptr());
+  void* output_ptr = out.mutable_data_ptr();
+  int64_t* out_splits_offsets_ptr = (int64_t*)(out_splits_offsets.mutable_data_ptr());
   int64_t* in_splits_offsets_ptr = (int64_t*)(in_splits_offsets.data_ptr());
 
   // Shape checks

--- a/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cu
@@ -110,12 +110,13 @@ at::Tensor nvshmem_broadcast(at::Tensor& input, const int64_t root, const std::s
   auto input_hdl = c10d::symmetric_memory::rendezvous(input, group_name);
   int rank = input_hdl->get_rank();
   auto team = group_to_team(group_name, input_hdl->get_rank_to_global_rank());
-  void* buffer_ptr = input_hdl->get_buffer_ptrs()[rank];
+  void* buffer_ptr = input.data_ptr();
+  auto buffer_size = input.numel() * input.element_size();
   int team_size = nvshmem_team_n_pes(team);
   TORCH_CHECK(root < team_size, "root must be smaller than group size");
 
   auto stream = at::cuda::getCurrentCUDAStream();
-  nvshmemx_broadcastmem_on_stream(team, buffer_ptr, buffer_ptr, input_hdl->get_buffer_size(), root, stream);
+  nvshmemx_broadcastmem_on_stream(team, buffer_ptr, buffer_ptr, buffer_size, root, stream);
   return input;
 }
 
@@ -161,9 +162,14 @@ at::Tensor nvshmem_all_to_all(
   int world_size = input_hdl->get_world_size();
   auto team = group_to_team(group_name, input_hdl->get_rank_to_global_rank());
 
-  void* input_ptr = input_hdl->get_buffer_ptrs()[rank];
-  void* output_ptr = out_hdl->get_buffer_ptrs()[rank];
-  size_t bytes_per_rank = input_hdl->get_buffer_size() / world_size;
+  void* input_ptr = input.data_ptr();
+  void* output_ptr = out.data_ptr();
+  TORCH_CHECK(input.is_contiguous() && out.is_contiguous());
+  TORCH_CHECK_EQ(input.numel(), out.numel());
+  TORCH_CHECK_EQ(input.dtype(), out.dtype());
+  TORCH_CHECK_EQ(input.numel() % world_size, 0);
+  auto buffer_size = input.numel() * input.element_size();
+  size_t bytes_per_rank = buffer_size / world_size;
 
   auto stream = at::cuda::getCurrentCUDAStream(input.device().index());
   nvshmemx_alltoallmem_on_stream(team, output_ptr, input_ptr, bytes_per_rank, stream);
@@ -294,9 +300,9 @@ at::Tensor all_to_all_vdev(
   int rank = input_hdl->get_rank();
   int world_size = input_hdl->get_world_size();
 
-  void* input_ptr = input_hdl->get_buffer_ptrs()[rank];
-  void* output_ptr = out_hdl->get_buffer_ptrs()[rank];
-  int64_t* splits_ptr = (int64_t*)(splits_hdl->get_buffer_ptrs()[rank]);
+  void* input_ptr = input.data_ptr();
+  void* output_ptr = out.data_ptr();
+  int64_t* splits_ptr = (int64_t*)(in_out_splits.data_ptr());
 
   auto stream = at::cuda::getCurrentCUDAStream(input.device().index());
 
@@ -618,10 +624,10 @@ void all_to_all_vdev_2d(
   int64_t major_align_val = major_align.value_or(1);
   TORCH_CHECK(major_align_val > 0, "major_align must be positive");
 
-  void* input_ptr = input_hdl->get_buffer_ptrs()[rank];
-  void* output_ptr = out_hdl->get_buffer_ptrs()[rank];
-  int64_t* in_splits_ptr = (int64_t*)(in_splits_hdl->get_buffer_ptrs()[rank]);
-  int64_t* out_splits_offsets_ptr = (int64_t*)(out_splits_offsets_hdl->get_buffer_ptrs()[rank]);
+  void* input_ptr = input.data_ptr();
+  void* output_ptr = out.data_ptr();
+  int64_t* in_splits_ptr = (int64_t*)(in_splits.data_ptr());
+  int64_t* out_splits_offsets_ptr = (int64_t*)(out_splits_offsets.data_ptr());
 
   // Shape checks
   TORCH_CHECK(in_splits.is_contiguous()
@@ -752,10 +758,10 @@ void all_to_all_vdev_2d_offset(
 
   int64_t major_align_val = 0;
 
-  void* input_ptr = input_hdl->get_buffer_ptrs()[rank];
-  void* output_ptr = out_hdl->get_buffer_ptrs()[rank];
-  int64_t* out_splits_offsets_ptr = (int64_t*)(out_splits_offsets_hdl->get_buffer_ptrs()[rank]);
-  int64_t* in_splits_offsets_ptr = (int64_t*)(in_splits_offsets_hdl->get_buffer_ptrs()[rank]);
+  void* input_ptr = input.data_ptr();
+  void* output_ptr = out.data_ptr();
+  int64_t* out_splits_offsets_ptr = (int64_t*)(out_splits_offsets.data_ptr());
+  int64_t* in_splits_offsets_ptr = (int64_t*)(in_splits_offsets.data_ptr());
 
   // Shape checks
   TORCH_CHECK(out_splits_offsets.is_contiguous()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #162193

After MemPool support, `get_buffer_ptrs` points to base address of allocation segment.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim