### PR TITLE
[BE][Ez]: Enable ruff rule RUF009

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,6 +243,7 @@ select = [
     "RSE",
     "RUF007", # pairwise over zip
     "RUF008", # mutable dataclass default
+    "RUF009", # mutable dataclass field function call
     "RUF013", # ban implicit optional
     "RUF015", # access first ele in constant time
     "RUF016", # type error non-integer index


### PR DESCRIPTION
Enable ruff rule RUF009 which bans function call assignment in dataclass. Most of the time, `dataclasses.field(defaultfactory=)` was the intention. We do not see any issues in the current codebase, but good to proactively guard against these issues. https://docs.astral.sh/ruff/rules/function-call-in-dataclass-default-argument/