### PR TITLE
Use computed buffer sizes of torch for cusparseLt metadata

### DIFF
--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -299,7 +299,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     }
   }
 
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(compressed_A.dim() == 2); // encoded M
+  TORCH_INTERNAL_ASSERT(compressed_A.dim() == 2); // encoded M x S
   int64_t k = dense_B.size(0);
   int64_t n = dense_B.size(1);
   int64_t m = compressed_A.size(0);

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -299,6 +299,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     }
   }
 
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(compressed_A.dim() == 2); // encoded M
   int64_t k = dense_B.size(0);
   int64_t n = dense_B.size(1);
   int64_t m = compressed_A.size(0);

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -646,7 +646,6 @@ def meta__cslt_sparse_mm(
     assert len(dense_B.shape) == 2, "_cslt_sparse_mm only supports 2d inputs"
 
     is_8bit_input_type = compressed_A.dtype in [torch.int8, torch.float8_e4m3fn]
-    compression_factor = 10 if is_8bit_input_type else 9
 
     if is_8bit_input_type:
         assert not dense_B.is_contiguous(), (
@@ -655,7 +654,7 @@ def meta__cslt_sparse_mm(
 
     k = dense_B.size(0)
     n = dense_B.size(1)
-    m = (compressed_A.numel() * 16) // (compression_factor * k)
+    m = compressed_A.size(0)
     if bias is not None:
         assert m == bias.size(0)
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -652,7 +652,6 @@ def meta__cslt_sparse_mm(
             "dense input must be transposed for 8bit dtypes"
         )
 
-    k = dense_B.size(0)
     n = dense_B.size(1)
     m = compressed_A.size(0)
     if bias is not None:

--- a/torch/sparse/_semi_structured_ops.py
+++ b/torch/sparse/_semi_structured_ops.py
@@ -40,7 +40,7 @@ def semi_sparse_values(func, types, args=(), kwargs=None) -> torch.Tensor:
     if A.meta is None:
         m, k = A.shape
         num_kept_elements = m * k // 2
-        return A.packed[:num_kept_elements:].view(m, -1)
+        return A.packed.ravel()[:num_kept_elements:].view(m, -1)
     else:
         return A.packed.detach()
 
@@ -53,7 +53,7 @@ def semi_sparse_indices(func, types, args=(), kwargs=None) -> torch.Tensor:
     if A.meta is None:
         m, k = A.shape
         num_kept_elements = m * k // 2
-        metadata = A.packed[num_kept_elements:].view(m, -1)
+        metadata = A.packed.ravel()[num_kept_elements:].view(m, -1)
         return metadata.view(torch.int32 if A.dtype == torch.int32 else torch.int16)
     else:
         return A.meta

--- a/torch/sparse/semi_structured.py
+++ b/torch/sparse/semi_structured.py
@@ -622,7 +622,7 @@ class SparseSemiStructuredTensorCUSPARSELT(SparseSemiStructuredTensor):
 
         return cls(
             original_tensor.shape,
-            packed=packed,
+            packed=packed.view(original_tensor.shape[0], -1),  # 2-d view
             meta=meta,
             packed_t=packed_t,
             meta_t=meta_t,

--- a/torch/sparse/semi_structured.py
+++ b/torch/sparse/semi_structured.py
@@ -576,7 +576,7 @@ class SparseSemiStructuredTensorCUSPARSELT(SparseSemiStructuredTensor):
         cls, original_tensor: torch.Tensor, algorithm=""
     ) -> "SparseSemiStructuredTensor":
         """
-        This function does the same thing as described in SparseSemiStructuredCUTLASS, but uses the cuSPASRELt metadata
+        This function does the same thing as described in SparseSemiStructuredCUTLASS, but uses the cuSPARSELt metadata
         layout and sparse matmul.
 
         The only functional difference is that cuSPARSELt stores `metadata` and `packed` together into a single tensor.
@@ -620,9 +620,14 @@ class SparseSemiStructuredTensorCUSPARSELT(SparseSemiStructuredTensor):
             original_tensor, algorithm=algorithm, use_cutlass=False
         )
 
+        # Map this two 2-dim view of packed data.
+        # TODO: is this proper cuSPARSELt metadata?
+        packed = packed.view(original_tensor.shape[0], -1)
+        packed_t = packed_t.view(original_tensor.shape[1], -1)
+
         return cls(
             original_tensor.shape,
-            packed=packed.view(original_tensor.shape[0], -1),  # 2-d view
+            packed=packed,
             meta=meta,
             packed_t=packed_t,
             meta_t=meta_t,


### PR DESCRIPTION
Making sure buffer allocation matches what is computed by cusparseLt compression
