### PR TITLE
Bring back `dtype` to `one_hot`

### DIFF
--- a/aten/src/ATen/functorch/BatchRulesModules.cpp
+++ b/aten/src/ATen/functorch/BatchRulesModules.cpp
@@ -218,7 +218,7 @@ static cudnn_grid_sample_backward_batch_rule(
 // mirrors the meta path in aten/src/ATen/native/Onehot.cpp,
 // but requires explicit positive num_classes under vmap to avoid
 // data-dependent output shapes.
-static Tensor one_hot_decomposition_hack(const Tensor &self, int64_t num_classes) {
+static Tensor one_hot_decomposition_hack(const Tensor &self, int64_t num_classes, std::optional<ScalarType> dtype) {
     TORCH_CHECK(self.dtype() == kLong, "one_hot is only applicable to index tensor.");
 
     // disallow implicit inference under vmap; this would be data-dependent
@@ -228,7 +228,7 @@ static Tensor one_hot_decomposition_hack(const Tensor &self, int64_t num_classes
 
     const auto options = self.options();
     at::Tensor index = at::arange(num_classes, options);
-    return at::eq(self.unsqueeze(-1), index).to(at::kLong);
+    return at::eq(self.unsqueeze(-1), index).to(dtype.value_or(at::kLong));
 }
 
 template <typename A, A a, typename C>

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6223,7 +6223,7 @@
     MkldnnCPU: mkldnn_transpose_
   autogen: _mkldnn_transpose.out
 
-- func: one_hot(Tensor self, int num_classes=-1) -> Tensor
+- func: one_hot(Tensor self, int num_classes=-1, *, ScalarType? dtype=None) -> Tensor
   python_module: nn
   variants: function
   tags: dynamic_output_shape

--- a/test/cpp/api/functional.cpp
+++ b/test/cpp/api/functional.cpp
@@ -1209,6 +1209,23 @@ TEST_F(FunctionalTest, OneHot) {
     ASSERT_TRUE(torch::allclose(y, expected));
     ASSERT_EQ(y.sizes(), std::vector<int64_t>({3, 2, 3}));
   }
+
+  { // Test #4 for dtype
+    auto x = torch::arange(0, 6, torch::kLong);
+    for (at::ScalarType dtype : {torch::kBool, torch::kByte, torch::kLong}) {
+      auto y = F::one_hot(x.view(std::vector<int64_t>({3, 2})) % 3, -1, dtype);
+      auto expected = torch::tensor(
+          {{{true, false, false}, {false, true, false}},
+           {{false, false, true}, {true, false, false}},
+           {{false, true, false}, {false, false, true}}},
+          dtype);
+
+      ASSERT_EQ(y.ndimension(), 3);
+      ASSERT_TRUE(torch::allclose(y, expected));
+      ASSERT_EQ(y.sizes(), std::vector<int64_t>({3, 2, 3}));
+      ASSERT_EQ(y.dtype(), dtype);
+    }
+  }
 }
 
 TEST_F(FunctionalTest, Hardtanh) {

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -4325,15 +4325,19 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_one_hot(self):
         class OneHot(torch.nn.Module):
-            def __init__(self, num_classes):
+            def __init__(self, num_classes, dtype=None):
                 super().__init__()
                 self.num_classes = num_classes
+                self.dtype = dtype
 
             def forward(self, x):
-                return torch.nn.functional.one_hot(x, self.num_classes)
+                dtype = self.dtype if self.dtype is not None else torch.long
+                return torch.nn.functional.one_hot(x, self.num_classes, dtype=dtype)
 
         x = torch.arange(10)
         self.run_test(OneHot(15), (x))
+        self.run_test(OneHot(15, torch.bool), (x))
+        self.run_test(OneHot(15, torch.uint8), (x))
 
         class OneHot(torch.nn.Module):
             def forward(self, x, num_classes):

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1733,7 +1733,7 @@
   self: grad.t()
   result: auto_linear
 
-- name: one_hot(Tensor self, int num_classes=-1) -> Tensor
+- name: one_hot(Tensor self, int num_classes=-1, *, ScalarType? dtype=None) -> Tensor
   self: non_differentiable
 
 - name: flip(Tensor self, int[] dims) -> Tensor

--- a/torch/csrc/api/include/torch/nn/functional/embedding.h
+++ b/torch/csrc/api/include/torch/nn/functional/embedding.h
@@ -4,8 +4,8 @@
 
 namespace torch::nn::functional {
 
-inline Tensor one_hot(const Tensor& tensor, int64_t num_classes = -1) {
-  return torch::one_hot(tensor, num_classes);
+inline Tensor one_hot(const Tensor& tensor, int64_t num_classes = -1, ScalarType dtype = at::kLong) {
+  return torch::one_hot(tensor, num_classes, dtype);
 }
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5484,7 +5484,7 @@ Example::
 one_hot = _add_docstr(
     torch._C._nn.one_hot,
     r"""
-one_hot(tensor, num_classes=-1) -> LongTensor
+one_hot(tensor, num_classes=-1, dtype=torch.long) -> LongTensor
 
 Takes LongTensor with index values of shape ``(*)`` and returns a tensor
 of shape ``(*, num_classes)`` that have zeros everywhere except where the
@@ -5501,6 +5501,8 @@ Arguments:
     num_classes (int, optional):  Total number of classes. If set to -1, the number
         of classes will be inferred as one greater than the largest class
         value in the input tensor. Default: -1
+    dtype (:class:`torch.dtype`): the desired output dtype.
+        Default: ``torch.int64``
 
 Returns:
     LongTensor that has one more dimension with 1 values at the

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5502,12 +5502,12 @@ Arguments:
         of classes will be inferred as one greater than the largest class
         value in the input tensor. Default: -1
     dtype (:class:`torch.dtype`): the desired output dtype.
-        Default: ``torch.int64``
+        Default: ``torch.int64``, supported: ``torch.bool``, ``torch.uint8``, ``torch.int64``
 
 Returns:
-    LongTensor that has one more dimension with 1 values at the
+    Tensor that has one more dimension with 1 values at the
     index of last dimension indicated by the input, and 0 everywhere
-    else.
+    else, with the specified ``dtype``.
 
 Examples:
     >>> F.one_hot(torch.arange(0, 5) % 3)
@@ -5522,13 +5522,13 @@ Examples:
             [0, 0, 1, 0, 0],
             [1, 0, 0, 0, 0],
             [0, 1, 0, 0, 0]])
-    >>> F.one_hot(torch.arange(0, 6).view(3,2) % 3)
-    tensor([[[1, 0, 0],
-             [0, 1, 0]],
-            [[0, 0, 1],
-             [1, 0, 0]],
-            [[0, 1, 0],
-             [0, 0, 1]]])
+    >>> F.one_hot(torch.arange(0, 6).view(3,2) % 3, dtype=torch.bool)
+    tensor([[[ True, False, False],
+             [False,  True, False]],
+            [[False, False,  True],
+             [ True, False, False]],
+            [[False,  True, False],
+             [False, False,  True]]])
 """,
 )
 

--- a/torch/onnx/_internal/torchscript_exporter/symbolic_opset9.py
+++ b/torch/onnx/_internal/torchscript_exporter/symbolic_opset9.py
@@ -5110,7 +5110,7 @@ def __isnot_(g: jit_utils.GraphContext, self, other):
 
 
 @_onnx_symbolic("aten::one_hot")
-def one_hot(g: jit_utils.GraphContext, self, num_classes):
+def one_hot(g: jit_utils.GraphContext, self, num_classes, dtype):
     values = g.op("Constant", value_t=torch.LongTensor([0, 1]))
     # onnxruntime supports limited type combinations for OneHot.
     if _type_utils.JitScalarType.from_value(
@@ -5122,7 +5122,11 @@ def one_hot(g: jit_utils.GraphContext, self, num_classes):
         _type_utils.JitScalarType.INT16,
     }:
         num_classes = g.op("Cast", num_classes, to_i=_C_onnx.TensorProtoDataType.INT64)
-    return g.op("OneHot", self, num_classes, values, axis_i=-1)
+    one_hot = g.op("OneHot", self, num_classes, values, axis_i=-1)
+    dtype = symbolic_helper._maybe_get_const(dtype, 'i')
+    if symbolic_helper._is_value(dtype):
+        dtype = 4  # Long
+    return g.op("Cast", one_hot, to_i=symbolic_helper.scalar_type_to_onnx[dtype])
 
 
 @_onnx_symbolic("aten::gather")


### PR DESCRIPTION
Fixes #33046.

Per @XuehaiPan in https://github.com/pytorch/pytorch/issues/33046#issuecomment-1855226683, it's reasonable to add `dtype` back to `one_hot`, previously implemented in #58090.
