### PR TITLE
Move file selection for ruff from .lintrunner.toml to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,27 @@ standard_library = ["typing_extensions"]
 line-length = 88
 src = ["caffe2", "torch", "torchgen", "functorch", "test"]
 
+include = [
+    "**/*.py",
+    "**/*.pyi",
+    "**/*.ipynb",
+]
+
+exclude = [
+    ".git/**",
+    "android/**",
+    "caffe2/**",
+    "functorch/docs/**",
+    "torch/_inductor/fx_passes/serialized_patterns/**",
+    "torch/_inductor/autoheuristic/artifacts/**",
+    "test/dynamo/cpython/**",
+    "scripts/**",
+    "third_party/**",
+    "fb/**",
+    "**/fb/**",
+]
+
+
 [tool.ruff.format]
 docstring-code-format = true
 quote-style = "double"


### PR DESCRIPTION
`test/dynamo/cpython/**` contains various valid and invalid python files for testing compilation. We should keep them untouched from linters.