### PR TITLE
[DTensor] Shortcut redistribution when num_shards == 1

### DIFF
--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -601,7 +601,8 @@ class RedistributeTest(DTensorTestBase):
         self.assertEqual(new_tensor.stride(), new_meta_tensor.stride())
 
     @with_comms
-    def test_one_shard_mesh(self):
+    def test_one_chunk_mesh(self):
+        # mesh size is 1 on second dim
         mesh = init_device_mesh(self.device_type, (4, 1))
 
         srcs = [Shard(1), Replicate(), Partial()]
@@ -613,6 +614,8 @@ class RedistributeTest(DTensorTestBase):
 
             with DebugMode() as debug_mode:
                 out = dt.redistribute(mesh, [Shard(0), dst])
+            
+            print(debug_mode.debug_string())
 
             self.assertTrue("redistribute_input" not in debug_mode.debug_string())
             self.assertEqual(out.placements, [Shard(0), dst])

--- a/torch/distributed/tensor/_redistribute.py
+++ b/torch/distributed/tensor/_redistribute.py
@@ -188,11 +188,11 @@ def redistribute_local_tensor(
         transform_infos = _gen_transform_infos_non_cached(current_spec, target_spec)
     else:
         transform_infos = _gen_transform_infos(current_spec, target_spec)
-    
+
     debug_mode = get_active_debug_mode()
     redistribute_context = (
         debug_mode.record_redistribute_calls(  # type: ignore[union-attr]
-            local_tensor, current_spec, target_specExpand commentComment on line R195Code has comments. Press enter to view.
+            local_tensor, current_spec, target_spec
         )
         if debug_mode is not None
         else contextlib.nullcontext()

--- a/torch/distributed/tensor/_redistribute.py
+++ b/torch/distributed/tensor/_redistribute.py
@@ -209,7 +209,7 @@ def redistribute_local_tensor(
                 new_local_tensor = local_tensor
                 continue
 
-            if num_shards == 1:
+            if num_chunks == 1:
                 # short cut, if there's only one shard, we don't need to do any collective
                 # comm, just use the original local tensor
                 new_local_tensor = local_tensor

--- a/torch/distributed/tensor/_redistribute.py
+++ b/torch/distributed/tensor/_redistribute.py
@@ -188,22 +188,32 @@ def redistribute_local_tensor(
         transform_infos = _gen_transform_infos_non_cached(current_spec, target_spec)
     else:
         transform_infos = _gen_transform_infos(current_spec, target_spec)
+    
+    debug_mode = get_active_debug_mode()
+    redistribute_context = (
+        debug_mode.record_redistribute_calls(  # type: ignore[union-attr]
+            local_tensor, current_spec, target_specExpand commentComment on line R195Code has comments. Press enter to view.
+        )
+        if debug_mode is not None
+        else contextlib.nullcontext()
+    )
 
-    for transform_info in transform_infos:
-        i = transform_info.mesh_dim
-        current, target = transform_info.src_dst_placements
-        num_shards = device_mesh.size(mesh_dim=i)
+    with redistribute_context:
+        for transform_info in transform_infos:
+            i = transform_info.mesh_dim
+            current, target = transform_info.src_dst_placements
+            num_shards = device_mesh.size(mesh_dim=i)
 
             if current == target:
                 # short cut, just use the original local tensor
                 new_local_tensor = local_tensor
                 continue
 
-        if num_shards == 1:
-            # short cut, if there's only one shard, we don't need to do any collective
-            # comm, just use the original local tensor
-            new_local_tensor = local_tensor
-            continue
+            if num_shards == 1:
+                # short cut, if there's only one shard, we don't need to do any collective
+                # comm, just use the original local tensor
+                new_local_tensor = local_tensor
+                continue
 
             logger.debug(
                 "redistribute from %s to %s on mesh dim %s", current, target, i

--- a/torch/distributed/tensor/_redistribute.py
+++ b/torch/distributed/tensor/_redistribute.py
@@ -202,10 +202,16 @@ def redistribute_local_tensor(
         for transform_info in transform_infos:
             i = transform_info.mesh_dim
             current, target = transform_info.src_dst_placements
-            device_mesh.size(mesh_dim=i)
+            num_shards = device_mesh.size(mesh_dim=i)
 
             if current == target:
                 # short cut, just use the original local tensor
+                new_local_tensor = local_tensor
+                continue
+
+            if num_shards == 1:
+                # short cut, if there's only one shard, we don't need to do any collective
+                # comm, just use the original local tensor
                 new_local_tensor = local_tensor
                 continue
 

--- a/torch/distributed/tensor/_redistribute.py
+++ b/torch/distributed/tensor/_redistribute.py
@@ -202,7 +202,7 @@ def redistribute_local_tensor(
         for transform_info in transform_infos:
             i = transform_info.mesh_dim
             current, target = transform_info.src_dst_placements
-            num_shards = device_mesh.size(mesh_dim=i)
+            num_chunks = device_mesh.size(mesh_dim=i)
 
             if current == target:
                 # short cut, just use the original local tensor


### PR DESCRIPTION
Redistribution doesn't need collectives when num_shards == 1 on a mesh dimension. 
Only placement update is needed, local_tensor remains unchanged. 

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci