### PR TITLE
Enabling WOQ fusion path on ACL

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1734,6 +1734,7 @@ test_linux_aarch64() {
        inductor/test_split_cat_fx_passes inductor/test_compile inductor/test_torchinductor \
        inductor/test_torchinductor_codegen_dynamic_shapes inductor/test_torchinductor_dynamic_shapes inductor/test_memory \
        inductor/test_triton_cpu_backend inductor/test_triton_extension_backend inductor/test_mkldnn_pattern_matcher inductor/test_cpu_cpp_wrapper \
+       inductor/test_cpu_select_algorithm \
        --shard "$SHARD_NUMBER" "$NUM_TEST_SHARDS" --verbose
 }
 

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -4139,9 +4139,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
             s = torch.randn(s_shape, dtype=torch.bfloat16)
 
             def matcher_check_fn():
-                self.assertEqual(
-                    counters["inductor"]["woq_matcher_count"], 0 if TEST_ACL else 1
-                )
+                self.assertEqual(counters["inductor"]["woq_matcher_count"], 1)
 
             self._test_common(
                 mod,

--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -1528,17 +1528,20 @@ if torch._C._has_mkldnn:
     def _mkldnn_fusion_init():
         # TODO: aarch64: enable op fusion for acl once it supports fused operators. Disabling it for now.
         # Otherwise even the matmul or innerproduct can not be accelerated with acl
-        if (
-            torch.backends.mkldnn.enabled
-            and torch.backends.mkldnn.is_available()
-            and not torch.ops.mkldnn._is_mkldnn_acl_supported()
-        ):
+        mkldnn_ready = (
+            torch.backends.mkldnn.enabled and torch.backends.mkldnn.is_available()
+        )
+        if not mkldnn_ready:
+            return
+
+        if not torch.ops.mkldnn._is_mkldnn_acl_supported():
             _register_unary_fusion()
             _register_inplace_fusion()
             _register_binary_unary_fusion()
             _register_binary_fusion()
             _register_quantization_lowerings()
-            _register_woq_lowerings()
+
+        _register_woq_lowerings()
 
     @functools.cache
     def _mkldnn_weight_pack_init():

--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -1528,10 +1528,10 @@ if torch._C._has_mkldnn:
     def _mkldnn_fusion_init():
         # TODO: aarch64: enable op fusion for acl once it supports fused operators. Disabling it for now.
         # Otherwise even the matmul or innerproduct can not be accelerated with acl
-        mkldnn_ready = (
-            torch.backends.mkldnn.enabled and torch.backends.mkldnn.is_available()
-        )
-        if not mkldnn_ready:
+        if (
+            not torch.backends.mkldnn.enabled
+            or not torch.backends.mkldnn.is_available()
+        ):
             return
 
         if not torch.ops.mkldnn._is_mkldnn_acl_supported():


### PR DESCRIPTION
- Enabling _register_woq_lowerings() under the ACL (Arm Compute Library) path, while keeping the other fusion operators disabled.
- Improves test coverage on (`inductor/test_cpu_select_algorithm.py test_int8_woq_mm_batch_*`). Previously, a list of **54 assertions were disabled/failed for aarch64**. List attached below.
- Modified pattern matcher assertions under `test/inductor/test_mkldnn_pattern_matcher.py` to reflect that both ACL should have a woq_matcher_count == 1 for `test_woq_int8`.

<details>
  <summary> test_cpu_select_algorithm.py  previously failing tests</summary>

- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_17_mid_dim_1_in_features_1024_out_features_1024_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_17_mid_dim_1_in_features_1024_out_features_64_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_17_mid_dim_1_in_features_1024_out_features_65_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_17_mid_dim_1_in_features_128_out_features_1024_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_17_mid_dim_1_in_features_128_out_features_64_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_17_mid_dim_1_in_features_128_out_features_65_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_17_mid_dim_1_in_features_144_out_features_1024_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_17_mid_dim_1_in_features_144_out_features_64_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_17_mid_dim_1_in_features_144_out_features_65_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_17_mid_dim_8_in_features_1024_out_features_1024_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_17_mid_dim_8_in_features_1024_out_features_64_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_17_mid_dim_8_in_features_1024_out_features_65_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_17_mid_dim_8_in_features_128_out_features_1024_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_17_mid_dim_8_in_features_128_out_features_64_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_17_mid_dim_8_in_features_128_out_features_65_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_17_mid_dim_8_in_features_144_out_features_1024_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_17_mid_dim_8_in_features_144_out_features_64_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_17_mid_dim_8_in_features_144_out_features_65_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_1_mid_dim_1_in_features_1024_out_features_1024_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_1_mid_dim_1_in_features_1024_out_features_64_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_1_mid_dim_1_in_features_1024_out_features_65_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_1_mid_dim_1_in_features_128_out_features_1024_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_1_mid_dim_1_in_features_128_out_features_64_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_1_mid_dim_1_in_features_128_out_features_65_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_1_mid_dim_1_in_features_144_out_features_1024_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_1_mid_dim_1_in_features_144_out_features_64_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_1_mid_dim_1_in_features_144_out_features_65_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_1_mid_dim_8_in_features_1024_out_features_1024_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_1_mid_dim_8_in_features_1024_out_features_64_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_1_mid_dim_8_in_features_1024_out_features_65_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_1_mid_dim_8_in_features_128_out_features_1024_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_1_mid_dim_8_in_features_128_out_features_64_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_1_mid_dim_8_in_features_128_out_features_65_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_1_mid_dim_8_in_features_144_out_features_1024_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_1_mid_dim_8_in_features_144_out_features_64_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_1_mid_dim_8_in_features_144_out_features_65_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_32_mid_dim_1_in_features_1024_out_features_1024_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_32_mid_dim_1_in_features_1024_out_features_64_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_32_mid_dim_1_in_features_1024_out_features_65_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_32_mid_dim_1_in_features_128_out_features_1024_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_32_mid_dim_1_in_features_128_out_features_64_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_32_mid_dim_1_in_features_128_out_features_65_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_32_mid_dim_1_in_features_144_out_features_1024_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_32_mid_dim_1_in_features_144_out_features_64_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_32_mid_dim_1_in_features_144_out_features_65_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_32_mid_dim_8_in_features_1024_out_features_1024_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_32_mid_dim_8_in_features_1024_out_features_64_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_32_mid_dim_8_in_features_1024_out_features_65_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_32_mid_dim_8_in_features_128_out_features_1024_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_32_mid_dim_8_in_features_128_out_features_64_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_32_mid_dim_8_in_features_128_out_features_65_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_32_mid_dim_8_in_features_144_out_features_1024_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_32_mid_dim_8_in_features_144_out_features_64_cpu_bfloat16
- TestSelectAlgorithmCPU::test_int8_woq_mm_batch_size_32_mid_dim_8_in_features_144_out_features_65_cpu_bfloat16

</details>

<details>
  <summary>Sample error Message:  <code>TestSelectAlgorithmCPU::test_int8_woq_mm_batch_*</code> (AssertionError)</summary>

**Status:** failure  
**Framework:** pytest

**Repro command (from repo root):**
```bash
python test/inductor/test_cpu_select_algorithm.py TestSelectAlgorithmCPU.test_int8_woq_mm_batch_size_17_mid_dim_1_in_features_144_out_features_65_cpu_bfloat16
```

**Assertion:**
```text
AssertionError: Scalars are not equal!

Expected 1 but got 0.
Absolute difference: 1
Relative difference: 1.0
```

**Traceback (sanitized):**
```text
Traceback (most recent call last):
  ... in test_int8_woq_mm
    self.assertEqual(counters["inductor"]["cpp_templated_kernel_counter"], 1)
  ... in assertEqual
    return super().assertEqual(x, y, *args, **kwargs)
  ... in assertEqual
    raise error_metas.pop()[0].to_error()
AssertionError: Scalars are not equal!
```

**Note:** Set `PYTORCH_PRINT_REPRO_ON_FAILURE=0` to suppress this message.

</details>

cc @snadampal @milpuz01 @aditew01 @nikhil-arm @fadara01 @nWEIdia @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @chenyang78 @malfet