### PR TITLE
Refactor PrecompileContext to be considerably more debuggable

### DIFF
--- a/test/dynamo/test_precompile_context.py
+++ b/test/dynamo/test_precompile_context.py
@@ -47,7 +47,8 @@ class PrecompileContextTests(InductorTestCase):
         x = torch.randn(10, device=GPU_TYPE, requires_grad=True)
         result = compiled_fn(x)
         result.sum().backward()
-        self.assertEqual(len(PrecompileContext._new_cache_artifacts_by_key), 2)
+        self.assertEqual(len(PrecompileContext._dynamo_cache_entries), 1)
+        self.assertEqual(len(PrecompileContext._backend_artifacts_by_key), 1)
         self.assertEqual(len(PrecompileContext._new_cache_artifacts), 0)
 
         result = PrecompileContext.serialize()
@@ -82,8 +83,9 @@ class PrecompileContextTests(InductorTestCase):
         x = torch.randn(10, device=GPU_TYPE, requires_grad=True)
         result = compiled_fn(x)
         result.sum().backward()
-        self.assertEqual(len(PrecompileContext._new_cache_artifacts_by_key), 2)
-        for key in PrecompileContext._new_cache_artifacts_by_key.keys():
+        self.assertEqual(len(PrecompileContext._dynamo_cache_entries), 1)
+        self.assertEqual(len(PrecompileContext._backend_artifacts_by_key), 1)
+        for key in PrecompileContext._backend_artifacts_by_key.keys():
             result = PrecompileContext.serialize_artifact_by_key(key)
             assert isinstance(result, PrecompileCacheArtifact)
             self.assertEqual(result.key, key)
@@ -109,11 +111,12 @@ class PrecompileContextTests(InductorTestCase):
         x = torch.randn(10, device=GPU_TYPE, requires_grad=True)
         result = compiled_fn(x)
         result.sum().backward()
-        self.assertEqual(len(PrecompileContext._new_cache_artifacts_by_key), 2)
+        self.assertEqual(len(PrecompileContext._dynamo_cache_entries), 1)
+        self.assertEqual(len(PrecompileContext._backend_artifacts_by_key), 1)
         # Find the key for the artifact of type "precompile_aot_autograd"
         key = next(
             k
-            for k, v in PrecompileContext._new_cache_artifacts_by_key.items()
+            for k, v in PrecompileContext._backend_artifacts_by_key.items()
             if isinstance(v, EditablePrecompileCacheArtifact)
         )
 

--- a/torch/_dynamo/precompile_context.py
+++ b/torch/_dynamo/precompile_context.py
@@ -1,4 +1,5 @@
 import copy
+import json
 import logging
 import pickle
 from abc import abstractmethod
@@ -7,6 +8,8 @@ from itertools import chain
 from typing import Any, Callable, Generic, Optional, TypeVar, Union
 from typing_extensions import override
 
+import torch
+from torch._dynamo.package import _DynamoCacheEntry
 from torch.compiler._cache import (
     _serialize_single_cache,
     CacheArtifact,
@@ -65,6 +68,16 @@ class PrecompileCacheArtifact(CacheArtifact, Generic[T]):
         ...
 
 
+@CacheArtifactFactory.register
+class EagerCacheArtifact(PrecompileCacheArtifact[Any]):
+    @staticmethod
+    def type() -> str:
+        return "precompile_eager"
+
+    def after_deserialization(self) -> Any:
+        return pickle.loads(self.content)
+
+
 class EditablePrecompileCacheArtifact(Generic[T]):
     """
     A PrecompileCacheArtifact whose content isn't encoded until we call PrecompileContext.serialize()
@@ -95,6 +108,21 @@ class EditablePrecompileCacheArtifact(Generic[T]):
         self.content = edit_fn(self.content)
 
 
+@CacheArtifactFactory.register
+class _DynamoCacheArtifact(PrecompileCacheArtifact[_DynamoCacheEntry]):
+    @staticmethod
+    def type() -> str:
+        return "precompile_dynamo"
+
+    def after_deserialization(self) -> _DynamoCacheEntry:
+        result = pickle.loads(self.content)
+        return result
+
+
+class BypassDynamoCacheEntry(Exception):
+    pass
+
+
 class PrecompileContext(CacheArtifactManager):
     """
     PrecompileContext is a special CacheArtifactManager for handling precompilation
@@ -102,20 +130,29 @@ class PrecompileContext(CacheArtifactManager):
     of placing each artifact into respective caches, it will stitch all the cache artifacts for a single key
     together and place it into a global Precompile Cache.
 
+    PrecompileContext has two main portions: dynamo_cache_entries and backend_cache_artifacts.
+    When saving, PrecompileContext.serialize() will serialize all dynamo cache entries along with any PrecompileCacheArtifacts that
+    are needed to save those dynamo cache entries.
+
     The following artifact types are supported by PrecompileContext:
      - BundledAOTAutogradCacheArtifact
-     - DynamoCodeStateArtifact
      - AutotuneCacheArtifact (regular autotune results, same as Megacache)
+
     """
 
     # Protected by the compile_lock
-    # _new_cache_artifacts_by_key organizes results by the key of each artifact.
+    # _backend_artifacts_by_key organizes results by the key of each artifact.
     # This allows us to implement serialize_by_key easily.
-    # On call to `serialize()`, all cache artifacts in _new_cache_artifacts_by_key
+    # On call to `serialize()`, all cache artifacts in _backend_artifacts_by_key
     # are transferred to _new_cache_artifacts before serialization.
-    _new_cache_artifacts_by_key: dict[
+    _backend_artifacts_by_key: dict[
         str, Union[EditablePrecompileCacheArtifact[object], CacheArtifact]
     ] = {}
+
+    # On call to `serialize()`, all cache artifacts in _dynamo_cache_entries are converted
+    # into DynamoCacheArtifacts and added to _new_cache_artifacts for serialization
+    _dynamo_cache_entries: dict[str, _DynamoCacheEntry] = {}
+
     _new_cache_artifacts: CacheArtifactsResult = defaultdict(list)
     # Keep a separate seen artifacts list to make avoid unnecessary duplicates
     # This list will not be cleared between serialize() calls
@@ -130,7 +167,8 @@ class PrecompileContext(CacheArtifactManager):
 
     @classmethod
     def clear(cls) -> None:
-        cls._new_cache_artifacts_by_key.clear()
+        cls._backend_artifacts_by_key.clear()
+        cls._dynamo_cache_entries.clear()
         super().clear()
 
     @override
@@ -160,29 +198,49 @@ class PrecompileContext(CacheArtifactManager):
                 return
             cls._seen_artifacts.add(artifact)
 
-        cls._new_cache_artifacts_by_key[key] = artifact
+        cls._backend_artifacts_by_key[key] = artifact
+
+    @classmethod
+    def record_dynamo_cache_entry(
+        cls, cache_entry: _DynamoCacheEntry, key: str
+    ) -> None:
+        cls._dynamo_cache_entries[key] = cache_entry
 
     @classmethod
     def _save_artifacts_by_type(cls) -> None:
         """
         We normally record artifacts by key, but serialization expects them to be organized
-        by artifact type. This function transfers artifacts from _new_cache_artifacts_by_key to _new_cache_artifacts
+        by artifact type. This function transfers artifacts from _backend_artifacts_by_key to _new_cache_artifacts
         """
-        for artifact in cls._new_cache_artifacts_by_key.values():
+        for key, cache_entry in cls._dynamo_cache_entries.items():
+            backends = cache_entry.backend_ids
+            try:
+                for id_ in backends:
+                    if id_ not in cls._backend_artifacts_by_key:
+                        logger.warning(
+                            "Bypassing %s because backend %s not found in artifacts"
+                        )
+                        raise BypassDynamoCacheEntry
+            except BypassDynamoCacheEntry:
+                continue
+            pickled_result = pickle.dumps(cache_entry)
+            artifact = _DynamoCacheArtifact(key, pickled_result)
+            cls._new_cache_artifacts[_DynamoCacheArtifact.type()].append(artifact)
+
+        # Save all the backend artifacts
+        for artifact in cls._backend_artifacts_by_key.values():
             if isinstance(artifact, EditablePrecompileCacheArtifact):
                 artifact = artifact.real_encode()
             cls._new_cache_artifacts[artifact.__class__.type()].append(artifact)
-        cls._new_cache_artifacts_by_key.clear()
+        cls._backend_artifacts_by_key.clear()
 
     @classmethod
     def edit_artifact(cls, key: str, edit_fn: Callable[..., Any]) -> None:
         """
         Edit the content of an existing artifact
         """
-        assert key in cls._new_cache_artifacts_by_key, (
-            f"Key {key} not found in artifacts"
-        )
-        artifact = cls._new_cache_artifacts_by_key[key]
+        assert key in cls._backend_artifacts_by_key, f"Key {key} not found in artifacts"
+        artifact = cls._backend_artifacts_by_key[key]
         assert isinstance(artifact, EditablePrecompileCacheArtifact), (
             "Artifact is not editable"
         )
@@ -191,55 +249,152 @@ class PrecompileContext(CacheArtifactManager):
     @classmethod
     def serialize_artifact_by_key(cls, key: str) -> Optional[CacheArtifact]:
         """
-        Serialize all artifacts with the given key returned in a list.
+        Serialize all backend artifacts with the given key returned in a list.
         """
-        result = cls._new_cache_artifacts_by_key.get(key, None)
+        result = cls._backend_artifacts_by_key.get(key, None)
         if isinstance(result, EditablePrecompileCacheArtifact):
             result = result.real_encode()
         return result
 
     @classmethod
     def serialize(cls) -> Optional[tuple[bytes, CacheInfo]]:
-        cls._save_artifacts_by_type()
-        # No need to serialize if there are no new dynamo compiles
-        if "precompile_dynamo" not in cls._new_cache_artifacts:
+        if not cls._dynamo_cache_entries:
             return None
-        return super().serialize()
+
+        debug_info = cls.dump_debug_info(
+            cls._dynamo_cache_entries, cls._backend_artifacts_by_key
+        )
+        torch._logging.trace_structured(
+            "artifact",
+            metadata_fn=lambda: {
+                "name": "dynamo_cache_save_contents",
+                "encoding": "json",
+            },
+            payload_fn=lambda: json.dumps({"artifacts": debug_info}),
+            expect_trace_id=False,
+        )
+        cls._save_artifacts_by_type()
+
+        result = super().serialize()
+        assert result is not None
+        data, info = result
+
+        return data, info
+
+    @staticmethod
+    def dump_debug_info(
+        dynamo_entries: dict[str, _DynamoCacheEntry],
+        backend_artifacts: dict[str, PrecompileCacheArtifact],
+    ) -> dict[str, Any]:
+        """
+        Return a JSON serializable debug dump of all entries in the precompile context
+        Called in serialize before serialization, and in populate_caches after deserialization
+        """
+        # Print debug information
+        debug_info = defaultdict(list)
+        debug_info["precompile_dynamo"] = [
+            cache_entry.debug_info() for cache_entry in dynamo_entries.values()
+        ]
+        for artifact in backend_artifacts.values():
+            if isinstance(artifact, EditablePrecompileCacheArtifact):
+                debug_info[artifact.artifact_type].append(artifact.key)
+            else:
+                debug_info[artifact.__class__.type()].append(artifact.key)
+
+        return debug_info
 
     @staticmethod
     def populate_caches(artifacts: CacheArtifactsResult) -> CacheInfo:
         PrecompileContext._ensure_cache_artifacts_registered()
 
-        artifacts_by_key = {}
+        backend_artifacts = {}
+        dynamo_entries: dict[str, _DynamoCacheEntry] = {}
         cache_info = CacheInfo()
         for artifact in chain(*artifacts.values()):
             if artifact.type() == "autotune":
                 # Populate autotune cache artifacts
                 artifact.populate_cache()
+            elif artifact.type() == "precompile_dynamo":
+                assert isinstance(artifact, _DynamoCacheArtifact)
+                cache_entry: _DynamoCacheEntry = artifact.after_deserialization()
+                dynamo_entries[artifact.key] = cache_entry
             else:
-                artifacts_by_key[artifact.key] = artifact
+                backend_artifacts[artifact.key] = artifact
             cache_info.add(artifact)
 
+        num_artifacts = len(artifacts["precompile_dynamo"])
+
+        debug_info = PrecompileContext.dump_debug_info(
+            dynamo_entries, backend_artifacts
+        )
+
+        torch._logging.trace_structured(
+            "artifact",
+            metadata_fn=lambda: {
+                "name": "dynamo_cache_entries",
+                "encoding": "json",
+            },
+            payload_fn=lambda: json.dumps(
+                {
+                    "num_entries": num_artifacts,
+                    "artifacts": debug_info,
+                },
+                default=str,
+            ),
+            expect_trace_id=False,
+        )
         from torch._dynamo.package import _BackendId, DynamoCache
 
-        for dynamo_entry in artifacts["precompile_dynamo"]:
-            assert isinstance(dynamo_entry, PrecompileCacheArtifact)
-            cache_entry = dynamo_entry.after_deserialization()
-            # Grab backends from the dynamo cache entry
-            backends = cache_entry.backend_ids
-            backend_content: dict[_BackendId, PrecompileCacheArtifact[Any]] = {}
-            for id_ in backends:
-                assert id_ in artifacts_by_key, f"Backend {id_} not found in artifacts"
-                artifact = artifacts_by_key[id_]
-                assert isinstance(artifact, PrecompileCacheArtifact)
-                backend_content[id_] = artifact
-            DynamoCache.write(cache_entry, backend_content, dynamo_entry.key)
+        for key, cache_entry in dynamo_entries.items():
+            try:
+                backends = cache_entry.backend_ids
+                backend_content: dict[_BackendId, PrecompileCacheArtifact[Any]] = {}
+                for id_ in backends:
+                    if id_ not in backend_artifacts:
+                        logger.warning("Backend not found")
+                        torch._logging.trace_structured(
+                            "artifact",
+                            metadata_fn=lambda: {
+                                "name": "dynamo_cache_bypass",
+                                "encoding": "json",
+                            },
+                            payload_fn=lambda: json.dumps(
+                                {
+                                    "entry": cache_entry.debug_info,
+                                    "key": key,
+                                }
+                            ),
+                            expect_trace_id=False,
+                        )
+                        continue
+                    artifact = backend_artifacts[id_]
+                    assert isinstance(artifact, PrecompileCacheArtifact)
+                    backend_content[id_] = artifact
+                DynamoCache.write(cache_entry, backend_content, key)
+            except Exception as e:
+                logger.warning("Failed to deserialize cache entry %s: %s", key, str(e))
+                import json
+
+                error = e
+                torch._logging.trace_structured(
+                    "artifact",
+                    metadata_fn=lambda: {
+                        "name": "dynamo_cache_exception",
+                        "encoding": "json",
+                    },
+                    payload_fn=lambda: json.dumps(
+                        {
+                            "key": key,
+                            "error": str(error),
+                        }
+                    ),
+                )
+                continue
 
         return cache_info
 
     @classmethod
     def _ensure_cache_artifacts_registered(cls) -> None:
-        from torch._dynamo.package import _DynamoCacheArtifact  # noqa: F401
         from torch._functorch._aot_autograd.autograd_cache import (  # noqa: F401
             BundledAOTAutogradCacheArtifact,
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #162735

This diff does a few things:
- It refactors PrecompileContext to store DynamoCacheEntries directly on the context. This allows us at serialization time to check if the dynamo cache entry has all its backends ready for serialization, and if not, skip unnecessarily serializing it
- It also gives us the ability to print out a `debug` JSON, which contains a mapping for everything being serialized and deserialized.

Here's an example of what that JSON looks like:

```
{
  "artifacts": {
    "precompile_aot_autograd": [
      "__compiled_fn_8_306d538b_f7f8_4ab4_98a1_b5ff4493f99d"
    ],
    "precompile_dynamo": [
      {
        "backend_ids": [
          "__compiled_fn_8_306d538b_f7f8_4ab4_98a1_b5ff4493f99d"
        ],
        "fn_name": "TorchBenchmarkRunner.forward_and_backward_pass",
        "num_codes": "10",
        "python_version": "3.12.11+meta",
        "torch_version": "2.10.0a0+fb"
      }
    ]
  },
  "num_entries": 1
}
```

Differential Revision: [D82232574](https://our.internmc.facebook.com/intern/diff/D82232574/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela