### PR TITLE
[Quantized][PowerPC] Vectorized Implementation of Per-Tensor and Per-Channel kernels

### DIFF
--- a/aten/src/ATen/native/quantized/AffineQuantizerBase.cpp
+++ b/aten/src/ATen/native/quantized/AffineQuantizerBase.cpp
@@ -147,6 +147,19 @@ T quantize_val_arm(
   return static_cast<T>(r);
 }
 
+template <typename T>
+T quantize_val_vsx(
+    const float scale,
+    const int32_t zero_point,
+    const float value) {
+  constexpr int32_t qmin = std::numeric_limits<T>::min();
+  constexpr int32_t qmax = std::numeric_limits<T>::max();
+  float inv_scale = 1.0f / scale;
+  auto r = static_cast<int32_t>(zero_point + std::nearbyint(value * inv_scale));
+  r = std::max(r, qmin);
+  r = std::min(r, qmax);
+  return static_cast<T>(r);
+}
 template <typename T, int precision>
 void quantize_vec(
     double scale,
@@ -165,6 +178,14 @@ template uint8_t quantize_val_arm<uint8_t>(
     const int32_t zero_point,
     const float value);
 template int8_t quantize_val_arm<int8_t>(
+    const float scale,
+    const int32_t zero_point,
+    const float value);
+template uint8_t quantize_val_vsx<uint8_t>(
+    const float scale,
+    const int32_t zero_point,
+    const float value);
+template int8_t quantize_val_vsx<int8_t>(
     const float scale,
     const int32_t zero_point,
     const float value);

--- a/aten/src/ATen/native/quantized/AffineQuantizerBase.h
+++ b/aten/src/ATen/native/quantized/AffineQuantizerBase.h
@@ -14,6 +14,11 @@ T quantize_val_arm(
     const float scale,
     const int32_t zero_point,
     const float value);
+template <typename T>
+T quantize_val_vsx(
+    const float scale,
+    const int32_t zero_point,
+    const float value);
 template <typename T, int precision = 8>
 void quantize_vec(
     double scale,


### PR DESCRIPTION
This PR introduces performance optimizations for quantized tensor operations on PowerPC architectures by leveraging VSX intrinsics.

**Key Changes:**

1. Enabled multi-threaded execution for per-tensor quantization paths.
2. Vectorized per-tensor and per-channel quantization kernels.

**Test Results:**

All quantization test cases were executed using:

```
pytest test/test_quantization.py -v

615 passed, 724 skipped in 488.09s (0:08:08)
```

**Performance Improvement:**

I have run the benchmark and below are the results:

Shape | Dim | Per-Tensor (ms) Before | Per-Tensor (ms) After | Speedup × | Per-Channel (ms) Before | Per-Channel (ms) After | Speedup ×
-- | -- | -- | -- | -- | -- | -- | --
2D | 2 | 20.8353 | 0.1057 | ~197× | 20.7788 | 0.2730 | ~76×
3D | 3 | 83.2763 | 0.3086 | ~270× | 83.0306 | 1.1135 | ~75×
4D | 4 | 665.5254 | 3.4039 | ~195× | 665.6367 | 8.9173 | ~75×




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01