### PR TITLE
[PyTorch] Compile SVE's box-cox only when building targeting SVE

### DIFF
--- a/caffe2/perfkernels/batch_box_cox_sve128.cc
+++ b/caffe2/perfkernels/batch_box_cox_sve128.cc
@@ -1,4 +1,4 @@
-#if defined(__aarch64__) && defined(CAFFE2_PERF_WITH_SVE128)
+#if defined(__aarch64__) && defined(__ARM_FEATURE_SVE) && defined(CAFFE2_PERF_WITH_SVE128)
 #include <arm_neon.h>
 #include <arm_neon_sve_bridge.h>
 #include <arm_sve.h>
@@ -240,4 +240,4 @@ template void compute_batch_box_cox__sve128<float>(
 
 } // namespace caffe2::details
 
-#endif // __aarch64__ && CAFFE2_PERF_WITH_SVE128
+#endif // __aarch64__ && __ARM_FEATURE_SVE && CAFFE2_PERF_WITH_SVE128


### PR DESCRIPTION
Summary:
Internally, we are building PyTorch on the compat layer.
Need to avoid compiling sve's box-cox, as sve is not marked as build target.


Rollback Plan:

Reviewed By: rraometa, YifanYuan3

Differential Revision:
D82544412

Privacy Context Container: L1208939


