### PR TITLE
Refactor api and configs of overlapping

### DIFF
--- a/test/distributed/test_aten_comm_compute_reordering.py
+++ b/test/distributed/test_aten_comm_compute_reordering.py
@@ -62,14 +62,14 @@ def run_and_get_aten_graph(fn, *inputs):
 
 def get_patches():
     return {
-        "test_configs.estimate_aten_runtime": estimate_aten_runtime,
+        "aten_distributed_optimizations.estimate_op_runtime": estimate_aten_runtime,
         "reorder_for_locality": False,
         "triton.native_matmul": False,
         "reorder_for_compute_comm_overlap_passes": [],
         "compile_threads": 1,
         "force_disable_caches": True,
         # Messes up existing test strings
-        "test_configs.aten_fx_overlap_insert_overlap_deps": False,
+        "aten_distributed_optimizations.insert_overlap_deps": False,
         # interferes with testing, / custom estimation
         "test_configs.assume_bucketing_reduces_latency": False,
     }
@@ -351,21 +351,56 @@ graph():
             # these have no overlap opportunities
             self.assertEqual(counters["inductor"]["overlap_scheduling_bad_exposed"], 0)
 
+    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    def test_overlap_scheduling_via_config(self):
+        """Test overlap scheduling enabled via config in post_grad pass."""
+
+        def func(a):
+            ar = _functional_collectives.all_reduce(a, "sum", "0")
+            b = torch.matmul(a, a)
+            return torch.matmul(ar, b)
+
+        patches = {
+            **get_patches(),
+            "aten_distributed_optimizations.enable_overlap_scheduling": True,
+        }
+
+        with _dynamo_dist_per_rank_init(
+            self.rank,
+            self.world_size,
+            self.backend(device_type),
+            fake_pg=not at_least_x_gpu(2),
+        ):
+            inputs = torch.ones(4, 4, dtype=torch.float, device=device_type) + self.rank
+
+            with torch._inductor.config.patch(patches):
+                compiled_func = torch.compile(func)
+                out, code = run_and_get_code(compiled_func, inputs)
+
+                # Verify that wait_tensor is sinked below matmul
+                FileCheck().check("all_reduce").check("mm").check("wait_tensor").check(
+                    "mm"
+                ).run(code[0])
+
+                correct = func(inputs)
+                self.assertTrue(same(out, correct))
+                self.assertEqual(counters["inductor"]["overlap_scheduling_exposed"], 0)
+
 
 def get_bucket_patches(compute_multiplier=1.0):
     estimate_aten_runtime_part = functools.partial(
         estimate_aten_runtime, compute_multiplier=compute_multiplier
     )
     return {
-        "test_configs.estimate_aten_runtime": estimate_aten_runtime_part,
-        "test_configs.aten_fx_overlap_preserving_bucketing": True,
+        "aten_distributed_optimizations.estimate_op_runtime": estimate_aten_runtime_part,
+        "aten_distributed_optimizations.enable_preserving_bucketing": True,
         "reorder_for_locality": False,
         "triton.native_matmul": False,
         "reorder_for_compute_comm_overlap_passes": [],
         "compile_threads": 1,
         "force_disable_caches": True,
         # messes up test strings
-        "test_configs.aten_fx_overlap_insert_overlap_deps": False,
+        "aten_distributed_optimizations.insert_overlap_deps": False,
         # interferes with testing, / custom estimation
         "test_configs.assume_bucketing_reduces_latency": False,
     }
@@ -806,7 +841,7 @@ class TestComputeCommReorderingBucketing(TestComputeCommReorderingMultiProc):
                 fake_pg=not at_least_x_gpu(2),
             ),
             torch._inductor.config.patch(
-                "test_configs.aten_fx_overlap_insert_overlap_deps", True
+                "aten_distributed_optimizations.insert_overlap_deps", True
             ),
             torch._inductor.config.patch(post_grad_custom_post_pass=apply),
         ):

--- a/test/distributed/test_aten_comm_compute_reordering.py
+++ b/test/distributed/test_aten_comm_compute_reordering.py
@@ -62,7 +62,7 @@ def run_and_get_aten_graph(fn, *inputs):
 
 def get_patches():
     return {
-        "aten_distributed_optimizations.estimate_op_runtime": estimate_aten_runtime,
+        "aten_distributed_optimizations.custom_runtime_estimation": estimate_aten_runtime,
         "reorder_for_locality": False,
         "triton.native_matmul": False,
         "reorder_for_compute_comm_overlap_passes": [],
@@ -392,8 +392,8 @@ def get_bucket_patches(compute_multiplier=1.0):
         estimate_aten_runtime, compute_multiplier=compute_multiplier
     )
     return {
-        "aten_distributed_optimizations.estimate_op_runtime": estimate_aten_runtime_part,
-        "aten_distributed_optimizations.enable_preserving_bucketing": True,
+        "aten_distributed_optimizations.custom_runtime_estimation": estimate_aten_runtime_part,
+        "aten_distributed_optimizations.collective_bucketing": True,
         "reorder_for_locality": False,
         "triton.native_matmul": False,
         "reorder_for_compute_comm_overlap_passes": [],

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -860,17 +860,21 @@ class aten_distributed_optimizations:
     # Enable overlap scheduling pass
     enable_overlap_scheduling: bool = False
 
-    # Insert ordering dependencies to preserve overlap relationships
-    insert_overlap_deps: bool = True
+    # Enable overlap-preserving collective bucketing
+    collective_bucketing: Optional[bool] = None
 
-    # Enable overlap-preserving bucketing
-    enable_preserving_bucketing: bool = False
+    # Insert ordering dependencies to preserve overlap relationships. This should only be used if
+    # compiling with inductor, or for subsequent passes before removing the ops prior to execution
+    insert_overlap_deps: Optional[bool] = None
 
-    # Runtime estimation function for ops
+    # Maximum compute node prefetch distance for overlap scheduling
+    max_compute_pre_fetch: Optional[int] = None
+
+    # Custom runtime estimation function for ops
     # For user-defined estimation function, pass in the function handle
     # None means use default estimations
     # TODO - need estimated and profile based version
-    estimate_op_runtime: Optional[Callable[[torch.fx.Node], Optional[float]]] = None
+    custom_runtime_estimation: Optional[Callable[[torch.fx.Node], Optional[float]]] = None
 
 
 def parallel_compile_enabled_internally() -> bool:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -854,6 +854,25 @@ class _collective:
     one_shot_all_reduce_threshold_bytes: int = 128 * 1024
 
 
+class aten_distributed_optimizations:
+    """Configuration for distributed optimization passes on ATen FX graphs."""
+
+    # Enable overlap scheduling pass
+    enable_overlap_scheduling: bool = False
+
+    # Insert ordering dependencies to preserve overlap relationships
+    insert_overlap_deps: bool = True
+
+    # Enable overlap-preserving bucketing
+    enable_preserving_bucketing: bool = False
+
+    # Runtime estimation function for ops
+    # For user-defined estimation function, pass in the function handle
+    # None means use default estimations
+    # TODO - need estimated and profile based version
+    estimate_op_runtime: Optional[Callable[[torch.fx.Node], Optional[float]]] = None
+
+
 def parallel_compile_enabled_internally() -> bool:
     """
     TODO: Remove when parallel compiled is fully enabled internally. For rollout, use a
@@ -2070,25 +2089,8 @@ class test_configs:
     # for unit testing
     use_libtorch = False
 
-    # to be migrated when ready for use
-    aten_fx_overlap_scheduling = False
-
-    # insert ordering deps for overlap
-    aten_fx_overlap_insert_overlap_deps = True
-
-    # to be migrated when ready for use
-    aten_fx_overlap_preserving_bucketing = False
-
-    # mostly disabled testing
-    assume_bucketing_reduces_latency = True
-
-    # to be migrated when ready for use
-    # runtime estimation function for ops
-    # for user-defined estimation function, pass in the function handle
-    # TODO - need estimated and profile based version
-    estimate_aten_runtime: Union[
-        Literal["default"], Callable[[torch.fx.Node], Optional[float]]
-    ] = "default"
+    # Assume bucketing reduces latency (mostly for testing)
+    assume_bucketing_reduces_latency: bool = True
 
     # A test config to ease the test for perf of reduction config filtering
     force_filter_reduction_configs = (

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -874,7 +874,9 @@ class aten_distributed_optimizations:
     # For user-defined estimation function, pass in the function handle
     # None means use default estimations
     # TODO - need estimated and profile based version
-    custom_runtime_estimation: Optional[Callable[[torch.fx.Node], Optional[float]]] = None
+    custom_runtime_estimation: Optional[Callable[[torch.fx.Node], Optional[float]]] = (
+        None
+    )
 
 
 def parallel_compile_enabled_internally() -> bool:

--- a/torch/_inductor/fx_passes/control_dependencies.py
+++ b/torch/_inductor/fx_passes/control_dependencies.py
@@ -11,7 +11,6 @@ with control_deps to make dependencies explicit.
 from typing import Any
 
 import torch.fx as fx
-from torch._C import DispatchKey
 from torch._higher_order_ops.utils import register_fake
 from torch._ops import HigherOrderOperator
 from torch.utils._ordered_set import OrderedSet
@@ -60,21 +59,6 @@ control_deps = ControlDeps()
 @register_fake(control_deps)
 def _(additional_deps, subgraph, *args, **kwargs):
     """Fake tensor implementation - execute the subgraph."""
-    return subgraph(*args, **kwargs)
-
-
-@control_deps.py_autograd_impl
-def _(additional_deps, subgraph, *args, **kwargs):
-    """Autograd implementation - just execute the subgraph with standard autograd."""
-    return subgraph(*args, **kwargs)
-
-
-@control_deps.py_impl(DispatchKey.CompositeExplicitAutograd)
-def _(additional_deps, subgraph, *args, **kwargs):
-    from torch.utils._python_dispatch import _get_current_dispatch_mode
-
-    mode = _get_current_dispatch_mode()
-    assert mode is None, "Mode should never be enabled for CPU/CUDA key"
     return subgraph(*args, **kwargs)
 
 

--- a/torch/_inductor/fx_passes/overlap_preserving_bucketer.py
+++ b/torch/_inductor/fx_passes/overlap_preserving_bucketer.py
@@ -27,6 +27,7 @@ class OverlapPreservingBucketer:
         scheduled: OrderedSet[fx.Node],
         max_bucket_memory_gb: float = 1.0,
         max_coll_distance: int = 1000,
+        insert_overlap_deps: bool = False,
     ):
         self.graph = graph
         self.collective_info = collective_info
@@ -36,6 +37,7 @@ class OverlapPreservingBucketer:
         self.node_idx = {n: i for i, n in enumerate(scheduled)}
         self.aug_graph = AugmentedGraphHelper(self.graph, self.node_ancestors)
         self.max_coll_distance = max_coll_distance
+        self.insert_overlap_deps = insert_overlap_deps
 
     def bucket_collectives(self) -> None:
         """Main entry point for bucketing collectives."""
@@ -78,7 +80,8 @@ class OverlapPreservingBucketer:
         _stable_topological_sort(self.graph, additional_deps)
 
         # After topological sort, preserve dependencies using effect tokens
-        self._preserve_dependencies_with_tokens(additional_deps)
+        if self.insert_overlap_deps:
+            self._preserve_dependencies_with_tokens(additional_deps)
 
         self.graph.lint()
 
@@ -266,5 +269,4 @@ class OverlapPreservingBucketer:
             preserve_node_ordering,
         )
 
-        if torch._inductor.config.test_configs.aten_fx_overlap_insert_overlap_deps:
-            preserve_node_ordering(self.graph, additional_deps)
+        preserve_node_ordering(self.graph, additional_deps)

--- a/torch/_inductor/fx_passes/overlap_preserving_bucketer.py
+++ b/torch/_inductor/fx_passes/overlap_preserving_bucketer.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 
-import torch
 import torch.fx as fx
 from torch._inductor.augmented_graph_helper import AugmentedGraphHelper
 from torch._inductor.fx_passes.bucketing import (

--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -902,11 +902,11 @@ def schedule_overlap_bucketing(
         compute_overlap_multipler: Scale factor for compute time used to hide collectives. This can be used
             to address over or under aggressive overlapping.
         max_coll_distance: Maximum node distance for overlap or bucketing. Mostly intended to reduce compile time.
-        custom_runtime_estimation: Custom runtime estimation function that estimates runtime in ms for an fx node. If None, uses default estimations.
-            Today, this is limited to collectives and compute nodes.
-        enable_preserving_bucketing: Enable overlap preserving bucketing. Note: memory tracking within bucketing still WIP.
-        insert_overlap_deps: Insert overlap dependencies using control deps operator. This should only be used if the graph is being compiled with inductor,
-            or to preserve overlap for subsequent graph passes before removal of control deps prior to execution.
+        custom_runtime_estimation: Custom runtime estimation function that estimates runtime in ms for an fx node.
+            If None, uses default estimations. This is currently limited to collectives and compute nodes.
+        enable_preserving_bucketing: Enable overlap preserving bucketing. Note: memory use within bucketing still WIP.
+        insert_overlap_deps: Insert overlap dependencies using control deps operator. This should only be used if
+            graph is being compiled with inductor, or for subsequent passes before removing the ops prior to execution.
     """
     from torch._inductor.config import aten_distributed_optimizations as aten_dist_opts
 

--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -43,7 +43,8 @@ def get_group_name(n: fx.Node) -> str:
 
 
 def get_custom_estimation(
-    n: fx.Node, custom_runtime_estimation: Callable[[fx.Node], float | None] | None = None
+    n: fx.Node,
+    custom_runtime_estimation: Callable[[fx.Node], float | None] | None = None,
 ) -> float | None:
     if custom_runtime_estimation is None:
         return None
@@ -105,7 +106,8 @@ def get_collective_do_bench() -> Callable[[Callable[[], Any]], float]:
 
 
 def benchmark_node_with_cache_key(
-    n: fx.Node, custom_runtime_estimation: Callable[[fx.Node], float | None] | None = None
+    n: fx.Node,
+    custom_runtime_estimation: Callable[[fx.Node], float | None] | None = None,
 ) -> tuple[float, str | None]:
     assert is_compute_node(n)
 
@@ -157,7 +159,10 @@ def benchmark_node_with_cache_key(
         return out, key
 
 
-def benchmark_node(n: fx.Node, custom_runtime_estimation: Callable[[fx.Node], float | None] | None = None) -> float:
+def benchmark_node(
+    n: fx.Node,
+    custom_runtime_estimation: Callable[[fx.Node], float | None] | None = None,
+) -> float:
     return benchmark_node_with_cache_key(n, custom_runtime_estimation)[0]
 
 
@@ -310,7 +315,9 @@ class OverlapScheduler:
         for node in self.nodes:
             if is_wait_tensor(node):
                 start = node.args[0]
-                coll_time_ms = estimate_collective_time(start, custom_runtime_estimation=self.custom_runtime_estimation)
+                coll_time_ms = estimate_collective_time(
+                    start, custom_runtime_estimation=self.custom_runtime_estimation
+                )
 
                 info = CollectiveInfo(
                     start_node=start,
@@ -535,7 +542,9 @@ class OverlapScheduler:
         info = self.collective_info[node]
 
         if self.should_assume_bucketed(node):
-            latency = estimate_collective_time(node, 0, custom_runtime_estimation=self.custom_runtime_estimation)
+            latency = estimate_collective_time(
+                node, 0, custom_runtime_estimation=self.custom_runtime_estimation
+            )
             assert latency <= info.exposed_time_ms
             info.exposed_time_ms = info.exposed_time_ms - latency
 

--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -890,7 +890,7 @@ def schedule_overlap_bucketing(
     max_in_flight_gb: float = 2.0,
     max_compute_pre_fetch: int = 5,
     collective_bucketing: bool = False,
-    insert_overlap_deps: bool = True,
+    insert_overlap_deps: bool = False,
     compute_overlap_multipler: float = 1.0,
     max_coll_distance: int = 1000,
     custom_runtime_estimation: Callable[[fx.Node], float | None] | None = None,

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -284,7 +284,6 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
         # by default, insert overlap deps within inductor
         kwargs: dict[str, object] = {"insert_overlap_deps": True}
 
-        # Read config values, only pass non-None values to use function defaults
         config_keys = (
             "collective_bucketing",
             "max_compute_pre_fetch",
@@ -296,7 +295,7 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
                 kwargs[key] = val
 
         GraphTransformObserver(gm, "overlap_scheduling").apply_graph_pass(
-            lambda graph: schedule_overlap_bucketing(graph.owning_module, **kwargs)
+            lambda graph: schedule_overlap_bucketing(graph.owning_module, **kwargs)  # type: ignore[arg-type]
         )
 
     # Keep these last, since they introduce mutation. Look at


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #166130

- pass important configs values directly into the class 
- migrate those configs from `test_configs` to another class 
- add an (off by default) config to enable inside inductor, instead of requiring a custom post pass

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben