### PR TITLE
Fix PrivateUse1 backend aliasing in de-serialization

### DIFF
--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -661,7 +661,7 @@ def validate_hpu_device(location):
 def _deserialize(backend_name, obj, location):
     if backend_name == "privateuse1":
         backend_name = torch._C._get_privateuse1_backend_name()
-    if location.split(":", 1)[0] == backend_name:
+    if location == backend_name or bool(re.match(f"{backend_name}(:|[0-9]+)", location)):
         device = _validate_device(location, backend_name)
         return obj.to(device=device)
 

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -661,7 +661,9 @@ def validate_hpu_device(location):
 def _deserialize(backend_name, obj, location):
     if backend_name == "privateuse1":
         backend_name = torch._C._get_privateuse1_backend_name()
-    if location == backend_name or bool(re.match(f"{backend_name}(:|[0-9]+)", location)):
+    if location == backend_name or bool(
+        re.match(f"{backend_name}(:|[0-9]+)", location)
+    ):
         device = _validate_device(location, backend_name)
         return obj.to(device=device)
 

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -661,7 +661,7 @@ def validate_hpu_device(location):
 def _deserialize(backend_name, obj, location):
     if backend_name == "privateuse1":
         backend_name = torch._C._get_privateuse1_backend_name()
-    if location.startswith(backend_name):
+    if location.split(":", 1)[0] == backend_name:
         device = _validate_device(location, backend_name)
         return obj.to(device=device)
 


### PR DESCRIPTION
Fixes #165455

During de-serialization, we iterate over all the backends in priority order (in this case `cpu`, `cuda`, and then `privateuse1`) and use the first backend that partially matches the device name. Presumably, the partial match is to generalize to cases with and without a device index (e.g. `cuda` vs `cuda:0`).

This partial match (using `startswith`) fails if the `privateuse1` backend is renamed to something that starts with `cpu` or `cuda` such as `cudacustom`. Since `cpu` and `cuda` have higher priority than `privateuse1`, the renamed `privateuse1` device will alias to the `cpu` to `cuda` backend and throw an error.

This PR fixes the issue by making the match stricter by splitting on the `:` in the device + device index string.