### PR TITLE
Improve repeat op to a single copy

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1880,43 +1880,30 @@ Tensor repeat(const Tensor& self, IntArrayRef repeats) {
 
   Tensor xtensor = self.expand(padded_size);
 
-  Tensor urtensor;
-  if (self.is_quantized()) {
-    urtensor = at::empty_quantized(target_size, self);
-  } else {
-    urtensor = at::empty(target_size, self.options());
-  }
-
-  // return an empty tensor if one of the repeat dimensions is zero
   if (zero_tensor) {
-    return urtensor;
+    return self.is_quantized() ? at::empty_quantized(target_size, self)
+                               : at::empty(target_size, self.options());
   }
 
+  Tensor view = xtensor;
+  // Create view of shape [1, s0, 1, s1, ...]
+  // where si is self.size(i).
   for (const auto i : c10::irange(xtensor.dim())) {
-    // can't unfold with step 0, so make sure step is at least 1
-    // (it doesn't matter what it is in that case, because the size is 0).
-    auto size_i = xtensor.sizes()[i];
-    urtensor = urtensor.unfold(i, size_i, std::max<int64_t>(size_i, 1));
+    view = view.unsqueeze(2 * i);
   }
 
-  urtensor.copy_(xtensor.expand_as(urtensor));
+  // Create view of shape [r0, s0, r1, s1, ...]
+  // where ri is repeat[i].
+  auto expand_shape = std::vector<int64_t>();
+  expand_shape.reserve(xtensor.dim() * 2);
+  for (const auto i : c10::irange(xtensor.dim())) {
+    expand_shape.push_back(repeats[i]);
+    expand_shape.push_back(xtensor.size(i));
+  }
+  auto expanded_view = view.expand(expand_shape);
 
-  // Combine the dimensions to produce the target_size.
-  // xtensor dims: [a0, ..., ad-1]
-  // urtensor dims: [a0, ..., ad-1, b0, ..., bd-1]
-  // b dims are produced by unfold.
-  // Transform urtensor to [a0 * b0, ..., ad-1 * bd-1]
-  const int64_t n_dims = xtensor.dim();
-  auto range_a = at::arange(xtensor.dim(), at::TensorOptions(at::kLong));
-  auto range_b = range_a + n_dims;
-  auto stacked = stack({std::move(range_a), std::move(range_b)}, 1).flatten();
-  auto permutation = IntArrayRef(stacked.data_ptr<int64_t>(), n_dims * 2);
-  // Permute from [a0, ..., ad-1, b0, ..., bd-1] to [a0, b0, ..., ad-1, bd-1]
-  urtensor = urtensor.permute(permutation);
-  // Reshape from [a0, b0, ..., ad-1, bd-1] to [a0 * b0, ..., ad-1 * bd-1]
-  urtensor = urtensor.reshape(target_size);
-
-  return urtensor;
+  // Reshape to shape [s0 * r0, s1 * r1, ...].
+  return expanded_view.reshape(target_size);
 }
 
 Tensor tile_symint(const Tensor& self, SymIntArrayRef reps) {

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1898,9 +1898,14 @@ Tensor repeat(const Tensor& self, IntArrayRef repeats) {
   // expanded_view is non-contiguous because .expand set stride to 0.
   auto expanded_view = view.expand(expand_shape);
 
-  // copy to contiguous tensor and reshape to [s0 * r0, s1 * r1, ...].
-  auto contiguous_copy = at::empty_like(expanded_view);
+  // copy to contiguous tensor.
+  auto contiguous_copy = at::empty(
+      expanded_view.sizes(),
+      expanded_view.options(),
+      at::MemoryFormat::Contiguous);
   contiguous_copy.copy_(expanded_view);
+
+  // Reshape to [s0 * r0, s1 * r1, ...].
   // No extra copy of data during reshape for a contiguous tensor.
   return contiguous_copy.reshape(target_size);
 }

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1898,9 +1898,11 @@ Tensor repeat(const Tensor& self, IntArrayRef repeats) {
   // expanded_view is non-contiguous because .expand set stride to 0.
   auto expanded_view = view.expand(expand_shape);
 
-  // Reshape to [s0 * r0, s1 * r1, ...].
-  // .contiguous() triggers a copy of data.
-  return expanded_view.contiguous().view(target_size);
+  // copy to result tensor with shape [s0 * r0, s1 * r1, ...].
+  auto result = at::empty(target_size, self.options());
+  result.copy_(expanded_view);
+
+  return result;
 }
 
 Tensor tile_symint(const Tensor& self, SymIntArrayRef reps) {

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1898,11 +1898,11 @@ Tensor repeat(const Tensor& self, IntArrayRef repeats) {
   // expanded_view is non-contiguous because .expand set stride to 0.
   auto expanded_view = view.expand(expand_shape);
 
-  // copy to result tensor with shape [s0 * r0, s1 * r1, ...].
-  auto result = at::empty(target_size, self.options());
-  result.copy_(expanded_view);
-
-  return result;
+  // copy to contiguous tensor and reshape to [s0 * r0, s1 * r1, ...].
+  auto contiguous_copy = at::empty_like(expanded_view);
+  contiguous_copy.copy_(expanded_view);
+  // No extra copy of data during reshape for a contiguous tensor.
+  return contiguous_copy.reshape(target_size);
 }
 
 Tensor tile_symint(const Tensor& self, SymIntArrayRef reps) {

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1907,7 +1907,7 @@ Tensor repeat(const Tensor& self, IntArrayRef repeats) {
 
   // Reshape to [s0 * r0, s1 * r1, ...].
   // No extra copy of data during reshape for a contiguous tensor.
-  return contiguous_copy.reshape(target_size);
+  return contiguous_copy.view(target_size);
 }
 
 Tensor tile_symint(const Tensor& self, SymIntArrayRef reps) {


### PR DESCRIPTION
In #163455 , the `reshape` was not a pure view op.

The `permute` before it created an non-contiguous tensor, which would trigger a data copy during the reshape.

This PR improved the implementation by remove the `urtensor` intermediate tensor completely.
By simply expanding the `xtensor` would achieve the `repeat` effect.

Before this PR, there were two data copies (in `urtensor.copy_` and `urtensor.reshape`).
Now, there is only one data copy in the `.copy_()`.
Reshape would not copy data because it is on a contiguous tensor.

One more note is that we do want at one copy because we want to duplicate the elements for the repeats.
User can inplace modify single elements without afffecting others.