### PR TITLE
[CD] Add statically linked windows libraries to exclude list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1706,13 +1706,16 @@ def main() -> None:
     }
     # windows libraries *.lib are excluded
     # these are statically linked
-    exclude_package_data = {
+    exclude_windows_libs = [
         "lib/dnnl.lib",
         "lib/kineto.lib",
         "lib/libprotobuf-lite.lib",
         "lib/libprotobuf.lib",
         "lib/libprotoc.lib",
-    }
+    ]
+    exclude_package_data = [
+        "torch": exclude_windows_libs,
+    ]
 
     if not BUILD_LIBTORCH_WHL:
         package_data["torchgen"] = torchgen_package_data

--- a/setup.py
+++ b/setup.py
@@ -1704,7 +1704,7 @@ def main() -> None:
     package_data = {
         "torch": torch_package_data,
     }
-    # windows libraries *.lib are excluded
+    # some win libraries are excluded
     # these are statically linked
     exclude_windows_libs = [
         "lib/dnnl.lib",

--- a/setup.py
+++ b/setup.py
@@ -1704,7 +1704,15 @@ def main() -> None:
     package_data = {
         "torch": torch_package_data,
     }
-    exclude_package_data = {}
+    # windows libraries *.lib are excluded
+    # these are statically linked
+    exclude_package_data = {
+        "lib/dnnl.lib",
+        "lib/kineto.lib",
+        "lib/libprotobuf-lite.lib",
+        "lib/libprotobuf.lib",
+        "lib/libprotoc.lib",
+    }
 
     if not BUILD_LIBTORCH_WHL:
         package_data["torchgen"] = torchgen_package_data

--- a/setup.py
+++ b/setup.py
@@ -1713,9 +1713,9 @@ def main() -> None:
         "lib/libprotobuf.lib",
         "lib/libprotoc.lib",
     ]
-    exclude_package_data = [
+    exclude_package_data = {
         "torch": exclude_windows_libs,
-    ]
+    }
 
     if not BUILD_LIBTORCH_WHL:
         package_data["torchgen"] = torchgen_package_data


### PR DESCRIPTION
Fixes: https://github.com/pytorch/pytorch/issues/159514

Seeing following in the Wheel build logs:
```
Linking CXX static library lib\kineto.lib
Linking CXX static library lib\dnnl.lib
....
```

These files are around 800MB uncompressed and 109MB compressed, hence provide ~50% size reduction for Windows CPU builds.

Test Plan: Build Pytorch Windows binary. Build vision, audio and torchcodec with this binary. Smoke test.