### PR TITLE
[export] Unified graph capture with fullgraph_capture.

### DIFF
--- a/torch/_dynamo/functional_export.py
+++ b/torch/_dynamo/functional_export.py
@@ -1,6 +1,8 @@
+import copy
 import inspect
 import logging
 import traceback
+import types
 from collections import namedtuple
 from typing import Any, Callable, Optional, TYPE_CHECKING, Union
 
@@ -26,6 +28,7 @@ from torch.fx.graph import _PyTreeCodeGen, _PyTreeInfo
 
 if TYPE_CHECKING:
     from torch._subclasses.fake_tensor import FakeTensorMode
+    from torch.utils._pytree import TreeSpec
 
 
 log = logging.getLogger(__name__)
@@ -444,6 +447,140 @@ def _suggest_or_raise_constraint_violation(
             constraint_violation_error, orig_callable, args, kwargs
         )
         raise constraint_violation_error
+
+
+def pytreeify(
+    out: CaptureOutput, mod: Any, args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> Any:
+    """
+    Given a dynamo capture output, return a callable graph module that
+    contain the following information:
+    1. input/output pytree spec
+    2. input/output shuffle functions
+    Input shuffle functions are the converters taking pytree falttened inputs
+    and reorder them to the calling convention of dynamo raw graph module.
+    Output shuffle functions are the converters taking the outputs of the
+    dynamo raw graph module and convert them to the pytree format.
+
+    This function will replay any side effects that happened during the bytecode,
+    so it is important to check against side effects before calling this function.
+    """
+    assert out.backend_input is not None
+    backend_input = out.backend_input
+    backend = out.backend_input.graph_module
+
+    if isinstance(mod, torch.nn.Module):
+        args = (mod,) + args
+    elif inspect.ismethod(mod):
+        args = (mod.__self__,) + args
+
+    flat_real_args, in_spec = pytree.tree_flatten((args, kwargs))
+
+    class Yield(Exception):
+        pass
+
+    class InShuffle(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.mod = mod
+            self.num_inputs = len(flat_real_args)
+            self.gm_inputs = None
+
+        def forward(self, *flat_proxy_args):
+            args, kwargs = pytree.tree_unflatten(
+                [flat_proxy_args[i] for i in range(self.num_inputs)], in_spec
+            )
+
+            def backend_dummy(*example_inputs):
+                self.gm_inputs = example_inputs
+                raise Yield
+
+            backend_input.graph_module = backend_dummy  # type: ignore[assignment]
+            try:
+                out.forward_callable()(*args, **kwargs)
+            except Yield:
+                assert self.gm_inputs is not None
+                return self.gm_inputs
+            finally:
+                backend_input.graph_module = backend
+            raise RuntimeError
+
+    in_shuffle_graph = torch.fx.symbolic_trace(InShuffle())
+
+    class OutShuffle(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.num_inputs = len(flat_real_args)
+            self.num_outputs = len(
+                next(iter(reversed(backend_input.graph_module.graph.nodes))).args[0]
+            )
+            self.out_spec: Optional[TreeSpec] = None
+
+        def forward(self, *flat_proxy_args):
+            args, kwargs = pytree.tree_unflatten(
+                [flat_proxy_args[i] for i in range(self.num_inputs)], in_spec
+            )
+
+            def backend_dummy(*example_inputs):
+                return [
+                    flat_proxy_args[self.num_inputs + i]
+                    for i in range(self.num_outputs)
+                ]
+
+            backend_input.graph_module = backend_dummy  # type: ignore[assignment]
+            try:
+                results = out.forward_callable()(*args, **kwargs)
+            finally:
+                backend_input.graph_module = backend
+            ret, self.out_spec = pytree.tree_flatten(results)
+            return ret
+
+    out_shuffle = OutShuffle()
+    out_shuffle_graph = torch.fx.symbolic_trace(out_shuffle)
+
+    def pytree_call(*args, **kwargs):
+        import torch.export._unlift
+
+        flat_args, in_spec_runtime = pytree.tree_flatten((args, kwargs))
+        if not torch.export._unlift.eq_spec(in_spec_runtime, in_spec):
+            raise RuntimeError(
+                f"Model input mismatch. Expected input spec: {in_spec}. Actual input spec: {in_spec_runtime}"
+            )
+        flat_outs = backend_input.graph_module(*in_shuffle_graph(*flat_args))
+        assert out_shuffle.out_spec is not None
+        return pytree.tree_unflatten(
+            out_shuffle_graph(*flat_args, *flat_outs), out_shuffle.out_spec
+        )
+
+    if isinstance(mod, torch.nn.Module):
+        compiled_mod = copy.copy(mod)
+        compiled_mod.forward = types.MethodType(pytree_call, compiled_mod)
+        if not hasattr(compiled_mod, "meta"):
+            compiled_mod.meta = {}  # type: ignore[attr-defined]
+        if isinstance(compiled_mod.meta, dict) and "fake_mode" not in compiled_mod.meta:
+            compiled_mod.meta["fake_mode"] = out.backend_input.fake_mode
+        return compiled_mod
+    elif inspect.ismethod(mod):
+        return types.MethodType(pytree_call, mod.__self__)
+    else:
+        return pytree_call
+
+
+def dynamo_graph_capture_for_export(
+    mod: Callable[..., Any],
+) -> Callable[..., Any]:
+    def inner(*args: Any, **kwargs: Any) -> Any:
+        with (
+            get_metrics_context(),
+            dynamo_timed("fullgraph_capture"),
+        ):
+            out = fullgraph_capture(mod, args, kwargs)
+
+        # TODO filter out side effects.
+
+        return pytreeify(out, mod, args, kwargs)
+
+    return inner
 
 
 def _dynamo_graph_capture_for_export(

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -463,6 +463,7 @@ class OutputGraphCommon(OutputGraphGuardsState):
     def __init__(
         self,
         output_graph_guards_state: OutputGraphGuardsState,
+        import_sources: Optional[dict[str, str]] = None,
         shape_env: Optional[ShapeEnv] = None,
         export_metadata: Optional[ExportMetaData] = None,
         tracked_fakes_id_to_source: Optional[dict[int, list[Source]]] = None,
@@ -485,6 +486,7 @@ class OutputGraphCommon(OutputGraphGuardsState):
             output_graph_guards_state.name_of_builtins_dict_key_in_fglobals,
         )
 
+        self.import_sources = import_sources or {}
         # The following fields are currently known to be used by clients.
         # In particular, we need:
         # - shape_env, for building guards


### PR DESCRIPTION
Summary:
_dynamo_graph_capture_for_export in the current form has the compability issue
with the main torch.compile() path despite we reuse fullgraph_capture as the
bytecode tracer. The reason is that we flip on many export specific flags
and even trace with a wrapped function which will cause divergence with
torch.compile() again.

This PR instead creates a new implementation of dynamo_graph_capture_for_export
which 100% relies on fullgraph capture and post-processing on CaptureOutput so
that we can avoid the inversion of phases in PT2 compiler stack.

This also benefits precompile workflow since we want to have a feature that
only accepts pytree inputs and ship portable python wrappers in package. In
other words, I think the code here is sharable between export and precompile
for exporting portable graph.

Test Plan:
===================================================================== test session starts =====================================================================
platform linux -- Python 3.12.11, pytest-7.3.2, pluggy-1.6.0
rootdir: /data/users/zhxchen17/pytorch
configfile: pytest.ini
plugins: xdoctest-1.1.0, hypothesis-5.35.1, xdist-3.3.1, subtests-0.13.1, rerunfailures-14.0, flakefinder-1.1.0, cpp-2.3.0, anyio-4.10.0
collected 9 items
Running 9 items in this shard

test/distributed/tensor/test_dtensor_export.py ........x                                                                                                [100%]

================================================================ 8 passed, 1 xfailed in 11.42s ================================================================

Reviewers:

Subscribers:

Tasks:

Tags:

Fixes #ISSUE_NUMBER


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela