### PR TITLE
Bump pinned transformers to 4.57.1

### DIFF
--- a/.ci/docker/ci_commit_pins/huggingface-requirements.txt
+++ b/.ci/docker/ci_commit_pins/huggingface-requirements.txt
@@ -1,2 +1,2 @@
-transformers==4.56.0
+transformers==4.57.1
 soxr==0.5.0


### PR DESCRIPTION
This PR bumps the transformers version to 4.57.1 for tests. 