### PR TITLE
[inductor] custom_graph_pass.get_hash_for_files: don't hash paths

### DIFF
--- a/torch/_inductor/custom_graph_pass.py
+++ b/torch/_inductor/custom_graph_pass.py
@@ -92,7 +92,9 @@ CustomGraphPassType: TypeAlias = Optional[
 
 
 @lru_cache(1)
-def get_hash_for_files(paths: tuple[str], extra: str = "") -> bytes:
+def get_hash_for_files(
+    paths: tuple[str], extra: str = "", hash_paths: bool = True
+) -> bytes:
     """
     Helper to compute a unique string by hashing the contents of a list of files.
     """
@@ -100,7 +102,8 @@ def get_hash_for_files(paths: tuple[str], extra: str = "") -> bytes:
     hasher.update(extra.encode("utf-8"))
     for path in paths:
         with open(path, "rb") as f:
-            hasher.update(path.encode("utf-8"))
+            if hash_paths:
+                hasher.update(path.encode("utf-8"))
             hasher.update(f.read())
     return hasher.digest()
 

--- a/torch/_inductor/custom_graph_pass.py
+++ b/torch/_inductor/custom_graph_pass.py
@@ -92,9 +92,7 @@ CustomGraphPassType: TypeAlias = Optional[
 
 
 @lru_cache(1)
-def get_hash_for_files(
-    paths: tuple[str], extra: str = "", hash_paths: bool = True
-) -> bytes:
+def get_hash_for_files(paths: tuple[str], extra: str = "") -> bytes:
     """
     Helper to compute a unique string by hashing the contents of a list of files.
     """
@@ -102,8 +100,6 @@ def get_hash_for_files(
     hasher.update(extra.encode("utf-8"))
     for path in paths:
         with open(path, "rb") as f:
-            if hash_paths:
-                hasher.update(path.encode("utf-8"))
             hasher.update(f.read())
     return hasher.digest()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #165020

Summary: We have an internal user where caching broke because the paths that are unzipped are probably different per host. We can't think of a use case where a path change matters when the file content has not changed, so removing this part

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben