### PR TITLE
[OpenReg][Random] Enrich OpenReg random number generator module implementation add focused documentation

### DIFF
--- a/docs/source/accelerator/generator.md
+++ b/docs/source/accelerator/generator.md
@@ -1,0 +1,213 @@
+# Random Number Generator
+
+## Background
+
+OpenReg Generator provides device-specific random number generation capabilities for the OpenReg accelerator backend. As part of PyTorch's extensibility framework, OpenReg implements custom random number generators that integrate seamlessly with PyTorch's `torch.Generator` infrastructure.
+
+The generator module enables:
+
+- **Per-device RNG state management**: Each OpenReg device maintains its own independent random number generator with isolated state.
+- **Reproducible computations**: Support for manual seeding ensures deterministic behavior when needed.
+- **PyTorch API compatibility**: Generators work with PyTorch's random operations (e.g., `torch.rand`, `torch.randn`) on OpenReg devices.
+- **State serialization**: RNG states can be saved and restored for checkpointing and resuming experiments.
+
+OpenReg's generator implementation subclasses `at::CPUGeneratorImpl`, leveraging CPU-based random number generation while maintaining proper device attribution. This design pattern is suitable for accelerators that delegate random number generation to the CPU or use CPU-compatible algorithms.
+
+## Design
+
+The following table lists the basic functionalities that accelerator vendors need to implement for random number generation:
+
+| Functionality       | Description                                                                  | Application Scenario                                                 |
+| ------------------- | ---------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `get_rng_state`     | Returns the current RNG state as a ByteTensor for a specific device          | Save RNG state for model checkpointing or experiment reproducibility |
+| `get_rng_state_all` | Returns RNG states for all devices as a list of ByteTensors                  | Save multi-device RNG states in distributed or multi-GPU scenarios   |
+| `set_rng_state`     | Restores a previously saved RNG state for a specific device                  | Resume experiments from checkpoints with exact RNG state             |
+| `set_rng_state_all` | Restores RNG states for all devices from a list of ByteTensors               | Restore multi-device RNG states in distributed settings              |
+| `manual_seed`       | Sets a specific seed for the current device                                  | Initialize RNG with a known seed for reproducible experiments        |
+| `manual_seed_all`   | Sets the same seed for all devices                                           | Ensure synchronized random number generation across all devices      |
+| `seed`              | Sets a random seed for the current device                                    | Initialize RNG with non-deterministic seed for production            |
+| `seed_all`          | Sets random seeds for all devices                                            | Initialize all device RNGs with non-deterministic seeds              |
+| `initial_seed`      | Returns the initial seed used to initialize the generator for current device | Retrieve the seed for debugging or logging purposes                  |
+
+## Implementation
+
+This section demonstrates how to implement RNG state management using `set_rng_state` as an example.
+
+### Python Side
+
+The Python implementation provides a user-friendly interface that handles device specification and delegates to C++ bindings:
+
+```{eval-rst}
+.. literalinclude:: ../../../test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/openreg/random.py
+    :language: python
+    :start-after: LITERALINCLUDE START: OPENREG GENERATOR PY WRAPPER EXAMPLE
+    :end-before: LITERALINCLUDE END: OPENREG GENERATOR PY WRAPPER EXAMPLE
+    :linenos:
+```
+
+**Key implementation details:**
+
+1. **Device normalization**: Accepts flexible device specifications (`int`, `str`, or `torch.device`) and normalizes them to a device index.
+2. **Device index resolution**: Defaults to the current device if no specific index is provided.
+3. **C++ delegation**: Calls `torch_openreg._C._get_default_generator(idx)` to obtain the device-specific generator from C++.
+4. **State manipulation**: Uses the generator's `set_state()` method to restore the RNG state.
+
+### C++ Side
+
+The C++ implementation manages per-device generator instances and provides access to them:
+
+**Generator Implementation Header:**
+
+```{eval-rst}
+.. literalinclude:: ../../../test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegGenerator.h
+    :language: c++
+    :start-after: LITERALINCLUDE START: OPENREG GENERATOR IMPL HEADER
+    :end-before: LITERALINCLUDE END: OPENREG GENERATOR IMPL HEADER
+    :linenos:
+```
+
+**Generator Implementation:**
+
+```{eval-rst}
+.. literalinclude:: ../../../test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegGenerator.cpp
+    :language: c++
+    :start-after: LITERALINCLUDE START: OPENREG GET DEFAULT GENERATOR IMPL
+    :end-before: LITERALINCLUDE END: OPENREG GET DEFAULT GENERATOR IMPL
+    :linenos:
+```
+
+**Key implementation details:**
+
+1. **Inheritance**: `OpenRegGeneratorImpl` extends `at::CPUGeneratorImpl` for CPU-compatible RNG behavior.
+2. **Device attribution**: Sets `device_` to `PrivateUse1` with the correct device index and configures `key_set_` for dispatch.
+3. **Singleton management**: `getDefaultOpenRegGenerator` maintains a static vector of per-device default generators.
+4. **Lazy initialization**: Generators are created and seeded on first access using a static initialization pattern.
+5. **Device validation**: Validates device indices and defaults to the current device when the index is -1.
+
+## Integration
+
+The following sections demonstrate how random number generator functionalities integrate from user-facing Python APIs down to the C++ implementation. We use `manual_seed` as an example to illustrate the complete layer-by-layer flow.
+
+### Layer 1: User Code
+
+User code initiates the operation by calling the high-level API to set a random seed:
+
+```python
+import torch_openreg
+
+# Set seed for reproducible random number generation
+torch.openreg.manual_seed(42)
+```
+
+### Layer 2: Python Wrapper Implementation
+
+The Python wrapper handles device resolution and calls the C++ binding:
+
+```{eval-rst}
+.. literalinclude:: ../../../test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/openreg/random.py
+    :language: python
+    :start-after: LITERALINCLUDE START: OPENREG MANUAL SEED
+    :end-before: LITERALINCLUDE END: OPENREG MANUAL SEED
+    :linenos:
+    :emphasize-lines: 11
+```
+
+**Layer 2 responsibilities:**
+
+1. **Input validation**: Converts the seed to an integer.
+2. **Device resolution**: Gets the current device index via `current_device()`.
+3. **Generator access**: Calls `torch_openreg._C._get_default_generator(idx)` to obtain the device-specific generator.
+4. **Seed application**: Invokes the generator's `manual_seed(seed)` method.
+
+### Layer 3: C++ Binding - Generator Access
+
+The C++ extension exposes `_getDefaultGenerator` to Python for accessing device generators:
+
+```{eval-rst}
+.. literalinclude:: ../../../test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/csrc/Module.cpp
+    :language: c++
+    :start-after: LITERALINCLUDE START: OPENREG MODULE METHODS
+    :end-before: LITERALINCLUDE END: OPENREG MODULE METHODS
+    :linenos:
+    :emphasize-lines: 3
+```
+
+```{eval-rst}
+.. literalinclude:: ../../../test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/csrc/Module.cpp
+    :language: c++
+    :start-after: LITERALINCLUDE START: OPENREG GET DEFAULT GENERATOR
+    :end-before: LITERALINCLUDE END: OPENREG GET DEFAULT GENERATOR
+    :linenos:
+    :emphasize-lines: 11-12
+```
+
+**Layer 3 responsibilities:**
+
+1. **Argument unpacking**: Extracts the device index from Python arguments using `THPUtils_unpackLong`.
+2. **Device construction**: Creates a `c10::Device` object with `PrivateUse1` type and the device index.
+3. **Context delegation**: Calls `at::globalContext().defaultGenerator(device)` to retrieve the generator.
+4. **Python wrapping**: Wraps the C++ generator in a `THPGenerator` Python object using `THPGenerator_initDefaultGenerator`.
+
+### Layer 4: PyTorch Core Context
+
+PyTorch's Context dispatches to the registered hooks to obtain the device-specific generator:
+
+```{eval-rst}
+.. literalinclude:: ../../../aten/src/ATen/Context.h
+    :language: c++
+    :lines: 61-73
+    :linenos:
+    :emphasize-lines: 8-9
+```
+
+**Layer 4 responsibilities:**
+
+1. **Device type check**: Determines if the device is CPU or an accelerator.
+2. **Hook dispatch**: For accelerator devices, calls `getAcceleratorHooksInterface(device_type).getDefaultGenerator(device.index())`.
+3. **Generator return**: Returns the device-specific generator reference.
+
+### Layer 5: Accelerator Hooks
+
+The hooks interface delegates to the device-specific generator implementation:
+
+```{eval-rst}
+.. literalinclude:: ../../../test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegHooks.h
+    :language: c++
+    :start-after: LITERALINCLUDE START: OPENREG HOOK EXAMPLES
+    :end-before: LITERALINCLUDE END: OPENREG HOOK EXAMPLES
+    :linenos:
+```
+
+**Layer 5 responsibilities:**
+
+1. **Hook implementation**: Overrides `getDefaultGenerator` from `PrivateUse1HooksInterface`.
+2. **Default generator delegation**: `getDefaultGenerator` calls `getDefaultOpenRegGenerator(device_index)` to access the per-device singleton.
+
+### Layer 6: Device-Specific Generator Implementation
+
+The final layer manages the actual per-device generator instances:
+
+```{eval-rst}
+.. literalinclude:: ../../../test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegGenerator.cpp
+    :language: c++
+    :start-after: LITERALINCLUDE START: OPENREG GET DEFAULT GENERATOR IMPL
+    :end-before: LITERALINCLUDE END: OPENREG GET DEFAULT GENERATOR IMPL
+    :linenos:
+```
+
+```{eval-rst}
+.. literalinclude:: ../../../test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegGenerator.cpp
+    :language: c++
+    :start-after: LITERALINCLUDE START: OPENREG CREATE GENERATOR IMPL
+    :end-before: LITERALINCLUDE END: OPENREG CREATE GENERATOR IMPL
+    :linenos:
+```
+
+**Layer 6 responsibilities:**
+
+1. **Static storage**: Maintains a static vector `default_generators` for per-device generator instances.
+2. **Lazy initialization**: Initializes all device generators on first access using a static lambda.
+3. **Generator creation**: Creates generator instances using `createOpenRegGenerator(i)`, which internally calls `createOpenRegGenerator(device_index)`.
+4. **Initial seeding**: Seeds each generator during initialization.
+5. **Device validation**: Validates the device index and defaults to the current device if the index is -1.
+6. **Generator return**: Returns a const reference to the appropriate device's generator.

--- a/docs/source/accelerator/index.md
+++ b/docs/source/accelerator/index.md
@@ -43,6 +43,7 @@ Next, we will delve into each chapter of this guide. Each chapter focuses on a k
 :maxdepth: 1
 
 device
+generator
 hooks
 guard
 autoload

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/aten/OpenRegMinimal.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/aten/OpenRegMinimal.cpp
@@ -1,9 +1,10 @@
-#include "native/Minimal.h"
+#include <c10/core/Scalar.h>
+#include <torch/library.h>
 
 #include <ATen/native/CPUFallback.h>
 #include <ATen/native/DispatchStub.h>
 
-#include <torch/library.h>
+#include "native/Minimal.h"
 
 namespace at::openreg {
 
@@ -105,6 +106,109 @@ bool wrapper_has_compatible_shallow_copy_type(const at::Tensor& self, const at::
   return true;
 }
 
+at::Tensor wrapper_rand_generator(
+    c10::IntArrayRef size,
+    std::optional<at::Generator> generator,
+    std::optional<c10::ScalarType> dtype_opt,
+    std::optional<c10::Layout> layout_opt,
+    std::optional<c10::Device> device_opt,
+    std::optional<bool> pin_memory_opt) {
+  return at::native::openreg::rand(
+      size, generator, dtype_opt, layout_opt, device_opt, pin_memory_opt);
+}
+
+at::Tensor wrapper_rand_like_generator(
+    const at::Tensor& self,
+    std::optional<at::Generator> generator,
+    std::optional<c10::ScalarType> dtype_opt,
+    std::optional<c10::Layout> layout_opt,
+    std::optional<c10::Device> device_opt,
+    std::optional<bool> pin_memory_opt,
+    std::optional<c10::MemoryFormat> memory_format_opt) {
+  (void)memory_format_opt; // schema includes memory_format; backend ignores for
+                           // now
+  return at::native::openreg::rand(
+      self.sizes(),
+      generator,
+      dtype_opt,
+      layout_opt,
+      device_opt,
+      pin_memory_opt);
+}
+
+at::Tensor wrapper_randn_generator(
+    c10::IntArrayRef size,
+    std::optional<at::Generator> generator,
+    std::optional<c10::ScalarType> dtype_opt,
+    std::optional<c10::Layout> layout_opt,
+    std::optional<c10::Device> device_opt,
+    std::optional<bool> pin_memory_opt) {
+  return at::native::openreg::randn(
+      size, generator, dtype_opt, layout_opt, device_opt, pin_memory_opt);
+}
+
+at::Tensor wrapper_randn_like_generator(
+    const at::Tensor& self,
+    std::optional<at::Generator> generator,
+    std::optional<c10::ScalarType> dtype_opt,
+    std::optional<c10::Layout> layout_opt,
+    std::optional<c10::Device> device_opt,
+    std::optional<bool> pin_memory_opt,
+    std::optional<c10::MemoryFormat> memory_format_opt) {
+  (void)memory_format_opt; // schema includes memory_format; backend ignores for
+                           // now
+  return at::native::openreg::randn(
+      self.sizes(),
+      generator,
+      dtype_opt,
+      layout_opt,
+      device_opt,
+      pin_memory_opt);
+}
+
+at::Tensor wrapper_randint_generator(
+    int64_t low,
+    int64_t high,
+    c10::IntArrayRef size,
+    std::optional<at::Generator> generator,
+    std::optional<c10::ScalarType> dtype_opt,
+    std::optional<c10::Layout> layout_opt,
+    std::optional<c10::Device> device_opt,
+    std::optional<bool> pin_memory_opt) {
+  return at::native::openreg::randint(
+      low,
+      high,
+      size,
+      generator,
+      dtype_opt,
+      layout_opt,
+      device_opt,
+      pin_memory_opt);
+}
+
+at::Tensor wrapper_randint_like_generator(
+    const at::Tensor& self,
+    int64_t low,
+    int64_t high,
+    std::optional<at::Generator> generator,
+    std::optional<c10::ScalarType> dtype_opt,
+    std::optional<c10::Layout> layout_opt,
+    std::optional<c10::Device> device_opt,
+    std::optional<bool> pin_memory_opt,
+    std::optional<c10::MemoryFormat> memory_format_opt) {
+  (void)memory_format_opt; // schema includes memory_format; backend ignores for
+                           // now
+  return at::native::openreg::randint(
+      low,
+      high,
+      self.sizes(),
+      generator,
+      dtype_opt,
+      layout_opt,
+      device_opt,
+      pin_memory_opt);
+}
+
 // LITERALINCLUDE START: FALLBACK WRAPPER
 void wrapper_cpu_fallback(
     const c10::OperatorHandle& op,
@@ -134,6 +238,12 @@ TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
       "set_.source_Storage_storage_offset",
       wrapper_set_source_Storage_storage_offsetset_);
   m.impl("view", wrapper_view);
+  m.impl("rand.generator", wrapper_rand_generator);
+  m.impl("randn.generator", wrapper_randn_generator);
+  m.impl("randint.low_generator", wrapper_randint_generator);
+  m.impl("rand_like.generator", wrapper_rand_like_generator);
+  m.impl("randn_like.generator", wrapper_randn_like_generator);
+  m.impl("randint_like.low_generator_dtype", wrapper_randint_like_generator);
 }
 // LITERALINCLUDE END: TORCH_LIBRARY_IMPL DEFAULT
 

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/aten/native/Minimal.h
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/aten/native/Minimal.h
@@ -58,4 +58,31 @@ at::Tensor view(const at::Tensor& self, c10::SymIntArrayRef size);
 
 void cpu_fallback(const c10::OperatorHandle& op, torch::jit::Stack* stack);
 
+// Random generation (explicit generator-aware) for PrivateUse1
+at::Tensor rand(
+    c10::IntArrayRef size,
+    std::optional<at::Generator> generator,
+    std::optional<c10::ScalarType> dtype_opt,
+    std::optional<c10::Layout> layout_opt,
+    std::optional<c10::Device> device_opt,
+    std::optional<bool> pin_memory_opt);
+
+at::Tensor randn(
+    c10::IntArrayRef size,
+    std::optional<at::Generator> generator,
+    std::optional<c10::ScalarType> dtype_opt,
+    std::optional<c10::Layout> layout_opt,
+    std::optional<c10::Device> device_opt,
+    std::optional<bool> pin_memory_opt);
+
+at::Tensor randint(
+    int64_t low,
+    int64_t high,
+    c10::IntArrayRef size,
+    std::optional<at::Generator> generator,
+    std::optional<c10::ScalarType> dtype_opt,
+    std::optional<c10::Layout> layout_opt,
+    std::optional<c10::Device> device_opt,
+    std::optional<bool> pin_memory_opt);
+
 } // namespace at::native::openreg

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegGenerator.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegGenerator.cpp
@@ -1,4 +1,5 @@
 #include "OpenRegGenerator.h"
+#include "runtime/OpenRegFunctions.h"
 
 // Default, global generators, one per device.
 static std::vector<at::Generator> default_generators;
@@ -11,13 +12,13 @@ const at::Generator& getDefaultOpenRegGenerator(c10::DeviceIndex device_index) {
     auto deivce_nums = device_count();
     default_generators.resize(deivce_nums);
     for (auto i = 0; i < deivce_nums; i++) {
-      default_generators[i] = at::make_generator<OpenRegGeneratorImpl>(i);
+      default_generators[i] = createOpenRegGenerator(i);
       default_generators[i].seed();
     }
     return true;
   }();
 
-  c10::DeviceIndex idx = device_index;
+  DeviceIndex idx = device_index;
   if (idx == -1) {
     idx = current_device();
   } else {
@@ -26,5 +27,19 @@ const at::Generator& getDefaultOpenRegGenerator(c10::DeviceIndex device_index) {
   return default_generators[idx];
 }
 // LITERALINCLUDE END: OPENREG GET DEFAULT GENERATOR IMPL
+
+// LITERALINCLUDE START: OPENREG CREATE GENERATOR IMPL
+at::Generator createOpenRegGenerator(DeviceIndex device_index) {
+  check_device_index(device_index);
+  auto gen = at::make_generator<OpenRegGeneratorImpl>(device_index);
+  auto openreg_gen = at::check_generator<OpenRegGeneratorImpl>(gen);
+  openreg_gen->set_current_seed(default_rng_seed_val);
+  return gen;
+}
+// LITERALINCLUDE END: OPENREG CREATE GENERATOR IMPL
+
+DeviceType OpenRegGeneratorImpl::device_type() {
+  return DeviceType::PrivateUse1;
+}
 
 } // namespace c10::openreg

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegGenerator.h
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegGenerator.h
@@ -5,17 +5,20 @@
 
 #include "OpenRegFunctions.h"
 
+// LITERALINCLUDE START: OPENREG GENERATOR IMPL HEADER
 namespace c10::openreg {
-class OpenRegGeneratorImpl : public at::CPUGeneratorImpl {
+class OPENREG_EXPORT OpenRegGeneratorImpl : public at::CPUGeneratorImpl {
  public:
   OpenRegGeneratorImpl(c10::DeviceIndex device_index) {
     device_ = c10::Device(c10::DeviceType::PrivateUse1, device_index);
     key_set_ = c10::DispatchKeySet(c10::DispatchKey::PrivateUse1);
   }
   ~OpenRegGeneratorImpl() override = default;
-};
+  static DeviceType device_type();
+}; // class OpenRegGeneratorImpl
 
-const at::Generator& getDefaultOpenRegGenerator(
-    c10::DeviceIndex device_index = -1);
+OPENREG_EXPORT const at::Generator& getDefaultOpenRegGenerator(c10::DeviceIndex device_index = -1);
 
+OPENREG_EXPORT at::Generator createOpenRegGenerator(c10::DeviceIndex device_index = -1);
 } // namespace c10::openreg
+// LITERALINCLUDE END: OPENREG GENERATOR IMPL HEADER

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegHooks.h
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegHooks.h
@@ -87,8 +87,8 @@ struct OPENREG_EXPORT OpenRegHooksInterface : public at::PrivateUse1HooksInterfa
   }
   // LITERALINCLUDE END: OPENREG HOOK EXAMPLES
 
-  at::Generator getNewGenerator(DeviceIndex device_index) const override {
-    return at::make_generator<OpenRegGeneratorImpl>(device_index);
+  at::Generator getNewGenerator(c10::DeviceIndex device_index) const override {
+    return createOpenRegGenerator(device_index);
   }
 };
 

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_rng.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_rng.py
@@ -18,10 +18,146 @@ class TestRNG(TestCase):
         state = torch.openreg.get_rng_state(0)
         torch.openreg.set_rng_state(state, 0)
 
+        states = torch.openreg.get_rng_state_all()
+        torch.openreg.set_rng_state_all(states)
+
     def test_manual_seed(self):
-        """Test manual seed setting"""
-        torch.openreg.manual_seed_all(2024)
-        self.assertEqual(torch.openreg.initial_seed(), 2024)
+        torch.openreg.manual_seed_all(42)
+        self.assertEqual(torch.openreg.initial_seed(), 42)
+
+    def test_seed(self):
+        torch.openreg.seed_all()
+        seed1 = torch.openreg.initial_seed()
+        torch.openreg.seed_all()
+        seed2 = torch.openreg.initial_seed()
+        self.assertNotEqual(seed1, seed2)
+
+    # LITERALINCLUDE START: OPENREG GENERATOR TEST EXAMPLES
+    def test_create_generator_and_seed(self):
+        generator = torch.Generator(device="openreg:0")
+        generator.manual_seed(42)
+        self.assertEqual(generator.initial_seed(), 42)
+
+    # LITERALINCLUDE END: OPENREG GENERATOR TEST EXAMPLES
+
+    def test_rand_with_explicit_generator(self):
+        gen = torch.Generator(device="openreg:0")
+        gen.manual_seed(1234)
+        a = torch.rand((4, 5), device="openreg:0", generator=gen)
+        # Reset seed and ensure determinism
+        gen.manual_seed(1234)
+        b = torch.rand((4, 5), device="openreg:0", generator=gen)
+        self.assertEqual(a, b)
+
+    def test_randn_with_explicit_generator(self):
+        gen = torch.Generator(device="openreg:0")
+        gen.manual_seed(5678)
+        a = torch.randn((3, 3), device="openreg:0", generator=gen)
+        gen.manual_seed(5678)
+        b = torch.randn((3, 3), device="openreg:0", generator=gen)
+        self.assertEqual(a, b)
+
+    def test_rand_range_and_dtype(self):
+        """rand returns values in [0,1) and honors dtype"""
+        gen = torch.Generator(device="openreg:0")
+        gen.manual_seed(7)
+
+        for dtype in (torch.float, torch.double):
+            x = torch.rand((1000,), device="openreg:0", dtype=dtype, generator=gen)
+            self.assertEqual(x.dtype, dtype)
+            self.assertTrue(torch.all(x >= 0).item())
+            # Strict upper bound: no element should be >= 1
+            self.assertTrue(torch.all(x < 1).item())
+
+    def test_randn_stats_float_double(self):
+        """randn samples have mean≈0 and std≈1 for sufficiently large sample"""
+        gen = torch.Generator(device="openreg:0")
+        gen.manual_seed(123)
+        for dtype in (torch.float, torch.double):
+            x = torch.randn((20000,), device="openreg:0", dtype=dtype, generator=gen)
+            mean = x.mean().item()
+            std = x.std(unbiased=False).item()
+            # Loose tolerances to avoid flaky failures
+            self.assertLess(abs(mean), 0.05)
+            self.assertLess(abs(std - 1.0), 0.05)
+
+    def test_generator_device_mismatch_raises(self):
+        gen = torch.Generator(device="openreg:0")
+        gen.manual_seed(1)
+        with self.assertRaisesRegex(
+            RuntimeError, "Generator device index.*does not match"
+        ):
+            torch.rand((2,), device="openreg:1", generator=gen)
+
+    def test_state_save_restore_determinism(self):
+        gen = torch.Generator(device="openreg:0")
+        gen.manual_seed(42)
+        state = gen.get_state()
+        x1 = torch.rand((5,), device="openreg:0", generator=gen)
+        # restore state and re-sample yields same values
+        gen.set_state(state)
+        x2 = torch.rand((5,), device="openreg:0", generator=gen)
+        self.assertEqual(x1, x2)
+
+    def test_empty_tensors(self):
+        gen = torch.Generator(device="openreg:0")
+        gen.manual_seed(123)
+        r = torch.rand((0,), device="openreg:0", generator=gen)
+        n = torch.randn((0,), device="openreg:0", generator=gen)
+        self.assertEqual(r.numel(), 0)
+        self.assertEqual(n.numel(), 0)
+
+    def test_randint_bounds_and_dtypes(self):
+        """Bounds checks for randint across dtypes; omit generator for overloads not implemented yet"""
+        # int32
+        x32 = torch.randint(0, 10, (1000,), device="openreg:0", dtype=torch.int32)
+        self.assertEqual(x32.dtype, torch.int32)
+        self.assertTrue(torch.all((x32 >= 0) & (x32 < 10)).item())
+
+        # int64
+        x64 = torch.randint(5, 15, (1000,), device="openreg:0", dtype=torch.int64)
+        self.assertEqual(x64.dtype, torch.int64)
+        self.assertTrue(torch.all((x64 >= 5) & (x64 < 15)).item())
+
+        # int16
+        x16 = torch.randint(-3, 3, (1000,), device="openreg:0", dtype=torch.int16)
+        self.assertEqual(x16.dtype, torch.int16)
+        self.assertTrue(torch.all((x16 >= -3) & (x16 < 3)).item())
+
+    def test_randint_with_explicit_generator_default_dtype(self):
+        """Explicit generator supported for default integral dtype path"""
+        gen = torch.Generator(device="openreg:0")
+        gen.manual_seed(99)
+        x = torch.randint(0, 10, (1000,), device="openreg:0", generator=gen)
+        self.assertEqual(x.dtype, torch.int64)  # default integral dtype
+        self.assertTrue(torch.all((x >= 0) & (x < 10)).item())
+
+    def test_noncontiguous_fill(self):
+        """Ensure RNG fills non-contiguous tensors via view/transpose without crash"""
+        gen = torch.Generator(device="openreg:0")
+        gen.manual_seed(2024)
+        base = torch.empty((32, 32), device="openreg:0")
+        # Create a non-contiguous view by transposing
+        nc = base.t()
+        self.assertFalse(nc.is_contiguous())
+
+        # Fill with rand and randn; just smoke check shapes and device
+        r = torch.rand(nc.shape, device="openreg:0", generator=gen)
+        n = torch.randn(nc.shape, device="openreg:0", generator=gen)
+        self.assertEqual(r.shape, nc.shape)
+        self.assertEqual(n.shape, nc.shape)
+        self.assertEqual(r.device.type, "openreg")
+        self.assertEqual(n.device.type, "openreg")
+
+    def test_large_tensor_smoke(self):
+        """Large tensor generation should not segfault"""
+        gen = torch.Generator(device="openreg:0")
+        gen.manual_seed(1)
+        # 1 million elements
+        r = torch.rand((1_000_000,), device="openreg:0", generator=gen)
+        n = torch.randn((1_000_000,), device="openreg:0", generator=gen)
+        self.assertEqual(r.numel(), 1_000_000)
+        self.assertEqual(n.numel(), 1_000_000)
 
     def test_generator_seed(self):
         """Test generator seed setting"""

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/csrc/Module.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/csrc/Module.cpp
@@ -1,5 +1,6 @@
 #include <ATen/Context.h>
 
+#include <c10/core/DeviceType.h>
 #include <torch/csrc/Exceptions.h>
 #include <torch/csrc/utils.h>
 #include <torch/csrc/utils/device_lazy_init.h>
@@ -13,6 +14,7 @@
 #include "distributed/init.hpp"
 #endif
 #include <runtime/OpenRegFunctions.h>
+#include <runtime/OpenRegGenerator.h>
 
 static PyObject* _initExtension(PyObject* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
@@ -43,13 +45,11 @@ static PyObject* _getDefaultGenerator(PyObject* self, PyObject* arg) {
   return THPGenerator_initDefaultGenerator(
       at::globalContext().defaultGenerator(
           c10::Device(c10::DeviceType::PrivateUse1, idx)));
-
   END_HANDLE_TH_ERRORS
 }
 // LITERALINCLUDE END: OPENREG GET DEFAULT GENERATOR
 
 // LITERALINCLUDE START: MODULE SET DEVICE HELPER
-
 PyObject* _setDevice(PyObject* self, PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(THPUtils_checkLong(arg), "invalid argument to setDevice");
@@ -60,7 +60,6 @@ PyObject* _setDevice(PyObject* self, PyObject* arg) {
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
-
 // LITERALINCLUDE END: MODULE SET DEVICE HELPER
 
 PyObject* _exchangeDevice(PyObject* self, PyObject* arg) {

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/openreg/__init__.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/openreg/__init__.py
@@ -1,4 +1,8 @@
+import traceback
+from collections.abc import Callable
+
 import torch
+from torch._utils import _LazySeedTracker
 
 import torch_openreg._C  # type: ignore[misc]
 from . import meta
@@ -7,6 +11,10 @@ from .amp import get_amp_supported_dtype
 
 _initialized = False
 _is_in_bad_fork = getattr(torch_openreg._C, "_isInBadFork", lambda: False)
+_queued_calls: list[
+    tuple[Callable[[], None], list[str]]
+] = []  # don't invoke these until initialization occurs
+_lazy_seed_tracker = _LazySeedTracker()
 
 
 class device:
@@ -58,8 +66,22 @@ def is_initialized():
     return _initialized and not _is_in_bad_fork()
 
 
+def _lazy_call(callable, **kwargs):
+    if is_initialized():
+        callable()
+    else:
+        global _lazy_seed_tracker
+        if kwargs.get("seed_all", False):
+            _lazy_seed_tracker.queue_seed_all(callable, traceback.format_stack())
+        elif kwargs.get("seed", False):
+            _lazy_seed_tracker.queue_seed(callable, traceback.format_stack())
+        else:
+            # Don't store the actual traceback to avoid memory cycle
+            _queued_calls.append((callable, traceback.format_stack()))
+
+
 def _lazy_init():
-    global _initialized
+    global _initialized, _queued_calls
     if is_initialized():
         return
     if _is_in_bad_fork():
@@ -68,6 +90,20 @@ def _lazy_init():
             "multiprocessing, you must use the 'spawn' start method"
         )
     torch_openreg._C._init()
+
+    _queued_calls.extend(call for call in _lazy_seed_tracker.get_calls() if call)
+
+    for queued_call, origin_trackback in _queued_calls:
+        try:
+            queued_call()
+        except Exception as e:
+            msg = (
+                "Error during lazy initialization call from:\n"
+                + "".join(origin_trackback)
+                + f"\nError message: {e}"
+            )
+            raise Exception(msg) from e  # noqa: TRY002
+
     _initialized = True
 
 
@@ -87,5 +123,9 @@ __all__ = [
     "manual_seed",
     "manual_seed_all",
     "get_rng_state",
+    "get_rng_state_all",
+    "seed",
+    "seed_all",
     "set_rng_state",
+    "set_rng_state_all",
 ]

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/openreg/random.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/openreg/random.py
@@ -4,8 +4,8 @@ import torch
 from torch import ByteTensor
 
 import torch_openreg._C  # type: ignore[misc]
-
 from . import _lazy_call, _lazy_init, current_device, device_count
+
 
 __all__ = [
     "get_rng_state",

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/openreg/random.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/openreg/random.py
@@ -1,19 +1,33 @@
+from collections.abc import Iterable
+
 import torch
+from torch import ByteTensor
 
 import torch_openreg._C  # type: ignore[misc]
-from . import _lazy_init, current_device, device_count
 
+from . import _lazy_call, _lazy_init, current_device, device_count
 
 __all__ = [
     "get_rng_state",
+    "get_rng_state_all",
     "set_rng_state",
+    "set_rng_state_all",
     "manual_seed",
     "manual_seed_all",
+    "seed",
+    "seed_all",
     "initial_seed",
 ]
 
 
-def get_rng_state(device="openreg"):
+def get_rng_state(device: int | str | torch.device = "openreg"):
+    r"""Return a ByteTensor representing the random number state of the current device.
+
+    Args:
+        device (int, str or torch.device): The device to get the RNG state.
+            Default: ``'openreg'`` (i.e., ``torch.device('openreg')``, the current OpenReg device).
+    """
+    _lazy_init()
     if isinstance(device, str):
         device = torch.device(device)
     elif isinstance(device, int):
@@ -25,19 +39,90 @@ def get_rng_state(device="openreg"):
     return default_generator.get_state()
 
 
-def set_rng_state(new_state, device="openreg"):
+def get_rng_state_all() -> list[ByteTensor]:
+    r"""Return a list of ByteTensor representing the random number states of all devices."""
+    results = [get_rng_state(i) for i in range(device_count())]
+    return results
+
+
+# LITERALINCLUDE START: OPENREG GENERATOR PY WRAPPER EXAMPLE
+def set_rng_state(new_state: ByteTensor, device: int | str | torch.device = "openreg"):
+    r"""Set the random number generator state of the specified device.
+
+    Args:
+        new_state (torch.ByteTensor): The desired state
+        device (int, str or torch.device): The device to set the RNG state.
+            Default: ``'openreg'`` (i.e., ``torch.device('openreg')``, the current OpenReg device).
+    """
     if isinstance(device, str):
         device = torch.device(device)
     elif isinstance(device, int):
         device = torch.device("openreg", device)
-    idx = device.index
-    if idx is None:
+
+    def cb():
+        idx = device.index
+        if idx is None:
+            idx = current_device()
+        default_generator = torch_openreg._C._get_default_generator(idx)
+        default_generator.set_state(new_state)
+
+    _lazy_call(cb)
+
+
+# LITERALINCLUDE END: OPENREG GENERATOR PY WRAPPER EXAMPLE
+
+
+def set_rng_state_all(new_states: Iterable[ByteTensor]) -> None:
+    r"""Set the random number generator state of all devices."""
+    for i, state in enumerate(new_states):
+        set_rng_state(state, i)
+
+
+def seed() -> None:
+    r"""Set the seed for generating random numbers to a random number for the current backend device.
+
+    It's safe to call this function if OpenReg device is not available; in that case, it is silently ignored.
+
+    .. warning::
+        If you are working with a multi-devices model, this function will only initialize
+        the seed on one device.  To initialize all devices, use :func:`seed_all`.
+    """
+
+    def cb():
         idx = current_device()
-    default_generator = torch_openreg._C._get_default_generator(idx)
-    default_generator.set_state(new_state)
+        default_generator = torch_openreg._C._get_default_generator(idx)
+        default_generator.seed()
+
+    _lazy_call(cb)
+
+
+def seed_all() -> None:
+    r"""Set the seed for generating random numbers to a random number for all backend devices.
+
+    It's safe to call this function if OpenReg device is not available; in that case, it is silently ignored.
+    """
+
+    def cb():
+        random_seed = 0
+        seeded = False
+        for i in range(device_count()):
+            default_generator = torch_openreg._C._get_default_generator(i)
+            if not seeded:
+                default_generator.seed()
+                random_seed = default_generator.initial_seed()
+                seeded = True
+            else:
+                default_generator.manual_seed(random_seed)
+
+    _lazy_call(cb)
 
 
 def initial_seed() -> int:
+    r"""Returns the initial seed for generating random numbers for the current backend device.
+
+    .. warning::
+        This function eagerly initializes OpenReg device.
+    """
     _lazy_init()
     idx = current_device()
     default_generator = torch_openreg._C._get_default_generator(idx)
@@ -46,19 +131,35 @@ def initial_seed() -> int:
 
 # LITERALINCLUDE START: OPENREG MANUAL SEED
 def manual_seed(seed: int) -> None:
+    r"""Set the seed for generating random numbers for the current backend device.
+
+    Args:
+        seed (int): The desired seed.
+    """
     seed = int(seed)
 
-    idx = current_device()
-    default_generator = torch_openreg._C._get_default_generator(idx)
-    default_generator.manual_seed(seed)
+    def cb():
+        idx = current_device()
+        default_generator = torch_openreg._C._get_default_generator(idx)
+        default_generator.manual_seed(seed)
+
+    _lazy_call(cb, seed=True)
 
 
 # LITERALINCLUDE END: OPENREG MANUAL SEED
 
 
 def manual_seed_all(seed: int) -> None:
+    r"""Set the seed for generating random numbers on all backend devices.
+
+    Args:
+        seed (int): The desired seed.
+    """
     seed = int(seed)
 
-    for idx in range(device_count()):
-        default_generator = torch_openreg._C._get_default_generator(idx)
-        default_generator.manual_seed(seed)
+    def cb():
+        for idx in range(device_count()):
+            default_generator = torch_openreg._C._get_default_generator(idx)
+            default_generator.manual_seed(seed)
+
+    _lazy_call(cb, seed_all=True)


### PR DESCRIPTION
## Summary
This PR enriches the OpenReg (PRIVATEUSE1) random number generation (RNG) module with:
- Generator-aware random kernels for PrivateUse1 (`rand`, `randn`, and partial `randint` support)
- Per-device generator plumbing and convenience Python APIs under `torch.openreg`
- Focused documentation and targeted tests validating determinism, bounds, and edge cases

## Motivation
- Enable deterministic sampling on OpenReg via explicit `torch.Generator(device="openreg:<idx>")`
- Provide parity with core PyTorch RNG ergonomics (`seed`, `seed_all`, `manual_seed`, `get/set_rng_state`)
- Clarify the recommended accelerator RNG design and integration points for third-party backends

## Changes
### C++ (PrivateUse1 backend)
- Implement `aten::rand.generator`, `aten::randn.generator` for PrivateUse1
- Device/layout validation, PrivateUse1 allocation via `empty_*` kernels
- Safe fill path: `MemoryGuard`
- Generator handling:
  - `get_openreg_gen(...)` validates device index and returns `OpenRegGeneratorImpl`
  - Default per-device generator fallback via `getDefaultOpenRegGenerator`

### Generator plumbing
- `OpenRegGenerator` creation and registration helpers
- PrivateUse1 hooks provide new generators through `createOpenRegGenerator`
- Fork-safety helpers and lazy per-device generator initialization

### Python APIs (`torch.openreg`)
- `seed`, `seed_all`, `manual_seed`, `manual_seed_all`
- `get_rng_state`, `set_rng_state`, `get_rng_state_all`, `set_rng_state_all`

### Tests
- Expanded OpenReg RNG tests (`test_rng.py`):
  - Determinism with explicit generator (`rand`, `randn`)
  - State save/restore determinism
  - Device mismatch error is raised clearly
  - Empty tensors (numel=0) return safely
  - Range and dtype checks for `rand` (float/double)
  - Statistical sanity for `randn` (mean≈0, std≈1 over 20k samples)
  - Bounds for `randint` across int32/int64/int16 (without explicit generator for dtype-specific overloads)
  - Large tensor smoke tests (1M elements) to catch segfaults
  - Non-contiguous shape smoke tests (transpose)

### Docs
- New focused page: accelerator RNG generator design and examples
- Index updated to include generator docs

## User-facing examples
- Explicit generator determinism on OpenReg:
```python
gen = torch.Generator(device="openreg:0")
gen.manual_seed(1234)
a = torch.rand((4, 5), device="openreg:0", generator=gen)
gen.manual_seed(1234)
b = torch.rand((4, 5), device="openreg:0", generator=gen)
assert torch.equal(a, b)
```

- Save/restore generator state:
```python
gen = torch.Generator(device="openreg:0")
gen.manual_seed(42)
s = gen.get_state()
x1 = torch.rand((5,), device="openreg:0", generator=gen)
gen.set_state(s)
x2 = torch.rand((5,), device="openreg:0", generator=gen)
assert torch.equal(x1, x2)
```

## Backward compatibility
- Scope limited to PrivateUse1; CPU/CUDA behavior unchanged
- CPU fallback retained for unimplemented ops

## How to run tests
```bash
python test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_rng.py
```
