### PR TITLE
[OpenReg][Docs] Correct docs about `openreg` usage example.

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/README.md
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/README.md
@@ -97,8 +97,8 @@ There are 4 DSOs in torch_openreg, and the dependencies between them are as foll
 - `csrc/`: Core device implementation, including operator registration, runtime, etc.
   - `csrc/aten/`: Operator registration
     - `csrc/aten/native/`: Specific operator implementations for the OpenReg device.
-      - `csrc/aten/OpenRegMinimal.cpp`: The most minimal set of operator implementations (allowing for the creation of Tensors and related operations upon completion).
-      - `csrc/aten/OpenRegExtra.cpp`: Implementations for other types of operators.
+      - `csrc/aten/native/OpenRegMinimal.cpp`: The most minimal set of operator implementations (allowing for the creation of Tensors and related operations upon completion).
+      - `csrc/aten/native/OpenRegExtra.cpp`: Implementations for other types of operators.
     - `csrc/runtime/`: Implementations for Host memory, device memory, Guard, Hooks, etc.
 - `third_party/`: A C++ library that simulates a CUDA-like device using the CPU.
 - `torch_openreg/`: Python interface implementation (Python code and C++ Bindings).

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/README.md
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/README.md
@@ -125,6 +125,7 @@ Please refer to [example](example/example.cpp) for example.
 The command to compile example.cpp is as follow:
 
 ```Shell
+# pwd: pytorch/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg
 mkdir build
 
 pushd build
@@ -132,7 +133,7 @@ cmake ..
 make -j 32
 popd
 
-g++ -o out example/example.cpp -L ./build -lopenreg
+g++ -o out example/example.cpp -L ./build -lopenreg -I ./
 LD_LIBRARY_PATH=./build ./out
 ```
 

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/README.md
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/README.md
@@ -125,7 +125,7 @@ Please refer to [example](example/example.cpp) for example.
 The command to compile example.cpp is as follow:
 
 ```Shell
-# pwd: pytorch/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg
+# The same directory as the current README.md file.
 mkdir build
 
 pushd build

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/example/example.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/example/example.cpp
@@ -1,6 +1,5 @@
 #include "include/openreg.h"
 
-#include <algorithm>
 #include <iostream>
 #include <numeric>
 #include <vector>


### PR DESCRIPTION
## Why this PR?
I've tried to follow the guidance of the `OpenReg` [usage example](https://github.com/pytorch/pytorch/tree/main/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg) and found that the command for compiling `example.cpp` (`g++ -o out example/example.cpp -L ./build -lopenreg`) is not compatible with my `gcc` (v11.4). 

Since I installed my `gcc` through `apt install build-essential`, and I think that's a common way to install `gcc` for a few developers? I believe it's necessary to slightly modify the command to add `-I ./` to explicitly indicate the header file search path.

## What I've changed?
- I added `-I ./` to correctly search for `./include/openreg.h`. 
- I also added a `pwd` comment for better readability and removed unused imports in `example/example.cpp`.