### PR TITLE
 [cpu][fix] Update ACL version to fix crashes with tensor sizes > 2^31-1

### DIFF
--- a/.ci/docker/common/install_acl.sh
+++ b/.ci/docker/common/install_acl.sh
@@ -3,7 +3,7 @@
 
 set -eux
 
-ACL_VERSION=${ACL_VERSION:-"v25.02"}
+ACL_VERSION=${ACL_VERSION:-"v52.6.0"}
 ACL_INSTALL_DIR="/acl"
 
 # Clone ACL

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -1232,14 +1232,12 @@ static ConvBackend _select_conv_backend(
     } else {
       return ConvBackend::Miopen;
     }
-  } else if (params.use_mkldnn(input, weight) && !params.transposed) {
-      return ConvBackend::Mkldnn;
-// Skip oneDNN's transposed conv impl when it's built with Arm Compute Library (ACL)
-// due to: https://github.com/pytorch/pytorch/issues/165654
-#if !AT_MKLDNN_ACL_ENABLED()
-  } else if (params.use_mkldnn(input, weight) && params.transposed) {
+  } else if (params.use_mkldnn(input, weight)) {
+    if (params.transposed) {
       return ConvBackend::MkldnnTranspose;
-#endif // !AT_MKLDNN_ACL_ENABLED()
+    } else {
+      return ConvBackend::Mkldnn;
+    }
   } else if (!need_backward && params.use_xnnpack(input, weight, bias_sizes_opt)) {
     // Using prepacked conv is preferred, but XNNPACK is still the fastest
     // option for NHWC.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #166731
* __->__ #165904

----

- Updates Arm Compute Library (ACL) to v52.6.0
- v52.6.0 contains https://github.com/ARM-software/ComputeLibrary/pull/1201 which fixes crashes with tensors of sizes > 2^31-1

fixes: #165654

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @malfet @snadampal @milpuz01 @aditew01 @nikhil-arm