### PR TITLE
fix input_put_ for torch.compile

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -7720,6 +7720,23 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         self.assertTrue(same(arg1, arg2))
         self.assertTrue(same(arg3, arg4))
 
+    def test_select_scatter_mutation_consistency(self):
+        def foo(x):
+            x[0].sin_()
+            x[1].sin_()
+            y = torch.zeros_like(x)
+            y[2] = x[0]
+            y[3] = x[1]
+            return y
+
+        x1 = torch.tensor(
+            [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]], dtype=torch.float32
+        )
+        x2 = x1.clone()
+        eager_result = foo(x1)
+        compiled_result = torch.compile(foo)(x2)
+        self.assertTrue(same(eager_result, compiled_result))
+
     def test_input_mutation2(self):
         def fn(a):
             b = a + 1

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3018,10 +3018,6 @@ def select_scatter(x, src, dim: int, index: int):
 
 @register_lowering(aten.slice_scatter, type_promotion_kind=None)
 def slice_scatter(x, src, dim=0, start=None, end=None, step=1):
-    if hasattr(src, "realize"):
-        src.realize()
-    if hasattr(x, "realize"):
-        x.realize()
     src = to_dtype(src, x.get_dtype())
     x_loader = x.make_loader()
     dim = _validate_dim(x, dim, 0)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2985,6 +2985,10 @@ def iota(
 @register_lowering(aten.select_scatter, type_promotion_kind=None)
 def select_scatter(x, src, dim: int, index: int):
     assert x.get_dtype() == src.get_dtype()
+    if hasattr(src, "realize"):
+        src.realize()
+    if hasattr(x, "realize"):
+        x.realize()
     x_loader = x.make_loader()
     dim = _validate_dim(x, dim, 0)
     if V.graph.sizevars.evaluate_expr(sympy.Lt(index, 0)):
@@ -3014,6 +3018,10 @@ def select_scatter(x, src, dim: int, index: int):
 
 @register_lowering(aten.slice_scatter, type_promotion_kind=None)
 def slice_scatter(x, src, dim=0, start=None, end=None, step=1):
+    if hasattr(src, "realize"):
+        src.realize()
+    if hasattr(x, "realize"):
+        x.realize()
     src = to_dtype(src, x.get_dtype())
     x_loader = x.make_loader()
     dim = _validate_dim(x, dim, 0)


### PR DESCRIPTION
Fixes #162146 

### Summary

Torch.compile was not synchronizing the mutations properly.

- Without realize(), the inductor creates inconsistent execution plans where mutations to tensor slices don't propagate correctly
- This leads to differences between eager mode and compiled mode results

Impacts:
module: inductor




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben