### PR TITLE
Fix #114629: ensure CPU DeviceMesh initializes gloo process groups

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -2,8 +2,8 @@
 # Owner(s): ["oncall: distributed"]
 import os
 import unittest
-from unittest import mock
 from datetime import timedelta
+from unittest import mock
 
 import torch
 import torch.distributed as dist
@@ -102,18 +102,26 @@ class DeviceMeshCPUFallbackTest(TestCase):
         # running without GPUs, which is hard to reproduce deterministically in
         # the shared test harness, so we simulate the relevant state here.
         dummy_pg = _DummyProcessGroup(("cpu",))
-        with mock.patch("torch.distributed.device_mesh.is_initialized", return_value=False), mock.patch(
-            "torch.distributed.device_mesh.get_world_size", return_value=1
-        ), mock.patch(
-            "torch.distributed.device_mesh.get_rank", return_value=0
-        ), mock.patch(
-            "torch.distributed.device_mesh._get_default_group", return_value=dummy_pg
-        ), mock.patch(
-            "torch.distributed.device_mesh.get_backend", return_value="gloo"
-        ), mock.patch(
-            "torch.distributed.device_mesh.init_process_group"
-        ) as mock_init_pg, mock.patch(
-            "torch.distributed.device_mesh.torch.cuda.is_available", return_value=False
+        with (
+            mock.patch(
+                "torch.distributed.device_mesh.is_initialized", return_value=False
+            ),
+            mock.patch("torch.distributed.device_mesh.get_world_size", return_value=1),
+            mock.patch("torch.distributed.device_mesh.get_rank", return_value=0),
+            mock.patch(
+                "torch.distributed.device_mesh._get_default_group",
+                return_value=dummy_pg,
+            ),
+            mock.patch(
+                "torch.distributed.device_mesh.get_backend", return_value="gloo"
+            ),
+            mock.patch(
+                "torch.distributed.device_mesh.init_process_group"
+            ) as mock_init_pg,
+            mock.patch(
+                "torch.distributed.device_mesh.torch.cuda.is_available",
+                return_value=False,
+            ),
         ):
             DeviceMesh("cpu", self.mesh_tensor)
             mock_init_pg.assert_called_once_with(backend="gloo")
@@ -122,20 +130,27 @@ class DeviceMeshCPUFallbackTest(TestCase):
         world_size = 2
         mesh = torch.arange(world_size, dtype=torch.int)
         dummy_pg = _DummyProcessGroup(("cuda",), world_size=world_size)
-        with mock.patch("torch.distributed.device_mesh.is_initialized", return_value=True), mock.patch(
-            "torch.distributed.device_mesh.get_world_size", return_value=world_size
-        ), mock.patch(
-            "torch.distributed.device_mesh.get_rank", return_value=0
-        ), mock.patch(
-            "torch.distributed.device_mesh._get_default_group", return_value=dummy_pg
-        ), mock.patch(
-            "torch.distributed.device_mesh.get_backend", return_value="nccl"
-        ), mock.patch(
-            "torch.distributed.device_mesh.split_group", return_value=None
-        ), mock.patch(
-            "torch.distributed.device_mesh.new_group"
-        ) as mock_new_group, mock.patch(
-            "torch.distributed.device_mesh.torch.cuda.is_available", return_value=False
+        with (
+            mock.patch(
+                "torch.distributed.device_mesh.is_initialized", return_value=True
+            ),
+            mock.patch(
+                "torch.distributed.device_mesh.get_world_size", return_value=world_size
+            ),
+            mock.patch("torch.distributed.device_mesh.get_rank", return_value=0),
+            mock.patch(
+                "torch.distributed.device_mesh._get_default_group",
+                return_value=dummy_pg,
+            ),
+            mock.patch(
+                "torch.distributed.device_mesh.get_backend", return_value="nccl"
+            ),
+            mock.patch("torch.distributed.device_mesh.split_group", return_value=None),
+            mock.patch("torch.distributed.device_mesh.new_group") as mock_new_group,
+            mock.patch(
+                "torch.distributed.device_mesh.torch.cuda.is_available",
+                return_value=False,
+            ),
         ):
             DeviceMesh("cpu", mesh)
             mock_new_group.assert_called_once()

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -272,10 +272,10 @@ else:
             # TODO: think about how to allow pg options to be passed to world group
             # or mesh dimension groups
             if not default_initialized:
-                init_pg_kwargs: dict[str, object] = {}
+                backend_override: Optional[str] = None
                 if self._device_type == "cpu" and not torch.cuda.is_available():
-                    init_pg_kwargs["backend"] = "gloo"
-                init_process_group(**init_pg_kwargs)
+                    backend_override = "gloo"
+                init_process_group(backend=backend_override)
 
             world_size = get_world_size()
             if self.mesh.numel() > world_size:
@@ -350,7 +350,10 @@ else:
                             ranks=ranks,
                             group_desc="mesh_default",
                         )
-                    elif torch.cuda.is_available() and get_backend(default_group) == "gloo":
+                    elif (
+                        torch.cuda.is_available()
+                        and get_backend(default_group) == "gloo"
+                    ):
                         dim_group = new_group(
                             backend="cpu:gloo,cuda:nccl",
                             ranks=ranks,
@@ -358,10 +361,7 @@ else:
                         )
                     else:
                         dim_group = default_group
-                elif (
-                    torch.cuda.is_available()
-                    and get_backend(default_group) == "gloo"
-                ):
+                elif torch.cuda.is_available() and get_backend(default_group) == "gloo":
                     dim_group = new_group(
                         backend="cpu:gloo,cuda:nccl",
                         ranks=ranks,


### PR DESCRIPTION
## Summary
- make `init_device_mesh("cpu", …)` pass `backend="gloo"` when it has to bootstrap distributed
- create gloo subgroups whenever the default process group lacks CPU support so CPU meshes can reuse DeviceMesh APIs on CUDA builds without GPUs
- document the mocked tests that exercise this edge case

## Testing
- python test/distributed/test_device_mesh.py -k DeviceMeshCPUFallbackTest -v
- ```python
  import os
  import tempfile
  import torch
  import torch.distributed as dist
  import torch.multiprocessing as mp

  def worker(rank, world_size, init_file):
      dist.init_process_group("gloo", rank=rank, world_size=world_size,
                              init_method=f"file://{init_file}")
      mesh = dist.init_device_mesh(device_type="cpu", mesh_shape=(world_size,))
      group = mesh.get_group()
      inp = torch.tensor([rank], dtype=torch.float32)
      out = torch.empty(world_size, dtype=torch.float32)
      dist.all_gather_into_tensor(out, inp, group=group)
      if rank == 0:
          print("all_gather result", out.tolist())
      dist.destroy_process_group()

  if __name__ == "__main__":
      world_size = 2
      fd, path = tempfile.mkstemp()
      os.close(fd)
      try:
          mp.spawn(worker, args=(world_size, path), nprocs=world_size, join=True)
      finally:
          if os.path.exists(path):
              os.remove(path)
  ```

## Not tested
- GPU/NCCL DeviceMesh coverage (will rely on CI or a separate GPU run)

Fixes #114629

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci
