### PR TITLE
Updated binary_cross_entropy_with_logits and BCEWithLogitsLoss docume…

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3590,8 +3590,8 @@ def binary_cross_entropy_with_logits(
     Args:
         input: Tensor of arbitrary shape as unnormalized scores (often referred to as logits).
         target: Tensor of the same shape as input with values between 0 and 1
-        weight (Tensor, optional): a manual rescaling weight
-            if provided it's repeated to match input tensor shape
+        weight (Tensor, optional): The dimension of weight supports :ref:`broadcasting to a common shape <broadcasting-semantics>`
+            with respect to the input (and target) shape.
         size_average (bool, optional): Deprecated (see :attr:`reduction`).
         reduce (bool, optional): Deprecated (see :attr:`reduction`).
         reduction (str, optional): Specifies the reduction to apply to the output:

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3590,8 +3590,9 @@ def binary_cross_entropy_with_logits(
     Args:
         input: Tensor of arbitrary shape as unnormalized scores (often referred to as logits).
         target: Tensor of the same shape as input with values between 0 and 1
-        weight (Tensor, optional): The dimension of weight supports :ref:`broadcasting to a common shape <broadcasting-semantics>`
-            with respect to the input (and target) shape.
+        weight (Tensor, optional): a manual rescaling weight. If provided, the dimension
+           of weight supports :ref:`broadcasting to a common shape <broadcasting-semantics>`
+           with respect to the input (and target) shape.
         size_average (bool, optional): Deprecated (see :attr:`reduction`).
         reduce (bool, optional): Deprecated (see :attr:`reduction`).
         reduction (str, optional): Specifies the reduction to apply to the output:

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -775,7 +775,8 @@ class BCEWithLogitsLoss(_Loss):
 
     Args:
         weight (Tensor, optional): a manual rescaling weight given to the loss
-            of each batch element. If given, has to be a Tensor of size `nbatch`.
+            of each batch element. The dimension of weight supports :ref:`broadcasting to a common shape <broadcasting-semantics>`
+            with respect to the output (and target) shape.
         size_average (bool, optional): Deprecated (see :attr:`reduction`). By default,
             the losses are averaged over each loss element in the batch. Note that for
             some losses, there are multiple elements per sample. If the field :attr:`size_average`


### PR DESCRIPTION
Fixes #68780

Updated binary_cross_entropy_with_logits and BCEWithLogitsLoss documentation to show that the weight supports shape broadcasting with respect to the input tensor's shape.

@albanD 