### PR TITLE
Less aggressive persistent reduction when it could induce large masking with dynamic shapes

### DIFF
--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -1132,8 +1132,12 @@ class TestInductorDynamic(TestCase):
         features = 5536
         reduction_dim = 6  # Actual size is small
 
-        x = torch.randn(reduction_dim, batch, features, device=GPU_TYPE).permute(1, 2, 0)
-        y = torch.randn(reduction_dim, batch, features, device=GPU_TYPE).permute(1, 2, 0)
+        x = torch.randn(reduction_dim, batch, features, device=GPU_TYPE).permute(
+            1, 2, 0
+        )
+        y = torch.randn(reduction_dim, batch, features, device=GPU_TYPE).permute(
+            1, 2, 0
+        )
 
         torch._dynamo.mark_dynamic(x, 2, min=6, max=64)
         torch._dynamo.mark_dynamic(y, 2, min=6, max=64)

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -1141,7 +1141,7 @@ class TestInductorDynamic(TestCase):
         compiled_fn = torch.compile(reduce_bounded)
         result, source_codes = run_and_get_code(compiled_fn, x, y)
 
-        FileCheck().check_not("@triton_heuristics.reduction").run(source_codes[0])
+        FileCheck().check_not("@triton_heuristics.persistent").run(source_codes[0])
         expected = reduce_bounded(x, y)
 
         assert torch.allclose(result, expected, atol=1e-3, rtol=1e-3)

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -1116,6 +1116,44 @@ class TestInductorDynamic(TestCase):
             self.assertEqual(fn(x), actual)
             FileCheck().check("R0_BLOCK: tl.constexpr = 64").run(source_codes[0])
 
+    def test_non_persistent_dynamic_rblock(self):
+        def reduce_bounded(x, y):
+            """Reduce over a dimension with bounded size."""
+            # x shape: [batch, features, reduction_dim]
+            # reduction_dim is dynamic but bounded to max 128
+            assert x.shape[2] <= 16, f"Reduction dim {x.shape[2]} exceeds max 128"
+
+            # Perform reduction (sum) over the last dimension
+            result = torch.sum(x * y, dim=2)
+            return result
+
+        # Create tensors where reduction dimension is 6 (but could be up to 128)
+        batch = 256
+        features = 5536
+        reduction_dim = 6  # Actual size is small
+
+        x = torch.randn(reduction_dim, batch, features, device="cuda").permute(1, 2, 0)
+        y = torch.randn(reduction_dim, batch, features, device="cuda").permute(1, 2, 0)
+
+        torch._dynamo.mark_dynamic(x, 2, min=6, max=16)
+        torch._dynamo.mark_dynamic(y, 2, min=6, max=16)
+
+        compiled_fn = torch.compile(reduce_bounded)
+        result, source_codes = run_and_get_code(compiled_fn, x, y)
+
+        FileCheck().check_not("@triton_heuristics.reduction").run(source_codes[0])
+
+        # Verify shape
+        assert result.shape == (batch, features)
+
+        # Test with expected value
+        expected = reduce_bounded(x, y)
+        import triton
+
+        print(triton.testing.do_bench(lambda: compiled_fn(x, y)))
+
+        assert torch.allclose(result, expected, atol=1e-3, rtol=1e-3)
+
     def test_unspecialized_float_dynamic(self):
         def fn(x, y):
             return x * y

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -1121,7 +1121,7 @@ class TestInductorDynamic(TestCase):
             """Reduce over a dimension with bounded size."""
             # x shape: [batch, features, reduction_dim]
             # reduction_dim is dynamic but bounded to max 128
-            assert x.shape[2] <= 128, f"Reduction dim {x.shape[2]} exceeds max 128"
+            assert x.shape[2] <= 64, f"Reduction dim {x.shape[2]} exceeds max 128"
 
             # Perform reduction (sum) over the last dimension
             result = torch.sum(x * y, dim=2)
@@ -1135,8 +1135,8 @@ class TestInductorDynamic(TestCase):
         x = torch.randn(reduction_dim, batch, features, device="cuda").permute(1, 2, 0)
         y = torch.randn(reduction_dim, batch, features, device="cuda").permute(1, 2, 0)
 
-        torch._dynamo.mark_dynamic(x, 2, min=6, max=128)
-        torch._dynamo.mark_dynamic(y, 2, min=6, max=128)
+        torch._dynamo.mark_dynamic(x, 2, min=6, max=64)
+        torch._dynamo.mark_dynamic(y, 2, min=6, max=64)
 
         compiled_fn = torch.compile(reduce_bounded)
         result, source_codes = run_and_get_code(compiled_fn, x, y)

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -1132,8 +1132,8 @@ class TestInductorDynamic(TestCase):
         features = 5536
         reduction_dim = 6  # Actual size is small
 
-        x = torch.randn(reduction_dim, batch, features, device="cuda").permute(1, 2, 0)
-        y = torch.randn(reduction_dim, batch, features, device="cuda").permute(1, 2, 0)
+        x = torch.randn(reduction_dim, batch, features, device=GPU_TYPE).permute(1, 2, 0)
+        y = torch.randn(reduction_dim, batch, features, device=GPU_TYPE).permute(1, 2, 0)
 
         torch._dynamo.mark_dynamic(x, 2, min=6, max=64)
         torch._dynamo.mark_dynamic(y, 2, min=6, max=64)

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -6,6 +6,8 @@ from typing import Any, Optional, TYPE_CHECKING, Union
 import sympy
 
 import torch
+from torch._inductor.runtime.runtime_utils import next_power_of_2
+from torch.utils._sympy.value_ranges import bound_sympy
 
 from . import config
 from .codecache import write_text
@@ -285,6 +287,34 @@ class InductorChoices:
             ReductionHint.INNER: 1024,
         }.get(features.get_reduction_hint(), 64)
 
+        if features.get_reduction_hint() not in (
+            ReductionHint.INNER,
+            ReductionHint.OUTER_TINY,
+        ):
+            bounds = bound_sympy(features.reduction_numel)
+            lower = bounds.lower
+            upper = bounds.upper
+
+            if not all(
+                (
+                    (isinstance(bound, int) or bound.is_constant())
+                    and bound != torch.utils._sympy.numbers.IntInfinity()
+                )
+                for bound in (lower, upper)
+            ):
+                return False
+
+            lower = next_power_of_2(int(lower))
+            upper = next_power_of_2(int(upper))
+
+            # If we are are coalescing on xblock (not ReductionHint.INNER) and this is not a tiny kernel
+            # (not ReductionHint.OUTER_TINY), do not use persistent reduction if it induces tile
+            # quantization. Peristent reduction forces rblock == rnumel, if the bounds between lower
+            # and upper are large, for the lower values we will be masking off large % of read/writes,
+            # when we could expand the coalescing xblock instead.
+            if lower != upper:
+                return False
+
         if cooperative_reduction:
             # The RSPLIT of cooperative reductions means each thread block is operating on fewer elements
             try:
@@ -300,6 +330,7 @@ class InductorChoices:
         # to pick the faster one.
         if config.triton.multi_kernel:
             threshold *= 16
+
         return V.graph.sizevars.statically_known_leq(
             features.reduction_numel, threshold
         )  # type: ignore[arg-types]

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -309,7 +309,7 @@ class InductorChoices:
 
             # If we are are coalescing on xblock (not ReductionHint.INNER) and this is not a tiny kernel
             # (not ReductionHint.OUTER_TINY), do not use persistent reduction if it induces tile
-            # quantization. Peristent reduction forces rblock == rnumel, if the bounds between lower
+            # quantization. Persistent reduction forces rblock == rnumel, if the bounds between lower
             # and upper are large, for the lower values we will be masking off large % of read/writes,
             # when we could expand the coalescing xblock instead.
             if lower != upper:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #163365

As per comment in source code:
```
            # If we are are coalescing on xblock (not ReductionHint.INNER) and this is not a tiny kernel
            # (not ReductionHint.OUTER_TINY), do not use persistent reduction if it induces tile
            # quantization. Peristent reduction forces rblock == rnumel, if the bounds between lower
            # and upper are large, for the lower values we will be masking off large % of read/writes,
            # when we could expand the coalescing xblock instead.
```

For the test case in question, this pr improves perf from 0.8573521325143717 -> 0.043151492193814305 because we were egregiously masking out rblock values (58/64 values). 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben

Differential Revision: [D82853279](https://our.internmc.facebook.com/intern/diff/D82853279)