### PR TITLE
[PP] Use default export mode (non-strict)

### DIFF
--- a/torch/distributed/pipelining/_IR.py
+++ b/torch/distributed/pipelining/_IR.py
@@ -1002,7 +1002,7 @@ class Pipe(torch.nn.Module):
     ) -> ExportedProgram:
         logger.info("Tracing model ...")
         try:
-            ep = torch.export.export(mod, example_args, example_kwargs, strict=True)
+            ep = torch.export.export(mod, example_args, example_kwargs)
         except Exception as e:
             raise RuntimeError(
                 "It seems that we cannot capture your model as a full graph. "


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #164078
* #164077
* #164037
* #164035
* __->__ #164045

export's default mode has switched from strict to non-strict. We just follow suit in PP.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci