### PR TITLE
Better error handling in torch/csrc/jit/passes by replacing std::runtime_error with TORCH_CHECK in passes

### DIFF
--- a/torch/csrc/jit/passes/dtype_analysis.cpp
+++ b/torch/csrc/jit/passes/dtype_analysis.cpp
@@ -1,5 +1,7 @@
 #include <ATen/core/jit_type.h>
 #include <c10/util/ArrayRef.h>
+#include <c10/util/Exception.h>
+#include <torch/csrc/jit/ir/alias_analysis.h>
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/passes/dtype_analysis.h>
@@ -45,14 +47,15 @@ std::unique_ptr<Stack> MTensorArgumentCreator(Node* n) {
     } else if (inp->type() == IntType::get()) {
       stack->emplace_back(1);
     } else if (inp->type() == BoolType::get()) {
-      throw std::runtime_error(
+      TORCH_CHECK(
+          false,
           "Bool currently unsupported, need to verify it's safe to add for all ops");
       stack->emplace_back(false);
     } else {
       // Arrays of values are specifically not handled due
       // to the fact that naive default values would likely be
       // incorrect anyways.
-      throw std::runtime_error("Unsupported input type for Tensor argument");
+      TORCH_CHECK(false, "Unsupported input type for Tensor argument");
     }
   }
   return stack;

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -359,10 +359,9 @@ struct GraphFuser {
           // the scalar is constant. In those cases we inline the constants
           // directly in the body of the fused group.
           AT_ASSERT(input->node()->kind() == prim::Constant);
-          Node* in_const =
-              subgraph.createClone(input->node(), [](Value*) -> Value* {
-                throw std::runtime_error("unexpected input");
-              });
+          Node* in_const = subgraph.createClone(
+              input->node(),
+              [](Value*) -> Value* { TORCH_CHECK(false, "unexpected input"); });
           subgraph.insertNode(in_const);
           inputs_map[input] = in_const->output();
         }

--- a/torch/csrc/jit/passes/inplace_check.cpp
+++ b/torch/csrc/jit/passes/inplace_check.cpp
@@ -1,15 +1,17 @@
 #include <torch/csrc/jit/passes/inplace_check.h>
 
+#include <c10/util/Exception.h>
+
 namespace torch::jit {
 
 static void CheckInplace(Block* block) {
   for (auto node : block->nodes()) {
     if (node->kind() == prim::PythonOp && node->hasAttribute(attr::inplace)) {
-      if (node->i(attr::inplace)) {
-        throw std::runtime_error(
-            std::string("inplace ") + static_cast<PythonOp*>(node)->name() +
-            " not supported in the JIT");
-      }
+      TORCH_CHECK(
+          !node->i(attr::inplace),
+          "inplace ",
+          static_cast<PythonOp*>(node)->name(),
+          " not supported in the JIT");
     }
   }
 }


### PR DESCRIPTION
Replace standard C++ exception throwing with PyTorch's TORCH_CHECK macro across JIT pass files for consistent error handling:

- dtype_analysis.cpp: Convert two runtime_error throws to TORCH_CHECK
- graph_fuser.cpp: Convert runtime_error throw to TORCH_CHECK
- inplace_check.cpp: Refactor if-throw pattern to use TORCH_CHECK

This standardizes error handling to use PyTorch's established exception framework, which provides better error messages and consistent behavior.

Fixes #148114

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel