### PR TITLE
fix copy_ for scalar in inductor

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -10707,12 +10707,12 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
 
     def test_copy_with_scalar_src(self):
         def fn(x):
-            buffer = torch.zeros(2, device=x.device, dtype=x.dtype)
+            buffer = torch.zeros_like(x)
             buffer.copy_(2)
-            result = x + buffer[: x.shape[0]]
+            result = x + buffer
             return result
 
-        x = torch.randn(2, dtype=torch.float32, device=self.device)
+        x = torch.randn(64, 64, dtype=torch.float32, device=self.device)
         self.common(fn, (x,))
 
     def test_kwargs(self):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -10705,6 +10705,16 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         for x in (torch.randn(2, 3), torch.randn(2, 2), torch.randn(3, 2)):
             self.common(fn, (x,))
 
+    def test_copy_with_scalar_src(self):
+        def fn(x):
+            buffer = torch.zeros(2, device=x.device, dtype=x.dtype)
+            buffer.copy_(2)
+            result = x + buffer[: x.shape[0]]
+            return result
+
+        x = torch.randn(2, dtype=torch.float32, device=self.device)
+        self.common(fn, (x,))
+
     def test_kwargs(self):
         if self.device == GPU_TYPE:
             raise unittest.SkipTest("histogramdd only supports cpu")

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2955,6 +2955,8 @@ make_fallback(aten.repeat_interleave.Tensor, override_decomp=True)
 # For example, fp16.copy_(fp32) should **not** promote the first input's dtype.
 @register_lowering(aten.copy, type_promotion_kind=None)
 def copy(self, src, non_blocking=False):
+    if not isinstance(src, (TensorBox, ir.IRNode)):
+        src = tensor(src, dtype=self.get_dtype(), device=self.get_device())
     x = src
     if self.get_device() != src.get_device():
         x = to_device(x, self.get_device())

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2955,7 +2955,7 @@ make_fallback(aten.repeat_interleave.Tensor, override_decomp=True)
 # For example, fp16.copy_(fp32) should **not** promote the first input's dtype.
 @register_lowering(aten.copy, type_promotion_kind=None)
 def copy(self, src, non_blocking=False):
-    if not isinstance(src, (TensorBox, ir.IRNode)):
+    if not isinstance(src, ir.IRNode):
         src = tensor(src, dtype=self.get_dtype(), device=self.get_device())
     x = src
     if self.get_device() != src.get_device():


### PR DESCRIPTION
Fixes #158437 

### Summary

- TorchInductor was not properly handling scalar copy operations `(tensor.copy_(scalar_value))`
- Ensured scalar sources are converted to appropriate tensor representations with correct dtype and device

### Impact

- Enables compilation of models using ` tensor.copy_(scalar) `patterns
- module: inductor


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben