### PR TITLE
[torchao][pt2e] Make prepare and convert faster by caching

### DIFF
--- a/torch/ao/quantization/fx/utils.py
+++ b/torch/ao/quantization/fx/utils.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 import copy
+import functools
 import operator
 import warnings
 from collections import namedtuple
@@ -245,6 +246,7 @@ def graph_module_from_producer_nodes(
 
 
 # TODO: delete
+@functools.cache
 def assert_and_get_unique_device(module: torch.nn.Module) -> Any:
     """
     Returns the unique device for a module, or None if no device is found.


### PR DESCRIPTION
Summary: D79674759 tried to fix the expensive prepare and convert steps, as `assert_and_get_unique_device` was called multiple times. This change fixes that issue by using `functools.cache` decorator.

Test Plan:
Verified on llm export to QNN.
LLM Quantization prepare time of ~20min reduced to ~3min.

Rollback Plan:

Differential Revision: D82073679




cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv