### PR TITLE
Raise TypeError in torch.export.load when input isn't a file or buffer

### DIFF
--- a/torch/export/pt2_archive/_package.py
+++ b/torch/export/pt2_archive/_package.py
@@ -989,18 +989,20 @@ def load_pt2(
 
     from torch._inductor.cpp_builder import normalize_path_separator
 
-    if not (
-        (isinstance(f, (io.IOBase, IO)) and f.readable() and f.seekable())
-        or (isinstance(f, (str, os.PathLike)) and os.fspath(f).endswith(".pt2"))
-    ):
-        # TODO: turn this into an error in 2.9
-        logger.warning(
-            "Unable to load package. f must be a buffer or a file ending in "
-            ".pt2. Instead got {%s}",
-            f,
+    is_buffer = isinstance(f, (io.IOBase, IO))
+    is_path = isinstance(f, (str, os.PathLike))
+
+    if not ((is_buffer and f.readable() and f.seekable()) or is_path):
+        raise TypeError(
+            "Unable to load package. `f` must be a buffer (i.e. a readable and "
+            "seekable file-like object) or a string path. "
+            f"Instead got {type(f).__name__}."
         )
 
-    if isinstance(f, (str, os.PathLike)):
+    if is_path and not os.fspath(f).endswith(".pt2"):
+        logger.warning("Path does not end with .pt2; proceeding anyway: {%s}", f)
+
+    if is_path:
         f = os.fspath(f)
 
     weights = {}


### PR DESCRIPTION
Fixes #163040 

Replaces a vague AttributeError with a clearer TypeError when torhc.export.load( ) is misused. For example, calling it with an ExportedProgram now raises immediately insteald of hitting .tell() downstream. The check I added matches the existed warning and turns it into a proper error as suggested in the TODO comment that existed before my change.
