### PR TITLE
add support for ir scalar literal parsing for inf/-inf/True/False 

### DIFF
--- a/test/jit/test_misc.py
+++ b/test/jit/test_misc.py
@@ -433,6 +433,17 @@ class TestMisc(JitTestCase):
         self.assertTrue(ret.numel() == 1)
         self.assertTrue(len(ret.size()) == 1)
 
+    def test_parse_ir_single_inf(self):
+        ir = """
+        graph():
+          %12 : float = prim::Constant[value=inf]()
+          return (%12)
+        """
+        graph = torch._C.parse_ir(ir, True)
+        func = torch._C._create_function_from_graph("forward", graph)
+        ret = func()
+        self.assertTrue(ret == float("inf"))
+
     def test_parse_ir_single_minus_inf(self):
         ir = """
         graph():
@@ -442,7 +453,7 @@ class TestMisc(JitTestCase):
         graph = torch._C.parse_ir(ir, True)
         func = torch._C._create_function_from_graph("forward", graph)
         ret = func()
-        self.assertTrue(ret == float(-inf))
+        self.assertTrue(ret == float("-inf"))
 
     def test_parse_ir_bool_true(self):
         ir = """

--- a/test/jit/test_misc.py
+++ b/test/jit/test_misc.py
@@ -444,6 +444,28 @@ class TestMisc(JitTestCase):
         ret = func()
         self.assertTrue(ret == float(-inf))
 
+    def test_parse_ir_bool_true(self):
+        ir = """
+        graph():
+          %12 : bool = prim::Constant[value=True]()
+          return (%12)
+        """
+        graph = torch._C.parse_ir(ir, True)
+        func = torch._C._create_function_from_graph("forward", graph)
+        ret = func()
+        self.assertTrue(ret == True)
+
+    def test_parse_ir_bool_false(self):
+        ir = """
+        graph():
+          %12 : bool = prim::Constant[value=False]()
+          return (%12)
+        """
+        graph = torch._C.parse_ir(ir, True)
+        func = torch._C._create_function_from_graph("forward", graph)
+        ret = func()
+        self.assertTrue(ret == False)
+
     def test_script_many_decorators(self):
         def no_op_decorator(f):
             return f

--- a/test/jit/test_misc.py
+++ b/test/jit/test_misc.py
@@ -464,7 +464,7 @@ class TestMisc(JitTestCase):
         graph = torch._C.parse_ir(ir, True)
         func = torch._C._create_function_from_graph("forward", graph)
         ret = func()
-        self.assertTrue(ret == True)
+        self.assertTrue(ret == True) # noqa: E712
 
     def test_parse_ir_bool_false(self):
         ir = """
@@ -475,7 +475,7 @@ class TestMisc(JitTestCase):
         graph = torch._C.parse_ir(ir, True)
         func = torch._C._create_function_from_graph("forward", graph)
         ret = func()
-        self.assertTrue(ret == False)
+        self.assertTrue(ret == False) # noqa: E712
 
     def test_script_many_decorators(self):
         def no_op_decorator(f):

--- a/test/jit/test_misc.py
+++ b/test/jit/test_misc.py
@@ -12,7 +12,11 @@ import torch.testing._internal.jit_utils
 from jit.test_module_interface import TestModuleInterface  # noqa: F401
 from torch import jit
 from torch.testing import FileCheck
-from torch.testing._internal.common_utils import freeze_rng_state, raise_on_run_directly
+from torch.testing._internal.common_utils import (
+    freeze_rng_state,
+    raise_on_run_directly,
+    skipIfTorchDynamo,
+)
 from torch.testing._internal.jit_utils import JitTestCase, make_global, RUN_CUDA_HALF
 
 
@@ -467,7 +471,7 @@ class TestMisc(JitTestCase):
         graph = torch._C.parse_ir(ir, True)
         func = torch._C._create_function_from_graph("forward", graph)
         ret = func()
-        self.assertTrue(ret == True) # noqa: E712
+        self.assertTrue(ret == True)  # noqa: E712
 
     @skipIfTorchDynamo("The test case only test the parser. No need to wrap dynamo.")
     def test_parse_ir_bool_false(self):
@@ -479,7 +483,7 @@ class TestMisc(JitTestCase):
         graph = torch._C.parse_ir(ir, True)
         func = torch._C._create_function_from_graph("forward", graph)
         ret = func()
-        self.assertTrue(ret == False) # noqa: E712
+        self.assertTrue(ret == False)  # noqa: E712
 
     def test_script_many_decorators(self):
         def no_op_decorator(f):

--- a/test/jit/test_misc.py
+++ b/test/jit/test_misc.py
@@ -433,6 +433,17 @@ class TestMisc(JitTestCase):
         self.assertTrue(ret.numel() == 1)
         self.assertTrue(len(ret.size()) == 1)
 
+    def test_parse_ir_single_minus_inf(self):
+        ir = """
+        graph():
+          %12 : float = prim::Constant[value=-inf]()
+          return (%12)
+        """
+        graph = torch._C.parse_ir(ir, True)
+        func = torch._C._create_function_from_graph("forward", graph)
+        ret = func()
+        self.assertTrue(ret == float(-inf))
+
     def test_script_many_decorators(self):
         def no_op_decorator(f):
             return f

--- a/test/jit/test_misc.py
+++ b/test/jit/test_misc.py
@@ -433,6 +433,7 @@ class TestMisc(JitTestCase):
         self.assertTrue(ret.numel() == 1)
         self.assertTrue(len(ret.size()) == 1)
 
+    @unittest.skipIf(os.environ.get("PYTORCH_TEST_WITH_DYNAMO") == "1", "Not supported with TorchDynamo")
     def test_parse_ir_single_inf(self):
         ir = """
         graph():
@@ -444,6 +445,7 @@ class TestMisc(JitTestCase):
         ret = func()
         self.assertTrue(ret == float("inf"))
 
+    @unittest.skipIf(os.environ.get("PYTORCH_TEST_WITH_DYNAMO") == "1", "Not supported with TorchDynamo")
     def test_parse_ir_single_minus_inf(self):
         ir = """
         graph():
@@ -455,6 +457,7 @@ class TestMisc(JitTestCase):
         ret = func()
         self.assertTrue(ret == float("-inf"))
 
+    @unittest.skipIf(os.environ.get("PYTORCH_TEST_WITH_DYNAMO") == "1", "Not supported with TorchDynamo")
     def test_parse_ir_bool_true(self):
         ir = """
         graph():
@@ -466,6 +469,7 @@ class TestMisc(JitTestCase):
         ret = func()
         self.assertTrue(ret == True) # noqa: E712
 
+    @unittest.skipIf(os.environ.get("PYTORCH_TEST_WITH_DYNAMO") == "1", "Not supported with TorchDynamo")
     def test_parse_ir_bool_false(self):
         ir = """
         graph():

--- a/test/jit/test_misc.py
+++ b/test/jit/test_misc.py
@@ -433,7 +433,7 @@ class TestMisc(JitTestCase):
         self.assertTrue(ret.numel() == 1)
         self.assertTrue(len(ret.size()) == 1)
 
-    @unittest.skipIf(os.environ.get("PYTORCH_TEST_WITH_DYNAMO") == "1", "Not supported with TorchDynamo")
+    @skipIfTorchDynamo("The test case only test the parser. No need to wrap dynamo.")
     def test_parse_ir_single_inf(self):
         ir = """
         graph():
@@ -445,7 +445,7 @@ class TestMisc(JitTestCase):
         ret = func()
         self.assertTrue(ret == float("inf"))
 
-    @unittest.skipIf(os.environ.get("PYTORCH_TEST_WITH_DYNAMO") == "1", "Not supported with TorchDynamo")
+    @skipIfTorchDynamo("The test case only test the parser. No need to wrap dynamo.")
     def test_parse_ir_single_minus_inf(self):
         ir = """
         graph():
@@ -457,7 +457,7 @@ class TestMisc(JitTestCase):
         ret = func()
         self.assertTrue(ret == float("-inf"))
 
-    @unittest.skipIf(os.environ.get("PYTORCH_TEST_WITH_DYNAMO") == "1", "Not supported with TorchDynamo")
+    @skipIfTorchDynamo("The test case only test the parser. No need to wrap dynamo.")
     def test_parse_ir_bool_true(self):
         ir = """
         graph():
@@ -469,7 +469,7 @@ class TestMisc(JitTestCase):
         ret = func()
         self.assertTrue(ret == True) # noqa: E712
 
-    @unittest.skipIf(os.environ.get("PYTORCH_TEST_WITH_DYNAMO") == "1", "Not supported with TorchDynamo")
+    @skipIfTorchDynamo("The test case only test the parser. No need to wrap dynamo.")
     def test_parse_ir_bool_false(self):
         ir = """
         graph():

--- a/torch/csrc/jit/ir/irparser.cpp
+++ b/torch/csrc/jit/ir/irparser.cpp
@@ -182,6 +182,16 @@ ParsedLiteral IRParser::parseScalarLiteral(Node* n) {
       r.s = parseStringLiteral(token.range, token.text());
       L.next();
       return r;
+    case TK_TRUE:
+      r.k = AttributeKind::i;
+      r.i = 1;
+      L.next();
+      return r;
+    case TK_FALSE:
+      r.k = AttributeKind::i;
+      r.i = 0;
+      L.next();
+      return r;
     case '-':
       str = "-";
       L.next();

--- a/torch/csrc/jit/ir/irparser.cpp
+++ b/torch/csrc/jit/ir/irparser.cpp
@@ -185,6 +185,12 @@ ParsedLiteral IRParser::parseScalarLiteral(Node* n) {
     case '-':
       str = "-";
       L.next();
+      if (L.cur().kind == TK_IDENT && L.cur().text() == "inf") {
+        r.k = AttributeKind::f;
+        r.f = -std::numeric_limits<double>::infinity();
+        L.next();
+        return r;
+      }
       if (L.cur().kind != TK_NUMBER) {
         throw(
             ErrorReport(token.range)

--- a/torch/csrc/jit/ir/irparser.cpp
+++ b/torch/csrc/jit/ir/irparser.cpp
@@ -254,6 +254,13 @@ ParsedLiteral IRParser::parseScalarLiteral(Node* n) {
       L.next();
       return r;
     case TK_IDENT:
+      if (L.cur().text() == "inf") {
+        r.k = AttributeKind::f;
+        r.f = std::numeric_limits<double>::infinity();
+        L.next();
+        return r;
+      }
+
       // Type literal
       r.k = AttributeKind::ty;
       type_alias = type_parser.parseType();


### PR DESCRIPTION
Currently the ir parser doesn't support parse ir like 
```
graph():
  %12 : float = prim::Constant[value=-inf]()
  %13 : float = prim::Constant[value=inf]()
  %14 : bool = prim::Constant[value=True]()
  %15 : bool = prim::Constant[value=False]()
  return (%12)
```

So the python script below will throw error.

```
#!/bin/env python
import torch

def test():
    return [True, False]
f = torch.jit.script(test)
torch._C._jit_pass_constant_propagation(f.graph)
ts_str = f.graph.__repr__()
print(ts_str)
ts = torch.parse_ir(ts_str)
func = torch._C._create_function_from_graph("forward", ts)
ret = func()
assert ret == [True, False]


def test():
    return [float("inf"), float("-inf")]
f = torch.jit.script(test)
torch._C._jit_pass_constant_propagation(f.graph)
ts_str = f.graph.__repr__()
print(ts_str)
ts = torch.parse_ir(ts_str)
func = torch._C._create_function_from_graph("forward", ts)
ret = func()
assert ret == [float("inf"), float("-inf")]
```

I add "inf" and bool cases for IRParser::parseScalarLiteral in irparser.cpp.

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel @ezyang 