### PR TITLE
Update doc for sparse matmul on CSR autograd support

### DIFF
--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -53,9 +53,6 @@ When inputs are COO tensors, this function also supports backward for both input
 
 Supports both CSR and COO storage formats.
 
-.. note::
-    This function doesn't support computing derivatives with respect to CSR matrices.
-
 Args:
     mat (Tensor): a dense matrix to be added
     mat1 (Tensor): a sparse matrix to be multiplied
@@ -79,8 +76,6 @@ mm = _add_docstr(
     Supports both CSR and COO storage formats.
 
 .. note::
-    This function doesn't support computing derivatives with respect to CSR matrices.
-
     This function also additionally accepts an optional :attr:`reduce` argument that allows
     specification of an optional reduction operation, mathematically performs the following operation:
 


### PR DESCRIPTION
Both torch.sparse.mm and torch.sparse.addmm appears to be able to calculate the gradient for CSR format on both CPU and CUDA, although using CSR with reduce as an argument will not work on CUDA. I am not entirely sure if there are some other edge cases for this, but it would probably be less misleading to remove the notes.

As a side note, it is also a bit misleading to do something like torch.sparse.mm(mat1, mat2, reduce="sum") with CSR on CUDA and get NotImplementedError (see below), but doing torch.sparse.mm(mat1, mat2) works just fine, where reduce defaults to "sum". Should this case be routed to the existing sparse mm implementation?

```
NotImplementedError: Could not run 'aten::_sparse_mm_reduce_impl' with arguments from the 'SparseCsrCUDA' backend. This could be because the operator doesn't exist for this backend, or was omitted during the selective/custom build process (if using custom build). If you are a Facebook employee using PyTorch on mobile, please visit https://fburl.com/ptmfixes for possible resolutions. 'aten::_sparse_mm_reduce_impl' is only available for these backends: [Meta, SparseCsrCPU, BackendSelect, Python, FuncTorchDynamicLayerBackMode, Functionalize, Named, Conjugate, Negative, ZeroTensor, ADInplaceOrView, AutogradOther, AutogradCPU, AutogradCUDA, AutogradHIP, AutogradXLA, AutogradMPS, AutogradIPU, AutogradXPU, AutogradHPU, AutogradVE, AutogradLazy, AutogradMTIA, AutogradMAIA, AutogradPrivateUse1, AutogradPrivateUse2, AutogradPrivateUse3, AutogradMeta, AutogradNestedTensor, Tracer, AutocastCPU, AutocastMTIA, AutocastMAIA, AutocastXPU, AutocastMPS, AutocastCUDA, FuncTorchBatched, BatchedNestedTensor, FuncTorchVmapMode, Batched, VmapMode, FuncTorchGradWrapper, PythonTLSSnapshot, FuncTorchDynamicLayerFrontMode, PreDispatch, PythonDispatcher].
```
