### PR TITLE
Fake process group Direct construction error

### DIFF
--- a/test/distributed/test_fake_pg.py
+++ b/test/distributed/test_fake_pg.py
@@ -265,6 +265,7 @@ class TestFakePG(TestCase):
             RuntimeError, "FakeProcessGroup collective operation error"
         ):
             dist.barrier()
+
     def test_fake_process_group_direct_usage_error(self):
         class SimpleTensorMode(TorchDispatchMode):
             def __torch_dispatch__(self, func, types, args=(), kwargs=None):

--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -597,6 +597,10 @@ class ProcessGroup:
 
 class FakeProcessGroup(Backend):
     def __init__(self, rank: int, world_size: int) -> None: ...
+    @staticmethod
+    def _create_internal(
+        rank: int, world_size: int, options: Optional[Options] = None
+    ) -> FakeProcessGroup: ...
 
 class FakeWork(Work):
     seq_id: int

--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -598,9 +598,7 @@ class ProcessGroup:
 class FakeProcessGroup(Backend):
     def __init__(self, rank: int, world_size: int) -> None: ...
     @staticmethod
-    def _create_internal(
-        rank: int, world_size: int, options: Optional[Options] = None
-    ) -> FakeProcessGroup: ...
+    def _create_internal(rank: int, world_size: int) -> FakeProcessGroup: ...
 
 class FakeWork(Work):
     seq_id: int

--- a/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
@@ -28,11 +28,15 @@ class FakeProcessGroup : public Backend {
     bool error_on_collective = false;
   };
 
-  FakeProcessGroup(
+  // Static factory method for official APIs
+  static c10::intrusive_ptr<FakeProcessGroup> _create_internal(
       int rank,
       int size,
-      c10::intrusive_ptr<Options> options = c10::make_intrusive<Options>())
-      : Backend(rank, size), options_(std::move(options)) {}
+      c10::intrusive_ptr<Options> options = c10::make_intrusive<Options>()) {
+    return c10::intrusive_ptr<FakeProcessGroup>(
+        new FakeProcessGroup(rank, size, std::move(options)),
+        c10::raw::DontIncreaseRefcount{});
+  }
 
   const std::string getBackendName() const override {
     return "fake";
@@ -235,6 +239,9 @@ class FakeProcessGroup : public Backend {
   }
 
  private:
+  // Private constructor used by official APIs
+  FakeProcessGroup(int rank, int size, c10::intrusive_ptr<Options> options)
+      : Backend(rank, size), options_(std::move(options)) {}
   c10::intrusive_ptr<Options> options_;
 
   void checkCollectiveError() {

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -3820,18 +3820,27 @@ such as `dist.all_reduce(tensor, async_op=True)`.
           "error_on_collective",
           &::c10d::FakeProcessGroup::Options::error_on_collective);
   fakeProcessGroup
-      .def(
-          py::init([](int rank,
-                      int size,
-                      c10::intrusive_ptr<::c10d::FakeProcessGroup::Options>
-                          options) {
-            return c10::make_intrusive<::c10d::FakeProcessGroup>(
+      .def_static(
+          "_create_internal",
+          [](int rank,
+             int size,
+             c10::intrusive_ptr<::c10d::FakeProcessGroup::Options> options) {
+            return ::c10d::FakeProcessGroup::_create_internal(
                 rank, size, std::move(options));
-          }),
+          },
           py::arg("rank"),
           py::arg("world_size"),
           py::arg("options") =
               c10::make_intrusive<::c10d::FakeProcessGroup::Options>())
+      .def(
+          "__init__",
+          [](py::object, py::args args, py::kwargs kwargs) {
+            TORCH_CHECK(
+                false,
+                "FakeProcessGroup cannot be constructed directly. "
+                "Use torch.distributed.init_process_group(backend='fake') instead to ensure "
+                "proper dispatch system integration.");
+          })
       .def_property_readonly(
           "options", &::c10d::FakeProcessGroup::getBackendOptions);
   auto fakeWork =

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -3834,7 +3834,9 @@ such as `dist.all_reduce(tensor, async_op=True)`.
               c10::make_intrusive<::c10d::FakeProcessGroup::Options>())
       .def(
           "__init__",
-          [](py::object, py::args args, py::kwargs kwargs) {
+          [](const py::object&,
+             const py::args& args,
+             const py::kwargs& kwargs) {
             TORCH_CHECK(
                 false,
                 "FakeProcessGroup cannot be constructed directly. "

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -3518,7 +3518,6 @@ def recv_object_list(
         >>> objects
         ['foo', 12, {1: 2}]
     """
-
     group = _group_or_default_group(group)
     group_src = _canonicalize_group_rank(group, src, group_src)
     _check_not_self_rank(group, group_src, "source")

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -997,32 +997,17 @@ def _store_based_barrier(
     )
 
 
-def _check_fake_process_group_usage(group):
-    """
-    Check if user is using FakeProcessGroup directly without proper initialization.
-    This can cause dispatch issues and should raise error.
-
-    Args:
-        group (ProcessGroup): Process group to validate.
-
-    Raises:
-        RuntimeError: If group is FakeProcessGroup and distributed is not initialized.
-            Users should call init_process_group(backend='fake') instead.
-    """
-    if isinstance(group, FakeProcessGroup) and not is_initialized():
-        raise RuntimeError(
-            "FakeProcessGroup is not supported for direct use. "
-            "Call torch.distributed.init_process_group(backend='fake') first to ensure "
-            "proper dispatch system integration."
-        )
-
-
 def _rank_not_in_group(group: Optional[ProcessGroup]) -> bool:
     """Check if the current process's rank is not in a given group."""
     if group is None:
         return False
     else:
-        _check_fake_process_group_usage(group)
+        if isinstance(group, FakeProcessGroup) and not is_initialized():
+            raise RuntimeError(
+                "FakeProcessGroup requires distributed to be initialized first. "
+                "Call torch.distributed.init_process_group(backend='fake') first to ensure "
+                "proper dispatch system integration."
+            )
     return group == GroupMember.NON_GROUP_MEMBER
 
 

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -1001,14 +1001,27 @@ def _rank_not_in_group(group: Optional[ProcessGroup]) -> bool:
     """Check if the current process's rank is not in a given group."""
     if group is None:
         return False
-    else:
-        if isinstance(group, FakeProcessGroup) and not is_initialized():
-            raise RuntimeError(
-                "FakeProcessGroup requires distributed to be initialized first. "
-                "Call torch.distributed.init_process_group(backend='fake') first to ensure "
-                "proper dispatch system integration."
-            )
     return group == GroupMember.NON_GROUP_MEMBER
+
+
+def _check_process_group_initialization(group: Optional[ProcessGroup]) -> None:
+    """
+    Check if user is using FakeProcessGroup directly without proper initialization.
+    This can cause dispatch issues and should raise error.
+
+    Args:
+        group (ProcessGroup): Process group to validate.
+
+    Raises:
+        RuntimeError: If group is FakeProcessGroup and distributed is not initialized.
+            Users should call init_process_group(backend='fake') instead.
+    """
+    if isinstance(group, FakeProcessGroup) and not is_initialized():
+        raise RuntimeError(
+            "FakeProcessGroup requires distributed to be initialized first. "
+            "Call torch.distributed.init_process_group(backend='fake') first to ensure "
+            "proper dispatch system integration."
+        )
 
 
 def _warn_not_in_group(op_name) -> None:
@@ -2417,6 +2430,8 @@ def isend(
         None, if not part of the group
 
     """
+    if group is not None:
+        _check_process_group_initialization(group)
     group = _group_or_default_group(group)
     group_dst = _canonicalize_group_rank(group, dst, group_dst)
     _check_single_tensor(tensor, "tensor")
@@ -2459,6 +2474,8 @@ def irecv(
         None, if not part of the group
 
     """
+    if group is not None:
+        _check_process_group_initialization(group)
     _check_single_tensor(tensor, "tensor")
     if _rank_not_in_group(group):
         _warn_not_in_group("irecv")
@@ -2499,6 +2516,8 @@ def send(
         group_dst (int, optional): Destination rank on ``group``.  Invalid to specify both ``dst`` and ``group_dst``.
 
     """
+    if group is not None:
+        _check_process_group_initialization(group)
     group = _group_or_default_group(group)
     group_dst = _canonicalize_group_rank(group, dst, group_dst)
     _check_not_self_rank(group, group_dst, "destination")
@@ -2534,6 +2553,8 @@ def recv(
         -1, if not part of the group
 
     """
+    if group is not None:
+        _check_process_group_initialization(group)
     work = irecv(tensor, src=src, group=group, tag=tag, group_src=group_src)
     if work is None:
         return -1
@@ -2830,6 +2851,8 @@ def broadcast(
         None, if not async_op or if not part of the group
 
     """
+    if group is not None:
+        _check_process_group_initialization(group)
     group = _group_or_default_group(group)
     group_src = _canonicalize_group_rank(group, src, group_src, return_global=False)
     _check_single_tensor(tensor, "tensor")
@@ -2904,6 +2927,8 @@ def all_reduce(tensor, op=ReduceOp.SUM, group=None, async_op=False):
         tensor([4.+4.j, 6.+6.j], device='cuda:1') # Rank 1
 
     """
+    if group is not None:
+        _check_process_group_initialization(group)
     # Dynamo has built-in logic to map legacy distributed ops to functional collectives.
     # Let's redirect to a torch function mode that can mimic this logic outside Dynamo
     # (e.g., non-strict export implements such a torch function mode).
@@ -3055,6 +3080,8 @@ def reduce(
         None, if not async_op or if not part of the group
 
     """
+    if group is not None:
+        _check_process_group_initialization(group)
     group = _group_or_default_group(group)
     group_dst = _canonicalize_group_rank(group, dst, group_dst, return_global=False)
     _check_single_tensor(tensor, "tensor")
@@ -3170,6 +3197,8 @@ def all_gather_object(object_list, obj, group=None):
         >>> output
         ['foo', 12, {1: 2}]
     """
+    if group is not None:
+        _check_process_group_initialization(group)
     if _rank_not_in_group(group):
         _warn_not_in_group("all_gather_object")
         return
@@ -3279,6 +3308,8 @@ def gather_object(
         >>> output
         ['foo', 12, {1: 2}]
     """
+    if group is not None:
+        _check_process_group_initialization(group)
     group = _group_or_default_group(group)
     if dst is None and group_dst is None:
         dst = 0
@@ -3409,6 +3440,8 @@ def send_object_list(
         >>> objects
         ['foo', 12, {1: 2}]
     """
+    if group is not None:
+        _check_process_group_initialization(group)
     group = _group_or_default_group(group)
     group_dst = _canonicalize_group_rank(group, dst, group_dst)
     _check_not_self_rank(group, group_dst, "destination")
@@ -3526,10 +3559,13 @@ def recv_object_list(
         >>> objects
         ['foo', 12, {1: 2}]
     """
+    if group is not None:
+        _check_process_group_initialization(group)
+
     group = _group_or_default_group(group)
     group_src = _canonicalize_group_rank(group, src, group_src)
     _check_not_self_rank(group, group_src, "source")
-
+    
     if _rank_not_in_group(group):
         _warn_not_in_group("recv_object_list")
         return -1
@@ -3671,6 +3707,8 @@ def broadcast_object_list(
         >>> objects
         ['foo', 12, {1: 2}]
     """
+    if group is not None:
+        _check_process_group_initialization(group)
     group = _group_or_default_group(group)
     if src is None and group_src is None:
         src = 0
@@ -3795,6 +3833,8 @@ def scatter_object_list(
         >>> output_list
         [{1: 2}]
     """
+    if group is not None:
+        _check_process_group_initialization(group)
     group = _group_or_default_group(group)
     if src is None and group_src is None:
         src = 0
@@ -3921,6 +3961,8 @@ def all_gather(tensor_list, tensor, group=None, async_op=False):
         [tensor([1.+1.j, 2.+2.j], device='cuda:1'), tensor([3.+3.j, 4.+4.j], device='cuda:1')] # Rank 1
 
     """
+    if group is not None:
+        _check_process_group_initialization(group)
     # Dynamo has built-in logic to map legacy distributed ops to functional collectives.
     # Let's redirect to a torch function mode that can mimic this logic outside Dynamo
     # (e.g., non-strict export implements such a torch function mode).
@@ -4012,6 +4054,8 @@ def all_gather_into_tensor(output_tensor, input_tensor, group=None, async_op=Fal
         tensor([[1, 2],
                 [3, 4]], device='cuda:1') # Rank 1
     """
+    if group is not None:
+        _check_process_group_initialization(group)
     # Dynamo has built-in logic to map legacy distributed ops to functional collectives.
     # Let's redirect to a torch function mode that can mimic this logic outside Dynamo
     # (e.g., non-strict export implements such a torch function mode).
@@ -4249,6 +4293,8 @@ def gather(
         None                                                                   # Rank 1
 
     """
+    if group is not None:
+        _check_process_group_initialization(group)
     _check_single_tensor(tensor, "tensor")
 
     # Parameter ``gather_list`` may be left unspecified on non-dst ranks.
@@ -4339,6 +4385,8 @@ def scatter(
         tensor([5., 5.], device='cuda:1') # Rank 1
 
     """
+    if group is not None:
+        _check_process_group_initialization(group)
     _check_single_tensor(tensor, "tensor")
     # Parameter ``scatter_list`` may be left unspecified on non-src ranks.
     if scatter_list:
@@ -4408,6 +4456,8 @@ def reduce_scatter(output, input_list, op=ReduceOp.SUM, group=None, async_op=Fal
         None, if not async_op or if not part of the group.
 
     """
+    if group is not None:
+        _check_process_group_initialization(group)
     _check_single_tensor(output, "output")
     _check_tensor_list(input_list, "input_list")
     _ensure_all_tensors_same_dtype(output, input_list)
@@ -4483,6 +4533,8 @@ def reduce_scatter_tensor(output, input, op=ReduceOp.SUM, group=None, async_op=F
         tensor([4, 6], device='cuda:1') # Rank 1
 
     """
+    if group is not None:
+        _check_process_group_initialization(group)
     # Dynamo has built-in logic to map legacy distributed ops to functional collectives.
     # Let's redirect to a torch function mode that can mimic this logic outside Dynamo
     # (e.g., non-strict export implements such a torch function mode).
@@ -4661,6 +4713,8 @@ def all_to_all_single(
         tensor([3+3j, 7+7j, 11+11j, 15+15j])                            # Rank 2
         tensor([4+4j, 8+8j, 12+12j, 16+16j])                            # Rank 3
     """
+    if group is not None:
+        _check_process_group_initialization(group)
     # Dynamo has built-in logic to map legacy distributed ops to functional collectives.
     # Let's redirect to a torch function mode that can mimic this logic outside Dynamo
     # (e.g., non-strict export implements such a torch function mode).
@@ -4802,6 +4856,8 @@ def all_to_all(output_tensor_list, input_tensor_list, group=None, async_op=False
         [tensor([4+4j]), tensor([8+8j]), tensor([12+12j]), tensor([16+16j])]        # Rank 3
 
     """
+    if group is not None:
+        _check_process_group_initialization(group)
     if _rank_not_in_group(group):
         _warn_not_in_group("all_to_all")
         return
@@ -4858,6 +4914,8 @@ def barrier(
        that was first used with this process group, if another collective with tensor inputs has been performed, (4)
        the device index indicated by the global rank mod local device count.
     """
+    if group is not None:
+        _check_process_group_initialization(group)
     group = group or _get_default_group()
 
     if _rank_not_in_group(group):
@@ -4952,6 +5010,8 @@ def monitored_barrier(
         >>> # indicating that ranks 1, 2, ... world_size - 1 did not call into
         >>> # monitored_barrier.
     """
+    if group is not None:
+        _check_process_group_initialization(group)
     # Need to call rank not in group before using the group, otherwise
     # "Invalid process group" error is raised.
     if _rank_not_in_group(group):

--- a/torch/distributed/fsdp/_flat_param.py
+++ b/torch/distributed/fsdp/_flat_param.py
@@ -543,7 +543,7 @@ class FlatParamHandle:
         self._device_handle = _FSDPDeviceHandle.from_device(self.device)
         self.process_group = process_group
         if self._use_fake_all_gather or self._use_fake_reduce:
-            self._fake_process_group = FakeProcessGroup(
+            self._fake_process_group = FakeProcessGroup._create_internal(
                 rank=process_group.rank(), world_size=process_group.size()
             )
         self.rank = process_group.rank()

--- a/torch/testing/_internal/distributed/fake_pg.py
+++ b/torch/testing/_internal/distributed/fake_pg.py
@@ -22,7 +22,7 @@ def _create_fake_pg(common_opts, backend_opts):
     for every collective. It should be used as a convenient tool when playing
     with distributed but don't care about the actual data.
     """
-    return FakeProcessGroup(
+    return FakeProcessGroup._create_internal(
         common_opts.group_rank, common_opts.group_size, backend_opts
     )
 


### PR DESCRIPTION
Fixes #162129. Added validation in _rank_not_in_group() to check if ```FakeProcessGroup``` is properly initialized before use, raising a clear error message if ```torch.distributed.init_process_group(backend='fake')``` hasn't been called first. 
This prevents silent failures and ensures proper dispatch system integration for all distributed operations. 

Added test case test_fake_process_group_direct_usage_error() that validates the error is raised for ```all_reduce``` and ```all_to_all_single``` operations. 

Please let me know if additional distributed operators should be tested or if any other updates are needed.


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci