### PR TITLE
Add waitcounters for torch.compile subprocess pool

### DIFF
--- a/torch/_inductor/compile_worker/subproc_pool.py
+++ b/torch/_inductor/compile_worker/subproc_pool.py
@@ -29,6 +29,7 @@ from torch._inductor.compile_worker.tracked_process_pool import (
 from torch._inductor.compile_worker.utils import _async_compile_initializer
 from torch._inductor.utils import get_ld_library_path, python_subprocess_env
 from torch._utils_internal import find_compile_subproc_binary
+from torch.monitor import _WaitCounter, _WaitCounterTracker
 
 
 log = logging.getLogger(__name__)
@@ -193,9 +194,26 @@ class SubprocPool:
 
         self.futures_lock = threading.Lock()
         self.pending_futures: dict[int, Future[Any]] = {}
+        # The pending waitcounter, is used to indicate the time when we have any specific job running.
+        self.pending_waitcounters: dict[int, Any] = {}
         self.job_id_count = itertools.count()
 
+        # The running waitcounter indicates the time when the SubProcPool object exists.
         self.running = True
+        self.running_waitcounter = _WaitCounter(
+            "pytorch.wait_counter.subproc_pool.running"
+        ).guard()
+        self.running_waitcounter.__enter__()
+
+        # The quiesce waitcounter indicates when the job is in a quiesced state.
+        self.quiesce_waitcounter: Optional[_WaitCounterTracker] = None
+
+        # Firstjob is used to capture the time from when the firstjob is queued, to when the first job is done.
+        self.firstjob = True
+        self.firstjob_id: Optional[int] = None
+        self.firstjob_waitcounter = _WaitCounter(
+            "pytorch.wait_counter.subproc_pool.first_job"
+        ).guard()
 
         # Start thread last to ensure all member variables are initialized
         # before any access.
@@ -212,6 +230,19 @@ class SubprocPool:
         with self.futures_lock:
             job_id = next(self.job_id_count)
             self.pending_futures[job_id] = future = Future()
+            self.pending_waitcounters[job_id] = _WaitCounter(
+                "pytorch.wait_counter.subproc_pool.job"
+            ).guard()
+            self.pending_waitcounters[job_id].__enter__()
+            if self.quiesce_waitcounter:
+                self.firstjob = True
+                self.quiesce_waitcounter.__exit__()
+                self.quiesce_waitcounter = None
+            # This can be entered from either quiesce wakeup, or from startup.
+            if self.firstjob:
+                self.firstjob_id = job_id
+                self.firstjob_waitcounter.__enter__()
+                self.firstjob = False
         future.set_running_or_notify_cancel()
         self._send(MsgHeader.JOB, job_id, job_data)
         return future
@@ -239,6 +270,7 @@ class SubprocPool:
                 if self.running:
                     log.warning("SubprocPool unclean exit")
                     self.running = False
+                    self.running_waitcounter.__exit__()
                 self.read_pipe.close()
                 # Cancel all the pending futures.
                 self.shutdown()
@@ -265,10 +297,21 @@ class SubprocPool:
                     self.pending_futures[job_id].set_exception(result)
                 else:
                     self.pending_futures[job_id].set_result(result)
+
+                self.pending_waitcounters[job_id].__exit__()
+                del self.pending_waitcounters[job_id]
+                if self.firstjob_id == job_id:
+                    self.firstjob_waitcounter.__exit__()
+
                 del self.pending_futures[job_id]
 
     def quiesce(self) -> None:
         self._send(MsgHeader.QUIESCE)
+        assert self.quiesce_waitcounter is None
+        self.quiesce_waitcounter = _WaitCounter(
+            "pytorch.wait_counter.subproc_pool.running"
+        ).guard()
+        self.quiesce_waitcounter.__enter__()
 
     def wakeup(self) -> None:
         self._send(MsgHeader.WAKEUP)
@@ -279,6 +322,7 @@ class SubprocPool:
                 if not self.running:
                     return
                 self.running = False
+                self.running_waitcounter.__exit__()
                 _send_msg(self.write_pipe, MsgHeader.SHUTDOWN)
                 self.write_pipe.close()
             self.process.wait(300)


### PR DESCRIPTION
Summary:
This ads waitcounter for whether or not the pool is running, as well as if we
are running jobs.

This also ads waitcounters for the first job within a pool. First job and running are working correctly. The job waitcounter seems to either be detecting a leak of a job, or is broken subtly.

Test Plan:
We've tested this internally and see valid ods metrics.

Note that we may be leaking jobs, or the job logic may not be handling an exception correctly.

Differential Revision: D83705931




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben