### PR TITLE
[ROCm] Add more timm models, forward fix #165381

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/aot_eager_timm_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/aot_eager_timm_inference.csv
@@ -10,7 +10,15 @@ beit_base_patch16_224,pass,0
 
 
 
+convnextv2_nano.fcmae_ft_in22k_in1k,pass,0
+
+
+
 deit_base_distilled_patch16_224,pass,0
+
+
+
+deit_tiny_patch16_224.fb_in1k,pass,0
 
 
 
@@ -55,3 +63,11 @@ tf_efficientnet_b0,pass,0
 
 
 visformer_small,pass,0
+
+
+
+vit_base_patch14_dinov2.lvd142m,pass,0
+
+
+
+vit_base_patch16_siglip_256,pass,0

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/aot_eager_timm_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/aot_eager_timm_training.csv
@@ -10,7 +10,15 @@ beit_base_patch16_224,pass,7
 
 
 
+convnextv2_nano.fcmae_ft_in22k_in1k,pass,7
+
+
+
 deit_base_distilled_patch16_224,pass,7
+
+
+
+deit_tiny_patch16_224.fb_in1k,pass,7
 
 
 
@@ -55,3 +63,11 @@ tf_efficientnet_b0,pass,6
 
 
 visformer_small,pass,7
+
+
+
+vit_base_patch14_dinov2.lvd142m,pass,7
+
+
+
+vit_base_patch16_siglip_256,pass,7

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/aot_inductor_timm_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/aot_inductor_timm_inference.csv
@@ -10,7 +10,15 @@ beit_base_patch16_224,pass,0
 
 
 
+convnextv2_nano.fcmae_ft_in22k_in1k,pass,0
+
+
+
 deit_base_distilled_patch16_224,pass,0
+
+
+
+deit_tiny_patch16_224.fb_in1k,pass,0
 
 
 
@@ -55,3 +63,11 @@ tf_efficientnet_b0,pass,0
 
 
 visformer_small,pass,0
+
+
+
+vit_base_patch14_dinov2.lvd142m,pass,0
+
+
+
+vit_base_patch16_siglip_256,pass,0

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_aot_eager_timm_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_aot_eager_timm_inference.csv
@@ -10,7 +10,15 @@ beit_base_patch16_224,pass,0
 
 
 
+convnextv2_nano.fcmae_ft_in22k_in1k,pass,0
+
+
+
 deit_base_distilled_patch16_224,pass,0
+
+
+
+deit_tiny_patch16_224.fb_in1k,pass,0
 
 
 
@@ -55,3 +63,11 @@ tf_efficientnet_b0,pass,0
 
 
 visformer_small,pass,0
+
+
+
+vit_base_patch14_dinov2.lvd142m,pass,0
+
+
+
+vit_base_patch16_siglip_256,pass,0

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_aot_eager_timm_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_aot_eager_timm_training.csv
@@ -10,7 +10,15 @@ beit_base_patch16_224,pass,7
 
 
 
+convnextv2_nano.fcmae_ft_in22k_in1k,pass,7
+
+
+
 deit_base_distilled_patch16_224,pass,7
+
+
+
+deit_tiny_patch16_224.fb_in1k,pass,7
 
 
 
@@ -55,3 +63,11 @@ tf_efficientnet_b0,pass,6
 
 
 visformer_small,pass,7
+
+
+
+vit_base_patch14_dinov2.lvd142m,pass,7
+
+
+
+vit_base_patch16_siglip_256,pass,7

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_inductor_timm_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_inductor_timm_inference.csv
@@ -10,7 +10,15 @@ beit_base_patch16_224,pass,0
 
 
 
+convnextv2_nano.fcmae_ft_in22k_in1k,pass,0
+
+
+
 deit_base_distilled_patch16_224,pass,0
+
+
+
+deit_tiny_patch16_224.fb_in1k,pass,0
 
 
 
@@ -55,3 +63,11 @@ tf_efficientnet_b0,pass,0
 
 
 visformer_small,pass,0
+
+
+
+vit_base_patch14_dinov2.lvd142m,pass,0
+
+
+
+vit_base_patch16_siglip_256,pass,0

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_inductor_timm_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_inductor_timm_training.csv
@@ -10,7 +10,15 @@ beit_base_patch16_224,pass,7
 
 
 
+convnextv2_nano.fcmae_ft_in22k_in1k,pass,7
+
+
+
 deit_base_distilled_patch16_224,pass,7
+
+
+
+deit_tiny_patch16_224.fb_in1k,pass,7
 
 
 
@@ -55,3 +63,11 @@ tf_efficientnet_b0,pass,6
 
 
 visformer_small,fail_accuracy,7
+
+
+
+vit_base_patch14_dinov2.lvd142m,pass,7
+
+
+
+vit_base_patch16_siglip_256,pass,7

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamo_eager_timm_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamo_eager_timm_inference.csv
@@ -10,7 +10,15 @@ beit_base_patch16_224,pass,0
 
 
 
+convnextv2_nano.fcmae_ft_in22k_in1k,pass,0
+
+
+
 deit_base_distilled_patch16_224,pass,0
+
+
+
+deit_tiny_patch16_224.fb_in1k,pass,0
 
 
 
@@ -55,3 +63,11 @@ tf_efficientnet_b0,pass,0
 
 
 visformer_small,pass,0
+
+
+
+vit_base_patch14_dinov2.lvd142m,pass,0
+
+
+
+vit_base_patch16_siglip_256,pass,0

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamo_eager_timm_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamo_eager_timm_training.csv
@@ -10,7 +10,15 @@ beit_base_patch16_224,pass,7
 
 
 
+convnextv2_nano.fcmae_ft_in22k_in1k,pass,7
+
+
+
 deit_base_distilled_patch16_224,pass,7
+
+
+
+deit_tiny_patch16_224.fb_in1k,pass,7
 
 
 
@@ -55,3 +63,11 @@ tf_efficientnet_b0,pass,6
 
 
 visformer_small,pass,7
+
+
+
+vit_base_patch14_dinov2.lvd142m,pass,7
+
+
+
+vit_base_patch16_siglip_256,pass,7

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/inductor_timm_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/inductor_timm_inference.csv
@@ -10,7 +10,15 @@ beit_base_patch16_224,pass,0
 
 
 
+convnextv2_nano.fcmae_ft_in22k_in1k,pass,0
+
+
+
 deit_base_distilled_patch16_224,pass,0
+
+
+
+deit_tiny_patch16_224.fb_in1k,pass,0
 
 
 
@@ -55,3 +63,11 @@ tf_efficientnet_b0,pass,0
 
 
 visformer_small,pass,0
+
+
+
+vit_base_patch14_dinov2.lvd142m,pass,0
+
+
+
+vit_base_patch16_siglip_256,pass,0

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/inductor_timm_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/inductor_timm_training.csv
@@ -10,7 +10,15 @@ beit_base_patch16_224,pass,7
 
 
 
+convnextv2_nano.fcmae_ft_in22k_in1k,fail_accuracy,7
+
+
+
 deit_base_distilled_patch16_224,pass,7
+
+
+
+deit_tiny_patch16_224.fb_in1k,pass,7
 
 
 
@@ -55,3 +63,11 @@ tf_efficientnet_b0,pass,6
 
 
 visformer_small,pass,7
+
+
+
+vit_base_patch14_dinov2.lvd142m,fail_accuracy,7
+
+
+
+vit_base_patch16_siglip_256,pass,7


### PR DESCRIPTION
PR #165381 added timm models to cuda and cpu expected accuracy files. ROCm expected accuracy files were not updated.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela