### PR TITLE
[Helion] add helion layernorm kernel to Optimus pass

### DIFF
--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -64,6 +64,7 @@ pre_grad_pass_names = [
     "unbind_stack_to_slices_pass",
     "move_reshape_out_of_split_stack_pass",
     "einsum_to_pointwise_pass",
+    "use_custom_rmsnorm_kernel_pass",
 ]
 
 post_grad_pass_names = [

--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -65,6 +65,7 @@ pre_grad_pass_names = [
     "move_reshape_out_of_split_stack_pass",
     "einsum_to_pointwise_pass",
     "use_custom_rmsnorm_kernel_pass",
+    "use_custom_layernorm_kernel_pass",
 ]
 
 post_grad_pass_names = [


### PR DESCRIPTION
Summary: We use pattern matcher to replace torch layernorm with helion layernorm

Test Plan:
```
buck2 test mode/dev-nosan //caffe2/test/inductor/fb:kernel_optimization_fb -- test_replace_layer_norm_with_helion
```

Buck UI: https://www.internalfb.com/buck2/602fba2a-547a-4acc-ae3a-06dd419b15e0
Test UI: https://www.internalfb.com/intern/testinfra/testrun/5066549895249381
Network: Up: 3.9MiB  Down: 44MiB  (reSessionID-51c9fd70-a130-4035-a6a3-88a2f74a3efa)
Command: test.
Time elapsed: 59.5s
Tests finished: Pass 1. Fail 0. Fatal 0. Skip 0. Build failure 0

Differential Revision: D84226831




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos @chenyang78