### PR TITLE
[2/N] Use "is" in python type comparison

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -990,7 +990,7 @@ def sym_ite(b, t, f):
     """SymInt-aware utility for ternary operator (``t if b else f``.)"""
     if overrides.has_torch_function((b, t, f)):
         return overrides.handle_torch_function(sym_ite, (b, t, f), b, t, f)
-    assert isinstance(b, (SymBool, builtins.bool)) and type(t) == type(f)
+    assert isinstance(b, (SymBool, builtins.bool)) and type(t) is type(f)
     if isinstance(b, SymBool):
         return b.__sym_ite__(t, f)
     return t if b else f

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -3559,7 +3559,7 @@ class CheckFunctionManager:
                 [make_guard_filter_entry(guard) for guard in sorted_guards]
             )
             assert len(filter_results) == len(sorted_guards)
-            assert all(type(x) == bool for x in filter_results)
+            assert all(type(x) is bool for x in filter_results)
             sorted_guards = [
                 guard for i, guard in enumerate(sorted_guards) if filter_results[i]
             ]

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1251,7 +1251,7 @@ class BuiltinVariable(VariableTracker):
             # Interaction between ndarray and tensors:
             #   We prefer the tensor op whenever there are tensors involved
             if check_numpy_ndarray_args(args, kwargs) and not any(
-                type(arg) == variables.TensorVariable for arg in args
+                type(arg) is variables.TensorVariable for arg in args
             ):
                 proxy = tx.output.create_proxy(
                     "call_function",

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -516,7 +516,7 @@ class TensorVariable(VariableTracker):
                 # these attributes are implemented under tp_getset, which appear
                 # as `getset_descriptor`s, (compared to, say, methods which appear
                 # as `method_descriptor`s)
-                if type(static_attr) != types.GetSetDescriptorType:
+                if type(static_attr) is not types.GetSetDescriptorType:
                     return None
 
                 proxy = GetAttrVariable.create_getattr_proxy(self.as_proxy(), name)

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1672,7 +1672,7 @@ class FrozenDataClassVariable(UserDefinedObjectVariable):
 
         def __eq__(self, other):
             return (
-                type(self) == type(other)
+                type(self) is type(other)
                 and self.cls == other.cls
                 and self.fields == other.fields
             )

--- a/torch/_export/passes/constant_folding.py
+++ b/torch/_export/passes/constant_folding.py
@@ -127,7 +127,7 @@ class ConstantFolder(torch.fx.Interpreter):
         # contains a ScriptObject, equality checking results in a type error if
         # the types are different.
         if any(
-            type(self.unknown_value) == type(input_) and self.unknown_value == input_
+            type(self.unknown_value) is type(input_) and self.unknown_value == input_
             for input_ in flattened_inputs
         ):
             return self.unknown_value

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -3190,7 +3190,7 @@ def _dict_to_dataclass(cls, data):
     elif isinstance(data, dict):
         v_type = typing.get_args(cls)[1]
         return {k: _dict_to_dataclass(v_type, v) for k, v in data.items()}
-    elif cls == float:
+    elif cls is float:
         return float(data)
     return data
 

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -235,7 +235,7 @@ def check_node_safe(node: Node):
                 f"Unsupported call_method target {method_target}. \nMethod module: {module}, \nMethod name: {name}"
             )
         if (
-            type(method_name) != str
+            type(method_name) is not str
             and type(method_name).__name__ != "method_descriptor"
         ):
             raise BypassAOTAutogradCache(

--- a/torch/_functorch/functional_call.py
+++ b/torch/_functorch/functional_call.py
@@ -230,7 +230,7 @@ def stack_module_state(
             "stack_module_state: Expected all models to have the same training/eval mode."
         )
     model0_typ = type(models[0])
-    if not all(type(m) == model0_typ for m in models):
+    if not all(type(m) is model0_typ for m in models):
         raise RuntimeError(
             "stack_module_state: Expected all models to be of the same class."
         )

--- a/torch/_functorch/make_functional.py
+++ b/torch/_functorch/make_functional.py
@@ -536,7 +536,7 @@ def combine_state_for_ensemble(
             "have the same training/eval mode."
         )
     model0_typ = type(models[0])
-    if not all(type(m) == model0_typ for m in models):
+    if not all(type(m) is model0_typ for m in models):
         raise RuntimeError(
             "combine_state_for_ensemble: Expected all models to be of the same class."
         )

--- a/torch/_higher_order_ops/schema.py
+++ b/torch/_higher_order_ops/schema.py
@@ -35,7 +35,7 @@ class HopArgumentInfoGen:
         kw_only: bool = False,
     ) -> HopArgumentInfo:
         if default_value is not None:
-            assert type(example_value) == type(default_value), (
+            assert type(example_value) is type(default_value), (
                 f"example_value type {type(example_value)} doesn't match default_value type: {type(default_value)}"
             )
 

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -2604,7 +2604,7 @@ class CppKernel(Kernel):
                     var_id = i
                     break
             if (
-                type(self) == CppKernel
+                type(self) is CppKernel
                 and var_id
                 and start == 0
                 and end == self.ranges[var_id]
@@ -4534,7 +4534,7 @@ class CppKernelProxy(CppKernel):
             assert isinstance(main_loop_kernel, self.vec_kernel_cls)
 
             # Prefix
-            if type(tail_loop_kernel) == self.kernel_cls:
+            if type(tail_loop_kernel) is self.kernel_cls:
                 # if tail loop kernel is a scalar kernel, we need to extend tmp_acc -> tmp_acc_arr[] to
                 # hold the temporary inner loop acc result for outer tail loop
                 tail_loop_kernel.finalize_reduction_prefix(
@@ -4562,7 +4562,7 @@ class CppKernelProxy(CppKernel):
                     suffix_buf, "C10_UNLIKELY", outer_loop.var
                 ):
                     stack.enter_context(suffix_buf.indent())
-                    if type(tail_loop_kernel) == self.kernel_cls:
+                    if type(tail_loop_kernel) is self.kernel_cls:
                         reduction_vars = tail_loop_kernel.reduction_var_names
                         for name in reduction_vars:
                             new_name = f"{name}_arr[{outer_loop.var}_tail - {cexpr_index(outer_loop.tiled_size)}]"

--- a/torch/_inductor/constant_folding.py
+++ b/torch/_inductor/constant_folding.py
@@ -206,7 +206,7 @@ class ConstantFolder(torch.fx.Interpreter):
         # contains a ScriptObject, equality checking results in a type error if
         # the types are different.
         if any(
-            type(self.unknown_value) == type(input_) and self.unknown_value == input_
+            type(self.unknown_value) is type(input_) and self.unknown_value == input_
             for input_ in flattened_inputs
         ):
             return self.unknown_value

--- a/torch/_inductor/mkldnn_lowerings.py
+++ b/torch/_inductor/mkldnn_lowerings.py
@@ -552,11 +552,11 @@ def register_onednn_fusion_ops():
             algorithm,
         ):
             # To align with qlinear where x_scale and x_zp are converted to Tensor
-            assert type(x_scale) == float
+            assert type(x_scale) is float
             x_scale = V.graph.add_tensor_constant(
                 torch.tensor(x_scale, dtype=torch.float32), name="x_scale"
             )
-            assert type(x_zp) == int
+            assert type(x_zp) is int
             x_zp = V.graph.add_tensor_constant(
                 torch.tensor(x_zp, dtype=torch.int32), name="x_zp"
             )
@@ -614,11 +614,11 @@ def register_onednn_fusion_ops():
             unary_algorithmm,
         ):
             # To align with qlinear where x_scale and x_zp are converted to Tensor
-            assert type(x_scale) == float
+            assert type(x_scale) is float
             x_scale = V.graph.add_tensor_constant(
                 torch.tensor(x_scale, dtype=torch.float32), name="x_scale"
             )
-            assert type(x_zp) == int
+            assert type(x_zp) is int
             x_zp = V.graph.add_tensor_constant(
                 torch.tensor(x_zp, dtype=torch.int32), name="x_zp"
             )
@@ -686,7 +686,7 @@ def register_onednn_fusion_ops():
                 # GEMM template needs 2D input, normalize input shape here
                 x = view(x, [-1, x_size[-1]])
             if not isinstance(x_scale, ir.TensorBox):
-                assert type(x_scale) == float
+                assert type(x_scale) is float
                 x_scale = V.graph.add_tensor_constant(
                     torch.tensor(x_scale, dtype=torch.float32), name="x_scale"
                 )
@@ -708,7 +708,7 @@ def register_onednn_fusion_ops():
                     torch.tensor(0, dtype=torch.int32), name="x_zp"
                 )
             if not isinstance(x_zp, ir.TensorBox):
-                assert type(x_zp) == int
+                assert type(x_zp) is int
                 x_zp = V.graph.add_tensor_constant(
                     torch.tensor(x_zp, dtype=torch.int32), name="x_zp"
                 )
@@ -1001,7 +1001,7 @@ def register_onednn_fusion_ops():
                 x = view(x, [-1, x_size[-1]])
                 x2 = view(x2, [-1, x2_size[-1]])
             if not isinstance(x_scale, ir.TensorBox):
-                assert type(x_scale) == float
+                assert type(x_scale) is float
                 x_scale = V.graph.add_tensor_constant(
                     torch.tensor(x_scale, dtype=torch.float32), name="x_scale"
                 )
@@ -1026,7 +1026,7 @@ def register_onednn_fusion_ops():
                 )
 
             if not isinstance(x_zp, ir.TensorBox):
-                assert type(x_zp) == int
+                assert type(x_zp) is int
                 x_zp = V.graph.add_tensor_constant(
                     torch.tensor(x_zp, dtype=torch.int32), name="x_zp"
                 )

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2637,7 +2637,7 @@ def is_collective(
         # TODO: this is a temporary solution to ensure that we can identify torchrec's
         # communication ops. But in order to allow better communication and computation
         # overlap, torchrec's communication ops should be not used.
-        type(node) == ir.FallbackKernel
+        type(node) is ir.FallbackKernel
         and (
             # NOTE: the `hasattr()` check is to bypass errors such as the following:
             # AttributeError: '_OpNamespace' 'torchrec' object has no attribute 'all_to_all_single'
@@ -2661,7 +2661,7 @@ def is_collective(
 def is_wait(node: Optional[Union[IRNode, Operation]]) -> bool:
     from . import ir
 
-    return type(node) == ir._WaitKernel
+    return type(node) is ir._WaitKernel
 
 
 def contains_collective(snode: BaseSchedulerNode) -> bool:

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -151,7 +151,7 @@ def infer_schema(
                 )
 
         schema_type = SUPPORTED_PARAM_TYPES[annotation_type]
-        if type(mutates_args) == str:
+        if type(mutates_args) is str:
             if mutates_args != UNKNOWN_MUTATES:
                 raise ValueError(
                     "mutates_args must either be a sequence of the names of "

--- a/torch/_prims_common/wrappers.py
+++ b/torch/_prims_common/wrappers.py
@@ -330,7 +330,7 @@ def out_wrapper(
                 # Naively you might expect this assert to be true, but
                 # it's not:
                 #
-                #   assert type(out) == type(result)
+                #   assert type(out) is type(result)
                 #
                 # The reason is that functions under this wrapper can
                 # get registered to the Meta dispatch key, and that

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -2099,7 +2099,7 @@ class FakeTensorMode(TorchDispatchMode):
             elif a is None:
                 assert b is None
             elif isinstance(a, py_sym_types):
-                assert type(a) == type(b) and a.node is b.node
+                assert type(a) is type(b) and a.node is b.node
             elif isinstance(a, torch.Tensor):
                 assert isinstance(b, torch.Tensor)
                 assert_metadata_eq(assert_eq, a, b)
@@ -2652,7 +2652,7 @@ class FakeTensorMode(TorchDispatchMode):
                 if (
                     not isinstance(fake_out, Tensor)
                     and not isinstance(real_out, Tensor)
-                    and type(fake_out) != type(real_out)
+                    and type(fake_out) is not type(real_out)
                 ):
                     # This can happen when decompositions have different return types,
                     # e.g. namedtuple vs. tuple vs. list.

--- a/torch/_subclasses/schema_check_mode.py
+++ b/torch/_subclasses/schema_check_mode.py
@@ -86,7 +86,7 @@ class SchemaCheckMode(TorchDispatchMode):
                 return torch.allclose(lhs, rhs, equal_nan=True)
 
         def has_mutated(before, after, md):
-            are_tensors = type(before) == torch.Tensor and type(after) == torch.Tensor
+            are_tensors = type(before) is torch.Tensor and type(after) is torch.Tensor
             if (
                 are_tensors
                 and before.layout != torch.sparse_csr
@@ -113,7 +113,7 @@ class SchemaCheckMode(TorchDispatchMode):
             return name if name != "self" else "input"
 
         def unwrap(e):
-            if isinstance(e, torch.Tensor) and type(e) != torch.Tensor:
+            if isinstance(e, torch.Tensor) and type(e) is not torch.Tensor:
                 try:
                     return e.elem
                 except AttributeError:

--- a/torch/ao/nn/intrinsic/modules/fused.py
+++ b/torch/ao/nn/intrinsic/modules/fused.py
@@ -245,7 +245,7 @@ class LinearLeakyReLU(_FusedModule):
     During quantization this will be replaced with the corresponding fused module."""
 
     def __init__(self, linear, leaky_relu):
-        assert type(linear) == Linear and type(leaky_relu) == torch.nn.LeakyReLU, (
+        assert type(linear) is Linear and type(leaky_relu) is torch.nn.LeakyReLU, (
             f"Incorrect types for input modules{type(linear)}{type(leaky_relu)}"
         )
         super().__init__(linear, leaky_relu)
@@ -256,7 +256,7 @@ class LinearTanh(_FusedModule):
     During quantization this will be replaced with the corresponding fused module."""
 
     def __init__(self, linear, tanh):
-        assert type(linear) == Linear and type(tanh) == torch.nn.Tanh, (
+        assert type(linear) is Linear and type(tanh) is torch.nn.Tanh, (
             f"Incorrect types for input modules{type(linear)}{type(tanh)}"
         )
         super().__init__(linear, tanh)

--- a/torch/ao/nn/intrinsic/qat/modules/conv_fused.py
+++ b/torch/ao/nn/intrinsic/qat/modules/conv_fused.py
@@ -361,7 +361,7 @@ class _ConvBnNd(nn.modules.conv._ConvNd, nni._FusedModule):
         """
         # The ignore is because _FLOAT_MODULE is a TypeVar here where the bound
         # has no __name__ (code is fine though)
-        assert type(mod) == cls._FLOAT_MODULE, (
+        assert type(mod) is cls._FLOAT_MODULE, (
             "qat."
             + cls.__name__
             + ".from_float only works for "

--- a/torch/ao/nn/intrinsic/qat/modules/linear_fused.py
+++ b/torch/ao/nn/intrinsic/qat/modules/linear_fused.py
@@ -150,7 +150,7 @@ class LinearBn1d(nn.modules.linear.Linear, nni._FusedModule):
         Args: `mod' a float module, either produced by torch.ao.quantization
         utilities or directly from user
         """
-        assert type(mod) == nni.LinearBn1d, (
+        assert type(mod) is nni.LinearBn1d, (
             "qat."
             + cls.__name__
             + ".from_float only works for "

--- a/torch/ao/nn/intrinsic/quantized/modules/conv_relu.py
+++ b/torch/ao/nn/intrinsic/quantized/modules/conv_relu.py
@@ -95,7 +95,7 @@ class ConvReLU1d(nnq.Conv1d):
 
     @classmethod
     def from_reference(cls, ref_qconv, output_scale, output_zero_point):
-        assert type(ref_qconv) != torch.ao.nn.intrinsic.ConvBnReLU1d, (
+        assert type(ref_qconv) is not torch.ao.nn.intrinsic.ConvBnReLU1d, (
             "BatchNorm1d should be fused into Conv1d before converting to reference module"
         )
         return super().from_reference(ref_qconv[0], output_scale, output_zero_point)
@@ -178,7 +178,7 @@ class ConvReLU2d(nnq.Conv2d):
 
     @classmethod
     def from_reference(cls, ref_qconv, output_scale, output_zero_point):
-        assert type(ref_qconv) != torch.ao.nn.intrinsic.ConvBnReLU2d, (
+        assert type(ref_qconv) is not torch.ao.nn.intrinsic.ConvBnReLU2d, (
             "BatchNorm2d should be fused into Conv2d before converting to reference module"
         )
         return super().from_reference(ref_qconv[0], output_scale, output_zero_point)
@@ -261,7 +261,7 @@ class ConvReLU3d(nnq.Conv3d):
 
     @classmethod
     def from_reference(cls, ref_qconv, output_scale, output_zero_point):
-        assert type(ref_qconv) != torch.ao.nn.intrinsic.ConvBnReLU3d, (
+        assert type(ref_qconv) is not torch.ao.nn.intrinsic.ConvBnReLU3d, (
             "BatchNorm3d should be fused into Conv3d before converting to reference module"
         )
         return super().from_reference(ref_qconv[0], output_scale, output_zero_point)

--- a/torch/ao/nn/intrinsic/quantized/modules/linear_relu.py
+++ b/torch/ao/nn/intrinsic/quantized/modules/linear_relu.py
@@ -94,7 +94,7 @@ class LinearLeakyReLU(nnq.Linear):
 
     @classmethod
     def from_float(cls, mod, use_precomputed_fake_quant=False):
-        assert type(mod) == nni.LinearLeakyReLU, (
+        assert type(mod) is nni.LinearLeakyReLU, (
             "Input float module should be LinearLeakyReLU"
         )
         assert hasattr(mod, "qconfig"), "Input float module must have qconfig defined"
@@ -163,7 +163,7 @@ class LinearTanh(nnq.Linear):
 
     @classmethod
     def from_float(cls, mod, use_precomputed_fake_quant=False):
-        assert type(mod) == nni.LinearTanh, "Input float module should be LinearTanh"
+        assert type(mod) is nni.LinearTanh, "Input float module should be LinearTanh"
         assert hasattr(mod, "qconfig"), "Input float module must have qconfig defined"
         activation_post_process = mod.activation_post_process
         mod = mod[0]

--- a/torch/ao/nn/qat/modules/conv.py
+++ b/torch/ao/nn/qat/modules/conv.py
@@ -62,7 +62,7 @@ class _ConvNd(nn.modules.conv._ConvNd):
            `mod`: a float module, either produced by torch.ao.quantization utilities
            or directly from user
         """
-        assert type(mod) == cls._FLOAT_MODULE, (
+        assert type(mod) is cls._FLOAT_MODULE, (
             "qat."
             + cls.__name__
             + ".from_float only works for "

--- a/torch/ao/nn/qat/modules/embedding_ops.py
+++ b/torch/ao/nn/qat/modules/embedding_ops.py
@@ -79,7 +79,7 @@ class Embedding(nn.Embedding):
         Args: `mod` a float module, either produced by torch.ao.quantization utilities
         or directly from user
         """
-        assert type(mod) == cls._FLOAT_MODULE, (
+        assert type(mod) is cls._FLOAT_MODULE, (
             " qat."
             + cls.__name__
             + ".from_float only works for "
@@ -202,7 +202,7 @@ class EmbeddingBag(nn.EmbeddingBag):
         Args: `mod` a float module, either produced by torch.ao.quantization utilities
         or directly from user
         """
-        assert type(mod) == cls._FLOAT_MODULE, (
+        assert type(mod) is cls._FLOAT_MODULE, (
             " qat."
             + cls.__name__
             + ".from_float only works for "

--- a/torch/ao/nn/quantizable/modules/activation.py
+++ b/torch/ao/nn/quantizable/modules/activation.py
@@ -116,7 +116,7 @@ class MultiheadAttention(nn.MultiheadAttention):
 
     @classmethod
     def from_float(cls, other):
-        assert type(other) == cls._FLOAT_MODULE
+        assert type(other) is cls._FLOAT_MODULE
         assert hasattr(other, "qconfig"), "The float module must have 'qconfig'"
         # Setting the dropout to 0.0!
         observed = cls(

--- a/torch/ao/nn/quantizable/modules/rnn.py
+++ b/torch/ao/nn/quantizable/modules/rnn.py
@@ -203,7 +203,7 @@ class LSTMCell(torch.nn.Module):
 
     @classmethod
     def from_float(cls, other, use_precomputed_fake_quant=False, split_gates=False):
-        assert type(other) == cls._FLOAT_MODULE
+        assert type(other) is cls._FLOAT_MODULE
         assert hasattr(other, "qconfig"), "The float module must have 'qconfig'"
         observed = cls.from_params(
             other.weight_ih,

--- a/torch/ao/nn/quantized/modules/conv.py
+++ b/torch/ao/nn/quantized/modules/conv.py
@@ -278,7 +278,7 @@ class _ConvNd(WeightedQuantizedModule):
     @staticmethod
     def from_float(cls, mod, use_precomputed_fake_quant=False):
         if hasattr(mod, "weight_fake_quant"):
-            # assert type(mod) == cls.__QAT_MODULE, " nnq." + cls.__name__ + \
+            # assert type(mod) is cls.__QAT_MODULE, " nnq." + cls.__name__ + \
             # ".from_float only works for " + cls.__QAT_MODULE.__name__
             if type(mod) is cls._NNIQAT_CONV_BN_MODULE:
                 mod.weight, mod.bias = fuse_conv_bn_weights(
@@ -296,7 +296,7 @@ class _ConvNd(WeightedQuantizedModule):
             weight_post_process = mod.weight_fake_quant
             activation_post_process = mod.activation_post_process
         else:
-            assert type(mod) == cls._FLOAT_MODULE, (
+            assert type(mod) is cls._FLOAT_MODULE, (
                 " nnq."
                 + cls.__name__
                 + ".from_float only works for "
@@ -808,7 +808,7 @@ class _ConvTransposeNd(_ConvNd):
             + ".from_float only works for "
             + cls._FLOAT_MODULE.__name__  # type: ignore[attr-defined]
         )
-        assert type(mod) == cls._FLOAT_MODULE, msg
+        assert type(mod) is cls._FLOAT_MODULE, msg
         assert hasattr(mod, "qconfig"), "Input float module must have qconfig defined."
         weight_post_process = mod.qconfig.weight()  # type: ignore[operator, union-attr]
         weight_post_process(mod.weight)

--- a/torch/ao/nn/quantized/modules/embedding_ops.py
+++ b/torch/ao/nn/quantized/modules/embedding_ops.py
@@ -196,7 +196,7 @@ class Embedding(torch.nn.Module):
                           utilities or provided by user
         """
         if hasattr(mod, "weight_fake_quant"):
-            assert type(mod) == torch.ao.nn.qat.Embedding, (
+            assert type(mod) is torch.ao.nn.qat.Embedding, (
                 "nnq."
                 + cls.__name__
                 + ".from_float "
@@ -205,7 +205,7 @@ class Embedding(torch.nn.Module):
             )
             weight_observer = mod.weight_fake_quant
         else:
-            assert type(mod) == nn.Embedding, (
+            assert type(mod) is nn.Embedding, (
                 "nnq."
                 + cls.__name__
                 + ".from_float only works for "
@@ -349,7 +349,7 @@ class EmbeddingBag(Embedding):
         if hasattr(mod, "weight_fake_quant"):
             weight_observer = mod.weight_fake_quant
         else:
-            assert type(mod) == nn.EmbeddingBag, (
+            assert type(mod) is nn.EmbeddingBag, (
                 "nnq."
                 + cls.__name__
                 + ".from_float only works for "

--- a/torch/ao/nn/quantized/modules/functional_modules.py
+++ b/torch/ao/nn/quantized/modules/functional_modules.py
@@ -288,7 +288,7 @@ class QFunctional(torch.nn.Module):
 
     @classmethod
     def from_float(cls, mod, use_precomputed_fake_quant=False):
-        assert type(mod) == FloatFunctional, (
+        assert type(mod) is FloatFunctional, (
             "QFunctional.from_float expects an instance of FloatFunctional"
         )
         scale, zero_point = mod.activation_post_process.calculate_qparams()  # type: ignore[operator]

--- a/torch/ao/nn/sparse/quantized/dynamic/linear.py
+++ b/torch/ao/nn/sparse/quantized/dynamic/linear.py
@@ -140,7 +140,7 @@ class Linear(torch.nn.Module):
 
         We only care about the convert at this stage, no need for observers just yet.
         """
-        assert type(mod) == cls._FLOAT_MODULE, (
+        assert type(mod) is cls._FLOAT_MODULE, (
             " nnq."
             + cls.__name__
             + ".from_float only works for "

--- a/torch/ao/nn/sparse/quantized/linear.py
+++ b/torch/ao/nn/sparse/quantized/linear.py
@@ -224,7 +224,7 @@ class Linear(torch.nn.Module):
 
         TODO(zaf): Need to add the sparse params to the qconfig
         """
-        assert type(mod) == cls._FLOAT_MODULE, (
+        assert type(mod) is cls._FLOAT_MODULE, (
             cls._get_name() + ".from_float only works for " + cls._FLOAT_MODULE.__name__
         )
         assert hasattr(mod, "sparse_params"), (

--- a/torch/ao/ns/fx/graph_matcher.py
+++ b/torch/ao/ns/fx/graph_matcher.py
@@ -243,11 +243,11 @@ def _get_subgraph_relationship_type(
         key = (type(mod_a), type(mod_b))
 
         if key not in type_a_related_to_b:
-            if type(mod_a) == type(mod_b):
+            if type(mod_a) is type(mod_b):
                 return SubgraphTypeRelationship.EQUAL_BUT_UKNOWN
             else:
                 return SubgraphTypeRelationship.NOT_RELATED
-        elif type(mod_a) == type(mod_b):
+        elif type(mod_a) is type(mod_b):
             return SubgraphTypeRelationship.EQUAL
         else:
             return SubgraphTypeRelationship.RELATED_BUT_NOT_EQUAL

--- a/torch/ao/ns/fx/graph_passes.py
+++ b/torch/ao/ns/fx/graph_passes.py
@@ -128,7 +128,7 @@ def add_loggers_to_model(
                 arg_indices_to_log = get_arg_indices_of_inputs_to_log(node)
                 for node_arg_idx in arg_indices_to_log:
                     node_arg = get_normalized_nth_input(node, gm, node_arg_idx)
-                    if type(node_arg) == Node:
+                    if type(node_arg) is Node:
                         # create a single input logger
                         prev_node = env[node_arg.name]
                         env[node_arg.name] = _insert_logger_after_node(
@@ -146,7 +146,7 @@ def add_loggers_to_model(
                             fqn=fqn,
                         )
                     elif (
-                        type(node_arg) == torch.fx.immutable_collections.immutable_list
+                        type(node_arg) is torch.fx.immutable_collections.immutable_list
                     ):
                         # create N input loggers, one for each node
                         for arg_idx, arg in enumerate(node_arg):  # type: ignore[var-annotated, arg-type]

--- a/torch/ao/quantization/fake_quantize.py
+++ b/torch/ao/quantization/fake_quantize.py
@@ -329,7 +329,7 @@ class FixedQParamsFakeQuantize(FakeQuantize):
     # TODO: rename observer to observer_ctr
     def __init__(self, observer):
         super().__init__(observer=observer)
-        assert type(self.activation_post_process) == FixedQParamsObserver, (
+        assert type(self.activation_post_process) is FixedQParamsObserver, (
             f"{self.__class__.__name__}'s observer must be a {FixedQParamsObserver.__name__}"
         )
         self._observer_ctr = observer

--- a/torch/ao/quantization/fx/_model_report/model_report.py
+++ b/torch/ao/quantization/fx/_model_report/model_report.py
@@ -370,10 +370,10 @@ class ModelReport:
             dict_b_val = info_dict_b[key]
 
             # if it's a tensor we have to handle separately
-            if type(dict_a_val) == torch.Tensor:
+            if type(dict_a_val) is torch.Tensor:
                 # if dict_b_val not tensor, automatically false
                 if (
-                    type(dict_b_val) != torch.Tensor
+                    type(dict_b_val) is not torch.Tensor
                     or sum(dict_a_val != dict_b_val) != 0
                 ):
                     return False

--- a/torch/ao/quantization/fx/_model_report/model_report_visualizer.py
+++ b/torch/ao/quantization/fx/_model_report/model_report_visualizer.py
@@ -520,7 +520,7 @@ class ModelReportVisualizer:
                 # the index of the feature will the 0 + num non feature columns
                 tensor_feature_index = feature_column_offset
                 row_value = row[tensor_feature_index]
-                if type(row_value) != str:
+                if type(row_value) is not str:
                     x_data.append(x_val_to_append)
                     y_data.append(row_value)
         elif is_valid_per_channel_plot:
@@ -543,7 +543,7 @@ class ModelReportVisualizer:
                 # the index of the feature will the 0 + num non feature columns
                 tensor_feature_index = feature_column_offset
                 row_value = row[tensor_feature_index]
-                if type(row_value) != str:
+                if type(row_value) is not str:
                     # only append if new index we are appending
                     if len(x_data) == 0 or x_data[-1] != x_val_to_append:
                         x_data.append(x_val_to_append)

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -939,7 +939,7 @@ def _maybe_insert_input_observer_for_arg_or_kwarg(
             if maybe_obs_node.op == "call_module":
                 maybe_obs_mod = named_modules[maybe_obs_node.target]  # type: ignore[index]
                 if (
-                    type(maybe_obs_mod) == type(arg_as_input_act_obs_or_fq)
+                    type(maybe_obs_mod) is type(arg_as_input_act_obs_or_fq)
                     and maybe_obs_mod.dtype == arg_as_input_target_dtype  # type: ignore[possibly-undefined]
                 ):
                     arg_as_input_act_obs_or_fq = maybe_obs_mod  # type: ignore[assignment]

--- a/torch/ao/quantization/pt2e/_numeric_debugger.py
+++ b/torch/ao/quantization/pt2e/_numeric_debugger.py
@@ -97,7 +97,7 @@ def _tensor_shape_equals(x: object, y: object) -> bool:
         return all_equal
     else:
         log.debug("Comparing non Tensors: %s and %s, they must be equal", x, y)
-        return type(x) == type(y) and x == y
+        return type(x) is type(y) and x == y
 
 
 def _loss_fn(

--- a/torch/distributed/collective_utils.py
+++ b/torch/distributed/collective_utils.py
@@ -208,7 +208,7 @@ def all_gather_object_enforce_type(
     # pyre-fixme[2]: Parameter must have a type other than `Any`
     obj: Any,
     # pyre-fixme[2]: Parameter must have a type that does not contain `Any`
-    type_checker: Callable[[Any, Any], bool] = lambda x, y: type(x) == type(y),
+    type_checker: Callable[[Any, Any], bool] = lambda x, y: type(x) is type(y),
 ) -> None:
     """
     Similar to plain all_gather_object but with additional type checking

--- a/torch/distributed/pipelining/_IR.py
+++ b/torch/distributed/pipelining/_IR.py
@@ -391,7 +391,7 @@ class DetachExecutor(fx.Interpreter):
 
         """
         def dont_traverse_size(a):
-            return type(a) != torch.Size
+            return type(a) is not torch.Size
         """
 
         args = map_aggregate(

--- a/torch/export/_swap.py
+++ b/torch/export/_swap.py
@@ -374,8 +374,8 @@ def _fix_input_output_signature(
         assert signature.in_spec.num_children == 2
         arg_spec = signature.in_spec.children_specs[0]
         kwarg_spec = signature.in_spec.children_specs[1]
-        assert arg_spec.type == tuple
-        assert kwarg_spec.type == dict
+        assert arg_spec.type is tuple
+        assert kwarg_spec.type is dict
         for i in range(arg_spec.num_children):
             forward_arg_names.append(f"arg_{i}")
         forward_arg_names.extend(kwarg_spec.context)

--- a/torch/export/_unlift.py
+++ b/torch/export/_unlift.py
@@ -355,10 +355,10 @@ def _get_codegen(
     if forward_arg_names:
         names = forward_arg_names
     elif (
-        in_spec.type == tuple
+        in_spec.type is tuple
         and in_spec.num_children == 2
-        and in_spec.children_specs[0].type == tuple
-        and in_spec.children_specs[1].type == dict
+        and in_spec.children_specs[0].type is tuple
+        and in_spec.children_specs[1].type is dict
     ):
         # if in_spec contains the args (tuple) and kwargs (dict)
         names = [f"arg_{i}" for i in range(in_spec.children_specs[0].num_children)]

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -927,7 +927,11 @@ class Tracer(TracerBase):
 
                     return out
                 # Union[int, bool] == bool in Python <= 3.6
-                if type(x) is bool or type(x) in base_types and type(x) != torch.Tensor:
+                if (
+                    type(x) is bool
+                    or type(x) in base_types
+                    and type(x) is not torch.Tensor
+                ):
                     torch._assert(
                         out == x,
                         f"{name} has been specialized to have value {x} but got another value",

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -2235,9 +2235,9 @@ class _MakefxTracer:
             self.fake_tensor_mode = parent_tracer.fake_tensor_mode
 
             def _create_sub_fx_tracer(parent_tracer: _ProxyTracer) -> PythonKeyTracer:
-                if type(parent_tracer) == PythonKeyTracer:
+                if type(parent_tracer) is PythonKeyTracer:
                     return PythonKeyTracer()
-                elif type(parent_tracer) == _ModuleStackTracer:
+                elif type(parent_tracer) is _ModuleStackTracer:
                     return _ModuleStackTracer(parent_tracer.scope_root)
                 else:
                     raise RuntimeError(

--- a/torch/fx/experimental/unification/variable.py
+++ b/torch/fx/experimental/unification/variable.py
@@ -31,7 +31,7 @@ class Var:
     __repr__ = __str__
 
     def __eq__(self, other):
-        return type(self) == type(other) and self.token == other.token  # type: ignore[attr-defined]
+        return type(self) is type(other) and self.token == other.token  # type: ignore[attr-defined]
 
     def __hash__(self):
         return hash((type(self), self.token))  # type: ignore[attr-defined]

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -951,10 +951,10 @@ class _PyTreeCodeGen(CodeGen):
         if len(free_vars) > 0:  # pytree has placeholders in it
             # when kwargs is present, in_spec is tuple(args, kwargs)
             has_args_kwargs_tuple = (
-                self.pytree_info.in_spec.type == tuple
+                self.pytree_info.in_spec.type is tuple
                 and self.pytree_info.in_spec.num_children == 2
-                and self.pytree_info.in_spec.children_specs[0].type == tuple
-                and self.pytree_info.in_spec.children_specs[1].type == dict
+                and self.pytree_info.in_spec.children_specs[0].type is tuple
+                and self.pytree_info.in_spec.children_specs[1].type is dict
             )
             fn_kwargs = "{}"
             fn_signature = f"[{', '.join(fn_args)}], self._in_spec"

--- a/torch/fx/passes/utils/matcher_utils.py
+++ b/torch/fx/passes/utils/matcher_utils.py
@@ -127,7 +127,7 @@ class SubgraphMatcher:
         pn_value = torch.fx.graph_module._get_attr(pn.graph.owning_module, pn.target)
         gn_value = torch.fx.graph_module._get_attr(gn.graph.owning_module, gn.target)
 
-        if type(pn_value) != type(gn_value):
+        if type(pn_value) is not type(gn_value):
             return False
 
         # Don't require exact match on tensor values.
@@ -213,7 +213,7 @@ class SubgraphMatcher:
         elif not isinstance(pn, Node) and isinstance(gn, Node):
             return False
         else:
-            return type(gn) == type(pn) and gn == pn
+            return type(gn) is type(pn) and gn == pn
 
     def _match_nodes(
         self, pn: Node, gn: Node, match: InternalMatch, node_name_match: str = ""

--- a/torch/jit/_monkeytype_config.py
+++ b/torch/jit/_monkeytype_config.py
@@ -68,7 +68,7 @@ def get_optional_of_element_type(types):
     from the list of consolidated types and returns `Optional[element type]`.
     TODO: To remove this check once Union support lands.
     """
-    elem_type = types[1] if type(None) == types[0] else types[0]
+    elem_type = types[1] if type(None) is types[0] else types[0]
     elem_type = get_type(elem_type)
 
     # Optional type is internally converted to Union[type, NoneType], which

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -714,7 +714,7 @@ class StmtBuilder(Builder):
 
         # Disallow type annotations on instance attributes outside of __init__
         if (
-            type(stmt.target) == ast.Attribute
+            type(stmt.target) is ast.Attribute
             and stmt.target.value.id == "self"  # type: ignore[attr-defined]
             and ctx.funcname != "__init__"
         ):

--- a/torch/nested/_internal/sdpa.py
+++ b/torch/nested/_internal/sdpa.py
@@ -658,7 +658,7 @@ def _is_computing_meta_flops(x):
             torch.utils._python_dispatch._get_current_dispatch_mode_stack()
         )
         return any(
-            type(x) == torch.utils.flop_counter._FlopCounterMode
+            type(x) is torch.utils.flop_counter._FlopCounterMode
             for x in torch_dispatch_mode_stack
         )
     return False

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1077,7 +1077,7 @@ def _is_make_fx_tracing():
         # this can be triggered when dynamo inlining the module too.
         return (
             any(
-                type(x) == torch.fx.experimental.proxy_tensor.ProxyTorchDispatchMode
+                type(x) is torch.fx.experimental.proxy_tensor.ProxyTorchDispatchMode
                 for x in torch_dispatch_mode_stack
             )
             or torch.compiler.is_exporting()

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -889,7 +889,7 @@ class TypedStorage:
         return self._untyped_storage
 
     def _new_wrapped_storage(self, untyped_storage) -> Self:
-        assert type(untyped_storage) == torch.UntypedStorage
+        assert type(untyped_storage) is torch.UntypedStorage
 
         if type(self) is TypedStorage:
             return cast(

--- a/torch/testing/_internal/autocast_test_lists.py
+++ b/torch/testing/_internal/autocast_test_lists.py
@@ -443,7 +443,7 @@ class TestAutocast(TestCase):
 
             # If both torch.* and Tensor.* variants were found, check outputs are identical
             if (output is not None) and (output_method is not None):
-                self.assertTrue(type(output) == type(output_method))
+                self.assertTrue(type(output) is type(output_method))
                 comparison = compare(output, output_method)
                 self.assertTrue(
                     comparison, f"torch.{op} result did not match Tensor.{op} result"
@@ -465,7 +465,7 @@ class TestAutocast(TestCase):
                     control = getattr(args[0].to(run_as_type), op)(
                         *cast(args[1:], run_as_type), **add_kwargs
                     )
-                self.assertTrue(type(output_to_compare) == type(control))
+                self.assertTrue(type(output_to_compare) is type(control))
                 comparison = compare(output_to_compare, control)
                 self.assertTrue(comparison, f"torch.{op} result did not match control")
             self.assertTrue(torch.is_autocast_enabled(device_type=device))

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -4243,7 +4243,7 @@ class TestCase(expecttest.TestCase):
             self.assertEqual(x, y, msg, atol=atol, rtol=rtol, **kwargs)
 
     def assertEqualTypeString(self, x, y) -> None:
-        # This API is used simulate deprecated x.type() == y.type()
+        # This API is used simulate deprecated x.type() is y.type()
         self.assertEqual(x.device, y.device)
         self.assertEqual(x.dtype, y.dtype)
         self.assertEqual(x.is_sparse, y.is_sparse)

--- a/torch/utils/_python_dispatch.py
+++ b/torch/utils/_python_dispatch.py
@@ -561,7 +561,7 @@ def _correct_storage_aliasing(func, schema_info, args, outs):
         ):
             ret_list = ret if isinstance(ret, list) else [ret]
             for r in ret_list:
-                assert type(arg) == type(
+                assert type(arg) is type(
                     r
                 ), f"""Called {str(func)} with input of type {type(arg)}
 and output of type {type(ret)}. But expected types to match."""


### PR DESCRIPTION
This is follow-up of #165037. It generally recommended to use `is/is not` to compare types. Therefore this series of changes apply this suggestion in the code base, and it aims to finally enabling related linter checks.


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @EikanWang @jgong5 @wenzhe-nrv @sanchitintel @ezyang @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @Lucaskabela