### PR TITLE
[dynamo] Clean up assert in dynamo [2/N]

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2769,22 +2769,24 @@ def slice_length(s: slice, seq_len: int) -> int:
 
 
 def raise_args_mismatch(
-    tx: InstructionTranslatorBase, name: str, expect: str = ""
+    tx: InstructionTranslatorBase,
+    name: str,
+    expect: str = "",
+    actual: str = "",
 ) -> None:
     from torch._dynamo.exc import raise_observed_exception
     from torch._dynamo.variables import ConstantVariable
 
-    msg = [
-        ConstantVariable(
-            f"wrong number of arguments or keyword arguments for {name}() call. "
-            + expect
-        )
-    ]
+    msg_str = (
+        f"wrong number of arguments or keyword arguments for {name}() call.\n"
+        f"  Expect: {expect}\n"
+        f"  Actual: {actual}"
+    )
 
     raise_observed_exception(
         TypeError,
         tx,
-        args=msg,
+        args=[ConstantVariable(msg_str)],
     )
 
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2768,14 +2768,23 @@ def slice_length(s: slice, seq_len: int) -> int:
     return max(0, (stop - start + (step - (1 if step > 0 else -1))) // step)
 
 
-def raise_args_mismatch(tx: InstructionTranslatorBase, name: str) -> None:
+def raise_args_mismatch(
+    tx: InstructionTranslatorBase, name: str, expect: str = ""
+) -> None:
     from torch._dynamo.exc import raise_observed_exception
     from torch._dynamo.variables import ConstantVariable
+
+    msg = [
+        ConstantVariable(
+            f"wrong number of arguments or keyword arguments for {name}() call. "
+            + expect
+        )
+    ]
 
     raise_observed_exception(
         TypeError,
         tx,
-        args=[ConstantVariable(f"wrong number of arguments for {name}() call")],
+        args=msg,
     )
 
 

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -77,16 +77,12 @@ from ..utils import (
     istype,
     numpy_operator_wrapper,
     proxy_args_kwargs,
+    raise_args_mismatch,
     set_methods,
     str_methods,
     tensortype_to_dtype,
 )
-from .base import (
-    AsPythonConstantNotImplementedError,
-    raise_type_error_exc,
-    ValueMutationNew,
-    VariableTracker,
-)
+from .base import AsPythonConstantNotImplementedError, ValueMutationNew, VariableTracker
 from .constant import ConstantVariable
 from .dicts import (
     ConstDictVariable,
@@ -1953,17 +1949,25 @@ class BuiltinVariable(VariableTracker):
                 or len(kwargs) != 1
                 or "value" not in kwargs
             ):
-                raise_type_error_exc(
-                    tx, f"{user_cls.__name__}.fromkeys() takes no keyword arguments"
+                raise_args_mismatch(
+                    tx,
+                    f"{user_cls.__name__}.fromkeys",
+                    f"Expect: 1 args and 1 kwargs (`value`), Actual: {len(args)} args and {len(kwargs)} kwargs",
                 )
             args = (*args, kwargs.pop("value"))
         if len(args) == 0:
-            raise_type_error_exc(tx, "fromkeys expected at least 1 arguments, got 0")
+            raise_args_mismatch(
+                tx,
+                f"{user_cls.__name__}.fromkeys",
+                f"Expect: at least 1 args, Actual: {len(args)} args",
+            )
         if len(args) == 1:
             args = (*args, ConstantVariable.create(None))
         if len(args) != 2:
-            raise_type_error_exc(
-                tx, f"fromkeys expected at most 2 arguments, got {len(args)}"
+            raise_args_mismatch(
+                tx,
+                f"{user_cls.__name__}.fromkeys",
+                f"Expect: 2 args, Actual: {len(args)} args",
             )
         arg, value = args
         DictVariableType = (
@@ -2061,9 +2065,10 @@ class BuiltinVariable(VariableTracker):
     def call_zip(self, tx: "InstructionTranslator", *args, **kwargs):
         if kwargs:
             if not (len(kwargs) == 1 and "strict" in kwargs):
-                raise_type_error_exc(
+                raise_args_mismatch(
                     tx,
-                    f"zip() should only have 'strict' keyword argument, but ({len(kwargs)} given)",
+                    "zip",
+                    f"Expect: 1 kwargs (`strict`), Actual: {len(kwargs)} kwargs",
                 )
         strict = kwargs.pop("strict", False)
         args = [BuiltinVariable(iter).call_function(tx, [arg], {}) for arg in args]

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1952,14 +1952,16 @@ class BuiltinVariable(VariableTracker):
                 raise_args_mismatch(
                     tx,
                     f"{user_cls.__name__}.fromkeys",
-                    f"Expect: 1 args and 1 kwargs (`value`), Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "1 args and 1 kwargs (`value`)",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             args = (*args, kwargs.pop("value"))
         if len(args) == 0:
             raise_args_mismatch(
                 tx,
                 f"{user_cls.__name__}.fromkeys",
-                f"Expect: at least 1 args, Actual: {len(args)} args",
+                "at least 1 args",
+                f"{len(args)} args",
             )
         if len(args) == 1:
             args = (*args, ConstantVariable.create(None))
@@ -1967,7 +1969,8 @@ class BuiltinVariable(VariableTracker):
             raise_args_mismatch(
                 tx,
                 f"{user_cls.__name__}.fromkeys",
-                f"Expect: 2 args, Actual: {len(args)} args",
+                "2 args",
+                f"{len(args)} args",
             )
         arg, value = args
         DictVariableType = (
@@ -2068,7 +2071,8 @@ class BuiltinVariable(VariableTracker):
                 raise_args_mismatch(
                     tx,
                     "zip",
-                    f"Expect: 1 kwargs (`strict`), Actual: {len(kwargs)} kwargs",
+                    "1 kwargs (`strict`)",
+                    f"{len(kwargs)} kwargs",
                 )
         strict = kwargs.pop("strict", False)
         args = [BuiltinVariable(iter).call_function(tx, [arg], {}) for arg in args]

--- a/torch/_dynamo/variables/constant.py
+++ b/torch/_dynamo/variables/constant.py
@@ -159,7 +159,8 @@ its type to `common_constant_types`.
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             arg_unpacked = args[0].force_unpack_var_sequence(tx)
             try:

--- a/torch/_dynamo/variables/constant.py
+++ b/torch/_dynamo/variables/constant.py
@@ -16,8 +16,14 @@ from torch._dynamo.source import AttrSource, GetItemSource
 
 from .. import graph_break_hints, variables
 from ..exc import raise_observed_exception, unimplemented_v2
-from ..utils import cmp_name_to_op_mapping, common_constant_types, istype, np
-from .base import raise_type_error_exc, VariableTracker
+from ..utils import (
+    cmp_name_to_op_mapping,
+    common_constant_types,
+    istype,
+    np,
+    raise_args_mismatch,
+)
+from .base import VariableTracker
 
 
 if TYPE_CHECKING:
@@ -149,8 +155,12 @@ its type to `common_constant_types`.
                 tx, [self, *args], kwargs
             )
         elif name == "join" and istype(self.value, str):
-            if not (len(args) == 1 and len(kwargs) == 0):
-                raise_type_error_exc(tx, "str.join() takes exactly one argument")
+            if kwargs or len(args) != 1:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             arg_unpacked = args[0].force_unpack_var_sequence(tx)
             try:
                 arg_const = [x.as_python_constant() for x in arg_unpacked]

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -44,7 +44,7 @@ from ..utils import (
     raise_args_mismatch,
     specialize_symnode,
 )
-from .base import raise_type_error_exc, ValueMutationNew, VariableTracker
+from .base import ValueMutationNew, VariableTracker
 from .constant import ConstantVariable
 
 
@@ -466,25 +466,37 @@ class ConstDictVariable(VariableTracker):
         elif name == "__getitem__":
             # Key guarding - Nothing to do. LazyVT for value will take care.
             if len(args) != 1:
-                raise_args_mismatch(tx, name)
+                raise_args_mismatch(
+                    tx, name, f"Expect: 1 args, Actual: {len(args)} args"
+                )
             return self.getitem_const_raise_exception_if_absent(tx, args[0])
         elif name == "items":
             if args or kwargs:
-                raise_args_mismatch(tx, name)
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             self.install_dict_keys_match_guard()
             if self.source:
                 tx.output.guard_on_key_order.add(self.source)
             return DictItemsVariable(self)
         elif name == "keys":
             if len(args):
-                raise_args_mismatch(tx, name)
+                raise_args_mismatch(
+                    tx, name, f"Expect: 0 args, Actual: {len(args)} args"
+                )
             self.install_dict_keys_match_guard()
             if self.source:
                 tx.output.guard_on_key_order.add(self.source)
             return DictKeysVariable(self)
         elif name == "values":
             if args or kwargs:
-                raise_args_mismatch(tx, name)
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             self.install_dict_keys_match_guard()
             if self.source:
                 tx.output.guard_on_key_order.add(self.source)
@@ -494,13 +506,21 @@ class ConstDictVariable(VariableTracker):
         elif name == "copy":
             self.install_dict_keys_match_guard()
             if args or kwargs:
-                raise_args_mismatch(tx, name)
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             return self.clone(
                 items=self.items.copy(), mutation_type=ValueMutationNew(), source=None
             )
         elif name == "__len__":
             if args or kwargs:
-                raise_args_mismatch(tx, name)
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             self.install_dict_keys_match_guard()
             return ConstantVariable.create(len(self.items))
         elif name == "__setitem__" and self.is_mutable():
@@ -509,9 +529,10 @@ class ConstDictVariable(VariableTracker):
 
             self.install_dict_keys_match_guard()
             if kwargs or len(args) != 2:
-                raise_type_error_exc(
+                raise_args_mismatch(
                     tx,
-                    f"dict.__setitem__ takes exactly two arguments ({len(args)} given)",
+                    name,
+                    f"Expect: 2 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
                 )
             tx.output.side_effects.mutation(self)
             self.items[Hashable(args[0])] = args[1]
@@ -524,7 +545,9 @@ class ConstDictVariable(VariableTracker):
             return ConstantVariable.create(None)
         elif name == "get":
             if len(args) not in (1, 2):
-                raise_args_mismatch(tx, name)
+                raise_args_mismatch(
+                    tx, name, f"Expect: 1 or 2 args, Actual: {len(args)} args"
+                )
 
             if not arg_hashable:
                 raise_unhashable(args[0])
@@ -539,7 +562,9 @@ class ConstDictVariable(VariableTracker):
             return self.getitem_const(tx, args[0])
         elif name == "pop" and self.is_mutable():
             if len(args) not in (1, 2):
-                raise_args_mismatch(tx, name)
+                raise_args_mismatch(
+                    tx, name, f"Expect: 1 or 2 args, Actual: {len(args)} args"
+                )
 
             if not arg_hashable:
                 raise_unhashable(args[0])
@@ -586,7 +611,11 @@ class ConstDictVariable(VariableTracker):
             return variables.TupleVariable([k.vt, v])
         elif name == "clear":
             if args or kwargs:
-                raise_args_mismatch(tx, name)
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             self.should_reconstruct_all = True
             tx.output.side_effects.mutation(self)
             self.items.clear()
@@ -620,7 +649,11 @@ class ConstDictVariable(VariableTracker):
                 return super().call_method(tx, name, args, kwargs)
         elif name == "__contains__":
             if not len(args):
-                raise_args_mismatch(tx, name)
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: more than 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
 
             if not arg_hashable:
                 raise_unhashable(args[0])
@@ -630,14 +663,22 @@ class ConstDictVariable(VariableTracker):
             return ConstantVariable.create(contains)
         elif name == "setdefault" and self.is_mutable():
             if len(args) not in (1, 2):
-                raise_args_mismatch(tx, name)
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 1 or 2 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
 
             if not arg_hashable:
                 raise_unhashable(args[0])
 
             self.install_dict_keys_match_guard()
-            assert not kwargs
-            assert len(args) <= 2
+            if kwargs and len(args) > 2:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: at most 2 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             value = self.maybe_getitem_const(args[0])
             if value is not None:
                 return value
@@ -673,7 +714,9 @@ class ConstDictVariable(VariableTracker):
             self, ConstDictVariable
         ):  # don't let Set use this function
             if len(args) != 1:
-                raise_args_mismatch(tx, name)
+                raise_args_mismatch(
+                    tx, name, f"Expect: 1 args, Actual: {len(args)} args"
+                )
 
             return variables.UserFunctionVariable(polyfills.dict___eq__).call_function(
                 tx, [self, args[0]], {}
@@ -683,7 +726,10 @@ class ConstDictVariable(VariableTracker):
                 not self.call_method(tx, "__eq__", args, kwargs).value
             )
         elif name == "__or__":
-            assert len(args) == 1
+            if len(args) != 1:
+                raise_args_mismatch(
+                    tx, name, f"Expect: 1 args, Actual: {len(args)} args"
+                )
             other = args[0]
 
             # Method resolution for binops works as follow (using __or__ as example):
@@ -879,7 +925,10 @@ class DefaultDictVariable(ConstDictVariable):
         kwargs: "dict[str, VariableTracker]",
     ) -> "VariableTracker":
         if name == "__getitem__":
-            assert len(args) == 1
+            if len(args) != 1:
+                raise_args_mismatch(
+                    tx, name, f"Expect: 1 args, Actual: {len(args)} args"
+                )
 
             if args[0] in self:
                 return self.getitem_const(tx, args[0])
@@ -998,14 +1047,21 @@ class SetVariable(ConstDictVariable):
             self.items.update(temp_set_vt.items)
             return ConstantVariable.create(None)
         elif name == "add":
-            assert not kwargs
-            if len(args) != 1:
-                raise_args_mismatch(tx, name)
+            if kwargs or len(args) != 1:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             name = "__setitem__"
             args = (args[0], SetVariable._default_value())
         elif name == "pop":
-            assert not kwargs
-            assert not args
+            if kwargs or args:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             # Choose an item at random and pop it via the Dict.pop method
             try:
                 result = self.set_items.pop().vt
@@ -1016,72 +1072,109 @@ class SetVariable(ConstDictVariable):
             super().call_method(tx, name, (result,), kwargs)
             return result
         elif name == "isdisjoint":
-            if len(args) != 1:
-                raise_args_mismatch(tx, name)
-            assert not kwargs
+            if kwargs or len(args) != 1:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             return variables.UserFunctionVariable(
                 polyfills.set_isdisjoint
             ).call_function(tx, [self, args[0]], {})
         elif name == "intersection":
-            assert not kwargs
+            if kwargs:
+                raise_args_mismatch(
+                    tx, name, f"Expect: 0 kwargs, Actual: {len(kwargs)} kwargs"
+                )
             return variables.UserFunctionVariable(
                 polyfills.set_intersection
             ).call_function(tx, [self, *args], {})
         elif name == "intersection_update":
-            assert not kwargs
+            if kwargs:
+                raise_args_mismatch(
+                    tx, name, f"Expect: 0 kwargs, Actual: {len(kwargs)} kwargs"
+                )
             return variables.UserFunctionVariable(
                 polyfills.set_intersection_update
             ).call_function(tx, [self, *args], {})
         elif name == "union":
-            assert not kwargs
+            if kwargs:
+                raise_args_mismatch(
+                    tx, name, f"Expect: 0 kwargs, Actual: {len(kwargs)} kwargs"
+                )
             return variables.UserFunctionVariable(polyfills.set_union).call_function(
                 tx, [self, *args], {}
             )
         elif name == "difference":
-            assert not kwargs
+            if kwargs:
+                raise_args_mismatch(
+                    tx, name, f"Expect: 0 kwargs, Actual: {len(kwargs)} kwargs"
+                )
             return variables.UserFunctionVariable(
                 polyfills.set_difference
             ).call_function(tx, [self, *args], {})
         elif name == "difference_update":
-            assert not kwargs
+            if kwargs:
+                raise_args_mismatch(
+                    tx, name, f"Expect: 0 kwargs, Actual: {len(kwargs)} kwargs"
+                )
             return variables.UserFunctionVariable(
                 polyfills.set_difference_update
             ).call_function(tx, [self, *args], {})
         elif name == "symmetric_difference":
-            if len(args) != 1:
-                raise_args_mismatch(tx, name)
-            assert not kwargs
+            if kwargs or len(args) != 1:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             return variables.UserFunctionVariable(
                 polyfills.set_symmetric_difference
             ).call_function(tx, [self, *args], {})
         elif name == "symmetric_difference_update":
-            if len(args) != 1:
-                raise_args_mismatch(tx, name)
-            assert not kwargs
+            if kwargs or len(args) != 1:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             return variables.UserFunctionVariable(
                 polyfills.set_symmetric_difference_update
             ).call_function(tx, [self, *args], {})
         elif name == "update" and self.is_mutable():
-            assert not kwargs
+            if kwargs:
+                raise_args_mismatch(
+                    tx, name, f"Expect: 0 kwargs, Actual: {len(kwargs)} kwargs"
+                )
             return variables.UserFunctionVariable(polyfills.set_update).call_function(
                 tx, [self, *args], {}
             )
         elif name == "remove":
-            assert not kwargs
-            assert len(args) == 1
+            if kwargs or len(args) != 1:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             if args[0] not in self:
                 raise_observed_exception(KeyError, tx, args=args)
             return super().call_method(tx, "pop", args, kwargs)
         elif name == "discard":
-            assert not kwargs
-            assert len(args) == 1
+            if kwargs or len(args) != 1:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             if args[0] in self:
                 return super().call_method(tx, "pop", args, kwargs)
             else:
                 return ConstantVariable.create(value=None)
         elif name in ("issubset", "issuperset"):
             if len(args) != 1:
-                raise_args_mismatch(tx, name)
+                raise_args_mismatch(
+                    tx, name, f"Expect: 1 args, Actual: {len(args)} args"
+                )
 
             op = {
                 "issubset": operator.le,
@@ -1382,7 +1475,10 @@ class DictItemsVariable(DictViewVariable):
         # TODO(guilhermeleobas): This should actually check if args[0]
         # implements the mapping protocol.
         if name == "__eq__":
-            assert len(args) == 1
+            if len(args) != 1:
+                raise_args_mismatch(
+                    tx, name, f"Expect: 1 args, Actual: {len(args)} args"
+                )
             if isinstance(args[0], DictItemsVariable):
                 return self.dv_dict.call_method(tx, "__eq__", [args[0].dv_dict], {})
             return ConstantVariable.create(False)

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -466,16 +466,15 @@ class ConstDictVariable(VariableTracker):
         elif name == "__getitem__":
             # Key guarding - Nothing to do. LazyVT for value will take care.
             if len(args) != 1:
-                raise_args_mismatch(
-                    tx, name, f"Expect: 1 args, Actual: {len(args)} args"
-                )
+                raise_args_mismatch(tx, name, "1 args", f"{len(args)} args")
             return self.getitem_const_raise_exception_if_absent(tx, args[0])
         elif name == "items":
             if args or kwargs:
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "0 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             self.install_dict_keys_match_guard()
             if self.source:
@@ -483,9 +482,7 @@ class ConstDictVariable(VariableTracker):
             return DictItemsVariable(self)
         elif name == "keys":
             if len(args):
-                raise_args_mismatch(
-                    tx, name, f"Expect: 0 args, Actual: {len(args)} args"
-                )
+                raise_args_mismatch(tx, name, "0 args", f"{len(args)} args")
             self.install_dict_keys_match_guard()
             if self.source:
                 tx.output.guard_on_key_order.add(self.source)
@@ -495,7 +492,8 @@ class ConstDictVariable(VariableTracker):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "0 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             self.install_dict_keys_match_guard()
             if self.source:
@@ -509,7 +507,8 @@ class ConstDictVariable(VariableTracker):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "0 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             return self.clone(
                 items=self.items.copy(), mutation_type=ValueMutationNew(), source=None
@@ -519,7 +518,8 @@ class ConstDictVariable(VariableTracker):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "0 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             self.install_dict_keys_match_guard()
             return ConstantVariable.create(len(self.items))
@@ -532,7 +532,8 @@ class ConstDictVariable(VariableTracker):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 2 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "2 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             tx.output.side_effects.mutation(self)
             self.items[Hashable(args[0])] = args[1]
@@ -545,9 +546,7 @@ class ConstDictVariable(VariableTracker):
             return ConstantVariable.create(None)
         elif name == "get":
             if len(args) not in (1, 2):
-                raise_args_mismatch(
-                    tx, name, f"Expect: 1 or 2 args, Actual: {len(args)} args"
-                )
+                raise_args_mismatch(tx, name, "1 or 2 args", f"{len(args)} args")
 
             if not arg_hashable:
                 raise_unhashable(args[0])
@@ -562,9 +561,7 @@ class ConstDictVariable(VariableTracker):
             return self.getitem_const(tx, args[0])
         elif name == "pop" and self.is_mutable():
             if len(args) not in (1, 2):
-                raise_args_mismatch(
-                    tx, name, f"Expect: 1 or 2 args, Actual: {len(args)} args"
-                )
+                raise_args_mismatch(tx, name, "1 or 2 args", f"{len(args)} args")
 
             if not arg_hashable:
                 raise_unhashable(args[0])
@@ -614,7 +611,8 @@ class ConstDictVariable(VariableTracker):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "0 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             self.should_reconstruct_all = True
             tx.output.side_effects.mutation(self)
@@ -652,7 +650,8 @@ class ConstDictVariable(VariableTracker):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: more than 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "more than 1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
 
             if not arg_hashable:
@@ -666,18 +665,20 @@ class ConstDictVariable(VariableTracker):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 1 or 2 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "1 or 2 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
 
             if not arg_hashable:
                 raise_unhashable(args[0])
 
             self.install_dict_keys_match_guard()
-            if kwargs and len(args) > 2:
+            if kwargs or len(args) > 2:
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: at most 2 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "at most 2 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             value = self.maybe_getitem_const(args[0])
             if value is not None:
@@ -714,9 +715,7 @@ class ConstDictVariable(VariableTracker):
             self, ConstDictVariable
         ):  # don't let Set use this function
             if len(args) != 1:
-                raise_args_mismatch(
-                    tx, name, f"Expect: 1 args, Actual: {len(args)} args"
-                )
+                raise_args_mismatch(tx, name, "1 args", f"{len(args)} args")
 
             return variables.UserFunctionVariable(polyfills.dict___eq__).call_function(
                 tx, [self, args[0]], {}
@@ -727,9 +726,7 @@ class ConstDictVariable(VariableTracker):
             )
         elif name == "__or__":
             if len(args) != 1:
-                raise_args_mismatch(
-                    tx, name, f"Expect: 1 args, Actual: {len(args)} args"
-                )
+                raise_args_mismatch(tx, name, "1 args", f"{len(args)} args")
             other = args[0]
 
             # Method resolution for binops works as follow (using __or__ as example):
@@ -926,9 +923,7 @@ class DefaultDictVariable(ConstDictVariable):
     ) -> "VariableTracker":
         if name == "__getitem__":
             if len(args) != 1:
-                raise_args_mismatch(
-                    tx, name, f"Expect: 1 args, Actual: {len(args)} args"
-                )
+                raise_args_mismatch(tx, name, "1 args", f"{len(args)} args")
 
             if args[0] in self:
                 return self.getitem_const(tx, args[0])
@@ -1051,7 +1046,8 @@ class SetVariable(ConstDictVariable):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             name = "__setitem__"
             args = (args[0], SetVariable._default_value())
@@ -1060,7 +1056,8 @@ class SetVariable(ConstDictVariable):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "0 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             # Choose an item at random and pop it via the Dict.pop method
             try:
@@ -1076,32 +1073,27 @@ class SetVariable(ConstDictVariable):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             return variables.UserFunctionVariable(
                 polyfills.set_isdisjoint
             ).call_function(tx, [self, args[0]], {})
         elif name == "intersection":
             if kwargs:
-                raise_args_mismatch(
-                    tx, name, f"Expect: 0 kwargs, Actual: {len(kwargs)} kwargs"
-                )
+                raise_args_mismatch(tx, name, "0 kwargs", f"{len(kwargs)} kwargs")
             return variables.UserFunctionVariable(
                 polyfills.set_intersection
             ).call_function(tx, [self, *args], {})
         elif name == "intersection_update":
             if kwargs:
-                raise_args_mismatch(
-                    tx, name, f"Expect: 0 kwargs, Actual: {len(kwargs)} kwargs"
-                )
+                raise_args_mismatch(tx, name, "0 kwargs", f"{len(kwargs)} kwargs")
             return variables.UserFunctionVariable(
                 polyfills.set_intersection_update
             ).call_function(tx, [self, *args], {})
         elif name == "union":
             if kwargs:
-                raise_args_mismatch(
-                    tx, name, f"Expect: 0 kwargs, Actual: {len(kwargs)} kwargs"
-                )
+                raise_args_mismatch(tx, name, "0 kwargs", f"{len(kwargs)} kwargs")
             return variables.UserFunctionVariable(polyfills.set_union).call_function(
                 tx, [self, *args], {}
             )
@@ -1115,9 +1107,7 @@ class SetVariable(ConstDictVariable):
             ).call_function(tx, [self, *args], {})
         elif name == "difference_update":
             if kwargs:
-                raise_args_mismatch(
-                    tx, name, f"Expect: 0 kwargs, Actual: {len(kwargs)} kwargs"
-                )
+                raise_args_mismatch(tx, name, "0 kwargs", f"{len(kwargs)} kwargs")
             return variables.UserFunctionVariable(
                 polyfills.set_difference_update
             ).call_function(tx, [self, *args], {})
@@ -1126,7 +1116,8 @@ class SetVariable(ConstDictVariable):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             return variables.UserFunctionVariable(
                 polyfills.set_symmetric_difference
@@ -1136,16 +1127,15 @@ class SetVariable(ConstDictVariable):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             return variables.UserFunctionVariable(
                 polyfills.set_symmetric_difference_update
             ).call_function(tx, [self, *args], {})
         elif name == "update" and self.is_mutable():
             if kwargs:
-                raise_args_mismatch(
-                    tx, name, f"Expect: 0 kwargs, Actual: {len(kwargs)} kwargs"
-                )
+                raise_args_mismatch(tx, name, "0 kwargs", f"{len(kwargs)} kwargs")
             return variables.UserFunctionVariable(polyfills.set_update).call_function(
                 tx, [self, *args], {}
             )
@@ -1154,7 +1144,8 @@ class SetVariable(ConstDictVariable):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             if args[0] not in self:
                 raise_observed_exception(KeyError, tx, args=args)
@@ -1164,7 +1155,8 @@ class SetVariable(ConstDictVariable):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             if args[0] in self:
                 return super().call_method(tx, "pop", args, kwargs)
@@ -1172,9 +1164,7 @@ class SetVariable(ConstDictVariable):
                 return ConstantVariable.create(value=None)
         elif name in ("issubset", "issuperset"):
             if len(args) != 1:
-                raise_args_mismatch(
-                    tx, name, f"Expect: 1 args, Actual: {len(args)} args"
-                )
+                raise_args_mismatch(tx, name, "1 args", f"{len(args)} args")
 
             op = {
                 "issubset": operator.le,
@@ -1476,9 +1466,7 @@ class DictItemsVariable(DictViewVariable):
         # implements the mapping protocol.
         if name == "__eq__":
             if len(args) != 1:
-                raise_args_mismatch(
-                    tx, name, f"Expect: 1 args, Actual: {len(args)} args"
-                )
+                raise_args_mismatch(tx, name, "1 args", f"{len(args)} args")
             if isinstance(args[0], DictItemsVariable):
                 return self.dv_dict.call_method(tx, "__eq__", [args[0].dv_dict], {})
             return ConstantVariable.create(False)

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -79,6 +79,7 @@ from ..utils import (
 from .base import (
     AsPythonConstantNotImplementedError,
     AttributeMutationNew,
+    raise_type_error_exc,
     ValueMutationNew,
     VariableTracker,
 )
@@ -2105,8 +2106,8 @@ class PolyfilledFunctionVariable(VariableTracker):
             return self.call_function(tx, args, kwargs)
 
         method = getattr(self.fn, name, None)
-        assert method is not None, f"Member {name} not found in {self.fn}"
-        assert is_function(method), f"Member {name} is not callable in {self.fn}"
+        if not (method or is_function(method)):
+            raise_type_error_exc(tx, f"Cannot find callable {name} in {self.fn}")
         options = {}
         if self.source:
             options["source"] = AttrSource(self.source, name)
@@ -2465,7 +2466,11 @@ class CreateTMADescriptorExperimentalVariable(VariableTracker):
             )
 
         if self.rank == 1:
-            assert len(args) + len(kwargs) == 4
+            if len(args) + len(kwargs) != 4:
+                raise_type_error_exc(
+                    tx,
+                    f"TMA metadata rank=1 requires exactly 4 arguments, got {len(args) + len(kwargs)}",
+                )
             dims = [
                 kwargs["dim"] if "dim" in kwargs else args[1],
             ]
@@ -2473,7 +2478,11 @@ class CreateTMADescriptorExperimentalVariable(VariableTracker):
                 kwargs["block_dim"] if "block_dim" in kwargs else args[2],
             ]
         else:
-            assert len(args) + len(kwargs) == 6
+            if len(args) + len(kwargs) != 6:
+                raise_type_error_exc(
+                    tx,
+                    f"TMA metadata rank=2 requires exactly 6 arguments, got {len(args) + len(kwargs)}",
+                )
             dims = [
                 kwargs["dim1"] if "dim1" in kwargs else args[1],
                 kwargs["dim0"] if "dim0" in kwargs else args[2],

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -47,7 +47,7 @@ from ..utils import (
     range_iterator,
     set_example_value,
 )
-from .base import raise_type_error_exc, ValueMutationNew, VariableTracker
+from .base import ValueMutationNew, VariableTracker
 from .constant import ConstantVariable
 from .functions import UserFunctionVariable, UserMethodVariable
 from .iter import IteratorVariable
@@ -148,8 +148,10 @@ class BaseListVariable(VariableTracker):
             from .tensor import TensorVariable
 
             if kwargs or len(args) != 1:
-                raise_type_error_exc(
-                    tx, f"{name} takes exactly one argument ({len(args)} given)"
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
                 )
 
             if isinstance(args[0], TensorVariable):
@@ -174,12 +176,20 @@ class BaseListVariable(VariableTracker):
 
             return self.getitem_const(tx, value)
         elif name == "__contains__":
-            if len(args) != 1 or kwargs:
-                raise_args_mismatch(tx, name)
+            if kwargs or len(args) != 1:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             return iter_contains(self.unpack_var_sequence(tx), args[0], tx)
         elif name == "index":
             if not len(args):
-                raise_args_mismatch(tx, name)
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
 
             return tx.inline_user_function_return(
                 VariableTracker.build(tx, polyfills.index),
@@ -188,7 +198,11 @@ class BaseListVariable(VariableTracker):
             )
         elif name == "count":
             if len(args) != 1:
-                raise_args_mismatch(tx, name)
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             return VariableTracker.build(tx, operator.countOf).call_function(
                 tx,
                 [self, args[0]],
@@ -196,7 +210,11 @@ class BaseListVariable(VariableTracker):
             )
         elif name in ("__add__", "__iadd__"):
             if kwargs or len(args) != 1:
-                raise_args_mismatch(tx, name)
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
 
             if type(self) is not type(args[0]):
                 tp_name = self.python_type_name()
@@ -213,7 +231,11 @@ class BaseListVariable(VariableTracker):
                 return self
         elif name in ("__mul__", "__imul__"):
             if kwargs or len(args) != 1:
-                raise_args_mismatch(tx, name)
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
 
             if not (args[0].is_python_constant() and args[0].python_type() is int):
                 msg = ConstantVariable.create(
@@ -230,7 +252,11 @@ class BaseListVariable(VariableTracker):
                 return self
         elif name in cmp_name_to_op_mapping:
             if len(args) != 1:
-                raise_args_mismatch(tx, name)
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
 
             left = self
             right = args[0]
@@ -541,16 +567,23 @@ class CommonListMethodsVariable(BaseListVariable):
         from .tensor import SymNodeVariable
 
         if name == "append" and self.is_mutable():
-            assert not kwargs
-            if len(args) != 1:
-                raise_args_mismatch(tx, name)
+            if kwargs or len(args) != 1:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             (arg,) = args
             tx.output.side_effects.mutation(self)
             self.items.append(arg)
             return ConstantVariable.create(None)
         elif name == "extend" and self.is_mutable():
-            if len(args) != 1 or kwargs:
-                raise_args_mismatch(tx, name)
+            if kwargs or len(args) != 1:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
 
             if not args[0].has_force_unpack_var_sequence(tx):
                 msg = ConstantVariable.create(f"{type(args[0])} object is not iterable")
@@ -563,7 +596,11 @@ class CommonListMethodsVariable(BaseListVariable):
             return ConstantVariable.create(None)
         elif name == "insert" and self.is_mutable():
             if kwargs or len(args) != 2:
-                raise_args_mismatch(tx, name)
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 2 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             idx, value = args
             if isinstance(idx, SymNodeVariable):
                 const_idx = idx.evaluate_expr()
@@ -573,9 +610,12 @@ class CommonListMethodsVariable(BaseListVariable):
             self.items.insert(const_idx, value)
             return ConstantVariable.create(None)
         elif name == "pop" and self.is_mutable():
-            assert not kwargs
             if kwargs or len(args) > 1:
-                raise_args_mismatch(tx, name)
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: at most 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
 
             if len(self.items) == 0:
                 msg = ConstantVariable.create("pop from empty list")
@@ -590,7 +630,11 @@ class CommonListMethodsVariable(BaseListVariable):
             return self.items.pop(*[a.as_python_constant() for a in args])
         elif name == "clear" and self.is_mutable():
             if args or kwargs:
-                raise_observed_exception(TypeError, tx)
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             tx.output.side_effects.mutation(self)
             self.items.clear()
             return ConstantVariable.create(None)
@@ -610,7 +654,10 @@ class CommonListMethodsVariable(BaseListVariable):
                 )
             )
         ):
-            assert not kwargs
+            if kwargs:
+                raise_args_mismatch(
+                    tx, name, f"Expect: 0 kwargs, Actual: {len(kwargs)} kwargs"
+                )
             key, value = args
             tx.output.side_effects.mutation(self)
             if isinstance(key, SymNodeVariable):
@@ -635,7 +682,11 @@ class CommonListMethodsVariable(BaseListVariable):
             return ConstantVariable.create(None)
         elif name == "__delitem__" and self.is_mutable():
             if kwargs or len(args) != 1:
-                raise_args_mismatch(tx, name)
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
 
             tx.output.side_effects.mutation(self)
             if args[0].is_python_constant() and isinstance(
@@ -663,18 +714,30 @@ class CommonListMethodsVariable(BaseListVariable):
         elif name == "copy":
             # List copy() doesn't have args and kwargs
             if args or kwargs:
-                raise_args_mismatch(tx, name)
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             items = list(self.items)
             return self.modified(items, mutation_type=ValueMutationNew())
         elif name == "reverse" and self.is_mutable():
             if args or kwargs:
-                raise_args_mismatch(tx, name)
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             self.items.reverse()
             tx.output.side_effects.mutation(self)
             return ConstantVariable.create(None)
         elif name == "remove" and self.is_mutable():
-            if len(args) != 1 or kwargs:
-                raise_args_mismatch(tx, name)
+            if kwargs or len(args) != 1:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
 
             idx = self.call_method(tx, "index", args, kwargs)
             self.call_method(tx, "pop", [idx], {})
@@ -708,7 +771,11 @@ class ListVariable(CommonListMethodsVariable):
 
         if name == "__setitem__" and self.is_mutable():
             if kwargs or len(args) != 2:
-                raise_args_mismatch(tx, name)
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 2 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             key, value = args
 
             if not key.is_python_constant():
@@ -750,12 +817,18 @@ class ListVariable(CommonListMethodsVariable):
             return ConstantVariable.create(None)
 
         if name == "sort" and self.is_mutable():
-            assert len(args) == 0
+            if len(args) != 0:
+                raise_args_mismatch(
+                    tx, name, f"Expect: 0 args, Actual: {len(args)} args"
+                )
             key_fn_var = kwargs.pop("key", ConstantVariable.create(None))
             reverse = kwargs.pop(
                 "reverse", ConstantVariable.create(False)
             ).as_python_constant()
-            assert len(kwargs) == 0
+            if len(kwargs) != 0:
+                raise_args_mismatch(
+                    tx, name, f"Expect: 0 kwargs, Actual: {len(kwargs)} kwargs"
+                )
 
             if (
                 key_fn_var.is_python_constant()
@@ -806,7 +879,10 @@ class ListVariable(CommonListMethodsVariable):
             return ConstantVariable.create(None)
 
         if name == "__init__" and self.is_mutable():
-            assert not kwargs
+            if kwargs:
+                raise_args_mismatch(
+                    tx, name, f"Expect: 0 kwargs, Actual: {len(kwargs)} kwargs"
+                )
             if len(args) == 0:
                 return ConstantVariable.create(None)
             elif len(args) == 1 and args[0].has_force_unpack_var_sequence(tx):
@@ -893,8 +969,12 @@ class DequeVariable(CommonListMethodsVariable):
             and args
             and args[0].is_python_constant()
         ):
-            assert len(args) == 2
-            assert not kwargs
+            if kwargs or len(args) != 2:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 2 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             key, value = args
             assert key.is_python_constant()
             assert isinstance(key.as_python_constant(), int)
@@ -914,8 +994,12 @@ class DequeVariable(CommonListMethodsVariable):
             and len(args) > 0
             and args[0].has_force_unpack_var_sequence(tx)
         ):
-            assert len(args) == 1
-            assert not kwargs
+            if kwargs or len(args) != 1:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             # NOTE this is inefficient, but the alternative is to represent self.items
             # as a deque, which is a more intrusive change.
             args[0].force_apply_to_var_sequence(
@@ -924,20 +1008,32 @@ class DequeVariable(CommonListMethodsVariable):
             slice_within_maxlen = slice(None, maxlen)
             result = ConstantVariable.create(None)
         elif name == "popleft" and self.is_mutable():
-            assert not args
-            assert not kwargs
+            if kwargs or len(args) > 0:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             tx.output.side_effects.mutation(self)
             result, *self.items[:] = self.items
         elif name == "appendleft" and len(args) > 0 and self.is_mutable():
-            assert len(args) == 1
-            assert not kwargs
+            if kwargs or len(args) != 1:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             tx.output.side_effects.mutation(self)
             self.items[:] = [args[0], *self.items]
             slice_within_maxlen = slice(None, maxlen)
             result = ConstantVariable.create(None)
         elif name == "insert" and len(args) > 0 and self.is_mutable():
-            assert len(args) == 2
-            assert not kwargs
+            if kwargs or len(args) != 2:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 2 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             if maxlen is not None and len(self.items) == maxlen:
                 raise_observed_exception(
                     IndexError, tx, args=["deque already at its maximum size"]
@@ -1114,14 +1210,20 @@ class SizeVariable(TupleVariable):
     ) -> "VariableTracker":
         if name == "__getitem__":
             if kwargs or len(args) != 1:
-                raise_type_error_exc(
-                    tx, f"{name} takes exactly one argument ({len(args)} given)"
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
                 )
             out = self.get_item_dyn(tx, args[0])
             return out
         elif name == "numel":
             if args or kwargs:
-                raise_type_error_exc(tx, f"{name} takes no arguments")
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             return self.numel(tx)
 
         return super().call_method(tx, name, args, kwargs)
@@ -1263,8 +1365,12 @@ class NamedTupleVariable(TupleVariable):
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
         if name == "__setattr__":
-            assert len(args) == 2
-            assert len(kwargs) == 0
+            if kwargs or len(args) != 2:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 2 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             attr, value = args
             attr = attr.as_python_constant()
             if (
@@ -1285,14 +1391,8 @@ class NamedTupleVariable(TupleVariable):
         elif name == "_replace":
             # NamedTuple._replace should create a new instance with replaced fields
             if args:
-                raise_observed_exception(
-                    TypeError,
-                    tx,
-                    args=[
-                        ConstantVariable.create(
-                            "_replace() takes no positional arguments"
-                        )
-                    ],
+                raise_args_mismatch(
+                    tx, name, f"Expect: 0 args, Actual: {len(args)} args"
                 )
 
             # Get the field names for validation

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -151,7 +151,8 @@ class BaseListVariable(VariableTracker):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
 
             if isinstance(args[0], TensorVariable):
@@ -180,7 +181,8 @@ class BaseListVariable(VariableTracker):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             return iter_contains(self.unpack_var_sequence(tx), args[0], tx)
         elif name == "index":
@@ -188,7 +190,8 @@ class BaseListVariable(VariableTracker):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "0 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
 
             return tx.inline_user_function_return(
@@ -201,7 +204,8 @@ class BaseListVariable(VariableTracker):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             return VariableTracker.build(tx, operator.countOf).call_function(
                 tx,
@@ -213,7 +217,8 @@ class BaseListVariable(VariableTracker):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
 
             if type(self) is not type(args[0]):
@@ -234,7 +239,8 @@ class BaseListVariable(VariableTracker):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
 
             if not (args[0].is_python_constant() and args[0].python_type() is int):
@@ -255,7 +261,8 @@ class BaseListVariable(VariableTracker):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
 
             left = self
@@ -571,7 +578,8 @@ class CommonListMethodsVariable(BaseListVariable):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             (arg,) = args
             tx.output.side_effects.mutation(self)
@@ -582,7 +590,8 @@ class CommonListMethodsVariable(BaseListVariable):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
 
             if not args[0].has_force_unpack_var_sequence(tx):
@@ -599,7 +608,8 @@ class CommonListMethodsVariable(BaseListVariable):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 2 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "2 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             idx, value = args
             if isinstance(idx, SymNodeVariable):
@@ -614,7 +624,8 @@ class CommonListMethodsVariable(BaseListVariable):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: at most 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "at most 1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
 
             if len(self.items) == 0:
@@ -633,7 +644,8 @@ class CommonListMethodsVariable(BaseListVariable):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "0 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             tx.output.side_effects.mutation(self)
             self.items.clear()
@@ -655,9 +667,7 @@ class CommonListMethodsVariable(BaseListVariable):
             )
         ):
             if kwargs:
-                raise_args_mismatch(
-                    tx, name, f"Expect: 0 kwargs, Actual: {len(kwargs)} kwargs"
-                )
+                raise_args_mismatch(tx, name, "0 kwargs", f"{len(kwargs)} kwargs")
             key, value = args
             tx.output.side_effects.mutation(self)
             if isinstance(key, SymNodeVariable):
@@ -685,7 +695,8 @@ class CommonListMethodsVariable(BaseListVariable):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
 
             tx.output.side_effects.mutation(self)
@@ -717,7 +728,8 @@ class CommonListMethodsVariable(BaseListVariable):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "0 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             items = list(self.items)
             return self.modified(items, mutation_type=ValueMutationNew())
@@ -726,7 +738,8 @@ class CommonListMethodsVariable(BaseListVariable):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "0 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             self.items.reverse()
             tx.output.side_effects.mutation(self)
@@ -736,7 +749,8 @@ class CommonListMethodsVariable(BaseListVariable):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
 
             idx = self.call_method(tx, "index", args, kwargs)
@@ -774,7 +788,8 @@ class ListVariable(CommonListMethodsVariable):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 2 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "2 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             key, value = args
 
@@ -818,17 +833,13 @@ class ListVariable(CommonListMethodsVariable):
 
         if name == "sort" and self.is_mutable():
             if len(args) != 0:
-                raise_args_mismatch(
-                    tx, name, f"Expect: 0 args, Actual: {len(args)} args"
-                )
+                raise_args_mismatch(tx, name, "0 args", f"{len(args)} args")
             key_fn_var = kwargs.pop("key", ConstantVariable.create(None))
             reverse = kwargs.pop(
                 "reverse", ConstantVariable.create(False)
             ).as_python_constant()
             if len(kwargs) != 0:
-                raise_args_mismatch(
-                    tx, name, f"Expect: 0 kwargs, Actual: {len(kwargs)} kwargs"
-                )
+                raise_args_mismatch(tx, name, "0 kwargs", f"{len(kwargs)} kwargs")
 
             if (
                 key_fn_var.is_python_constant()
@@ -880,9 +891,7 @@ class ListVariable(CommonListMethodsVariable):
 
         if name == "__init__" and self.is_mutable():
             if kwargs:
-                raise_args_mismatch(
-                    tx, name, f"Expect: 0 kwargs, Actual: {len(kwargs)} kwargs"
-                )
+                raise_args_mismatch(tx, name, "0 kwargs", f"{len(kwargs)} kwargs")
             if len(args) == 0:
                 return ConstantVariable.create(None)
             elif len(args) == 1 and args[0].has_force_unpack_var_sequence(tx):
@@ -973,7 +982,8 @@ class DequeVariable(CommonListMethodsVariable):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 2 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "2 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             key, value = args
             assert key.is_python_constant()
@@ -998,7 +1008,8 @@ class DequeVariable(CommonListMethodsVariable):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             # NOTE this is inefficient, but the alternative is to represent self.items
             # as a deque, which is a more intrusive change.
@@ -1012,7 +1023,8 @@ class DequeVariable(CommonListMethodsVariable):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "0 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             tx.output.side_effects.mutation(self)
             result, *self.items[:] = self.items
@@ -1021,7 +1033,8 @@ class DequeVariable(CommonListMethodsVariable):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             tx.output.side_effects.mutation(self)
             self.items[:] = [args[0], *self.items]
@@ -1032,7 +1045,8 @@ class DequeVariable(CommonListMethodsVariable):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 2 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "2 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             if maxlen is not None and len(self.items) == maxlen:
                 raise_observed_exception(
@@ -1213,7 +1227,8 @@ class SizeVariable(TupleVariable):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             out = self.get_item_dyn(tx, args[0])
             return out
@@ -1222,7 +1237,8 @@ class SizeVariable(TupleVariable):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "0 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             return self.numel(tx)
 
@@ -1369,7 +1385,8 @@ class NamedTupleVariable(TupleVariable):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 2 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "2 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             attr, value = args
             attr = attr.as_python_constant()
@@ -1391,9 +1408,7 @@ class NamedTupleVariable(TupleVariable):
         elif name == "_replace":
             # NamedTuple._replace should create a new instance with replaced fields
             if args:
-                raise_args_mismatch(
-                    tx, name, f"Expect: 0 args, Actual: {len(args)} args"
-                )
+                raise_args_mismatch(tx, name, "0 args", f"{len(args)} args")
 
             # Get the field names for validation
             fields = self.fields()

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -58,6 +58,7 @@ from ..utils import (
     istype,
     list_methods,
     proxy_args_kwargs,
+    raise_args_mismatch,
     tuple_methods,
 )
 from .base import raise_type_error_exc, VariableTracker
@@ -587,20 +588,24 @@ class ComptimeVariable(VariableTracker):
         from ..comptime import ComptimeContext
 
         # TODO: support an expression form as well
-
-        assert not kwargs
         # Second argument is runtime lambda, ignored
-        assert len(args) <= 2
+        if kwargs or len(args) > 2:
+            raise_args_mismatch(
+                tx,
+                "comptime()",
+                f"Expect: at most 2 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+            )
         fn = args[0]
         if isinstance(fn, UserFunctionVariable):
             fn.get_function()(ComptimeContext(tx))
         elif isinstance(fn, NestedUserFunctionVariable):
             # We have to manually bind the freevars ourselves
             code = fn.get_code()
-            assert not fn.closure, (
-                "comptime function must not have free variables, "
-                f"but these variables were free: {code.co_freevars}"
-            )
+            if fn.closure:
+                raise_type_error_exc(
+                    tx,
+                    f"comptime function must not have free variables, but these variables were free: {code.co_freevars}",
+                )
             func = types.FunctionType(
                 code,
                 fn.f_globals,
@@ -942,7 +947,10 @@ class AutogradFunctionContextVariable(UserDefinedObjectVariable):
         if name == "__setattr__":
             return super().call_method(tx, name, args, kwargs)
         elif name == "mark_non_differentiable":
-            assert len(kwargs) == 0
+            if kwargs:
+                raise_args_mismatch(
+                    tx, name, f"Expect: 0 kwargs, Actual: {len(kwargs)} kwargs"
+                )
             self.non_differentiable = proxy_args_kwargs(args, {})[0]
             return variables.ConstantVariable.create(None)
 
@@ -970,7 +978,10 @@ class AutogradFunctionContextVariable(UserDefinedObjectVariable):
             )
 
         if not self.inference:
-            assert self.source and not kwargs
+            if kwargs or not self.source:
+                raise_type_error_exc(
+                    tx, "save_for_backward() requires a source and no keyword arguments"
+                )
             tx.output.side_effects.track_save_for_backward(self, args)
 
         # In eager mode, multiple calls to .save_for_backward() will overwrite previous calls.

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -593,7 +593,8 @@ class ComptimeVariable(VariableTracker):
             raise_args_mismatch(
                 tx,
                 "comptime()",
-                f"Expect: at most 2 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                "at most 2 args and 0 kwargs",
+                f"{len(args)} args and {len(kwargs)} kwargs",
             )
         fn = args[0]
         if isinstance(fn, UserFunctionVariable):
@@ -948,9 +949,7 @@ class AutogradFunctionContextVariable(UserDefinedObjectVariable):
             return super().call_method(tx, name, args, kwargs)
         elif name == "mark_non_differentiable":
             if kwargs:
-                raise_args_mismatch(
-                    tx, name, f"Expect: 0 kwargs, Actual: {len(kwargs)} kwargs"
-                )
+                raise_args_mismatch(tx, name, "0 kwargs", f"{len(kwargs)} kwargs")
             self.non_differentiable = proxy_args_kwargs(args, {})[0]
             return variables.ConstantVariable.create(None)
 

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -62,11 +62,12 @@ from ..utils import (
     nnmodule_has_hooks,
     object_has_getattribute,
     proxy_args_kwargs,
+    raise_args_mismatch,
     set_example_value,
     unpatched_nn_module_call,
     unpatched_nn_module_call_impl,
 )
-from .base import typestr, ValueMutationNew, VariableTracker
+from .base import raise_type_error_exc, typestr, ValueMutationNew, VariableTracker
 from .functions import invoke_and_store_as_constant
 from .lazy import LazyVariableTracker
 from .lists import SliceVariable
@@ -457,7 +458,12 @@ class NNModuleVariable(VariableTracker):
                 assert not is_lazy, (
                     "Expected lazy sequential isn't a valid combination?"
                 )
-                assert not kwargs
+                if kwargs:
+                    raise_args_mismatch(
+                        tx,
+                        "torch.nn.Module.Sequential",
+                        f"Expect: 0 kwargs, Actual: {len(kwargs)} kwargs",
+                    )
                 (arg,) = args
                 # TODO: Use named_children when it supports remove_duplicate=False.
                 for child_name, submod in mod._modules.items():
@@ -601,8 +607,16 @@ class NNModuleVariable(VariableTracker):
             return ConstantVariable.create(True)
 
         if name == "_get_item_by_idx":
-            assert args[1].is_python_constant()
-            assert isinstance(args[0], TupleVariable)
+            if not args[1].is_python_constant():
+                raise_type_error_exc(
+                    tx,
+                    f"``nn.Module`` {module}'s call method {name} requires a constant index argument",
+                )
+            if not isinstance(args[0], TupleVariable):
+                raise_type_error_exc(
+                    tx,
+                    f"``nn.Module`` {module}'s call method {name} requires a tuple as first argument",
+                )
             mod_var = args[0].items[args[1].value]
             if isinstance(mod_var, UnspecializedNNModuleVariable):
                 return mod_var
@@ -680,7 +694,12 @@ class NNModuleVariable(VariableTracker):
 
         if name == "named_children":
             tx.output.guard_on_key_order.add(AttrSource(self.source, "_modules"))
-            assert not (args or kwargs)
+            if args or kwargs:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             result = []
             for name, submod in module.named_children():
                 result.append(named_embed(name, submod))
@@ -711,7 +730,12 @@ class NNModuleVariable(VariableTracker):
             return ListIteratorVariable(result, mutation_type=ValueMutationNew())
         elif name == "children":
             tx.output.guard_on_key_order.add(AttrSource(self.source, "_modules"))
-            assert not (args or kwargs)
+            if args or kwargs:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             return wrap_values(module.named_children())
         elif name == "modules":
             tx.output.guard_on_key_order.add(AttrSource(self.source, "_modules"))
@@ -723,22 +747,42 @@ class NNModuleVariable(VariableTracker):
             tx.output.guard_on_key_order.add(AttrSource(self.source, "_buffers"))
             return wrap_values(module.named_buffers(**get_kwargs("recurse")))
         elif name == "keys":
-            assert not (args or kwargs)
+            if args or kwargs:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             result = []
             for name in module.keys():
                 result.append(ConstantVariable.create(name))
             return ListIteratorVariable(result, mutation_type=ValueMutationNew())
         elif name == "values":
-            assert not (args or kwargs)
+            if args or kwargs:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             return wrap_values(module.items())
         elif name == "items":
-            assert not (args or kwargs)
+            if args or kwargs:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             result = []
             for name, submod in module.items():
                 result.append(named_embed(name, submod))
             return ListIteratorVariable(result, mutation_type=ValueMutationNew())
         elif name == "__len__":
-            assert not (args or kwargs)
+            if args or kwargs:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             return ConstantVariable.create(len(module))
         elif (
             name == "__contains__"
@@ -750,7 +794,12 @@ class NNModuleVariable(VariableTracker):
                 args[0].as_python_constant() in module._modules
             )
         elif name == "__getitem__":
-            assert not kwargs and len(args) == 1
+            if kwargs or len(args) != 1:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             builtin_supported = (
                 torch.nn.ModuleDict.__getitem__,
                 torch.nn.ModuleList.__getitem__,

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -462,7 +462,8 @@ class NNModuleVariable(VariableTracker):
                     raise_args_mismatch(
                         tx,
                         "torch.nn.Module.Sequential",
-                        f"Expect: 0 kwargs, Actual: {len(kwargs)} kwargs",
+                        "0 kwargs",
+                        f"{len(kwargs)} kwargs",
                     )
                 (arg,) = args
                 # TODO: Use named_children when it supports remove_duplicate=False.
@@ -698,7 +699,8 @@ class NNModuleVariable(VariableTracker):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "0 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             result = []
             for name, submod in module.named_children():
@@ -734,7 +736,8 @@ class NNModuleVariable(VariableTracker):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "0 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             return wrap_values(module.named_children())
         elif name == "modules":
@@ -751,7 +754,8 @@ class NNModuleVariable(VariableTracker):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "0 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             result = []
             for name in module.keys():
@@ -762,7 +766,8 @@ class NNModuleVariable(VariableTracker):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "0 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             return wrap_values(module.items())
         elif name == "items":
@@ -770,7 +775,8 @@ class NNModuleVariable(VariableTracker):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "0 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             result = []
             for name, submod in module.items():
@@ -781,7 +787,8 @@ class NNModuleVariable(VariableTracker):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "0 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             return ConstantVariable.create(len(module))
         elif (
@@ -798,7 +805,8 @@ class NNModuleVariable(VariableTracker):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             builtin_supported = (
                 torch.nn.ModuleDict.__getitem__,

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -66,7 +66,7 @@ from ..utils import (
     set_example_value,
     tensortype_to_dtype,
 )
-from .base import AttributeMutationNew, raise_type_error_exc, VariableTracker
+from .base import AttributeMutationNew, VariableTracker
 from .constant import ConstantVariable
 from .lists import SizeVariable
 from .user_defined import UserDefinedClassVariable
@@ -1766,7 +1766,8 @@ class UntypedStorageVariable(VariableTracker):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 0 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "0 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             result = self.example_value.size()
             if not has_free_symbols(result):
@@ -1787,9 +1788,7 @@ class UntypedStorageVariable(VariableTracker):
                 )
         if name == "resize_" and len(args) == 1:
             if kwargs:
-                raise_args_mismatch(
-                    tx, name, f"Expect: 0 kwargs, Actual: {len(kwargs)} kwargs"
-                )
+                raise_args_mismatch(tx, name, "0 kwargs", f"{len(kwargs)} kwargs")
             tx.output.create_proxy(
                 "call_function",
                 torch.ops.inductor.resize_storage_bytes_,

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -87,12 +87,13 @@ from ..utils import (
     namedtuple_fields,
     object_has_getattribute,
     proxy_args_kwargs,
+    raise_args_mismatch,
     set_methods,
     tensortype_to_dtype,
     tuple_methods,
     unpatched_nn_module_getattr,
 )
-from .base import ValueMutationNew, VariableTracker
+from .base import raise_type_error_exc, ValueMutationNew, VariableTracker
 from .dicts import DefaultDictVariable
 from .lists import SizeVariable
 
@@ -436,8 +437,12 @@ class UserDefinedClassVariable(UserDefinedVariable):
             and isinstance(args[0], UserDefinedClassVariable)
             and args[0].value is collections.OrderedDict
         ):
-            assert len(args) == 1
-            assert len(kwargs) == 0
+            if kwargs and len(args) != 1:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                )
             return variables.ConstDictVariable(
                 {}, collections.OrderedDict, mutation_type=ValueMutationNew()
             )
@@ -586,7 +591,10 @@ class UserDefinedClassVariable(UserDefinedVariable):
         elif self.value is warnings.catch_warnings and not args:
             return variables.CatchWarningsCtxManagerVariable.create(tx, kwargs)
         elif self.value is torch.cuda.device and not kwargs and len(args) == 1:
-            assert args[0].is_python_constant()
+            if not args[0].is_python_constant():
+                raise_type_error_exc(
+                    tx, "torch.cuda.device() requires a constant argument"
+                )
             return variables.CUDADeviceVariable.create(tx, args[0].as_python_constant())
         elif (
             issubclass(type(self.value), type)
@@ -688,8 +696,12 @@ class UserDefinedClassVariable(UserDefinedVariable):
             fields = namedtuple_fields(self.value)
             # check if this a quasi-namedtuple or a real one
             if self.value.__module__ == "torch.return_types":
-                assert len(args) == 1
-                assert not kwargs
+                if kwargs or len(args) != 1:
+                    raise_args_mismatch(
+                        tx,
+                        "torch.return_types",
+                        f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    )
                 items = args[0].force_unpack_var_sequence(tx)
             else:
                 field_defaults = self.value._field_defaults

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -441,7 +441,8 @@ class UserDefinedClassVariable(UserDefinedVariable):
                 raise_args_mismatch(
                     tx,
                     name,
-                    f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             return variables.ConstDictVariable(
                 {}, collections.OrderedDict, mutation_type=ValueMutationNew()
@@ -700,7 +701,8 @@ class UserDefinedClassVariable(UserDefinedVariable):
                     raise_args_mismatch(
                         tx,
                         "torch.return_types",
-                        f"Expect: 1 args and 0 kwargs, Actual: {len(args)} args and {len(kwargs)} kwargs",
+                        "1 args and 0 kwargs",
+                        f"{len(args)} args and {len(kwargs)} kwargs",
                     )
                 items = args[0].force_unpack_var_sequence(tx)
             else:


### PR DESCRIPTION
Extend from #165430
* #165903(Clean up for graph break)
* ->#165745
* #165430

One main refractor from the previous PR:
* For assertions like checking `len(args)` or `len(kwargs)`, using `raise_args_mismatch` instead of `raise_type_error_exc`

I am also considering moving `raise_type_error_exc` into `utils.py` for consistency.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela @williamwen42 