### PR TITLE
DisableTorchFunction in debug_string

### DIFF
--- a/test/distributed/tensor/debug/test_debug_mode.py
+++ b/test/distributed/tensor/debug/test_debug_mode.py
@@ -58,6 +58,20 @@ class TestDTensorDebugMode(TestCase):
       aten::sum(t: f32[1, 32])""",
         )
 
+    def test_debug_string_inside_context(self):
+        mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
+
+        x = torch.randn(1, 8, requires_grad=False)
+        y = torch.randn(1, 32, requires_grad=True)
+        x_dtensor = DTensor.from_local(x, mesh, [Shard(0)], run_check=False)
+        y_dtensor = DTensor.from_local(y, mesh, [Shard(0)], run_check=False)
+
+        with DebugMode() as debug_mode:
+            torch.mm(x_dtensor, y_dtensor).sum()
+            s0 = debug_mode.debug_string()
+        s1 = debug_mode.debug_string()
+        self.assertEqual(s0, s1)
+
     def test_debug_mode_backward(self):
         mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
 

--- a/torch/utils/debug_mode.py
+++ b/torch/utils/debug_mode.py
@@ -160,9 +160,10 @@ class DebugMode(TorchDispatchMode):
             self.call_depth -= 1
 
     def debug_string(self) -> str:
-        result = ""
-        result += "\n".join(
-            "  " + "  " * depth + _op_to_str(op, *args, **kwargs)
-            for op, args, kwargs, depth in self.operators
-        )
+        with torch._C.DisableTorchFunction():
+            result = ""
+            result += "\n".join(
+                "  " + "  " * depth + _op_to_str(op, *args, **kwargs)
+                for op, args, kwargs, depth in self.operators
+            )
         return result


### PR DESCRIPTION
debug_string() invokes some torch functions under the hood. 
Use DisableTorchFunction() to avoid re-invoking __torch_function__ when calling debug_sting() inside DebugMode()

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci