### PR TITLE
[SymmMem] Use global pe for put and get

### DIFF
--- a/test/distributed/test_nvshmem.py
+++ b/test/distributed/test_nvshmem.py
@@ -629,9 +629,11 @@ class NVSHMEMAll2AllTest(MultiProcContinuousTest):
     @skipIfRocm
     @parametrize("align", [1, 8, 16])  # `major_align` of output
     def test_dispatch_combine(self, align: int) -> None:
+        """
+        Test dispatch-and-combine over World group
+        """
         torch.manual_seed(42 + self.rank)
         self._init_device()
-        # Test on World
         self.helper_test_dispatch_combine(align, dist.group.WORLD.group_name)
 
     @skipIfRocm
@@ -639,6 +641,9 @@ class NVSHMEMAll2AllTest(MultiProcContinuousTest):
     # failure
     @skip_if_lt_x_gpu(4)
     def test_dispatch_combine_subgroup(self) -> None:
+        """
+        Test dispatch-and-combine over concurrent subgroups
+        """
         torch.manual_seed(42 + self.rank)
         self._init_device()
         symm_mem.enable_symm_mem_for_group(dist.group.WORLD.group_name)

--- a/test/distributed/test_nvshmem.py
+++ b/test/distributed/test_nvshmem.py
@@ -7,7 +7,11 @@
 import torch
 import torch.distributed as dist
 import torch.distributed._symmetric_memory as symm_mem
-from torch.testing._internal.common_distributed import MultiProcContinuousTest
+from torch.distributed.device_mesh import init_device_mesh
+from torch.testing._internal.common_distributed import (
+    MultiProcContinuousTest,
+    skip_if_lt_x_gpu,
+)
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -544,17 +548,11 @@ class NVSHMEMAll2AllTest(MultiProcContinuousTest):
         # Check data
         torch.testing.assert_close(out_expected, out[:out_numel])
 
-    @skipIfRocm
-    @parametrize("align", [1, 8, 16])  # `major_align` of output
-    def test_shuffle_combine(self, align: int) -> None:
+    def helper_test_dispatch_combine(self, align: int, group_name) -> None:
         """
         Shuffle the tokens, then combine them, and check if the combined data is
         exactly the same as the original input data
         """
-        torch.manual_seed(42 + self.rank)
-        self._init_device()
-
-        group_name = dist.group.WORLD.group_name
         symm_mem.enable_symm_mem_for_group(group_name)
 
         dtype = torch.float
@@ -627,6 +625,31 @@ class NVSHMEMAll2AllTest(MultiProcContinuousTest):
             [torch.zeros(1, device=self.device), inp_offsets[:-1]]
         ).to(torch.int64)
         torch.testing.assert_close(combine_out_splits_offsets[1], inp_offsets)
+
+    @skipIfRocm
+    @parametrize("align", [1, 8, 16])  # `major_align` of output
+    def test_dispatch_combine(self, align: int) -> None:
+        torch.manual_seed(42 + self.rank)
+        self._init_device()
+        # Test on World
+        self.helper_test_dispatch_combine(align, dist.group.WORLD.group_name)
+
+    @skipIfRocm
+    # TODO: FIXIT. Currently, `MultiProcContinuousTest` treats the skip code as a
+    # failure
+    @skip_if_lt_x_gpu(4)
+    def test_dispatch_combine_subgroup(self) -> None:
+        torch.manual_seed(42 + self.rank)
+        self._init_device()
+        symm_mem.enable_symm_mem_for_group(dist.group.WORLD.group_name)
+        # Test on two concurrent subgroups
+        ngroups = 2
+        subgroup_size = self.world_size // ngroups
+        dm = init_device_mesh(
+            device_type, (ngroups, subgroup_size), mesh_dim_names=("dp", "ep")
+        )
+        subgroup = dm.get_group("ep")
+        self.helper_test_dispatch_combine(align=8, group_name=subgroup.group_name)
 
 
 if __name__ == "__main__":

