### PR TITLE
[CI] Update legacy nvidia driver to: 570.133.07

### DIFF
--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -169,7 +169,7 @@ jobs:
         id: install-nvidia-driver
         uses: pytorch/test-infra/.github/actions/setup-nvidia@main
         with:
-          driver-version: ${{ matrix.config == 'legacy_nvidia_driver' && '525.105.17' || '580.82.07' }}
+          driver-version: ${{ matrix.config == 'legacy_nvidia_driver' && '570.133.07' || '580.82.07' }}
         if: ${{ contains(inputs.build-environment, 'cuda') && !contains(matrix.config, 'nogpu') && steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false' && !contains(matrix.runner, 'b200') }}
 
       - name: Setup GPU_FLAG for docker run

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -167,7 +167,7 @@ jobs:
 
       - name: Install nvidia driver, nvidia-docker runtime, set GPU_FLAG
         id: install-nvidia-driver
-        uses: pytorch/test-infra/.github/actions/setup-nvidia@main
+        uses: pytorch/test-infra/.github/actions/setup-nvidia@driver_reset
         with:
           driver-version: ${{ matrix.config == 'legacy_nvidia_driver' && '570.133.07' || '580.82.07' }}
         if: ${{ contains(inputs.build-environment, 'cuda') && !contains(matrix.config, 'nogpu') && steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false' && !contains(matrix.runner, 'b200') }}

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -169,7 +169,7 @@ jobs:
         id: install-nvidia-driver
         uses: pytorch/test-infra/.github/actions/setup-nvidia@driver_reset
         with:
-          driver-version: ${{ matrix.config == 'legacy_nvidia_driver' && '570.133.07' || '580.82.07' }}
+          driver-version: ${{ matrix.config == 'legacy_nvidia_driver' && '525.105.17' || '580.82.07' }}
         if: ${{ contains(inputs.build-environment, 'cuda') && !contains(matrix.config, 'nogpu') && steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false' && !contains(matrix.runner, 'b200') }}
 
       - name: Setup GPU_FLAG for docker run


### PR DESCRIPTION
Periodic failures when using legacy nvidia driver: https://github.com/pytorch/pytorch/actions/runs/17818330158/job/50660333689

Looks like we are getting something like after downgrading CUDA driver:
```
No devices were found
+ nvidia-smi --query-gpu=gpu_name --format=csv,noheader --id=0
No devices were found
+ NVIDIA_SMI_STATUS=6
+ '[' 6 -eq 0 ']'
+ '[' 6 -eq 14 ']'
+ echo 'ERROR: nvidia-smi exited with unresolved status 6'
+ exit 6
ERROR: nvidia-smi exited with unresolved status 6
```