### PR TITLE
[inductor][heuristics] move use_fast_accum into kernel_inputs

### DIFF
--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -1240,7 +1240,11 @@ def tuned_scaled_mm(
 
     # Create MMKernelInputs for Scaled MM (matrices are at indices 0, 1)
     kernel_inputs = MMKernelInputs(
-        input_nodes, mat1_idx=0, mat2_idx=1, out_dtype=out_dtype
+        input_nodes,
+        mat1_idx=0,
+        mat2_idx=1,
+        out_dtype=out_dtype,
+        kwargs=dict(use_fast_accum=use_fast_accum),
     )
 
     choices: list[ChoiceCaller] = []
@@ -1251,7 +1255,6 @@ def tuned_scaled_mm(
 
     if use_aten_gemm_kernels():
         templates_to_use.append(aten__fp8_mm)
-        kwarg_overrides[aten__fp8_mm.uid] = dict(use_fast_accum=use_fast_accum)
 
     _, is_nonzero = _is_static_problem(layout)
 

--- a/torch/_inductor/template_heuristics/aten.py
+++ b/torch/_inductor/template_heuristics/aten.py
@@ -42,7 +42,6 @@ class ATenConfigHeuristics(TemplateConfigHeuristics):
 
 
 @register_template_heuristic(aten_bmm_dtype.uid, "cuda")
-@register_template_heuristic(aten__fp8_mm.uid, None)
 class ATenOutDtypeConfigHeuristics(ATenConfigHeuristics):
     def get_extra_kwargs(
         self,
@@ -55,6 +54,20 @@ class ATenOutDtypeConfigHeuristics(ATenConfigHeuristics):
             f"out_dtype is required for {op_name} but got None"
         )
         kwargs["out_dtype"] = out_dtype
+        return kwargs
+
+
+@register_template_heuristic(aten__fp8_mm.uid, None)
+class ATenFP8ConfigHeuristics(ATenOutDtypeConfigHeuristics):
+    def get_extra_kwargs(
+        self,
+        kernel_inputs: KernelInputs,
+        op_name: str,
+    ) -> dict[str, Any]:
+        kwargs = super().get_extra_kwargs(kernel_inputs, op_name)
+        use_fast_accum = kernel_inputs.get_kwarg("use_fast_accum")
+        assert use_fast_accum is not None, f"use_fast_accum is required for {op_name}"
+        kwargs["use_fast_accum"] = use_fast_accum
         return kwargs
 
 

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -1529,7 +1529,7 @@ class MMTemplateConfigMixin(GemmMaxAutotuneTemplateConfigHeuristics):
         options_dict = dict(
             EVEN_K=even_k_symbolic,
             ALLOW_TF32=allow_tf32,
-            USE_FAST_ACCUM=False,  # Option for _scaled_mm
+            USE_FAST_ACCUM=False,  # Default value, will be overridden if needed
             ACC_TYPE=self._get_acc_type(out_dtype),
             num_stages=triton_config.num_stages,
             num_warps=triton_config.num_warps,
@@ -1782,6 +1782,11 @@ class BaseScaledMMConfigMixin(MMTemplateConfigMixin):
             # Add SCALING_ROWWISE attribute based on scale tensor shapes
             both_scalar_like = is_scalar_like(size_a) and is_scalar_like(size_b)
             template_kwargs["SCALING_ROWWISE"] = not both_scalar_like
+
+            # Extract use_fast_accum from kernel inputs if available
+            use_fast_accum = kernel_inputs.get_kwarg("use_fast_accum")
+            if use_fast_accum is not None:
+                template_kwargs["USE_FAST_ACCUM"] = use_fast_accum
 
             yield template_kwargs
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

# why

- remove last user of kwarg overriders

# what

- all scaled_mm kernels (triton, aten) that need this, are now getting
  it from the kwargs inside kernel_inputs

# testing

```
python3 -bb -m pytest test/inductor/test_max_autotune.py -v
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @jataylo @chenyang78