### PR TITLE
Validate file and handle exceptions for weights_only unpickler

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -1241,6 +1241,21 @@ class TestSerialization(TestCase, SerializationMixin):
             )
             torch.load(checkpoint, weights_only=True)
 
+    def test_weights_only_unpickler_error_handling(self):
+        # Check validation for too short files for unpickler
+        data_too_short = b'\x80\x02\x8a\x0a\x6c\xfc\x9c\x46\xf9\x20\x6a\xa8\x50\x19\x2e\x80'
+        buf = io.BytesIO(data_too_short)
+        with self.assertRaisesRegex(pickle.UnpicklingError, "file is too short: corrupt file?"):
+            torch.load(buf, weights_only=True)
+
+        # Check execptions are handled for corrupted ops unpickling
+        data_corrupted_ops = (b'\x80\x02\x8a\x0a\x6c\xfc\x9c\x46\xf9\x20\x6a\xa8\x50\x19\x2e\x80'
+                              b'\x02\x4d\xe9\x03\x2e\x80\x02\x75\x78\x0b\x00\x03\x50\x4b\x03\x04'
+                              b'\x0a\x00\x00\x40\x00\x00\x2a')
+        buf = io.BytesIO(data_corrupted_ops)
+        with self.assertRaisesRegex(pickle.UnpicklingError, "Unable to unpickle file due to error: pop from empty list"):
+            torch.load(buf, weights_only=True)
+
     def test_weights_only_assert(self):
         class HelloWorld:
             def __reduce__(self):

--- a/torch/_weights_only_unpickler.py
+++ b/torch/_weights_only_unpickler.py
@@ -573,4 +573,7 @@ class Unpickler:
 
 
 def load(file, *, encoding: str = "ASCII"):
-    return Unpickler(file, encoding=encoding).load()
+    try:
+        return Unpickler(file, encoding=encoding).load()
+    except Exception as e:
+        raise RuntimeError(f"Unable to unpickle file due to error: {e}") from e

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -1799,6 +1799,16 @@ def _legacy_load(f, map_location, pickle_module, **pickle_load_args):
             # if not a tarfile, reset file offset and proceed
             f.seek(0)
 
+    start = f.tell()
+    f.seek(0, 2)
+    file_size = f.tell()
+    # Check that file is long enough to contain magic number and
+    # protocol version: 10 bytes for MAGIC_NUMBER, 2 bytes for
+    # PROTOCOL_VERSION, 8 bytes for unpickling operators.
+    if file_size < 20:
+        raise RuntimeError("file is too short: corrupt file?")
+    f.seek(start)
+
     magic_number = pickle_module.load(f, **pickle_load_args)
     if magic_number != MAGIC_NUMBER:
         raise RuntimeError("Invalid magic number; corrupt file?")


### PR DESCRIPTION
Fixes #127525

Fixing a lot of unhandled exceptions raised from weights_only model loading:

 - Validate file size to be able to contain at least magic number and protocol version
 - Also catch all exceptions from unpickler due to inconsistent operators interpretation.

A previous PR #127526 was closed, but the changes didn't get into main.
