### PR TITLE
fix: handle zero local shards correctly in distributed checkpoint

### DIFF
--- a/torch/distributed/checkpoint/planner.py
+++ b/torch/distributed/checkpoint/planner.py
@@ -349,7 +349,7 @@ class LoadPlanner:
     >>>         state_dict = {"foo_" + k: v for k, v in state_dict.items()}
     >>>
     >>>         if self.flatten_sharded_tensors:
-    >>>             state_dict = _flatten_sharded_tensors(state_dict)
+    >>>             state_dict, _ = _flatten_sharded_tensors(state_dict)
     >>>
     >>>         if self.flatten_state_dict:
     >>>             state_dict, self.mappings = flatten_state_dict(state_dict)


### PR DESCRIPTION
This fixes a subtle issue that can occur when there are zero local shards for a sharded tensor in a saved distributed checkpoint.

The following sequence of events could occur:
  1. `_flatten_sharded_tensors` would filter out the item from the state dict
  2. Then `DefaultLoadPlanner.create_local_plan` would wrongly treat the key as missing
  3. Which would then lead it to fall back to the old key format and fail

I fixed this by having `_flatten_sharded_tensors` return a set of paths that were being omitted so they wouldn't count as missing keys in the checkpoint.

(note: i observed this issue when saving/loading parameters of shape `1, N, D` and `1, D`, but it seems like a general issue)

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci