### PR TITLE
Remove autograd code for Python < 3.9

### DIFF
--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -57,10 +57,6 @@ PythonEngine::~PythonEngine() {
   Engine::stop();
 }
 
-#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 9
-#define IS_PYTHON_3_9_PLUS
-#endif
-
 void PythonEngine::thread_init(
     int device,
     const std::shared_ptr<ReadyQueue>& ready_queue,
@@ -72,11 +68,7 @@ void PythonEngine::thread_init(
   // Create a PyThreadState, but release the GIL. This lets
   // pybind11::gil_scoped_acquire calls inside thread_main acquire the GIL
   // without having to create a new PyThreadState each time.
-#if defined(IS_PYTHON_3_9_PLUS)
   auto gil = std::make_unique<pybind11::gil_scoped_acquire>();
-#else
-  pybind11::gil_scoped_acquire gil;
-#endif
   pybind11::gil_scoped_release no_gil;
   Engine::thread_init(device, ready_queue, false);
 
@@ -85,7 +77,6 @@ void PythonEngine::thread_init(
     decrement_non_reentrant_thread_count();
   }
 
-#if defined(IS_PYTHON_3_9_PLUS)
   // Do not call PyEval_RestoreThread, PyThreadState_[Clear|DeleteCurrent] if
   // runtime is finalizing
   if (!Py_IsInitialized()) {
@@ -96,7 +87,6 @@ void PythonEngine::thread_init(
     auto ptr = gil.release();
     operator delete(ptr);
   }
-#endif
 }
 
 void PythonEngine::thread_on_exception(


### PR DESCRIPTION
As PyTorch is moving to Python 3.10, it is safe to remove code for Python < 3.9.