### PR TITLE
[dynamo] Dont guard on getset descriptors for torch_function

### DIFF
--- a/torch/_dynamo/variables/torch_function.py
+++ b/torch/_dynamo/variables/torch_function.py
@@ -583,12 +583,6 @@ class TensorWithTFOverrideVariable(TensorVariable):
         ):
             args, kwargs = [self], {}
             if can_dispatch_torch_function(tx, args, kwargs):
-                if self.source:
-                    install_guard(
-                        AttrSource(
-                            AttrSource(self.source, "__class__"), name
-                        ).make_guard(GuardBuilder.CLOSURE_MATCH)
-                    )
                 get_fn = VariableTracker.build(tx, getattr(torch.Tensor, name).__get__)
 
                 return self.call_torch_function(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #166321
* __->__ #166346
* #166329



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela