### PR TITLE
[flex attention] change "==" to "is" in inspect parameter comparison

### DIFF
--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -243,7 +243,7 @@ def _get_mod_type(fn: Callable) -> _ModificationType:
     num_positional_args = sum(
         1
         for param in inspect.signature(fn).parameters.values()
-        if param.default == inspect.Parameter.empty
+        if param.default is inspect.Parameter.empty
     )
     assert num_positional_args == 5 or num_positional_args == 4
     if num_positional_args == 5:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #165003

Patch for https://github.com/pytorch/pytorch/issues/164760.

This doesn't actually fix the underlying torch function issue though.

Explanation: `is` is traced differently compared to `__eq__`, so we end up avoiding the issue where we attempt to evaluate `torch.eq(tensor, inspect._empty)` in the first place.

cc @Chillee @drisspg @yanboliang @BoyuanFeng