### PR TITLE
[FSDP2] idempotent reset_sharded_param: no-op if _local_tensor is already padded

### DIFF
--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
@@ -837,6 +837,7 @@ class FSDPParam:
         # 1st time in fully_shard(model)
         # 2nd time in model(input) lazy_init
         # 2nd time should be no-op if parameters remain unchanged
+        # 2nd time shouldn't be no-op if people call model.load_state_dict(...) before lazy_init
         # this makes it possible for trainer to call `sd = model.state_dict()` before the training loop
         # and use `sd` without calling .state_dict() per iteration
         same_local_tensor = (

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
@@ -253,11 +253,6 @@ class FSDPParam:
                 lambda *args, **kwargs: self.reset_sharded_param()
             )
         )
-        self._state_dict_pre_hook_handle = (
-            module_info.module.register_state_dict_pre_hook(
-                lambda *args, **kwargs: self.reset_sharded_param()
-            )
-        )
 
     @torch.no_grad()
     def _init_sharded_param(

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
@@ -833,12 +833,12 @@ class FSDPParam:
         if local_tensor.is_meta:
             return
         updated_local_tensor = False
-        # `reset_sharded_param` can be called twice
-        # 1st time in sd = model.state_dict()
+        # local_tensor can be padded twice
+        # 1st time in fully_shard(model)
         # 2nd time in model(input) lazy_init
         # 2nd time should be no-op if parameters remain unchanged
-        # this makes it possible for trainer to use sd directly in training loop
-        # without paying cpu overhead for state_dict() for every iteration
+        # this makes it possible for trainer to call `sd = model.state_dict()` before the training loop
+        # and use `sd` without calling .state_dict() per iteration
         same_local_tensor = (
             self._sharded_param_data.untyped_storage().data_ptr()
             == local_tensor.untyped_storage().data_ptr()

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
@@ -864,9 +864,9 @@ class FSDPParam:
         if self.pin_memory and not local_tensor.is_pinned():
             local_tensor = local_tensor.cpu().pin_memory()
             updated_local_tensor = True
-        assert isinstance(self.sharded_param, DTensor)  # mypy
         if not same_local_tensor:
             self._sharded_param_data = local_tensor.view(-1)
+        assert isinstance(self.sharded_param, DTensor)  # mypy
         if updated_local_tensor:
             # Only change the local tensor object if needed
             self.sharded_param._local_tensor = local_tensor.narrow(

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
@@ -840,10 +840,13 @@ class FSDPParam:
         # 2nd time shouldn't be no-op if people call model.load_state_dict(...) before lazy_init
         # this makes it possible for trainer to call `sd = model.state_dict()` before the training loop
         # and use `sd` without calling .state_dict() per iteration
-        same_local_tensor = (
-            self._sharded_param_data.untyped_storage().data_ptr()
-            == local_tensor.untyped_storage().data_ptr()
-        )
+        same_local_tensor = False
+        # TODO: need to support tensor subclass
+        if type(self._sharded_param_data) is torch.Tensor:
+            same_local_tensor = (
+                self._sharded_param_data.untyped_storage().data_ptr()
+                == local_tensor.untyped_storage().data_ptr()
+            )
         padded_sharded_size = self.padded_sharded_param_size
         shard_dim = self.fsdp_placement.dim
         length = local_tensor.size(shard_dim) if local_tensor.numel() > 0 else 0

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -713,9 +713,16 @@ class FSDPParamGroup:
         def to_sharded_hook(*args: Any, **kwargs: Any) -> None:
             self._to_sharded()
 
+        def to_sharded_and_reset_sharded_param_hook(*args: Any, **kwargs: Any) -> None:
+            self._to_sharded()
+            for fsdp_param in self.fsdp_params:
+                fsdp_param.reset_sharded_param()
+
         for module in modules_with_fsdp_params:
             self._module_to_pre_save_state_dict_hook_handle[module] = (
-                module.register_state_dict_pre_hook(to_sharded_hook)
+                module.register_state_dict_pre_hook(
+                    to_sharded_and_reset_sharded_param_hook
+                )
             )
             self._module_to_pre_load_state_dict_hook_handle[module] = (
                 module._register_load_state_dict_pre_hook(to_sharded_hook)

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -713,16 +713,9 @@ class FSDPParamGroup:
         def to_sharded_hook(*args: Any, **kwargs: Any) -> None:
             self._to_sharded()
 
-        def to_sharded_and_reset_sharded_param_hook(*args: Any, **kwargs: Any) -> None:
-            self._to_sharded()
-            for fsdp_param in self.fsdp_params:
-                fsdp_param.reset_sharded_param()
-
         for module in modules_with_fsdp_params:
             self._module_to_pre_save_state_dict_hook_handle[module] = (
-                module.register_state_dict_pre_hook(
-                    to_sharded_and_reset_sharded_param_hook
-                )
+                module.register_state_dict_pre_hook(to_sharded_hook)
             )
             self._module_to_pre_load_state_dict_hook_handle[module] = (
                 module._register_load_state_dict_pre_hook(to_sharded_hook)


### PR DESCRIPTION
resolves https://github.com/pytorch/torchtitan/issues/1136

torchtitan use cached state dict for ft. reset_sharded_param should be idempotent if model.parameters() are padded already

```
# pad DTensor._local_tensor
fully_shard(model)
sd = fsdp_model.state_dict()
# reset_sharded_param should be a no-op in lazy_init
loss = fsdp_model(inp).sum()
```

this PR make `reset_sharded_param` idempotent by checking storage data ptr and return early

unit test
```
pytest -s test/distributed/_composable/fsdp/test_fully_shard_state_dict.py -k test_cached_state_dict
```
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #163130



cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci