### PR TITLE
fix pattern matcher

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -2099,14 +2099,13 @@ class TestPatternMatcherLogging(LoggingTestCase):
         def target_pattern(xs: list[torch.Tensor]):
             return xs
 
-        class BackendTwo:
-            def __init__(self) -> None:
-                super().__init__()
+        class Backend:
+            def __init__(self, example_inputs) -> None:
                 self.pm = PatternMatcherPass()
                 register_replacement(
                     src_pattern,
                     target_pattern,
-                    [[torch.empty(4, 5), torch.empty(4, 5)]],
+                    example_inputs,
                     fwd_only,
                     self.pm,
                 )
@@ -2117,57 +2116,20 @@ class TestPatternMatcherLogging(LoggingTestCase):
                 self.pm.apply(gm.graph)
                 return gm.forward
 
-        def test_function():
-            xs = [torch.randn(4, 5), torch.randn(4, 5)]
-            return torch.ops.custom.list_op(xs)
+        def run_test(example_inputs, expected_length):
+            def test_function():
+                xs = [torch.randn(4, 5) for _ in range(expected_length)]
+                return torch.ops.custom.list_op(xs)
 
-        compiled_fn = torch.compile(test_function, backend=BackendTwo())
-        result = compiled_fn()
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0].shape, torch.Size([4, 5]))
-        self.assertEqual(result[1].shape, torch.Size([4, 5]))
+            backend = Backend([example_inputs])
+            compiled_fn = torch.compile(test_function, backend=backend)
+            result = compiled_fn()
+            self.assertEqual(len(result), expected_length)
+            for i in range(expected_length):
+                self.assertEqual(result[i].shape, torch.Size([4, 5]))
 
-    def test_list_tensor_pattern_replacement_single_item(self):
-        @torch.library.custom_op("custom::list_op", mutates_args=())
-        def list_op(xs: list[torch.Tensor]) -> list[torch.Tensor]:
-            return [x + 1 for x in xs]
-
-        @list_op.register_fake
-        def list_op_fake(xs: list[torch.Tensor]) -> list[torch.Tensor]:
-            return xs
-
-        def src_pattern(xs: list[torch.Tensor]):
-            return torch.ops.custom.list_op(xs)
-
-        def target_pattern(xs: list[torch.Tensor]):
-            return xs
-
-        class BackendSingle:
-            def __init__(self) -> None:
-                super().__init__()
-                self.pm = PatternMatcherPass()
-                register_replacement(
-                    src_pattern,
-                    target_pattern,
-                    [[torch.empty(4, 5)]],
-                    fwd_only,
-                    self.pm,
-                )
-
-            def __call__(
-                self, gm: torch.fx.GraphModule, example_inputs: list[torch.Tensor]
-            ):
-                self.pm.apply(gm.graph)
-                return gm.forward
-
-        def test_function():
-            xs = [torch.randn(4, 5)]
-            return torch.ops.custom.list_op(xs)
-
-        compiled_fn = torch.compile(test_function, backend=BackendSingle())
-        result = compiled_fn()
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0].shape, torch.Size([4, 5]))
+        run_test([torch.empty(4, 5), torch.empty(4, 5)], expected_length=2)
+        run_test([torch.empty(4, 5)], expected_length=1)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -2085,51 +2085,57 @@ class TestPatternMatcherLogging(LoggingTestCase):
         )
 
     def test_list_tensor_pattern_replacement(self):
-        @torch.library.custom_op("custom::list_op", mutates_args=())
-        def list_op(xs: list[torch.Tensor]) -> list[torch.Tensor]:
+        @torch.library.custom_op("custom::list_op_check", mutates_args=())
+        def list_op_check(xs: list[torch.Tensor]) -> list[torch.Tensor]:
             return [x + 1 for x in xs]
 
-        @list_op.register_fake
-        def list_op_fake(xs: list[torch.Tensor]) -> list[torch.Tensor]:
+        @list_op_check.register_fake
+        def list_op_check_fake(xs: list[torch.Tensor]) -> list[torch.Tensor]:
             return xs
 
-        def src_pattern(xs: list[torch.Tensor]):
-            return torch.ops.custom.list_op(xs)
+        def register_pattern(custom_pass: PatternMatcherPass):
+            def src_pattern(xs: list[torch.Tensor]):
+                return torch.ops.custom.list_op_check.default(xs)
 
-        def target_pattern(xs: list[torch.Tensor]):
-            return xs
+            def target_pattern(xs: list[torch.Tensor]):
+                return xs
+
+            register_replacement(
+                src_pattern,
+                target_pattern,
+                [[torch.empty((5, 3)), torch.empty((5, 3))]],
+                fwd_only,
+                custom_pass,
+            )
 
         class Backend:
-            def __init__(self, example_inputs) -> None:
+            def __init__(self):
                 self.pm = PatternMatcherPass()
-                register_replacement(
-                    src_pattern,
-                    target_pattern,
-                    example_inputs,
-                    fwd_only,
-                    self.pm,
-                )
+                register_pattern(self.pm)
 
             def __call__(
                 self, gm: torch.fx.GraphModule, example_inputs: list[torch.Tensor]
             ):
-                self.pm.apply(gm.graph)
                 return gm.forward
 
-        def run_test(example_inputs, expected_length):
-            def test_function():
-                xs = [torch.randn(4, 5) for _ in range(expected_length)]
-                return torch.ops.custom.list_op(xs)
+        backend_instance = Backend()
 
-            backend = Backend([example_inputs])
-            compiled_fn = torch.compile(test_function, backend=backend)
-            result = compiled_fn()
-            self.assertEqual(len(result), expected_length)
-            for i in range(expected_length):
-                self.assertEqual(result[i].shape, torch.Size([4, 5]))
+        def test_function():
+            xs = [torch.randn(5, 3), torch.randn(5, 3)]
+            return torch.ops.custom.list_op_check.default(xs)
 
-        run_test([torch.empty(4, 5), torch.empty(4, 5)], expected_length=2)
-        run_test([torch.empty(4, 5)], expected_length=1)
+        test_function()
+
+        fn = torch.compile(test_function, backend=Backend())
+
+        result = fn()
+
+        self.assertGreater(
+            len(backend_instance.pm.patterns), 0, "Pattern should be registered"
+        )
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].shape, torch.Size([5, 3]))
+        self.assertEqual(result[1].shape, torch.Size([5, 3]))
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -2084,6 +2084,26 @@ class TestPatternMatcherLogging(LoggingTestCase):
             specific_record.getMessage(),
         )
 
+    def test_list_tensor_pattern_replacement(self):
+        @torch.library.custom_op("custom::list_op", mutates_args=())
+        def list_op(xs: list[torch.Tensor]) -> list[torch.Tensor]:
+            return [x + 1 for x in xs]
+
+        @list_op.register_fake
+        def list_op_fake(xs: list[torch.Tensor]) -> list[torch.Tensor]:
+            return xs
+
+        def pattern(xs: list[torch.Tensor]):
+            return torch.ops.custom.list_op(xs)
+
+        def replacement(xs: list[torch.Tensor]):
+            return xs
+
+        patterns = PatternMatcherPass()
+        inputs = [[torch.empty(4, 5), torch.empty(4, 5)]]
+
+        register_replacement(pattern, replacement, inputs, fwd_only, patterns)
+
 
 if __name__ == "__main__":
     if IS_LINUX and HAS_GPU:

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -2115,8 +2115,7 @@ def fx_to_pattern(
             n = next(argnum)
             if n < len(argnames):
                 name = argnames[n]
-            elif argnames:
-                assert target.startswith("tangent")
+            elif argnames and target.startswith("tangent"):
                 name = target
             else:
                 target = re.sub(r"_\d+$", "", target)  # de-mangle arg name


### PR DESCRIPTION
Fixes #165845 

### Summary

- Fixes a crash in the pattern matcher when registering replacement patterns with `list[Tensor]` or other collection type arguments.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos @chenyang78