### PR TITLE
Support multiple commits on push events in trunk tagging workflow

### DIFF
--- a/.github/workflows/trunk-tagging.yml
+++ b/.github/workflows/trunk-tagging.yml
@@ -114,6 +114,24 @@ jobs:
             return 1
           }
 
+          # Counters for summary reporting
+          created_count=0
+          skipped_count=0
+          failed_count=0
+
+          # Always write outputs once on exit
+          finish() {
+            set +e
+            if [ -n "${GITHUB_OUTPUT:-}" ]; then
+              {
+                echo "created_count=${created_count}"
+                echo "skipped_count=${skipped_count}"
+                echo "failed_count=${failed_count}"
+              } >> "${GITHUB_OUTPUT}"
+            fi
+          }
+          trap finish EXIT
+
           # Retry configuration
           MAX_RETRIES=5
           BASE_DELAY=2
@@ -190,11 +208,6 @@ jobs:
           # New behavior for push events: enumerate commits in the push and tag each one.
           # For workflow_dispatch, retain existing single-SHA behavior.
 
-          # Counters for summary reporting
-          created_count=0
-          skipped_count=0
-          failed_count=0
-
           # Always fetch tags once up front to improve idempotency in loops
           git fetch origin --tags --quiet || true
 
@@ -208,12 +221,6 @@ jobs:
 
             if [ ! -s "${commits_file}" ]; then
               echo "No new commits found between ${BEFORE_SHA}..${AFTER_SHA}; nothing to tag."
-              {
-                echo "exists=true"
-                echo "created_count=0"
-                echo "skipped_count=0"
-                echo "failed_count=0"
-              } >> "${GITHUB_OUTPUT}"
               rm -f "${commits_file}"
               exit 0
             fi
@@ -247,21 +254,6 @@ jobs:
 
             rm -f "${commits_file}"
 
-            # Determine aggregate existence flag: true iff nothing was created and nothing failed
-            if [ "${created_count}" -eq 0 ] && [ "${failed_count}" -eq 0 ]; then
-              exists_flag=true
-            else
-              exists_flag=false
-            fi
-
-            # Expose summary outputs for downstream step in a single redirection
-            {
-              echo "exists=${exists_flag}"
-              echo "created_count=${created_count}"
-              echo "skipped_count=${skipped_count}"
-              echo "failed_count=${failed_count}"
-            } >> "${GITHUB_OUTPUT}"
-
             if [ "${failed_count}" -gt 0 ]; then
               exit 1
             fi
@@ -272,33 +264,18 @@ jobs:
             # Exit early if tag already exists
             if check_tag_exists; then
               echo "✅ Tag already exists - no action needed"
-              {
-                echo "exists=true"
-                echo "created_count=0"
-                echo "skipped_count=1"
-                echo "failed_count=0"
-              } >> "${GITHUB_OUTPUT}"
+              skipped_count=1
               exit 0
             fi
 
             echo "Tag ${TAG_NAME} does not exist, proceeding with creation"
 
             if retry_with_backoff "tag_with_retry" "Creating tag ${TAG_NAME} for commit ${COMMIT_SHA}"; then
-              {
-                echo "exists=false"
-                echo "created_count=1"
-                echo "skipped_count=0"
-                echo "failed_count=0"
-              } >> "${GITHUB_OUTPUT}"
+              created_count=1
               exit 0
             else
               echo "Tag creation failed after all retry attempts"
-              {
-                echo "exists=false"
-                echo "created_count=0"
-                echo "skipped_count=0"
-                echo "failed_count=1"
-              } >> "${GITHUB_OUTPUT}"
+              failed_count=1
               exit 1
             fi
           fi
@@ -317,10 +294,12 @@ jobs:
               echo "❌ Some tags failed to create for push range ${{ github.event.before }}..${{ github.sha }}"
             fi
           else
-            if [ "${{ steps.check_tag.outputs.exists }}" = "true" ]; then
-              echo "✅ Tag ${{ steps.commit.outputs.tag_name }} already existed - no action needed"
-            elif [ "${{ job.status }}" = "success" ]; then
-              echo "✅ Successfully created tag ${{ steps.commit.outputs.tag_name }} for commit ${{ steps.commit.outputs.sha }}"
+            if [ "${{ steps.check_tag.outputs.failed_count }}" = "0" ]; then
+              if [ "${{ steps.check_tag.outputs.created_count }}" = "0" ]; then
+                echo "✅ Tag ${{ steps.commit.outputs.tag_name }} already existed - no action needed"
+              else
+                echo "✅ Successfully created tag ${{ steps.commit.outputs.tag_name }} for commit ${{ steps.commit.outputs.sha }}"
+              fi
             else
               echo "❌ Failed to create tag ${{ steps.commit.outputs.tag_name }} for commit ${{ steps.commit.outputs.sha }}"
             fi

--- a/.github/workflows/trunk-tagging.yml
+++ b/.github/workflows/trunk-tagging.yml
@@ -203,9 +203,10 @@ jobs:
             AFTER_SHA="${{ github.sha }}"  # same as event.after
 
             # List commits introduced by this push (old..new), oldest first for stable ordering
-            mapfile -t COMMITS < <(git rev-list --reverse "${BEFORE_SHA}..${AFTER_SHA}")
+            commits_file="$(mktemp)"
+            git rev-list --reverse "${BEFORE_SHA}..${AFTER_SHA}" > "${commits_file}"
 
-            if [ ${#COMMITS[@]} -eq 0 ]; then
+            if [ ! -s "${commits_file}" ]; then
               echo "No new commits found between ${BEFORE_SHA}..${AFTER_SHA}; nothing to tag."
               {
                 echo "exists=true"
@@ -213,13 +214,17 @@ jobs:
                 echo "skipped_count=0"
                 echo "failed_count=0"
               } >> "${GITHUB_OUTPUT}"
+              rm -f "${commits_file}"
               exit 0
             fi
 
-            echo "Found ${#COMMITS[@]} commit(s) to tag for push:"
-            printf '  %s\n' "${COMMITS[@]}"
+            commit_count="$(wc -l < "${commits_file}" | tr -d ' ')"
+            echo "Found ${commit_count} commit(s) to tag for push:"
+            while IFS= read -r sha; do
+              printf '  %s\n' "${sha}"
+            done < "${commits_file}"
 
-            for sha in "${COMMITS[@]}"; do
+            while IFS= read -r sha; do
               TAG_NAME="trunk/${sha}"
               COMMIT_SHA="${sha}"
 
@@ -238,7 +243,9 @@ jobs:
                 echo "Tag creation failed after all retry attempts for ${TAG_NAME}"
                 failed_count=$((failed_count + 1))
               fi
-            done
+            done < "${commits_file}"
+
+            rm -f "${commits_file}"
 
             # Determine aggregate existence flag: true iff nothing was created and nothing failed
             if [ "${created_count}" -eq 0 ] && [ "${failed_count}" -eq 0 ]; then

--- a/.github/workflows/trunk-tagging.yml
+++ b/.github/workflows/trunk-tagging.yml
@@ -58,8 +58,10 @@ jobs:
           else
             COMMIT_SHA="${{ github.sha }}"
           fi
-          echo "sha=${COMMIT_SHA}" >> "${GITHUB_OUTPUT}"
-          echo "tag_name=trunk/${COMMIT_SHA}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "sha=${COMMIT_SHA}"
+            echo "tag_name=trunk/${COMMIT_SHA}"
+          } >> "${GITHUB_OUTPUT}"
 
       - name: Validate commit SHA
         run: |
@@ -87,7 +89,7 @@ jobs:
             echo "✅ Commit ${COMMIT_SHA} is valid (automatic push trigger)"
           fi
 
-      - name: Create and push tag with retry
+      - name: Create and push tag(s) with retry
         id: check_tag
         env:
           TAG_NAME: ${{ steps.commit.outputs.tag_name }}
@@ -111,15 +113,6 @@ jobs:
 
             return 1
           }
-
-          # Exit early if tag already exists
-          if check_tag_exists; then
-            echo "✅ Tag already exists - no action needed"
-            echo "exists=true" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          echo "Tag ${TAG_NAME} does not exist, proceeding with creation"
 
           # Retry configuration
           MAX_RETRIES=5
@@ -194,31 +187,143 @@ jobs:
             }
           }
 
-          # Execute with retry
-          if retry_with_backoff "tag_with_retry" "Creating tag ${TAG_NAME} for commit ${COMMIT_SHA}"; then
-            echo "exists=false" >> "${GITHUB_OUTPUT}"
+          # New behavior for push events: enumerate commits in the push and tag each one.
+          # For workflow_dispatch, retain existing single-SHA behavior.
+
+          # Counters for summary reporting
+          created_count=0
+          skipped_count=0
+          failed_count=0
+
+          # Always fetch tags once up front to improve idempotency in loops
+          git fetch origin --tags --quiet || true
+
+          if [ "${{ github.event_name }}" = "push" ]; then
+            BEFORE_SHA="${{ github.event.before }}"
+            AFTER_SHA="${{ github.sha }}"  # same as event.after
+
+            # List commits introduced by this push (old..new), oldest first for stable ordering
+            mapfile -t COMMITS < <(git rev-list --reverse "${BEFORE_SHA}..${AFTER_SHA}")
+
+            if [ ${#COMMITS[@]} -eq 0 ]; then
+              echo "No new commits found between ${BEFORE_SHA}..${AFTER_SHA}; nothing to tag."
+              {
+                echo "exists=true"
+                echo "created_count=0"
+                echo "skipped_count=0"
+                echo "failed_count=0"
+              } >> "${GITHUB_OUTPUT}"
+              exit 0
+            fi
+
+            echo "Found ${#COMMITS[@]} commit(s) to tag for push:"
+            printf '  %s\n' "${COMMITS[@]}"
+
+            for sha in "${COMMITS[@]}"; do
+              TAG_NAME="trunk/${sha}"
+              COMMIT_SHA="${sha}"
+
+              # If tag already exists locally or remotely, skip (idempotent)
+              if check_tag_exists; then
+                echo "✅ Tag ${TAG_NAME} already exists - skipping"
+                skipped_count=$((skipped_count + 1))
+                continue
+              fi
+
+              echo "Tag ${TAG_NAME} does not exist, proceeding with creation"
+
+              if retry_with_backoff "tag_with_retry" "Creating tag ${TAG_NAME} for commit ${COMMIT_SHA}"; then
+                created_count=$((created_count + 1))
+              else
+                echo "Tag creation failed after all retry attempts for ${TAG_NAME}"
+                failed_count=$((failed_count + 1))
+              fi
+            done
+
+            # Determine aggregate existence flag: true iff nothing was created and nothing failed
+            if [ "${created_count}" -eq 0 ] && [ "${failed_count}" -eq 0 ]; then
+              exists_flag=true
+            else
+              exists_flag=false
+            fi
+
+            # Expose summary outputs for downstream step in a single redirection
+            {
+              echo "exists=${exists_flag}"
+              echo "created_count=${created_count}"
+              echo "skipped_count=${skipped_count}"
+              echo "failed_count=${failed_count}"
+            } >> "${GITHUB_OUTPUT}"
+
+            if [ "${failed_count}" -gt 0 ]; then
+              exit 1
+            fi
             exit 0
           else
-            echo "Tag creation failed after all retry attempts"
-            exit 1
+            # workflow_dispatch path (single SHA tagging preserved)
+
+            # Exit early if tag already exists
+            if check_tag_exists; then
+              echo "✅ Tag already exists - no action needed"
+              {
+                echo "exists=true"
+                echo "created_count=0"
+                echo "skipped_count=1"
+                echo "failed_count=0"
+              } >> "${GITHUB_OUTPUT}"
+              exit 0
+            fi
+
+            echo "Tag ${TAG_NAME} does not exist, proceeding with creation"
+
+            if retry_with_backoff "tag_with_retry" "Creating tag ${TAG_NAME} for commit ${COMMIT_SHA}"; then
+              {
+                echo "exists=false"
+                echo "created_count=1"
+                echo "skipped_count=0"
+                echo "failed_count=0"
+              } >> "${GITHUB_OUTPUT}"
+              exit 0
+            else
+              echo "Tag creation failed after all retry attempts"
+              {
+                echo "exists=false"
+                echo "created_count=0"
+                echo "skipped_count=0"
+                echo "failed_count=1"
+              } >> "${GITHUB_OUTPUT}"
+              exit 1
+            fi
           fi
 
       - name: Tag creation summary
         if: always()
         run: |
-          if [ "${{ steps.check_tag.outputs.exists }}" = "true" ]; then
-            echo "✅ Tag ${{ steps.commit.outputs.tag_name }} already existed - no action needed"
-          elif [ "${{ job.status }}" = "success" ]; then
-            echo "✅ Successfully created tag ${{ steps.commit.outputs.tag_name }} for commit ${{ steps.commit.outputs.sha }}"
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "Trigger: push on main"
+            echo "Created: ${{ steps.check_tag.outputs.created_count }}"
+            echo "Skipped (already existed): ${{ steps.check_tag.outputs.skipped_count }}"
+            echo "Failed: ${{ steps.check_tag.outputs.failed_count }}"
+            if [ "${{ steps.check_tag.outputs.failed_count }}" = "0" ]; then
+              echo "✅ Completed tagging for push range ${{ github.event.before }}..${{ github.sha }}"
+            else
+              echo "❌ Some tags failed to create for push range ${{ github.event.before }}..${{ github.sha }}"
+            fi
           else
-            echo "❌ Failed to create tag ${{ steps.commit.outputs.tag_name }} for commit ${{ steps.commit.outputs.sha }}"
-          fi
+            if [ "${{ steps.check_tag.outputs.exists }}" = "true" ]; then
+              echo "✅ Tag ${{ steps.commit.outputs.tag_name }} already existed - no action needed"
+            elif [ "${{ job.status }}" = "success" ]; then
+              echo "✅ Successfully created tag ${{ steps.commit.outputs.tag_name }} for commit ${{ steps.commit.outputs.sha }}"
+            else
+              echo "❌ Failed to create tag ${{ steps.commit.outputs.tag_name }} for commit ${{ steps.commit.outputs.sha }}"
+            fi
 
-          echo ""
-          echo "Tag details:"
-          echo "  Name: ${{ steps.commit.outputs.tag_name }}"
-          echo "  Commit: ${{ steps.commit.outputs.sha }}"
-          echo "  Trigger: ${{ github.event_name }}"
-          if [ -n "${{ github.event.inputs.commit_sha }}" ]; then
-            echo "  Manual commit: ${{ github.event.inputs.commit_sha }}"
+            echo ""
+            echo "Tag details:"
+            echo "  Name: ${{ steps.commit.outputs.tag_name }}"
+            echo "  Commit: ${{ steps.commit.outputs.sha }}"
+            echo "  Trigger: ${{ github.event_name }}"
+            if [ -n "${{ github.event.inputs.commit_sha }}" ]; then
+              echo "  Manual commit: ${{ github.event.inputs.commit_sha }}"
+            fi
           fi


### PR DESCRIPTION
Context:
* this workflow is used to create tags like `trunk/{sha}` for all `main` commits
* those tags are used by [autorevert](https://github.com/pytorch/test-infra/blob/main/aws/lambda/pytorch-auto-revert/README.md) to rerun selected workflows


Problem: currently the workflow creates only a single tag per push event, while ghstack pushes multiple commits per single push.

This PR supports tag creation for all commits in the push event.

Complimentary autorevert PR: https://github.com/pytorch/test-infra/pull/7291


---


### Testing

I created an identical copy of this workflow in my personal repo: https://github.com/izaitsevfb/pr-head-test/actions/workflows/trunk-tagging.yml

See action runs there.