### PR TITLE
[WIP] separate wait on FSDP reduce scatters

### DIFF
--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -1561,6 +1561,7 @@ class PipelineScheduleMulti(_PipelineSchedule):
 
         # TODO: hack, now wait for reduce scatter events to finish
         for stage in self._stages:
+            print(f"waiting on reduce scatters for stage {stage.stage_index}")
             for event in stage.reduce_scatter_events:
                 torch.cuda.current_stream().wait_event(event)
 

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -1558,6 +1558,12 @@ class PipelineScheduleMulti(_PipelineSchedule):
         for stage in self._stages:
             if stage.is_last:
                 return self._merge_outputs(stage.output_chunks)
+
+        # TODO: hack, now wait for reduce scatter events to finish
+        for stage in self._stages:
+            for event in stage.reduce_scatter_events:
+                torch.cuda.current_stream().wait_event(event)
+
         # Does not contain the last stage
         return None
 

--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -667,7 +667,7 @@ class _PipelineStageBase(ABC):
 
                     for state in distributed_state._state_ctx.all_states:
                         if state._fsdp_param_group:
-                            state._fsdp_param_group.post_backward()
+                            state._fsdp_param_group.post_backward(reduce_scatter_events=self.reduce_scatter_events)
 
                     # it would be much better if pipelining backward invoked .backward so autograd hooks
                     # worked and modules like DDP/FSDP behaved as expected.  Working around this for the time being,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #164982
* #164976
* #164962
* #162016

Pass a `reduce_scatter_event` list into the FSDP `post_backward` to hold the reduce scatter events. Only wait on them AFTER the schedule has finished execution.

cc @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci