### PR TITLE
[SymmMem] Add `num_active_allocations` and dealloc checks

### DIFF
--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -779,6 +779,8 @@ class _SymmetricMemory:
     def rendezvous(
         tensor: torch.Tensor, group_name: str | None = None
     ) -> _SymmetricMemory: ...
+    @staticmethod
+    def num_active_allocations(device: torch.device) -> int: ...
     def get_buffer(
         self,
         rank: int,

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1131,6 +1131,9 @@ This class does not support ``__members__`` property.)");
       .def_static(
           "get_mempool_allocator",
           &::c10d::symmetric_memory::get_mempool_allocator)
+      .def_static(
+          "num_active_allocations",
+          &::c10d::symmetric_memory::num_active_allocations)
       .def_property_readonly("rank", &SymmetricMemory::get_rank)
       .def_property_readonly("world_size", &SymmetricMemory::get_world_size)
       .def_property_readonly(

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -817,6 +817,11 @@ c10::intrusive_ptr<Block> CUDASymmetricMemoryAllocator::find_block(void* ptr) {
   return it->second;
 }
 
+size_t CUDASymmetricMemoryAllocator::num_active_allocations() {
+  std::shared_lock lock(mutex_);
+  return ptr_to_block_.size();
+}
+
 struct RegisterCUDASymmetricMemoryAllocator {
   RegisterCUDASymmetricMemoryAllocator() {
     auto allocator = c10::make_intrusive<CUDASymmetricMemoryAllocator>();

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.hpp
@@ -110,6 +110,7 @@ class CUDASymmetricMemoryAllocator : public SymmetricMemoryAllocator {
   bool has_multicast_support(int device_idx) override;
   c10::DeviceType supported_device_type() override;
   std::string name() override;
+  size_t num_active_allocations() override;
 
  private:
   c10::intrusive_ptr<Block> find_block(void* ptr);

--- a/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
@@ -260,6 +260,10 @@ class NCCLSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
     return "NCCL";
   }
 
+  size_t num_active_allocations() override {
+    return allocations_.size();
+  }
+
  private:
   std::unordered_map<void*, c10::intrusive_ptr<SymmetricMemory>>
       ptr_to_symm_mem_;

--- a/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cu
@@ -421,6 +421,10 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
     return "NVSHMEM";
   }
 
+  size_t num_active_allocations() override {
+    return allocations_.size();
+  }
+
  private:
   std::unordered_map<void*, std::unique_ptr<NVSHMEMAllocation>> allocations_;
   std::map<std::tuple<void*, std::string>, c10::intrusive_ptr<NVSHMEMSymmetricMemory>>

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
@@ -267,6 +267,11 @@ TORCH_API bool has_multicast_support(
   }
 }
 
+TORCH_API size_t num_active_allocations(c10::Device device) {
+  auto allocator = get_allocator(device.type());
+  return allocator->num_active_allocations();
+}
+
 // MemPool Support
 
 // A map from device type to allocator for MemPool.

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
@@ -114,6 +114,7 @@ class SymmetricMemoryAllocator : public c10::intrusive_ptr_target {
   virtual bool has_multicast_support(int device_idx) = 0;
   virtual c10::DeviceType supported_device_type() = 0;
   virtual std::string name() = 0;
+  virtual size_t num_active_allocations() = 0;
 };
 
 C10_EXPORT bool is_finalizing();
@@ -206,5 +207,7 @@ C10_EXPORT void register_mempool_allocator(
 
 TORCH_API std::shared_ptr<c10::Allocator> get_mempool_allocator(
     c10::Device device);
+
+TORCH_API size_t num_active_allocations(c10::Device device);
 
 } // namespace c10d::symmetric_memory


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #162681
* #162680
* #163298

As titled.
`del tensor` should cause `num_active_allocations` to go down to 0.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci