### PR TITLE
[FP8][H100][TF32] Disable tf32 for emulated reference computation in `test_scaled_mm_vs_emulated_block_wise`

### DIFF
--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -975,6 +975,7 @@ class TestFP8Matmul(TestCase):
     @parametrize("output_dtype", [torch.bfloat16, torch.float32])
     @parametrize("lhs_block,rhs_block", [(1, 1), (128, 1), (1, 128)])
     @parametrize("M,N,K", [(256, 768, 512)])
+    @with_tf32_off
     def test_scaled_mm_vs_emulated_block_wise(self, output_dtype, lhs_block, rhs_block, M, N, K):
         torch.manual_seed(42)
 


### PR DESCRIPTION
Fails with 2 mismatches otherwise

cc @ptrblck @msaroufim @jerryzh168 @zasdfgbnm