### PR TITLE
fix test_type_hints

### DIFF
--- a/test/test_type_hints.py
+++ b/test/test_type_hints.py
@@ -49,7 +49,7 @@ def get_all_examples():
         "",
         "from typing import Any, ClassVar, Generic, List, Tuple, Union",
         "from typing_extensions import Literal, get_origin, TypeAlias",
-        "T: TypeAlias = Any",
+        "T: TypeAlias = object",
         "",
         "import numpy",
         "",
@@ -57,7 +57,7 @@ def get_all_examples():
         "import torch.nn.functional as F",
         "",
         "from typing_extensions import ParamSpec as _ParamSpec",
-        "ParamSpec: Any = _ParamSpec",
+        "ParamSpec = _ParamSpec",
         "",
         # for requires_grad_ example
         # NB: We are parsing this file as Python 2, so we must use

--- a/test/test_type_hints.py
+++ b/test/test_type_hints.py
@@ -47,10 +47,17 @@ def get_all_examples():
         "import io",
         "import itertools",
         "",
+        "from typing import Any, ClassVar, Generic, List, Tuple, Union",
+        "from typing_extensions import Literal, get_origin, TypeAlias",
+        "T: TypeAlias = Any",
+        "",
         "import numpy",
         "",
         "import torch",
         "import torch.nn.functional as F",
+        "",
+        "from typing_extensions import ParamSpec as _ParamSpec",
+        "ParamSpec: Any = _ParamSpec",
         "",
         # for requires_grad_ example
         # NB: We are parsing this file as Python 2, so we must use

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1570,7 +1570,7 @@ class Tensor(torch._C.TensorBase):
             ... )  # It can be mapped to contiguous format
             (0, 1, 2, 3)
             >>> try:
-            ...     torch.empty((1, 2, 3, 4)).dim_order(ambiguity_check="ILLEGAL")
+            ...     torch.empty((1, 2, 3, 4)).dim_order(ambiguity_check="ILLEGAL") # type: ignore[arg-type]
             ... except TypeError as e:
             ...     print(e)
             The ambiguity_check argument must be a bool or a list of memory formats.

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -1393,7 +1393,7 @@ def load(
         # Load all tensors onto GPU 1
         >>> torch.load(
         ...     "tensors.pt",
-        ...     map_location=lambda storage, loc: storage.cuda(1),
+        ...     map_location=lambda storage, loc: storage.cuda(1),  # type: ignore[attr-defined]
         ...     weights_only=True,
         ... )  # type: ignore[attr-defined]
         # Map tensors from GPU 1 to GPU 0


### PR DESCRIPTION
Fixes #163149

### Summary:
Fixes mypy type checking failures in `test_type_hints` by consolidating typing imports and eliminating duplicate/conflicting import patterns that caused mypy to fail resolving type annotations.

### Impact:

- `test_type_hints` works fine now
- module: tests

cc @mruberry