### PR TITLE
multimem reduce

### DIFF
--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -918,6 +918,37 @@ class SymmMemCollectiveTest(MultiProcContinuousTest):
             gathered_inps.sum(dim=0), res, rtol=1e-03, atol=1e-05
         )
 
+    @skip_if_lt_x_gpu(4)
+    @requires_multicast_support()
+    @parametrize("dtype", [torch.float, torch.bfloat16])
+    @parametrize("size_bytes", [4, 8192, 8196])
+    # https://github.com/pytorch/pytorch/issues/164015
+    @xfailIfSM100OrLater
+    def test_multimem_one_shot_reduce_out(
+        self, dtype: torch.dtype, size_bytes: int
+    ) -> None:
+        self._init_process()
+        group_name = dist.group.WORLD.group_name
+
+        inp = symm_mem.empty(
+            size_bytes // dtype.itemsize, dtype=dtype, device=self.device
+        ).normal_()
+        out = torch.empty_like(inp)
+        symm_mem.rendezvous(inp, group=group_name)
+
+        root = 0
+        torch.ops.symm_mem.multimem_one_shot_reduce_out(
+            inp, "sum", root, group_name, out
+        )
+
+        gathered_inps = all_gather_tensor(inp, 0, "0").view(self.world_size, -1)
+        # Only verify that the results are close to the sum of inputs across
+        # ranks (see Note [multimem_one_shot_all_reduce]).
+        if self.rank == root:
+            torch.testing.assert_close(
+                gathered_inps.sum(dim=0), out, rtol=1e-03, atol=1e-05
+            )
+
     @skipIf(
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryOps.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryOps.cu
@@ -16,6 +16,7 @@
 #endif
 
 #include <torch/csrc/distributed/c10d/cuda/AsyncMM.cuh>
+#include <torch/csrc/distributed/c10d/GroupRegistry.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory-inl.h>
 #include <torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.hpp>
 
@@ -213,55 +214,68 @@ at::Tensor multimem_all_reduce_(
 }
 
 template <typename T, int alignment>
-static __global__ void multimem_one_shot_all_reduce_kernel(
+static __global__ void multimem_one_shot_reduce_kernel(
     T* input_mc_ptr,
     T* output_ptr,
     size_t numel,
     uint32_t** signal_pads,
     size_t rank,
-    size_t world_size) {
+    size_t world_size,
+    int64_t root) {
   static_assert(alignment % sizeof(T) == 0);
   constexpr size_t numel_per_thread = alignment / sizeof(T);
 
   sync_remote_blocks<false, true>(signal_pads, rank, world_size);
   __syncthreads();
 
-  auto offset = (blockDim.x * blockIdx.x + threadIdx.x) * numel_per_thread;
-  auto stride = blockDim.x * gridDim.x * numel_per_thread;
-  for (size_t i = offset; i < numel; i += stride) {
-    auto vec = multimem_ld_reduce_add<alignment>(input_mc_ptr + i);
-    at::native::memory::st_vec<alignment>(output_ptr + i, vec);
+  if (rank == root) {
+    auto offset = (blockDim.x * blockIdx.x + threadIdx.x) * numel_per_thread;
+    auto stride = blockDim.x * gridDim.x * numel_per_thread;
+    for (size_t i = offset; i < numel; i += stride) {
+      auto vec = multimem_ld_reduce_add<alignment>(input_mc_ptr + i);
+      at::native::memory::st_vec<alignment>(output_ptr + i, vec);
+    }
   }
 
   __syncthreads();
   sync_remote_blocks<true, false>(signal_pads, rank, world_size);
 }
 
-at::Tensor multimem_one_shot_all_reduce_out(
+at::Tensor multimem_one_shot_reduce_out(
     const at::Tensor& input,
     std::string reduce_op,
+    int64_t root,
     std::string group_name,
     at::Tensor out) {
   TORCH_CHECK(
       input.is_contiguous(),
-      "multimem_one_shot_all_reduce: input must be contiguous.");
-  TORCH_CHECK(
-      out.is_contiguous(),
-      "multimem_one_shot_all_reduce: output must be contiguous.");
-  TORCH_CHECK(
-      out.sizes() == input.sizes(),
-      "multimem_one_shot_all_reduce: input/output size mismatch.");
+      "multimem_one_shot_reduce: input must be contiguous.");
   TORCH_CHECK(
       reduce_op == "sum",
-      "multimem_one_shot_all_reduce: only sum is supported for now.");
+      "multimem_one_shot_reduce: only sum is supported for now.");
 
   auto symm_mem = c10d::symmetric_memory::rendezvous(input, group_name);
   TORCH_CHECK(
       symm_mem != nullptr,
-      "multimem_one_shot_all_reduce: input must be allocated with empty_strided_p2p().");
+      "multimem_one_shot_reduce: input must be allocated with empty_strided_p2p().");
   TORCH_CHECK(
       symm_mem->has_multicast_support(),
-      "multimem_one_shot_all_reduce: requires multicast support.");
+      "multimem_one_shot_reduce: requires multicast support.");
+
+  int rank = symm_mem->get_rank();
+  int world_size = symm_mem->get_world_size();
+  TORCH_CHECK(
+      root >= 0 && root < world_size,
+      "multimem_one_shot_reduce: root must be in [0, world_size).")
+
+  if (rank == root) {
+    TORCH_CHECK(
+        out.is_contiguous(),
+        "multimem_one_shot_reduce: output must be contiguous.");
+    TORCH_CHECK(
+        out.sizes() == input.sizes(),
+        "multimem_one_shot_reduce: input/output size mismatch.");
+  }
 
   const size_t alignment =
       get_and_verify_alignment(input, "multimem_one_shot_all_reduce");
@@ -281,7 +295,7 @@ at::Tensor multimem_one_shot_all_reduce_out(
   AT_DISPATCH_FLOAT_AND_BFLOAT16(
       input.scalar_type(), "multimem_one_shot_all_reduce", [&]() {
         DISPATCH_ALIGNMENTS_16_8_4(alignment, [&]() {
-          multimem_one_shot_all_reduce_kernel<scalar_t, k_alignment>
+          multimem_one_shot_reduce_kernel<scalar_t, k_alignment>
               <<<num_blocks,
                  num_threads,
                  0,
@@ -292,12 +306,23 @@ at::Tensor multimem_one_shot_all_reduce_out(
                   input.numel(),
                   reinterpret_cast<uint32_t**>(
                       symm_mem->get_signal_pad_ptrs_dev()),
-                  symm_mem->get_rank(),
-                  symm_mem->get_world_size());
+                  rank,
+                  world_size,
+                  root);
           C10_CUDA_KERNEL_LAUNCH_CHECK();
         });
       });
   return out;
+}
+
+at::Tensor multimem_one_shot_all_reduce_out(
+    const at::Tensor& input,
+    std::string reduce_op,
+    std::string group_name,
+    at::Tensor out) {
+  auto group = c10d::resolve_process_group(group_name);
+  int root = group->getRank();  // each rank reduces to itself
+  return multimem_one_shot_reduce_out(input, reduce_op, root, group_name, out);
 }
 
 at::Tensor multimem_one_shot_all_reduce(
@@ -1211,6 +1236,8 @@ TORCH_LIBRARY_IMPL(symm_mem, CUDA, m) {
   m.impl("multimem_one_shot_all_reduce", ::multimem_one_shot_all_reduce);
   m.impl(
       "multimem_one_shot_all_reduce_out", ::multimem_one_shot_all_reduce_out);
+  m.impl(
+      "multimem_one_shot_reduce_out", ::multimem_one_shot_reduce_out);
   m.impl("multimem_all_gather_out", ::multimem_all_gather_out);
 #endif
   m.impl("stream_write_value32_", ::stream_write_value32_);

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryOps.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryOps.cu
@@ -1088,6 +1088,17 @@ at::Tensor reduce_scatter_out(
   TORCH_CHECK(false, "reduce_scatter_out: requires CUDA 12.3+.");
   return output;
 }
+
+at::Tensor multimem_one_shot_reduce_out(
+    const at::Tensor& input,
+    std::string reduce_op,
+    int64_t root,
+    std::string group_name,
+    at::Tensor out) {
+  TORCH_CHECK(false, "multimem_one_shot_reduce_out: requires CUDA 12.3+.");
+  return out;
+}
+
 } // namespace
 #endif // #if defined(CUDART_VERSION) && CUDART_VERSION < 12030
 

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
@@ -458,6 +458,8 @@ TORCH_LIBRARY_FRAGMENT(symm_mem, m) {
   m.def(
       "multimem_one_shot_all_reduce_out(Tensor input, str reduce_op, str group_name, Tensor(a!) out) -> Tensor(a!)");
   m.def(
+      "multimem_one_shot_reduce_out(Tensor input, str reduce_op, int root, str group_name, Tensor(a!) out) -> Tensor(a!)");
+  m.def(
       "multimem_all_gather_out(Tensor input, str group_name, Tensor(a!) out) -> Tensor(a!)");
   m.def(
       "one_shot_all_reduce(Tensor input, str reduce_op, str group_name) -> Tensor");


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #164517

Modified `multimem_one_shot_all_reduce_out` function to accept a `root` argument, making it a `multimem_reduce` op.

The original `multimem_one_shot_all_reduce` op becomes a caller of the `multimem_reduce`, with each rank providing its own rank id as root.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci