### PR TITLE
Add weights_only=True to torch.load

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -22,9 +22,6 @@ ignore =
     # TorchFix codes that don't make sense for PyTorch itself:
     # removed and deprecated PyTorch functions.
     TOR001,TOR101,
-    # TODO(kit1980): fix all TOR102 issues
-    # `torch.load` without `weights_only` parameter is unsafe
-    TOR102,
     # TODO(kit1980): resolve all TOR003 issues
     # pass `use_reentrant` explicitly to `checkpoint`.
     TOR003

--- a/torch/ao/pruning/_experimental/data_sparsifier/benchmarks/dlrm_utils.py
+++ b/torch/ao/pruning/_experimental/data_sparsifier/benchmarks/dlrm_utils.py
@@ -169,7 +169,9 @@ def fetch_model(model_path, device, sparse_dlrm=False):
         unzip_path = model_path
 
     model = get_dlrm_model(sparse_dlrm=sparse_dlrm)
-    model.load_state_dict(torch.load(unzip_path, map_location=device))
+    model.load_state_dict(
+        torch.load(unzip_path, map_location=device, weights_only=True)
+    )
     model = model.to(device)
     model.eval()
 

--- a/torch/ao/pruning/_experimental/data_sparsifier/benchmarks/evaluate_disk_savings.py
+++ b/torch/ao/pruning/_experimental/data_sparsifier/benchmarks/evaluate_disk_savings.py
@@ -112,7 +112,7 @@ def sparsify_model(path_to_model, sparsified_model_dump_path):
     print("Running for norms - ", norms)
 
     orig_model = get_dlrm_model()
-    saved_state = torch.load(path_to_model, map_location=device)
+    saved_state = torch.load(path_to_model, map_location=device, weights_only=True)
     orig_model.load_state_dict(saved_state["state_dict"])
 
     orig_model = orig_model.to(device)

--- a/torch/distributed/benchmarks/benchmark_ddp_rpc.py
+++ b/torch/distributed/benchmarks/benchmark_ddp_rpc.py
@@ -116,7 +116,7 @@ def _run_printable(cmd):
 
     output = []
     buffer = io.BytesIO(np.asarray(input_tensor).tobytes())
-    output.append(torch.load(buffer))
+    output.append(torch.load(buffer, weights_only=True))
     return output
 
 

--- a/torch/distributed/checkpoint/_experimental/checkpoint_reader.py
+++ b/torch/distributed/checkpoint/_experimental/checkpoint_reader.py
@@ -78,7 +78,7 @@ class CheckpointReader:
 
         if state_dict is None:
             result: tuple[STATE_DICT, list[str]] = (
-                torch.load(file_path, map_location=map_location),
+                torch.load(file_path, map_location=map_location, weights_only=True),
                 [],
             )
         else:
@@ -115,7 +115,9 @@ class CheckpointReader:
         """
 
         with FakeTensorMode():
-            metadata_dict = torch.load(file_path, map_location=map_location)
+            metadata_dict = torch.load(
+                file_path, map_location=map_location, weights_only=True
+            )
 
         missing_keys = []
 

--- a/torch/export/pt2_archive/_package.py
+++ b/torch/export/pt2_archive/_package.py
@@ -1136,7 +1136,7 @@ def load_pt2(
                     len(WEIGHTS_DIR) :
                 ]  # remove data/weights/ prefix
                 weight_bytes = archive_reader.read_bytes(file)
-                loaded_weight = torch.load(io.BytesIO(weight_bytes))
+                loaded_weight = torch.load(io.BytesIO(weight_bytes), weights_only=True)
                 weights[weight_file_name] = loaded_weight
 
     if isinstance(f, (io.IOBase, IO)):

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -1352,7 +1352,7 @@ class QuantizationTestCase(TestCase):
         b = io.BytesIO()
         torch.save(emb_dict, b)
         b.seek(0)
-        loaded_dict = torch.load(b)
+        loaded_dict = torch.load(b, weights_only=True)
         embedding_unpack = torch.ops.quantized.embedding_bag_unpack
         # Check unpacked weight values explicitly
         for key in emb_dict:

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -5737,7 +5737,9 @@ class DistributedTest:
 
             dist.barrier()
             map_location = {"cuda:0": f"cuda:{self.rank:d}"}
-            checkpoint = torch.load(chkpt_file, map_location=map_location)
+            checkpoint = torch.load(
+                chkpt_file, map_location=map_location, weights_only=True
+            )
             dummy_post_localSGD_opt.load_state_dict(checkpoint["optimizer_state_dict"])
 
             # Check that we didn't hit the trivial case
@@ -10160,7 +10162,9 @@ class DistributedTest:
             dist.barrier()
             map_location = {"cuda:0": f"cuda:{rank:d}"}
             with self.assertLogs("torch.distributed") as captured:
-                checkpoint = torch.load(chkpt_file, map_location=map_location)
+                checkpoint = torch.load(
+                    chkpt_file, map_location=map_location, weights_only=True
+                )
 
             # Check that the logger has only one entry
             self.assertEqual(len(captured.records), 1)

--- a/torch/utils/data/datapipes/utils/decoder.py
+++ b/torch/utils/data/datapipes/utils/decoder.py
@@ -75,7 +75,7 @@ def basichandlers(extension: str, data):
 
     if extension in ["pt"]:
         stream = io.BytesIO(data)
-        return torch.load(stream)
+        return torch.load(stream, weights_only=True)
 
     # if extension in "ten tb".split():
     #     from . import tenbin


### PR DESCRIPTION
This PR adds `weights_only=True` to remaining `torch.load` calls and enables `TOR102` in pyflake8.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci