### PR TITLE
Fix MSCV C++ compilation error of `pycore_stackref.h` header

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -929,6 +929,7 @@ libtorch_python_core_sources = [
     "torch/csrc/dynamo/guards.cpp",
     "torch/csrc/dynamo/utils.cpp",
     "torch/csrc/dynamo/init.cpp",
+    "torch/csrc/dynamo/stackref_bridge.c",
     "torch/csrc/functorch/init.cpp",
     "torch/csrc/fx/node.cpp",
     "torch/csrc/mps/Module.cpp",

--- a/torch/csrc/dynamo/cpython_defs.c
+++ b/torch/csrc/dynamo/cpython_defs.c
@@ -2,7 +2,15 @@
 #include <torch/csrc/dynamo/cpython_includes.h>
 #include <torch/csrc/dynamo/debug_macros.h>
 
-#if IS_PYTHON_3_15_PLUS || (IS_PYTHON_3_14_PLUS && defined(_WIN32))
+#if IS_PYTHON_3_14_PLUS && defined(_WIN32)
+#define Py_BUILD_CORE
+#include <internal/pycore_stackref.h>
+#include <internal/pycore_genobject.h>
+#include <internal/pycore_interpframe.h>
+#undef Py_BUILD_CORE
+#endif
+
+#if IS_PYTHON_3_15_PLUS
 
 const uint8_t* THP_PyOpcode_Caches = NULL;
 int THP_PyOpcode_Caches_size = 0;

--- a/torch/csrc/dynamo/cpython_defs.c
+++ b/torch/csrc/dynamo/cpython_defs.c
@@ -2,6 +2,8 @@
 #include <torch/csrc/dynamo/cpython_includes.h>
 #include <torch/csrc/dynamo/debug_macros.h>
 
+// Include CPython header files here (.c file) as MSVC C++ compiler cannot
+// compile pycore_stackref.h. See PyTorch issue #160647
 #if IS_PYTHON_3_14_PLUS && defined(_WIN32)
 #define Py_BUILD_CORE
 #include <internal/pycore_stackref.h>

--- a/torch/csrc/dynamo/cpython_includes.h
+++ b/torch/csrc/dynamo/cpython_includes.h
@@ -46,7 +46,8 @@ extern "C" {
 
 #elif IS_PYTHON_3_14_PLUS && defined(_WIN32)
 
-#define F_CODE(x) ((PyCodeObject*)Torch_PyStackRef_AsPyObjectBorrow(&x->f_executable))
+#define F_CODE(x) \
+  ((PyCodeObject*)Torch_PyStackRef_AsPyObjectBorrow(&x->f_executable))
 #define PREV_INSTR(x) (x)->instr_ptr
 
 #else

--- a/torch/csrc/dynamo/cpython_includes.h
+++ b/torch/csrc/dynamo/cpython_includes.h
@@ -21,6 +21,7 @@
 #if IS_PYTHON_3_11_PLUS
 #include <internal/pycore_frame.h>
 
+#include "stackref_bridge.h"
 #if IS_PYTHON_3_14_PLUS && !defined(_WIN32)
 #include <internal/pycore_code.h>
 #include <internal/pycore_genobject.h>
@@ -28,7 +29,6 @@
 #include <internal/pycore_stackref.h>
 #elif IS_PYTHON_3_14_PLUS && defined(_WIN32)
 #include <internal/pycore_interpframe_structs.h> // _PyInterpreterFrame
-#include "stackref_bridge.h"
 #endif
 
 #endif
@@ -39,15 +39,10 @@
 extern "C" {
 #endif
 
-#if IS_PYTHON_3_14_PLUS && !defined(_WIN32)
-
-#define F_CODE(x) ((PyCodeObject*)PyStackRef_AsPyObjectBorrow(x->f_executable))
-#define PREV_INSTR(x) (x)->instr_ptr
-
-#elif IS_PYTHON_3_14_PLUS && defined(_WIN32)
+#if IS_PYTHON_3_14_PLUS
 
 #define F_CODE(x) \
-  ((PyCodeObject*)Torch_PyStackRef_AsPyObjectBorrow(&x->f_executable))
+  ((PyCodeObject*)THP_PyStackRef_AsPyObjectBorrow(&x->f_executable))
 #define PREV_INSTR(x) (x)->instr_ptr
 
 #else
@@ -58,14 +53,13 @@ extern "C" {
 #else
 #define F_CODE(x) ((PyCodeObject*)(x)->f_code)
 #define PREV_INSTR(x) (x)->prev_instr
-#endif
+#endif // IS_PYTHON_3_13_PLUS
 
 #endif // IS_PYTHON_3_14_PLUS
 
-#if IS_PYTHON_3_14_PLUS && !defined(_WIN32)
-#define FUNC(x) ((PyFunctionObject*)PyStackRef_AsPyObjectBorrow((x)->f_funcobj))
-#elif IS_PYTHON_3_14_PLUS && defined(_WIN32)
-#define FUNC(x) ((PyFunctionObject*)((x)->f_funcobj.bits))
+#if IS_PYTHON_3_14_PLUS
+#define FUNC(x) \
+  ((PyFunctionObject*)THP_PyStackRef_AsPyObjectBorrow(&x->f_funcobj))
 #elif IS_PYTHON_3_12_PLUS
 #define FUNC(x) ((PyFunctionObject*)(x)->f_funcobj)
 #else

--- a/torch/csrc/dynamo/cpython_includes.h
+++ b/torch/csrc/dynamo/cpython_includes.h
@@ -28,6 +28,7 @@
 #include <internal/pycore_stackref.h>
 #elif IS_PYTHON_3_14_PLUS && defined(_WIN32)
 #include <internal/pycore_interpframe_structs.h> // _PyInterpreterFrame
+#include "stackref_bridge.h"
 #endif
 
 #endif
@@ -45,7 +46,7 @@ extern "C" {
 
 #elif IS_PYTHON_3_14_PLUS && defined(_WIN32)
 
-#define F_CODE(x) ((PyCodeObject*)((x)->f_executable.bits))
+#define F_CODE(x) ((PyCodeObject*)Torch_PyStackRef_AsPyObjectBorrow(&x->f_executable))
 #define PREV_INSTR(x) (x)->instr_ptr
 
 #else

--- a/torch/csrc/dynamo/cpython_includes.h
+++ b/torch/csrc/dynamo/cpython_includes.h
@@ -21,7 +21,7 @@
 #if IS_PYTHON_3_11_PLUS
 #include <internal/pycore_frame.h>
 
-#include "stackref_bridge.h"
+#include <torch/csrc/dynamo/stackref_bridge.h>
 #if IS_PYTHON_3_14_PLUS && !defined(_WIN32)
 #include <internal/pycore_code.h>
 #include <internal/pycore_genobject.h>

--- a/torch/csrc/dynamo/cpython_includes.h
+++ b/torch/csrc/dynamo/cpython_includes.h
@@ -42,7 +42,7 @@ extern "C" {
 #if IS_PYTHON_3_14_PLUS
 
 #define F_CODE(x) \
-  ((PyCodeObject*)THP_PyStackRef_AsPyObjectBorrow(&x->f_executable))
+  ((PyCodeObject*)THP_PyStackRef_AsPyObjectBorrow(&(x)->f_executable))
 #define PREV_INSTR(x) (x)->instr_ptr
 
 #else
@@ -59,7 +59,7 @@ extern "C" {
 
 #if IS_PYTHON_3_14_PLUS
 #define FUNC(x) \
-  ((PyFunctionObject*)THP_PyStackRef_AsPyObjectBorrow(&x->f_funcobj))
+  ((PyFunctionObject*)THP_PyStackRef_AsPyObjectBorrow(&(x)->f_funcobj))
 #elif IS_PYTHON_3_12_PLUS
 #define FUNC(x) ((PyFunctionObject*)(x)->f_funcobj)
 #else

--- a/torch/csrc/dynamo/eval_frame.c
+++ b/torch/csrc/dynamo/eval_frame.c
@@ -43,7 +43,6 @@ void eval_frame_callback_set(PyObject* obj) {
 }
 
 // 3.15 Not supported at all. See cpython_defs.c for hints
-// 3.14 currently not fully supported on Windows
 #if !(IS_PYTHON_3_15_PLUS)
 
 #define DECLARE_PYOBJ_ATTR(name)                        \

--- a/torch/csrc/dynamo/eval_frame.c
+++ b/torch/csrc/dynamo/eval_frame.c
@@ -10,6 +10,14 @@
 #include <torch/csrc/dynamo/eval_frame_cpp.h>
 #include <torch/csrc/utils/python_compat.h>
 
+#if IS_PYTHON_3_14_PLUS && defined(_WIN32)
+#define Py_BUILD_CORE
+#include <internal/pycore_stackref.h>
+#include <internal/pycore_code.h>
+#include <internal/pycore_interpframe.h>
+#undef Py_BUILD_CORE
+#endif
+
 PyObject* guard_error_hook = NULL;
 PyObject* guard_complete_hook = NULL;
 
@@ -36,7 +44,7 @@ void eval_frame_callback_set(PyObject* obj) {
 
 // 3.15 Not supported at all. See cpython_defs.c for hints
 // 3.14 currently not fully supported on Windows
-#if !(IS_PYTHON_3_15_PLUS || (IS_PYTHON_3_14_PLUS && defined(_WIN32)))
+#if !(IS_PYTHON_3_15_PLUS)
 
 #define DECLARE_PYOBJ_ATTR(name)                        \
   static PyObject* THPPyInterpreterFrame_##name(        \

--- a/torch/csrc/dynamo/framelocals_mapping.cpp
+++ b/torch/csrc/dynamo/framelocals_mapping.cpp
@@ -64,7 +64,7 @@ FrameLocalsMapping::FrameLocalsMapping(FrameLocalsFrameType* frame)
 
   auto offset = co->co_nlocalsplus - co->co_nfreevars;
 #if IS_PYTHON_3_15_PLUS
-  TORCH_CHECK(false, "Python 3.15+ / 3.14 on Windows not supported");
+  TORCH_CHECK(false, "Python 3.15+");
 #elif IS_PYTHON_3_14_PLUS
   for (int i = 0; i < offset; i++) {
     update_framelocals(
@@ -79,7 +79,7 @@ FrameLocalsMapping::FrameLocalsMapping(FrameLocalsFrameType* frame)
   // Get references to closure variables
 #if IS_PYTHON_3_15_PLUS
   PyObject* closure;
-  TORCH_CHECK(false, "Python 3.15+ / 3.14 on Windows not supported");
+  TORCH_CHECK(false, "Python 3.15+");
 #else
   PyObject* closure = FUNC(frame)->func_closure;
 #endif

--- a/torch/csrc/dynamo/framelocals_mapping.cpp
+++ b/torch/csrc/dynamo/framelocals_mapping.cpp
@@ -28,7 +28,7 @@ FrameLocalsMapping::FrameLocalsMapping(FrameLocalsFrameType* frame)
   PyCodeObject* co = F_CODE(frame);
   _framelocals.resize(co->co_nlocalsplus, nullptr);
 
-#if IS_PYTHON_3_15_PLUS || (IS_PYTHON_3_14_PLUS && defined(_WIN32))
+#if IS_PYTHON_3_15_PLUS
   TORCH_CHECK(false, "Python 3.15+ / 3.14 on Windows not supported");
 #elif IS_PYTHON_3_14_PLUS
   if (!frame->stackpointer) {
@@ -63,11 +63,11 @@ FrameLocalsMapping::FrameLocalsMapping(FrameLocalsFrameType* frame)
   };
 
   auto offset = co->co_nlocalsplus - co->co_nfreevars;
-#if IS_PYTHON_3_15_PLUS || (IS_PYTHON_3_14_PLUS && defined(_WIN32))
+#if IS_PYTHON_3_15_PLUS
   TORCH_CHECK(false, "Python 3.15+ / 3.14 on Windows not supported");
 #elif IS_PYTHON_3_14_PLUS
   for (int i = 0; i < offset; i++) {
-    update_framelocals(i, PyStackRef_AsPyObjectBorrow(frame->localsplus[i]));
+    update_framelocals(i, THP_PyStackRef_AsPyObjectBorrow(&frame->localsplus[i]));
   }
 #else
   for (int i = 0; i < offset; i++) {
@@ -76,7 +76,7 @@ FrameLocalsMapping::FrameLocalsMapping(FrameLocalsFrameType* frame)
 #endif
 
   // Get references to closure variables
-#if IS_PYTHON_3_15_PLUS || (IS_PYTHON_3_14_PLUS && defined(_WIN32))
+#if IS_PYTHON_3_15_PLUS
   PyObject* closure;
   TORCH_CHECK(false, "Python 3.15+ / 3.14 on Windows not supported");
 #else

--- a/torch/csrc/dynamo/framelocals_mapping.cpp
+++ b/torch/csrc/dynamo/framelocals_mapping.cpp
@@ -29,7 +29,7 @@ FrameLocalsMapping::FrameLocalsMapping(FrameLocalsFrameType* frame)
   _framelocals.resize(co->co_nlocalsplus, nullptr);
 
 #if IS_PYTHON_3_15_PLUS
-  TORCH_CHECK(false, "Python 3.15+ / 3.14 on Windows not supported");
+  TORCH_CHECK(false, "Python 3.15+");
 #elif IS_PYTHON_3_14_PLUS
   if (!frame->stackpointer) {
     return;

--- a/torch/csrc/dynamo/framelocals_mapping.cpp
+++ b/torch/csrc/dynamo/framelocals_mapping.cpp
@@ -68,7 +68,7 @@ FrameLocalsMapping::FrameLocalsMapping(FrameLocalsFrameType* frame)
 #elif IS_PYTHON_3_14_PLUS
   for (int i = 0; i < offset; i++) {
     update_framelocals(
-      i, THP_PyStackRef_AsPyObjectBorrow(&frame->localsplus[i]));
+        i, THP_PyStackRef_AsPyObjectBorrow(&frame->localsplus[i]));
   }
 #else
   for (int i = 0; i < offset; i++) {

--- a/torch/csrc/dynamo/framelocals_mapping.cpp
+++ b/torch/csrc/dynamo/framelocals_mapping.cpp
@@ -67,7 +67,8 @@ FrameLocalsMapping::FrameLocalsMapping(FrameLocalsFrameType* frame)
   TORCH_CHECK(false, "Python 3.15+ / 3.14 on Windows not supported");
 #elif IS_PYTHON_3_14_PLUS
   for (int i = 0; i < offset; i++) {
-    update_framelocals(i, THP_PyStackRef_AsPyObjectBorrow(&frame->localsplus[i]));
+    update_framelocals(
+      i, THP_PyStackRef_AsPyObjectBorrow(&frame->localsplus[i]));
   }
 #else
   for (int i = 0; i < offset; i++) {

--- a/torch/csrc/dynamo/stackref_bridge.c
+++ b/torch/csrc/dynamo/stackref_bridge.c
@@ -8,7 +8,7 @@
 
 #include <torch/csrc/utils/python_compat.h>
 
-#if IS_PYTHON_3_14_PLUS && defined(_WIN32)
+#if IS_PYTHON_3_14_PLUS
 
 #define Py_BUILD_CORE
 #include <Python.h>
@@ -16,8 +16,7 @@
 #include "stackref_bridge.h"
 #undef Py_BUILD_CORE
 
-
-PyObject* Torch_PyStackRef_AsPyObjectBorrow(void* stackref) {
+PyObject* THP_PyStackRef_AsPyObjectBorrow(void* stackref) {
   _PyStackRef *sr = (_PyStackRef*)stackref;
   return PyStackRef_AsPyObjectBorrow(*sr);
 }

--- a/torch/csrc/dynamo/stackref_bridge.c
+++ b/torch/csrc/dynamo/stackref_bridge.c
@@ -6,6 +6,16 @@
 // initializers that are not supported in older C++ standards, but is supported
 // in C.
 
+#include <torch/csrc/utils/python_compat.h>
+
+#if IS_PYTHON_3_14_PLUS
+#pragma message("is Python 3.14+")
+#endif
+
+#if defined(_WIN32)
+#pragma message("WIN32 defined")
+#endif
+
 #if IS_PYTHON_3_14_PLUS && defined(_WIN32)
 
 #define Py_BUILD_CORE

--- a/torch/csrc/dynamo/stackref_bridge.c
+++ b/torch/csrc/dynamo/stackref_bridge.c
@@ -8,14 +8,6 @@
 
 #include <torch/csrc/utils/python_compat.h>
 
-#if IS_PYTHON_3_14_PLUS
-#pragma message("is Python 3.14+")
-#endif
-
-#if defined(_WIN32)
-#pragma message("WIN32 defined")
-#endif
-
 #if IS_PYTHON_3_14_PLUS && defined(_WIN32)
 
 #define Py_BUILD_CORE

--- a/torch/csrc/dynamo/stackref_bridge.c
+++ b/torch/csrc/dynamo/stackref_bridge.c
@@ -6,7 +6,7 @@
 // initializers that are not supported in older C++ standards, but is supported
 // in C.
 
-#if defined(_WIN32)
+#if IS_PYTHON_3_14_PLUS && defined(_WIN32)
 
 #define Py_BUILD_CORE
 #include <Python.h>

--- a/torch/csrc/dynamo/stackref_bridge.c
+++ b/torch/csrc/dynamo/stackref_bridge.c
@@ -13,7 +13,7 @@
 #define Py_BUILD_CORE
 #include <Python.h>
 #include <internal/pycore_stackref.h>
-#include "stackref_bridge.h"
+#include <torch/csrc/dynamo/stackref_bridge.h>
 #undef Py_BUILD_CORE
 
 PyObject* THP_PyStackRef_AsPyObjectBorrow(void* stackref) {

--- a/torch/csrc/dynamo/stackref_bridge.c
+++ b/torch/csrc/dynamo/stackref_bridge.c
@@ -1,0 +1,19 @@
+// Compile this file as C, not C++.
+
+// Wrap inclusion of pycore_stackref.h inside a pure C file and ensure this file
+// is compiled as C (not C++). This avoids MSVC’s “designated initializers
+// require /std:c++20” error, since pycore_stackref.h uses C99-style designated
+// initializers that are not supported in older C++ standards, but is supported
+// in C.
+
+#define Py_BUILD_CORE
+#include <Python.h>
+#include <internal/pycore_stackref.h>
+#include "stackref_bridge.h"
+#undef Py_BUILD_CORE
+
+
+PyObject* Torch_PyStackRef_AsPyObjectBorrow(void* stackref) {
+  _PyStackRef *sr = (_PyStackRef*)stackref;
+  return PyStackRef_AsPyObjectBorrow(*sr);
+}

--- a/torch/csrc/dynamo/stackref_bridge.c
+++ b/torch/csrc/dynamo/stackref_bridge.c
@@ -6,6 +6,8 @@
 // initializers that are not supported in older C++ standards, but is supported
 // in C.
 
+#if defined(_WIN32)
+
 #define Py_BUILD_CORE
 #include <Python.h>
 #include <internal/pycore_stackref.h>
@@ -17,3 +19,5 @@ PyObject* Torch_PyStackRef_AsPyObjectBorrow(void* stackref) {
   _PyStackRef *sr = (_PyStackRef*)stackref;
   return PyStackRef_AsPyObjectBorrow(*sr);
 }
+
+#endif

--- a/torch/csrc/dynamo/stackref_bridge.h
+++ b/torch/csrc/dynamo/stackref_bridge.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#ifdef _WIN32
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Use a void* to avoid exposing the internal _PyStackRef union on this
+// translation unit
+PyObject* Torch_PyStackRef_AsPyObjectBorrow(void* stackref);
+
+#ifdef __cplusplus
+}
+#endif  // #ifdef __cplusplus
+
+#endif  // #ifdef _WIN32

--- a/torch/csrc/dynamo/stackref_bridge.h
+++ b/torch/csrc/dynamo/stackref_bridge.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(_WIN32)
+#if IS_PYTHON_3_14_PLUS && defined(_WIN32)
 
 #ifdef __cplusplus
 extern "C" {

--- a/torch/csrc/dynamo/stackref_bridge.h
+++ b/torch/csrc/dynamo/stackref_bridge.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 #ifdef __cplusplus
 extern "C" {
-#endif  // __cplusplus
+#endif
 
 // Use a void* to avoid exposing the internal _PyStackRef union on this
 // translation unit
@@ -12,6 +12,6 @@ PyObject* Torch_PyStackRef_AsPyObjectBorrow(void* stackref);
 
 #ifdef __cplusplus
 }
-#endif  // #ifdef __cplusplus
+#endif
 
-#endif  // #ifdef _WIN32
+#endif

--- a/torch/csrc/dynamo/stackref_bridge.h
+++ b/torch/csrc/dynamo/stackref_bridge.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <torch/csrc/utils/python_compat.h>
+
 #if IS_PYTHON_3_14_PLUS && defined(_WIN32)
 
 #ifdef __cplusplus

--- a/torch/csrc/dynamo/stackref_bridge.h
+++ b/torch/csrc/dynamo/stackref_bridge.h
@@ -2,18 +2,17 @@
 
 #include <torch/csrc/utils/python_compat.h>
 
-#if IS_PYTHON_3_14_PLUS && defined(_WIN32)
+#if IS_PYTHON_3_14_PLUS
 
 #ifdef __cplusplus
 extern "C" {
-#endif
+#endif // __cplusplus
 
 // Use a void* to avoid exposing the internal _PyStackRef union on this
 // translation unit
-PyObject* Torch_PyStackRef_AsPyObjectBorrow(void* stackref);
+PyObject* THP_PyStackRef_AsPyObjectBorrow(void* stackref);
 
 #ifdef __cplusplus
 }
-#endif
-
-#endif
+#endif // __cplusplus
+#endif // IS_PYTHON_3_14_PLUS


### PR DESCRIPTION
Wraps the header in a C file and compile it using a C compiler, which should support designated initializers

Fix issue #160647


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela