### PR TITLE
[DO NOT REVIEW] Inductor lite mode with CUDAGraph support

### DIFF
--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -179,6 +179,10 @@ def aot_stage1_graph_capture(
             )
         )
 
+    if maybe_subclass_meta is not None and maybe_subclass_meta.fw_metadata is not None:
+        # TODO: maybe_subclass_meta.fw_metadata.static_input_indices is wrong. This is a hack to workaround.
+        maybe_subclass_meta.fw_metadata.static_input_indices = aot_state.fw_metadata.static_input_indices
+
     return AOTGraphCapture(
         wrappers=wrappers,
         graph_module=graph,
@@ -2209,7 +2213,7 @@ def _aot_stage2b_compile_forward_or_inference(
         # Set tracing context
         if tracing_context := torch._guards.TracingContext.try_get():
             tracing_context.fw_metadata = _get_inner_meta(
-                maybe_subclass_meta, fw_metadata
+                maybe_subclass_meta, fw_metadata # maybe_subclass_meta is wrong.
             )
 
         with TracingContext.report_output_strides() as fwd_output_strides:

--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -332,6 +332,21 @@ def list_mode_options(
 
     mode_options: dict[str, dict[str, bool]] = {
         "default": {},
+        # lightweight backend
+        "light": {
+            "fallback_by_default": True,
+            "use_dce": False,
+            "allow_buffer_reuse": False,
+            "reorder_for_peak_memory": False,
+            "reorder_for_compute_comm_overlap": False,
+            "triton.reorder_for_reducing_graph_partitions": False,
+            "use_pre_grad_passes": False,
+            "use_joint_graph_passes": False,
+            "use_post_grad_passes": False,
+            "aten_distributed_optimizations.enable_overlap_scheduling": True,
+            "use_decomposition": False,
+            # "triton.cudagraphs": True,
+        },
         # enable cudagraphs
         "reduce-overhead": {
             "triton.cudagraphs": True,

--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -342,10 +342,10 @@ def list_mode_options(
             "triton.reorder_for_reducing_graph_partitions": False,
             "use_pre_grad_passes": False,
             "use_joint_graph_passes": False,
-            "use_post_grad_passes": False,
+            "use_post_grad_passes": True,
             "aten_distributed_optimizations.enable_overlap_scheduling": True,
             "use_decomposition": False,
-            # "triton.cudagraphs": True,
+            "triton.cudagraphs": True,
         },
         # enable cudagraphs
         "reduce-overhead": {

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -508,6 +508,9 @@ def _recursive_pre_grad_passes(
         log_pt2_compile_event=True,
         dynamo_compile_column_us="pre_grad_pass_time_us",
     ):
+        if not config.use_pre_grad_passes:
+            return gm
+
         add_passes = config.add_pre_grad_passes
         remove_passes = config.remove_pre_grad_passes
         for subgraph_name in _get_subgraph_names(gm):
@@ -526,6 +529,9 @@ def _recursive_joint_graph_passes(
         log_pt2_compile_event=True,
         dynamo_compile_column_us="joint_graph_pass_time_us",
     ):
+        if not config.use_joint_graph_passes:
+            return
+
         # invoke_subgraph already runs the _recursive_joint_graph_passes.  In
         # AOTAutograd, `run_joint_graph_passes_on_hops` partitions the
         # invoke_subgraph HOP before calling the partitioner on the outer graph.
@@ -544,6 +550,9 @@ def _recursive_post_grad_passes(gm: GraphModule, is_inference: bool = False) -> 
         log_pt2_compile_event=True,
         dynamo_compile_column_us="post_grad_pass_time_us",
     ):
+        if not config.use_post_grad_passes:
+            return
+
         for subgraph_name in _get_subgraph_names(gm):
             subgraph = getattr(gm, subgraph_name)
             _recursive_post_grad_passes(subgraph, is_inference)
@@ -2633,6 +2642,9 @@ def _compile_fx_main(
         decompositions = (
             decompositions if decompositions is not None else select_decomp_table()
         )
+
+        if not config.use_decomposition:
+            decompositions = None
 
         def fw_compiler_base(
             gm: GraphModule,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -546,6 +546,25 @@ max_autotune_flex_search_space: Literal["DEFAULT", "EXHAUSTIVE"] = os.environ.ge
     "TORCHINDUCTOR_MAX_AUTOTUNE_FLEX_SEARCH_SPACE", "DEFAULT"
 ).upper()  # type: ignore[assignment]
 
+
+# Fall back to ATen for all ops by default, except for fx nodes with
+# "compile_with_inductor" in node.meta["custom"]
+fallback_by_default: bool = False
+
+
+# Use dead code elimination
+use_dce: bool = True
+
+
+# Skip all decompositions when False
+use_decomposition: bool = True
+
+
+# Use fx graph passes
+use_pre_grad_passes: bool = True
+use_joint_graph_passes: bool = True
+use_post_grad_passes: bool = True
+
 # DEPRECATED. This setting is ignored.
 autotune_fallback_to_aten = False
 
@@ -1343,6 +1362,10 @@ class triton:
         env_name_force="TORCHINDUCTOR_CUDAGRAPH_OR_ERROR",
         default=False,
     )
+
+    # reorder nodes to minimize the number of graph partitions while
+    # not incurring large memory overhead
+    reorder_for_reducing_graph_partitions: bool = True
 
     # assertions on the fast path
     fast_path_cudagraph_asserts = False

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -2305,6 +2305,7 @@ class CUDAGraphTreeManager:
         ModelType,
         OutputType,
     ]:
+        print(f"mode:{mode}, num inputs:{len(inputs)}, num static inputs:{len(static_input_idxs)}, num constants:{len(constants)}, static_input_idxs:{static_input_idxs}")
         id = self.new_func_id()
         self.ids_to_stack_traces[id] = stack_traces
         self.ids_to_funcs[id] = WrappedFunction(

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -328,10 +328,11 @@ def cudagraph_partition_post_compile(
     # is cudagraphable. Non-cudagraphable ops (e.g., cpu ops) are inlined into
     # `call` function and not included in partition functions.
     cudagraphify_fns = []
-    for partition_metadata in partition_metadatas:
-        print("mutated_input_idxs: ", partition_metadata.mutated_input_idxs)
+    # TODO: remove this. only for debug
+    for i, partition_metadata in enumerate(partition_metadatas):
+        # print("mutated_input_idxs: ", partition_metadata.mutated_input_idxs)
 
-        print("static_input_idxs: ", partition_metadata.static_input_idxs)
+        print(f"post_compile. is_backward:{is_backward}, i:{i}, static_input_idxs: {partition_metadata.static_input_idxs}")
 
         cudagraphify_fn = partial(
             cudagraphify,

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -2713,6 +2713,7 @@ class Scheduler:
         if (
             torch._inductor.config.graph_partition
             and torch._inductor.config.triton.cudagraphs
+            and torch._inductor.config.triton.reorder_for_reducing_graph_partitions
         ):
             self.nodes = self.maybe_reorder_for_minimizing_partition(self.nodes)
             self.nodes = self.reorder_for_partition_with_simple_dependency(self.nodes)
@@ -3160,6 +3161,9 @@ class Scheduler:
         """
         Remove any nodes without users
         """
+        if not config.use_dce:
+            return
+
         # self.nodes is in topological order, so by iterating in reverse order
         # we have visited (and potentially removed) all users before visiting a
         # given node.

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -3861,6 +3861,14 @@ class CUDAGraphWrapperMetadata:
     # Index of the current partition.
     partition_index: int
 
+    # index of static inputs that do not need to be copied
+    static_input_idxs: list[int]
+
+    # index of mutated inputs. If a mutated input is NOT a static
+    # input, it needs to be copied after graph.replay().
+    # TODO: more doc
+    mutated_input_idxs: list[int]
+
 
 PartitionFnType = Callable[..., Any]
 CUDAGraphWrapperType = Callable[

--- a/torch/fx/passes/regional_inductor.py
+++ b/torch/fx/passes/regional_inductor.py
@@ -112,7 +112,7 @@ def _compile_submod(gm, prefix):
     return gm
 
 
-def _needs_inductor_compile(node):
+def _needs_inductor_compile(node: torch.fx.Node) -> bool:
     return (
         node.op not in ("placeholder", "output")
         and hasattr(node, "meta")


### PR DESCRIPTION
This PR tracks the inductor fallback cudagraph backend. The code changes will be landed in smaller PRs.

- [x] Cache `get_free_symbol_uses` for faster compilation time of inductor graph partition #166338
- [x] Land inductor lite mode without cudagrah #167115
- [x] Receive right static input indices when tensor subclass is used (#167127 by @bdhirsh and #166761 by @angelayi)



cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @ezyang @EikanWang @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @zhuhaozhe @blzheng @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @Lucaskabela @xmfan