### PR TITLE
Change DebugMode record_torchfunction default to False

### DIFF
--- a/test/distributed/tensor/debug/test_debug_mode.py
+++ b/test/distributed/tensor/debug/test_debug_mode.py
@@ -41,7 +41,7 @@ class TestDTensorDebugMode(TestCase):
         x_dtensor = DTensor.from_local(x, mesh, [Shard(0)], run_check=False)
         y_dtensor = DTensor.from_local(y, mesh, [Shard(0)], run_check=False)
 
-        with DebugMode() as debug_mode:
+        with DebugMode(record_torchfunction=True) as debug_mode:
             torch.mm(x_dtensor, y_dtensor).sum()
 
         self.assertExpectedInline(
@@ -80,7 +80,7 @@ class TestDTensorDebugMode(TestCase):
         x_dtensor = DTensor.from_local(x, mesh, [Shard(0)], run_check=False)
         y_dtensor = DTensor.from_local(y, mesh, [Shard(1)], run_check=False)
 
-        with DebugMode() as debug_mode:
+        with DebugMode(record_torchfunction=True) as debug_mode:
             z = x_dtensor + y_dtensor
             z.sum().backward()
 
@@ -121,7 +121,7 @@ class TestDTensorDebugMode(TestCase):
         b_dt = DTensor.from_local(b, mesh, [Replicate(), Partial()], run_check=False)
 
         # Capture the operator decomposition
-        with DebugMode() as debug_mode:
+        with DebugMode(record_torchfunction=True) as debug_mode:
             torch.einsum("bld,dnh->blnh", a_dt, b_dt)
 
         self.assertExpectedInline(
@@ -174,7 +174,7 @@ class TestDTensorDebugMode(TestCase):
         x = torch.randn(8, 8, 8)
         linear = torch.nn.Linear(8, 8)
 
-        with DebugMode() as debug_mode:
+        with DebugMode(record_torchfunction=True) as debug_mode:
             linear(x).sum()
 
         self.assertExpectedInline(
@@ -194,7 +194,7 @@ class TestDTensorDebugMode(TestCase):
             x = torch.randn(8, 8)
             y = torch.randn(8, 8, 8)
 
-        with DebugMode(record_faketensor=True) as debug_mode:
+        with DebugMode(record_torchfunction=True, record_faketensor=True) as debug_mode:
             torch.matmul(y, x)
 
         self.assertExpectedInline(

--- a/torch/utils/debug_mode.py
+++ b/torch/utils/debug_mode.py
@@ -81,7 +81,7 @@ class DebugMode(TorchDispatchMode):
     def __init__(
         self,
         *,
-        record_torchfunction=True,
+        record_torchfunction=False,
         record_faketensor=False,
         record_realtensor=True,
     ):


### PR DESCRIPTION
Result is too noisy with `record_torchfunction = True`. Change it to False, to make it clean. 

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci