### PR TITLE
Enable torch.nn.functional.batch_norm in test_export_opinfo

### DIFF
--- a/test/export/test_export_opinfo.py
+++ b/test/export/test_export_opinfo.py
@@ -131,7 +131,7 @@ instantiate_device_type_tests(TestExportOpInfo, globals(), only_for="cpu")
 
 selected_ops = {
     "__getitem__",
-    # "nn.functional.batch_norm",  # needs to fix
+    "nn.functional.batch_norm",
     "nn.functional.conv2d",
     "nn.functional.instance_norm",
     "nn.functional.multi_margin_loss",
@@ -157,49 +157,48 @@ from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from torch.utils import _pytree as pytree
 
 ops = [op for op in op_db if op.name == "{op.name}"]
-assert len(ops) == 1
-op = ops[0]
+assert len(ops) > 0
 
-sample_inputs_itr = op.sample_inputs("cpu", torch.float, requires_grad=False)
+for op in ops:
+    sample_inputs_itr = op.sample_inputs("cpu", torch.float, requires_grad=False)
 
-mode = FakeTensorMode(allow_non_fake_inputs=True)
-converter = mode.fake_tensor_converter
-# intentionally avoid cuda:0 to flush out some bugs
-target_device = "cuda:1"
+    mode = FakeTensorMode(allow_non_fake_inputs=True)
 
-def to_fake_device(x):
-    return x.to(target_device)
+    target_device = "cuda:0"
 
-# Limit to first 100 inputs so tests don't take too long
-for sample_input in itertools.islice(sample_inputs_itr, 100):
-    args = tuple([sample_input.input] + list(sample_input.args))
-    kwargs = sample_input.kwargs
+    def to_fake_device(x):
+        return x.to(target_device)
 
-    # hack to skip non-tensor in args, as export doesn't support it
-    if any(not isinstance(arg, torch.Tensor) for arg in args):
-        continue
+    # Limit to first 100 inputs so tests don't take too long
+    for sample_input in itertools.islice(sample_inputs_itr, 100):
+        args = tuple([sample_input.input] + list(sample_input.args))
+        kwargs = sample_input.kwargs
 
-    if "device" in kwargs:
-        kwargs["device"] = target_device
+        # hack to skip non-tensor in args, as export doesn't support it
+        if any(not isinstance(arg, torch.Tensor) for arg in args):
+            continue
 
-    with mode:
-        args, kwargs = pytree.tree_map_only(
-            torch.Tensor, to_fake_device, (args, kwargs)
-        )
+        if "device" in kwargs:
+            kwargs["device"] = target_device
 
-        class Module(torch.nn.Module):
-            def forward(self, *args):
-                return op.op(*args, **kwargs)
+        with mode:
+            args, kwargs = pytree.tree_map_only(
+                torch.Tensor, to_fake_device, (args, kwargs)
+            )
 
-        m = Module()
+            class Module(torch.nn.Module):
+                def forward(self, *args):
+                    return op.op(*args, **kwargs)
 
-        ep = torch.export.export(m, args)
+            m = Module()
 
-        for node in ep.graph.nodes:
-            if node.op == "call_function":
-                fake_tensor = node.meta.get("val", None)
-                if isinstance(fake_tensor, FakeTensor):
-                    assert fake_tensor.device == torch.device(target_device)
+            ep = torch.export.export(m, args)
+
+            for node in ep.graph.nodes:
+                if node.op == "call_function":
+                    fake_tensor = node.meta.get("val", None)
+                    if isinstance(fake_tensor, FakeTensor):
+                        assert fake_tensor.device == torch.device(target_device)
 """
         r = (
             (


### PR DESCRIPTION
Summary: 
There are actually 2 `nn.functional.batch_norm` in op_db. See https://github.com/pytorch/pytorch/blob/main/torch/testing/_internal/common_methods_invocations.py#L16797-L16831

So previously the test failed at `assert len(ops)==1`

Test Plan: python test/export/test_export_opinfo.py TestExportOnFakeCudaCUDA

Differential Revision: D83581427


