### PR TITLE
[BE][Ez]: Update torch.is_tensor documentation

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1120,11 +1120,6 @@ def typename(obj: _Any, /) -> str:
 def is_tensor(obj: _Any, /) -> _TypeIs["torch.Tensor"]:
     r"""Returns True if `obj` is a PyTorch tensor.
 
-    Note that this function is simply doing ``isinstance(obj, Tensor)``.
-    Using that ``isinstance`` check is better for type checking with mypy,
-    and more explicit - so it's recommended to use that instead of
-    ``is_tensor``.
-
     Args:
         obj (object): Object to test
     Example::


### PR DESCRIPTION
TypeIs propogates the isinstance check with the typing system. They are now equivalent.

cc @svekars @sekyondaMeta @AlannaBurke