### PR TITLE
[MPS] Fix random in-place ops on non-contiguous tensors

### DIFF
--- a/aten/src/ATen/native/mps/operations/Distributions.mm
+++ b/aten/src/ATen/native/mps/operations/Distributions.mm
@@ -66,7 +66,7 @@ Tensor& random_mps_impl(Tensor& self,
   }
 
   // MPS random is broken for 5D+ tensors, see https://github.com/pytorch/pytorch/issues/147624
-  const auto need_reshape = self_.ndimension() > 4;
+  const auto need_reshape = self.ndimension() > 4;
   auto mps_gen = get_generator_or_default<MPSGeneratorImpl>(gen, at::mps::detail::getDefaultMPSGenerator());
   auto stream = getCurrentMPSStream();
 
@@ -87,7 +87,7 @@ Tensor& random_mps_impl(Tensor& self,
         if constexpr (std::is_same_v<scalar_t, bool>) {
           return MPSDataTypeFloat32;
         }
-        switch (self_.scalar_type()) {
+        switch (self.scalar_type()) {
           case kHalf:
             return MPSDataTypeFloat16;
           case kFloat:
@@ -96,7 +96,7 @@ Tensor& random_mps_impl(Tensor& self,
             return MPSDataTypeBFloat16;
           }
           default:
-            TORCH_CHECK_TYPE(false, "Unsupported type ", self_.scalar_type(), " for operation ", op_name);
+            TORCH_CHECK_TYPE(false, "Unsupported type ", self.scalar_type(), " for operation ", op_name);
         }
       }();
       const MPSDataType outputDataType = std::is_same_v<scalar_t, bool> ? MPSDataTypeBool : inputDataType;
@@ -118,9 +118,9 @@ Tensor& random_mps_impl(Tensor& self,
       // we don't use the output state tensor from the MPSGraph API as it requires reading back from GPU to CPU.
       // Instead, we keep the Philox state in the MPSGenerator and use the PyTorch's philox_engine to maintain
       // the counters, and feed them to the graph manually
-      auto self_shape = getMPSShape(self_);
+      auto self_shape = getMPSShape(self);
       NSArray<MPSGraphTensor*>* resultTensors =
-          [mpsGraph randomTensorWithShape:need_reshape ? @[ @(self_.numel()) ] : self_shape
+          [mpsGraph randomTensorWithShape:need_reshape ? @[ @(self.numel()) ] : self_shape
                                descriptor:desc
                               stateTensor:newCachedGraph->stateTensor
                                      name:nil];
@@ -130,8 +130,8 @@ Tensor& random_mps_impl(Tensor& self,
         newCachedGraph->resultTensor = randomBlock(newCachedGraph, newCachedGraph->resultTensor);
       }
       // results will be cast if self's scalar type isn't directly supported by MPS backend.
-      if (getMPSDataType(self_) != outputDataType)
-        newCachedGraph->resultTensor = castMPSTensor(mpsGraph, newCachedGraph->resultTensor, self_.scalar_type());
+      if (getMPSDataType(self) != outputDataType)
+        newCachedGraph->resultTensor = castMPSTensor(mpsGraph, newCachedGraph->resultTensor, self.scalar_type());
     });
     // feed the updated state values to the graph
     MPSNDArrayDescriptor* stateDesc =

--- a/test/nn/test_dropout.py
+++ b/test/nn/test_dropout.py
@@ -12,7 +12,6 @@ from torch.testing._internal.common_device_type import (
     dtypes,
     dtypesIfMPS,
     expectedFailureMPS,
-    expectedFailureMPSPre15,
     expectedFailureXLA,
     instantiate_device_type_tests,
 )
@@ -173,7 +172,6 @@ class TestDropoutNNDeviceType(NNTestCase):
                     else:
                         self.assertNotEqual(permuted_inp, out)
 
-    @expectedFailureMPSPre15
     def test_Dropout(self, device):
         input = torch.empty(1000)
         self._test_dropout(nn.Dropout, device, input)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7867,7 +7867,7 @@ class TestMPS(TestCaseMPS):
                 # Create non-contiguous tensor via transpose
                 t_mps = torch.zeros(50, 50, device='mps').T.clone()
                 self.assertFalse(t_mps.is_contiguous(),
-                                f"{name}: tensor should be non-contiguous")
+                                 f"{name}: tensor should be non-contiguous")
 
                 # Apply operation
                 op_func(t_mps)
@@ -7875,7 +7875,7 @@ class TestMPS(TestCaseMPS):
                 # Verify tensor was modified (not all zeros)
                 max_val = t_mps.max().item()
                 self.assertNotEqual(max_val, 0.0,
-                                   f"{name}: operation failed to modify non-contiguous tensor")
+                                    f"{name}: operation failed to modify non-contiguous tensor")
 
         # Test rand_like specifically (issue #124029)
         t = torch.ones((3, 2, 2), device='mps').permute(2, 0, 1)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7845,6 +7845,45 @@ class TestMPS(TestCaseMPS):
         y = torch.normal(torch.zeros(shape, device="mps"), torch.ones(shape, device="mps"))
         self.assertNotEqual(y[0], y[1])
 
+    def test_random_ops_noncontiguous(self):
+        """Test random in-place operations on non-contiguous tensors.
+
+        All random in-place operations should work on non-contiguous tensors.
+        See issues #165257 and #124029.
+        """
+        # Test each random in-place operation
+        ops = [
+            ("normal_", lambda t: t.normal_(0, 1)),
+            ("uniform_", lambda t: t.uniform_(0, 1)),
+            ("exponential_", lambda t: t.exponential_(1.0)),
+            ("bernoulli_", lambda t: t.bernoulli_(0.5)),
+            ("random_", lambda t: t.random_()),
+            ("random_with_to", lambda t: t.random_(10)),
+            ("random_with_range", lambda t: t.random_(0, 10)),
+        ]
+
+        for name, op_func in ops:
+            with self.subTest(operation=name):
+                # Create non-contiguous tensor via transpose
+                t_mps = torch.zeros(50, 50, device='mps').T.clone()
+                self.assertFalse(t_mps.is_contiguous(),
+                                f"{name}: tensor should be non-contiguous")
+
+                # Apply operation
+                op_func(t_mps)
+
+                # Verify tensor was modified (not all zeros)
+                max_val = t_mps.max().item()
+                self.assertNotEqual(max_val, 0.0,
+                                   f"{name}: operation failed to modify non-contiguous tensor")
+
+        # Test rand_like specifically (issue #124029)
+        t = torch.ones((3, 2, 2), device='mps').permute(2, 0, 1)
+        self.assertFalse(t.is_contiguous(), "rand_like input should be non-contiguous")
+        result = torch.rand_like(t)
+        self.assertFalse(result.is_contiguous(), "rand_like result should be non-contiguous")
+        self.assertNotEqual(result.max().item(), 0.0, "rand_like should generate non-zero values")
+
     # Test exponential
     @unittest.skip("This does not test anything")
     def test_exponential(self):


### PR DESCRIPTION
Random in-place operations (normal_, uniform_, exponential_, bernoulli_, random_) were silently failing on non-contiguous tensors on macOS < 15.0.

* Added needsGather check and scatter-back logic to handle non-contiguous output tensors, following the pattern used in PointwiseOps.

* Adds test to confirm these now work
* Remove pre-macOS15 xfail for test_Dropout

Fixes #165257 and #124029
