### PR TITLE
[Inductor] Make combo kernel MAX_NUM_ARGS configurable

### DIFF
--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -172,15 +172,13 @@ class PartitionState:
 
 
 class ComboKernel(Kernel):
-    MAX_NUM_ARGS = 250  # number where I would no longer get triton errors
-
     @staticmethod
     def _update_partition(
         partition_state: PartitionState,
         node_rw_count: int,
         node_info: BaseSchedulerNode,
     ) -> None:
-        if partition_state.cur_count + node_rw_count > ComboKernel.MAX_NUM_ARGS:
+        if partition_state.cur_count + node_rw_count > config.combo_kernel_max_num_args:
             partition_state.partitions.append(partition_state.cur_partition)
             partition_state.cur_partition = [node_info]
             partition_state.cur_count = node_rw_count

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -745,6 +745,8 @@ combo_kernels_autotune = 1
 combo_kernel_allow_mixed_sizes = 1
 # Enable dynamic shapes for foreach kernels
 combo_kernel_foreach_dynamic_shapes = True
+# Maximum number of arguments (read/write buffers) allowed in a combo kernel
+combo_kernel_max_num_args = 250
 
 # constant folding on the joint graph
 joint_graph_constant_folding = True


### PR DESCRIPTION
The MAX_NUM_ARGS of ComboKernel is currently a fixed number. We need to tune this number to avoid large fusion for MTIA, thus making it configurable.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #166276
* #166275
* __->__ #166274

Differential Revision: [D85509352](https://our.internmc.facebook.com/intern/diff/D85509352/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben