### PR TITLE
[inductor] Add flag to run post-grad graph

### DIFF
--- a/test/inductor/test_inductor_utils.py
+++ b/test/inductor/test_inductor_utils.py
@@ -4,9 +4,17 @@ import functools
 import logging
 
 import torch
+from torch._inductor import config
 from torch._inductor.runtime.benchmarking import benchmarker
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import do_bench_using_profiling
+from torch.testing._internal.logging_utils import logs_to_string
+
+
+try:
+    from .test_codecache import capture_logs
+except ImportError:
+    from test_codecache import capture_logs
 
 
 log = logging.getLogger(__name__)
@@ -29,6 +37,40 @@ class TestBench(TestCase):
         res = do_bench_using_profiling(self._bench_fn)
         log.warning("do_bench_using_profiling result: %s", res)
         self.assertGreater(res, 0)
+
+
+@config.patch("run_with_post_grad_graph", True)
+class TestPostGradRun(TestCase):
+    def test_post_grad_run(self):
+        post_grad_log_stream, post_grad_log_ctx = logs_to_string(
+            "torch._inductor.compile_fx", "post_grad_graphs"
+        )
+
+        class PostGrad(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(10, 10)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        model = PostGrad()
+        inp = (torch.randn(10, 10),)
+        res1 = model(*inp)
+
+        with (
+            capture_logs("torch._inductor.scheduler", logging.DEBUG) as scheduler_logs,
+            post_grad_log_ctx(),
+        ):
+            res2 = torch.compile(model)(*inp)
+
+        self.assertTrue(torch.allclose(res1, res2))
+
+        post_grad_log = "\n".join(
+            post_grad_log_stream.getvalue().strip().split("\n")[3:]
+        ).strip()
+        self.assertEqual(scheduler_logs, [])
+        self.assertTrue(len(post_grad_log) > 0)
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -13,7 +13,7 @@ import sys
 import time
 import warnings
 from abc import ABC, abstractmethod
-from collections import defaultdict
+from collections import Counter, defaultdict
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from inspect import currentframe
@@ -640,6 +640,52 @@ def is_tf32_warning_applicable(gm: GraphModule) -> bool:
             ):
                 return True
     return False
+
+
+def create_post_grad_runnable(
+    gm: torch.fx.GraphModule,
+    *,
+    static_input_idxs: Sequence[int],
+    fx_kwargs: _CompileFxKwargs,
+    inputs_to_check: Sequence[int],
+    runnable_graph_str: str,
+    inductor_post_grad_graph_str: str,
+) -> CompiledFxGraph:
+    """
+    Creates a CompiledFxGraph given a graph module. This is used to directly run
+    with the post-grad graph.
+    """
+
+    def compiled_fn(args):  # type: ignore[no-untyped-def]
+        return torch.fx.Interpreter(gm).boxed_run(args)
+
+    compiled_fn._boxed_call = True  # type: ignore[attr-defined]
+
+    dummy_metrics_deltas = metrics.CachedMetricsDeltas(
+        generated_kernel_count=0,
+        generated_cpp_vec_kernel_count=0,
+        ir_nodes_pre_fusion=0,
+        cpp_to_dtype_count=0,
+        num_bytes_accessed=0,
+        num_matches_for_scatter_upon_const_tensor=0,
+    )
+
+    return CompiledFxGraph(
+        current_callable=compiled_fn,
+        graph=GraphLowering(gm),  # type: ignore[arg-type]
+        gm=gm,
+        output_strides=[],
+        disabled_cudagraphs_reason="Running with post-grad graph",
+        metrics_deltas=dummy_metrics_deltas,
+        counter_deltas=Counter(),
+        cudagraphs=BoxedBool(False),
+        example_inputs=[],
+        static_input_idxs=static_input_idxs,
+        fx_kwargs=fx_kwargs,
+        inputs_to_check=inputs_to_check,
+        runnable_graph_str=runnable_graph_str,
+        inductor_post_grad_graph_str=inductor_post_grad_graph_str,
+    )
 
 
 def maybe_disable_comprehensive_padding(
@@ -1348,6 +1394,16 @@ class _InProcessFxCompile(FxCompile):
                         # TODO(T216453900): need to work around for now to support vllm
                         # See details in vllm/compilation/pass_manager.py.
                         log.warning("failed to log pt2_configs")
+
+            if config.debug_return_post_grad_graph:
+                return create_post_grad_runnable(
+                    gm,
+                    static_input_idxs=static_input_idxs,
+                    fx_kwargs=graph_kwargs,
+                    inputs_to_check=inputs_to_check,
+                    runnable_graph_str=runnable_graph_str,
+                    inductor_post_grad_graph_str=inductor_post_grad_graph_str,
+                )
 
             with (
                 V.set_fake_mode(fake_mode),

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1078,6 +1078,14 @@ enable_caching_generated_triton_templates: bool = True
 # Lookup table for overriding autotune configs based on hash of Triton source code
 autotune_lookup_table: dict[str, dict[str, Any]] = {}
 
+# This is used for debugging purposes in JIT Inductor where you just want to
+# check the graph after post-grad passes. Instead of running with Inductor's
+# generated python code + generated triton kernels, we will just run with the
+# post-grad graph.
+debug_return_post_grad_graph: bool = (
+    os.environ.get("TORCHINDUCTOR_DEBUG_RETURN_POST_GRAD", "0") == "1"
+)
+
 
 def get_worker_log_path() -> Optional[str]:
     log_loc = None

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -816,9 +816,9 @@ def scatter_upon_const_tensor(
 
     # Check if inputs are tensors instead of inductor IR nodes
     if isinstance(selector, torch.Tensor):
-        # Return a fake tensor with the proper shape that this operator is intended to return
         device = selector.device if hasattr(selector, "device") else torch.device("cpu")
-        return torch.empty(shape, dtype=dtype, device=device)
+        background_tensor = torch.full(shape, background_val, dtype=dtype, device=device)
+        return torch.scatter(background_tensor, dim, selector, val)
 
     metrics.num_matches_for_scatter_upon_const_tensor += 1
 


### PR DESCRIPTION
Adding an inductor config and envvar `TORCHINDUCTOR_RUN_WITH_POST_GRAD` so that when specified, instead of running the code with inductor's generated python code, we just run the post-grad graph eagerly. This is helpful when debugging VLLM to rule out any issues due to inductor's codegen (it's a little complicated to specify backend="aot_eager_..." in the context of VLLM).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @mlazos