### PR TITLE
forward fix shape guards handling for executorch

### DIFF
--- a/torch/ao/quantization/pt2e/lowering.py
+++ b/torch/ao/quantization/pt2e/lowering.py
@@ -52,7 +52,7 @@ def lower_pt2e_quantized_to_x86(
     lowered_model = (
         torch.export.export_for_training(model, example_inputs, strict=True)
         .run_decompositions(_post_autograd_decomp_table())
-        .module()
+        .module(check_guards=False)
     )
     _node_replace(lowered_model)
     freezing_passes(lowered_model, example_inputs)

--- a/torch/ao/quantization/pt2e/qat_utils.py
+++ b/torch/ao/quantization/pt2e/qat_utils.py
@@ -651,6 +651,14 @@ def _fuse_conv_bn_qat_helper(
 
     Note: This also handles the (conv + bn + relu) pattern.
     """
+    if hasattr(m, "_guards_fn"):
+        # Do not compile the guards function, since it may contain checks
+        # that are not currently supported by ExecuTorch pass infra.
+        node = next(iter(m.graph.find_nodes(op="call_module", target="_guards_fn")))
+        m.graph.erase_node(node)
+        delattr(m, "_guards_fn")
+        m.recompile()
+
     m.graph.eliminate_dead_code()
     m.recompile()
 
@@ -906,6 +914,13 @@ def _fold_conv_bn_qat_helper(
     """
     Replace the quantized (conv + bn) pattern with conv with bn weights folded into the weights of conv.
     """
+    if hasattr(m, "_guards_fn"):
+        # Do not compile the guards function, since it may contain checks
+        # that are not currently supported by ExecuTorch pass infra.
+        node = next(iter(m.graph.find_nodes(op="call_module", target="_guards_fn")))
+        m.graph.erase_node(node)
+        delattr(m, "_guards_fn")
+        m.recompile()
 
     m.graph.eliminate_dead_code()
     m.recompile()

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -2020,7 +2020,7 @@ class _ModuleStackTracer(PythonKeyTracer):
 
         # nn_module_stack
         if node.op not in ["placeholder", "output"]:
-            if "nn_module_stack" not in node.meta:
+            if node.meta.get("nn_module_stack") is None:
                 node.meta["nn_module_stack"] = self.module_stack.copy()
             # convert nn_module_stack from Dict[key, (FQN, class)] -> Dict[str, Tuple[str, str]]
             for key, (fqn, mod_cls) in node.meta["nn_module_stack"].items():


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/ao/pull/2969

D80713603 introduces a call module to a generated `_guards_fn` by export that ET pass infra cannot handle right now.

It is possible to omit this generation by using `ep.module(check_guards=False)` but there are too many places to update, so meanwhile we can explicitly remove the generated instruction as in here.

Test Plan:
broken tests should pass

This diff has been blamed as the cause of 27 test breakages:
tests:test_pt2e - test_pt2e_quant_joiner (pyspeech.tests.models.test_pt2e_compatibilities.JoinerNumericalEval)
MS Request 60655532 ⋅ Sep 9, 2025, 2:25 AM
tests:test_pt2e - test_pt2e_quant_encoder (pyspeech.tests.models.test_pt2e_compatibilities.EncoderNumericalEval)
MS Request 60655534 ⋅ Sep 9, 2025, 2:05 AM
tests:test_pt2e - test_pt2e_fp32_joiner (pyspeech.tests.models.test_pt2e_compatibilities.JoinerNumericalEval)
MS Request 60655533 ⋅ Sep 9, 2025, 1:51 AM
tests:test_model - test_qat_model_et (vizard_projects.ml_depth.tests.test_model.TestModel)
MS Request 60654585 ⋅ Sep 9, 2025, 1:45 AM
tests:test_load_fbl - test_load_qat (vizard_projects.ml_depth.tests.test_load_fbl.TestData)
MS Request 60654613 ⋅ Sep 9, 2025, 1:26 AM
tests:test_pt2e - test_pt2e_quant_predictor (pyspeech.tests.models.test_pt2e_compatibilities.PredictorNumericalEval)
MS Request 60655536 ⋅ Sep 9, 2025, 1:20 AM
tests:test_pt2e - test_pt2e_fp32_predictor (pyspeech.tests.models.test_pt2e_compatibilities.PredictorNumericalEval)
MS Request 60655535 ⋅ Sep 9, 2025, 12:57 AM
tests:trainer - test_hello_world_qat_executorch (motion_algos.deepmotion.tests.trainer_tests.TrainerTests)
MS Request 60654651 ⋅ Sep 9, 2025, 12:45 AM
tests:test_model - test_qat_model_et_per_channel (vizard_projects.ml_depth.tests.test_model.TestModel)
MS Request 60654576 ⋅ Sep 9, 2025, 12:39 AM
tests:test_model - test_qat_uncertainty_model_et (vizard_projects.ml_depth.tests.test_model.TestModel)
MS Request 60654572 ⋅ Sep 9, 2025, 12:08 AM
test:e2e_test_cpu - test_interpreter (sigmoid.inference.test.e2e_test.E2ETestGraphInputAsStr2)
MS Request 60654118 ⋅ Sep 9, 2025, 12:05 AM
tests:test_model - test_qat_uncertainty_model_et_per_channel (vizard_projects.ml_depth.tests.test_model.TestModel)
MS Request 60654573 ⋅ Sep 9, 2025, 12:03 AM
test:e2e_test_cpu - test_package_reader (sigmoid.inference.test.e2e_test.E2ETestGraphInputAsStr2)
MS Request 60654108 ⋅ Sep 8, 2025, 11:55 PM
test:e2e_test_cpu - test_aotinductor_simple (sigmoid.inference.test.e2e_test.E2ETestGraphInputAsStr2)
MS Request 60654105 ⋅ Sep 8, 2025, 11:39 PM
test:torchao_test_quantization_pt2e_quantization_pt2e_test_numeric_debugger - test_added_node_gets_unique_id (pytorch.ao.test.quantization.pt2e.test_numeric_debugger.TestNumericDebuggerInfra)
MS Request 60654198 ⋅ Sep 8, 2025, 11:27 PM
quantization:test_turing_quantizer - test_masked_attention_turing_3_0 (on_device_ai.helios.quantization.test_turing_quantizer.TestPatterns)
MS Request 60654829 ⋅ Sep 8, 2025, 11:25 PM
test:torchao_test_quantization_pt2e_quantization_pt2e_test_numeric_debugger - test_run_decompositions_same_handle_id (pytorch.ao.test.quantization.pt2e.test_numeric_debugger.TestNumericDebuggerInfra)
MS Request 60654203 ⋅ Sep 8, 2025, 11:21 PM
test:torchao_test_quantization_pt2e_quantization_pt2e_test_numeric_debugger - test_simple (pytorch.ao.test.quantization.pt2e.test_numeric_debugger.TestNumericDebuggerInfra)
MS Request 60654209 ⋅ Sep 8, 2025, 11:18 PM
test:torchao_test_quantization_pt2e_quantization_pt2e_test_numeric_debugger - test_copy_preserve_handle (pytorch.ao.test.quantization.pt2e.test_numeric_debugger.TestNumericDebuggerInfra)
MS Request 60654202 ⋅ Sep 8, 2025, 11:11 PM
test:torchao_test_quantization_pt2e_quantization_pt2e_test_numeric_debugger - test_re_export_preserve_handle (pytorch.ao.test.quantization.pt2e.test_numeric_debugger.TestNumericDebuggerInfra)
MS Request 60654197 ⋅ Sep 8, 2025, 11:10 PM
test:torchao_test_quantization_pt2e_quantization_pt2e_test_numeric_debugger - test_run_decompositions_map_handle_to_new_nodes (pytorch.ao.test.quantization.pt2e.test_numeric_debugger.TestNumericDebuggerInfra)
MS Request 60654204 ⋅ Sep 8, 2025, 11:10 PM
test:torchao_test_quantization_pt2e_quantization_pt2e_test_numeric_debugger - test_deepcopy_preserve_handle (pytorch.ao.test.quantization.pt2e.test_numeric_debugger.TestNumericDebuggerInfra)
MS Request 60654201 ⋅ Sep 8, 2025, 11:06 PM
tests:test_ptq - test_convert_model (vizard_projects.ego_ocr_recognition.tests.test_ptq.TestPTQ)
MS Request 60644273 ⋅ Sep 8, 2025, 9:01 PM
test:test_backends_lifted - test_backend_with_compiler_delegate_and_operator (executorch.exir.backend.test.test_backends_lifted.TestBackends)
MS Request 60644108 ⋅ Sep 8, 2025, 8:10 PM
test:test_backends_lifted - test_backend_with_compiler_delegate_and_operator_with_two_modules (executorch.exir.backend.test.test_backends_lifted.TestBackends)
MS Request 60644092 ⋅ Sep 8, 2025, 8:04 PM
test:test_backends - test_backend_with_compiler_delegate_and_operator_with_two_modules (executorch.exir.backend.test.test_backends.TestBackends)
MS Request 60644086 ⋅ Sep 8, 2025, 7:56 PM
test:test_backends - test_backend_with_compiler_delegate_and_operator (executorch.exir.backend.test.test_backends.TestBackends)
MS Request 60644083 ⋅

Rollback Plan:

Differential Revision: D82030581


cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv