### PR TITLE
[hop] support local_map + SAC

### DIFF
--- a/test/higher_order_ops/test_local_map.py
+++ b/test/higher_order_ops/test_local_map.py
@@ -23,7 +23,6 @@ if torch.distributed.is_available():
     from torch.distributed.tensor.placement_types import Replicate, Shard
 
 from torch.testing._internal.common_utils import run_tests, TEST_WITH_CROSSREF, TestCase
-from torch.testing._internal.triton_utils import requires_cuda_and_triton
 
 
 nested_compile_region = torch.compiler.nested_compile_region
@@ -149,7 +148,6 @@ class TestLocalMap(TestCase):
     def tearDown(self):
         self.exit_stack.close()
 
-    @requires_cuda_and_triton
     @unittest.skipIf(
         not torch.distributed.is_available(), "Torch distributed not available."
     )
@@ -165,14 +163,14 @@ class TestLocalMap(TestCase):
 
         backend = EagerAndRecordGraphs()
 
-        model = create_model(cp_decorated, nheads, dim1, dim2).cuda()
-        inputs = (torch.randn(bs, seq_len, dim1, requires_grad=True).cuda(),)
+        model = create_model(cp_decorated, nheads, dim1, dim2)
+        inputs = (torch.randn(bs, seq_len, dim1, requires_grad=True),)
         with LocalMapWrappedHigherOrderVariable.enable():
             out = torch.compile(model, backend=backend)(*inputs)
         out.sum().backward()
 
-        model = create_model(cp_function, nheads, dim1, dim2).cuda()
-        inputs = (torch.randn(bs, seq_len, dim1, requires_grad=True).cuda(),)
+        model = create_model(cp_function, nheads, dim1, dim2)
+        inputs = (torch.randn(bs, seq_len, dim1, requires_grad=True),)
         with LocalMapWrappedHigherOrderVariable.enable():
             out = torch.compile(model, backend=backend)(*inputs)
         out.sum().backward()
@@ -238,7 +236,6 @@ class GraphModule(torch.nn.Module):
 """,
             )
 
-    @requires_cuda_and_triton
     @unittest.skipIf(
         not torch.distributed.is_available(), "Torch distributed not available."
     )
@@ -256,16 +253,16 @@ class GraphModule(torch.nn.Module):
 
         model = create_model(
             cp_decorated, nheads, dim1, dim2, sac_policy=save_scalar_muls
-        ).cuda()
-        inputs = (torch.randn(bs, seq_len, dim1, requires_grad=True).cuda(),)
+        )
+        inputs = (torch.randn(bs, seq_len, dim1, requires_grad=True),)
         with LocalMapWrappedHigherOrderVariable.enable():
             out = torch.compile(model, backend=backend)(*inputs)
         out.sum().backward()
 
         model = create_model(
             cp_function, nheads, dim1, dim2, sac_policy=save_scalar_muls
-        ).cuda()
-        inputs = (torch.randn(bs, seq_len, dim1, requires_grad=True).cuda(),)
+        )
+        inputs = (torch.randn(bs, seq_len, dim1, requires_grad=True),)
         with LocalMapWrappedHigherOrderVariable.enable():
             out = torch.compile(model, backend=backend)(*inputs)
         out.sum().backward()
@@ -314,7 +311,6 @@ class GraphModule(torch.nn.Module):
                         # can still be in fw_outs for post-graph bytecode
                         self.assertFalse(node.name in bw_ins)
 
-    @requires_cuda_and_triton
     @unittest.skipIf(
         not torch.distributed.is_available(), "Torch distributed not available."
     )
@@ -336,8 +332,8 @@ class GraphModule(torch.nn.Module):
 
         model = create_model(
             cp_decorated, nheads, dim1, dim2, sac_policy=save_scalar_muls
-        ).cuda()
-        inputs = (torch.randn(bs, seq_len, dim1, requires_grad=True).cuda(),)
+        )
+        inputs = (torch.randn(bs, seq_len, dim1, requires_grad=True),)
         try:
             with (
                 LocalMapWrappedHigherOrderVariable.enable(),
@@ -354,8 +350,8 @@ class GraphModule(torch.nn.Module):
 
         model = create_model(
             cp_function, nheads, dim1, dim2, sac_policy=save_scalar_muls
-        ).cuda()
-        inputs = (torch.randn(bs, seq_len, dim1, requires_grad=True).cuda(),)
+        )
+        inputs = (torch.randn(bs, seq_len, dim1, requires_grad=True),)
         try:
             with (
                 LocalMapWrappedHigherOrderVariable.enable(),

--- a/test/higher_order_ops/test_local_map.py
+++ b/test/higher_order_ops/test_local_map.py
@@ -22,10 +22,26 @@ if torch.distributed.is_available():
     from torch.distributed._tensor.experimental import local_map
     from torch.distributed.tensor.placement_types import Replicate, Shard
 
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_CROSSREF, TestCase
+from torch.testing._internal.common_utils import (
+    run_tests,
+    TEST_WITH_CROSSREF,
+    TEST_WITH_TORCHDYNAMO,
+    TEST_WITH_TORCHINDUCTOR,
+    TestCase,
+)
 
 
 nested_compile_region = torch.compiler.nested_compile_region
+
+
+def get_skip_reasons():
+    msg = ""
+    if not torch.distributed.is_available():
+        msg += "Torch distributed not available. "
+    if TEST_WITH_TORCHINDUCTOR or TEST_WITH_TORCHDYNAMO:
+        msg += "Already manually torch.compile'd. "
+
+    return msg != "", msg
 
 
 class MyTransform(torch.autograd.Function):
@@ -148,9 +164,7 @@ class TestLocalMap(TestCase):
     def tearDown(self):
         self.exit_stack.close()
 
-    @unittest.skipIf(
-        not torch.distributed.is_available(), "Torch distributed not available."
-    )
+    @unittest.skipIf(*get_skip_reasons())
     def test_simple(self):
         cp_decorated, cp_function = get_local_mapped_functions()
         bs = 8 * 1
@@ -236,9 +250,7 @@ class GraphModule(torch.nn.Module):
 """,
             )
 
-    @unittest.skipIf(
-        not torch.distributed.is_available(), "Torch distributed not available."
-    )
+    @unittest.skipIf(*get_skip_reasons())
     def test_sac(self):
         cp_decorated, cp_function = get_local_mapped_functions()
         bs = 8 * 1
@@ -311,9 +323,7 @@ class GraphModule(torch.nn.Module):
                         # can still be in fw_outs for post-graph bytecode
                         self.assertFalse(node.name in bw_ins)
 
-    @unittest.skipIf(
-        not torch.distributed.is_available(), "Torch distributed not available."
-    )
+    @unittest.skipIf(*get_skip_reasons())
     def test_sac_deferred(self):
         # This test is in a bit of a weird state, it needs compositional compile API
         # so that we can defer inlining for up until AOTAutograd stage 1.

--- a/test/higher_order_ops/test_local_map.py
+++ b/test/higher_order_ops/test_local_map.py
@@ -2,6 +2,7 @@
 # flake8: noqa: B950
 
 
+import functools
 import unittest
 
 import torch
@@ -12,6 +13,7 @@ import torch._inductor.decomposition
 import torch.nn.functional as F
 from torch import nn
 from torch._dynamo.variables.higher_order_ops import LocalMapWrappedHigherOrderVariable
+from torch.utils.checkpoint import create_selective_checkpoint_contexts
 
 
 if torch.distributed.is_available():
@@ -42,7 +44,17 @@ def context_parallel_attention(query, key, value):
     return out
 
 
-def create_model(attention_fn, nheads, dim1, dim2):
+def save_attention(ctx, op, *args, **kwargs):
+    if (
+        op == torch.ops.aten._scaled_dot_product_flash_attention.default
+        or op == torch.ops.aten._scaled_dot_product_efficient_attention.default
+    ):
+        # NOTE: we can't save nondeterministic_seeded ops, the run with rng wrapper is not traceable yet
+        return torch.utils.checkpoint.CheckpointPolicy.PREFER_SAVE
+    return torch.utils.checkpoint.CheckpointPolicy.PREFER_RECOMPUTE
+
+
+def create_model(attention_fn, nheads, dim1, dim2, sac_policy=None):
     class LocalMapTransformerBlock(nn.Module):
         def __init__(self, nheads, dim1, dim2):
             super().__init__()
@@ -54,8 +66,14 @@ def create_model(attention_fn, nheads, dim1, dim2):
             self.wo = nn.Linear(dim1, dim1, bias=bias)
             self.w1 = nn.Linear(dim1, dim2, bias=bias)
             self.w2 = nn.Linear(dim2, dim1, bias=bias)
+            if sac_policy:
+                self.sac_context_fn = functools.partial(
+                    create_selective_checkpoint_contexts, sac_policy
+                )
+            else:
+                self.sac_context_fn = None
 
-        def forward(self, x):
+        def _forward(self, x):
             q = self.wq(x)
             k = self.wk(x)
             v = self.wv(x)
@@ -78,7 +96,50 @@ def create_model(attention_fn, nheads, dim1, dim2):
             o = o0 + o
             return o
 
+        def forward(self, x):
+            if self.sac_context_fn is not None:
+                return torch.utils.checkpoint.checkpoint(
+                    self._forward,
+                    x,
+                    use_reentrant=False,
+                    context_fn=self.sac_context_fn,
+                )
+            return self._forward(x)
+
     return LocalMapTransformerBlock(nheads, dim1, dim2)
+
+
+def get_local_mapped_functions():
+    assert torch.distributed.is_available()
+
+    @local_map(
+        out_placements=((Shard(0), Shard(1), Shard(2)),),
+        in_placements=(
+            (Shard(0), Shard(1), Shard(2)),  # query
+            (Shard(0), Shard(1), Replicate()),  # key
+            (Shard(0), Shard(1), Replicate()),  # value
+        ),
+        redistribute_inputs=True,
+        in_grad_placements=None,
+        device_mesh=None,
+    )
+    def cp_decorated(query, key, value):
+        return context_parallel_attention(query, key, value)
+
+    cp_function = local_map(
+        context_parallel_attention,
+        out_placements=(Shard(0), Shard(1), Shard(2)),
+        in_placements=(
+            (Shard(0), Shard(1), Shard(2)),  # query
+            (Shard(0), Shard(1), Replicate()),  # key
+            (Shard(0), Shard(1), Replicate()),  # value
+        ),
+        redistribute_inputs=True,
+        in_grad_placements=None,
+        device_mesh=None,
+    )
+
+    return cp_decorated, cp_function
 
 
 class TestLocalMap(TestCase):
@@ -87,32 +148,7 @@ class TestLocalMap(TestCase):
         not torch.distributed.is_available(), "Torch distributed not available."
     )
     def test_simple(self):
-        @local_map(
-            out_placements=((Shard(0), Shard(1), Shard(2)),),
-            in_placements=(
-                (Shard(0), Shard(1), Shard(2)),  # query
-                (Shard(0), Shard(1), Replicate()),  # key
-                (Shard(0), Shard(1), Replicate()),  # value
-            ),
-            redistribute_inputs=True,
-            in_grad_placements=None,
-            device_mesh=None,
-        )
-        def cp_decorated(query, key, value):
-            return context_parallel_attention(query, key, value)
-
-        cp_function = local_map(
-            context_parallel_attention,
-            out_placements=(Shard(0), Shard(1), Shard(2)),
-            in_placements=(
-                (Shard(0), Shard(1), Shard(2)),  # query
-                (Shard(0), Shard(1), Replicate()),  # key
-                (Shard(0), Shard(1), Replicate()),  # value
-            ),
-            redistribute_inputs=True,
-            in_grad_placements=None,
-            device_mesh=None,
-        )
+        cp_decorated, cp_function = get_local_mapped_functions()
         bs = 8 * 1
         dim1 = 96
         dim2 = dim1 * 4
@@ -137,7 +173,10 @@ class TestLocalMap(TestCase):
 
         if not TEST_WITH_CROSSREF:
             self.assertEqual(len(backend.graphs), 2)
-            # should see local_map_hop in both
+            self.assertEqual(
+                normalize_gm(backend.graphs[0].print_readable(print_output=False)),
+                normalize_gm(backend.graphs[1].print_readable(print_output=False)),
+            )
             self.assertExpectedInline(
                 normalize_gm(backend.graphs[0].print_readable(print_output=False)),
                 """\
@@ -193,9 +232,113 @@ class GraphModule(torch.nn.Module):
 """,
             )
 
+    @requires_cuda_and_triton
+    @unittest.skipIf(
+        not torch.distributed.is_available(), "Torch distributed not available."
+    )
+    def test_sac(self):
+        cp_decorated, cp_function = get_local_mapped_functions()
+        bs = 8 * 1
+        dim1 = 96
+        dim2 = dim1 * 4
+        nheads = 16
+        seq_len = 16
+
+        from torch._dynamo.testing import EagerAndRecordGraphs, normalize_gm
+
+        backend = EagerAndRecordGraphs()
+
+        model = create_model(
+            cp_decorated, nheads, dim1, dim2, sac_policy=save_attention
+        ).cuda()
+        inputs = (torch.randn(bs, seq_len, dim1, requires_grad=True).cuda(),)
+        with LocalMapWrappedHigherOrderVariable.enable():
+            out = torch.compile(model, backend=backend)(*inputs)
+        out.sum().backward()
+
+        model = create_model(
+            cp_function, nheads, dim1, dim2, sac_policy=save_attention
+        ).cuda()
+        inputs = (torch.randn(bs, seq_len, dim1, requires_grad=True).cuda(),)
+        with LocalMapWrappedHigherOrderVariable.enable():
+            out = torch.compile(model, backend=backend)(*inputs)
+        out.sum().backward()
+
+        if not TEST_WITH_CROSSREF:
+            self.assertEqual(len(backend.graphs), 2)
             self.assertEqual(
                 normalize_gm(backend.graphs[0].print_readable(print_output=False)),
                 normalize_gm(backend.graphs[1].print_readable(print_output=False)),
+            )
+            self.assertEqual(
+                len(
+                    backend.graphs[0].graph.find_nodes(
+                        op="call_function",
+                        target=torch._higher_order_ops.wrap.tag_activation_checkpoint,
+                    )
+                ),
+                1,
+            )
+            self.assertExpectedInline(
+                normalize_gm(backend.graphs[0].print_readable(print_output=False)),
+                """\
+class GraphModule(torch.nn.Module):
+    def forward(self, L_x_: "f32[8, 16, 96]", L_self_modules_wq_parameters_weight_: "f32[96, 96]", L_self_modules_wk_parameters_weight_: "f32[96, 96]", L_self_modules_wv_parameters_weight_: "f32[96, 96]", L_self_modules_wo_parameters_weight_: "f32[96, 96]", L_self_modules_w1_parameters_weight_: "f32[384, 96]", L_self_modules_w2_parameters_weight_: "f32[96, 384]"):
+        l_x_ = L_x_
+        l_self_modules_wq_parameters_weight_ = L_self_modules_wq_parameters_weight_
+        l_self_modules_wk_parameters_weight_ = L_self_modules_wk_parameters_weight_
+        l_self_modules_wv_parameters_weight_ = L_self_modules_wv_parameters_weight_
+        l_self_modules_wo_parameters_weight_ = L_self_modules_wo_parameters_weight_
+        l_self_modules_w1_parameters_weight_ = L_self_modules_w1_parameters_weight_
+        l_self_modules_w2_parameters_weight_ = L_self_modules_w2_parameters_weight_
+
+        wrap_body_0 = self.wrap_body_0
+        tag_activation_checkpoint = torch.ops.higher_order.tag_activation_checkpoint(wrap_body_0, l_x_, l_self_modules_wq_parameters_weight_, l_self_modules_wk_parameters_weight_, l_self_modules_wv_parameters_weight_, l_self_modules_wo_parameters_weight_, l_self_modules_w1_parameters_weight_, l_self_modules_w2_parameters_weight_, use_reentrant = False);  wrap_body_0 = l_x_ = l_self_modules_wq_parameters_weight_ = l_self_modules_wk_parameters_weight_ = l_self_modules_wv_parameters_weight_ = l_self_modules_wo_parameters_weight_ = l_self_modules_w1_parameters_weight_ = l_self_modules_w2_parameters_weight_ = None
+        getitem: "f32[8, 16, 96]" = tag_activation_checkpoint[0];  tag_activation_checkpoint = None
+        return (getitem,)
+
+    class wrap_body_0(torch.nn.Module):
+        def forward(self, l_x_: "f32[8, 16, 96]", l_self_modules_wq_parameters_weight_: "f32[96, 96]", l_self_modules_wk_parameters_weight_: "f32[96, 96]", l_self_modules_wv_parameters_weight_: "f32[96, 96]", l_self_modules_wo_parameters_weight_: "f32[96, 96]", l_self_modules_w1_parameters_weight_: "f32[384, 96]", l_self_modules_w2_parameters_weight_: "f32[96, 384]"):
+            q: "f32[8, 16, 96]" = torch._C._nn.linear(l_x_, l_self_modules_wq_parameters_weight_, None);  l_self_modules_wq_parameters_weight_ = None
+
+            k: "f32[8, 16, 96]" = torch._C._nn.linear(l_x_, l_self_modules_wk_parameters_weight_, None);  l_self_modules_wk_parameters_weight_ = None
+
+            v: "f32[8, 16, 96]" = torch._C._nn.linear(l_x_, l_self_modules_wv_parameters_weight_, None);  l_self_modules_wv_parameters_weight_ = None
+
+            unflatten: "f32[8, 16, 16, 6]" = q.unflatten(-1, (16, -1));  q = None
+            q_1: "f32[8, 16, 16, 6]" = unflatten.permute(0, 2, 1, 3);  unflatten = None
+
+            unflatten_1: "f32[8, 16, 16, 6]" = k.unflatten(-1, (16, -1));  k = None
+            k_1: "f32[8, 16, 16, 6]" = unflatten_1.permute(0, 2, 1, 3);  unflatten_1 = None
+
+            unflatten_2: "f32[8, 16, 16, 6]" = v.unflatten(-1, (16, -1));  v = None
+            v_1: "f32[8, 16, 16, 6]" = unflatten_2.permute(0, 2, 1, 3);  unflatten_2 = None
+
+            subgraph_0 = self.subgraph_0
+            local_map_hop = torch.ops.higher_order.local_map_hop(subgraph_0, q_1, k_1, v_1);  subgraph_0 = q_1 = k_1 = v_1 = None
+            o: "f32[8, 16, 16, 6]" = local_map_hop[0];  local_map_hop = None
+
+            permute_3: "f32[8, 16, 16, 6]" = o.permute(0, 2, 1, 3);  o = None
+            o_1: "f32[8, 16, 96]" = permute_3.flatten(-2);  permute_3 = None
+
+            o_2: "f32[8, 16, 96]" = torch._C._nn.linear(o_1, l_self_modules_wo_parameters_weight_, None);  o_1 = l_self_modules_wo_parameters_weight_ = None
+
+            o0: "f32[8, 16, 96]" = o_2 + l_x_;  o_2 = l_x_ = None
+
+            o_3: "f32[8, 16, 384]" = torch._C._nn.linear(o0, l_self_modules_w1_parameters_weight_, None);  l_self_modules_w1_parameters_weight_ = None
+
+            o_4: "f32[8, 16, 384]" = torch.nn.functional.relu(o_3);  o_3 = None
+
+            o_5: "f32[8, 16, 96]" = torch._C._nn.linear(o_4, l_self_modules_w2_parameters_weight_, None);  o_4 = l_self_modules_w2_parameters_weight_ = None
+
+            o_6: "f32[8, 16, 96]" = o0 + o_5;  o0 = o_5 = None
+            return (o_6,)
+
+        class subgraph_0(torch.nn.Module):
+            def forward(self, q_1: "f32[8, 16, 16, 6]", k_1: "f32[8, 16, 16, 6]", v_1: "f32[8, 16, 16, 6]"):
+                out: "f32[8, 16, 16, 6]" = torch._C._nn.scaled_dot_product_attention(query = q_1, key = k_1, value = v_1, is_causal = False);  q_1 = k_1 = v_1 = None
+                return (out,)
+""",
             )
 
 

--- a/torch/_higher_order_ops/local_map.py
+++ b/torch/_higher_order_ops/local_map.py
@@ -15,6 +15,7 @@ import torch.utils._pytree as pytree
 from torch._C import DispatchKey
 from torch._higher_order_ops.utils import (
     clone_outputs_aliasing_inputs,
+    redirect_to_mode,
     save_tensors_and_symints_for_backward,
     saved_tensors_and_symints,
 )
@@ -22,6 +23,7 @@ from torch._ops import HigherOrderOperator
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx import GraphModule
 from torch.fx.experimental.proxy_tensor import ProxyTorchDispatchMode, track_tensor_tree
+from torch.utils.checkpoint import _CachedTorchDispatchMode, _CachingTorchDispatchMode
 
 
 # Proxy the HOP instead of inlining into it
@@ -48,6 +50,10 @@ class LocalMapHOP(HigherOrderOperator):
 
 
 local_map_hop = LocalMapHOP()
+
+# Registers dispatches for SAC
+redirect_to_mode(local_map_hop, _CachingTorchDispatchMode)
+redirect_to_mode(local_map_hop, _CachedTorchDispatchMode)
 
 
 def create_hop_fw_bw(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #163602
* __->__ #163322

Some ops like local_map hop's deferred mode are not desugared by make_fx, this means that when we apply SAC tags, we will need to define dispatch rules for the SAC torch dispatch modes as pointed out here: https://github.com/pytorch/pytorch/issues/162246#issuecomment-3259176721. This PR adds those rules.

Additionally it fixes a pre-existing issue where we weren't coercing tangent layout (that AOTAutograd typically does) when partitioning the HOP joint.