### PR TITLE
[export] Tag lifted constants with source object id.

### DIFF
--- a/test/export/test_metadata.py
+++ b/test/export/test_metadata.py
@@ -1,0 +1,41 @@
+# Owner(s): ["oncall: export"]
+
+import torch
+from torch._dynamo.test_case import TestCase
+from torch.testing._internal.common_utils import run_tests
+
+
+class TestExportTools(TestCase):
+    def test_source_id(self):
+        forward_context = (torch.randn(3, 2),)
+
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return x + forward_context[0]
+
+        model = Model()
+        inputs = (torch.randn(3, 2),)
+
+        ep = torch.export.export(model, inputs, strict=False)
+        lifted_node = next(iter(ep.graph.nodes))
+        self.assertEqual(lifted_node.op, "placeholder")
+        self.assertEqual(lifted_node.meta["source_id"], id(forward_context[0]))
+
+        # rename the node
+        lifted_node.name += "_kv_cache"
+        lifted_node.target = lifted_node.name
+        gm = ep.graph_module
+        gm.recompile()
+        self.assertExpectedInline(
+            str(gm.graph),
+            """\
+graph():
+    %c_lifted_tensor_0_kv_cache : [num_users=1] = placeholder[target=c_lifted_tensor_0_kv_cache]
+    %x : [num_users=1] = placeholder[target=x]
+    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %c_lifted_tensor_0_kv_cache), kwargs = {})
+    return (add,)""",
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_export/passes/lift_constants_pass.py
+++ b/torch/_export/passes/lift_constants_pass.py
@@ -337,6 +337,11 @@ def lift_constants_pass(
                         f"tried to lift unsupported type {type(constant_val)} from node {node.format_node()}"
                     )
 
+                # source id is not meant to be serialized and expected to be
+                # used for tracking correspondence between placeholder nodes and
+                # the it's original constant objects. It's up to downstream to
+                # preserve this metadata or not.
+                const_placeholder_node.meta["source_id"] = id(constant_val)
                 lifted_objs.add(constant_val, const_placeholder_node)
                 node.replace_all_uses_with(const_placeholder_node)
                 gm.graph.erase_node(node)


### PR DESCRIPTION
Summary:
Adds a metadata to node which should achieve the same end goal as https://github.com/pytorch/pytorch/pull/162926

Basically we want to have a generic way to associate graph inputs with its original source. To achieve this, we can store an additional field "source_id" on the placeholder node so that export downstream can track the mapping between tensor objects and its placeholder node.

Test Plan:
buck2 run --flagfile fbcode//mode/opt fbcode//caffe2/test:test_export -- -r test_source_id

Rollback Plan:

Differential Revision: D82698063


