### PR TITLE
Change phlippe resnet tolerance on torchbench for bf16

### DIFF
--- a/benchmarks/dynamo/torchbench.yaml
+++ b/benchmarks/dynamo/torchbench.yaml
@@ -58,6 +58,7 @@ tolerance:
   # These models need higher tolerance for xpu devices with bf16
   higher_bf16_xpu:
     - squeezenet1_1
+    - phlippe_resnet
 
   freezing:
     # Similar logic to timm_models.py:get_tolerance_and_cosine_flag


### PR DESCRIPTION
With 2.6.0 cosine_similarity was forced. See https://github.com/pytorch/pytorch/blob/main/benchmarks/dynamo/common.py#L2227
We hit exception because "Double and complex datatype matmul is not supported in oneDNN", since we started to support in later releases cosine_similarity is set to False, which causes fail.
When I forced it to True on latest pytorch, we pass the benchmark.

I'd argue for adding phlippe_resnet here:
https://github.com/pytorch/pytorch/blob/main/benchmarks/dynamo/torchbench.yaml#L60

Fixes https://github.com/intel/torch-xpu-ops/issues/1799

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @chenyang78