### PR TITLE
[distributed] Replace 94 assert statements in tensor ops files

### DIFF
--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -104,7 +104,8 @@ class _NormPartial(Partial):
                 raise NotImplementedError(f"Unsupported norm type:: {self.norm_type}")
             elif self.norm_type == 1:
                 return tensor / mesh.size(mesh_dim)
-            assert isinstance(self.norm_type, (int, float))
+            if not isinstance(self.norm_type, (int, float)):
+                raise AssertionError(f"Expected int or float, got {type(self.norm_type)}")
             return tensor / math.pow(mesh.size(mesh_dim), 1 / self.norm_type)
         raise NotImplementedError(self.reduce_op)
 
@@ -115,7 +116,8 @@ class _NormPartial(Partial):
         mesh_dim: int,
         shard_spec: Placement,
     ) -> torch.Tensor:
-        assert isinstance(shard_spec, Shard), f"{shard_spec}"
+        if not isinstance(shard_spec, Shard):
+            raise AssertionError(f"Expected Shard, got {type(shard_spec)}")
         tensor = self._pre_reduce_transform(tensor)
         reduced_tensor = super()._reduce_shard_value(tensor, mesh, mesh_dim, shard_spec)
         return self._post_reduce_transform(reduced_tensor)
@@ -129,7 +131,8 @@ class _NormPartial(Partial):
 
     def _pre_reduce_transform(self, tensor: torch.Tensor) -> torch.Tensor:
         if self.reduce_op == "sum":
-            assert isinstance(self.norm_type, (int, float)), f"{self.norm_type}"
+            if not isinstance(self.norm_type, (int, float)):
+                raise AssertionError(f"Expected int or float, got {type(self.norm_type)}")
             if self.norm_type != 0 and self.norm_type != 1:
                 # pyrefly: ignore  # unsupported-operation
                 return tensor**self.norm_type
@@ -137,7 +140,8 @@ class _NormPartial(Partial):
 
     def _post_reduce_transform(self, tensor: torch.Tensor) -> torch.Tensor:
         if self.reduce_op == "sum":
-            assert isinstance(self.norm_type, (int, float)), f"{self.norm_type}"
+            if not isinstance(self.norm_type, (int, float)):
+                raise AssertionError(f"Expected int or float, got {type(self.norm_type)}")
             if self.norm_type != 0 and self.norm_type != 1:
                 # pyrefly: ignore  # unsupported-operation
                 return tensor ** (1.0 / self.norm_type)
@@ -236,7 +240,8 @@ def map_placements_after_reduction(
         if isinstance(placement, (Replicate, Partial)):
             new_placements.append(placement)
         else:
-            assert isinstance(placement, Shard)
+            if not isinstance(placement, Shard):
+                raise AssertionError(f"Expected Shard, got {type(placement)}")
             shard_dim = placement.dim
             new_shard_dim = reduction_dims_map[shard_dim]
             if new_shard_dim == -1 or shard_dim in reduction_dims:
@@ -348,7 +353,8 @@ LINEAR_REDUCTION_OP_MAP = {
 def linear_reduction_strategy(op_schema: OpSchema) -> OpStrategy:
     args_schema = op_schema.args_schema
     input_strategy = args_schema[0]
-    assert isinstance(input_strategy, OpStrategy)
+    if not isinstance(input_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(input_strategy)}")
 
     dims = None
     if len(op_schema.args_schema) > 1:
@@ -371,9 +377,11 @@ def linear_reduction_strategy(op_schema: OpSchema) -> OpStrategy:
 def cumsum_strategy(op_schema: OpSchema) -> OpStrategy:
     args_schema = op_schema.args_schema
     input_strategy = args_schema[0]
-    assert isinstance(input_strategy, OpStrategy)
+    if not isinstance(input_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(input_strategy)}")
     dim = args_schema[1]
-    assert isinstance(dim, int), f"{dim}"
+    if not isinstance(dim, int):
+        raise AssertionError(f"Expected int, got {type(dim)}")
 
     return common_reduction_strategy(
         input_strategy, [dim], keep_dim=True, reduction_linear=False
@@ -387,7 +395,8 @@ def cumsum_strategy(op_schema: OpSchema) -> OpStrategy:
 def var_reduction_strategy(op_schema: OpSchema) -> OpStrategy:
     args_schema = op_schema.args_schema
     input_strategy = args_schema[0]
-    assert isinstance(input_strategy, OpStrategy)
+    if not isinstance(input_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(input_strategy)}")
     dims = None
     if len(op_schema.args_schema) > 1:
         dims = _infer_reduction_dims(args_schema[1], input_strategy.ndim)
@@ -406,10 +415,12 @@ def var_reduction_strategy(op_schema: OpSchema) -> OpStrategy:
 def vector_norm_strategy(op_schema: OpSchema) -> OpStrategy:
     args_schema = op_schema.args_schema
     input_strategy = args_schema[0]
-    assert isinstance(input_strategy, OpStrategy)
+    if not isinstance(input_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(input_strategy)}")
 
     norm_type = args_schema[1] if len(args_schema) > 1 else 2
-    assert isinstance(norm_type, (int, float, str)), f"{norm_type}"
+    if not isinstance(norm_type, (int, float, str)):
+        raise AssertionError(f"Expected int, float, or str, got {type(norm_type)}")
     dim = args_schema[2] if len(args_schema) > 2 else None
     keepdim = args_schema[3] if len(args_schema) > 3 else False
     dims = _infer_reduction_dims(dim, input_strategy.ndim)
@@ -429,12 +440,15 @@ def vector_norm_strategy(op_schema: OpSchema) -> OpStrategy:
 def foreach_norm_strategy(op_schema: OpSchema) -> TupleStrategy:
     args_schema = op_schema.args_schema
     input_tuple_strategy = args_schema[0]
-    assert isinstance(input_tuple_strategy, TupleStrategy)
+    if not isinstance(input_tuple_strategy, TupleStrategy):
+        raise AssertionError(f"Expected TupleStrategy, got {type(input_tuple_strategy)}")
     norm_type = args_schema[1] if len(args_schema) > 1 else 2
-    assert isinstance(norm_type, (int, float, str)), f"{norm_type}"
+    if not isinstance(norm_type, (int, float, str)):
+        raise AssertionError(f"Expected int, float, or str, got {type(norm_type)}")
     output_tuple_strategy_children: list[OpStrategy] = []
     for op_strategy in input_tuple_strategy.children:
-        assert isinstance(op_strategy, OpStrategy), f"{op_strategy}"
+        if not isinstance(op_strategy, OpStrategy):
+            raise AssertionError(f"Expected OpStrategy, got {type(op_strategy)}")
         reduce_dims = list(range(op_strategy.ndim))
         output_strategy = common_reduction_strategy(
             op_strategy,
@@ -475,7 +489,8 @@ def linalg_replicate_strategy(op_schema: OpSchema) -> OpStrategy:
     """
     args_schema = op_schema.args_schema
     input_strategy = args_schema[0]
-    assert isinstance(input_strategy, OpStrategy), f"{input_strategy}"
+    if not isinstance(input_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(input_strategy)}")
     mesh = input_strategy.mesh
 
     output_strategies: list[OpSpec] = []
@@ -599,7 +614,8 @@ def softmax_backward_strategy(op_schema: OpSchema) -> OpStrategy:
 def nll_loss_forward_strategy(op_schema: OpSchema) -> OpStrategy:
     mesh = op_schema.get_mesh_from_args()
 
-    assert len(op_schema.args_schema) == 5
+    if not len(op_schema.args_schema) == 5:
+        raise AssertionError(f"Expected 5 args, got {len(op_schema.args_schema)}")
 
     (
         input_strategy,
@@ -649,7 +665,8 @@ def nll_loss_forward_strategy(op_schema: OpSchema) -> OpStrategy:
         # weight tensor, if given, has to be a Tensor of size input_shape[channel_dim]
         # make sure it is replicated
         if weight_strategy is not None:
-            assert isinstance(weight_strategy, OpStrategy)
+            if not isinstance(weight_strategy, OpStrategy):
+                raise AssertionError(f"Expected OpStrategy, got {type(weight_strategy)}")
             weight_src_spec = weight_strategy.strategies[idx].output_spec
             weight_expected_spec = DTensorSpec(
                 mesh=mesh,
@@ -724,7 +741,8 @@ def nll_loss_backward_strategy(op_schema: OpSchema) -> OpStrategy:
     # backward op does not need to validate the mesh since forward op has already done it
     mesh = op_schema.get_mesh_from_args(validate=False)
 
-    assert len(op_schema.args_schema) == 7
+    if not len(op_schema.args_schema) == 7:
+        raise AssertionError(f"Expected 7 args, got {len(op_schema.args_schema)}")
     (
         grad_out_strategy,
         input_strategy,
@@ -793,7 +811,8 @@ def nll_loss_backward_strategy(op_schema: OpSchema) -> OpStrategy:
         # weight tensor, if given, has to be a Tensor of size input_shape[channel_dim]
         # make sure it is replicated
         if weight_strategy is not None:
-            assert isinstance(weight_strategy, OpStrategy)
+            if not isinstance(weight_strategy, OpStrategy):
+                raise AssertionError(f"Expected OpStrategy, got {type(weight_strategy)}")
             weight_src_spec = weight_strategy.strategies[idx].output_spec
             weight_expected_spec = DTensorSpec(
                 mesh=mesh,
@@ -843,7 +862,8 @@ def _common_norm_forward_strategy(
         # for None weight and bias, their corresponding objects will
         # be None as well. layer_norm_strategy returns one OpStrategy
         # for the triple return values (out, mean, rstd).
-        assert len(op_schema.args_schema) == 5
+        if not len(op_schema.args_schema) == 5:
+            raise AssertionError(f"Expected 5 args, got {len(op_schema.args_schema)}")
         (
             input_strategy,
             normalized_shape,
@@ -853,7 +873,8 @@ def _common_norm_forward_strategy(
         ) = op_schema.args_schema
     else:
         # rms_norm args: input, normalized_shape, weight, eps
-        assert len(op_schema.args_schema) == 4
+        if not len(op_schema.args_schema) == 4:
+            raise AssertionError(f"Expected 4 args, got {len(op_schema.args_schema)}")
         (
             input_strategy,
             normalized_shape,
@@ -864,8 +885,10 @@ def _common_norm_forward_strategy(
 
     # the current norm implementation requires that all
     # input DTensor's sharding must be in form of OpStrategy
-    assert isinstance(input_strategy, OpStrategy)
-    assert isinstance(normalized_shape, (int, Sequence, torch.Size))
+    if not isinstance(input_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(input_strategy)}")
+    if not isinstance(normalized_shape, (int, Sequence, torch.Size)):
+        raise AssertionError(f"Expected int, Sequence, or torch.Size, got {type(normalized_shape)}")
     normalized_size = normalize_to_torch_size(normalized_shape)
 
     input_ndim = input_strategy.ndim
@@ -893,7 +916,8 @@ def _common_norm_forward_strategy(
         )
 
         if weight_strategy is not None:
-            assert isinstance(weight_strategy, OpStrategy)
+            if not isinstance(weight_strategy, OpStrategy):
+                raise AssertionError(f"Expected OpStrategy, got {type(weight_strategy)}")
             weight_src_spec = weight_strategy.strategies[idx].output_spec
 
             # for the weight tensor, we replicate it on all dims if necessary
@@ -910,7 +934,8 @@ def _common_norm_forward_strategy(
             )
 
         if bias_strategy is not None:
-            assert isinstance(bias_strategy, OpStrategy)
+            if not isinstance(bias_strategy, OpStrategy):
+                raise AssertionError(f"Expected OpStrategy, got {type(bias_strategy)}")
             bias_src_spec = bias_strategy.strategies[idx].output_spec
 
             # for the bias tensor, we replicate it on all dims if necessary
@@ -967,7 +992,8 @@ def _common_norm_backward_strategy(
         # layer_norm args: grad_out, input, normalized_shape, mean, rstd,
         # weight, bias, output_mask. For None weight and bias, their
         # corresponding objects will be None as well.
-        assert len(op_schema.args_schema) == 8
+        if not len(op_schema.args_schema) == 8:
+            raise AssertionError(f"Expected 8 args, got {len(op_schema.args_schema)}")
         (
             grad_out_strategy,
             input_strategy,
@@ -980,7 +1006,8 @@ def _common_norm_backward_strategy(
         ) = op_schema.args_schema
     else:
         # rms_norm args: grad_out, input, normalized_shape, rstd,
-        assert len(op_schema.args_schema) == 6
+        if not len(op_schema.args_schema) == 6:
+            raise AssertionError(f"Expected 6 args, got {len(op_schema.args_schema)}")
         (
             grad_out_strategy,
             input_strategy,
@@ -992,22 +1019,29 @@ def _common_norm_backward_strategy(
         mean_strategy = None
         bias_strategy = None
 
-    assert isinstance(grad_out_strategy, OpStrategy)
-    assert isinstance(input_strategy, OpStrategy)
-    assert isinstance(rstd_strategy, OpStrategy)
+    if not isinstance(grad_out_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(grad_out_strategy)}")
+    if not isinstance(input_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(input_strategy)}")
+    if not isinstance(rstd_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(rstd_strategy)}")
     if mean_strategy is not None:
-        assert isinstance(mean_strategy, OpStrategy)
+        if not isinstance(mean_strategy, OpStrategy):
+            raise AssertionError(f"Expected OpStrategy, got {type(mean_strategy)}")
 
-    assert isinstance(normalized_shape, (int, Sequence, torch.Size))
+    if not isinstance(normalized_shape, (int, Sequence, torch.Size)):
+        raise AssertionError(f"Expected int, Sequence, or torch.Size, got {type(normalized_shape)}")
     normalized_size = normalize_to_torch_size(normalized_shape)
     input_ndim = input_strategy.ndim
     axis = input_ndim - len(normalized_size)
     outer_dims = list(range(axis))
 
     if not rms_norm:
-        assert isinstance(output_mask, list) and len(output_mask) == 3
+        if not (isinstance(output_mask, list) and len(output_mask) == 3):
+            raise AssertionError(f"Expected output_mask to be list of length 3, got {type(output_mask)} of length {len(output_mask) if isinstance(output_mask, list) else 'N/A'}")
     else:
-        assert isinstance(output_mask, list) and len(output_mask) == 2
+        if not (isinstance(output_mask, list) and len(output_mask) == 2):
+            raise AssertionError(f"Expected output_mask to be list of length 2, got {type(output_mask)} of length {len(output_mask) if isinstance(output_mask, list) else 'N/A'}")
 
     # output tuple: (d_input, d_weight[, d_bias])
     out_tuple_strategy = OpStrategy([])
@@ -1052,7 +1086,8 @@ def _common_norm_backward_strategy(
 
         # arg: mean
         if not rms_norm:
-            assert mean_strategy is not None  # mypy fix
+            if mean_strategy is None:
+                raise AssertionError("Expected mean_strategy to not be None")
             mean_src_spec = mean_strategy.strategies[idx].output_spec
             input_specs_list.append(mean_src_spec)
             redistribute_costs.append([0.0 for _ in mean_strategy.strategies])
@@ -1064,7 +1099,8 @@ def _common_norm_backward_strategy(
 
         def _add_target_input_spec(strategy) -> DTensorSpec:
             # shared logic for setting the weight and bias target input specs
-            assert isinstance(strategy, OpStrategy)
+            if not isinstance(strategy, OpStrategy):
+                raise AssertionError(f"Expected OpStrategy, got {type(strategy)}")
             src_spec = strategy.strategies[idx].output_spec
             # no need to redistribute since they should be replicated in forward pass
             input_specs_list.append(src_spec)
@@ -1097,7 +1133,8 @@ def _common_norm_backward_strategy(
                 error_msg = "output_mask[1] should not be `True` while weight argument is `None` in native_layer_norm_backward."
             else:
                 error_msg = "output_mask[1] should not be `True` while weight argument is `None` in _fused_rms_norm_backward."
-            assert output_mask[1] is False, error_msg
+            if not output_mask[1] is False:
+                raise AssertionError(error_msg)
             output_specs_list.append(None)
 
         # arg: bias
@@ -1122,9 +1159,8 @@ def _common_norm_backward_strategy(
                 )
                 output_specs_list.append(bias_out_spec if output_mask[2] else None)
             else:
-                assert output_mask[2] is False, (
-                    "output_mask[2] should not be `True` while bias argument is `None` in native_layer_norm_backward."
-                )
+                if not output_mask[2] is False:
+                    raise AssertionError("output_mask[2] should not be `True` while bias argument is `None` in native_layer_norm_backward.")
                 output_specs_list.append(None)
 
         out_tuple_strategy.strategies.append(
@@ -1189,7 +1225,8 @@ def topk_strategy(op_schema: OpSchema) -> OpStrategy:
 def sort_default_strategy(op_schema: OpSchema) -> OpStrategy:
     # mostly copy paste from topk_strategy
     input_strategy = op_schema.args_schema[0]
-    assert isinstance(input_strategy, OpStrategy)
+    if not isinstance(input_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(input_strategy)}")
     sort_dim = -1
     if len(op_schema.args_schema) > 1:
         sort_dim = cast(int, op_schema.args_schema[1])
@@ -1206,7 +1243,8 @@ def sort_default_strategy(op_schema: OpSchema) -> OpStrategy:
 def sort_stable_strategy(op_schema: OpSchema) -> OpStrategy:
     # mostly copy paste from topk_strategy
     input_strategy = op_schema.args_schema[0]
-    assert isinstance(input_strategy, OpStrategy)
+    if not isinstance(input_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(input_strategy)}")
     sort_dim = -1
     if "dim" in op_schema.kwargs_schema:
         sort_dim = cast(int, op_schema.kwargs_schema["dim"])
@@ -1252,14 +1290,17 @@ def logsumexp_strategy(op_schema: OpSchema) -> OpStrategy:
 
     # args_schema contains all but the DTensor args (e.g., dim, keepdim).
     args_schema = op_schema.args_schema
-    assert len(args_schema) > 1  # input and dim are required.
+    if not len(args_schema) > 1:
+        raise AssertionError(f"Expected more than 1 arg (input and dim are required), got {len(args_schema)}")
 
     input_strategy = args_schema[0]
-    assert isinstance(input_strategy, OpStrategy)
+    if not isinstance(input_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(input_strategy)}")
 
     dims_arg = args_schema[1]
     reduce_dims = _infer_reduction_dims(dims_arg, input_strategy.ndim)
-    assert reduce_dims is not None
+    if reduce_dims is None:
+        raise AssertionError("Expected reduce_dims to not be None")
 
     keep_dim = cast(bool, op_schema.kwargs_schema.get("keepdim", False))
     return common_reduction_strategy(

--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -1057,12 +1057,14 @@ def _common_norm_backward_strategy(
     if not rms_norm:
         if not (isinstance(output_mask, list) and len(output_mask) == 3):
             raise AssertionError(
-                f"Expected output_mask to be list of length 3, got {type(output_mask)} of length {len(output_mask) if isinstance(output_mask, list) else 'N/A'}"
+                f"Expected output_mask to be list of length 3, got {type(output_mask)} "
+                f"of length {len(output_mask) if isinstance(output_mask, list) else 'N/A'}"
             )
     else:
         if not (isinstance(output_mask, list) and len(output_mask) == 2):
             raise AssertionError(
-                f"Expected output_mask to be list of length 2, got {type(output_mask)} of length {len(output_mask) if isinstance(output_mask, list) else 'N/A'}"
+                f"Expected output_mask to be list of length 2, got {type(output_mask)} "
+                f"of length {len(output_mask) if isinstance(output_mask, list) else 'N/A'}"
             )
 
     # output tuple: (d_input, d_weight[, d_bias])

--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -105,7 +105,9 @@ class _NormPartial(Partial):
             elif self.norm_type == 1:
                 return tensor / mesh.size(mesh_dim)
             if not isinstance(self.norm_type, (int, float)):
-                raise AssertionError(f"Expected int or float, got {type(self.norm_type)}")
+                raise AssertionError(
+                    f"Expected int or float, got {type(self.norm_type)}"
+                )
             return tensor / math.pow(mesh.size(mesh_dim), 1 / self.norm_type)
         raise NotImplementedError(self.reduce_op)
 
@@ -132,7 +134,9 @@ class _NormPartial(Partial):
     def _pre_reduce_transform(self, tensor: torch.Tensor) -> torch.Tensor:
         if self.reduce_op == "sum":
             if not isinstance(self.norm_type, (int, float)):
-                raise AssertionError(f"Expected int or float, got {type(self.norm_type)}")
+                raise AssertionError(
+                    f"Expected int or float, got {type(self.norm_type)}"
+                )
             if self.norm_type != 0 and self.norm_type != 1:
                 # pyrefly: ignore  # unsupported-operation
                 return tensor**self.norm_type
@@ -141,7 +145,9 @@ class _NormPartial(Partial):
     def _post_reduce_transform(self, tensor: torch.Tensor) -> torch.Tensor:
         if self.reduce_op == "sum":
             if not isinstance(self.norm_type, (int, float)):
-                raise AssertionError(f"Expected int or float, got {type(self.norm_type)}")
+                raise AssertionError(
+                    f"Expected int or float, got {type(self.norm_type)}"
+                )
             if self.norm_type != 0 and self.norm_type != 1:
                 # pyrefly: ignore  # unsupported-operation
                 return tensor ** (1.0 / self.norm_type)
@@ -441,7 +447,9 @@ def foreach_norm_strategy(op_schema: OpSchema) -> TupleStrategy:
     args_schema = op_schema.args_schema
     input_tuple_strategy = args_schema[0]
     if not isinstance(input_tuple_strategy, TupleStrategy):
-        raise AssertionError(f"Expected TupleStrategy, got {type(input_tuple_strategy)}")
+        raise AssertionError(
+            f"Expected TupleStrategy, got {type(input_tuple_strategy)}"
+        )
     norm_type = args_schema[1] if len(args_schema) > 1 else 2
     if not isinstance(norm_type, (int, float, str)):
         raise AssertionError(f"Expected int, float, or str, got {type(norm_type)}")
@@ -666,7 +674,9 @@ def nll_loss_forward_strategy(op_schema: OpSchema) -> OpStrategy:
         # make sure it is replicated
         if weight_strategy is not None:
             if not isinstance(weight_strategy, OpStrategy):
-                raise AssertionError(f"Expected OpStrategy, got {type(weight_strategy)}")
+                raise AssertionError(
+                    f"Expected OpStrategy, got {type(weight_strategy)}"
+                )
             weight_src_spec = weight_strategy.strategies[idx].output_spec
             weight_expected_spec = DTensorSpec(
                 mesh=mesh,
@@ -812,7 +822,9 @@ def nll_loss_backward_strategy(op_schema: OpSchema) -> OpStrategy:
         # make sure it is replicated
         if weight_strategy is not None:
             if not isinstance(weight_strategy, OpStrategy):
-                raise AssertionError(f"Expected OpStrategy, got {type(weight_strategy)}")
+                raise AssertionError(
+                    f"Expected OpStrategy, got {type(weight_strategy)}"
+                )
             weight_src_spec = weight_strategy.strategies[idx].output_spec
             weight_expected_spec = DTensorSpec(
                 mesh=mesh,
@@ -888,7 +900,9 @@ def _common_norm_forward_strategy(
     if not isinstance(input_strategy, OpStrategy):
         raise AssertionError(f"Expected OpStrategy, got {type(input_strategy)}")
     if not isinstance(normalized_shape, (int, Sequence, torch.Size)):
-        raise AssertionError(f"Expected int, Sequence, or torch.Size, got {type(normalized_shape)}")
+        raise AssertionError(
+            f"Expected int, Sequence, or torch.Size, got {type(normalized_shape)}"
+        )
     normalized_size = normalize_to_torch_size(normalized_shape)
 
     input_ndim = input_strategy.ndim
@@ -917,7 +931,9 @@ def _common_norm_forward_strategy(
 
         if weight_strategy is not None:
             if not isinstance(weight_strategy, OpStrategy):
-                raise AssertionError(f"Expected OpStrategy, got {type(weight_strategy)}")
+                raise AssertionError(
+                    f"Expected OpStrategy, got {type(weight_strategy)}"
+                )
             weight_src_spec = weight_strategy.strategies[idx].output_spec
 
             # for the weight tensor, we replicate it on all dims if necessary
@@ -1030,7 +1046,9 @@ def _common_norm_backward_strategy(
             raise AssertionError(f"Expected OpStrategy, got {type(mean_strategy)}")
 
     if not isinstance(normalized_shape, (int, Sequence, torch.Size)):
-        raise AssertionError(f"Expected int, Sequence, or torch.Size, got {type(normalized_shape)}")
+        raise AssertionError(
+            f"Expected int, Sequence, or torch.Size, got {type(normalized_shape)}"
+        )
     normalized_size = normalize_to_torch_size(normalized_shape)
     input_ndim = input_strategy.ndim
     axis = input_ndim - len(normalized_size)
@@ -1038,10 +1056,14 @@ def _common_norm_backward_strategy(
 
     if not rms_norm:
         if not (isinstance(output_mask, list) and len(output_mask) == 3):
-            raise AssertionError(f"Expected output_mask to be list of length 3, got {type(output_mask)} of length {len(output_mask) if isinstance(output_mask, list) else 'N/A'}")
+            raise AssertionError(
+                f"Expected output_mask to be list of length 3, got {type(output_mask)} of length {len(output_mask) if isinstance(output_mask, list) else 'N/A'}"
+            )
     else:
         if not (isinstance(output_mask, list) and len(output_mask) == 2):
-            raise AssertionError(f"Expected output_mask to be list of length 2, got {type(output_mask)} of length {len(output_mask) if isinstance(output_mask, list) else 'N/A'}")
+            raise AssertionError(
+                f"Expected output_mask to be list of length 2, got {type(output_mask)} of length {len(output_mask) if isinstance(output_mask, list) else 'N/A'}"
+            )
 
     # output tuple: (d_input, d_weight[, d_bias])
     out_tuple_strategy = OpStrategy([])
@@ -1133,7 +1155,7 @@ def _common_norm_backward_strategy(
                 error_msg = "output_mask[1] should not be `True` while weight argument is `None` in native_layer_norm_backward."
             else:
                 error_msg = "output_mask[1] should not be `True` while weight argument is `None` in _fused_rms_norm_backward."
-            if not output_mask[1] is False:
+            if output_mask[1] is not False:
                 raise AssertionError(error_msg)
             output_specs_list.append(None)
 
@@ -1159,8 +1181,10 @@ def _common_norm_backward_strategy(
                 )
                 output_specs_list.append(bias_out_spec if output_mask[2] else None)
             else:
-                if not output_mask[2] is False:
-                    raise AssertionError("output_mask[2] should not be `True` while bias argument is `None` in native_layer_norm_backward.")
+                if output_mask[2] is not False:
+                    raise AssertionError(
+                        "output_mask[2] should not be `True` while bias argument is `None` in native_layer_norm_backward."
+                    )
                 output_specs_list.append(None)
 
         out_tuple_strategy.strategies.append(
@@ -1291,7 +1315,9 @@ def logsumexp_strategy(op_schema: OpSchema) -> OpStrategy:
     # args_schema contains all but the DTensor args (e.g., dim, keepdim).
     args_schema = op_schema.args_schema
     if not len(args_schema) > 1:
-        raise AssertionError(f"Expected more than 1 arg (input and dim are required), got {len(args_schema)}")
+        raise AssertionError(
+            f"Expected more than 1 arg (input and dim are required), got {len(args_schema)}"
+        )
 
     input_strategy = args_schema[0]
     if not isinstance(input_strategy, OpStrategy):

--- a/torch/distributed/tensor/_ops/_matrix_ops.py
+++ b/torch/distributed/tensor/_ops/_matrix_ops.py
@@ -80,7 +80,9 @@ def _mm_like_strategy(
     filtered_strategies = []
     for strtg in strategies:
         if strtg.input_specs is None:
-            raise AssertionError(f"Expected input_specs to be not None, got {strtg.input_specs}")
+            raise AssertionError(
+                f"Expected input_specs to be not None, got {strtg.input_specs}"
+            )
         self_spec = strtg.input_specs[0]
         mat2_spec = strtg.input_specs[1]
         if is_tensor_shardable(self_strategy.shape, self_spec) and is_tensor_shardable(
@@ -123,7 +125,9 @@ def _addmm_like_strategy(
     for strtg in strategies:
         # construct new strategy by consider the self arg
         if strtg.input_specs is None:
-            raise AssertionError(f"Expected input_specs to be not None, got {strtg.input_specs}")
+            raise AssertionError(
+                f"Expected input_specs to be not None, got {strtg.input_specs}"
+            )
         mat1_spec = strtg.input_specs[0]
         mat2_spec = strtg.input_specs[1]
         out_spec = strtg.output_spec
@@ -188,7 +192,9 @@ def _scaled_mm_like_strategy(
     filtered_strategies = []
     for strtg in strategies:
         if strtg.input_specs is None:
-            raise AssertionError(f"Expected input_specs to be not None, got {strtg.input_specs}")
+            raise AssertionError(
+                f"Expected input_specs to be not None, got {strtg.input_specs}"
+            )
         self_spec = strtg.input_specs[0]
         mat2_spec = strtg.input_specs[1]
         # propagate the operands' specs to their scales, except for tensor-wise
@@ -813,7 +819,9 @@ def scaled_scaled_dot_product_cudnn_attention_backward_strategy(
     mesh = op_schema.get_mesh_from_args(validate=False)
 
     if len(op_schema.args_schema) < 15:
-        raise AssertionError(f"Expected at least 15 args_schema, got {len(op_schema.args_schema)}")
+        raise AssertionError(
+            f"Expected at least 15 args_schema, got {len(op_schema.args_schema)}"
+        )
     has_attn_bias = op_schema.args_schema[8] is not None
     has_scale = len(op_schema.args_schema) >= 16 and False
 
@@ -1072,9 +1080,13 @@ def grouped_mm_strategy(op_schema: OpSchema) -> OpStrategy:
         # UGH the input DTensorSpecs are missing their tensormetas... so i can get them another way
         def local_meta(spec: OpSpec, placements: tuple[Placement, ...]) -> TensorMeta:
             if not isinstance(spec.output_specs, DTensorSpec):
-                raise AssertionError(f"Expected DTensorSpec, got {type(spec.output_specs)}")
+                raise AssertionError(
+                    f"Expected DTensorSpec, got {type(spec.output_specs)}"
+                )
             if not isinstance(spec.output_specs.tensor_meta, TensorMeta):
-                raise AssertionError(f"Expected TensorMeta, got {type(spec.output_specs.tensor_meta)}")
+                raise AssertionError(
+                    f"Expected TensorMeta, got {type(spec.output_specs.tensor_meta)}"
+                )
             meta: TensorMeta = spec.output_specs.tensor_meta
             local_stride = compute_local_stride(meta.stride, mesh, placements)
             local_shape, _ = compute_local_shape_and_global_offset(

--- a/torch/distributed/tensor/_ops/_matrix_ops.py
+++ b/torch/distributed/tensor/_ops/_matrix_ops.py
@@ -42,7 +42,8 @@ aten = torch.ops.aten
 @register_op_strategy(aten.t.default)
 def transpose_strategy(op_schema: OpSchema) -> OpStrategy:
     self_strategy = op_schema.args_schema[0]
-    assert isinstance(self_strategy, OpStrategy)
+    if not isinstance(self_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(self_strategy)}")
 
     transpose_strategies = []
     for input_strategy in self_strategy.strategies:
@@ -68,15 +69,18 @@ def _mm_like_strategy(
     mm_equation: str, mesh: DeviceMesh, op_schema: OpSchema
 ) -> OpStrategy:
     self_strategy, mat2_strategy = op_schema.args_schema
-    assert isinstance(self_strategy, OpStrategy)
-    assert isinstance(mat2_strategy, OpStrategy)
+    if not isinstance(self_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(self_strategy)}")
+    if not isinstance(mat2_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(mat2_strategy)}")
     # generate all possible strategies for mm
     mm_strategy = gen_einsum_strategies(mm_equation, mesh)
     # filter out invalid strategies and associate costs
     strategies = mm_strategy.strategies
     filtered_strategies = []
     for strtg in strategies:
-        assert strtg.input_specs is not None
+        if strtg.input_specs is None:
+            raise AssertionError(f"Expected input_specs to be not None, got {strtg.input_specs}")
         self_spec = strtg.input_specs[0]
         mat2_spec = strtg.input_specs[1]
         if is_tensor_shardable(self_strategy.shape, self_spec) and is_tensor_shardable(
@@ -98,9 +102,12 @@ def _addmm_like_strategy(
     mm_equation: str, mesh: DeviceMesh, op_schema: OpSchema
 ) -> OpStrategy:
     self_strategy, mat1_strategy, mat2_strategy = op_schema.args_schema
-    assert isinstance(self_strategy, OpStrategy)
-    assert isinstance(mat1_strategy, OpStrategy)
-    assert isinstance(mat2_strategy, OpStrategy)
+    if not isinstance(self_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(self_strategy)}")
+    if not isinstance(mat1_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(mat1_strategy)}")
+    if not isinstance(mat2_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(mat2_strategy)}")
     self_shape = self_strategy.shape
     mm_out_shape = torch.Size(
         [
@@ -115,7 +122,8 @@ def _addmm_like_strategy(
     filtered_strategies = []
     for strtg in strategies:
         # construct new strategy by consider the self arg
-        assert strtg.input_specs is not None
+        if strtg.input_specs is None:
+            raise AssertionError(f"Expected input_specs to be not None, got {strtg.input_specs}")
         mat1_spec = strtg.input_specs[0]
         mat2_spec = strtg.input_specs[1]
         out_spec = strtg.output_spec
@@ -160,22 +168,27 @@ def _scaled_mm_like_strategy(
         scale_result_strategy,
         *_,
     ) = op_schema.args_schema
-    assert isinstance(self_strategy, OpStrategy)
-    assert isinstance(mat2_strategy, OpStrategy)
-    assert isinstance(scale_self_strategy, OpStrategy)
-    assert isinstance(scale_mat2_strategy, OpStrategy)
+    if not isinstance(self_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(self_strategy)}")
+    if not isinstance(mat2_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(mat2_strategy)}")
+    if not isinstance(scale_self_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(scale_self_strategy)}")
+    if not isinstance(scale_mat2_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(scale_mat2_strategy)}")
     # TODO: add support for these later
-    assert bias_strategy is None, "_scaled_mm on DTensors doesn't support bias"
-    assert scale_result_strategy is None, (
-        "_scaled_mm on DTensors doesn't support scale_result"
-    )
+    if bias_strategy is not None:
+        raise AssertionError("_scaled_mm on DTensors doesn't support bias")
+    if scale_result_strategy is not None:
+        raise AssertionError("_scaled_mm on DTensors doesn't support scale_result")
     # generate all possible strategies for mm
     mm_strategy = gen_einsum_strategies(mm_equation, mesh)
     # filter out invalid strategies and associate costs
     strategies = mm_strategy.strategies
     filtered_strategies = []
     for strtg in strategies:
-        assert strtg.input_specs is not None
+        if strtg.input_specs is None:
+            raise AssertionError(f"Expected input_specs to be not None, got {strtg.input_specs}")
         self_spec = strtg.input_specs[0]
         mat2_spec = strtg.input_specs[1]
         # propagate the operands' specs to their scales, except for tensor-wise
@@ -260,7 +273,8 @@ def scaled_dot_product_flash_attention_strategy(op_schema: OpSchema) -> OpStrate
 
     return_debug_mask = len(op_schema.args_schema) >= 6 and op_schema.args_schema[5]
     q_input_strategy = op_schema.args_schema[0]
-    assert isinstance(q_input_strategy, OpStrategy)
+    if not isinstance(q_input_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(q_input_strategy)}")
     # assuming q/k/v have the same shape
 
     single_mesh_dim_strategies = []
@@ -361,7 +375,8 @@ def scaled_dot_product_flash_attention_backward_strategy(
     mesh = op_schema.get_mesh_from_args(validate=False)
 
     q_input_strategy = op_schema.args_schema[1]
-    assert isinstance(q_input_strategy, OpStrategy)
+    if not isinstance(q_input_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(q_input_strategy)}")
     # assuming q/k/v have the same shape
 
     tensor_input_indices = [
@@ -473,7 +488,8 @@ def scaled_dot_product_efficient_attention_strategy(op_schema: OpSchema) -> OpSt
     # NOTE: currently we only support some simple strategies to support tensor parallelism
     mesh = op_schema.get_mesh_from_args()
     q_input_strategy = op_schema.args_schema[0]
-    assert isinstance(q_input_strategy, OpStrategy)
+    if not isinstance(q_input_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(q_input_strategy)}")
     # assuming q/k/v have the same shape
 
     has_attn_bias = op_schema.args_schema[3] is not None
@@ -570,7 +586,8 @@ def scaled_dot_product_efficient_attention_backward_strategy(
     mesh = op_schema.get_mesh_from_args(validate=False)
 
     q_input_strategy = op_schema.args_schema[1]
-    assert isinstance(q_input_strategy, OpStrategy)
+    if not isinstance(q_input_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(q_input_strategy)}")
     # assuming q/k/v have the same shape
     has_attn_bias = op_schema.args_schema[4] is not None
 
@@ -689,7 +706,8 @@ def scaled_dot_product_cudnn_attention_strategy(op_schema: OpSchema) -> OpStrate
         Replicate() if return_debug_mask else None
     )
 
-    assert isinstance(query_strategy, OpStrategy)
+    if not isinstance(query_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(query_strategy)}")
     # assuming q/k/v have the same shape
 
     single_mesh_dim_strategies = []
@@ -794,12 +812,14 @@ def scaled_scaled_dot_product_cudnn_attention_backward_strategy(
     # backward op does not need to validate the mesh since forward op has already done it
     mesh = op_schema.get_mesh_from_args(validate=False)
 
-    assert len(op_schema.args_schema) >= 15
+    if len(op_schema.args_schema) < 15:
+        raise AssertionError(f"Expected at least 15 args_schema, got {len(op_schema.args_schema)}")
     has_attn_bias = op_schema.args_schema[8] is not None
     has_scale = len(op_schema.args_schema) >= 16 and False
 
     query_strategy = op_schema.args_schema[1]
-    assert isinstance(query_strategy, OpStrategy)
+    if not isinstance(query_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(query_strategy)}")
     # assuming q/k/v have the same shape
 
     single_mesh_dim_strategies = []
@@ -911,12 +931,15 @@ def grouped_mm_strategy(op_schema: OpSchema) -> OpStrategy:
     mesh = op_schema.get_mesh_from_args()
 
     mat1_strategy = op_schema.args_schema[0]
-    assert isinstance(mat1_strategy, OpStrategy)
+    if not isinstance(mat1_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(mat1_strategy)}")
     mat2_strategy = op_schema.args_schema[1]
-    assert isinstance(mat2_strategy, OpStrategy)
+    if not isinstance(mat2_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(mat2_strategy)}")
     if len(op_schema.args_schema) > 3:
         bias_strategy = op_schema.args_schema[3]
-        assert bias_strategy is None, "grouped_mm doesn't support bias yet"
+        if bias_strategy is not None:
+            raise AssertionError("grouped_mm doesn't support bias yet")
 
     single_mesh_dim_strategies = []
 
@@ -1048,8 +1071,10 @@ def grouped_mm_strategy(op_schema: OpSchema) -> OpStrategy:
         # 2. apply the logic from the groped_mm meta function
         # UGH the input DTensorSpecs are missing their tensormetas... so i can get them another way
         def local_meta(spec: OpSpec, placements: tuple[Placement, ...]) -> TensorMeta:
-            assert isinstance(spec.output_specs, DTensorSpec)
-            assert isinstance(spec.output_specs.tensor_meta, TensorMeta)
+            if not isinstance(spec.output_specs, DTensorSpec):
+                raise AssertionError(f"Expected DTensorSpec, got {type(spec.output_specs)}")
+            if not isinstance(spec.output_specs.tensor_meta, TensorMeta):
+                raise AssertionError(f"Expected TensorMeta, got {type(spec.output_specs.tensor_meta)}")
             meta: TensorMeta = spec.output_specs.tensor_meta
             local_stride = compute_local_stride(meta.stride, mesh, placements)
             local_shape, _ = compute_local_shape_and_global_offset(

--- a/torch/distributed/tensor/_ops/_view_ops.py
+++ b/torch/distributed/tensor/_ops/_view_ops.py
@@ -142,7 +142,9 @@ class Split(DimSpec):
     @classmethod
     def new(cls, dim: DimSpec, group_shape: tuple[int, ...], idx: int) -> DimSpec:
         if not len(group_shape) > 0:
-            raise AssertionError(f"Expected group_shape length > 0, got {len(group_shape)}")
+            raise AssertionError(
+                f"Expected group_shape length > 0, got {len(group_shape)}"
+            )
         if len(group_shape) == 1:
             # not really a group, just return the input dim back
             if not idx == 0:
@@ -184,7 +186,9 @@ def dim_atleast_3d(ndim: int) -> DimMap:
 def expand(input_shape: Shape, shape: Shape) -> DimMap:
     """Implement broadcast on multiple dimensions."""
     if not len(shape) >= len(input_shape):
-        raise AssertionError(f"Expected len(shape) >= len(input_shape), got {len(shape)} < {len(input_shape)}")
+        raise AssertionError(
+            f"Expected len(shape) >= len(input_shape), got {len(shape)} < {len(input_shape)}"
+        )
 
     # 1. create padded input dimensions
     padded_input = dim_pad_left(len(input_shape), len(shape))
@@ -200,7 +204,9 @@ def expand(input_shape: Shape, shape: Shape) -> DimMap:
                 raise AssertionError(f"DimSpec not supported in expand: {p}")
             actual_s = input_shape[p.input_dim]
             if not (actual_s == 1 or desired_s == -1 or desired_s == actual_s):
-                raise AssertionError(f"Expected actual_s == 1 or desired_s == -1 or desired_s == actual_s, got actual_s={actual_s}, desired_s={desired_s}")
+                raise AssertionError(
+                    f"Expected actual_s == 1 or desired_s == -1 or desired_s == actual_s, got actual_s={actual_s}, desired_s={desired_s}"
+                )
         mapping.append(
             p
             if desired_s in (1, -1) or desired_s == actual_s
@@ -245,7 +251,9 @@ def dim_movedim(
     destination = normalize_dims(destination, ndim)
 
     if not len(input) == len(destination):
-        raise AssertionError(f"Expected len(input) == len(destination), got {len(input)} != {len(destination)}")
+        raise AssertionError(
+            f"Expected len(input) == len(destination), got {len(input)} != {len(destination)}"
+        )
     input_set = set(input)
     if not len(input_set) == len(input):
         raise AssertionError("Found repeated input dims")
@@ -254,7 +262,9 @@ def dim_movedim(
     if not max(input) < ndim:
         raise AssertionError(f"Expected max(input) < ndim, got {max(input)} >= {ndim}")
     if not max(destination) < ndim:
-        raise AssertionError(f"Expected max(destination) < ndim, got {max(destination)} >= {ndim}")
+        raise AssertionError(
+            f"Expected max(destination) < ndim, got {max(destination)} >= {ndim}"
+        )
 
     dest = [-1] * ndim
     for i, d in zip(input, destination):
@@ -509,9 +519,7 @@ def propagate_shape_and_sharding(
       if the leftmost split size is divisible by the mesh dimension
     """
     if not len(input_src_placements) == len(mesh_sizes):
-        raise AssertionError(
-            f"{input_src_placements} != {mesh_sizes}"
-        )
+        raise AssertionError(f"{input_src_placements} != {mesh_sizes}")
     # for each input dim, for each mesh dim, provides a list of possible shardable dimensions
     mesh_ndim = len(mesh_sizes)
     shardable_dims: dict[int, list[bool]] = {}
@@ -569,7 +577,9 @@ def propagate_shape_and_sharding(
                         )
                 elif input_sharded:
                     if not (shard_placement is not None and shard_mesh_dim is not None):
-                        raise AssertionError(f"Expected shard_placement and shard_mesh_dim to be not None")
+                        raise AssertionError(
+                            "Expected shard_placement and shard_mesh_dim to be not None"
+                        )
                     tensor_dim_size = global_input_shape[shard_placement.dim]
                     mesh_dim_size = mesh_sizes[shard_mesh_dim]
                     if tensor_dim_size % mesh_dim_size != 0:
@@ -583,7 +593,9 @@ def propagate_shape_and_sharding(
                 shardable_dims[dim.input_dim] = [can_shard_dim] * mesh_ndim
 
             if not isinstance(cmd.input_dims[0], InputDim):
-                raise AssertionError(f"Expected InputDim, got {type(cmd.input_dims[0])}")
+                raise AssertionError(
+                    f"Expected InputDim, got {type(cmd.input_dims[0])}"
+                )
             return cmd.input_dims[0]
         elif isinstance(cmd, Split):
             in_dim = get_in_dim_to_shard(cmd.input_dim)

--- a/torch/distributed/tensor/_ops/_view_ops.py
+++ b/torch/distributed/tensor/_ops/_view_ops.py
@@ -141,10 +141,12 @@ class Split(DimSpec):
 
     @classmethod
     def new(cls, dim: DimSpec, group_shape: tuple[int, ...], idx: int) -> DimSpec:
-        assert len(group_shape) > 0
+        if not len(group_shape) > 0:
+            raise AssertionError(f"Expected group_shape length > 0, got {len(group_shape)}")
         if len(group_shape) == 1:
             # not really a group, just return the input dim back
-            assert idx == 0
+            if not idx == 0:
+                raise AssertionError(f"Expected idx == 0, got {idx}")
             return dim
         elif group_shape[idx] == 1:
             return Singleton()
@@ -181,7 +183,8 @@ def dim_atleast_3d(ndim: int) -> DimMap:
 
 def expand(input_shape: Shape, shape: Shape) -> DimMap:
     """Implement broadcast on multiple dimensions."""
-    assert len(shape) >= len(input_shape)
+    if not len(shape) >= len(input_shape):
+        raise AssertionError(f"Expected len(shape) >= len(input_shape), got {len(shape)} < {len(input_shape)}")
 
     # 1. create padded input dimensions
     padded_input = dim_pad_left(len(input_shape), len(shape))
@@ -190,11 +193,14 @@ def expand(input_shape: Shape, shape: Shape) -> DimMap:
     for p, desired_s in zip(padded_input, shape):
         if isinstance(p, Singleton):
             actual_s = 1
-            assert desired_s >= 0
+            if not desired_s >= 0:
+                raise AssertionError(f"Expected desired_s >= 0, got {desired_s}")
         else:
-            assert isinstance(p, InputDim), f"DimSpec not supported in expand: {p}"
+            if not isinstance(p, InputDim):
+                raise AssertionError(f"DimSpec not supported in expand: {p}")
             actual_s = input_shape[p.input_dim]
-            assert actual_s == 1 or desired_s == -1 or desired_s == actual_s
+            if not (actual_s == 1 or desired_s == -1 or desired_s == actual_s):
+                raise AssertionError(f"Expected actual_s == 1 or desired_s == -1 or desired_s == actual_s, got actual_s={actual_s}, desired_s={desired_s}")
         mapping.append(
             p
             if desired_s in (1, -1) or desired_s == actual_s
@@ -238,12 +244,17 @@ def dim_movedim(
     input = normalize_dims(input, ndim)
     destination = normalize_dims(destination, ndim)
 
-    assert len(input) == len(destination)
+    if not len(input) == len(destination):
+        raise AssertionError(f"Expected len(input) == len(destination), got {len(input)} != {len(destination)}")
     input_set = set(input)
-    assert len(input_set) == len(input), "Found repeated input dims"
-    assert len(set(destination)) == len(destination), "Found repeated output dims"
-    assert max(input) < ndim
-    assert max(destination) < ndim
+    if not len(input_set) == len(input):
+        raise AssertionError("Found repeated input dims")
+    if not len(set(destination)) == len(destination):
+        raise AssertionError("Found repeated output dims")
+    if not max(input) < ndim:
+        raise AssertionError(f"Expected max(input) < ndim, got {max(input)} >= {ndim}")
+    if not max(destination) < ndim:
+        raise AssertionError(f"Expected max(destination) < ndim, got {max(destination)} >= {ndim}")
 
     dest = [-1] * ndim
     for i, d in zip(input, destination):
@@ -259,9 +270,10 @@ def dim_movedim(
 
 def dim_repeat(ndim: int, sizes: Shape) -> DimMap:
     sizes = normalize_sizes(sizes)
-    assert len(sizes) >= ndim, (
-        f"Number of dimensions of repeat dims {sizes} can not be smaller than number of dimensions of tensor {ndim}."
-    )
+    if not len(sizes) >= ndim:
+        raise AssertionError(
+            f"Number of dimensions of repeat dims {sizes} can not be smaller than number of dimensions of tensor {ndim}."
+        )
     pad = len(sizes) - ndim
     return tuple(Repeat.new(Singleton(), s) for s in sizes[:pad]) + tuple(
         Repeat.new(InputDim(i), s) for i, s in enumerate(sizes[pad:])
@@ -276,15 +288,18 @@ def infer_size(total_size: int, sizes: Shape) -> Shape:
     """
     infers = [i for i, s in enumerate(sizes) if s == -1]
     size = prod(sizes)
-    assert len(infers) <= 1, "can only infer one size"
+    if not len(infers) <= 1:
+        raise AssertionError("can only infer one size")
     if infers:
         size = -size
         missing_size = total_size // size
-        assert total_size % size == 0, (
-            f"size inferred for -1 is not integral {sizes} should have {total_size} elements."
-        )
+        if not total_size % size == 0:
+            raise AssertionError(
+                f"size inferred for -1 is not integral {sizes} should have {total_size} elements."
+            )
         return tuple(s if s != -1 else missing_size for s in sizes)
-    assert size == total_size, f"sizes do not match {total_size} vs {size}"
+    if not size == total_size:
+        raise AssertionError(f"sizes do not match {total_size} vs {size}")
     return sizes
 
 
@@ -320,7 +335,8 @@ def view_groups(from_size: Shape, to_size: Shape) -> DimMap:
     from_nelem = prod(from_size)
     to_size = infer_size(from_nelem, normalize_sizes(to_size))
 
-    assert from_nelem == prod(to_size), "Total view shape does not add up"
+    if not from_nelem == prod(to_size):
+        raise AssertionError("Total view shape does not add up")
 
     from_idx = 0
     to_idx = 0
@@ -390,8 +406,10 @@ def dim_tile(ndim: int, dims: tuple[int, ...]) -> DimMap:
 def dim_transpose(ndim: int, dim1: int, dim2: int) -> DimMap:
     dim1 = normalize_dim(dim1, ndim)
     dim2 = normalize_dim(dim2, ndim)
-    assert dim1 < ndim
-    assert dim2 < ndim
+    if not dim1 < ndim:
+        raise AssertionError(f"Expected dim1 < ndim, got {dim1} >= {ndim}")
+    if not dim2 < ndim:
+        raise AssertionError(f"Expected dim2 < ndim, got {dim2} >= {ndim}")
     dimmap = [InputDim(i) for i in range(ndim)]
     swapdim = dimmap[dim1]
     dimmap[dim1] = dimmap[dim2]
@@ -490,9 +508,10 @@ def propagate_shape_and_sharding(
     - An output dimension that is a split of the input dimension can only be sharded
       if the leftmost split size is divisible by the mesh dimension
     """
-    assert len(input_src_placements) == len(mesh_sizes), (
-        f"{input_src_placements} != {mesh_sizes}"
-    )
+    if not len(input_src_placements) == len(mesh_sizes):
+        raise AssertionError(
+            f"{input_src_placements} != {mesh_sizes}"
+        )
     # for each input dim, for each mesh dim, provides a list of possible shardable dimensions
     mesh_ndim = len(mesh_sizes)
     shardable_dims: dict[int, list[bool]] = {}
@@ -534,7 +553,8 @@ def propagate_shape_and_sharding(
         elif isinstance(cmd, Flatten):
             for i, dim in enumerate(cmd.input_dims):
                 # so far all Flatten is always composed of InputDims; revisit this if needed
-                assert isinstance(dim, InputDim)
+                if not isinstance(dim, InputDim):
+                    raise AssertionError(f"Expected InputDim, got {type(dim)}")
                 can_shard_dim = True
                 shard_mesh_dim, shard_placement = (
                     maybe_get_shard_mesh_dim_and_placement(dim)
@@ -548,7 +568,8 @@ def propagate_shape_and_sharding(
                             "It cannot be performed without redistribution, which is disallowed by the current operator.",
                         )
                 elif input_sharded:
-                    assert shard_placement is not None and shard_mesh_dim is not None
+                    if not (shard_placement is not None and shard_mesh_dim is not None):
+                        raise AssertionError(f"Expected shard_placement and shard_mesh_dim to be not None")
                     tensor_dim_size = global_input_shape[shard_placement.dim]
                     mesh_dim_size = mesh_sizes[shard_mesh_dim]
                     if tensor_dim_size % mesh_dim_size != 0:
@@ -561,7 +582,8 @@ def propagate_shape_and_sharding(
                             )
                 shardable_dims[dim.input_dim] = [can_shard_dim] * mesh_ndim
 
-            assert isinstance(cmd.input_dims[0], InputDim)
+            if not isinstance(cmd.input_dims[0], InputDim):
+                raise AssertionError(f"Expected InputDim, got {type(cmd.input_dims[0])}")
             return cmd.input_dims[0]
         elif isinstance(cmd, Split):
             in_dim = get_in_dim_to_shard(cmd.input_dim)
@@ -594,9 +616,10 @@ def propagate_shape_and_sharding(
                 for size, shard in zip(mesh_sizes, input_src_placements):
                     if isinstance(shard, Shard) and shard.dim == in_dim:
                         submesh_size *= size
-                assert out_size % submesh_size == 0, (
-                    f"Resulting dimension size {out_size} is not divisible by its mesh dimension {submesh_size}."
-                )
+                if not out_size % submesh_size == 0:
+                    raise AssertionError(
+                        f"Resulting dimension size {out_size} is not divisible by its mesh dimension {submesh_size}."
+                    )
 
             # we will only shard our first component of the split
             return in_dim if cmd.split_id == 0 else None
@@ -677,7 +700,8 @@ def register_op_strategy_map(
         mesh = op_schema.get_mesh_from_args(validate=False)
 
         global_in_shape = input_strategy.shape
-        assert global_in_shape is not None, "Shape required."
+        if not global_in_shape is not None:
+            raise AssertionError("Shape required.")
 
         output_strategy = OpStrategy([])
         for input_placement_strategy in input_strategy.strategies:

--- a/torch/distributed/tensor/_ops/_view_ops.py
+++ b/torch/distributed/tensor/_ops/_view_ops.py
@@ -205,7 +205,8 @@ def expand(input_shape: Shape, shape: Shape) -> DimMap:
             actual_s = input_shape[p.input_dim]
             if not (actual_s == 1 or desired_s == -1 or desired_s == actual_s):
                 raise AssertionError(
-                    f"Expected actual_s == 1 or desired_s == -1 or desired_s == actual_s, got actual_s={actual_s}, desired_s={desired_s}"
+                    f"Expected actual_s == 1 or desired_s == -1 or "
+                    f"desired_s == actual_s, got actual_s={actual_s}, desired_s={desired_s}"
                 )
         mapping.append(
             p
@@ -712,7 +713,7 @@ def register_op_strategy_map(
         mesh = op_schema.get_mesh_from_args(validate=False)
 
         global_in_shape = input_strategy.shape
-        if not global_in_shape is not None:
+        if global_in_shape is None:
             raise AssertionError("Shape required.")
 
         output_strategy = OpStrategy([])


### PR DESCRIPTION
Replace assert statements with explicit if/raise patterns in:
- _math_ops.py (43 asserts)
- _matrix_ops.py (27 asserts)
- _view_ops.py (24 asserts)

This prevents assertions from being disabled with Python -O flag.

Fixes partially #164878. 

cc: @albanD 


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci