### PR TITLE
Fix FloorDiv should not generate non integer rationals (due to sympy bug)

### DIFF
--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -254,6 +254,45 @@ class TestIndexingSimplification(InductorTestCase):
             ms = benchmarker.benchmark_gpu(lambda: f(x))
             print(f"{ms=:.03f}")
 
+    def test_floordiv_div_sympy_is_integer_bug(self):
+        def foo(arg0, arg1, arg2, arg3, arg4, sentinel):
+            t0 = arg0
+            t1 = t0.reshape((28, 24, 3, 127))
+            t2 = t1.var(dim=2)
+            t3 = arg1
+            t4 = arg2
+            t5 = torch.nn.functional.embedding(
+                torch.clamp(t3, 0, t4.size(0) - 1).to(torch.long), t4
+            )
+            t6 = arg3
+            t7 = torch.nn.functional.pad(t6, [0, 1], mode="constant", value=0.0)
+            t8 = arg4
+            t9 = t8.sum(dim=1)
+            t10 = torch.baddbmm(t5, t7, t9)
+            t11 = torch.cat([t2, t10], dim=0)
+            output = t11 + sentinel
+            return output
+
+        arg0 = torch.rand(
+            [36, 7112, 1, 1], dtype=torch.bfloat16, device=GPU_TYPE, requires_grad=True
+        )
+        arg1 = torch.randint(0, 512, [30, 24], dtype=torch.int64, device=GPU_TYPE)
+        arg2 = torch.rand(
+            [512, 127], dtype=torch.bfloat16, device=GPU_TYPE, requires_grad=True
+        )
+        arg3 = torch.rand(
+            [30, 24, 15], dtype=torch.bfloat16, device=GPU_TYPE, requires_grad=True
+        )
+        arg4 = torch.rand(
+            [30, 4, 16, 127], dtype=torch.bfloat16, device=GPU_TYPE, requires_grad=True
+        )
+        sentinel = torch.tensor(
+            0.0, dtype=torch.bfloat16, device=GPU_TYPE, requires_grad=True
+        )
+        compiled_foo = torch.compile(foo, fullgraph=True, dynamic=True)
+        out_compiled = compiled_foo(arg0, arg1, arg2, arg3, arg4, sentinel)
+        out_compiled.sum().backward()
+
 
 class ExprPrinterTests(InductorTestCase):
     def test_print_pow(self):

--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -254,6 +254,7 @@ class TestIndexingSimplification(InductorTestCase):
             ms = benchmarker.benchmark_gpu(lambda: f(x))
             print(f"{ms=:.03f}")
 
+    @unittest.skipUnless(HAS_GPU, "Need GPU for this test")
     def test_floordiv_div_sympy_is_integer_bug(self):
         def foo(arg0, arg1, arg2, arg3, arg4, sentinel):
             t0 = arg0

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -1953,8 +1953,6 @@ class TestFloorDiv(TestCase):
         s14 = sympy.Symbol("s14", integer=True, positive=True)
         s37 = sympy.Symbol("s37", integer=True, positive=True)
 
-        print("Testing FloorDiv with complex symbolic expression...")
-
         inner_expr = FloorDiv(s14, 2016)
         middle_expr = (24 * s37 + 672) * inner_expr
         numerator = middle_expr + 21

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -1949,7 +1949,7 @@ class TestFloorDiv(TestCase):
                 TestFloorDiv.python_floordiv(x, y), TestFloorDiv.torch_floordiv(x, y)
             )
 
-    def test_floordiv_div_does_not_generate_non_int_rational1(self):
+    def test_floordiv_div_does_not_generate_non_int_rational(self):
         s14 = sympy.Symbol("s14", integer=True, positive=True)
         s37 = sympy.Symbol("s37", integer=True, positive=True)
 
@@ -1966,45 +1966,6 @@ class TestFloorDiv(TestCase):
         rationals = result.atoms(sympy.Rational)
         all_rationals_ints = all(r.q == 1 for r in rationals)
         self.assertTrue(all_rationals_ints)
-
-    def test_floordiv_div_does_not_generate_non_int_rational2(self):
-        def foo(arg0, arg1, arg2, arg3, arg4, sentinel):
-            t0 = arg0
-            t1 = t0.reshape((28, 24, 3, 127))
-            t2 = t1.var(dim=2)
-            t3 = arg1
-            t4 = arg2
-            t5 = torch.nn.functional.embedding(
-                torch.clamp(t3, 0, t4.size(0) - 1).to(torch.long), t4
-            )
-            t6 = arg3
-            t7 = torch.nn.functional.pad(t6, [0, 1], mode="constant", value=0.0)
-            t8 = arg4
-            t9 = t8.sum(dim=1)
-            t10 = torch.baddbmm(t5, t7, t9)
-            t11 = torch.cat([t2, t10], dim=0)
-            output = t11 + sentinel
-            return output
-
-        arg0 = torch.rand(
-            [36, 7112, 1, 1], dtype=torch.bfloat16, device="cuda", requires_grad=True
-        )
-        arg1 = torch.randint(0, 512, [30, 24], dtype=torch.int64, device="cuda")
-        arg2 = torch.rand(
-            [512, 127], dtype=torch.bfloat16, device="cuda", requires_grad=True
-        )
-        arg3 = torch.rand(
-            [30, 24, 15], dtype=torch.bfloat16, device="cuda", requires_grad=True
-        )
-        arg4 = torch.rand(
-            [30, 4, 16, 127], dtype=torch.bfloat16, device="cuda", requires_grad=True
-        )
-        sentinel = torch.tensor(
-            0.0, dtype=torch.bfloat16, device="cuda", requires_grad=True
-        )
-        compiled_foo = torch.compile(foo, fullgraph=True, dynamic=True)
-        out_compiled = compiled_foo(arg0, arg1, arg2, arg3, arg4, sentinel)
-        out_compiled.sum().backward()
 
     def test_floordiv_simplify(self):
         # Tests how we simplify or evaluate FloorDiv without free variables

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -1949,6 +1949,80 @@ class TestFloorDiv(TestCase):
                 TestFloorDiv.python_floordiv(x, y), TestFloorDiv.torch_floordiv(x, y)
             )
 
+    def test_floordiv_div_does_not_generate_non_int_rational1(self):
+        s14 = sympy.Symbol("s14", integer=True, positive=True)
+        s37 = sympy.Symbol("s37", integer=True, positive=True)
+
+        print("Testing FloorDiv with complex symbolic expression...")
+
+        # Build the numerator expression step by step
+        inner_expr = FloorDiv(s14, 2016)  # This creates a FloorDiv
+        middle_expr = (24 * s37 + 672) * inner_expr
+        numerator = middle_expr + 21
+        denominator = 22
+
+        print(f"Numerator: {numerator}")
+        print(f"Denominator: {denominator}")
+        result = FloorDiv(numerator, denominator)
+        print(sympy.srepr(result))
+        print(result.has(sympy.Rational))
+        rationals = result.atoms(sympy.Rational)
+        all_rationals_ints = all(r.q == 1 for r in rationals)
+        self.assertTrue(all_rationals_ints)
+
+    def test_floordiv_div_does_not_generate_non_int_rational2(self):
+        def foo(arg0, arg1, arg2, arg3, arg4, sentinel):
+            t0 = arg0  
+            t1 = t0.reshape(
+                (28, 24, 3, 127)
+            )  
+            t2 = t1.var(
+                dim=2
+            )  
+            t3 = arg1  
+            t4 = arg2 
+            t5 = torch.nn.functional.embedding(
+                torch.clamp(t3, 0, t4.size(0) - 1).to(torch.long), t4
+            )  
+            t6 = arg3 
+            t7 = torch.nn.functional.pad(
+                t6, [0, 1], mode="constant", value=0.0
+            )  
+            t8 = arg4 
+            t9 = t8.sum(
+                dim=1
+            ) 
+            t10 = torch.baddbmm(
+                t5, t7, t9
+            ) 
+            t11 = torch.cat(
+                [t2, t10], dim=0
+            ) 
+            output = t11 + sentinel 
+            return output
+
+        arg0 = torch.rand(
+            [36, 7112, 1, 1], dtype=torch.bfloat16, device="cuda", requires_grad=True
+        )  
+        arg1 = torch.randint(
+            0, 512, [30, 24], dtype=torch.int64, device="cuda"
+        )  
+        arg2 = torch.rand(
+            [512, 127], dtype=torch.bfloat16, device="cuda", requires_grad=True
+        ) 
+        arg3 = torch.rand(
+            [30, 24, 15], dtype=torch.bfloat16, device="cuda", requires_grad=True
+        ) 
+        arg4 = torch.rand(
+            [30, 4, 16, 127], dtype=torch.bfloat16, device="cuda", requires_grad=True
+        )  
+        sentinel = torch.tensor(
+            0.0, dtype=torch.bfloat16, device="cuda", requires_grad=True
+        )  
+        compiled_foo = torch.compile(foo, fullgraph=True, dynamic=True)
+        out_compiled = compiled_foo(arg0, arg1, arg2, arg3, arg4, sentinel)
+        out_compiled.sum().backward()
+
     def test_floordiv_simplify(self):
         # Tests how we simplify or evaluate FloorDiv without free variables
         shape_env = ShapeEnv()

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -1955,7 +1955,7 @@ class TestFloorDiv(TestCase):
 
         print("Testing FloorDiv with complex symbolic expression...")
 
-        inner_expr = FloorDiv(s14, 2016) 
+        inner_expr = FloorDiv(s14, 2016)
         middle_expr = (24 * s37 + 672) * inner_expr
         numerator = middle_expr + 21
         denominator = 22

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -1957,12 +1957,7 @@ class TestFloorDiv(TestCase):
         middle_expr = (24 * s37 + 672) * inner_expr
         numerator = middle_expr + 21
         denominator = 22
-
-        print(f"Numerator: {numerator}")
-        print(f"Denominator: {denominator}")
         result = FloorDiv(numerator, denominator)
-        print(sympy.srepr(result))
-        print(result.has(sympy.Rational))
         rationals = result.atoms(sympy.Rational)
         all_rationals_ints = all(r.q == 1 for r in rationals)
         self.assertTrue(all_rationals_ints)

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -1972,53 +1972,39 @@ class TestFloorDiv(TestCase):
 
     def test_floordiv_div_does_not_generate_non_int_rational2(self):
         def foo(arg0, arg1, arg2, arg3, arg4, sentinel):
-            t0 = arg0  
-            t1 = t0.reshape(
-                (28, 24, 3, 127)
-            )  
-            t2 = t1.var(
-                dim=2
-            )  
-            t3 = arg1  
-            t4 = arg2 
+            t0 = arg0
+            t1 = t0.reshape((28, 24, 3, 127))
+            t2 = t1.var(dim=2)
+            t3 = arg1
+            t4 = arg2
             t5 = torch.nn.functional.embedding(
                 torch.clamp(t3, 0, t4.size(0) - 1).to(torch.long), t4
-            )  
-            t6 = arg3 
-            t7 = torch.nn.functional.pad(
-                t6, [0, 1], mode="constant", value=0.0
-            )  
-            t8 = arg4 
-            t9 = t8.sum(
-                dim=1
-            ) 
-            t10 = torch.baddbmm(
-                t5, t7, t9
-            ) 
-            t11 = torch.cat(
-                [t2, t10], dim=0
-            ) 
-            output = t11 + sentinel 
+            )
+            t6 = arg3
+            t7 = torch.nn.functional.pad(t6, [0, 1], mode="constant", value=0.0)
+            t8 = arg4
+            t9 = t8.sum(dim=1)
+            t10 = torch.baddbmm(t5, t7, t9)
+            t11 = torch.cat([t2, t10], dim=0)
+            output = t11 + sentinel
             return output
 
         arg0 = torch.rand(
             [36, 7112, 1, 1], dtype=torch.bfloat16, device="cuda", requires_grad=True
-        )  
-        arg1 = torch.randint(
-            0, 512, [30, 24], dtype=torch.int64, device="cuda"
-        )  
+        )
+        arg1 = torch.randint(0, 512, [30, 24], dtype=torch.int64, device="cuda")
         arg2 = torch.rand(
             [512, 127], dtype=torch.bfloat16, device="cuda", requires_grad=True
-        ) 
+        )
         arg3 = torch.rand(
             [30, 24, 15], dtype=torch.bfloat16, device="cuda", requires_grad=True
-        ) 
+        )
         arg4 = torch.rand(
             [30, 4, 16, 127], dtype=torch.bfloat16, device="cuda", requires_grad=True
-        )  
+        )
         sentinel = torch.tensor(
             0.0, dtype=torch.bfloat16, device="cuda", requires_grad=True
-        )  
+        )
         compiled_foo = torch.compile(foo, fullgraph=True, dynamic=True)
         out_compiled = compiled_foo(arg0, arg1, arg2, arg3, arg4, sentinel)
         out_compiled.sum().backward()

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -1955,8 +1955,7 @@ class TestFloorDiv(TestCase):
 
         print("Testing FloorDiv with complex symbolic expression...")
 
-        # Build the numerator expression step by step
-        inner_expr = FloorDiv(s14, 2016)  # This creates a FloorDiv
+        inner_expr = FloorDiv(s14, 2016) 
         middle_expr = (24 * s37 + 672) * inner_expr
         numerator = middle_expr + 21
         denominator = 22

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -276,7 +276,7 @@ class FloorDiv(sympy.Function):
                 quotient_is_integer = None
                 if isinstance(quotient, sympy.Mul) and TorchVersion(
                     sympy.__version__
-                ) < TorchVersion("1.14.0"):
+                ) < TorchVersion("1.15.0"):
                     rationals = quotient.atoms(sympy.Rational)
                     all_rationals_ints = all(r.q == 1 for r in rationals)
                     quotient_is_integer = quotient.is_integer and all_rationals_ints

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -267,10 +267,8 @@ class FloorDiv(sympy.Function):
             terms = []
             for term in sympy.Add.make_args(base):
                 quotient = term / divisor
-                # Ok so (s14//2016)*(24 * s37 + 672)*(s14//2016)//22
-                # is Mul(Rational(1, 22), Add(Mul(Integer(24), Symbol('s37', integer=True, positive=True)), Integer(672)),
-                # Pow(floor(Mul(Rational(1, 2016), Symbol('s14', integer=True, positive=True))), Integer(2)))
-                # yet even though is_integer we do not want to allow quotients with rationals in the results!
+                # sympy can generate a quotient with (1/22)*.... such that quotient.is_integer is True
+                # FloorDiv should not allow that as output.
                 rationals = quotient.atoms(sympy.Rational)
                 all_rationals_ints = all(r.q == 1 for r in rationals)
                 if quotient.is_integer and all_rationals_ints:

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -20,6 +20,8 @@ from sympy.core.traversal import walk
 from sympy.printing.precedence import PRECEDENCE
 from sympy.utilities.iterables import sift
 
+from torch.torch_version import TorchVersion
+
 from .numbers import int_oo
 
 
@@ -272,7 +274,9 @@ class FloorDiv(sympy.Function):
                 # sympy can generate a quotient with (1/22)*.... such that quotient.is_integer is True
                 # FloorDiv should not allow that as output. see
                 quotient_is_integer = None
-                if isinstance(quotient, sympy.Mul) and sympy.__version__ < "1.14.0":
+                if isinstance(quotient, sympy.Mul) and TorchVersion(
+                    sympy.__version__
+                ) < TorchVersion("1.14.0"):
                     rationals = quotient.atoms(sympy.Rational)
                     all_rationals_ints = all(r.q == 1 for r in rationals)
                     quotient_is_integer = quotient.is_integer and all_rationals_ints

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -267,11 +267,19 @@ class FloorDiv(sympy.Function):
             terms = []
             for term in sympy.Add.make_args(base):
                 quotient = term / divisor
+
+                # This is a sympy bug fixed in https://github.com/sympy/sympy/pull/28442
                 # sympy can generate a quotient with (1/22)*.... such that quotient.is_integer is True
                 # FloorDiv should not allow that as output. see
-                rationals = quotient.atoms(sympy.Rational)
-                all_rationals_ints = all(r.q == 1 for r in rationals)
-                if quotient.is_integer and all_rationals_ints:
+                quotient_is_integer = None
+                if isinstance(quotient, sympy.Mul) and sympy.__version__ < "1.14.0":
+                    rationals = quotient.atoms(sympy.Rational)
+                    all_rationals_ints = all(r.q == 1 for r in rationals)
+                    quotient_is_integer = quotient.is_integer and all_rationals_ints
+                else:
+                    quotient_is_integer = quotient.is_integer
+
+                if quotient_is_integer:
                     terms.append(term)
                     quotients += quotient
 

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -268,7 +268,7 @@ class FloorDiv(sympy.Function):
             for term in sympy.Add.make_args(base):
                 quotient = term / divisor
                 # sympy can generate a quotient with (1/22)*.... such that quotient.is_integer is True
-                # FloorDiv should not allow that as output.
+                # FloorDiv should not allow that as output. see
                 rationals = quotient.atoms(sympy.Rational)
                 all_rationals_ints = all(r.q == 1 for r in rationals)
                 if quotient.is_integer and all_rationals_ints:
@@ -311,10 +311,6 @@ class ModularIndexing(sympy.Function):
     ) -> Optional[sympy.Basic]:
         if base == 0 or modulus == 1:
             return sympy.S.Zero
-        # if "/11" in str(base):
-        #     import fbvscode
-        #     fbvscode.set_trace()
-
         if (
             isinstance(base, sympy.Integer)
             and isinstance(divisor, sympy.Integer)

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -267,8 +267,13 @@ class FloorDiv(sympy.Function):
             terms = []
             for term in sympy.Add.make_args(base):
                 quotient = term / divisor
-
-                if quotient.is_integer:
+                # Ok so (s14//2016)*(24 * s37 + 672)*(s14//2016)//22
+                # is Mul(Rational(1, 22), Add(Mul(Integer(24), Symbol('s37', integer=True, positive=True)), Integer(672)),
+                # Pow(floor(Mul(Rational(1, 2016), Symbol('s14', integer=True, positive=True))), Integer(2)))
+                # yet even though is_integer we do not want to allow quotients with rationals in the results!
+                rationals = quotient.atoms(sympy.Rational)
+                all_rationals_ints = all(r.q == 1 for r in rationals)
+                if quotient.is_integer and all_rationals_ints:
                     terms.append(term)
                     quotients += quotient
 
@@ -308,6 +313,9 @@ class ModularIndexing(sympy.Function):
     ) -> Optional[sympy.Basic]:
         if base == 0 or modulus == 1:
             return sympy.S.Zero
+        # if "/11" in str(base):
+        #     import fbvscode
+        #     fbvscode.set_trace()
 
         if (
             isinstance(base, sympy.Integer)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #164398

FloorDiv eval have this optimization
```
  # Expands (x + y) // b into x // b + y // b.
  # This only works if floor is an identity, i.e. x / b is an integer.
 ```
 
 Before this PR this optimization would generate a result in an expression like this. Duo to a bug in sympy. 
 ```
Mul(Rational(1, 22), Add(Mul(Integer(24), Symbol('s37', integer=True, positive=True)), Integer(672)), FloorDiv(Mul(Symbol('s14', integer=True, positive=True), Symbol('s46', integer=True, positive=True)), Integer(2016)))
 ```
 
 This is because in sympy an expression can have .is_integer =True yet have 1/22 in it!
 This PR ensure we do not generate that by simply opting out if this optimization if we end 
 up with quotient that have such rational.
  
  Fix 
  https://github.com/pytorch/pytorch/issues/164385, 
  https://github.com/pytorch/pytorch/issues/154996
  https://github.com/pytorch/pytorch/issues/153375
  https://github.com/pytorch/pytorch/issues/164063
and internal user issue.
cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben