### PR TITLE
[APF Logging][Error Trait] To fill the errorTraits for ChildFailedError with signal abort

### DIFF
--- a/torch/distributed/elastic/multiprocessing/errors/__init__.py
+++ b/torch/distributed/elastic/multiprocessing/errors/__init__.py
@@ -60,9 +60,9 @@ from datetime import datetime
 from functools import wraps
 from string import Template
 from typing import Any, Optional, TypeVar, Union
-from typing_extensions import ParamSpec
 
 from torch.distributed.elastic.utils.logging import get_logger
+from typing_extensions import ParamSpec
 
 from .error_handler import ErrorHandler  # noqa: F401
 from .handlers import get_error_handler  # noqa: F401
@@ -79,9 +79,9 @@ __all__ = [
 logger = get_logger(__name__)
 
 
-JSON = dict
+JSON = dict[str, Any]
 
-_EMPTY_ERROR_DATA = {"message": "<NONE>"}
+_EMPTY_ERROR_DATA: dict[str, Any] = {"message": "<NONE>"}
 _NOT_AVAILABLE = "<N/A>"
 
 _R = TypeVar("_R")
@@ -142,6 +142,10 @@ class ProcessFailure:
                     f"Signal {-self.exitcode} ({self.signal_name()})"
                     f" received by PID {self.pid}"
                 )
+                self.error_file_data["errorTraits"] = {
+                    "category": "system_terminated_error",
+                    "retryability": "False",
+                }
             else:
                 self.message = "To enable traceback see: https://pytorch.org/docs/stable/elastic/errors.html"
 


### PR DESCRIPTION
Summary:
Continue to fix the null error category for the top contributor of UnknonwError, we can see that the major is from ChildFailedError:

https://fburl.com/scuba/apf_training_events/s9zlhtim

 {F1982718500} 

Picked 2 example jobs:
https://www.internalfb.com/mlhub/pipelines/runs/mast/aps-athena_gmp_mtml_mobile_cvr_model_16_epoxy_1432023824567828_a?job_attempt=0&version=0&tab=summary&env=PRODUCTION
 {F1982718527}  

https://www.internalfb.com/mlhub/pipelines/runs/mast/aps-t21_npi_mtiasw_mast_mai_full-ca813eef46?job_attempt=2&version=0&tab=summary&env=PRODUCTION
{F1982718536}

The message of "Signal 6 (SIGABRT) received by PID" is only from the `ProcessFailure.__post_init__`, with exitcode < 0 condition. 
In this diff I just inject the ErrorTraits object into the `error_file_data`

Test Plan: `buck build`

Differential Revision: D84648122




cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci