### PR TITLE
[dynamo] Add recompile reason for set_stance fail_on_recompile

### DIFF
--- a/test/dynamo/test_decorators.py
+++ b/test/dynamo/test_decorators.py
@@ -1472,6 +1472,25 @@ class DecoratorTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(out1, inp + 2)
         self.assertEqual(out2, inp + 2)
 
+    def test_fail_on_recompile_shows_guard_details(self):
+        @torch.compile(backend="eager", dynamic=False)
+        def f(x):
+            return x + 1
+
+        f(torch.ones(4))
+        f(torch.ones(5))
+        with torch.compiler.set_stance("fail_on_recompile"):
+            f(torch.ones(4))
+            self.assertExpectedInlineMunged(
+                RuntimeError,
+                lambda: f(torch.ones(7)),
+                """\
+Detected recompile when torch.compile stance is 'fail_on_recompile'. filename: 'test_decorators.py', function name: 'f', line number: 1476
+    triggered by the following guard failure(s):
+    - 0/0: tensor 'x' size mismatch at index 0. expected 4, actual 7
+    - 0/1: tensor 'x' size mismatch at index 0. expected 5, actual 7""",  # noqa: B950
+            )
+
     def test_set_stance_fail_on_recompile_with_disable(self):
         @torch.compiler.disable
         def inner(x):

--- a/test/dynamo/test_decorators.py
+++ b/test/dynamo/test_decorators.py
@@ -2,6 +2,7 @@
 import functools
 import operator
 import os
+import re
 import unittest.mock as mock
 from unittest.mock import patch
 
@@ -1479,16 +1480,21 @@ class DecoratorTests(torch._dynamo.test_case.TestCase):
 
         f(torch.ones(4))
         f(torch.ones(5))
+
+        def post_munge(s):
+            return re.sub(r"line number: \d+", "line number: N", s)
+
         with torch.compiler.set_stance("fail_on_recompile"):
             f(torch.ones(4))
             self.assertExpectedInlineMunged(
                 RuntimeError,
                 lambda: f(torch.ones(7)),
                 """\
-Detected recompile when torch.compile stance is 'fail_on_recompile'. filename: 'test_decorators.py', function name: 'f', line number: 1476
+Detected recompile when torch.compile stance is 'fail_on_recompile'. filename: 'test_decorators.py', function name: 'f', line number: N
     triggered by the following guard failure(s):
     - 0/0: tensor 'x' size mismatch at index 0. expected 4, actual 7
     - 0/1: tensor 'x' size mismatch at index 0. expected 5, actual 7""",  # noqa: B950
+                post_munge=post_munge,
             )
 
     def test_set_stance_fail_on_recompile_with_disable(self):

--- a/test/dynamo/test_recompile_ux.py
+++ b/test/dynamo/test_recompile_ux.py
@@ -291,23 +291,6 @@ class RecompileUxTests(torch._dynamo.test_case.TestCase):
             for line in ["len(x) == 2", "len(x) == 3"]:
                 self.assertIn(line, filter_reasons())
 
-    def test_fail_on_recompile_shows_guard_details(self):
-        def f(x):
-            return x + 1
-
-        compiled_f = torch.compile(f, backend="eager", dynamic=False)
-        compiled_f(torch.ones(4))
-        with torch.compiler.set_stance("fail_on_recompile"):
-            compiled_f(torch.ones(4))
-            with self.assertRaisesRegex(
-                RuntimeError, "triggered by the following guard failure"
-            ):
-                compiled_f(torch.ones(7))
-            with self.assertRaisesRegex(
-                RuntimeError, "size mismatch.*expected 4.*actual 7"
-            ):
-                compiled_f(torch.ones(7))
-
     @torch._dynamo.config.patch(recompile_limit=1)
     def test_recompile_child_run_only(self):
         def f(x, n):

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -235,7 +235,11 @@ def _callback_from_stance(callback: DynamoCallback) -> DynamoCallback:
             if not convert_frame.has_tensor_in_frame(frame):
                 return ConvertFrameReturn()
 
-            from torch._C._dynamo.eval_frame import _debug_get_precompile_entries
+            from torch._C._dynamo.eval_frame import (
+                _debug_get_cache_entry_list,
+                _debug_get_precompile_entries,
+            )
+            from torch._dynamo.guards import get_and_maybe_log_recompilation_reasons
 
             message = (
                 "Detected recompile when torch.compile stance is 'fail_on_recompile'. "
@@ -243,6 +247,20 @@ def _callback_from_stance(callback: DynamoCallback) -> DynamoCallback:
                 + f"function name: '{frame.f_code.co_name}', "
                 + f"line number: {frame.f_lineno}"
             )
+            cache_entries = _debug_get_cache_entry_list(frame.f_code)
+            if cache_entries:
+                all_reasons = []
+                for cache_entry in cache_entries:
+                    reasons = get_and_maybe_log_recompilation_reasons(
+                        cache_entry, frame, skip_logging=True
+                    )
+                    all_reasons.extend(reasons)
+                if all_reasons:
+                    failures = textwrap.indent("\n".join(all_reasons), "- ")
+                    guard_failure_details = (
+                        f"triggered by the following guard failure(s):\n{failures}"
+                    )
+                    message += f"\n{textwrap.indent(guard_failure_details, '    ')}"
             precompile_entries = _debug_get_precompile_entries(frame.f_code)
             if len(precompile_entries) > 0:
                 message += "\nFailed on the following precompiled guards: "

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -249,14 +249,11 @@ def _callback_from_stance(callback: DynamoCallback) -> DynamoCallback:
             )
             cache_entries = _debug_get_cache_entry_list(frame.f_code)
             if cache_entries:
-                all_reasons = []
-                for cache_entry in cache_entries:
-                    reasons = get_and_maybe_log_recompilation_reasons(
-                        cache_entry, frame, skip_logging=True
-                    )
-                    all_reasons.extend(reasons)
-                if all_reasons:
-                    failures = textwrap.indent("\n".join(all_reasons), "- ")
+                reasons = get_and_maybe_log_recompilation_reasons(
+                    cache_entries[0], frame, skip_logging=True
+                )
+                if reasons:
+                    failures = textwrap.indent("\n".join(reasons), "- ")
                     guard_failure_details = (
                         f"triggered by the following guard failure(s):\n{failures}"
                     )


### PR DESCRIPTION
Fixes #163500

### Summary:
For `set_stance("fail_on_recompile")` failures will provide the reason why the recompilation occurred

### Impacts:
module: dynamo

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela