### PR TITLE
[AMP] Add deprecated decorator for torch.xxx.amp.GradScaler class

### DIFF
--- a/torch/cpu/amp/grad_scaler.py
+++ b/torch/cpu/amp/grad_scaler.py
@@ -6,17 +6,17 @@ import torch
 __all__ = ["GradScaler"]
 
 
+@deprecated(
+    "`torch.cpu.amp.GradScaler(args...)` is deprecated. "
+    "Please use `torch.amp.GradScaler('cpu', args...)` instead.",
+    category=FutureWarning,
+)
 class GradScaler(torch.amp.GradScaler):
     r"""
     See :class:`torch.amp.GradScaler`.
     ``torch.cpu.amp.GradScaler(args...)`` is deprecated. Please use ``torch.amp.GradScaler("cpu", args...)`` instead.
     """
 
-    @deprecated(
-        "`torch.cpu.amp.GradScaler(args...)` is deprecated. "
-        "Please use `torch.amp.GradScaler('cpu', args...)` instead.",
-        category=FutureWarning,
-    )
     def __init__(
         self,
         init_scale: float = 2.0**16,

--- a/torch/cuda/amp/grad_scaler.py
+++ b/torch/cuda/amp/grad_scaler.py
@@ -9,17 +9,17 @@ from torch.amp.grad_scaler import OptState  # noqa: F401
 __all__ = ["GradScaler"]
 
 
+@deprecated(
+    "`torch.cuda.amp.GradScaler(args...)` is deprecated. "
+    "Please use `torch.amp.GradScaler('cuda', args...)` instead.",
+    category=FutureWarning,
+)
 class GradScaler(torch.amp.GradScaler):
     r"""
     See :class:`torch.amp.GradScaler`.
     ``torch.cuda.amp.GradScaler(args...)`` is deprecated. Please use ``torch.amp.GradScaler("cuda", args...)`` instead.
     """
 
-    @deprecated(
-        "`torch.cuda.amp.GradScaler(args...)` is deprecated. "
-        "Please use `torch.amp.GradScaler('cuda', args...)` instead.",
-        category=FutureWarning,
-    )
     def __init__(
         self,
         init_scale: float = 2.0**16,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #164043
* __->__ #164042

As the title stated.

**Changes:**
- torch.cuda.amp.GradScaler
- torch.cpu.amp.GradScaler

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168