### PR TITLE
[DCP] Add timeout for checkpoint background process join

### DIFF
--- a/torch/distributed/checkpoint/_async_process_executor.py
+++ b/torch/distributed/checkpoint/_async_process_executor.py
@@ -113,9 +113,16 @@ class _AsyncCheckpointProcess:
 
     def __del__(self) -> None:
         if self._save_process.is_alive():
-            logger.info("Terminating the checkpoint background process...")
-            self._send(_CheckpointSaveProcessControlOpts.TERMINATE)
-            self._save_process.join()
+            try:
+                logger.info("Terminating the checkpoint background process.")
+                self._send(_CheckpointSaveProcessControlOpts.TERMINATE)
+                self._save_process.join(timeout=5)
+            finally:
+                if self._save_process.is_alive():
+                    logger.warning(
+                        "Checkpoint background process is still alive after termination request. Sending SIGTERM."
+                    )
+                    self._save_process.terminate()
 
     def _send(self, data: Any) -> None:
         self._process_pipe.send(data)


### PR DESCRIPTION
Summary:
Cleaning up checkpoint background process can currently block trainer thread indefinitely if the process is hanging (notably due to Gloo pg init timeout).

This diff adds a 5s grace period for normal termination and sends SIGTERM if unable to shut down in that period.

Rollback Plan:

Differential Revision: D82268979




cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci