### PR TITLE
Smoke tests don't run nvshmem on Windows

### DIFF
--- a/.ci/pytorch/smoke_test/smoke_test.py
+++ b/.ci/pytorch/smoke_test/smoke_test.py
@@ -396,7 +396,9 @@ def smoke_test_nvshmem() -> None:
     except ImportError:
         # Not built with NVSHMEM support.
         # torch is not compiled with NVSHMEM prior to 2.9
-        if torch.__version__ < "2.9.*":
+        maj = int(torch.__version__.split(".")[0])
+        min = int(torch.__version__.split(".")[1])
+        if (maj, min) < (2,9):
             return
         else:
             # After 2.9: NVSHMEM is expected to be compiled in current build

--- a/.ci/pytorch/smoke_test/smoke_test.py
+++ b/.ci/pytorch/smoke_test/smoke_test.py
@@ -398,7 +398,7 @@ def smoke_test_nvshmem() -> None:
         # torch is not compiled with NVSHMEM prior to 2.9
         maj = int(torch.__version__.split(".")[0])
         min = int(torch.__version__.split(".")[1])
-        if (maj, min) < (2,9):
+        if (maj, min) < (2, 9):
             return
         else:
             # After 2.9: NVSHMEM is expected to be compiled in current build

--- a/.ci/pytorch/smoke_test/smoke_test.py
+++ b/.ci/pytorch/smoke_test/smoke_test.py
@@ -397,6 +397,7 @@ def smoke_test_nvshmem() -> None:
         # Not built with NVSHMEM support.
         # torch is not compiled with NVSHMEM prior to 2.9
         from torch.torch_version import TorchVersion
+
         if TorchVersion(torch.__version__) < (2, 9):
             return
         else:

--- a/.ci/pytorch/smoke_test/smoke_test.py
+++ b/.ci/pytorch/smoke_test/smoke_test.py
@@ -386,8 +386,8 @@ def smoke_test_compile(device: str = "cpu") -> None:
 
 
 def smoke_test_nvshmem() -> None:
-    if not torch.cuda.is_available():
-        print("CUDA is not available, skipping NVSHMEM test")
+    if not torch.cuda.is_available() or target_os == "windows":
+        print("Windows platform or CUDA is not available, skipping NVSHMEM test")
         return
 
     # Check if NVSHMEM is compiled in current build

--- a/.ci/pytorch/smoke_test/smoke_test.py
+++ b/.ci/pytorch/smoke_test/smoke_test.py
@@ -396,7 +396,7 @@ def smoke_test_nvshmem() -> None:
     except ImportError:
         # Not built with NVSHMEM support.
         # torch is not compiled with NVSHMEM prior to 2.9
-        if torch.__version__ < "2.9":
+        if torch.__version__ < "2.9.*":
             return
         else:
             # After 2.9: NVSHMEM is expected to be compiled in current build

--- a/.ci/pytorch/smoke_test/smoke_test.py
+++ b/.ci/pytorch/smoke_test/smoke_test.py
@@ -396,9 +396,8 @@ def smoke_test_nvshmem() -> None:
     except ImportError:
         # Not built with NVSHMEM support.
         # torch is not compiled with NVSHMEM prior to 2.9
-        maj = int(torch.__version__.split(".")[0])
-        min = int(torch.__version__.split(".")[1])
-        if (maj, min) < (2, 9):
+        from torch.torch_version import TorchVersion
+        if TorchVersion(torch.__version__) < (2, 9):
             return
         else:
             # After 2.9: NVSHMEM is expected to be compiled in current build


### PR DESCRIPTION
Only available for linux x86 and aarch64 :
https://pypi.org/project/nvidia-nvshmem-cu13/#files


nvshmem is available only on linux:
``
"nvidia-nvshmem-cu12==3.3.24; platform_system == 'Linux' and platform_machine == 'x86_64' | "
``
https://github.com/pytorch/pytorch/blob/main/.github/scripts/generate_binary_build_matrix.py#L57