### PR TITLE
Add input_size validation for RNN modules with clear error messages

### DIFF
--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -134,6 +134,12 @@ class RNNBase(Module):
             raise TypeError(
                 f"batch_first should be of type bool, got: {type(batch_first).__name__}"
             )
+        if not isinstance(input_size, int):
+            raise TypeError(
+                f"input_size should be of type int, got: {type(input_size).__name__}"
+            )
+        if input_size <= 0:
+            raise ValueError("input_size must be greater than zero")
         if not isinstance(hidden_size, int):
             raise TypeError(
                 f"hidden_size should be of type int, got: {type(hidden_size).__name__}"

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -3392,6 +3392,39 @@ def module_error_inputs_torch_nn_RNN_GRU(module_info, device, dtype, requires_gr
             error_type=TypeError,
             error_regex="batch_first should be of type bool, got: str"
         ),
+        # Test input_size parameter type validation
+        ErrorModuleInput(
+            ModuleInput(constructor_input=FunctionInput(3.0, 5)),
+            error_on=ModuleErrorEnum.CONSTRUCTION_ERROR,
+            error_type=TypeError,
+            error_regex="input_size should be of type int, got: float"
+        ),
+        ErrorModuleInput(
+            ModuleInput(constructor_input=FunctionInput("10", 5)),
+            error_on=ModuleErrorEnum.CONSTRUCTION_ERROR,
+            error_type=TypeError,
+            error_regex="input_size should be of type int, got: str"
+        ),
+        # Test input_size parameter value validation
+        ErrorModuleInput(
+            ModuleInput(constructor_input=FunctionInput(0, 5)),
+            error_on=ModuleErrorEnum.CONSTRUCTION_ERROR,
+            error_type=ValueError,
+            error_regex="input_size must be greater than zero"
+        ),
+        ErrorModuleInput(
+            ModuleInput(constructor_input=FunctionInput(-1, 5)),
+            error_on=ModuleErrorEnum.CONSTRUCTION_ERROR,
+            error_type=ValueError,
+            error_regex="input_size must be greater than zero"
+        ),
+        # Test hidden_size parameter type validation
+        ErrorModuleInput(
+            ModuleInput(constructor_input=FunctionInput(3, 5.0)),
+            error_on=ModuleErrorEnum.CONSTRUCTION_ERROR,
+            error_type=TypeError,
+            error_regex="hidden_size should be of type int, got: float"
+        ),
     ]
     return samples
 


### PR DESCRIPTION
Validates that input_size is an int > 0, providing clear TypeError/ValueError instead of cryptic torch.empty() errors. Applies to nn.RNN, nn.LSTM, nn.GRU.

Fixes #136936
