### PR TITLE
Load cuda deps more aggressively

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -324,8 +324,6 @@ def _preload_cuda_deps(err: _Union[ImportError, OSError]) -> builtins.bool:
     """Preloads cuda deps if they could not be found otherwise."""
     # Can only happen for wheel with cuda libs as PYPI deps
     # As PyTorch is not purelib, but nvidia-*-cu12 is
-    from torch.version import cuda as cuda_version
-
     cuda_libs: dict[str, str] = {
         "nvjitlink": "libnvJitLink.so.*[0-9]",
         "cublas": "libcublas.so.*[0-9]",


### PR DESCRIPTION
Previously cuda deps were only loaded if loading the globals library
failed with a cuda shared lib related error. It's possible the globals
library to load successfully, but then for the torch native libraries to
fail with a cuda error. This now handles both of these cases.

Fixes https://github.com/pytorch/pytorch/issues/117350
