### PR TITLE
[FlexAttention][CUDA] Add flex configs for Blackwell

### DIFF
--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -915,12 +915,15 @@ class CUDAConfigHeuristic(BaseConfigHeuristic):
         self.sm_100_default_flex_config = {
             (torch.float32, 64): FlexConfig(128, 32, 3, 4),
             (torch.float32, 128): FlexConfig(32, 64, 3, 4),
+            (torch.float32, 192): FlexConfig(32, 64, 2, 4),
             (torch.float32, 256): FlexConfig(32, 32, 3, 4),
             (torch.bfloat16, 64): FlexConfig(128, 128, 3, 4),
             (torch.bfloat16, 128): FlexConfig(128, 64, 3, 8),
+            (torch.bfloat16, 192): FlexConfig(128, 128, 1, 8),
             (torch.bfloat16, 256): FlexConfig(64, 32, 3, 4),
             (torch.float16, 64): FlexConfig(128, 128, 3, 4),
             (torch.float16, 128): FlexConfig(128, 64, 3, 8),
+            (torch.float16, 192): FlexConfig(128, 128, 1, 8),
             (torch.float16, 256): FlexConfig(64, 32, 3, 4),
         }
 
@@ -1034,9 +1037,9 @@ class CUDAConfigHeuristic(BaseConfigHeuristic):
                 FlexBwDConfig(64, 64, 64, 64, 2, 4)
             ),
             "sm10x": lambda h: (
-                FlexBwDConfig(64, 128, 128, 64, 3, 4)
-                if h <= 128
-                else FlexBwDConfig(64, 64, 64, 64, 2, 4)
+                FlexBwDConfig(64, 128, 128, 64, 3, 4) if h <= 128 else
+                FlexBwDConfig(64, 64, 64, 64, 1, 8) if h <= 192 else
+                FlexBwDConfig(64, 64, 64, 64, 1, 4)
             ),
             "sm8x": lambda h: (
                 FlexBwDConfig(32, 128, 128, 32, 3, 4)

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -951,7 +951,8 @@ class CUDAConfigHeuristic(BaseConfigHeuristic):
             (torch.float16, 256): FlexConfig(32, 64, 3, 4),
         }
 
-        self.flex_attn_bwd_autotune_configs_sm_100: list[FlexBwDConfig] = [
+        # Overwriting the configs omitting BLOCK_N of size 128 that cause ULFs
+        self.flex_attn_bwd_autotune_configs: list[FlexBwDConfig] = [
             # See Note: flex bwd configs
             FlexBwDConfig(BLOCK_M, BLOCK_N, BLOCK_N, BLOCK_M, s, 4)
             for BLOCK_M in [32, 64]
@@ -1010,10 +1011,7 @@ class CUDAConfigHeuristic(BaseConfigHeuristic):
         if config.max_autotune:
             if config.max_autotune_flex_search_space == "EXHAUSTIVE":
                 return self.exhaustive_flex_attn_bwd_configs
-            if capability >= (10, 0) and head_dim >= 192:
-                flex_attn_bwd_configs += self.flex_attn_bwd_autotune_configs_sm_100
-            else:
-                flex_attn_bwd_configs += self.flex_attn_bwd_autotune_configs
+            flex_attn_bwd_configs += self.flex_attn_bwd_autotune_configs
 
         major, minor = capability
         if dtype == torch.float32:

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -1007,7 +1007,7 @@ class CUDAConfigHeuristic(BaseConfigHeuristic):
         if config.max_autotune:
             if config.max_autotune_flex_search_space == "EXHAUSTIVE":
                 return self.exhaustive_flex_attn_bwd_configs
-            if capability == (10, 0):
+            if capability >= (10, 0) and head_dim >= 192:
                 flex_attn_bwd_configs += self.flex_attn_bwd_autotune_configs_sm_100
             else:
                 flex_attn_bwd_configs += self.flex_attn_bwd_autotune_configs


### PR DESCRIPTION
This PR fixes ULFs on `max_autotune` mode for high head-dim sizes on B200. Closes https://github.com/pytorch/torchtitan/issues/1791

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @Chillee @drisspg @yanboliang @BoyuanFeng