### PR TITLE
Remove FIXME comment about reset_max_memory_reserved

### DIFF
--- a/docs/source/cuda.md
+++ b/docs/source/cuda.md
@@ -176,10 +176,6 @@
 .. autoclass:: torch.cuda.use_mem_pool
 ```
 
-% FIXME The following doesn't seem to exist. Is it supposed to?
-% https://github.com/pytorch/pytorch/issues/27785
-% .. autofunction:: reset_max_memory_reserved
-
 ## NVIDIA Tools Extension (NVTX)
 
 ```{eval-rst}


### PR DESCRIPTION
The function doesn't actually exist https://github.com/pytorch/pytorch/blob/main/torch/cuda/__init__.py#L1816

Fixes https://github.com/pytorch/pytorch/issues/27785
