### PR TITLE
Simplify PrecompileContext to no longer be a CacheArtifactManager

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -3580,18 +3580,10 @@ def process_caching_precompile():
     )
     from torch._dynamo.precompile_context import PrecompileContext
 
-    # Serialize all callables, clear PrecompileContext
-    # TODO: put this under torch.compiler API once ready
-    serialized = PrecompileContext.serialize()
-    PrecompileContext.clear()
-    if serialized is not None:
-        artifacts, info = serialized
-        print(
-            f"Saving {len(info.precompile_dynamo_artifacts)} Precompile Artifact(s)..."
-        )
-        results = PrecompileContext.deserialize(artifacts)
-        assert results is not None
-        PrecompileContext.populate_caches(results)
+    debug_info = PrecompileContext.save_to_dynamo_cache()
+    print(
+        f"Saved {len(debug_info['dynamo'])} precompile artifacts with {len(debug_info['backends'])} backends"
+    )
 
 
 def process_entry(rank, runner, original_dir, args):

--- a/test/dynamo/test_package.py
+++ b/test/dynamo/test_package.py
@@ -16,13 +16,10 @@ from torch._dynamo.package import CompilePackage, DiskDynamoStore, DynamoCache
 from torch._dynamo.precompile_context import PrecompileContext
 from torch._dynamo.testing import reduce_to_scalar_loss
 from torch._functorch import config as functorch_config
-from torch._inductor.mock_cache import global_stats, PatchCaches, Stats
 from torch._inductor.runtime.runtime_utils import cache_dir
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
-    skipIfRocm,
-    skipIfXpu,
 )
 from torch.testing._internal.inductor_utils import (
     HAS_CUDA_AND_TRITON,
@@ -50,9 +47,7 @@ class TestPackage(torch._inductor.test_case.TestCase):
         DynamoCache.clear()
         PrecompileContext.clear()
 
-    def _save_and_reload(
-        self, expected_backends, expected_dynamo, expected_autotune=None
-    ):
+    def _save_and_reload(self, expected_backends, expected_dynamo):
         """
         Serializes all artifacts, clears all caches, then reloads the serialized artifact
         Simulates a new process.
@@ -61,23 +56,11 @@ class TestPackage(torch._inductor.test_case.TestCase):
             expected_backends: Expected number of precompile_aot_autograd_artifacts
             expected_dynamo: Expected number of precompile_dynamo_artifacts
         """
-        serialized = PrecompileContext.serialize()
-        assert serialized is not None
-        (bytes_, cache_info) = serialized
-        self.assertEqual(
-            len(cache_info.precompile_aot_autograd_artifacts), expected_backends
-        )
-        self.assertEqual(len(cache_info.precompile_dynamo_artifacts), expected_dynamo)
-        if expected_autotune is not None:
-            self.assertEqual(len(cache_info.autotune_artifacts), expected_autotune)
-
+        debug_info = PrecompileContext.save_to_dynamo_cache()
+        self.assertEqual(len(debug_info["dynamo"]), expected_dynamo)
+        self.assertEqual(len(debug_info["backends"]), expected_backends)
         torch._dynamo.reset()
-        DynamoCache.clear()
         PrecompileContext.clear()
-
-        deserialized = PrecompileContext.deserialize(bytes_)
-        assert deserialized is not None
-        PrecompileContext.populate_caches(deserialized)
 
     @unittest.expectedFailure  # FUNCTION_MATCH guard not serializable today
     def test_nn_module(self):
@@ -439,41 +422,6 @@ def add(x, y):
             result2 = compiled_fn2(arg2)
             self.assertEqual(expected, [result1, result2])
         self.assertEqual(torch._dynamo.convert_frame.FRAME_COUNTER, total_frames)
-
-    @parametrize("device", ("cuda", "xpu"))
-    @torch._dynamo.config.patch(caching_precompile=True)
-    @skipIfXpu
-    @skipIfRocm
-    def test_automatic_dynamo_autotune_cache(self, device):
-        if device == "cuda" and not HAS_CUDA_AND_TRITON:
-            raise unittest.SkipTest("Requires CUDA/Triton")
-        if device == "xpu" and not HAS_XPU_AND_TRITON:
-            raise unittest.SkipTest("Requires XPU/Triton")
-
-        def fn(x, y):
-            return x.sin() + y
-
-        arg1 = torch.randn(3, 3, device=device)
-        arg2 = torch.randn(3, 3, device=device)
-        expected = fn(arg1, arg2).clone()
-
-        with PatchCaches():
-            compiled_fn1 = torch.compile(fn, mode="max-autotune")
-            result = compiled_fn1(arg1, arg2).clone()
-            self.assertEqual(expected, result)
-            self.assertEqual(global_stats.autotune_local, Stats(1, 0, 1))
-            DynamoCache.clear()
-
-            total_frames = torch._dynamo.convert_frame.FRAME_COUNTER
-            self._save_and_reload(
-                expected_backends=1, expected_dynamo=1, expected_autotune=1
-            )
-            compiled_fn1 = torch.compile(fn, mode="max-autotune")
-            with torch.compiler.set_stance("fail_on_recompile"):
-                result1 = compiled_fn1(arg1, arg2).clone()
-                self.assertEqual(expected, result1)
-            self.assertEqual(torch._dynamo.convert_frame.FRAME_COUNTER, total_frames)
-            self.assertEqual(global_stats.autotune_local, Stats(2, 1, 1))
 
     @parametrize("device", ("cpu", "cuda", "xpu"))
     @torch._dynamo.config.patch(caching_precompile=True)

--- a/test/dynamo/test_precompile_context.py
+++ b/test/dynamo/test_precompile_context.py
@@ -1,16 +1,9 @@
 # Owner(s): ["module: dynamo"]
-
-import pickle
-
 import torch
 import torch._dynamo
 import torch._dynamo.test_case
 import torch._functorch
-from torch._dynamo.precompile_context import (
-    EditablePrecompileCacheArtifact,
-    PrecompileCacheArtifact,
-    PrecompileContext,
-)
+from torch._dynamo.precompile_context import BackendCacheArtifact, PrecompileContext
 from torch._functorch import config as functorch_config
 from torch._functorch._aot_autograd.autograd_cache import (
     BundledAOTAutogradCacheArtifact,
@@ -49,31 +42,11 @@ class PrecompileContextTests(InductorTestCase):
         result.sum().backward()
         self.assertEqual(len(PrecompileContext._dynamo_cache_entries), 1)
         self.assertEqual(len(PrecompileContext._backend_artifacts_by_key), 1)
-        self.assertEqual(len(PrecompileContext._new_cache_artifacts), 0)
-
-        result = PrecompileContext.serialize()
-        assert result is not None
-        serialized, cache_info = result
-        self.assertEqual(len(cache_info.precompile_aot_autograd_artifacts), 1)
-
-        artifacts = PrecompileContext.deserialize(serialized)
-        assert artifacts is not None
-        deserialized = artifacts["precompile_aot_autograd"]
-        assert len(deserialized) == 1
-        entry = deserialized[0]
-        assert isinstance(entry, BundledAOTAutogradCacheArtifact)
-        entry = entry.after_deserialization()
-        # Now that we've serialized, there should be no new cache artifacts
-        self.assertEqual(
-            len(PrecompileContext._new_cache_artifacts["precompile_aot_autograd"]), 0
-        )
+        cache_entries, _ = PrecompileContext.create_cache_entries()
+        self.assertEqual(len(cache_entries), 1)
 
     @requires_triton()
     def test_serialize_by_key(self):
-        """
-        Test that after torch.compile, PrecompileContext._new_cache_artifacts length is 1
-        """
-
         def simple_function(x):
             return x.sin() + x.cos()
 
@@ -87,14 +60,12 @@ class PrecompileContextTests(InductorTestCase):
         self.assertEqual(len(PrecompileContext._backend_artifacts_by_key), 1)
         for key in PrecompileContext._backend_artifacts_by_key.keys():
             result = PrecompileContext.serialize_artifact_by_key(key)
-            assert isinstance(result, PrecompileCacheArtifact)
+            assert isinstance(result, BackendCacheArtifact)
             self.assertEqual(result.key, key)
 
-        self.assertEqual(len(PrecompileContext._new_cache_artifacts), 0)
-        result = PrecompileContext.serialize()
-        assert result is not None
-        _, cache_info = result
-        self.assertEqual(len(cache_info.precompile_aot_autograd_artifacts), 1)
+        # This should still work
+        result, _ = PrecompileContext.create_cache_entries()
+        assert len(result) == 1
 
     @requires_triton()
     def test_editable(self):
@@ -114,11 +85,7 @@ class PrecompileContextTests(InductorTestCase):
         self.assertEqual(len(PrecompileContext._dynamo_cache_entries), 1)
         self.assertEqual(len(PrecompileContext._backend_artifacts_by_key), 1)
         # Find the key for the artifact of type "precompile_aot_autograd"
-        key = next(
-            k
-            for k, v in PrecompileContext._backend_artifacts_by_key.items()
-            if isinstance(v, EditablePrecompileCacheArtifact)
-        )
+        key = next(iter(PrecompileContext._backend_artifacts_by_key))
 
         def edit_fn(x):
             x._my_private_field = 42
@@ -130,24 +97,12 @@ class PrecompileContextTests(InductorTestCase):
         assert isinstance(result, BundledAOTAutogradCacheArtifact)
         self.assertEqual(result.key, key)
 
-        self.assertEqual(len(PrecompileContext._new_cache_artifacts), 0)
-        result = PrecompileContext.serialize()
-        assert result is not None
-        artifacts, cache_info = result
-        self.assertEqual(len(cache_info.precompile_aot_autograd_artifacts), 1)
-
-        deserialized = PrecompileContext.deserialize(artifacts)
-        assert deserialized is not None
-        aot_autograd_artifacts = deserialized["precompile_aot_autograd"]
+        result, _ = PrecompileContext.create_cache_entries()
+        assert len(result) == 1
+        aot_autograd_artifacts = next(iter(result.values())).backends
         assert len(aot_autograd_artifacts) == 1
-        entry = aot_autograd_artifacts[0]
-        assert isinstance(entry, BundledAOTAutogradCacheArtifact)
-        raw_entry = pickle.loads(entry.content)
-        self.assertEqual(raw_entry._my_private_field, 42)
-        # Now that we've serialized, there should be no new cache artifacts
-        self.assertEqual(
-            len(PrecompileContext._new_cache_artifacts["precompile_aot_autograd"]), 0
-        )
+        entry = next(iter(aot_autograd_artifacts.values())).content
+        self.assertEqual(entry._my_private_field, 42)
 
 
 if __name__ == "__main__":

--- a/torch/_dynamo/aot_compile.py
+++ b/torch/_dynamo/aot_compile.py
@@ -182,7 +182,9 @@ class BundledAOTAutogradSerializableCallable(SerializableCallable):
             deserialize_bundled_cache_entry,
         )
 
-        compiled_fn = deserialize_bundled_cache_entry(data)
+        entry = pickle.loads(data)
+
+        compiled_fn = deserialize_bundled_cache_entry(entry)
         return cls(compiled_fn)
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -747,12 +747,11 @@ class _TorchDynamoContext:
                     # Create a fresh CompilePackage
                     self._package.initialize(fn, None, ignore_inlined_sources=False)
                 else:
-                    cache_entry, backends = result
                     try:
                         self._package.initialize(
-                            fn, cache_entry, ignore_inlined_sources=False
+                            fn, result.dynamo, ignore_inlined_sources=False
                         )
-                        self._package.install(backends)
+                        self._package.install(result.backends)
                     except RuntimeError as e:
                         log.warning("Failed to load entry from dynamo cache: %s", e)
                         self._package.initialize(fn, None, ignore_inlined_sources=False)

--- a/torch/_dynamo/precompile_context.py
+++ b/torch/_dynamo/precompile_context.py
@@ -1,25 +1,18 @@
 import copy
 import json
 import logging
-import pickle
 from abc import abstractmethod
 from collections import defaultdict
-from itertools import chain
-from typing import Any, Callable, Generic, Optional, TypeVar, Union
-from typing_extensions import override
+from dataclasses import dataclass
+from typing import Any, Callable, Generic, Optional, TypeVar
 
 import torch
-from torch._dynamo.package import _DynamoCacheEntry
-from torch.compiler._cache import (
-    _serialize_single_cache,
-    CacheArtifact,
-    CacheArtifactFactory,
-    CacheArtifactManager,
-    CacheArtifactsResult,
-    CacheInfo,
+from torch._dynamo.package import (
+    _BackendId,
+    _DynamoCacheEntry,
+    DynamoCache,
+    PrecompileCacheEntry,
 )
-from torch.utils._appending_byte_serializer import AppendingByteSerializer
-from torch.utils._ordered_set import OrderedSet
 
 
 """
@@ -30,14 +23,12 @@ T = TypeVar("T")
 logger = logging.getLogger(__name__)
 
 
-class PrecompileCacheArtifact(CacheArtifact, Generic[T]):
+@dataclass
+class BackendCacheArtifact(Generic[T]):
     """
-    Data for each cache artifact that will be serialized and deserialized by
-    PrecompileContext, rather than CacheArtifactManager.
-    T represents the deserialized type of the artifact, i.e. the return type of after_deserialization
-
-    PrecompileCacheArtifact is a frozen dataclass - you can add new serializable fields and metadata specific to your own artifacts
-    as needed, and use them in after_deserialization.
+    Represents a single serializable backend artifact from a dynamo backend.
+    Each BackendCacheArtifact has a key associated with it along with some
+    serializable content.
 
     Example implementation:
 
@@ -51,13 +42,8 @@ class PrecompileCacheArtifact(CacheArtifact, Generic[T]):
             return result
     """
 
-    @override
-    def populate_cache(self) -> None:
-        raise RuntimeError("Precompile cache artifacts do not populate caches")
-
-    @override
-    def precompile_compatible(self) -> bool:
-        return True
+    key: str
+    content: Any
 
     @abstractmethod
     def after_deserialization(self) -> T:
@@ -67,63 +53,23 @@ class PrecompileCacheArtifact(CacheArtifact, Generic[T]):
         """
         ...
 
-
-@CacheArtifactFactory.register
-class EagerCacheArtifact(PrecompileCacheArtifact[Any]):
-    @staticmethod
-    def type() -> str:
-        return "precompile_eager"
-
-    def after_deserialization(self) -> Any:
-        return pickle.loads(self.content)
-
-
-class EditablePrecompileCacheArtifact(Generic[T]):
-    """
-    A PrecompileCacheArtifact whose content isn't encoded until we call PrecompileContext.serialize()
-    """
-
-    def __init__(self, artifact_type: str, content: Any, key: str) -> None:
-        # Deepcopy the content for now, but don't pickle it yet.
-        # This allows us to make changes to self.content before true serialization
-        self.content = copy.deepcopy(content)
-        self.key = key
-        self.artifact_type = artifact_type
-
-    def real_encode(self) -> PrecompileCacheArtifact[T]:
-        """
-        Actually encode the object
-        """
-        content = pickle.dumps(self.content)
-        artifact = CacheArtifactFactory.encode_create(
-            self.artifact_type, self.key, content
-        )
-        assert isinstance(artifact, PrecompileCacheArtifact)
-        return artifact
-
     def edit_contents(self, edit_fn: Callable[..., Any]) -> None:
         """
-        Edit the content of an existing artifact
+        Edit the contents of the artifact.
         """
         self.content = edit_fn(self.content)
 
 
-@CacheArtifactFactory.register
-class _DynamoCacheArtifact(PrecompileCacheArtifact[_DynamoCacheEntry]):
-    @staticmethod
-    def type() -> str:
-        return "precompile_dynamo"
-
-    def after_deserialization(self) -> _DynamoCacheEntry:
-        result = pickle.loads(self.content)
-        return result
+class EagerCacheArtifact(BackendCacheArtifact[Any]):
+    def after_deserialization(self) -> Any:
+        return self.content
 
 
 class BypassDynamoCacheEntry(Exception):
     pass
 
 
-class PrecompileContext(CacheArtifactManager):
+class PrecompileContext:
     """
     PrecompileContext is a special CacheArtifactManager for handling precompilation
     It uses the same interface as CacheArtifactManager, but handles deserialization differently: instead
@@ -136,69 +82,32 @@ class PrecompileContext(CacheArtifactManager):
 
     The following artifact types are supported by PrecompileContext:
      - BundledAOTAutogradCacheArtifact
-     - AutotuneCacheArtifact (regular autotune results, same as Megacache)
 
     """
 
     # Protected by the compile_lock
     # _backend_artifacts_by_key organizes results by the key of each artifact.
-    # This allows us to implement serialize_by_key easily.
-    # On call to `serialize()`, all cache artifacts in _backend_artifacts_by_key
-    # are transferred to _new_cache_artifacts before serialization.
-    _backend_artifacts_by_key: dict[
-        str, Union[EditablePrecompileCacheArtifact[object], CacheArtifact]
-    ] = {}
+    # Each object here must be serializable
+    _backend_artifacts_by_key: dict[str, BackendCacheArtifact[Any]] = {}
 
     # On call to `serialize()`, all cache artifacts in _dynamo_cache_entries are converted
     # into DynamoCacheArtifacts and added to _new_cache_artifacts for serialization
     _dynamo_cache_entries: dict[str, _DynamoCacheEntry] = {}
 
-    _new_cache_artifacts: CacheArtifactsResult = defaultdict(list)
-    # Keep a separate seen artifacts list to make avoid unnecessary duplicates
-    # This list will not be cleared between serialize() calls
-    _seen_artifacts: OrderedSet[CacheArtifact] = OrderedSet()
-    # When serialize() is called, artifacts are transferred from _cache_artifacts to
-    # internal data structure of the _serializer
-    # This allows us to only pay the cost of serialization if serialize() is called
-    _serializer: AppendingByteSerializer[tuple[str, list[CacheArtifact]]] = (
-        AppendingByteSerializer(serialize_fn=_serialize_single_cache)
-    )
-    _cache_info: CacheInfo = CacheInfo()
-
     @classmethod
     def clear(cls) -> None:
         cls._backend_artifacts_by_key.clear()
         cls._dynamo_cache_entries.clear()
-        super().clear()
 
-    @override
     @classmethod
     def record_artifact(
         cls,
-        artifact_type: str,
-        key: str,
-        content: Any,
-        editable: bool = False,
+        artifact: BackendCacheArtifact[Any],
     ) -> None:
         """
-        Called from each caching operation to record the artifact in this
-        "mega" list
+        Records a backend artifact to be used with dynamo cache entries
         """
-        artifact: Union[EditablePrecompileCacheArtifact[object], CacheArtifact]
-        if editable:
-            artifact = EditablePrecompileCacheArtifact(artifact_type, content, key)
-        else:
-            artifact = CacheArtifactFactory.encode_create(artifact_type, key, content)
-            # TODO: although this covers completely same artifacts, it's possible
-            # with AOTAutogradCacheEntries to have multiple artifacts whose keys
-            # (i.e. backend_ids) are different, but whose contents are equal.
-            # In those cases, it would be much better if we only serialize once instead
-            # of N times.
-            if artifact in cls._seen_artifacts:
-                return
-            cls._seen_artifacts.add(artifact)
-
-        cls._backend_artifacts_by_key[key] = artifact
+        cls._backend_artifacts_by_key[artifact.key] = copy.deepcopy(artifact)
 
     @classmethod
     def record_dynamo_cache_entry(
@@ -207,89 +116,25 @@ class PrecompileContext(CacheArtifactManager):
         cls._dynamo_cache_entries[key] = cache_entry
 
     @classmethod
-    def _save_artifacts_by_type(cls) -> None:
-        """
-        We normally record artifacts by key, but serialization expects them to be organized
-        by artifact type. This function transfers artifacts from _backend_artifacts_by_key to _new_cache_artifacts
-        """
-        for key, cache_entry in cls._dynamo_cache_entries.items():
-            backends = cache_entry.backend_ids
-            try:
-                for id_ in backends:
-                    if id_ not in cls._backend_artifacts_by_key:
-                        logger.warning(
-                            "Bypassing %s because backend %s not found in artifacts"
-                        )
-                        raise BypassDynamoCacheEntry
-            except BypassDynamoCacheEntry:
-                continue
-            pickled_result = pickle.dumps(cache_entry)
-            dynamo_artifact = _DynamoCacheArtifact(key, pickled_result)
-            cls._new_cache_artifacts[_DynamoCacheArtifact.type()].append(
-                dynamo_artifact
-            )
-
-        # Save all the backend artifacts
-        for artifact in cls._backend_artifacts_by_key.values():
-            if isinstance(artifact, EditablePrecompileCacheArtifact):
-                artifact = artifact.real_encode()
-            cls._new_cache_artifacts[artifact.__class__.type()].append(artifact)
-        cls._backend_artifacts_by_key.clear()
-
-    @classmethod
     def edit_artifact(cls, key: str, edit_fn: Callable[..., Any]) -> None:
         """
         Edit the content of an existing artifact
         """
         assert key in cls._backend_artifacts_by_key, f"Key {key} not found in artifacts"
         artifact = cls._backend_artifacts_by_key[key]
-        assert isinstance(artifact, EditablePrecompileCacheArtifact), (
-            "Artifact is not editable"
-        )
         artifact.edit_contents(edit_fn)
 
     @classmethod
-    def serialize_artifact_by_key(cls, key: str) -> Optional[CacheArtifact]:
+    def serialize_artifact_by_key(cls, key: str) -> Optional[BackendCacheArtifact[Any]]:
         """
-        Serialize all backend artifacts with the given key returned in a list.
+        Return the backend cache artifact with the associated key
         """
-        result = cls._backend_artifacts_by_key.get(key, None)
-        if isinstance(result, EditablePrecompileCacheArtifact):
-            result = result.real_encode()
-        return result
-
-    @classmethod
-    def serialize(cls) -> Optional[tuple[bytes, CacheInfo]]:
-        if not cls._dynamo_cache_entries:
-            return None
-
-        debug_info = cls.dump_debug_info(
-            cls._dynamo_cache_entries, cls._backend_artifacts_by_key
-        )
-        artifacts = json.dumps({"artifacts": debug_info})
-        torch._logging.trace_structured(
-            "artifact",
-            metadata_fn=lambda: {
-                "name": "dynamo_cache_save_contents",
-                "encoding": "json",
-            },
-            payload_fn=lambda: artifacts,
-            expect_trace_id=False,
-        )
-        cls._save_artifacts_by_type()
-
-        result = super().serialize()
-        assert result is not None
-        data, info = result
-
-        return data, info
+        return cls._backend_artifacts_by_key.get(key, None)
 
     @staticmethod
     def dump_debug_info(
         dynamo_entries: dict[str, _DynamoCacheEntry],
-        backend_artifacts: dict[
-            str, Union[EditablePrecompileCacheArtifact[object], CacheArtifact]
-        ],
+        backend_artifacts: dict[str, BackendCacheArtifact[Any]],
     ) -> dict[str, Any]:
         """
         Return a JSON serializable debug dump of all entries in the precompile context
@@ -300,36 +145,32 @@ class PrecompileContext(CacheArtifactManager):
         for key, cache_entry in dynamo_entries.items():
             info = cache_entry.debug_info()
             info["key"] = key
-            debug_info["precompile_dynamo"].append(info)
+            debug_info["dynamo"].append(info)
 
         for artifact in backend_artifacts.values():
-            if isinstance(artifact, EditablePrecompileCacheArtifact):
-                debug_info[artifact.artifact_type].append(artifact.key)
-            else:
-                debug_info[artifact.__class__.type()].append(artifact.key)
+            debug_info["backends"].append(artifact.key)
 
         return debug_info
 
-    @staticmethod
-    def populate_caches(artifacts: CacheArtifactsResult) -> CacheInfo:
-        PrecompileContext._ensure_cache_artifacts_registered()
+    @classmethod
+    def save_to_dynamo_cache(cls) -> dict[str, Any]:
+        precompile_cache_entries, debug_info = cls.create_cache_entries()
+        for key, entry in precompile_cache_entries.items():
+            DynamoCache.write(entry, key)
+        return debug_info
 
-        backend_artifacts: dict[str, Any] = {}
-        dynamo_entries: dict[str, _DynamoCacheEntry] = {}
-        cache_info = CacheInfo()
-        for artifact in chain(*artifacts.values()):
-            if artifact.type() == "autotune":
-                # Populate autotune cache artifacts
-                artifact.populate_cache()
-            elif artifact.type() == "precompile_dynamo":
-                assert isinstance(artifact, _DynamoCacheArtifact)
-                cache_entry: _DynamoCacheEntry = artifact.after_deserialization()
-                dynamo_entries[artifact.key] = cache_entry
-            else:
-                backend_artifacts[artifact.key] = artifact
-            cache_info.add(artifact)
+    @classmethod
+    def create_cache_entries(
+        cls,
+    ) -> tuple[dict[str, PrecompileCacheEntry], dict[str, Any]]:
+        """
+        Grabs all the cache entries in the precompile context and
+        stitches them together into full PrecompileCacheEntries.
+        """
+        dynamo_entries = cls._dynamo_cache_entries
+        backend_artifacts = cls._backend_artifacts_by_key
 
-        num_artifacts = len(artifacts["precompile_dynamo"])
+        num_artifacts = len(dynamo_entries)
 
         debug_info = PrecompileContext.dump_debug_info(
             dynamo_entries, backend_artifacts
@@ -349,12 +190,13 @@ class PrecompileContext(CacheArtifactManager):
             payload_fn=lambda: debug_str,
             expect_trace_id=False,
         )
-        from torch._dynamo.package import _BackendId, DynamoCache
+
+        precompile_cache_entries = {}
 
         for key, cache_entry in dynamo_entries.items():
             try:
                 backends = cache_entry.backend_ids
-                backend_content: dict[_BackendId, PrecompileCacheArtifact[Any]] = {}
+                backend_content: dict[_BackendId, BackendCacheArtifact[Any]] = {}
                 for id_ in backends:
                     if id_ not in backend_artifacts:
                         debug_str = json.dumps(
@@ -375,11 +217,13 @@ class PrecompileContext(CacheArtifactManager):
                         )
                         continue
                     artifact = backend_artifacts[id_]
-                    assert isinstance(artifact, PrecompileCacheArtifact)
+                    assert isinstance(artifact, BackendCacheArtifact)
                     backend_content[id_] = artifact
-                DynamoCache.write(cache_entry, backend_content, key)
+                precompile_cache_entries[key] = PrecompileCacheEntry(
+                    dynamo=cache_entry, backends=backend_content
+                )
             except Exception as e:
-                logger.warning("Failed to deserialize cache entry %s: %s", key, str(e))
+                logger.warning("Failed to create cache entry %s: %s", key, str(e))
 
                 error = e
                 data = json.dumps(
@@ -397,11 +241,4 @@ class PrecompileContext(CacheArtifactManager):
                     payload_fn=lambda: data,
                 )
                 continue
-
-        return cache_info
-
-    @classmethod
-    def _ensure_cache_artifacts_registered(cls) -> None:
-        from torch._functorch._aot_autograd.autograd_cache import (  # noqa: F401
-            BundledAOTAutogradCacheArtifact,
-        )
+        return precompile_cache_entries, debug_info

--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -35,7 +35,6 @@ from typing import Any, Optional, TYPE_CHECKING
 from typing_extensions import override
 
 import torch
-from torch._dynamo.precompile_context import PrecompileContext
 from torch._inductor.runtime.runtime_utils import cache_dir
 from torch.compiler._cache import (
     CacheArtifact,
@@ -302,10 +301,6 @@ class AutotuneCache:
             CacheArtifactManager.record_artifact(
                 AutotuneCacheArtifact.type(), autotune_artifact_key, data
             )
-            if torch._dynamo.config.caching_precompile:
-                PrecompileContext.record_artifact(
-                    AutotuneCacheArtifact.type(), autotune_artifact_key, data
-                )
 
             if log.isEnabledFor(logging.DEBUG):
                 type_str = "coordesc" if found_by_coordesc else "heuristic"
@@ -631,10 +626,6 @@ class LocalAutotuneCache(RemoteCache[JsonDataTy]):
             CacheArtifactManager.record_artifact(
                 AutotuneCacheArtifact.type(), autotune_artifact_key, result
             )
-            if torch._dynamo.config.caching_precompile:
-                PrecompileContext.record_artifact(
-                    AutotuneCacheArtifact.type(), autotune_artifact_key, result
-                )
         return result
 
     @override

--- a/torch/compiler/_cache.py
+++ b/torch/compiler/_cache.py
@@ -48,9 +48,6 @@ class CacheArtifact(ABC):
     def populate_cache(self) -> None:
         pass
 
-    def precompile_compatible(self) -> bool:
-        return False
-
     @staticmethod
     def type() -> str:
         """
@@ -129,14 +126,6 @@ class CacheInfo:
 
     @property
     def pgo_artifacts(self) -> list[str]:  # type: ignore[empty-body]
-        ...
-
-    @property
-    def precompile_aot_autograd_artifacts(self) -> list[str]:  # type: ignore[empty-body]
-        ...
-
-    @property
-    def precompile_dynamo_artifacts(self) -> list[str]:  # type: ignore[empty-body]
         ...
 
     def add(self, artifact: CacheArtifact) -> None:


### PR DESCRIPTION
Summary:
This diff does a big refactor of PrecompileContext to make it considerably simpler: instead of being a CacheArtifactManager and managing a bunch of bytes, it simply stores two things: dynamo cache entries and backend cache entries. When asked, it stitches them together into PrecompileCacheEntries, which are stored by DynamoCache. 

This structure then allows us to register DynamoCache to the regular Megacache API, instead of having two separate APIs that are confusing. It also lets us remove the autotune cache integration, since MegaCache API will automatically store autotune cache entries. 

The intent here is that users who want to use caching precompile will simply be able to use torch.compiler.save_cache_artifacts as before, just with `torch.dynamo.config.caching_precompile` set to True. They can also directly interact with PrecompileContext if they wish to specifically only load Precompile entries, using PrecompileContext.create_cache_entries(). 

Saving single entries and such with DynamoCache still works normally.

Test Plan:
All existing unit tests pass.

Rollback Plan:

Differential Revision: D82380307




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @Lucaskabela