### PR TITLE
[pcache] Cache and AsyncCache implementations

### DIFF
--- a/test/inductor/test_pcache.py
+++ b/test/inductor/test_pcache.py
@@ -1,0 +1,297 @@
+# Owner(s): ["module: inductor"]
+from __future__ import annotations
+
+from concurrent.futures import Future, ThreadPoolExecutor
+from os import environ
+from random import randint
+from typing import TYPE_CHECKING
+from typing_extensions import Self
+
+from torch._inductor import pcache
+from torch._inductor.test_case import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+)
+
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+str_key_gen: Generator[str, None, None] = (
+    f"dummy_key_{randint(0, 100000)}" for _ in iter(int, 1)
+)
+bytes_value_gen: Generator[bytes, None, None] = (
+    f"dummy_value_{randint(0, 100000)}".encode() for _ in iter(int, 1)
+)
+
+
+Caches: list[type[pcache.Cache]] = [pcache.InMemoryCache]
+AsyncCaches: list[type[pcache.AsyncCache]] = [pcache.InductorOnDiskCache]
+
+
+@instantiate_parametrized_tests
+class CacheTest(TestCase):
+    @parametrize("Cache", Caches)
+    def test_get_insert_get(self: Self, Cache: type[pcache.Cache]) -> None:
+        key: str = next(str_key_gen)
+        value: bytes = next(bytes_value_gen)
+
+        cache: pcache.Cache = Cache()
+
+        # make sure our key is fresh
+        while cache.get(key) is not None:
+            key = next(str_key_gen)
+
+        # first get should return None, no hit
+        self.assertIsNone(cache.get(key))
+        # insert should return True, having set key -> value
+        self.assertTrue(cache.insert(key, value))
+        # second get should return value, hit
+        self.assertEqual(cache.get(key), value)
+
+    @parametrize("Cache", Caches)
+    def test_insert_insert(self: Self, Cache: type[pcache.Cache]) -> None:
+        key: str = next(str_key_gen)
+        value: bytes = next(bytes_value_gen)
+
+        cache: pcache.Cache = Cache()
+
+        if cache.get(key) is None:
+            # if key isn't already cached, cache it
+            self.assertTrue(cache.insert(key, value))
+
+        # second insert should not update the value
+        self.assertFalse(cache.insert(key, value))
+
+    def test_in_memory_cache_from_env_var(
+        self: Self, Cache: type[pcache.InMemoryCache] = pcache.InMemoryCache
+    ) -> None:
+        key_1: str = next(str_key_gen)
+        value_1: bytes = next(bytes_value_gen)
+
+        key_2: str = next(str_key_gen)
+        while key_2 == key_1:
+            key_2 = next(str_key_gen)
+        value_2: bytes = next(bytes_value_gen)
+
+        key_3: str = next(str_key_gen)
+        while key_3 in (key_1, key_2):
+            key_3 = next(str_key_gen)
+
+        env_var = "INMEMORYCACHE_TEST"
+        env_val = f"{key_1},{value_1!r};{key_2},{value_2!r}"
+        environ[env_var] = env_val
+
+        cache = Cache.from_env_var(env_var)
+
+        # key_1 -> value_1 is in env_val, so we should hit
+        self.assertEqual(cache.get(key_1), value_1)
+        # key_2 -> value_2 is in env_val, so we should hit
+        self.assertEqual(cache.get(key_2), value_2)
+        # key_3 -> value_3 is not in env_val, so we should miss
+        self.assertIsNone(cache.get(key_3))
+
+    def test_in_memory_cache_from_env_var_bad_kv_pair(
+        self: Self, Cache: type[pcache.InMemoryCache] = pcache.InMemoryCache
+    ) -> None:
+        key_1: str = next(str_key_gen)
+        value_1: bytes = next(bytes_value_gen)
+
+        env_var = "INMEMORYCACHE_TEST"
+        # missing "," delimiter
+        env_val = f"{key_1}{value_1!r};"
+        kv_pair = env_val[:-1]
+        environ[env_var] = env_val
+
+        with self.assertRaisesRegex(
+            ValueError,
+            f"Malformed kv_pair {kv_pair!r} in env_var {env_var!r}, missing comma separator!",
+        ):
+            _ = Cache.from_env_var(env_var)
+
+    def test_in_memory_cache_from_env_var_bad_value(
+        self: Self, Cache: type[pcache.InMemoryCache] = pcache.InMemoryCache
+    ) -> None:
+        key_1: str = next(str_key_gen)
+        # exclude b' prefix and ' suffix
+        value_1: str = "bad_value"
+
+        env_var = "INMEMORYCACHE_TEST"
+        env_val = f"{key_1},{value_1};"
+        kv_pair = env_val[:-1]
+        environ[env_var] = env_val
+
+        with self.assertRaisesRegex(
+            ValueError,
+            f"Malformed value {value_1!r} in kv_pair {kv_pair!r}, expected b'...' format!",
+        ):
+            _ = Cache.from_env_var(env_var)
+
+        # not encoded
+        value_2: str = f"b'{chr(256)}'"
+
+        env_val = f"{key_1},{value_2};"
+        kv_pair = env_val[:-1]
+        environ[env_var] = env_val
+
+        with self.assertRaisesRegex(
+            ValueError, f"Malformed value {value_2!r} in kv_pair {kv_pair!r}!"
+        ):
+            _ = Cache.from_env_var(env_var)
+
+    def test_in_memory_cache_from_env_var_one_key_many_values(
+        self: Self, Cache: type[pcache.InMemoryCache] = pcache.InMemoryCache
+    ) -> None:
+        key_1: str = next(str_key_gen)
+        value_1: bytes = next(bytes_value_gen)
+        value_2: bytes = next(bytes_value_gen)
+
+        env_var = "INMEMORYCACHE_TEST"
+        env_val = f"{key_1},{value_1!r};{key_1},{value_2!r}"
+        environ[env_var] = env_val
+
+        with self.assertRaisesRegex(
+            ValueError,
+            f"Duplicated values for key {key_1!r}, got {value_1!r} and {value_2!r}!",
+        ):
+            _ = Cache.from_env_var(env_var)
+
+
+@instantiate_parametrized_tests
+class AsyncCacheTest(TestCase):
+    @parametrize("AsyncCache", AsyncCaches)
+    @parametrize("Executor", [ThreadPoolExecutor, None])
+    def test_get_insert_get(
+        self: Self,
+        AsyncCache: type[pcache.AsyncCache],
+        Executor: type[ThreadPoolExecutor] | None = None,
+    ) -> None:
+        key: str = next(str_key_gen)
+        value: bytes = next(bytes_value_gen)
+
+        async_cache: pcache.AsyncCache = AsyncCache()
+        executor: ThreadPoolExecutor = Executor() if Executor is not None else None
+
+        if executor is None:
+            # make sure our key is fresh
+            while async_cache.get(key) is not None:
+                key = next(str_key_gen)
+
+            # first get should miss
+            self.assertIsNone(async_cache.get(key))
+            # insert should set key -> value mapping
+            self.assertTrue(async_cache.insert(key, value))
+            # second get should hit
+            self.assertEqual(async_cache.get(key), value)
+        else:
+            # make sure our key is fresh
+            while async_cache.get_async(key, executor).result() is not None:
+                key = next(str_key_gen)
+
+            # first get should miss
+            self.assertIsNone(async_cache.get_async(key, executor).result())
+            # insert should set key -> value mapping
+            self.assertTrue(async_cache.insert_async(key, value, executor).result())
+            # second get should hit
+            self.assertEqual(async_cache.get_async(key, executor).result(), value)
+            executor.shutdown()
+
+    @parametrize("AsyncCache", AsyncCaches)
+    @parametrize("Executor", [ThreadPoolExecutor, None])
+    def test_insert_insert(
+        self: Self,
+        AsyncCache: type[pcache.AsyncCache],
+        Executor: type[ThreadPoolExecutor] | None = None,
+    ) -> None:
+        key: str = next(str_key_gen)
+        value: bytes = next(bytes_value_gen)
+
+        async_cache: pcache.AsyncCache = AsyncCache()
+        executor: ThreadPoolExecutor = Executor() if Executor is not None else None
+
+        if executor is None:
+            if async_cache.get(key) is None:
+                # set key -> value mapping if unset
+                self.assertTrue(async_cache.insert(key, value))
+            # second insert should not override the prior insert
+            self.assertFalse(async_cache.insert(key, value))
+        else:
+            if async_cache.get_async(key, executor).result() is None:
+                # set key -> value mapping if unset
+                self.assertTrue(async_cache.insert_async(key, value, executor).result())
+            # second insert should not override the prior insert
+            self.assertFalse(async_cache.insert_async(key, value, executor).result())
+            executor.shutdown()
+
+    @parametrize("AsyncCache", AsyncCaches)
+    def test_concurrent_insert_insert(
+        self: Self,
+        AsyncCache: type[pcache.AsyncCache],
+        Executor: type[ThreadPoolExecutor] = ThreadPoolExecutor,
+    ) -> None:
+        key: str = next(str_key_gen)
+        value: bytes = next(bytes_value_gen)
+
+        async_cache: pcache.AsyncCache = AsyncCache()
+        executor: ThreadPoolExecutor = Executor()
+
+        # make sure our key is fresh
+        while async_cache.get_async(key, executor).result() is not None:
+            key = next(str_key_gen)
+
+        insert_1: Future[bool] = async_cache.insert_async(key, value, executor)
+        insert_2: Future[bool] = async_cache.insert_async(key, value, executor)
+
+        # only one insert should succeed
+        self.assertTrue(insert_1.result() ^ insert_2.result())
+        executor.shutdown()
+
+    @parametrize("AsyncCache", AsyncCaches)
+    def test_concurrent_get_insert(
+        self: Self,
+        AsyncCache: type[pcache.AsyncCache],
+        Executor: type[ThreadPoolExecutor] = ThreadPoolExecutor,
+    ) -> None:
+        key: str = next(str_key_gen)
+        value: bytes = next(bytes_value_gen)
+
+        async_cache: pcache.AsyncCache = AsyncCache()
+        executor: ThreadPoolExecutor = Executor()
+
+        # make sure our key is fresh
+        while async_cache.get_async(key, executor).result() is not None:
+            key = next(str_key_gen)
+
+        # try get first
+        get_1: Future[bytes | None] = async_cache.get_async(key, executor)
+        insert_1: Future[bool] = async_cache.insert_async(key, value, executor)
+
+        if get_1.result() is not None:
+            # if the get succeeded it should return the value stored by the insert
+            self.assertEqual(get_1.result(), value)
+
+        # either way the insert should succeed as the key is fresh
+        self.assertTrue(insert_1.result())
+
+        # make sure our key is fresh
+        while async_cache.get_async(key, executor).result() is not None:
+            key = next(str_key_gen)
+
+        # try insert first
+        insert_2: Future[bool] = async_cache.insert_async(key, value, executor)
+        get_2: Future[bytes | None] = async_cache.get_async(key, executor)
+
+        if get_2.result() is not None:
+            # if the get succeeded it should return the value stored by the insert
+            self.assertEqual(get_2.result(), value)
+
+        # either way the insert should succeed as the key is fresh
+        self.assertTrue(insert_2.result())
+
+        executor.shutdown()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/pcache.py
+++ b/torch/_inductor/pcache.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+from functools import cached_property
+from os import getenv
+from pathlib import Path
+from typing import Generic, TYPE_CHECKING, TypeVar
+from typing_extensions import override, Self
+
+from torch.utils._filelock import FileLock
+
+
+if TYPE_CHECKING:
+    from concurrent.futures import Future, ThreadPoolExecutor
+
+
+Key = TypeVar("Key")
+Value = TypeVar("Value")
+
+
+class Cache(Generic[Key, Value]):
+    """
+    Abstract base class for cache implementations.
+
+    Provides the interface for basic synchronous get and insert methods for storing and retrieving data.
+    Subclasses must implement both methods.
+
+    Note:
+        - Not guaranteed to be thread-safe.
+        - For asynchronous and thread-safe cache, see `AsyncCache`.
+
+    Methods:
+        get(key): Retrieve a value by key.
+        insert(key, value): Insert a value if the key does not already exist.
+    """
+
+    def get(self: Self, key: Key) -> Value | None:
+        """
+        Retrieve the value associated with the given key from the cache.
+
+        Args:
+            key (Key): The key used to query the cache.
+
+        Returns:
+            Value | None: The value associated with the key, or None if not found.
+
+        Raises:
+            NotImplementedError: If not implemented by a subclass.
+        """
+        raise NotImplementedError
+
+    def insert(self: Self, key: Key, value: Value) -> bool:
+        """
+        Store the given value in the cache with the associated key if the key does
+        not already exist in the cache, otherwise do nothing.
+
+        Args:
+            key (Key): The key to associate with the value.
+            value (Value): The value to be stored in the cache.
+
+        Returns:
+            bool: True if the value was stored successfully, False if the key already exists.
+
+        Raises:
+            NotImplementedError: If not implemented by a subclass.
+        """
+        raise NotImplementedError
+
+
+class InMemoryCache(Cache[str, bytes]):
+    """
+    In-memory cache implementation.
+
+    Stores cache data in a dictionary for fast lookups and insertions.
+    Not thread-safe.
+    """
+
+    def __init__(self: Self) -> None:
+        """
+        Initialize the in-memory cache.
+        """
+        self._cache: dict[str, bytes] = {}
+
+    @override
+    def get(self: Self, key: str) -> bytes | None:
+        """
+        Retrieve the value associated with the given key from the cache.
+
+        Args:
+            key (str): The key used to query the cache.
+
+        Returns:
+            bytes | None: The value associated with the key, or None if not found.
+        """
+        return self._cache.get(key)
+
+    @override
+    def insert(self: Self, key: str, value: bytes) -> bool:
+        """
+        Store the given value in the cache with the associated key if the key does
+        not already exist in the cache, otherwise do nothing.
+
+        Args:
+            key (str): The key to associate with the value.
+            value (bytes): The value to be stored in the cache.
+
+        Returns:
+            bool: True if the value was stored successfully, False if the key already exists.
+        """
+        if key in self._cache:
+            return False
+        self._cache[key] = value
+        return True
+
+    @classmethod
+    def from_env_var(cls, env_var: str) -> Self:
+        """
+        Create a new in-memory cache instance from an environment variable.
+
+        The environment variable should contain key-value pairs separated by ';',
+        with each pair formatted as 'key,value'. The value should be a string
+        representation of bytes (e.g., b'...').
+
+        Args:
+            env_var (str): The environment variable containing cache data.
+
+        Returns:
+            InMemoryCache: A new in-memory cache instance populated with data from the environment variable.
+
+        Raises:
+            ValueError: If a key is associated with two distinct values, or if the environment variable
+                is malformed (e.g., missing comma, value not a bytes string).
+        """
+        cache: Self = cls()
+        env_val: str | None = getenv(env_var, None)
+
+        if env_val is not None:
+            for kv_pair in env_val.split(";"):
+                if not kv_pair:
+                    # can happen if env_val is an empty string, or ends with ;
+                    continue
+                try:
+                    key, raw_value = kv_pair.split(",", 1)
+                except ValueError as err:
+                    raise ValueError(
+                        f"Malformed kv_pair {kv_pair!r} in env_var {env_var!r}, missing comma separator!"
+                    ) from err
+                # check that raw_value is a str repr of bytes
+                if (not raw_value.startswith("b'")) or (not raw_value.endswith("'")):
+                    raise ValueError(
+                        f"Malformed value {raw_value!r} in kv_pair {kv_pair!r}, expected b'...' format!"
+                    )
+                # remove b' prefix and ' suffix
+                str_value = raw_value[2:-1]
+                try:
+                    # make sure the value is legitimately encoded
+                    value = bytes([ord(char) for char in str_value])
+                except ValueError as err:
+                    raise ValueError(
+                        f"Malformed value {raw_value!r} in kv_pair {kv_pair!r}!"
+                    ) from err
+                # duplicates are ok, so long as the key does not point to two distinct values
+                if (not cache.insert(key, value)) and (cache.get(key) != value):
+                    raise ValueError(
+                        f"Duplicated values for key {key!r}, got {cache.get(key)!r} and {value!r}!"
+                    )
+
+        return cache
+
+
+class AsyncCache(Cache[Key, Value]):
+    """
+    Abstract base class for asynchronous, thread-safe cache implementations.
+
+    Provides synchronous get/insert methods and additional asynchronous (_async) methods
+    for concurrent access using a ThreadPoolExecutor. All methods are thread-safe.
+
+    Note:
+        - Use this class or its subclasses when thread safety or async access is required.
+        - The _async methods return concurrent.futures.Future objects.
+
+    Methods:
+        get(key): Retrieve a value by key.
+        get_async(key, executor): Asynchronously retrieve a value by key.
+        insert(key, value): Insert a value.
+        insert_async(key, value, executor): Asynchronously insert a value.
+    """
+
+    def get_async(
+        self: Self, key: Key, executor: ThreadPoolExecutor
+    ) -> Future[Value | None]:
+        """
+        Retrieve the value associated with the given key from the cache asynchronously.
+
+        Args:
+            key (Key): The key used to query the cache.
+            executor (ThreadPoolExecutor): The executor to use for asynchronous execution.
+
+        Returns:
+            Future[Value | None]: A Future representing the result of the asynchronous operation.
+        """
+        return executor.submit(self.get, key)
+
+    def insert_async(
+        self: Self, key: Key, value: Value, executor: ThreadPoolExecutor
+    ) -> Future[bool]:
+        """
+        Store the given value in the cache with the associated key if the key does
+        not already exist in the cache, otherwise do nothing, asynchronously.
+
+        Args:
+            key (Key): The key to associate with the value.
+            value (Value): The value to be stored in the cache.
+            executor (ThreadPoolExecutor): The executor to use for asynchronous execution.
+
+        Returns:
+            Future[bool]: A Future representing the result of the asynchronous operation.
+        """
+        return executor.submit(self.insert, key, value)
+
+
+class OnDiskCache(AsyncCache[str, bytes]):
+    """
+    Abstract base class for on-disk cache implementations.
+
+    Provides synchronous and asynchronous get/insert methods for storing and retrieving data on disk.
+    All methods are thread-safe.
+
+    Methods:
+        get(key): Retrieve a value by key from disk.
+        get_async(key, executor): Asynchronously retrieve a value by key from disk.
+        insert(key, value): Insert a value on disk.
+        insert_async(key, value, executor): Asynchronously insert a value on disk.
+    """
+
+    @property
+    def base_dir(self: Self) -> Path:
+        """
+        Get the base directory for the on-disk cache.
+
+        Returns:
+            Path: The base directory for the on-disk cache.
+
+        Raises:
+            NotImplementedError: If not implemented by a subclass.
+        """
+        raise NotImplementedError
+
+    def _fpath_from_key(self: Self, key: str) -> Path:
+        """
+        Get the file path associated with the given key.
+
+        Args:
+            key (str): The key used to query the cache.
+
+        Returns:
+            Path: The file path associated with the key.
+        """
+        return self.base_dir / key
+
+    def _flock_from_fpath(self: Self, fpath: Path) -> FileLock:
+        """
+        Get the file lock associated with the given file path.
+
+        Args:
+            fpath (Path): The file path to lock.
+
+        Returns:
+            FileLock: The file lock associated with the file path.
+        """
+        return FileLock(str(fpath) + ".lock")
+
+    @override
+    def get(self: Self, key: str) -> bytes | None:
+        """
+        Retrieve the value associated with the given key from the cache on disk.
+
+        Args:
+            key (str): The key used to query the cache.
+
+        Returns:
+            bytes | None: The value associated with the key, or None if not found.
+        """
+        fpath = self._fpath_from_key(key)
+        flock = self._flock_from_fpath(fpath)
+        with flock:
+            return fpath.read_bytes() if fpath.is_file() else None
+
+    @override
+    def insert(self: Self, key: str, value: bytes) -> bool:
+        """
+        Store the given value in the cache with the associated key on disk.
+
+        Args:
+            key (str): The key to associate with the value.
+            value (bytes): The value to be stored in the cache.
+
+        Returns:
+            bool: True if the value was stored successfully, False if the key already exists.
+        """
+        fpath = self._fpath_from_key(key)
+        flock = self._flock_from_fpath(fpath)
+        fpath.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            # "x" mode is exclusive creation, meaning the file will be created
+            # iff the file does not already exist (atomic w/o overwrite)
+            with flock as _, open(fpath, "xb") as fp:
+                fp.write(value)
+        except FileExistsError:
+            return False
+        return True
+
+
+class InductorOnDiskCache(OnDiskCache):
+    """
+    On-disk cache implementation for Inductor.
+
+    Uses the default cache directory provided by Inductor.
+    """
+
+    @cached_property
+    def base_dir(self: Self) -> Path:
+        """
+        Get the base directory for the on-disk cache.
+
+        Returns:
+            Path: The base directory for the on-disk cache.
+        """
+        from torch._inductor.runtime.runtime_utils import default_cache_dir
+
+        return Path(default_cache_dir(), "pcache")


### PR DESCRIPTION
Summary:
Implemented caching abstractions: `Cache` and `AsyncCache`.

`Cache` provides an abstraction for defining simple key -> value stores with get and put functionality. We propose using `Cache` for implementations with very low (microseconds) overhead, for example an in-memory cache.

`AsyncCache` provides an abstraction for defining simple key -> value stores with asynchronous get and put functionality. We propose using `AsyncCache` for implementations with medium to high (> millisecond) overhead, for example an on-disk cache.

We provide an initial extension of `Cache` in the form of `InMemoryCache`. `InMemoryCache` provides fast, in-memory caching that can be later used to memoize more expensive cache accesses. `InMemoryCache` also provides a custom constructor `InMemoryCache.from_env_var` that can be used to pre-populate the in-memory cache, which will be helpful for enabling determinism in the future.

We also provides extensions of `AsyncCache`. `OnDiskCache` subclasses `AsyncCache` and serves as a generic on-disk caching implementation with atomic, write-once guarantees. `OnDiskCache` is semi-generic, allowing subclassing to alter the output directory. `InductorOnDiskCache` subclasses `OnDiskCache` to create an Inductor-specific on-disk cache that outputs to Inductor's default caching directory.

Test Plan:
`Cache` Tests:
1. Get -> Set -> Get
- Checks that `get(key)` returns `None` when `key` is not cached, and that after calling `put(key, value)` subsequent `get(key)` calls return `value`
2. Set -> Set
- Checks that with duplicated `set(key, value)` calls only the initial call is successful
3. From env var
- Checks that constructing an `InMemoryCache` from an environment variable works.

`AsyncCache` Tests:
1. Get -> Set -> Get
- Same as `Cache` test, but checks both with synchronous and asynchronous execution
2. Set -> Set
- Same as `Cache` test, but checks both with synchronous and asynchronous execution
3. Set -> Set Concurrent
- Checks that of two concurrent `set(key, value)` operations, only one passes

```
cd ~/fbsource/fbcode && buck test mode/opt //caffe2/test/inductor:pcache
```

 {F1981926248}

Rollback Plan:

Differential Revision: D82269762




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben