### PR TITLE
[fx][traceback] Actually disable preservation of node metadata when enable=False

### DIFF
--- a/torch/fx/traceback.py
+++ b/torch/fx/traceback.py
@@ -219,19 +219,15 @@ class NodeSource:
 def preserve_node_meta(enable=True):
     global should_preserve_node_meta
     global current_meta
-    # If enable is False, this context manager is a no-op
-    if not enable:
+    saved_should_preserve_node_meta = should_preserve_node_meta
+    # Shallow copy is OK since fields of current_meta are not mutated
+    saved_current_meta = current_meta.copy()
+    try:
+        should_preserve_node_meta = enable
         yield
-    else:
-        saved_should_preserve_node_meta = should_preserve_node_meta
-        # Shallow copy is OK since fields of current_meta are not mutated
-        saved_current_meta = current_meta.copy()
-        try:
-            should_preserve_node_meta = True
-            yield
-        finally:
-            should_preserve_node_meta = saved_should_preserve_node_meta
-            current_meta = saved_current_meta
+    finally:
+        should_preserve_node_meta = saved_should_preserve_node_meta
+        current_meta = saved_current_meta
 
 
 @compatibility(is_backward_compatible=False)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #164776
* #164795
* __->__ #164772

This will come in handy when we run graph passes that add new nodes, and
create_proxy can add seq_nr meta.

cc @ezyang @EikanWang @jgong5 @wenzhe-nrv