### PR TITLE
[Fix] remove legacy function `_jinja2_env()` in inductor

### DIFF
--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1503,18 +1503,6 @@ class TritonTemplateKernel(TritonKernel):
         ]
 
 
-@functools.cache
-def _jinja2_env():
-    try:
-        import jinja2
-
-        return jinja2.Environment(
-            undefined=jinja2.StrictUndefined,
-        )
-    except ImportError:
-        return None
-
-
 class GenerateAndLoadResult(NamedTuple):
     """
     Return type of TritonTemplate.generate_and_load.


### PR DESCRIPTION
`_jinja2_env()` in select_algorithm.py is legacy. Because when rendering the template below.
https://github.com/pytorch/pytorch/blob/26b3ae58908becbb03b28636f7384d2972a8c9a5/torch/_inductor/select_algorithm.py#L1431
`self._template_from_string(source)` comes from common.py
https://github.com/pytorch/pytorch/blob/26b3ae58908becbb03b28636f7384d2972a8c9a5/torch/_inductor/codegen/common.py#L2347-L2349


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben