### PR TITLE
[CUDAGraph][UX] warn many times for rerecording from dynamic shapes

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -2664,7 +2664,7 @@ if HAS_CUDA_AND_TRITON:
             ).run(captured_output[0])
 
         @torch._inductor.config.patch("triton.cudagraph_dynamic_shape_warn_limit", 1)
-        def test_warn_many_times_if_dynamic_shape_limit_reached(self):
+        def test_warn_once_if_dynamic_shape_limit_reached(self):
             class Mod(torch.nn.Module):
                 def __init__(self) -> None:
                     super().__init__()
@@ -2681,19 +2681,19 @@ if HAS_CUDA_AND_TRITON:
             mod = torch.compile(Mod(), mode="reduce-overhead")
 
             with capture_stderr() as captured_output:
-                for batch_size in range(1, 21):
+                for batch_size in range(10, 200, 10):
                     iter(batch_size, mod)
-
-            # 20 total shapes but 1) first shape is not dynamic yet
-            # and 2) cudagraph_dynamic_shape_warn_limit=1 avoids
-            # warning for the first dynamic shape.
-            expected_num_warns = 18
 
             FileCheck().check_count(
                 "CUDAGraph supports dynamic shapes by recording a new graph for each "
                 "distinct input size. Recording too many CUDAGraphs may lead to "
-                "extra overhead.",
-                expected_num_warns,
+                "extra overhead. We have observed 2 distinct sizes. "
+                "Please consider the following options for better performance: "
+                "a) padding inputs to a few fixed number of shapes; or b) set "
+                "torch._inductor.config.triton.cudagraph_skip_dynamic_graphs=True. "
+                "Set torch._inductor.config.triton.cudagraph_dynamic_shape_warn_limit=None "
+                "to silence this warning.",
+                1,
                 exactly=True,
             ).run("\n".join(captured_output))
 

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -2664,7 +2664,7 @@ if HAS_CUDA_AND_TRITON:
             ).run(captured_output[0])
 
         @torch._inductor.config.patch("triton.cudagraph_dynamic_shape_warn_limit", 1)
-        def test_warn_once_if_dynamic_shape_limit_reached(self):
+        def test_warn_many_times_if_dynamic_shape_limit_reached(self):
             class Mod(torch.nn.Module):
                 def __init__(self) -> None:
                     super().__init__()
@@ -2681,21 +2681,19 @@ if HAS_CUDA_AND_TRITON:
             mod = torch.compile(Mod(), mode="reduce-overhead")
 
             with capture_stderr() as captured_output:
-                for batch_size in range(10, 200, 10):
+                for batch_size in range(1, 21):
                     iter(batch_size, mod)
 
-            print(captured_output)
+            # 20 total shapes but 1) first shape is not dynamic yet
+            # and 2) cudagraph_dynamic_shape_warn_limit=1 avoids
+            # warning for the first dynamic shape.
+            expected_num_warns = 18
 
             FileCheck().check_count(
                 "CUDAGraph supports dynamic shapes by recording a new graph for each "
                 "distinct input size. Recording too many CUDAGraphs may lead to "
-                "extra overhead. We have observed 2 distinct sizes. "
-                "Please consider the following options for better performance: "
-                "a) padding inputs to a few fixed number of shapes; or b) set "
-                "torch._inductor.config.triton.cudagraph_skip_dynamic_graphs=True. "
-                "Set torch._inductor.config.triton.cudagraph_dynamic_shape_warn_limit=None "
-                "to silence this warning.",
-                1,
+                "extra overhead.",
+                expected_num_warns,
                 exactly=True,
             ).run("\n".join(captured_output))
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1245,7 +1245,7 @@ class triton:
 
     # Warn loudly when the number of cudagraphs due to dynamic shape
     # exceeds this limit
-    cudagraph_dynamic_shape_warn_limit: Optional[int] = 50
+    cudagraph_dynamic_shape_warn_limit: Optional[int] = 8
 
     # synchronize after cudagraph invocation
     force_cudagraph_sync = False

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -371,13 +371,9 @@ def cudagraphify_impl(
     int_key = [i for i, v in enumerate(inputs) if isinstance(v, int)]
     get_ints: Any = operator.itemgetter(*int_key) if int_key else lambda _: None
 
-    has_warn = False
-
     del inputs
 
     def deferred_cudagraphify(inputs: list[InputType]) -> OutputType:
-        nonlocal has_warn
-
         int_key = get_ints(inputs)
 
         if not is_cudagraph_capture_sizes(int_key):
@@ -392,8 +388,7 @@ def cudagraphify_impl(
         else:
             log.info("recording cudagraph tree for symint key %s", int_key)
 
-        if not has_warn:
-            has_warn = maybe_warning_due_to_dynamic_shape(fn_cache, int_key)
+        maybe_warning_due_to_dynamic_shape(fn_cache, int_key)
 
         # first get indices we need to check to align, then update our static inputs,
         # and finally copy

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -371,9 +371,13 @@ def cudagraphify_impl(
     int_key = [i for i, v in enumerate(inputs) if isinstance(v, int)]
     get_ints: Any = operator.itemgetter(*int_key) if int_key else lambda _: None
 
+    has_warn = False
+
     del inputs
 
     def deferred_cudagraphify(inputs: list[InputType]) -> OutputType:
+        nonlocal has_warn
+
         int_key = get_ints(inputs)
 
         if not is_cudagraph_capture_sizes(int_key):
@@ -388,7 +392,8 @@ def cudagraphify_impl(
         else:
             log.info("recording cudagraph tree for symint key %s", int_key)
 
-        maybe_warning_due_to_dynamic_shape(fn_cache, int_key)
+        if not has_warn:
+            has_warn = maybe_warning_due_to_dynamic_shape(fn_cache, int_key)
 
         # first get indices we need to check to align, then update our static inputs,
         # and finally copy


### PR DESCRIPTION
Excessive re-recording CUDAGraphs lead to bad performance. We previously warns once if this happens.

However, the limit (=50) is too high and users may just observe bad performance before actually seeing the warning message. Even worse, users may not see the warning message when there are many other logs. @anijain2305 reported that he never saw this warning message when using transformer library, but he DOES observe slowdown due to cudagraph re-recording & needs to turn off cudagraph.

#162663 attempts to hard error when re-recording too many times due to dynamic shapes. But it is a bc-breaking change. Actually, hf-t5-generate model in torchbench failed due to 256 re-recordings.

This PR a) reduces to smaller limit (=8); and b) makes the warning more spam, i.e., warn once for every distinct shapes once the limit is reached.

Fixes #162299

cc @mcarilli @ezyang @eellison @penguinwu @voznesenskym @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @mlazos