### PR TITLE
[Bugfix][dynamo] Implement __sym_float__ for SymBool to fix multiplication TypeError

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -71,6 +71,7 @@ from torch.fx.experimental.symbolic_shapes import (
     expect_true,
     guard_size_oblivious,
     ShapeEnv,
+    guard_or_false
 )
 from torch.nn import functional as F
 from torch.testing import make_tensor
@@ -101,6 +102,7 @@ from torch.testing._internal.common_utils import (
 )
 from torch.testing._internal.jit_utils import JitTestCase
 from torch.testing._internal.logging_utils import logs_to_string
+
 
 
 pytree_modules = {
@@ -13634,6 +13636,70 @@ devices = ("cuda", "hpu", "xpu")
 instantiate_device_type_tests(
     MiscTestsDevice, globals(), only_for=devices, allow_xpu=True
 )
+
+
+class DynamoOpPromotionTests(torch._dynamo.test_case.TestCase):
+    @unittest.skipIf(not TEST_CUDA, "This test requires a CUDA device")
+    def test_symbool_tensor_mul(self):
+        def symbool_mul_fn(x_bool, sentinel):
+            result = x_bool * sentinel
+            return result
+        x_true = torch.tensor([True], device="cuda")
+        x_false = torch.tensor([False], device="cuda")
+        sentinel = torch.tensor(2.0, requires_grad=True, device="cuda")
+        eager_result_true = symbool_mul_fn(x_true, sentinel)
+        eager_result_false = symbool_mul_fn(x_false, sentinel)
+        compiled_fn = torch.compile(symbool_mul_fn, fullgraph=True, dynamic=True)
+        compiled_result_true = compiled_fn(x_true, sentinel)
+        compiled_result_false = compiled_fn(x_false, sentinel)
+        self.assertEqual(eager_result_true, compiled_result_true)
+        self.assertEqual(eager_result_false, compiled_result_false)
+        self.assertEqual(compiled_result_true.item(), 2.0)
+        self.assertEqual(compiled_result_false.item(), 0.0)
+
+
+    @unittest.skipIf(not TEST_CUDA, "This test requires a CUDA device")
+    def test_symbool_guard_or_false(self):
+        def symbool_guard_fn(a_bool_tensor, b):
+            u0 = a_bool_tensor.item()
+            # Make sure guard_or_false still handles SymBool produced by .item()
+            if guard_or_false(u0):
+                return b * 10
+            else:
+                return b * 100
+        compiled_guard_fn = torch.compile(symbool_guard_fn, backend="eager", dynamic=True)
+        a_true = torch.tensor(True, device="cuda")
+        a_false = torch.tensor(False, device="cuda")
+        b = torch.randn(6, device="cuda")
+        eager_res_true = symbool_guard_fn(a_true, b)
+        compiled_res_true = compiled_guard_fn(a_true, b)
+        self.assertEqual(eager_res_true, compiled_res_true)
+        eager_res_false = symbool_guard_fn(a_false, b)
+        compiled_res_false = compiled_guard_fn(a_false, b)
+        self.assertEqual(eager_res_false, compiled_res_false)
+        self.assertEqual(compiled_res_true, b * 10)
+        self.assertEqual(compiled_res_false, b * 100)
+
+
+    @unittest.skipIf(not TEST_CUDA, "This test requires a CUDA device")
+    def test_symbool_tensor_mul_does_not_fail(self):
+        def fuzzed_program(arg_0, sentinel):
+            var_node_2 = arg_0
+            var_node_1 = torch.squeeze(var_node_2)
+            var_node_0 = var_node_1.item()
+            result = var_node_0 * sentinel
+            if result.is_complex():
+                 result = result.real
+            return result
+        sentinel = torch.tensor(1.0, requires_grad=True, device="cuda")
+        arg_0 = torch.tensor([True], dtype=torch.bool, device="cuda")
+        args = (arg_0,) + (sentinel,)
+        try:
+            compiled_program = torch.compile(fuzzed_program, fullgraph=True, dynamic=True)
+            compiled_program(*args)
+        except Exception as e:
+            self.fail(f"torch.compile failed with error: {e}")
+
 
 
 if __name__ == "__main__":

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -810,6 +810,14 @@ class SymBool:
         else:
             # Force specialization
             return hash(builtins.bool(self))
+        
+    def __sym_float__(self):
+        """
+        Provides a SymFloat representation (0.0 or 1.0) for this SymBool.
+        Called by torch.sym_float() when casting SymBool to float.
+        """
+        float_node = self.node.sym_float()
+        return torch.fx.experimental.sym_node.wrap_node(float_node)
 
 
 def sym_not(a):

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -817,6 +817,7 @@ class SymBool:
         Called by torch.sym_float() when casting SymBool to float.
         """
         from torch.fx.experimental.sym_node import wrap_node
+
         return wrap_node(self.node.sym_float())
 
 

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -810,14 +810,14 @@ class SymBool:
         else:
             # Force specialization
             return hash(builtins.bool(self))
-        
+
     def __sym_float__(self):
         """
         Provides a SymFloat representation (0.0 or 1.0) for this SymBool.
         Called by torch.sym_float() when casting SymBool to float.
         """
-        float_node = self.node.sym_float()
-        return torch.fx.experimental.sym_node.wrap_node(float_node)
+        from torch.fx.experimental.sym_node import wrap_node
+        return wrap_node(self.node.sym_float())
 
 
 def sym_not(a):

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1182,7 +1182,6 @@ class BuiltinVariable(VariableTracker):
 
         if kwargs and not self.tensor_args(*args, *kwargs.values()):
             return
-        
         # insert handling for torch function here
         from .builder import SourcelessBuilder
         from .torch_function import can_dispatch_torch_function, dispatch_torch_function

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1182,6 +1182,7 @@ class BuiltinVariable(VariableTracker):
 
         if kwargs and not self.tensor_args(*args, *kwargs.values()):
             return
+        
         # insert handling for torch function here
         from .builder import SourcelessBuilder
         from .torch_function import can_dispatch_torch_function, dispatch_torch_function

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1182,7 +1182,7 @@ class BuiltinVariable(VariableTracker):
 
         if kwargs and not self.tensor_args(*args, *kwargs.values()):
             return
-
+        
         # insert handling for torch function here
         from .builder import SourcelessBuilder
         from .torch_function import can_dispatch_torch_function, dispatch_torch_function

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1182,7 +1182,7 @@ class BuiltinVariable(VariableTracker):
 
         if kwargs and not self.tensor_args(*args, *kwargs.values()):
             return
-        
+
         # insert handling for torch function here
         from .builder import SourcelessBuilder
         from .torch_function import can_dispatch_torch_function, dispatch_torch_function


### PR DESCRIPTION
Fixes #164684

### Description

Symbolic tracing fails during multiplication between a `SymBool` and a `Tensor`. This scenario is triggered when `.item()` is called on a 0-dim boolean tensor within a `torch.compile` region. In compile mode, this yields a `SymBool`, and the subsequent `SymBool * FakeTensor` operation is unsupported, leading to a `TypeError` or a data-dependent `UserError`.

### Solution

This PR addresses the issue at the type-conversion level, as suggested by reviewers.

The root cause of the TypeError is that torch.sym_float() (which is called by _maybe_convert_to_dtype during type promotion for aten.mul) lacks a conversion path for SymBool and incorrectly falls back to builtins.float(SymBool).

This fix addresses this by implementing the __sym_float__(self) method within the SymBool class (defined in torch/__init__.py).

The torch.sym_float(a) utility function is already designed to check for hasattr(a, "__sym_float__") before falling back to builtins.float(). By adding this method, SymBool instances now correctly advertise their ability to be cast to SymFloat. The new method implementation leverages self.node.sym_float() to correctly convert the symbolic boolean value to its symbolic float representation (0.0 or 1.0), resolving the TypeError at its source.

This approach is more fundamental than modifying a specific operation in builtin.py and ensures SymBool can be correctly promoted to SymFloat in any operation, while still preserving its boolean nature for control flow operations like guard_or_false (which is verified by a new test case).

### Verification

1.  **Bug Reproduced**: The initial `UserError: Could not guard on data-dependent expression` was successfully reproduced with the script from the issue. As shown below
<img width="1369" height="945" alt="Screenshot 2025-10-13 at 10 29 05" src="https://github.com/user-attachments/assets/8daa4555-3347-4af5-906a-02150b8df9d1" />


2.  **Fix Validated**: After applying the code changes, the same script now runs to completion, printing `✅ eager success` and `✅ compile success`. As shown below
<img width="1228" height="82" alt="Screenshot 2025-10-13 at 10 29 21" src="https://github.com/user-attachments/assets/94c4f143-b898-4dda-9bff-0ad5450a30fa" />

3. Added a new test class DynamoOpPromotionTests to test/dynamo/test_misc.py with three new test cases:
1. test_symbool_tensor_mul_does_not_fail: Verifies that the original bug report code (with .item() + *) no longer raises an error when compiled.
2. test_symbool_guard_or_false: Verifies that this fix does not cause a regression for guard_or_false(SymBool) (the concern raised by reviewers).
3. test_symbool_tensor_mul: Verifies the behavior of Tensor(bool) * Tensor(float) (without .item()) for completeness.
All new tests were added and pass locally.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela