### PR TITLE
Avoid crash with release_available_cached_blocks

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -2977,8 +2977,8 @@ class DeviceCachingAllocator {
           --it;
         }
         if (!(*cur)->expandable_segment_) {
-          release_block(*cur, context);
           totalReleased += (*cur)->size;
+          release_block(*cur, context);
         }
         if (is_first) {
           break;


### PR DESCRIPTION
updated release behavior for cached blocks
Fixes #159567


cc @ptrblck @msaroufim @eqy @jerryzh168