### PR TITLE
[TD] Job level TD sort of

### DIFF
--- a/.github/workflows/target_determination.yml
+++ b/.github/workflows/target_determination.yml
@@ -71,9 +71,11 @@ jobs:
           JOB_NAME: ${{ steps.get-job-id.outputs.job-name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          set -euox pipefail
           unzip -o .additional_ci_files/llm_results/mappings.zip -d .additional_ci_files/llm_results || true
           python3 -m pip install boto3==1.35.42
-          python3 tools/testing/do_target_determination_for_s3.py
+          python3 tools/testing/do_target_determination_for_s3.py \
+            --workflow-ref "${{ github.workflow_ref }}" \
 
       - name: Upload TD results to s3
         uses: seemethere/upload-artifact-s3@baba72d0712b404f646cebe0730933554ebce96a # v5.1.0

--- a/tools/test/heuristics/test_do_td_with_job_info.py
+++ b/tools/test/heuristics/test_do_td_with_job_info.py
@@ -1,0 +1,38 @@
+# For testing specific heuristics
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.append(str(REPO_ROOT))
+
+from tools.testing.target_determination.do_td_with_job_info import (
+    get_job_info_from_workflow_file,
+)
+
+
+sys.path.remove(str(REPO_ROOT))
+
+
+class TestGetJobInfoFromWorkflowFile(unittest.TestCase):
+    def test_parsing(self):
+        workflow_file = (
+            "pytorch/pytorch/.github/workflows/pull.yml@refs/pull/165793/merge"
+        )
+        # Just some sanity checks on the output.  Don't check against a fixed
+        # value since pull.yml changes often.
+        job_info = get_job_info_from_workflow_file(workflow_file)
+        self.assertGreater(len(job_info), 5)
+        unique_jobs = {job["job_name"] for jobs in job_info for job in jobs}
+        unique_configs = {job["config"] for jobs in job_info for job in jobs}
+        self.assertGreater(len(unique_jobs), 5)
+        self.assertGreater(len(unique_configs), 5)
+        self.assertIn("default", unique_configs)
+        self.assertIn("crossref", unique_configs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/testing/target_determination/__init__.py
+++ b/tools/testing/target_determination/__init__.py
@@ -1,0 +1,11 @@
+from tools.testing.target_determination.determinator import (
+    get_test_prioritizations as get_test_prioritizations,
+)
+from tools.testing.target_determination.do_td_with_job_info import (
+    get_job_info_from_workflow_file as get_job_info_from_workflow_file,
+)
+from tools.testing.target_determination.heuristics import (
+    AggregatedHeuristics as AggregatedHeuristics,
+    TestPrioritizations as TestPrioritizations,
+    TestsToRun as TestsToRun,
+)

--- a/tools/testing/target_determination/do_td_with_job_info.py
+++ b/tools/testing/target_determination/do_td_with_job_info.py
@@ -1,0 +1,123 @@
+import re
+from pathlib import Path
+from typing import Any
+
+
+HAS_PYYAML = True
+try:
+    import yaml
+except ImportError:
+    print("Please install pyyaml to use target determination features.")
+    HAS_PYYAML = False
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def get_job_info_from_workflow_file(workflow_file: str) -> list[list[dict[str, Any]]]:
+    """
+    Returns groups of jobs that are similar based on the test configurations
+    they run.
+
+    This is pretty hardcoded, so it is fragile, but it returns a pretty accurate
+    mapping
+
+    TODO replace with better (automated?) system. Maybe a separate workflow that
+    generates an artifact that says which jobs are similar according what tests
+    they run, correlation etc, also looks at jobs on main branch or merge base
+    to better determine what jobs exist.
+    """
+    if not HAS_PYYAML:
+        return []
+    # Usually takes the form
+    # pytorch/pytorch/.github/workflows/pull.yml@refs/pull/165793/merge in CI?
+    workflow_file = workflow_file.split("@")[0].split(".github/workflows/")
+    workflow_file = ".github/workflows/" + workflow_file[1]
+
+    regex = r"needs\.([a-zA-Z0-9_-]+)\.outputs\.test-matrix"
+
+    with open(REPO_ROOT / workflow_file) as f:
+        yml = yaml.safe_load(f)
+    raw_jobs = yml.get("jobs", {})
+    jobs: list[dict[str, Any]] = []
+    dependent_jobs = {}
+
+    for job, job_info in raw_jobs.items():
+        if "test-matrix" not in job_info.get("with", {}):
+            continue
+        try:
+            test_matrix = yaml.safe_load(job_info["with"]["test-matrix"])
+            if "include" not in test_matrix:
+                # ${{ needs.linux-jammy-cuda12_8-py3_10-gcc11-sm86-build.outputs.test-matrix }}
+                match = re.search(regex, test_matrix)
+                if match:
+                    dep_job = match.group(1)
+                    dependent_jobs[f"{job_info.get('name', job)}"] = {
+                        "depends_on": f"{dep_job}",
+                        "uses": job_info.get("uses", ""),
+                    }
+                continue
+        except yaml.YAMLError as e:
+            print(f"Error parsing test-matrix for job {job}: {e}")
+            continue
+        jobs.append(
+            {
+                "job_id": f"{job}",
+                "job_name": f"{job_info.get('name', job)}",
+                "test_matrix": sorted(
+                    {entry["config"] for entry in test_matrix["include"]}
+                ),
+                "uses": job_info.get("uses", ""),
+            }
+        )
+
+    # Fill in dependent jobs
+    for job, info in dependent_jobs.items():
+        for j in jobs:
+            if j["job_id"] == info["depends_on"]:
+                jobs.append(
+                    {
+                        "job_id": job,
+                        "job_name": job,
+                        "test_matrix": j["test_matrix"],
+                        "uses": info["uses"],
+                    }
+                )
+                break
+
+    # Remove everything that doesn't use test
+    jobs = [j for j in jobs if "test" in j["uses"]]
+
+    individual_jobs = [
+        {"job_name": j["job_name"], "config": config, "uses": j.get("uses", "")}
+        for j in jobs
+        for config in j["test_matrix"]
+    ]
+
+    # Group the jobs together
+    # generally same test config -> same group
+    grouped_jobs: dict[str, list[dict[str, Any]]] = {}
+    for job in individual_jobs:
+        key = []
+        if "onnx" in job["job_name"]:
+            key.append("onnx")
+        if "bazel" in job["job_name"]:
+            key.append("bazel")
+        if "cuda" in job["job_name"]:
+            key.append("cuda")
+        if "mac" in job["job_name"]:
+            key.append("mac")
+        if "windows" in job["job_name"]:
+            key.append("windows")
+        key.append(job["config"])
+        key.append(job["uses"])
+        key_str = "|".join(sorted(key))
+        if key_str not in grouped_jobs:
+            grouped_jobs[key_str] = []
+        grouped_jobs[key_str].append(job)
+
+    for group in grouped_jobs.values():
+        for j in group:
+            j.pop("uses", None)
+
+    return list(grouped_jobs.values())

--- a/tools/testing/target_determination/do_td_with_job_info.py
+++ b/tools/testing/target_determination/do_td_with_job_info.py
@@ -31,8 +31,10 @@ def get_job_info_from_workflow_file(workflow_file: str) -> list[list[dict[str, A
         return []
     # Usually takes the form
     # pytorch/pytorch/.github/workflows/pull.yml@refs/pull/165793/merge in CI?
-    workflow_file = workflow_file.split("@")[0].split(".github/workflows/")
-    workflow_file = ".github/workflows/" + workflow_file[1]
+    workflow_file = (
+        ".github/workflows/"
+        + workflow_file.split("@")[0].split(".github/workflows/")[1]
+    )
 
     regex = r"needs\.([a-zA-Z0-9_-]+)\.outputs\.test-matrix"
 

--- a/tools/testing/target_determination/heuristics/__init__.py
+++ b/tools/testing/target_determination/heuristics/__init__.py
@@ -16,6 +16,7 @@ from tools.testing.target_determination.heuristics.historical_edited_files impor
 from tools.testing.target_determination.heuristics.interface import (
     AggregatedHeuristics as AggregatedHeuristics,
     TestPrioritizations as TestPrioritizations,
+    TestsToRun as TestsToRun,
 )
 from tools.testing.target_determination.heuristics.llm import LLM
 from tools.testing.target_determination.heuristics.mentioned_in_pr import MentionedInPR


### PR DESCRIPTION
I tried to do a correlation analysis using copilot script: P2001937663 results: P2001936725

Jobs with the same test configs and similar arches tend to have the same results, so this PR attempts to use similar jobs as a sort of extra shard by distributing tests across similar jobs.  However, it's hard to tell if a test job exists prior to it actually running, so we have to be a bit conservative about it.  We always run the top 10% of tests for every job.  Then for the rest, we round robin them among the job groups, and also concat the round robining so that every job runs every test, just in different orders.  If we assume the job groups usually have the same results, this increases coverage when applying the threshold

Also
* move threshold determination to TD job instead of inside the test job.  previously the filter was applied after any filtering for tests that dont run on the job (ex they specify jobs, they filter some out b/c not supported by platform).  Now it happens with the rest of target determination
  * Pros: stuff like distributed tests which only get run on distributed jobs can be filtered in or out more strongly (ex td says to put distributed tests first, but if the distributed test jobs filter out non distributed tests, then the threshold is applied on this shorter list -> runs fewer distributed tests.  Now since the threshold is applied earlier, then the list will have all the tests -> threshold applied on longer list -> more distributed tests get run)
  * Cons: the pro, but in the opposite direction.  Since the threshold is applied earlier, on the longer list, then it's possible that you end up running fewer tests on some configs 
* very small threshold increase from from .25 -> .3 to help with the above 