### PR TITLE
[flex_attention] replace sliced BlockMask noop with helpful error

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -4963,6 +4963,7 @@ class TestBlockMask(InductorTestCase):
     @supported_platform
     def test_sliced_blockmask_mask_mod_error(self, device):
         """Test that sliced BlockMask raises helpful error when used with flex_attention"""
+
         def causal_mask(b, h, q_idx, kv_idx):
             return q_idx >= kv_idx
 

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -4962,7 +4962,7 @@ class TestBlockMask(InductorTestCase):
 
     @supported_platform
     def test_sliced_blockmask_mask_mod_error(self, device):
-        """Test that sliced BlockMask raises helpful error when mask_mod is called"""
+        """Test that sliced BlockMask raises helpful error when used with flex_attention"""
         def causal_mask(b, h, q_idx, kv_idx):
             return q_idx >= kv_idx
 
@@ -4971,15 +4971,15 @@ class TestBlockMask(InductorTestCase):
         )
         sliced_mask = base_mask[:, :, 0]
 
-        b = torch.tensor(0, device=device)
-        h = torch.tensor(0, device=device)
-        q = torch.tensor(10, device=device)
-        kv = torch.tensor(5, device=device)
+        q = torch.randn(1, 1, 1, 64, device=device)
+        k = torch.randn(1, 1, 256, 64, device=device)
+        v = torch.randn(1, 1, 256, 64, device=device)
 
+        compiled_fa = torch.compile(flex_attention)
         with self.assertRaisesRegex(
             RuntimeError, "Cannot use mask_mod from a sliced BlockMask"
         ):
-            sliced_mask.mask_mod(b, h, q, kv)
+            compiled_fa(q, k, v, block_mask=sliced_mask)
 
     @supported_platform
     def test_block_mask_device_change(self, device):

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -4961,6 +4961,27 @@ class TestBlockMask(InductorTestCase):
             )
 
     @supported_platform
+    def test_sliced_blockmask_mask_mod_error(self, device):
+        """Test that sliced BlockMask raises helpful error when mask_mod is called"""
+        def causal_mask(b, h, q_idx, kv_idx):
+            return q_idx >= kv_idx
+
+        base_mask = create_block_mask(
+            causal_mask, B=1, H=1, Q_LEN=256, KV_LEN=256, device=device
+        )
+        sliced_mask = base_mask[:, :, 0]
+
+        b = torch.tensor(0, device=device)
+        h = torch.tensor(0, device=device)
+        q = torch.tensor(10, device=device)
+        kv = torch.tensor(5, device=device)
+
+        with self.assertRaisesRegex(
+            RuntimeError, "Cannot use mask_mod from a sliced BlockMask"
+        ):
+            sliced_mask.mask_mod(b, h, q, kv)
+
+    @supported_platform
     def test_block_mask_device_change(self, device):
         device = torch.device(device)
         offset = torch.zeros(8, device=device)

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -321,6 +321,33 @@ def noop_mask(
     return batch.new_ones(size=(), dtype=torch.bool, device=batch.device)
 
 
+def _sliced_mask_mod_error(
+    batch: Tensor,
+    head: Tensor,
+    token_q: Tensor,
+    token_kv: Tensor,
+) -> Tensor:
+    """
+    Raises helpful error when using mask_mod from a sliced BlockMask.
+    
+    After slicing a BlockMask, the mask_mod is reset and cannot be used directly.
+    Users must reassign mask_mod from the original (unsliced) BlockMask.
+    """
+    raise RuntimeError(
+        "Cannot use mask_mod from a sliced BlockMask. "
+        "When you slice a BlockMask using [], the mask_mod attribute is reset. "
+        "You must set it from the original BlockMask's mask_mod."
+        "\n\nIncorrect usage:"
+        "\n  base_mask = create_block_mask(my_mask_fn, ...)"
+        "\n  sliced_mask = base_mask[:, :, block_idx]"
+        "\n  sliced_mask.mask_mod = apply_offset(sliced_mask.mask_mod, offset)  # WRONG!"
+        "\n\nCorrect usage:"
+        "\n  base_mask = create_block_mask(my_mask_fn, ...)"
+        "\n  sliced_mask = base_mask[:, :, block_idx]"
+        "\n  sliced_mask.mask_mod = apply_offset(base_mask.mask_mod, offset)  # Use base_mask!"
+    )
+
+
 _DEFAULT_SPARSE_BLOCK_SIZE = 128
 _LARGE_SPARSE_BLOCK_SIZE = 1 << 30
 
@@ -673,7 +700,7 @@ class BlockMask:
             new_full_kv_num_blocks,
             new_full_kv_indices,
             BLOCK_SIZE=self.BLOCK_SIZE,
-            mask_mod=None,
+            mask_mod=_sliced_mask_mod_error,
             seq_lengths=self.seq_lengths,
             compute_q_blocks=self.q_indices is not None,
         )

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -1406,9 +1406,7 @@ def flex_attention(
     # If BlockMask was sliced, its mask_mod is intentionally replaced with an error-raising stub.
     # This guard ensures we surface the intended error message before any shape-based checks.
     if getattr(block_mask, "mask_mod", None) is _sliced_mask_mod_error:
-        raise RuntimeError(
-            "Cannot use mask_mod from a sliced BlockMask"
-        )
+        raise RuntimeError("Cannot use mask_mod from a sliced BlockMask")
 
     if (
         block_mask.BLOCK_SIZE[0] == _LARGE_SPARSE_BLOCK_SIZE

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -329,7 +329,7 @@ def _sliced_mask_mod_error(
 ) -> Tensor:
     """
     Raises helpful error when using mask_mod from a sliced BlockMask.
-    
+
     After slicing a BlockMask, the mask_mod is reset and cannot be used directly.
     Users must reassign mask_mod from the original (unsliced) BlockMask.
     """

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -1403,6 +1403,13 @@ def flex_attention(
     if block_mask is None:
         block_mask = _create_empty_block_mask(query, key)
 
+    # If BlockMask was sliced, its mask_mod is intentionally replaced with an error-raising stub.
+    # This guard ensures we surface the intended error message before any shape-based checks.
+    if getattr(block_mask, "mask_mod", None) is _sliced_mask_mod_error:
+        raise RuntimeError(
+            "Cannot use mask_mod from a sliced BlockMask"
+        )
+
     if (
         block_mask.BLOCK_SIZE[0] == _LARGE_SPARSE_BLOCK_SIZE
         and block_mask.BLOCK_SIZE[1] == _LARGE_SPARSE_BLOCK_SIZE


### PR DESCRIPTION
Fixes part of #163314

After slicing BlockMask with `[]`, mask_mod was silently replaced with noop_mask. This caused silent incorrect results when users applied transformations to `sliced_mask.mask_mod`.

Replace noop with `_sliced_mask_mod_error` that raises RuntimeError with guidance to use `base_mask.mask_mod` instead.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @drisspg @Chillee @yanboliang @BoyuanFeng
