### PR TITLE
[triton][nativert] Add num_cpu_threads for triton-cpu

### DIFF
--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -739,11 +739,7 @@ class GraphModuleSerializer(metaclass=Final):
                 output_keys = meta_val.keys()
                 output_indices = []
 
-                constexpr_keys = set()
-                for p in kernel.params:
-                    if p.is_constexpr:
-                        constexpr_keys.add(p.name)
-
+                constexpr_keys = {p.name for p in kernel.params if p.is_constexpr}
                 found_constexpr = False
                 args_new = ()
                 i = 0
@@ -773,6 +769,10 @@ class GraphModuleSerializer(metaclass=Final):
                     "output_indices": output_indices,
                     "num_warps": kernel_cache_metadata.num_warps,
                 }
+                if hasattr(kernel_cache_metadata, "num_cpu_threads"):
+                    kwargs_new["num_cpu_threads"] = (
+                        kernel_cache_metadata.num_cpu_threads
+                    )
 
                 if hasattr(kernel_cache_metadata, "shared"):
                     kwargs_new["shared_memory_bytes"] = kernel_cache_metadata.shared

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -1729,6 +1729,7 @@ class TritonHOPifier:
             "num_ctas",
             "num_consumer_groups",
             "num_buffers_warp_spec",
+            "num_cpu_threads",
         }
 
         # move special config names to configs out of kwargs

--- a/torch/nativert/executor/triton/CpuTritonKernelManager.cpp
+++ b/torch/nativert/executor/triton/CpuTritonKernelManager.cpp
@@ -39,7 +39,7 @@ char* _dlerror() {
 
 typedef void* kernel_ptr_t;
 typedef void (
-    *launcher_ptr_t)(uint32_t, uint32_t, uint32_t, void**, kernel_ptr_t);
+    *launcher_ptr_t)(uint32_t, uint32_t, uint32_t, int, void**, kernel_ptr_t);
 
 struct DlcloseDeleter {
   void operator()(void* p) const {
@@ -110,8 +110,8 @@ void CpuTritonKernelManager::load() {
       ": ",
       _dlerror());
 
-  launcher_fn_ =
-      reinterpret_cast<launcher_ptr_t>(_dlsym(launcher_handle_.get(), "run"));
+  launcher_fn_ = reinterpret_cast<launcher_ptr_t>(
+      _dlsym(launcher_handle_.get(), "run_from_nativert"));
   TORCH_CHECK(launcher_fn_ != nullptr, "could not dlsym run: ", _dlerror());
 }
 
@@ -123,6 +123,7 @@ void CpuTritonKernelManager::launch(
       launch_params.grid_dims.x,
       launch_params.grid_dims.y,
       launch_params.grid_dims.z,
+      launch_params.num_cpu_threads,
       args,
       kernel_fn_);
 }

--- a/torch/nativert/executor/triton/TritonKernelManager.h
+++ b/torch/nativert/executor/triton/TritonKernelManager.h
@@ -17,6 +17,10 @@ struct GridDims {
 };
 
 struct LaunchParams {
+  // CPU params
+  int num_cpu_threads = 0; // 0 means use all available threads
+  // GPU params
+  // TODO: Add more GPU autotuning parameters
   int num_warps = 4;
   int shared_memory_bytes = 0;
   GridDims grid_dims;

--- a/torch/nativert/kernels/TritonKernel.cpp
+++ b/torch/nativert/kernels/TritonKernel.cpp
@@ -59,6 +59,12 @@ TritonKernel::TritonKernel(
           static_cast<int>(grid[0]),
           static_cast<int>(grid[1]),
           static_cast<int>(grid[2]));
+    } else if (attr.name == "num_cpu_threads") {
+      if (const int num_cpu_threads =
+              static_cast<int>(std::get<int64_t>(attr.value));
+          num_cpu_threads >= 0) {
+        launch_params_.num_cpu_threads = num_cpu_threads;
+      }
     } else if (attr.name == "num_warps") {
       if (const int num_warps = static_cast<int>(std::get<int64_t>(attr.value));
           num_warps > 0) {


### PR DESCRIPTION
Summary:
The new triton-cpu has `num_cpu_threads` like `num_warps`, which are auto-tunable. This diff adds `num_cpu_threads` to NativeRT.

Differential Revision: D85515240


