### PR TITLE
[DTensor] fix uneven _StridedShard

### DIFF
--- a/test/distributed/tensor/test_random_ops.py
+++ b/test/distributed/tensor/test_random_ops.py
@@ -31,6 +31,7 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
     skip_unless_torch_gpu,
     with_comms,
 )
+from torch.utils._typing_utils import not_none
 
 
 def get_generator_seed_for_device_type(device_type: str) -> int:
@@ -549,7 +550,9 @@ class DistTensorRandomOpTest(DTensorTestBase):
             # local_shard_list_on_dim[i] has the list of all shards on that dim
             # as a tuple (local_shard_offset, local_shard_size)
             dtensor_shape = dtensor.shape
-            local_shard_list_on_dim = [[(0, l)] for l in dtensor_shape]
+            local_shard_list_on_dim: list[list[tuple[int, int]]] = [
+                [(0, l)] for l in dtensor_shape
+            ]
             for idx, placement in enumerate(placements):
                 if isinstance(placement, Shard):
                     mesh_dim_size = device_mesh.size(idx)
@@ -565,7 +568,7 @@ class DistTensorRandomOpTest(DTensorTestBase):
                             shard_idx_on_dim,
                         )
                         local_shard_list_on_dim[shard_dim].append(
-                            (shard_offset, shard_size)
+                            (not_none(shard_offset), shard_size)
                         )
 
             local_shard_comb = itertools.product(*local_shard_list_on_dim)

--- a/test/distributed/tensor/test_utils.py
+++ b/test/distributed/tensor/test_utils.py
@@ -700,7 +700,7 @@ class TestStridedSharding(DTensorTestBase):
         )
 
         for size in (2, 3, 5, 11):
-            tensor = torch.arange(size).view(1, -1).cuda()
+            tensor = torch.arange(size, device=self.device_type).view(1, -1)
             dtensor = distribute_tensor(
                 tensor,
                 device_mesh=mesh,

--- a/test/distributed/tensor/test_utils.py
+++ b/test/distributed/tensor/test_utils.py
@@ -691,6 +691,25 @@ class TestStridedSharding(DTensorTestBase):
         )
         self.assertEqual(full_tensor, x)
 
+    @with_comms
+    def test_2d_mesh_uneven_strided_shard(self):
+        mesh = init_device_mesh(
+            self.device_type,
+            (self.world_size // 2, 2),
+            mesh_dim_names=("fsdp", "tp"),
+        )
+
+        for size in (2, 3, 5, 11):
+            tensor = torch.arange(size).view(1, -1).cuda()
+            dtensor = distribute_tensor(
+                tensor,
+                device_mesh=mesh,
+                placements=(Replicate(), Replicate()),
+            ).redistribute(
+                mesh, placements=(_StridedShard(dim=1, split_factor=2), Shard(1))
+            )
+            self.assertEqual(dtensor.full_tensor(), tensor)
+
 
 class Test2DStridedLocalShard(DTensorTestBase):
     @property

--- a/torch/distributed/tensor/_ops/_embedding_ops.py
+++ b/torch/distributed/tensor/_ops/_embedding_ops.py
@@ -92,7 +92,7 @@ class _MaskPartial(Partial):
         assert self.offset_shape is not None, (
             "offset_shape needs to be set for _MaskPartial"
         )
-        local_shard_size, local_offset_on_dim = Shard._local_shard_size_and_offset(
+        local_shard_size, local_offset_on_dim = Shard.local_shard_size_and_offset(
             self.offset_shape[self.offset_dim],
             num_chunks,
             mesh.get_local_rank(mesh_dim),

--- a/torch/distributed/tensor/_utils.py
+++ b/torch/distributed/tensor/_utils.py
@@ -15,6 +15,7 @@ from torch.distributed.tensor.placement_types import (
     Replicate,
     Shard,
 )
+from torch.utils._typing_utils import not_none
 
 
 def _explicit_order_placements(
@@ -182,7 +183,7 @@ def _compute_local_shape_and_global_offset(
                 # As we successively shard the same dimension, we keep
                 # advancing our pointer beyond our original offset until we
                 # get to the final chunk start.
-                global_offset[shard_dim] + shard_offset,
+                global_offset[shard_dim] + not_none(shard_offset),
             )
 
     # NOTE: the offset compute relies on the local shard index and it has no

--- a/torch/distributed/tensor/placement_types.py
+++ b/torch/distributed/tensor/placement_types.py
@@ -111,7 +111,7 @@ class Shard(Placement):
         return shard_list, pad_sizes
 
     @staticmethod
-    def _local_shard_size_and_offset(
+    def local_shard_size_and_offset(
         curr_local_size: int,
         num_chunks: int,
         rank: int,
@@ -144,6 +144,14 @@ class Shard(Placement):
                 - shard_starting_idx
             )
             return local_shard_size, shard_starting_idx
+
+    def _local_shard_size_and_offset(
+        self,
+        curr_local_size: int,
+        num_chunks: int,
+        rank: int,
+    ) -> tuple[int, Optional[int]]:
+        return Shard.local_shard_size_and_offset(curr_local_size, num_chunks, rank)
 
     def _shard_tensor(
         self,
@@ -460,33 +468,36 @@ class _StridedShard(Shard):
             f"Sharding dim {self.dim} greater than tensor ndim {tensor.ndim}"
         )
 
-        # num_chunks represents the size of this StridedShard mesh dim, while self.split_factor
-        # represents the aggregate num chunks for other shardings applied logically earlier than this strided shard.
-        # (e.g. in FSDP+TP case, num_chunks is size(dp dim), split_factor is size(tp dim))
-        total_split = num_chunks * self.split_factor
-
-        tensor_list = list(torch.chunk(tensor, total_split, dim=self.dim))
-        tensor_list = fill_empty_tensor_to_shards(
-            tensor_list, self.dim, total_split - len(tensor_list)
+        # Essentially _StridedShard express the right-to-left sharding in the
+        # reversed order. Here we perform first_split as the virtual "right" sharding,
+        # and then second_split as the virtual "left" sharding, and finally assemble
+        # results in the transposed left-first order.
+        first_split, _ = super()._split_tensor(
+            tensor, self.split_factor, with_padding=False, contiguous=False
         )
-
-        # compute the chunk size inline with ``torch.chunk`` to calculate padding
-        full_chunk_size = (tensor.size(self.dim) + total_split - 1) // total_split
+        second_split = [
+            super(_StridedShard, self)._split_tensor(
+                s, num_chunks=num_chunks, with_padding=False, contiguous=False
+            )[0]
+            for s in first_split
+        ]
 
         shard_list: list[torch.Tensor] = []
-        pad_sizes: list[int] = []
         for i in range(num_chunks):
             shard = torch.cat(
-                [tensor_list[i + j * num_chunks] for j in range(self.split_factor)],
+                [second_split[j][i] for j in range(self.split_factor)],
                 dim=self.dim,
             )
-            if with_padding:
-                pad_size = full_chunk_size * self.split_factor - shard.size(self.dim)
-                shard = pad_tensor(shard, self.dim, pad_size)
-                pad_sizes.append(pad_size)
             if contiguous:
                 shard = shard.contiguous()
             shard_list.append(shard)
+
+        # The amount of padding is determined by the local chunk with the largest size.
+        pad_sizes: list[int] = []
+        max_chunk_size = max([shard.size(self.dim) for shard in shard_list])
+        if with_padding:
+            pad_sizes = [max_chunk_size - shard.size(self.dim) for shard in shard_list]
+
         return shard_list, pad_sizes
 
     def _to_replicate_tensor(
@@ -497,106 +508,85 @@ class _StridedShard(Shard):
         current_logical_shape: list[int],
     ) -> torch.Tensor:
         """
-        Given a tensor with strided sharding (e.g. [StridedShard(d), Shard(d)]),
-        this function is called during the process of converting to [Replicate(), Replicate()],
-        and `local_tensor` represents the portion of the tensor on this rank after the intermediate step of
-        converting to [StridedShard(d), Replicate()] in right-to-left unsharding order.
-
-        note: this conversion logic is pretty specialized on this 2D case.  It could be generalized further. This
-        is a common enough case to be worth fixing (since it occurs when applying TP and then FSDP to a model).
-
-        note: this does not support 'reduce_scatter' for StridedShard.
-
-        Example
-        -------
-        mesh = (DP=2, TP=2)
-        # single-gpu "weight" of size 5, will be 'uneven' for sharding
-        original = torch.arange(5)
-
-        tp sharded tensor
-        -----------------
-        `tp = distribute_tensor(x, world_mesh['tp'], [Shard(0)])`
-
-        local_tensors:
-        rank0: [0,1,2]    rank1: [3,4]
-        rank1: [0,1,2]    rank3: [3,4]
-
-        fsdp+tp sharded tensor
-        ----------------------
-        `dp_tp = ...` (the process of creating a strided-shard tensor is skipped over as it is complicated
-        dp_tp has placement (_StridedShard(0, split_factor=2), Shard(0))
-        local_tensors:
-        rank0: [0,1]  rank1: [3]
-        rank1: [2]    rank3: [4]
-
-        Now, say someone wants to reconstruct dp_tp's full tensor. This will invoke 'redistribute' to replicate.
-        redistribute will first replicate the "Shard(0)" placement on the rightmost mesh dim, then replicate the
-        StridedShard placement second, which is implemented by this function.
-        So our starting point (`local_tensor` arg) is the result of replicating the Shard(0) placement across the
-        TP dim, which looks like this.
-
-        Note the discrepancy with the 'tp sharded tensor' line above!  We'll fix it by locally shuffling data.
-
-        local_tensors:
-        rank0: [0,1,3]  rank1: [0,1,3]
-        rank2: [2,4]    rank3: [2,4]
-
-        Step 1: replicate over the DP dimension.  Afterwards, each rank can locally sort the values.
-          note: we need padding to do this allgather, and we'll need to keep track of the padding amount for later
-                local_tensors:
-        rank0: [0,1,3,2,4]    rank1: [0,1,3,2,4]
-        rank2: [0,1,3,2,4]    rank3: [0,1,3,2,4]
-
-        Step 2: chunk and shuffle values around to account for the wrong order of operations above
-        and get the original tensor content back
-
-        01324#       <- our allgather includes padding, if padding was applied in step 1
-        01324        <- Remove the padding
-        013, 24      <- chunk once, 'undoing' the DP allgather
-        01, 3, 2, 4  <- chunk each chunk, 'undoing' the initial (wrong) TP allgather performed by Shard(0)->Replicate()
-        012, 34      <- interleave with stride=TP mesh dim size
-        01234        <- concatenate
-
-        Note: the current implementation of this function is incomplete, and supports only the common pattern of one
-        strided shard placement, which is used in the FSDP + TP case.  We could extend this implementation to handle
-        multiple strided shardings (e.g. [StridedShard, StridedShard, Shard]), by repeating the chunking step more times
-        and handling more complex shuffling in the last step.  On the other hand, we plan to replace 'StridedShard'
-        with using just Shard and specifying a sharding order, so it may be ok to leave this as-is for the time being.
+        replay the replicate-to-shard process to understand how to stitch shards back
         """
         num_chunks = mesh.size(mesh_dim=mesh_dim)
         logical_dim_size = current_logical_shape[self.dim]
-        full_chunk_size = (logical_dim_size + num_chunks - 1) // num_chunks
-        local_pad_size = full_chunk_size - local_tensor.size(self.dim)
 
-        local_tensor = pad_tensor(local_tensor, self.dim, local_pad_size)
+        # indices_tensor is 1D torch.arange(logical_dim_size) unsqueezed
+        # so that we can reuse self._split_tensor which splits on self.dim
+        shape = [1] * self.dim + [logical_dim_size]
+        indices_tensor = torch.arange(
+            logical_dim_size, device=local_tensor.device
+        ).view(shape)
 
-        if not local_tensor.is_contiguous():
-            local_tensor = local_tensor.contiguous()
+        sharded_indices, _ = self._split_tensor(
+            indices_tensor,
+            num_chunks,
+            with_padding=False,
+            contiguous=False,
+        )
+        # squeeze back to 1D indices tensor
+        sharded_indices = [shard.view(-1) for shard in sharded_indices]
 
-        result = funcol.all_gather_tensor(
-            local_tensor,
+        max_chunk_size = max([len(shard) for shard in sharded_indices])
+        local_pad_size = max_chunk_size - local_tensor.size(self.dim)
+        local_tensor_padded = pad_tensor(local_tensor, self.dim, local_pad_size)
+
+        if not local_tensor_padded.is_contiguous():
+            local_tensor_padded = local_tensor_padded.contiguous()
+
+        replicate_tensor_permuted_padded = funcol.all_gather_tensor(
+            local_tensor_padded,
             gather_dim=self.dim,
             group=(mesh, mesh_dim),
         )
-        if isinstance(result, funcol.AsyncCollectiveTensor):
-            result = result.wait()
+        if isinstance(replicate_tensor_permuted_padded, funcol.AsyncCollectiveTensor):
+            replicate_tensor_permuted_padded = replicate_tensor_permuted_padded.wait()
 
-        if result.shape[self.dim] > logical_dim_size:
-            result = unpad_tensor(
-                result, self.dim, result.shape[self.dim] - logical_dim_size
+        if replicate_tensor_permuted_padded.shape[self.dim] > logical_dim_size:
+            replicate_tensor_permuted = unpad_tensor(
+                replicate_tensor_permuted_padded,
+                self.dim,
+                replicate_tensor_permuted_padded.shape[self.dim] - logical_dim_size,
             )
+        else:
+            replicate_tensor_permuted = replicate_tensor_permuted_padded
 
-        # this reverses our 'all_gather' but gives every rank a copy
-        outer_shards = torch.chunk(result, num_chunks, dim=self.dim)
-        # this undoes the 'Shard(0)' -> Replicate() that happened over the wrong mesh dim in the first place
-        inner_shards: list[torch.Tensor] = []
-        for p in outer_shards:
-            inner_shards.extend(torch.chunk(p, self.split_factor, dim=self.dim))
-        # now we just have to correctly stride the shards
-        reordered_shards = []
-        for i in range(self.split_factor):
-            reordered_shards.extend(inner_shards[i :: self.split_factor])
-        return torch.cat(reordered_shards, dim=self.dim).contiguous()
+        permutation = torch.cat(sharded_indices)
+        inv_permutation = torch.argsort(permutation)
+        replicate_tensor = torch.index_select(
+            replicate_tensor_permuted, self.dim, inv_permutation
+        )
+
+        return replicate_tensor.contiguous()
+
+    def _local_shard_size_and_offset(
+        self,
+        curr_local_size: int,
+        num_chunks: int,
+        rank: int,
+    ) -> tuple[int, Optional[int]]:
+        # indices_tensor is 1D torch.arange(logical_dim_size) unsqueezed
+        # so that we can reuse self._split_tensor which splits on self.dim
+        shape = [1] * self.dim + [curr_local_size]
+        indices_tensor = torch.arange(
+            curr_local_size,
+        ).view(shape)
+
+        sharded_indices, _ = self._split_tensor(
+            indices_tensor,
+            num_chunks,
+            with_padding=False,
+            contiguous=False,
+        )
+        # squeeze back to 1D indices tensor
+        sharded_indices = [shard.view(-1) for shard in sharded_indices]
+
+        local_shard_size = len(sharded_indices[rank])
+
+        # offsets from _StridedShard is never used
+        return local_shard_size, None
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #163843

Previous uneven `_StridedShard` in https://github.com/pytorch/pytorch/pull/150490 seems failing cases like sharding `tensor = torch.arange(6)` with FSDP 2, TP 2.

This PR attempts to reinvent `_StridedShard`.

I didn't test nested `_StridedShard`, because there shouldn't be any use cases. I think it will become quite messy when it comes to **nested uneven** `_StridedShard`. We are probably going to deprecate it anyway after @zpcore 's work https://github.com/pytorch/pytorch/pull/160266 on ordered sharding, so IMO not worth it to make it too general.


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci