### PR TITLE
[Bugfix] Match eager stride semantics for cloned tensors with preserve_format in compile

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -4823,6 +4823,7 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         ):
             f_compiled(a)
         # See https://github.com/pytorch/pytorch/issues/161010
+
     def test_preserve_stride_with_clone(self) -> None:
         A = torch.rand(5, 5, device="cuda" if torch.cuda.is_available() else "cpu")
         B = torch.rand(5, 5, device="cuda" if torch.cuda.is_available() else "cpu")
@@ -4861,14 +4862,28 @@ class ReproTests(torch._dynamo.test_case.TestCase):
             return y
 
         y = foo()
-        self.assertEqual(y.stride(), (1, 4), "Reference eager implementation should have stride (1, 4)")
+        self.assertEqual(
+            y.stride(),
+            (1, 4),
+            "Reference eager implementation should have stride (1, 4)",
+        )
         y = torch.compile(foo, backend="eager")()
-        self.assertEqual(y.stride(), (1, 4), "Compile with eager backend should have stride (1, 4)")
+        self.assertEqual(
+            y.stride(), (1, 4), "Compile with eager backend should have stride (1, 4)"
+        )
         y = torch.compile(foo, backend="aot_eager")()
-        self.assertEqual(y.stride(), (1, 4), "Compile with aot_eager backend should have stride (1, 4)")
+        self.assertEqual(
+            y.stride(),
+            (1, 4),
+            "Compile with aot_eager backend should have stride (1, 4)",
+        )
         y = torch.compile(foo, backend="inductor")()
-        self.assertEqual(y.stride(), (1, 4), "Compile with inductor backend should have stride (1, 4)")
-        
+        self.assertEqual(
+            y.stride(),
+            (1, 4),
+            "Compile with inductor backend should have stride (1, 4)",
+        )
+
     # https://github.com/pytorch/pytorch/issues/146598
     @unittest.expectedFailure
     def test_lru_cache_tracing(self):

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -4822,7 +4822,53 @@ class ReproTests(torch._dynamo.test_case.TestCase):
             "encountered a mutation on a view chain of length 2, where view 1 was an as_strided",
         ):
             f_compiled(a)
+        # See https://github.com/pytorch/pytorch/issues/161010
+    def test_preserve_stride_with_clone(self) -> None:
+        A = torch.rand(5, 5, device="cuda" if torch.cuda.is_available() else "cpu")
+        B = torch.rand(5, 5, device="cuda" if torch.cuda.is_available() else "cpu")
 
+        def fn(
+            src: torch.Tensor, count: torch.Tensor
+        ) -> tuple[tuple[int, ...], tuple[int, ...]]:
+            Q, R = torch.linalg.qr(src)
+            rhs = torch.ones(Q.shape[0], 1, device=src.device)
+            a = torch.linalg.solve_triangular(R, Q.T @ rhs, upper=True)
+            cloned = a.clone(memory_format=torch.preserve_format)
+            return a.stride(), cloned.stride()
+
+        a_stride, cloned_stride = fn(A, torch.zeros(1))
+        self.assertEqual(
+            a_stride,
+            cloned_stride,
+            f"Strides should match in eager: {a_stride} against {cloned_stride}",
+        )
+
+        compiled_a_stride, compiled_cloned_stride = torch.compile(fn, backend="eager")(
+            B, torch.zeros(1)
+        )
+        self.assertEqual(
+            compiled_a_stride,
+            compiled_cloned_stride,
+            f"Strides should match in eager: {compiled_a_stride} against {compiled_cloned_stride}",
+        )
+
+    # Extension of https://github.com/pytorch/pytorch/issues/161010
+    # in the non memory dense case
+    def test_clone_not_memory_dense(self):
+        def foo() -> torch.Tensor:
+            x = torch.randn(10, 8).t()[::2, ::2]
+            y = x.clone()
+            return y
+
+        y = foo()
+        self.assertEqual(y.stride(), (1, 4), "Reference eager implementation should have stride (1, 4)")
+        y = torch.compile(foo, backend="eager")()
+        self.assertEqual(y.stride(), (1, 4), "Compile with eager backend should have stride (1, 4)")
+        y = torch.compile(foo, backend="aot_eager")()
+        self.assertEqual(y.stride(), (1, 4), "Compile with aot_eager backend should have stride (1, 4)")
+        y = torch.compile(foo, backend="inductor")()
+        self.assertEqual(y.stride(), (1, 4), "Compile with inductor backend should have stride (1, 4)")
+        
     # https://github.com/pytorch/pytorch/issues/146598
     @unittest.expectedFailure
     def test_lru_cache_tracing(self):

--- a/test/test_prims.py
+++ b/test/test_prims.py
@@ -342,6 +342,16 @@ $1: f32[2] = torch._ops.prims.sin.default($0)""")
             x = torch.randn(4, dtype=torch.complex64, device='meta').conj()
             x + 1
 
+    def test_clone_meta_stride_preservation_dense(self):
+        tensor = torch.randn(1, 5).t()
+        meta_clone = prims._clone_meta(tensor, memory_format=torch.preserve_format)
+        self.assertEqual(tensor.stride(), meta_clone.stride())
+
+    def test_clone_meta_stride_preservation_sparse(self):
+        tensor = torch.arange(12).float().view(3, 4)[1:, ::2]
+        meta_clone = prims._clone_meta(tensor, memory_format=torch.preserve_format)
+        self.assertEqual(tensor.contiguous().stride(), meta_clone.stride())
+
     def test_check_deprecation_warning(self):
         with self.assertWarnsRegex(FutureWarning, 'will be removed in the future'):
             torch._prims_common.check(True, lambda: 'message')

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -694,7 +694,7 @@ def _clone_meta(
         )
 
     # memory_format == torch.preserve_format
-    strides = input.stride() #strides = utils.compute_elementwise_output_strides(input) #
+    strides = input.stride()
     return torch.empty_strided(
         input.shape,
         strides,

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -694,7 +694,10 @@ def _clone_meta(
         )
 
     # memory_format == torch.preserve_format
-    strides = input.stride()
+    if torch._prims_common.is_non_overlapping_and_dense(input):
+        strides = input.stride()
+    else:
+        strides = input.contiguous().stride()
     return torch.empty_strided(
         input.shape,
         strides,

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -694,10 +694,7 @@ def _clone_meta(
         )
 
     # memory_format == torch.preserve_format
-    if torch._prims_common.is_non_overlapping_and_dense(input):
-        strides = input.stride()
-    else:
-        strides = input.contiguous().stride()
+    strides = utils.compute_elementwise_output_strides(input)
     return torch.empty_strided(
         input.shape,
         strides,

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -694,7 +694,7 @@ def _clone_meta(
         )
 
     # memory_format == torch.preserve_format
-    strides = utils.compute_elementwise_output_strides(input)
+    strides = input.stride() #strides = utils.compute_elementwise_output_strides(input) #
     return torch.empty_strided(
         input.shape,
         strides,

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -670,6 +670,12 @@ def compute_elementwise_output_strides(*tensors) -> tuple[int, ...]:
     if len(tensors) == 0:
         return ()
 
+    if len(tensors) == 1:
+        if torch._prims_common.is_non_overlapping_and_dense(tensors[0]):
+            return tensors[0].stride()
+        else:
+            return tensors[0].contiguous().stride()
+
     ndim = tensors[0].ndim
     shape = tensors[0].shape
 
@@ -687,7 +693,6 @@ def compute_elementwise_output_strides(*tensors) -> tuple[int, ...]:
     permuted_strides = apply_perm(
         new_strides, invert_perm(logical_to_physical_perm)
     )  # to logical
-
     return tuple(permuted_strides)
 
 

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -670,12 +670,6 @@ def compute_elementwise_output_strides(*tensors) -> tuple[int, ...]:
     if len(tensors) == 0:
         return ()
 
-    if len(tensors) == 1:
-        if torch._prims_common.is_non_overlapping_and_dense(tensors[0]):
-            return tensors[0].stride()
-        else:
-            return tensors[0].contiguous().stride()
-
     ndim = tensors[0].ndim
     shape = tensors[0].shape
 
@@ -693,6 +687,7 @@ def compute_elementwise_output_strides(*tensors) -> tuple[int, ...]:
     permuted_strides = apply_perm(
         new_strides, invert_perm(logical_to_physical_perm)
     )  # to logical
+
     return tuple(permuted_strides)
 
 


### PR DESCRIPTION
Fixes #161010 by making `clone_meta` match the semantics of strides for eager mode.  

This is: 
  * Case 1: Tensor is_non_overlapping_and_dense; in this case, stride should match input tensor stride
  * Case 2: Otherwise, stride should be contiguous computed from input tensor using `compute_elementwise_output_strides`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames