### PR TITLE
[CD] CUDA 13.0 fix preload logic to include nvidia/cu13/lib/

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -346,7 +346,7 @@ def _load_global_deps() -> None:
                 return
             # If all above-mentioned conditions are met, preload nvrtc and nvjitlink
             _preload_cuda_deps("cuda_nvrtc", "libnvrtc.so.*[0-9]")
-            _preload_cuda_deps("cuda_nvrtc", "libnvrtc-builtins.*[0-9]")
+            _preload_cuda_deps("cuda_nvrtc", "libnvrtc-builtins.so.*[0-9]")
             _preload_cuda_deps("nvjitlink", "libnvJitLink.so.*[0-9]")
         except Exception:
             pass

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -282,19 +282,18 @@ if sys.platform == "win32":
     del _load_dll_libraries
 
 
-def _get_cuda_dep_paths(
-    path: str, lib_folder: str, lib_name: str
-) -> list[str]:
+def _get_cuda_dep_paths(path: str, lib_folder: str, lib_name: str) -> list[str]:
     # Libraries can either be in
     # path/nvidia/lib_folder/lib or
     # path/nvidia/cuXX/lib (since CUDA 13.0) or
     # path/lib_folder/lib
     from torch.version import cuda as cuda_version
+
     nvidia_lib_paths = glob.glob(
         os.path.join(path, "nvidia", lib_folder, "lib", lib_name)
     )
     if cuda_version is not None:
-        maj_cuda_version = int(cuda_version.split(".")[0])
+        maj_cuda_version = cuda_version.split(".")[0]
         nvidia_lib_paths += glob.glob(
             os.path.join(path, "nvidia", f"cu{maj_cuda_version}", "lib", lib_name)
         )
@@ -310,9 +309,7 @@ def _preload_cuda_deps(lib_folder: str, lib_name: str) -> None:
 
     lib_path = None
     for path in sys.path:
-        candidate_lib_paths = _get_cuda_dep_paths(
-            path, lib_folder, lib_name
-        )
+        candidate_lib_paths = _get_cuda_dep_paths(path, lib_folder, lib_name)
         if candidate_lib_paths:
             lib_path = candidate_lib_paths[0]
             break

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -306,9 +306,8 @@ def _preload_cuda_deps(lib_folder: str, lib_name: str) -> None:
     assert platform.system() == "Linux", "Should only be called on Linux"
 
     from torch.version import cuda as cuda_version
-    from torch.utils._typing_utils import not_none
 
-    maj_cuda_version = int(not_none(cuda_version.split(".")[0]))
+    maj_cuda_version = int(cuda_version.split(".")[0])  # type: ignore[union-attr]
 
     lib_path = None
     for path in sys.path:


### PR DESCRIPTION
Preload logic no longer works with CUDA 13.0
See the installation path:
```
ls /home/ubuntu/.venv/lib/python3.10/site-packages/nvidia/cu13/lib/
libcheckpoint.so   libcudadevrt.a      libcufft.so.12   libcufile_rdma.so.1  libcusolver.so.12    libnvJitLink.so.13  libnvperf_target.so            libnvrtc.alt.so.13    libpcsamplingutil.so
libcublas.so.13    libcudart.so.13     libcufftw.so.12  libcupti.so.13       libcusolverMg.so.12  libnvblas.so.13     libnvrtc-builtins.alt.so.13.0  libnvrtc.so.13
libcublasLt.so.13  libcudart_static.a  libcufile.so.0   libcurand.so.10      libcusparse.so.12    libnvperf_host.so   libnvrtc-builtins.so.13.0      libnvtx3interop.so.1

ls /home/ubuntu/.venv/lib/python3.10/site-packages/nvidia/
cu13  cudnn  cusparselt  nccl  nvshmem
```

Test using script from : https://github.com/pytorch/pytorch/issues/162367
```
Kernel test passed!
```