### PR TITLE
Stable IValue FC/BC PoC (newer extension older libtorch)

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -1028,22 +1028,8 @@ struct TORCH_API IValue final {
   at::Generator toGenerator() const&;
 
   // Dummy - use v2_9 as the current version
-  IValue(const dummy_types::v2_9::Dummy& d) : tag(Tag::Dummy) {
-    payload.u.as_dummy.foo = d.get_foo();
-    payload.u.as_dummy.id = d.get_id();
-  }
-
-  bool isDummy() const {
-    return Tag::Dummy == tag;
-  }
-
-  dummy_types::v2_9::Dummy toDummy() const {
-    AT_ASSERT(isDummy());
-    return dummy_types::v2_9::Dummy(
-        payload.u.as_dummy.foo, payload.u.as_dummy.id);
-  }
-
-  // IValue(const dummy_types::v2_8::Dummy& d) : tag(Tag::Dummy) {
+  // IValue(const dummy_types::v2_9::Dummy& d) : tag(Tag::Dummy) {
+  //   payload.u.as_dummy.foo = d.get_foo();
   //   payload.u.as_dummy.id = d.get_id();
   // }
 
@@ -1051,11 +1037,25 @@ struct TORCH_API IValue final {
   //   return Tag::Dummy == tag;
   // }
 
-  // dummy_types::v2_8::Dummy toDummy() const {
+  // dummy_types::v2_9::Dummy toDummy() const {
   //   AT_ASSERT(isDummy());
-  //   return dummy_types::v2_8::Dummy(
-  //       payload.u.as_dummy.id);
+  //   return dummy_types::v2_9::Dummy(
+  //       payload.u.as_dummy.foo, payload.u.as_dummy.id);
   // }
+
+  IValue(const dummy_types::v2_8::Dummy& d) : tag(Tag::Dummy) {
+    payload.u.as_dummy.id = d.get_id();
+  }
+
+  bool isDummy() const {
+    return Tag::Dummy == tag;
+  }
+
+  dummy_types::v2_8::Dummy toDummy() const {
+    AT_ASSERT(isDummy());
+    return dummy_types::v2_8::Dummy(
+        payload.u.as_dummy.id);
+  }
 
   // for debugging
   std::string tagKind() const {

--- a/test/cpp_extensions/dummy_type_test_extension/dummy_type_test/csrc/test_extension.cpp
+++ b/test/cpp_extensions/dummy_type_test_extension/dummy_type_test/csrc/test_extension.cpp
@@ -14,6 +14,9 @@ using torch::stable::Tensor;
 // with it
 Tensor test_fn_impl(const Tensor& a, const dummy_types::Dummy& b) {
   int32_t id_value = b.get_id();
+  int8_t foo = b.get_foo();
+
+  STD_TORCH_CHECK(static_cast<int32_t>(foo) == 1, "foo must be 1");
 
   Tensor result = torch::stable::empty_like(a);
   torch::stable::fill_(result, static_cast<double>(id_value));

--- a/test/cpp_extensions/dummy_type_test_extension/test_dummy_type.py
+++ b/test/cpp_extensions/dummy_type_test_extension/test_dummy_type.py
@@ -46,7 +46,7 @@ if not IS_WINDOWS:
             inp = torch.empty((2, 3))
             dummy = dummy_type_test.ops.create_dummy(inp)
             self.assertTrue(dummy.id == 42)
-            self.assertTrue(dummy.foo == 1)
+            self.assertFalse(hasattr(dummy, "foo"))
 
 
 if __name__ == "__main__":

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -2785,24 +2785,24 @@ Call this whenever a new thread is created in order to propagate values from
 #ifdef USE_KINETO
   torch::global_kineto_init();
 #endif
-  py::class_<dummy_types::v2_9::Dummy>(py_module, "_Dummy")
+  // py::class_<dummy_types::v2_9::Dummy>(py_module, "_Dummy")
+  //     .def(py::init<int32_t>(), py::arg("id"))
+  //     .def(py::init<int8_t, int32_t>(), py::arg("foo"), py::arg("id"))
+  //     .def("get_foo", &dummy_types::v2_9::Dummy::get_foo)
+  //     .def("get_id", &dummy_types::v2_9::Dummy::get_id)
+  //     .def_readwrite("foo", &dummy_types::v2_9::Dummy::foo)
+  //     .def_readwrite("id", &dummy_types::v2_9::Dummy::id)
+  //     .def("__repr__", [](const dummy_types::v2_9::Dummy& d) {
+  //       return "Dummy(foo=" + std::to_string(d.get_foo()) +
+  //           ", id=" + std::to_string(d.get_id()) + ")";
+  //     });
+  py::class_<dummy_types::v2_8::Dummy>(py_module, "_Dummy")
       .def(py::init<int32_t>(), py::arg("id"))
-      .def(py::init<int8_t, int32_t>(), py::arg("foo"), py::arg("id"))
-      .def("get_foo", &dummy_types::v2_9::Dummy::get_foo)
-      .def("get_id", &dummy_types::v2_9::Dummy::get_id)
-      .def_readwrite("foo", &dummy_types::v2_9::Dummy::foo)
-      .def_readwrite("id", &dummy_types::v2_9::Dummy::id)
-      .def("__repr__", [](const dummy_types::v2_9::Dummy& d) {
-        return "Dummy(foo=" + std::to_string(d.get_foo()) +
-            ", id=" + std::to_string(d.get_id()) + ")";
+      .def("get_id", &dummy_types::v2_8::Dummy::get_id)
+      .def_readwrite("id", &dummy_types::v2_8::Dummy::id)
+      .def("__repr__", [](const dummy_types::v2_8::Dummy& d) {
+        return "Dummy(id=" + std::to_string(d.get_id()) + ")";
       });
-  // py::class_<dummy_types::v2_8::Dummy>(py_module, "_Dummy")
-  //   .def(py::init<int32_t>(), py::arg("id"))
-  //   .def("get_id", &dummy_types::v2_8::Dummy::get_id)
-  //   .def_readwrite("id", &dummy_types::v2_8::Dummy::id)
-  //   .def("__repr__", [](const dummy_types::v2_8::Dummy& d) {
-  //     return "Dummy(id=" + std::to_string(d.get_id()) + ")";
-  //   });
 
   auto nativert_module = py_module.def_submodule("_nativert");
   torch::nativert::initModelRunnerPybind(nativert_module);

--- a/torch/csrc/api/include/torch/version.h.in
+++ b/torch/csrc/api/include/torch/version.h.in
@@ -4,7 +4,7 @@
 #define TORCH_VERSION_MAJOR @TORCH_VERSION_MAJOR@
 
 /// Indicates the minor version of LibTorch.
-#define TORCH_VERSION_MINOR @TORCH_VERSION_MINOR@
+#define TORCH_VERSION_MINOR 8
 
 /// Indicates the patch version of LibTorch.
 #define TORCH_VERSION_PATCH @TORCH_VERSION_PATCH@

--- a/torch/csrc/stable/library.h
+++ b/torch/csrc/stable/library.h
@@ -82,7 +82,7 @@ class StableLibrary final {
 //    [stable_ret1, stable_ret2, -, -]
 
 // Uncomment this to pretend extension built against old version
-#ifdef FAKE_TORCH_VERSION
+#ifndef FAKE_TORCH_VERSION
 #define FAKE_VERSION                                              \
   (((0ULL + 2) << 56) | ((0ULL + 8) << 48) | ((0ULL + 0) << 40) | \
    ((0ULL + 0) << 0))

--- a/torch/csrc/stable/stableivalue_conversions.h
+++ b/torch/csrc/stable/stableivalue_conversions.h
@@ -228,7 +228,7 @@ struct FromImpl<torch::stable::Tensor> {
 // This demonstrates version-aware conversion where we encode differently based
 // on version
 
-#ifdef FAKE_TORCH_VERSION
+#ifndef FAKE_TORCH_VERSION
 template <>
 struct FromImpl<dummy_types::v2_8::Dummy> {
   static StableIValue call(
@@ -429,7 +429,7 @@ struct ToImpl<torch::stable::Tensor> {
 // DUMMY TYPE TO-CONVERSIONS (DEMONSTRATION OF VERSION-AWARE CONVERSIONS)
 // =============================================================================
 
-#ifdef FAKE_TORCH_VERSION
+#ifndef FAKE_TORCH_VERSION
 template <>
 struct ToImpl<dummy_types::v2_8::Dummy> {
   static dummy_types::v2_8::Dummy call(

--- a/torch/headeronly/dummy.h
+++ b/torch/headeronly/dummy.h
@@ -7,7 +7,7 @@ namespace dummy_types {
 // This ifdef is just to ease testing, if a type in headeronly were to be
 // updated we would inline the namespace corresponding to the new version
 // (e.g. v2_9) and not inline the old one (e.g. v2_8).
-#ifdef FAKE_TORCH_VERSION
+#ifndef FAKE_TORCH_VERSION
 inline
 #endif
     namespace v2_8 {
@@ -23,7 +23,7 @@ struct Dummy {
 };
 } // namespace v2_8
 
-#ifndef FAKE_TORCH_VERSION
+#ifdef FAKE_TORCH_VERSION
 inline
 #endif
     namespace v2_9 {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #164376
* #163832
* #163683
* #164356

(1) Extension --> Libtorch
```
C++ Dummy created by extension
↓ from() (2.9 ext) (passes 2.8 Dummy)
StableIValue
↓ to_ivalue() (calls _to() which reads 2.8 Dummy) (2.8 libtorch)
IValue
```

(2) Libtorch --> Extension
```
Legacy 2.8 python Dummy created by libtorch
↓ existing libtorch IValue logic
IValue
↓ from_ivalue() (calls _from() 2.8 libtorch)
StableIValue
↓ to (2.9 extension handles conversion from 2.8 to 2.9 Dummy)
2.9 Dummy
```

