### PR TITLE
[DebugMode] output, tensor id annotations for DebugMode

### DIFF
--- a/test/distributed/tensor/debug/test_debug_mode.py
+++ b/test/distributed/tensor/debug/test_debug_mode.py
@@ -138,10 +138,10 @@ class TestDTensorDebugMode(TestCase):
         aten::clone(t$17: f32[8, 1]) -> t$25: f32[8, 1]
       aten::_to_copy(t$25: f32[8, 1], dtype=torch.float32, layout=torch.strided, device=cpu) -> t$26: f32[8, 1]
       redistribute_input(t$16: f32[8, 8], [R] -> [S(0)])
-        aten::split.Tensor(t$16: f32[8, 8], 1) -> ['t$27: f32[1, 8]', 't$28: f32[1, 8]', 't$29: f32[1, 8]', 't$30: f32[1, 8]', 't$31: f32[1, 8]', 't$32: f32[1, 8]', 't$33: f32[1, 8]', 't$34: f32[1, 8]']
-        aten::new_empty_strided(t$26: f32[8, 1], [8, 1], [1, 1], dtype=torch.float32, layout=torch.strided, device=cpu) -> t$35: f32[8, 1]
-        aten::copy_(t$35: f32[8, 1], t$26: f32[8, 1]) -> t$35: f32[8, 1]
-        aten::clone(t$27: f32[1, 8]) -> t$36: f32[1, 8]
+        aten::split.Tensor(t$16: f32[8, 8], 1) -> ['t$28: f32[1, 8]', 't$29: f32[1, 8]', 't$30: f32[1, 8]', 't$31: f32[1, 8]', 't$32: f32[1, 8]', 't$33: f32[1, 8]', 't$34: f32[1, 8]', 't$35: f32[1, 8]']
+        aten::new_empty_strided(t$26: f32[8, 1], [8, 1], [1, 1], dtype=torch.float32, layout=torch.strided, device=cpu) -> t$27: f32[8, 1]
+        aten::copy_(t$27: f32[8, 1], t$26: f32[8, 1]) -> t$27: f32[8, 1]
+        aten::clone(t$28: f32[1, 8]) -> t$36: f32[1, 8]
       aten::_to_copy(t$36: f32[1, 8], dtype=torch.float32, layout=torch.strided, device=cpu) -> t$37: f32[1, 8]
       aten::new_empty_strided(t$37: f32[1, 8], [1, 8], [8, 1], dtype=torch.float32, layout=torch.strided, device=cpu) -> t$38: f32[1, 8]
       aten::copy_(t$38: f32[1, 8], t$37: f32[1, 8]) -> t$38: f32[1, 8]"""

--- a/test/distributed/tensor/debug/test_debug_mode.py
+++ b/test/distributed/tensor/debug/test_debug_mode.py
@@ -107,8 +107,8 @@ class TestDTensorDebugMode(TestCase):
         aten::clone(t: f32[8, 1])
       aten::_to_copy(t: f32[8, 1], dtype=torch.float32, layout=torch.strided, device=cpu)
       redistribute_input(t: f32[8, 8], [R] -> [S(0)])
-        aten::new_empty_strided(t: f32[8, 1], [8, 1], [1, 1], dtype=torch.float32, layout=torch.strided, device=cpu)
         aten::split.Tensor(t: f32[8, 8], 1)
+        aten::new_empty_strided(t: f32[8, 1], [8, 1], [1, 1], dtype=torch.float32, layout=torch.strided, device=cpu)
         aten::copy_(t: f32[8, 1], t: f32[8, 1])
         aten::clone(t: f32[1, 8])
       aten::_to_copy(t: f32[1, 8], dtype=torch.float32, layout=torch.strided, device=cpu)
@@ -138,10 +138,10 @@ class TestDTensorDebugMode(TestCase):
         aten::clone(t$17: f32[8, 1]) -> t$25: f32[8, 1]
       aten::_to_copy(t$25: f32[8, 1], dtype=torch.float32, layout=torch.strided, device=cpu) -> t$26: f32[8, 1]
       redistribute_input(t$16: f32[8, 8], [R] -> [S(0)])
-        aten::new_empty_strided(t$26: f32[8, 1], [8, 1], [1, 1], dtype=torch.float32, layout=torch.strided, device=cpu) -> t$27: f32[8, 1]
-        aten::split.Tensor(t$16: f32[8, 8], 1) -> ['t$28: f32[1, 8]', 't$29: f32[1, 8]', 't$30: f32[1, 8]', 't$31: f32[1, 8]', 't$32: f32[1, 8]', 't$33: f32[1, 8]', 't$34: f32[1, 8]', 't$35: f32[1, 8]']
-        aten::copy_(t$27: f32[8, 1], t$26: f32[8, 1]) -> t$27: f32[8, 1]
-        aten::clone(t$28: f32[1, 8]) -> t$36: f32[1, 8]
+        aten::split.Tensor(t$16: f32[8, 8], 1) -> ['t$27: f32[1, 8]', 't$28: f32[1, 8]', 't$29: f32[1, 8]', 't$30: f32[1, 8]', 't$31: f32[1, 8]', 't$32: f32[1, 8]', 't$33: f32[1, 8]', 't$34: f32[1, 8]']
+        aten::new_empty_strided(t$26: f32[8, 1], [8, 1], [1, 1], dtype=torch.float32, layout=torch.strided, device=cpu) -> t$35: f32[8, 1]
+        aten::copy_(t$35: f32[8, 1], t$26: f32[8, 1]) -> t$35: f32[8, 1]
+        aten::clone(t$27: f32[1, 8]) -> t$36: f32[1, 8]
       aten::_to_copy(t$36: f32[1, 8], dtype=torch.float32, layout=torch.strided, device=cpu) -> t$37: f32[1, 8]
       aten::new_empty_strided(t$37: f32[1, 8], [1, 8], [8, 1], dtype=torch.float32, layout=torch.strided, device=cpu) -> t$38: f32[1, 8]
       aten::copy_(t$38: f32[1, 8], t$37: f32[1, 8]) -> t$38: f32[1, 8]"""

--- a/torch/utils/_debug_mode.py
+++ b/torch/utils/_debug_mode.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 import contextlib
+import weakref
 from typing import Optional
 
 import torch
@@ -10,7 +11,8 @@ from torch.utils._python_dispatch import (
     _get_current_dispatch_mode_stack,
     TorchDispatchMode,
 )
-from torch.utils._pytree import tree_map
+from torch.utils._pytree import tree_map, tree_map_only
+from torch.utils.weak import WeakIdRef
 
 
 __all__ = ["DebugMode", "get_active_debug_mode"]
@@ -30,25 +32,35 @@ def _stringify_placement(placement) -> str:
     return f"[{', '.join([str(p) for p in placement])}]"
 
 
-def _tensor_debug_string(tensor) -> str:
+def _tensor_debug_string(tensor, tensor_memo=None) -> str:
     """Convert tensor to debug string representation."""
     if isinstance(tensor, torch.distributed.tensor.DTensor):
         # omitted device mesh
-        return f"dt: {dtype_abbrs[tensor.dtype]}{_stringify_shape(tensor.shape)}{_stringify_placement(tensor.placements)}"
+        prefix = "dt"
+        base_str = f"{dtype_abbrs[tensor.dtype]}{_stringify_shape(tensor.shape)}{_stringify_placement(tensor.placements)}"
     elif isinstance(tensor, FakeTensor):
-        return f"ft: {dtype_abbrs[tensor.dtype]}{_stringify_shape(tensor.shape)}"
+        prefix = "ft"
+        base_str = f"{dtype_abbrs[tensor.dtype]}{_stringify_shape(tensor.shape)}"
     elif isinstance(tensor, torch.Tensor):
-        return f"t: {dtype_abbrs[tensor.dtype]}{_stringify_shape(tensor.shape)}"
+        prefix = "t"
+        base_str = f"{dtype_abbrs[tensor.dtype]}{_stringify_shape(tensor.shape)}"
     else:
         raise RuntimeError(f"Unsupported tensor type: {type(tensor)}")
 
+    tensor_id = (
+        f"${tensor_memo.get(tensor)}"
+        if tensor_memo and tensor in tensor_memo
+        else ""
+    )
+    return f"{prefix}{tensor_id}: {base_str}"
 
-def _arg_to_str(arg) -> str:
+
+def _arg_to_str(arg, tensor_memo=None) -> str:
     from torch.distributed.tensor._dtensor_spec import DTensorSpec
 
     def to_str(x):
         if isinstance(x, torch.Tensor):
-            return _tensor_debug_string(x)
+            return _tensor_debug_string(x, tensor_memo)
         elif isinstance(x, DTensorSpec):
             return _stringify_placement(x.placements)
         return x
@@ -57,17 +69,17 @@ def _arg_to_str(arg) -> str:
     return str(arg)
 
 
-def _op_to_str(op, *args, **kwargs) -> str:
+def _op_to_str(op, *args, output=None, tensor_memo=None, **kwargs) -> str:
     if op == REDISTRIBUTE_FUNC:
         assert len(args) == 3
-        _args = [_arg_to_str(arg) for arg in args]
+        _args = [_arg_to_str(arg, tensor_memo) for arg in args]
         args_str = f"{_args[0]}, {_args[1]} -> {_args[2]}"
     else:
-        args_str = ", ".join(_arg_to_str(arg) for arg in args)
+        args_str = ", ".join(_arg_to_str(arg, tensor_memo) for arg in args)
 
     if kwargs:
         kwargs_str = ", " + ", ".join(
-            f"{k}={_arg_to_str(v)}" for k, v in kwargs.items()
+            f"{k}={_arg_to_str(v, tensor_memo)}" for k, v in kwargs.items()
         )
     else:
         kwargs_str = ""
@@ -79,7 +91,12 @@ def _op_to_str(op, *args, **kwargs) -> str:
     else:
         op_name = str(op)
 
-    return f"{op_name}({args_str}{kwargs_str})"
+    # Add output annotation
+    output_str = ""
+    if output is not None:
+        output_str = f" -> {_arg_to_str(output, tensor_memo)}"
+
+    return f"{op_name}({args_str}{kwargs_str}){output_str}"
 
 
 class DebugMode(TorchDispatchMode):
@@ -101,8 +118,36 @@ class DebugMode(TorchDispatchMode):
         self.operators = []
         self.call_depth = 0
 
+        self._tensor_memo: dict[WeakIdRef, int] = {}
+        self._next_tensor_id = 0
+        self._output_info: dict[int, object] = {}
+
+    def _assign_tensor_id(self, tensor):
+        o = WeakIdRef(tensor)
+        weak_self = weakref.ref(self)
+
+        def del_memo():
+            self = weak_self()
+            if self is None:
+                return
+            self._tensor_memo.pop(o, None)
+
+        weakref.finalize(tensor, del_memo)
+        if tensor not in self._tensor_memo:
+            self._tensor_memo[tensor] = self._next_tensor_id
+            self._next_tensor_id += 1
+
+    def _track_tensor_ids(self, obj):
+        """Recursively assign IDs to all tensors in a pytree."""
+        tree_map_only(torch.Tensor, self._track_tensor_ids, obj)
+
+    def _track_op_output(self, op_index, result):
+        """Assign IDs to output tensors and store in output_info."""
+        self._track_tensor_ids(result)
+        self._output_info[op_index] = result
+
     # Without this override, running torch.compile under DebugMode
-    # will force torch.compile to always use the “eager” backend
+    # will force torch.compile to always use the "eager" backend
     # With this, DebugMode will not take effect on torch.compile
     @classmethod
     def ignore_compile_internals(cls):
@@ -112,20 +157,35 @@ class DebugMode(TorchDispatchMode):
         if kwargs is None:
             kwargs = {}
 
+        # assign ids to input tensors
+        self._track_tensor_ids((args, kwargs))
+
+        # Store operator before execution
+        op_index = len(self.operators)
         self.operators.append((func, args, kwargs, self.call_depth))
 
         try:
             self.call_depth += 1
-            return func(*args, **kwargs)
+            result = func(*args, **kwargs)
         finally:
             self.call_depth -= 1
+
+        # Track output
+        self._track_op_output(op_index, result)
+
+        return result
 
     def __torch_dispatch__(self, func, types, args=(), kwargs=None):
         if kwargs is None:
             kwargs = {}
 
+        # assign ids to input tensors
+        self._track_tensor_ids((args, kwargs))
+
         # Record the operation with its call depth
+        op_index = None
         if torch.distributed.tensor.DTensor in types:
