### PR TITLE
Make `Tensor.__dlpack__(stream=None)` capture-safe during CUDA Graph capture

### DIFF
--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1750,12 +1750,7 @@ class Tensor(torch._C.TensorBase):
             is_cuda = not is_rocm
 
             if stream is None:
-                if torch.cuda.is_current_stream_capturing():
-                    # During capture, default-stream ops would invalidate capture.
-                    # Route to the current (capturing) stream instead.
-                    stream = torch.cuda.current_stream()
-                else:
-                    stream = torch.cuda.default_stream()
+                stream = torch.cuda.current_stream()
             elif (is_rocm and stream == 0) or (is_cuda and stream == 1):
                 stream = torch.cuda.default_stream()
             else:

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1772,7 +1772,7 @@ class Tensor(torch._C.TensorBase):
                 event.record(current_stream)
                 stream.wait_event(event)
         elif self.device.type == "cpu":
-            assert stream is None or stream == -1, "stream should be None or -1 on cpu."
+            assert stream is None or stream == -1, "stream should be None on cpu."
 
         if self.device.type == "xla":
             import torch_xla

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1749,7 +1749,14 @@ class Tensor(torch._C.TensorBase):
             is_rocm = torch.version.hip is not None
             is_cuda = not is_rocm
 
-            if stream is None or (is_rocm and stream == 0) or (is_cuda and stream == 1):
+            if stream is None:
+                if torch.cuda.is_current_stream_capturing():
+                    # During capture, default-stream ops would invalidate capture.
+                    # Route to the current (capturing) stream instead.
+                    stream = torch.cuda.current_stream()
+                else:
+                    stream = torch.cuda.default_stream()
+            elif (is_rocm and stream == 0) or (is_cuda and stream == 1):
                 stream = torch.cuda.default_stream()
             else:
                 if is_cuda and stream == 2:

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1671,7 +1671,7 @@ class Tensor(torch._C.TensorBase):
     def __dlpack__(
         self,
         *,
-        stream: Optional[Any] = None,
+        stream: Optional[Any] = -1,
         max_version: Optional[tuple[int, int]] = None,
         dl_device: Optional[tuple[enum.IntEnum, int]] = None,
         copy: Optional[bool] = None,
@@ -1689,7 +1689,7 @@ class Tensor(torch._C.TensorBase):
                 pointer to a CUDA stream. The current stream is synchronized with
                 this stream before the capsule is created, and since the capsule
                 shares its storage with the tensor this make it safe to access from
-                both streams.  If None or -1 is passed then no synchronization is performed.
+                both streams.  If -1 is passed then no synchronization is performed.
                 If 1 (on CUDA) or 0 (on ROCM) then the default stream is used for
                 synchronization.
 
@@ -1749,9 +1749,7 @@ class Tensor(torch._C.TensorBase):
             is_rocm = torch.version.hip is not None
             is_cuda = not is_rocm
 
-            if stream is None:
-                stream = torch.cuda.current_stream()
-            elif (is_rocm and stream == 0) or (is_cuda and stream == 1):
+            if stream is None or (is_rocm and stream == 0) or (is_cuda and stream == 1):
                 stream = torch.cuda.default_stream()
             else:
                 if is_cuda and stream == 2:

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1691,7 +1691,10 @@ class Tensor(torch._C.TensorBase):
                 shares its storage with the tensor this make it safe to access from
                 both streams.  If -1 is passed then no synchronization is performed.
                 If 1 (on CUDA) or 0 (on ROCM) then the default stream is used for
-                synchronization.
+                synchronization. This API intentionally slightly deviates from the DLPack
+                guidance: the default stream is -1 (stream-preserving; no cross-stream sync),
+                because many from_dlpack implementations intend stream preservation.
+                For non-CUDA devices, -1 is treated the same as None.
 
             max_version (tuple[int, int] or None): An optional Python tuple with
                 2 integers, representing the maximum version the caller supports. If
@@ -1769,7 +1772,7 @@ class Tensor(torch._C.TensorBase):
                 event.record(current_stream)
                 stream.wait_event(event)
         elif self.device.type == "cpu":
-            assert stream is None, "stream should be None on cpu."
+            assert stream is None or stream == -1, "stream should be None or -1 on cpu."
 
         if self.device.type == "xla":
             import torch_xla


### PR DESCRIPTION
Many extensions (including pybind helpers) call `Tensor.__dlpack__()` without a stream argument. Before #150217, `stream=None` behaved like “no cross-stream sync” and was safe inside CUDA Graph capture. After #150217, `stream=None` maps to the legacy default stream, adding a cross-stream wait that invalidates capture when running on a non-default stream.

See this example

```
import torch
s = torch.cuda.Stream()
x = torch.randn(8, device="cuda")
g = torch.cuda.CUDAGraph()

with torch.cuda.stream(s):
    with torch.cuda.graph(g):
        _ = x + 1
        cap = x.__dlpack__()
        _ = torch.utils.dlpack.from_dlpack(cap)
```

This PR partially reverts #150217 that stream=None defaults to no sync.





cc @mcarilli @ezyang @eellison @penguinwu @BoyuanFeng