### PR TITLE
Refactor PrecompileContext to be considerably more debuggable

### DIFF
--- a/test/dynamo/test_precompile_context.py
+++ b/test/dynamo/test_precompile_context.py
@@ -47,7 +47,8 @@ class PrecompileContextTests(InductorTestCase):
         x = torch.randn(10, device=GPU_TYPE, requires_grad=True)
         result = compiled_fn(x)
         result.sum().backward()
-        self.assertEqual(len(PrecompileContext._new_cache_artifacts_by_key), 2)
+        self.assertEqual(len(PrecompileContext._dynamo_cache_entries), 1)
+        self.assertEqual(len(PrecompileContext._backend_artifacts_by_key), 1)
         self.assertEqual(len(PrecompileContext._new_cache_artifacts), 0)
 
         result = PrecompileContext.serialize()
@@ -82,8 +83,9 @@ class PrecompileContextTests(InductorTestCase):
         x = torch.randn(10, device=GPU_TYPE, requires_grad=True)
         result = compiled_fn(x)
         result.sum().backward()
-        self.assertEqual(len(PrecompileContext._new_cache_artifacts_by_key), 2)
-        for key in PrecompileContext._new_cache_artifacts_by_key.keys():
+        self.assertEqual(len(PrecompileContext._dynamo_cache_entries), 1)
+        self.assertEqual(len(PrecompileContext._backend_artifacts_by_key), 1)
+        for key in PrecompileContext._backend_artifacts_by_key.keys():
             result = PrecompileContext.serialize_artifact_by_key(key)
             assert isinstance(result, PrecompileCacheArtifact)
             self.assertEqual(result.key, key)
@@ -109,11 +111,12 @@ class PrecompileContextTests(InductorTestCase):
         x = torch.randn(10, device=GPU_TYPE, requires_grad=True)
         result = compiled_fn(x)
         result.sum().backward()
-        self.assertEqual(len(PrecompileContext._new_cache_artifacts_by_key), 2)
+        self.assertEqual(len(PrecompileContext._dynamo_cache_entries), 1)
+        self.assertEqual(len(PrecompileContext._backend_artifacts_by_key), 1)
         # Find the key for the artifact of type "precompile_aot_autograd"
         key = next(
             k
-            for k, v in PrecompileContext._new_cache_artifacts_by_key.items()
+            for k, v in PrecompileContext._backend_artifacts_by_key.items()
             if isinstance(v, EditablePrecompileCacheArtifact)
         )
 

--- a/torch/_dynamo/aot_compile.py
+++ b/torch/_dynamo/aot_compile.py
@@ -13,7 +13,7 @@ from typing import Any, Callable, Optional, TYPE_CHECKING
 import torch
 import torch.fx
 from torch._dynamo.graph_utils import _graph_device_type
-from torch._dynamo.precompile_context import SystemInfo
+from torch._dynamo.package import SystemInfo
 
 from . import convert_frame
 from .hooks import Hooks

--- a/torch/_dynamo/precompile_context.py
+++ b/torch/_dynamo/precompile_context.py
@@ -1,8 +1,7 @@
 import copy
-import dataclasses
+import json
 import logging
 import pickle
-import platform
 from abc import abstractmethod
 from collections import defaultdict
 from itertools import chain
@@ -10,6 +9,7 @@ from typing import Any, Callable, Generic, Optional, TypeVar, Union
 from typing_extensions import override
 
 import torch
+from torch._dynamo.package import _DynamoCacheEntry
 from torch.compiler._cache import (
     _serialize_single_cache,
     CacheArtifact,
@@ -20,7 +20,6 @@ from torch.compiler._cache import (
 )
 from torch.utils._appending_byte_serializer import AppendingByteSerializer
 from torch.utils._ordered_set import OrderedSet
-from torch.utils._triton import get_triton_version
 
 
 """
@@ -69,6 +68,16 @@ class PrecompileCacheArtifact(CacheArtifact, Generic[T]):
         ...
 
 
+@CacheArtifactFactory.register
+class EagerCacheArtifact(PrecompileCacheArtifact[Any]):
+    @staticmethod
+    def type() -> str:
+        return "precompile_eager"
+
+    def after_deserialization(self) -> Any:
+        return pickle.loads(self.content)
+
+
 class EditablePrecompileCacheArtifact(Generic[T]):
     """
     A PrecompileCacheArtifact whose content isn't encoded until we call PrecompileContext.serialize()
@@ -99,6 +108,21 @@ class EditablePrecompileCacheArtifact(Generic[T]):
         self.content = edit_fn(self.content)
 
 
+@CacheArtifactFactory.register
+class _DynamoCacheArtifact(PrecompileCacheArtifact[_DynamoCacheEntry]):
+    @staticmethod
+    def type() -> str:
+        return "precompile_dynamo"
+
+    def after_deserialization(self) -> _DynamoCacheEntry:
+        result = pickle.loads(self.content)
+        return result
+
+
+class BypassDynamoCacheEntry(Exception):
+    pass
+
+
 class PrecompileContext(CacheArtifactManager):
     """
     PrecompileContext is a special CacheArtifactManager for handling precompilation
@@ -106,20 +130,29 @@ class PrecompileContext(CacheArtifactManager):
     of placing each artifact into respective caches, it will stitch all the cache artifacts for a single key
     together and place it into a global Precompile Cache.
 
+    PrecompileContext has two main portions: dynamo_cache_entries and backend_cache_artifacts.
+    When saving, PrecompileContext.serialize() will serialize all dynamo cache entries along with any PrecompileCacheArtifacts that
+    are needed to save those dynamo cache entries.
+
     The following artifact types are supported by PrecompileContext:
      - BundledAOTAutogradCacheArtifact
-     - DynamoCodeStateArtifact
      - AutotuneCacheArtifact (regular autotune results, same as Megacache)
+
     """
 
     # Protected by the compile_lock
-    # _new_cache_artifacts_by_key organizes results by the key of each artifact.
+    # _backend_artifacts_by_key organizes results by the key of each artifact.
     # This allows us to implement serialize_by_key easily.
-    # On call to `serialize()`, all cache artifacts in _new_cache_artifacts_by_key
+    # On call to `serialize()`, all cache artifacts in _backend_artifacts_by_key
     # are transferred to _new_cache_artifacts before serialization.
-    _new_cache_artifacts_by_key: dict[
+    _backend_artifacts_by_key: dict[
         str, Union[EditablePrecompileCacheArtifact[object], CacheArtifact]
     ] = {}
+
+    # On call to `serialize()`, all cache artifacts in _dynamo_cache_entries are converted
+    # into DynamoCacheArtifacts and added to _new_cache_artifacts for serialization
+    _dynamo_cache_entries: dict[str, _DynamoCacheEntry] = {}
+
     _new_cache_artifacts: CacheArtifactsResult = defaultdict(list)
     # Keep a separate seen artifacts list to make avoid unnecessary duplicates
     # This list will not be cleared between serialize() calls
@@ -134,7 +167,8 @@ class PrecompileContext(CacheArtifactManager):
 
     @classmethod
     def clear(cls) -> None:
-        cls._new_cache_artifacts_by_key.clear()
+        cls._backend_artifacts_by_key.clear()
+        cls._dynamo_cache_entries.clear()
         super().clear()
 
     @override
@@ -164,29 +198,51 @@ class PrecompileContext(CacheArtifactManager):
                 return
             cls._seen_artifacts.add(artifact)
 
-        cls._new_cache_artifacts_by_key[key] = artifact
+        cls._backend_artifacts_by_key[key] = artifact
+
+    @classmethod
+    def record_dynamo_cache_entry(
+        cls, cache_entry: _DynamoCacheEntry, key: str
+    ) -> None:
+        cls._dynamo_cache_entries[key] = cache_entry
 
     @classmethod
     def _save_artifacts_by_type(cls) -> None:
         """
         We normally record artifacts by key, but serialization expects them to be organized
-        by artifact type. This function transfers artifacts from _new_cache_artifacts_by_key to _new_cache_artifacts
+        by artifact type. This function transfers artifacts from _backend_artifacts_by_key to _new_cache_artifacts
         """
-        for artifact in cls._new_cache_artifacts_by_key.values():
+        for key, cache_entry in cls._dynamo_cache_entries.items():
+            backends = cache_entry.backend_ids
+            try:
+                for id_ in backends:
+                    if id_ not in cls._backend_artifacts_by_key:
+                        logger.warning(
+                            "Bypassing %s because backend %s not found in artifacts"
+                        )
+                        raise BypassDynamoCacheEntry
+            except BypassDynamoCacheEntry:
+                continue
+            pickled_result = pickle.dumps(cache_entry)
+            dynamo_artifact = _DynamoCacheArtifact(key, pickled_result)
+            cls._new_cache_artifacts[_DynamoCacheArtifact.type()].append(
+                dynamo_artifact
+            )
+
+        # Save all the backend artifacts
+        for artifact in cls._backend_artifacts_by_key.values():
             if isinstance(artifact, EditablePrecompileCacheArtifact):
                 artifact = artifact.real_encode()
             cls._new_cache_artifacts[artifact.__class__.type()].append(artifact)
-        cls._new_cache_artifacts_by_key.clear()
+        cls._backend_artifacts_by_key.clear()
 
     @classmethod
     def edit_artifact(cls, key: str, edit_fn: Callable[..., Any]) -> None:
         """
         Edit the content of an existing artifact
         """
-        assert key in cls._new_cache_artifacts_by_key, (
-            f"Key {key} not found in artifacts"
-        )
-        artifact = cls._new_cache_artifacts_by_key[key]
+        assert key in cls._backend_artifacts_by_key, f"Key {key} not found in artifacts"
+        artifact = cls._backend_artifacts_by_key[key]
         assert isinstance(artifact, EditablePrecompileCacheArtifact), (
             "Artifact is not editable"
         )
@@ -195,133 +251,157 @@ class PrecompileContext(CacheArtifactManager):
     @classmethod
     def serialize_artifact_by_key(cls, key: str) -> Optional[CacheArtifact]:
         """
-        Serialize all artifacts with the given key returned in a list.
+        Serialize all backend artifacts with the given key returned in a list.
         """
-        result = cls._new_cache_artifacts_by_key.get(key, None)
+        result = cls._backend_artifacts_by_key.get(key, None)
         if isinstance(result, EditablePrecompileCacheArtifact):
             result = result.real_encode()
         return result
 
     @classmethod
     def serialize(cls) -> Optional[tuple[bytes, CacheInfo]]:
-        cls._save_artifacts_by_type()
-        # No need to serialize if there are no new dynamo compiles
-        if "precompile_dynamo" not in cls._new_cache_artifacts:
+        if not cls._dynamo_cache_entries:
             return None
-        return super().serialize()
+
+        debug_info = cls.dump_debug_info(
+            cls._dynamo_cache_entries, cls._backend_artifacts_by_key
+        )
+        artifacts = json.dumps({"artifacts": debug_info})
+        torch._logging.trace_structured(
+            "artifact",
+            metadata_fn=lambda: {
+                "name": "dynamo_cache_save_contents",
+                "encoding": "json",
+            },
+            payload_fn=lambda: artifacts,
+            expect_trace_id=False,
+        )
+        cls._save_artifacts_by_type()
+
+        result = super().serialize()
+        assert result is not None
+        data, info = result
+
+        return data, info
+
+    @staticmethod
+    def dump_debug_info(
+        dynamo_entries: dict[str, _DynamoCacheEntry],
+        backend_artifacts: dict[
+            str, Union[EditablePrecompileCacheArtifact[object], CacheArtifact]
+        ],
+    ) -> dict[str, Any]:
+        """
+        Return a JSON serializable debug dump of all entries in the precompile context
+        Called in serialize before serialization, and in populate_caches after deserialization
+        """
+        # Print debug information
+        debug_info: defaultdict[str, list[Any]] = defaultdict(list)
+        for key, cache_entry in dynamo_entries.items():
+            info = cache_entry.debug_info()
+            info["key"] = key
+            debug_info["precompile_dynamo"].append(info)
+
+        for artifact in backend_artifacts.values():
+            if isinstance(artifact, EditablePrecompileCacheArtifact):
+                debug_info[artifact.artifact_type].append(artifact.key)
+            else:
+                debug_info[artifact.__class__.type()].append(artifact.key)
+
+        return debug_info
 
     @staticmethod
     def populate_caches(artifacts: CacheArtifactsResult) -> CacheInfo:
         PrecompileContext._ensure_cache_artifacts_registered()
 
-        artifacts_by_key = {}
+        backend_artifacts: dict[str, Any] = {}
+        dynamo_entries: dict[str, _DynamoCacheEntry] = {}
         cache_info = CacheInfo()
         for artifact in chain(*artifacts.values()):
             if artifact.type() == "autotune":
                 # Populate autotune cache artifacts
                 artifact.populate_cache()
+            elif artifact.type() == "precompile_dynamo":
+                assert isinstance(artifact, _DynamoCacheArtifact)
+                cache_entry: _DynamoCacheEntry = artifact.after_deserialization()
+                dynamo_entries[artifact.key] = cache_entry
             else:
-                artifacts_by_key[artifact.key] = artifact
+                backend_artifacts[artifact.key] = artifact
             cache_info.add(artifact)
 
+        num_artifacts = len(artifacts["precompile_dynamo"])
+
+        debug_info = PrecompileContext.dump_debug_info(
+            dynamo_entries, backend_artifacts
+        )
+        debug_str = json.dumps(
+            {
+                "num_entries": num_artifacts,
+                "artifacts": debug_info,
+            },
+        )
+        torch._logging.trace_structured(
+            "artifact",
+            metadata_fn=lambda: {
+                "name": "dynamo_cache_entries",
+                "encoding": "json",
+            },
+            payload_fn=lambda: debug_str,
+            expect_trace_id=False,
+        )
         from torch._dynamo.package import _BackendId, DynamoCache
 
-        for dynamo_entry in artifacts["precompile_dynamo"]:
-            assert isinstance(dynamo_entry, PrecompileCacheArtifact)
-            cache_entry = dynamo_entry.after_deserialization()
-            # Grab backends from the dynamo cache entry
-            backends = cache_entry.backend_ids
-            backend_content: dict[_BackendId, PrecompileCacheArtifact[Any]] = {}
-            for id_ in backends:
-                assert id_ in artifacts_by_key, f"Backend {id_} not found in artifacts"
-                artifact = artifacts_by_key[id_]
-                assert isinstance(artifact, PrecompileCacheArtifact)
-                backend_content[id_] = artifact
-            DynamoCache.write(cache_entry, backend_content, dynamo_entry.key)
+        for key, cache_entry in dynamo_entries.items():
+            try:
+                backends = cache_entry.backend_ids
+                backend_content: dict[_BackendId, PrecompileCacheArtifact[Any]] = {}
+                for id_ in backends:
+                    if id_ not in backend_artifacts:
+                        debug_str = json.dumps(
+                            {
+                                "entry": cache_entry.debug_info,
+                                "key": key,
+                            }
+                        )
+                        logger.warning("Backend not found")
+                        torch._logging.trace_structured(
+                            "artifact",
+                            metadata_fn=lambda: {
+                                "name": "dynamo_cache_bypass",
+                                "encoding": "json",
+                            },
+                            payload_fn=lambda: debug_str,
+                            expect_trace_id=False,
+                        )
+                        continue
+                    artifact = backend_artifacts[id_]
+                    assert isinstance(artifact, PrecompileCacheArtifact)
+                    backend_content[id_] = artifact
+                DynamoCache.write(cache_entry, backend_content, key)
+            except Exception as e:
+                logger.warning("Failed to deserialize cache entry %s: %s", key, str(e))
+
+                error = e
+                data = json.dumps(
+                    {
+                        "key": key,
+                        "error": str(error),
+                    }
+                )
+                torch._logging.trace_structured(
+                    "artifact",
+                    metadata_fn=lambda: {
+                        "name": "dynamo_cache_exception",
+                        "encoding": "json",
+                    },
+                    payload_fn=lambda: data,
+                )
+                continue
 
         return cache_info
 
     @classmethod
     def _ensure_cache_artifacts_registered(cls) -> None:
-        from torch._dynamo.package import _DynamoCacheArtifact  # noqa: F401
         from torch._functorch._aot_autograd.autograd_cache import (  # noqa: F401
             BundledAOTAutogradCacheArtifact,
         )
-
-
-@dataclasses.dataclass(frozen=True)
-class SystemInfo:
-    """
-    System information including Python, PyTorch, and GPU details.
-    This information is used to ensure compiled artifacts can only be loaded
-    with compatible system configurations.
-    """
-
-    python_version: str
-    torch_version: str
-    toolkit_version: Optional[str]
-    triton_version: Optional[tuple[int, int]]
-    gpu_name: Optional[str]
-    CHECK_GPUS = ("cuda", "xpu")
-
-    @classmethod
-    def current(cls) -> "SystemInfo":
-        """Create a SystemInfo instance with current system information."""
-        # Get GPU name if CUDA or XPU is available
-        gpu_name, toolkit_version = None, None
-        for device_type in cls.CHECK_GPUS:
-            if getattr(torch, device_type).is_available():
-                try:
-                    gpu_name = getattr(torch, device_type).get_device_name()
-                    toolkit_version = getattr(torch.version, device_type)
-                    break
-                except Exception:
-                    pass
-
-        return cls(
-            python_version=platform.python_version(),
-            torch_version=torch.__version__,
-            toolkit_version=toolkit_version,
-            triton_version=get_triton_version((0, 0)),
-            gpu_name=gpu_name,
-        )
-
-    def check_compatibility(
-        self, other: "SystemInfo", device_type: str = "cpu"
-    ) -> None:
-        """
-        Check if this SystemInfo is compatible with another SystemInfo.
-        Raises RuntimeError if incompatible.
-        """
-        if self.python_version != other.python_version:
-            raise RuntimeError(
-                f"Compile package was created with a different Python version: {self.python_version}"
-            )
-
-        if self.torch_version != other.torch_version:
-            raise RuntimeError(
-                f"Compile package was created with a different PyTorch version: {self.torch_version}"
-            )
-        if device_type in self.CHECK_GPUS:
-            if not getattr(torch, device_type).is_available():
-                raise RuntimeError(f"{device_type} is not available")
-
-            if self.toolkit_version != other.toolkit_version:
-                raise RuntimeError(
-                    f"Compile package was created with a different toolkit version: {self.toolkit_version}"
-                )
-
-            if (
-                other.triton_version != (0, 0)
-                and self.triton_version != other.triton_version
-            ):
-                raise RuntimeError(
-                    f"Compile package was created with a different Triton version: {self.triton_version}"
-                )
-
-            # Check GPU name if CUDA/XPU was used
-            if other.gpu_name is not None and self.gpu_name != other.gpu_name:
-                raise RuntimeError(
-                    f"Compile package was created with different GPU: "
-                    f"cached={self.gpu_name}, current={other.gpu_name}"
-                )


### PR DESCRIPTION
Summary:
This diff does a few things: 
- It refactors PrecompileContext to store DynamoCacheEntries directly on the context. This allows us at serialization time to check if the dynamo cache entry has all its backends ready for serialization, and if not, skip unnecessarily serializing it
- It also gives us the ability to print out a `debug` JSON, which contains a mapping for everything being serialized and deserialized. 

Here's an example of what that JSON looks like:

```
{
  "artifacts": {
    "precompile_aot_autograd": [
      "__compiled_fn_8_306d538b_f7f8_4ab4_98a1_b5ff4493f99d"
    ],
    "precompile_dynamo": [
      {
        "backend_ids": [
          "__compiled_fn_8_306d538b_f7f8_4ab4_98a1_b5ff4493f99d"
        ],
        "fn_name": "TorchBenchmarkRunner.forward_and_backward_pass",
        "num_codes": "10",
        "python_version": "3.12.11+meta",
        "torch_version": "2.10.0a0+fb"
      }
    ]
  },
  "num_entries": 1
}
```

Test Plan:
Existing tests pass. 

NanoGPT tlparse showing the new debug:

https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/.tmpeIsL5G/index.html?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=10000

Note that there aren't compile ids since we're logging this in PrecompileContext.serialize() for now, where there isn't a compile yet. I think this is fine for now, as no compile ID makes sense here. If anything, these kind of belong in a "Global" compile ID, which I will not implement in this PR.

Rollback Plan:

Differential Revision: D82232574




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela