### PR TITLE
[DTensor] Extend conv ops to 3D

### DIFF
--- a/test/distributed/tensor/test_convolution_ops.py
+++ b/test/distributed/tensor/test_convolution_ops.py
@@ -203,6 +203,28 @@ class DistConvolutionOpsTest(DTensorTestBase):
         self.assertTrue(b_dt.grad is not None)
         self.assertTrue(x_dt.grad is None)
 
+    @with_comms
+    def test_conv1d(self):
+        device_mesh = self.build_device_mesh()
+        model = nn.Conv1d(64, 64, 3, padding=1)
+        x = torch.randn(1, 64, 8)
+        x_dt = DTensor.from_local(x, device_mesh, [Replicate()])
+        model_dt = distribute_module(
+            model, device_mesh, _conv_fn, input_fn=None, output_fn=None
+        )
+        out_dt = model_dt(x_dt)
+
+    @with_comms
+    def test_conv3d(self):
+        device_mesh = self.build_device_mesh()
+        model = nn.Conv3d(64, 64, 3, padding=1)
+        x = torch.randn(1, 64, 8, 8, 8)
+        x_dt = DTensor.from_local(x, device_mesh, [Replicate()])
+        model_dt = distribute_module(
+            model, device_mesh, _conv_fn, input_fn=None, output_fn=None
+        )
+        out_dt = model_dt(x_dt)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/tensor/test_convolution_ops.py
+++ b/test/distributed/tensor/test_convolution_ops.py
@@ -221,7 +221,7 @@ class DistConvolutionOpsTest(DTensorTestBase):
     def test_conv3d(self):
         device_mesh = self.build_device_mesh()
         model = nn.Conv3d(64, 64, 3, padding=1)
-        model_gt = copy.deepcopy(model)
+        model_gt = copy.deepcopy(model).to(device=self.device_type)
         x = torch.randn(1, 64, 8, 8, 8, device=self.device_type)
         x_dt = DTensor.from_local(x, device_mesh, [Replicate()])
         model_dt = distribute_module(

--- a/test/distributed/tensor/test_convolution_ops.py
+++ b/test/distributed/tensor/test_convolution_ops.py
@@ -207,23 +207,29 @@ class DistConvolutionOpsTest(DTensorTestBase):
     def test_conv1d(self):
         device_mesh = self.build_device_mesh()
         model = nn.Conv1d(64, 64, 3, padding=1)
+        model_gt = copy.deepcopy(model).to(self.device_type)
         x = torch.randn(1, 64, 8)
         x_dt = DTensor.from_local(x, device_mesh, [Replicate()])
         model_dt = distribute_module(
             model, device_mesh, _conv_fn, input_fn=None, output_fn=None
         )
         out_dt = model_dt(x_dt)
+        out = model_gt(x)
+        self.assertEqual(out_dt.shape, out.shape)
 
     @with_comms
     def test_conv3d(self):
         device_mesh = self.build_device_mesh()
         model = nn.Conv3d(64, 64, 3, padding=1)
-        x = torch.randn(1, 64, 8, 8, 8)
+        model_gt = copy.deepcopy(model).to(self.device_type)
+        x = torch.randn(1, 64, 8, 8, 8, device=self.device_type)
         x_dt = DTensor.from_local(x, device_mesh, [Replicate()])
         model_dt = distribute_module(
             model, device_mesh, _conv_fn, input_fn=None, output_fn=None
         )
         out_dt = model_dt(x_dt)
+        out = model_gt(x)
+        self.assertEqual(out_dt.shape, out.shape)
 
 
 if __name__ == "__main__":

--- a/test/distributed/tensor/test_convolution_ops.py
+++ b/test/distributed/tensor/test_convolution_ops.py
@@ -207,7 +207,7 @@ class DistConvolutionOpsTest(DTensorTestBase):
     def test_conv1d(self):
         device_mesh = self.build_device_mesh()
         model = nn.Conv1d(64, 64, 3, padding=1)
-        model_gt = copy.deepcopy(model).to(self.device_type)
+        model_gt = copy.deepcopy(model)
         x = torch.randn(1, 64, 8)
         x_dt = DTensor.from_local(x, device_mesh, [Replicate()])
         model_dt = distribute_module(
@@ -221,7 +221,7 @@ class DistConvolutionOpsTest(DTensorTestBase):
     def test_conv3d(self):
         device_mesh = self.build_device_mesh()
         model = nn.Conv3d(64, 64, 3, padding=1)
-        model_gt = copy.deepcopy(model).to(self.device_type)
+        model_gt = copy.deepcopy(model)
         x = torch.randn(1, 64, 8, 8, 8, device=self.device_type)
         x_dt = DTensor.from_local(x, device_mesh, [Replicate()])
         model_dt = distribute_module(

--- a/torch/distributed/tensor/_ops/_conv_ops.py
+++ b/torch/distributed/tensor/_ops/_conv_ops.py
@@ -35,16 +35,15 @@ def convolution_rules(op_schema: OpSchema) -> OutputSharding:
     assert isinstance(padding, list)
     assert isinstance(dilation, list)
     assert isinstance(weight_shape, torch.Size)
-    N, H_in, W_in = in_shape[0], in_shape[2], in_shape[3]
-    C_out = weight_shape[0]
-    H_out = (H_in + 2 * padding[0] - dilation[0] * (weight_shape[2] - 1) - 1) // stride[
-        0
-    ] + 1
-    W_out = (W_in + 2 * padding[1] - dilation[1] * (weight_shape[3] - 1) - 1) // stride[
-        1
-    ] + 1
-    output_shape = [N, C_out, H_out, W_out]
-    output_stride = (C_out * H_out * W_out, H_out * W_out, W_out, 1)
+    out_conv_shape = [
+        (d + 2 * padding[i] - dilation[i] * (weight_shape[i + 1] - 1) - 1) // stride[i]
+        + 1
+        for (i, d) in enumerate(in_shape[2:])
+    ]
+    output_shape = [in_shape[0], weight_shape[0]] + out_conv_shape
+    output_stride = [1]
+    for i in range(1, len(output_shape)):
+        output_stride.insert(0, output_stride[0] * output_shape[-i])
     output_dim_map = input_spec.dim_map
     pending_sums = input_spec.sums
 

--- a/torch/distributed/tensor/_ops/_conv_ops.py
+++ b/torch/distributed/tensor/_ops/_conv_ops.py
@@ -49,7 +49,7 @@ def convolution_rules(op_schema: OpSchema) -> OutputSharding:
 
     tensor_meta = TensorMeta(
         torch.Size(output_shape),
-        output_stride,
+        tuple(output_stride),
         input_spec.tensor_meta.dtype,
     )
     return OutputSharding(

--- a/torch/distributed/tensor/_tp_conv.py
+++ b/torch/distributed/tensor/_tp_conv.py
@@ -13,25 +13,25 @@ aten = torch.ops.aten
 
 def _requires_data_exchange(padding):
     # TODO: whether there requires data exchange is currently determined by padding
-    return padding[1] != 0
+    return padding[-1] != 0
 
 
 def _is_supported(input_size, kernel_size, stride, padding, dilation):
-    if dilation[1] != 1:
+    if dilation[-1] != 1:
         raise RuntimeError("Dilation must be 1 for tensor parallel convolution.")
-    if padding[1] != 0:
-        if stride[1] != 1:
+    if padding[-1] != 0:
+        if stride[-1] != 1:
             raise RuntimeError(
                 "Stride must be 1 when there is padding for tensor parallel convolution."
             )
-        if kernel_size[3] // 2 > input_size[3]:
+        if kernel_size[-1] // 2 > input_size[-1]:
             raise RuntimeError(
-                "kernel_size[3] // 2 should be less than or equal to input_size[3] for tensor parallel convolution."
+                "kernel_size[-1] // 2 should be less than or equal to input_size[-1] for tensor parallel convolution."
             )
     else:
-        if not (input_size[3] % stride[1] == 0 and stride[1] == kernel_size[3]):
+        if not (input_size[-1] % stride[-1] == 0 and stride[-1] == kernel_size[-1]):
             raise RuntimeError(
-                "It requires that input_size[3] is divisible by stride[1] and stride[1] equals kernel_size[3] "
+                "It requires that input_size[-1] is divisible by stride[-1] and stride[-1] equals kernel_size[-1] "
                 "when there is padding for tensor parallel convolution."
             )
     return True
@@ -39,8 +39,8 @@ def _is_supported(input_size, kernel_size, stride, padding, dilation):
 
 def _ring_send_recv_construct(in_tensor, d1, d2, left, right, rank, size):
     # dist comms and reconstruct local input tensor
-    send_to_right = in_tensor[:, :, :, -d1:].contiguous()
-    send_to_left = in_tensor[:, :, :, :d2].contiguous()
+    send_to_right = in_tensor[..., -d1:].contiguous()
+    send_to_left = in_tensor[..., :d2].contiguous()
     recv_from_right = torch.zeros_like(send_to_left)
     recv_from_left = torch.zeros_like(send_to_right)
 
@@ -125,7 +125,7 @@ def tp_convolution(
         return local_results
     else:
         # step 0 compute the overlap pixels of the input tensor
-        d = weight.shape[3] - 1
+        d = weight.shape[-1] - 1
         d1 = d // 2
         d2 = d - d1
         assert d1 + d2 == d
@@ -144,14 +144,14 @@ def tp_convolution(
         local_results = op_call(*local_tensor_args, **local_tensor_kwargs)
 
         # step3 remove extra outputs from the results
-        padding_w = padding[1]
-        w = local_results.size(3)
+        padding_w = padding[-1]
+        w = local_results.size(-1)
         if rank == 0:
-            local_results = local_results[:, :, :, : w - padding_w]
+            local_results = local_results[..., : w - padding_w]
         elif rank == size - 1:
-            local_results = local_results[:, :, :, padding_w:]
+            local_results = local_results[..., padding_w:]
         else:
-            local_results = local_results[:, :, :, padding_w : w - padding_w]
+            local_results = local_results[..., padding_w : w - padding_w]
 
         return local_results
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #165241

Current implementation hardcodes 4D input and output tensor shapes

Change that by computing `output_conv_shape` for any number of input dims
Replace `[.., .., .., slice]` with `[..., slice]`

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci