### PR TITLE
dynamo: relax input-type guard to allow Tensor subclasses (addresses #135011)

### DIFF
--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -457,7 +457,7 @@ PyObject* TensorGuards_check(
   for (auto i : c10::irange(len)) {
     PyObject* item = PyTuple_GET_ITEM(args, i);
 
-    if (Py_TYPE(item) != checks[i].pytype) {
+    if (!PyObject_TypeCheck(item, checks[i].pytype)) {
       Py_RETURN_FALSE;
     }
     auto insertion = unique_tensors.insert({item, nullptr});
@@ -525,7 +525,7 @@ PyObject* TensorGuards_check_verbose(
   ska::flat_hash_map<PyObject*, std::nullptr_t> unique_tensors;
   for (auto i : c10::irange(len)) {
     PyObject* item = PyTuple_GET_ITEM(args, i);
-    if (Py_TYPE(item) != checks[i].pytype) {
+    if (!PyObject_TypeCheck(item, checks[i].pytype)) {
       std::stringstream fail_reason;
       PyObject* type_str = PyObject_Str(PyObject_Type(item));
       fail_reason << "expected type of '" << tensor_check_names[i]
@@ -4390,7 +4390,7 @@ class TENSOR_MATCH : public LeafGuard {
   }
 
   bool check_nopybind(PyObject* value) override { // borrowed ref
-    if (Py_TYPE(value) != _tensor_check->pytype) {
+    if (!PyObject_TypeCheck(value, _tensor_check->pytype)) {
       return false;
     }
     return _tensor_check->check(
@@ -4400,7 +4400,7 @@ class TENSOR_MATCH : public LeafGuard {
   GuardDebugInfo check_verbose_nopybind(
       PyObject* value) override { // borrowed ref
 
-    if (Py_TYPE(value) != _tensor_check->pytype) {
+    if (!PyObject_TypeCheck(value, _tensor_check->pytype)) {
       std::stringstream fail_reason;
       PyObject* type_str = PyObject_Str(PyObject_Type(value));
       fail_reason << "expected type of '" << _tensor_name


### PR DESCRIPTION
### Summary
`torch.compile(dynamic=True)` would compile a frame for `Tensor(…)` and then **recompile** when called with an `nn.Parameter(…)` of identical metadata (dtype/device/shape/stride/requires_grad). Logs show a guard failure:
> expected type of 'x' to be a tensor type, but found `torch.nn.parameter.Parameter`

### Root cause
The input guard compared **exact Python types** (`Py_TYPE(...) == ...`), rejecting subclasses like `nn.Parameter`.

### Fix
Relax the type check to be **subclass-aware**:
- use `PyObject_TypeCheck` instead of `Py_TYPE(...) == ...`
- updated in `TensorGuards_check`, `TensorGuards_check_verbose`, and `TENSOR_MATCH::{check_nopybind, check_verbose_nopybind}`

All other tensor checks (dtype, device, size/stride, dispatch keys, etc.) are unchanged.

### Test
Adds `test_parameter_and_tensor_same_shape_do_not_force_recompile` in `test/dynamo/test_misc.py`:
- compile once with `Tensor(1x1, requires_grad=True)`
- call with `nn.Parameter(1x1, requires_grad=True)`
- call again with the Tensor
- assert `CompileCounter.frame_count == 1`

### Scope
This **addresses the Tensor↔Parameter recompile** part of #135011.  
It **does not** change:
- “0/1 specialization” guards on tiny shapes
- late `mark_dynamic` behavior

**Partially addresses #135011**


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @chenyang78