### PR TITLE
Generalize the testcase for a given world size

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_state_dict.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_state_dict.py
@@ -176,7 +176,7 @@ class TestFullyShardStateDictMultiProcess(FSDPTest):
     def _test_dp_state_dict_cpu_offload(
         self, offload_policy: CPUOffloadPolicy, cpu_state_dict: bool
     ):
-        mlp_dim = 4
+        mlp_dim = self.world_size
         torch.manual_seed(42)
         with torch.device("meta"):
             model = nn.Sequential(


### PR DESCRIPTION
Currently, the test case fails when more than 4-ranks are used with the following error:
NotImplementedError: Cannot copy out of meta tensor; no data!

The patch keeps existing functionality of supporting four-ranks or devices, in addition, make the test case more generic for a given world_size, e.g. 8-ranks.

Fixes internal PyTorch issue no 7192 


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci