### PR TITLE
typo corrected from A[:,0].sum() to A[0,:].sum()

### DIFF
--- a/docs/source/notes/numerical_accuracy.rst
+++ b/docs/source/notes/numerical_accuracy.rst
@@ -35,7 +35,7 @@ even though mathematically it's an identical computation.
 Similarly, an operation applied to a tensor slice is not guaranteed to produce results that are
 identical to the slice of the result of the same operation applied to the full tensor. E.g. let
 ``A`` be a 2-dimensional tensor. ``A.sum(-1)[0]`` is not guaranteed to be bitwise equal to
-``A[:,0].sum()``.
+``A[0,:].sum()``.
 
 
 Extremal values


### PR DESCRIPTION
Fixes #162882

typo corrected A[:,0].sum() to A[0,:].sum() 
