### PR TITLE
Untie building test_aoti_abi_check from BUILD_AOT_INDUCTOR_TEST

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1374,11 +1374,11 @@ if(BUILD_TEST)
     endif()
     add_subdirectory(${TORCH_ROOT}/test/cpp/lazy
                      ${CMAKE_BINARY_DIR}/test_lazy)
-  endif()
-  if(BUILD_AOT_INDUCTOR_TEST)
     add_subdirectory(
       ${TORCH_ROOT}/test/cpp/aoti_abi_check
       ${CMAKE_BINARY_DIR}/test_aoti_abi_check)
+  endif()
+  if(BUILD_AOT_INDUCTOR_TEST)
     add_subdirectory(
       ${TORCH_ROOT}/test/cpp/aoti_inference
       ${CMAKE_BINARY_DIR}/test_aoti_inference)

--- a/test/cpp/aoti_abi_check/CMakeLists.txt
+++ b/test/cpp/aoti_abi_check/CMakeLists.txt
@@ -33,6 +33,9 @@ target_compile_definitions(test_aoti_abi_check PRIVATE USE_GTEST)
 target_link_libraries(test_aoti_abi_check PRIVATE gtest_main)
 target_include_directories(test_aoti_abi_check PRIVATE ${ATen_CPU_INCLUDE})
 
+target_compile_options_if_supported(test_aoti_abi_check -Wno-unused-variable)
+target_compile_options_if_supported(test_aoti_abi_check -Wno-unused-but-set-variable)
+
 foreach(test_src ${AOTI_ABI_CHECK_VEC_TEST_SRCS})
   foreach(i RANGE ${NUM_CPU_CAPABILITY_NAMES})
     get_filename_component(test_name ${test_src} NAME_WE)
@@ -47,6 +50,8 @@ foreach(test_src ${AOTI_ABI_CHECK_VEC_TEST_SRCS})
     # Define CPU_CAPABILITY and CPU_CAPABILITY_XXX macros for conditional compilation
     target_compile_definitions(${test_name}_${CPU_CAPABILITY} PRIVATE CPU_CAPABILITY=${CPU_CAPABILITY} CPU_CAPABILITY_${CPU_CAPABILITY})
     target_compile_options(${test_name}_${CPU_CAPABILITY} PRIVATE ${FLAGS})
+    target_compile_options_if_supported(${test_name}_${CPU_CAPABILITY} -Wno-unused-variable)
+    target_compile_options_if_supported(${test_name}_${CPU_CAPABILITY} -Wno-unused-but-set-variable)
   endforeach()
 endforeach()
 


### PR DESCRIPTION
Currently, to build test_aoti_abi_check, one may use
```bash
BUILD_TEST=1 BUILD_AOT_INDUCTOR_TEST=1 python -m pip install -v -e . --no-build-isolation
```
that fails when building from a clean source tree (see also https://github.com/pytorch/pytorch/issues/159400):

<details>

```bash
...
[3318/3324] Generating script_data.pt, script_model_cpu.pt, script_model_cuda.pt
  FAILED: test_aoti_inference/script_data.pt test_aoti_inference/script_model_cpu.pt test_aoti_inference/script_model_cuda.pt /home/pearu/git/pytorch/pytorch-stable/build/test_aoti_inference/script_data.pt /home/pearu/git/pytorch/pytorch-stable/build/test_aoti_inference/script_model_cpu.pt /home/pearu/git/pytorch/pytorch-stable/build/test_aoti_inference/script_model_cuda.pt
  cd /home/pearu/git/pytorch/pytorch-stable/build/test_aoti_inference && python /home/pearu/git/pytorch/pytorch-stable/test/cpp/aoti_inference/compile_model.py
  Traceback (most recent call last):
    File "/home/pearu/git/pytorch/pytorch-stable/test/cpp/aoti_inference/compile_model.py", line 1, in <module>
      import torch
    File "/home/pearu/git/pytorch/pytorch-stable/torch/__init__.py", line 425, in <module>
      _load_global_deps()
      ~~~~~~~~~~~~~~~~~^^
    File "/home/pearu/git/pytorch/pytorch-stable/torch/__init__.py", line 381, in _load_global_deps
      raise err
    File "/home/pearu/git/pytorch/pytorch-stable/torch/__init__.py", line 333, in _load_global_deps
      ctypes.CDLL(global_deps_lib_path, mode=ctypes.RTLD_GLOBAL)
      ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/home/pearu/miniconda3/envs/pytorch-cuda-dev/lib/python3.13/ctypes/__init__.py", line 390, in __init__
      self._handle = _dlopen(self._name, mode)
                     ~~~~~~~^^^^^^^^^^^^^^^^^^
  OSError: /home/pearu/git/pytorch/pytorch-stable/torch/lib/libtorch_global_deps.so: cannot open shared object file: No such file or directory
```

</details>

This PR unties test_aoti_abi_check from BUILD_AOT_INDUCTOR_TEST so that to build test_aoti_abi_check one can use
```
BUILD_TEST=1 python -m pip install -v -e . --no-build-isolation
```

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #166088

