### PR TITLE
FlopCounterMode compatibility with out_dtype in torch.addmm

### DIFF
--- a/torch/utils/flop_counter.py
+++ b/torch/utils/flop_counter.py
@@ -60,6 +60,7 @@ def mm_flop(a_shape, b_shape, *args, out_shape=None, **kwargs) -> int:
     """Count flops for matmul."""
     # Inputs should be a list of length 2.
     # Inputs contains the shapes of two matrices.
+    # *args absorbs out_dtype
     m, k = a_shape
     k2, n = b_shape
     assert k == k2
@@ -67,12 +68,12 @@ def mm_flop(a_shape, b_shape, *args, out_shape=None, **kwargs) -> int:
     return m * n * 2 * k
 
 @register_flop_formula(aten.addmm)
-def addmm_flop(self_shape, a_shape, b_shape, out_shape=None, **kwargs) -> int:
+def addmm_flop(self_shape, a_shape, b_shape, *args, out_shape=None, **kwargs) -> int:
     """Count flops for addmm."""
     return mm_flop(a_shape, b_shape)
 
 @register_flop_formula(aten.bmm)
-def bmm_flop(a_shape, b_shape, out_shape=None, **kwargs) -> int:
+def bmm_flop(a_shape, b_shape, *args, out_shape=None, **kwargs) -> int:
     """Count flops for the bmm operation."""
     # Inputs should be a list of length 2.
     # Inputs contains the shapes of two tensor.
@@ -85,7 +86,7 @@ def bmm_flop(a_shape, b_shape, out_shape=None, **kwargs) -> int:
     return flop
 
 @register_flop_formula(aten.baddbmm)
-def baddbmm_flop(self_shape, a_shape, b_shape, out_shape=None, **kwargs) -> int:
+def baddbmm_flop(self_shape, a_shape, b_shape, *args, out_shape=None, **kwargs) -> int:
     """Count flops for the baddbmm operation."""
     # Inputs should be a list of length 3.
     # Inputs contains the shapes of three tensors.


### PR DESCRIPTION
This fixes this testcase:
```
import torch
from torch.utils.flop_counter import FlopCounterMode

bias = torch.rand((1024, 1024), device="cuda", dtype=torch.float16)
A = torch.rand((1024, 1024), device="cuda", dtype=torch.float16)
B = torch.rand((1024, 1024), device="cuda", dtype=torch.float16)

with FlopCounterMode(display=True):
    # torch.mm(B, A, out_dtype=torch.float32)
    # torch.addmm(bias, B, A, out_dtype=torch.float32)
    torch.addmm(bias, B, A, beta=0.5, out_dtype=torch.float32)
    # torch.bmm(B.view(1, 1024, 1024), A.view(1, 1024, 1024), out_dtype=torch.float32)
    # torch.baddbmm(bias.view(1, 1024, 1024), B.view(1, 1024, 1024), A.view(1, 1024, 1024), out_dtype=torch.float32)
```
Output: `addmm_flop() got multiple values for argument 'out_shape'`.

`addmm`, `bmm`, and `baddbmm` error, while`mm` works. (Try switching the uncommented line.)

Adding `*args` after `b_shape` mirrors the `*args` inside `mm_flop`.

However, I'm not sure this is the correct fix. The `beta` argument is always placed in `kwargs` by the torch dispatcher, as seen when inspecting the stack trace (or with a breakpoint inside `addmm_flop`). Meanwhile, `out_dtype` is always placed in `args`. Without knowing the intention of the torch dispatcher, it may be that the correct fix is to change the dispatcher instead of changing these flop counter functions. (In which case `mm_flop` having `*args` is a pre-existing bug.)