### PR TITLE
Fix scaled_dot_product_attention reference implementation to match MATH backend

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2078,7 +2078,7 @@ class TestSDPA(NNTestCase):
     @parametrize("dtype", [torch.float32, torch.bfloat16, torch.half])
     @parametrize("n_heads", [[8, 8], [16, 8], [10, 2]])  # [q_heads, kv_heads]
     @parametrize("is_causal", [True, False])
-    def test_reference_implementation_bitwise_match_math_backend(self, device, dtype, n_heads, is_causal, dropout_p):
+    def test_reference_implementation_bitwise_match_math_backend(self, device, dtype, n_heads, is_causal):
         """Regression test for scaled_dot_product_attention documentation [1] implementation.
         Should produces bitwise identical results to the MATH backend.
 

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2078,7 +2078,6 @@ class TestSDPA(NNTestCase):
     @parametrize("dtype", [torch.float32, torch.bfloat16, torch.half])
     @parametrize("n_heads", [[8, 8], [16, 8], [10, 2]])  # [q_heads, kv_heads]
     @parametrize("is_causal", [True, False])
-    @parametrize("dropout_p", [0., 0.1])
     def test_reference_implementation_bitwise_match_math_backend(self, device, dtype, n_heads, is_causal, dropout_p):
         """Regression test for scaled_dot_product_attention documentation [1] implementation.
         Should produces bitwise identical results to the MATH backend.
@@ -2129,12 +2128,12 @@ class TestSDPA(NNTestCase):
         value = torch.randn(batch_size, kv_heads, seq_len, head_dim, device=device, dtype=dtype)
 
         doc_result = scaled_dot_product_attention(
-            query, key, value, dropout_p=dropout_p, is_causal=is_causal, enable_gqa=enable_gqa
+            query, key, value, dropout_p=0.0, is_causal=is_causal, enable_gqa=enable_gqa
         )
 
         with sdpa_kernel(backends=[SDPBackend.MATH]):
             math_ref = F.scaled_dot_product_attention(
-                query, key, value, dropout_p=dropout_p, is_causal=is_causal, enable_gqa=enable_gqa
+                query, key, value, dropout_p=0.0, is_causal=is_causal, enable_gqa=enable_gqa
             )
 
         # Must be exact bitwise match - no tolerance allowed

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2092,13 +2092,15 @@ class TestSDPA(NNTestCase):
             query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None, enable_gqa=False
         ) -> torch.Tensor:
             L, S = query.size(-2), key.size(-2)
-            scale_factor = 1 / math.sqrt(query.size(-1)) if scale is None else scale
+
+            # Default float32 upcast across all backends
             origin_dtype = query.dtype
             if not torch.backends.cuda.fp16_bf16_reduction_math_sdp_allowed():
-                # Convert to float32 for numerical stability (default behavior)
-                # Note: This flag affects the math backend globally (CPU and CUDA)
                 query, key, value = query.float(), key.float(), value.float()
+
+            scale_factor = 1 / math.sqrt(query.size(-1)) if scale is None else scale
             query, key = query * math.sqrt(scale_factor), key * math.sqrt(scale_factor)
+
             attn_bias = torch.zeros(L, S, dtype=query.dtype, device=query.device)
             if is_causal:
                 assert attn_mask is None

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2088,8 +2088,9 @@ class TestSDPA(NNTestCase):
         If you modify the reference implementation, update this test.
         """
         # Efficient implementation equivalent to the following:
-        def scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0,
-                is_causal=False, scale=None, enable_gqa=False) -> torch.Tensor:
+        def scaled_dot_product_attention(
+            query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None, enable_gqa=False
+        ) -> torch.Tensor:
             L, S = query.size(-2), key.size(-2)
             scale_factor = 1 / math.sqrt(query.size(-1)) if scale is None else scale
             origin_dtype = query.dtype
@@ -2108,8 +2109,8 @@ class TestSDPA(NNTestCase):
                     attn_bias = attn_mask + attn_bias
 
             if enable_gqa:
-                key = key.repeat_interleave(query.size(-3)//key.size(-3), -3)
-                value = value.repeat_interleave(query.size(-3)//value.size(-3), -3)
+                key = key.repeat_interleave(query.size(-3) // key.size(-3), -3)
+                value = value.repeat_interleave(query.size(-3) // value.size(-3), -3)
 
             attn_weight = query @ key.transpose(-2, -1)
             attn_weight += attn_bias

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2104,7 +2104,7 @@ class TestSDPA(NNTestCase):
             attn_bias = torch.zeros(L, S, dtype=query.dtype, device=query.device)
             if is_causal:
                 assert attn_mask is None
-                temp_mask = torch.ones(L, S, dtype=torch.bool).tril(diagonal=0)
+                temp_mask = torch.ones(L, S, dtype=torch.bool, device=attn_bias.device).tril(diagonal=0)
                 attn_bias.masked_fill_(temp_mask.logical_not(), float("-inf"))
 
             if attn_mask is not None:

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5819,7 +5819,10 @@ scaled_dot_product_attention = _add_docstr(
             L, S = query.size(-2), key.size(-2)
             scale_factor = 1 / math.sqrt(query.size(-1)) if scale is None else scale
             origin_dtype = query.dtype
-            query, key, value = query.float(), key.float(), value.float()
+            if not torch.backends.cuda.fp16_bf16_reduction_math_sdp_allowed():
+                # Convert to float32 for numerical stability (default behavior)
+                # Note: This flag affects the math backend globally (CPU and CUDA)
+                query, key, value = query.float(), key.float(), value.float()
             query, key = query * math.sqrt(scale_factor), key * math.sqrt(scale_factor)
             attn_bias = torch.zeros(L, S, dtype=query.dtype, device=query.device)
             if is_causal:

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5829,7 +5829,7 @@ scaled_dot_product_attention = _add_docstr(
             attn_bias = torch.zeros(L, S, dtype=query.dtype, device=query.device)
             if is_causal:
                 assert attn_mask is None
-                temp_mask = torch.ones(L, S, dtype=torch.bool).tril(diagonal=0)
+                temp_mask = torch.ones(L, S, dtype=torch.bool, device=attn_bias.device).tril(diagonal=0)
                 attn_bias.masked_fill_(temp_mask.logical_not(), float("-inf"))
 
             if attn_mask is not None:


### PR DESCRIPTION
- Fixes #119188 (exact match on MATH backend)
- Fixes #123911 (document float32 upcasting behaviour)

### Summary

The documented [reference implementation](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html) of SDPA doesn't numerically match the MATH. This causes confusion when testing numerical accuracy of kernels / code vs MATH.

### Changes

Updated the reference implementation to match MATH's actual behavior. The key corrections are:

- The MATH backend pre-scales both query and key tensors before matmul for numerical stability, rather than scaling after the matmul operation.
- The MATH backend internally upcasts to float32 for fp16/bf16 inputs, then converts back to original dtype at the end.

Added regression test `test_reference_implementation_bitwise_match_math_backend`. Test verifies exact bitwise match (rtol=0, atol=0) between the reference implementation and MATH.