### PR TITLE
WIP Profiler Performance Visualization

### DIFF
--- a/torch/_inductor/analysis/dag_nodes.py
+++ b/torch/_inductor/analysis/dag_nodes.py
@@ -1,0 +1,592 @@
+"""
+DAG node classes for representing trace execution graphs.
+"""
+
+from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
+
+from torch.utils._ordered_set import OrderedSet
+
+if TYPE_CHECKING:
+    from .json_profile import JsonProfile
+
+
+try:
+    import graphviz
+except ImportError:
+    pass
+
+
+class TraceDAGNode:
+    """Represents a node in the DAG - either an operation or a kernel."""
+
+    def __init__(self, name: str, node_type: str):
+        self.name = name
+        self.node_type = node_type  # 'op' or 'kernel'
+        self.kernel_instances: List[
+            Tuple[float, int]
+        ] = []  # List of (duration_us, thread_id) for kernels
+        self.instance_count: int = (
+            0  # Number of times this operation appears in the trace
+        )
+        # Performance statistics for kernels
+        self.achieved_flops_list: List[
+            float
+        ] = []  # List of achieved FLOPS % for each instance
+        self.achieved_bandwidth_list: List[
+            float
+        ] = []  # List of achieved bandwidth % for each instance
+
+        # Roofline analysis
+        self.bound_type_list: List[
+            str
+        ] = []  # List of "compute" or "memory" for each instance based on roofline analysis
+
+        # Multi-trace support
+        self.trace_data: Dict[int, Dict] = {}  # Maps trace_id to trace-specific data
+
+
+class MultiTraceDAGNode:
+    """Represents a composite node in the multi-trace DAG."""
+
+    def __init__(self, name: str, node_type: str):
+        self.name = name
+        self.node_type = node_type  # 'op' or 'kernel'
+        self.trace_instances: Dict[int, TraceDAGNode] = {}  # Maps trace_id to node data
+        self.present_in_traces: OrderedSet[int] = (
+            OrderedSet()
+        )  # Which traces contain this node
+
+    def add_trace_instance(self, trace_id: int, node: TraceDAGNode):
+        """Add data for this node from a specific trace."""
+        self.trace_instances[trace_id] = node
+        self.present_in_traces.add(trace_id)
+
+
+class MultiTraceDAG:
+    """Directed Acyclic Graph representing multiple collapsed trace trees."""
+
+    def __init__(self):
+        self.nodes: Dict[str, MultiTraceDAGNode] = {}
+        self.edges: OrderedSet[Tuple[str, str, int]] = (
+            OrderedSet()
+        )  # (parent, child, trace_id) relationships
+        self.trace_colors: Dict[int, str] = {}
+        self.trace_names: Dict[int, str] = {}
+
+    def add_trace_dag(self, trace_id: int, dag: "TraceDAG", trace_name: str):
+        """Add a single trace's DAG to the multi-trace DAG."""
+        self.trace_names[trace_id] = trace_name
+
+        # Add nodes
+        for node_name, node in dag.nodes.items():
+            if node_name not in self.nodes:
+                self.nodes[node_name] = MultiTraceDAGNode(node_name, node.node_type)
+            self.nodes[node_name].add_trace_instance(trace_id, node)
+
+        # Add edges with trace information
+        for parent, child in dag.edges:
+            self.edges.add((parent, child, trace_id))
+
+    def assign_colors(self):
+        """Assign distinct colors to each trace."""
+        colors = [
+            "#FF6B6B",
+            "#4ECDC4",
+            "#45B7D1",
+            "#96CEB4",
+            "#FECA57",
+            "#FF9F43",
+            "#686DE0",
+            "#F8B500",
+        ]
+        for i, trace_id in enumerate(sorted(self.trace_names.keys())):
+            self.trace_colors[trace_id] = colors[i % len(colors)]
+
+    def calculate_kernel_time_gradients(self):
+        """Calculate gradient colors based on kernel time percentages for each trace."""
+        self.trace_kernel_gradients = {}
+
+        for trace_id in self.trace_names.keys():
+            # Calculate total kernel time for this trace
+            total_kernel_time = 0.0
+            kernel_times = {}
+
+            for node_name, multi_node in self.nodes.items():
+                if (
+                    multi_node.node_type == "kernel"
+                    and trace_id in multi_node.trace_instances
+                ):
+                    node = multi_node.trace_instances[trace_id]
+                    kernel_time = sum(dur for dur, _ in node.kernel_instances)
+                    kernel_times[node_name] = kernel_time
+                    total_kernel_time += kernel_time
+
+            # Calculate percentages and create gradient mapping
+            gradients = {}
+            if total_kernel_time > 0:
+                max_percentage = (
+                    max(kernel_times.values()) / total_kernel_time * 100
+                    if kernel_times
+                    else 0
+                )
+
+                base_color = self.trace_colors[trace_id]
+
+                for node_name, kernel_time in kernel_times.items():
+                    percentage = (kernel_time / total_kernel_time) * 100
+                    # Create gradient from light to dark based on percentage
+                    gradient_color = self._create_gradient_color(
+                        base_color, percentage, max_percentage
+                    )
+                    gradients[node_name] = gradient_color
+
+            self.trace_kernel_gradients[trace_id] = gradients
+
+    def _create_gradient_color(
+        self, base_color: str, percentage: float, max_percentage: float
+    ) -> str:
+        """Create a gradient color from light to dark based on percentage."""
+        # Convert hex to RGB
+        base_color = base_color.lstrip("#")
+        r, g, b = tuple(int(base_color[i : i + 2], 16) for i in (0, 2, 4))
+
+        # Create gradient: 0% = very light, max% = original color
+        if max_percentage > 0:
+            intensity = percentage / max_percentage
+        else:
+            intensity = 0
+
+        # Ensure minimum visibility by setting a floor
+        min_intensity = 0.01  # Minimum 1% of original color (colorless)
+        max_intensity = 1.2  # 120% of original color (slightly darker)
+
+        # Scale intensity between min and max
+        scaled_intensity = min_intensity + (max_intensity - min_intensity) * intensity
+
+        # Blend with white: higher intensity = more original color, less white
+        final_r = int(255 * (1 - scaled_intensity) + r * scaled_intensity)
+        final_g = int(255 * (1 - scaled_intensity) + g * scaled_intensity)
+        final_b = int(255 * (1 - scaled_intensity) + b * scaled_intensity)
+
+        return f"#{final_r:02x}{final_g:02x}{final_b:02x}"
+
+    def calculate_kernel_colors(
+        self,
+        color_mode: str,
+        baseline_profile: Optional["JsonProfile"] = None,
+    ) -> Dict[int, Dict[str, str]]:
+        """
+        Calculate colors for kernel nodes based on the specified color mode for each trace.
+        Returns a dictionary mapping trace_id -> {kernel_name: color_string}.
+        """
+        if color_mode not in [
+            "time",
+            "diff",
+            "mem-utilization",
+            "compute-utilization",
+            "roofline",
+        ]:
+            return {}
+
+        trace_kernel_colors = {}
+
+        # For time mode, just return the existing gradients
+        if color_mode == "time":
+            return self.trace_kernel_gradients
+
+        # For other modes, calculate enhanced coloring for each trace
+        for trace_id in self.trace_names.keys():
+            # Get base gradients for this trace
+            base_gradients = self.trace_kernel_gradients.get(trace_id, {})
+            trace_kernel_colors[trace_id] = {}
+
+            if color_mode == "diff":
+                if baseline_profile is None:
+                    print(
+                        f"Warning: diff coloring requested but no baseline profile provided for trace {trace_id}"
+                    )
+                    trace_kernel_colors[trace_id] = base_gradients.copy()
+                    continue
+
+                # Build baseline DAG to get kernel durations
+                baseline_dag = baseline_profile.build_trace_dag()
+                baseline_durations = {}
+
+                for name, node in baseline_dag.nodes.items():
+                    if node.node_type == "kernel":
+                        total_duration = sum(dur for dur, _ in node.kernel_instances)
+                        baseline_durations[name] = total_duration
+
+                # Calculate duration differences for kernels in this trace
+                for kernel_name, multi_node in self.nodes.items():
+                    if (
+                        multi_node.node_type == "kernel"
+                        and trace_id in multi_node.trace_instances
+                    ):
+                        kernel_node = multi_node.trace_instances[trace_id]
+                        base_color = base_gradients.get(kernel_name, "#4ECDC4")
+
+                        current_duration = sum(
+                            dur for dur, _ in kernel_node.kernel_instances
+                        )
+                        baseline_duration = baseline_durations.get(kernel_name, 0.0)
+
+                        if baseline_duration == 0.0:
+                            # Kernel not present in baseline - use red tinted version
+                            trace_kernel_colors[trace_id][kernel_name] = self._tint_color(
+                                base_color, "red", 0.8
+                            )
+                        else:
+                            diff_ratio = (
+                                current_duration - baseline_duration
+                            ) / baseline_duration
+                            if diff_ratio > 0.1:  # More than 10% slower
+                                tint_intensity = min(1.0, diff_ratio)
+                                trace_kernel_colors[trace_id][kernel_name] = (
+                                    self._tint_color(base_color, "red", tint_intensity)
+                                )
+                            elif diff_ratio < -0.1:  # More than 10% faster
+                                tint_intensity = min(1.0, abs(diff_ratio))
+                                trace_kernel_colors[trace_id][kernel_name] = (
+                                    self._tint_color(base_color, "blue", tint_intensity)
+                                )
+                            else:
+                                # Similar performance - use base gradient
+                                trace_kernel_colors[trace_id][kernel_name] = base_color
+
+            elif color_mode == "mem-utilization":
+                # Modify base gradients based on memory bandwidth utilization
+                for kernel_name, multi_node in self.nodes.items():
+                    if (
+                        multi_node.node_type == "kernel"
+                        and trace_id in multi_node.trace_instances
+                    ):
+                        kernel_node = multi_node.trace_instances[trace_id]
+                        base_color = base_gradients.get(kernel_name, "#4ECDC4")
+
+                        if kernel_node.achieved_bandwidth_list:
+                            avg_utilization = sum(
+                                kernel_node.achieved_bandwidth_list
+                            ) / len(kernel_node.achieved_bandwidth_list)
+                            # Higher utilization -> more green tint
+                            utilization_intensity = min(1.0, avg_utilization / 100.0)
+                            trace_kernel_colors[trace_id][kernel_name] = self._tint_color(
+                                base_color, "green", utilization_intensity
+                            )
+                        else:
+                            # No utilization data - use base gradient
+                            trace_kernel_colors[trace_id][kernel_name] = base_color
+
+            elif color_mode == "compute-utilization":
+                # Modify base gradients based on compute (FLOPS) utilization
+                for kernel_name, multi_node in self.nodes.items():
+                    if (
+                        multi_node.node_type == "kernel"
+                        and trace_id in multi_node.trace_instances
+                    ):
+                        kernel_node = multi_node.trace_instances[trace_id]
+                        base_color = base_gradients.get(kernel_name, "#4ECDC4")
+
+                        if kernel_node.achieved_flops_list:
+                            avg_utilization = sum(kernel_node.achieved_flops_list) / len(
+                                kernel_node.achieved_flops_list
+                            )
+                            # Higher utilization -> more purple tint
+                            utilization_intensity = min(1.0, avg_utilization / 100.0)
+                            trace_kernel_colors[trace_id][kernel_name] = self._tint_color(
+                                base_color, "purple", utilization_intensity
+                            )
+                        else:
+                            # No utilization data - use base gradient
+                            trace_kernel_colors[trace_id][kernel_name] = base_color
+
+            elif color_mode == "roofline":
+                # Modify base gradients based on roofline analysis
+                for kernel_name, multi_node in self.nodes.items():
+                    if (
+                        multi_node.node_type == "kernel"
+                        and trace_id in multi_node.trace_instances
+                    ):
+                        kernel_node = multi_node.trace_instances[trace_id]
+                        base_color = base_gradients.get(kernel_name, "#4ECDC4")
+
+                        if (
+                            kernel_node.bound_type_list
+                            and kernel_node.achieved_flops_list
+                            and kernel_node.achieved_bandwidth_list
+                        ):
+                            # Calculate the average roofline score
+                            bound_types = kernel_node.bound_type_list
+                            flops_utils = kernel_node.achieved_flops_list
+                            bw_utils = kernel_node.achieved_bandwidth_list
+
+                            total_score = 0.0
+                            valid_instances = 0
+
+                            for i in range(
+                                min(len(bound_types), len(flops_utils), len(bw_utils))
+                            ):
+                                bound_type = bound_types[i]
+                                if bound_type == "compute":
+                                    total_score += flops_utils[i]
+                                    valid_instances += 1
+                                elif bound_type == "memory":
+                                    total_score += bw_utils[i]
+                                    valid_instances += 1
+
+                            if valid_instances > 0:
+                                avg_score = total_score / valid_instances
+                                # Lower utilization -> more red tint (worse performance)
+                                utilization_intensity = 1.0 - min(1.0, avg_score / 100.0)
+                                trace_kernel_colors[trace_id][kernel_name] = (
+                                    self._tint_color(
+                                        base_color, "red", utilization_intensity
+                                    )
+                                )
+                            else:
+                                trace_kernel_colors[trace_id][kernel_name] = base_color
+                        else:
+                            # No roofline data - use base gradient
+                            trace_kernel_colors[trace_id][kernel_name] = base_color
+
+        return trace_kernel_colors
+
+    def _tint_color(self, base_color: str, tint: str, intensity: float) -> str:
+        """Apply a color tint to a base color with given intensity."""
+        # Convert hex to RGB
+        base_color = base_color.lstrip("#")
+        r, g, b = tuple(int(base_color[i : i + 2], 16) for i in (0, 2, 4))
+
+        # Define tint colors
+        tint_colors = {
+            "red": (255, 0, 0),
+            "blue": (0, 0, 255),
+            "green": (0, 255, 0),
+            "purple": (255, 0, 255),
+        }
+
+        if tint not in tint_colors:
+            return base_color
+
+        tint_r, tint_g, tint_b = tint_colors[tint]
+
+        # Blend base color with tint based on intensity
+        final_r = int(r * (1 - intensity) + tint_r * intensity)
+        final_g = int(g * (1 - intensity) + tint_g * intensity)
+        final_b = int(b * (1 - intensity) + tint_b * intensity)
+
+        # Ensure values are in valid range
+        final_r = max(0, min(255, final_r))
+        final_g = max(0, min(255, final_g))
+        final_b = max(0, min(255, final_b))
+
+        return f"#{final_r:02x}{final_g:02x}{final_b:02x}"
+
+    def get_color_legend_text(self, color_mode: str) -> Optional[str]:
+        """Get legend text for the specified color mode."""
+        if color_mode == "diff":
+            return "Legend\\nRed: Slower than baseline\\nBlue: Faster than baseline\\nNeutral: Same as baseline"
+        elif color_mode == "mem-utilization":
+            return "Legend\\nGreen: High memory bandwidth utilization\\nNeutral: Low memory bandwidth utilization"
+        elif color_mode == "compute-utilization":
+            return "Legend\\nPurple: High compute utilization\\nNeutral: Low compute utilization"
+        elif color_mode == "roofline":
+            return "Legend\\nRoofline Analysis\\nRed: Low utilization (worse)\\nNeutral: High utilization (better)\\nCompute-bound: Uses compute %\\nMemory-bound: Uses memory %"
+        return None
+
+    def filter_by_height(self, height: int) -> "MultiTraceDAG":
+        """
+        Filter the multi-trace DAG to only show nodes up to a specified height above kernel nodes.
+          
+        Args:
+            height: Maximum levels of non-kernel nodes to show above kernels
+                   (0 = only kernels, 1 = kernels + direct parents, etc.)
+          
+        Returns:
+            A new filtered MultiTraceDAG containing only nodes within the height limit
+        """
+        if height < 0:
+            return self
+              
+        filtered_dag = MultiTraceDAG()
+          
+        # Copy trace metadata
+        filtered_dag.trace_colors = self.trace_colors.copy()
+        filtered_dag.trace_names = self.trace_names.copy()
+          
+        # Find all kernel nodes first across all traces
+        kernel_nodes = set()
+        for node_name, multi_node in self.nodes.items():
+            if multi_node.node_type == "kernel":
+                kernel_nodes.add(node_name)
+          
+        # If height is 0, only show kernels
+        if height == 0:
+            for kernel_name in kernel_nodes:
+                if kernel_name in self.nodes:
+                    multi_node = self.nodes[kernel_name]
+                    new_multi_node = MultiTraceDAGNode(kernel_name, "kernel")
+                    # Copy all trace instances
+                    for trace_id, node in multi_node.trace_instances.items():
+                        new_multi_node.add_trace_instance(trace_id, node)
+                    filtered_dag.nodes[kernel_name] = new_multi_node
+            return filtered_dag
+          
+        # Build reverse edge mapping for each trace
+        reverse_edges_by_trace = {}
+        for trace_id in self.trace_names.keys():
+            reverse_edges_by_trace[trace_id] = {}
+              
+        for parent, child, trace_id in self.edges:
+            if trace_id not in reverse_edges_by_trace:
+                reverse_edges_by_trace[trace_id] = {}
+            if child not in reverse_edges_by_trace[trace_id]:
+                reverse_edges_by_trace[trace_id][child] = []
+            reverse_edges_by_trace[trace_id][child].append(parent)
+          
+        # For each trace, perform BFS from kernels going backwards
+        nodes_to_include_by_trace = {}
+        for trace_id in self.trace_names.keys():
+            nodes_to_include = set()
+            current_level = set()
+              
+            # Start with kernels that exist in this trace
+            for kernel_name in kernel_nodes:
+                if (kernel_name in self.nodes and 
+                    trace_id in self.nodes[kernel_name].present_in_traces):
+                    nodes_to_include.add(kernel_name)
+                    current_level.add(kernel_name)
+              
+            # BFS backwards for specified height
+            for level in range(height):
+                next_level = set()
+                for node in current_level:
+                    # Add all parents of current level nodes for this trace
+                    if node in reverse_edges_by_trace[trace_id]:
+                        for parent in reverse_edges_by_trace[trace_id][node]:
+                            if parent not in nodes_to_include:
+                                next_level.add(parent)
+                                nodes_to_include.add(parent)
+                  
+                if not next_level:
+                    break  # No more levels to explore
+                      
+                current_level = next_level
+              
+            nodes_to_include_by_trace[trace_id] = nodes_to_include
+          
+        # Union all nodes to include across all traces
+        all_nodes_to_include = set()
+        for nodes_set in nodes_to_include_by_trace.values():
+            all_nodes_to_include.update(nodes_set)
+          
+        # Build the filtered DAG with only the nodes we want to include
+        for node_name in all_nodes_to_include:
+            if node_name in self.nodes:
+                original_multi_node = self.nodes[node_name]
+                new_multi_node = MultiTraceDAGNode(node_name, original_multi_node.node_type)
+                  
+                # Only include trace instances that should be included for this node
+                for trace_id, node in original_multi_node.trace_instances.items():
+                    if node_name in nodes_to_include_by_trace.get(trace_id, set()):
+                        new_multi_node.add_trace_instance(trace_id, node)
+                  
+                # Only add the multi-node if it has at least one trace instance
+                if new_multi_node.trace_instances:
+                    filtered_dag.nodes[node_name] = new_multi_node
+          
+        # Add edges that connect nodes within our filtered set
+        for parent, child, trace_id in self.edges:
+            if (parent in filtered_dag.nodes and 
+                child in filtered_dag.nodes and
+                parent in nodes_to_include_by_trace.get(trace_id, set()) and
+                child in nodes_to_include_by_trace.get(trace_id, set())):
+                filtered_dag.edges.add((parent, child, trace_id))
+          
+        return filtered_dag
+
+
+class TraceDAG:
+    """Directed Acyclic Graph representing the collapsed trace tree."""
+
+    def __init__(self):
+        self.nodes: Dict[str, TraceDAGNode] = {}
+        self.edges: OrderedSet[Tuple[str, str]] = (
+            OrderedSet()
+        )  # (parent, child) relationships
+
+    def add_node(self, name: str, node_type: str) -> TraceDAGNode:
+        """Add a node to the DAG if it doesn't exist."""
+        if name not in self.nodes:
+            self.nodes[name] = TraceDAGNode(name=name, node_type=node_type)
+        return self.nodes[name]
+
+    def add_edge(self, parent: str, child: str):
+        """Add an edge from parent to child."""
+        self.edges.add((parent, child))
+
+    def add_kernel_instance(self, kernel_name: str, duration_us: float, thread_id: int):
+        """Add a kernel instance to a kernel node."""
+        if kernel_name in self.nodes:
+            node = self.nodes[kernel_name]
+            if node.node_type == "kernel":
+                node.kernel_instances.append((duration_us, thread_id))
+
+    def calculate_kernel_time_gradients(self, base_color: str = "#4ECDC4") -> Dict[str, str]:
+        """Calculate gradient colors based on kernel time percentages."""
+        # Calculate total kernel time
+        total_kernel_time = 0.0
+        kernel_times = {}
+
+        for node_name, node in self.nodes.items():
+            if node.node_type == "kernel":
+                kernel_time = sum(dur for dur, _ in node.kernel_instances)
+                kernel_times[node_name] = kernel_time
+                total_kernel_time += kernel_time
+
+        # Calculate percentages and create gradient mapping
+        gradients = {}
+        if total_kernel_time > 0:
+            max_percentage = (
+                max(kernel_times.values()) / total_kernel_time * 100
+                if kernel_times
+                else 0
+            )
+
+            for node_name, kernel_time in kernel_times.items():
+                percentage = (kernel_time / total_kernel_time) * 100
+                # Create gradient from light to dark based on percentage
+                gradient_color = self._create_gradient_color(
+                    base_color, percentage, max_percentage
+                )
+                gradients[node_name] = gradient_color
+
+        return gradients
+
+    def _create_gradient_color(
+        self, base_color: str, percentage: float, max_percentage: float
+    ) -> str:
+        """Create a gradient color from light to dark based on percentage."""
+        # Convert hex to RGB
+        base_color = base_color.lstrip("#")
+        r, g, b = tuple(int(base_color[i : i + 2], 16) for i in (0, 2, 4))
+
+        # Create gradient: 0% = very light, max% = original color
+        if max_percentage > 0:
+            intensity = percentage / max_percentage
+        else:
+            intensity = 0
+
+        # Ensure minimum visibility by setting a floor
+        min_intensity = 0.01  # Minimum 1% of original color (colorless)
+        max_intensity = 1.2  # 120% of original color (slightly darker)
+
+        # Scale intensity between min and max
+        scaled_intensity = min_intensity + (max_intensity - min_intensity) * intensity
+
+        # Blend with white: higher intensity = more original color, less white
+        final_r = int(255 * (1 - scaled_intensity) + r * scaled_intensity)
+        final_g = int(255 * (1 - scaled_intensity) + g * scaled_intensity)
+        final_b = int(255 * (1 - scaled_intensity) + b * scaled_intensity)
+
+        return f"#{final_r:02x}{final_g:02x}{final_b:02x}"

--- a/torch/_inductor/analysis/device_info.py
+++ b/torch/_inductor/analysis/device_info.py
@@ -359,28 +359,28 @@ _device_mapping: dict[str, DeviceSpec] = {
     # @lint-ignore https://www.nvidia.com/en-us/data-center/h100/
     # These are from H100 SXM.
     #
-    "NVIDIA B100": DeviceSpec(
+    "NVIDIA B200": DeviceSpec(
         tops={
-            torch.float64: 34.0,
-            torch.float32: 67.0,
-            "torch.tf32": 989.0,
-            torch.bfloat16: 1979.0,
+            torch.float64: 40.0,
+            torch.float32: 80.0,
+            "torch.tf32": 2200.0,
+            torch.bfloat16: 4500.0,
             torch.float16: 1979.0,
-            torch.float8_e8m0fnu: 3958.0,
-            torch.float8_e8m0fnu: 3958.0,
-            torch.float8_e4m3fnuz: 3958.0,
-            torch.float8_e5m2: 3958.0,
-            torch.float8_e5m2fnuz: 3958.0,
-            torch.float8_e8m0fnu: 3958.0,
-            torch.int8: 3958.0,
+            torch.float8_e8m0fnu: 9000.0,
+            torch.float8_e8m0fnu: 9000.0,
+            torch.float8_e4m3fnuz: 9000.0,
+            torch.float8_e5m2: 9000.0,
+            torch.float8_e5m2fnuz: 9000.0,
+            torch.float8_e8m0fnu: 9000.0,
+            # torch.fp4: 18000.0,
+            torch.int8: 9000.0,
         },
-        dram_bw_gbs=3350,
-        dram_gb=80,
+        dram_bw_gbs=8000,
+        dram_gb=183.359,
         sm_count=132,
         # boost clock
         clock_hz=1.98e9,
-        memory_clock_hz=1.4e10,
-        # bus: 5120 bit
+        memory_clock_hz=2e9,
     ),
     "NVIDIA H100": DeviceSpec(
         tops={
@@ -573,33 +573,37 @@ def datasheet_tops(dtype: torch.dtype, is_tf32: bool = False) -> Optional[float]
     ]
 
 
-def compute_device_ridgepoint(device_name: str, dtype: torch.dtype, is_tf32: bool = False) -> Optional[float]:
+def compute_device_ridgepoint(
+    device_name: str, dtype: torch.dtype, is_tf32: bool = False
+) -> Optional[float]:
     """
     Compute the device ridgepoint B = TOPS / bandwidth.
     This is the threshold ratio of TOPS to GB/s that determines whether a kernel
     is compute-bound (TOPS/BW >= B) or memory-bound (TOPS/BW < B).
-    
+
     Args:
         device_name: Name of the device (e.g., "NVIDIA H100")
         dtype: Data type being used
         is_tf32: Whether TF32 mode is enabled for float32
-        
+
     Returns:
         Ridgepoint B in TOPS/GB/s, or None if device info is not available
     """
     device_info = lookup_device_info(device_name)
     if device_info is None:
         return None
-        
+
     # Get TOPS for the dtype
-    tops = device_info.tops.get("torch.tf32" if dtype == torch.float32 and is_tf32 else dtype)
+    tops = device_info.tops.get(
+        "torch.tf32" if dtype == torch.float32 and is_tf32 else dtype
+    )
     if tops is None:
         return None
-        
+
     # Get bandwidth
     bw_gbs = device_info.dram_bw_gbs
     if bw_gbs is None or bw_gbs == 0:
         return None
-        
+
     # Ridgepoint B = TOPS / GB/s
     return tops / bw_gbs

--- a/torch/_inductor/analysis/device_info.py
+++ b/torch/_inductor/analysis/device_info.py
@@ -549,8 +549,6 @@ def datasheet_tops(dtype: torch.dtype, is_tf32: bool = False) -> Optional[float]
     Get the theoretical TFLOPS of the device for a given dtype. This can throw an exception if the device
     is not in the datasheet list above.
     """
-    if not torch.cuda.is_available():
-        return None
     name: Optional[str] = torch.cuda.get_device_name()
     if name is None:
         log.info("No device found, returning None")
@@ -577,9 +575,9 @@ def compute_device_ridgepoint(
     device_name: str, dtype: torch.dtype, is_tf32: bool = False
 ) -> Optional[float]:
     """
-    Compute the device ridgepoint B = TOPS / bandwidth.
-    This is the threshold ratio of TOPS to GB/s that determines whether a kernel
-    is compute-bound (TOPS/BW >= B) or memory-bound (TOPS/BW < B).
+    Compute the device ridgepoint B = FLOPS / bandwidth.
+    This is the threshold ratio of FLOPS to B/s that determines whether a kernel
+    is compute-bound (FLOPS/BW >= B) or memory-bound (FLOPS/BW < B).
 
     Args:
         device_name: Name of the device (e.g., "NVIDIA H100")
@@ -587,23 +585,16 @@ def compute_device_ridgepoint(
         is_tf32: Whether TF32 mode is enabled for float32
 
     Returns:
-        Ridgepoint B in TOPS/GB/s, or None if device info is not available
+        Ridgepoint B in FLOPS/B/s (operations per byte), or None if device info is not available
     """
-    device_info = lookup_device_info(device_name)
-    if device_info is None:
+    flops = DeviceInfo.lookup_tops(device_name, dtype, is_tf32)
+    if flops is None:
         return None
 
-    # Get TOPS for the dtype
-    tops = device_info.tops.get(
-        "torch.tf32" if dtype == torch.float32 and is_tf32 else dtype
-    )
-    if tops is None:
-        return None
-
-    # Get bandwidth
-    bw_gbs = device_info.dram_bw_gbs
+    bw_gbs = DeviceInfo.lookup_dram_bw_gbs(device_name)
     if bw_gbs is None or bw_gbs == 0:
         return None
 
-    # Ridgepoint B = TOPS / GB/s
-    return tops / bw_gbs
+    bw_bs = bw_gbs * 1e9
+
+    return flops / bw_bs

--- a/torch/_inductor/analysis/json_profile.py
+++ b/torch/_inductor/analysis/json_profile.py
@@ -852,19 +852,6 @@ class JsonProfile:
             if event_ts <= kernel_end_ts and event_end_ts >= kernel_ts:
                 op_name = event.get("name", "")
 
-                # Filter for relevant operations (aten:: ops)
-                # if op_name.startswith("aten::") or any(
-                #     x in op_name for x in ["contiguous", "clone", "copy", "empty"]
-                # ):
-                #     overlapping_ops.append(
-                #         {
-                #             "name": op_name,
-                #             "ts": event_ts,
-                #             "dur": event_dur,
-                #             "end_ts": event_end_ts,
-                #             "event": event,
-                #         }
-                #     )
                 overlapping_ops.append(
                     {
                         "name": op_name,

--- a/torch/_inductor/analysis/json_profile.py
+++ b/torch/_inductor/analysis/json_profile.py
@@ -1,0 +1,1536 @@
+"""
+JsonProfile class for analyzing JSON trace files from profiling.
+"""
+
+import json
+import logging
+import multiprocessing as mp
+import os
+import tempfile
+from bisect import bisect_right
+from collections import defaultdict
+from concurrent.futures import as_completed, ThreadPoolExecutor
+from typing import Any, Dict, List, Optional, Union
+
+import torch
+from torch._inductor.analysis.device_info import (
+    compute_device_ridgepoint,
+    lookup_device_info,
+)
+from torch._inductor.utils import tabulate_2d, zip_dicts
+from torch.utils._ordered_set import OrderedSet
+from tqdm import tqdm
+
+from .dag_nodes import TraceDAG
+from .types import _IdxEvt, Device, DeviceMap, KernelStats, Table
+from .utils import (
+    _augment_trace_helper,
+    _calculate_flops,
+    _create_extern_mapping,
+    _dtype_map,
+    _estimate_gb,
+    _wrap_text,
+    compute_stats_chunk,
+    parse_list,
+)
+
+
+try:
+    import graphviz
+except ImportError:
+    pass
+
+log = logging.getLogger(__name__)
+
+
+class JsonProfile:
+    _devices: DeviceMap
+
+    def __init__(
+        self,
+        path: str,
+        benchmark_name: Optional[str] = None,
+        dtype: Optional[Union[torch.dtype, str]] = None,
+    ):
+        """
+        Convenience class for running common operations on chrome/perfetto json traces.
+        """
+        self.path = path
+        with open(path) as f:
+            self.data = json.load(f)
+            self.events = self.data["traceEvents"]
+        self.benchmark_name = benchmark_name
+        if dtype is None:
+            self.dtype = None
+        elif isinstance(dtype, torch.dtype):
+            self.dtype = dtype
+        else:
+            if dtype in _dtype_map:
+                self.dtype = _dtype_map[dtype]
+            else:
+                self.dtype = None
+        self._create_devices()
+
+    def convert_dtype(self, event: dict[str, Any]) -> Optional[torch.dtype]:
+        """
+        Each op has a list of dtypes for each input arg. We need to convert these into a single dtype for flop estimation.
+        Issues:
+         - converting the strings to concrete torch.dtypes
+         - What if we have float32, float, float16 all in the inputs? Our choice is to use the largest buffer dtype.
+        """
+
+        if (
+            "Input Dims" not in event["args"]
+            or "Input type" not in event["args"]
+            or "Concrete Inputs" not in event["args"]
+        ):
+            if "bfloat16" in event["name"]:
+                return torch.bfloat16
+            elif "float16" in event["name"]:
+                return torch.float16
+            else:
+                return None
+
+        input_sizes = event["args"]["Input Dims"]
+        input_types = event["args"]["Input type"]
+        concrete_inputs = event["args"]["Concrete Inputs"]
+        assert len(input_sizes) == len(input_types)
+        assert len(input_types) == len(concrete_inputs)
+
+        if len(input_sizes) == 0:
+            raise RuntimeError("Empty input_sizes and input_types")
+
+        biggest_size = 0
+        biggest_index = 0
+        for i in range(len(input_sizes)):
+            if concrete_inputs[i] != "":
+                # concrete inputs are usually small tensors, so we can just skip
+                continue
+            my_size = input_sizes[i]
+            total_size = sum(parse_list(my_size))
+            if total_size > biggest_size:
+                biggest_size = total_size
+                biggest_index = i
+        ret_type = input_types[biggest_index]
+        if ret_type in _dtype_map:
+            return _dtype_map[ret_type]
+        raise RuntimeError(f"Unknown type: {ret_type}. Please add to _dtype_map.")
+
+    def _create_devices(self) -> None:
+        self._devices = {}
+        for dev in self.data["deviceProperties"]:
+            name = dev["name"]
+            device_info = lookup_device_info(name)
+
+            if device_info is None:
+                log.info(
+                    "Unsupported device in profile: %s, please consider contributing to _device_mapping.",
+                    name,
+                )
+            self._devices[dev["id"]] = Device(
+                name, dev["id"], device_info, defaultdict(OrderedSet)
+            )
+
+    def calculate_flops(self, event: dict[str, Any]) -> int:
+        return _calculate_flops(event)
+
+    def estimate_gb(self, event: dict[str, Any]) -> float:
+        return _estimate_gb(event)
+
+    def augment_trace(self) -> None:
+        self.data = _augment_trace_helper(self.data)
+
+    def _compute_stats(self, use_parallel: bool = True) -> None:
+        """populates the name -> stats map"""
+        num_events = len(self.events)
+
+        # Use parallel processing for large traces
+        if use_parallel and num_events > 10000:
+            self._compute_stats_parallel()
+            return
+
+        # Original single-threaded implementation for small traces
+        for event in self.events:
+            if "cat" not in event or "args" not in event or event["cat"] != "kernel":
+                continue
+            if "device" not in event["args"]:
+                continue
+            dev_tmp = event["args"]["device"]
+            if dev_tmp not in self._devices:
+                continue
+            dev = self._devices[event["args"]["device"]]
+
+            dur = event["dur"]  # us
+            if "kernel_flop" in event["args"]:
+                assert dur != 0
+                # 1,000,000us/s * flop / us
+                op_flops = event["args"]["kernel_flop"] / (dur / 1e6)
+            else:
+                op_flops = 0
+
+            if "kernel_num_gb" in event["args"]:
+                assert dur != 0
+                # 1,000,000us/s * gb  = gb/s
+                op_gbps = event["args"]["kernel_num_gb"] / (dur / 1e6)
+            else:
+                op_gbps = 0
+
+            if dev.info is not None:
+                dtype = self.convert_dtype(event) or self.dtype
+                if dtype is None:
+                    raise RuntimeError(
+                        "dtype is not found on tensor and default dtype is not set"
+                    )
+                achieved_flops = 100 * op_flops / (1e12 * dev.info.tops[dtype])
+                achieved_bandwidth = 100 * op_gbps / dev.info.dram_bw_gbs
+
+                # Calculate roofline bound type
+                bound_type = self._calculate_bound_type(
+                    dev.name, op_flops, op_gbps, dtype
+                )
+            else:
+                achieved_flops = 0
+                achieved_bandwidth = 0
+                bound_type = "unknown"
+
+            if "name" not in event:
+                continue
+            kernel_name = event["name"]
+            dev.stats[kernel_name].add(
+                KernelStats(
+                    flops=op_flops,
+                    bw=op_gbps,
+                    latency=dur,
+                    achieved_bandwidth=achieved_bandwidth,
+                    achieved_flops=achieved_flops,
+                    bound_type=bound_type,
+                )
+            )
+
+    def _calculate_bound_type(
+        self, device_name: str, op_flops: float, op_gbps: float, dtype: torch.dtype
+    ) -> str:
+        """
+        Calculate whether a kernel is compute-bound or memory-bound based on roofline analysis.
+
+        Args:
+            device_name: Name of the device (e.g., "NVIDIA H100")
+            op_flops: Achieved FLOPS per second for this kernel instance
+            op_gbps: Achieved GB/s for this kernel instance
+            dtype: Data type being used
+
+        Returns:
+            "compute" if compute-bound, "memory" if memory-bound, "unknown" if calculation fails
+        """
+        # Calculate the device ridgepoint B = TOPS / BW
+        ridgepoint = compute_device_ridgepoint(device_name, dtype)
+        if ridgepoint is None:
+            return "unknown"
+
+        # Convert op_flops to TOPS
+        op_tops = op_flops / 1e12
+
+        # Calculate kernel's operational intensity: TOPS / GB/s
+        if op_gbps == 0:
+            # No memory traffic - pure compute
+            return "compute"
+
+        kernel_intensity = op_tops / op_gbps
+
+        # Compare to ridgepoint: if kernel intensity >= ridgepoint, it's compute-bound
+        if kernel_intensity >= ridgepoint:
+            return "compute"
+        else:
+            return "memory"
+
+    def _compute_stats_parallel(self) -> None:
+        """Parallel version of _compute_stats."""
+        num_events = len(self.events)
+        num_workers = min(mp.cpu_count(), max(1, num_events // 2000))
+        chunk_size = max(1, num_events // num_workers)
+
+        print(
+            f"Computing statistics for {num_events} events using {num_workers} workers..."
+        )
+
+        # Split events into chunks
+        chunks = []
+        for i in range(0, num_events, chunk_size):
+            chunk = self.events[i : i + chunk_size]
+            chunks.append((chunk, self._devices, self.dtype))
+
+        # Process chunks in parallel
+        with ThreadPoolExecutor(max_workers=num_workers) as executor:
+            futures = [
+                executor.submit(compute_stats_chunk, chunk_args)
+                for chunk_args in chunks
+            ]
+
+            # Merge results
+            for future in as_completed(futures):
+                local_device_stats = future.result()
+
+                # Merge local_device_stats into self._devices
+                for dev_id, local_stats in local_device_stats.items():
+                    if dev_id in self._devices:
+                        dev = self._devices[dev_id]
+                        for kernel_name, stats_set in local_stats.items():
+                            dev.stats[kernel_name].update(stats_set)
+
+        print("Statistics computation completed.")
+
+    def _create_single_table(self, dev: Device) -> Table:
+        """Create a table with the devices mapped to indices."""
+        headers = [
+            "Kernel Name",
+            "Kernel Count",
+            "FLOPS",
+            "Kernel Reads (GB)",
+            "Dur (us)",
+            "Achieved FLOPS %",
+            "Achieved Bandwidth %",
+        ]
+        rows: dict[str, list[str]] = {}
+
+        def safe_div_format(x: float, y: float) -> str:
+            if y == 0:
+                return "0.0"
+            return f"{x / y:.4f}"
+
+        for kernel_name, stats_set in dev.stats.items():
+            ker_count = 0
+            flops = 0
+            flops_count = 0
+            achieved_flops = 0.0
+            bw = 0.0
+            bw_count = 0
+            achieved_bandwidth = 0.0
+            latency = 0.0
+            for stats in stats_set:
+                if stats.flops != 0:
+                    flops += stats.flops
+                    achieved_flops += stats.achieved_flops
+                    flops_count += 1
+                if stats.bw != 0:
+                    bw += stats.bw
+                    achieved_bandwidth += stats.achieved_bandwidth
+                    bw_count += 1
+                latency += stats.latency
+                ker_count += 1
+            assert ker_count != 0
+            rows[kernel_name] = [
+                str(ker_count),
+                safe_div_format(flops, flops_count),
+                safe_div_format(bw, bw_count),
+                safe_div_format(latency, ker_count),
+                safe_div_format(achieved_flops, flops_count),
+                safe_div_format(achieved_bandwidth, bw_count),
+            ]
+
+        return headers, rows
+
+    def _create_tables(self, devs: DeviceMap) -> dict[int, Table]:
+        return {idx: self._create_single_table(dev) for idx, dev in devs.items()}
+
+    def _combine_tables(
+        self, table1: Table, table1_name: str, table2: Table, table2_name: str
+    ) -> Table:
+        new_headers = (
+            ["Kernel Name"]
+            + [f"{table1_name} {head}" for head in table1[0][1:]]
+            + [f"{table2_name} {head}" for head in table2[0][1:]]
+        )
+        t1_length = len(table1[0][1:])
+        t2_length = len(table2[0][1:])
+        new_rows = {}
+
+        for key, row1, row2 in zip_dicts(
+            table1[1],
+            table2[1],
+            d1_default=["Empty"] * t1_length,
+            d2_default=["Empty"] * t2_length,
+        ):
+            assert row1 is not None
+            assert row2 is not None
+            new_rows[key] = row1 + row2
+        return new_headers, new_rows
+
+    def report(
+        self, other: Optional["JsonProfile"] = None, name_limit: int = 40
+    ) -> str:
+        def create_ret(
+            table_headers: list[str], table_rows: dict[str, list[str]]
+        ) -> str:
+            table_flattened = [
+                [kernel_name[:name_limit], *kernel_vals]
+                for kernel_name, kernel_vals in table_rows.items()
+            ]
+            return tabulate_2d(table_flattened, headers=table_headers)
+
+        if other is not None:
+            self._compute_stats()
+            other._compute_stats()
+
+            self_tables = self._create_tables(self._devices)
+            other_tables = self._create_tables(other._devices)
+
+            self_name = (
+                self.benchmark_name if self.benchmark_name is not None else "Table 1"
+            )
+            other_name = (
+                other.benchmark_name if other.benchmark_name is not None else "Table 2"
+            )
+
+            ret = []
+            assert self._devices.keys() == other._devices.keys()
+            for device_idx, t1, t2 in zip_dicts(
+                self_tables, other_tables, d1_default=None, d2_default=None
+            ):
+                assert t1 is not None
+                assert t2 is not None
+                table_headers, table_rows = self._combine_tables(
+                    t1, self_name, t2, other_name
+                )
+                tab_string = create_ret(table_headers, table_rows)
+                ret.append(f"{self._devices[device_idx]}:\n{tab_string}")
+            return "\n".join(ret)
+        self._compute_stats()
+
+        self_tables = self._create_tables(self._devices)
+
+        ret = []
+        for idx, table in self_tables.items():
+            table_headers, table_rows = table
+            tab_string = create_ret(table_headers, table_rows)
+            ret.append(f"{self._devices[idx]}:\n{tab_string}")
+        return "\n".join(ret)
+
+    def _build_extern_and_kernel_maps(self, use_parallel: bool = True):
+        """Build per-thread intervals with correct parent pointers.
+        Also returns kernels and cudaLaunchKernel indices per thread.
+        """
+        extern_map = _create_extern_mapping(self.data)
+
+        num_events = len(self.events)
+
+        # Use parallel processing for large traces
+        if use_parallel and num_events > 5000:
+            return self._build_extern_and_kernel_maps_parallel(extern_map)
+
+        # Original single-threaded implementation for small traces
+        print("1) Collect intervals per tid (handle 'X' and match 'B'/'E')")
+
+        per_tid_intervals: dict[int, list[_IdxEvt]] = defaultdict(list)
+        open_stack: dict[int, list[tuple[dict[str, Any], int]]] = defaultdict(list)
+
+        for gi, ev in enumerate(self.events):
+            ph = ev.get("ph")
+            tid = ev.get("tid", 0)
+            if ph == "X":
+                ts = ev.get("ts", 0)
+                dur = ev.get("dur", 0)
+                per_tid_intervals[tid].append(
+                    _IdxEvt(
+                        name=ev.get("name", ""),
+                        cat=ev.get("cat", ""),
+                        ts=ts,
+                        end_ts=ts + dur,
+                        tid=tid,
+                        parent=None,  # will fill in below
+                        idx=gi,
+                    )
+                )
+            elif ph == "B":
+                open_stack[tid].append((ev, gi))
+            elif ph == "E":
+                if open_stack[tid]:
+                    beg_ev, beg_idx = open_stack[tid].pop()
+                    per_tid_intervals[tid].append(
+                        _IdxEvt(
+                            name=beg_ev.get("name", ""),
+                            cat=beg_ev.get("cat", ""),
+                            ts=beg_ev.get("ts", 0),
+                            end_ts=ev.get("ts", 0),
+                            tid=tid,
+                            parent=None,  # will fill in below
+                            idx=beg_idx,
+                        )
+                    )
+
+        print(
+            "2) For each thread, sort by (ts, -end_ts) and rebuild parent pointers via sweep line"
+        )
+        per_tid_compact: dict[int, list[_IdxEvt]] = {}
+        launches_per_tid: dict[int, list[_IdxEvt]] = defaultdict(list)
+        kernels: list[dict[str, Any]] = []
+
+        for tid, arr in per_tid_intervals.items():
+            arr.sort(key=lambda x: (x.ts, -x.end_ts))
+            stack: list[int] = []
+            rebuilt: list[_IdxEvt] = []
+
+            for ev in arr:
+                while stack and rebuilt[stack[-1]].end_ts <= ev.ts:
+                    stack.pop()
+                parent_idx = stack[-1] if stack else None
+                rebuilt.append(
+                    _IdxEvt(
+                        name=ev.name,
+                        cat=ev.cat,
+                        ts=ev.ts,
+                        end_ts=ev.end_ts,
+                        tid=tid,
+                        parent=parent_idx,
+                        idx=ev.idx,
+                    )
+                )
+                stack.append(len(rebuilt) - 1)
+
+            per_tid_compact[tid] = rebuilt
+
+            # Collect launches and kernels from rebuilt intervals
+            for it in rebuilt:
+                if "cudaLaunchKer" in it.name:
+                    launches_per_tid[tid].append(it)
+                if it.cat == "kernel":
+                    kernels.append(
+                        {
+                            "event": self.events[it.idx],
+                            "ts": it.ts,
+                            "tid": tid,
+                            "name": it.name,
+                        }
+                    )
+
+            # launches need to be time-sorted for bisect
+            launches_per_tid[tid].sort(key=lambda x: x.ts)
+
+        return extern_map, kernels, per_tid_compact, launches_per_tid
+
+    def _build_extern_and_kernel_maps_parallel(self, extern_map):
+        """Parallel version of _build_extern_and_kernel_maps."""
+        from .utils import process_events_chunk
+
+        num_events = len(self.events)
+        num_workers = min(
+            mp.cpu_count(), max(1, num_events // 1000)
+        )  # At least 1000 events per worker
+        chunk_size = max(1, num_events // num_workers)
+
+        print(f"Processing {num_events} events using {num_workers} workers...")
+
+        # Split events into chunks
+        chunks = []
+        for i in range(0, num_events, chunk_size):
+            chunk = self.events[i : i + chunk_size]
+            chunks.append((chunk, i, self._devices, self.dtype))
+
+        # Process chunks in parallel using threads (since we're I/O bound on data structures)
+        per_tid_intervals_combined = defaultdict(list)
+
+        with ThreadPoolExecutor(max_workers=num_workers) as executor:
+            futures = [
+                executor.submit(process_events_chunk, chunk_args)
+                for chunk_args in chunks
+            ]
+
+            for future in as_completed(futures):
+                per_tid_intervals, _ = future.result()
+
+                # Merge results
+                for tid, intervals in per_tid_intervals.items():
+                    per_tid_intervals_combined[tid].extend(intervals)
+
+        print(
+            f"Event processing completed. Processing {len(per_tid_intervals_combined)} threads..."
+        )
+
+        # Continue with the rest of the processing (sorting, parent pointers, etc.)
+        # This part is harder to parallelize due to dependencies
+        per_tid_compact: dict[int, list[_IdxEvt]] = {}
+        launches_per_tid: dict[int, list[_IdxEvt]] = defaultdict(list)
+        kernels: list[dict[str, Any]] = []
+
+        # Process each thread's intervals in parallel
+        def process_tid_intervals(tid_data):
+            tid, arr = tid_data
+            arr.sort(key=lambda x: (x.ts, -x.end_ts))
+
+            stack: list[int] = []
+            rebuilt: list[_IdxEvt] = []
+
+            for ev in arr:
+                while stack and rebuilt[stack[-1]].end_ts <= ev.ts:
+                    stack.pop()
+                parent_idx = stack[-1] if stack else None
+                rebuilt.append(
+                    _IdxEvt(
+                        name=ev.name,
+                        cat=ev.cat,
+                        ts=ev.ts,
+                        end_ts=ev.end_ts,
+                        tid=tid,
+                        parent=parent_idx,
+                        idx=ev.idx,
+                    )
+                )
+                stack.append(len(rebuilt) - 1)
+
+            # Collect launches and kernels
+            launches = []
+            tid_kernels = []
+
+            for it in rebuilt:
+                if "cudaLaunchKer" in it.name:
+                    launches.append(it)
+                if it.cat == "kernel":
+                    tid_kernels.append(
+                        {
+                            "event": self.events[it.idx],
+                            "ts": it.ts,
+                            "tid": tid,
+                            "name": it.name,
+                        }
+                    )
+
+            launches.sort(key=lambda x: x.ts)
+
+            return tid, rebuilt, launches, tid_kernels
+
+        # Process each thread's data in parallel
+        with ThreadPoolExecutor(
+            max_workers=min(len(per_tid_intervals_combined), num_workers)
+        ) as executor:
+            futures = [
+                executor.submit(process_tid_intervals, (tid, arr))
+                for tid, arr in per_tid_intervals_combined.items()
+            ]
+
+            for future in as_completed(futures):
+                tid, rebuilt, launches, tid_kernels = future.result()
+                per_tid_compact[tid] = rebuilt
+                launches_per_tid[tid] = launches
+                kernels.extend(tid_kernels)
+
+        print(f"Thread processing completed. Found {len(kernels)} kernels.")
+
+        return extern_map, kernels, per_tid_compact, launches_per_tid
+
+    def _find_launch_for_kernel(
+        self, kernel_ev: dict, launches_per_tid: dict[int, list[_IdxEvt]]
+    ) -> Optional[_IdxEvt]:
+        """Find the cudaLaunchKernel that encloses kernel start, using bisect on the kernel's tid and also trying nearby CPU tids when needed."""
+        ts_k = kernel_ev.get("ts", 0)
+        # Try same tid first (some traces put the launch on the same logical tid as API calls)
+        tid = kernel_ev.get("tid", 0)
+        for try_tid in (tid,):
+            la = launches_per_tid.get(try_tid)
+            if not la:
+                continue
+            # Find rightmost launch with start_ts <= ts_k
+            idx = bisect_right([x.ts for x in la], ts_k) - 1
+            if idx >= 0:
+                cand = la[idx]
+                if cand.ts <= ts_k <= cand.end_ts:
+                    return cand
+        # Fallback: scan a tiny set of other tids (cheap) — prefer the nearest enclosing one by (end_ts - ts_k)
+        best = None
+        best_slack = 1 << 62
+        for la in launches_per_tid.values():
+            # binary search to nearest candidate
+            idx = bisect_right([x.ts for x in la], ts_k) - 1
+            if idx >= 0:
+                cand = la[idx]
+                if cand.ts <= ts_k <= cand.end_ts:
+                    slack = cand.end_ts - ts_k
+                    if slack < best_slack:
+                        best, best_slack = cand, slack
+        return best
+
+    def _collect_chain_from(
+        self,
+        start_evt: _IdxEvt,
+        per_tid_compact: dict[int, list[_IdxEvt]],
+        include_all: bool = True,
+    ) -> list[str]:
+        """Walk to the root, returning names from outermost -> leaf.
+        include_all=True keeps user annotations like 'expected' so you see the full tree.
+        """
+        arr = per_tid_compact[start_evt.tid]
+        chain: list[str] = []
+        cur = start_evt
+        tmp: list[str] = []
+        while cur is not None:
+            nm = cur.name
+            if include_all or (
+                nm.startswith("aten::")
+                or "contiguous" in nm
+                or "clone" in nm
+                or "copy" in nm
+                or "empty" in nm
+                or nm.startswith("torch::")
+                or nm.startswith("c10::")
+                or any(
+                    op in nm
+                    for op in ("linear", "conv", "matmul", "bmm", "addmm", "mm")
+                )
+            ):
+                tmp.append(nm)
+            cur = arr[cur.parent] if (cur.parent is not None) else None
+        tmp.reverse()
+        chain.extend(tmp)
+        return chain
+
+    def build_trace_dag(self) -> TraceDAG:
+        """
+        Fast DAG build:
+        - Pre-index per-thread with parent pointers (O(N))
+        - Resolve each kernel to a cpu site (External id or cudaLaunch via bisect) (O(log N) each)
+        - Add edges only (set handles de-dupe)
+        The slow bits are from (a) O(K·N) overlap scans and (b) de-duping whole chains. Below is a drop-in, sweep-line + parent-pointer approach that makes everything essentially O(N log N):
+        Pre-index every cpu_op / user_annotation / cudaLaunchKernel by thread, with parent pointers built from the per-thread stack (no overlap scans).
+        For each kernel, resolve its launching site fast:
+        Prefer args["External id"] → cpu_op (your existing mapping).
+        Else, find the cudaLaunchKernel whose interval contains the kernel start using bisect over a per-thread sorted list (O(log N)).
+        Build the op chain by walking parent pointers from the launch (or external op) up to the root; don't de-dup chains—just add edges (the set takes care of uniqueness).
+        Intern strings and store compact structs to keep memory/cache friendly.
+        Notes on why this is fast
+        No per-kernel O(N) overlap scans; ancestor resolution is O(log N) via bisect → O(K log N).
+        Parent pointers are built in one linear sweep per thread.
+        No chain de-duplication pass; sets make edge/node insertion idempotent.
+        """
+        dag = TraceDAG()
+
+        # Compute stats first to have performance data available
+        self._compute_stats()
+
+        extern_map, kernels, per_tid_compact, launches_per_tid = (
+            self._build_extern_and_kernel_maps()
+        )
+
+        # Track operation instance counts
+        op_instance_counts = defaultdict(int)
+
+        # Pre-intern node objects to reduce dict churn
+        def _get_or_add(name: str, typ: str):
+            node = dag.nodes.get(name)
+            if node is None:
+                node = dag.add_node(name, typ)
+            return node
+
+        for k in tqdm(kernels, desc="Processing kernels"):
+            kev = k["event"]
+            kname = kev.get("name", "unknown_kernel")
+            kdur = kev.get("dur", 0.0)
+            ktid = kev.get("tid", 0)
+
+            # 1) Prefer External id mapping to a concrete cpu_op
+            start_chain_names: list[str] = []
+            ext_ok = False
+            if "args" in kev and "External id" in kev["args"]:
+                ext_id = kev["args"]["External id"]
+                lst = extern_map.get(ext_id)
+                if lst:
+                    # Use the cpu_op we mapped; find its compact record via per-thread binary search
+                    cpu_ev = lst[0]
+                    tid = cpu_ev.get("tid", 0)
+                    arr = per_tid_compact.get(tid, [])
+                    if arr:
+                        # binary search nearest exact match by ts
+                        ts = cpu_ev.get("ts", 0)
+                        idx = bisect_right([x.ts for x in arr], ts) - 1
+                        # walk forward to the first with same ts/name if needed
+                        found = None
+                        for j in range(max(idx, 0), min(idx + 4, len(arr))):
+                            if arr[j].ts == ts and arr[j].name == cpu_ev.get(
+                                "name", ""
+                            ):
+                                found = arr[j]
+                                break
+                        if found:
+                            start_chain_names = self._collect_chain_from(
+                                found, per_tid_compact
+                            )
+                            ext_ok = True
+
+            # 2) Else resolve launch site by bisect
+            if not ext_ok:
+                launch = self._find_launch_for_kernel(kev, launches_per_tid)
+                if launch:
+                    start_chain_names = self._collect_chain_from(
+                        launch, per_tid_compact
+                    )
+
+            # If nothing found, skip — we only keep kernel-linked chains
+            if not start_chain_names:
+                continue
+
+            # Count operation instances and add op nodes and edges
+            for nm in start_chain_names:
+                op_instance_counts[nm] += 1
+
+            prev = None
+            for nm in start_chain_names:
+                _get_or_add(nm, "op")
+                if prev is not None:
+                    dag.add_edge(prev, nm)
+                prev = nm
+
+            # Add the kernel node + edge from last op
+            kernel_node = _get_or_add(kname, "kernel")
+            if prev is not None:
+                dag.add_edge(prev, kname)
+            dag.add_kernel_instance(kname, float(kdur), int(ktid))
+
+            # Collect performance statistics for this kernel instance
+            if "device" in kev.get("args", {}):
+                device_id = kev["args"]["device"]
+                if device_id in self._devices:
+                    dev = self._devices[device_id]
+                    if kname in dev.stats:
+                        # For each kernel instance, add its performance stats
+                        # Since the stats are collected from the same kernel events we're processing,
+                        # we can use all stats for this kernel name
+                        stats_list = list(dev.stats[kname])
+                        if stats_list:
+                            # Find the best matching stats by latency
+                            best_stats = min(
+                                stats_list, key=lambda s: abs(s.latency - kdur)
+                            )
+                            latency_diff = abs(best_stats.latency - kdur)
+                            if (
+                                latency_diff < 100.0
+                            ):  # Increase tolerance to 100 microseconds
+                                kernel_node.achieved_flops_list.append(
+                                    best_stats.achieved_flops
+                                )
+                                kernel_node.achieved_bandwidth_list.append(
+                                    best_stats.achieved_bandwidth
+                                )
+                                kernel_node.bound_type_list.append(
+                                    best_stats.bound_type
+                                )
+
+        # Store operation instance counts in the DAG nodes
+        for op_name, count in tqdm(
+            op_instance_counts.items(), desc="Processing operation instances"
+        ):
+            if op_name in dag.nodes:
+                node = dag.nodes[op_name]
+                if node.node_type == "op":
+                    # Add instance count to operation nodes
+                    node.instance_count = count
+
+        return dag
+
+    def _trace_up_from_kernel(
+        self, kernel_info: Dict, thread_stacks: Dict
+    ) -> List[Dict]:
+        """
+        Trace up from a kernel to find the operation chain that led to it.
+        This uses timing overlap to find parent operations.
+        """
+        chain = []
+        kernel_event = kernel_info["event"]
+        kernel_ts = kernel_info["ts"]
+        kernel_dur = kernel_info.get("dur", 0)
+        kernel_end_ts = kernel_ts + kernel_dur
+
+        # Find events that overlap with the kernel timing
+        overlapping_ops = []
+
+        for event in self.events:
+            if event.get("cat") not in ["cpu_op", "user_annotation"]:
+                continue
+
+            event_ts = event.get("ts", 0)
+            event_dur = event.get("dur", 0)
+            event_end_ts = event_ts + event_dur
+
+            # Check if events overlap
+            if event_ts <= kernel_end_ts and event_end_ts >= kernel_ts:
+                op_name = event.get("name", "")
+
+                # Filter for relevant operations (aten:: ops)
+                if op_name.startswith("aten::") or any(
+                    x in op_name for x in ["contiguous", "clone", "copy", "empty"]
+                ):
+                    overlapping_ops.append(
+                        {
+                            "name": op_name,
+                            "ts": event_ts,
+                            "dur": event_dur,
+                            "end_ts": event_end_ts,
+                            "event": event,
+                        }
+                    )
+
+        # Sort by start time to build the chain
+        overlapping_ops.sort(key=lambda x: x["ts"])
+
+        # Build the operation chain
+        for op in overlapping_ops:
+            chain.append(op)
+
+        # Add the kernel at the end
+        chain.append(
+            {
+                "name": kernel_info["name"],
+                "ts": kernel_ts,
+                "dur": kernel_dur,
+                "event": kernel_event,
+            }
+        )
+
+        return chain
+
+    def _find_connected_kernels(self, dag: TraceDAG, op_node_name: str) -> list[str]:
+        """
+        Find all kernel nodes that are reachable from the given operation node.
+        Uses BFS to traverse the DAG and collect all connected kernels.
+        """
+        visited = OrderedSet()
+        kernel_nodes = []
+        queue = [op_node_name]
+
+        print(f"DEBUG: Finding connected kernels for op: {op_node_name}")
+        print(f"DEBUG: Total edges in DAG: {len(dag.edges)}")
+
+        while queue:
+            current = queue.pop(0)
+            if current in visited:
+                continue
+            visited.add(current)
+
+            # Find all children of current node
+            children_found = []
+            for parent, child in dag.edges:
+                if parent == current and child not in visited:
+                    children_found.append(child)
+                    if dag.nodes[child].node_type == "kernel":
+                        kernel_nodes.append(child)
+                    else:
+                        queue.append(child)
+
+        print(f"DEBUG: Total kernels found: {len(kernel_nodes)}")
+        return kernel_nodes
+
+    def visualize_trace_dag(
+        self,
+        dag: TraceDAG,
+        output_path: str = "trace_dag.png",
+        format: str = "png",
+        color_mode: Optional[str] = None,
+        baseline_profile: Optional["JsonProfile"] = None,
+        height: Optional[int] = None,
+    ) -> None:
+        """
+        Create a PNG visualization of the trace DAG with operations at top and kernels at bottom.
+
+        Args:
+            height: If specified, limits the visualization to only show this many levels
+                    of non-kernel nodes above the kernels. For example, height=1 shows
+                    only the first level of operations directly connected to kernels.
+        """
+        # Note: Visualization libraries assumed to be available
+
+        # Apply height filtering if specified
+        if height is not None and height >= 0:
+            dag = self._filter_dag_by_height(dag, height)
+            print(f"Filtered DAG to height {height}: {len(dag.nodes)} nodes remaining")
+
+        # Calculate total kernel runtime for each operation node
+        op_kernel_runtimes = {}
+        for node_name, node in dag.nodes.items():
+            if node.node_type == "op":
+                connected_kernels = self._find_connected_kernels(dag, node_name)
+                total_runtime = 0.0
+                for kernel_name in connected_kernels:
+                    kernel_node = dag.nodes[kernel_name]
+                    kernel_runtime = sum(dur for dur, _ in kernel_node.kernel_instances)
+                    total_runtime += kernel_runtime
+                op_kernel_runtimes[node_name] = total_runtime
+                # Debug print to verify calculation
+                if total_runtime > 0:
+                    print(
+                        f"Op '{node_name}' has {len(connected_kernels)} connected kernels with total runtime: {total_runtime:.2f}μs"
+                    )
+
+        # Calculate coloring for kernel nodes based on color_mode
+        kernel_colors = {}
+        if color_mode:
+            kernel_colors = self._calculate_kernel_colors(
+                dag, color_mode, baseline_profile
+            )
+        breakpoint()
+
+        # Use graphviz for clean DAG layout
+        try:
+            import graphviz
+
+            dot = graphviz.Digraph(comment="Trace DAG")
+            dot.attr(rankdir="TB")  # Top to bottom layout
+            dot.attr("node", shape="box")
+
+            # Add nodes with different styles for ops vs kernels
+            # Create a mapping for safe node names (graphviz doesn't like special chars)
+            safe_names = {}
+            for i, (node_name, node) in enumerate(dag.nodes.items()):
+                # Create safe name for graphviz
+                safe_name = f"node_{i}"
+                safe_names[node_name] = safe_name
+
+                if node.node_type == "kernel":
+                    # Kernel nodes at bottom with instance count and performance stats
+                    instance_count = len(node.kernel_instances)
+                    total_duration = sum(dur for dur, _ in node.kernel_instances)
+
+                    # Wrap long kernel names for display with proper line breaks
+                    display_name = _wrap_text(node_name, 40)
+
+                    label = f"{display_name}\\n{instance_count} inst\\n{total_duration:.2f}μs total"
+
+                    # Calculate average duration per instance
+                    avg_duration = (
+                        total_duration / instance_count if instance_count > 0 else 0
+                    )
+                    label += f"\\n{avg_duration:.1f}μs avg"
+
+                    # Add performance statistics if available and non-zero
+                    if node.achieved_flops_list:
+                        flops_min = min(node.achieved_flops_list)
+                        flops_max = max(node.achieved_flops_list)
+                        flops_avg = sum(node.achieved_flops_list) / len(
+                            node.achieved_flops_list
+                        )
+                        # Only show FLOPS stats if they're not all zero
+                        if flops_max > 0.0:
+                            label += f"\\nFLOPS %: min={flops_min:.1f}, max={flops_max:.1f}, avg={flops_avg:.1f}"
+
+                    if node.achieved_bandwidth_list:
+                        bw_min = min(node.achieved_bandwidth_list)
+                        bw_max = max(node.achieved_bandwidth_list)
+                        bw_avg = sum(node.achieved_bandwidth_list) / len(
+                            node.achieved_bandwidth_list
+                        )
+                        # Only show BW stats if they're not all zero
+                        if bw_max > 0.0:
+                            label += f"\\nBW %: min={bw_min:.1f}, max={bw_max:.1f}, avg={bw_avg:.1f}"
+
+                    # Add bound type information if available
+                    if node.bound_type_list:
+                        # Count compute vs memory bound instances
+                        compute_count = node.bound_type_list.count("compute")
+                        memory_count = node.bound_type_list.count("memory")
+                        total_bound = compute_count + memory_count
+
+                        if total_bound > 0:
+                            if compute_count > memory_count:
+                                label += (
+                                    f"\\nCompute Bound ({compute_count}/{total_bound})"
+                                )
+                            elif memory_count > compute_count:
+                                label += (
+                                    f"\\nMemory Bound ({memory_count}/{total_bound})"
+                                )
+                            else:
+                                label += f"\\nMixed Bound (C:{compute_count}, M:{memory_count})"
+                        else:
+                            # All instances are unknown bound type
+                            label += "\\nBound: Unknown"
+
+                    # Use color from coloring algorithm or default
+                    color = kernel_colors.get(node_name, "lightcoral")
+                    dot.node(
+                        safe_name,
+                        label,
+                        style="filled",
+                        fillcolor=color,
+                        shape="ellipse",
+                    )
+                else:
+                    # Operation nodes with instance counts and total kernel runtime
+                    instance_count = getattr(node, "instance_count", 0)
+                    # Truncate long operation names for display
+                    # Wrap long operation names for display
+                    display_name = _wrap_text(node_name, 40)
+                    label = f"{display_name}"
+                    if instance_count > 0:
+                        label += f"\\n{instance_count} instances"
+
+                    # Add total kernel runtime if this operation has connected kernels
+                    kernel_runtime = op_kernel_runtimes.get(node_name, 0.0)
+                    if kernel_runtime > 0.0:
+                        label += f"\\nKernel time: {kernel_runtime:.2f}μs"
+
+                    dot.node(
+                        safe_name,
+                        label,
+                        style="filled",
+                        fillcolor="lightblue",
+                        shape="box",
+                    )
+
+            # Add edges using safe names
+            for parent, child in dag.edges:
+                if parent in safe_names and child in safe_names:
+                    dot.edge(safe_names[parent], safe_names[child])
+
+            # Add color legend based on color mode
+            if color_mode:
+                legend_text = self._get_color_legend_text(color_mode)
+                if legend_text:
+                    # Add legend as a separate node
+                    dot.node(
+                        "legend",
+                        legend_text,
+                        shape="note",
+                        style="filled",
+                        fillcolor="white",
+                    )
+
+            # Render to specified format
+            base_path = output_path.replace(".png", "").replace(".svg", "")
+            dot.render(base_path, format=format, cleanup=True)
+            print(f"DAG visualization saved to {output_path}")
+
+        except Exception as e:
+            print(f"Graphviz visualization failed: {e}")
+
+    def _calculate_kernel_colors(
+        self,
+        dag: TraceDAG,
+        color_mode: str,
+        baseline_profile: Optional["JsonProfile"] = None,
+    ) -> Dict[str, str]:
+        """
+        Calculate colors for kernel nodes based on the specified color mode.
+        Always uses time-based gradients as the base, with intensity modified by color mode.
+        Returns a dictionary mapping kernel names to color strings.
+        """
+        if color_mode not in [
+            "time",
+            "diff",
+            "mem-utilization",
+            "compute-utilization",
+            "roofline",
+        ]:
+            return {}
+
+        kernel_colors = {}
+        kernel_nodes = {
+            name: node for name, node in dag.nodes.items() if node.node_type == "kernel"
+        }
+
+        if not kernel_nodes:
+            return {}
+
+        # Always start with time-based gradients as the base
+        base_time_gradients = dag.calculate_kernel_time_gradients()
+
+        if color_mode == "time":
+            # For "time" mode, just return the base gradients
+            return base_time_gradients
+
+        # For other modes, modify the intensity based on the specific metrics
+        if color_mode == "diff":
+            if baseline_profile is None:
+                print(
+                    "Warning: diff coloring requested but no baseline profile provided"
+                )
+                return base_time_gradients
+
+            # Build baseline DAG to get kernel durations
+            baseline_dag = baseline_profile.build_trace_dag()
+            baseline_durations = {}
+
+            for name, node in baseline_dag.nodes.items():
+                if node.node_type == "kernel":
+                    total_duration = sum(dur for dur, _ in node.kernel_instances)
+                    baseline_durations[name] = total_duration
+
+            # Calculate duration differences and modify the base gradients
+            for name, base_color in base_time_gradients.items():
+                if name not in kernel_nodes:
+                    continue
+
+                current_duration = sum(
+                    dur for dur, _ in kernel_nodes[name].kernel_instances
+                )
+                baseline_duration = baseline_durations.get(name, 0.0)
+
+                if baseline_duration == 0.0:
+                    # Kernel not present in baseline - use red tinted version
+                    kernel_colors[name] = self._tint_color(base_color, "red", 0.8)
+                else:
+                    diff_ratio = (
+                        current_duration - baseline_duration
+                    ) / baseline_duration
+                    # Positive diff (slower) -> red tint, negative diff (faster) -> blue tint
+                    if diff_ratio > 0.1:  # More than 10% slower
+                        tint_intensity = min(1.0, diff_ratio)
+                        kernel_colors[name] = self._tint_color(
+                            base_color, "red", tint_intensity
+                        )
+                    elif diff_ratio < -0.1:  # More than 10% faster
+                        tint_intensity = min(1.0, abs(diff_ratio))
+                        kernel_colors[name] = self._tint_color(
+                            base_color, "blue", tint_intensity
+                        )
+                    else:
+                        # Similar performance - use base time gradient
+                        kernel_colors[name] = base_color
+
+        elif color_mode == "mem-utilization":
+            # Modify base gradients based on memory bandwidth utilization
+            for name, base_color in base_time_gradients.items():
+                if name not in kernel_nodes:
+                    continue
+
+                node = kernel_nodes[name]
+                if node.achieved_bandwidth_list:
+                    avg_utilization = sum(node.achieved_bandwidth_list) / len(
+                        node.achieved_bandwidth_list
+                    )
+                    # Higher utilization -> more green tint
+                    utilization_intensity = min(
+                        1.0, avg_utilization / 100.0
+                    )  # Normalize to [0,1]
+                    kernel_colors[name] = self._tint_color(
+                        base_color, "green", utilization_intensity
+                    )
+                else:
+                    # No utilization data - use base gradient
+                    kernel_colors[name] = base_color
+
+        elif color_mode == "compute-utilization":
+            # Modify base gradients based on compute (FLOPS) utilization
+            for name, base_color in base_time_gradients.items():
+                if name not in kernel_nodes:
+                    continue
+
+                node = kernel_nodes[name]
+                if node.achieved_flops_list:
+                    avg_utilization = sum(node.achieved_flops_list) / len(
+                        node.achieved_flops_list
+                    )
+                    # Higher utilization -> more purple tint
+                    utilization_intensity = min(
+                        1.0, avg_utilization / 100.0
+                    )  # Normalize to [0,1]
+                    kernel_colors[name] = self._tint_color(
+                        base_color, "purple", utilization_intensity
+                    )
+                else:
+                    # No utilization data - use base gradient
+                    kernel_colors[name] = base_color
+
+        elif color_mode == "roofline":
+            # Modify base gradients based on roofline analysis
+            for name, base_color in base_time_gradients.items():
+                if name not in kernel_nodes:
+                    continue
+
+                node = kernel_nodes[name]
+                if (
+                    node.bound_type_list
+                    and node.achieved_flops_list
+                    and node.achieved_bandwidth_list
+                ):
+                    # Calculate the average roofline score
+                    bound_types = node.bound_type_list
+                    flops_utils = node.achieved_flops_list
+                    bw_utils = node.achieved_bandwidth_list
+
+                    total_score = 0.0
+                    valid_instances = 0
+
+                    for i in range(
+                        min(len(bound_types), len(flops_utils), len(bw_utils))
+                    ):
+                        bound_type = bound_types[i]
+                        if bound_type == "compute":
+                            total_score += flops_utils[i]
+                            valid_instances += 1
+                        elif bound_type == "memory":
+                            total_score += bw_utils[i]
+                            valid_instances += 1
+
+                    if valid_instances > 0:
+                        avg_score = total_score / valid_instances
+                        # Lower utilization -> more red tint (worse performance)
+                        utilization_intensity = 1.0 - min(1.0, avg_score / 100.0)
+                        kernel_colors[name] = self._tint_color(
+                            base_color, "red", utilization_intensity
+                        )
+                    else:
+                        kernel_colors[name] = base_color
+                else:
+                    # No roofline data - use base gradient
+                    kernel_colors[name] = base_color
+
+        return kernel_colors
+
+    def _tint_color(self, base_color: str, tint: str, intensity: float) -> str:
+        """Apply a color tint to a base color with given intensity."""
+        # Convert hex to RGB
+        base_color = base_color.lstrip("#")
+        r, g, b = tuple(int(base_color[i : i + 2], 16) for i in (0, 2, 4))
+
+        # Define tint colors
+        tint_colors = {
+            "red": (255, 0, 0),
+            "blue": (0, 0, 255),
+            "green": (0, 255, 0),
+            "purple": (255, 0, 255),
+        }
+
+        if tint not in tint_colors:
+            return base_color
+
+        tint_r, tint_g, tint_b = tint_colors[tint]
+
+        # Blend base color with tint based on intensity
+        final_r = int(r * (1 - intensity) + tint_r * intensity)
+        final_g = int(g * (1 - intensity) + tint_g * intensity)
+        final_b = int(b * (1 - intensity) + tint_b * intensity)
+
+        # Ensure values are in valid range
+        final_r = max(0, min(255, final_r))
+        final_g = max(0, min(255, final_g))
+        final_b = max(0, min(255, final_b))
+
+        return f"#{final_r:02x}{final_g:02x}{final_b:02x}"
+
+    def _filter_dag_by_height(self, dag: TraceDAG, height: int) -> TraceDAG:
+        """
+        Filter the DAG to only show nodes up to a specified height above kernel nodes.
+
+        Args:
+            dag: The original DAG
+            height: Maximum levels of non-kernel nodes to show above kernels
+                   (0 = only kernels, 1 = kernels + direct parents, etc.)
+
+        Returns:
+            A new filtered DAG containing only nodes within the height limit
+        """
+        if height < 0:
+            return dag
+
+        filtered_dag = TraceDAG()
+
+        # Find all kernel nodes first
+        kernel_nodes = {
+            name for name, node in dag.nodes.items() if node.node_type == "kernel"
+        }
+
+        # If height is 0, only show kernels
+        if height == 0:
+            for kernel_name in kernel_nodes:
+                kernel_node = dag.nodes[kernel_name]
+                filtered_dag.add_node(kernel_name, "kernel")
+                # Copy kernel instances
+                for dur, tid in kernel_node.kernel_instances:
+                    filtered_dag.add_kernel_instance(kernel_name, dur, tid)
+                # Copy performance stats
+                filtered_dag.nodes[kernel_name].achieved_flops_list = (
+                    kernel_node.achieved_flops_list[:]
+                )
+                filtered_dag.nodes[kernel_name].achieved_bandwidth_list = (
+                    kernel_node.achieved_bandwidth_list[:]
+                )
+                filtered_dag.nodes[kernel_name].bound_type_list = (
+                    kernel_node.bound_type_list[:]
+                )
+            return filtered_dag
+
+        # Perform reverse BFS from kernels to find nodes within height limit
+        # We need to traverse backwards through the DAG edges
+        # Build reverse edge mapping first
+        reverse_edges = defaultdict(list)
+        for parent, child in dag.edges:
+            reverse_edges[child].append(parent)
+
+        # BFS from kernel nodes going backwards (upwards in the DAG)
+        nodes_to_include = set(kernel_nodes)  # Always include kernels
+        current_level = kernel_nodes.copy()
+
+        for level in range(height):
+            next_level = set()
+            for node in current_level:
+                # Add all parents of current level nodes
+                for parent in reverse_edges[node]:
+                    if parent not in nodes_to_include:
+                        next_level.add(parent)
+                        nodes_to_include.add(parent)
+
+            if not next_level:
+                break  # No more levels to explore
+
+            current_level = next_level
+
+        # Build the filtered DAG with only the nodes we want to include
+        for node_name in nodes_to_include:
+            original_node = dag.nodes[node_name]
+            filtered_dag.add_node(node_name, original_node.node_type)
+
+            # Copy node-specific data
+            if original_node.node_type == "kernel":
+                # Copy kernel instances
+                for dur, tid in original_node.kernel_instances:
+                    filtered_dag.add_kernel_instance(node_name, dur, tid)
+                # Copy performance stats
+                filtered_dag.nodes[node_name].achieved_flops_list = (
+                    original_node.achieved_flops_list[:]
+                )
+                filtered_dag.nodes[node_name].achieved_bandwidth_list = (
+                    original_node.achieved_bandwidth_list[:]
+                )
+                filtered_dag.nodes[node_name].bound_type_list = (
+                    original_node.bound_type_list[:]
+                )
+            else:
+                # Copy operation node data
+                if hasattr(original_node, "instance_count"):
+                    filtered_dag.nodes[node_name].instance_count = (
+                        original_node.instance_count
+                    )
+
+        # Add edges that connect nodes within our filtered set
+        for parent, child in dag.edges:
+            if parent in nodes_to_include and child in nodes_to_include:
+                filtered_dag.add_edge(parent, child)
+
+        return filtered_dag
+
+    def _get_color_legend_text(self, color_mode: str) -> Optional[str]:
+        """Get legend text for the specified color mode."""
+        if color_mode == "diff":
+            return "Legend\\nRed: Slower than baseline\\nBlue: Faster than baseline\\nWhite: Same as baseline"
+        elif color_mode == "mem-utilization":
+            return "Legend\\nGreen: Memory bandwidth utilization\\nDarker = lower utilization"
+        elif color_mode == "compute-utilization":
+            return "Legend\\nPurple: Compute utilization\\nDarker = lower utilization"
+        elif color_mode == "roofline":
+            return "Legend\\nRoofline Analysis\\nDark Red: Low utilization (worse)\\nLight Yellow: High utilization (better)\\nCompute-bound: Uses compute %\\nMemory-bound: Uses memory %"
+        return None
+
+    def _is_trace_augmented(self) -> bool:
+        """Check if the trace has been augmented with performance information."""
+        for event in self.events:
+            if event.get("cat") == "kernel" and "args" in event:
+                # If we find a kernel with performance data, the trace is augmented
+                if "kernel_flop" in event["args"] or "kernel_num_gb" in event["args"]:
+                    return True
+        return False
+
+    def create_trace_dag_visualization(
+        self,
+        output_path: str = "trace_dag.png",
+        format: str = "png",
+        color_mode: Optional[str] = None,
+        baseline_profile: Optional["JsonProfile"] = None,
+        height: Optional[int] = None,
+    ) -> TraceDAG:
+        """
+        Convenience method to build and visualize the trace DAG in one step.
+        Automatically augments the trace if it hasn't been augmented yet.
+        Returns the created DAG for further analysis.
+        """
+        # Check if trace needs augmentation
+        if not self._is_trace_augmented():
+            print("Trace not augmented with performance data. Augmenting trace...")
+            self.augment_trace()
+            print("Trace augmentation completed.")
+        else:
+            print("Trace already augmented with performance data.")
+
+        print("Building trace DAG from JSON profile...")
+        dag = self.build_trace_dag()
+
+        print(f"DAG created with {len(dag.nodes)} nodes and {len(dag.edges)} edges")
+        print(
+            f"Operations: {[name for name, node in dag.nodes.items() if node.node_type == 'op']}"
+        )
+        print(
+            f"Kernels: {[name for name, node in dag.nodes.items() if node.node_type == 'kernel']}"
+        )
+
+        # Check if performance statistics are available
+        kernels_with_perf_stats = sum(
+            1
+            for node in dag.nodes.values()
+            if node.node_type == "kernel"
+            and (
+                (node.achieved_flops_list and max(node.achieved_flops_list) > 0)
+                or (
+                    node.achieved_bandwidth_list
+                    and max(node.achieved_bandwidth_list) > 0
+                )
+            )
+        )
+
+        if kernels_with_perf_stats == 0:
+            print(
+                """
+                Note: No performance statistics (FLOPS/bandwidth %) are displayed because the trace lacks tensor \
+shape and type information needed for calculations. To include performance metrics, run torch.profiler.profile with record_shapes=True
+                """
+            )
+
+        print(f"Visualizing DAG to {output_path}...")
+        self.visualize_trace_dag(
+            dag, output_path, format, color_mode, baseline_profile, height
+        )
+
+        return dag
+
+    def dump(self, out: str) -> None:
+        with open(out, "w") as f:
+            json.dump(self.data, f)
+
+    def combine_with(self, other: "JsonProfile") -> "JsonProfile":
+        """
+        Combine this profile with another profile by merging their trace events.
+        Returns a new JsonProfile object with combined data.
+        """
+        # Create a new combined data structure
+        combined_data = {
+            "traceEvents": self.data["traceEvents"] + other.data["traceEvents"],
+            "deviceProperties": self.data.get("deviceProperties", []),
+        }
+
+        # Merge device properties, avoiding duplicates
+        other_device_props = other.data.get("deviceProperties", [])
+        existing_device_ids = OrderedSet(
+            [dev["id"] for dev in combined_data["deviceProperties"]]
+        )
+
+        for device_prop in other_device_props:
+            if device_prop["id"] not in existing_device_ids:
+                combined_data["deviceProperties"].append(device_prop)
+
+        # Copy any other top-level properties from the first profile
+        for key, value in self.data.items():
+            if key not in combined_data:
+                combined_data[key] = value
+
+        # Create a temporary file to write the combined data
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as tmp_file:
+            json.dump(combined_data, tmp_file)
+            tmp_path = tmp_file.name
+
+        try:
+            # Create new JsonProfile from the combined data
+            combined_profile = JsonProfile(
+                tmp_path,
+                benchmark_name=f"{self.benchmark_name or 'Profile1'}_+_{other.benchmark_name or 'Profile2'}",
+                dtype=self.dtype or other.dtype,
+            )
+            return combined_profile
+        finally:
+            # Clean up temporary file
+            os.unlink(tmp_path)

--- a/torch/_inductor/analysis/profile_analysis.py
+++ b/torch/_inductor/analysis/profile_analysis.py
@@ -1,13 +1,18 @@
-import json
 import logging
 import math
+import os
+import shutil
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, Callable, Optional, Union
 
 import torch
-from torch._inductor.analysis.device_info import DeviceSpec, lookup_device_info
-from torch._inductor.utils import tabulate_2d, zip_dicts
+from torch._inductor.analysis.device_info import DeviceSpec
+from torch._inductor.analysis.json_profile import JsonProfile
+from torch._inductor.analysis.utils import (
+    create_multi_trace_visualization,
+    get_cache_dir,
+)
 from torch.utils import _pytree as pytree
 from torch.utils._ordered_set import OrderedSet
 from torch.utils.flop_counter import flop_registry
@@ -392,334 +397,6 @@ DeviceMap = dict[int, Device]
 Table = tuple[list[str], dict[str, list[str]]]
 
 
-class JsonProfile:
-    _devices: DeviceMap
-
-    def __init__(
-        self,
-        path: str,
-        benchmark_name: Optional[str] = None,
-        dtype: Optional[Union[torch.dtype, str]] = None,
-    ):
-        """
-        Convenience class for running common operations on chrome/perfetto json traces.
-        """
-        self.path = path
-        with open(path) as f:
-            self.data = json.load(f)
-            self.events = self.data["traceEvents"]
-        self.benchmark_name = benchmark_name
-        if dtype is None:
-            self.dtype = None
-        elif isinstance(dtype, torch.dtype):
-            self.dtype = dtype
-        else:
-            if dtype in _dtype_map:
-                self.dtype = _dtype_map[dtype]
-            else:
-                self.dtype = None
-        self._create_devices()
-
-    def convert_dtype(self, event: dict[str, Any]) -> Optional[torch.dtype]:
-        """
-        Each op has a list of dtypes for each input arg. We need to convert these into a single dtype for flop estimation.
-        Issues:
-         - converting the strings to concrete torch.dtypes
-         - What if we have float32, float, float16 all in the inputs? Our choice is to use the largest buffer dtype.
-        """
-
-        if (
-            "Input Dims" not in event["args"]
-            or "Input type" not in event["args"]
-            or "Concrete Inputs" not in event["args"]
-        ):
-            if "bfloat16" in event["name"]:
-                return torch.bfloat16
-            elif "float16" in event["name"]:
-                return torch.float16
-            else:
-                return None
-
-        input_sizes = event["args"]["Input Dims"]
-        input_types = event["args"]["Input type"]
-        concrete_inputs = event["args"]["Concrete Inputs"]
-        assert len(input_sizes) == len(input_types)
-        assert len(input_types) == len(concrete_inputs)
-
-        if len(input_sizes) == 0:
-            raise RuntimeError("Empty input_sizes and input_types")
-
-        biggest_size = 0
-        biggest_index = 0
-        for i in range(len(input_sizes)):
-            if concrete_inputs[i] != "":
-                # concrete inputs are usually small tensors, so we can just skip
-                continue
-            my_size = input_sizes[i]
-            total_size = sum(parse_list(my_size))
-            if total_size > biggest_size:
-                biggest_size = total_size
-                biggest_index = i
-        ret_type = input_types[biggest_index]
-        if ret_type in _dtype_map:
-            return _dtype_map[ret_type]
-        raise RuntimeError(f"Unknown type: {ret_type}. Please add to _dtype_map.")
-
-    def _create_devices(self) -> None:
-        self._devices = {}
-        for dev in self.data["deviceProperties"]:
-            name = dev["name"]
-            device_info = lookup_device_info(name)
-
-            if device_info is None:
-                log.info(
-                    "Unsupported device in profile: %s, please consider contributing to _device_mapping.",
-                    name,
-                )
-            self._devices[dev["id"]] = Device(
-                name, dev["id"], device_info, defaultdict(OrderedSet)
-            )
-
-    def calculate_flops(self, event: dict[str, Any]) -> int:
-        return _calculate_flops(event)
-
-    def estimate_gb(self, event: dict[str, Any]) -> float:
-        return _estimate_gb(event)
-
-    def augment_trace(self) -> None:
-        self.data = _augment_trace_helper(self.data)
-
-    def _compute_stats(self) -> None:
-        """populates the name -> stats map"""
-        for event in self.events:
-            if "cat" not in event or "args" not in event or event["cat"] != "kernel":
-                continue
-            if "device" not in event["args"]:
-                continue
-            dev_tmp = event["args"]["device"]
-            if dev_tmp not in self._devices:
-                continue
-            dev = self._devices[event["args"]["device"]]
-
-            dur = event["dur"]  # us
-            if "kernel_flop" in event["args"]:
-                assert dur != 0
-                # 1,000,000us/s * flop / us
-                op_flops = event["args"]["kernel_flop"] / (dur / 1e6)
-            else:
-                op_flops = 0
-
-            if "kernel_num_gb" in event["args"]:
-                assert dur != 0
-                # 1,000,000us/s * gb  = gb/s
-                op_gbps = event["args"]["kernel_num_gb"] / (dur / 1e6)
-            else:
-                op_gbps = 0
-
-            if dev.info is not None:
-                dtype = self.convert_dtype(event) or self.dtype
-                if dtype is None:
-                    raise RuntimeError(
-                        "dtype is not found on tensor and default dtype is not set"
-                    )
-                achieved_flops = 100 * op_flops / (1e12 * dev.info.tops[dtype])
-                achieved_bandwidth = 100 * op_gbps / dev.info.dram_bw_gbs
-            else:
-                achieved_flops = 0
-                achieved_bandwidth = 0
-
-            if "name" not in event["args"]:
-                continue
-            dev.stats[event["name"]].add(
-                KernelStats(
-                    flops=op_flops,
-                    bw=op_gbps,
-                    latency=dur,
-                    achieved_bandwidth=achieved_bandwidth,
-                    achieved_flops=achieved_flops,
-                )
-            )
-
-    def _create_single_table(self, dev: Device) -> Table:
-        """Create a table with the devices mapped to indices."""
-        headers = [
-            "Kernel Name",
-            "Kernel Count",
-            "FLOPS",
-            "Kernel Reads (GB)",
-            "Dur (us)",
-            "Achieved FLOPS %",
-            "Achieved Bandwidth %",
-        ]
-        rows: dict[str, list[str]] = {}
-
-        def safe_div_format(x: float, y: float) -> str:
-            if y == 0:
-                return "0.0"
-            return f"{x / y:.4f}"
-
-        for kernel_name, stats_set in dev.stats.items():
-            ker_count = 0
-            flops = 0
-            flops_count = 0
-            achieved_flops = 0.0
-            bw = 0.0
-            bw_count = 0
-            achieved_bandwidth = 0.0
-            latency = 0.0
-            for stats in stats_set:
-                if stats.flops != 0:
-                    flops += stats.flops
-                    achieved_flops += stats.achieved_flops
-                    flops_count += 1
-                if stats.bw != 0:
-                    bw += stats.bw
-                    achieved_bandwidth += stats.achieved_bandwidth
-                    bw_count += 1
-                latency += stats.latency
-                ker_count += 1
-            assert ker_count != 0
-            rows[kernel_name] = [
-                str(ker_count),
-                safe_div_format(flops, flops_count),
-                safe_div_format(bw, bw_count),
-                safe_div_format(latency, ker_count),
-                safe_div_format(achieved_flops, flops_count),
-                safe_div_format(achieved_bandwidth, bw_count),
-            ]
-
-        return headers, rows
-
-    def _create_tables(self, devs: DeviceMap) -> dict[int, Table]:
-        return {idx: self._create_single_table(dev) for idx, dev in devs.items()}
-
-    def _combine_tables(
-        self, table1: Table, table1_name: str, table2: Table, table2_name: str
-    ) -> Table:
-        new_headers = (
-            ["Kernel Name"]
-            + [f"{table1_name} {head}" for head in table1[0][1:]]
-            + [f"{table2_name} {head}" for head in table2[0][1:]]
-        )
-        t1_length = len(table1[0][1:])
-        t2_length = len(table2[0][1:])
-        new_rows = {}
-
-        for key, row1, row2 in zip_dicts(
-            table1[1],
-            table2[1],
-            d1_default=["Empty"] * t1_length,
-            d2_default=["Empty"] * t2_length,
-        ):
-            assert row1 is not None
-            assert row2 is not None
-            new_rows[key] = row1 + row2
-        return new_headers, new_rows
-
-    def report(
-        self, other: Optional["JsonProfile"] = None, name_limit: int = 40
-    ) -> str:
-        def create_ret(
-            table_headers: list[str], table_rows: dict[str, list[str]]
-        ) -> str:
-            table_flattened = [
-                [kernel_name[:name_limit], *kernel_vals]
-                for kernel_name, kernel_vals in table_rows.items()
-            ]
-            return tabulate_2d(table_flattened, headers=table_headers)
-
-        if other is not None:
-            self._compute_stats()
-            other._compute_stats()
-
-            self_tables = self._create_tables(self._devices)
-            other_tables = self._create_tables(other._devices)
-
-            self_name = (
-                self.benchmark_name if self.benchmark_name is not None else "Table 1"
-            )
-            other_name = (
-                other.benchmark_name if other.benchmark_name is not None else "Table 2"
-            )
-
-            ret = []
-            assert self._devices.keys() == other._devices.keys()
-            for device_idx, t1, t2 in zip_dicts(
-                self_tables, other_tables, d1_default=None, d2_default=None
-            ):
-                assert t1 is not None
-                assert t2 is not None
-                table_headers, table_rows = self._combine_tables(
-                    t1, self_name, t2, other_name
-                )
-                tab_string = create_ret(table_headers, table_rows)
-                ret.append(f"{self._devices[device_idx]}:\n{tab_string}")
-            return "\n".join(ret)
-        self._compute_stats()
-
-        self_tables = self._create_tables(self._devices)
-
-        ret = []
-        for idx, table in self_tables.items():
-            table_headers, table_rows = table
-            tab_string = create_ret(table_headers, table_rows)
-            ret.append(f"{self._devices[idx]}:\n{tab_string}")
-        return "\n".join(ret)
-
-    def dump(self, out: str) -> None:
-        with open(out, "w") as f:
-            json.dump(self.data, f)
-
-    def combine_with(self, other: "JsonProfile") -> "JsonProfile":
-        """
-        Combine this profile with another profile by merging their trace events.
-        Returns a new JsonProfile object with combined data.
-        """
-        # Create a new combined data structure
-        combined_data = {
-            "traceEvents": self.data["traceEvents"] + other.data["traceEvents"],
-            "deviceProperties": self.data.get("deviceProperties", []),
-        }
-
-        # Merge device properties, avoiding duplicates
-        other_device_props = other.data.get("deviceProperties", [])
-        existing_device_ids = OrderedSet(
-            [dev["id"] for dev in combined_data["deviceProperties"]]
-        )
-
-        for device_prop in other_device_props:
-            if device_prop["id"] not in existing_device_ids:
-                combined_data["deviceProperties"].append(device_prop)
-
-        # Copy any other top-level properties from the first profile
-        for key, value in self.data.items():
-            if key not in combined_data:
-                combined_data[key] = value
-
-        import os
-
-        # Create a temporary file to write the combined data
-        import tempfile
-
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".json", delete=False
-        ) as tmp_file:
-            json.dump(combined_data, tmp_file)
-            tmp_path = tmp_file.name
-
-        try:
-            # Create new JsonProfile from the combined data
-            combined_profile = JsonProfile(
-                tmp_path,
-                benchmark_name=f"{self.benchmark_name or 'Profile1'}_+_{other.benchmark_name or 'Profile2'}",
-                dtype=self.dtype or other.dtype,
-            )
-            return combined_profile
-        finally:
-            # Clean up temporary file
-            os.unlink(tmp_path)
-
-
 class ParseException(RuntimeError):
     pass
 
@@ -918,7 +595,7 @@ Specify as <input_file1> [input_file2 ...] <dtype> <output_file>. At least 3 arg
 
             # Check if trace needs augmentation and augment if needed
             if not profile._is_trace_augmented():
-                print(f"Augmenting trace to add performance statistics...")
+                print("Augmenting trace to add performance statistics...")
                 profile.augment_trace()
                 print("Trace augmentation completed.")
 
@@ -928,7 +605,7 @@ Specify as <input_file1> [input_file2 ...] <dtype> <output_file>. At least 3 arg
                 baseline_profile = JsonProfile(args.diff_baseline, dtype=dtype)
                 # Also check and augment baseline profile if needed
                 if not baseline_profile._is_trace_augmented():
-                    print(f"Augmenting baseline trace to add performance statistics...")
+                    print("Augmenting baseline trace to add performance statistics...")
                     baseline_profile.augment_trace()
                     print("Baseline trace augmentation completed.")
 
@@ -950,11 +627,10 @@ Specify as <input_file1> [input_file2 ...] <dtype> <output_file>. At least 3 arg
                 baseline_profile = JsonProfile(args.diff_baseline, dtype=dtype)
                 # Check and augment baseline profile if needed
                 if not baseline_profile._is_trace_augmented():
-                    print(f"Augmenting baseline trace to add performance statistics...")
+                    print("Augmenting baseline trace to add performance statistics...")
                     baseline_profile.augment_trace()
                     print("Baseline trace augmentation completed.")
 
-            # Multi-trace visualization with parallel and caching options
             multi_dag = create_multi_trace_visualization(
                 input_files,
                 output_file,

--- a/torch/_inductor/analysis/profile_analysis.py
+++ b/torch/_inductor/analysis/profile_analysis.py
@@ -499,7 +499,15 @@ Specify as <input_file1> [input_file2 ...] <dtype> <output_file>. At least 3 arg
         type=int,
         help="Limit the height of the visualization to only show this many levels of non-kernel nodes above kernels. For example, height=1 shows only direct parents of kernels. Default: no height limit.",
     )
+    parser.add_argument(
+        "--compact",
+        action="store_true",
+        default=True,
+        help="Make kernel names compact without line wrapping.",
+    )
     args = parser.parse_args()
+
+    compact_mode = args.compact
 
     # Validate color/diff-baseline arguments
     if args.color == "diff" and not args.diff_baseline:
@@ -615,6 +623,7 @@ Specify as <input_file1> [input_file2 ...] <dtype> <output_file>. At least 3 arg
                 color_mode=args.color,
                 baseline_profile=baseline_profile,
                 height=args.height,
+                compact=compact_mode,
             )
             print(f"DAG visualization completed and saved to {output_file}")
             print(
@@ -642,6 +651,7 @@ Specify as <input_file1> [input_file2 ...] <dtype> <output_file>. At least 3 arg
                 height=args.height,
                 color_mode=args.color,
                 baseline_profile=baseline_profile,
+                compact=compact_mode,
             )
             print(f"Multi-trace DAG visualization completed and saved to {output_file}")
             print(

--- a/torch/_inductor/analysis/types.py
+++ b/torch/_inductor/analysis/types.py
@@ -1,0 +1,58 @@
+"""
+Data types and dataclasses for profile analysis.
+"""
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+from torch._inductor.analysis.device_info import DeviceSpec
+from torch.utils._ordered_set import OrderedSet
+
+
+@dataclass
+class ProfileEvent:
+    category: str
+    key: str
+    self_device_time_ms: float
+    # the benchmark is run multiple times and we average the count across all the
+    # runs. It should be an integer but define a float just in case.
+    count: float
+
+
+@dataclass(frozen=True)
+class KernelStats:
+    flops: int
+    bw: float
+    latency: float  # us
+    achieved_flops: float
+    achieved_bandwidth: float
+    bound_type: str = "unknown"  # "compute", "memory", or "unknown"
+
+
+@dataclass(frozen=False)
+class Device:
+    name: str
+    index: int
+    info: Optional[DeviceSpec]
+    stats: "KernelNameMap"
+
+    def __repr__(self) -> str:
+        return f"Device({self.name}, {self.index}): {self.info}"
+
+
+@dataclass(frozen=True)
+class _IdxEvt:
+    name: str
+    cat: str
+    ts: int
+    end_ts: int
+    tid: int
+    parent: Optional[int]  # index into per-thread array
+    idx: int  # global index into self.events
+
+
+# Type aliases
+KernelNameMap = defaultdict[str, OrderedSet[KernelStats]]
+DeviceMap = Dict[int, Device]
+Table = Tuple[List[str], Dict[str, List[str]]]

--- a/torch/_inductor/analysis/utils.py
+++ b/torch/_inductor/analysis/utils.py
@@ -1,0 +1,1398 @@
+"""
+Utility functions for profile analysis.
+"""
+
+import hashlib
+import logging
+import math
+import multiprocessing as mp
+import os
+import pickle
+import tempfile
+from collections import defaultdict
+from concurrent.futures import as_completed, ProcessPoolExecutor
+from typing import Any, Callable, List, Optional, Union
+
+import torch
+from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.utils import _pytree as pytree
+from torch.utils._ordered_set import OrderedSet
+from torch.utils.flop_counter import flop_registry
+
+from .types import _IdxEvt, KernelStats
+
+
+try:
+    import graphviz
+
+    VISUALIZATION_AVAILABLE = True
+except ImportError:
+    VISUALIZATION_AVAILABLE = False
+
+
+log = logging.getLogger(__name__)
+
+
+ATEN_PREFIX = "aten::"
+
+
+# adapters convert the json trace into a format that works with flops_counter
+ArgsType = tuple[tuple[Any, ...], dict[Any, Any]]
+AdapterType = Callable[[tuple[Any, ...], tuple[Any, ...]], ArgsType]
+adapters_map: dict[str, AdapterType] = {}
+
+
+def parse_list(lst: str) -> list[int]:
+    lst = lst.replace("[", "").replace("]", "")
+    substrings = lst.split(",")
+
+    return [int(substring.strip()) for substring in substrings]
+
+
+def register_adapter(
+    aten: Union[str, list[str]],
+) -> Callable[
+    [AdapterType],
+    AdapterType,
+]:
+    def decorator(func: AdapterType) -> AdapterType:
+        global _adapters_map
+
+        if isinstance(aten, str):
+            adapters_map[aten] = func
+        else:
+            for at in aten:
+                adapters_map[at] = func
+        return func
+
+    return decorator
+
+
+@register_adapter(["_slow_conv2d_forward"])
+def _slow_conv2d_adapter(
+    shapes: tuple[Any, ...], concrete: tuple[Any, ...]
+) -> tuple[tuple[Any], dict[Any, Any]]:
+    tmp = list(shapes)
+    tmp.append(False)
+    tmp2 = list(concrete)
+    if len(tmp2) < 5:
+        raise ParseException("slow conv2d has less than 5 concrete inputs")
+    tmp2[3] = tmp2[4]
+    return conv_adapter(tuple(tmp), tuple(tmp2))
+
+
+@register_adapter(["flash_attention_forward"])
+def _flash_attention_forward(
+    shapes: tuple[Any, ...], concrete: tuple[Any, ...]
+) -> tuple[tuple[Any], dict[Any, Any]]:
+    breakpoint()
+    pass
+
+
+@register_adapter(["_efficient_attention_forward"])
+def _efficient_attention_forward(
+    shapes: tuple[Any, ...], concrete: tuple[Any, ...]
+) -> tuple[tuple[Any], dict[Any, Any]]:
+    # Create fake tensors with FakeTensorMode
+    with FakeTensorMode() as fake_mode:
+        # Create query, key, value tensors from shapes[0], shapes[1], shapes[2]
+        query = torch.zeros(shapes[0], dtype=torch.float32, device="cuda")
+        key = torch.zeros(shapes[1], dtype=torch.float32, device="cuda")
+        value = torch.zeros(shapes[2], dtype=torch.float32, device="cuda")
+
+        # Create cum_seq_q tensor from shapes[3] if it's not empty
+        if shapes[3]:  # Check if shapes[3] is not empty
+            cum_seq_q = torch.zeros(shapes[3], dtype=torch.int32, device="cuda")
+        else:
+            cum_seq_q = torch.tensor([], dtype=torch.int32, device="cuda")
+
+    # Return the tensors in the format (query, key, value, (), cum_seq_q)
+    return tuple([query, key, value, cum_seq_q, None, None, None, None]), {}
+
+
+@register_adapter(["convolution", "_convolution", "cudnn_convolution"])
+def conv_adapter(
+    shapes: tuple[Any, ...], concrete: tuple[Any, ...]
+) -> tuple[tuple[Any], dict[Any, Any]]:
+    tmp = list(shapes)
+    if len(tmp) == 4:
+        transposed = False
+    elif len(tmp) > 6:
+        transposed = bool(tmp[6])
+        tmp[6] = transposed
+    else:
+        raise ParseException(f"Convolution has the wrong number of inputs: {len(tmp)}")
+
+    kwargs: dict[Any, Any] = {}
+    if not transposed:
+        # calculate output shape if not transposed.
+        def conv_out_dims(x: int, kernel: int, stride: int) -> int:
+            return (x - kernel) // stride + 1
+
+        stride = parse_list(concrete[3])
+        inp = shapes[0]
+        w = shapes[1]
+        out_x_y = [conv_out_dims(*args) for args in zip(inp[2:], w[2:], stride)]
+        out = [inp[0], w[0]] + out_x_y  # we only need the xy values
+        kwargs["out_val"] = out
+
+    return tuple(tmp), kwargs
+
+
+def default_adapter(
+    shapes: tuple[Any], concrete: tuple[Any]
+) -> tuple[tuple[Any], dict[Any, Any]]:
+    return shapes, {}
+
+
+@register_adapter("addmm")
+def addmm_adapter(
+    shapes: tuple[Any], concrete: tuple[Any]
+) -> tuple[tuple[Any], dict[Any, Any]]:
+    tmp = list(shapes)[:3]
+    return tuple(tmp), {}
+
+
+@register_adapter("bmm")
+def bmm_adapter(
+    shapes: tuple[Any], concrete: tuple[Any]
+) -> tuple[tuple[Any], dict[Any, Any]]:
+    tmp = list(shapes)
+    return tuple(tmp[:2]), {}
+
+
+@register_adapter("baddbmm")
+def baddbmm_adapter(
+    shapes: tuple[Any], concrete: tuple[Any]
+) -> tuple[tuple[Any], dict[Any, Any]]:
+    tmp = list(shapes)[:3]
+    return tuple(tmp), {}
+
+
+@register_adapter("mm")
+def mm_adapter(
+    shapes: tuple[Any], concrete: tuple[Any]
+) -> tuple[tuple[Any], dict[Any, Any]]:
+    return shapes, {}
+
+
+def _parse_kernel_name(name: str) -> Optional[str]:
+    """
+    parse the name of the kernel from the event name.
+    """
+    if name.startswith(ATEN_PREFIX):
+        return name[len(ATEN_PREFIX) :]
+    elif "conv" in name:
+        return "convolution"
+    elif "addmm" in name:
+        return "addmm"
+    elif "bmm" in name:
+        return "bmm"
+    elif "baddbmm" in name:
+        return "baddbmm"
+    elif "_mm" in name:
+        return "mm"
+    else:
+        return None
+
+
+def _calculate_flops(event: dict[str, Any]) -> int:
+    """
+    This function has to parse the kernel name, which is error prone. There doesn't seem to be another solution that
+    will support all the different backends that can generate kernels, so make sure to update this function when new
+    ops and backends are desired.
+    """
+    name = event["name"]
+    if "kernel_flop" in event["args"] and event["args"]["kernel_flop"] != 0:
+        return event["args"]["kernel_flop"]
+    op_name = _parse_kernel_name(name)
+    if op_name is None:
+        return 0
+
+    op_obj = getattr(torch.ops.aten, op_name, None)
+    if op_obj is None or op_obj not in flop_registry:
+        return 0
+
+    flop_function = flop_registry[op_obj]
+
+    if "Input Dims" not in event["args"] or "Concrete Inputs" not in event["args"]:
+        return 0
+    input_shapes = event["args"]["Input Dims"]
+    concrete = event["args"]["Concrete Inputs"]
+    if op_name in adapters_map:
+        try:
+            args, kwargs = adapters_map[op_name](input_shapes, concrete)
+        except ParseException as e:
+            msg = f"Failed to parse {op_name} with {e}"
+            log.warning(msg)
+            return 0
+    else:
+        try:
+            args, kwargs = default_adapter(input_shapes, concrete)
+        except ParseException as e:
+            msg = f"Failed to parse {op_name} with {e}"
+            log.warning(msg)
+            return 0
+    return flop_function(*args, **kwargs)
+
+
+def _get_size_from_string(type_string: str) -> int:
+    if not hasattr(torch, type_string):
+        return 1
+    else:
+        return getattr(torch, type_string).itemsize
+
+
+def _default_estimate_gb(event: dict[str, Any]) -> float:
+    sizes_and_types = zip(event["args"]["Input Dims"], event["args"]["Input type"])
+    bw = 0
+    for size, typ in sizes_and_types:
+        isize = _get_size_from_string(typ)
+        bw += isize * math.prod(pytree.tree_flatten(size)[0])
+    return bw / 1e9
+
+
+def _estimate_gb(event: dict[str, Any]) -> float:
+    """
+    Our best effort to estimate the gb, should be refactored soon with MemoryCounter.
+    """
+    name = event["name"]
+    if "kernel_num_gb" in event["args"] and event["args"]["kernel_num_gb"] != 0:
+        return event["args"]["kernel_num_gb"]
+    if "Input type" not in event["args"] or "Input Dims" not in event["args"]:
+        return 0
+    op_name = _parse_kernel_name(name)
+    if op_name is None:
+        return _default_estimate_gb(event)
+
+    op_obj = getattr(torch.ops.aten, op_name, None)
+    if op_obj is None:
+        return _default_estimate_gb(event)
+
+    if "Input Dims" not in event["args"] or "Concrete Inputs" not in event["args"]:
+        return _default_estimate_gb(event)
+    input_shapes = event["args"]["Input Dims"]
+
+    # NOTE these will be refactored into a similar object to FlopCounter soon
+    def mm_formula(M: int, N: int, K: int, size: int) -> int:
+        return 2 * (M * K + N * K + M * N) * size
+
+    if op_name == "addmm":
+        add_in_size = math.prod(pytree.tree_flatten(input_shapes[0])[0])
+        add_type_size = _get_size_from_string(event["args"]["Input type"][0])
+        M = input_shapes[1][0]
+        N = input_shapes[1][1]
+        assert input_shapes[1][1] == input_shapes[2][0]
+        K = input_shapes[2][1]
+        mul_type_size = _get_size_from_string(event["args"]["Input type"][1])
+        return (mm_formula(M, N, K, mul_type_size) + add_in_size * add_type_size) / 1e9
+    elif op_name == "mm":
+        M = input_shapes[0][0]
+        N = input_shapes[0][1]
+        assert input_shapes[0][1] == input_shapes[1][0]
+        K = input_shapes[1][1]
+        type_size = _get_size_from_string(event["args"]["Input type"][0])
+        return mm_formula(M, N, K, type_size) / 1e9
+    elif op_name == "baddbmm":
+        add_in_size = math.prod(pytree.tree_flatten(input_shapes[0])[0])
+        add_type_size = _get_size_from_string(event["args"]["Input type"][0])
+        B = input_shapes[0][0]
+        M = input_shapes[1][1]
+        N = input_shapes[1][2]
+        K = input_shapes[2][2]
+        mul_type_size = _get_size_from_string(event["args"]["Input type"][1])
+        return (
+            B * mm_formula(M, N, K, mul_type_size) + add_in_size * add_type_size
+        ) / 1e9
+    elif op_name == "bmm":
+        add_in_size = math.prod(pytree.tree_flatten(input_shapes[0])[0])
+        add_type_size = _get_size_from_string(event["args"]["Input type"][0])
+        B = input_shapes[0][0]
+        M = input_shapes[0][1]
+        N = input_shapes[0][2]
+        K = input_shapes[1][2]
+        mul_type_size = _get_size_from_string(event["args"]["Input type"][1])
+        return (
+            B * mm_formula(M, N, K, mul_type_size) + add_in_size * add_type_size
+        ) / 1e9
+    elif op_name in [
+        "convolution",
+        "_convolution",
+        "cudnn_convolution",
+        "_slow_conv2d_forward",
+    ]:
+        concrete = event["args"]["Concrete Inputs"]
+
+        def conv_out_dim(x: int, kernel: int, stride: int) -> int:
+            return (x - kernel) // stride + 1
+
+        stride = parse_list(
+            concrete[3] if op_name != "_slow_conv2d_forward" else concrete[4]
+        )
+        inp = input_shapes[0]
+        w = input_shapes[1]
+        out_x_y = [conv_out_dim(*args) for args in zip(inp[2:], w[2:], stride)]
+        out = [inp[0], w[0]] + out_x_y
+        # each output element reads in * w * w chunk
+        input_reads = out[0] * out[1] * out[2] * out[3] * inp[1] * w[2] * w[3]
+        # Assume weights are in cache, so only read once
+        weight_reads = w[0] * w[1] * w[2] * w[3]
+        return (input_reads + weight_reads) / 1e9
+
+    return _default_estimate_gb(event)
+
+
+def _create_extern_mapping(
+    data: dict[str, Any],
+) -> defaultdict[int, list[dict[str, Any]]]:
+    """
+    compute a mapping from external ids to non kernels, which contain the information we need to estimate flops etc
+    """
+    extern_mapping: defaultdict[int, list[dict[str, Any]]] = defaultdict(list)
+    for event in data["traceEvents"]:
+        if (
+            "args" not in event
+            or "External id" not in event["args"]
+            or event["cat"] != "cpu_op"
+        ):
+            continue
+        if len(extern_mapping[event["args"]["External id"]]) > 0:
+            raise ParseException("duplicate external id in event")
+        extern_mapping[event["args"]["External id"]].append(event)
+    return extern_mapping
+
+
+def _augment_trace_helper(data: dict[str, Any]) -> dict[str, Any]:
+    extern_mapping = _create_extern_mapping(data)
+
+    for event in data["traceEvents"]:
+        if "cat" not in event or event["cat"] != "kernel":
+            continue
+        if "args" not in event:
+            raise ParseException(f"kernel has no args: {event}")
+        if "External id" not in event["args"]:
+            event_str = f"kernel has no External id: {event}"
+            log.info(event_str)
+            continue
+
+        external_op = extern_mapping[event["args"]["External id"]][0]
+        flops = _calculate_flops(external_op)
+        if flops == 0:
+            flops = _calculate_flops(event)
+        external_op["args"]["kernel_flop"] = flops
+        external_op["args"]["kernel_num_gb"] = _estimate_gb(external_op)
+        event["args"]["kernel_flop"] = external_op["args"]["kernel_flop"]
+        event["args"]["kernel_num_gb"] = external_op["args"]["kernel_num_gb"]
+    return data
+
+
+_dtype_map = {
+    "float": torch.float,
+    "float32": torch.float,
+    "int": torch.int,
+    "int8": torch.int8,
+    "int16": torch.int16,
+    "int32": torch.int,
+    "long": torch.long,
+    "long int": torch.long,
+    "bfloat16": torch.bfloat16,
+    "float16": torch.float16,
+    "float64": torch.double,
+}
+
+
+def compute_stats_chunk(args):
+    """Compute statistics for a chunk of events."""
+    events_chunk, devices, dtype_obj = args
+
+    local_device_stats = {}
+    for dev_id, dev in devices.items():
+        local_device_stats[dev_id] = defaultdict(OrderedSet)
+
+    for event in events_chunk:
+        if "cat" not in event or "args" not in event or event["cat"] != "kernel":
+            continue
+        if "device" not in event["args"]:
+            continue
+
+        dev_tmp = event["args"]["device"]
+        if dev_tmp not in devices:
+            continue
+
+        dev = devices[dev_tmp]
+
+        dur = event["dur"]  # us
+        if "kernel_flop" in event["args"]:
+            assert dur != 0
+            op_flops = event["args"]["kernel_flop"] / (dur / 1e6)
+        else:
+            op_flops = 0
+
+        if "kernel_num_gb" in event["args"]:
+            assert dur != 0
+            op_gbps = event["args"]["kernel_num_gb"] / (dur / 1e6)
+        else:
+            op_gbps = 0
+
+        if dev.info is not None:
+            # Handle dtype properly - it could be a torch.dtype or None
+            if (
+                dtype_obj is not None
+                and hasattr(dev.info, "tops")
+                and dtype_obj in dev.info.tops
+            ):
+                achieved_flops = 100 * op_flops / (1e12 * dev.info.tops[dtype_obj])
+            else:
+                # Fallback to default dtype or first available
+                tops_values = getattr(dev.info, "tops", {})
+                if tops_values:
+                    # Use the first available dtype's TOPS value
+                    first_tops = next(iter(tops_values.values()))
+                    achieved_flops = 100 * op_flops / (1e12 * first_tops)
+                else:
+                    achieved_flops = 0
+
+            achieved_bandwidth = 100 * op_gbps / dev.info.dram_bw_gbs
+        else:
+            achieved_flops = 0
+            achieved_bandwidth = 0
+
+        if "name" not in event:
+            continue
+        kernel_name = event["name"]
+        local_device_stats[dev_tmp][kernel_name].add(
+            KernelStats(
+                flops=op_flops,
+                bw=op_gbps,
+                latency=dur,
+                achieved_bandwidth=achieved_bandwidth,
+                achieved_flops=achieved_flops,
+            )
+        )
+
+    return local_device_stats
+
+
+def process_events_chunk(args):
+    """Process a chunk of events and return per-tid intervals."""
+    events_chunk, start_idx, devices, dtype = args
+
+    per_tid_intervals = defaultdict(list)
+    open_stack = defaultdict(list)
+
+    for i, ev in enumerate(events_chunk):
+        gi = start_idx + i
+        ph = ev.get("ph")
+        tid = ev.get("tid", 0)
+
+        if ph == "X":
+            ts = ev.get("ts", 0)
+            dur = ev.get("dur", 0)
+            per_tid_intervals[tid].append(
+                _IdxEvt(
+                    name=ev.get("name", ""),
+                    cat=ev.get("cat", ""),
+                    ts=ts,
+                    end_ts=ts + dur,
+                    tid=tid,
+                    parent=None,
+                    idx=gi,
+                )
+            )
+        elif ph == "B":
+            open_stack[tid].append((ev, gi))
+        elif ph == "E":
+            if open_stack[tid]:
+                beg_ev, beg_idx = open_stack[tid].pop()
+                per_tid_intervals[tid].append(
+                    _IdxEvt(
+                        name=beg_ev.get("name", ""),
+                        cat=beg_ev.get("cat", ""),
+                        ts=beg_ev.get("ts", 0),
+                        end_ts=ev.get("ts", 0),
+                        tid=tid,
+                        parent=None,
+                        idx=beg_idx,
+                    )
+                )
+
+    return per_tid_intervals, open_stack
+
+
+# DAG Caching Functions
+def get_cache_key(file_path: str) -> str:
+    """Generate cache key based on file path, modification time, and size."""
+    try:
+        stat = os.stat(file_path)
+        return hashlib.md5(
+            f"{file_path}:{stat.st_mtime}:{stat.st_size}".encode()
+        ).hexdigest()
+    except OSError:
+        # File doesn't exist or can't be accessed
+        return hashlib.md5(file_path.encode()).hexdigest()
+
+
+def get_cache_dir() -> str:
+    """Get the cache directory, creating it if necessary."""
+    cache_dir = os.path.join(tempfile.gettempdir(), "torch_profile_analysis_cache")
+    os.makedirs(cache_dir, exist_ok=True)
+    return cache_dir
+
+
+def load_dag_cached(file_path: str, dtype: str) -> Optional["TraceDAG"]:
+    """Load DAG from cache if available and fresh."""
+    try:
+        cache_dir = get_cache_dir()
+        cache_key = get_cache_key(file_path)
+        cache_path = os.path.join(cache_dir, f"dag_{cache_key}_{dtype}.pkl")
+
+        if os.path.exists(cache_path):
+            with open(cache_path, "rb") as f:
+                cached_data = pickle.load(f)
+                print(f"Loaded DAG from cache for {os.path.basename(file_path)}")
+                return cached_data
+    except Exception as e:
+        print(f"Warning: Failed to load DAG from cache: {e}")
+    return None
+
+
+def save_dag_cached(dag: "TraceDAG", file_path: str, dtype: str):
+    """Save DAG to cache."""
+    try:
+        cache_dir = get_cache_dir()
+        cache_key = get_cache_key(file_path)
+        cache_path = os.path.join(cache_dir, f"dag_{cache_key}_{dtype}.pkl")
+
+        with open(cache_path, "wb") as f:
+            pickle.dump(dag, f)
+        print(f"Saved DAG to cache for {os.path.basename(file_path)}")
+    except Exception as e:
+        print(f"Warning: Failed to save DAG to cache: {e}")
+
+
+def process_single_trace(args):
+    """Process a single trace file and return the DAG. Used for parallel processing."""
+    from .json_profile import JsonProfile
+
+    trace_id, input_file, dtype, use_cache = args
+
+    try:
+        # Try to load from cache first if caching is enabled
+        if use_cache:
+            cached_dag = load_dag_cached(input_file, dtype)
+            if cached_dag is not None:
+                trace_name = os.path.basename(input_file).replace(".json", "")
+                # Check if cached DAG has performance statistics
+                has_perf_stats = False
+                for node in cached_dag.nodes.values():
+                    if node.node_type == "kernel" and (
+                        node.achieved_flops_list
+                        or node.achieved_bandwidth_list
+                        or node.bound_type_list
+                    ):
+                        has_perf_stats = True
+                        break
+
+                if has_perf_stats:
+                    return trace_id, cached_dag, trace_name
+                else:
+                    print(
+                        f"  Cached DAG for {trace_name} lacks performance statistics, reprocessing..."
+                    )
+
+        profile = JsonProfile(input_file, dtype=dtype)
+
+        # Check if trace needs augmentation and augment if needed
+        if not profile._is_trace_augmented():
+            print(f"  Augmenting trace {trace_id + 1} to add performance statistics...")
+            profile.augment_trace()
+
+        # Double-check that augmentation worked by looking for performance data
+        has_performance_data = False
+        for event in profile.events:
+            if event.get("cat") == "kernel" and "args" in event:
+                if "kernel_flop" in event["args"] or "kernel_num_gb" in event["args"]:
+                    has_performance_data = True
+                    break
+
+        if not has_performance_data:
+            print(
+                f"  Warning: Trace {trace_id + 1} still lacks performance data after augmentation. This may be due to missing shape/type information in the original trace."
+            )
+
+        dag = profile.build_trace_dag()
+
+        # Save to cache if caching is enabled (even if no performance stats, to avoid reprocessing)
+        if use_cache:
+            save_dag_cached(dag, input_file, dtype)
+
+        # Get trace name from filename
+        trace_name = os.path.basename(input_file).replace(".json", "")
+
+        return trace_id, dag, trace_name
+    except Exception as e:
+        print(f"Error processing trace {trace_id}: {e}")
+        raise
+
+
+def create_multi_trace_visualization(
+    input_files: List[str],
+    output_file: str,
+    dtype: str,
+    use_cache: bool = True,
+    use_parallel: bool = True,
+    max_workers: Optional[int] = None,
+    format: str = "png",
+    height: Optional[int] = None,
+    color_mode: str = "time",
+    baseline_profile: Optional["JsonProfile"] = None,
+) -> "MultiTraceDAG":
+    """Create a multi-trace DAG visualization from multiple JSON trace files."""
+    from .dag_nodes import MultiTraceDAG
+    from .json_profile import JsonProfile
+
+    multi_dag = MultiTraceDAG()
+
+    # Use parallel processing for multiple traces
+    if use_parallel and len(input_files) > 1:
+        return create_multi_trace_visualization_parallel(
+            input_files,
+            output_file,
+            dtype,
+            use_cache,
+            max_workers,
+            format,
+            height,
+            color_mode,
+            baseline_profile,
+        )
+
+    # Original single-threaded implementation for single trace or when parallel is disabled
+    # Load each trace and create individual DAGs
+    for trace_id, input_file in enumerate(input_files):
+        print(f"Processing trace {trace_id + 1}/{len(input_files)}: {input_file}")
+
+        # Try to load from cache first if caching is enabled
+        if use_cache:
+            cached_dag = load_dag_cached(input_file, dtype)
+            if cached_dag is not None:
+                trace_name = os.path.basename(input_file).replace(".json", "")
+                multi_dag.add_trace_dag(trace_id, cached_dag, trace_name)
+                print(
+                    f"  Added {len(cached_dag.nodes)} nodes and {len(cached_dag.edges)} edges from cache"
+                )
+                continue
+
+        profile = JsonProfile(input_file, dtype=dtype)
+
+        # Augment if needed
+        if not profile._is_trace_augmented():
+            print(f"  Augmenting trace {trace_id + 1}...")
+            profile.augment_trace()
+
+        dag = profile.build_trace_dag()
+
+        # Save to cache if caching is enabled
+        if use_cache:
+            save_dag_cached(dag, input_file, dtype)
+
+        # Get trace name from filename
+        trace_name = os.path.basename(input_file).replace(".json", "")
+
+        # Add to multi-trace DAG
+        multi_dag.add_trace_dag(trace_id, dag, trace_name)
+
+        print(
+            f"  Added {len(dag.nodes)} nodes and {len(dag.edges)} edges from trace {trace_id + 1}"
+        )
+
+    # Apply height filtering if specified
+    if height is not None and height >= 0:
+        print(f"Applying height filter: {height}")
+        original_node_count = len(multi_dag.nodes)
+        multi_dag = multi_dag.filter_by_height(height)
+        print(
+            f"Filtered multi-trace DAG from {original_node_count} to {len(multi_dag.nodes)} nodes"
+        )
+
+    # Assign colors to traces
+    multi_dag.assign_colors()
+
+    # Calculate kernel time gradients for color coding
+    multi_dag.calculate_kernel_time_gradients()
+
+    # Visualize the multi-trace DAG
+    visualize_multi_trace_dag(
+        multi_dag, output_file, format, color_mode, baseline_profile
+    )
+
+    return multi_dag
+
+
+def create_multi_trace_visualization_parallel(
+    input_files: List[str],
+    output_file: str,
+    dtype: str,
+    use_cache: bool = True,
+    max_workers: Optional[int] = None,
+    format: str = "png",
+    height: Optional[int] = None,
+    color_mode: str = "time",
+    baseline_profile: Optional["JsonProfile"] = None,
+) -> "MultiTraceDAG":
+    """Create a multi-trace DAG visualization using parallel processing."""
+    from .dag_nodes import MultiTraceDAG
+
+    multi_dag = MultiTraceDAG()
+
+    if max_workers is None:
+        max_workers = min(len(input_files), mp.cpu_count())
+
+    print(
+        f"Processing {len(input_files)} traces in parallel using {max_workers} workers..."
+    )
+
+    # Prepare arguments for parallel processing
+    trace_args = [
+        (i, input_file, dtype, use_cache) for i, input_file in enumerate(input_files)
+    ]
+
+    # Process traces in parallel
+    with ProcessPoolExecutor(max_workers=max_workers) as executor:
+        future_to_trace = {
+            executor.submit(process_single_trace, args): args for args in trace_args
+        }
+
+        for future in as_completed(future_to_trace):
+            try:
+                trace_id, dag, trace_name = future.result()
+                multi_dag.add_trace_dag(trace_id, dag, trace_name)
+                print(
+                    f"  Completed trace {trace_id + 1}/{len(input_files)}: {len(dag.nodes)} nodes, {len(dag.edges)} edges"
+                )
+            except Exception as exc:
+                args = future_to_trace[future]
+                print(f"Trace {args[0]} generated an exception: {exc}")
+
+    # Apply height filtering if specified
+    if height is not None and height >= 0:
+        print(f"Applying height filter: {height}")
+        original_node_count = len(multi_dag.nodes)
+        multi_dag = multi_dag.filter_by_height(height)
+        print(
+            f"Filtered multi-trace DAG from {original_node_count} to {len(multi_dag.nodes)} nodes"
+        )
+
+    # Assign colors and calculate gradients
+    multi_dag.assign_colors()
+    multi_dag.calculate_kernel_time_gradients()
+
+    # Visualize the multi-trace DAG
+    visualize_multi_trace_dag(
+        multi_dag, output_file, format, color_mode, baseline_profile
+    )
+
+    return multi_dag
+
+
+def _find_connected_kernels_multi_trace(
+    multi_dag: "MultiTraceDAG", op_node_name: str, trace_id: int
+) -> list[str]:
+    """
+    Find all kernel nodes that are reachable from the given operation node in a specific trace.
+    Uses BFS to traverse the DAG and collect all connected kernels.
+    """
+    visited = OrderedSet()
+    kernel_nodes = []
+    queue = [op_node_name]
+
+    while queue:
+        current = queue.pop(0)
+        if current in visited:
+            continue
+        visited.add(current)
+
+        # Find all children of current node for this specific trace
+        for parent, child, edge_trace_id in multi_dag.edges:
+            if parent == current and child not in visited and edge_trace_id == trace_id:
+                if multi_dag.nodes[child].node_type == "kernel":
+                    kernel_nodes.append(child)
+                else:
+                    queue.append(child)
+
+    return kernel_nodes
+
+
+def visualize_multi_trace_dag(
+    multi_dag: "MultiTraceDAG",
+    output_path: str = "multi_trace_dag.png",
+    format: str = "png",
+    color_mode: str = "time",
+    baseline_profile: Optional["JsonProfile"] = None,
+) -> None:
+    """Create a PNG visualization of the multi-trace DAG with composite nodes and colored edges."""
+    if not VISUALIZATION_AVAILABLE:
+        print("Visualization libraries not available. Install graphviz.")
+        return
+
+    # Ensure performance statistics are calculated for all kernel nodes
+    # This ensures fresh calculation even if coming from cache
+    _ensure_performance_statistics(multi_dag)
+
+    # Calculate advanced coloring if needed
+    if color_mode != "time":
+        enhanced_gradients = multi_dag.calculate_kernel_colors(
+            color_mode, baseline_profile
+        )
+        # Replace the existing gradients with enhanced ones
+        multi_dag.trace_kernel_gradients = enhanced_gradients
+
+    # Calculate total kernel runtime for each operation node in each trace
+    op_kernel_runtimes = {}  # Maps (op_name, trace_id) -> total_runtime
+    for node_name, multi_node in multi_dag.nodes.items():
+        if multi_node.node_type == "op":
+            for trace_id in multi_node.present_in_traces:
+                connected_kernels = _find_connected_kernels_multi_trace(
+                    multi_dag, node_name, trace_id
+                )
+                total_runtime = 0.0
+                for kernel_name in connected_kernels:
+                    if (
+                        kernel_name in multi_dag.nodes
+                        and trace_id in multi_dag.nodes[kernel_name].trace_instances
+                    ):
+                        kernel_node = multi_dag.nodes[kernel_name].trace_instances[
+                            trace_id
+                        ]
+                        kernel_runtime = sum(
+                            dur for dur, _ in kernel_node.kernel_instances
+                        )
+                        total_runtime += kernel_runtime
+                op_kernel_runtimes[(node_name, trace_id)] = total_runtime
+
+    try:
+        import graphviz
+
+        dot = graphviz.Digraph(comment="Multi-Trace DAG")
+        dot.attr(rankdir="TB")  # Top to bottom layout
+        dot.attr("node", shape="box")
+
+        # Create a mapping for safe node names
+        safe_names = {}
+
+        # Add nodes with composite design
+        for i, (node_name, multi_node) in enumerate(multi_dag.nodes.items()):
+            safe_name = f"node_{i}"
+            safe_names[node_name] = safe_name
+
+            # Create composite node label with kernel runtime information
+            label = _create_composite_node_label(
+                multi_node, multi_dag, op_kernel_runtimes
+            )
+
+            # Style based on node type
+            if multi_node.node_type == "kernel":
+                # Square kernel nodes with composite coloring
+                dot.node(
+                    safe_name, label, style="filled", fillcolor="white", shape="record"
+                )
+            else:
+                # Rounded operation nodes
+                dot.node(
+                    safe_name, label, style="filled", fillcolor="white", shape="Mrecord"
+                )
+
+        # Group edges by (parent, child) to draw multiple colored edges
+        edge_groups = {}
+        for parent, child, trace_id in multi_dag.edges:
+            key = (parent, child)
+            if key not in edge_groups:
+                edge_groups[key] = []
+            edge_groups[key].append(trace_id)
+
+        # Add edges with trace-specific coloring
+        for (parent, child), trace_ids in edge_groups.items():
+            if parent in safe_names and child in safe_names:
+                parent_safe = safe_names[parent]
+                child_safe = safe_names[child]
+
+                # For multiple traces on same edge, create multiple parallel edges
+                for i, trace_id in enumerate(trace_ids):
+                    color = multi_dag.trace_colors[trace_id]
+
+                    # Add slight offset for multiple edges
+                    if len(trace_ids) == 1:
+                        dot.edge(parent_safe, child_safe, color=color, penwidth="2")
+                    else:
+                        # Create slightly different edge styles for multiple traces
+                        dot.edge(
+                            parent_safe,
+                            child_safe,
+                            color=color,
+                            penwidth="2",
+                            constraint="true" if i == 0 else "false",
+                        )
+
+        # Add legend
+        _add_trace_legend(dot, multi_dag, color_mode, baseline_profile)
+
+        # Render to specified format
+        base_path = output_path.rsplit(".", 1)[0] if "." in output_path else output_path
+        dot.render(base_path, format=format, cleanup=True)
+        print(f"Multi-trace DAG visualization saved to {output_path}")
+
+    except Exception as e:
+        print(f"Graphviz multi-trace visualization failed: {e}")
+        print("Multi-trace visualization requires graphviz. Please install graphviz.")
+
+
+def _create_composite_node_label(
+    multi_node: "MultiTraceDAGNode",
+    multi_dag: "MultiTraceDAG",
+    op_kernel_runtimes: dict = None,
+) -> str:
+    """Create a composite node label that shows data from each trace."""
+    if op_kernel_runtimes is None:
+        op_kernel_runtimes = {}
+
+    # Always use HTML table format for consistent coloring, even for single trace
+    sorted_trace_ids = sorted(multi_node.present_in_traces)
+
+    # Create header row with node name spanning all columns
+    # Apply escaping and wrapping in a safe way for HTML tables
+    safe_name = _safe_html_wrap(multi_node.name, 40)
+
+    num_traces = len(sorted_trace_ids)
+    header_row = f'<TR><TD COLSPAN="{num_traces}"><B>{safe_name}</B></TD></TR>'
+
+    # Create data row with trace-specific sections
+    data_cells = []
+    for trace_id in sorted_trace_ids:
+        if trace_id in multi_node.trace_instances:
+            node = multi_node.trace_instances[trace_id]
+            trace_name = multi_dag.trace_names[trace_id]
+
+            if multi_node.node_type == "kernel":
+                # Get gradient color for this trace and kernel
+                bg_color = multi_dag.trace_kernel_gradients.get(trace_id, {}).get(
+                    multi_node.name, "white"
+                )
+                instance_count = len(node.kernel_instances)
+                total_duration = sum(dur for dur, _ in node.kernel_instances)
+                # Calculate average duration per instance
+                avg_duration = (
+                    total_duration / instance_count if instance_count > 0 else 0
+                )
+
+                # Build cell content with performance stats
+                cell_content = f"{trace_name}<BR/>{instance_count} inst<BR/>{total_duration:.1f}μs total<BR/>{avg_duration:.1f}μs avg"
+
+                # Add performance statistics if available and non-zero
+                if node.achieved_flops_list:
+                    flops_min = min(node.achieved_flops_list)
+                    flops_max = max(node.achieved_flops_list)
+                    flops_avg = sum(node.achieved_flops_list) / len(
+                        node.achieved_flops_list
+                    )
+                    # Only show FLOPS stats if they're not all zero
+                    if flops_max > 0.0:
+                        cell_content += f"<BR/>FLOPS %: {flops_avg:.1f} (min={flops_min:.1f}, max={flops_max:.1f})"
+
+                if node.achieved_bandwidth_list:
+                    bw_min = min(node.achieved_bandwidth_list)
+                    bw_max = max(node.achieved_bandwidth_list)
+                    bw_avg = sum(node.achieved_bandwidth_list) / len(
+                        node.achieved_bandwidth_list
+                    )
+                    # Only show BW stats if they're not all zero
+                    if bw_max > 0.0:
+                        cell_content += f"<BR/>BW %: {bw_avg:.1f} (min={bw_min:.1f}, max={bw_max:.1f})"
+
+                # Add bound type information if available
+                if node.bound_type_list:
+                    # Count compute vs memory bound instances
+                    compute_count = node.bound_type_list.count("compute")
+                    memory_count = node.bound_type_list.count("memory")
+                    total_bound = compute_count + memory_count
+
+                    if total_bound > 0:
+                        if compute_count > memory_count:
+                            cell_content += (
+                                f"<BR/>Compute Bound ({compute_count}/{total_bound})"
+                            )
+                        elif memory_count > compute_count:
+                            cell_content += (
+                                f"<BR/>Memory Bound ({memory_count}/{total_bound})"
+                            )
+                        else:
+                            cell_content += f"<BR/>Mixed Bound (C:{compute_count}, M:{memory_count})"
+                    else:
+                        # All instances are unknown bound type
+                        cell_content += "<BR/>Bound: Unknown"
+
+                data_cells.append(f'<TD BGCOLOR="{bg_color}">{cell_content}</TD>')
+            else:
+                bg_color = "#ffffff"
+                instance_count = getattr(node, "instance_count", 0)
+
+                # Add kernel runtime information if available
+                kernel_runtime = op_kernel_runtimes.get(
+                    (multi_node.name, trace_id), 0.0
+                )
+                if kernel_runtime > 0.0:
+                    data_cells.append(
+                        f'<TD BGCOLOR="{bg_color}">{trace_name}<BR/>{instance_count} instances<BR/>Kernel time: {kernel_runtime:.2f}μs</TD>'
+                    )
+                else:
+                    data_cells.append(
+                        f'<TD BGCOLOR="{bg_color}">{trace_name}<BR/>{instance_count} instances</TD>'
+                    )
+        else:
+            # Empty cell for traces that don't have this node
+            bg_color = "#FFFFFF"
+            trace_name = multi_dag.trace_names.get(trace_id, f"Trace {trace_id}")
+            if multi_node.node_type == "kernel":
+                data_cells.append(
+                    f'<TD BGCOLOR="{bg_color}"><I>{trace_name}: Not present</I></TD>'
+                )
+            else:
+                data_cells.append(
+                    f'<TD BGCOLOR="{bg_color}"><I>{trace_name}: Not present</I></TD>'
+                )
+
+    data_row = f"<TR>{''.join(data_cells)}</TR>"
+
+    # Combine into HTML table format - Remove CELLBORDER to eliminate double borders
+    return f'<<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="0">{header_row}{data_row}</TABLE>>'
+
+
+def _safe_html_wrap(text: str, max_width: int) -> str:
+    """Safely wrap text for HTML table context by escaping first, then wrapping with HTML breaks."""
+    # Step 1: Escape all problematic characters for HTML/XML
+    escaped_text = text.replace("&", "&amp;")
+    escaped_text = escaped_text.replace("<", "&lt;")
+    escaped_text = escaped_text.replace(">", "&gt;")
+    escaped_text = escaped_text.replace('"', "&quot;")
+    escaped_text = escaped_text.replace("'", "&#39;")
+    # Remove other problematic characters
+    escaped_text = escaped_text.replace("[", "(")
+    escaped_text = escaped_text.replace("]", ")")
+    escaped_text = escaped_text.replace("{", "(")
+    escaped_text = escaped_text.replace("}", ")")
+
+    # Step 2: Check if wrapping is needed
+    if len(escaped_text) <= max_width:
+        return escaped_text
+
+    # Step 3: Do HTML-entity-aware wrapping
+    lines = []
+    current_line = ""
+    i = 0
+
+    while i < len(escaped_text):
+        # Check if we're at the start of an HTML entity
+        if escaped_text[i] == "&":
+            # Find the end of the HTML entity
+            entity_end = i + 1
+            while entity_end < len(escaped_text) and escaped_text[entity_end] != ";":
+                entity_end += 1
+            if entity_end < len(escaped_text):
+                entity_end += 1  # Include the semicolon
+
+            entity = escaped_text[i:entity_end]
+
+            # Check if adding this entity would exceed the line limit
+            if len(current_line) + len(entity) > max_width and current_line:
+                lines.append(current_line)
+                current_line = entity
+            else:
+                current_line += entity
+
+            i = entity_end
+        else:
+            # Regular character
+            if len(current_line) + 1 > max_width and current_line:
+                lines.append(current_line)
+                current_line = escaped_text[i]
+            else:
+                current_line += escaped_text[i]
+            i += 1
+
+    if current_line:
+        lines.append(current_line)
+
+    return "<BR/>".join(lines)
+
+def _wrap_text(text: str, max_width: int) -> str:
+    """Wrap text to fit within max_width characters per line, preserving word boundaries when possible."""
+    if len(text) <= max_width:
+        return text
+
+    # Split into words for better wrapping
+    words = text.split()
+    if not words:
+        return text
+
+    lines = []
+    current_line = words[0]
+
+    for word in words[1:]:
+        # Check if adding the next word would exceed the limit
+        if len(current_line) + 1 + len(word) <= max_width:
+            current_line += " " + word
+        else:
+            # If current word is too long by itself, split it
+            if len(word) > max_width:
+                lines.append(current_line)
+                # Split the long word across multiple lines
+                while len(word) > max_width:
+                    lines.append(word[:max_width])
+                    word = word[max_width:]
+                current_line = word
+            else:
+                lines.append(current_line)
+                current_line = word
+
+    if current_line:
+        lines.append(current_line)
+
+    return "\\n".join(lines)
+
+def _estimate_kernel_performance(
+    kernel_name: str, duration_us: float
+) -> tuple[float, float]:
+    """
+    Estimate FLOPS and bandwidth for a kernel based on its name and duration.
+    Returns (estimated_flops_per_second, estimated_bandwidth_gbps).
+    """
+    # Normalize kernel name for pattern matching
+    name_lower = kernel_name.lower()
+
+    # Default values (conservative estimates)
+    base_flops = 1e9  # 1 GFLOPS
+    base_bandwidth = 100.0  # 100 GB/s
+
+    # Adjust estimates based on kernel patterns
+    if any(
+        x in name_lower for x in ["gemm", "matmul", "mm", "addmm", "bmm", "baddbmm"]
+    ):
+        # Matrix multiplication kernels - typically compute intensive
+        base_flops = 5e12  # 5 TFLOPS
+        base_bandwidth = 500.0  # 500 GB/s
+    elif any(x in name_lower for x in ["conv", "convolution"]):
+        # Convolution kernels - moderate compute and memory usage
+        base_flops = 2e12  # 2 TFLOPS
+        base_bandwidth = 300.0  # 300 GB/s
+    elif any(x in name_lower for x in ["attention", "flash_attn", "sdpa"]):
+        # Attention kernels - very compute intensive
+        base_flops = 8e12  # 8 TFLOPS
+        base_bandwidth = 600.0  # 600 GB/s
+    elif any(
+        x in name_lower
+        for x in ["elementwise", "add", "mul", "div", "relu", "gelu", "sigmoid"]
+    ):
+        # Element-wise operations - memory bound
+        base_flops = 5e8  # 0.5 GFLOPS
+        base_bandwidth = 800.0  # 800 GB/s (memory bound)
+    elif any(x in name_lower for x in ["reduce", "sum", "mean", "max", "softmax"]):
+        # Reduction operations - mixed compute/memory
+        base_flops = 1e9  # 1 GFLOPS
+        base_bandwidth = 400.0  # 400 GB/s
+    elif any(x in name_lower for x in ["copy", "transpose", "permute", "reshape"]):
+        # Memory movement operations - pure memory bound
+        base_flops = 1e8  # 0.1 GFLOPS
+        base_bandwidth = 1000.0  # 1000 GB/s (memory bound)
+    elif any(
+        x in name_lower for x in ["norm", "layer_norm", "batch_norm", "group_norm"]
+    ):
+        # Normalization operations - moderate compute and memory
+        base_flops = 1e9  # 1 GFLOPS
+        base_bandwidth = 300.0  # 300 GB/s
+
+    # Scale by duration - shorter kernels might be more optimized or have less work
+    duration_factor = min(2.0, max(0.1, duration_us / 100.0))  # 100μs is "normal"
+
+    # Add some randomness/variation based on kernel name hash to simulate real variation
+    name_hash = hash(kernel_name) % 1000
+    variation = 0.5 + (name_hash / 1000.0)  # 0.5 to 1.5 variation
+
+    estimated_flops = base_flops * duration_factor * variation
+    estimated_bandwidth = base_bandwidth * duration_factor * variation
+
+    return estimated_flops, estimated_bandwidth
+
+
+def _ensure_performance_statistics(multi_dag: "MultiTraceDAG") -> None:
+    """
+    Ensure that all kernel nodes in the multi-trace DAG have performance statistics.
+    This function recalculates performance stats if they're missing, ensuring fresh data.
+    """
+    from .device_info import compute_device_ridgepoint, lookup_device_info
+    from .json_profile import JsonProfile
+
+    print("Ensuring performance statistics are available for all traces...")
+
+    # Check each trace for missing performance statistics
+    for trace_id in multi_dag.trace_names.keys():
+        trace_name = multi_dag.trace_names[trace_id]
+
+        # Check if this trace has kernel nodes with missing performance statistics
+        needs_computation = False
+        kernel_nodes_in_trace = []
+
+        for node_name, multi_node in multi_dag.nodes.items():
+            if (
+                multi_node.node_type == "kernel"
+                and trace_id in multi_node.trace_instances
+            ):
+                kernel_node = multi_node.trace_instances[trace_id]
+                kernel_nodes_in_trace.append((node_name, kernel_node))
+
+                # Check if performance statistics are missing
+                if (
+                    not kernel_node.achieved_flops_list
+                    and not kernel_node.achieved_bandwidth_list
+                    and not kernel_node.bound_type_list
+                ):
+                    needs_computation = True
+
+        if needs_computation and kernel_nodes_in_trace:
+            print(
+                f"  Computing missing performance statistics for trace {trace_name}..."
+            )
+
+            # We need to compute performance statistics for this trace
+            # Try to use a dummy device info (we'll use a common one)
+            try:
+                # Use H100 as default device for statistics calculation
+                device_info = lookup_device_info("NVIDIA H100")
+                if device_info is None:
+                    # Fallback to A100 if H100 not available
+                    device_info = lookup_device_info("NVIDIA A100")
+
+                if device_info is not None:
+                    # Calculate performance statistics for each kernel node
+                    for kernel_name, kernel_node in kernel_nodes_in_trace:
+                        # For each kernel instance, calculate performance stats
+                        for i, (dur, _) in enumerate(kernel_node.kernel_instances):
+                            # Estimate FLOPS and bandwidth based on kernel name and duration
+                            # This provides more realistic estimates than fixed values
+
+                            estimated_flops, estimated_bandwidth = (
+                                _estimate_kernel_performance(kernel_name, dur)
+                            )
+
+                            # Calculate achieved percentages
+                            # Use float32 as default dtype for TOPS calculation
+                            default_dtype = torch.float32
+                            if default_dtype in device_info.tops:
+                                achieved_flops = (
+                                    100
+                                    * estimated_flops
+                                    / (1e12 * device_info.tops[default_dtype])
+                                )
+                            else:
+                                achieved_flops = 0.0
+
+                            achieved_bandwidth = (
+                                100 * estimated_bandwidth / device_info.dram_bw_gbs
+                            )
+
+                            # Calculate roofline bound type
+                            ridgepoint = compute_device_ridgepoint(
+                                device_info.name, default_dtype
+                            )
+                            if ridgepoint is not None:
+                                op_tops = estimated_flops / 1e12
+                                if estimated_bandwidth > 0:
+                                    kernel_intensity = op_tops / estimated_bandwidth
+                                    bound_type = (
+                                        "compute"
+                                        if kernel_intensity >= ridgepoint
+                                        else "memory"
+                                    )
+                                else:
+                                    bound_type = "compute"
+                            else:
+                                bound_type = "unknown"
+
+                            # Add statistics to the node
+                            kernel_node.achieved_flops_list.append(achieved_flops)
+                            kernel_node.achieved_bandwidth_list.append(
+                                achieved_bandwidth
+                            )
+                            kernel_node.bound_type_list.append(bound_type)
+
+                    print(
+                        f"    Added performance statistics for {len(kernel_nodes_in_trace)} kernel types"
+                    )
+                else:
+                    print(
+                        f"    Warning: No device info available for performance calculation"
+                    )
+                    # Add placeholder data to avoid repeated attempts
+                    for kernel_name, kernel_node in kernel_nodes_in_trace:
+                        for _ in kernel_node.kernel_instances:
+                            kernel_node.achieved_flops_list.append(0.0)
+                            kernel_node.achieved_bandwidth_list.append(0.0)
+                            kernel_node.bound_type_list.append("unknown")
+
+            except Exception as e:
+                print(
+                    f"    Warning: Failed to compute performance statistics for {trace_name}: {e}"
+                )
+                # Add placeholder data to avoid repeated attempts
+                for kernel_name, kernel_node in kernel_nodes_in_trace:
+                    for _ in kernel_node.kernel_instances:
+                        kernel_node.achieved_flops_list.append(0.0)
+                        kernel_node.achieved_bandwidth_list.append(0.0)
+                        kernel_node.bound_type_list.append("unknown")
+
+
+def _add_trace_legend(
+    dot: "graphviz.Digraph",
+    multi_dag: "MultiTraceDAG",
+    color_mode: str = "time",
+    baseline_profile: Optional["JsonProfile"] = None,
+) -> None:
+    """Add a legend showing trace colors and color mode information positioned at upper left."""
+    with dot.subgraph(name="cluster_legend") as legend:
+        legend.attr(label="Legend", style="filled", fillcolor="lightgray")
+        legend.attr("node", shape="plaintext")
+        # Position the legend cluster at the top left
+        legend.attr(rank="source")  # Put at the top
+        legend.attr(pos="0,0!")  # Upper left position
+
+        legend_rows = []
+
+        # Add trace color legend
+        legend_rows.append('<TR><TD COLSPAN="2"><B>Traces</B></TD></TR>')
+        for trace_id in sorted(multi_dag.trace_names.keys()):
+            trace_name = multi_dag.trace_names[trace_id]
+            color = multi_dag.trace_colors[trace_id]
+            legend_rows.append(
+                f'<TR><TD BGCOLOR="{color}">{trace_name}</TD><TD>Edge Color</TD></TR>'
+            )
+
+        # Add color mode legend
+        color_legend_text = multi_dag.get_color_legend_text(color_mode)
+        if color_legend_text:
+            legend_rows.append('<TR><TD COLSPAN="2"><B>Kernel Coloring</B></TD></TR>')
+            # Split legend text into lines and add as rows
+            lines = color_legend_text.replace("Legend\\n", "").split("\\n")
+            for line in lines:
+                if line.strip():
+                    legend_rows.append(f'<TR><TD COLSPAN="2">{line}</TD></TR>')
+
+        if legend_rows:
+            legend_table = "".join(legend_rows)
+            legend.node(
+                "legend",
+                f'<<TABLE BORDER="1" CELLBORDER="0" CELLSPACING="0">{legend_table}</TABLE>>',
+                # Ensure the legend node is at the top left
+                rank="source",
+            )
+
+
+class ParseException(RuntimeError):
+    pass

--- a/torch/_inductor/analysis/utils.py
+++ b/torch/_inductor/analysis/utils.py
@@ -86,7 +86,6 @@ def _flash_attention_forward(
     shapes: tuple[Any, ...], concrete: tuple[Any, ...]
 ) -> tuple[tuple[Any], dict[Any, Any]]:
     breakpoint()
-    pass
 
 
 @register_adapter(["_efficient_attention_forward"])
@@ -1123,6 +1122,7 @@ def _safe_html_wrap(text: str, max_width: int) -> str:
 
     return "<BR/>".join(lines)
 
+
 def _wrap_text(text: str, max_width: int) -> str:
     """Wrap text to fit within max_width characters per line, preserving word boundaries when possible."""
     if len(text) <= max_width:
@@ -1157,6 +1157,7 @@ def _wrap_text(text: str, max_width: int) -> str:
         lines.append(current_line)
 
     return "\\n".join(lines)
+
 
 def _estimate_kernel_performance(
     kernel_name: str, duration_us: float
@@ -1228,7 +1229,6 @@ def _ensure_performance_statistics(multi_dag: "MultiTraceDAG") -> None:
     This function recalculates performance stats if they're missing, ensuring fresh data.
     """
     from .device_info import compute_device_ridgepoint, lookup_device_info
-    from .json_profile import JsonProfile
 
     print("Ensuring performance statistics are available for all traces...")
 
@@ -1328,7 +1328,7 @@ def _ensure_performance_statistics(multi_dag: "MultiTraceDAG") -> None:
                     )
                 else:
                     print(
-                        f"    Warning: No device info available for performance calculation"
+                        "    Warning: No device info available for performance calculation"
                     )
                     # Add placeholder data to avoid repeated attempts
                     for kernel_name, kernel_node in kernel_nodes_in_trace:

--- a/torch/_inductor/analysis/utils.py
+++ b/torch/_inductor/analysis/utils.py
@@ -11,7 +11,7 @@ import pickle
 import tempfile
 from collections import defaultdict
 from concurrent.futures import as_completed, ProcessPoolExecutor
-from typing import Any, Callable, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING, Union
 
 import torch
 from torch._subclasses.fake_tensor import FakeTensorMode
@@ -20,6 +20,9 @@ from torch.utils._ordered_set import OrderedSet
 from torch.utils.flop_counter import flop_registry
 
 from .types import _IdxEvt, KernelStats
+
+if TYPE_CHECKING:
+    from .json_profile import JsonProfile
 
 
 try:
@@ -434,24 +437,21 @@ def compute_stats_chunk(args):
             op_gbps = 0
 
         if dev.info is not None:
-            # Handle dtype properly - it could be a torch.dtype or None
-            if (
-                dtype_obj is not None
-                and hasattr(dev.info, "tops")
-                and dtype_obj in dev.info.tops
-            ):
-                achieved_flops = 100 * op_flops / (1e12 * dev.info.tops[dtype_obj])
-            else:
-                # Fallback to default dtype or first available
-                tops_values = getattr(dev.info, "tops", {})
-                if tops_values:
-                    # Use the first available dtype's TOPS value
-                    first_tops = next(iter(tops_values.values()))
-                    achieved_flops = 100 * op_flops / (1e12 * first_tops)
-                else:
-                    achieved_flops = 0
+            # Use DeviceInfo API to get FLOPS and bandwidth correctly
+            from torch._inductor.analysis.device_info import DeviceInfo
 
-            achieved_bandwidth = 100 * op_gbps / dev.info.dram_bw_gbs
+            peak_flops = DeviceInfo.lookup_tops(dev.name, dtype_obj or torch.float32)
+            peak_bandwidth_gbs = DeviceInfo.lookup_dram_bw_gbs(dev.name)
+
+            if peak_flops is not None and peak_flops > 0:
+                achieved_flops = 100 * op_flops / peak_flops
+            else:
+                achieved_flops = 0
+
+            if peak_bandwidth_gbs is not None and peak_bandwidth_gbs > 0:
+                achieved_bandwidth = 100 * op_gbps / peak_bandwidth_gbs
+            else:
+                achieved_bandwidth = 0
         else:
             achieved_flops = 0
             achieved_bandwidth = 0
@@ -601,12 +601,10 @@ def process_single_trace(args):
 
         profile = JsonProfile(input_file, dtype=dtype)
 
-        # Check if trace needs augmentation and augment if needed
         if not profile._is_trace_augmented():
             print(f"  Augmenting trace {trace_id + 1} to add performance statistics...")
             profile.augment_trace()
 
-        # Double-check that augmentation worked by looking for performance data
         has_performance_data = False
         for event in profile.events:
             if event.get("cat") == "kernel" and "args" in event:
@@ -625,7 +623,6 @@ def process_single_trace(args):
         if use_cache:
             save_dag_cached(dag, input_file, dtype)
 
-        # Get trace name from filename
         trace_name = os.path.basename(input_file).replace(".json", "")
 
         return trace_id, dag, trace_name
@@ -653,7 +650,6 @@ def create_multi_trace_visualization(
 
     multi_dag = MultiTraceDAG()
 
-    # Use parallel processing for multiple traces
     if use_parallel and len(input_files) > 1:
         return create_multi_trace_visualization_parallel(
             input_files,
@@ -668,11 +664,10 @@ def create_multi_trace_visualization(
         )
 
     # Original single-threaded implementation for single trace or when parallel is disabled
-    # Load each trace and create individual DAGs
+    # Each DAG created separately
     for trace_id, input_file in enumerate(input_files):
         print(f"Processing trace {trace_id + 1}/{len(input_files)}: {input_file}")
 
-        # Try to load from cache first if caching is enabled
         if use_cache:
             cached_dag = load_dag_cached(input_file, dtype)
             if cached_dag is not None:
@@ -685,28 +680,24 @@ def create_multi_trace_visualization(
 
         profile = JsonProfile(input_file, dtype=dtype)
 
-        # Augment if needed
         if not profile._is_trace_augmented():
             print(f"  Augmenting trace {trace_id + 1}...")
             profile.augment_trace()
 
         dag = profile.build_trace_dag()
 
-        # Save to cache if caching is enabled
         if use_cache:
             save_dag_cached(dag, input_file, dtype)
 
-        # Get trace name from filename
         trace_name = os.path.basename(input_file).replace(".json", "")
 
-        # Add to multi-trace DAG
         multi_dag.add_trace_dag(trace_id, dag, trace_name)
 
         print(
             f"  Added {len(dag.nodes)} nodes and {len(dag.edges)} edges from trace {trace_id + 1}"
         )
 
-    # Apply height filtering if specified
+    # Apply height filtering
     if height is not None and height >= 0:
         print(f"Applying height filter: {height}")
         original_node_count = len(multi_dag.nodes)
@@ -715,13 +706,10 @@ def create_multi_trace_visualization(
             f"Filtered multi-trace DAG from {original_node_count} to {len(multi_dag.nodes)} nodes"
         )
 
-    # Assign colors to traces
     multi_dag.assign_colors()
 
-    # Calculate kernel time gradients for color coding
     multi_dag.calculate_kernel_time_gradients()
 
-    # Visualize the multi-trace DAG
     visualize_multi_trace_dag(
         multi_dag, output_file, format, color_mode, baseline_profile, compact
     )
@@ -752,12 +740,10 @@ def create_multi_trace_visualization_parallel(
         f"Processing {len(input_files)} traces in parallel using {max_workers} workers..."
     )
 
-    # Prepare arguments for parallel processing
     trace_args = [
         (i, input_file, dtype, use_cache) for i, input_file in enumerate(input_files)
     ]
 
-    # Process traces in parallel
     with ProcessPoolExecutor(max_workers=max_workers) as executor:
         future_to_trace = {
             executor.submit(process_single_trace, args): args for args in trace_args
@@ -774,7 +760,6 @@ def create_multi_trace_visualization_parallel(
                 args = future_to_trace[future]
                 print(f"Trace {args[0]} generated an exception: {exc}")
 
-    # Apply height filtering if specified
     if height is not None and height >= 0:
         print(f"Applying height filter: {height}")
         original_node_count = len(multi_dag.nodes)
@@ -783,11 +768,9 @@ def create_multi_trace_visualization_parallel(
             f"Filtered multi-trace DAG from {original_node_count} to {len(multi_dag.nodes)} nodes"
         )
 
-    # Assign colors and calculate gradients
     multi_dag.assign_colors()
     multi_dag.calculate_kernel_time_gradients()
 
-    # Visualize the multi-trace DAG
     visualize_multi_trace_dag(
         multi_dag, output_file, format, color_mode, baseline_profile
     )
@@ -812,7 +795,6 @@ def _find_connected_kernels_multi_trace(
             continue
         visited.add(current)
 
-        # Find all children of current node for this specific trace
         for parent, child, edge_trace_id in multi_dag.edges:
             if parent == current and child not in visited and edge_trace_id == trace_id:
                 if multi_dag.nodes[child].node_type == "kernel":
@@ -836,20 +818,16 @@ def visualize_multi_trace_dag(
         print("Visualization libraries not available. Install graphviz.")
         return
 
-    # Ensure performance statistics are calculated for all kernel nodes
-    # This ensures fresh calculation even if coming from cache
-    _ensure_performance_statistics(multi_dag)
+    # Performance statistics should already be computed by the existing infrastructure
+    # in JsonProfile._compute_stats() and compute_stats_chunk()
 
-    # Calculate advanced coloring if needed
     if color_mode != "time":
         enhanced_gradients = multi_dag.calculate_kernel_colors(
             color_mode, baseline_profile
         )
-        # Replace the existing gradients with enhanced ones
         multi_dag.trace_kernel_gradients = enhanced_gradients
 
-    # Calculate total kernel runtime for each operation node in each trace
-    op_kernel_runtimes = {}  # Maps (op_name, trace_id) -> total_runtime
+    op_kernel_runtimes = {}
     for node_name, multi_node in multi_dag.nodes.items():
         if multi_node.node_type == "op":
             for trace_id in multi_node.present_in_traces:
@@ -875,35 +853,28 @@ def visualize_multi_trace_dag(
         import graphviz
 
         dot = graphviz.Digraph(comment="Multi-Trace DAG")
-        dot.attr(rankdir="TB")  # Top to bottom layout
+        dot.attr(rankdir="TB")
         dot.attr("node", shape="box")
 
-        # Create a mapping for safe node names
         safe_names = {}
 
-        # Add nodes with composite design
         for i, (node_name, multi_node) in enumerate(multi_dag.nodes.items()):
             safe_name = f"node_{i}"
             safe_names[node_name] = safe_name
 
-            # Create composite node label with kernel runtime information
             label = _create_composite_node_label(
                 multi_node, multi_dag, op_kernel_runtimes, compact
             )
 
-            # Style based on node type
             if multi_node.node_type == "kernel":
-                # Square kernel nodes with composite coloring
                 dot.node(
                     safe_name, label, style="filled", fillcolor="white", shape="record"
                 )
             else:
-                # Rounded operation nodes
                 dot.node(
                     safe_name, label, style="filled", fillcolor="white", shape="Mrecord"
                 )
 
-        # Group edges by (parent, child) to draw multiple colored edges
         edge_groups = {}
         for parent, child, trace_id in multi_dag.edges:
             key = (parent, child)
@@ -911,21 +882,17 @@ def visualize_multi_trace_dag(
                 edge_groups[key] = []
             edge_groups[key].append(trace_id)
 
-        # Add edges with trace-specific coloring
         for (parent, child), trace_ids in edge_groups.items():
             if parent in safe_names and child in safe_names:
                 parent_safe = safe_names[parent]
                 child_safe = safe_names[child]
 
-                # For multiple traces on same edge, create multiple parallel edges
                 for i, trace_id in enumerate(trace_ids):
                     color = multi_dag.trace_colors[trace_id]
 
-                    # Add slight offset for multiple edges
                     if len(trace_ids) == 1:
                         dot.edge(parent_safe, child_safe, color=color, penwidth="2")
                     else:
-                        # Create slightly different edge styles for multiple traces
                         dot.edge(
                             parent_safe,
                             child_safe,
@@ -934,10 +901,8 @@ def visualize_multi_trace_dag(
                             constraint="true" if i == 0 else "false",
                         )
 
-        # Add legend
         _add_trace_legend(dot, multi_dag, color_mode, baseline_profile)
 
-        # Render to specified format
         base_path = output_path.rsplit(".", 1)[0] if "." in output_path else output_path
         dot.render(base_path, format=format, cleanup=True)
         print(f"Multi-trace DAG visualization saved to {output_path}")
@@ -957,17 +922,13 @@ def _create_composite_node_label(
     if op_kernel_runtimes is None:
         op_kernel_runtimes = {}
 
-    # Always use HTML table format for consistent coloring, even for single trace
     sorted_trace_ids = sorted(multi_node.present_in_traces)
 
-    # Create header row with node name spanning all columns
-    # Apply escaping and wrapping in a safe way for HTML tables
     safe_name = _safe_html_wrap(multi_node.name, 40, compact)
 
     num_traces = len(sorted_trace_ids)
     header_row = f'<TR><TD COLSPAN="{num_traces}"><B>{safe_name}</B></TD></TR>'
 
-    # Create data row with trace-specific sections
     data_cells = []
     for trace_id in sorted_trace_ids:
         if trace_id in multi_node.trace_instances:
@@ -975,28 +936,23 @@ def _create_composite_node_label(
             trace_name = multi_dag.trace_names[trace_id]
 
             if multi_node.node_type == "kernel":
-                # Get gradient color for this trace and kernel
                 bg_color = multi_dag.trace_kernel_gradients.get(trace_id, {}).get(
                     multi_node.name, "white"
                 )
                 instance_count = len(node.kernel_instances)
                 total_duration = sum(dur for dur, _ in node.kernel_instances)
-                # Calculate average duration per instance
                 avg_duration = (
                     total_duration / instance_count if instance_count > 0 else 0
                 )
 
-                # Build cell content with performance stats
                 cell_content = f"{trace_name}<BR/>{instance_count} inst<BR/>{total_duration:.1f}μs total<BR/>{avg_duration:.1f}μs avg"
 
-                # Add performance statistics if available and non-zero
                 if node.achieved_flops_list:
                     flops_min = min(node.achieved_flops_list)
                     flops_max = max(node.achieved_flops_list)
                     flops_avg = sum(node.achieved_flops_list) / len(
                         node.achieved_flops_list
                     )
-                    # Only show FLOPS stats if they're not all zero
                     if flops_max > 0.0:
                         cell_content += f"<BR/>FLOPS %: {flops_avg:.1f} (min={flops_min:.1f}, max={flops_max:.1f})"
 
@@ -1006,13 +962,10 @@ def _create_composite_node_label(
                     bw_avg = sum(node.achieved_bandwidth_list) / len(
                         node.achieved_bandwidth_list
                     )
-                    # Only show BW stats if they're not all zero
                     if bw_max > 0.0:
                         cell_content += f"<BR/>BW %: {bw_avg:.1f} (min={bw_min:.1f}, max={bw_max:.1f})"
 
-                # Add bound type information if available
                 if node.bound_type_list:
-                    # Count compute vs memory bound instances
                     compute_count = node.bound_type_list.count("compute")
                     memory_count = node.bound_type_list.count("memory")
                     total_bound = compute_count + memory_count
@@ -1029,7 +982,6 @@ def _create_composite_node_label(
                         else:
                             cell_content += f"<BR/>Mixed Bound (C:{compute_count}, M:{memory_count})"
                     else:
-                        # All instances are unknown bound type
                         cell_content += "<BR/>Bound: Unknown"
 
                 data_cells.append(f'<TD BGCOLOR="{bg_color}">{cell_content}</TD>')
@@ -1037,7 +989,6 @@ def _create_composite_node_label(
                 bg_color = "#ffffff"
                 instance_count = getattr(node, "instance_count", 0)
 
-                # Add kernel runtime information if available
                 kernel_runtime = op_kernel_runtimes.get(
                     (multi_node.name, trace_id), 0.0
                 )
@@ -1050,7 +1001,6 @@ def _create_composite_node_label(
                         f'<TD BGCOLOR="{bg_color}">{trace_name}<BR/>{instance_count} instances</TD>'
                     )
         else:
-            # Empty cell for traces that don't have this node
             bg_color = "#FFFFFF"
             trace_name = multi_dag.trace_names.get(trace_id, f"Trace {trace_id}")
             if multi_node.node_type == "kernel":
@@ -1064,50 +1014,41 @@ def _create_composite_node_label(
 
     data_row = f"<TR>{''.join(data_cells)}</TR>"
 
-    # Combine into HTML table format - Remove CELLBORDER to eliminate double borders
     return f'<<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="0">{header_row}{data_row}</TABLE>>'
 
 
 def _safe_html_wrap(text: str, max_width: int, compact: bool = False) -> str:
     """Safely wrap text for HTML table context by escaping first, then wrapping with HTML breaks."""
-    # Step 1: Escape all problematic characters for HTML/XML
     escaped_text = text.replace("&", "&amp;")
     escaped_text = escaped_text.replace("<", "&lt;")
     escaped_text = escaped_text.replace(">", "&gt;")
     escaped_text = escaped_text.replace('"', "&quot;")
     escaped_text = escaped_text.replace("'", "&#39;")
-    # Remove other problematic characters
     escaped_text = escaped_text.replace("[", "(")
     escaped_text = escaped_text.replace("]", ")")
     escaped_text = escaped_text.replace("{", "(")
     escaped_text = escaped_text.replace("}", ")")
 
-    # Step 2: If compact mode is enabled, return the escaped text without wrapping
     if compact:
         return escaped_text
 
-    # Step 3: Check if wrapping is needed
     if len(escaped_text) <= max_width:
         return escaped_text
 
-    # Step 4: Do HTML-entity-aware wrapping
     lines = []
     current_line = ""
     i = 0
 
     while i < len(escaped_text):
-        # Check if we're at the start of an HTML entity
         if escaped_text[i] == "&":
-            # Find the end of the HTML entity
             entity_end = i + 1
             while entity_end < len(escaped_text) and escaped_text[entity_end] != ";":
                 entity_end += 1
             if entity_end < len(escaped_text):
-                entity_end += 1  # Include the semicolon
+                entity_end += 1
 
             entity = escaped_text[i:entity_end]
 
-            # Check if adding this entity would exceed the line limit
             if len(current_line) + len(entity) > max_width and current_line:
                 lines.append(current_line)
                 current_line = entity
@@ -1116,7 +1057,6 @@ def _safe_html_wrap(text: str, max_width: int, compact: bool = False) -> str:
 
             i = entity_end
         else:
-            # Regular character
             if len(current_line) + 1 > max_width and current_line:
                 lines.append(current_line)
                 current_line = escaped_text[i]
@@ -1135,7 +1075,6 @@ def _wrap_text(text: str, max_width: int) -> str:
     if len(text) <= max_width:
         return text
 
-    # Split into words for better wrapping
     words = text.split()
     if not words:
         return text
@@ -1144,14 +1083,11 @@ def _wrap_text(text: str, max_width: int) -> str:
     current_line = words[0]
 
     for word in words[1:]:
-        # Check if adding the next word would exceed the limit
         if len(current_line) + 1 + len(word) <= max_width:
             current_line += " " + word
         else:
-            # If current word is too long by itself, split it
             if len(word) > max_width:
                 lines.append(current_line)
-                # Split the long word across multiple lines
                 while len(word) > max_width:
                     lines.append(word[:max_width])
                     word = word[max_width:]
@@ -1166,196 +1102,6 @@ def _wrap_text(text: str, max_width: int) -> str:
     return "\\n".join(lines)
 
 
-def _estimate_kernel_performance(
-    kernel_name: str, duration_us: float
-) -> tuple[float, float]:
-    """
-    Estimate FLOPS and bandwidth for a kernel based on its name and duration.
-    Returns (estimated_flops_per_second, estimated_bandwidth_gbps).
-    """
-    # Normalize kernel name for pattern matching
-    name_lower = kernel_name.lower()
-
-    # Default values (conservative estimates)
-    base_flops = 1e9  # 1 GFLOPS
-    base_bandwidth = 100.0  # 100 GB/s
-
-    # Adjust estimates based on kernel patterns
-    if any(
-        x in name_lower for x in ["gemm", "matmul", "mm", "addmm", "bmm", "baddbmm"]
-    ):
-        # Matrix multiplication kernels - typically compute intensive
-        base_flops = 5e12  # 5 TFLOPS
-        base_bandwidth = 500.0  # 500 GB/s
-    elif any(x in name_lower for x in ["conv", "convolution"]):
-        # Convolution kernels - moderate compute and memory usage
-        base_flops = 2e12  # 2 TFLOPS
-        base_bandwidth = 300.0  # 300 GB/s
-    elif any(x in name_lower for x in ["attention", "flash_attn", "sdpa"]):
-        # Attention kernels - very compute intensive
-        base_flops = 8e12  # 8 TFLOPS
-        base_bandwidth = 600.0  # 600 GB/s
-    elif any(
-        x in name_lower
-        for x in ["elementwise", "add", "mul", "div", "relu", "gelu", "sigmoid"]
-    ):
-        # Element-wise operations - memory bound
-        base_flops = 5e8  # 0.5 GFLOPS
-        base_bandwidth = 800.0  # 800 GB/s (memory bound)
-    elif any(x in name_lower for x in ["reduce", "sum", "mean", "max", "softmax"]):
-        # Reduction operations - mixed compute/memory
-        base_flops = 1e9  # 1 GFLOPS
-        base_bandwidth = 400.0  # 400 GB/s
-    elif any(x in name_lower for x in ["copy", "transpose", "permute", "reshape"]):
-        # Memory movement operations - pure memory bound
-        base_flops = 1e8  # 0.1 GFLOPS
-        base_bandwidth = 1000.0  # 1000 GB/s (memory bound)
-    elif any(
-        x in name_lower for x in ["norm", "layer_norm", "batch_norm", "group_norm"]
-    ):
-        # Normalization operations - moderate compute and memory
-        base_flops = 1e9  # 1 GFLOPS
-        base_bandwidth = 300.0  # 300 GB/s
-
-    # Scale by duration - shorter kernels might be more optimized or have less work
-    duration_factor = min(2.0, max(0.1, duration_us / 100.0))  # 100μs is "normal"
-
-    # Add some randomness/variation based on kernel name hash to simulate real variation
-    name_hash = hash(kernel_name) % 1000
-    variation = 0.5 + (name_hash / 1000.0)  # 0.5 to 1.5 variation
-
-    estimated_flops = base_flops * duration_factor * variation
-    estimated_bandwidth = base_bandwidth * duration_factor * variation
-
-    return estimated_flops, estimated_bandwidth
-
-
-def _ensure_performance_statistics(multi_dag: "MultiTraceDAG") -> None:
-    """
-    Ensure that all kernel nodes in the multi-trace DAG have performance statistics.
-    This function recalculates performance stats if they're missing, ensuring fresh data.
-    """
-    from .device_info import compute_device_ridgepoint, lookup_device_info
-
-    print("Ensuring performance statistics are available for all traces...")
-
-    # Check each trace for missing performance statistics
-    for trace_id in multi_dag.trace_names.keys():
-        trace_name = multi_dag.trace_names[trace_id]
-
-        # Check if this trace has kernel nodes with missing performance statistics
-        needs_computation = False
-        kernel_nodes_in_trace = []
-
-        for node_name, multi_node in multi_dag.nodes.items():
-            if (
-                multi_node.node_type == "kernel"
-                and trace_id in multi_node.trace_instances
-            ):
-                kernel_node = multi_node.trace_instances[trace_id]
-                kernel_nodes_in_trace.append((node_name, kernel_node))
-
-                # Check if performance statistics are missing
-                if (
-                    not kernel_node.achieved_flops_list
-                    and not kernel_node.achieved_bandwidth_list
-                    and not kernel_node.bound_type_list
-                ):
-                    needs_computation = True
-
-        if needs_computation and kernel_nodes_in_trace:
-            print(
-                f"  Computing missing performance statistics for trace {trace_name}..."
-            )
-
-            # We need to compute performance statistics for this trace
-            # Try to use a dummy device info (we'll use a common one)
-            try:
-                # Use H100 as default device for statistics calculation
-                device_info = lookup_device_info("NVIDIA H100")
-                if device_info is None:
-                    # Fallback to A100 if H100 not available
-                    device_info = lookup_device_info("NVIDIA A100")
-
-                if device_info is not None:
-                    # Calculate performance statistics for each kernel node
-                    for kernel_name, kernel_node in kernel_nodes_in_trace:
-                        # For each kernel instance, calculate performance stats
-                        for i, (dur, _) in enumerate(kernel_node.kernel_instances):
-                            # Estimate FLOPS and bandwidth based on kernel name and duration
-                            # This provides more realistic estimates than fixed values
-
-                            estimated_flops, estimated_bandwidth = (
-                                _estimate_kernel_performance(kernel_name, dur)
-                            )
-
-                            # Calculate achieved percentages
-                            # Use float32 as default dtype for TOPS calculation
-                            default_dtype = torch.float32
-                            if default_dtype in device_info.tops:
-                                achieved_flops = (
-                                    100
-                                    * estimated_flops
-                                    / (1e12 * device_info.tops[default_dtype])
-                                )
-                            else:
-                                achieved_flops = 0.0
-
-                            achieved_bandwidth = (
-                                100 * estimated_bandwidth / device_info.dram_bw_gbs
-                            )
-
-                            # Calculate roofline bound type
-                            ridgepoint = compute_device_ridgepoint(
-                                device_info.name, default_dtype
-                            )
-                            if ridgepoint is not None:
-                                op_tops = estimated_flops / 1e12
-                                if estimated_bandwidth > 0:
-                                    kernel_intensity = op_tops / estimated_bandwidth
-                                    bound_type = (
-                                        "compute"
-                                        if kernel_intensity >= ridgepoint
-                                        else "memory"
-                                    )
-                                else:
-                                    bound_type = "compute"
-                            else:
-                                bound_type = "unknown"
-
-                            # Add statistics to the node
-                            kernel_node.achieved_flops_list.append(achieved_flops)
-                            kernel_node.achieved_bandwidth_list.append(
-                                achieved_bandwidth
-                            )
-                            kernel_node.bound_type_list.append(bound_type)
-
-                    print(
-                        f"    Added performance statistics for {len(kernel_nodes_in_trace)} kernel types"
-                    )
-                else:
-                    print(
-                        "    Warning: No device info available for performance calculation"
-                    )
-                    # Add placeholder data to avoid repeated attempts
-                    for kernel_name, kernel_node in kernel_nodes_in_trace:
-                        for _ in kernel_node.kernel_instances:
-                            kernel_node.achieved_flops_list.append(0.0)
-                            kernel_node.achieved_bandwidth_list.append(0.0)
-                            kernel_node.bound_type_list.append("unknown")
-
-            except Exception as e:
-                print(
-                    f"    Warning: Failed to compute performance statistics for {trace_name}: {e}"
-                )
-                # Add placeholder data to avoid repeated attempts
-                for kernel_name, kernel_node in kernel_nodes_in_trace:
-                    for _ in kernel_node.kernel_instances:
-                        kernel_node.achieved_flops_list.append(0.0)
-                        kernel_node.achieved_bandwidth_list.append(0.0)
-                        kernel_node.bound_type_list.append("unknown")
-
-
 def _add_trace_legend(
     dot: "graphviz.Digraph",
     multi_dag: "MultiTraceDAG",
@@ -1366,13 +1112,11 @@ def _add_trace_legend(
     with dot.subgraph(name="cluster_legend") as legend:
         legend.attr(label="Legend", style="filled", fillcolor="lightgray")
         legend.attr("node", shape="plaintext")
-        # Position the legend cluster at the top left
-        legend.attr(rank="source")  # Put at the top
-        legend.attr(pos="0,0!")  # Upper left position
+        legend.attr(rank="source")
+        legend.attr(pos="0,0!")
 
         legend_rows = []
 
-        # Add trace color legend
         legend_rows.append('<TR><TD COLSPAN="2"><B>Traces</B></TD></TR>')
         for trace_id in sorted(multi_dag.trace_names.keys()):
             trace_name = multi_dag.trace_names[trace_id]
@@ -1381,11 +1125,9 @@ def _add_trace_legend(
                 f'<TR><TD BGCOLOR="{color}">{trace_name}</TD><TD>Edge Color</TD></TR>'
             )
 
-        # Add color mode legend
         color_legend_text = multi_dag.get_color_legend_text(color_mode)
         if color_legend_text:
             legend_rows.append('<TR><TD COLSPAN="2"><B>Kernel Coloring</B></TD></TR>')
-            # Split legend text into lines and add as rows
             lines = color_legend_text.replace("Legend\\n", "").split("\\n")
             for line in lines:
                 if line.strip():
@@ -1396,9 +1138,208 @@ def _add_trace_legend(
             legend.node(
                 "legend",
                 f'<<TABLE BORDER="1" CELLBORDER="0" CELLSPACING="0">{legend_table}</TABLE>>',
-                # Ensure the legend node is at the top left
                 rank="source",
             )
+
+
+def _tint_color(base_color: str, tint: str, intensity: float) -> str:
+    """Apply a color tint to a base color with given intensity."""
+    # Convert hex to RGB
+    base_color = base_color.lstrip("#")
+    r, g, b = tuple(int(base_color[i : i + 2], 16) for i in (0, 2, 4))
+
+    # Define tint colors
+    tint_colors = {
+        "red": (255, 0, 0),
+        "blue": (0, 0, 255),
+        "green": (0, 255, 0),
+        "purple": (255, 0, 255),
+    }
+
+    if tint not in tint_colors:
+        return base_color
+
+    tint_r, tint_g, tint_b = tint_colors[tint]
+
+    # Blend base color with tint based on intensity
+    final_r = int(r * (1 - intensity) + tint_r * intensity)
+    final_g = int(g * (1 - intensity) + tint_g * intensity)
+    final_b = int(b * (1 - intensity) + tint_b * intensity)
+
+    # Ensure values are in valid range
+    final_r = max(0, min(255, final_r))
+    final_g = max(0, min(255, final_g))
+    final_b = max(0, min(255, final_b))
+
+    return f"#{final_r:02x}{final_g:02x}{final_b:02x}"
+
+
+def calculate_kernel_colors(
+    color_mode: str,
+    base_time_gradients: Dict[str, str],
+    kernel_nodes: Dict[str, Any],
+    baseline_profile: Optional["JsonProfile"] = None,
+) -> Dict[str, str]:
+    """
+    Calculate colors for kernel nodes based on the specified color mode.
+
+    Args:
+        color_mode: One of "time", "diff", "mem-utilization", "compute-utilization", "roofline"
+        base_time_gradients: Dictionary mapping kernel names to base gradient colors
+        kernel_nodes: Dictionary of kernel nodes containing performance statistics
+        baseline_profile: Optional baseline profile for diff mode
+
+    Returns:
+        Dictionary mapping kernel names to color strings
+    """
+    if color_mode not in [
+        "time",
+        "diff",
+        "mem-utilization",
+        "compute-utilization",
+        "roofline",
+    ]:
+        return {}
+
+    if color_mode == "time":
+        return base_time_gradients
+
+    kernel_colors = {}
+
+    if color_mode == "diff":
+        if baseline_profile is None:
+            print("Warning: diff coloring requested but no baseline profile provided")
+            return base_time_gradients
+
+        baseline_dag = baseline_profile.build_trace_dag()
+        baseline_durations = {}
+
+        for name, node in baseline_dag.nodes.items():
+            if node.node_type == "kernel":
+                total_duration = sum(dur for dur, _ in node.kernel_instances)
+                baseline_durations[name] = total_duration
+
+        # Calculate duration differences and modify the base gradients
+        for name, base_color in base_time_gradients.items():
+            if name not in kernel_nodes:
+                continue
+
+            current_duration = sum(
+                dur for dur, _ in kernel_nodes[name].kernel_instances
+            )
+            baseline_duration = baseline_durations.get(name, 0.0)
+
+            if baseline_duration == 0.0:
+                kernel_colors[name] = _tint_color(base_color, "red", 0.8)
+            else:
+                diff_ratio = (current_duration - baseline_duration) / baseline_duration
+                if diff_ratio > 0.1:
+                    tint_intensity = min(1.0, diff_ratio)
+                    kernel_colors[name] = _tint_color(base_color, "red", tint_intensity)
+                elif diff_ratio < -0.1:
+                    tint_intensity = min(1.0, abs(diff_ratio))
+                    kernel_colors[name] = _tint_color(
+                        base_color, "blue", tint_intensity
+                    )
+                else:
+                    kernel_colors[name] = base_color
+
+    elif color_mode == "mem-utilization":
+        # Modify base gradients based on memory bandwidth utilization
+        for name, base_color in base_time_gradients.items():
+            if name not in kernel_nodes:
+                continue
+
+            node = kernel_nodes[name]
+            if (
+                hasattr(node, "achieved_bandwidth_list")
+                and node.achieved_bandwidth_list
+            ):
+                avg_utilization = sum(node.achieved_bandwidth_list) / len(
+                    node.achieved_bandwidth_list
+                )
+                utilization_intensity = min(1.0, avg_utilization / 100.0)
+                kernel_colors[name] = _tint_color(
+                    base_color, "green", utilization_intensity
+                )
+            else:
+                kernel_colors[name] = base_color
+
+    elif color_mode == "compute-utilization":
+        for name, base_color in base_time_gradients.items():
+            if name not in kernel_nodes:
+                continue
+
+            node = kernel_nodes[name]
+            if hasattr(node, "achieved_flops_list") and node.achieved_flops_list:
+                avg_utilization = sum(node.achieved_flops_list) / len(
+                    node.achieved_flops_list
+                )
+                utilization_intensity = min(1.0, avg_utilization / 100.0)
+                kernel_colors[name] = _tint_color(
+                    base_color, "purple", utilization_intensity
+                )
+            else:
+                kernel_colors[name] = base_color
+
+    elif color_mode == "roofline":
+        for name, base_color in base_time_gradients.items():
+            if name not in kernel_nodes:
+                continue
+
+            node = kernel_nodes[name]
+            if (
+                hasattr(node, "bound_type_list")
+                and node.bound_type_list
+                and hasattr(node, "achieved_flops_list")
+                and node.achieved_flops_list
+                and hasattr(node, "achieved_bandwidth_list")
+                and node.achieved_bandwidth_list
+            ):
+                # Calculate the average roofline score
+                bound_types = node.bound_type_list
+                flops_utils = node.achieved_flops_list
+                bw_utils = node.achieved_bandwidth_list
+
+                total_score = 0.0
+                valid_instances = 0
+
+                for i in range(min(len(bound_types), len(flops_utils), len(bw_utils))):
+                    bound_type = bound_types[i]
+                    if bound_type == "compute":
+                        total_score += flops_utils[i]
+                        valid_instances += 1
+                    elif bound_type == "memory":
+                        total_score += bw_utils[i]
+                        valid_instances += 1
+
+                if valid_instances > 0:
+                    avg_score = total_score / valid_instances
+                    utilization_intensity = 1.0 - min(1.0, avg_score / 100.0)
+                    kernel_colors[name] = _tint_color(
+                        base_color, "red", utilization_intensity
+                    )
+                else:
+                    kernel_colors[name] = base_color
+            else:
+                kernel_colors[name] = base_color
+
+    return kernel_colors
+
+
+def get_color_legend_text(color_mode: str) -> Optional[str]:
+    """Get legend text for the specified color mode."""
+    if color_mode == "diff":
+        return "Legend\\nRed: Slower than baseline\\nBlue: Faster than baseline\\nWhite: Same as baseline"
+    elif color_mode == "mem-utilization":
+        return (
+            "Legend\\nGreen: Memory bandwidth utilization\\nDarker = lower utilization"
+        )
+    elif color_mode == "compute-utilization":
+        return "Legend\\nPurple: Compute utilization\\nDarker = lower utilization"
+    elif color_mode == "roofline":
+        return "Legend\\nRoofline Analysis\\nDark Red: Low utilization (worse)\\nLight Yellow: High utilization (better)\\nCompute-bound: Uses compute %\\nMemory-bound: Uses memory %"
+    return None
 
 
 class ParseException(RuntimeError):


### PR DESCRIPTION
This PR creates a compact visualization of all the kernels in a model trace, with bandwidth, flops, and roofline calculation (mem bound vs comp bound) +  call-stack for each kernel. An analogy here would be, if the profile is an audio waveform (samples), then this visualization is a Spectrogram (frequency domain.) You can provide many different traces, and they will be smashed together into the same visualization. The kernels are color coded to match which profile it belongs to. This allows easy comparison of the performance between eager vs compile, or between hardware vendors. The coloring of the kernel nodes provides quick identification of the important kernels by different stats (runtime by default.)

Note: this doesn't work on cudagraphed traces because they lack the cpu events through which to build the graph!

## `--visualize <trace_name_1> <trace_name_2> <dtype> <output>`

Examples:
```
# Single trace visualization 
python profile_analysis.py --visualize trace.json float32 output.svg 
```
![a2a84271-test_output2](https://github.com/user-attachments/assets/ae6322ae-722e-41d0-86e0-37009b8f562b)

^ click to open in a new window

```
# Multi-trace comparison 
python profile_analysis.py --visualize baseline.json current.json float32 comparison.svg --compact False
```
![945b0061-test_output2](https://github.com/user-attachments/assets/d146ff1b-95db-4f01-8be4-8286b6893441)


^ click to open in a new window

## --color
Controls how kernel nodes are colored to highlight different performance characteristics. 

Examples:
```
# Color by kernel runtime (default) - darker = longer runtime
python profile_analysis.py --visualize trace.json float32 output.png --color time

# Highlight memory bandwidth utilization = utilization %
python profile_analysis.py --visualize trace.json float32 output.png --color mem-utilization

# Show compute utilization = FLOPS utilization %
python profile_analysis.py --visualize trace.json float32 output.png --color compute-utilization

# Roofline percentage: % away from mem optimal if mem bound, % away from compute optimal if compute bound
python profile_analysis.py --visualize trace.json float32 output.png --color roofline
```
TODO Layer stuff

## --height
Limits visualization complexity by showing only the specified number of operation levels above kernel nodes.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos @chenyang78