### PR TITLE
Add runtime_overhead PR Time Benchmark

### DIFF
--- a/benchmarks/dynamo/pr_time_benchmarks/README.md
+++ b/benchmarks/dynamo/pr_time_benchmarks/README.md
@@ -6,4 +6,4 @@
 4. (Optional) flip a flag that you know will change the benchmark and run again with b.txt `PYTHONPATH=./ python benchmarks/[YOUR_BENCHMARK].py a.txt`
 5. Compare `a.txt` and `b.txt` located within the `benchmarks/dynamo/pr_time_benchmarks` folder to make sure things look as you expect
 6. Check in your new benchmark file and submit a new PR
-7. In a few days, if your benchmark is stable, bug Laith Sakka to enable running your benchmark on all PRs. If you are a meta employee, you can find the dashboard here: internalfb.com/intern/unidash/dashboard/pt2_diff_time_metrics
+7. In a few days, if your benchmark is stable, bug Laith Sakka to enable running your benchmark on all PRs. If you are a meta employee, you can find the dashboard here: https://internalfb.com/intern/unidash/dashboard/pt2_diff_time_metrics

--- a/benchmarks/dynamo/pr_time_benchmarks/README.md
+++ b/benchmarks/dynamo/pr_time_benchmarks/README.md
@@ -6,4 +6,4 @@
 4. (Optional) flip a flag that you know will change the benchmark and run again with b.txt `PYTHONPATH=./ python benchmarks/[YOUR_BENCHMARK].py a.txt`
 5. Compare `a.txt` and `b.txt` located within the `benchmarks/dynamo/pr_time_benchmarks` folder to make sure things look as you expect
 6. Check in your new benchmark file and submit a new PR
-7. In a few days, if your benchmark is stable, bug Laith Sakka to enable running your benchmark on all PRs. If your a meta employee, you can find the dashboard here: internalfb.com/intern/unidash/dashboard/pt2_diff_time_metrics
+7. In a few days, if your benchmark is stable, bug Laith Sakka to enable running your benchmark on all PRs. If you are a meta employee, you can find the dashboard here: internalfb.com/intern/unidash/dashboard/pt2_diff_time_metrics

--- a/benchmarks/dynamo/pr_time_benchmarks/benchmarks/runtime_overhead.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmarks/runtime_overhead.py
@@ -1,14 +1,16 @@
 import sys
 
-from benchmark_base import BenchmarkBase
-
 import torch
+
+from benchmark_base import BenchmarkBase
 from torch.autograd.grad_mode import inference_mode
 
 
 class Benchmark(BenchmarkBase):
     def __init__(self, requires_grad, inference_mode, backward, dynamic):
-        assert not (inference_mode and backward), "inference_mode and backward cannot be both True"
+        assert not (
+            inference_mode and backward
+        ), "inference_mode and backward cannot be both True"
 
         self._requires_grad = requires_grad
         self._inference_mode = inference_mode
@@ -70,17 +72,34 @@ class Benchmark(BenchmarkBase):
         else:
             self._add1(self.a)
 
+
 def main():
     result_path = sys.argv[1]
     all = [
-        Benchmark(requires_grad=False, inference_mode=False, backward=False, dynamic=False),
-        Benchmark(requires_grad=False, inference_mode=True, backward=False, dynamic=False),
-        Benchmark(requires_grad=True, inference_mode=False, backward=False, dynamic=False),
-        Benchmark(requires_grad=True, inference_mode=False, backward=True, dynamic=False),
-        Benchmark(requires_grad=False, inference_mode=False, backward=False, dynamic=True),
-        Benchmark(requires_grad=False, inference_mode=True, backward=False, dynamic=True),
-        Benchmark(requires_grad=True, inference_mode=False, backward=False, dynamic=True),
-        Benchmark(requires_grad=True, inference_mode=False, backward=True, dynamic=True),
+        Benchmark(
+            requires_grad=False, inference_mode=False, backward=False, dynamic=False
+        ),
+        Benchmark(
+            requires_grad=False, inference_mode=True, backward=False, dynamic=False
+        ),
+        Benchmark(
+            requires_grad=True, inference_mode=False, backward=False, dynamic=False
+        ),
+        Benchmark(
+            requires_grad=True, inference_mode=False, backward=True, dynamic=False
+        ),
+        Benchmark(
+            requires_grad=False, inference_mode=False, backward=False, dynamic=True
+        ),
+        Benchmark(
+            requires_grad=False, inference_mode=True, backward=False, dynamic=True
+        ),
+        Benchmark(
+            requires_grad=True, inference_mode=False, backward=False, dynamic=True
+        ),
+        Benchmark(
+            requires_grad=True, inference_mode=False, backward=True, dynamic=True
+        ),
     ]
 
     for benchmark in all:

--- a/benchmarks/dynamo/pr_time_benchmarks/benchmarks/runtime_overhead.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmarks/runtime_overhead.py
@@ -1,0 +1,76 @@
+import sys
+
+from benchmark_base import BenchmarkBase
+
+import torch
+from torch._inductor.utils import fresh_inductor_cache
+from torch.autograd.grad_mode import inference_mode
+
+
+class Benchmark(BenchmarkBase):
+    def __init__(self, requires_grad, inference_mode):
+        self._requires_grad = requires_grad
+        self._inference_mode = inference_mode
+
+        super().__init__(
+            category="runtime_overhead",
+            backend="inductor",
+            device="cuda",
+            dynamic=False,
+        )
+
+    def name(self):
+        prefix = f"{self.category()}_{self.backend()}"
+        if self._requires_grad:
+            prefix += "_requires_grad"
+        if self._inference_mode:
+            prefix += "_inference_mode"
+        return prefix
+
+    def description(self):
+        return "runtime of a compiled add1 op small input"
+
+    def _prepare_once(self):
+        torch._dynamo.reset()
+        self.a = torch.ones(1, device=self.device(), requires_grad=self._requires_grad)
+        
+        @torch.compile(
+            backend=self.backend(),
+            fullgraph=True,
+            dynamic=self.is_dynamic(),
+        )
+        def add1(a):
+            return a + 1
+        
+        self._add1 = add1
+
+        # warmup
+        self._work()
+
+    def _prepare(self):
+        pass
+
+    def _work(self):
+        if self._inference_mode:
+            with inference_mode():
+                self._add1(self.a)
+        else:
+            self._add1(self.a)
+
+
+def main():
+    result_path = sys.argv[1]
+    all = [
+        Benchmark(False, False),
+        Benchmark(False, True),
+        Benchmark(True, False),
+    ]
+
+    for benchmark in all:
+        benchmark.enable_instruction_count().collect_all().append_results(
+            result_path
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/dynamo/pr_time_benchmarks/benchmarks/runtime_overhead.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmarks/runtime_overhead.py
@@ -71,9 +71,7 @@ def main():
     ]
 
     for benchmark in all:
-        benchmark.enable_instruction_count().collect_all().append_results(
-            result_path
-        )
+        benchmark.enable_instruction_count().collect_all().append_results(result_path)
 
 
 if __name__ == "__main__":

--- a/benchmarks/dynamo/pr_time_benchmarks/benchmarks/runtime_overhead.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmarks/runtime_overhead.py
@@ -42,7 +42,7 @@ class Benchmark(BenchmarkBase):
         )
         def add1(a):
             return a + 1
-        
+
         self._add1 = add1
 
         # warmup

--- a/benchmarks/dynamo/pr_time_benchmarks/benchmarks/runtime_overhead.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmarks/runtime_overhead.py
@@ -53,11 +53,12 @@ class Benchmark(BenchmarkBase):
         self._add1 = add1
 
         # warmup
-        if self._backward:
-            self.forward_val = self._add1(self.a).sum()
-            self.forward_val.backward()
-        else:
-            self._work()
+        for _ in range(10):
+            if self._backward:
+                self.forward_val = self._add1(self.a).sum()
+                self.forward_val.backward()
+            else:
+                self._work()
 
     def _prepare(self):
         if self._backward:

--- a/benchmarks/dynamo/pr_time_benchmarks/benchmarks/runtime_overhead.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmarks/runtime_overhead.py
@@ -3,12 +3,11 @@ import sys
 from benchmark_base import BenchmarkBase
 
 import torch
-from torch._inductor.utils import fresh_inductor_cache
 from torch.autograd.grad_mode import inference_mode
 
 
 class Benchmark(BenchmarkBase):
-    def __init__(self, requires_grad, inference_mode):
+    def __init__(self, requires_grad, inference_mode, dynamic):
         self._requires_grad = requires_grad
         self._inference_mode = inference_mode
 
@@ -16,7 +15,7 @@ class Benchmark(BenchmarkBase):
             category="runtime_overhead",
             backend="inductor",
             device="cuda",
-            dynamic=False,
+            dynamic=dynamic,
         )
 
     def name(self):
@@ -25,6 +24,8 @@ class Benchmark(BenchmarkBase):
             prefix += "_requires_grad"
         if self._inference_mode:
             prefix += "_inference_mode"
+        if self.is_dynamic():
+            prefix += "_dynamic"
         return prefix
 
     def description(self):
@@ -32,8 +33,8 @@ class Benchmark(BenchmarkBase):
 
     def _prepare_once(self):
         torch._dynamo.reset()
-        self.a = torch.ones(1, device=self.device(), requires_grad=self._requires_grad)
-        
+        self.a = torch.ones(2, device=self.device(), requires_grad=self._requires_grad)
+
         @torch.compile(
             backend=self.backend(),
             fullgraph=True,
@@ -61,9 +62,12 @@ class Benchmark(BenchmarkBase):
 def main():
     result_path = sys.argv[1]
     all = [
-        Benchmark(False, False),
-        Benchmark(False, True),
-        Benchmark(True, False),
+        Benchmark(False, False, False),
+        Benchmark(False, True, False),
+        Benchmark(True, False, False),
+        Benchmark(False, False, True),
+        Benchmark(False, True, True),
+        Benchmark(True, False, True),
     ]
 
     for benchmark in all:

--- a/benchmarks/dynamo/pr_time_benchmarks/benchmarks/runtime_overhead.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmarks/runtime_overhead.py
@@ -1,16 +1,16 @@
 import sys
 
-import torch
-
 from benchmark_base import BenchmarkBase
+
+import torch
 from torch.autograd.grad_mode import inference_mode
 
 
 class Benchmark(BenchmarkBase):
     def __init__(self, requires_grad, inference_mode, backward, dynamic):
-        assert not (
-            inference_mode and backward
-        ), "inference_mode and backward cannot be both True"
+        assert not (inference_mode and backward), (
+            "inference_mode and backward cannot be both True"
+        )
 
         self._requires_grad = requires_grad
         self._inference_mode = inference_mode


### PR DESCRIPTION
This adds a PR time benchmark that checks for runtime overhead on a very small graph. This will help track regressions in runtime overhead.

Example Results:
```
runtime_overhead_inductor,instruction_count,222645
runtime_overhead_inductor_inference_mode,instruction_count,234998
runtime_overhead_inductor_requires_grad,instruction_count,293556
runtime_overhead_inductor_requires_grad_backward,instruction_count,78181
runtime_overhead_inductor_dynamic,instruction_count,234870
runtime_overhead_inductor_inference_mode_dynamic,instruction_count,248711
runtime_overhead_inductor_requires_grad_dynamic,instruction_count,309979
runtime_overhead_inductor_requires_grad_backward_dynamic,instruction_count,77599
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela