### PR TITLE
[Benchmark] [Discussion] [Not for merge] Show benchmark for associative_scan and scan against pure PyTorch an JAX

### DIFF
--- a/benchmarks/dynamo/associative_scan/associative_scan_matrix.py
+++ b/benchmarks/dynamo/associative_scan/associative_scan_matrix.py
@@ -1,0 +1,911 @@
+# mypy: allow-untyped-defs
+import functools
+import itertools
+from collections.abc import Callable
+from typing import Any
+
+import torch
+import torch._prims_common as utils
+import torch.utils._pytree as pytree
+from torch._C import DispatchKey
+from torch._higher_order_ops.utils import (
+    _maybe_compile_and_run_fn,
+    _maybe_run_with_interpreter,
+    check_input_alias_and_mutation_return_outputs,
+    check_meta_consistency,
+    create_bw_fn,
+    first_slice_copy,
+    first_slice_copy_with_grad,
+    materialize_as_graph,
+    reenter_make_fx,
+    save_tensors_and_symints_for_backward,
+    saved_tensors_and_symints,
+    split_into_chunks,
+    unique_graph_id,
+    validate_subgraph_args_types,
+)
+from torch._ops import HigherOrderOperator
+from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.fx.experimental.proxy_tensor import (
+    disable_proxy_modes_tracing,
+    ProxyTorchDispatchMode,
+    track_tensor_tree,
+)
+
+
+aten = torch._ops.ops.aten
+
+
+def wrap_combine_fn_flat(*args, combine_fn, spec, num_leaves):
+    assert len(args) == 2 * num_leaves, (
+        f"Combin_fn received wrong number of arguments, expected {2 * num_leaves}, but got {len(args)}"
+    )
+    lhs = pytree.tree_unflatten(args[:num_leaves], spec)
+    rhs = pytree.tree_unflatten(args[num_leaves:], spec)
+    return combine_fn(lhs, rhs)
+
+
+def _interleave(a, b, dim=0):
+    # https://stackoverflow.com/questions/60869537/how-can-i-interleave-5-pytorch-tensors
+    if b_trunc := (a.shape[dim] == b.shape[dim] + 1):
+        pad = (
+            [0] * ((b.ndim - dim - 1) * 2 + 1)
+            + [1]
+            + [0] * (b.ndim * 2 - ((b.ndim - dim - 1) * 2 + 2))
+        )
+        b = torch.nn.functional.pad(b, pad)
+
+    stacked = torch.stack([a, b], dim=dim + 1)
+    interleaved = torch.flatten(stacked, start_dim=dim, end_dim=dim + 1)
+    if b_trunc:
+        # TODO: find torch alternative for slice_along dim for torch.jit.script to work
+        interleaved = aten.slice(interleaved, dim, 0, b.shape[dim] + a.shape[dim] - 1)
+    return interleaved
+
+
+def safe_map(f, *args):
+    args = list(map(list, args))
+    n = len(args[0])
+    for arg in args[1:]:
+        if len(arg) != n:
+            raise ValueError("length mismatch: {list(map(len, args))}")
+
+    def nf(a):
+        return f(*a)
+
+    return list(map(nf, zip(*args)))
+
+
+class AssociativeScanOp(HigherOrderOperator):
+    def __init__(self):
+        super().__init__("associative_scan")
+
+    def __call__(self, combine_fn, xs, additional_inputs):
+        # There is currently an issue that the ScanOp is sometimes called with
+        # the additional_inputs being a list. See https://github.com/pytorch/pytorch/issues/145785
+        # Once this issue is resolved, the assertion should only allow tuples
+        # and the tuple cast should be removed
+        assert isinstance(additional_inputs, (tuple, list)), (
+            "additional_inputs must be a tuple."
+        )
+        additional_inputs = (
+            tuple(additional_inputs)
+            if isinstance(additional_inputs, list)
+            else additional_inputs
+        )
+        validate_subgraph_args_types(additional_inputs)
+        return super().__call__(combine_fn, xs, additional_inputs)
+
+    # pyrefly: ignore  # bad-override
+    def gen_schema(self, combine_fn, xs, additional_inputs):
+        from torch._higher_order_ops.schema import HopSchemaGenerator
+        from torch._higher_order_ops.utils import materialize_as_graph
+
+        # For associative scan, we need two copies of xs for the combine function
+        # The combine function takes two elements and returns one element
+        xs_slice1 = [first_slice_copy(x) for x in xs]
+        xs_slice2 = [first_slice_copy(x) for x in xs]
+        all_inputs = tuple(xs_slice1 + xs_slice2 + list(additional_inputs))
+
+        combine_gm: torch.fx.GraphModule = materialize_as_graph(combine_fn, all_inputs)
+        (
+            _,
+            _,
+            _,
+            mutated_inputs,
+            outputs,
+        ) = check_input_alias_and_mutation_return_outputs(combine_gm)
+        if len(mutated_inputs) > 0:
+            raise RuntimeError(
+                "For associative_scan, combine_fn cannot have in-place mutations but found "
+                f"{mutated_inputs}-th inputs are mutated."
+            )
+
+        schema_gen = HopSchemaGenerator(self)
+        schema_gen.add_arg("combine_fn", combine_gm)
+
+        for idx, x in enumerate(xs):
+            schema_gen.add_arg(f"xs{idx}", x)
+
+        for idx, arg in enumerate(additional_inputs):
+            schema_gen.add_arg(
+                f"additional_input{idx}",
+                arg,
+            )
+
+        for out in outputs:
+            schema_gen.add_output(out)
+
+        schema_gen.add_schema_tree_spec(combine_fn, xs, additional_inputs)
+        return schema_gen.gen_schema()
+
+
+associative_scan_op = AssociativeScanOp()
+
+
+def associative_scan(
+    combine_fn: Callable[[pytree.PyTree, pytree.PyTree], pytree.PyTree],
+    xs: pytree.PyTree,
+    dim: int,
+    reverse: bool = False,
+    combine_mode: str = "pointwise",
+) -> torch.Tensor:
+    r"""
+    Performs an inclusive scan with an associative combine function.
+
+    .. warning::
+        `torch.associative_scan` is a prototype feature in PyTorch. It currently
+        does not support autograd and you may run into miscompiles.
+        Read more about feature classification at:
+        https://pytorch.org/blog/pytorch-feature-classification-changes/#prototype
+
+    This operator requires runtime code generation and so requires support for
+    ``torch.compile``. Further, only CUDA device codegen is supported at the moment.
+
+    Args:
+        combine_fn (Callable): A binary callable with type ``(Tensor, Tensor) -> Tensor``,
+            or if input is a pytree ``(pytree, pytree) -> pytree``.
+            This function must be pure, i.e., no lifted arguments are supported at the moment,
+            satisfy the associative property and have no side-effects.
+        xs (torch.Tensor): The input tensor, or nested pytree of tensors.
+            All inputs are expected to have the same shape.
+        dim (int): the dimension to scan over
+        reverse (bool): A boolean stating if the scan should be reversed with respect to ``dim``, default ``False``.
+        combine_mode (str): A string indicating whether the ``combine_fn`` is ``pointwise`` or ``generic``, default ``pointwise``.
+            If ``combine_mode=pointwise``, ``combine_fn`` must be pure, may only contain pointwise operations
+            and ``xs`` must be CUDA tensors.
+            In all other cases ``combine_mode=generic`` should be used.
+            Note: ``combine_mode=pointwise`` is more efficient than ``combine_mode=generic``.
+
+
+    Example::
+
+        def add(x: torch.Tensor, y: torch.Tensor):
+            return x + y
+
+
+        cumsum = associative_scan(add, x, dim)
+
+    """
+    # TODO: Support lifted arguments in inductor for associative_scan
+    # TODO: Support autograd for cases with lifted arguments for combine_mode=pointwise
+
+    # The reason we flatten xs before calling into dynamo is that
+    # we want to create a consistent input ordering for combine_fn
+    # and we also want to the input ordering matches the output ordering.
+    leaves_xs_orig, spec_xs = pytree.tree_flatten(xs)
+
+    def _validate_input(cfn, lxs, d, r, cm):
+        # Basic arguments check
+        if not callable(cfn):
+            raise ValueError(f"Combine_fn must be a callable, but got {cfn}")
+        if not isinstance(d, int):
+            raise ValueError("Dim must be an int, but got " + str(type(d)))
+        if not isinstance(r, bool):
+            raise RuntimeError("Reverse must be a bool, but got " + str(type(r)))
+        if cm not in ["pointwise", "generic"]:
+            raise ValueError(
+                f"Combine_mode must either 'pointwise' or 'generic', but got {cm}"
+            )
+        if cm == "pointwise" and not all(l.device.type == "cuda" for l in lxs):
+            raise ValueError(
+                "For combine_mode='pointwise', all input tensors need to be on CUDA"
+            )
+
+        # Checks for xs
+        if len(lxs) == 0:
+            raise ValueError("Expected at least 1 xs leaf")
+        if any(not isinstance(x, torch.Tensor) for x in lxs):
+            raise ValueError("xs leaves must be a Tensor")
+        if any(x.is_sparse for x in lxs):
+            raise ValueError(
+                "xs leaves must dense Tensors, consider using `to_dense()`"
+            )
+        if any(x.ndim <= d for x in lxs):
+            raise ValueError(
+                "All xs leaves must at least have 'dim' number of dimensions and scan dimension > 0"
+            )
+        if any(x.shape[d] == 0 for x in lxs):
+            raise ValueError(
+                "All xs leaves must at least have 'dim' number of dimensions and scan dimension > 0"
+            )
+
+    ndim = leaves_xs_orig[0].ndim
+    dim = utils.canonicalize_dim(ndim, dim)
+
+    _validate_input(combine_fn, leaves_xs_orig, dim, reverse, combine_mode)
+
+    # Move scan dim to 0 and always perform scan on dim 0
+    leaves_xs = [torch.movedim(elem, dim, 0) for elem in leaves_xs_orig]
+
+    if reverse:
+        leaves_xs = [torch.flip(elem, [0]) for elem in leaves_xs]
+
+    if combine_mode == "generic":
+        # The generic_associative_scan implementation calls the combine_fn with a `batch` along the scan dimension
+        # For example, consider:
+        # def add(x: torch.Tensor, y: torch.Tensor):
+        #     return x + y
+        # leaves = torch.tensor([[0.0, 1.0, 2.0, 3.0]
+        #                        [0.0, 1.0, 2.0, 3.0]])
+        # which has shape 2 x 4;
+        # dim = 1;
+        # In the first iteration of `_scan` the combine_fn gets invoked with
+        # combine_fn([torch.tensor([[0.0, 2.0],
+        #                           [0.0, 2.0]])],
+        #            [torch.tensor([[1.0, 3.0],
+        #                           [1.0, 3.0]])])
+        # The arguments are of shape 2 x 2, but can be evaluated in parallel along the scan dimension.
+        combine_fn = functools.partial(
+            wrap_combine_fn_flat,
+            combine_fn=torch.vmap(
+                combine_fn,
+                in_dims=(
+                    pytree.tree_unflatten([0] * len(leaves_xs), spec_xs),
+                    pytree.tree_unflatten([0] * len(leaves_xs), spec_xs),
+                ),
+                out_dims=0,
+            ),
+            spec=spec_xs,
+            num_leaves=len(leaves_xs),
+        )
+        out = generic_associative_scan(combine_fn, leaves_xs, additional_inputs=())
+        out = pytree.tree_unflatten(out, spec_xs)
+    else:
+        combine_fn = functools.partial(
+            wrap_combine_fn_flat,
+            combine_fn=combine_fn,
+            spec=spec_xs,
+            num_leaves=len(leaves_xs),
+        )
+
+        def run_flattened_associative_scan(combine_fn, leaves_xs):
+            return associative_scan_op(combine_fn, leaves_xs, additional_inputs=())
+
+        out = _maybe_compile_and_run_fn(
+            run_flattened_associative_scan,
+            combine_fn,
+            leaves_xs,
+        )
+
+    if reverse:
+        out = pytree.tree_map(lambda elem: elem.flip([0]), out)
+
+    out = pytree.tree_map(lambda elem: torch.movedim(elem, 0, dim), out)
+
+    return out
+
+
+def generic_associative_scan(operator, leaves, dim=0, additional_inputs=()):
+    r"""
+    This function performs the associative_scan operation.
+    The algorithm works by recursively collecting neighbours of ``leaves`` and subsequently
+    applying the ``operator`` on all pairs in parallel along ``dim``.
+    The results of the recursive calls are later combined.
+
+    Args:
+        operator (Callable): A binary callable with type ``(Tensor, Tensor) -> Tensor``,
+            or if input is a pytree ``(pytree, pytree) -> pytree``.
+            This function must be pure, pointwise, and satisfy the associative property.
+        leaves (torch.Tensor): A list of torch.Tensors converted from the pytree of
+            ``xs`` provided to ``associative_scan``.
+            All inputs are expected to have the same shape.
+        dim (int): the dimension to scan over
+        additional_inputs (Tuple of tensors): A tuple of lifted parameters from the global scope.
+            This parameter will be populated internally.
+
+    Example::
+
+        def add(x: torch.Tensor, y: torch.Tensor):
+            return x + y
+
+        leaves = torch.tensor([0.0, 1.0, 2.0, 3.0])
+
+        First iteration of _scan ->
+            # odd_elems -> apply operator on all neighbours
+            # odd_elems = operator([torch.tensor([0.0, 2.0])],
+            #                      [torch.tensor([1.0, 3.0])])
+            odd_elems = torch.tensor([1.0, 5.0])
+            Second iteration of _scan ->
+                # odd_elems = operator([torch.tensor([1.0])],
+                #                      [torch.tensor([5.0])])
+                odd_elems = torch.tensor([6.0])
+                # even_elems -> apply operator on all odd_elems and
+                # every second element of ``elems``, starting from the second element.
+                # even_elems is expanded with the first element of ``elems``
+                even_elems = [1.0]
+                # Merges odd_elems and even_elems
+                res = torch.tensor([1.0, 6.0])
+            # even_elems -> apply operator on all odd_elems and
+            # every second element of ``elems``, starting from the second element.
+            # even_elems is expanded with the first element of ``elems``
+            even_elems = [0.0, 3.0]
+            # Merges odd_elems and even_elems
+            res = torch.tensor([0.0, 1.0, 3.0, 6.0])
+
+    """
+
+    def call_operator(*args):
+        return pytree.tree_leaves(operator(*args))
+
+    def _scan(elems):
+        """Perform the actual recursive scan on ``elems``."""
+        num_elems = elems[0].shape[dim]
+
+        if num_elems < 2:
+            return elems
+
+        reduced_elems = call_operator(
+            *[aten.slice(elem, dim, 0, -1, 2) for elem in elems],
+            *[aten.slice(elem, dim, 1, None, 2) for elem in elems],
+            *additional_inputs,
+        )
+
+        # Recursively compute scan for partially reduced tensors.
+        odd_elems = _scan(reduced_elems)
+
+        if num_elems % 2 == 0:
+            even_elems = call_operator(
+                *[aten.slice(e, dim, 0, -1) for e in odd_elems],
+                *[aten.slice(e, dim, 2, None, 2) for e in elems],
+                *additional_inputs,
+            )
+        else:
+            even_elems = call_operator(
+                *odd_elems,
+                *[aten.slice(e, dim, 2, None, 2) for e in elems],
+                *additional_inputs,
+            )
+
+        # The first element of a scan is the same as the first element
+        # of the original `elems`.
+        even_elems = [
+            torch.cat([aten.slice(elem, dim, 0, 1), result], dim=dim)
+            if result.shape.numel() > 0 and elem.shape[dim] > 0
+            else result
+            if result.shape.numel() > 0
+            else aten.slice(
+                elem, dim, 0, 1
+            )  # Jax allows/ignores concat with 0-dim, Pytorch does not
+            for (elem, result) in zip(elems, even_elems)
+        ]
+
+        return list(
+            safe_map(functools.partial(_interleave, dim=dim), even_elems, odd_elems)
+        )
+
+    scans = _scan(leaves)
+
+    return scans
+
+
+def trace_associative_scan(
+    proxy_mode,
+    func_overload,
+    combine_fn: Callable,
+    xs: list[torch.Tensor],
+    additional_inputs: tuple[torch.Tensor],
+):
+    from torch._dynamo.utils import clone_input
+
+    with disable_proxy_modes_tracing():
+        sample_xs = [first_slice_copy(x) for x in itertools.chain(xs, xs)]
+        sample_additional_inputs = [
+            clone_input(x) if isinstance(x, torch.Tensor) else x
+            for x in additional_inputs
+        ]
+        combine_graph = reenter_make_fx(combine_fn)(
+            *sample_xs, *sample_additional_inputs
+        )
+
+    outputs = None
+    for node in combine_graph.graph.nodes:
+        if node.op == "output":
+            assert outputs is None
+            assert len(node.args) == 1
+            outputs = node.args[0]
+
+    assert outputs is not None
+    outputs = pytree.tree_leaves(outputs)
+    assert len(outputs) == len(xs), (
+        f"expected combine_fn to return {len(xs)} results but got {len(outputs)}"
+    )
+
+    xs_fake_tensors: list[torch.Tensor | torch.SymInt | int] = [
+        first_slice_copy(x) for x in xs
+    ]
+    output_fake_tensors: list[torch.Tensor | torch.SymInt | int] = [
+        c.meta["val"] for c in outputs
+    ]
+    check_meta_consistency(
+        xs_fake_tensors, output_fake_tensors, "init", "carry", include_contiguity=False
+    )
+
+    _, combine_graph_name = unique_graph_id(
+        proxy_mode, prefix="associative_scan_combine_graph"
+    )
+
+    proxy_mode.tracer.root.register_module(combine_graph_name, combine_graph)
+
+    args = (combine_graph, xs, additional_inputs)
+    proxy_args = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, args)
+    out_proxy = proxy_mode.tracer.create_proxy(
+        "call_function", func_overload, proxy_args, {}, name="associative_scan"
+    )
+
+    with disable_proxy_modes_tracing():
+        out = tuple(aten.clone(x) for x in xs)
+
+    return track_tensor_tree(out, out_proxy, constant=None, tracer=proxy_mode.tracer)
+
+
+@associative_scan_op.py_impl(DispatchKey.CompositeExplicitAutograd)
+def associative_scan_op_dense(combine_fn, xs, additional_inputs):
+    return generic_associative_scan(combine_fn, xs, additional_inputs=additional_inputs)
+
+
+class AssociativeScanAutogradOp(torch.autograd.Function):
+    r""" associative_scan
+        Example::
+            xs = torch.arange(1, 5) = [1, 2, 3, 4]
+
+            def combine_fn(a: torch.Tensor, b: torch.Tensor):
+                return a * b
+
+            ys = associative_scan(comine_fn, xs),
+            which can be unpacked as:
+            ys0 = xs0                                         = 1
+            ys1 = combine_fn(ys0, xs1) = combine_fn(1, 2)     = 2
+            ...
+            ysT = combine_fn(ys(T-1), xsT) = combine_fn(6, 4) = 24
+            ys = [1, 2, 6, 24]
+
+            This creates a recursive data dependency structure where each output yst
+            depends on all prior inputs xs0 through xst. The dependency can be visualized as:
+
+    Level 0 (Input):    xs0    xs1    xs2    xs3    xs4
+                        \    /       |      |      |
+                         \  /        |      |      |
+    Level 1:              ys1 ───────┘      |      |
+                           \               /       |
+                            \             /        |
+    Level 2:                 ys2 ────────┘         |
+                              \                   /
+                               \                 /
+    Level 3:                    ys3 ────────────┘
+                                 \
+                                  \
+    Level 4:                        ys4
+
+
+    We could get the following backward gradient graph:
+
+
+    Level 0 (output):   g_xs0   g_xs1   g_xs2   g_xs3   g_xs4
+                         \      /       |       |       |
+                          \    /        |       |       |
+    Level 1:    gl_ys1  ─> g_ys1  ──────┘       |       |
+                            \                  /        |
+                             \                /         |
+    Level 2:    gl_ys2     ─> g_ys2  ────────┘          |
+                               \                       /
+                                \                    /
+    Level 3:    gl_ys3        ─> g_ys3  ────────────┘
+                                  \
+                                   \
+    Level 4:    gl_ys4           ─> g_ys4,
+
+    where gl_y1 is the gradient of the loss with respect to ys1 and the input of backward.
+
+    To calculate the gradients of the inputs, the chain rule suggests:
+
+    g_xs0 = g_ys1
+    g_xs1 = g_ys1 * bw(ys0, xs1) = g_ys1 * bwxs01
+    g_xs2 = g_ys2 * bw(ys1, xs2) = g_ys2 * bwxs12
+    g_xs3 = g_ys3 * bw(ys2, xs3) = g_ys3 * bwxs23
+    g_xs4 = g_ys4 * bw(ys3, xs4) = g_ys4 * bwxs34
+
+    Notice the bw(...) is just the single step bw (instantaneous gradients), whose formula can be computed from combine_fn.
+    For example bw(ys3, xs4) (also abbreviated with bwxs34) computes the gradients ∂/∂xs4 combine_fn(ys3, xs4).
+    Similarly, bw(ys4, ys3) (also abbreviated with bwys43) computes the gradients ∂/∂ys3 combine_fn(ys3, xs4).
+
+    Let's break down how to calculate g_ys by recursively substituting the unknowns:
+
+    g_ys1 = gl_ys1 + g_ys2 * bw(ys2, ys1)
+          = gl_ys1 + (gl_ys2  + g_ys3 * bw(ys3, ys2)) * bw(ys2, ys1)
+          = gl_ys1 + gl_ys2 * bw(ys2, ys1) + g_ys3 * bw(ys3, ys2) * bw(y2, y1)
+          = gl_ys1 + gl_ys2 * bw(ys2, ys1) + gl_ys3 * bw(ys3, ys2) * bw(y2, y1) \
+                   + g_ys4 * bw(ys4, ys3) * bw(ys3, ys2) * bw(ys2, ys1)
+          = gl_ys1 + gl_ys2 * bw(ys2, ys1) + gl_ys3 * bw(ys3, ys2) * bw(y2, y1) \
+                   + gl_ys4 * bw(ys4, ys3) * bw(ys3, ys2) * bw(ys2, ys1)
+
+    Let's do the same for all the g_ys:
+    g_ys2 = gl_ys2 + gl_ys3 * bw(ys3, ys2) + gl_y4 * bw(ys4, ys3) * bw(ys3, ys2)
+    g_ys3 = gl_ys3 + gl_ys4 * bw(ys4, ys3)
+    g_ys4 = gl_ys4
+
+    Notice that the above can be re-written as columnwise multiplication of y_mat and gl_ys:
+
+    g_ys1   1, bwys21, bwys321, bwys4321       gl_ys1
+    g_ys2 = 0,    1  , bwys321, bwys4321   .   gl_ys2
+    g_ys3   0,    0  ,     1  , bwys4321       gl_ys3
+    g_ys4   0,    0  ,     0  ,        1       gl_ys4,
+
+    where bwys21 is an abbreviation for bw(ys2, ys1),
+    bwys321 is an abbreviation for bw(ys3, ys2) * bw(ys2, ys1) so on and so forth.
+
+    We could effectively compute the upper triangular matrix y_mat with:
+    cumprod([1, bwys21, bwys32, bwys43]) then masking out the values as needed.
+    Thus, only [1, bwys21, bwys32, bwys43] are required to compute the y_mat.
+
+
+        References: https://justintchiu.com/blog/pscan_diff/
+
+        NOTE: [associative_scan autograd implementation]
+
+        The forward of associative_scan can be computed with the following steps:
+
+        1.) Compute the forward output of the associative_scan
+            ys = associative_scan(combine_fn, xs, additional_inputs)
+
+        The backward of associative_scan can be computed with the following steps:
+
+        2.) Prepare the backward graph
+            We prepare the backward graph to be used in the backward function.
+            We utilize ``create_bw_fn`` to generate the joint function:
+            combine_fn_bw = create_bw_fn(combine_fn, operands)
+            where operands = [ys{t-1}, xst, additional_inputs]
+
+        3.) Materialize the ``combine_fn_bw``
+            This is required because torch.compile and torch.autograd.grad
+            cannot trace through the joint backward function dynamically.
+
+        4.) Compute the single step bw (instantaneous gradients) at every step t
+            bwys{t-1}, bwxst = combine_fn_bw(ys{t-1}, xst, 1.)
+            Here we pass 1 as the upstream gradient to obtain the local partial derivatives.
+
+            This gives:
+                bwys = [bw(ys1, ys0), bw(ys2, ys1), ..., bw(ysT, ys{T-1})]
+                bwxs = [bw(ys1, xs0), bw(ys2, xs1), ..., bw(ys{T-1}, xsT)]
+
+        5.) Compute the gradient transition matrix y_mat
+
+            As shown in the example above, each input xst affects all later outputs ysi for i ≥ t.
+            According to the chain rule, each such path contributes a product of local gradients g_ysk.
+
+            For example:
+                ∂ysT/∂xst = ∂ysT/∂ys{T-1} * ∂ys{T-1}/∂ys{T-2} * ... * ∂ys{t+1}/∂yst * ∂yst/∂xst
+                        = bw(ysT, ys{T-1}) * bw(ys{T-1}, ys{T-2}) * ... * bw(ys{t+1}, yst) * bw(ys{t-1}, xst)
+
+            This motivates the use of a cumulative product over bwys to compute all such paths efficiently.
+
+            We now construct the matrix of gradient transition paths:
+
+            5.1 Repeat g_y values to form the base matrix
+                y_mat = [[1, bwys21, bwys32, bwys43],
+                         [1, bwys21, bwys32, bwys43],
+                         [1, bwys21, bwys32, bwys43],
+                         [1, bwys21, bwys32, bwys43]]
+
+            5.2 Mask the lower triangle (inclusive) with 1s
+                y_mat = [[1, bwys21, bwys32, bwys43],
+                         [1, 1     , bwys32, bwys43],
+                         [1, 1     , 1     , bwys43],
+                         [1, 1     , 1     , 1    ]]
+
+            5.3 Apply cumulative product row-wise
+                y_mat = cumprod(y_mat, dim=1)
+                Resulting in:
+                y_mat = [[1, bwys21, bwys32 * bwys21, bwys43 * bwys32 * bwys21],
+                         [1, 1      , bwys32         , bwys43 * bwys32         ],
+                         [1, 1      , 1              , bwys43                  ],
+                         [1, 1      , 1              , 1                       ]]
+
+            5.4 Zero out the lower triangle (exclusive)
+                Final y_mat:
+                y_mat = [[1, bwys21, bwys32 * bwys21, bwys43 * bwys32 * bwys21],
+                         [0, 1      , bwys32         , bwys43 * bwys32         ],
+                         [0, 0      , 1              , bwys43                  ],
+                         [0, 0      , 0              , 1                       ]]
+
+        6.) Scale the y_mat with the upstream gradients gl_ys
+            scaled_y_mat = y_mat * gl_ys
+            Each entry now holds the full contribution of ∂L/∂ysj to ∂L/∂xsi via the path through ysj.
+
+        7.) Reduce the scaled_y_mat with a row-wise sum
+            summed_y_mat = scaled_y_mat.sum(dim=1)
+            This accumulates all downstream contributions for each xst.
+
+        8.) Scale with the instantaneous input gradients bwxs
+            g_xs = summed_y_mat * bwxs
+
+            This gives the final input gradients:
+                g_xs = [∂L/∂xs0, ∂L/∂xs1, ..., ∂L/∂xsT]
+
+        NOTE: [scan partial grad handling]
+            If any element of xs or of the outputs does not require gradients
+            (i.e., requires_grad=False), then the corresponding gradients will be returned
+            as tensors of zeros with the same shape as the element.
+    """
+
+    @staticmethod
+    # pyrefly: ignore  # bad-override
+    def forward(
+        ctx,
+        combine_fn,
+        num_xs,
+        num_additional_inputs,
+        *operands,
+    ):
+        ctx._num_xs = num_xs
+        ctx._num_additional_inputs = num_additional_inputs
+        ctx._combine_fn = combine_fn
+        xs, additional_inputs = split_into_chunks(
+            operands, [num_xs, num_additional_inputs]
+        )
+
+        scan_length = xs[0].shape[0]
+        ctx._scan_length = scan_length
+
+        # We snapshot the dispatch keys in forward for materializing the
+        # the bw_graph in backward.
+        ctx._fw_include_key_set = torch._C._dispatch_tls_local_include_set()
+        ctx._fw_exclude_key_set = torch._C._dispatch_tls_local_exclude_set()
+
+        with torch._C._AutoDispatchBelowAutograd():
+            # 1.) Compute the forward output of the associative_scan
+            ys = associative_scan_op(combine_fn, xs, additional_inputs)
+            save_tensors_and_symints_for_backward(ctx, list(operands) + list(ys))
+
+        return (*ys,)
+
+    @staticmethod
+    def backward(ctx, *gl_ys):
+        r"""
+        This function computes the gradients of the scan operation.
+        For a detailed description see the document above.
+
+        Args:
+            flat_grads (torch.Tensor): The tensor of upstream gradients, or a nested pytree of tensors.
+                                       E.g.: Gradient of the loss with respect to the forward output ys
+        """
+
+        # The backward of associative_scan is always performed on the first dimension
+        dim = 0
+        scan_length = ctx._scan_length
+        num_xs = ctx._num_xs
+        num_additional_inputs = ctx._num_additional_inputs
+
+        # Extract the inputs to the forward path and outputs from the forward path
+        flat_args = saved_tensors_and_symints(ctx)
+        xs, additional_inputs, outs = split_into_chunks(
+            flat_args, [num_xs, num_additional_inputs, num_xs]
+        )
+        ndim = outs[0].ndim
+
+        # First_slice_copy does not keep the original requires_grad flag,
+        # but we need it here in order to compute the correcte gradients
+        xs_slices = first_slice_copy_with_grad(itertools.chain(xs, xs))
+
+        # Construct the operands from the forward, fw_operands
+        # and the operands for a single event t of the forward, fw_operands_slice
+        fw_operands = (*xs, *additional_inputs)
+        fw_operands_slice = (*xs_slices, *additional_inputs)
+
+        # 2.) Prepare the backward graph
+        combine_fn_bw = create_bw_fn(ctx._combine_fn, fw_operands_slice)
+
+        # 3.) Materialize the ``combine_fn_bw``
+        # TODO: we need to materialize the bw graphs because dynamo is unable to
+        # trace through the joint function when torch.compile torch.autograd.grad.
+        combine_fn_bw_gm = materialize_as_graph(
+            combine_fn_bw,
+            (
+                *fw_operands_slice,
+                *[first_slice_copy(o) for o in outs],
+            ),
+            ctx._fw_include_key_set,
+            ctx._fw_exclude_key_set,
+            force_enable_grad=True,
+        )
+
+        # vmap joint graph over scan dimension to compute the individual
+        # gradients for each time slice ``t`` in parallel.
+        # This computation can be parallelized, as these are just the instantaneous gradients and not the full chain-rule
+        mapped_combine_fn_bw_gm = torch.vmap(combine_fn_bw_gm, 0, 0)
+
+        # 4.) Compute the single step bw (instantaneous gradients) at every step ``t``
+        # Use a ones_like tensor in order not to scale the bwyst and bwxst,
+        # with the upstream gradients yet.
+        # Note: All bwyst and bwxst are computed in parallel, thus the tensors bwys and bwxs are the result.
+        dummy_upstream_grad = (torch.ones_like(x) for x in gl_ys)
+        grads = mapped_combine_fn_bw_gm(
+            *(o.roll(1, dim) for o in outs), *fw_operands, *dummy_upstream_grad
+        )
+        bwys, bwxs = split_into_chunks(grads, [num_xs, num_xs])
+
+        def compute_y_mat(bwys: torch.Tensor) -> torch.Tensor:
+            # Prepare a ones and a zeros helper mask in order to easily compute the y_mat
+            def compute_helper_tril_mask(diagonal):
+                def expand_masks(mask):
+                    for _ in range(ndim - 1):
+                        mask = mask.unsqueeze(-1)
+                    return mask
+
+                tril_mask = torch.tril(
+                    torch.ones(
+                        scan_length, scan_length, device=bwys.device, dtype=torch.bool
+                    ),
+                    diagonal=diagonal,
+                )
+                tril_mask = expand_masks(tril_mask)
+                tril_mask = tril_mask.expand(-1, -1, *bwys.shape[1:])
+                return tril_mask
+
+            # The ones mask is used to fill the main diagonal and all elements below it with 1s
+            ones_mask = compute_helper_tril_mask(0)
+
+            # The zero mask is used to set all elements below the main diagonal to 0
+            zeros_mask = compute_helper_tril_mask(-1)
+
+            # 5.1) Repeat the elements of bwys to form the square matrix
+            y_mat = bwys.unsqueeze(dim).repeat_interleave(scan_length, dim)
+
+            # 5.2) Fill the lower triangular part, including the diagonal,
+            # of the h_mat with 1s. I.e., use the ones_mask to fill with 1s.
+            y_mat.masked_fill_(ones_mask, 1.0)
+
+            # 5.3) Compute the cumulative products across dim + 1
+            y_mat = y_mat.cumprod(dim=dim + 1)
+
+            # 5.4) Replace the elements we filled with 1s before with 0s
+            y_mat.masked_fill_(zeros_mask, 0.0)
+
+            return y_mat
+
+        def compute_grad(bwxs, bwys, gl_ys):
+            # Set the first gradient component of bwxs to 1.0, per definition.
+            torch.select(bwxs, dim, 0).fill_(1.0)
+
+            # 5.) Compute the gradient transition matrix
+            y_mat = compute_y_mat(bwys)
+
+            # 6.) scale the y_mat with the upstream gradients gl_ys
+            scaled_y_mat = y_mat * gl_ys
+
+            # 7.) Reduce the y_mat with sum along the columns to get the total contributions for xs_t
+            summed_y_mat = scaled_y_mat.sum(dim + 1)
+
+            # 8.) Scale with the bwxs to obtain the final gradients g_xs
+            g_xs = summed_y_mat * bwxs
+
+            return g_xs
+
+        # Stack all leaves of the gradients along the first dimension.
+        # This is useful as later the gradients of those leaves can be computed in parallel.
+        bwxs_stacked_leaves = torch.stack(bwxs)
+        bwys_stacked_leaves = torch.stack(bwys)
+        gl_ys_stacked_leaves = torch.stack(gl_ys)
+
+        # The compute_grad function is parallelized across all individual leaves of xs
+        # as these gradients can be computed independently from each other
+        # TODO: torch.vmap may create composability issues
+        compute_grad_mapped = torch.vmap(compute_grad, 0, 0)
+
+        g_xs = compute_grad_mapped(
+            bwxs_stacked_leaves, bwys_stacked_leaves, gl_ys_stacked_leaves
+        )
+
+        # TODO: Currently the gradients for the additional_inputs are not computed properly
+        return *[None] * 3, *g_xs, *[None] * num_additional_inputs
+
+
+@associative_scan_op.py_autograd_impl
+def associative_scan_autograd(combine_fn, xs, additional_inputs):
+    num_xs = len(xs)
+    num_additional_inputs = len(additional_inputs)
+
+    if num_additional_inputs > 0:
+        raise RuntimeError(
+            "Associative_scan does currently not support gradients for lifted parameters!"
+        )
+
+    flat_out = AssociativeScanAutogradOp.apply(
+        combine_fn,
+        num_xs,
+        num_additional_inputs,
+        *(tuple(xs) + tuple(additional_inputs)),
+    )
+    return (*flat_out,)
+
+
+@associative_scan_op.py_impl(ProxyTorchDispatchMode)
+def associative_scan_proxy_mode(mode, combine_fn, xs, additional_inputs):
+    return trace_associative_scan(
+        mode, associative_scan_op, combine_fn, xs, additional_inputs
+    )
+
+
+@associative_scan_op.py_impl(FakeTensorMode)
+def assoiciative_scan_fake_tensor_mode(mode, combine_fn, xs, additional_inputs):
+    with mode:
+        return tuple(x.clone() for x in xs)
+
+
+@associative_scan_op.py_functionalize_impl
+def associative_scan_functionalize(ctx, combine_fn, xs, additional_inputs):
+    from torch._higher_order_ops.utils import _check_alias_and_mutation
+
+    unwrapped_xs = ctx.unwrap_tensors(xs)
+    unwrapped_additional_inputs = ctx.unwrap_tensors(additional_inputs)
+    with ctx.redispatch_to_next():
+        functional_combine_fn = ctx.functionalize(
+            _maybe_run_with_interpreter(combine_fn)
+        )
+        pre_dispatch = hasattr(ctx, "mode") and ctx.mode.pre_dispatch
+        sample_unwrapped_xs_sliced = [
+            first_slice_copy(inp) for inp in itertools.chain(unwrapped_xs, unwrapped_xs)
+        ]
+        sample_inputs = list(
+            itertools.chain(
+                sample_unwrapped_xs_sliced,
+                unwrapped_additional_inputs,
+            )
+        )
+        _check_alias_and_mutation(
+            combine_fn, sample_inputs, "associative_scan", pre_dispatch
+        )
+        ret = associative_scan_op(
+            functional_combine_fn,
+            unwrapped_xs,
+            unwrapped_additional_inputs,
+        )
+    return ctx.wrap_tensors(ret)
+
+
+def _fake_associative_scan(combine_fn, xs, dim, reverse=False):
+    inp_leaves, spec = pytree.tree_flatten(xs)
+    result_flat: list[Any] = []
+    num_leaves = len(inp_leaves)
+    op = reversed if reverse else lambda x: x
+
+    for ind in op(range(inp_leaves[0].size(dim))):
+        r = [
+            inp_leaves[leave_ind][(slice(None),) * dim + (ind,)]
+            for leave_ind in range(num_leaves)
+        ]
+        if (ind > 0 and not reverse) or (
+            ind < (inp_leaves[0].size(dim) - 1) and reverse
+        ):
+            r = combine_fn(
+                pytree.tree_unflatten(result_flat[-1], spec),
+                pytree.tree_unflatten(r, spec),
+            )
+        r_flat, _ = pytree.tree_flatten(r)
+        result_flat.append(r_flat)
+
+    results = [
+        torch.stack([e[leave_ind] for e in op(result_flat)], dim)
+        for leave_ind in range(num_leaves)
+    ]
+    return pytree.tree_unflatten(results, spec)

--- a/benchmarks/dynamo/associative_scan/associative_scan_memeff.py
+++ b/benchmarks/dynamo/associative_scan/associative_scan_memeff.py
@@ -1,0 +1,873 @@
+# mypy: allow-untyped-defs
+import functools
+import itertools
+from typing import Any, Callable
+
+import torch
+import torch._prims_common as utils
+import torch.utils._pytree as pytree
+from torch._C import DispatchKey
+from torch._higher_order_ops.utils import (
+    _maybe_compile_and_run_fn,
+    _maybe_run_with_interpreter,
+    check_input_alias_and_mutation_return_outputs,
+    check_meta_consistency,
+    create_bw_fn,
+    first_slice_copy,
+    first_slice_copy_with_grad,
+    materialize_as_graph,
+    reenter_make_fx,
+    save_tensors_and_symints_for_backward,
+    saved_tensors_and_symints,
+    split_into_chunks,
+    unique_graph_id,
+    validate_subgraph_args_types,
+)
+from torch._ops import HigherOrderOperator
+from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.fx.experimental.proxy_tensor import (
+    disable_proxy_modes_tracing,
+    ProxyTorchDispatchMode,
+    track_tensor_tree,
+)
+
+
+aten = torch._ops.ops.aten
+
+
+def wrap_combine_fn_flat(*args, combine_fn, spec, num_leaves):
+    assert len(args) == 2 * num_leaves, (
+        f"Combin_fn received wrong number of arguments, expected {2 * num_leaves}, but got {len(args)}"
+    )
+    lhs = pytree.tree_unflatten(args[:num_leaves], spec)
+    rhs = pytree.tree_unflatten(args[num_leaves:], spec)
+    return combine_fn(lhs, rhs)
+
+
+def _interleave(a, b, dim=0):
+    # https://stackoverflow.com/questions/60869537/how-can-i-interleave-5-pytorch-tensors
+    if b_trunc := (a.shape[dim] == b.shape[dim] + 1):
+        pad = (
+            [0] * ((b.ndim - dim - 1) * 2 + 1)
+            + [1]
+            + [0] * (b.ndim * 2 - ((b.ndim - dim - 1) * 2 + 2))
+        )
+        b = torch.nn.functional.pad(b, pad)
+
+    stacked = torch.stack([a, b], dim=dim + 1)
+    interleaved = torch.flatten(stacked, start_dim=dim, end_dim=dim + 1)
+    if b_trunc:
+        # TODO: find torch alternative for slice_along dim for torch.jit.script to work
+        interleaved = aten.slice(interleaved, dim, 0, b.shape[dim] + a.shape[dim] - 1)
+    return interleaved
+
+
+def safe_map(f, *args):
+    args = list(map(list, args))
+    n = len(args[0])
+    for arg in args[1:]:
+        if len(arg) != n:
+            raise ValueError("length mismatch: {list(map(len, args))}")
+
+    def nf(a):
+        return f(*a)
+
+    return list(map(nf, zip(*args)))
+
+
+class AssociativeScanOp(HigherOrderOperator):
+    def __init__(self):
+        super().__init__("associative_scan")
+
+    def __call__(self, combine_fn, xs, additional_inputs):
+        # There is currently an issue that the ScanOp is sometimes called with
+        # the additional_inputs being a list. See https://github.com/pytorch/pytorch/issues/145785
+        # Once this issue is resolved, the assertion should only allow tuples
+        # and the tuple cast should be removed
+        assert isinstance(additional_inputs, (tuple, list)), (
+            "additional_inputs must be a tuple."
+        )
+        additional_inputs = (
+            tuple(additional_inputs)
+            if isinstance(additional_inputs, list)
+            else additional_inputs
+        )
+        validate_subgraph_args_types(additional_inputs)
+        return super().__call__(combine_fn, xs, additional_inputs)
+
+    def gen_schema(self, combine_fn, xs, additional_inputs):
+        from torch._higher_order_ops.schema import HopSchemaGenerator
+        from torch._higher_order_ops.utils import materialize_as_graph
+
+        # For associative scan, we need two copies of xs for the combine function
+        # The combine function takes two elements and returns one element
+        xs_slice1 = [first_slice_copy(x) for x in xs]
+        xs_slice2 = [first_slice_copy(x) for x in xs]
+        all_inputs = tuple(xs_slice1 + xs_slice2 + list(additional_inputs))
+
+        combine_gm: torch.fx.GraphModule = (
+            combine_fn
+            if isinstance(combine_fn, torch.fx.GraphModule)
+            else materialize_as_graph(combine_fn, all_inputs)
+        )
+
+        example_inputs = [
+            n.meta["val"] if "val" in n.meta else n.meta["example_value"]
+            for n in combine_gm.graph.find_nodes(op="placeholder")
+        ]
+
+        (
+            _,
+            _,
+            _,
+            mutated_inputs,
+            outputs,
+        ) = check_input_alias_and_mutation_return_outputs(combine_gm, example_inputs)
+        if len(mutated_inputs) > 0:
+            raise RuntimeError(
+                "For associative_scan, combine_fn cannot have in-place mutations but found "
+                f"{mutated_inputs}-th inputs are mutated."
+            )
+
+        schema_gen = HopSchemaGenerator(self)
+        schema_gen.add_arg("combine_fn", combine_gm)
+
+        for idx, x in enumerate(xs):
+            schema_gen.add_arg(f"xs{idx}", x)
+
+        for idx, arg in enumerate(additional_inputs):
+            schema_gen.add_arg(
+                f"additional_input{idx}",
+                arg,
+            )
+
+        for out in outputs:
+            schema_gen.add_output(out)
+
+        schema_gen.add_schema_tree_spec(combine_fn, xs, additional_inputs)
+        return schema_gen.gen_schema()
+
+
+associative_scan_op = AssociativeScanOp()
+
+
+def associative_scan(
+    combine_fn: Callable[[pytree.PyTree, pytree.PyTree], pytree.PyTree],
+    xs: pytree.PyTree,
+    dim: int,
+    reverse: bool = False,
+    combine_mode: str = "pointwise",
+) -> torch.Tensor:
+    r"""
+    Performs an inclusive scan with an associative combine function.
+
+    .. warning::
+        `torch.associative_scan` is a prototype feature in PyTorch. It currently
+        does not support autograd and you may run into miscompiles.
+        Read more about feature classification at:
+        https://pytorch.org/blog/pytorch-feature-classification-changes/#prototype
+
+    This operator requires runtime code generation and so requires support for
+    ``torch.compile``. Further, only CUDA device codegen is supported at the moment.
+
+    Args:
+        combine_fn (Callable): A binary callable with type ``(Tensor, Tensor) -> Tensor``,
+            or if input is a pytree ``(pytree, pytree) -> pytree``.
+            This function must be pure, i.e., no lifted arguments are supported at the moment,
+            satisfy the associative property and have no side-effects.
+        xs (torch.Tensor): The input tensor, or nested pytree of tensors.
+            All inputs are expected to have the same shape.
+        dim (int): the dimension to scan over
+        reverse (bool): A boolean stating if the scan should be reversed with respect to ``dim``, default ``False``.
+        combine_mode (str): A string indicating whether the ``combine_fn`` is ``pointwise`` or ``generic``, default ``pointwise``.
+            If ``combine_mode=pointwise``, ``combine_fn`` must be pure, may only contain pointwise operations
+            and ``xs`` must be CUDA tensors.
+            In all other cases ``combine_mode=generic`` should be used.
+            Note: ``combine_mode=pointwise`` is more efficient than ``combine_mode=generic``.
+
+
+    Example::
+
+        def add(x: torch.Tensor, y: torch.Tensor):
+            return x + y
+
+
+        cumsum = associative_scan(add, x, dim)
+
+    """
+    # TODO: Support lifted arguments in inductor for associative_scan
+    # TODO: Support autograd for cases with lifted arguments for combine_mode=pointwise
+
+    # The reason we flatten xs before calling into dynamo is that
+    # we want to create a consistent input ordering for combine_fn
+    # and we also want to the input ordering matches the output ordering.
+    leaves_xs_orig, spec_xs = pytree.tree_flatten(xs)
+
+    def _validate_input(cfn, lxs, d, r, cm):
+        # Basic arguments check
+        if not callable(cfn):
+            raise ValueError("Combine_fn must be a callable, but got {cfn}")
+        if not isinstance(d, int):
+            raise ValueError("Dim must be an int, but got " + str(type(d)))
+        if not isinstance(r, bool):
+            raise RuntimeError("Reverse must be a bool, but got " + str(type(r)))
+        if cm not in ["pointwise", "generic"]:
+            raise ValueError(
+                "Combine_mode must either 'pointwise' or 'generic', but got {cm}"
+            )
+        if cm == "pointwise" and not all(l.device.type == "cuda" for l in lxs):
+            raise ValueError(
+                "For combine_mode='pointwise', all input tensors need to be on CUDA"
+            )
+
+        # Checks for xs
+        if len(lxs) == 0:
+            raise ValueError("Expected at least 1 xs leaf")
+        if any(not isinstance(x, torch.Tensor) for x in lxs):
+            raise ValueError("xs leaves must be a Tensor")
+        if any(x.is_sparse for x in lxs):
+            raise ValueError(
+                "xs leaves must dense Tensors, consider using `to_dense()`"
+            )
+        if any(x.ndim <= d for x in lxs):
+            raise ValueError(
+                "All xs leaves must at least have 'dim' number of dimensions and scan dimension > 0"
+            )
+        if any(x.shape[d] == 0 for x in lxs):
+            raise ValueError(
+                "All xs leaves must at least have 'dim' number of dimensions and scan dimension > 0"
+            )
+
+    ndim = leaves_xs_orig[0].ndim
+    dim = utils.canonicalize_dim(ndim, dim)
+
+    _validate_input(combine_fn, leaves_xs_orig, dim, reverse, combine_mode)
+
+    # Move scan dim to 0 and always perform scan on dim 0
+    leaves_xs = [torch.movedim(elem, dim, 0) for elem in leaves_xs_orig]
+
+    if reverse:
+        leaves_xs = [torch.flip(elem, [0]) for elem in leaves_xs]
+
+    if combine_mode == "generic":
+        # The generic_associative_scan implementation calls the combine_fn with a `batch` along the scan dimension
+        # For example, consider:
+        # def add(x: torch.Tensor, y: torch.Tensor):
+        #     return x + y
+        # leaves = torch.tensor([[0.0, 1.0, 2.0, 3.0]
+        #                        [0.0, 1.0, 2.0, 3.0]])
+        # which has shape 2 x 4;
+        # dim = 1;
+        # In the first iteration of `_scan` the combine_fn gets invoked with
+        # combine_fn([torch.tensor([[0.0, 2.0],
+        #                           [0.0, 2.0]])],
+        #            [torch.tensor([[1.0, 3.0],
+        #                           [1.0, 3.0]])])
+        # The arguments are of shape 2 x 2, but can be evaluated in parallel along the scan dimension.
+        combine_fn = functools.partial(
+            wrap_combine_fn_flat,
+            combine_fn=torch.vmap(
+                combine_fn,
+                in_dims=(
+                    pytree.tree_unflatten([0] * len(leaves_xs), spec_xs),
+                    pytree.tree_unflatten([0] * len(leaves_xs), spec_xs),
+                ),
+                out_dims=0,
+            ),
+            spec=spec_xs,
+            num_leaves=len(leaves_xs),
+        )
+        out = generic_associative_scan(combine_fn, leaves_xs, additional_inputs=())
+        out = pytree.tree_unflatten(out, spec_xs)
+    else:
+        combine_fn = functools.partial(
+            wrap_combine_fn_flat,
+            combine_fn=combine_fn,
+            spec=spec_xs,
+            num_leaves=len(leaves_xs),
+        )
+
+        def run_flattened_associative_scan(combine_fn, leaves_xs):
+            return associative_scan_op(combine_fn, leaves_xs, additional_inputs=())
+
+        out = _maybe_compile_and_run_fn(
+            run_flattened_associative_scan,
+            combine_fn,
+            leaves_xs,
+        )
+
+    if reverse:
+        out = pytree.tree_map(lambda elem: elem.flip([0]), out)
+
+    out = pytree.tree_map(lambda elem: torch.movedim(elem, 0, dim), out)
+
+    return out
+
+
+def generic_associative_scan(operator, leaves, dim=0, additional_inputs=()):
+    r"""
+    This function performs the associative_scan operation.
+    The algorithm works by recursively collecting neighbours of ``leaves`` and subsequently
+    applying the ``operator`` on all pairs in parallel along ``dim``.
+    The results of the recursive calls are later combined.
+
+    Args:
+        operator (Callable): A binary callable with type ``(Tensor, Tensor) -> Tensor``,
+            or if input is a pytree ``(pytree, pytree) -> pytree``.
+            This function must be pure, pointwise, and satisfy the associative property.
+        leaves (torch.Tensor): A list of torch.Tensors converted from the pytree of
+            ``xs`` provided to ``associative_scan``.
+            All inputs are expected to have the same shape.
+        dim (int): the dimension to scan over
+        additional_inputs (Tuple of tensors): A tuple of lifted parameters from the global scope.
+            This parameter will be populated internally.
+
+    Example::
+
+        def add(x: torch.Tensor, y: torch.Tensor):
+            return x + y
+
+        leaves = torch.tensor([0.0, 1.0, 2.0, 3.0])
+
+        First iteration of _scan ->
+            # odd_elems -> apply operator on all neighbours
+            # odd_elems = operator([torch.tensor([0.0, 2.0])],
+            #                      [torch.tensor([1.0, 3.0])])
+            odd_elems = torch.tensor([1.0, 5.0])
+            Second iteration of _scan ->
+                # odd_elems = operator([torch.tensor([1.0])],
+                #                      [torch.tensor([5.0])])
+                odd_elems = torch.tensor([6.0])
+                # even_elems -> apply operator on all odd_elems and
+                # every second element of ``elems``, starting from the second element.
+                # even_elems is expanded with the first element of ``elems``
+                even_elems = [1.0]
+                # Merges odd_elems and even_elems
+                res = torch.tensor([1.0, 6.0])
+            # even_elems -> apply operator on all odd_elems and
+            # every second element of ``elems``, starting from the second element.
+            # even_elems is expanded with the first element of ``elems``
+            even_elems = [0.0, 3.0]
+            # Merges odd_elems and even_elems
+            res = torch.tensor([0.0, 1.0, 3.0, 6.0])
+
+    """
+
+    def call_operator(*args):
+        return pytree.tree_leaves(operator(*args))
+
+    def _scan(elems):
+        """Perform the actual recursive scan on ``elems``."""
+        num_elems = elems[0].shape[dim]
+
+        if num_elems < 2:
+            return elems
+
+        reduced_elems = call_operator(
+            *[aten.slice(elem, dim, 0, -1, 2) for elem in elems],
+            *[aten.slice(elem, dim, 1, None, 2) for elem in elems],
+            *additional_inputs,
+        )
+
+        # Recursively compute scan for partially reduced tensors.
+        odd_elems = _scan(reduced_elems)
+
+        if num_elems % 2 == 0:
+            even_elems = call_operator(
+                *[aten.slice(e, dim, 0, -1) for e in odd_elems],
+                *[aten.slice(e, dim, 2, None, 2) for e in elems],
+                *additional_inputs,
+            )
+        else:
+            even_elems = call_operator(
+                *odd_elems,
+                *[aten.slice(e, dim, 2, None, 2) for e in elems],
+                *additional_inputs,
+            )
+
+        # The first element of a scan is the same as the first element
+        # of the original `elems`.
+        even_elems = [
+            torch.cat([aten.slice(elem, dim, 0, 1), result], dim=dim)
+            if result.shape.numel() > 0 and elem.shape[dim] > 0
+            else result
+            if result.shape.numel() > 0
+            else aten.slice(
+                elem, dim, 0, 1
+            )  # Jax allows/ignores concat with 0-dim, Pytorch does not
+            for (elem, result) in zip(elems, even_elems)
+        ]
+
+        return list(
+            safe_map(functools.partial(_interleave, dim=dim), even_elems, odd_elems)
+        )
+
+    scans = _scan(leaves)
+
+    return scans
+
+
+def trace_associative_scan(
+    proxy_mode,
+    func_overload,
+    combine_fn: Callable,
+    xs: list[torch.Tensor],
+    additional_inputs: tuple[torch.Tensor],
+):
+    from torch._dynamo.utils import clone_input
+
+    with disable_proxy_modes_tracing():
+        sample_xs = [first_slice_copy(x) for x in itertools.chain(xs, xs)]
+        sample_additional_inputs = [
+            clone_input(x) if isinstance(x, torch.Tensor) else x
+            for x in additional_inputs
+        ]
+        combine_graph = reenter_make_fx(combine_fn)(
+            *sample_xs, *sample_additional_inputs
+        )
+
+    outputs = None
+    for node in combine_graph.graph.nodes:
+        if node.op == "output":
+            assert outputs is None
+            assert len(node.args) == 1
+            outputs = node.args[0]
+
+    assert outputs is not None
+    outputs = pytree.tree_leaves(outputs)
+    assert len(outputs) == len(xs), (
+        f"expected combine_fn to return {len(xs)} results but got {len(outputs)}"
+    )
+
+    xs_fake_tensors: list[torch.Tensor | torch.SymInt | int] = [
+        first_slice_copy(x) for x in xs
+    ]
+    output_fake_tensors: list[torch.Tensor | torch.SymInt | int] = [
+        c.meta["val"] for c in outputs
+    ]
+    check_meta_consistency(
+        xs_fake_tensors, output_fake_tensors, "init", "carry", include_contiguity=False
+    )
+
+    _, combine_graph_name = unique_graph_id(
+        proxy_mode, prefix="associative_scan_combine_graph"
+    )
+
+    proxy_mode.tracer.root.register_module(combine_graph_name, combine_graph)
+
+    args = (combine_graph, xs, additional_inputs)
+    proxy_args = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, args)
+    out_proxy = proxy_mode.tracer.create_proxy(
+        "call_function", func_overload, proxy_args, {}, name="associative_scan"
+    )
+
+    with disable_proxy_modes_tracing():
+        out = tuple(aten.clone(x) for x in xs)
+
+    return track_tensor_tree(out, out_proxy, constant=None, tracer=proxy_mode.tracer)
+
+
+@associative_scan_op.py_impl(DispatchKey.CompositeExplicitAutograd)
+def associative_scan_op_dense(combine_fn, xs, additional_inputs):
+    return generic_associative_scan(combine_fn, xs, additional_inputs=additional_inputs)
+
+
+class AssociativeScanAutogradOp(torch.autograd.Function):
+    r""" associative_scan
+        Example::
+            xs = torch.arange(1, 5) = [1, 2, 3, 4]
+
+            def combine_fn(a: torch.Tensor, b: torch.Tensor):
+                return a * b
+
+            ys = associative_scan(comine_fn, xs),
+            which can be unpacked as:
+            ys0 = xs0                                         = 1
+            ys1 = combine_fn(ys0, xs1) = combine_fn(1, 2)     = 2
+            ...
+            ysT = combine_fn(ys(T-1), xsT) = combine_fn(6, 4) = 24
+            ys = [1, 2, 6, 24]
+
+            This creates a recursive data dependency structure where each output yst
+            depends on all prior inputs xs0 through xst. The dependency can be visualized as:
+
+        Level 0 (Input):    xs0    xs1    xs2    xs3    xs4
+                            \    /       |      |      |
+                            \  /        |      |      |
+        Level 1:               ys1 ───────┘      |      |
+                                \               /       |
+                                \             /        |
+        Level 2:                  ys2 ────────┘         |
+                                \                   /
+                                    \                 /
+        Level 3:                     ys3 ────────────┘
+                                    \
+                                    \
+        Level 4:                        ys4
+
+
+        We could get the following backward gradient graph:
+
+
+        Level 0 (output):   g_xs0   g_xs1   g_xs2   g_xs3   g_xs4
+                            \      /       |       |     |
+                            \    /        |       |     |
+        Level 1:    gl_ys1  ─> g_ys1  ──────┘       |     |
+                                \                  /      |
+                                \                /       |
+        Level 2:    gl_ys2     ─> g_ys2  ────────┘        |
+                                \                     /
+                                    \                   /
+        Level 3:    gl_ys3        ─> g_ys3  ───────────┘
+                                    \
+                                    \
+        Level 4:    gl_ys4           ─> g_ys4,
+
+        where gl_y1 is the gradient of the loss with respect to ys1 and the input of backward.
+
+        To calculate the gradients of the inputs, the chain rule suggests:
+
+        g_xs0 = g_ys1
+        g_xs1 = g_ys1 * bw(ys0, xs1) = g_ys1 * bwxs01
+        g_xs2 = g_ys2 * bw(ys1, xs2) = g_ys2 * bwxs12
+        g_xs3 = g_ys3 * bw(ys2, xs3) = g_ys3 * bwxs23
+        g_xs4 = g_ys4 * bw(ys3, xs4) = g_ys4 * bwxs34
+
+        Notice the bw(...) is just the single step bw (instantaneous gradients), whose formula can be computed from combine_fn.
+        For example bw(ys3, xs4) (also abbreviated with bwxs34) computes the gradients ∂/∂xs4 combine_fn(ys3, xs4).
+        Similarly, bw(ys4, ys3) (also abbreviated with bwys43) computes the gradients ∂/∂ys3 combine_fn(ys3, xs4).
+
+        Let's break down how to calculate g_ys by recursively substituting the unknowns:
+
+        g_ys1 = gl_ys1 + g_ys2 * bw(ys2, ys1)
+            = gl_ys1 + (gl_ys2  + g_ys3 * bw(ys3, ys2)) * bw(ys2, ys1)
+            = gl_ys1 + gl_ys2 * bw(ys2, ys1) + g_ys3 * bw(ys3, ys2) * bw(y2, y1)
+            = gl_ys1 + gl_ys2 * bw(ys2, ys1) + gl_ys3 * bw(ys3, ys2) * bw(y2, y1) \
+                    + gl_ys4 * bw(ys4, ys3) * bw(ys3, ys2) * bw(ys2, ys1)
+        g_ys1 = gl_ys1 + gl_ys2 * bw(ys2, ys1) + gl_ys3 * bw(ys3, ys2) * bw(y2, y1) \
+                    + gl_ys4 * bw(ys4, ys3) * bw(ys3, ys2) * bw(ys2, ys1)
+
+        Let's do the same for all the g_ys:
+        g_ys2 = gl_ys2 + gl_ys3 * bw(ys3, ys2) + gl_ys4 * bw(ys4, ys3) * bw(ys3, ys2)
+        g_ys3 = gl_ys3 + gl_ys4 * bw(ys4, ys3)
+        g_ys4 = gl_ys4
+
+        Notice that the above can be re-written as an associative_scan operation with
+
+        def g_ys_combine_fn_rev(bw_gl, bw_next_gl_next):
+            bw, gl = bw_gl
+            bw_next, gl_next = bw_next_gl_next
+            bw_prod = bw * bw_next
+            gl_acc = gl_next + bw_next * gl
+            return bw_prod, gl_acc
+
+        gl_ys_pinit = [gl_ys4, gl_ys3, gl_ys2, gl_ys1, 0]
+        bwys_pinit =  [bwys43, bwys32, bwys21,      1, 1]
+
+        g_ys_inputs = (bwys_pinit, gl_ys_pinit)
+        g_ys = associative_scan_op(g_ys_combine_fn_rev, g_ys_inputs, ())[1][1:]
+
+        References: https://justintchiu.com/blog/pscan_diff/
+
+        NOTE: [associative_scan autograd implementation]
+
+        The forward of associative_scan can be computed with the following steps:
+
+        1.) Compute the forward output of the associative_scan
+            ys = associative_scan(combine_fn, xs, additional_inputs)
+
+        The backward of associative_scan can be computed with the following steps:
+
+        2.) Prepare the backward graph
+            We prepare the backward graph to be used in the backward function.
+            We utilize ``create_bw_fn`` to generate the joint function:
+            combine_fn_bw = create_bw_fn(combine_fn, operands)
+            where operands = [ys{t-1}, xst, additional_inputs]
+
+        3.) Materialize the ``combine_fn_bw``
+            This is required because torch.compile and torch.autograd.grad
+            cannot trace through the joint backward function dynamically.
+
+        4.) Compute the single step bw (instantaneous gradients) at every step t
+            bwys{t-1}, bwxst = combine_fn_bw(ys{t-1}, xst, 1.)
+            Here we pass 1 as the upstream gradient to obtain the local partial derivatives.
+
+            This gives:
+                bwys = [bw(ys1, ys0), bw(ys2, ys1), ..., bw(ysT, ys{T-1})]
+                bwxs = [bw(ys1, xs0), bw(ys2, xs1), ..., bw(ys{T-1}, xsT)]
+
+        5.) Compute the gradients using an associative_scan
+
+            As shown in the example above, each input xst affects all later outputs ysi for i ≥ t.
+            According to the chain rule, each such path contributes a product of local gradients g_ysk.
+
+            For example:
+                g_yst = gl_yst + g_ys{t+1} * bw(ys{t+1}, yst)
+
+            This motivates the use of an right-to-left associative scan with bwys and gl_ys to compute all such paths efficiently.
+
+            5.1) Append the initial values for the associative_scan operation to gl_ys and bwys
+
+                The initial values for the gls is 0:
+                gl_ys_pinit = torch.cat([gl_ys, torch.zeros_like(gl_ys[0:1])], 0).
+
+                The initial value for the bwys is 1 and in addition, since ys0 = xs0,
+                the first bwys is always 1 (see example above), resultig in:
+                bwys_pinit = torch.cat([bwys[1:], torch.ones_like(bwys[0:1]), torch.ones_like(bwys[0:1])], 0)
+
+            5.2) Perform the associative scan from right-to-left and cut off the irrelevant values
+            in order to compute the g_ys
+
+                In particular, use reverse=True for the associative_scan to compute from right-to-left
+                g_ys = associative_scan(g_ys_combine_fn_rev, g_ys_inputs, dim=dim, reverse=True)[1][:-1]
+
+        6.) Scale with the instantaneous input gradients bwxs
+            g_xs = summed_y_mat * bwxs
+
+            This gives the final input gradients:
+                g_xs = [∂L/∂xs0, ∂L/∂xs1, ..., ∂L/∂xsT]
+
+        NOTE: [scan partial grad handling]
+            If any element of xs or of the outputs does not require gradients
+            (i.e., requires_grad=False), then the corresponding gradients will be returned
+            as tensors of zeros with the same shape as the element.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        combine_fn,
+        num_xs,
+        num_additional_inputs,
+        *operands,
+    ):
+        ctx._num_xs = num_xs
+        ctx._num_additional_inputs = num_additional_inputs
+        ctx._combine_fn = combine_fn
+        xs, additional_inputs = split_into_chunks(
+            operands, [num_xs, num_additional_inputs]
+        )
+
+        scan_length = xs[0].shape[0]
+        ctx._scan_length = scan_length
+
+        # We snapshot the dispatch keys in forward for materializing the
+        # the bw_graph in backward.
+        ctx._fw_include_key_set = torch._C._dispatch_tls_local_include_set()
+        ctx._fw_exclude_key_set = torch._C._dispatch_tls_local_exclude_set()
+
+        with torch._C._AutoDispatchBelowAutograd():
+            # 1.) Compute the forward output of the associative_scan
+            ys = associative_scan_op(combine_fn, xs, additional_inputs)
+            save_tensors_and_symints_for_backward(ctx, list(operands) + list(ys))
+
+        return (*ys,)
+
+    @staticmethod
+    def backward(ctx, *gl_ys):
+        r"""
+        This function computes the gradients of the scan operation.
+        For a detailed description see the document above.
+
+        Args:
+            flat_grads (torch.Tensor): The tensor of upstream gradients, or a nested pytree of tensors.
+                                       E.g.: Gradient of the loss with respect to the forward output ys
+        """
+
+        # The backward of associative_scan is always performed on the first dimension
+        dim = 0
+        num_xs = ctx._num_xs
+        num_additional_inputs = ctx._num_additional_inputs
+
+        # Extract the inputs to the forward path and outputs from the forward path
+        flat_args = saved_tensors_and_symints(ctx)
+        xs, additional_inputs, outs = split_into_chunks(
+            flat_args, [num_xs, num_additional_inputs, num_xs]
+        )
+
+        # First_slice_copy does not keep the original requires_grad flag,
+        # but we need it here in order to compute the correcte gradients
+        xs_slices = first_slice_copy_with_grad(itertools.chain(xs, xs))
+
+        # Construct the operands from the forward, fw_operands
+        # and the operands for a single event t of the forward, fw_operands_slice
+        fw_operands = (*xs, *additional_inputs)
+        fw_operands_slice = (*xs_slices, *additional_inputs)
+
+        # 2.) Prepare the backward graph
+        combine_fn_bw = create_bw_fn(ctx._combine_fn, fw_operands_slice)
+
+        # 3.) Materialize the ``combine_fn_bw``
+        # TODO: we need to materialize the bw graphs because dynamo is unable to
+        # trace through the joint function when torch.compile torch.autograd.grad.
+        combine_fn_bw_gm = materialize_as_graph(
+            combine_fn_bw,
+            (
+                *fw_operands_slice,
+                *[first_slice_copy(o) for o in outs],
+            ),
+            ctx._fw_include_key_set,
+            ctx._fw_exclude_key_set,
+            force_enable_grad=True,
+        )
+
+        # vmap joint graph over scan dimension to compute the individual
+        # gradients for each time slice ``t`` in parallel.
+        # This computation can be parallelized, as these are just the instantaneous gradients and not the full chain-rule
+        mapped_combine_fn_bw_gm = torch.vmap(combine_fn_bw_gm, 0, 0)
+
+        # 4.) Compute the single step bw (instantaneous gradients) at every step ``t``
+        # Use a ones_like tensor in order not to scale the bwyst and bwxst,
+        # with the upstream gradients yet.
+        # Note: All bwyst and bwxst are computed in parallel, thus the tensors bwys and bwxs are the result.
+        dummy_upstream_grad = (torch.ones_like(x) for x in gl_ys)
+        grads = mapped_combine_fn_bw_gm(
+            *(o.roll(1, dim) for o in outs), *fw_operands, *dummy_upstream_grad
+        )
+        bwys, bwxs = split_into_chunks(grads, [num_xs, num_xs])
+
+        def compute_gys_associative_scan(
+            gl_ys: torch.Tensor, bwys: torch.Tensor, dim: int
+        ) -> torch.Tensor:
+            """
+            Computes the gradient g_ys via a right-to-left associative scan:
+            I.e., the gradients are computed from the last time step to the first, following this equation
+                g_yst = gl_yst + g_ys{t+1} * bw(ys{t+1}, yst)
+            """
+
+            # 5.1) Append the initial values for the associative_scan operation to gl_ys and bwys
+            gl_ys_pinit = torch.cat([gl_ys, torch.zeros_like(gl_ys[0:1])], 0)
+            bwys_pinit = torch.cat(
+                [bwys[1:], torch.ones_like(bwys[0:1]), torch.ones_like(bwys[0:1])], 0
+            )
+
+            def g_ys_combine_fn_rev(bw_gl, bw_next_gl_next):
+                bw, gl = bw_gl
+                bw_next, gl_next = bw_next_gl_next
+                bw_prod = bw * bw_next
+                gl_acc = gl_next + bw_next * gl
+                return bw_prod, gl_acc
+
+            # 5.2) Perform the associative_scan from right-to-left and cut off the irrelevant values
+            # in order to compute the g_ys
+            g_ys_inputs = (bwys_pinit, gl_ys_pinit)
+            g_ys = associative_scan(
+                g_ys_combine_fn_rev, g_ys_inputs, dim=dim, reverse=True
+            )[1][:-1]
+
+            return g_ys
+
+        def compute_grad(
+            bwxs: torch.Tensor, bwys: torch.Tensor, gl_ys: torch.Tensor
+        ) -> torch.Tensor:
+            # Set the first gradient component of bwxs to 1.0, per definition.
+            # Set ∂ys0 / ∂xs0 = 1
+            torch.select(bwxs, dim, 0).fill_(1.0)
+
+            # 5.) Compute the gradients via an associative_scan
+            g_ys = compute_gys_associative_scan(gl_ys, bwys, dim)
+
+            # 6.) Scale with the instantaneous input gradients bwxs
+            g_xs = g_ys * bwxs
+
+            return g_xs
+
+        # Compute the gradients of all leaves sequentially
+        # TODO: Use torch.vmap here for parallelization, requires vmap of associative_scan
+        g_xs = [
+            compute_grad(bwxs[ind], bwys[ind], gl_ys[ind]) for ind in range(len(gl_ys))
+        ]
+
+        # TODO: Currently the gradients for the additional_inputs are not computed properly
+        return *[None] * 3, *g_xs, *[None] * num_additional_inputs
+
+
+@associative_scan_op.py_autograd_impl
+def associative_scan_autograd(combine_fn, xs, additional_inputs):
+    num_xs = len(xs)
+    num_additional_inputs = len(additional_inputs)
+
+    if num_additional_inputs > 0:
+        raise RuntimeError(
+            "Associative_scan does currently not support gradients for lifted parameters!"
+        )
+
+    flat_out = AssociativeScanAutogradOp.apply(
+        combine_fn,
+        num_xs,
+        num_additional_inputs,
+        *(tuple(xs) + tuple(additional_inputs)),
+    )
+    return (*flat_out,)
+
+
+@associative_scan_op.py_impl(ProxyTorchDispatchMode)
+def associative_scan_proxy_mode(mode, combine_fn, xs, additional_inputs):
+    return trace_associative_scan(
+        mode, associative_scan_op, combine_fn, xs, additional_inputs
+    )
+
+
+@associative_scan_op.py_impl(FakeTensorMode)
+def assoiciative_scan_fake_tensor_mode(mode, combine_fn, xs, additional_inputs):
+    with mode:
+        return tuple(x.clone() for x in xs)
+
+
+@associative_scan_op.py_functionalize_impl
+def associative_scan_functionalize(ctx, combine_fn, xs, additional_inputs):
+    from torch._higher_order_ops.utils import _check_alias_and_mutation
+
+    unwrapped_xs = ctx.unwrap_tensors(xs)
+    unwrapped_additional_inputs = ctx.unwrap_tensors(additional_inputs)
+    with ctx.redispatch_to_next():
+        functional_combine_fn = ctx.functionalize(
+            _maybe_run_with_interpreter(combine_fn)
+        )
+        pre_dispatch = hasattr(ctx, "mode") and ctx.mode.pre_dispatch
+        sample_unwrapped_xs_sliced = [
+            first_slice_copy(inp) for inp in itertools.chain(unwrapped_xs, unwrapped_xs)
+        ]
+        sample_inputs = list(
+            itertools.chain(
+                sample_unwrapped_xs_sliced,
+                unwrapped_additional_inputs,
+            )
+        )
+        _check_alias_and_mutation(
+            combine_fn, sample_inputs, "associative_scan", pre_dispatch
+        )
+        ret = associative_scan_op(
+            functional_combine_fn,
+            unwrapped_xs,
+            unwrapped_additional_inputs,
+        )
+    return ctx.wrap_tensors(ret)
+
+
+def _fake_associative_scan(combine_fn, xs, dim, reverse=False):
+    inp_leaves, spec = pytree.tree_flatten(xs)
+    result_flat: list[Any] = []
+    num_leaves = len(inp_leaves)
+    op = reversed if reverse else lambda x: x
+
+    for ind in op(range(inp_leaves[0].size(dim))):
+        r = [
+            inp_leaves[leave_ind][(slice(None),) * dim + (ind,)]
+            for leave_ind in range(num_leaves)
+        ]
+        if (ind > 0 and not reverse) or (
+            ind < (inp_leaves[0].size(dim) - 1) and reverse
+        ):
+            r = combine_fn(
+                pytree.tree_unflatten(result_flat[-1], spec),
+                pytree.tree_unflatten(r, spec),
+            )
+        r_flat, _ = pytree.tree_flatten(r)
+        result_flat.append(r_flat)
+
+    results = [
+        torch.stack([e[leave_ind] for e in op(result_flat)], dim)
+        for leave_ind in range(num_leaves)
+    ]
+    return pytree.tree_unflatten(results, spec)

--- a/benchmarks/dynamo/associative_scan/benchmark.py
+++ b/benchmarks/dynamo/associative_scan/benchmark.py
@@ -1,0 +1,142 @@
+import torch
+from associative_scan_memeff import associative_scan as associative_scan_memeff
+from associative_scan_matrix import associative_scan as associative_scan_matrix
+
+from time import perf_counter
+
+import numpy as np
+
+import jax
+import jax.numpy as jnp
+
+###############################################################################
+# Auxiliary function for timing
+###############################################################################
+def time_fn(fn, xs, warm_up=1):
+    for _ in range(warm_up):
+        result = fn(xs)
+
+    t_start = perf_counter() 
+    result = fn(xs)
+    t_stop = perf_counter()
+    t_ = t_stop - t_start
+    return result, t_
+
+###############################################################################
+# Define the SSM kernels for PyTorch and for JAX
+###############################################################################
+# Define the SSM kernel module for PyTorch
+class S5Kernel(torch.nn.Module):
+    def __init__(self, op):
+        super(S5Kernel, self).__init__()
+        self.op = op
+    
+    def forward(self, xs: torch.Tensor):
+        def s5_operator(x: torch.Tensor, y: torch.Tensor):
+            A_i, Bu_i = x
+            A_j, Bu_j = y
+            return A_j * A_i, A_j * Bu_i + Bu_j
+
+        result = self.op(s5_operator, xs, dim=0,)
+        return result
+    
+# Define models
+model_matrix = S5Kernel(associative_scan_matrix)
+model_memeff = S5Kernel(associative_scan_memeff)
+
+def binary_operator_efficient_jax(x, y):
+    A_i, Bu_i = x
+    A_j, Bu_j = y
+    return A_j * A_i, A_j * Bu_i + Bu_j
+
+def s5_operator_jax(xs):
+    result_jax = jax.lax.associative_scan(binary_operator_efficient_jax, xs, axis=0)
+    return result_jax
+
+@jax.jit
+def s5_operator_jax_jit(xs):
+    result_jax = jax.lax.associative_scan(binary_operator_efficient_jax, xs, axis=0)
+    return result_jax
+
+###############################################################################
+# Define the inputs
+###############################################################################
+warm_up_cycles = 3
+timesteps = 200
+state_dim = 40
+A = torch.randn(state_dim, device='cuda')
+B = torch.randn(timesteps, state_dim, device='cuda', requires_grad=True)
+xs = (torch.tensor(A.repeat((timesteps, 1)).cpu().numpy(), device='cuda', requires_grad=True), B)
+
+# Prepare JAX inputs
+jax_device = jax.devices('cuda')[0]
+xs_jax = tuple([jnp.array(el.detach().cpu(), device=jax_device) for el in xs])
+
+###############################################################################
+# Run models forward (inference-only)
+###############################################################################
+
+# Matrix implementation for associative_scan
+result_matrix, t_matrix = time_fn(model_matrix, xs, warm_up=warm_up_cycles)
+
+# Memory-efficient implementation for associative_scan
+result_memeff, t_memeff = time_fn(model_memeff, xs, warm_up=warm_up_cycles)
+torch.testing.assert_close(result_matrix, result_memeff)
+
+# Non-jit compiled JAX model
+result_jax, t_jax = time_fn(s5_operator_jax, xs_jax, warm_up=warm_up_cycles)
+for jax_array, torch_array in zip([np.asarray(el) for el in result_jax], [el.detach().cpu().numpy() for el in result_memeff]):
+    if not np.array_equal(jax_array, torch_array):
+        raise Exception('results not equal')
+
+# jit compiled JAX model
+result_jax_jit, t_jax_jit = time_fn(s5_operator_jax_jit, xs_jax, warm_up=warm_up_cycles)
+for jax_array, torch_array in zip([np.asarray(el) for el in result_jax], [el.detach().cpu().numpy() for el in result_memeff]):
+    if not np.array_equal(jax_array, torch_array):
+        raise Exception('results not equal')
+
+print(f"Matrix {t_matrix} vs. Mem eff. {t_memeff} vs. JAX {t_jax} vs. JAX (JIT) {t_jax_jit}")
+
+###############################################################################
+# Run models with backward
+###############################################################################
+def wrapper_torch_bwd(fn, xs):
+    result = fn(xs)
+    result = result[0][:10, :30].sum()
+    # grad_init = [torch.ones_like(el) for el in result]
+    # grad = torch.autograd.grad(result, xs, grad_init)
+    grad = torch.autograd.grad(result, xs)
+    return grad
+
+def wrapper_jax_bwd(fn, xs):
+    def inner_fn(xs):
+        result = fn(xs)
+        result = result[0][:10, :30].sum()
+        return result
+    result = inner_fn(xs)
+    grad = jax.grad(inner_fn)(xs)
+    return grad
+
+def wrapper_jax_jit_bwd(fn, xs):
+    @jax.jit
+    def inner_fn(xs):
+        result = fn(xs)
+        result = result[0][:10, :30].sum()
+        return result
+    result = inner_fn(xs)
+    grad = jax.grad(inner_fn)(xs)
+    return grad
+    
+# Matrix implementation for associative_scan
+result_grad_matrix, t_grad_matrix = time_fn(lambda xs: wrapper_torch_bwd(model_matrix, xs), xs, warm_up=warm_up_cycles)
+
+# Memory-efficient implementation for associative_scan
+result_grad_memeff, t_grad_memeff = time_fn(lambda xs: wrapper_torch_bwd(model_memeff, xs), xs, warm_up=warm_up_cycles)
+
+# Non-jit compiled JAX model
+result_grad_jax, t_grad_jax = time_fn(lambda xs: wrapper_jax_bwd(s5_operator_jax, xs), xs_jax, warm_up=warm_up_cycles)
+
+# jit compiled JAX model
+result_grad_jax_jit, t_grad_jax_jit = time_fn(lambda xs: wrapper_jax_jit_bwd(s5_operator_jax, xs), xs_jax, warm_up=warm_up_cycles)
+
+print(f"Matrix {t_grad_matrix} vs. Mem eff. {t_grad_memeff} vs. JAX {t_grad_jax} vs. JAX (JIT) {t_grad_jax_jit}")

--- a/benchmarks/dynamo/scan/benchmark_lstm.py
+++ b/benchmarks/dynamo/scan/benchmark_lstm.py
@@ -1,0 +1,144 @@
+import torch
+from torch._higher_order_ops.scan import scan
+
+from time import perf_counter
+
+###############################################################################
+# Auxiliary function for timing
+###############################################################################
+def time_fn(fn, xs, warm_up=1):
+    for _ in range(warm_up):
+        result = fn(*xs)
+
+    t_start = perf_counter() 
+    result = fn(*xs)
+    t_stop = perf_counter()
+    t_ = t_stop - t_start
+    return result, t_
+
+###############################################################################
+# Define the RNN for PyTorch
+###############################################################################
+class LSTM(torch.nn.Module):
+    def __init__(self, Wii, bii, Whi, bhi, Wif, bif, Whf, bhf, Wig, big, Whg, bhg, Wio, bio, Who, bho):
+        super(LSTM, self).__init__()
+        self.Wii = Wii.clone()
+        self.bii = bii.clone()
+        self.Whi = Whi.clone()
+        self.bhi = bhi.clone()
+        self.Wif = Wif.clone()
+        self.bif = bif.clone()
+        self.Whf = Whf.clone()
+        self.bhf = bhf.clone()
+        self.Wig = Wig.clone()
+        self.big = big.clone()
+        self.Whg = Whg.clone()
+        self.bhg = bhg.clone()
+        self.Wio = Wio.clone()
+        self.bio = bio.clone()
+        self.Who = Who.clone()
+        self.bho = bho.clone()
+        
+    def forward(self, init: torch.Tensor, xs: torch.Tensor):
+        def lstm_combine(carry, x):
+            h, c = carry
+            
+            i = torch.sigmoid(x @ self.Wii + self.bii + h @ self.Whi + self.bhi)
+            f = torch.sigmoid(x @ self.Wif + self.bif + h @ self.Whf + self.bhf)
+            g = torch.tanh(x @ self.Wig + self.big + h @ self.Whg + self.bhg)
+            o = torch.sigmoid(x @ self.Wio + self.bio + h @ self.Who + self.bho)
+            
+            c_new = f * c + i * g
+            h_new = o * torch.tanh(c_new)
+            
+            return (h_new, c_new), o + 0.
+        
+        carry, outs = scan(lstm_combine, init, xs, dim=0)
+        
+        return carry, outs
+
+# Define the RNN with pure PyTorch
+lstm_pytorch = torch.nn.LSTM(3, 5)
+
+Wii, Wif, Wig, Wio = torch.chunk(lstm_pytorch.weight_ih_l0, 4)
+Whi, Whf, Whg, Who = torch.chunk(lstm_pytorch.weight_hh_l0, 4)
+bii, bif, big, bio = torch.chunk(lstm_pytorch.bias_ih_l0, 4)
+bhi, bhf, bhg, bho = torch.chunk(lstm_pytorch.bias_hh_l0, 4)
+
+lstm_scan = LSTM(
+                Wii.T, bii,
+                Whi.T, bhi,
+                
+                Wif.T, bif,
+                Whf.T, bhf,
+                
+                Wig.T, big,
+                Whg.T, bhg,
+                
+                Wio.T, bio,
+                Who.T, bho,
+                )
+
+###############################################################################
+# Define the inputs
+###############################################################################
+warm_up_cycles = 3
+xs = torch.randn(1, 3, requires_grad=True)
+init = (torch.zeros(5, requires_grad=True), torch.zeros(5, requires_grad=True))
+
+###############################################################################
+# Run models forward (inference-only)
+###############################################################################
+# Native PyTorch implementation
+result_pytorch, t_pytorch = time_fn(lstm_pytorch, (xs,), warm_up=warm_up_cycles)
+# result_pytorch = result_pytorch[0]
+
+# Implementation with scan
+result_scan, t_scan = time_fn(lstm_scan, (init, xs), warm_up=warm_up_cycles)
+# torch.testing.assert_close(result_pytorch[0], result_scan[1])
+
+# Implementation with scan - compiled
+result_scan, t_scan_comp = time_fn(torch.compile(lstm_scan, fullgraph=True), (init, xs), warm_up=warm_up_cycles)
+# torch.testing.assert_close(result_pytorch[0], result_scan[1])
+
+print(f"PyTorch {t_pytorch} vs. Scan {t_scan} vs. Scan (Comp.) {t_scan_comp}")
+
+###############################################################################
+# Run models with backward
+###############################################################################
+# TODO: This is to be done!
+def wrapper_torch_bwd(fn, xs):
+    result = fn(xs)
+    result = result[0][:10, :30].sum()
+    # grad_init = [torch.ones_like(el) for el in result]
+    # grad = torch.autograd.grad(result, xs, grad_init)
+    grad = torch.autograd.grad(result, xs)
+    return grad
+
+
+# torch.testing.assert_close(result_pytorch, result)
+
+# grad_init = torch.ones_like(result_pytorch)
+# grad_pytorch = torch.autograd.grad(result_pytorch, xs, grad_init)[0]
+# grad = torch.autograd.grad(result, xs, grad_init)[0]
+
+# # The map function computes x ** y for each element, where y = 2
+# # Therefore, we expect the correct gradients to be x * 2
+# print("Gradient of PyTorch:\n", grad_pytorch)
+# print("Gradient of cond:\n", grad)
+# torch.testing.assert_close(grad_pytorch, grad)
+
+    
+# # Matrix implementation for associative_scan
+# result_grad_matrix, t_grad_matrix = time_fn(lambda xs: wrapper_torch_bwd(model_matrix, xs), xs, warm_up=warm_up_cycles)
+
+# # Memory-efficient implementation for associative_scan
+# result_grad_memeff, t_grad_memeff = time_fn(lambda xs: wrapper_torch_bwd(model_memeff, xs), xs, warm_up=warm_up_cycles)
+
+# # Non-jit compiled JAX model
+# result_grad_jax, t_grad_jax = time_fn(lambda xs: wrapper_jax_bwd(s5_operator_jax, xs), xs_jax, warm_up=warm_up_cycles)
+
+# # jit compiled JAX model
+# result_grad_jax_jit, t_grad_jax_jit = time_fn(lambda xs: wrapper_jax_jit_bwd(s5_operator_jax, xs), xs_jax, warm_up=warm_up_cycles)
+
+# print(f"Matrix {t_grad_matrix} vs. Mem eff. {t_grad_memeff} vs. JAX {t_grad_jax} vs. JAX (JIT) {t_grad_jax_jit}")

--- a/benchmarks/dynamo/scan/benchmark_lstm.py
+++ b/benchmarks/dynamo/scan/benchmark_lstm.py
@@ -6,22 +6,52 @@ from time import perf_counter
 ###############################################################################
 # Auxiliary function for timing
 ###############################################################################
-def time_fn(fn, xs, warm_up=1):
-    for _ in range(warm_up):
-        result = fn(*xs)
+def time_fn(fn, args, warm_up=1):
+    t_initial = -1.
+    for ind in range(warm_up):
+        t_start = perf_counter() 
+        result = fn(*args)
+        t_stop = perf_counter()
+        if ind == 0:
+            t_initial = t_stop - t_start
 
     t_start = perf_counter() 
-    result = fn(*xs)
+    result = fn(*args)
     t_stop = perf_counter()
-    t_ = t_stop - t_start
-    return result, t_
+    t_run = t_stop - t_start
+    return result, t_initial, t_run
 
 ###############################################################################
-# Define the RNN for PyTorch
+# Define the RNN models
 ###############################################################################
-class LSTM(torch.nn.Module):
+warm_up_cycles = 3
+# input_size = 15
+input_size = 50
+# hidden_size = 20
+hidden_size = 200
+time_steps = 20
+
+class LSTM_forloop(torch.nn.Module):
+    def __init__(self, input_size, hidden_size):
+        super(LSTM_forloop, self).__init__()
+        
+        self.lstm_cell = torch.nn.LSTMCell(input_size, hidden_size)
+        
+    # Implementation adopted from 
+    # https://docs.pytorch.org/docs/stable/generated/torch.nn.LSTMCell.html
+    def forward(self, init: torch.Tensor, xs: torch.Tensor):
+        # The input `xs` has the time as the first dimsion
+        output = []
+        for i in range(xs.size()[0]):
+            hx, cx = self.lstm_cell(xs[i], init)
+            init = (hx, cx)
+            output.append(hx)
+        output = torch.stack(output, dim=0)
+        return output
+
+class LSTM_scan(torch.nn.Module):
     def __init__(self, Wii, bii, Whi, bhi, Wif, bif, Whf, bhf, Wig, big, Whg, bhg, Wio, bio, Who, bho):
-        super(LSTM, self).__init__()
+        super(LSTM_scan, self).__init__()
         self.Wii = Wii.clone()
         self.bii = bii.clone()
         self.Whi = Whi.clone()
@@ -57,15 +87,26 @@ class LSTM(torch.nn.Module):
         
         return carry, outs
 
-# Define the RNN with pure PyTorch
-lstm_pytorch = torch.nn.LSTM(3, 5)
+# Define the for-loop LSTM model
+lstm_forloop = LSTM_forloop(input_size, hidden_size)
+lstm_forloop_comp = torch.compile(lstm_forloop, fullgraph=True)
 
-Wii, Wif, Wig, Wio = torch.chunk(lstm_pytorch.weight_ih_l0, 4)
-Whi, Whf, Whg, Who = torch.chunk(lstm_pytorch.weight_hh_l0, 4)
-bii, bif, big, bio = torch.chunk(lstm_pytorch.bias_ih_l0, 4)
-bhi, bhf, bhg, bho = torch.chunk(lstm_pytorch.bias_hh_l0, 4)
 
-lstm_scan = LSTM(
+# Define the LSTM using CUDA kernels
+lstm_forloop_state_dict = lstm_forloop.state_dict()
+lstm_cuda_state_dict = {}
+for key, value in lstm_forloop_state_dict.items():
+    new_key = key.replace('lstm_cell.', '') + '_l0'
+    lstm_cuda_state_dict[new_key] = value.clone()
+lstm_cuda = torch.nn.LSTM(input_size, hidden_size)
+lstm_cuda.load_state_dict(lstm_cuda_state_dict)
+
+# Define the LSTM model using scan
+Wii, Wif, Wig, Wio = torch.chunk(lstm_cuda.weight_ih_l0, 4)
+Whi, Whf, Whg, Who = torch.chunk(lstm_cuda.weight_hh_l0, 4)
+bii, bif, big, bio = torch.chunk(lstm_cuda.bias_ih_l0, 4)
+bhi, bhf, bhg, bho = torch.chunk(lstm_cuda.bias_hh_l0, 4)
+lstm_scan = LSTM_scan(
                 Wii.T, bii,
                 Whi.T, bhi,
                 
@@ -78,30 +119,47 @@ lstm_scan = LSTM(
                 Wio.T, bio,
                 Who.T, bho,
                 )
+lstm_scan_comp = torch.compile(lstm_scan, fullgraph=True)
 
 ###############################################################################
 # Define the inputs
 ###############################################################################
-warm_up_cycles = 3
-xs = torch.randn(1, 3, requires_grad=True)
-init = (torch.zeros(5, requires_grad=True), torch.zeros(5, requires_grad=True))
+xs = torch.randn(time_steps, input_size, requires_grad=True)
+init = (torch.zeros(hidden_size, requires_grad=True), torch.zeros(hidden_size, requires_grad=True))
 
 ###############################################################################
 # Run models forward (inference-only)
 ###############################################################################
-# Native PyTorch implementation
-result_pytorch, t_pytorch = time_fn(lstm_pytorch, (xs,), warm_up=warm_up_cycles)
-# result_pytorch = result_pytorch[0]
+# For-loop model
+result_forloop, time_initial_forloop, time_run_forloop = time_fn(lstm_forloop, (init, xs), warm_up=warm_up_cycles)
 
-# Implementation with scan
-result_scan, t_scan = time_fn(lstm_scan, (init, xs), warm_up=warm_up_cycles)
-# torch.testing.assert_close(result_pytorch[0], result_scan[1])
+# For-loop model compiled
+result_forloop_comp, time_initial_forloop_comp, time_run_forloop_comp = time_fn(lstm_forloop_comp, (init, xs), warm_up=warm_up_cycles)
 
-# Implementation with scan - compiled
-result_scan, t_scan_comp = time_fn(torch.compile(lstm_scan, fullgraph=True), (init, xs), warm_up=warm_up_cycles)
-# torch.testing.assert_close(result_pytorch[0], result_scan[1])
+# CUDA model
+result_cuda, time_initial_cuda, time_run_cuda = time_fn(lstm_cuda, (xs.clone(), (init[0].clone().unsqueeze(0), init[1].clone().unsqueeze(0))), warm_up=warm_up_cycles)
 
-print(f"PyTorch {t_pytorch} vs. Scan {t_scan} vs. Scan (Comp.) {t_scan_comp}")
+# Scan model
+result_scan, time_initial_scan, time_run_scan = time_fn(lstm_scan, ((init[0].clone().unsqueeze(0), init[1].clone().unsqueeze(0)), xs.clone()), warm_up=warm_up_cycles)
+
+# Scan model compiled
+result_scan_comp, time_initial_scan_comp, time_run_scan_comp = time_fn(lstm_scan_comp, ((init[0].clone().unsqueeze(0), init[1].clone().unsqueeze(0)), xs.clone()), warm_up=warm_up_cycles)
+
+torch.testing.assert_close(result_forloop, result_forloop_comp)
+torch.testing.assert_close(result_forloop, result_cuda[0])
+torch.testing.assert_close(result_forloop, result_scan[1][:, 0, :])
+torch.testing.assert_close(result_forloop, result_scan_comp[1][:, 0, :])
+
+print(f'T={time_steps}:')
+print(f'Compile times:\n\
+For-Loop        : {time_initial_forloop_comp:.5f}\n\
+Scan            : {time_initial_scan_comp:.5f}\n')
+print(f'Run times       :\n\
+For-Loop        : {time_run_forloop:.5f} \n\
+For-Loop compile: {time_run_forloop_comp:.5f} \n\
+CUDA            : {time_run_cuda:.5f} \n\
+Scan            : {time_run_scan:.5f} \n\
+Scan compile    : {time_run_scan_comp:.5f}')
 
 ###############################################################################
 # Run models with backward

--- a/benchmarks/dynamo/scan/benchmark_lstm.py
+++ b/benchmarks/dynamo/scan/benchmark_lstm.py
@@ -1,43 +1,43 @@
+from time import perf_counter
+
 import torch
 from torch._higher_order_ops.scan import scan
 
-from time import perf_counter
 
 ###############################################################################
 # Auxiliary function for timing
 ###############################################################################
 def time_fn(fn, args, warm_up=1):
-    t_initial = -1.
+    t_initial = -1.0
     for ind in range(warm_up):
-        t_start = perf_counter() 
+        t_start = perf_counter()
         result = fn(*args)
         t_stop = perf_counter()
         if ind == 0:
             t_initial = t_stop - t_start
 
-    t_start = perf_counter() 
+    t_start = perf_counter()
     result = fn(*args)
     t_stop = perf_counter()
     t_run = t_stop - t_start
     return result, t_initial, t_run
 
+
 ###############################################################################
 # Define the RNN models
 ###############################################################################
 warm_up_cycles = 3
-# input_size = 15
 input_size = 50
-# hidden_size = 20
 hidden_size = 200
-time_steps = 20
+
 
 class LSTM_forloop(torch.nn.Module):
     def __init__(self, input_size, hidden_size):
-        super(LSTM_forloop, self).__init__()
-        
+        super().__init__()
+
         self.lstm_cell = torch.nn.LSTMCell(input_size, hidden_size)
-        
-    # Implementation adopted from 
+
+    # Implementation adopted from
     # https://docs.pytorch.org/docs/stable/generated/torch.nn.LSTMCell.html
     def forward(self, init: torch.Tensor, xs: torch.Tensor):
         # The input `xs` has the time as the first dimsion
@@ -49,9 +49,28 @@ class LSTM_forloop(torch.nn.Module):
         output = torch.stack(output, dim=0)
         return output
 
+
 class LSTM_scan(torch.nn.Module):
-    def __init__(self, Wii, bii, Whi, bhi, Wif, bif, Whf, bhf, Wig, big, Whg, bhg, Wio, bio, Who, bho):
-        super(LSTM_scan, self).__init__()
+    def __init__(
+        self,
+        Wii,
+        bii,
+        Whi,
+        bhi,
+        Wif,
+        bif,
+        Whf,
+        bhf,
+        Wig,
+        big,
+        Whg,
+        bhg,
+        Wio,
+        bio,
+        Who,
+        bho,
+    ):
+        super().__init__()
         self.Wii = Wii.clone()
         self.bii = bii.clone()
         self.Whi = Whi.clone()
@@ -68,24 +87,39 @@ class LSTM_scan(torch.nn.Module):
         self.bio = bio.clone()
         self.Who = Who.clone()
         self.bho = bho.clone()
-        
+
     def forward(self, init: torch.Tensor, xs: torch.Tensor):
         def lstm_combine(carry, x):
             h, c = carry
-            
+
             i = torch.sigmoid(x @ self.Wii + self.bii + h @ self.Whi + self.bhi)
             f = torch.sigmoid(x @ self.Wif + self.bif + h @ self.Whf + self.bhf)
             g = torch.tanh(x @ self.Wig + self.big + h @ self.Whg + self.bhg)
             o = torch.sigmoid(x @ self.Wio + self.bio + h @ self.Who + self.bho)
-            
+
             c_new = f * c + i * g
             h_new = o * torch.tanh(c_new)
-            
+
             return (h_new, c_new.clone()), h_new.clone()
-        
+
         carry, outs = scan(lstm_combine, init, xs, dim=0)
-        
         return carry, outs
+
+
+class LSTM_scan_cell(torch.nn.Module):
+    def __init__(self, state_dict):
+        super().__init__()
+        self.lstm_cell = torch.nn.LSTMCell(input_size, hidden_size)
+        self.lstm_cell.load_state_dict(state_dict)
+
+    def forward(self, init: torch.Tensor, xs: torch.Tensor):
+        def lstm_combine(carry, x):
+            hx, cx = self.lstm_cell(x, carry)
+            return (hx, cx.clone()), hx.clone()
+
+        carry, outs = scan(lstm_combine, init, xs, dim=0)
+        return carry, outs
+
 
 # Define the for-loop LSTM model
 lstm_forloop = LSTM_forloop(input_size, hidden_size)
@@ -96,7 +130,7 @@ lstm_forloop_comp = torch.compile(lstm_forloop, fullgraph=True)
 lstm_forloop_state_dict = lstm_forloop.state_dict()
 lstm_cuda_state_dict = {}
 for key, value in lstm_forloop_state_dict.items():
-    new_key = key.replace('lstm_cell.', '') + '_l0'
+    new_key = key.replace("lstm_cell.", "") + "_l0"
     lstm_cuda_state_dict[new_key] = value.clone()
 lstm_cuda = torch.nn.LSTM(input_size, hidden_size)
 lstm_cuda.load_state_dict(lstm_cuda_state_dict)
@@ -107,59 +141,119 @@ Whi, Whf, Whg, Who = torch.chunk(lstm_cuda.weight_hh_l0, 4)
 bii, bif, big, bio = torch.chunk(lstm_cuda.bias_ih_l0, 4)
 bhi, bhf, bhg, bho = torch.chunk(lstm_cuda.bias_hh_l0, 4)
 lstm_scan = LSTM_scan(
-                Wii.T, bii,
-                Whi.T, bhi,
-                
-                Wif.T, bif,
-                Whf.T, bhf,
-                
-                Wig.T, big,
-                Whg.T, bhg,
-                
-                Wio.T, bio,
-                Who.T, bho,
-                )
+    Wii.T,
+    bii,
+    Whi.T,
+    bhi,
+    Wif.T,
+    bif,
+    Whf.T,
+    bhf,
+    Wig.T,
+    big,
+    Whg.T,
+    bhg,
+    Wio.T,
+    bio,
+    Who.T,
+    bho,
+)
 lstm_scan_comp = torch.compile(lstm_scan, fullgraph=True)
 
-###############################################################################
-# Define the inputs
-###############################################################################
-xs = torch.randn(time_steps, input_size, requires_grad=True)
-init = (torch.zeros(hidden_size, requires_grad=True), torch.zeros(hidden_size, requires_grad=True))
+# Define the LSTM model using scan and LSTMCell
+lstm_scan_cell_state_dict = {}
+for key, value in lstm_forloop_state_dict.items():
+    new_key = key.replace("lstm_cell.", "")
+    lstm_scan_cell_state_dict[new_key] = value.clone()
+lstm_scan_cell = LSTM_scan_cell(lstm_scan_cell_state_dict)
+lstm_scan_cell_comp = torch.compile(lstm_scan_cell, fullgraph=True)
 
-###############################################################################
-# Run models forward (inference-only)
-###############################################################################
-# For-loop model
-result_forloop, time_initial_forloop, time_run_forloop = time_fn(lstm_forloop, (init, xs), warm_up=warm_up_cycles)
+for time_steps in [3, 20, 70, 100]:
+    ###############################################################################
+    # Define the inputs
+    ###############################################################################
+    xs = torch.randn(time_steps, input_size, requires_grad=True)
+    init = (
+        torch.zeros(hidden_size, requires_grad=True),
+        torch.zeros(hidden_size, requires_grad=True),
+    )
 
-# For-loop model compiled
-result_forloop_comp, time_initial_forloop_comp, time_run_forloop_comp = time_fn(lstm_forloop_comp, (init, xs), warm_up=warm_up_cycles)
+    ###############################################################################
+    # Run models forward (inference-only)
+    ###############################################################################
+    # For-loop model
+    result_forloop, time_initial_forloop, time_run_forloop = time_fn(
+        lstm_forloop, (init, xs), warm_up=warm_up_cycles
+    )
 
-# CUDA model
-result_cuda, time_initial_cuda, time_run_cuda = time_fn(lstm_cuda, (xs.clone(), (init[0].clone().unsqueeze(0), init[1].clone().unsqueeze(0))), warm_up=warm_up_cycles)
+    # For-loop model compiled
+    result_forloop_comp, time_initial_forloop_comp, time_run_forloop_comp = time_fn(
+        lstm_forloop_comp,
+        ((init[0].clone(), init[1].clone()), xs.clone()),
+        warm_up=warm_up_cycles,
+    )
 
-# Scan model
-result_scan, time_initial_scan, time_run_scan = time_fn(lstm_scan, ((init[0].clone().unsqueeze(0), init[1].clone().unsqueeze(0)), xs.clone()), warm_up=warm_up_cycles)
+    # CUDA model
+    result_cuda, time_initial_cuda, time_run_cuda = time_fn(
+        lstm_cuda,
+        (xs.clone(), (init[0].clone().unsqueeze(0), init[1].clone().unsqueeze(0))),
+        warm_up=warm_up_cycles,
+    )
 
-# Scan model compiled
-result_scan_comp, time_initial_scan_comp, time_run_scan_comp = time_fn(lstm_scan_comp, ((init[0].clone().unsqueeze(0), init[1].clone().unsqueeze(0)), xs.clone()), warm_up=warm_up_cycles)
+    # Scan model
+    result_scan, time_initial_scan, time_run_scan = time_fn(
+        lstm_scan,
+        ((init[0].clone().unsqueeze(0), init[1].clone().unsqueeze(0)), xs.clone()),
+        warm_up=warm_up_cycles,
+    )
 
-torch.testing.assert_close(result_forloop, result_forloop_comp)
-torch.testing.assert_close(result_forloop, result_cuda[0])
-torch.testing.assert_close(result_forloop, result_scan[1][:, 0, :])
-torch.testing.assert_close(result_forloop, result_scan_comp[1][:, 0, :])
+    # Scan model compiled
+    result_scan_comp, time_initial_scan_comp, time_run_scan_comp = time_fn(
+        lstm_scan_comp,
+        ((init[0].clone().unsqueeze(0), init[1].clone().unsqueeze(0)), xs.clone()),
+        warm_up=warm_up_cycles,
+    )
 
-print(f'T={time_steps}:')
-print(f'Compile times:\n\
-For-Loop        : {time_initial_forloop_comp:.5f}\n\
-Scan            : {time_initial_scan_comp:.5f}\n')
-print(f'Run times       :\n\
-For-Loop        : {time_run_forloop:.5f} \n\
-For-Loop compile: {time_run_forloop_comp:.5f} \n\
-CUDA            : {time_run_cuda:.5f} \n\
-Scan            : {time_run_scan:.5f} \n\
-Scan compile    : {time_run_scan_comp:.5f}')
+    # Scan cell model
+    result_scan_cell, time_initial_scan_cell, time_run_scan_cell = time_fn(
+        lstm_scan_cell,
+        ((init[0].clone(), init[1].clone()), xs.clone()),
+        warm_up=warm_up_cycles,
+    )
+
+    # Scan cell model compiled
+    result_scan_cell_comp, time_initial_scan_cell_comp, time_run_scan_cell_comp = (
+        time_fn(
+            lstm_scan_cell_comp,
+            ((init[0].clone(), init[1].clone()), xs.clone()),
+            warm_up=warm_up_cycles,
+        )
+    )
+
+    torch.testing.assert_close(result_forloop, result_forloop_comp)
+    torch.testing.assert_close(result_forloop, result_cuda[0])
+    torch.testing.assert_close(result_forloop, result_scan[1][:, 0, :])
+    torch.testing.assert_close(result_forloop, result_scan_comp[1][:, 0, :])
+    torch.testing.assert_close(result_forloop, result_scan_cell[1])
+    torch.testing.assert_close(result_forloop, result_scan_cell_comp[1])
+
+    print(f"T={time_steps}:")
+    print(
+        f"Compile times      :\n\
+For-Loop           : {time_initial_forloop_comp:.5f}\n\
+Scan               : {time_initial_scan_comp:.5f}\n\
+Scan Cell          : {time_initial_scan_cell_comp:.5f}\n"
+    )
+    print(
+        f"Run times          :\n\
+For-Loop           : {time_run_forloop:.5f}\n\
+For-Loop compile.  : {time_run_forloop_comp:.5f}\n\
+CUDA               : {time_run_cuda:.5f}\n\
+Scan               : {time_run_scan:.5f}\n\
+Scan compile       : {time_run_scan_comp:.5f}\n\
+Scan Cell          : {time_run_scan_cell:.5f}\n\
+Scan Cell compile  : {time_run_scan_cell_comp:.5f}"
+    )
 
 ###############################################################################
 # Run models with backward

--- a/benchmarks/dynamo/scan/benchmark_lstm.py
+++ b/benchmarks/dynamo/scan/benchmark_lstm.py
@@ -51,7 +51,7 @@ class LSTM(torch.nn.Module):
             c_new = f * c + i * g
             h_new = o * torch.tanh(c_new)
             
-            return (h_new, c_new), o + 0.
+            return (h_new, c_new.clone()), h_new.clone()
         
         carry, outs = scan(lstm_combine, init, xs, dim=0)
         
@@ -106,39 +106,4 @@ print(f"PyTorch {t_pytorch} vs. Scan {t_scan} vs. Scan (Comp.) {t_scan_comp}")
 ###############################################################################
 # Run models with backward
 ###############################################################################
-# TODO: This is to be done!
-def wrapper_torch_bwd(fn, xs):
-    result = fn(xs)
-    result = result[0][:10, :30].sum()
-    # grad_init = [torch.ones_like(el) for el in result]
-    # grad = torch.autograd.grad(result, xs, grad_init)
-    grad = torch.autograd.grad(result, xs)
-    return grad
-
-
-# torch.testing.assert_close(result_pytorch, result)
-
-# grad_init = torch.ones_like(result_pytorch)
-# grad_pytorch = torch.autograd.grad(result_pytorch, xs, grad_init)[0]
-# grad = torch.autograd.grad(result, xs, grad_init)[0]
-
-# # The map function computes x ** y for each element, where y = 2
-# # Therefore, we expect the correct gradients to be x * 2
-# print("Gradient of PyTorch:\n", grad_pytorch)
-# print("Gradient of cond:\n", grad)
-# torch.testing.assert_close(grad_pytorch, grad)
-
-    
-# # Matrix implementation for associative_scan
-# result_grad_matrix, t_grad_matrix = time_fn(lambda xs: wrapper_torch_bwd(model_matrix, xs), xs, warm_up=warm_up_cycles)
-
-# # Memory-efficient implementation for associative_scan
-# result_grad_memeff, t_grad_memeff = time_fn(lambda xs: wrapper_torch_bwd(model_memeff, xs), xs, warm_up=warm_up_cycles)
-
-# # Non-jit compiled JAX model
-# result_grad_jax, t_grad_jax = time_fn(lambda xs: wrapper_jax_bwd(s5_operator_jax, xs), xs_jax, warm_up=warm_up_cycles)
-
-# # jit compiled JAX model
-# result_grad_jax_jit, t_grad_jax_jit = time_fn(lambda xs: wrapper_jax_jit_bwd(s5_operator_jax, xs), xs_jax, warm_up=warm_up_cycles)
-
-# print(f"Matrix {t_grad_matrix} vs. Mem eff. {t_grad_memeff} vs. JAX {t_grad_jax} vs. JAX (JIT) {t_grad_jax_jit}")
+# TODO To be done

--- a/benchmarks/dynamo/scan/benchmark_rnn.py
+++ b/benchmarks/dynamo/scan/benchmark_rnn.py
@@ -1,43 +1,43 @@
+from time import perf_counter
+
 import torch
 from torch._higher_order_ops.scan import scan
 
-from time import perf_counter
 
 ###############################################################################
 # Auxiliary function for timing
 ###############################################################################
 def time_fn(fn, args, warm_up=1):
-    t_initial = -1.
+    t_initial = -1.0
     for ind in range(warm_up):
-        t_start = perf_counter() 
+        t_start = perf_counter()
         result = fn(*args)
         t_stop = perf_counter()
         if ind == 0:
             t_initial = t_stop - t_start
 
-    t_start = perf_counter() 
+    t_start = perf_counter()
     result = fn(*args)
     t_stop = perf_counter()
     t_run = t_stop - t_start
     return result, t_initial, t_run
 
+
 ###############################################################################
 # Define the RNN models
 ###############################################################################
 warm_up_cycles = 3
-# input_size = 15
 input_size = 50
-# hidden_size = 20
 hidden_size = 200
-time_steps = 20
+
 
 class RNN_forloop(torch.nn.Module):
     def __init__(self, input_size, hidden_size):
-        super(RNN_forloop, self).__init__()
-        
+        super().__init__()
+
         self.rnn_cell = torch.nn.RNNCell(input_size, hidden_size)
-        
-    # Implementation adopted from 
+
+    # Implementation adopted from
     # https://docs.pytorch.org/docs/stable/generated/torch.nn.LSTMCell.html
     def forward(self, init: torch.Tensor, xs: torch.Tensor):
         # The input `xs` has the time as the first dimsion
@@ -48,33 +48,49 @@ class RNN_forloop(torch.nn.Module):
         output = torch.stack(output, dim=0)
         return output
 
+
 class RNN_scan(torch.nn.Module):
     def __init__(self, Wih, bih, Whh, bhh):
-        super(RNN_scan, self).__init__()
+        super().__init__()
         self.Wih = Wih.clone()
         self.bih = bih.clone()
         self.Whh = Whh.clone()
         self.bhh = bhh.clone()
-        
+
     def forward(self, init: torch.Tensor, xs: torch.Tensor):
         def rnn_combine(carry, x):
             h = torch.tanh(x @ self.Wih + self.bih + carry @ self.Whh + self.bhh)
             # Needed to not trigger aliasing errors in inductor
-            return h + 0., h.clone()
-        
+            return h + 0.0, h.clone()
+
         carry, outs = scan(rnn_combine, init, xs, dim=0)
         return carry, outs
+
+
+class RNN_scan_cell(torch.nn.Module):
+    def __init__(self, state_dict):
+        super().__init__()
+        self.rnn_cell = torch.nn.RNNCell(input_size, hidden_size)
+        self.rnn_cell.load_state_dict(state_dict)
+
+    def forward(self, init: torch.Tensor, xs: torch.Tensor):
+        def rnn_combine(carry, x):
+            hx = self.rnn_cell(x, carry)
+            return hx, hx.clone()
+
+        carry, outs = scan(rnn_combine, init, xs, dim=0)
+        return carry, outs
+
 
 # Define the for-loop LSTM model
 rnn_forloop = RNN_forloop(input_size, hidden_size)
 rnn_forloop_comp = torch.compile(rnn_forloop, fullgraph=True)
 
-
 # Define the LSTM using CUDA kernels
 rnn_forloop_state_dict = rnn_forloop.state_dict()
 rnn_cuda_state_dict = {}
 for key, value in rnn_forloop_state_dict.items():
-    new_key = key.replace('rnn_cell.', '') + '_l0'
+    new_key = key.replace("rnn_cell.", "") + "_l0"
     rnn_cuda_state_dict[new_key] = value.clone()
 rnn_cuda = torch.nn.RNN(input_size, hidden_size)
 rnn_cuda.load_state_dict(rnn_cuda_state_dict)
@@ -84,53 +100,86 @@ W_ih = rnn_cuda.weight_ih_l0.T.clone()
 b_ih = rnn_cuda.bias_ih_l0.clone()
 W_hh = rnn_cuda.weight_hh_l0.T.clone()
 b_hh = rnn_cuda.bias_hh_l0.clone()
-rnn_scan = RNN_scan(
-                    W_ih,
-                    b_ih, 
-                    W_hh,
-                    b_hh
-                )
+rnn_scan = RNN_scan(W_ih, b_ih, W_hh, b_hh)
 rnn_scan_comp = torch.compile(rnn_scan, fullgraph=True)
 
-###############################################################################
-# Define the inputs
-###############################################################################
-xs = torch.randn(time_steps, input_size, requires_grad=True)
-init = torch.zeros(hidden_size, requires_grad=True)
+# Define the LSTM model using scan and LSTMCell
+rnn_scan_cell_state_dict = {}
+for key, value in rnn_forloop_state_dict.items():
+    new_key = key.replace("rnn_cell.", "")
+    rnn_scan_cell_state_dict[new_key] = value.clone()
+rnn_scan_cell = RNN_scan_cell(rnn_scan_cell_state_dict)
+rnn_scan_cell_comp = torch.compile(rnn_scan_cell, fullgraph=True)
 
-###############################################################################
-# Run models forward (inference-only)
-###############################################################################
-# For-loop model
-result_forloop, time_initial_forloop, time_run_forloop = time_fn(rnn_forloop, (init, xs), warm_up=warm_up_cycles)
+for time_steps in [3, 20, 70, 100]:
+    ###############################################################################
+    # Define the inputs
+    ###############################################################################
+    xs = torch.randn(time_steps, input_size, requires_grad=True)
+    init = torch.zeros(hidden_size, requires_grad=True)
 
-# For-loop model compiled
-result_forloop_comp, time_initial_forloop_comp, time_run_forloop_comp = time_fn(rnn_forloop_comp, (init, xs), warm_up=warm_up_cycles)
+    ###############################################################################
+    # Run models forward (inference-only)
+    ###############################################################################
+    # For-loop model
+    result_forloop, time_initial_forloop, time_run_forloop = time_fn(
+        rnn_forloop, (init, xs), warm_up=warm_up_cycles
+    )
 
-# CUDA model
-result_cuda, time_initial_cuda, time_run_cuda = time_fn(rnn_cuda, (xs.clone(), init.clone().unsqueeze(0)), warm_up=warm_up_cycles)
+    # For-loop model compiled
+    result_forloop_comp, time_initial_forloop_comp, time_run_forloop_comp = time_fn(
+        rnn_forloop_comp, (init, xs), warm_up=warm_up_cycles
+    )
 
-# Scan model
-result_scan, time_initial_scan, time_run_scan = time_fn(rnn_scan, (init.clone().unsqueeze(0), xs.clone()), warm_up=warm_up_cycles)
+    # CUDA model
+    result_cuda, time_initial_cuda, time_run_cuda = time_fn(
+        rnn_cuda, (xs.clone(), init.clone().unsqueeze(0)), warm_up=warm_up_cycles
+    )
 
-# Scan model compiled
-result_scan_comp, time_initial_scan_comp, time_run_scan_comp = time_fn(rnn_scan_comp, (init.clone().unsqueeze(0), xs.clone()), warm_up=warm_up_cycles)
+    # Scan model
+    result_scan, time_initial_scan, time_run_scan = time_fn(
+        rnn_scan, (init.clone().unsqueeze(0), xs.clone()), warm_up=warm_up_cycles
+    )
 
-torch.testing.assert_close(result_forloop, result_forloop_comp)
-torch.testing.assert_close(result_forloop, result_cuda[0])
-torch.testing.assert_close(result_forloop, result_scan[1][:, 0, :])
-torch.testing.assert_close(result_forloop, result_scan_comp[1][:, 0, :])
+    # Scan model compiled
+    result_scan_comp, time_initial_scan_comp, time_run_scan_comp = time_fn(
+        rnn_scan_comp, (init.clone().unsqueeze(0), xs.clone()), warm_up=warm_up_cycles
+    )
 
-print(f'T={time_steps}:')
-print(f'Compile times:\n\
-For-Loop        : {time_initial_forloop_comp:.5f}\n\
-Scan            : {time_initial_scan_comp:.5f}\n')
-print(f'Run times       :\n\
-For-Loop        : {time_run_forloop:.5f} \n\
-For-Loop compile: {time_run_forloop_comp:.5f} \n\
-CUDA            : {time_run_cuda:.5f} \n\
-Scan            : {time_run_scan:.5f} \n\
-Scan compile    : {time_run_scan_comp:.5f}')
+    # Scan cell model
+    result_scan_cell, time_initial_scan_cell, time_run_scan_cell = time_fn(
+        rnn_scan_cell, (init.clone(), xs.clone()), warm_up=warm_up_cycles
+    )
+
+    # Scan cell model compiled
+    result_scan_cell_comp, time_initial_scan_cell_comp, time_run_scan_cell_comp = (
+        time_fn(rnn_scan_cell_comp, (init.clone(), xs.clone()), warm_up=warm_up_cycles)
+    )
+
+    torch.testing.assert_close(result_forloop, result_forloop_comp)
+    torch.testing.assert_close(result_forloop, result_cuda[0])
+    torch.testing.assert_close(result_forloop, result_scan[1][:, 0, :])
+    torch.testing.assert_close(result_forloop, result_scan_comp[1][:, 0, :])
+    torch.testing.assert_close(result_forloop, result_scan_cell[1])
+    torch.testing.assert_close(result_forloop, result_scan_cell_comp[1])
+
+    print(f"T={time_steps}:")
+    print(
+        f"Compile times       :\n\
+For-Loop            : {time_initial_forloop_comp:.5f}\n\
+Scan                : {time_initial_scan_comp:.5f}\n\
+Scan Cell           : {time_initial_scan_cell_comp:.5f}\n"
+    )
+    print(
+        f"Run times           :\n\
+For-Loop            : {time_run_forloop:.5f}\n\
+For-Loop compile.   : {time_run_forloop_comp:.5f}\n\
+CUDA                : {time_run_cuda:.5f}\n\
+Scan                : {time_run_scan:.5f}\n\
+Scan compile        : {time_run_scan_comp:.5f}\n\
+Scan RNNCell        : {time_run_scan_cell:.5f}\n\
+Scan RNNCell compile: {time_run_scan_cell_comp:.5f}"
+    )
 
 ###############################################################################
 # Run models with backward

--- a/benchmarks/dynamo/scan/benchmark_rnn.py
+++ b/benchmarks/dynamo/scan/benchmark_rnn.py
@@ -6,22 +6,51 @@ from time import perf_counter
 ###############################################################################
 # Auxiliary function for timing
 ###############################################################################
-def time_fn(fn, xs, warm_up=1):
-    for _ in range(warm_up):
-        result = fn(*xs)
+def time_fn(fn, args, warm_up=1):
+    t_initial = -1.
+    for ind in range(warm_up):
+        t_start = perf_counter() 
+        result = fn(*args)
+        t_stop = perf_counter()
+        if ind == 0:
+            t_initial = t_stop - t_start
 
     t_start = perf_counter() 
-    result = fn(*xs)
+    result = fn(*args)
     t_stop = perf_counter()
-    t_ = t_stop - t_start
-    return result, t_
+    t_run = t_stop - t_start
+    return result, t_initial, t_run
 
 ###############################################################################
-# Define the RNN for PyTorch
+# Define the RNN models
 ###############################################################################
-class RNN(torch.nn.Module):
+warm_up_cycles = 3
+# input_size = 15
+input_size = 50
+# hidden_size = 20
+hidden_size = 200
+time_steps = 20
+
+class RNN_forloop(torch.nn.Module):
+    def __init__(self, input_size, hidden_size):
+        super(RNN_forloop, self).__init__()
+        
+        self.rnn_cell = torch.nn.RNNCell(input_size, hidden_size)
+        
+    # Implementation adopted from 
+    # https://docs.pytorch.org/docs/stable/generated/torch.nn.LSTMCell.html
+    def forward(self, init: torch.Tensor, xs: torch.Tensor):
+        # The input `xs` has the time as the first dimsion
+        output = []
+        for i in range(xs.size()[0]):
+            init = self.rnn_cell(xs[i], init)
+            output.append(init)
+        output = torch.stack(output, dim=0)
+        return output
+
+class RNN_scan(torch.nn.Module):
     def __init__(self, Wih, bih, Whh, bhh):
-        super(RNN, self).__init__()
+        super(RNN_scan, self).__init__()
         self.Wih = Wih.clone()
         self.bih = bih.clone()
         self.Whh = Whh.clone()
@@ -31,50 +60,77 @@ class RNN(torch.nn.Module):
         def rnn_combine(carry, x):
             h = torch.tanh(x @ self.Wih + self.bih + carry @ self.Whh + self.bhh)
             # Needed to not trigger aliasing errors in inductor
-            return h, h.clone()
+            return h + 0., h.clone()
         
-        outs = scan(rnn_combine, init, xs, dim=0)[1]
-        return outs
+        carry, outs = scan(rnn_combine, init, xs, dim=0)
+        return carry, outs
 
-# Define the RNN with pure PyTorch
-rnn_pytorch = torch.nn.RNN(
-            input_size=5,
-            hidden_size=7,
-        )
+# Define the for-loop LSTM model
+rnn_forloop = RNN_forloop(input_size, hidden_size)
+rnn_forloop_comp = torch.compile(rnn_forloop, fullgraph=True)
 
-W_ih = rnn_pytorch.weight_ih_l0.T.clone()
-b_ih = rnn_pytorch.bias_ih_l0.clone()
-W_hh = rnn_pytorch.weight_hh_l0.T.clone()
-b_hh = rnn_pytorch.bias_hh_l0.clone()
 
-rnn_scan = RNN(W_ih,
-               b_ih, 
-               W_hh,
-               b_hh)
+# Define the LSTM using CUDA kernels
+rnn_forloop_state_dict = rnn_forloop.state_dict()
+rnn_cuda_state_dict = {}
+for key, value in rnn_forloop_state_dict.items():
+    new_key = key.replace('rnn_cell.', '') + '_l0'
+    rnn_cuda_state_dict[new_key] = value.clone()
+rnn_cuda = torch.nn.RNN(input_size, hidden_size)
+rnn_cuda.load_state_dict(rnn_cuda_state_dict)
+
+# Define the LSTM model using scan
+W_ih = rnn_cuda.weight_ih_l0.T.clone()
+b_ih = rnn_cuda.bias_ih_l0.clone()
+W_hh = rnn_cuda.weight_hh_l0.T.clone()
+b_hh = rnn_cuda.bias_hh_l0.clone()
+rnn_scan = RNN_scan(
+                    W_ih,
+                    b_ih, 
+                    W_hh,
+                    b_hh
+                )
+rnn_scan_comp = torch.compile(rnn_scan, fullgraph=True)
 
 ###############################################################################
 # Define the inputs
 ###############################################################################
-warm_up_cycles = 3
-xs = torch.randn(10, 5, requires_grad=True)
-init = torch.zeros(7, requires_grad=True)
+xs = torch.randn(time_steps, input_size, requires_grad=True)
+init = torch.zeros(hidden_size, requires_grad=True)
 
 ###############################################################################
 # Run models forward (inference-only)
 ###############################################################################
+# For-loop model
+result_forloop, time_initial_forloop, time_run_forloop = time_fn(rnn_forloop, (init, xs), warm_up=warm_up_cycles)
 
-# Native PyTorch implementation
-result_pytorch, t_pytorch = time_fn(rnn_pytorch, (xs,), warm_up=warm_up_cycles)
+# For-loop model compiled
+result_forloop_comp, time_initial_forloop_comp, time_run_forloop_comp = time_fn(rnn_forloop_comp, (init, xs), warm_up=warm_up_cycles)
 
-# Implementation with scan
-result_scan, t_scan = time_fn(rnn_scan, (init, xs), warm_up=warm_up_cycles)
-torch.testing.assert_close(result_pytorch[0], result_scan)
+# CUDA model
+result_cuda, time_initial_cuda, time_run_cuda = time_fn(rnn_cuda, (xs.clone(), init.clone().unsqueeze(0)), warm_up=warm_up_cycles)
 
-# Implementation with scan - compiled
-result_scan, t_scan_comp = time_fn(torch.compile(rnn_scan, fullgraph=True), (init, xs), warm_up=warm_up_cycles)
-torch.testing.assert_close(result_pytorch[0], result_scan)
+# Scan model
+result_scan, time_initial_scan, time_run_scan = time_fn(rnn_scan, (init.clone().unsqueeze(0), xs.clone()), warm_up=warm_up_cycles)
 
-print(f"PyTorch {t_pytorch} vs. Scan {t_scan} vs. Scan (Comp.) {t_scan_comp}")
+# Scan model compiled
+result_scan_comp, time_initial_scan_comp, time_run_scan_comp = time_fn(rnn_scan_comp, (init.clone().unsqueeze(0), xs.clone()), warm_up=warm_up_cycles)
+
+torch.testing.assert_close(result_forloop, result_forloop_comp)
+torch.testing.assert_close(result_forloop, result_cuda[0])
+torch.testing.assert_close(result_forloop, result_scan[1][:, 0, :])
+torch.testing.assert_close(result_forloop, result_scan_comp[1][:, 0, :])
+
+print(f'T={time_steps}:')
+print(f'Compile times:\n\
+For-Loop        : {time_initial_forloop_comp:.5f}\n\
+Scan            : {time_initial_scan_comp:.5f}\n')
+print(f'Run times       :\n\
+For-Loop        : {time_run_forloop:.5f} \n\
+For-Loop compile: {time_run_forloop_comp:.5f} \n\
+CUDA            : {time_run_cuda:.5f} \n\
+Scan            : {time_run_scan:.5f} \n\
+Scan compile    : {time_run_scan_comp:.5f}')
 
 ###############################################################################
 # Run models with backward

--- a/benchmarks/dynamo/scan/benchmark_rnn.py
+++ b/benchmarks/dynamo/scan/benchmark_rnn.py
@@ -1,0 +1,124 @@
+import torch
+from torch._higher_order_ops.scan import scan
+
+from time import perf_counter
+
+###############################################################################
+# Auxiliary function for timing
+###############################################################################
+def time_fn(fn, xs, warm_up=1):
+    for _ in range(warm_up):
+        result = fn(*xs)
+
+    t_start = perf_counter() 
+    result = fn(*xs)
+    t_stop = perf_counter()
+    t_ = t_stop - t_start
+    return result, t_
+
+###############################################################################
+# Define the RNN for PyTorch
+###############################################################################
+class RNN(torch.nn.Module):
+    def __init__(self, Wih, bih, Whh, bhh):
+        super(RNN, self).__init__()
+        self.Wih = Wih
+        self.bih = bih
+        self.Whh = Whh
+        self.bhh = bhh
+        
+    def forward(self, init: torch.Tensor, xs: torch.Tensor):
+        def rnn_combine(carry, x):
+            h = torch.tanh(x @ self.Wih + self.bih + carry @ self.Whh + self.bhh)
+            # Needed to not trigger aliasing errors in inductor
+            return h + 0., h.clone()
+        
+        carry, outs = scan(rnn_combine, init, xs, dim=0)
+        
+        return carry, outs
+
+# Define the RNN with pure PyTorch
+rnn_pytorch = torch.nn.RNN(3, 5)
+
+rnn_scan = RNN(rnn_pytorch.weight_ih_l0.T, rnn_pytorch.bias_ih_l0, 
+               rnn_pytorch.weight_hh_l0.T, rnn_pytorch.bias_hh_l0)
+
+###############################################################################
+# Define the inputs
+###############################################################################
+warm_up_cycles = 3
+xs = torch.randn(4, 3, requires_grad=True)
+init = torch.zeros(5, requires_grad=True)
+
+###############################################################################
+# Run models forward (inference-only)
+###############################################################################
+# torch.testing.assert_close(result_pytorch, result)
+
+# grad_init = torch.ones_like(result_pytorch)
+# grad_pytorch = torch.autograd.grad(result_pytorch, xs, grad_init)[0]
+# grad = torch.autograd.grad(result, xs, grad_init)[0]
+
+# # The map function computes x ** y for each element, where y = 2
+# # Therefore, we expect the correct gradients to be x * 2
+# print("Gradient of PyTorch:\n", grad_pytorch)
+# print("Gradient of cond:\n", grad)
+# torch.testing.assert_close(grad_pytorch, grad)
+
+
+# Native PyTorch implementation
+result_pytorch, t_pytorch = time_fn(rnn_pytorch, (xs,), warm_up=warm_up_cycles)
+
+# Implementation with scan
+result_scan, t_scan = time_fn(rnn_scan, (init, xs), warm_up=warm_up_cycles)
+torch.testing.assert_close(result_pytorch[0], result_scan[1])
+
+# Implementation with scan - compiled
+result_scan, t_scan_comp = time_fn(torch.compile(rnn_scan, fullgraph=True), (init, xs), warm_up=warm_up_cycles)
+torch.testing.assert_close(result_pytorch[0], result_scan[1])
+
+print(f"PyTorch {t_pytorch} vs. Scan {t_scan} vs. Scan (Comp.) {t_scan_comp}")
+
+###############################################################################
+# Run models with backward
+###############################################################################
+def wrapper_torch_bwd(fn, xs):
+    result = fn(xs)
+    result = result[0][:10, :30].sum()
+    # grad_init = [torch.ones_like(el) for el in result]
+    # grad = torch.autograd.grad(result, xs, grad_init)
+    grad = torch.autograd.grad(result, xs)
+    return grad
+
+def wrapper_jax_bwd(fn, xs):
+    def inner_fn(xs):
+        result = fn(xs)
+        result = result[0][:10, :30].sum()
+        return result
+    result = inner_fn(xs)
+    grad = jax.grad(inner_fn)(xs)
+    return grad
+
+def wrapper_jax_jit_bwd(fn, xs):
+    @jax.jit
+    def inner_fn(xs):
+        result = fn(xs)
+        result = result[0][:10, :30].sum()
+        return result
+    result = inner_fn(xs)
+    grad = jax.grad(inner_fn)(xs)
+    return grad
+    
+# Matrix implementation for associative_scan
+result_grad_matrix, t_grad_matrix = time_fn(lambda xs: wrapper_torch_bwd(model_matrix, xs), xs, warm_up=warm_up_cycles)
+
+# Memory-efficient implementation for associative_scan
+result_grad_memeff, t_grad_memeff = time_fn(lambda xs: wrapper_torch_bwd(model_memeff, xs), xs, warm_up=warm_up_cycles)
+
+# Non-jit compiled JAX model
+result_grad_jax, t_grad_jax = time_fn(lambda xs: wrapper_jax_bwd(s5_operator_jax, xs), xs_jax, warm_up=warm_up_cycles)
+
+# jit compiled JAX model
+result_grad_jax_jit, t_grad_jax_jit = time_fn(lambda xs: wrapper_jax_jit_bwd(s5_operator_jax, xs), xs_jax, warm_up=warm_up_cycles)
+
+print(f"Matrix {t_grad_matrix} vs. Mem eff. {t_grad_memeff} vs. JAX {t_grad_jax} vs. JAX (JIT) {t_grad_jax_jit}")

--- a/benchmarks/dynamo/scan/benchmark_rnn.py
+++ b/benchmarks/dynamo/scan/benchmark_rnn.py
@@ -22,103 +22,61 @@ def time_fn(fn, xs, warm_up=1):
 class RNN(torch.nn.Module):
     def __init__(self, Wih, bih, Whh, bhh):
         super(RNN, self).__init__()
-        self.Wih = Wih
-        self.bih = bih
-        self.Whh = Whh
-        self.bhh = bhh
+        self.Wih = Wih.clone()
+        self.bih = bih.clone()
+        self.Whh = Whh.clone()
+        self.bhh = bhh.clone()
         
     def forward(self, init: torch.Tensor, xs: torch.Tensor):
         def rnn_combine(carry, x):
             h = torch.tanh(x @ self.Wih + self.bih + carry @ self.Whh + self.bhh)
             # Needed to not trigger aliasing errors in inductor
-            return h + 0., h.clone()
+            return h, h.clone()
         
-        carry, outs = scan(rnn_combine, init, xs, dim=0)
-        
-        return carry, outs
+        outs = scan(rnn_combine, init, xs, dim=0)[1]
+        return outs
 
 # Define the RNN with pure PyTorch
-rnn_pytorch = torch.nn.RNN(3, 5)
+rnn_pytorch = torch.nn.RNN(
+            input_size=5,
+            hidden_size=7,
+        )
 
-rnn_scan = RNN(rnn_pytorch.weight_ih_l0.T, rnn_pytorch.bias_ih_l0, 
-               rnn_pytorch.weight_hh_l0.T, rnn_pytorch.bias_hh_l0)
+W_ih = rnn_pytorch.weight_ih_l0.T.clone()
+b_ih = rnn_pytorch.bias_ih_l0.clone()
+W_hh = rnn_pytorch.weight_hh_l0.T.clone()
+b_hh = rnn_pytorch.bias_hh_l0.clone()
+
+rnn_scan = RNN(W_ih,
+               b_ih, 
+               W_hh,
+               b_hh)
 
 ###############################################################################
 # Define the inputs
 ###############################################################################
 warm_up_cycles = 3
-xs = torch.randn(4, 3, requires_grad=True)
-init = torch.zeros(5, requires_grad=True)
+xs = torch.randn(10, 5, requires_grad=True)
+init = torch.zeros(7, requires_grad=True)
 
 ###############################################################################
 # Run models forward (inference-only)
 ###############################################################################
-# torch.testing.assert_close(result_pytorch, result)
-
-# grad_init = torch.ones_like(result_pytorch)
-# grad_pytorch = torch.autograd.grad(result_pytorch, xs, grad_init)[0]
-# grad = torch.autograd.grad(result, xs, grad_init)[0]
-
-# # The map function computes x ** y for each element, where y = 2
-# # Therefore, we expect the correct gradients to be x * 2
-# print("Gradient of PyTorch:\n", grad_pytorch)
-# print("Gradient of cond:\n", grad)
-# torch.testing.assert_close(grad_pytorch, grad)
-
 
 # Native PyTorch implementation
 result_pytorch, t_pytorch = time_fn(rnn_pytorch, (xs,), warm_up=warm_up_cycles)
 
 # Implementation with scan
 result_scan, t_scan = time_fn(rnn_scan, (init, xs), warm_up=warm_up_cycles)
-torch.testing.assert_close(result_pytorch[0], result_scan[1])
+torch.testing.assert_close(result_pytorch[0], result_scan)
 
 # Implementation with scan - compiled
 result_scan, t_scan_comp = time_fn(torch.compile(rnn_scan, fullgraph=True), (init, xs), warm_up=warm_up_cycles)
-torch.testing.assert_close(result_pytorch[0], result_scan[1])
+torch.testing.assert_close(result_pytorch[0], result_scan)
 
 print(f"PyTorch {t_pytorch} vs. Scan {t_scan} vs. Scan (Comp.) {t_scan_comp}")
 
 ###############################################################################
 # Run models with backward
 ###############################################################################
-def wrapper_torch_bwd(fn, xs):
-    result = fn(xs)
-    result = result[0][:10, :30].sum()
-    # grad_init = [torch.ones_like(el) for el in result]
-    # grad = torch.autograd.grad(result, xs, grad_init)
-    grad = torch.autograd.grad(result, xs)
-    return grad
-
-def wrapper_jax_bwd(fn, xs):
-    def inner_fn(xs):
-        result = fn(xs)
-        result = result[0][:10, :30].sum()
-        return result
-    result = inner_fn(xs)
-    grad = jax.grad(inner_fn)(xs)
-    return grad
-
-def wrapper_jax_jit_bwd(fn, xs):
-    @jax.jit
-    def inner_fn(xs):
-        result = fn(xs)
-        result = result[0][:10, :30].sum()
-        return result
-    result = inner_fn(xs)
-    grad = jax.grad(inner_fn)(xs)
-    return grad
-    
-# Matrix implementation for associative_scan
-result_grad_matrix, t_grad_matrix = time_fn(lambda xs: wrapper_torch_bwd(model_matrix, xs), xs, warm_up=warm_up_cycles)
-
-# Memory-efficient implementation for associative_scan
-result_grad_memeff, t_grad_memeff = time_fn(lambda xs: wrapper_torch_bwd(model_memeff, xs), xs, warm_up=warm_up_cycles)
-
-# Non-jit compiled JAX model
-result_grad_jax, t_grad_jax = time_fn(lambda xs: wrapper_jax_bwd(s5_operator_jax, xs), xs_jax, warm_up=warm_up_cycles)
-
-# jit compiled JAX model
-result_grad_jax_jit, t_grad_jax_jit = time_fn(lambda xs: wrapper_jax_jit_bwd(s5_operator_jax, xs), xs_jax, warm_up=warm_up_cycles)
-
-print(f"Matrix {t_grad_matrix} vs. Mem eff. {t_grad_memeff} vs. JAX {t_grad_jax} vs. JAX (JIT) {t_grad_jax_jit}")
+# TODO To be done


### PR DESCRIPTION
This PR contains some benchmark scripts that can be used as a starting point to trace performance shortcomings of the ``associative_scan`` and ``scan`` function compared to native PyTorch or JAX.

For example, the benchmark for the associative_scan compares four approaches:
1. Associative_scan with the matrix way of computing the backward path
2. Associative_scan with the memory-efficient way of computing the backward path (via associative_scan)
3. JAX associative_scan without jax.jit
4. JAX associative_scan with jax.jit

The associative_scan benchmarks designed such that the combine_mode='pointwise' is used, as this uses tl.associative_scan and should be much more performant.
One can see that the forward pass of JAX with JIT is much faster compared to the torch equivalent.
```Matrix 0.01150136103387922 vs. Mem eff. 0.011591693037189543 vs. JAX 0.013425306999124587 vs. JAX (JIT) 4.626100417226553e-05```

Apart from the performance, I noticed that JAX supports more complex operations within their associative_scan operator, such as `jnp.take`, which would be the equivalent of torch.gather. These operators are not supported in the PyTorch version, as they would mark the combine_fn as non-pointwise and thus lead to a fallback to the `combine_mode='generic'`, which is much slower. 

These benchmark scripts are by no means complete, but should just serve as a starting point for further investigations.
In particular, around:

- [ ] Operations that currently break pointwise assumption, such as `torch.gather` and `torch.scatter`.
- [ ] Performance improvements compared to native PyTorch and JAX
- [ ] Output-to-Output aliasing limitation that can be problematic, see `benchmark_rnn.py` and `benchmark_lstm.py`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @chenyang78 @ydwu4 @vadimkantorov 