### PR TITLE
Move file selection for ruff from .lintrunner.toml to pyproject.toml 

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -1560,23 +1560,7 @@ command = [
 
 [[linter]]
 code = 'RUFF'
-include_patterns = [
-    '**/*.py',
-    '**/*.pyi',
-    '**/*.ipynb',
-    'pyproject.toml',
-]
-exclude_patterns = [
-    'caffe2/**',
-    'functorch/docs/**',
-    'torch/_inductor/fx_passes/serialized_patterns/**',
-    'torch/_inductor/autoheuristic/artifacts/**',
-    'test/dynamo/cpython/**',
-    'scripts/**',
-    'third_party/**',
-    'fb/**',
-    '**/fb/**',
-]
+# include_patterns and exclude_patterns for RUFF are specified in pyproject.toml
 command = [
     'python3',
     'tools/linter/adapters/ruff_linter.py',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,26 @@ standard_library = ["typing_extensions"]
 line-length = 88
 src = ["caffe2", "torch", "torchgen", "functorch", "test"]
 
+include = [
+    "**/*.py",
+    "**/*.pyi",
+    "**/*.ipynb",
+]
+
+exclude = [
+    ".git/**",
+    "android/**",
+    "caffe2/**",
+    "functorch/docs/**",
+    "torch/_inductor/fx_passes/serialized_patterns/**",
+    "torch/_inductor/autoheuristic/artifacts/**",
+    "test/dynamo/cpython/**",
+    "scripts/**",
+    "third_party/**",
+    "fb/**",
+    "**/fb/**",
+]
+
 [tool.ruff.format]
 docstring-code-format = true
 quote-style = "double"


### PR DESCRIPTION
`.lintrunner.toml` contains the file selection config for `ruff`
```

[[linter]]
code = 'RUFF'
include_patterns = [
    '**/*.py',
    '**/*.pyi',           
    '**/*.ipynb',
    'pyproject.toml',
]
exclude_patterns = [
    'caffe2/**',
    'functorch/docs/**',
    'torch/_inductor/fx_passes/serialized_patterns/**',
    'torch/_inductor/autoheuristic/artifacts/**',
    'test/dynamo/cpython/**',
    'scripts/**',
    'third_party/**',
    'fb/**',         
    '**/fb/**',
]
```

However, if `ruff` is invoked without using linterrunner, it cannot see the `include_patterns` and `exclude_patterns` in `.lintrunner.toml`. It is better to move `include_patterns` and `exclude_patterns` into `pyproject.toml` because `ruff` is very fast that it's convenient to be able to directly invoke it.