### PR TITLE
QoL: add pip to requirements-build.txt

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -8,3 +8,4 @@ pyyaml
 requests
 six  # dependency chain: NNPACK -> PeachPy -> six
 typing-extensions>=4.10.0
+pip  # not technically needed, but this makes setup.py invocation work


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.11.0) (oldest at bottom):
* __->__ #162896

uv venvs by default don't come with pip, but for example setup.py assumes it is available.

Signed-off-by: Edward Yang <ezyang@meta.com>