### PR TITLE
[AOTI] Add verbose error information for extract file

### DIFF
--- a/torch/csrc/inductor/aoti_package/model_package_loader.cpp
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.cpp
@@ -335,16 +335,6 @@ bool recursive_mkdir(const std::string& dir) {
   return ret == 0;
 }
 
-bool recursive_make_parent_dir(const std::string& file_path) {
-  std::string str_file_path = normalize_path_separator(file_path);
-  const size_t found = str_file_path.find_last_of(k_separator);
-  std::string str_parent_path = (found == std::string::npos)
-      ? str_file_path
-      : str_file_path.substr(found + 1);
-
-  return recursive_mkdir(str_parent_path);
-}
-
 bool recursive_rmdir(const std::string& path) {
 #ifdef _WIN32
   std::error_code ec;
@@ -554,7 +544,6 @@ class RAIIMinizArchive {
       const std::string& dest_filename) {
     // Can't normalize_path_separator zip_filename, as it is zip index.
     std::string path_dest_filename = normalize_path_separator(dest_filename);
-    recursive_make_parent_dir(path_dest_filename);
     if (!mz_zip_reader_extract_file_to_file(
             &_zip_archive,
             zip_filename.c_str(),

--- a/torch/csrc/inductor/aoti_package/model_package_loader.cpp
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.cpp
@@ -541,12 +541,14 @@ class RAIIMinizArchive {
   void extract_file(
       const std::string& zip_filename,
       const std::string& dest_filename) {
+    // Can't normalize_path_separator zip_filename, as it is zip index.
+    std::string path_dest_filename = normalize_path_separator(dest_filename);
     if (!mz_zip_reader_extract_file_to_file(
-            &_zip_archive, zip_filename.c_str(), dest_filename.c_str(), 0)) {
+            &_zip_archive, zip_filename.c_str(), path_dest_filename.c_str(), 0)) {
       throw std::runtime_error(fmt::format(
           "Failed to extract zip file {} to destination file {}, error info {}",
           zip_filename,
-          dest_filename,  mz_zip_get_error_string(mz_zip_get_last_error(&_zip_archive))));
+          path_dest_filename,  mz_zip_get_error_string(mz_zip_get_last_error(&_zip_archive))));
     }
   }
 

--- a/torch/csrc/inductor/aoti_package/model_package_loader.cpp
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.cpp
@@ -544,11 +544,15 @@ class RAIIMinizArchive {
     // Can't normalize_path_separator zip_filename, as it is zip index.
     std::string path_dest_filename = normalize_path_separator(dest_filename);
     if (!mz_zip_reader_extract_file_to_file(
-            &_zip_archive, zip_filename.c_str(), path_dest_filename.c_str(), 0)) {
+            &_zip_archive,
+            zip_filename.c_str(),
+            path_dest_filename.c_str(),
+            0)) {
       throw std::runtime_error(fmt::format(
           "Failed to extract zip file {} to destination file {}, error info {}",
           zip_filename,
-          path_dest_filename,  mz_zip_get_error_string(mz_zip_get_last_error(&_zip_archive))));
+          path_dest_filename,
+          mz_zip_get_error_string(mz_zip_get_last_error(&_zip_archive))));
     }
   }
 

--- a/torch/csrc/inductor/aoti_package/model_package_loader.cpp
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.cpp
@@ -544,9 +544,9 @@ class RAIIMinizArchive {
     if (!mz_zip_reader_extract_file_to_file(
             &_zip_archive, zip_filename.c_str(), dest_filename.c_str(), 0)) {
       throw std::runtime_error(fmt::format(
-          "Failed to extract zip file {} to destination file {}",
+          "Failed to extract zip file {} to destination file {}, error info {}",
           zip_filename,
-          dest_filename));
+          dest_filename,  mz_zip_get_error_string(mz_zip_get_last_error(&_zip_archive))));
     }
   }
 

--- a/torch/csrc/inductor/aoti_package/model_package_loader.cpp
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.cpp
@@ -24,6 +24,7 @@ namespace fs = std::filesystem;
 
 // TODO: C++17 has the filesystem header, which may replace these
 #ifdef _WIN32
+#include <Windows.h>
 // On Windows, the POSIX implementations are considered deprecated. We simply
 // map to the newer variant.
 #include <direct.h>
@@ -559,11 +560,21 @@ class RAIIMinizArchive {
             zip_filename.c_str(),
             path_dest_filename.c_str(),
             0)) {
+#ifdef _WIN32
+      DWORD dwErrCode = GetLastError();
       throw std::runtime_error(fmt::format(
-          "Failed to extract zip file {} to destination file {}, error info {}",
+          "Failed to extract zip file {} to destination file {}, error code: {}, mz_zip error string: {}",
+          zip_filename,
+          path_dest_filename,
+          dwErrCode,
+          mz_zip_get_error_string(mz_zip_get_last_error(&_zip_archive))));
+#else
+      throw std::runtime_error(fmt::format(
+          "Failed to extract zip file {} to destination file {}, mz_zip error string: {}",
           zip_filename,
           path_dest_filename,
           mz_zip_get_error_string(mz_zip_get_last_error(&_zip_archive))));
+#endif
     }
   }
 

--- a/torch/csrc/inductor/aoti_package/model_package_loader.cpp
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.cpp
@@ -334,6 +334,16 @@ bool recursive_mkdir(const std::string& dir) {
   return ret == 0;
 }
 
+bool recursive_make_parent_dir(const std::string& file_path) {
+  std::string str_file_path = normalize_path_separator(file_path);
+  const size_t found = str_file_path.find_last_of(k_separator);
+  std::string str_parent_path = (found == std::string::npos)
+      ? str_file_path
+      : str_file_path.substr(found + 1);
+
+  return recursive_mkdir(str_parent_path);
+}
+
 bool recursive_rmdir(const std::string& path) {
 #ifdef _WIN32
   std::error_code ec;
@@ -543,6 +553,7 @@ class RAIIMinizArchive {
       const std::string& dest_filename) {
     // Can't normalize_path_separator zip_filename, as it is zip index.
     std::string path_dest_filename = normalize_path_separator(dest_filename);
+    recursive_make_parent_dir(path_dest_filename);
     if (!mz_zip_reader_extract_file_to_file(
             &_zip_archive,
             zip_filename.c_str(),


### PR DESCRIPTION
This PR optimize `extract_file` functions:
1. `normalize_path_separator` the dest path for Windows.
2. Add verbose error message:
a. On Linux, add mz_zip error string.
b. On Windows, add mz_zip error string and Windows error code.

For the UT `test_package_user_managed_weight`:
<img width="1910" height="442" alt="image" src="https://github.com/user-attachments/assets/6a63eda1-70ce-40fb-9681-adc955463884" />

It still have issue with error code `32`, checked https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499- and find the verbose is `ERROR_SHARING_VIOLATION`.

It is a little complex to debug, I will continue to working on it in further PR.


cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 