### PR TITLE
Fix identity expansion

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2486,12 +2486,14 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
             torch.zeros(1, 32, dtype=torch.int64, device=device),
             torch.zeros(1, dtype=torch.int32, device=device),
         )
-
         # This crashes
-        compile_out = torch.compile(f)(
+        compile_out, code = run_and_get_code(torch.compile(f),
             torch.zeros(1, 32, dtype=torch.int64, device=device),
             torch.zeros(1, dtype=torch.int32, device=device),
         )
+        # make sure the identity is maintained
+        FileCheck().check("(1 + ((31)").run(code[0])
+
         self.assertEqual(eager_out, compile_out)
 
     def test_qwen2_7b_sdpa_input_alignment_requires_recompile(self):

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2461,6 +2461,39 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
 
         self.assertEqual(eager, compiled)
 
+    def test_identity_load(self):
+        device = "cuda"
+
+        def f(x, y):
+            y2 = torch.cat(
+                [
+                    x[:, 1:],
+                    y[:, None] + 32 * 2048,
+                ],
+                dim=1,
+            )
+
+            x2 = x[:, 1:, None]
+            y3 = y2[:, -1:, None]
+
+            return (
+                torch.cat([x2, y3], dim=1)
+                + torch.arange(-2048, 0, device=device)[None, None, :]
+            ).reshape(1, 32 * 2048)
+
+        # This succeeds
+        eager_out = f(
+            torch.zeros(1, 32, dtype=torch.int64, device=device),
+            torch.zeros(1, dtype=torch.int32, device=device),
+        )
+
+        # This crashes
+        compile_out = torch.compile(f)(
+            torch.zeros(1, 32, dtype=torch.int64, device=device),
+            torch.zeros(1, dtype=torch.int32, device=device),
+        )
+        self.assertEqual(eager_out, compile_out)
+
     def test_qwen2_7b_sdpa_input_alignment_requires_recompile(self):
         # SDPA constraints ensures inputs have alignment (8).
         device = "cuda"

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2430,7 +2430,8 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
             torch.zeros(1, dtype=torch.int32, device=device),
         )
         # This crashes
-        compile_out, code = run_and_get_code(torch.compile(f),
+        compile_out, code = run_and_get_code(
+            torch.compile(f),
             torch.zeros(1, 32, dtype=torch.int64, device=device),
             torch.zeros(1, dtype=torch.int32, device=device),
         )

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2759,8 +2759,11 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     line, indexing.block_shape, indexing.final_shape, True
                 )
                 shape = indexing.final_shape
-            elif isinstance(original_index, sympy.Integer):
-                line = f"tl.load({var} + ({original_index}))"
+            elif isinstance(original_index, sympy.Integer) or (
+                isinstance(original_index, sympy.Expr)
+                and len(original_index.free_symbols) == 0
+            ):
+                line = f"tl.load({var} + ({original_index.expand(identity=True)}))"
                 append_broadcast = indexing.expand_str
                 shape = ()
             else:

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -120,6 +120,18 @@ fusion_log = torch._logging.getArtifactLogger(__name__, "fusion")
 async_compile = AsyncCompile()
 
 
+def is_sympy_integer_like(expr: object):
+    """ "
+    Is this expression a Sympy Integer or is it an integer sympy Expr
+    containing no free symbols. The latter case can happen with Identity expr.
+    """
+    if not isinstance(expr, sympy.Expr):
+        return False
+    return isinstance(expr, sympy.Integer) or (
+        expr.is_integer and len(expr.free_symbols) == 0
+    )
+
+
 class OpDtypeSupport:
     """
     Some Triton ops such as libdevice and tl.math only support float32 and float64.
@@ -2414,7 +2426,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             else:
                 return self.dense_size_str(), tuple(self.dense_size_list())
 
-        if isinstance(index, sympy.Integer):
+        if is_sympy_integer_like(index):
             expand_str, expand_shape = _get_expand_str()
             index_str = f"tl.full({expand_str}, {index_str}, tl.int32)"
             if self.fixed_config and not self._has_constant_xmask():
@@ -2759,11 +2771,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     line, indexing.block_shape, indexing.final_shape, True
                 )
                 shape = indexing.final_shape
-            elif isinstance(original_index, sympy.Integer) or (
-                isinstance(original_index, sympy.Expr)
-                and len(original_index.free_symbols) == 0
-            ):
-                line = f"tl.load({var} + ({original_index.expand(identity=True)}))"
+            elif is_sympy_integer_like(original_index):
+                line = f"tl.load({var} + ({original_index}))"
                 append_broadcast = indexing.expand_str
                 shape = ()
             else:

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -1298,6 +1298,10 @@ class Identity(sympy.Function):
     def __repr__(self):  # type: ignore[override]
         return f"Identity({self.args[0]})"
 
+    def _sympystr(self, printer):
+        """Controls how sympy's StrPrinter prints this"""
+        return f"({printer.doprint(self.args[0])})"
+
     def _eval_is_real(self):
         return self.args[0].is_real
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #165064
* __->__ #165066

In some cases, we wrap indexing with `Identity` to prevent expansion from int32 -> int64 range. There are some checks in codegen which intend to check for constants, which did not handle Identity. Update these checks and update Identity so that it recursively prints inputs.

Fix for https://github.com/pytorch/pytorch/issues/164700

Replaces https://github.com/pytorch/pytorch/pull/160190 cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @njriasan

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben