### PR TITLE
[AOTI] [XPU] add null-pointer-deference check for `malloc` in `sycl_runtime_wrappers.h`

### DIFF
--- a/torch/csrc/inductor/aoti_runtime/sycl_runtime_wrappers.h
+++ b/torch/csrc/inductor/aoti_runtime/sycl_runtime_wrappers.h
@@ -1,6 +1,7 @@
 // NOLINT
 #pragma once
 #ifdef USE_XPU
+#include <c10/util/Exception.h>
 #include <c10/xpu/XPUFunctions.h>
 #include <level_zero/ze_api.h>
 #include <sycl/sycl.hpp>
@@ -46,6 +47,7 @@ static ze_module_handle_t _createModule(
     size_t szLog = 0;
     ZE_CHECK(zeModuleBuildLogGetString(buildLog, &szLog, nullptr));
     char* strLog = (char*)malloc(szLog);
+    TORCH_CHECK(strLog != nullptr, "Failed to allocate log buffer, size=", szLog);
     ZE_CHECK(zeModuleBuildLogGetString(buildLog, &szLog, strLog));
     std::cerr << "L0 build module failed. Log: " << strLog << std::endl;
     free(strLog);

--- a/torch/csrc/inductor/aoti_runtime/sycl_runtime_wrappers.h
+++ b/torch/csrc/inductor/aoti_runtime/sycl_runtime_wrappers.h
@@ -47,7 +47,7 @@ static ze_module_handle_t _createModule(
     size_t szLog = 0;
     ZE_CHECK(zeModuleBuildLogGetString(buildLog, &szLog, nullptr));
     char* strLog = (char*)malloc(szLog);
-    TORCH_CHECK(strLog != nullptr, "Failed to allocate log buffer, size=", szLog);
+    TORCH_INTERNAL_ASSERT(strLog != nullptr, "Failed to allocate log buffer, size=", szLog);
     ZE_CHECK(zeModuleBuildLogGetString(buildLog, &szLog, strLog));
     std::cerr << "L0 build module failed. Log: " << strLog << std::endl;
     free(strLog);


### PR DESCRIPTION
Fixes #163624
I use `TORCH_CHECK` because I think this `npd` issue can be caused by users when they try to allocate too large memory