### PR TITLE
Slightly improve speed of AdamW by rearranging order of bias_correction2_sqrt

### DIFF
--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -773,7 +773,12 @@ def _multi_tensor_adam(
 
             bias_correction2_sqrt = [bc**0.5 for bc in bias_correction2]  # type: ignore[arg-type]
 
-            step_size = _stack_if_compiling([-(lr * bc2 / bc1) for bc1, bc2 in zip(bias_correction1, bias_correction2_sqrt)])
+            step_size = _stack_if_compiling(
+                [
+                    -(lr * bc2 / bc1)
+                    for bc1, bc2 in zip(bias_correction1, bias_correction2_sqrt)
+                ]
+            )
 
             if amsgrad:
                 device_max_exp_avg_sqs = cast(list[Tensor], device_max_exp_avg_sqs_)


### PR DESCRIPTION
Source of idea: https://x.com/Tim_Dettmers/status/1969131103798567295

> Looking closer, PyTorch also uses FP32, but here's the real reason why bnb Adam is better: we optimized for float numerics, order does matter! Computing sqrt(v) + eps*c2 then dividing avoids amplifying errors vs PyTorch's sqrt(v)/c2 + eps. Same math, better stability!

I don't believe this is true. The stability benefit should be meaningless; there is some discussion at https://discord.com/channels/729741769192767510/1079865324087803985/1418777002592174190 (accessing this requires joining the [EleutherAI discord](https://discord.gg/zBGx3azzUn))

However, Dettmer's version is faster than PyTorch's, because it does 2 tensor-wise multiplications instead of 1 elementwise division on sqrt(v). So I copied it to the torch implementation. My own optimizer does not have an eps/beta2 interaction, so I have no prior testing of this change. If momentum buffers are changed to fp16/bf16, instead of float32 as they are now, this new formulation will have higher precision than the old formulation.

Changed:
_single_tensor_adam, non-capturable
_multi_tensor_adam, non-capturable
_multi_tensor_adam, capturable

Not changed:
_single_tensor_adam, capturable. The existing code is extremely inefficient for reasons I don't understand. Thus, I left it alone.
fused adam

Not tested:
Whether "capturable multi tensor adam" still satisfies being "capturable". I don't know the contract it must satisfy, so I can't test it.

Tested:
It's faster for normal usecases, but testing is not comprehensive. If there are only 2 tensors, the change to capturable `_multi_tensor_adam` is slower.
Loss curves match exactly with the changed versions. In this testcase, `eps` is set to a deliberately high number to make differences obvious:
```
import torch
import torch.nn as nn
from torch.optim.adamw import AdamW

torch.manual_seed(42)
torch.cuda.manual_seed_all(42)

class SimpleModel(nn.Module):
    def __init__(self):
        super(SimpleModel, self).__init__()
        self.linear = nn.Linear(10, 10)
        self.linear2 = nn.Linear(10, 1)

    def forward(self, x):
        return self.linear2(self.linear(x))

model = SimpleModel()

learning_rate = 0.1
weight_decay = 0.01

# to change: capturable, foreach
optimizer = AdamW(model.parameters(), lr=learning_rate, weight_decay=weight_decay, eps=1.0, capturable=True)

criterion = nn.MSELoss()

input_data = torch.randn(32, 10)
target_data = torch.randn(32, 1)

# optional: cuda
model = model.cuda()
input_data = input_data.cuda()
target_data = target_data.cuda()

num_epochs = 10
for epoch in range(num_epochs):
    outputs = model(input_data)
    loss = criterion(outputs, target_data)

    optimizer.zero_grad()
    loss.backward()
    optimizer.step()

    print(f'Epoch [{epoch+1}/{num_epochs}], Loss: {loss.item():.4f}')
```

Unknown:
Why the old code used `(lr / bc) * -1`. I changed it instead to `-(lr / bc)` (and then `-(lr * bc2 / bc1)`), but maybe there is some hidden behavior?

cc @jerryzh168