### PR TITLE
[MPS] Fix internal assertion in torch.linalg.solve for singular matrices

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -1610,12 +1610,6 @@ void _linalg_check_errors(
       TORCH_CHECK_LINALG(info != -4, api_name, batch_str,
           ": The algorithm failed to converge because the input matrix contained non-finite values.");
     }
-    // MPSMatrixDecompositionLU `info` for singular matrices is -2 (MPSMatrixDecompositionStatus.singular)
-    // keep in sync with info > 0 branch error message.
-    if (api_name.find("solve") != api_name.npos && infos.device().type() == at::kMPS) {
-      TORCH_CHECK_LINALG(info != -2, api_name, batch_str,
-          ": The solver failed because the input matrix is singular.");
-    }
     TORCH_INTERNAL_ASSERT(false, api_name, batch_str,
         ": Argument ", -info, " has illegal value. Most certainly there is a bug in the implementation calling the backend library.");
   } else if (info > 0) {

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -1610,6 +1610,12 @@ void _linalg_check_errors(
       TORCH_CHECK_LINALG(info != -4, api_name, batch_str,
           ": The algorithm failed to converge because the input matrix contained non-finite values.");
     }
+    // MPSMatrixDecompositionLU `info` for singular matrices is -2 (MPSMatrixDecompositionStatus.singular)
+    // keep in sync with info > 0 branch error message.
+    if (api_name.find("solve") != api_name.npos && infos.device().type() == at::kMPS) {
+      TORCH_CHECK_LINALG(info != -2, api_name, batch_str,
+          ": The solver failed because the input matrix is singular.");
+    }
     TORCH_INTERNAL_ASSERT(false, api_name, batch_str,
         ": Argument ", -info, " has illegal value. Most certainly there is a bug in the implementation calling the backend library.");
   } else if (info > 0) {

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -196,6 +196,28 @@ bool use_metal_mm(const Tensor& self, const Tensor& other, const Tensor& output)
        other.size(0) > max_stride_size || other.size(1) > max_stride_size);
 }
 
+void map_mps_decomposition_error_code_to_blas(const Tensor& status) {
+  Tensor status_flat = status.view(-1);
+
+  for (const auto i : c10::irange(status_flat.size(0))) {
+    int code = status_flat[i].item<int>();
+    switch (code) {
+      case MPSMatrixDecompositionStatusSuccess:
+        status_flat[i] = 0;
+        break;
+      case MPSMatrixDecompositionStatusNonPositiveDefinite:
+      case MPSMatrixDecompositionStatusSingular:
+        status_flat[i] = 2;
+        break;
+      case MPSMatrixDecompositionStatusFailure:
+        status_flat[i] = -1;
+        break;
+      default:
+        TORCH_INTERNAL_ASSERT(false, "Unknown MPSMatrixDecompositionStatus enum value: ", code);
+    }
+  }
+}
+
 } // anonymous namespace
 
 static void linalg_lu_factor_ex_out_mps_impl(const Tensor& A,
@@ -487,6 +509,9 @@ static void linalg_solve_out_mps_impl(const Tensor& A,
                   "mpsmatrixdecompositionstatus for details.");
     }
   }
+
+  map_mps_decomposition_error_code_to_blas(info);
+
   if (!left) {
     // If this was a right solve, transpose the result back
     result.copy_(result_t.transpose(-2, -1).contiguous());

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -197,7 +197,7 @@ bool use_metal_mm(const Tensor& self, const Tensor& other, const Tensor& output)
 }
 
 void map_mps_decomposition_error_code_to_blas(const Tensor& status) {
-  Tensor status_flat = status.view(-1);
+  const auto& status_flat = status.view(-1);
 
   for (const auto i : c10::irange(status_flat.size(0))) {
     int code = status_flat[i].item<int>();

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1975,6 +1975,16 @@ class TestMPS(TestCaseMPS):
         run_linalg_solve_test(32, 10, 10)
         run_linalg_solve_test(32, 2, 2, 2, 2, 10, 10)
 
+    def test_linalg_solve_singular(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/163962
+
+        # Explicit singular matrix
+        A = torch.tensor([[1.0, 2.0], [2.0, 4.0]], device="mps")
+        b = torch.rand_like(A)
+
+        with self.assertRaisesRegex(RuntimeError, "input matrix is singular"):
+            torch.linalg.solve(A, b)
+
     def test_linalg_solve_with_broadcasting(self):
         from functools import partial
         import torch


### PR DESCRIPTION
Fixes #163962 by special casing MPS in the negative status code branch in `_linalg_check_errors`.

Checks if info is [`MPSMatrixDecompositionStatus.singular`](https://developer.apple.com/documentation/metalperformanceshaders/mpsmatrixdecompositionstatus/singular) (which has a raw value of -2). I didn't find an official Apple source with this raw value (besides printing the enum value), so I'm not sure if we can (or should) depend on it? Is there a way to directly get the Objective-C enum value in C++?