### PR TITLE
Clean up unexpected success in test_export_opinfo

### DIFF
--- a/test/export/test_export_opinfo.py
+++ b/test/export/test_export_opinfo.py
@@ -58,12 +58,6 @@ fake_export_failures = {
     xfail("to_sparse"),
     # cannot xfail as it is passing for cpu-only build
     skip("nn.functional.scaled_dot_product_attention"),
-    # following are failing due to OptionalDeviceGuard
-    xfail("__getitem__"),
-    xfail("nn.functional.batch_norm"),
-    xfail("nn.functional.instance_norm"),
-    xfail("nn.functional.multi_margin_loss"),
-    xfail("nonzero"),
 }
 
 fake_decomposition_failures = {


### PR DESCRIPTION
Summary: There tests show unexpected success locally. Remove xfail on them

Test Plan: buck2 run mode/dev-nosan caffe2/test:test_export -- -r TestExportOpInfo

Differential Revision: D83497892


