### PR TITLE
use torch.accelerator and device_module instead of cuda to make DataParallel more device agnostic.

### DIFF
--- a/torch/nn/parallel/parallel_apply.py
+++ b/torch/nn/parallel/parallel_apply.py
@@ -63,8 +63,8 @@ def parallel_apply(
         devices = [None] * len(modules)
     devices = [_get_device_index(x, True) for x in devices]
     streams = [torch.accelerator.current_stream(x) for x in devices]
-    device_type = _get_available_device_type()
-    assert device_type is not None, "No available device found"
+    assert torch.accelerator.is_available(), "No available accelerator found."
+    device_type = torch.accelerator.current_accelerator().type
     device_module = _get_device_module(device_type)
     lock = threading.Lock()
     results = {}

--- a/torch/nn/parallel/parallel_apply.py
+++ b/torch/nn/parallel/parallel_apply.py
@@ -3,7 +3,11 @@ from collections.abc import Sequence
 from typing import Any, cast, Optional, Union
 
 import torch
-from torch._utils import ExceptionWrapper
+from torch._utils import (
+    _get_available_device_type,
+    _get_device_module,
+    ExceptionWrapper,
+)
 from torch.cuda._utils import _get_device_index
 from torch.nn.modules import Module
 
@@ -58,7 +62,10 @@ def parallel_apply(
     else:
         devices = [None] * len(modules)
     devices = [_get_device_index(x, True) for x in devices]
-    streams = [torch.cuda.current_stream(x) for x in devices]
+    streams = [torch.accelerator.current_stream(x) for x in devices]
+    device_type = _get_available_device_type()
+    assert device_type is not None, "No available device found"
+    device_module = _get_device_module(device_type)
     lock = threading.Lock()
     results = {}
     grad_enabled, autocast_enabled = (
@@ -72,7 +79,7 @@ def parallel_apply(
         input: Any,
         kwargs: dict[str, Any],
         device: Optional[Union[int, torch.device]] = None,
-        stream: Optional[torch.cuda.Stream] = None,
+        stream: Optional[torch.Stream] = None,
     ) -> None:
         torch.set_grad_enabled(grad_enabled)
         if device is None:
@@ -86,12 +93,12 @@ def parallel_apply(
                 return
             device = t.get_device()
         if stream is None:
-            stream = torch.cuda.current_stream(device)
+            stream = torch.accelerator.current_stream(device)
         try:
             with (
-                torch.cuda.device(device),
-                torch.cuda.stream(stream),
-                torch.amp.autocast("cuda", enabled=autocast_enabled),
+                device_module.device(device),
+                device_module.stream(stream),
+                torch.amp.autocast(device_type, enabled=autocast_enabled),
             ):
                 # this also avoids accidental slicing of `input` if it is a Tensor
                 if not isinstance(input, (list, tuple)):

--- a/torch/nn/parallel/parallel_apply.py
+++ b/torch/nn/parallel/parallel_apply.py
@@ -61,7 +61,6 @@ def parallel_apply(
     streams = [torch.accelerator.current_stream(x) for x in devices]
     assert torch.accelerator.is_available(), "No available accelerator found."
     device_type = torch.accelerator.current_accelerator().type  # type: ignore[union-attr]
-    device_module = _get_device_module(device_type)
     lock = threading.Lock()
     results = {}
     grad_enabled, autocast_enabled = (

--- a/torch/nn/parallel/parallel_apply.py
+++ b/torch/nn/parallel/parallel_apply.py
@@ -64,7 +64,7 @@ def parallel_apply(
     devices = [_get_device_index(x, True) for x in devices]
     streams = [torch.accelerator.current_stream(x) for x in devices]
     assert torch.accelerator.is_available(), "No available accelerator found."
-    device_type = torch.accelerator.current_accelerator().type
+    device_type = torch.accelerator.current_accelerator().type  # type: ignore[union-attr]
     device_module = _get_device_module(device_type)
     lock = threading.Lock()
     results = {}
@@ -92,6 +92,8 @@ def parallel_apply(
                     )
                 return
             device = t.get_device()
+        if isinstance(device, torch.device):
+            device = device.index
         if stream is None:
             stream = torch.accelerator.current_stream(device)
         try:

--- a/torch/nn/parallel/parallel_apply.py
+++ b/torch/nn/parallel/parallel_apply.py
@@ -96,8 +96,8 @@ def parallel_apply(
             stream = torch.accelerator.current_stream(device)
         try:
             with (
-                device_module.device(device),
-                device_module.stream(stream),
+                torch.accelerator.device_index(device),
+                stream,
                 torch.amp.autocast(device_type, enabled=autocast_enabled),
             ):
                 # this also avoids accidental slicing of `input` if it is a Tensor

--- a/torch/nn/parallel/parallel_apply.py
+++ b/torch/nn/parallel/parallel_apply.py
@@ -3,11 +3,7 @@ from collections.abc import Sequence
 from typing import Any, cast, Optional, Union
 
 import torch
-from torch._utils import (
-    _get_available_device_type,
-    _get_device_module,
-    ExceptionWrapper,
-)
+from torch._utils import ExceptionWrapper
 from torch.cuda._utils import _get_device_index
 from torch.nn.modules import Module
 


### PR DESCRIPTION
use torch.accelerator and `_get_device_module` instead of cuda to make DataParallel more device agnostic.

Fixes #162152

recently, I've done some works to support my own privateuse1 backend in DataParallel module, but I found some cuda related APIs exist in parallel_apply.py file, that makes me have to monkey patch DataParallel module to support DP on my own backend.

so I make some small changes to replace cuda.xxx to accelerator.xxx, and acquire device module by `_get_device_module`.

this is my first time to contribute to pytorch, please let me know if there is any problem about the change.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci