### PR TITLE
Call internal log_compilation_event if it exists

### DIFF
--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -13,6 +13,12 @@ import torch
 from torch._strobelight.compile_time_profiler import StrobelightCompileTimeProfiler
 
 
+try:
+    from pt2_internal import log_compilation_event as internal_log_compilation_event  # type: ignore[import-not-found]
+except ImportError:
+    internal_log_compilation_event = None
+
+
 _T = TypeVar("_T")
 _P = ParamSpec("_P")
 
@@ -127,7 +133,10 @@ def add_mlhub_insight(category: str, insight: str, insight_description: str):
 
 
 def log_compilation_event(metrics):
-    log.info("%s", metrics)
+    if internal_log_compilation_event:
+        internal_log_compilation_event(vars(metrics))
+    else:
+        log.info("%s", metrics)
 
 
 def upload_graph(graph):


### PR DESCRIPTION
Summary: For internal conda on mast jobs, call the internal version of log_compilation_event if it exists.

Test Plan: Ran a simple test job that just calls the API: https://fburl.com/scuba/dynamo_compile/dqx8d10g

