### PR TITLE
[NVRTC] Enable compiling templated kernels

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -1772,12 +1772,10 @@ def _compile_kernel(
         >>> c = torch.empty_like(a)
         >>> add_kernel(grid=(4, 1, 1), block=(256, 1, 1), args=[a, b, c, a.numel()])
     """
-    import ctypes
-
     from torch.cuda._utils import _cuda_load_module, _nvrtc_compile
 
     # Compile the kernel to PTX
-    ptx = _nvrtc_compile(
+    ptx, mangled_name = _nvrtc_compile(
         kernel_source,
         kernel_name,
         compute_capability,
@@ -1787,14 +1785,14 @@ def _compile_kernel(
     )
 
     # Load the module and get the kernel
-    result = _cuda_load_module(ptx, [kernel_name])
+    result = _cuda_load_module(ptx, [mangled_name])
 
     if isinstance(result, dict):
-        return result[kernel_name]
+        return result[mangled_name]
     else:
         # This branch shouldn't be executed if kernel_names is provided,
         # but MyPy needs this to understand type narrowing
-        return getattr(result, kernel_name)
+        return getattr(result, mangled_name)
 
 
 from . import amp, jiterator, nvtx, profiler, sparse, tunable

--- a/torch/cuda/_utils.py
+++ b/torch/cuda/_utils.py
@@ -239,7 +239,9 @@ def _nvrtc_compile(
 
     # Get mangled name
     c_mangled_name = ctypes.c_char_p()
-    check_nvrtc(libnvrtc.nvrtcGetLoweredName(prog, c_kernel_name, ctypes.byref(c_mangled_name)))
+    check_nvrtc(
+        libnvrtc.nvrtcGetLoweredName(prog, c_kernel_name, ctypes.byref(c_mangled_name))
+    )
     if c_mangled_name.value is not None:
         mangled_name = c_mangled_name.value.decode()  # make a copy
     else:

--- a/torch/cuda/_utils.py
+++ b/torch/cuda/_utils.py
@@ -65,6 +65,8 @@ def _get_hiprtc_library() -> ctypes.CDLL:
     lib.nvrtcGetPTX = lib.hiprtcGetCode  # type: ignore[attr-defined]
     lib.nvrtcGetProgramLogSize = lib.hiprtcGetProgramLogSize  # type: ignore[attr-defined]
     lib.nvrtcGetProgramLog = lib.hiprtcGetProgramLog  # type: ignore[attr-defined]
+    lib.nvrtcAddNameExpression = lib.hiprtcAddNameExpression # type: ignore[attr-defined]
+    lib.nvrtcGetLoweredName = lib.hiprtcGetLoweredName  # type: ignore[attr-defined]
     return lib
 
 
@@ -235,6 +237,7 @@ def _nvrtc_compile(
     ptx = ctypes.create_string_buffer(ptx_size.value)
     check_nvrtc(libnvrtc.nvrtcGetPTX(prog, ptx))
 
+    # Get mangled name
     c_mangled_name = ctypes.c_char_p()
     check_nvrtc(libnvrtc.nvrtcGetLoweredName(prog, c_kernel_name, ctypes.byref(c_mangled_name)))
     mangled_name = c_mangled_name.value.decode()  # make a copy

--- a/torch/cuda/_utils.py
+++ b/torch/cuda/_utils.py
@@ -65,7 +65,7 @@ def _get_hiprtc_library() -> ctypes.CDLL:
     lib.nvrtcGetPTX = lib.hiprtcGetCode  # type: ignore[attr-defined]
     lib.nvrtcGetProgramLogSize = lib.hiprtcGetProgramLogSize  # type: ignore[attr-defined]
     lib.nvrtcGetProgramLog = lib.hiprtcGetProgramLog  # type: ignore[attr-defined]
-    lib.nvrtcAddNameExpression = lib.hiprtcAddNameExpression # type: ignore[attr-defined]
+    lib.nvrtcAddNameExpression = lib.hiprtcAddNameExpression  # type: ignore[attr-defined]
     lib.nvrtcGetLoweredName = lib.hiprtcGetLoweredName  # type: ignore[attr-defined]
     return lib
 
@@ -240,7 +240,10 @@ def _nvrtc_compile(
     # Get mangled name
     c_mangled_name = ctypes.c_char_p()
     check_nvrtc(libnvrtc.nvrtcGetLoweredName(prog, c_kernel_name, ctypes.byref(c_mangled_name)))
-    mangled_name = c_mangled_name.value.decode()  # make a copy
+    if c_mangled_name.value is not None:
+        mangled_name = c_mangled_name.value.decode()  # make a copy
+    else:
+        mangled_name = ""
 
     libnvrtc.nvrtcDestroyProgram(ctypes.byref(prog))
 

--- a/torch/cuda/_utils.py
+++ b/torch/cuda/_utils.py
@@ -1,6 +1,6 @@
 import ctypes
 import sys
-from typing import Any, Optional, Union, Tuple
+from typing import Any, Optional, Union
 
 import torch
 
@@ -115,7 +115,7 @@ def _nvrtc_compile(
     header_code: str = "",
     cuda_include_dirs: Optional[list] = None,
     nvcc_options: Optional[list] = None,
-) -> Tuple[bytes, str]:
+) -> tuple[bytes, str]:
     """
     Compiles a CUDA kernel using NVRTC and returns the PTX code.
 
@@ -151,10 +151,6 @@ def _nvrtc_compile(
                 else "Unknown CUDA error"
             )
             raise RuntimeError(f"CUDA error: {error_message}")
-
-    # Add 'extern "C"' if not already present to ensure C linkage
-    # if not kernel_source.strip().startswith('extern "C"'):
-    #     kernel_source = f'extern "C" {kernel_source}'
 
     # Combine header code and kernel source
     if header_code:

--- a/torch/cuda/_utils.py
+++ b/torch/cuda/_utils.py
@@ -1,6 +1,6 @@
 import ctypes
 import sys
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, Tuple
 
 import torch
 
@@ -115,7 +115,7 @@ def _nvrtc_compile(
     header_code: str = "",
     cuda_include_dirs: Optional[list] = None,
     nvcc_options: Optional[list] = None,
-) -> bytes:
+) -> Tuple[bytes, str]:
     """
     Compiles a CUDA kernel using NVRTC and returns the PTX code.
 
@@ -129,7 +129,7 @@ def _nvrtc_compile(
         nvcc_options (list, None): Additional options to pass to NVRTC
 
     Returns:
-        str: The compiled PTX code
+        Tuple[bytes, str]: The compiled PTX code and mangled kernel name
     """
     # Ensure CUDA is initialized
     import torch.cuda
@@ -153,8 +153,8 @@ def _nvrtc_compile(
             raise RuntimeError(f"CUDA error: {error_message}")
 
     # Add 'extern "C"' if not already present to ensure C linkage
-    if not kernel_source.strip().startswith('extern "C"'):
-        kernel_source = f'extern "C" {kernel_source}'
+    # if not kernel_source.strip().startswith('extern "C"'):
+    #     kernel_source = f'extern "C" {kernel_source}'
 
     # Combine header code and kernel source
     if header_code:
@@ -217,6 +217,10 @@ def _nvrtc_compile(
         )
     )
 
+    # Add kernel name, which can be a template expression
+    c_kernel_name = kernel_name.encode("utf-8")
+    check_nvrtc(libnvrtc.nvrtcAddNameExpression(prog, c_kernel_name))
+
     # Compile program
     res = libnvrtc.nvrtcCompileProgram(prog, num_options, options_array)
 
@@ -234,12 +238,18 @@ def _nvrtc_compile(
     check_nvrtc(libnvrtc.nvrtcGetPTXSize(prog, ctypes.byref(ptx_size)))
     ptx = ctypes.create_string_buffer(ptx_size.value)
     check_nvrtc(libnvrtc.nvrtcGetPTX(prog, ptx))
+
+    c_mangled_name = ctypes.c_char_p()
+    check_nvrtc(libnvrtc.nvrtcGetLoweredName(prog, c_kernel_name, ctypes.byref(c_mangled_name)))
+    mangled_name = c_mangled_name.value.decode()  # make a copy
+
     libnvrtc.nvrtcDestroyProgram(ctypes.byref(prog))
 
     # For HIP, hipRTC generates raw CO binaries instead of PTX,
     # and for some reason, ".value" causes the string to be truncated,
     # likely due to the presence of '\0' in the string. So we use .raw instead.
-    return ptx.raw if torch.version.hip else ptx.value
+    ptx_bytes = ptx.raw if torch.version.hip else ptx.value
+    return ptx_bytes, mangled_name
 
 
 class _CudaModule:


### PR DESCRIPTION
Per NVRTC doc - https://docs.nvidia.com/cuda/nvrtc/index.html#accessing-lowered-names, we can compile a templated kernel (e.g. `kernel<float>`) with the following steps

NVRTC side
- (new) `nvrtcAddNameExpression` -> C++ template e.g. `f<float>`
- `nvrtcCompileProgram`
- (new) `nvrtcGetLoweredName` -> get mangled name. need to do a copy since later this string is freed after NVRTC program is destroyed
- `nvrtcDestroyProgram`

CUDA side
- use mangled name instead of normal name -> profit
- `extern "C"` is not even needed

cc @msaroufim 