### PR TITLE
[inductor] rename kernel inputs scalars to kwargs

### DIFF
--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -260,7 +260,7 @@ def tuned_baddbmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
 
     # Create MMKernelInputs for BadDBMM at the top
     kernel_inputs = MMKernelInputs(
-        [inp, mat1, mat2], scalars=dict(alpha=alpha, beta=beta)
+        [inp, mat1, mat2], kwargs=dict(alpha=alpha, beta=beta)
     )
 
     # below is for getting an overview logging info of inductor mms

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -1037,7 +1037,7 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
     name = "addmm"
     # Create MMKernelInputs for AddMM at the top
     kernel_inputs = MMKernelInputs(
-        [inp_expanded, mat1, mat2], scalars=dict(alpha=alpha, beta=beta)
+        [inp_expanded, mat1, mat2], kwargs=dict(alpha=alpha, beta=beta)
     )
     choices: list[ChoiceCaller] = []
 
@@ -1059,7 +1059,7 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
         # a subgraph or something as inp vs inp_expanded causes some slight numeric
         # differences
         kernel_inputs = MMKernelInputs(
-            [inp, mat1, mat2], scalars=dict(alpha=alpha, beta=beta)
+            [inp, mat1, mat2], kwargs=dict(alpha=alpha, beta=beta)
         )
         choices.extend(
             V.choices.get_template_configs(

--- a/torch/_inductor/template_heuristics/aten.py
+++ b/torch/_inductor/template_heuristics/aten.py
@@ -55,8 +55,8 @@ class ATenAddMMConfigHeuristics(ATenConfigHeuristics):
         op_name: str,
     ) -> dict[str, Any]:
         kwargs = super().get_extra_kwargs(kernel_inputs, op_name)
-        alpha = kernel_inputs.get_scalar("alpha")
-        beta = kernel_inputs.get_scalar("beta")
+        alpha = kernel_inputs.get_kwarg("alpha")
+        beta = kernel_inputs.get_kwarg("beta")
         return {
             **kwargs,
             "alpha": alpha,

--- a/torch/_inductor/template_heuristics/triton_addmm.py
+++ b/torch/_inductor/template_heuristics/triton_addmm.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 class AddMMConfigMixin(TemplateConfigHeuristics):
     """
-    Simple mixin to handle scalars for addmm like operators (addmm, baddbmm)
+    Simple mixin to handle kwargs for addmm like operators (addmm, baddbmm)
     """
 
     def get_extra_kwargs(
@@ -25,8 +25,8 @@ class AddMMConfigMixin(TemplateConfigHeuristics):
             "addmm",
             "baddbmm",
         ], f"op_name={op_name} invalid for AddMMConfigMixin"
-        alpha = kernel_inputs.get_scalar("alpha")
-        beta = kernel_inputs.get_scalar("beta")
+        alpha = kernel_inputs.get_kwarg("alpha")
+        beta = kernel_inputs.get_kwarg("beta")
         return {
             **kwargs,
             "epilogue_fn": addmm_epilogue(kernel_inputs.out_dtype(), alpha, beta),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #163201
* #163200
* #163199
* __->__ #163198

# why

- evolve the kernel inputs to be nodes + kwargs
- clearer that this is not limited to just scalars

- this is 1/n of removing the extra_kwargs and overriders from
  get_template_configs in favor of simplifying it to just being
  - template
  - kernel inputs
  - heuristic generated kwargs

# what

- rename scalars related stuff to kwargs
- replace invocations in addmm related configs

# testing

```
python3 -bb -m pytest test/inductor/test_max_autotune.py -v -k "_addmm"
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @jataylo @chenyang78