### PR TITLE
[ez][CI] Run vllm workflow on vllm pin updates

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -130,3 +130,6 @@
 - torch/csrc/inductor/aoti_include/**
 - torchgen/aoti/**
 - torchgen/gen_aoti_c_shim.py
+
+"ciflow/vllm":
+- .github/ci_commit_pins/vllm.txt


### PR DESCRIPTION
As in title

The auto pin update was merged without running vllm workflow