### PR TITLE
[AOTI] Fix model_package_loader get_cpp_compile_command

### DIFF
--- a/torch/csrc/inductor/aoti_package/model_package_loader.cpp
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.cpp
@@ -127,14 +127,13 @@ const char* extension_file_ext() {
 }
 
 const char* get_output_flags(bool compile_only) {
-if(compile_only)
-{
+  if (compile_only) {
 #ifdef _WIN32
-  return "/c /Fo";
+    return "/c /Fo"; // codespell:ignore
 #else
-  return "-c -o";
+    return "-c -o";
 #endif
-}
+  }
 
 #ifdef _WIN32
   return "/Fe";
@@ -248,12 +247,7 @@ std::tuple<std::string, std::string> get_cpp_compile_command(
     passthrough_parameters_args += arg_str + " ";
   }
 
-  #if 0
-  std::string compile_only_arg =
-    compile_only ? (_is_windows_os() ? "/c" : "-c") : ""; 
-  #endif
-
-  std::string output_flags =  get_output_flags(compile_only);
+  std::string output_flags = get_output_flags(compile_only);
 
   std::string cmd;
   /*

--- a/torch/csrc/inductor/aoti_package/model_package_loader.cpp
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.cpp
@@ -400,7 +400,6 @@ std::string compile_so(
 
   std::string compile_flags_path =
       normalize_path_separator(filename + "_compile_flags.json");
-  printf("compile_flags_path: %s\n", compile_flags_path.c_str());
   const nlohmann::json compile_flags = load_json_file(compile_flags_path);
 
   auto [compile_cmd, output_o] =
@@ -408,7 +407,6 @@ std::string compile_so(
 
   std::string linker_flags_path = normalize_path_separator(
       cpp_filename.substr(0, lastindex) + "_linker_flags.json");
-  printf("linker_flags_path: %s\n", linker_flags_path.c_str());
   const nlohmann::json linker_flags = load_json_file(linker_flags_path);
 
   obj_filenames.push_back(output_o);
@@ -416,12 +414,10 @@ std::string compile_so(
       get_cpp_compile_command(filename, obj_filenames, linker_flags);
 
   // Run the commands to generate a .so file
-  printf("build command: %s\n", compile_cmd.c_str());
   int status = system(compile_cmd.c_str());
   if (status != 0) {
     throw std::runtime_error("Failed to compile cpp file.");
   }
-  printf("link command: %s\n", link_cmd.c_str());
   status = system(link_cmd.c_str());
   if (status != 0) {
     throw std::runtime_error("Failed to link files.");

--- a/torch/csrc/inductor/aoti_package/model_package_loader.cpp
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.cpp
@@ -42,16 +42,18 @@ const std::string k_separator = "/";
 
 std::string remove_duplicate_separator_of_path(const std::string& path) {
   /*
+  On Windows, temp file path maybe has duplicate separator.
+  Need to remove the duplication:
   Origin: C:/Users/Xuhan/AppData/Local/Temp//tmpl10jfwef/filename
   Processed: C:/Users/Xuhan/AppData/Local/Temp/tmpl10jfwef/filename
   */
   std::string result = path;
   size_t pos = 0;
-  
+
   while ((pos = result.find("//", pos)) != std::string::npos) {
-      result.replace(pos, 2, "/");
+    result.replace(pos, 2, "/");
   }
-  
+
   return result;
 }
 
@@ -71,8 +73,8 @@ std::string normalize_path_separator(const std::string& orig_path) {
   std::string normalized_path = orig_path;
 #ifdef _WIN32
   std::replace(normalized_path.begin(), normalized_path.end(), '\\', '/');
-  normalized_path = remove_duplicate_separator_of_path(normalized_path);
 #endif
+  normalized_path = remove_duplicate_separator_of_path(normalized_path);
   return normalized_path;
 }
 
@@ -176,25 +178,28 @@ std::tuple<std::string, std::string> get_cpp_compile_command(
 
   std::string cflags_args;
   for (auto& arg : compile_options["cflags"]) {
-    // [Windows compiler need it] convert first char arg to std::string, for following plus(+) strings.
-    cflags_args += std::string(_is_windows_os() ? "/" : "-") + arg.get<std::string>() + " ";
+    // [Windows compiler need it] convert first char arg to std::string, for
+    // following plus(+) strings.
+    cflags_args += std::string(_is_windows_os() ? "/" : "-") +
+        arg.get<std::string>() + " ";
   }
 
   std::string definitions_args;
   for (auto& arg : compile_options["definitions"]) {
-    definitions_args +=
-        std::string(_is_windows_os() ? "/D" : "-D ") + arg.get<std::string>() + " ";
+    definitions_args += std::string(_is_windows_os() ? "/D" : "-D ") +
+        arg.get<std::string>() + " ";
   }
 
   std::string include_dirs_args;
   for (auto& arg : compile_options["include_dirs"]) {
-    include_dirs_args +=
-        std::string(_is_windows_os() ? "/I" : "-I") + arg.get<std::string>() + " ";
+    include_dirs_args += std::string(_is_windows_os() ? "/I" : "-I") +
+        arg.get<std::string>() + " ";
   }
 
   std::string ldflags_args;
   for (auto& arg : compile_options["ldflags"]) {
-    ldflags_args += std::string(_is_windows_os() ? "/" : "-") + arg.get<std::string>() + " ";
+    ldflags_args += std::string(_is_windows_os() ? "/" : "-") +
+        arg.get<std::string>() + " ";
   }
 
   std::string libraries_dirs_args;
@@ -367,15 +372,16 @@ std::string compile_so(
   size_t lastindex = cpp_filename.find_last_of('.');
   std::string filename = cpp_filename.substr(0, lastindex);
 
-  std::string compile_flags_path = normalize_path_separator(filename + "_compile_flags.json");
+  std::string compile_flags_path =
+      normalize_path_separator(filename + "_compile_flags.json");
   printf("compile_flags_path: %s\n", compile_flags_path.c_str());
   const nlohmann::json compile_flags = load_json_file(compile_flags_path);
 
   auto [compile_cmd, output_o] =
       get_cpp_compile_command(filename, {cpp_filename}, compile_flags);
 
-  std::string linker_flags_path =
-      normalize_path_separator(cpp_filename.substr(0, lastindex) + "_linker_flags.json");
+  std::string linker_flags_path = normalize_path_separator(
+      cpp_filename.substr(0, lastindex) + "_linker_flags.json");
   printf("linker_flags_path: %s\n", linker_flags_path.c_str());
   const nlohmann::json linker_flags = load_json_file(linker_flags_path);
 
@@ -384,12 +390,12 @@ std::string compile_so(
       get_cpp_compile_command(filename, obj_filenames, linker_flags);
 
   // Run the commands to generate a .so file
-  printf_s("build command: %s\n", compile_cmd.c_str());
+  printf("build command: %s\n", compile_cmd.c_str());
   int status = system(compile_cmd.c_str());
   if (status != 0) {
     throw std::runtime_error("Failed to compile cpp file.");
   }
-  printf_s("link command: %s\n", link_cmd.c_str());
+  printf("link command: %s\n", link_cmd.c_str());
   status = system(link_cmd.c_str());
   if (status != 0) {
     throw std::runtime_error("Failed to link files.");


### PR DESCRIPTION
It should fix AOTI UTs of `test_aot_inductor_package.py`, these cases are failed at `compile_so`.

reproducer:
```cmd
pytest test\inductor\test_aot_inductor_package.py -v -k test_multiple_methods
```
<img width="1262" height="95" alt="image" src="https://github.com/user-attachments/assets/49458536-1cfe-498e-a12a-2bfd8da67a9e" />

Major fix at `get_cpp_compile_command`. The code is aligned to cpp_builder frontend code:  https://github.com/pytorch/pytorch/blob/3ef1bef36c73b4def0e1b71847e27fde1556c0fb/torch/_inductor/cpp_builder.py#L1780-L1790
https://github.com/pytorch/pytorch/blob/3ef1bef36c73b4def0e1b71847e27fde1556c0fb/torch/_inductor/cpp_builder.py#L1959-L1976

Fixed on Windows:
<img width="1261" height="89" alt="Image" src="https://github.com/user-attachments/assets/9bf43b11-aac1-4161-a625-e602e313a299" />

Also validated on Linux:
<img width="1039" height="81" alt="Image" src="https://github.com/user-attachments/assets/46063e16-6cf1-4a28-8466-0496871b8619" />

