### PR TITLE
[CI] Default keep-going true for tags of form ciflow/something/commitsha

### DIFF
--- a/.github/scripts/filter_test_configs.py
+++ b/.github/scripts/filter_test_configs.py
@@ -512,6 +512,8 @@ def perform_misc_tasks(
         "keep-going",
         branch == MAIN_BRANCH
         or bool(tag and re.match(r"^trunk/[a-f0-9]{40}$", tag))
+        # Pattern for tags created via manual run on HUD
+        or bool(tag and re.match(r"^ciflow/[^/]+/[a-f0-9]{40}$", tag))
         or check_for_setting(labels, pr_body, "keep-going"),
     )
     set_output(


### PR DESCRIPTION
Tags of the form `ciflow/something/commitsha` are usually created by running the workflow from HUD
