### PR TITLE
[Quant] extend the op list for quant lift up

### DIFF
--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -4703,7 +4703,6 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
                 self.k_proj = torch.nn.Linear(input_dim, input_dim, bias=False)
                 self.v_proj = torch.nn.Linear(input_dim, input_dim, bias=False)
                 self.softmax = torch.nn.Softmax(dim=-1)
-                self.transpose_for_score = transpose_for_score
                 self.num_attention_heads = num_attention_heads
                 self.attention_head_size = attention_head_size
                 self.all_head_size = self.num_attention_heads * self.attention_head_size

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -4750,7 +4750,7 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
                 )
                 self.assertEqual(
                     counters["inductor"]["quant_lift_up_count"],
-                    4 if annotate_matmul and not TEST_ACL else 1,
+                    4 if (annotate_matmul and not TEST_ACL and IS_X86) else 1,
                 )
 
             quantizer = X86InductorQuantizer()

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -4694,7 +4694,6 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
             def __init__(
                 self,
                 input_dim,
-                transpose_for_score=False,
                 num_attention_heads=None,
                 attention_head_size=None,
             ) -> None:
@@ -4705,11 +4704,10 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
                 self.v_proj = torch.nn.Linear(input_dim, input_dim, bias=False)
                 self.softmax = torch.nn.Softmax(dim=-1)
                 self.transpose_for_score = transpose_for_score
-                if self.transpose_for_score:
-                    assert num_attention_heads is not None
-                    assert attention_head_size is not None
-                    self.num_attention_heads = num_attention_heads
-                    self.attention_head_size = attention_head_size
+                self.num_attention_heads = num_attention_heads
+                self.attention_head_size = attention_head_size
+                self.all_head_size = self.num_attention_heads * self.attention_head_size
+                self.dense = torch.nn.Linear(self.all_head_size, self.all_head_size)
 
             def transpose_for_scores(self, x: torch.Tensor) -> torch.Tensor:
                 new_x_shape = x.size()[:-1] + (
@@ -4723,19 +4721,21 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
                 q = self.q_proj(x)
                 k = self.k_proj(x)
                 v = self.v_proj(x)
-                if self.transpose_for_score:
-                    q = self.transpose_for_scores(q)
-                    k = self.transpose_for_scores(k)
-                    v = self.transpose_for_scores(v)
+                q = self.transpose_for_scores(q)
+                k = self.transpose_for_scores(k)
+                v = self.transpose_for_scores(v)
                 scores = torch.matmul(q, k.transpose(-1, -2)) / (self.input_dim**0.5)
                 attention = self.softmax(scores)
                 weighted = torch.matmul(attention, v)
-                return weighted
+                weighted = weighted.permute(0, 2, 1, 3).contiguous()
+                weighted = weighted.reshape(
+                    weighted.size()[:-2] + (self.all_head_size,)
+                )
+                return self.dense(weighted)
 
-        for annotate_matmul in [False, True]:
+        for annotate_matmul in [True, False]:
             mod = SelfAttnLikeModule(
                 input_dim=64 * 16,
-                transpose_for_score=True,
                 num_attention_heads=16,
                 attention_head_size=64,
             ).eval()
@@ -4743,11 +4743,15 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
 
             def matcher_check_fn():
                 self.assertEqual(
-                    counters["inductor"]["qlinear_weight_prepack_matcher_count"], 3
+                    counters["inductor"]["qlinear_weight_prepack_matcher_count"], 4
                 )
                 self.assertEqual(
                     counters["inductor"]["qlinear_unary_matcher_count"],
                     3 if annotate_matmul and not TEST_ACL else 0,
+                )
+                self.assertEqual(
+                    counters["inductor"]["quant_lift_up_count"],
+                    4 if annotate_matmul and not TEST_ACL else 1,
                 )
 
             quantizer = X86InductorQuantizer()

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -4748,10 +4748,11 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
                     counters["inductor"]["qlinear_unary_matcher_count"],
                     3 if annotate_matmul and not TEST_ACL else 0,
                 )
-                self.assertEqual(
-                    counters["inductor"]["quant_lift_up_count"],
-                    1 if ((not annotate_matmul or TEST_ACL) and IS_X86) else 4,
-                )
+                if IS_X86:  # Some issues on ARM
+                    self.assertEqual(
+                        counters["inductor"]["quant_lift_up_count"],
+                        4 if annotate_matmul and not TEST_ACL else 1,
+                    )
 
             quantizer = X86InductorQuantizer()
             quantizer.set_global(xiq.get_default_x86_inductor_quantization_config())

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -4750,7 +4750,7 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
                 )
                 self.assertEqual(
                     counters["inductor"]["quant_lift_up_count"],
-                    4 if (annotate_matmul and not TEST_ACL and IS_X86) else 1,
+                    1 if ((not annotate_matmul or TEST_ACL) and IS_X86) else 4,
                 )
 
             quantizer = X86InductorQuantizer()

--- a/torch/_inductor/fx_passes/quantization.py
+++ b/torch/_inductor/fx_passes/quantization.py
@@ -43,6 +43,7 @@ _VIEW_OPS = [
     aten.transpose.int,
     aten.permute.default,
     aten.view.default,
+    aten.reshape.default,
 ]
 
 """
@@ -3917,6 +3918,7 @@ def quant_lift_up(graph_module: torch.fx.GraphModule):
 
             # Further check the input node of the first view node has only 1 user node
             if could_lift_up and len(input_node.users) == 1:
+                counters["inductor"]["quant_lift_up_count"] += 1
                 # Replace dequant's input from quant to quant's input
                 quant_node.replace_all_uses_with(input_node_of_quant)
                 # Insert the new quant node


### PR DESCRIPTION
Add `aten.reshape.default` into the op list of quant lift up, in order to fuse more potential quantized kernels.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben