### PR TITLE
fix wait() missing in redistribute tensor

### DIFF
--- a/test/distributed/tensor/debug/test_debug_mode.py
+++ b/test/distributed/tensor/debug/test_debug_mode.py
@@ -139,6 +139,8 @@ class TestDTensorDebugMode(TestCase):
         aten::chunk(t: f32[1, 96, 8], 4, 2)
         aten::cat(['t: f32[1, 96, 2]', 't: f32[1, 96, 2]', 't: f32[1, 96, 2]', 't: f32[1, 96, 2]'])
         _c10d_functional::reduce_scatter_tensor(t: f32[4, 96, 2], sum, 4, 1)
+        _c10d_functional::wait_tensor(t: f32[1, 96, 2])
+        aten::chunk(t: f32[1, 96, 2], 2, 2)
         aten::clone(t: f32[1, 96, 1])
       redistribute_input(1, [R, P] -> [S(1), S(1)])
         aten::chunk(t: f32[1, 8, 16], 4, 1)

--- a/torch/distributed/tensor/_redistribute.py
+++ b/torch/distributed/tensor/_redistribute.py
@@ -270,11 +270,9 @@ def redistribute_local_tensor(
                 # partial -> partial no op, should never hit
                 new_local_tensor = local_tensor
 
+        if not async_op and isinstance(new_local_tensor, funcol.AsyncCollectiveTensor):
+            new_local_tensor = new_local_tensor.wait()
         local_tensor = new_local_tensor
-
-    if not async_op and isinstance(new_local_tensor, funcol.AsyncCollectiveTensor):
-        new_local_tensor = new_local_tensor.wait()
-
     return new_local_tensor
 
 

--- a/torch/distributed/tensor/placement_types.py
+++ b/torch/distributed/tensor/placement_types.py
@@ -221,6 +221,8 @@ class Shard(Placement):
         output = funcol.reduce_scatter_tensor(
             tensor, reduce_op, scatter_dim=self.dim, group=(mesh, mesh_dim)
         )
+        if isinstance(output, funcol.AsyncCollectiveTensor):
+            output = output.wait()
 
         if is_padded:
             output = unpad_tensor(output, self.dim, pad_sizes[my_coordinate[mesh_dim]])  # type: ignore[possibly-undefined]
@@ -255,6 +257,9 @@ class Shard(Placement):
             gather_dim=self.dim,
             group=(mesh, mesh_dim),
         )
+        if isinstance(result, funcol.AsyncCollectiveTensor):
+            result = result.wait()
+
         if is_padded:
             unpad_size = full_chunk_size * num_chunks - logical_dim_size  # type: ignore[possibly-undefined]
             result = unpad_tensor(result, self.dim, unpad_size)
@@ -681,9 +686,12 @@ class Partial(Placement):
     ) -> torch.Tensor:
         # Partial placement contract #1:
         # _reduce_value: reduce the value of the tensor on the mesh dimension
-        return funcol.all_reduce(
+        output = funcol.all_reduce(
             tensor, reduceOp=self.reduce_op, group=(mesh, mesh_dim)
         )
+        if isinstance(output, funcol.AsyncCollectiveTensor):
+            output = output.wait()
+        return output
 
     def _reduce_shard_value(
         self,


### PR DESCRIPTION
We notice that the wait() op is missing after collective op call: https://github.com/pytorch/pytorch/pull/162665#discussion_r2338460562.

The issue is that `_maybe_warp_tensor` calls AsyncCollectiveTensor in https://github.com/pytorch/pytorch/blob/3ad3bfe11df7bf542885a6dd2dc2ada4ab940e53/torch/distributed/_functional_collectives.py#L829 We need to check whether the wait() is required after collective op call.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci