### PR TITLE
Add support for NestedTensor share_memory_

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -1230,6 +1230,24 @@ class TestNestedTensorDeviceType(NestedTensorTestCase):
         is_cuda = "cuda" in str(device)
         self.assertEqual(nt.is_cuda, is_cuda)
 
+    def test_share_memory(self, device):
+        a = torch.randn(3, 4, device=device)
+        b = torch.randn(5, 4, device=device)
+        nt = torch.nested.nested_tensor([a, b], layout=torch.jagged)
+
+        # Guard CUDA tensors
+        if device == "cuda":
+            result = nt.share_memory_()
+            self.assertIs(result, nt)
+            return
+
+        result = nt.share_memory_()
+        self.assertIs(result, nt)
+
+        # Verify values/offsets are in shared memory
+        self.assertTrue(nt._values.is_shared())
+        self.assertTrue(nt._offsets.is_shared())
+
     @dtypes(torch.float, torch.float16, torch.double)
     def test_nested_tensor_indexing(self, device, dtype):
         # edge case: empty nested tensor

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -1230,6 +1230,7 @@ class TestNestedTensorDeviceType(NestedTensorTestCase):
         is_cuda = "cuda" in str(device)
         self.assertEqual(nt.is_cuda, is_cuda)
 
+    @skipIfTorchDynamo("Not a suitable test for TorchDynamo")
     def test_share_memory(self, device):
         a = torch.randn(3, 4, device=device)
         b = torch.randn(5, 4, device=device)

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -1237,7 +1237,7 @@ class TestNestedTensorDeviceType(NestedTensorTestCase):
         nt = torch.nested.nested_tensor([a, b], layout=torch.jagged)
 
         # Guard CUDA tensors
-        if device == "cuda":
+        if "cuda" in device:
             result = nt.share_memory_()
             self.assertIs(result, nt)
             return

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -1245,9 +1245,8 @@ class TestNestedTensorDeviceType(NestedTensorTestCase):
         result = nt.share_memory_()
         self.assertIs(result, nt)
 
-        # Verify values/offsets are in shared memory
-        self.assertTrue(nt._values.is_shared())
-        self.assertTrue(nt._offsets.is_shared())
+        # Verify in shared memory
+        self.assertTrue(nt.is_shared())
 
     @dtypes(torch.float, torch.float16, torch.double)
     def test_nested_tensor_indexing(self, device, dtype):

--- a/torch/nested/_internal/nested_tensor.py
+++ b/torch/nested/_internal/nested_tensor.py
@@ -163,6 +163,25 @@ class NestedTensor(torch.Tensor):
     def lengths(self):
         return self._lengths
 
+    def share_memory_(self):
+        # Guard CUDA tensors
+        if self._values.is_cuda:
+            return self
+
+        # Share NestedTensor components
+        self._values.share_memory_()
+        self._offsets.share_memory_()
+
+        if self._lengths is not None:
+            self._lengths.share_memory_()
+
+        if self._min_seqlen_tensor is not None:
+            self._min_seqlen_tensor.share_memory_()
+        if self._max_seqlen_tensor is not None:
+            self._max_seqlen_tensor.share_memory_()
+
+        return self
+
     # Private accessor functions for min / max sequence length. They're
     # purposefully not @properties because those don't work with PT2 (yet).
     # These compute / cache if not present.

--- a/torch/nested/_internal/nested_tensor.py
+++ b/torch/nested/_internal/nested_tensor.py
@@ -165,21 +165,15 @@ class NestedTensor(torch.Tensor):
 
     def share_memory_(self):
         # Guard CUDA tensors
-        if self._values.is_cuda:
+        if self.is_cuda:
             return self
 
         # Share NestedTensor components
-        self._values.share_memory_()
-        self._offsets.share_memory_()
-
-        if self._lengths is not None:
-            self._lengths.share_memory_()
-
-        if self._min_seqlen_tensor is not None:
-            self._min_seqlen_tensor.share_memory_()
-        if self._max_seqlen_tensor is not None:
-            self._max_seqlen_tensor.share_memory_()
-
+        component_names, _ = self.__tensor_flatten__()
+        for name in component_names:
+            component = getattr(self, name, None)
+            if component is not None:
+                component.share_memory_()
         return self
 
     # Private accessor functions for min / max sequence length. They're

--- a/torch/nested/_internal/nested_tensor.py
+++ b/torch/nested/_internal/nested_tensor.py
@@ -163,19 +163,6 @@ class NestedTensor(torch.Tensor):
     def lengths(self):
         return self._lengths
 
-    def share_memory_(self):
-        # Guard CUDA tensors
-        if self.is_cuda:
-            return self
-
-        # Share NestedTensor components
-        component_names, _ = self.__tensor_flatten__()
-        for name in component_names:
-            component = getattr(self, name, None)
-            if component is not None:
-                component.share_memory_()
-        return self
-
     # Private accessor functions for min / max sequence length. They're
     # purposefully not @properties because those don't work with PT2 (yet).
     # These compute / cache if not present.


### PR DESCRIPTION
Fixes: https://github.com/pytorch/pytorch/issues/161915

### Summary

Implements share_memory_() support for NestedTensor! 

### Changes

- Added share_memory_() method to NestedTensor class.
  - Shares storage for all NestedTensor components: _values, _offsets, _lengths, and cached seqlen tensors.
  - Guard for CUDA Tensors.

### Testing

Before Fix:

`pytest -q test/test_nestedtensor.py -k "test_share_memory" -v`

Output:

```
Running 1 items in this shard

test/test_nestedtensor.py Fatal Python error: Segmentation fault
```

After Fix:

`pytest -q test/test_nestedtensor.py -k "test_share_memory" -v`

Output:

```
Running 1 items in this shard

test/test_nestedtensor.py::TestNestedTensorDeviceTypeCPU::test_share_memory_cpu PASSED [0.0753s] 
```
