### PR TITLE
Add DTensor/CP support for Fused SDPA overrideable

### DIFF
--- a/test/distributed/tensor/test_matrix_ops.py
+++ b/test/distributed/tensor/test_matrix_ops.py
@@ -24,6 +24,7 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
     TEST_WITH_ROCM,
+    TEST_HPU
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
@@ -426,7 +427,8 @@ class DistMatrixOpsTest(DTensorTestBase):
             available_backends.append(SDPBackend.FLASH_ATTENTION)
         if torch.backends.cuda.can_use_efficient_attention(params, debug=False):
             available_backends.append(SDPBackend.EFFICIENT_ATTENTION)
-
+        if TEST_HPU: # extend to other platforms that support overrideable attention
+            available_backends.append(SDPBackend.OVERRIDEABLE)
         placement_specs = [(Replicate(),), (Shard(0),), (Shard(1),)]
         for backend, input_placements in itertools.product(
             available_backends, placement_specs

--- a/torch/distributed/tensor/experimental/_attention.py
+++ b/torch/distributed/tensor/experimental/_attention.py
@@ -760,7 +760,6 @@ def _scaled_dot_product_ring_fused_attention_overrideable(
     group = mesh.get_group()
     return _templated_ring_attention(
         group,
-        mesh,
         seq_dim,
         aten._scaled_dot_product_fused_attention_overrideable,
         query=query,
@@ -928,7 +927,6 @@ def _scaled_dot_product_ring_fused_attention_overrideable_backward(
     group = mesh.get_group()
     result = _templated_ring_attention_backward(
         group,
-        mesh,
         seq_dim,
         aten._scaled_dot_product_fused_attention_overrideable_backward.default,
         grad_out=grad_out,


### PR DESCRIPTION
In summary, this PR aims to extend DTensor and Context Parallel support for the aten._scaled_dot_product_fused_attention_overrideable ops so that vendors of devices who override this operator (in this case, HPU) can benefit from torch's DTensor framework and CP support for the attention operator.

- Add DTensor strategies for SDPA overrideable forward and backward
- Add overrideable in Ring Attention list of supported ops

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci @drisspg 