### PR TITLE
[ISSUES] Update ci:sev template to include ci: disable-autorevert label

### DIFF
--- a/.github/ISSUE_TEMPLATE/ci-sev.md
+++ b/.github/ISSUE_TEMPLATE/ci-sev.md
@@ -2,12 +2,13 @@
 name: "⚠️ CI SEV"
 about: Tracking incidents for PyTorch's CI infra.
 title: ''
-labels: ''
+labels: 'ci: sev, ci: disable-autorevert'
 assignees: ''
 
 ---
 
-> NOTE: Remember to label this issue with "`ci: sev`"
+> NOTE: - Remember to keep this issue with "`ci: sev`" label
+>.      - If you want autorevert to be disabled, keep the ci: disable-autorevert label
 
  <!-- Add the `merge blocking` label to this PR to prevent PRs from being merged while this issue is open -->
 

--- a/.github/ISSUE_TEMPLATE/ci-sev.md
+++ b/.github/ISSUE_TEMPLATE/ci-sev.md
@@ -2,13 +2,12 @@
 name: "⚠️ CI SEV"
 about: Tracking incidents for PyTorch's CI infra.
 title: ''
-labels: 'ci: sev, ci: disable-autorevert'
+labels: ''
 assignees: ''
 
 ---
 
-> NOTE: - Remember to keep this issue with "`ci: sev`" label
->.      - If you want autorevert to be disabled, keep the ci: disable-autorevert label
+> NOTE: Remember to label this issue with "`ci: sev`"
 
  <!-- Add the `merge blocking` label to this PR to prevent PRs from being merged while this issue is open -->
 

--- a/.github/ISSUE_TEMPLATE/ci-sev.md
+++ b/.github/ISSUE_TEMPLATE/ci-sev.md
@@ -2,13 +2,13 @@
 name: "⚠️ CI SEV"
 about: Tracking incidents for PyTorch's CI infra.
 title: ''
-labels: 'ci: sev, ci: disable-autorevert'
+labels: ''
 assignees: ''
 
 ---
 
-> NOTE: - Remember to keep this issue with "`ci: sev`" label
->.      - If you want autorevert to be disabled, keep the ci: disable-autorevert label
+> NOTE: Remember to label this issue with "`ci: sev`"
+>.      If you want autorevert to be disabled while this issue is open, add the "`ci: disable-autorevert`" label
 
  <!-- Add the `merge blocking` label to this PR to prevent PRs from being merged while this issue is open -->
 

--- a/.github/ISSUE_TEMPLATE/disable-autorevert.md
+++ b/.github/ISSUE_TEMPLATE/disable-autorevert.md
@@ -1,7 +1,7 @@
 ---
-name: DISABLE AUTOREVERT
+name: "❌​\U0001F519 DISABLE AUTOREVERT"
 about: Disables autorevert when open
-title: "❌​\U0001F519​ [DISABLE AUTOREVERT]"
+title: "[DISABLE AUTOREVERT]"
 labels: 'ci: disable-autorevert'
 assignees: ''
 


### PR DESCRIPTION
We noticed that disabling autorevert in any and all ci:sevs is too impactful, as ci: sevs are sometimes created just to communicate an action or a impactful change. But sometimes durring a SEV we might not want to disable autorevert anyways, a example is a ci: sev impacting jobs we don't use as basis for autorevert.

So, by default we add the cl: disable-autorevert tag, that can optionally be removed, allowing a ci:sev be nonblocking for autorevert.