### PR TITLE
[ROCm][CI] skip test_max_autotune until resolved

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -171,6 +171,7 @@ ROCM_BLOCKLIST = [
     "distributed/rpc/test_tensorpipe_agent",
     "distributed/rpc/test_share_memory",
     "distributed/rpc/cuda/test_tensorpipe_agent",
+    "inductor/test_max_autotune",  # taking excessive time, many tests >30 min
     "test_determination",
     "test_jit_legacy",
     "test_cuda_nvml_based_avail",


### PR DESCRIPTION
many tests taking >30 min and causing timeouts


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd