### PR TITLE
[PyTorch][aarch64] Cast to signed char to fix aarch64 build

### DIFF
--- a/torch/csrc/jit/serialization/pickler_helper.h
+++ b/torch/csrc/jit/serialization/pickler_helper.h
@@ -53,7 +53,8 @@ enum class PickleOpCode : char {
   BINFLOAT = 'G',
 
   // Protocol 2
-  PROTO = '\x80',
+  // NOLINTNEXTLINE(readability-redundant-inline-specifier)
+  PROTO = char('\x80'),
   NEWOBJ = '\x81',
   EXT1 = '\x82',
   EXT2 = '\x83',
@@ -71,7 +72,8 @@ enum class PickleOpCode : char {
   SHORT_BINBYTES = 'C',
 
   // Protocol 4
-  SHORT_BINUNICODE = '\x8c',
+  // NOLINTNEXTLINE(readability-redundant-inline-specifier)
+  SHORT_BINUNICODE = char('\x8c'),
   BINUNICODE8 = '\x8d',
   BINBYTES8 = '\x8e',
   EMPTY_SET = '\x8f',


### PR DESCRIPTION
Summary:
Initial fix: D39198776
Reverted by clang-tidy bot: D83948172

Test Plan:
Can now build on aarch64
{P1983767795}

Reviewed By: bigning

Differential Revision: D84203406




cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel