### PR TITLE
[ROCM]enable TF32 config in MIOpen

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -180,6 +180,7 @@ void Context::setUserEnabledNNPACK(bool e) {
 }
 
 bool Context::allowTF32CuDNN(const std::string& op) const {
+  // TODO(LYM): miopen
   if (op.size() == 0){
     bool allow_tf32_rnn = float32Precision("cuda", "rnn") == "tf32";
     bool allow_tf32_conv = float32Precision("cuda", "conv") == "tf32";

--- a/aten/src/ATen/miopen/Descriptors.cpp
+++ b/aten/src/ATen/miopen/Descriptors.cpp
@@ -1,12 +1,15 @@
 #include <ATen/miopen/Descriptors.h>
+
 #include <ATen/ATen.h>
 #include <c10/util/irange.h>
 
 #include <iostream>
+#include <sstream>
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
+
 
 inline miopenDataType_t getDataType(const at::Tensor& t) {
   auto scalar_type = t.scalar_type();
@@ -16,34 +19,37 @@ inline miopenDataType_t getDataType(const at::Tensor& t) {
     return miopenHalf;
   } else if (scalar_type == at::kBFloat16) {
     return miopenBFloat16;
-  } else {
-    TORCH_CHECK(
-        false,
-        "TensorDescriptor only supports float, half and bfloat16 tensors");
   }
-}
-
-} // anonymous namespace
-
-
-void TensorDescriptor::set(const at::Tensor &t, size_t pad) {
-  set(getDataType(t), t.sizes(), t.strides(), pad);
+  TORCH_CHECK(false, "TensorDescriptor does not support ", scalar_type);
 }
 
 constexpr size_t MIOPEN_DIM_MAX = 5;
 
+} // anonymous namespace
+
+void TensorDescriptor::set(const at::Tensor &t, at::MemoryFormat memory_format, size_t pad) {
+  set(getDataType(t), t.sizes(), t.strides(), pad,
+    memory_format == at::MemoryFormat::ChannelsLast ||
+    memory_format == at::MemoryFormat::ChannelsLast3d);
+}
+
+void TensorDescriptor::set(const at::Tensor &t, size_t pad) {
+  auto memory_format = t.suggest_memory_format();
+  set(getDataType(t), t.sizes(), t.strides(), pad,
+    memory_format == at::MemoryFormat::ChannelsLast ||
+    memory_format == at::MemoryFormat::ChannelsLast3d);
+}
+
 void TensorDescriptor::set(miopenDataType_t datatype, IntArrayRef t_sizes, IntArrayRef t_strides, size_t pad) {
+  set(datatype, t_sizes, t_strides, pad,
+    is_channels_last_strides_2d(t_sizes, t_strides) ||
+    is_channels_last_strides_3d(t_sizes, t_strides));
+}
+
+void TensorDescriptor::set(miopenDataType_t datatype, IntArrayRef t_sizes, IntArrayRef t_strides, size_t pad, bool nhwc) {
   size_t dim = t_sizes.size();
   if (dim > MIOPEN_DIM_MAX || pad > MIOPEN_DIM_MAX)
-#define _STR(X) #X
-#define STR(X) _STR(X)
-    TORCH_CHECK(
-        false,
-        "MIOpen supports only up to ",
-        STR(MIOPEN_DIM_MAX),
-        " dimensions");
-#undef _STR
-#undef STR
+    TORCH_CHECK(false, "MIOpen supports only up to ", MIOPEN_DIM_MAX, " dimensions");
   int size[MIOPEN_DIM_MAX];
   int stride[MIOPEN_DIM_MAX];
   for (const auto i : c10::irange(dim)) {
@@ -54,7 +60,7 @@ void TensorDescriptor::set(miopenDataType_t datatype, IntArrayRef t_sizes, IntAr
     size[i] = 1;
     stride[i] = 1;
   }
-  set(datatype, static_cast<int>(std::max(dim, pad)), size, stride);
+  set(datatype, static_cast<int>(std::max(dim, pad)), size, stride, nhwc);
 }
 
 std::string miopenTypeToString(miopenDataType_t dtype) {
@@ -74,10 +80,11 @@ std::string miopenTypeToString(miopenDataType_t dtype) {
 
 std::ostream& operator<<(std::ostream & out, const TensorDescriptor& d) {
   out << "TensorDescriptor " << static_cast<void*>(d.desc()) << "\n";
-  int nbDims = 4;
+  int nbDims = 0;
   int dimA[MIOPEN_DIM_MAX];
   int strideA[MIOPEN_DIM_MAX];
   miopenDataType_t dtype;
+  miopenGetTensorDescriptorSize(d.desc(), &nbDims);
   miopenGetTensorDescriptor(d.desc(), &dtype, dimA, strideA);
   out << "    type = " << miopenTypeToString(dtype) << "\n";
   out << "    nbDims = " << nbDims << "\n";
@@ -99,19 +106,17 @@ void TensorDescriptor::print() { std::cout << *this; }
 
 void FilterDescriptor::set(const at::Tensor &t, const at::MemoryFormat memory_format, int64_t pad) {
   auto dim = t.ndimension();
-  if (dim > static_cast<int64_t>(MIOPEN_DIM_MAX) || pad > static_cast<int64_t>(MIOPEN_DIM_MAX)) {
-#define _STR(X) #X
-#define STR(X) _STR(X)
-    TORCH_CHECK(
-        false,
-        "MIOpen supports only up to ",
-        STR(MIOPEN_DIM_MAX),
-        " dimensions");
-#undef _STR
-#undef STR
-  }
+  if (dim > MIOPEN_DIM_MAX || pad > MIOPEN_DIM_MAX)
+  TORCH_CHECK(false, "MIOpen supports only up to ", MIOPEN_DIM_MAX, " dimensions");
+  // NB: It is possible for this test to be insufficient, because the
+  // Tensor passed in to set the filter descriptor may not be the actual
+  // Tensor whose data pointer is passed to cuDNN.  Nevertheless,
+  // that is the common case, so we can catch most client errors with this test.
   TORCH_CHECK(t.is_contiguous(memory_format),
-      "MIOpen filters (a.k.a. weights) must be contiguous");
+    "MIOpen filters (a.k.a. weights) must be contiguous in desired memory_format\n",
+    "Weight sizes: ", t.sizes(), "\n",
+    "Weight strides: ", t.strides(), "\n",
+    "cuDNN suggested memory_format: ", memory_format);
 
   int size[MIOPEN_DIM_MAX];
   int stride[MIOPEN_DIM_MAX];
@@ -131,7 +136,33 @@ void FilterDescriptor::set(const at::Tensor &t, const at::MemoryFormat memory_fo
   }
 
   dim = std::max<int64_t>(dim, pad);
-  set(getDataType(t), (int) dim, size, stride);
+  set(getDataType(t), static_cast<int>(dim), size, stride);
 }
 
-}}
+std::ostream& operator<<(std::ostream & out, const FilterDescriptor& d) {
+  out << "FilterDescriptor " << static_cast<void*>(d.desc()) << "\n";
+  int nbDims = 0;
+  int dimA[MIOPEN_DIM_MAX];
+  int strideA[MIOPEN_DIM_MAX];
+  miopenDataType_t dtype;
+  miopenGetTensorDescriptorSize(d.desc(), &nbDims);
+  miopenGetTensorDescriptor(d.desc(), &dtype, dimA, strideA);
+  out << "    type = " << miopenTypeToString(dtype) << "\n";
+  out << "    nbDims = " << nbDims << "\n";
+  // Read out only nbDims of the arrays!
+  out << "    dimA = ";
+  for (auto i : ArrayRef<int>{dimA, static_cast<size_t>(nbDims)}) {
+    out << i << ", ";
+  }
+  out << "\n";
+  out << "    strideA = ";
+  for (auto i : ArrayRef<int>{strideA, static_cast<size_t>(nbDims)}) {
+    out << i << ", ";
+  }
+  out << "\n";
+  return out;
+}
+
+void FilterDescriptor::print() { std::cout << *this; }
+
+}

--- a/aten/src/ATen/miopen/Descriptors.h
+++ b/aten/src/ATen/miopen/Descriptors.h
@@ -173,10 +173,22 @@ struct TORCH_HIP_CPP_API ConvolutionDescriptor
           miopenConvolutionDescriptor,
           &miopenCreateConvolutionDescriptor,
           &miopenDestroyConvolutionDescriptor> {
-  void set(miopenDataType_t dataType, miopenConvolutionMode_t c_mode,  int dim, int* pad, int* stride, int * upscale /* aka dilation */, int groups, bool benchmark, bool deterministic) {
+  void set(miopenDataType_t dataType,
+           miopenConvolutionMode_t c_mode,
+           int dim,
+           int* pad,
+           int* stride,
+           int* upscale /* aka dilation */,
+           int groups,
+           bool benchmark,
+           bool deterministic,
+           bool allow_tf32) {
     MIOPEN_CHECK(miopenInitConvolutionNdDescriptor(mut_desc(), dim, pad, stride, upscale, c_mode));
     MIOPEN_CHECK(miopenSetConvolutionGroupCount(mut_desc(), groups));
-    MIOPEN_CHECK(miopenSetConvolutionAttribute(mut_desc(), MIOPEN_CONVOLUTION_ATTRIB_DETERMINISTIC, deterministic ? 1 : 0));
+    MIOPEN_CHECK(
+        miopenSetConvolutionAttribute(mut_desc(), MIOPEN_CONVOLUTION_ATTRIB_DETERMINISTIC, deterministic ? 1 : 0));
+    MIOPEN_CHECK(miopenSetConvolutionAttribute(
+        mut_desc(), MIOPEN_CONVOLUTION_ATTRIB_MATH_TYPE, allow_tf32 ? miopenMathDefault : miopenMathPedantic));
     if (benchmark) {
       MIOPEN_CHECK(miopenSetConvolutionFindMode(mut_desc(), miopenConvolutionFindModeNormal));
     }

--- a/aten/src/ATen/miopen/Descriptors.h
+++ b/aten/src/ATen/miopen/Descriptors.h
@@ -1,13 +1,16 @@
 #pragma once
 
-#include <ATen/miopen/Exceptions.h>
+#include <string>
 
+#include <ATen/miopen/Exceptions.h>
 #include <ATen/miopen/miopen-wrapper.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/TensorUtils.h>
 #include <c10/macros/Export.h>
 
-namespace at { namespace native {
+namespace at::native {
+
+std::string miopenTypeToString(miopenDataType_t dtype);
 
 inline int dataSize(miopenDataType_t dataType)
 {
@@ -16,6 +19,43 @@ inline int dataSize(miopenDataType_t dataType)
     case miopenFloat: return 4;
     case miopenBFloat16: return 2;
     default: return 8;
+  }
+}
+
+// The stride for a size-1 dimensions is not uniquely determined; in
+// fact, it can be anything you want, because the fact that the
+// tensor is size 1 at this dimension means that you will never actually
+// try advancing your pointer by this stride.
+//
+// We duplicate the CuDNN restriction here for MIOpen.
+//
+// However, CuDNN has a much more stringent requirement on strides:
+// if you are passing a contiguous input, it better be the case
+// that the stride for dim i is the product of the sizes of dims
+// i+1 to the end.  This stride is indeed uniquely determined.  This
+// function modifies 'stride' in place so this invariant holds.
+template <typename T>
+static inline void fixSizeOneDimStride(int dim, const T *size, T *stride, bool nhwc) {
+  int64_t z = 1;
+  int index = 0;
+  std::vector<int> permutation(dim);
+
+  if (nhwc) {
+    permutation[index++] = 1;
+  }
+  for (int d = dim-1; d > 1; d--) {
+    permutation[index++] = d;
+  }
+  if (!nhwc) {
+    permutation[index++] = 1;
+  }
+  permutation[index++] = 0;
+  for (int d : permutation) {
+    if (size[d] == 1) {
+      stride[d] = z;
+    } else {
+      z *= size[d];
+    }
   }
 }
 
@@ -41,6 +81,8 @@ template <typename T, miopenStatus_t (*ctor)(T**), miopenStatus_t (*dtor)(T*)>
 // NOLINTNEXTLINE(bugprone-exception-escape)
 class TORCH_HIP_CPP_API Descriptor {
  public:
+  // TODO: Figure out why const-correctness doesn't work here
+
   // Use desc() to access the underlying descriptor pointer in
   // a read-only fashion.  Most client code should use this.
   // If the descriptor was never initialized, this will return
@@ -75,14 +117,32 @@ class TORCH_HIP_CPP_API TensorDescriptor : public Descriptor<
     set(t, pad);
   }
 
+  // Note [MIOpen broadcast padding]
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // pad specifies the minimum dimensionality of the tensor descriptor
+  // we produce (it doesn't have anything to do with, e.g., convolution
+  // padding).  If 't' is lower-dimensional than 'pad', the remaining
+  // dimensions (on the right) are padded with ones.  This doesn't
+  // affect the underlying data layout.  This is particularly useful for
+  // dealing with a peculiarity of the MIOpen API, which is that broadcasting in MIOpen is
+  // done in two steps: first, the client code is expected to pad out
+  // (the dimensions) input tensors to be the same dimension as the
+  // target broadcast, and then second, MIOpen takes of actually
+  // broadcasting size 1 dimensions.
+
   void set(const at::Tensor &t, size_t pad = 0);
+  void set(const at::Tensor &t, at::MemoryFormat memory_format, size_t pad = 0);
   void set(miopenDataType_t dataType, IntArrayRef sizes, IntArrayRef strides, size_t pad = 0);
 
   void print();
 
 private:
-  void set(miopenDataType_t dataType, int dim, int* size, int* stride) {
-    MIOPEN_CHECK(miopenSetTensorDescriptor(mut_desc(), dataType, dim, size, stride));
+  void set(miopenDataType_t dataType, IntArrayRef sizes, IntArrayRef strides, size_t pad, bool nhwc);
+
+  void set(miopenDataType_t dataType, int dim, int* size, int* stride, bool nhwc) {
+    std::vector<int> strides_copy(stride, stride + dim);
+    fixSizeOneDimStride<int>(dim, size, strides_copy.data(), nhwc);
+    MIOPEN_CHECK(miopenSetTensorDescriptor(mut_desc(), dataType, dim, size, strides_copy.data()));
   }
 };
 
@@ -99,11 +159,14 @@ class TORCH_HIP_CPP_API FilterDescriptor : public Descriptor<
 
   void set(const at::Tensor &t, const at::MemoryFormat memory_format, int64_t pad = 0);
 
+  void print();
 private:
   void set(miopenDataType_t dataType, int dim, int* size, int* stride) {
     MIOPEN_CHECK(miopenSetTensorDescriptor(mut_desc(), dataType, dim, size, stride));
   }
 };
+
+std::ostream& operator<<(std::ostream & out, const FilterDescriptor& d);
 
 struct TORCH_HIP_CPP_API ConvolutionDescriptor
     : public Descriptor<
@@ -166,4 +229,4 @@ union Constant
   }
 };
 
-}}  // namespace
+} // namespace

--- a/aten/src/ATen/native/ConvUtils.h
+++ b/aten/src/ATen/native/ConvUtils.h
@@ -392,6 +392,11 @@ inline at::MemoryFormat miopen_conv_suggest_memory_format(const at::Tensor& inpu
   return at::MemoryFormat::Contiguous;
 }
 
+// deprecated, but to remove would be BC-breaking
+inline bool miopen_conv_use_channels_last(const at::Tensor& input, const at::Tensor& weight) {
+  return miopen_conv_suggest_memory_format(input, weight) != at::MemoryFormat::Contiguous;
+}
+
 inline bool mkldnn_conv_use_channels_last(const at::Tensor& input, const at::Tensor& weight) {
 
   // disable NHWC for float64 input.

--- a/aten/src/ATen/native/ConvUtils.h
+++ b/aten/src/ATen/native/ConvUtils.h
@@ -353,19 +353,21 @@ TORCH_API void _cudnn_set_conv_benchmark_empty_cache(bool enable);
 TORCH_API bool _cudnn_get_conv_benchmark_empty_cache();
 
 
-inline bool miopen_conv_use_channels_last(const at::Tensor& input, const at::Tensor& weight) {
-
+inline at::MemoryFormat miopen_conv_suggest_memory_format(const at::Tensor& input, const at::Tensor& weight) {
   // disable NHWC for float64 input.
   if (!at::detail::getCUDAHooks().compiledWithMIOpen() ||
       input.scalar_type() == at::kDouble ||
       weight.scalar_type() == at::kDouble) {
-    return false;
+    return at::MemoryFormat::Contiguous;
   }
 
   // TODO: Remove PYTORCH_MIOPEN_SUGGEST_NHWC once ROCm officially supports NHWC in MIOpen
-  // See #64427
-  static std::optional<bool> PYTORCH_MIOPEN_SUGGEST_NHWC = c10::utils::check_env("PYTORCH_MIOPEN_SUGGEST_NHWC");
-  static bool suggest_nhwc = PYTORCH_MIOPEN_SUGGEST_NHWC && *PYTORCH_MIOPEN_SUGGEST_NHWC;
+  // See https://github.com/pytorch/pytorch/issues/64427.
+  // non static variable is used to be able to change environment variable in runtime for testing
+  // enabled by default for ROCm >= 7.0.0 with miopen 3.5
+  int miopen_version = detail::getCUDAHooks().compiledWithMIOpen() ? detail::getCUDAHooks().versionMIOpen() : 0;
+  bool is_miopen_3_5 = miopen_version >= 30500;  // ROCm 7.0
+  bool suggest_nhwc = c10::utils::check_env("PYTORCH_MIOPEN_SUGGEST_NHWC").value_or(is_miopen_3_5);
 
   auto input_memory_format = input.suggest_memory_format();
   auto weight_memory_format = weight.suggest_memory_format();
@@ -375,13 +377,19 @@ inline bool miopen_conv_use_channels_last(const at::Tensor& input, const at::Ten
     (input_memory_format  == at::MemoryFormat::ChannelsLast) ||
     (weight_memory_format == at::MemoryFormat::ChannelsLast)
   );
+  if (can_use_miopen_channels_last_2d) {
+    return at::MemoryFormat::ChannelsLast;
+  }
 
   bool can_use_miopen_channels_last_3d = suggest_nhwc && (weight_ndim == 5) && (
     (input_memory_format  == at::MemoryFormat::ChannelsLast3d) ||
     (weight_memory_format == at::MemoryFormat::ChannelsLast3d)
   );
+  if (can_use_miopen_channels_last_3d) {
+    return at::MemoryFormat::ChannelsLast3d;
+  }
 
-  return can_use_miopen_channels_last_2d || can_use_miopen_channels_last_3d;
+  return at::MemoryFormat::Contiguous;
 }
 
 inline bool mkldnn_conv_use_channels_last(const at::Tensor& input, const at::Tensor& weight) {

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -1573,8 +1573,16 @@ at::Tensor _convolution(
     case ConvBackend::Miopen:
       check_input_same_type_as_parameters(input, weight, bias);
       output = at::miopen_convolution(
-          input.contiguous(backend_memory_format), weight, bias, params.padding, params.stride,
-          params.dilation, params.groups, params.benchmark, params.deterministic);
+          input.contiguous(backend_memory_format),
+          weight,
+          bias,
+          params.padding,
+          params.stride,
+          params.dilation,
+          params.groups,
+          params.benchmark,
+          params.deterministic,
+          params.allow_tf32);
       break;
     case ConvBackend::MiopenDepthwise:
       output = at::miopen_depthwise_convolution(

--- a/aten/src/ATen/native/miopen/ConvPlaceholders.cpp
+++ b/aten/src/ATen/native/miopen/ConvPlaceholders.cpp
@@ -34,7 +34,8 @@ at::Tensor miopen_convolution(
     IntArrayRef dilation,
     int64_t groups,
     bool benchmark,
-    bool deterministic) {
+    bool deterministic,
+    bool allow_tf32) {
   TORCH_CHECK(
       false,
       "miopen_convolution: ATen not compiled with MIOpen support");

--- a/aten/src/ATen/native/miopen/ConvPlaceholders.cpp
+++ b/aten/src/ATen/native/miopen/ConvPlaceholders.cpp
@@ -1,0 +1,266 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/cuda/CUDAConfig.h>  // for the definition of AT_ROCM_ENABLED
+#include <ATen/core/Tensor.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/miopen_convolution_add_relu_native.h>
+#include <ATen/ops/miopen_convolution_native.h>
+#include <ATen/ops/miopen_convolution_relu_native.h>
+#include <ATen/ops/miopen_convolution_transpose_native.h>
+#include <ATen/ops/miopen_depthwise_convolution_native.h>
+#endif
+
+namespace at::native {
+
+// ---------------------------------------------------------------------
+//
+// Placeholder operators
+//
+// ---------------------------------------------------------------------
+
+#if !AT_ROCM_ENABLED()
+
+// See Note [ATen preprocessor philosophy]
+
+at::Tensor miopen_convolution(
+    const Tensor& input,
+    const Tensor& weight,
+    const std::optional<Tensor>& bias_opt,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic) {
+  TORCH_CHECK(
+      false,
+      "miopen_convolution: ATen not compiled with MIOpen support");
+}
+
+at::Tensor& miopen_convolution_out(
+    const Tensor& input,
+    const Tensor& weight,
+    const std::optional<Tensor>& bias_opt,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic,
+    Tensor& output_t) {
+  TORCH_CHECK(
+      false,
+      "miopen_convolution_out: ATen not compiled with MIOpen support");
+}
+
+at::Tensor miopen_convolution_backward_input(
+    IntArrayRef input_size,
+    const at::Tensor& grad_output,
+    const at::Tensor& weight,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic) {
+  TORCH_CHECK(
+      false,
+      "miopen_convolution_backward_input: ATen not compiled with MIOpen support");
+}
+
+at::Tensor miopen_convolution_backward_weight(
+    IntArrayRef weight_size,
+    const at::Tensor& grad_output,
+    const at::Tensor& input,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic) {
+  TORCH_CHECK(
+      false,
+      "miopen_convolution_backward_weight: ATen not compiled with MIOpen support");
+}
+
+at::Tensor miopen_convolution_backward_bias(
+    const at::Tensor& grad_output) {
+  TORCH_CHECK(
+      false,
+      "miopen_convolution_backward_bias: ATen not compiled with MIOpen support");
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor> miopen_convolution_backward(
+    const at::Tensor& input,
+    const at::Tensor& grad_output,
+    const at::Tensor& weight,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic,
+    std::array<bool,3> output_mask) {
+  TORCH_CHECK(
+      false,
+      "miopen_convolution_backward: ATen not compiled with MIOpen support");
+}
+
+at::Tensor miopen_convolution_transpose(
+    const Tensor& input,
+    const Tensor& weight,
+    const std::optional<Tensor>& bias_opt,
+    IntArrayRef padding,
+    IntArrayRef output_padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic) {
+  TORCH_CHECK(
+      false,
+      "miopen_convolution_transpose: ATen not compiled with MIOpen support");
+}
+
+at::Tensor miopen_convolution_transpose_backward_input(
+    const at::Tensor& grad_output,
+    const at::Tensor& weight,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic) {
+  TORCH_CHECK(
+      false,
+      "miopen_convolution_transpose_backward: ATen not compiled with MIOpen support");
+}
+
+at::Tensor miopen_convolution_transpose_backward_weight(
+    IntArrayRef weight_size,
+    const at::Tensor& grad_output,
+    const at::Tensor& input,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic) {
+  TORCH_CHECK(
+      false,
+      "miopen_convolution_transpose_backward_weight: ATen not compiled with MIOpen support");
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor> miopen_convolution_transpose_backward(
+    const at::Tensor& input,
+    const at::Tensor& grad_output,
+    const at::Tensor& weight,
+    IntArrayRef padding,
+    IntArrayRef output_padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic,
+    std::array<bool,3> output_mask) {
+  TORCH_CHECK(
+      false,
+      "miopen_convolution_transpose_backward: ATen not compiled with MIOpen support");
+}
+
+at::Tensor miopen_depthwise_convolution(
+    const Tensor& input,
+    const Tensor& weight,
+    const std::optional<Tensor>& bias_opt,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic) {
+  TORCH_CHECK(
+      false,
+      "miopen_depthwise_convolution: ATen not compiled with MIOpen support");
+}
+
+at::Tensor miopen_depthwise_convolution_backward_input(
+    IntArrayRef input_size,
+    const at::Tensor& grad_output,
+    const at::Tensor& weight,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic) {
+  TORCH_CHECK(
+      false,
+      "miopen_depthwise_convolution_backward_input: ATen not compiled with MIOpen support");
+}
+
+at::Tensor miopen_depthwise_convolution_backward_weight(
+    IntArrayRef weight_size,
+    const at::Tensor& grad_output,
+    const at::Tensor& input,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic) {
+  TORCH_CHECK(
+      false,
+      "miopen_depthwise_convolution_backward_weight: ATen not compiled with MIOpen support");
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor> miopen_depthwise_convolution_backward(
+    const at::Tensor& input,
+    const at::Tensor& grad_output,
+    const at::Tensor& weight,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic,
+    std::array<bool,3> output_mask) {
+  TORCH_CHECK(
+      false,
+      "miopen_depthwise_convolution_backward: ATen not compiled with MIOpen support");
+}
+
+
+at::Tensor miopen_convolution_add_relu(
+    const at::Tensor& input,
+    const at::Tensor& weight,
+    const at::Tensor& z,
+    const std::optional<Scalar>& alpha,
+    const std::optional<Tensor>& bias,
+    IntArrayRef stride,
+    IntArrayRef padding,
+    IntArrayRef dilation,
+    int64_t groups) {
+  TORCH_CHECK(
+      false,
+      "miopen_convolution_add_relu: ATen not compiled with MIOpen support");
+}
+
+at::Tensor miopen_convolution_relu(
+    const at::Tensor& input,
+    const at::Tensor& weight,
+    const std::optional<Tensor>& bias,
+    IntArrayRef stride,
+    IntArrayRef padding,
+    IntArrayRef dilation,
+    int64_t groups) {
+  TORCH_CHECK(
+      false,
+      "miopen_convolution_relu: ATen not compiled with MIOpen support");
+}
+
+#endif // AT_ROCM_ENABLED()
+
+} // namespace at::native

--- a/aten/src/ATen/native/miopen/Conv_miopen.cpp
+++ b/aten/src/ATen/native/miopen/Conv_miopen.cpp
@@ -1,7 +1,9 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/cuda/CUDAConfig.h>  // for the definition of AT_ROCM_ENABLED
+
+#if AT_ROCM_ENABLED()
+
 #include <ATen/core/Tensor.h>
-#include <ATen/Config.h>
-#include <ATen/native/ConvUtils.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -9,7 +11,6 @@
 #else
 #include <ATen/ops/empty.h>
 #include <ATen/ops/empty_like.h>
-#include <ATen/ops/empty_native.h>
 #include <ATen/ops/miopen_convolution_add_relu_native.h>
 #include <ATen/ops/miopen_convolution_native.h>
 #include <ATen/ops/miopen_convolution_relu_native.h>
@@ -18,162 +19,88 @@
 #include <ATen/ops/squeeze.h>
 #include <ATen/ops/sum.h>
 #include <ATen/ops/zeros.h>
+#include <ATen/ops/zeros_like.h>
 #endif
 
-// TODO: Remove the condition on AT_ROCM_ENABLED entirely,
-// don't build this file as part of CPU build.
-#include <ATen/cuda/CUDAConfig.h>
+#include <ATen/Config.h>
 
-#if !AT_ROCM_ENABLED()
-
-namespace at { namespace native {
-
-// See Note [ATen preprocessor philosophy]
-
-at::Tensor miopen_convolution(
-    const Tensor& input, const Tensor& weight, const std::optional<Tensor>& bias_opt /* optional */,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation,
-    int64_t groups, bool benchmark, bool deterministic) {
-  TORCH_CHECK(false, "miopen_convolution: ATen not compiled with MIOpen support");
-}
-
-at::Tensor miopen_convolution_backward_input(
-    IntArrayRef input_size, const at::Tensor& grad_output, const at::Tensor& weight,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
-    bool benchmark, bool deterministic) {
-  TORCH_CHECK(false, "miopen_convolution_backward_input: ATen not compiled with MIOpen support");
-}
-
-at::Tensor miopen_convolution_backward_weight(
-    IntArrayRef weight_size, const at::Tensor& grad_output, const at::Tensor& input,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
-    bool benchmark, bool deterministic) {
-  TORCH_CHECK(false, "miopen_convolution_backward_weight: ATen not compiled with MIOpen support");
-}
-
-at::Tensor miopen_convolution_backward_bias(
-    const at::Tensor& grad_output) {
-  TORCH_CHECK(false, "miopen_convolution_backward_bias: ATen not compiled with MIOpen support");
-}
-
-std::tuple<at::Tensor,at::Tensor,at::Tensor> miopen_convolution_backward(
-    const at::Tensor& input, const at::Tensor& grad_output, const at::Tensor& weight,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
-    bool benchmark, bool deterministic, std::array<bool,3> output_mask) {
-  TORCH_CHECK(false, "miopen_convolution_backward: ATen not compiled with MIOpen support");
-}
-
-at::Tensor miopen_convolution_transpose(
-    const Tensor& input, const Tensor& weight, const std::optional<Tensor>& bias_opt /* optional */,
-    IntArrayRef padding, IntArrayRef output_padding, IntArrayRef stride, IntArrayRef dilation,
-    int64_t groups, bool benchmark, bool deterministic) {
-  TORCH_CHECK(false, "miopen_convolution_transpose: ATen not compiled with MIOpen support");
-}
-
-at::Tensor miopen_convolution_transpose_backward_input(
-    const at::Tensor& grad_output, const at::Tensor& weight,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation,
-    int64_t groups, bool benchmark, bool deterministic) {
-  TORCH_CHECK(false, "miopen_convolution_transpose_backward: ATen not compiled with MIOpen support");
-}
-
-at::Tensor miopen_convolution_transpose_backward_weight(
-    IntArrayRef weight_size, const at::Tensor& grad_output, const at::Tensor& input,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
-    bool benchmark, bool deterministic) {
-  TORCH_CHECK(false, "miopen_convolution_transpose_backward_weight: ATen not compiled with MIOpen support");
-}
-
-std::tuple<at::Tensor,at::Tensor,at::Tensor> miopen_convolution_transpose_backward(
-    const at::Tensor& input, const at::Tensor& grad_output, const at::Tensor& weight,
-    IntArrayRef padding, IntArrayRef output_padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
-    bool benchmark, bool deterministic, std::array<bool,3> output_mask) {
-  TORCH_CHECK(false, "miopen_convolution_transpose_backward: ATen not compiled with MIOpen support");
-}
-
-at::Tensor miopen_depthwise_convolution(
-    const Tensor& input, const Tensor& weight, const std::optional<Tensor>& bias_opt /* optional */,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation,
-    int64_t groups, bool benchmark, bool deterministic) {
-  TORCH_CHECK(false, "miopen_depthwise_convolution: ATen not compiled with MIOpen support");
-}
-
-at::Tensor miopen_depthwise_convolution_backward_input(
-    IntArrayRef input_size, const at::Tensor& grad_output, const at::Tensor& weight,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
-    bool benchmark, bool deterministic) {
-  TORCH_CHECK(false, "miopen_depthwise_convolution_backward_input: ATen not compiled with MIOpen support");
-}
-
-at::Tensor miopen_depthwise_convolution_backward_weight(
-    IntArrayRef weight_size, const at::Tensor& grad_output, const at::Tensor& input,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
-    bool benchmark, bool deterministic) {
-  TORCH_CHECK(false, "miopen_depthwise_convolution_backward_weight: ATen not compiled with MIOpen support");
-}
-
-std::tuple<at::Tensor,at::Tensor,at::Tensor> miopen_depthwise_convolution_backward(
-    const at::Tensor& input, const at::Tensor& grad_output, const at::Tensor& weight,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
-    bool benchmark, bool deterministic, std::array<bool,3> output_mask) {
-  TORCH_CHECK(false, "miopen_depthwise_convolution_backward: ATen not compiled with MIOpen support");
-}
-
-
-at::Tensor miopen_convolution_add_relu(
-    const at::Tensor& input, const at::Tensor& weight, const at::Tensor& z,
-    const std::optional<Scalar>& alpha, const std::optional<Tensor>& bias, IntArrayRef stride,
-    IntArrayRef padding, IntArrayRef dilation, int64_t groups) {
-  TORCH_CHECK(false, "miopen_convolution_add_relu: ATen not compiled with MIOpen support");
-}
-
-at::Tensor miopen_convolution_relu(
-    const at::Tensor& input, const at::Tensor& weight, const std::optional<Tensor>& bias,
-    IntArrayRef stride, IntArrayRef padding, IntArrayRef dilation, int64_t groups) {
-  TORCH_CHECK(false, "miopen_convolution_relu: ATen not compiled with MIOpen support");
-}
-
-}}
-
-#else  // AT_ROCM_ENABLED
-
+#include <ATen/hip/EmptyTensor.h>
 #include <ATen/miopen/miopen-wrapper.h>
 #include <ATen/miopen/Descriptors.h>
 #include <ATen/miopen/Types.h>
 #include <ATen/miopen/Utils.h>
-#include <ATen/hip/EmptyTensor.h>
+#include <ATen/native/ConvUtils.h>
+#include <ATen/native/utils/ParamsHash.h>
 
 #include <ATen/TensorUtils.h>
-#include <ATen/native/ConvUtils.h>
+#include <c10/hip/HIPCachingAllocator.h>
 #include <c10/util/irange.h>
 
-#include <c10/hip/HIPCachingAllocator.h>
-
+#include <stdint.h>
+#include <algorithm>
 #include <functional>
 #include <iterator>
-#include <sstream>
-#include <algorithm>
 #include <memory>
 #include <mutex>
-#include <stdint.h>
+#include <sstream>
 #include <unordered_map>
+#include <vector>
 
 #define AT_MIOPEN_MAX_SOLUTIONS 10
 
-namespace at { namespace native {
+namespace at::native {
 
-Tensor narrowGroup(const Tensor& t, int dim, int group_idx, int64_t groups) {
-  auto group_size = t.size(dim) / groups;
-  return t.narrow(dim, group_idx * group_size, group_size);
-}
+// ConvPlaceholders.cpp contains placeholder implementation of miopen
+// convolution when miopen is not enabled. These operators only raises
+// errors, and do no real computation. These operators are implemented
+// using current operators.
+//
+// NOTE [ Convolution design ]
+//
+// miopen convolutions does not handle bias. Bias is handled outside.
+// However, bias is passed as an optional Tensor in torch's public miopen APIs.
+//
+// The general strategy:
+//
+//    - miopen_convolution (Tensor)
+//      Entry points for clients
+//
+//    - miopen_convolution_forward (TensorArg)
+//      Entry point, which may be reused between regular
+//      convolution and transposed convolution.
+//
+//    - raw_miopen_convolution_forward_out (Tensor)
+//      Directly invokes MIOpen.
+//
+// There are a few reasons raw should never be directly exposed
+// via ATen:
+//
+//    - It takes output as a parameter (this should be computed!)
+//    - It doesn't do input checking
+//    - It doesn't resize output (it is assumed to be correctly sized)
+//
+// Where does argument checking happen?  Here's the division of
+// responsibility:
+//  - Things that happen in at::Tensor
+//    - TensorArg allocation
+//  - Things that happen in TensorArg
+//    - Check arguments (type, GPU, shape)
+
+// ---------------------------------------------------------------------
+//
+// Helper classes
+//
+// ---------------------------------------------------------------------
 
 // This POD struct is used to let us easily compute hashes of the
 // parameters
-struct ConvolutionParams
-{
+struct ConvolutionParams {
+  c10::DeviceIndex device_id; //This is needed to distinguish between miopen handles of multiple gpus.
   miopenHandle_t handle;
   miopenDataType_t dataType;
   int input_size[2 + max_dim];
+  uint8_t input_dim;
+  at::MemoryFormat memory_format;
   int input_stride[2 + max_dim];
   int weight_size[2 + max_dim];
   int padding[max_dim];
@@ -181,29 +108,46 @@ struct ConvolutionParams
   int dilation[max_dim];
   int64_t groups;
   bool deterministic;
-  int device_id; //This is needed to distinguish between miopen handles of multiple gpus.
   // NB: transposed purposely omitted: transposed just swaps
   // forward and backward, so you can reuse the benchmark entry,
 };
-// ConvolutionParams must be a POD because we read out its memory
-// contenst as char* when hashing
-static_assert(std::is_standard_layout_v<ConvolutionParams>, "ConvolutionParams not POD");
+
+std::ostream& operator<<(std::ostream& out, const ConvolutionParams& params) {
+  out << "ConvolutionParams \n"
+      << "    memory_format = " << params.memory_format << "\n"
+      << "    data_type = " << miopenTypeToString(params.dataType) << "\n"
+      << "    padding = " << ArrayRef<int>{params.padding} << "\n"
+      << "    stride = " << ArrayRef<int>{params.stride} << "\n"
+      << "    dilation = " << ArrayRef<int>{params.dilation} << "\n"
+      << "    groups = " << params.groups << "\n"
+      << "    deterministic = " << (params.deterministic ? "true" : "false") << "\n";
+
+  return out;
+}
 
 void setConvolutionParams(
-    ConvolutionParams* params, miopenHandle_t handle,
-    const at::Tensor& input, const at::Tensor& weight,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation,
-    int64_t groups, bool deterministic) {
-
+    ConvolutionParams* params,
+    miopenHandle_t handle,
+    const at::Tensor& input,
+    const at::Tensor& weight,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool deterministic,
+    at::MemoryFormat memory_format) {
   miopenDataType_t dataType = getMiopenDataType(input);
   memset(params, 0, sizeof(ConvolutionParams));
+  params->device_id = at::cuda::current_device();
   params->dataType = dataType;
   params->handle = handle;
   // ASSERT(weight.dim() == input.dim())
-  for (int i = 0; i != input.dim(); ++i) {
-    params->input_size[i] = (int) input.size(i);
-    params->input_stride[i] = (int) input.stride(i);
-    params->weight_size[i] = (int) weight.size(i);
+  params->input_dim = input.dim();
+  params->memory_format = memory_format;
+  for (int i = 0; i != params->input_dim; ++i) {
+    params->input_size[i] = (int)input.sizes()[i];
+    params->weight_size[i] = (int)weight.sizes()[i];
+    params->input_stride[i] = (int)input.stride(i);
   }
   // ASSERT(padding.size() == stride.size())
   // ASSERT(padding.size() == dilation.size())
@@ -214,9 +158,65 @@ void setConvolutionParams(
   }
   params->groups = groups;
   params->deterministic = deterministic;
-  int device_id;
-  HIP_CHECK(hipGetDevice(&device_id));
-  params->device_id = device_id;
+}
+
+std::string repro_from_args(const ConvolutionParams& params) {
+  auto pybool = [](bool b) -> const char* { return b ? "True" : "False"; };
+  std::string partial_dtype;
+  switch (params.dataType) {
+    case miopenFloat:
+      partial_dtype = "float";
+      break;
+    case miopenHalf:
+      partial_dtype = "half";
+      break;
+    case miopenBFloat16:
+      partial_dtype = "bfloat16";
+      break;
+    default:
+      partial_dtype = "unsupported";
+  }
+  const std::string full_dtype = "torch." + partial_dtype;
+  const int out_channels = params.weight_size[0];
+  const int in_channels = params.weight_size[1] * params.groups;
+  const size_t dim = params.input_dim;
+  const std::string channels_last_xd =
+      dim == 4 ? "channels_last" : "channels_last_3d";
+  const std::string to_channels_last =
+      ((params.memory_format == at::MemoryFormat::ChannelsLast) ||
+       (params.memory_format == at::MemoryFormat::ChannelsLast3d))
+      ? ".to(memory_format=torch." + channels_last_xd + ")"
+      : "";
+
+  std::ostringstream ss;
+  ss << "You can try to repro this exception using the following code snippet. ";
+  ss << "If that doesn't trigger the error, please include your original repro script when reporting this issue.\n\n";
+  ss << "import torch\n";
+  ss << "torch.backends.cuda.matmul.allow_tf32 = "
+     << pybool(at::globalContext().float32Precision("cuda", "matmul") == "tf32")
+     << "\n";
+  ss << "torch.backends.cudnn.benchmark = "
+     << pybool(at::globalContext().benchmarkCuDNN()) << "\n";
+  ss << "torch.backends.cudnn.deterministic = " << pybool(params.deterministic)
+     << "\n";
+  ss << "data = torch.randn(" << ArrayRef<int>(params.input_size, dim)
+     << ", dtype=" << full_dtype << ", ";
+  ss << "device='cuda', requires_grad=True)" << to_channels_last << "\n";
+  ss << "net = torch.nn.Conv" << dim - 2 << "d(" << in_channels << ", "
+     << out_channels << ", ";
+  ss << "kernel_size=" << ArrayRef<int>(&params.weight_size[2], dim - 2)
+     << ", ";
+  ss << "padding=" << ArrayRef<int>(params.padding, dim - 2) << ", ";
+  ss << "stride=" << ArrayRef<int>(params.stride, dim - 2) << ", ";
+  ss << "dilation=" << ArrayRef<int>(params.dilation, dim - 2) << ", ";
+  ss << "groups=" << params.groups << ")\n";
+  ss << "net = net.cuda()." << partial_dtype << "()" << to_channels_last
+     << "\n";
+  ss << "out = net(data)\n";
+  ss << "out.backward(torch.randn_like(out))\n";
+  ss << "torch.cuda.synchronize()\n\n";
+
+  return ss.str();
 }
 
 // Convenience struct for passing around descriptors and data
@@ -226,12 +226,30 @@ struct ConvolutionArgs {
   ConvolutionParams params;
   TensorDescriptor idesc, odesc;
   FilterDescriptor wdesc;
-  const Tensor& input, output, weight;
+  const Tensor &input, output, weight;
   ConvolutionDescriptor cdesc;
 
-  ConvolutionArgs(const Tensor& input, const Tensor& output, const Tensor& weight) : input(input), output(output), weight(weight) {
-  }
+  ConvolutionArgs(
+      const Tensor& input,
+      const Tensor& output,
+      const Tensor& weight)
+      : input(input), output(output), weight(weight) {}
 };
+
+std::ostream& operator<<(std::ostream& out, const ConvolutionArgs& args) {
+  out << repro_from_args(args.params) // already has a trailing newline
+      << args.params // already has a trailing newline
+      << "input: " << args.idesc // already has a trailing newline
+      << "output: " << args.odesc // already has a trailing newline
+      << "weight: " << args.wdesc // already has a trailing newline
+      << "Pointer addresses: "
+      << "\n"
+      << "    input: " << args.input.const_data_ptr() << "\n"
+      << "    output: " << args.output.const_data_ptr() << "\n"
+      << "    weight: " << args.weight.const_data_ptr() << "\n";
+
+  return out;
+}
 
 // ---------------------------------------------------------------------
 //
@@ -239,31 +257,15 @@ struct ConvolutionArgs {
 //
 // ---------------------------------------------------------------------
 
-// Hashing machinery for ConvolutionParams
-struct ParamsHash {
-  std::size_t operator()(const ConvolutionParams& params) const {
-    auto ptr = reinterpret_cast<const uint8_t*>(&params);
-    uint32_t value = 0x811C9DC5;
-    for (const auto i : c10::irange((int)sizeof(ConvolutionParams))) {
-      value ^= ptr[i];
-      value *= 0x01000193;
-    }
-    return (size_t)value;
-  }
-};
-
-struct ParamsEqual {
-  bool operator()(const ConvolutionParams& a, const ConvolutionParams& b) const {
-    auto ptr1 = reinterpret_cast<const uint8_t*>(&a);
-    auto ptr2 = reinterpret_cast<const uint8_t*>(&b);
-    return memcmp(ptr1, ptr2, sizeof(ConvolutionParams)) == 0;
-  }
-};
-
 template <typename T>
 struct BenchmarkCache {
   std::mutex mutex;
-  std::unordered_map<ConvolutionParams, T, ParamsHash, ParamsEqual> map;
+  std::unordered_map<
+      ConvolutionParams,
+      T,
+      ParamsHash<ConvolutionParams>,
+      ParamsEqual<ConvolutionParams>>
+      map;
 
   bool find(const ConvolutionParams& params, T* results) {
     std::lock_guard<std::mutex> guard(mutex);
@@ -306,56 +308,55 @@ struct Workspace {
   void* data;
 };
 
-template<typename algo_t>
-struct algorithm_search {
-};
+template <typename algo_t>
+struct algorithm_search {};
 
 size_t getWorkspaceSize(
-    const ConvolutionArgs& args, const miopenConvFwdAlgorithm_t)
-{
-    size_t sz = 0;
-    miopenConvolutionForwardGetWorkSpaceSize(
-        args.handle,
-        args.wdesc.desc(),
-        args.idesc.desc(),
-        args.cdesc.desc(),
-        args.odesc.desc(),
-        &sz);
-    return sz;
+    const ConvolutionArgs& args,
+    const miopenConvFwdAlgorithm_t) {
+  size_t sz = 0;
+  MIOPEN_CHECK(miopenConvolutionForwardGetWorkSpaceSize(
+      args.handle,
+      args.wdesc.desc(),
+      args.idesc.desc(),
+      args.cdesc.desc(),
+      args.odesc.desc(),
+      &sz));
+  return sz;
 }
 size_t getWorkspaceSize(
-    const ConvolutionArgs& args, const miopenConvBwdDataAlgorithm_t)
-{
-    size_t sz = 0;
-    miopenConvolutionBackwardDataGetWorkSpaceSize(
-        args.handle,
-        args.odesc.desc(),
-        args.wdesc.desc(),
-        args.cdesc.desc(),
-        args.idesc.desc(),
-        &sz);
-    return sz;
+    const ConvolutionArgs& args,
+    const miopenConvBwdDataAlgorithm_t) {
+  size_t sz = 0;
+  MIOPEN_CHECK(miopenConvolutionBackwardDataGetWorkSpaceSize(
+      args.handle,
+      args.odesc.desc(),
+      args.wdesc.desc(),
+      args.cdesc.desc(),
+      args.idesc.desc(),
+      &sz));
+  return sz;
 }
 size_t getWorkspaceSize(
-    const ConvolutionArgs& args, const miopenConvBwdWeightsAlgorithm_t)
-{
-    size_t sz = 0;
-    miopenConvolutionBackwardWeightsGetWorkSpaceSize(
-        args.handle,
-        args.odesc.desc(),
-        args.idesc.desc(),
-        args.cdesc.desc(),
-        args.wdesc.desc(),
-        &sz);
-    return sz;
+    const ConvolutionArgs& args,
+    const miopenConvBwdWeightsAlgorithm_t) {
+  size_t sz = 0;
+  MIOPEN_CHECK(miopenConvolutionBackwardWeightsGetWorkSpaceSize(
+      args.handle,
+      args.odesc.desc(),
+      args.idesc.desc(),
+      args.cdesc.desc(),
+      args.wdesc.desc(),
+      &sz));
+  return sz;
 }
 
-template<typename perf_t>
+template <typename perf_t>
 perf_t getBestAlgorithm(perf_t *perfResults, bool deterministic, int n_algo) {
   return perfResults[0];
 }
 
-template<>
+template <>
 struct algorithm_search<miopenConvFwdAlgorithm_t> {
   using perf_t = miopenConvAlgoPerf_t;
   using algo_t = miopenConvFwdAlgorithm_t;
@@ -428,7 +429,7 @@ struct algorithm_search<miopenConvFwdAlgorithm_t> {
   }
 };
 
-template<>
+template <>
 struct algorithm_search<miopenConvBwdDataAlgorithm_t> {
   using perf_t = miopenConvAlgoPerf_t;
   using algo_t = miopenConvBwdDataAlgorithm_t;
@@ -501,7 +502,7 @@ struct algorithm_search<miopenConvBwdDataAlgorithm_t> {
   }
 };
 
-template<>
+template <>
 struct algorithm_search<miopenConvBwdWeightsAlgorithm_t> {
   using perf_t = miopenConvAlgoPerf_t;
   using algo_t = miopenConvBwdWeightsAlgorithm_t;
@@ -574,22 +575,13 @@ struct algorithm_search<miopenConvBwdWeightsAlgorithm_t> {
   }
 };
 
-template<typename algo_t>
+template <typename algo_t>
 void findAlgorithm(const ConvolutionArgs& args, bool benchmark, algo_t* algo) {
   using search = algorithm_search<algo_t>;
   auto& cache = search::cache();
   auto& wsscache = search::wsscache();
 
   if (cache.find(args.params, algo)) {
-    return;
-  }
-
-  if (args.params.deterministic && !benchmark) {
-    *algo = search::DEFAULT_ALGO;
-  }
-
-  if (cache.find(args.params, algo)) {
-    // re-check cache since another thread may have benchmarked the algorithm
     return;
   }
 
@@ -600,12 +592,11 @@ void findAlgorithm(const ConvolutionArgs& args, bool benchmark, algo_t* algo) {
   wsscache.insert(args.params, perfResults.memory);
 
   if (at::native::_cudnn_get_conv_benchmark_empty_cache()) {
-      c10::hip::HIPCachingAllocator::emptyCache();
+    c10::hip::HIPCachingAllocator::emptyCache();
   }
-
 }
 
-template<typename algo_t>
+template <typename algo_t>
 Workspace chooseAlgorithm(
     const ConvolutionArgs& args,
     bool benchmark,
@@ -631,7 +622,7 @@ Workspace chooseAlgorithm(
   }
 }
 
-template<typename algo_t>
+template <typename algo_t>
 Workspace chooseSolution(const ConvolutionArgs& args, uint64_t* solution_id)
 {
   using search = algorithm_search<algo_t>;
@@ -647,6 +638,104 @@ Workspace chooseSolution(const ConvolutionArgs& args, uint64_t* solution_id)
     *solution_id = solution.solution_id;
     return Workspace(solution.workspace_size);
   }
+}
+
+// NOTE [ raw_miopen_convolution_forward_out ]
+//
+//    - raw_miopen_convolution_forward_out (Tensor)
+//      Functiont that handles tensors that are too large to use 32bit indexing.
+//      It just split the tensor and dispatches to
+//      `raw_miopen_convolution_forward_out_32bit`.
+//
+//    - raw_miopen_convolution_forward_out_32bit (Tensor)
+//      Low level function which invokes MIOpen, and takes an output
+//      tensor which is directly written to (thus _out).
+//
+
+// ---------------------------------------------------------------------
+//
+// Splitting to 32bit
+//
+// ---------------------------------------------------------------------
+
+template <typename func_t>
+static inline void split_batch_dim_to_32bit_out(
+    const at::Tensor& output,
+    const at::Tensor& input,
+    const at::Tensor& weight,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic,
+    bool depthwise,
+    int64_t max_worksize,
+    func_t func_32bit) {
+  constexpr int64_t int_max = std::numeric_limits<int>::max();
+  const int64_t ni = input.numel();
+  const int64_t no = output.numel();
+  // Assume the shape of the tensor is (N, C, D1, D2, ...)
+  // if N * C * D1 * D2 * ... <= int_max, then no need to split at all
+  if (ni <= int_max && no <= int_max) {
+    func_32bit(
+        output,
+        input,
+        weight,
+        padding,
+        stride,
+        dilation,
+        groups,
+        benchmark,
+        deterministic,
+        depthwise);
+    return;
+  }
+  // else, if C * D1 * D2 * ... <= int_max, then we just need to split across
+  // the N dimension
+  //
+  // Here we use a simple heuristics to determine the size of each split
+  // We don't max out the 2^31 address space because this number is super
+  // large and very likely to get an OOM.
+  int64_t n = output.size(0);
+  int64_t max_inner_size = std::max<int64_t>(ni, no) / n;
+  int64_t split_size = std::max<int64_t>(max_worksize / max_inner_size, 1L);
+  int64_t num_splits = (n + split_size - 1) / split_size;
+  if (split_size * max_inner_size < int_max) {
+    for (const auto i : c10::irange(num_splits)) {
+      int64_t start = split_size * i;
+      int64_t split_size_ = std::min<int64_t>(split_size, n - start);
+      Tensor input_ = input.narrow(0, start, split_size_);
+      Tensor output_ = output.narrow(0, start, split_size_);
+      func_32bit(
+          output_,
+          input_,
+          weight,
+          padding,
+          stride,
+          dilation,
+          groups,
+          benchmark,
+          deterministic,
+          depthwise);
+    }
+    return;
+  }
+  // If control flow reaches here, this means even splitting N is not enough,
+  // then things starts to become complicated: For example, for conv2d, there
+  // following questions needs to be considered.
+  // - Is the memory layout NCHW or NHWC ?
+  // - If the conv is NCHW -> NC'H'W', then should we
+  //   - split only NC?
+  //   - split only N'C'?
+  //   - split both?
+  // - If the conv is NHWC, then we need to split across H, we need to be very
+  // careful about the boundary condition
+  //   to make sure that the boundary is handled correctly.
+  // - If we decide to make these splits, is the memory contiguous? Do we need
+  // to copy the memory? Considering the complexity of this issue, it is better
+  // not to use cuDNN for this case
+  TORCH_INTERNAL_ASSERT(false, "This case should not be dispatched to cuDNN.");
 }
 
 // ---------------------------------------------------------------------
@@ -690,240 +779,7 @@ void miopen_convolution_add_bias_(CheckedFrom c, const TensorArg& output, const 
   */
 }
 
-// see NOTE [ Convolution design ] in src/Aten/native/cudnn/Conv.cpp
-
-
-// ---------------------------------------------------------------------
-//
-// Convolution forward / Transposed convolution backward
-//
-// ---------------------------------------------------------------------
-
-// The raw API directly invokes MIOpen.
-//
-// There are a few reasons this should never be directly exposed
-// via ATen:
-//
-//    - It takes output as a parameter (this should be computed!)
-//    - It doesn't do input checking
-//    - It doesn't resize output (it is assumed to be correctly sized)
-//
-void raw_miopen_convolution_forward_out(
-    const Tensor& output, const Tensor& input, const Tensor& weight,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
-    bool benchmark, bool deterministic) {
-
-  auto dataType = getMiopenDataType(input);
-  miopenConvolutionMode_t c_mode = miopenConvolution;
-
-  ConvolutionArgs args{ input, output, weight };
-  args.handle = getMiopenHandle();
-  setConvolutionParams(&args.params, args.handle, input, weight, padding, stride, dilation, groups, deterministic);
-  args.idesc.set(input);
-  args.wdesc.set(weight, input.suggest_memory_format(), 0);
-  args.odesc.set(output);
-  args.cdesc.set(dataType, c_mode, input.dim() - 2, args.params.padding, args.params.stride, args.params.dilation, args.params.groups, benchmark, deterministic);
-
-  if (at::globalContext().immediateMiopen()) {
-      uint64_t solution_id;
-      Workspace workspace = chooseSolution<miopenConvFwdAlgorithm_t>(args, &solution_id);
-
-      MIOPEN_CHECK(miopenConvolutionForwardImmediate(
-        args.handle,
-        args.wdesc.desc(), weight.const_data_ptr(),
-        args.idesc.desc(), input.const_data_ptr(),
-        args.cdesc.desc(),
-        args.odesc.desc(), output.data_ptr(), workspace.data, workspace.size, solution_id));
-  }
-  else {
-      miopenConvFwdAlgorithm_t fwdAlg;
-      Workspace workspace = chooseAlgorithm(args, benchmark, &fwdAlg);
-
-      Constant one(dataType, 1);
-      Constant zero(dataType, 0);
-
-      MIOPEN_CHECK(miopenConvolutionForward(
-        args.handle,
-        &one, args.idesc.desc(), input.const_data_ptr(),
-        args.wdesc.desc(), weight.const_data_ptr(),
-        args.cdesc.desc(), fwdAlg, &zero,
-        args.odesc.desc(), output.data_ptr(), workspace.data, workspace.size));
-  }
-}
-
-Tensor miopen_convolution_forward(
-    CheckedFrom c,
-    const TensorArg& input, const TensorArg& weight,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
-    bool benchmark, bool deterministic)
-{
-  checkAllSameType(c, {input, weight});
-  checkAllSameGPU(c, {input, weight});
-
-  auto memory_format = at::MemoryFormat::Contiguous;
-  if (miopen_conv_use_channels_last(*input, *weight)) {
-    memory_format = (weight->ndimension() == 5) ? at::MemoryFormat::ChannelsLast3d : at::MemoryFormat::ChannelsLast;
-  }
-
-  Tensor output_t = at::detail::empty_cuda(
-      conv_output_size(input->sizes(), weight->sizes(),
-                       padding, stride, dilation),
-      input->options().memory_format(memory_format));
-
-  if (output_t.numel() == 0) {
-    return output_t;
-  }
-
-  // Avoid ambiguity of "output" when this is being used as backwards
-  TensorArg output{ output_t, "result", 0 };
-  convolution_shape_check(c, input, weight, output, padding, stride, dilation, groups);
-
-  // See #4500
-  Tensor weight_contig = weight->contiguous(memory_format);
-  // Make sure that NC11 strides follow formula
-  weight_contig.resize_(weight_contig.sizes(), memory_format);
-  Tensor input_contig = input->contiguous(memory_format);
-  input_contig.resize_(input_contig.sizes(), memory_format);
-
-
-
-  raw_miopen_convolution_forward_out(
-      *output, input_contig, weight_contig,
-      padding, stride, dilation, groups, benchmark, deterministic);
-
-  return *output;
-}
-
-Tensor miopen_convolution(
-    const Tensor& input_t, const Tensor& weight_t, const std::optional<Tensor>& bias_t_opt,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation,
-    int64_t groups, bool benchmark, bool deterministic)
-{
-  // See [Note: hacky wrapper removal for optional tensor]
-  c10::MaybeOwned<Tensor> bias_t_maybe_owned = at::borrow_from_optional_tensor(bias_t_opt);
-  const Tensor& bias_t = *bias_t_maybe_owned;
-
-  TensorArg input  { input_t,  "input",  1 },
-            weight { weight_t, "weight", 2 },
-            bias   { bias_t,   "bias",   3 };
-  CheckedFrom c = "miopen_convolution";
-  auto output_t = miopen_convolution_forward(
-    c, input, weight, padding, stride, dilation, groups, benchmark, deterministic);
-  if (bias->defined()) {
-    miopen_convolution_add_bias_(c, { output_t, "result", 0 }, bias);
-  }
-  return output_t;
-}
-
-//Depthwise Convolutions
-void raw_miopen_depthwise_convolution_forward_out(
-    const Tensor& output, const Tensor& input, const Tensor& weight,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
-    bool benchmark, bool deterministic) {
-
-  auto dataType = getMiopenDataType(input);
-  miopenConvolutionMode_t c_mode = miopenDepthwise;
-
-  ConvolutionArgs args{ input, output, weight };
-  args.handle = getMiopenHandle();
-  setConvolutionParams(&args.params, args.handle, input, weight, padding, stride, dilation, groups, deterministic);
-  args.idesc.set(input);
-  args.wdesc.set(weight, input.suggest_memory_format(), 0);
-  args.odesc.set(output);
-  args.cdesc.set(dataType, c_mode, input.dim() - 2, args.params.padding, args.params.stride, args.params.dilation, args.params.groups, benchmark, deterministic);
-
-  if (at::globalContext().immediateMiopen()) {
-      uint64_t solution_id;
-      Workspace workspace = chooseSolution<miopenConvFwdAlgorithm_t>(args, &solution_id);
-
-      MIOPEN_CHECK(miopenConvolutionForwardImmediate(
-        args.handle,
-        args.wdesc.desc(), weight.const_data_ptr(),
-        args.idesc.desc(), input.const_data_ptr(),
-        args.cdesc.desc(),
-        args.odesc.desc(), output.data_ptr(), workspace.data, workspace.size, solution_id));
-  }
-  else {
-      miopenConvFwdAlgorithm_t fwdAlg;
-      Workspace workspace = chooseAlgorithm(args, benchmark, &fwdAlg);
-
-      Constant one(dataType, 1);
-      Constant zero(dataType, 0);
-
-      MIOPEN_CHECK(miopenConvolutionForward(
-        args.handle,
-        &one, args.idesc.desc(), input.const_data_ptr(),
-        args.wdesc.desc(), weight.const_data_ptr(),
-        args.cdesc.desc(), fwdAlg, &zero,
-        args.odesc.desc(), output.data_ptr(), workspace.data, workspace.size));
-  }
-}
-
-Tensor miopen_depthwise_convolution_forward(
-    CheckedFrom c,
-    const TensorArg& input, const TensorArg& weight,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
-    bool benchmark, bool deterministic)
-{
-  checkAllSameType(c, {input, weight});
-  checkAllSameGPU(c, {input, weight});
-
-  auto memory_format = at::MemoryFormat::Contiguous;
-  if (miopen_conv_use_channels_last(*input, *weight)) {
-    memory_format = (weight->ndimension() == 5) ? at::MemoryFormat::ChannelsLast3d : at::MemoryFormat::ChannelsLast;
-  }
-
-  Tensor output_t = at::detail::empty_cuda(
-      conv_output_size(input->sizes(), weight->sizes(),
-                       padding, stride, dilation),
-      input->options().memory_format(memory_format));
-
-  TensorArg output{ output_t, "result", 0 };
-  convolution_shape_check(c, input, weight, output, padding, stride, dilation, groups);
-
-  // See #4500
-  Tensor weight_contig = weight->contiguous(memory_format);
-  // Make sure that NC11 strides follow formula
-  weight_contig.resize_(weight_contig.sizes(), memory_format);
-  Tensor input_contig = input->contiguous(memory_format);
-  input_contig.resize_(input_contig.sizes(), memory_format);
-
-  raw_miopen_depthwise_convolution_forward_out(
-      *output, input_contig, weight_contig,
-      padding, stride, dilation, groups, benchmark, deterministic);
-
-  return *output;
-}
-
-Tensor miopen_depthwise_convolution(
-    const Tensor& input_t, const Tensor& weight_t, const std::optional<Tensor>& bias_t_opt,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation,
-    int64_t groups, bool benchmark, bool deterministic)
-{
-  // See [Note: hacky wrapper removal for optional tensor]
-  c10::MaybeOwned<Tensor> bias_t_maybe_owned = at::borrow_from_optional_tensor(bias_t_opt);
-  const Tensor& bias_t = *bias_t_maybe_owned;
-
-  TensorArg input  { input_t,  "input",  1 },
-            weight { weight_t, "weight", 2 },
-            bias   { bias_t,   "bias",   3 };
-  CheckedFrom c = "miopen_depthwise_convolution";
-  auto output_t = miopen_depthwise_convolution_forward(
-    c, input, weight, padding, stride, dilation, groups, benchmark, deterministic);
-  if (bias->defined()) {
-    miopen_convolution_add_bias_(c, { output_t, "result", 0 }, bias);
-  }
-  return output_t;
-}
-
-// ---------------------------------------------------------------------
-//
-// Convolution backward (bias)
-//
-// ---------------------------------------------------------------------
-
-Tensor miopen_convolution_backward_bias(
-    const Tensor& grad_output_t)
+Tensor miopen_convolution_backward_bias(const Tensor& grad_output_t)
 {
   TensorArg grad_output{ grad_output_t, "grad_output", 1 };
 
@@ -931,18 +787,18 @@ Tensor miopen_convolution_backward_bias(
   // See #64426
   std::vector<int64_t> discard_dims;
   for( int i = 0; i < grad_output_t.dim(); i++ ) {
-      if(i != output_channels_dim ) {
-          discard_dims.push_back(i);
-      }
+    if(i != output_channels_dim ) {
+      discard_dims.push_back(i);
+    }
   }
 
   Tensor outputBias = at::squeeze( at::sum(grad_output_t, discard_dims, true) );
   if( outputBias.dim() == 0 ) {
-      // always return a tensor of shape [_]
-      return outputBias.unsqueeze(0);
+    // always return a tensor of shape [_]
+    return outputBias.unsqueeze(0);
   }
   else {
-      return outputBias;
+    return outputBias;
   }
 
 /* MIOpen does not support NHWC bias. Activate once support is added.
@@ -967,249 +823,289 @@ Tensor miopen_convolution_backward_bias(
 
 // ---------------------------------------------------------------------
 //
-// Convolution backward (weight)
+// Convolution forward / Transposed convolution backward
 //
 // ---------------------------------------------------------------------
 
-void raw_miopen_convolution_backward_weight_out(
-    const Tensor& grad_weight, const Tensor& grad_output, const Tensor& input,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
-    bool benchmark, bool deterministic) {
-
+void raw_miopen_convolution_forward_out_32bit(
+    const Tensor& output,
+    const Tensor& input,
+    const Tensor& weight,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic,
+    bool depthwise=false) {
   auto dataType = getMiopenDataType(input);
-  miopenConvolutionMode_t c_mode = miopenConvolution;
+  miopenConvolutionMode_t c_mode = depthwise ? miopenDepthwise : miopenConvolution;
 
-  ConvolutionArgs args{ input, grad_output, grad_weight };
+  ConvolutionArgs args{input, output, weight};
   args.handle = getMiopenHandle();
-  setConvolutionParams(&args.params, args.handle, input, grad_weight, padding, stride, dilation, groups, deterministic);
-  args.idesc.set(input);
-  args.wdesc.set(grad_weight, input.suggest_memory_format(), 0);
-  args.odesc.set(grad_output);
-  args.cdesc.set(dataType, c_mode, input.dim() - 2, args.params.padding, args.params.stride, args.params.dilation, args.params.groups, benchmark, deterministic);
+  at::MemoryFormat memory_format =
+      miopen_conv_suggest_memory_format(input, weight);
+  setConvolutionParams(
+      &args.params,
+      args.handle,
+      input,
+      weight,
+      padding,
+      stride,
+      dilation,
+      groups,
+      deterministic,
+      memory_format);
+  args.idesc.set(input, memory_format);
+  args.wdesc.set(weight, memory_format, 0);
+  args.odesc.set(output, memory_format);
+  args.cdesc.set(
+      dataType,
+      c_mode,
+      input.dim() - 2,
+      args.params.padding,
+      args.params.stride,
+      args.params.dilation,
+      args.params.groups,
+      benchmark,
+      deterministic);
 
   if (at::globalContext().immediateMiopen()) {
       uint64_t solution_id;
-      Workspace workspace = chooseSolution<miopenConvBwdWeightsAlgorithm_t>(args, &solution_id);
+      Workspace workspace = chooseSolution<miopenConvFwdAlgorithm_t>(args, &solution_id);
 
-      MIOPEN_CHECK(miopenConvolutionBackwardWeightsImmediate(
-          args.handle,
-          args.odesc.desc(), grad_output.const_data_ptr(),
-          args.idesc.desc(), input.const_data_ptr(),
-          args.cdesc.desc(),
-          args.wdesc.desc(), grad_weight.data_ptr(), workspace.data, workspace.size, solution_id));
+      MIOPEN_CHECK(miopenConvolutionForwardImmediate(
+        args.handle,
+        args.wdesc.desc(),
+        weight.const_data_ptr(),
+        args.idesc.desc(),
+        input.const_data_ptr(),
+        args.cdesc.desc(),
+        args.odesc.desc(),
+        output.data_ptr(),
+        workspace.data,
+        workspace.size,
+        solution_id));
   }
   else {
-      miopenConvBwdWeightsAlgorithm_t bwdFilterAlg;
-      Workspace workspace = chooseAlgorithm(args, benchmark, &bwdFilterAlg);
+      miopenConvFwdAlgorithm_t fwdAlg;
+      Workspace workspace = chooseAlgorithm(args, benchmark, &fwdAlg);
 
       Constant one(dataType, 1);
       Constant zero(dataType, 0);
 
-      MIOPEN_CHECK(miopenConvolutionBackwardWeights(
-          args.handle,
-          &one, args.odesc.desc(), grad_output.const_data_ptr(),
-          args.idesc.desc(), input.const_data_ptr(),
-          args.cdesc.desc(), bwdFilterAlg, &zero,
-          args.wdesc.desc(), grad_weight.data_ptr(), workspace.data, workspace.size));
+      MIOPEN_CHECK(miopenConvolutionForward(
+        args.handle,
+        &one,
+        args.idesc.desc(),
+        input.const_data_ptr(),
+        args.wdesc.desc(),
+        weight.const_data_ptr(),
+        args.cdesc.desc(),
+        fwdAlg,
+        &zero,
+        args.odesc.desc(),
+        output.data_ptr(),
+        workspace.data,
+        workspace.size));
   }
 }
 
-//Depthwise backward weights.
-void raw_miopen_depthwise_convolution_backward_weight_out(
-    const Tensor& grad_weight, const Tensor& grad_output, const Tensor& input,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
-    bool benchmark, bool deterministic) {
-
-  auto dataType = getMiopenDataType(input);
-  miopenConvolutionMode_t c_mode = miopenDepthwise;
-
-  ConvolutionArgs args{ input, grad_output, grad_weight };
-  args.handle = getMiopenHandle();
-  setConvolutionParams(&args.params, args.handle, input, grad_weight, padding, stride, dilation, groups, deterministic);
-  args.idesc.set(input);
-  args.wdesc.set(grad_weight, input.suggest_memory_format(), 0);
-  args.odesc.set(grad_output);
-  args.cdesc.set(dataType, c_mode, input.dim() - 2, args.params.padding, args.params.stride, args.params.dilation, args.params.groups, benchmark, deterministic);
-
-  if (at::globalContext().immediateMiopen()) {
-      uint64_t solution_id;
-      Workspace workspace = chooseSolution<miopenConvBwdWeightsAlgorithm_t>(args, &solution_id);
-
-      MIOPEN_CHECK(miopenConvolutionBackwardWeightsImmediate(
-          args.handle,
-          args.odesc.desc(), grad_output.const_data_ptr(),
-          args.idesc.desc(), input.const_data_ptr(),
-          args.cdesc.desc(),
-          args.wdesc.desc(), grad_weight.data_ptr(), workspace.data, workspace.size, solution_id));
-  }
-  else {
-      miopenConvBwdWeightsAlgorithm_t bwdFilterAlg;
-      Workspace workspace = chooseAlgorithm(args, benchmark, &bwdFilterAlg);
-
-      Constant one(dataType, 1);
-      Constant zero(dataType, 0);
-
-      MIOPEN_CHECK(miopenConvolutionBackwardWeights(
-          args.handle,
-          &one, args.odesc.desc(), grad_output.const_data_ptr(),
-          args.idesc.desc(), input.const_data_ptr(),
-          args.cdesc.desc(), bwdFilterAlg, &zero,
-          args.wdesc.desc(), grad_weight.data_ptr(), workspace.data, workspace.size));
-  }
+void raw_miopen_convolution_forward_out(
+    const Tensor& output,
+    const Tensor& input,
+    const Tensor& weight,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic,
+    bool depthwise=false) {
+  split_batch_dim_to_32bit_out(
+      output,
+      input,
+      weight,
+      padding,
+      stride,
+      dilation,
+      groups,
+      benchmark,
+      deterministic,
+      depthwise,
+      1024 * 1024 * 256,
+      raw_miopen_convolution_forward_out_32bit);
 }
 
-Tensor miopen_depthwise_convolution_backward_weight(
+void miopen_convolution_forward_out(
+    TensorArg& output,
     CheckedFrom c,
-    IntArrayRef weight_size, const TensorArg& grad_output, const TensorArg& input,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
-    bool benchmark, bool deterministic)
-{
+    const TensorArg& input,
+    const TensorArg& weight,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic,
+    bool depthwise=false) {
+  checkAllSameType(c, {input, weight});
+  checkAllSameGPU(c, {input, weight});
 
-  checkAllSameType(c, {grad_output, input});
-  checkAllSameGPU(c, {grad_output, input});
+  auto memory_format = output->suggest_memory_format();
+  convolution_shape_check(
+      c, input, weight, output, padding, stride, dilation, groups);
 
-  auto memory_format = at::MemoryFormat::Contiguous;
-  if (miopen_conv_use_channels_last(*input, *grad_output)) {
-    memory_format = (input->ndimension() == 5) ? at::MemoryFormat::ChannelsLast3d : at::MemoryFormat::ChannelsLast;
-  }
+  Tensor weight_contig = weight->contiguous(memory_format);
+  Tensor input_contig = input->contiguous(memory_format);
 
-  Tensor grad_output_contig_t = grad_output->contiguous(memory_format);
-  // Make sure that NC11 strides follow formula
-  grad_output_contig_t.resize_(grad_output_contig_t.sizes(), memory_format);
-  TensorArg grad_output_contig{ grad_output_contig_t, "grad_output", 1 };
-
-  Tensor input_contig_t = input->contiguous(memory_format);
-  input_contig_t.resize_(input_contig_t.sizes(), memory_format);
-  TensorArg input_contig{ input_contig_t, "input", 2};
-
-  auto grad_weight_t = at::empty(weight_size, grad_output_contig->options(), memory_format);
-
-  // For uniformity with everything else, although it seems grad_weight
-  // would be unambiguous too.
-  TensorArg grad_weight{ grad_weight_t, "result", 0 };
-  convolution_shape_check(c, input, grad_weight, grad_output_contig, padding, stride, dilation, groups);
-
-  raw_miopen_depthwise_convolution_backward_weight_out(
-      *grad_weight, *grad_output_contig, *input_contig,
-      padding, stride, dilation, groups, benchmark, deterministic);
-
-  return grad_weight_t;
+  raw_miopen_convolution_forward_out(
+      *output,
+      input_contig,
+      weight_contig,
+      padding,
+      stride,
+      dilation,
+      groups,
+      benchmark,
+      deterministic,
+      depthwise);
 }
 
-Tensor miopen_depthwise_convolution_backward_weight(
-    IntArrayRef weight_size,
-    const Tensor& grad_output_t,
+Tensor miopen_convolution(
     const Tensor& input_t,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
-    bool benchmark, bool deterministic)
-{
-  TensorArg grad_output{ grad_output_t, "grad_output", 1 },
-            input{ input_t, "input", 2 };
-  return miopen_depthwise_convolution_backward_weight(
-      "miopen_depthwise_convolution_backward_weight",
-      weight_size, grad_output, input,
-      padding, stride, dilation, groups, benchmark, deterministic);
-}
+    const Tensor& weight_t,
+    const std::optional<Tensor>& bias_t_opt,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic) {
+  // See [Note: hacky wrapper removal for optional tensor]
+  c10::MaybeOwned<Tensor> bias_t_maybe_owned = at::borrow_from_optional_tensor(bias_t_opt);
+  const Tensor& bias_t = *bias_t_maybe_owned;
 
-Tensor miopen_convolution_backward_weight(
-    CheckedFrom c,
-    IntArrayRef weight_size, const TensorArg& grad_output, const TensorArg& input,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
-    bool benchmark, bool deterministic)
-{
-
-  checkAllSameType(c, {grad_output, input});
-  checkAllSameGPU(c, {grad_output, input});
-
-  auto memory_format = at::MemoryFormat::Contiguous;
-  if (miopen_conv_use_channels_last(*input, *grad_output)) {
-    memory_format = (input->ndimension() == 5) ? at::MemoryFormat::ChannelsLast3d : at::MemoryFormat::ChannelsLast;
+  TensorArg input{input_t, "input",  1 }, weight{weight_t, "weight", 2}, bias{bias_t, "bias", 3};
+  CheckedFrom c = "miopen_convolution";
+  auto memory_format = miopen_conv_suggest_memory_format(input_t, weight_t);
+  Tensor output_t = at::detail::empty_cuda(
+      conv_output_size(
+        input_t.sizes(), weight_t.sizes(), padding, stride, dilation),
+      input->options().memory_format(memory_format));
+  if (output_t.numel() == 0) {
+    return output_t;
   }
-
-  Tensor grad_output_contig_t = grad_output->contiguous(memory_format);
-  // Make sure that NC11 strides follow formula
-  grad_output_contig_t.resize_(grad_output_contig_t.sizes(), memory_format);
-  TensorArg grad_output_contig{ grad_output_contig_t, "grad_output", 1 };
-
-  Tensor input_contig_t = input->contiguous(memory_format);
-  input_contig_t.resize_(input_contig_t.sizes(), memory_format);
-  TensorArg input_contig{ input_contig_t, "input", 2};
-
-  auto grad_weight_t = at::empty(weight_size, grad_output_contig->options(), memory_format);
-
-  // For uniformity with everything else, although it seems grad_weight
-  // would be unambiguous too.
-  TensorArg grad_weight{ grad_weight_t, "result", 0 };
-  convolution_shape_check(c, input, grad_weight, grad_output_contig, padding, stride, dilation, groups);
-
-  raw_miopen_convolution_backward_weight_out(
-      *grad_weight, *grad_output_contig, *input_contig,
-      padding, stride, dilation, groups, benchmark, deterministic);
-
-  return grad_weight_t;
-}
-
-Tensor miopen_convolution_backward_weight(
-    IntArrayRef weight_size,
-    const Tensor& grad_output_t,
-    const Tensor& input_t,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
-    bool benchmark, bool deterministic)
-{
-  TensorArg grad_output{ grad_output_t, "grad_output", 1 },
-            input{ input_t, "input", 2 };
-  return miopen_convolution_backward_weight(
-      "miopen_convolution_backward_weight",
-      weight_size, grad_output, input,
-      padding, stride, dilation, groups, benchmark, deterministic);
+  // Avoid ambiguity of "output" when this is being used as backwards
+  TensorArg output{output_t, "result", 0};
+  miopen_convolution_forward_out(
+      output,
+      c,
+      input,
+      weight,
+      padding,
+      stride,
+      dilation,
+      groups,
+      benchmark,
+      deterministic);
+  if (bias->defined()) {
+    miopen_convolution_add_bias_(c, output, bias);
+  }
+  return *output;
 }
 
 Tensor miopen_convolution_transpose_backward_input(
-    const Tensor& grad_output_t, const Tensor& weight_t,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation,
-    int64_t groups, bool benchmark, bool deterministic)
-{
-  TensorArg grad_output { grad_output_t,  "grad_output", 1 },
-            weight      { weight_t, "weight", 2 };
-  return miopen_convolution_forward(
-    "miopen_convolution_transpose_backward_input",
-    grad_output, weight, padding, stride, dilation, groups, benchmark, deterministic);
+    const Tensor& grad_output_t,
+    const Tensor& weight_t,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic) {
+  TensorArg grad_output{ grad_output_t,  "grad_output", 1 }, weight{weight_t, "weight", 2};
+  auto memory_format =
+    miopen_conv_suggest_memory_format(grad_output_t, weight_t);
+  Tensor output_t = at::detail::empty_cuda(
+      conv_output_size(
+        grad_output_t.sizes(), weight_t.sizes(), padding, stride, dilation),
+      grad_output_t.options().memory_format(memory_format));
+
+  if (output_t.numel() == 0) {
+    return output_t;
+  }
+  TensorArg output{output_t, "result", 0};
+  miopen_convolution_forward_out(
+      output,
+      "miopen_convolution_transpose_backward_input",
+      grad_output,
+      weight,
+      padding,
+      stride,
+      dilation,
+      groups,
+      benchmark,
+      deterministic);
+  return *output;
 }
 
+// file organization would put miopen_convolution_transpose_backward_weight here,
+// but it depends on miopen_convolution_backward_weight which is defined later
 Tensor miopen_convolution_transpose_backward_weight(
     IntArrayRef weight_size,
     const Tensor& grad_output_t,
     const Tensor& input_t,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
-    bool benchmark, bool deterministic)
-{
-  TensorArg grad_output{ grad_output_t, "grad_output", 1 },
-            input{ input_t, "input", 2 };
-  return miopen_convolution_backward_weight(
-      "miopen_convolution_backward_weight",
-      weight_size, input, grad_output,
-      padding, stride, dilation, groups, benchmark, deterministic);
-}
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic);
 
-std::tuple<at::Tensor,at::Tensor,at::Tensor> miopen_convolution_transpose_backward(
-    const at::Tensor& input, const at::Tensor& grad_output_t, const at::Tensor& weight,
-    IntArrayRef padding, IntArrayRef output_padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
-    bool benchmark, bool deterministic, std::array<bool,3> output_mask) {
-
+std::tuple<at::Tensor, at::Tensor, at::Tensor> miopen_convolution_transpose_backward(
+    const at::Tensor& input,
+    const at::Tensor& grad_output_t,
+    const at::Tensor& weight,
+    IntArrayRef padding,
+    IntArrayRef output_padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic,
+    std::array<bool,3> output_mask) {
   Tensor grad_output = grad_output_t.contiguous(input.suggest_memory_format());
 
   Tensor grad_input, grad_weight, grad_bias;
   if (output_mask[0]) {
-    grad_input = miopen_convolution_transpose_backward_input(grad_output, weight, padding, stride, dilation, groups, benchmark, deterministic);
+    grad_input = miopen_convolution_transpose_backward_input(
+        grad_output,
+        weight,
+        padding,
+        stride,
+        dilation,
+        groups,
+        benchmark,
+        deterministic);
   }
   if (output_mask[1]) {
-    grad_weight = miopen_convolution_transpose_backward_weight(weight.sizes(), grad_output, input, padding, stride, dilation, groups, benchmark, deterministic);
+    grad_weight = miopen_convolution_transpose_backward_weight(
+        weight.sizes(),
+        grad_output,
+        input,
+        padding,
+        stride,
+        dilation,
+        groups,
+        benchmark,
+        deterministic);
   }
   if (output_mask[2]) {
     grad_bias = miopen_convolution_backward_bias(grad_output);
   }
 
-  return std::tuple<Tensor,Tensor,Tensor>{grad_input, grad_weight, grad_bias};
+  return std::tuple<Tensor, Tensor, Tensor>{grad_input, grad_weight, grad_bias};
 }
 
 // ---------------------------------------------------------------------
@@ -1218,254 +1114,599 @@ std::tuple<at::Tensor,at::Tensor,at::Tensor> miopen_convolution_transpose_backwa
 //
 // ---------------------------------------------------------------------
 
+// NOTE [ Backward vs transpose convolutions ]
+//
+// Backward and transpose are algorithmically equivalent, but they
+// compute their geometry differently.  In a backwards, you knew what
+// the original size of the input tensor was, so you can cache that
+// geometry and fill it directly.  In transposed convolution, it is
+// more conventional to not explicitly specify the output (previously
+// input) size, and compute it.  This, however, leaves a degree of
+// freedom; this degree of freedom is resolved using the
+// output_padding parameter.  Both of these interfaces are equivalent,
+// but they are differently convenient depending on the use case.
+
+void raw_miopen_convolution_backward_input_out_32bit(
+    const at::Tensor& grad_input,
+    const at::Tensor& grad_output,
+    const at::Tensor& weight,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic,
+    bool depthwise=false) {
+  auto dataType = getMiopenDataType(grad_output);
+  miopenConvolutionMode_t c_mode = depthwise ? miopenDepthwise : miopenConvolution;
+
+  ConvolutionArgs args{grad_input, grad_output, weight};
+  args.handle = getMiopenHandle();
+  at::MemoryFormat memory_format =
+    miopen_conv_suggest_memory_format(grad_input, weight);
+  setConvolutionParams(
+      &args.params,
+      args.handle,
+      grad_input,
+      weight,
+      padding,
+      stride,
+      dilation,
+      groups,
+      deterministic,
+      memory_format);
+  args.idesc.set(grad_input, memory_format);
+  args.wdesc.set(weight, memory_format, 0);
+  args.odesc.set(grad_output, memory_format);
+  args.cdesc.set(
+      dataType,
+      c_mode,
+      grad_output.dim() - 2,
+      args.params.padding,
+      args.params.stride,
+      args.params.dilation,
+      args.params.groups,
+      benchmark,
+      deterministic);
+
+  if (at::globalContext().immediateMiopen()) {
+      uint64_t solution_id;
+      Workspace workspace = chooseSolution<miopenConvBwdDataAlgorithm_t>(args, &solution_id);
+
+      MIOPEN_CHECK(miopenConvolutionBackwardDataImmediate(
+          args.handle,
+          args.odesc.desc(), grad_output.const_data_ptr(),
+          args.wdesc.desc(), weight.const_data_ptr(),
+          args.cdesc.desc(),
+          args.idesc.desc(), grad_input.mutable_data_ptr(),
+          workspace.data,
+          workspace.size,
+          solution_id));
+  }
+  else {
+      miopenConvBwdDataAlgorithm_t bwdDataAlg;
+      Workspace workspace = chooseAlgorithm(args, benchmark, &bwdDataAlg);
+
+      Constant one(dataType, 1);
+      Constant zero(dataType, 0);
+
+      MIOPEN_CHECK(miopenConvolutionBackwardData(
+          args.handle,
+          &one,
+          args.odesc.desc(), grad_output.const_data_ptr(),
+          args.wdesc.desc(), weight.const_data_ptr(),
+          args.cdesc.desc(),
+          bwdDataAlg,
+          &zero,
+          args.idesc.desc(), grad_input.mutable_data_ptr(),
+          workspace.data,
+          workspace.size));
+  }
+}
+
 void raw_miopen_convolution_backward_input_out(
     const at::Tensor& grad_input,
     const at::Tensor& grad_output,
     const at::Tensor& weight,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
-    bool benchmark, bool deterministic) {
-
-  auto dataType = getMiopenDataType(grad_output);
-  miopenConvolutionMode_t c_mode = miopenConvolution;
-
-  ConvolutionArgs args{ grad_input, grad_output, weight };
-  args.handle = getMiopenHandle();
-  setConvolutionParams(&args.params, args.handle, grad_input, weight, padding, stride, dilation, groups, deterministic);
-  args.idesc.set(grad_input);
-  args.wdesc.set(weight, grad_output.suggest_memory_format(), 0);
-  args.odesc.set(grad_output);
-  args.cdesc.set(dataType, c_mode, grad_output.dim() - 2, args.params.padding, args.params.stride, args.params.dilation, args.params.groups, benchmark, deterministic);
-
-  if (at::globalContext().immediateMiopen()) {
-      uint64_t solution_id;
-      Workspace workspace = chooseSolution<miopenConvBwdDataAlgorithm_t>(args, &solution_id);
-
-      MIOPEN_CHECK(miopenConvolutionBackwardDataImmediate(
-          args.handle,
-          args.odesc.desc(), grad_output.const_data_ptr(),
-          args.wdesc.desc(), weight.const_data_ptr(),
-          args.cdesc.desc(),
-          args.idesc.desc(), grad_input.mutable_data_ptr(), workspace.data, workspace.size, solution_id));
-  }
-  else {
-      miopenConvBwdDataAlgorithm_t bwdDataAlg;
-      Workspace workspace = chooseAlgorithm(args, benchmark, &bwdDataAlg);
-
-      Constant one(dataType, 1);
-      Constant zero(dataType, 0);
-
-      MIOPEN_CHECK(miopenConvolutionBackwardData(
-          args.handle,
-          &one, args.odesc.desc(), grad_output.const_data_ptr(),
-          args.wdesc.desc(), weight.const_data_ptr(),
-          args.cdesc.desc(), bwdDataAlg, &zero,
-          args.idesc.desc(), grad_input.mutable_data_ptr(), workspace.data, workspace.size));
-  }
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic,
+    bool depthwise=false) {
+  split_batch_dim_to_32bit_out(
+      grad_input,
+      grad_output,
+      weight,
+      padding,
+      stride,
+      dilation,
+      groups,
+      benchmark,
+      deterministic,
+      depthwise,
+      1024 * 1024 * 128,
+      raw_miopen_convolution_backward_input_out_32bit);
 }
-
-// see NOTE [ Backward vs transpose convolutions ] in src/Aten/native/cudnn/Conv.cpp
 
 Tensor miopen_convolution_backward_input(
     CheckedFrom c,
-    IntArrayRef input_size, const TensorArg& grad_output, const TensorArg& weight,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
-    bool benchmark, bool deterministic)
-{
+    IntArrayRef input_size,
+    const TensorArg& grad_output,
+    const TensorArg& weight,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic,
+    bool depthwise=false) {
   checkAllSameType(c, {grad_output, weight});
   checkAllSameGPU(c, {grad_output, weight});
 
-  auto memory_format = at::MemoryFormat::Contiguous;
-  if (miopen_conv_use_channels_last(*grad_output, *weight)) {
-    memory_format = (weight->ndimension() == 5) ? at::MemoryFormat::ChannelsLast3d : at::MemoryFormat::ChannelsLast;
-  }
-
+  auto memory_format = miopen_conv_suggest_memory_format(*grad_output, *weight);
   Tensor grad_input_t = at::detail::empty_cuda(
       input_size, grad_output->options().memory_format(memory_format));
 
   // Avoid "grad_input" when this is being used as transposed convolution
-  TensorArg grad_input{ grad_input_t, "result", 0 };
-  convolution_shape_check(c, grad_input, weight, grad_output, padding, stride, dilation, groups);
+  TensorArg grad_input{grad_input_t, "result", 0};
+  convolution_shape_check(
+      c, grad_input, weight, grad_output, padding, stride, dilation, groups);
 
-  // See #4500
   Tensor weight_contig = weight->contiguous(memory_format);
-  // Make sure that NC11 strides follow formula
-  weight_contig.resize_(weight_contig.sizes(), memory_format);
-
   Tensor grad_output_contig = grad_output->contiguous(memory_format);
-  grad_output_contig.resize_(grad_output_contig.sizes(), memory_format);
 
   raw_miopen_convolution_backward_input_out(
-      *grad_input, grad_output_contig, weight_contig,
-      padding, stride, dilation, groups, benchmark, deterministic);
+      *grad_input,
+      grad_output_contig,
+      weight_contig,
+      padding,
+      stride,
+      dilation,
+      groups,
+      benchmark,
+      deterministic,
+      depthwise);
 
   return *grad_input;
 }
 
-Tensor miopen_convolution_transpose_forward(
-    CheckedFrom c,
-    const TensorArg& grad_output, const TensorArg& weight,
-    IntArrayRef padding, IntArrayRef output_padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
-    bool benchmark, bool deterministic)
-{
-  auto input_size = conv_input_size(grad_output->sizes(), weight->sizes(),
-                                    padding, output_padding, stride, dilation, groups);
-  return miopen_convolution_backward_input(c, input_size, grad_output, weight,
-                                    padding, stride, dilation, groups, benchmark, deterministic);
-}
-
+// overload
 Tensor miopen_convolution_backward_input(
-    IntArrayRef input_size, const Tensor& grad_output_t, const Tensor& weight_t,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
-    bool benchmark, bool deterministic)
-{
-  TensorArg grad_output{ grad_output_t, "grad_output", 1 },
-            weight{ weight_t, "weight", 2 };
+    IntArrayRef input_size,
+    const Tensor& grad_output_t,
+    const Tensor& weight_t,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic,
+    bool depthwise=false) {
+  TensorArg grad_output{grad_output_t, "grad_output", 1},
+      weight{weight_t, "weight", 2};
   return miopen_convolution_backward_input(
       "miopen_convolution_backward_input",
-      input_size, grad_output, weight,
-      padding, stride, dilation, groups, benchmark, deterministic);
+      input_size,
+      grad_output,
+      weight,
+      padding,
+      stride,
+      dilation,
+      groups,
+      benchmark,
+      deterministic,
+      depthwise);
 }
 
-//Depthwise convolutions backward data.
-void raw_miopen_depthwise_convolution_backward_input_out(
-    const at::Tensor& grad_input,
-    const at::Tensor& grad_output,
-    const at::Tensor& weight,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
-    bool benchmark, bool deterministic) {
+void raw_miopen_convolution_backward_weight_out_32bit(
+    const Tensor& grad_weight,
+    const Tensor& grad_output,
+    const Tensor& input,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic,
+    bool depthwise=false) {
+  auto dataType = getMiopenDataType(input);
+  miopenConvolutionMode_t c_mode = depthwise ? miopenDepthwise : miopenConvolution;
 
-  auto dataType = getMiopenDataType(grad_output);
-  miopenConvolutionMode_t c_mode = miopenDepthwise;
-
-  ConvolutionArgs args{ grad_input, grad_output, weight };
+  ConvolutionArgs args{input, grad_output, grad_weight};
   args.handle = getMiopenHandle();
-  setConvolutionParams(&args.params, args.handle, grad_input, weight, padding, stride, dilation, groups, deterministic);
-  args.idesc.set(grad_input);
-  args.wdesc.set(weight, grad_output.suggest_memory_format(), 0);
-  args.odesc.set(grad_output);
-  args.cdesc.set(dataType, c_mode, grad_output.dim() - 2, args.params.padding, args.params.stride, args.params.dilation, args.params.groups, benchmark, deterministic);
+  at::MemoryFormat memory_format =
+    miopen_conv_suggest_memory_format(input, grad_weight);
+  setConvolutionParams(
+      &args.params,
+      args.handle,
+      input,
+      grad_weight,
+      padding,
+      stride,
+      dilation,
+      groups,
+      deterministic,
+      memory_format);
+  args.idesc.set(input, memory_format);
+  args.wdesc.set(grad_weight, memory_format, 0);
+  args.odesc.set(grad_output, memory_format);
+  args.cdesc.set(
+      dataType,
+      c_mode,
+      input.dim() - 2,
+      args.params.padding,
+      args.params.stride,
+      args.params.dilation,
+      args.params.groups,
+      benchmark,
+      deterministic);
 
   if (at::globalContext().immediateMiopen()) {
       uint64_t solution_id;
-      Workspace workspace = chooseSolution<miopenConvBwdDataAlgorithm_t>(args, &solution_id);
+      Workspace workspace = chooseSolution<miopenConvBwdWeightsAlgorithm_t>(args, &solution_id);
 
-      MIOPEN_CHECK(miopenConvolutionBackwardDataImmediate(
+      MIOPEN_CHECK(miopenConvolutionBackwardWeightsImmediate(
           args.handle,
           args.odesc.desc(), grad_output.const_data_ptr(),
-          args.wdesc.desc(), weight.const_data_ptr(),
+          args.idesc.desc(), input.const_data_ptr(),
           args.cdesc.desc(),
-          args.idesc.desc(), grad_input.mutable_data_ptr(), workspace.data, workspace.size, solution_id));
+          args.wdesc.desc(), grad_weight.data_ptr(),
+          workspace.data,
+          workspace.size,
+          solution_id));
   }
   else {
-      miopenConvBwdDataAlgorithm_t bwdDataAlg;
-      Workspace workspace = chooseAlgorithm(args, benchmark, &bwdDataAlg);
+      miopenConvBwdWeightsAlgorithm_t bwdFilterAlg;
+      Workspace workspace = chooseAlgorithm(args, benchmark, &bwdFilterAlg);
 
       Constant one(dataType, 1);
       Constant zero(dataType, 0);
 
-      MIOPEN_CHECK(miopenConvolutionBackwardData(
+      MIOPEN_CHECK(miopenConvolutionBackwardWeights(
           args.handle,
-          &one, args.odesc.desc(), grad_output.const_data_ptr(),
-          args.wdesc.desc(), weight.const_data_ptr(),
-          args.cdesc.desc(), bwdDataAlg, &zero,
-          args.idesc.desc(), grad_input.mutable_data_ptr(), workspace.data, workspace.size));
+          &one,
+          args.odesc.desc(), grad_output.const_data_ptr(),
+          args.idesc.desc(), input.const_data_ptr(),
+          args.cdesc.desc(),
+          bwdFilterAlg,
+          &zero,
+          args.wdesc.desc(), grad_weight.data_ptr(),
+          workspace.data,
+          workspace.size));
   }
 }
 
-Tensor miopen_depthwise_convolution_backward_input(
+void raw_miopen_convolution_backward_weight_out(
+    const Tensor& grad_weight,
+    const Tensor& grad_output,
+    const Tensor& input,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic,
+    bool depthwise=false) {
+  constexpr int64_t int_max = std::numeric_limits<int>::max();
+  const int64_t ni = input.numel();
+  const int64_t no = grad_output.numel();
+  // Assume the shape of the tensor is (N, C, D1, D2, ...)
+  // if N * C * D1 * D2 * ... <= int_max, then no need to split at all
+  if (ni <= int_max && no <= int_max) {
+    raw_miopen_convolution_backward_weight_out_32bit(
+        grad_weight,
+        grad_output,
+        input,
+        padding,
+        stride,
+        dilation,
+        groups,
+        benchmark,
+        deterministic,
+        depthwise);
+    return;
+  }
+  // else, if C * D1 * D2 * ... <= int_max, then we just need to split across
+  // the N dimension
+  //
+  // Here we use a simple heuristics to determine the size of each split
+  // We don't max out the 2^31 address space because this number is super
+  // large and very likely to get an OOM.
+  int64_t n = grad_output.size(0);
+  int64_t max_inner_size = std::max<int64_t>(ni, no) / n;
+  int64_t split_size =
+      std::max<int64_t>(1024 * 1024 * 512 / max_inner_size, 1L);
+  int64_t num_splits = (n + split_size - 1) / split_size;
+  if (split_size * max_inner_size < int_max) {
+    const auto kAccType = (grad_weight.scalar_type() == kHalf ||
+                           grad_weight.scalar_type() == kBFloat16)
+        ? kFloat
+        : grad_weight.scalar_type();
+    Tensor grad_weight_accumulator =
+        at::zeros(grad_weight.sizes(), grad_weight.options().dtype(kAccType));
+    for (const auto i : c10::irange(num_splits)) {
+      int64_t start = split_size * i;
+      int64_t split_size_ = std::min<int64_t>(split_size, n - start);
+      Tensor input_ = input.narrow(0, start, split_size_);
+      Tensor grad_output_ = grad_output.narrow(0, start, split_size_);
+      Tensor grad_weight_ = at::empty_like(grad_weight);
+      raw_miopen_convolution_backward_weight_out_32bit(
+          grad_weight_,
+          grad_output_,
+          input_,
+          padding,
+          stride,
+          dilation,
+          groups,
+          benchmark,
+          deterministic,
+          depthwise);
+      grad_weight_accumulator.add_(grad_weight_);
+    }
+    grad_weight.copy_(grad_weight_accumulator);
+    return;
+  }
+  // If control flow reaches here, this means even splitting N is not enough,
+  // then things starts to become complicated: For example, for conv2d, there
+  // following questions needs to be considered.
+  // - Is the memory layout NCHW or NHWC ?
+  // - If the conv is NCHW -> NC'H'W', then should we
+  //   - split only NC?
+  //   - split only N'C'?
+  //   - split both?
+  // - If the conv is NHWC, then we need to split across H, we need to be very
+  // careful about the boundary condition
+  //   to make sure that the boundary is handled correctly.
+  // - If we decide to make these splits, is the memory contiguous? Do we need
+  // to copy the memory? Considering the complexity of this issue, it is better
+  // not to use cuDNN for this case
+  TORCH_INTERNAL_ASSERT(false, "This case should not be dispatched to cuDNN.");
+}
+
+Tensor miopen_convolution_backward_weight(
     CheckedFrom c,
-    IntArrayRef input_size, const TensorArg& grad_output, const TensorArg& weight,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
-    bool benchmark, bool deterministic)
-{
-  checkAllSameType(c, {grad_output, weight});
-  checkAllSameGPU(c, {grad_output, weight});
+    IntArrayRef weight_size,
+    const Tensor& grad_output_t,
+    const Tensor& input_t,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic,
+    bool depthwise=false) {
+  auto memory_format = miopen_conv_suggest_memory_format(input_t, grad_output_t);
 
-  auto memory_format = at::MemoryFormat::Contiguous;
-  if (miopen_conv_use_channels_last(*grad_output, *weight)) {
-    memory_format = (weight->ndimension() == 5) ? at::MemoryFormat::ChannelsLast3d : at::MemoryFormat::ChannelsLast;
-  }
+  Tensor grad_output_contig_t = grad_output_t.contiguous(memory_format);
+  TensorArg grad_output_contig{grad_output_contig_t, "grad_output", 1};
 
-  Tensor grad_input_t = at::detail::empty_cuda(
-      input_size, grad_output->options().memory_format(memory_format));
+  Tensor input_contig_t = input_t.contiguous(memory_format);
+  TensorArg input{input_contig_t, "input", 2};
 
-  TensorArg grad_input{ grad_input_t, "result", 0 };
-  convolution_shape_check(c, grad_input, weight, grad_output, padding, stride, dilation, groups);
+  checkAllSameType(c, {grad_output_contig, input});
+  checkAllSameGPU(c, {grad_output_contig, input});
 
-  // See #4500
-  Tensor weight_contig = weight->contiguous(memory_format);
-  // Make sure that NC11 strides follow formula
-  weight_contig.resize_(weight_contig.sizes(), memory_format);
+  auto grad_weight_t =
+    at::empty(weight_size, grad_output_contig->options(), memory_format);
 
-  Tensor grad_output_contig = grad_output->contiguous(memory_format);
-  grad_output_contig.resize_(grad_output_contig.sizes(), memory_format);
+  // For uniformity with everything else, although it seems grad_weight
+  // would be unambiguous too.
+  TensorArg grad_weight{grad_weight_t, "result", 0};
+  convolution_shape_check(
+      c,
+      input,
+      grad_weight,
+      grad_output_contig,
+      padding,
+      stride,
+      dilation,
+      groups);
 
-  raw_miopen_depthwise_convolution_backward_input_out(
-      *grad_input, grad_output_contig, weight_contig,
-      padding, stride, dilation, groups, benchmark, deterministic);
+  raw_miopen_convolution_backward_weight_out(
+      *grad_weight,
+      *grad_output_contig,
+      *input,
+      padding,
+      stride,
+      dilation,
+      groups,
+      benchmark,
+      deterministic,
+      depthwise);
 
-  return *grad_input;
+  return grad_weight_t;
 }
 
-Tensor miopen_depthwise_convolution_backward_input(
-    IntArrayRef input_size, const Tensor& grad_output_t, const Tensor& weight_t,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
-    bool benchmark, bool deterministic)
-{
-  TensorArg grad_output{ grad_output_t, "grad_output", 1 },
-            weight{ weight_t, "weight", 2 };
-  return miopen_depthwise_convolution_backward_input(
-      "miopen_depthwise_convolution_backward_input",
-      input_size, grad_output, weight,
-      padding, stride, dilation, groups, benchmark, deterministic);
+// overload
+Tensor miopen_convolution_backward_weight(
+    IntArrayRef weight_size,
+    const Tensor& grad_output_t,
+    const Tensor& input_t,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic,
+    bool depthwise=false) {
+  return miopen_convolution_backward_weight(
+      "miopen_convolution_backward_weight",
+      weight_size,
+      grad_output_t,
+      input_t,
+      padding,
+      stride,
+      dilation,
+      groups,
+      benchmark,
+      deterministic,
+      depthwise);
 }
 
-std::tuple<at::Tensor,at::Tensor,at::Tensor> miopen_convolution_backward(
-    const at::Tensor& input, const at::Tensor& grad_output_t, const at::Tensor& weight,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
-    bool benchmark, bool deterministic, std::array<bool,3> output_mask) {
-
-  Tensor grad_output = grad_output_t.contiguous(input.suggest_memory_format());
+std::tuple<at::Tensor, at::Tensor, at::Tensor> miopen_convolution_backward(
+    const at::Tensor& input,
+    const at::Tensor& grad_output_t,
+    const at::Tensor& weight,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic,
+    std::array<bool,3> output_mask) {
+  Tensor grad_output = grad_output_t.to(input.suggest_memory_format());
 
   Tensor grad_input, grad_weight, grad_bias;
-  if (output_mask[0]) {
-    grad_input = miopen_convolution_backward_input(input.sizes(), grad_output, weight, padding, stride, dilation, groups, benchmark, deterministic);
-  }
-  if (output_mask[1]) {
-    grad_weight = miopen_convolution_backward_weight(weight.sizes(), grad_output, input, padding, stride, dilation, groups, benchmark, deterministic);
-  }
-  if (output_mask[2]) {
-    grad_bias = miopen_convolution_backward_bias(grad_output);
+  if (input.numel() == 0) {
+    if (output_mask[0]) {
+      grad_input = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+    }
+    if (output_mask[1]) {
+      grad_weight = at::zeros_like(weight, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+    }
+    if (output_mask[2]) {
+      grad_bias = at::zeros_like(grad_output_t, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+    }
+  } else {
+    if (output_mask[0]) {
+      grad_input = miopen_convolution_backward_input(
+          input.sizes(),
+          grad_output,
+          weight,
+          padding,
+          stride,
+          dilation,
+          groups,
+          benchmark,
+          deterministic);
+    }
+    if (output_mask[1]) {
+      grad_weight = miopen_convolution_backward_weight(
+          weight.sizes(),
+          grad_output,
+          input,
+          padding,
+          stride,
+          dilation,
+          groups,
+          benchmark,
+          deterministic);
+    }
+    if (output_mask[2]) {
+      grad_bias = miopen_convolution_backward_bias(grad_output);
+    }
   }
 
-  return std::tuple<Tensor,Tensor,Tensor>{grad_input, grad_weight, grad_bias};
+  return std::tuple<Tensor, Tensor, Tensor>{grad_input, grad_weight, grad_bias};
 }
 
-std::tuple<at::Tensor,at::Tensor,at::Tensor> miopen_depthwise_convolution_backward(
-    const at::Tensor& input, const at::Tensor& grad_output_t, const at::Tensor& weight,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
-    bool benchmark, bool deterministic, std::array<bool,3> output_mask) {
+Tensor miopen_convolution_transpose_forward(
+    CheckedFrom c,
+    const TensorArg& grad_output,
+    const TensorArg& weight,
+    IntArrayRef padding,
+    IntArrayRef output_padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic) {
+  auto input_size = conv_input_size(
+      grad_output->sizes(),
+      weight->sizes(),
+      padding,
+      output_padding,
+      stride,
+      dilation,
+      groups);
+  return miopen_convolution_backward_input(
+      c,
+      input_size,
+      grad_output,
+      weight,
+      padding,
+      stride,
+      dilation,
+      groups,
+      benchmark,
+      deterministic);
+}
 
-  Tensor grad_output = grad_output_t.contiguous(input.suggest_memory_format());
-
-  Tensor grad_input, grad_weight, grad_bias;
-  if (output_mask[0]) {
-    grad_input = miopen_depthwise_convolution_backward_input(input.sizes(), grad_output, weight, padding, stride, dilation, groups, benchmark, deterministic);
-  }
-  if (output_mask[1]) {
-    grad_weight = miopen_depthwise_convolution_backward_weight(weight.sizes(), grad_output, input, padding, stride, dilation, groups, benchmark, deterministic);
-  }
-  if (output_mask[2]) {
-    grad_bias = miopen_convolution_backward_bias(grad_output);
-  }
-
-  return std::tuple<Tensor,Tensor,Tensor>{grad_input, grad_weight, grad_bias};
+Tensor miopen_convolution_transpose_backward_weight(
+    IntArrayRef weight_size,
+    const Tensor& grad_output_t,
+    const Tensor& input_t,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic) {
+  return miopen_convolution_backward_weight(
+      "miopen_convolution_backward_weight",
+      weight_size,
+      input_t,
+      grad_output_t,
+      padding,
+      stride,
+      dilation,
+      groups,
+      benchmark,
+      deterministic);
 }
 
 Tensor miopen_convolution_transpose(
-    const Tensor& input_t, const Tensor& weight_t, const std::optional<Tensor>& bias_t_opt,
-    IntArrayRef padding, IntArrayRef output_padding, IntArrayRef stride, IntArrayRef dilation,
-    int64_t groups, bool benchmark, bool deterministic)
+    const Tensor& input_t,
+    const Tensor& weight_t,
+    const std::optional<Tensor>& bias_t_opt,
+    IntArrayRef padding,
+    IntArrayRef output_padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic) {
+  // See [Note: hacky wrapper removal for optional tensor]
+  c10::MaybeOwned<Tensor> bias_t_maybe_owned = at::borrow_from_optional_tensor(bias_t_opt);
+  const Tensor& bias_t = *bias_t_maybe_owned;
+
+  TensorArg input{input_t, "input", 1}, weight{weight_t, "weight", 2}, bias{bias_t, "bias", 3};
+  CheckedFrom c = "miopen_convolution_transpose";
+  auto output_t = miopen_convolution_transpose_forward(
+      c,
+      input,
+      weight,
+      padding,
+      output_padding,
+      stride,
+      dilation,
+      groups,
+      benchmark,
+      deterministic);
+  if (bias->defined()) {
+    miopen_convolution_add_bias_(c, { output_t, "result", 0 }, bias);
+  }
+  return output_t;
+}
+
+// ---------------------------------------------------------------------
+//
+// Convolution depthwise
+//
+// ---------------------------------------------------------------------
+
+Tensor miopen_depthwise_convolution(
+    const Tensor& input_t,
+    const Tensor& weight_t,
+    const std::optional<Tensor>& bias_t_opt,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic)
 {
   // See [Note: hacky wrapper removal for optional tensor]
   c10::MaybeOwned<Tensor> bias_t_maybe_owned = at::borrow_from_optional_tensor(bias_t_opt);
@@ -1474,16 +1715,86 @@ Tensor miopen_convolution_transpose(
   TensorArg input  { input_t,  "input",  1 },
             weight { weight_t, "weight", 2 },
             bias   { bias_t,   "bias",   3 };
-  CheckedFrom c = "miopen_convolution_transpose";
-  auto output_t = miopen_convolution_transpose_forward(
-    c, input, weight, padding, output_padding, stride, dilation, groups, benchmark, deterministic);
-  if (bias->defined()) {
-    miopen_convolution_add_bias_(c, { output_t, "result", 0 }, bias);
+  CheckedFrom c = "miopen_depthwise_convolution";
+  auto memory_format = miopen_conv_suggest_memory_format(input_t, weight_t);
+  Tensor output_t = at::detail::empty_cuda(
+      conv_output_size(
+        input_t.sizes(), weight_t.sizes(), padding, stride, dilation),
+      input_t.options().memory_format(memory_format));
+  if (output_t.numel() == 0) {
+    return output_t;
   }
-  return output_t;
+  // Avoid ambiguity of "output" when this is being used as backwards
+  TensorArg output{output_t, "result", 0};
+  miopen_convolution_forward_out(
+      output,
+      c,
+      input,
+      weight,
+      padding,
+      stride,
+      dilation,
+      groups,
+      benchmark,
+      deterministic,
+      true);
+  if (bias->defined()) {
+    miopen_convolution_add_bias_(c, output, bias);
+  }
+  return *output;
 }
 
-// MIOpen fused convolution bias activation forward
+std::tuple<at::Tensor, at::Tensor, at::Tensor> miopen_depthwise_convolution_backward(
+    const at::Tensor& input,
+    const at::Tensor& grad_output_t,
+    const at::Tensor& weight,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic,
+    std::array<bool,3> output_mask) {
+  Tensor grad_output = grad_output_t.to(input.suggest_memory_format());
+
+  Tensor grad_input, grad_weight, grad_bias;
+  if (output_mask[0]) {
+    grad_input = miopen_convolution_backward_input(
+        input.sizes(),
+        grad_output,
+        weight,
+        padding,
+        stride,
+        dilation,
+        groups,
+        benchmark,
+        deterministic,
+        true);
+  }
+  if (output_mask[1]) {
+    grad_weight = miopen_convolution_backward_weight(
+        weight.sizes(),
+        grad_output,
+        input,
+        padding,
+        stride,
+        dilation,
+        groups,
+        benchmark,
+        deterministic,
+        true);
+  }
+  if (output_mask[2]) {
+    grad_bias = miopen_convolution_backward_bias(grad_output);
+  }
+
+  return std::tuple<Tensor,Tensor,Tensor>{grad_input, grad_weight, grad_bias};
+}
+
+// ---------------------------------------------------------------------
+// fusions
+// ---------------------------------------------------------------------
+
 void raw_miopen_convolution_relu_out(
     const Tensor& output,
     const Tensor& input,
@@ -1495,17 +1806,35 @@ void raw_miopen_convolution_relu_out(
     int64_t groups,
     bool benchmark,
     bool deterministic) {
-
   auto dataType = getMiopenDataType(input);
   miopenConvolutionMode_t c_mode = miopenConvolution;
-
   ConvolutionArgs args{ input, output, weight };
   args.handle = getMiopenHandle();
-  setConvolutionParams(&args.params, args.handle, input, weight, padding, stride, dilation, groups, deterministic);
-  args.idesc.set(input);
-  args.wdesc.set(weight, input.suggest_memory_format(), 0);
-  args.odesc.set(output);
-  args.cdesc.set(dataType, c_mode, input.dim() - 2, args.params.padding, args.params.stride, args.params.dilation, args.params.groups, benchmark, deterministic);
+  at::MemoryFormat memory_format = miopen_conv_suggest_memory_format(input, weight);
+  setConvolutionParams(
+      &args.params,
+      args.handle,
+      input,
+      weight,
+      padding,
+      stride,
+      dilation,
+      groups,
+      deterministic,
+      memory_format);
+  args.idesc.set(input, memory_format);
+  args.wdesc.set(weight, memory_format, 0);
+  args.odesc.set(output, memory_format);
+  args.cdesc.set(
+      dataType,
+      c_mode,
+      input.dim() - 2,
+      args.params.padding,
+      args.params.stride,
+      args.params.dilation,
+      args.params.groups,
+      benchmark,
+      deterministic);
 
   TensorDescriptor bdesc;
   bdesc.set(bias.expand({1, bias.size(0)}), output.dim());
@@ -1549,8 +1878,8 @@ static at::Tensor self_or_new_memory_format(at::Tensor& self, at::MemoryFormat m
 }
 
 Tensor miopen_convolution_add_relu(
-    const Tensor& input,
-    const Tensor& weight,
+    const Tensor& input_t,
+    const Tensor& weight_t,
     const Tensor& z,
     const std::optional<Scalar>& alpha,
     const std::optional<Tensor>& bias,
@@ -1562,17 +1891,28 @@ Tensor miopen_convolution_add_relu(
   // MIOpen does not support fusion of add, the alpha2 * z step of the below cuDNN function:
   // y = act ( alpha1 * conv(x) + alpha2 * z + bias )
 
-  auto memory_format = input.suggest_memory_format();
+  auto memory_format = miopen_conv_suggest_memory_format(input_t, weight_t);
 
   auto& ctx = at::globalContext();
   bool benchmark = ctx.benchmarkCuDNN();
 
-  TensorArg input_arg  { input,  "input",  1 },
-            weight_arg { weight, "weight", 2 };
-  auto output = miopen_convolution_forward(
+  TensorArg input  { input_t,  "input",  1 },
+            weight { weight_t, "weight", 2 };
+
+  Tensor output_t = at::detail::empty_cuda(
+      conv_output_size(
+        input_t.sizes(), weight_t.sizes(), padding, stride, dilation),
+      input_t.options().memory_format(memory_format));
+  if (output_t.numel() == 0){
+    return output_t;
+  }
+  // Avoid ambiguity of "output" when this is being used as backwards
+  TensorArg output{output_t, "result", 0};
+  miopen_convolution_forward_out(
+      output,
       "miopen_convolution_add_relu",
-      input_arg,
-      weight_arg,
+      input,
+      weight,
       padding,
       stride,
       dilation,
@@ -1581,53 +1921,51 @@ Tensor miopen_convolution_add_relu(
       false // deterministic
   );
 
-  auto contig_output = self_or_new_memory_format(output, memory_format);
+  auto contig_output_t = self_or_new_memory_format(output_t, memory_format);
 
-  if (!output.is_same(contig_output)) {
-    contig_output.copy_(output);
+  if (!output_t.is_same(contig_output_t)) {
+    contig_output_t.copy_(output_t);
   }
 
   auto _alpha = alpha.has_value() ? alpha.value().to<float>() : 1.0;
   auto _bias = bias.has_value()
           ? bias.value()
           : at::zeros(
-                {contig_output.size(1)},
-                optTypeMetaToScalarType(contig_output.options().dtype_opt()),
-                contig_output.options().layout_opt(),
-                contig_output.options().device_opt(),
-                contig_output.options().pinned_memory_opt());
+                {contig_output_t.size(1)},
+                optTypeMetaToScalarType(contig_output_t.options().dtype_opt()),
+                contig_output_t.options().layout_opt(),
+                contig_output_t.options().device_opt(),
+                contig_output_t.options().pinned_memory_opt());
 
-  at::Tensor alpha_mul_z_add_bias = at::native::reshape_bias(input.dim(), _bias).add(z, _alpha);
-  contig_output.add_(alpha_mul_z_add_bias);
-  contig_output.relu_();
+  at::Tensor alpha_mul_z_add_bias = at::native::reshape_bias(input_t.dim(), _bias).add(z, _alpha);
+  contig_output_t.add_(alpha_mul_z_add_bias);
+  contig_output_t.relu_();
 
-  return contig_output;
+  return contig_output_t;
 }
 
 Tensor miopen_convolution_relu(
-    const Tensor& input,
-    const Tensor& weight,
+    const Tensor& input_t,
+    const Tensor& weight_t,
     const std::optional<Tensor>& bias,
     IntArrayRef stride,
     IntArrayRef padding,
     IntArrayRef dilation,
     int64_t groups) {
 
-  auto memory_format = input.suggest_memory_format();
-
   auto& ctx = at::globalContext();
   bool benchmark = ctx.benchmarkCuDNN();
 
   // MIOpen currently only supports MemoryFormat::Contiguous and fp32 and 2d
-  if (input.suggest_memory_format() == at::MemoryFormat::Contiguous
-          && input.scalar_type() == at::kFloat
-          && input.ndimension() == 4) {
+  if (input_t.suggest_memory_format() == at::MemoryFormat::Contiguous
+          && input_t.scalar_type() == at::kFloat
+          && input_t.ndimension() == 4) {
 
     // FuseFrozenConvAddRelu performs some tensor shape checking
     Tensor output_t = at::detail::empty_cuda(
         conv_output_size(
-            input.sizes(), weight.sizes(), padding, stride, dilation),
-        input.options().memory_format(input.suggest_memory_format()));
+            input_t.sizes(), weight_t.sizes(), padding, stride, dilation),
+        input_t.options().memory_format(input_t.suggest_memory_format()));
     if (output_t.numel() == 0) {
       return output_t;
     }
@@ -1643,8 +1981,8 @@ Tensor miopen_convolution_relu(
 
     raw_miopen_convolution_relu_out(
         output_t,
-        input,
-        weight,
+        input_t,
+        weight_t,
         _bias,
         stride,
         padding,
@@ -1659,12 +1997,25 @@ Tensor miopen_convolution_relu(
   else {
     // fallback
 
-    TensorArg input_arg  { input,  "input",  1 },
-              weight_arg { weight, "weight", 2 };
-    auto output = miopen_convolution_forward(
+    auto memory_format = miopen_conv_suggest_memory_format(input_t, weight_t);
+
+    TensorArg input  { input_t,  "input",  1 },
+              weight { weight_t, "weight", 2 };
+
+    Tensor output_t = at::detail::empty_cuda(
+        conv_output_size(
+          input_t.sizes(), weight_t.sizes(), padding, stride, dilation),
+        input->options().memory_format(memory_format));
+    if (output_t.numel() == 0){
+      return output_t;
+    }
+    // Avoid ambiguity of "output" when this is being used as backwards
+    TensorArg output{output_t, "result", 0};
+    miopen_convolution_forward_out(
+        output,
         "miopen_convolution_relu",
-        input_arg,
-        weight_arg,
+        input,
+        weight,
         padding,
         stride,
         dilation,
@@ -1673,26 +2024,26 @@ Tensor miopen_convolution_relu(
         false // deterministic
     );
 
-    auto contig_output = self_or_new_memory_format(output, memory_format);
+    auto contig_output_t = self_or_new_memory_format(output_t, memory_format);
 
-    if (!output.is_same(contig_output)) {
-      contig_output.copy_(output);
+    if (!output_t.is_same(contig_output_t)) {
+      contig_output_t.copy_(output_t);
     }
 
     auto _bias = bias.has_value()
             ? bias.value()
             : at::zeros(
-                  {contig_output.size(1)},
-                  optTypeMetaToScalarType(contig_output.options().dtype_opt()),
-                  contig_output.options().layout_opt(),
-                  contig_output.options().device_opt(),
-                  contig_output.options().pinned_memory_opt());
+                  {contig_output_t.size(1)},
+                  optTypeMetaToScalarType(contig_output_t.options().dtype_opt()),
+                  contig_output_t.options().layout_opt(),
+                  contig_output_t.options().device_opt(),
+                  contig_output_t.options().pinned_memory_opt());
 
-    at::Tensor reshaped_bias = at::native::reshape_bias(input.dim(), _bias);
-    contig_output.add_(reshaped_bias);
-    contig_output.relu_();
+    at::Tensor reshaped_bias = at::native::reshape_bias(input_t.dim(), _bias);
+    contig_output_t.add_(reshaped_bias);
+    contig_output_t.relu_();
 
-    return contig_output;
+    return contig_output_t;
   }
 }
 
@@ -1700,6 +2051,6 @@ REGISTER_CUDA_DISPATCH(miopen_convolution_backward_stub, &miopen_convolution_bac
 REGISTER_CUDA_DISPATCH(miopen_convolution_transpose_backward_stub, &miopen_convolution_transpose_backward)
 REGISTER_CUDA_DISPATCH(miopen_depthwise_convolution_backward_stub, &miopen_depthwise_convolution_backward)
 
-}}  // namespace
+}  // namespace
 
-#endif
+#endif // AT_ROCM_ENABLED()

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4126,7 +4126,7 @@
     CUDA: miopen_batch_norm_backward
   autogen: miopen_batch_norm_backward.out
 
-- func: miopen_convolution(Tensor self, Tensor weight, Tensor? bias, SymInt[] padding, SymInt[] stride, SymInt[] dilation, SymInt groups, bool benchmark, bool deterministic) -> Tensor
+- func: miopen_convolution(Tensor self, Tensor weight, Tensor? bias, SymInt[] padding, SymInt[] stride, SymInt[] dilation, SymInt groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor
   dispatch:
     CUDA: miopen_convolution
   autogen: miopen_convolution.out

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4144,10 +4144,12 @@
 - func: miopen_convolution_relu(Tensor self, Tensor weight, Tensor? bias, SymInt[] stride, SymInt[] padding, SymInt[] dilation, SymInt groups) -> Tensor
   dispatch:
     CUDA: miopen_convolution_relu
+  autogen: miopen_convolution_relu.out
 
 - func: miopen_convolution_add_relu(Tensor self, Tensor weight, Tensor z, Scalar? alpha, Tensor? bias, SymInt[] stride, SymInt[] padding, SymInt[] dilation, SymInt groups) -> Tensor
   dispatch:
     CUDA: miopen_convolution_add_relu
+  autogen: miopen_convolution_add_relu.out
 
 - func: miopen_rnn(Tensor input, Tensor[] weight, int weight_stride0, Tensor hx, Tensor? cx, int mode, int hidden_size, int num_layers, bool batch_first, float dropout, bool train, bool bidirectional, int[] batch_sizes, Tensor? dropout_state) -> (Tensor, Tensor, Tensor, Tensor, Tensor)
   dispatch:

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -4032,6 +4032,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
         self.assertEqual(grad_input.shape, input.shape)
         self.assertEqual(grad_weight.shape, weight.shape)
 
+    @skipCUDAIfRocm
     @onlyCUDA
     @largeTensorTest("40GB")
     @largeTensorTest("24GB", "cpu")

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2794,7 +2794,7 @@
 - name: miopen_convolution_transpose(Tensor self, Tensor weight, Tensor? bias, SymInt[] padding, SymInt[] output_padding, SymInt[] stride, SymInt[] dilation, SymInt groups, bool benchmark, bool deterministic) -> Tensor
   self, weight, bias: "grad.defined() ? convolution_backward_symint(grad, self, weight, bias->sym_sizes(), stride, padding, dilation, true, output_padding, groups, grad_input_mask) : std::tuple<Tensor, Tensor, Tensor>()"
 
-- name: miopen_convolution(Tensor self, Tensor weight, Tensor? bias, SymInt[] padding, SymInt[] stride, SymInt[] dilation, SymInt groups, bool benchmark, bool deterministic) -> Tensor
+- name: miopen_convolution(Tensor self, Tensor weight, Tensor? bias, SymInt[] padding, SymInt[] stride, SymInt[] dilation, SymInt groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor
   self, weight, bias: "grad.defined() ? convolution_backward_symint(grad, self, weight, bias->sym_sizes(), stride, padding, dilation, false, std::vector<c10::SymInt>(padding.size(), 0), groups, grad_input_mask) : std::tuple<Tensor, Tensor, Tensor>()"
 
 - name: miopen_depthwise_convolution(Tensor self, Tensor weight, Tensor? bias, SymInt[] padding, SymInt[] stride, SymInt[] dilation, SymInt groups, bool benchmark, bool deterministic) -> Tensor

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -793,7 +793,7 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         torch.miopen_batch_norm: (
             lambda input, weight, bias, running_mean, running_var, training, exponential_average_factor, epsilon: -1
         ),
-        torch.miopen_convolution: lambda input, weight, bias, padding, stride, dilation, groups, benchmark, deterministic: -1,  # noqa: B950
+        torch.miopen_convolution: lambda input, weight, bias, padding, stride, dilation, groups, benchmark, deterministic: -1, allow_tf32: 1,  # noqa: B950
         torch.miopen_convolution_add_relu: lambda input, weight, z, alpha, bias, stride, padding, dilation, groups: -1,
         torch.miopen_convolution_relu: lambda input, weight, bias, stride, padding, dilation, groups: -1,
         torch.miopen_convolution_transpose: (


### PR DESCRIPTION
MI30X series GPGPU support TF32 gemm compute while this feature is not introduced into conv now.
MIOpen is enabling this feature ([PR:1414](https://github.com/ROCm/rocm-libraries/pull/1414)). Corresponding config will be also applied to MIOpen backend just like cudnn does( Refer to  https://docs.pytorch.org/docs/main/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices).

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01