### PR TITLE
[Fix]  Use sys.executable instead of hardcoded "python" command when one has multiple Python runtimes

### DIFF
--- a/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
+++ b/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
@@ -640,7 +640,7 @@ class _ValgrindWrapper:
                         stat_log=stat_log,
                         bindings=self._bindings_module))
 
-                run_loop_cmd = ["python", script_file]
+                run_loop_cmd = [sys.executable, script_file]
             else:
                 if collect_baseline:
                     raise AssertionError("collect_baseline must be False for non-Python timers")


### PR DESCRIPTION
Fix hardcoded python executable path with sys.executable Replace hardcoded "python" string with sys.executable to ensure correct Python interpreter is used. This fixes failures on systems with multiple Python runtimes or where "python" is not in PATH. Similar to pytorch/pytorch#155918

Fixes #ISSUE_NUMBER
