### PR TITLE
[CUDA13][CUDA Graphs] Fix `test_graph_external_wait_and_record` to account for minimum supported compute-capability

### DIFF
--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -416,6 +416,7 @@ struct ReduceOp {
     if (config.should_block_y_reduce()) {
       value = block_y_reduce<output_vec_size>(value, shared_memory);
     }
+    __syncthreads();
     if (config.should_block_x_reduce()) {
       value = block_x_reduce<output_vec_size>(value, shared_memory);
     }

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -7243,8 +7243,10 @@ class TestCudaDeviceParametrized(TestCase):
         """
         from torch.cuda import _compile_kernel
 
+        compute_capability = "70" if torch.version.cuda < "13.0" else "75"
+
         spin_wait_kernel = _compile_kernel(
-            kernel_source, "wait_for_cpu", compute_capability="70"
+            kernel_source, "wait_for_cpu", compute_capability
         )
 
         x = torch.ones(4, device="cuda")

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -1555,6 +1555,7 @@ class TestFP8Matmul(TestCase):
     )
     @parametrize("output_dtype", [torch.bfloat16, torch.float32])
     @parametrize("lhs_block,rhs_block", [(1, 1), (128, 1), (1, 128)])
+    @with_tf32_off
     def test_scaled_mm_vs_emulated_block_wise(self, output_dtype, lhs_block, rhs_block):
         torch.manual_seed(42)
 


### PR DESCRIPTION
CUDA 13 requires SM 7.5

cc @ptrblck @msaroufim @jerryzh168 @tinglvv @nWEIdia @mcarilli @ezyang @eellison @penguinwu @BoyuanFeng