### PR TITLE
[xpu] Support high stream for ProcessGroupXCCL

### DIFF
--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -3532,8 +3532,8 @@ Example::
               py::arg("rank"),
               py::arg("size"),
               py::arg("options"),
-              R"(Create a new ProcessGroupXCCL instance.)"),
-        .def(
+              R"(Create a new ProcessGroupXCCL instance.)")
+          .def(
               py::init([](const c10::intrusive_ptr<::c10d::Store>& store,
                           int rank,
                           int size) {
@@ -3550,11 +3550,18 @@ Example::
               py::arg("store"),
               py::arg("rank"),
               py::arg("size"),
-              R"(Create a new ProcessGroupNCCL instance.)");
+              R"(Create a new ProcessGroupNCCL instance.)")
+          .def_property_readonly(
+              "options",
+              &::c10d::ProcessGroupXCCL::getOptions,
+              R"(Return the options used to create this ProcessGroupXCCL instance.)");
 
   intrusive_ptr_class_<::c10d::ProcessGroupXCCL::Options>(
       processGroupXCCL, "Options", backendOptions)
-      .def(py::init<>());
+      .def(py::init<bool>(), py::arg("is_high_priority_stream") = false)
+      .def_readwrite(
+          "is_high_priority_stream",
+          &::c10d::ProcessGroupXCCL::Options::is_high_priority_stream);
   module
       .def(
           "_dump_xccl_trace",

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -3543,14 +3543,13 @@ Example::
 
                 auto options = ::c10d::ProcessGroupXCCL::Options::create();
                 options->is_high_priority_stream = false;
-                options->timeout = timeout;
                 return c10::make_intrusive<::c10d::ProcessGroupXCCL>(
                     store, rank, size, options);
               }),
               py::arg("store"),
               py::arg("rank"),
               py::arg("size"),
-              R"(Create a new ProcessGroupNCCL instance.)")
+              R"(Create a new ProcessGroupXCCL instance.)")
           .def_property_readonly(
               "options",
               &::c10d::ProcessGroupXCCL::getOptions,


### PR DESCRIPTION
Add high priority stream support for ProcessGroupXCCL. Just like CUDA, XPU streams also support execution with higher priority compared to other streams. Implementation in https://github.com/intel/torch-xpu-ops/pull/1715, add register here.




cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci