### PR TITLE
bf16 support for fused_moving_avg_obs_fake_quant() op

### DIFF
--- a/aten/src/ATen/native/quantized/cuda/FusedObsFakeQuant.cu
+++ b/aten/src/ATen/native/quantized/cuda/FusedObsFakeQuant.cu
@@ -1,5 +1,6 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/core/Tensor.h>
+#include <ATen/Dispatch.h>
 #include <ATen/ceil_div.h>
 #include <ATen/native/cuda/Loops.cuh>
 #include <c10/cuda/CUDAGuard.h>
@@ -21,10 +22,11 @@
 namespace at::native {
 
 namespace {
+template <typename T>
 __global__ void ChooseQuantizationParamsKernelImpl(
     const int64_t* fake_quant_on,
-    const float* x_min,
-    const float* x_max,
+    const T* x_min,
+    const T* x_max,
     int32_t qmin,
     int32_t qmax,
     int size,
@@ -93,34 +95,44 @@ __global__ void ChooseQuantizationParamsKernelImpl(
   }
 }
 
+__device__ inline bool isinf_device(float v) {
+  return ::isinf(v);
+}
+__device__ inline bool isinf_device(c10::BFloat16 v) {
+  return ::isinf(static_cast<float>(v));
+}
+
 // CUDA kernel to compute Moving Average Min/Max of the tensor.
 // It uses the running_min and running_max along with averaging const, c.
 // The formula used to compute the new min/max is as follows
 //
 // running_min = (1 - c) * running_min + c * x_min, if running_min != inf
 // running_min = x_min, if running_min == inf
+template <typename T>
 __global__ void MovingAverageMinMax(
     const int64_t* observer_on,
-    const float* x_min,
-    const float* x_max,
-    float* running_min,
-    float* running_max,
+    const T* x_min,
+    const T* x_max,
+    T* running_min,
+    T* running_max,
     const float averaging_const,
     const int size) {
   int i = blockIdx.x * blockDim.x + threadIdx.x;
 
   if (*observer_on == 1) {
     if (i < size) {
-      float curr_min = x_min[i];
-      float curr_max = x_max[i];
+      T curr_min = x_min[i];
+      T curr_max = x_max[i];
 
-      float adjusted_min = ::isinf(running_min[i])
-          ? curr_min
-          : (running_min[i]) + averaging_const * (curr_min - (running_min[i]));
+      T averaging_const_t = static_cast<T>(averaging_const);
 
-      float adjusted_max = ::isinf(running_max[i])
-          ? curr_max
-          : (running_max[i]) + averaging_const * (curr_max - (running_max[i]));
+      T adjusted_min = isinf_device(running_min[i]) ? curr_min
+                                                    : (running_min[i]) +
+              averaging_const_t * (curr_min - (running_min[i]));
+
+      T adjusted_max = isinf_device(running_max[i]) ? curr_max
+                                                    : (running_max[i]) +
+              averaging_const_t * (curr_max - (running_max[i]));
 
       running_min[i] = adjusted_min;
       running_max[i] = adjusted_max;
@@ -142,40 +154,51 @@ void _calculate_moving_average(
   at::Tensor x_min, x_max;
 
   int64_t* observer_on_data = observer_on.data_ptr<int64_t>();
-  float* running_min_data = running_min.data_ptr<float>();
-  float* running_max_data = running_max.data_ptr<float>();
   cudaStream_t cuda_stream = at::cuda::getCurrentCUDAStream();
 
   if (per_row_fq) {
     std::tie(x_min, x_max) = at::aminmax(x, 1);
-    float* x_min_data = x_min.data_ptr<float>();
-    float* x_max_data = x_max.data_ptr<float>();
     int num_threads = std::min(size, (int64_t)512);
     const uint64_t num_blocks = ceil_div<uint64_t>(size, num_threads);
+    AT_DISPATCH_FLOATING_TYPES_AND(
+        at::kBFloat16, x.scalar_type(), "aminmax_kernel", [&] {
+          scalar_t* x_min_data = x_min.data_ptr<scalar_t>();
+          scalar_t* x_max_data = x_max.data_ptr<scalar_t>();
 
-    // Moving Average Min/Max observer for activations
-    MovingAverageMinMax<<<num_blocks, num_threads, 0, cuda_stream>>>(
-        observer_on_data,
-        x_min_data,
-        x_max_data,
-        running_min_data,
-        running_max_data,
-        averaging_const,
-        size);
+          scalar_t* running_min_data = running_min.data_ptr<scalar_t>();
+          scalar_t* running_max_data = running_max.data_ptr<scalar_t>();
+
+          // Moving Average Min/Max observer for activations
+          MovingAverageMinMax<<<num_blocks, num_threads, 0, cuda_stream>>>(
+              observer_on_data,
+              x_min_data,
+              x_max_data,
+              running_min_data,
+              running_max_data,
+              averaging_const,
+              size);
+        });
     C10_CUDA_KERNEL_LAUNCH_CHECK();
   } else {
     std::tie(x_min, x_max) = at::aminmax(x);
-    float* x_min_data = x_min.data_ptr<float>();
-    float* x_max_data = x_max.data_ptr<float>();
-    // Moving Average Min/Max observer for activations
-    MovingAverageMinMax<<<1, 1, 0, cuda_stream>>>(
-        observer_on_data,
-        x_min_data,
-        x_max_data,
-        running_min_data,
-        running_max_data,
-        averaging_const,
-        1 /*size*/);
+    AT_DISPATCH_FLOATING_TYPES_AND(
+        at::kBFloat16, x.scalar_type(), "aminmax_kernel", [&] {
+          scalar_t* x_min_data = x_min.data_ptr<scalar_t>();
+          scalar_t* x_max_data = x_max.data_ptr<scalar_t>();
+
+          scalar_t* running_min_data = running_min.data_ptr<scalar_t>();
+          scalar_t* running_max_data = running_max.data_ptr<scalar_t>();
+
+          // Moving Average Min/Max observer for activations
+          MovingAverageMinMax<<<1, 1, 0, cuda_stream>>>(
+              observer_on_data,
+              x_min_data,
+              x_max_data,
+              running_min_data,
+              running_max_data,
+              averaging_const,
+              1 /*size*/);
+        });
     C10_CUDA_KERNEL_LAUNCH_CHECK();
   }
 }
@@ -198,34 +221,44 @@ void _calc_moving_avg_qparams_helper(
   cudaStream_t cuda_stream = at::cuda::getCurrentCUDAStream();
   int64_t* fake_quant_on_data = fake_quant_on.data_ptr<int64_t>();
   if (per_row_fq) {
-    float* running_min_data = running_min.data_ptr<float>();
-    float* running_max_data = running_max.data_ptr<float>();
-    int num_threads = std::min(size, (int64_t)512);
-    const uint64_t num_blocks = ceil_div<uint64_t>(size, num_threads);
-    ChooseQuantizationParamsKernelImpl<<<num_blocks, num_threads, 0, cuda_stream>>>(
-        fake_quant_on_data,
-        running_min_data,
-        running_max_data,
-        qmin,
-        qmax,
-        size,
-        symmetric_quant,
-        scale_ptr,
-        zp_ptr);
+    AT_DISPATCH_FLOATING_TYPES_AND(
+        at::kBFloat16, x.scalar_type(), "aminmax_kernel", [&] {
+          scalar_t* running_min_data = running_min.data_ptr<scalar_t>();
+          scalar_t* running_max_data = running_max.data_ptr<scalar_t>();
+          int num_threads = std::min(size, (int64_t)512);
+          const uint64_t num_blocks = ceil_div<uint64_t>(size, num_threads);
+          ChooseQuantizationParamsKernelImpl<<<
+              num_blocks,
+              num_threads,
+              0,
+              cuda_stream>>>(
+              fake_quant_on_data,
+              running_min_data,
+              running_max_data,
+              qmin,
+              qmax,
+              size,
+              symmetric_quant,
+              scale_ptr,
+              zp_ptr);
+        });
     C10_CUDA_KERNEL_LAUNCH_CHECK();
   } else {
-    float* running_min_data = running_min.data_ptr<float>();
-    float* running_max_data = running_max.data_ptr<float>();
-    ChooseQuantizationParamsKernelImpl<<<1, 1, 0, cuda_stream>>>(
-        fake_quant_on_data,
-        running_min_data,
-        running_max_data,
-        qmin,
-        qmax,
-        1, // size
-        symmetric_quant, // preserve_sparsity
-        scale_ptr,
-        zp_ptr);
+    AT_DISPATCH_FLOATING_TYPES_AND(
+        at::kBFloat16, x.scalar_type(), "aminmax_kernel", [&] {
+          scalar_t* running_min_data = running_min.data_ptr<scalar_t>();
+          scalar_t* running_max_data = running_max.data_ptr<scalar_t>();
+          ChooseQuantizationParamsKernelImpl<<<1, 1, 0, cuda_stream>>>(
+              fake_quant_on_data,
+              running_min_data,
+              running_max_data,
+              qmin,
+              qmax,
+              1, // size
+              symmetric_quant, // preserve_sparsity
+              scale_ptr,
+              zp_ptr);
+        });
     C10_CUDA_KERNEL_LAUNCH_CHECK();
   }
 }

--- a/test/quantization/core/test_workflow_module.py
+++ b/test/quantization/core/test_workflow_module.py
@@ -908,6 +908,19 @@ class TestFakeQuantize(TestCase):
         self.assertEqual(fq_module.activation_post_process.quant_min, 0)
         self.assertEqual(fq_module.activation_post_process.quant_max, 127)
 
+    @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']))
+    def test_fused_moving_avg_obs_fake_quant(self, device):
+        try:
+            sampled_dtype = st.sampled_from(["bf16", "fp32"]) if device == "cuda" else "fp32"
+            dtype = torch.bfloat16 if sampled_dtype == "bf16" else torch.float32
+            torch.set_default_dtype(dtype)
+
+            with torch.device(device):
+                fake_quantize = FusedMovingAvgObsFakeQuantize()
+                fake_quantize.forward(torch.rand((256, 512)))
+        finally:
+            torch.set_default_dtype(torch.float32)
+
 def _get_buffer_ids(module):
     """
     Object addresses stay constant if and only if all modifications are in-place


### PR DESCRIPTION
enabling bf16 support for `torch.fused_moving_avg_obs_fake_quant()` op on cuda

**testing**
`python test/quantization/pt2e/test_quantize_pt2e.py`

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd