### PR TITLE
[standalone_compile] binary format write should be atomic

### DIFF
--- a/torch/_inductor/standalone_compile.py
+++ b/torch/_inductor/standalone_compile.py
@@ -10,7 +10,6 @@ from typing import Any, Callable, Literal, Optional, TYPE_CHECKING
 
 import torch.fx
 from torch._dynamo.utils import dynamo_timed
-from torch._inductor.codecache import write_atomic
 from torch._inductor.cpp_builder import normalize_path_separator
 from torch._inductor.cudagraph_utils import BoxedDeviceIndex
 from torch._inductor.runtime.cache_dir_utils import temporary_cache_dir
@@ -87,6 +86,9 @@ class CompiledArtifact:
                 writer.write_bytes(torch_key())
                 writer.write_str(key)
                 writer.write_bytes(artifact_bytes)
+
+                from torch._inductor.codecache import write_atomic
+
                 write_atomic(path, writer.to_bytes())
             else:
                 assert format == "unpacked"

--- a/torch/_inductor/standalone_compile.py
+++ b/torch/_inductor/standalone_compile.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Literal, Optional, TYPE_CHECKING
 
 import torch.fx
 from torch._dynamo.utils import dynamo_timed
+from torch._inductor.codecache import write_atomic
 from torch._inductor.cpp_builder import normalize_path_separator
 from torch._inductor.cudagraph_utils import BoxedDeviceIndex
 from torch._inductor.runtime.cache_dir_utils import temporary_cache_dir
@@ -86,8 +87,7 @@ class CompiledArtifact:
                 writer.write_bytes(torch_key())
                 writer.write_str(key)
                 writer.write_bytes(artifact_bytes)
-                with open(path, "wb") as file:
-                    file.write(writer.to_bytes())
+                write_atomic(path, writer.to_bytes())
             else:
                 assert format == "unpacked"
                 if os.path.exists(path):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #162432

We update it to call write_atomic instead of file.write

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @mlazos