### PR TITLE
Fix typing for current_accelerator

### DIFF
--- a/torch/accelerator/__init__.py
+++ b/torch/accelerator/__init__.py
@@ -91,7 +91,7 @@ def is_available() -> bool:
     return mod.is_available()
 
 
-def current_accelerator(check_available: bool = False) -> Optional[torch.device]:
+def current_accelerator(check_available: bool = False) -> Optional[torch.Device]:
     r"""Return the device of the accelerator available at compilation time.
     If no accelerator were available at compilation time, returns None.
     See :ref:`accelerator<accelerators>` for details.


### PR DESCRIPTION
Change `torch.device` to `torch.Device`. While the former is also valid, linters report errors due to recursive initialisation in ``torch/__init__.py`` and `torch.device` is not ready at that time.