### PR TITLE
Add support for name kwarg in mark_dynamic

### DIFF
--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -2,7 +2,6 @@
 This module provides decorators and utilities for controlling TorchDynamo's behavior during compilation.
 """
 
-import collections
 import functools
 import inspect
 import weakref
@@ -646,7 +645,7 @@ def mark_dynamic(
             t._specialize_on = {}
 
         if not hasattr(t, "_dynamo_dynamic_names"):
-            t._dynamo_dynamic_names = collections.defaultdict(lambda: None)
+            t._dynamo_dynamic_names = {}
 
         if hint_override:
             t._dynamo_hint_overrides[index] = hint_override

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -2,6 +2,7 @@
 This module provides decorators and utilities for controlling TorchDynamo's behavior during compilation.
 """
 
+import collections
 import functools
 import inspect
 import weakref
@@ -585,6 +586,7 @@ def mark_dynamic(
     t: Any,
     index: Union[int, list[Any], tuple[Any]],
     *,
+    name: Optional[str] = None,
     hint_override: Optional[int] = None,
     min: Optional[int] = None,
     max: Optional[int] = None,
@@ -643,8 +645,15 @@ def mark_dynamic(
         if not hasattr(t, "_specialize_on"):
             t._specialize_on = {}
 
+        if not hasattr(t, "_dynamo_dynamic_names"):
+            t._dynamo_dynamic_names = collections.defaultdict(lambda: None)
+
         if hint_override:
             t._dynamo_hint_overrides[index] = hint_override
+
+        if name is not None:
+            t._dynamo_dynamic_names[index] = name
+
         # TODO(voz): Should we bounds check?
         t._dynamo_dynamic_indices.add(index)
         t._dynamo_dynamic_range.add(_DimRange(index, min, max))  # type: ignore[arg-type]

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -3447,9 +3447,7 @@ def _automatic_dynamic(
         dynamic_sizes.append(dynamic_size)
         dynamic_strides.append(dynamic_stride)
 
-    dynamic_names = getattr(
-        e, "_dynamo_dynamic_names", collections.defaultdict(lambda: None)
-    )
+    dynamic_names = getattr(e, "_dynamo_dynamic_names", {})
 
     return StatefulSymbolicContext(
         dynamic_sizes=dynamic_sizes,

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -3325,7 +3325,6 @@ def _automatic_dynamic(
         marked_dynamic = i in getattr(e, "_dynamo_dynamic_indices", set())
         marked_weak_dynamic = i in getattr(e, "_dynamo_weak_dynamic_indices", set())
         marked_static = i in getattr(e, "_dynamo_static_indices", set())
-
         specialize_on.append(getattr(e, "_specialize_on", {}).get(i, []))
 
         # Reflect the user directive in the frame_state
@@ -3448,6 +3447,10 @@ def _automatic_dynamic(
         dynamic_sizes.append(dynamic_size)
         dynamic_strides.append(dynamic_stride)
 
+    dynamic_names = getattr(
+        e, "_dynamo_dynamic_names", collections.defaultdict(lambda: None)
+    )
+
     return StatefulSymbolicContext(
         dynamic_sizes=dynamic_sizes,
         dynamic_strides=dynamic_strides,
@@ -3457,6 +3460,7 @@ def _automatic_dynamic(
         view_base_context=view_base_context,
         tensor_source=source,
         shape_env_to_source_to_symbol_cache=shape_env_to_source_to_symbol_cache,
+        dynamic_names=dynamic_names,
     )
 
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -2064,6 +2064,8 @@ class StatelessSymbolicContext(Generic[_P1, _T1], SymbolicContext):
     constraint_sizes: DimList[DimConstraint] = None  # type: ignore[assignment]
     constraint_strides: DimList[DimConstraint] = None  # type: ignore[assignment]
     specialize_on: Optional[list[list[Callable[_P1, _T1]]]] = None
+    # Maps dimension indices to dynamic names for symbol sharing
+    dynamic_names: Optional[dict[int, str]] = None
     # If the tensor is a view, this should be populated for the base. It contains
     # information on how to allocate symbols when recursively fakeifying the base
     # during view fake-ification.
@@ -3702,6 +3704,7 @@ class ShapeEnv:
         # Maps symbolic ints to their original concrete values
         # Currently populated from tensors
         self.var_to_val: dict[sympy.Symbol, sympy.Integer] = {}
+
         # Like var_to_val, but only set when propagate_real_tensors is on.
         # Used as last resort to avoid GuardOnDataDependent error
         self.unbacked_var_to_val: dict[sympy.Symbol, sympy.Integer] = {}
@@ -3734,6 +3737,7 @@ class ShapeEnv:
         # Duck-shaping says that if two input tensors have the same size,
         # they get assigned the same symbolic variable
         self.val_to_var: dict[int, sympy.Symbol] = {}
+        self.name_to_var: dict[str, sympy.Symbol] = {}
         self.unbacked_symfloat_counter = itertools.count()
         self.unbacked_symint_counter = itertools.count()
         # Similar to guards, but these MUST evaluate to true and can
@@ -5008,12 +5012,17 @@ class ShapeEnv:
             raise AssertionError(f"unhandled dynamic_dim {dynamic_dim}")
 
         sloc = self._get_sloc()
+        name = symbolic_context.dynamic_names[source.idx]
 
         if val in (0, 1) and specialize_zero_one:
             if val == 0:
                 return sympy.S.Zero
             else:
                 return sympy.S.One
+        elif name and name in self.name_to_var:
+            r = self.name_to_var[name]
+            self.source_to_var[source_name] = r
+            self.log.debug("create_symbol %s shared via name %s", r, name)
         elif not duck or val not in self.val_to_var:
             # If we're not duck shaping, we always create a new symbol
             # Even if we're duck shaping, if we haven't seen this particular
@@ -5117,6 +5126,8 @@ class ShapeEnv:
                     'TORCHDYNAMO_EXTENDED_ADVICE="0"'
                 )
             sloc, maybe_extra_debug = self._get_stack_summary(is_debug)
+            if name:
+                self.name_to_var[name] = sympy_expr
             self.log.info(
                 "create_symbol %s = %s for %s %s %s%s%s",
                 sympy_expr,

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -5012,7 +5012,14 @@ class ShapeEnv:
             raise AssertionError(f"unhandled dynamic_dim {dynamic_dim}")
 
         sloc = self._get_sloc()
-        name = symbolic_context.dynamic_names[source.idx]
+        name = None
+        if (
+            symbolic_context
+            and hasattr(source, "idx")
+            and symbolic_context.dynamic_names is not None
+            and source.idx in symbolic_context.dynamic_names
+        ):
+            name = symbolic_context.dynamic_names[source.idx]
 
         if val in (0, 1) and specialize_zero_one:
             if val == 0:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #163421
* __->__ #163246

Ergonomic improvement to allow sharing symbols without having to do the complex torch._check paradigm as described by @anijain2305 in his recent UED:

```
Different symbols for KV cached tensors - One property in my case was that the KV cache for different attention blocks had the same seq length, but there is no API to enforce that. The only way is to add torch._check but torch.compile must trace those functions to instruct the dynamic shape infra. This required me to change the model code.
Changing model code is not the best experience. Lets see how transformers maintainers react to my PR. Maybe an API with fullgraph=True is a better bet here.
```

cc @ezyang @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela