### PR TITLE
[Bugfix][Inductor][Dynamo] Fix stride incorrectness issues for stride 0 tensor

### DIFF
--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -1652,15 +1652,29 @@ SeqNr|OrigAten|SrcFn|FwdSrcFn
 
     # See # https://github.com/pytorch/pytorch/issues/164814
     def test_aot_autograd_stride_reconstruction_on_zero_dim_dynamic_shaped_tensor(self) -> None:
-        def repro(sentinel: torch.Tensor) -> torch.Tensor:
+        def repro(sentinel: torch.Tensor, skip_squeeze: bool = False) -> torch.Tensor:
             x = torch.unique(torch.ones(1))
             x = torch.reshape(x, [1])
-            x = torch.squeeze(x)  # 0-d tensor
+            if not skip_squeeze:
+                x = torch.squeeze(x)  # 0-d tensor
             return x * sentinel
 
         # Grad required to trigger the issue (need to replay stride)
         sentinel = torch.tensor(1.0, requires_grad=True)
-        self.assertEqual(repro(sentinel), torch.compile(repro, backend="aot_eager",fullgraph=True)(sentinel))
+        eager_sq = repro(sentinel)
+        comp_aot_sq = torch.compile(repro, backend="aot_eager",fullgraph=True)(sentinel)
+        comp_ind_sq = torch.compile(repro, backend="inductor",fullgraph=True)(sentinel)
+        self.assertEqual(eager_sq, comp_aot_sq)
+        self.assertEqual(eager_sq, comp_ind_sq)
+        self.assertEqual(eager_sq.stride(), comp_ind_sq.stride())
+
+        # Now check semantics preserved when skipping squeeze
+        eager_no_sq = repro(sentinel, skip_squeeze=True)
+        comp_aot_no_sq = torch.compile(repro, backend="aot_eager",fullgraph=True)(sentinel, skip_squeeze=True)
+        comp_ind_no_sq = torch.compile(repro, backend="inductor",fullgraph=True)(sentinel, skip_squeeze=True)
+        self.assertEqual(eager_no_sq, comp_aot_no_sq)
+        self.assertEqual(eager_no_sq, comp_ind_no_sq)
+        self.assertEqual(eager_no_sq.stride(), comp_ind_no_sq.stride())
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -1651,7 +1651,9 @@ SeqNr|OrigAten|SrcFn|FwdSrcFn
         self.assertLess(len(shape_env_guards), 1000)
 
     # See # https://github.com/pytorch/pytorch/issues/164814
-    def test_aot_autograd_stride_reconstruction_on_zero_dim_dynamic_shaped_tensor(self) -> None:
+    def test_aot_autograd_stride_reconstruction_on_zero_dim_dynamic_shaped_tensor(
+        self,
+    ) -> None:
         def repro(sentinel: torch.Tensor, skip_squeeze: bool = False) -> torch.Tensor:
             x = torch.unique(torch.ones(1))
             x = torch.reshape(x, [1])
@@ -1662,19 +1664,26 @@ SeqNr|OrigAten|SrcFn|FwdSrcFn
         # Grad required to trigger the issue (need to replay stride)
         sentinel = torch.tensor(1.0, requires_grad=True)
         eager_sq = repro(sentinel)
-        comp_aot_sq = torch.compile(repro, backend="aot_eager",fullgraph=True)(sentinel)
-        comp_ind_sq = torch.compile(repro, backend="inductor",fullgraph=True)(sentinel)
+        comp_aot_sq = torch.compile(repro, backend="aot_eager", fullgraph=True)(
+            sentinel
+        )
+        comp_ind_sq = torch.compile(repro, backend="inductor", fullgraph=True)(sentinel)
         self.assertEqual(eager_sq, comp_aot_sq)
         self.assertEqual(eager_sq, comp_ind_sq)
         self.assertEqual(eager_sq.stride(), comp_ind_sq.stride())
 
         # Now check semantics preserved when skipping squeeze
         eager_no_sq = repro(sentinel, skip_squeeze=True)
-        comp_aot_no_sq = torch.compile(repro, backend="aot_eager",fullgraph=True)(sentinel, skip_squeeze=True)
-        comp_ind_no_sq = torch.compile(repro, backend="inductor",fullgraph=True)(sentinel, skip_squeeze=True)
+        comp_aot_no_sq = torch.compile(repro, backend="aot_eager", fullgraph=True)(
+            sentinel, skip_squeeze=True
+        )
+        comp_ind_no_sq = torch.compile(repro, backend="inductor", fullgraph=True)(
+            sentinel, skip_squeeze=True
+        )
         self.assertEqual(eager_no_sq, comp_aot_no_sq)
         self.assertEqual(eager_no_sq, comp_ind_no_sq)
         self.assertEqual(eager_no_sq.stride(), comp_ind_no_sq.stride())
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -1650,6 +1650,17 @@ SeqNr|OrigAten|SrcFn|FwdSrcFn
         # However, at the time this change was introduced, it went down from 15154 to 403.
         self.assertLess(len(shape_env_guards), 1000)
 
+    # See # https://github.com/pytorch/pytorch/issues/164814
+    def test_aot_autograd_stride_reconstruction_on_zero_dim_dynamic_shaped_tensor(self) -> None:
+        def repro(sentinel: torch.Tensor) -> torch.Tensor:
+            x = torch.unique(torch.ones(1))
+            x = torch.reshape(x, [1])
+            x = torch.squeeze(x)  # 0-d tensor
+            return x * sentinel
+
+        # Grad required to trigger the issue (need to replay stride)
+        sentinel = torch.tensor(1.0, requires_grad=True)
+        self.assertEqual(repro(sentinel), torch.compile(repro, backend="aot_eager",fullgraph=True)(sentinel))
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -1764,7 +1764,7 @@ def aot_stage2_autograd(
                     # (2408448, 1, 21504, 192). The solution mentioned will
                     # decide a stride of (802816, 1, 7168, 64) for this
                     # tensor which is wrong.
-                    
+
                     ph_size = ph_arg.size()
                     if len(ph_size) == 0 and len(real_stride) > 0:
                         # Fix for 0-dimensional tensors: When a tensor becomes 0-d
@@ -1773,7 +1773,7 @@ def aot_stage2_autograd(
                         # tensors that are later squeezed to 0-d. The stride metadata
                         # may get preserved causing a dimension mismatch (#164814)
                         real_stride = ()
-                    
+
                     # pyrefly: ignore  # bad-argument-type
                     placeholder_list[i] = ph_arg.as_strided(ph_size, real_stride)
             compiled_bw_func = None

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -1764,9 +1764,18 @@ def aot_stage2_autograd(
                     # (2408448, 1, 21504, 192). The solution mentioned will
                     # decide a stride of (802816, 1, 7168, 64) for this
                     # tensor which is wrong.
+                    
+                    ph_size = ph_arg.size()
+                    if len(ph_size) == 0 and len(real_stride) > 0:
+                        # Fix for 0-dimensional tensors: When a tensor becomes 0-d
+                        # (e.g., via squeeze), its stride should be () not (1,).
+                        # This mismatch can occur when dynamic shape operations produce
+                        # tensors that are later squeezed to 0-d. The stride metadata
+                        # may get preserved causing a dimension mismatch (#164814)
+                        real_stride = ()
+                    
                     # pyrefly: ignore  # bad-argument-type
-                    placeholder_list[i] = ph_arg.as_strided(ph_arg.size(), real_stride)
-
+                    placeholder_list[i] = ph_arg.as_strided(ph_size, real_stride)
             compiled_bw_func = None
             if (
                 num_symints_saved_for_bw > 0

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1745,10 +1745,15 @@ class GraphLowering(torch.fx.Interpreter):
                                 allow_padding=allow_padding,
                             )
                         else:
-                            strides = [
-                                s.node.expr if isinstance(s, torch.SymInt) else s
-                                for s in strides
-                            ]
+                            # Fix for 0-d tensors: if result size is empty,
+                            # strides should also be empty
+                            if len(result.get_size()) == 0 and len(strides) > 0:
+                                strides = []
+                            else:
+                                strides = [
+                                    s.node.expr if isinstance(s, torch.SymInt) else s
+                                    for s in strides
+                                ]
                             result = ir.ExternKernel.require_exact_strides(
                                 result, strides, allow_padding=allow_padding
                             )

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -2999,9 +2999,17 @@ class SqueezeView(BaseView):
                 assert isinstance(dim, int), type(dim)
                 assert 0 <= dim and dim < len(old_layout.size)
 
+            # Fix for #164814: Handle symbolic expressions that are equal to 1
+            from torch._inductor.virtualized import V
+              
             for i, (size, stride) in enumerate(zip(old_layout.size, old_layout.stride)):
                 if dim is None:
-                    if size != 1:
+                    # Skip dimensions that are 1 (literal or symbolic)
+                    is_one = size == 1 or (
+                        isinstance(size, sympy.Expr)
+                        and V.graph.sizevars.statically_known_equals(size, 1)
+                    )
+                    if not is_one:
                         new_size.append(size)
                         new_stride.append(stride)
                 else:
@@ -3023,7 +3031,19 @@ class SqueezeView(BaseView):
 
         if dim is None:
             # redirect to a generic view
-            return View.create(x, [s for s in x.get_size() if s != 1])
+            # Fix for #164814: Filter out dimensions that are symbolically equal to 1.
+            # When dynamic shape operations produce tensors with symbolic shapes like (u0,)
+            # where u0 is guarded to equal 1, we need to filter them out properly.
+            from torch._inductor.virtualized import V
+            new_size = []
+            for s in x.get_size():
+                # Keep dimension if it's not literally 1 and not symbolically equal to 1
+                if s != 1 and not (
+                    isinstance(s, sympy.Expr)
+                    and V.graph.sizevars.statically_known_equals(s, 1)
+                ):
+                    new_size.append(s)
+            return View.create(x, new_size)
         else:
             assert x.get_size()[dim] == 1
             return View.create(x, [s for i, s in enumerate(x.get_size()) if i != dim])


### PR DESCRIPTION
Fixes #164814 - we update to include cases where we know symbolic expression is statically one.  There are two errors here; first in graph capture, where a tensor with size 0 yet symbolic stride would attempt to keep the symbolic stride, resulting in a mismatch.  The second is in inductor code gen, where we only checked in squeeze if size == 1, missing the case where a symbolic stride equals 1.

Also fixes #164924 (@bobrenjc93  for fuzzer finding an issue affecting users : ) 

### Test plan:
```
python test/dynamo/test_aot_autograd.py AotAutogradFallbackTests
```

Results in:
```
..
----------------------------------------------------------------------
Ran 49 tests in 45.622s

OK (expected failures=1)
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben