### PR TITLE
Normalize ROCm/HIP version string to be PEP 440 compliant

### DIFF
--- a/tools/generate_torch_version.py
+++ b/tools/generate_torch_version.py
@@ -49,6 +49,14 @@ def get_tag(pytorch_root: str | Path) -> str:
         return UNKNOWN
 
 
+def normalize_hip_version(version_str: str | None) -> str | None:
+    """Normalize ROCm/HIP version to PEP 440 format by removing git hash suffix."""
+    if version_str is None or version_str == "":
+        return None
+    # Strip git hash (e.g., '6.4.43482-0f2d60242' -> '6.4.43482')
+    return version_str.split("-")[0]
+
+
 def get_torch_version(sha: str | None = None) -> str:
     """Determine the torch version string.
 
@@ -127,6 +135,9 @@ if __name__ == "__main__":
     args.cuda_version = None if args.cuda_version == "" else args.cuda_version
     args.hip_version = None if args.hip_version == "" else args.hip_version
     args.xpu_version = None if args.xpu_version == "" else args.xpu_version
+
+    # Normalize HIP version to be PEP 440 compliant
+    args.hip_version = normalize_hip_version(args.hip_version)
 
     pytorch_root = Path(__file__).parent.parent
     version_path = pytorch_root / "torch" / "version.py"


### PR DESCRIPTION
ROCm/HIP version strings from CMake often include build metadata and git hashes (e.g., '6.4.43482-0f2d60242') which are not PEP 440 compliant. This causes packaging.version.parse(torch.version.hip) to fail with InvalidVersion error.

This change normalizes the HIP version string by removing the git hash suffix (everything after the first hyphen) before writing it to torch/version.py. This ensures that torch.version.hip contains a clean, PEP 440-compliant version string that can be safely used with packaging.version.parse().

The normalization is applied in tools/generate_torch_version.py which is the script responsible for generating torch/version.py during build.

Fixes #166068




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd