### PR TITLE
fix default backend inference for custom distributed backend

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -1,7 +1,6 @@
 # mypy: allow-untyped-defs
 """Distributed Collective Communication (c10d)."""
 
-import collections.abc
 import contextlib
 import ctypes
 import hashlib
@@ -14,7 +13,7 @@ import sys
 import time
 import warnings
 from collections import namedtuple
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from datetime import timedelta
 from typing import Any, Optional, TYPE_CHECKING, Union
 from typing_extensions import deprecated
@@ -1176,7 +1175,7 @@ def _check_not_self_rank(group: ProcessGroup, rank: int, rank_type: str):
         )
 
 
-def _as_iterable(obj) -> collections.abc.Iterable:
+def _as_iterable(obj) -> Iterable:
     return obj if isinstance(obj, list) else (obj,)
 
 
@@ -1957,8 +1956,9 @@ def _new_process_group_helper(
         if Backend.NCCL in backend_config.device_backend_map.values():
             pg._set_default_backend(ProcessGroup.BackendType.NCCL)
         elif Backend._plugins.keys():
-            custom_backend = next(iter(Backend._plugins.keys()))
-            if custom_backend in backend_config.device_backend_map.values():
+            # Set custom as default if backend config contains at least one custom backend
+            custom_backends: Iterable[str] = Backend._plugins.keys() and backend_config.device_backend_map.values()
+            if len(custom_backends) > 0:
                 pg._set_default_backend(ProcessGroup.BackendType.CUSTOM)
         else:
             pg._set_default_backend(ProcessGroup.BackendType.GLOO)


### PR DESCRIPTION
Current implementation uses `custom_backend = next(iter(Backend._plugins.keys()))` and it only makes sense when `Backend._plugins.keys()` contains exactly one custom backend. However, this invariant breaks with `import torch._dynamo` which indirectly adds the `fake` distributed backend used for testing.

This causes the default backend to not get set when:
- using a custom device + custom ccl backend
- using multiple backends config when calling `init_process_group` i.e. `cpu:gloo,custom_device:custom_backend`
- 'FAKE' comes before `custom_backend` name in the dict key order

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci