### PR TITLE
[inductor] fix TemplateBuffer.extract_read_writes

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4833,7 +4833,7 @@ class TemplateBuffer(OperationBuffer):
                 return ops.load(inp.get_name(), indexer(index))
 
             deps.reads |= dependencies.extract_read_writes(
-                dummy, inp.get_size(), (), normalize=True
+                dummy, inp.get_size(), (), normalize=normalize
             ).reads
 
         return deps


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #162102
* #162030
* #162126
* #162101
* #162311
* #162303
* __->__ #162221
* #162028


Make sure TemplateBuffer & ComputedBuffer have the same dependencies prefix.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben