### PR TITLE
Make bucketing aware of collective LIFO semantics

### DIFF
--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -106,29 +106,6 @@ def compute_ancestors(graph):
     return node_ancestors
 
 
-# @requires_accelerator_dist_backend(["nccl", "xccl"])
-# @instantiate_parametrized_tests
-# class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
-#     """
-#     Run correctness checks in multi-proc runner, mark with minimum # GPUs to run under
-#     """
-
-#     device = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
-
-#     def get_world_trs(self):
-#         return {
-#             "tag": "",
-#             "ranks": list(range(self.world_size)),
-#             "group_size": self.world_size,
-#         }
-
-#     @property
-#     def world_size(self) -> int:
-#         # hack: no matter whether we have 2 or 3 or 4 gpus, just run on 2
-#         # works around issue with skipif<2 and workers with unpredictable #s gpu
-#         return 2
-
-
 @requires_accelerator_dist_backend()
 @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
 @instantiate_parametrized_tests

--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -1,0 +1,524 @@
+# Owner(s): ["module: inductor"]
+import unittest
+
+import torch
+import torch._dynamo
+import torch._dynamo.logging
+import torch._dynamo.test_case
+import torch.distributed as dist
+import torch.fx as fx
+
+# for some reason importing functional collectives after dynamo breaks collectives handling!
+from torch._C import FileCheck
+from torch._inductor.test_case import TestCase as InductorTestCase
+from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.fx.experimental.proxy_tensor import make_fx
+from torch.testing import FileCheck
+from torch.testing._internal.common_distributed import requires_accelerator_dist_backend
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+)
+from torch.testing._internal.inductor_utils import HAS_GPU
+from torch.utils._ordered_set import OrderedSet
+
+
+# flake8: noqa: B950
+# Owner(s): ["module: inductor"]
+
+
+aten = torch.ops.aten
+
+from torch.testing._internal.common_fsdp import get_devtype
+
+
+device_type = str(get_devtype())
+
+
+import torch
+import torch._dynamo
+import torch._dynamo.logging
+import torch._dynamo.test_case
+
+
+# for some reason importing functional collectives after dynamo breaks collectives handling!
+
+
+@requires_accelerator_dist_backend(["nccl", "xccl"])
+def build_collective_info(graph, hiding_annotations):
+    """
+    Build CollectiveInfo dict from manual hiding annotations.
+
+    hiding_annotations: dict mapping collective_start -> hiding_compute_node
+    """
+    from torch._inductor.fx_passes.overlap_scheduling import CollectiveInfo
+
+    collective_info = {}
+
+    # Find all collective starts and their corresponding waits
+    start_to_wait = {}
+    for node in graph.nodes:
+        if node.op == "call_function" and "wait_tensor" in str(node.target):
+            wait_input = node.args[0]
+            if isinstance(wait_input, fx.Node):
+                start_to_wait[wait_input] = node
+
+    # Build CollectiveInfo for each collective
+    for start_node, wait_node in start_to_wait.items():
+        hiding_node = hiding_annotations.get(start_node)
+
+        # Estimate size and time
+        size_bytes = 16 * 4  # 4x4 tensor of floats
+        estimated_time_ms = 1.0  # Dummy time
+        exposed_time_ms = 0.0 if hiding_node else 1.0  # Hidden if has hiding_node
+
+        collective_info[start_node] = CollectiveInfo(
+            start_node=start_node,
+            wait_node=wait_node,
+            size_bytes=size_bytes,
+            estimated_time_ms=estimated_time_ms,
+            exposed_time_ms=exposed_time_ms,
+            hiding_node=hiding_node,
+        )
+
+    return collective_info
+
+
+def compute_ancestors(graph):
+    """Compute ancestor sets for all nodes in the graph."""
+    node_ancestors = {}
+
+    for node in graph.nodes:
+        ancestors = OrderedSet()
+        stack = list(node.all_input_nodes)
+        visited = set()
+
+        while stack:
+            current = stack.pop()
+            if current in visited:
+                continue
+            visited.add(current)
+            ancestors.add(current)
+            stack.extend(current.all_input_nodes)
+
+        node_ancestors[node] = ancestors
+
+    return node_ancestors
+
+
+# @requires_accelerator_dist_backend(["nccl", "xccl"])
+# @instantiate_parametrized_tests
+# class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
+#     """
+#     Run correctness checks in multi-proc runner, mark with minimum # GPUs to run under
+#     """
+
+#     device = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
+
+#     def get_world_trs(self):
+#         return {
+#             "tag": "",
+#             "ranks": list(range(self.world_size)),
+#             "group_size": self.world_size,
+#         }
+
+#     @property
+#     def world_size(self) -> int:
+#         # hack: no matter whether we have 2 or 3 or 4 gpus, just run on 2
+#         # works around issue with skipif<2 and workers with unpredictable #s gpu
+#         return 2
+
+
+@requires_accelerator_dist_backend()
+@unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+@instantiate_parametrized_tests
+class TestOverlapPreservingBucketing(InductorTestCase):
+    """
+    Unit tests for overlap-preserving bucketing pass.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        from torch.testing._internal.distributed.fake_pg import FakeStore
+
+        store = FakeStore()
+        dist.init_process_group(backend="fake", rank=0, world_size=2, store=store)
+        cls.device = "cuda"
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        dist.destroy_process_group()
+
+    def test_can_bucket_independent_collectives(self):
+        """
+        Test that independent collectives with separate hiding nodes CAN bucket.
+
+        Graph structure:
+        ag1_start -> ag2_start -> mm1 (hides ag1) -> mm2 (hides ag2) -> ag1_wait -> ag2_wait
+        """
+
+        def func(a, b):
+            group_name = "0"
+            group_size = 1
+
+            # Start both collectives
+            ag1 = torch.ops._c10d_functional.all_gather_into_tensor(
+                a, group_size, group_name
+            )
+            ag2 = torch.ops._c10d_functional.all_gather_into_tensor(
+                b, group_size, group_name
+            )
+
+            # Independent compute that can hide both
+            mm1 = torch.mm(a, a)
+            mm2 = torch.mm(b, b)
+
+            # Wait for both
+            ag1_out = torch.ops._c10d_functional.wait_tensor(ag1)
+            ag2_out = torch.ops._c10d_functional.wait_tensor(ag2)
+
+            return ag1_out.sum() + ag2_out.sum() + mm1.sum() + mm2.sum()
+
+        # Use fake mode to trace without executing
+        with FakeTensorMode():
+            a = torch.ones(4, 4, device=self.device)
+            b = torch.ones(4, 4, device=self.device) * 2
+
+            # Trace with make_fx
+            traced = make_fx(func)(a, b)
+
+        # Find nodes by iterating through graph
+        ag1, ag2, mm1, mm2 = None, None, None, None
+        ag1_wait, ag2_wait = None, None
+
+        for node in traced.graph.nodes:
+            if node.op == "call_function":
+                if "all_gather_into_tensor" in str(node.target):
+                    if ag1 is None:
+                        ag1 = node
+                    else:
+                        ag2 = node
+                elif "mm" in str(node.target):
+                    if mm1 is None:
+                        mm1 = node
+                    else:
+                        mm2 = node
+                elif "wait_tensor" in str(node.target):
+                    if ag1_wait is None:
+                        ag1_wait = node
+                    else:
+                        ag2_wait = node
+
+        # Manually annotate hiding relationships
+        hiding_annotations = {
+            ag1: mm1,  # mm1 hides ag1
+            ag2: mm2,  # mm2 hides ag2
+        }
+
+        # Build collective info and ancestors
+        collective_info = build_collective_info(traced.graph, hiding_annotations)
+        node_ancestors = compute_ancestors(traced.graph)
+        scheduled = OrderedSet(traced.graph.nodes)
+
+        # Run bucketing logic to find buckets (without applying them)
+        from torch._inductor.fx_passes.bucketing import bucket_key
+        from torch._inductor.fx_passes.overlap_preserving_bucketer import (
+            OverlapPreservingBucketer,
+        )
+
+        bucketer = OverlapPreservingBucketer(
+            traced.graph,
+            collective_info,
+            node_ancestors,
+            scheduled,
+        )
+
+        # Find buckets manually (same logic as bucket_collectives but without applying)
+        from collections import defaultdict
+
+        from torch._inductor.fx_passes.overlap_scheduling import get_group_name
+        from torch.utils._ordered_set import OrderedSet as OS
+
+        # Group by PG first
+        pg_collectives = defaultdict(OS)
+        for start in collective_info:
+            pg = get_group_name(start)
+            pg_collectives[pg].add(start)
+
+        all_buckets = []
+        for pg, collectives in pg_collectives.items():
+            # Populate node_to_event for this PG
+            bucketer._populate_node_to_event(pg)
+
+            # Group by bucket key within this PG
+            grouped_collectives = defaultdict(OS)
+            for start in collectives:
+                key = bucket_key(start)
+                if key is not None:
+                    grouped_collectives[key].add(start)
+
+            # Find buckets for this PG
+            for collective_group in grouped_collectives.values():
+                buckets = bucketer._find_buckets(collective_group)
+                all_buckets.extend(buckets)
+
+        # Verify: should have 1 bucket with 2 collectives
+        self.assertEqual(
+            len(all_buckets), 1, f"Expected 1 bucket, got {len(all_buckets)}"
+        )
+        self.assertEqual(
+            len(all_buckets[0].collectives),
+            2,
+            f"Expected 2 collectives in bucket, got {len(all_buckets[0].collectives)}",
+        )
+
+        # Verify both collectives are in the bucket
+        bucketed_colls = set(all_buckets[0].collectives)
+        self.assertIn(ag1, bucketed_colls)
+        self.assertIn(ag2, bucketed_colls)
+
+    def test_cant_bucket_nested_hiding_intervals(self):
+        """
+        Test that nested hiding intervals prevent bucketing.
+
+        Graph structure:
+        ag1_start -> ag2_start -> mm2 (hides ag2) -> ag2_wait -> mm1 (hides ag1) -> ag1_wait
+
+        ag2's hiding interval is nested inside ag1's hiding interval.
+        """
+
+        def func(a, b):
+            group_name = "0"
+            group_size = 1
+
+            # ag1 starts first
+            ag1 = torch.ops._c10d_functional.all_gather_into_tensor(
+                a, group_size, group_name
+            )
+
+            # ag2 starts (inside ag1's interval)
+            ag2 = torch.ops._c10d_functional.all_gather_into_tensor(
+                b, group_size, group_name
+            )
+
+            # mm2 hides ag2
+            mm2 = torch.mm(b[:2, :2], b[:2, :2])
+
+            # ag2 waits (still inside ag1's interval)
+            ag2_out = torch.ops._c10d_functional.wait_tensor(ag2)
+
+            # mm1 uses ag2's result and hides ag1
+            mm1 = torch.mm(a + ag2_out[:4, :4], a)
+
+            # ag1 waits last
+            ag1_out = torch.ops._c10d_functional.wait_tensor(ag1)
+
+            return ag1_out.sum() + ag2_out.sum() + mm1.sum() + mm2.sum()
+
+        # Use fake mode to trace without executing
+        with FakeTensorMode():
+            a = torch.ones(4, 4, device=self.device)
+            b = torch.ones(4, 4, device=self.device) * 2
+
+            # Trace with make_fx
+            traced = make_fx(func)(a, b)
+
+        # Find nodes
+        ag1, ag2, mm1, mm2 = None, None, None, None
+
+        for node in traced.graph.nodes:
+            if node.op == "call_function":
+                if "all_gather_into_tensor" in str(node.target):
+                    if ag1 is None:
+                        ag1 = node
+                    else:
+                        ag2 = node
+                elif "mm" in str(node.target):
+                    if mm2 is None:
+                        mm2 = node
+                    else:
+                        mm1 = node
+
+        # Manually annotate hiding relationships
+        hiding_annotations = {
+            ag1: mm1,  # mm1 hides ag1
+            ag2: mm2,  # mm2 hides ag2
+        }
+
+        # Build collective info and ancestors
+        collective_info = build_collective_info(traced.graph, hiding_annotations)
+        node_ancestors = compute_ancestors(traced.graph)
+        scheduled = OrderedSet(traced.graph.nodes)
+
+        # Run bucketing logic to find buckets (without applying them)
+        from torch._inductor.fx_passes.bucketing import bucket_key
+        from torch._inductor.fx_passes.overlap_preserving_bucketer import (
+            OverlapPreservingBucketer,
+        )
+
+        bucketer = OverlapPreservingBucketer(
+            traced.graph,
+            collective_info,
+            node_ancestors,
+            scheduled,
+        )
+
+        # Find buckets manually
+        from collections import defaultdict
+
+        from torch._inductor.fx_passes.overlap_scheduling import get_group_name
+        from torch.utils._ordered_set import OrderedSet as OS
+
+        # Group by PG first
+        pg_collectives = defaultdict(OS)
+        for start in collective_info:
+            pg = get_group_name(start)
+            pg_collectives[pg].add(start)
+
+        all_buckets = []
+        for pg, collectives in pg_collectives.items():
+            # Populate node_to_event for this PG
+            bucketer._populate_node_to_event(pg)
+
+            # Group by bucket key within this PG
+            grouped_collectives = defaultdict(OS)
+            for start in collectives:
+                key = bucket_key(start)
+                if key is not None:
+                    grouped_collectives[key].add(start)
+
+            # Find buckets for this PG
+            for collective_group in grouped_collectives.values():
+                buckets = bucketer._find_buckets(collective_group)
+                all_buckets.extend(buckets)
+
+        # Verify: nested hiding intervals should prevent bucketing
+        # So we should have either 0 buckets (both stay separate) or 2 buckets with 1 collective each
+        # Either way, no bucket should have 2 collectives
+        for bucket in all_buckets:
+            self.assertLess(
+                len(bucket.collectives),
+                2,
+                "Nested hiding intervals should prevent bucketing of both collectives",
+            )
+
+    @parametrize("final_mm_hidden", (True, False))
+    def test_cant_bucket_ag_with_rs_hiding_interval_between(self, final_mm_hidden):
+        """
+        Test that all_gathers can't bucket when a reduce_scatter's hiding interval is between them.
+
+        Graph structure:
+        ag1_start -> mm1 (hides ag1) -> ag1_wait ->
+        rs_start -> mm2 (hides rs) -> rs_wait ->
+
+        if final_mm_hidden:
+            ag2_start -> mm3 (hides ag2) -> ag2_wait
+
+        if final_mm_hidden:
+            Bucketing ag1 and ag2 would require moving one of them, which would break hiding relationships:
+            - Moving ag2 earlier would break ag2's hiding by mm3
+            - Moving ag1 later would break ag1's hiding by mm1
+            - The rs hiding interval creates an obstacle between them
+
+        otherwise, we can bucket
+        """
+
+        def func(a, b, c):
+            group_name = dist.distributed_c10d._get_default_group().group_name
+            group_size = 1
+
+            # First all_gather
+            ag1 = torch.ops._c10d_functional.all_gather_into_tensor(
+                a, group_size, group_name
+            )
+            mm1 = torch.mm(a, a)  # hides ag1
+            ag1_out = torch.ops._c10d_functional.wait_tensor(ag1)
+
+            # Reduce scatter in between
+            rs = torch.ops._c10d_functional.reduce_scatter_tensor(
+                b, "sum", group_size, group_name
+            )
+            mm2 = torch.mm(b[:4, :4], b[:4, :4])  # hides rs
+            rs_out = torch.ops._c10d_functional.wait_tensor(rs)
+
+            # Second all_gather
+            ag2 = torch.ops._c10d_functional.all_gather_into_tensor(
+                c, group_size, group_name
+            )
+            mm3 = torch.mm(c, c)  # hides ag2
+            ag2_out = torch.ops._c10d_functional.wait_tensor(ag2)
+
+            return ag1_out.sum() + rs_out.sum() + ag2_out.sum(), mm1, mm2, mm3
+
+        # Use fake mode to trace without executing
+        with FakeTensorMode():
+            a = torch.ones(4, 4, device=self.device)
+            b = torch.ones(8, 4, device=self.device)
+            c = torch.ones(4, 4, device=self.device)
+
+            # Trace with make_fx
+            traced = make_fx(func)(a, b, c)
+
+        ag1, ag2 = traced.graph.find_nodes(
+            op="call_function",
+            target=torch.ops._c10d_functional.all_gather_into_tensor.default,
+        )
+        (rs,) = traced.graph.find_nodes(
+            op="call_function",
+            target=torch.ops._c10d_functional.reduce_scatter_tensor.default,
+        )
+        mm1, mm2, mm3 = traced.graph.find_nodes(
+            op="call_function", target=torch.ops.aten.mm.default
+        )
+
+        # Manually annotate hiding relationships
+        hiding_annotations = {
+            ag1: mm1,  # mm1 hides ag1
+            # rs: mm2,   # mm2 hides rs
+            ag2: mm3,
+        }
+        if final_mm_hidden:
+            hiding_annotations[rs] = mm2
+
+        # Build collective info and ancestors
+        collective_info = build_collective_info(traced.graph, hiding_annotations)
+        node_ancestors = compute_ancestors(traced.graph)
+        scheduled = OrderedSet(traced.graph.nodes)
+
+        # Run bucketing logic to find buckets (without applying them, which would require process groups)
+        from torch._inductor.fx_passes.overlap_preserving_bucketer import (
+            OverlapPreservingBucketer,
+        )
+
+        bucketer = OverlapPreservingBucketer(
+            traced.graph,
+            collective_info,
+            node_ancestors,
+            scheduled,
+        )
+
+        bucketer.bucket_collectives()
+
+        graph_str = str(traced.graph)
+
+        # check order of mms preserved
+        FileCheck().check("%mm").check("%mm_1").check("%mm_2").run(graph_str)
+
+        if final_mm_hidden:
+            # Should NOT bucket - 2 separate all_gathers
+            # Count all_gather node names (works even when wrapped in control_deps)
+            FileCheck().check_count("%all_gather_into_tensor", 2, exactly=False).run(
+                graph_str
+            )
+        else:
+            # Should bucket - 1 bucketed all_gather (all_gather_into_tensor_out)
+            FileCheck().check_count(
+                "%all_gather_into_tensor_out", 1, exactly=False
+            ).run(graph_str)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/fx_passes/overlap_preserving_bucketer.py
+++ b/torch/_inductor/fx_passes/overlap_preserving_bucketer.py
@@ -39,8 +39,11 @@ class WhyNoBucket:
 
     def __call__(self, reason: str, *args: Any) -> None:
         if bucket_log.isEnabledFor(logging.DEBUG):
-            bucket_log.debug(  # noqa: G003
-                "cannot bucket %s with %s: " + reason, self.name1, self.name2, *args
+            bucket_log.debug(
+                "cannot bucket %s with %s: " + reason,  # noqa: G003
+                self.name1,
+                self.name2,
+                *args,
             )
 
 

--- a/torch/_inductor/fx_passes/overlap_preserving_bucketer.py
+++ b/torch/_inductor/fx_passes/overlap_preserving_bucketer.py
@@ -1,6 +1,9 @@
 from collections import defaultdict
+from dataclasses import dataclass
+from typing import Literal, Optional
 
 import torch.fx as fx
+from torch._dynamo.utils import counters
 from torch._inductor.augmented_graph_helper import AugmentedGraphHelper
 from torch._inductor.fx_passes.bucketing import (
     bucket_key,
@@ -8,8 +11,71 @@ from torch._inductor.fx_passes.bucketing import (
     is_reduce_scatter_tensor as is_reduce_scatter,
     is_wait_tensor,
 )
-from torch._inductor.fx_passes.overlap_scheduling import CollBucket, CollectiveInfo
+from torch._inductor.fx_passes.overlap_scheduling import (
+    CollBucket,
+    CollectiveInfo,
+    get_group_name,
+    is_compute_node,
+)
 from torch.utils._ordered_set import OrderedSet
+
+
+def is_collective_or_wait(n: fx.Node) -> bool:
+    """Check if node is a collective start or wait."""
+    if is_wait_tensor(n):
+        return True
+    # Collective starts have exactly one use: the wait_tensor
+    if len(n.users) == 1:
+        user = next(iter(n.users.keys()))
+        if is_wait_tensor(user):
+            return True
+    return False
+
+
+@dataclass
+class Event:
+    """Represents a point in the timeline with a representative operation."""
+
+    node: fx.Node  # Single representative node
+    event_type: Literal["compute", "starts", "waits"]
+    position: int
+    prev: Optional["Event"] = None
+    next: Optional["Event"] = None
+
+    @property
+    def is_start(self) -> bool:
+        return self.event_type == "starts"
+
+    @property
+    def is_wait(self) -> bool:
+        return self.event_type == "waits"
+
+    @property
+    def is_compute(self) -> bool:
+        return self.event_type == "compute"
+
+    def unlink(self) -> tuple[Optional["Event"], Optional["Event"]]:
+        """Remove this event from the linked list, return (prev, next)."""
+        prev_event, next_event = self.prev, self.next
+        if self.prev:
+            self.prev.next = self.next
+        if self.next:
+            self.next.prev = self.prev
+        self.prev = None
+        self.next = None
+        return prev_event, next_event
+
+    def insert_between(
+        self, prev_event: Optional["Event"], next_event: Optional["Event"]
+    ) -> None:
+        """Insert this event between prev_event and next_event in the linked list."""
+        if prev_event:
+            prev_event.next = self
+        self.prev = prev_event
+
+        if next_event:
+            next_event.prev = self
+        self.next = next_event
 
 
 class OverlapPreservingBucketer:
@@ -37,50 +103,145 @@ class OverlapPreservingBucketer:
         self.aug_graph = AugmentedGraphHelper(self.graph, self.node_ancestors)
         self.max_coll_distance = max_coll_distance
         self.insert_overlap_deps = insert_overlap_deps
+        self.node_to_event: dict[fx.Node, Event] = {}
+        self.pg_to_timeline: dict[str, Optional[Event]] = self.build_timelines()
+
+        self._add_hiding_interval_constraints()
+
+    def build_timelines(self) -> dict[str, Optional[Event]]:
+        all_pgs: OrderedSet[str] = OrderedSet()
+        for start in self.collective_info:
+            pg = get_group_name(start)
+            all_pgs.add(pg)
+
+        pg_timeline: dict[str, Optional[Event]] = {}
+        for pg in all_pgs:
+            pg_timeline[pg] = self.build_timeline(pg)
+
+        return pg_timeline
+
+    def build_timeline(self, pg: str) -> Optional[Event]:
+        head = None
+        prev_event = None
+        position = 0
+
+        for node in self.scheduled:
+            node_type = None
+
+            # Determine if this node is relevant for this PG
+            if node in self.collective_info and get_group_name(node) == pg:
+                node_type = "starts"
+            elif is_wait_tensor(node):
+                wait_input = node.args[0]
+                if isinstance(wait_input, fx.Node) and get_group_name(wait_input) == pg:
+                    node_type = "waits"
+            elif is_compute_node(node):
+                node_type = "compute"
+
+            if node_type is None:
+                continue
+
+            event = Event(node=node, event_type=node_type, position=position)  # type: ignore[arg-type]
+
+            # Link to previous event using insert_between
+            event.insert_between(prev_event, None)
+
+            # Add sequential dependency to augmented graph
+            if prev_event:
+                self.aug_graph.add_extra_dep(n=event.node, dep=prev_event.node)
+            else:
+                head = event
+
+            prev_event = event
+            position += 1
+
+        return head
+
+    def _populate_node_to_event(self, pg: str) -> None:
+        """Populate node_to_event mapping for a specific PG's timeline."""
+        self.node_to_event.clear()
+        head = self.pg_to_timeline[pg]
+        curr = head
+        while curr is not None:
+            self.node_to_event[curr.node] = curr
+            curr = curr.next
+
+    def _add_hiding_interval_constraints(self) -> None:
+        """
+        Add hiding interval constraints: start -> compute -> wait.
+        """
+        for start, info in self.collective_info.items():
+            if info.hiding_node and not info.is_exposed:
+                # Enforce: start -> compute -> wait
+                self.aug_graph.add_extra_dep(n=info.hiding_node, dep=start)
+                self.aug_graph.add_extra_dep(n=info.wait_node, dep=info.hiding_node)
 
     def bucket_collectives(self) -> None:
         """Main entry point for bucketing collectives."""
 
-        # Add extra dependencies for hidden collectives
-        # For each hidden collective, add: compute -> start and wait -> compute
-        for start_node, info in self.collective_info.items():
-            if info.hiding_node and not info.is_exposed:
-                # Add edge: hiding_compute depends on start (start must come before compute)
-                self.aug_graph.add_extra_dep(n=info.hiding_node, dep=start_node)
-                # Add edge: wait depends on hiding_compute (compute must come before wait)
-                self.aug_graph.add_extra_dep(n=info.wait_node, dep=info.hiding_node)
-
-        # Group collectives by bucket key (type, group, etc.)
-        grouped_collectives: dict[object, OrderedSet[fx.Node]] = defaultdict(OrderedSet)
+        # Group collectives by PG first
+        pg_collectives: dict[str, OrderedSet[fx.Node]] = defaultdict(OrderedSet)
         for start in self.collective_info:
-            key = bucket_key(start)
-            if key is not None:
-                grouped_collectives[key].add(start)
+            pg = get_group_name(start)
+            pg_collectives[pg].add(start)
 
         all_buckets: list[CollBucket] = []
-        for collective_group in grouped_collectives.values():
-            buckets = self._find_buckets(collective_group)
-            all_buckets.extend(buckets)
+        for pg, collectives in pg_collectives.items():
+            # Populate node_to_event for this PG's timeline
+            self._populate_node_to_event(pg)
 
-        # Collect all extra dependencies to preserve after bucketing
-        additional_deps: dict[fx.Node, OrderedSet[fx.Node]] = defaultdict(OrderedSet)
+            # Group by bucket key within this PG
+            grouped_collectives: dict[object, OrderedSet[fx.Node]] = defaultdict(
+                OrderedSet
+            )
+            for start in collectives:
+                key = bucket_key(start)
+                if key is not None:
+                    grouped_collectives[key].add(start)
+
+            # Find buckets for this PG
+            for collective_group in grouped_collectives.values():
+                buckets = self._find_buckets(collective_group)
+                all_buckets.extend(buckets)
 
         # Apply bucketing transformations
+        # Dependencies are tracked in aug_graph.extra_deps during bucketing
         for coll_bucket in all_buckets:
             if len(coll_bucket.collectives) <= 1:
                 continue
 
-            bucket_deps = self._apply_bucket(coll_bucket)
-            additional_deps.update(bucket_deps)
+            counters["inductor"]["collective_buckets"] += 1
+            self._apply_bucket(coll_bucket)
 
-        # Apply topological sort with all the collected dependencies
+        # Extract all dependencies from augmented graph
+        # This includes:
+        # - Sequential timeline deps (added during build_timeline)
+        # - Hiding interval deps (added during _add_hiding_interval_constraints)
+        # - All transferred deps from bucketing (transferred during _apply_bucket)
+        additional_deps = self.aug_graph.get_all_extra_deps()
+
+        # Apply topological sort with all dependencies
         from torch._dynamo.graph_deduplication import _stable_topological_sort
 
         _stable_topological_sort(self.graph, additional_deps)
 
         # After topological sort, preserve dependencies using effect tokens
+        # Only preserve edges where NOT both nodes are collective starts or waits
         if self.insert_overlap_deps:
-            self._preserve_dependencies_with_tokens(additional_deps)
+            filtered_deps: dict[fx.Node, OrderedSet[fx.Node]] = {}
+            for node, deps in additional_deps.items():
+                filtered_node_deps: OrderedSet[fx.Node] = OrderedSet()
+
+                # only preserve comm-comptue overlap for now, although we could more
+                # generally constrain
+                for dep in deps:
+                    if not (is_collective_or_wait(node) and is_collective_or_wait(dep)):
+                        filtered_node_deps.add(dep)
+
+                if filtered_node_deps:
+                    filtered_deps[node] = filtered_node_deps
+
+            self._preserve_dependencies_with_tokens(filtered_deps)
 
         self.graph.lint()
 
@@ -134,6 +295,303 @@ class OverlapPreservingBucketer:
         """Check if there's an ancestor relationship between two nodes."""
         return n1 in self.node_ancestors[n2] or n2 in self.node_ancestors[n1]
 
+    def _get_intervals(
+        self, event: Event
+    ) -> tuple[Optional[tuple[int, int]], Optional[tuple[int, int]]]:
+        """Get (execution_interval, hiding_interval) for a collective event.
+
+        Returns:
+            (execution_interval, hiding_interval) where:
+            - execution_interval is (start_pos, wait_pos) or None
+            - hiding_interval is (start_pos, compute_pos) or None if no hiding node
+
+        Works for both start and wait events by looking up the collective info.
+        """
+        # For start events, directly use the node
+        if event.is_start:
+            coll = event.node
+        # For wait events, look up the start node from the event's args
+        elif event.is_wait:
+            wait_input = event.node.args[0]
+            if not isinstance(wait_input, fx.Node):
+                return None, None
+            coll = wait_input
+        else:
+            return None, None
+
+        if coll not in self.collective_info:
+            return None, None
+
+        info = self.collective_info[coll]
+        start_event = self.node_to_event[coll]
+        wait_event = self.node_to_event[info.wait_node]
+
+        execution_interval = (start_event.position, wait_event.position)
+
+        hiding_interval = None
+        if info.hiding_node:
+            hiding_interval = (
+                start_event.position,
+                self.node_to_event[info.hiding_node].position,
+            )
+
+        return execution_interval, hiding_interval
+
+    def _preserves_hiding_intervals(
+        self,
+        bucket_info: CollBucket,
+        candidate: fx.Node,
+        start_pos: fx.Node,
+        wait_pos: fx.Node,
+    ) -> bool:
+        """
+        Check that (start_pos, wait_pos) doesn't violate any hiding intervals or collectives.
+
+        Collects all execution and hiding intervals in the affected timeline regions,
+        then checks:
+        1. All bucket hiding compute stays between new start/wait
+        2. No other collective's compute interval is enclosed by bucket execution interval
+        3. No other collective's execution interval encloses bucket compute intervals
+        """
+        # Collect all collectives being bucketed
+        all_bucketed_colls = [candidate] + list(bucket_info.collectives)
+        all_bucketed_waits = [
+            self.collective_info[coll].wait_node for coll in all_bucketed_colls
+        ]
+
+        # Collect hiding compute positions for the bucket
+        bucket_hiding_compute_positions = []
+        for coll in all_bucketed_colls:
+            if hiding_node := self.collective_info[coll].hiding_node:
+                bucket_hiding_compute_positions.append(
+                    self.node_to_event[hiding_node].position
+                )
+
+        # Get new positions
+        new_start_event = self.node_to_event[start_pos]
+        new_wait_event = self.node_to_event[wait_pos]
+
+        # Check 1: All bucket hiding compute must be between new start and wait
+        for compute_pos in bucket_hiding_compute_positions:
+            if not (new_start_event.position < compute_pos < new_wait_event.position):
+                return False
+
+        def get_wait(n: fx.Node) -> fx.Node:
+            return self.collective_info[n].wait_node
+
+        def get_pos(n: fx.Node) -> int:
+            return self.node_to_event[n].position
+
+        latest_start_pos = max(get_pos(candidate), get_pos(bucket_info.collectives[0]))
+        earliest_wait_pos = min(
+            get_pos(get_wait(candidate)), get_pos(get_wait(bucket_info.collectives[0]))
+        )
+
+        # Bucket execution interval
+        bucket_execution_interval = (new_start_event.position, new_wait_event.position)
+
+        # Because collectives on the same PG operate under LIFO semantics,
+        # it's only possible for us to force an early realization of an unrelated collective
+        # by delaying a start or raising a wait.
+        # We search in the interval from old_start -> new_start, to see if would be
+        # forcing another collective to be realized prior to its hiding nodes.
+        # Similarly, we search from old_wait -> new_wait, in the reverse direction,
+        # to check the same thing.
+
+        execution_intervals = [bucket_execution_interval]
+        hiding_intervals = [
+            (bucket_execution_interval[0], pos)
+            for pos in bucket_hiding_compute_positions
+        ]
+
+        curr_event = new_start_event.next
+        while curr_event is not None and curr_event.position < latest_start_pos:
+            if (
+                curr_event.node not in all_bucketed_colls
+                and curr_event.node not in all_bucketed_waits
+            ):
+                exec_interval, hiding_interval = self._get_intervals(curr_event)
+                if exec_interval:
+                    execution_intervals.append(exec_interval)
+                if hiding_interval:
+                    hiding_intervals.append(hiding_interval)
+            curr_event = curr_event.next
+
+        curr_event = new_wait_event.prev
+        while curr_event is not None and curr_event.position > earliest_wait_pos:
+            if (
+                curr_event.node not in all_bucketed_colls
+                and curr_event.node not in all_bucketed_waits
+            ):
+                exec_interval, hiding_interval = self._get_intervals(curr_event)
+                if exec_interval:
+                    execution_intervals.append(exec_interval)
+                if hiding_interval:
+                    hiding_intervals.append(hiding_interval)
+            curr_event = curr_event.prev
+
+        # Check: no hiding interval should be enclosed by any execution interval
+        def enclosed_interval(inner: tuple[int, int], outer: tuple[int, int]) -> bool:
+            return outer[0] < inner[0] and inner[1] < outer[1]
+
+        for hiding_interval in hiding_intervals:
+            for execution_interval in execution_intervals:
+                if enclosed_interval(hiding_interval, execution_interval):
+                    return False
+
+        return True
+
+    def remove_from_event(
+        self, node: fx.Node
+    ) -> tuple[Optional[Event], Optional[Event]]:
+        """Remove node from timeline and return (prev_event, next_event)."""
+        event = self.node_to_event[node]
+        assert not event.is_compute, "Cannot remove compute events from timeline"
+
+        prev_event, next_event = event.unlink()
+
+        # Remove augmented graph dependency
+        if prev_event:
+            self.aug_graph.remove_extra_dep(n=node, dep=prev_event.node)
+        if next_event:
+            self.aug_graph.remove_extra_dep(n=next_event.node, dep=node)
+
+        # Add bypass dependency
+        if prev_event and next_event:
+            self.aug_graph.add_extra_dep(n=next_event.node, dep=prev_event.node)
+
+        return prev_event, next_event
+
+    def restore_to_event(
+        self, node: fx.Node, prev_event: Optional[Event], next_event: Optional[Event]
+    ) -> None:
+        """Restore node to timeline after failed merge attempt."""
+        event = self.node_to_event[node]
+
+        # Reinsert into linked list
+        event.insert_between(prev_event, next_event)
+        if prev_event:
+            self.aug_graph.add_extra_dep(n=node, dep=prev_event.node)
+        if next_event and not prev_event:
+            self.aug_graph.add_extra_dep(n=next_event.node, dep=node)
+
+        # Remove bypass dependency
+        if prev_event and next_event:
+            self.aug_graph.remove_extra_dep(n=next_event.node, dep=prev_event.node)
+
+    def _try_rail_position(
+        self,
+        bucket_info: CollBucket,
+        candidate: fx.Node,
+        start_pos: fx.Node,
+        wait_pos: fx.Node,
+    ) -> bool:
+        """
+        Try a specific rail position for the candidate.
+        Returns True if valid and merges are successful.
+        """
+        candidate_info = self.collective_info[candidate]
+        candidate_start = candidate
+        candidate_wait = candidate_info.wait_node
+
+        # Quick check: does this violate hiding intervals?
+        if not self._preserves_hiding_intervals(
+            bucket_info, candidate, start_pos, wait_pos
+        ):
+            return False
+
+        # Determine which start needs to move
+        existing_coll = bucket_info.collectives[0]
+        if start_pos == existing_coll:
+            start_to_move = candidate
+        else:
+            assert start_pos == candidate
+            start_to_move = existing_coll
+
+        # Remove start from timeline
+        start_prev, start_next = self.remove_from_event(start_to_move)
+
+        # Check if starts can be merged
+        if self.aug_graph.has_path(existing_coll, candidate) or self.aug_graph.has_path(
+            candidate, existing_coll
+        ):
+            # Restore start constraints
+            self.restore_to_event(start_to_move, start_prev, start_next)
+            return False
+
+        # Merge starts
+        self.aug_graph.merge_to_set(existing_coll, candidate)
+
+        # Determine which wait needs to move
+        existing_wait = self.collective_info[existing_coll].wait_node
+        candidate_wait = self.collective_info[candidate].wait_node
+
+        if wait_pos == existing_wait:
+            wait_to_move = candidate_wait
+        else:
+            wait_to_move = existing_wait
+
+        # Remove wait from timeline
+        wait_prev, wait_next = self.remove_from_event(wait_to_move)
+
+        # Check if waits can be merged
+        if self.aug_graph.has_path(
+            existing_wait, candidate_wait
+        ) or self.aug_graph.has_path(candidate_wait, existing_wait):
+            # Restore wait constraints
+            self.restore_to_event(wait_to_move, wait_prev, wait_next)
+            # Unmerge the start we just merged
+            self.aug_graph.unmerge_node(candidate)
+            # Restore start constraints
+            self.restore_to_event(start_to_move, start_prev, start_next)
+            return False
+
+        # Merge waits - success!
+        self.aug_graph.merge_to_set(existing_wait, candidate_wait)
+
+        # Update node_to_event for moved nodes
+        target_start_event = self.node_to_event[start_pos]
+        target_wait_event = self.node_to_event[wait_pos]
+
+        self.node_to_event[candidate] = target_start_event
+        self.node_to_event[candidate_wait] = target_wait_event
+        self.node_to_event[existing_coll] = target_start_event
+        self.node_to_event[existing_wait] = target_wait_event
+
+        return True
+
+    def _has_ancestor_conflicts(
+        self, bucket_info: CollBucket, candidate: fx.Node
+    ) -> bool:
+        """
+        Check if candidate has ancestor conflicts with bucket collectives.
+        Returns True if there are conflicts.
+        """
+        candidate_info = self.collective_info[candidate]
+        candidate_wait = candidate_info.wait_node
+
+        for coll in bucket_info.collectives:
+            # Check if collectives are ancestors of each other
+            if self._ancestor_dep(coll, candidate):
+                return True
+
+            # Check if waits are ancestors of each other
+            coll_wait = self.collective_info[coll].wait_node
+            if self._ancestor_dep(candidate_wait, coll_wait):
+                return True
+
+            # Check if existing hiding node conflicts with candidate wait
+            if hiding_node := self.collective_info[coll].hiding_node:
+                if self._ancestor_dep(hiding_node, candidate_wait):
+                    return True
+
+            # Check if candidate hiding node conflicts with existing wait
+            if new_hiding_node := candidate_info.hiding_node:
+                if self._ancestor_dep(new_hiding_node, coll_wait):
+                    return True
+
+        return False
+
     def _can_add_to_bucket(
         self,
         bucket_info: CollBucket,
@@ -143,62 +601,49 @@ class OverlapPreservingBucketer:
         Check if candidate can be added to bucket without interfering
         with comm/compute overlap.
         """
-
         candidate_info = self.collective_info[candidate]
-        candidate_wait = candidate_info.wait_node
 
         # Step 1: Quick check using precomputed ancestors
-        # This will not be fully up to date because bucketing changes ancestors,
-        # however any ancestor at the start of bucketing will remain an ancestor.
-        for coll in bucket_info.collectives:
-            if self._ancestor_dep(coll, candidate):
-                return False
+        # These ancestors are computed prior to adding augmented dependencies and not updated,
+        # so if any of these checks fail then the merge will not be topologically valid
+        # even ignoring comm/compute overlap
+        if self._has_ancestor_conflicts(bucket_info, candidate):
+            return False
 
-            coll_wait = self.collective_info[coll].wait_node
-            if self._ancestor_dep(candidate_wait, coll_wait):
-                return False
-
-            if hiding_node := self.collective_info[coll].hiding_node:
-                if self._ancestor_dep(hiding_node, candidate_wait):
-                    return False
-
-            if new_hiding_node := candidate_info.hiding_node:
-                if self._ancestor_dep(new_hiding_node, coll_wait):
-                    return False
-
-        # Step 2: Check and merge starts
-        # Check if there's a path between any existing start and candidate start.
-        # Because the collectives have already been merged, we can just start from one
-        # of them.
-        # TODO: we have a range of possible idxs of the merged node, and idx of new node.
-        # we should not do path search beyond that range
+        # Step 2: Try different rail positions
         existing_coll = bucket_info.collectives[0]
-        if self.aug_graph.has_path(existing_coll, candidate):
-            return False
-        if self.aug_graph.has_path(candidate, existing_coll):
-            return False
-
-        # Safe to merge starts - do the merge
-        self.aug_graph.merge_to_set(existing_coll, candidate)
-
-        # Step 3: Check and merge waits
         existing_wait = self.collective_info[existing_coll].wait_node
+
+        candidate_start = candidate
         candidate_wait = candidate_info.wait_node
-        # TODO - as above, limit search by idx
-        if self.aug_graph.has_path(
-            existing_wait, candidate_wait
-        ) or self.aug_graph.has_path(candidate_wait, existing_wait):
-            # Unmerge the start we just merged
-            self.aug_graph.unmerge_node(candidate)
-            return False
 
-        self.aug_graph.merge_to_set(existing_wait, candidate_wait)
-        return True
+        # Try combinations in order of likelihood to succeed
+        # (early start, later wait is most likely to work)
+        combinations = [
+            (
+                existing_coll,
+                candidate_wait,
+            ),  # Move candidate start early, keep wait late
+            (
+                existing_coll,
+                existing_wait,
+            ),  # Move candidate start early, move wait early
+            (candidate_start, candidate_wait),  # Keep both in place
+            (candidate_start, existing_wait),  # Keep start in place, move wait early
+        ]
 
-    def _apply_bucket(
-        self, bucket_info: CollBucket
-    ) -> dict[fx.Node, OrderedSet[fx.Node]]:
-        """Apply bucketing transformation and return dependencies to preserve."""
+        for start_pos, wait_pos in combinations:
+            if self._try_rail_position(bucket_info, candidate, start_pos, wait_pos):
+                return True
+
+        return False
+
+    def _apply_bucket(self, bucket_info: CollBucket) -> None:
+        """
+        Apply bucketing transformation.
+
+        Dependencies are added to aug_graph.extra_deps and transferred from old nodes.
+        """
 
         from torch._inductor.fx_passes.bucketing import (
             merge_all_gather_bucket,
@@ -207,19 +652,23 @@ class OverlapPreservingBucketer:
 
         bucket = bucket_info.collectives
 
+        # Collect old nodes BEFORE they're erased
+        old_starts = list(bucket)
+        old_waits = [self.collective_info[n].wait_node for n in bucket]
+
         # Find where to place the bucketed operations
         next_node = bucket[0]
         while next_node in bucket:
             next_node = next_node.next
-        waits = [self.collective_info[n].wait_node for n in bucket]
-        first_wait = min(waits, key=lambda w: self.node_idx[w])
 
-        # Create bucketed collective
+        # Don't use wait_insertion_point - let merge functions place waits naturally
+        # The wait_insertion_point feature tries to move waits to a specific location,
+        # but this can cause issues when that location is one of the nodes being erased
+        # Create bucketed collective (this will erase old nodes)
         if is_all_gather(bucket[0]):
             new_nodes, replacements = merge_all_gather_bucket(
                 self.graph,
                 bucket,
-                wait_insertion_point=first_wait,
                 insert_before=next_node,
                 mode="custom_ops",
             )
@@ -228,13 +677,11 @@ class OverlapPreservingBucketer:
             new_nodes, replacements = merge_reduce_scatter_bucket(
                 self.graph,
                 bucket,
-                wait_insertion_point=first_wait,
                 insert_before=next_node,
                 mode="custom_ops",
             )
 
-        # Build dependencies to preserve overlap
-        # replacements maps old_start -> new_start, old_wait -> new_wait
+        # Get new nodes
         new_waits = [n for n in new_nodes if is_wait_tensor(n)]
         assert len(new_waits) == 1
 
@@ -242,18 +689,15 @@ class OverlapPreservingBucketer:
         new_start = new_wait.args[0]
         assert isinstance(new_start, fx.Node)
 
-        overlap_deps: dict[fx.Node, OrderedSet[fx.Node]] = defaultdict(OrderedSet)
+        # Create mapping of all erased nodes to their replacements
+        erased_to_new = {}
+        for old_start in old_starts:
+            erased_to_new[old_start] = new_start
+        for old_wait in old_waits:
+            erased_to_new[old_wait] = new_wait
 
-        # Create dependencies to preserve overlap
-        for coll in bucket:
-            info = self.collective_info[coll]
-            if info.hiding_node and not info.is_exposed:
-                # Compute depends on collective start
-                overlap_deps[info.hiding_node].add(new_start)
-                # Wait depends on compute
-                overlap_deps[new_wait].add(info.hiding_node)
-
-        return overlap_deps
+        # Transfer all dependencies from old nodes to new nodes
+        self.aug_graph.transfer_erased_node_deps(erased_to_new)
 
     def _preserve_dependencies_with_tokens(
         self, additional_deps: dict[fx.Node, OrderedSet[fx.Node]]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #166528
* #166527
* __->__ #166324
* #166309

In the initial pr for overlapping preserving bucketing, for a graph like:

```
def foo(...):
     ag = all_gather(...)
     hiding_compute = mm(...)
     wait(ag)
```

We would add dependencies from mm -> ag, and wait from wait -> hiding_compute, to prevent bucketing reordering these collectives so that overlap no long occurred. however, there is an additional way for bucketing to prevent overlap.

If we were to reorder another collective so the graph looked like: 


```
def foo(...):
     ag = all_gather(...)
     ar = all_reduce(...)
     wait(ar)
     hiding_compute = mm(...)
     wait(ag)
```

Overlap would not occur, because the wait for the all reduce would also force realization of every collective enqueued on the same stream prior to the all reduce. NCCL uses a single stream per process group.

To model, we set a set a strict ordering of all collective starts, waits, and hiding compute initially when bucketing. Then, when trying to add a collective to a bucket, we will see if we interfere with overlap for all of the following possible bucketings:

[move collective start to bucket start, move bucket start to collective start] x [move collective wait to bucket wait x move bucket wait to collective wait].

For any of these positions, we check if overlap would have been interfered with because of stream queue semantics. Then, if not, we remove the moving start and wait from the constrained ordering of collectives, and see if it's topologically valid to merge the nodes.



cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben