### PR TITLE
Remove workarounds for Python 3.6

### DIFF
--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -87,10 +87,7 @@ class C10dRendezvousBackend(RendezvousBackend):
             if not isinstance(token, bytes):
                 result = self.get_state()
                 if result is not None:
-                    tmp = *result, False
-                    # Python 3.6 does not support tuple unpacking in return
-                    # statements.
-                    return tmp
+                    return *result, False
                 return None
 
             token = token.decode()

--- a/torch/distributed/elastic/rendezvous/etcd_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/etcd_rendezvous_backend.py
@@ -96,10 +96,7 @@ class EtcdRendezvousBackend(RendezvousBackend):
         def get_state():
             result = self.get_state()
             if result is not None:
-                tmp = *result, False
-                # Python 3.6 does not support tuple unpacking in return
-                # statements.
-                return tmp
+                return *result, False
             return None
 
         if token:


### PR DESCRIPTION
This PR removes tuple unpacking workarounds for Py 3.6 form two distributed files. 

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci