### PR TITLE
Remove likely unnecessary _EXPAND trick for non-windows in HIDDEN_NAMESPACE_BEGIN

### DIFF
--- a/torch/headeronly/macros/Macros.h
+++ b/torch/headeronly/macros/Macros.h
@@ -619,10 +619,7 @@ __host__ __device__
 // loading custom extensions compiled against different libtorch
 // versions where these APIs may have changed.
 
-// Helper macros for nested namespace expansion
-#define _EXPAND(...) __VA_ARGS__
-
-// Macros to handle 1-3 hidden namespace levels when not windows
+// Helper macros to handle 1-3 hidden namespace levels when not windows
 #define _HIDDEN_NS_GET_MACRO(_1, _2, _3, NAME, ...) NAME
 #define _HIDDEN_NS_1(n1) namespace n1 __attribute__((visibility("hidden"))) {
 #define _HIDDEN_NS_2(n1, n2) \
@@ -632,13 +629,15 @@ __host__ __device__
   namespace n1::n2 {             \
   namespace n3 __attribute__((visibility("hidden"))) {
 
-// Macros to close namespaces when not windows
+// Helper macros to close namespaces when not windows
 #define _HIDDEN_NS_END_1(n1) }
 #define _HIDDEN_NS_END_N(n1, ...) \
   }                               \
   }
 
-// Macros to join strs with :: (for win, where symbols are hidden by default)
+// Helper macros to join strs with :: (for win, where symbols are hidden by
+// default)
+#define _EXPAND(...) __VA_ARGS__
 #define _JOIN_GET_MACRO(_1, _2, _3, NAME, ...) NAME
 #define _JOIN_NS1(a) a
 #define _JOIN_NS2(a, b) a::b
@@ -647,8 +646,8 @@ __host__ __device__
 #if !defined(HIDDEN_NAMESPACE_BEGIN)
 #if defined(__GNUG__) && !defined(_WIN32)
 #define HIDDEN_NAMESPACE_BEGIN(...) \
-  _EXPAND(_HIDDEN_NS_GET_MACRO(     \
-      __VA_ARGS__, _HIDDEN_NS_3, _HIDDEN_NS_2, _HIDDEN_NS_1)(__VA_ARGS__))
+  _HIDDEN_NS_GET_MACRO(             \
+      __VA_ARGS__, _HIDDEN_NS_3, _HIDDEN_NS_2, _HIDDEN_NS_1)(__VA_ARGS__)
 #else
 #define HIDDEN_NAMESPACE_BEGIN(...)  \
   namespace _EXPAND(_JOIN_GET_MACRO( \
@@ -659,9 +658,9 @@ __host__ __device__
 #if !defined(HIDDEN_NAMESPACE_END)
 #if defined(__GNUG__) && !defined(_WIN32)
 #define HIDDEN_NAMESPACE_END(...)                                         \
-  _EXPAND(_HIDDEN_NS_GET_MACRO(                                           \
+  _HIDDEN_NS_GET_MACRO(                                                   \
       __VA_ARGS__, _HIDDEN_NS_END_N, _HIDDEN_NS_END_N, _HIDDEN_NS_END_1)( \
-      __VA_ARGS__))
+      __VA_ARGS__)
 #else
 #define HIDDEN_NAMESPACE_END(...) }
 #endif


### PR DESCRIPTION
I've learned that the EXPAND trick is needed mostly for an MSVC quirk to properly expand arguments. I tested on Linux locally and suspect that we don't need the _EXPAND for non-windows.  This PR is BE to minimalize what we need and remove what we don't, but I'm also okay not landing this if @malfet tells me that this quirk goes beyond MSVC.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #166203
* #166079
* #166078
* #166077
* #166076

