### PR TITLE
[PT2][AutoAC] force save custom triton kernels

### DIFF
--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -330,6 +330,12 @@ strict_autograd_cache = False
 # that any decisions on collectives are made consistently.
 unsafe_allow_optimization_of_collectives = False
 
+# Currently, custom triton kernels are recomputed. However, custom kernels are
+# paired with custom backward implementations that handle recomputation internally.
+# Therefore, recomputation is redundant and should be avoided.
+# This flag ensures that custom triton kernel are never recomputed
+force_save_custom_triton_kernels = False
+
 # See Note [AOTAutograd Tangent Subclassness for mutated inputs]
 # TODO(ivankobzarev): Remove this config, being able to deduce it compile time.
 disable_guess_zero_tangent_for_mutated_input_subclass = False


### PR DESCRIPTION
Below are trace from before and after the changes. The highlighted region are `_attn_fwd`. Before the change, these kernels are recomputed in the backward; and after the change, they are no longer recomputed.

**before**
<img width="2218" height="370" alt="image" src="https://github.com/user-attachments/assets/67710ba7-13c9-4e9c-806d-301d72b1c784" />

**after**
<img width="2210" height="388" alt="image" src="https://github.com/user-attachments/assets/d9294c1a-f0f0-4529-bae7-44d3cc421625" />


Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #163139

