### PR TITLE
Strengthen the implementation of OpenReg Stream

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegStream.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegStream.cpp
@@ -49,11 +49,12 @@ thread_local std::unique_ptr<StreamId[]> current_streams = nullptr;
  *                ignored for ext   ignored for ext
  *
  * StreamIdType:
- *  000-001 = OpenReg priority stream
+ *  000 = high stream
+ *  001 = normal stream
  *  110 = default stream
  *  111 = external stream
- * Priorities 000-101 are reserved for the normal stream pool and can be extended as per practical requirements.
- * OpenReg currently supports priorities 0 and 1.
+
+ * The range 000 to 101 is reserved for stream pools of different priorities and can be expanded as needed. (OpenReg currently supports two priorities: 0 and 1)
  *
  * For external stream, StreamID is a orStream_t pointer. This means that last
  * bit will always be 0. So when constructing StreamId for a native stream we
@@ -94,7 +95,7 @@ inline std::ostream& operator<<(std::ostream& stream, StreamIdType s) {
     case StreamIdType::EXT:
       return stream << "EXT";
     default:
-      return stream << "NORMAL" << static_cast<int>(s.getStreamType());
+      return stream << "PRIORITY" << static_cast<int>(s.getStreamType());
   }
 }
 

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegStream.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegStream.cpp
@@ -49,8 +49,8 @@ thread_local std::unique_ptr<StreamId[]> current_streams = nullptr;
  *                ignored for ext   ignored for ext
  *
  * StreamIdType:
- *  000 = high stream
- *  001 = normal stream
+ *  000 = normal stream
+ *  001 = high stream
  *  110 = default stream
  *  111 = external stream
 
@@ -240,7 +240,7 @@ OpenRegStream getStreamFromPool(const int priority, DeviceIndex device_index) {
 
 OpenRegStream getStreamFromPool(const bool isHighPriority, DeviceIndex device) {
   initOpenRegStreamsOnce();
-  int priority = isHighPriority ? 0 : max_stream_priorities - 1;
+  int priority = isHighPriority ? max_stream_priorities - 1 : 0;
   return getStreamFromPool(priority, device);
 }
 

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegStream.h
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegStream.h
@@ -12,7 +12,7 @@
 namespace c10::openreg {
 
 // Derive compile-time priority count from shared openreg backend constant.
-static constexpr int max_compile_time_stream_priorities = ::openreg::kOpenRegMaxStreamPriorities;
+static constexpr int max_compile_time_stream_priorities = 2;
 
 class OpenRegStream {
  public:

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegStream.h
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegStream.h
@@ -11,7 +11,8 @@
 
 namespace c10::openreg {
 
-static constexpr int max_compile_time_stream_priorities = 1;
+// Derive compile-time priority count from shared openreg backend constant.
+static constexpr int max_compile_time_stream_priorities = ::openreg::kOpenRegMaxStreamPriorities;
 
 class OpenRegStream {
  public:

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_streams.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_streams.py
@@ -30,8 +30,6 @@ class TestStream(TestCase):
             self.assertEqual(torch.accelerator.current_stream(), stream)
 
     def test_stream_context_exception_restore(self):
-        prev_stream = torch.Stream(device="openreg:0")
-        torch.accelerator.set_stream(prev_stream)
         prev = torch.accelerator.current_stream()
         inner_stream = torch.Stream(device="openreg:1")
         try:

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/csrc/stream.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/csrc/stream.cpp
@@ -177,6 +177,7 @@ orError_t orStreamCreateWithPriority(
     orStream_t* stream,
     [[maybe_unused]] unsigned int flag,
     int priority) {
+  priority = -priority;
   if (!stream) {
     return orErrorUnknown;
   }
@@ -282,9 +283,9 @@ orError_t orDeviceGetStreamPriorityRange(
     return orErrorUnknown;
   }
 
-  // OpenReg priority levels are 0 .. kOpenRegMaxStreamPriorities-1
-  *leastPriority = 0;
-  *greatestPriority = openreg::kOpenRegMaxStreamPriorities;
+  // OpenReg priority levels are -1 and 0
+  *leastPriority = -1;
+  *greatestPriority = 0;
   return orSuccess;
 }
 

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/csrc/stream.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/csrc/stream.cpp
@@ -1,5 +1,4 @@
 #include <include/openreg.h>
-
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
@@ -210,7 +209,7 @@ orError_t orStreamCreate(orStream_t* stream) {
   int min_p, max_p;
   orDeviceGetStreamPriorityRange(&min_p, &max_p);
 
-  return orStreamCreateWithPriority(stream, 0, max_p);
+  return orStreamCreateWithPriority(stream, min_p, max_p);
 }
 
 orError_t orStreamGetPriority(
@@ -283,9 +282,9 @@ orError_t orDeviceGetStreamPriorityRange(
     return orErrorUnknown;
   }
 
-  // OpenReg have only one priority now.
+  // OpenReg priority levels are 0 .. kOpenRegMaxStreamPriorities-1
   *leastPriority = 0;
-  *greatestPriority = 0;
+  *greatestPriority = openreg::kOpenRegMaxStreamPriorities;
   return orSuccess;
 }
 

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/csrc/stream.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/csrc/stream.cpp
@@ -177,7 +177,6 @@ orError_t orStreamCreateWithPriority(
     orStream_t* stream,
     [[maybe_unused]] unsigned int flag,
     int priority) {
-  priority = -priority;
   if (!stream) {
     return orErrorUnknown;
   }
@@ -210,7 +209,7 @@ orError_t orStreamCreate(orStream_t* stream) {
   int min_p, max_p;
   orDeviceGetStreamPriorityRange(&min_p, &max_p);
 
-  return orStreamCreateWithPriority(stream, min_p, max_p);
+  return orStreamCreateWithPriority(stream, 0, max_p);
 }
 
 orError_t orStreamGetPriority(
@@ -283,9 +282,9 @@ orError_t orDeviceGetStreamPriorityRange(
     return orErrorUnknown;
   }
 
-  // OpenReg priority levels are -1 and 0
-  *leastPriority = -1;
-  *greatestPriority = 0;
+  // OpenReg priority levels are 0 and 1
+  *leastPriority = 0;
+  *greatestPriority = 1;
   return orSuccess;
 }
 

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/include/openreg.h
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/include/openreg.h
@@ -104,6 +104,11 @@ orEventElapsedTime(float* ms, orEvent_t start, orEvent_t end);
 #ifdef __cplusplus
 
 #define OPENREG_H
+#include <cstdint>
+namespace openreg {
+constexpr int kOpenRegMaxStreamPriorities = 2;
+}
+
 #include "openreg.inl"
 
 #endif

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/include/openreg.h
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/include/openreg.h
@@ -104,11 +104,6 @@ orEventElapsedTime(float* ms, orEvent_t start, orEvent_t end);
 #ifdef __cplusplus
 
 #define OPENREG_H
-#include <cstdint>
-namespace openreg {
-constexpr int kOpenRegMaxStreamPriorities = 2;
-}
-
 #include "openreg.inl"
 
 #endif

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/tests/stream_tests.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/tests/stream_tests.cpp
@@ -127,7 +127,7 @@ TEST_F(StreamTest, StreamPriorityRange) {
   // OpenReg currently exposes only one priority level; verify the fixed range.
   EXPECT_EQ(orDeviceGetStreamPriorityRange(&min_p, &max_p), orSuccess);
   EXPECT_EQ(min_p, 0);
-  EXPECT_EQ(max_p, 0);
+  EXPECT_EQ(max_p, 1);
 }
 
 } // namespace


### PR DESCRIPTION
This PR redesigns the implementation of OpenRegStream, enabling it to support default streams and normal stream pools with multiple priorities. It also adds robustness checks such as device ID validation and supplements relevant test cases for stream context management.

**Changes and Reasons**

1. OpenReg runtime (OpenRegStream.cpp)

1）Redesigned the ID of OpenReg Stream. In the new implementation:
- StreamIdType=6 indicates the default stream, and StreamIdType=7 represents the external stream. Values 0-5 are reserved as priority codes for normal stream pools. OpenReg currently supports stream pools with priorities 0-1. This design makes the priority of stream pools more intuitive and easier to understand.
- Modified StreamIdType from an enum to a regular class to support multi-priority scenarios.
- Updated the implementation of OpenRegStream::stream() for retrieving orStream_t.
- Adjusted the code in the original implementation that restricted stream pools to single-priority, enabling multi-priority support.

2）Enhanced robustness: added device validation, DeviceGuard initialization. 

2. Tests (test_streams.py)

Added assertions for "original stream restoration" in context exception paths and stream switching checks, covering key code paths.