### PR TITLE
[Build] clean up unused TH code

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1278,8 +1278,6 @@ endif()
 if(NOT BUILD_LITE_INTERPRETER)
   set(TH_CPU_INCLUDE
     # dense
-    aten/src/TH
-    ${CMAKE_CURRENT_BINARY_DIR}/aten/src/TH
     ${TORCH_ROOT}/aten/src
     ${CMAKE_CURRENT_BINARY_DIR}/aten/src
 

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -53,7 +53,6 @@ set(TORCH_PYTHON_INCLUDE_DIRECTORIES
 
     ${TORCH_ROOT}
     ${TORCH_ROOT}/aten/src
-    ${TORCH_ROOT}/aten/src/TH
 
     ${CMAKE_BINARY_DIR}
     ${CMAKE_BINARY_DIR}/aten/src


### PR DESCRIPTION
It appears that the TH source code directory is missing from PyTorch. Should we remove the related CMakeLists.txt lines?
