### PR TITLE
Add `tabulate` as a PyTorch runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ requires = [
     "requests",
     "six",  # dependency chain: NNPACK -> PeachPy -> six
     "typing-extensions>=4.10.0",
+    "tabulate",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ psutil
 sympy>=1.13.3
 typing-extensions>=4.13.2
 wheel
+tabulate

--- a/setup.py
+++ b/setup.py
@@ -1597,6 +1597,7 @@ def main() -> None:
         "networkx>=2.5.1",
         "jinja2",
         "fsspec>=0.8.5",
+        "tabulate",
     ]
     if BUILD_PYTHON_ONLY:
         install_requires += [f"{LIBTORCH_PKG_NAME}=={TORCH_VERSION}"]


### PR DESCRIPTION
Fixes #144564, cc @zou3519 