### PR TITLE
[CI] Re-enable test_all_to_all_vdev_2d_offset

### DIFF
--- a/test/distributed/test_nvshmem.py
+++ b/test/distributed/test_nvshmem.py
@@ -460,14 +460,6 @@ class NVSHMEMAll2AllTest(MultiProcContinuousTest):
             0, k * nsplits, k, dtype=torch.int64, device=self.device
         )
 
-        # Exchange input splits to get output splits
-        out_splits = torch.zeros_like(inp_splits)
-        # First need to transpose the input splits
-        inp_splits_t = inp_splits.reshape(ne, self.world_size).t().contiguous()
-        dist.all_to_all_single(out_splits, inp_splits_t)
-
-        # Actual number of output elements
-        out_numel = out_splits.sum().item()
         # Max number of input elements (must be a constant across ranks for symmetric memory allocation)
         # Remember that we up-align each input split to k?
         max_inp_numel = k * nsplits
@@ -508,6 +500,11 @@ class NVSHMEMAll2AllTest(MultiProcContinuousTest):
         torch.testing.assert_close(in_splits_offsets[1], inp_offsets)
 
         # Check output splits (row 1)
+        # Exchange input splits to get output splits
+        out_splits = torch.zeros_like(inp_splits)
+        # First need to transpose the input splits
+        inp_splits_t = inp_splits.reshape(ne, self.world_size).t().contiguous()
+        dist.all_to_all_single(out_splits, inp_splits_t)
         torch.testing.assert_close(received_out_splits, out_splits)
 
         # Check output offsets (row 2)
@@ -550,6 +547,8 @@ class NVSHMEMAll2AllTest(MultiProcContinuousTest):
 
         # Concatenate the output chunks received from all peers
         out_expected = torch.cat(out_chunks)
+        # Actual number of output elements
+        out_numel = out_splits.sum().item()
         self.assertEqual(out_expected.shape[0], out_numel)
 
         # Check data


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #163985

Fixes https://github.com/pytorch/pytorch/issues/163847
Moving allocations upfront and collectives later. The hang goes away. 

My investigation indicates that the hang is inside the last call `torch.testing.assert_close(out_expected, out[:out_numel])`. Rank 3 calls into it, but never gets out. Don't know why yet. I will investigate more.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci