### PR TITLE
[easy][while_loop] use copy_input instead of clone in _clone_aliased_inputs

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -8693,7 +8693,6 @@ class WhileLoop(ExternKernel):
             return carried_inputs
 
         # Import clone from lowering module
-        from .lowering import clone
 
         # Unwrap views to get the underlying buffers for comparison
         unwrapped_buffers = [
@@ -8703,13 +8702,13 @@ class WhileLoop(ExternKernel):
 
         # Track which buffers we've seen and their indices
         seen_buffers: OrderedSet[int] = OrderedSet()
-        result = []
+        result: list[Union[IRNode, TensorBox, ShapeAsConstantBuffer]] = []
 
         for i, (original_input, unwrapped_buffer) in enumerate(
             zip(carried_inputs, unwrapped_buffers)
         ):
             if id(unwrapped_buffer) in seen_buffers:
-                result.append(clone(original_input))
+                result.append(ExternKernel.copy_input(original_input))
             else:
                 seen_buffers.add(id(unwrapped_buffer))
                 result.append(original_input)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #164955

Compared with clone, ExternKernel.copy_input additionally realize the buffer, which downstream assumes the input buffer are realized. 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben