### PR TITLE
Do not use // but use CleanDiv or FloorDiv instead

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -282,6 +282,21 @@ class TestPySymInt(TestCase):
         c = create_symbool(shape_env, True)
         self.assertIs(sympy.sympify(c), c.node.expr)
 
+    def test_trunc_int_div_true(self):
+        @torch.compile(backend="inductor", dynamic=True, fullgraph=True)
+        def f(x, s13, s57, s77):
+            torch._check(s13 >= 0)
+            torch._check(s57 >= 0)
+            torch._check(s77 >= 0)
+            if int(s13 * ((s57 // s13) + (s77 // s13)) / s13) >= 1:
+                return x * 2
+            else:
+                return x * 100
+
+        # ensure we compile this with no errors.
+        x = torch.rand(10)
+        f(x, 4, 4096, 3920)
+
     def test_roundtrip(self):
         shape_env = ShapeEnv()
         x = create_symbolic_tensor("x", torch.randn(5, 4, 3), shape_env)

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -6251,7 +6251,6 @@ class ShapeEnv:
         hint for the particular hint values of backed and unbacked SymInts,
         e.g., if s0 happens to be 3 this run, compute_hint will substitute s0 with 3.
         """
-
         # axioms with compute hint NYE
         assert not compute_hint or not axioms
         expr = self.simplify(expr, size_oblivious)
@@ -6393,7 +6392,10 @@ class ShapeEnv:
                 if isinstance(atom.args[0], IntTrueDiv):
                     base, divisor = atom.args[0].args
                     if base % divisor == 0:
-                        trunc_replacements[atom] = base // divisor
+                        trunc_replacements[atom] = CleanDiv(base, divisor)
+                    else:
+                        # TruncToInt(IntTrueDiv(a,b)) == FloorDiv(a, b)
+                        trunc_replacements[atom] = FloorDiv(base, divisor)
             if trunc_replacements:
                 expr = expr.xreplace(trunc_replacements)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #162867

When operating rewriting sympy expressions in the compiler code base we want to generate
FloorDiv(a, b) CleanDiv(a, b) directly and not a//b. since the later become floor(a*pow(b, -1))

For symnodes we automatically handle that conversions in the symnode op dispatch. 

I will follow up with an issue to track all other usages of //.

Block internal Model. 

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv