### PR TITLE
Fix inconsistenty in cholesky complex between cuda and cpu

### DIFF
--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -957,9 +957,9 @@ Tensor& cholesky_inverse_kernel_impl_cusolver(Tensor &result, Tensor& infos, boo
     // Find the first zero diagonal element
     auto zero_positions = zero_diag_mask.nonzero();
     if (zero_positions.numel() > 0) {
-      int64_t first_zero_idx = zero_positions[0][-1].item<int64_t>() + 1; 
+      int64_t first_zero_idx = zero_positions[0][-1].item<int64_t>() + 1;
       auto error_infos = at::full_like(infos, static_cast<int>(first_zero_idx));
-      TORCH_CHECK_LINALG(false, "cholesky_inverse", result.dim() == 2 ? "" : ": (Batch element ", zero_positions[0][0].item<int64_t>(), ")",
+      TORCH_CHECK_LINALG(false, "cholesky_inverse", result.dim() == 2 ? "" : (": (Batch element ", zero_positions[0][0].item<int64_t>(), ")"),
           ": The diagonal element ", first_zero_idx, " is zero, the inversion could not be completed because the input matrix is singular.");
     }
   }

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -956,12 +956,9 @@ Tensor& cholesky_inverse_kernel_impl_cusolver(Tensor &result, Tensor& infos, boo
   if (zero_diag_mask.any().item<bool>()) {
     // Find the first zero diagonal element
     auto zero_positions = zero_diag_mask.nonzero();
-    if (zero_positions.numel() > 0) {
-      int64_t first_zero_idx = zero_positions[0][-1].item<int64_t>() + 1;
-      auto error_infos = at::full_like(infos, static_cast<int>(first_zero_idx));
-      TORCH_CHECK_LINALG(false, "cholesky_inverse", result.dim() == 2 ? "" : (": (Batch element ", zero_positions[0][0].item<int64_t>(), ")"),
-          ": The diagonal element ", first_zero_idx, " is zero, the inversion could not be completed because the input matrix is singular.");
-    }
+    int64_t first_zero_idx = zero_positions[0][-1].item<int64_t>() + 1;
+    TORCH_CHECK_LINALG(false, "cholesky_inverse", result.dim() == 2 ? "" : (": (Batch element ", zero_positions[0][0].item<int64_t>(), ")"),
+        ": The diagonal element ", first_zero_idx, " is zero, the inversion could not be completed because the input matrix is singular.");
   }
 
   _cholesky_inverse_cusolver_potrs_based(result, infos, upper);

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -957,7 +957,7 @@ Tensor& cholesky_inverse_kernel_impl_cusolver(Tensor &result, Tensor& infos, boo
     // Find the first zero diagonal element
     auto zero_positions = zero_diag_mask.nonzero();
     int64_t first_zero_idx = zero_positions[0][-1].item<int64_t>() + 1;
-    TORCH_CHECK_LINALG(false, "cholesky_inverse", result.dim() == 2 ? "" : (": (Batch element ", zero_positions[0][0].item<int64_t>(), ")"),
+    TORCH_CHECK_LINALG(false, "cholesky_inverse", result.dim() == 2 ? "" : ": (Batch element " + std::to_string(zero_positions[0][0].item<int64_t>()) + ")",
         ": The diagonal element ", first_zero_idx, " is zero, the inversion could not be completed because the input matrix is singular.");
   }
 

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -952,7 +952,7 @@ void _cholesky_inverse_cusolver_potrs_based(Tensor& result, Tensor& infos, bool 
 Tensor& cholesky_inverse_kernel_impl_cusolver(Tensor &result, Tensor& infos, bool upper) {
   // Check for zero diagonal elements before attempting inversion
   auto diag_elements = result.diagonal(/*offset=*/0, /*dim1=*/-2, /*dim2=*/-1);
-  auto zero_diag_mask = diag_elements.abs().lt(std::numeric_limits<double>::epsilon());
+  auto zero_diag_mask = diag_elements.eq(0);
   if (zero_diag_mask.any().item<bool>()) {
     // Find the first zero diagonal element
     auto zero_positions = zero_diag_mask.nonzero();

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -952,14 +952,11 @@ void _cholesky_inverse_cusolver_potrs_based(Tensor& result, Tensor& infos, bool 
 Tensor& cholesky_inverse_kernel_impl_cusolver(Tensor &result, Tensor& infos, bool upper) {
   // Check for zero diagonal elements before attempting inversion
   auto diag_elements = result.diagonal(/*offset=*/0, /*dim1=*/-2, /*dim2=*/-1);
-  auto zero_diag_mask = diag_elements.eq(0);
-  if (zero_diag_mask.any().item<bool>()) {
-    // Find the first zero diagonal element
-    auto zero_positions = zero_diag_mask.nonzero();
-    int64_t first_zero_idx = zero_positions[0][-1].item<int64_t>() + 1;
-    TORCH_CHECK_LINALG(false, "cholesky_inverse", result.dim() == 2 ? "" : ": (Batch element " + std::to_string(zero_positions[0][0].item<int64_t>()) + ")",
-        ": The diagonal element ", first_zero_idx, " is zero, the inversion could not be completed because the input matrix is singular.");
-  }
+  auto has_zero = diag_elements.eq(0).any();
+  at::_assert_async(
+      has_zero.logical_not(),
+      "cholesky_inverse: Diagonal contains zero element, matrix is singular."
+  );
 
   _cholesky_inverse_cusolver_potrs_based(result, infos, upper);
   return result;

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -9289,17 +9289,12 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
             with self.assertRaisesRegex(RuntimeError, "Expected all tensors to be on the same device"):
                 torch.cholesky_inverse(a, out=out)
 
-        # cholesky_inverse raises an error for invalid inputs on CPU
+        # cholesky_inverse raises an error for invalid inputs
         # for example if at least one diagonal element is zero
         a = torch.randn(3, 3, device=device, dtype=dtype)
         a[1, 1] = 0
-        if self.device_type == 'cpu':
-            with self.assertRaisesRegex(torch.linalg.LinAlgError, r"cholesky_inverse: The diagonal element 2 is zero"):
-                torch.cholesky_inverse(a)
-        # cholesky_inverse on GPU does not raise an error for this case
-        elif self.device_type == 'cuda':
-            out = torch.cholesky_inverse(a)
-            self.assertTrue(out.isinf().any() or out.isnan().any())
+        with self.assertRaisesRegex(torch.linalg.LinAlgError, r"cholesky_inverse: The diagonal element 2 is zero"):
+            torch.cholesky_inverse(a)
 
     def _select_broadcastable_dims(self, dims_full=None):
         # select full dimensionality


### PR DESCRIPTION
Fixes #158428

Updated torch.cholesky_inverse to throw the same error on CUDA as is does on the CPU when it has zero's on the diagonal (i.e. is a singular matrix).

@drisspg 