### PR TITLE
[precompile] Add option to disable guard check on aot-compiled function.

### DIFF
--- a/torch/_dynamo/aot_compile.py
+++ b/torch/_dynamo/aot_compile.py
@@ -69,6 +69,7 @@ class CompileArtifacts:
 @dataclass
 class AOTCompiledFunction:
     _artifacts: CompileArtifacts
+    _guard_check_enabled: bool = True
 
     def guard_check(self, *args: Any, **kwargs: Any) -> bool:
         f_locals = bind_locals(self._artifacts.signature, *args, **kwargs)
@@ -101,7 +102,7 @@ class AOTCompiledFunction:
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         assert self._artifacts.guard_manager is not None
-        if not self.guard_check(*args, **kwargs):
+        if self._guard_check_enabled and not self.guard_check(*args, **kwargs):
             f_locals = bind_locals(self._artifacts.signature, *args, **kwargs)
             reason = str(self._artifacts.guard_manager.check_verbose(f_locals))
             raise RuntimeError(f"GuardManager check failed, reason: {reason}")
@@ -141,6 +142,9 @@ class AOTCompiledFunction:
 
         artifacts = CompileArtifacts(**state)
         return cls(artifacts)
+
+    def disable_guard_check(self) -> None:
+        self._guard_check_enabled = False
 
 
 class BundledAOTAutogradSerializableCallable(SerializableCallable):


### PR DESCRIPTION
Summary:
Under circumstances it seems reasonable to return a callable directly without guard check when user use aot_compile on a function with single compilation result.

When having multiple entries (aot_compile_module), we should start enabling guard check to differetiate different compiled functions apart.

Test Plan: CI




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela