### PR TITLE
[DTensor] Handle Broadcast properly for aten.expand

### DIFF
--- a/test/distributed/tensor/test_dtensor_ops.py
+++ b/test/distributed/tensor/test_dtensor_ops.py
@@ -699,7 +699,9 @@ class TestDTensorOps(DTensorOpTestBase):
         dt1 = distribute_tensor(tensor, self.mesh, [Shard(1)])
 
         funcs = [
+            lambda t: t.expand(2, 4),
             lambda t: t.expand(4, 4),
+            lambda t: t.expand(5, 4),
             lambda t: t.expand(4, 4, 4),
             lambda t: t.expand(1, 4, 4),
             lambda t: t.broadcast_to(4, 4),

--- a/torch/distributed/tensor/_ops/_view_ops.py
+++ b/torch/distributed/tensor/_ops/_view_ops.py
@@ -605,6 +605,11 @@ def propagate_shape_and_sharding(
             if in_dim is not None:
                 shardable_dims[in_dim.input_dim] = [False] * mesh_ndim
             return None
+        elif isinstance(cmd, Broadcast):
+            in_dim = get_in_dim_to_shard(cmd.dim)
+            if in_dim is not None:
+                shardable_dims[in_dim.input_dim] = [False] * mesh_ndim
+            return None
         else:
             return None
 


### PR DESCRIPTION
Fixes #160968

Think about following case
```
        mesh = init_device_mesh(DEVICE_TYPE, (4,))
        tensor = torch.randn(1, 4)
        dt = distribute_tensor(tensor, mesh, [Shard(0)])
        out = dt.expand(4, 4)
```
Tensor of shape[1, 4] is unevenly sharded on 0-th dim into 4 shard. Only the first rank holds the local_tensor [1, 4], other ranks holds local_tensor of shape[0, 4]. 

When expanding to shape of [4, 4], (or more generally [N, 4]), there could be 2 potential resulting placements
1. [S(0)].  Each rank would result in local_tensor of [1, 4]. This would require one-to-all broadcast.
2. [Replicated]. Each rank would result in local_tensor of [4, 4]. But in practice, it would first replicate the input of shape [1, 4], and then expand locally. 

In both cases, this would require a broadcasting collective, and the redistribution cost is the same. 
However, we are using "AllGather followed by Slice" to simulate "one-to-all broadcasting" collective. 

So I am choosing Option 2, to replicate the input tensor first, and then expand locally. 

Generally, for view operation on DTensor, we would need some kind of "lazy communication": record the op, and only materialize communication when need. 



cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci