### PR TITLE
support a few features for vllm inductor precompile

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -20,7 +20,11 @@ from torch._dynamo.package import DynamoCache
 from torch._dynamo.precompile_context import PrecompileContext
 from torch._dynamo.utils import counters
 from torch._functorch import config as functorch_config
-from torch._functorch._aot_autograd.autograd_cache import AOTAutogradCache
+from torch._functorch._aot_autograd.autograd_cache import (
+    AOTAutogradCache,
+    BundledAOTAutogradCacheEntry,
+    deserialize_bundled_cache_entry,
+)
 from torch._inductor import config, metrics
 from torch._inductor.codecache import (
     BypassFxGraphCache,
@@ -1886,6 +1890,64 @@ class TestStandaloneCompile(TestCase):
                 self.assertEqual(eager_out, compiled_out)
 
             self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
+
+    @config.patch({"fx_graph_cache": True})
+    @config.patch({"fx_graph_remote_cache": False})
+    @functorch_config.patch({"enable_autograd_cache": True})
+    @parametrize("device", (GPU_TYPE, "cpu"))
+    @parametrize("format", ("binary", "unpacked"))
+    @parametrize("dynamic", (False, True))
+    @parametrize("graph_partition", (False, True))
+    def test_basic_nosave(
+        self, device: str, format: str, dynamic: bool, graph_partition: bool
+    ) -> None:
+        if device == GPU_TYPE and not HAS_GPU:
+            raise unittest.SkipTest(f"requires {GPU_TYPE}")
+
+        mod = torch.nn.Linear(1, 3, device=device)
+        x = torch.randn(4, 1, device=device)
+        if dynamic:
+            torch._dynamo.mark_dynamic(x, 0)
+
+        def f(x):
+            with torch.no_grad():
+                return mod(x), x.sin()
+
+        eager_out = f(x)
+
+        with (
+            config.patch(graph_partition=graph_partition),
+        ):
+            pickled = None
+
+            with fresh_cache():
+                gm, args, kwargs = self.capture(f)(x)
+                assert not kwargs
+
+                with torch._functorch.config.patch("bundled_autograd_cache", True):
+                    fn = torch._inductor.standalone_compile(
+                        gm, args, options={"save_artifacts": False}
+                    )
+                    entry = fn.serialize()
+                    entry.pre_save()
+                    pickled = pickle.dumps(entry)
+
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+
+            with fresh_cache():
+                entry_loaded = pickle.loads(pickled)
+                assert isinstance(entry_loaded, BundledAOTAutogradCacheEntry)
+                loaded = deserialize_bundled_cache_entry(entry_loaded)
+                if dynamic:
+                    concrete_args = [
+                        4 if isinstance(a, torch.SymInt) else a for a in args
+                    ]
+                else:
+                    concrete_args = args
+                compiled_out = loaded(*concrete_args)
+                self.assertEqual(eager_out, compiled_out)
+
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
 
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -537,6 +537,8 @@ class CompiledFxGraphLoadable(InductorOutput[CompiledFxGraph]):
         disk_compiled_graph = copy(self.result)
         disk_compiled_graph.prepare_for_serialization()
         self.result = disk_compiled_graph
+        # this will have faketensor which isn't serializable
+        self.example_inputs = None
         return
 
     def load(self, example_inputs) -> CompiledFxGraph:
@@ -561,7 +563,7 @@ class CompiledFxGraphLoadable(InductorOutput[CompiledFxGraph]):
             payload_fn=lambda: json.dumps(cache_info),
         )
         # Run normal post compile
-        graph.post_compile(self.example_inputs, constants, fx_config)
+        graph.post_compile(self.example_inputs, constants, fx_config)  # type: ignore[arg-type]
         return graph
 
 
@@ -571,6 +573,8 @@ class FxGraphCacheLoadable(InductorOutput[CompiledFxGraph]):
     fx_graph_guard_expr: Optional[str]
 
     def pre_save(self):
+        # this will have faketensor which isn't serializable
+        self.example_inputs = None
         return
 
     def _is_backward(self) -> bool:
@@ -647,7 +651,7 @@ class FxGraphCacheLoadable(InductorOutput[CompiledFxGraph]):
         """
         Called after FXGraphCacheLoadable.load, mutates fx_config
         """
-        result.post_compile(self.example_inputs, self.constants, fx_config)
+        result.post_compile(self.example_inputs, self.constants, fx_config)  # type: ignore[arg-type]
         return result
 
 

--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import io
 import logging
 import os
-from typing import Any, IO, Literal, Optional, TYPE_CHECKING, Union
+from typing import Any, Callable, IO, Literal, Optional, TYPE_CHECKING, Union
 
 import torch.fx
 
@@ -391,7 +391,7 @@ def standalone_compile(
         "from_example_inputs", "from_tracing_context", "from_graph"
     ] = "from_graph",
     options: Optional[dict[str, Any]] = None,
-) -> CompiledArtifact:
+) -> CompiledArtifact | Callable[..., Any]:
     """
     Precompilation API for inductor.
 
@@ -416,7 +416,8 @@ def standalone_compile(
         options: Inductor compilation options
 
     Returns:
-        CompiledArtifact that can be saved to disk or invoked directly.
+        CompiledArtifact that can be saved to disk or invoked directly,
+        or a callable if options["save_artifacts"] is set to false.
     """
     from .standalone_compile import standalone_compile
 


### PR DESCRIPTION
add support to directly serialize to byes and deserialize from bytes so we can store in vllm's serializable callable.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben