### PR TITLE
Skip test_conv3d_cudnn_broken on ROCM

### DIFF
--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -4084,6 +4084,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
         y = m.to(device=device)(x.to(device=device))
         self.assertEqual(yref, y)
 
+    @skipCUDAIfRocm
     @onlyCUDA
     @largeTensorTest("40GB", "cuda")
     def test_conv3d_cudnn_broken(self, device):


### PR DESCRIPTION
Followup after https://github.com/pytorch/pytorch/pull/163903  
Fixes https://github.com/pytorch/pytorch/issues/164137


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd