### PR TITLE
[AMP] using device-agnostic API like torch.amp.autocast

### DIFF
--- a/.ci/pytorch/smoke_test/smoke_test.py
+++ b/.ci/pytorch/smoke_test/smoke_test.py
@@ -309,7 +309,7 @@ def smoke_test_conv2d() -> None:
         print("Testing smoke_test_conv2d with cuda")
         conv = nn.Conv2d(3, 3, 3).cuda()
         x = torch.randn(1, 3, 24, 24, device="cuda")
-        with torch.cuda.amp.autocast():
+        with torch.amp.autocast(device_type="cuda"):
             out = conv(x)
         assert out is not None
 

--- a/test/distributed/test_data_parallel.py
+++ b/test/distributed/test_data_parallel.py
@@ -11,7 +11,6 @@ import torch
 import torch.nn.functional as F
 import torch.nn.parallel as dp
 from torch import nn
-from torch.cuda.amp import autocast
 from torch.testing._internal.common_cuda import TEST_CUDA, TEST_MULTIGPU
 from torch.testing._internal.common_device_type import (
     dtypes,
@@ -130,7 +129,7 @@ class TestDataParallel(TestCase):
         l2 = nn.Linear(10, 5).to("cuda:1", torch.float)
         i1 = torch.randn(2, 10, device="cuda:0", dtype=torch.float)
         i2 = torch.randn(2, 10, device="cuda:1", dtype=torch.float)
-        with autocast():
+        with torch.amp.autocast(device_type="cuda"):
             expected1 = l1(i1)
             expected2 = l2(i2)
         modules = (l1, l2)
@@ -139,7 +138,7 @@ class TestDataParallel(TestCase):
         # each input can be either a collection of positional arguments
         #                       or an object representing the single argument
         for inputs in [((i1,), (i2,)), (i1, i2)]:
-            with autocast():
+            with torch.amp.autocast(device_type="cuda"):
                 outputs = dp.parallel_apply(modules, inputs, None)
             for out, expected in zip(outputs, expected_outputs):
                 self.assertEqual(out, expected)

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -7348,7 +7348,7 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
         ]
 
         torch.compile(foo, backend="aot_eager_decomp_partition")
-        with torch.cuda.amp.autocast(enabled=True):
+        with torch.amp.autocast(device_type="cuda", enabled=True):
             ref = foo(*args)[0]
             res = foo(*args)[0]
             self.assertEqual(ref.dtype, res.dtype)

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -3707,11 +3707,11 @@ def forward(self, tangents_1):
             torch.rand((1, 256), dtype=torch.float32, device="cuda"),
             torch.rand((30, 256), dtype=torch.float16, device="cuda"),
         ]
-        with torch.cuda.amp.autocast(enabled=True):
+        with torch.amp.autocast(device_type="cuda", enabled=True):
             self.verify_aot_autograd(f, args)
 
         args = [e.requires_grad_(True) for e in args]
-        with torch.cuda.amp.autocast(enabled=True):
+        with torch.amp.autocast(device_type="cuda", enabled=True):
             self.verify_aot_autograd(f, args)
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
@@ -5962,7 +5962,7 @@ def forward(self, primals_1, tangents_1):
         aot_mod = memory_efficient_fusion(mod)
 
         # Ensure that AOT Autograd works with AMP
-        with torch.cuda.amp.autocast(True):
+        with torch.amp.autocast(device_type="cuda", enabled=True):
             res = aot_mod(x)
         res.sum().backward()
 

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -600,7 +600,7 @@ class CudaReproTests(TestCase):
             rand_strided(sh, st, dt, dev).requires_grad_(rg)
             for (sh, st, dt, dev, rg) in args
         ]
-        with torch.cuda.amp.autocast(enabled=False):
+        with torch.amp.autocast(device_type="cuda", enabled=False):
             assert same_two_models(mod, opt_mod, args), "Dynamo failed"
 
     @config.patch(allow_buffer_reuse=False)

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -1353,7 +1353,7 @@ if HAS_CUDA_AND_TRITON:
             # amp cache for cudagraph outputs should be disabled
             t2 = torch.rand([4, 4], device="cuda")
 
-            with torch.cuda.amp.autocast():
+            with torch.amp.autocast(device_type="cuda"):
                 run_once = out @ t2
 
                 out.detach().zero_()

--- a/test/onnx/test_pytorch_onnx_onnxruntime_cuda.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime_cuda.py
@@ -15,7 +15,6 @@ from pytorch_test_common import (
 from test_pytorch_onnx_onnxruntime import _parameterized_class_attrs_and_values
 
 import torch
-from torch.cuda.amp import autocast
 from torch.testing._internal import common_utils
 
 
@@ -53,7 +52,7 @@ class TestONNXRuntime_cuda(onnx_test_common._TestONNXRuntime):
                 super().__init__()
                 self.layer_norm = torch.nn.LayerNorm([10, 10])
 
-            @autocast()
+            @torch.amp.autocast(device_type="cuda")
             def forward(self, x):
                 return self.layer_norm(x)
 
@@ -78,7 +77,7 @@ class TestONNXRuntime_cuda(onnx_test_common._TestONNXRuntime):
                 self.loss = torch.nn.NLLLoss(reduction="none")
                 self.m = torch.nn.LogSoftmax(dim=1)
 
-            @autocast()
+            @torch.amp.autocast(device_type="cuda")
             def forward(self, input, target):
                 output = self.loss(self.m(2 * input), target)
                 return output

--- a/test/quantization/core/test_workflow_ops.py
+++ b/test/quantization/core/test_workflow_ops.py
@@ -306,7 +306,7 @@ class TestFakeQuantizeOps(TestCase):
         net.qconfig = torch.ao.quantization.get_default_qat_qconfig('fbgemm')
         net_prep = torch.ao.quantization.prepare_qat(net)
 
-        with torch.cuda.amp.autocast():
+        with torch.amp.autocast(device_type="cuda"):
             x = torch.randn(4, 1, 5, 5)
             out = net_prep(x).sum()
             out.backward()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5966,11 +5966,13 @@ class TestCudaOptims(TestCase):
                     grads_graphed = [[g.clone() for g in gs] for gs in grads]
 
                 # Gradient Scaler
-                scaler_for_control = torch.cuda.amp.GradScaler(init_scale=128.0)
+                scaler_for_control = torch.amp.GradScaler(
+                    device="cuda", init_scale=128.0
+                )
                 with torch.no_grad():
                     scaler_for_control._lazy_init_scale_growth_tracker(device)
 
-                scaler_for_graphed = torch.cuda.amp.GradScaler()
+                scaler_for_graphed = torch.amp.GradScaler(device="cuda")
                 scaler_for_graphed.load_state_dict(scaler_for_control.state_dict())
                 with torch.no_grad():
                     scaler_for_graphed._lazy_init_scale_growth_tracker(device)

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -35,7 +35,6 @@ from torch._utils_internal import (
     TEST_MASTER_PORT as MASTER_PORT,
 )
 from torch.autograd import DeviceType
-from torch.cuda.amp import autocast, GradScaler
 from torch.distributed.algorithms.ddp_comm_hooks import (
     default_hooks as default,
     post_localSGD_hook as post_localSGD,
@@ -5503,7 +5502,7 @@ class DistributedTest:
             optimizer = torch.optim.SGD(model.parameters(), lr=0.03)
 
             # Creates a GradScaler once at the beginning of training.
-            scaler = GradScaler()
+            scaler = torch.amp.GradScaler(device="cuda")
 
             ddp_model = nn.parallel.DistributedDataParallel(
                 model, device_ids=[self.rank], gradient_as_bucket_view=grad_is_view
@@ -5521,7 +5520,7 @@ class DistributedTest:
             for idx in range(20):
                 optimizer.zero_grad()
                 # Runs the forward pass with autocasting.
-                with autocast():
+                with torch.autocast(device_type="cuda"):
                     output = ddp_model(input)
                     loss = loss_fn(output, target)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #164043
* #164042

As the title stated.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @Lucaskabela