### PR TITLE
Skip reuse PyTorch wheel when building vLLM

### DIFF
--- a/.github/workflows/vllm.yml
+++ b/.github/workflows/vllm.yml
@@ -36,6 +36,8 @@ jobs:
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
+      # When building vLLM, uv doesn't like that we rename wheel without changing the wheel metadata
+      allow-reuse-old-whl: false
       build-additional-packages: "vision audio"
       build-external-packages: "vllm"
       build-environment: linux-jammy-cuda12.8-py3.12-gcc11


### PR DESCRIPTION
This issues starts surfacing in [trunk](https://hud.pytorch.org/hud/pytorch/pytorch/b26d4c9a7a41727e7f842224a6566396fb664476/1?per_page=50&name_filter=vllm).  When building vLLM, uv doesn't like that we rename CI wheel without changing its metadata to match it.

cc @zou3519 
