### PR TITLE
Re-enable ConvTranspose operator benchmarks for AArch64

### DIFF
--- a/benchmarks/operator_benchmark/pt/conv_test.py
+++ b/benchmarks/operator_benchmark/pt/conv_test.py
@@ -39,15 +39,12 @@ op_bench.generate_pt_test(
     configs.conv_1d_configs_short + configs.conv_1d_configs_long, Conv1dBenchmark
 )
 
-
-if not torch.backends.mkldnn.is_acl_available():
-    # convtranpose1d crashes with ACL, see https://github.com/pytorch/pytorch/issues/165654
-    op_bench.generate_pt_test(
-        configs.convtranspose_1d_configs_short
-        + configs.conv_1d_configs_short
-        + configs.conv_1d_configs_long,
-        ConvTranspose1dBenchmark,
-    )
+op_bench.generate_pt_test(
+    configs.convtranspose_1d_configs_short
+    + configs.conv_1d_configs_short
+    + configs.conv_1d_configs_long,
+    ConvTranspose1dBenchmark,
+)
 
 
 """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #165905
* #165904

#165585 enabled AArch64 operator benchmarks except for ConvTranspose1D due to #165654
#165904 fixes the issue by updating ACL version.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @malfet @snadampal @milpuz01 @aditew01 @nikhil-arm