### PR TITLE
Allow fake inputs

### DIFF
--- a/torch/_functorch/_aot_autograd/frontend_utils.py
+++ b/torch/_functorch/_aot_autograd/frontend_utils.py
@@ -100,7 +100,7 @@ def construct_fake_mode(
     fake_mode = detect_fake_mode(flat_args)
     if fake_mode is None:
         shape_env = ShapeEnv() if aot_config.dynamic_shapes else None
-        fake_mode = FakeTensorMode(shape_env=shape_env)
+        fake_mode = FakeTensorMode(shape_env=shape_env, allow_non_fake_inputs=True)
     else:
         shape_env = fake_mode.shape_env
     return (fake_mode, shape_env)


### PR DESCRIPTION
Running into an issue where if the graph module passed to aot_export_joint_with_descriptors contains tensor constants that don't get lifted as inputs, and we trace with real tensors, since AOTAutograd's default FakeMode does not mark allow_fake_inputs=True, we'll then error with `Please convert all Tensors to FakeTensors first or instantiate FakeTensorMode with 'allow_non_fake_inputs'`.

We can either change this code to have allow_non_fake_inputs=True by default, or we can move the args to our own FakeMode.