### PR TITLE
Revise FindOpenBLAS.cmake logic to allow overriding location

### DIFF
--- a/cmake/Modules/FindOpenBLAS.cmake
+++ b/cmake/Modules/FindOpenBLAS.cmake
@@ -1,6 +1,9 @@
 
 
 SET(Open_BLAS_INCLUDE_SEARCH_PATHS
+  $ENV{OpenBLAS_HOME}
+  $ENV{OpenBLAS_HOME}/include
+  $ENV{OpenBLAS_HOME}/include/openblas
   /usr/include
   /usr/include/openblas
   /usr/include/openblas-base
@@ -9,12 +12,13 @@ SET(Open_BLAS_INCLUDE_SEARCH_PATHS
   /usr/local/include/openblas-base
   /usr/local/opt/openblas/include
   /opt/OpenBLAS/include
-  $ENV{OpenBLAS_HOME}
-  $ENV{OpenBLAS_HOME}/include
-  $ENV{OpenBLAS_HOME}/include/openblas
 )
 
 SET(Open_BLAS_LIB_SEARCH_PATHS
+        $ENV{OpenBLAS}
+        $ENV{OpenBLAS}/lib
+        $ENV{OpenBLAS_HOME}
+        $ENV{OpenBLAS_HOME}/lib
         /lib/
         /lib/openblas-base
         /lib64/
@@ -25,14 +29,18 @@ SET(Open_BLAS_LIB_SEARCH_PATHS
         /usr/local/lib64
         /usr/local/opt/openblas/lib
         /opt/OpenBLAS/lib
-        $ENV{OpenBLAS}
-        $ENV{OpenBLAS}/lib
-        $ENV{OpenBLAS_HOME}
-        $ENV{OpenBLAS_HOME}/lib
  )
 
-FIND_PATH(OpenBLAS_INCLUDE_DIR NAMES cblas.h PATHS ${Open_BLAS_INCLUDE_SEARCH_PATHS})
-FIND_LIBRARY(OpenBLAS_LIB NAMES openblas PATHS ${Open_BLAS_LIB_SEARCH_PATHS})
+IF("$ENV{OpenBLAS_HOME}" STREQUAL "")
+  FIND_PATH(OpenBLAS_INCLUDE_DIR NAMES cblas.h PATHS ${Open_BLAS_INCLUDE_SEARCH_PATHS})
+ELSE($ENV{OpenBLAS_HOME})
+  FIND_PATH(OpenBLAS_INCLUDE_DIR NAMES cblas.h PATHS ${Open_BLAS_INCLUDE_SEARCH_PATHS} NO_DEFAULT_PATH)
+ENDIF()
+IF("$ENV{OpenBLAS}" STREQUAL "" AND "$ENV{OpenBLAS_HOME}" STREQUAL "")
+  FIND_LIBRARY(OpenBLAS_LIB NAMES openblas PATHS ${Open_BLAS_LIB_SEARCH_PATHS})
+ELSE()
+  FIND_LIBRARY(OpenBLAS_LIB NAMES openblas PATHS ${Open_BLAS_LIB_SEARCH_PATHS} NO_DEFAULT_PATH)
+ENDIF()
 
 SET(OpenBLAS_FOUND ON)
 


### PR DESCRIPTION
CMake has a specific resolution order for `find_library()`:

1. <PackageName>_ROOT variables specified via command line or environment, in various permutations, only when inside a `find_package()`
2. `CMAKE`-prefixed defines like `CMAKE_LIBRARY_PATH` passed via `-DCMAKE_LIBRARY_PATH`
3. same, but with env vars
4. paths specified by the `HINTS` option
5. some env vars like `PATH` and `LIB`
6. standard system paths like `/usr/lib/x86_64-linux-gnu` and `/usr/local/lib`
7. paths specified by the `PATHS` option

See https://cmake.org/cmake/help/latest/command/find_library.html

The first match is used, meaning a match discovered in step 2 will stop all further efforts to find a match, and within any option with multiple parameters (like paths specified in `HINTS`), the first matching location works.

All this means it is impossible to override a distro-provided OpenBLAS found in /usr/lib, with an optimized version in a location specified by `${OpenBLAS_HOME}`.

This change a) swaps the content of `Open_BLAS_LIB_SEARCH_PATHS` to consider the env var override before the hardcoded list of potential folders, and b) in the event that an env var override is specified, disables all default location searching such that system paths are not considered.

Similar rules apply for `find_path()`, used for finding the headers, and a similar resolution to allow overriding is applied.