### PR TITLE
[pre_compile] Add check for cuda and hardware version

### DIFF
--- a/torch/_dynamo/aot_compile.py
+++ b/torch/_dynamo/aot_compile.py
@@ -1,5 +1,6 @@
 import abc
 import builtins
+import dataclasses
 import importlib
 import inspect
 import logging
@@ -10,7 +11,8 @@ from typing import Any, Callable, Optional
 
 import torch
 import torch.fx
-from torch._dynamo.precompile_context import PrecompileContext
+from torch._dynamo.graph_utils import _graph_uses_non_cpu
+from torch._dynamo.precompile_context import PrecompileContext, SystemInfo
 
 from . import convert_frame
 from .hooks import Hooks
@@ -50,6 +52,12 @@ class CompileArtifacts:
     compiled_fn: SerializableCallable
     original_code: types.CodeType
     closure: Optional[tuple[Any, ...]]
+    use_cuda: bool
+    system_info: SystemInfo = dataclasses.field(default_factory=SystemInfo.current)
+
+    def check_compatibility(self) -> None:
+        current_system = SystemInfo.current()
+        current_system.check_compatibility(self.system_info, self.use_cuda)
 
 
 @dataclass
@@ -62,6 +70,8 @@ class AOTCompiledFunction:
         return self._artifacts.guard_manager.check(f_locals)
 
     def __post_init__(self) -> None:
+        self._artifacts.check_compatibility()
+
         import_sources = {
             alias: importlib.import_module(module_name)
             for alias, module_name in self._artifacts.import_sources.items()
@@ -258,6 +268,8 @@ def aot_compile_fullgraph(
     backend_input.graph_module._backend_id = backend_input.backend_id  # type: ignore[assignment]
     output_graph = dynamo_output.tracer_output.output_graph
     assert output_graph is not None
+    use_cuda = _graph_uses_non_cpu(output_graph.current_tracer.graph)
+
     import_sources = output_graph.import_sources
     with (
         torch._guards.tracing(TracingContext(backend_input.fake_mode)),
@@ -292,6 +304,7 @@ def aot_compile_fullgraph(
         compiled_fn=compiled_fn,
         original_code=fn.__code__,
         closure=fn.__closure__,
+        use_cuda=use_cuda,
     )
     aot_compiled_fn = AOTCompiledFunction(_artifacts=artifacts)
     return aot_compiled_fn

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1259,6 +1259,7 @@ def _compile(
             assert check_fn.guards_state is not None
             package.add_guarded_code(check_fn.guards_state, out_code)
             package.add_inlined_source(output.tracing_context.traced_code)
+            package.update_use_cuda(output.current_tracer.graph)
 
         compile_id_str = str(compile_id) if compile_id is not None else "Unknown"
         annotation_str = "Torch-Compiled Region: " + compile_id_str

--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -19,7 +19,6 @@ import inspect
 import logging
 import os
 import pickle
-import platform
 import shutil
 import sys
 import types
@@ -30,7 +29,12 @@ from typing_extensions import Never
 import torch
 import torch._inductor.package
 from torch._dynamo.exc import PackageError
-from torch._dynamo.precompile_context import PrecompileCacheArtifact, PrecompileContext
+from torch._dynamo.graph_utils import _graph_uses_non_cpu
+from torch._dynamo.precompile_context import (
+    PrecompileCacheArtifact,
+    PrecompileContext,
+    SystemInfo,
+)
 from torch._inductor.runtime.cache_dir_utils import cache_dir
 from torch.compiler._cache import CacheArtifactFactory
 
@@ -275,12 +279,17 @@ def _get_code_source(code: types.CodeType) -> tuple[str, str]:
 class _DynamoCacheEntry:
     codes: list[_DynamoCodeCacheEntry]
     inlined_sources: set[InlinedSource]
-    python_version: str = platform.python_version()
-    torch_version: str = torch.__version__
+    use_cuda: bool
+    system_info: SystemInfo = dataclasses.field(default_factory=SystemInfo.current)
 
     @property
     def backend_ids(self) -> set[_BackendId]:
         return {backend_id for code in self.codes for backend_id in code.backend_ids}
+
+    def check_versions(self) -> None:
+        """Check if the current system is compatible with the system used to create this cache entry."""
+        current_system_info = SystemInfo.current()
+        self.system_info.check_compatibility(current_system_info, self.use_cuda)
 
 
 @CacheArtifactFactory.register
@@ -369,6 +378,8 @@ class CompilePackage:
 
         self._current_entry: Optional[_DynamoCodeCacheEntry] = None
         self._installed_globals: dict[types.ModuleType, list[str]] = {}
+        # whether cuda is used
+        self._use_cuda = False
 
         # For debugging/testing purpose only.
         self._cached_backends: dict[_BackendId, Any] = {}
@@ -397,14 +408,7 @@ class CompilePackage:
         assert self._innermost_fn is not None
         if dynamo is not None:
             assert isinstance(dynamo, _DynamoCacheEntry)
-            if dynamo.python_version != platform.python_version():
-                raise RuntimeError(
-                    f"Compile package was created with a different Python version: {dynamo.python_version}"
-                )
-            if dynamo.torch_version != torch.__version__:
-                raise RuntimeError(
-                    f"Compile package was created with a different PyTorch version: {dynamo.torch_version}"
-                )
+            dynamo.check_versions()
             if not ignore_inlined_sources:
                 for code in dynamo.inlined_sources:
                     m = importlib.import_module(code.module)
@@ -534,6 +538,9 @@ class CompilePackage:
                     checksum=_hash_source(source),
                 )
             )
+
+    def update_use_cuda(self, graph: Optional[torch.fx.Graph]) -> None:
+        self._use_cuda = _graph_uses_non_cpu(graph)
 
     def bypass_current_entry(self) -> None:
         assert self._current_entry is not None
@@ -671,7 +678,9 @@ class CompilePackage:
     def cache_entry(self) -> _DynamoCacheEntry:
         self.validate()
         return _DynamoCacheEntry(
-            codes=list(self._codes.values()), inlined_sources=self._inlined_sources
+            codes=list(self._codes.values()),
+            inlined_sources=self._inlined_sources,
+            use_cuda=self._use_cuda,
         )
 
     @staticmethod

--- a/torch/_dynamo/precompile_context.py
+++ b/torch/_dynamo/precompile_context.py
@@ -1,12 +1,15 @@
 import copy
+import dataclasses
 import logging
 import pickle
+import platform
 from abc import abstractmethod
 from collections import defaultdict
 from itertools import chain
 from typing import Any, Callable, Generic, Optional, TypeVar, Union
 from typing_extensions import override
 
+import torch
 from torch.compiler._cache import (
     _serialize_single_cache,
     CacheArtifact,
@@ -17,6 +20,7 @@ from torch.compiler._cache import (
 )
 from torch.utils._appending_byte_serializer import AppendingByteSerializer
 from torch.utils._ordered_set import OrderedSet
+from torch.utils._triton import get_triton_version
 
 
 """
@@ -243,3 +247,76 @@ class PrecompileContext(CacheArtifactManager):
         from torch._functorch._aot_autograd.autograd_cache import (  # noqa: F401
             BundledAOTAutogradCacheArtifact,
         )
+
+
+@dataclasses.dataclass(frozen=True)
+class SystemInfo:
+    """
+    System information including Python, PyTorch, and GPU details.
+    This information is used to ensure compiled artifacts can only be loaded
+    with compatible system configurations.
+    """
+
+    python_version: str
+    torch_version: str
+    cuda_version: Optional[str]
+    triton_version: Optional[tuple[int, int]]
+    gpu_name: Optional[str]
+
+    @classmethod
+    def current(cls) -> "SystemInfo":
+        """Create a SystemInfo instance with current system information."""
+        # Get GPU name if CUDA is available
+        gpu_name = None
+        if torch.cuda.is_available():
+            try:
+                gpu_name = torch.cuda.get_device_name()
+            except Exception:
+                # If we can't get GPU info, leave as None
+                pass
+
+        return cls(
+            python_version=platform.python_version(),
+            torch_version=torch.__version__,
+            cuda_version=torch.version.cuda,
+            triton_version=get_triton_version((0, 0)),
+            gpu_name=gpu_name,
+        )
+
+    def check_compatibility(self, other: "SystemInfo", use_cuda: bool = False) -> None:
+        """
+        Check if this SystemInfo is compatible with another SystemInfo.
+        Raises RuntimeError if incompatible.
+        """
+        if self.python_version != other.python_version:
+            raise RuntimeError(
+                f"Compile package was created with a different Python version: {self.python_version}"
+            )
+
+        if self.torch_version != other.torch_version:
+            raise RuntimeError(
+                f"Compile package was created with a different PyTorch version: {self.torch_version}"
+            )
+
+        if use_cuda:
+            if not torch.cuda.is_available():
+                raise RuntimeError("CUDA is not available")
+            if self.cuda_version != other.cuda_version:
+                raise RuntimeError(
+                    f"Compile package was created with a different CUDA version: {self.cuda_version}"
+                )
+
+            if (
+                other.triton_version != (0, 0)
+                and self.triton_version != other.triton_version
+            ):
+                raise RuntimeError(
+                    f"Compile package was created with a different Triton version: {self.triton_version}"
+                )
+
+            # Check GPU name if CUDA was used
+            if other.gpu_name is not None and self.gpu_name != other.gpu_name:
+                raise RuntimeError(
+                    f"Compile package was created with different GPU: "
+                    f"cached={self.gpu_name}, current={other.gpu_name}"
+                )


### PR DESCRIPTION
 if we detect compiled model is using cuda in meaningful way, we should store information about cuda + hardware
 
 Example: `SystemInfo(python_version='3.12.9', torch_version='2.9.0a0+gite02b0e6', cuda_version='12.6', triton_version=(3, 4), gpu_name='NVIDIA PG509-210')`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela