### PR TITLE
[inductor] tune some fields for reduction in CDT

### DIFF
--- a/test/inductor/test_deterministic.py
+++ b/test/inductor/test_deterministic.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: inductor"]
 import contextlib
+import unittest
 
 import torch
 import torch._inductor.config as inductor_config
@@ -81,13 +82,35 @@ class DeterministicTest(TestCase):
 
             inp = torch.rand([2048, 2048], device=GPU_TYPE)
 
-            out = foo(inp)
+            from torch._inductor.runtime.triton_heuristics import CachingAutotuner
+
+            old_init = CachingAutotuner.__init__
+            caching_autotuners = []
+
+            def new_init(self, *args, **kwargs):
+                old_init(self, *args, **kwargs)
+                nonlocal caching_autotuners
+                caching_autotuners.append(self)
+
+            with unittest.mock.patch.object(CachingAutotuner, "__init__", new_init):
+                out = foo(inp)
+
             self.assertEqual(out, inp.sum(dim=-1))
 
+            self.assertEqual(len(caching_autotuners), 1)
+
+            coordesc_tuner = caching_autotuners[0].coordesc_tuner
+            frozen_fields = coordesc_tuner.frozen_fields
+
             if deterministic:
-                self.assertTrue(counters["inductor"]["coordesc_tuning_bench"] == 0)
+                self.assertTrue(len(frozen_fields) > 0)
+                self.assertTrue("R0_BLOCK" in frozen_fields)
+                self.assertTrue("R1_BLOCK" in frozen_fields)
+                self.assertTrue("num_warps" in frozen_fields)
             else:
-                self.assertTrue(counters["inductor"]["coordesc_tuning_bench"] > 0)
+                self.assertTrue(len(frozen_fields) == 0)
+
+            self.assertTrue(counters["inductor"]["coordesc_tuning_bench"] > 0)
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/runtime/coordinate_descent_tuner.py
+++ b/torch/_inductor/runtime/coordinate_descent_tuner.py
@@ -222,7 +222,7 @@ class CoordescTuner:
         Return a tuple of (compare_result, candidate_timing).
         compare_result is true iff candidate_config is better.
         """
-        print("Try config %s", candidate_config)
+        log.debug("Try config %s", candidate_config)
         try:
             candidate_timing = self.call_func(func, candidate_config)
         except Exception as e:

--- a/torch/_inductor/runtime/coordinate_descent_tuner.py
+++ b/torch/_inductor/runtime/coordinate_descent_tuner.py
@@ -4,6 +4,8 @@ import itertools
 import logging
 from typing import Callable, Optional, TYPE_CHECKING
 
+from torch.utils._ordered_set import OrderedSet
+
 from .hints import TRITON_MAX_BLOCK
 from .runtime_utils import red_text, triton_config_to_hashable
 
@@ -47,13 +49,21 @@ class CoordescTuner:
     """
 
     def __init__(
-        self, is_mm=False, name="unknown", size_hints=None, inductor_meta=None
+        self,
+        is_mm=False,
+        name="unknown",
+        size_hints=None,
+        inductor_meta=None,
+        frozen_fields=None,
     ):
         self.is_mm = is_mm  # we will tune num_stages for mm
         self.cached_benchmark_results = {}
         self.name = name
         self.size_hints = size_hints
         self.inductor_meta = inductor_meta or {}
+        self.frozen_fields: OrderedSet[str] = (
+            OrderedSet(frozen_fields) if frozen_fields is not None else OrderedSet()
+        )
 
     def get_config_max(self, prefix: str) -> int:
         max_block = TRITON_MAX_BLOCK[prefix.upper()]
@@ -102,7 +112,7 @@ class CoordescTuner:
         if self.inductor_meta.get("is_hip") is True:
             out.append("waves_per_eu")
 
-        return out
+        return [f for f in out if f not in self.frozen_fields]
 
     def value_too_large(self, name: str, val: int) -> bool:
         block_suffix = "BLOCK"
@@ -174,6 +184,7 @@ class CoordescTuner:
         """
         candidate_values_list = []
         effective_fields = []
+
         for field in self.tunable_fields:
             old_value = get_field(best_config, field)
             if old_value is None:
@@ -211,7 +222,7 @@ class CoordescTuner:
         Return a tuple of (compare_result, candidate_timing).
         compare_result is true iff candidate_config is better.
         """
-        log.debug("Try config %s", candidate_config)
+        print("Try config %s", candidate_config)
         try:
             candidate_timing = self.call_func(func, candidate_config)
         except Exception as e:

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -113,6 +113,14 @@ class HeuristicType(Enum):
     FIXED = auto()
 
 
+def is_reduction_heuristic(heuristic: HeuristicType):
+    return heuristic in (
+        HeuristicType.REDUCTION,
+        HeuristicType.PERSISTENT_REDUCTION,
+        HeuristicType.SPLIT_SCAN,
+    )
+
+
 class AutotuneHint(Enum):
     ONE_ELEMENT_PER_THREAD = 0
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #164533
* #164532
* __->__ #164525
* #163589

With the change, in deterministic mode, we should still be able to tune XBLOCK for a reduction with coordinate descent tuning.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben