### PR TITLE
[MPS] Make deviceCount() implementation consistent with Python to fix at::manual_seed()

### DIFF
--- a/aten/src/ATen/mps/MPSHooks.h
+++ b/aten/src/ATen/mps/MPSHooks.h
@@ -66,6 +66,9 @@ struct MPSHooks : public at::MPSHooksInterface {
     // When MPS is available, it is always in use for the one device.
     return true;
   }
+  DeviceIndex deviceCount() const override {
+    return static_cast<int>(hasMPS() && isAvailable());
+  }
 };
 
 } // namespace at::mps

--- a/aten/src/ATen/mps/MPSHooks.h
+++ b/aten/src/ATen/mps/MPSHooks.h
@@ -67,7 +67,7 @@ struct MPSHooks : public at::MPSHooksInterface {
     return true;
   }
   DeviceIndex deviceCount() const override {
-    return static_cast<int>(hasMPS() && isAvailable());
+    return hasMPS() ? 1 : 0;
   }
 };
 


### PR DESCRIPTION
In #144370 it was assumed that MPS would have at least 1 device, but that wasn't the case since MPSHooks wasn't overriding it.

This meant that `at::manual_seed()` wouldn't have any effect on MPS and using it, for example in tests, didn't make `at::rand()` deterministic.

Digging a bit deeper we see that `torch.mps.device_count()` returns 1 if MPS is available:

https://github.com/pytorch/pytorch/blob/aed66248a01d309eb2ac1149b5f51310545b0783/torch/mps/__init__.py#L27-L29

Mimicking that behaviour in C++ land fixes the determinism issue and makes the 2 APIs consistent.