### PR TITLE
 [dynamo] Fix tensor factory functions ignoring default device in torch.compile

### DIFF
--- a/test/dynamo/test_modes.py
+++ b/test/dynamo/test_modes.py
@@ -820,7 +820,9 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(input_tensor.device.type, GPU_TYPE)
 
         # Verify the computation worked correctly
-        expected = input_tensor / torch.tensor([1000], dtype=torch.int64, device=GPU_TYPE)
+        expected = input_tensor / torch.tensor(
+            [1000], dtype=torch.int64, device=GPU_TYPE
+        )
         self.assertEqual(result, expected)
 
         torch.set_default_device(None)

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -225,17 +225,14 @@ def get_overridable_functions():
     from itertools import chain
 
     from torch.overrides import get_overridable_functions as get_overridable_functions_
+    from torch.utils._device import _device_constructors
 
     funcs = set(chain.from_iterable(get_overridable_functions_().values()))
-    more: set[Callable[..., Any]] = {
-        torch.ones,
-        torch.ones_like,
-        torch.zeros,
-        torch.zeros_like,
-        torch.empty,
-        torch.full,
-    }
-    funcs.update(more)
+
+    # Add all device constructor functions to support torch.set_default_device()
+    # These functions accept a 'device' parameter and should respect the default device
+    funcs.update(_device_constructors())
+
     return funcs
 
 


### PR DESCRIPTION
Fixes #159041 #151202 
## Summary

This PR fixes a bug where `torch.compile` does not respect `torch.set_default_device()` for tensor creation functions like `torch.randn`, `torch.zeros`, `torch.ones`, etc.

## Problem

When a default device is set using `torch.set_default_device()` before compilation, tensor factory functions inside the compiled region ignore this setting and create tensors on CPU instead:

```python
torch.set_default_device("cuda")

@torch.compile
def foo(x):
    return x * torch.randn(1)  # Creates tensor on CPU instead of CUDA

x = torch.randn(1)  # Correctly on CUDA
result = foo(x)  # Fails: device mismatch between cuda:0 and cpu
```

## Root Cause

Tensor factory functions (e.g., `torch.randn`, `torch.zeros`, `torch.ones`) were not included in the `get_overridable_functions()` list. This prevented `__torch_function__` dispatch from being triggered during Dynamo tracing, so the existing `DeviceContext` torch function mode could not intercept these calls to inject the device parameter.

## Solution

**Single-line fix** in `torch/_dynamo/variables/torch.py`:

Replace the manual list of device constructors with the authoritative `_device_constructors()` function:

```python
@functools.cache
def get_overridable_functions():
    from itertools import chain
    from torch.overrides import get_overridable_functions as get_overridable_functions_
    from torch.utils._device import _device_constructors

    funcs = set(chain.from_iterable(get_overridable_functions_().values()))

    # Add all device constructor functions to support torch.set_default_device()
    funcs.update(_device_constructors())

    return funcs
```

## Code Example - Before and After

### Before (Fails)
```python
import torch

torch.set_default_device("cuda")

@torch.compile
def fn(input_tensor):
    input_tensor = input_tensor / torch.tensor([1000], dtype=torch.int64)
    return input_tensor

fn(torch.randn([10, 10], dtype=torch.float32))
# RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```

### After (Works)
```python
import torch

torch.set_default_device("cuda")

@torch.compile
def fn(input_tensor):
    input_tensor = input_tensor / torch.tensor([1000], dtype=torch.int64)
    return input_tensor

result = fn(torch.randn([10, 10], dtype=torch.float32))
print(result.device)  # cuda:0
# Success! All tensors are on CUDA
```



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @mlazos @chenyang78