### PR TITLE
[Release Only] Increase default timeout for libtorch-rocm-shared-with-deps-release-build

### DIFF
--- a/.github/workflows/_binary-build-linux.yml
+++ b/.github/workflows/_binary-build-linux.yml
@@ -23,7 +23,7 @@ on:
         description: Hardware to run this "build" job on, linux.12xlarge or linux.arm64.2xlarge.
       timeout-minutes:
         required: false
-        default: 240
+        default: 300
         type: number
         description: timeout for the job
       ALPINE_IMAGE:


### PR DESCRIPTION
Increase timeout to be able to build libtorch
Related issue: https://github.com/pytorch/pytorch/issues/162601

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd