### PR TITLE
[BE] Fix metal compilation warnings

### DIFF
--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.h
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.h
@@ -1,4 +1,3 @@
-#pragma onces
 #include <c10/metal/common.h>
 
 template <unsigned N = c10::metal::max_ndim>

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.h
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <c10/metal/common.h>
 
 template <unsigned N = c10::metal::max_ndim>

--- a/c10/metal/utils.h
+++ b/c10/metal/utils.h
@@ -329,17 +329,17 @@ struct pair {
 };
 
 template <typename T>
-static T conj(T a) {
+inline T conj(T a) {
   return a;
 }
 
 template <>
-half2 conj(half2 a) {
+inline half2 conj(half2 a) {
   return half2(a.x, -a.y);
 }
 
 template <>
-float2 conj(float2 a) {
+inline float2 conj(float2 a) {
   return float2(a.x, -a.y);
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #166315

- Fixes `s/#pragma onces/#pragma once` typoe

All methods in the headers must be inline, otherwise one gets barrage of following warnings
```
/Users/malfet/git/pytorch/pytorch/c10/metal/utils.h:337:7: warning: unused function 'conj<half __attribute__((ext_vector_type(2)))>' [-Wunused-function]
half2 conj(half2 a) {
      ^
/Users/malfet/git/pytorch/pytorch/c10/metal/utils.h:342:8: warning: unused function 'conj<float __attribute__((ext_vector_type(2)))>' [-Wunused-function]
float2 conj(float2 a) {
       ^
2 warnings generated.
```