### PR TITLE
[BC breaking] Remove assert_allclose

### DIFF
--- a/docs/source/testing.md
+++ b/docs/source/testing.md
@@ -15,7 +15,3 @@
 ```{eval-rst}
 .. autofunction:: make_tensor
 ```
-
-```{eval-rst}
-.. autofunction:: assert_allclose
-```

--- a/test/allowlist_for_publicAPI.json
+++ b/test/allowlist_for_publicAPI.json
@@ -995,7 +995,6 @@
     "all_types_and_complex",
     "all_types_and_complex_and",
     "all_types_and_half",
-    "assert_allclose",
     "assert_close",
     "complex_types",
     "double_types",

--- a/test/allowlist_for_publicAPI.json
+++ b/test/allowlist_for_publicAPI.json
@@ -996,7 +996,6 @@
     "all_types_and_complex",
     "all_types_and_complex_and",
     "all_types_and_half",
-    "assert_allclose",
     "assert_close",
     "complex_types",
     "double_types",

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2405,7 +2405,7 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
             if mark_dynamic:
                 torch._dynamo.mark_dynamic(inp, 0)
             foo_c = torch.compile(foo)
-            torch.testing.assert_allclose(foo(inp), foo_c(inp))
+            torch.testing.assert_close(foo(inp), foo_c(inp))
 
     @skipCUDAIf(
         not SM90OrLater, "uses bfloat16 atomic add instrs which requires SM >= 90"

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2405,9 +2405,14 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
             if mark_dynamic:
                 torch._dynamo.mark_dynamic(inp, 0)
             foo_c = torch.compile(foo)
-            gc.collect()
-            torch.cuda.empty_cache()
-            torch.testing.assert_close(foo(inp), foo_c(inp), equal_nan=True)
+            torch.testing.assert_close(
+                foo(inp),
+                foo_c(inp),
+                equal_nan=True,
+                check_device=True,
+                check_dtype=False,
+                check_stride=False,
+            )
 
     @skipCUDAIf(
         not SM90OrLater, "uses bfloat16 atomic add instrs which requires SM >= 90"

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2405,7 +2405,7 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
             if mark_dynamic:
                 torch._dynamo.mark_dynamic(inp, 0)
             foo_c = torch.compile(foo)
-            torch.testing.assert_close(foo(inp), foo_c(inp))
+            torch.testing.assert_close(foo(inp), foo_c(inp), equal_nan=True)
 
     @skipCUDAIf(
         not SM90OrLater, "uses bfloat16 atomic add instrs which requires SM >= 90"

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2405,6 +2405,8 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
             if mark_dynamic:
                 torch._dynamo.mark_dynamic(inp, 0)
             foo_c = torch.compile(foo)
+            gc.collect()
+            torch.cuda.empty_cache()
             torch.testing.assert_close(foo(inp), foo_c(inp), equal_nan=True)
 
     @skipCUDAIf(

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2763,6 +2763,8 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
             torch.testing.assert_close(
                 foo(inp),
                 foo_c(inp),
+                rtol=0,
+                atol=0,
                 equal_nan=True,
                 check_device=True,
                 check_dtype=False,

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2760,7 +2760,7 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
             if mark_dynamic:
                 torch._dynamo.mark_dynamic(inp, 0)
             foo_c = torch.compile(foo)
-            torch.testing.assert_close(foo(inp), foo_c(inp))
+            torch.testing.assert_close(foo(inp), foo_c(inp), equal_nan=True)
 
     @skipCUDAIf(
         not SM90OrLater, "uses bfloat16 atomic add instrs which requires SM >= 90"

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2760,7 +2760,7 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
             if mark_dynamic:
                 torch._dynamo.mark_dynamic(inp, 0)
             foo_c = torch.compile(foo)
-            torch.testing.assert_allclose(foo(inp), foo_c(inp))
+            torch.testing.assert_close(foo(inp), foo_c(inp))
 
     @skipCUDAIf(
         not SM90OrLater, "uses bfloat16 atomic add instrs which requires SM >= 90"

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2760,6 +2760,8 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
             if mark_dynamic:
                 torch._dynamo.mark_dynamic(inp, 0)
             foo_c = torch.compile(foo)
+            gc.collect()
+            torch.cuda.empty_cache()
             torch.testing.assert_close(foo(inp), foo_c(inp), equal_nan=True)
 
     @skipCUDAIf(

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2760,9 +2760,14 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
             if mark_dynamic:
                 torch._dynamo.mark_dynamic(inp, 0)
             foo_c = torch.compile(foo)
-            gc.collect()
-            torch.cuda.empty_cache()
-            torch.testing.assert_close(foo(inp), foo_c(inp), equal_nan=True)
+            torch.testing.assert_close(
+                foo(inp),
+                foo_c(inp),
+                equal_nan=True,
+                check_device=True,
+                check_dtype=False,
+                check_stride=False,
+            )
 
     @skipCUDAIf(
         not SM90OrLater, "uses bfloat16 atomic add instrs which requires SM >= 90"

--- a/torch/testing/__init__.py
+++ b/torch/testing/__init__.py
@@ -1,7 +1,5 @@
 from torch._C import FileCheck as FileCheck
 
 from . import _utils
-
-# pyrefly: ignore [deprecated]
-from ._comparison import assert_allclose, assert_close as assert_close
+from ._comparison import assert_close as assert_close
 from ._creation import make_tensor as make_tensor

--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -5,7 +5,6 @@ import collections.abc
 import contextlib
 from collections.abc import Callable, Collection, Sequence
 from typing import Any, NoReturn
-from typing_extensions import deprecated
 
 import torch
 
@@ -1629,53 +1628,3 @@ def assert_close(
     if error_metas:
         # TODO: compose all metas into one AssertionError
         raise error_metas[0].to_error(msg)
-
-
-@deprecated(
-    "`torch.testing.assert_allclose()` is deprecated since 1.12 and will be removed in a future release. "
-    "Please use `torch.testing.assert_close()` instead. "
-    "You can find detailed upgrade instructions in https://github.com/pytorch/pytorch/issues/61844.",
-    category=FutureWarning,
-)
-def assert_allclose(
-    actual: Any,
-    expected: Any,
-    rtol: float | None = None,
-    atol: float | None = None,
-    equal_nan: bool = True,
-    msg: str = "",
-) -> None:
-    """
-    .. warning::
-
-       :func:`torch.testing.assert_allclose` is deprecated since ``1.12`` and will be removed in a future release.
-       Please use :func:`torch.testing.assert_close` instead. You can find detailed upgrade instructions
-       `here <https://github.com/pytorch/pytorch/issues/61844>`_.
-    """
-    if not isinstance(actual, torch.Tensor):
-        actual = torch.tensor(actual)
-    if not isinstance(expected, torch.Tensor):
-        expected = torch.tensor(expected, dtype=actual.dtype)
-
-    if rtol is None and atol is None:
-        rtol, atol = default_tolerances(
-            actual,
-            expected,
-            dtype_precisions={
-                torch.float16: (1e-3, 1e-3),
-                torch.float32: (1e-4, 1e-5),
-                torch.float64: (1e-5, 1e-8),
-            },
-        )
-
-    torch.testing.assert_close(
-        actual,
-        expected,
-        rtol=rtol,
-        atol=atol,
-        equal_nan=equal_nan,
-        check_device=True,
-        check_dtype=False,
-        check_stride=False,
-        msg=msg or None,
-    )

--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -7,7 +7,6 @@ import dataclasses
 import types
 from collections.abc import Callable, Collection, Sequence
 from typing import Any, NoReturn
-from typing_extensions import deprecated
 
 import torch
 
@@ -1687,53 +1686,3 @@ def assert_close(
     if error_metas:
         # TODO: compose all metas into one AssertionError
         raise error_metas[0].to_error(msg)
-
-
-@deprecated(
-    "`torch.testing.assert_allclose()` is deprecated since 1.12 and will be removed in a future release. "
-    "Please use `torch.testing.assert_close()` instead. "
-    "You can find detailed upgrade instructions in https://github.com/pytorch/pytorch/issues/61844.",
-    category=FutureWarning,
-)
-def assert_allclose(
-    actual: Any,
-    expected: Any,
-    rtol: float | None = None,
-    atol: float | None = None,
-    equal_nan: bool = True,
-    msg: str = "",
-) -> None:
-    """
-    .. warning::
-
-       :func:`torch.testing.assert_allclose` is deprecated since ``1.12`` and will be removed in a future release.
-       Please use :func:`torch.testing.assert_close` instead. You can find detailed upgrade instructions
-       `here <https://github.com/pytorch/pytorch/issues/61844>`_.
-    """
-    if not isinstance(actual, torch.Tensor):
-        actual = torch.tensor(actual)
-    if not isinstance(expected, torch.Tensor):
-        expected = torch.tensor(expected, dtype=actual.dtype)
-
-    if rtol is None and atol is None:
-        rtol, atol = default_tolerances(
-            actual,
-            expected,
-            dtype_precisions={
-                torch.float16: (1e-3, 1e-3),
-                torch.float32: (1e-4, 1e-5),
-                torch.float64: (1e-5, 1e-8),
-            },
-        )
-
-    torch.testing.assert_close(
-        actual,
-        expected,
-        rtol=rtol,
-        atol=atol,
-        equal_nan=equal_nan,
-        check_device=True,
-        check_dtype=False,
-        check_stride=False,
-        msg=msg or None,
-    )


### PR DESCRIPTION
`torch.testing.assert_allclose` was deprecated in favour of `torch.testing.assert_close`. This PR thus replaces usage of `torch.testing.assert_close` with `torch.testing.assert_allclose` and removes `torch.testing.assert_allclose`. Thus the PR breaks backward compatibility. 

Because `torch.testing.assert_allclose` is actually a wrapper of `torch.testing.assert_close`, the `kwargs` of the two functions overlaps largely as well as some of their default values, so it is relatively easy to move to the new way. One notable default value change is that `torch.testing.assert_allclose` uses `check_dtype=False` while `dtype` check is enabled by default in `torch.testing.assert_close`. Another change is that `eq_nan=True` in `torch.testing.assert_allclose` and it is `False` in `torch.testing.assert_close`

For example, before the PR we have
```
torch.testing.assert_allclose(a, b)
```

After the PR it should be changed to 
```
torch.testing.assert_close(a, b, check_dtype=False)
```
or simply to
```
torch.testing.assert_close(a, b)
```
to also check `dtype`.




cc @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @aditvenk @weifengpy @kapilsh @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98 @H-Huang @Lucaskabela @chenyang78