### PR TITLE
Remove CompositeImplicitAutograd from _fused_rms_norm

### DIFF
--- a/aten/src/ATen/native/layer_norm.cpp
+++ b/aten/src/ATen/native/layer_norm.cpp
@@ -261,6 +261,14 @@ std::tuple<Tensor, Tensor, Tensor> math_native_layer_norm(
   return outputs;
 }
 
+std::tuple<Tensor, Tensor> _rms_norm_composite(
+    const Tensor& input,
+    IntArrayRef normalized_shape,
+    const std::optional<Tensor>& weight_opt /* optional */,
+    std::optional<double> eps) {
+  return rms_norm_composite(input, normalized_shape, weight_opt, eps);
+}
+
 std::tuple<Tensor, Tensor> rms_norm_composite(
     const Tensor& input,
     IntArrayRef normalized_shape,

--- a/aten/src/ATen/native/layer_norm.cpp
+++ b/aten/src/ATen/native/layer_norm.cpp
@@ -370,7 +370,11 @@ Tensor rms_norm_symint(
     return std::get<0>(rms_norm_composite(input, IntArrayRef(reinterpret_cast<const int64_t*>(normalized_shape.data()), normalized_shape.size()), weight_opt, eps));
   }
   #endif
-  return std::get<0>(at::_fused_rms_norm(input, IntArrayRef(reinterpret_cast<const int64_t*>(normalized_shape.data()), normalized_shape.size()), weight_opt, eps));
+  if (input.device.type() == DeviceType::CUDA) {
+    return std::get<0>(at::_fused_rms_norm(input, IntArrayRef(reinterpret_cast<const int64_t*>(normalized_shape.data()), normalized_shape.size()), weight_opt, eps));
+  } else {
+    return std::get<0>(rms_norm_composite(input, IntArrayRef(reinterpret_cast<const int64_t*>(normalized_shape.data()), normalized_shape.size()), weight_opt, eps));
+  }
 }
 
 } // namespace at::native

--- a/aten/src/ATen/native/layer_norm.cpp
+++ b/aten/src/ATen/native/layer_norm.cpp
@@ -370,7 +370,7 @@ Tensor rms_norm_symint(
     return std::get<0>(rms_norm_composite(input, IntArrayRef(reinterpret_cast<const int64_t*>(normalized_shape.data()), normalized_shape.size()), weight_opt, eps));
   }
   #endif
-  if (input.device.type() == DeviceType::CUDA) {
+  if (input.device().type() == DeviceType::CUDA) {
     return std::get<0>(at::_fused_rms_norm(input, IntArrayRef(reinterpret_cast<const int64_t*>(normalized_shape.data()), normalized_shape.size()), weight_opt, eps));
   } else {
     return std::get<0>(rms_norm_composite(input, IntArrayRef(reinterpret_cast<const int64_t*>(normalized_shape.data()), normalized_shape.size()), weight_opt, eps));

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3334,6 +3334,8 @@
     MPS: _fused_rms_norm_mps
     CompositeImplicitAutograd: rms_norm_composite
 
+- func: _rms_norm_composite(Tensor input, int[] normalized_shape, Tensor? weight, float? eps) -> (Tensor, Tensor)
+
 - func: _fused_rms_norm_backward(Tensor grad_out, Tensor input, int[] normalized_shape, Tensor rstd, Tensor? weight, bool[2] output_mask) -> (Tensor, Tensor)
   dispatch:
     CUDA: _fused_rms_norm_backward_cuda

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3332,7 +3332,7 @@
   dispatch:
     CUDA: _fused_rms_norm_cuda
     MPS: _fused_rms_norm_mps
-    CompositeImplicitAutograd: rms_norm_composite
+    CompositeExplicitAutograd: rms_norm_composite
 
 - func: _rms_norm_composite(Tensor input, int[] normalized_shape, Tensor? weight, float? eps) -> (Tensor, Tensor)
 

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -7209,7 +7209,6 @@ metadata incorrectly.
         aot_eager = torch.compile(backend='aot_eager')(fn)(x)
         self.assertEqual(eager, aot_eager, atol=0, rtol=0)
 
-    @unittest.expectedFailure
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
     def test_rms_norm(self):
         # Only CUDA rms norm fails to be decomposed

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -28,6 +28,7 @@ from common_utils import (
 import torch
 import torch._dynamo as torchdynamo
 import torch.nn as nn
+import torch.nn.functional as F
 import torch.utils._pytree as pytree
 from functorch import grad, jacrev, make_fx, vjp, vmap
 from functorch.compile import (
@@ -101,7 +102,6 @@ from torch.testing._internal.optests import (
 from torch.testing._internal.subclasses import WrapperSubclass
 from torch.testing._internal.two_tensor import TwoTensor, TwoTensorMode
 from torch.utils._python_dispatch import TorchDispatchMode
-import torch.nn.functional as F
 
 
 USE_TORCHVISION = False
@@ -7206,7 +7206,7 @@ metadata incorrectly.
 
         x = torch.randn(2, 4, 8)
         eager = fn(x)
-        aot_eager = torch.compile(backend='aot_eager')(fn)(x)
+        aot_eager = torch.compile(backend="aot_eager")(fn)(x)
         self.assertEqual(eager, aot_eager, atol=0, rtol=0)
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
@@ -7215,9 +7215,9 @@ metadata incorrectly.
         def fn(x):
             return F.rms_norm(x, normalized_shape=(8,))
 
-        x = torch.randn(2, 4, 8, device='cuda')
+        x = torch.randn(2, 4, 8, device="cuda")
         eager = fn(x)
-        aot_eager = torch.compile(backend='aot_eager')(fn)(x)
+        aot_eager = torch.compile(backend="aot_eager")(fn)(x)
         self.assertEqual(eager, aot_eager, atol=0, rtol=0)
 
     def test_subclass_parameters(self):

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1749,7 +1749,7 @@ def native_layer_norm_backward_out(
 
 @register_decomposition(aten._fused_rms_norm.default)
 def _fused_rms_norm(input, normalized_shape, weight, float):
-    return torch.ops.aten.rms_norm_composite(input, normalized_shape, weight, float)
+    return torch.ops.aten._rms_norm_composite(input, normalized_shape, weight, float)
 
 
 @register_decomposition(aten._fused_rms_norm_backward.default)

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1747,6 +1747,11 @@ def native_layer_norm_backward_out(
     return grad_input
 
 
+@register_decomposition(aten._fused_rms_norm.default)
+def _fused_rms_norm(input, normalized_shape, weight, float):
+    return torch.ops.aten.rms_norm_composite(input, normalized_shape, weight, float)
+
+
 @register_decomposition(aten._fused_rms_norm_backward.default)
 def _fused_rms_norm_backward(
     grad_out: Tensor,

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -88,6 +88,7 @@ inductor_decompositions = get_decompositions(
         aten.native_batch_norm,
         aten.native_group_norm,
         aten.native_layer_norm,
+        aten._fused_rms_norm,
         aten.nll_loss2d_backward,
         aten.permute_copy,
         aten.rrelu_with_noise_backward,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #164289
* #164280

The failure of bitwise equivalence is because aot_eager decomposes rms_norm. The decomposition occurs from Functionalize, because CompositeImplicitAutograd registrations will fill the Functionalize entry, which performs a decomposition (even though we had an explicit autograd formula and can go to the fused implementation directly).

This PR takes the approach of just removing the CompositeImplicitAutograd from the entry entirely, since it is not being used by out-of-tree backends (it was just a technical trick when fused RMS norm originally landed). An alternative approach would be to ensure we don't register CompositeImplicitAutograd to Functionalize, but this is tricky, as to register here or not needs to be done on a per-backend basis (since some backends DO decompose and we want to decompose in functionalize too), but we cannot do this because Functionalize is not a per-backend key.

Some more history: https://github.com/pytorch/pytorch/pull/103275

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben