### PR TITLE
Remove C++ workarounds for Python < 3.10

### DIFF
--- a/torch/csrc/dynamo/cpython_includes.h
+++ b/torch/csrc/dynamo/cpython_includes.h
@@ -10,7 +10,6 @@
 #endif
 
 // see https://bugs.python.org/issue35886
-#if PY_VERSION_HEX >= 0x03080000
 #define Py_BUILD_CORE
 
 #ifndef __cplusplus
@@ -34,7 +33,6 @@
 #endif
 
 #undef Py_BUILD_CORE
-#endif // PY_VERSION_HEX >= 0x03080000
 
 #ifdef __cplusplus
 extern "C" {

--- a/torch/csrc/utils/python_scalars.h
+++ b/torch/csrc/utils/python_scalars.h
@@ -11,16 +11,12 @@ namespace torch::utils {
 
 template <typename T>
 inline T unpackIntegral(PyObject* obj, const char* type) {
-#if PY_VERSION_HEX >= 0x030a00f0
   // In Python-3.10 floats can no longer be silently converted to integers
   // Keep backward compatible behavior for now
   if (PyFloat_Check(obj)) {
     return c10::checked_convert<T>(THPUtils_unpackDouble(obj), type);
   }
   return c10::checked_convert<T>(THPUtils_unpackLong(obj), type);
-#else
-  return static_cast<T>(THPUtils_unpackLong(obj));
-#endif
 }
 
 inline void store_scalar(void* data, at::ScalarType scalarType, PyObject* obj) {


### PR DESCRIPTION
Remove two unnecessary `PY_VERSION_HEX` branches.
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela