### PR TITLE
Speed up return_and_correct_aliasing by caching write_aliases for outputs

### DIFF
--- a/torch/utils/_python_dispatch.py
+++ b/torch/utils/_python_dispatch.py
@@ -780,11 +780,11 @@ def return_and_correct_aliasing(func, args, kwargs, out):
 
     # Next: we need to make sure to return inputs directly, if the output is a mutable alias (e.g. add_()).
 
-    # simple case: none of our outputs have mutable aliases, so we can return the output as-is
     schema_info_outs_write_aliases = schema_info.outs_write_aliases
 
+    # simple case: none of our outputs have mutable aliases, so we can return the output as-is
     if schema_info_outs_write_aliases is None:
-        return None
+        return out
 
     if len(schema_info_outs_write_aliases) == 1:
         return get_arg_from_alias(

--- a/torch/utils/_python_dispatch.py
+++ b/torch/utils/_python_dispatch.py
@@ -602,6 +602,22 @@ class SchemaInfo:
     # of overhead. Converting to int once and caching removes this per-op overhead.
     int_tags: list[int]
 
+    # Result of _get_write_alias(x) for x in self.outs. Guaranteed that no elements of
+    # the list are None; if all were None, we store None instead of a list. If some but
+    # not all were None, that's unsupported.
+    outs_write_aliases: list[str] | None
+
+
+def _get_write_alias(x):
+    alias_set = x.alias_set
+    if not alias_set or not x.is_write:
+        return None
+    # torchscript allows for complicated alias sets, but our dispatcher ops only really involve simple aliasing
+    assert len(alias_set) == 1
+    # timeit says next(iter(alias_set)) is faster than list(alias_set)[0] even for
+    # set of size 1 on Python 3.13.
+    return next(iter(alias_set))
+
 
 # Given an OpOverload, returns schema information on it.
 # This is cached for efficiency, since it can involve running torchgen
@@ -668,8 +684,19 @@ def get_alias_info(func) -> SchemaInfo:
             )
             for a in func._schema.returns
         ]
+
+    out_schemas_write_aliases = [_get_write_alias(r) for r in out_schemas]
+    if not any(x is not None for x in out_schemas_write_aliases):
+        out_schemas_write_aliases = None
+    # simplifying assumption: we don't have **any** ops with return types like "-> (Tensor(a!), Tensor)"
+    elif not all(x is not None for x in out_schemas_write_aliases):
+        raise RuntimeError("Unsupported schema: " + str(func._schema))
+
     schema_info = SchemaInfo(
-        args=arg_schemas, outs=out_schemas, int_tags=[int(x) for x in func.tags]
+        args=arg_schemas,
+        outs=out_schemas,
+        int_tags=[int(x) for x in func.tags],
+        outs_write_aliases=out_schemas_write_aliases,
     )
     return schema_info
 
@@ -697,16 +724,6 @@ def return_and_correct_aliasing(func, args, kwargs, out):
     # Caching here because torchgen parsing is definitely not fast, and this function is called
     # once for every op in the graph during functionalization.
     schema_info = get_alias_info(func)
-
-    def get_write_alias(x):
-        alias_set = x.alias_set
-        if not alias_set or not x.is_write:
-            return None
-        # torchscript allows for complicated alias sets, but our dispatcher ops only really involve simple aliasing
-        assert len(alias_set) == 1
-        # timeit says next(iter(alias_set)) is faster than list(alias_set)[0] even for
-        # set of size 1 on Python 3.13.
-        return next(iter(alias_set))
 
     def get_arg_from_alias(output_alias, schema_info, args, kwargs):
         new_args, new_kwargs = torch.fx.operator_schemas.normalize_function(  # type: ignore[misc]
@@ -736,6 +753,7 @@ def return_and_correct_aliasing(func, args, kwargs, out):
     if _TORCH_TAG_INPLACE_VIEW_INT in schema_info.int_tags:
         # no_dispatch() to make sure that we secretly change the metadata on the wrapper,
         # but don't end up dispatching the op anywhere else.
+        get_write_alias = _get_write_alias
         mutated_args = [
             x
             for i, x in enumerate(args)
@@ -762,15 +780,11 @@ def return_and_correct_aliasing(func, args, kwargs, out):
 
     # Next: we need to make sure to return inputs directly, if the output is a mutable alias (e.g. add_()).
 
-    # Compute write aliases once instead of repeatedly.
-    schema_info_outs_write_aliases = [get_write_alias(r) for r in schema_info.outs]
     # simple case: none of our outputs have mutable aliases, so we can return the output as-is
-    if not any(x is not None for x in schema_info_outs_write_aliases):
-        return out
+    schema_info_outs_write_aliases = schema_info.outs_write_aliases
 
-    # simplifying assumption: we don't have **any** ops with return types like "-> (Tensor(a!), Tensor)"
-    if not all(x is not None for x in schema_info_outs_write_aliases):
-        raise RuntimeError("Unsupported schema: " + str(func._schema))
+    if schema_info_outs_write_aliases is None:
+        return None
 
     if len(schema_info_outs_write_aliases) == 1:
         return get_arg_from_alias(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #163911

We did some validation-type checks every time that only need to be
done once because they depend only on the schema.

Benchmark: https://gist.github.com/swolchok/92ef7dd1017b4fb4f17bbbf5ab59a510

Ran on M4 Mac. Output cleaned up to reduce visual noise and only show the return_and_correct_aliasing case.

```
Before:
> python torchdispatchbench.py
__torch_dispatch__ with return_and_correct_aliasing:
_ = t_aliasing.detach()
  Median: 3.69 us
  IQR:    0.03 us (3.68 to 3.71)
  4 measurements, 10000 runs per measurement, 1 thread

After:
> python torchdispatchbench.py
__torch_dispatch__ with return_and_correct_aliasing:
_ = t_aliasing.detach()
  Median: 3.33 us
  IQR:    0.02 us (3.33 to 3.34)
  4 measurements, 10000 runs per measurement, 1 thread
```

Observed similar results on Linux server, with before median of 19.92 usec and after of 18.78 usec.