### PR TITLE
[testing] Fix internal testing not being able to import some tests

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -877,7 +877,7 @@ def cppProfilingFlagsToProfilingMode():
     else:
         return ProfilingMode.LEGACY
 
-# Set default value to for the internal test runner which imports files/modules
+# Set default value for the internal test runner which imports files/modules
 # directly
 GRAPH_EXECUTOR : ProfilingMode = cppProfilingFlagsToProfilingMode()
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -115,7 +115,6 @@ CI_FUNCTORCH_ROOT = ""
 CI_PT_ROOT = ""
 CI_TEST_PREFIX = ""
 DISABLED_TESTS_FILE = ""
-GRAPH_EXECUTOR : Optional[ProfilingMode] = None
 LOG_SUFFIX = ""
 PYTEST_SINGLE_TEST = ""
 REPEAT_COUNT = 0
@@ -877,6 +876,10 @@ def cppProfilingFlagsToProfilingMode():
             return ProfilingMode.SIMPLE
     else:
         return ProfilingMode.LEGACY
+
+# Set default value to for the internal test runner which imports files/modules
+# directly
+GRAPH_EXECUTOR : ProfilingMode = cppProfilingFlagsToProfilingMode()
 
 @contextmanager
 def enable_profiling_mode_for_profiling_tests():


### PR DESCRIPTION
I think the internal runner imports modules and files directly, so it doesn't run the `if __name__ == "__main__"` and the command line parsing there that would set the default values for some global variables

See https://github.com/pytorch/pytorch/pull/156703#issuecomment-3362135688 for context

Testing:
ran locally on devserver to see if tests could be collected