### PR TITLE
[PP] Fix edge case with FSDP when stages_per_rank > 3

### DIFF
--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -2036,6 +2036,7 @@ BACKWARD_INPUT, BACKWARD_WEIGHT, and OVERLAP_F_B are supported."
                         if not isinstance(submodule, FSDPModule):
                             continue
                         submodule.reshard()
+                    unsharded_stages.remove(stage_idx)
             elif comp_type == FORWARD:
                 if stage_uses_fsdp:
                     _assert_unsharded(stage_idx)


### PR DESCRIPTION
There is an edge case with FSDP + PP when we add UNSHARD + RESHARD, we at max have 3 stages unsharded, https://github.com/pytorch/pytorch/blob/3f83e8915e86a93da2fe01fda45602dcd0e3ebfd/torch/distributed/pipelining/schedules.py#L1029-L1031

This change is need to be able to unshard and reshard a stage multiple times.

cc @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci