### PR TITLE
[distributed] Replace 89 assert statements in pipelining directory

### DIFF
--- a/torch/distributed/pipelining/_backward.py
+++ b/torch/distributed/pipelining/_backward.py
@@ -314,18 +314,23 @@ def stage_backward(
             if isinstance(output_val, torch.Tensor):
                 if not output_val.requires_grad and output_val.grad_fn is None:
                     return
-                assert isinstance(grad_val, (torch.Tensor, type(None))), (
-                    f"Expected Tensor or None gradient but got {type(grad_val)}"
-                )
+                if not isinstance(grad_val, (torch.Tensor, type(None))):
+                    raise AssertionError(
+                        f"Expected Tensor or None gradient but got {type(grad_val)}"
+                    )
                 stage_output_tensors.append(output_val)
                 output_grad_tensors.append(grad_val)
             elif isinstance(output_val, (tuple, list)):
                 if grad_val is None:
                     return
-                assert isinstance(grad_val, (tuple, list)), (
-                    f"grad_value expected to have type {type(output_val)} but got {type(grad_val)}"
-                )
-                assert len(output_val) == len(grad_val)
+                if not isinstance(grad_val, (tuple, list)):
+                    raise AssertionError(
+                        f"grad_value expected to have type {type(output_val)} but got {type(grad_val)}"
+                    )
+                if not len(output_val) == len(grad_val):
+                    raise AssertionError(
+                        f"Expected len(output_val) == len(grad_val), got {len(output_val)} != {len(grad_val)}"
+                    )
                 for ov, gv in zip(output_val, grad_val):
                     extract_tensors_with_grads(
                         ov,
@@ -335,8 +340,12 @@ def stage_backward(
             elif isinstance(output_val, dict):
                 if grad_val is None:
                     return
-                assert isinstance(grad_val, dict)
-                assert set(output_val.keys()) == set(grad_val.keys())
+                if not isinstance(grad_val, dict):
+                    raise AssertionError(f"Expected dict, got {type(grad_val)}")
+                if not set(output_val.keys()) == set(grad_val.keys()):
+                    raise AssertionError(
+                        f"Expected keys {set(output_val.keys())}, got {set(grad_val.keys())}"
+                    )
                 for k in output_val:
                     extract_tensors_with_grads(
                         output_val[k], grad_val[k], extract_tensors_with_grads

--- a/torch/distributed/pipelining/microbatch.py
+++ b/torch/distributed/pipelining/microbatch.py
@@ -131,13 +131,10 @@ def _split_block_mask(
         chunk_block_masks: List of chunked block masks
     """
 
-    # BlockMask will broadcast if B is 1.
-    if block_mask.kv_num_blocks.size(0) == 1:
-        return [block_mask] * num_chunks
-
-    assert block_mask.kv_num_blocks.size(0) >= num_chunks, (
-        "Block mask has fewer batch size than the number of chunks. "
-    )
+    if not block_mask.kv_num_blocks.size(0) >= num_chunks:
+        raise AssertionError(
+            "Block mask has fewer batch size than the number of chunks. "
+        )
 
     batch_dim = 0
     kv_num_blocks_chunks = torch.tensor_split(
@@ -197,9 +194,10 @@ def _split_tensor(
         chunk_tensors: List of chunked tensors
     """
 
-    assert tensor.size(spec.split_dim) >= num_chunks, (
-        f"Tensor size {tensor.size(spec.split_dim)} is smaller than num_chunks"
-    )
+    if not tensor.size(spec.split_dim) >= num_chunks:
+        raise AssertionError(
+            f"Tensor size {tensor.size(spec.split_dim)} is smaller than num_chunks"
+        )
     chunk_tensors = torch.tensor_split(tensor, num_chunks, spec.split_dim)
 
     if not _debug_mask_minibatches:
@@ -243,11 +241,13 @@ def _shard_dict_of_args(
     if not args_dict:
         return [{} for _ in range(num_chunks)]
 
-    assert len(args_dict) == len(args_chunk_spec), (
-        f"args_dict.keys() = {list(args_dict.keys())} "
-        f"args_chunk_spec.keys() = {list(args_chunk_spec.keys())}"
-    )
-    assert args_chunk_spec is not None  # Should have been set by caller
+    if not len(args_dict) == len(args_chunk_spec):
+        raise AssertionError(
+            f"args_dict.keys() = {list(args_dict.keys())} "
+            f"args_chunk_spec.keys() = {list(args_chunk_spec.keys())}"
+        )
+    if args_chunk_spec is None:
+        raise AssertionError("args_chunk_spec should have been set by caller")
 
     values, tree_spec = tree_flatten(
         args_dict, is_leaf=lambda x: isinstance(x, BlockMask)
@@ -264,16 +264,15 @@ def _shard_dict_of_args(
         if spec is _Replicate or isinstance(spec, _Replicate):
             split_sizes.append(num_chunks)
         elif isinstance(v, torch.Tensor):
-            assert isinstance(spec, TensorChunkSpec)
+            if not isinstance(spec, TensorChunkSpec):
+                raise AssertionError(f"Expected TensorChunkSpec, got {type(spec)}")
             split_sizes.append(v.size(spec.split_dim))
         elif isinstance(v, BlockMask):
-            assert isinstance(spec, TensorChunkSpec)
-            assert spec.split_dim == 0, "BlockMask only supports split_dim=0"
-            # BlockMask will broadcast if B is 1.
-            if v.kv_num_blocks.size(0) == 1:
-                split_sizes.append(num_chunks)
-            else:
-                split_sizes.append(v.kv_num_blocks.size(0))
+            if not isinstance(spec, TensorChunkSpec):
+                raise AssertionError(f"Expected TensorChunkSpec, got {type(spec)}")
+            if not spec.split_dim == 0:
+                raise AssertionError("BlockMask only supports split_dim=0")
+            split_sizes.append(v.kv_num_blocks.size(0))
         else:
             raise ValueError(
                 f"Unsupported chunk spec: {spec} and value: {v} combination."
@@ -499,7 +498,10 @@ def merge_chunks(
                 # Infer size of individual chunks by running `tensor_split` again
                 overall_shape = partial_values[0].shape
                 for val in partial_values[1:]:
-                    assert val.shape == overall_shape
+                    if not val.shape == overall_shape:
+                        raise AssertionError(
+                            f"Expected shape {overall_shape}, got {val.shape}"
+                        )
                 meta_chunks = torch.tensor_split(
                     torch.empty(*overall_shape, device="meta"),
                     sections=len(partial_values),
@@ -508,10 +510,11 @@ def merge_chunks(
 
                 values_to_cat = []
                 chunk_start_idx = 0
-                assert len(partial_values) == len(meta_chunks)
-                for partial_value, meta_chunk in zip(
-                    partial_values, meta_chunks, strict=True
-                ):
+                if not len(partial_values) == len(meta_chunks):
+                    raise AssertionError(
+                        f"Expected len(partial_values) == len(meta_chunks), got {len(partial_values)} != {len(meta_chunks)}"
+                    )
+                for partial_value, meta_chunk in zip(partial_values, meta_chunks):
                     chunk_end_idx = chunk_start_idx + meta_chunk.size(arg.split_dim)
 
                     slice_indices = [slice(None, None, None)] * partial_value.ndim
@@ -537,7 +540,10 @@ def merge_chunks(
         else:
             value = chunks_flattened[0][arg_idx]
             for chunk_idx in range(1, len(chunks_flattened)):
-                assert chunks_flattened[chunk_idx][arg_idx] == value
+                if not chunks_flattened[chunk_idx][arg_idx] == value:
+                    raise AssertionError(
+                        f"Expected {value}, got {chunks_flattened[chunk_idx][arg_idx]}"
+                    )
             args_flattened.append(value)
 
     # Stage 4: Unflatten combined args

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -1246,7 +1246,8 @@ def _add_send_recv(
         return False
 
     def _get_comms(action: _Action) -> tuple[_Action, _Action]:
-        assert _has_comms(action), f"{action} is not a valid comm action"
+        if not _has_comms(action):
+            raise AssertionError(f"{action} is not a valid comm action")
         stage_idx = action.stage_index
         ctype = action.computation_type
         mb_idx = action.microbatch_index
@@ -1301,9 +1302,8 @@ def _add_send_recv(
         progress = False
         # go in order of ranks even if dict keys aren't ordered
         for rank in sorted(compute_actions):
-            assert len(compute_actions[rank]) > 0, (
-                f"{rank=}, {len(compute_actions[rank])=}"
-            )
+            if not (len(compute_actions[rank]) > 0):
+                raise AssertionError(f"{rank=}, {len(compute_actions[rank])=}")
             action = compute_actions[rank][0]
             # handle case where parent action (e.g. OVERLAP_F_B) can be comprised of subactions
             if action is not None and action.sub_actions is not None:
@@ -1332,7 +1332,10 @@ def _add_send_recv(
             if len(compute_actions[rank]) == 0:
                 del compute_actions[rank]
             progress = True
-        assert progress, "Malformed compute schedule, can't schedule sends/recvs"
+        if not progress:
+            raise AssertionError(
+                "Malformed compute schedule, can't schedule sends/recvs"
+            )
     return comm_actions
 
 
@@ -1342,11 +1345,13 @@ def _validate_schedule(
     num_stages: int,
     num_microbatches: int,
 ) -> dict[int, int]:
-    assert len(actions) == pp_group_size, (
-        f"Schedule has incorrect number of ranks - expected {pp_group_size}, actual {len(actions)}"
-    )
+    if not (len(actions) == pp_group_size):
+        raise AssertionError(
+            f"Schedule has incorrect number of ranks - expected {pp_group_size}, actual {len(actions)}"
+        )
     for rank in range(pp_group_size):
-        assert rank in actions, f"Schedule is missing actions for rank {rank}"
+        if rank not in actions:
+            raise AssertionError(f"Schedule is missing actions for rank {rank}")
 
     # We will count all the actions per stage and ensure they happen in a valid order
     # (e.g. F before (B, I) before W for a given microbatch)
@@ -1416,17 +1421,19 @@ def _validate_schedule(
             stage_index_to_rank_mapping[s_id] = rank
         else:
             existing_rank = stage_index_to_rank_mapping[s_id]
-            assert rank == existing_rank, (
-                f"Rank {rank}, step {step}: Stage {s_id} is assigned to both rank {rank} and rank {existing_rank}"
-            )
+            if not (rank == existing_rank):
+                raise AssertionError(
+                    f"Rank {rank}, step {step}: Stage {s_id} is assigned to both rank {rank} and rank {existing_rank}"
+                )
 
     for rank in actions:
         for step, action in enumerate(actions[rank]):
             if action is None:
                 continue
-            assert isinstance(action, _Action), (
-                f"Rank {rank}, step {step}: Got an invalid action: {action}, expected instance of _Action"
-            )
+            if not isinstance(action, _Action):
+                raise AssertionError(
+                    f"Rank {rank}, step {step}: Got an invalid action: {action}, expected instance of _Action"
+                )
 
             # Check if action has sub_actions
             if action.sub_actions is not None:
@@ -1443,19 +1450,22 @@ def _validate_schedule(
         i_mb = len(stage_actions[s_id][I])
         w_mb = len(stage_actions[s_id][W])
 
-        assert f_mb == num_microbatches, (
-            f"Got {f_mb} {F} microbatches for stage {s_id}, expected {num_microbatches}"
-        )
+        if not (f_mb == num_microbatches):
+            raise AssertionError(
+                f"Got {f_mb} {F} microbatches for stage {s_id}, expected {num_microbatches}"
+            )
 
-        assert i_mb == w_mb, (
-            f"Invalid backward microbatches for stage {s_id}: I and W must have equal counts, \
+        if not (i_mb == w_mb):
+            raise AssertionError(
+                f"Invalid backward microbatches for stage {s_id}: I and W must have equal counts, \
             but got I={i_mb}, W={w_mb}"
-        )
+            )
 
-        assert b_mb + (i_mb + w_mb) // 2 == num_microbatches, (
-            f"Invalid backward microbatches for stage {s_id}: expected {num_microbatches} total backwards, \
+        if not (b_mb + (i_mb + w_mb) // 2 == num_microbatches):
+            raise AssertionError(
+                f"Invalid backward microbatches for stage {s_id}: expected {num_microbatches} total backwards, \
             but got B={b_mb}, I={i_mb}, W={w_mb}"
-        )
+            )
     return stage_index_to_rank_mapping
 
 
@@ -1580,7 +1590,8 @@ class PipelineScheduleMulti(_PipelineSchedule):
 
         format must be "compute_only" for PipelineScheduleMulti.
         """
-        assert format == "compute_only"
+        if format != "compute_only":
+            raise AssertionError(f'format must be "compute_only", got {format}')
         with open(filename, newline="") as csvfile:
             reader = csv.reader(csvfile)
             for rank, row in enumerate(reader):
@@ -1692,9 +1703,10 @@ class PipelineScheduleMulti(_PipelineSchedule):
                     computation_type = action.computation_type
                     mb_index = action.microbatch_index
                     stage_index = action.stage_index
-                    assert mb_index is not None, (
-                        "All currently supported action types require valid microbatch_index"
-                    )
+                    if not (mb_index is not None):
+                        raise AssertionError(
+                            "All currently supported action types require valid microbatch_index"
+                        )
                     if computation_type == _ComputationType.FORWARD:
                         # perform forward computation
                         stage = stage_index_to_stage[stage_index]
@@ -1768,9 +1780,10 @@ class PipelineScheduleMulti(_PipelineSchedule):
                         computation_type = prev_rank_action.computation_type
                         mb_index = prev_rank_action.microbatch_index
                         stage_index = prev_rank_action.stage_index
-                        assert mb_index is not None, (
-                            "All currently supported action types require valid microbatch_index"
-                        )
+                        if not (mb_index is not None):
+                            raise AssertionError(
+                                "All currently supported action types require valid microbatch_index"
+                            )
                         # Only handle sends for the forward from a previous rank
                         if computation_type == _ComputationType.FORWARD:
                             # If not the last stage, then receive fwd activations
@@ -1799,9 +1812,10 @@ class PipelineScheduleMulti(_PipelineSchedule):
                         computation_type = next_rank_action.computation_type
                         mb_index = next_rank_action.microbatch_index
                         stage_index = next_rank_action.stage_index
-                        assert mb_index is not None, (
-                            "All currently supported action types require valid microbatch_index"
-                        )
+                        if not (mb_index is not None):
+                            raise AssertionError(
+                                "All currently supported action types require valid microbatch_index"
+                            )
                         # Only handle receives for the backwards from a next rank
                         if computation_type in (FORWARD, BACKWARD_WEIGHT):
                             # Next rank doing forward or weight update has no influence for the current rank backward recv
@@ -1940,20 +1954,24 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
             for rank in actions:
                 self.pipeline_order_with_comms[rank] = []
                 for action in actions[rank]:
-                    assert action is not None
+                    if not (action is not None):
+                        raise AssertionError(
+                            f"Expected action to be not None, got {type(action)}"
+                        )
                     self.pipeline_order_with_comms[rank].append(action)
             # TODO what level of validation should we offer for compute+comms schedule?
         elif format == "compute_only":
             # Validate that the schedule does not have comms already added to it
             for rank, action_list in actions.items():
                 for i, action in enumerate(action_list):
-                    if action is not None and not action.is_compute_op:
-                        raise ValueError(
-                            f"Expected compute-only schedule but found communication action "
-                            f"'{action}' at rank {rank}, position {i}. "
-                            f"Communication actions (e.g. SEND_F, RECV_F, etc.) "
-                            f"should not be present when format='compute_only'."
-                        )
+                    if action is not None:
+                        if not action.is_compute_op:
+                            raise ValueError(
+                                f"Expected compute-only schedule but found communication action "
+                                f"'{action}' at rank {rank}, position {i}. "
+                                f"Communication actions (e.g. SEND_F, RECV_F, etc.) "
+                                f"should not be present when format='compute_only'."
+                            )
 
             # Perform schedule lowering
             for rank in actions:
@@ -1997,17 +2015,17 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
     def _dump_csv(self, filename: str, format: str = "compute_comms"):
         """Dump a CSV representation of the schedule into a file with the provided filename."""
         if format == "compute_only":
-            assert self.pipeline_order is not None, (
-                "Compute only schedule must be available"
-            )
+            if not (self.pipeline_order is not None):
+                raise AssertionError("Compute only schedule must be available")
             with open(filename, "w", newline="") as csvfile:
                 writer = csv.writer(csvfile)
                 for rank in self.pipeline_order:
                     writer.writerow(self.pipeline_order[rank])
         elif format == "compute_comms":
-            assert self.pipeline_order_with_comms is not None, (
-                "Must initialize compute_comms schedule before dump_csv"
-            )
+            if not (self.pipeline_order_with_comms is not None):
+                raise AssertionError(
+                    "Must initialize compute_comms schedule before dump_csv"
+                )
             with open(filename, "w", newline="") as csvfile:
                 writer = csv.writer(csvfile)
                 for rank in self.pipeline_order_with_comms:
@@ -2057,9 +2075,10 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
             stage.stage_index: stage for stage in self._stages
         }
 
-        assert self.pipeline_order_with_comms is not None, (
-            "Must call _prepare_schedule_with_comms() before calling _step_microbatches()"
-        )
+        if not (self.pipeline_order_with_comms is not None):
+            raise AssertionError(
+                "Must call _prepare_schedule_with_comms() before calling _step_microbatches()"
+            )
 
         # send ops should be waited on before step() exists, mainly for hygiene
         send_ops: list[list[dist.Work]] = []
@@ -2069,11 +2088,16 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
             mb_index: int = (
                 action.microbatch_index if action.microbatch_index is not None else -1
             )
-            assert mb_index >= 0 or comp_type in (
-                UNSHARD,
-                RESHARD,
-                REDUCE_GRAD,
-            ), f"{action=} missing mb_index"
+            if not (
+                mb_index >= 0
+                or comp_type
+                in (
+                    UNSHARD,
+                    RESHARD,
+                    REDUCE_GRAD,
+                )
+            ):
+                raise AssertionError(f"{action=} missing mb_index")
             stage_idx = action.stage_index
             stage = stage_index_to_stage[stage_idx]
             stage_uses_fsdp = isinstance(stage.submod, FSDPModule)
@@ -2091,31 +2115,28 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
             elif comp_type == SEND_B:
                 send_ops.append(_batch_p2p(stage.get_bwd_send_ops(mb_index)))
             elif comp_type == RECV_F:
-                assert (
-                    stage_idx,
-                    mb_index,
-                ) not in self.fwd_recv_ops, (
-                    f"Recv twice for {stage_idx=} {mb_index=} without executing forward"
-                )
+                if (stage_idx, mb_index) in self.fwd_recv_ops:
+                    raise AssertionError(
+                        f"Recv twice for {stage_idx=} {mb_index=} without executing forward"
+                    )
                 self.fwd_recv_ops[(stage_idx, mb_index)] = _batch_p2p(
                     stage.get_fwd_recv_ops(mb_index)
                 )
             elif comp_type == RECV_B:
-                assert (
-                    stage_idx,
-                    mb_index,
-                ) not in self.bwd_recv_ops, (
-                    f"Recv twice for {stage_idx=} {mb_index=} without executing backward"
-                )
+                if (stage_idx, mb_index) in self.bwd_recv_ops:
+                    raise AssertionError(
+                        f"Recv twice for {stage_idx=} {mb_index=} without executing backward"
+                    )
                 self.bwd_recv_ops[(stage_idx, mb_index)] = _batch_p2p(
                     stage.get_bwd_recv_ops(mb_index)
                 )
             elif comp_type == UNSHARD:
                 if stage_uses_fsdp:
-                    assert (
+                    if not (
                         stage_idx not in self.unsharded_stages
                         and stage_idx not in self.unshard_ops
-                    ), f"Unsharding the same {stage_idx=} twice"
+                    ):
+                        raise AssertionError(f"Unsharding the same {stage_idx=} twice")
                     for submodule in stage.submod.modules():
                         if not isinstance(submodule, FSDPModule):
                             continue
@@ -2123,12 +2144,14 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
                         self.unshard_ops[stage_idx].append(handle)
             elif comp_type == RESHARD:
                 if stage_uses_fsdp:
-                    assert stage_idx in self.unsharded_stages, (
-                        f"Resharding {stage_idx=} without unsharding"
-                    )
-                    assert stage_idx not in self.unshard_ops, (
-                        f"Resharding {stage_idx=} before finishing unshard"
-                    )
+                    if stage_idx not in self.unsharded_stages:
+                        raise AssertionError(
+                            f"Resharding {stage_idx=} without unsharding"
+                        )
+                    if not (stage_idx not in self.unshard_ops):
+                        raise AssertionError(
+                            f"Resharding {stage_idx=} before finishing unshard"
+                        )
                     for submodule in stage.submod.modules():
                         if not isinstance(submodule, FSDPModule):
                             continue
@@ -2142,12 +2165,10 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
                     # no recv op expected for V-schedule special case (see [Note: V-schedule special case])
                     and not is_prev_stage_on_this_rank
                 ):
-                    assert (
-                        stage_idx,
-                        mb_index,
-                    ) in self.fwd_recv_ops, (
-                        f"Computing {action=} before receiving input"
-                    )
+                    if (stage_idx, mb_index) not in self.fwd_recv_ops:
+                        raise AssertionError(
+                            f"Computing {action=} before receiving input"
+                        )
                     _wait_batch_p2p(self.fwd_recv_ops.pop((stage_idx, mb_index)))
 
                 output = stage.forward_one_chunk(
@@ -2173,12 +2194,10 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
                     # no recv op expected for V-schedule special case (see [Note: V-schedule special case])
                     and not is_next_stage_on_this_rank
                 ):
-                    assert (
-                        stage_idx,
-                        mb_index,
-                    ) in self.bwd_recv_ops, (
-                        f"Attempted to run compute {action=} before receiving input"
-                    )
+                    if (stage_idx, mb_index) not in self.bwd_recv_ops:
+                        raise AssertionError(
+                            f"Attempted to run compute {action=} before receiving input"
+                        )
                     _wait_batch_p2p(self.bwd_recv_ops.pop((stage_idx, mb_index)))
                 loss = self._maybe_get_loss(stage, mb_index)
                 self.backward_counter[stage_idx] += 1
@@ -2199,12 +2218,10 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
                 self._assert_unsharded(stage)
 
                 if not stage.is_last and not is_next_stage_on_this_rank:
-                    assert (
-                        stage_idx,
-                        mb_index,
-                    ) in self.bwd_recv_ops, (
-                        f"Attempted to run compute {action=} before receiving input"
-                    )
+                    if (stage_idx, mb_index) not in self.bwd_recv_ops:
+                        raise AssertionError(
+                            f"Attempted to run compute {action=} before receiving input"
+                        )
                     _wait_batch_p2p(self.bwd_recv_ops.pop((stage_idx, mb_index)))
                 loss = self._maybe_get_loss(stage, mb_index)
                 stage.backward_one_chunk(
@@ -2255,7 +2272,8 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
                             action, ctx
                         )
                     elif action.computation_type == OVERLAP_F_B:
-                        assert action.sub_actions is not None, "sub_actions must be set"
+                        if not (action.sub_actions is not None):
+                            raise AssertionError("sub_actions must be set")
                         for sub_a in action.sub_actions:
                             _perform_action(sub_a)
                     else:
@@ -2278,7 +2296,8 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
         while send_ops:
             _wait_batch_p2p(send_ops.pop())
 
-        assert len(self.unshard_ops) == 0, "Unused unshard operations"
+        if len(self.unshard_ops) != 0:
+            raise AssertionError("Unused unshard operations")
 
         # Return losses if there is a container passed in
         self._update_losses(self._stages, losses)
@@ -2776,7 +2795,10 @@ class ScheduleInterleavedZeroBubble(_PipelineScheduleRuntime):
 
                 if actions[rank][timestamp] is not None:
                     temp_action = actions[rank][timestamp]
-                    assert temp_action is not None
+                    if not (temp_action is not None):
+                        raise AssertionError(
+                            f"Expected temp_action to be not None, got {type(temp_action)}"
+                        )
                     stage_index, op, microbatch, _ = temp_action
                     if not need_bubble(
                         stage_index, op, microbatch, num_stages_global, seen_ops
@@ -2974,8 +2996,14 @@ class ScheduleZBVZeroBubble(_PipelineScheduleRuntime):
             )
             w0_cnt += 1
 
-        assert w0_cnt == b0_cnt and b0_cnt == f0_cnt
-        assert w1_cnt == b1_cnt and b1_cnt == f1_cnt
+        if not (w0_cnt == b0_cnt and b0_cnt == f0_cnt):
+            raise AssertionError(
+                f"Expected w0_cnt == b0_cnt == f0_cnt, got w0_cnt={w0_cnt}, b0_cnt={b0_cnt}, f0_cnt={f0_cnt}"
+            )
+        if not (w1_cnt == b1_cnt and b1_cnt == f1_cnt):
+            raise AssertionError(
+                f"Expected w1_cnt == b1_cnt == f1_cnt, got w1_cnt={w1_cnt}, b1_cnt={b1_cnt}, f1_cnt={f1_cnt}"
+            )
         # We use max() in the n_micro computation above, so we may need to
         # remove redundant microbatches
         rank_ops = [

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -2048,9 +2048,8 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
                     op.wait()
                 del self.unshard_ops[stage_idx]
                 self.unsharded_stages.add(stage_idx)
-            assert stage_idx in self.unsharded_stages, (
-                f"Attempted to compute on sharded {stage_idx=}"
-            )
+            if stage_idx not in self.unsharded_stages:
+                raise AssertionError(f"Attempted to compute on sharded {stage_idx=}")
 
     def _step_microbatches(
         self,

--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -246,16 +246,18 @@ class _PipelineStageBase(ABC):
         configuration, so it's important to also freeze/validate the output side to avoid any send/recv mismatches
         which could show up as hangs, silent corruption, or other errors.
         """
-        assert self._outputs_meta is None, (
-            "Attempting to reconfigure output_meta, which is not supported"
-        )
+        if self._outputs_meta is not None:
+            raise AssertionError(
+                "Attempting to reconfigure output_meta, which is not supported"
+            )
         self._outputs_meta = tuple(outputs_meta)  # type: ignore[assignment]
 
     def get_outputs_meta(self) -> tuple[torch.Tensor, ...]:
-        """Get the output metadata (meta tensors) representing the outputs of this stage"""
-        assert self._outputs_meta is not None, (
-            "Attempted to get_outputs_meta() without configuring output meta"
-        )
+        """Get the output metadata (meta tensors) reprensenting the outputs of this stage"""
+        if self._outputs_meta is None:
+            raise AssertionError(
+                "Attempted to get_outputs_meta() without configuring output meta"
+            )
         return self._outputs_meta
 
     def _create_grad_send_info(
@@ -361,12 +363,14 @@ class _PipelineStageBase(ABC):
         prev_stage_outputs = _normalize_model_output_as_tuple(prev_stage_outputs)
 
         for info, tensor in zip(recv_infos, prev_stage_outputs):
-            assert isinstance(tensor, torch.Tensor), (
-                f"expected tensor values as outputs from prev stage, got {type(tensor)}"
-            )
-            assert isinstance(info, _RecvInfo), (
-                "set_local_Fwd_input should only be called on non-first stage, which should always have RecvInfo"
-            )
+            if not isinstance(tensor, torch.Tensor):
+                raise AssertionError(
+                    f"expected tensor values as outputs from prev stage, got {type(tensor)}"
+                )
+            if not isinstance(info, _RecvInfo):
+                raise AssertionError(
+                    "set_local_Fwd_input should only be called on non-first stage, which should always have RecvInfo"
+                )
 
             # We don't need to do a data copy here, since we can directly pass the activation tensor reference from
             # one stage to the next.  However, we do need to mark the activation as a leaf tensor since it will serve
@@ -379,10 +383,12 @@ class _PipelineStageBase(ABC):
         """
         Returns the input grad tensors for this stage, which correspond to the stage inputs during forward.
         """
-        assert self.has_backward, (
-            "can't steal_bwd_input if this stage doesn't have backward"
-        )
-        assert not self.is_first, "can't get bwd output if this stage is first"
+        if not self.has_backward:
+            raise AssertionError(
+                "can't steal_bwd_input if this stage doesn't have backward"
+            )
+        if self.is_first:
+            raise AssertionError("can't get bwd output if this stage is first")
 
         self._check_chunk_id(mb_index)
         return self.bwd_cache.pop(mb_index)
@@ -394,22 +400,23 @@ class _PipelineStageBase(ABC):
         Moves 'grad input' tensors from the next stage to 'grad_output' on this stage, avoiding a copy or send/recv.
         Does not detach or set '_requires_grad'.
         """
-        assert isinstance(next_stage_bwd_outputs, tuple), (
-            f"Expected tuple, got {type(next_stage_bwd_outputs)}"
-        )
+        if not isinstance(next_stage_bwd_outputs, tuple):
+            raise AssertionError(f"Expected tuple, got {type(next_stage_bwd_outputs)}")
 
-        assert self.has_backward, (
-            "can't set bwd input if this stage doesn't have backward"
-        )
-        assert not self.is_last, "can't set bwd input if this stage is last"
+        if not self.has_backward:
+            raise AssertionError(
+                "can't set bwd input if this stage doesn't have backward"
+            )
+        if self.is_last:
+            raise AssertionError("can't set bwd input if this stage is last")
         recv_infos = self.grad_recv_info[mb_index]
         for info, tensor in zip(recv_infos, next_stage_bwd_outputs):
-            assert isinstance(tensor, torch.Tensor), (
-                f"expected tensor values as outputs from prev stage, got {type(tensor)}"
-            )
-            assert isinstance(info, _RecvInfo), (
-                f"Expected a recv info, got {type(info)}"
-            )
+            if not isinstance(tensor, torch.Tensor):
+                raise AssertionError(
+                    f"expected tensor values as outputs from prev stage, got {type(tensor)}"
+                )
+            if not isinstance(info, _RecvInfo):
+                raise AssertionError(f"Expected a recv info, got {type(info)}")
             info.buffer = tensor
 
     def get_fwd_recv_ops(self, fwd_chunk_id: int) -> list[dist.P2POp]:
@@ -842,10 +849,11 @@ class _PipelineStageBase(ABC):
         if not self.has_backward:
             return
 
-        assert bwd_chunk_id in self.dw_runner, (
-            f"{self.log_prefix} Attempted to run backward_weight_one_chunk for chunk {bwd_chunk_id}"
-            " without first calling `backward_one_chunk(full_backward=False)`"
-        )
+        if bwd_chunk_id not in self.dw_runner:
+            raise AssertionError(
+                f"{self.log_prefix} Attempted to run backward_weight_one_chunk for chunk {bwd_chunk_id}"
+                " without first calling `backward_one_chunk(full_backward=False)`"
+            )
 
         if self.dw_builder is not None:
             self.dw_runner.pop(bwd_chunk_id)()
@@ -1135,9 +1143,8 @@ class _PipelineStage(_PipelineStageBase):
                 # If the input is a getitem, we need to go deeper
                 arg_node = arg_node.args[0]
 
-            assert arg_node.op == "call_module", (
-                f"Expecting call_module, got {arg_node.op}"
-            )
+            if arg_node.op != "call_module":
+                raise AssertionError(f"Expecting call_module, got {arg_node.op}")
             src_stage = self.get_stage_index_of_submod(arg_node.name)
 
             # Create a receive buffer for this placeholder
@@ -1242,7 +1249,8 @@ class _PipelineStage(_PipelineStageBase):
 
     def _get_output_node(self):
         output_nodes = [node for node in self.submod.graph.nodes if node.op == "output"]  # type: ignore[union-attr]
-        assert len(output_nodes) == 1
+        if len(output_nodes) != 1:
+            raise AssertionError(f"Expected 1 output node, got {len(output_nodes)}")
         output_node = output_nodes[0]
         return output_node
 
@@ -1273,7 +1281,8 @@ class _PipelineStage(_PipelineStageBase):
             )
 
             # TODO: otherwise needs grad accumulation
-            assert len(dst_list) == 1, "Backward of skip connections not supported yet"
+            if len(dst_list) != 1:
+                raise AssertionError("Backward of skip connections not supported yet")
             grad_src = dst_list[0]
             grad_recv_info[out_idx] = _RecvInfo(
                 f"{grad_src}",  # noqa: G004
@@ -1358,10 +1367,11 @@ class PipelineStage(_PipelineStageBase):
         # Note: inputs and submod should ideally be on meta device. We decided not to assert this (yet) because it
         # might be breaking for existing users.
         if input_args is None:
-            assert output_args is None, (
-                "If specifying output_args, input_args must also be specified. "
-                "Otherwise, shape inference will be performed at runtime"
-            )
+            if output_args is not None:
+                raise AssertionError(
+                    "If specifying output_args, input_args must also be specified. "
+                    "Otherwise, shape inference will be performed at runtime"
+                )
         else:
             self.inputs_meta = (
                 (input_args,) if isinstance(input_args, torch.Tensor) else input_args
@@ -1383,9 +1393,10 @@ class PipelineStage(_PipelineStageBase):
                     raise RuntimeError(
                         "Failed to perform pipeline shape inference- are your inputs on the same device as your module?"
                     ) from e
-            assert output_args is not None, (
-                "If passing input_args, also pass output_args to override shape inference"
-            )
+            if output_args is None:
+                raise AssertionError(
+                    "If passing input_args, also pass output_args to override shape inference"
+                )
             self._configure_outputs_meta(
                 (output_args,) if isinstance(output_args, torch.Tensor) else output_args
             )
@@ -1414,7 +1425,8 @@ class PipelineStage(_PipelineStageBase):
     ):
         if kwargs is None:
             kwargs = {}
-        assert args is not None, "Args may be an empty tuple but not None"
+        if args is None:
+            raise AssertionError("Args may be an empty tuple but not None")
 
         # We skip recv communication if we're the first stage, but also if the previous stage is on the same rank
         # and can pass its output shapes in as args instead of using send/recv.
@@ -1429,9 +1441,10 @@ class PipelineStage(_PipelineStageBase):
             )
             args = tree_map_only(torch.Tensor, lambda x: x.to("meta"), args)
         else:
-            assert len(args) == 0, (
-                "Can't supply input args for shape inference on non-first stage"
-            )
+            if len(args) != 0:
+                raise AssertionError(
+                    "Can't supply input args for shape inference on non-first stage"
+                )
             objects = [None]
             logger.debug(
                 "Shape inference: stage %s receiving from stage %s",
@@ -1449,7 +1462,8 @@ class PipelineStage(_PipelineStageBase):
                 use_batch=True,
             )
             recv_args = objects[0]
-            assert isinstance(recv_args, tuple), type(recv_args)
+            if not isinstance(recv_args, tuple):
+                raise AssertionError(f"Expected tuple, got {type(recv_args)}")
             args = recv_args
 
         # cache input shapes for use during recv buffer allocation
@@ -1525,13 +1539,15 @@ class PipelineStage(_PipelineStageBase):
         kwargs: dict[str, Any] | None = None,
     ) -> tuple[Any, ...]:
         # TODO move self.device to an argument from step API (from its input tensors)?
-        assert num_microbatches is not None, "TODO fix num_microbatches"
+        if num_microbatches is None:
+            raise AssertionError("TODO fix num_microbatches")
 
         outputs: tuple[Any, ...] = tuple()
         if self.inputs_meta is None:
             outputs = self._shape_inference(args, kwargs)
 
-        assert self.inputs_meta is not None
+        if self.inputs_meta is None:
+            raise AssertionError("Expected inputs_meta to be set after shape inference")
         # Receive info during forward
         # TODO: create args_recv_info lazily? (same needed for PipelineStage)
         for chunk_id in range(num_microbatches):


### PR DESCRIPTION
Replace assert statements with explicit if/raise patterns across 6 files:
- schedules.py (33 asserts)
- stage.py (22 asserts)
- _IR.py (11 asserts)
- microbatch.py (10 asserts)
- _schedule_visualizer.py (8 asserts)
- _backward.py (5 asserts)

This prevents assertions from being disabled with Python -O flag.

Fixes partially #164878 

cc: @albanD 


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci