### PR TITLE
[MPS] Allocate `MPSGraphPooling2DOpDescriptor` with autorelease

### DIFF
--- a/aten/src/ATen/native/mps/operations/Pooling.mm
+++ b/aten/src/ATen/native/mps/operations/Pooling.mm
@@ -167,19 +167,19 @@ static void pool2d_template(const Tensor& input,
 
     auto cachedGraph = LookUpOrCreateCachedGraph<PoolingCachedGraph>(key, [&](auto* mpsGraph, auto* newCachedGraph) {
       MPSGraphPooling2DOpDescriptor* desc = [[MPSGraphPooling2DOpDescriptor
-      descriptorWithKernelWidth:kW
-                   kernelHeight:kH
-                      strideInX:dW
-                      strideInY:dH
-                dilationRateInX:dilationW
-                dilationRateInY:dilationH
-                    paddingLeft:padW
-                   paddingRight:ceil_mode ? padW * dW : padW
-                     paddingTop:padH
-                  paddingBottom:ceil_mode ? padH * dH : padH
-                   paddingStyle:MPSGraphPaddingStyleExplicit
-                     dataLayout:memory_format == MemoryFormat::ChannelsLast ? MPSGraphTensorNamedDataLayoutNHWC
-                                                                            : MPSGraphTensorNamedDataLayoutNCHW] autorelease];
+          descriptorWithKernelWidth:kW
+                       kernelHeight:kH
+                          strideInX:dW
+                          strideInY:dH
+                    dilationRateInX:dilationW
+                    dilationRateInY:dilationH
+                        paddingLeft:padW
+                       paddingRight:ceil_mode ? padW * dW : padW
+                         paddingTop:padH
+                      paddingBottom:ceil_mode ? padH * dH : padH
+                       paddingStyle:MPSGraphPaddingStyleExplicit
+                         dataLayout:memory_format == MemoryFormat::ChannelsLast ? MPSGraphTensorNamedDataLayoutNHWC
+                                                                                : MPSGraphTensorNamedDataLayoutNCHW] autorelease];
       desc.ceilMode = (padW == 0 && padH == 0) ? ceil_mode : false;
       if (has_indices) {
         desc.returnIndicesMode = MPSGraphPoolingReturnIndicesGlobalFlatten2D;

--- a/aten/src/ATen/native/mps/operations/Pooling.mm
+++ b/aten/src/ATen/native/mps/operations/Pooling.mm
@@ -166,20 +166,20 @@ static void pool2d_template(const Tensor& input,
     MPSShape* gradOutputShape = is_backward_pass ? getMPSShape(grad_output, memory_format) : nullptr;
 
     auto cachedGraph = LookUpOrCreateCachedGraph<PoolingCachedGraph>(key, [&](auto* mpsGraph, auto* newCachedGraph) {
-      MPSGraphPooling2DOpDescriptor* desc = [MPSGraphPooling2DOpDescriptor
-          descriptorWithKernelWidth:kW
-                       kernelHeight:kH
-                          strideInX:dW
-                          strideInY:dH
-                    dilationRateInX:dilationW
-                    dilationRateInY:dilationH
-                        paddingLeft:padW
-                       paddingRight:ceil_mode ? padW * dW : padW
-                         paddingTop:padH
-                      paddingBottom:ceil_mode ? padH * dH : padH
-                       paddingStyle:MPSGraphPaddingStyleExplicit
-                         dataLayout:memory_format == MemoryFormat::ChannelsLast ? MPSGraphTensorNamedDataLayoutNHWC
-                                                                                : MPSGraphTensorNamedDataLayoutNCHW];
+      MPSGraphPooling2DOpDescriptor* desc = [[MPSGraphPooling2DOpDescriptor
+      descriptorWithKernelWidth:kW
+                   kernelHeight:kH
+                      strideInX:dW
+                      strideInY:dH
+                dilationRateInX:dilationW
+                dilationRateInY:dilationH
+                    paddingLeft:padW
+                   paddingRight:ceil_mode ? padW * dW : padW
+                     paddingTop:padH
+                  paddingBottom:ceil_mode ? padH * dH : padH
+                   paddingStyle:MPSGraphPaddingStyleExplicit
+                     dataLayout:memory_format == MemoryFormat::ChannelsLast ? MPSGraphTensorNamedDataLayoutNHWC
+                                                                            : MPSGraphTensorNamedDataLayoutNCHW] autorelease];
       desc.ceilMode = (padW == 0 && padH == 0) ? ceil_mode : false;
       if (has_indices) {
         desc.returnIndicesMode = MPSGraphPoolingReturnIndicesGlobalFlatten2D;

--- a/aten/src/ATen/native/mps/operations/Pooling.mm
+++ b/aten/src/ATen/native/mps/operations/Pooling.mm
@@ -166,20 +166,20 @@ static void pool2d_template(const Tensor& input,
     MPSShape* gradOutputShape = is_backward_pass ? getMPSShape(grad_output, memory_format) : nullptr;
 
     auto cachedGraph = LookUpOrCreateCachedGraph<PoolingCachedGraph>(key, [&](auto* mpsGraph, auto* newCachedGraph) {
-      auto desc = [[MPSGraphPooling2DOpDescriptor
-          descriptorWithKernelWidth:kW
-                       kernelHeight:kH
-                          strideInX:dW
-                          strideInY:dH
-                    dilationRateInX:dilationW
-                    dilationRateInY:dilationH
-                        paddingLeft:padW
-                       paddingRight:ceil_mode ? padW * dW : padW
-                         paddingTop:padH
-                      paddingBottom:ceil_mode ? padH * dH : padH
-                       paddingStyle:MPSGraphPaddingStyleExplicit
-                         dataLayout:memory_format == MemoryFormat::ChannelsLast ? MPSGraphTensorNamedDataLayoutNHWC
-                                                                                : MPSGraphTensorNamedDataLayoutNCHW] autorelease];
+      auto desc = [[MPSGraphPooling2DOpDescriptor descriptorWithKernelWidth:kW
+                                                               kernelHeight:kH
+                                                                  strideInX:dW
+                                                                  strideInY:dH
+                                                            dilationRateInX:dilationW
+                                                            dilationRateInY:dilationH
+                                                                paddingLeft:padW
+                                                               paddingRight:ceil_mode ? padW * dW : padW
+                                                                 paddingTop:padH
+                                                              paddingBottom:ceil_mode ? padH * dH : padH
+                                                               paddingStyle:MPSGraphPaddingStyleExplicit
+                                                                 dataLayout:memory_format == MemoryFormat::ChannelsLast
+                                                                     ? MPSGraphTensorNamedDataLayoutNHWC
+                                                                     : MPSGraphTensorNamedDataLayoutNCHW] autorelease];
       desc.ceilMode = (padW == 0 && padH == 0) ? ceil_mode : false;
       if (has_indices) {
         desc.returnIndicesMode = MPSGraphPoolingReturnIndicesGlobalFlatten2D;

--- a/aten/src/ATen/native/mps/operations/Pooling.mm
+++ b/aten/src/ATen/native/mps/operations/Pooling.mm
@@ -166,7 +166,7 @@ static void pool2d_template(const Tensor& input,
     MPSShape* gradOutputShape = is_backward_pass ? getMPSShape(grad_output, memory_format) : nullptr;
 
     auto cachedGraph = LookUpOrCreateCachedGraph<PoolingCachedGraph>(key, [&](auto* mpsGraph, auto* newCachedGraph) {
-      MPSGraphPooling2DOpDescriptor* desc = [[MPSGraphPooling2DOpDescriptor
+      auto desc = [[MPSGraphPooling2DOpDescriptor
           descriptorWithKernelWidth:kW
                        kernelHeight:kH
                           strideInX:dW


### PR DESCRIPTION
## Description
This PR fixes Objective-C memory leaks in MPS operations by adding proper `autorelease` calls to MPSGraph descriptor objects. The fixes follow the same pattern established in PR #154765 for Linear.mm.

## Changes
  - **Pooling.mm**: Added `autorelease` to MPSGraphPooling2DOpDescriptor creation

## Problem
MPS operations were creating Objective-C objects without proper memory management, leading to memory leaks in the MPS backend. The descriptor objects created using factory methods like `[MPSGraphPooling2DOpDescriptor descriptorWith...]` were not being released, causing gradual memory accumulation.

## Solution
Apply the same fix pattern from PR #154765 by wrapping descriptor creation with `[[...] autorelease]` to ensure proper memory management through Objective-C's autorelease pool system.

## Related PR
  - Inspired by #154765 which fixed similar issues in Linear.mm