### PR TITLE
[export] add node.meta["val"] when HOO's output is empty

### DIFF
--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -2717,6 +2717,10 @@ class GraphModuleDeserializer(metaclass=Final):
     def deserialize_outputs(self, serialized_node: Node, fx_node: torch.fx.Node):
         # Check single value return
         if len(serialized_node.outputs) == 0:
+            if isinstance(
+                fx_node.target, torch._higher_order_ops.wrap.WrapWithSetGradEnabled
+            ):
+                fx_node.meta["val"] = tuple()
             return
 
         if (


### PR DESCRIPTION
Summary: as title. Otherwise the verifier will complain that node.meta has no val

Test Plan: 

Differential Revision: D82691627


