### PR TITLE
[DTensor] fix F.one_hot

### DIFF
--- a/test/distributed/tensor/test_dtensor_ops.py
+++ b/test/distributed/tensor/test_dtensor_ops.py
@@ -508,7 +508,7 @@ class TestDTensorOps(DTensorOpTestBase):
         return OP_DB_WORLD_SIZE
 
     def run_opinfo_test(
-        self, dtype, op, requires_grad, sample_inputs_filter=lambda s: True
+        self, dtype, op, requires_grad=True, sample_inputs_filter=lambda s: True
     ):
         self.mesh = DeviceMesh(DEVICE_TYPE, torch.arange(self.world_size))
 

--- a/test/distributed/tensor/test_dtensor_ops.py
+++ b/test/distributed/tensor/test_dtensor_ops.py
@@ -536,7 +536,7 @@ class TestDTensorOps(DTensorOpTestBase):
     @ops(op_db, allowed_dtypes=(torch.float,))
     @skipOps("TestDTensorOps", "test_dtensor_op_db", dtensor_fails)
     def test_dtensor_op_db(self, dtype, op):
-        self.run_opinfo_test(dtype, dtype, op)
+        self.run_opinfo_test(dtype, op)
 
     def assert_ref_dtensor_equal(self, dtensor_rs, rs):
         flat_dtensor_rs = pytree.tree_leaves(dtensor_rs)

--- a/test/distributed/tensor/test_dtensor_ops.py
+++ b/test/distributed/tensor/test_dtensor_ops.py
@@ -507,18 +507,17 @@ class TestDTensorOps(DTensorOpTestBase):
     def world_size(self) -> int:
         return OP_DB_WORLD_SIZE
 
-    # only allow float dytpe for now, we can relax this constraint
-    # when feel necessary later (i.e when adding quantization support).
-    @suppress_warnings
-    @ops(op_db, allowed_dtypes=(torch.float,))
-    @skipOps("TestDTensorOps", "test_dtensor_op_db", dtensor_fails)
-    def test_dtensor_op_db(self, dtype, op):
+    def run_opinfo_test(
+        self, dtype, op, requires_grad, sample_inputs_filter=lambda s: True
+    ):
         self.mesh = DeviceMesh(DEVICE_TYPE, torch.arange(self.world_size))
 
         # test each op with dist tensor inputs and normal inputs
         def test():
-            samples = op.sample_inputs(DEVICE_TYPE, dtype, requires_grad=True)
+            samples = op.sample_inputs(DEVICE_TYPE, dtype, requires_grad=requires_grad)
             for sample_input in samples:
+                if sample_inputs_filter(sample_input):
+                    continue
                 args = [sample_input.input] + list(sample_input.args)
                 kwargs = sample_input.kwargs
 
@@ -530,6 +529,14 @@ class TestDTensorOps(DTensorOpTestBase):
                 #     func(*args, **kwargs, out=expected)
 
         self.check_dtensor_func(test, op)
+
+    # only allow float dytpe for now, we can relax this constraint
+    # when feel necessary later (i.e when adding quantization support).
+    @suppress_warnings
+    @ops(op_db, allowed_dtypes=(torch.float,))
+    @skipOps("TestDTensorOps", "test_dtensor_op_db", dtensor_fails)
+    def test_dtensor_op_db(self, dtype, op):
+        self.run_opinfo_test(dtype, dtype, op)
 
     def assert_ref_dtensor_equal(self, dtensor_rs, rs):
         flat_dtensor_rs = pytree.tree_leaves(dtensor_rs)
@@ -643,6 +650,18 @@ class TestDTensorOps(DTensorOpTestBase):
                     print(f"xfail('{opinfo.name}', '{opinfo.variant_test_name}'),")
                 else:
                     print(f"xfail('{opinfo.name}'),")
+
+    def test_one_hot(self):
+        ops = [op for op in op_db if op.name == "nn.functional.one_hot"]
+        assert len(ops) == 1
+        op = ops[0]
+        # num_classes = -1 appears to have a bug with dtensor.max().item()
+        self.run_opinfo_test(
+            torch.int64,
+            op,
+            requires_grad=False,
+            sample_inputs_filter=lambda s: s.kwargs["num_classes"] != -1,
+        )
 
 
 # only instantiate tests for DEVICE_TYPE alone (i.e. either CPU or GPU)

--- a/test/distributed/tensor/test_dtensor_ops.py
+++ b/test/distributed/tensor/test_dtensor_ops.py
@@ -516,7 +516,7 @@ class TestDTensorOps(DTensorOpTestBase):
         def test():
             samples = op.sample_inputs(DEVICE_TYPE, dtype, requires_grad=requires_grad)
             for sample_input in samples:
-                if sample_inputs_filter(sample_input):
+                if not sample_inputs_filter(sample_input):
                     continue
                 args = [sample_input.input] + list(sample_input.args)
                 kwargs = sample_input.kwargs

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -355,12 +355,11 @@ class DTensor(torch.Tensor):
     # pyre-fixme[3]: Return type must be annotated.
     # pyre-fixme[2]: Parameter must be annotated.
     def __torch_dispatch__(cls, func, types, args=(), kwargs=None):  # type: ignore[override]
-        result = DTensor._op_dispatcher.dispatch(
+        return DTensor._op_dispatcher.dispatch(
             func,
             args,
             kwargs or {},
         )
-        return result
 
     @staticmethod
     def from_local(

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -355,11 +355,12 @@ class DTensor(torch.Tensor):
     # pyre-fixme[3]: Return type must be annotated.
     # pyre-fixme[2]: Parameter must be annotated.
     def __torch_dispatch__(cls, func, types, args=(), kwargs=None):  # type: ignore[override]
-        return DTensor._op_dispatcher.dispatch(
+        result = DTensor._op_dispatcher.dispatch(
             func,
             args,
             kwargs or {},
         )
+        return result
 
     @staticmethod
     def from_local(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #162312
* __->__ #162307
* #162117

F.one_hot(dtensor) used to run into a mixed DTensor-Tensor operation due
to an arange call creating a new Tensor (not DTensor). This PR fixes it
by allowing implicit replication of Tensors for the arange call and the
one consumer of the arange call (the at::eq call).

Test Plan:
- new test. Also, F.one_hot(num_classes=-1) is broken so we skip that.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim