### PR TITLE
[fx] fix qualified name for methods of torch.Tensor

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2998,7 +2998,7 @@ class CommonTemplate:
         x = torch.rand(10)
 
         with x.device:
-            out = torch.compile(fn)(x)
+            out = torch.compile(fn, backend=lambda gm, _: gm)(x)
             ref = fn(x)
             for a, b in zip(out, ref):
                 self.assertTrue(torch.allclose(a, b))

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -155,7 +155,7 @@ def _get_qualified_name(func: Callable[..., Any]) -> str:
         isinstance(func, (types.MethodDescriptorType, types.WrapperDescriptorType))
         and func is getattr(torch.Tensor, func.__name__, None)
     ) or (
-        func.__module__ == torch._tensor
+        func.__module__ == torch._tensor.__name__
         and func.__qualname__ == f"Tensor.{func.__name__}"
     ):
         return f"torch.Tensor.{func.__name__}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #162407

This fixes an error in the previous PR.

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben