### PR TITLE
Skip tests requiring NCCL if no GPU is found

### DIFF
--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -497,7 +497,7 @@ def requires_gloo():
 
 def requires_nccl_version(version, msg):
     if not TEST_CUDA:
-        return lambda f: f
+        return skip_but_pass_in_sandcastle(TEST_SKIPS["no_cuda"].message)
     if not c10d.is_nccl_available():
         return skip_but_pass_in_sandcastle(
             "c10d was not compiled with the NCCL backend",
@@ -517,6 +517,8 @@ def requires_nccl_shrink():
 
 
 def requires_nccl():
+    if not TEST_CUDA:
+        return skip_but_pass_in_sandcastle(TEST_SKIPS["no_cuda"].message)
     return skip_but_pass_in_sandcastle_if(
         not c10d.is_nccl_available(),
         "c10d was not compiled with the NCCL backend",

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -486,7 +486,7 @@ def requires_gloo():
 
 def requires_nccl_version(version, msg):
     if not TEST_CUDA:
-        return lambda f: f
+        return skip_but_pass_in_sandcastle(TEST_SKIPS["no_cuda"].message)
     if not c10d.is_nccl_available():
         return skip_but_pass_in_sandcastle(
             "c10d was not compiled with the NCCL backend",
@@ -506,6 +506,8 @@ def requires_nccl_shrink():
 
 
 def requires_nccl():
+    if not TEST_CUDA:
+        return skip_but_pass_in_sandcastle(TEST_SKIPS["no_cuda"].message)
     return skip_but_pass_in_sandcastle_if(
         not c10d.is_nccl_available(),
         "c10d was not compiled with the NCCL backend",


### PR DESCRIPTION
If a test is restricted to NCCL it will very likely also require a CUDA device. Put a check directly into the decorators to skip the tests if no CUDA is present


With this many test decorators additionally checking for CUDA/GPUs can be removed as is done for (most?) of the tests using the `requires_nccl*` decorators.
With this change it can at least not be forgotten again.
