### PR TITLE
Add CUDA release architecture matrix

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -71,13 +71,13 @@ For Release 2.9 PyTorch Supports following CUDA Architectures:
 | CUDA | architectures supported for Linux x86 and Windows builds | notes |
 | --- | --- | --- |
 | 12.6.3 | Maxwell(5.0), Pascal(6.0), Volta(7.0), Turing(7.5), Ampere(8.0, 8.6), Hopper(9.0) | |
-| 12.8.0 | Volta(7.0), Turing(7.5), Ampere(8.0, 8.6), Hopper(9.0), Blackwell(10.0, 12.0)  | |
+| 12.8.1 | Volta(7.0), Turing(7.5), Ampere(8.0, 8.6), Hopper(9.0), Blackwell(10.0, 12.0)  | |
 | 13.0.0 | Turing(7.5), Ampere(8.0, 8.6), Hopper(9.0), Blackwell(10.0, 12.0+PTX) | +PTX available on linux builds only |
 
 | CUDA | architectures supported for Linux aarch64 builds |
 | --- | --- |
 | 12.6.3 | Ampere(8.0), Hopper(9.0) |
-| 12.8.0 | Ampere(8.0), Hopper(9.0), Blackwell(10.0, 12.0)  |
+| 12.8.1 | Ampere(8.0), Hopper(9.0), Blackwell(10.0, 12.0)  |
 | 13.0.0 | Ampere(8.0), Hopper(9.0), Blackwell(10.0, 11.0, 12.0+PTX) |
 
 ## Release Cadence

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,7 @@
 <!-- toc -->
 
   - [Release Compatibility Matrix](#release-compatibility-matrix)
+    - [PyTorch CUDA Support Matrix](#pytorch-cuda-support-matrix)
   - [Release Cadence](#release-cadence)
   - [General Overview](#general-overview)
     - [Frequently Asked Questions](#frequently-asked-questions)
@@ -44,7 +45,7 @@
 
 <!-- tocstop -->
 
-## Release Compatibility Matrix and Current CUDA Support Matrix
+## Release Compatibility Matrix
 
 Following is the Release Compatibility Matrix for PyTorch releases:
 
@@ -63,17 +64,17 @@ Following is the Release Compatibility Matrix for PyTorch releases:
 | 1.13 | >=3.7, <=3.10 | C++14 | CUDA 11.6, CUDNN 8.3.2.44 | CUDA 11.7, CUDNN 8.5.0.96 | ROCm 5.2 |
 | 1.12 | >=3.7, <=3.10 | C++14 | CUDA 11.3, CUDNN 8.3.2.44 | CUDA 11.6, CUDNN 8.3.2.44 | ROCm 5.0 |
 
-PyTorch 2.9 release supports following CUDA architectures for Linux x86 and Windows builds:
+### PyTorch CUDA Support Matrix
 
+For Release 2.9 PyTorch Supports following CUDA Architectures:
 
-| CUDA | architectures supported | notes |
+| CUDA | architectures supported for Linux x86 and Windows builds | notes |
 | --- | --- | --- |
 | 12.6.3 | Maxwell(5.0), Pascal(6.0), Volta(7.0), Turing(7.5), Ampere(8.0, 8.6), Hopper(9.0) | |
 | 12.8.0 | Volta(7.0), Turing(7.5), Ampere(8.0, 8.6), Hopper(9.0), Blackwell(10.0, 12.0)  | |
 | 13.0.0 | Turing(7.5), Ampere(8.0, 8.6), Hopper(9.0), Blackwell(10.0, 12.0+PTX) | +PTX available on linux builds only |
 
-PyTorch 2.9 release supports following CUDA architectures for Linux aarch64 builds:
-| CUDA | architectures supported |
+| CUDA | architectures supported for Linux aarch64 builds |
 | --- | --- |
 | 12.6.3 | Ampere(8.0), Hopper(9.0) |
 | 12.8.0 | Ampere(8.0), Hopper(9.0), Blackwell(10.0, 12.0)  |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -63,16 +63,17 @@ Following is the Release Compatibility Matrix for PyTorch releases:
 | 1.13 | >=3.7, <=3.10 | C++14 | CUDA 11.6, CUDNN 8.3.2.44 | CUDA 11.7, CUDNN 8.5.0.96 | ROCm 5.2 |
 | 1.12 | >=3.7, <=3.10 | C++14 | CUDA 11.3, CUDNN 8.3.2.44 | CUDA 11.6, CUDNN 8.3.2.44 | ROCm 5.0 |
 
-PyTorch 2.9 release supports following CUDA architectures
+PyTorch 2.9 release supports following CUDA architectures for Linux x86 and Windows builds:
 
-For Linux x86 and Windows builds
+
 | CUDA | architectures supported | notes |
 | --- | --- | --- |
 | 12.6.3 | Maxwell(5.0), Pascal(6.0), Volta(7.0), Turing(7.5), Ampere(8.0, 8.6), Hopper(9.0) | |
 | 12.8.0 | Volta(7.0), Turing(7.5), Ampere(8.0, 8.6), Hopper(9.0), Blackwell(10.0, 12.0)  | |
 | 13.0.0 | Turing(7.5), Ampere(8.0, 8.6), Hopper(9.0), Blackwell(10.0, 12.0+PTX) | +PTX available on linux builds only |
 
-For Linux aarch64 builds
+PyTorch 2.9 release supports following CUDA architectures for Linux aarch64 builds:
+| CUDA | architectures supported |
 | --- | --- |
 | 12.6.3 | Ampere(8.0), Hopper(9.0) |
 | 12.8.0 | Ampere(8.0), Hopper(9.0), Blackwell(10.0, 12.0)  |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -44,7 +44,7 @@
 
 <!-- tocstop -->
 
-## Release Compatibility Matrix
+## Release Compatibility Matrix and Current CUDA Support Matrix
 
 Following is the Release Compatibility Matrix for PyTorch releases:
 
@@ -62,6 +62,21 @@ Following is the Release Compatibility Matrix for PyTorch releases:
 | 2.0 | >=3.8, <=3.11 | C++14 | CUDA 11.7, CUDNN 8.5.0.96 | CUDA 11.8, CUDNN 8.7.0.84 | ROCm 5.4 |
 | 1.13 | >=3.7, <=3.10 | C++14 | CUDA 11.6, CUDNN 8.3.2.44 | CUDA 11.7, CUDNN 8.5.0.96 | ROCm 5.2 |
 | 1.12 | >=3.7, <=3.10 | C++14 | CUDA 11.3, CUDNN 8.3.2.44 | CUDA 11.6, CUDNN 8.3.2.44 | ROCm 5.0 |
+
+PyTorch 2.9 release supports following CUDA architectures
+
+For Linux x86 and Windows builds
+| CUDA | architectures supported | notes |
+| --- | --- | --- |
+| 12.6.3 | Maxwell(5.0), Pascal(6.0), Volta(7.0), Turing(7.5), Ampere(8.0, 8.6), Hopper(9.0) | |
+| 12.8.0 | Volta(7.0), Turing(7.5), Ampere(8.0, 8.6), Hopper(9.0), Blackwell(10.0, 12.0)  | |
+| 13.0.0 | Turing(7.5), Ampere(8.0, 8.6), Hopper(9.0), Blackwell(10.0, 12.0+PTX) | +PTX available on linux builds only |
+
+For Linux aarch64 builds
+| --- | --- |
+| 12.6.3 | Ampere(8.0), Hopper(9.0) |
+| 12.8.0 | Ampere(8.0), Hopper(9.0), Blackwell(10.0, 12.0)  |
+| 13.0.0 | Ampere(8.0), Hopper(9.0), Blackwell(10.0, 12.0+PTX) |
 
 ## Release Cadence
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -78,7 +78,7 @@ For Release 2.9 PyTorch Supports following CUDA Architectures:
 | --- | --- |
 | 12.6.3 | Ampere(8.0), Hopper(9.0) |
 | 12.8.0 | Ampere(8.0), Hopper(9.0), Blackwell(10.0, 12.0)  |
-| 13.0.0 | Ampere(8.0), Hopper(9.0), Blackwell(10.0, 12.0+PTX) |
+| 13.0.0 | Ampere(8.0), Hopper(9.0), Blackwell(10.0, 11.0, 12.0+PTX) |
 
 ## Release Cadence
 


### PR DESCRIPTION
We should surface the CUDA architecture matrix to make things more transparent. I believe this can later become its own page where we will publish supported matrix for each release.