### PR TITLE
Better error handling in torch/nativert/*

### DIFF
--- a/torch/nativert/common/FileUtil.cpp
+++ b/torch/nativert/common/FileUtil.cpp
@@ -12,6 +12,7 @@
 #endif
 #include <cerrno>
 
+#include <c10/util/Exception.h>
 #include <fmt/core.h>
 
 namespace torch::nativert {
@@ -130,14 +131,14 @@ File::File(int fd, bool ownsFd) noexcept : fd_(fd), ownsFd_(ownsFd) {
 
 File::File(std::string_view name, int flags, mode_t mode)
     : fd_(::open(std::string(name).c_str(), flags, mode)), ownsFd_(false) {
-  if (fd_ == -1) {
-    throw std::runtime_error(fmt::format(
-        "open(\"{}\", {}, 0{}) failed with errno {}.",
-        name,
-        flags,
-        mode,
-        errno));
-  }
+  TORCH_CHECK(
+      fd_ != -1,
+      fmt::format(
+          "open(\"{}\", {}, 0{}) failed with errno {}.",
+          name,
+          flags,
+          mode,
+          errno));
   ownsFd_ = true;
 }
 
@@ -166,15 +167,11 @@ File::~File() {
 /* static */ File File::temporary() {
   // make a temp file with tmpfile(), dup the fd, then return it in a File.
   FILE* tmpFile = tmpfile();
-  if (!tmpFile) {
-    throw std::runtime_error("tmpfile() failed");
-  }
+  TORCH_CHECK(tmpFile != nullptr, "tmpfile() failed");
   auto guard = c10::make_scope_exit([&]() { fclose(tmpFile); });
 
   int fd = ::dup(fileno(tmpFile));
-  if (fd == -1) {
-    throw std::runtime_error("dup() failed");
-  }
+  TORCH_CHECK(fd != -1, "dup() failed");
 
   return File(fd, true);
 }
@@ -193,9 +190,7 @@ void File::swap(File& other) noexcept {
 }
 
 void File::close() {
-  if (!closeNoThrow()) {
-    throw std::runtime_error("close() failed");
-  }
+  TORCH_CHECK(closeNoThrow(), "close() failed");
 }
 
 [[nodiscard]] bool File::closeNoThrow() {

--- a/torch/nativert/executor/ExecutionFrame.cpp
+++ b/torch/nativert/executor/ExecutionFrame.cpp
@@ -1,4 +1,5 @@
 #include <c10/util/Enumerate.h>
+#include <c10/util/Exception.h>
 #include <c10/util/Logging.h>
 
 #include <torch/nativert/executor/ExecutionFrame.h>
@@ -156,11 +157,8 @@ void ExecutionFrame::setBorrowedIValue(ValueId id, c10::IValue ivalue) {
 
 at::Tensor ExecutionFrame::getTensor(ValueId id) const {
   const auto& ivalue = getIValue(id);
-  if (C10_LIKELY(ivalue.isTensor())) {
-    return ivalue.toTensor();
-  } else {
-    throw std::runtime_error("getTensor called on non-tensor value");
-  }
+  TORCH_CHECK(ivalue.isTensor(), "getTensor called on non-tensor value");
+  return ivalue.toTensor();
 }
 
 std::vector<c10::IValue> ExecutionFrame::tryMoveUserOutputs() {

--- a/torch/nativert/executor/triton/CpuTritonKernelManager.cpp
+++ b/torch/nativert/executor/triton/CpuTritonKernelManager.cpp
@@ -1,5 +1,6 @@
 #include <torch/nativert/executor/triton/TritonKernelManager.h>
 
+#include <c10/util/Exception.h>
 #include <c10/util/FbcodeMaps.h>
 #include <c10/util/Logging.h>
 
@@ -28,7 +29,8 @@ void* _dlsym(void* handle, const char* name) {
 
 char* _dlerror() {
 #if defined(_WIN32)
-  throw std::runtime_error("dlerror not supported on Windows");
+  TORCH_CHECK(false, "dlerror not supported on Windows");
+  return nullptr; // This line will never be reached, but needed for compilation
 #else
   return dlerror();
 #endif

--- a/torch/nativert/graph/passes/SubgraphRewriter.cpp
+++ b/torch/nativert/graph/passes/SubgraphRewriter.cpp
@@ -1,8 +1,9 @@
 #include <variant>
 
+#include <c10/util/Exception.h>
+#include <fmt/core.h>
 #include <torch/nativert/graph/Graph.h>
 #include <torch/nativert/graph/passes/SubgraphRewriter.h>
-
 namespace torch::nativert {
 
 const std::string kDummyTarget = "dummy";
@@ -66,7 +67,12 @@ bool compareConstants(const Constant& a, const Constant& b) {
         // Unsupported types (Graph)
         LOG(ERROR) << "Unsupported Constant types for pattern matching: "
                    << typeid(lhs).name() << " vs " << typeid(rhs).name();
-        throw std::runtime_error("Unsupported Constant types.");
+        TORCH_CHECK(
+            false,
+            fmt::format(
+                "Unsupported Constant types for pattern matching: {} vs {}",
+                typeid(lhs).name(),
+                typeid(rhs).name()))
       },
       a,
       b);

--- a/torch/nativert/graph/passes/pass_manager/GraphPassRegistry.h
+++ b/torch/nativert/graph/passes/pass_manager/GraphPassRegistry.h
@@ -3,9 +3,10 @@
 #include <functional>
 #include <map>
 
+#include <c10/util/Exception.h>
 #include <c10/util/Logging.h>
+#include <fmt/core.h>
 #include <torch/nativert/graph/Graph.h>
-
 namespace torch::nativert {
 
 using PassSignature = std::function<bool(Graph*)>;
@@ -63,9 +64,9 @@ class GraphPassRegistry {
 
   const GraphPass& get_pass(const GraphPassIdentifier& name) {
     auto it = registry_.find(name);
-    if (it == registry_.end()) {
-      throw std::runtime_error("Pass " + name + " not registered to get");
-    }
+    TORCH_CHECK(
+        it != registry_.end(),
+        fmt::format("Pass {} not registered to get", name));
     return it->second;
   }
 

--- a/torch/nativert/kernels/AutoFunctionalizeKernel.cpp
+++ b/torch/nativert/kernels/AutoFunctionalizeKernel.cpp
@@ -3,6 +3,7 @@
 #include <fmt/format.h>
 
 #include <c10/util/Enumerate.h>
+#include <c10/util/Exception.h>
 
 namespace torch::nativert {
 
@@ -37,10 +38,12 @@ void UnsafeAutoFunctionalizeKernel::computeInternal(
     // IndexError, ValueError). If retaining this information is important
     // to us, we'll have to change this up a little.
     auto stackTrace = node_->getMetadata("stack_trace");
-    throw std::runtime_error(fmt::format(
-        "Original Python stacktrace:\n{}\n{}",
-        stackTrace ? *stackTrace : "<no stack trace>",
-        ex.what()));
+    TORCH_CHECK(
+        false,
+        fmt::format(
+            "Original Python stacktrace:\n{}\n{}",
+            stackTrace ? *stackTrace : "<no stack trace>",
+            ex.what()));
   }
 
   const auto& outputValues = node_->outputs();

--- a/torch/nativert/kernels/HigherOrderKernel.cpp
+++ b/torch/nativert/kernels/HigherOrderKernel.cpp
@@ -2,6 +2,7 @@
 
 #include <fmt/format.h>
 
+#include <c10/util/Exception.h>
 #include <c10/util/string_view.h>
 
 namespace torch::nativert {
@@ -34,8 +35,7 @@ HigherOrderKernel::HigherOrderKernel(
     TORCH_CHECK(!node_->attributes().empty());
     TORCH_CHECK(node_->inputs().size() == 1);
   } else {
-    throw std::runtime_error(
-        fmt::format("Unknown higher order op: {}", opName));
+    TORCH_CHECK(false, fmt::format("Unknown higher order op: {}", opName));
   }
 }
 
@@ -53,7 +53,7 @@ void HigherOrderKernel::computeInternal(ExecutionFrame& executionFrame) const {
       } else if (cond.isBool()) {
         branchIdx = cond.toBool() ? 0 : 1;
       } else {
-        throw std::runtime_error("Unsupported type for cond predicate");
+        TORCH_CHECK(false, "Unsupported type for cond predicate");
       }
       ExecutionFrame branchFrame(*std::get<std::unique_ptr<Graph>>(
           node_->attributes()[branchIdx].value));


### PR DESCRIPTION
Replace the **runtime_error** of the vallina C++ exceptions with **TORCH_CEHCK** in torch/nativert/*

The vallina C++ exception should not exist in the core part of pytorch for its corss-languanges trait. Comparing with the vallina C++ exceptions, TORCH_CHECK have the richer error context and It has the unified error handling mechanism. This commit replace the runtime_error with TORCH_CHECK of the files in torch/nativert/*   .

Fixes part of #148114

@pytorchbot label "topic: not user facing"