### PR TITLE
Fix device mismatch in sdpa docstring example

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5936,7 +5936,7 @@ scaled_dot_product_attention = _add_docstr(
             attn_bias = torch.zeros(L, S, dtype=query.dtype, device=query.device)
             if is_causal:
                 assert attn_mask is None
-                temp_mask = torch.ones(L, S, dtype=torch.bool).tril(diagonal=0)
+                temp_mask = torch.ones(L, S, device=query.device, dtype=torch.bool).tril(diagonal=0)
                 attn_bias.masked_fill_(temp_mask.logical_not(), float("-inf"))
 
             if attn_mask is not None:


### PR DESCRIPTION
Fixes #166117 

This PR corrects the Python code example in the `scaled_dot_product_attention` docstring using the fix I suggested in the issue.

The Python code example in the docstring for torch.nn.functional.scaled_dot_product_attention can cause a device mismatch error when the input tensors are on a GPU.

Problematic line: `temp_mask = torch.ones(L, S, dtype=torch.bool).tril(diagonal=0)`