### PR TITLE
[cuDNN][SDPA] Disable dropout for cuDNN SDPA on 9.11 - 9.13

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -689,6 +689,14 @@ bool can_use_cudnn_attention(const sdp_params& params, bool debug) {
   }
   return false;
 #endif
+#if defined(CUDNN_VERSION) && CUDNN_VERSION > 91000 && CUDNN_VERSION < 91400
+  if (params.dropout > 0.0) {
+    if (debug) {
+      TORCH_WARN(CUDNN_VERSION, " cuDNN version does not support droppout in SDPA (9.11 - 9.13).");
+    }
+    return false;
+  }
+#endif
   // Define gate functions that determine if a flash kernel can be ran
   // Replace with std::to_array when we migrate to c++20
   constexpr auto general_constraints =

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -689,8 +689,9 @@ bool can_use_cudnn_attention(const sdp_params& params, bool debug) {
   }
   return false;
 #endif
-#if defined(CUDNN_VERSION) && CUDNN_VERSION > 91000 && CUDNN_VERSION < 91400
-  if (params.dropout > 0.0) {
+#if defined(CUDNN_VERSION)
+  static auto cudnn_version = cudnnGetVersion();
+  if (params.dropout > 0.0 && cudnn_version > 91100 && cudnn_version < 91400) {
     if (debug) {
       TORCH_WARN(CUDNN_VERSION, " cuDNN version does not support droppout in SDPA (9.11 - 9.13).");
     }


### PR DESCRIPTION
cuDNN introduced some broken heuristics for these cases so we need to disable dropout to avoid unexpected crashes due to heuristics refusing to proceed

cc @csarofeen @ptrblck @xwang233