### PR TITLE
fix: raise value error on init ParametrizationList if original.device != new.device

### DIFF
--- a/test/nn/test_parametrization.py
+++ b/test/nn/test_parametrization.py
@@ -593,6 +593,22 @@ class TestNNParametrization(NNTestCase):
             parametrize.register_parametrization(module, "weight", ChangeDtypeInverse())
         self.assertFalse(parametrize.is_parametrized(module))
 
+        class ChangeDeviceInverse(nn.Module):
+            def forward(self, x):
+                return x.float()
+
+            def right_inverse(self, w):
+                return w.to(torch.device("meta"))
+
+        # For parametrizations that return one tensor, right_inverse may not change the device
+        with self.assertRaisesRegex(
+            ValueError, "outputs one tensor, it may not change the device"
+        ):
+            parametrize.register_parametrization(
+                module, "weight", ChangeDeviceInverse()
+            )
+        self.assertFalse(parametrize.is_parametrized(module))
+
         # Doesn't return a tensor
         class NotTensor(nn.Module):
             def forward(self, x):

--- a/torch/nn/utils/parametrize.py
+++ b/torch/nn/utils/parametrize.py
@@ -185,6 +185,14 @@ class ParametrizationList(ModuleList):
                     f"original.dtype: {original.dtype}\n"
                     f"right_inverse(original).dtype: {new.dtype}"
                 )
+
+            if original.device != new.device:
+                raise ValueError(
+                    "When `right_inverse` outputs one tensor, it may not change the device.\n"
+                    f"original.device: {original.device}\n"
+                    f"right_inverse(original).device: {new.device}"
+                )
+
             # Set the original to original so that the user does not need to re-register the parameter
             # manually in the optimiser
             with torch.no_grad():


### PR DESCRIPTION
raise value error on init `ParametrizationList`, if `original.device != new.device`.
currently `_maybe_set` will throw below error in such situations, which I think it's not convenient to debug.

```
[rank1]: RuntimeError: Attempted to set the storage of a tensor on device "cuda:1" to a storage on different device "cpu".  This is no longer allowed; the devices must match.
```