### PR TITLE
[OpenReg][Docs]Strengthen the implementation of OpenReg Event and add implementation documentation

### DIFF
--- a/docs/source/accelerator/event.md
+++ b/docs/source/accelerator/event.md
@@ -1,0 +1,77 @@
+# Event
+
+## Background
+
+Events are lightweight synchronization primitives used to coordinate work across streams on the same device. In PyTorch, an event API should:
+- Record a point on a stream’s work queue
+- Make another stream wait until that point completes
+- Allow non-blocking completion queries and host-side synchronization
+- Optionally measure elapsed time between two recorded events (when timing is enabled)
+
+Goal: deliver a minimal, production-ready Event implementation aligned with the OpenReg reference, with correct device routing and full `torch.Event` interop.
+
+## Design
+
+The accelerator needs to support the following basic functionalities.
+
+| Functionality | Description | When to use |
+| :-- | :-- | :-- |
+| Record | Record the event on a given stream (or the current stream). | Mark a synchronization point in a stream. |
+| Wait/Block | Make a stream wait until the event completes. | Coordinate work across streams. |
+| Query | Non-blocking completion check. | Poll for completion. |
+| Synchronize | Host-side wait until completion. | Ensure completion before host continues. |
+| Timing (optional) | Measure elapsed time between two completed, timing-enabled events. | Lightweight timing when the backend supports it. |
+
+## Implementation
+
+Below we use a single representative function, record, to walk through how an Event is implemented across layers.
+
+### Python Side
+
+The Python wrapper `torch.Event.record(stream=None)` either records on an explicit stream or, if none is provided, fetches the current stream from the backend via `VirtualGuardImpl` and records there.
+
+```{eval-rst}
+.. literalinclude:: ../../../torch/csrc/Event.cpp
+    :language: c++
+    :start-after: LITERALINCLUDE START: PYTORCH EVENT RECORD
+    :end-before: LITERALINCLUDE END: PYTORCH EVENT RECORD
+    :linenos:
+```
+
+### C++ Side
+
+On the backend, OpenReg provides two entry points: a convenience `record()` that uses the current stream, and the core `record(stream)` that validates device consistency, lazily creates the event if needed, then enqueues the record operation.
+
+```{eval-rst}
+.. literalinclude:: ../../../test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegEvent.h
+    :language: c++
+    :start-after: LITERALINCLUDE START: OPENREG EVENT RECORD DEFAULT
+    :end-before: LITERALINCLUDE END: OPENREG EVENT RECORD DEFAULT
+    :linenos:
+
+.. literalinclude:: ../../../test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegEvent.h
+    :language: c++
+    :start-after: LITERALINCLUDE START: OPENREG EVENT RECORD
+    :end-before: LITERALINCLUDE END: OPENREG EVENT RECORD
+    :linenos:
+```
+
+### Integration
+
+#### Guard
+
+When no stream is provided from Python, the record path uses `VirtualGuardImpl(DeviceType)` to retrieve the current stream for the event’s device type and device index. This dispatch relies on the backend registering a `DeviceGuardImplInterface` implementation. OpenReg wires this up as follows:
+
+```{eval-rst}
+.. literalinclude:: ../../../test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegGuard.cpp
+    :language: c++
+    :start-after: LITERALINCLUDE START: OPENREG GUARD REGISTRATION
+    :end-before: LITERALINCLUDE END: OPENREG GUARD REGISTRATION
+    :linenos:
+```
+
+With this registration in place, `VirtualGuardImpl` can obtain the backend’s current stream, ensuring `torch.Event.record()` without an explicit stream is correctly routed.
+
+## Summary
+
+This minimal design implements Event by routing Python calls through `VirtualGuardImpl` and delegating backend specifics to OpenReg. Using the record path as an example, we showed how Python resolves the stream (explicit or current), how the backend validates devices and records, and how Guard wiring makes the integration work uniformly across backends.

--- a/docs/source/accelerator/index.md
+++ b/docs/source/accelerator/index.md
@@ -45,6 +45,7 @@ Next, we will delve into each chapter of this guide. Each chapter focuses on a k
 autoload
 operators
 amp
+event
 ```
 
 [OpenReg URL]: https://github.com/pytorch/pytorch/tree/main/test/cpp_extensions/open_registration_extension/torch_openreg "OpenReg URL"

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegEvent.h
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegEvent.h
@@ -11,9 +11,11 @@ struct OpenRegEvent {
   OpenRegEvent(bool enable_timing) noexcept : enable_timing_{enable_timing} {}
 
   ~OpenRegEvent() {
-    if (is_created_) {
-      OPENREG_CHECK(orEventDestroy(event_));
-    }
+    try {
+      if (is_created_) {
+        OPENREG_CHECK(orEventDestroy(event_));
+      }
+    } catch (...) { /* No throw */ }
   }
 
   OpenRegEvent(const OpenRegEvent&) = delete;
@@ -66,15 +68,18 @@ struct OpenRegEvent {
     return false;
   }
 
+  // LITERALINCLUDE START: OPENREG EVENT RECORD DEFAULT
   void record() {
     record(getCurrentOpenRegStream());
   }
+  // LITERALINCLUDE END: OPENREG EVENT RECORD DEFAULT
 
   void recordOnce(const OpenRegStream& stream) {
     if (!was_recorded_)
       record(stream);
   }
 
+  // LITERALINCLUDE START: OPENREG EVENT RECORD
   void record(const OpenRegStream& stream) {
     if (!is_created_) {
       createEvent(stream.device_index());
@@ -91,6 +96,7 @@ struct OpenRegEvent {
     OPENREG_CHECK(orEventRecord(event_, stream));
     was_recorded_ = true;
   }
+  // LITERALINCLUDE END: OPENREG EVENT RECORD
 
   void block(const OpenRegStream& stream) {
     if (is_created_) {

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegGuard.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegGuard.cpp
@@ -2,6 +2,8 @@
 
 namespace c10::openreg {
 
+// LITERALINCLUDE START: OPENREG GUARD REGISTRATION
 C10_REGISTER_GUARD_IMPL(PrivateUse1, OpenRegGuardImpl);
+// LITERALINCLUDE END: OPENREG GUARD REGISTRATION
 
 } // namespace c10::openreg

--- a/torch/csrc/Event.cpp
+++ b/torch/csrc/Event.cpp
@@ -56,13 +56,13 @@ static PyObject* THPEvent_pynew(
   (void)blocking;
   (void)interprocess;
 
+  // LITERALINCLUDE START: PYTORCH EVENT CTOR
   new (&self->event) c10::Event(
       device->type(),
       // See note [Flags defining the behavior of events]
-      // BACKEND_DEFAULT is a enable-timing flag, and
-      // PYTORCH_DEFAULT is a disable-timing flag.
       (enable_timing ? c10::EventFlag::BACKEND_DEFAULT
                      : c10::EventFlag::PYTORCH_DEFAULT));
+  // LITERALINCLUDE END: PYTORCH EVENT CTOR
 
   return static_cast<PyObject*>(ptr.release());
   END_HANDLE_TH_ERRORS
@@ -110,6 +110,7 @@ static PyObject* THPEvent_record(
     TORCH_WARN("Parsing THPEvent_record arg fails");
     return nullptr;
   }
+  // LITERALINCLUDE START: PYTORCH EVENT RECORD
   if (_stream != Py_None) {
     auto stream = reinterpret_cast<THPStream*>(_stream);
     self->event.record(c10::Stream::unpack3(
@@ -121,6 +122,7 @@ static PyObject* THPEvent_record(
         static_cast<c10::DeviceType>(self->event.device_type())};
     self->event.record(impl.getStream(impl.getDevice()));
   }
+  // LITERALINCLUDE END: PYTORCH EVENT RECORD
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
@@ -188,6 +190,7 @@ static PyObject* THPEvent_wait(
       TORCH_WARN("Parsing THPEvent_wait arg fails");
       return nullptr;
     }
+    // LITERALINCLUDE START: PYTORCH EVENT WAIT
     if (_stream != Py_None) {
       auto stream = reinterpret_cast<THPStream*>(_stream);
       self->event.block(c10::Stream::unpack3(
@@ -199,6 +202,7 @@ static PyObject* THPEvent_wait(
           static_cast<c10::DeviceType>(self->event.device_type())};
       self->event.block(impl.getStream(impl.getDevice()));
     }
+    // LITERALINCLUDE END: PYTORCH EVENT WAIT
   }
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
@@ -207,7 +211,9 @@ static PyObject* THPEvent_wait(
 static PyObject* THPEvent_query(PyObject* _self, PyObject* noargs) {
   HANDLE_TH_ERRORS
   auto self = reinterpret_cast<THPEvent*>(_self);
+  // LITERALINCLUDE START: PYTORCH EVENT QUERY
   return PyBool_FromLong(self->event.query());
+  // LITERALINCLUDE END: PYTORCH EVENT QUERY
   END_HANDLE_TH_ERRORS
 }
 
@@ -215,7 +221,9 @@ static PyObject* THPEvent_elapsed_time(PyObject* _self, PyObject* _other) {
   HANDLE_TH_ERRORS
   auto self = reinterpret_cast<THPEvent*>(_self);
   auto other = reinterpret_cast<THPEvent*>(_other);
+  // LITERALINCLUDE START: PYTORCH EVENT ELAPSED
   return PyFloat_FromDouble(self->event.elapsedTime(other->event));
+  // LITERALINCLUDE END: PYTORCH EVENT ELAPSED
   END_HANDLE_TH_ERRORS
 }
 
@@ -223,7 +231,9 @@ static PyObject* THPEvent_synchronize(PyObject* _self, PyObject* noargs) {
   HANDLE_TH_ERRORS {
     pybind11::gil_scoped_release no_gil{};
     auto self = reinterpret_cast<THPEvent*>(_self);
+    // LITERALINCLUDE START: PYTORCH EVENT SYNC
     self->event.synchronize();
+    // LITERALINCLUDE END: PYTORCH EVENT SYNC
   }
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS


### PR DESCRIPTION
Changes

- Implementation hardening: Wrap orEventDestroy in a try/catch in the OpenRegEvent destructor to prevent exceptions from escaping the destructor and causing terminate.
- Documentation: Add literalinclude anchors to event-related code (constructor/record/wait/query/synchronize/timing, etc.) and author the initial Event implementation document.