### PR TITLE
Test torch/csrc/stable clang-tidy rules error in CI

### DIFF
--- a/torch/csrc/stable/ops.h
+++ b/torch/csrc/stable/ops.h
@@ -10,6 +10,8 @@
 #include <torch/csrc/inductor/aoti_torch/generated/c_shim_aten.h>
 #include <torch/headeronly/core/ScalarType.h>
 
+using torch::headeronly::ScalarType;
+
 namespace torch::stable {
 
 // We expect this to be the stable version of the empty_like op that takes in


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #164963

