### PR TITLE
Add nn.Module tracking to DebugMode

### DIFF
--- a/test/distributed/tensor/debug/test_debug_mode.py
+++ b/test/distributed/tensor/debug/test_debug_mode.py
@@ -527,6 +527,7 @@ class TestDTensorDebugMode(TestCase):
                 super().__init__()
                 self.l1 = torch.nn.Linear(4, 4)
                 self.l2 = torch.nn.Linear(4, 4)
+
             def forward(self, x):
                 return self.l2(self.l1(x))
 
@@ -535,6 +536,7 @@ class TestDTensorDebugMode(TestCase):
                 super().__init__()
                 self.abc = Foo()
                 self.xyz = torch.nn.Linear(4, 4)
+
             def forward(self, x):
                 return self.xyz(self.abc(x))
 
@@ -558,6 +560,7 @@ class TestDTensorDebugMode(TestCase):
         aten::t(t: f32[4, 4])
         aten::addmm(t: f32[4], t: f32[4, 4], t: f32[4, 4])""",
         )
+
 
 instantiate_parametrized_tests(TestDTensorDebugMode)
 

--- a/torch/utils/_debug_mode.py
+++ b/torch/utils/_debug_mode.py
@@ -14,6 +14,7 @@ from torch.utils._python_dispatch import (
 from torch.utils._pytree import tree_map
 from torch.utils._traceback import CapturedTraceback
 
+
 if TYPE_CHECKING:
     from torch.distributed._tools.mod_tracker import ModTracker
 
@@ -361,7 +362,7 @@ class DebugMode(TorchDispatchMode):
 
         self.record_nn_module = record_nn_module
 
-        self.module_tracker: Optional["ModTracker"] = None
+        self.module_tracker: Optional[ModTracker] = None
         if self.record_nn_module:
             self.module_tracker_setup()
 
@@ -425,14 +426,14 @@ class DebugMode(TorchDispatchMode):
 
         super().__enter__()
         if self.record_nn_module:
-            self.module_tracker.__enter__()  # type: ignore[attribute]
+            self.module_tracker.__enter__()  # type: ignore[union-attr]
         return self
 
     # pyrefly: ignore  # bad-override
     def __exit__(self, *args):
         super().__exit__(*args)
         if self.record_nn_module:
-            self.module_tracker.__exit__()  # type: ignore[attribute]
+            self.module_tracker.__exit__()  # type: ignore[union-attr]
         if self.record_torchfunction:
             torch._C._pop_torch_function_stack()
 
@@ -443,7 +444,7 @@ class DebugMode(TorchDispatchMode):
 
         # module pre-fw hook: record module call
         def pre_fw_hook(module, input):
-            fqn = self.module_tracker._get_mod_name(module)  # type: ignore[attribute]
+            fqn = self.module_tracker._get_mod_name(module)  # type: ignore[union-attr]
             self.operators.append(_NNModuleCall(fqn, self.call_depth + 1))
             self.call_depth += 1
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #165499
* __->__ #165519
* #165498
* #165462
* #165497
* #165377
* #165461
* #165376

Apply linter fixes and update type annotations for better type safety.