### PR TITLE
[export] handling NamedTuple inputs

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -16017,6 +16017,26 @@ def forward(self, q, k, v):
         ):
             export(Foo(), (torch.randn(1, 33, 256, 128), k, v))
 
+    def test_namedtuple_input_export(self):
+        # test for NamedTuple inputs with both strict and non-strict export modes
+        from collections import namedtuple
+
+        PointNT = namedtuple("PointNT", ["x", "y"])
+
+        class M(torch.nn.Module):
+            def forward(self, x, y):
+                return x + y
+
+        inp = PointNT(torch.ones(3), torch.ones(3))
+
+        ep_non_strict = export(M(), inp, strict=False)
+        result_non_strict = ep_non_strict.module()(*inp)
+
+        ep_strict = export(M(), inp, strict=True)
+        result_strict = ep_strict.module()(*inp)
+
+        self.assertEqual(result_non_strict, result_strict)
+
 
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
 class TestOneOffModelExportResult(TestCase):

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -16029,7 +16029,7 @@ def forward(self, q, k, v):
 
         inp = PointNT(torch.ones(3), torch.ones(3))
 
-        ep_non_strict = export(M(), inp, strict=False)
+        ep_non_strict = export(M(), inp)
         result_non_strict = ep_non_strict.module()(*inp)
 
         ep_strict = export(M(), inp, strict=True)

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -1263,6 +1263,9 @@ def _process_export_inputs(
             f"Expecting `args` to be a tuple of example positional inputs, got {type(args)}",
         )
     kwargs = kwargs if kwargs is not None else {}
+    if pytree.is_namedtuple_instance(args):
+        args = tuple(args)
+
     _, original_in_spec = pytree.tree_flatten((args, kwargs))
 
     verify_additional_inputs: Callable[[ExportedProgram], None]


### PR DESCRIPTION
Fixes #160547
### Summary:
bug
```
    def test_namedtuple(self):
        from collections import namedtuple
        Point = namedtuple('Point', 'x y')
        
        class M(torch.nn.Module):
            def forward(self, x, y):
                return x + y 
        
        inp = Point(torch.ones(3), torch.ones(3))
        print(M()(*inp))
        
        # errors
        ep = torch.export.export(M(), inp, strict=False)
        print(ep)

        # succeeds
        ep = torch.export.export(M(), inp, strict=True)
        print(ep)

        # workaround could be to convert namedtuple to a kwarg
        inp_kwargs =  {field: getattr(inp, field) for field in inp._fields}
        ep = torch.export.export(M(), (), inp_kwargs)
        print(ep)
```
FIx :
namedtuple is subclass of tuple 
but namedtuple is not expected 
So, this change handles named tuple case

I have added 🧪 test case for this as well 