### PR TITLE
[CUDA][Expandable Segments] Follow-up cleanups for even more expandable segments tests

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -3118,6 +3118,8 @@ class DeviceCachingAllocator {
 
     bool active_pool =
         p.pool->owner_PrivatePool && p.pool->owner_PrivatePool->allocator();
+    TORCH_WARN(total_allocated_memory + size);
+    TORCH_WARN(allowed_memory_maximum);
     if (set_fraction &&
         total_allocated_memory + size > allowed_memory_maximum) {
       p.err = cudaErrorMemoryAllocation;

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -3118,8 +3118,6 @@ class DeviceCachingAllocator {
 
     bool active_pool =
         p.pool->owner_PrivatePool && p.pool->owner_PrivatePool->allocator();
-    TORCH_WARN(total_allocated_memory + size);
-    TORCH_WARN(allowed_memory_maximum);
     if (set_fraction &&
         total_allocated_memory + size > allowed_memory_maximum) {
       p.err = cudaErrorMemoryAllocation;

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4396,7 +4396,6 @@ class TestCudaMallocAsync(TestCase):
             _, all_memory = torch.cuda.memory.mem_get_info()
             pre_reserved = torch.cuda.memory_reserved()
             total_allowed = 120 * mb + pre_reserved
-            print(total_allowed)
             fraction_allowed = total_allowed / all_memory
             self.assertEqual(int(round(fraction_allowed * all_memory)), total_allowed)
             torch.cuda.memory.set_per_process_memory_fraction(fraction_allowed)


### PR DESCRIPTION
Gets original setting even earlier in case of crashes, fixes previous get call where set should be 

cc @ptrblck @msaroufim @jerryzh168 @mruberry