### PR TITLE
[DTensor] add op support for aten.unbind.int

### DIFF
--- a/test/distributed/tensor/test_tensor_ops.py
+++ b/test/distributed/tensor/test_tensor_ops.py
@@ -1,6 +1,8 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 # Owner(s): ["oncall: distributed"]
 
+import itertools
+
 import torch
 from torch.distributed.tensor import (
     DeviceMesh,
@@ -775,6 +777,33 @@ class DistTensorOpsTest(DTensorTestBase):
             split_size,
             dim=split_dim,
         )
+
+    @with_comms
+    def test_unbind(self):
+        device_mesh = self.build_device_mesh()
+        shard_dims = [0, 1]
+        unbind_dims = [0, 1]
+        local_tensor = torch.randn(4, 8, requires_grad=True)
+        for shard_dim, unbind_dim in itertools.product(shard_dims, unbind_dims):
+            dist_tensor = distribute_tensor(
+                local_tensor, device_mesh, (Shard(shard_dim),)
+            )
+            unbinded_tensors = dist_tensor.unbind(dim=unbind_dim)
+
+            if shard_dim == unbind_dim:
+                self.assertTrue(
+                    all(elem.placements[0].is_replicate() for elem in unbinded_tensors)
+                )
+            else:
+                new_shard_dim = shard_dim if shard_dim < unbind_dim else shard_dim - 1
+                self.assertTrue(
+                    all(
+                        elem.placements[0].is_shard(dim=new_shard_dim)
+                        for elem in unbinded_tensors
+                    )
+                )
+            for x, y in zip(unbinded_tensors, local_tensor.unbind(dim=unbind_dim)):
+                self.assertEqual(x.full_tensor(), y)
 
 
 if __name__ == "__main__":

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -328,7 +328,7 @@ def select_int_strategy(op_schema: OpSchema) -> StrategyType:
         output_specs = input_specs
         if input_specs.is_sharded():
             # handle cases with sharded_dim != selected_dim
-            output_placements = shift_shard_dims_after_insert(
+            output_placements = shift_shard_dims_after_remove(
                 input_specs.placements, selected_dim
             )
             output_specs = DTensorSpec(

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -1162,6 +1162,8 @@ def split_strategy(op_schema: OpSchema) -> OpStrategy:
     return OpStrategy(all_strategies)
 
 
+# TODO: fix remaining failures in xfail("unbind") in test_dtensor_ops.py
+#       and remove this xfail item
 @register_op_strategy(aten.unbind.int, schema_info=RuntimeSchemaInfo(1))
 def gen_unbind_strategy(op_schema: OpSchema) -> StrategyType:
     """Forward all shardings except the unbind dimension."""

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -27,6 +27,8 @@ from torch.distributed.tensor._ops.utils import (
     normalize_dim,
     register_op_strategy,
     register_prop_rule,
+    shift_shard_dims_after_insert,
+    shift_shard_dims_after_remove,
 )
 from torch.distributed.tensor.placement_types import (
     Partial,
@@ -326,16 +328,11 @@ def select_int_strategy(op_schema: OpSchema) -> StrategyType:
         output_specs = input_specs
         if input_specs.is_sharded():
             # handle cases with sharded_dim != selected_dim
-            output_spec_placements = []
-            for placement in input_specs.placements:
-                if placement.is_shard():
-                    shard_dim = cast(Shard, placement).dim
-                    if shard_dim > selected_dim:
-                        shard_dim -= 1
-                    placement = Shard(dim=shard_dim)
-                output_spec_placements.append(placement)
+            output_placements = shift_shard_dims_after_insert(
+                input_specs.placements, selected_dim
+            )
             output_specs = DTensorSpec(
-                arg_spec.mesh, placements=tuple(output_spec_placements)
+                arg_spec.mesh, placements=tuple(output_placements)
             )
 
         select_strategy.strategies.append(
@@ -360,19 +357,10 @@ def select_backward_strategy(op_schema: OpSchema) -> OpStrategy:
     output_strategies: list[OpSpec] = []
     for placement_strategy in input_strategy.strategies:
         input_spec = placement_strategy.output_spec
-        output_spec_placements: list[Placement] = []
-        for placement in input_spec.placements:
-            if isinstance(placement, Shard):
-                shard_dim = placement.dim
-                if shard_dim >= dim:
-                    # NOTE: shard_dim is guaranteed to exist because
-                    # grad_input has one more dim than grad_output
-                    output_spec_placements.append(Shard(shard_dim + 1))
-                else:
-                    output_spec_placements.append(Shard(shard_dim))
-            else:
-                output_spec_placements.append(placement)
-        output_specs = DTensorSpec(input_spec.mesh, tuple(output_spec_placements))
+        # NOTE: shard_dim is guaranteed to exist because
+        # grad_input has one more dim than grad_output
+        output_placements = shift_shard_dims_after_insert(input_spec.placements, dim)
+        output_specs = DTensorSpec(input_spec.mesh, tuple(output_placements))
         output_strategies.append(
             OpSpec(output_specs=output_specs, input_specs=(input_spec,))
         )
@@ -741,20 +729,6 @@ def _derive_follow_placements_from_tuple_strategy(
     return follow_placements
 
 
-def normalize_shard_for_stack(
-    placements: Sequence[Placement], insert_dim: int = 0
-) -> Sequence[Placement]:
-    # stack op would "insert" new dim, so all sharded dim >= the inserted dim need to
-    # be normalized with the new Shard placement
-    normalized_placements: list[Placement] = []
-    for placement in placements:
-        if isinstance(placement, Shard) and placement.dim >= insert_dim:
-            normalized_placements.append(Shard(placement.dim + 1))
-        else:
-            normalized_placements.append(placement)
-    return normalized_placements
-
-
 @register_op_strategy(aten.stack.default, RuntimeSchemaInfo(1, needs_pytree=True))
 def stack_strategy(op_schema: OpSchema) -> StrategyType:
     args_schema = op_schema.args_schema
@@ -781,7 +755,9 @@ def stack_strategy(op_schema: OpSchema) -> StrategyType:
         for _ in range(len(input_tuple_strategy.children))
     )
 
-    follow_placements = normalize_shard_for_stack(follow_placements, dim)
+    # stack op would "insert" new dim, so all sharded dim >= the inserted dim need to
+    # be normalized with the new Shard placement
+    follow_placements = shift_shard_dims_after_insert(follow_placements, dim)
 
     for strategy in input_tuple_strategy.children:
         assert isinstance(strategy, OpStrategy)
@@ -1184,3 +1160,62 @@ def split_strategy(op_schema: OpSchema) -> OpStrategy:
         )
 
     return OpStrategy(all_strategies)
+
+
+# similar to the strategy for aten.slice.Tensor but simpler
+@register_op_strategy(aten.unbind.int, schema_info=RuntimeSchemaInfo(1))
+def gen_unbind_strategy(op_schema: OpSchema) -> StrategyType:
+    """Forward all shardings except the unbind dimension."""
+    input_strategy = op_schema.args_schema[0]
+    assert isinstance(input_strategy, OpStrategy)
+    input_ndim = input_strategy.ndim
+    input_shape = input_strategy.shape
+    unbind_dim = (
+        cast(int, op_schema.args_schema[1]) if len(op_schema.args_schema) > 1 else 0
+    )
+    unbind_dim = normalize_dim(unbind_dim, input_ndim)
+
+    mesh = input_strategy.mesh
+    unbind_strategy = OpStrategy([])
+    for arg_strategy in input_strategy.strategies:
+        arg_spec = arg_strategy.output_spec
+        if not is_tensor_dim_sharded(arg_spec, dim=unbind_dim):
+            # only add the strategy if the unbind dim is not sharded
+            output_placements = shift_shard_dims_after_remove(
+                arg_spec.placements, unbind_dim
+            )
+            output_specs = tuple(
+                DTensorSpec(mesh, tuple(output_placements))
+                for _ in range(input_shape[unbind_dim])
+            )
+            unbind_strategy.strategies.append(
+                OpSpec(
+                    output_specs=output_specs,
+                    input_specs=(arg_spec,),
+                    redistribute_cost=[[0.0] * len(input_strategy.strategies)],
+                )
+            )
+    if not unbind_strategy.strategies:
+        # if all strategies are filtered out, unsharding all specs on unbind dim
+        # of the input strategy, and use that as the op strategy
+        for arg_strategy in input_strategy.strategies:
+            arg_spec = arg_strategy.output_spec
+            input_placements = unshard_tensor_dim(arg_spec.placements, dim=unbind_dim)
+            input_spec = DTensorSpec(mesh, input_placements, arg_spec.tensor_meta)
+            output_placements = shift_shard_dims_after_remove(
+                input_placements, unbind_dim
+            )
+            unshard_specs = tuple(
+                DTensorSpec(mesh, tuple(output_placements))
+                for _ in range(input_shape[unbind_dim])
+            )
+            unbind_strategy.strategies.append(
+                OpSpec(
+                    output_specs=unshard_specs,
+                    input_specs=(input_spec,),
+                    redistribute_cost=[
+                        generate_redistribute_costs(input_strategy, input_spec)
+                    ],
+                )
+            )
+    return unbind_strategy

--- a/torch/distributed/tensor/_ops/utils.py
+++ b/torch/distributed/tensor/_ops/utils.py
@@ -370,3 +370,27 @@ def expand_to_full_mesh_op_strategy(
         )
         all_strategies.append(strategy)
     return OpStrategy(all_strategies)
+
+
+def shift_shard_dims_after_insert(
+    placements: Sequence[Placement], insert_dim: int = 0
+) -> Sequence[Placement]:
+    normalized_placements: list[Placement] = []
+    for placement in placements:
+        if isinstance(placement, Shard) and placement.dim >= insert_dim:
+            normalized_placements.append(Shard(placement.dim + 1))
+        else:
+            normalized_placements.append(placement)
+    return normalized_placements
+
+
+def shift_shard_dims_after_remove(
+    placements: Sequence[Placement], remove_dim: int = 0
+) -> Sequence[Placement]:
+    normalized_placements: list[Placement] = []
+    for placement in placements:
+        if isinstance(placement, Shard) and placement.dim > remove_dim:
+            normalized_placements.append(Shard(placement.dim - 1))
+        else:
+            normalized_placements.append(placement)
+    return normalized_placements


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #162560

As titled.

It seems unbind returns views of the original tensor. E.g. see https://stackoverflow.com/questions/78910951/does-unbind-return-the-views-of-tensors-in-pytorch

So we error out when `shard_dim == unbind_dim`. This is similar to why we error out in view ops.
https://github.com/pytorch/pytorch/blob/main/torch/distributed/tensor/_ops/_view_ops.py#L544-L546

This PR also refactors some other tensor ops code, by creating two utils function `shift_shard_dims_after_insert`, `shift_shard_dims_after_remove`.


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci