### PR TITLE
Update compute elementwise output strides semantics

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -915,9 +915,9 @@ def forward(self, x_1):
             )
         )
 
-    def test_prims_non_overlapping_and_dense(self):
+    def test_is_non_overlapping_and_dense_or_false(self):
         shape_env = ShapeEnv()
-        cf = torch._prims_common.is_non_overlapping_and_dense
+        cf = torch._prims_common.is_non_overlapping_and_dense_or_false
 
         # backed case
         a0 = create_symint(shape_env, 5)

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -915,7 +915,7 @@ def forward(self, x_1):
             )
         )
 
-    def test_is_non_overlapping_and_dense_or_false(self):
+    def test_prims_is_non_overlapping_and_dense_or_false(self):
         shape_env = ShapeEnv()
         cf = torch._prims_common.is_non_overlapping_and_dense_or_false
 

--- a/torch/_inductor/freezing.py
+++ b/torch/_inductor/freezing.py
@@ -220,7 +220,9 @@ def enforce_output_layout(gm: torch.fx.GraphModule):
         for n in out_list:
             if not isinstance(
                 n.meta["val"], torch.Tensor
-            ) or not torch._prims_common.is_non_overlapping_and_dense_or_false(n.meta["val"]):
+            ) or not torch._prims_common.is_non_overlapping_and_dense_or_false(
+                n.meta["val"]
+            ):
                 continue
 
             # add a node to enforce eager layout

--- a/torch/_inductor/freezing.py
+++ b/torch/_inductor/freezing.py
@@ -220,7 +220,7 @@ def enforce_output_layout(gm: torch.fx.GraphModule):
         for n in out_list:
             if not isinstance(
                 n.meta["val"], torch.Tensor
-            ) or not torch._prims_common.is_non_overlapping_and_dense(n.meta["val"]):
+            ) or not torch._prims_common.is_non_overlapping_and_dense_or_false(n.meta["val"]):
                 continue
 
             # add a node to enforce eager layout

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1777,7 +1777,7 @@ class GraphLowering(torch.fx.Interpreter):
                     allow_padding = (
                         config.pad_outputs or not is_user_visible
                     ) and not is_input_for_as_strided
-                    dense = torch._prims_common.is_non_overlapping_and_dense(
+                    dense = torch._prims_common.is_non_overlapping_and_dense_or_false(
                         n.meta["val"]
                     )
                     unbacked_symbols_in_strides = (

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -693,12 +693,8 @@ def _clone_meta(
     else:
         # Match eager behavior by preserving strides for non_overlapping_and_dense tensors
         # If not, eager clone creates contiguous strides
-        computed_stride = None
-        if utils.is_non_overlapping_and_dense(input):
-            computed_stride = input.stride()
-        else:
-            computed_stride = utils.compute_elementwise_output_strides(input)
-
+        computed_stride = utils.compute_elementwise_output_strides(input)
+    
         return torch.empty_strided(
             input.shape,
             computed_stride,

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -694,7 +694,6 @@ def _clone_meta(
         # Match eager behavior by preserving strides for non_overlapping_and_dense tensors
         # If not, eager clone creates contiguous strides
         computed_stride = utils.compute_elementwise_output_strides(input)
-
         return torch.empty_strided(
             input.shape,
             computed_stride,

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -1946,7 +1946,7 @@ def _convert_element_type_meta(a: TensorLikeType, dtype: torch.dtype) -> TensorL
     assert isinstance(dtype, torch.dtype)
 
     # dtype conversion preserves dense strides
-    if torch._prims_common.is_non_overlapping_and_dense(a):
+    if torch._prims_common.is_non_overlapping_and_dense_or_false(a):
         strides = a.stride()
     else:
         strides = utils.compute_elementwise_output_strides(a)

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -694,7 +694,7 @@ def _clone_meta(
         # Match eager behavior by preserving strides for non_overlapping_and_dense tensors
         # If not, eager clone creates contiguous strides
         computed_stride = utils.compute_elementwise_output_strides(input)
-    
+
         return torch.empty_strided(
             input.shape,
             computed_stride,

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -666,6 +666,7 @@ def compute_elementwise_output_strides(*tensors) -> tuple[int, ...]:
     if len(tensors) == 0:
         msg = "Can't compute elementwise output strides for zero tensors!"
         raise ValueError(msg)
+    
 
     check_same_shape(*tensors, allow_cpu_scalar_tensors=True)
 
@@ -685,6 +686,10 @@ def compute_elementwise_output_strides(*tensors) -> tuple[int, ...]:
         return ()
     if ndim == 1:
         return (1,)
+    
+    if len(tensors) == 1:
+        if torch._prims_common.is_non_overlapping_and_dense(tensors[0]):
+            return tensors[0].stride()
 
     logical_to_physical_perm, _ = compute_elementwise_output_logical_to_physical_perm(
         *tensors, _skip_checks=True

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -666,7 +666,6 @@ def compute_elementwise_output_strides(*tensors) -> tuple[int, ...]:
     if len(tensors) == 0:
         msg = "Can't compute elementwise output strides for zero tensors!"
         raise ValueError(msg)
-    
 
     check_same_shape(*tensors, allow_cpu_scalar_tensors=True)
 
@@ -686,10 +685,11 @@ def compute_elementwise_output_strides(*tensors) -> tuple[int, ...]:
         return ()
     if ndim == 1:
         return (1,)
-    
-    if len(tensors) == 1:
-        if torch._prims_common.is_non_overlapping_and_dense_or_false(tensors[0]):
-            return tensors[0].stride()
+
+    if len(tensors) == 1 and torch._prims_common.is_non_overlapping_and_dense_or_false(
+        tensors[0]
+    ):
+        return tensors[0].stride()
 
     logical_to_physical_perm, _ = compute_elementwise_output_logical_to_physical_perm(
         *tensors, _skip_checks=True

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -686,10 +686,12 @@ def compute_elementwise_output_strides(*tensors) -> tuple[int, ...]:
     if ndim == 1:
         return (1,)
 
-    if len(tensors) == 1 and torch._prims_common.is_non_overlapping_and_dense_or_false(
-        tensors[0]
-    ):
-        return tensors[0].stride()
+    if len(tensors) == 1:
+        if torch._prims_common.is_non_overlapping_and_dense_or_false(tensors[0]):
+            return tensors[0].stride()
+        else:
+            empty_like_tensor = torch.empty_like(tensors[0])
+            return empty_like_tensor.stride()
 
     logical_to_physical_perm, _ = compute_elementwise_output_logical_to_physical_perm(
         *tensors, _skip_checks=True

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -518,7 +518,7 @@ def _is_non_overlapping_and_dense_or_false(sizes, strides) -> bool:
     return check_contiguous_sizes_strides(sizes, strides, false_if_dde=True)
 
 
-def is_non_overlapping_and_dense(a: Tensor) -> bool:
+def is_non_overlapping_and_dense_or_false(a: Tensor) -> bool:
     """
     True when a tensor is non-overlapping and dense.
 
@@ -688,7 +688,7 @@ def compute_elementwise_output_strides(*tensors) -> tuple[int, ...]:
         return (1,)
     
     if len(tensors) == 1:
-        if torch._prims_common.is_non_overlapping_and_dense(tensors[0]):
+        if torch._prims_common.is_non_overlapping_and_dense_or_false(tensors[0]):
             return tensors[0].stride()
 
     logical_to_physical_perm, _ = compute_elementwise_output_logical_to_physical_perm(


### PR DESCRIPTION
Continuation of work from https://github.com/pytorch/pytorch/pull/161400 and https://github.com/pytorch/pytorch/pull/163017. 

Updating stride semantics for ```clone_meta``` and underlying function, ```compute_elementwise_output_strides```. 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @chenyang78