### PR TITLE
[torchfuzz] remove erroneous can_produce check

### DIFF
--- a/tools/experimental/dynamic_shapes/torchfuzz/operators/tensor_pointwise.py
+++ b/tools/experimental/dynamic_shapes/torchfuzz/operators/tensor_pointwise.py
@@ -29,8 +29,6 @@ class PointwiseOperator(Operator):
 
     def can_produce(self, output_spec: Spec) -> bool:
         """Tensor pointwise operations can produce tensors but not scalars."""
-        if not super().can_produce(output_spec):
-            return False
         if isinstance(output_spec, TensorSpec) and output_spec.dtype == torch.bool:
             return False
         return isinstance(output_spec, TensorSpec)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #164284
* #164113
* #164210
* #164211
* __->__ #164209
* #164034

can_produce is an abstract method that always return false