### PR TITLE
fix f-string in errors.py

### DIFF
--- a/torch/onnx/errors.py
+++ b/torch/onnx/errors.py
@@ -44,7 +44,7 @@ class UnsupportedOperatorError(OnnxExporterError):
             )
         else:
             msg = (
-                "ONNX export failed on an operator with unrecognized namespace {op_name}. "
+                f"ONNX export failed on an operator with unrecognized namespace {name}. "
                 "If you are trying to export a custom operator, make sure you registered it with "
                 "the right domain and version."
             )


### PR DESCRIPTION
Add missing "f" for formatted f-string in UnsupportedOperandError, change "op_name" (undefined) to "name" for more descriptive error message in case of an unsupported operand with an unrecognized namespace.

cc @justinchuby @titaiwangms