### PR TITLE
[inductor][triton] support static cuda launcher after triton # 7866

### DIFF
--- a/torch/_inductor/runtime/static_cuda_launcher.py
+++ b/torch/_inductor/runtime/static_cuda_launcher.py
@@ -54,7 +54,7 @@ class StaticallyLaunchedCudaKernel:
             launch_enter = triton_knobs.runtime.launch_enter_hook
             launch_exit = triton_knobs.runtime.launch_exit_hook
 
-        def hook_is_empty(hook) -> bool:
+        def hook_is_empty(hook: Any) -> bool:
             if hook is None:
                 return True
             if (

--- a/torch/_inductor/runtime/static_cuda_launcher.py
+++ b/torch/_inductor/runtime/static_cuda_launcher.py
@@ -54,7 +54,20 @@ class StaticallyLaunchedCudaKernel:
             launch_enter = triton_knobs.runtime.launch_enter_hook
             launch_exit = triton_knobs.runtime.launch_exit_hook
 
-        if launch_enter is not None or launch_exit is not None:
+        def hook_is_empty(hook) -> bool:
+            if hook is None:
+                return True
+            if (
+                triton_knobs
+                and (HookChain := getattr(triton_knobs, "HookChain", None)) is not None
+                and isinstance(hook, HookChain)
+            ):
+                # Support hooks after https://github.com/triton-lang/triton/pull/7866
+                return len(hook.calls) == 0
+            return False
+
+        if not hook_is_empty(launch_enter) or not hook_is_empty(launch_exit):
+            breakpoint()
             raise NotImplementedError(
                 "We don't support launch enter or launch exit hooks"
             )

--- a/torch/_inductor/runtime/static_cuda_launcher.py
+++ b/torch/_inductor/runtime/static_cuda_launcher.py
@@ -67,7 +67,6 @@ class StaticallyLaunchedCudaKernel:
             return False
 
         if not hook_is_empty(launch_enter) or not hook_is_empty(launch_exit):
-            breakpoint()
             raise NotImplementedError(
                 "We don't support launch enter or launch exit hooks"
             )

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1530,7 +1530,6 @@ class StaticTritonCompileResult(CompileResult[StaticallyLaunchedCudaKernel]):
             else:
                 kernel._cubin_path = cubin_location
 
-            static_kernel = StaticallyLaunchedCudaKernel(kernel)
             try:
                 static_kernel = StaticallyLaunchedCudaKernel(kernel)
             except NotImplementedError as e:

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1530,6 +1530,7 @@ class StaticTritonCompileResult(CompileResult[StaticallyLaunchedCudaKernel]):
             else:
                 kernel._cubin_path = cubin_location
 
+            static_kernel = StaticallyLaunchedCudaKernel(kernel)
             try:
                 static_kernel = StaticallyLaunchedCudaKernel(kernel)
             except NotImplementedError as e:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #162278
* __->__ #162309
* #162244

Fixes static cuda launcher after https://github.com/triton-lang/triton/pull/7866.

Static cuda launcher checks to make sure that no hook knobs are set (and if they are, it throws an error). But Triton has changed the semantics of hooks so that "empty hooks" are now represented by empty `HookChain`s instead of being represented by `None`. This PR changes the way we define "empty hooks" to account for HookChains.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @mlazos