--- a/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cu
@@ -180,15 +180,19 @@ __device__ int64_t prefixSum(int64_t *odata, int64_t *idata, int n) {
 // - input splits (IN)
 // - output splits (OUT) and
 // - source offsets (OUT).
-__global__ void exchangeSplitAndOffset(int64_t* in_out_splits, int mype, int npes) {
+__global__ void exchangeSplitAndOffset(int64_t* in_out_splits, nvshmem_team_t team) {
 #ifndef _NVSHMEM_DEVICELIB_SUPPORTED
   CUDA_KERNEL_ASSERT_MSG(false, "SM arch unsupported for NVSHMEM");
 #else
+  CUDA_KERNEL_ASSERT(team != NVSHMEM_TEAM_INVALID);
+  int mype = nvshmem_team_my_pe(team);
+  int npes = nvshmem_team_n_pes(team);
   auto input_splits = in_out_splits;
   auto output_splits = in_out_splits + npes;
   auto source_offsets = in_out_splits + npes * 2;
   int tid = threadIdx.x;
 
+  CUDA_KERNEL_ASSERT(npes <= THREADS_PER_BLOCK);
   __shared__ int64_t peer_offsets[THREADS_PER_BLOCK];
 
   // Scan input splits to get the source offsets
@@ -197,9 +201,10 @@ __global__ void exchangeSplitAndOffset(int64_t* in_out_splits, int mype, int npe
 
   // Use 1 block to do the exchange
   if (tid < npes) {
-    int peer = tid;
-    nvshmem_int64_p(source_offsets + mype, peer_offsets[peer], peer);
-    nvshmem_int64_p(output_splits + mype, input_splits[peer], peer);
+    // tid is peer index within team, but put calls require global rank
+    int peer_global = nvshmem_team_translate_pe(team, tid, NVSHMEM_TEAM_WORLD);
+    nvshmem_int64_p(source_offsets + mype, peer_offsets[tid], peer_global);
+    nvshmem_int64_p(output_splits + mype, input_splits[tid], peer_global);
   }
   // This barrier ensures that all remote PEs see the updated values
   nvshmemx_barrier_all_block();
@@ -209,10 +214,13 @@ __global__ void exchangeSplitAndOffset(int64_t* in_out_splits, int mype, int npe
 // This kernel is used to do the actual data exchange.
 // `in_out_splits` has the same definition as in `exchangeSplitAndOffset`.
 // `stride` is the stride at dim 0, unit in byte.
-__global__ void allToAllV(void *send_data, void *recv_data, int64_t* in_out_splits, size_t stride, int mype, int npes) {
+__global__ void allToAllV(void *send_data, void *recv_data, int64_t* in_out_splits, size_t stride, nvshmem_team_t team) {
 #ifndef _NVSHMEM_DEVICELIB_SUPPORTED
   CUDA_KERNEL_ASSERT_MSG(false, "SM arch unsupported for NVSHMEM");
 #else
+  CUDA_KERNEL_ASSERT(team != NVSHMEM_TEAM_INVALID);
+  int mype = nvshmem_team_my_pe(team);
+  int npes = nvshmem_team_n_pes(team);
   auto output_splits = in_out_splits + npes;
   auto source_offsets = in_out_splits + npes * 2;
   int bid = blockIdx.x;
@@ -220,6 +228,7 @@ __global__ void allToAllV(void *send_data, void *recv_data, int64_t* in_out_spli
   int blocks_per_peer = max(gridDim.x / npes, 1);
 
   // Calculate the output offsets
+  CUDA_KERNEL_ASSERT(npes <= THREADS_PER_BLOCK);
   __shared__ int64_t peer_offsets[THREADS_PER_BLOCK];
   prefixSum(peer_offsets, output_splits, npes);
   __syncthreads();
@@ -227,6 +236,7 @@ __global__ void allToAllV(void *send_data, void *recv_data, int64_t* in_out_spli
   // Target a different peer based on bid
   for (int i = bid / blocks_per_peer; i < npes; i += gridDim.x / blocks_per_peer) {
     int peer = (mype + i) % npes;
+    auto peer_global = nvshmem_team_translate_pe(team, peer, NVSHMEM_TEAM_WORLD);
     // Total amount from `peer`
     auto peer_size = output_splits[peer] * stride;
     // Amount to get from `peer` in this block
@@ -241,7 +251,7 @@ __global__ void allToAllV(void *send_data, void *recv_data, int64_t* in_out_spli
       (char*)recv_data + write_offset,
       (char*)send_data + source_offset,
       block_size,
-      peer);
+      peer_global);
   }
   // Write out the output offsets (to the scratchpad line)
   if (bid == 0 && tid < npes) {
@@ -276,14 +286,18 @@ at::Tensor all_to_all_vdev(
   void* output_ptr = out.mutable_data_ptr();
   int64_t* splits_ptr = (int64_t*)(in_out_splits.mutable_data_ptr());
 
-  auto stream = at::cuda::getCurrentCUDAStream(input.device().index());
+  TORCH_CHECK(input.device() == out.device());
+  auto device = input.device();
+  c10::cuda::CUDAGuard guard(device);
+  auto& team_manager = TeamManager::get(device);
+  auto team = team_manager.get_team(group_name, input_hdl->get_rank_to_global_rank());
+  auto stream = at::cuda::getCurrentCUDAStream(device.index());
 
   // Exchange output splits and source offsets
   // Use collective launch because kernel involves nvshmem barrier
   void* args0[] = {
       &splits_ptr,
-      &rank,
-      &world_size};
+      &team};
   nvshmemx_collective_launch(
       (const void*)exchangeSplitAndOffset,
       dim3(1),
@@ -325,8 +339,7 @@ at::Tensor all_to_all_vdev(
       &output_ptr,
       &splits_ptr,
       &stride_bytes,
-      &rank,
-      &world_size};
+      &team};
   nvshmemx_collective_launch(
       (const void*)allToAllV,
       dim3(num_blocks),
@@ -357,10 +370,13 @@ at::Tensor all_to_all_vdev(
 */
 
 template <bool HAS_IN_OFFSETS>
-__global__ void exchangeSplitAndOffset_2d(int64_t* in_splits_offsets, int64_t* out_splits_offsets, int mype, int npes, int ne, size_t input_dim0, bool rank_is_row_in) {
+__global__ void exchangeSplitAndOffset_2d(int64_t* in_splits_offsets, int64_t* out_splits_offsets, nvshmem_team_t team, int ne, size_t input_dim0, bool rank_is_row_in) {
 #ifndef _NVSHMEM_DEVICELIB_SUPPORTED
   CUDA_KERNEL_ASSERT_MSG(false, "SM arch unsupported for NVSHMEM");
 #else
+  CUDA_KERNEL_ASSERT(team != NVSHMEM_TEAM_INVALID);
+  int mype = nvshmem_team_my_pe(team);
+  int npes = nvshmem_team_n_pes(team);
   int nsplits = npes * ne;
   auto input_splits = in_splits_offsets;
   auto output_splits = out_splits_offsets;
@@ -399,8 +415,9 @@ __global__ void exchangeSplitAndOffset_2d(int64_t* in_splits_offsets, int64_t* o
     // (or vice versa).
     auto split_val = input_splits[tid];
     CUDA_KERNEL_ASSERT(split_val >= 0 && "split value is negative\n");
-    nvshmem_int64_p(source_offsets + dst_offset, input_offsets[tid], peer);
-    nvshmem_int64_p(output_splits + dst_offset, split_val, peer);
+    auto peer_global = nvshmem_team_translate_pe(team, peer, NVSHMEM_TEAM_WORLD);
+    nvshmem_int64_p(source_offsets + dst_offset, input_offsets[tid], peer_global);
+    nvshmem_int64_p(output_splits + dst_offset, split_val, peer_global);
   }
   // This barrier ensures that all remote PEs see the updated values
   nvshmemx_barrier_all_block();
@@ -453,7 +470,7 @@ __device__ int64_t prefixSum_warp(int64_t *odata, int64_t *idata, int n) {
 // In dispatch case, rank_is_row_out = false, major_size = ne, minor_size = npes.
 // In combine case, rank_is_row_out = true, major_size = npes, minor_size = ne.
 
-__global__ void allToAllV_2d(void *send_data, void *recv_data, int64_t* in_splits, int64_t* out_splits_offsets, size_t stride, int minor_size, int major_size, int64_t major_align, bool rank_is_row_out) {
+__global__ void allToAllV_2d(void *send_data, void *recv_data, int64_t* in_splits, int64_t* out_splits_offsets, size_t stride, int minor_size, int major_size, int64_t major_align, bool rank_is_row_out, nvshmem_team_t team) {
 #ifndef _NVSHMEM_DEVICELIB_SUPPORTED
   CUDA_KERNEL_ASSERT_MSG(false, "SM arch unsupported for NVSHMEM");
 #else
@@ -525,11 +542,12 @@ __global__ void allToAllV_2d(void *send_data, void *recv_data, int64_t* in_split
     auto source_offset = source_offsets[eid] * stride;
     auto e_offset = tile_prefix_sums[row][col];
     auto write_offset = e_offset * stride;
+    auto peer_global = nvshmem_team_translate_pe(team, rank_is_row_out ? row : col, NVSHMEM_TEAM_WORLD);
     nvshmemx_getmem_nbi_block(
       (char*)recv_data + write_offset,
       (char*)send_data + source_offset,
       peer_size,
-      rank_is_row_out ? row : col);  // peer
+      peer_global);  // peer's global index
   }
   // Write out the output offsets (to the scratchpad line)
   if (bid == 0 && tid < nsplits) {
@@ -638,6 +656,8 @@ void all_to_all_vdev_2d(
       "all tensor arguments must be on the same CUDA device");
   c10::cuda::CUDAGuard guard(device);
   auto stream = at::cuda::getCurrentCUDAStream();
+  auto& team_manager = TeamManager::get(device);
+  auto team = team_manager.get_team(group_name, input_hdl->get_rank_to_global_rank());
 
   // Exchange output splits and source offsets
   auto input_dim0 = input.size(0);
@@ -646,8 +666,7 @@ void all_to_all_vdev_2d(
   void* args0[] = {
       &in_splits_ptr,
       &out_splits_offsets_ptr,
-      &rank,
-      &world_size,
+      &team,
       &ne,
       &input_dim0,
       &rank_is_row_in};
@@ -678,7 +697,8 @@ void all_to_all_vdev_2d(
       &world_size,
       &ne,
       &major_align_val,
-      &rank_is_row_out};
+      &rank_is_row_out,
+      &team};
   nvshmemx_collective_launch(
       (const void*)allToAllV_2d,
       dim3(num_blocks),
@@ -771,6 +791,8 @@ void all_to_all_vdev_2d_offset(
       "all tensor arguments must be on the same CUDA device");
   c10::cuda::CUDAGuard guard(device);
   auto stream = at::cuda::getCurrentCUDAStream();
+  auto& team_manager = TeamManager::get(device);
+  auto team = team_manager.get_team(group_name, input_hdl->get_rank_to_global_rank());
 
   // Exchange output splits and source offsets
   auto input_dim0 = input.size(0);
@@ -779,8 +801,7 @@ void all_to_all_vdev_2d_offset(
   void* args0[] = {
       &in_splits_offsets_ptr,
       &out_splits_offsets_ptr,
-      &rank,
-      &world_size,
+      &team,
       &ne,
       &input_dim0,
       &rank_is_row_in};
@@ -811,7 +832,8 @@ void all_to_all_vdev_2d_offset(
       &ne,
       &world_size,
       &major_align_val,
-      &rank_is_row_out};
+      &rank_is_row_out,
+      &team};
   nvshmemx_collective_launch(
       (const void*)allToAllV_2d,
       dim3(num_blocks),

--- a/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cu
@@ -286,7 +286,7 @@ at::Tensor all_to_all_vdev(
   void* output_ptr = out.mutable_data_ptr();
   int64_t* splits_ptr = (int64_t*)(in_out_splits.mutable_data_ptr());
 
-  TORCH_CHECK(input.device() == out.device());
+  TORCH_CHECK_EQ(input.device(), out.device());
   auto device = input.device();
   c10::cuda::CUDAGuard guard(device);
   auto& team_manager = TeamManager::get(device);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #162394
* #162320

NVSHMEM put/get APIs take global PE instead of local counterpart. So we'd need to do a translation within the kernel.

Also added a sub-group test for dispatch and combine mimic'ing the Expert Parallel cases.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim