### PR TITLE
[data foundation][vizard] Prevent checking the device type of numpy object in Tensorboard logger

### DIFF
--- a/torch/utils/tensorboard/_convert_np.py
+++ b/torch/utils/tensorboard/_convert_np.py
@@ -20,6 +20,8 @@ def make_np(x: torch.Tensor) -> np.ndarray:
     if np.isscalar(x):
         return np.array([x])
     if isinstance(x, torch.Tensor):
+        if x.device.type == "meta":
+            return np.random.randn(1)
         return _prepare_pytorch(x)
     raise NotImplementedError(
         f"Got {type(x)}, but numpy array or torch tensor are expected."


### PR DESCRIPTION
Summary:
The check is introduced in D82262053
- `scalar_value` could be a numpy object
  - Move the check of `device.type` into `make_np` method where it happens only when it's a `torch.Tensor`.

Test Plan:
```
vizard launch -j 1x8 --launch=flow --config-path=pkg://vizard_projects.image_classification.configs --config-name=resnet50 ++flow.secure_group=ml_sensors ++flow.entitlement=ai_frameworks_pnb ++max_train_steps_per_epoch=10 ++max_epochs=5 ++log_every_n_steps=10 ++profiler=null ++max_eval_steps_per_epoch=10
```

Rollback Plan:

Differential Revision: D82383428


