### PR TITLE
[DebugMode] dispatch call hooks

### DIFF
--- a/test/distributed/tensor/debug/test_debug_mode.py
+++ b/test/distributed/tensor/debug/test_debug_mode.py
@@ -73,11 +73,13 @@ class TestDTensorDebugMode(TestCase):
 
         # check numerical equivalence
         self.assertTrue(torch.equal(eager_out, compiled_out))
-        sum_op = next(iter(
-            op
-            for op in debug_mode.operators
-            if isinstance(op, _OpCall) and str(op.op) == "aten::sum"
-        ))
+        sum_op = next(
+            iter(
+                op
+                for op in debug_mode.operators
+                if isinstance(op, _OpCall) and str(op.op) == "aten::sum"
+            )
+        )
         self.assertTrue(torch.equal(sum_op.record["output"], eager_out.to_local()))
 
     def test_debug_string_inside_context(self):

--- a/test/distributed/tensor/debug/test_debug_mode.py
+++ b/test/distributed/tensor/debug/test_debug_mode.py
@@ -73,11 +73,11 @@ class TestDTensorDebugMode(TestCase):
 
         # check numerical equivalence
         self.assertTrue(torch.equal(eager_out, compiled_out))
-        sum_op = [
+        sum_op = next(iter(
             op
             for op in debug_mode.operators
             if isinstance(op, _OpCall) and str(op.op) == "aten::sum"
-        ][0]
+        ))
         self.assertTrue(torch.equal(sum_op.record["output"], eager_out.to_local()))
 
     def test_debug_string_inside_context(self):

--- a/torch/utils/_debug_mode.py
+++ b/torch/utils/_debug_mode.py
@@ -1,6 +1,6 @@
 # mypy: allow-untyped-defs
 import contextlib
-from typing import Optional
+from typing import Any, Callable, Optional
 
 import torch
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
@@ -16,6 +16,8 @@ from torch.utils._pytree import tree_map
 __all__ = ["DebugMode", "get_active_debug_mode"]
 
 REDISTRIBUTE_FUNC = "redistribute_input"
+_DISPATCH_RECORD_HOOKS: list[Callable] = []
+_DISPATCH_LOG_HOOKS: list[Callable] = []
 
 
 def _stringify_shape(shape) -> str:
@@ -80,8 +82,17 @@ def _arg_to_str(arg, attributes) -> str:
 class _DebugCall:
     """Base class for tracking operator calls in DebugMode"""
 
-    def __init__(self, call_depth: int):
+    def __init__(
+        self,
+        call_depth: int,
+        record: Optional[dict[str, Any]] = None,
+        log: Optional[dict[str, Any]] = None,
+    ):
         self.call_depth = call_depth
+
+        # results from dispatch hooks
+        self.record = record
+        self.log = log
 
     def render(self, attributes: list[str]) -> str:
         raise NotImplementedError("Subclasses must implement string render()")
@@ -113,7 +124,11 @@ class _OpCall(_DebugCall):
         else:
             op_name = str(self.op)
 
-        return f"{op_name}({args_str}{kwargs_str})"
+        base_str = f"{op_name}({args_str}{kwargs_str})"
+
+        if self.log:
+            base_str += f"  # {self.log}"
+        return base_str
 
     def __iter__(self):
         # for BC; tuple(self) returns (op, args, kwargs, call_depth)
@@ -157,6 +172,33 @@ class _RedistributeCall(_DebugCall):
 
     def __repr__(self) -> str:
         return self.render([])
+
+
+def _run_hook(hook, *args):
+    out = hook(*args)
+    assert out is None or isinstance(out, dict)
+    return out
+
+
+def _run_dispatch_hooks(call: _DebugCall, func, types, args, kwargs, result) -> None:
+    global _DISPATCH_RECORD_HOOKS, _DISPATCH_LOG_HOOKS
+    if _DISPATCH_RECORD_HOOKS:
+        record = {}
+        for hook in _DISPATCH_RECORD_HOOKS:
+            hook_out = _run_hook(hook, func, types, args, kwargs, result)
+            if hook_out is not None:
+                record.update(hook_out)
+        if record:
+            call.record = record
+
+    if _DISPATCH_LOG_HOOKS:
+        log = {}
+        for hook in _DISPATCH_LOG_HOOKS:
+            hook_out = _run_hook(hook, func, types, args, kwargs, result)
+            if hook_out is not None:
+                log.update(hook_out)
+        if log:
+            call.log = log
 
 
 class DebugMode(TorchDispatchMode):
@@ -204,22 +246,26 @@ class DebugMode(TorchDispatchMode):
             kwargs = {}
 
         # Record the operation with its call depth
+        call = None
         if torch.distributed.tensor.DTensor in types:
-            self.operators.append(_OpCall(func, args, kwargs, self.call_depth))
+            call = _OpCall(func, args, kwargs, self.call_depth)
+            self.operators.append(call)
             return NotImplemented
         elif FakeTensor in types or isinstance(
             _get_current_dispatch_mode(), FakeTensorMode
         ):
             if self.record_faketensor:
                 if func != torch.ops.prim.device.default:
-                    self.operators.append(
-                        _OpCall(func, args, kwargs, self.call_depth + 1)
-                    )
+                    call = _OpCall(func, args, kwargs, self.call_depth + 1)
+                    self.operators.append(call)
         elif len(types) == 0:
             if self.record_realtensor:
-                self.operators.append(_OpCall(func, args, kwargs, self.call_depth + 1))
+                call = _OpCall(func, args, kwargs, self.call_depth + 1)
+                self.operators.append(call)
 
         result = func(*args, **kwargs)
+        if call:
+            _run_dispatch_hooks(call, func, types, args, kwargs, result)
 
         return result
 
@@ -270,6 +316,39 @@ class DebugMode(TorchDispatchMode):
                 for op in self.operators
             )
         return result
+
+    @staticmethod
+    @contextlib.contextmanager
+    def dispatch_hooks(
+        record_hook: Optional[Callable] = None,
+        log_hook: Optional[Callable] = None,
+    ):
+        global _DISPATCH_RECORD_HOOKS, _DISPATCH_LOG_HOOKS
+
+        if record_hook:
+            _DISPATCH_RECORD_HOOKS.append(record_hook)
+        if log_hook:
+            _DISPATCH_LOG_HOOKS.append(log_hook)
+        try:
+            yield
+        finally:
+            if record_hook:
+                _DISPATCH_RECORD_HOOKS.pop()
+            if log_hook:
+                _DISPATCH_LOG_HOOKS.pop()
+
+    @staticmethod
+    @contextlib.contextmanager
+    def record_outputs():
+        def dispatch_hook(func, types, args, kwargs, result):
+            with torch._C._DisablePythonDispatcher():
+                out = tree_map(
+                    lambda x: x.clone() if isinstance(x, torch.Tensor) else x, result
+                )
+            return {"output": out}
+
+        with DebugMode.dispatch_hooks(record_hook=dispatch_hook):
+            yield
 
 
 def get_active_debug_mode() -> Optional[DebugMode]:


### PR DESCRIPTION
Adds customizable hooks on `__torch_dispatch__` calls for logging/recording.

Recording hooks store the hook outputs for each call at `debug_mode.operators[*].record`
```python
with DebugMode() as debug_mode, DebugMode.dispatch_hooks(record_hook = some_func):
    # some compute    
    ...
```

Logging hooks annotate the string dump:
```python
with DebugMode() as debug_mode, DebugMode.dispatch_hooks(log_hook = some_func):
    ...
```

e.g. string dump with a tensor hashing hook, for numerical equivalence (from the Observer): https://gist.github.com/pianpwk/c629446d5fdaac3d00657787d6701c91
```
eager:

aten::mm(dt: f32[8, 8]| S(0), dt: f32[8, 32]| S(0))
  redistribute_input(1, S(0) -> R)
    redistribute_input(t: f32[1, 32], trace: S(0)->R)
      _c10d_functional::all_gather_into_tensor(t: f32[1, 32], 8, 0)  # {'hash': 204.8783062621951}
      _c10d_functional::wait_tensor(t: f32[8, 32])  # {'hash': 204.8783062621951}
  aten::mm(t: f32[1, 8], t: f32[8, 32])  # {'hash': 12.014171155635267}


compile(backend="aot_eager"):

aten::sum(dt: f32[8, 32]| S(0))
  aten::sum(t: f32[1, 32])  # {'hash': 3.2215590476989746}
  _c10d_functional::all_gather_into_tensor(t: f32[1, 32], 8, 0)  # {'hash': 204.8783062621951}
  _c10d_functional::wait_tensor(t: f32[8, 32])  # {'hash': 204.8783062621951}
  aten::mm(t: f32[1, 8], t: f32[8, 32])  # {'hash': 12.014171155635267}
  aten::sum(t: f32[1, 32])  # {'hash': 3.2215590476989746}
  aten::t(t: f32[1, 8])  # {'hash': 3.7167285680770874}
  aten::detach(t: f32[8, 1])  # {'hash': 3.7167285680770874}
```

Adds a default hook `record_outputs`.

Another example for logging per-op memory usage: https://gist.github.com/pianpwk/372082bf29467aa4aa25cb26dee24aea


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci