### PR TITLE
[reland] Add provenance to inductor IR nodes created after graph.run (#164255)

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -1533,7 +1533,7 @@ class TestMaxAutotune(TestCase):
             ).run(code[0])
         else:
             FileCheck().check("extern_kernels.bmm_dtype").check_regex(
-                "triton_.*_fused_0.run"
+                "triton_.*_fused_mm_0.run"
             ).check("decompose_k").run(code[0])
             check_divisors(code)
             torch.testing.assert_close(
@@ -1554,7 +1554,7 @@ class TestMaxAutotune(TestCase):
             ).run(code[0])
         else:
             FileCheck().check("extern_kernels.bmm_dtype").check_regex(
-                "triton_.*_fused_0.run"
+                "triton_.*_fused_.*_0.run"
             ).check("decompose_k").run(code[0])
             check_divisors(code)
             torch.testing.assert_close(
@@ -1609,7 +1609,7 @@ class TestMaxAutotune(TestCase):
 
             out, code = run_and_get_code(compiled_func, a, b)
             FileCheck().check("extern_kernels.bmm_dtype").check_regex(
-                "triton_.*_fused_0.run"
+                "triton_.*_fused_.*.run"
             ).check("decompose_k").check_regex(r"s[0-9]+ = s[0-9]+").check_regex(
                 r"2\*s[0-9]+"
             ).check_regex("s[0-9]+ = 32").run(code[0])

--- a/test/inductor/test_provenance_tracing.py
+++ b/test/inductor/test_provenance_tracing.py
@@ -13,6 +13,7 @@ import zipfile
 from pathlib import Path
 
 import torch
+from torch._C import FileCheck
 from torch._dynamo.utils import detect_fake_mode
 from torch._inductor import config
 from torch._inductor.debug import (
@@ -23,6 +24,7 @@ from torch._inductor.debug import (
 )
 from torch._inductor.fx_passes.post_grad import post_grad_passes
 from torch._inductor.test_case import run_tests, TestCase
+from torch._inductor.utils import run_and_get_code
 from torch._inductor.virtualized import V
 from torch.testing._internal.common_utils import IS_MACOS
 from torch.testing._internal.triton_utils import requires_cuda_and_triton
@@ -589,6 +591,32 @@ class TestProvenanceTracingStackTraces(TestCase):
                         sorted(expected_lines),
                         f"Mismatch for key: {key}",
                     )
+
+    @torch._inductor.config.patch(
+        {"trace.provenance_tracking_level": 2, "max_autotune_gemm_backends": "ATEN"}
+    )
+    @requires_cuda_and_triton
+    def test_deferred_triton_kernels(self):
+        def foo(m, inp):
+            a = m(inp)
+            return a
+
+        foo_c = torch.compile(mode="max-autotune-no-cudagraphs")(foo)
+
+        m = torch.nn.Linear(512, 512, bias=True).half().cuda()
+        inp = torch.rand([1, 512]).half().cuda()
+
+        with self._setup_provenance_capture() as payload_buffer:
+            with torch.no_grad():
+                _, out_code = run_and_get_code(foo_c, m, inp)
+            payload_content = payload_buffer.getvalue().strip()
+            data = json.loads(payload_content)
+            self.assertTrue("a = m(inp)" in str(data))
+
+            # Check that debug handle is in the output code
+            FileCheck().check("Topologically Sorted Source Nodes: [a]").check(
+                "[Provenance debug handles]"
+            ).run(out_code[0])
 
     def _check_kernel_information_json(self, kernel_info, expected_kernels):
         """Validate kernel information JSON structure and content."""

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -9463,3 +9463,30 @@ def maybe_free_symbols(s: object) -> OrderedSet[Symbol]:
         return free_symbols(s)
     else:
         return OrderedSet()
+
+
+def assign_origin_node(result: Any, n: torch.fx.Node) -> None:
+    # This is not complete, but it doesn't have to be: origin_node
+    # tracking is best effort.  The logic here critically relies on direct
+    # TensorBox -> StorageBox denoting a non-view; we don't bother trying
+    # to get views to work.  Feel free to add any extra cases as needed.
+    #
+    # Note: we can't YOLO tree_map over this result, because if there are
+    # buffers or a view involved, we might not be able to validly assign
+    # the origin_node here.
+    if isinstance(result, TensorBox) and isinstance(result.data, StorageBox):
+        if isinstance(result.data.data, Loops):
+            result.data.data._post_init_setattr("origin_node", n)
+        elif isinstance(result.data.data, Buffer):
+            result.data.data._post_init_setattr("origin_node", n)
+            if isinstance(result.data.data, ComputedBuffer) and isinstance(
+                result.data.data.data, Loops
+            ):
+                result.data.data.data._post_init_setattr("origin_node", n)
+            # Not really multi-output, can straightforwardly recurse in
+            elif (
+                isinstance(result.data.data, MultiOutput)
+                and not result.data.data.indices
+            ):
+                if isinstance(result.data.data.inputs[0], Buffer):
+                    result.data.data.inputs[0]._post_init_setattr("origin_node", n)


### PR DESCRIPTION
Summary:

as title

- Some IR nodes are created during `finalize_multi_template_buffers()` in Scheduler. This PR adds provenance (`origin_node` and `origins`) for those nodes.

- Extract `assign_origin_node` function

Test Plan:
```
buck run mode/opt fbcode//caffe2/test/inductor:provenance_tracing -- -r  test_deferred_triton_kernels
```

Differential Revision: D83979975




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben