### PR TITLE
[async_tp] Do not apply mm+splt(k)+cat+rs when k is the last mm dim

### DIFF
--- a/torch/_inductor/fx_passes/micro_pipeline_tp.py
+++ b/torch/_inductor/fx_passes/micro_pipeline_tp.py
@@ -897,6 +897,10 @@ def fuse_matmul_reduce_scatter(reduce_scatter: _ReduceScatterMatch) -> None:
         )
         return
 
+    if orig_scatter_dim >= len(_get_tensor(matmul.nodes[0]).shape) - 1:
+        # Decomposing the matmul on the K dimension is not supported
+        return
+
     if rs_wait_tensor_node in matmul.arg_ancestor_nodes:
         log.warning(
             "reduce-scatter result node is an ancestor of matmul, skipping fuse_matmul_reduce_scatter fusion"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #162736

```
       permute_7: "bf16[1024, 4096][1, 1024]cuda:0" = torch.ops.aten.permute.default(wait_tensor_9, [1, 0]);  wait_tensor_9 = None
        view_17: "bf16[32768, 1024][1024, 1]cuda:0" = torch.ops.aten.reshape.default(view_16, [32768, 1024]);  view_16 = None
        mm_3: "bf16[32768, 4096][4096, 1]cuda:0" = torch.ops.aten.mm.default(view_17, permute_7);  view_17 = permute_7 = None
        split_5 = torch.ops.aten.split.Tensor(mm_3, 1024, 1);  mm_3 = None
        getitem_25: "bf16[32768, 1024][4096, 1]cuda:0" = split_5[0]
        getitem_26: "bf16[32768, 1024][4096, 1]cuda:0" = split_5[1]
        getitem_27: "bf16[32768, 1024][4096, 1]cuda:0" = split_5[2]
        getitem_28: "bf16[32768, 1024][4096, 1]cuda:0" = split_5[3];  split_5 = None
        cat_3: "bf16[131072, 1024][1024, 1]cuda:0" = torch.ops.aten.cat.default([getitem_25, getitem_26, getitem_27, getitem_28]);  getitem_25 = getitem_26 = getitem_27 = getitem_28 = None
        reduce_scatter_tensor: "bf16[32768, 1024][1024, 1]cuda:0" = torch.ops._c10d_functional.reduce_scatter_tensor.default(cat_3, 'sum', 4, '5');  cat_3 = None
        wait_tensor_10: "bf16[32768, 1024][1024, 1]cuda:0" = torch.ops._c10d_functional.wait_tensor.default(reduce_scatter_tensor);  reduce_scatter_tensor = None
        view_18: "bf16[4, 8192, 1024][8388608, 1024, 1]cuda:0" = torch.ops.aten.reshape.default(wait_tensor_10, [4, 8192, 1024]);  wait_tensor_10 = None
```
->
```
        permute_7: "bf16[1024, 4096][1, 1024]cuda:0" = torch.ops.aten.permute.default(wait_tensor_9, [1, 0]);  wait_tensor_9 = None
        view_17: "bf16[32768, 1024][1024, 1]cuda:0" = torch.ops.aten.reshape.default(view_16, [32768, 1024]);  view_16 = None
        
        # No stacktrace found for following nodes
        inductor_force_stride_order_default_1 = torch.ops.prims.inductor_force_stride_order.default(view_17, (1, 32768));  view_17 = None
        fused_matmul_reduce_scatter_default = torch.ops.symm_mem.fused_matmul_reduce_scatter.default(inductor_force_stride_order_default_1, permute_7, 'sum', 1, '5');  inductor_force_stride_order_default_1 = permute_7 = None
        
         # File: /data/users/ivankobzarev/b/torchtitan-autoparallel/torchtitan/torchtitan/models/llama3/model/model.py:198 in forward, code: return self.wo(output)
        view_18: "bf16[4, 8192, 1024][8388608, 1024, 1]cuda:0" = torch.ops.aten.reshape.default(fused_matmul_reduce_scatter_default, [4, 8192, 1024]);  fused_matmul_reduce_scatter_default = None

```

will fail with mat muls mismatch:

```
    File "/tmp/torchinductor_ivankobzarev/tmpexhi913l/6j/c6jlxwlb7pwqesmdblol7bqub6qq5ef7tibe5wvn37ojtwk5s4h2.py", line 1618, in call
      buf72 = torch.ops.symm_mem.fused_matmul_reduce_scatter.default(buf71, reinterpret_tensor(buf68, (1024, 4096), (1, 1024), 0), 'sum', 1, '6')
    File "/data/users/ivankobzarev/e/pytorch/torch/_ops.py", line 841, in __call__
      return self._op(*args, **kwargs)
    File "/data/users/ivankobzarev/e/pytorch/torch/distributed/_symmetric_memory/__init__.py", line 1032, in _fused_matmul_reduce_scatter
      return _fused_matmul_reduce_scatter_impl(
    File "/data/users/ivankobzarev/e/pytorch/torch/distributed/_symmetric_memory/__init__.py", line 1097, in _fused_matmul_reduce_scatter_impl
      _pipelined_produce_and_all2all(
    File "/data/users/ivankobzarev/e/pytorch/torch/distributed/_symmetric_memory/__init__.py", line 419, in _pipelined_produce_and_all2all
      chunk_producer((rank + step) % group_size, p2p_buf)
    File "/data/users/ivankobzarev/e/pytorch/torch/distributed/_symmetric_memory/__init__.py", line 1093, in chunk_producer
      mm_out_op(A_shards[rank], B, **kwargs, out=out)
    File "/data/users/ivankobzarev/e/pytorch/torch/_ops.py", line 841, in __call__
      return self._op(*args, **kwargs)
  RuntimeError: mat1 and mat2 shapes cannot be multiplied (256x32768 and 1024x4096)
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben