### PR TITLE
Fix setattr exception handling for read-only attributes

### DIFF
--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1092,7 +1092,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         if name in ("__weakref__", "__dict__"):
             raise_observed_exception(AttributeError, tx)
 
-        # Properties witout setters are read-only
+        # Properties without setters are read-only
         try:
             desc = inspect.getattr_static(type(self.value), name)
         except AttributeError:

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1101,10 +1101,9 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         if isinstance(desc, property) and desc.fset is None:
             raise_observed_exception(AttributeError, tx)
 
-        # Objects using __slots__ can only set attributes that aer in the slots
-        if not hasattr(self.value, "__dict__"):
-            if desc is None:
-                raise_observed_exception(AttributeError, tx)
+        # Objects using __slots__ can only set attributes that are in the slots
+        if not hasattr(self.value, "__dict__") and desc is None:
+            raise_observed_exception(AttributeError, tx)
         if directly_update_dict:
             self.attrs_directly_modifed_on_dict.add(name)
         else:


### PR DESCRIPTION
Fixes #165385 

Fixes an issue where Dynamo doesn't check if setattr is allowed before generating bytecode. In eager mode the exception gets caught and the function works,  but the complied version crashes.

The fix adds validation in method_setattr_standard to catch operations that  would raise AttributeError:
 __weakref_ and __dict__ (not writable on instances), Read-only properties (no setter), and  __slots__ violations (attribute not in slots)

When detected, raise_observed_exception is called so try-except blocks work correctly in compiled code.

Tests added in test/dynamo/test_misc.py.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @chenyang78