### PR TITLE
always save expr in sympy_expr_tracker

### DIFF
--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -285,23 +285,7 @@ def set_proxy_slot(  # type: ignore[no-redef]
         assert isinstance(obj, py_sym_types), type(obj)
         if obj not in tracer.symnode_tracker:
             tracer.symnode_tracker[obj] = typing.cast(_PySymProxyType, proxy)
-
-            # WAR: python test/dynamo/test_subclasses.py
-            # TestNestedTensor.test_basic_autograd
-            #
-            # AOTAutograd doesn't pass the "outer sizes" as an actual argument
-            # to make_fx, but it is made use of internally in AOTAutograd's
-            # call to tensor unflatten.  Because the outer sizes isn't passed
-            # as an argument, it is therefore untracked.  However, it turns
-            # out you luck out, because *Dynamo* will manually add the outer
-            # sizes as an argument so you can fix up the proxy'ness.
-            #
-            # This is probably fixed in
-            # https://github.com/pytorch/pytorch/pull/125941/
-            import sympy
-
-            if isinstance(obj.node.expr, sympy.Symbol):
-                tracer.sympy_expr_tracker[obj.node.expr] = proxy
+            tracer.sympy_expr_tracker[obj.node.expr] = proxy
 
 
 def has_proxy_slot(obj: Tensor, tracer: _ProxyTracer) -> bool:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #164334
* #164284
* __->__ #164113
* #164210
* #164211
* #164209
* #164034

In certain cases, such as with tensor subclasses like dtensor, symnodes are created in create_aot_state and stored within the dtensor spec. However, since create_aot_state runs without proxy tensor tracing enabled, no thunked proxy is created at this stage. As a result, when execution reaches aot_stage1_graph_capture, errors occur in our new internal training library, for example:

```
RuntimeError: 202048*s81 (140026802016016) is not tracked with proxy for <torch.fx.experimental.proxy_tensor.PythonKeyTracer object at 0x7f5a505fce20>
Adding TORCHDYNAMO_VERBOSE=1 doesn't seem to give me more information.
```

This PR modifies the code so that we can now use sympy_expr_tracker to map symnodes created outside of proxy-traced contexts to their corresponding thunked proxies when operating in traced contexts.

I'm still not certain if this is the right long term fix, but this at least unblocks the internal high priority workstream that is blocked on this issue.

cc @ezyang @EikanWang @jgong5 @wenzhe-nrv