### PR TITLE
[DeviceMesh] Add a warning for slicing flattened dim from root mesh and types for _get_slice_mesh_layout

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -894,11 +894,9 @@ class TestDeviceMeshGetItem(DTensorTestBase):
         self.assertEqual(dp_cp_mesh.mesh.flatten(), flattened_dp_cp_mesh.mesh)
         self.assertEqual(flattened_dp_cp_mesh.mesh_dim_names[0], "dp_cp")
         self.assertEqual(flattened_dp_cp_mesh.get_group().group_desc, "mesh_dp_cp")
-        root_mesh = _mesh_resources.get_root_mesh(dp_cp_mesh)
+        root_mesh = dp_cp_mesh._get_root_mesh()
         self.assertEqual(root_mesh, mesh_3d)
-        flatten_mesh_layout = _mesh_resources.root_to_flatten_mapping[root_mesh][
-            "dp_cp"
-        ]._layout
+        flatten_mesh_layout = root_mesh._flatten_mapping["dp_cp"]._layout
         self.assertEqual(flatten_mesh_layout, flattened_dp_cp_mesh._layout)
         self.assertEqual(
             flattened_dp_cp_mesh._layout.global_ranks(8),
@@ -916,11 +914,9 @@ class TestDeviceMeshGetItem(DTensorTestBase):
         flattened_dp_tp_mesh = dp_tp_mesh._flatten()
         self.assertEqual(dp_tp_mesh.mesh.flatten(), flattened_dp_tp_mesh.mesh)
         self.assertEqual(flattened_dp_tp_mesh.mesh_dim_names[0], "dp_tp")
-        root_mesh = _mesh_resources.get_root_mesh(dp_tp_mesh)
+        root_mesh = dp_tp_mesh._get_root_mesh()
         self.assertEqual(root_mesh, mesh_3d)
-        flatten_mesh_root_layout = _mesh_resources.root_to_flatten_mapping[root_mesh][
-            "dp_tp"
-        ]._layout
+        flatten_mesh_root_layout = root_mesh._flatten_mapping["dp_tp"]._layout
         self.assertEqual(flatten_mesh_root_layout, flattened_dp_tp_mesh._layout)
         self.assertEqual(
             flattened_dp_tp_mesh._layout.global_ranks(8),
@@ -964,7 +960,7 @@ class TestDeviceMeshGetItem(DTensorTestBase):
         # check flattened mesh dim names is correct
         self.assertEqual(dp_cp_mesh.mesh_dim_names, ("dp_cp",))
         # check flattened mesh dependency
-        self.assertEqual(_mesh_resources.get_root_mesh(dp_cp_mesh), mesh_4d)
+        self.assertEqual(dp_cp_mesh._get_root_mesh(), mesh_4d)
 
     @with_comms
     def test_reconstruct_mesh_with_flatten_dim(self):
@@ -1014,12 +1010,19 @@ class TestMeshEnv(DTensorTestBase):
         dp_mesh = mesh_3d["dp"]
         cp_mesh = mesh_3d["cp"]
         tp_mesh = mesh_3d["tp"]
+        # Test BC case is still working
         self.assertEqual(_mesh_resources.get_root_mesh(dp_cp_mesh), mesh_3d)
         self.assertEqual(_mesh_resources.get_root_mesh(dp_tp_mesh), mesh_3d)
         self.assertEqual(_mesh_resources.get_root_mesh(cp_tp_mesh), mesh_3d)
         self.assertEqual(_mesh_resources.get_root_mesh(dp_mesh), mesh_3d)
         self.assertEqual(_mesh_resources.get_root_mesh(cp_mesh), mesh_3d)
         self.assertEqual(_mesh_resources.get_root_mesh(tp_mesh), mesh_3d)
+        self.assertEqual(dp_cp_mesh._get_root_mesh(), mesh_3d)
+        self.assertEqual(dp_tp_mesh._get_root_mesh(), mesh_3d)
+        self.assertEqual(cp_tp_mesh._get_root_mesh(), mesh_3d)
+        self.assertEqual(dp_mesh._get_root_mesh(), mesh_3d)
+        self.assertEqual(cp_mesh._get_root_mesh(), mesh_3d)
+        self.assertEqual(tp_mesh._get_root_mesh(), mesh_3d)
 
     @with_comms
     def test_get_root_mesh_dim_exist(self):
@@ -1029,15 +1032,15 @@ class TestMeshEnv(DTensorTestBase):
             self.device_type, mesh_shape, mesh_dim_names=mesh_dim_names
         )
 
-        self.assertEqual(_mesh_resources.get_root_mesh_dim(mesh_2d["DP"]), 0)
-        self.assertEqual(_mesh_resources.get_root_mesh_dim(mesh_2d["TP"]), 1)
+        self.assertEqual(mesh_2d["DP"].get_root_mesh_dim(), 0)
+        self.assertEqual(mesh_2d["TP"].get_root_mesh_dim(), 1)
 
     @with_comms
     def test_get_root_mesh_dim_not_exist(self):
         mesh_shape = (self.world_size,)
         mesh = init_device_mesh(self.device_type, mesh_shape)
 
-        self.assertEqual(_mesh_resources.get_root_mesh_dim(mesh), None)
+        self.assertEqual(mesh.get_root_mesh_dim(), None)
 
     @with_comms
     def test_get_mesh_dim_by_name(self):
@@ -1047,8 +1050,8 @@ class TestMeshEnv(DTensorTestBase):
             self.device_type, mesh_shape, mesh_dim_names=mesh_dim_names
         )
 
-        self.assertEqual(_mesh_resources.get_mesh_dim_by_name(mesh_2d, "DP"), 0)
-        self.assertEqual(_mesh_resources.get_mesh_dim_by_name(mesh_2d, "TP"), 1)
+        self.assertEqual(mesh_2d.get_mesh_dim_by_name("DP"), 0)
+        self.assertEqual(mesh_2d.get_mesh_dim_by_name("TP"), 1)
 
     @with_comms
     def test_get_all_submeshes(self):
@@ -1057,7 +1060,7 @@ class TestMeshEnv(DTensorTestBase):
             (2, 4),
             mesh_dim_names=("replicate", "shard"),
         )
-        all_submeshes = _mesh_resources._get_all_submeshes(mesh_2d, "replicate")
+        all_submeshes = mesh_2d._get_all_submeshes("replicate")
         self.assertEqual(len(all_submeshes), 4)
         self.assertEqual(
             all(submesh.mesh.numel() == 2 for submesh in all_submeshes), True

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -894,9 +894,11 @@ class TestDeviceMeshGetItem(DTensorTestBase):
         self.assertEqual(dp_cp_mesh.mesh.flatten(), flattened_dp_cp_mesh.mesh)
         self.assertEqual(flattened_dp_cp_mesh.mesh_dim_names[0], "dp_cp")
         self.assertEqual(flattened_dp_cp_mesh.get_group().group_desc, "mesh_dp_cp")
-        root_mesh = dp_cp_mesh._get_root_mesh()
+        root_mesh = _mesh_resources.get_root_mesh(dp_cp_mesh)
         self.assertEqual(root_mesh, mesh_3d)
-        flatten_mesh_layout = root_mesh._flatten_mapping["dp_cp"]._layout
+        flatten_mesh_layout = _mesh_resources.root_to_flatten_mapping[root_mesh][
+            "dp_cp"
+        ]._layout
         self.assertEqual(flatten_mesh_layout, flattened_dp_cp_mesh._layout)
         self.assertEqual(
             flattened_dp_cp_mesh._layout.global_ranks(8),
@@ -914,9 +916,11 @@ class TestDeviceMeshGetItem(DTensorTestBase):
         flattened_dp_tp_mesh = dp_tp_mesh._flatten()
         self.assertEqual(dp_tp_mesh.mesh.flatten(), flattened_dp_tp_mesh.mesh)
         self.assertEqual(flattened_dp_tp_mesh.mesh_dim_names[0], "dp_tp")
-        root_mesh = dp_tp_mesh._get_root_mesh()
+        root_mesh = _mesh_resources.get_root_mesh(dp_tp_mesh)
         self.assertEqual(root_mesh, mesh_3d)
-        flatten_mesh_root_layout = root_mesh._flatten_mapping["dp_tp"]._layout
+        flatten_mesh_root_layout = _mesh_resources.root_to_flatten_mapping[root_mesh][
+            "dp_tp"
+        ]._layout
         self.assertEqual(flatten_mesh_root_layout, flattened_dp_tp_mesh._layout)
         self.assertEqual(
             flattened_dp_tp_mesh._layout.global_ranks(8),
@@ -960,7 +964,7 @@ class TestDeviceMeshGetItem(DTensorTestBase):
         # check flattened mesh dim names is correct
         self.assertEqual(dp_cp_mesh.mesh_dim_names, ("dp_cp",))
         # check flattened mesh dependency
-        self.assertEqual(dp_cp_mesh._get_root_mesh(), mesh_4d)
+        self.assertEqual(_mesh_resources.get_root_mesh(dp_cp_mesh), mesh_4d)
 
     @with_comms
     def test_reconstruct_mesh_with_flatten_dim(self):
@@ -1010,19 +1014,12 @@ class TestMeshEnv(DTensorTestBase):
         dp_mesh = mesh_3d["dp"]
         cp_mesh = mesh_3d["cp"]
         tp_mesh = mesh_3d["tp"]
-        # Test BC case is still working
         self.assertEqual(_mesh_resources.get_root_mesh(dp_cp_mesh), mesh_3d)
         self.assertEqual(_mesh_resources.get_root_mesh(dp_tp_mesh), mesh_3d)
         self.assertEqual(_mesh_resources.get_root_mesh(cp_tp_mesh), mesh_3d)
         self.assertEqual(_mesh_resources.get_root_mesh(dp_mesh), mesh_3d)
         self.assertEqual(_mesh_resources.get_root_mesh(cp_mesh), mesh_3d)
         self.assertEqual(_mesh_resources.get_root_mesh(tp_mesh), mesh_3d)
-        self.assertEqual(dp_cp_mesh._get_root_mesh(), mesh_3d)
-        self.assertEqual(dp_tp_mesh._get_root_mesh(), mesh_3d)
-        self.assertEqual(cp_tp_mesh._get_root_mesh(), mesh_3d)
-        self.assertEqual(dp_mesh._get_root_mesh(), mesh_3d)
-        self.assertEqual(cp_mesh._get_root_mesh(), mesh_3d)
-        self.assertEqual(tp_mesh._get_root_mesh(), mesh_3d)
 
     @with_comms
     def test_get_root_mesh_dim_exist(self):
@@ -1032,15 +1029,15 @@ class TestMeshEnv(DTensorTestBase):
             self.device_type, mesh_shape, mesh_dim_names=mesh_dim_names
         )
 
-        self.assertEqual(mesh_2d["DP"].get_root_mesh_dim(), 0)
-        self.assertEqual(mesh_2d["TP"].get_root_mesh_dim(), 1)
+        self.assertEqual(_mesh_resources.get_root_mesh_dim(mesh_2d["DP"]), 0)
+        self.assertEqual(_mesh_resources.get_root_mesh_dim(mesh_2d["TP"]), 1)
 
     @with_comms
     def test_get_root_mesh_dim_not_exist(self):
         mesh_shape = (self.world_size,)
         mesh = init_device_mesh(self.device_type, mesh_shape)
 
-        self.assertEqual(mesh.get_root_mesh_dim(), None)
+        self.assertEqual(_mesh_resources.get_root_mesh_dim(mesh), None)
 
     @with_comms
     def test_get_mesh_dim_by_name(self):
@@ -1050,8 +1047,8 @@ class TestMeshEnv(DTensorTestBase):
             self.device_type, mesh_shape, mesh_dim_names=mesh_dim_names
         )
 
-        self.assertEqual(mesh_2d.get_mesh_dim_by_name("DP"), 0)
-        self.assertEqual(mesh_2d.get_mesh_dim_by_name("TP"), 1)
+        self.assertEqual(_mesh_resources.get_mesh_dim_by_name(mesh_2d, "DP"), 0)
+        self.assertEqual(_mesh_resources.get_mesh_dim_by_name(mesh_2d, "TP"), 1)
 
     @with_comms
     def test_get_all_submeshes(self):
@@ -1060,7 +1057,7 @@ class TestMeshEnv(DTensorTestBase):
             (2, 4),
             mesh_dim_names=("replicate", "shard"),
         )
-        all_submeshes = mesh_2d._get_all_submeshes("replicate")
+        all_submeshes = _mesh_resources._get_all_submeshes(mesh_2d, "replicate")
         self.assertEqual(len(all_submeshes), 4)
         self.assertEqual(
             all(submesh.mesh.numel() == 2 for submesh in all_submeshes), True

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -72,145 +72,23 @@ else:
     class _MeshEnv(threading.local):
         def __init__(self) -> None:
             self.mesh_stack: list[DeviceMesh] = []
-            # TODO: Move the bookkeeping maps from _MeshEnv to DeviceMesh.
-            self.child_to_root_mapping: dict[DeviceMesh, DeviceMesh] = {}
-            # Record flatten mesh name to its flattened mesh in root mesh.
-            self.root_to_flatten_mapping: dict[DeviceMesh, dict[str, DeviceMesh]] = {}
 
         def get_current_mesh(self) -> "DeviceMesh":
             if len(self.mesh_stack) == 0:
                 raise RuntimeError("No device mesh is currently active!")
             return self.mesh_stack[-1]
 
-        def create_sub_mesh(
-            self,
-            device_mesh: "DeviceMesh",
-            layout: _MeshLayout,
-            submesh_dim_names: tuple[str, ...],
-        ) -> "DeviceMesh":
-            root_mesh = self.get_root_mesh(device_mesh)
-            slice_dim_group_name = []
-            for name in submesh_dim_names:
-                if name in not_none(device_mesh.mesh_dim_names):
-                    slice_dim_group_name.append(
-                        device_mesh._dim_group_names[  # type: ignore[has-type]
-                            not_none(device_mesh.mesh_dim_names).index(name)
-                        ]
-                    )
-                else:
-                    # If device_mesh is not root_mesh, we already throw error in _get_slice_mesh_layout
-                    # Since we will deprecate the slicing of flattened dim_name from root mesh soon,
-                    # we don't want to optimize the code furthermore.
-                    flatten_mesh = self.root_to_flatten_mapping[device_mesh][name]
-                    slice_dim_group_name.append(
-                        flatten_mesh._dim_group_names[  # type: ignore[has-type]
-                            not_none(flatten_mesh.mesh_dim_names).index(name)
-                        ]
-                    )
-            cur_rank = device_mesh.get_rank()
-            pg_ranks_by_dim = layout.remap_to_tensor(
-                root_mesh.mesh,
-            )
-            res_submesh = DeviceMesh._create_mesh_from_ranks(
-                device_mesh.device_type,
-                pg_ranks_by_dim,
-                cur_rank,
-                submesh_dim_names,
-                _init_backend=False,
-                _layout=layout,
-            )
-            res_submesh._dim_group_names = slice_dim_group_name
-            self.child_to_root_mapping[res_submesh] = root_mesh
-            return res_submesh
-
-        def create_flatten_mesh(
-            self,
-            device_mesh: "DeviceMesh",
-            mesh_dim_name: Optional[str] = None,
-            backend_override: BackendConfig = (None, None),
-        ) -> "DeviceMesh":
-            root_mesh = self.get_root_mesh(device_mesh)
-
-            if not mesh_dim_name:
-                mesh_dim_name = "_".join(not_none(device_mesh.mesh_dim_names))
-
-            # Flatten a 1D device mesh into its original mesh_dim_name will return itself.
-            if device_mesh.ndim == 1 and mesh_dim_name in not_none(
-                device_mesh.mesh_dim_names
-            ):
-                return device_mesh
-
-            # Check whether the mesh_dim_name for flattened mesh is valid.
-            invalid_dim_names = not_none(root_mesh.mesh_dim_names)
-            if mesh_dim_name in invalid_dim_names:
-                raise ValueError(
-                    f"{mesh_dim_name} already exists for submesh of the {root_mesh}. ",
-                    f"The mesh_dim_names of submesh and flattened mesh are {invalid_dim_names}. "
-                    f"Please specify another valid mesh_dim_name.",
-                )
-
-            flattened_mesh_layout = device_mesh._layout.coalesce()
-            # Quick return if the flatten mesh has been created before.
-            if (
-                root_mesh in self.root_to_flatten_mapping
-                and mesh_dim_name in self.root_to_flatten_mapping[root_mesh]
-            ):
-                if (
-                    flattened_mesh_layout
-                    == self.root_to_flatten_mapping[root_mesh][mesh_dim_name]._layout
-                ):
-                    return self.root_to_flatten_mapping[root_mesh][mesh_dim_name]
-                else:
-                    raise ValueError(
-                        f"Flatten mesh with mesh_dim_name {mesh_dim_name} has been created before, "
-                        f"Please specify another valid mesh_dim_name."
-                    )
-
-            cur_rank = root_mesh.get_rank()
-            # Due to the limitation of ProcessGroup api, we need to start from root mesh so that all ranks call the
-            # new_group api to avoid potential hang.
-            pg_ranks_by_dim = flattened_mesh_layout.remap_to_tensor(
-                root_mesh.mesh,
-            )
-            res_flattened_mesh = DeviceMesh._create_mesh_from_ranks(
-                root_mesh.device_type,
-                pg_ranks_by_dim.flatten(
-                    start_dim=1
-                ),  # this is needed for flatten non-contiguous mesh dims.
-                cur_rank,
-                (mesh_dim_name,),
-                (backend_override,),
-                _layout=device_mesh._layout.coalesce(),
-            )
-            self.child_to_root_mapping[res_flattened_mesh] = root_mesh
-            self.root_to_flatten_mapping.setdefault(root_mesh, {})[mesh_dim_name] = (
-                res_flattened_mesh
-            )
-
-            return res_flattened_mesh
-
+        # TODO: to remove it once we move all use cases into new API.
         def get_root_mesh(self, device_mesh: "DeviceMesh") -> "DeviceMesh":
             # If a mesh could not be found in the child_to_root_mapping, it is a root mesh itself.
             # A root mesh is not created through slicing.
             # We considers the root mesh of a root mesh is itself.
-            root_mesh = self.child_to_root_mapping.get(device_mesh, None)
-            return device_mesh if not root_mesh else root_mesh
-
-        def get_root_mesh_dim(self, device_mesh: "DeviceMesh") -> Optional[int]:
-            """
-            Returns the index of the mesh dim in the root mesh.
-            The device_mesh passed in needs to be sliced out from the root mesh
-            or submesh of the root mesh.
-            """
-            root_mesh = self.get_root_mesh(device_mesh)
-            child_mesh_dim_names = device_mesh.mesh_dim_names
-            if root_mesh and child_mesh_dim_names:
-                assert len(child_mesh_dim_names) == 1, (
-                    "The submesh can only be a 1D mesh."
-                )
-                child_mesh_dim_name = child_mesh_dim_names[0]
-                return self.get_mesh_dim_by_name(root_mesh, child_mesh_dim_name)
-            return None
+            # We keep this function for backward compatibility.
+            warnings.warn(
+                "This _get_all_submeshes API will be deprecated soon."
+                "Please use `_get_all_submeshes` inside DeviceMesh instead."
+            )
+            return device_mesh._get_root_mesh()
 
         @staticmethod
         def num_devices_per_host(device_type: str) -> int:
@@ -222,144 +100,16 @@ else:
             # homogeneous hardware for now
             return get_world_size() // _MeshEnv.num_devices_per_host(device_type)
 
-        def get_mesh_dim_by_name(
-            self, device_mesh: "DeviceMesh", mesh_dim_name: str
-        ) -> int:
-            if (
-                device_mesh.mesh_dim_names is None
-                or len(device_mesh.mesh_dim_names) == 0
-            ):
-                raise KeyError(
-                    "No `mesh_dim_names` found.",
-                )
-            if mesh_dim_name not in device_mesh.mesh_dim_names:
-                raise KeyError(
-                    f"Mesh dimension '{mesh_dim_name}' does not exist.",
-                    f"Available mesh dimensions are: mesh_dim_names={device_mesh.mesh_dim_names}",
-                )
-            return not_none(device_mesh.mesh_dim_names.index(mesh_dim_name))
-
-        def _get_slice_mesh_layout(
-            self, device_mesh: "DeviceMesh", mesh_dim_names: tuple[str, ...]
-        ) -> _MeshLayout:
-            """
-            Validate whether the mesh_dim_names is valid for slicing the given device_mesh.
-            If valid, return dim indexes of the slice mesh in the device mesh.
-            """
-            slice_from_root = True
-            if device_mesh != self.get_root_mesh(device_mesh):
-                warnings.warn(
-                    "You are attempting to slice a submesh from another submesh. While we support this operation, "
-                    "it is users' responsibility to ensure that the submesh is consistently sliced across all ranks. "
-                    "If not, this may result in some ranks receiving the submesh while others encounter errors."
-                )
-                slice_from_root = False
-
-            # The slice mesh_dim_names should consist either the device_mesh's mesh_dim_names
-            # or its flattened mesh's mesh_dim_names if it's root_mesh.
-            flatten_name_to_root_layout = (
-                {
-                    key: mesh._layout
-                    for key, mesh in self.root_to_flatten_mapping.setdefault(
-                        device_mesh, {}
-                    ).items()
-                }
-                if slice_from_root
-                else {}
-            )
-            valid_mesh_dim_names = [
-                *not_none(device_mesh.mesh_dim_names),
-                *flatten_name_to_root_layout,
-            ]
-
-            if not all(
-                mesh_dim_name in valid_mesh_dim_names
-                for mesh_dim_name in mesh_dim_names
-            ):
-                raise KeyError(
-                    f"Invalid mesh_dim_names {mesh_dim_names} specified. "
-                    f"Valid mesh_dim_names are {valid_mesh_dim_names}."
-                )
-
-            layout_sliced = []
-            for name in mesh_dim_names:
-                if name in not_none(device_mesh.mesh_dim_names):
-                    layout_sliced.append(
-                        device_mesh._layout[
-                            not_none(device_mesh.mesh_dim_names).index(name)
-                        ]
-                    )
-                elif name in flatten_name_to_root_layout:
-                    warnings.warn(
-                        "Slicing a flattened dim from root mesh will be deprecated soon. "
-                        "Users need to use and bookkeep the flattened mesh directly. "
-                    )
-                    layout_sliced.append(flatten_name_to_root_layout[name])
-
-            sliced_sizes = tuple(l.sizes for l in layout_sliced)
-            sliced_strides = tuple(l.strides for l in layout_sliced)
-
-            # The check below is from DeviceMesh's implementation before adopting CuTe layout for internal
-            # bookkeeping and it can be removed but we need to define what is the expected behavior.
-            # TODO: Remove the below check and define the expected behavior.
-            # Validate the order of the slice mesh dim indices.
-            # This needs to be in ascending order.
-            pre_stride = -1
-            for stride in reversed(sliced_strides):
-                # Note that with CuTe layout, we can support slicing flattened non-contiguous mesh dims with no problem.
-                # But this will make this behavior complicated so we decided to not support it for now.
-                if not is_int(stride):
-                    raise NotImplementedError(
-                        "Currently, this only allows slicing out a contiguous flattened dim."
-                    )
-                if stride < pre_stride:
-                    raise KeyError(
-                        f"Invalid mesh_dim_names {mesh_dim_names} specified. "
-                        "Mesh dim indices should be in ascending order."
-                    )
-                pre_stride = stride
-
-            # When users sliced dim_names outside from current mesh, we will check whether
-            # there is layout overlap.
-            # TODO: Eventually we will just directly throw error here because
-            # we will deprecate the slicing of flattened dim_name from root mesh.
-            layout_sliced = _MeshLayout(sliced_sizes, sliced_strides)
-            if not layout_sliced.check_non_overlap():
-                raise RuntimeError(
-                    f"Slicing overlapping dim_names {mesh_dim_names} is not allowed."
-                )
-
-            return layout_sliced
-
-        # TODO: to make this use case by other components public API in the future.
+        # TODO: to remove it once we move all use cases into new API.
+        # We keep this API for backward compatibility.
         def _get_all_submeshes(
             self, device_mesh: "DeviceMesh", mesh_dim_name: str
         ) -> list["DeviceMesh"]:
-            """
-            Return all the submeshes of a given mesh dimension of the device mesh.
-            """
-            mesh_dim = self.get_mesh_dim_by_name(device_mesh, mesh_dim_name)
-            layout = device_mesh._layout[mesh_dim]
-            pg_ranks_by_dim = layout.remap_to_tensor(
-                device_mesh.mesh,
+            warnings.warn(
+                "This _get_all_submeshes API will be deprecated soon."
+                "Please use `_get_all_submeshes` inside DeviceMesh instead."
             )
-            cur_rank = device_mesh.get_rank()
-            res_submeshes = []
-            for mesh_1d in pg_ranks_by_dim:
-                submesh = DeviceMesh(
-                    device_mesh.device_type,
-                    mesh_1d,
-                    mesh_dim_names=(mesh_dim_name,),
-                    _init_backend=False,
-                )
-                submesh._dim_group_names = (  # type: ignore[has-type]
-                    [device_mesh._dim_group_names[mesh_dim]]  # type: ignore[has-type]
-                    if cur_rank in mesh_1d
-                    else []
-                )
-                res_submeshes.append(submesh)
-
-            return res_submeshes
+            return device_mesh._get_all_submeshes(mesh_dim_name)
 
     _mesh_resources: _MeshEnv = _MeshEnv()
 
@@ -424,6 +174,9 @@ else:
         _mesh: torch.Tensor
         _mesh_dim_names: Optional[tuple[str, ...]]
         _layout: _MeshLayout
+        _root_mesh: Optional["DeviceMesh"] = None
+        # Record flatten mesh name to its flattened mesh in root mesh.
+        _flatten_mapping: dict[str, "DeviceMesh"] = {}
 
         def __init__(
             self,
@@ -668,6 +421,9 @@ else:
                             dim_group_names.append(dim_group.group_name)  # type: ignore[union-attr]
             self._dim_group_names = dim_group_names
 
+        def _get_root_mesh(self) -> "DeviceMesh":
+            return self._root_mesh if self._root_mesh else self
+
         def __enter__(self) -> "DeviceMesh":
             # set this mesh as the current mesh in mesh env
             _mesh_resources.mesh_stack.append(self)
@@ -701,6 +457,7 @@ else:
                         self._device_type,
                         self._mesh_dim_names,
                         self._thread_id,
+                        self._root_mesh,
                     )
                 )
             return self._hash
@@ -716,6 +473,7 @@ else:
                 and self._device_type == other._device_type
                 and self._mesh_dim_names == other._mesh_dim_names
                 and self._thread_id == other._thread_id
+                and self._root_mesh == other._root_mesh
             )
 
         def __getitem__(
@@ -774,22 +532,18 @@ else:
             if mesh_dim_names == self._mesh_dim_names:
                 return self
             else:
-                sliced_mesh_layout = _mesh_resources._get_slice_mesh_layout(
-                    self, mesh_dim_names
-                )
-                # When using FakeTensorMode to trace the model, `create_sub_mesh()` will
+                sliced_mesh_layout = self._get_slice_mesh_layout(mesh_dim_names)
+                # When using FakeTensorMode to trace the model, `_create_sub_mesh()` will
                 # fail as it will require a real tensor to manipulate.
                 # `unset_fake_temporarily()` will allow us to materialize the tensors
-                # within `_mesh_resources`, which should not affect modling.
+                # within `_create_sub_mesh`, which should not affect modling.
                 #
                 # Note that this should be orthogonal to torch.compile(). But whether
                 # we can compile device_mesh `slicing` (no graph break) is not verified
                 # yet and need a follow-up,
                 # TODO: compiler + device_mesh slicing.
                 with torch._subclasses.fake_tensor.unset_fake_temporarily():
-                    submesh = _mesh_resources.create_sub_mesh(
-                        self, sliced_mesh_layout, mesh_dim_names
-                    )
+                    submesh = self._create_sub_mesh(sliced_mesh_layout, mesh_dim_names)
                 return submesh
 
         def get_group(self, mesh_dim: Optional[Union[int, str]] = None) -> ProcessGroup:
@@ -819,10 +573,8 @@ else:
             if self.mesh.ndim == 1 and mesh_dim is None:
                 return not_none(_resolve_process_group(self._dim_group_names[0]))
 
-            root_mesh = _mesh_resources.get_root_mesh(self)
-            root_to_flatten_mapping = _mesh_resources.root_to_flatten_mapping.get(
-                root_mesh, None
-            )
+            root_mesh = self._get_root_mesh()
+            root_to_flatten_mapping = root_mesh._flatten_mapping
             if root_to_flatten_mapping and mesh_dim in root_to_flatten_mapping.keys():
                 dim_group_name = root_to_flatten_mapping[
                     mesh_dim  # type: ignore[index]
@@ -830,7 +582,7 @@ else:
                 return not_none(_resolve_process_group(dim_group_name))
             else:
                 mesh_dim = (
-                    _mesh_resources.get_mesh_dim_by_name(self, mesh_dim)
+                    self.get_mesh_dim_by_name(mesh_dim)
                     if isinstance(mesh_dim, str)
                     else mesh_dim
                 )
@@ -846,6 +598,244 @@ else:
             """
             return [self.get_group(i) for i in range(self.mesh.ndim)]
 
+        def _create_sub_mesh(
+            self,
+            layout: _MeshLayout,
+            submesh_dim_names: tuple[str, ...],
+        ) -> "DeviceMesh":
+            root_mesh = self._get_root_mesh()
+            slice_dim_group_name = []
+            for name in submesh_dim_names:
+                if name in not_none(self.mesh_dim_names):
+                    slice_dim_group_name.append(
+                        self._dim_group_names[  # type: ignore[has-type]
+                            not_none(self.mesh_dim_names).index(name)
+                        ]
+                    )
+                else:
+                    # If device_mesh is not root_mesh, we already throw error in _get_slice_mesh_layout
+                    # Since we will deprecate the slicing of flattened dim_name from root mesh soon,
+                    # we don't want to optimize the code furthermore.
+                    flatten_mesh = self._flatten_mapping[name]
+                    slice_dim_group_name.append(
+                        flatten_mesh._dim_group_names[  # type: ignore[has-type]
+                            not_none(flatten_mesh.mesh_dim_names).index(name)
+                        ]
+                    )
+            cur_rank = self.get_rank()
+            pg_ranks_by_dim = layout.remap_to_tensor(
+                root_mesh.mesh,
+            )
+            res_submesh = DeviceMesh._create_mesh_from_ranks(
+                self.device_type,
+                pg_ranks_by_dim,
+                cur_rank,
+                submesh_dim_names,
+                _init_backend=False,
+                _layout=layout,
+                _root_mesh=root_mesh,
+            )
+            res_submesh._dim_group_names = slice_dim_group_name
+            return res_submesh
+
+        def _create_flatten_mesh(
+            self,
+            mesh_dim_name: Optional[str] = None,
+            backend_override: BackendConfig = (None, None),
+        ) -> "DeviceMesh":
+            root_mesh = self._get_root_mesh()
+
+            if not mesh_dim_name:
+                mesh_dim_name = "_".join(not_none(self.mesh_dim_names))
+
+            # Flatten a 1D device mesh into its original mesh_dim_name will return itself.
+            if self.ndim == 1 and mesh_dim_name in not_none(self.mesh_dim_names):
+                return self
+
+            # Check whether the mesh_dim_name for flattened mesh is valid.
+            invalid_dim_names = not_none(root_mesh.mesh_dim_names)
+            if mesh_dim_name in invalid_dim_names:
+                raise ValueError(
+                    f"{mesh_dim_name} already exists for submesh of the {root_mesh}. ",
+                    f"The mesh_dim_names of submesh and flattened mesh are {invalid_dim_names}. "
+                    f"Please specify another valid mesh_dim_name.",
+                )
+
+            flattened_mesh_layout = self._layout.coalesce()
+            # Quick return if the flatten mesh has been created before.
+            if mesh_dim_name in root_mesh._flatten_mapping:
+                if (
+                    flattened_mesh_layout
+                    == root_mesh._flatten_mapping[mesh_dim_name]._layout
+                ):
+                    return root_mesh._flatten_mapping[mesh_dim_name]
+                else:
+                    raise ValueError(
+                        f"Flatten mesh with mesh_dim_name {mesh_dim_name} has been created before, "
+                        f"Please specify another valid mesh_dim_name."
+                    )
+
+            cur_rank = root_mesh.get_rank()
+            # Due to the limitation of ProcessGroup api, we need to start from root mesh so that all ranks call the
+            # new_group api to avoid potential hang.
+            pg_ranks_by_dim = flattened_mesh_layout.remap_to_tensor(
+                root_mesh.mesh,
+            )
+            res_flattened_mesh = DeviceMesh._create_mesh_from_ranks(
+                root_mesh.device_type,
+                pg_ranks_by_dim.flatten(
+                    start_dim=1
+                ),  # this is needed for flatten non-contiguous mesh dims.
+                cur_rank,
+                (mesh_dim_name,),
+                (backend_override,),
+                _layout=self._layout.coalesce(),
+                _root_mesh=root_mesh,
+            )
+            root_mesh._flatten_mapping[mesh_dim_name] = res_flattened_mesh
+
+            return res_flattened_mesh
+
+        def get_root_mesh_dim(self) -> Optional[int]:
+            """
+            Returns the index of the mesh dim in the root mesh.
+            The device_mesh passed in needs to be sliced out from the root mesh
+            or submesh of the root mesh.
+            """
+            root_mesh = self._get_root_mesh()
+            child_mesh_dim_names = self.mesh_dim_names
+            if root_mesh and child_mesh_dim_names:
+                assert len(child_mesh_dim_names) == 1, (
+                    "The submesh can only be a 1D mesh."
+                )
+                child_mesh_dim_name = child_mesh_dim_names[0]
+                return root_mesh.get_mesh_dim_by_name(child_mesh_dim_name)
+            return None
+
+        def get_mesh_dim_by_name(self, mesh_dim_name: str) -> int:
+            if self.mesh_dim_names is None or len(self.mesh_dim_names) == 0:
+                raise KeyError(
+                    "No `mesh_dim_names` found.",
+                )
+            if mesh_dim_name not in self.mesh_dim_names:
+                raise KeyError(
+                    f"Mesh dimension '{mesh_dim_name}' does not exist.",
+                    f"Available mesh dimensions are: mesh_dim_names={self.mesh_dim_names}",
+                )
+            return not_none(self.mesh_dim_names.index(mesh_dim_name))
+
+        def _get_slice_mesh_layout(
+            self, mesh_dim_names: tuple[str, ...]
+        ) -> _MeshLayout:
+            """
+            Validate whether the mesh_dim_names is valid for slicing the given device_mesh.
+            If valid, return dim indexes of the slice mesh in the device mesh.
+            """
+            slice_from_root = True
+            if self != self._get_root_mesh():
+                warnings.warn(
+                    "You are attempting to slice a submesh from another submesh. While we support this operation, "
+                    "it is users' responsibility to ensure that the submesh is consistently sliced across all ranks. "
+                    "If not, this may result in some ranks receiving the submesh while others encounter errors."
+                )
+                slice_from_root = False
+
+            # The slice mesh_dim_names should consist either the current device_mesh's mesh_dim_names
+            # or its flattened mesh's mesh_dim_names if it's root_mesh.
+            flatten_name_to_root_layout = (
+                {
+                    key: mesh._layout
+                    for key, mesh in self._get_root_mesh()._flatten_mapping.items()
+                }
+                if slice_from_root
+                else {}
+            )
+            valid_mesh_dim_names = [
+                *not_none(self.mesh_dim_names),
+                *flatten_name_to_root_layout,
+            ]
+
+            if not all(
+                mesh_dim_name in valid_mesh_dim_names
+                for mesh_dim_name in mesh_dim_names
+            ):
+                raise KeyError(
+                    f"Invalid mesh_dim_names {mesh_dim_names} specified. "
+                    f"Valid mesh_dim_names are {valid_mesh_dim_names}."
+                )
+
+            layout_sliced = []
+            for name in mesh_dim_names:
+                if name in not_none(self.mesh_dim_names):
+                    layout_sliced.append(
+                        self._layout[not_none(self.mesh_dim_names).index(name)]
+                    )
+                elif name in flatten_name_to_root_layout:
+                    layout_sliced.append(flatten_name_to_root_layout[name])
+
+            sliced_sizes = tuple(l.sizes for l in layout_sliced)
+            sliced_strides = tuple(l.strides for l in layout_sliced)
+
+            # The check below is from DeviceMesh's implementation before adopting CuTe layout for internal
+            # bookkeeping and it can be removed but we need to define what is the expected behavior.
+            # TODO: Remove the below check and define the expected behavior.
+            # Validate the order of the slice mesh dim indices.
+            # This needs to be in ascending order.
+            pre_stride = -1
+            for stride in reversed(sliced_strides):
+                # Note that with CuTe layout, we can support slicing flattened non-contiguous mesh dims with no problem.
+                # But this will make this behavior complicated so we decided to not support it for now.
+                if not is_int(stride):
+                    raise NotImplementedError(
+                        "Currently, this only allows slicing out a contiguous flattened dim."
+                    )
+                if stride < pre_stride:
+                    raise KeyError(
+                        f"Invalid mesh_dim_names {mesh_dim_names} specified. "
+                        "Mesh dim indices should be in ascending order."
+                    )
+                pre_stride = stride
+
+            # When users sliced dim_names outside from current mesh, we will check whether
+            # there is layout overlap.
+            # TODO: Eventually we will just directly throw error here because
+            # we will deprecate the slicing of flattened dim_name from root mesh.
+            layout_sliced = _MeshLayout(sliced_sizes, sliced_strides)
+            if not layout_sliced.check_non_overlap():
+                raise RuntimeError(
+                    f"Slicing overlapping dim_names {mesh_dim_names} is not allowed."
+                )
+
+            return layout_sliced
+
+        # TODO: to make this use case by other components public API in the future.
+        def _get_all_submeshes(self, mesh_dim_name: str) -> list["DeviceMesh"]:
+            """
+            Return all the submeshes of a given mesh dimension of the device mesh.
+            """
+            mesh_dim = self.get_mesh_dim_by_name(mesh_dim_name)
+            layout = self._layout[mesh_dim]
+            pg_ranks_by_dim = layout.remap_to_tensor(
+                self.mesh,
+            )
+            cur_rank = self.get_rank()
+            res_submeshes = []
+            for mesh_1d in pg_ranks_by_dim:
+                submesh = DeviceMesh(
+                    self.device_type,
+                    mesh_1d,
+                    mesh_dim_names=(mesh_dim_name,),
+                    _init_backend=False,
+                )
+                submesh._dim_group_names = (  # type: ignore[has-type]
+                    [self._dim_group_names[mesh_dim]]  # type: ignore[has-type]
+                    if cur_rank in mesh_1d
+                    else []
+                )
+                res_submeshes.append(submesh)
+
+            return res_submeshes
+
         @staticmethod
         def _create_mesh_from_ranks(
             device_type: str,
@@ -855,6 +845,7 @@ else:
             backend_override: Optional[tuple[BackendConfig, ...]] = None,
             _init_backend: bool = True,
             _layout: Optional[_MeshLayout] = None,
+            _root_mesh: Optional["DeviceMesh"] = None,
         ) -> "DeviceMesh":
             """
             Helper method to create a DeviceMesh from tensor `pg_ranks_by_dim`. This is due to
@@ -895,6 +886,8 @@ else:
                     f"Current rank {cur_rank} not found in any mesh, "
                     f"input {pg_ranks_by_dim} does not contain all ranks in the world"
                 )
+            if _root_mesh is not None:
+                res_mesh._root_mesh = _root_mesh
             return res_mesh
 
         @staticmethod
@@ -1090,9 +1083,7 @@ else:
             else:
                 backend_override_tuple = (None, None)
 
-            return _mesh_resources.create_flatten_mesh(
-                self, mesh_dim_name, backend_override_tuple
-            )
+            return self._create_flatten_mesh(mesh_dim_name, backend_override_tuple)
 
     def _normalize_backend_override(
         backend_override: dict[

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -239,7 +239,9 @@ else:
                 )
             return not_none(device_mesh.mesh_dim_names.index(mesh_dim_name))
 
-        def _get_slice_mesh_layout(self, device_mesh, mesh_dim_names) -> _MeshLayout:
+        def _get_slice_mesh_layout(
+            self, device_mesh: "DeviceMesh", mesh_dim_names: tuple[str, ...]
+        ) -> _MeshLayout:
             """
             Validate whether the mesh_dim_names is valid for slicing the given device_mesh.
             If valid, return dim indexes of the slice mesh in the device mesh.
@@ -266,7 +268,7 @@ else:
                 else {}
             )
             valid_mesh_dim_names = [
-                *device_mesh.mesh_dim_names,
+                *not_none(device_mesh.mesh_dim_names),
                 *flatten_name_to_root_layout,
             ]
 
@@ -281,11 +283,17 @@ else:
 
             layout_sliced = []
             for name in mesh_dim_names:
-                if name in device_mesh.mesh_dim_names:
+                if name in not_none(device_mesh.mesh_dim_names):
                     layout_sliced.append(
-                        device_mesh._layout[device_mesh.mesh_dim_names.index(name)]
+                        device_mesh._layout[
+                            not_none(device_mesh.mesh_dim_names).index(name)
+                        ]
                     )
                 elif name in flatten_name_to_root_layout:
+                    warnings.warn(
+                        "Slicing a flattened dim from root mesh will be deprecated soon. "
+                        "Users need to use and bookkeep the flattened mesh directly. "
+                    )
                     layout_sliced.append(flatten_name_to_root_layout[name])
 
             sliced_sizes = tuple(l.sizes for l in layout_sliced)

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -72,23 +72,145 @@ else:
     class _MeshEnv(threading.local):
         def __init__(self) -> None:
             self.mesh_stack: list[DeviceMesh] = []
+            # TODO: Move the bookkeeping maps from _MeshEnv to DeviceMesh.
+            self.child_to_root_mapping: dict[DeviceMesh, DeviceMesh] = {}
+            # Record flatten mesh name to its flattened mesh in root mesh.
+            self.root_to_flatten_mapping: dict[DeviceMesh, dict[str, DeviceMesh]] = {}
 
         def get_current_mesh(self) -> "DeviceMesh":
             if len(self.mesh_stack) == 0:
                 raise RuntimeError("No device mesh is currently active!")
             return self.mesh_stack[-1]
 
-        # TODO: to remove it once we move all use cases into new API.
+        def create_sub_mesh(
+            self,
+            device_mesh: "DeviceMesh",
+            layout: _MeshLayout,
+            submesh_dim_names: tuple[str, ...],
+        ) -> "DeviceMesh":
+            root_mesh = self.get_root_mesh(device_mesh)
+            slice_dim_group_name = []
+            for name in submesh_dim_names:
+                if name in not_none(device_mesh.mesh_dim_names):
+                    slice_dim_group_name.append(
+                        device_mesh._dim_group_names[  # type: ignore[has-type]
+                            not_none(device_mesh.mesh_dim_names).index(name)
+                        ]
+                    )
+                else:
+                    # If device_mesh is not root_mesh, we already throw error in _get_slice_mesh_layout
+                    # Since we will deprecate the slicing of flattened dim_name from root mesh soon,
+                    # we don't want to optimize the code furthermore.
+                    flatten_mesh = self.root_to_flatten_mapping[device_mesh][name]
+                    slice_dim_group_name.append(
+                        flatten_mesh._dim_group_names[  # type: ignore[has-type]
+                            not_none(flatten_mesh.mesh_dim_names).index(name)
+                        ]
+                    )
+            cur_rank = device_mesh.get_rank()
+            pg_ranks_by_dim = layout.remap_to_tensor(
+                root_mesh.mesh,
+            )
+            res_submesh = DeviceMesh._create_mesh_from_ranks(
+                device_mesh.device_type,
+                pg_ranks_by_dim,
+                cur_rank,
+                submesh_dim_names,
+                _init_backend=False,
+                _layout=layout,
+            )
+            res_submesh._dim_group_names = slice_dim_group_name
+            self.child_to_root_mapping[res_submesh] = root_mesh
+            return res_submesh
+
+        def create_flatten_mesh(
+            self,
+            device_mesh: "DeviceMesh",
+            mesh_dim_name: Optional[str] = None,
+            backend_override: BackendConfig = (None, None),
+        ) -> "DeviceMesh":
+            root_mesh = self.get_root_mesh(device_mesh)
+
+            if not mesh_dim_name:
+                mesh_dim_name = "_".join(not_none(device_mesh.mesh_dim_names))
+
+            # Flatten a 1D device mesh into its original mesh_dim_name will return itself.
+            if device_mesh.ndim == 1 and mesh_dim_name in not_none(
+                device_mesh.mesh_dim_names
+            ):
+                return device_mesh
+
+            # Check whether the mesh_dim_name for flattened mesh is valid.
+            invalid_dim_names = not_none(root_mesh.mesh_dim_names)
+            if mesh_dim_name in invalid_dim_names:
+                raise ValueError(
+                    f"{mesh_dim_name} already exists for submesh of the {root_mesh}. ",
+                    f"The mesh_dim_names of submesh and flattened mesh are {invalid_dim_names}. "
+                    f"Please specify another valid mesh_dim_name.",
+                )
+
+            flattened_mesh_layout = device_mesh._layout.coalesce()
+            # Quick return if the flatten mesh has been created before.
+            if (
+                root_mesh in self.root_to_flatten_mapping
+                and mesh_dim_name in self.root_to_flatten_mapping[root_mesh]
+            ):
+                if (
+                    flattened_mesh_layout
+                    == self.root_to_flatten_mapping[root_mesh][mesh_dim_name]._layout
+                ):
+                    return self.root_to_flatten_mapping[root_mesh][mesh_dim_name]
+                else:
+                    raise ValueError(
+                        f"Flatten mesh with mesh_dim_name {mesh_dim_name} has been created before, "
+                        f"Please specify another valid mesh_dim_name."
+                    )
+
+            cur_rank = root_mesh.get_rank()
+            # Due to the limitation of ProcessGroup api, we need to start from root mesh so that all ranks call the
+            # new_group api to avoid potential hang.
+            pg_ranks_by_dim = flattened_mesh_layout.remap_to_tensor(
+                root_mesh.mesh,
+            )
+            res_flattened_mesh = DeviceMesh._create_mesh_from_ranks(
+                root_mesh.device_type,
+                pg_ranks_by_dim.flatten(
+                    start_dim=1
+                ),  # this is needed for flatten non-contiguous mesh dims.
+                cur_rank,
+                (mesh_dim_name,),
+                (backend_override,),
+                _layout=device_mesh._layout.coalesce(),
+            )
+            self.child_to_root_mapping[res_flattened_mesh] = root_mesh
+            self.root_to_flatten_mapping.setdefault(root_mesh, {})[mesh_dim_name] = (
+                res_flattened_mesh
+            )
+
+            return res_flattened_mesh
+
         def get_root_mesh(self, device_mesh: "DeviceMesh") -> "DeviceMesh":
             # If a mesh could not be found in the child_to_root_mapping, it is a root mesh itself.
             # A root mesh is not created through slicing.
             # We considers the root mesh of a root mesh is itself.
-            # We keep this function for backward compatibility.
-            warnings.warn(
-                "This _get_all_submeshes API will be deprecated soon."
-                "Please use `_get_all_submeshes` inside DeviceMesh instead."
-            )
-            return device_mesh._get_root_mesh()
+            root_mesh = self.child_to_root_mapping.get(device_mesh, None)
+            return device_mesh if not root_mesh else root_mesh
+
+        def get_root_mesh_dim(self, device_mesh: "DeviceMesh") -> Optional[int]:
+            """
+            Returns the index of the mesh dim in the root mesh.
+            The device_mesh passed in needs to be sliced out from the root mesh
+            or submesh of the root mesh.
+            """
+            root_mesh = self.get_root_mesh(device_mesh)
+            child_mesh_dim_names = device_mesh.mesh_dim_names
+            if root_mesh and child_mesh_dim_names:
+                assert len(child_mesh_dim_names) == 1, (
+                    "The submesh can only be a 1D mesh."
+                )
+                child_mesh_dim_name = child_mesh_dim_names[0]
+                return self.get_mesh_dim_by_name(root_mesh, child_mesh_dim_name)
+            return None
 
         @staticmethod
         def num_devices_per_host(device_type: str) -> int:
@@ -100,16 +222,144 @@ else:
             # homogeneous hardware for now
             return get_world_size() // _MeshEnv.num_devices_per_host(device_type)
 
-        # TODO: to remove it once we move all use cases into new API.
-        # We keep this API for backward compatibility.
+        def get_mesh_dim_by_name(
+            self, device_mesh: "DeviceMesh", mesh_dim_name: str
+        ) -> int:
+            if (
+                device_mesh.mesh_dim_names is None
+                or len(device_mesh.mesh_dim_names) == 0
+            ):
+                raise KeyError(
+                    "No `mesh_dim_names` found.",
+                )
+            if mesh_dim_name not in device_mesh.mesh_dim_names:
+                raise KeyError(
+                    f"Mesh dimension '{mesh_dim_name}' does not exist.",
+                    f"Available mesh dimensions are: mesh_dim_names={device_mesh.mesh_dim_names}",
+                )
+            return not_none(device_mesh.mesh_dim_names.index(mesh_dim_name))
+
+        def _get_slice_mesh_layout(
+            self, device_mesh: "DeviceMesh", mesh_dim_names: tuple[str, ...]
+        ) -> _MeshLayout:
+            """
+            Validate whether the mesh_dim_names is valid for slicing the given device_mesh.
+            If valid, return dim indexes of the slice mesh in the device mesh.
+            """
+            slice_from_root = True
+            if device_mesh != self.get_root_mesh(device_mesh):
+                warnings.warn(
+                    "You are attempting to slice a submesh from another submesh. While we support this operation, "
+                    "it is users' responsibility to ensure that the submesh is consistently sliced across all ranks. "
+                    "If not, this may result in some ranks receiving the submesh while others encounter errors."
+                )
+                slice_from_root = False
+
+            # The slice mesh_dim_names should consist either the device_mesh's mesh_dim_names
+            # or its flattened mesh's mesh_dim_names if it's root_mesh.
+            flatten_name_to_root_layout = (
+                {
+                    key: mesh._layout
+                    for key, mesh in self.root_to_flatten_mapping.setdefault(
+                        device_mesh, {}
+                    ).items()
+                }
+                if slice_from_root
+                else {}
+            )
+            valid_mesh_dim_names = [
+                *not_none(device_mesh.mesh_dim_names),
+                *flatten_name_to_root_layout,
+            ]
+
+            if not all(
+                mesh_dim_name in valid_mesh_dim_names
+                for mesh_dim_name in mesh_dim_names
+            ):
+                raise KeyError(
+                    f"Invalid mesh_dim_names {mesh_dim_names} specified. "
+                    f"Valid mesh_dim_names are {valid_mesh_dim_names}."
+                )
+
+            layout_sliced = []
+            for name in mesh_dim_names:
+                if name in not_none(device_mesh.mesh_dim_names):
+                    layout_sliced.append(
+                        device_mesh._layout[
+                            not_none(device_mesh.mesh_dim_names).index(name)
+                        ]
+                    )
+                elif name in flatten_name_to_root_layout:
+                    warnings.warn(
+                        "Slicing a flattened dim from root mesh will be deprecated in PT 2.11. "
+                        "Users need to bookkeep the flattened mesh directly. "
+                    )
+                    layout_sliced.append(flatten_name_to_root_layout[name])
+
+            sliced_sizes = tuple(l.sizes for l in layout_sliced)
+            sliced_strides = tuple(l.strides for l in layout_sliced)
+
+            # The check below is from DeviceMesh's implementation before adopting CuTe layout for internal
+            # bookkeeping and it can be removed but we need to define what is the expected behavior.
+            # TODO: Remove the below check and define the expected behavior.
+            # Validate the order of the slice mesh dim indices.
+            # This needs to be in ascending order.
+            pre_stride = -1
+            for stride in reversed(sliced_strides):
+                # Note that with CuTe layout, we can support slicing flattened non-contiguous mesh dims with no problem.
+                # But this will make this behavior complicated so we decided to not support it for now.
+                if not is_int(stride):
+                    raise NotImplementedError(
+                        "Currently, this only allows slicing out a contiguous flattened dim."
+                    )
+                if stride < pre_stride:
+                    raise KeyError(
+                        f"Invalid mesh_dim_names {mesh_dim_names} specified. "
+                        "Mesh dim indices should be in ascending order."
+                    )
+                pre_stride = stride
+
+            # When users sliced dim_names outside from current mesh, we will check whether
+            # there is layout overlap.
+            # TODO: Eventually we will just directly throw error here because
+            # we will deprecate the slicing of flattened dim_name from root mesh.
+            layout_sliced = _MeshLayout(sliced_sizes, sliced_strides)
+            if not layout_sliced.check_non_overlap():
+                raise RuntimeError(
+                    f"Slicing overlapping dim_names {mesh_dim_names} is not allowed."
+                )
+
+            return layout_sliced
+
+        # TODO: to make this use case by other components public API in the future.
         def _get_all_submeshes(
             self, device_mesh: "DeviceMesh", mesh_dim_name: str
         ) -> list["DeviceMesh"]:
-            warnings.warn(
-                "This _get_all_submeshes API will be deprecated soon."
-                "Please use `_get_all_submeshes` inside DeviceMesh instead."
+            """
+            Return all the submeshes of a given mesh dimension of the device mesh.
+            """
+            mesh_dim = self.get_mesh_dim_by_name(device_mesh, mesh_dim_name)
+            layout = device_mesh._layout[mesh_dim]
+            pg_ranks_by_dim = layout.remap_to_tensor(
+                device_mesh.mesh,
             )
-            return device_mesh._get_all_submeshes(mesh_dim_name)
+            cur_rank = device_mesh.get_rank()
+            res_submeshes = []
+            for mesh_1d in pg_ranks_by_dim:
+                submesh = DeviceMesh(
+                    device_mesh.device_type,
+                    mesh_1d,
+                    mesh_dim_names=(mesh_dim_name,),
+                    _init_backend=False,
+                )
+                submesh._dim_group_names = (  # type: ignore[has-type]
+                    [device_mesh._dim_group_names[mesh_dim]]  # type: ignore[has-type]
+                    if cur_rank in mesh_1d
+                    else []
+                )
+                res_submeshes.append(submesh)
+
+            return res_submeshes
 
     _mesh_resources: _MeshEnv = _MeshEnv()
 
@@ -174,9 +424,6 @@ else:
         _mesh: torch.Tensor
         _mesh_dim_names: Optional[tuple[str, ...]]
         _layout: _MeshLayout
-        _root_mesh: Optional["DeviceMesh"] = None
-        # Record flatten mesh name to its flattened mesh in root mesh.
-        _flatten_mapping: dict[str, "DeviceMesh"] = {}
 
         def __init__(
             self,
@@ -421,9 +668,6 @@ else:
                             dim_group_names.append(dim_group.group_name)  # type: ignore[union-attr]
             self._dim_group_names = dim_group_names
 
-        def _get_root_mesh(self) -> "DeviceMesh":
-            return self._root_mesh if self._root_mesh else self
-
         def __enter__(self) -> "DeviceMesh":
             # set this mesh as the current mesh in mesh env
             _mesh_resources.mesh_stack.append(self)
@@ -457,7 +701,6 @@ else:
                         self._device_type,
                         self._mesh_dim_names,
                         self._thread_id,
-                        self._root_mesh,
                     )
                 )
             return self._hash
@@ -473,7 +716,6 @@ else:
                 and self._device_type == other._device_type
                 and self._mesh_dim_names == other._mesh_dim_names
                 and self._thread_id == other._thread_id
-                and self._root_mesh == other._root_mesh
             )
 
         def __getitem__(
@@ -532,18 +774,22 @@ else:
             if mesh_dim_names == self._mesh_dim_names:
                 return self
             else:
-                sliced_mesh_layout = self._get_slice_mesh_layout(mesh_dim_names)
-                # When using FakeTensorMode to trace the model, `_create_sub_mesh()` will
+                sliced_mesh_layout = _mesh_resources._get_slice_mesh_layout(
+                    self, mesh_dim_names
+                )
+                # When using FakeTensorMode to trace the model, `create_sub_mesh()` will
                 # fail as it will require a real tensor to manipulate.
                 # `unset_fake_temporarily()` will allow us to materialize the tensors
-                # within `_create_sub_mesh`, which should not affect modling.
+                # within `_mesh_resources`, which should not affect modling.
                 #
                 # Note that this should be orthogonal to torch.compile(). But whether
                 # we can compile device_mesh `slicing` (no graph break) is not verified
                 # yet and need a follow-up,
                 # TODO: compiler + device_mesh slicing.
                 with torch._subclasses.fake_tensor.unset_fake_temporarily():
-                    submesh = self._create_sub_mesh(sliced_mesh_layout, mesh_dim_names)
+                    submesh = _mesh_resources.create_sub_mesh(
+                        self, sliced_mesh_layout, mesh_dim_names
+                    )
                 return submesh
 
         def get_group(self, mesh_dim: Optional[Union[int, str]] = None) -> ProcessGroup:
@@ -573,8 +819,10 @@ else:
             if self.mesh.ndim == 1 and mesh_dim is None:
                 return not_none(_resolve_process_group(self._dim_group_names[0]))
 
-            root_mesh = self._get_root_mesh()
-            root_to_flatten_mapping = root_mesh._flatten_mapping
+            root_mesh = _mesh_resources.get_root_mesh(self)
+            root_to_flatten_mapping = _mesh_resources.root_to_flatten_mapping.get(
+                root_mesh, None
+            )
             if root_to_flatten_mapping and mesh_dim in root_to_flatten_mapping.keys():
                 dim_group_name = root_to_flatten_mapping[
                     mesh_dim  # type: ignore[index]
@@ -582,7 +830,7 @@ else:
                 return not_none(_resolve_process_group(dim_group_name))
             else:
                 mesh_dim = (
-                    self.get_mesh_dim_by_name(mesh_dim)
+                    _mesh_resources.get_mesh_dim_by_name(self, mesh_dim)
                     if isinstance(mesh_dim, str)
                     else mesh_dim
                 )
@@ -598,244 +846,6 @@ else:
             """
             return [self.get_group(i) for i in range(self.mesh.ndim)]
 
-        def _create_sub_mesh(
-            self,
-            layout: _MeshLayout,
-            submesh_dim_names: tuple[str, ...],
-        ) -> "DeviceMesh":
-            root_mesh = self._get_root_mesh()
-            slice_dim_group_name = []
-            for name in submesh_dim_names:
-                if name in not_none(self.mesh_dim_names):
-                    slice_dim_group_name.append(
-                        self._dim_group_names[  # type: ignore[has-type]
-                            not_none(self.mesh_dim_names).index(name)
-                        ]
-                    )
-                else:
-                    # If device_mesh is not root_mesh, we already throw error in _get_slice_mesh_layout
-                    # Since we will deprecate the slicing of flattened dim_name from root mesh soon,
-                    # we don't want to optimize the code furthermore.
-                    flatten_mesh = self._flatten_mapping[name]
-                    slice_dim_group_name.append(
-                        flatten_mesh._dim_group_names[  # type: ignore[has-type]
-                            not_none(flatten_mesh.mesh_dim_names).index(name)
-                        ]
-                    )
-            cur_rank = self.get_rank()
-            pg_ranks_by_dim = layout.remap_to_tensor(
-                root_mesh.mesh,
-            )
-            res_submesh = DeviceMesh._create_mesh_from_ranks(
-                self.device_type,
-                pg_ranks_by_dim,
-                cur_rank,
-                submesh_dim_names,
-                _init_backend=False,
-                _layout=layout,
-                _root_mesh=root_mesh,
-            )
-            res_submesh._dim_group_names = slice_dim_group_name
-            return res_submesh
-
-        def _create_flatten_mesh(
-            self,
-            mesh_dim_name: Optional[str] = None,
-            backend_override: BackendConfig = (None, None),
-        ) -> "DeviceMesh":
-            root_mesh = self._get_root_mesh()
-
-            if not mesh_dim_name:
-                mesh_dim_name = "_".join(not_none(self.mesh_dim_names))
-
-            # Flatten a 1D device mesh into its original mesh_dim_name will return itself.
-            if self.ndim == 1 and mesh_dim_name in not_none(self.mesh_dim_names):
-                return self
-
-            # Check whether the mesh_dim_name for flattened mesh is valid.
-            invalid_dim_names = not_none(root_mesh.mesh_dim_names)
-            if mesh_dim_name in invalid_dim_names:
-                raise ValueError(
-                    f"{mesh_dim_name} already exists for submesh of the {root_mesh}. ",
-                    f"The mesh_dim_names of submesh and flattened mesh are {invalid_dim_names}. "
-                    f"Please specify another valid mesh_dim_name.",
-                )
-
-            flattened_mesh_layout = self._layout.coalesce()
-            # Quick return if the flatten mesh has been created before.
-            if mesh_dim_name in root_mesh._flatten_mapping:
-                if (
-                    flattened_mesh_layout
-                    == root_mesh._flatten_mapping[mesh_dim_name]._layout
-                ):
-                    return root_mesh._flatten_mapping[mesh_dim_name]
-                else:
-                    raise ValueError(
-                        f"Flatten mesh with mesh_dim_name {mesh_dim_name} has been created before, "
-                        f"Please specify another valid mesh_dim_name."
-                    )
-
-            cur_rank = root_mesh.get_rank()
-            # Due to the limitation of ProcessGroup api, we need to start from root mesh so that all ranks call the
-            # new_group api to avoid potential hang.
-            pg_ranks_by_dim = flattened_mesh_layout.remap_to_tensor(
-                root_mesh.mesh,
-            )
-            res_flattened_mesh = DeviceMesh._create_mesh_from_ranks(
-                root_mesh.device_type,
-                pg_ranks_by_dim.flatten(
-                    start_dim=1
-                ),  # this is needed for flatten non-contiguous mesh dims.
-                cur_rank,
-                (mesh_dim_name,),
-                (backend_override,),
-                _layout=self._layout.coalesce(),
-                _root_mesh=root_mesh,
-            )
-            root_mesh._flatten_mapping[mesh_dim_name] = res_flattened_mesh
-
-            return res_flattened_mesh
-
-        def get_root_mesh_dim(self) -> Optional[int]:
-            """
-            Returns the index of the mesh dim in the root mesh.
-            The device_mesh passed in needs to be sliced out from the root mesh
-            or submesh of the root mesh.
-            """
-            root_mesh = self._get_root_mesh()
-            child_mesh_dim_names = self.mesh_dim_names
-            if root_mesh and child_mesh_dim_names:
-                assert len(child_mesh_dim_names) == 1, (
-                    "The submesh can only be a 1D mesh."
-                )
-                child_mesh_dim_name = child_mesh_dim_names[0]
-                return root_mesh.get_mesh_dim_by_name(child_mesh_dim_name)
-            return None
-
-        def get_mesh_dim_by_name(self, mesh_dim_name: str) -> int:
-            if self.mesh_dim_names is None or len(self.mesh_dim_names) == 0:
-                raise KeyError(
-                    "No `mesh_dim_names` found.",
-                )
-            if mesh_dim_name not in self.mesh_dim_names:
-                raise KeyError(
-                    f"Mesh dimension '{mesh_dim_name}' does not exist.",
-                    f"Available mesh dimensions are: mesh_dim_names={self.mesh_dim_names}",
-                )
-            return not_none(self.mesh_dim_names.index(mesh_dim_name))
-
-        def _get_slice_mesh_layout(
-            self, mesh_dim_names: tuple[str, ...]
-        ) -> _MeshLayout:
-            """
-            Validate whether the mesh_dim_names is valid for slicing the given device_mesh.
-            If valid, return dim indexes of the slice mesh in the device mesh.
-            """
-            slice_from_root = True
-            if self != self._get_root_mesh():
-                warnings.warn(
-                    "You are attempting to slice a submesh from another submesh. While we support this operation, "
-                    "it is users' responsibility to ensure that the submesh is consistently sliced across all ranks. "
-                    "If not, this may result in some ranks receiving the submesh while others encounter errors."
-                )
-                slice_from_root = False
-
-            # The slice mesh_dim_names should consist either the current device_mesh's mesh_dim_names
-            # or its flattened mesh's mesh_dim_names if it's root_mesh.
-            flatten_name_to_root_layout = (
-                {
-                    key: mesh._layout
-                    for key, mesh in self._get_root_mesh()._flatten_mapping.items()
-                }
-                if slice_from_root
-                else {}
-            )
-            valid_mesh_dim_names = [
-                *not_none(self.mesh_dim_names),
-                *flatten_name_to_root_layout,
-            ]
-
-            if not all(
-                mesh_dim_name in valid_mesh_dim_names
-                for mesh_dim_name in mesh_dim_names
-            ):
-                raise KeyError(
-                    f"Invalid mesh_dim_names {mesh_dim_names} specified. "
-                    f"Valid mesh_dim_names are {valid_mesh_dim_names}."
-                )
-
-            layout_sliced = []
-            for name in mesh_dim_names:
-                if name in not_none(self.mesh_dim_names):
-                    layout_sliced.append(
-                        self._layout[not_none(self.mesh_dim_names).index(name)]
-                    )
-                elif name in flatten_name_to_root_layout:
-                    layout_sliced.append(flatten_name_to_root_layout[name])
-
-            sliced_sizes = tuple(l.sizes for l in layout_sliced)
-            sliced_strides = tuple(l.strides for l in layout_sliced)
-
-            # The check below is from DeviceMesh's implementation before adopting CuTe layout for internal
-            # bookkeeping and it can be removed but we need to define what is the expected behavior.
-            # TODO: Remove the below check and define the expected behavior.
-            # Validate the order of the slice mesh dim indices.
-            # This needs to be in ascending order.
-            pre_stride = -1
-            for stride in reversed(sliced_strides):
-                # Note that with CuTe layout, we can support slicing flattened non-contiguous mesh dims with no problem.
-                # But this will make this behavior complicated so we decided to not support it for now.
-                if not is_int(stride):
-                    raise NotImplementedError(
-                        "Currently, this only allows slicing out a contiguous flattened dim."
-                    )
-                if stride < pre_stride:
-                    raise KeyError(
-                        f"Invalid mesh_dim_names {mesh_dim_names} specified. "
-                        "Mesh dim indices should be in ascending order."
-                    )
-                pre_stride = stride
-
-            # When users sliced dim_names outside from current mesh, we will check whether
-            # there is layout overlap.
-            # TODO: Eventually we will just directly throw error here because
-            # we will deprecate the slicing of flattened dim_name from root mesh.
-            layout_sliced = _MeshLayout(sliced_sizes, sliced_strides)
-            if not layout_sliced.check_non_overlap():
-                raise RuntimeError(
-                    f"Slicing overlapping dim_names {mesh_dim_names} is not allowed."
-                )
-
-            return layout_sliced
-
-        # TODO: to make this use case by other components public API in the future.
-        def _get_all_submeshes(self, mesh_dim_name: str) -> list["DeviceMesh"]:
-            """
-            Return all the submeshes of a given mesh dimension of the device mesh.
-            """
-            mesh_dim = self.get_mesh_dim_by_name(mesh_dim_name)
-            layout = self._layout[mesh_dim]
-            pg_ranks_by_dim = layout.remap_to_tensor(
-                self.mesh,
-            )
-            cur_rank = self.get_rank()
-            res_submeshes = []
-            for mesh_1d in pg_ranks_by_dim:
-                submesh = DeviceMesh(
-                    self.device_type,
-                    mesh_1d,
-                    mesh_dim_names=(mesh_dim_name,),
-                    _init_backend=False,
-                )
-                submesh._dim_group_names = (  # type: ignore[has-type]
-                    [self._dim_group_names[mesh_dim]]  # type: ignore[has-type]
-                    if cur_rank in mesh_1d
-                    else []
-                )
-                res_submeshes.append(submesh)
-
-            return res_submeshes
-
         @staticmethod
         def _create_mesh_from_ranks(
             device_type: str,
@@ -845,7 +855,6 @@ else:
             backend_override: Optional[tuple[BackendConfig, ...]] = None,
             _init_backend: bool = True,
             _layout: Optional[_MeshLayout] = None,
-            _root_mesh: Optional["DeviceMesh"] = None,
         ) -> "DeviceMesh":
             """
             Helper method to create a DeviceMesh from tensor `pg_ranks_by_dim`. This is due to
@@ -886,8 +895,6 @@ else:
                     f"Current rank {cur_rank} not found in any mesh, "
                     f"input {pg_ranks_by_dim} does not contain all ranks in the world"
                 )
-            if _root_mesh is not None:
-                res_mesh._root_mesh = _root_mesh
             return res_mesh
 
         @staticmethod
@@ -1083,7 +1090,9 @@ else:
             else:
                 backend_override_tuple = (None, None)
 
-            return self._create_flatten_mesh(mesh_dim_name, backend_override_tuple)
+            return _mesh_resources.create_flatten_mesh(
+                self, mesh_dim_name, backend_override_tuple
+            )
 
     def _normalize_backend_override(
         backend_override: dict[


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #164510
* __->__ #164993
* #164954
* #164750

As title, we want to add a deprecate warning for slicing flattened dim from root mesh. Also cosmetic changes for adding types for `_get_slice_mesh_layout`.


cc @H-Huang @awgu @wanchaol @fegin @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci