### PR TITLE
Create alias c10 and c10_cuda to distinguish xplat and ovrsource.

### DIFF
--- a/c10/ovrsource_defs.bzl
+++ b/c10/ovrsource_defs.bzl
@@ -18,9 +18,9 @@ cuda_supported_platforms = [
 
 def define_c10_ovrsource(name, is_mobile):
     if is_mobile:
-        pp_flags = ["-DC10_MOBILE=1"]
+        pp_flags = ["-DC10_MOBILE=1", "-DC10_USE_GLOG"]
     else:
-        pp_flags = []
+        pp_flags = ["-DC10_USE_GLOG"]
 
     oxx_static_library(
         name = name,


### PR DESCRIPTION
Summary: #buildall

Test Plan:
sandcastle

This jobs in particular I found cause problems:

```
buck build --flagfile fbobjc/mode/buck2/ios-tests --config cxx.default_platform=iphonesimulator-arm64 fbsource//xplat/executorch/kernels/test:aten_op_avg_pool2d_testApple
buck build --flagfile fbsource//arvr/apps/hsr/mode/mac-arm/development --flagfile fbsource//arvr/projects/hsr/mode/avatarsdk/mainline --flagfile fbsource//arvr/apps/hsr/avatars_sandbox/flavor/codec fbsource//arvr/apps/hsr/avatars_sandbox:client_server_app_launcher
buck build --flagfile fbsource//arvr/mode/android/apk/vr_standalone/linux/dev fbsource//arvr/projects/codec_avatar/prod/client/androidTests:ca_clientlib_integration_tests
buck build --flagfile fbsource//arvr/mode/android/linux/dev fbsource//arvr/libraries/vega/colocation/inference:colocation_inference
buck build --flagfile fbsource//arvr/mode/android/linux/opt fbsource//arvr/projects/ariane/anon:simple_model_test
buck build --flagfile fbsource//arvr/mode/android/starlet/linux/release-stripped fbsource//arvr/projects/bolt/bolt/nn/tests:unit_test_torch_delegate
buck build --flagfile fbsource//arvr/mode/platform010/dev fbsource//xplat/supernova/arvrsync/supernova/palmvision:bolt_palm_vision_inference_test
buck build --flagfile fbsource//arvr/mode/win/vs2022/opt fbsource//arvr/libraries/vega/slam_mapper/semantics:semantic_inference_module
buck build --flagfile fbsource//arvr/mode/win/vs2022/opt fbsource//arvr/projects/nimble/prod/tools/HandReplay:HandReplay
buck2 build "arvr/mode/fb-linux-nh/opt-stripped" "//arvr/projects/nimble/research/Ctrl-R/tests/..."
buck2 build "arvr/mode/platform010/opt" //arvr/libraries/ctrlr:ctrl-r -c "python.ctrlr_version_override=3.12"
buck2 build arvr/mode/platform010/opt //arvr/projects/viper/viper/vega_mapper/simulator:vega_mapper_simulator
buck2 build fbsource//xplat/caffe2:torch_lib_ovrsource
buck2 run //arvr/tools/scripts/regression_tests:binary_size_increase_check -- --target_name //arvr/libraries/visioninterface/products/eureka:eureka_tracker_dev_shared --product_name eureka --build_mode release-strippedsource//arvr/mode/win/vs2022/opt fbsource//arvr/libraries/vega/slam_mapper/semantics:semantic_inference_module
```

Rollback Plan:

Differential Revision: D82224960


