### PR TITLE
Avoid unnecessary instantiation of default capture stream

### DIFF
--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -221,7 +221,7 @@ class graph:
         # Lazy-init of default_capture_stream helps avoid circular-import errors.
         # Not thread safe, but graphs already have the general (explicitly documented)
         # restriction that only one capture may be underway at a time in the process.
-        if self.__class__.default_capture_stream is None:
+        if stream is None and self.__class__.default_capture_stream is None:
             self.__class__.default_capture_stream = torch.cuda.Stream()
 
         self.pool: tuple[()] | tuple[_POOL_HANDLE] = () if pool is None else (pool,)


### PR DESCRIPTION
Removes the unnecessary instantiation of the default capture stream if a stream is provided in the constructor.

Fixes #ISSUE_NUMBER
