### PR TITLE
feat: add out_dtype parameter support to torch.einsum

### DIFF
--- a/aten/src/ATen/native/Linear.cpp
+++ b/aten/src/ATen/native/Linear.cpp
@@ -632,16 +632,13 @@ Tensor einsum(std::string_view equation, TensorList operands, at::OptionalIntArr
       for (auto dim = perm_index - 1; dim >= out_num_dim; --dim) {
         sizes.erase(sizes.begin() + dim);
       }
-      return out_dtype.has_value() ? ops[0].view_symint(sizes).to(out_dtype.value()) : ops[0].view_symint(sizes);
-    } else {
+return ops[0].view_symint(sizes);    } else {
       std::vector<int64_t> sum_dims(perm_index - out_num_dim);
       std::iota(sum_dims.begin(), sum_dims.end(), out_num_dim);
-      return out_dtype.has_value() ? ops[0].sum(sum_dims).to(out_dtype.value()) : ops[0].sum(sum_dims);
-    }
+return ops[0].sum(sum_dims);    }
   }
 
-  return out_dtype.has_value() ? ops[0].to(out_dtype.value()) : ops[0];
-}
+return ops[0];}
 
 // _trilinear computes a trilinear einstein sum with an unrolled dimension
 // the result is `(i1.unsqueeze(expand1)*i2.unsqueeze(expand2)*i2.unsqueeze(expand3)).sum(sumdim)`

--- a/aten/src/ATen/native/Linear.cpp
+++ b/aten/src/ATen/native/Linear.cpp
@@ -259,7 +259,7 @@ static Tensor sumproduct_pair(const Tensor& left_, const Tensor& right_, IntArra
 // If a path is specified, we reduce in the order specified by the path, else we
 // default to going left => right. The path is a list of indices processed the same
 // way as opt-einsum: https://optimized-einsum.readthedocs.io/en/stable/path_finding.html#format-of-the-path
-Tensor einsum(std::string_view equation, TensorList operands, at::OptionalIntArrayRef path, c10::optional<ScalarType> out_dtype=c10::nullopt) {
+Tensor einsum(std::string_view equation, TensorList operands, at::OptionalIntArrayRef path) {
   TORCH_CHECK(!operands.empty(), "einsum(): must provide at least one operand");
   const auto num_ops = operands.size();
 
@@ -632,13 +632,16 @@ Tensor einsum(std::string_view equation, TensorList operands, at::OptionalIntArr
       for (auto dim = perm_index - 1; dim >= out_num_dim; --dim) {
         sizes.erase(sizes.begin() + dim);
       }
-return ops[0].view_symint(sizes);    } else {
+      return ops[0].view_symint(sizes);
+    } else {
       std::vector<int64_t> sum_dims(perm_index - out_num_dim);
       std::iota(sum_dims.begin(), sum_dims.end(), out_num_dim);
-return ops[0].sum(sum_dims);    }
+      return ops[0].sum(sum_dims);
+    }
   }
 
-return ops[0];}
+  return ops[0];
+}
 
 // _trilinear computes a trilinear einstein sum with an unrolled dimension
 // the result is `(i1.unsqueeze(expand1)*i2.unsqueeze(expand2)*i2.unsqueeze(expand3)).sum(sumdim)`

--- a/aten/src/ATen/native/Linear.cpp
+++ b/aten/src/ATen/native/Linear.cpp
@@ -259,7 +259,7 @@ static Tensor sumproduct_pair(const Tensor& left_, const Tensor& right_, IntArra
 // If a path is specified, we reduce in the order specified by the path, else we
 // default to going left => right. The path is a list of indices processed the same
 // way as opt-einsum: https://optimized-einsum.readthedocs.io/en/stable/path_finding.html#format-of-the-path
-Tensor einsum(std::string_view equation, TensorList operands, at::OptionalIntArrayRef path) {
+Tensor einsum(std::string_view equation, TensorList operands, at::OptionalIntArrayRef path, c10::optional<ScalarType> out_dtype=c10::nullopt) {
   TORCH_CHECK(!operands.empty(), "einsum(): must provide at least one operand");
   const auto num_ops = operands.size();
 
@@ -632,15 +632,15 @@ Tensor einsum(std::string_view equation, TensorList operands, at::OptionalIntArr
       for (auto dim = perm_index - 1; dim >= out_num_dim; --dim) {
         sizes.erase(sizes.begin() + dim);
       }
-      return ops[0].view_symint(sizes);
+      return out_dtype.has_value() ? ops[0].view_symint(sizes).to(out_dtype.value()) : ops[0].view_symint(sizes);
     } else {
       std::vector<int64_t> sum_dims(perm_index - out_num_dim);
       std::iota(sum_dims.begin(), sum_dims.end(), out_num_dim);
-      return ops[0].sum(sum_dims);
+      return out_dtype.has_value() ? ops[0].sum(sum_dims).to(out_dtype.value()) : ops[0].sum(sum_dims);
     }
   }
 
-  return ops[0];
+  return out_dtype.has_value() ? ops[0].to(out_dtype.value()) : ops[0];
 }
 
 // _trilinear computes a trilinear einstein sum with an unrolled dimension

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2308,7 +2308,7 @@
   dispatch:
     CompositeExplicitAutograd: vdot_out
 
-- func: einsum(str equation, Tensor[] tensors, *, int[]? path=None) -> Tensor
+- func: einsum(str equation, Tensor[] tensors, *, int[]? path=None, ScalarType? out_dtype=None) -> Tensor
 
 - func: embedding(Tensor weight, Tensor indices, SymInt padding_idx=-1, bool scale_grad_by_freq=False, bool sparse=False) -> Tensor
   dispatch:

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -173,7 +173,7 @@ def split(
     return tensor.split(split_size_or_sections, dim)
 
 
-def einsum(*args: Any) -> Tensor:
+def einsum(equation: str, *operands: Tensor, out_dtype: Optional[torch.dtype] = None) -> Tensor:
     r"""einsum(equation, *operands) -> Tensor
 
     Sums the product of the elements of the input :attr:`operands` along dimensions specified using a notation
@@ -380,7 +380,7 @@ def einsum(*args: Any) -> Tensor:
         )[0]
         # flatten path for dispatching to C++
         path = [*itertools.chain.from_iterable(tupled_path)]
-    return _VF.einsum(equation, operands, path=path)  # type: ignore[attr-defined]
+    return _VF.einsum(equation, operands, path=path, out_dtype=out_dtype)  # type: ignore[attr-defined]
 
 
 # This wrapper exists to support variadic args.


### PR DESCRIPTION
## 🚀 Feature
Adds `out_dtype` parameter to `torch.einsum` for consistent precision control, aligning with other linear algebra functions like `torch.mm` and `torch.matmul`.

## Changes
- Modified C++ implementation in `Linear.cpp`
- Updated Python bindings in `functional.py` 
- Added parameter declaration in `native_functions.yaml`

## Usage
```python
result = torch.einsum("ij,jk->ik", A, B, out_dtype=torch.float32)
