### PR TITLE
config for dcache + unit tests

### DIFF
--- a/test/inductor/test_caching.py
+++ b/test/inductor/test_caching.py
@@ -1,0 +1,111 @@
+# Owner(s): ["module: inductor"]
+# pyre-strict
+
+import os
+from unittest.mock import patch
+
+from filelock import FileLock
+
+from torch._inductor.runtime.caching import config
+from torch._inductor.test_case import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+)
+
+
+@instantiate_parametrized_tests
+class ConfigTest(TestCase):
+    FOO_THIS_VERSION: int = 0
+    FOO_JK_NAME: str = "foo_jk_name"
+    FOO_OSS_DEFAULT: bool = False
+    FOO_ENV_VAR_OVERRIDE: str = "foo_env_var_override"
+    FOO_ENV_VAR_OVERRIDE_LOCK: FileLock = FileLock(
+        f"/tmp/testing/{FOO_ENV_VAR_OVERRIDE}.lock"
+    )
+
+    def assert_versioned_config(self, expected_enabled: bool) -> None:
+        actual_enabled: bool = config._versioned_config(
+            self.FOO_JK_NAME,
+            self.FOO_THIS_VERSION,
+            self.FOO_OSS_DEFAULT,
+            env_var_override=self.FOO_ENV_VAR_OVERRIDE,
+        )
+        self.assertEqual(actual_enabled, expected_enabled)
+
+    @parametrize("enabled", [True, False])
+    def test_versioned_config_env_var_override(
+        self,
+        enabled: bool,
+    ) -> None:
+        """Test that environment variable overrides take precedence over other configuration sources.
+
+        Verifies that when an environment variable override is set to "1" or "0",
+        the _versioned_config function returns the corresponding boolean value
+        regardless of other configuration settings.
+        """
+        with (
+            self.FOO_ENV_VAR_OVERRIDE_LOCK.acquire(timeout=1),
+            patch.dict(
+                os.environ,
+                {
+                    self.FOO_ENV_VAR_OVERRIDE: "1" if enabled else "0",
+                },
+            ),
+            patch(
+                "torch._inductor.runtime.caching.config.is_fbcode",
+                return_value=False,
+            ),
+            patch.object(self, "FOO_OSS_DEFAULT", not enabled),
+        ):
+            self.assert_versioned_config(enabled)
+
+    @parametrize("enabled", [True, False])
+    def test_versioned_config_version_check(
+        self,
+        enabled: bool,
+    ) -> None:
+        """Test that _versioned_config responds correctly to version changes in Facebook environments.
+
+        Verifies that when running in fbcode environments (is_fbcode=True), the configuration
+        is enabled when the JustKnobs version matches the expected version, and disabled when
+        the version differs. This ensures proper rollout control through version management.
+        """
+        with (
+            self.FOO_ENV_VAR_OVERRIDE_LOCK.acquire(timeout=1),
+            patch.dict(os.environ, {}, clear=True),
+            patch(
+                "torch._inductor.runtime.caching.config.is_fbcode",
+                return_value=True,
+            ),
+            patch(
+                "torch._utils_internal.justknobs_getval_int",
+                return_value=self.FOO_THIS_VERSION + (-1 if enabled else 1),
+            ),
+        ):
+            self.assert_versioned_config(enabled)
+
+    @parametrize("enabled", [True, False])
+    def test_versioned_config_oss_default(
+        self,
+        enabled: bool,
+    ) -> None:
+        """Test that _versioned_config uses OSS default values in non-Facebook environments.
+
+        Verifies that when running in non-fbcode environments (is_fbcode=False) with no
+        environment variable overrides, the configuration falls back to the OSS default
+        value. This ensures proper behavior for open-source PyTorch distributions.
+        """
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch(
+                "torch._inductor.runtime.caching.config.is_fbcode",
+                return_value=False,
+            ),
+            patch.object(self, "FOO_OSS_DEFAULT", enabled),
+        ):
+            self.assert_versioned_config(enabled)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/runtime/caching/config.py
+++ b/torch/_inductor/runtime/caching/config.py
@@ -1,0 +1,57 @@
+import os
+from typing import Optional
+
+import torch
+from torch._environment import is_fbcode
+
+
+def _versioned_config(
+    jk_name: str,
+    this_version: int,
+    oss_default: bool,
+    env_var_override: Optional[str] = None,
+) -> bool:
+    """
+    A versioned configuration utility that determines boolean settings based on:
+    1. Environment variable override (highest priority)
+    2. JustKnobs version comparison in fbcode environments
+    3. OSS default fallback
+
+    This function enables gradual rollouts of features in fbcode by comparing
+    a local version against a JustKnobs-controlled remote version, while
+    allowing environment variable overrides for testing and OSS defaults
+    for non-fbcode environments.
+
+    Args:
+        jk_name: JustKnobs key name (e.g., "pytorch/inductor:feature_version")
+        this_version: Local version number to compare against JustKnobs version
+        oss_default: Default value to use in non-fbcode environments
+        env_var_override: Optional environment variable name that, when set,
+                         overrides all other logic
+
+    Returns:
+        bool: Configuration value determined by the priority order above
+    """
+    if (
+        env_var_override
+        and (env_var_value := os.environ.get(env_var_override)) is not None
+    ):
+        return env_var_value == "1"
+    elif is_fbcode():
+        jk_version: int = torch._utils_internal.justknobs_getval_int(jk_name)
+        return this_version >= jk_version
+    return oss_default
+
+
+_DETERMINISTIC_CACHING_VERSION: int = 0
+_DETERMINISTIC_CACHING_VERSION_JK: str = (
+    "pytorch/inductor:deterministic_caching_version"
+)
+_DETERMINISTIC_CACHING_OSS_DEFAULT: bool = False
+_DETERMINISTIC_CACHING_ENV_VAR_OVERRIDE: str = "TORCHINDUCTOR_DETERMINISTIC_CACHING"
+DETERMINISTIC_CACHING: bool = _versioned_config(
+    _DETERMINISTIC_CACHING_VERSION_JK,
+    _DETERMINISTIC_CACHING_VERSION,
+    _DETERMINISTIC_CACHING_OSS_DEFAULT,
+    _DETERMINISTIC_CACHING_ENV_VAR_OVERRIDE,
+)


### PR DESCRIPTION
Test Plan:
```
buck test fbcode//mode/opt caffe2/test/inductor:caching
```

Reviewed By: aorenste

Differential Revision: D83714687




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben