### PR TITLE
[Dynamic Shape][BE] trim _DimHint serialization

### DIFF
--- a/test/export/test_dynamic_shapes.py
+++ b/test/export/test_dynamic_shapes.py
@@ -1,0 +1,40 @@
+# Owner(s): ["oncall: export"]
+
+from torch._dynamo.test_case import run_tests, TestCase
+from torch.export.dynamic_shapes import _DimHint, _DimHintType, Dim
+
+
+class TestDimHint(TestCase):
+    def test_dimhint_repr(self):
+        hint = _DimHint(_DimHintType.DYNAMIC)
+        self.assertEqual(repr(hint), "DimHint(DYNAMIC)")
+
+        hint_with_bounds = _DimHint(_DimHintType.AUTO, min=1, max=64)
+        self.assertEqual(repr(hint_with_bounds), "DimHint(AUTO, min=1, max=64)")
+
+        non_factory_hint = _DimHint(_DimHintType.STATIC, min=16, _factory=False)
+        self.assertEqual(repr(non_factory_hint), "DimHint(STATIC, min=16)")
+
+    def test_dimhint_factory(self):
+        factory = _DimHint(_DimHintType.AUTO)
+        self.assertTrue(factory._factory)
+
+        result = factory(min=8, max=32)
+        self.assertEqual(result.type, _DimHintType.AUTO)
+        self.assertEqual(result.min, 8)
+        self.assertEqual(result.max, 32)
+        self.assertFalse(result._factory)
+
+        with self.assertRaises(TypeError) as cm:
+            result(min=1, max=10)
+        self.assertIn("object is not callable", str(cm.exception))
+
+        bounded = Dim.DYNAMIC(min=4, max=16)
+        self.assertEqual(repr(bounded), "DimHint(DYNAMIC, min=4, max=16)")
+
+        with self.assertRaises(AssertionError):
+            factory(min=-1)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/export/dynamic_shapes.py
+++ b/torch/export/dynamic_shapes.py
@@ -57,6 +57,15 @@ class _DimHintType(Enum):
 
 @dataclasses.dataclass
 class _DimHint:
+    """
+    Internal class for dynamic shape hints.
+    - min and max are optional.
+    - _factory is for UX only, below example:
+        auto_hint = _DimHint.AUTO()  # _factory=True
+        bounded_hint = auto_hint(min=10, max=100)  # Returns new instance with _factory=False
+        bounded_hint(min=5, max=50)  # Will fail, non-factory instance cannot be called
+    """
+
     type: _DimHintType
     min: Optional[int] = None
     max: Optional[int] = None
@@ -81,6 +90,14 @@ class _DimHint:
         assert max is None or max >= 0, "max must be non-negative"
         assert min is None or max is None or min <= max, "min must be <= max"
         return _DimHint(self.type, min=min, max=max, _factory=False)
+
+    def __repr__(self):
+        parts = [self.type.name]
+        if self.min is not None:
+            parts.append(f"min={self.min}")
+        if self.max is not None:
+            parts.append(f"max={self.max}")
+        return f"DimHint({', '.join(parts)})"
 
 
 class Dim:


### PR DESCRIPTION
Summary:
current serialization is a bit hard to read
```
Exporting with the dynamic shape spec: {getitem_123: (_DimHint(type=<_DimHintType.DYNAMIC: 3>, min=1, max=64, _factory=False)), getitem_118: (_DimHint(type=<_DimHintType.DYNAMIC: 3>,
min=489, max=31232, _factory=False)), getitem_117: (_DimHint(type=<_DimHintType.DYNAMIC: 3>, min=489, max=31232, _factory=False)), getitem_116: (_DimHint(type=<_DimHintType.DYNAMIC: 3>, min=489, max=31232, _factory=False)), getitem_115: (
_DimHint(type=<_DimHintType.STATIC: 2>, min=None, max=None, _factory=True), _DimHint(type=<_DimHintType.DYNAMIC: 3>, min=1, max=64, _factory=False)), getitem_46: (_DimHint(type=<_DimHintType.DYNAMIC: 3>, min=29, max=1792, _factory=False),
 _DimHint(type=<_DimHintType.STATIC: 2>, min=None, max=None, _factory=True)), _predict_module__base_model_model_ro_sparse_arch_ebc__output_dists_0__dist: (_DimHint(type=<_DimHintType.DYNAMIC: 3>, min=1, max=64, _factory=False), _DimHint(t
ype=<_DimHintType.STATIC: 2>, min=None, max=None, _factory=True)), _predict_module__base_model_model_nro_sparse_arch_ebc__output_dists_0__dist: (_DimHint(type=<_DimHintType.DYNAMIC: 3>, min=29, max=1792, _factory=False)... 
```

Test Plan: UT

Differential Revision: D83175131


