### PR TITLE
[Fix] Adding missing `f` prefixes to formatted strings [3/N]

### DIFF
--- a/tools/jit/test/test_gen_unboxing.py
+++ b/tools/jit/test/test_gen_unboxing.py
@@ -53,7 +53,7 @@ class TestGenUnboxing(unittest.TestCase):
         temp_file.seek(0)
         args = [
             "--op-registration-allowlist=op1",
-            "--TEST-ONLY-op-registration-allowlist-yaml-path={temp_file.name}",
+            f"--TEST-ONLY-op-registration-allowlist-yaml-path={temp_file.name}",
             "--op-selection-yaml-path=path2",
         ]
         gen_unboxing.main(args)

--- a/tools/linter/adapters/pip_init.py
+++ b/tools/linter/adapters/pip_init.py
@@ -89,7 +89,7 @@ def main() -> None:
         package_name, _, version = package.partition("=")
         if version == "":
             raise RuntimeError(
-                "Package {package_name} did not have a version specified. "
+                f"Package {package_name} did not have a version specified. "
                 "Please specify a version to produce a consistent linting experience."
             )
 


### PR DESCRIPTION
As stated in the title.

* #164068
* __->__ #164067
* #164066
* #164065

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel