### PR TITLE
[cuDNN][Convolution] Disable cuDNN for 3D convolutions with kernel size != 1 for cuDNN 9.8+

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -421,6 +421,16 @@ struct ConvParams {
                         " Consider upgrading cuDNN and/or enabling the V8 API for better efficiency.");
         return false;
       }
+      // broken on cuDNN 9.8 - 9.10
+      if (cudnn_version >= 90800 && cudnn_version < 91300) {
+        if (input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf) {
+          for (auto it = weight.sizes().begin(); it != weight.sizes().end(); it++) {
+            if (*it != 1) {
+              return false;
+            }
+          }
+        }
+      }
     }
     if (!input.is_cuda() || !cudnn_enabled) {
       return false;

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -424,8 +424,8 @@ struct ConvParams {
       // broken on cuDNN 9.8
       if (cudnn_version >= 90800) {
         if (input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf) {
-          for (auto it = weight.sizes().begin(); it != weight.sizes().end(); it++) {
-            if (*it != 1) {
+          for (auto val : weight.sizes()) {
+            if (val != 1) {
               return false;
             }
           }

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -413,23 +413,23 @@ struct ConvParams {
     if (!detail::getCUDAHooks().compiledWithCuDNN()) {
       return false;
     }
+    static long cudnn_version = detail::getCUDAHooks().versionCuDNN();
+    // broken on cuDNN 9.8
+    if (cudnn_version >= 90800) {
+      if (input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf) {
+        for (auto val : weight.sizes()) {
+          if (val != 1) {
+            return false;
+          }
+        }
+      }
+    }
     if (needs_64bit_indexing_no_split(input, weight)) {
-      static long cudnn_version = detail::getCUDAHooks().versionCuDNN();
       if (!(cudnn_version >= 90300 && at::native::cudnnv8_enabled_check_debug())) {
         TORCH_WARN_ONCE("cuDNN cannot be used for large non-batch-splittable convolutions"
                         " if the V8 API is not enabled or before cuDNN version 9.3+."
                         " Consider upgrading cuDNN and/or enabling the V8 API for better efficiency.");
         return false;
-      }
-      // broken on cuDNN 9.8
-      if (cudnn_version >= 90800) {
-        if (input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf) {
-          for (auto val : weight.sizes()) {
-            if (val != 1) {
-              return false;
-            }
-          }
-        }
       }
     }
     if (!input.is_cuda() || !cudnn_enabled) {

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -417,7 +417,7 @@ struct ConvParams {
     // broken on cuDNN 9.8
     if (cudnn_version >= 90800) {
       if (cudnn_conv_suggest_memory_format(input, weight) == at::MemoryFormat::Contiguous &&
-          input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf) {
+          (input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf)) {
         for (int i = 2; i < weight.dim(); i++) {
           if (weight.size(i) != 1) {
             return false;

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -417,7 +417,8 @@ struct ConvParams {
     // broken on cuDNN 9.8
     if (cudnn_version >= 90800) {
       if (cudnn_conv_suggest_memory_format(input, weight) == at::MemoryFormat::Contiguous &&
-          (input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf)) {
+          (input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf) &&
+          weight.dim() == 5) {
         for (int i = 2; i < weight.dim(); i++) {
           if (weight.size(i) != 1) {
             return false;

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -421,8 +421,8 @@ struct ConvParams {
                         " Consider upgrading cuDNN and/or enabling the V8 API for better efficiency.");
         return false;
       }
-      // broken on cuDNN 9.8 - 9.10
-      if (cudnn_version >= 90800 && cudnn_version < 91300) {
+      // broken on cuDNN 9.8
+      if (cudnn_version >= 90800) {
         if (input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf) {
           for (auto it = weight.sizes().begin(); it != weight.sizes().end(); it++) {
             if (*it != 1) {

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -416,9 +416,10 @@ struct ConvParams {
     static long cudnn_version = detail::getCUDAHooks().versionCuDNN();
     // broken on cuDNN 9.8
     if (cudnn_version >= 90800) {
-      if (input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf) {
-        for (auto val : weight.sizes()) {
-          if (val != 1) {
+      if (cudnn_conv_suggest_memory_format(input, weight) == at::MemoryFormat::Contiguous &&
+          input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf) {
+        for (int i = 2; i < weight.dim(); i++) {
+          if (weight.size(i) != 1) {
             return false;
           }
         }

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4705,7 +4705,7 @@ class CommonTemplate:
         self.common(
             m,
             (torch.randn([1, 3, 8, 16, 32]),),
-            atol=6e-5,
+            atol=1e-3,
             rtol=0.001,
             # Make sure we compute also with fp16 in the reference. Otherwise,
             # the reference will compute with fp32 and cast back to fp16, which

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -4040,8 +4040,16 @@ class TestConvolutionNNDeviceType(NNTestCase):
     @onlyCUDA
     def test_conv3d_cudnn_broken(self, device):
         for dtype in (torch.half, torch.bfloat16):
-            x = torch.rand(1, 16, 1282, 722, 124, dtype=dtype, device=device)
-            m = torch.nn.Conv3d(16, 1, kernel_size=(1, 3, 3), padding=0, stride=1, bias=False, dtype=dtype, device=device)
+            x = torch.rand(1, 16, 124, 1282, 722, dtype=dtype, device=device)
+            m = torch.nn.Conv3d(16,
+                16,
+                kernel_size=(1, 3, 3),
+                padding=0,
+                stride=1,
+                bias=False,
+                dtype=dtype,
+                device=device,
+            )
             with torch.backends.cudnn.flags(enabled=False):
                 yref = m(x)
             y = m(x)

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -4037,6 +4037,16 @@ class TestConvolutionNNDeviceType(NNTestCase):
         y = m.to(device=device)(x.to(device=device))
         self.assertEqual(yref, y)
 
+    @onlyCUDA
+    def test_conv3d_cudnn_broken(self, device):
+        for dtype in (torch.half, torch.bfloat16):
+            x = torch.rand(1, 16, 1282, 722, 124, dtype=dtype, device=device)
+            m = torch.nn.Conv3d(16, 1, kernel_size=(1, 3, 3), padding=0, stride=1, bias=False, dtype=dtype, device=device)
+            with torch.backends.cudnn.flags(enabled=False):
+                yref = m(x)
+            y = m(x)
+            self.assertEqual(yref, y)
+
     @skipCUDAIfRocm
     @onlyCUDA
     @largeTensorTest("20GB")

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -4038,6 +4038,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
         self.assertEqual(yref, y)
 
     @onlyCUDA
+    @largeTensorTest("40GB", "cuda")
     def test_conv3d_cudnn_broken(self, device):
         for dtype in (torch.half, torch.bfloat16):
             x = torch.rand(1, 16, 124, 1282, 722, dtype=dtype, device=device)

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -4041,7 +4041,8 @@ class TestConvolutionNNDeviceType(NNTestCase):
     def test_conv3d_cudnn_broken(self, device):
         for dtype in (torch.half, torch.bfloat16):
             x = torch.rand(1, 16, 124, 1282, 722, dtype=dtype, device=device)
-            m = torch.nn.Conv3d(16,
+            m = torch.nn.Conv3d(
+                16,
                 16,
                 kernel_size=(1, 3, 3),
                 padding=0,


### PR DESCRIPTION
To workaround #163539

Still confirming whether 9.10 is affected. The original test states that the convolution is "large," but note that the input size does not apepar to require 64-bit indexing.

cc @csarofeen @ptrblck @xwang233 @msaroufim @jerryzh168 @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben