### PR TITLE
unskip tests blocked by py3.12

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1628,18 +1628,6 @@ def get_selected_tests(options) -> list[str]:
     if torch.version.cuda is not None:
         options.exclude.extend(["distributions/test_constraints"])
 
-    # these tests failing in Python 3.12 temporarily disabling
-    if sys.version_info >= (3, 12):
-        options.exclude.extend(
-            [
-                "functorch/test_dims",
-                "functorch/test_rearrange",
-                "functorch/test_parsing",
-                "functorch/test_memory_efficient_fusion",
-                "torch_np/numpy_tests/core/test_multiarray",
-            ]
-        )
-
     if sys.version_info[:2] < (3, 13):
         # Skip tests for older Python versions as they may use syntax or features
         # not supported in those versions


### PR DESCRIPTION
Skipped by #117853.  Let's see if the situation has improved since Feb 2024.