### PR TITLE
[SymmMem] Not use run_test.py in CI

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -339,10 +339,10 @@ test_h100_distributed() {
 
 test_h100_symm_mem() {
   # symmetric memory test
-  time python test/run_test.py --include distributed/test_symmetric_memory.py  $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
-  time python test/run_test.py --include distributed/test_nvshmem.py $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
-  time python test/run_test.py --include distributed/test_nvshmem_triton.py $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
-  time python test/run_test.py --include distributed/test_nccl.py $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  pytest -v test/distributed/test_symmetric_memory.py
+  pytest -v test/distributed/test_nvshmem.py
+  pytest -v test/distributed/test_nvshmem_triton.py
+  pytest -v test/distributed/test_nccl.py
   assert_git_not_dirty
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #162981

run_test.py can mute errors in test (mechanism unknown, issue filed #162978).
Replacing it with bare pytest in SymmMem CI commands.