### PR TITLE
[precompile] Store traced file information with CompileArtifacts.

### DIFF
--- a/torch/_dynamo/aot_compile.py
+++ b/torch/_dynamo/aot_compile.py
@@ -8,7 +8,7 @@ import pickle
 import types
 from contextlib import AbstractContextManager, ExitStack
 from dataclasses import dataclass
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, TYPE_CHECKING
 
 import torch
 import torch.fx
@@ -17,6 +17,11 @@ from torch._dynamo.precompile_context import PrecompileContext, SystemInfo
 
 from . import convert_frame
 from .hooks import Hooks
+
+
+if TYPE_CHECKING:
+    from .guards import GuardManagerWrapper
+    from .package import SourceInfo
 
 
 log = logging.getLogger(__name__)
@@ -46,13 +51,14 @@ def bind_locals(
 class CompileArtifacts:
     signature: inspect.Signature
     bytecode: types.CodeType
-    guard_manager: Optional[torch._dynamo.guards.GuardManagerWrapper]
+    guard_manager: Optional["GuardManagerWrapper"]
     guards_state: bytes
     import_sources: dict[str, str]
     backend_id: str
     compiled_fn: SerializableCallable
     original_code: types.CodeType
     closure: Optional[tuple[Any, ...]]
+    source_info: "SourceInfo"
     use_cuda: bool
     system_info: SystemInfo = dataclasses.field(default_factory=SystemInfo.current)
 
@@ -101,6 +107,9 @@ class AOTCompiledFunction:
             reason = str(self._artifacts.guard_manager.check_verbose(f_locals))
             raise RuntimeError(f"GuardManager check failed, reason: {reason}")
         return self.fn(*args, **kwargs)
+
+    def source_info(self) -> "SourceInfo":
+        return self._artifacts.source_info
 
     def save_compiled_function(self, path: str) -> None:
         with open(path, "wb") as f:
@@ -201,6 +210,7 @@ def aot_compile_fullgraph(
     backend: Callable[[torch.fx.GraphModule, list[torch.Tensor]], SerializableCallable],
 ) -> AOTCompiledFunction:
     from torch._dynamo.guards import CheckFunctionManager
+    from torch._dynamo.package import SourceInfo
     from torch._dynamo.utils import dynamo_timed, get_metrics_context
     from torch._guards import compile_context, CompileContext, TracingContext
 
@@ -302,6 +312,10 @@ def aot_compile_fullgraph(
                 + f"from backend {compiler_fn}) does not implement SerializableCallable."
             )
 
+        source_info = SourceInfo(inlined_sources=set())
+        for traced_code in output_graph.traced_code:
+            source_info.add_code(traced_code)
+
         artifacts = CompileArtifacts(
             signature=signature,
             bytecode=dynamo_output.bytecode,
@@ -312,6 +326,7 @@ def aot_compile_fullgraph(
             compiled_fn=compiled_fn,
             original_code=fn.__code__,
             closure=fn.__closure__,
+            source_info=source_info,
             use_cuda=use_cuda,
         )
         aot_compiled_fn = AOTCompiledFunction(_artifacts=artifacts)

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -506,6 +506,7 @@ class OutputGraph(OutputGraphGuardsState):
             )
         self.tracing_context: TracingContext = TracingContext(fake_mode)
         self.tracing_context.traced_code.append(f_code)
+        self.traced_code = self.tracing_context.traced_code
         self.dynamo_compile_id: Optional[CompileId] = (
             CompileContext.current_compile_id()
         )


### PR DESCRIPTION
Summary:
Add some metadata to CompileArtifacts, so that it contains the source code information about the original code while they are being traced.

For now, we will not provide a verification method to end user and instead we just provide which files are inlined. It's up to user to verify the content from these files are not changed (because it's optional for many users to validate source code changes anyway in aot precompile)

Test Plan:
buck run @mode/opt test/dynamo:test_dynamo -- -k test_file_change
buck run @mode/opt test/dynamo:test_dynamo -- -k test_aot_compile_source_info

Fixes #ISSUE_NUMBER


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela