### PR TITLE
Change exported torch.sparse.solve to torch.sparse.spsolve

### DIFF
--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -32,7 +32,7 @@ __all__ = [
     "mm",
     "sum",
     "softmax",
-    "solve",
+    "spsolve",
     "log_softmax",
     "SparseSemiStructuredTensor",
     "SparseSemiStructuredTensorCUTLASS",


### PR DESCRIPTION
It is likely a typo to export `solve`. And indeed
```
import torch.sparse

a = torch.sparse.solve
```
failed with
```
Traceback (most recent call last):
  File "/home/cyy/a.py", line 3, in <module>
    a = torch.sparse.solve
        ^^^^^^^^^^^^^^^^^^
AttributeError: module 'torch.sparse' has no attribute 'solve'. Did you mean: 'spsolve'?
```