### PR TITLE
Ops convolution_backward optional flag bug

### DIFF
--- a/test/distributed/tensor/test_dtensor_ops.py
+++ b/test/distributed/tensor/test_dtensor_ops.py
@@ -157,6 +157,7 @@ dtensor_fails = {
     xfail("cholesky_solve"),
     xfail("combinations"),
     xfail("complex"),
+    xfail("convolution_backward"),
     xfail("count_nonzero"),
     xfail("cross"),
     xfail("cummax"),

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -8223,7 +8223,9 @@ symbolic_aot_autograd_failures = {
         "nn.functional.fractional_max_pool3d", ""
     ),  # rand() received an invalid combination of arguments - g...
     xfail("trace", ""),  # Cannot call sizes() on tensor with symbolic sizes/strides
-    xfail("convolution_backward", ""),  # Cannot call sizes() on tensor with symbolic sizes/strides
+    xfail(
+        "convolution_backward", ""
+    ),  # Cannot call sizes() on tensor with symbolic sizes/strides
     decorate(
         "linalg.householder_product",
         decorator=unittest.skipIf(IS_MACOS and IS_X86, "flaky"),

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -8223,6 +8223,7 @@ symbolic_aot_autograd_failures = {
         "nn.functional.fractional_max_pool3d", ""
     ),  # rand() received an invalid combination of arguments - g...
     xfail("trace", ""),  # Cannot call sizes() on tensor with symbolic sizes/strides
+    xfail("convolution_backward", ""),  # Cannot call sizes() on tensor with symbolic sizes/strides
     decorate(
         "linalg.householder_product",
         decorator=unittest.skipIf(IS_MACOS and IS_X86, "flaky"),

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -381,6 +381,7 @@ CHECK_STRIDES_SKIPS = {
 
     # channel_last and channel_last_3d related failures
     aten.convolution.default,
+    aten.convolution_backward.default,
 
     # following ops fails if include_storage_offset = True, but these are a bit edge casey
     # we should still fix them, leaving them here for tracking.

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -3534,14 +3534,12 @@ def meta_convolution_backward(
         backend_grad_weight = grad_output_.new_empty(weight_.size())
     if output_mask[2]:
         if bias_sizes_opt:
-            backend_grad_bias = grad_output_.new_empty(bias_sizes_opt.size())
+            backend_grad_bias = grad_output_.new_empty(bias_sizes_opt)
         else:
-            backend_grad_bias = grad_output_.new_empty([])
-            #Optionally could do the following to prepare the tensor
-            #if transposed:
-            #    backend_grad_bias = grad_output_.new_empty(weight_.size(1)*groups)
-            #else:
-            #    backend_grad_bias = grad_output_.new_empty(weight_.size(0))
+            if transposed:
+               backend_grad_bias = grad_output_.new_empty(weight_.size(1)*groups)
+            else:
+               backend_grad_bias = grad_output_.new_empty(weight_.size(0))
     return (backend_grad_input, backend_grad_weight, backend_grad_bias)
 
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -3533,8 +3533,15 @@ def meta_convolution_backward(
     if output_mask[1]:
         backend_grad_weight = grad_output_.new_empty(weight_.size())
     if output_mask[2]:
-        backend_grad_bias = grad_output_.new_empty(bias_sizes_opt)
-
+        if bias_sizes_opt:
+            backend_grad_bias = grad_output_.new_empty(bias_sizes_opt.size())
+        else:
+            backend_grad_bias = grad_output_.new_empty([])
+            #Optionally could do the following to prepare the tensor
+            #if transposed:
+            #    backend_grad_bias = grad_output_.new_empty(weight_.size(1)*groups)
+            #else:
+            #    backend_grad_bias = grad_output_.new_empty(weight_.size(0))
     return (backend_grad_input, backend_grad_weight, backend_grad_bias)
 
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -3537,9 +3537,9 @@ def meta_convolution_backward(
             backend_grad_bias = grad_output_.new_empty(bias_sizes_opt)
         else:
             if transposed:
-               backend_grad_bias = grad_output_.new_empty(weight_.size(1)*groups)
+                backend_grad_bias = grad_output_.new_empty(weight_.size(1) * groups)
             else:
-               backend_grad_bias = grad_output_.new_empty(weight_.size(0))
+                backend_grad_bias = grad_output_.new_empty(weight_.size(0))
     return (backend_grad_input, backend_grad_weight, backend_grad_bias)
 
 

--- a/torch/csrc/lazy/core/shape_inference.cpp
+++ b/torch/csrc/lazy/core/shape_inference.cpp
@@ -254,27 +254,27 @@ std::vector<Shape> compute_shape_convolution_backward(
     int64_t groups,
     ::std::array<bool, 3> output_mask) {
   Shape s0, s1, s2;
-  if (output_mask[0]){
+  if (output_mask[0]) {
     s0 = Shape(input.scalar_type(), input.sizes().vec());
-  } else{
+  } else {
     s0 = Shape();
   }
-  if (output_mask[1]){
+  if (output_mask[1]) {
     s1 = Shape(weight.scalar_type(), weight.sizes().vec());
-  } else{
+  } else {
     s1 = Shape();
   }
-  if (output_mask[2]){
+  if (output_mask[2]) {
     if (bias_sizes.has_value()) {
       s2 = Shape(grad_output.scalar_type(), bias_sizes.value().vec());
-    } else{
-      if (transposed){
+    } else {
+      if (transposed) {
         s2 = Shape(grad_output.scalar_type(), weight.size(1) * groups);
-      } else{
+      } else {
         s2 = Shape(grad_output.scalar_type(), weight.size(0));
       }
     }
-  } else{
+  } else {
     s2 = Shape();
   }
   return {s0, s1, s2};

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -21060,7 +21060,7 @@ op_db: list[OpInfo] = [
             ),
             DecorateInfo(
                 toleranceOverride({torch.float32: tol(atol=2e-3, rtol=2e-3)}),
-                'TestCommon', 'test_noncontiguous_samples', device_type="rocm"
+                'TestCommon', 'test_noncontiguous_samples', active_if=TEST_WITH_ROCM
             ),
             DecorateInfo(
                 toleranceOverride({torch.float32: tol(atol=2e-3, rtol=3e-3)}),
@@ -21072,7 +21072,7 @@ op_db: list[OpInfo] = [
             ),
             DecorateInfo(
                 toleranceOverride({torch.float32: tol(atol=1e-3, rtol=1e-3)}),
-                'TestCompositeCompliance', device_type="rocm"
+                'TestCompositeCompliance', active_if=TEST_WITH_ROCM
             ),
             DecorateInfo(
                 toleranceOverride({torch.float16: tol(atol=2e-3, rtol=6e-1)}),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -21049,11 +21049,26 @@ op_db: list[OpInfo] = [
         aten_name="convolution_backward",
         dtypes=floating_types_and(torch.float16, torch.bfloat16),
         dtypesIfCUDA=floating_types_and(torch.float16, torch.bfloat16),
+        gradcheck_nondet_tol=GRADCHECK_NONDET_TOL,
+        supports_forward_ad=True,
+        supports_fwgrad_bwgrad=True,
         supports_out=False,
         decorators=(
             DecorateInfo(
-                toleranceOverride({torch.float32: tol(atol=5e-4, rtol=1e-6)}),
+                toleranceOverride({torch.float32: tol(atol=5e-4, rtol=2e-6)}),
                 'TestCommon', 'test_noncontiguous_samples',
+            ),
+            DecorateInfo(
+                toleranceOverride({torch.float32: tol(atol=5e-4, rtol=1e-3)}),
+                'TestOperators',
+            ),
+            DecorateInfo(
+                toleranceOverride({torch.float16: tol(atol=2e-3, rtol=6e-1)}),
+                'TestInductorOpInfo', 'test_comprehensive',
+            ),
+            DecorateInfo(
+                toleranceOverride({torch.float32: tol(atol=5e-4, rtol=5e-4)}),
+                'TestVmapOperatorsOpInfo', 'test_vmap_exhaustive',
             ),
         ),
         sample_inputs_func=sample_inputs_convolution_backward

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8054,7 +8054,7 @@ def sample_inputs_convolution_backward(op_info, device, dtype, requires_grad, **
                 [True, False],
                 [True, False],
                 [1, 4],
-                [[M, M, M, L, L], [M, M, S, L, L]]
+                [[S, M, M, L, L], [S, M, S, L, L]]
         ):
             [N, C_in, C_out, H_out, W_out] = tensor_sizes
             C_in = (C_in // groups) * groups
@@ -21088,6 +21088,8 @@ op_db: list[OpInfo] = [
                          'TestConsistency', 'test_output_match', device_type="mps"),
             DecorateInfo(unittest.expectedFailure,
                          'TestConsistency', 'test_output_grad_match', device_type="mps"),
+            # Tuples not supported
+            DecorateInfo(unittest.expectedFailure, 'TestNNCOpInfo'),
         ),
         sample_inputs_func=sample_inputs_convolution_backward
     ),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -21059,12 +21059,20 @@ op_db: list[OpInfo] = [
                 'TestCommon', 'test_noncontiguous_samples',
             ),
             DecorateInfo(
+                toleranceOverride({torch.float32: tol(atol=2e-3, rtol=2e-3)}),
+                'TestCommon', 'test_noncontiguous_samples', device_type="rocm"
+            ),
+            DecorateInfo(
                 toleranceOverride({torch.float32: tol(atol=2e-3, rtol=3e-3)}),
                 'TestOperators',
             ),
             DecorateInfo(
                 toleranceOverride({torch.float32: tol(atol=5e-4, rtol=2e-5)}),
                 'TestCompositeCompliance',
+            ),
+            DecorateInfo(
+                toleranceOverride({torch.float32: tol(atol=1e-3, rtol=1e-3)}),
+                'TestCompositeCompliance', device_type="rocm"
             ),
             DecorateInfo(
                 toleranceOverride({torch.float16: tol(atol=2e-3, rtol=6e-1)}),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -21050,6 +21050,12 @@ op_db: list[OpInfo] = [
         dtypes=floating_types_and(torch.float16, torch.bfloat16),
         dtypesIfCUDA=floating_types_and(torch.float16, torch.bfloat16),
         supports_out=False,
+        decorators=(
+            DecorateInfo(
+                toleranceOverride({torch.float32: tol(atol=5e-4, rtol=1e-6)}),
+                'TestCommon', 'test_noncontiguous_samples',
+            ),
+        ),
         sample_inputs_func=sample_inputs_convolution_backward
     ),
     OpInfo(

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -21059,8 +21059,12 @@ op_db: list[OpInfo] = [
                 'TestCommon', 'test_noncontiguous_samples',
             ),
             DecorateInfo(
-                toleranceOverride({torch.float32: tol(atol=5e-4, rtol=1e-3)}),
+                toleranceOverride({torch.float32: tol(atol=2e-3, rtol=3e-3)}),
                 'TestOperators',
+            ),
+            DecorateInfo(
+                toleranceOverride({torch.float32: tol(atol=5e-4, rtol=2e-5)}),
+                'TestCompositeCompliance',
             ),
             DecorateInfo(
                 toleranceOverride({torch.float16: tol(atol=2e-3, rtol=6e-1)}),
@@ -21070,6 +21074,12 @@ op_db: list[OpInfo] = [
                 toleranceOverride({torch.float32: tol(atol=5e-4, rtol=5e-4)}),
                 'TestVmapOperatorsOpInfo', 'test_vmap_exhaustive',
             ),
+        ),
+        skips=(
+            DecorateInfo(unittest.expectedFailure,
+                         'TestConsistency', 'test_output_match', device_type="mps"),
+            DecorateInfo(unittest.expectedFailure,
+                         'TestConsistency', 'test_output_grad_match', device_type="mps"),
         ),
         sample_inputs_func=sample_inputs_convolution_backward
     ),


### PR DESCRIPTION
Fixes #89629

When using torch.ops.aten.convolution_backward, the optional argument bias_sizes was being used in the python function registration without checking whether it was defined.

## For the fix 
there are two modes to consider with different results.

First @dynamo.optimize("inductor") is the most demanding. 
We cannot be wrong about the size passed into the function. But we should not ignore what the user wants/thinks they are doing. For this case, we want to throw an error when the user is wrong. If the user passes in None, we calculate the expected size directly.

Second @dynamo.optimize("eager") is very lenient. 
We really can provide any value we want here. If the user is wrong about bias shape in eager mode, the op will just reshape the bias to the proper size so no error is thrown here.

## For testing
An OpInfo was added for torch.ops.aten.convolution_backward.default.
For the CUDA test_noncontiguous_samples test, a slightly updated error tolerance was necessary for the compounded add multiply (for 2x2 kernel).

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela @mlazos