### PR TITLE
Fix: Prevent Direct Inheritance of torch._C.ScriptObject

### DIFF
--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -748,7 +748,7 @@ void initJitScriptBindings(PyObject* module) {
   py::class_<c10::Capsule>(m, "Capsule");
 
   auto object_class =
-      py::class_<Object>(m, "ScriptObject")
+      py::class_<Object>(m, "ScriptObject", py::is_final())
           .def("_type", [](Object& o) { return o.type(); })
           .def(
               "_get_method",


### PR DESCRIPTION
Direct Inheritance of ScriptObject causes Segmentation fault or Assertion Error. Reason being, @torch.jit.script decorator compiles the Python class and creates a proper classType with static schema. This constructs ivalue::Object with valid information and initializes all constructors properly.
With direct inheritance, super.init() calls C++ default constructor. Default Constructor leaves ivalue uninitialized or corrupted. When someone created class variable that triggers setattr, which calls self.type(). Here type() method calls ivalue->type->expect()

Adding py::isfinal() gives meanigful error:
```TypeError: type 'torch._C.ScriptObject' is not an acceptable base type```

I think design was not to support direct inheritance . However, If we need to support it then this will be a feature enhancement. Would you like me to implement the feature to enable indirect inheritance?



Fixes #161854


cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel