### PR TITLE
Nan to num complex args

### DIFF
--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -819,45 +819,8 @@ Tensor& nan_to_num_out(const Tensor& self,
     return result;
   }
 
-  // Check if any of the scalar parameters are complex
-  bool has_complex_scalar = false;
-  if (nan.has_value() && nan.value().isComplex()) {
-    has_complex_scalar = true;
-  } else if (pos_inf.has_value() && pos_inf.value().isComplex()) {
-    has_complex_scalar = true;
-  } else if (neg_inf.has_value() && neg_inf.value().isComplex()) {
-    has_complex_scalar = true;
-  }
-
-  if (has_complex_scalar) {
-    // Convert Scalar to complex<double>
-    std::optional<c10::complex<double>> complex_nan = nan.has_value()
-        ? std::make_optional(nan.value().toComplexDouble())
-        : std::nullopt;
-    std::optional<c10::complex<double>> complex_pos_inf = pos_inf.has_value()
-        ? std::make_optional(pos_inf.value().toComplexDouble())
-        : std::nullopt;
-    std::optional<c10::complex<double>> complex_neg_inf = neg_inf.has_value()
-        ? std::make_optional(neg_inf.value().toComplexDouble())
-        : std::nullopt;
-
-    auto iter = TensorIterator::unary_op(result, self);
-    nan_to_num_complex_stub(iter.device_type(), iter, complex_nan, complex_pos_inf, complex_neg_inf);
-  } else {
-    // Convert Scalar to double
-    std::optional<double> double_nan = nan.has_value()
-        ? std::make_optional(nan.value().toDouble())
-        : std::nullopt;
-    std::optional<double> double_pos_inf = pos_inf.has_value()
-        ? std::make_optional(pos_inf.value().toDouble())
-        : std::nullopt;
-    std::optional<double> double_neg_inf = neg_inf.has_value()
-        ? std::make_optional(neg_inf.value().toDouble())
-        : std::nullopt;
-
-    auto iter = TensorIterator::unary_op(result, self);
-    nan_to_num_stub(iter.device_type(), iter, double_nan, double_pos_inf, double_neg_inf);
-  }
+  auto iter = TensorIterator::unary_op(result, self);
+  nan_to_num_stub(iter.device_type(), iter, nan, pos_inf, neg_inf);
   return result;
 }
 
@@ -1045,7 +1008,6 @@ DEFINE_DISPATCH(special_ndtri_stub); // NOLINT(cppcoreguidelines-avoid-non-const
 DEFINE_DISPATCH(special_log_ndtr_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_DISPATCH(neg_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_DISPATCH(nan_to_num_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-DEFINE_DISPATCH(nan_to_num_complex_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_DISPATCH(polygamma_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_DISPATCH(reciprocal_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_DISPATCH(round_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)

--- a/aten/src/ATen/native/UnaryOps.h
+++ b/aten/src/ATen/native/UnaryOps.h
@@ -112,17 +112,10 @@ DECLARE_DISPATCH(
 DECLARE_DISPATCH(
     void (*)(
         TensorIteratorBase&,
-        std::optional<double>,
-        std::optional<double>,
-        std::optional<double>),
+        const std::optional<Scalar>&,
+        const std::optional<Scalar>&,
+        const std::optional<Scalar>&),
     nan_to_num_stub)
-DECLARE_DISPATCH(
-    void (*)(
-        TensorIteratorBase&,
-        std::optional<c10::complex<double>>,
-        std::optional<c10::complex<double>>,
-        std::optional<c10::complex<double>>),
-    nan_to_num_complex_stub)
 DECLARE_DISPATCH(void (*)(TensorIteratorBase&, int64_t), round_decimals_stub)
 
 // Missing unary functions

--- a/aten/src/ATen/native/UnaryOps.h
+++ b/aten/src/ATen/native/UnaryOps.h
@@ -116,6 +116,13 @@ DECLARE_DISPATCH(
         std::optional<double>,
         std::optional<double>),
     nan_to_num_stub)
+DECLARE_DISPATCH(
+    void (*)(
+        TensorIteratorBase&,
+        std::optional<c10::complex<double>>,
+        std::optional<c10::complex<double>>,
+        std::optional<c10::complex<double>>),
+    nan_to_num_complex_stub)
 DECLARE_DISPATCH(void (*)(TensorIteratorBase&, int64_t), round_decimals_stub)
 
 // Missing unary functions

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -553,21 +553,21 @@ static void nan_to_num_kernel(
   });
 }
 
-static void nan_to_num_complex_kernel(
+static void nan_to_num_complex_args_kernel(
     TensorIteratorBase& iter,
     std::optional<complex<double>> nan,
     std::optional<complex<double>> pos_inf,
     std::optional<complex<double>> neg_inf) {
   if (isComplexType(iter.dtype())) {
     AT_DISPATCH_COMPLEX_TYPES(iter.dtype(), "nan_to_num", [&]() {
-      using value_t = scalar_t::value_type;
-      auto nan_replacement = static_cast<scalar_t>(nan.value_or(scalar_t(0.0, 0.0)));
-      auto pos_inf_replacement = static_cast<scalar_t>(pos_inf.has_value()
-          ? pos_inf.value()
-          : scalar_t(std::numeric_limits<value_t>::max(), 0.0));
-      auto neg_inf_replacement = static_cast<scalar_t>(neg_inf.has_value()
-          ? neg_inf.value()
-          : scalar_t(std::numeric_limits<value_t>::lowest(), 0.0));
+      using value_t = c10::scalar_value_type<scalar_t>::type;
+      scalar_t nan_replacement = static_cast<scalar_t>(nan.value_or(scalar_t(0.0, 0.0)));
+      scalar_t pos_inf_replacement = pos_inf.has_value()
+          ? static_cast<scalar_t>(pos_inf.value())
+          : scalar_t(std::numeric_limits<value_t>::max(), 0.0);
+      scalar_t neg_inf_replacement = neg_inf.has_value()
+          ? static_cast<scalar_t>(neg_inf.value())
+          : scalar_t(std::numeric_limits<value_t>::lowest(), 0.0);
       cpu_kernel(iter, [=](scalar_t a) -> scalar_t {
         return _nan_to_num_replace(a, nan_replacement, pos_inf_replacement, neg_inf_replacement);
       });
@@ -881,7 +881,7 @@ REGISTER_DISPATCH(sinc_stub, &CPU_CAPABILITY::sinc_kernel)
 REGISTER_DISPATCH(bitwise_not_stub, &CPU_CAPABILITY::bitwise_not_kernel)
 REGISTER_DISPATCH(logical_not_stub, &CPU_CAPABILITY::logical_not_kernel)
 REGISTER_DISPATCH(nan_to_num_stub, &CPU_CAPABILITY::nan_to_num_kernel)
-REGISTER_DISPATCH(nan_to_num_complex_stub, &CPU_CAPABILITY::nan_to_num_complex_kernel)
+REGISTER_DISPATCH(nan_to_num_complex_stub, &CPU_CAPABILITY::nan_to_num_complex_args_kernel)
 REGISTER_DISPATCH(conj_physical_stub, &CPU_CAPABILITY::conj_kernel)
 REGISTER_DISPATCH(rsqrt_stub, &CPU_CAPABILITY::rsqrt_kernel)
 REGISTER_DISPATCH(frac_stub, &CPU_CAPABILITY::frac_kernel)

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -561,15 +561,15 @@ static void nan_to_num_complex_kernel(
   if (isComplexType(iter.dtype())) {
     AT_DISPATCH_COMPLEX_TYPES(iter.dtype(), "nan_to_num", [&]() {
       using value_t = scalar_t::value_type;
-      auto nan_replacement = static_cast<c10::complex<value_t>>(nan.value_or(c10::complex<double>(0.0, 0.0)));
-      auto pos_inf_replacement = static_cast<c10::complex<value_t>>(pos_inf.has_value()
+      auto nan_replacement = static_cast<scalar_t>(nan.value_or(scalar_t(0.0, 0.0)));
+      auto pos_inf_replacement = static_cast<scalar_t>(pos_inf.has_value()
           ? pos_inf.value()
-          : c10::complex<double>(std::numeric_limits<double>::max(), 0.0));
-      auto neg_inf_replacement = static_cast<c10::complex<value_t>>(neg_inf.has_value()
+          : scalar_t(std::numeric_limits<value_t>::max(), 0.0));
+      auto neg_inf_replacement = static_cast<scalar_t>(neg_inf.has_value()
           ? neg_inf.value()
-          : c10::complex<double>(std::numeric_limits<double>::lowest(), 0.0));
+          : scalar_t(std::numeric_limits<value_t>::lowest(), 0.0));
       cpu_kernel(iter, [=](scalar_t a) -> scalar_t {
-        return _nan_to_num_replace(static_cast<c10::complex<value_t>>(a), nan_replacement, pos_inf_replacement, neg_inf_replacement);
+        return _nan_to_num_replace(a, nan_replacement, pos_inf_replacement, neg_inf_replacement);
       });
     });
   } else {

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -497,25 +497,32 @@ inline c10::complex<scalar_t> _nan_to_num_replace(
     c10::complex<scalar_t> nan_replacement,
     c10::complex<scalar_t> pos_inf_replacement,
     c10::complex<scalar_t> neg_inf_replacement) {
-  if (at::_isnan(a)) {
-    return static_cast<c10::complex<scalar_t>>(nan_replacement);
-  }
   if (!std::isfinite(a.real()) || !std::isfinite(a.imag())) {
     scalar_t new_real = 0;
     scalar_t new_imag = 0;
-    if (a.real() == std::numeric_limits<scalar_t>::infinity()) {
+    if (at::_isnan(a.real())) {
+      new_real += nan_replacement.real();
+      new_imag += nan_replacement.imag();
+    } else if (a.real() == std::numeric_limits<scalar_t>::infinity()) {
       new_real += pos_inf_replacement.real();
       new_imag += pos_inf_replacement.imag();
     } else if (a.real() == -std::numeric_limits<scalar_t>::infinity()) {
       new_real += neg_inf_replacement.real();
       new_imag += neg_inf_replacement.imag();
+    } else {
+      new_real += a.real();
     }
-    if (a.imag() == std::numeric_limits<scalar_t>::infinity()) {
-      new_real += -pos_inf_replacement.imag();
+    if (at::_isnan(a.imag())) {
+      new_real -= nan_replacement.imag();
+      new_imag += nan_replacement.real();
+    } else if (a.imag() == std::numeric_limits<scalar_t>::infinity()) {
+      new_real -= pos_inf_replacement.imag();
       new_imag += pos_inf_replacement.real();
     } else if (a.imag() == -std::numeric_limits<scalar_t>::infinity()) {
-      new_real += -neg_inf_replacement.imag();
+      new_real -= neg_inf_replacement.imag();
       new_imag += neg_inf_replacement.real();
+    } else {
+      new_imag += a.imag();
     }
     return c10::complex<scalar_t> {new_real, new_imag};
   }

--- a/aten/src/ATen/native/cuda/UnaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryOpsKernel.cu
@@ -219,7 +219,7 @@ C10_HOST_DEVICE static inline scalar_t _nan_to_num_replace(scalar_t a, scalar_t 
         : a));
 }
 
-// used to calulate complex values
+// used to calculate complex values
 // Note that z = a + bi with a = c1 + c2i and b = d1 + d2i,
 // z = (c1+c2i) + (d1+d2i)i = (c1-d2) + (c2+d1)i
 template <typename scalar_t>

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3356,21 +3356,21 @@
   dispatch:
     CUDA: _fused_rms_norm_backward_cuda
 
-- func: nan_to_num(Tensor self, float? nan=None, float? posinf=None, float? neginf=None) -> Tensor
+- func: nan_to_num(Tensor self, Scalar? nan=None, Scalar? posinf=None, Scalar? neginf=None) -> Tensor
   variants: function, method
   dispatch:
     CompositeExplicitAutograd: nan_to_num
     SparseCPU, SparseCUDA, SparseMPS: nan_to_num_sparse
   tags: pointwise
 
-- func: nan_to_num_(Tensor(a!) self, float? nan=None, float? posinf=None, float? neginf=None) -> Tensor(a!)
+- func: nan_to_num_(Tensor(a!) self, Scalar? nan=None, Scalar? posinf=None, Scalar? neginf=None) -> Tensor(a!)
   variants: function, method
   dispatch:
     CompositeExplicitAutograd: nan_to_num_
     SparseCPU, SparseCUDA, SparseMPS: nan_to_num_sparse_
   tags: pointwise
 
-- func: nan_to_num.out(Tensor self, float? nan=None, float? posinf=None, float? neginf=None, *, Tensor(a!) out) -> Tensor(a!)
+- func: nan_to_num.out(Tensor self, Scalar? nan=None, Scalar? posinf=None, Scalar? neginf=None, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU, CUDA, MTIA: nan_to_num_out
     MPS: nan_to_num_out_mps

--- a/aten/src/ATen/native/sparse/SparseUnaryOps.cpp
+++ b/aten/src/ATen/native/sparse/SparseUnaryOps.cpp
@@ -259,16 +259,16 @@ Tensor& threshold_backward_sparse_out(
 }
 
 Tensor nan_to_num_sparse(
-    const Tensor &self, std::optional<double> nan,
-    std::optional<double> posinf, std::optional<double> neginf) {
+    const Tensor &self, const std::optional<Scalar> &nan,
+    const std::optional<Scalar> &posinf, const std::optional<Scalar> &neginf) {
   return coalesced_unary_ufunc(
       self, [&](const Tensor &t) {
         return at::nan_to_num(t, nan, posinf, neginf);
       });
 }
 Tensor& nan_to_num_sparse_out(
-    const Tensor &self, std::optional<double> nan,
-    std::optional<double> posinf, std::optional<double> neginf,
+    const Tensor &self, const std::optional<Scalar> &nan,
+    const std::optional<Scalar> &posinf, const std::optional<Scalar> &neginf,
     Tensor &out) {
   return coalesced_unary_ufunc_out(
       self, out, [&](const Tensor &t, Tensor &out) {
@@ -276,8 +276,8 @@ Tensor& nan_to_num_sparse_out(
       });
 }
 Tensor& nan_to_num_sparse_(
-    Tensor &self, std::optional<double> nan,
-    std::optional<double> posinf, std::optional<double> neginf) {
+    Tensor &self, const std::optional<Scalar> &nan,
+    const std::optional<Scalar> &posinf, const std::optional<Scalar> &neginf) {
   TORCH_CHECK(self.is_coalesced(), "nan_to_num_ requires coalesced input");
   return nan_to_num_sparse_out(self, nan, posinf, neginf, self);
 }

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -509,6 +509,32 @@ class TestUnaryUfuncs(TestCase):
             torch.nan_to_num(x, out=out, nan=nan, posinf=posinf, neginf=neginf)
             self.assertEqual(result, out)
 
+    @dtypes(torch.complex128, torch.complex64)
+    def test_nan_to_num_complex_args(self, device, dtype):
+        old_values = {"nan": torch.tensor(float('nan')),
+                      "posinf": torch.tensor(float("inf")),
+                      "neginf": torch.tensor(float("-inf"))}
+        new_values = {"nan": complex(random.random(), random.random()),
+                      "posinf": complex(random.random() * 5, random.random() * 5),
+                      "neginf": complex(random.random() * 10, random.random() * 10)}
+        x = torch.zeros(1, dtype=dtype, device=device)
+        # test mixture of 'NAN' values (e.g. nan-inf*j)
+        for key1, new_value1 in new_values.items():
+            for key2, new_value2 in new_values.items():
+                x[0] = torch.complex(old_values[key1], old_values[key2])
+                x = x.nan_to_num(**new_values)
+                self.assertEqual(x[0], new_value1 + new_value2 * 1j)
+
+        # test mixture of 'NAN' values with 'normal' values (e.g. nan+2*j)
+        for key1, new_value1 in new_values.items():
+            x[0] = torch.complex(old_values[key1], torch.tensor(2.))
+            x = x.nan_to_num(**new_values)
+            self.assertEqual(x[0], new_value1 + 2j)
+
+            x[0] = torch.complex(torch.tensor(2.), old_values[key1])
+            x = x.nan_to_num(**new_values)
+            self.assertEqual(x[0], 2 + new_value1 * 1j)
+
     @onlyCPU
     def test_nan_to_num_bfloat16(self, device):
         def test_dtype(fn, input, dtype):

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1232,7 +1232,7 @@
   self: mvlgamma_backward(grad, self, p)
   result: auto_element_wise
 
-- name: nan_to_num(Tensor self, float? nan=None, float? posinf=None, float? neginf=None) -> Tensor
+- name: nan_to_num(Tensor self, Scalar? nan=None, Scalar? posinf=None, Scalar? neginf=None) -> Tensor
   self: grad * at::isfinite(self)
   result: auto_element_wise
 


### PR DESCRIPTION
Fixes #131283

Updated nan_to_num to allow for arguments nan, posinf, and neginf to be complex when the tensor is complex. Currently works for torch.complex128 and torch.complex64 dtypes. To allow for torch.complex32 dtype, casting from complex double to complex Half would need to be implemented first.  

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @malfet
