### PR TITLE
Improve error message for non-positive groups in convolution

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -658,6 +658,7 @@ static void check_shape_forward(const at::Tensor& input,
   TORCH_CHECK(!params.is_output_padding_neg(), "negative output_padding is not supported");
   TORCH_CHECK(!params.is_stride_nonpos(), "non-positive stride is not supported");
   TORCH_CHECK(!params.is_dilation_neg(), "dilation should be greater than zero");
+  TORCH_CHECK(groups > 0, "expected groups to be greater than 0, but got groups=", groups);
 
   TORCH_CHECK(weight_dim == k,
            "Expected ", weight_dim, "-dimensional input for ", weight_dim,

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -230,6 +230,55 @@ class TestConvolutionNN(NNTestCase):
         with self.assertRaisesRegex(ValueError, "groups must be a positive integer"):
             torch.nn.Conv3d(1, 1, kernel_size=3, dilation=2, stride=2, groups=-2)
 
+    def test_conv_aten_invalid_groups(self):
+        # test low-level aten ops with invalid groups parameter
+        grad_output = torch.randn(2, 4, 8, dtype=torch.double)
+        input = torch.randn(2, 5, 8, dtype=torch.double)
+        weight = torch.randn(5, 4, 3, dtype=torch.double)
+        bias_sizes = [4]
+        stride = [1]
+        padding = [1]
+        dilation = [1]
+        transposed = True
+        output_padding = [0]
+        output_mask = [True, True, True]
+
+        # test groups=0
+        with self.assertRaisesRegex(
+            RuntimeError, "expected groups to be greater than 0, but got groups=0"
+        ):
+            torch.ops.aten.convolution_backward(
+                grad_output,
+                input,
+                weight,
+                bias_sizes,
+                stride,
+                padding,
+                dilation,
+                transposed,
+                output_padding,
+                0,
+                output_mask,
+            )
+
+        # test groups=-1
+        with self.assertRaisesRegex(
+            RuntimeError, "expected groups to be greater than 0, but got groups=-1"
+        ):
+            torch.ops.aten.convolution_backward(
+                grad_output,
+                input,
+                weight,
+                bias_sizes,
+                stride,
+                padding,
+                dilation,
+                transposed,
+                output_padding,
+                -1,
+                output_mask,
+            )
+
     def test_conv3d_overflow_values(self):
         input = torch.full(
             (


### PR DESCRIPTION
Prevents from segmentation fault for invalid groups value in convolution.

Fixes #142835


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168