### PR TITLE
Remove not needed code path. 

### DIFF
--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -1781,14 +1781,14 @@ def _aot_stage2b_bw_compile(
                     # tensor which is wrong.
 
                     ph_size = ph_arg.size()
-                    # pyrefly: ignore  # bad-argument-type
-                    if len(ph_size) == 0 and len(real_stride) > 0:
-                        # Fix for 0-dimensional tensors: When a tensor becomes 0-d
-                        # (e.g., via squeeze), its stride should be () not (1,).
-                        # This mismatch can occur when dynamic shape operations produce
-                        # tensors that are later squeezed to 0-d. The stride metadata
-                        # may get preserved causing a dimension mismatch (#164814)
-                        real_stride = ()
+                    # # pyrefly: ignore  # bad-argument-type
+                    # if len(ph_size) == 0 and len(real_stride) > 0:
+                    #     # Fix for 0-dimensional tensors: When a tensor becomes 0-d
+                    #     # (e.g., via squeeze), its stride should be () not (1,).
+                    #     # This mismatch can occur when dynamic shape operations produce
+                    #     # tensors that are later squeezed to 0-d. The stride metadata
+                    #     # may get preserved causing a dimension mismatch (#164814)
+                    #     real_stride = ()
 
                     # pyrefly: ignore  # bad-argument-type
                     placeholder_list[i] = ph_arg.as_strided(ph_size, real_stride)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #166278

I accepted a PR that added this code, but re-examining it now, I'm questioning the approach. It seems like we're working around an issue with the inductor generating incorrect sizes. A comment suggests it might be related to unsqueezed u0 values. Removing this code didn't cause any failures, so I'll take it out and address the root issue if it arises.
