### PR TITLE
[AOTI-FX] Solve for undefined symbols in dynamic input shapes

### DIFF
--- a/test/inductor/test_fxir_backend.py
+++ b/test/inductor/test_fxir_backend.py
@@ -866,6 +866,19 @@ class AOTFxirTestCase(InductorTestCase):
         # Now the backend should have been called.
         self.assertTrue(called)
 
+    def test_dynamic_input_expr(self):
+        """
+        Test dynamic shapes with a nontrivial input expression.
+        """
+
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return x.reshape(x.shape[0] * x.shape[1]) + x.shape[1]
+
+        dynamic_shapes = {"x": {0: 2 * Dim("x", min=1) + 1}}
+        inp = (torch.randn((5, 4), device=self.device),)
+        self.check(M().to(self.device), inp, dynamic_shapes=dynamic_shapes)
+
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -31,6 +31,7 @@ from torch.utils import _pytree as pytree
 from torch.utils._sympy.functions import FloorDiv
 from torch.utils._sympy.interp import _run_sympy_handler, sympy_interp
 from torch.utils._sympy.reference import OptimizedPythonReferenceAnalysis
+from torch.utils._sympy.solve import try_solve
 
 from .. import config, ir
 from ..runtime.triton_compat import Config
@@ -106,32 +107,36 @@ def replace_floor_div(expr: sympy.Expr) -> sympy.Expr:
     """
     Replace sympy.floor with FloorDiv.
     """
-    expr = sympy.together(expr)
 
-    # Find division operations in the sympy.floor expression
-    # Div is either represented as Mul with:
-    # Rational denominator or Pow with negative exponent
-    if not isinstance(expr, sympy.core.mul.Mul):
-        return sympy.floor(expr)
+    def replace(expr: sympy.Expr) -> sympy.Expr:
+        expr = sympy.together(expr)
 
-    if isinstance(expr.args[0], sympy.Rational):
-        frac = expr.args[0]
-        numerator = sympy_product(expr.args[1:]) * frac.numerator
-        denominator = frac.denominator
+        # Find division operations in the sympy.floor expression
+        # Div is either represented as Mul with:
+        # Rational denominator or Pow with negative exponent
+        if not isinstance(expr, sympy.core.mul.Mul):
+            return sympy.floor(expr)
 
-        return FloorDiv(numerator, denominator)
-    elif isinstance(expr.args[0], sympy.Pow):
-        base = expr.args[0].base
-        exp = expr.args[0].exp
-        numerator = sympy_product(expr.args[1:])
-        if exp < 0:
-            denominator = base ** (-exp)
+        if isinstance(expr.args[0], sympy.Rational):
+            frac = expr.args[0]
+            numerator = sympy_product(expr.args[1:]) * frac.numerator
+            denominator = frac.denominator
+
+            return FloorDiv(numerator, denominator)
+        elif isinstance(expr.args[0], sympy.Pow):
+            base = expr.args[0].base
+            exp = expr.args[0].exp
+            numerator = sympy_product(expr.args[1:])
+            if exp < 0:
+                denominator = base ** (-exp)
+            else:
+                numerator = numerator * (base**exp)
+                denominator = 1
+            return FloorDiv(numerator, denominator)
         else:
-            numerator = numerator * (base**exp)
-            denominator = 1
-        return FloorDiv(numerator, denominator)
-    else:
-        return sympy.floor(expr)
+            return sympy.floor(expr)
+
+    return expr.replace(sympy.floor, replace)
 
 
 class WrapperFxCodegen(PythonWrapperCodegen):
@@ -140,6 +145,12 @@ class WrapperFxCodegen(PythonWrapperCodegen):
     """
 
     supports_caching = False
+
+    def codegen_inputs(self) -> None:
+        """
+        This would generate code for symbolic input shapes, strides, etc.
+        Since the FX converter handles this, do nothing here.
+        """
 
     def _generate(self, is_inference: bool) -> tuple[FileBackedGraphModule, None]:
         self.run_wrapper_ir_passes(is_inference)
@@ -331,20 +342,59 @@ class FxConverter:
             target: torch._ops.OpOverload,
             dim: int,
         ) -> None:
+            def codegen_proxy() -> torch.fx.Proxy:
+                size_node = self.gm.graph.call_function(target, (base_node, dim))
+                size_proxy = torch.fx.Proxy(size_node, tracer=self.tracer)
+                self.expr_to_proxy[sym_or_exp] = size_proxy
+                return size_proxy
+
             if isinstance(sym_or_exp, sympy.Symbol):
                 if sym_or_exp in self.expr_to_proxy:
                     return
-
-                size_node = self.gm.graph.call_function(target, (base_node, dim))
-                size_proxy = torch.fx.Proxy(size_node, tracer=self.tracer)
-
-                self.expr_to_proxy[sym_or_exp] = size_proxy
+                codegen_proxy()
 
             elif isinstance(sym_or_exp, sympy.Integer):
                 return
 
             elif isinstance(sym_or_exp, sympy.Expr):
-                self._sympy_interp(sym_or_exp)
+                # Try to solve for one undefined symbol.
+                undefined_symbols = [
+                    sym
+                    for sym in sym_or_exp.free_symbols
+                    if sym not in self.expr_to_proxy
+                ]
+                if len(undefined_symbols) == 0:
+                    self._sympy_interp(sym_or_exp)
+                    return
+
+                # Define a new symbol for the overall size.
+                size_proxy = codegen_proxy()
+                size_symbol = sympy.Symbol(
+                    size_proxy.node.name, integer=True, nonnegative=True
+                )
+                self.expr_to_proxy[size_symbol] = size_proxy
+
+                # Solve for the undefined symbol.
+                undefined_symbol = undefined_symbols[0]
+                solution = try_solve(
+                    sympy.Eq(sym_or_exp, size_symbol), undefined_symbol
+                )
+                if solution is None:
+                    raise ValueError(f"Cannot solve input expression: {sym_or_exp}")
+
+                # Since the symbol is a size, it must be an integer.
+                # Therefore, we can convert division to FloorDiv.
+                undefined_symbol_expr = solution[1]
+                if undefined_symbol.is_integer:
+                    undefined_symbol_expr = replace_floor_div(
+                        sympy.floor(undefined_symbol_expr)
+                    )
+
+                # Generate FX for the symbol.
+                self._sympy_interp(undefined_symbol_expr)
+                self.expr_to_proxy[undefined_symbol] = self.expr_to_proxy[
+                    undefined_symbol_expr
+                ]
 
         for node in V.graph.module.graph.find_nodes(op="placeholder"):  # type: ignore[operator, union-attr]
             name = node.name
@@ -772,12 +822,7 @@ class FxConverter:
 
         # Replace all sympy.floor with FloorDiv
         # _generate_sym_node does not support sympy.floor
-        grid = [
-            x.replace(sympy.floor, replace_floor_div)
-            if isinstance(x, sympy.Expr)
-            else x
-            for x in grid
-        ]
+        grid = [replace_floor_div(x) if isinstance(x, sympy.Expr) else x for x in grid]
         wrapper_grid = [tuple(self._generate_sym_nodes(grid))]
         call_kwargs = {
             name: self._generate_sym_node(val) for name, val in call_kwargs.items()

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -357,7 +357,7 @@ class FxConverter:
                 return
 
             elif isinstance(sym_or_exp, sympy.Expr):
-                # Try to solve for one undefined symbol.
+                # Check if we need to solve for an undefined symbol.
                 undefined_symbols = [
                     sym
                     for sym in sym_or_exp.free_symbols
@@ -366,8 +366,10 @@ class FxConverter:
                 if len(undefined_symbols) == 0:
                     self._sympy_interp(sym_or_exp)
                     return
+                elif len(undefined_symbols) > 1:
+                    raise ValueError(f"Underdetermined input expression: {sym_or_exp}")
 
-                # Define a new symbol for the overall size.
+                # Define a new symbol for the input size.
                 size_proxy = codegen_proxy()
                 size_symbol = sympy.Symbol(
                     size_proxy.node.name, integer=True, nonnegative=True


### PR DESCRIPTION
# Problem
When dynamic shapes are passed to AOTInductor, they usually have a very basic form like `(s0, 5, 27)`. In these cases it's straightforward to generate code defining the symbol `s0` as a specific dimension of the input tensor. However, AOTI can handle slightly more generic expressions than this, such as `(2 * s0, 5, 27)`. In these cases, we don't immediately know the value of `s0`, but we need to solve for it, since it may be referenced in other parts of the program such as kernel call arguments, launch grids, etc.

# Feature
This PR adds support for more generic dynamic input expressions in the FX backend, following the implementation already present in AOTI's C++ backend:
 1. Check if the expression contains *one* undefined symbol, as multiple variables would make the equation underdetermined. Let's call this `s0`. (We could potentially generalize this, but this PR focuses on cases AOTI can already handle.)
 2. Generate a new symbol for the relevant size or stride of the input tensor. Let's call this `size`. This is computed with FX nodes just as a normal symbol would be.
 3. Use sympy to solve for `s0` in terms of `size`. Let's call the resulting expression `solution`.
 4. Since we know `s0` is an integer, `solution == floor(solution)`. Take the floor and then convert division to `FloorDiv`. This is required to trace through the expression, since the return value of regular division is not guaranteed to be an integer.
 5. Generate FX for the modified `solution`, which defines the value `s0`.
 6. Override the relevant method of `PythonWrapperCodegen` to a no-op, since the FX converter handles the above on its own.

# Test plan
In addition to the existing dynamic shapes tests, this PR adds new test cases where the input shape contains a non-trivial expression. This dynamic input dimension is then multiplied by other dimensions to form the argument to a `reshape`.

Here's an example graph from one of the CI tests. In this case, the input expression was `2*x + 1`, and the solution is `x = (sym_size_int - 1) / 2`:
```
graph():
    %arg0_1 : [num_users=2] = placeholder[target=arg0_1]
    %sym_size_int : [num_users=1] = call_function[target=torch.ops.aten.sym_size.int](args = (%arg0_1, 0), kwargs = {})
    %sym_sum : [num_users=1] = call_function[target=torch.sym_sum](args = ([-1, %sym_size_int],), kwargs = {})
    %floordiv : [num_users=1] = call_function[target=operator.floordiv](args = (%sym_sum, 2), kwargs = {})
    %mul : [num_users=2] = call_function[target=operator.mul](args = (8, %floordiv), kwargs = {})
    %sym_sum_1 : [num_users=2] = call_function[target=torch.sym_sum](args = ([4, %mul],), kwargs = {})
    %buf0 : [num_users=2] = call_function[target=torch.empty_strided](args = ([%sym_sum_1], [1]), kwargs = {dtype: torch.float32, device: cuda:0})
    %sym_sum_2 : [num_users=1] = call_function[target=torch.sym_sum](args = ([35, %mul],), kwargs = {})
    %floordiv_1 : [num_users=1] = call_function[target=operator.floordiv](args = (%sym_sum_2, 32), kwargs = {})
    %triton_kernel_wrapper_mutation : [num_users=0] = call_function[target=torch.ops.higher_order.triton_kernel_wrapper_mutation](args = (), kwargs = {kernel_idx: 0, constant_args_idx: 0, grid: [(%floordiv_1, 1, 1)], tma_descriptor_metadata: {}, kwargs: {in_ptr0: %arg0_1, out_ptr0: %buf0, xnumel: %sym_sum_1, XBLOCK: 32}})
    return buf0
```

The `sym_size_int` node returns the first dimension of the input tensor. Next, `floordiv` computes the input symbol in terms of the input size. Then, the launch grid is computed by `floordiv_1`, the kernel argument by `sym_sum_1`.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben