### PR TITLE
add PYTORCH_VERSION_SUFFIX to append local build version suffix

### DIFF
--- a/tools/generate_torch_version.py
+++ b/tools/generate_torch_version.py
@@ -90,6 +90,9 @@ def get_torch_version(sha: str | None = None) -> str:
                 sha = get_sha(pytorch_root)
             version += "+git" + sha[:7]
             origin += " and git commit"
+    # Add custom suffix if specified
+    if pytorch_version_suffix := os.getenv("PYTORCH_VERSION_SUFFIX"):
+        version += pytorch_version_suffix
     # Validate that the version is PEP 440 compliant
     parsed_version = Version(version)
     if sdist_version:


### PR DESCRIPTION
Allows flexibility of appending additional local build version to pytorch local version string using env `PYTORCH_VERSION_SUFFIX`. This is a more generalized version of this other PR: https://github.com/pytorch/pytorch/pull/123955

Local testing:
```
2025-10-17T22:52:08.909563Z 01O PYTORCH_VERSION_SUFFIX: .nvinternal.add-pytorch-version-suffix
....
2025-10-17T22:57:43.668478Z 01E #36 7.394 Building wheel torch-2.9.0a0+145a3a7bda.nvinternal.add-pytorch-version-suffix
2025-10-17T22:57:43.830243Z 01E #36 7.555 Found cmake (/opt/python/v/bin/cmake) version: 3.31.6 (>=3.27)
2025-10-17T22:57:43.976888Z 01E #36 7.564 Found cmake3 (/usr/bin/cmake3) version: 3.26.5 (<3.27)
2025-10-17T22:57:43.976894Z 01E #36 7.642 /opt/python/v/lib/python3.12/site-packages/setuptools/dist.py:334: InformationOnly: Normalizing '2.9.0a0+145a3a7bda.nvinternal.add-pytorch-version-suffix' to '2.9.0a0+145a3a7bda.nvinternal.add.pytorch.version.suffix'
```

cc: @nWEIdia