### PR TITLE
[Helion] Add helion rmsnorm kernel to Optimus pass

### DIFF
--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -64,6 +64,7 @@ pre_grad_pass_names = [
     "unbind_stack_to_slices_pass",
     "move_reshape_out_of_split_stack_pass",
     "einsum_to_pointwise_pass",
+    "use_custom_rmsnorm_kernel_pass",
 ]
 
 post_grad_pass_names = [


### PR DESCRIPTION
Summary: We use pattern matcher to replace torch rms with helion rms

Test Plan:
```
buck2 test mode/dev-nosan //caffe2/test/inductor/fb:kernel_optimization_fb -- test_replace_rms_norm_with_helion
```

Buck UI: https://www.internalfb.com/buck2/57fe3544-4c6b-4af5-bc8b-c470fcefecfc
Test UI: https://www.internalfb.com/intern/testinfra/testrun/4503599943322024
Network: Up: 43KiB  Down: 2.2MiB  (reSessionID-1b28f262-3b8e-492c-9461-491e4bdd47f6)
Loading targets.   Remaining      0/5097                                                                                                        105414 dirs read, 1061277 targets declared
Analyzing targets. Remaining      0/63615                                                                                                       2461513 actions, 3372898 artifacts declared
Executing actions. Remaining      0/431051                                                                                                      16:29.3s exec time total
Command: test.     Finished 3 local, 1 remote, 608 cache (99% hit)                                                                              16:26.4s exec time cached (99%)                                      
Time elapsed: 2:54.8s
Tests finished: Pass 1. Fail 0. Fatal 0. Skip 0. Build failure 0

Differential Revision: D84226858




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos @chenyang78