### PR TITLE
[ROCm][SymmMem] Fix skip condition for PLATFORM_SUPPORTS_SYMM_MEM

### DIFF
--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -419,10 +419,9 @@ def evaluate_platform_supports_symm_mem():
         for arch in arch_list:
             if arch in torch.cuda.get_device_properties(0).gcnArchName:
                 return True
-    if TEST_CUDA:
+        return False
+    else:
         return True
-
-    return False
 
 
 PLATFORM_SUPPORTS_SYMM_MEM: bool = LazyVal(

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -414,14 +414,17 @@ def requires_multicast_support():
 
 
 def evaluate_platform_supports_symm_mem():
-    if TEST_WITH_ROCM:
-        arch_list = ["gfx942", "gfx950"]
-        for arch in arch_list:
-            if arch in torch.cuda.get_device_properties(0).gcnArchName:
-                return True
-        return False
+    if TEST_CUDA:
+        if TEST_WITH_ROCM:
+            arch_list = ["gfx942", "gfx950"]
+            for arch in arch_list:
+                if arch in torch.cuda.get_device_properties(0).gcnArchName:
+                    return True
+            return False
+        else:
+            return True
     else:
-        return True
+        return False
 
 
 PLATFORM_SUPPORTS_SYMM_MEM: bool = LazyVal(


### PR DESCRIPTION
It seems `TEST_CUDA` is set to true even for ROCm (MI200) jobs. Changing if TEST_CUDA to an else condition to avoid running symmetric memory UTs on MI200. For other non-rocm arch, it should return true and can be skipped using other skip decorators. 

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @ezyang @msaroufim @dcci @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd