### PR TITLE
Avoid fast path mask left-align check in compiled TransformerEncoder

### DIFF
--- a/test/nn/test_multihead_attention.py
+++ b/test/nn/test_multihead_attention.py
@@ -940,6 +940,26 @@ class TestMultiheadAttentionNNDeviceType(NNTestCase):
         mha(query, query, query)
 
     @dtypes(torch.double)
+    def test_fast_path_check_with_mask_does_not_break_in_compile(self, device, dtype):
+        # Test TransformerEncoder fast path determination with src_key_padding_mask set.
+        # Specifically, ensure the mask left-align check doesn't fail in torch.compile.
+        # See https://github.com/pytorch/pytorch/issues/163640
+        layer = nn.TransformerEncoderLayer(
+            d_model=512,
+            nhead=8,
+            batch_first=True,
+            dropout=0.1,
+            device=device,
+            dtype=dtype,
+        )
+        encoder = nn.TransformerEncoder(layer, num_layers=2).eval()
+        encoder = torch.compile(encoder, fullgraph=True)
+        x = torch.randn(1, 41, 512, dtype=dtype, device=device)
+        pad_mask = torch.rand(1, 41, device=device) > 0.5
+        pad_mask[..., 0] = True
+        encoder(x, mask=None, src_key_padding_mask=pad_mask)
+
+    @dtypes(torch.double)
     @torch.no_grad()
     def test_multihead_attn_in_proj_bias_none(self, device, dtype):
         mha = torch.nn.MultiheadAttention(2, 2, bias=False, dtype=dtype, device=device)

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -443,6 +443,7 @@ class TransformerEncoder(Module):
         str_first_layer = "self.layers[0]"
         batch_first = first_layer.self_attn.batch_first
         is_fastpath_enabled = torch.backends.mha.get_fastpath_enabled()
+        do_mask_check = getattr(self, "mask_check", True)
 
         if not is_fastpath_enabled:
             why_not_sparsity_fast_path = (
@@ -464,15 +465,11 @@ class TransformerEncoder(Module):
             why_not_sparsity_fast_path = "src_key_padding_mask was None"
         # This check avoids a call to torch._nested_tensor_from_mask_left_aligned() that
         # breaks in torch.compile.
-        elif (
-            (not hasattr(self, "mask_check")) or self.mask_check
-        ) and torch.compiler.is_compiling():
+        elif do_mask_check and torch.compiler.is_compiling():
             why_not_sparsity_fast_path = (
                 "mask_check enabled with torch.compile or torch.export"
             )
-        elif (
-            (not hasattr(self, "mask_check")) or self.mask_check
-        ) and not torch._nested_tensor_from_mask_left_aligned(
+        elif do_mask_check and not torch._nested_tensor_from_mask_left_aligned(
             src, src_key_padding_mask.logical_not()
         ):
             why_not_sparsity_fast_path = "mask_check enabled, and src and src_key_padding_mask was not left aligned"

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -462,6 +462,14 @@ class TransformerEncoder(Module):
             )
         elif src_key_padding_mask is None:
             why_not_sparsity_fast_path = "src_key_padding_mask was None"
+        # This check avoids a call to torch._nested_tensor_from_mask_left_aligned() that
+        # breaks in torch.compile.
+        elif (
+            (not hasattr(self, "mask_check")) or self.mask_check
+        ) and torch.compiler.is_compiling():
+            why_not_sparsity_fast_path = (
+                "mask_check enabled with torch.compile or torch.export"
+            )
         elif (
             (not hasattr(self, "mask_check")) or self.mask_check
         ) and not torch._nested_tensor_from_mask_left_aligned(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #163773

Fixes #163640

This PR avoids a mask left align check in the case that we're operating under torch.compile / torch.export. Originally, I planned to make a more invasive change to auto-disable the fast path entirely underneath torch.compile / torch.export, but I realized during testing that the fast path wasn't actually causing compile issues outside of the narrow issue identified here.