### PR TITLE
Remove all labels from s390x workflows except for ciflow/s390

### DIFF
--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -264,7 +264,6 @@ S390X_BINARY_BUILD_WORKFLOWS = [
             OperatingSystem.LINUX_S390X
         ),
         ciflow_config=CIFlowConfig(
-            labels={LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_WHEEL},
             isolated_workflow=True,
         ),
     ),

--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -17,9 +17,11 @@ on:
       - !{{ branches }}
     {%- if branches == "nightly" %}
     tags:
+        {%- if "s390x" not in build_environment %}
       # NOTE: Binary build pipelines should only get triggered on release candidate builds
       # Release candidate tags look like: v1.11.0-rc1
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+        {%- endif %}
     {%- endif %}
 {%- for label in ciflow_config.labels | sort %}
     {%- if loop.first and branches != "nightly" %}

--- a/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
@@ -11,11 +11,6 @@ on:
     branches:
       - nightly
     tags:
-      # NOTE: Binary build pipelines should only get triggered on release candidate builds
-      # Release candidate tags look like: v1.11.0-rc1
-      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
-      - 'ciflow/binaries/*'
-      - 'ciflow/binaries_wheel/*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/s390x-periodic.yml
+++ b/.github/workflows/s390x-periodic.yml
@@ -7,7 +7,6 @@ on:
     - cron: 29 8 * * *  # about 1:29am PDT, for mem leak check and rerun disabled tests
   push:
     tags:
-      - ciflow/periodic/*
       - ciflow/s390/*
   workflow_dispatch:
 


### PR DESCRIPTION
s390x-periodic workflow: remove ciflow/periodic label.

Update workflow generation script and template to remove all tags from s390x nightly build workflow.

Regenerate workflows.