### PR TITLE
[inductor][choices] pass through annotations from KTC to ChoiceCaller

### DIFF
--- a/torch/_inductor/kernel_template_choice.py
+++ b/torch/_inductor/kernel_template_choice.py
@@ -33,6 +33,7 @@ class KernelTemplateChoice:
         self.extra_kwargs = extra_kwargs
         self.layout = layout
         self.inputs = inputs
+        self.annotations: dict[str, Any] = {"ktc": self}
 
     @property
     def choice(self) -> Optional[ChoiceCaller]:
@@ -54,6 +55,8 @@ class KernelTemplateChoice:
                 input_nodes=self.inputs.nodes(),
                 **self.extra_kwargs,
             )
+            if self._choice is not None:
+                self._choice.annotations = self.annotations
         return self._choice
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #163117

# why

- KTC might regenerate a choicecaller e.g. through FlexibleLayout
  optimization. This in turn would delete any annotations

# what

- provide an annotations dict inside KTC
- forward that dict towards the ChoiceCaller's annotations

- ChoiceCaller users e.g. in selectalgorithm now have access to the KTC
  and can register handlers do record/make decisions based on the KTC

# testing

n/a

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov

Differential Revision: [D82587631](https://our.internmc.facebook.com/intern/diff/D82587631)