### PR TITLE
[CUDA] Cleanup persistent cuBLASLt workspaces before compile-regions test

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4305,7 +4305,6 @@ class TestCudaMallocAsync(TestCase):
             pass
         finally:
             torch.cuda.memory._record_memory_history(None)
-            torch._C._cuda_clearCublasWorkspaces()
 
     @unittest.skipIf(
         TEST_CUDAMALLOCASYNC, "setContextRecorder not supported by CUDAMallocAsync"
@@ -4352,6 +4351,7 @@ class TestCudaMallocAsync(TestCase):
     def test_memory_plots_free_segment_stack(self):
         for context in ["alloc", "all", "state"]:
             try:
+                torch._C._cuda_clearCublasWorkspaces()
                 torch.cuda.memory.empty_cache()
                 torch.cuda.memory._record_memory_history(context=context)
                 x = torch.rand(3, 4, device="cuda")
@@ -4368,6 +4368,7 @@ class TestCudaMallocAsync(TestCase):
     )
     def test_memory_snapshot_script(self):
         try:
+            torch._C._cuda_clearCublasWorkspaces()
             torch.cuda.memory.empty_cache()
             torch.cuda.memory._record_memory_history("state", stacks="python")
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4249,6 +4249,7 @@ class TestCudaMallocAsync(TestCase):
     )
     @unittest.skipIf(not has_triton(), "test needs triton")
     @requiresCppContext
+    @serialTest()
     def test_memory_compile_regions(self):
         expected_allocation_sequence = [
             "Torch-Compiled Region: 0/0",
@@ -4304,6 +4305,7 @@ class TestCudaMallocAsync(TestCase):
             pass
         finally:
             torch.cuda.memory._record_memory_history(None)
+            torch._C._cuda_clearCublasWorkspaces()
 
     @unittest.skipIf(
         TEST_CUDAMALLOCASYNC, "setContextRecorder not supported by CUDAMallocAsync"


### PR DESCRIPTION
Fixes some tests that seemed to start flaking out as reported in #163202, due to cuBLASLt workspaces becoming persistent following that change.

It's relatively obvious why the workspaces/allocations corresponding to them should be cleaned up for `test_memory_snapshot_script` but less obvious for `test_memory_plots_free_segment_stack`?  Why does not cleaning up workspace prevent `empty_cache` from showing up?



cc @ptrblck @msaroufim @jerryzh168 @mruberry @csarofeen @xwang233