### PR TITLE
Fix unwrap_to_op_info for `broadcast([tensor])` call.

### DIFF
--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -398,7 +398,9 @@ class OpDispatcher:
         kwargs_schema: dict[str, object] = {}
         local_args: list[object] = []
         local_kwargs: dict[str, object] = {}
-        compute_mesh: Optional[DeviceMesh] = None
+        compute_mesh: Optional[DeviceMesh] = try_find_mesh_from_args(
+            op_call, args_list
+        )
 
         for arg in args_list:
             if isinstance(arg, dtensor.DTensor):
@@ -408,9 +410,6 @@ class OpDispatcher:
                     # record the first compute device mesh from args
                     compute_mesh = arg.device_mesh
             elif isinstance(arg, torch.Tensor):
-                compute_mesh = compute_mesh or try_find_mesh_from_args(
-                    op_call, args_list
-                )
                 args_schema.append(
                     self._try_replicate_spec_for_scalar_tensor(
                         op_call, arg, compute_mesh
@@ -427,9 +426,6 @@ class OpDispatcher:
                 local_kwargs[k] = v._local_tensor
                 kwargs_schema[k] = v._spec
             elif isinstance(v, torch.Tensor):
-                compute_mesh = compute_mesh or try_find_mesh_from_args(
-                    op_call, args_list
-                )
                 kwargs_schema[k] = self._try_replicate_spec_for_scalar_tensor(
                     op_call, v, compute_mesh
                 )


### PR DESCRIPTION
Broadcast is called with a list of tensors. https://github.com/pytorch/pytorch/blob/main/torch/distributed/distributed_c10d.py#L2838

The current unwrap_to_op_info doesn't account for args_list containing a list of tensors, and results in this error:

```
  traceback : Traceback (most recent call last):
    File "/.env/lib/python3.12/site-packages/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 357, in wrapper
      return f(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^
    File "/train_llm.py", line 120, in main
      set_model_state_dict(
    File "/.env/lib/python3.12/site-packages/torch/distributed/checkpoint/state_dict.py", line 1271, in set_model_state_dict
      return _load_model_state_dict(model, model_state_dict, info)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/.env/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
      return func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
    File "/.env/lib/python3.12/site-packages/torch/distributed/checkpoint/state_dict.py", line 585, in _load_model_state_dict
      _broadcast_state_dict(
    File "/.env/lib/python3.12/site-packages/torch/distributed/_state_dict_utils.py", line 673, in _broadcast_state_dict
      _broadcast_tensors(ret, local_state_dict, keys, device, pg)
    File "/.env/lib/python3.12/site-packages/torch/distributed/_state_dict_utils.py", line 573, in _broadcast_tensors
      dist.broadcast(tensors[0], src=0, group=pg)
    File "/.env/lib/python3.12/site-packages/torch/distributed/c10d_logger.py", line 81, in wrapper
      return func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
    File "/.env/lib/python3.12/site-packages/torch/distributed/distributed_c10d.py", line 2824, in broadcast
      work = group.broadcast([tensor], opts)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/.env/lib/python3.12/site-packages/torch/_compile.py", line 53, in inner
      return disable_fn(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/.env/lib/python3.12/site-packages/torch/_dynamo/eval_frame.py", line 929, in _fn
      return fn(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^
    File "/.env/lib/python3.12/site-packages/torch/distributed/tensor/_api.py", line 350, in __torch_dispatch__
      return DTensor._op_dispatcher.dispatch(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/.env/lib/python3.12/site-packages/torch/distributed/tensor/_dispatch.py", line 151, in dispatch
      op_info = self.unwrap_to_op_info(op_call, args, kwargs)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/.env/lib/python3.12/site-packages/torch/distributed/tensor/_dispatch.py", line 377, in unwrap_to_op_info
      assert compute_mesh is not None, (
             ^^^^^^^^^^^^^^^^^^^^^^^^
  AssertionError: found no DeviceMesh from dtensor args for c10d.broadcast_.default!
```

Updating the logic to account for this.

I produced this error with this code:
```python
    config = AutoConfig.from_pretrained(args.model_name, use_cache=False)
    if rank == 0:
        with torch.device("cpu"):
            model = AutoModelForCausalLM.from_pretrained(
                args.model_name,
                dtype=dtype,
                use_cache=False,
            )
    else:
        with torch.device("meta"):
            model = AutoModelForCausalLM.from_config(
                config,
                dtype=dtype,
            )

    fsdp_config = dict(
        reshard_after_forward=True,
        offload_policy=CPUOffloadPolicy() if args.cpu_offload == "on" else None,
        mp_policy=MixedPrecisionPolicy(
            param_dtype=torch.bfloat16,
            reduce_dtype=torch.float32,
        ),
    )
    for decoder in model.model.layers:
        fully_shard(decoder, **fsdp_config)
    fully_shard(model, **fsdp_config)

    model.to_empty(device=device)

    set_model_state_dict(
        model,
        model.state_dict(),
        options=StateDictOptions(
            full_state_dict=True,
            broadcast_from_rank0=True,
        ),
    )
```


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci