### PR TITLE
[torchfuzz] fix bool propagation

### DIFF
--- a/tools/experimental/dynamic_shapes/torchfuzz/operators/scalar_pointwise.py
+++ b/tools/experimental/dynamic_shapes/torchfuzz/operators/scalar_pointwise.py
@@ -1,6 +1,7 @@
 """Scalar pointwise operator implementation."""
 
 import random
+import torch
 from typing import Optional
 
 from torchfuzz.operators.base import Operator
@@ -21,6 +22,8 @@ class ScalarPointwiseOperator(Operator):
 
     def can_produce(self, output_spec: Spec) -> bool:
         """Scalar pointwise operations can only produce scalars."""
+        if output_spec.dtype == torch.bool:
+            return False
         return isinstance(output_spec, ScalarSpec)
 
     def fuzz_inputs_specs(self, output_spec: Spec, num_inputs: int = 2) -> list[Spec]:
@@ -54,13 +57,11 @@ class ScalarAddOperator(ScalarPointwiseOperator):
     def __init__(self):
         super().__init__("scalar_add", "+")
 
-
 class ScalarMulOperator(ScalarPointwiseOperator):
     """Operator for scalar multiplication."""
 
     def __init__(self):
         super().__init__("scalar_mul", "*")
-
 
 class ScalarSubOperator(ScalarPointwiseOperator):
     """Operator for scalar subtraction."""

--- a/tools/experimental/dynamic_shapes/torchfuzz/operators/tensor_pointwise.py
+++ b/tools/experimental/dynamic_shapes/torchfuzz/operators/tensor_pointwise.py
@@ -3,6 +3,8 @@
 import random
 from typing import Optional
 
+import torch
+
 from torchfuzz.operators.base import Operator
 from torchfuzz.tensor_fuzzer import Spec, TensorSpec
 from torchfuzz.type_promotion import (
@@ -27,6 +29,10 @@ class PointwiseOperator(Operator):
 
     def can_produce(self, output_spec: Spec) -> bool:
         """Tensor pointwise operations can produce tensors but not scalars."""
+        if not super().can_produce(output_spec):
+            return False
+        if isinstance(output_spec, TensorSpec) and output_spec.dtype == torch.bool:
+            return False
         return isinstance(output_spec, TensorSpec)
 
     def fuzz_inputs_specs(self, output_spec: Spec, num_inputs: int = 2) -> list[Spec]:
@@ -85,20 +91,17 @@ class AddOperator(PointwiseOperator):
     def __init__(self):
         super().__init__("add", "torch.add", "+")
 
-
 class MulOperator(PointwiseOperator):
     """Operator for element-wise multiplication."""
 
     def __init__(self):
         super().__init__("mul", "torch.mul", "*")
 
-
 class SubOperator(PointwiseOperator):
     """Operator for element-wise subtraction."""
 
     def __init__(self):
         super().__init__("sub", "torch.sub", "-")
-
 
 class DivOperator(PointwiseOperator):
     """Operator for element-wise division."""

--- a/tools/experimental/dynamic_shapes/torchfuzz/type_promotion.py
+++ b/tools/experimental/dynamic_shapes/torchfuzz/type_promotion.py
@@ -136,6 +136,9 @@ def get_promotion_table_for_strings() -> dict:
             ("int32", "int64"),
             ("int64", "int32"),
         ],
+        "bool": [
+            ("bool", "bool"),
+        ],
     }
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #164034
* __->__ #164003
* #164002
* #163890
* #163812
* #163743

bools can't propogate through the current pointwise ops such as add/mul. once we add more that can, we'll probably want to add an additional subclass that supports pointwise bools, but for now just don't allow it.