### PR TITLE
[Inductor-FX] Don't flatten constant args

### DIFF
--- a/test/inductor/test_fxir_backend.py
+++ b/test/inductor/test_fxir_backend.py
@@ -761,6 +761,43 @@ class FxirTestCase(InductorTestCase):
         args = [torch.rand([4, 4, 4, 4], device=self.device)]
         self._compile_and_check(foo, args, expected_num_triton_kernels=0)
 
+    def test_fallback_tuple_constant_arg(self):
+        """
+        Test a fallback op with tuple constant argument.
+        Check that tuple arguments are not flattened during codegen.
+        """
+
+        def foo(x):
+            # permute with a tuple argument
+            return torch.permute(x, (0, 2, 1))
+
+        # Use complex64 to force permute to become a fallback op
+        args = [torch.randn(2, 3, 4, dtype=torch.complex64, device=self.device)]
+
+        (gm,) = self._compile_and_check(foo, args, expected_num_triton_kernels=0)
+
+        # Check for the fallback kernel with permute
+        num_fallback = self._count_ops(gm, torch.ops.aten.permute.default)
+        self.assertEqual(num_fallback, 1)
+
+        # Verify the permute node has the correct tuple argument
+        permute_node = next(
+            iter(
+                gm.graph.find_nodes(
+                    op="call_function", target=torch.ops.aten.permute.default
+                )
+            )
+        )
+
+        # The second argument should be the permutation (0, 2, 1)
+        # Check that it's not flattened
+        perm_arg = permute_node.args[1]
+        self.assertIsInstance(
+            perm_arg, list, "Permutation argument should not be flattened"
+        )
+        self.assertEqual(len(perm_arg), 3)
+        self.assertEqual(tuple(perm_arg), (0, 2, 1))
+
 
 @instantiate_parametrized_tests
 class AOTFxirTestCase(InductorTestCase):

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -1112,11 +1112,15 @@ class FxConverter:
         # Get FX nodes corresponding to the call args.
         assert ir.is_node_sequence(kernel.inputs)
         tensor_nodes = tuple(self._generate_buffer(arg) for arg in kernel.inputs)
-        args = tensor_nodes + tuple(kernel.constant_args)
+        if hasattr(kernel, "unflatten_args"):
+            args, _ = kernel.unflatten_args(tensor_nodes, kernel.constant_args)
+        else:
+            args = tensor_nodes + tuple(kernel.constant_args)
 
         # Get the result buffer.
         # Some kernels write to a pre-existing output tensor via the "out" kwarg.
         kwargs = kernel.kwargs.copy()
+
         result_buffer: Optional[str] = None
         if isinstance(kernel, ir.ExternKernelOut):
             kwargs["out"] = self.buffer_to_node[out_ir_node.codegen_reference()]


### PR DESCRIPTION
Summary: Fallback kernels are created with flattened constant args and an `unflatten` utility to unflatten them when needed. Apply it in FXConverter to preserve the original structure

Test Plan: added new CI tests

Differential Revision: D85347589




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben