### PR TITLE
Improve efficiency of at::float32Precision APIs

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -77,7 +77,7 @@ std::pair<detail::Float32Backend, detail::Float32Op> check_fp32_prec_backend_and
   return std::make_pair(result_backend, detail::Float32Op(op_it - operators.begin()));
 }
 
-constexpr std::array<std::string_view, 4> float32_precision_strs = {"ieee", "tf32", "bf16", "none"};
+constexpr std::array<std::string_view, 4> float32_precision_strs = {"none", "ieee", "tf32", "bf16"};
 
 std::string_view fp32_prec_to_str(detail::Float32Precision prec) {
   return float32_precision_strs.at(static_cast<int>(prec));

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -41,7 +41,7 @@ enum class TORCH_API Float32MatmulPrecision { HIGHEST, HIGH, MEDIUM };
 namespace detail {
 enum class Float32Backend { GENERIC, MKLDNN, CUDA };
 enum class Float32Op { MATMUL, CONV, RNN, ALL };
-enum class Float32Precision { IEEE, TF32, BF16, NONE };
+enum class Float32Precision { NONE, IEEE, TF32, BF16 };
 } // namespace detail
 
 class TORCH_API Context {

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -2498,7 +2498,7 @@ Call this whenever a new thread is created in order to propagate values from
 
   py_module.def(
       "_get_fp32_precision_getter",
-      [](const std::string& backend, const std::string& op) {
+      [](std::string_view backend, std::string_view op) {
         return at::globalContext().float32Precision(backend, op);
       });
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #164387

I saw this taking up 1% total time when profiling training in torchtitan with (requires Python 3.13+ for PYTHON_PERF_JIT_SUPPORT):

```
MASTER_PORT=3000 MASTER_ADDR=0.0.0.0 RANK=0 LOCAL_RANK=0 WORLD_SIZE=1 PYTHON_PERF_JIT_SUPPORT=1 perf record -m 1024  -D11500 -k 1 -g --call-graph dwarf python -m torchtitan.train --job.config-file ./torchtitan/models/llama3/tra
in_configs/debug_model.toml --compile.enable --training.steps 30 --compile.backend=aot_eager
```

It's a straightforward enough fix (should've used enums all along, IMO) so I went ahead and fixed it.