### PR TITLE
Add validation for precomputed format in YAML parsing

### DIFF
--- a/torchgen/model.py
+++ b/torchgen/model.py
@@ -713,6 +713,11 @@ class NativeFunction:
 
         precomputed_dict = e.pop("precomputed", None)
         assert precomputed_dict is None or structured is True
+        # Add validation before calling parse
+        if precomputed_dict is not None and not isinstance(precomputed_dict, list):
+            raise ValueError(
+                f"'precomputed' must be a list of strings, got {type(precomputed_dict).__name__}: {precomputed_dict}"
+            )
         precomputed = Precompute.parse(precomputed_dict) if precomputed_dict else None
 
         tags_inp = e.pop("tags", [])


### PR DESCRIPTION
Fixes #162398 

## Problem

When parsing YAML files with malformed precomputed sections the parser crashes with: AttributeError: dict object has no attribute split

This happens when the YAML has precomputed: as a dictionary instead the expected list format. Although the error shows what went wrong, it doesn't explain what format is expected.

## Solution

Add input validation in NativeFunction.from_yaml() to check that precomputed is a list before passing it to Precompute.parse( ). This provide a clearer error message showing the expected format: ValueError: precomputed must be a list of strings, got dict: {dim: int dim, int valid}

## Testing

Tested locally with malformed YAML to confirm the new validation catch the error and provides a helpful message.

