### PR TITLE
sparse_broadcast_to: fix false-positive coalesced with inputs of shape ()

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -563,9 +563,10 @@ Tensor sparse_broadcast_to(const Tensor& self, IntArrayRef size) {
   // sparse dimensions are expanded. Possible expansion of dense
   // dimensions can be discarded as it does not affect the is_coalesce
   // property.
-  bool is_coalesced = !self.dim() ||
-      (self.is_coalesced() &&
-       (max_unchanged_dim < min_broadcast_dim || min_broadcast_dim == -1));
+  bool is_coalesced = (
+      self.is_coalesced() &&
+      (max_unchanged_dim < min_broadcast_dim || min_broadcast_dim == -1)
+  );
 
   // Replace non-broadcastable dims with 1 in the `size` vector {
   auto res_sparse_dim_broadcast_mask =


### PR DESCRIPTION

ghstack-source-id: 3a3a79a3bc5ff093d4c462f1d38688d3db253364
Pull-Request: https://github.com/pytorch/pytorch/pull/162490

Fixes #162482
