### PR TITLE
CUDA 13.0 builds fix on Amazon Linux 2023

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -303,7 +303,7 @@ def _get_cuda_dep_paths(path: str, lib_folder: str, lib_name: str) -> list[str]:
     return nvidia_lib_paths + lib_paths
 
 
-def _preload_cuda_deps(lib_folder: str, lib_name: str, required: bool = True) -> None:
+def _preload_cuda_deps(lib_folder: str, lib_name: str, required: bool = True) -> None:  # type: ignore[valid-type]
     """Preloads cuda deps if they could not be found otherwise."""
     # Should only be called on Linux if default path resolution have failed
     assert platform.system() == "Linux", "Should only be called on Linux"

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -370,10 +370,18 @@ def _load_global_deps() -> None:
             "cusparselt": "libcusparseLt.so.*[0-9]",
             "cusolver": "libcusolver.so.*[0-9]",
             "nccl": "libnccl.so.*[0-9]",
-            "nvtx": "libnvToolsExt.so.*[0-9]",
             "nvshmem": "libnvshmem_host.so.*[0-9]",
             "cufile": "libcufile.so.*[0-9]",
         }
+
+        from torch.version import cuda as cuda_ver
+        from torch.torch_version import TorchVersion
+        cuda_version = TorchVersion(cuda_ver)
+
+        # Include libnvToolsExt only for older CUDA builds
+        # See: https://github.com/pytorch/pytorch/issues/152756
+        if (cuda_version and cuda_version < "12.9"):
+            cuda_libs["nvtx"] = "libnvToolsExt.so.*[0-9]"
 
         is_cuda_lib_err = [
             lib for lib in cuda_libs.values() if lib.split(".")[0] in err.args[0]

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -304,7 +304,7 @@ def _get_cuda_dep_paths(path: str, lib_folder: str, lib_name: str) -> list[str]:
 
 
 def _preload_cuda_deps(
-    lib_folder: str, lib_name: str, is_required: boolean = True
+    lib_folder: str, lib_name: str, is_required: bool = True
 ) -> None:
     """Preloads cuda deps if they could not be found otherwise."""
     # Should only be called on Linux if default path resolution have failed

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -384,7 +384,7 @@ def _load_global_deps() -> None:
             _preload_cuda_deps(lib_folder, lib_name)
 
         # libnvToolsExt is Optional Dependency
-        _preload_cuda_deps("nvtx", "libnvToolsExt.so.*[0-9]", False)
+        _preload_cuda_deps("nvtx", "libnvToolsExt.so.*[0-9]", required=False)
         ctypes.CDLL(global_deps_lib_path, mode=ctypes.RTLD_GLOBAL)
 
 

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -318,7 +318,8 @@ def _preload_cuda_deps(
             break
     if not lib_path and is_required:
         raise ValueError(f"{lib_name} not found in the system path {sys.path}")
-    ctypes.CDLL(lib_path)
+    else if lib_path:
+        ctypes.CDLL(lib_path)
 
 
 # See Note [Global dependencies]

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -316,7 +316,7 @@ def _preload_cuda_deps(
         if candidate_lib_paths:
             lib_path = candidate_lib_paths[0]
             break
-    if not lib_path and is_required:
+    if not lib_path and required:
         raise ValueError(f"{lib_name} not found in the system path {sys.path}")
     else if lib_path:
         ctypes.CDLL(lib_path)

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -303,9 +303,7 @@ def _get_cuda_dep_paths(path: str, lib_folder: str, lib_name: str) -> list[str]:
     return nvidia_lib_paths + lib_paths
 
 
-def _preload_cuda_deps(
-    lib_folder: str, lib_name: str, required: bool = True
-) -> None:
+def _preload_cuda_deps(lib_folder: str, lib_name: str, required: bool = True) -> None:
     """Preloads cuda deps if they could not be found otherwise."""
     # Should only be called on Linux if default path resolution have failed
     assert platform.system() == "Linux", "Should only be called on Linux"
@@ -318,7 +316,7 @@ def _preload_cuda_deps(
             break
     if not lib_path and required:
         raise ValueError(f"{lib_name} not found in the system path {sys.path}")
-    else if lib_path:
+    if lib_path:
         ctypes.CDLL(lib_path)
 
 

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -355,8 +355,6 @@ def _load_global_deps() -> None:
     except OSError as err:
         # Can only happen for wheel with cuda libs as PYPI deps
         # As PyTorch is not purelib, but nvidia-*-cu12 is
-        from torch.version import cuda as cuda_version
-
         cuda_libs: dict[str, str] = {
             "cublas": "libcublas.so.*[0-9]",
             "cudnn": "libcudnn.so.*[0-9]",
@@ -374,13 +372,14 @@ def _load_global_deps() -> None:
             "cufile": "libcufile.so.*[0-9]",
         }
 
-        from torch.version import cuda as cuda_ver
         from torch.torch_version import TorchVersion
+        from torch.version import cuda as cuda_ver
+
         cuda_version = TorchVersion(cuda_ver)
 
         # Include libnvToolsExt only for older CUDA builds
         # See: https://github.com/pytorch/pytorch/issues/152756
-        if (cuda_version and cuda_version < "12.9"):
+        if cuda_version and cuda_version < "12.9":
             cuda_libs["nvtx"] = "libnvToolsExt.so.*[0-9]"
 
         is_cuda_lib_err = [

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -304,7 +304,7 @@ def _get_cuda_dep_paths(path: str, lib_folder: str, lib_name: str) -> list[str]:
 
 
 def _preload_cuda_deps(
-    lib_folder: str, lib_name: str, is_required: bool = True
+    lib_folder: str, lib_name: str, required: bool = True
 ) -> None:
     """Preloads cuda deps if they could not be found otherwise."""
     # Should only be called on Linux if default path resolution have failed


### PR DESCRIPTION
During 2.9 rc testing I am seeing an issue on Amazon Linux 2023 with CUDA 13.0 builds

This is related to:
 https://github.com/pytorch/pytorch/issues/152756

Workflow: https://github.com/pytorch/test-infra/actions/runs/18324074610/job/52184079262

Error:
```
WARNING: There was an error checking the latest version of pip.
+ python3.11 .ci/pytorch/smoke_test/smoke_test.py --package torchonly
Traceback (most recent call last):
  File "/usr/local/lib64/python3.11/site-packages/torch/__init__.py", line 333, in _load_global_deps
    ctypes.CDLL(global_deps_lib_path, mode=ctypes.RTLD_GLOBAL)
  File "/usr/lib64/python3.11/ctypes/__init__.py", line 376, in __init__
    self._handle = _dlopen(self._name, mode)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: libcudart.so.13: cannot open shared object file: No such file or directory

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/pytorch/pytorch/.ci/pytorch/smoke_test/smoke_test.py", line 12, in <module>
    import torch
  File "/usr/local/lib64/python3.11/site-packages/torch/__init__.py", line 425, in <module>
    _load_global_deps()
  File "/usr/local/lib64/python3.11/site-packages/torch/__init__.py", line 383, in _load_global_deps
    _preload_cuda_deps(lib_folder, lib_name)
  File "/usr/local/lib64/python3.11/site-packages/torch/__init__.py", line 317, in _preload_cuda_deps
    raise ValueError(f"{lib_name} not found in the system path {sys.path}")
Traceback (most recent call last):
ValueError: libnvToolsExt.so.*[0-9] not found in the system path ['/pytorch/pytorch/.ci/pytorch/smoke_test', '/usr/lib64/python311.zip', '/usr/lib64/python3.11', '/usr/lib64/python3.11/lib-dynload', '/usr/local/lib64/python3.11/site-packages', '/usr/local/lib/python3.11/site-packages', '/usr/lib64/python3.11/site-packages', '/usr/lib/python3.11/site-packages']
  File "/home/ec2-user/actions-runner/_work/test-infra/test-infra/test-infra/.github/scripts/run_with_env_secrets.py", line 102, in <module>
    main()
  File "/home/ec2-user/actions-runner/_work/test-infra/test-infra/test-infra/.github/scripts/run_with_env_secrets.py", line 98, in main
    run_cmd_or_die(f"docker exec -t {container_name} /exec")
  File "/home/ec2-user/actions-runner/_work/test-infra/test-infra/test-infra/.github/scripts/run_with_env_secrets.py", line 39, in run_cmd_or_die
    raise RuntimeError(f"Command {cmd} failed with exit code {exit_code}")
RuntimeError: Command docker exec -t 7d9c5bd403cac9a9ee824d63a1d6f6057ecce89a7daa94a81617dbf8eff0ff2e /exec failed with exit code 1
```