### PR TITLE
[Test][elastic]fix test_etcd_server_with_rendezvous

### DIFF
--- a/test/distributed/elastic/rendezvous/etcd_server_test.py
+++ b/test/distributed/elastic/rendezvous/etcd_server_test.py
@@ -9,8 +9,6 @@ import os
 import sys
 import unittest
 
-import etcd
-
 from torch.distributed.elastic.rendezvous import RendezvousParameters
 from torch.distributed.elastic.rendezvous.etcd_rendezvous import create_rdzv_handler
 from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer
@@ -51,7 +49,7 @@ class EtcdServerTest(unittest.TestCase):
                 max_nodes=1,
                 timeout=60,
                 last_call_timeout=30,
-                local_addr="127.0.0.1"
+                local_addr="127.0.0.1",
             )
             rdzv_handler = create_rdzv_handler(rdzv_params)
             rdzv_info = rdzv_handler.next_rendezvous()

--- a/test/distributed/elastic/rendezvous/etcd_server_test.py
+++ b/test/distributed/elastic/rendezvous/etcd_server_test.py
@@ -11,10 +11,8 @@ import unittest
 
 import etcd
 
-from torch.distributed.elastic.rendezvous.etcd_rendezvous import (
-    EtcdRendezvous,
-    EtcdRendezvousHandler,
-)
+from torch.distributed.elastic.rendezvous import RendezvousParameters
+from torch.distributed.elastic.rendezvous.etcd_rendezvous import create_rdzv_handler
 from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer
 
 
@@ -44,18 +42,18 @@ class EtcdServerTest(unittest.TestCase):
         server.start()
 
         try:
-            client = etcd.Client(server.get_host(), server.get_port())
-
-            rdzv = EtcdRendezvous(
-                client=client,
-                prefix="test",
-                run_id=1,
-                num_min_workers=1,
-                num_max_workers=1,
+            endpoint = server.get_endpoint()
+            rdzv_params = RendezvousParameters(
+                backend="etcd",
+                endpoint=endpoint,
+                run_id="test_run_1",
+                min_nodes=1,
+                max_nodes=1,
                 timeout=60,
                 last_call_timeout=30,
+                local_addr="127.0.0.1"
             )
-            rdzv_handler = EtcdRendezvousHandler(rdzv)
+            rdzv_handler = create_rdzv_handler(rdzv_params)
             rdzv_info = rdzv_handler.next_rendezvous()
             self.assertIsNotNone(rdzv_info.store)
             self.assertEqual(0, rdzv_info.rank)


### PR DESCRIPTION
Fixes [#2124](https://github.com/intel/torch-xpu-ops/issues/2124)

This PR fixes the following error observed while running the unit test:

`python -m unittest etcd_server_test.EtcdServerTest.test_etcd_server_with_rendezvous
`
Error log:
```
======================================================================
ERROR: test_etcd_server_with_rendezvous (etcd_server_test.EtcdServerTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/sdp/xiangdong/pytorch/test/distributed/elastic/rendezvous/etcd_server_test.py", line 58, in test_etcd_server_with_rendezvous
    rdzv_handler = EtcdRendezvousHandler(rdzv)
TypeError: EtcdRendezvousHandler.__init__() missing 1 required positional argument: 'local_addr'
----------------------------------------------------------------------
Ran 1 test in 1.016s
FAILED (errors=1)
```
Root cause:
The test case instantiates `EtcdRendezvousHandler `without providing the required `local_addr `argument, leading to a `TypeError`.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben