### PR TITLE
[ONNX] Fix rotary_embedding_23 implementation

### DIFF
--- a/test/onnx/ops/test_ops.py
+++ b/test/onnx/ops/test_ops.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import onnx_ir.passes.common as common_passes
-from onnxscript import ir
 import onnxruntime
+from onnxscript import ir
 from packaging import version
 
 import torch
@@ -480,7 +480,7 @@ class NativeOnnxOpsTest(common_utils.TestCase):
 
     def test_rotary_embedding_opcheck(self):
         input_data = torch.rand(2, 3, 4, 8)
-        position_ids_data = torch.randint(0, 50, (2, 3)).long()
+        position_ids_data = torch.randint(0, 50, (2, 4)).long()
         sin_cache_data = torch.rand(50, 4)
         cos_cache_data = torch.rand(50, 4)
 
@@ -491,7 +491,7 @@ class NativeOnnxOpsTest(common_utils.TestCase):
 
     def test_rotary_embedding(self):
         input_data = torch.rand(2, 3, 4, 8)
-        position_ids_data = torch.randint(0, 50, (2, 3)).long()
+        position_ids_data = torch.randint(0, 50, (2, 4)).long()
         sin_cache_data = torch.rand(50, 4)
         cos_cache_data = torch.rand(50, 4)
 

--- a/test/onnx/ops/test_ops.py
+++ b/test/onnx/ops/test_ops.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import onnx_ir.passes.common as common_passes
-import onnxruntime
 from onnxscript import ir
+import onnxruntime
 from packaging import version
 
 import torch
@@ -540,7 +540,7 @@ class NativeOnnxOpsTest(common_utils.TestCase):
 
     def test_rotary_embedding_3d(self):
         num_heads = 2
-        input_data = torch.rand(2, 3, 6)
+        input_data = torch.rand(2, 3, 8)
         sin_cache_data = torch.rand(2, 3, 4)
         cos_cache_data = torch.rand(2, 3, 4)
 

--- a/test/onnx/ops/test_ops.py
+++ b/test/onnx/ops/test_ops.py
@@ -541,8 +541,8 @@ class NativeOnnxOpsTest(common_utils.TestCase):
     def test_rotary_embedding_3d(self):
         num_heads = 2
         input_data = torch.rand(2, 3, 8)
-        sin_cache_data = torch.rand(2, 3, 4)
-        cos_cache_data = torch.rand(2, 3, 4)
+        sin_cache_data = torch.rand(2, 3, 2)
+        cos_cache_data = torch.rand(2, 3, 2)
 
         class Model(torch.nn.Module):
             def forward(self, input_data, cos_cache_data, sin_cache_data):

--- a/test/onnx/ops/test_ops.py
+++ b/test/onnx/ops/test_ops.py
@@ -439,7 +439,7 @@ class NativeOnnxOpsTest(common_utils.TestCase):
 
     def test_onnx_ops_can_be_decomposed_to_aten(self):
         input_data = torch.rand(2, 3, 4, 8)
-        position_ids_data = torch.randint(0, 50, (2, 3)).long()
+        position_ids_data = torch.randint(0, 50, (2, 4)).long()
         sin_cache_data = torch.rand(50, 4)
         cos_cache_data = torch.rand(50, 4)
 

--- a/torch/onnx/ops/_impl.py
+++ b/torch/onnx/ops/_impl.py
@@ -79,13 +79,13 @@ def rotary_embedding_23(
         )
         torch._check(
             cos_cache.dim() == 2 and sin_cache.dim() == 2,
-            lambda: "cos_cache/sin_cache must be 2D (sequence_length, head_half) when position_ids is provided. "
+            lambda: "cos_cache/sin_cache must be 2D when position_ids is provided. "
             f"Received cos_cache shape {cos_cache.shape}, sin_cache shape {sin_cache.shape}",
         )
     else:
         torch._check(
             cos_cache.dim() == 3 and sin_cache.dim() == 3,
-            lambda: "cos_cache/sin_cache must be 3D (batch, sequence_length, head_half) when position_ids is not provided",
+            lambda: "cos_cache/sin_cache must be 3D when position_ids is not provided",
         )
 
     # First ensure x has shape [batch_size, num_heads, seq_len, head_size]

--- a/torch/onnx/ops/_impl.py
+++ b/torch/onnx/ops/_impl.py
@@ -85,7 +85,8 @@ def rotary_embedding_23(
     else:
         torch._check(
             cos_cache.dim() == 3 and sin_cache.dim() == 3,
-            lambda: "cos_cache/sin_cache must be 3D when position_ids is not provided",
+            lambda: "cos_cache/sin_cache must be 3D when position_ids is not provided. "
+            f"Received cos_cache shape {cos_cache.shape}, sin_cache shape {sin_cache.shape}",
         )
 
     # First ensure x has shape [batch_size, num_heads, seq_len, head_size]

--- a/torch/onnx/ops/_impl.py
+++ b/torch/onnx/ops/_impl.py
@@ -56,6 +56,29 @@ def rotary_embedding_23(
     rotary_embedding_dim: int = 0,
 ) -> torch.Tensor:
     """RotaryEmbedding-23 https://onnx.ai/onnx/operators/onnx__RotaryEmbedding.html#rotaryembedding-23"""
+    if position_ids is None:
+        torch._check(
+            len(cos_cache.shape) == 3,
+            lambda: f"cos_cache must be 3D when position_ids is not provided. Received shape: {cos_cache.shape}",
+        )
+        torch._check(
+            len(sin_cache.shape) == 3,
+            lambda: f"sin_cache must be 3D when position_ids is not provided. Received shape: {sin_cache.shape}",
+        )
+    else:
+        torch._check(
+            len(cos_cache.shape) == 2,
+            lambda: f"cos_cache must be 2D when position_ids is provided. Received shape: {cos_cache.shape}",
+        )
+        torch._check(
+            len(sin_cache.shape) == 2,
+            lambda: f"sin_cache must be 2D when position_ids is provided. Received shape: {sin_cache.shape}",
+        )
+        torch._check(
+            len(position_ids.shape) == 2,
+            lambda: f"position_ids must be 2D when provided. Received shape: {position_ids.shape}",
+        )
+
     # x has shape (batch_size, num_heads, sequence_length, head_size)
     # or (batch_size, sequence_length, hidden_size)
     input_shape = x.shape

--- a/torch/onnx/ops/_impl.py
+++ b/torch/onnx/ops/_impl.py
@@ -66,8 +66,8 @@ def rotary_embedding_23(
     # First ensure x has shape [batch_size, num_heads, seq_len, head_size]
     # So that the rotation logic can be shared with reshaped 3D inputs
     if input_rank == 4:
-        # Reshape from (batch_size, num_heads, sequence_length, head_size)
-        # to [batch_size, num_heads, seq_len, head_size]
+        # Reshape from (batch_size, num_heads, seq_len, head_size)
+        # to [batch_size, seq_len, num_heads, head_size]
         x = torch.permute(x, (0, 2, 1, 3))
     elif input_rank == 3:
         torch._check(

--- a/torch/onnx/ops/_impl.py
+++ b/torch/onnx/ops/_impl.py
@@ -67,20 +67,20 @@ def rotary_embedding_23(
     if position_ids is not None:
         torch._check(
             position_ids.dim() == 2,
-            lambda: f"position_ids must be 2D when provided. Got {position_ids.shape}",
+            lambda: f"position_ids must be 2D when provided. Received shape {position_ids.shape}",
         )
         torch._check(
             position_ids.shape[0] == batch_size,
-            lambda: f"position_ids first dim (batch) must match x.batch_size ({batch_size}). Got {position_ids.shape[0]}",
+            lambda: f"position_ids first dim (batch) must match x.shape[0] ({batch_size}). Received {position_ids.shape[0]}",
         )
         torch._check(
             position_ids.shape[1] == sequence_length,
-            lambda: f"position_ids second dim (sequence) must match x.sequence_length ({sequence_length}). Got {position_ids.shape[1]}",
+            lambda: f"position_ids second dim (sequence) must match x.shape[-2] ({sequence_length}). Received {position_ids.shape[1]}",
         )
         torch._check(
             cos_cache.dim() == 2 and sin_cache.dim() == 2,
             lambda: "cos_cache/sin_cache must be 2D (sequence_length, head_half) when position_ids is provided. "
-            f"Got cos_cache shape {cos_cache.shape}, sin_cache shape {sin_cache.shape}",
+            f"Received cos_cache shape {cos_cache.shape}, sin_cache shape {sin_cache.shape}",
         )
     else:
         torch._check(
@@ -130,6 +130,10 @@ def rotary_embedding_23(
     torch._check(
         cos.shape[0] == batch_size and cos.shape[1] == sequence_length,
         lambda: f"cos has shape {cos.shape} but expected (batch={batch_size}, seq={sequence_length}, ...)",
+    )
+    torch._check(
+        sin.shape[0] == batch_size and sin.shape[1] == sequence_length,
+        lambda: f"sin has shape {sin.shape} but expected (batch={batch_size}, seq={sequence_length}, ...)",
     )
 
     cos = cos[

--- a/torch/onnx/ops/_impl.py
+++ b/torch/onnx/ops/_impl.py
@@ -124,8 +124,8 @@ def rotary_embedding_23(
             position_ids
         ]  # Shape: [batch_size, sequence_length, head_size/2]
     else:
-        cos = cos_cache
-        sin = sin_cache
+        cos = cos_cache  # Shape: [batch_size, sequence_length, rotary_embedding_dim/2]
+        sin = sin_cache  # Shape: [batch_size, sequence_length, rotary_embedding_dim/2]
 
     torch._check(
         cos.shape[0] == batch_size and cos.shape[1] == sequence_length,
@@ -135,13 +135,14 @@ def rotary_embedding_23(
         sin.shape[0] == batch_size and sin.shape[1] == sequence_length,
         lambda: f"sin has shape {sin.shape} but expected (batch={batch_size}, seq={sequence_length}, ...)",
     )
-
-    cos = cos[
-        :, :, :rotary_embedding_dim_half
-    ]  # Shape: [batch_size, sequence_length, rotary_embedding_dim/2]
-    sin = sin[
-        :, :, :rotary_embedding_dim_half
-    ]  # Shape: [batch_size, sequence_length, rotary_embedding_dim/2]
+    torch._check(
+        cos.shape[-1] == rotary_embedding_dim_half,
+        lambda: f"Last dimension of cos cache ({cos.shape[-1]}) should match rotary_embedding_dim/2 ({rotary_embedding_dim_half}).",
+    )
+    torch._check(
+        sin.shape[-1] == rotary_embedding_dim_half,
+        lambda: f"Last dimension of sin cache ({sin.shape[-1]}) should match rotary_embedding_dim/2 ({rotary_embedding_dim_half}).",
+    )
     cos = torch.unsqueeze(
         cos, 2
     )  # Shape: [batch_size, sequence_length, 1, rotary_embedding_dim/2]


### PR DESCRIPTION
The implementation of rotary_embedding_23 when input is 3D was incorrect.

## Tested

Locally with 

```py
import onnx_ir as ir
import onnx
import torch
import os
import numpy as np

base_path = "/home/justinchu/dev/onnx/onnx/backend/test/data/node"
test_names = [
    "test_rotary_embedding",
    "test_rotary_embedding_3d_input",
    "test_rotary_embedding_interleaved",
    "test_rotary_embedding_no_position_ids",
    "test_rotary_embedding_no_position_ids_interleaved",
    "test_rotary_embedding_no_position_ids_rotary_dim",
    "test_rotary_embedding_with_interleaved_rotary_dim",
    "test_rotary_embedding_with_rotary_dim",
]
model_paths = [os.path.join(base_path, name) for name in test_names]


for path in model_paths:
    print(f"Checking {path} for issues...")

    model = onnx.load(os.path.join(path, "model.onnx"))
    input0 = ir.from_proto(
        onnx.load_tensor(os.path.join(path, "test_data_set_0", "input_0.pb"))
    ).numpy()
    input1 = ir.from_proto(
        onnx.load_tensor(os.path.join(path, "test_data_set_0", "input_1.pb"))
    ).numpy()
    input2 = ir.from_proto(
        onnx.load_tensor(os.path.join(path, "test_data_set_0", "input_2.pb"))
    ).numpy()
    if os.path.exists(os.path.join(path, "test_data_set_0", "input_3.pb")):
        input3 = ir.from_proto(
            onnx.load_tensor(os.path.join(path, "test_data_set_0", "input_3.pb"))
        ).numpy()
    else:
        input3 = None
    output0 = ir.from_proto(
        onnx.load_tensor(os.path.join(path, "test_data_set_0", "output_0.pb"))
    ).numpy()

    m = ir.from_proto(model)

    node = m.graph[-1]
    print(node)
    assert node.op_type == "RotaryEmbedding"

    interleaved = node.attributes.get_int("interleaved", 0)
    num_heads = node.attributes.get_int("num_heads", 0)
    rotary_embedding_dim = node.attributes.get_int("rotary_embedding_dim", 0)

    torch_out = torch.onnx.ops.rotary_embedding(
        torch.tensor(input0),
        torch.tensor(input1),
        torch.tensor(input2),
        position_ids=torch.tensor(input3) if input3 is not None else None,
        interleaved=bool(interleaved),
        num_heads=num_heads,
        rotary_embedding_dim=rotary_embedding_dim,
    )
    torch_out = torch_out.detach().cpu().numpy()
    np.testing.assert_allclose(torch_out, output0)
```

Fix https://github.com/pytorch/pytorch/issues/162848

cc @titaiwangms @kunal-vaishnavi