### PR TITLE
Add cuda headers automatically for compile_kernel

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -7023,6 +7023,39 @@ class TestCompileKernel(TestCase):
         expected = input_data + scalar_val
         torch.testing.assert_close(result, expected, rtol=1e-5, atol=1e-5)
 
+    @unittest.skipIf(TEST_WITH_ROCM, "ROCM does not support nvrtc")
+    @unittest.skipIf(not TEST_CUDA, "No CUDA")
+    def test_compile_kernel_cuda_headers(self):
+        """Test that kernels can include and use CUDA headers like cuda_fp16.h."""
+        kernel_source = """
+        #include <cuda_fp16.h>
+
+        extern "C"
+        __global__ void half_precision_kernel(__half* output, float input_value, int n) {
+            int idx = blockIdx.x * blockDim.x + threadIdx.x;
+            if (idx < n) {
+                output[idx] = __float2half(input_value);
+            }
+        }
+        """
+
+        from torch.cuda import _compile_kernel
+
+        compiled_kernel = _compile_kernel(kernel_source, "half_precision_kernel")
+
+        n = 100
+        test_value = 3.14159
+        output = torch.zeros(n, device="cuda", dtype=torch.float16)
+
+        compiled_kernel(
+            grid=(1, 1, 1),
+            block=(256, 1, 1),
+            args=[output, test_value, n],
+        )
+
+        expected = torch.full((n,), test_value, device="cuda", dtype=torch.float16)
+        torch.testing.assert_close(output, expected, rtol=1e-3, atol=1e-3)
+
 
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 class TestCudaDeviceParametrized(TestCase):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -7056,6 +7056,47 @@ class TestCompileKernel(TestCase):
         expected = torch.full((n,), test_value, device="cuda", dtype=torch.float16)
         torch.testing.assert_close(output, expected, rtol=1e-3, atol=1e-3)
 
+    @unittest.skipIf(TEST_WITH_ROCM, "ROCM does not support nvrtc")
+    @unittest.skipIf(not TEST_CUDA, "No CUDA")
+    def test_compile_kernel_cuda_cpp_stdlib(self):
+        """Test that kernels can use CUDA C++ Standard Library headers."""
+        kernel_source = """
+        #include <cuda/std/cstdint>
+        #include <cuda/std/type_traits>
+
+        extern "C"
+        __global__ void cpp_stdlib_kernel(
+            cuda::std::uint32_t* output,
+            cuda::std::uint32_t input_value,
+            int n
+        ) {
+            int idx = blockIdx.x * blockDim.x + threadIdx.x;
+            if (idx < n) {
+                // Use type_traits to check if uint32_t is integral
+                if constexpr (cuda::std::is_integral_v<cuda::std::uint32_t>) {
+                    output[idx] = input_value + static_cast<cuda::std::uint32_t>(idx);
+                }
+            }
+        }
+        """
+
+        from torch.cuda import _compile_kernel
+
+        compiled_kernel = _compile_kernel(kernel_source, "cpp_stdlib_kernel")
+
+        n = 100
+        input_value = 42
+        output = torch.zeros(n, device="cuda", dtype=torch.uint32)
+
+        compiled_kernel(
+            grid=(1, 1, 1),
+            block=(256, 1, 1),
+            args=[output, input_value, n],
+        )
+
+        expected = torch.arange(n, device="cuda", dtype=torch.uint32) + input_value
+        torch.testing.assert_close(output, expected)
+
 
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 class TestCudaDeviceParametrized(TestCase):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -7062,20 +7062,16 @@ class TestCompileKernel(TestCase):
         """Test that kernels can use CUDA C++ Standard Library headers."""
         kernel_source = """
         #include <cuda/std/cstdint>
-        #include <cuda/std/type_traits>
-
-        extern "C"
+        
         __global__ void cpp_stdlib_kernel(
-            cuda::std::uint32_t* output,
-            cuda::std::uint32_t input_value,
+            cuda::std::uint32_t* output, 
+            cuda::std::uint32_t input_value, 
             int n
         ) {
             int idx = blockIdx.x * blockDim.x + threadIdx.x;
             if (idx < n) {
-                // Use type_traits to check if uint32_t is integral
-                if constexpr (cuda::std::is_integral_v<cuda::std::uint32_t>) {
-                    output[idx] = input_value + static_cast<cuda::std::uint32_t>(idx);
-                }
+                // Use CUDA C++ stdlib types
+                output[idx] = input_value + static_cast<cuda::std::uint32_t>(idx);
             }
         }
         """

--- a/torch/cuda/_utils.py
+++ b/torch/cuda/_utils.py
@@ -104,6 +104,13 @@ def _nvrtc_compile(
     options = []
     options.append(f"--gpu-architecture=sm_{compute_capability}".encode())
 
+    # Auto-detect and add CUDA include paths
+    from torch.utils.cpp_extension import include_paths
+
+    cuda_include_paths = include_paths("cuda")
+    for cuda_path in cuda_include_paths:
+        options.append(f"-I{cuda_path}".encode())
+
     # Add custom include directories
     if cuda_include_dirs:
         for directory in cuda_include_dirs:


### PR DESCRIPTION
Issue was pointed out before by @ngimel and more recently by https://gau-nernst.github.io/nvrtc-matmul/#missing-cuda-and-c-headers- by @gau-nernst 

Benefit is now we can add 

`#include <cuda_fp16.h>` without crapping out