### PR TITLE
[test, do not merge][cuBLAS] addmm with Lt: check we can now use 1-row/col in the Lt

### DIFF
--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -397,9 +397,10 @@ Tensor& addmm_out_cuda_impl(Tensor& result, const Tensor& self, const Tensor& ma
            scalar_type == at::ScalarType::BFloat16) &&
 #endif
 #if (defined(CUDA_VERSION) && CUDA_VERSION >= 12010 || defined(USE_ROCM))
-          mat2_sizes[0] > 1 && mat2_sizes[1] > 1;
+          true;
+          //mat2_sizes[0] > 1 && mat2_sizes[1] > 1;
 #else
-          mat2_sizes[0] > 1 && mat2_sizes[1] > 1 &&
+          //mat2_sizes[0] > 1 && mat2_sizes[1] > 1 &&
           mat2_sizes[0] < 65535 * 32 && mat2_sizes[1] < 65535 * 32 &&
           mat1_sizes[0] < 65535 * 32 && mat1_sizes[1] < 65535 * 32 &&
           // avoid leading dim >> rows bugs


### PR DESCRIPTION
[#72148](https://github.com/pytorch/pytorch/pull/72148) introduced Lt path for `addmm` which is being blocked when the second matrix has a single row or a column. That, unfortunately, disqualifies Lt from handling `mv`-like cases with activation epilogue fusions.

Having investigated this case, I have observed that the input preparation method in `cublasCommonArgs` can produce parameters where the leading dimension of the second matrix, `ldb`, can violate `ldb >= max(1, k or n based on transposition)` which, judging from the documentation, should cause a failure. It seems like `cublasXgemm` can swallow such inputs, despite this non-compliance. Now is the time to check whether Lt did catch up. And if not, we know how to fix the issue and, hopefully, unblock Lt here.

cc @ptrblck @msaroufim @eqy @jerryzh168 @tinglvv @nWEIdia @csarofeen @xwang233