### PR TITLE
[ROCm] enable aoti tests, forward fix 162353

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -551,8 +551,10 @@ if(USE_CUDA OR USE_ROCM)
 endif()
 
 if(USE_CUDA)
-  # eventually do rocm
   append_filelist("libtorch_nativert_cuda_sources" Caffe2_GPU_SRCS)
+endif()
+if(USE_ROCM)
+  append_filelist("libtorch_nativert_cuda_sources" Caffe2_HIP_SRCS)
 endif()
 
 if(USE_CUDA)

--- a/test/cpp/nativert/CMakeLists.txt
+++ b/test/cpp/nativert/CMakeLists.txt
@@ -48,7 +48,7 @@ set(NATIVERT_TEST_SRCS
   ${TORCH_ROOT}/torch/csrc/inductor/aoti_torch/oss_proxy_executor.cpp
 )
 
-if(USE_CUDA)
+if(USE_CUDA OR USE_ROCM)
   list(APPEND NATIVERT_TEST_SRCS ${TORCH_ROOT}/torch/nativert/executor/triton/CudaTritonKernelManager.cpp)
   list(APPEND NATIVERT_TEST_SRCS ${TORCH_ROOT}/torch/nativert/executor/AOTInductorModelContainerCudaShim.cpp)
 endif()

--- a/test/cpp/nativert/test_aoti_model_container_registration.cpp
+++ b/test/cpp/nativert/test_aoti_model_container_registration.cpp
@@ -8,7 +8,7 @@ using namespace torch::nativert;
 TEST(AOTIModelContainerRegistrationTests, TestRegister) {
   EXPECT_TRUE(AOTIModelContainerRunnerRegistry()->Has(at::kCPU));
 
-#ifdef USE_CUDA
+#if defined(USE_CUDA) || defined(USE_ROCM)
   EXPECT_TRUE(AOTIModelContainerRunnerRegistry()->Has(at::kCUDA));
 #else
   EXPECT_FALSE(AOTIModelContainerRunnerRegistry()->Has(at::kCUDA));


### PR DESCRIPTION
Forward fix for tests added by #162353.  Enables aoti tests on rocm.

cc @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd