### PR TITLE
[ROCm][CI] Update rocm.yml workflow to use 1 GPU ARC runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -57,6 +57,9 @@ self-hosted-runner:
     # MI2xx runners
     - linux.rocm.gpu
     - linux.rocm.gpu.mi250
+    - linux.rocm.gpu.mi250.1
+    - linux.rocm.gpu.mi250.2
+    - linux.rocm.gpu.mi250.4
     - linux.rocm.gpu.2
     - linux.rocm.gpu.4
     # gfx942 runners

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,4 +1,4 @@
-runnerssted-runner:
+self-hosted-runner:
   labels:
     # GitHub hosted runner that actionlint doesn't recognize because actionlint version (1.6.21) is too old
     - ubuntu-24.04

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,4 +1,4 @@
-self-hosted-runner:
+runnerssted-runner:
   labels:
     # GitHub hosted runner that actionlint doesn't recognize because actionlint version (1.6.21) is too old
     - ubuntu-24.04
@@ -54,15 +54,17 @@ self-hosted-runner:
     - windows-11-arm64
     - windows-11-arm64-preview
     # Organization-wide AMD-hosted runners
-    # MI2xx runners
+    # MI2xx non-ARC runners
     - linux.rocm.gpu
+    - linux.rocm.gpu.2
+    - linux.rocm.gpu.4
     - linux.rocm.gpu.mi250
+    - linux.rocm.gpu.gfx1100
+    # MI2xx ARC runners
     - linux.rocm.gpu.mi250.1
     - linux.rocm.gpu.mi250.2
     - linux.rocm.gpu.mi250.4
-    - linux.rocm.gpu.2
-    - linux.rocm.gpu.4
-    # gfx942 runners
+    # gfx942 ARC runners
     - linux.rocm.gpu.gfx942.1
     - linux.rocm.gpu.gfx942.2
     - linux.rocm.gpu.gfx942.4

--- a/.github/workflows/rocm.yml
+++ b/.github/workflows/rocm.yml
@@ -36,12 +36,12 @@ jobs:
       sync-tag: rocm-build
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 6, runner: "linux.rocm.gpu.2" },
-          { config: "default", shard: 2, num_shards: 6, runner: "linux.rocm.gpu.2" },
-          { config: "default", shard: 3, num_shards: 6, runner: "linux.rocm.gpu.2" },
-          { config: "default", shard: 4, num_shards: 6, runner: "linux.rocm.gpu.2" },
-          { config: "default", shard: 5, num_shards: 6, runner: "linux.rocm.gpu.2" },
-          { config: "default", shard: 6, num_shards: 6, runner: "linux.rocm.gpu.2" },
+          { config: "default", shard: 1, num_shards: 6, runner: "linux.rocm.gpu.mi250.1" },
+          { config: "default", shard: 2, num_shards: 6, runner: "linux.rocm.gpu.mi250.1" },
+          { config: "default", shard: 3, num_shards: 6, runner: "linux.rocm.gpu.mi250.1" },
+          { config: "default", shard: 4, num_shards: 6, runner: "linux.rocm.gpu.mi250.1" },
+          { config: "default", shard: 5, num_shards: 6, runner: "linux.rocm.gpu.mi250.1" },
+          { config: "default", shard: 6, num_shards: 6, runner: "linux.rocm.gpu.mi250.1" },
         ]}
     secrets: inherit
 

--- a/.github/workflows/rocm.yml
+++ b/.github/workflows/rocm.yml
@@ -36,12 +36,12 @@ jobs:
       sync-tag: rocm-build
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 6, runner: "linux.rocm.gpu.mi250.1" },
-          { config: "default", shard: 2, num_shards: 6, runner: "linux.rocm.gpu.mi250.1" },
-          { config: "default", shard: 3, num_shards: 6, runner: "linux.rocm.gpu.mi250.1" },
-          { config: "default", shard: 4, num_shards: 6, runner: "linux.rocm.gpu.mi250.1" },
-          { config: "default", shard: 5, num_shards: 6, runner: "linux.rocm.gpu.mi250.1" },
-          { config: "default", shard: 6, num_shards: 6, runner: "linux.rocm.gpu.mi250.1" },
+          { config: "default", shard: 1, num_shards: 6, runner: "linux.rocm.gpu.mi250.2" },
+          { config: "default", shard: 2, num_shards: 6, runner: "linux.rocm.gpu.mi250.2" },
+          { config: "default", shard: 3, num_shards: 6, runner: "linux.rocm.gpu.mi250.2" },
+          { config: "default", shard: 4, num_shards: 6, runner: "linux.rocm.gpu.mi250.2" },
+          { config: "default", shard: 5, num_shards: 6, runner: "linux.rocm.gpu.mi250.2" },
+          { config: "default", shard: 6, num_shards: 6, runner: "linux.rocm.gpu.mi250.2" },
         ]}
     secrets: inherit
 


### PR DESCRIPTION
* Moving rocm.yml from using persistent non-ARC runners from the combined MI2xx (MI210 + MI250) cluster to the ARC runners from the MI250 cluster. This halves the number of nodes, but provides access to approximately 4 times the runners, since every 8-GPU MI250 node now provides 8 1-GPU runners. This should help with concurrent capacity and queueing on the MI2xx jobs.
* This PR was reverted due to following issues:

1. I can see three different issues:
The jobs themselves are taking a long time (4.5H+). This is not something we've seen before. The specific test that's causing timeouts will take longer to triage. I'll tackle this first.
2. Some of the machines appear have issues with rocminfo. With the below error:
hsa api call failure at: /longer_pathname_so_that_rpms_can_support_packaging_the_debug_info_for_all_os_profiles/src/rocminfo/rocminfo.cc:1306
Call returned HSA_STATUS_ERROR_OUT_OF_RESOURCES: The runtime failed to allocate the necessary resources. This error may also occur when the core runtime library needs to spawn threads or create internal OS-specific events.
This error is typically resolved with a reboot. THIS ISSUE IS RESOLVED.
3. The jobs started off with really long docker pull times (1H). This decreased down to ~8M towards the later jobs. 

See HUD here:
https://hud.pytorch.org/hud/pytorch/pytorch/21131a2/1?per_page=50&name_filter=rocm&mergeEphemeralLF=true

Tested here successfully: https://github.com/pytorch/pytorch/actions/runs/18620814622/job/53092469720
cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @dllehr-amd