### PR TITLE
[dynamo] Use relaxed CLOSURE_MATCH guard then ID_MATCH

### DIFF
--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -1483,7 +1483,7 @@ class SkipFunctionVariable(VariableTracker):
                     guard_on_source, "_torchdynamo_orig_callable"
                 )
 
-            guard_on_source.make_guard(GuardBuilder.FUNCTION_MATCH)
+            guard_on_source.make_guard(GuardBuilder.CLOSURE_MATCH)
         elif not is_wrapper_or_member_descriptor(value):
             # These descriptors are not guaranteed to return the same object on
             # attribute lookup. They are unlikely to be changed, so we can skip


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #162247

I am unable to write a test that would fail here. The reason is that when we do _dynamo.disable(fn) in the compiled frame, the id of disabled function changes but currently we guard on the original function - `fn` whose id is not changing. This PR still guards on the `fn.__code__` just to be more precise.

Thanks to @thenumberouscode for pointing this out.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela