### PR TITLE
Skip test_ind_worker_queue on Windows and macOS (flaky)

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -25,6 +25,7 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_utils import (
     IS_CI,
     IS_JETSON,
+    IS_MACOS,
     IS_S390X,
     IS_SANDCASTLE,
     IS_WINDOWS,
@@ -3477,6 +3478,9 @@ class TestIndividualWorkerQueue(TestCase):
             if current_worker_idx == num_workers:
                 current_worker_idx = 0
 
+    @unittest.skipIf(
+        IS_WINDOWS or IS_MACOS, "https://github.com/pytorch/pytorch/issues/68643"
+    )
     def test_ind_worker_queue(self):
         max_num_workers = None
         if hasattr(os, "sched_getaffinity"):

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -3479,7 +3479,8 @@ class TestIndividualWorkerQueue(TestCase):
                 current_worker_idx = 0
 
     @unittest.skipIf(
-        IS_WINDOWS or IS_MACOS, "https://github.com/pytorch/pytorch/issues/68643"
+        IS_WINDOWS or IS_MACOS,
+        "Flaky on Windows and MacOS https://github.com/pytorch/pytorch/issues/68643",
     )
     def test_ind_worker_queue(self):
         max_num_workers = None


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/68643

It was closed by the bot yesterday and the issue was still there https://github.com/pytorch/pytorch/actions/runs/17595694816/job/49989589647.  It's better to just skip it directly in the code as this test has been disabled on Windows and MacOS since 2021 O_o