### PR TITLE
[feature][dtensor] support nn.Module inputs containing DTensor param

### DIFF
--- a/test/distributed/tensor/experimental/test_local_map.py
+++ b/test/distributed/tensor/experimental/test_local_map.py
@@ -494,5 +494,6 @@ class TestLocalMap(DTensorTestBase):
         Y_expected = torch.nn.functional.linear(X, weight)
         self.assertEqual(Y_dt.full_tensor(), Y_expected)
 
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/tensor/experimental/_func_map.py
+++ b/torch/distributed/tensor/experimental/_func_map.py
@@ -187,7 +187,7 @@ def _convert_module_dtensor_to_local(
 
                 if param.placements != placements:
                     if redistribute:
-                        param = param.redistribute(placements=placements)
+                        param = param.redistribute(placements=placements)  # type: ignore[assignment]
                     else:
                         raise ValueError(
                             f"Parameter {name} in module has mismatched placements: "
@@ -207,7 +207,7 @@ def _convert_module_dtensor_to_local(
             if isinstance(local_param, AsyncCollectiveTensor):
                 local_param = local_param.wait()
 
-            module._parameters[name] = local_param
+            module._parameters[name] = local_param  # type: ignore[assignment]
 
     return module
 
@@ -231,7 +231,7 @@ def _local_map_wrapped(
         )
 
     # we assume every DTensor object is placed on the same device mesh
-    flat_local_args = []
+    flat_local_args: list = []
     seen_dtensor_arg = False
     for idx, arg in enumerate(flat_args):
         if isinstance(arg, DTensor):
@@ -281,6 +281,7 @@ def _local_map_wrapped(
                 local_arg = local_arg.wait()
 
             flat_local_args.append(local_arg)
+
         elif isinstance(arg, torch.nn.Module):
             if _has_dtensor_parameters(arg):
                 seen_dtensor_arg = True

--- a/torch/distributed/tensor/experimental/_func_map.py
+++ b/torch/distributed/tensor/experimental/_func_map.py
@@ -62,6 +62,12 @@ def local_map(
             ``redistribute_inputs`` is ``False``, an exception will be raised. Otherwise if
             ``redistribute_inputs`` is ``True``, the argument will be first redistributed to
             the required sharding placements before passing its local tensor to ``func``.
+
+            For :class:`torch.nn.Module` inputs containing :class:`DTensor` parameters,
+            the placements will be applied to all DTensor parameters in the module. The
+            module's parameters will be converted to local tensors before being passed
+            to ``func``.
+
             The only exception is when required placements are not ``None`` and the
             argument is a :class:`torch.Tensor`. In this case, the placements examination
             will be skipped and the argument will be directly passed to ``func``.
@@ -158,6 +164,54 @@ def local_map(
     )
 
 
+def _has_dtensor_parameters(module: torch.nn.Module) -> bool:
+    """check if an nn.Module has any DTensor parameters."""
+    for param in module.parameters():
+        if isinstance(param, DTensor):
+            return True
+    return False
+
+
+def _convert_module_dtensor_to_local(
+    module: torch.nn.Module,
+    placements: Optional[Sequence[Placement]],
+    redistribute: bool,
+    grad_placements: Optional[Sequence[Placement]] = None,
+) -> torch.nn.Module:
+    """convert DTensor parameters in an nn.Module to local tensors."""
+    for name, param in module.named_parameters(recurse=False):
+        if isinstance(param, DTensor):
+            if placements is not None:
+                if not isinstance(placements, tuple):
+                    placements = tuple(placements)
+
+                if param.placements != placements:
+                    if redistribute:
+                        param = param.redistribute(placements=placements)
+                    else:
+                        raise ValueError(
+                            f"Parameter {name} in module has mismatched placements: "
+                            f"param placements is {param.placements} but the input "
+                            f"placements is {placements}! "
+                            "If redistribute_inputs is wanted, set "
+                            "redistribute_inputs=True to local_map."
+                        )
+
+            if grad_placements is not None:
+                if not isinstance(grad_placements, tuple):
+                    grad_placements = tuple(grad_placements)
+                local_param = param.to_local(grad_placements=grad_placements)
+            else:
+                local_param = param.to_local()
+
+            if isinstance(local_param, AsyncCollectiveTensor):
+                local_param = local_param.wait()
+
+            module._parameters[name] = local_param
+
+    return module
+
+
 def _local_map_wrapped(
     func: Callable,
     out_placements: OutputPlacements,
@@ -227,6 +281,35 @@ def _local_map_wrapped(
                 local_arg = local_arg.wait()
 
             flat_local_args.append(local_arg)
+        elif isinstance(arg, torch.nn.Module):
+            if _has_dtensor_parameters(arg):
+                seen_dtensor_arg = True
+
+                if device_mesh is None:
+                    for param in arg.parameters():
+                        if isinstance(param, DTensor):
+                            device_mesh = param.device_mesh
+                            break
+
+                spec = in_placements[idx] if in_placements is not None else None
+                grad_spec = (
+                    in_grad_placements[idx] if in_grad_placements is not None else None
+                )
+
+                # convert DTensor parameters to local tensors
+                # note: this modifies the module in-place
+                local_module = _convert_module_dtensor_to_local(
+                    arg, spec, redistribute_inputs, grad_spec
+                )
+                flat_local_args.append(local_module)
+            else:
+                if in_placements is not None:
+                    spec = in_placements[idx]
+                    assert spec is None, (
+                        f"Non-DTensor nn.Module input {arg} expects None placements "
+                        f"but received {spec}!"
+                    )
+                flat_local_args.append(arg)
         else:
             # Non-Tensor input must have None in `in_placements`
             if in_placements is not None and not isinstance(arg, torch.Tensor):

--- a/torch/distributed/tensor/experimental/_func_map.py
+++ b/torch/distributed/tensor/experimental/_func_map.py
@@ -300,10 +300,11 @@ def _local_map_wrapped(
                     in_grad_placements[idx] if in_grad_placements is not None else None
                 )
 
-                original_params = {}
-                for name, param in arg.named_parameters(recurse=False):
-                    if isinstance(param, DTensor):
-                        original_params[name] = param
+                original_params = {
+                    name: param
+                    for name, param in arg.named_parameters(recurse=False)
+                    if isinstance(param, DTensor)
+                }
 
                 # convert DTensor parameters to local tensors
                 # note: this modifies the module in-place, but we restore it later

--- a/torch/distributed/tensor/experimental/_func_map.py
+++ b/torch/distributed/tensor/experimental/_func_map.py
@@ -64,9 +64,10 @@ def local_map(
             the required sharding placements before passing its local tensor to ``func``.
 
             For :class:`torch.nn.Module` inputs containing :class:`DTensor` parameters,
-            the placements will be applied to all DTensor parameters in the module. The
-            module's parameters will be converted to local tensors before being passed
-            to ``func``.
+            the placements will be applied to all DTensor parameters in the module (but
+            not to parameters in submodules). The module's parameters will be converted
+            to local tensors before being passed to ``func``, and the original DTensor
+            parameters will be restored after ``func`` completes.
 
             The only exception is when required placements are not ``None`` and the
             argument is a :class:`torch.Tensor`. In this case, the placements examination


### PR DESCRIPTION
[feature][dtensor] support nn.Module inputs containing DTensor parameters in local_map

Fixes #163692

This patch adds support for `nn.Module` inputs containing DTensor parameters in the `local_map` function. Previously, users had to set `in_placements=None` for `nn.Module` arguments, which was not ergonomic. So now converts DTensor parameters in the module to local tensors before calling the user function, and supports redistribution and gradient placements like regular DTensor arguments.

```python
import torch
from torch.distributed.tensor.placement_types import Replicate, Shard
from torch.testing._internal.distributed.fake_pg import FakeStore
from torch.distributed.tensor import DTensor, distribute_tensor
from torch.distributed.tensor.experimental._func_map import local_map

world_size = 2
fake_store = FakeStore()
torch.distributed.init_process_group(
    "fake", store=fake_store, rank=0, world_size=world_size
)
mesh = torch.distributed.device_mesh.init_device_mesh("cuda", (world_size,))

print("Using Replicate placements")
print("=" * 60)

@local_map(
    out_placements=[Replicate()],
    in_placements=(
        [Replicate()],
        [Replicate()]
    ),
    redistribute_inputs=True,
    device_mesh=mesh,
)
def fn_replicate(linear, y):
    return linear(y)

linear = torch.nn.Linear(8, 16, bias=False).cuda()
linear.weight = torch.nn.Parameter(
    distribute_tensor(linear.weight, mesh, [Replicate()])
)

y = torch.randn(4, 8).cuda()
result = fn_replicate(linear, y)

print(f"Input shape: {y.shape}")
print(f"Weight shape: {linear.weight.shape}")
print(f"Output shape: {result.shape}")
print(f"Output is DTensor: {isinstance(result, DTensor)}")
if isinstance(result, DTensor):
    print(f"Output placements: {result.placements}")

print("\nbefore this fix, in_placements had to be None")
print("=" * 60)

@local_map(
    out_placements=[Replicate()],
    in_placements=(
        None,
        [Replicate()]
    ),
    redistribute_inputs=True,
    device_mesh=mesh,
)
def fn_old_way(linear, y):
    return linear(y)

linear2 = torch.nn.Linear(8, 16, bias=False).cuda()

result2 = fn_old_way(linear2, y)
print(f"Old way (in_placements=None) still works")
print(f"Output shape: {result2.shape}")

print("\n" + "=" * 60)
torch.distributed.destroy_process_group()
```

```
Using Replicate placements
============================================================
Input shape: torch.Size([4, 8])
Weight shape: torch.Size([16, 8])
Output shape: torch.Size([4, 16])
Output is DTensor: True
Output placements: (Replicate(),)

before this fix, in_placements had to be None
============================================================
Old way (in_placements=None) still works
Output shape: torch.Size([4, 16])
```                                                                                                                                                          


cc @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @aditvenk @xmfan @weifengpy @H-Huang