### PR TITLE
[testing] Print something for log classifier to better differentiate reruns vs real failures

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -799,6 +799,12 @@ def run_test_retries(
         )
     if len(consistent_failures) > 0:
         print_to_file(f"The following tests failed consistently: {consistent_failures}")
+        # TODO: print stdout/error
+        print_to_file(
+            "Please ctrl-f for the tests, they might be much earlier in the log"
+        )
+        for x in consistent_failures:
+            print_to_file(f"[FAILED CONSISTENTLY] {x}")
         return 1, True
     return ret_code, any(x > 0 for x in num_failures.values())
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -801,8 +801,6 @@ def run_test_retries(
         )
     if len(consistent_failures) > 0:
         print_to_file(f"The following tests failed consistently: {consistent_failures}")
-        for x in consistent_failures:
-            print_to_file(f"[FAILED CONSISTENTLY] {x}")
         return 1, True
     return ret_code, any(x > 0 for x in num_failures.values())
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -778,8 +778,9 @@ def run_test_retries(
                 print_to_file("Stopping at first consistent failure")
                 break
             sc_command = f"--scs={stepcurrent_key}"
-            # This is for log classifier
-            print_to_file(f"[FAILED CONSISTENTLY] {current_failure}")
+            # This is for log classifier so it can prioritize consistently
+            # failing tests instead of reruns. [1:-1] to remove quotes
+            print_to_file(f"[FAILED CONSISTENTLY] {current_failure[1:-1]}")
             print_to_file(
                 "Test failed consistently, "
                 "continuing with the rest of the tests due to continue-through-error being set"

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -780,7 +780,7 @@ def run_test_retries(
             sc_command = f"--scs={stepcurrent_key}"
             # This is for log classifier so it can prioritize consistently
             # failing tests instead of reruns. [1:-1] to remove quotes
-            print_to_file(f"[FAILED CONSISTENTLY] {current_failure[1:-1]}")
+            print_to_file(f"FAILED CONSISTENTLY: {current_failure[1:-1]}")
             print_to_file(
                 "Test failed consistently, "
                 "continuing with the rest of the tests due to continue-through-error being set"

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -774,13 +774,13 @@ def run_test_retries(
                 "Test succeeeded in new process, continuing with the rest of the tests"
             )
         elif num_failures[current_failure] >= 3:
+            # This is for log classifier so it can prioritize consistently
+            # failing tests instead of reruns. [1:-1] to remove quotes
+            print_to_file(f"FAILED CONSISTENTLY: {current_failure[1:-1]}")
             if not continue_through_error:
                 print_to_file("Stopping at first consistent failure")
                 break
             sc_command = f"--scs={stepcurrent_key}"
-            # This is for log classifier so it can prioritize consistently
-            # failing tests instead of reruns. [1:-1] to remove quotes
-            print_to_file(f"FAILED CONSISTENTLY: {current_failure[1:-1]}")
             print_to_file(
                 "Test failed consistently, "
                 "continuing with the rest of the tests due to continue-through-error being set"

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -778,6 +778,8 @@ def run_test_retries(
                 print_to_file("Stopping at first consistent failure")
                 break
             sc_command = f"--scs={stepcurrent_key}"
+            # This is for log classifier
+            print_to_file(f"[FAILED CONSISTENTLY] {current_failure}")
             print_to_file(
                 "Test failed consistently, "
                 "continuing with the rest of the tests due to continue-through-error being set"
@@ -799,10 +801,6 @@ def run_test_retries(
         )
     if len(consistent_failures) > 0:
         print_to_file(f"The following tests failed consistently: {consistent_failures}")
-        # TODO: print stdout/error
-        print_to_file(
-            "Please ctrl-f for the tests, they might be much earlier in the log"
-        )
         for x in consistent_failures:
             print_to_file(f"[FAILED CONSISTENTLY] {x}")
         return 1, True


### PR DESCRIPTION
The normal pytest/unittest failure patterns also match flaky tests (specifically I think tests that fail -> succeed on rerun in a new subprocess)

So print something specifically for log classifier that it can match against 