### PR TITLE
Complete fix for non-power-of-2 head dimensions in FlexAttention decode

### DIFF
--- a/test/inductor/test_flex_decoding.py
+++ b/test/inductor/test_flex_decoding.py
@@ -1278,14 +1278,14 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         self.run_test_with_paged_attention(score_mod_scale, dtype, device=device)
 
     @supported_platform
-    @common_utils.parametrize("head_dim", [17, 24, 96, 121])
+    @common_utils.parametrize("head_dim", [17, 24, 94, 121])
     @common_utils.parametrize("dtype", test_dtypes_fast)
     @common_utils.serialTest()
     def test_non_pow_2_headdim(self, device, dtype, head_dim):
         # Use Q_S=1 (decode path) by not passing Q_S parameter - it defaults to 1
         # This tests the flex_decode kernel with non-power-of-2 head dimensions
         self.run_test(
-            _rel_bias, dtype, Q_B=B, Q_H=Hq, Q_D=head_dim, 
+            _rel_bias, dtype, Q_B=B, Q_H=Hq, Q_D=head_dim,
             KV_B=B, KV_H=Hkv, KV_S=S, V_D=head_dim, device=device
         )
 

--- a/test/inductor/test_flex_decoding.py
+++ b/test/inductor/test_flex_decoding.py
@@ -1294,7 +1294,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             KV_H=Hkv,
             KV_S=S,
             V_D=head_dim,
-            device=device
+            device=device,
         )
 
     @supported_platform

--- a/test/inductor/test_flex_decoding.py
+++ b/test/inductor/test_flex_decoding.py
@@ -1278,12 +1278,15 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         self.run_test_with_paged_attention(score_mod_scale, dtype, device=device)
 
     @supported_platform
-    @common_utils.parametrize("head_dim", [17, 24, 94, 121])
+    @common_utils.parametrize("head_dim", [17, 24, 96, 121])
     @common_utils.parametrize("dtype", test_dtypes_fast)
     @common_utils.serialTest()
     def test_non_pow_2_headdim(self, device, dtype, head_dim):
+        # Use Q_S=1 (decode path) by not passing Q_S parameter - it defaults to 1
+        # This tests the flex_decode kernel with non-power-of-2 head dimensions
         self.run_test(
-            _rel_bias, dtype, B, Hq, S, head_dim, B, Hkv, S, head_dim, device=device
+            _rel_bias, dtype, Q_B=B, Q_H=Hq, Q_D=head_dim, 
+            KV_B=B, KV_H=Hkv, KV_S=S, V_D=head_dim, device=device
         )
 
     @supported_platform

--- a/test/inductor/test_flex_decoding.py
+++ b/test/inductor/test_flex_decoding.py
@@ -1285,8 +1285,16 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         # Use Q_S=1 (decode path) by not passing Q_S parameter - it defaults to 1
         # This tests the flex_decode kernel with non-power-of-2 head dimensions
         self.run_test(
-            _rel_bias, dtype, Q_B=B, Q_H=Hq, Q_D=head_dim,
-            KV_B=B, KV_H=Hkv, KV_S=S, V_D=head_dim, device=device
+            _rel_bias,
+            dtype,
+            Q_B=B,
+            Q_H=Hq,
+            Q_D=head_dim,
+            KV_B=B,
+            KV_H=Hkv,
+            KV_S=S,
+            V_D=head_dim,
+            device=device
         )
 
     @supported_platform

--- a/torch/_inductor/kernel/flex/templates/flex_decode.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/flex_decode.py.jinja
@@ -250,5 +250,5 @@
     idx_d = offs_vd[None, None, :]
 
     mask = (idx_m < Q_LEN) & (idx_d < V_HEAD_DIM)
-    acc = acc.reshape(G, BLOCK_M_PER_HQ, V_HEAD_DIM)
-    {{store_output(("idx_z", "idx_t", "idx_hq", "idx_m", "idx_d"), "acc", "mask", val_shape=("GQA_SHARED_HEADS", "BLOCK_M_PER_HQ", "V_HEAD_DIM"))}}
+    acc = acc.reshape(G, BLOCK_M_PER_HQ, V_HEAD_DIM_ROUNDED)
+    {{store_output(("idx_z", "idx_t", "idx_hq", "idx_m", "idx_d"), "acc", "mask", val_shape=("GQA_SHARED_HEADS", "BLOCK_M_PER_HQ", "V_HEAD_DIM_ROUNDED"))}}


### PR DESCRIPTION
# Fix for FlexAttention with Non-Power-of-2 Head Dimensions

## Summary
This PR completes the fix started in PR #133495 for supporting non-power-of-2 head dimensions in FlexAttention's decoding path.

## Problem
PR #133495 added `V_HEAD_DIM_ROUNDED` and `QK_HEAD_DIM_ROUNDED` to `common.py` but did not update all usages in the Jinja templates. Specifically, `flex_decode.py.jinja` still used `V_HEAD_DIM` in critical tensor operations, causing Triton compilation failures for non-power-of-2 head dimensions like 96.

### Error Message
```
InductorError: LoweringException: NoValidChoicesError: No choices to select.
Provided reason: All choices failed to compile for backend.
...
Shape element 2 must be a power of 2
target: flex_attention
```

### Root Cause
In `flex_decode.py.jinja`:
1. **Line 81**: Accumulator created with `V_HEAD_DIM_ROUNDED` (e.g., 128 for head_dim=96)
   ```jinja
   acc = tl.zeros([BLOCK_M, V_HEAD_DIM_ROUNDED], dtype=tl.float32)
   ```

2. **Line 241**: Reshape operation used `V_HEAD_DIM` (96) instead of `V_HEAD_DIM_ROUNDED` (128)
   ```jinja
   acc = acc.reshape(G, BLOCK_M_PER_HQ, V_HEAD_DIM)  
   ```

3. **Line 242**: Store operation specified `V_HEAD_DIM` in val_shape
   ```jinja
   {{store_output(..., val_shape=(..., "V_HEAD_DIM"))}}  
   ```

This caused a dimension mismatch: trying to reshape a tensor with dimension 128 to dimension 96.

## Solution
Update `flex_decode.py.jinja` to consistently use `V_HEAD_DIM_ROUNDED` in tensor operations:

### Changes Made

**File**: `torch/_inductor/kernel/flex/templates/flex_decode.py.jinja`

**Line 241**:
```diff
- acc = acc.reshape(G, BLOCK_M_PER_HQ, V_HEAD_DIM)
+ acc = acc.reshape(G, BLOCK_M_PER_HQ, V_HEAD_DIM_ROUNDED)
```

**Line 242**:
```diff
- {{store_output(("idx_z", "idx_t", "idx_hq", "idx_m", "idx_d"), "acc", "mask", val_shape=("GQA_SHARED_HEADS", "BLOCK_M_PER_HQ", "V_HEAD_DIM"))}}
+ {{store_output(("idx_z", "idx_t", "idx_hq", "idx_m", "idx_d"), "acc", "mask", val_shape=("GQA_SHARED_HEADS", "BLOCK_M_PER_HQ", "V_HEAD_DIM_ROUNDED"))}}
```

### Why This Works
- `V_HEAD_DIM_ROUNDED` is calculated in `common.py` as the next power of 2:
  ```python
  kernel_options["V_HEAD_DIM_ROUNDED"] = next_power_of_two(v_head_dim_static)
  ```
- For `head_dim=96`, `V_HEAD_DIM_ROUNDED=128`
- All tensor operations now use power-of-2 dimensions, satisfying Triton's requirements
- The mask `(idx_d < V_HEAD_DIM)` still correctly bounds the output to the actual head dimension


### Expected Results
- **Before fix**: `InductorError` about power-of-2 constraint
- **After fix**: Test passes, FlexAttention works with head_dim=96/80 

## Impact
This fix enables FlexAttention to work with models that use non-power-of-2 head dimensions, such as:
- `head_dim=96,` , `head_dim=80`, `head_dim=160`, etc.

Previously, these models would fail during compilation with `torch.compile` and FlexAttention.

## Related Issues
- PR #133495: Added `V_HEAD_DIM_ROUNDED` but incomplete template updates
- This PR completes that work




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Chillee @drisspg @yanboliang @BoyuanFeng @chenyang78