### PR TITLE
Fix for torch.inf.to(torch.int32) produces different values on CPU vs…

### DIFF
--- a/c10/util/TypeCast.h
+++ b/c10/util/TypeCast.h
@@ -60,7 +60,9 @@ struct maybe_bool<true, src_t> {
 // Note: deliberately ignores undefined behavior, consistent with NumPy.
 // PyTorch's type conversions can cause a variety of undefined behavior,
 // including float to integral overflow and signed to unsigned integer overflow.
-// Some of this undefined behavior is addressed below.
+// Some of this undefined behavior is addressed below. In particular, conversions
+// from floating-point infinity and NaN to integer types are now well-defined:
+// +inf -> max value, -inf -> min value, NaN -> 0.
 template <typename dest_t, typename src_t>
 struct static_cast_with_inter_type {
   C10_HOST_DEVICE __ubsan_ignore_undefined__ static inline dest_t apply(

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -1101,7 +1101,6 @@ class TestTensorCreation(TestCase):
     # Note: This test validates undefined behavior consistency in float-to-ints casts
     # NB: torch.uint16, torch.uint32, torch.uint64 excluded as this
     # nondeterministically fails, warning "invalid value encountered in cast"
-    @onlyCPU
     @unittest.skipIf(IS_S390X, "Test fails for int16 on s390x. Needs investigation.")
     @dtypes(torch.bool, torch.uint8, torch.int8, torch.uint16, torch.int16, torch.uint32, torch.int32, torch.int64)
     def test_float_to_int_conversion_nonfinite(self, device, dtype):

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -1103,7 +1103,7 @@ class TestTensorCreation(TestCase):
     # nondeterministically fails, warning "invalid value encountered in cast"
     @onlyCPU
     @unittest.skipIf(IS_S390X, "Test fails for int16 on s390x. Needs investigation.")
-    @dtypes(torch.bool, torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64)
+    @dtypes(torch.bool, torch.uint8, torch.int8, torch.uint16, torch.int16, torch.uint32, torch.int32, torch.int64)
     def test_float_to_int_conversion_nonfinite(self, device, dtype):
         vals = (float('-inf'), float('inf'), float('nan'))
 
@@ -1114,9 +1114,8 @@ class TestTensorCreation(TestCase):
             if dtype in (torch.int8, torch.int16):
                 refs = (0, -1, 0)
         else:
-            refs = (0, 0, 0)
-            if dtype in (torch.int32, torch.int64):
-                refs = (torch.iinfo(dtype).min, ) * 3
+            # reference values for -inf, inf, nan conversions
+            refs = (torch.iinfo(dtype).min, torch.iinfo(dtype).max, 0)
         self._float_to_int_conversion_helper(vals, device, dtype, refs)
 
     @onlyNativeDeviceTypes

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -5260,8 +5260,15 @@ Here are the ways to call ``to``:
 
     According to `C++ type conversion rules <https://en.cppreference.com/w/cpp/language/implicit_conversion.html>`_,
     converting floating point value to integer type will truncate the fractional part.
-    If the truncated value cannot fit into the target type (e.g., casting ``torch.inf`` to ``torch.long``),
-    the behavior is undefined and the result may vary across platforms.
+
+    For non-finite values (infinity and NaN), PyTorch defines the following behavior
+    to ensure consistency across platforms:
+
+    - Positive infinity (``+inf``) maps to the maximum representable value of the target integer type
+    - Negative infinity (``-inf``) maps to the minimum representable value of the target integer type
+    - NaN maps to 0
+
+    This behavior is consistent across CPU and CUDA devices.
 
 .. method:: to(device=None, dtype=None, non_blocking=False, copy=False, memory_format=torch.preserve_format) -> Tensor
    :noindex:


### PR DESCRIPTION
Code Changes for:

Mapping from +inf to max, -inf to min and Nan to 0, when we type cast to integer type.
Updating for respective test case.

Fixes #154311
