### PR TITLE
Fix inplace ops on Partial DTensors to preserve aliasing semantics

### DIFF
--- a/test/distributed/tensor/test_pointwise_ops.py
+++ b/test/distributed/tensor/test_pointwise_ops.py
@@ -333,7 +333,7 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
 
     def test_inplace_op_partial_to_replicate(self):
         # test that in-place operations correctly update the spec when converting
-        # from Partial to Replicate placement (issue #163374)
+        # from partial to replicate placement (issue #163374)
         device_mesh = self.build_device_mesh()
 
         tensor = torch.ones(8, 8, device=self.device_type)

--- a/test/distributed/tensor/test_pointwise_ops.py
+++ b/test/distributed/tensor/test_pointwise_ops.py
@@ -331,6 +331,24 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         self.assertEqual(z.placements, (Replicate(),))
         self.assertEqual(z.to_local(), input)
 
+    def test_inplace_op_partial_to_replicate(self):
+        # test that in-place operations correctly update the spec when converting
+        # from Partial to Replicate placement (issue #163374)
+        device_mesh = self.build_device_mesh()
+
+        tensor = torch.ones(8, 8, device=self.device_type)
+        in_dtensor = distribute_tensor(tensor, device_mesh, [Shard(0)])
+        partial_dt = in_dtensor.sum()
+
+        self.assertTrue(partial_dt.placements[0].is_partial())
+        self.assertTrue(partial_dt.placements[0].is_partial("sum"))
+        out = partial_dt.clamp_(max=10)
+        self.assertEqual(out.placements, (Replicate(),))
+        self.assertEqual(partial_dt.placements, (Replicate(),))
+
+        full = out.full_tensor()
+        self.assertEqual(full.item(), 10.0)
+        self.assertEqual(out.to_local().item(), 10.0)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Fixes #163374. 

Here is the output from reproducible code:

```
W1006 09:09:26.329000 2457 /home/fedora/github/pytorch/torch/distributed/run.py:811] 
W1006 09:09:26.329000 2457 /home/fedora/github/pytorch/torch/distributed/run.py:811] *****************************************
W1006 09:09:26.329000 2457 /home/fedora/github/pytorch/torch/distributed/run.py:811] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
W1006 09:09:26.329000 2457 /home/fedora/github/pytorch/torch/distributed/run.py:811] *****************************************
  aten::clamp_(dt: f32[][R], None, 2)
    redistribute_input(0, [P] -> [R])
      redistribute_input(t: f32[], [P] -> [R])
        _c10d_functional::all_reduce(t: f32[], sum, 0)
        _c10d_functional::wait_tensor(t: f32[])
    aten::clamp_(t: f32[], None, 2)
    aten::view(t: f32[], [])
(Replicate(),)
tensor(2., device='cuda:0')
```

The behavior is now matching what you were expecting in issue #163374:

Expected behavior (from the issue):
  1. Placement should change from Partial(sum) to Replicate()
  2. Value should be tensor(2.) instead of tensor(144.)

  Actual output from your test:
  1. (Replicate(),) - placement is correct
  2. tensor(2., device='cuda:0') - value is correct

so the inplace operation now properly redistributes the partial DTensor to replicate before performing the clamp snd maintains the correct aliasing semantics. It also produces the expected clamped value. 

cc: @SherlockNoMad @ezyang @janeyx99 

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci