### PR TITLE
Fixes floating point exception in torch.nn.PixelShuffle

### DIFF
--- a/aten/src/ATen/native/PixelShuffle.h
+++ b/aten/src/ATen/native/PixelShuffle.h
@@ -1,5 +1,6 @@
 #include <ATen/core/Tensor.h>
 #include <c10/util/Exception.h>
+#include <c10/util/safe_numerics.h>
 
 namespace at::native {
 
@@ -11,8 +12,10 @@ inline void check_pixel_shuffle_shapes(const Tensor& self, int64_t upscale_facto
               "pixel_shuffle expects a positive upscale_factor, but got ",
               upscale_factor);
   int64_t c = self.size(-3);
-  int64_t upscale_factor_squared = upscale_factor * upscale_factor;
-  TORCH_CHECK(c % upscale_factor_squared == 0,
+  uint64_t upscale_factor_squared;
+  TORCH_CHECK(!(c10::mul_overflows(upscale_factor, upscale_factor, &upscale_factor_squared)), 
+        "upscale factor is too large, (upscale_factor}^2 overflowed: upscale_factor=", upscale_factor);
+  TORCH_CHECK(c % static_cast<int64_t>(upscale_factor_squared) == 0,
               "pixel_shuffle expects its input's 'channel' dimension to be divisible by the square of "
               "upscale_factor, but input.size(-3)=", c, " is not divisible by ", upscale_factor_squared);
 }

--- a/aten/src/ATen/native/PixelShuffle.h
+++ b/aten/src/ATen/native/PixelShuffle.h
@@ -13,7 +13,7 @@ inline void check_pixel_shuffle_shapes(const Tensor& self, int64_t upscale_facto
               upscale_factor);
   int64_t c = self.size(-3);
   uint64_t upscale_factor_squared;
-  TORCH_CHECK(!(c10::mul_overflows(upscale_factor, upscale_factor, &upscale_factor_squared)), 
+  TORCH_CHECK(!(c10::mul_overflows(upscale_factor, upscale_factor, &upscale_factor_squared)),
         "upscale factor is too large, (upscale_factor}^2 overflowed: upscale_factor=", upscale_factor);
   TORCH_CHECK(c % static_cast<int64_t>(upscale_factor_squared) == 0,
               "pixel_shuffle expects its input's 'channel' dimension to be divisible by the square of "

--- a/aten/src/ATen/native/PixelShuffle.h
+++ b/aten/src/ATen/native/PixelShuffle.h
@@ -13,8 +13,8 @@ inline void check_pixel_shuffle_shapes(const Tensor& self, int64_t upscale_facto
               upscale_factor);
   int64_t c = self.size(-3);
   uint64_t upscale_factor_squared;
-  TORCH_CHECK(!(c10::mul_overflows(upscale_factor, upscale_factor, &upscale_factor_squared)),
-        "upscale factor is too large, (upscale_factor}^2 overflowed: upscale_factor=", upscale_factor);
+  TORCH_CHECK_VALUE(!(c10::mul_overflows(upscale_factor, upscale_factor, &upscale_factor_squared)),
+        "upscale factor is too large, (upscale_factor)^2 overflowed: upscale_factor=", upscale_factor);
   TORCH_CHECK(c % static_cast<int64_t>(upscale_factor_squared) == 0,
               "pixel_shuffle expects its input's 'channel' dimension to be divisible by the square of "
               "upscale_factor, but input.size(-3)=", c, " is not divisible by ", upscale_factor_squared);

--- a/aten/src/ATen/native/PixelShuffle.h
+++ b/aten/src/ATen/native/PixelShuffle.h
@@ -15,7 +15,7 @@ inline void check_pixel_shuffle_shapes(const Tensor& self, int64_t upscale_facto
   TORCH_CHECK_VALUE(upscale_factor <= std::numeric_limits<decltype(upscale_factor)>::max() / upscale_factor,
         "upscale factor is too large, (upscale_factor)^2 overflowed: upscale_factor=", upscale_factor);
   int64_t upscale_factor_squared = upscale_factor * upscale_factor;
-  TORCH_CHECK(c % upscale_factor_squared == 0
+  TORCH_CHECK(c % upscale_factor_squared == 0,
               "pixel_shuffle expects its input's 'channel' dimension to be divisible by the square of "
               "upscale_factor, but input.size(-3)=", c, " is not divisible by ", upscale_factor_squared);
 }

--- a/aten/src/ATen/native/PixelShuffle.h
+++ b/aten/src/ATen/native/PixelShuffle.h
@@ -1,6 +1,5 @@
 #include <ATen/core/Tensor.h>
 #include <c10/util/Exception.h>
-#include <c10/util/safe_numerics.h>
 
 namespace at::native {
 

--- a/aten/src/ATen/native/PixelShuffle.h
+++ b/aten/src/ATen/native/PixelShuffle.h
@@ -12,10 +12,10 @@ inline void check_pixel_shuffle_shapes(const Tensor& self, int64_t upscale_facto
               "pixel_shuffle expects a positive upscale_factor, but got ",
               upscale_factor);
   int64_t c = self.size(-3);
-  uint64_t upscale_factor_squared;
-  TORCH_CHECK_VALUE(!(c10::mul_overflows(upscale_factor, upscale_factor, &upscale_factor_squared)),
+  TORCH_CHECK_VALUE(upscale_factor <= std::numeric_limits<decltype(upscale_factor)>::max() / upscale_factor,
         "upscale factor is too large, (upscale_factor)^2 overflowed: upscale_factor=", upscale_factor);
-  TORCH_CHECK(c % static_cast<int64_t>(upscale_factor_squared) == 0,
+  int64_t upscale_factor_squared = upscale_factor * upscale_factor;
+  TORCH_CHECK(c % upscale_factor_squared == 0
               "pixel_shuffle expects its input's 'channel' dimension to be divisible by the square of "
               "upscale_factor, but input.size(-3)=", c, " is not divisible by ", upscale_factor_squared);
 }

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -511,7 +511,7 @@ class TestPixelShuffle(TestCaseMPS):
             _test_pixel_unshuffle_error_case_helper(num_input_dims=num_input_dims, valid_width_dim=False)
             _test_pixel_unshuffle_error_case_helper(num_input_dims=num_input_dims, downscale_factor=0)
             _test_pixel_unshuffle_error_case_helper(num_input_dims=num_input_dims, downscale_factor=-2)
-  
+
         def test_pixel_shuffle_large_upscale_factor():
             with self.assertRaises(RuntimeError):
                 ps = nn.PixelShuffle(545460846592)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -511,6 +511,11 @@ class TestPixelShuffle(TestCaseMPS):
             _test_pixel_unshuffle_error_case_helper(num_input_dims=num_input_dims, valid_width_dim=False)
             _test_pixel_unshuffle_error_case_helper(num_input_dims=num_input_dims, downscale_factor=0)
             _test_pixel_unshuffle_error_case_helper(num_input_dims=num_input_dims, downscale_factor=-2)
+  
+        def test_pixel_shuffle_large_upscale_factor():
+            with self.assertRaises(RuntimeError):
+                ps = nn.PixelShuffle(545460846592)
+                ps(torch.randn(2, 16, 9, 3))
 
         def test_pixel_shuffle_unshuffle_1D():
             _test_pixel_shuffle_unshuffle_for_input_dims(num_input_dims=1)
@@ -527,6 +532,7 @@ class TestPixelShuffle(TestCaseMPS):
         def test_pixel_shuffle_unshuffle_5D():
             _test_pixel_shuffle_unshuffle_for_input_dims(num_input_dims=5)
 
+        test_pixel_shuffle_large_upscale_factor()
         test_pixel_shuffle_unshuffle_1D()
         test_pixel_shuffle_unshuffle_2D()
         test_pixel_shuffle_unshuffle_3D()

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -513,7 +513,7 @@ class TestPixelShuffle(TestCaseMPS):
             _test_pixel_unshuffle_error_case_helper(num_input_dims=num_input_dims, downscale_factor=-2)
 
         def test_pixel_shuffle_large_upscale_factor():
-            with self.assertRaises(RuntimeError):
+            with self.assertRaises(ValueError):
                 ps = nn.PixelShuffle(545460846592)
                 ps(torch.randn(2, 16, 9, 3))
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4566,7 +4566,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             _test_pixel_unshuffle_error_case_helper(num_input_dims=num_input_dims, downscale_factor=-2)
 
         def test_pixel_shuffle_large_upscale_factor():
-            with self.assertRaises(RuntimeError):
+            with self.assertRaises(ValueError):
                 ps = nn.PixelShuffle(545460846592)
                 ps(torch.randn(2, 16, 9, 3))
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4564,6 +4564,11 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             _test_pixel_unshuffle_error_case_helper(num_input_dims=num_input_dims, valid_width_dim=False)
             _test_pixel_unshuffle_error_case_helper(num_input_dims=num_input_dims, downscale_factor=0)
             _test_pixel_unshuffle_error_case_helper(num_input_dims=num_input_dims, downscale_factor=-2)
+        
+        def test_pixel_shuffle_large_upscale_factor():
+            with self.assertRaises(RuntimeError):
+                ps = nn.PixelShuffle(545460846592)
+                ps(torch.randn(2, 16, 9, 3))
 
         def test_pixel_shuffle_unshuffle_1D():
             _test_pixel_shuffle_unshuffle_for_input_dims(num_input_dims=1)
@@ -4580,6 +4585,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         def test_pixel_shuffle_unshuffle_5D():
             _test_pixel_shuffle_unshuffle_for_input_dims(num_input_dims=5)
 
+        test_pixel_shuffle_large_upscale_factor()
         test_pixel_shuffle_unshuffle_1D()
         test_pixel_shuffle_unshuffle_2D()
         test_pixel_shuffle_unshuffle_3D()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4564,7 +4564,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             _test_pixel_unshuffle_error_case_helper(num_input_dims=num_input_dims, valid_width_dim=False)
             _test_pixel_unshuffle_error_case_helper(num_input_dims=num_input_dims, downscale_factor=0)
             _test_pixel_unshuffle_error_case_helper(num_input_dims=num_input_dims, downscale_factor=-2)
-        
+
         def test_pixel_shuffle_large_upscale_factor():
             with self.assertRaises(RuntimeError):
                 ps = nn.PixelShuffle(545460846592)


### PR DESCRIPTION
Fixes #162251

**Previous Output:**
`Floating point exception (core dumped)`

**Now Output:**
`RuntimeError: upscale factor is too large, (upscale_factor}^2 overflowed: upscale_factor=545460846592`