### PR TITLE
Better error handling in torch/nativert/*

### DIFF
--- a/torch/nativert/executor/ExecutionFrame.cpp
+++ b/torch/nativert/executor/ExecutionFrame.cpp
@@ -1,4 +1,5 @@
 #include <c10/util/Enumerate.h>
+#include <c10/util/Exception.h>
 #include <c10/util/Logging.h>
 
 #include <torch/nativert/executor/ExecutionFrame.h>
@@ -156,11 +157,8 @@ void ExecutionFrame::setBorrowedIValue(ValueId id, c10::IValue ivalue) {
 
 at::Tensor ExecutionFrame::getTensor(ValueId id) const {
   const auto& ivalue = getIValue(id);
-  if (C10_LIKELY(ivalue.isTensor())) {
-    return ivalue.toTensor();
-  } else {
-    throw std::runtime_error("getTensor called on non-tensor value");
-  }
+  TORCH_CHECK(ivalue.isTensor(), "getTensor called on non-tensor value");
+  return ivalue.toTensor();
 }
 
 std::vector<c10::IValue> ExecutionFrame::tryMoveUserOutputs() {

--- a/torch/nativert/executor/triton/CpuTritonKernelManager.cpp
+++ b/torch/nativert/executor/triton/CpuTritonKernelManager.cpp
@@ -1,5 +1,6 @@
 #include <torch/nativert/executor/triton/TritonKernelManager.h>
 
+#include <c10/util/Exception.h>
 #include <c10/util/FbcodeMaps.h>
 #include <c10/util/Logging.h>
 
@@ -28,7 +29,7 @@ void* _dlsym(void* handle, const char* name) {
 
 char* _dlerror() {
 #if defined(_WIN32)
-  throw std::runtime_error("dlerror not supported on Windows");
+  TORCH_CHECK(false, "dlerror not supported on Windows");
 #else
   return dlerror();
 #endif

--- a/torch/nativert/graph/passes/SubgraphRewriter.cpp
+++ b/torch/nativert/graph/passes/SubgraphRewriter.cpp
@@ -1,8 +1,8 @@
 #include <variant>
 
+#include <c10/util/Exception.h>
 #include <torch/nativert/graph/Graph.h>
 #include <torch/nativert/graph/passes/SubgraphRewriter.h>
-
 namespace torch::nativert {
 
 const std::string kDummyTarget = "dummy";
@@ -66,7 +66,12 @@ bool compareConstants(const Constant& a, const Constant& b) {
         // Unsupported types (Graph)
         LOG(ERROR) << "Unsupported Constant types for pattern matching: "
                    << typeid(lhs).name() << " vs " << typeid(rhs).name();
-        throw std::runtime_error("Unsupported Constant types.");
+        TORCH_CHECK(
+            false,
+            "Unsupported Constant types for pattern matching: ",
+            typeid(lhs).name(),
+            " vs ",
+            typeid(rhs).name())
       },
       a,
       b);

--- a/torch/nativert/graph/passes/pass_manager/GraphPassRegistry.h
+++ b/torch/nativert/graph/passes/pass_manager/GraphPassRegistry.h
@@ -3,9 +3,9 @@
 #include <functional>
 #include <map>
 
+#include <c10/util/Exception.h>
 #include <c10/util/Logging.h>
 #include <torch/nativert/graph/Graph.h>
-
 namespace torch::nativert {
 
 using PassSignature = std::function<bool(Graph*)>;
@@ -63,9 +63,7 @@ class GraphPassRegistry {
 
   const GraphPass& get_pass(const GraphPassIdentifier& name) {
     auto it = registry_.find(name);
-    if (it == registry_.end()) {
-      throw std::runtime_error("Pass " + name + " not registered to get");
-    }
+    TORCH_CHECK(it != registry_.end(), "Pass ", name, " not registered to get");
     return it->second;
   }
 

--- a/torch/nativert/kernels/AutoFunctionalizeKernel.cpp
+++ b/torch/nativert/kernels/AutoFunctionalizeKernel.cpp
@@ -1,8 +1,7 @@
 #include <torch/nativert/kernels/AutoFunctionalizeKernel.h>
 
-#include <fmt/format.h>
-
 #include <c10/util/Enumerate.h>
+#include <c10/util/Exception.h>
 
 namespace torch::nativert {
 
@@ -37,10 +36,12 @@ void UnsafeAutoFunctionalizeKernel::computeInternal(
     // IndexError, ValueError). If retaining this information is important
     // to us, we'll have to change this up a little.
     auto stackTrace = node_->getMetadata("stack_trace");
-    throw std::runtime_error(fmt::format(
-        "Original Python stacktrace:\n{}\n{}",
+    TORCH_CHECK(
+        false,
+        "Oringinal Python stacktrace:\n",
         stackTrace ? *stackTrace : "<no stack trace>",
-        ex.what()));
+        "\n",
+        ex.what())
   }
 
   const auto& outputValues = node_->outputs();

--- a/torch/nativert/kernels/C10Kernel.cpp
+++ b/torch/nativert/kernels/C10Kernel.cpp
@@ -3,6 +3,7 @@
 #include <fmt/ostream.h>
 
 #include <c10/util/Enumerate.h>
+#include <c10/util/Exception.h>
 
 #ifdef __SIGRID_USE_GPU__
 #include <ATen/cuda/CUDAContext.h>
@@ -31,15 +32,18 @@ void C10Kernel::computeInternal(ExecutionFrame& executionFrame) const {
     op_.callBoxed(stack);
   } catch (const std::exception& ex) {
     auto stackTrace = node_->getMetadata("stack_trace");
-    throw std::runtime_error(fmt::format(
-        "Exception while executing node: {}\n"
-        "with args:\n{}\n"
-        "{}\n"
-        "Original Python stacktrace:\n{}",
-        fmt::streamed(*node_),
+    TORCH_CHECK(
+        false,
+        "Exception while executing node: ",
+        *node_,
+        "\n"
+        "with args:\n",
         readableArgs(op_.schema(), stack),
+        "\n",
         ex.what(),
-        stackTrace ? *stackTrace : "<no stack trace>"));
+        "\n",
+        "Original Python stacktrace:\n",
+        stackTrace ? *stackTrace : "<no stack trace>")
   }
 
   // Write out results
@@ -67,7 +71,7 @@ std::unordered_map<std::string, c10::IValue> getSymInputs(
     if (val.isInt() || val.isDouble() || val.isBool()) {
       inputs[input.name] = val;
     } else {
-      throw std::runtime_error("unsupported type for symbolic input");
+      TORCH_CHECK(false, "unsupported type for symbolic input");
     }
   }
   for (const auto& attribute : node.attributes()) {
@@ -78,7 +82,7 @@ std::unordered_map<std::string, c10::IValue> getSymInputs(
     } else if (std::holds_alternative<bool>(attribute.value)) {
       inputs[attribute.name] = std::get<bool>(attribute.value);
     } else {
-      throw std::runtime_error("unsupported type for symbolic input");
+      TORCH_CHECK(false, "unsupported type for symbolic input");
     }
   }
   return inputs;
@@ -102,8 +106,7 @@ void computeScalarBinaryOp(
   } else if (target == "_operator.pow") {
     out = std::pow(a, b);
   } else {
-    throw std::runtime_error(
-        fmt::format("unsupported operator for symbolic values: {}", target));
+    TORCH_CHECK(false, "unsupported operator for scalar binary op: ", target);
   }
 
   executionFrame.setIValue(node.outputs()[0]->id(), out);
@@ -130,7 +133,7 @@ void ScalarBinaryOpKernel::computeInternal(
     } else if (x.isDouble()) {
       return x.toDouble();
     } else {
-      throw std::runtime_error("unsupported type for symbolic input");
+      TORCH_CHECK(false, "unsupported type for symbolic input");
     }
   };
 
@@ -171,8 +174,7 @@ void SymIntOpKernel::computeInternal(ExecutionFrame& executionFrame) const {
   } else if (target == "torch.sym_min") {
     out = std::min(a, b);
   } else {
-    throw std::runtime_error(
-        fmt::format("unsupported operator for SymInt: {}", node_->target()));
+    TORCH_CHECK(false, "unsupported operator for SymInt: ", node_->target())
   }
 
   executionFrame.setIValue(node_->outputs()[0]->id(), out);
@@ -219,8 +221,7 @@ void SymBoolOpKernel::computeInternal(ExecutionFrame& executionFrame) const {
     bool b = inputs.at("b").toBool();
     out = a && b;
   } else {
-    throw std::runtime_error(
-        fmt::format("unsupported operator for SymBool: {}", node_->target()));
+    TORCH_CHECK(false, "unsupported operator for SymBool: ", node_->target())
   }
 
   executionFrame.setIValue(node_->outputs()[0]->id(), out);
@@ -247,7 +248,7 @@ void SymFloatOpKernel::computeInternal(ExecutionFrame& executionFrame) const {
     } else if (a.isDouble()) {
       out = -a.toDouble();
     } else {
-      throw std::runtime_error("unsupported type for symbolic input");
+      TORCH_CHECK(false, "unsupported type for symbolic input");
     }
     executionFrame.setIValue(node_->outputs()[0]->id(), out);
   } else if (target == "_operator.truediv") {
@@ -258,9 +259,7 @@ void SymFloatOpKernel::computeInternal(ExecutionFrame& executionFrame) const {
     double out = a / b;
     executionFrame.setIValue(node_->outputs()[0]->id(), out);
   } else {
-    throw std::runtime_error(
-        fmt::format("unsupported operator for SymFloat: {}", node_->target()));
+    TORCH_CHECK(false, "unsupported operator for SymFloat: ", node_->target());
   }
 }
-
 } // namespace torch::nativert

--- a/torch/nativert/kernels/HigherOrderKernel.cpp
+++ b/torch/nativert/kernels/HigherOrderKernel.cpp
@@ -1,7 +1,6 @@
 #include <torch/nativert/kernels/HigherOrderKernel.h>
 
-#include <fmt/format.h>
-
+#include <c10/util/Exception.h>
 #include <c10/util/string_view.h>
 
 namespace torch::nativert {
@@ -34,8 +33,7 @@ HigherOrderKernel::HigherOrderKernel(
     TORCH_CHECK(!node_->attributes().empty());
     TORCH_CHECK(node_->inputs().size() == 1);
   } else {
-    throw std::runtime_error(
-        fmt::format("Unknown higher order op: {}", opName));
+    TORCH_CHECK(false, "Unknown higher order op: ", opName);
   }
 }
 
@@ -53,7 +51,7 @@ void HigherOrderKernel::computeInternal(ExecutionFrame& executionFrame) const {
       } else if (cond.isBool()) {
         branchIdx = cond.toBool() ? 0 : 1;
       } else {
-        throw std::runtime_error("Unsupported type for cond predicate");
+        TORCH_CHECK(false, "Unsupported type for cond predicate");
       }
       ExecutionFrame branchFrame(*std::get<std::unique_ptr<Graph>>(
           node_->attributes()[branchIdx].value));


### PR DESCRIPTION
Replace the **runtime_error** of the vallina C++ exceptions with **TORCH_CEHCK** in **torch/nativert/***

The vallina C++ exception should not exist in the core part of pytorch for its corss-languanges trait. Comparing with the vallina C++ exceptions, TORCH_CHECK have the richer error context and It has the unified error handling mechanism. This commit replace the runtime_error with TORCH_CHECK of the files in
torch/nativert/*   .

Fixes part of #148114
