### PR TITLE
Numpy zerotensor handling

### DIFF
--- a/test/test_numpy_interop.py
+++ b/test/test_numpy_interop.py
@@ -164,6 +164,9 @@ class TestNumPyInterop(TestCase):
         self.assertEqual(y.dtype, np.bool_)
         self.assertEqual(x[0], y[0])
 
+    @skipIfTorchDynamo(
+        "can't check if value is ZeroTensor since _is_zerotensor returns a bool and not a TensorVariable"
+    )
     def test_to_numpy_zero_tensor(self, device) -> None:
         dtypes = [
             torch.uint8,

--- a/test/test_numpy_interop.py
+++ b/test/test_numpy_interop.py
@@ -164,6 +164,26 @@ class TestNumPyInterop(TestCase):
         self.assertEqual(y.dtype, np.bool_)
         self.assertEqual(x[0], y[0])
 
+    def test_to_numpy_zero_tensor(self, device) -> None:
+        dtypes = [
+            torch.uint8,
+            torch.int8,
+            torch.short,
+            torch.int,
+            torch.half,
+            torch.float,
+            torch.double,
+            torch.long,
+            torch.bool,
+        ]
+        
+        for dtype in dtypes:
+            x = torch._efficientzerotensor((10), dtype=dtype)
+            self.assertRaises(RuntimeError, lambda: x.numpy())
+            y = x.numpy(force=True)
+            for i in range(10):
+                self.assertEqual(y[i], 0)
+
     @skipIfTorchDynamo("conj bit not implemented in TensorVariable yet")
     def test_to_numpy_force_argument(self, device) -> None:
         for force in [False, True]:

--- a/test/test_numpy_interop.py
+++ b/test/test_numpy_interop.py
@@ -176,7 +176,6 @@ class TestNumPyInterop(TestCase):
             torch.long,
             torch.bool,
         ]
-        
         for dtype in dtypes:
             x = torch._efficientzerotensor((10), dtype=dtype)
             self.assertRaises(RuntimeError, lambda: x.numpy())

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -933,16 +933,6 @@ class TensorVariable(VariableTracker):
             proxy = tx.output.create_proxy(
                 "call_method", "view_as", *proxy_args_kwargs([self, self], {})
             )
-
-        # Add zero tensor check (similar to C++ implementation)
-        if not force or not force.as_python_constant():
-            # Check if this is a zero tensor
-            is_zero_tensor = self.call_method(tx, "_is_zerotensor", [], {})
-            if is_zero_tensor.as_python_constant():
-                raise RuntimeError(
-                    "Cannot convert a ZeroTensor to numpy. Set force=True if you need the zero array."
-                )
-
         return NumpyNdarrayVariable.create(tx, proxy)
 
     def method_tolist(self):

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -933,6 +933,16 @@ class TensorVariable(VariableTracker):
             proxy = tx.output.create_proxy(
                 "call_method", "view_as", *proxy_args_kwargs([self, self], {})
             )
+
+        # Add zero tensor check (similar to C++ implementation)
+        if not force or not force.as_python_constant():
+            # Check if this is a zero tensor
+            is_zero_tensor = self.call_method(tx, "_is_zerotensor", [], {})
+            if is_zero_tensor.as_python_constant():
+                raise RuntimeError(
+                    "Cannot convert a ZeroTensor to numpy. Set force=True if you need the zero array."
+                )
+
         return NumpyNdarrayVariable.create(tx, proxy)
 
     def method_tolist(self):


### PR DESCRIPTION
Fixes #89034

Updated tensor_to_numpy() function in tensor_numpy.cpp to handle ZeroTensors by throwing an error if force=False and returning an array full of zeros if force=True.

@ngimel, I just saw that you mentioned PyTorch is not too concerned with this issue but I had already worked on it so I figured I would push it anyways and see what you thought. Feel free to close the PR if you think it is not worth merging. 

@albanD  


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela