### PR TITLE
[hop] make other control flow operators use register_fake

### DIFF
--- a/torch/_higher_order_ops/associative_scan.py
+++ b/torch/_higher_order_ops/associative_scan.py
@@ -18,6 +18,7 @@ from torch._higher_order_ops.utils import (
     first_slice_copy_with_grad,
     materialize_as_graph,
     reenter_make_fx,
+    register_fake,
     save_tensors_and_symints_for_backward,
     saved_tensors_and_symints,
     split_into_chunks,
@@ -25,7 +26,6 @@ from torch._higher_order_ops.utils import (
     validate_subgraph_args_types,
 )
 from torch._ops import HigherOrderOperator
-from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import (
     disable_proxy_modes_tracing,
     ProxyTorchDispatchMode,
@@ -846,10 +846,9 @@ def associative_scan_proxy_mode(mode, combine_fn, xs, additional_inputs):
     )
 
 
-@associative_scan_op.py_impl(FakeTensorMode)
-def assoiciative_scan_fake_tensor_mode(mode, combine_fn, xs, additional_inputs):
-    with mode:
-        return tuple(x.clone() for x in xs)
+@register_fake(associative_scan_op)
+def assoiciative_scan_fake_tensor_mode(combine_fn, xs, additional_inputs):
+    return tuple(x.clone() for x in xs)
 
 
 @associative_scan_op.py_functionalize_impl

--- a/torch/_higher_order_ops/map.py
+++ b/torch/_higher_order_ops/map.py
@@ -10,7 +10,6 @@ from torch._C import DispatchKey
 from torch._dispatch.python import suspend_functionalization
 from torch._higher_order_ops.utils import _maybe_run_with_interpreter, reenter_make_fx
 from torch._ops import HigherOrderOperator
-from torch._subclasses.fake_tensor import FakeTensorMode
 from torch._subclasses.functional_tensor import disable_functional_mode
 from torch.fx.experimental.proxy_tensor import (
     disable_proxy_modes_tracing,
@@ -26,6 +25,7 @@ from .utils import (
     fill_none_with_masks,
     filter_with_masks,
     materialize_as_graph,
+    register_fake,
     save_tensors_and_symints_for_backward,
     saved_tensors_and_symints,
     split_into_chunks,
@@ -251,10 +251,9 @@ def map_proxy_torch_dispatch_mode(mode, f, xs, args):
     return trace_map(mode, map_impl, f, xs, args)
 
 
-@map_impl.py_impl(FakeTensorMode)
-def map_fake_tensor_mode(mode, f, xs, args):
-    with mode:
-        return map_dense(f, xs, args)
+@register_fake(map_impl)
+def map_fake_tensor_mode(f, xs, args):
+    return map_dense(f, xs, args)
 
 
 @map_impl.py_functionalize_impl

--- a/torch/_higher_order_ops/while_loop.py
+++ b/torch/_higher_order_ops/while_loop.py
@@ -916,7 +916,7 @@ while_loop_stack_output_op.py_impl(ProxyTorchDispatchMode)(
     functools.partial(while_loop_tracing, stack_output=True)
 )
 
-while_loop_stack_output_op.py_impl(FakeTensorMode)(
+register_fake(while_loop_stack_output_op)(
     functools.partial(while_loop_fake_tensor_mode, stack_output=True)
 )
 

--- a/torch/_higher_order_ops/while_loop.py
+++ b/torch/_higher_order_ops/while_loop.py
@@ -16,7 +16,9 @@ from torch._higher_order_ops.utils import (
     fill_none_with_masks,
     filter_with_masks,
     materialize_as_graph,
+    maybe_ignore_fresh_unbacked_symbols,
     reenter_make_fx,
+    register_fake,
     validate_subgraph_args_types,
 )
 from torch._ops import HigherOrderOperator
@@ -493,74 +495,64 @@ def while_loop_tracing(
     )
 
 
-@while_loop_op.py_impl(FakeTensorMode)
+@register_fake(while_loop_op)
 def while_loop_fake_tensor_mode(
-    mode, cond_fn, body_fn, carried_inputs, additional_inputs, stack_output=False
+    cond_fn, body_fn, carried_inputs, additional_inputs, stack_output=False
 ):
-    with mode:
-        # NOTE: [Handling unback symints in subgraph of while_loop]
-        # The idea is that the scope of unbacked symints are limited to the subgraph.
-        #
-        # We're implementing the fake tensor mode of while_loop operator.
-        # and we run body_fn once to get an fake output.
-        # Let's first consider the case that unbacked symints are tensor shapes:
-        #
-        # Case 1:
-        # if the unbacked symints is local to the subgraph e.g.
-        #   def body_fn(it, x):
-        #     nz = x.nonzero()
-        #     return it+1. nz.sum()
-        # we can just ignore the newly created unbacked symints because it has
-        # no effect on the output of while_loop and it's tracked when we tracing.
-        # the subgraph.
-        #
-        # Case 2:
-        # if the unbacked symints are shape of output of while_loop e.g.
-        #   def body_fn(it, x):
-        #     nz = x.nonzero()
-        #     return it+1, nz
-        # This will fail the shape check because in each iteration, the carried_input's shape
-        # must match the output shape as nz.shape contains newly allocated unbacked symint, this
-        # won't match the carried_input's shape.
-        #
-        # Case 3:
-        # if the unbacked symints are shape of carried_inputs e.g.
-        #   nz = a.nonzero()
-        #   body_fn(it, nz):
-        #     return it+1. nz.sin() + 1,
-        # There's no new unbacked symints allocated in subgraph, so we're safe.
-        with mode.shape_env.ignore_fresh_unbacked_symbols():
-            # body_fn return output with the same pytree and tensor meta data as carried_inputs
-            # so we could just return the output after one iteration.
-            body_outs = body_fn(*carried_inputs, *additional_inputs)
-            check_meta_consistency(
-                carried_inputs,
-                body_outs,
-                "carried_inputs",
-                "body_output",
-                include_contiguity=False,
-            )
+    mode = torch.utils._python_dispatch._get_current_dispatch_mode()
+    assert isinstance(mode, FakeTensorMode), f"expect FakeTensorMode but got {mode}"
+    # NOTE: [Handling unback symints in subgraph of while_loop]
+    # The idea is that the scope of unbacked symints are limited to the subgraph.
+    #
+    # We're implementing the fake tensor mode of while_loop operator.
+    # and we run body_fn once to get an fake output.
+    # Let's first consider the case that unbacked symints are tensor shapes:
+    #
+    # Case 1:
+    # if the unbacked symints is local to the subgraph e.g.
+    #   def body_fn(it, x):
+    #     nz = x.nonzero()
+    #     return it+1. nz.sum()
+    # we can just ignore the newly created unbacked symints because it has
+    # no effect on the output of while_loop and it's tracked when we tracing.
+    # the subgraph.
+    #
+    # Case 2:
+    # if the unbacked symints are shape of output of while_loop e.g.
+    #   def body_fn(it, x):
+    #     nz = x.nonzero()
+    #     return it+1, nz
+    # This will fail the shape check because in each iteration, the carried_input's shape
+    # must match the output shape as nz.shape contains newly allocated unbacked symint, this
+    # won't match the carried_input's shape.
+    #
+    # Case 3:
+    # if the unbacked symints are shape of carried_inputs e.g.
+    #   nz = a.nonzero()
+    #   body_fn(it, nz):
+    #     return it+1. nz.sin() + 1,
+    # There's no new unbacked symints allocated in subgraph, so we're safe.
+    with maybe_ignore_fresh_unbacked_symbols(mode):
+        # body_fn return output with the same pytree and tensor meta data as carried_inputs
+        # so we could just return the output after one iteration.
+        body_outs = body_fn(*carried_inputs, *additional_inputs)
+        check_meta_consistency(
+            carried_inputs,
+            body_outs,
+            "carried_inputs",
+            "body_output",
+            include_contiguity=False,
+        )
 
-        if stack_output:
-            n_iter = _create_unbacked_symint(mode, ignore_fresh_unbacked_symbols=False)
-            assert all(isinstance(x, torch.Tensor) for x in carried_inputs)
-            fake_outputs = tuple(
-                out.clone()
-                .unsqueeze(0)
-                .repeat((n_iter,) + tuple(1 for _ in range(out.dim())))
-                for out in body_outs
-            )
-            return pytree.tree_map_only(
-                (int, torch.SymInt),
-                # For while_loop's unbacked symint output, we want them to be bound
-                # to the proxy of while_loop's output.
-                lambda _: _create_unbacked_symint(
-                    mode, ignore_fresh_unbacked_symbols=False
-                ),
-                fake_outputs,
-            )
-
-        # See NOTE [unspecialize int carry with unbacked symints]
+    if stack_output:
+        n_iter = _create_unbacked_symint(mode, ignore_fresh_unbacked_symbols=False)
+        assert all(isinstance(x, torch.Tensor) for x in carried_inputs)
+        fake_outputs = tuple(
+            out.clone()
+            .unsqueeze(0)
+            .repeat((n_iter,) + tuple(1 for _ in range(out.dim())))
+            for out in body_outs
+        )
         return pytree.tree_map_only(
             (int, torch.SymInt),
             # For while_loop's unbacked symint output, we want them to be bound
@@ -568,8 +560,17 @@ def while_loop_fake_tensor_mode(
             lambda _: _create_unbacked_symint(
                 mode, ignore_fresh_unbacked_symbols=False
             ),
-            body_outs,
+            fake_outputs,
         )
+
+    # See NOTE [unspecialize int carry with unbacked symints]
+    return pytree.tree_map_only(
+        (int, torch.SymInt),
+        # For while_loop's unbacked symint output, we want them to be bound
+        # to the proxy of while_loop's output.
+        lambda _: _create_unbacked_symint(mode, ignore_fresh_unbacked_symbols=False),
+        body_outs,
+    )
 
 
 @while_loop_op.py_functionalize_impl


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #164852
* __->__ #164792
* #164548
* #164778

After this PR, all control flow operator's fake impl are reigstered via register_fake. Test with existing tests.
