### PR TITLE
upgrade agios to py3.12

### DIFF
--- a/torch/csrc/dynamo/cpython_defs.c
+++ b/torch/csrc/dynamo/cpython_defs.c
@@ -261,7 +261,7 @@ THP_PyObject_VirtualFree(void *obj, size_t size)
 {
     PyObjectArenaAllocator arena;
     PyObject_GetArenaAllocator(&arena);
-    return arena.free(arena.ctx, obj, size);
+    arena.free(arena.ctx, obj, size);
 }
 
 // https://github.com/python/cpython/blob/051b8a2589ff28f0194c3701b21f729444691752/Python/pystate.c#L728
@@ -363,7 +363,7 @@ THP_PyThreadState_PopFrame(PyThreadState *tstate, _PyInterpreterFrame * frame)
 
 #endif
 
-#if IS_PYTHON_3_11_PLUS
+#if IS_PYTHON_3_11_PLUS && !defined(_WIN32)
 
 const uint8_t* THP_PyOpcode_Caches = _PyOpcode_Caches;
 const int THP_PyOpcode_Caches_size = sizeof(_PyOpcode_Caches) / sizeof(uint8_t);


### PR DESCRIPTION
Summary:
Python 3.10 is being deprecated by EOY 2025.
By using Python 3.10 past EOL deadline, changes in the codebase that are incompatible with Python 3.10 might break your build, test, or release.
You will not be able to initiate new builds using Python 3.10 in H1 2026!
So we apply py3.12 to all agios project;

When upgrading from Python 3.10 → 3.12, hit two errors:
Error A: 
warning: void function 'THP_PyObject_VirtualFree' should not return void expression
That was a simple mismatch (trying to return rom a void function). Simple Fix;

Error B (the important one)
error: initializer element is not a compile-time constant;
const uint8_t* THP_PyOpcode_Caches = _PyOpcode_Caches;
Analysis: 
In Python 3.10, _PyOpcode_Caches was defined as a global array → original code
const uint8_t* THP_PyOpcode_Caches = _PyOpcode_Caches;  // allowed
In Python 3.11+, _PyOpcode_Caches changed → it’s no longer treated as a compile-time constant (more like a runtime pointer).
So when tried to initialize THP_PyOpcode_Caches with it, the compiler rejected it:

initializer element is not a compile-time constant

Fix:
const uint8_t* THP_PyOpcode_Caches = NULL;

void THP_Init(void) {
    THP_PyOpcode_Caches = _PyOpcode_Caches;  // set at runtime
}

ensured THP_Init() is called during module initialization.
PyMODINIT_FUNC PyInit__C(void) {
    THP_Init();          // <-- pointer set here
    return initModule(); // continue with normal init
}

Test Plan:
manul test with different pipelines (pp3, sensel etc.)

Rollback Plan:

Differential Revision: D82250826




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela