### PR TITLE
CUDA 13.0 Warning update for supported architectures

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -259,7 +259,7 @@ def _check_capability():
     CUDA_ARCHES_SUPPORTED = {
         "12.6": {"min": 50, "max": 90},
         "12.8": {"min": 70, "max": 120},
-        "12.9": {"min": 70, "max": 120},
+        "13.0": {"min": 75, "max": 120},
     }
 
     if (


### PR DESCRIPTION
Please see build script: https://github.com/pytorch/pytorch/blob/8da008678fcb95dbf55a33451136a242871ae4e2/.ci/manywheel/build_cuda.sh#L69-L71


This should display correct warning:
``
Please install PyTorch with a following CUDA
configurations: 12.6 12.8 13.0 following instructions at
https://pytorch.org/get-started/locally/
``