### PR TITLE
ci: Add a way to lint all files in a PR from label

### DIFF
--- a/.github/workflows/_get-changed-files.yml
+++ b/.github/workflows/_get-changed-files.yml
@@ -26,11 +26,12 @@ jobs:
             # Get the PR number from the github context
             PR_NUMBER="${{ github.event.number }}"
 
-            # Check if the PR has the lint-all-files label
-            HAS_LINT_ALL_LABEL=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER --jq '.labels[] | select(.name == "lint-all-files") | .name')
+            # Check if the PR has the lint-all-files or Reverted label
+            # Reverted PRs probably have a high likelihood of needing to have all files linted, so we should lint all files
+            HAS_LINT_ALL_LABEL=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER --jq '.labels[] | select(.name == "lint-all-files" or .name == "Reverted") | .name')
 
             if [ -n "$HAS_LINT_ALL_LABEL" ]; then
-              echo "Found 'lint-all-files' label, linting all files"
+              echo "Found 'lint-all-files' or 'Reverted' label, linting all files"
               echo "changed-files=*" >> "$GITHUB_OUTPUT"
             else
               # Use gh CLI to get changed files in the PR with explicit repo

--- a/.github/workflows/_get-changed-files.yml
+++ b/.github/workflows/_get-changed-files.yml
@@ -2,6 +2,12 @@ name: Get Changed Files
 
 on:
   workflow_call:
+    inputs:
+      all_files:
+        description: "Whether to return all files instead of just changed files"
+        required: false
+        type: boolean
+        default: false
     outputs:
       changed-files:
         description: "List of changed files (space-separated) or '*' if not in a PR"
@@ -26,12 +32,9 @@ jobs:
             # Get the PR number from the github context
             PR_NUMBER="${{ github.event.number }}"
 
-            # Check if the PR has the lint-all-files or Reverted label
-            # Reverted PRs probably have a high likelihood of needing to have all files linted, so we should lint all files
-            HAS_LINT_ALL_LABEL=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER --jq '.labels[] | select(.name == "lint-all-files" or .name == "Reverted") | .name')
-
-            if [ -n "$HAS_LINT_ALL_LABEL" ]; then
-              echo "Found 'lint-all-files' or 'Reverted' label, linting all files"
+            # Check if all_files is requested
+            if [ "${{ inputs.all_files }}" = "true" ]; then
+              echo "all_files input is true, returning all files"
               echo "changed-files=*" >> "$GITHUB_OUTPUT"
             else
               # Use gh CLI to get changed files in the PR with explicit repo

--- a/.github/workflows/_get-changed-files.yml
+++ b/.github/workflows/_get-changed-files.yml
@@ -26,16 +26,24 @@ jobs:
             # Get the PR number from the github context
             PR_NUMBER="${{ github.event.number }}"
 
-            # Use gh CLI to get changed files in the PR with explicit repo
-            CHANGED_FILES=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER/files --paginate --jq '.[] | select(.status != "removed") | .filename' | tr '\n' ' ' | sed 's/ $//')
+            # Check if the PR has the lint-all-files label
+            HAS_LINT_ALL_LABEL=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER --jq '.labels[] | select(.name == "lint-all-files") | .name')
 
-            if [ -z "$CHANGED_FILES" ]; then
-              echo "No changed files found, setting to '*'"
-              CHANGED_FILES="*"
+            if [ -n "$HAS_LINT_ALL_LABEL" ]; then
+              echo "Found 'lint-all-files' label, linting all files"
+              echo "changed-files=*" >> "$GITHUB_OUTPUT"
+            else
+              # Use gh CLI to get changed files in the PR with explicit repo
+              CHANGED_FILES=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER/files --paginate --jq '.[] | select(.status != "removed") | .filename' | tr '\n' ' ' | sed 's/ $//')
+
+              if [ -z "$CHANGED_FILES" ]; then
+                echo "No changed files found, setting to '*'"
+                CHANGED_FILES="*"
+              fi
+
+              echo "Changed files: $CHANGED_FILES"
+              echo "changed-files=$CHANGED_FILES" >> "$GITHUB_OUTPUT"
             fi
-
-            echo "Changed files: $CHANGED_FILES"
-            echo "changed-files=$CHANGED_FILES" >> "$GITHUB_OUTPUT"
 
           else
             echo "Not in PR context, setting changed files to '*'"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,6 +31,8 @@ jobs:
     if: github.repository_owner == 'pytorch'
     name: Get changed files
     uses: ./.github/workflows/_get-changed-files.yml
+    with:
+      all_files: ${{ contains(github.event.pull_request.labels.*.name, 'lint-all-files') || contains(github.event.pull_request.labels.*.name, 'Reverted') }}
 
   lintrunner-clang:
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #163526
* __->__ #163525

Works by either applying `lint-all-files` and should automatically apply when `Reverted` appears on PRs as well

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>