### PR TITLE
[precompile] Fix guard serialization loading bugs.

### DIFF
--- a/test/dynamo/test_guard_serialization.py
+++ b/test/dynamo/test_guard_serialization.py
@@ -4,8 +4,10 @@ import dataclasses
 import importlib
 import pickle
 import sys
+import tempfile
 import types
 import unittest
+import weakref
 from collections.abc import Iterator
 from unittest.mock import patch
 
@@ -18,6 +20,7 @@ import torch.utils.cpp_extension
 from torch._dynamo.bytecode_transformation import transform_code_object
 from torch._dynamo.exc import PackageError
 from torch._dynamo.guards import CheckFunctionManager, CompileId
+from torch._dynamo.package import CompilePackage
 from torch._dynamo.symbolic_convert import (
     ExceptionStack,
     InstructionTranslator,
@@ -44,8 +47,31 @@ class GlobalModule(torch.nn.Module):
         return x + 1
 
 
+class GlobalNestedModule(torch.nn.Module):
+    def __init__(self, submodule=None):
+        super().__init__()
+        self.linear = torch.nn.Linear(10, 10)
+        self.param = torch.nn.Parameter(torch.randn(3, 2))
+        self.nested = submodule or GlobalModule()
+
+    def forward(self, x):
+        return self.linear(x) + 1
+
+
 def global_func(x):
     return x + 1
+
+
+class ModuleNotSerializable(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.param = torch.nn.Parameter(torch.randn(3, 2))
+
+    def __getstate__(self):
+        raise NotImplementedError("not serialzable")
+
+    def forward(self, x):
+        return x + self.param
 
 
 class GlobalTorchFunctionMode(TorchFunctionMode):
@@ -61,6 +87,39 @@ class MyClass:
 
     def add(self, x):
         return x + 1
+
+
+class MyClassNotSerializable:
+    def __getstate__(self):
+        raise NotImplementedError
+
+    def add(self, x):
+        return x + 1
+
+
+class Inputs:
+    def __init__(self, x, unused):
+        self.x = x
+        self.unused = unused
+
+
+def _global_func_wrong_fqn(x):
+    return x + 1
+
+
+global_func_wrong_fqn = _global_func_wrong_fqn
+del _global_func_wrong_fqn
+
+
+class FlatModule(torch.nn.Module):
+    def forward(self, x):
+        return x + 2
+
+
+class ModWithDict(torch.nn.Module):
+    def __init__(self, d):
+        super().__init__()
+        self.d = d
 
 
 class SubclassWithMeta(torch.Tensor):
@@ -355,13 +414,14 @@ class TestGuardSerializationBase(torch._inductor.test_case.TestCase):
                 self._cached_guards_state = guards_state
                 self._cached_f_code = self._frame_state.f_code
                 self.assertIsNotNone(guards_state)
-                guards_state = pickle.loads(guards_state)
+                guards_state = torch._dynamo.package.load_guards_state(guards_state)
 
                 check_fn_manager = CheckFunctionManager(
                     self._frame_state.f_code,
                     guards_state.output_graph,
                     shape_code_parts=guards_state.shape_code_parts,
                     runtime_global_scope=self._frame_state.f_globals,
+                    source_get_cache=guards_state.source_get_cache,
                 )
                 loaded_gm = check_fn_manager.guard_manager
 
@@ -1372,10 +1432,289 @@ class TestGuardSerialization(TestGuardSerializationBase):
             ref, loaded, {"self": m, "foo": MyClass().add, "x": torch.randn(3, 2)}, True
         )
 
+    def test_bound_methods_missing(self):
+        class MyClass:
+            def __getstate__(self):
+                raise NotImplementedError
+
+            def add(self, x):
+                return x + 1
+
+        def foo(x: torch.Tensor, y: list[MyClass]):
+            assert len(y) == 1
+            return x + 1
+
+        ref, loaded = self._test_serialization(
+            "TYPE_MATCH", foo, torch.randn(3, 2), [MyClass()]
+        )
+        self._test_check_fn(
+            ref, loaded, {"x": torch.randn(3, 2), "y": [MyClass()]}, True
+        )
+
+    def test_bound_methods_empty(self):
+        def foo(x, y):
+            assert callable(y[0])
+            return x + 1
+
+        ref, loaded = self._test_serialization(
+            "TYPE_MATCH", foo, torch.randn(3, 2), [MyClassNotSerializable().add]
+        )
+        self._test_check_fn(
+            ref,
+            loaded,
+            {"x": torch.randn(3, 2), "y": [MyClassNotSerializable().add]},
+            True,
+        )
+
+    def test_ddp_module(self):
+        import torch.distributed as dist
+
+        if not dist.is_available():
+            self.skipTest("Torch distributed is not available")
+        from torch.nn.parallel import DistributedDataParallel as DDP
+
+        tmpfile = tempfile.NamedTemporaryFile()
+        dist.init_process_group(
+            backend="gloo", rank=0, world_size=1, init_method=f"file://{tmpfile.name}"
+        )
+        try:
+            ddp_model = DDP(GlobalNestedModule())
+
+            def foo(ddp, x):
+                return ddp(x)
+
+            x = torch.randn(10)
+            package = CompilePackage(foo)
+            torch._dynamo.optimize(
+                package=package,
+                guard_filter_fn=lambda gs: [
+                    x.guard_type not in ("CLOSURE_MATCH", "ID_MATCH") for x in gs
+                ],
+            )(foo)(ddp_model, x)
+            self.assertEqual(len(package._codes[foo.__code__].guarded_codes), 1)
+            torch._dynamo.package.load_guards_state(
+                package._codes[foo.__code__].guarded_codes[0].guards_state
+            )
+        finally:
+            dist.destroy_process_group()
+
+    def test_dict_keys_serialization(self):
+        d = {1: 2, 3: 4}
+
+        def foo(x, y):
+            for k in y:
+                x += k
+            return x
+
+        ref, loaded = self._test_serialization(
+            "TYPE_MATCH", foo, torch.randn(3, 2), d.keys()
+        )
+        self._test_check_fn(
+            ref,
+            loaded,
+            {"x": torch.randn(3, 2), "y": d.keys()},
+            True,
+        )
+
+    def test_unserializable_sharded_tensor(self):
+        import torch.distributed as dist
+
+        if not dist.is_available():
+            self.skipTest("Torch distributed is not available")
+
+        tmpfile = tempfile.NamedTemporaryFile()
+        dist.init_process_group(
+            backend="gloo", rank=0, world_size=1, init_method=f"file://{tmpfile.name}"
+        )
+        try:
+            ChunkShardingSpec = dist._shard.sharding_spec.ChunkShardingSpec
+            ShardedTensor = dist._shard.sharded_tensor.ShardedTensor
+            tensor = torch.arange(2, dtype=torch.int64)
+            local_tensor = torch.unsqueeze(torch.cat([tensor, tensor + 2]), 0)
+
+            sharding_dim = 0
+            sharding_spec = ChunkShardingSpec(
+                dim=sharding_dim,
+                placements=[
+                    "rank:0/cpu",
+                ],
+            )
+            st = ShardedTensor._init_from_local_tensor(
+                local_tensor, sharding_spec, [1, 4]
+            )
+
+            def foo(inputs):
+                return inputs.x + 1
+
+            ref, loaded = self._test_serialization(
+                "TENSOR_MATCH", foo, Inputs(torch.randn(3, 2), st)
+            )
+            self._test_check_fn(
+                ref, loaded, {"inputs": Inputs(torch.randn(3, 2), st)}, True
+            )
+        finally:
+            dist.destroy_process_group()
+
+    def test_function_with_wrong_fqn(self):
+        def foo(inputs):
+            return inputs.x + 1
+
+        x = torch.randn(3, 2)
+        ref, loaded = self._test_serialization(
+            "TENSOR_MATCH", foo, Inputs(x, global_func_wrong_fqn)
+        )
+        self._test_check_fn(
+            ref, loaded, {"inputs": Inputs(x, global_func_wrong_fqn)}, True
+        )
+
+    def test_c10d_work(self):
+        import torch.distributed as dist
+
+        if not dist.is_available():
+            self.skipTest("Torch distributed is not available")
+
+        Work = dist.distributed_c10d.Work
+
+        class DummyWork(Work):
+            def __init__(self, should_succeed=True):
+                super().__init__()
+                self._done = False
+                self._should_succeed = should_succeed
+
+            def is_completed(self):
+                return self._done
+
+            def is_success(self):
+                return self._should_succeed
+
+            def wait(self, timeout=None):
+                self._done = True
+                if not self._should_succeed:
+                    raise RuntimeError("DummyWork failed")
+                return self
+
+            def result(self):
+                if not self._should_succeed:
+                    raise RuntimeError("DummyWork failed")
+                return "dummy_result"
+
+        def foo(inputs):
+            return inputs.x + 1
+
+        x = torch.randn(3, 2)
+        ref, loaded = self._test_serialization(
+            "TENSOR_MATCH", foo, Inputs(x, DummyWork())
+        )
+        self._test_check_fn(ref, loaded, {"inputs": Inputs(x, DummyWork())}, True)
+
+    def test_unused_weakref(self):
+        def foo(inputs):
+            return inputs.x + 1
+
+        x = torch.randn(3, 2)
+        ref, loaded = self._test_serialization(
+            "TENSOR_MATCH", foo, Inputs(x, weakref.ref(x))
+        )
+        self._test_check_fn(ref, loaded, {"inputs": Inputs(x, weakref.ref(x))}, True)
+
+    def test_unused_stream(self):
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA is not available")
+
+        def foo(inputs):
+            return inputs.x + 1
+
+        x = torch.randn(3, 2)
+        ref, loaded = self._test_serialization(
+            "TENSOR_MATCH", foo, Inputs(x, torch.cuda.Stream())
+        )
+        self._test_check_fn(
+            ref, loaded, {"inputs": Inputs(x, torch.cuda.Stream())}, True
+        )
+
+    def test_unused_process_group(self):
+        import torch.distributed as dist
+
+        if not dist.is_available():
+            self.skipTest("Torch distributed is not available")
+
+        def foo(inputs):
+            return inputs.x + 1
+
+        tmpfile = tempfile.NamedTemporaryFile()
+        dist.init_process_group(
+            backend="gloo",
+            init_method=f"file://{tmpfile.name}",
+            rank=0,
+            world_size=1,
+        )
+
+        try:
+            pg = dist.distributed_c10d._get_default_group()
+            x = torch.randn(3, 2)
+            ref, loaded = self._test_serialization("TENSOR_MATCH", foo, Inputs(x, pg))
+            self._test_check_fn(ref, loaded, {"inputs": Inputs(x, pg)}, True)
+        finally:
+            dist.destroy_process_group()
+
+    def test_unserializable_submodule(self):
+        def foo(mod, x):
+            return mod(x)
+
+        x = torch.randn(10, 10)
+        mod = GlobalNestedModule(ModuleNotSerializable())
+        ref, loaded = self._test_serialization("TENSOR_MATCH", foo, mod, x)
+        self._test_check_fn(ref, loaded, {"mod": mod, "x": x}, True)
+
+    def test_closure_var_missing(self):
+        captured = torch.randn(3, 2)
+
+        def bar(x):
+            return x + captured
+
+        def foo(f, x):
+            return f(x)
+
+        x = torch.randn(3, 2)
+        ref, loaded = self._test_serialization("TENSOR_MATCH", foo, bar, x)
+        self._test_check_fn(ref, loaded, {"f": bar, "x": x}, True)
+
+    def test_bound_method_patched_forward(self):
+        def forward(x):
+            return x + 1
+
+        m = FlatModule()
+        m_forward = m.forward
+        m.forward = forward
+
+        def foo(f, x):
+            assert callable(f)
+            return f(x)
+
+        x = torch.randn(3, 2)
+        ref, loaded = self._test_serialization("TYPE_MATCH", foo, m_forward, x)
+        self._test_check_fn(ref, loaded, {"f": m_forward, "x": x}, True)
+
+    def test_guard_on_key_order_with_cache(self):
+        def foo(x, mod):
+            for y in mod.d.values():
+                x *= y
+            return x
+
+        x = torch.randn(3, 2)
+        d = {"a": 1e9, "b": 1e-9}
+        ref, loaded = self._test_serialization(
+            "DICT_KEYS_MATCH", foo, x, ModWithDict(d)
+        )
+        self._test_check_fn(
+            ref, loaded, {"x": x, "d": ModWithDict({"b": 1e-9, "a": 1e9})}, False
+        )
+
 
 class SimpleModule(torch.nn.Module):
-    def __init__(self):
+    def __init__(self, c):
         super().__init__()
+        self.c = c
         self.p = torch.nn.Parameter(torch.randn(3, 2))
 
     def forward(self, x):
@@ -1400,7 +1739,7 @@ if not IS_MACOS:
             from torch.distributed.fsdp import fully_shard
 
             mesh = init_device_mesh(str(torch.get_default_device()), (1,))
-            m = SimpleModule()
+            m = SimpleModule(42)
             m = fully_shard(m, mesh=mesh)
             inputs = distribute_tensor(torch.randn(3, 2), mesh, [Replicate()])
             ref, loaded = self._test_serialization("TENSOR_MATCH", m, inputs)

--- a/torch/_dynamo/aot_compile.py
+++ b/torch/_dynamo/aot_compile.py
@@ -77,6 +77,8 @@ class AOTCompiledFunction:
         return self._artifacts.guard_manager.check(f_locals)
 
     def __post_init__(self) -> None:
+        from .package import load_guards_state
+
         self._artifacts.check_compatibility()
 
         import_sources = {
@@ -92,7 +94,7 @@ class AOTCompiledFunction:
         )
 
         if self._artifacts.guard_manager is None:
-            guards_state = pickle.loads(self._artifacts.guards_state)
+            guards_state = load_guards_state(self._artifacts.guards_state)
             self._artifacts.guard_manager = torch._dynamo.guards.CheckFunctionManager(
                 self._artifacts.original_code,
                 guards_state.output_graph,

--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -24,6 +24,7 @@ import shutil
 import sys
 import types
 from collections.abc import Generator, Iterator
+from contextlib import nullcontext
 from typing import Any, Callable, NewType, Optional
 from typing_extensions import Never
 
@@ -94,6 +95,17 @@ class _GuardedCodeCacheEntry:
 
     guards_state: bytes
     dynamo_code: SerializedCode
+
+
+def load_guards_state(guards_state: bytes) -> Any:
+    try:
+        import torch.distributed.fsdp._fully_shard._fully_shard as _fully_shard
+
+        ctx = _fully_shard.disable_fsdp_module_new_init()
+    except ImportError:
+        ctx = nullcontext()  # type: ignore[assignment]
+    with ctx:
+        return pickle.loads(guards_state)
 
 
 _BackendId = NewType("_BackendId", str)  # __compiled_fn
@@ -750,7 +762,7 @@ class CompilePackage:
                     torch._dynamo.eval_frame.skip_code(target_code)
 
                 for guarded_code in entry.guarded_codes:
-                    guards_state = pickle.loads(guarded_code.guards_state)
+                    guards_state = load_guards_state(guarded_code.guards_state)
                     runtime_global_scope = sys.modules[entry.python_module].__dict__
                     # The installed builtins dict might be absent from the runtime
                     # while loading guards. Populate it if it's missing.
@@ -771,6 +783,7 @@ class CompilePackage:
                         OutputGraphCommon(guards_state.output_graph),
                         shape_code_parts=guards_state.shape_code_parts,
                         runtime_global_scope=runtime_global_scope,
+                        source_get_cache=guards_state.source_get_cache,
                     )
                     _load_precompile_entry(
                         target_code,


### PR DESCRIPTION
Summary: Added a set of fixes triggered by fm training job. Overall the theme here is that we should get rid of saved objects as much as possible when they are not used in guard reconstruction. Sometimes for objects that cannot be saved (like local functions) we still try our best to save their closures.

Test Plan:
test_guard_serialization.py
test_lazy_awatiable.py

Differential Revision: D83766926




cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela