### PR TITLE
[lint][CI] Don't checkout submodules for lintrunner-noclang

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -105,7 +105,7 @@ jobs:
       # NB: A shallow checkout won't work here because calculate-docker-image requires a full checkout
       # to run git rev-parse HEAD~:.ci/docker when a new image is needed
       fetch-depth: 0
-      submodules: true
+      submodules: false
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
         CHANGED_FILES="${{ needs.get-changed-files.outputs.changed-files }}"


### PR DESCRIPTION
Shouldn't be needed?
