### PR TITLE
Enable bool dtype for meta lshift and rshift

### DIFF
--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -1864,6 +1864,24 @@ class TestMeta(TestCase):
         else:
             self.assertEqual(out_dtype, [in_dtype,])
 
+
+    @parametrize("x_dtype", [torch.int64, torch.int32, torch.bool])
+    @parametrize("y_dtype", [torch.int64, torch.int32, torch.bool])
+    def test_bitwise_shift(self, x_dtype, y_dtype):
+        device = "meta"
+
+        x = torch.empty(10, dtype=x_dtype, device=device)
+        y = torch.empty(10, dtype=y_dtype, device=device)
+        if x_dtype == torch.bool and y_dtype == torch.bool:
+            with self.assertRaisesRegex(RuntimeError, "lshift not implemented for 'Bool'"):
+                x << y
+            with self.assertRaisesRegex(RuntimeError, "rshift not implemented for 'Bool'"):
+                x >> y
+        else:
+            x << y
+            x >> y
+
+
 instantiate_device_type_tests(TestMeta, globals())
 
 def print_op_str_if_not_supported(op_str):

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -4210,18 +4210,30 @@ def meta_round(self, **kwargs):
 
 def shift_dtype_check(fn_name, self, val):
     torch._check(
-        utils.is_integer_dtype(self.dtype),
-        lambda: f"{fn_name}: Expected input tensor to have an integral dtype. Got {self.dtype}",
+        utils.is_integer_dtype(self.dtype) or utils.is_boolean_dtype(self.dtype),
+        lambda: f"{fn_name}: Expected input tensor to have an integral or boolean dtype. Got {self.dtype}",
     )
     if isinstance(val, torch.Tensor):
         torch._check(
-            utils.is_integer_dtype(val.dtype),
-            lambda: f"{fn_name}: Expected shift value to have an integral dtype. Got {val.dtype}",
+            utils.is_integer_dtype(val.dtype) or utils.is_boolean_dtype(val.dtype),
+            lambda: f"{fn_name}: Expected shift value to have an integral or boolean dtype. Got {val.dtype}",
+        )
+        torch._check(
+            not (
+                utils.is_boolean_dtype(self.dtype) and utils.is_boolean_dtype(val.dtype)
+            ),
+            lambda: f"{fn_name} not implemented for 'Bool'",
         )
     else:
         torch._check(
-            isinstance(val, IntLike),
-            lambda: f"{fn_name}: Expected shift value to be an int. Got {val}",
+            isinstance(val, utils.IntLike + utils.BoolLike),
+            lambda: f"{fn_name}: Expected shift value to be an int or bool. Got {val}",
+        )
+        torch._check(
+            not (
+                utils.is_boolean_dtype(self.dtype) and isinstance(val, utils.BoolLike)
+            ),
+            lambda: f"{fn_name} not implemented for 'Bool'",
         )
 
 


### PR DESCRIPTION
lshift and rshift allow one of argument to be bool, but not both. Meta op should follow the same rule.