### PR TITLE
[inductor][choices] remove kwargs overriders

### DIFF
--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -1251,7 +1251,6 @@ def tuned_scaled_mm(
 
     # Collect all templates for unified call
     templates_to_use: list[Union[ExternKernelChoice, KernelTemplate]] = []
-    kwarg_overrides = {}
 
     if use_aten_gemm_kernels():
         templates_to_use.append(aten__fp8_mm)
@@ -1264,16 +1263,12 @@ def tuned_scaled_mm(
         and is_nonzero
         and use_triton_template(layout, enable_float8=True, check_max_autotune=False)
     ):
-        overriders = dict(USE_FAST_ACCUM=use_fast_accum)
-
         # TODO (paulzhan): There is no template that exists for bias and TMA
         # Don't run tma template currently if bias exist
         if use_triton_tma_template(mat_a, mat_b, output_layout=layout) and not bias:
             templates_to_use.append(scaled_mm_device_tma_template)
-            kwarg_overrides[scaled_mm_device_tma_template.uid] = overriders
 
         templates_to_use.append(mm_template)
-        kwarg_overrides[mm_template.uid] = overriders
 
     # Single unified call for all templates
     choices.extend(
@@ -1281,7 +1276,6 @@ def tuned_scaled_mm(
             kernel_inputs,
             templates_to_use,
             name,
-            kwarg_overrides=kwarg_overrides,
         )
     )
 

--- a/torch/_inductor/kernel_template_choice.py
+++ b/torch/_inductor/kernel_template_choice.py
@@ -63,7 +63,6 @@ class KernelTemplateChoice:
 def make_ktc_generator(
     template: Union[KernelTemplate, ExternKernelChoice],
     cs: Generator[dict[str, Any], None, None],
-    overrides: dict[str, Any],
     extra_kwargs: dict[str, Any],
     layout: Layout,
     inputs: KernelInputs,
@@ -74,9 +73,8 @@ def make_ktc_generator(
     Args:
         template: The template object (KernelTemplate or ExternKernelChoice)
         cs: Generator of configurations from template heuristic
-        overrides: Override kwargs for the template
         extra_kwargs: Extra kwargs from the heuristic
-        layout_val: Layout value for the template
+        layout: Layout value for the template
         inputs: KernelInputs for the op
 
     Yields:
@@ -85,7 +83,7 @@ def make_ktc_generator(
     for ckwargs in cs:
         yield KernelTemplateChoice(
             template=template,
-            kwargs={**ckwargs, **overrides},
+            kwargs=ckwargs,
             extra_kwargs=extra_kwargs,
             layout=layout,
             inputs=inputs,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #163201
* #163200
* #163199
* #163198

# why

- usage is fully migrated towards passing the kwargs through
  kernel_inputs
- interface simplification

# what

- remove unused kwarg_overriders in get_template_configs and
  _finalize_template_configs

# testing

```
python3 -bb -m pytest test/inductor/test_max_autotune.py -v
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @jataylo @chenyang78