### PR TITLE
[DO NOT LAND] hack fsdp2 to support AC(fully_shard(model))

### DIFF
--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -42,7 +42,9 @@ _ModuleToHandleDict = dict[nn.Module, RemovableHandle]  # for state dict
 
 def is_in_ac() -> bool:
     import inspect
-    return any(frame.function == 'recompute_fn' for frame in inspect.stack())
+
+    return any(frame.function == "recompute_fn" for frame in inspect.stack())
+
 
 """
 [Note: Overlapping all-gather copy-in and all-gather]
@@ -301,10 +303,6 @@ class FSDPParamGroup:
 
     # Runtime #
     def unshard(self, async_op: bool = False):
-        # if torch.distributed.get_rank() == 0:
-        #     logger.error(f"unshard {self}")
-        #     import fbvscode
-        #     fbvscode.set_trace()
         if self._all_gather_result is not None:  # already called, pending wait
             return
         if self.is_unsharded:
@@ -425,10 +423,6 @@ class FSDPParamGroup:
             self.comm_ctx.all_gather_stream.wait_event(event)
 
     def reshard(self):
-        # if torch.distributed.get_rank() == 0:
-        #     logger.error(f"reshard {self}")
-        #     import fbvscode
-        #     fbvscode.set_trace()
         if self._training_state == TrainingState.FORWARD:
             if not self._reshard_after_forward:
                 return

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -461,7 +461,6 @@ class FSDPParamGroup:
     def _record_post_forward(self) -> None:
         # Since a group has one pre-backward unshard for each forward call
         # before the backward, we record each usage (with multiplicity)
-
         post_forward_index = len(self.comm_ctx.post_forward_order)
         self.comm_ctx.post_forward_order.append(self)
         self._post_forward_indices.append(post_forward_index)


### PR DESCRIPTION
for fsdp2 + EP, titan has fully_shard(AC(layer)) and fully_shard(layer.moe.experts): https://github.com/pytorch/torchtitan/issues/1624

for implicit prefetching, backward order is
* _pre_backward unshard (norm, output)
* _backward_prefetch unshard layers.6
* post_backward reshard (norm, output)
* _pre_backward unshard layers.6 (no-op, unsharded already)
* _backward_prefetch unshard layers.6.moe.experts
* recompute_fn pre_forward unshard layers.6.moe.experts (no-op, unsharded already)
* ~~recompute_fn post_forward reshard layers.6.moe.experts~~ <----- this PR make it a no-op
* _pre_backward unshard layers.6.moe.experts (no-op, unsharded already)
* _backward_prefetch unshard layers.5
* post_backward reshard layers.6.moe.experts
* post_backward reshard layers.6

before fix: `NGPU=4 CONFIG_FILE="./torchtitan/models/deepseek_v3/train_configs/deepseek_v3_16b.toml" ./run_train.sh --parallelism.expert_parallel_degree=2`
```
[rank0]:[titan] 2025-09-25 17:25:11,844 - root - INFO - step:  1  loss: 12.0118  grad_norm:  1.7139  memory: 45.65GiB(48.05%)  tps: 976  tflops: 10.32  mfu: 1.04%
[rank0]:[titan] 2025-09-25 17:25:11,844 - root - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:[titan] 2025-09-25 17:25:18,339 - root - INFO - step: 10  loss:  8.6772  grad_norm: 10.2347  memory: 59.90GiB(63.06%)  tps: 11,352  tflops: 120.08  mfu: 12.14%
```

after fix: `NGPU=4 CONFIG_FILE="./torchtitan/models/deepseek_v3/train_configs/deepseek_v3_16b.toml" ./run_train.sh --parallelism.expert_parallel_degree=2`
```
[rank0]:[titan] 2025-09-25 17:19:46,049 - root - INFO - step:  1  loss: 12.0490  grad_norm:  1.7109  memory: 38.39GiB(40.42%)  tps: 1,041  tflops: 11.01  mfu: 1.11%
[rank0]:[titan] 2025-09-25 17:19:46,049 - root - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:[titan] 2025-09-25 17:19:54,096 - root - INFO - step: 10  loss:  8.5467  grad_norm:  9.8088  memory: 52.43GiB(55.19%)  tps: 9,163  tflops: 96.93  mfu: 9.80%
```

for explicit prefetching, layers.6 backward prefetch layers.5 and layers.5.moe.experts. layers.6.moe.experts does not have explicit prefetch. backward order is like this
* _pre_backward unshard (norm, output)
* _prefetch_unshard layers.6
* post_backward reshard (norm, output)
* _pre_backward unshard layers.6 (no-op, unsharded already)
* _prefetch_unshard layers.5
* _prefetch_unshard layers.5.moe.experts
* recompute_fn pre_forward unshard layers.6.moe.experts
* ~~recompute_fn post_forward reshard layers.6.moe.experts~~ <----- this PR makes it a no-op
* _pre_backward unshard layers.6.moe.expert (no-op, unsharded already)
* post_backward reshard layers.6.moe.expert
* post_backward reshard layers.6

before fix: `NGPU=4 CONFIG_FILE="./torchtitan/models/deepseek_v3/train_configs/deepseek_v3_16b.toml" ./run_train.sh --parallelism.expert_parallel_degree=2`
```
rank0]:[titan] 2025-09-25 17:32:36,230 - root - INFO - step:  1  loss: 12.0652  grad_norm:  1.7036  memory: 45.73GiB(48.14%)  tps: 1,066  tflops: 11.27  mfu: 1.14%
[rank0]:[titan] 2025-09-25 17:32:36,230 - root - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:[titan] 2025-09-25 17:32:42,714 - root - INFO - step: 10  loss:  8.8573  grad_norm: 13.0669  memory: 59.88GiB(63.04%)  tps: 11,371  tflops: 120.28  mfu: 12.16%
```

after fix: `NGPU=4 CONFIG_FILE="./torchtitan/models/deepseek_v3/train_configs/deepseek_v3_16b.toml" ./run_train.sh --parallelism.expert_parallel_degree=2`
```
[rank0]:[titan] 2025-09-25 17:33:54,528 - root - INFO - step:  1  loss: 12.0285  grad_norm:  1.6655  memory: 38.57GiB(40.61%)  tps: 1,036  tflops: 10.95  mfu: 1.11%
[rank0]:[titan] 2025-09-25 17:33:54,528 - root - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:[titan] 2025-09-25 17:34:02,243 - root - INFO - step: 10  loss:  8.8151  grad_norm: 12.5944  memory: 52.87GiB(55.66%)  tps: 9,558  tflops: 101.10  mfu: 10.22%
```

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #163391
* #163130

Summary:

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci