### PR TITLE
[multi-kernel] apply size hints atomically

### DIFF
--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -1736,12 +1736,7 @@ class SIMDScheduling(BaseScheduling):
         """
         shapes = self._get_multikernel_shapes(node)
         return tuple(
-            tuple(
-                hint
-                if isinstance(s, sympy.Expr) and not isinstance(s, sympy.Integer)
-                else s
-                for s in shape
-            )
+            tuple(V.graph.sizevars.size_hint(s, hint_override=hint) for s in shape)
             for shape in shapes
         )
 

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -573,6 +573,7 @@ class SizeVarAllocator:
             return expr
         # Substitute all hints into expr, but leave unbacked symints alone
         expr = self.simplify(expr)
+        expr = self.remove_precomputed_replacements(expr)
         if not isinstance(expr, Expr):
             assert isinstance(expr, int)
             return expr
@@ -584,9 +585,12 @@ class SizeVarAllocator:
                 return expr  # inf/nan/I
 
         if hint_override:
-            return hint_override
-
-        expr = self.remove_precomputed_replacements(expr)
+            out = sympy_subs(
+                expr,
+                {symbol: sympy.Integer(hint_override) for symbol in free_symbols},
+            )
+            assert isinstance(out, sympy.Integer)
+            return out
 
         if use_user_provided_hint_override:
             expr = sympy_subs(expr, self.var_to_hint_override)


### PR DESCRIPTION
Summary: atomic applies for hint_override (doesn't apply for fallback values).

Test Plan: test_multi_kernel

Differential Revision: D84089824




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos @chenyang78