### PR TITLE
[CD][CUDA][Triton][PTXAS] Turn on  BUILD_BUNDLE_PTXAS=1 for CUDA13 X86 Wheel Build

### DIFF
--- a/.ci/manywheel/build_cuda.sh
+++ b/.ci/manywheel/build_cuda.sh
@@ -121,8 +121,8 @@ if [[ $CUDA_VERSION == 12* || $CUDA_VERSION == 13* ]]; then
     # Compress the fatbin with -compress-mode=size for CUDA 13
     if [[ $CUDA_VERSION == 13* ]]; then
         export TORCH_NVCC_FLAGS="$TORCH_NVCC_FLAGS -compress-mode=size"
-	# Bundle ptxas into the cu13 wheel, see https://github.com/pytorch/pytorch/issues/163801
-	export BUILD_BUNDLE_PTXAS=1
+        # Bundle ptxas into the cu13 wheel, see https://github.com/pytorch/pytorch/issues/163801
+        export BUILD_BUNDLE_PTXAS=1
     fi
     if [[ -z "$PYTORCH_EXTRA_INSTALL_REQUIREMENTS" ]]; then
         echo "Bundling with cudnn and cublas."

--- a/.ci/manywheel/build_cuda.sh
+++ b/.ci/manywheel/build_cuda.sh
@@ -121,6 +121,8 @@ if [[ $CUDA_VERSION == 12* || $CUDA_VERSION == 13* ]]; then
     # Compress the fatbin with -compress-mode=size for CUDA 13
     if [[ $CUDA_VERSION == 13* ]]; then
         export TORCH_NVCC_FLAGS="$TORCH_NVCC_FLAGS -compress-mode=size"
+	# Bundle ptxas into the cu13 wheel, see https://github.com/pytorch/pytorch/issues/163801
+	export BUILD_BUNDLE_PTXAS=1
     fi
     if [[ -z "$PYTORCH_EXTRA_INSTALL_REQUIREMENTS" ]]; then
         echo "Bundling with cudnn and cublas."


### PR DESCRIPTION
Triton (release/3.5.x) by default ships CUDA12.8 ptxas. 
This PR tries to bundle a ptxas version for cuda13, so that it can help #163801 when users run on new devices like THOR and Spark. 

Fixes #163801 

Test Plan: 
1) Check binary size increase against nightly or v2.9RC 
2) Install the binary from into a working THOR and B200/H100 machine (reproduce the original issue first on THOR), then install the binary built from this PR and we expect the issue to be gone without any additional user setting. Testing on B200 is to ensure no regression.  

[Update: since the original ptxas issue seems to be an ARM specific issue - THOR device is on ARM], This PR seems not appropriate. 

Reference: https://github.com/pytorch/pytorch/pull/119750 and https://github.com/pytorch/builder/commit/5c814e2527b3f5797488bf57d9d5425e63dcc1ac 

cc @ptrblck @eqy @tinglvv @atalman @malfet  
