### PR TITLE
[BE] Add Documentation for Device APIs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -210,10 +210,6 @@ templates_path = [
 coverage_ignore_functions = [
     # torch
     "typename",
-    # torch.cuda
-    "check_error",
-    "cudart",
-    "is_bf16_supported",
     # torch.cuda._sanitizer
     "zip_arguments",
     "zip_by_key",

--- a/docs/source/cuda.md
+++ b/docs/source/cuda.md
@@ -15,6 +15,7 @@
 
     StreamContext
     can_device_access_peer
+    check_error
     current_blas_handle
     current_device
     current_stream
@@ -34,6 +35,7 @@
     init
     ipc_collect
     is_available
+    is_bf16_supported
     is_initialized
     is_tf32_supported
     memory_usage

--- a/docs/source/mtia.md
+++ b/docs/source/mtia.md
@@ -22,6 +22,7 @@ The MTIA backend is implemented out of the tree, only interfaces are be defined 
     device_count
     init
     is_available
+    is_bf16_supported
     is_initialized
     memory_stats
     get_device_capability

--- a/docs/source/xpu.md
+++ b/docs/source/xpu.md
@@ -25,6 +25,7 @@
     get_stream_from_external
     init
     is_available
+    is_bf16_supported
     is_initialized
     set_device
     set_stream

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -500,7 +500,7 @@ class CudaError(RuntimeError):
 
 
 def check_error(res: int) -> None:
-    r"""Raise an error if the result of a CUDA runtime API call is not sucess."""
+    r"""Raise an error if the result of a CUDA runtime API call is not success."""
     if res != _cudart.cudaError.success:
         raise CudaError(res)
 

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -500,6 +500,7 @@ class CudaError(RuntimeError):
 
 
 def check_error(res: int) -> None:
+    r"""Raise an error if the result of a CUDA runtime API call is not sucess."""
     if res != _cudart.cudaError.success:
         raise CudaError(res)
 

--- a/torch/mtia/__init__.py
+++ b/torch/mtia/__init__.py
@@ -205,6 +205,7 @@ def attach_out_of_memory_observer(
 
 
 def is_bf16_supported(including_emulation: bool = True):
+    r"""Return a bool indicating if the current MTIA device supports dtype bfloat16."""
     return True
 
 


### PR DESCRIPTION
Added documentation for torch.cuda APIs. 
Fixed docstring for xpu and mtia is_bf16_supported API.

