### PR TITLE
[ROCm][SymmMem] re-enable UTs

### DIFF
--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -29,8 +29,8 @@ from torch.testing._internal.common_distributed import (
     MultiProcessTestCase,
     requires_multicast_support,
     skip_if_lt_x_gpu,
-    skip_if_rocm_multiprocess,
     skip_if_rocm_arch_multiprocess,
+    skip_if_rocm_multiprocess,
     skip_if_rocm_ver_lessthan_multiprocess,
 )
 from torch.testing._internal.common_utils import (
@@ -50,6 +50,7 @@ test_contexts = [nullcontext, _test_mode]
 # So that tests are written in device-agnostic way
 device_type = "cuda"
 device_module = torch.get_device_module(device_type)
+
 
 @skip_if_rocm_arch_multiprocess(MI200_ARCH)
 @instantiate_parametrized_tests
@@ -654,7 +655,7 @@ class SymmMemEmptySetDeviceTest(MultiProcessTestCase):
         del t
         self._verify_symmetric_memory(symm_mem_hdl)
 
-    @skip_if_rocm_ver_lessthan_multiprocess((7,0))
+    @skip_if_rocm_ver_lessthan_multiprocess((7, 0))
     @skip_if_lt_x_gpu(2)
     @parametrize("set_device", [True, False])
     def test_empty_strided_p2p_persistent(self, set_device: bool) -> None:

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -45,8 +45,6 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_TSAN,
     TEST_XPU,
     TestCase,
-    MI300_ARCH,
-    MI200_ARCH
 )
 from torch.testing._internal.distributed.multi_threaded_pg import (
     _install_threaded_pg,
@@ -427,6 +425,7 @@ def skip_if_rocm_multiprocess(func):
     """Skips a test for ROCm"""
     return unittest.skipIf(TEST_WITH_ROCM, TEST_SKIPS["skipIfRocm"].message)(func)
 
+
 def skip_if_rocm_arch_multiprocess(arch: tuple[str, ...]):
     """Skips a test for ROCm"""
     prop = torch.cuda.get_device_properties(0)
@@ -437,13 +436,18 @@ def skip_if_rocm_arch_multiprocess(arch: tuple[str, ...]):
 
     return unittest.skipIf(reason is not None, reason)
 
+
 def skip_if_rocm_ver_lessthan_multiprocess(version=None):
     reason = None
     if TEST_WITH_ROCM:
         rocm_version = str(torch.version.hip)
-        rocm_version = rocm_version.split("-", maxsplit=1)[0]    # ignore git sha
+        rocm_version = rocm_version.split("-", maxsplit=1)[0]  # ignore git sha
         rocm_version_tuple = tuple(int(x) for x in rocm_version.split("."))
-        if rocm_version_tuple is None or version is None or rocm_version_tuple < tuple(version):
+        if (
+            rocm_version_tuple is None
+            or version is None
+            or rocm_version_tuple < tuple(version)
+        ):
             reason = f"skip_if_rocm_ver_lessthan_multiprocess: ROCm {rocm_version_tuple} is available but {version} required"
 
         return unittest.skipIf(reason is not None, reason)

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -36,6 +36,7 @@ from torch.testing._internal.common_utils import (
     FILE_SCHEMA,
     find_free_port,
     IS_SANDCASTLE,
+    LazyVal,
     retry_on_connect_failures,
     skip_but_pass_in_sandcastle,
     skip_but_pass_in_sandcastle_if,
@@ -419,6 +420,23 @@ def requires_multicast_support():
         not has_multicast_support,
         "multicast support is not available",
     )
+
+
+def evaluate_platform_supports_symm_mem():
+    if TEST_WITH_ROCM:
+        arch_list = ["gfx942", "gfx950"]
+        for arch in arch_list:
+            if arch in torch.cuda.get_device_properties(0).gcnArchName:
+                return True
+    if TEST_CUDA:
+        return True
+
+    return False
+
+
+PLATFORM_SUPPORTS_SYMM_MEM: bool = LazyVal(
+    lambda: evaluate_platform_supports_symm_mem()
+)
 
 
 def skip_if_rocm_multiprocess(func):

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -45,6 +45,8 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_TSAN,
     TEST_XPU,
     TestCase,
+    MI300_ARCH,
+    MI200_ARCH
 )
 from torch.testing._internal.distributed.multi_threaded_pg import (
     _install_threaded_pg,
@@ -423,15 +425,28 @@ def requires_multicast_support():
 
 def skip_if_rocm_multiprocess(func):
     """Skips a test for ROCm"""
-    func.skip_if_rocm_multiprocess = True
+    return unittest.skipIf(TEST_WITH_ROCM, TEST_SKIPS["skipIfRocm"].message)(func)
 
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        if not TEST_WITH_ROCM:
-            return func(*args, **kwargs)
-        sys.exit(TEST_SKIPS["skipIfRocm"].exit_code)
+def skip_if_rocm_arch_multiprocess(arch: tuple[str, ...]):
+    """Skips a test for ROCm"""
+    prop = torch.cuda.get_device_properties(0)
+    arch_match = prop.gcnArchName.split(":")[0] in arch
+    reason = None
+    if TEST_WITH_ROCM and arch_match:
+        reason = f"skip_if_rocm_arch_multiprocess: test skipped on {arch}"
 
-    return wrapper
+    return unittest.skipIf(reason is not None, reason)
+
+def skip_if_rocm_ver_lessthan_multiprocess(version=None):
+    reason = None
+    if TEST_WITH_ROCM:
+        rocm_version = str(torch.version.hip)
+        rocm_version = rocm_version.split("-", maxsplit=1)[0]    # ignore git sha
+        rocm_version_tuple = tuple(int(x) for x in rocm_version.split("."))
+        if rocm_version_tuple is None or version is None or rocm_version_tuple < tuple(version):
+            reason = f"skip_if_rocm_ver_lessthan_multiprocess: ROCm {rocm_version_tuple} is available but {version} required"
+
+        return unittest.skipIf(reason is not None, reason)
 
 
 def skip_if_win32():

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -102,7 +102,7 @@ except ImportError:
 
 
 MI300_ARCH = ("gfx942",)
-
+MI200_ARCH = ("gfx90a")
 
 def freeze_rng_state(*args, **kwargs):
     return torch.testing._utils.freeze_rng_state(*args, **kwargs)


### PR DESCRIPTION
After the UT suite moved to `MultiProcContinuousTest`, `skipIfRocm` decorator started failing rather than skipping UTs because now we spawn multiple threads before the skip decorator is taken into account and the skip decorator was raising an exception to exit the process. But, the parent process treated the child process exiting as a crash rather than a skip. Additionally, in `MultiProcContinuousTest`, if one UT fails all subsequent ones are also skipped which makes sense since there's one setup for the entire suite. However, this showed up as many failing/skipped UTs in the parity.

I added multiprocess version of skip decorators for ROCm, including, `skip_if_rocm_arch_multiprocess` and
`skip_if_rocm_ver_lessthan_multiprocess`. These are needed as symmetric memory feature is only supported on MI300 onwards and we need to skip them for other archs and some UTs only work after ROCm7.0.

Fixes #161249
Fixes #161187
Fixes #161078
Fixes #160989
Fixes #160881
Fixes #160768
Fixes #160716
Fixes #160665
Fixes #160621
Fixes #160549
Fixes #160506
Fixes #160445
Fixes #160347
Fixes #160203
Fixes #160177
Fixes #160049
Fixes #159921
Fixes #159764
Fixes #159643
Fixes #159499
Fixes #159397
Fixes #159396
Fixes #159347
Fixes #159067
Fixes #159066
Fixes #158916
Fixes #158760
Fixes #158759
Fixes #158422
Fixes #158138
Fixes #158136
Fixes #158135

Fixes #ISSUE_NUMBER


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @ezyang @msaroufim @dcci @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd