### PR TITLE
[nativert] AOTI delegate with flat inputs and outputs

### DIFF
--- a/torch/nativert/backends/lower_utils.py
+++ b/torch/nativert/backends/lower_utils.py
@@ -1,9 +1,44 @@
+import types
+
 import torch
+import torch.utils._pytree as pytree
 from torch.export import ExportedProgram
 from torch.export.pt2_archive._package import AOTI_FILES, package_pt2
 from torch.types import FileLike
 
 from .lowered_aoti_module import LoweredBackendModule
+
+
+def get_new_ep_with_flat_inputs_outputs(ep: ExportedProgram) -> ExportedProgram:
+    class FlattenedModule(torch.nn.Module):
+        def __init__(
+            self,
+            original_module: torch.fx.GraphModule,
+            in_spec: pytree.TreeSpec,
+            out_spec: pytree.TreeSpec,
+        ) -> None:
+            super().__init__()
+            self.original_module = original_module
+            self.in_spec = in_spec
+            self.out_spec = out_spec
+
+        def forward(self, *flat_inputs):  # type: ignore[no-untyped-def]
+            # Unflatten inputs to original structure
+            inputs = pytree.tree_unflatten(flat_inputs, self.in_spec)
+            args, kwargs = inputs
+            outputs = self.original_module(*args, **kwargs)
+            # Flatten outputs
+            flat_outputs, _ = pytree.tree_flatten(outputs)
+            return tuple(flat_outputs)
+
+    flattened_module = FlattenedModule(
+        ep.module(), ep.call_spec.in_spec, ep.call_spec.out_spec
+    )
+    args, kwargs = ep.example_inputs
+    flat_inputs, _ = pytree.tree_flatten((args, kwargs))
+    flat_ep = torch.export.export(flattened_module, tuple(flat_inputs))
+
+    return flat_ep
 
 
 def lower_exported_program(
@@ -14,14 +49,30 @@ def lower_exported_program(
     with the `executorch_call_delegate` HOP
     """
     args, kwargs = exported_program.example_inputs
+    out_spec = exported_program.call_spec.out_spec
+    flat_ep = get_new_ep_with_flat_inputs_outputs(exported_program)
+    flat_inputs, _ = pytree.tree_flatten((args, kwargs))
+
     aoti_files = torch._inductor.aot_compile(
-        exported_program.module(), args, kwargs, options={"aot_inductor.package": True}
+        flat_ep.module(), tuple(flat_inputs), options={"aot_inductor.package": True}
     )
     assert isinstance(aoti_files, list)
 
     lowered_aoti_module = LoweredBackendModule(
-        exported_program, backend_id, module_name=model_name
+        flat_ep, backend_id, module_name=model_name
     )
+
+    def patched_forward(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        flat_inputs, _ = pytree.tree_flatten((args, kwargs))
+        flat_outputs = torch._higher_order_ops.executorch_call_delegate(
+            self, *flat_inputs
+        )
+        if out_spec is not None and flat_outputs is not None:
+            return pytree.tree_unflatten(flat_outputs, out_spec)
+        else:
+            return flat_outputs
+
+    lowered_aoti_module.forward = types.MethodType(patched_forward, lowered_aoti_module)  # type: ignore[method-assign]
 
     aoti_delegate_ep = torch.export.export(lowered_aoti_module, args, kwargs)
 

--- a/torch/nativert/backends/lowered_aoti_module.py
+++ b/torch/nativert/backends/lowered_aoti_module.py
@@ -29,5 +29,5 @@ class LoweredBackendModule(torch.nn.Module):
     def original_module(self) -> ExportedProgram:
         return self._original_exported_program
 
-    def forward(self, *args):  # type: ignore[no-untyped-def]
-        return torch._higher_order_ops.executorch_call_delegate(self, *args)
+    def forward(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        return torch._higher_order_ops.executorch_call_delegate(self, *args, **kwargs)


### PR DESCRIPTION
Summary: `executorch_call_delegate` should have flattened inputs and outputs. So that it can be correctly serialized and the input/output specs are consistent with runtime.

Test Plan:
CI

Rollback Plan:

Differential Revision: D82064354


