### PR TITLE
.venv/ in .gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,4 @@ CLAUDE.local.md
 /test_*.py
 /debug_*.py
 CLAUDE_CONTEXT/
+.venv/

--- a/.gitignore
+++ b/.gitignore
@@ -374,8 +374,8 @@ third_party/ruy/
 third_party/glog/
 
 # Virtualenv
-venv/
 .venv/
+venv/
 
 # Log files
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -375,6 +375,7 @@ third_party/glog/
 
 # Virtualenv
 venv/
+.venv/
 
 # Log files
 *.log
@@ -396,4 +397,3 @@ CLAUDE.local.md
 /test_*.py
 /debug_*.py
 CLAUDE_CONTEXT/
-.venv/


### PR DESCRIPTION
`uv venv` creates venv in `.venv/` directory. So, it's useful to have `.venv/` in `.gitignore`, since perhaps more people are using `uv` in their work. As per comment https://github.com/pytorch/pytorch/pull/164923/files/3592f5f4e5e536797cb042f03b048169661a428f#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947

uv docs  that confirms it: https://docs.astral.sh/uv/pip/environments/#using-arbitrary-python-environments