### PR TITLE
[CUDA][cuBLAS][FP8] Forward-fix #162022

### DIFF
--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -1550,7 +1550,7 @@ class TestFP8Matmul(TestCase):
 
         # only cuBLAS supports rowwise with fp32 output and cuBLAS only supports
         # rowwise on SM 9.0
-        if torch.cuda.get_device_capability != (9, 0) and output_dtype == torch.float:
+        if torch.cuda.get_device_capability() != (9, 0) and output_dtype == torch.float:
             with self.assertRaisesRegex(
                 RuntimeError,
                 "Only bf16 high precision output types are supported for row-wise scaling."


### PR DESCRIPTION
@ngimel is right, `ciflow/h100` doesn't actually appear to test the PR :(

cc @ptrblck @msaroufim @jerryzh168 @csarofeen @xwang233