### PR TITLE
[MPS] Do not explicit wait for sync

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -382,7 +382,7 @@ cmake==4.0.0
 tlparse==0.4.0
 #Description: required for log parsing
 
-cuda-bindings>=12.0,<13.0 ; platform_machine != "s390x"
+cuda-bindings>=12.0,<13.0 ; platform_machine != "s390x" and sys_platform != "darwin"
 #Description: required for testing CUDAGraph::raw_cuda_graph(). See https://nvidia.github.io/cuda-python/cuda-bindings/latest/support.html for how this version was chosen. Note "Any fix in the latest bindings would be backported to the prior major version" means that only the newest version of cuda-bindings will get fixes. Depending on the latest version of 12.x is okay because all 12.y versions will be supported via "CUDA minor version compatibility". Pytorch builds against 13.z versions of cuda toolkit work with 12.x versions of cuda-bindings as well because newer drivers work with old toolkits.
 #test that import: test_cuda.py
 

--- a/aten/src/ATen/mps/MPSEvent.mm
+++ b/aten/src/ATen/mps/MPSEvent.mm
@@ -226,8 +226,7 @@ double MPSEventPool::elapsedTime(id_t start_event_id, id_t end_event_id) {
   std::lock_guard<std::recursive_mutex> lock(m_mutex);
   MPSEvent* start_event = getInUseEvent(start_event_id, false);
   MPSEvent* end_event = getInUseEvent(end_event_id, false);
-  // the notify is called on a separate thread, so this waits for that
-  end_event->waitForCpuSync();
+
   const uint64_t start_time = start_event->getCompletionTime();
   const uint64_t end_time = end_event->getCompletionTime();
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7675,7 +7675,9 @@ class TestMPS(TestCaseMPS):
         x = net1(x)
         torch.mps.profiler.stop()
 
-    def test_mps_event_module(self):
+    @parametrize("sync_start", [True, False])
+    @parametrize("sync_end", [True, False])
+    def test_mps_event_module(self, sync_start, sync_end):
         startEvent = torch.mps.Event(enable_timing=True)
         startEvent.record()
         net1 = torch.nn.ConvTranspose2d(128, 64, kernel_size=3, stride=2, padding=1, output_padding=1)\
@@ -7684,6 +7686,10 @@ class TestMPS(TestCaseMPS):
         x = net1(x)
         endEvent = torch.mps.Event(enable_timing=True)
         endEvent.record()
+        if sync_start:
+            startEvent.synchronize()
+        if sync_end:
+            endEvent.synchronize()
         elapsedTime = startEvent.elapsed_time(endEvent)
         self.assertGreater(elapsedTime, 0.0)
 


### PR DESCRIPTION
Fixes #162872

The deleted line was waiting for this notify:

https://github.com/pytorch/pytorch/blob/aa41d3e49cbfef8117693ab80ec1ad57accfcb41/aten/src/ATen/mps/MPSEvent.mm#L28

But when we explicitly sync stream as in #162872, this will trigger a dead lock as no other threads will notify.

I think users are responsible for syncing, not here. Or we can add a full sync here, not just a wait.