### PR TITLE
Give a friendly message for older Intel GPU

### DIFF
--- a/c10/xpu/XPUFunctions.cpp
+++ b/c10/xpu/XPUFunctions.cpp
@@ -131,8 +131,8 @@ inline void initGlobalDevicePoolState() {
           "The detected GPU (",
           device->get_info<sycl::info::device::name>(),
           ") is not officially supported by PyTorch XPU. Running workloads on this device may result in ",
-          "unexpected behavior, reduced performance, or runtime errors.\n",
-          "For stable and fully supported execution, please use GPUs based on Intel Arc Alchemist series or newer.\n",
+          "unexpected behavior, reduced performance, or even runtime errors.\n",
+          "For stable and fully supported execution, please use GPUs based on Intel Arc (Alchemist) series or newer.\n",
           "Refer to the hardware prerequisites for more information: ",
           "https://github.com/pytorch/pytorch/blob/main/docs/source/notes/get_start_xpu.rst#hardware-prerequisite");
     }

--- a/c10/xpu/XPUFunctions.cpp
+++ b/c10/xpu/XPUFunctions.cpp
@@ -125,11 +125,11 @@ inline void initGlobalDevicePoolState() {
   // (Alchemist) series).
   namespace syclex = sycl::ext::oneapi::experimental;
   for (const auto& device : gDevicePool.devices) {
-    auto architecture = device.get_info<syclex::info::device::architecture>();
+    auto architecture = device->get_info<syclex::info::device::architecture>();
     if (architecture < syclex::architecture::intel_gpu_acm_g10) {
       TORCH_WARN(
           "The current GPU (",
-          device.get_info<sycl::info::device::name>(),
+          device->get_info<sycl::info::device::name>(),
           ") is not officially supported. Please refer to the hardware prerequisites: ",
           "https://github.com/pytorch/pytorch/blob/main/docs/source/notes/get_start_xpu.rst#hardware-prerequisite");
     }

--- a/c10/xpu/XPUFunctions.cpp
+++ b/c10/xpu/XPUFunctions.cpp
@@ -128,9 +128,12 @@ inline void initGlobalDevicePoolState() {
     auto architecture = device->get_info<syclex::info::device::architecture>();
     if (architecture < syclex::architecture::intel_gpu_acm_g10) {
       TORCH_WARN(
-          "The current GPU (",
+          "The detected GPU (",
           device->get_info<sycl::info::device::name>(),
-          ") is not officially supported. Please refer to the hardware prerequisites: ",
+          ") is not officially supported by PyTorch XPU. Running workloads on this device may result in ",
+          "unexpected behavior, reduced performance, or runtime errors.\n",
+          "For stable and fully supported execution, please use GPUs based on Intel Arc Alchemist series or newer.\n",
+          "Refer to the hardware prerequisites for more information: ",
           "https://github.com/pytorch/pytorch/blob/main/docs/source/notes/get_start_xpu.rst#hardware-prerequisite");
     }
   }

--- a/c10/xpu/XPUFunctions.cpp
+++ b/c10/xpu/XPUFunctions.cpp
@@ -120,6 +120,20 @@ inline void initGlobalDevicePoolState() {
   TORCH_CHECK(
       gDevicePool.devices.size() <= std::numeric_limits<DeviceIndex>::max(),
       "Too many XPU devices, DeviceIndex overflowed!");
+  // Check each device's architecture and issue a warning if it is older
+  // than the officially supported range (Intel GPUs starting from Arc
+  // (Alchemist) series).
+  namespace syclex = sycl::ext::oneapi::experimental;
+  for (const auto& device : gDevicePool.devices) {
+    auto architecture = device.get_info<syclex::info::device::architecture>();
+    if (architecture < syclex::architecture::intel_gpu_acm_g10) {
+      TORCH_WARN(
+          "The current GPU (",
+          device.get_info<sycl::info::device::name>(),
+          ") is not officially supported. Please refer to the hardware prerequisites: ",
+          "https://github.com/pytorch/pytorch/blob/main/docs/source/notes/get_start_xpu.rst#hardware-prerequisite");
+    }
+  }
 
 #if defined(_WIN32) && SYCL_COMPILER_VERSION < 20250000
   // The default context feature is disabled by default on Windows for SYCL

--- a/c10/xpu/XPUFunctions.cpp
+++ b/c10/xpu/XPUFunctions.cpp
@@ -130,8 +130,7 @@ inline void initGlobalDevicePoolState() {
       TORCH_WARN(
           "The detected GPU (",
           device->get_info<sycl::info::device::name>(),
-          ") is not officially supported by PyTorch XPU. Running workloads on this device may result in ",
-          "unexpected behavior, reduced performance, or even runtime errors.\n",
+          ") is not officially supported by PyTorch XPU. Running workloads on this device may result in unexpected behavior.\n",
           "For stable and fully supported execution, please use GPUs based on Intel Arc (Alchemist) series or newer.\n",
           "Refer to the hardware prerequisites for more information: ",
           "https://github.com/pytorch/pytorch/blob/main/docs/source/notes/get_start_xpu.rst#hardware-prerequisite");

--- a/c10/xpu/XPUFunctions.cpp
+++ b/c10/xpu/XPUFunctions.cpp
@@ -120,9 +120,9 @@ inline void initGlobalDevicePoolState() {
   TORCH_CHECK(
       gDevicePool.devices.size() <= std::numeric_limits<DeviceIndex>::max(),
       "Too many XPU devices, DeviceIndex overflowed!");
-  // Check each device's architecture and issue a warning if it is older
-  // than the officially supported range (Intel GPUs starting from Arc
-  // (Alchemist) series).
+  // Check each device's architecture and issue a warning if it is older than
+  // the officially supported range (Intel GPUs starting from Arc (Alchemist)
+  // series).
   namespace syclex = sycl::ext::oneapi::experimental;
   for (const auto& device : gDevicePool.devices) {
     auto architecture = device->get_info<syclex::info::device::architecture>();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #165623
* __->__ #165622

# Motivation
Notify the user if the GPU is older than officially supported. This provides a friendly warning that the GPU may work, but the experience could be unstable.
