### PR TITLE
Repackage vLLM nightlies

### DIFF
--- a/.github/scripts/prepare_vllm_wheels.sh
+++ b/.github/scripts/prepare_vllm_wheels.sh
@@ -18,10 +18,10 @@ make_wheel_record() {
 }
 
 change_wheel_version() {
-  package=$1
-  wheel=$2
-  f_version=$3
-  t_version=$4
+  local package=$1
+  local wheel=$2
+  local f_version=$3
+  local t_version=$4
 
   # Extract the wheel
   ${PYTHON_EXECUTABLE} -mwheel unpack $wheel
@@ -54,19 +54,20 @@ change_wheel_version() {
 }
 
 repackage_wheel() {
-  package=$1
+  local package=$1
   pushd $package
 
-  orig_wheel=$(find . -name *${package//-/_}*)
-  orig_version=$(unzip -p $orig_wheel '**/METADATA' | grep '^Version: ' | cut -d' ' -f2)
+  local orig_wheel=$(find . -name *${package//-/_}*)
+  local orig_version=$(unzip -p $orig_wheel '**/METADATA' | grep '^Version: ' | cut -d' ' -f2)
 
+  local version=""
   if [[ "${package}" == vllm ]]; then
     # Copied from vllm/.buildkite/scripts/upload-wheels.sh
     version=1.0.0
   else
     version=$(echo $orig_version | tr '.+' '.' | cut -d'.' -f1-3)
   fi
-  nightly_version=$version.$nightly
+  local nightly_version=$version.$nightly
 
   # Use nightly version
   change_wheel_version ${package//-/_} $orig_wheel $orig_version $nightly_version
@@ -75,8 +76,8 @@ repackage_wheel() {
 
   auditwheel repair --plat $PLATFORM *.whl \
     --exclude libc10* --exclude libtorch* --exclude libcu* --exclude libnv*
-  repair_wheel=$(find wheelhouse -name *${PLATFORM}*)
-  repair_wheel=$(basename ${repair_wheel})
+  local repair_wheel=$(find wheelhouse -name *${PLATFORM}*)
+  local repair_wheel=$(basename ${repair_wheel})
   popd
 
   cp ${package}/wheelhouse/${repair_wheel} .

--- a/.github/scripts/prepare_vllm_wheels.sh
+++ b/.github/scripts/prepare_vllm_wheels.sh
@@ -2,7 +2,8 @@
 
 set -eux
 
-nightly=$(unzip -p torch-* '**/METADATA' | grep '^Version: ' | cut -d' ' -f2 | cut -d'.' -f4)
+torch_version=$(unzip -p torch-* '**/METADATA' | grep '^Version: ')
+nightly=$(echo ${torch_version} | cut -d' ' -f2 | cut -d'.' -f4)
 
 # Copied from .ci/manywheel/build_common.sh
 make_wheel_record() {
@@ -35,6 +36,10 @@ change_wheel_version() {
 
   # Update the version in METADATA and its SHA256 hash
   sed -i "s/Version: ${f_version}/Version: ${t_version}/g" METADATA
+  # then add PyTorch nightly dependency of vLLM
+  if [[ "${package}" == vllm ]]; then
+    sed -i "/License-File/a\Requires-Dist: torch==${torch_version}" METADATA
+  fi
   sed -i '/METADATA,sha256/d' RECORD
   popd
 

--- a/.github/scripts/prepare_vllm_wheels.sh
+++ b/.github/scripts/prepare_vllm_wheels.sh
@@ -57,7 +57,7 @@ repackage_wheel() {
   package=$1
   pushd $package
 
-  orig_wheel=$(find . -name *${package}*)
+  orig_wheel=$(find . -name *${package//-/_}*)
   orig_version=$(unzip -p $orig_wheel '**/METADATA' | grep '^Version: ' | cut -d' ' -f2)
 
   if [[ "${package}" == vllm ]]; then
@@ -69,7 +69,7 @@ repackage_wheel() {
   nightly_version=$version.$nightly
 
   # Use nightly version
-  change_wheel_version $package $orig_wheel $orig_version $nightly_version
+  change_wheel_version ${package//-/_} $orig_wheel $orig_version $nightly_version
   # Clean up
   rm "${orig_wheel}"
 

--- a/.github/scripts/prepare_vllm_wheels.sh
+++ b/.github/scripts/prepare_vllm_wheels.sh
@@ -2,8 +2,8 @@
 
 set -eux
 
-torch_version=$(unzip -p torch-* '**/METADATA' | grep '^Version: ')
-nightly=$(echo ${torch_version} | cut -d' ' -f2 | cut -d'.' -f4)
+torch_version=$(unzip -p torch-* '**/METADATA' | grep '^Version: ' | cut -d' ' -f2)
+nightly=$(echo ${torch_version} | cut -d'.' -f4)
 
 # Copied from .ci/manywheel/build_common.sh
 make_wheel_record() {
@@ -37,7 +37,7 @@ change_wheel_version() {
   # Update the version in METADATA and its SHA256 hash
   sed -i "s/Version: ${f_version}/Version: ${t_version}/g" METADATA
   # then add PyTorch nightly dependency of vLLM
-  if [[ "${package}" == vllm ]]; then
+  if [[ "${package}" == vllm ]] || [[ "${package}" == xformers ]]; then
     sed -i "/License-File/a\Requires-Dist: torch==${torch_version}" METADATA
   fi
   sed -i '/METADATA,sha256/d' RECORD

--- a/.github/scripts/prepare_vllm_wheels.sh
+++ b/.github/scripts/prepare_vllm_wheels.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+set -eux
+
+nightly=$(unzip -p torch-* '**/METADATA' | grep '^Version: ' | cut -d' ' -f2 | cut -d'.' -f4)
+
+# Copied from .ci/manywheel/build_common.sh
+make_wheel_record() {
+  fpath=$1
+  if echo $fpath | grep RECORD >/dev/null 2>&1; then
+    echo "$fpath,,"
+  else
+    fhash=$(openssl dgst -sha256 -binary $fpath | openssl base64 | sed -e 's/+/-/g' | sed -e 's/\//_/g' | sed -e 's/=//g')
+    fsize=$(ls -nl $fpath | awk '{print $5}')
+    echo "$fpath,sha256=$fhash,$fsize"
+  fi
+}
+
+change_wheel_version() {
+  package=$1
+  wheel=$1
+  f_version=$2
+  t_version=$3
+
+  # Extract the wheel
+  ${PYTHON_EXECUTABLE} -mwheel unpack $wheel
+
+  mv "${package}-${f_version}" "${package}-${t_version}"
+  # Change the version from f_version to t_version in the dist-info dir
+  pushd "${package}-${t_version}"
+  mv "${package}-${f_version}.dist-info" "${package}-${t_version}.dist-info"
+
+  pushd "${package}-${t_version}.dist-info"
+  sed -i "s/${package}-${f_version}.dist-info/${package}-${t_version}.dist-info/g" RECORD
+
+  # Update the version in METADATA and its SHA256 hash
+  sed -i "s/Version: ${f_version}/Version: ${t_version}/g" METADATA
+  sed -i '/METADATA,sha256/d' RECORD
+  popd
+
+  make_wheel_record "${package}-${t_version}.dist-info/METADATA" >> "${package}-${t_version}.dist-info/RECORD"
+  popd
+
+  # Repack the wheel
+  ${PYTHON_EXECUTABLE} -mwheel pack "${package}-${t_version}"
+
+  # Clean up
+  rm -rf "${package}-${t_version}"
+}
+
+repackage_wheel() {
+  package=$1
+  pushd $package
+
+  orig_wheel=$(find . -name *${package}*)
+  orig_version=$(unzip -p $orig_wheel '**/METADATA' | grep '^Version: ' | cut -d' ' -f2)
+
+  if [[ "${package}" == vllm ]]; then
+    # Copied from vllm/.buildkite/scripts/upload-wheels.sh
+    version=1.0.0
+  else
+    version=$(echo $orig_version | tr '.+' '.' | cut -d'.' -f1-3)
+  fi
+  nightly_version=$version.$nightly
+
+  # Use nightly version
+  change_wheel_version $package $orig_wheel $orig_version $nightly_version
+  # Clean up
+  rm "${orig_wheel}"
+
+  auditwheel repair --plat $PLATFORM *.whl \
+    --exclude libc10* --exclude libtorch* --exclude libcu* --exclude libnv*
+  repair_wheel=$(find wheelhouse -name *${PLATFORM}*)
+  repair_wheel=$(basename ${repair_wheel})
+  popd
+
+  cp ${package}/wheelhouse/${repair_wheel} .
+  rm -rf $package
+}
+
+pushd externals/vllm/wheels
+for package in xformers flashinfer-python vllm; do
+  repackage_wheel $package
+done
+popd

--- a/.github/scripts/prepare_vllm_wheels.sh
+++ b/.github/scripts/prepare_vllm_wheels.sh
@@ -19,9 +19,9 @@ make_wheel_record() {
 
 change_wheel_version() {
   package=$1
-  wheel=$1
-  f_version=$2
-  t_version=$3
+  wheel=$2
+  f_version=$3
+  t_version=$4
 
   # Extract the wheel
   ${PYTHON_EXECUTABLE} -mwheel unpack $wheel

--- a/.github/workflows/build-vllm-wheel.yml
+++ b/.github/workflows/build-vllm-wheel.yml
@@ -59,20 +59,6 @@ jobs:
         run: |
           set -eux
 
-          # Keep PyTorch nightly wheel here so that we can install it later during
-          # vLLM build process
-          mkdir -p "${RUNNER_TEMP}/artifacts/"
-
-          container_name=$(docker run \
-            --tty \
-            --detach \
-            -e PLATFORM \
-            -v "${GITHUB_WORKSPACE}:/pytorch" \
-            -v "${RUNNER_TEMP}/artifacts:/artifacts" \
-            -w /artifacts/ \
-            "${MANYLINUX_IMAGE}"
-          )
-
           # Determine python executable for given version (copied from build-triton-wheel)
           case $PY_VERS in
           3.10)
@@ -102,6 +88,21 @@ jobs:
             ;;
           esac
 
+          # Keep PyTorch nightly wheel here so that we can install it later during
+          # vLLM build process
+          mkdir -p "${RUNNER_TEMP}/artifacts/"
+
+          container_name=$(docker run \
+            --tty \
+            --detach \
+            -e PLATFORM \
+            -e PYTHON_EXECUTABLE \
+            -v "${GITHUB_WORKSPACE}:/pytorch" \
+            -v "${RUNNER_TEMP}/artifacts:/artifacts" \
+            -w /artifacts/ \
+            "${MANYLINUX_IMAGE}"
+          )
+
           docker exec -t "${container_name}" "${PYTHON_EXECUTABLE}" -mpip install \
             --pre torch torchvision torchaudio \
             --index-url "https://download.pytorch.org/whl/nightly/${BUILD_DEVICE}"
@@ -113,7 +114,6 @@ jobs:
             --index-url "https://download.pytorch.org/whl/nightly/${BUILD_DEVICE}"
 
           # Save this for later
-          echo "PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}" >> "$GITHUB_ENV"
           echo "container_name=${container_name}" >> "$GITHUB_ENV"
 
       - name: Build vLLM wheel

--- a/.github/workflows/build-vllm-wheel.yml
+++ b/.github/workflows/build-vllm-wheel.yml
@@ -131,36 +131,7 @@ jobs:
           set -eux
 
           # Get these wheels ready, the vllm renaming logic is copied from its .buildkite/scripts/upload-wheels.sh
-          docker exec -t "${container_name}" bash -c "
-            set -eux
-
-            nightly=\$(unzip -p torch-* '**/METADATA' | grep '^Version: ' | cut -d' ' -f2 | cut -d'.' -f4)
-
-            pushd externals/vllm/wheels
-            for package in xformers flashinfer-python vllm; do
-              pushd \$package
-              auditwheel repair --plat \$PLATFORM *.whl \
-                --exclude libc10* --exclude libtorch* --exclude libcu* --exclude libnv*
-              repair_wheel=\$(find wheelhouse -name *\${PLATFORM}*)
-              repair_wheel=\$(basename \${repair_wheel})
-              popd
-
-              cp \${package}/wheelhouse/\${repair_wheel} .
-              version=\$(unzip -p \$repair_wheel '**/METADATA' | grep '^Version: ' | cut -d' ' -f2)
-
-              if [[ \$package == vllm ]]; then
-                new_wheel=\${repair_wheel/\$version/1.0.0.\$nightly}
-              else
-                major_version=\$(echo \$version | tr '.+' '.' | cut -d'.' -f1-3)
-                new_wheel=\${repair_wheel/\$version/\$major_version.\$nightly}
-              fi
-
-              mv -- \$repair_wheel \$new_wheel
-              rm -rf \$package
-            done
-            popd
-          "
-
+          docker exec -t "${container_name}" bash -c /pytorch/.github/scripts/prepare_vllm_wheels.sh
           docker exec -t "${container_name}" chown -R 1000:1000 /artifacts
 
       - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0

--- a/.github/workflows/build-vllm-wheel.yml
+++ b/.github/workflows/build-vllm-wheel.yml
@@ -96,7 +96,7 @@ jobs:
             --tty \
             --detach \
             -e PLATFORM \
-            -e PYTHON_EXECUTABLE \
+            -e PYTHON_EXECUTABLE="${PYTHON_EXECUTABLE}" \
             -v "${GITHUB_WORKSPACE}:/pytorch" \
             -v "${RUNNER_TEMP}/artifacts:/artifacts" \
             -w /artifacts/ \


### PR DESCRIPTION
I suspected that I would need to repack vLLM wheels from https://github.com/pytorch/pytorch/pull/162000 because I renamed the wheel, and it turns out to be true.  The error is as follows:

```
$ uv pip install --pre xformers --index-url https://download.pytorch.org/whl/nightly/cu129
Using Python 3.12.11+meta environment at: venv/py3.12
Resolved 28 packages in 759ms
error: Failed to install: xformers-0.0.33.dev20250901+cu129-cp39-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (xformers==0.0.33.dev20250901+cu129)
  Caused by: Wheel version does not match filename: 0.0.33+5d4b92a5.d20250907 != 0.0.33.dev20250901+cu129
```
