### PR TITLE
[xpu][fix] Use default warps for inner reductions on XPU 

### DIFF
--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2436,7 +2436,6 @@ def triton_config_reduction(
         else:
             num_warps = total_numel() // 128
 
-
     max_num_warps = 16 if r <= 8192 else 32
     num_warps = _num_warps(
         num_warps, max_num_warps=max_num_warps, register_intensive=register_intensive

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2428,14 +2428,14 @@ def triton_config_reduction(
             # vectorized loads, assuming bf16/fp16
             # xblock is usually 1-2, default to giving each thread more work
             num_warps = r // 128
+            # Workaround here since less warps cause register spills on XPU.
+            # TODO: remove this workaround after https://github.com/intel/intel-xpu-backend-for-triton/issues/5367
+            # resolved.
+            if torch.xpu.is_available():
+                num_warps = total_numel() // 128
         else:
             num_warps = total_numel() // 128
 
-    # Workaround here since less warps cause register spills on XPU.
-    # TODO: remove this workaround after https://github.com/intel/intel-xpu-backend-for-triton/issues/5367
-    # resolved.
-    if torch.xpu.is_available():
-        num_warps = total_numel() // 128
 
     max_num_warps = 16 if r <= 8192 else 32
     num_warps = _num_warps(

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2431,7 +2431,7 @@ def triton_config_reduction(
         else:
             num_warps = total_numel() // 128
 
-    # Workaround here since less warp causes register spills on XPU.
+    # Workaround here since less warps cause register spills on XPU.
     # TODO: remove this workaround after https://github.com/intel/intel-xpu-backend-for-triton/issues/5367
     # resolved.
     if torch.xpu.is_available():

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2431,6 +2431,12 @@ def triton_config_reduction(
         else:
             num_warps = total_numel() // 128
 
+    # Workaround here since less warp causes register spills on XPU.
+    # TODO: remove this workaround after https://github.com/intel/intel-xpu-backend-for-triton/issues/5367
+    # resolved.
+    if torch.xpu.is_available():
+        num_warps = total_numel() // 128
+
     max_num_warps = 16 if r <= 8192 else 32
     num_warps = _num_warps(
         num_warps, max_num_warps=max_num_warps, register_intensive=register_intensive


### PR DESCRIPTION
Fixes [[#triton-xpu-issue](https://github.com/intel/intel-xpu-backend-for-triton/issues/5367)], the config of less warps for reduction on XPU devices causes register spill and performance drop of 70%.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben