### PR TITLE
Remove tests-to-include from rocm-mi300 workflow

### DIFF
--- a/.github/workflows/rocm-mi300.yml
+++ b/.github/workflows/rocm-mi300.yml
@@ -70,5 +70,4 @@ jobs:
       build-environment: linux-noble-rocm-py3.12-mi300
       docker-image: ${{ needs.linux-noble-rocm-py3_12-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-noble-rocm-py3_12-build.outputs.test-matrix }}
-      tests-to-include: "inductor/test_ck_backend"
     secrets: inherit


### PR DESCRIPTION
Accidentally introduced by https://github.com/pytorch/pytorch/pull/162288 (was meant to be a temporary change)


cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd