### PR TITLE
fix(mps): Handle non-contiguous tensors in linear op for v2.8.0

### DIFF
--- a/aten/src/ATen/native/mps/operations/Linear.mm
+++ b/aten/src/ATen/native/mps/operations/Linear.mm
@@ -115,11 +115,9 @@ Tensor _mps_linear(const Tensor& input, const Tensor& weight_arg, const std::opt
     return output;
   }
 
-
-
   // No-graph execution causes nonsense if these are non-contiguous.
- const bool is_contiguous = input.is_contiguous() && weight.is_contiguous() && bias.is_contiguous();
- if (is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS) && is_contiguous) {
+  const bool is_contiguous = input.is_contiguous() && weight.is_contiguous() && bias.is_contiguous();
+  if (is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS) && is_contiguous) {
     _mps_linear_nograph(input, weight, bias, output);
     // Squeeze last dim of 1D linear
     return weight_arg.dim() != 1 ? output : output.squeeze(-1);

--- a/aten/src/ATen/native/mps/operations/Linear.mm
+++ b/aten/src/ATen/native/mps/operations/Linear.mm
@@ -115,7 +115,11 @@ Tensor _mps_linear(const Tensor& input, const Tensor& weight_arg, const std::opt
     return output;
   }
 
-  if (is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS)) {
+
+
+  // No-graph execution causes nonsense if these are non-contiguous.
+ const bool is_contiguous = input.is_contiguous() && weight.is_contiguous() && bias.is_contiguous();
+ if (is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS) && is_contiguous) {
     _mps_linear_nograph(input, weight, bias, output);
     // Squeeze last dim of 1D linear
     return weight_arg.dim() != 1 ? output : output.squeeze(-1);


### PR DESCRIPTION
This PR fixes an issue where `torch.nn.functional.linear` produces incorrect numerical results on the MPS backend when the weight tensor is non-contiguous.

The fix is a backport of the solution from commit `ee0ec211914dfb0fc5e8c4f355fe76eafa91c276` on the main branch. It adds a check to ensure all input tensors are contiguous before using the fast no-graph implementation, falling back to the robust graph-based path if not.

Fixes #162730 
