### PR TITLE
Enable computing Hessian matrices of larger functions by chunking in torch.func.hessian via jacrev

### DIFF
--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -2507,10 +2507,12 @@ class TestHessian(TestCase):
         def f(x, y):
             return (x.sin() * (x + y)).sum()
 
+        def foo(inputs):
+            return f(*inputs)
+
         x = torch.randn(10, 2, device=device)
         y = torch.randn(1, 2, device=device)
         inputs = (x, y)
-        foo = lambda inputs: f(*inputs)
 
         for chunk_size in (1, 2, 3, 4, 7, 10, 1000):
             expected = torch.autograd.functional.hessian(f, inputs)
@@ -2523,8 +2525,6 @@ class TestHessian(TestCase):
 
         with self.assertRaisesRegex(ValueError, err_msg):
             hessian(foo, chunk_size=-2)(inputs)
-
-
 
 @markDynamoStrictTest
 class TestJvp(TestCase):

--- a/torch/_functorch/deprecated.py
+++ b/torch/_functorch/deprecated.py
@@ -125,9 +125,9 @@ def jacfwd(
     return _impl.jacfwd(func, argnums, has_aux, randomness=randomness)
 
 
-def hessian(func, argnums=0):
+def hessian(func, argnums=0, *, chunk_size: Optional[int] = None):
     warn_deprecated("hessian")
-    return _impl.hessian(func, argnums=argnums)
+    return _impl.hessian(func, argnums=argnums, chunk_size=chunk_size)
 
 
 def functionalize(func: Callable, *, remove: str = "mutations") -> Callable:

--- a/torch/_functorch/eager_transforms.py
+++ b/torch/_functorch/eager_transforms.py
@@ -1308,7 +1308,7 @@ def jacfwd(
 
 
 @exposed_in("torch.func")
-def hessian(func, argnums=0):
+def hessian(func, argnums=0, *, chunk_size: Optional[int] = None):
     """
     Computes the Hessian of ``func`` with respect to the arg(s) at index
     ``argnum`` via a forward-over-reverse strategy.
@@ -1324,6 +1324,10 @@ def hessian(func, argnums=0):
         argnums (int or Tuple[int]): Optional, integer or tuple of integers,
             saying which arguments to get the Hessian with respect to.
             Default: 0.
+        chunk_size (None or int): If not None, computes the Hessian using
+            chunked jacrev. Use this to trade computation time for
+            reduced memory usage when computing Hessians of larger functions.
+            Default: None.
 
     Returns:
         Returns a function that takes in the same inputs as ``func`` and
@@ -1346,8 +1350,14 @@ def hessian(func, argnums=0):
         >>> hess = hessian(f)(x)  # equivalent to jacfwd(jacrev(f))(x)
         >>> assert torch.allclose(hess, torch.diag(-x.sin()))
 
+    Example with chunking for a large input:
+        >>> x = torch.randn(1000)  # Large input
+        >>> # Use chunking to reduce memory usage
+        >>> # Equivalent to jacfwd(jacrev(f, chunk_size=50))(x)
+        >>> hess = hessian(f, chunk_size=50)(x)
+        >>> assert torch.allclose(hess, torch.diag(-x.sin()))
     """
-    return jacfwd(jacrev(func, argnums), argnums)
+    return jacfwd(jacrev(func, argnums, chunk_size=chunk_size), argnums)
 
 
 @doesnt_support_saved_tensors_hooks


### PR DESCRIPTION
In func.hessian I added passing `chunk_size` to `jacrev` to enable chunking when computing Hessian, so we can use bigger functions as input

cc @zou3519 @Chillee @samdow @kshitij12345