+            op_index = len(self.operators)
             self.operators.append((func, args, kwargs, self.call_depth))
             return NotImplemented
         elif FakeTensor in types or isinstance(
@@ -133,18 +193,25 @@ class DebugMode(TorchDispatchMode):
         ):
             if self.record_faketensor:
                 if func != torch.ops.prim.device.default:
+                    op_index = len(self.operators)
                     self.operators.append((func, args, kwargs, self.call_depth + 1))
         elif len(types) == 0:
             if self.record_realtensor:
+                op_index = len(self.operators)
                 self.operators.append((func, args, kwargs, self.call_depth + 1))
 
         result = func(*args, **kwargs)
+        if op_index is not None:  # we logged something, track index -> output
+            self._track_op_output(op_index, result)
 
         return result
 
     def __enter__(self):
         self.operators = []
         self.call_depth = 0
+        self._tensor_memo = {}
+        self._next_tensor_id = 0
+        self._output_info = {}
 
         if self.record_torchfunction:
             torch._C._push_on_torch_function_stack(self)
@@ -173,12 +240,13 @@ class DebugMode(TorchDispatchMode):
         finally:
             self.call_depth -= 1
 
-    def debug_string(self) -> str:
+    def debug_string(self, show_ids: bool = False) -> str:
         with torch._C.DisableTorchFunction():
             result = ""
+            tensor_memo = self._tensor_memo if show_ids else None
             result += "\n".join(
-                "  " + "  " * depth + _op_to_str(op, *args, **kwargs)
-                for op, args, kwargs, depth in self.operators
+                "  " + "  " * depth + _op_to_str(op, *args, output=self._output_info.get(idx), tensor_memo=tensor_memo, **kwargs)
+                for idx, (op, args, kwargs, depth) in enumerate(self.operators)
             )
         return result
 

--- a/torch/utils/_debug_mode.py
+++ b/torch/utils/_debug_mode.py
@@ -134,13 +134,15 @@ class DebugMode(TorchDispatchMode):
             self._next_tensor_id += 1
 
     def _track_tensor_ids(self, obj):
-        """Recursively assign IDs to all tensors in a pytree."""
-        tree_map_only(torch.Tensor, self._assign_tensor_id, obj)
+        """Recursively assign IDs to all tensors in a pytree"""
+        with torch._C.DisableTorchFunction():
+            tree_map_only(torch.Tensor, self._assign_tensor_id, obj)
 
     def _track_op_output(self, op_index, result):
-        """Assign IDs to output tensors and store in output_info."""
-        self._track_tensor_ids(result)
-        self._output_info[op_index] = result
+        """Assign IDs to output tensors and store in output_info"""
+        with torch._C.DisableTorchFunction():
+            self._track_tensor_ids(result)
+            self._output_info[op_index] = result
 
     # Without this override, running torch.compile under DebugMode
     # will force torch.compile to always use the "eager" backend

--- a/torch/utils/_debug_mode.py
+++ b/torch/utils/_debug_mode.py
@@ -47,11 +47,7 @@ def _tensor_debug_string(tensor, tensor_memo=None) -> str:
     else:
         raise RuntimeError(f"Unsupported tensor type: {type(tensor)}")
 
-    tensor_id = (
-        f"${tensor_memo.get(tensor)}"
-        if tensor_memo and tensor in tensor_memo
-        else ""
-    )
+    tensor_id = f"${tensor_memo.get(tensor)}" if tensor_memo and tensor in tensor_memo else ""
     return f"{prefix}{tensor_id}: {base_str}"
 
 
@@ -240,12 +236,19 @@ class DebugMode(TorchDispatchMode):
         finally:
             self.call_depth -= 1
 
-    def debug_string(self, show_ids: bool = False) -> str:
+    def debug_string(self, show_outputs: bool = False, show_ids: bool = False) -> str:
         with torch._C.DisableTorchFunction():
             result = ""
             tensor_memo = self._tensor_memo if show_ids else None
             result += "\n".join(
-                "  " + "  " * depth + _op_to_str(op, *args, output=self._output_info.get(idx), tensor_memo=tensor_memo, **kwargs)
+                "  "
+                + "  " * depth
+                + _op_to_str(
+                    op,
+                    *args,
+                    output=self._output_info.get(idx) if show_outputs else None,
+                    tensor_memo=tensor_memo, **kwargs
+                )
                 for idx, (op, args, kwargs, depth) in enumerate(self.operators)
             )
         return result

--- a/torch/utils/_debug_mode.py
+++ b/torch/utils/_debug_mode.py
@@ -139,7 +139,7 @@ class DebugMode(TorchDispatchMode):
 
     def _track_tensor_ids(self, obj):
         """Recursively assign IDs to all tensors in a pytree."""
-        tree_map_only(torch.Tensor, self._track_tensor_ids, obj)
+        tree_map_only(torch.Tensor, self._assign_tensor_id, obj)
 
     def _track_op_output(self, op_index, result):
         """Assign IDs to output tensors and store in output_info."""


### PR DESCRIPTION
Adds optional tensor id, output info annotations to DebugMode.

Example output for `test_debug_mode_backward`, with both enabled:
```
  <method 'add' of 'torch._C.TensorBase' objects>(dt$0: f32[8, 8][S(0)], dt$1: f32[8, 8][S(1)]) -> dt$8: f32[8, 8][S(0)]
    aten::add.Tensor(dt$0: f32[8, 8][S(0)], dt$1: f32[8, 8][S(1)])
      redistribute_input(1, [S(1)] -> [S(0)])
        redistribute_input(t$4: f32[8, 1], [S(1)] -> [S(0)])
          _dtensor::shard_dim_alltoall(t$4: f32[8, 1], 1, 0, 0) -> t$5: f32[1, 8]
      aten::add.Tensor(t$6: f32[1, 8], t$5: f32[1, 8]) -> t$7: f32[1, 8]
  <method 'sum' of 'torch._C.TensorBase' objects>(dt$8: f32[8, 8][S(0)]) -> dt$11: f32[][P]
    aten::sum(dt$8: f32[8, 8][S(0)])
      aten::sum(t$7: f32[1, 8]) -> t$10: f32[]
  torch._tensor.backward(dt$11: f32[][P], gradient=None, retain_graph=None, create_graph=False, inputs=None)
    aten::ones_like(dt$11: f32[][P], pin_memory=False, memory_format=torch.preserve_format)
      aten::ones_like(t$10: f32[], pin_memory=False, memory_format=torch.preserve_format) -> t$13: f32[]
    aten::expand(dt$14: f32[][R], [8, 8])
      aten::expand(t$13: f32[], [8, 8]) -> t$16: f32[8, 8]
      redistribute_input(t$16: f32[8, 8], [R] -> [S(1)])
        aten::split.Tensor(t$16: f32[8, 8], 1, 1) -> ['t$17: f32[8, 1]', 't$18: f32[8, 1]', 't$19: f32[8, 1]', 't$20: f32[8, 1]', 't$21: f32[8, 1]', 't$22: f32[8, 1]', 't$23: f32[8, 1]', 't$24: f32[8, 1]']
        aten::clone(t$17: f32[8, 1]) -> t$25: f32[8, 1]
      aten::_to_copy(t$25: f32[8, 1], dtype=torch.float32, layout=torch.strided, device=cpu) -> t$26: f32[8, 1]
      redistribute_input(t$16: f32[8, 8], [R] -> [S(0)])
        aten::split.Tensor(t$16: f32[8, 8], 1) -> ['t$28: f32[1, 8]', 't$29: f32[1, 8]', 't$30: f32[1, 8]', 't$31: f32[1, 8]', 't$32: f32[1, 8]', 't$33: f32[1, 8]', 't$34: f32[1, 8]', 't$35: f32[1, 8]']
        aten::new_empty_strided(t$26: f32[8, 1], [8, 1], [1, 1], dtype=torch.float32, layout=torch.strided, device=cpu) -> t$27: f32[8, 1]
        aten::copy_(t$27: f32[8, 1], t$26: f32[8, 1]) -> t$27: f32[8, 1]
        aten::clone(t$28: f32[1, 8]) -> t$36: f32[1, 8]
      aten::_to_copy(t$36: f32[1, 8], dtype=torch.float32, layout=torch.strided, device=cpu) -> t$37: f32[1, 8]
      aten::new_empty_strided(t$37: f32[1, 8], [1, 8], [8, 1], dtype=torch.float32, layout=torch.strided, device=cpu) -> t$38: f32[1, 8]
      aten::copy_(t$38: f32[1, 8], t$37: f32[1, 8]) -> t$38: f32[1, 8]
```

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci