### PR TITLE
[testing] Do not run inductor/test_caching.py when built for gpu but cpu machine

### DIFF
--- a/test/inductor/test_caching.py
+++ b/test/inductor/test_caching.py
@@ -28,6 +28,7 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
 )
+from torch.testing._internal.inductor_utils import HAS_GPU
 
 
 if TYPE_CHECKING:
@@ -825,4 +826,5 @@ class UtilsTest(TestMixin, TestCase):
 
 
 if __name__ == "__main__":
-    run_tests()
+    if HAS_GPU:
+        run_tests()

--- a/test/inductor/test_caching.py
+++ b/test/inductor/test_caching.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 
 from filelock import FileLock
 
+import torch
 from torch._inductor.runtime.caching import (
     config,
     context,
@@ -28,7 +29,6 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
 )
-from torch.testing._internal.inductor_utils import HAS_GPU
 
 
 if TYPE_CHECKING:
@@ -826,5 +826,7 @@ class UtilsTest(TestMixin, TestCase):
 
 
 if __name__ == "__main__":
-    if HAS_GPU:
+    if torch.version.cuda is not None and not torch.cuda.is_available():
+        print("Skipping because binary was built with CUDA but no GPU is available")
+    else:
         run_tests()


### PR DESCRIPTION
There are some CI configs where the binary is built for cuda, but run on a cpu only machine.  Some of the tests in inductor/test_caching.py call torch.version.cuda and then do things thinking that there is a cuda gpu but there isn't, causing it to fail

In CI, the jobs that check for when a binary is built for cuda but run on a cpu only machine also double as testing for other cpu instruction sets, so this will take away coverage on some cpu instruction sets for this test

I don't know what the expected behavior here is supposed to be, and I don't know if this is something we want to support

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @nmacchioni as the person who originally added these tests

Example failure in CI
https://github.com/pytorch/pytorch/actions/runs/18412934763/job/52476807594
```

2025-10-10T19:33:32.9156425Z _ ContextTest.test_selected_isolation_context_runtime_forms_of_context_selected3_compile_forms_of_context_selected9 _
2025-10-10T19:33:32.9156553Z Traceback (most recent call last):
2025-10-10T19:33:32.9157032Z   File "/var/lib/jenkins/workspace/test/inductor/test_caching.py", line 184, in test_selected_isolation_context
2025-10-10T19:33:32.9157163Z     context._isolation_context(ischema),
2025-10-10T19:33:32.9157741Z   File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/torch/_inductor/runtime/caching/context.py", line 270, in _isolation_context
2025-10-10T19:33:32.9157907Z     selected_context[form_of_context] = getattr(
2025-10-10T19:33:32.9158535Z   File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/torch/_inductor/runtime/caching/context.py", line 199, in accelerator_properties
2025-10-10T19:33:32.9158691Z     repr(torch.cuda.get_device_properties())
2025-10-10T19:33:32.9159166Z   File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/torch/cuda/__init__.py", line 619, in get_device_properties
2025-10-10T19:33:32.9159334Z     _lazy_init()  # will define _get_device_properties
2025-10-10T19:33:32.9159764Z   File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/torch/cuda/__init__.py", line 411, in _lazy_init
2025-10-10T19:33:32.9159875Z     torch._C._cuda_init()
2025-10-10T19:33:32.9160546Z RuntimeError: Found no NVIDIA driver on your system. Please check that you have an NVIDIA GPU and installed a driver from http://www.nvidia.com/Download/index.aspx
2025-10-10T19:33:32.9161081Z Exception raised from device_count_impl at /var/lib/jenkins/workspace/c10/cuda/CUDAFunctions.cpp:40 (most recent call first):
```