### PR TITLE
fp8-kv-cache-flex

### DIFF
--- a/torch/_inductor/kernel/flex/templates/common.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/common.py.jinja
@@ -38,6 +38,7 @@ def forward_block_mn(
     {%- endif %}
 
     k = tl.trans(k)
+    k = k.to(q.dtype)
     # -- compute qk ---
     qk = tl.dot(q, k, input_precision=FLOAT32_PRECISION) # TODO: use cuda matmul when q_len <= 2.
     if not PRESCALE_QK:
@@ -111,7 +112,7 @@ def forward_block_mn(
     offs_v = tl.arange(0, V_HEAD_DIM_ROUNDED)
     v = load_checked_2d(V, offs_n_load, offs_v, stride_vn, stride_vk, IS_DIVISIBLE, SAFE_HEAD_DIM, KV_LEN, V_HEAD_DIM)
     {%- endif %}
-    acc = tl.dot(p.to(MATMUL_PRECISION), v, acc, input_precision=FLOAT32_PRECISION)
+    acc = tl.dot(p.to(MATMUL_PRECISION), v.to(q.dtype), acc, input_precision=FLOAT32_PRECISION)
 
     # -- update m_i
     m_i = m_ij

--- a/torch/nn/attention/_utils.py
+++ b/torch/nn/attention/_utils.py
@@ -40,13 +40,15 @@ def _validate_sdpa_input(
     dropout_p=0.0,
     is_causal=False,
     scale=None,
+    allow_lowp_kv=False,
 ):
-    if query.dtype != key.dtype or query.dtype != value.dtype:
-        raise ValueError(
-            f"Expected query, key, and value to have the same dtype, "
-            f"but got query.dtype: {query.dtype}, key.dtype: {key.dtype}, "
-            f"and value.dtype: {value.dtype} instead."
-        )
+    if not allow_lowp_kv:
+        if query.dtype != key.dtype or query.dtype != value.dtype:
+            raise ValueError(
+                f"Expected query, key, and value to have the same dtype, "
+                f"but got query.dtype: {query.dtype}, key.dtype: {key.dtype}, "
+                f"and value.dtype: {value.dtype} instead."
+            )
     if query.device != key.device or query.device != value.device:
         raise ValueError(
             f"Expected query, key, and value to have the same device type, "

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -1514,7 +1514,7 @@ def flex_attention(
 
     """
     # Some basic input validation
-    _validate_sdpa_input(query, key, value)
+    _validate_sdpa_input(query, key, value, allow_lowp_kv=True)
     _validate_embed_dim(query, key, value)
     _validate_device(query, key, value)
     _validate_nestedness(query, key, value)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #162679


```Py
import torch
from torch.nn.attention.flex_attention import flex_attention
from functools import partial
from typing import Callable
import logging
from transformer_nuggets.utils.benchmark import benchmark_cuda_function_in_microseconds


logging.getLogger("transformer_nuggets").setLevel(logging.INFO)
Tensor = torch.Tensor

def scaled_flex(
    query: Tensor,
    key: Tensor,
    value: Tensor,
    k_scale: float,
    v_scale: Tensor,
    **kwargs
):
    combined_scale =  k_scale * (1.0 / (query.size(-1) ** 0.5))
    out = flex_attention(query, key, value, scale=combined_scale, **kwargs)
    # out = out.to(torch.query.dtype)
    out *= v_scale
    return out


compiled_scale_flex = torch.compile(scaled_flex, fullgraph=True, dynamic=False)
compiled_flex = torch.compile(flex_attention, fullgraph=True, dynamic=False)

torch._dynamo.config.cache_size_limit = 1000

make_tensor = partial(torch.randn, device="cuda", dtype=torch.bfloat16)
B, H, seq_q, seq_k, D = 16, 16, 1, 1024, 64

query = make_tensor((B, H, seq_q, D))
key = make_tensor((B, H, seq_k, D))
value = make_tensor((B, H, seq_k, D))

q_scale = torch.tensor(1, device="cuda", dtype=torch.float32)
k_scale = torch.tensor(1, device="cuda", dtype=torch.float32).item()
v_scale = torch.tensor(1, device="cuda", dtype=torch.float32).item()

k_fp8 = key.to(torch.float8_e4m3fn)
v_fp8 = value.to(torch.float8_e4m3fn)



for _ in range(10):
    out = compiled_scale_flex(
        query,
        k_fp8,
        v_fp8,
        k_scale=k_scale,
        v_scale=v_scale,
    )
    out_bf16 = compiled_flex(query, key, value)


time_fp8 = benchmark_cuda_function_in_microseconds(compiled_scale_flex, query, k_fp8, v_fp8, k_scale=k_scale, v_scale=v_scale)
time_bf16 = benchmark_cuda_function_in_microseconds(compiled_flex, query, key, value)

print(f"fp8 time: {time_fp8} us")
print(f"bf16 time: {time_bf16} us")
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @Chillee @yanboliang @BoyuanFeng