### PR TITLE
CUDACachingHostAllocatorImpl skip event query during capture

### DIFF
--- a/aten/src/ATen/cuda/CachingHostAllocator.cpp
+++ b/aten/src/ATen/cuda/CachingHostAllocator.cpp
@@ -151,6 +151,11 @@ struct CUDACachingHostAllocatorImpl
   }
 
   bool query_event(EventPool::Event& event) override {
+    // Do not call cudaEventQuery if captureing is underway
+    if (at::cuda::currentStreamCaptureStatusMayInitCtx() !=
+        at::cuda::CaptureStatus::None) {
+      return false;
+    }
     cudaError_t err = cudaEventQuery(*event);
     if (err == cudaErrorNotReady) {
       (void)cudaGetLastError(); // clear CUDA error

--- a/aten/src/ATen/cuda/CachingHostAllocator.cpp
+++ b/aten/src/ATen/cuda/CachingHostAllocator.cpp
@@ -151,7 +151,7 @@ struct CUDACachingHostAllocatorImpl
   }
 
   bool query_event(EventPool::Event& event) override {
-    // Do not call cudaEventQuery if captureing is underway
+    // Do not call cudaEventQuery if capturing is underway
     if (at::cuda::currentStreamCaptureStatusMayInitCtx() !=
         at::cuda::CaptureStatus::None) {
       return false;


### PR DESCRIPTION
The CUDACachingAllocator already does this, so there is precedent.