### PR TITLE
[CI] Fix test_triton_wait_until hang

### DIFF
--- a/test/distributed/test_nvshmem_triton.py
+++ b/test/distributed/test_nvshmem_triton.py
@@ -544,8 +544,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
             [FLAG_FINAL_VALUE], dtype=torch.int32, device=self.device
         )
 
-        nvshmem_barrier_all_kernel[(1,)](extern_libs=nvshmem_lib)
-
         if rank == 0:
             # Rank 0 (the waiter)
             nvshmem_wait_until_kernel[(1,)](


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #163815
* #163814
* #163837
* __->__ #163886

I don't know why `nvshmem_barrier_all_kernel`  leads the test to hang. Will investigate. 
But since it is an unnecessary call here, I am removing it to unblock other PRs.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci