### PR TITLE
Add device argument to torch.random.get_rng_state

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -561,6 +561,43 @@ class TestCheckpoint(TestCase):
         self.assertTrue("first device type: cuda" in warning_msg)
 
 
+class TestRNGState(TestCase):
+    def test_get_rng_state_cpu(self):
+        # get state from get_rng_state with no arguments
+        state_no_args = torch.get_rng_state()
+
+        # get state from get_rng_state with device passed in
+        device = torch.device("cpu")
+        state_device_arg = torch.get_rng_state(device)
+
+        # get state from get_rng_state with string passed in
+        state_string_arg = torch.get_rng_state("cpu")
+
+        # assert that all three are equal
+        self.assertEqual(state_no_args, state_device_arg)
+        self.assertEqual(state_no_args, state_string_arg)
+
+    @unittest.skipIf(not HAS_CUDA, "No CUDA")
+    def test_get_rng_state_cuda(self):
+        # get state from cuda's get_rng_state
+        state_no_args = torch.cuda.get_rng_state()
+
+        # get state from get_rng_state with device passed in
+        device = torch.device("cuda")
+        state_device_arg = torch.get_rng_state(device)
+
+        # get state from get_rng_state with string passed in
+        state_string_arg = torch.get_rng_state("cuda")
+
+        # get state from get_rng_state with integer passed in
+        state_int_arg = torch.get_rng_state(0)
+
+        # assert that all four are equal
+        self.assertEqual(state_no_args, state_device_arg)
+        self.assertEqual(state_no_args, state_string_arg)
+        self.assertEqual(state_no_args, state_int_arg)
+
+
 class TestDataLoaderUtils(TestCase):
     MAX_TIMEOUT_IN_SECOND = 300
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -570,12 +570,7 @@ class TestRNGState(TestCase):
         device = torch.device("cpu")
         state_device_arg = torch.get_rng_state(device)
 
-        # get state from get_rng_state with string passed in
-        state_string_arg = torch.get_rng_state("cpu")
-
-        # assert that all three are equal
         self.assertEqual(state_no_args, state_device_arg)
-        self.assertEqual(state_no_args, state_string_arg)
 
     @unittest.skipIf(not HAS_CUDA, "No CUDA")
     def test_get_rng_state_cuda(self):
@@ -586,16 +581,7 @@ class TestRNGState(TestCase):
         device = torch.device("cuda")
         state_device_arg = torch.get_rng_state(device)
 
-        # get state from get_rng_state with string passed in
-        state_string_arg = torch.get_rng_state("cuda")
-
-        # get state from get_rng_state with integer passed in
-        state_int_arg = torch.get_rng_state(0)
-
-        # assert that all four are equal
         self.assertEqual(state_no_args, state_device_arg)
-        self.assertEqual(state_no_args, state_string_arg)
-        self.assertEqual(state_no_args, state_int_arg)
 
 
 class TestDataLoaderUtils(TestCase):

--- a/torch/random.py
+++ b/torch/random.py
@@ -20,11 +20,11 @@ def set_rng_state(new_state: torch.Tensor) -> None:
     default_generator.set_state(new_state)
 
 
-def get_rng_state(device: Union[int, str, torch.device] = "cpu") -> torch.Tensor:
+def get_rng_state(device: Union[str, torch.device] = "cpu") -> torch.Tensor:
     r"""Returns the random number generator state as a `torch.ByteTensor`.
 
     Args:
-        device (torch.device or int, optional): The device to return the RNG state of.
+        device (torch.device, optional): The device to return the RNG state of.
             Default: ``'cpu'`` (i.e., ``torch.device('cpu')``, the current CPU device).
 
     See also: :func:`torch.random.fork_rng`.
@@ -32,8 +32,6 @@ def get_rng_state(device: Union[int, str, torch.device] = "cpu") -> torch.Tensor
 
     if isinstance(device, str):
         device = torch.device(device)
-    elif isinstance(device, int):
-        device = torch.device("cuda", device)
 
     if device.type == "cpu":
         return default_generator.get_state()

--- a/torch/random.py
+++ b/torch/random.py
@@ -20,17 +20,19 @@ def set_rng_state(new_state: torch.Tensor) -> None:
     default_generator.set_state(new_state)
 
 
-def get_rng_state(device: Union[str, torch.device] = "cpu") -> torch.Tensor:
+def get_rng_state(device: Union[int, str, torch.device] = "cpu") -> torch.Tensor:
     r"""Returns the random number generator state as a `torch.ByteTensor`.
 
     Args:
-        device (torch.device, optional): The device to return the RNG state of.
+        device (torch.device, int, optional): The device to return the RNG state of.
             Default: ``'cpu'`` (i.e., ``torch.device('cpu')``, the current CPU device).
 
     See also: :func:`torch.random.fork_rng`.
     """
 
     if isinstance(device, str):
+        device = torch.device(device)
+    elif isinstance(device, int):
         device = torch.device(device)
 
     if device.type == "cpu":

--- a/torch/random.py
+++ b/torch/random.py
@@ -19,17 +19,16 @@ def set_rng_state(new_state: torch.Tensor) -> None:
     default_generator.set_state(new_state)
 
 
-def get_rng_state(device: torch.device = torch.device("cpu")) -> torch.Tensor:
+def get_rng_state(device: torch.device = None) -> torch.Tensor:
     r"""Returns the random number generator state as a `torch.ByteTensor`.
 
     Args:
         device (torch.device, optional): The device to return the RNG state of.
-            Default: ``torch.device('cpu')``, the current CPU device.
 
     See also: :func:`torch.random.fork_rng`.
     """
 
-    if device.type == "cpu":
+    if device is None or device.type == "cpu":
         return default_generator.get_state()
     else:
         return torch.get_device_module(device).get_rng_state(device)

--- a/torch/random.py
+++ b/torch/random.py
@@ -2,7 +2,6 @@
 import contextlib
 import warnings
 from collections.abc import Generator
-from typing import Union
 
 import torch
 from torch._C import default_generator
@@ -20,20 +19,15 @@ def set_rng_state(new_state: torch.Tensor) -> None:
     default_generator.set_state(new_state)
 
 
-def get_rng_state(device: Union[int, str, torch.device] = "cpu") -> torch.Tensor:
+def get_rng_state(device: torch.device = torch.device("cpu")) -> torch.Tensor:
     r"""Returns the random number generator state as a `torch.ByteTensor`.
 
     Args:
-        device (torch.device, int, optional): The device to return the RNG state of.
-            Default: ``'cpu'`` (i.e., ``torch.device('cpu')``, the current CPU device).
+        device (torch.device, optional): The device to return the RNG state of.
+            Default: ``torch.device('cpu')``, the current CPU device.
 
     See also: :func:`torch.random.fork_rng`.
     """
-
-    if isinstance(device, str):
-        device = torch.device(device)
-    elif isinstance(device, int):
-        device = torch.device(device)
 
     if device.type == "cpu":
         return default_generator.get_state()


### PR DESCRIPTION
Fixes #162812

Adds support for either passing a device directly into get_rng_state, or passing in a string or int (which is then wrapped into a device inside, as in torch.cuda.get_rng_state).

I wasn't exactly sure where tests for this should go, please let me know. I used this script for testing:
```python
import torch

# note: when running with CUDA GPU, first three tests will give the same result,
# as will the last two

# test with no device specified
print(torch.get_rng_state())

# test with CPU
cpu_device = torch.device("cpu")
print(torch.get_rng_state(cpu_device))

# test with direct name
print(torch.get_rng_state("cpu"))

# test with CUDA
cuda_device = torch.device("cuda:0")
print(torch.get_rng_state(cuda_device))

# test with integer
print(torch.get_rng_state(0))
```