### PR TITLE
remove deprecated vllm test

### DIFF
--- a/.ci/lumen_cli/cli/lib/core/vllm/lib.py
+++ b/.ci/lumen_cli/cli/lib/core/vllm/lib.py
@@ -76,7 +76,6 @@ def sample_vllm_test_library():
                 ),
                 "pytest -v -s entrypoints/llm/test_lazy_outlines.py",
                 "pytest -v -s entrypoints/llm/test_generate.py ",
-                "pytest -v -s entrypoints/llm/test_generate_multiple_loras.py",
                 "VLLM_USE_V1=0 pytest -v -s entrypoints/offline_mode",
             ],
         },


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/162274

the test is removed from vllm side
