### PR TITLE
Skip grouped_gemm_compiled on Spark

### DIFF
--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -21,6 +21,7 @@ from torch.testing._internal.common_cuda import (
     SM100OrLater,
     xfailIfSM120OrLater,
     _get_torch_cuda_version,
+    IS_SM121,
 )
 from torch.testing._internal.common_device_type import (
     dtypes,
@@ -492,6 +493,7 @@ class TestMatmulCuda(InductorTestCase):
     @unittest.skipIf(TEST_WITH_ROCM, "ROCm doesn't support CUTLASS")
     # TODO(future PR): enable compile for torch._grouped_mm fallback path
     @unittest.skipIf(not SM90OrLater, "Grouped gemm with compile supported on SM90")
+    @unittest.skipIf(IS_SM121, "Grouped gemm with compile not supported on SM121")
     @parametrize("op", ["2d/2d", "2d/3d", "3d/2d", "3d/3d"])
     @parametrize("a_row_major", [False, True])
     @parametrize("b_row_major", [False, True])

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -42,6 +42,7 @@ IS_JETSON = LazyVal(lambda: torch.cuda.is_available() and (torch.cuda.get_device
 IS_SM89 = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability() == (8, 9))
 IS_SM90 = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability() == (9, 0))
 IS_SM100 = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability() == (10, 0))
+IS_SM121 = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability() == (12, 1))
 
 def evaluate_gfx_arch_within(arch_list):
     if not torch.cuda.is_available():


### PR DESCRIPTION
skipped grouped_gemm_compiled on Spark as it is failing on nvidia internal CI

cc @Aidyn-A @nWEIdia @eqy 