### PR TITLE
Refactor test_dtensor_compile

### DIFF
--- a/test/distributed/tensor/test_fake.py
+++ b/test/distributed/tensor/test_fake.py
@@ -5,10 +5,12 @@ import torch
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.placement_types import Shard
+from torch.testing._internal.common_distributed import requires_nccl
 from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.testing._internal.distributed.fake_pg import FakeStore
 
 
+@requires_nccl()
 class TestFakeDTensor(TestCase):
     def test_fake_dtensor_operations(self):
         # Use FakeTensorMode to handle CUDA tensors without actual CUDA

--- a/test/dynamo/test_fake_distributed.py
+++ b/test/dynamo/test_fake_distributed.py
@@ -6,7 +6,10 @@ import torch
 import torch.distributed as dist
 from torch._dynamo.test_case import TestCase as DynamoTestCase
 from torch._dynamo.testing import AotEagerAndRecordGraphs, normalize_gm
-from torch.testing._internal.common_utils import instantiate_parametrized_tests
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    IS_LINUX,
+)
 
 
 if dist.is_available():
@@ -119,6 +122,7 @@ class GraphModule(torch.nn.Module):
         )
 
 
+@skipIf(not IS_LINUX, "libuv TCPStore works only on Linux")
 @skipIf(not dist.is_available(), "requires distributed")
 class TestDeviceMesh(DynamoTestCase):
     def tearDown(self):

--- a/test/dynamo/test_fx_graph_runnable.py
+++ b/test/dynamo/test_fx_graph_runnable.py
@@ -10,7 +10,11 @@ import torch._logging.structured
 import torch.distributed as dist
 from torch._inductor.codecache import WritableTempFile
 from torch._inductor.test_case import TestCase
-from torch.testing._internal.common_utils import IS_FBCODE, IS_SANDCASTLE
+from torch.testing._internal.common_utils import (
+    IS_FBCODE,
+    IS_SANDCASTLE,
+    skip_but_pass_in_sandcastle,
+)
 from torch.utils._triton import has_triton
 
 
@@ -337,6 +341,7 @@ class FxGraphRunnableTest(TestCase):
 
         self._exec_and_verify_payload()
 
+    @skip_but_pass_in_sandcastle("Fake PG + real DeviceMesh doesn't work")
     @unittest.skipIf(
         not torch.distributed.is_available(), "Torch distributed not available"
     )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #162571
* #162549
* __->__ #163058
* #162770
* #162545
* #162529

I don't know how the following worked previously:
```
store = FakeStore()
init_process_group("fake", rank=0, world_size=2, store=store)
init_device_mesh("cpu", ...)
```
But it is not supported now.
Updating tests accordingly.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela