### PR TITLE
Change the variable source impl into the repr in Lazy

### DIFF
--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -886,7 +886,7 @@ from user code:
             # Split the string into lines
             lines = long_string.split("\n")
             # More comprehensive pattern to capture LazyVariableTracker info
-            pattern = r"LazyVariableTracker\([^)]*\)"
+            pattern = r"LazyVariableTracker\((.*?)\)"
             # Find all lines containing the pattern
             result = [line for line in lines if re.search(pattern, line)]
             return result
@@ -895,11 +895,11 @@ from user code:
         all_messages = []
         for record in records:
             msg = munge_exc(record.getMessage(), skip=0)
+
             all_messages.append(msg)
 
         # Combine all messages to search through
         combined_msg = "\n".join(all_messages)
-
         all_lines = find_trace_bytecode_lines(combined_msg)
 
         # For now, just check that we found some lines

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -113,7 +113,7 @@ sort with non-constant keys
   Explanation: Cannot perform sort with non-constant key. First non-constant key type: <class 'torch.Tensor'>. Most notably, we cannot sort with Tensor or SymInt keys, but we can sort ints.
   Hint: Use something else as the key.
 
-  Developer debug context: TensorVariable()
+  Developer debug context: LazyVariableTracker(realized:<class 'method'>, TensorVariable())
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0207.html
 
@@ -216,7 +216,7 @@ Unsupported context manager
   Hint: If the context manager seems like it should be supported (e.g. torch.set_grad_enabled), then it may be the case that it was created outside the compiled region, which Dynamo does not support. Supported context managers can cross graph break boundaries only if they are local non-closure variables, or are intermediate values.
   Hint: File an issue to PyTorch. Simple context managers can potentially be supported, but note that context managers can't be supported in general
 
-  Developer debug context: Attempted SETUP_WITH/BEFORE_WITH/LOAD_SPECIAL on ConstantVariable(int: 3)
+  Developer debug context: Attempted SETUP_WITH/BEFORE_WITH/LOAD_SPECIAL on LazyVariableTracker(realized:<class 'method'>, ConstantVariable(int: 3))
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0142.html
 
@@ -543,7 +543,7 @@ Dynamic slicing with Tensor arguments
   Explanation: Creating slices with Tensor arguments is not supported. e.g. `l[:x]`, where `x` is a 1-element tensor.
   Hint: It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues.
 
-  Developer debug context: SliceVariable start: ConstantVariable(NoneType: None), stop: TensorVariable(), step: ConstantVariable(NoneType: None)
+  Developer debug context: SliceVariable start: ConstantVariable(NoneType: None), stop: LazyVariableTracker(realized:<class 'method'>, TensorVariable()), step: ConstantVariable(NoneType: None)
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0038.html
 
@@ -886,7 +886,7 @@ from user code:
             # Split the string into lines
             lines = long_string.split("\n")
             # More comprehensive pattern to capture LazyVariableTracker info
-            pattern = r"LazyVariableTracker\((.*?)\)"
+            pattern = r"LazyVariableTracker\([^)]*\)"
             # Find all lines containing the pattern
             result = [line for line in lines if re.search(pattern, line)]
             return result
@@ -902,7 +902,7 @@ from user code:
         combined_msg = "\n".join(all_messages)
         all_lines = find_trace_bytecode_lines(combined_msg)
 
-        # For now, just check that we found some lines
+        # For now, just check that we found some lines with LazyVariableTracker
         self.assertGreater(
             len(all_lines), 0, "Should find at least one LazyVariableTracker line"
         )

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1337,30 +1337,7 @@ class InstructionTranslatorBase(
                 return False
 
         if self.is_trace_bytecode_log_enabled:
-            if self.stack:
-                variables_tracker = []
-                for var in self.stack:
-                    if isinstance(var, LazyVariableTracker):
-                        variable_info = "LazyVariableTracker("
-                        if not var.is_realized():
-                            variable_info += f"Unrealized: {var.peek_type()})"
-
-                        else:
-                            variable_info += (
-                                f"realized:{type(var.original_value)}, {var}"
-                            )
-
-                        variables_tracker.append(variable_info)
-
-                    else:
-                        variables_tracker.append(str(var))
-
-                trace_bytecode_log.debug(
-                    "TRACE %s %s %s", inst.opname, inst.argval, variables_tracker
-                )
-
-            else:
-                trace_bytecode_log.debug("TRACE %s %s %s", inst.opname, inst.argval, [])
+            trace_bytecode_log.debug("TRACE %s %s %s", inst.opname, inst.argval, self.stack)
 
         self.update_block_stack(inst)
 

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1337,7 +1337,9 @@ class InstructionTranslatorBase(
                 return False
 
         if self.is_trace_bytecode_log_enabled:
-            trace_bytecode_log.debug("TRACE %s %s %s", inst.opname, inst.argval, repr(self.stack))
+            trace_bytecode_log.debug(
+                "TRACE %s %s %s", inst.opname, inst.argval, repr(self.stack)
+            )
 
         self.update_block_stack(inst)
 

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1337,7 +1337,7 @@ class InstructionTranslatorBase(
                 return False
 
         if self.is_trace_bytecode_log_enabled:
-            trace_bytecode_log.debug("TRACE %s %s %s", inst.opname, inst.argval, self.stack)
+            trace_bytecode_log.debug("TRACE %s %s %s", inst.opname, inst.argval, repr(self.stack))
 
         self.update_block_stack(inst)
 

--- a/torch/_dynamo/variables/lazy.py
+++ b/torch/_dynamo/variables/lazy.py
@@ -104,10 +104,6 @@ class LazyVariableTracker(VariableTracker):
             self._cache.name_hint = name
 
     def __str__(self) -> str:
-        # if self.is_realized():
-        #     return repr(self.unwrap())
-        # return super().__repr__()
-
         variable_info = "LazyVariableTracker("
         if self.is_realized():
             variable_info += (

--- a/torch/_dynamo/variables/lazy.py
+++ b/torch/_dynamo/variables/lazy.py
@@ -2,7 +2,6 @@ import collections
 import functools
 import inspect
 from typing import Any, Callable, final, Optional, Union
-
 from typing_extensions import Self
 
 from ..utils import is_function_or_wrapper

--- a/torch/_dynamo/variables/lazy.py
+++ b/torch/_dynamo/variables/lazy.py
@@ -2,6 +2,7 @@ import collections
 import functools
 import inspect
 from typing import Any, Callable, final, Optional, Union
+
 from typing_extensions import Self
 
 from ..utils import is_function_or_wrapper
@@ -104,9 +105,19 @@ class LazyVariableTracker(VariableTracker):
             self._cache.name_hint = name
 
     def __str__(self) -> str:
+        # if self.is_realized():
+        #     return repr(self.unwrap())
+        # return super().__repr__()
+
+        variable_info = "LazyVariableTracker("
         if self.is_realized():
-            return repr(self.unwrap())
-        return super().__repr__()
+            variable_info += (
+                f"realized:{type(self.original_value)}, {repr(self.unwrap())})"
+            )
+        else:
+            variable_info += f"Unrealized: {self.peek_type()})"
+
+        return variable_info
 
     def __getattr__(self, item: str) -> Any:
         return getattr(self.realize(), item)


### PR DESCRIPTION
Addressed comment on moving items into the ``__repr__``. The test plan is inherited from the previous PR for variable tracker within the symbolic convert. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela