### PR TITLE
[AMP][Refactor] Simplify dtype support logic in autocast context manager

### DIFF
--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -346,7 +346,7 @@ class TestAutocastMPS(TestCase):
     def test_mps_autocast_error_message(self):
         with self.assertWarnsRegex(
             UserWarning,
-            "MPS Autocast only supports dtype of torch.bfloat16 and torch.float16 currently.",
+            "MPS Autocast only supports dtypes of torch.bfloat16, torch.float16 currently.",
         ):
             with torch.autocast(device_type="mps", dtype=torch.float32):
                 _ = torch.ones(10)

--- a/torch/amp/autocast_mode.py
+++ b/torch/amp/autocast_mode.py
@@ -284,18 +284,18 @@ class autocast:
         }
 
         if self.device in device_supported_dtypes:
-            supported_dtype = device_supported_dtypes[self.device]
+            supported_dtypes = device_supported_dtypes[self.device]
             device_name = (
                 self.device
                 if self.device == self.custom_backend_name
                 else self.device.upper()
             )
 
-            if self.fast_dtype not in supported_dtype and enabled:
+            if self.fast_dtype not in supported_dtypes and enabled:
                 error_message = (
                     f"In {device_name} autocast, but the target dtype is not supported. Disabling autocast.\n"
                     f"{device_name} Autocast only supports dtypes of "
-                    + ", ".join(str(dtype) for dtype in supported_dtype)
+                    + ", ".join(map(str, supported_dtypes))
                     + " currently."
                 )
                 warnings.warn(error_message)


### PR DESCRIPTION

## Description:

This PR refactors the autocast context manager in `autocast_mode.py` to simplify and centralize the logic for checking supported dtypes for each device. The previous implementation repeated similar checks for multiple device types. Now, a single mapping `device_supported_dtypes` is used to associate device types with their supported dtypes, and the validation logic is unified. 

In my view, this makes the code easier to maintain and extend for new devices.

Please share any suggestions and comments with me.

BTW, in the original `xla` branch, the `supported_dtype` are `[torch.float16, torch.bfloat16]`, https://github.com/pytorch/pytorch/blob/5d8a226e23339e7243a2a84afd174f685f145b68/torch/amp/autocast_mode.py#L358-L363 but the warning message has only `torch.bfloat16`.

cc @mcarilli @ptrblck @leslie-fang-intel @jgong5