### PR TITLE
Add `inference_mode` hint message to use `eval` with inference.

### DIFF
--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -237,6 +237,12 @@ class inference_mode(_DecoratorContextManager):
        Unlike some other mechanisms that locally enable or disable grad,
        entering inference_mode also disables :ref:`forward-mode AD <forward-mode-ad>`.
 
+    .. warning::
+        `inference_mode` does NOT automatically set the model to evaluation mode.
+        For proper inference behavior (e.g., disabling dropout, using running statistics
+        in batch normalization), you must explicitly set your model to evaluation mode using
+        `model.eval()` in addition to using this context manager.
+
     Args:
         mode (bool or function): Either a boolean flag to enable or disable
             inference mode, or a Python function to decorate with inference


### PR DESCRIPTION
Fixes #162923

## Test Result

### Before

<img width="985" height="889" alt="image" src="https://github.com/user-attachments/assets/41de5cfa-7b25-4ba4-ade8-a6df745dcb30" />

### After

<img width="913" height="977" alt="image" src="https://github.com/user-attachments/assets/b6c06860-8db3-4b5d-9d46-31ece01fb04d" />

