### PR TITLE
[CUDA] hack for host-memory stats test

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -175,7 +175,8 @@ class TestCuda(TestCase):
             thread.join()
 
     @serialTest()
-    def test_host_memory_stats(self):
+    # FIXME: broken if not run as first test to pin memory?
+    def test_a_host_memory_stats(self):
         # Helper functions
         def empty_stats():
             return {


### PR DESCRIPTION
Basically this test appears to fail when run with other tests that manipulate pinned memory, even with the `@serialTest` decorator

An ugly workaround here is to ensure it runs first due to alphabetical ordering...

cc @ptrblck @msaroufim @jerryzh168 @tinglvv @nWEIdia