### PR TITLE
Use _RecordFunctionFast for torch.autograd.profiler.record_function

### DIFF
--- a/test/profiler/test_execution_trace.py
+++ b/test/profiler/test_execution_trace.py
@@ -328,6 +328,7 @@ class TestExecutionTrace(TestCase):
         found_root_node = False
         for n in nodes:
             assert "name" in n
+            print(n["name"])
             if "[pytorch|profiler|execution_trace|process]" in n["name"]:
                 found_root_node = True
             if n["name"].startswith("## LOOP "):

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -781,9 +781,7 @@ class record_function(_ContextDecorator):
         )
 
     def __enter__(self):
-        self.record = torch._C._profiler._RecordFunctionFast(
-            self.name, self.args
-        )
+        self.record = torch._C._profiler._RecordFunctionFast(self.name)
         return self
 
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any):

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -782,8 +782,10 @@ class record_function(_ContextDecorator):
 
     def __enter__(self):
         # If args is empty, then pass an empty tuple
+        # if "TEST" in self.name or "LOOP" in self.name:
+        #     breakpoint()
         args = (self.args,) if self.args else tuple()
-        self.record = torch._C._profiler._RecordFunctionFast(self.name, args)
+        self.record = torch._C._profiler._RecordFunctionFast(self.name, args, {"scope": "user_scope"})
         self.record.__enter__()
         return self
 

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -781,7 +781,8 @@ class record_function(_ContextDecorator):
         )
 
     def __enter__(self):
-        self.record = torch._C._profiler._RecordFunctionFast(self.name)
+        self.record = torch._C._profiler._RecordFunctionFast(self.name, (self.args,))
+        self.record.__enter__()
         return self
 
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any):

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -781,7 +781,9 @@ class record_function(_ContextDecorator):
         )
 
     def __enter__(self):
-        self.record = torch._C._profiler._RecordFunctionFast(self.name, (self.args,))
+        # If args is empty, then pass an empty tuple
+        args = (self.args,) if self.args else tuple()
+        self.record = torch._C._profiler._RecordFunctionFast(self.name, args)
         self.record.__enter__()
         return self
 


### PR DESCRIPTION
This changes `record_function` to use _RecordFunctionFast, which is more efficient. This is important for Compiler runtime overhead in smaller graphs. Currently this profiler takes half of the overhead.

To measure impact on runtime overhead, here are results from [benchmarks/dynamo/microbenchmarks/overheads.py](https://github.com/pytorch/pytorch/blob/main/benchmarks/dynamo/microbenchmarks/overheads.py).

Before changes:
```
requires_grad=False
compiled 56.9us (warmup=19.3s)

requires_grad=True
compiled 101.6us (warmup=0.2s)

inference_mode()
compiled 53.4us (warmup=0.1s)
```

After changes:
```
requires_grad=False
compiled 27.2us (warmup=9.9s)

requires_grad=True
compiled 61.6us (warmup=0.1s)

inference_mode()
compiled 25.3us (warmup=0.1s)
```