### PR TITLE
fix(load_aoti): Explicitly import codecache to get device info

### DIFF
--- a/torch/export/pt2_archive/_package.py
+++ b/torch/export/pt2_archive/_package.py
@@ -1022,7 +1022,7 @@ def _load_aoti(
     )
 
     from torch._inductor.codecache import get_device_information
-    
+
     device = loaded_metadata["AOTI_DEVICE_KEY"]
     current_device_info = get_device_information(device)
 

--- a/torch/export/pt2_archive/_package.py
+++ b/torch/export/pt2_archive/_package.py
@@ -1021,8 +1021,10 @@ def _load_aoti(
         file, model_name
     )
 
+    from torch._inductor.codecache import get_device_information
+    
     device = loaded_metadata["AOTI_DEVICE_KEY"]
-    current_device_info = torch._inductor.codecache.get_device_information(device)
+    current_device_info = get_device_information(device)
 
     for k, v in current_device_info.items():
         if k in loaded_metadata:


### PR DESCRIPTION
Currently leads to an `AttributeError` if `torch._inductor.codecache` import has not been triggered by another code path.

Follow-up of:
- https://github.com/pytorch/pytorch/pull/163792

cc @angelayi 
