### PR TITLE
[SDPA] [MPS] Fixes regression in 2.8.0 for scaled_dot_product_attention using mps

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Attention.metal
+++ b/aten/src/ATen/native/mps/kernels/Attention.metal
@@ -58,7 +58,8 @@ template <typename T, int D, int V = D>
   const int Q = tpg.y;
   const int group_offset = head_idx * Q + q_seq_idx;
   const int o_offset = group_offset;
-  queries += head_idx * q_head_stride + q_seq_idx * q_seq_stride + simd_lid * qk_per_thread;
+  queries += head_idx * q_head_stride + q_seq_idx * q_seq_stride +
+      simd_lid * qk_per_thread;
   keys += kv_head_idx * k_head_stride + simd_gid * k_seq_stride +
       simd_lid * qk_per_thread;
   values += kv_head_idx * v_head_stride + simd_gid * v_seq_stride +
@@ -203,7 +204,8 @@ template <typename T, int D, int V = D>
   const int o_offset = head_idx * tpg.y + q_seq_idx;
   const int kv_head_idx = head_idx / gqa_factor;
 
-  queries += head_idx * q_head_stride + q_seq_idx * q_seq_stride + simd_lid * qk_per_thread;
+  queries += head_idx * q_head_stride + q_seq_idx * q_seq_stride +
+      simd_lid * qk_per_thread;
   keys += kv_head_idx * k_head_stride +
       (block_idx * BN + simd_gid) * k_seq_stride + simd_lid * qk_per_thread;
   values += kv_head_idx * v_head_stride +

--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -182,6 +182,8 @@ static std::tuple<Tensor, Tensor> sdpa_vector_fast_mps(const Tensor& q_,
   uint maxSeqLength = k_.size(2);
   uint N = k_.size(2);
   uint B = q_.size(0) * q_.size(1);
+  uint q_head_stride = q_.stride(1);
+  uint q_seq_stride = q_.stride(2);
   uint k_head_stride = k_.stride(1);
   uint k_seq_stride = k_.stride(2);
   uint v_head_stride = v_.stride(1);
@@ -209,6 +211,7 @@ static std::tuple<Tensor, Tensor> sdpa_vector_fast_mps(const Tensor& q_,
                   out,
                   1,
                   N,
+                  std::array<uint32_t, 2>{q_head_stride, q_seq_stride},
                   std::array<uint32_t, 2>{k_head_stride, k_seq_stride},
                   std::array<uint32_t, 2>{v_head_stride, v_seq_stride},
                   scale_factor);
@@ -218,10 +221,10 @@ static std::tuple<Tensor, Tensor> sdpa_vector_fast_mps(const Tensor& q_,
         uint kv_seq_stride = (nd >= 1 && mask_.value().size(nd - 1) > 1) ? mask_.value().stride(nd - 1) : 0;
         uint q_seq_stride = (nd >= 2 && mask_.value().size(nd - 2) > 1) ? mask_.value().stride(nd - 2) : 0;
         uint head_stride = (nd >= 3 && mask_.value().size(nd - 3) > 1) ? mask_.value().stride(nd - 3) : 0;
-        mtl_setArgs<9>(
+        mtl_setArgs<10>(
             computeEncoder, mask_.value(), std::array<uint32_t, 3>{kv_seq_stride, q_seq_stride, head_stride});
       }
-      mtl_setArgs<11>(computeEncoder, has_mask);
+      mtl_setArgs<12>(computeEncoder, has_mask);
       [computeEncoder dispatchThreadgroups:grid_dims threadsPerThreadgroup:group_dims];
     }
   });
@@ -257,6 +260,8 @@ static std::tuple<Tensor, Tensor> sdpa_vector_2pass_mps(const Tensor& q_,
   uint B = batchSize * num_heads;
   uint gqa_factor = q_.size(1) / k_.size(1);
 
+  uint q_head_stride = q_.stride(1);
+  uint q_seq_stride = q_.stride(2);
   uint k_head_stride = k_.stride(1);
   uint k_seq_stride = k_.stride(2);
   uint v_head_stride = v_.stride(1);
@@ -294,6 +299,7 @@ static std::tuple<Tensor, Tensor> sdpa_vector_2pass_mps(const Tensor& q_,
                   maxs,
                   gqa_factor,
                   N,
+                  std::array<uint32_t, 2>{q_head_stride, q_seq_stride},
                   std::array<uint32_t, 2>{k_head_stride, k_seq_stride},
                   std::array<uint32_t, 2>{v_head_stride, v_seq_stride},
                   scale_factor);
@@ -304,9 +310,9 @@ static std::tuple<Tensor, Tensor> sdpa_vector_2pass_mps(const Tensor& q_,
         uint kv_seq_stride = (nd >= 1 && mask.size(nd - 1) > 1) ? mask.stride(nd - 1) : 0;
         uint q_seq_stride = (nd >= 2 && mask.size(nd - 2) > 1) ? mask.stride(nd - 2) : 0;
         uint head_stride = (nd >= 3 && mask.size(nd - 3) > 1) ? mask.stride(nd - 3) : 0;
-        mtl_setArgs<11>(computeEncoder, mask, std::array<uint32_t, 3>{kv_seq_stride, q_seq_stride, head_stride});
+        mtl_setArgs<12>(computeEncoder, mask, std::array<uint32_t, 3>{kv_seq_stride, q_seq_stride, head_stride});
       }
-      mtl_setArgs<13>(computeEncoder, has_mask);
+      mtl_setArgs<14>(computeEncoder, has_mask);
       [computeEncoder dispatchThreadgroups:grid_dims threadsPerThreadgroup:group_dims];
       // 2nd pass
       [computeEncoder setComputePipelineState:sdpa_vector_pass2PSO];

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9472,7 +9472,7 @@ class TestSDPA(TestCaseMPS):
         # 5 MB different maximum allowed value(could be decreased even more)
         torch.testing.assert_close(memory_footprints[-1], memory_footprints[0], atol=5, rtol=1)
 
-    def generate_qkv(self, batch, NH, q_len, s_len, head_dim, layout, dtype):
+    def generate_qkv(self, batch: int, NH: int, q_len: int, s_len: int, head_dim: int, layout: str, dtype: torch.dtype):
         if layout == "contiguous":
             q = torch.randn(batch, NH, q_len, head_dim, dtype=dtype, device="mps")
             k = torch.randn(batch, NH, s_len, head_dim, dtype=dtype, device="mps")
@@ -9494,7 +9494,15 @@ class TestSDPA(TestCaseMPS):
         v = torch.randn(batch, NH, s_len, head_dim, dtype=dtype, device="mps")
         return q, k, v
 
-    def run_fast_attention_test(self, q, k, v, with_mask, dropout_p=0.0, is_causal=False):
+    def run_fast_attention_test(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        with_mask: bool,
+        dropout_p: float = 0.0,
+        is_causal: bool = False,
+    ):
         q_len = q.shape[2]
         s_len = k.shape[2]
 
@@ -9538,7 +9546,7 @@ class TestSDPA(TestCaseMPS):
     @parametrize("layout", ["contiguous", "mT", "transpose_seq_head", "permute"])
     @parametrize("head_dim", [64, 96, 128])  # 64, 96, 128 are for the fast kernel
     @parametrize("with_mask", [True, False])
-    def test_fast_vector_attention(self, dtype, layout, head_dim, with_mask):
+    def test_fast_vector_attention(self, dtype: torch.dtype, layout: str, head_dim: int, with_mask: bool):
         torch.manual_seed(1729)
         batch = 1
         NH = 2
@@ -9550,7 +9558,7 @@ class TestSDPA(TestCaseMPS):
     @parametrize("dtype", [torch.float32])  # float16 underflows sometimes, which leads to flaky tests
     @parametrize("layout", ["contiguous", "mT", "transpose_seq_head", "permute"])
     @parametrize("with_mask", [True, False])
-    def test_fast_vector_attention_2pass(self, dtype, layout, with_mask):
+    def test_fast_vector_attention_2pass(self, dtype: torch.dtype, layout: str, with_mask: bool):
         torch.manual_seed(1729)
         batch = 1
         NH = 32
@@ -9565,7 +9573,7 @@ class TestSDPA(TestCaseMPS):
     @parametrize("layout", ["contiguous", "mT"])
     @parametrize("head_dim", [64, 80, 128])  # 64, 80, 128 are for the fast kernel
     @parametrize("with_mask", [True, False])
-    def test_fast_full_attention(self, dtype, layout, head_dim, with_mask):
+    def test_fast_full_attention(self, dtype: torch.dtype, layout: str, head_dim: int, with_mask: bool):
         torch.manual_seed(1729)
         batch = 1
         NH = 2

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9562,6 +9562,87 @@ class TestSDPA(TestCaseMPS):
         q, k, v = self.generate_qkv(batch, NH, q_len, s_len, head_dim, contiguous, dtype)
         self.run_fast_attention_test(q, k, v, with_mask)
 
+    def generate_transpose_layout_qkv(self, batch, NH, q_len, s_len, head_dim, dtype, layout="transpose"):
+        if layout == "transpose":
+            # Original transpose bug - transpose seq_len and num_heads dimensions
+            q = torch.randn(batch, q_len, NH, head_dim, dtype=dtype, device="mps").transpose(1, 2)
+            k = torch.randn(batch, s_len, NH, head_dim, dtype=dtype, device="mps").transpose(1, 2)
+            v = torch.randn(batch, s_len, NH, head_dim, dtype=dtype, device="mps").transpose(1, 2)
+        elif layout == "permute":
+            # Different permutation to create non-contiguous layout
+            q = torch.randn(batch, head_dim, NH, q_len, dtype=dtype, device="mps").permute(0, 2, 3, 1)
+            k = torch.randn(batch, head_dim, NH, s_len, dtype=dtype, device="mps").permute(0, 2, 3, 1)
+            v = torch.randn(batch, head_dim, NH, s_len, dtype=dtype, device="mps").permute(0, 2, 3, 1)
+        elif layout == "view_transpose":
+            # Create via view + transpose for different stride pattern
+            q = torch.randn(batch * q_len, NH, head_dim, dtype=dtype, device="mps").view(batch, q_len, NH, head_dim).transpose(1, 2)
+            k = torch.randn(batch * s_len, NH, head_dim, dtype=dtype, device="mps").view(batch, s_len, NH, head_dim).transpose(1, 2)
+            v = torch.randn(batch * s_len, NH, head_dim, dtype=dtype, device="mps").view(batch, s_len, NH, head_dim).transpose(1, 2)
+        else:
+            # Contiguous baseline
+            q = torch.randn(batch, NH, q_len, head_dim, dtype=dtype, device="mps")
+            k = torch.randn(batch, NH, s_len, head_dim, dtype=dtype, device="mps")
+            v = torch.randn(batch, NH, s_len, head_dim, dtype=dtype, device="mps")
+        
+        return q, k, v
+
+    def run_noncontiguous_attention_test(self, q, k, v, with_mask=False, is_causal=False):
+        # Ensure tensors are actually non-contiguous for the test
+        if not q.is_contiguous():
+            y_mps = F.scaled_dot_product_attention(q, k, v, is_causal=is_causal)
+            y_cpu = F.scaled_dot_product_attention(q.cpu(), k.cpu(), v.cpu(), is_causal=is_causal)
+            self._compare_tensors(y_mps.cpu(), y_cpu)
+            
+            # Test against contiguous MPS version
+            q_contig = q.contiguous()
+            k_contig = k.contiguous() 
+            v_contig = v.contiguous()
+            y_mps_contig = F.scaled_dot_product_attention(q_contig, k_contig, v_contig, is_causal=is_causal)
+            self._compare_tensors(y_mps, y_mps_contig)
+            
+            # Test with mask
+            if with_mask:
+                seq_len = q.shape[2]
+                kv_len = k.shape[2]
+                mask = torch.tril(torch.ones(seq_len, kv_len, dtype=torch.bool, device="mps"))
+                
+                y_mps_mask = F.scaled_dot_product_attention(q, k, v, attn_mask=mask, is_causal=is_causal)
+                y_cpu_mask = F.scaled_dot_product_attention(q.cpu(), k.cpu(), v.cpu(), attn_mask=mask.cpu(), is_causal=is_causal)
+                y_mps_contig_mask = F.scaled_dot_product_attention(q_contig, k_contig, v_contig, attn_mask=mask, is_causal=is_causal)
+                
+                self._compare_tensors(y_mps_mask.cpu(), y_cpu_mask)
+                self._compare_tensors(y_mps_mask, y_mps_contig_mask)
+
+    @parametrize("dtype", [torch.float16, torch.float32])
+    @parametrize("head_dim", [64, 96, 128]) # 64, 96, 128 are for the fast kernel
+    @parametrize("with_mask", [True, False])
+    @parametrize("layout", ["transpose", "permute", "view_transpose"])
+    def test_fast_vector_attention_noncontiguous_query(self, dtype, head_dim, with_mask, layout):
+        """Test fast vector attention (one-pass) with non-contiguous query tensor layouts."""
+        torch.manual_seed(1729)
+        batch = 1
+        NH = 2
+        q_len = 4  # <8 so that vector fast is eligible
+        s_len = 16  # smaller than 1024 so that we use the one–pass variant
+        
+        q, k, v = self.generate_transpose_layout_qkv(batch, NH, q_len, s_len, head_dim, dtype, layout)
+        self.run_noncontiguous_attention_test(q, k, v, with_mask)
+
+    @parametrize("dtype", [torch.float32]) # float16 underflows sometimes, which leads to flaky tests
+    @parametrize("with_mask", [True, False])
+    @parametrize("layout", ["transpose", "permute"])
+    def test_fast_vector_attention_2pass_noncontiguous_query(self, dtype, with_mask, layout):
+        """Test fast vector attention (two-pass) with non-contiguous query tensor layouts."""
+        torch.manual_seed(1729)
+        batch = 1
+        NH = 32
+        q_len = 8
+        s_len = 1024  # large enough to trigger the two–pass path
+        head_dim = 64  # supported head dimension for vector attention
+        
+        q, k, v = self.generate_transpose_layout_qkv(batch, NH, q_len, s_len, head_dim, dtype, layout)
+        self.run_noncontiguous_attention_test(q, k, v, with_mask)
+
 
 
 


### PR DESCRIPTION
Fixes #163597

- Updates fast SDPA implementations to take in query tensor stride info similar to key and value instead of assuming stride.
- Updated tests with additional transpose/permutation layouts. New tests catch the regression.

### Benchmarking with script found in [implementation PR](https://github.com/pytorch/pytorch/pull/152781#:~:text=19.8%25%20speed%20improvement-,Script%20to%20get%20perf%3A,-import%20torch%0Aimport)

Times are averaged over 100000 iterations. This change should not have any significant performance difference. Tested on an M3 Pro

### Vector Fast Path (q_len=1, k_len=256)

- Before: 0.160 ms
- After: 0.157 ms

### Vector 2-pass (q_len=1, k_len=4096)

- Before: 0.342 ms
- After: 0.339 ms

### Vector Fast Path (q_len=8, k_len=256)

- Before: 0.228 ms
- After: 0.231 ms

### Vector 2-pass (q_len=8, k_len=4096)

- Before: 0.432 ms
- After:  0.436 ms

cc @ezyang @gchanan @zou3519 @kadeng @msaroufim