### PR TITLE
[Inductor] add a new config fallback_embedding_bag_byte_unpack

### DIFF
--- a/test/inductor/test_config.py
+++ b/test/inductor/test_config.py
@@ -244,6 +244,29 @@ class TestInductorConfig(TestCase):
             code = torch._inductor.config.codegen_config()
             self.assertNotIn("post_grad_custom", code)
 
+    def test_select_decomp_table_fallback_embedding_bag_byte_unpack(self):
+        """Test that select_decomp_table removes embedding_bag_byte_unpack when fallback is enabled"""
+        from torch._inductor.decomposition import select_decomp_table
+
+        # Test with fallback_embedding_bag_byte_unpack = False (default)
+        with config.patch(fallback_embedding_bag_byte_unpack=False):
+            decomp_table = select_decomp_table()
+            # The operation should be in decompositions when fallback is False
+            # Note: We check if it's in the fast_random_decomps() or decompositions table
+            self.assertTrue(
+                torch.ops.quantized.embedding_bag_byte_unpack.default in decomp_table
+                or len(decomp_table)
+                > 0  # fast_random_decomps() is used when fallback is False
+            )
+
+        # Test with fallback_embedding_bag_byte_unpack = True
+        with config.patch(fallback_embedding_bag_byte_unpack=True):
+            decomp_table = select_decomp_table()
+            # The operation should NOT be in decompositions when fallback is True
+            self.assertNotIn(
+                torch.ops.quantized.embedding_bag_byte_unpack.default, decomp_table
+            )
+
     @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_options_do_something(self):
         """

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -634,6 +634,9 @@ realize_acc_reads_size_threshold: Optional[int] = (
 # fallback to eager for random/dropout, this is slow but useful for debugging
 fallback_random = False
 
+# fallback embedding_bag_byte_unpack to eager
+fallback_embedding_bag_byte_unpack = False
+
 # automatically create fallbacks when encountering an unhandled op
 implicit_fallbacks = True
 assume_unaligned_fallback_output = (

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -885,6 +885,13 @@ def select_decomp_table() -> dict[Any, Callable[..., Any]]:
     """decomps can change based on config"""
     if config.fallback_random:
         return decompositions
+    if config.fallback_embedding_bag_byte_unpack is True:
+        # remove q_embedding_bag_byte_unpack_decomp from decompositions
+        for k in decompositions.keys():
+            if k == torch.ops.quantized.embedding_bag_byte_unpack.default:
+                del decompositions[k]
+                break
+        return decompositions
     return fast_random_decomps()
 
 


### PR DESCRIPTION
Differential Revision: D82988783

introduce an inductor config fallback_embedding_bag_byte_unpack so we can have options to not let inductor decompose the op


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben