### PR TITLE
[precompile] Fix inlined source tracking with generators.

### DIFF
--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -521,15 +521,14 @@ class CompilePackage:
             module = inspect.getmodule(code)
             if module is None:
                 continue
-            source = inspect.getsource(code)
-            lastlineno = code.co_firstlineno + len(inspect.getsourcelines(code)[0])
-            assert source == "".join(
-                _get_sourcelines(module, code.co_firstlineno, lastlineno)
-            )
+            sourcelines, firstlineno = inspect.getsourcelines(code)
+            lastlineno = firstlineno + len(sourcelines)
+            source = "".join(sourcelines)
+            assert source == "".join(_get_sourcelines(module, firstlineno, lastlineno))
             self._inlined_sources.add(
                 InlinedSource(
                     module=module.__name__,
-                    firstlineno=code.co_firstlineno,
+                    firstlineno=firstlineno,
                     lastlineno=lastlineno,
                     checksum=_hash_source(source),
                 )


### PR DESCRIPTION
Summary:
When compiled code has generator, code.co_firstlineno will be inconsistent with the result from inspect.getsource, which returns the toplevel enclosing code source rather than the inner code location.

In this case, it seems simpler to just use the toplevel enclosing code location rather than the co_firstlineno field.

Test Plan:
test_package.py -k test_code_with_generator

Rollback Plan:

Differential Revision: D81929751




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela