### PR TITLE
[testing] Add test owner labels for some cuda? tests

### DIFF
--- a/test/test_kernel_launch_checks.py
+++ b/test/test_kernel_launch_checks.py
@@ -1,4 +1,4 @@
-# Owner(s): ["module: unknown"]
+# Owner(s): ["module: cuda"]
 
 from torch.testing._internal.common_utils import TestCase, run_tests
 from torch.testing._internal.check_kernel_launches import (

--- a/test/test_numba_integration.py
+++ b/test/test_numba_integration.py
@@ -1,4 +1,4 @@
-# Owner(s): ["module: unknown"]
+# Owner(s): ["module: cuda"]
 
 import unittest
 


### PR DESCRIPTION
I am trying to give some test files better owner labels than `module: unknown`.  I am not sure them, but they seem pretty reasonable

cc @ptrblck @msaroufim @eqy @jerryzh168