### PR TITLE
[FakeTensor] Make view_copy meta copy-if-needed to match eager

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -2861,5 +2861,52 @@ class FakeTensorPreferDeviceType(TestCase):
                 self.assertTrue(isinstance(result, FakeTensor))
 
 
+class FakeTensorViewCopy(TestCase):
+    def test_expand_then_view_copy_matches_eager_mode(self):
+        x = torch.arange(7)
+        y = x.expand(12, 7)
+
+        # Eager baseline
+        eager = torch.ops.aten.view_copy.default(y, [84])
+        self.assertEqual(eager.shape, (84,))
+        self.assertIsNone(eager._base)  # non-aliasing
+
+        # FakeTensor behavior should match eager
+        with FakeTensorMode():
+            xf = torch.arange(7)
+            yf = xf.expand(12, 7)
+            fake = torch.ops.aten.view_copy.default(yf, [84])
+            self.assertEqual(fake.shape, (84,))
+            self.assertIsNone(fake._base)  # non-aliasing
+
+    def test_expand_then_view_still_not_allowed(self):
+        with FakeTensorMode():
+            xf = torch.arange(7)
+            yf = xf.expand(12, 7)
+            with self.assertRaisesRegex(
+                ValueError, "Cannot view a tensor with shape *"
+            ):
+                _ = yf.view(-1)
+
+    def test_expand_then_view_copy_unbacked_matches_eager_mode(self):
+        with torch.fx.experimental._config.patch(backed_size_oblivious=True):
+            with FakeTensorMode():
+                xf = torch.arange(7)
+                yf = xf.expand(12, 7)
+                fake = torch.ops.aten.view_copy.default(yf, [84])
+                self.assertEqual(fake.shape, (84,))
+                self.assertIsNone(fake._base)  # non-aliasing
+
+    def test_expand_then_view_unbacked_still_not_allowed(self):
+        with torch.fx.experimental._config.patch(backed_size_oblivious=True):
+            with FakeTensorMode():
+                xf = torch.arange(7)
+                yf = xf.expand(12, 7)
+                with self.assertRaisesRegex(
+                    ValueError, "Cannot view a tensor with shape *"
+                ):
+                    _ = yf.view(-1)
+
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -728,7 +728,7 @@ def _view_unbacked_meta(
     # as "materialize": clone the input to break aliasing, then reshape.
     if allow_copy:
         strides = make_contiguous_strides_for(shape)
-        return a.clone().as_strided(shape, strides)
+        return a.clone(memory_format=torch.contiguous_format).as_strided(shape, strides)
 
     msg = f"Cannot view a tensor with shape {a.shape} and strides {a.stride()} as a tensor with shape {shape}!"
     raise ValueError(msg)

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -656,6 +656,7 @@ def _view_unbacked_meta(
     a: torch.Tensor,
     shape: ShapeType | tuple[ShapeType],
     size_oblivious_enabled: bool = True,
+    allow_copy: bool = False,
 ) -> torch.Tensor:
     from torch._prims import view_of
     from torch.fx.experimental.symbolic_shapes import guard_or_false, sym_eq
@@ -719,7 +720,15 @@ def _view_unbacked_meta(
         torch.fx.experimental._config.backed_size_oblivious
         or _view_has_unbacked_input(a, shape)
     ):
-        return _view_unbacked_meta(a, shape, size_oblivious_enabled=False)
+        return _view_unbacked_meta(
+            a, shape, size_oblivious_enabled=False, allow_copy=allow_copy
+        )
+
+    # When allow_copy=True (i.e., view_copy), define unbacked semantics
+    # as "materialize": clone the input to break aliasing, then reshape.
+    if allow_copy:
+        strides = make_contiguous_strides_for(shape)
+        return a.clone().as_strided(shape, strides)
 
     msg = f"Cannot view a tensor with shape {a.shape} and strides {a.stride()} as a tensor with shape {shape}!"
     raise ValueError(msg)
@@ -755,14 +764,15 @@ def _view_meta(
     func: OpOverload,
     a: FakeTensor,
     *shape: Any,
+    allow_copy: bool = False,
 ) -> FakeTensor:
     if torch.fx.experimental._config.backed_size_oblivious or _view_has_unbacked_input(
         a, shape
     ):
-        return typing_cast(FakeTensor, _view_unbacked_meta(a, shape))
+        return typing_cast(FakeTensor, _view_unbacked_meta(a, shape, allow_copy=allow_copy))
     else:
         return typing_cast(
-            FakeTensor, torch._refs._reshape_view_helper(a, *shape, allow_copy=False)
+            FakeTensor, torch._refs._reshape_view_helper(a, *shape, allow_copy=allow_copy)
         )
 
 
@@ -774,7 +784,10 @@ def _view_meta_copy(
     *shape: IntLikeType,
     out: FakeTensor | None = None,
 ) -> FakeTensor:
-    result = _view_meta(fake_mode, func, a, *shape)
+    # view_copy is the non-aliasing counterpart of view. Eager may succeed on
+    # cases where a pure view is impossible (e.g. expand -> flatten) by
+    # materializing the result. Match eager by allowing copy-if-needed in meta.
+    result = _view_meta(fake_mode, func, a, *shape, allow_copy=True)
 
     if out is not None:
         return result

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -728,6 +728,7 @@ def _view_unbacked_meta(
     # as "materialize": clone the input to break aliasing, then reshape.
     if allow_copy:
         strides = make_contiguous_strides_for(shape)
+        # pyrefly: ignore[bad-return]
         return a.clone(memory_format=torch.contiguous_format).as_strided(shape, strides)
 
     msg = f"Cannot view a tensor with shape {a.shape} and strides {a.stride()} as a tensor with shape {shape}!"
@@ -769,10 +770,13 @@ def _view_meta(
     if torch.fx.experimental._config.backed_size_oblivious or _view_has_unbacked_input(
         a, shape
     ):
-        return typing_cast(FakeTensor, _view_unbacked_meta(a, shape, allow_copy=allow_copy))
+        return typing_cast(
+            FakeTensor, _view_unbacked_meta(a, shape, allow_copy=allow_copy)
+        )
     else:
         return typing_cast(
-            FakeTensor, torch._refs._reshape_view_helper(a, *shape, allow_copy=allow_copy)
+            FakeTensor,
+            torch._refs._reshape_view_helper(a, *shape, allow_copy=allow_copy),
         )
 
 


### PR DESCRIPTION
Eager `aten.view_copy` flattens broadcasted tensors by materializing when a view is not possible (e.g., expand -> flatten), returning a non-aliasing result. The FakeTensor meta kernel delegated to `_reshape_view_helper` with `allow_copy=False`, so the same call raised:

    x = torch.arange(7)
    y = x.expand(12, 7)  # strides (0, 1)
    aten.view_copy(y, [84])  # eager: OK, fake: ValueError

This change plumbs `allow_copy=True` for `aten.view_copy` in the FakeTensor impl while keeping `view` / `_unsafe_view` unchanged. This aligns FakeTensor with eager semantics.

Fixes #162817


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @chenyang78