### PR TITLE
Enable keep-going for trunk tags

### DIFF
--- a/.github/scripts/filter_test_configs.py
+++ b/.github/scripts/filter_test_configs.py
@@ -502,6 +502,7 @@ def perform_misc_tasks(
     job_name: str,
     pr_body: str,
     branch: Optional[str] = None,
+    tag: Optional[str] = None,
 ) -> None:
     """
     In addition to apply the filter logic, the script also does the following
@@ -509,7 +510,9 @@ def perform_misc_tasks(
     """
     set_output(
         "keep-going",
-        branch == MAIN_BRANCH or check_for_setting(labels, pr_body, "keep-going"),
+        branch == MAIN_BRANCH
+        or bool(tag and re.match(r"^trunk/[a-f0-9]{40}$", tag))
+        or check_for_setting(labels, pr_body, "keep-going"),
     )
     set_output(
         "ci-verbose-test-logs",
@@ -634,6 +637,7 @@ def main() -> None:
         job_name=args.job_name,
         pr_body=pr_body if pr_body else "",
         branch=args.branch,
+        tag=tag,
     )
 
     # Set the filtered test matrix as the output


### PR DESCRIPTION
Tags like `trunk/{sha}` are used to re-run signals by [autorevert project](https://github.com/pytorch/test-infra/blob/main/aws/lambda/pytorch-auto-revert/README.md).

We need to have `keep-going` enabled for those reruns, so that they surface all test failures, not just the first one.