### PR TITLE
[Code Clean] Replace `std::runtime_error` with `TORCH_CHECK`

### DIFF
--- a/torch/csrc/dynamo/eval_frame_cpp.cpp
+++ b/torch/csrc/dynamo/eval_frame_cpp.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/Exception.h>
 #include <torch/csrc/dynamo/cache_entry.h>
 #include <torch/csrc/dynamo/cpp_shim.h>
 #include <torch/csrc/dynamo/cpython_includes.h>
@@ -23,10 +24,8 @@ static py::object dynamo_call_callback(
     CacheEntry* cache_entry,
     FrameState* frame_state) {
   THPPyInterpreterFrame* frame = THPPyInterpreterFrame_New(_frame);
-  if (frame == nullptr) {
-    throw std::runtime_error(
-        "Dynamo failed to initialize CPython interpreter frame wrapper");
-  }
+  TORCH_CHECK(
+      frame, "Dynamo failed to initialize CPython interpreter frame wrapper");
   frame->locals = (PyObject*)framelocals_mapping_to_dict(locals);
 
   py::object cache_entry_obj = py::none();

--- a/torch/csrc/dynamo/extra_state.cpp
+++ b/torch/csrc/dynamo/extra_state.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/Exception.h>
 #include <torch/csrc/dynamo/extra_state.h>
 
 #include <torch/csrc/dynamo/cache_entry.h>
@@ -232,9 +233,8 @@ py::list _debug_get_cache_entry_list(const py::handle& code_obj) {
 
 PrecompileEntry::PrecompileEntry(py::object gm, py::object c)
     : guard_manager(std::move(gm)), code(std::move(c)) {
-  if (!PyCode_Check(code.ptr())) {
-    throw std::runtime_error("Expecting CodeType from PrecompileEntry.");
-  }
+  TORCH_CHECK(
+      PyCode_Check(code.ptr()), "Expecting CodeType from PrecompileEntry.");
   root_mgr =
       torch::dynamo::convert_to_root_guard_manager(guard_manager.attr("root"));
 }

--- a/torch/csrc/dynamo/init.cpp
+++ b/torch/csrc/dynamo/init.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/Exception.h>
 #include <torch/csrc/dynamo/init.h>
 #include <torch/csrc/dynamo/utils.h>
 
@@ -111,7 +112,7 @@ THPObjectPtr _unicode_dispatch(PyObject* str) {
       return F::apply(str, PyUnicode_4BYTE_DATA(str), length);
     default:
       // This should be impossible - throw to make the compiler happy.
-      throw std::runtime_error("unreachable");
+      TORCH_CHECK(false, "unreachable");
   }
 }
 

--- a/torch/csrc/instruction_counter/Module.cpp
+++ b/torch/csrc/instruction_counter/Module.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/Exception.h>
 #include <c10/util/error.h>
 #include <torch/csrc/instruction_counter/Module.h>
 #include <torch/csrc/utils/pybind.h>
@@ -20,7 +21,7 @@ namespace torch::instruction_counter {
 
 static long start() {
 #if !defined(__linux__)
-  throw std::runtime_error("This systems seems not to be Linux");
+  TORCH_CHECK(false, "This systems seems not to be Linux");
 #else
 
   // Construct base perf_event_attr struct
@@ -51,7 +52,7 @@ static long start() {
 
 static uint64_t end(int fd) {
 #if !defined(__linux__)
-  throw std::runtime_error("This systems seems not to be Linux");
+  TORCH_CHECK(false, "This systems seems not to be Linux");
 #else
   // Disable the event group
   if (ioctl(fd, PERF_EVENT_IOC_DISABLE, PERF_IOC_FLAG_GROUP) == -1) {

--- a/torch/csrc/lazy/core/multi_wait.cpp
+++ b/torch/csrc/lazy/core/multi_wait.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/Exception.h>
 #include <torch/csrc/lazy/core/multi_wait.h>
 
 #include <chrono>
@@ -31,7 +32,7 @@ void MultiWait::Wait(double wait_seconds) {
   if (!cv_.wait_for(lock, std::chrono::duration<double>(wait_seconds), [this] {
         return completed_count_ >= count_;
       })) {
-    throw std::runtime_error("Timeout");
+    TORCH_CHECK(false, "Timeout");
   }
   if (exptr_ != nullptr) {
     std::rethrow_exception(exptr_);

--- a/torch/csrc/lazy/ts_backend/ts_lowering_context.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_lowering_context.cpp
@@ -1,4 +1,5 @@
 #include <c10/core/ScalarType.h>
+#include <c10/util/Exception.h>
 #include <torch/csrc/lazy/ts_backend/ts_backend_impl.h>
 #include <torch/csrc/lazy/ts_backend/ts_lowering_context.h>
 #include <torch/csrc/lazy/ts_backend/ts_node.h>
@@ -44,8 +45,8 @@ void TSLoweringContext::Lower(const Node* node) {
       AssignOutputOp(torch::lazy::Output(node, i), ops[i]);
     }
   } else {
-    throw std::runtime_error(
-        "Expected torch::lazy::TsNode but could not dynamic cast");
+    TORCH_CHECK(
+        false, "Expected torch::lazy::TsNode but could not dynamic cast");
   }
 }
 

--- a/torch/csrc/lazy/ts_backend/ts_lowering_context.h
+++ b/torch/csrc/lazy/ts_backend/ts_lowering_context.h
@@ -2,6 +2,7 @@
 
 #include <sstream>
 
+#include <c10/util/Exception.h>
 #include <torch/csrc/api/include/torch/jit.h>
 #include <torch/csrc/jit/runtime/graph_executor.h>
 #include <torch/csrc/lazy/backend/lowering_context.h>
@@ -26,8 +27,8 @@ class TORCH_API TSComputation : public Computation {
   }
 
   const std::vector<Shape>& parameter_shapes() const override {
-    throw std::runtime_error(
-        "TODO(whc) implement TS computation shapes or change interface");
+    TORCH_CHECK(
+        false, "TODO(whc) implement TS computation shapes or change interface");
     return parameter_shapes_;
   }
 
@@ -36,8 +37,8 @@ class TORCH_API TSComputation : public Computation {
   }
 
   const Shape& result_shape() const override {
-    throw std::runtime_error(
-        "TODO(whc) implement TS computation shapes or change interface");
+    TORCH_CHECK(
+        false, "TODO(whc) implement TS computation shapes or change interface");
     return result_shape_;
   }
 

--- a/torch/csrc/monitor/counters.cpp
+++ b/torch/csrc/monitor/counters.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/Exception.h>
 #include <torch/csrc/monitor/counters.h>
 
 #include <unordered_set>
@@ -21,8 +22,10 @@ const char* aggregationName(Aggregation agg) {
     case Aggregation::MIN:
       return "min";
     default:
-      throw std::runtime_error(
-          "unknown aggregation: " + std::to_string(static_cast<int>(agg)));
+      TORCH_CHECK(
+          false,
+          "unknown aggregation: ",
+          std::to_string(static_cast<int>(agg)));
   }
 }
 

--- a/torch/csrc/monitor/python_init.cpp
+++ b/torch/csrc/monitor/python_init.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/Exception.h>
 #include <utility>
 
 #include <c10/util/WaitCounter.h>
@@ -58,7 +59,7 @@ struct type_caster<torch::monitor::data_value_t> {
       std::string& str = std::get<std::string>(src);
       return THPUtils_packString(str);
     }
-    throw std::runtime_error("unknown data_value_t type");
+    TORCH_CHECK(false, "unknown data_value_t type");
   }
 };
 } // namespace pybind11::detail

--- a/torch/csrc/profiler/python/init.cpp
+++ b/torch/csrc/profiler/python/init.cpp
@@ -2,6 +2,7 @@
 
 #include <ATen/record_function.h>
 #include <c10/core/impl/PyInterpreter.h>
+#include <c10/util/Exception.h>
 #include <c10/util/overloaded.h>
 #include <torch/csrc/DynamicTypes.h>
 #include <torch/csrc/autograd/utils/wrap_outputs.h>
@@ -436,9 +437,7 @@ void initPythonBindings(PyObject* module) {
                 p.performance_events);
           },
           [](const py::tuple& t) { // __setstate__
-            if (t.size() >= 5) {
-              throw std::runtime_error("Expected at least 5 values in state");
-            }
+            TORCH_CHECK(t.size() < 5, "Expected at least 5 values in state");
 
             py::list py_metrics = t[0].cast<py::list>();
             std::vector<std::string> metrics{py_metrics.size()};

--- a/torch/csrc/profiler/stubs/cuda.cpp
+++ b/torch/csrc/profiler/stubs/cuda.cpp
@@ -36,7 +36,7 @@ static void cudaCheck(cudaError_t result, const char* file, int line) {
     } else {
       ss << cudaGetErrorString(result);
     }
-    throw std::runtime_error(ss.str());
+    TORCH_CHECK(false, ss.str());
   }
 }
 #define TORCH_CUDA_CHECK(result) cudaCheck(result, __FILE__, __LINE__);


### PR DESCRIPTION
Including:
- `torch/csrc/instruction_counter`
- `torch/csrc/lazy`
- `torch/csrc/monitor`
- `torch/csrc/profiler`
- `torch/csrc/dynamo`

Fixes part of #148114 

Personal mistake about (PR #163317), this PR does the same thing **and PR #163317 has already been approved by @albanD.**

This is a personal mistake on my part, and I'm so sorry about that. Hope you won't mind @albanD. 🥹

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela