### PR TITLE
Fix #164742, all header-impl'd userfacing functions should be inline

### DIFF
--- a/torch/csrc/stable/tensor_inl.h
+++ b/torch/csrc/stable/tensor_inl.h
@@ -14,7 +14,7 @@ namespace torch::stable {
 
 using torch::headeronly::ScalarType;
 
-ScalarType Tensor::scalar_type() const {
+inline ScalarType Tensor::scalar_type() const {
   int32_t dtype;
   TORCH_ERROR_CODE_CHECK(aoti_torch_get_dtype(ath_.get(), &dtype));
   return to<ScalarType>(from(dtype));


### PR DESCRIPTION
It is as @mxmpl pointed out; we are missing an inline.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #164882
* __->__ #164871

