### PR TITLE
[SymmMem] Fix memory allocation hold-up

### DIFF
--- a/test/distributed/test_nvshmem.py
+++ b/test/distributed/test_nvshmem.py
@@ -240,10 +240,11 @@ class NVSHMEMAll2AllTest(MultiProcContinuousTest):
     def _init_device(self) -> None:
         # TODO: relieve this (seems to hang if without)
         device_module.set_device(self.device)
-        # NOTE: required for nvshmem allocation
-        torch.empty(1, device=self.device)
         # Set NVSHMEM as SymmMem backend
         symm_mem.set_backend("NVSHMEM")
+        # Sync all ranks
+        torch.cuda.synchronize(self.device)
+        dist.barrier()
 
     @property
     def device(self) -> torch.device:

--- a/test/distributed/test_nvshmem.py
+++ b/test/distributed/test_nvshmem.py
@@ -242,9 +242,6 @@ class NVSHMEMAll2AllTest(MultiProcContinuousTest):
         device_module.set_device(self.device)
         # Set NVSHMEM as SymmMem backend
         symm_mem.set_backend("NVSHMEM")
-        # Sync all ranks
-        torch.cuda.synchronize(self.device)
-        dist.barrier()
 
     @property
     def device(self) -> torch.device:
@@ -307,6 +304,9 @@ class NVSHMEMAll2AllTest(MultiProcContinuousTest):
         )
         # Row 0 is input splits
         in_out_splits[0].copy_(inp_splits)
+
+        # Sync all ranks to ensure remote tensors are allocated
+        dist.barrier()
 
         torch.ops.symm_mem.all_to_all_vdev(inp, out, in_out_splits, group_name)
 
@@ -375,6 +375,9 @@ class NVSHMEMAll2AllTest(MultiProcContinuousTest):
         out_splits_offsets = symm_mem.empty(
             (2, nsplits), dtype=torch.int64, device=self.device
         ).fill_(-1)
+
+        # Sync all ranks to ensure remote tensors are allocated
+        dist.barrier()
 
         torch.ops.symm_mem.all_to_all_vdev_2d(
             inp, out, in_splits, out_splits_offsets, group_name, major_align=align
@@ -490,6 +493,9 @@ class NVSHMEMAll2AllTest(MultiProcContinuousTest):
         in_splits_offsets[0].copy_(inp_splits)
         # Row 1 is input offsets
         in_splits_offsets[1].copy_(inp_offsets)
+
+        # Sync all ranks to ensure remote tensors are allocated
+        dist.barrier()
 
         torch.ops.symm_mem.all_to_all_vdev_2d_offset(
             inp, out, in_splits_offsets, out_splits_offsets, group_name

--- a/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cu
@@ -51,7 +51,7 @@ struct NVSHMEMAllocation {
 class NVSHMEMPeerAllocInfo : public c10::intrusive_ptr_target {
  public:
   NVSHMEMPeerAllocInfo(
-      std::shared_ptr<NVSHMEMAllocation> allocation,
+      const std::unique_ptr<NVSHMEMAllocation>& allocation,
       const std::string& group_name)
       : base_ptr_(allocation->ptr),
         buffer_size_(allocation->buffer_size) {
@@ -144,10 +144,9 @@ class NVSHMEMPeerAllocInfo : public c10::intrusive_ptr_target {
 class NVSHMEMSymmetricMemory : public SymmetricMemory {
  public:
   NVSHMEMSymmetricMemory(
-      std::shared_ptr<NVSHMEMAllocation> allocation,
+      const std::unique_ptr<NVSHMEMAllocation>& allocation,
       const std::string& group_name)
-      : allocation_(allocation),
-        device_idx_(allocation->device_idx),
+      : device_idx_(allocation->device_idx),
         group_name_(group_name) {
     // A handle stores two types of info:
     // (i) allocation's base ptrs and base signal pads, ours and peers'
@@ -162,7 +161,7 @@ class NVSHMEMSymmetricMemory : public SymmetricMemory {
   // Copy with offset is allowed
   // This is mostly a shallow copy that shares the pointer to `NVSHMEMPeerAllocInfo` which has been created by `other`
   NVSHMEMSymmetricMemory(const NVSHMEMSymmetricMemory& other, size_t offset)
-      : allocation_(other.allocation_), device_idx_(other.device_idx_), group_name_(other.group_name_), pai_(other.pai_) {
+      : device_idx_(other.device_idx_), group_name_(other.group_name_), pai_(other.pai_) {
     offset_ = offset;
   }
 
@@ -245,7 +244,6 @@ class NVSHMEMSymmetricMemory : public SymmetricMemory {
   }
 
  private:
-  std::shared_ptr<NVSHMEMAllocation> allocation_;
   int device_idx_;
   std::string group_name_;
   c10::intrusive_ptr<NVSHMEMPeerAllocInfo> pai_;
@@ -335,10 +333,10 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
     auto ptr = nvshmem_malloc(size);
     // If size is 0 (which is legal allocation request) we shouldn't error out
     TORCH_CHECK(ptr != nullptr || size == 0, "nvshmem_malloc failed");
-    auto allocation =
-        std::make_shared<NVSHMEMAllocation>(ptr, size, device_idx);
     // TODO: thread safety
-    allocations_.try_emplace(ptr, std::move(allocation));
+    allocations_.try_emplace(
+      ptr,
+      std::make_unique<NVSHMEMAllocation>(ptr, size, device_idx));
     return ptr;
   }
 
@@ -424,7 +422,7 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
   }
 
  private:
-  std::unordered_map<void*, std::shared_ptr<NVSHMEMAllocation>> allocations_;
+  std::unordered_map<void*, std::unique_ptr<NVSHMEMAllocation>> allocations_;
   std::map<std::tuple<void*, std::string>, c10::intrusive_ptr<NVSHMEMSymmetricMemory>>
       symm_mems_;
 };

--- a/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cu
@@ -51,7 +51,7 @@ struct NVSHMEMAllocation {
 class NVSHMEMPeerAllocInfo : public c10::intrusive_ptr_target {
  public:
   NVSHMEMPeerAllocInfo(
-      const std::unique_ptr<NVSHMEMAllocation>& allocation,
+      NVSHMEMAllocation* allocation,
       const std::string& group_name)
       : base_ptr_(allocation->ptr),
         buffer_size_(allocation->buffer_size) {
@@ -144,7 +144,7 @@ class NVSHMEMPeerAllocInfo : public c10::intrusive_ptr_target {
 class NVSHMEMSymmetricMemory : public SymmetricMemory {
  public:
   NVSHMEMSymmetricMemory(
-      const std::unique_ptr<NVSHMEMAllocation>& allocation,
+      NVSHMEMAllocation* allocation,
       const std::string& group_name)
       : device_idx_(allocation->device_idx),
         group_name_(group_name) {
@@ -388,7 +388,7 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
     } else {
       // Create a new rendezvous
       symm_mem =
-          c10::make_intrusive<NVSHMEMSymmetricMemory>(allocation, *group_name);
+          c10::make_intrusive<NVSHMEMSymmetricMemory>(allocation.get(), *group_name);
     }
 
     // Cache rendezvous using allocation's base address as key


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #162681
* __->__ #162680
* #163298

Problem:
Without MemPool it looks like nvshmem backend never deallocates memory.

Cause:
Handles in `symm_mems_` (a map) keeps reference to memory allocations.

Solution:
- Remove reference to allocation from handles -- the reference is never used anyway.
- Use `unique_ptr` instead of `shared_ptr` to wrap allocation to ensure single ownership.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci