### PR TITLE
Bce with logits loss extreme

### DIFF
--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -1,6 +1,5 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/core/Tensor.h>
-#include <ATen/ops/clamp.h>
 #include <ATen/core/Reduction.h>
 #include <ATen/Dispatch.h>
 #include <ATen/TensorIterator.h>
@@ -19,6 +18,7 @@
 #include <ATen/ops/binary_cross_entropy_backward_native.h>
 #include <ATen/ops/binary_cross_entropy_native.h>
 #include <ATen/ops/binary_cross_entropy_with_logits_native.h>
+#include <ATen/ops/clamp.h>
 #include <ATen/ops/clamp_min.h>
 #include <ATen/ops/cosine_embedding_loss_native.h>
 #include <ATen/ops/empty.h>
@@ -348,12 +348,6 @@ Tensor& binary_cross_entropy_backward_out_cpu(const Tensor& grad, const Tensor& 
 }
 
 Tensor binary_cross_entropy_with_logits(const Tensor& input, const Tensor& target, const std::optional<Tensor>& weight_opt, const std::optional<Tensor>& pos_weight_opt, int64_t reduction) {
-  // Binary cross entropy with logits tensor is defined by the equation:
-  // L = -w (p y ln(sigma(x)) + (1-y) ln(1-sigma(x)))
-  // Which can be simplified to
-  // L = -w (x (1-y) - ln(sigma(x))(1+y(p-1))
-  // => L = -w (x (1-y) - ln(sigma(x)), when p==1.
-
   // // Threshold when ln(sigma(x)) or ln(1-sigma(x)) < -100 to be consistent with binary_cross_entropy
   // // Note: ln(sigma(x)) ~= x if x < -100 and ln(1-sigma(x)) ~= -x for x > 100
   Tensor input_clamped = at::clamp(input, -100, 100);

--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -56,8 +56,6 @@
 #include <ATen/ops/where.h>
 #include <ATen/ops/xlogy.h>
 #include <ATen/ops/zeros_like.h>
-#include <ATen/ops/ones_like.h>
-#include <ATen/ops/any.h>
 #endif
 
 constexpr float EPSILON = 1e-12;

--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -383,7 +383,7 @@ Tensor binary_cross_entropy_with_logits(const Tensor& input, const Tensor& targe
 
     // Handle small values
     if (has_small_values) {
-      auto small_target = at::where(large_mask, target, at::zeros_like(target));
+      auto small_target = at::where(small_mask, target, at::zeros_like(target));
       auto small_loss = thresh_value * small_target;
       loss = at::where(small_mask, small_loss, loss);
     }

--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -379,7 +379,7 @@ Tensor binary_cross_entropy_with_logits(const Tensor& input, const Tensor& targe
     if (has_large_values) {
       auto large_target = at::where(large_mask, target, at::zeros_like(target));
       auto large_loss = thresh_value * (1 - large_target);
-      // Note: position weight does not effect loss if log(sigma(x)) ~= 0. 
+      // Note: pos_weight does not effect loss if log(sigma(x)) ~= 0.
       loss = at::where(large_mask, large_loss, loss);
     }
 

--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -366,7 +366,7 @@ Tensor binary_cross_entropy_with_logits(const Tensor& input, const Tensor& targe
       log_sigmoid_input.mul_(log_weight);
   }
   Tensor loss = (1 - target).mul_(input_clamped).sub_(log_sigmoid_input);
-  
+
   if (weight_opt.has_value() && weight_opt->defined()) {
       loss.mul_(*weight_opt);
   }

--- a/test/cpp/api/functional.cpp
+++ b/test/cpp/api/functional.cpp
@@ -3187,11 +3187,12 @@ TEST_F(FunctionalTest, BCEWithLogitsLoss) {
             sigmoid(output),
             target,
             F::BinaryCrossEntropyFuncOptions().weight(weight))));
-
-    // test extreme values
+  }
+  {
+    // test BCEWithLogits and BCE with sigmoid give same with extreme values
     float inf_f = std::numeric_limits<float>::infinity();
-    target = torch::rand(2);
-    output = torch::tensor({inf_f, -inf_f});
+    const auto target = torch::rand(2);
+    const auto output = torch::tensor({inf_f, -inf_f});
 
     auto bce_with_logits = F::binary_cross_entropy_with_logits(
         output,
@@ -3251,6 +3252,20 @@ TEST_F(FunctionalTest, BCEWithLogitsLoss) {
     const auto target = torch::rand({64, 4});
     const auto output = torch::rand({64, 4}) - 0.5;
     const auto pos_weight = torch::ones({64, 4});
+
+    ASSERT_TRUE(torch::allclose(
+        F::binary_cross_entropy_with_logits(output, target),
+        F::binary_cross_entropy_with_logits(
+            output,
+            target,
+            F::BinaryCrossEntropyWithLogitsFuncOptions().pos_weight(
+                pos_weight))));
+  }
+  { // test BCE with logits ones in pos weights with extreme values
+    float inf_f = std::numeric_limits<float>::infinity();
+    const auto target = torch::rand(2);
+    const auto output = torch::tensor({inf_f, -inf_f});
+    const auto pos_weight = torch::ones(2);
 
     ASSERT_TRUE(torch::allclose(
         F::binary_cross_entropy_with_logits(output, target),

--- a/test/cpp/api/functional.cpp
+++ b/test/cpp/api/functional.cpp
@@ -3187,6 +3187,22 @@ TEST_F(FunctionalTest, BCEWithLogitsLoss) {
             sigmoid(output),
             target,
             F::BinaryCrossEntropyFuncOptions().weight(weight))));
+
+    // test extreme values
+    float inf_f = std::numeric_limits<float>::infinity();
+    target = torch::rand(2);
+    output = torch::tensor({inf_f, -inf_f});
+
+    auto bce_with_logits = F::binary_cross_entropy_with_logits(
+        output,
+        target,
+        F::BinaryCrossEntropyWithLogitsFuncOptions().reduction(torch::kNone));
+    auto bce_sigmoid = F::binary_cross_entropy(
+        sigmoid(output),
+        target,
+        F::BinaryCrossEntropyFuncOptions().reduction(torch::kNone));
+
+    ASSERT_TRUE(torch::allclose(bce_with_logits, bce_sigmoid));
   }
   { // test BCE with logits has correct grad at zero
     const auto output = torch::zeros({3, 1}, torch::requires_grad());


### PR DESCRIPTION
Fixes #102894 

Updated the Loss Function binary_cross_entropy_with_logits to handle extreme values in a similar manner as binary_cross_entropy.

BCELoss inputs $x\in[0, 1]$ and thresholds $ln\_x := \max(\log(x), -100)$ (similarly for $\log(1-x)$). 

BCEWithLogitsLoss, which uses $\log(\sigma(x))$ and $\log(1-\sigma(x))$ for any $x\in[-\infty, \infty]$, did not have any threshold before. This caused inconsistency between the two methods and without any threshold arbitrarily large loss values could cause major problems in training. These commits fix this issue by clamping 'input = at::clamp(input, -100, 100)' (Note: $\log(\sigma(x)) \approx x$ for $x \leq -100$ and $\log(1-\sigma(x))) \approx -x$ for $x\geq100$). 

This fix is tested in the C++ unit test FunctionalTest::BCEWithLogitsLoss in 'test/cpp/api/functional.cpp'. 

Note: BCELoss does not update gradient for extreme cases in backwards so I didn't update the BCELossWithLogits backwards either.

@janeyx99 