### PR TITLE
[Inductor] CompiledFxGraph replace record_function with _RecordFunctionFast

### DIFF
--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -50,7 +50,6 @@ from torch._inductor.utils import (
     output_node,
     set_tracing_context_output_strides,
 )
-from torch.autograd.profiler import record_function
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._python_dispatch import is_in_torch_dispatch_mode
 

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -630,7 +630,8 @@ class CompiledFxGraph(OutputCode):
             # Checking the profiler directly is faster than nullcontext
             if torch.autograd.profiler._is_profiler_enabled:
                 with torch._C._profiler._RecordFunctionFast(
-                    f"## Call CompiledFxGraph {self._fx_graph_cache_key} ##"
+                    f"## Call CompiledFxGraph {self._fx_graph_cache_key} ##",
+                    keyword_values={"scope": "user_scope"}
                 ):
                     return self.current_callable(inputs)
             else:

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -630,7 +630,7 @@ class CompiledFxGraph(OutputCode):
         try:
             # Checking the profiler directly is faster than nullcontext
             if torch.autograd.profiler._is_profiler_enabled:
-                with record_function(
+                with torch._C._profiler._RecordFunctionFast(
                     f"## Call CompiledFxGraph {self._fx_graph_cache_key} ##"
                 ):
                     return self.current_callable(inputs)

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -631,7 +631,7 @@ class CompiledFxGraph(OutputCode):
             if torch.autograd.profiler._is_profiler_enabled:
                 with torch._C._profiler._RecordFunctionFast(
                     f"## Call CompiledFxGraph {self._fx_graph_cache_key} ##",
-                    keyword_values={"scope": "user_scope"}
+                    keyword_values={"scope": "user_scope"},
                 ):
                     return self.current_callable(inputs)
             else:


### PR DESCRIPTION
This replaces `record_function` in `CompiledFxGraph.__call__` with `_RecordFunctionFast`, which is less expensive in scenarios that don't require tracing (such as runtime). This should help with more accurate profiles.

`TestExecutionTrace.test_execution_trace_with_pt2` in https://github.com/pytorch/pytorch/blob/main/test/profiler/test_execution_trace.py#L372 already checks that the `record_function` region is tracked during profiling.

Note: This is related to #163566, but this avoids the failures coming up with uses of `record_function` elsewhere.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @chenyang78