### PR TITLE
[Bugfix][vLLM] Explicitly do not support instead of crashing for named tuples in infer schema

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -1070,8 +1070,9 @@ class TestCustomOp(CustomOpTestCaseBase):
             del foo
 
         # Define a named tuple for a Point with x and y coordinates
-        Point = collections.namedtuple('Point', ['x', 'y'])
+        Point = collections.namedtuple("Point", ["x", "y"])
         with self.assertRaisesRegex(ValueError, "unsupported type"):
+
             @custom_ops.custom_op(f"{TestCustomOp.test_ns}::foo")
             def foo(x: Tensor, y: Point) -> Tensor:
                 raise NotImplementedError

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -1069,6 +1069,15 @@ class TestCustomOp(CustomOpTestCaseBase):
 
             del foo
 
+        # Define a named tuple for a Point with x and y coordinates
+        Point = collections.namedtuple('Point', ['x', 'y'])
+        with self.assertRaisesRegex(ValueError, "unsupported type"):
+            @custom_ops.custom_op(f"{TestCustomOp.test_ns}::foo")
+            def foo(x: Tensor, y: Point) -> Tensor:
+                raise NotImplementedError
+
+            del foo
+
     def test_supported_schemas(self):
         # All of these should already be tested by PyTorch codegen
         # (we share the same mechanism), but here's a sanity check.

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -135,7 +135,7 @@ def infer_schema(
                     "as it is a ScriptObject. Please manually specify the schema "
                     "using the `schema=` kwarg with the actual type of the ScriptObject."
                 )
-            elif annotation_type.__origin__ is tuple:
+            elif hasattr(annotation_type, "__origin__") and annotation_type.__origin__ is tuple:
                 list_type = tuple_to_list(annotation_type)
                 example_type_str = "\n\n"
                 # Only suggest the list type if this type is supported.

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -135,7 +135,10 @@ def infer_schema(
                     "as it is a ScriptObject. Please manually specify the schema "
                     "using the `schema=` kwarg with the actual type of the ScriptObject."
                 )
-            elif hasattr(annotation_type, "__origin__") and annotation_type.__origin__ is tuple:
+            elif (
+                hasattr(annotation_type, "__origin__")
+                and annotation_type.__origin__ is tuple
+            ):
                 list_type = tuple_to_list(annotation_type)
                 example_type_str = "\n\n"
                 # Only suggest the list type if this type is supported.


### PR DESCRIPTION
Fixes https://github.com/vllm-project/vllm/issues/25270 by being explicit in erroring; previously we had a cryptic `__origin__ undefined` error, but now should give proper error message that we don't support NamedTuples in schema

Test with
```
python test/test_custom_ops.py TestCustomOp.test_unsupported_param_types
```
