### PR TITLE
`_compile_kernel()`: handle smem > 48kb

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -6879,7 +6879,7 @@ class TestCompileKernel(TestCase):
             grid=(blocks_per_grid, 1, 1),
             block=(threads_per_block, 1, 1),
             args=[a, b, c, N],
-            shared_mem=shared_mem
+            shared_mem=shared_mem,
         )
 
         # Verify results
@@ -6894,7 +6894,7 @@ class TestCompileKernel(TestCase):
                 grid=(blocks_per_grid, 1, 1),
                 block=(threads_per_block, 1, 1),
                 args=[a, b, c, N],
-                shared_mem=shared_mem
+                shared_mem=shared_mem,
             )
 
     @tf32_on_and_off(0.005)

--- a/torch/cuda/_utils.py
+++ b/torch/cuda/_utils.py
@@ -266,6 +266,18 @@ class _CudaKernel:
 
             stream = torch.cuda.current_stream()
 
+        # kernels require more than 48KB shared memory require explicit opt-in
+        if shared_mem >= 48 * 1024:
+            # https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html
+            cudaFuncAttributeMaxDynamicSharedMemorySize = 8
+            _check_cuda(
+                libcuda.cuFuncSetAttribute(
+                    self.func,
+                    cudaFuncAttributeMaxDynamicSharedMemorySize,
+                    shared_mem,
+                )
+            )
+
         _check_cuda(
             libcuda.cuLaunchKernel(
                 self.func,


### PR DESCRIPTION
When shared memory is more than 48kb, we need to manually set `cudaFuncAttributeMaxDynamicSharedMemorySize` to the required shared memory size. This is documented in CUDA C++ API guide https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#shared-memory-7-x. And we can also see it in CUTLASS https://github.com/NVIDIA/cutlass/blob/76c96b0be35cb263debe3e3d8418b80911a544ab/include/cutlass/transform/device/transform_universal_adapter.hpp#L143-L148

When the requested shared memory is more than what is supported, `CUDA Invalid arguments` will be thrown. I decided not to check against `torch.cuda.get_device_properties().shared_memory_per_block_optin` at kernel invocation time to avoid overhead.

@msaroufim 