### PR TITLE
Do not generate guards on unbacked SymInt inputs

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -3271,7 +3271,7 @@ class TestUnbacked(TestCase):
 | | +- TYPE_MATCH: ___check_type_id(L['b'], 94515018331968)
 | | +- TENSOR_MATCH: check_tensor(L['b'], Tensor, DispatchKeySet(CPU, BackendSelect, ADInplaceOrView, AutogradCPU), torch.float32, device=None, requires_grad=False, size=[None, None], stride=[None, 1])
 | | +- NO_HASATTR: hasattr(L['b'], '_dynamo_dynamic_indices') == False
-| | +- NO_TENSOR_ALIASING""",
+| | +- NO_TENSOR_ALIASING""",  # noqa: B950
             ignore_comments=True,
             ignore_empty_lines=True,
         )

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -3304,9 +3304,55 @@ class TestUnbacked(TestCase):
         except:
             pass
 
+    @skipIfTorchDynamo("mark_unbacked is not traceable")
+    def test_do_not_guard_unbacked_inputs3(self):
+        cnt = CompileCounterWithBackend("inductor")
+
+        @torch.compile(fullgraph=True, dynamic=True, backend=cnt)
+        def func(a):
+            # this should generate runtime assertio and no guard.
+            torch._check(a.size()[0] == a.size()[1])
+            # This should generate guard
+            torch._check(a.size()[1] < 10)
+            return a * 10
+
+           # no reocmpile if we pass 9, 8
+        # recompile if we pass 11
+        a = torch.rand(4,4)
+        torch._dynamo.decorators.mark_unbacked(a, 0)
+        torch._dynamo.mark_dynamic(a, 1)
+        func(a)
+
+        # no recompile
+        try :
+            func(torch.rand(4, 7))
+        except:
+            pass
+        # recompile
+        try :
+            func(torch.rand(100, 100))
+        except:
+            pass
 
 
 
+    @skipIfTorchDynamo("mark_unbacked is not traceable")
+    def test_do_not_guard_unbacked_inputs4(self):
+        cnt = CompileCounterWithBackend("inductor")
+
+        @torch.compile(fullgraph=True, dynamic=True, backend=cnt)
+        def func(a):
+            return a*10
+
+           # no reocmpile if we pass 9, 8
+        # recompile if we pass 11
+        a = torch.rand(1,2,3,4,5)
+        torch._dynamo.decorators.mark_unbacked(a, 0)
+        torch._dynamo.decorators.mark_unbacked(a, 1)
+        torch._dynamo.decorators.mark_unbacked(a, 2)
+        torch._dynamo.decorators.mark_unbacked(a, 3)
+        torch._dynamo.decorators.mark_unbacked(a, 4)
+        func(a)
 
 class TestUbackedOps(TestCase):
     @fresh_cache()

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -3232,6 +3232,52 @@ class TestUnbacked(TestCase):
             func(a, torch.rand(2, 1))
 
 
+    @skipIfTorchDynamo("mark_unbacked is not traceable")
+    def test_do_no_guard_unbacked_inputs(self):
+        @torch.compile(fullgraph=True, dynamic=True, backend="inductor")
+        def func(a, b):
+            a.expand(b.shape)
+            return a * 10
+
+        a = torch.rand(1, 1)
+        b = torch.rand(1, 1)
+
+        torch._dynamo.decorators.mark_unbacked(a, 0)
+        torch._dynamo.decorators.mark_unbacked(a, 1)
+        torch._dynamo.decorators.mark_unbacked(b, 0)
+        torch._dynamo.decorators.mark_unbacked(b, 1)
+
+
+        log_stream, ctx = logs_to_string("torch._dynamo.guards","guards")
+        with ctx():
+            func(a, b)
+            func(torch.rand(4, 5), torch.rand(4, 5))
+
+        guards = "\n".join(log_stream.getvalue().strip().split("\n")[4:]).strip()
+        # Strip comments from each line
+        guards = "\n".join(line.split('#')[0].rstrip() for line in guards.split('\n'))
+        # Remove the last line (Guard eval latency)
+        guards = "\n".join(guards.split('\n')[:-1])
+        self.assertExpectedInline(
+            guards,
+            """\
+| +- LAMBDA_GUARD_NO_ARGS: torch._functorch.aot_autograd.utils.top_saved_tensors_hooks ids == None
+| +- DEFAULT_DEVICE: utils_device.CURRENT_DEVICE == None
+| +- GLOBAL_STATE: ___check_global_state()
+| +- TORCH_FUNCTION_MODE_STACK: ___check_torch_function_mode_stack()
+| +- GuardManager: source=L['a'], accessed_by=FrameLocalsGuardAccessor(key='a', framelocals_idx=0), type=<class 'torch.Tensor'>, tag_safe=(True, False)
+| | +- TENSOR_MATCH: check_tensor(L['a'], Tensor, DispatchKeySet(CPU, BackendSelect, ADInplaceOrView, AutogradCPU), torch.float32, device=None, requires_grad=False, size=[None, None], stride=[None, 1])
+| | +- NO_HASATTR: hasattr(L['a'], '_dynamo_dynamic_indices') == False
+| | +- NO_TENSOR_ALIASING: check_no_aliasing(L['a'], L['b'])
+| +- GuardManager: source=L['b'], accessed_by=FrameLocalsGuardAccessor(key='b', framelocals_idx=1), type=<class 'torch.Tensor'>, tag_safe=(True, False)
+| | +- TYPE_MATCH: ___check_type_id(L['b'], 94515018331968)
+| | +- TENSOR_MATCH: check_tensor(L['b'], Tensor, DispatchKeySet(CPU, BackendSelect, ADInplaceOrView, AutogradCPU), torch.float32, device=None, requires_grad=False, size=[None, None], stride=[None, 1])
+| | +- NO_HASATTR: hasattr(L['b'], '_dynamo_dynamic_indices') == False
+| | +- NO_TENSOR_ALIASING""",
+            ignore_comments=True,
+            ignore_empty_lines=True,
+        )
+
 class TestUbackedOps(TestCase):
     @fresh_cache()
     @skipIfTorchDynamo("not allowed to trace mark_unbacked")

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -3252,30 +3252,7 @@ class TestUnbacked(TestCase):
             func(torch.rand(4, 5), torch.rand(4, 5))
 
         guards = "\n".join(log_stream.getvalue().strip().split("\n")[4:]).strip()
-        # Strip comments from each line
-        guards = "\n".join(line.split("#")[0].rstrip() for line in guards.split("\n"))
-        # Remove the last line (Guard eval latency)
-        guards = "\n".join(guards.split("\n")[:-1])
-        # Remove all lines containing ___check_type_id
-        guards = "\n".join(line for line in guards.split('\n') if '___check_type_id' not in line)
-        self.assertExpectedInline(
-            guards,
-            """\
-| +- LAMBDA_GUARD_NO_ARGS: torch._functorch.aot_autograd.utils.top_saved_tensors_hooks ids == None
-| +- DEFAULT_DEVICE: utils_device.CURRENT_DEVICE == None
-| +- GLOBAL_STATE: ___check_global_state()
-| +- TORCH_FUNCTION_MODE_STACK: ___check_torch_function_mode_stack()
-| +- GuardManager: source=L['a'], accessed_by=FrameLocalsGuardAccessor(key='a', framelocals_idx=0), type=<class 'torch.Tensor'>, tag_safe=(True, False)
-| | +- TENSOR_MATCH: check_tensor(L['a'], Tensor, DispatchKeySet(CPU, BackendSelect, ADInplaceOrView, AutogradCPU), torch.float32, device=None, requires_grad=False, size=[None, None], stride=[None, 1])
-| | +- NO_HASATTR: hasattr(L['a'], '_dynamo_dynamic_indices') == False
-| | +- NO_TENSOR_ALIASING: check_no_aliasing(L['a'], L['b'])
-| +- GuardManager: source=L['b'], accessed_by=FrameLocalsGuardAccessor(key='b', framelocals_idx=1), type=<class 'torch.Tensor'>, tag_safe=(True, False)
-| | +- TENSOR_MATCH: check_tensor(L['b'], Tensor, DispatchKeySet(CPU, BackendSelect, ADInplaceOrView, AutogradCPU), torch.float32, device=None, requires_grad=False, size=[None, None], stride=[None, 1])
-| | +- NO_HASATTR: hasattr(L['b'], '_dynamo_dynamic_indices') == False
-| | +- NO_TENSOR_ALIASING""",  # noqa: B950
-            ignore_comments=True,
-            ignore_empty_lines=True,
-        )
+        self.assertFalse("SYMBOLIC_SHAPE_GUARD" in guards)
 
 
 class TestUbackedOps(TestCase):

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -3231,7 +3231,6 @@ class TestUnbacked(TestCase):
         with self.assertRaises(RuntimeError):
             func(a, torch.rand(2, 1))
 
-
     @skipIfTorchDynamo("mark_unbacked is not traceable")
     def test_do_no_guard_unbacked_inputs(self):
         @torch.compile(fullgraph=True, dynamic=True, backend="inductor")
@@ -3247,17 +3246,16 @@ class TestUnbacked(TestCase):
         torch._dynamo.decorators.mark_unbacked(b, 0)
         torch._dynamo.decorators.mark_unbacked(b, 1)
 
-
-        log_stream, ctx = logs_to_string("torch._dynamo.guards","guards")
+        log_stream, ctx = logs_to_string("torch._dynamo.guards", "guards")
         with ctx():
             func(a, b)
             func(torch.rand(4, 5), torch.rand(4, 5))
 
         guards = "\n".join(log_stream.getvalue().strip().split("\n")[4:]).strip()
         # Strip comments from each line
-        guards = "\n".join(line.split('#')[0].rstrip() for line in guards.split('\n'))
+        guards = "\n".join(line.split("#")[0].rstrip() for line in guards.split("\n"))
         # Remove the last line (Guard eval latency)
-        guards = "\n".join(guards.split('\n')[:-1])
+        guards = "\n".join(guards.split("\n")[:-1])
         self.assertExpectedInline(
             guards,
             """\
@@ -3277,6 +3275,7 @@ class TestUnbacked(TestCase):
             ignore_comments=True,
             ignore_empty_lines=True,
         )
+
 
 class TestUbackedOps(TestCase):
     @fresh_cache()

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -5525,7 +5525,7 @@ class ShapeEnv:
 
                 # We do not want to guard on unbacked symbols. All replacements and
                 # bounds should have originated from torch._checks, so runtime
-                # assertions should be there to covor those guards.
+                # assertions should be there to cover those guards.
                 if not has_free_unbacked_symbols(s):
                     input_guards.append((source, s))
             else:
@@ -5852,7 +5852,7 @@ class ShapeEnv:
         for symbol, sources in symbol_to_source.items():
             # We do not want to guard on unbacked symbols. All replacements and
             # bounds should have originated from torch._checks, so runtime
-            # assertions should be there to covor those guards.
+            # assertions should be there to cover those guards.
             if self.is_unbacked_symint(symbol):
                 continue
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -5246,7 +5246,8 @@ class ShapeEnv:
         default.
         """
         self.log.info("produce_guards")
-
+        # import fbvscode
+        # fbvscode.set_trace()
         # Check if we get to the same ShapeEnv state by replaying the recorded events.
         # This will create a new ShapeEnv instance, and call all recorded function
         # calls on this new instance. Finally, it will check whether this new instance
@@ -5467,18 +5468,18 @@ class ShapeEnv:
         def track_symint(
             source: Source, val: IntLikeType, constraint: DimConstraint = None
         ) -> None:
-            # We should not generate guards for unbacked inputs.
-            if isinstance(val, SymInt) and has_free_unbacked_symbols(val.node.expr):
-                return
-
-            log.debug("track_symint %s %s %s", LazyString(source.name), val, constraint)
+            log.debug("track_symint %s %s %s", LazyString(source.name), val.node._expr if isinstance(val, SymInt) else val , constraint)
             assert not isinstance(val, SymInt) or is_symbolic(val)
 
             if isinstance(val, SymInt) and val.node.maybe_as_int() is not None:
                 val = val.node.maybe_as_int()
 
             if isinstance(val, SymInt):
-                s = val.node.expr
+                s = val.node._expr
+
+                if  has_free_unbacked_symbols(s):
+                    return
+
                 if isinstance(s, sympy.Symbol):
                     symbol_to_source[s].append(source)
                     if constraint is not None and not isinstance(
@@ -5658,6 +5659,8 @@ class ShapeEnv:
         #    if we have an input (2, 3), we must show s0*2 == 2 and s1 == 3.
         #    This does a lot of work: it covers duck sizing and equality guards.
         all_exprs: list[list[str]] = [[] for _ in langs]
+        # import fbvscode
+        # fbvscode.set_trace()
         self.dim_constraints = DimConstraints(
             symbol_to_source,
             self.var_to_val,

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -5467,6 +5467,10 @@ class ShapeEnv:
         def track_symint(
             source: Source, val: IntLikeType, constraint: DimConstraint = None
         ) -> None:
+            # Do not track unbacked inputs ! we do not generates guards on unbacked.
+            if isinstance(val, SymInt) and self.is_unbacked_symint(val.node.expr):
+                return
+
             log.debug("track_symint %s %s %s", LazyString(source.name), val, constraint)
             assert not isinstance(val, SymInt) or is_symbolic(val)
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -5467,7 +5467,7 @@ class ShapeEnv:
         def track_symint(
             source: Source, val: IntLikeType, constraint: DimConstraint = None
         ) -> None:
-            # Do not track unbacked inputs ! we do not generates guards on unbacked.
+            # We should not generate guards for unbacked inputs.
             if isinstance(val, SymInt) and self.is_unbacked_symint(val.node.expr):
                 return
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -5468,7 +5468,11 @@ class ShapeEnv:
             source: Source, val: IntLikeType, constraint: DimConstraint = None
         ) -> None:
             # We should not generate guards for unbacked inputs.
-            if isinstance(val, SymInt) and self.is_unbacked_symint(val.node.expr):
+            if (
+                isinstance(val, SymInt)
+                and isinstance(val.node.expr, sympy.Symbol)
+                and self.is_unbacked_symint(val.node.expr)
+            ):
                 return
 
             log.debug("track_symint %s %s %s", LazyString(source.name), val, constraint)

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -5468,11 +5468,7 @@ class ShapeEnv:
             source: Source, val: IntLikeType, constraint: DimConstraint = None
         ) -> None:
             # We should not generate guards for unbacked inputs.
-            if (
-                isinstance(val, SymInt)
-                and isinstance(val.node.expr, sympy.Symbol)
-                and self.is_unbacked_symint(val.node.expr)
-            ):
+            if isinstance(val, SymInt) and has_free_unbacked_symbols(val.node.expr):
                 return
 
             log.debug("track_symint %s %s %s", LazyString(source.name), val, constraint)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #163705

We should not generate guards on unbacked symbols, i found that we do some recompilations 
with my changes in [](https://github.com/pytorch/pytorch/pull/163652) and also found the following error messages
on current state of pytorch when running the program with the graph below.

TODO:
Still figuring out what is the right approach here. 
We need to know what guards are side effects of torch checks and which ones are things that did not go through a torch 
check yet. (like striding relations...)

cc @ezyang @EikanWang @jgong5 @wenzhe-nrv