### PR TITLE
[distributed] Replace 54 assert statements in tensor/_ops/_tensor_ops.py

### DIFF
--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -46,11 +46,15 @@ def propagate_single_input_strategy(op_schema: OpSchema) -> StrategyType:
     # for each strategy that the input supports, we create a corresponding strategy.
     # Note: this may be a complete waste of work, because it should be equivalent to
     # `return first_input_strategy` (unless creating a deep copy is important for some reason)
-    assert len([s for s in op_schema.args_schema if isinstance(s, OpStrategy)]) == 1, (
-        "propagate_single_input_strategy only works for single-tensor-input ops"
-    )
+    if len([s for s in op_schema.args_schema if isinstance(s, OpStrategy)]) != 1:
+        raise AssertionError(
+            "propagate_single_input_strategy only works for single-tensor-input ops"
+        )
     first_input_strategy = op_schema.args_schema[0]
-    assert isinstance(first_input_strategy, OpStrategy)
+    if not isinstance(first_input_strategy, OpStrategy):
+        raise AssertionError(
+            f"Expected OpStrategy, got {type(first_input_strategy)}"
+        )
     return OpStrategy(
         [
             OpSpec(
@@ -107,8 +111,10 @@ def equal_strategy(op_schema: OpSchema) -> StrategyType:
     # same strategy in theory.
     mesh = op_schema.get_mesh_from_args()
     self_strategy, other_strategy = op_schema.args_schema
-    assert isinstance(self_strategy, OpStrategy)
-    assert isinstance(other_strategy, OpStrategy)
+    if not isinstance(self_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(self_strategy)}")
+    if not isinstance(other_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(other_strategy)}")
 
     select_strategy = (
         self_strategy
@@ -164,7 +170,8 @@ def create_like_strategy(op_schema: OpSchema) -> StrategyType:
     # move from partial to replicated.
     select_strategy = op_schema.args_schema[0]
     create_like_strategy = OpStrategy([])
-    assert isinstance(select_strategy, OpStrategy)
+    if not isinstance(select_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(select_strategy)}")
     for arg_strategy in select_strategy.strategies:
         arg_spec = arg_strategy.output_spec
         output_spec = DTensorSpec(
@@ -196,12 +203,14 @@ def new_factory_strategy(op_schema: OpSchema) -> StrategyType:
     # 1. let the output be replicated
     # 2. let the output follow the input if input and output have the same shape
     input_strategy = op_schema.args_schema[0]
-    assert isinstance(input_strategy, OpStrategy)
+    if not isinstance(input_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(input_strategy)}")
 
     mesh = input_strategy.mesh
     input_shape = input_strategy.shape
     output_shape = op_schema.args_schema[1]
-    assert isinstance(output_shape, list)
+    if not isinstance(output_shape, list):
+        raise AssertionError(f"Expected list, got {type(output_shape)}")
 
     new_factory_strategy = OpStrategy([])
     for arg_strategy in input_strategy.strategies:
@@ -242,8 +251,10 @@ def gen_bucketize_strategy(op_schema: OpSchema) -> StrategyType:
     mesh = op_schema.get_mesh_from_args()
     input_strategy, boundaries_strategy = op_schema.args_schema
     bucketize_strategy = OpStrategy([])
-    assert isinstance(input_strategy, OpStrategy)
-    assert isinstance(boundaries_strategy, OpStrategy)
+    if not isinstance(input_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(input_strategy)}")
+    if not isinstance(boundaries_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(boundaries_strategy)}")
     for arg_strategy in input_strategy.strategies:
         arg_spec = DTensorSpec(
             mesh,
@@ -283,8 +294,12 @@ def select_int_strategy(op_schema: OpSchema) -> StrategyType:
         - Case 3 shard_dim > selected_dim: shard_dim -= 1.
     """
     input_strategy = op_schema.args_schema[0]
-    assert isinstance(input_strategy, OpStrategy)
-    assert len(op_schema.args_schema) == 3
+    if not isinstance(input_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(input_strategy)}")
+    if len(op_schema.args_schema) != 3:
+        raise AssertionError(
+            f"Expected 3 args, got {len(op_schema.args_schema)}"
+        )
     selected_dim, index = (
         cast(int, op_schema.args_schema[1]),
         cast(int, op_schema.args_schema[2]),
@@ -335,8 +350,10 @@ def select_backward_strategy(op_schema: OpSchema) -> OpStrategy:
     # func: select_backward(Tensor grad_output, SymInt[] input_sizes, int dim, SymInt index) -> Tensor
     args_schema = op_schema.args_schema
     input_strategy, dim = args_schema[0], args_schema[2]
-    assert isinstance(input_strategy, OpStrategy), f"{input_strategy}"
-    assert isinstance(dim, int)
+    if not isinstance(input_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {input_strategy}")
+    if not isinstance(dim, int):
+        raise AssertionError(f"Expected int, got {type(dim)}")
     output_strategies: list[OpSpec] = []
     for placement_strategy in input_strategy.strategies:
         input_spec = placement_strategy.output_spec
@@ -357,19 +374,24 @@ def gen_slice_strategy(op_schema: OpSchema) -> StrategyType:
     input_strategy, dim, start, end, step = (
         op_schema.args_schema + defaults[len(op_schema.args_schema) :]
     )
-    assert isinstance(input_strategy, OpStrategy)
+    if not isinstance(input_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(input_strategy)}")
 
     mesh = input_strategy.mesh
     input_shape = input_strategy.shape
     input_ndim = input_strategy.ndim
-    assert isinstance(dim, int)
+    if not isinstance(dim, int):
+        raise AssertionError(f"Expected int, got {type(dim)}")
     if start is None:
         start = 0
     if end is None or end > input_shape[dim]:
         end = input_shape[dim]
-    assert isinstance(start, IntLike)
-    assert isinstance(end, IntLike)
-    assert isinstance(step, IntLike)
+    if not isinstance(start, IntLike):
+        raise AssertionError(f"Expected IntLike, got {type(start)}")
+    if not isinstance(end, IntLike):
+        raise AssertionError(f"Expected IntLike, got {type(end)}")
+    if not isinstance(step, IntLike):
+        raise AssertionError(f"Expected IntLike, got {type(step)}")
 
     # normalize args
     slice_dim = normalize_dim(dim, input_ndim)  # type: ignore[arg-type]
@@ -419,7 +441,8 @@ def slice_backward_rules(op_schema: OpSchema) -> OpStrategy:
     # func: slice_backward(Tensor grad_output, SymInt[] input_sizes, int dim, SymInt start, SymInt end, SymInt step) -> Tensor
     args_schema = op_schema.args_schema
     input_strategy, dim = args_schema[0], args_schema[2]
-    assert isinstance(input_strategy, OpStrategy), f"{input_strategy}"
+    if not isinstance(input_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {input_strategy}")
     output_strategies: list[OpSpec] = []
     for placement_strategy in input_strategy.strategies:
         output_spec = placement_strategy.output_spec
@@ -473,8 +496,10 @@ def gen_slice_scatter_strategy(op_schema: OpSchema) -> StrategyType:
     mesh = op_schema.get_mesh_from_args()
     input_strategy = op_schema.args_schema[0]
     src_strategy = op_schema.args_schema[1]
-    assert isinstance(input_strategy, OpStrategy)
-    assert isinstance(src_strategy, OpStrategy)
+    if not isinstance(input_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(input_strategy)}")
+    if not isinstance(src_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(src_strategy)}")
     input_ndim = input_strategy.ndim
     slice_dim = (
         cast(int, op_schema.args_schema[2]) if len(op_schema.args_schema) > 2 else 0
@@ -529,7 +554,8 @@ def gen_slice_scatter_strategy(op_schema: OpSchema) -> StrategyType:
 def replica_only_strategy(op_schema: OpSchema) -> StrategyType:
     """Only allow replication on the input/output."""
     input_strategy = op_schema.args_schema[0]
-    assert isinstance(input_strategy, OpStrategy)
+    if not isinstance(input_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(input_strategy)}")
     mesh = input_strategy.mesh
     replicate_spec = DTensorSpec(mesh, tuple([Replicate()] * mesh.ndim))
     return OpStrategy([OpSpec(replicate_spec)])
@@ -573,9 +599,12 @@ def scatter_add_strategy(op_schema: OpSchema) -> StrategyType:
     dim = op_schema.args_schema[1]
     index_strategy = op_schema.args_schema[2]
 
-    assert isinstance(input_strategy, OpStrategy)
-    assert isinstance(index_strategy, OpStrategy)
-    assert isinstance(dim, int)
+    if not isinstance(input_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(input_strategy)}")
+    if not isinstance(index_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(index_strategy)}")
+    if not isinstance(dim, int):
+        raise AssertionError(f"Expected int, got {type(dim)}")
     dim = normalize_dim(dim, input_strategy.ndim)
     mesh = input_strategy.mesh
     input_shape = input_strategy.shape
@@ -690,7 +719,8 @@ def _derive_follow_placements_from_tuple_strategy(
     follow_placements: Optional[list[Placement]] = None
     mesh = tuple_strategy.child_mesh(0)
     for arg_strategy in tuple_strategy.children:
-        assert isinstance(arg_strategy, OpStrategy)
+        if not isinstance(arg_strategy, OpStrategy):
+            raise AssertionError(f"Expected OpStrategy, got {type(arg_strategy)}")
         if arg_strategy.mesh != mesh:
             raise ValueError(
                 f"All operands in {op} must have the same mesh, "
@@ -702,13 +732,15 @@ def _derive_follow_placements_from_tuple_strategy(
             if follow_placements is None:
                 follow_placements = list(arg_placements)
                 continue
-            assert follow_placements is not None
+            if follow_placements is None:
+                raise AssertionError("follow_placements should not be None at this point")
             for mesh_idx in range(mesh.ndim):
                 # merge placements with the priority
                 follow_placements[mesh_idx] = merge_placement(
                     follow_placements[mesh_idx], arg_placements[mesh_idx]
                 )
-    assert follow_placements is not None, "follow placements should not be None!"
+    if follow_placements is None:
+        raise AssertionError("follow placements should not be None!")
     return follow_placements
 
 
@@ -716,9 +748,11 @@ def _derive_follow_placements_from_tuple_strategy(
 def stack_strategy(op_schema: OpSchema) -> StrategyType:
     args_schema = op_schema.args_schema
     input_tuple_strategy = args_schema[0]
-    assert isinstance(input_tuple_strategy, TupleStrategy), f"{input_tuple_strategy}"
+    if not isinstance(input_tuple_strategy, TupleStrategy):
+        raise AssertionError(f"Expected TupleStrategy, got {input_tuple_strategy}")
     first_input_strategy = input_tuple_strategy.children[0]
-    assert isinstance(first_input_strategy, OpStrategy), f"{first_input_strategy}"
+    if not isinstance(first_input_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {first_input_strategy}")
     common_input_ndim = first_input_strategy.ndim
     dim = cast(int, args_schema[1]) if len(args_schema) > 1 else 0
     # normalize the dim to be within the common input ndim
@@ -743,7 +777,8 @@ def stack_strategy(op_schema: OpSchema) -> StrategyType:
     follow_placements = shift_shard_dims_after_insert(follow_placements, dim)
 
     for strategy in input_tuple_strategy.children:
-        assert isinstance(strategy, OpStrategy)
+        if not isinstance(strategy, OpStrategy):
+            raise AssertionError(f"Expected OpStrategy, got {type(strategy)}")
         output_spec = DTensorSpec(mesh, tuple(follow_placements))
         redistribute_cost = []
         for input_spec in input_specs:
@@ -763,10 +798,12 @@ def stack_strategy(op_schema: OpSchema) -> StrategyType:
 def cat_strategy(op_schema: OpSchema) -> StrategyType:
     args_schema = op_schema.args_schema
     input_tuple_strategy = args_schema[0]
-    assert isinstance(input_tuple_strategy, TupleStrategy), f"{input_tuple_strategy}"
+    if not isinstance(input_tuple_strategy, TupleStrategy):
+        raise AssertionError(f"Expected TupleStrategy, got {input_tuple_strategy}")
     num_input_tensor = len(input_tuple_strategy.children)
     first_input_strategy = input_tuple_strategy.children[0]
-    assert isinstance(first_input_strategy, OpStrategy), f"{first_input_strategy}"
+    if not isinstance(first_input_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {first_input_strategy}")
     common_input_ndim = first_input_strategy.ndim
     dim = cast(int, args_schema[1]) if len(args_schema) > 1 else 0
     # normalize the dim to be within the common input ndim
@@ -779,16 +816,17 @@ def cat_strategy(op_schema: OpSchema) -> StrategyType:
     strategies_placement_pool = set()
     for this_strategy in input_tuple_strategy.children:
         # check strategy of each tensor to be concatenated
-        assert isinstance(this_strategy, OpStrategy)
-        assert this_strategy.mesh == mesh, (
-            "cat op doesn't support cross mesh concatenation"
-        )
+        if not isinstance(this_strategy, OpStrategy):
+            raise AssertionError(f"Expected OpStrategy, got {type(this_strategy)}")
+        if this_strategy.mesh != mesh:
+            raise AssertionError("cat op doesn't support cross mesh concatenation")
         for op_spec in this_strategy.strategies:
             # Check each OpSpec of the tensor, the placement in this OpSpec
             # is used as the exemplar strategy that other tensors and output
             # tensor should follow. We also need to deduplicate the output
             # strategy with the same placement.
-            assert isinstance(op_spec, OpSpec)
+            if not isinstance(op_spec, OpSpec):
+                raise AssertionError(f"Expected OpSpec, got {type(op_spec)}")
             # exemplar OpSpec to follow
             exemplar_spec = op_spec.output_spec
             # check if the tensor is sharded on the concat dim
@@ -806,7 +844,8 @@ def cat_strategy(op_schema: OpSchema) -> StrategyType:
                 for idx in range(num_input_tensor):
                     # extract the strategy for the idx tensors to build the tensor_metadata and redistribute_cost
                     that_tensor_strategy = input_tuple_strategy.children[idx]
-                    assert isinstance(that_tensor_strategy, OpStrategy)
+                    if not isinstance(that_tensor_strategy, OpStrategy):
+                        raise AssertionError(f"Expected OpStrategy, got {type(that_tensor_strategy)}")
                     input_spec = DTensorSpec(
                         mesh,
                         exemplar_placement,
@@ -832,9 +871,12 @@ def cat_strategy(op_schema: OpSchema) -> StrategyType:
 def prop_index_select(op_schema: OpSchema) -> OutputSharding:
     values_spec, dim, indices_spec = op_schema.args_schema
 
-    assert isinstance(values_spec, DTensorSpec)
-    assert isinstance(dim, int)
-    assert isinstance(indices_spec, DTensorSpec)
+    if not isinstance(values_spec, DTensorSpec):
+        raise AssertionError(f"Expected DTensorSpec, got {type(values_spec)}")
+    if not isinstance(dim, int):
+        raise AssertionError(f"Expected int, got {type(dim)}")
+    if not isinstance(indices_spec, DTensorSpec):
+        raise AssertionError(f"Expected DTensorSpec, got {type(indices_spec)}")
 
     all_indices_spec: list[Optional[DTensorSpec]] = [
         indices_spec if dim == i else None for i in range(values_spec.ndim)
@@ -872,17 +914,21 @@ def prop_index_put(op_schema: OpSchema) -> StrategyType:
     # We have 3 DTensor spec from argument `in`, `indices` and `values`
     # accordingly.
     in_spec, indices_spec, values_spec, *_ = op_schema.args_schema
-    assert isinstance(in_spec, OpStrategy)
+    if not isinstance(in_spec, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(in_spec)}")
     # `indices`` is a tuple of scalar LongTensor, so we use TupleStrategy.
-    assert isinstance(indices_spec, TupleStrategy)
-    assert isinstance(values_spec, OpStrategy)
+    if not isinstance(indices_spec, TupleStrategy):
+        raise AssertionError(f"Expected TupleStrategy, got {type(indices_spec)}")
+    if not isinstance(values_spec, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(values_spec)}")
     mesh = values_spec.mesh
     op_strategy = OpStrategy([])
     # 1. `indices` should all be replicated first.
     indices_redistribute_costs = []
     new_indices_spec: list[Optional[DTensorSpec]] = []
     for indices_spec_child in indices_spec.children:
-        assert isinstance(indices_spec_child, OpStrategy)
+        if not isinstance(indices_spec_child, OpStrategy):
+            raise AssertionError(f"Expected OpStrategy, got {type(indices_spec_child)}")
 
         replicated_spec = DTensorSpec(
             mesh=mesh,
@@ -910,7 +956,8 @@ def prop_index_put(op_schema: OpSchema) -> StrategyType:
             placements = strategy.output_spec.placements
             for placement in placements:
                 if placement.is_shard():
-                    assert isinstance(placement, Shard)
+                    if not isinstance(placement, Shard):
+                        raise AssertionError(f"Expected Shard, got {type(placement)}")
                     if exemplar_spec is in_spec:
                         # let `values_spce` follow `in_spec`
                         if placement.dim < size_offset:
@@ -984,8 +1031,10 @@ def prop_index(op_schema: OpSchema) -> OutputSharding:
     #   into either sharded or replicated)
 
     values_spec, multi_indices_spec = op_schema.args_schema
-    assert isinstance(values_spec, DTensorSpec)
-    assert isinstance(multi_indices_spec, list)
+    if not isinstance(values_spec, DTensorSpec):
+        raise AssertionError(f"Expected DTensorSpec, got {type(values_spec)}")
+    if not isinstance(multi_indices_spec, list):
+        raise AssertionError(f"Expected list, got {type(multi_indices_spec)}")
     multi_indices_spec = cast(list[Optional[DTensorSpec]], multi_indices_spec)
     valid_indices_spec: list[tuple[int, DTensorSpec]] = [
         (i, a) for i, a in enumerate(multi_indices_spec) if a is not None
@@ -1004,17 +1053,20 @@ def prop_index(op_schema: OpSchema) -> OutputSharding:
 
     if not need_reshard_on_indices:
         # this means that our inputs are already sharded properly and we will use that as our indices_spec
-        assert isinstance(indices_out.output_spec, DTensorSpec)
+        if not isinstance(indices_out.output_spec, DTensorSpec):
+            raise AssertionError(f"Expected DTensorSpec, got {type(indices_out.output_spec)}")
         indices_spec: DTensorSpec = indices_out.output_spec
     else:
-        assert indices_out.redistribute_schema is not None
+        if indices_out.redistribute_schema is None:
+            raise AssertionError("redistribute_schema should not be None")
         valid_indices_suggestion = indices_out.redistribute_schema
         for i, v in enumerate(valid_indices_suggestion.args_spec):
             multi_indices_spec[valid_indices_spec[i][0]] = v
         # we'll need to call pointwise_rule again to see what's our ideal indices_spec and then
         # use that to compute our ideal values_spec
         indices_output_spec = pointwise_rule(valid_indices_suggestion).output_spec
-        assert isinstance(indices_output_spec, DTensorSpec)
+        if not isinstance(indices_output_spec, DTensorSpec):
+            raise AssertionError(f"Expected DTensorSpec, got {type(indices_output_spec)}")
         indices_spec = indices_output_spec
 
     lookup_dims = {v[0] for v in valid_indices_spec}
@@ -1097,7 +1149,8 @@ def prop_index(op_schema: OpSchema) -> OutputSharding:
 def split_strategy(op_schema: OpSchema) -> OpStrategy:
     input_strategy = op_schema.args_schema[0]
     split_size_or_sections = op_schema.args_schema[1]
-    assert isinstance(input_strategy, OpStrategy)
+    if not isinstance(input_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(input_strategy)}")
     input_ndim = input_strategy.ndim
     split_dim = (
         cast(int, op_schema.args_schema[2]) if len(op_schema.args_schema) > 2 else 0
@@ -1107,7 +1160,8 @@ def split_strategy(op_schema: OpSchema) -> OpStrategy:
     def size_split(N, i) -> list:
         # Last chunk will be smaller if the tensor size N
         # along the given dimension dim is not divisible by i.
-        assert i > 0
+        if not i > 0:
+            raise AssertionError(f"Split size must be positive, got {i}")
         return [i] * (N // i) + ([N % i] if N % i != 0 else [])
 
     output_size_list = (
@@ -1115,7 +1169,8 @@ def split_strategy(op_schema: OpSchema) -> OpStrategy:
         if isinstance(split_size_or_sections, int)
         else split_size_or_sections
     )
-    assert isinstance(output_size_list, Sized)
+    if not isinstance(output_size_list, Sized):
+        raise AssertionError(f"Expected Sized, got {type(output_size_list)}")
 
     all_strategies = []
     for strategy in input_strategy.strategies:
@@ -1149,7 +1204,8 @@ def split_strategy(op_schema: OpSchema) -> OpStrategy:
 def gen_unbind_strategy(op_schema: OpSchema) -> StrategyType:
     """Forward all shardings except the unbind dimension."""
     input_strategy = op_schema.args_schema[0]
-    assert isinstance(input_strategy, OpStrategy)
+    if not isinstance(input_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(input_strategy)}")
     input_ndim = input_strategy.ndim
     input_shape = input_strategy.shape
     unbind_dim = (

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -52,9 +52,7 @@ def propagate_single_input_strategy(op_schema: OpSchema) -> StrategyType:
         )
     first_input_strategy = op_schema.args_schema[0]
     if not isinstance(first_input_strategy, OpStrategy):
-        raise AssertionError(
-            f"Expected OpStrategy, got {type(first_input_strategy)}"
-        )
+        raise AssertionError(f"Expected OpStrategy, got {type(first_input_strategy)}")
     return OpStrategy(
         [
             OpSpec(
@@ -297,9 +295,7 @@ def select_int_strategy(op_schema: OpSchema) -> StrategyType:
     if not isinstance(input_strategy, OpStrategy):
         raise AssertionError(f"Expected OpStrategy, got {type(input_strategy)}")
     if len(op_schema.args_schema) != 3:
-        raise AssertionError(
-            f"Expected 3 args, got {len(op_schema.args_schema)}"
-        )
+        raise AssertionError(f"Expected 3 args, got {len(op_schema.args_schema)}")
     selected_dim, index = (
         cast(int, op_schema.args_schema[1]),
         cast(int, op_schema.args_schema[2]),
@@ -733,7 +729,9 @@ def _derive_follow_placements_from_tuple_strategy(
                 follow_placements = list(arg_placements)
                 continue
             if follow_placements is None:
-                raise AssertionError("follow_placements should not be None at this point")
+                raise AssertionError(
+                    "follow_placements should not be None at this point"
+                )
             for mesh_idx in range(mesh.ndim):
                 # merge placements with the priority
                 follow_placements[mesh_idx] = merge_placement(
@@ -845,7 +843,9 @@ def cat_strategy(op_schema: OpSchema) -> StrategyType:
                     # extract the strategy for the idx tensors to build the tensor_metadata and redistribute_cost
                     that_tensor_strategy = input_tuple_strategy.children[idx]
                     if not isinstance(that_tensor_strategy, OpStrategy):
-                        raise AssertionError(f"Expected OpStrategy, got {type(that_tensor_strategy)}")
+                        raise AssertionError(
+                            f"Expected OpStrategy, got {type(that_tensor_strategy)}"
+                        )
                     input_spec = DTensorSpec(
                         mesh,
                         exemplar_placement,
@@ -1054,7 +1054,9 @@ def prop_index(op_schema: OpSchema) -> OutputSharding:
     if not need_reshard_on_indices:
         # this means that our inputs are already sharded properly and we will use that as our indices_spec
         if not isinstance(indices_out.output_spec, DTensorSpec):
-            raise AssertionError(f"Expected DTensorSpec, got {type(indices_out.output_spec)}")
+            raise AssertionError(
+                f"Expected DTensorSpec, got {type(indices_out.output_spec)}"
+            )
         indices_spec: DTensorSpec = indices_out.output_spec
     else:
         if indices_out.redistribute_schema is None:
@@ -1066,7 +1068,9 @@ def prop_index(op_schema: OpSchema) -> OutputSharding:
         # use that to compute our ideal values_spec
         indices_output_spec = pointwise_rule(valid_indices_suggestion).output_spec
         if not isinstance(indices_output_spec, DTensorSpec):
-            raise AssertionError(f"Expected DTensorSpec, got {type(indices_output_spec)}")
+            raise AssertionError(
+                f"Expected DTensorSpec, got {type(indices_output_spec)}"
+            )
         indices_spec = indices_output_spec
 
     lookup_dims = {v[0] for v in valid_indices_spec}


### PR DESCRIPTION
Replace assert statements with explicit if/raise patterns to prevent assertions from being disabled with Python -O flag.

Fixes partially #164878

cc: @albanD 

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci