### PR TITLE
Schema error clarity (#122129)

### DIFF
--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -1661,19 +1661,16 @@ class ErrorMessageClarityTest(TestCase):
         S0 = 420
         S1 = N - S0
 
-        self.assertExpectedInlineMunged(
+        with self.assertRaisesRegex(
             Exception,
-            lambda: f(
+            re.escape(
+                """got RuntimeError("test_clarity_list::iterator_mismatch() Expected a value of type 'List[int]' for argument 'sizes' but instead found type 'immutable_list(SymInt, SymInt)'."""
+            ),
+        ):
+            f(
                 torch.tensor([S0, S1], device=device),
                 make_tensor(N, dtype=torch.float32, device=device),
-            ),
-            """\
-Dynamo failed to run FX node with fake tensors: call_function test_clarity_list.iterator_mismatch.default(*(FakeTensor(..., size=(7312,)), [u0, u1]), **{}): got RuntimeError("test_clarity_list::iterator_mismatch() Expected a value of type 'List[int]' for argument 'sizes' but instead found type 'immutable_list(SymInt, SymInt)'.\\nPosition: 1\\nValue: [u0, u1]\\nDeclaration: test_clarity_list::iterator_mismatch(Tensor input, int[] sizes) -> Tensor[]\\nCast error details: Unable to cast Python instance of type <class 'torch.fx.immutable_collections.immutable_list'> to C++ type '?' (#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for details)")
-
-from user code:
-   File "test_error_messages.py", line N, in f
-    r0, r1 = torch.ops.test_clarity_list.iterator_mismatch.default(x, [s0, s1])""",
-        )
+            )
 
     def test_tuple_iterator_contents_error_message(self, device):
         lib_name = "test_clarity_tuple"
@@ -1689,19 +1686,16 @@ from user code:
         S0 = 420
         S1 = N - S0
 
-        self.assertExpectedInlineMunged(
+        with self.assertRaisesRegex(
             Exception,
-            lambda: f(
+            re.escape(
+                """got RuntimeError("test_clarity_tuple::iterator_mismatch() Expected a value of type 'List[int]' for argument 'sizes' but instead found type 'tuple(SymInt, SymInt)'."""
+            ),
+        ):
+            f(
                 torch.tensor((S0, S1), device=device),
                 make_tensor(N, dtype=torch.float32, device=device),
-            ),
-            """\
-Dynamo failed to run FX node with fake tensors: call_function test_clarity_tuple.iterator_mismatch.default(*(FakeTensor(..., size=(7312,)), (u0, u1)), **{}): got RuntimeError("test_clarity_tuple::iterator_mismatch() Expected a value of type 'List[int]' for argument 'sizes' but instead found type 'tuple(SymInt, SymInt)'.\\nPosition: 1\\nValue: (u0, u1)\\nDeclaration: test_clarity_tuple::iterator_mismatch(Tensor input, int[] sizes) -> Tensor[]\\nCast error details: Unable to cast Python instance of type <class 'tuple'> to C++ type '?' (#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for details)")
-
-from user code:
-   File "test_error_messages.py", line N, in f
-    r0, r1 = torch.ops.test_clarity_tuple.iterator_mismatch.default(x, (s0, s1))""",
-        )
+            )
 
     def test_dict_iterator_contents_error_message(self, device):
         lib_name = "test_clarity_dict"
@@ -1719,19 +1713,16 @@ from user code:
         S0 = 420
         S1 = N - S0
 
-        self.assertExpectedInlineMunged(
+        with self.assertRaisesRegex(
             Exception,
-            lambda: f(
+            re.escape(
+                """got RuntimeError("test_clarity_dict::iterator_mismatch() Expected a value of type 'List[int]' for argument 'sizes' but instead found type 'immutable_dict(int, int)'."""
+            ),
+        ):
+            f(
                 torch.tensor((S0, S1), device=device),
                 make_tensor(N, dtype=torch.float32, device=device),
-            ),
-            """\
-Dynamo failed to run FX node with fake tensors: call_function test_clarity_dict.iterator_mismatch.default(*(FakeTensor(..., size=(7312,)), {1: u0, 2: u1}), **{}): got RuntimeError("test_clarity_dict::iterator_mismatch() Expected a value of type 'List[int]' for argument 'sizes' but instead found type 'immutable_dict(int, int)'.\\nPosition: 1\\nValue: {1: u0, 2: u1}\\nDeclaration: test_clarity_dict::iterator_mismatch(Tensor input, int[] sizes) -> Tensor[]\\nCast error details: Unable to cast Python instance of type <class 'torch.fx.immutable_collections.immutable_dict'> to C++ type '?' (#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for details)")
-
-from user code:
-   File "test_error_messages.py", line N, in f
-    r0, r1 = torch.ops.test_clarity_dict.iterator_mismatch.default(""",
-        )
+            )
 
     def test_named_tuple_iterator_contents_error_message(self, device):
         lib_name = "test_clarity_named_tuple"
@@ -1750,19 +1741,16 @@ from user code:
         S0 = 420
         S1 = N - S0
 
-        self.assertExpectedInlineMunged(
+        with self.assertRaisesRegex(
             Exception,
-            lambda: f(
+            re.escape(
+                """got RuntimeError("test_clarity_named_tuple::iterator_mismatch() Expected a value of type 'List[int]' for argument 'sizes' but instead found type 'inSizes (aka NamedTuple(size_0, size_1))'."""
+            ),
+        ):
+            f(
                 torch.tensor([S0, S1], device=device),
                 make_tensor(N, dtype=torch.float32, device=device),
-            ),
-            """\
-Dynamo failed to run FX node with fake tensors: call_function test_clarity_named_tuple.iterator_mismatch.default(*(FakeTensor(..., size=(7312,)), inSizes(size_0=u0, size_1=u1)), **{}): got RuntimeError("test_clarity_named_tuple::iterator_mismatch() Expected a value of type 'List[int]' for argument 'sizes' but instead found type 'inSizes (aka NamedTuple(size_0, size_1))'.\\nPosition: 1\\nValue: inSizes(size_0=u0, size_1=u1)\\nDeclaration: test_clarity_named_tuple::iterator_mismatch(Tensor input, int[] sizes) -> Tensor[]\\nCast error details: Unable to cast Python instance of type <class 'torch._dynamo.variables.functions.inSizes'> to C++ type '?' (#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for details)")
-
-from user code:
-   File "test_error_messages.py", line N, in f
-    r0, r1 = torch.ops.test_clarity_named_tuple.iterator_mismatch.default(""",
-        )
+            )
 
     def test_noniter_contents_error_message(self, device):
         lib_name = "test_clarity_noniter"
@@ -1778,19 +1766,16 @@ from user code:
         S0 = 420
         S1 = N - S0
 
-        self.assertExpectedInlineMunged(
+        with self.assertRaisesRegex(
             Exception,
-            lambda: f(
+            re.escape(
+                """got RuntimeError("test_clarity_noniter::iterator_mismatch() Expected a value of type 'List[int]' for argument 'sizes' but instead found type 'SymInt'."""
+            ),
+        ):
+            f(
                 torch.tensor([S0, S1], device=device),
                 make_tensor(N, dtype=torch.float32, device=device),
-            ),
-            """\
-Dynamo failed to run FX node with fake tensors: call_function test_clarity_noniter.iterator_mismatch.default(*(FakeTensor(..., size=(7312,)), u0), **{}): got RuntimeError("test_clarity_noniter::iterator_mismatch() Expected a value of type 'List[int]' for argument 'sizes' but instead found type 'SymInt'.\\nPosition: 1\\nValue: u0\\nDeclaration: test_clarity_noniter::iterator_mismatch(Tensor input, int[] sizes) -> Tensor[]\\nCast error details: Unable to cast Python instance of type <class 'torch.SymInt'> to C++ type '?' (#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for details)")
-
-from user code:
-   File "test_error_messages.py", line N, in f
-    r0, r1 = torch.ops.test_clarity_noniter.iterator_mismatch.default(x, s0)""",
-        )
+            )
 
 
 instantiate_device_type_tests(ErrorMessageClarityTest, globals())

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -1627,6 +1627,7 @@ from user code:
     torch._dynamo.graph_break()""",
             )
 
+
 class ErrorMessageClarityTest(TestCase):
     def __init__(self, method_name):
         super().__init__(method_name)

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -1628,6 +1628,12 @@ from user code:
             )
 
 class ErrorMessageClarityTest(TestCase):
+    def __init__(self, method_name):
+        super().__init__(method_name)
+        self.N = 7312
+        self.S0 = 420
+        self.S1 = self.N - self.S0
+
     def opSetup(self, lib_name):
         torch.library.define(
             lib_name + "::iterator_mismatch", "(Tensor input, int[] sizes) -> Tensor[]"
@@ -1657,10 +1663,6 @@ class ErrorMessageClarityTest(TestCase):
             r0, r1 = torch.ops.test_clarity_list.iterator_mismatch.default(x, [s0, s1])
             return torch.ops.aten.sort.default(r1)
 
-        N = 7312
-        S0 = 420
-        S1 = N - S0
-
         with self.assertRaisesRegex(
             Exception,
             re.escape(
@@ -1668,8 +1670,8 @@ class ErrorMessageClarityTest(TestCase):
             ),
         ):
             f(
-                torch.tensor([S0, S1], device=device),
-                make_tensor(N, dtype=torch.float32, device=device),
+                torch.tensor([self.S0, self.S1], device=device),
+                make_tensor(self.N, dtype=torch.float32, device=device),
             )
 
     def test_tuple_iterator_contents_error_message(self, device):
@@ -1682,10 +1684,6 @@ class ErrorMessageClarityTest(TestCase):
             r0, r1 = torch.ops.test_clarity_tuple.iterator_mismatch.default(x, (s0, s1))
             return torch.ops.aten.sort.default(r1)
 
-        N = 7312
-        S0 = 420
-        S1 = N - S0
-
         with self.assertRaisesRegex(
             Exception,
             re.escape(
@@ -1693,8 +1691,8 @@ class ErrorMessageClarityTest(TestCase):
             ),
         ):
             f(
-                torch.tensor((S0, S1), device=device),
-                make_tensor(N, dtype=torch.float32, device=device),
+                torch.tensor((self.S0, self.S1), device=device),
+                make_tensor(self.N, dtype=torch.float32, device=device),
             )
 
     def test_dict_iterator_contents_error_message(self, device):
@@ -1709,10 +1707,6 @@ class ErrorMessageClarityTest(TestCase):
             )
             return torch.ops.aten.sort.default(r1)
 
-        N = 7312
-        S0 = 420
-        S1 = N - S0
-
         with self.assertRaisesRegex(
             Exception,
             re.escape(
@@ -1720,8 +1714,8 @@ class ErrorMessageClarityTest(TestCase):
             ),
         ):
             f(
-                torch.tensor((S0, S1), device=device),
-                make_tensor(N, dtype=torch.float32, device=device),
+                torch.tensor((self.S0, self.S1), device=device),
+                make_tensor(self.N, dtype=torch.float32, device=device),
             )
 
     def test_named_tuple_iterator_contents_error_message(self, device):
@@ -1737,10 +1731,6 @@ class ErrorMessageClarityTest(TestCase):
             )
             return torch.ops.aten.sort.default(r1)
 
-        N = 7312
-        S0 = 420
-        S1 = N - S0
-
         with self.assertRaisesRegex(
             Exception,
             re.escape(
@@ -1748,8 +1738,8 @@ class ErrorMessageClarityTest(TestCase):
             ),
         ):
             f(
-                torch.tensor([S0, S1], device=device),
-                make_tensor(N, dtype=torch.float32, device=device),
+                torch.tensor([self.S0, self.S1], device=device),
+                make_tensor(self.N, dtype=torch.float32, device=device),
             )
 
     def test_noniter_contents_error_message(self, device):
@@ -1762,10 +1752,6 @@ class ErrorMessageClarityTest(TestCase):
             r0, r1 = torch.ops.test_clarity_noniter.iterator_mismatch.default(x, s0)
             return torch.ops.aten.sort.default(r1)
 
-        N = 7312
-        S0 = 420
-        S1 = N - S0
-
         with self.assertRaisesRegex(
             Exception,
             re.escape(
@@ -1773,8 +1759,8 @@ class ErrorMessageClarityTest(TestCase):
             ),
         ):
             f(
-                torch.tensor([S0, S1], device=device),
-                make_tensor(N, dtype=torch.float32, device=device),
+                torch.tensor([self.S0, self.S1], device=device),
+                make_tensor(self.N, dtype=torch.float32, device=device),
             )
 
 

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -1633,6 +1633,7 @@ class ErrorMessageClarityTest(TestCase):
         self.N = 7312
         self.S0 = 420
         self.S1 = self.N - self.S0
+        torch._dynamo.config.capture_scalar_outputs = True
 
     def opSetup(self, lib_name):
         torch.library.define(

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -17,8 +17,10 @@ import torch.utils._pytree as python_pytree
 from torch._dynamo.exc import ResumePrologueTracingError, Unsupported
 from torch._dynamo.testing import skipIfNotPy312, skipIfOnlyNotPy312
 from torch._dynamo.utils import counters
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     IS_FBCODE,
+    make_tensor,
     munge_exc,
     scoped_load_inline,
     TestCase,
@@ -1645,7 +1647,7 @@ class ErrorMessageClarityTest(TestCase):
             rs = torch.ops.aten.split_with_sizes.default(input, sizes)
             return [input.new_empty(r.size()) for r in rs]
 
-    def test_list_iterator_contents_error_message(self):
+    def test_list_iterator_contents_error_message(self, device):
         lib_name = "test_clarity_list"
         self.opSetup(lib_name)
 
@@ -1661,7 +1663,10 @@ class ErrorMessageClarityTest(TestCase):
 
         self.assertExpectedInlineMunged(
             Exception,
-            lambda: f(torch.tensor([S0, S1]), torch.randn(N)),
+            lambda: f(
+                torch.tensor([S0, S1], device=device),
+                make_tensor(N, dtype=torch.float32, device=device),
+            ),
             """\
 Dynamo failed to run FX node with fake tensors: call_function test_clarity_list.iterator_mismatch.default(*(FakeTensor(..., size=(7312,)), [u0, u1]), **{}): got RuntimeError("test_clarity_list::iterator_mismatch() Expected a value of type 'List[int]' for argument 'sizes' but instead found type 'immutable_list(SymInt, SymInt)'.\\nPosition: 1\\nValue: [u0, u1]\\nDeclaration: test_clarity_list::iterator_mismatch(Tensor input, int[] sizes) -> Tensor[]\\nCast error details: Unable to cast Python instance of type <class 'torch.fx.immutable_collections.immutable_list'> to C++ type '?' (#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for details)")
 
@@ -1670,7 +1675,7 @@ from user code:
     r0, r1 = torch.ops.test_clarity_list.iterator_mismatch.default(x, [s0, s1])""",
         )
 
-    def test_tuple_iterator_contents_error_message(self):
+    def test_tuple_iterator_contents_error_message(self, device):
         lib_name = "test_clarity_tuple"
         self.opSetup(lib_name)
 
@@ -1686,7 +1691,10 @@ from user code:
 
         self.assertExpectedInlineMunged(
             Exception,
-            lambda: f(torch.tensor((S0, S1)), torch.randn(N)),
+            lambda: f(
+                torch.tensor((S0, S1), device=device),
+                make_tensor(N, dtype=torch.float32, device=device),
+            ),
             """\
 Dynamo failed to run FX node with fake tensors: call_function test_clarity_tuple.iterator_mismatch.default(*(FakeTensor(..., size=(7312,)), (u0, u1)), **{}): got RuntimeError("test_clarity_tuple::iterator_mismatch() Expected a value of type 'List[int]' for argument 'sizes' but instead found type 'tuple(SymInt, SymInt)'.\\nPosition: 1\\nValue: (u0, u1)\\nDeclaration: test_clarity_tuple::iterator_mismatch(Tensor input, int[] sizes) -> Tensor[]\\nCast error details: Unable to cast Python instance of type <class 'tuple'> to C++ type '?' (#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for details)")
 
@@ -1695,7 +1703,7 @@ from user code:
     r0, r1 = torch.ops.test_clarity_tuple.iterator_mismatch.default(x, (s0, s1))""",
         )
 
-    def test_dict_iterator_contents_error_message(self):
+    def test_dict_iterator_contents_error_message(self, device):
         lib_name = "test_clarity_dict"
         self.opSetup(lib_name)
 
@@ -1713,7 +1721,10 @@ from user code:
 
         self.assertExpectedInlineMunged(
             Exception,
-            lambda: f(torch.tensor((S0, S1)), torch.randn(N)),
+            lambda: f(
+                torch.tensor((S0, S1), device=device),
+                make_tensor(N, dtype=torch.float32, device=device),
+            ),
             """\
 Dynamo failed to run FX node with fake tensors: call_function test_clarity_dict.iterator_mismatch.default(*(FakeTensor(..., size=(7312,)), {1: u0, 2: u1}), **{}): got RuntimeError("test_clarity_dict::iterator_mismatch() Expected a value of type 'List[int]' for argument 'sizes' but instead found type 'immutable_dict(int, int)'.\\nPosition: 1\\nValue: {1: u0, 2: u1}\\nDeclaration: test_clarity_dict::iterator_mismatch(Tensor input, int[] sizes) -> Tensor[]\\nCast error details: Unable to cast Python instance of type <class 'torch.fx.immutable_collections.immutable_dict'> to C++ type '?' (#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for details)")
 
@@ -1722,7 +1733,7 @@ from user code:
     r0, r1 = torch.ops.test_clarity_dict.iterator_mismatch.default(""",
         )
 
-    def test_named_tuple_iterator_contents_error_message(self):
+    def test_named_tuple_iterator_contents_error_message(self, device):
         lib_name = "test_clarity_named_tuple"
         self.opSetup(lib_name)
 
@@ -1741,7 +1752,10 @@ from user code:
 
         self.assertExpectedInlineMunged(
             Exception,
-            lambda: f(torch.tensor([S0, S1]), torch.randn(N)),
+            lambda: f(
+                torch.tensor([S0, S1], device=device),
+                make_tensor(N, dtype=torch.float32, device=device),
+            ),
             """\
 Dynamo failed to run FX node with fake tensors: call_function test_clarity_named_tuple.iterator_mismatch.default(*(FakeTensor(..., size=(7312,)), inSizes(size_0=u0, size_1=u1)), **{}): got RuntimeError("test_clarity_named_tuple::iterator_mismatch() Expected a value of type 'List[int]' for argument 'sizes' but instead found type 'inSizes (aka NamedTuple(size_0, size_1))'.\\nPosition: 1\\nValue: inSizes(size_0=u0, size_1=u1)\\nDeclaration: test_clarity_named_tuple::iterator_mismatch(Tensor input, int[] sizes) -> Tensor[]\\nCast error details: Unable to cast Python instance of type <class 'torch._dynamo.variables.functions.inSizes'> to C++ type '?' (#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for details)")
 
@@ -1750,7 +1764,7 @@ from user code:
     r0, r1 = torch.ops.test_clarity_named_tuple.iterator_mismatch.default(""",
         )
 
-    def test_noniter_contents_error_message(self):
+    def test_noniter_contents_error_message(self, device):
         lib_name = "test_clarity_noniter"
         self.opSetup(lib_name)
 
@@ -1766,15 +1780,20 @@ from user code:
 
         self.assertExpectedInlineMunged(
             Exception,
-            lambda: f(torch.tensor([S0, S1]), torch.randn(N)),
+            lambda: f(
+                torch.tensor([S0, S1], device=device),
+                make_tensor(N, dtype=torch.float32, device=device),
+            ),
             """\
 Dynamo failed to run FX node with fake tensors: call_function test_clarity_noniter.iterator_mismatch.default(*(FakeTensor(..., size=(7312,)), u0), **{}): got RuntimeError("test_clarity_noniter::iterator_mismatch() Expected a value of type 'List[int]' for argument 'sizes' but instead found type 'SymInt'.\\nPosition: 1\\nValue: u0\\nDeclaration: test_clarity_noniter::iterator_mismatch(Tensor input, int[] sizes) -> Tensor[]\\nCast error details: Unable to cast Python instance of type <class 'torch.SymInt'> to C++ type '?' (#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for details)")
 
 from user code:
    File "test_error_messages.py", line N, in f
-    r0, r1 = torch.ops.test_clarity_noniter.iterator_mismatch.default(""",
+    r0, r1 = torch.ops.test_clarity_noniter.iterator_mismatch.default(x, s0)""",
         )
 
+
+instantiate_device_type_tests(ErrorMessageClarityTest, globals())
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -17,10 +17,10 @@ from torch._dynamo.exc import ResumePrologueTracingError, Unsupported
 from torch._dynamo.testing import skipIfNotPy312, skipIfOnlyNotPy312
 from torch._dynamo.utils import counters
 from torch.testing._internal.common_utils import (
-    TestCase,
     IS_FBCODE,
     munge_exc,
     scoped_load_inline,
+    TestCase,
 )
 from torch.testing._internal.logging_utils import LoggingTestCase, make_logging_test
 
@@ -1625,23 +1625,27 @@ from user code:
             )
 
 class ErrorMessageClarityTest(TestCase):
-
     def setUp(self):
         super().setUp()
-        torch.library.define("test_clarity::iterator_mismatch", "(Tensor input, int[] sizes) -> Tensor[]")
+        torch.library.define(
+            "test_clarity::iterator_mismatch", "(Tensor input, int[] sizes) -> Tensor[]"
+        )
 
         def iterator_mismatch_fn(input, sizes):
-            return [t.clone() for t in torch.ops.aten.split_with_sizes.default(input, sizes)]
+            return [
+                t.clone() for t in torch.ops.aten.split_with_sizes.default(input, sizes)
+            ]
 
-        torch.library.impl("test_clarity::iterator_mismatch", "default", iterator_mismatch_fn)
+        torch.library.impl(
+            "test_clarity::iterator_mismatch", "default", iterator_mismatch_fn
+        )
 
         @torch.library.register_fake("test_clarity::iterator_mismatch")
         def iterator_mismatch_abstract(input, sizes):
             rs = torch.ops.aten.split_with_sizes.default(input, sizes)
             return [input.new_empty(r.size()) for r in rs]
 
-    def test_iterator_contents_error_message(self):
-
+    def test_list_iterator_contents_error_message(self):
         @torch.compile()
         def f(sz, x):
             s0, s1 = sz.tolist()
@@ -1651,21 +1655,40 @@ class ErrorMessageClarityTest(TestCase):
         N = 7312
         S0 = 420
         S1 = N - S0
-        #f(torch.tensor([S0, S1]), torch.randn(N))
-
-        #for test_type in iterable_types:
-        #    f(torch.tensor(test_type([S0, S1])), torch.randn(N))
 
         self.assertExpectedInlineMunged(
             Exception,
             lambda: f(torch.tensor([S0, S1]), torch.randn(N)),
             """\
-Dynamo failed to run FX node with fake tensors: call_function test_clarity.iterator_mismatch.default(*(FakeTensor(..., size=(7312,)), [u0, u1]), **{}): got RuntimeError("test_clarity::iterator_mismatch() Expected a value of type 'List[int]' for argument 'sizes' but instead found type 'immutable_list(SymInt, SymInt)'.\nPosition: 1\nValue: [u0, u1]\nDeclaration: test_clarity::iterator_mismatch(Tensor input, int[] sizes) -> Tensor[]\nCast error details: Unable to cast Python instance of type <class 'torch.fx.immutable_collections.immutable_list'> to C++ type '?' (#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for details)")
+Dynamo failed to run FX node with fake tensors: call_function test_clarity.iterator_mismatch.default(*(FakeTensor(..., size=(7312,)), [u0, u1]), **{}): got RuntimeError("test_clarity::iterator_mismatch() Expected a value of type 'List[int]' for argument 'sizes' but instead found type 'immutable_list(SymInt, SymInt)'.\\nPosition: 1\\nValue: [u0, u1]\\nDeclaration: test_clarity::iterator_mismatch(Tensor input, int[] sizes) -> Tensor[]\\nCast error details: Unable to cast Python instance of type <class 'torch.fx.immutable_collections.immutable_list'> to C++ type '?' (#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for details)")
 
 from user code:
    File "test_error_messages.py", line N, in f
-    r0, r1 = torch.ops.test_clarity.iterator_mismatch.default(x, [s0, s1])"""
+    r0, r1 = torch.ops.test_clarity.iterator_mismatch.default(x, [s0, s1])""",
         )
+
+    def test_tuple_iterator_contents_error_message(self):
+        @torch.compile()
+        def f(sz, x):
+            s0, s1 = sz.tolist()
+            r0, r1 = torch.ops.test_clarity.iterator_mismatch.default(x, (s0, s1))
+            return torch.ops.aten.sort.default(r1)
+
+        N = 7312
+        S0 = 420
+        S1 = N - S0
+
+        self.assertExpectedInlineMunged(
+            Exception,
+            lambda: f(torch.tensor((S0, S1)), torch.randn(N)),
+            """\
+Dynamo failed to run FX node with fake tensors: call_function test_clarity.iterator_mismatch.default(*(FakeTensor(..., size=(7312,)), (u0, u1)), **{}): got RuntimeError("test_clarity::iterator_mismatch() Expected a value of type 'List[int]' for argument 'sizes' but instead found type 'tuple(SymInt, SymInt)'.\\nPosition: 1\\nValue: (u0, u1)\\nDeclaration: test_clarity::iterator_mismatch(Tensor input, int[] sizes) -> Tensor[]\\nCast error details: Unable to cast Python instance of type <class 'tuple'> to C++ type '?' (#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for details)")
+
+from user code:
+   File "test_error_messages.py", line N, in f
+    r0, r1 = torch.ops.test_clarity.iterator_mismatch.default(x, (s0, s1))""",
+        )
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -800,7 +800,7 @@ inline std::string friendlyTypeName(py::handle obj) {
     ss << py::str(py::type::handle_of(obj).attr("__name__"));
     ss << "(";
     bool first = true;
-    for (auto item : obj) {
+    for (const auto& item : obj) {
       if (!first) {
         ss << ", ";
       }

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -795,19 +795,23 @@ inline std::string friendlyTypeName(py::handle obj) {
     }
     ss << "))";
     return ss.str();
-  } else if (py::hasattr(obj, "__iter__")) {
+  } else if (py::isinstance<py::iterable>(obj)) {
     std::stringstream ss;
     ss << py::str(py::type::handle_of(obj).attr("__name__"));
-    ss << "(";
-    bool first = true;
-    for (const auto& item : obj) {
-      if (!first) {
-        ss << ", ";
+    try {
+      ss << "(";
+      bool first = true;
+      for (const auto& item : obj) {
+        if (!first) {
+          ss << ", ";
+        }
+        ss << py::str(py::type::handle_of(item).attr("__name__"));
+        first = false;
       }
-      ss << py::str(py::type::handle_of(item).attr("__name__"));
-      first = false;
+      ss << ")";
+    } catch (const py::error_already_set& e) {
+      ss << "empty)";
     }
-    ss << ")";
     return ss.str();
   } else {
     return py::str(py::type::handle_of(obj).attr("__name__"));

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -795,6 +795,20 @@ inline std::string friendlyTypeName(py::handle obj) {
     }
     ss << "))";
     return ss.str();
+  } else if (py::hasattr(obj, "__iter__")) {
+    std::stringstream ss;
+    ss << py::str(py::type::handle_of(obj).attr("__name__"));
+    ss << "(";
+    bool first = true;
+    for (auto item : obj) {
+      if (!first) {
+        ss << ", ";
+      }
+      ss << py::str(py::type::handle_of(item).attr("__name__"));
+      first = false;
+    }
+    ss << ")";
+    return ss.str();
   } else {
     return py::str(py::type::handle_of(obj).attr("__name__"));
   }


### PR DESCRIPTION
Fixes #122129

- The issue noted is that immutable_list(SymInt) -> SymInt[] is not the problem but actually immutable_list(SymInt) -> Int[]. For this the vital part is the internals of the iterable not necessarily the container.
 
- The change maintains the friendly naming print for named tuples, but adds friendly naming for any iterable where the contents of iterable are exposed.

- As this is part of a RuntimeError and aims to provide a user with useful debug information, the decision to return the full contents of the list may provide more utility for debugging that restricting to the first N positions.

- Tests were added to cover the three control flows. The first two are existing namedtuple and else. Added catching all other iterables before the else. Tested several iterables to ensure friendly naming.

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela