### PR TITLE
Revert "simplify nvrtc discovery login in compile_kernel (#156674)"

### DIFF
--- a/torch/cuda/_utils.py
+++ b/torch/cuda/_utils.py
@@ -10,25 +10,11 @@ from torch._utils import _get_device_index as _torch_get_device_index
 
 
 def _get_nvrtc_version(cuda_version: int) -> str:
-    # TODO: Expose this from native code
-    # Follows same logic as LazyNVRTC.cpp getLibVersion()
     major = cuda_version // 1000
-    minor = (cuda_version // 10) % 10
-
     if sys.platform == "win32":
-        if major < 11 or (major == 11 and minor < 3):
-            return f"{major}{minor}"
-        elif major == 11:
-            return "112"
-        else:
-            return f"{major}0"
+        return f"{major}0"
     else:
-        if major < 11 or (major == 11 and minor < 3):
-            return f"{major}.{minor}"
-        elif major == 11:
-            return "11.2"
-        else:
-            return str(major)
+        return str(major)
 
 
 # Load CUDA driver and NVRTC

--- a/torch/cuda/_utils.py
+++ b/torch/cuda/_utils.py
@@ -1,4 +1,5 @@
 import ctypes
+import os
 import sys
 from typing import Any, Optional, Union
 
@@ -6,6 +7,28 @@ import torch
 
 # The _get_device_index has been moved to torch.utils._get_device_index
 from torch._utils import _get_device_index as _torch_get_device_index
+
+
+def _get_nvrtc_version(cuda_version: int) -> str:
+    # TODO: Expose this from native code
+    # Follows same logic as LazyNVRTC.cpp getLibVersion()
+    major = cuda_version // 1000
+    minor = (cuda_version // 10) % 10
+
+    if sys.platform == "win32":
+        if major < 11 or (major == 11 and minor < 3):
+            return f"{major}{minor}"
+        elif major == 11:
+            return "112"
+        else:
+            return f"{major}0"
+    else:
+        if major < 11 or (major == 11 and minor < 3):
+            return f"{major}.{minor}"
+        elif major == 11:
+            return "11.2"
+        else:
+            return str(major)
 
 
 # Load CUDA driver and NVRTC
@@ -30,12 +53,51 @@ def _check_cuda(result: int) -> None:
 
 
 def _get_nvrtc_library() -> ctypes.CDLL:
-    # Since PyTorch already loads NVRTC, we can use the system library
-    # which should be compatible with PyTorch's version
+    # Get NVRTC version based on CUDA runtime version
+    # Use an alternative approach to get the CUDA version
+    # since cudart().getVersion() is failing
+    import torch
+
+    try:
+        import torch.cuda
+
+        cuda_runtime_version = torch.cuda.cudart().getVersion()
+    except (ImportError, AttributeError):
+        # Fallback: if we have CUDA available, get version from device properties
+        if hasattr(torch, "cuda") and torch.cuda.is_available():
+            # Import locally to avoid circular imports
+            import torch.cuda
+
+            props = torch.cuda.get_device_properties(torch.cuda.current_device())
+            cuda_runtime_version = props.major * 1000 + props.minor * 10
+        else:
+            # Hardcode a default CUDA version if all else fails
+            cuda_runtime_version = 12000  # Assume CUDA 12.0 as default
+
+    version = _get_nvrtc_version(cuda_runtime_version)
+
     if sys.platform == "win32":
-        return ctypes.CDLL("nvrtc64_120_0.dll")
+        # Windows handling remains the same
+        lib_name = f"nvrtc64_{version}_0.dll"
+        return ctypes.CDLL(lib_name)
     else:
-        return ctypes.CDLL("libnvrtc.so")
+        lib_paths = [
+            f"libnvrtc.so.{version}",
+            os.path.join(
+                os.environ.get("CUDA_HOME", ""), f"lib64/libnvrtc.so.{version}"
+            ),
+            "/usr/local/cuda/lib64/libnvrtc.so",
+        ]
+
+        for path in lib_paths:
+            try:
+                return ctypes.CDLL(path)
+            except OSError:
+                continue
+
+        raise RuntimeError(
+            "Could not find libnvrtc.so. Please make sure CUDA is installed."
+        )
 
 
 def _nvrtc_compile(


### PR DESCRIPTION
This reverts commit 4e8dd11. Also removing cuda 11 logic.
Since we have cuda 12 and cuda 13 builds now. Lib name should be: ``lib_name = f"nvrtc64_{version}_0.dll"`` or ``f"lib64/libnvrtc.so.{version}"``

