### PR TITLE
Relax equality check

### DIFF
--- a/test/dynamo/test_dicts.py
+++ b/test/dynamo/test_dicts.py
@@ -70,9 +70,9 @@ class DictTests(torch._dynamo.test_case.TestCase):
 
             def forward(self, x):
                 val = x.sin()
-                if TensorDim.DDP in set(["ddp"]):
+                if TensorDim.DDP in {"ddp"}:
                     val += x.cos()
-                if "ddp" in set([TensorDim.DDP]):
+                if "ddp" in {TensorDim.DDP}:
                     val += x.cos()
                 return val
 

--- a/test/dynamo/test_dicts.py
+++ b/test/dynamo/test_dicts.py
@@ -2,6 +2,7 @@
 
 # ruff: noqa: TRY002
 
+import enum
 import itertools
 import operator
 import types
@@ -55,6 +56,30 @@ class DictTests(torch._dynamo.test_case.TestCase):
         x = torch.randn(4)
         opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
         self.assertEqual(fn(x), opt_fn(x))
+
+    def test_dict_contains_enum(self):
+        class TensorDim(str, enum.Enum):
+            DDP = "ddp"
+            FSDP = "fsdp"
+            CP = "cp"
+            TP = "tp"
+
+        class Foo(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                val = x.sin()
+                if TensorDim.DDP in set(["ddp"]):
+                    val += x.cos()
+                if "ddp" in set([TensorDim.DDP]):
+                    val += x.cos()
+                return val
+
+        inp = torch.randn(4, 4)
+        mod = Foo()
+        opt_f = torch.compile(mod)
+        self.assertEqual(mod(inp), opt_f(inp))
 
     def test_dict_subclass_local_with_non_dict_method(self):
         # Checks that add_1 method is inlined

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -15194,9 +15194,9 @@ graph():
 
             def forward(self, x):
                 val = x.sin()
-                if TensorDim.DDP in set(["ddp"]):
+                if TensorDim.DDP in {"ddp"}:
                     val += x.cos()
-                if "ddp" in set([TensorDim.DDP]):
+                if "ddp" in {TensorDim.DDP}:
                     val += x.cos()
                 return val
 

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -197,9 +197,7 @@ class ConstDictVariable(VariableTracker):
         @staticmethod
         def _eq_impl(a, b):
             # TODO: Put this in utils and share it between variables/builtin.py and here
-            if type(a) is not type(b):
-                return False
-            elif isinstance(a, tuple):
+            if isinstance(a, tuple):
                 Hashable = ConstDictVariable._HashableTracker
                 return len(a) == len(b) and all(
                     Hashable._eq_impl(u, v) for u, v in zip(a, b)

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -197,6 +197,10 @@ class ConstDictVariable(VariableTracker):
         @staticmethod
         def _eq_impl(a, b):
             # TODO: Put this in utils and share it between variables/builtin.py and here
+            type_a, type_b = type(a), type(b)
+            if not (issubclass(type_a, type_b) or issubclass(type_b, type_a)):
+                return False
+
             if isinstance(a, tuple):
                 Hashable = ConstDictVariable._HashableTracker
                 return len(a) == len(b) and all(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #165460



When an object is inherited from multiple types, the previous check would fail. So we should relax it to respect eager semantic 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela

Differential Revision: [D84635322](https://our.internmc.facebook.com/intern/diff/D84635322)