### PR TITLE
[torchfuzz] don't use the first gpu in multi process fuzzer

### DIFF
--- a/tools/experimental/dynamic_shapes/torchfuzz/runner.py
+++ b/tools/experimental/dynamic_shapes/torchfuzz/runner.py
@@ -95,7 +95,10 @@ class ProgramRunner:
                 import torch
 
                 num_gpus = torch.cuda.device_count()
-                devices = [str(i) for i in range(num_gpus)]
+                if num_gpus > 1:
+                    devices = [str(i) for i in range(1, num_gpus)]
+                else:
+                    devices = [str(i) for i in range(num_gpus)]
             except ImportError:
                 devices = []
         if devices:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #164749
* #164716
* #164715
* #164694
* #164693
* #164688
* #164687
* #164649
* __->__ #164647
* #164646
* #164514
* #164434
* #164432

