### PR TITLE
[ROCm][CI] Change rocm periodic workflow label to linux.rocm.gpu.mi250.4

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -213,9 +213,9 @@ jobs:
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3
       test-matrix: |
         { include: [
-          { config: "distributed", shard: 1, num_shards: 3, runner: "linux.rocm.gpu.4", owners: ["module:rocm", "oncall:distributed"] },
-          { config: "distributed", shard: 2, num_shards: 3, runner: "linux.rocm.gpu.4", owners: ["module:rocm", "oncall:distributed"] },
-          { config: "distributed", shard: 3, num_shards: 3, runner: "linux.rocm.gpu.4", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed", shard: 1, num_shards: 3, runner: "linux.rocm.gpu.mi250.4", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed", shard: 2, num_shards: 3, runner: "linux.rocm.gpu.mi250.4", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed", shard: 3, num_shards: 3, runner: "linux.rocm.gpu.mi250.4", owners: ["module:rocm", "oncall:distributed"] },
         ]}
     secrets: inherit
 


### PR DESCRIPTION
Testing done on this PR: https://github.com/pytorch/pytorch/pull/156491

New label `linux.rocm.gpu.mi250.4` uses K8s-based ARC runners.

From "Job Duration (all branches)" table on metrics.pytorch.org:
231 jobs per month * 3H (per job) * 3 shards = 2079H per month / 30 days = 69.3H per day / 3H for periodic job = ~23 Runners (assuming all jobs are run simultaneously) = 12 nodes
 
 
<img width="1881" height="503" alt="image" src="https://github.com/user-attachments/assets/6782867a-98b0-41f4-a335-8457cac53aea" />

69.3H for jobs per day automatically assumes we are not running in parallel. If you divide this value by the time for each job then you get the max concurrent number of runners (23 i.e 12 nodes) you would have to handle the average job load per day. However, since all those jobs are usually not concurrently running, we started with 5 nodes (ie. 10 runners) with this label.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd