### PR TITLE
Fix int32 overflow in embedding_dense_backward

### DIFF
--- a/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
@@ -88,9 +88,9 @@ __global__ void compute_grad_weight_bags(
     const int64_t stride_warped) {
 
   int64_t num_of_segments = *num_of_segments_ptr;
-  const int gid = blockIdx.x * blockDim.x + threadIdx.x;
-  const int id = gid / stride_warped;
-  const int startFeature = gid % stride_warped;
+  const int64_t gid = blockIdx.x * blockDim.x + threadIdx.x;
+  const int64_t id = gid / stride_warped;
+  const int64_t startFeature = gid % stride_warped;
   if (startFeature >= stride) {
     return;
   }
@@ -134,9 +134,9 @@ __global__ void compute_grad_weight(
 
   int64_t num_of_segments = *num_of_segments_ptr;
   using accscalar_t = acc_type<scalar_t, true>;
-  const int gid = blockIdx.x * blockDim.x + threadIdx.x;
-  const int id = gid / stride_warped;
-  const int startFeature = gid % stride_warped;
+  const int64_t gid = blockIdx.x * blockDim.x + threadIdx.x;
+  const int64_t id = gid / stride_warped;
+  const int64_t startFeature = gid % stride_warped;
   if (startFeature >= stride) {
     return;
   }
@@ -167,9 +167,9 @@ __global__ void sum_and_scatter(
 
   int64_t num_of_segments = *num_of_segments_ptr;
   int64_t num_of_partial_segments = *num_of_partial_segments_ptr;
-  const int gid = blockIdx.x * blockDim.x + threadIdx.x;
-  const int id = gid / stride_warped;
-  const int startFeature = gid % stride_warped;
+  const int64_t gid = blockIdx.x * blockDim.x + threadIdx.x;
+  const int64_t id = gid / stride_warped;
+  const int64_t startFeature = gid % stride_warped;
   if (startFeature >= stride) {
     return;
   }

--- a/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
@@ -88,7 +88,7 @@ __global__ void compute_grad_weight_bags(
     const int64_t stride_warped) {
 
   int64_t num_of_segments = *num_of_segments_ptr;
-  const int64_t gid = blockIdx.x * blockDim.x + threadIdx.x;
+  const int64_t gid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   const int64_t id = gid / stride_warped;
   const int64_t startFeature = gid % stride_warped;
   if (startFeature >= stride) {
@@ -134,7 +134,7 @@ __global__ void compute_grad_weight(
 
   int64_t num_of_segments = *num_of_segments_ptr;
   using accscalar_t = acc_type<scalar_t, true>;
-  const int64_t gid = blockIdx.x * blockDim.x + threadIdx.x;
+  const int64_t gid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   const int64_t id = gid / stride_warped;
   const int64_t startFeature = gid % stride_warped;
   if (startFeature >= stride) {
@@ -167,7 +167,7 @@ __global__ void sum_and_scatter(
 
   int64_t num_of_segments = *num_of_segments_ptr;
   int64_t num_of_partial_segments = *num_of_partial_segments_ptr;
-  const int64_t gid = blockIdx.x * blockDim.x + threadIdx.x;
+  const int64_t gid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   const int64_t id = gid / stride_warped;
   const int64_t startFeature = gid % stride_warped;
   if (startFeature >= stride) {

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -638,7 +638,7 @@ class TestEmbeddingNNDeviceType(NNTestCase):
     def test_embedding_backward_large_batch_overflow(self, device, dtype):
         """
         Test that embedding_dense_backward handles large batches that exceed INT32_MAX thread IDs.
-        
+
         This reproduces the bug where gid = blockIdx.x * blockDim.x + threadIdx.x overflows
         when declared as int32, causing negative indices and illegal memory access.
         """
@@ -648,46 +648,46 @@ class TestEmbeddingNNDeviceType(NNTestCase):
         num_weights = 1280
         padding_idx = -1
         scale_grad_by_freq = False
-        
+
         # Verify parameters guarantee overflow
         NROWS_PER_THREAD = 10
         max_segments = min(num_indices, num_weights)
         min_partial_for_overflow = (2**31) // 4096
         required_indices = (min_partial_for_overflow - max_segments) * NROWS_PER_THREAD
-        
+
         assert num_indices > required_indices, \
             f"Test bug: num_indices={num_indices:,} too small! Need >{required_indices:,}"
-        
+
         # Generate indices that create many partial segments
         # Strategy: ~950 unique indices, each appearing many times
         num_unique = 954
         unique_indices = torch.randint(2, 1276, (num_unique,), dtype=torch.int64, device=device)
         counts = torch.randint(5000, 12000, (num_unique,), dtype=torch.int64, device=device)
-        
+
         # Normalize to exactly num_indices
         counts = (counts.float() / counts.float().sum() * num_indices).long()
         counts[-1] = num_indices - counts[:-1].sum()
-        
+
         indices = torch.repeat_interleave(unique_indices, counts)
         assert indices.numel() == num_indices
-        
+
         # Verify we'll trigger overflow
         approx_partial_segments = num_indices // NROWS_PER_THREAD + max_segments
         stride_warped = ((embedding_dim + 31) // 32) * 32
         total_threads = approx_partial_segments * stride_warped
-        
+
         assert total_threads > 2**31 - 1, \
             f"Test bug: threads={total_threads:,} <= INT32_MAX, won't trigger overflow!"
-        
+
         # Create gradient output
         grad_output = torch.randn(num_indices, embedding_dim, dtype=dtype, device=device)
-        
+
         # This should complete without error (after fix)
         # Before fix: RuntimeError with "illegal memory access"
         grad_weight = torch.ops.aten.embedding_dense_backward(
             grad_output, indices, num_weights, padding_idx, scale_grad_by_freq
         )
-        
+
         # Verify output shape
         assert grad_weight.shape == (num_weights, embedding_dim)
         assert grad_weight.dtype == torch.bfloat16

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -636,61 +636,61 @@ class TestEmbeddingNNDeviceType(NNTestCase):
     @dtypes(torch.bfloat16,)
     @largeTensorTest
     def test_embedding_backward_large_batch_overflow(self, device, dtype):
-    """
-    Test that embedding_dense_backward handles large batches that exceed INT32_MAX thread IDs.
-    
-    This reproduces the bug where gid = blockIdx.x * blockDim.x + threadIdx.x overflows
-    when declared as int32, causing negative indices and illegal memory access.
-    """
-    # Parameters chosen to GUARANTEE int32 overflow
-    num_indices = 8_214_880
-    embedding_dim = 4096
-    num_weights = 1280
-    padding_idx = -1
-    scale_grad_by_freq = False
-    
-    # Verify parameters guarantee overflow
-    NROWS_PER_THREAD = 10
-    max_segments = min(num_indices, num_weights)
-    min_partial_for_overflow = (2**31) // 4096
-    required_indices = (min_partial_for_overflow - max_segments) * NROWS_PER_THREAD
-    
-    assert num_indices > required_indices, \
-        f"Test bug: num_indices={num_indices:,} too small! Need >{required_indices:,}"
-    
-    # Generate indices that create many partial segments
-    # Strategy: ~950 unique indices, each appearing many times
-    num_unique = 954
-    unique_indices = torch.randint(2, 1276, (num_unique,), dtype=torch.int64, device=device)
-    counts = torch.randint(5000, 12000, (num_unique,), dtype=torch.int64, device=device)
-    
-    # Normalize to exactly num_indices
-    counts = (counts.float() / counts.float().sum() * num_indices).long()
-    counts[-1] = num_indices - counts[:-1].sum()
-    
-    indices = torch.repeat_interleave(unique_indices, counts)
-    assert indices.numel() == num_indices
-    
-    # Verify we'll trigger overflow
-    approx_partial_segments = num_indices // NROWS_PER_THREAD + max_segments
-    stride_warped = ((embedding_dim + 31) // 32) * 32
-    total_threads = approx_partial_segments * stride_warped
-    
-    assert total_threads > 2**31 - 1, \
-        f"Test bug: threads={total_threads:,} <= INT32_MAX, won't trigger overflow!"
-    
-    # Create gradient output
-    grad_output = torch.randn(num_indices, embedding_dim, dtype=dtype, device=device)
-    
-    # This should complete without error (after fix)
-    # Before fix: RuntimeError with "illegal memory access"
-    grad_weight = torch.ops.aten.embedding_dense_backward(
-        grad_output, indices, num_weights, padding_idx, scale_grad_by_freq
-    )
-    
-    # Verify output shape
-    assert grad_weight.shape == (num_weights, embedding_dim)
-    assert grad_weight.dtype == torch.bfloat16
+        """
+        Test that embedding_dense_backward handles large batches that exceed INT32_MAX thread IDs.
+        
+        This reproduces the bug where gid = blockIdx.x * blockDim.x + threadIdx.x overflows
+        when declared as int32, causing negative indices and illegal memory access.
+        """
+        # Parameters chosen to GUARANTEE int32 overflow
+        num_indices = 8_214_880
+        embedding_dim = 4096
+        num_weights = 1280
+        padding_idx = -1
+        scale_grad_by_freq = False
+        
+        # Verify parameters guarantee overflow
+        NROWS_PER_THREAD = 10
+        max_segments = min(num_indices, num_weights)
+        min_partial_for_overflow = (2**31) // 4096
+        required_indices = (min_partial_for_overflow - max_segments) * NROWS_PER_THREAD
+        
+        assert num_indices > required_indices, \
+            f"Test bug: num_indices={num_indices:,} too small! Need >{required_indices:,}"
+        
+        # Generate indices that create many partial segments
+        # Strategy: ~950 unique indices, each appearing many times
+        num_unique = 954
+        unique_indices = torch.randint(2, 1276, (num_unique,), dtype=torch.int64, device=device)
+        counts = torch.randint(5000, 12000, (num_unique,), dtype=torch.int64, device=device)
+        
+        # Normalize to exactly num_indices
+        counts = (counts.float() / counts.float().sum() * num_indices).long()
+        counts[-1] = num_indices - counts[:-1].sum()
+        
+        indices = torch.repeat_interleave(unique_indices, counts)
+        assert indices.numel() == num_indices
+        
+        # Verify we'll trigger overflow
+        approx_partial_segments = num_indices // NROWS_PER_THREAD + max_segments
+        stride_warped = ((embedding_dim + 31) // 32) * 32
+        total_threads = approx_partial_segments * stride_warped
+        
+        assert total_threads > 2**31 - 1, \
+            f"Test bug: threads={total_threads:,} <= INT32_MAX, won't trigger overflow!"
+        
+        # Create gradient output
+        grad_output = torch.randn(num_indices, embedding_dim, dtype=dtype, device=device)
+        
+        # This should complete without error (after fix)
+        # Before fix: RuntimeError with "illegal memory access"
+        grad_weight = torch.ops.aten.embedding_dense_backward(
+            grad_output, indices, num_weights, padding_idx, scale_grad_by_freq
+        )
+        
+        # Verify output shape
+        assert grad_weight.shape == (num_weights, embedding_dim)
+        assert grad_weight.dtype == torch.bfloat16
 
 
     # Check correctness of torch.nn.functional.embedding_bag forward and

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -632,6 +632,66 @@ class TestEmbeddingNNDeviceType(NNTestCase):
                     weights.grad, weights_check.grad, msg=msg, atol=atol, rtol=rtol
                 )
 
+    @onlyCUDA
+    @dtypes(torch.bfloat16,)
+    def test_embedding_backward_large_batch_overflow(self, device, dtype):
+    	"""
+    	Test that embedding_dense_backward handles large batches that exceed INT32_MAX thread IDs.
+
+    	This reproduces the bug where gid = blockIdx.x * blockDim.x + threadIdx.x overflows
+    	when declared as int32, causing negative indices and illegal memory access.
+    	"""
+    	# Parameters chosen to GUARANTEE int32 overflow
+    	num_indices = 8_214_880
+    	embedding_dim = 4096
+    	num_weights = 1280
+    	padding_idx = -1
+    	scale_grad_by_freq = False
+
+    	# Verify parameters guarantee overflow
+    	NROWS_PER_THREAD = 10
+    	max_segments = min(num_indices, num_weights)
+    	min_partial_for_overflow = (2**31) // 4096
+    	required_indices = (min_partial_for_overflow - max_segments) * NROWS_PER_THREAD
+
+    	assert num_indices > required_indices, \
+    	    f"Test bug: num_indices={num_indices:,} too small! Need >{required_indices:,}"
+
+    	# Generate indices that create many partial segments
+    	# Strategy: ~950 unique indices, each appearing many times
+    	num_unique = 954
+    	unique_indices = torch.randint(2, 1276, (num_unique,), dtype=torch.int64, device=device)
+    	counts = torch.randint(5000, 12000, (num_unique,), dtype=torch.int64, device=device)
+
+    	# Normalize to exactly num_indices
+    	counts = (counts.float() / counts.float().sum() * num_indices).long()
+    	counts[-1] = num_indices - counts[:-1].sum()
+
+    	indices = torch.repeat_interleave(unique_indices, counts)
+    	assert indices.numel() == num_indices
+
+    	# Verify we'll trigger overflow
+    	approx_partial_segments = num_indices // NROWS_PER_THREAD + max_segments
+    	stride_warped = ((embedding_dim + 31) // 32) * 32
+    	total_threads = approx_partial_segments * stride_warped
+
+    	assert total_threads > 2**31 - 1, \
+    	    f"Test bug: threads={total_threads:,} <= INT32_MAX, won't trigger overflow!"
+
+    	# Create gradient output
+    	grad_output = torch.randn(num_indices, embedding_dim, dtype=dtype, device=device)
+
+    	# This should complete without error (after fix)
+    	# Before fix: RuntimeError with "illegal memory access"
+    	grad_weight = torch.ops.aten.embedding_dense_backward(
+    	    grad_output, indices, num_weights, padding_idx, scale_grad_by_freq
+    	)
+
+    	# Verify output shape
+    	assert grad_weight.shape == (num_weights, embedding_dim)
+    	assert grad_weight.dtype == torch.bfloat16
+
+
     # Check correctness of torch.nn.functional.embedding_bag forward and
     # backward functions with padding_idx, given a 2D indices input. Compare
     # against torch.nn.functional.embedding followed by a reduction.

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -636,7 +636,7 @@ class TestEmbeddingNNDeviceType(NNTestCase):
     @dtypes(
         torch.bfloat16,
     )
-    @largeTensorTest
+    @largeTensorTest("80GB", device="cuda")
     def test_embedding_backward_large_batch_overflow(self, device, dtype):
         """
         Test that embedding_dense_backward handles large batches that exceed INT32_MAX thread IDs.

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -634,62 +634,63 @@ class TestEmbeddingNNDeviceType(NNTestCase):
 
     @onlyCUDA
     @dtypes(torch.bfloat16,)
+    @largeTensorTest
     def test_embedding_backward_large_batch_overflow(self, device, dtype):
-    	"""
-    	Test that embedding_dense_backward handles large batches that exceed INT32_MAX thread IDs.
-
-    	This reproduces the bug where gid = blockIdx.x * blockDim.x + threadIdx.x overflows
-    	when declared as int32, causing negative indices and illegal memory access.
-    	"""
-    	# Parameters chosen to GUARANTEE int32 overflow
-    	num_indices = 8_214_880
-    	embedding_dim = 4096
-    	num_weights = 1280
-    	padding_idx = -1
-    	scale_grad_by_freq = False
-
-    	# Verify parameters guarantee overflow
-    	NROWS_PER_THREAD = 10
-    	max_segments = min(num_indices, num_weights)
-    	min_partial_for_overflow = (2**31) // 4096
-    	required_indices = (min_partial_for_overflow - max_segments) * NROWS_PER_THREAD
-
-    	assert num_indices > required_indices, \
-    	    f"Test bug: num_indices={num_indices:,} too small! Need >{required_indices:,}"
-
-    	# Generate indices that create many partial segments
-    	# Strategy: ~950 unique indices, each appearing many times
-    	num_unique = 954
-    	unique_indices = torch.randint(2, 1276, (num_unique,), dtype=torch.int64, device=device)
-    	counts = torch.randint(5000, 12000, (num_unique,), dtype=torch.int64, device=device)
-
-    	# Normalize to exactly num_indices
-    	counts = (counts.float() / counts.float().sum() * num_indices).long()
-    	counts[-1] = num_indices - counts[:-1].sum()
-
-    	indices = torch.repeat_interleave(unique_indices, counts)
-    	assert indices.numel() == num_indices
-
-    	# Verify we'll trigger overflow
-    	approx_partial_segments = num_indices // NROWS_PER_THREAD + max_segments
-    	stride_warped = ((embedding_dim + 31) // 32) * 32
-    	total_threads = approx_partial_segments * stride_warped
-
-    	assert total_threads > 2**31 - 1, \
-    	    f"Test bug: threads={total_threads:,} <= INT32_MAX, won't trigger overflow!"
-
-    	# Create gradient output
-    	grad_output = torch.randn(num_indices, embedding_dim, dtype=dtype, device=device)
-
-    	# This should complete without error (after fix)
-    	# Before fix: RuntimeError with "illegal memory access"
-    	grad_weight = torch.ops.aten.embedding_dense_backward(
-    	    grad_output, indices, num_weights, padding_idx, scale_grad_by_freq
-    	)
-
-    	# Verify output shape
-    	assert grad_weight.shape == (num_weights, embedding_dim)
-    	assert grad_weight.dtype == torch.bfloat16
+    """
+    Test that embedding_dense_backward handles large batches that exceed INT32_MAX thread IDs.
+    
+    This reproduces the bug where gid = blockIdx.x * blockDim.x + threadIdx.x overflows
+    when declared as int32, causing negative indices and illegal memory access.
+    """
+    # Parameters chosen to GUARANTEE int32 overflow
+    num_indices = 8_214_880
+    embedding_dim = 4096
+    num_weights = 1280
+    padding_idx = -1
+    scale_grad_by_freq = False
+    
+    # Verify parameters guarantee overflow
+    NROWS_PER_THREAD = 10
+    max_segments = min(num_indices, num_weights)
+    min_partial_for_overflow = (2**31) // 4096
+    required_indices = (min_partial_for_overflow - max_segments) * NROWS_PER_THREAD
+    
+    assert num_indices > required_indices, \
+        f"Test bug: num_indices={num_indices:,} too small! Need >{required_indices:,}"
+    
+    # Generate indices that create many partial segments
+    # Strategy: ~950 unique indices, each appearing many times
+    num_unique = 954
+    unique_indices = torch.randint(2, 1276, (num_unique,), dtype=torch.int64, device=device)
+    counts = torch.randint(5000, 12000, (num_unique,), dtype=torch.int64, device=device)
+    
+    # Normalize to exactly num_indices
+    counts = (counts.float() / counts.float().sum() * num_indices).long()
+    counts[-1] = num_indices - counts[:-1].sum()
+    
+    indices = torch.repeat_interleave(unique_indices, counts)
+    assert indices.numel() == num_indices
+    
+    # Verify we'll trigger overflow
+    approx_partial_segments = num_indices // NROWS_PER_THREAD + max_segments
+    stride_warped = ((embedding_dim + 31) // 32) * 32
+    total_threads = approx_partial_segments * stride_warped
+    
+    assert total_threads > 2**31 - 1, \
+        f"Test bug: threads={total_threads:,} <= INT32_MAX, won't trigger overflow!"
+    
+    # Create gradient output
+    grad_output = torch.randn(num_indices, embedding_dim, dtype=dtype, device=device)
+    
+    # This should complete without error (after fix)
+    # Before fix: RuntimeError with "illegal memory access"
+    grad_weight = torch.ops.aten.embedding_dense_backward(
+        grad_output, indices, num_weights, padding_idx, scale_grad_by_freq
+    )
+    
+    # Verify output shape
+    assert grad_weight.shape == (num_weights, embedding_dim)
+    assert grad_weight.dtype == torch.bfloat16
 
 
     # Check correctness of torch.nn.functional.embedding_bag forward and


### PR DESCRIPTION
If `max_partial_segment` is large we can overflow `gid` and cause a bunch of IMA. 