### PR TITLE
[testing] Add test owner labels for some tests

### DIFF
--- a/test/custom_backend/test_custom_backend.py
+++ b/test/custom_backend/test_custom_backend.py
@@ -1,4 +1,4 @@
-# Owner(s): ["module: unknown"]
+# Owner(s): ["module: custom-operators"]
 
 import os
 import tempfile

--- a/test/custom_operator/test_custom_ops.py
+++ b/test/custom_operator/test_custom_ops.py
@@ -1,4 +1,4 @@
-# Owner(s): ["module: unknown"]
+# Owner(s): ["module: custom-operators"]
 
 import os.path
 import sys

--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -1,4 +1,4 @@
-# Owner(s): ["module: unknown"]
+# Owner(s): ["module: amp (automated mixed precision)"]
 
 import unittest
 

--- a/test/test_mkl_verbose.py
+++ b/test/test_mkl_verbose.py
@@ -1,4 +1,4 @@
-# Owner(s): ["module: unknown"]
+# Owner(s): ["module: mkl"]
 
 from torch.testing._internal.common_utils import TestCase, run_tests
 import os

--- a/test/test_mkldnn_verbose.py
+++ b/test/test_mkldnn_verbose.py
@@ -1,4 +1,4 @@
-# Owner(s): ["module: unknown"]
+# Owner(s): ["module: mkldnn"]
 
 from torch.testing._internal.common_utils import TestCase, run_tests
 import os

--- a/test/test_openmp.py
+++ b/test/test_openmp.py
@@ -1,4 +1,4 @@
-# Owner(s): ["module: unknown"]
+# Owner(s): ["module: openmp"]
 
 import collections
 import unittest

--- a/test/test_tensorboard.py
+++ b/test/test_tensorboard.py
@@ -1,4 +1,4 @@
-# Owner(s): ["module: unknown"]
+# Owner(s): ["module: tensorboard"]
 
 import io
 import os

--- a/test/typing/test_python_operators.py
+++ b/test/typing/test_python_operators.py
@@ -1,5 +1,5 @@
 # mypy: ignore-errors
-# Owner(s): ["module: unknown"]
+# Owner(s): ["module: typing"]
 import token
 from itertools import product
 from pathlib import Path


### PR DESCRIPTION
I am trying to give some test files better owner labels than `module: unknown`.  I am not sure them, but they seem pretty reasonable


cc @lolpack @maggiemoss @ndmitchell @kinto0 @samwgoldman @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal @mcarilli @ptrblck @leslie-fang-intel