### PR TITLE
[CuTe] Change the logic of pycute manipulation ops like coalesce, complement from co-lex to lex

### DIFF
--- a/test/distributed/_pycute/test_coalesce.py
+++ b/test/distributed/_pycute/test_coalesce.py
@@ -47,11 +47,14 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class TestCoalesce(TestCase):
-    def helper_test_coalesce(self, layout):
+    def helper_test_coalesce(self, layout, coalesced_layout=None):
         layoutR = coalesce(layout)
 
         _LOGGER.debug(f"{layout}  =>  {layoutR}")
 
+        if coalesced_layout:
+            self.assertEqual(coalesced_layout.shape, layoutR.shape)
+            self.assertEqual(coalesced_layout.stride, layoutR.stride)
         self.assertEqual(size(layoutR), size(layout))
 
         for i in range(size(layout)):
@@ -82,17 +85,27 @@ class TestCoalesce(TestCase):
         layout = Layout((2, (4, 6)))
         self.helper_test_coalesce(layout)
 
+        layout = Layout((1, 2), (8, 1))
+        coalesced_layout = Layout(2, 1)
+        self.helper_test_coalesce(layout, coalesced_layout)
+
         layout = Layout((2, 4), (4, 1))
-        self.helper_test_coalesce(layout)
+        coalesced_layout = Layout(8, 1)
+        self.helper_test_coalesce(layout, coalesced_layout)
 
         layout = Layout((2, 4, 6), (24, 6, 1))
-        self.helper_test_coalesce(layout)
+        coalesced_layout = Layout(48, 1)
+        self.helper_test_coalesce(layout, coalesced_layout)
 
         layout = Layout((2, 1, 3), (2, 4, 4))
         self.helper_test_coalesce(layout)
 
         layout = Layout(((2, 2), (2, 2)), ((1, 4), (8, 32)))
         self.helper_test_coalesce(layout)
+
+        layout = Layout(((2, 2), (2, 2)), ((32, 8), (4, 1)))
+        coalesced_layout = Layout((2, 4, 2), (32, 4, 1))
+        self.helper_test_coalesce(layout, coalesced_layout)
 
 
 if __name__ == "__main__":

--- a/test/distributed/_pycute/test_composition.py
+++ b/test/distributed/_pycute/test_composition.py
@@ -51,11 +51,13 @@ class TestComposition(TestCase):
         layoutR = composition(layoutA, layoutB)
 
         _LOGGER.debug(f"{layoutA} o {layoutB}  =>  {layoutR}")
+        print(layoutR.shape, layoutR.stride, size(layoutR))
 
         # True post-condition: Every coordinate c of layoutB with L1D(c) < size(layoutR) is a coordinate of layoutR.
 
         # Test that R(c) = A(B(c)) for all coordinates c in layoutR
         for i in range(size(layoutR)):
+            print(i, layoutR(i), layoutB(i), layoutA(layoutB(i)))
             self.assertEqual(layoutR(i), layoutA(layoutB(i)))
 
     def test_composition(self):
@@ -208,9 +210,24 @@ class TestComposition(TestCase):
         layoutB = Layout((6), (1))
         self.helper_test_composition(layoutA, layoutB)
 
+        # Pre-coalesced RHS
+        layoutA = Layout((8, 6, 4), (7, 4, 1))
+        layoutB = Layout((6), (1))
+        self.helper_test_composition(layoutA, layoutB)
+
+        # Case when not meet stride divisibility condition
+        with self.assertRaises(AssertionError):
+            layoutA = Layout((4, 6, 8, 10), (2, 3, 5, 7))
+            layoutB = Layout(6, 12)
+            self.helper_test_composition(layoutA, layoutB)
+
         # Mid-layout truncation
-        layoutA = Layout((4, 6, 8, 10), (2, 3, 5, 7))
+        layoutA = Layout((10, 8, 6, 4), (7, 5, 3, 2))
         layoutB = Layout(6, 12)
+        self.helper_test_composition(layoutA, layoutB)
+
+        layoutA = Layout((4,), (3,))
+        layoutB = Layout((6,), (2,))
         self.helper_test_composition(layoutA, layoutB)
 
 

--- a/test/distributed/_pycute/test_composition.py
+++ b/test/distributed/_pycute/test_composition.py
@@ -51,13 +51,11 @@ class TestComposition(TestCase):
         layoutR = composition(layoutA, layoutB)
 
         _LOGGER.debug(f"{layoutA} o {layoutB}  =>  {layoutR}")
-        print(layoutR.shape, layoutR.stride, size(layoutR))
 
         # True post-condition: Every coordinate c of layoutB with L1D(c) < size(layoutR) is a coordinate of layoutR.
 
         # Test that R(c) = A(B(c)) for all coordinates c in layoutR
         for i in range(size(layoutR)):
-            print(i, layoutR(i), layoutB(i), layoutA(layoutB(i)))
             self.assertEqual(layoutR(i), layoutA(layoutB(i)))
 
     def test_composition(self):

--- a/test/distributed/_pycute/test_int_tuple.py
+++ b/test/distributed/_pycute/test_int_tuple.py
@@ -70,16 +70,155 @@ class TestIntTuple(TestCase):
     def test_prefix_product(self):
         self.assertEqual(prefix_product(2), 1)
 
-        self.assertEqual(prefix_product((3, 2)), (1, 3))
+        self.assertEqual(prefix_product((3, 2)), (2, 1))
 
-        self.assertEqual(prefix_product((3, 2, 4)), (1, 3, 6))
+        self.assertEqual(prefix_product((3, 2, 4)), (8, 4, 1))
 
-        self.assertEqual(prefix_product(((2, 3), 4)), ((1, 2), 6))
+        self.assertEqual(prefix_product(((2, 3), 4)), ((12, 4), 1))
 
         self.assertEqual(
             prefix_product(((2, 3), (2, 1, 2), (5, 2, 1))),
-            ((1, 2), (6, 12, 12), (24, 120, 240)),
+            ((120, 40), (20, 20, 10), (2, 1, 1)),
         )
+
+    def test_crd2idx_basic(self):
+        # Test basic int/int case
+        self.assertEqual(crd2idx(2, 5, 1), 2)
+        self.assertEqual(crd2idx(0, 5, 1), 0)
+        self.assertEqual(crd2idx(4, 5, 1), 4)
+
+        # Test with custom stride
+        self.assertEqual(crd2idx(2, 5, 3), 6)
+        self.assertEqual(crd2idx(1, 5, 3), 3)
+
+    def test_crd2idx_tuple(self):
+        # Test tuple coordinates with default stride
+        self.assertEqual(crd2idx((1, 2), (3, 4)), 6)  # 1*4 + 2*1 = 6
+        self.assertEqual(crd2idx((0, 0), (3, 4)), 0)
+        self.assertEqual(crd2idx((2, 3), (3, 4)), 11)  # 2*4 + 3*1 = 11
+
+        # Test with custom stride
+        self.assertEqual(crd2idx((1, 2), (3, 4), (8, 2)), 12)  # 1*8 + 2*2 = 12
+
+        # Test 3D case
+        self.assertEqual(crd2idx((1, 0, 2), (2, 3, 4)), 14)  # 1*12 + 0*4 + 2*1 = 14
+
+    def test_crd2idx_none(self):
+        # Test None coordinate (should default to 0)
+        self.assertEqual(crd2idx(None, 5), 0)
+        self.assertEqual(crd2idx(None, (3, 4)), 0)
+
+    def test_crd2idx_int_with_tuple_shape(self):
+        # Test single integer coordinate with multi-dimensional shape and stride
+        # When crd is int and shape is tuple, it converts the int to multi-dim coordinate first
+        self.assertEqual(crd2idx(0, (2, 2), (2, 1)), 0)  # 0 -> (0,0) -> 0*2 + 0*1 = 0
+        self.assertEqual(crd2idx(1, (2, 2), (2, 1)), 1)  # 1 -> (0,1) -> 0*2 + 1*1 = 1
+        self.assertEqual(crd2idx(2, (2, 2), (2, 1)), 2)  # 2 -> (1,0) -> 1*2 + 0*1 = 2
+        self.assertEqual(crd2idx(3, (2, 2), (2, 1)), 3)  # 3 -> (1,1) -> 1*2 + 1*1 = 3
+
+        # Test with non-trivial strides
+        self.assertEqual(crd2idx(0, (2, 3), (6, 2)), 0)  # 0 -> (0,0) -> 0*6 + 0*2 = 0
+        self.assertEqual(crd2idx(1, (2, 3), (6, 2)), 2)  # 1 -> (0,1) -> 0*6 + 1*2 = 2
+        self.assertEqual(crd2idx(2, (2, 3), (6, 2)), 4)  # 2 -> (0,2) -> 0*6 + 2*2 = 4
+        self.assertEqual(crd2idx(3, (2, 3), (6, 2)), 6)  # 3 -> (1,0) -> 1*6 + 0*2 = 6
+        self.assertEqual(crd2idx(4, (2, 3), (6, 2)), 8)  # 4 -> (1,1) -> 1*6 + 1*2 = 8
+        self.assertEqual(crd2idx(5, (2, 3), (6, 2)), 10)  # 5 -> (1,2) -> 1*6 + 2*2 = 10
+
+        # Test with larger strides
+        self.assertEqual(crd2idx(0, (3, 2), (10, 5)), 0)  # 0 -> (0,0) -> 0*10 + 0*5 = 0
+        self.assertEqual(crd2idx(1, (3, 2), (10, 5)), 5)  # 1 -> (0,1) -> 0*10 + 1*5 = 5
+        self.assertEqual(
+            crd2idx(2, (3, 2), (10, 5)), 10
+        )  # 2 -> (1,0) -> 1*10 + 0*5 = 10
+        self.assertEqual(
+            crd2idx(3, (3, 2), (10, 5)), 15
+        )  # 3 -> (1,1) -> 1*10 + 1*5 = 15
+        self.assertEqual(
+            crd2idx(4, (3, 2), (10, 5)), 20
+        )  # 4 -> (2,0) -> 2*10 + 0*5 = 20
+        self.assertEqual(
+            crd2idx(5, (3, 2), (10, 5)), 25
+        )  # 5 -> (2,1) -> 2*10 + 1*5 = 25
+
+        # Test with 3D shape and various strides
+        self.assertEqual(
+            crd2idx(0, (2, 2, 2), (8, 4, 2)), 0
+        )  # 0 -> (0,0,0) -> 0*8 + 0*4 + 0*2 = 0
+        self.assertEqual(
+            crd2idx(1, (2, 2, 2), (8, 4, 2)), 2
+        )  # 1 -> (0,0,1) -> 0*8 + 0*4 + 1*2 = 2
+        self.assertEqual(
+            crd2idx(2, (2, 2, 2), (8, 4, 2)), 4
+        )  # 2 -> (0,1,0) -> 0*8 + 1*4 + 0*2 = 4
+        self.assertEqual(
+            crd2idx(3, (2, 2, 2), (8, 4, 2)), 6
+        )  # 3 -> (0,1,1) -> 0*8 + 1*4 + 1*2 = 6
+        self.assertEqual(
+            crd2idx(4, (2, 2, 2), (8, 4, 2)), 8
+        )  # 4 -> (1,0,0) -> 1*8 + 0*4 + 0*2 = 8
+        self.assertEqual(
+            crd2idx(7, (2, 2, 2), (8, 4, 2)), 14
+        )  # 7 -> (1,1,1) -> 1*8 + 1*4 + 1*2 = 14
+
+        self.assertEqual(
+            crd2idx(4, ((2, 2, 2), (2, 2, 2)), ((1, 16, 4), (8, 2, 32))), 8
+        )  # 4 -> (1,0,0) -> 1*8 = 8
+
+    def test_idx2crd_basic(self):
+        # Test basic int/int case
+        self.assertEqual(idx2crd(2, 5, 1), 2)
+        self.assertEqual(idx2crd(0, 5, 1), 0)
+        self.assertEqual(idx2crd(4, 5, 1), 4)
+
+        # Test with custom stride
+        self.assertEqual(idx2crd(6, 5, 3), 2)  # (6 // 3) % 5 = 2
+        self.assertEqual(idx2crd(3, 5, 3), 1)  # (3 // 3) % 5 = 1
+
+    def test_idx2crd_tuple(self):
+        # Test tuple shape with default stride
+        self.assertEqual(idx2crd(6, (3, 4)), (1, 2))  # 6 -> (1, 2)
+        self.assertEqual(idx2crd(0, (3, 4)), (0, 0))
+        self.assertEqual(idx2crd(11, (3, 4)), (2, 3))
+
+        # Test 3D case
+        self.assertEqual(idx2crd(14, (2, 3, 4)), (1, 0, 2))
+
+    def test_crd2idx_idx2crd_roundtrip(self):
+        # Test that crd2idx and idx2crd are inverse operations
+        shapes = [
+            5,
+            (3, 4),
+            (2, 3, 4),
+            (2, 2, 2, 2),
+        ]
+
+        for shape in shapes:
+            size = product(shape)
+            for idx in range(size):
+                crd = idx2crd(idx, shape)
+                recovered_idx = crd2idx(crd, shape)
+                self.assertEqual(
+                    recovered_idx, idx, f"Failed roundtrip for shape {shape}, idx {idx}"
+                )
+
+    def test_idx2crd_crd2idx_roundtrip(self):
+        # Test roundtrip starting from coordinates
+        test_cases = [
+            (0, 5),
+            (4, 5),
+            ((0, 0), (3, 4)),
+            ((1, 2), (3, 4)),
+            ((2, 3), (3, 4)),
+            ((0, 0, 0), (2, 3, 4)),
+            ((1, 2, 3), (2, 3, 4)),
+        ]
+
+        for crd, shape in test_cases:
+            idx = crd2idx(crd, shape)
+            recovered_crd = idx2crd(idx, shape)
+            self.assertEqual(
+                recovered_crd, crd, f"Failed roundtrip for crd {crd}, shape {shape}"
+            )
 
 
 if __name__ == "__main__":

--- a/torch/distributed/_pycute/int_tuple.py
+++ b/torch/distributed/_pycute/int_tuple.py
@@ -137,11 +137,13 @@ def prefix_product(a: IntTuple, init: IntTuple = 1) -> IntTuple:
             r: list[IntTuple] = []
             current_init = init
 
-            # Calculate products from right to left
+            # Calculate products from right to left, appending to list
             for i in range(len(a) - 1, -1, -1):
-                r.insert(0, prefix_product(a[i], current_init))
+                r.append(prefix_product(a[i], current_init))
                 current_init = current_init * product(a[i])
 
+            # Reverse to get correct lexicographic order
+            r.reverse()
             return tuple(r)
     else:
         if is_tuple(init):  # "int" tuple

--- a/torch/distributed/_pycute/layout.py
+++ b/torch/distributed/_pycute/layout.py
@@ -167,14 +167,10 @@ def coalesce(layout: Layout, profile: LayoutProfile = None) -> Layout:
             )
         )
 
-    flattened_shape = flatten(layout.shape)
-    flattened_stride = flatten(layout.stride)
-    # Skip leading shape-1 modes and find the first non-unit mode
     result_shape: list[int] = []
     result_stride: list[int] = []
-
-    for shape, stride in zip(flattened_shape, flattened_stride):
-        # skip shape-1s
+    for shape, stride in zip(flatten(layout.shape), flatten(layout.stride)):
+        # skip their shape-1s
         if shape == 1:
             continue
         # merge modes if the shape*stride match
@@ -245,8 +241,8 @@ def composition(layoutA: Layout, layoutB: LayoutInput) -> Layout:
     else:
         result_shape = []
         result_stride = []
-        rest_shape = layoutB.shape if is_int(layoutB.shape) else layoutB.shape[0]  # type: ignore[union-attr]
-        rest_stride = layoutB.stride if is_int(layoutB.stride) else layoutB.stride[0]  # type: ignore[union-attr]
+        rest_shape = layoutB.shape if is_int(layoutB.shape) else layoutB.shape[0]  # type: ignore[union-attr,index]
+        rest_stride = layoutB.stride if is_int(layoutB.stride) else layoutB.stride[0]  # type: ignore[union-attr,index]
         flat_A = coalesce(layoutA)
 
         # Process from right to left for lexicographic ordering
@@ -279,7 +275,6 @@ def composition(layoutA: Layout, layoutB: LayoutInput) -> Layout:
         # Reverse the lists to get lexicographic order
         result_shape.reverse()
         result_stride.reverse()
-        print(result_shape, result_stride)
 
         if len(result_shape) == 1:
             return Layout(result_shape[0], result_stride[0])  # type: ignore[arg-type]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #161106
* #161016
* __->__ #162690
* #162414
* #162534
* #162413

PyTorch tensor iteration (.view, contiguous, broadcasting) and NumPy array indexing all follow lexicographic (row-major) order. In Lexicographic (lex) on (i0, i1, …, i{k-1}): the leftmost index(stride is larger) changes fastest and the rightmost index changes slowest and usually last dim is contiguous.

However original pycute is all based on co-lex, after porting their code into pytorch and some cosmetic change, we now make it lex so that we can use it for use cases like device mesh internal bookkeeping and other stuff as well.

Changes included in this PR:
1. We changes all API ported in, included prefix_product(stride inferring and rename it to suffix_product), idx2crd, crd2idx, coalesce, composition, complement, right_inverse and left_inverse to make sure they are working in the lex way.
2. Added more unit test cases for some API mentioned above since existing unit tests do not have full coverage.
3. One bug fix inside composition, which will lead to infinite recursive call.

cc @H-Huang @awgu @wanchaol @fegin @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci