### PR TITLE
Changes for Memory Management

### DIFF
--- a/aten/src/ATen/mps/MPSAllocator.mm
+++ b/aten/src/ATen/mps/MPSAllocator.mm
@@ -687,6 +687,9 @@ void MPSHeapAllocatorImpl::freeInactiveBuffers() {
 
 void MPSHeapAllocatorImpl::emptyCache() {
   std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  // Free buffers waiting for command buffer completion first
+  // This is critical - without this, buffers in buffers_pending_free accumulate indefinitely
+  freeInactiveBuffers();
   release_cached_buffers();
 }
 


### PR DESCRIPTION
# MPS Graph Cache (henceforth referred to as G-Cache) Memory Issue Analysis and fix

This PR aims to address Issue 1 from the monolithic Pull Request #164322 for Issue #164299. 

In this PR, I implement a small fix suggested in the monolith, go over the File changes, the test results of those changes on a custom [test bench](https://github.com/dharvpat/pytorch-PRs/tree/main/GCache-Issues), the link includes other models I ran on and at the end, the unit tests written for this particular change.

## File Changes:

### Python API Additions (torch/mps/__init__.py)

Three new public APIs were added to provide fine-grained control over G-Cache management:

1. **`torch.mps.empty_graph_cache()`** - Clears the MPSGraph and MPSKernel object caches
   - Primary function for managing graph accumulation
   - Should be called at strategic points (end of epoch recommended)
   - Triggers graph recompilation on next operation

2. **`torch.mps.graph_cache_size()`** - Returns the current number of cached MPSGraph objects
   - Monitoring/debugging function
   - Allows tracking cache growth during training
   - Used extensively in our testing to validate clearing strategies

3. **`torch.mps.kernel_cache_size()`** - Returns the current number of cached MPSKernel objects
   - Companion to graph_cache_size()
   - Tracks compiled Metal kernel accumulation

### C++ Backend Implementation (G-Cache Specific)

The G-Cache clearing implementation required modifications to the MPS backend:

**File: aten/src/ATen/mps/MPSHooks.mm**
- Implemented `emptyGraphCache()` to clear MPSGraph and MPSKernel caches
- Added `graphCacheSize()` and `kernelCacheSize()` accessor functions for monitoring
- Exposed these functions to Python through C bindings

**Design**: The implementation provides explicit control over graph cache lifecycle, allowing users to clear accumulated graphs without affecting other MPS subsystems. This separation enables the strategic clearing strategies validated in this analysis.

## Summary

Testing across 9 foundational model architectures (CNN, Transformer, LSTM, RNN, GRU, VAE, ResNet, UNet, AttentionLSTM) trained on junk data using the standard training loops for each of them reveals that **clearing the graph cache every epoch or every 20+ batches** is the optimal strategy for managing MPS G-Cache accumulation while not hampering runtime performance of pytorch.

Additional Plots / Source code for test bench can be found in [this repo](https://github.com/dharvpat/pytorch-PRs/tree/main/GCache-Issues)

## Scenario Breakdown

### 1. Baseline Behavior: Unbounded Linear Growth

The baseline (no cache clearing) demonstrates severe issues:

- **Linear G-Cache Growth**: All models show unbounded linear accumulation, growing ~8-10 graphs per batch (approximately 1 graph per sample in the batch)
- **Memory Pressure**: Driver-allocated memory does not grow continuously across training however, the MPSGraphCache Object count accumulates more and more graphs leading a runaway memory issue. 
- **Runtime Degradation**: **Batch processing time increases linearly over time** due to memory pressure and eventual swap usage
  - CNN: Starts at ~0.08s/batch, grows to 0.12-0.15s/batch by batch 500
  - Transformer: Similar degradation pattern, with increasing variance
  - ResNet: More pronounced effect due to larger model size
  - Each of the 9 models we tested show slowdowns between 50 and 100% in 5 epochs with 100 batches per epoch

**Root Cause**: The loop pattern creates unique graph signatures for each sample due to a variance in the index. This is an O(n) memory growth pattern that eventually exhausts available memory and forces the system into swap. Same issue is not present when using the 'cpu' device. 

### 2. Clear Every Batch: Maximum Memory Efficiency, Highest Overhead

**Results**:
- **G-Cache Growth**: Near-zero accumulation (0-60 graphs total across 500+ batches)
- **Memory**: Excellent memory control, stays constant throughout training
- **Batch Time (excl. clear)**: **~40-50% slower** than baseline
  - CNN: 0.104s vs 0.028s
  - Transformer: 0.151s vs 0.036s
  - ResNet: 0.145s vs 0.035s
  - Each of the 9 models followed this trend of slowing down dramatically (~3-10x slower)
- **Cache Clear Time**: 0.01-0.07s per batch while this is a significant overhead every iteration, it is not enough to account for all the time lost in the batch performance. 

**Discussion**:
As we can see from the charts, if we exclude cache clearing time from the Batch Processing time, the difference in performance is still there. The reason for this is still unclear to me. It is possible, the MPS backend utilizes compilation optimizations/other factors from old graphs to speed up the compilation of new graphs. 

We Can see from the baseline graphs across all models that the code is actually recompiling graphs and adding them to memory, (we can be certain that torch is re-computing graphs as if it were cache hits, they would go through the hashkey collision path defined in aten/src/ATen/native/mps/OperationUtils.h:370-388 and not be added to the cache) 

However, if we clear graphs each batch, the computaation of the next graph is significantly slower. Additionally, this puzzling behavior is exhibited in the baseline too where once every few batches, the runtime explodes. The worst spikes are over 100% slower. I am unable to process these or provide a substantial answer for them at this time.

### 3. Clear Every 20 Batches: Balanced Approach

**Results**:
- **G-Cache Growth**: Controlled sawtooth pattern (peaks at ~150-200 graphs, then clears)
- **Memory**: Stable with periodic resets
- **Batch Time (excl. clear)**: Minimal overhead (5% worse than baseline)
- **Cache Clear Time**: 0.06-0.16s once every 20 batches (negligible amortization)

**Discussion**:
Again we observe a continuation of the puzzling runtime behavior seen in Scenario 2 (Clear every Batch), When the cache is wiped, the runtime of the very next batch explodes however, a few batches after that, it returns back to baseline. This behavior could indicate that there's other optimizations being used by MPS to compile graphs.

### 4. Clear Every Epoch: Optimal Approach

**Results**:
- **G-Cache Growth**: Controlled growth within epoch (~800-900 graphs peak)
- **Memory**: Stable across epochs with periodic cleanup
- **Batch Time (excl. clear)**: Fastest and most consistent (~within margin of error of Baseline), more critically, it stays there over hundreds of batches while baseline deteriorates.
- **Cache Clear Time**: ~0.08s once per epoch (effectively zero overhead per batch)

**Why This is Optimal**:
1. **Negligible Overhead**: Clearing once per epoch has virtually no performance impact
2. **Performance Profile**: Over hundreds of batches, this methoid maintains an average runtime close to the best runtime posted by the baseline. Baseline deteriorates due to relying on Swap. Things will only get worse for baseline if we extrapolate performance out to thousands of batches.
2. **Discussion**: Following our hypothesis built from the previous two Scenarios, it is clear that this scenario supports the hypothesis. There's some other factor making performance better even when graphs are not being re-used.

## Detailed Performance Comparison for 3 models. Check attached images and source code to reproduce/study the json files provided with the data dump in [this repo](https://github.com/dharvpat/pytorch-PRs/tree/main/GCache-Issues). 

### CNN Model

| Strategy | G-Cache Growth | Avg Batch Time | Clear Overhead | Total Time |
|----------|---------------|----------------|----------------|------------|
| Baseline | 4839 graphs | 0.028s → 0.04s | N/A | 18.7s |
| Every Batch | 0 graphs | 0.104s | 0.010s | 54.3s |
| Every 20 Batches | ~90 graphs | 0.027s | 0.003s | 15.3s |
| Every Epoch | ~900 graphs | 0.020s | 0.0008s | 12.5s |

<img width="2684" height="1434" alt="cnn_comparison" src="https://github.com/user-attachments/assets/47b436f3-b7d1-4252-a41e-7fd71d8c63a3" />

### Transformer Model

| Strategy | G-Cache Growth | Avg Batch Time | Clear Overhead | Total Time |
|----------|---------------|----------------|----------------|------------|
| Baseline | 4868 graphs | 0.025s → 0.04s | N/A | 18.7s |
| Every Batch | 0 graphs | 0.151s | 0.015s | 76.5s |
| Every 20 Batches | ~80 graphs | 0.039s | 0.004s | 20.0s |
| Every Epoch | ~900 graphs | 0.026s | 0.0008s | 14.5s |

<img width="2684" height="1434" alt="transformer_comparison" src="https://github.com/user-attachments/assets/0ee82f8b-4808-4af9-8388-f47d73e6e89d" />

### ResNet Model

| Strategy | G-Cache Growth | Avg Batch Time | Clear Overhead | Total Time |
|----------|---------------|----------------|----------------|------------|
| Baseline | 4863 graphs | 0.025s → 0.04s | N/A | 18.7s |
| Every Batch | 0 graphs | 0.145s | 0.014s | 73.7s |
| Every 20 Batches | ~80 graphs | 0.035s | 0.003s | 18.6s |
| Every Epoch | ~900 graphs | 0.024s | 0.0008s | 13.9s |

<img width="2684" height="1434" alt="resnet_comparison" src="https://github.com/user-attachments/assets/a86941b1-2ad3-4e0d-8fb8-74ad89da1ff7" />

## Baseline Runtime - Discussion

The baseline shows a clear **linear increase in batch processing time** over the course of training:

1. **Initial Phase (Batches 0-100)**: Fast execution with sufficient memory
2. **Memory Pressure Phase (Batches 100-300)**: Gradual slowdown as G-Cache grows to 2000+ graphs
3. **Swap Phase (Batches 300+)**: Significant degradation as system begins swapping

**Memory Exhaustion Timeline**:
- G-Cache grows at ~8-10 graphs/batch
- By batch 500: 4000-5000 graphs cached
- Eventually exceeds available system memory, forcing system to swap graph data to/from main memory or disk. This point of transition may come later in systems with higher memory configs but it will come nonetheless.

This swap activity adds latency to **every graph lookup and execution**, causing the observed linear runtime degradation.

## Recommended Strategy: 
(This removes the platform-agnostic approach that pytorch is known for but it is a relatively small addition that can make the lives of users a lot simpler)

### For Training
**Clear every epoch** (`torch.mps.empty_graph_cache()` at end of each epoch)

**Rationale**:
- Prevents unbounded growth across multi-epoch training
- Amortizes compilation cost across entire epoch
- Eliminates swap-induced runtime degradation
- Minimal overhead
- Total training time reduced compared to baseline and per-batch clearing. The reduction of runtime for per-batch clearing is ~4x reduction in time but the reduction compared to baseline depends on the number of epochs, generally: the more epochs that you have, the better it will be to clear cache every epoch.

## Conclusion

1. **Unbounded baseline growth is unsustainable**: Linear G-Cache accumulation leads to memory exhaustion and swap-dependence evn for smaller models leading to a limit on epochs that the user can run.

2. **Clearing every batch is counterproductive**: The compilation overhead negates any memory benefits, resulting in 3-4x slower training

3. **Clearing every epoch is optimal**: Provides excellent memory control with negligible overhead, reducing total training time by 75-80% compared to clearing every batch and compared to baseline it allows the user to train for a lot more epochs at near stable execution times (except for 1 or 2 batches after clearing the cache)

4. **Graph reuse is critical**: This PR sidesteps the issue of why Graphs are not being re-used and instead focuses on making the cache sustainable. The core problem lies in the fact that we have setup a cache to directly reuse computation graphs but that system is failing to do so. I suspect the issue is with some scalars associated with the computation graph but I can't be certain. 

5. **Batch time degradation is real**: Baseline shows clear linear runtime increase due to reliance on swap memory and incurring SSD-speed slowdowns, validating the need for periodic cache management

---
---

# G-Cache Unit Tests

## Summary

Unit tests have been added to validate the three new G-Cache management APIs:

### Python APIs Tested
1. `torch.mps.empty_graph_cache()` - Clears MPSGraph and MPSKernel caches, returns Nothing 
2. `torch.mps.graph_cache_size()` - Returns number of cached MPSGraph objects
3. `torch.mps.kernel_cache_size()` - Returns number of cached MPSKernel objects

### C++ Backend Functions Tested (via Python APIs)
1. `MPSHooks::emptyGraphCache()` - Implementation in `aten/src/ATen/mps/MPSHooks.mm`
2. `MPSHooks::graphCacheSize()` - Implementation in `aten/src/ATen/mps/MPSHooks.mm`
3. `MPSHooks::kernelCacheSize()` - Implementation in `aten/src/ATen/mps/MPSHooks.mm`

## Test File Location

**File**: `test/test_mps.py`

**Test Class**: `TestGraphCache` (lines 12634-12750)

## Test Suite Breakdown

### 1. `test_graph_cache_size_returns_int()`
**Purpose**: Verify `torch.mps.graph_cache_size()` returns a non-negative integer.

**File reference**: `test/test_mps.py:12648-12652`

---

### 2. `test_kernel_cache_size_returns_int()`
**Purpose**: Verify `torch.mps.kernel_cache_size()` returns a non-negative integer.

**File reference**: `test/test_mps.py:12654-12658`

---

### 3. `test_empty_graph_cache_callable()`
**Purpose**: Verify `torch.mps.empty_graph_cache()` executes without errors.

**File reference**: `test/test_mps.py:12660-12664`

---

### 4. `test_empty_graph_cache_clears_graph_cache()`
**Purpose**: Verify `empty_graph_cache()` actually clears the graph cache to zero.

**File reference**: `test/test_mps.py:12666-12679`

**C++ function tested**: `MPSGraphCache::clearCache()` (called via `MPSHooks::emptyGraphCache()`)

---

### 5. `test_empty_graph_cache_clears_kernel_cache()`
**Purpose**: Verify `empty_graph_cache()` also clears the kernel cache to zero.

**File reference**: `test/test_mps.py:12681-12694`

**C++ function tested**: `MPSKernelCache::clearCache()` (called via `MPSHooks::emptyGraphCache()`)

---

### 6. `test_operations_work_after_cache_clear()`
**Purpose**: Verify operations produce correct results after cache clearing.

**File reference**: `test/test_mps.py:12696-12711`

**Why this matters**: When cache is cleared, graphs must be recompiled on next use. This test ensures recompilation produces correct results.

---

### 7. `test_multiple_clear_operations_safe()`
**Purpose**: Verify calling `empty_graph_cache()` multiple times is safe.

**File reference**: `test/test_mps.py:12713-12720`

---

### 8. `test_cache_clear_with_synchronize()`
**Purpose**: Test the recommended pattern: synchronize before clearing cache.

**File reference**: `test/test_mps.py:12722-12734`

**Recommended pattern validated**:
```python
torch.mps.synchronize()
torch.mps.empty_graph_cache()
```

---

### 9. `test_empty_cache_integration()`
**Purpose**: Test integration between `empty_cache()` and `empty_graph_cache()`.

**File reference**: `test/test_mps.py:12736-12750`

**Recommended pattern validated**:
```python
torch.mps.empty_graph_cache()
torch.mps.empty_cache()
```

---

## Running the Tests

### Run all Graph Cache tests:
```bash
python test/test_mps.py TestGraphCache -v
```

### Run specific test:
```bash
python test/test_mps.py TestGraphCache.test_empty_graph_cache_clears_graph_cache -v
```
---

## C++ Backend Coverage

All three C++ functions are tested indirectly through the Python API tests:

1. **`MPSHooks::graphCacheSize()`**
   - Tested by: All tests that call `torch.mps.graph_cache_size()`
   - Implementation: `aten/src/ATen/mps/MPSHooks.mm`

2. **`MPSHooks::kernelCacheSize()`**
   - Tested by: All tests that call `torch.mps.kernel_cache_size()`
   - Implementation: `aten/src/ATen/mps/MPSHooks.mm`

3. **`MPSHooks::emptyGraphCache()`**
   - Tested by: All tests that call `torch.mps.empty_graph_cache()`
   - Implementation: `aten/src/ATen/mps/MPSHooks.mm`
   - Internally calls:
     - `MPSGraphCache::clearCache()` - Clears graph cache
     - `MPSKernelCache::clearCache()` - Clears kernel cache

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @mcarilli @ptrblck @leslie-fang-intel @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @xmfan @chenyang78