### PR TITLE
[flatbuffer] Fix compile error due to discarded result

### DIFF
--- a/torch/csrc/jit/mobile/file_format.h
+++ b/torch/csrc/jit/mobile/file_format.h
@@ -153,7 +153,8 @@ static inline std::tuple<std::shared_ptr<char>, size_t> get_file_content(
   size_t buffer_size = (size / kMaxAlignment + 1) * kMaxAlignment;
   std::shared_ptr<char> data(
       static_cast<char*>(c10::alloc_cpu(buffer_size)), c10::free_cpu);
-  fread(data.get(), size, 1, f);
+  auto nread = fread(data.get(), size, 1, f);
+  TORCH_CHECK(nread == 1, "Failed to read file: ", filename);
   fclose(f);
 #endif
   return std::make_tuple(data, size);


### PR DESCRIPTION
Summary:
One of our builds fails because the return value of fread is discarded. Explicit cast to void fixes the build.

```log
In file included from fbcode/caffe2/torch/csrc/jit/mobile/import.cpp:15:
fbcode/caffe2/torch/csrc/jit/mobile/file_format.h:156:3: error: ignoring return value of function declared with 'warn_unused_result' attribute [-Werror,-Wunused-result]
  156 |   fread(data.get(), size, 1, f);
      |   ^~~~~ ~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
...
BUILD FAILED
Failed to build 'fbcode//caffe2:libtorch (cfg:opt-linux-x86_64-clang19-no-san-opt-by-default#fef256f7ee896871)'
```

Test Plan:
No runtime behavior change. CI.

Rollback Plan:

Differential Revision: D82265002




cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel