### PR TITLE
Fix B200 test fails in scaled_mm

### DIFF
--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -154,8 +154,8 @@ def infer_scale_swizzle(mat, scale):
 
     # MXFP4 w/o swizzle
     if (
-        scale.numel() == 2 * math.ceil(mat.shape[0] // 32) * mat.shape[1]
-        or scale.numel() == 2 * math.ceil(mat.shape[1] // 32) * mat.shape[0]
+        (scale.numel() == 2 * math.ceil(mat.shape[0] // 32) * mat.shape[1]
+        or scale.numel() == 2 * math.ceil(mat.shape[1] // 32) * mat.shape[0])
         and mat.dtype == torch.float4_e2m1fn_x2
         and scale.dtype == torch.float8_e8m0fnu
     ):
@@ -1485,6 +1485,7 @@ class TestFP8Matmul(TestCase):
 
                 approx_match_sqnr_target = 15 if torch.version.hip else 15.8
 
+        print(f'{A.dtype=}, {B.dtype=}')
         C_ref = A_ref @ B_ref.t()
 
         # convert to swizzled format

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -155,7 +155,7 @@ def infer_scale_swizzle(mat, scale):
     # MXFP4 w/o swizzle
     if (
         (scale.numel() == 2 * math.ceil(mat.shape[0] // 32) * mat.shape[1]
-        or scale.numel() == 2 * math.ceil(mat.shape[1] // 32) * mat.shape[0])
+            or scale.numel() == 2 * math.ceil(mat.shape[1] // 32) * mat.shape[0])
         and mat.dtype == torch.float4_e2m1fn_x2
         and scale.dtype == torch.float8_e8m0fnu
     ):

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -1485,7 +1485,6 @@ class TestFP8Matmul(TestCase):
 
                 approx_match_sqnr_target = 15 if torch.version.hip else 15.8
 
-        print(f'{A.dtype=}, {B.dtype=}')
         C_ref = A_ref @ B_ref.t()
 
         # convert to swizzled format


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #165747

Summary:

PR #165528 changes some scale/swizzle inference behavior in scaled_mm
tests - mxfp8 tests on Blackwell can get incorrectly classified,
resulting in failures.

Fix the scale/swizzle inference code to prevent this.

Fixes https://github.com/pytorch/pytorch/issues/165743

Test Plan:

```
pytest -svv test/test_scaled_matmul_cuda.py
```

Reviewers:

@jagadish-amd @jeffdaily @drisspg

Subscribers:

@Aidyn-A

Tasks:

Tags:
Signed-off-by: Simon Layton <simonlaytonmeta.com>