### PR TITLE
[dynamo][logging] Add most recent bytecode to graph break with torch._dynamo.graph_break() and verbose

### DIFF
--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -1096,6 +1096,7 @@ Most recent bytecode instructions traced (max 20):
 
         pattern = r"TRACE.*"
         s = munge_exc(records[-1].getMessage(), skip=0)
+        breakpoint()
         matches = re.findall(pattern, s)
         self.assertIn(len(matches), [13, 20])
         # TODO: Checking inconsistent logging output

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -1140,17 +1140,17 @@ User code traceback:
 NOTE: the most recent `torch.compile` tracing attempt might not be where you applied `torch.compile`! This is due to how graph breaks are implemented - the optimized code object returned by Dynamo will call another Dynamo-generated resume function and tracing is re-enabled by calling the resume function as a normal Python function, which Dynamo intercepts as a top-level frame.
 Most recent bytecode instructions traced (max 20):
 TRACE RESUME 0 []
-TRACE LOAD_FAST x []
+TRACE LOAD_FAST 'x' []
 TRACE LOAD_CONST 1 [LazyVariableTracker()]
 TRACE BINARY_OP 0 [LazyVariableTracker(), ConstantVariable(int: 1)]
-TRACE STORE_FAST y [TensorVariable()]
-TRACE LOAD_FAST x []
-TRACE LOAD_FAST y [TensorVariable()]
+TRACE STORE_FAST 'y' [TensorVariable()]
+TRACE LOAD_FAST 'x' []
+TRACE LOAD_FAST 'y' [TensorVariable()]
 TRACE BINARY_OP 0 [TensorVariable(), TensorVariable()]
-TRACE STORE_FAST z [TensorVariable()]
-TRACE LOAD_GLOBAL torch []
-TRACE LOAD_ATTR _dynamo [LazyVariableTracker()]
-TRACE LOAD_ATTR graph_break [LazyVariableTracker()]
+TRACE STORE_FAST 'z' [TensorVariable()]
+TRACE LOAD_GLOBAL 'torch' []
+TRACE LOAD_ATTR '_dynamo' [LazyVariableTracker()]
+TRACE LOAD_ATTR 'graph_break' [LazyVariableTracker()]
 TRACE CALL 0 [NullVariable, LazyVariableTracker()]""",
         )
 

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -1085,7 +1085,6 @@ Most recent bytecode instructions traced (max 20):
     @torch._dynamo.config.patch(verbose=True)
     @make_logging_test(graph_breaks=True)
     def test_variable_tracker_bytecode_to_graph_break_fullgraph(self, records):
-        # def test_bytecode_graphbreak_fullgraph(self, x):
         def fn(x):
             y = x + 1
             z = x + y
@@ -1190,36 +1189,6 @@ TRACE CALL 0 [NullVariable, LazyVariableTracker()]""",
         # breakpoint()
         matches = re.findall(pattern, s)
         self.assertEqual(len(matches), 13)
-        # TODO: Checking inconsistent logging output
-
-        def post_munge(s):
-            s = re.sub(r"TRACE.*\n", "", s, flags=re.MULTILINE)
-            return re.sub(r"TRACE.*", "", s)
-
-        self.assertExpectedInline(
-            post_munge(s),
-            """\
-Graph break in user code at test_error_messages.py:N
-Graph Break Reason: Call to `torch._dynamo.graph_break()`
-  Explanation: User-inserted graph break. Message: None
-  Hint: Remove the `torch._dynamo.graph_break()` call.
-
-  Developer debug context: Called `torch._dynamo.graph_break()` with args `[]`, kwargs `{}`
-
- For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0025.html
-User code traceback:
-  File "test_error_messages.py", line N, in test_variable_tracker_bytecode_to_graph_break
-    fn(torch.ones(3))
-
-========== most recent `torch.compile` tracing attempt started here ==========
-
-  File "test_error_messages.py", line N, in fn
-    torch._dynamo.graph_break()
-
-NOTE: the most recent `torch.compile` tracing attempt might not be where you applied `torch.compile`! This is due to how graph breaks are implemented - the optimized code object returned by Dynamo will call another Dynamo-generated resume function and tracing is re-enabled by calling the resume function as a normal Python function, which Dynamo intercepts as a top-level frame.
-Most recent bytecode instructions traced (max 20):
-""",
-        )
 
     @torch._dynamo.config.patch(verbose=True)
     @make_logging_test(graph_breaks=True)

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -1097,9 +1097,6 @@ Most recent bytecode instructions traced (max 20):
         pattern = r"TRACE.*"
         s = munge_exc(records[-1].getMessage(), skip=0)
         matches = re.findall(pattern, s)
-        # The expected number of "TRACE" matches (13 and 20) depends on the Python version,
-        # as bytecode generation can differ between versions. These values are correct for
-        # currently supported Python versions. Update if bytecode changes in future versions.
         self.assertIn(len(matches), [13, 20])
 
         def post_munge(s):

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -1179,7 +1179,8 @@ TRACE CALL 0 [NullVariable, LazyVariableTracker()]""",
         s = munge_exc(records[0].getMessage(), skip=0)
         # breakpoint()
         matches = re.findall(pattern, s)
-        self.assertEqual(len(matches), 13)
+        self.assertEqual((len(matches) > 10), True)
+        self.assertEqual((len(matches) <= 20), True)
 
     @torch._dynamo.config.patch(verbose=True)
     @make_logging_test(graph_breaks=True)

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -1177,7 +1177,6 @@ TRACE CALL 0 [NullVariable, LazyVariableTracker()]""",
 
         pattern = r"TRACE.*"
         s = munge_exc(records[0].getMessage(), skip=0)
-        # breakpoint()
         matches = re.findall(pattern, s)
         self.assertEqual((len(matches) > 10), True)
         self.assertEqual((len(matches) <= 20), True)

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -1097,6 +1097,9 @@ Most recent bytecode instructions traced (max 20):
         pattern = r"TRACE.*"
         s = munge_exc(records[-1].getMessage(), skip=0)
         matches = re.findall(pattern, s)
+        # The expected number of "TRACE" matches (13 and 20) depends on the Python version,
+        # as bytecode generation can differ between versions. These values are correct for
+        # currently supported Python versions. Update if bytecode changes in future versions.
         self.assertIn(len(matches), [13, 20])
 
         def post_munge(s):

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -1189,7 +1189,7 @@ TRACE CALL 0 [NullVariable, LazyVariableTracker()]""",
         s = munge_exc(records[0].getMessage(), skip=0)
         # breakpoint()
         matches = re.findall(pattern, s)
-        self.assertIn(len(matches), [13, 20])
+        self.assertEqual(len(matches), 13)
         # TODO: Checking inconsistent logging output
 
         def post_munge(s):

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -773,6 +773,8 @@ from user code:
             return f
 
         def post_munge(s):
+            s = re.sub(r"TRACE.*\n", "", s, flags=re.MULTILINE)
+            s = re.sub(r"\nTRACE.*", "", s)
             return re.sub(r"0x[0-9A-Fa-f]+", "0xmem_addr", s)
 
         torch.compile(fn, backend="eager")()
@@ -795,7 +797,7 @@ User code traceback:
     torch.compile(fn, backend="eager")()
   File "test_error_messages.py", line N, in fn
     torch._dynamo.graph_break()
-""",
+Most recent bytecode instructions traced (max 20):""",
         )
 
         self.assertExpectedInline(
@@ -1015,6 +1017,7 @@ Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especiall
             "<Internal traceback>\n",
             msg,
         )
+        msg = re.sub(r"TRACE.*\n", "", msg, flags=re.MULTILINE)
         self.assertExpectedInline(
             msg,
             """\
@@ -1051,9 +1054,12 @@ from user code:
 
         torch.compile(fn, backend="eager")(torch.randn(3))
 
-        # check the log for the 2nd torch._dynamo.graph_break()
+        def post_munge(s):
+            s = re.sub(r"TRACE.*\n", "", s, flags=re.MULTILINE)
+            return re.sub(r"TRACE.*", "", s)
+
         self.assertExpectedInline(
-            munge_exc(records[-1].getMessage(), skip=0),
+            post_munge(munge_exc(records[-1].getMessage(), skip=0)),
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Call to `torch._dynamo.graph_break()`
@@ -1072,6 +1078,54 @@ User code traceback:
     hn(x + 1)
   File "test_error_messages.py", line N, in hn
     torch._dynamo.graph_break()  # 1
+Most recent bytecode instructions traced (max 20):
+""",
+        )
+
+    @torch._dynamo.config.patch(verbose=True)
+    @make_logging_test(graph_breaks=True)  # , bytecode=True)
+    def test_variable_tracker_bytecode_to_graph_break(self, records):
+        @torch.compile(backend="eager")
+        def fn(x):
+            y = x + 1
+            z = x + y
+            torch._dynamo.graph_break()
+            return z
+
+        fn(torch.ones(3))
+
+        pattern = r"TRACE.*"
+        s = munge_exc(records[-1].getMessage(), skip=0)
+        matches = re.findall(pattern, s)
+        self.assertIn(len(matches), [13, 20])
+
+        def post_munge(s):
+            s = re.sub(r"TRACE.*\n", "", s, flags=re.MULTILINE)
+            return re.sub(r"TRACE.*", "", s)
+
+        # check the log for the 2nd torch._dynamo.graph_break()
+        self.assertExpectedInline(
+            post_munge(s),
+            """\
+Graph break in user code at test_error_messages.py:N
+Graph Break Reason: Call to `torch._dynamo.graph_break()`
+  Explanation: User-inserted graph break. Message: None
+  Hint: Remove the `torch._dynamo.graph_break()` call.
+
+  Developer debug context: Called `torch._dynamo.graph_break()` with args `[]`, kwargs `{}`
+
+ For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0025.html
+User code traceback:
+  File "test_error_messages.py", line N, in test_variable_tracker_bytecode_to_graph_break
+    fn(torch.ones(3))
+
+========== most recent `torch.compile` tracing attempt started here ==========
+
+  File "test_error_messages.py", line N, in fn
+    torch._dynamo.graph_break()
+
+NOTE: the most recent `torch.compile` tracing attempt might not be where you applied `torch.compile`! This is due to how graph breaks are implemented - the optimized code object returned by Dynamo will call another Dynamo-generated resume function and tracing is re-enabled by calling the resume function as a normal Python function, which Dynamo intercepts as a top-level frame.
+Most recent bytecode instructions traced (max 20):
 """,
         )
 
@@ -1166,8 +1220,13 @@ NOTE: the most recent `torch.compile` tracing attempt might not be where you app
 
         f1(torch.randn(3))
 
+        def post_munge(s):
+            s = re.sub(r"TRACE.*\n", "", s, flags=re.MULTILINE)
+            s = re.sub(r"\nTRACE.*", "", s)
+            return s
+
         self.assertExpectedInline(
-            munge_exc(records[-1].getMessage(), skip=0),
+            post_munge(munge_exc(records[-1].getMessage(), skip=0)),
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Call to `torch._dynamo.graph_break()`
@@ -1186,7 +1245,7 @@ User code traceback:
     f3(x)
   File "test_error_messages.py", line N, in f3
     torch._dynamo.graph_break()  # correct
-""",
+Most recent bytecode instructions traced (max 20):""",
         )
 
     @make_logging_test(dynamo=logging.DEBUG)

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -1083,7 +1083,7 @@ Most recent bytecode instructions traced (max 20):
         )
 
     @torch._dynamo.config.patch(verbose=True)
-    @make_logging_test(graph_breaks=True)  # , bytecode=True)
+    @make_logging_test(graph_breaks=True)
     def test_variable_tracker_bytecode_to_graph_break(self, records):
         @torch.compile(backend="eager")
         def fn(x):
@@ -1098,12 +1098,12 @@ Most recent bytecode instructions traced (max 20):
         s = munge_exc(records[-1].getMessage(), skip=0)
         matches = re.findall(pattern, s)
         self.assertIn(len(matches), [13, 20])
+        # TODO: Checking inconsistent logging output
 
         def post_munge(s):
             s = re.sub(r"TRACE.*\n", "", s, flags=re.MULTILINE)
             return re.sub(r"TRACE.*", "", s)
 
-        # check the log for the 2nd torch._dynamo.graph_break()
         self.assertExpectedInline(
             post_munge(s),
             """\

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -1092,7 +1092,7 @@ User code traceback:
         self.assertIsNotNone(e)
         msg = "".join(traceback.format_exception(type(e), e, e.__traceback__))
         self.assertExpectedInline(
-            munge_exc(msg, suppress_suffix=True, skip=0),
+            munge_exc(msg, skip=0),
             """Traceback (most recent call last):
   File "test_error_messages.py", line N, in test_latest_bytecode_to_graph_break_fullgraph
     torch.compile(fn, backend="eager", fullgraph=True)(torch.ones(3))

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -1084,6 +1084,54 @@ Most recent bytecode instructions traced (max 20):
 
     @torch._dynamo.config.patch(verbose=True)
     @make_logging_test(graph_breaks=True)
+    def test_variable_tracker_bytecode_to_graph_break_fullgraph(self, records):
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x):
+            y = x + 1
+            z = x + y
+            torch._dynamo.graph_break()
+            return z
+
+        fn(torch.ones(3))
+
+        pattern = r"TRACE.*"
+        s = munge_exc(records[-1].getMessage(), skip=0)
+        breakpoint()
+        matches = re.findall(pattern, s)
+        self.assertIn(len(matches), [13, 20])
+        # TODO: Checking inconsistent logging output
+
+        def post_munge(s):
+            s = re.sub(r"TRACE.*\n", "", s, flags=re.MULTILINE)
+            return re.sub(r"TRACE.*", "", s)
+
+        self.assertExpectedInline(
+            post_munge(s),
+            """\
+Graph break in user code at test_error_messages.py:N
+Graph Break Reason: Call to `torch._dynamo.graph_break()`
+  Explanation: User-inserted graph break. Message: None
+  Hint: Remove the `torch._dynamo.graph_break()` call.
+
+  Developer debug context: Called `torch._dynamo.graph_break()` with args `[]`, kwargs `{}`
+
+ For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0025.html
+User code traceback:
+  File "test_error_messages.py", line N, in test_variable_tracker_bytecode_to_graph_break
+    fn(torch.ones(3))
+
+========== most recent `torch.compile` tracing attempt started here ==========
+
+  File "test_error_messages.py", line N, in fn
+    torch._dynamo.graph_break()
+
+NOTE: the most recent `torch.compile` tracing attempt might not be where you applied `torch.compile`! This is due to how graph breaks are implemented - the optimized code object returned by Dynamo will call another Dynamo-generated resume function and tracing is re-enabled by calling the resume function as a normal Python function, which Dynamo intercepts as a top-level frame.
+Most recent bytecode instructions traced (max 20):
+""",
+        )
+
+    @torch._dynamo.config.patch(verbose=True)
+    @make_logging_test(graph_breaks=True)
     def test_variable_tracker_bytecode_to_graph_break(self, records):
         @torch.compile(backend="eager")
         def fn(x):

--- a/test/dynamo/test_exc.py
+++ b/test/dynamo/test_exc.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: dynamo"]
 
 import logging
+import re
 import unittest
 
 import torch
@@ -170,11 +171,13 @@ from user code:
         torch.compile(fn001, backend="eager")(torch.randn(1))
 
         record = self.getRecord(records, "Graph break in user code")
+        msg = re.sub(r"TRACE.*\n", "", record.getMessage(), flags=re.MULTILINE)
+        # msg =
 
         # TODO: This should also report the enclosing frames; need to plumb
         # frame object to it
         self.assertExpectedInline(
-            munge_exc(record.getMessage()),
+            munge_exc(re.sub(r"TRACE.*", "", msg)),
             """\
 Graph break in user code at test_exc.py:N
 Graph Break Reason: Call to `torch._dynamo.graph_break()`
@@ -191,6 +194,7 @@ User code traceback:
     return fn002(x)
   File "test_exc.py", line N, in fn002
     torch._dynamo.graph_break()
+Most recent bytecode instructions traced (max 20):
 """,  # noqa: B950
         )
 

--- a/test/dynamo/test_exc.py
+++ b/test/dynamo/test_exc.py
@@ -172,6 +172,7 @@ from user code:
 
         record = self.getRecord(records, "Graph break in user code")
         msg = re.sub(r"TRACE.*\n", "", record.getMessage(), flags=re.MULTILINE)
+        # msg =
 
         # TODO: This should also report the enclosing frames; need to plumb
         # frame object to it

--- a/test/dynamo/test_exc.py
+++ b/test/dynamo/test_exc.py
@@ -171,12 +171,11 @@ from user code:
         torch.compile(fn001, backend="eager")(torch.randn(1))
 
         record = self.getRecord(records, "Graph break in user code")
-        msg = re.sub(r"TRACE.*\n", "", record.getMessage(), flags=re.MULTILINE)
 
         # TODO: This should also report the enclosing frames; need to plumb
         # frame object to it
         self.assertExpectedInline(
-            munge_exc(re.sub(r"TRACE.*", "", msg)),
+            munge_exc(record.getMessage()),
             """\
 Graph break in user code at test_exc.py:N
 Graph Break Reason: Call to `torch._dynamo.graph_break()`
@@ -193,7 +192,6 @@ User code traceback:
     return fn002(x)
   File "test_exc.py", line N, in fn002
     torch._dynamo.graph_break()
-Most recent bytecode instructions traced (max 20):
 """,  # noqa: B950
         )
 

--- a/test/dynamo/test_exc.py
+++ b/test/dynamo/test_exc.py
@@ -1,7 +1,6 @@
 # Owner(s): ["module: dynamo"]
 
 import logging
-import re
 import unittest
 
 import torch

--- a/test/dynamo/test_exc.py
+++ b/test/dynamo/test_exc.py
@@ -172,7 +172,6 @@ from user code:
 
         record = self.getRecord(records, "Graph break in user code")
         msg = re.sub(r"TRACE.*\n", "", record.getMessage(), flags=re.MULTILINE)
-        # msg =
 
         # TODO: This should also report the enclosing frames; need to plumb
         # frame object to it

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1191,7 +1191,7 @@ class InstructionTranslatorBase(
     parent: Optional[InstructionTranslatorBase]
     debug_locals: list[tuple[VariableTracker, list[VariableTracker]]]
     package: Optional[CompilePackage]
-    latest_bytecode_queue: deque[str] = deque(maxlen=20)
+    latest_bytecode_queue: deque[str]
     # Store the latest bytecode before graph_break() call by user
 
     def mark_inconsistent_side_effects(self) -> None:
@@ -4933,7 +4933,6 @@ class InliningGeneratorInstructionTranslator(InliningInstructionTranslator):
         self.generated_items = []
         self.generator_exhausted = False
         self.is_generator_from_ctx_manager = False
-        self.latest_bytecode_queue = Queue
 
     def YIELD_VALUE(self, inst: Instruction) -> None:
         top = self.pop()

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1362,8 +1362,13 @@ class InstructionTranslatorBase(
 
         # Store the latest 20 bytecode execution for the process,
         # Used repr for byte processing and limiting the length to 2048
+        try:
+            stack_repr = repr(self.stack)
+        except ValueError:
+            # Handle large integers that exceed sys.int_info.str_digits_check_threshold
+            stack_repr = "<self.stack repr truncated due to large integer>"
         self.latest_bytecode_queue.append(
-            f"TRACE {inst.opname} {repr(inst.argval)} {repr(self.stack)[:2048]}"
+            f"TRACE {inst.opname} {repr(inst.argval)} {stack_repr}"
         )
 
         self.update_block_stack(inst)

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1361,7 +1361,9 @@ class InstructionTranslatorBase(
             )
 
         # Store the latest 20 bytecode execution for the process
-        self.latest_bytecode_queue.append(f"TRACE {inst.opname} {inst.argval} {self.stack}")
+        self.latest_bytecode_queue.append(
+            f"TRACE {inst.opname} {inst.argval} {self.stack}"
+        )
 
         self.update_block_stack(inst)
 

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1362,7 +1362,7 @@ class InstructionTranslatorBase(
 
         # Store the latest 20 bytecode execution for the process
         self.latest_bytecode_queue.append(
-            f"TRACE {inst.opname} {repr(inst.argval)} {self.stack}"
+            f"TRACE {inst.opname} {repr(inst.argval)} {repr(self.stack)}"
         )
 
         self.update_block_stack(inst)

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1361,9 +1361,14 @@ class InstructionTranslatorBase(
             )
 
         # Store the latest 20 bytecode execution for the process
-        self.latest_bytecode_queue.append(
-            f"TRACE {inst.opname} {str(inst.argval)} {self.stack}"
-        )
+        if isinstance(inst.argval, bytes):
+            self.latest_bytecode_queue.append(
+                f"TRACE {inst.opname} {inst.argval.decode('utf-8')} {self.stack}"
+            )
+        else:
+            self.latest_bytecode_queue.append(
+                f"TRACE {inst.opname} {str(inst.argval)} {self.stack}"
+            )
 
         self.update_block_stack(inst)
 

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -608,7 +608,7 @@ def log_graph_break(
         # This log line MUST contain the string "Graph break in user code",
         # This log line is exercised from
         #   python test/dynamo/test_exc.py -k test_graph_break_log
-        if latest_bytecode_log:
+        if latest_bytecode_log and config.verbose:
             user_stack_trace += "Most recent bytecode instructions traced (max 20):\n"
             user_stack_trace += latest_bytecode_log
 

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1358,11 +1358,11 @@ class InstructionTranslatorBase(
 
         if self.is_trace_bytecode_log_enabled:
             trace_bytecode_log.debug(
-                "TRACE %s %s %s", inst.opname, inst.argval, self.stack
+                _format_trace_bytecode(inst, self.stack)
             )
 
         # Store the latest 20 bytecode execution for the process
-        latest_bytecode_queue.append(f"TRACE {inst.opname} {inst.argval} {self.stack}")
+        latest_bytecode_queue.append(_format_trace_bytecode(inst, self.stack))
 
         self.update_block_stack(inst)
 

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1358,11 +1358,11 @@ class InstructionTranslatorBase(
 
         if self.is_trace_bytecode_log_enabled:
             trace_bytecode_log.debug(
-                _format_trace_bytecode(inst, self.stack)
+                "TRACE %s %s %s", inst.opname, inst.argval, self.stack
             )
 
         # Store the latest 20 bytecode execution for the process
-        latest_bytecode_queue.append(_format_trace_bytecode(inst, self.stack))
+        latest_bytecode_queue.append(f"TRACE {inst.opname} {inst.argval} {self.stack}")
 
         self.update_block_stack(inst)
 

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -4095,6 +4095,7 @@ class InstructionTranslatorBase(
         self.accept_prefix_inst = True
         self.prefix_insts = []
         self.exn_vt_stack = exn_vt_stack
+        self.latest_bytecode_queue = deque(maxlen=20)
 
         # Properties of the input/output code
         self.instructions: list[Instruction] = instructions
@@ -4930,6 +4931,7 @@ class InliningGeneratorInstructionTranslator(InliningInstructionTranslator):
         self.generated_items = []
         self.generator_exhausted = False
         self.is_generator_from_ctx_manager = False
+        self.latest_bytecode_queue = Queue
 
     def YIELD_VALUE(self, inst: Instruction) -> None:
         top = self.pop()

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1361,14 +1361,9 @@ class InstructionTranslatorBase(
             )
 
         # Store the latest 20 bytecode execution for the process
-        if isinstance(inst.argval, bytes):
-            self.latest_bytecode_queue.append(
-                f"TRACE {inst.opname} {inst.argval.decode('utf-8', errors='ignore')} {self.stack}"
-            )
-        else:
-            self.latest_bytecode_queue.append(
-                f"TRACE {inst.opname} {str(inst.argval)} {self.stack}"
-            )
+        self.latest_bytecode_queue.append(
+            f"TRACE {inst.opname} {str(inst.argval)} {self.stack}"
+        )
 
         self.update_block_stack(inst)
 

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1363,7 +1363,7 @@ class InstructionTranslatorBase(
         # Store the latest 20 bytecode execution for the process
         if isinstance(inst.argval, bytes):
             self.latest_bytecode_queue.append(
-                f"TRACE {inst.opname} {inst.argval.decode('utf-8')} {self.stack}"
+                f"TRACE {inst.opname} {inst.argval.decode('utf-8', errors='ignore')} {self.stack}"
             )
         else:
             self.latest_bytecode_queue.append(

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1362,7 +1362,7 @@ class InstructionTranslatorBase(
 
         # Store the latest 20 bytecode execution for the process
         self.latest_bytecode_queue.append(
-            f"TRACE {inst.opname} {inst.argval} {self.stack}"
+            f"TRACE {inst.opname} {str(inst.argval)} {self.stack}"
         )
 
         self.update_block_stack(inst)

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1360,9 +1360,10 @@ class InstructionTranslatorBase(
                 "TRACE %s %s %s", inst.opname, inst.argval, self.stack
             )
 
-        # Store the latest 20 bytecode execution for the process
+        # Store the latest 20 bytecode execution for the process,
+        # Used repr for byte processing and limiting the length to 2048
         self.latest_bytecode_queue.append(
-            f"TRACE {inst.opname} {repr(inst.argval)} {repr(self.stack)}"
+            f"TRACE {inst.opname} {repr(inst.argval)} {repr(self.stack)[:2048]}"
         )
 
         self.update_block_stack(inst)

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1362,7 +1362,7 @@ class InstructionTranslatorBase(
 
         # Store the latest 20 bytecode execution for the process
         self.latest_bytecode_queue.append(
-            f"TRACE {inst.opname} {str(inst.argval)} {self.stack}"
+            f"TRACE {inst.opname} {repr(inst.argval)} {self.stack}"
         )
 
         self.update_block_stack(inst)

--- a/torch/_dynamo/testing.py
+++ b/torch/_dynamo/testing.py
@@ -508,8 +508,8 @@ def skipIfNotPy312(fn: Callable[_P, _T]) -> Callable[_P, _T]:
 
 def skipIfOnlyNotPy312(fn: Callable[_P, _T]) -> Callable[_P, _T]:
     if sys.version_info >= (3, 13) or sys.version_info < (3, 12):
-        return fn
-    return unittest.skip("Requires Python 3.12")(fn)
+        return unittest.skip("Requires Python 3.12")(fn)
+    return fn
 
 
 def xfailIfPy312(fn: Callable[_P, _T]) -> Callable[_P, _T]:

--- a/torch/_dynamo/testing.py
+++ b/torch/_dynamo/testing.py
@@ -509,7 +509,7 @@ def skipIfNotPy312(fn: Callable[_P, _T]) -> Callable[_P, _T]:
 def skipIfOnlyNotPy312(fn: Callable[_P, _T]) -> Callable[_P, _T]:
     if sys.version_info == (3, 12):
         return fn
-    return unittest.skip("Requires Python 3.12+")(fn)
+    return unittest.skip("Requires Python 3.12")(fn)
 
 
 def xfailIfPy312(fn: Callable[_P, _T]) -> Callable[_P, _T]:

--- a/torch/_dynamo/testing.py
+++ b/torch/_dynamo/testing.py
@@ -25,13 +25,13 @@ import types
 import unittest
 from collections.abc import Sequence
 from typing import Any, Callable, Optional, overload, TypeVar, Union
+from typing_extensions import ParamSpec
 from unittest.mock import patch
 
 import torch
 from torch import fx
 from torch._dynamo.backends.debugging import aot_eager
 from torch._dynamo.output_graph import OutputGraph
-from typing_extensions import ParamSpec
 
 from . import config, eval_frame, optimize_assert, reset
 from .bytecode_transformation import (

--- a/torch/_dynamo/testing.py
+++ b/torch/_dynamo/testing.py
@@ -506,6 +506,12 @@ def skipIfNotPy312(fn: Callable[_P, _T]) -> Callable[_P, _T]:
     return unittest.skip("Requires Python 3.12+")(fn)
 
 
+def skipIfOnlyNotPy312(fn: Callable[_P, _T]) -> Callable[_P, _T]:
+    if sys.version_info == (3, 12):
+        return fn
+    return unittest.skip("Requires Python 3.12+")(fn)
+
+
 def xfailIfPy312(fn: Callable[_P, _T]) -> Callable[_P, _T]:
     if sys.version_info >= (3, 12):
         return unittest.expectedFailure(fn)

--- a/torch/_dynamo/testing.py
+++ b/torch/_dynamo/testing.py
@@ -507,9 +507,9 @@ def skipIfNotPy312(fn: Callable[_P, _T]) -> Callable[_P, _T]:
 
 
 def skipIfOnlyNotPy312(fn: Callable[_P, _T]) -> Callable[_P, _T]:
-    if sys.version_info == (3, 12):
-        return fn
-    return unittest.skip("Requires Python 3.12")(fn)
+    if sys.version_info < (3, 12) or sys.version_info >= (3, 13):
+        return unittest.skip("Requires Python 3.12")
+    return fn
 
 
 def xfailIfPy312(fn: Callable[_P, _T]) -> Callable[_P, _T]:

--- a/torch/_dynamo/testing.py
+++ b/torch/_dynamo/testing.py
@@ -25,13 +25,13 @@ import types
 import unittest
 from collections.abc import Sequence
 from typing import Any, Callable, Optional, overload, TypeVar, Union
-from typing_extensions import ParamSpec
 from unittest.mock import patch
 
 import torch
 from torch import fx
 from torch._dynamo.backends.debugging import aot_eager
 from torch._dynamo.output_graph import OutputGraph
+from typing_extensions import ParamSpec
 
 from . import config, eval_frame, optimize_assert, reset
 from .bytecode_transformation import (
@@ -507,9 +507,9 @@ def skipIfNotPy312(fn: Callable[_P, _T]) -> Callable[_P, _T]:
 
 
 def skipIfOnlyNotPy312(fn: Callable[_P, _T]) -> Callable[_P, _T]:
-    if sys.version_info < (3, 12) or sys.version_info >= (3, 13):
-        return unittest.skip("Requires Python 3.12")
-    return fn
+    if sys.version_info >= (3, 13) or sys.version_info < (3, 12):
+        return fn
+    return unittest.skip("Requires Python 3.12")(fn)
 
 
 def xfailIfPy312(fn: Callable[_P, _T]) -> Callable[_P, _T]:


### PR DESCRIPTION
https://github.com/pytorch/pytorch/issues/162858 The issue described the feature implemented.

This adds to the existing graph break log with the latest 20 (or viable user frame) bytecode instructions. The scenario is when the graph_break happens without errors. It happens during the case when user calling torch._dynamo.graph_break().

Meanwhile, in the testing, one can find that the generated frame based on step() is not deterministic as sometimes it reached the maximum amount, sometimes it generated the less than that. The bytecode generation is python version dependent. Thus, the testing plan excludes the bytecode output but generated the total bytecode line count.

This is a helpful process to understand bytecode transformation, symbolic convert, and convert frame. It is a helpful task to provide hands-on experience with dynamo workflow.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela