### PR TITLE
[inductor] return constant shape for ops that do not return

### DIFF
--- a/torch/_inductor/shape_propagation.py
+++ b/torch/_inductor/shape_propagation.py
@@ -92,8 +92,9 @@ class ShapePropagationOpsHandler:
             return ()
 
     @staticmethod
-    def store_reduction(name: str, index: int, value: ShapeArg) -> None:
-        return None
+    def store_reduction(name: str, index: int, value: ShapeArg):
+        # This doesn't return anything, but None means we don't know the shape
+        return ()
 
     @staticmethod
     def reduction(
@@ -107,8 +108,9 @@ class ShapePropagationOpsHandler:
     @staticmethod
     def store(
         name: str, index: int, value: ShapeArg, mode: Optional[str] = None
-    ) -> None:
-        return None
+    ):
+        # This doesn't return anything, but None means we don't know the shape
+        return ()
 
     @staticmethod
     def to_dtype(
@@ -141,5 +143,6 @@ class ShapePropagationOpsHandler:
         return lambda *args, **kwargs: broadcast_shapes_for_args(args)
 
     @staticmethod
-    def device_assert_async(cond: ShapeArg, msg: str) -> None:
-        return None
+    def device_assert_async(cond: ShapeArg, msg: str):
+        # This doesn't return anything, but None means we don't know the shape
+        return ()

--- a/torch/_inductor/shape_propagation.py
+++ b/torch/_inductor/shape_propagation.py
@@ -92,7 +92,7 @@ class ShapePropagationOpsHandler:
             return ()
 
     @staticmethod
-    def store_reduction(name: str, index: int, value: ShapeArg):
+    def store_reduction(name: str, index: int, value: ShapeArg) -> BlockShapeType:
         # This doesn't return anything, but None means we don't know the shape
         return ()
 
@@ -108,7 +108,7 @@ class ShapePropagationOpsHandler:
     @staticmethod
     def store(
         name: str, index: int, value: ShapeArg, mode: Optional[str] = None
-    ):
+    ) -> BlockShapeType:
         # This doesn't return anything, but None means we don't know the shape
         return ()
 
@@ -143,6 +143,6 @@ class ShapePropagationOpsHandler:
         return lambda *args, **kwargs: broadcast_shapes_for_args(args)
 
     @staticmethod
-    def device_assert_async(cond: ShapeArg, msg: str):
+    def device_assert_async(cond: ShapeArg, msg: str) -> BlockShapeType:
         # This doesn't return anything, but None means we don't know the shape
         return ()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #162275
* __->__ #163023

Returning None is bad because None means that we don't know the shape.
Returning () is a good choice as that shape broadcasts with any other
shape.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben