### PR TITLE
Add view_as_real and view_as_complex for sparse tensors

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -424,6 +424,7 @@
   variants: function
   dispatch:
     CPU, CUDA, MPS, Meta: view_as_complex
+    SparseCPU, SparseCUDA: view_as_complex_sparse
 
 - func: sgn(Tensor self) -> Tensor
   variants: function, method

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -418,13 +418,13 @@
   variants: function
   dispatch:
     CPU, CUDA, MPS, Meta: view_as_real
-    SparseCPU, SparseCUDA: view_as_real_sparse
+    SparseCPU, SparseCUDA, SparseMPS: view_as_real_sparse
 
 - func: view_as_complex(Tensor(a) self) -> Tensor(a)
   variants: function
   dispatch:
     CPU, CUDA, MPS, Meta: view_as_complex
-    SparseCPU, SparseCUDA: view_as_complex_sparse
+    SparseCPU, SparseCUDA, SparseMPS: view_as_complex_sparse
 
 - func: sgn(Tensor self) -> Tensor
   variants: function, method

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -418,6 +418,7 @@
   variants: function
   dispatch:
     CPU, CUDA, MPS, Meta: view_as_real
+    SparseCPU, SparseCUDA: view_as_real_sparse   # , MPS, Meta: view_as_real
 
 - func: view_as_complex(Tensor(a) self) -> Tensor(a)
   variants: function

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -418,7 +418,7 @@
   variants: function
   dispatch:
     CPU, CUDA, MPS, Meta: view_as_real
-    SparseCPU, SparseCUDA: view_as_real_sparse   # , MPS, Meta: view_as_real
+    SparseCPU, SparseCUDA: view_as_real_sparse
 
 - func: view_as_complex(Tensor(a) self) -> Tensor(a)
   variants: function

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -903,7 +903,7 @@ Tensor view_as_real_sparse(const Tensor& self) {
   TORCH_CHECK(self.is_sparse() && self.is_complex(), "view_as_real_sparse is only supported for complex sparse tensors");
   TORCH_CHECK(!self.is_conj(), "view_as_real_sparse doesn't work on unresolved conjugated tensors.  To resolve the conjugate tensor so you can view it as real, use self.resolve_conj(); however, be warned that the resulting tensor will NOT alias the original.");
 
-  auto new_sizes = self.sizes().vec();
+  auto new_sizes = self.sym_sizes().vec();
   // last dimension will always have two elements containing the real and imag vals
   new_sizes.push_back(2);
 
@@ -911,7 +911,7 @@ Tensor view_as_real_sparse(const Tensor& self) {
   const auto float_type = c10::toRealValueType(self.scalar_type());
   auto options = self.options().dtype(float_type);
 
-  return at::_sparse_coo_tensor_with_dims_and_tensors(
+  return at::_sparse_coo_tensor_with_dims_and_tensors_symint(
       self.sparse_dim(),
       self.dense_dim() + 1,  // Add one dense dimension for real/imag
       new_sizes,

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -66,6 +66,7 @@
 #include <ATen/ops/unique_dim.h>
 #include <ATen/ops/values_native.h>
 #include <ATen/ops/view_as_real.h>
+#include <ATen/ops/view_as_real_native.h>
 #include <ATen/ops/zeros.h>
 #include <ATen/ops/ones.h>
 #endif

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -67,6 +67,8 @@
 #include <ATen/ops/values_native.h>
 #include <ATen/ops/view_as_real.h>
 #include <ATen/ops/view_as_real_native.h>
+#include <ATen/ops/view_as_complex.h>
+#include <ATen/ops/view_as_complex_native.h>
 #include <ATen/ops/zeros.h>
 #include <ATen/ops/ones.h>
 #endif
@@ -917,6 +919,31 @@ Tensor view_as_real_sparse(const Tensor& self) {
       new_sizes,
       self._indices(),
       real_values,
+      options,
+      self.is_coalesced()
+  );
+}
+
+Tensor view_as_complex_sparse(const Tensor& self) {
+  TORCH_CHECK(self.is_sparse() &&
+    (self.scalar_type() == kFloat || self.scalar_type() == kDouble || self.scalar_type() == kHalf),
+    "view_as_complex_sparse is only supported for half, float, and double sparse tensors");
+  TORCH_CHECK(self.dense_dim() > 0 && self.size(-1) == 2, "view_as_complex_sparse is only supported for sparse tensors with the last dim == 2 and dense_dim > 0.");
+
+  auto new_sizes = self.sym_sizes().vec();
+  // remove the last dimension. They will be combined to one complex dimension.
+  new_sizes.pop_back();
+
+  auto comlpex_values = at::view_as_complex(self._values());
+  const auto complex_type = c10::toComplexType(self.scalar_type());
+  auto options = self.options().dtype(complex_type);
+
+  return at::_sparse_coo_tensor_with_dims_and_tensors_symint(
+      self.sparse_dim(),
+      self.dense_dim() - 1,
+      new_sizes,
+      self._indices(),
+      comlpex_values,
       options,
       self.is_coalesced()
   );

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -900,8 +900,7 @@ Tensor _pin_memory_sparse_coo(const Tensor& self, std::optional<Device> device) 
 }
 
 Tensor view_as_real_sparse(const Tensor& self) {
-  TORCH_CHECK(self.is_sparse(), "view_as_real_sparse is only supported for sparse tensors");
-  TORCH_CHECK(self.is_complex(), "view_as_real_sparse is only supported for complex sparse tensors");
+  TORCH_CHECK(self.is_sparse() && self.is_complex(), "view_as_real_sparse is only supported for complex sparse tensors");
   TORCH_CHECK(!self.is_conj(), "view_as_real_sparse doesn't work on unresolved conjugated tensors.  To resolve the conjugate tensor so you can view it as real, use self.resolve_conj(); however, be warned that the resulting tensor will NOT alias the original.");
 
   auto new_sizes = self.sizes().vec();

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -5695,7 +5695,7 @@ class TestSparseAny(TestCase):
     @dtypes(torch.complex32, torch.complex64, torch.complex128)
     def test_view_as_real(self, device, dtype):
         x = torch.tensor(2 + 3j, dtype=dtype, device=device)
-        indices = torch.tensor([[0], [0]])
+        indices = torch.tensor([[0], [0]], device=device)
         size = torch.Size([3, 3])
         xs = torch.sparse_coo_tensor(indices, x, size, dtype=dtype)
         res = torch.view_as_real(xs).coalesce()

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -5691,6 +5691,19 @@ class TestSparseAny(TestCase):
                     RuntimeError, r"memory pinning of \w*indices \(=0\) must match memory pinning of values \(=1\)"):
                 generic_constructor(*args2, **kwargs)
 
+    @onlyNativeDeviceTypes
+    @dtypes(torch.complex32, torch.complex64, torch.complex128)
+    def test_view_as_real(self, device, dtype):
+        x = torch.tensor(2 + 3j, dtype=dtype, device=device)
+        indices = torch.tensor([[0], [0]])
+        size = torch.Size([3, 3])
+        xs = torch.sparse_coo_tensor(indices, x, size, dtype=dtype)
+        res = torch.view_as_real(xs).coalesce()
+
+        self.assertEqual(res.indices(), indices)
+        self.assertEqual(res.values()[0][0], x.real)
+        self.assertEqual(res.values()[0][1], x.imag)
+        self.assertEqual(res.shape, xs.shape + (2,))
 
 # e.g., TestSparseUnaryUfuncsCPU and TestSparseUnaryUfuncsCUDA
 instantiate_device_type_tests(TestSparseUnaryUfuncs, globals(), allow_mps=True, except_for='meta')

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -5707,6 +5707,32 @@ class TestSparseAny(TestCase):
                 continue
             self.assertEqual(res.to_dense(), torch.view_as_real(xs.to_dense()))
 
+    @onlyNativeDeviceTypes
+    @dtypes(torch.float16, torch.float32, torch.float64)
+    def test_view_as_complex(self, device, dtype):
+        for xs in self.generate_simple_inputs(torch.sparse_coo, device=device, dtype=dtype):
+            try:
+                res = torch.view_as_complex(xs)
+                self.assertEqual(res.layout, torch.sparse_coo)
+                self.assertEqual(res._indices(), xs._indices())
+                self.assertEqual(res.shape, xs.shape[:-1])
+                if dtype is torch.float16 and torch.device(device).type == "cpu":
+                    # ComplexHalf to_dense() is not supported on CPU.
+                    # check res values manually
+                    self.assertEqual(res._values().real, xs._values()[..., 0])
+                    self.assertEqual(res._values().imag, xs._values()[..., 1])
+                continue
+                self.assertEqual(res.to_dense(), torch.view_as_complex(xs.to_dense()))
+            except RuntimeError as e:
+                if xs.shape[-1] != 2 or xs.dense_dim() == 0:
+                    self.assertIn(
+                        "view_as_complex_sparse is only supported for sparse tensors with the last dim == 2 and dense_dim > 0.",
+                        str(e))
+                elif xs._values().stride()[-1] != 1:
+                    self.assertIn("Tensor must have a last dimension with stride 1", str(e))
+                else:
+                    raise
+
 # e.g., TestSparseUnaryUfuncsCPU and TestSparseUnaryUfuncsCUDA
 instantiate_device_type_tests(TestSparseUnaryUfuncs, globals(), allow_mps=True, except_for='meta')
 

--- a/test/test_view_ops.py
+++ b/test/test_view_ops.py
@@ -409,6 +409,21 @@ class TestViewOps(TestCase):
         self.assertTrue(self.is_view_of(x, res))
         self.assertEqual(res.shape, torch.Size([2]))
 
+        # sparse matrix
+        x = torch.tensor(2 + 3j, dtype=dtype, device=device)
+        indices = torch.tensor([[0], [0]], device=device)
+        size = torch.Size([3, 3])
+        xs = torch.sparse_coo_tensor(indices, x, size, dtype=dtype)
+        res = torch.view_as_real(xs).coalesce()
+        # self.is_view_of() does not work with sparse tensors
+        self.assertTrue(res._is_view())
+        self.assertIs(res._base, xs)
+        self.assertEqual(
+            res.values().untyped_storage().data_ptr(),
+            xs.values().untyped_storage().data_ptr(),
+        )
+        self.assertEqual(res.shape, xs.shape + (2,))
+
     @onlyNativeDeviceTypes
     @dtypes(*all_types_and_complex_and(torch.half, torch.bfloat16, torch.bool))
     @dtypesIfMPS(*all_mps_types_and(torch.bool))


### PR DESCRIPTION
Fixes #118153

Updated torch.view_as_real and torch.view_as_complex to work with sparse matrices. 

@janeyx99 