### PR TITLE
[cuda] fix sort/argsort -0.0 vs +0.0 comparison

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4057,6 +4057,26 @@ print(ret)
         )
         self.assertEqual(r, "1.0")
 
+    def test_sort_negative_zero_consistency(self):
+        """
+        Test that sort/argsort handle -0.0 vs +0.0 consistently with CPU.
+        Regression test for https://github.com/pytorch/pytorch/issues/162235
+        """
+        # Test with pair [-0.0, 0.0]
+        x_cpu = torch.tensor([-0.0, 0.0], dtype=torch.float32)
+        x_cuda = x_cpu.cuda()
+
+        # Test sort operator (both values and indices)
+        vals_cpu, idx_cpu = torch.sort(x_cpu)
+        vals_cuda, idx_cuda = torch.sort(x_cuda)
+        self.assertEqual(vals_cpu, vals_cuda.cpu())
+        self.assertEqual(idx_cpu, idx_cuda.cpu())
+
+        # Test argsort operator
+        idx_cpu = torch.argsort(x_cpu)
+        idx_cuda = torch.argsort(x_cuda)
+        self.assertEqual(idx_cpu, idx_cuda.cpu())
+
 
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 @torch.testing._internal.common_utils.markDynamoStrictTest


### PR DESCRIPTION
Fixes #162235

Sort and argsort operators now treat -0.0 < +0.0 on CUDA to match CPU behavior. Modified comparison operators (LTOp/GTOp) to use signbit as tiebreaker when values are equal.

cc @ptrblck @msaroufim @eqy @jerryzh168