### PR TITLE
[cuda] fix nll_loss2d backward bounds check with reduction=none

### DIFF
--- a/aten/src/ATen/native/cuda/NLLLoss2d.cu
+++ b/aten/src/ATen/native/cuda/NLLLoss2d.cu
@@ -146,6 +146,7 @@ __global__ void nll_loss2d_backward_no_reduce_kernel(
   int64_t batch_size = target.size(0);
   int64_t H = target.size(1);
   int64_t W = target.size(2);
+  int64_t n_classes = grad_input.size(1);
 
   CUDA_KERNEL_LOOP(index, n_threads) {
     const int64_t b = index % batch_size;
@@ -156,6 +157,7 @@ __global__ void nll_loss2d_backward_no_reduce_kernel(
     if (cur_target == ignore_index) {
       continue;
     }
+    CUDA_KERNEL_ASSERT(cur_target >= 0 && cur_target < n_classes);
     scalar_t value = -(weight != nullptr ? weight[cur_target] : static_cast<scalar_t>(1));
     grad_input[b][cur_target][h][w] = value * grad_output[b][h][w];
   }

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12098,23 +12098,6 @@ class TestNNDeviceType(NNTestCase):
         for reduction in ['mean', 'none']:
             F.nll_loss(x, t, ignore_index=255, reduction=reduction).sum().backward()
 
-    @onlyCUDA
-    def test_nll_loss2d_out_of_bounds_target(self, device):
-        # Regression test for https://github.com/pytorch/pytorch/issues/49882
-        input = torch.randn(1, 19, 32, 64, requires_grad=True, device=device)
-        target = torch.randint(22, size=(1, 32, 64), device=device)
-
-        # Forward with reduction='none' should error on out-of-bounds
-        with self.assertRaises(RuntimeError):
-            F.cross_entropy(input, target, reduction='none')
-
-        # Backward with reduction='none' should also error
-        with self.assertRaises(RuntimeError):
-            output = F.cross_entropy(input, target.clamp(0, 18), reduction='none')
-            output.sum().backward()
-            input2 = torch.randn(1, 19, 32, 64, requires_grad=True, device=device)
-            output2 = F.cross_entropy(input2, target, reduction='none')
-
     def test_nll_loss_invalid_target_dim(self, device):
         x = torch.randn((10, 3), device=device)
         t = torch.zeros((10, 2), dtype=torch.int64, device=device)


### PR DESCRIPTION
Fixes #49882

Add missing bounds check in nll_loss2d backward kernel with reduction=none. Forward kernel already had CUDA_KERNEL_ASSERT for target bounds, now backward kernel matches.

cc @albanD @mruberry @jbschlosser @ngimel @ptrblck