### PR TITLE
[inductor] template registry

### DIFF
--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -45,6 +45,7 @@ from .. import config, metrics
 from ..dtype_propagation import DtypePropagationOpsHandler
 from ..ops_handler import BasicMathOpsMixin, DefaultHandler
 from ..shape_propagation import ShapePropagationOpsHandler
+from ..template_heuristics.registry import register_template
 from ..utils import (
     boolean_ops,
     DeferredLineBase,
@@ -2411,6 +2412,8 @@ class KernelTemplate:
     def __init__(self, name: str, hash: Optional[str] = None) -> None:
         self.name = name
         self._hash = hash
+        # Register this template instance in the global registry
+        register_template(self)
 
     @property
     def uid(self) -> str:

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -76,6 +76,7 @@ from .runtime.benchmarking import benchmarker
 from .runtime.hints import DeviceProperties
 from .runtime.triton_compat import HAS_WARP_SPEC
 from .runtime.triton_heuristics import FixedGrid
+from .template_heuristics.registry import register_template
 from .utils import (
     ceildiv,
     do_bench_using_profiling,
@@ -2104,6 +2105,9 @@ class ExternKernelChoice:
         # There is no src hash for ExternKernelChoice in the traditional sense
         # so we indicate this by returning None
         self.src_hash = None
+        # Register this template instance in the global registry
+
+        register_template(self)
 
     def to_callable(self):
         return getattr(extern_kernels, self.name)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #163727
* __->__ #163726

# why

find templates by uid and enable information passing about which
templates is used

# what

- expand registry for heuristics to also track templates
- register all templates on creation
- register extern kernels (pseudo templates) on creation

- this also now enforces that uid is unique

# testing

existing tests

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @jataylo @chenyang78