### PR TITLE
Expose torch.nn.utils.parametrize

### DIFF
--- a/torch/nn/utils/__init__.py
+++ b/torch/nn/utils/__init__.py
@@ -1,4 +1,4 @@
-from . import parametrizations, rnn, stateless, parametrize
+from . import parametrizations, parametrize, rnn, stateless
 from .clip_grad import (
     _clip_grads_with_norm_ as clip_grads_with_norm_,
     _get_total_norm as get_total_norm,

--- a/torch/nn/utils/__init__.py
+++ b/torch/nn/utils/__init__.py
@@ -1,4 +1,4 @@
-from . import parametrizations, rnn, stateless
+from . import parametrizations, rnn, stateless, parametrize
 from .clip_grad import (
     _clip_grads_with_norm_ as clip_grads_with_norm_,
     _get_total_norm as get_total_norm,
@@ -36,6 +36,7 @@ __all__ = [
     "get_total_norm",
     "parameters_to_vector",
     "parametrizations",
+    "parametrize",
     "remove_spectral_norm",
     "remove_weight_norm",
     "rnn",


### PR DESCRIPTION
`torch.nn.utils.parametrize` is not imported from `torch/nn/utils/__init__.py`, thus is not exposed and make it hard for code editors to statically analyze the code and provide auto-completion based on the function signature.

<img width="615" height="292" alt="Screenshot 2025-09-25 at 12 01 52 PM" src="https://github.com/user-attachments/assets/a276f6f0-87f3-4732-943d-2a92ea871974" />


after the fix:

<img width="964" height="393" alt="Screenshot 2025-09-25 at 12 02 16 PM" src="https://github.com/user-attachments/assets/ca47f09e-dc4e-4420-a2d2-11669e07471a" />
