### PR TITLE
[inductor][heuristics] move out_dtype into kernel_inputs

### DIFF
--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -191,21 +191,17 @@ def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
     )
 
     aten_handler: ExternKernelChoice = aten_bmm
-    aten_extra_kwargs = {}
     if out_dtype:
         assert mat1.get_device().type == "cuda", "out_dtype is only supported for CUDA"
         aten_handler = aten_bmm_dtype
-        aten_extra_kwargs = {"out_dtype": out_dtype}
 
     choices: list[ChoiceCaller] = []
 
     # Collect all templates for unified call
     templates_to_use: list[Union[ExternKernelChoice, KernelTemplate]] = []
-    kwarg_overrides = {}
 
     if use_aten_gemm_kernels():
         templates_to_use.append(aten_handler)
-        kwarg_overrides[aten_handler.uid] = aten_extra_kwargs
 
     if use_triton_template(layout, check_max_autotune=False):
         # TODO: add out_dtype support for Triton Template
@@ -218,7 +214,6 @@ def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
             kernel_inputs,
             templates_to_use,
             name,
-            kwarg_overrides=kwarg_overrides,
         )
     )
     _, is_nonzero = _is_static_problem(layout)

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -1251,9 +1251,7 @@ def tuned_scaled_mm(
 
     if use_aten_gemm_kernels():
         templates_to_use.append(aten__fp8_mm)
-        kwarg_overrides[aten__fp8_mm.uid] = dict(
-            out_dtype=out_dtype, use_fast_accum=use_fast_accum
-        )
+        kwarg_overrides[aten__fp8_mm.uid] = dict(use_fast_accum=use_fast_accum)
 
     _, is_nonzero = _is_static_problem(layout)
 

--- a/torch/_inductor/kernel_inputs.py
+++ b/torch/_inductor/kernel_inputs.py
@@ -187,6 +187,15 @@ class KernelInputs(ABC):
             The output dtype
         """
 
+    def out_dtype_explicit(self) -> Optional[torch.dtype]:
+        """
+        Get the explicitly set output dtype without any inference
+
+        Returns:
+            The explicit output dtype or None if not set
+        """
+        return self._out_dtype
+
     def kwargs(self) -> dict[str, Union[float, int, bool]]:
         """
         Get the kwargs values for all input nodes.
@@ -286,12 +295,6 @@ class MMKernelInputs(KernelInputs):
         return (m, n, k)
 
     def out_dtype(self) -> torch.dtype:
-        """
-        Get the output dtype, whether passed in or inferred from the nodes
-
-        Returns:
-            The output dtype
-        """
         if self._out_dtype is not None:
             return self._out_dtype
         return self.mat1mat2()[0].get_dtype()

--- a/torch/_inductor/template_heuristics/aten.py
+++ b/torch/_inductor/template_heuristics/aten.py
@@ -21,12 +21,9 @@ if TYPE_CHECKING:
 # These are all labeled as device type None to indicate that they
 # are valid for all device types
 @register_template_heuristic(aten_mm.uid, None)
-@register_template_heuristic(aten__fp8_mm.uid, None)
 @register_template_heuristic(aten__int_mm.uid, None)
 @register_template_heuristic(aten_bmm.uid, None)
 @register_template_heuristic(aten_mm_plus_mm.uid, None)
-# bmm dtype is only valid on cuda
-@register_template_heuristic(aten_bmm_dtype.uid, "cuda")
 class ATenConfigHeuristics(TemplateConfigHeuristics):
     """
     Pseudo heuristic to make ATen choices go through the same flow as other templates
@@ -44,8 +41,23 @@ class ATenConfigHeuristics(TemplateConfigHeuristics):
         yield dict()
 
 
-# None here indicates that this is valid for all device types on that op
-# Note (None, op) takes precedence over (device_type, None)
+@register_template_heuristic(aten_bmm_dtype.uid, "cuda")
+@register_template_heuristic(aten__fp8_mm.uid, None)
+class ATenOutDtypeConfigHeuristics(ATenConfigHeuristics):
+    def get_extra_kwargs(
+        self,
+        kernel_inputs: KernelInputs,
+        op_name: str,
+    ) -> dict[str, Any]:
+        kwargs = super().get_extra_kwargs(kernel_inputs, op_name)
+        out_dtype = kernel_inputs.out_dtype_explicit()
+        assert out_dtype is not None, (
+            f"out_dtype is required for {op_name} but got None"
+        )
+        kwargs["out_dtype"] = out_dtype
+        return kwargs
+
+
 @register_template_heuristic(aten_addmm.uid, None, op_name="addmm")
 @register_template_heuristic(aten_baddbmm.uid, None, op_name="baddbmm")
 class ATenAddMMConfigHeuristics(ATenConfigHeuristics):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #163201
* #163200
* __->__ #163199
* #163198

# why

- step closer towards simplifying the interface to not need kwargs
  overriders

# what

- avoid passing out_dtype through kwargs_overriders
- extract where needed for ATen templates through kernel_inputs

# testing

```
python3 -bb -m pytest test/inductor/test_max_autotune.py -v
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @jataylo @chenyang78