### PR TITLE
[DO NOT LAND] Make LSTM exportable

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -16026,6 +16026,17 @@ def forward(self, q, k, v):
         ):
             export(Foo(), (torch.randn(1, 33, 256, 128), k, v))
 
+    def test_lstm_export(self):
+        mod = torch.nn.LSTM(
+            input_size=8, hidden_size=16, num_layers=1, batch_first=True
+        )
+        sample_inputs = (torch.randn(4, 16, 8),)
+        ep = export(mod, sample_inputs)
+
+        eager_out = mod(*sample_inputs)
+        ep_out = ep.module()(*sample_inputs)
+        self.assertEqual(eager_out, ep_out)
+
 
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
 class TestOneOffModelExportResult(TestCase):

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -388,7 +388,7 @@ class RNNBase(Module):
         return s.format(**self.__dict__)
 
     def _update_flat_weights(self) -> None:
-        if not torch.jit.is_scripting():
+        if not torch.jit.is_scripting() and not torch.compiler.is_exporting():
             if self._weights_have_changed():
                 self._init_flat_weights()
 


### PR DESCRIPTION
Summary:
LSTM was not exportable as it failed at `_detect_attribute_assignment` check.

This is because the `_flat_weights` attribute in LSTM is a list of parameters that could be updated by the `_update_flat_weights` method, and this could cause silent fake tensor leakage.

We add `torch.compiler.is_exporting()` check in the `_update_flat_weights` to make sure that `_flat_weights` won't be updated during export so that no fake tensor leakage will happen.

Test Plan:
buck2 run mode/dev-nosan caffe2/test:test_export -- -r test_lstm_export

Rollback Plan:

Differential Revision: D82682791


