### PR TITLE
[sdpa] make sure to recompile if alignment is different than before

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -1348,7 +1348,7 @@ class CudaReproTests(TestCase):
             out2 = model(input2)
             out3 = model(input3)
 
-        self.assertEqual(cnts.frame_count, 1)
+        self.assertEqual(cnts.frame_count, 2)
 
     @config.patch({"triton.cudagraphs": True})
     def test_index_put_no_fallback_cudagraph(self):

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2215,6 +2215,109 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
                     f"Max diff: {torch.max(torch.abs(eager_output - compiled_output)):.6f}",
                 )
 
+    def test_qwen2_7b_sdpa_input_alignment_requires_recompile(self):
+        # SDPA constraints ensures inputs have alignment (8).
+        device = "cuda"
+
+        def forward(q_proj, k_proj, attn_mask):
+            scale = 0.08838834764831845  # 1/sqrt(128)
+
+            B = attn_mask.size(0)
+            S = attn_mask.size(3)
+            D = 128
+            d_model = q_proj.size(1)
+
+            query_states = q_proj.view(B, S, -1, D).transpose(1, 2)  # [B, Hq, S, D]
+            q = query_states.contiguous()
+
+            Hkv = k_proj.size(1) // D
+            Hq = query_states.size(1)
+
+            nrepeats = Hq // Hkv
+            key_states = k_proj.view(B, S, -1, D).transpose(1, 2)  # [B, Hkv, S, D]
+            kv_repeated = key_states[:, :, None, :].expand(B, Hkv, nrepeats, S, D)
+            kv_repeated = kv_repeated.contiguous()
+            k = kv_repeated.reshape(B, Hq, S, D)
+            v = k.clone()  # value tensor
+
+            inf = torch.scalar_tensor(
+                float("-inf"), dtype=torch.bfloat16, device=device
+            )
+            zero = torch.scalar_tensor(0.0, dtype=torch.bfloat16, device=device)
+            where = torch.where(condition=attn_mask, input=zero, other=inf)
+            pad_amount = 8 - (S % 8)
+            padded = torch.nn.functional.pad(
+                where, (0, pad_amount), value=0.0
+            )  # pad last-dim
+            sliced = padded[..., :S]  # back to [B,1,S,S]
+            attn_bias = sliced.expand(B, Hq, S, S)
+
+            sdpa_out, logsumexp, seed, offset = (
+                torch.ops.aten._scaled_dot_product_efficient_attention.default(
+                    q,
+                    k,
+                    v,
+                    attn_bias,
+                    dropout_p=0.0,
+                    is_causal=True,
+                    scale=scale,
+                    compute_log_sumexp=True,
+                )
+            )
+
+            zeros = torch.zeros(B, S, d_model, device=device, dtype=torch.bfloat16)
+            zeros = zeros.reshape(B, S, Hq, D)
+            grad_out = zeros.permute(0, 2, 1, 3)
+
+            out = (
+                torch.ops.aten._scaled_dot_product_efficient_attention_backward.default(
+                    grad_out,
+                    q,
+                    k,
+                    v,
+                    attn_bias,
+                    sdpa_out,
+                    logsumexp,
+                    seed,
+                    offset,
+                    dropout_p=0.0,
+                    scale=scale,
+                    grad_input_mask=[True, True, True, False],
+                )
+            )
+            return out
+
+        B = 2
+        S = 6144
+        D = 128
+        Hq = 28
+        Hkv = 4
+
+        example_inputs = (
+            torch.randn((B * S, Hq * D), dtype=torch.bfloat16, device=device),  # q_proj
+            torch.randn(
+                (B * S, Hkv * D), dtype=torch.bfloat16, device=device
+            ),  # k_proj
+            torch.zeros((B, 1, S, S), dtype=torch.bool, device=device),  # attn_mask
+        )
+        correct = forward(*example_inputs)
+        compiled = torch.compile(forward, dynamic=True)
+        actual = compiled(*example_inputs)
+        self.assertEqual(actual, correct)
+
+        # run once more with seqlen that isn't divisible by 8
+        S = 6102
+        example_inputs = (
+            torch.randn((S * B, Hq * D), dtype=torch.bfloat16, device=device),  # q_proj
+            torch.randn(
+                (S * B, Hkv * D), dtype=torch.bfloat16, device=device
+            ),  # k_proj
+            torch.zeros((B, 1, S, S), dtype=torch.bool, device=device),  # attn_mask
+        )
+        correct = forward(*example_inputs)
+        actual = compiled(*example_inputs)
+        self.assertEqual(actual, correct)
+
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -446,14 +446,13 @@ def is_aligned_realized_tensor_hint(
         return False
 
     aligned_strides = all(
-        (V.graph.sizevars.size_hint_or_throw(x.get_stride()[i]) % alignment) == 0
+        (V.graph.sizevars.guard_or_false(sympy.Eq(x.get_stride()[i] % alignment, 0)))
         for i in range(len(x.get_stride()) - 1)
     )
-    # if the last dim size is <= 1, stride doesn't matter
-    aligned_last_dim = (
-        V.graph.sizevars.size_hint_or_throw(x.get_stride()[-1]) == 1
-        or V.graph.sizevars.size_hint_or_throw(x.get_size()[-1]) <= 1
-    )
+    aligned_last_dim = V.graph.sizevars.guard_or_false(
+        sympy.Eq(x.get_stride()[-1], 1)
+    ) or V.graph.sizevars.guard_or_false(sympy.Lte(x.get_size()[-1], 1))
+
     return aligned_last_dim and aligned_strides
 
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -433,10 +433,9 @@ def is_cpu(x: Union[IRNode, torch.device, None, str]) -> bool:
     return get_device_type(x) == "cpu"
 
 
-def is_aligned_realized_tensor_hint(
+def is_aligned_realized_tensor(
     x: Union[Buffer, TensorBox], alignment: int
 ) -> bool:
-    # Use this as a hint. This won't guard since size_hint doesn't guard.
     if (
         not isinstance(x, IRNode)
         or x.maybe_get_stride() is None
@@ -445,6 +444,7 @@ def is_aligned_realized_tensor_hint(
     ):
         return False
 
+    # Make sure to guard to recompile when necessary.
     aligned_strides = all(
         (V.graph.sizevars.guard_or_false(sympy.Eq(x.get_stride()[i] % alignment, 0)))
         for i in range(len(x.get_stride()) - 1)

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -433,9 +433,7 @@ def is_cpu(x: Union[IRNode, torch.device, None, str]) -> bool:
     return get_device_type(x) == "cpu"
 
 
-def is_aligned_realized_tensor(
-    x: Union[Buffer, TensorBox], alignment: int
-) -> bool:
+def is_aligned_realized_tensor(x: Union[Buffer, TensorBox], alignment: int) -> bool:
     if (
         not isinstance(x, IRNode)
         or x.maybe_get_stride() is None
@@ -451,7 +449,7 @@ def is_aligned_realized_tensor(
     )
     aligned_last_dim = V.graph.sizevars.guard_or_false(
         sympy.Eq(x.get_stride()[-1], 1)
-    ) or V.graph.sizevars.guard_or_false(sympy.Lte(x.get_size()[-1], 1))
+    ) or V.graph.sizevars.guard_or_false(sympy.Le(x.get_size()[-1], 1))
 
     return aligned_last_dim and aligned_strides
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2680,7 +2680,9 @@ def sdpa_constraint(fx_node, *args, **kwargs):
             )
 
         def is_aligned(x):
-            return (V.graph.sizevars.size_hint(x.get_size()[-1]) % ALIGNMENT) == 0
+            return V.graph.sizevars.guard_or_false(
+                sympy.Eq(x.get_size()[-1] % ALIGNMENT, 0)
+            )
 
         if isinstance(arg.data, ir.BaseView):
             if not is_aligned(arg):

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2612,7 +2612,7 @@ def sdpa_constraint(fx_node, *args, **kwargs):
         if len(arg.get_size()) not in (3, 4):
             return arg
 
-        is_aligned_tensor = ir.is_aligned_realized_tensor_hint(arg, ALIGNMENT)
+        is_aligned_tensor = ir.is_aligned_realized_tensor(arg, ALIGNMENT)
         if is_aligned_tensor:
             return ir.try_match_insignificant_strides(
                 ir.ExternKernel.realize_input(arg), meta_stride_expr

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -47,7 +47,13 @@ from torch.fx.experimental.symbolic_shapes import (
     resolve_unbacked_bindings,
 )
 from torch.utils._ordered_set import OrderedSet
-from torch.utils._sympy.functions import CeilDiv, FloorDiv, Identity, ModularIndexing
+from torch.utils._sympy.functions import (
+    CeilDiv,
+    FloorDiv,
+    Identity,
+    Mod,
+    ModularIndexing,
+)
 
 from .._dynamo.utils import import_submodule
 from . import config, inductor_prims, ir, test_operators  # NOQA: F401
@@ -2681,7 +2687,7 @@ def sdpa_constraint(fx_node, *args, **kwargs):
 
         def is_aligned(x):
             return V.graph.sizevars.guard_or_false(
-                sympy.Eq(x.get_size()[-1] % ALIGNMENT, 0)
+                sympy.Eq(Mod(x.get_size()[-1], ALIGNMENT), 0)
             )
 
         if isinstance(arg.data, ir.BaseView):


### PR DESCRIPTION
## Context
An example from Qwen2-7B
- This come from running torch.compile with a sequence length that is
divisible by 8 (no padding needed). Call this `Run1`.
- If we then run the compiled model with a difference length that isn't
divisible by 8 (requires padding). Call this `Run2`.
- Then we'll see this error.
```
File "/var/tmp/torchinductor_nobody/2w/c2wby7ilxbna45xrtrrfjqpeutwouruviu2742ockunnd2bleeiz.py", line 1963, in call
    buf24 = torch.ops.aten._scaled_dot_product_efficient_attention_backward.default(reinterpret_tensor(buf18, (s85, 3584 // s19, s48, 512 // (512 // s19)), (s48*(512 // (512 // s19))*(3584 // s19), 512 // (512 // s19), (512 // (512 // s19))*(3584 // s19), 1), 0), buf20, buf21, buf22, buf23, getitem, getitem_1, getitem_2, getitem_3, 0.0, [True, True, True, False], scale=0.08838834764831845)
File "torch/_ops.py", line 841, in __call__
    return self._op(*args, **kwargs)
RuntimeError: attn_bias is not correctly aligned (strideM). attn_bias.stride(2) = 6102, and should be a multiple of 4.
```
- We only see the error because we did not recompile on `Run2`. Instead we ran the inputs on the same graph as `Run1`.


### A bit more on why.
Here we check whether to realize the unpadded buffer (unwrapped slice) which we want for `Run1` but not for `Run2`.
https://github.com/pytorch/pytorch/blob/0897affcd5e0e5281db7202408ca637bbf2f7abe/torch/_inductor/lowering.py#L2687-L2694

## Fix
Size hint doesn't guard, so the fix is to use `guard_or*` to guard. 

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #163083



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben