### PR TITLE
[AOTI] raise PyTorchStreamWriter open failed error code on windows

### DIFF
--- a/caffe2/serialize/inline_container.cc
+++ b/caffe2/serialize/inline_container.cc
@@ -713,13 +713,13 @@ void PyTorchStreamWriter::setup(const string& file_name) {
   }
   if (!writer_func_) {
     valid("opening archive ", file_name.c_str());
-    file_stream_.exceptions(std::ios_base::failbit | std::ios_base::badbit);
     try {
+      file_stream_.exceptions(std::ios_base::failbit | std::ios_base::badbit);
       file_stream_.open(
           file_name,
           std::ofstream::out | std::ofstream::trunc | std::ofstream::binary);
     } catch (const std::ios_base::failure& e) {
-        CAFFE_THROW("open file failed with: ", e.what());
+        CAFFE_THROW("open file failed with: ", strerror(errno));
     }
 
     const std::string dir_name = parentdir(file_name);

--- a/caffe2/serialize/inline_container.cc
+++ b/caffe2/serialize/inline_container.cc
@@ -712,10 +712,15 @@ void PyTorchStreamWriter::setup(const string& file_name) {
     CAFFE_THROW("invalid file name: ", file_name);
   }
   if (!writer_func_) {
-    file_stream_.open(
-        file_name,
-        std::ofstream::out | std::ofstream::trunc | std::ofstream::binary);
     valid("opening archive ", file_name.c_str());
+    file_stream_.exceptions(std::ios_base::failbit | std::ios_base::badbit);
+    try {
+      file_stream_.open(
+          file_name,
+          std::ofstream::out | std::ofstream::trunc | std::ofstream::binary);
+    } catch (const std::ios_base::failure& e) {
+        CAFFE_THROW("open file failed with: ", e.what());
+    }
 
     const std::string dir_name = parentdir(file_name);
     if (!dir_name.empty()) {


### PR DESCRIPTION
When I debug AOTI UT: `TestAOTInductorPackage_cpu::test_add`.  I found it didn't output the verbose error code, when PyTorchStreamWriter open failed.

This PR add the verbose error code output for debug. Local test shows as below:
<img width="1124" height="653" alt="image" src="https://github.com/user-attachments/assets/01cb1a51-2982-4106-8b5b-c608ac26a075" />

The error code is 32, we can check the Windows error code 32 at https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499- 
```
ERROR_SHARING_VIOLATION
32 (0x20)
The process cannot access the file because it is being used by another process.
```

This issue is caused by the file is opened by another process. I fixed same issue in zip open as PR: https://github.com/pytorch/pytorch/pull/162617 But still no idea how to open file with shared access in `std::ofstream`. I will continue to researching it. 

cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10