### PR TITLE
[aarch64] Fix libnvrtc.so unversioned symlink

### DIFF
--- a/.ci/aarch64_linux/aarch64_wheel_ci_build.py
+++ b/.ci/aarch64_linux/aarch64_wheel_ci_build.py
@@ -152,20 +152,15 @@ def package_cuda_wheel(wheel_path, desired_cuda) -> None:
     
     # Determine CUDA major version and create appropriate symlink
     if "130" in desired_cuda:
-        nvrtc_versioned = f"{folder}/tmp/torch/lib/libnvrtc.so.13"
         symlink_target = "libnvrtc.so.13"
-    elif "12" in desired_cuda:
-        nvrtc_versioned = f"{folder}/tmp/torch/lib/libnvrtc.so.12"
+    else:  # CUDA 12.x
         symlink_target = "libnvrtc.so.12"
-    else:
-        nvrtc_versioned = None
-        symlink_target = None
     
-    if nvrtc_versioned and os.path.exists(nvrtc_versioned):
-        if os.path.exists(nvrtc_unversioned):
-            os.remove(nvrtc_unversioned)
-        os.symlink(symlink_target, nvrtc_unversioned)
-        print(f"Created symlink: libnvrtc.so -> {symlink_target}")
+    # Remove existing symlink if present and create new one
+    if os.path.exists(nvrtc_unversioned):
+        os.remove(nvrtc_unversioned)
+    os.symlink(symlink_target, nvrtc_unversioned)
+    print(f"Created symlink: libnvrtc.so -> {symlink_target}")
 
     # Make sure the wheel is tagged with manylinux_2_28
     for f in os.scandir(f"{folder}/tmp/"):


### PR DESCRIPTION
error reported by @xwang233 internally when testing upstream ARM 12.9 wheel
error from TestCompileKernel.test_compile_kernel:
```
root@e8faae565f19:/# python a.py
/usr/local/lib/python3.12/site-packages/torch/_subclasses/functional_tensor.py:279: UserWarning: Failed to initialize NumPy: No module named 'numpy' (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:84.)
  cpu = _conversion_method_template(device=torch.device("cpu"))
Traceback (most recent call last):
  File "//a.py", line 17, in <module>
    add_kernel = _compile_kernel(kernel_source, "add_tensors")
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/torch/cuda/__init__.py", line 1780, in _compile_kernel
    ptx = _nvrtc_compile(
          ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/torch/cuda/_utils.py", line 68, in _nvrtc_compile
    libnvrtc = _get_nvrtc_library()
               ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/torch/cuda/_utils.py", line 38, in _get_nvrtc_library
    return ctypes.CDLL("libnvrtc.so")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/ctypes/__init__.py", line 379, in __init__
    self._handle = _dlopen(self._name, mode)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: libnvrtc.so: cannot open shared object file: No such file or directory
```

Need to create symlink from unversioned `libnvrtc.so` to the versioned `libnvrtc.so.12/13.`, as it is loaded dynamically at runtime through `ctypes.CDLL("libnvrtc.so")`