### PR TITLE
 Raise error for 1D (size > 1) -> 0D parameter loads

### DIFF
--- a/test/nn/test_load_state_dict.py
+++ b/test/nn/test_load_state_dict.py
@@ -66,20 +66,22 @@ class TestLoadStateDict(NNTestCase):
         class SimpleModule(nn.Module):
             def __init__(self):
                 super().__init__()
-                self.threshold = nn.Parameter(torch.tensor(0.0))  # 0D
+                self.threshold = nn.Parameter(torch.tensor(0.0))
 
             def forward(self, x):
                 return x
 
         m = SimpleModule()
 
+        # Test that [3] -> scalar raises error
         sd = {"threshold": torch.randn(3)}
         with self.assertRaisesRegex(RuntimeError, "size mismatch for threshold"):
             m.load_state_dict(sd)
 
+        # Test that [1] -> scalar is allowed (backward compatibility)
         sd = {"threshold": torch.tensor([1.0])}
-        with self.assertRaisesRegex(RuntimeError, "size mismatch for threshold"):
-            m.load_state_dict(sd)
+        m.load_state_dict(sd)
+        self.assertEqual(m.threshold.item(), 1.0)
 
     @swap([True, False])
     @skipIfTorchDynamo("dynamo installs weakrefs on some params")

--- a/test/nn/test_load_state_dict.py
+++ b/test/nn/test_load_state_dict.py
@@ -62,6 +62,27 @@ class TestLoadStateDict(NNTestCase):
 
     @swap([True, False])
     @skipIfTorchDynamo("dynamo installs weakrefs on some params")
+    def test_scalar_param_1d_tensor_raises(self):
+        class SimpleModule(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.threshold = nn.Parameter(torch.tensor(0.0))  # 0D
+
+            def forward(self, x):
+                return x
+
+        m = SimpleModule()
+
+        sd = {"threshold": torch.randn(3)}
+        with self.assertRaisesRegex(RuntimeError, "size mismatch for threshold"):
+            m.load_state_dict(sd)
+
+        sd = {"threshold": torch.tensor([1.0])}
+        with self.assertRaisesRegex(RuntimeError, "size mismatch for threshold"):
+            m.load_state_dict(sd)
+
+    @swap([True, False])
+    @skipIfTorchDynamo("dynamo installs weakrefs on some params")
     def test_load_state_dict(self):
         l = nn.Linear(5, 5)
         block = nn.Module()

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -2438,12 +2438,9 @@ class Module:
                     not is_param_lazy
                     and len(param.shape) == 0
                     and len(input_param.shape) == 1
+                    and input_param.shape[0] == 1
                 ):
-                    error_msgs.append(
-                        f"size mismatch for {key}: copying a param with shape {input_param.shape} from checkpoint, "
-                        f"the shape in current model is {param.shape}."
-                    )
-                    continue
+                    input_param = input_param[0]
 
                 if not is_param_lazy and input_param.shape != param.shape:
                     # local shape should match the one in checkpoint

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -2439,7 +2439,11 @@ class Module:
                     and len(param.shape) == 0
                     and len(input_param.shape) == 1
                 ):
-                    input_param = input_param[0]
+                    error_msgs.append(
+                        f"size mismatch for {key}: copying a param with shape {input_param.shape} from checkpoint, "
+                        f"the shape in current model is {param.shape}."
+                    )
+                    continue
 
                 if not is_param_lazy and input_param.shape != param.shape:
                     # local shape should match the one in checkpoint


### PR DESCRIPTION
Fixes #165873 

# Title
Fix load_state_dict: raise error for 1D (size > 1) -> 0D parameter loads

## Summary
This PR fixes a bug where loading a 1D tensor (size > 1) into a scalar (0D) parameter would silently take the first element instead of raising an error. The fix preserves backward compatibility for 1D tensors of size 1 while catching genuine shape mismatches.

## Motivation
Previously, loading a 1D tensor like torch.randn(32000) into a 0D scalar parameter would silently slice the first element, leading to silent data loss and potential bugs. This change ensures users get a clear error when there's a genuine shape mismatch.

## Behavior change

Before: 
1D tensor (any length) -> 0D scalar -> silently coerced using input_param[0]

After: 
- 1D tensor (size == 1) -> 0D scalar -> allowed (backward compatibility)
- 1D tensor (size > 1) -> 0D scalar -> raises RuntimeError with size mismatch message

In torch/nn/modules/module.py, _load_from_state_dict, added input_param.shape[0] == 1 check to the backward compatibility condition to only allow single-element 1D tensors.

## Tests
Added test_scalar_param_1d_tensor_raises to verify that loading 1D tensors of size > 1 raises an error, while size 1 loads successfully.