### PR TITLE
_SymExprDict => _SymExprDict for proxy_tensor PythonKeyTracer

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -40,11 +40,6 @@ import torch._inductor.test_case
 import torch.onnx.operators
 import torch.utils._pytree as python_pytree
 import torch.utils.cpp_extension
-import torch
-import sys
-from torch.distributed.tensor.placement_types import Replicate
-from torch.testing._internal.distributed.fake_pg import FakeStore
-from torch.distributed.tensor import DTensor
 from torch import Tensor
 from torch._C import FileCheck
 from torch._dynamo import allow_in_graph
@@ -67,6 +62,8 @@ from torch.ao.quantization import MinMaxObserver
 from torch.ao.quantization.fake_quantize import FakeQuantize
 from torch.ao.quantization.qconfig import QConfig
 from torch.ao.quantization.quantize_fx import prepare_qat_fx
+from torch.distributed.tensor import DTensor
+from torch.distributed.tensor.placement_types import Replicate
 from torch.fx.experimental.recording import NotEqualError, replay_shape_env_events
 from torch.fx.experimental.symbolic_shapes import (
     _constrain_range_for_size,
@@ -104,6 +101,7 @@ from torch.testing._internal.common_utils import (
     TEST_XPU,
     wrapDeterministicFlagAPITest,
 )
+from torch.testing._internal.distributed.fake_pg import FakeStore
 from torch.testing._internal.jit_utils import JitTestCase
 from torch.testing._internal.logging_utils import logs_to_string
 
@@ -13397,25 +13395,31 @@ class MiscTestsDevice(torch._inductor.test_case.TestCase):
     def test_dtensor_embedding(self):
         world_size = 1
         fake_store = FakeStore()
-        torch.distributed.init_process_group("fake", store=fake_store, rank=0, world_size=world_size)
+        torch.distributed.init_process_group(
+            "fake", store=fake_store, rank=0, world_size=world_size
+        )
         mesh = torch.distributed.device_mesh.init_device_mesh(
             "cuda",
-            (1, ),
+            (1,),
             mesh_dim_names=("dim1",),
         )
 
         placements = (Replicate(),)
-        arg0 = torch.randint(low=0, high=8, size=(2, 8), dtype=torch.int64, device='cuda')
+        arg0 = torch.randint(
+            low=0, high=8, size=(2, 8), dtype=torch.int64, device="cuda"
+        )
         arg0 = DTensor.from_local(arg0, mesh, placements)
-        arg1 = torch.rand((8, 16), dtype=torch.float16, device='cuda', requires_grad=True)
+        arg1 = torch.rand(
+            (8, 16), dtype=torch.float16, device="cuda", requires_grad=True
+        )
         arg1 = DTensor.from_local(arg1, mesh, placements)
 
         @torch.compile(fullgraph=True, dynamic=True)
         def foo(arg0, arg1):
             output = torch.nn.functional.embedding(arg0, arg1)
             return output
-        foo(arg0, arg1)
 
+        foo(arg0, arg1)
 
     def test_dynamic_float_scalar_tensor_coersion(self):
         # Minified version of https://github.com/pytorch/pytorch/issues/158376#issuecomment-3079591367

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -1071,23 +1071,23 @@ class _SymNodeDict:
     """
 
     def __init__(self) -> None:
-        self.sym_node_dict: dict[PySymType, _PySymProxyType] = {}
+        self.sym_node_dict: dict[sympy.Expr, _PySymProxyType] = {}
 
     def __setitem__(self, key: PySymType, value: _PySymProxyType) -> None:
-        self.sym_node_dict[key.node] = value
+        self.sym_node_dict[key.node.expr] = value
 
     def __getitem__(self, key: PySymType) -> _PySymProxyType:
-        return self.sym_node_dict[key.node]
+        return self.sym_node_dict[key.node.expr]
 
     def __contains__(self, key: PySymType) -> bool:
-        return key.node in self.sym_node_dict
+        return key.node.expr in self.sym_node_dict
 
     def get(
         self, key: PySymType, default: Optional[_PySymProxyType] = None
     ) -> _PySymProxyType:
         # dict.get()'s annotation doesn't accept `None` when the value type
         # isn't Optional.
-        return self.sym_node_dict.get(key.node, default)  # type: ignore[arg-type, return-value]
+        return self.sym_node_dict.get(key.node.expr, default)  # type: ignore[arg-type, return-value]
 
     def __iter__(self) -> Any:
         raise NotImplementedError

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -1074,20 +1074,20 @@ class _SymNodeDict:
         self.sym_node_dict: dict[sympy.Expr, _PySymProxyType] = {}
 
     def __setitem__(self, key: PySymType, value: _PySymProxyType) -> None:
-        self.sym_node_dict[key.node.expr] = value
+        self.sym_node_dict[key.node._expr] = value
 
     def __getitem__(self, key: PySymType) -> _PySymProxyType:
-        return self.sym_node_dict[key.node.expr]
+        return self.sym_node_dict[key.node._expr]
 
     def __contains__(self, key: PySymType) -> bool:
-        return key.node.expr in self.sym_node_dict
+        return key.node._expr in self.sym_node_dict
 
     def get(
         self, key: PySymType, default: Optional[_PySymProxyType] = None
     ) -> _PySymProxyType:
         # dict.get()'s annotation doesn't accept `None` when the value type
         # isn't Optional.
-        return self.sym_node_dict.get(key.node.expr, default)  # type: ignore[arg-type, return-value]
+        return self.sym_node_dict.get(key.node._expr, default)  # type: ignore[arg-type, return-value]
 
     def __iter__(self) -> Any:
         raise NotImplementedError


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #164034
* __->__ #164047

Fixes problem with new internal deeplearning library where when using dtensors we would hit an assert that looks like this

```
torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
RuntimeError: 256*s2 (140111119021248)is not tracked with proxy for <torch.fx.experimental.proxy_tensor.PythonKeyTracer object at 0x7f6b1e129360>
```

Managed to get a small one file representative repro that looks as follows

```
import torch
import sys
from torch.distributed.tensor.placement_types import Replicate, Shard
from torch.testing._internal.distributed.fake_pg import FakeStore
from torch.distributed.tensor import DTensor
torch._dynamo.config.capture_scalar_outputs = True
torch._dynamo.config.capture_dynamic_output_shape_ops = True
torch._inductor.config.emulate_precision_casts = True

def foo(arg0, arg1):
    output = torch.nn.functional.embedding(arg0, arg1)
    return output
# FakeStore will mock collective results so that it can be ran on a single rank
# =============================================================================
world_size = 128
fake_store = FakeStore()
torch.distributed.init_process_group(
    "fake", store=fake_store, rank=0, world_size=world_size
)
mesh = torch.distributed.device_mesh.init_device_mesh(
    "cuda",
    (8, 2, 2),
    mesh_dim_names=(
        "dim1", "dim2", "dim3",
    ),
)
placements = (Replicate(), Replicate(), Replicate())
arg0 = torch.randint(low=0, high=100, size=(2, 512), dtype=torch.int64, device='cuda')
arg0 = DTensor.from_local(arg0, mesh, placements)
arg1 = torch.rand([512, 256], dtype=torch.float16, device='cuda', requires_grad=True) # size=(5, 3), stride=(3, 1), dtype=float16, device=cuda
arg1 = DTensor.from_local(arg1, mesh, placements)
if __name__ == '__main__':
    out_eager = foo(arg0, arg1)
    out_eager.sum().backward()
    print('Eager Success! ✅')
    # DTensor compilation often fails - this is expected and valuable for fuzzing
    compiled_foo = torch.compile(foo, fullgraph=True, dynamic=True)
    out_compiled = compiled_foo(arg0, arg1)
    out_compiled.sum().backward()
    print('Compile Success! ✅')

    # Compare outputs (forward)
    out_eager_sum = out_eager.sum()
    out_compiled_sum = out_compiled.sum()
    diff = (out_eager_sum - out_compiled_sum).abs().item()
    rel_diff = diff / (out_eager_sum.abs().item() + 1e-12) * 100
    print(f'Relative diff (sum): {rel_diff:.6f}%')
    if rel_diff > 5:
        print(f'❌ Forward output sums differ significantly (relative)!')
        print('out_eager_sum:', out_eager_sum.item())
        print('out_compiled_sum:', out_compiled_sum.item())
        print('Absolute diff:', diff)
        print('Relative diff (%):', rel_diff)
        sys.exit(1)
    torch.distributed.destroy_process_group()
```

The key problem is there are many sym nodes with the same expr. When we construct a new dtensor instance during aotautograd, we create a new SymNode within `computeStorageNbytes`

<img width="2946" height="403" alt="image" src="https://github.com/user-attachments/assets/42170615-b228-49fd-a3fb-40772cf65e7c" />

and when we look up that symnode we get a miss in proxy_tensor::get_proxy_slot even though the expression `s46*s76` has been seen before.

This PR updates the SymNodeDict lookup code to use `_expr` instead of symnode, which enables proper sharing of proxies

NB: this does break BC for users depending on the symnode_tracker field. I did a quick github search and [only found one reference in helion](https://github.com/search?q=symnode_tracker&type=code). I think we can fix forward since it seems better to consolidate on a more accurate name.

cc @ezyang @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela