### PR TITLE
Add docstring to dedup_tensors function

### DIFF
--- a/torch/distributed/checkpoint/_dedup_tensors.py
+++ b/torch/distributed/checkpoint/_dedup_tensors.py
@@ -30,8 +30,26 @@ def init_logger() -> logging.Logger:
 logger = init_logger()
 
 
-# TODO add docstring for dedup_tensors
 def dedup_tensors(all_plans: list[SavePlan]) -> list[SavePlan]:
+    """
+    Remove duplicate tensor entries across multiple SavePlan objects.
+
+    When multiple ranks attempt to save the same tensor (identified by MetadataIndex),
+    this function deduplicates by keeping only the first occurrence and removing
+    subsequent duplicates from their respective SavePlans.
+
+    Args:
+        all_plans (list[SavePlan]): List of SavePlan objects, one per rank, that may
+            contain duplicate tensor entries.
+
+    Returns:
+        list[SavePlan]: List of SavePlan objects with duplicates removed. For each
+            duplicated tensor, only the first occurrence (by plan order) is retained.
+
+    Note:
+        The deduplication strategy always keeps the tensor from the first plan that
+        contains it, removing it from all subsequent plans.
+    """
     all_plans = list(all_plans)
     key_to_plan: dict[MetadataIndex, list[int]] = {}
     for plan_idx, plan in enumerate(all_plans):


### PR DESCRIPTION
## Summary
Adds comprehensive docstring to the `dedup_tensors()` function in `torch/distributed/checkpoint/_dedup_tensors.py`.

## Changes
- Removed TODO comment on line 33
- Added complete docstring including:
- Function description
- Args section with parameter details
- Returns section with return type documentation
- Note about deduplication strategy

## Motivation
The function had a TODO comment requesting a docstring. This improves code documentation for distributed checkpoint functionality.

## Testing
Documentation formatting follows PyTorch conventions and includes proper docstring structure.a

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci