### PR TITLE
Don't use declarations in global namespace in stable headers

### DIFF
--- a/torch/csrc/stable/.clang-tidy
+++ b/torch/csrc/stable/.clang-tidy
@@ -1,7 +1,3 @@
-# NOTE there must be no spaces before the '-', so put the comma after.
-# When making changes, be sure to verify the output of the following command to ensure
-# the desired checks are enabled (run from the directory containing a .clang-tidy file):
-# ~/fbsource/tools/lint/clangtidy/clang-tidy-platform010-clang-17 -list-checks
 # NOTE: Please don't disable inheritance from the parent to make sure that common checks get propagated.
 
 # This configuration prevents global namespace pollution in headers.

--- a/torch/csrc/stable/.clang-tidy
+++ b/torch/csrc/stable/.clang-tidy
@@ -1,0 +1,13 @@
+# NOTE there must be no spaces before the '-', so put the comma after.
+# When making changes, be sure to verify the output of the following command to ensure
+# the desired checks are enabled (run from the directory containing a .clang-tidy file):
+# ~/fbsource/tools/lint/clangtidy/clang-tidy-platform010-clang-17 -list-checks
+# NOTE: Please don't disable inheritance from the parent to make sure that common checks get propagated.
+
+# This configuration prevents global namespace pollution in headers.
+---
+InheritParentConfig: true
+Checks: '
+google-global-names-in-headers,
+'
+...

--- a/torch/csrc/stable/accelerator.h
+++ b/torch/csrc/stable/accelerator.h
@@ -5,9 +5,9 @@
 
 #include <memory>
 
-using DeleterFnPtr = void (*)(void*);
-
 namespace torch::stable::accelerator {
+
+using DeleterFnPtr = void (*)(void*);
 
 namespace {
 inline void delete_device_guard(void* ptr) {

--- a/torch/csrc/stable/accelerator.h
+++ b/torch/csrc/stable/accelerator.h
@@ -5,9 +5,9 @@
 
 #include <memory>
 
-namespace torch::stable::accelerator {
-
 using DeleterFnPtr = void (*)(void*);
+
+namespace torch::stable::accelerator {
 
 namespace {
 inline void delete_device_guard(void* ptr) {


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/163338

Configured https://clang.llvm.org/extra/clang-tidy/checks/google/global-names-in-headers.html for torch/csrc/stable

Note that doesn't error for the DeleterFnPtr case, but will generate the following for the `using torch::stable::Tensor;`

```
>>> Lint for torch/csrc/stable/ops.h:

  Error (CLANGTIDY) [google-global-names-in-headers,-warnings-as-errors]
    using declarations in the global namespace in headers are prohibited

         10  |#include <torch/csrc/inductor/aoti_torch/generated/c_shim_aten.h>
         11  |#include <torch/headeronly/core/ScalarType.h>
         12  |
    >>>  13  |using torch::stable::Tensor;
         14  |
         15  |namespace torch::stable {
         16  |
   ```


Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #163352

