### PR TITLE
[annotation] add logging for debugging annotation

### DIFF
--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -982,6 +982,7 @@ exclusions = {
     "graph_region_expansion",
     "hierarchical_compile",
     "compute_dependencies",
+    "annotation",
 }
 for name in torch._logging._internal.log_registry.artifact_names:
     if name not in exclusions:

--- a/torch/_logging/_registrations.py
+++ b/torch/_logging/_registrations.py
@@ -246,4 +246,9 @@ register_artifact(
     "Logs debug info for hierarchical compilation",
     off_by_default=True,
 )
+register_artifact(
+    "annotation",
+    "Logs detailed steps of the creating annotation on graph nodes",
+    off_by_default=True,
+)
 register_artifact("custom_format_test_artifact", "Testing only", log_format="")

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -17,6 +17,7 @@ from typing import Any, Optional
 import torch
 import torch.fx.traceback as fx_traceback
 from torch._C import _fx_map_aggregate as map_aggregate, _fx_map_arg as map_arg
+from torch._logging import getArtifactLogger
 from torch.utils._traceback import CapturedTraceback
 
 from ._compatibility import compatibility
@@ -40,6 +41,7 @@ __all__ = [
 
 
 log = logging.getLogger(__name__)
+annotation_log = getArtifactLogger(__name__, "annotation")
 
 
 @compatibility(is_backward_compatible=False)
@@ -202,7 +204,9 @@ class TracerBase:
             # BWD pass we retrieve the sequence_nr stored on the current
             # executing autograd Node. See NOTE [ Sequence Number ].
             if current_meta.get("in_grad_fn", 0) > 0:
+                annotation_log.debug("seq_nr from current_meta")
                 new_seq_nr = current_meta["grad_fn_seq_nr"][-1]
+            annotation_log.debug("Assigning new_seq_nr %s to %s", new_seq_nr, node.name)
             node.meta["seq_nr"] = new_seq_nr
 
         elif self.module_stack:


### PR DESCRIPTION
Add logging for debugging annotation bugs. Log will show with `TORCH_LOGS="+annotation" `

cc @ezyang @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela