### PR TITLE
[Test] Add more instructions for installing CI requirements on local machine

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1943,6 +1943,8 @@ def check_pip_packages() -> None:
     except PackageNotFoundError:
         print_to_stderr(
             f"Missing pip dependency: {pkg}, please run `pip install -r .ci/docker/requirements-ci.txt`"
+            f" or `pip install -r <(grep -v 'cuda-bindings' .ci/docker/requirements-ci.txt)`"
+            f" if you don't test on CUDA."
         )
         sys.exit(1)
 


### PR DESCRIPTION
# Motivation

When I run `python test/run_tests.py` on my Mac, I get a message "Missing pip dependency: matplotlib, please run `pip install -r .ci/docker/requirements-ci.txt`". However, `cuda-bindings` is a mandatory package in this file. 
https://github.com/pytorch/pytorch/blob/32911ff541e8a60693412f575b4363c546d251df/.ci/docker/requirements-ci.txt#L385

I guess most CI machines have CUDA installed, but for our users, `cuda-bindings` is unnecessary unless we are operating on a CUDA machine. Additionally, there is no compatible version of `cuda-bindings` available for Mac users. Therefore, this pull request aims to provide clearer instructions for users who do not intend to test CUDA on their local machines.

# Changes

The original suggestion only instructs users to run `pip install -r .ci/docker/requirements-ci.txt`. In contrast, this pull request adds another command: `pip install -r <(grep -v 'cuda-bindings' .ci/docker/requirements-ci.txt)`. This command removes `cuda-bindings` from the installation requirements.

# Advantages

- Removing `cuda-bindings` from the requirements for Mac users will help them avoid errors related to the installation of an incompatible `cuda-bindings` package.
- For Linux and Windows users who also do not plan to test on CUDA, this way of installation will save time, bandwidth, and storage space by eliminating the need to download `cuda-bindings`.


cc @mruberry