### PR TITLE
[Inductor][triton] Shape propagation and tensor descriptor codegen fixes

### DIFF
--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -240,6 +240,7 @@ class CommonTemplate:
                     test_torchinductor.skip_if_triton_cpu("Triton CPU: slow test")
                 ],
             ),
+        ((64,), (64, ), None, None, True)
         ],
     )
     def test_pointwise(

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -240,7 +240,7 @@ class CommonTemplate:
                     test_torchinductor.skip_if_triton_cpu("Triton CPU: slow test")
                 ],
             ),
-        ((64,), (64, ), None, None, True)
+            ((64,), (64,), None, None, True),
         ],
     )
     def test_pointwise(

--- a/torch/_inductor/shape_propagation.py
+++ b/torch/_inductor/shape_propagation.py
@@ -1,6 +1,6 @@
 import functools
 from collections.abc import Sequence
-from typing import Callable, Optional, Protocol, Union
+from typing import Callable, cast, Optional, Protocol, Union
 
 import sympy
 
@@ -10,6 +10,16 @@ from .virtualized import OpsValue, V
 
 
 BlockShapeType = Optional[Sequence[Union[int, str]]]
+SymBlockShapeType = Optional[Sequence[Union[int, str, sympy.Expr]]]
+
+
+def cast_sym_block_shape(sym_block_shape: SymBlockShapeType) -> BlockShapeType:
+    shape = sym_block_shape
+    if shape is not None:
+        shape = tuple(
+            V.kernel.index_to_str(s) if isinstance(s, sympy.Expr) else s for s in shape
+        )
+    return cast(BlockShapeType, shape)
 
 
 class ShapeVar(Protocol):


### PR DESCRIPTION
Fixes:
- `BlockShapeType` is `Sequence[int, str]`, so convert `sympy.Expr` types that may appear (e.g. `indexing.final_shape`) in triton block shapes to `str` when creating the CSE variable
- `codegen_block_ptr_store_line`: only transpose if the block shape is atleast rank 2, and ensure sequence types match. Added a unit test for tensor descriptor matches for rank 1 tensors



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @chenyang78