### PR TITLE
[ONNX] Create fake implementations for onnx ops; fix boolean mask in attention

### DIFF
--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -5,20 +5,14 @@ from __future__ import annotations
 
 import logging
 
-import onnxruntime
 import pytest
 import transformers
 from onnxscript import ir
-from packaging import version
 
 import torch
 from torch.onnx._internal.exporter import _testing as onnx_testing
 from torch.testing._internal import common_utils
 from torch.utils import _pytree as torch_pytree
-
-
-def has_onnxruntime_opset_23() -> bool:
-    return version.parse(onnxruntime.__version__) >= version.parse("1.23")
 
 
 class _WithExport:
@@ -746,13 +740,7 @@ class DynamoExporterNewOpsetsTest(common_utils.TestCase, _WithExport):
         onnx_program = self.export(Model(), (query, key, value), opset_version=23)
         self.assertEqual(["Attention"], [n.op_type for n in onnx_program.model.graph])
 
-        if has_onnxruntime_opset_23():
-            onnx_testing.assert_onnx_program(onnx_program, atol=1e-2, rtol=1)
-        else:
-            # Test with reference evaluator because ORT does not support the op as of version 1.22
-            onnx_testing.assert_onnx_program(
-                onnx_program, atol=1e-2, rtol=1, backend="reference"
-            )
+        onnx_testing.assert_onnx_program(onnx_program, atol=1e-2, rtol=1)
 
     def test_rms_norm(self):
         """Test RMS normalization with various configurations."""
@@ -763,7 +751,7 @@ class DynamoExporterNewOpsetsTest(common_utils.TestCase, _WithExport):
 
         x = torch.randn(2, 5, 3)
         onnx_program = self.export(RMSNormModel(), (x,), opset_version=23)
-        onnx_testing.assert_onnx_program(onnx_program, backend="reference")
+        onnx_testing.assert_onnx_program(onnx_program)
 
         # Test with multi-dimensional normalized_shape
         class RMSNormModel2D(torch.nn.Module):
@@ -772,7 +760,7 @@ class DynamoExporterNewOpsetsTest(common_utils.TestCase, _WithExport):
 
         x = torch.randn(2, 5, 7, 3)
         onnx_program = self.export(RMSNormModel2D(), (x,), opset_version=23)
-        onnx_testing.assert_onnx_program(onnx_program, backend="reference")
+        onnx_testing.assert_onnx_program(onnx_program)
 
     def test_rms_norm_with_weight(self):
         """Test RMS normalization with weight parameter."""
@@ -789,8 +777,7 @@ class DynamoExporterNewOpsetsTest(common_utils.TestCase, _WithExport):
 
         onnx_program = self.export(RMSNormWithWeight(), (x,), opset_version=23)
 
-        # Test with reference evaluator because ORT does not support the op as of version 1.22
-        onnx_testing.assert_onnx_program(onnx_program, backend="reference")
+        onnx_testing.assert_onnx_program(onnx_program)
 
     def test_rms_norm_with_eps(self):
         """Test RMS normalization with custom epsilon."""
@@ -803,8 +790,7 @@ class DynamoExporterNewOpsetsTest(common_utils.TestCase, _WithExport):
 
         onnx_program = self.export(RMSNormWithEps(), (x,), opset_version=23)
 
-        # Test with reference evaluator because ORT does not support the op as of version 1.22
-        onnx_testing.assert_onnx_program(onnx_program, backend="reference")
+        onnx_testing.assert_onnx_program(onnx_program)
 
     def test_enable_gqa_in_attention_23_with_dropout(self):
         class Model(torch.nn.Module):

--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -760,7 +760,7 @@ class DynamoExporterNewOpsetsTest(common_utils.TestCase, _WithExport):
 
         x = torch.randn(2, 5, 7, 3)
         onnx_program = self.export(RMSNormModel2D(), (x,), opset_version=23)
-        onnx_testing.assert_onnx_program(onnx_program)
+        onnx_testing.assert_onnx_program(onnx_program, backend="reference")
 
     def test_rms_norm_with_weight(self):
         """Test RMS normalization with weight parameter."""

--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -751,7 +751,7 @@ class DynamoExporterNewOpsetsTest(common_utils.TestCase, _WithExport):
 
         x = torch.randn(2, 5, 3)
         onnx_program = self.export(RMSNormModel(), (x,), opset_version=23)
-        onnx_testing.assert_onnx_program(onnx_program)
+        onnx_testing.assert_onnx_program(onnx_program, backend="reference")
 
         # Test with multi-dimensional normalized_shape
         class RMSNormModel2D(torch.nn.Module):
@@ -790,7 +790,7 @@ class DynamoExporterNewOpsetsTest(common_utils.TestCase, _WithExport):
 
         onnx_program = self.export(RMSNormWithEps(), (x,), opset_version=23)
 
-        onnx_testing.assert_onnx_program(onnx_program)
+        onnx_testing.assert_onnx_program(onnx_program, backend="reference")
 
     def test_enable_gqa_in_attention_23_with_dropout(self):
         class Model(torch.nn.Module):

--- a/test/onnx/ops/test_ops.py
+++ b/test/onnx/ops/test_ops.py
@@ -427,7 +427,6 @@ class NativeOnnxOpsTest(common_utils.TestCase):
             dynamo=True,
             fallback=False,
             verbose=False,
-            optimize=False,
             **options,
         )
         assert onnx_program is not None

--- a/test/onnx/ops/test_ops.py
+++ b/test/onnx/ops/test_ops.py
@@ -4,9 +4,7 @@
 from __future__ import annotations
 
 import onnx_ir.passes.common as common_passes
-import onnxruntime
 from onnxscript import ir
-from packaging import version
 
 import torch
 from torch.onnx._internal.exporter import _testing as onnx_testing
@@ -418,6 +416,7 @@ class SymbolicOpsTest(common_utils.TestCase):
             )
 
 
+@common_utils.instantiate_parametrized_tests
 class NativeOnnxOpsTest(common_utils.TestCase):
     def export(self, model, args=(), kwargs=None, **options) -> torch.onnx.ONNXProgram:
         onnx_program = torch.onnx.export(
@@ -564,7 +563,7 @@ class NativeOnnxOpsTest(common_utils.TestCase):
         self.assertEqual("RotaryEmbedding", onnx_program.model.graph.node(0).op_type)
         onnx_testing.assert_onnx_program(onnx_program)
 
-    def test_attention_basic(self):
+    def test_attention_without_past_kv_caches(self):
         """Test basic attention functionality."""
         batch_size, q_seq_len, kv_seq_len = 2, 4, 6
         q_num_heads, kv_num_heads = 8, 8
@@ -615,10 +614,16 @@ class NativeOnnxOpsTest(common_utils.TestCase):
             present_value.shape, (batch_size, kv_num_heads, kv_seq_len, head_size)
         )
 
-    def test_attention_gqa(self):
-        """Test Group Query Attention (GQA)."""
+    @common_utils.parametrize(
+        "name, kv_num_heads",
+        [
+            ("group_query_attention", 4),
+            ("multi_query_attention", 1),
+        ],
+    )
+    def test_attention_kv_num_heads(self, name: str, kv_num_heads: int):
         batch_size, q_seq_len, kv_seq_len = 2, 4, 6
-        q_num_heads, kv_num_heads = 8, 4  # GQA: q_num_heads % kv_num_heads = 0
+        q_num_heads = 8
         head_size = 64
 
         Q = torch.rand(batch_size, q_num_heads, q_seq_len, head_size)
@@ -779,26 +784,6 @@ class NativeOnnxOpsTest(common_utils.TestCase):
             output_4d.shape, (batch_size, q_num_heads, q_seq_len, head_size)
         )
 
-    def test_attention_with_large_negative_float_mask(self):
-        """Test attention with large negative values in float mask."""
-        batch_size, q_seq_len, kv_seq_len = 2, 4, 6
-        q_num_heads, kv_num_heads = 8, 8
-        head_size = 64
-
-        Q = torch.rand(batch_size, q_num_heads, q_seq_len, head_size)
-        K = torch.rand(batch_size, kv_num_heads, kv_seq_len, head_size)
-        V = torch.rand(batch_size, kv_num_heads, kv_seq_len, head_size)
-
-        # Create mask with large negative values (similar to -inf masking)
-        float_mask = torch.full((q_seq_len, kv_seq_len), -1e9)
-        # Allow some positions
-        float_mask[:, :3] = 0.0
-
-        torch.library.opcheck(_impl.attention_23, (Q, K, V), dict(attn_mask=float_mask))
-        output, _, _, _ = torch.onnx.ops.attention(Q, K, V, attn_mask=float_mask)
-
-        self.assertEqual(output.shape, (batch_size, q_num_heads, q_seq_len, head_size))
-
     def test_attention_causal(self):
         """Test causal attention."""
         batch_size, q_seq_len, kv_seq_len = 2, 4, 4  # Square for causal
@@ -916,9 +901,7 @@ class NativeOnnxOpsTest(common_utils.TestCase):
 
         class AttentionModel(torch.nn.Module):
             def forward(self, Q, K, V):
-                output, present_key, present_value, qk_output = (
-                    torch.onnx.ops.attention(Q, K, V)
-                )
+                output, _, _, _ = torch.onnx.ops.attention(Q, K, V)
                 return output
 
         model = AttentionModel()
@@ -943,14 +926,12 @@ class NativeOnnxOpsTest(common_utils.TestCase):
         K = torch.rand(batch_size, kv_num_heads, kv_seq_len, head_size)
         V = torch.rand(batch_size, kv_num_heads, kv_seq_len, head_size)
         attn_mask = torch.randint(
-            0, 2, (batch_size, 1, kv_seq_len), dtype=torch.bool
+            0, 2, (batch_size, 1, q_seq_len, kv_seq_len), dtype=torch.bool
         )
 
         class AttentionModel(torch.nn.Module):
             def forward(self, Q, K, V, attn_mask):
-                output, present_key, present_value, qk_output = (
-                    torch.onnx.ops.attention(Q, K, V, attn_mask=attn_mask)
-                )
+                output, _, _, _ = torch.onnx.ops.attention(Q, K, V, attn_mask=attn_mask)
                 return output
 
         model = AttentionModel()
@@ -959,7 +940,7 @@ class NativeOnnxOpsTest(common_utils.TestCase):
             "Q": {0: "batch", 2: "q_seq_len"},
             "K": {0: "batch", 2: "kv_seq_len"},
             "V": {0: "batch", 2: "kv_seq_len"},
-            "attn_mask": {0: "batch", 2: "q_seq_len"},
+            "attn_mask": {0: "batch", 2: "q_seq_len", 3: "kv_seq_len"},
         }
 
         onnx_program = self.export(
@@ -1127,13 +1108,15 @@ class NativeOnnxOpsTest(common_utils.TestCase):
 
         class FullAttentionModel(torch.nn.Module):
             def forward(self, Q, K, V, attn_mask, past_key, past_value):
-                output, present_key, present_value, qk_matmul = torch.onnx.ops.attention(
-                    Q,
-                    K,
-                    V,
-                    attn_mask=attn_mask,
-                    past_key=past_key,
-                    past_value=past_value,
+                output, present_key, present_value, qk_matmul = (
+                    torch.onnx.ops.attention(
+                        Q,
+                        K,
+                        V,
+                        attn_mask=attn_mask,
+                        past_key=past_key,
+                        past_value=past_value,
+                    )
                 )
                 return output, present_key, present_value, qk_matmul
 
@@ -1417,7 +1400,17 @@ class NativeOnnxOpsTest(common_utils.TestCase):
         )
         onnx_testing.assert_onnx_program(onnx_program)
 
-    def test_attention_export_with_softmax_precision(self):
+    @common_utils.parametrize(
+        "precision_enum, precision_name",
+        [
+            (1, "FLOAT"),
+            (10, "FLOAT16"),
+            (11, "DOUBLE"),
+        ],
+    )
+    def test_attention_export_with_softmax_precision(
+        self, precision_enum, precision_name
+    ):
         """Test export with different softmax precision values."""
         batch_size, q_seq_len, kv_seq_len = 2, 4, 6
         q_num_heads, kv_num_heads = 8, 8
@@ -1427,38 +1420,28 @@ class NativeOnnxOpsTest(common_utils.TestCase):
         K = torch.rand(batch_size, kv_num_heads, kv_seq_len, head_size)
         V = torch.rand(batch_size, kv_num_heads, kv_seq_len, head_size)
 
-        # Test different ONNX precision types
-        precision_types = [
-            (1, "FLOAT"),
-            (10, "FLOAT16"),
-            (11, "DOUBLE"),
-            (16, "BFLOAT16"),
-        ]
+        class SoftmaxPrecisionModel(torch.nn.Module):
+            def __init__(self, precision):
+                super().__init__()
+                self.precision = precision
 
-        for precision_val, precision_name in precision_types:
+            def forward(self, Q, K, V):
+                output, _, _, _ = torch.onnx.ops.attention(
+                    Q, K, V, softmax_precision=self.precision
+                )
+                return output
 
-            class SoftmaxPrecisionModel(torch.nn.Module):
-                def __init__(self, precision):
-                    super().__init__()
-                    self.precision = precision
+        model = SoftmaxPrecisionModel(precision_enum)
+        onnx_program = self.export(model, (Q, K, V), opset_version=23)
 
-                def forward(self, Q, K, V):
-                    output, _, _, _ = torch.onnx.ops.attention(
-                        Q, K, V, softmax_precision=self.precision
-                    )
-                    return output
+        node = onnx_program.model.graph.node(0)
+        self.assertEqual(node.op_type, "Attention")
 
-            model = SoftmaxPrecisionModel(precision_val)
-            onnx_program = self.export(model, (Q, K, V), opset_version=23)
-
-            node = onnx_program.model.graph.node(0)
-            self.assertEqual(node.op_type, "Attention")
-
-            # Verify softmax_precision attribute
-            attrs = node.attributes
-            self.assertIn("softmax_precision", attrs)
-            self.assertEqual(attrs["softmax_precision"].value, precision_val)
-            onnx_testing.assert_onnx_program(onnx_program)
+        # Verify softmax_precision attribute
+        attrs = node.attributes
+        self.assertIn("softmax_precision", attrs)
+        self.assertEqual(attrs["softmax_precision"].value, precision_enum)
+        onnx_testing.assert_onnx_program(onnx_program, atol=1e-3, rtol=1e-3)
 
     def test_attention_export_gqa(self):
         """Test export and verify output tensor shapes."""
@@ -1472,7 +1455,8 @@ class NativeOnnxOpsTest(common_utils.TestCase):
 
         class AttentionOutputsModel(torch.nn.Module):
             def forward(self, Q, K, V):
-                return torch.onnx.ops.attention(Q, K, V)
+                result, _, _, _ = torch.onnx.ops.attention(Q, K, V)
+                return result
 
         model = AttentionOutputsModel()
         onnx_program = self.export(model, (Q, K, V), opset_version=23)
@@ -1489,22 +1473,7 @@ class NativeOnnxOpsTest(common_utils.TestCase):
             outputs[0].shape, [batch_size, q_num_heads, q_seq_len, head_size]
         )
 
-        # present_key: (batch_size, kv_num_heads, kv_seq_len, head_size)
-        self.assertEqual(
-            outputs[1].shape, [batch_size, kv_num_heads, kv_seq_len, head_size]
-        )
-
-        # present_value: (batch_size, kv_num_heads, kv_seq_len, head_size)
-        self.assertEqual(
-            outputs[2].shape, [batch_size, kv_num_heads, kv_seq_len, head_size]
-        )
-
-        # qk_output: (batch_size, q_num_heads, q_seq_len, kv_seq_len)
-        self.assertEqual(
-            outputs[3].shape, [batch_size, q_num_heads, q_seq_len, kv_seq_len]
-        )
-        # ORT does not allow all outputs when past key/value are not provided
-        onnx_testing.assert_onnx_program(onnx_program, backend="reference")
+        onnx_testing.assert_onnx_program(onnx_program)
 
 
 if __name__ == "__main__":

--- a/test/onnx/ops/test_ops.py
+++ b/test/onnx/ops/test_ops.py
@@ -1406,10 +1406,11 @@ class NativeOnnxOpsTest(common_utils.TestCase):
             (1, "FLOAT"),
             (10, "FLOAT16"),
             (11, "DOUBLE"),
+            (16, "BFLOAT16"),
         ],
     )
     def test_attention_export_with_softmax_precision(
-        self, precision_enum, precision_name
+        self, precision_enum, precision_name: str
     ):
         """Test export with different softmax precision values."""
         batch_size, q_seq_len, kv_seq_len = 2, 4, 6
@@ -1441,7 +1442,7 @@ class NativeOnnxOpsTest(common_utils.TestCase):
         attrs = node.attributes
         self.assertIn("softmax_precision", attrs)
         self.assertEqual(attrs["softmax_precision"].value, precision_enum)
-        onnx_testing.assert_onnx_program(onnx_program, atol=1e-3, rtol=1e-3)
+        onnx_testing.assert_onnx_program(onnx_program, atol=2e-3, rtol=6e-3)
 
     def test_attention_export_gqa(self):
         """Test export and verify output tensor shapes."""

--- a/test/onnx/ops/test_ops.py
+++ b/test/onnx/ops/test_ops.py
@@ -943,7 +943,7 @@ class NativeOnnxOpsTest(common_utils.TestCase):
         K = torch.rand(batch_size, kv_num_heads, kv_seq_len, head_size)
         V = torch.rand(batch_size, kv_num_heads, kv_seq_len, head_size)
         attn_mask = torch.randint(
-            0, 2, (batch_size, q_num_heads, q_seq_len, kv_seq_len), dtype=torch.bool
+            0, 2, (batch_size, 1, kv_seq_len), dtype=torch.bool
         )
 
         class AttentionModel(torch.nn.Module):
@@ -959,6 +959,7 @@ class NativeOnnxOpsTest(common_utils.TestCase):
             "Q": {0: "batch", 2: "q_seq_len"},
             "K": {0: "batch", 2: "kv_seq_len"},
             "V": {0: "batch", 2: "kv_seq_len"},
+            "attn_mask": {0: "batch", 2: "q_seq_len"},
         }
 
         onnx_program = self.export(
@@ -972,7 +973,7 @@ class NativeOnnxOpsTest(common_utils.TestCase):
         self.assertEqual("Attention", onnx_program.model.graph.node(0).op_type)
         node = onnx_program.model.graph.node(0)
         # Verify inputs
-        self.assertEqual(len(node.inputs), 3)  # Q, K, V (no optional inputs)
+        self.assertEqual(len(node.inputs), 4)
         self.assertEqual(
             node.inputs[0].shape, ["batch", q_num_heads, "q_seq_len", head_size]
         )

--- a/torch/onnx/ops/_impl.py
+++ b/torch/onnx/ops/_impl.py
@@ -423,18 +423,11 @@ def attention_23(
 
     if can_use_sdpa:
         # Use PyTorch's optimized scaled_dot_product_attention
-
-        # Prepare attention mask for SDPA
-        sdpa_attn_mask = None
-        if attn_mask is not None:
-            # Convert boolean mask: True means participate, SDPA expects True to mask out
-            sdpa_attn_mask = ~attn_mask if attn_mask.dtype == torch.bool else attn_mask
-
         output = torch.nn.functional.scaled_dot_product_attention(
             Q,
             K,
             V,
-            attn_mask=sdpa_attn_mask,
+            attn_mask=attn_mask,
             dropout_p=0.0,
             is_causal=is_causal,
             scale=scale,

--- a/torch/onnx/ops/_impl.py
+++ b/torch/onnx/ops/_impl.py
@@ -1,3 +1,10 @@
+"""Implementations of ONNX operators as native Torch ops.
+
+NOTE: Fake implementations:
+    Refer to https://docs.pytorch.org/docs/stable/library.html#torch.library.register_fake
+    for more details on how to create fake kernels.
+"""
+
 # flake8: noqa: B950
 import math
 from collections.abc import Callable

--- a/torch/onnx/ops/_impl.py
+++ b/torch/onnx/ops/_impl.py
@@ -54,7 +54,7 @@ def _rotary_embedding_23_fake_impl(
     rotary_embedding_dim: int = 0,
 ) -> torch.Tensor:
     """Fake implementation for RotaryEmbedding-23 for torch.compile purposes."""
-    return x
+    return x.clone()
 
 
 @_onnx_op("RotaryEmbedding", 23, _rotary_embedding_23_fake_impl)
@@ -313,7 +313,8 @@ def _attention_23_fake_impl(
     else:
         # 4D input: (batch_size, num_heads, sequence_length, head_size)
         q_sequence_length = Q.shape[2]
-        output_shape = Q.shape  # Same shape as Q for 4D output
+        # Same shape as Q for 4D output
+        output_shape = Q.shape  # type: ignore[assignment]
 
         # Handle past key/value concatenation
         if past_key is not None:
@@ -324,7 +325,7 @@ def _attention_23_fake_impl(
                 K.shape[3],  # head_size
             )
         else:
-            present_key_shape = K.shape
+            present_key_shape = K.shape  # type: ignore[assignment]
         present_value_shape = present_key_shape  # Same shape as present_key
 
         # QK output shape

--- a/torch/onnx/ops/_impl.py
+++ b/torch/onnx/ops/_impl.py
@@ -2,11 +2,11 @@
 import math
 from collections.abc import Callable
 from typing import Optional, TypeVar
-
 from typing_extensions import ParamSpec
 
 import torch
 from torch.onnx.ops import _dtype_mappings
+
 
 # Use ParamSpec for better type preservation instead of bound Callable TypeVar
 _P = ParamSpec("_P")


### PR DESCRIPTION
Previously we rely on the concreate implementation to generate fake implementation. This makes the fake implementation overly complicated and breaks in some cases when there are dynamic shapes.

This PR updates onnx op registration to instead take a dedicated fake implementation.

**Also fixed: When boolean mask is supplied to torch sdpa, it was previously taken the negation, which is incorrect.**

Fix https://github.com/pytorch/pytorch/issues/164909 Also taken changes from https://github.com/pytorch/pytorch/pull/156635

cc @titaiwangms