### PR TITLE
[xpu][test]port embedding indexing and native_mha test files for Intel GPU

### DIFF
--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -357,13 +357,7 @@ class TestEmbeddingNNDeviceType(NNTestCase):
             else (torch.float, torch.double, torch.half)
         )
     )
-    @dtypesIfXPU(
-        *(
-            (torch.float, torch.double, torch.bfloat16, torch.half)
-            if TEST_WITH_ROCM
-            else (torch.float, torch.double, torch.half)
-        )
-    )
+    @dtypesIfXPU(torch.float, torch.double, torch.half)
     @dtypes(torch.float32)
     def test_embedding_max_norm_backward(self, device, dtype):
         # can't use gradcheck since in place renorm makes analytical gradients different from produced ones
@@ -388,13 +382,7 @@ class TestEmbeddingNNDeviceType(NNTestCase):
             else (torch.float, torch.double, torch.half)
         )
     )
-    @dtypesIfXPU(
-        *(
-            (torch.float, torch.double, torch.bfloat16, torch.half)
-            if TEST_WITH_ROCM
-            else (torch.float, torch.double, torch.half)
-        )
-    )
+    @dtypesIfXPU(torch.float, torch.double, torch.half)
     @dtypes(torch.float32)
     def test_embedding_max_norm_fwd_AD(self, device, dtype):
         if torch.device(device).type == "xla":
@@ -419,13 +407,7 @@ class TestEmbeddingNNDeviceType(NNTestCase):
             else (torch.float, torch.double, torch.half)
         )
     )
-    @dtypesIfXPU(
-        *(
-            (torch.float, torch.double, torch.bfloat16, torch.half)
-            if TEST_WITH_ROCM
-            else (torch.float, torch.double, torch.half)
-        )
-    )
+    @dtypesIfXPU(torch.float, torch.double, torch.half)
     @dtypes(torch.float32)
     def test_embedding_padding_idx(self, device, dtype):
         embedding = nn.Embedding(10, 20, padding_idx=0).to(device, dtype)
@@ -1450,8 +1432,8 @@ class TestEmbeddingNNDeviceType(NNTestCase):
         ):
             run_tests(mode, sparse, trainable_per_sample_weights)
 
-        # Test CUDA Dense on half precision
-        if device == "cuda" or device == "xpu":
+        # Test CUDA/XPU Dense on half precision
+        if device != "cpu":
             modes = ("sum",)
             sparsity = (False,)
             trainable_scale = (True, False)
@@ -1649,10 +1631,10 @@ class TestEmbeddingNNDeviceType(NNTestCase):
             )
 
             test_backward = False
-            if self.device_type == "cuda" or self.device_type == "xpu":
+            if self.device_type != "cpu":
                 # see 'todo' in test_embedding_bag.
                 test_backward = dtypes[2] is not torch.float16
-            elif self.device_type == "cpu":
+            else:
                 # TODO: figure out why precision on sparse embeddings isn't the
                 # same as for dense.
                 test_backward = (

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -1604,6 +1604,8 @@ class TestEmbeddingNNDeviceType(NNTestCase):
     def test_embedding_bag_device(self, device, dtypes):
         if IS_JETSON and torch.bfloat16 in dtypes and device == "cpu":
             self.skipTest("bfloat16 not supported with Jetson cpu")
+        if dtypes == (torch.int32, torch.int32, torch.float64) and "xpu" in device:
+            self.skipTest("https://github.com/intel/torch-xpu-ops/issues/2295")
         with set_default_dtype(torch.double):
             self._test_EmbeddingBag(
                 device,

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -1604,7 +1604,7 @@ class TestEmbeddingNNDeviceType(NNTestCase):
     def test_embedding_bag_device(self, device, dtypes):
         if IS_JETSON and torch.bfloat16 in dtypes and device == "cpu":
             self.skipTest("bfloat16 not supported with Jetson cpu")
-        if dtypes[0] == torch.int32 and dtypes[2] == torch.float64 and "xpu" in device:
+        if dtypes[2] == torch.float64 and "xpu" in device:
             self.skipTest("https://github.com/intel/torch-xpu-ops/issues/2295")
         with set_default_dtype(torch.double):
             self._test_EmbeddingBag(

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -357,7 +357,7 @@ class TestEmbeddingNNDeviceType(NNTestCase):
             else (torch.float, torch.double, torch.half)
         )
     )
-    @dtypesIfXPU(torch.float, torch.double, torch.half)
+    @dtypesIfXPU(torch.float32, torch.double, torch.half)
     @dtypes(torch.float32)
     def test_embedding_max_norm_backward(self, device, dtype):
         # can't use gradcheck since in place renorm makes analytical gradients different from produced ones
@@ -382,7 +382,7 @@ class TestEmbeddingNNDeviceType(NNTestCase):
             else (torch.float, torch.double, torch.half)
         )
     )
-    @dtypesIfXPU(torch.float, torch.double, torch.half)
+    @dtypesIfXPU(torch.float32, torch.double, torch.half)
     @dtypes(torch.float32)
     def test_embedding_max_norm_fwd_AD(self, device, dtype):
         if torch.device(device).type == "xla":
@@ -407,7 +407,7 @@ class TestEmbeddingNNDeviceType(NNTestCase):
             else (torch.float, torch.double, torch.half)
         )
     )
-    @dtypesIfXPU(torch.float, torch.double, torch.half)
+    @dtypesIfXPU(torch.float32, torch.double, torch.half)
     @dtypes(torch.float32)
     def test_embedding_padding_idx(self, device, dtype):
         embedding = nn.Embedding(10, 20, padding_idx=0).to(device, dtype)
@@ -1086,7 +1086,7 @@ class TestEmbeddingNNDeviceType(NNTestCase):
         *itertools.product(
             (torch.int, torch.long),
             (torch.int, torch.long),
-            (torch.float, torch.double, torch.half),
+            (torch.float32, torch.double, torch.half),
         )
     )
     def test_EmbeddingBag_empty_per_sample_weights_and_offsets(self, device, dtypes):
@@ -1159,7 +1159,7 @@ class TestEmbeddingNNDeviceType(NNTestCase):
         *itertools.product(
             (torch.int, torch.long),
             (torch.int, torch.long),
-            (torch.float, torch.double, torch.half),
+            (torch.float32, torch.double, torch.half),
         )
     )
     def test_EmbeddingBag_per_sample_weights_and_offsets(self, device, dtypes):
@@ -1227,7 +1227,7 @@ class TestEmbeddingNNDeviceType(NNTestCase):
         *itertools.product(
             (torch.int, torch.long),
             (torch.int, torch.long),
-            (torch.float, torch.double, torch.half),
+            (torch.float32, torch.double, torch.half),
         )
     )
     def test_EmbeddingBag_per_sample_weights_and_new_offsets(self, device, dtypes):
@@ -1396,7 +1396,7 @@ class TestEmbeddingNNDeviceType(NNTestCase):
     )
     @dtypesIfXPU(
         *itertools.product(
-            (torch.int, torch.long), (torch.half, torch.float, torch.double)
+            (torch.int, torch.long), (torch.half, torch.float32, torch.double)
         )
     )
     @dtypes(*itertools.product((torch.int, torch.long), (torch.float, torch.double)))
@@ -1598,13 +1598,13 @@ class TestEmbeddingNNDeviceType(NNTestCase):
         *itertools.product(
             (torch.int, torch.long),
             (torch.int, torch.long),
-            (torch.float, torch.double, torch.half),
+            (torch.float32, torch.double, torch.half),
         )
     )
     def test_embedding_bag_device(self, device, dtypes):
         if IS_JETSON and torch.bfloat16 in dtypes and device == "cpu":
             self.skipTest("bfloat16 not supported with Jetson cpu")
-        if dtypes == (torch.int32, torch.int32, torch.float64) and "xpu" in device:
+        if dtypes[0] == torch.int32 and dtypes[2] == torch.float64 and "xpu" in device:
             self.skipTest("https://github.com/intel/torch-xpu-ops/issues/2295")
         with set_default_dtype(torch.double):
             self._test_EmbeddingBag(
@@ -1681,7 +1681,7 @@ class TestEmbeddingNNDeviceType(NNTestCase):
         *itertools.product(
             (torch.int, torch.long),
             (torch.int, torch.long),
-            (torch.float, torch.double, torch.half),
+            (torch.float32, torch.double, torch.half),
         )
     )
     def test_embedding_bag_non_contiguous_weight(self, device, dtypes):

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -601,9 +601,8 @@ class TestIndexing(TestCase):
 
         # test invalid index fails
         reference = torch.empty(10, dtype=dtype, device=device)
-        print(reference.device.type, flush=True)
         # can't test cuda/xpu because it is a device assert
-        if not reference.is_cuda and not reference.device.type == "xpu":
+        if reference.device.type == "cpu":
             for err_idx in (10, -11):
                 with self.assertRaisesRegex(IndexError, r"out of"):
                     reference[err_idx]
@@ -2377,7 +2376,7 @@ class NumpyTests(TestCase):
     def test_trivial_fancy_out_of_bounds(self, device):
         a = torch.zeros(5, device=device)
         ind = torch.ones(20, dtype=torch.int64, device=device)
-        if a.is_cuda or a.device.type == "xpu":
+        if a.device.type in ["cuda", "xpu"]:
             raise unittest.SkipTest("CUDA/XPU asserts instead of raising an exception")
         ind[-1] = 10
         self.assertRaises(IndexError, a.__getitem__, ind)

--- a/test/test_native_mha.py
+++ b/test/test_native_mha.py
@@ -6,9 +6,11 @@ import torch
 from torch.testing._internal.common_device_type import (
     dtypes,
     dtypesIfCUDA,
+    dtypesIfXPU,
     instantiate_device_type_tests,
     onlyOn,
     skipMeta,
+    skipXPUIf,
 )
 from torch.testing._internal.common_utils import parametrize, run_tests, TestCase, TEST_WITH_ROCM
 from torch.nn.attention import SDPBackend
@@ -90,6 +92,7 @@ class TestMHADeviceType(TestCase):
                 torch.testing.assert_close(v, correct_v)
 
     @dtypesIfCUDA(torch.float)
+    @dtypesIfXPU(torch.float)
     @dtypes(torch.float)
     @skipMeta
     def test_transform_bias_rescale_qkv(self, device, dtype):
@@ -100,8 +103,10 @@ class TestMHADeviceType(TestCase):
                 )
 
     @dtypesIfCUDA(torch.float)
+    @dtypesIfXPU(torch.float)
     @dtypes(torch.float)
     @skipMeta
+    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2182")
     @onlyOn(["cuda", "xpu"])
     def test_transform_bias_rescale_qkv_nested(self, device, dtype):
         for use_padding in (False, True):
@@ -267,6 +272,7 @@ class TestMHADeviceType(TestCase):
             self.assertEqual(weight_pt, weight_npt)
 
     @dtypesIfCUDA(torch.float, torch.half)
+    @dtypesIfXPU(torch.float, torch.half)
     @dtypes(torch.float)
     @skipMeta
     @parametrize("use_nt", [False, True])
@@ -322,6 +328,7 @@ class TestMHADeviceType(TestCase):
                         )
 
     @dtypesIfCUDA(torch.float, torch.half)
+    @dtypesIfXPU(torch.float, torch.half)
     @dtypes(torch.float)
     @skipMeta
     @torch.no_grad()
@@ -336,6 +343,7 @@ class TestMHADeviceType(TestCase):
         )
 
     @dtypesIfCUDA(torch.float, torch.half)
+    @dtypesIfXPU(torch.float, torch.half)
     @dtypes(torch.float)
     @skipMeta
     @torch.no_grad()

--- a/test/test_native_mha.py
+++ b/test/test_native_mha.py
@@ -9,7 +9,6 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyOn,
     skipMeta,
-    #skipXPU,
 )
 from torch.testing._internal.common_utils import parametrize, run_tests, TestCase, TEST_WITH_ROCM
 from torch.nn.attention import SDPBackend
@@ -188,8 +187,6 @@ class TestMHADeviceType(TestCase):
         ).to(dtype)
 
         if device == "cuda" or device == "xpu":
-            #pt = pt.cuda()
-            #npt = npt.cuda()
             pt = pt.to(device)
             npt = npt.to(device)
 
@@ -293,10 +290,10 @@ class TestMHADeviceType(TestCase):
                               average_attn_weights=average_attn_weights):
                 if device == "cuda":
                     with torch.backends.cuda.sdp_kernel(
-                        enable_flash=False, enable_mem_efficient=False
-                        ) if not fused else torch.backends.cuda.sdp_kernel(
-                                enable_flash=True, enable_mem_efficient=True
-                                ):
+                            enable_flash=False, enable_mem_efficient=False
+                    ) if not fused else torch.backends.cuda.sdp_kernel(
+                            enable_flash=True, enable_mem_efficient=True
+                    ):
                         self._test_multihead_attention_impl(
                             device,
                             dtype,
@@ -306,9 +303,13 @@ class TestMHADeviceType(TestCase):
                             pad_all=pad_all,
                             need_weights=need_weights,
                             average_attn_weights=average_attn_weights,
-                            )
+                        )
                 elif "xpu" in device:
-                    with torch.nn.attention.sdpa_kernel([SDPBackend.MATH]) if not fused else torch.nn.attention.sdpa_kernel([SDPBackend.OVERRIDEABLE]):
+                    with torch.nn.attention.sdpa_kernel(
+                            SDPBackend.MATH
+                    ) if not fused else torch.nn.attention.sdpa_kernel(
+                            [SDPBackend.OVERRIDEABLE, SDPBackend.MATH]
+                    ):
                         self._test_multihead_attention_impl(
                             device,
                             dtype,
@@ -318,7 +319,7 @@ class TestMHADeviceType(TestCase):
                             pad_all=pad_all,
                             need_weights=need_weights,
                             average_attn_weights=average_attn_weights,
-                            )
+                        )
 
     @dtypesIfCUDA(torch.float, torch.half)
     @dtypes(torch.float)

--- a/test/test_native_mha.py
+++ b/test/test_native_mha.py
@@ -288,8 +288,6 @@ class TestMHADeviceType(TestCase):
                 self.skipTest("Large numerical errors on ROCM to investigate.")
             if use_padding and not pad_all and fused:
                 self.skipTest("Large numerical errors on ROCM to investigate.")
-        print(device)
-        print(fused)
         for need_weights in (False, not pad_all):
             with self.subTest(use_padding=use_padding, pad_all=pad_all,
                               use_nt=use_nt, need_weights=need_weights,


### PR DESCRIPTION
we port test_indexing, test_native_mha and test_embedding for Intel GPU in this pr.
We could enable Intel GPU with following methods and try the best to keep the original code styles:

Use torch.accelerator for general gpu
Skip the case if running on xpu which has known issues
using torch.nn.attention.sdpa_kernel() to replace torch.backends.cuda.sdp_kernel() for Intel GPU as torch.backends.cuda.sdp_kernel() is depricated and Intel xpu did not support it.



cc @frank-wei @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10