### PR TITLE
Unable to build dpp_dataset_debug due to fbcode//glass/engine\:graph_engine_factory

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -27,6 +27,7 @@
 #include <torch/csrc/distributed/c10d/NanCheck.hpp>
 #include <torch/csrc/distributed/c10d/ParamCommsUtils.hpp>
 #include <torch/csrc/distributed/c10d/PrefixStore.hpp>
+#include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
 #include <torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp>
 #include <torch/csrc/distributed/c10d/TraceUtils.h>
 #include <torch/csrc/distributed/c10d/Utils.hpp>


### PR DESCRIPTION
Summary:
We are getting build failure for dpp_dataset_debug due to graph_engine_factory.

```sh
[rajeevdsingh@devvm16396.vll0 /data/users/rajeevdsingh/fbsource/fbcode (8153ff1c88|remote/master)]$ buck2 build mode/opt koski/tools/dpp_dataset_debug:dpp_dataset_debug
2025-10-23T17:32:41.356488Z  WARN buck2_interpreter_for_build::interpreter::functions::warning: ptxas 12.8 is not available on platform platform010-aarch64-compat
2025-10-23T17:32:41.356540Z  WARN buck2_interpreter_for_build::interpreter::functions::warning: ptxas 12.8 is not available on platform platform010-compat
2025-10-23T17:32:41.356547Z  WARN buck2_interpreter_for_build::interpreter::functions::warning: ptxas 12.8 is not available on platform platform010-libcxx
Action failed: fbcode//glass/engine:graph_engine_factory (cxx_compile graph_engine_factory.cc)
Local command returned non-zero exit code 1
Reproduce locally: `env -- 'BUCK_SCRATCH_PATH=buck-out/v2/tmp/fbcode/11819271bfc5867c/cxx_compile/graph_engine_factory.c ...<omitted>... code/glass/engine/__graph_engine_factory__/output_artifacts/__objects__/graph_engine_factory.cc.dwo' (run `buck2 log what-failed` to get the full command)`
stdout:
stderr:
In file included from fbcode/glass/engine/graph_engine_factory.cc:4:
In file included from buck-out/v2/gen/fbcode/glass/engine/__glass_engine__/3fa0f225e1847aa8/buck-headers/glass/engine/glass_engine.h:14:
In file included from buck-out/v2/gen/fbcode/glass/graph_engine/apps/__constrainedlouvain__/c01e01633e4e6b9c/buck-headers/glass/graph_engine/apps/ConstrainedLouvain.h:12:
In file included from buck-out/v2/gen/fbcode/glass/graph_engine/apps/__louvaincluster__/5f2eb2dd7e366b1c/buck-headers/glass/graph_engine/apps/Louvain.h:43:
In file included from ./xplat/caffe2/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp:24:
In file included from fbcode/caffe2/torch/csrc/distributed/c10d/logger.hpp:4:
In file included from fbcode/caffe2/torch/csrc/distributed/c10d/reducer.hpp:17:
fbcode/caffe2/torch/csrc/distributed/c10d/ProcessGroup.hpp:21:16: error: redefinition of 'kProcessGroupDefaultTimeout'
   21 | constexpr auto kProcessGroupDefaultTimeout =
      |                ^
./xplat/caffe2/torch/csrc/distributed/c10d/ProcessGroup.hpp:21:16: note: previous definition is here
   21 | constexpr auto kProcessGroupDefaultTimeout =
      |                ^
In file included from fbcode/glass/engine/graph_engine_factory.cc:4:
In file included from buck-out/v2/gen/fbcode/glass/engine/__glass_engine__/3fa0f225e1847aa8/buck-headers/glass/engine/glass_engine.h:14:
In file included from buck-out/v2/gen/fbcode/glass/graph_engine/apps/__constrainedlouvain__/c01e01633e4e6b9c/buck-headers/glass/graph_engine/apps/ConstrainedLouvain.h:12:
In file included from buck-out/v2/gen/fbcode/glass/graph_engine/apps/__louvaincluster__/5f2eb2dd7e366b1c/buck-headers/glass/graph_engine/apps/Louvain.h:43:
In file included from ./xplat/caffe2/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp:24:
In file included from fbcode/caffe2/torch/csrc/distributed/c10d/logger.hpp:4:
In file included from fbcode/caffe2/torch/csrc/distributed/c10d/reducer.hpp:17:
fbcode/caffe2/torch/csrc/distributed/c10d/ProcessGroup.hpp:71:17: error: redefinition of 'ProcessGroup'
   71 | class TORCH_API ProcessGroup : public torch::CustomClassHolder {
      |                 ^
./xplat/caffe2/torch/csrc/distributed/c10d/ProcessGroup.hpp:71:17: note: previous definition is here
   71 | class TORCH_API ProcessGroup : public torch::CustomClassHolder {
      |                 ^
2 errors generated.
[cxx_compiler_error] fbcode/caffe2/torch/csrc/distributed/c10d/ProcessGroup.hpp:21:16 e: redefinition of 'kProcessGroupDefaultTimeout'
[cxx_compiler_error] fbcode/caffe2/torch/csrc/distributed/c10d/ProcessGroup.hpp:71:17 e: redefinition of 'ProcessGroup'
Buck UI: https://www.internalfb.com/buck2/79310b74-9116-4266-9921-a1b183fe9ed9
Network: Up: 1.4MiB  Down: 1.2GiB  (reSessionID-7d9eec75-7ccb-4e13-9568-a40358e6d033)
Loading targets.   Remaining      0/8351                                                                                               123865 dirs read, 1591587 targets declared
Analyzing targets. Remaining      0/83283                                                                                              2759693 actions, 3954817 artifacts declared
Executing actions. Remaining      0/425913                                                                                             189:15:45.2s exec time total
Command: build.    Finished 19 local, 305 remote, 162188 cache (99% hit)                                                               186:37:07.6s exec time cached (98%)                                  
Time elapsed: 3:37.6s
BUILD FAILED
Failed to build 'fbcode//glass/engine:graph_engine_factory (cfg:opt-linux-x86_64-fbcode-platform010-clang19-no-san#71ea4657f8ae610e)'
[rajeevdsingh@devvm16396.vll0 /data/users/rajeevdsingh/fbsource/fbcode (8153ff1c88|remote/master)]$ 

```

Test Plan:
```sh
[rajeevdsingh@devvm16396.vll0 /data/users/rajeevdsingh/fbsource/fbcode (8153ff1c88|remote/master)]$ buck2 build mode/opt koski/tools/dpp_dataset_debug:dpp_dataset_debug
File changed: fbcode//caffe2/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
Buck UI: https://www.internalfb.com/buck2/63d06dad-a21f-444a-8b93-52b6b3050287
Network: Up: 68KiB  Down: 17GiB  (reSessionID-c270204a-75e7-4f90-833f-598a67f920fd)
Executing actions. Remaining     0/22                                                                                                  5:02.3s exec time total
Command: build.    Finished 4 local, 15 cache (79% hit)                                                                                3:45.0s exec time cached (74%)                                       
Time elapsed: 3:31.6s
BUILD SUCCEEDED
[rajeevdsingh@devvm16396.vll0 /data/users/rajeevdsingh/fbsource/fbcode (8e66740438)]$ 

```

Reviewed By: Hadi-Ayache

Differential Revision: D85357695




cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci