### PR TITLE
Enable Vulkan backend support for more than Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,7 +298,7 @@ cmake_dependent_option(
     "LINUX" OFF)
 
 if(NOT DEFINED USE_VULKAN)
-  cmake_dependent_option(USE_VULKAN "Use Vulkan GPU backend" ON "ANDROID" OFF)
+  option(USE_VULKAN "Use Vulkan GPU backend" OFF)
 endif()
 
 option(USE_SOURCE_DEBUG_ON_MOBILE "Enable" ON)

--- a/test/test_vulkan.py
+++ b/test/test_vulkan.py
@@ -8,6 +8,26 @@ from torch.testing._internal.common_utils import TestCase, run_tests
 from torch.testing import FileCheck
 import io
 
+class TestVulkanBackend(TestCase):
+    def test_vulkan_backend_module(self):
+        """Test that the vulkan backend module works correctly."""
+        # Test that we can import the backend
+        from torch.backends import vulkan
+        
+        # Test that both availability functions return the same result
+        main_available = torch.is_vulkan_available()
+        backend_available = vulkan.is_available()
+        
+        # They should be consistent
+        self.assertEqual(main_available, backend_available,
+                        "torch.is_vulkan_available() and torch.backends.vulkan.is_available() should return the same value")
+        
+        # Test that the function returns a boolean
+        self.assertIsInstance(main_available, bool,
+                            "is_vulkan_available should return a boolean")
+        self.assertIsInstance(backend_available, bool,
+                            "vulkan.is_available should return a boolean")
+
 @unittest.skipUnless(torch.is_vulkan_available(),
                      "Vulkan backend must be available for these tests.")
 class TestVulkanRewritePass(TestCase):

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -102,6 +102,7 @@ __all__ = [
     "is_deterministic_algorithms_warn_only_enabled",
     "is_storage",
     "is_tensor",
+    "is_vulkan_available",
     "is_warn_always_enabled",
     "load",
     "lobpcg",
@@ -2247,6 +2248,11 @@ del _torch_docs, _tensor_docs, _storage_docs, _size_docs
 def compiled_with_cxx11_abi() -> builtins.bool:
     r"""Returns whether PyTorch was built with _GLIBCXX_USE_CXX11_ABI=1"""
     return True
+
+
+def is_vulkan_available() -> builtins.bool:
+    r"""Returns whether PyTorch was built with Vulkan support."""
+    return torch._C._is_vulkan_available()
 
 
 from torch import _library as _library, _ops as _ops

--- a/torch/backends/__init__.py
+++ b/torch/backends/__init__.py
@@ -139,4 +139,5 @@ from torch.backends import (
     openmp as openmp,
     opt_einsum as opt_einsum,
     quantized as quantized,
+    vulkan as vulkan,
 )

--- a/torch/backends/vulkan/__init__.py
+++ b/torch/backends/vulkan/__init__.py
@@ -1,0 +1,10 @@
+# mypy: allow-untyped-defs
+import torch
+
+
+def is_available():
+    r"""Return whether PyTorch is built with Vulkan support."""
+    return torch._C._is_vulkan_available()
+
+
+__all__ = ["is_available"]

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -108,6 +108,10 @@
 #include <torch/csrc/profiler/kineto_client_interface.h>
 #include <sstream>
 
+#ifdef USE_VULKAN_API
+#include <ATen/vulkan/Context.h>
+#endif
+
 #ifdef USE_CUDA
 #include <ATen/ROCmFABackend.h>
 #include <ATen/cuda/CUDAConfig.h>
@@ -2379,6 +2383,13 @@ Call this whenever a new thread is created in order to propagate values from
   py_module.def("_is_flash_attention_available", []() {
 #ifdef USE_CUDA
     return sdp::is_flash_attention_available();
+#else
+    return false;
+#endif
+  });
+  py_module.def("_is_vulkan_available", []() {
+#ifdef USE_VULKAN_API
+    return at::native::is_vulkan_available();
 #else
     return false;
 #endif


### PR DESCRIPTION
So we can build pytorch and Vulkan for platforms like non-Android Linux

