### PR TITLE
[CUDA][Inductor][B200] re-bump tolerances for `test_baddmm` in `test_max_autotune.py` 

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -1094,7 +1094,7 @@ class TestMaxAutotune(TestCase):
         with config.patch({"max_autotune_gemm_search_space": search_space}):
             m_c = torch.compile(mode="max-autotune")(mod)
             out, code = run_and_get_code(m_c, x)
-            self.assertEqual(out, mod(x), atol=2e-3, rtol=1e-3)
+            self.assertEqual(out, mod(x), atol=2e-3, rtol=2e-3)
 
             FileCheck().check("triton_tem_fused_baddbmm").run(code[0])
 


### PR DESCRIPTION
Was originally landed in #159915 but was implicitly reverted https://github.com/pytorch/pytorch/pull/161957 perhaps due to incorrect rebase

Avoid failures that look like ` 1 / 25165824 (0.0%)` mismatches

cc @ptrblck @msaroufim @jerryzh168 @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben