### PR TITLE
[CD][CUDA13] Fix wrong incompatibility warning on Spark device 

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -260,7 +260,7 @@ def _check_capability():
     CUDA_ARCHES_SUPPORTED = {
         "12.6": {"min": 50, "max": 90},
         "12.8": {"min": 70, "max": 120},
-        "13.0": {"min": 75, "max": 120},
+        "13.0": {"min": 75, "max": 121},
     }
 
     if (


### PR DESCRIPTION
~Fixes: https://github.com/pytorch/pytorch/issues/164596~
TLDR: this PR does not remove the warning, worse, it brings extra warning as shown in https://github.com/pytorch/pytorch/pull/164590#issuecomment-3367772854, i.e. it failed the test plan.

Example warning: 

`0: /usr/local/lib/python3.12/dist-packages/torch/cuda/__init__.py:283: UserWarning: 
0:     Found GPU0 NVIDIA GB10 which is of cuda capability 12.1.
0:     Minimum and Maximum cuda capability supported by this version of PyTorch is
0:     (8.0) - (12.0)`

The above warning is incorrect because pytorch binary compiled with 12.0 can directly run on 12.1 (Spark) 

Redo https://github.com/pytorch/pytorch/pull/161299 to benefit Spark users

Test Plan: 
Test the newly generated cu13 binary on a Spark device and a non-Spark device with "import torch; torch.randn(1).cuda()".

Thanks @ptrblck for this suggestion! 
cc @eqy @tinglvv  @atalman @malfet 