### PR TITLE
fix symint is passed to require_exact_stride instead of sympy.expr

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6101,6 +6101,9 @@ class ExternKernel(InputsKernel):
     def require_exact_strides(
         cls, x: IRNode, exact_strides: Sequence[_IntLike], allow_padding: bool = False
     ) -> IRNode:
+        assert all(isinstance(s, (int, Expr)) for s in exact_strides), (
+            f"Expect stride to be int or Expr but got {exact_strides}"
+        )
         return cls.require_strides(
             x, exact_strides=exact_strides, allow_padding=allow_padding
         )
@@ -8763,7 +8766,9 @@ class WhileLoop(ExternKernel):
                     new_tb = WhileLoop._maybe_wrap_as_tensor_box(tb)
                     ret.append(
                         ExternKernel.require_exact_strides(
-                            new_tb, fk.stride(), allow_padding=False
+                            new_tb,
+                            [Conditional._maybe_expr(s) for s in fk.stride()],
+                            allow_padding=False,
                         )
                     )
                 else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #164874
* #164867
* __->__ #164866
* #164865
* #164548
* #164778



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @chenyang78