### PR TITLE
[PP] Fix split_args_kwargs_into_chunks issues

### DIFF
--- a/test/distributed/pipelining/test_microbatch.py
+++ b/test/distributed/pipelining/test_microbatch.py
@@ -102,6 +102,14 @@ class MicrobatchTests(TestCase):
             KV_LEN=SEQ_LEN,
             device=device,
         )
+        block_mask2 = block_mask_fn(
+            create_block_causal_mask(batch, DOC_LEN - 1),
+            B=B,
+            H=H,
+            Q_LEN=SEQ_LEN,
+            KV_LEN=SEQ_LEN,
+            device=device,
+        )
         if device == "cuda":
             flex_fn = torch.compile(flex_attention)
         else:
@@ -112,12 +120,18 @@ class MicrobatchTests(TestCase):
 
         q_clone, k_clone, v_clone = (target.clone().detach() for target in (q, k, v))
         arg_split, _ = split_args_kwargs_into_chunks(
-            (q_clone, k_clone, v_clone, {"block_mask": block_mask}),
+            (
+                q_clone,
+                k_clone,
+                v_clone,
+                {"unused_block_mask": block_mask2, "block_mask": block_mask},
+            ),
             {},
-            chunks=B,
+            chunks=4,
             args_chunk_spec=None,
             kwargs_chunk_spec=None,
         )
+        assert len(arg_split) == 4
 
         q_total_chunks = []
         dq_total_chunks = []
@@ -177,6 +191,83 @@ class MicrobatchTests(TestCase):
         self.assertEqual(concat_kv_full_num_blocks, block_mask.full_kv_num_blocks)
         self.assertEqual(concat_kv_full_indices, block_mask.full_kv_indices)
         self.assertEqual(concat_out, out)
+
+    def test_split_block_mask_batch_size_one(self, device):
+        B = 6
+        H = 1
+        SEQ_LEN = 512
+        DIM = 32
+
+        def create_causal_mask():
+            def causal_mask(
+                b: torch.Tensor,
+                h: torch.Tensor,
+                q_idx: torch.Tensor,
+                kv_idx: torch.Tensor,
+            ):
+                return q_idx >= kv_idx
+
+            return causal_mask
+
+        q, k, v = (torch.randn(B, H, SEQ_LEN, DIM, device=device) for i in range(3))
+        block_mask_fn = torch.compile(create_block_mask, fullgraph=True)
+        block_mask = block_mask_fn(
+            create_causal_mask(),
+            B=1,
+            H=H,
+            Q_LEN=SEQ_LEN,
+            KV_LEN=SEQ_LEN,
+            device=device,
+        )
+        if device == "cuda":
+            flex_fn = torch.compile(flex_attention)
+        else:
+            # It's unclear why CPU + torch.compile + flex_attention can cause an issue.
+            flex_fn = flex_attention
+        out = flex_fn(q, k, v, block_mask=block_mask)
+
+        q_clone, k_clone, v_clone = (target.clone().detach() for target in (q, k, v))
+        arg_split, _ = split_args_kwargs_into_chunks(
+            (q_clone, k_clone, v_clone, {"block_mask": block_mask}),
+            {},
+            chunks=4,
+            args_chunk_spec=None,
+            kwargs_chunk_spec=None,
+        )
+
+        assert len(arg_split) == 4
+
+        out_total_chunks = []
+        for i in range(len(arg_split)):
+            q_chunk, k_chunk, v_chunk, block_mask_chunk = arg_split[i]
+            out_chunk = flex_fn(
+                q_chunk, k_chunk, v_chunk, block_mask=block_mask_chunk["block_mask"]
+            )
+            out_total_chunks.append(out_chunk)
+
+        concat_out = torch.cat(out_total_chunks, dim=0)
+        self.assertEqual(concat_out, out)
+
+    def test_split_block_mask_none(self, device):
+        B = 6
+        H = 1
+        SEQ_LEN = 512
+        DIM = 32
+
+        q, k, v = (torch.randn(B, H, SEQ_LEN, DIM, device=device) for i in range(3))
+        arg_split, kwarg_split = split_args_kwargs_into_chunks(
+            (q, k, v, None),
+            {"attention_mask": None},
+            chunks=4,
+            args_chunk_spec=None,
+            kwargs_chunk_spec=None,
+        )
+
+        assert len(arg_split) == 4
+
+        for i in range(len(arg_split)):
+            self.assertIsNone(arg_split[i][3])
+            self.assertIsNone(kwarg_split[i]["attention_mask"])
 
     @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/1682")
     def test_chunk_spec(self, device):

--- a/torch/distributed/pipelining/microbatch.py
+++ b/torch/distributed/pipelining/microbatch.py
@@ -7,7 +7,7 @@ from typing import Any, Optional, Sequence
 import torch
 from torch.fx.node import map_aggregate
 from torch.nn.attention.flex_attention import BlockMask
-from torch.utils._pytree import tree_flatten, tree_unflatten
+from torch.utils._pytree import tree_flatten, tree_map, tree_unflatten
 
 
 __all__ = [
@@ -130,6 +130,10 @@ def _split_block_mask(
         chunk_block_masks: List of chunked block masks
     """
 
+    # BlockMask will broadcast if B is 1.
+    if block_mask.kv_num_blocks.size(0) == 1:
+        return [block_mask] * num_chunks
+
     assert block_mask.kv_num_blocks.size(0) >= num_chunks, (
         "Block mask has fewer batch size than the number of chunks. "
     )
@@ -250,7 +254,9 @@ def _shard_dict_of_args(
     # First check and find the actual number of chunks
     split_sizes = []
     for v, spec in zip(values, chunk_specs, strict=True):
-        if spec is _Replicate:
+        # The original logic is "spec is _Replicate". This doesn't seem to be
+        # correct. But we keep it for backward compatibility.
+        if spec is _Replicate or isinstance(spec, _Replicate):
             split_sizes.append(num_chunks)
         elif isinstance(v, torch.Tensor):
             assert isinstance(spec, TensorChunkSpec)
@@ -258,7 +264,11 @@ def _shard_dict_of_args(
         elif isinstance(v, BlockMask):
             assert isinstance(spec, TensorChunkSpec)
             assert spec.split_dim == 0, "BlockMask only supports split_dim=0"
-            split_sizes.append(v.kv_num_blocks.size(0))
+            # BlockMask will broadcast if B is 1.
+            if v.kv_num_blocks.size(0) == 1:
+                split_sizes.append(num_chunks)
+            else:
+                split_sizes.append(v.kv_num_blocks.size(0))
         else:
             raise ValueError(
                 f"Unsupported chunk spec: {spec} and value: {v} combination."
@@ -268,7 +278,7 @@ def _shard_dict_of_args(
     flat_split_results: list[Any] = [[] for _ in range(result_num_chunks)]
     for v, spec in zip(values, chunk_specs, strict=True):
         v_splits: Sequence[Any] = []
-        if spec is _Replicate:
+        if spec is _Replicate or isinstance(spec, _Replicate):
             v_splits = [v] * result_num_chunks
         elif isinstance(v, torch.Tensor):
             v_splits = _split_tensor(v, spec, result_num_chunks)
@@ -352,11 +362,17 @@ def split_args_kwargs_into_chunks(
 
     # If user did not provide args_chunk_spec or kwargs_chunk_spec, we extend
     # their format and use default chunking along dim 0
+    def default_spec(v):
+        if isinstance(v, torch.Tensor | BlockMask):
+            return TensorChunkSpec(DEFAULT_CHUNK_DIM)
+        else:
+            return _Replicate()
+
     if args_chunk_spec is None:
-        args_chunk_spec = (TensorChunkSpec(DEFAULT_CHUNK_DIM),) * len(args)
+        args_chunk_spec = tree_map(default_spec, args)
 
     if kwargs_chunk_spec is None:
-        kwargs_chunk_spec = dict.fromkeys(kwargs, TensorChunkSpec(DEFAULT_CHUNK_DIM))
+        kwargs_chunk_spec = tree_map(default_spec, kwargs)
 
     args_split_dict = _shard_dict_of_args(
         dict(enumerate(args)),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #165306

1. https://github.com/pytorch/pytorch/pull/164111/ adds the support of splitting BlockMask. But BlockMask actually has B=1 case that the BlockMask will be broadcast. This PR adds the support of B=1 case.

2. The original split_args_kwargs_into_chunks doesn't initialize the default specs correctly. Since we now use tree_flatten and tree_unflatten to do split, we should also use tree_map to initialize the default spec. This will actually support the case when the values are not torch.Tensor, which were only supported if users explicitly provide the shard spec.

cc @H-Huang @awgu @wanchaol @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci