### PR TITLE
[cuDNN] Smoke-test runtime cuDNN version matches compile time version in CI

### DIFF
--- a/.ci/pytorch/smoke_test/smoke_test.py
+++ b/.ci/pytorch/smoke_test/smoke_test.py
@@ -284,13 +284,14 @@ def smoke_test_cuda(
         torch_cudnn_compile_version = torch._C._cudnn.getCompileVersion()
         print(f"Torch cuDNN compile-time version: {torch_cudnn_compile_version}")
         torch_cudnn_runtime_version = tuple(
-            [int(x) for x in torch_cudnn_version.split('.')]
+            [int(x) for x in torch_cudnn_version.split(".")]
         )
         if torch_cudnn_runtime_version != torch_cudnn_compile_version:
             raise RuntimeError(
                 "cuDNN runtime version doesn't match comple version. "
                 f"Loaded: {torch_cudnn_runtime_version} "
-                f"Expected: {torch_cudnn_compile_version}")
+                f"Expected: {torch_cudnn_compile_version}"
+            )
 
         if sys.platform in ["linux", "linux2"]:
             torch_nccl_version = ".".join(str(v) for v in torch.cuda.nccl.version())

--- a/.ci/pytorch/smoke_test/smoke_test.py
+++ b/.ci/pytorch/smoke_test/smoke_test.py
@@ -283,12 +283,14 @@ def smoke_test_cuda(
 
         torch_cudnn_compile_version = torch._C._cudnn.getCompileVersion()
         print(f"Torch cuDNN compile-time version: {torch_cudnn_compile_version}")
-        torch_cudnn_runtime_version = tuple([int(x) for x in torch_cudnn_version.split('.')])
+        torch_cudnn_runtime_version = tuple(
+            [int(x) for x in torch_cudnn_version.split('.')]
+        )
         if torch_cudnn_runtime_version != torch_cudnn_compile_version:
             raise RuntimeError(
-                    f"cuDNN runtime version doesn't match comple version. "
-                     f"Loaded: {torch_cudnn_runtime_version} "
-                     f"Expected: {torch_cudnn_compile_version}")
+                "cuDNN runtime version doesn't match comple version. "
+                f"Loaded: {torch_cudnn_runtime_version} "
+                f"Expected: {torch_cudnn_compile_version}")
 
         if sys.platform in ["linux", "linux2"]:
             torch_nccl_version = ".".join(str(v) for v in torch.cuda.nccl.version())

--- a/.ci/pytorch/smoke_test/smoke_test.py
+++ b/.ci/pytorch/smoke_test/smoke_test.py
@@ -281,6 +281,15 @@ def smoke_test_cuda(
         torch_cudnn_version = cudnn_to_version_str(torch.backends.cudnn.version())
         print(f"Torch cuDNN version: {torch_cudnn_version}")
 
+        torch_cudnn_compile_version = torch._C._cudnn.getCompileVersion()
+        print(f"Torch cuDNN compile-time version: {torch_cudnn_compile_version}")
+        torch_cudnn_runtime_version = tuple([int(x) for x in torch_cudnn_version.split('.')])
+        if torch_cudnn_runtime_version != torch_cudnn_compile_version:
+            raise RuntimeError(
+                    f"cuDNN runtime version doesn't match comple version. "
+                     f"Loaded: {torch_cudnn_runtime_version} "
+                     f"Expected: {torch_cudnn_compile_version}")
+
         if sys.platform in ["linux", "linux2"]:
             torch_nccl_version = ".".join(str(v) for v in torch.cuda.nccl.version())
             print(f"Torch nccl; version: {torch_nccl_version}")


### PR DESCRIPTION
Fix and regression test for https://github.com/pytorch/pytorch/issues/165801


cc @seemethere @malfet @atalman @tinglvv @nWEIdia @csarofeen @ptrblck @xwang233