### PR TITLE
[precompile] Load source cache for AOT compile as well.

### DIFF
--- a/test/dynamo/test_guard_serialization.py
+++ b/test/dynamo/test_guard_serialization.py
@@ -416,14 +416,11 @@ class TestGuardSerializationBase(torch._inductor.test_case.TestCase):
                 self.assertIsNotNone(guards_state)
                 guards_state = torch._dynamo.package.load_guards_state(guards_state)
 
-                check_fn_manager = CheckFunctionManager(
+                loaded_gm = torch._dynamo.package.load_guard_manager(
+                    guards_state,
                     self._frame_state.f_code,
-                    guards_state.output_graph,
-                    shape_code_parts=guards_state.shape_code_parts,
-                    runtime_global_scope=self._frame_state.f_globals,
-                    source_get_cache=guards_state.source_get_cache,
+                    self._frame_state.f_globals,
                 )
-                loaded_gm = check_fn_manager.guard_manager
 
         try:
             transform_code_object(self._frame_state.f_code, transform)

--- a/torch/_dynamo/aot_compile.py
+++ b/torch/_dynamo/aot_compile.py
@@ -77,7 +77,7 @@ class AOTCompiledFunction:
         return self._artifacts.guard_manager.check(f_locals)
 
     def __post_init__(self) -> None:
-        from .package import load_guards_state
+        from .package import load_guard_manager, load_guards_state
 
         self._artifacts.check_compatibility()
 
@@ -95,12 +95,11 @@ class AOTCompiledFunction:
 
         if self._artifacts.guard_manager is None:
             guards_state = load_guards_state(self._artifacts.guards_state)
-            self._artifacts.guard_manager = torch._dynamo.guards.CheckFunctionManager(
+            self._artifacts.guard_manager = load_guard_manager(
+                guards_state,
                 self._artifacts.original_code,
-                guards_state.output_graph,
-                shape_code_parts=guards_state.shape_code_parts,
-                runtime_global_scope=f_globals,
-            ).guard_manager
+                f_globals,
+            )
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         assert self._artifacts.guard_manager is not None


### PR DESCRIPTION
Adding source_get_cache also to AOT compile case. Since the guard manager loader code can be shared between AOT and caching, we added a new function load_guard_manager to avoid code duplication between two workflows, for loading guards.

Test Plan: test_guard_serialization.py

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela