### PR TITLE
Draft: skip ignore_fresh_unbacked_symbols when applying views in _inplace_generalized_scatter to avoid PendingUnbackedSymbolNotFound error

### DIFF
--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1836,8 +1836,10 @@ def select(x, dim, idx):
             # Additionally, we want to avoid accidental unbacked unsqueeze semantics. To resolve this,
             # we use as_strided instead.
             # Removing this branch will cause test_unbacked_select_index_with_check to fail.
+            x.realize()
             new_size = x.get_size()
             new_stride = x.get_stride()
+
             new_storage_offset = x.get_layout().offset + new_stride[dim] * actual_index
 
             del new_size[dim]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #164090
* #164075

address two issues referenced bellow
still need to add tests. 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @Lucaskabela