### PR TITLE
[DTensor] DTensor.item() should Replicate() inputs

### DIFF
--- a/test/distributed/tensor/test_dtensor_ops.py
+++ b/test/distributed/tensor/test_dtensor_ops.py
@@ -655,12 +655,10 @@ class TestDTensorOps(DTensorOpTestBase):
         ops = [op for op in op_db if op.name == "nn.functional.one_hot"]
         assert len(ops) == 1
         op = ops[0]
-        # num_classes = -1 appears to have a bug with dtensor.max().item()
         self.run_opinfo_test(
             torch.int64,
             op,
             requires_grad=False,
-            sample_inputs_filter=lambda s: s.kwargs["num_classes"] != -1,
         )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #162312
* #162307
* #162117

Previously, DTensor.item() didn't replicate inputs. This caused silent
incorrectness in the case of DTensor.max().item() -- .max() returns
DTensors with Partial(max) placement and .item() just returned the local
values.

This PR changes it so that DTensor.item() replicates the inputs before
calling .item().

Test Plan:
- new tests

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci @gchanan