### PR TITLE
[WIP] mm recompilations hook

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -3120,66 +3120,65 @@ class TestGuardsExpressions(TestCase):
 
         self.assertEqual(f"{x_clean.stride()}", "(8, 1)")
         self.assertEqual(f"{x_clean.shape}", "torch.Size([5, 8])")
-    
+
     def test_mm_recompilation(self):
         """
         Test matrix multiplication with different dimension scenarios does not recompile
         by default and recompile with proper mm_recompile_hooks config.
-        Three cases: 
+        Three cases:
         1. m, n, k all same (should use cached version if hook configured)
-        2. One dimension < 16 (should trigger recompilation if hook configured)  
+        2. One dimension < 16 (should trigger recompilation if hook configured)
         3. All dimensions > 16 (should trigger recompilation if hook configured)
         """
         cnt = CompileCounterWithBackend("inductor")
 
         @torch.compile(backend=cnt, dynamic=True)
         def func(a, b):
-          return torch.mm(a, b)
+            return torch.mm(a, b)
 
         def run_all():
             # start with this to avoid duck sizing recompilations.
             # Case 1: All dimensions > 16
             m, n, k = 64, 128, 32  # all > 16
-            a3 = torch.randn(m, k, device="cuda")
-            b3 = torch.randn(k, n, device="cuda")
+            a3 = torch.randn(m, k)
+            b3 = torch.randn(k, n)
             func(a3, b3)
-            
+
             # Case 1: One dimension < 16 (should use cached)
             m, n, k = 32, 32, 4  # k < 16
-            a2 = torch.randn(m, k, device="cuda")
-            b2 = torch.randn(k, n, device="cuda")
+            a2 = torch.randn(m, k)
+            b2 = torch.randn(k, n)
             func(a2, b2)
-            
 
             # Case 3: m=n=k=8 (all same - should use cached)
             m = n = k = 8
-            a1 = torch.randn(m, k, device="cuda")
-            b1 = torch.randn(k, n, device="cuda")  
+            a1 = torch.randn(m, k)
+            b1 = torch.randn(k, n)
             func(a1, b1)
-        
+
         run_all()
         self.assertEqual(cnt.frame_count, 1)
 
         # Clear dynamo cache
         torch._dynamo.reset()
-        
+
         def mm_recompile_hook(m, n, k, sizevars):
             # Specialization for square matrices
             if sizevars.guard_or_false(sympy.And(sympy.Eq(m, n), sympy.Eq(n, k))):
                 pass
             # Specialization for any small given 1 small dim.
-            elif sizevars.guard_or_false(sympy.Or(sympy.Lt(m, 16), sympy.Lt(n, 16), sympy.Lt(k,16))):
+            elif sizevars.guard_or_false(
+                sympy.Or(sympy.Lt(m, 16), sympy.Lt(n, 16), sympy.Lt(k, 16))
+            ):
                 pass
             else:
-            # all > 16
+                # all > 16
                 pass
 
         # do it again but with mm_recompile_hooks
-        with torch._inductor.config.patch(mm_recompile_hooks={"mm":mm_recompile_hook}):
+        with torch._inductor.config.patch(mm_recompile_hooks={"mm": mm_recompile_hook}):
             run_all()
             self.assertEqual(cnt.frame_count, 4)
-
-
 
 
 def custom_pass(graph: torch.fx.Graph) -> torch.fx.Graph:
@@ -3759,57 +3758,6 @@ def forward(self, arg0_1: "i64[2][1]cpu", arg1_1: "Sym(u2)", arg2_1: "Sym(u3)", 
         # ensure we compile this with no errors.
         x = torch.rand(10)
         f(x, 4, 4096, 3920)
-    
-    # def test_mm_with_recompile_hook():
-    #     """Test the matmul_recompile_hook with controlled recompilation scenarios"""
-    #     import torch._inductor.config
-        
-    #     # Track hook calls
-    #     hook_calls = []
-        
-    #     def test_hook(a: torch.Tensor, b: torch.Tensor, op_name: str) -> bool:
-    #         m, k = a.shape
-    #         k2, n = b.shape
-    #         hook_calls.append((op_name, m, n, k))
-            
-    #         # Test logic: 
-    #         # - If m == n == k: use cached (return False)
-    #         # - If any dim < 16: force recompile (return True)
-    #         # - If all dims > 16: force recompile (return True)
-    #         if m == n == k:
-    #             return False  # Use cached
-    #         elif m < 16 or n < 16 or k < 16:
-    #             return True   # Force recompilation
-    #         elif m > 16 and n > 16 and k > 16:
-    #             return True   # Force recompilation
-    #         return False
-        
-    #     # Set up the hook
-    #     original_hook = torch._inductor.config.matmul_recompile_hook
-    #     torch._inductor.config.matmul_recompile_hook = test_hook
-        
-    #     try:
-    #         compiled_mm = torch.compile(test_mm)
-    #         device = "cuda" if torch.cuda.is_available() else "cpu"
-            
-         
-            
-    #         # Verify shapes
-    #         assert result1.shape == (8, 8)
-    #         assert result2.shape == (32, 32)
-    #         assert result3.shape == (64, 128)
-            
-    #         # Verify hook was called
-    #         assert len(hook_calls) >= 3, f"Expected at least 3 hook calls, got {len(hook_calls)}"
-            
-    #         return len(hook_calls)
-            
-    #     finally:
-    #         # Restore original hook
-    #         torch._inductor.config.matmul_recompile_hook = original_hook
-
-    
-
 
 
 instantiate_parametrized_tests(TestUnbacked)

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -3120,7 +3120,10 @@ class TestGuardsExpressions(TestCase):
 
         self.assertEqual(f"{x_clean.stride()}", "(8, 1)")
         self.assertEqual(f"{x_clean.shape}", "torch.Size([5, 8])")
-
+    
+    # TODO atributeError: Can't pickle local object 
+    # 'TestGuardsExpressions.test_mm_recompilation.<locals>.mm_recompile_hook'
+    @torch.compiler.config.patch({"force_disable_caches":1})
     def test_mm_recompilation(self):
         """
         Test matrix multiplication with different dimension scenarios does not recompile

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -467,6 +467,38 @@ max_autotune_prune_choices_based_on_shared_mem = (
     == "1"
 )
 
+"""
+Matrix Multiplication Recompilation API
+
+This API allows users to trigger recompilations for matrix multiplications in 
+compiled models based on custom conditions. By providing a callable function, 
+users can control when recompilations occur.
+
+Example Usage:
+  def mm_recompile_hook(m, n, k, sizevars):
+            # Specialization for square matrices
+            if sizevars.guard_or_false(sympy.Eq(m == n) and sympy.Eq(n == k)):
+                pass
+            # Specialization for any small given 1 small dim.
+            elif sizevars.guard_or_false(m < 16 or n < 16 or k < 16):
+                pass
+            else:
+            # all > 16
+                pass
+
+if we call this before tuned_mm we can avoid passing sizevars and make it simpler
+operating on symNodes.
+
+The callable will force recompilations based on conditions specified. 
+For instance, the code above would trigger three recompilations:
+    1. When m == n == k (square matrices)
+    2. When all dimensions (m, n, k) are greater than 16
+    3. When at least one dimension is less than 16
+
+TODO: Add controllers for other matrix operations (e.g., bmm, add_mm)
+"""
+mm_recompile_hooks = {}
+
 # enable inductor graph partition to allow multiple inductor graphs for the same dynamo graph
 graph_partition: bool = (
     os.environ.get("TORCHINDUCTOR_GRAPH_PARTITION", "1" if not is_fbcode() else "0")

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -470,8 +470,8 @@ max_autotune_prune_choices_based_on_shared_mem = (
 """
 Matrix Multiplication Recompilation API
 
-This API allows users to trigger recompilations for matrix multiplications in 
-compiled models based on custom conditions. By providing a callable function, 
+This API allows users to trigger recompilations for matrix multiplications in
+compiled models based on custom conditions. By providing a callable function,
 users can control when recompilations occur.
 
 Example Usage:
@@ -486,10 +486,10 @@ Example Usage:
             # all > 16
                 pass
 
-if we call this before tuned_mm we can avoid passing sizevars and make it simpler
-operating on symNodes.
+if we call this before tuned_mm we can avoid passing sizevars we can make it
+simpler by operating on symNodes.
 
-The callable will force recompilations based on conditions specified. 
+The callable will force recompilations based on conditions specified.
 For instance, the code above would trigger three recompilations:
     1. When m == n == k (square matrices)
     2. When all dimensions (m, n, k) are greater than 16

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -747,10 +747,10 @@ def tuned_mm(mat1, mat2, *, layout=None):
     m, n, k, layout, mat1, mat2 = mm_args(mat1, mat2, layout=layout)
     static_shape, is_nonzero = _is_static_problem(layout)
     name = "mm"
-   
+
     if name in torch._inductor.config.mm_recompile_hooks:
         torch._inductor.config.mm_recompile_hooks["mm"](m, n, k, V.graph.sizevars)
-        
+
     # Create MMKernelInputs for standard MM at the top
     kernel_inputs = MMKernelInputs([mat1, mat2])
 

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -747,7 +747,10 @@ def tuned_mm(mat1, mat2, *, layout=None):
     m, n, k, layout, mat1, mat2 = mm_args(mat1, mat2, layout=layout)
     static_shape, is_nonzero = _is_static_problem(layout)
     name = "mm"
-
+   
+    if name in torch._inductor.config.mm_recompile_hooks:
+        torch._inductor.config.mm_recompile_hooks["mm"](m, n, k, V.graph.sizevars)
+        
     # Create MMKernelInputs for standard MM at the top
     kernel_inputs = MMKernelInputs([mat1, mat2])
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #163020

Note : idea seems not very convincing so probably killing it

MM Recompilation API

This API allows users to trigger recompilations for matrix multiplications in 
compiled models based on custom conditions. By providing a callable function, 
users can control when recompilations occur. This can be used as a way to ensure
the mm space is properly splitted to regions that are potentially max auto tuned. 

It requires that the users know how they want to split the space. 

cons:
- does not work with unbacked. 
- compile time probably >> dynamic dispatch ( require repeated dynamo + auto grad)
- Compile time can go crazy exponentially. 

pros:
- Very Simple
- User have all power to control recompilations of mm. 

Example Usage:
```
        def mm_recompile_hook(m, n, k, sizevars):
            # Specialization for square matrices
            if sizevars.guard_or_false(sympy.And(sympy.Eq(m, n), sympy.Eq(n, k))):
                pass
            # Specialization for any small given 1 small dim.
            elif sizevars.guard_or_false(sympy.Or(sympy.Lt(m, 16), sympy.Lt(n, 16), sympy.Lt(k,16))):
                pass
            else:
            # all > 16
                pass

        # do it again but with mm_recompile_hooks
        with torch._inductor.config.patch(mm_recompile_hooks={"mm":mm_recompile_hook}):
            run_all()
            self.assertEqual(cnt.frame_count, 4)
```
This could be
```
 def mm_recompile_hook(m, n, k, sizevars):
        # Specialization for square matrices
        if m==n and n==k:
                # Specialization for any small given 1 small dim.
               pass
        elif sm<16 or n<16 or k<16:
               pass
        else:
          # all > 16
              pass

        # do it again but with mm_recompile_hooks
        with torch._inductor.config.patch(mm_recompile_hooks={"mm":mm_recompile_hook}):
            run_all()
            self.assertEqual(cnt.frame_count, 4)
```

The callable will force recompilations based on conditions specified. 
For instance, the code above would trigger three recompilations:
    1. When m == n == k (square matrices)
    2. When all dimensions (m, n, k) are greater than 16
    3. When at least one dimension is less than 16

TODO: Add controllers for other matrix operations (e.g., bmm, add_mm)



Note 1:  if we call this before tuned_mm we can avoid passing sizevars we can make it simpler by operating on symNodes.
Note 3:  We need a story for reconciling this with overriden hint.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben