### PR TITLE
Fix preserve annotation with decomp

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -15072,9 +15072,6 @@ def forward(self, x):
             test_serdes=True,
         )
 
-    # TODO: following tests should be fixed
-    @testing.expectedFailureTrainingIRToRunDecomp
-    @testing.expectedFailureTrainingIRToRunDecompNonStrict
     def test_preserve_annotation(self):
         class M(torch.nn.Module):
             def forward(self, x):

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -905,7 +905,6 @@ def _export_to_aten_ir(
             # make sure we don't override any meta
             if "desc" in new_output_node.meta:
                 del new_output_node.meta["desc"]
-            assert len(new_output_node.meta) == 0
             new_output_node.meta.update(old_output_node.meta)
 
     # TODO unfortunately preserving graph-level metadata and output node's meta


### PR DESCRIPTION
If we use `fx_traceback.preserve_node_meta()`, we will have a few extra node.meta fields on nodes, such as "seq_nr", added from `fx/proxy.py`. As a result, there might be non-empty node.meta on graph nodes. 