### PR TITLE
[CI] Install libuv for Win testing

### DIFF
--- a/.github/actions/setup-win/action.yml
+++ b/.github/actions/setup-win/action.yml
@@ -59,7 +59,7 @@ runs:
         set -x
 
         # Create new py_tmp env with python-version
-        ${CONDA} create -y -n py_tmp python=${PYTHON_VERSION} intel-openmp
+        ${CONDA} create -y -n py_tmp python=${PYTHON_VERSION} intel-openmp libuv
 
         PYTHON3=$(${CONDA_RUN} -n py_tmp which python3)
         EXIT_CODE=$?


### PR DESCRIPTION
Current working theory why https://hud.pytorch.org/pytorch/pytorch/commit/f0078941cf4e9cfa1a464d0d12d999926fdd8cc5 caused a regression, are because Windows CI no longer could be build with distributed, as it could not find libuv