### PR TITLE
Add rfft declaration in pyi file

### DIFF
--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -2761,3 +2761,30 @@ class _StaticCudaLauncher:
 class fft:
     @staticmethod
     def rfft(input: Tensor, n: _int = ..., dim: _int = ..., norm: str = ...) -> Tensor: ...
+
+def stft(
+    input: Tensor,
+    n_fft: _int,
+    hop_length: _int = ...,
+    win_length: _int = ...,
+    window: Tensor = ...,
+    center: _bool = ...,
+    pad_mode: str = ...,
+    normalized: _bool = ...,
+    onesided: _bool = ...,
+    return_complex: _bool = ...,
+    align_to_window: _bool = ...,
+) -> Tensor: ...
+
+def istft(
+    input: Tensor,
+    n_fft: _int,
+    hop_length: _int = ...,
+    win_length: _int = ...,
+    window: Tensor = ...,
+    center: _bool = ...,
+    normalized: _bool = ...,
+    onesided: _bool = ...,
+    length: _int = ...,
+    return_complex: _bool = ...,
+) -> Tensor: ...

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -2757,3 +2757,7 @@ class _StaticCudaLauncher:
         args: tuple[Any, ...],
         stream: _int,
     ) -> None: ...
+
+class fft:
+    @staticmethod
+    def rfft(input: Tensor, n: _int = ..., dim: _int = ..., norm: str = ...) -> Tensor: ...

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -37,6 +37,7 @@ from torch._C import (
     _onnx,
     _VariableFunctions,
     _verbose,
+    fft,
 )
 from torch._prims_common import DeviceLikeType
 from torch.autograd.graph import Node as _Node
@@ -2758,33 +2759,29 @@ class _StaticCudaLauncher:
         stream: _int,
     ) -> None: ...
 
-class fft:
-    @staticmethod
-    def rfft(input: Tensor, n: _int = ..., dim: _int = ..., norm: str = ...) -> Tensor: ...
-
 def stft(
     input: Tensor,
     n_fft: _int,
-    hop_length: _int = ...,
-    win_length: _int = ...,
-    window: Tensor = ...,
+    hop_length: _int | None = ...,
+    win_length: _int | None = ...,
+    window: Tensor | None = ...,
     center: _bool = ...,
     pad_mode: str = ...,
     normalized: _bool = ...,
-    onesided: _bool = ...,
-    return_complex: _bool = ...,
-    align_to_window: _bool = ...,
+    onesided: _bool | None = ...,
+    return_complex: _bool | None = ...,
+    align_to_window: _bool | None = ...,
 ) -> Tensor: ...
 
 def istft(
     input: Tensor,
     n_fft: _int,
-    hop_length: _int = ...,
-    win_length: _int = ...,
-    window: Tensor = ...,
+    hop_length: _int | None = ...,
+    win_length: _int | None = ...,
+    window: Tensor | None = ...,
     center: _bool = ...,
     normalized: _bool = ...,
-    onesided: _bool = ...,
-    length: _int = ...,
+    onesided: _bool | None = ...,
+    length: _int | None = ...,
     return_complex: _bool = ...,
 ) -> Tensor: ...

--- a/torch/_C/fft.pyi
+++ b/torch/_C/fft.pyi
@@ -1,0 +1,94 @@
+# Defined in aten/src/ATen/native/SpectralOps.cpp
+from torch import Tensor
+from torch.types import _int
+
+def fft(
+    input: Tensor, s: _int | None = ..., dim: _int = ..., norm: str | None = ...
+) -> Tensor: ...
+def ifft(
+    input: Tensor, s: _int | None = ..., dim: _int = ..., norm: str | None = ...
+) -> Tensor: ...
+def fft2(
+    input: Tensor,
+    s: tuple[_int] | None = ...,
+    dim: tuple[_int] = ...,
+    norm: str | None = ...,
+) -> Tensor: ...
+def ifft2(
+    input: Tensor,
+    s: tuple[_int] | None = ...,
+    dim: tuple[_int] = ...,
+    norm: str | None = ...,
+) -> Tensor: ...
+def fftn(
+    input: Tensor,
+    s: tuple[_int] | None = ...,
+    dim: tuple[_int] = ...,
+    norm: str | None = ...,
+) -> Tensor: ...
+def ifftn(
+    input: Tensor,
+    s: tuple[_int] | None = ...,
+    dim: tuple[_int] = ...,
+    norm: str | None = ...,
+) -> Tensor: ...
+def rfft(
+    input: Tensor, s: _int | None = ..., dim: _int = ..., norm: str | None = ...
+) -> Tensor: ...
+def irfft(
+    input: Tensor, s: _int | None = ..., dim: _int = ..., norm: str | None = ...
+) -> Tensor: ...
+def rfft2(
+    input: Tensor,
+    s: tuple[_int] | None = ...,
+    dim: tuple[_int] = ...,
+    norm: str | None = ...,
+) -> Tensor: ...
+def irfft2(
+    input: Tensor,
+    s: tuple[_int] | None = ...,
+    dim: tuple[_int] = ...,
+    norm: str | None = ...,
+) -> Tensor: ...
+def rfftn(
+    input: Tensor,
+    s: tuple[_int] | None = ...,
+    dim: tuple[_int] = ...,
+    norm: str | None = ...,
+) -> Tensor: ...
+def irfftn(
+    input: Tensor,
+    s: tuple[_int] | None = ...,
+    dim: tuple[_int] = ...,
+    norm: str | None = ...,
+) -> Tensor: ...
+def hfft(
+    input: Tensor, s: _int | None = ..., dim: _int = ..., norm: str | None = ...
+) -> Tensor: ...
+def ihfft(
+    input: Tensor, s: _int | None = ..., dim: _int = ..., norm: str | None = ...
+) -> Tensor: ...
+def hfft2(
+    input: Tensor,
+    s: tuple[_int] | None = ...,
+    dim: tuple[_int] = ...,
+    norm: str | None = ...,
+) -> Tensor: ...
+def ihfft2(
+    input: Tensor,
+    s: tuple[_int] | None = ...,
+    dim: tuple[_int] = ...,
+    norm: str | None = ...,
+) -> Tensor: ...
+def hfftn(
+    input: Tensor,
+    s: tuple[_int] | None = ...,
+    dim: tuple[_int] = ...,
+    norm: str | None = ...,
+) -> Tensor: ...
+def ihfftn(
+    input: Tensor,
+    s: tuple[_int] | None = ...,
+    dim: tuple[_int] = ...,
+    norm: str | None = ...,
+) -> Tensor: ...


### PR DESCRIPTION
Fixes #162373

## Test Result

No warning about `not callable`

```python
# test.py
import torch

if __name__ == "__main__":
    t = torch.arange(4)
    V = torch.fft.rfft(t)

pylint test.py 
************* Module test
test.py:1:0: C0114: Missing module docstring (missing-module-docstring)

------------------------------------------------------------------
Your code has been rated at 7.50/10 (previous run: 7.50/10, +0.00)

```


```python
# test2.py
import torch

signal = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])

stft_result = torch.stft(
    signal,
    n_fft=4,
    hop_length=2,
    return_complex=True
)

recovered = torch.istft(
    stft_result,
    n_fft=4,
    hop_length=2
)

pylint test2.py 
************* Module test2
test2.py:1:0: C0114: Missing module docstring (missing-module-docstring)
test2.py:12:0: C0103: Constant name "recovered" doesn't conform to UPPER_CASE naming style (invalid-name)

------------------------------------------------------------------
Your code has been rated at 5.00/10 (previous run: 5.00/10, +0.00)

```