### PR TITLE
[cpu/gpu split]

### DIFF
--- a/torch/_inductor/codegen/aoti_hipify_utils.py
+++ b/torch/_inductor/codegen/aoti_hipify_utils.py
@@ -1,7 +1,6 @@
 import re
 
 import torch
-from torch.utils.hipify.hipify_python import PYTORCH_MAP, PYTORCH_TRIE
 
 
 # It is not a good idea to directly apply hipify_torch to codegen, which will be vulnerable to cases like:
@@ -13,6 +12,12 @@ from torch.utils.hipify.hipify_python import PYTORCH_MAP, PYTORCH_TRIE
 
 def maybe_hipify_code_wrapper(source_codes: str, force_hipify: bool = False) -> str:
     if torch.version.hip is None and not force_hipify:
+        return source_codes
+
+    try:
+        from torch.utils.hipify.hipify_python import PYTORCH_MAP, PYTORCH_TRIE
+    except ImportError:
+        # hipify not available for non-AMD builds
         return source_codes
 
     def c2_repl(m: re.Match[str]) -> object:


### PR DESCRIPTION
Summary: cpu/gpu split. cuda is default due to some downstream targets configurations.

Test Plan: test in CI

Differential Revision: D80712802




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben