### PR TITLE
replace expect_true with guard_or_true in maybe_reduce

### DIFF
--- a/torch/csrc/autograd/input_metadata.cpp
+++ b/torch/csrc/autograd/input_metadata.cpp
@@ -98,7 +98,7 @@ at::Tensor InputMetadata::maybe_reduce(
         needs_reduce = true;
       }
     } else {
-      if (!size.sym_eq(target).expect_true(__FILE__, __LINE__)) {
+      if (!TORCH_GUARD_OR_TRUE(size.sym_eq(target))) {
         fail();
       }
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #162289

Fixes #161276

Tested within repo via `python test/dynamo/test_misc.py -k test_validate_outputs_unbacked`

Tested in torchtitan via `LOG_RANK=0,1 TORCHINDUCTOR_COMPILE_THREADS=1 NGPU=2 CONFIG_FILE="./torchtitan/experiments/llama4/train_configs/debug_model.toml" tlp ./run_train.sh --parallelism.data_parallel_shard_degree=2 --parallelism.expert_parallel_degree=2`

<img width="1796" height="403" alt="image" src="https://github.com/user-attachments/assets/822aec7d-524f-4e6c-8375-57353be5d32d" />


