### PR TITLE
Fix torch.linalg.eig inductor stride mismatch

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5876,6 +5876,21 @@ class CommonTemplate:
             reference_in_float=False,
         )
 
+    def test_linalg_eig_stride_consistency(self):
+        def fn(x):
+            eigenvals, eigenvecs = torch.linalg.eig(x)
+            return eigenvecs
+
+        x = torch.randn(5, 5, device=self.device, dtype=torch.float32)
+
+        self.common(
+            fn,
+            [x],
+            exact_stride=True,
+            exact_dtype=True,
+            check_lowp=False,
+        )
+
     def test_view_as_complex(self):
         class Repro(torch.nn.Module):
             def __init__(self) -> None:

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5876,6 +5876,7 @@ class CommonTemplate:
             reference_in_float=False,
         )
 
+    @skipIfMPS
     def test_linalg_eig_stride_consistency(self):
         def fn(x):
             eigenvals, eigenvecs = torch.linalg.eig(x)

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -159,6 +159,9 @@ test_failures = {
     #
     "test_complex_fallback_dynamic_shapes": TestFailure(("cpu", "cuda", "xpu")),
     "test_adaptive_avg_pool2d2_dynamic_shapes": TestFailure(("cpu", "cuda", "xpu")),
+    "test_linalg_eig_stride_consistency_dynamic_shapes": TestFailure(
+        ("cpu", "cuda", "xpu")
+    ),
     "test_adaptive_max_pool2d2_dynamic_shapes": TestFailure(("cpu", "cuda", "xpu")),
     "test_argmax_to_float_dynamic_shapes": TestFailure(("cpu", "cuda", "xpu")),
     "test_avg_pool2d7_dynamic_shapes": TestFailure(("cpu", "cuda", "xpu")),

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -1777,6 +1777,12 @@ class TestMeta(TestCase):
         self.assertEqual(out[1].shape, meta_out[1].shape)
         self.assertEqual(out[1].dtype, meta_out[1].dtype)
 
+    @onlyCPU
+    def test_linalg_eig_meta_stride_consistency(self):
+        x = torch.randn(5, 5, device='meta')
+        eigenvals, eigenvecs = torch.linalg.eig(x)
+        self.assertEqual(eigenvecs.stride(), (1, 5))
+
     def test_meta_consistency_out_dtype_mismatch_pow_Tensor_Scalar(self):
         S = (5,)
 

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -1777,12 +1777,6 @@ class TestMeta(TestCase):
         self.assertEqual(out[1].shape, meta_out[1].shape)
         self.assertEqual(out[1].dtype, meta_out[1].dtype)
 
-    @onlyCPU
-    def test_linalg_eig_meta_stride_consistency(self):
-        x = torch.randn(5, 5, device='meta')
-        eigenvals, eigenvecs = torch.linalg.eig(x)
-        self.assertEqual(eigenvecs.stride(), (1, 5))
-
     def test_meta_consistency_out_dtype_mismatch_pow_Tensor_Scalar(self):
         S = (5,)
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -1021,8 +1021,9 @@ def meta_linalg_eig(input: Tensor):
     )
     values = input.new_empty(input.shape[:-1], dtype=complex_dtype)
     vectors = input.new_empty(input.shape, dtype=complex_dtype)
+    is_cuda = device_hint(input) == "cuda"
     vectors.as_strided_(
-        input.shape, make_contiguous_strides_for(input.shape, row_major=False)
+        input.shape, make_contiguous_strides_for(input.shape, row_major=is_cuda)
     )
     return values, vectors
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -1021,6 +1021,9 @@ def meta_linalg_eig(input: Tensor):
     )
     values = input.new_empty(input.shape[:-1], dtype=complex_dtype)
     vectors = input.new_empty(input.shape, dtype=complex_dtype)
+    vectors.as_strided_(
+        input.shape, make_contiguous_strides_for(input.shape, row_major=False)
+    )
     return values, vectors
 
 


### PR DESCRIPTION
Fixes #159445

### Summary

- Fixed a stride layout issue in the `torch.linalg.eig` meta kernel that prevented successful compilation with the inductor backend. The meta kernel was producing incorrect row-major strides.

- LAPACK/BLAS libraries (underlying implementation) expect column-major layout



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben