### PR TITLE
In pipeline parallelism: Use same dtype for receive and send tensor when initializing p2p communication.

### DIFF
--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -932,8 +932,8 @@ class _PipelineStageBase(ABC):
         next_stage_peer_rank = self.stage_index_to_group_rank.get(self.stage_index + 1)
         prev_stage_peer_rank = self.stage_index_to_group_rank.get(self.stage_index - 1)
 
-        recv_tensor = torch.zeros(1, device=self.device)
-        send_tensor = torch.tensor(self.stage_index, device=self.device)
+        recv_tensor = torch.zeros(1, device=self.device, dtype=torch.float32)
+        send_tensor = torch.tensor(self.stage_index, device=self.device, dtype=torch.float32)
         # forward
         if not self.is_first:
             ops.append(

--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -933,7 +933,9 @@ class _PipelineStageBase(ABC):
         prev_stage_peer_rank = self.stage_index_to_group_rank.get(self.stage_index - 1)
 
         recv_tensor = torch.zeros(1, device=self.device, dtype=torch.float32)
-        send_tensor = torch.tensor(self.stage_index, device=self.device, dtype=torch.float32)
+        send_tensor = torch.tensor(
+            self.stage_index, device=self.device, dtype=torch.float32
+        )
         # forward
         if not self.is_first:
             ops.append(


### PR DESCRIPTION
When initializing the p2p communication for pipeline parallelism, currently different default dtypes are used for the send and receive tensor here:
https://github.com/pytorch/pytorch/blob/5c583e2573f29243742e00b9fa36b266c5c78bb3/torch/distributed/pipelining/stage.py#L935-L936

This caused hard to trace issues when training on multiple nodes. Multiple stages on one node seem to work for some reason which probably caused the unit tests not to catch this.

Fixes #165143



cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci