### PR TITLE
Remove outdated FBGEMM check in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -900,7 +900,7 @@ include(ExternalProject)
 
 # ---[ Dependencies ---[ FBGEMM doesn't work on x86 32bit and
 # CMAKE_SYSTEM_PROCESSOR thinks its 64bit
-if(USE_FBGEMM AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|aarch64)$")
+if(USE_FBGEMM AND NOT (CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|aarch64)$" OR APPLE))
   message(WARNING
     "x86_64 or aarch64 required for FBGEMM. "
     "Not compiling with FBGEMM. "

--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
@@ -190,7 +190,7 @@ at::Tensor& embedding_lookup_fallback_impl(
   return output;
 }
 
-#ifdef __aarch64__
+#if defined(__aarch64__) && !defined(__APPLE__)
 static inline void embedding_neon_kernel(
     const uint8_t* weight_ptr,
     float32x4_t& output1,

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -696,7 +696,6 @@ if(USE_FBGEMM)
 
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       target_compile_options_if_supported(asmjit -Wno-extra-semi)
-      target_compile_options_if_supported(fbgemm -Wno-extra-semi)
     endif()
     target_compile_options_if_supported(asmjit -Wno-unused-but-set-variable)
     target_compile_options_if_supported(asmjit -Wno-unused-variable)


### PR DESCRIPTION
FBGEMM can check 32 bit systems itself.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01