### PR TITLE
[ROCm] Fix test_cuda_synchronize failure on ROCm

### DIFF
--- a/test/jit/test_cuda.py
+++ b/test/jit/test_cuda.py
@@ -14,7 +14,6 @@ from torch.testing._internal.common_utils import (
     NoTest,
     raise_on_run_directly,
     skipCUDANonDefaultStreamIf,
-    skipIfRocm,
     TEST_CUDA,
 )
 from torch.testing._internal.jit_utils import JitTestCase
@@ -48,7 +47,6 @@ class TestCUDA(JitTestCase):
         torch.cuda.empty_cache()
         super().tearDown()
 
-    @skipIfRocm
     @unittest.skipIf(not TEST_MULTIGPU, "detected only one GPU")
     def test_cuda_synchronize(self):
         # Test device synchronization.
@@ -160,7 +158,6 @@ class TestCUDA(JitTestCase):
         self.assertEqual(0, d2)
         self.assertEqual(d0, d2)
 
-    @skipIfRocm
     @unittest.skipIf(not TEST_MULTIGPU, "detected only one GPU")
     @unittest.skipIf(not TEST_LARGE_TENSOR, "not enough memory")
     @skipCUDANonDefaultStreamIf(True)

--- a/test/jit/test_cuda.py
+++ b/test/jit/test_cuda.py
@@ -16,10 +16,8 @@ from torch.testing._internal.common_utils import (
     skipCUDANonDefaultStreamIf,
     skipIfRocm,
     TEST_CUDA,
-    TEST_WITH_ROCM,
 )
 from torch.testing._internal.jit_utils import JitTestCase
-
 
 # Make the helper files in test/ importable
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))

--- a/test/jit/test_cuda.py
+++ b/test/jit/test_cuda.py
@@ -19,7 +19,6 @@ from torch.testing._internal.common_utils import (
 )
 from torch.testing._internal.jit_utils import JitTestCase
 
-
 # Make the helper files in test/ importable
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(pytorch_test_dir)
@@ -79,9 +78,11 @@ class TestCUDA(JitTestCase):
             return prev_current_device_index == after_current_device_index
 
         self.assertTrue(test_device_synchronize)
-        FileCheck().check("cuda::synchronize(").run(test_device_synchronize.graph)
         self.assertTrue(test_multi_device_synchronize)
-        FileCheck().check("cuda::synchronize(").run(test_multi_device_synchronize.graph)
+
+        if not TEST_WITH_ROCM:
+            FileCheck().check("cuda::synchronize(").run(test_device_synchronize.graph)
+            FileCheck().check("cuda::synchronize(").run(test_multi_device_synchronize.graph)
 
     def test_stream_args(self):
         # Test stream creation with default arguments

--- a/test/jit/test_cuda.py
+++ b/test/jit/test_cuda.py
@@ -19,6 +19,7 @@ from torch.testing._internal.common_utils import (
 )
 from torch.testing._internal.jit_utils import JitTestCase
 
+
 # Make the helper files in test/ importable
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(pytorch_test_dir)
@@ -78,11 +79,9 @@ class TestCUDA(JitTestCase):
             return prev_current_device_index == after_current_device_index
 
         self.assertTrue(test_device_synchronize)
+        FileCheck().check("cuda::synchronize(").run(test_device_synchronize.graph)
         self.assertTrue(test_multi_device_synchronize)
-
-        if not TEST_WITH_ROCM:
-            FileCheck().check("cuda::synchronize(").run(test_device_synchronize.graph)
-            FileCheck().check("cuda::synchronize(").run(test_multi_device_synchronize.graph)
+        FileCheck().check("cuda::synchronize(").run(test_multi_device_synchronize.graph)
 
     def test_stream_args(self):
         # Test stream creation with default arguments

--- a/test/jit/test_cuda.py
+++ b/test/jit/test_cuda.py
@@ -16,8 +16,10 @@ from torch.testing._internal.common_utils import (
     skipCUDANonDefaultStreamIf,
     skipIfRocm,
     TEST_CUDA,
+    TEST_WITH_ROCM,
 )
 from torch.testing._internal.jit_utils import JitTestCase
+
 
 # Make the helper files in test/ importable
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))

--- a/tools/amd_build/build_amd.py
+++ b/tools/amd_build/build_amd.py
@@ -137,6 +137,7 @@ ignores = [
     "third_party/nvfuser/runtime/helpers.cu",
     "torch/csrc/jit/codegen/fuser/cuda/resource_strings.h",
     "torch/csrc/jit/tensorexpr/ir_printer.cpp",
+    "torch/csrc/jit/ir/ir.h",
     # generated files we shouldn't frob
     "torch/lib/tmp_install/*",
     "torch/include/*",

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -1175,12 +1175,10 @@ bool Node::hasSideEffects() const {
     case prim::rpc_sync: // It represents RPC message sent.
     case prim::rpc_remote: // It represents RPC message sent.
     case aten::wait: // It can represent RPC message received.
-#if !defined(USE_ROCM)
     case cuda::set_stream:
     case cuda::_set_device:
     case cuda::_current_device:
     case cuda::synchronize:
-#endif
     case prim::Enter:
     case prim::Exit:
       return true;

--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -78,9 +78,7 @@ namespace aten {
 using namespace ::c10::aten;
 }
 namespace cuda {
-#if !defined(USE_ROCM)
 using namespace ::c10::cuda;
-#endif
 } // namespace cuda
 
 struct Function;


### PR DESCRIPTION
This PR skips the hipify step of torch/csrc/jit/ir/ir.h to avoid a build-time error for the JIT cuda namespace.  This fixes two skipped tests in test/jit/test_cuda.py.

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd