### PR TITLE
[DebugMode] record inductor compiled graph calls

### DIFF
--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -51,6 +51,7 @@ from torch._inductor.utils import (
     set_tracing_context_output_strides,
 )
 from torch.autograd.profiler import record_function
+from torch.utils._debug_mode import get_active_debug_mode
 from torch.utils._ordered_set import OrderedSet
 
 from . import config
@@ -591,6 +592,15 @@ class CompiledFxGraph(OutputCode):
     def __call__(self, inputs: Sequence[Any]) -> Any:
         assert self.current_callable is not None
 
+        if (debug_mode := get_active_debug_mode()) is not None:
+            debug_mode.record_inductor_graph_call(
+                post_grad_graph=self.inductor_post_grad_graph_str,
+                cache_key=self._fx_graph_cache_key,
+                inputs=tuple(inputs),
+                fx_kwargs=dict(self.fx_kwargs),
+            )
+            debug_mode.call_depth += 1  # manually indent call_depth to avoid context manager usage
+
         if (
             torch._inductor.debug.RECORD_GRAPH_EXECUTION
             and torch._inductor.debug.GRAPH_EXECUTION_ORDER is not None
@@ -613,9 +623,12 @@ class CompiledFxGraph(OutputCode):
                 with record_function(
                     f"## Call CompiledFxGraph {self._fx_graph_cache_key} ##"
                 ):
-                    return self.current_callable(inputs)
+                    result = self.current_callable(inputs)
             else:
-                return self.current_callable(inputs)
+                result = self.current_callable(inputs)
+            if debug_mode:
+                debug_mode.call_depth -= 1
+            return result
         finally:
             get_runtime_metrics_context().finish()
             AutotuneCacheBundler.end_compile()


### PR DESCRIPTION
Example for `torch.mm(x, y).sum().backward()` on 2 DTensors:
```
    inductor_graph_call(
      inputs: (t: f32[1, 8], t: f32[1, 32])
      cache_key: f3ckshcwfrbbfxcrcc2psb62hbl3mmp5wbqbb3uymncnixzbqyp2
      fx_kwargs: {static_input_idxs=[], cudagraphs=BoxedBool(value=False), graph_id=0, is_inference=False, boxed_forward_device_index=BoxedDeviceIndex(value=None), is_backward=False, cpp_wrapper=False, fx_wrapper=False, layout_opt=None, extern_node_serializer=None}
      post_grad_graph:
        class GraphModule(torch.nn.Module):
            def forward(self, primals_1: "f32[1, 8][8, 1]cuda:0", primals_2: "f32[1, 32][32, 1]cuda:0"):
                 # File: /data/users/pianpwk/ptclone/pytorch/test/distributed/tensor/debug/test_debug_mode.py:300 in fn, code: return torch.mm(x, y)
                all_gather_into_tensor: "f32[8, 32][32, 1]cuda:0" = torch.ops._c10d_functional.all_gather_into_tensor.default(primals_2, 8, '0');  primals_2 = None
                wait_tensor: "f32[8, 32][32, 1]cuda:0" = torch.ops._c10d_functional.wait_tensor.default(all_gather_into_tensor);  all_gather_into_tensor = None
                mm: "f32[1, 32][32, 1]cuda:0" = torch.ops.aten.mm.default(primals_1, wait_tensor);  wait_tensor = None
                permute: "f32[8, 1][1, 8]cuda:0" = torch.ops.aten.permute.default(primals_1, [1, 0]);  primals_1 = None
                return (mm, permute)
    )
      _c10d_functional::all_gather_into_tensor(t: f32[1, 32], 8, 0)
      _c10d_functional::wait_tensor(t: f32[8, 32])
      aten::mm.out(t: f32[1, 8], t: f32[8, 32], out=t: f32[1, 32])
  aten::sum(dt: f32[8, 32][S(0)])
    aten::sum(t: f32[1, 32])
  aten::ones_like(dt: f32[][P], pin_memory=False, memory_format=torch.preserve_format)
    aten::ones_like(t: f32[], pin_memory=False, memory_format=torch.preserve_format)
  aten::expand(dt: f32[][R], [8, 32])
    aten::expand(t: f32[], [8, 32])
    redistribute_input(t: f32[8, 32], [R] -> [S(0)])
      aten::split.Tensor(t: f32[8, 32], 1)
      aten::clone(t: f32[1, 32])
  aten::clone(dt: f32[8, 32][S(0)], memory_format=torch.contiguous_format)
    aten::clone(t: f32[1, 32], memory_format=torch.contiguous_format)
    profiler::_record_function_enter_new(backward._backward_impl (dynamo_timed))
    profiler::_record_function_enter_new(compile_fx.<locals>.bw_compiler (dynamo_timed))
    profiler::_record_function_exit._RecordFunction(ScriptObject <__torch__.torch.classes.profiler._RecordFunction>)
    profiler::_record_function_exit._RecordFunction(ScriptObject <__torch__.torch.classes.profiler._RecordFunction>)
    inductor_graph_call(
      inputs: (t: f32[8, 1], t: f32[1, 32])
      cache_key: fsnyocggi2loaax6imaueniogtvgd2ta4wlrcfydcp4qzv7rmhqi
      fx_kwargs: {static_input_idxs=[0], cudagraphs=BoxedBool(value=False), is_backward=True, graph_id=0, boxed_forward_device_index=BoxedDeviceIndex(value=None), cpp_wrapper=False, fx_wrapper=False, is_inference=False, layout_opt=None, extern_node_serializer=None}
      post_grad_graph:
        class GraphModule(torch.nn.Module):
            def forward(self, permute: "f32[8, 1][1, 8]cuda:0", tangents_1: "f32[1, 32][32, 1]cuda:0"):
                 # File: /data/users/pianpwk/ptclone/pytorch/test/distributed/tensor/debug/test_debug_mode.py:300 in fn, code: return torch.mm(x, y)
                mm_1: "f32[8, 32][32, 1]cuda:0" = torch.ops.aten.mm.default(permute, tangents_1);  permute = tangents_1 = None
                return (None, mm_1)
    )
      aten::mm.out(t: f32[8, 1], t: f32[1, 32], out=t: f32[8, 32])
    redistribute_input(t: f32[8, 32], [P] -> [S(0)])
      _c10d_functional::reduce_scatter_tensor(t: f32[8, 32], sum, 8, 0)
      _c10d_functional::wait_tensor(t: f32[1, 32])
    aten::_to_copy(t: f32[1, 32], dtype=torch.float32, layout=torch.strided, device=cpu)
    aten::detach(t: f32[1, 32])"""
```

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben