### PR TITLE
Add support for 16 KB page size alignment

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,7 +24,7 @@ allprojects {
         }
 
         dependencies {
-            classpath 'com.android.tools.build:gradle:4.1.2'
+            classpath 'com.android.tools.build:gradle:4.2.0'
             classpath 'com.vanniktech:gradle-maven-publish-plugin:0.14.2'
         }
     }

--- a/android/pytorch_android/CMakeLists.txt
+++ b/android/pytorch_android/CMakeLists.txt
@@ -70,6 +70,7 @@ else()
     ${pytorch_android_DIR}/pytorch_jni_common.h
   )
 endif()
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,max-page-size=16384,-z,common-page-size=16384")
 add_library(${PYTORCH_JNI_TARGET} SHARED ${pytorch_android_SOURCES})
 
 if(APPLE)

--- a/android/pytorch_android/build.gradle
+++ b/android/pytorch_android/build.gradle
@@ -75,6 +75,9 @@ android {
             doNotStrip "**/*.so"
             logger.warn('WARNING: nativeLibsDoNotStrip==true; debug symbols included')
         }
+        jniLibs {
+            useLegacyPackaging true
+        }
     }
 
     useLibrary 'android.test.runner'

--- a/android/pytorch_android_torchvision/CMakeLists.txt
+++ b/android/pytorch_android_torchvision/CMakeLists.txt
@@ -9,6 +9,8 @@ file(GLOB pytorch_vision_SOURCES
   ${pytorch_vision_cpp_DIR}/pytorch_vision_jni.cpp
 )
 
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,max-page-size=16384,-z,common-page-size=16384")
+
 add_library(pytorch_vision_jni SHARED
     ${pytorch_vision_SOURCES}
 )

--- a/android/pytorch_android_torchvision/build.gradle
+++ b/android/pytorch_android_torchvision/build.gradle
@@ -34,6 +34,12 @@ android {
         }
     }
 
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging true
+        }
+    }
+
     useLibrary 'android.test.runner'
     useLibrary 'android.test.base'
     useLibrary 'android.test.mock'


### PR DESCRIPTION
Align shared library ELF segments to support the 16 KB page size requirement for apps targeting Android 15+ on Google Play.

The project is constrained by older NDK and CMake versions, preventing a direct upgrade to the latest Android Gradle Plugin (AGP). To achieve compatibility, the following workarounds were implemented:

- Upgraded to AGP 4.2.0 to enable the `useLegacyPackaging` flag. This ensures native libraries are stored uncompressed in the APK, a prerequisite for 16 KB alignment.

- Added linker flags (`-Wl,-z,max-page-size=16384`) to the build. Since the project's minimum CMake version (3.5) is too old to support the modern `target_link_options` command (requires 3.13+), the flags are set globally using the legacy `CMAKE_SHARED_LINKER_FLAGS` variable.

Fixes #154449
