### PR TITLE
[c10d] Differentiate participate requirements between init_device_mesh and direct construction

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -1253,7 +1253,7 @@ class InitWithoutGroup(DTensorTestBase):
 
     def test_mesh_without_dist_init(self):
         _set_env_var(world_size=self.world_size, rank=self.rank)
-        # Must be `init_device_mesh` instead of `DeviceMesh` due to implicit dist init
+        # Only `init_device_mesh` provides backward support for implicit dist init
         init_device_mesh(self.device_type, (self.world_size,))
 
 

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -1268,14 +1268,10 @@ class InitWithoutGroup(DTensorTestBase):
             self.device_type, torch.arange(self.world_size), _init_backend=init_backend
         )
 
-    @parametrize(
-        "init_backend", [False, True]
-    )  # Whether DeviceMesh init dim groups during creation
-    def test_mesh_without_dist_init(self, init_backend: bool):
+    def test_mesh_without_dist_init(self):
         _set_env_var(world_size=self.world_size, rank=self.rank)
-        DeviceMesh(
-            self.device_type, torch.arange(self.world_size), _init_backend=init_backend
-        )
+        # Must be `init_device_mesh` instead of `DeviceMesh` due to implicit dist init
+        init_device_mesh(self.device_type, (self.world_size,))
 
 
 if __name__ == "__main__":

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -454,7 +454,9 @@ if True:  # just to temporarily avoid reindentation
                 world_size = get_world_size()
             except RuntimeError:
                 logger.error(
-                    "DeviceMesh construction requires the distributed environment to be initialized first. "
+                    "`DeviceMesh` construction requires information from the distribute environment. "
+                    "Please call `torch.distributed.init` to initialize the environment before using "
+                    "the `DeviceMesh` constructor. "
                 )
                 raise
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #162571
* #162549
* #163058
* #162770
* #162545
* #162529

1. `init_device_mesh` is a collective call across World.
Reason: it supports implicit `dist.init()` which is a world-wide call.
```
# Valid
dist.init()
init_device_mesh(...)

# Valid
init_device_mesh(...)
```

2. `DeviceMesh` direct construction is more flexible, can be called on a subset of ranks. But, prior to `DeviceMesh` construction, *the* distributed environment must have been initialized. We don't want to take the risk to perform `dist.init()` implicitly here due to the flexibility of the constructor API. 
```
# Valid
dist.init()
dm = DeviceMesh(...)

# Invalid, will throw environment uninitialized error
dm = DeviceMesh(...)
```

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci