### PR TITLE
[AOTI] Fix Windows fail to zip opened file.

### DIFF
--- a/third_party/miniz-3.0.2/miniz.c
+++ b/third_party/miniz-3.0.2/miniz.c
@@ -3136,6 +3136,7 @@ extern "C" {
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <share.h>
 
 static WCHAR* mz_utf8z_to_widechar(const char* str)
 {
@@ -3149,11 +3150,13 @@ static FILE *mz_fopen(const char *pFilename, const char *pMode)
 {
   WCHAR* wFilename = mz_utf8z_to_widechar(pFilename);
   WCHAR* wMode = mz_utf8z_to_widechar(pMode);
-  FILE* pFile = NULL;
-  errno_t err = _wfopen_s(&pFile, wFilename, wMode);
+  /*
+  Must use _wfsopen with _SH_DENYNO on Windows, to open opened temp files.
+  */
+  FILE* pFile = _wfsopen(wFilename, wMode, _SH_DENYNO);
   free(wFilename);
   free(wMode);
-  return err ? NULL : pFile;
+  return pFile;
 }
 
 static FILE *mz_freopen(const char *pPath, const char *pMode, FILE *pStream)

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -390,7 +390,14 @@ class WritableTempFile:
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         self.temp_file.close()
-        os.unlink(self.temp_file.name)
+        try:
+            os.unlink(self.temp_file.name)
+        except OSError as e:
+            if _IS_WINDOWS:
+                # On Windows, some case temp file is opened and fail to unlink. Need to ignore it.
+                pass
+            else:
+                raise e
 
 
 def write(


### PR DESCRIPTION
Original issue:
<img width="1767" height="544" alt="Image" src="https://github.com/user-attachments/assets/9de90d50-217f-4049-8f19-77ff1660c8b0" />

reproducer:
```cmd
pytest test\inductor\test_aot_inductor.py -v -k test_weight_on_disk_legacy_cpu
```

Fixed list:
1. `WritableTempFile`'s `__exit__` function auto unlink opened file, when the file was opened, it should raise error. Ignore it on Windows.
2. When open zip file, if the file is opened, it would be failed. Switch to `_wfsopen` with shared access flag, which can open file with shared access.

Local test passed:
<img width="1101" height="233" alt="image" src="https://github.com/user-attachments/assets/935cbf2e-52db-41f1-80fa-617569b92a96" />


cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben 