### PR TITLE
Add explicit dependency on ATen Headers when building FBGEMM_GENAI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -941,6 +941,8 @@ if(USE_FBGEMM)
 endif()
 
 if(USE_FBGEMM_GENAI)
+  # FBGEMM_GENAI depends on ATen headers generation
+  add_dependencies(fbgemm_genai ATEN_CPU_FILES_GEN_TARGET)
   string(APPEND CMAKE_CXX_FLAGS " -DUSE_FBGEMM_GENAI")
 endif()
 


### PR DESCRIPTION
FBGEMM_GENAI has a dependency on ATen headers being generated but currently there is no strict dependency setup, this ensures that they are sequenced to allow for correct parallel builds without failures on missing header files.

When running parallel builds there are failures like the following, which can be avoided by significantly reducing build parallelism.

```
In file included from $SRC_DIR/aten/src/ATen/core/List_inl.h:4,
                   from $SRC_DIR/aten/src/ATen/core/List.h:491,
                   from $SRC_DIR/aten/src/ATen/core/IListRef_inl.h:3,
                   from $SRC_DIR/aten/src/ATen/core/IListRef.h:631,
                   from $SRC_DIR/aten/src/ATen/DeviceGuard.h:3,
                   from $SRC_DIR/aten/src/ATen/ATen.h:9,
                   from $SRC_DIR/third_party/fbgemm/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/mx8mx8bf16_grouped/mx8mx8bf16_grouped_common.cuh:9,
                   from $SRC_DIR/third_party/fbgemm/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/mx8mx8bf16_grouped/mx8mx8bf16_grouped_256_128_256_2_1_1.cu:9:
  $SRC_DIR/aten/src/ATen/core/ivalue.h:4:10: fatal error: ATen/core/TensorBody.h: No such file or directory
      4 | #include <ATen/core/TensorBody.h>
        |          ^~~~~~~~~~~~~~~~~~~~~~~~
  compilation terminated.
  distcc[502846] ERROR: compile (null) on localhost failed
```
Adding the dependency will avoid this and allow us to increase parallelism. Note that this is a corner case as FBGEMM_GENAI is only installed in very specific cases: https://github.com/pytorch/pytorch/blob/84d673ef577d42d6ec20c6c9f09863583c3111f5/CMakeLists.txt#L904-L908