### PR TITLE
Add stack trace to kineto trace for aot_eager

### DIFF
--- a/torch/fx/config.py
+++ b/torch/fx/config.py
@@ -1,6 +1,10 @@
+import os
+
 # Whether to disable showing progress on compilation passes
 # Need to add a new config otherwise will get a circular import if dynamo config is imported here
 disable_progress = True
 
 # If True this also shows the node names in each pass, for small models this is great but larger models it's quite noisy
 verbose_progress = False
+
+profiler_interpreter_stack_trace = os.environ.get("TORCH_PROFILE_INTERPRETER_STACK_TRACE", "0") == "1"


### PR DESCRIPTION
Current approach:

- we add a "stack_trace" metadata to the profiler at the end of each Interpreter run via `torch.autograd._add_metadata_json`.  The key is node name and the value is the stack trace
- After the stack trace is produced, we modify attach the stack trace information to it.



We can't directly modify the profiler output (instead of exporting to json and then loading it back),  because the profiler result is stored as a list of `KinetoEvent` and I don't see any method exposed to modify `KinetoEvent` in python. 


How to use it:

```
import torch
import torch.profiler
import json
from torch.fx.traceback import populate_stack_traces_to_kineto_trace

def fn(x):
    x = torch.relu(x) 
    return x + 2

compiled_fn = torch.compile(fn, backend="aot_eager")
x = torch.randn(10, 10, requires_grad=True)


with torch.profiler.profile(
    activities=[torch.profiler.ProfilerActivity.CPU],
    schedule=torch.profiler.schedule(wait=1, warmup=1, active=3, repeat=1),
) as prof:
    for step in range(6):
        y = compiled_fn(x)

        loss = y.sum()

        loss.backward()

        x.grad.zero_()

        prof.step()


prof.export_chrome_trace("trace.json")
populate_stack_traces_to_kineto_trace("trace.json")

```