### PR TITLE
[export] Fix wrap_with_set_grad_enabled retracing

### DIFF
--- a/torch/_higher_order_ops/wrap.py
+++ b/torch/_higher_order_ops/wrap.py
@@ -52,8 +52,11 @@ class WrapWithSetGradEnabled(HigherOrderOperator):
 
         @disable
         def wrapper():
-            with torch.set_grad_enabled(enable_grad):
-                return wrapped_func(*args, **kwargs)
+            prev = torch.is_grad_enabled()
+            torch.set_grad_enabled(enable_grad)
+            res = wrapped_func(*args, **kwargs)
+            torch.set_grad_enabled(prev)
+            return res
 
         return wrapper()
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/163294

The code `with torch.set_grad_enabled(enable_grad)` calls `torch._C._set_grad_enabled` three times -- (1) when [initializing set_grad_enabled](https://github.com/pytorch/pytorch/blob/bb7c9a2d4127ff178fe8787caf070d7072d015b6/torch/autograd/grad_mode.py#L187C9-L187C35), (2) when [entering the context](https://github.com/pytorch/pytorch/blob/bb7c9a2d4127ff178fe8787caf070d7072d015b6/torch/autograd/grad_mode.py#L194), and (3) when [exiting the context](https://github.com/pytorch/pytorch/blob/bb7c9a2d4127ff178fe8787caf070d7072d015b6/torch/autograd/grad_mode.py#L197). 

This results in the the retraced export module to have a duplicate `torch._C._set_grad_enabled` like:
```
def forward(self, arg0_1):
    add = torch.ops.aten.add.Tensor(arg0_1, 1);  arg0_1 = None
    _set_grad_enabled = torch._C._set_grad_enabled(False);  _set_grad_enabled = None
    _set_grad_enabled = torch._C._set_grad_enabled(False);  _set_grad_enabled = None
    add_1 = torch.ops.aten.add.Tensor(add, 2);  add = None
    _set_grad_enabled_1 = torch._C._set_grad_enabled(True);  _set_grad_enabled_1 = None
    add_2 = torch.ops.aten.add.Tensor(add_1, 3);  add_1 = None
    return (add_2,)
```

When export runs the `replace_set_grad_with_hop_pass`, it will look through the graph for `torch._C._set_grad_enabled` and create subgraphs. The duplicate `torch._C._set_grad_enabled` results in an empty submod in the graph, which resulted in an error in [this post](https://fb.workplace.com/groups/1028545332188949/posts/1844720036398281/?comment_id=1862175381319413). 