### PR TITLE
Add python bindings for NCCL CTA policies

### DIFF
--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -3366,6 +3366,22 @@ options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
             return ::c10d::getNcclVersionTuple();
           });
 
+#ifdef NCCL_HAS_CTA_POLICY
+  processGroupNCCL
+#ifdef NCCL_CTA_POLICY_ZERO
+      // NCCL_CTA_POLICY_ZERO is available in NCCL versions >= 2.28
+      .def_property_readonly_static(
+          "NCCL_CTA_POLICY_ZERO",
+          [](py::object&) { return NCCL_CTA_POLICY_ZERO; })
+#endif // NCCL_CTA_POLICY_ZERO
+      .def_property_readonly_static(
+          "NCCL_CTA_POLICY_DEFAULT",
+          [](py::object&) { return NCCL_CTA_POLICY_DEFAULT; })
+      .def_property_readonly_static(
+          "NCCL_CTA_POLICY_EFFICIENCY",
+          [](py::object&) { return NCCL_CTA_POLICY_EFFICIENCY; });
+#endif // NCCL_HAS_CTA_POLICY
+
   module.def(
       "_get_intra_node_comm_usage_counter",
       &::c10d::intra_node_comm::getIntraNodeCommUsageCounter);

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -3367,19 +3367,17 @@ options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
           });
 
 #ifdef NCCL_HAS_CTA_POLICY
-  processGroupNCCL
-#ifdef NCCL_CTA_POLICY_ZERO
-      // NCCL_CTA_POLICY_ZERO is available in NCCL versions >= 2.28
-      .def_property_readonly_static(
-          "NCCL_CTA_POLICY_ZERO",
-          [](py::object&) { return NCCL_CTA_POLICY_ZERO; })
+  processGroupNCCL.def_property_readonly_static(
+      "NCCL_CTA_POLICY_DEFAULT",
+      [](const py::object&) { return NCCL_CTA_POLICY_DEFAULT; });
+  processGroupNCCL.def_property_readonly_static(
+      "NCCL_CTA_POLICY_EFFICIENCY",
+      [](const py::object&) { return NCCL_CTA_POLICY_EFFICIENCY; });
+#ifdef NCCL_CTA_POLICY_ZERO // requires NCCL version >= 2.28
+  processGroupNCCL.def_property_readonly_static(
+      "NCCL_CTA_POLICY_ZERO",
+      [](const py::object&) { return NCCL_CTA_POLICY_ZERO; });
 #endif // NCCL_CTA_POLICY_ZERO
-      .def_property_readonly_static(
-          "NCCL_CTA_POLICY_DEFAULT",
-          [](py::object&) { return NCCL_CTA_POLICY_DEFAULT; })
-      .def_property_readonly_static(
-          "NCCL_CTA_POLICY_EFFICIENCY",
-          [](py::object&) { return NCCL_CTA_POLICY_EFFICIENCY; });
 #endif // NCCL_HAS_CTA_POLICY
 
   module.def(


### PR DESCRIPTION
NCCLConfig can now be constructed with non-default [cta policies][1]

```python
import torch
from torch.distributed import ProcessGroupNCCL as nccl

config = nccl.NCCLConfig()
config.cta_policy = nccl.NCCL_CTA_POLICY_ZERO  # NCCL version >= 2.28
```

[1]: https://docs.nvidia.com/deeplearning/nccl/archives/nccl_2283/user-guide/docs/api/flags.html#nccl-communicator-cta-policy-flags


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci