### PR TITLE
[doc infra] update docs dependencies

### DIFF
--- a/.ci/docker/requirements-docs.txt
+++ b/.ci/docker/requirements-docs.txt
@@ -24,4 +24,4 @@ beautifulsoup4==4.14.2
 python-etcd==0.4.5
 
 # For notebook examples which use torch.utils.cpp_extension
-ninja==1.13.0  
+ninja==1.13.0

--- a/.ci/docker/requirements-docs.txt
+++ b/.ci/docker/requirements-docs.txt
@@ -1,68 +1,27 @@
-sphinx==5.3.0
-#Description: This is used to generate PyTorch docs
-#Pinned versions: 5.3.0
-
-standard-imghdr==3.13.0; python_version >= "3.13"
-#Description: This is needed by Sphinx, so it needs to be added here.
-# The reasons are as follows:
-# 1) This module has been removed from the Python standard library since Python 3.13(https://peps.python.org/pep-0594/#imghdr);
-# 2) The current version of Sphinx (5.3.0) is not compatible with Python 3.13.
-# Once Sphinx is upgraded to a version compatible with Python 3.13 or later, we can remove this dependency.
-
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git@71e55749be14ceb56e7f8211a9fb649866b87ad4#egg=pytorch_sphinx_theme2
-# TODO: sphinxcontrib.katex 0.9.0 adds a local KaTeX server to speed up pre-rendering
-# but it doesn't seem to work and hangs around idly. The initial thought that it is probably
-# something related to Docker setup. We can investigate this later.
 
-sphinxcontrib.katex==0.8.6
-#Description: This is used to generate PyTorch docs
-#Pinned versions: 0.8.6
-
-sphinxext-opengraph==0.9.1
-#Description: This is used to generate PyTorch docs
-#Pinned versions: 0.9.1
-
-sphinx_sitemap==2.6.0
-#Description: This is used to generate sitemap for PyTorch docs
-#Pinned versions: 2.6.0
-
-matplotlib==3.5.3 ; python_version < "3.13"
-matplotlib==3.6.3 ; python_version >= "3.13"
-#Description: This is used to generate PyTorch docs
-#Pinned versions: 3.6.3 if python > 3.12. Otherwise 3.5.3.
-
-tensorboard==2.13.0 ; python_version < "3.13"
-tensorboard==2.18.0 ; python_version >= "3.13"
-#Description: This is used to generate PyTorch docs
-#Pinned versions: 2.13.0
-
-breathe==4.34.0
-#Description: This is used to generate PyTorch C++ docs
-#Pinned versions: 4.34.0
-
-exhale==0.2.3
-#Description: This is used to generate PyTorch C++ docs
-#Pinned versions: 0.2.3
-
-docutils==0.16
-#Description: This is used to generate PyTorch C++ docs
-#Pinned versions: 0.16
-
-bs4==0.0.1
-#Description: This is used to generate PyTorch C++ docs
-#Pinned versions: 0.0.1
-
-IPython==8.12.0
-#Description: This is used to generate PyTorch functorch docs
-#Pinned versions: 8.12.0
-
-myst-nb==0.17.2
-#Description: This is used to generate PyTorch functorch and torch.compile docs.
-#Pinned versions: 0.17.2
-
-# The following are required to build torch.distributed.elastic.rendezvous.etcd* docs
-python-etcd==0.4.5
-sphinx-copybutton==0.5.0
-sphinx-design==0.4.0
+sphinx==7.2.6
+sphinxcontrib-katex==0.9.11
+sphinx_sitemap==2.8.0
+sphinx-copybutton==0.5.2
+sphinx-design==0.6.1
 sphinxcontrib-mermaid==1.0.0
-myst-parser==0.18.1
+
+myst-parser==4.0.1
+myst-nb==1.3.0
+ipython==8.37.0
+matplotlib==3.10.6
+tensorboard==2.20.0
+numpy==2.2.6
+
+# Used to generate C++ docs
+docutils==0.20.1
+breathe==4.36.0
+exhale==0.3.7
+beautifulsoup4==4.14.2
+
+# For torch.distributed.elastic.rendezvous.etcd* docs
+python-etcd==0.4.5
+
+# For notebook examples which use torch.utils.cpp_extension
+ninja==1.13.0  

--- a/docs/source/_templates/classtemplate.rst
+++ b/docs/source/_templates/classtemplate.rst
@@ -3,9 +3,9 @@
 .. currentmodule:: {{ module }}
 
 
-{{ name | underline}}
+{{ fullname | underline}}
 
-.. autoclass:: {{ name }}
+.. autoclass:: {{ fullname }}
     :members:
 
 


### PR DESCRIPTION
1. Updates `.ci/docker/requirements-docs.txt`, which now uses a single set of dependencies which work for Python 3.10-3.13 (inclusive).
2. Removes `standard-imghdr` (no longer necessary with Sphinx 7.2.6).
3. Adds `ninja`, which is needed for some notebook examples which use `torch.utils.cpp_extension`.

Fixes #164010