### PR TITLE
remove unnecessary registration

### DIFF
--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -471,10 +471,7 @@ class TestFP8Lowering(TestCase):
             else:
                 self.assertEqual(y_eager, y_compiled, rtol=1e-2, atol=0.05)
 
-    @unittest.skipIf(
-        torch.cuda.is_available() and torch.cuda.get_device_capability() < (9, 0),
-        "Triton does not support fp8 on A100",
-    )
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     def test_scaled_mm_preserves_strides(self):
         """Test that scaled_mm preserves stride ordering through a custom pass."""
 

--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -7,6 +7,7 @@ from typing import Union
 import torch
 from torch import Tensor
 from torch._inductor import config, utils
+from torch._inductor.pattern_matcher import PatternMatcherPass
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import run_and_get_code
 from torch.testing._internal.common_cuda import (
@@ -469,6 +470,88 @@ class TestFP8Lowering(TestCase):
                 self.assertEqual(y_eager, y_compiled, rtol=5e-2, atol=0.07)
             else:
                 self.assertEqual(y_eager, y_compiled, rtol=1e-2, atol=0.05)
+
+    @unittest.skipIf(
+        torch.cuda.is_available() and torch.cuda.get_device_capability() < (9, 0),
+        "Triton does not support fp8 on A100",
+    )
+    def test_scaled_mm_preserves_strides(self):
+        """Test that scaled_mm preserves stride ordering through a custom pass."""
+
+        GPU_TYPE = "cuda"
+
+        def f(a, b, scale_a, scale_b):
+            # Convert to fp8 with correct strides for scaled_mm
+            a_fp8 = a.to(torch.float8_e4m3fn).contiguous()  # row-major
+            b_fp8 = b.t().contiguous().t().to(torch.float8_e4m3fn)  # column-major
+            return torch._scaled_mm(
+                a_fp8, b_fp8, scale_a, scale_b, out_dtype=torch.bfloat16
+            )
+
+        class ScaledMMStridePass(PatternMatcherPass):
+            def __init__(self) -> None:
+                super().__init__()
+                self.called = False
+
+            def __call__(self, g: torch.fx.Graph):
+                # Directly manipulate the graph without using pattern matching
+                for node in g.nodes:
+                    if (
+                        node.op == "call_function"
+                        and node.target == torch.ops.aten._scaled_mm.default
+                    ):
+                        # Insert clone operations before scaled_mm
+                        with g.inserting_before(node):
+                            a_fp8, b_fp8 = node.args[0], node.args[1]
+
+                            # Clone the inputs to potentially change stride ordering
+                            a_cloned = g.call_function(
+                                torch.ops.aten.clone,
+                                (a_fp8,),
+                                {"memory_format": torch.contiguous_format},
+                            )
+                            b_cloned = g.call_function(
+                                torch.ops.aten.clone,
+                                (b_fp8,),
+                                {"memory_format": torch.contiguous_format},
+                            )
+
+                            # Replace the arguments in the scaled_mm call
+                            node.args = (a_cloned, b_cloned) + node.args[2:]
+                            self.called = True
+
+                g.lint()
+                return g
+
+        stride_pass = ScaledMMStridePass()
+
+        # Create inputs with correct strides for scaled_mm
+        a = torch.randn((64, 128), dtype=torch.bfloat16, device=GPU_TYPE)
+        b = torch.randn((128, 64), dtype=torch.bfloat16, device=GPU_TYPE)
+        scale_a = torch.tensor(1.0, device=GPU_TYPE)
+        scale_b = torch.tensor(1.0, device=GPU_TYPE)
+
+        # First, verify that f works without the pass (baseline)
+        expected = f(a, b, scale_a, scale_b)
+
+        from torch._inductor import config
+
+        with config.patch(post_grad_custom_post_pass=stride_pass):
+            f_compiled = torch.compile(f, dynamic=False)
+            result = f_compiled(a, b, scale_a, scale_b)
+
+            # Verify the pattern was called
+            self.assertTrue(stride_pass.called, "Stride ordering pass was not called")
+
+            # Verify correctness - the pass should preserve correctness
+            # even though it modified strides
+            self.assertEqual(expected, result, atol=1e-2, rtol=1e-2)
+
+            # Verify the generated code contains the clones inserted by our pass
+            _, (wrapper,) = run_and_get_code(f_compiled, a, b, scale_a, scale_b)
+            self.assertIn("scaled_mm", wrapper.lower())
+            # The clones should be visible in the generated code
+            self.assertIn("clone", wrapper.lower())
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     @unittest.skipIf(

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -25,7 +25,7 @@ from ..codegen.rocm.ck_universal_gemm_template import CKGemmTemplate
 from ..codegen.subgraph import SubgraphChoiceCaller, SubgraphTemplate
 from ..ir import Buffer, ChoiceCaller, is_triton, Layout
 from ..kernel_inputs import MMKernelInputs
-from ..lowering import add_layout_constraint, constrain_to_fx_strides, register_lowering
+from ..lowering import register_lowering
 from ..select_algorithm import (
     autotune_select_algorithm,
     ExternKernelChoice,
@@ -1251,9 +1251,6 @@ def tuned_sparse_semi_structured_mm(
     return autotune_select_algorithm(
         "sparse_semi_structured_mm", choices, (mat1, mat1_meta, mat2), layout
     )
-
-
-add_layout_constraint(aten._scaled_mm.default, constrain_to_fx_strides)
 
 
 @register_lowering(aten._scaled_mm.default, type_promotion_kind=None)  # type: ignore[misc]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #164481

scaled_mm already had `needs_exact_strides` in its op registration. also added a test showing these strides are being respected.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben