### PR TITLE
[test] Skip testing of source_fn_stack in light of export changes

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e_qat.py
+++ b/test/quantization/pt2e/test_quantize_pt2e_qat.py
@@ -665,12 +665,6 @@ class TestQuantizePT2EQAT_ConvBn_Base(PT2EQATTestCase):
         self.assertNotEqual(get_source_fn(second_conv), get_source_fn(second_relu))
         self.assertNotEqual(get_source_fn(first_relu), get_source_fn(second_relu))
 
-        # Assert that "backbone" exists only in the second set of conv and relu's partition
-        self.assertTrue("backbone" not in get_source_fn(first_conv))
-        self.assertTrue("backbone" not in get_source_fn(first_relu))
-        self.assertTrue("backbone" in get_source_fn(second_conv))
-        self.assertTrue("backbone" in get_source_fn(second_relu))
-
     def test_qat_conv_bn_bias_derived_qspec(self):
         m = self._get_conv_bn_model()
         example_inputs = self.example_inputs


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #164691
* __->__ #165176
* #165172

This is in regards to https://github.com/pytorch/pytorch/pull/164691
where we are inlining into nn modules, and therefore it is causing this
test to fail. The test here looks for node.name which is quite different
with inlining.