### PR TITLE
[SymmMem] Promote `@requires_nvshmem` instead of `enable_triton`

### DIFF
--- a/test/distributed/test_nvshmem_triton.py
+++ b/test/distributed/test_nvshmem_triton.py
@@ -9,6 +9,7 @@ import torch.distributed as dist
 import torch.distributed._symmetric_memory as symm_mem
 import torch.distributed._symmetric_memory._nvshmem_triton as nvshmem
 from torch._inductor.runtime.triton_compat import triton
+from torch.distributed._symmetric_memory._nvshmem_triton import requires_nvshmem
 from torch.testing._internal.common_distributed import MultiProcContinuousTest
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
@@ -21,7 +22,7 @@ from torch.testing._internal.inductor_utils import IS_H100, requires_triton
 
 
 # Decorators
-def requires_nvshmem():
+def skip_if_no_nvshmem():
     return skip_but_pass_in_sandcastle_if(
         not symm_mem.is_nvshmem_available(),
         "test_nvshmem requires NVSHMEM, skipping tests",
@@ -41,8 +42,9 @@ device_module = torch.get_device_module(device_type)
 
 
 # Shared Triton JIT kernels
+@requires_nvshmem
 @triton.jit
-def nvshmem_put_kernel(
+def my_put_kernel(
     dest,
     src,
     nelems,
@@ -51,8 +53,9 @@ def nvshmem_put_kernel(
     nvshmem.put(dest, src, nelems, pe)
 
 
+@requires_nvshmem
 @triton.jit
-def nvshmem_get_kernel(
+def my_get_kernel(
     dest,
     src,
     nelems,
@@ -61,8 +64,9 @@ def nvshmem_get_kernel(
     nvshmem.get(dest, src, nelems, pe)
 
 
+@requires_nvshmem
 @triton.jit
-def nvshmem_putmem_signal_block_kernel(
+def my_putmem_signal_block_kernel(
     dst,
     src,
     size_bytes,
@@ -74,13 +78,15 @@ def nvshmem_putmem_signal_block_kernel(
     nvshmem.putmem_signal_block(dst, src, size_bytes, signal, sig_val, sig_op, peer)
 
 
+@requires_nvshmem
 @triton.jit
-def nvshmem_signal_wait_until_kernel(signal, cmp_op, cmp_val):
+def my_signal_wait_until_kernel(signal, cmp_op, cmp_val):
     nvshmem.signal_wait_until(signal, cmp_op, cmp_val)
 
 
+@requires_nvshmem
 @triton.jit
-def nvshmem_signal_op_kernel(
+def my_signal_op_kernel(
     sig_addr,
     signal,
     sig_op,
@@ -89,8 +95,9 @@ def nvshmem_signal_op_kernel(
     nvshmem.signal_op(sig_addr, signal, sig_op, peer)
 
 
+@requires_nvshmem
 @triton.jit
-def nvshmem_wait_until_kernel(
+def my_wait_until_kernel(
     ivar,
     cmp_op,
     cmp_val,
@@ -98,13 +105,15 @@ def nvshmem_wait_until_kernel(
     nvshmem.wait_until(ivar, cmp_op, cmp_val)
 
 
+@requires_nvshmem
 @triton.jit
-def nvshmem_fence_kernel():
+def my_fence_kernel():
     nvshmem.fence()
 
 
+@requires_nvshmem
 @triton.jit
-def nvshmem_put_with_fence_kernel(
+def my_put_with_fence_kernel(
     dst1,
     src1,
     dst2,
@@ -126,8 +135,9 @@ def nvshmem_put_with_fence_kernel(
     nvshmem.put(flag_dst, flag_src, 1, peer)
 
 
+@requires_nvshmem
 @triton.jit
-def nvshmem_put_with_quiet_kernel(
+def my_put_with_quiet_kernel(
     dst,
     src,
     flag_dst,
@@ -144,8 +154,9 @@ def nvshmem_put_with_quiet_kernel(
     nvshmem.put(flag_dst, flag_src, 1, peer)
 
 
+@requires_nvshmem
 @triton.jit
-def nvshmem_barrier_test_kernel(
+def my_barrier_test_kernel(
     dst,
     src,
     nelems,
@@ -178,13 +189,15 @@ def nvshmem_barrier_test_kernel(
         tl.store(p_dst, received + 1)
 
 
+@requires_nvshmem
 @triton.jit
-def nvshmem_barrier_all_kernel():
+def my_barrier_all_kernel():
     nvshmem.barrier_all()
 
 
+@requires_nvshmem
 @triton.jit
-def nvshmem_sync_test_kernel(
+def my_sync_test_kernel(
     local_data,
     remote_data,
     nelems,
@@ -210,8 +223,9 @@ def nvshmem_sync_test_kernel(
     # because sync_all() made those local stores visible
 
 
+@requires_nvshmem
 @triton.jit
-def nvshmem_alltoall_kernel(
+def my_alltoall_kernel(
     team_handle,
     dst,
     src,
@@ -220,8 +234,9 @@ def nvshmem_alltoall_kernel(
     nvshmem.alltoall(team_handle, dst, src, nelems_per_pe)
 
 
+@requires_nvshmem
 @triton.jit
-def nvshmem_broadcast_kernel(
+def my_broadcast_kernel(
     team_handle,
     dst,
     src,
@@ -231,8 +246,9 @@ def nvshmem_broadcast_kernel(
     nvshmem.broadcast(team_handle, dst, src, nelems, pe_root)
 
 
+@requires_nvshmem
 @triton.jit
-def nvshmem_reduce_kernel(
+def my_reduce_kernel(
     team_handle,
     dest_tensor,
     source_tensor,
@@ -243,7 +259,7 @@ def nvshmem_reduce_kernel(
 
 
 @instantiate_parametrized_tests
-@requires_nvshmem()
+@skip_if_no_nvshmem()
 class NVSHMEMTritonTest(MultiProcContinuousTest):
     def _init_device(self) -> None:
         # TODO: relieve this (seems to hang if without)
@@ -261,9 +277,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
     def test_triton_put(self) -> None:
         torch.manual_seed(42 + self.rank)
         self._init_device()
-
-        # Enable NVSHMEM for Triton
-        nvshmem_lib = nvshmem.enable_triton()
 
         group_name = dist.distributed_c10d._get_default_group().group_name
         symm_mem.enable_symm_mem_for_group(group_name)
@@ -294,12 +307,11 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
         peer = 1 - rank
         if rank == 0:
             # Rank 0 puts its data to Rank 1
-            nvshmem_put_kernel[(1,)](
+            my_put_kernel[(1,)](
                 dst,
                 src,
                 nelems,
                 peer,
-                extern_libs=nvshmem_lib,
             )
 
         # Synchronize after operation
@@ -319,7 +331,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
         torch.manual_seed(42 + self.rank)
         self._init_device()
 
-        nvshmem_lib = nvshmem.enable_triton()
         group_name = dist.distributed_c10d._get_default_group().group_name
         symm_mem.enable_symm_mem_for_group(group_name)
         rank = self.rank
@@ -341,12 +352,11 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
         peer = 1 - rank
         if rank == 1:
             # Rank 1 gets data from rank 0 using tensor-aware API
-            nvshmem_get_kernel[(1,)](
+            my_get_kernel[(1,)](
                 out,
                 inp,
                 numel,
                 peer,
-                extern_libs=nvshmem_lib,
             )
         if rank == 1:
             torch.testing.assert_close(
@@ -360,7 +370,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
         torch.manual_seed(42 + self.rank)
         self._init_device()
 
-        nvshmem_lib = nvshmem.enable_triton()
         group_name = dist.distributed_c10d._get_default_group().group_name
         symm_mem.enable_symm_mem_for_group(group_name)
         rank = self.rank
@@ -383,12 +392,11 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
         peer = (rank - 1) % world_size
 
         # All ranks execute the get operation using tensor-aware API
-        nvshmem_get_kernel[(1,)](
+        my_get_kernel[(1,)](
             out,
             inp,
             numel,
             peer,
-            extern_libs=nvshmem_lib,
         )
 
         expected_value = peer
@@ -402,8 +410,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
     def test_triton_put_signal_set(self) -> None:
         torch.manual_seed(42 + self.rank)
         self._init_device()
-
-        nvshmem_lib = nvshmem.enable_triton()
 
         group_name = dist.distributed_c10d._get_default_group().group_name
         symm_mem.enable_symm_mem_for_group(group_name)
@@ -431,7 +437,7 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
 
         if rank == 0:
             # Rank 0 puts into Rank 1
-            nvshmem_putmem_signal_block_kernel[(1, 1, 1)](
+            my_putmem_signal_block_kernel[(1, 1, 1)](
                 out,
                 inp,
                 size_bytes=msg_size_bytes,
@@ -439,16 +445,14 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
                 sig_val=SIGNAL_VAL,
                 sig_op=NVSHMEM_SIGNAL_SET,
                 peer=peer,
-                extern_libs=nvshmem_lib,
             )
 
         if rank == 1:
             # Wait until signal flag is set by Rank 0
-            nvshmem_signal_wait_until_kernel[(1,)](
+            my_signal_wait_until_kernel[(1,)](
                 flag,
                 cmp_op=NVSHMEM_CMP_EQ,
                 cmp_val=SIGNAL_VAL,
-                extern_libs=nvshmem_lib,
             )
             # After wait completes, verify data and flag contents
             torch.testing.assert_close(
@@ -464,8 +468,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
     def test_triton_put_signal_add(self) -> None:
         torch.manual_seed(42 + self.rank)
         self._init_device()
-
-        nvshmem_lib = nvshmem.enable_triton()
 
         group_name = dist.distributed_c10d._get_default_group().group_name
         symm_mem.enable_symm_mem_for_group(group_name)
@@ -493,7 +495,7 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
 
         if rank == 0:
             # Rank 0 puts into Rank 1
-            nvshmem_putmem_signal_block_kernel[(1, 1, 1)](
+            my_putmem_signal_block_kernel[(1, 1, 1)](
                 out,
                 inp,
                 size_bytes=msg_size_bytes,
@@ -501,15 +503,13 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
                 sig_val=SIGNAL_VAL,
                 sig_op=NVSHMEM_SIGNAL_ADD,
                 peer=peer,
-                extern_libs=nvshmem_lib,
             )
 
         if rank == 1:
-            nvshmem_signal_wait_until_kernel[(1, 1, 1)](
+            my_signal_wait_until_kernel[(1, 1, 1)](
                 flag,
                 cmp_op=NVSHMEM_CMP_EQ,
                 cmp_val=SIGNAL_VAL,
-                extern_libs=nvshmem_lib,
             )
             torch.testing.assert_close(
                 out, val * torch.ones(numel, dtype=dtype, device=self.device)
@@ -525,7 +525,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
         torch.manual_seed(42 + self.rank)
         self._init_device()
 
-        nvshmem_lib = nvshmem.enable_triton()
         group_name = dist.distributed_c10d._get_default_group().group_name
         symm_mem.enable_symm_mem_for_group(group_name)
 
@@ -544,15 +543,14 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
             [FLAG_FINAL_VALUE], dtype=torch.int32, device=self.device
         )
 
-        nvshmem_barrier_all_kernel[(1,)](extern_libs=nvshmem_lib)
+        my_barrier_all_kernel[(1,)]()
 
         if rank == 0:
             # Rank 0 (the waiter)
-            nvshmem_wait_until_kernel[(1,)](
+            my_wait_until_kernel[(1,)](
                 flag,
                 cmp_op=NVSHMEM_CMP_EQ,
                 cmp_val=FLAG_FINAL_VALUE,
-                extern_libs=nvshmem_lib,
             )
 
             # Verification
@@ -564,12 +562,11 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
         if rank == 1:
             # Rank 1 (the signaler)
             # Launch a kernel to put the value to Rank 0's flag tensor.
-            nvshmem_put_kernel[(1,)](
+            my_put_kernel[(1,)](
                 flag,  # Destination symmetric tensor on the remote PE
                 expected_flag,  # Source data tensor (local)
                 1,  # Number of elements
                 peer,  # The target PE (Rank 0)
-                extern_libs=nvshmem_lib,
             )
 
     @skipIfRocm
@@ -577,8 +574,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
     @requires_h100()
     def test_triton_signal_wait_until(self) -> None:
         self._init_device()
-        # Enable NVSHMEM for Triton
-        nvshmem_lib = nvshmem.enable_triton()
         group_name = dist.distributed_c10d._get_default_group().group_name
         symm_mem.enable_symm_mem_for_group(group_name)
         rank = self.rank
@@ -608,7 +603,7 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
 
         if rank == 0:
             # Producer (rank 0): Puts data into rank 1's `out` buffer and then sets the flag
-            nvshmem_putmem_signal_block_kernel[(1, 1, 1)](
+            my_putmem_signal_block_kernel[(1, 1, 1)](
                 out,
                 inp,
                 size_bytes=msg_size_bytes,
@@ -616,15 +611,13 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
                 sig_val=COMPLETION_FLAG_VAL,
                 sig_op=NVSHMEM_SIGNAL_SET,
                 peer=peer,
-                extern_libs=nvshmem_lib,
             )
         elif rank == 1:
             # Consumer (rank 1): Waits on the signal variable using `signal_wait_until`.
-            nvshmem_signal_wait_until_kernel[(1, 1, 1)](
+            my_signal_wait_until_kernel[(1, 1, 1)](
                 flag,
                 cmp_op=NVSHMEM_CMP_EQ,
                 cmp_val=COMPLETION_FLAG_VAL,
-                extern_libs=nvshmem_lib,
             )
             # After the wait returns, verify data and flag
             torch.testing.assert_close(
@@ -651,7 +644,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
         """
         torch.manual_seed(42 + self.rank)
         self._init_device()
-        nvshmem_lib = nvshmem.enable_triton()
         group_name = dist.distributed_c10d._get_default_group().group_name
         symm_mem.enable_symm_mem_for_group(group_name)
         rank = self.rank
@@ -682,7 +674,7 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
         NVSHMEM_CMP_EQ = 0  # compare equal
 
         if rank == 0:
-            nvshmem_put_with_fence_kernel[(1,)](
+            my_put_with_fence_kernel[(1,)](
                 out1,
                 inp1,
                 out2,
@@ -691,15 +683,13 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
                 flag_update_val,
                 nelems=numel,
                 peer=peer,
-                extern_libs=nvshmem_lib,
             )
         elif rank == 1:
             # Wait until flag is set by Rank 0
-            nvshmem_wait_until_kernel[(1,)](
+            my_wait_until_kernel[(1,)](
                 flag,
                 cmp_op=NVSHMEM_CMP_EQ,
                 cmp_val=flag_val,
-                extern_libs=nvshmem_lib,
             )
 
             # Verify ordered data arrival.
@@ -719,7 +709,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
     def test_triton_quiet(self) -> None:
         torch.manual_seed(42 + self.rank)
         self._init_device()
-        nvshmem_lib = nvshmem.enable_triton()
         group_name = dist.distributed_c10d._get_default_group().group_name
         symm_mem.enable_symm_mem_for_group(group_name)
         rank = self.rank
@@ -745,21 +734,19 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
 
         dist.barrier()
         if rank == 1:
-            nvshmem_put_with_quiet_kernel[(1,)](
+            my_put_with_quiet_kernel[(1,)](
                 out,
                 inp,
                 flag,
                 flag_update_val,
                 nelems=numel,
                 peer=peer,
-                extern_libs=nvshmem_lib,
             )
         elif rank == 0:
-            nvshmem_wait_until_kernel[(1,)](
+            my_wait_until_kernel[(1,)](
                 flag,
                 cmp_op=NVSHMEM_CMP_EQ,
                 cmp_val=flag_val,
-                extern_libs=nvshmem_lib,
             )
             torch.testing.assert_close(
                 out, val * torch.ones(numel, dtype=dtype, device=self.device)
@@ -772,7 +759,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
     def test_triton_barrier(self) -> None:
         torch.manual_seed(42 + self.rank)
         self._init_device()
-        nvshmem_lib = nvshmem.enable_triton()
         group_name = dist.distributed_c10d._get_default_group().group_name
         symm_mem.enable_symm_mem_for_group(group_name)
         rank = self.rank
@@ -784,11 +770,10 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
         symm_mem.rendezvous(src, group=group_name)
         symm_mem.rendezvous(dst, group=group_name)
 
-        nvshmem_barrier_test_kernel[(1,)](
+        my_barrier_test_kernel[(1,)](
             dst,
             src,
             nelems=numel,
-            extern_libs=nvshmem_lib,
             launch_cooperative_grid=True,
             num_ctas=1,
         )
@@ -810,7 +795,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
         torch.manual_seed(42 + self.rank)
         self._init_device()
 
-        nvshmem_lib = nvshmem.enable_triton()
         group_name = dist.distributed_c10d._get_default_group().group_name
         symm_mem.enable_symm_mem_for_group(group_name)
         rank = self.rank
@@ -824,11 +808,10 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
         symm_mem.rendezvous(remote_data, group=group_name)
 
         # Launch kernel with cooperative grid
-        nvshmem_sync_test_kernel[(1,)](
+        my_sync_test_kernel[(1,)](
             local_data,
             remote_data,
             nelems=numel,
-            extern_libs=nvshmem_lib,
             launch_cooperative_grid=True,
             num_ctas=1,
         )
@@ -855,7 +838,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
     def test_triton_alltoall(self) -> None:
         torch.manual_seed(42 + self.rank)
         self._init_device()
-        nvshmem_lib = nvshmem.enable_triton()
         group_name = dist.distributed_c10d._get_default_group().group_name
         symm_mem.enable_symm_mem_for_group(group_name)
         world_size = dist.get_world_size()
@@ -880,12 +862,11 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
         dist.barrier()
         team_handle = 0  # NVSHMEM_TEAM_WORLD handle is 0
         # Launch the kernel using new tensor-aware API
-        nvshmem_alltoall_kernel[(1,)](
+        my_alltoall_kernel[(1,)](
             team_handle,
             dst,
             src,
             nelems_per_pe,
-            extern_libs=nvshmem_lib,
             launch_cooperative_grid=True,
         )
         # Synchronize after alltoall
@@ -904,7 +885,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
     def test_triton_broadcast(self) -> None:
         torch.manual_seed(42 + self.rank)
         self._init_device()
-        nvshmem_lib = nvshmem.enable_triton()
         group_name = dist.distributed_c10d._get_default_group().group_name
         symm_mem.enable_symm_mem_for_group(group_name)
         rank = self.rank
@@ -935,13 +915,12 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
 
         # Execute broadcast
         team_handle = 0  # NVSHMEM_TEAM_WORLD
-        nvshmem_broadcast_kernel[(1,)](
+        my_broadcast_kernel[(1,)](
             team_handle,
             dst,
             src,
             nelems,
             pe_root,
-            extern_libs=nvshmem_lib,
             launch_cooperative_grid=True,
         )
 
@@ -974,7 +953,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
     def test_triton_sum_reduce(self, dtype) -> None:
         torch.manual_seed(42 + self.rank)
         self._init_device()
-        nvshmem_lib = nvshmem.enable_triton()
         group_name = dist.distributed_c10d._get_default_group().group_name
         symm_mem.enable_symm_mem_for_group(group_name)
         world_size = dist.get_world_size()
@@ -1001,13 +979,12 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
 
         # Execute sum reduction across all ranks
         team_handle = 0  # NVSHMEM_TEAM_WORLD
-        nvshmem_reduce_kernel[(1,)](
+        my_reduce_kernel[(1,)](
             team_handle,
             dst,
             src,
             nreduce,
             operation="sum",
-            extern_libs=nvshmem_lib,
             launch_cooperative_grid=True,
         )
 
@@ -1038,7 +1015,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
     def test_triton_minmax_reduce(self, dtype) -> None:
         torch.manual_seed(42 + self.rank)
         self._init_device()
-        nvshmem_lib = nvshmem.enable_triton()
         group_name = dist.distributed_c10d._get_default_group().group_name
         symm_mem.enable_symm_mem_for_group(group_name)
         world_size = dist.get_world_size()
@@ -1080,23 +1056,21 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
         dist.barrier()
         # Execute MIN reduction
         team_handle = 0
-        nvshmem_reduce_kernel[(1,)](
+        my_reduce_kernel[(1,)](
             team_handle,
             dst_min,
             src_min,
             nreduce,
             operation="min",
-            extern_libs=nvshmem_lib,
             launch_cooperative_grid=True,
         )
         # Execute MAX reduction
-        nvshmem_reduce_kernel[(1,)](
+        my_reduce_kernel[(1,)](
             team_handle,
             dst_max,
             src_max,
             nreduce,
             operation="max",
-            extern_libs=nvshmem_lib,
             launch_cooperative_grid=True,
         )
         dist.barrier()
@@ -1127,7 +1101,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
     def test_triton_prod_reduce(self, dtype) -> None:
         torch.manual_seed(42 + self.rank)
         self._init_device()
-        nvshmem_lib = nvshmem.enable_triton()
         group_name = dist.distributed_c10d._get_default_group().group_name
         symm_mem.enable_symm_mem_for_group(group_name)
         world_size = dist.get_world_size()
@@ -1167,13 +1140,12 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
 
         # Execute product reduction across all ranks
         team_handle = 0  # NVSHMEM_TEAM_WORLD
-        nvshmem_reduce_kernel[(1,)](
+        my_reduce_kernel[(1,)](
             team_handle,
             dst,
             src,
             nreduce,
             operation="prod",
-            extern_libs=nvshmem_lib,
             launch_cooperative_grid=True,
         )
 

--- a/test/distributed/test_nvshmem_triton.py
+++ b/test/distributed/test_nvshmem_triton.py
@@ -2,6 +2,8 @@
 # To run:
 # python test/distributed/test_nvshmem_triton.py
 
+import sys
+
 import triton.language as tl
 
 import torch
@@ -21,12 +23,9 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.inductor_utils import IS_H100, requires_triton
 
 
-# Decorators
-def skip_if_no_nvshmem():
-    return skip_but_pass_in_sandcastle_if(
-        not symm_mem.is_nvshmem_available(),
-        "test_nvshmem requires NVSHMEM, skipping tests",
-    )
+if not symm_mem.is_nvshmem_available():
+    print("NVSHMEM not available, skipping tests")
+    sys.exit(0)
 
 
 def requires_h100():
@@ -42,6 +41,8 @@ device_module = torch.get_device_module(device_type)
 
 
 # Shared Triton JIT kernels
+
+
 @requires_nvshmem
 @triton.jit
 def my_put_kernel(
@@ -259,7 +260,6 @@ def my_reduce_kernel(
 
 
 @instantiate_parametrized_tests
-@skip_if_no_nvshmem()
 class NVSHMEMTritonTest(MultiProcContinuousTest):
     def _init_device(self) -> None:
         # TODO: relieve this (seems to hang if without)

--- a/torch/distributed/_symmetric_memory/_nvshmem_triton.py
+++ b/torch/distributed/_symmetric_memory/_nvshmem_triton.py
@@ -5,7 +5,6 @@ import sysconfig
 from typing import Any, Optional
 
 import torch.distributed as dist
-from torch.distributed._distributed_c10d import _nvshmemx_cumodule_init
 from torch.utils._triton import has_triton
 
 
@@ -155,6 +154,7 @@ def _nvshmem_init_hook(*args, **kwargs) -> None:  # type: ignore[no-untyped-def]
     A hook function to initialize the CUModule created by `triton.jit` with
     NVSHMEM device context
     """
+    from torch._C._distributed_c10d import _nvshmemx_cumodule_init
     jit_function = kwargs["fn"].jit_function
     fn_name = jit_function.fn.__name__
 

--- a/torch/distributed/_symmetric_memory/_nvshmem_triton.py
+++ b/torch/distributed/_symmetric_memory/_nvshmem_triton.py
@@ -5,114 +5,235 @@ import sysconfig
 from typing import Any, Optional
 
 import torch.distributed as dist
+from torch.distributed._distributed_c10d import _nvshmemx_cumodule_init
 from torch.utils._triton import has_triton
 
 
 logger = logging.getLogger(__name__)
 
 
-def _find_nvshmem_device_library() -> str:
-    paths = [os.path.join(sysconfig.get_path("purelib"), "nvidia", "nvshmem", "lib")]
+class NvshmemLibFinder:
+    """
+    A class to find path to the NVSHMEM device library.
 
-    # Add common system installation paths
-    common_paths = [
-        "/usr/local/lib",
-        "/usr/lib",
-        "/opt/nvidia/nvshmem/lib",
-    ]
-    paths.extend(common_paths)
+    Environment variable:
 
-    try:
-        import torch
+    `NVSHMEM_LIB_DIR` (Optional[str]): The directory where the NVSHMEM device
+    library is located. If not provided, it will use the default path where
+    NVSHMEM wheel is installed, or search for the library in common system
+    paths.
+    """
 
-        torch_lib = os.path.join(os.path.dirname(torch.__file__), "lib")
-        so_path = os.path.join(torch_lib, "libtorch_nvshmem.so")
+    # Class variable to store the found library path for reuse
+    found_device_lib_path: Optional[str] = None
 
-        if os.path.exists(so_path):
-            try:
-                result = subprocess.run(
-                    ["readelf", "-d", so_path],
-                    capture_output=True,
-                    text=True,
-                    check=True,
+    @classmethod
+    def find_device_library(cls) -> str:
+        """
+        Find the path to the NVSHMEM device library.
+
+        Returns:
+            str: The path to libnvshmem_device.bc (included).
+        """
+        if cls.found_device_lib_path is not None:
+            # Return the cached path if it exists
+            return cls.found_device_lib_path
+
+        # First, check if the user has specified a custom library path
+        user_lib_dir = os.environ.get("NVSHMEM_LIB_DIR", None)
+        if user_lib_dir is not None:
+            lib_path = os.path.join(user_lib_dir, "libnvshmem_device.bc")
+            if not os.path.exists(lib_path):
+                raise RuntimeError(
+                    f"NVSHMEM device library not found at specified path: {user_lib_dir}"
                 )
+            cls.found_device_lib_path = lib_path
+            return lib_path
 
-                for line in result.stdout.splitlines():
-                    if ("RPATH" in line or "RUNPATH" in line) and "[" in line:
-                        rpath = line.split("[", 1)[1].split("]", 1)[0]
-                        for p in rpath.split(":"):
-                            p = p.strip().replace("$ORIGIN", torch_lib)
-                            if p and p not in paths:
-                                paths.append(p)
-            except subprocess.CalledProcessError:
-                pass
+        # Otherwise, search for the library in the default installation paths
+        paths = [
+            os.path.join(sysconfig.get_path("purelib"), "nvidia", "nvshmem", "lib")
+        ]
 
-    except ImportError:
-        pass
+        # Add common system installation paths
+        common_paths = [
+            "/usr/local/lib",
+            "/usr/lib",
+            "/opt/nvidia/nvshmem/lib",
+        ]
+        paths.extend(common_paths)
 
-    for path in paths:
-        device_lib = os.path.join(path, "libnvshmem_device.bc")
-        if os.path.exists(device_lib):
-            return device_lib
+        try:
+            import torch
 
-    raise RuntimeError(f"NVSHMEM device library not found. Searched: {paths}")
+            torch_lib = os.path.join(os.path.dirname(torch.__file__), "lib")
+            so_path = os.path.join(torch_lib, "libtorch_nvshmem.so")
+
+            if os.path.exists(so_path):
+                try:
+                    result = subprocess.run(
+                        ["readelf", "-d", so_path],
+                        capture_output=True,
+                        text=True,
+                        check=True,
+                    )
+
+                    for line in result.stdout.splitlines():
+                        if ("RPATH" in line or "RUNPATH" in line) and "[" in line:
+                            rpath = line.split("[", 1)[1].split("]", 1)[0]
+                            for p in rpath.split(":"):
+                                p = p.strip().replace("$ORIGIN", torch_lib)
+                                if p and p not in paths:
+                                    paths.append(p)
+                except subprocess.CalledProcessError:
+                    pass
+
+        except ImportError:
+            pass
+
+        for path in paths:
+            device_lib = os.path.join(path, "libnvshmem_device.bc")
+            if os.path.exists(device_lib):
+                cls.found_device_lib_path = device_lib
+                return device_lib
+
+        raise RuntimeError(f"NVSHMEM device library not found. Searched: {paths}")
 
 
 def enable_triton(lib_dir: Optional[str] = None) -> dict[str, str]:
+    raise NotImplementedError(
+        "`enable_triton` is deprecated. "
+        "If you need NVSHMEM device function support for Triton, "
+        "please use `@requires_nvshmem` to decorate your Triton kernel. ",
+    )
+
+
+class NvshmemKernelRegistry:
     """
-    Enable NVSHMEM device functions for Triton. It performs a NVSHMEM
-    device-side initialization on the kernel module created by Triton.
-
-    This function sets a global hook that initializes NVSHMEM for Triton
-    kernels. To avoid unnecessary initializations, the hook only acts on
-    kernels that have "nvshmem" in their function name. Therefore, it is
-    required that all Triton kernels using NVSHMEM primitives follow this
-    naming convention.
-
-    Args:
-        lib_dir (Optional[str]): The directory where the NVSHMEM device library
-        is located. If not provided, it will use the default path where NVSHMEM
-        wheel is installed.
-
-    Returns:
-        dict[str, str]: A dictionary containing the NVSHMEM device library name
-        and path.
+    A class to register kernel functions that ** require NVSHMEM initialization **
     """
-    import triton
 
-    from torch._C._distributed_c10d import _nvshmemx_cumodule_init
+    # Class variable to store the functions to be initialized
+    _to_init: dict[str, Any] = {}
 
-    if lib_dir is not None:
-        lib_path = os.path.join(lib_dir, "libnvshmem_device.bc")
-        if not os.path.exists(lib_path):
-            raise RuntimeError(
-                f"NVSHMEM device library not found at specified path: {lib_path}"
+    @classmethod
+    def register(cls, name: str) -> None:
+        """
+        Register a kernel function with the given name.
+
+        Args:
+            name (str): The name of the kernel function.
+        """
+        cls._to_init.setdefault(name)
+
+    @classmethod
+    def deregister(cls, name: str) -> None:
+        """
+        Deregister a kernel function with the given name.
+
+        Args:
+            name (str): The name of the kernel function.
+        """
+        cls._to_init.pop(name, None)
+
+    @classmethod
+    def has(cls, name: str) -> bool:
+        """
+        Check if a kernel function with the given name is registered.
+
+        Args:
+            name (str): The name of the kernel function.
+
+        Returns:
+            bool: True if the kernel function is registered, False otherwise.
+        """
+        return name in cls._to_init
+
+
+def _nvshmem_init_hook(*args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+    """
+    A hook function to initialize the CUModule created by `triton.jit` with
+    NVSHMEM device context
+    """
+    jit_function = kwargs["fn"].jit_function
+    fn_name = jit_function.fn.__name__
+
+    # Only initialize NVSHMEM module for kernels registered via @requires_nvshmem
+    if NvshmemKernelRegistry.has(fn_name):
+        key = kwargs["key"]
+        device = kwargs["compile"]["device"]
+        jit_function = kwargs["fn"].jit_function
+        kernel_cache = jit_function.device_caches[device][0]
+        kernel = kernel_cache.get(key, None)
+        if kernel is not None:
+            kernel.run
+            # Initialize NVSHMEM for the CU module
+            _nvshmemx_cumodule_init(kernel.module)
+        else:
+            logger.warning(
+                f"It seems Triton hasn't created a kernel for function {fn_name}. "  # noqa: G004
+                "Please report this issue to Triton."
             )
-    else:
-        # Otherwise, search for the library automatically.
-        lib_path = _find_nvshmem_device_library()
 
+
+def requires_nvshmem(  # type: ignore[no-untyped-def]
+    jit_func,  # JITFunction created by triton.jit
+):
+    """
+    A decorator to register a Triton kernel function that requires NVSHMEM initialization.
+
+    Example usage:
+    ```
+        @requires_nvshmem
+        @triton.jit
+        def foo(...):
+            ...
+    ```
+
+    If you would like to specify a path to the NVSHMEM device library other
+    than standard search locations, you can use the following environment
+    variable:
+    ```
+        export NVSHMEM_LIB_DIR=/path/to/nvshmem/lib
+    ```
+    """
+
+    import triton
+    from triton.runtime.jit import JITFunction, KernelInterface
+
+    if not isinstance(jit_func, JITFunction):
+        raise TypeError(f"Expected a JITFunction, but got {type(jit_func)}")
+
+    # Find the NVSHMEM device library
+    lib_path = NvshmemLibFinder.find_device_library()
     extern_libs = {"libnvshmem_device": lib_path}
 
-    # A hook function to initialize NVSHMEM in Triton
-    def nvshmem_init_hook(*args, **kwargs) -> None:  # type: ignore[no-untyped-def]
-        jit_function = kwargs["fn"].jit_function
-        # Only initialize NVSHMEM module for kernels containing "nvshmem" in their name
-        if "nvshmem" in jit_function.fn.__name__:
-            key = kwargs["key"]
-            device = kwargs["compile"]["device"]
-            jit_function = kwargs["fn"].jit_function
-            kernel_cache = jit_function.device_caches[device][0]
-            kernel = kernel_cache.get(key, None)
-            if kernel is not None:
-                kernel.run
-                _nvshmemx_cumodule_init(kernel.module)
+    # Register the JITFunction with the kernel registry as "to be initialized"
+    NvshmemKernelRegistry.register(jit_func.fn.__name__)
 
-    # Register the function as a post-compile hook
-    triton.knobs.runtime.jit_post_compile_hook = nvshmem_init_hook
+    # Register the NVSHMEM init function as a post-compile hook.
+    # [Note] This is a global setting (due to lack of Triton API exposure). To
+    # avoid initializing Triton kernels that do not require NVSHMEM, filtering
+    # is performed in the hook function itself by checking against
+    # NvshmemKernelRegistry.
+    triton.knobs.runtime.jit_post_compile_hook = _nvshmem_init_hook
 
-    # Return to user so that they can use it in Triton kernel invocation
-    return extern_libs
+    # Create a new Callable class that follows the KernelInterface protocol so
+    # that the Callable works with the subscript operator, e.g. `foo[(1, 1)]`
+    class MyGridCallable(KernelInterface):
+        """
+        `KernelInterface` invokes `self.run` in `__getitem__`, i.e. [].  We
+        implement a `run` method by directing the call to `JITFunction.run`,
+        with added extern_libs kwarg, so that users don't have to pass it
+        """
+
+        def run(self, *args, grid, warmup, **kwargs):  # type: ignore[no-untyped-def]
+            # Call the JITFunction.run with added extern_libs kwarg
+            return jit_func.run(
+                *args, **kwargs, grid=grid, warmup=warmup, extern_libs=extern_libs
+            )
+
+    return MyGridCallable()
 
 
 if has_triton():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #163423

### Issue
The previous `enable_triton` UI requires the user-defined Triton kernel have a "nvshmem" in its name.
If users did not do so, the kernel would miss the NVSHMEM init, and silently hit CUDA IMA. 

The `@require_nvshmem` decorator eliminates the above name requirement (and the `enable_triton` call).

### Usage:
```
@requires_nvshmem
@triton.jit
def foo(...):
    ...

foo[(1, 1)](...)
```
It also remove the need of passing `extern_lib` to `foo` (handled by the decorator now).

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @gujinghui @PenghuiCheng @jianyuh @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal @mcarilli @ptrblck @leslie-fang-intel @voznesenskym @penguinwu @EikanWang @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @Lucaskabela