### PR TITLE
[APF Logging][Error Trait] To inject <errorTraits> for SystemExit in the decorator @Record

### DIFF
--- a/torch/distributed/elastic/multiprocessing/errors/__init__.py
+++ b/torch/distributed/elastic/multiprocessing/errors/__init__.py
@@ -366,6 +366,11 @@ def record(
                 if se.code == 0:
                     return None
                 else:
+                    # For all other SystemExit, we will let it propagate with error traits injected.
+                    se["errorTraits"] = {
+                        "category": "system_terminated_error",
+                        "retryability": "False",
+                    }
                     raise
             except ChildFailedError as e:
                 rank, failure = e.get_first_failure()


### PR DESCRIPTION
Summary:
Similar to the https://github.com/pytorch/pytorch/pull/165688

How does Error Propagation from Elastic Agent to APF Event Logging works: https://www.internalfb.com/intern/phabricator/paste/markdown/P2000347395/

The `record` decorator is the key place to catch up the errors happen in workers. 
After inspecting the logic, I believe the `SystemExit` branch is the gap missing error trait for APF/APS stack.

Test Plan: github build

Differential Revision: D85078290




cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci