### PR TITLE
[xpu][feature] Supports woq_int8 inductor pattern on Intel GPU

### DIFF
--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -4280,14 +4280,19 @@ class TestPatternMatcher(TestPatternMatcherBase):
             def matcher_check_fn():
                 self.assertEqual(counters["inductor"]["woq_matcher_count"], 1)
 
-            self._test_common(
-                mod,
-                (x, w, s),
-                matcher_check_fn,
-                check_quantization=False,
-                atol=0.001,
-                rtol=0.07,
-            )
+                def matcher_check_fn():
+                    self.assertEqual(
+                        counters["inductor"]["woq_matcher_count"], 0 if TEST_ACL else 1
+                    )
+
+                self._test_common(
+                    mod,
+                    (x.to(device), w.to(device), s.to(device)),
+                    matcher_check_fn,
+                    check_quantization=False,
+                    atol=0.001,
+                    rtol=0.07,
+                )
 
     @skipIfNoDynamoSupport
     def test_woq_int4_cpu(self):

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -749,9 +749,7 @@ class TestPatternMatcherGeneric(TestPatternMatcherBase):
             s = torch.randn(s_shape, dtype=torch.bfloat16).to(device)
 
             def matcher_check_fn():
-                self.assertEqual(
-                    counters["inductor"]["woq_matcher_count"], 0 if TEST_ACL else 1
-                )
+                self.assertEqual(counters["inductor"]["woq_matcher_count"], 1)
 
             self._test_common(
                 mod,

--- a/torch/_inductor/fx_passes/quantization.py
+++ b/torch/_inductor/fx_passes/quantization.py
@@ -1165,7 +1165,7 @@ def _is_valid_woq_optimization_pattern():
             x.dtype == torch.bfloat16
             and weight.dtype == torch.int8
             and scales.dtype == torch.bfloat16
-            and x.device.type in ("cpu", "cuda")
+            and x.device.type in ("cpu", "cuda", "xpu")
             and x.device == weight.device
             and x.device == scales.device
         )


### PR DESCRIPTION
Summary:

Supports woq_int8 inductor pattern on Intel GPU. When using torch.compile, woq_int8 will be lowering to _weight_int8pack_mm instead of being falled back mul().sum(). The Intel GPU backend of _weight_int8pack_mm was supported in https://github.com/pytorch/pytorch/pull/160938.



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @chenyang78