### PR TITLE
[Code Clean] Better error handling in  aten/src/ATen/native/* and aten/src/ATen/mkl/Exceptions.h

### DIFF
--- a/aten/src/ATen/mkl/Exceptions.h
+++ b/aten/src/ATen/mkl/Exceptions.h
@@ -5,16 +5,13 @@
 #include <sstream>
 #include <mkl_dfti.h>
 #include <mkl_spblas.h>
+#include <c10/util/Exception.h>
 
 namespace at::native {
 
 static inline void MKL_DFTI_CHECK(MKL_INT status)
 {
-  if (status && !DftiErrorClass(status, DFTI_NO_ERROR)) {
-    std::ostringstream ss;
-    ss << "MKL FFT error: " << DftiErrorMessage(status);
-    throw std::runtime_error(ss.str());
-  }
+  TORCH_CHECK(!status || DftiErrorClass(status, DFTI_NO_ERROR), "MKL FFT error: ", DftiErrorMessage(status));
 }
 
 }  // namespace at::native

--- a/aten/src/ATen/native/TriangularOps.cpp
+++ b/aten/src/ATen/native/TriangularOps.cpp
@@ -6,6 +6,7 @@
 #include <ATen/native/TriangularOpsUtils.h>
 #include <ATen/TensorSubclassLikeUtils.h>
 #include <c10/util/irange.h>
+#include <c10/util/Exception.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -181,9 +182,7 @@ TORCH_IMPL_FUNC(triu_cpu)(const Tensor& self, int64_t k, const Tensor &result) {
 }
 
 Tensor trace_backward_symint(const Tensor& grad, c10::SymIntArrayRef sizes) {
-  if (sizes.size() != 2) {
-    throw std::runtime_error("expected matrix input");
-  }
+  TORCH_CHECK(sizes.size() == 2, "expected matrix input");
 
   auto grad_input = at::zeros_symint(sizes[0] * sizes[1], grad.options());
   auto indices = at::arange(0, grad_input.numel(), sizes[1] + 1, grad.options().dtype(at::kLong));

--- a/aten/src/ATen/native/ao_sparse/quantized/cpu/packed_params.h
+++ b/aten/src/ATen/native/ao_sparse/quantized/cpu/packed_params.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 
 #include <ATen/core/ivalue.h>
+#include <c10/util/Exception.h>
 
 namespace ao::sparse {
 
@@ -62,9 +63,7 @@ struct LinearPackedParamsBase : public torch::jit::CustomClassHolder {
   virtual std::optional<at::Tensor> bias() = 0;
 
   virtual void set_bias(const std::optional<at::Tensor>& bias) {
-    throw std::runtime_error(
-        "set_bias is not implemented for this packed "
-        "parameter type");
+    TORCH_CHECK(false, "set_bias is not implemented for this packed parameter type");
   }
 
  protected:

--- a/aten/src/ATen/native/cuda/jit_utils.cpp
+++ b/aten/src/ATen/native/cuda/jit_utils.cpp
@@ -12,7 +12,7 @@
 #include <ATen/native/cuda/jit_utils.h>
 #include <ATen/cuda/llvm_jit_strings.h>
 #include <ATen/native/cuda/reduction_template.cuh>
-
+#include <c10/util/Exception.h>
 #include <sstream>
 #include <fstream>
 #include <cstdio>
@@ -1615,7 +1615,7 @@ NvrtcFunction jit_pwise_function(
     AT_CUDA_NVRTC_CHECK(nvrtc.nvrtcGetProgramLogSize(program, &logsize));
     std::string log(logsize, '\0');
     AT_CUDA_NVRTC_CHECK(nvrtc.nvrtcGetProgramLog(program, &log[0]));
-    throw std::runtime_error(code + log);
+    TORCH_CHECK(false, code + log);
   }
 
   size_t ptx_size = 0;

--- a/aten/src/ATen/native/hip/bgemm_kernels/bgemm_kernel_template.h
+++ b/aten/src/ATen/native/hip/bgemm_kernels/bgemm_kernel_template.h
@@ -4,7 +4,7 @@
 #include <ATen/OpMathType.h>
 #include <ATen/hip/HIPBlas.h>
 #include <ATen/native/hip/ck_types.h>
-
+#include <c10/util/Exception.h>
 #include <ck/ck.hpp>
 #include <ck/tensor_operation/gpu/device/tensor_layout.hpp>
 #include <ck/tensor_operation/gpu/device/gemm_specialization.hpp>
@@ -151,12 +151,7 @@ void bgemm_kernel_impl(CUDABLAS_BGEMM_ARGTYPES(at::BFloat16)) {
     b_element_op,
     cde_element_op
   );
-  if(!gemm.IsSupportedArgument(argument))
-  {
-      throw std::runtime_error(
-          "wrong! device_gemm with the specified compilation parameters does "
-          "not support this GEMM problem");
-  }
+  TORCH_CHECK(gemm.IsSupportedArgument(argument), "wrong! device_gemm with the specified compilation parameters does not support this GEMM problem");
   auto stream = at::cuda::getCurrentHIPStream().stream();
   invoker.Run(argument, StreamConfig{stream, false});
 }

--- a/aten/src/ATen/native/hip/ck_gemm_template.h
+++ b/aten/src/ATen/native/hip/ck_gemm_template.h
@@ -14,7 +14,7 @@
 #include <ATen/hip/impl/HIPStreamMasqueradingAsCUDA.h>
 #include <ATen/native/hip/ck_gemm.h>
 #include <ATen/native/hip/ck_types.h>
-
+#include <c10/util/Exception.h>
 #include <ck/ck.hpp>
 #include <ck/tensor_operation/gpu/device/gemm_specialization.hpp>
 #include <ck/tensor_operation/gpu/device/tensor_layout.hpp>
@@ -225,12 +225,7 @@ void gemm_impl(CUDABLAS_GEMM_ARGTYPES(Dtype)) {
      c_element_op);
 
 
- if(!gemm.IsSupportedArgument(argument))
- {
-        throw std::runtime_error(
-            "wrong! device_gemm with the specified compilation parameters does "
-            "not support this GEMM problem");
- }
+ TORCH_CHECK(gemm.IsSupportedArgument(argument) != nullptr, "wrong! device_gemm with the specified compilation parameters does not support this GEMM problem");
 
 
  auto stream = at::cuda::getCurrentHIPStream().stream();
@@ -384,10 +379,7 @@ void gemm_impl_wmma(CUDABLAS_GEMM_ARGTYPES(Dtype)) {
  {
         printf("error shape = %ld %ld %ld TRANSA=%d TRANSB=%d \n",
                         n, m, k,TRANSA, TRANSB);
-
-        throw std::runtime_error(
-            "wrong! device_gemm with the specified compilation parameters does "
-            "not support this GEMM problem");
+        TORCH_CHECK(false, "wrong! device_gemm with the specified compilation parameters does not support this GEMM problem");
  }
 
 

--- a/aten/src/ATen/native/hip/ck_gemm_template.h
+++ b/aten/src/ATen/native/hip/ck_gemm_template.h
@@ -225,7 +225,7 @@ void gemm_impl(CUDABLAS_GEMM_ARGTYPES(Dtype)) {
      c_element_op);
 
 
- TORCH_CHECK(gemm.IsSupportedArgument(argument) != nullptr, "wrong! device_gemm with the specified compilation parameters does not support this GEMM problem");
+ TORCH_CHECK(gemm.IsSupportedArgument(argument), "wrong! device_gemm with the specified compilation parameters does not support this GEMM problem");
 
 
  auto stream = at::cuda::getCurrentHIPStream().stream();

--- a/aten/src/ATen/native/nested/NestedTensorMath.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorMath.cpp
@@ -14,6 +14,7 @@
 #include <ATen/native/layer_norm.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/nested/NestedTensorUtils.h>
+#include <c10/util/Exception.h>
 
 #include <tuple>
 #include <utility>
@@ -745,12 +746,8 @@ inline std::tuple<bool, Tensor, Tensor> NestedTensor_compute_size_stride(
           numel_reshaped *= size_reshaped;
         }
         else if (size_reshaped == -1) {
-          if (infer_index > -1) {
-            throw std::runtime_error("only one dimension can be inferred");
-          }
-          else {
-            infer_index = idim;
-          }
+          TORCH_CHECK(infer_index <= -1, "only one dimension can be inferred");
+          infer_index = idim;
         }
         else {
           TORCH_CHECK(false, "invalid shape dimension ", size_reshaped);

--- a/aten/src/ATen/native/quantized/PackedParams.h
+++ b/aten/src/ATen/native/quantized/PackedParams.h
@@ -2,6 +2,7 @@
 
 #include <ATen/core/Tensor.h>
 #include <ATen/core/ivalue.h>
+#include <c10/util/Exception.h>
 
 struct LinearPackedParamsBase : public torch::jit::CustomClassHolder {
   virtual at::Tensor apply(
@@ -19,9 +20,7 @@ struct LinearPackedParamsBase : public torch::jit::CustomClassHolder {
       double /*output_scale*/,
       int64_t /*output_zero_point*/,
       at::Tensor& output) {
-    throw std::runtime_error(
-        "apply_out is not implemented for this packed "
-        "parameter type");
+    TORCH_CHECK(false, "apply_out is not implemented for this packed parameter type");
     return output;
   }
 
@@ -30,9 +29,7 @@ struct LinearPackedParamsBase : public torch::jit::CustomClassHolder {
       double /*output_scale*/,
       int64_t /*output_zero_point*/,
       at::Tensor& output) {
-    throw std::runtime_error(
-        "apply_relu_out is not implemented for this packed "
-        "parameter type");
+    TORCH_CHECK(false, "apply_relu_out is not implemented for this packed parameter type");
     return output;
   }
 
@@ -55,9 +52,7 @@ struct LinearPackedParamsBase : public torch::jit::CustomClassHolder {
       at::Tensor input,
       double input_scale,
       int64_t input_zero_point) {
-    throw std::runtime_error(
-        "apply_with_input_q_dq_qweight_dq_output_fp32 is not implemented for this packed "
-        "parameter type");
+    TORCH_CHECK(false, "apply_with_input_q_dq_qweight_dq_output_fp32 is not implemented for this packed parameter type");
     return {};
   }
 
@@ -79,9 +74,7 @@ struct LinearPackedParamsBase : public torch::jit::CustomClassHolder {
       at::Tensor input,
       double input_scale,
       int64_t input_zero_point) {
-    throw std::runtime_error(
-        "apply_with_input_q_dq_qweight_dq_relu_output_fp32 is not implemented for this packed "
-        "parameter type");
+        TORCH_CHECK(false, "apply_with_input_q_dq_qweight_dq_relu_output_fp32 is not implemented for this packed parameter type");
     return {};
   }
 
@@ -96,18 +89,14 @@ struct LinearPackedParamsBase : public torch::jit::CustomClassHolder {
       const at::Tensor& /* input */,
       at::Tensor& output,
       bool /* reduce_range */) {
-    throw std::runtime_error(
-        "apply_dynamic_out is not implemented for this packed "
-        "parameter type");
+        TORCH_CHECK(false, "apply_dynamic_out is not implemented for this packed parameter type");
     return output;
   }
   virtual at::Tensor& apply_dynamic_relu_out(
       const at::Tensor& /* input */,
       at::Tensor& output,
       bool /* reduce_range */) {
-    throw std::runtime_error(
-        "apply_dynamic_relu_out is not implemented for this packed "
-        "parameter type");
+    TORCH_CHECK(false, "apply_dynamic_relu_out is not implemented for this packed parameter type");
     return output;
   }
 
@@ -116,9 +105,7 @@ struct LinearPackedParamsBase : public torch::jit::CustomClassHolder {
   virtual std::optional<at::Tensor> bias() = 0;
 
   virtual void set_bias(std::optional<at::Tensor> /*bias*/) {
-    throw std::runtime_error(
-        "set_bias is not implemented for this packed "
-        "parameter type");
+        TORCH_CHECK(false, "set_bias is not implemented for this packed parameter type");
   }
 };
 

--- a/aten/src/ATen/native/quantized/cudnn/utils.h
+++ b/aten/src/ATen/native/quantized/cudnn/utils.h
@@ -13,6 +13,7 @@ This file contains some of the auxiliary functions used by both Conv.cpp & Linea
 #include <ATen/native/quantized/PackedParams.h>
 #include <c10/core/QScheme.h>
 #include <c10/util/ArrayRef.h>
+#include <c10/util/Exception.h>
 
 C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wsuggest-override")
 #include <cudnn_frontend.h>
@@ -43,14 +44,10 @@ struct PackedLinearWeightCudnn : public LinearPackedParamsBase {
       int64_t output_zero_point) override;
 
   at::Tensor apply_dynamic(at::Tensor input, bool reduce_range = false) override {
-    throw std::runtime_error(
-    "apply_dynamic is not implemented for this packed "
-    "parameter type");
+    TORCH_CHECK(false, "apply_dynamic is not implemented for this packed parameter type");
   }
   at::Tensor apply_dynamic_relu(at::Tensor input, bool reduce_range = false) override {
-    throw std::runtime_error(
-    "apply_dynamic_relu is not implemented for this packed "
-    "parameter type");
+    TORCH_CHECK(false, "apply_dynamic_relu is not implemented for this packed parameter type");
   }
 
   std::tuple<at::Tensor, std::optional<at::Tensor>> unpack() override;

--- a/aten/src/ATen/native/sparse/SparseBlasImpl.cpp
+++ b/aten/src/ATen/native/sparse/SparseBlasImpl.cpp
@@ -7,7 +7,7 @@
 
 // Required for checking whether Triton kernels are available
 #include <ATen/core/dispatch/Dispatcher.h>
-
+#include <c10/util/Exception.h>
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
@@ -248,10 +248,7 @@ Tensor& _compressed_row_strided_addmm_out(
         try {
           return triton_kernel.call(self, mat1, mat2, beta, alpha, result);
         } catch (std::runtime_error& e) {
-          const std::string msg = e.what();
-          if (msg != std::string("Unable to cast NotImplemented to Tensor")) {
-            throw std::runtime_error(msg);
-          }
+          TORCH_CHECK(e.what() == std::string("Unable to cast NotImplemented to Tensor"), e.what());
         } /* else triton_kernel returned NotImplemented, continue
              with the generic method below */
       }


### PR DESCRIPTION
Replace the runtime_error of the vallina C++ exceptions with TORCH_CEHCK
Including:

- aten/src/ATen/native/*
- aten/src/ATen/mkl/Exceptions.h


fix partialy #148114 
