### PR TITLE
Return fake mode from export graph capture API

### DIFF
--- a/test/distributed/tensor/test_dtensor_export.py
+++ b/test/distributed/tensor/test_dtensor_export.py
@@ -83,7 +83,8 @@ def strict_export_and_aot_export_joint_with_descriptors(model, inputs):
 def graph_capture_and_aot_export_joint_with_descriptors(model, inputs):
     with torch._dynamo.config.patch(install_free_tensors=True):
         # TODO: switch to use the official graph_capture API once it is ready
-        gm, fake_mode = _dynamo_graph_capture_for_export(model)(inputs)
+        gm = _dynamo_graph_capture_for_export(model)(inputs)
+        fake_mode = gm.meta.get("fake_mode", None)
     with tracing(TracingContext(fake_mode)):
         return aot_export_joint_with_descriptors_alone(gm, inputs)
 

--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -382,7 +382,7 @@ def forward(self, x):
 
         from torch._dynamo.functional_export import _dynamo_graph_capture_for_export
 
-        graph_module, _ = _dynamo_graph_capture_for_export(Foo())(
+        graph_module = _dynamo_graph_capture_for_export(Foo())(
             *export_inputs[0], **export_inputs[1]
         )
 
@@ -401,7 +401,7 @@ def forward(self, x):
 
         from torch._dynamo.functional_export import _dynamo_graph_capture_for_export
 
-        graph_module, _ = _dynamo_graph_capture_for_export(Foo())(
+        graph_module = _dynamo_graph_capture_for_export(Foo())(
             *export_inputs[0], **export_inputs[1]
         )
 

--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -382,7 +382,7 @@ def forward(self, x):
 
         from torch._dynamo.functional_export import _dynamo_graph_capture_for_export
 
-        graph_module = _dynamo_graph_capture_for_export(Foo())(
+        graph_module, _ = _dynamo_graph_capture_for_export(Foo())(
             *export_inputs[0], **export_inputs[1]
         )
 
@@ -401,7 +401,7 @@ def forward(self, x):
 
         from torch._dynamo.functional_export import _dynamo_graph_capture_for_export
 
-        graph_module = _dynamo_graph_capture_for_export(Foo())(
+        graph_module, _ = _dynamo_graph_capture_for_export(Foo())(
             *export_inputs[0], **export_inputs[1]
         )
 

--- a/test/functorch/test_aot_joint_with_descriptors.py
+++ b/test/functorch/test_aot_joint_with_descriptors.py
@@ -36,6 +36,7 @@ from torch._functorch.aot_autograd import (
     aot_compile_joint_with_descriptors,
     aot_export_joint_with_descriptors,
 )
+from torch._guards import tracing, TracingContext
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
@@ -781,17 +782,25 @@ class inner_f(torch.nn.Module):
         for with_export in [False]:  # TODO: make dynamo work for annotation
             with ExitStack() as stack:
                 model = None
-                with fx_traceback.preserve_node_meta():
-                    if with_export:
-                        with torch._dynamo.config.patch(install_free_tensors=True):
-                            # TODO: switch to use the official graph_capture API once it is ready
-                            model = _dynamo_graph_capture_for_export(model)(*inputs)
-                    else:
-                        model = SimpleLinear()
+                fake_mode = None
 
-                    joint_with_descriptors = aot_export_joint_with_descriptors(
-                        stack, model, inputs, decompositions={}
+                stack.enter_context(fx_traceback.preserve_node_meta())
+
+                if with_export:
+                    from torch._export.utils import _compiling_state_context
+
+                    stack.enter_context(
+                        torch._dynamo.config.patch(install_free_tensors=True)
                     )
+                    # TODO: switch to use the official graph_capture API once it is ready
+                    model, fake_mode = _dynamo_graph_capture_for_export(model)(*inputs)
+                else:
+                    model = SimpleLinear()
+
+                stack.enter_context(tracing(TracingContext(fake_mode)))
+                joint_with_descriptors = aot_export_joint_with_descriptors(
+                    stack, model, inputs, decompositions={}
+                )
 
                 for node in joint_with_descriptors.graph_module.graph.nodes:
                     if node.op in ("placeholder", "output"):

--- a/test/functorch/test_aot_joint_with_descriptors.py
+++ b/test/functorch/test_aot_joint_with_descriptors.py
@@ -781,21 +781,17 @@ class inner_f(torch.nn.Module):
 
         for with_export in [False]:  # TODO: make dynamo work for annotation
             with ExitStack() as stack:
-                model = None
+                model = SimpleLinear()
                 fake_mode = None
 
                 stack.enter_context(fx_traceback.preserve_node_meta())
 
                 if with_export:
-                    from torch._export.utils import _compiling_state_context
-
                     stack.enter_context(
                         torch._dynamo.config.patch(install_free_tensors=True)
                     )
                     # TODO: switch to use the official graph_capture API once it is ready
                     model, fake_mode = _dynamo_graph_capture_for_export(model)(*inputs)
-                else:
-                    model = SimpleLinear()
 
                 stack.enter_context(tracing(TracingContext(fake_mode)))
                 joint_with_descriptors = aot_export_joint_with_descriptors(

--- a/test/functorch/test_aot_joint_with_descriptors.py
+++ b/test/functorch/test_aot_joint_with_descriptors.py
@@ -791,7 +791,8 @@ class inner_f(torch.nn.Module):
                         torch._dynamo.config.patch(install_free_tensors=True)
                     )
                     # TODO: switch to use the official graph_capture API once it is ready
-                    model, fake_mode = _dynamo_graph_capture_for_export(model)(*inputs)
+                    model = _dynamo_graph_capture_for_export(model)(*inputs)
+                    fake_mode = model.meta.get("fake_mode", None)
 
                 stack.enter_context(tracing(TracingContext(fake_mode)))
                 joint_with_descriptors = aot_export_joint_with_descriptors(

--- a/torch/_dynamo/functional_export.py
+++ b/torch/_dynamo/functional_export.py
@@ -403,10 +403,7 @@ def _dynamo_graph_capture_for_export(
     *,
     constraints: Optional[list[Constraint]] = None,
     dynamic_shapes: Optional[Union[dict[str, Any], tuple[Any], list[Any]]] = None,
-) -> Callable[
-    ...,
-    tuple[torch.fx.GraphModule, Optional[torch._subclasses.fake_tensor.FakeTensorMode]],
-]:
+) -> Callable[..., torch.fx.GraphModule]:
     """
     Improved dynamo graph capture using transformer approach with proper fake tensor handling.
 
@@ -431,11 +428,7 @@ def _dynamo_graph_capture_for_export(
     _dynamic_shapes = dynamic_shapes
     _constraints = constraints
 
-    def inner(
-        *args: Any, **kwargs: Any
-    ) -> tuple[
-        torch.fx.GraphModule, Optional[torch._subclasses.fake_tensor.FakeTensorMode]
-    ]:
+    def inner(*args: Any, **kwargs: Any) -> torch.fx.GraphModule:
         # This sets the is_exporting flag when building guards.
         with _compiling_state_context():
             flat_inputs, in_spec = pytree.tree_flatten((args, kwargs))
@@ -554,7 +547,8 @@ def _dynamo_graph_capture_for_export(
             clean_export_root(transformed_graph)
 
             transformed_graph.meta["module_call_specs"] = module_call_spec
+            transformed_graph.meta["fake_mode"] = fake_mode
 
-            return transformed_graph, fake_mode
+            return transformed_graph
 
     return inner

--- a/torch/_dynamo/functional_export.py
+++ b/torch/_dynamo/functional_export.py
@@ -403,7 +403,9 @@ def _dynamo_graph_capture_for_export(
     *,
     constraints: Optional[list[Constraint]] = None,
     dynamic_shapes: Optional[Union[dict[str, Any], tuple[Any], list[Any]]] = None,
-) -> Callable[..., torch.fx.GraphModule]:
+) -> Callable[
+    ..., tuple[torch.fx.GraphModule, torch._subclasses.fake_tensor.FakeTensorMode]
+]:
     """
     Improved dynamo graph capture using transformer approach with proper fake tensor handling.
 
@@ -548,6 +550,6 @@ def _dynamo_graph_capture_for_export(
 
             transformed_graph.meta["module_call_specs"] = module_call_spec
 
-            return transformed_graph
+            return transformed_graph, fake_mode
 
     return inner

--- a/torch/_dynamo/functional_export.py
+++ b/torch/_dynamo/functional_export.py
@@ -404,7 +404,8 @@ def _dynamo_graph_capture_for_export(
     constraints: Optional[list[Constraint]] = None,
     dynamic_shapes: Optional[Union[dict[str, Any], tuple[Any], list[Any]]] = None,
 ) -> Callable[
-    ..., tuple[torch.fx.GraphModule, torch._subclasses.fake_tensor.FakeTensorMode]
+    ...,
+    tuple[torch.fx.GraphModule, Optional[torch._subclasses.fake_tensor.FakeTensorMode]],
 ]:
     """
     Improved dynamo graph capture using transformer approach with proper fake tensor handling.
@@ -430,7 +431,11 @@ def _dynamo_graph_capture_for_export(
     _dynamic_shapes = dynamic_shapes
     _constraints = constraints
 
-    def inner(*args: Any, **kwargs: Any) -> torch.fx.GraphModule:
+    def inner(
+        *args: Any, **kwargs: Any
+    ) -> tuple[
+        torch.fx.GraphModule, Optional[torch._subclasses.fake_tensor.FakeTensorMode]
+    ]:
         # This sets the is_exporting flag when building guards.
         with _compiling_state_context():
             flat_inputs, in_spec = pytree.tree_flatten((args, kwargs))

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -834,8 +834,8 @@ def _export_to_torch_ir(
                     # We can't serialize entire fake mode yet, so this is to make sure
                     # things like copy.deepcopy(ep.graph_module) not crash.
                     # see test_export.py::test_custom_tag_metadata_re_export
-                    # Once we delete the old strict export, we can use this fake mode in the 
-                    # subsequent logic when lowering to aten IR. 
+                    # Once we delete the old strict export, we can use this fake mode in the
+                    # subsequent logic when lowering to aten IR.
                     del gm_torch_level.meta["fake_mode"]
 
                 else:

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -828,7 +828,7 @@ def _export_to_torch_ir(
                         _dynamo_graph_capture_for_export,
                     )
 
-                    gm_torch_level = _dynamo_graph_capture_for_export(
+                    gm_torch_level, _ = _dynamo_graph_capture_for_export(
                         f, constraints=constraints, dynamic_shapes=dynamic_shapes
                     )(*args, **kwargs)
 

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -828,9 +828,13 @@ def _export_to_torch_ir(
                         _dynamo_graph_capture_for_export,
                     )
 
-                    gm_torch_level, _ = _dynamo_graph_capture_for_export(
+                    gm_torch_level = _dynamo_graph_capture_for_export(
                         f, constraints=constraints, dynamic_shapes=dynamic_shapes
                     )(*args, **kwargs)
+                    # We can't serialize entire fake mode yet, so this is to make sure
+                    # things like copy.deepcopy(ep.graph_module) not crash.
+                    # see test_export.py::test_custom_tag_metadata_re_export
+                    del gm_torch_level.meta["fake_mode"]
 
                 else:
                     gm_torch_level, _ = torch._dynamo.export(

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -834,6 +834,8 @@ def _export_to_torch_ir(
                     # We can't serialize entire fake mode yet, so this is to make sure
                     # things like copy.deepcopy(ep.graph_module) not crash.
                     # see test_export.py::test_custom_tag_metadata_re_export
+                    # Once we delete the old strict export, we can use this fake mode in the 
+                    # subsequent logic when lowering to aten IR. 
                     del gm_torch_level.meta["fake_mode"]
 
                 else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #164730

This PR is to temporarily unblock various experiments to re-use dynamo create fake mode. Note that this is still not what we want as the end state. The end state should look sth like:
```
out = fulllgraph_capture(mod, inputs)
fake_mode = out.backend_inputs.fake_mode 
gm  = out.module()
```
This doesn't work today because export requires we need to wrap the original module to setup a flat module to trace for easier handling of pytree. As a result, we would need to carry export specific flag in fullgraph_capture which seems not ideal. 
Regardless, the end state is that we need to give downstream user a graph module and a fake mode in some form, so I think _dynamo_graph_capture_for_export returning a fake mode within graph module itself via gm.meta 

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela