### PR TITLE
[Inductor] Bitwise equivalence between compile and eager for small reductions, rnumel < 8 and 1D

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -1449,17 +1449,39 @@ class Reduction(Loops):
         reduction_ranges = V.graph.sizevars.guard_int_seq(reduction_ranges)
 
         combine_fn = get_reduction_combine_fn(reduction_type, src_dtype)
-
+        
+        # Number of default accumulators for thread_reduce for eager
+        # to emulate reduction order
         def fn(index: Sequence[_IntLike]) -> Any:
-            return functools.reduce(
-                combine_fn,
-                (
-                    value_fn(index, rindex)
-                    for rindex in itertools.product(
-                        *[range(x) for x in reduction_ranges]
+            # Currently only support eager emulation for 1 reduction range
+            if len(reduction_ranges) > 1:
+                return functools.reduce(
+                    combine_fn,
+                    (
+                        value_fn(index, rindex)
+                        for rindex in itertools.product(
+                            *[range(x) for x in reduction_ranges]
+                        )
+                    ),
+                )
+
+            # num_accs based on vt0 in aten/native/cuda/Reduce.cuh
+            num_accs = 4
+            rnumel = reduction_ranges[0]
+            accs = []
+            for acc_num in range(min(num_accs, rnumel)):
+                accs.append(
+                    functools.reduce(
+                        combine_fn,
+                        (
+                            value_fn(index, rindex)
+                            for rindex in itertools.product(
+                                *[range(acc_num, x, num_accs) for x in reduction_ranges]
+                            )
+                        ),
                     )
-                ),
-            )
+                )
+            return functools.reduce(combine_fn, accs)
 
         value_fn: Callable[[Sequence[_IntLike], Sequence[_IntLike]], Any]
         if reduction_type in ("argmin", "argmax"):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #164144
* __->__ #164755
* #164790

We move inductor numerics ever so slightly closer to eager by emulating thread_reduce reduction order, fixing flakiness of `test_emulate_precision_casts_mean_ratio_chain`. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben