### PR TITLE
forward fix #164481

### DIFF
--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -479,8 +479,10 @@ class TestFP8Lowering(TestCase):
 
         def f(a, b, scale_a, scale_b):
             # Convert to fp8 with correct strides for scaled_mm
-            a_fp8 = a.to(torch.float8_e4m3fn).contiguous()  # row-major
-            b_fp8 = b.t().contiguous().t().to(torch.float8_e4m3fn)  # column-major
+            dtype_float8 = torch.float8_e4m3fn
+            dtype_float8 = _fix_fp8_dtype_for_rocm(dtype_float8, GPU_TYPE)
+            a_fp8 = a.to(dtype_float8).contiguous()  # row-major
+            b_fp8 = b.t().contiguous().t().to(dtype_float8)  # column-major
             return torch._scaled_mm(
                 a_fp8, b_fp8, scale_a, scale_b, out_dtype=torch.bfloat16
             )


### PR DESCRIPTION
PR #164481 added unit test test_scaled_mm_preserves_strides in test/inductor/test_fp8.py. It was missing the adjustment for ROCm's F8 types on MI300.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben