### PR TITLE
Fix pre-dispatch AC HOP calling convention

### DIFF
--- a/torch/_higher_order_ops/wrap.py
+++ b/torch/_higher_order_ops/wrap.py
@@ -325,7 +325,8 @@ def proxy_mode_key(
     qualname = proxy_mode.tracer.get_fresh_qualname("wrap_body")  # type: ignore[union-attr]
 
     # TODO (tmanlaibaatar) don't we need flat_apply here??
-    flat_args, _ = pytree.tree_flatten((args, kwargs))
+    # Dynamo already traced the gmod body without kwargs
+    flat_args, _ = pytree.tree_flatten(args)
     with fx_traceback.preserve_node_meta():
         gmod_aten = reenter_make_fx(Interpreter(gmod).run)(*flat_args)
         gmod_aten.meta["_checkpoint_context_fn"] = gmod.meta["_checkpoint_context_fn"]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #165145
* #164437
* #164433
* #164431
* #163602
* #164340
* #164420
* #164419
* #164321
* #164296

For AC HOP, dynamo traces it without kwargs. (kwargs are only inputs to the HOP, not to the body)
https://github.com/pytorch/pytorch/blob/55f01a48afae8b53ab2a22d2bc9b0a9e39dc1b4b/torch/_dynamo/variables/higher_order_ops.py#L2594-L2609

When we add non-strict support, we should match this calling convention too.