### PR TITLE
Remove unused PyIntXXX, THPUtils_newReal_BOOL, THPQXXX macros

### DIFF
--- a/torch/csrc/Exceptions.cpp
+++ b/torch/csrc/Exceptions.cpp
@@ -336,7 +336,7 @@ PyObject* _new_accelerator_error_object(const c10::AcceleratorError& e) {
 
   auto py_msg = PyUnicode_FromString(msg);
   auto rc = PyObject_CallOneArg(THPException_AcceleratorError, py_msg);
-  auto error_code = PyInt_FromLong(e.get_error_code());
+  auto error_code = PyLong_FromLong(e.get_error_code());
   PyObject_SetAttrString(rc, "error_code", error_code);
   Py_XDECREF(py_msg);
   Py_XDECREF(error_code);

--- a/torch/csrc/Exceptions.cpp
+++ b/torch/csrc/Exceptions.cpp
@@ -336,7 +336,7 @@ PyObject* _new_accelerator_error_object(const c10::AcceleratorError& e) {
 
   auto py_msg = PyUnicode_FromString(msg);
   auto rc = PyObject_CallOneArg(THPException_AcceleratorError, py_msg);
-  auto error_code = PyLong_FromLong(e.get_error_code());
+  auto error_code = THPUtils_packUInt32(e.get_error_code());
   PyObject_SetAttrString(rc, "error_code", error_code);
   Py_XDECREF(py_msg);
   Py_XDECREF(error_code);

--- a/torch/csrc/Storage.cpp
+++ b/torch/csrc/Storage.cpp
@@ -440,7 +440,7 @@ static PyObject* THPStorage_get(THPStorage* self, PyObject* index) {
       return nullptr;
     }
     uint8_t value = storage_get(storage, nindex);
-    return THPByteUtils_newReal(value);
+    return THPUtils_packUInt32(value);
     /* Slice index */
   } else if (PySlice_Check(index)) {
     Py_ssize_t start = 0, stop = 0, slicelength = 0, step = 0;

--- a/torch/csrc/THP.h
+++ b/torch/csrc/THP.h
@@ -4,16 +4,6 @@
 #include <torch/csrc/Export.h>
 #include <torch/csrc/python_headers.h>
 
-// Back-compatibility macros, Thanks to http://cx-oracle.sourceforge.net/
-// define PyInt_* macros for Python 3.x.  NB: We must include Python.h first,
-// otherwise we'll incorrectly conclude PyInt_Check isn't defined!
-#ifndef PyInt_Check
-#define PyInt_Check PyLong_Check
-#define PyInt_FromLong PyLong_FromLong
-#define PyInt_AsLong PyLong_AsLong
-#define PyInt_Type PyLong_Type
-#endif
-
 #include <torch/csrc/Exceptions.h>
 #include <torch/csrc/Generator.h>
 #include <torch/csrc/Module.h>

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -1228,7 +1228,7 @@ static PyObject* THPVariable_get_version(THPVariable* self, void* unused) {
     return handle_torch_function_getter(self, "_version");
   }
   const auto& var = THPVariable_Unpack(self);
-  return PyLong_FromLong(var._version());
+  return THPUtils_packInt64(var._version());
   END_HANDLE_TH_ERRORS
 }
 
@@ -1383,9 +1383,8 @@ static PyObject* THPVariable_get_output_nr(THPVariable* self, void* unused) {
   if (check_has_torch_function((PyObject*)self)) {
     return handle_torch_function_getter(self, "output_nr");
   }
-  const auto output_nr =
-      static_cast<long>(THPVariable_Unpack(self).output_nr());
-  return PyLong_FromLong(output_nr);
+  const auto output_nr = THPVariable_Unpack(self).output_nr();
+  return THPUtils_packInt64(output_nr);
   END_HANDLE_TH_ERRORS
 }
 
@@ -1422,7 +1421,7 @@ static PyObject* THPVariable_get_ndim(THPVariable* self, void* unused) {
   if (check_has_torch_function((PyObject*)self)) {
     return handle_torch_function_getter(self, "ndim");
   }
-  return PyLong_FromLong(THPVariable_Unpack(self).dim());
+  return THPUtils_packInt64(THPVariable_Unpack(self).dim());
   END_HANDLE_TH_ERRORS
 }
 

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -1228,7 +1228,7 @@ static PyObject* THPVariable_get_version(THPVariable* self, void* unused) {
     return handle_torch_function_getter(self, "_version");
   }
   const auto& var = THPVariable_Unpack(self);
-  return PyInt_FromLong(var._version());
+  return PyLong_FromLong(var._version());
   END_HANDLE_TH_ERRORS
 }
 
@@ -1385,7 +1385,7 @@ static PyObject* THPVariable_get_output_nr(THPVariable* self, void* unused) {
   }
   const auto output_nr =
       static_cast<long>(THPVariable_Unpack(self).output_nr());
-  return PyInt_FromLong(output_nr);
+  return PyLong_FromLong(output_nr);
   END_HANDLE_TH_ERRORS
 }
 
@@ -1422,7 +1422,7 @@ static PyObject* THPVariable_get_ndim(THPVariable* self, void* unused) {
   if (check_has_torch_function((PyObject*)self)) {
     return handle_torch_function_getter(self, "ndim");
   }
-  return PyInt_FromLong(THPVariable_Unpack(self).dim());
+  return PyLong_FromLong(THPVariable_Unpack(self).dim());
   END_HANDLE_TH_ERRORS
 }
 

--- a/torch/csrc/utils.h
+++ b/torch/csrc/utils.h
@@ -59,7 +59,6 @@
   PyComplex_Check(object) || PyFloat_Check(object) || PyLong_Check(object)
 
 #define THPUtils_newReal_FLOAT(value) PyFloat_FromDouble(value)
-#define THPUtils_newReal_INT(value) PyLong_FromLong(value)
 
 #define THPUtils_newReal_BOOL(value) PyBool_FromLong(value)
 
@@ -104,36 +103,16 @@
 #define THPBoolUtils_newAccreal(value) THPUtils_newReal_BOOL(value)
 #define THPLongUtils_checkReal(object) THPUtils_checkReal_INT(object)
 #define THPLongUtils_unpackReal(object) (int64_t)THPUtils_unpackReal_INT(object)
-#define THPLongUtils_newReal(value) THPUtils_newReal_INT(value)
 #define THPIntUtils_checkReal(object) THPUtils_checkReal_INT(object)
 #define THPIntUtils_unpackReal(object) (int)THPUtils_unpackReal_INT(object)
-#define THPIntUtils_newReal(value) THPUtils_newReal_INT(value)
 #define THPShortUtils_checkReal(object) THPUtils_checkReal_INT(object)
 #define THPShortUtils_unpackReal(object) (short)THPUtils_unpackReal_INT(object)
-#define THPShortUtils_newReal(value) THPUtils_newReal_INT(value)
 #define THPCharUtils_checkReal(object) THPUtils_checkReal_INT(object)
 #define THPCharUtils_unpackReal(object) (char)THPUtils_unpackReal_INT(object)
-#define THPCharUtils_newReal(value) THPUtils_newReal_INT(value)
 #define THPByteUtils_checkReal(object) THPUtils_checkReal_INT(object)
 #define THPByteUtils_unpackReal(object) \
   (unsigned char)THPUtils_unpackReal_INT(object)
 #define THPByteUtils_newReal(value) THPUtils_newReal_INT(value)
-// quantized types
-#define THPQUInt8Utils_checkReal(object) THPUtils_checkReal_INT(object)
-#define THPQUInt8Utils_unpackReal(object) (int)THPUtils_unpackReal_INT(object)
-#define THPQUInt8Utils_newReal(value) THPUtils_newReal_INT(value)
-#define THPQInt8Utils_checkReal(object) THPUtils_checkReal_INT(object)
-#define THPQInt8Utils_unpackReal(object) (int)THPUtils_unpackReal_INT(object)
-#define THPQInt8Utils_newReal(value) THPUtils_newReal_INT(value)
-#define THPQInt32Utils_checkReal(object) THPUtils_checkReal_INT(object)
-#define THPQInt32Utils_unpackReal(object) (int)THPUtils_unpackReal_INT(object)
-#define THPQInt32Utils_newReal(value) THPUtils_newReal_INT(value)
-#define THPQUInt4x2Utils_checkReal(object) THPUtils_checkReal_INT(object)
-#define THPQUInt4x2Utils_unpackReal(object) (int)THPUtils_unpackReal_INT(object)
-#define THPQUInt4x2Utils_newReal(value) THPUtils_newReal_INT(value)
-#define THPQUInt2x4Utils_checkReal(object) THPUtils_checkReal_INT(object)
-#define THPQUInt2x4Utils_unpackReal(object) (int)THPUtils_unpackReal_INT(object)
-#define THPQUInt2x4Utils_newReal(value) THPUtils_newReal_INT(value)
 
 /*
    From https://github.com/python/cpython/blob/v3.7.0/Modules/xxsubtype.c

--- a/torch/csrc/utils.h
+++ b/torch/csrc/utils.h
@@ -55,12 +55,11 @@
 
 #define THPUtils_checkReal_BOOL(object) PyBool_Check(object)
 
-#define THPUtils_checkReal_COMPLEX(object)                                    \
-  PyComplex_Check(object) || PyFloat_Check(object) || PyLong_Check(object) || \
-      PyInt_Check(object)
+#define THPUtils_checkReal_COMPLEX(object) \
+  PyComplex_Check(object) || PyFloat_Check(object) || PyLong_Check(object)
 
 #define THPUtils_newReal_FLOAT(value) PyFloat_FromDouble(value)
-#define THPUtils_newReal_INT(value) PyInt_FromLong(value)
+#define THPUtils_newReal_INT(value) PyLong_FromLong(value)
 
 #define THPUtils_newReal_BOOL(value) PyBool_FromLong(value)
 


### PR DESCRIPTION
The removed macros are not used in other places of the `pytorch` GitHub org.