### PR TITLE
[torch] Preserve buffer attributes in _apply

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13660,6 +13660,14 @@ if __name__ == '__main__':
         y = y.contiguous(memory_format=torch.contiguous_format)
         self.assertEqual(y, y_ref)
 
+    @onlyCUDA
+    def test_buffer_attribute_preservation(self):
+        model = torch.nn.Linear(1, 1)
+        model.register_buffer("test", torch.Tensor([0]))
+        model.test.test_attr = "test_attr"
+        model = model.to('cuda')
+        self.assertEqual(model.test.test_attr, "test_attr")
+
 
 class TestFunctionalPickle(TestCase):
 

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1021,7 +1021,12 @@ class Module:
 
         for key, buf in self._buffers.items():
             if buf is not None:
-                self._buffers[key] = fn(buf)
+                buf_applied = fn(buf)
+
+                if compute_should_use_set_data(buf, buf_applied):
+                    buf.data = buf_applied
+                else:
+                    self._buffers[key] = buf_applied
 
         return self
 


### PR DESCRIPTION
Summary: Preserves buffer attributes in _apply so that attributes added to buffers are not lost when, for example, the model is moved to a different device.

Test Plan: `test_buffer_attribute_preservation`

Differential Revision: D83883919


