### PR TITLE
Use upper bound for persistent rblock

### DIFF
--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -9,6 +9,7 @@ import unittest
 from functools import partial
 
 import torch
+from torch._inductor.choices import InductorChoices
 import torch.library
 from torch._dynamo.testing import CompileCounterWithBackend, make_test_cls_with_patches
 from torch._inductor import metrics
@@ -1077,6 +1078,39 @@ class TestInductorDynamic(TestCase):
         self.assertEqual(fn(x, 3.0), fn_opt(x, 3.0))
         self.assertEqual(fn(x, 4.0), fn_opt(x, 4.0))
         self.assertEqual(cnt.frame_count, 2)
+
+    @onlyOn(GPU_TYPE)
+    def test_dynamic_rblock_bounds(self):
+
+        class ForcePersistent(InductorChoices):
+
+            @staticmethod
+            def should_use_cooperative_reduction(*args, **kwargs) -> bool:
+                return False
+
+            @staticmethod
+            def should_use_persistent_reduction(*args, **kwargs) -> bool:
+                return True
+
+        def fn(x):
+            return x.sum()
+
+        x = torch.rand([31], device=GPU_TYPE)
+
+        with V.set_choices_handler(ForcePersistent()):
+
+            torch._dynamo.mark_dynamic(x, 0, min=1, max=62)
+            fn_c = torch.compile(fn)
+            actual, source_codes = run_and_get_code(fn_c, x)
+            self.assertEqual(fn(x), actual)
+            FileCheck().check("R0_BLOCK: tl.constexpr = 64").run(source_codes[0])
+            torch._dynamo.reset()
+
+            torch._dynamo.mark_dynamic(x, 2, min=1, max=64)
+            fn_c = torch.compile(fn)
+            actual, source_codes = run_and_get_code(fn_c, x)
+            self.assertEqual(fn(x), actual)
+            FileCheck().check("R0_BLOCK: tl.constexpr = 64").run(source_codes[0])
 
     def test_unspecialized_float_dynamic(self):
         def fn(x, y):

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -9,10 +9,10 @@ import unittest
 from functools import partial
 
 import torch
-from torch._inductor.choices import InductorChoices
 import torch.library
 from torch._dynamo.testing import CompileCounterWithBackend, make_test_cls_with_patches
 from torch._inductor import metrics
+from torch._inductor.choices import InductorChoices
 from torch._inductor.codegen.wrapper import PythonWrapperCodegen
 from torch._inductor.test_case import TestCase
 from torch._inductor.utils import run_and_get_code
@@ -1081,9 +1081,7 @@ class TestInductorDynamic(TestCase):
 
     @onlyOn(GPU_TYPE)
     def test_dynamic_rblock_bounds(self):
-
         class ForcePersistent(InductorChoices):
-
             @staticmethod
             def should_use_cooperative_reduction(*args, **kwargs) -> bool:
                 return False
@@ -1098,7 +1096,6 @@ class TestInductorDynamic(TestCase):
         x = torch.rand([31], device=GPU_TYPE)
 
         with V.set_choices_handler(ForcePersistent()):
-
             torch._dynamo.mark_dynamic(x, 0, min=1, max=62)
             fn_c = torch.compile(fn)
             actual, source_codes = run_and_get_code(fn_c, x)

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -4267,6 +4267,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             val = bound_sympy(rnumel).upper
             assert isinstance(val, int) or val.is_constant()
 
+            if val == torch.utils._sympy.numbers.IntInfinity():
+                raise ValueError(f"Failed to find static RBLOCK for {rnumel}")
+
             val = next_power_of_2(int(val))
 
             if val > 16 * 1024:

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -14,7 +14,6 @@ import textwrap
 from collections.abc import Iterable, Sequence
 from functools import lru_cache
 from typing import Any, Callable, cast, Optional, TYPE_CHECKING, Union
-from torch.utils._sympy.value_ranges import bound_sympy
 
 import sympy
 from sympy.printing.precedence import PRECEDENCE
@@ -27,6 +26,7 @@ from torch._dynamo.utils import identity, preserve_rng_state
 from torch._prims_common import is_integer_dtype
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.functions import CeilDiv, FloorDiv, ModularIndexing
+from torch.utils._sympy.value_ranges import bound_sympy
 from torch.utils._triton import has_triton_package, has_triton_stable_tma_api
 
 from ...utils._sympy.symbol import free_symbol_is_type, prefix_str, symbol_is_type, SymT


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #162441

Previously, we were using 128 and increasing to upper bound. We should be setting at the upper bound and raising to next power of 2.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben

Differential Revision: [D81984103](https://our.internmc.facebook.com/intern/diff/D81984103)