### PR TITLE
[lint] workflow consistency linter to look at all files instead of just changed files

### DIFF
--- a/tools/linter/adapters/workflow_consistency_linter.py
+++ b/tools/linter/adapters/workflow_consistency_linter.py
@@ -122,13 +122,15 @@ if __name__ == "__main__":
         if not path.is_file() or path.suffix not in {".yml", ".yaml"}:
             continue
         workflow = load_yaml(path)
-        if is_workflow(workflow):
-            jobs = workflow.get("jobs", {})
-            for job_id, job in jobs.items():
-                res = get_jobs_with_sync_tag(job)
-                if res is not None:
-                    sync_tag, path, job_dict = res
-                    tag_to_jobs[sync_tag].append((path, {job_id: job}))
+        if not is_workflow(workflow):
+            continue
+        jobs = workflow.get("jobs", {})
+        for job_id, job in jobs.items():
+            res = get_jobs_with_sync_tag(job)
+            if res is None:
+                continue
+            sync_tag, path, job_dict = res
+            tag_to_jobs[sync_tag].append((path, {job_id: job}))
 
     # Check the files passed as arguments
     for path in args.filenames:

--- a/tools/linter/adapters/workflow_consistency_linter.py
+++ b/tools/linter/adapters/workflow_consistency_linter.py
@@ -158,4 +158,3 @@ if __name__ == "__main__":
                     print_lint_message(
                         path, job_dict, sync_tag, baseline_path, baseline_job_id
                     )
-                    break

--- a/tools/linter/adapters/workflow_consistency_linter.py
+++ b/tools/linter/adapters/workflow_consistency_linter.py
@@ -116,7 +116,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    # Go through the provided files, aggregating jobs with the same sync tag
+    # Go through all files, aggregating jobs with the same sync tag
     tag_to_jobs = defaultdict(list)
     for path in REPO_ROOT.glob(".github/workflows/*"):
         if not path.is_file() or path.suffix not in {".yml", ".yaml"}:
@@ -130,6 +130,7 @@ if __name__ == "__main__":
                     sync_tag, path, job_dict = res
                     tag_to_jobs[sync_tag].append((path, {job_id: job}))
 
+    # Check the files passed as arguments
     for path in args.filenames:
         workflow = load_yaml(Path(path))
         jobs = workflow["jobs"]

--- a/tools/linter/adapters/workflow_consistency_linter.py
+++ b/tools/linter/adapters/workflow_consistency_linter.py
@@ -16,6 +16,9 @@ from typing import Any, NamedTuple, TYPE_CHECKING
 from yaml import dump, load
 
 
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+
+
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
@@ -82,6 +85,25 @@ def print_lint_message(path: Path, job: dict[str, Any], sync_tag: str) -> None:
     print(json.dumps(lint_message._asdict()), flush=True)
 
 
+def get_jobs_with_sync_tag(
+    job: dict[str, Any],
+) -> tuple[str, Path, dict[str, Any]] | None:
+    sync_tag = job.get("with", {}).get("sync-tag")
+    if sync_tag is None:
+        return None
+
+    # remove the "if" field, which we allow to be different between jobs
+    # (since you might have different triggering conditions on pull vs.
+    # trunk, say.)
+    if "if" in job:
+        del job["if"]
+
+    # same is true for ['with']['test-matrix']
+    if "test-matrix" in job.get("with", {}):
+        del job["with"]["test-matrix"]
+    return (sync_tag, path, {job_id: job})
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="workflow consistency linter.",
@@ -96,39 +118,33 @@ if __name__ == "__main__":
 
     # Go through the provided files, aggregating jobs with the same sync tag
     tag_to_jobs = defaultdict(list)
+    for path in REPO_ROOT.glob(".github/workflows/*"):
+        if not path.is_file() or path.suffix not in {".yml", ".yaml"}:
+            continue
+        workflow = load_yaml(path)
+        if is_workflow(workflow):
+            jobs = workflow.get("jobs", {})
+            for job_id, job in jobs.items():
+                res = get_jobs_with_sync_tag(job)
+                if res is not None:
+                    sync_tag, path, job_dict = res
+                    tag_to_jobs[sync_tag].append((path, {job_id: job}))
+
     for path in args.filenames:
         workflow = load_yaml(Path(path))
         jobs = workflow["jobs"]
         for job_id, job in jobs.items():
-            try:
-                sync_tag = job["with"]["sync-tag"]
-            except KeyError:
+            res = get_jobs_with_sync_tag(job)
+            if res is None:
                 continue
+            sync_tag, path, job_dict = res
 
-            # remove the "if" field, which we allow to be different between jobs
-            # (since you might have different triggering conditions on pull vs.
-            # trunk, say.)
-            if "if" in job:
-                del job["if"]
+            # For each sync tag, check that all the jobs have the same code.
+            for baseline_path, baseline_dict in tag_to_jobs[sync_tag]:
+                baseline_str = dump(baseline_dict)
 
-            # same is true for ['with']['test-matrix']
-            if "test-matrix" in job.get("with", {}):
-                del job["with"]["test-matrix"]
+                printed_baseline = False
 
-            tag_to_jobs[sync_tag].append((path, {job_id: job}))
-
-    # For each sync tag, check that all the jobs have the same code.
-    for sync_tag, path_and_jobs in tag_to_jobs.items():
-        baseline_path, baseline_dict = path_and_jobs.pop()
-        baseline_str = dump(baseline_dict)
-
-        printed_baseline = False
-
-        for path, job_dict in path_and_jobs:
-            job_str = dump(job_dict)
-            if baseline_str != job_str:
-                print_lint_message(path, job_dict, sync_tag)
-
-                if not printed_baseline:
-                    print_lint_message(baseline_path, baseline_dict, sync_tag)
-                    printed_baseline = True
+                job_str = dump(job_dict)
+                if baseline_str != job_str:
+                    print_lint_message(path, job_dict, sync_tag)


### PR DESCRIPTION
As in title

If you change only one workflow file, lintrunner (default arg, also the one in CI since it only inputs changed files) won't look at other files in the repo, but the sync-tag might come from those other files

This makes it so that it looks at all workflow files so it will catch those failures

Also change output line so it prints which file + which job it is different from

Pros:
catches errors

Cons:
unusual behavior (getting around what lintrunner says the linter should run on)