### PR TITLE
Remove old workaround in launch_logcumsumexp_cuda_kernel

### DIFF
--- a/aten/src/ATen/native/cuda/LogcumsumexpKernel.cu
+++ b/aten/src/ATen/native/cuda/LogcumsumexpKernel.cu
@@ -102,13 +102,7 @@ __host__ __device__ c10::complex<scalar_t> _log_add_exp_helper(const c10::comple
 }
 
 void launch_logcumsumexp_cuda_kernel(const TensorBase& result, const TensorBase& self, int64_t dim) {
-// Compile time for CUDA-11.4 is 3x slower than with CUDA-11.6+, specifically for complex numbers
-#if defined(FBCODE_CAFFE2) || defined(OVRSOURCE)
-#define _LCME_DISPATCH AT_DISPATCH_FLOATING_TYPES_AND2
-#else
-#define _LCME_DISPATCH AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2
-#endif
-  _LCME_DISPATCH(ScalarType::Half, ScalarType::BFloat16,
+  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16,
       self.scalar_type(), "logcumsumexp_cuda",
       [&]() {
         using opmath_t = at::opmath_type<scalar_t>;


### PR DESCRIPTION
Remove workaround for CUDA 11.4 .
