### PR TITLE
Use runner with more memory for ASAN builds

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -128,6 +128,7 @@ jobs:
     needs: get-label-type
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      runner: linux.2xlarge.memory
       build-environment: linux-jammy-py3.10-clang18-asan
       docker-image-name: ci-image:pytorch-linux-jammy-py3-clang18-asan
       test-matrix: |


### PR DESCRIPTION
An attempt to [address OOM here](https://hud.pytorch.org/hud/pytorch/pytorch/aed5ed1076d3e73e0b6357dafac1002aa6a221e9/1?per_page=50&name_filter=pull%20%2F%20linux-jammy-py3.10-clang18-asan%20%2F%20build&mergeEphemeralLF=true).