### PR TITLE
[MTIA] [PyTorch] [Export] Allow setting names for lifted constants before tracing.

### DIFF
--- a/torch/export/_name_tensor_constants.py
+++ b/torch/export/_name_tensor_constants.py
@@ -1,0 +1,49 @@
+# Owner(s): ["oncall: export"]
+
+
+import torch
+from torch._subclasses.fake_tensor import FakeTensor
+
+
+def set_tensor_name(tensor: torch.Tensor, name: str) -> torch.Tensor:
+    """
+    Associates a custom name with a tensor for torch export.
+    This is only supported for strict=False.
+
+    When the tensor is lifted during torch export, it will use the custom name
+    instead of the auto-generated name like "lifted_tensor_{N}".
+
+    Args:
+        tensor: The tensor to name
+        name: The custom name to associate with the tensor
+
+    Returns:
+        The same tensor (for chaining)
+
+    Raises:
+        RuntimeError: If the tensor is a FakeTensor
+
+    Example:
+        >>> key = torch.tensor([1, 2, 3])
+        >>> torch.export._name_tensor_constants.set_tensor_name(key, "my_key_tensor")
+        >>> # When exported, this will be named "my_key_tensor" instead of "lifted_tensor_0"
+    """
+    if not isinstance(tensor, torch.Tensor):
+        raise TypeError(f"Expected torch.Tensor, got {type(tensor)}")
+    if isinstance(tensor, FakeTensor):
+        raise RuntimeError("Cannot name FakeTensor. Only real tensors can be named.")
+    if not isinstance(name, str):
+        raise TypeError(f"Expected str for name, got {type(name)}")
+    if not name:
+        raise ValueError("Name cannot be empty")
+
+    # Validate name contains only valid characters for FQNs
+    if not all(c.isalnum() or c in "_." for c in name):
+        raise ValueError(
+            f"Name '{name}' contains invalid characters. Only alphanumeric, underscore, and dot are allowed."
+        )
+
+    # Store the name as a custom attribute on the tensor itself
+    # This survives tensor transformations better than WeakKeyDictionary
+    tensor._export_name = name  # type: ignore[attr-defined]
+    return tensor


### PR DESCRIPTION
Summary:
The lift_constants_pass will set the name of lifted to constants to module_path_{lifted_tensor_counter}. This makes it very difficult for a compiler or runtime to map certain constants to what the placeholder value is in the IR. 

This PR adds a new API to Torch Export allowing users to set the names of certain tensors. The lift_constants_pass then respects this name. 

This is not supported for strict=True or for naming FakeTensors.

```
        tensor = torch.tensor([1, 2, 3])
        result = torch.export._name_tensor_constants.set_tensor_name(tensor, "my_custom_tensor")
        self.assertIs(result, tensor)  # Should return the same tensor
```

Before:
```
 %model_layers_0_self_attn_attn_lifted_tensor_0 : bf16[2, 346732, 16, 8, 64][num_users=2] = placeholder[target='model_layers_0_self_attn_attn_lifted_tensor_0']
```

```
 kv_cache = torch.export._name_tensor_constants.set_tensor_name(kv_cache, "kv_cache")
```

After:


```
%model_layers_0_self_attn_attn_kv_cache : bf16[2, 346544, 16, 8, 64][num_users=2] = placeholder[target='model_layers_0_self_attn_attn_kv_cache']
```

Test Plan:
Added unit tests

Rollback Plan:

Differential Revision: D82387095


