### PR TITLE
Add extra debug info for the super common "index out of bounds" error.

### DIFF
--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -117,7 +117,8 @@ void gpu_index_kernel(TensorIteratorBase& iter, const IntArrayRef index_size, co
     #pragma unroll
     for (int i = 0; i < num_indices; i++) {
       int64_t index = *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
-      CUDA_KERNEL_ASSERT(-sizes[i] <= index && index < sizes[i] && "index out of bounds");
+      CUDA_KERNEL_ASSERT_PRINTF(-sizes[i] <= index && index < sizes[i] && "index out of bounds",
+        "index=%lld sizes[i]=%lld i=%d ", (long long)index, (long long)sizes[i], i);
       if (index < 0) {
         index += sizes[i];
       }


### PR DESCRIPTION
Print values of `index`, `sizes[i]` and `i` in the  "index out of bounds" error.

Motivation:
"Index out of bounds" is one of the most common device-side assertion. Current error message:

```/pytorch/aten/src/ATen/native/cuda/IndexKernel.cu:113: operator(): block: [4984,0,0], thread: [31,0,0] Assertion `-sizes[i] <= index && index < sizes[i] && "index out of bounds"` failed.```

Together with lack of accurate code line makes debugging super hard. One solution is to rerun with CUDA_LAUNCH_BLOCKING=1 and hope for the error to appear soon, which is not always the case.

If the error message included the actual values of `index`, `sizes[i]` and `i`, it would often be possible to understand the cause of the index error. Eg, for embedding `sizes[i]` would be equal to the vocab size, giving a huge hint.

I don't understand why we currently don't provide this info - seems like we can do it for free here, using existing macro, but maybe I am missing something. 