### PR TITLE
[docs] update instructions for locally building docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -473,7 +473,7 @@ In addition to the standard Google Style docstring formatting rules, the followi
 
 ### Building documentation
 
-Docs builds are tested with Python 3.10 and may fail with other Python versions. To build the documentation:
+Currently, the docs can only be built with Python 3.10. To build the documentation:
 
 1. Set up a Python 3.10 environment and install `pip`. We recommend using separate environments for PyTorch development and building the docs. For example:
 ```bash
@@ -491,15 +491,15 @@ uv pip install -U pip
 
 2. Install PyTorch in that environment.
 
-- If you're building the docs without changes, or only changed `.md`/`.rst` files in `docs/source`, install PyTorch nightly by [selecting "Preview (Nightly)" on this page](https://pytorch.org/get-started/locally/) and following its instructions. Be careful - you may need to replace `pip3` with `pip` to install `torch` in `.venv-docs` (and not system-wide).
-- If you created or modified Python files and want to build the docs with those changes, follow the [*Nightly Checkout & Pull*](#nightly-checkout--pull) instructions. When you run `tools/nightly.py`, use `--prefix .venv-docs` to use the environment created in step 1.
+- If you're building the docs without changes, or only changed `.md`/`.rst` files in `docs/source`, install PyTorch nightly by [selecting "Preview (Nightly)" on this page](https://pytorch.org/get-started/locally/) and following its instructions. Be careful - you may need to replace `pip3` with `pip` to install `torch` in your `.venv-docs` environment (and not system-wide).
+- If you created or modified Python files and want to build docs reflecting those changes, follow the [*Nightly Checkout & Pull*](#nightly-checkout--pull) instructions. When you run `tools/nightly.py`, use `--prefix .venv-docs` to use the environment created in step 1.
 - If your changes are more involved, or you run into errors when using the methods above, [install PyTorch from source](https://github.com/pytorch/pytorch#from-source).
 
 3. If `node` is not already on your system, [download and install Node.js](https://nodejs.org/en/download). Then, [install the KaTeX CLI](https://katex.org/docs/node) and ensure it's available in your `$PATH`:
 ```bash
 # Installs KaTeX globally:
 npm install -g katex
-# If you would prefer to avoid the global installation, use:
+# If you would prefer to avoid the global installation, you can use:
 npm install katex && export PATH="$PATH:$(pwd)/node_modules/.bin"
 ```
 
@@ -511,22 +511,22 @@ Note that:
 ```bash
 cd docs
 pip install -r requirements.txt
-pip install 'numpy<2'  # numpy>2 is incompatible with matplotlib 3.5.3
+pip install 'numpy<2'  # numpy>2 will error at runtime.
 ```
 
 5. Use `make` to build the docs. For example:
 ```bash
-make html  # Generate HTML documentation in docs/build/html
-make  # List available output formats
+make html  # Generate HTML documentation in docs/build/html.
+make  # List available output formats.
 ```
 
-Output formats may have additional dependencies. For example, `pdflatex` must be available in order to build a PDF with `make latexpdf`.
+Other output formats may have additional dependencies. For example, `pdflatex` must be available in order to build a PDF with `make latexpdf`.
 
 #### Building a PDF
 
-To build a PDF of all PyTorch documentation:
+To build a PDF of the PyTorch docs:
 
-1. Install a LaTeX distribution that provides `pdflatex` (for example, `brew install --cask mactex-no-gui` on MacOS).
+1. Install a LaTeX distribution that provides `pdflatex`. For example, you can use `brew install --cask mactex-no-gui` on MacOS.
 2. From the `docs` directory, run `make latexpdf`. This populates `docs/build/latex` with the LaTeX output.
 3. To build the PDF, `cd build/latex` and run `make LATEXOPTS="-interaction=nonstopmode"` twice. The first run builds a preliminary `pytorch.pdf`, and the second run resolves references and updates its table of contents and index.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -475,18 +475,11 @@ In addition to the standard Google Style docstring formatting rules, the followi
 
 Currently, the docs can only be built with Python 3.10. To build the documentation:
 
-1. Set up a Python 3.10 environment and install `pip`. We recommend using separate environments for PyTorch development and building the docs. For example:
+1. Set up a Python 3.10 virtual environment and install `pip`. We recommend using separate environments for PyTorch development and building the docs. For example:
 ```bash
 python3.10 -m venv .venv-docs
 source .venv-docs/bin/activate  # or `& .\venv-docs\Scripts\Activate.ps1` on Windows
 python -m ensurepip --upgrade
-```
-
-Or with `uv`:
-```bash
-uv venv -p 3.10 .venv-docs
-source .venv-docs/bin/activate  # or `& .\venv-docs\Scripts\Activate.ps1` on Windows
-uv pip install -U pip
 ```
 
 2. Install PyTorch in that environment.
@@ -503,9 +496,11 @@ npm install -g katex
 npm install katex && export PATH="$PATH:$(pwd)/node_modules/.bin"
 ```
 
-Note that:
-- If you installed `node` and `npm` with different package managers (such as `conda` and `brew`), your `node` and `katex` versions may be incompatible. `node@6.13.1` and `katex@0.13.18` are known to be compatible with one another. To install the latter, you can use `npm install -g katex@0.13.18`.
-- If you are a Meta employee using a devserver, it may be more convenient to install KaTeX with `yarn global add katex`. You can install a specific version with e.g. `yarn global add katex@0.13.18`
+> [!TIP]
+> If you are a Meta employee using a devserver, it may be more convenient to install KaTeX with `yarn global add katex`. You can install a specific version with e.g. `yarn global add katex@0.13.18`
+
+> [!CAUTION]
+> If you installed `node` and `npm` with different package managers (such as `conda` and `brew`), your `node` and `katex` versions may be incompatible. `node@6.13.1` and `katex@0.13.18` are known to be compatible with one another. To install the latter, you can use `npm install -g katex@0.13.18`.
 
 4. Install the docs' Python dependencies:
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -473,22 +473,15 @@ In addition to the standard Google Style docstring formatting rules, the followi
 
 ### Building documentation
 
-Currently, the docs can only be built with Python 3.10. To build the documentation:
+The docs can be built with Python 3.10 or later:
 
-1. Set up a Python 3.10 virtual environment and install `pip`. We recommend using separate environments for PyTorch development and building the docs. For example:
-```bash
-python3.10 -m venv .venv-docs
-source .venv-docs/bin/activate  # or `& .\venv-docs\Scripts\Activate.ps1` on Windows
-python -m ensurepip --upgrade
-```
+1. Set up a Python environment and install PyTorch.
 
-2. Install PyTorch in that environment.
+- To build the docs without changes, or reflecting changes to `.md`/`.rst` files in `docs/source`, [select "Preview (Nightly)" on this page](https://pytorch.org/get-started/locally/) and following its instructions.
+- To build the docs reflecting changes to Python source code (including docstrings), follow the instructions under [Nightly Checkout & Pull](#nightly-checkout--pull).
+- To build the docs reflecting more involved changes, or if you run into errors using the methods above, [install PyTorch from source](https://github.com/pytorch/pytorch#from-source).
 
-- If you're building the docs without changes, or only changed `.md`/`.rst` files in `docs/source`, install PyTorch nightly by [selecting "Preview (Nightly)" on this page](https://pytorch.org/get-started/locally/) and following its instructions. Be careful - you may need to replace `pip3` with `pip` to install `torch` in your `.venv-docs` environment (and not system-wide).
-- If you created or modified Python files and want to build docs reflecting those changes, follow the [*Nightly Checkout & Pull*](#nightly-checkout--pull) instructions. When you run `tools/nightly.py`, use `--prefix .venv-docs` to use the environment created in step 1.
-- If your changes are more involved, or you run into errors when using the methods above, [install PyTorch from source](https://github.com/pytorch/pytorch#from-source).
-
-3. If `node` is not already on your system, [download and install Node.js](https://nodejs.org/en/download). Then, [install the KaTeX CLI](https://katex.org/docs/node) and ensure it's available in your `$PATH`:
+2. If `node` is not already on your system, [download and install Node.js](https://nodejs.org/en/download). Then, [install the KaTeX CLI](https://katex.org/docs/node) and ensure it's available in your `$PATH`:
 ```bash
 # Installs KaTeX globally:
 npm install -g katex
@@ -502,20 +495,22 @@ npm install katex && export PATH="$PATH:$(pwd)/node_modules/.bin"
 > [!CAUTION]
 > If you installed `node` and `npm` with different package managers (such as `conda` and `brew`), your `node` and `katex` versions may be incompatible. `node@6.13.1` and `katex@0.13.18` are known to be compatible with one another. To install the latter, you can use `npm install -g katex@0.13.18`.
 
-4. Install the docs' Python dependencies:
+3. Install the docs' Python dependencies:
 ```bash
-cd docs
-pip install -r requirements.txt
-pip install 'numpy<2'  # numpy>2 will error at runtime.
+pip install -r docs/requirements.txt
 ```
 
-5. Use `make` to build the docs. For example:
+4. Use `make` to build the docs. For example:
 ```bash
+cd docs
 make html  # Generate HTML documentation in docs/build/html.
 make  # List available output formats.
 ```
 
 Other output formats may have additional dependencies. For example, `pdflatex` must be available in order to build a PDF with `make latexpdf`.
+
+> [!TIP]
+> To run some notebook examples, a C++ compiler such as `gcc` or `clang` must be available.
 
 #### Tips
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -517,16 +517,6 @@ make  # List available output formats.
 
 Other output formats may have additional dependencies. For example, `pdflatex` must be available in order to build a PDF with `make latexpdf`.
 
-#### Building a PDF
-
-To build a PDF of the PyTorch docs:
-
-1. Install a LaTeX distribution that provides `pdflatex`. For example, you can use `brew install --cask mactex-no-gui` on MacOS.
-2. From the `docs` directory, run `make latexpdf`. This populates `docs/build/latex` with the LaTeX output.
-3. To build the PDF, `cd build/latex` and run `make LATEXOPTS="-interaction=nonstopmode"` twice. The first run builds a preliminary `pytorch.pdf`, and the second run resolves references and updates its table of contents and index.
-
-To navigate the document, use the table of contents view in your PDF reader.
-
 #### Tips
 
 The `.rst` source files live in [docs/source](docs/source). Some of the `.rst`
@@ -563,6 +553,16 @@ commands. To run this check locally, run `./check-doxygen.sh` from inside
 
 To build the documentation, follow the same steps as above, but run them from
 `docs/cpp` instead of `docs`.
+
+#### Building a PDF
+
+To build a PDF of the PyTorch docs:
+
+1. Install a LaTeX distribution that provides `pdflatex`. For example, you can use `brew install --cask mactex-no-gui` on MacOS.
+2. From the `docs` directory, run `make latexpdf`. This populates `docs/build/latex` with the LaTeX output.
+3. To build the PDF, `cd build/latex` and run `make LATEXOPTS="-interaction=nonstopmode"` twice. The first run builds a preliminary `pytorch.pdf`, and the second run resolves references and updates its table of contents and index.
+
+To navigate the document, use the table of contents view in your PDF reader.
 
 ### Previewing changes locally
 

--- a/README.md
+++ b/README.md
@@ -433,13 +433,12 @@ make -f docker.Makefile
 
 ### Building the Documentation
 
-For detailed instructions on building the docs, see [CONTRIBUTING.md](https://github.com/pytorch/pytorch/blob/main/CONTRIBUTING.md#building-documentation). For example:
+Currently, the docs can only be built with Python 3.10.
 
 ```bash
-# Set up a Python 3.10 environment with pip
-uv venv -p 3.10 .venv-docs
-source .venv-docs/bin/activate
-uv pip install -U pip
+# Set up a Python 3.10 environment
+python3.10 -m venv .venv-docs
+source .venv-docs/bin/activate  # or `& .\venv-docs\Scripts\Activate.ps1` on Windows
 # Install PyTorch nightly
 pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
 # Install the docs' dependencies
@@ -450,6 +449,8 @@ npm install -g katex
 cd docs
 make html
 ```
+
+For detailed instructions on how to build the docs in other formats or reflecting changes in `torch/`, see [CONTRIBUTING.md](https://github.com/pytorch/pytorch/blob/main/CONTRIBUTING.md#building-documentation).
 
 ### Previous Versions
 

--- a/README.md
+++ b/README.md
@@ -436,9 +436,10 @@ make -f docker.Makefile
 Currently, the docs can only be built with Python 3.10.
 
 ```bash
-# Set up a Python 3.10 environment
+# Set up a Python 3.10 environment with pip
 python3.10 -m venv .venv-docs
 source .venv-docs/bin/activate  # or `& .\venv-docs\Scripts\Activate.ps1` on Windows
+python -m ensurepip --upgrade
 # Install PyTorch nightly
 pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
 # Install the docs' dependencies

--- a/README.md
+++ b/README.md
@@ -433,25 +433,31 @@ make -f docker.Makefile
 
 ### Building the Documentation
 
-Currently, the docs can only be built with Python 3.10.
+Currently, the docs can only be built with Python 3.10. To build them:
 
+1. Set up a Python 3.10 environment which includes `pip`. For example:
 ```bash
-# Set up a Python 3.10 environment with pip
 python3.10 -m venv .venv-docs
 source .venv-docs/bin/activate  # or `& .\venv-docs\Scripts\Activate.ps1` on Windows
 python -m ensurepip --upgrade
-# Install PyTorch nightly
-pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
-# Install the docs' dependencies
+```
+
+2. Install PyTorch in that environment. If you're building the docs without changes, [select "Preview (Nightly)" on this page](https://pytorch.org/get-started/locally/) and follow its instructions. If you're building the docs with changes, see the instructions in [CONTRIBUTING.md](https://github.com/pytorch/pytorch/blob/main/CONTRIBUTING.md#building-documentation).
+
+3. Install the docs' Python dependencies and the [`katex` CLI](https://katex.org/docs/node). If `node` is not already on your system, you may have to [download and install Node.js](https://nodejs.org/en/download). For example:
+```bash
 pip install -r docs/requirements.txt
 pip install 'numpy<2'
 npm install -g katex
-# Build the docs as HTML files in docs/build/html
+```
+
+4. Build the docs with `make`. For example, to build HTML files in `docs/build/html`:
+```bash
 cd docs
 make html
 ```
 
-For detailed instructions on how to build the docs in other formats or reflecting changes in `torch/`, see [CONTRIBUTING.md](https://github.com/pytorch/pytorch/blob/main/CONTRIBUTING.md#building-documentation).
+To build the docs in other formats, or reflecting changes in `torch/`, see [CONTRIBUTING.md](https://github.com/pytorch/pytorch/blob/main/CONTRIBUTING.md#building-documentation).
 
 ### Previous Versions
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Our trunk health (Continuous Integration signals) can be found at [hud.pytorch.o
     - [Using pre-built images](#using-pre-built-images)
     - [Building the image yourself](#building-the-image-yourself)
   - [Building the Documentation](#building-the-documentation)
-    - [Building a PDF](#building-a-pdf)
   - [Previous Versions](#previous-versions)
 - [Getting Started](#getting-started)
 - [Resources](#resources)
@@ -434,80 +433,23 @@ make -f docker.Makefile
 
 ### Building the Documentation
 
-To build documentation in various formats, you will need [Sphinx](http://www.sphinx-doc.org)
-and the pytorch_sphinx_theme2.
-
-Before you build the documentation locally, ensure `torch` is
-installed in your environment. For small fixes, you can install the
-nightly version as described in [Getting Started](https://pytorch.org/get-started/locally/).
-
-For more complex fixes, such as adding a new module and docstrings for
-the new module, you might need to install torch [from source](#from-source).
-See [Docstring Guidelines](https://github.com/pytorch/pytorch/wiki/Docstring-Guidelines)
-for docstring conventions.
+For detailed instructions on building the docs, see [CONTRIBUTING.md](https://github.com/pytorch/pytorch/blob/main/CONTRIBUTING.md#building-documentation). For example:
 
 ```bash
-cd docs/
-pip install -r requirements.txt
+# Set up a Python 3.10 environment with pip
+uv venv -p 3.10 .venv-docs
+source .venv-docs/bin/activate
+uv pip install -U pip
+# Install PyTorch nightly
+pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
+# Install the docs' dependencies
+pip install -r docs/requirements.txt
+pip install 'numpy<2'
+npm install -g katex
+# Build the docs as HTML files in docs/build/html
+cd docs
 make html
-make serve
 ```
-
-Run `make` to get a list of all available output formats.
-
-If you get a katex error run `npm install katex`.  If it persists, try
-`npm install -g katex`
-
-> [!NOTE]
-> If you installed `nodejs` with a different package manager (e.g.,
-> `conda`) then `npm` will probably install a version of `katex` that is not
-> compatible with your version of `nodejs` and doc builds will fail.
-> A combination of versions that is known to work is `node@6.13.1` and
-> `katex@0.13.18`. To install the latter with `npm` you can run
-> ```npm install -g katex@0.13.18```
-
-> [!NOTE]
-> If you see a numpy incompatibility error, run:
-> ```
-> pip install 'numpy<2'
-> ```
-
-When you make changes to the dependencies run by CI, edit the
-`.ci/docker/requirements-docs.txt` file.
-
-#### Building a PDF
-
-To compile a PDF of all PyTorch documentation, ensure you have
-`texlive` and LaTeX installed. On macOS, you can install them using:
-
-```
-brew install --cask mactex
-```
-
-To create the PDF:
-
-1. Run:
-
-   ```
-   make latexpdf
-   ```
-
-   This will generate the necessary files in the `build/latex` directory.
-
-2. Navigate to this directory and execute:
-
-   ```
-   make LATEXOPTS="-interaction=nonstopmode"
-   ```
-
-   This will produce a `pytorch.pdf` with the desired content. Run this
-   command one more time so that it generates the correct table
-   of contents and index.
-
-> [!NOTE]
-> To view the Table of Contents, switch to the **Table of Contents**
-> view in your PDF viewer.
-
 
 ### Previous Versions
 

--- a/README.md
+++ b/README.md
@@ -433,31 +433,7 @@ make -f docker.Makefile
 
 ### Building the Documentation
 
-Currently, the docs can only be built with Python 3.10. To build them:
-
-1. Set up a Python 3.10 environment which includes `pip`. For example:
-```bash
-python3.10 -m venv .venv-docs
-source .venv-docs/bin/activate  # or `& .\venv-docs\Scripts\Activate.ps1` on Windows
-python -m ensurepip --upgrade
-```
-
-2. Install PyTorch in that environment. If you're building the docs without changes, [select "Preview (Nightly)" on this page](https://pytorch.org/get-started/locally/) and follow its instructions. If you're building the docs with changes, see the instructions in [CONTRIBUTING.md](https://github.com/pytorch/pytorch/blob/main/CONTRIBUTING.md#building-documentation).
-
-3. Install the docs' Python dependencies and the [`katex` CLI](https://katex.org/docs/node). If `node` is not already on your system, you may have to [download and install Node.js](https://nodejs.org/en/download). For example:
-```bash
-pip install -r docs/requirements.txt
-pip install 'numpy<2'
-npm install -g katex
-```
-
-4. Build the docs with `make`. For example, to build HTML files in `docs/build/html`:
-```bash
-cd docs
-make html
-```
-
-To build the docs in other formats, or reflecting changes in `torch/`, see [CONTRIBUTING.md](https://github.com/pytorch/pytorch/blob/main/CONTRIBUTING.md#building-documentation).
+The PyTorch docs can be built in a variety of formats (such as HTML, PDF, plain text, and epub) by following the instructions in [`CONTRIBUTING.md`](https://github.com/pytorch/pytorch/blob/main/CONTRIBUTING.md#building-documentation).
 
 ### Previous Versions
 


### PR DESCRIPTION
Updates the instructions for locally building the docs in `CONTRIBUTING.md`. In specific:
- Note that docs can only be built with Python 3.10. This may change soon; see #164010 for more context.
- Explain when/why users may need to install PyTorch via wheel, `tools/nightly.py`, or from source when building docs.
- Move instructions to build the docs as a PDF from the README to `CONTRIBUTING.md`.

Fixes #163789