### PR TITLE
Fix Windows CI missing pwlf dependency for sac_ilp tests

### DIFF
--- a/.ci/pytorch/win-test.sh
+++ b/.ci/pytorch/win-test.sh
@@ -49,8 +49,9 @@ python -m pip install tlparse==0.4.0
 # Install parameterized
 python -m pip install parameterized==0.8.1
 
-# Install pulp for testing ilps under torch\distributed\_tools
+# Install pulp and pwlf for testing ilps under torch\distributed\_tools
 python -m pip install pulp==2.9.0
+python -m pip install pwlf==2.2.1
 
 # Install expecttest to merge https://github.com/pytorch/pytorch/pull/155308
 python -m pip install expecttest==0.3.0


### PR DESCRIPTION
Fixes #162453 
   ## Problem
   The test `test_sac_ilp_case1` was failing in Windows CI because the `pwlf` dependency was missing, while other CI environments already had it.

   ## Solution
   Added `pwlf==2.2.1` to the Windows CI dependencies in `.ci/pytorch/win-test.sh`.

   ## Testing
   - Verified both `pwlf` and `pulp` dependencies work correctly
   - No linting errors introduced
   - Fix addresses the exact issue described in #162453