### PR TITLE
[xpu][fix] Infer runtime out dtype based on dequant node in pattern

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/detail/QConv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QConv.cpp
@@ -51,9 +51,10 @@ qconv_get_md(
   wgh_usr_md = dnnl::memory::desc(wgh_tz, wei_data_t, fmt_wgh);
 
   if (bias.has_value()) {
+    auto bias_dt = get_onednn_dtype(bias.value());
     bias_usr_md = dnnl::memory::desc(
         bias.value().sizes().vec(),
-        dnnl::memory::data_type::f32,
+        bias_dt,
         dnnl::memory::format_tag::x);
   }
 

--- a/aten/src/ATen/native/mkldnn/xpu/detail/QConv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QConv.cpp
@@ -53,9 +53,7 @@ qconv_get_md(
   if (bias.has_value()) {
     auto bias_dt = get_onednn_dtype(bias.value());
     bias_usr_md = dnnl::memory::desc(
-        bias.value().sizes().vec(),
-        bias_dt,
-        dnnl::memory::format_tag::x);
+        bias.value().sizes().vec(),bias_dt,dnnl::memory::format_tag::x);
   }
 
   return {src_usr_md, wgh_usr_md, bias_usr_md, dst_usr_md};

--- a/aten/src/ATen/native/mkldnn/xpu/detail/QConv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QConv.cpp
@@ -53,7 +53,7 @@ qconv_get_md(
   if (bias.has_value()) {
     auto bias_dt = get_onednn_dtype(bias.value());
     bias_usr_md = dnnl::memory::desc(
-        bias.value().sizes().vec(),bias_dt,dnnl::memory::format_tag::x);
+        bias.value().sizes().vec(), bias_dt, dnnl::memory::format_tag::x);
   }
 
   return {src_usr_md, wgh_usr_md, bias_usr_md, dst_usr_md};

--- a/aten/src/ATen/native/mkldnn/xpu/qconv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/qconv.cpp
@@ -12,13 +12,11 @@ namespace at::native::xpu {
 inline c10::ScalarType QConvoneDNNXPU::qconv_decide_out_dtype(
     const at::Tensor& act,
     const std::optional<c10::ScalarType> output_dtype) {
-  bool fp32_output = output_dtype.has_value() && (output_dtype == c10::kFloat);
-  bool bfloat16_output =
-      output_dtype.has_value() && (output_dtype == c10::kBFloat16);
-  auto dst_dtype = fp32_output
-      ? c10::kFloat
-      : (bfloat16_output ? c10::kBFloat16 : act.scalar_type());
-  return dst_dtype;
+  if (output_dtype.has_value()) {
+    return output_dtype.value();
+  } else {
+    return act.scalar_type();
+  }
 }
 
 at::Tensor QConvoneDNNXPU::qconv_prepack_xpu(

--- a/aten/src/ATen/native/mkldnn/xpu/qlinear.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/qlinear.cpp
@@ -11,13 +11,11 @@ namespace at::native::xpu {
 inline c10::ScalarType QLinearOnednnXPU::qlinear_decide_out_dtype(
     const at::Tensor& act,
     const std::optional<c10::ScalarType> output_dtype) {
-  bool fp32_output = output_dtype.has_value() && (output_dtype == c10::kFloat);
-  bool bfloat16_output =
-      output_dtype.has_value() && (output_dtype == c10::kBFloat16);
-  auto dst_dtype = fp32_output
-      ? c10::kFloat
-      : (bfloat16_output ? c10::kBFloat16 : act.scalar_type());
-  return dst_dtype;
+  if (output_dtype.has_value()) {
+    return output_dtype.value();
+  } else {
+    return act.scalar_type();
+  }
 }
 
 Tensor QLinearOnednnXPU::q_linear_pointwise(

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -1090,9 +1090,9 @@ static at::Tensor linear_int8_with_onednn_weight(
       weight_scales.scalar_type() == c10::ScalarType::Float, "weight scales should be dtype c10::ScalarType::Float.");
   TORCH_CHECK(
       binary_alpha == 1.0f, "onednn qlinear: alpha != 1 for binary post op is not yet supported.");
-  bool fp32_output = output_dtype.has_value() && (output_dtype.value() == c10::kFloat);
-  bool bf16_output = output_dtype.has_value() && (output_dtype.value() == c10::kBFloat16);
-  if (fp32_output || bf16_output) {
+  bool high_prec_output = output_dtype.has_value() &&
+     ((output_dtype.value() != c10::ScalarType::Byte) && !is_fp8);
+  if (high_prec_output) {
     TORCH_CHECK(
         output_scale == 1.0f && output_zero_point == 0, "onednn qlinear: expect scale=1 and zero point=0 for fp32 output");
   }
@@ -1111,7 +1111,7 @@ static at::Tensor linear_int8_with_onednn_weight(
       +-------------------+--------------+---------------+
     */
     TORCH_CHECK(other.has_value(), "onednn qlinear: the extra input is missing for post op ", binary_post_op);
-    if (fp32_output || bf16_output) {
+    if (high_prec_output) {
       TORCH_CHECK(
           other_scale == 1.0f && other_zero_point == 0,
           "onednn qlinear: expect extra input scale = 1.0 and zero point = 0 when output dtype is ", output_dtype.value(),
@@ -1173,7 +1173,7 @@ static at::Tensor linear_int8_with_onednn_weight(
       at::empty(
         dst_dims,
         at::device(c10::kCPU)
-            .dtype(out_dtype)
+            .dtype(high_prec_output ? output_dtype.value() : input.scalar_type())
       );
   if (output.numel() == 0) {
     return output;

--- a/torch/_inductor/fx_passes/quantization.py
+++ b/torch/_inductor/fx_passes/quantization.py
@@ -1597,7 +1597,7 @@ def _register_qconv_weight_prepack_pass(
             convert_to_bf16 = conv_node.args[0]
             dequant_node = convert_to_bf16.args[0]  # type: ignore[union-attr]
 
-        dequant_dtype = dequant_node.kwargs.get("out_dtype", dtype)
+        dequant_dtype = dequant_node.kwargs.get("out_dtype", dtype)  # type: ignore[union-attr]
         is_amp = dtype == torch.bfloat16
         if is_amp:
             dequant_dtype = torch.bfloat16
@@ -2932,7 +2932,13 @@ def _register_qconv_post_op_fusion_pass(
             kwargs["groups"],
         )
         output_dtype = _get_pattern_output_dtype(match)
-        assert output_dtype in [torch.int8, torch.uint8, torch.float32, torch.bfloat16, torch.float16]
+        assert output_dtype in [
+            torch.int8,
+            torch.uint8,
+            torch.float32,
+            torch.bfloat16,
+            torch.float16,
+        ]
         # Output QParams
         o_inv_scale = (
             kwargs["o_inv_scale"]

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1572,7 +1572,7 @@ def quantized_decomposed_quantize_per_tensor_default(
 ) -> Union[TensorBox, ShapeAsConstantBuffer]:
     if input.get_dtype() == torch.bfloat16:
         input = to_dtype(input, torch.float32)
-    assert input.get_dtype() == torch.float32, (
+    assert input.get_dtype() in [torch.float32, torch.float16], (
         f"Expecting input to have dtype torch.float32, but got dtype: {input.get_dtype()}"
     )
 

--- a/torch/_inductor/mkldnn_ir.py
+++ b/torch/_inductor/mkldnn_ir.py
@@ -670,7 +670,7 @@ class QConvPointWisePT2E(ExternKernelAlloc):
         ]
 
         assert output_dtype is not None
-        if output_dtype in [torch.float32, torch.bfloat16]:
+        if output_dtype in [torch.float32, torch.bfloat16, torch.float16]:
             # in _prepare_convolution_fusion_create, we use x.dtype (uint8) to create kernel_layout
             # if we set output_dtype is not None, the output buf should be output_dtype instead of uint8.
             kernel_layout.dtype = output_dtype
@@ -1045,7 +1045,7 @@ class QLinearPointwisePT2E(ExternKernelAlloc):
         ]
 
         assert output_dtype is not None
-        if output_dtype in [torch.float32, torch.bfloat16]:
+        if output_dtype in [torch.float32, torch.bfloat16, torch.float16]:
             # in _prepare_linear_fusion_create, we use x.dtype (uint8) to create kernel_layout
             # if we set fp32_output, the output buf should be dtype float32 instead of uint8.
             kernel_layout.dtype = output_dtype

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2559,6 +2559,7 @@ if torch._C._has_mkldnn:
             output_dtype = x.dtype
         assert output_dtype in [
             torch.float32,
+            torch.float16,
             torch.bfloat16,
             torch.uint8,
             torch.int8,
@@ -2626,6 +2627,7 @@ if torch._C._has_mkldnn:
         output_shape[-1] = w.shape[1]
         assert output_dtype in [
             torch.float32,
+            torch.float16,
             torch.bfloat16,
             torch.int8,
             torch.uint8,


### PR DESCRIPTION
Adds support for `float16` (FP16) output in quantized convolution (`QConv`) and linear (`QLinear`) operators for the XPU backend, and updates the relevant code paths, pattern matchers, and tests to handle FP16. The changes ensure that FP16 is correctly propagated as an output dtype, and extend pattern matching, lowering, and meta functions to recognize and accept FP16. Additionally, new tests are added to validate FP16 quantization for both QConv and QLinear on XPU.

## Motivation

Current `qlinear_weight_prepack` and `qconv_weight_prepack` fx passes at x86Quantizer and XPUQuantizer cannot guarantee the dtype consistency between matched pattern and the replaced pattern. Take qlinear as example,

```
          x                           w
          |                           |
    dequant(fp16)                 dequant(fp16)
          |                            |
          |                        permute
           \                       /
                 addmm(fp16)
```
Would be replaced by
```
             x                        w
              \                      /   
                 qlinear(...,fp32)
```
The original output node data type info is lost during graph rewriting.

## Solution
As graph talks itself, the output dtype can be inferred from dequant node directly.

**Support for FP16 output in quantized operators:**

* Added `torch.float16` as a valid output dtype for quantized convolution and linear operators in pattern matching, meta registrations, and IR creation functions. 

**Pattern matcher and lowering improvements:**

* Updated quantization pattern matching logic to propagate the real output dtype from the dequant node, ensuring correct dtype is used for FP16 cases in both `qconv_weight_prepack` and `qlinear_weight_prepack`. 
* Modified the lowering for quantize-per-tensor to accept both `float32` and `float16` as valid input dtypes.

**Operator kernel and dtype selection updates:**

* Simplified output dtype selection logic in `QConvoneDNNXPU::qconv_decide_out_dtype` and `QLinearOnednnXPU::qlinear_decide_out_dtype` to directly use the provided `output_dtype` if available, supporting FP16. 
* Updated quantized convolution and linear kernels to use a more general `high_prec_output` condition, allowing for FP16 output in addition to FP32 and BF16, and fixed output allocation to use the correct dtype. 
* In QConv, ensured bias memory descriptor uses the correct dtype.

**Test coverage for FP16 quantization:**

* Added new test helpers and test cases for FP16 quantized convolution and linear on XPU in `test_mkldnn_pattern_matcher.py`, including both bias and bias-free scenarios. 


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @chenyang78