### PR TITLE
[DTensor] Fix adding Partial(sum) with Scalar

### DIFF
--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -61,7 +61,7 @@ def add_scalar_handler(
     kwargs: dict[str, object],
 ) -> object:
     assert add_handler_predicate(op_call, args, kwargs)
-    new_args = (args[0], torch.tensor(args[1]))
+    new_args = (args[0], torch.tensor(args[1], device=args[0].device))  # type: ignore[attr-defined]
     return op_call(*new_args, **kwargs)
 
 


### PR DESCRIPTION
Fixes #163193

When adding Partial(Sum) with a ScalarTensor, a few thing are happening
1. ScalarTensor is auto converted as Replicated DTensor
2. Propagator decide to redistribute R -> Partial(sum)
3. This result as the div by num_shards
```
    aten::add.Tensor(dt: f32[][P], t: i64[])
      redistribute_input(1, [R] -> [P])
        aten::div.Tensor(t: i64[], 4)
      aten::add.Tensor(t: f32[], t: f32[])
```

When adding Partial(Sum) with a Scalar
1. Scalar remains as scalar 
2. Propagator only sees a single Partial DTensor, and sets output placement also as Partial
3. As a result, scalar is added locally in all ranks, resulting in a wrong global result.
```
    aten::add.Tensor(dt: f32[][P], 2)
      aten::add.Tensor(t: f32[], 2)
```

In contrast, aten.sub(Partial, ScalarTensor) would redistribute Partial tensor as Replicate first. Although, it could have follow the same strategy used in aten.add. 
```
    aten::sub.Tensor(dt: f32[][P], t: i64[])
      redistribute_input(0, [P] -> [R])
        _c10d_functional::all_reduce(t: f32[], sum, 0)
        _c10d_functional::wait_tensor(t: f32[])
      aten::sub.Tensor(t: f32[], t: i64[])
```
cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci