### PR TITLE
xpu: test py_limited_api with SyclExtension

### DIFF
--- a/test/cpp_extensions/python_agnostic_extension/python_agnostic/__init__.py
+++ b/test/cpp_extensions/python_agnostic_extension/python_agnostic/__init__.py
@@ -3,19 +3,9 @@ from pathlib import Path
 import torch
 
 
-if torch.cuda.is_available():
-    cuda_so_files = list(Path(__file__).parent.glob("cuda*.so"))
-    assert len(cuda_so_files) == 1, (
-        f"Expected one cuda*.so file, found {len(cuda_so_files)}"
-    )
-    torch.ops.load_library(cuda_so_files[0])
-
-if torch.xpu.is_available():
-    sycl_so_files = list(Path(__file__).parent.glob("sycl*.so"))
-    assert len(sycl_so_files) == 1, (
-        f"Expected one sycl*.so file, found {len(sycl_so_files)}"
-    )
-    torch.ops.load_library(sycl_so_files[0])
+so_files = list(Path(__file__).parent.glob("_C*.so"))
+assert len(so_files) == 1, f"Expected one _C*.so file, found {len(so_files)}"
+torch.ops.load_library(so_files[0])
 
 from . import ops
 
@@ -25,19 +15,19 @@ from . import ops
 # The following is used to assert the ultra_norm op is properly loaded and
 # calculates correct results upon import of this extension.
 
-devices = []
 if torch.cuda.is_available():
-    devices.append("cuda")
-if torch.xpu.is_available():
-    devices.append("xpu")
+    device = "cuda"
+elif torch.xpu.is_available():
+    device = "xpu"
+else:
+    raise AssertionError("Expected CUDA or XPU device backend, found none")
 
-for device in devices:
-    inputs = [
-        torch.tensor([1.0, 2.0, 3.0], device=device),
-        torch.tensor([-4.0, -5.0, -6.0], device=device),
-    ]
+inputs = [
+    torch.tensor([1.0, 2.0, 3.0], device=device),
+    torch.tensor([-4.0, -5.0, -6.0], device=device),
+]
 
-    assert torch.equal(
-        ops.ultra_norm(inputs),
-        torch.norm(torch.tensor([1.0, 2.0, 3.0, -4.0, -5.0, -6.0], device=device)),
-    )
+assert torch.equal(
+    ops.ultra_norm(inputs),
+    torch.norm(torch.tensor([1.0, 2.0, 3.0, -4.0, -5.0, -6.0], device=device)),
+)

--- a/test/cpp_extensions/python_agnostic_extension/python_agnostic/__init__.py
+++ b/test/cpp_extensions/python_agnostic_extension/python_agnostic/__init__.py
@@ -3,9 +3,19 @@ from pathlib import Path
 import torch
 
 
-so_files = list(Path(__file__).parent.glob("_C*.so"))
-assert len(so_files) == 1, f"Expected one _C*.so file, found {len(so_files)}"
-torch.ops.load_library(so_files[0])
+if torch.cuda.is_available():
+    cuda_so_files = list(Path(__file__).parent.glob("cuda*.so"))
+    assert len(cuda_so_files) == 1, (
+        f"Expected one cuda*.so file, found {len(cuda_so_files)}"
+    )
+    torch.ops.load_library(cuda_so_files[0])
+
+if torch.xpu.is_available():
+    sycl_so_files = list(Path(__file__).parent.glob("sycl*.so"))
+    assert len(sycl_so_files) == 1, (
+        f"Expected one sycl*.so file, found {len(sycl_so_files)}"
+    )
+    torch.ops.load_library(sycl_so_files[0])
 
 from . import ops
 
@@ -15,12 +25,19 @@ from . import ops
 # The following is used to assert the ultra_norm op is properly loaded and
 # calculates correct results upon import of this extension.
 
-inputs = [
-    torch.tensor([1.0, 2.0, 3.0], device="cuda"),
-    torch.tensor([-4.0, -5.0, -6.0], device="cuda"),
-]
+devices = []
+if torch.cuda.is_available():
+    devices.append("cuda")
+if torch.xpu.is_available():
+    devices.append("xpu")
 
-assert torch.equal(
-    ops.ultra_norm(inputs),
-    torch.norm(torch.tensor([1.0, 2.0, 3.0, -4.0, -5.0, -6.0], device="cuda")),
-)
+for device in devices:
+    inputs = [
+        torch.tensor([1.0, 2.0, 3.0], device=device),
+        torch.tensor([-4.0, -5.0, -6.0], device=device),
+    ]
+
+    assert torch.equal(
+        ops.ultra_norm(inputs),
+        torch.norm(torch.tensor([1.0, 2.0, 3.0, -4.0, -5.0, -6.0], device=device)),
+    )

--- a/test/cpp_extensions/python_agnostic_extension/python_agnostic/csrc/ultra_norm.sycl
+++ b/test/cpp_extensions/python_agnostic_extension/python_agnostic/csrc/ultra_norm.sycl
@@ -1,0 +1,19 @@
+#include <ATen/ops/_foreach_norm_native.h>
+#include <ATen/ops/cat_xpu_dispatch.h>
+#include <ATen/ops/norm_xpu_dispatch.h>
+#include <ATen/ops/unsqueeze.h>
+#include <torch/library.h>
+
+at::Tensor ultra_norm(at::TensorList inputs) {
+    auto res = at::native::foreach_tensor_norm_xpu(inputs);
+    std::vector<at::Tensor> unsqueezed;
+    for (const auto& scalar_tensor : res) {
+        unsqueezed.push_back(at::unsqueeze(scalar_tensor, 0));
+    }
+    auto stacked = at::xpu::cat(unsqueezed);
+    return at::xpu::norm(stacked, 2, at::IntArrayRef{}, false);
+}
+
+TORCH_LIBRARY_IMPL(python_agnostic, XPU, m) {
+  m.impl("python_agnostic::ultra_norm", &ultra_norm);
+}

--- a/test/cpp_extensions/python_agnostic_extension/test/test_python_agnostic.py
+++ b/test/cpp_extensions/python_agnostic_extension/test/test_python_agnostic.py
@@ -7,11 +7,15 @@ import sys
 import unittest
 from pathlib import Path
 
-from torch.testing._internal.common_device_type import (
-    instantiate_device_type_tests,
-    onlyCUDA,
+from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import (
+    IS_LINUX,
+    run_tests,
+    shell,
+    TEST_XPU,
+    TestCase,
 )
-from torch.testing._internal.common_utils import IS_LINUX, run_tests, shell, TestCase
 
 
 class TestPythonAgnostic(TestCase):
@@ -29,7 +33,10 @@ class TestPythonAgnostic(TestCase):
         if return_code != 0:
             raise RuntimeError("python_agnostic bdist_wheel failed to build")
 
-    @onlyCUDA
+    @unittest.skipIf(
+        not (TEST_CUDA or TEST_XPU),
+        "test requires CUDA or XPU",
+    )
     @unittest.skipIf(not IS_LINUX, "test requires linux tools ldd and nm")
     def test_extension_is_python_agnostic(self, device):
         # For this test, run_test.py will call `python setup.py bdist_wheel` in the
@@ -59,7 +66,10 @@ class TestPythonAgnostic(TestCase):
         self.assertFalse("Py" in missing_symbols)
 
 
-instantiate_device_type_tests(TestPythonAgnostic, globals(), only_for="cuda")
+devices = ("cuda", "xpu")
+instantiate_device_type_tests(
+    TestPythonAgnostic, globals(), only_for=devices, allow_xpu=True
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -38,6 +38,7 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_ASAN,
     TEST_WITH_ROCM,
     TEST_WITH_SLOW_GRADCHECK,
+    TEST_XPU,
 )
 
 
@@ -841,8 +842,9 @@ def _test_cpp_extensions_aot(test_directory, options, use_ninja):
         exts_to_build = [
             (install_cmd, "no_python_abi_suffix_test"),
         ]
-        if TEST_CUDA:
+        if TEST_CUDA or TEST_XPU:
             exts_to_build.append((wheel_cmd, "python_agnostic_extension"))
+        if TEST_CUDA:
             exts_to_build.append((install_cmd, "libtorch_agnostic_extension"))
         for cmd, extension_dir in exts_to_build:
             return_code = shell(


### PR DESCRIPTION
Commit extends existing CUDA test to cover XPU SyclExtension case for the same feature - `py_limited_api`. Commit required a fix for xpu to install some Aten header files (#145902) which got resolved after the merge of #159621.

See: https://github.com/pytorch/pytorch/issues/145902
Requires: https://github.com/pytorch/pytorch/pull/159621
Requires: https://github.com/intel/torch-xpu-ops/pull/1743

CC: @guangyey, @EikanWang 
