### PR TITLE
Add interface for passing in constant names using FQN names

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1585,6 +1585,8 @@ class aot_inductor:
     package_constants_in_so: bool = True
 
     # Experimental. Flag to control whether to package weight separately on disk
+    # The key for the weights are FQN names, not the constant name in AOTI model.
+    # The FQN name and constant name map can be obtained using getConstantNamesToOriginalFQNs.
     package_constants_on_disk: bool = False
 
     # Experimental.  Controls automatic precompiling of common AOTI include files.

--- a/torch/csrc/inductor/aoti_runtime/interface.h
+++ b/torch/csrc/inductor/aoti_runtime/interface.h
@@ -158,8 +158,18 @@ AOTInductorModelContainerUpdateUserManagedConstantBuffer(
 
 // Same as AOTInductorModelContainerUpdateUserManagedConstantBuffer,
 // but no std::unordered_map crosses DLL boundaries for cross-compilation.
+// The keys in pairs are constant names in AOTI model.
 AOTI_API AOTIRuntimeError
 AOTInductorModelContainerUpdateUserManagedConstantBufferPairs(
+    AOTInductorModelContainerHandle container_handle,
+    const AOTInductorConstantMapEntry* pairs,
+    size_t num_pairs,
+    bool use_inactive,
+    bool validate_full_update);
+
+// The keys in pairs are original_fqn names in AOTI model.
+AOTI_API AOTIRuntimeError
+AOTInductorModelContainerUpdateUserManagedConstantBufferPairsFQNNames(
     AOTInductorModelContainerHandle container_handle,
     const AOTInductorConstantMapEntry* pairs,
     size_t num_pairs,


### PR DESCRIPTION
As title. We need an API to pass in the names using FQN names because this is the name that aligns with module state dict names

Will be tested together with https://github.com/pytorch/pytorch/pull/164811 when https://github.com/pytorch/pytorch/pull/164811 is ready to land.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @chenyang78