### PR TITLE
(2/3)[DTensor][AllPermute] Implement AllPermute collective op for ordered shard

### DIFF
--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -1166,47 +1166,108 @@ class DistributeWithDeviceOrderTest(DTensorTestBase):
         self.assertEqual(x_ordered_dt.to_local(), x_strided_dt.to_local())
 
     @with_comms
-    def test_all_permute_mesh_dim(self):
+    def test_all_permute_mesh_dim_between_tensor_dims(self):
         torch.manual_seed(21)
         mesh = init_device_mesh(self.device_type, (2, 2, 2))
         input_tensor = torch.randn(4, 4, 4, self.world_size, device=self.device_type)
-        src_distribution = (
-            ShardOrderEntry(tensor_dim=0, mesh_dims=(0,)),
-            ShardOrderEntry(tensor_dim=1, mesh_dims=(1,)),
-            ShardOrderEntry(tensor_dim=2, mesh_dims=(2,)),
-        )
+        # generate all permutations of [0, 1, 2] as the shard order
+        perms = list(itertools.permutations([0, 1, 2]))
 
-        input_tensor_dt = self.distribute_tensor(
-            input_tensor,
-            mesh,
-            [Shard(0), Shard(1), Shard(2)],
-            shard_order=src_distribution,
-        )
-        full_tensor_shape = input_tensor.shape
-        tgt_distribution = (
-            ShardOrderEntry(tensor_dim=0, mesh_dims=(2,)),
-            ShardOrderEntry(tensor_dim=1, mesh_dims=(0,)),
-            ShardOrderEntry(tensor_dim=2, mesh_dims=(1,)),
-        )
+        # pick any two from `perms`, to redistribute from one to another using AllPermute op
+        for i in range(len(perms)):
+            src_distribution = {0: [perms[i][0]], 1: [perms[i][1]], 2: [perms[i][2]]}
+            src_shard_order = self._convert_shard_order_dict_to_ShardOrder(
+                src_distribution
+            )
+            for j in range(len(perms)):
+                tgt_distribution = {
+                    0: [perms[j][0]],
+                    1: [perms[j][1]],
+                    2: [perms[j][2]],
+                }
+                tgt_shard_order = self._convert_shard_order_dict_to_ShardOrder(
+                    tgt_distribution
+                )
+                input_tensor_dt = self.distribute_tensor(
+                    input_tensor,
+                    mesh,
+                    self._shard_order_to_placement(src_shard_order, mesh),
+                    shard_order=src_shard_order,
+                )
+                full_tensor_shape = input_tensor.shape
+                comm_mode = CommDebugMode()
+                with comm_mode:
+                    new_tensor = all_permute_mesh_dim(
+                        input_tensor_dt.to_local(),
+                        full_tensor_shape,
+                        src_shard_order,
+                        tgt_shard_order,
+                        mesh,
+                    )
+                # only need 1 all_to_all_single to permute over all mesh axes
+                self.assertEqual(
+                    comm_mode.get_total_counts(),
+                    1,
+                    f"detected all comms: {comm_mode.get_comm_counts()}",
+                )
 
-        # TODO: test with comm
+                input_tensor_from_spec_dt = self.distribute_tensor(
+                    input_tensor,
+                    mesh,
+                    self._shard_order_to_placement(tgt_shard_order, mesh),
+                    shard_order=tgt_shard_order,
+                )
+                self.assertEqual(new_tensor, input_tensor_from_spec_dt.to_local())
 
-        # all_permute_mesh_dim can mutate on multiple mesh dims together
-        new_tensor = all_permute_mesh_dim(
-            input_tensor_dt.to_local(),
-            full_tensor_shape,
-            src_distribution,
-            tgt_distribution,
-            mesh,
-        )
+    @with_comms
+    def test_all_permute_tensor_dim_inner_exchange(self):
+        torch.manual_seed(21)
+        mesh = init_device_mesh(self.device_type, (2, 2, 2))
+        input_tensor = torch.randn(8, 8, 4, self.world_size, device=self.device_type)
+        perms = list(itertools.permutations([0, 1, 2]))
 
-        input_tensor_from_spec_dt = self.distribute_tensor(
-            input_tensor,
-            mesh,
-            [Shard(1), Shard(2), Shard(0)],
-            shard_order=tgt_distribution,
-        )
-        self.assertEqual(new_tensor, input_tensor_from_spec_dt.to_local())
+        # pick any two from `perms`, to redistribute from one to another using AllPermute op
+        for i in range(len(perms)):
+            for j in range(len(perms)):
+                src_distribution = {0: perms[i]}
+                tgt_distribution = {0: perms[j]}
+                src_shard_order = self._convert_shard_order_dict_to_ShardOrder(
+                    src_distribution
+                )
+                input_tensor_dt = self.distribute_tensor(
+                    input_tensor,
+                    mesh,
+                    self._shard_order_to_placement(src_shard_order, mesh),
+                    shard_order=src_shard_order,
+                )
+                full_tensor_shape = input_tensor.shape
+                tgt_shard_order = self._convert_shard_order_dict_to_ShardOrder(
+                    tgt_distribution
+                )
+
+                comm_mode = CommDebugMode()
+                with comm_mode:
+                    new_tensor = all_permute_mesh_dim(
+                        input_tensor_dt.to_local(),
+                        full_tensor_shape,
+                        src_shard_order,
+                        tgt_shard_order,
+                        mesh,
+                    )
+                # only need 1 all_to_all_single to permute over all mesh axes
+                self.assertEqual(
+                    comm_mode.get_total_counts(),
+                    1,
+                    f"detected all comms: {comm_mode.get_comm_counts()}",
+                )
+
+                input_tensor_from_spec_dt = self.distribute_tensor(
+                    input_tensor,
+                    mesh,
+                    self._shard_order_to_placement(tgt_shard_order, mesh),
+                    shard_order=tgt_shard_order,
+                )
+                self.assertEqual(new_tensor, input_tensor_from_spec_dt.to_local())
 
 
 if __name__ == "__main__":

--- a/torch/distributed/tensor/_collective_utils.py
+++ b/torch/distributed/tensor/_collective_utils.py
@@ -11,6 +11,7 @@ import torch.distributed.tensor._dtensor_spec as dtensor_spec
 from torch._C._distributed_c10d import _resolve_process_group
 from torch._logging import warning_once
 from torch.distributed._local_tensor import local_tensor_mode
+from torch.distributed._pycute.int_tuple import crd2idx, idx2crd
 from torch.distributed.device_mesh import _mesh_resources, DeviceMesh
 from torch.distributed.distributed_c10d import (
     _get_group_size_by_name,
@@ -61,6 +62,149 @@ def shard_dim_alltoall(input, gather_dim, shard_dim, mesh, mesh_dim):
     return torch.ops._dtensor.shard_dim_alltoall(
         input, gather_dim, shard_dim, group_name
     )
+
+
+def all_permute_mesh_dim(
+    input: torch.Tensor,
+    full_tensor_shape: torch.Size,
+    src_distribution: "dtensor_spec.ShardOrder",
+    tgt_distribution: "dtensor_spec.ShardOrder",
+    mesh: DeviceMesh,
+):
+    """
+    Perform an AllPermute operation to redistribute a tensor from source to target sharding.
+
+    AllPermute is a collective communication primitive that can transform any tensor distribution
+    τ1 to τ2 if their local and global shapes match. Unlike traditional redistributions that may
+    require multiple AllGather operations, AllPermute achieves the transformation through a single
+    permutation-based communication, significantly reducing memory overhead.
+
+    Mathematical Background:
+    ------------------------
+    Given a DeviceMesh with dimensions {X, Y, Z, ...} and a tensor with shape [D0, D1, D2, ...],
+    sharding annotations specify how tensor dimensions are distributed across mesh dimensions.
+
+    Notation (from https://arxiv.org/pdf/2112.01075 "section 2.1 Distributed array types"):
+        - [32{X,Y}512, 128]: Tensor of shape [32*512, 128] sharded on mesh dims X,Y for dim 0
+        - [128{Y}512, 32{X}128]: First tensor dim sharded on mesh Y, second dim on mesh X
+
+    Examples:
+    ---------
+    Given mesh with size {X:4, Y:4, Z:16}:
+
+    Example 1: Swap mesh dimension order for the same tensor dimension
+        Source: [32{X,Y}512, 128]  → Target: [32{Y,X}512, 128]
+        This swaps the order in which mesh dimensions X and Y shard the first tensor dimension.
+
+    Example 2: Swap which tensor dimensions are sharded on which mesh dimensions
+        Source: [128{Y}512, 32{X}128] → Target: [128{X}512, 32{Y}128]
+        Tensor dimension 0 moves from mesh dim Y to X, dimension 1 moves from X to Y.
+
+    Example 3: Change mesh dimensions entirely while preserving shapes
+        Source: [32{X,Y}512, 128] → Target: [32{Z}512, 128]
+        Re-shard from mesh dimensions X,Y to mesh dimension Z.
+
+    Algorithm:
+    ----------
+    1. For each source rank, compute its position in the global tensor based on src_distribution
+    2. Determine which target rank should receive this data based on tgt_distribution
+    3. Build a permutation mapping: src_rank → tgt_rank
+    4. Execute permute_tensor to swap data according to the mapping
+
+    The key insight is that each rank knows exactly where its data should go in the target
+    distribution without requiring intermediate gather operations.
+
+    Args:
+        input (torch.Tensor): Local tensor shard to redistribute. Must be the actual data
+            held by the current rank according to src_distribution.
+        full_tensor_shape (torch.Size): Shape of the global (unsharded) tensor before any
+            distribution. Used to compute correct offsets and mappings.
+        src_distribution (ShardOrder): Description of how the input tensor is currently
+            distributed across the mesh. Specifies which tensor dimensions are sharded
+            on which mesh dimensions.
+        tgt_distribution (ShardOrder): Target distribution specification. Describes the
+            desired sharding pattern after the AllPermute operation.
+        mesh (DeviceMesh): The device mesh over which the tensor is distributed. Defines
+            the process group topology for communication.
+
+    Returns:
+        torch.Tensor: The redistributed local tensor shard according to tgt_distribution.
+            The returned tensor represents this rank's portion of the global tensor under
+            the new distribution scheme.
+
+    Preconditions:
+        - Source and target distributions must have matching local and global tensor shapes
+        - Input must be a local tensor (not a DTensor wrapper)
+        - The mesh topology must match both src_distribution and tgt_distribution
+
+    Example Usage:
+        >>> # 2D mesh [4, 4] with tensor shape [64, 128]
+        >>> mesh = DeviceMesh(
+        ...     "cuda", [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11], [12, 13, 14, 15]]
+        ... )
+        >>> # Redistribute from [64{mesh_dim=0}, 128] to [64, 128{mesh_dim=1}]
+        >>> src_dist = ShardOrder([ShardEntry(tensor_dim=0, mesh_dims=[0])])
+        >>> tgt_dist = ShardOrder([ShardEntry(tensor_dim=1, mesh_dims=[1])])
+        >>> output = all_permute_mesh_dim(
+        ...     local_shard, (64, 128), src_dist, tgt_dist, mesh
+        ... )
+    """
+    orig_tensor_shape = list(input.shape)
+    for entry in src_distribution:
+        tensor_dim = entry.tensor_dim
+        shard_tensor_on_mesh_dims = entry.mesh_dims
+        for mesh_dim in shard_tensor_on_mesh_dims:
+            orig_tensor_shape[tensor_dim] *= mesh.size(mesh_dim)
+
+    permuted_rank = list(range(0, torch.distributed.get_world_size()))
+    for src_rank in range(mesh.size()):
+        # get target coordinate for src_rank
+        tgt_coordinate = [0] * mesh.ndim
+
+        src_distr_idx, tgt_distr_idx = 0, 0
+        for tensor_dim in range(len(full_tensor_shape)):
+            src_distribute_to_mesh_dims: tuple[int, ...] = ()
+            if (
+                src_distr_idx < len(src_distribution)
+                and src_distribution[src_distr_idx].tensor_dim == tensor_dim
+            ):
+                src_distribute_to_mesh_dims = src_distribution[src_distr_idx].mesh_dims
+                src_distr_idx += 1
+            tgt_distribute_to_mesh_dims: tuple[int, ...] = ()
+            if (
+                tgt_distr_idx < len(tgt_distribution)
+                and tgt_distribution[tgt_distr_idx].tensor_dim == tensor_dim
+            ):
+                tgt_distribute_to_mesh_dims = tgt_distribution[tgt_distr_idx].mesh_dims
+                tgt_distr_idx += 1
+            # map current rank to global coordinate [x, y, u]
+            src_coordinate = idx2crd(src_rank, mesh.shape)
+            dividend_size = 0
+            # map back from src_distribution
+            prev_size = full_tensor_shape[tensor_dim]
+            for mesh_dim in src_distribute_to_mesh_dims:
+                cur_size = math.ceil(prev_size / mesh.size(mesh_dim))
+                assert isinstance(src_coordinate, tuple), (
+                    "src_coordinate should be a tuple"
+                )
+                coord_val = src_coordinate[mesh_dim]
+                assert isinstance(coord_val, int), (
+                    f"Expected int coordinate, got {type(coord_val)}"
+                )
+                dividend_size += coord_val * cur_size
+                prev_size = cur_size
+            divisor_size = full_tensor_shape[tensor_dim]
+            for mesh_dim in tgt_distribute_to_mesh_dims:
+                divisor_size = math.ceil(divisor_size / mesh.size(mesh_dim))
+                tgt_coordinate[mesh_dim] = dividend_size // divisor_size
+
+            tgt_rank = crd2idx(tuple(tgt_coordinate), mesh.shape)
+            # plan to send src_rank data to tgt_rank
+            permuted_rank[src_rank] = tgt_rank
+    output = funcol.permute_tensor(input, permuted_rank, mesh)
+    if isinstance(output, funcol.AsyncCollectiveTensor):
+        output = output.wait()
+    return output
 
 
 def mesh_scatter(

--- a/torch/distributed/tensor/debug/_comm_mode.py
+++ b/torch/distributed/tensor/debug/_comm_mode.py
@@ -249,6 +249,7 @@ class CommDebugMode(TorchDispatchMode):
             self.comm_registry.add(py_op)
 
         self.comm_registry.add(torch.ops._dtensor.shard_dim_alltoall)
+        self.comm_registry.add(torch.ops._c10d_functional.all_to_all_single)
         self.advanced_module_tracker = _CommModeModuleTracker()
 
     def generate_json_dump(self, file_name="comm_mode_log.json", noise_level=3):


### PR DESCRIPTION
### Summary
Introduce the `AllPermute` collective operation as mentioned in https://arxiv.org/pdf/2112.01075 "section 2.6 Collective operations".  

### What is AllPermute?
AllPermute can transform any 𝜏1 to 𝜏2 if their local and global shapes match. For example:
Given mesh and size {X:4, Y:4, Z:16}, we have
- example 1: [32{X,Y}}512, 128] -> [32{Y,X}512, 128]
- example 2: [128{Y}512, 32{X}128] -> [128{X}512, 32{Y}128]
- example 3: [32{X,Y}512, 128] -> [32{Z}512, 128]
Note: annotation borrowed from https://arxiv.org/pdf/2112.01075 "section 2.1 Distributed array types"

### Why we need AllPermute?
With AllPermute, we can eliminate some AllGather ops during redistribution. This plays an important role in reducing the memory overhead. In theory, at most one AllPermute is needed to redistribute from any 𝜏1 to 𝜏2. The `AllPermute` can be performed as the final step, or moved before the last `AllGather` to minimize the amount of data relocated between shards in the `AllPermute`.


### Algorithm
The function `all_permute_mesh_dim` determines, for a given local tensor shard (the data on the current rank), which target rank should receive this data when redistributing a tensor from a source sharding distribution to a target sharding distribution across a device mesh. It computes a permutation mapping between source and target ranks based on how tensor dimensions are sharded on mesh dimensions, and then uses this mapping to permute the data accordingly. This enables efficient redistribution of tensor shards without intermediate gather operations.

We use device coordinate as a bridge to compute where the data should be send to. Let's use the 3D mesh (size: [X, Y, U]) and 3D tensor (size: [I, J, K]) as the example:  
Assume data is located on device with coordinate:

 $$\tau_1 = (x, y, u)$$

(using tensor-centric format) When we do AllPermute from source distribution ``S(I)[X, Y]S(K)[U]`` to target distribution ``S(I)[U]S(K)[X,Y]`` , the data will be relocated from `(x, y, u)` to:

$$\tau_2 = (\frac{u\lceil \frac{K}{U} \rceil}{\lceil\frac{K}{X}\rceil},  \frac{u\lceil\frac{K}{U}\rceil(mod\ \lceil \frac{K}{X} \rceil)}{\lceil \frac{\lceil \frac{K}{X}\rceil}{Y} \rceil},   \frac{x\lceil\frac{I}{X}\rceil + y\lceil \frac{\lceil \frac{I}{X} \rceil}{Y}\rceil}{\lceil \frac{I}{U} \rceil})$$

Luckily the main logic can be implemented with ~10 lines of code. Hope the algorithm is self-explainable with the example :) 

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #165712
* #165711



cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci