### PR TITLE
[export] Better state_dict and constant dedup in torch.export.save

### DIFF
--- a/torch/export/pt2_archive/_package_weights.py
+++ b/torch/export/pt2_archive/_package_weights.py
@@ -1,6 +1,7 @@
 import collections
 
 import torch
+from torch._subclasses.fake_tensor import FakeTensor
 from torch.utils._ordered_set import OrderedSet
 
 
@@ -14,22 +15,42 @@ def _end_ptr(tensor: torch.Tensor) -> int:
 
 class TensorProperties:
     def __init__(self, tensor: torch.Tensor):
-        # info about underlying storage
-        self.storage_ptr = tensor.untyped_storage().data_ptr()
-        self.storage_size = tensor.untyped_storage().nbytes()
+        self.is_fake = isinstance(tensor, FakeTensor)
+        self.is_contiguous = tensor.is_contiguous()
+        self.storage_ptr = None
+        self.storage_size = None
+        self.start = None
+        self.end = None
+
+        if not self.is_fake:
+            # only get the storage pointer for real tensors
+            self.storage_ptr = tensor.untyped_storage().data_ptr()
+            if self.is_contiguous:
+                # only get storage size and start/end pointers for contiguous tensors
+                self.storage_size = tensor.untyped_storage().nbytes()
+                self.start = tensor.data_ptr()
+                self.end = _end_ptr(tensor)
 
         # info to recover tensor
         self.shape = tensor.shape
         self.stride = tensor.stride()
         self.offset = tensor.storage_offset()
 
-        self.start = tensor.data_ptr()
-        self.end = _end_ptr(tensor)
-
     def is_complete(self) -> bool:
         """
         Whether the tensor completely overlaps with its underlying storage
         """
+        if self.is_fake:
+            # Theoretically, fake tensors should not appear in weights
+            # But we handle this corner case to make it always complete
+            return True
+        if not self.is_contiguous:
+            return False
+
+        assert self.storage_ptr is not None
+        assert self.storage_size is not None
+        assert self.start is not None
+        assert self.end is not None
         return (
             self.start == self.storage_ptr
             and self.end == self.storage_ptr + self.storage_size
@@ -79,6 +100,10 @@ def get_complete(
         tensor_property = get_tensor_properties(name_tuple)
         if tensor_property.is_complete():
             return name_tuple
+
+    if len(group) == 1:
+        # When there is only one tensor in the group, we return it.
+        return name_tuple
 
     raise RuntimeError("No complete tensor found in the group!")
 


### PR DESCRIPTION
Summary:

Previously, weight deduplication was done by simply grouping tensors with their untyped storage and saving the first tensor in the group.

A more rigorous approach would be to find a complete tensor that covers the storage and store that tensor. This is particularly important for GPU weights because when saving to raw bytes, we move the weight to CPU first, and if the weight being saved is not a complete one, it will lose the storage information during the copy to CPU.

In this diff, we reuse code in `_package_weights.py` for better weights and constants deduplication in `torch.export.save`.

Test Plan: buck2 run mode/dev-nosan caffe2/test:test_export -- -r test_weight_sharing_gpu

Differential Revision: D83523690


