### PR TITLE
[WIP]Do we need to assert on non-broadcasting for implicit ops. 

### DIFF
--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -1243,7 +1243,7 @@ def register_fast_op_impl(func: OpOverload):
 
 # infer_size_impl in ExpandUtils
 def infer_size(a, b):
-    from torch.fx.experimental.symbolic_shapes import sym_or
+    from torch.fx.experimental.symbolic_shapes import guard_or_false
 
     dimsA = len(a)
     dimsB = len(b)
@@ -1268,7 +1268,7 @@ def infer_size(a, b):
         # were not the case, we'd need to write this using torch.sym_or() or
         # something like that).
         torch._check(
-            sym_or (sizeA == 1,sizeB == 1, sizeA == sizeB),
+            guard_or_false (sizeA == 1) or guard_or_false(sizeB == 1) or  sizeA == sizeB,
             lambda: f"The size of tensor a ({sizeA}) "
             f"must match the size of tensor b ({sizeB}) "
             f"at non-singleton dimension {i})",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #165108
* #165091
* #164889
* #164888
* #164887
* #164886
* #164885
* #164884

Do we need to assert on non-broadcasting
this code with the change in this PR compile fine without asserting that. 
````
import torch

# torch.compile(fullgraph=True, backend="eager")
@torch.compile(fullgraph=True, backend="inductor", dynamic=True)
def func(a, b):
    e= a*b
    return e, a*10, b*10


a =torch.rand(1)
b =torch.rand(6)
torch._dynamo.decorators.mark_unbacked(a, 0)
torch._dynamo.decorators.mark_unbacked(b, 0)
func(a,b)
````
We need to be careful that inductor DID NOT ASSUME that DYANMO ALREADY specialized this is something it does often ! it look at hint and make a decision with out guarding when it comes to 0/1 .