### PR TITLE
[DebugMode] store stringify args by default

### DIFF
--- a/test/distributed/tensor/debug/test_debug_mode.py
+++ b/test/distributed/tensor/debug/test_debug_mode.py
@@ -64,6 +64,10 @@ class TestDTensorDebugMode(TestCase):
         self.assertTrue(isinstance(debug_mode.operators[2], _RedistributeCall))
         self.assertEqual(next(iter(debug_mode.operators[1])), torch.ops.aten.mm.default)
 
+        # check stringification
+        self.assertTrue(hasattr(debug_mode.operators[0], "args_str"))
+        self.assertFalse(hasattr(debug_mode.operators[0], "args"))
+
     def test_debug_string_inside_context(self):
         mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
 
@@ -267,6 +271,7 @@ class TestDTensorDebugMode(TestCase):
             record_torchfunction=True,
             record_faketensor=True,
             record_tensor_attributes=["a1", "a2"],
+            store_original_args=True,
         ) as debug_mode:
             torch.matmul(y, x)
 
@@ -278,6 +283,8 @@ class TestDTensorDebugMode(TestCase):
       aten::mm(t: f32[64, 8], t: f32[8, 8]{a1=x1, a2=x2})
       aten::_unsafe_view(t: f32[64, 8], [8, 8, 8])""",
         )
+
+        self.assertTrue(hasattr(debug_mode.operators[0], "args"))
 
     @parametrize("has_inner_mode", [True, False])
     @parametrize("has_outer_mode", [True, False])

--- a/test/distributed/tensor/debug/test_debug_mode.py
+++ b/test/distributed/tensor/debug/test_debug_mode.py
@@ -285,6 +285,7 @@ class TestDTensorDebugMode(TestCase):
         )
 
         self.assertTrue(hasattr(debug_mode.operators[0], "args"))
+        self.assertEqual(id(debug_mode.operators[0].args[0]), id(y))
 
     @parametrize("has_inner_mode", [True, False])
     @parametrize("has_outer_mode", [True, False])

--- a/torch/utils/_debug_mode.py
+++ b/torch/utils/_debug_mode.py
@@ -91,9 +91,7 @@ class _DebugCall:
         """
         To reduce memory consumption, this method stringifies args/kwargs, stores the result, and deletes original args/kwargs.
         """
-        raise NotImplementedError(
-            "Subclasses must implement stringify_args(), even if no-op"
-        )
+        raise NotImplementedError("Subclasses must implement stringify_args(), even if no-op")
 
     def render(self, attributes: list[str]) -> str:
         raise NotImplementedError("Subclasses must implement string render()")
@@ -243,11 +241,18 @@ class DebugMode(TorchDispatchMode):
         import torch.distributed.tensor  # noqa: F401
 
         self.supports_higher_order_operators = True
-        self.record_torchfunction = record_torchfunction
-        self.record_faketensor = record_faketensor
-        self.record_realtensor = record_realtensor
-        self.record_tensor_attributes = record_tensor_attributes or []
 
+        # Pushes DebugMode onto the torchfunction stack, and records __torch_function__ calls as well.
+        # WARNING: currently incompatible with torch.compile due to dynamo guard failures.
+        self.record_torchfunction = record_torchfunction
+        # Records __torch_dispatch__ calls on FakeTensors.
+        self.record_faketensor = record_faketensor
+        # Records __torch_dispatch__ calls on real tensors.
+        self.record_realtensor = record_realtensor
+        # Optional list[str] of tensor attributes, to be annotated in the string dump.
+        self.record_tensor_attributes = record_tensor_attributes or []
+        # Uses ModTracker to record nn.Module entrances, as _NNModuleCall entries.
+        # This flag currently has no effect on torch.compiled-regions.
         self.record_nn_module = record_nn_module
 
         self.module_tracker: Optional[ModTracker] = None
@@ -298,7 +303,9 @@ class DebugMode(TorchDispatchMode):
         ):
             if self.record_faketensor:
                 if func != torch.ops.prim.device.default:
-                    self._record_call(_OpCall(func, args, kwargs, self.call_depth + 1))
+                    self._record_call(
+                        _OpCall(func, args, kwargs, self.call_depth + 1)
+                    )
         elif len(types) == 0:
             if self.record_realtensor:
                 self._record_call(_OpCall(func, args, kwargs, self.call_depth + 1))

--- a/torch/utils/_debug_mode.py
+++ b/torch/utils/_debug_mode.py
@@ -91,7 +91,9 @@ class _DebugCall:
         """
         To reduce memory consumption, this method stringifies args/kwargs, stores the result, and deletes original args/kwargs.
         """
-        raise NotImplementedError("Subclasses must implement stringify_args(), even if no-op")
+        raise NotImplementedError(
+            "Subclasses must implement stringify_args(), even if no-op"
+        )
 
     def render(self, attributes: list[str]) -> str:
         raise NotImplementedError("Subclasses must implement string render()")
@@ -296,9 +298,7 @@ class DebugMode(TorchDispatchMode):
         ):
             if self.record_faketensor:
                 if func != torch.ops.prim.device.default:
-                    self._record_call(
-                        _OpCall(func, args, kwargs, self.call_depth + 1)
-                    )
+                    self._record_call(_OpCall(func, args, kwargs, self.call_depth + 1))
         elif len(types) == 0:
             if self.record_realtensor:
                 self._record_call(_OpCall(func, args, kwargs, self.call_depth + 1))

--- a/torch/utils/_debug_mode.py
+++ b/torch/utils/_debug_mode.py
@@ -91,7 +91,9 @@ class _DebugCall:
         """
         To reduce memory consumption, this method stringifies args/kwargs, stores the result, and deletes original args/kwargs.
         """
-        raise NotImplementedError("Subclasses must implement stringify_args(), even if no-op")
+        raise NotImplementedError(
+            "Subclasses must implement stringify_args(), even if no-op"
+        )
 
     def render(self, attributes: list[str]) -> str:
         raise NotImplementedError("Subclasses must implement string render()")
@@ -303,9 +305,7 @@ class DebugMode(TorchDispatchMode):
         ):
             if self.record_faketensor:
                 if func != torch.ops.prim.device.default:
-                    self._record_call(
-                        _OpCall(func, args, kwargs, self.call_depth + 1)
-                    )
+                    self._record_call(_OpCall(func, args, kwargs, self.call_depth + 1))
         elif len(types) == 0:
             if self.record_realtensor:
                 self._record_call(_OpCall(func, args, kwargs, self.call_depth + 1))

--- a/torch/utils/_debug_mode.py
+++ b/torch/utils/_debug_mode.py
@@ -87,6 +87,12 @@ class _DebugCall:
     def __init__(self, call_depth: int):
         self.call_depth = call_depth
 
+    def stringify_args(self, attributes: list[str]) -> None:
+        """
+        To reduce memory consumption, this method stringifies args/kwargs, stores the result, and deletes original args/kwargs.
+        """
+        raise NotImplementedError("Subclasses must implement stringify_args(), even if no-op")
+
     def render(self, attributes: list[str]) -> str:
         raise NotImplementedError("Subclasses must implement string render()")
 
@@ -103,15 +109,35 @@ class _OpCall(_DebugCall):
         self.args = args
         self.kwargs = kwargs
 
-    def render(self, attributes: list[str]) -> str:
-        args_str = ", ".join(_arg_to_str(arg, attributes) for arg in self.args)
+        self.args_str: Optional[str] = None
+        self.kwargs_str: Optional[str] = None
 
+    def stringify_args(self, attributes: list[str]) -> None:
+        self.args_str = ", ".join(_arg_to_str(arg, attributes) for arg in self.args)
         if self.kwargs:
-            kwargs_str = ", " + ", ".join(
+            self.kwargs_str = ", " + ", ".join(
                 f"{k}={_arg_to_str(v, attributes)}" for k, v in self.kwargs.items()
             )
         else:
-            kwargs_str = ""
+            self.kwargs_str = ""
+        del self.args
+        del self.kwargs
+
+    def render(self, attributes: list[str]) -> str:
+        if self.args_str is not None:
+            args_str = self.args_str
+        else:
+            args_str = ", ".join(_arg_to_str(arg, attributes) for arg in self.args)
+
+        if self.kwargs_str is not None:
+            kwargs_str = self.kwargs_str
+        else:
+            if self.kwargs:
+                kwargs_str = ", " + ", ".join(
+                    f"{k}={_arg_to_str(v, attributes)}" for k, v in self.kwargs.items()
+                )
+            else:
+                kwargs_str = ""
 
         if isinstance(self.op, torch._ops.OpOverload):
             op_name = self.op.__qualname__
@@ -124,7 +150,10 @@ class _OpCall(_DebugCall):
 
     def __iter__(self):
         # for BC; tuple(self) returns (op, args, kwargs, call_depth)
-        yield from [self.op, self.args, self.kwargs, self.call_depth]
+        if self.args_str is not None:
+            yield from [self.op, self.args_str, self.kwargs_str, self.call_depth]
+        else:
+            yield from [self.op, self.args, self.kwargs, self.call_depth]
 
 
 class _RedistributeCall(_DebugCall):
@@ -139,8 +168,18 @@ class _RedistributeCall(_DebugCall):
         self.dst_placement = dst_placement
         self.transform_info_str = transform_info_str
 
+        self.arg_str: Optional[str] = None
+
+    def stringify_args(self, attributes: list[str]) -> None:
+        self.arg_str = f"{_arg_to_str(self.arg, attributes)}"
+        del self.arg
+
     def render(self, attributes: list[str]) -> str:
-        arg_str = f"{_arg_to_str(self.arg, attributes)}"
+        if self.arg_str is not None:
+            arg_str = self.arg_str
+        else:
+            arg_str = f"{_arg_to_str(self.arg, attributes)}"
+
         if self.transform_info_str is not None:  # prioritize over src/dst placements
             placement_str = f"trace: {self.transform_info_str}"
         else:
@@ -151,11 +190,16 @@ class _RedistributeCall(_DebugCall):
 
     def __iter__(self):
         # for BC; tuple(self) returns (op, placement info, kwargs, call_depth)
+        if self.arg_str is not None:
+            arg = self.arg_str
+        else:
+            arg = self.arg
+
         yield REDISTRIBUTE_FUNC
         if self.transform_info_str:
-            yield [self.arg, self.transform_info_str]
+            yield [arg, self.transform_info_str]
         else:
-            yield [self.arg, self.src_placement, self.dst_placement]
+            yield [arg, self.src_placement, self.dst_placement]
         yield {}
         yield self.call_depth
 
@@ -166,6 +210,9 @@ class _NNModuleCall(_DebugCall):
     def __init__(self, module_name: str, call_depth: int):
         super().__init__(call_depth)
         self.module_name = module_name
+
+    def stringify_args(self, attributes: list[str]) -> None:
+        pass  # nothing to stringify
 
     def render(self, attributes: list[str]) -> str:
         return f"[nn.Mod] {self.module_name}"
@@ -188,6 +235,7 @@ class DebugMode(TorchDispatchMode):
         record_realtensor=True,
         record_tensor_attributes=None,
         record_nn_module=False,
+        store_original_args=False,
     ):
         super().__init__()
         import torch.distributed.tensor  # noqa: F401
@@ -204,6 +252,10 @@ class DebugMode(TorchDispatchMode):
         if self.record_nn_module:
             self.module_tracker_setup()
 
+        # If True, stores call args/kwargs in logs, without immediately stringifying.
+        # Defaults to False for memory concerns.
+        self.store_original_args = store_original_args
+
         self.operators = []
         self.call_depth = 0
 
@@ -214,11 +266,16 @@ class DebugMode(TorchDispatchMode):
     def ignore_compile_internals(cls):
         return True
 
+    def _record_call(self, call):
+        if not self.store_original_args:
+            call.stringify_args(self.record_tensor_attributes)
+        self.operators.append(call)
+
     def __torch_function__(self, func, types, args=(), kwargs=None):
         if kwargs is None:
             kwargs = {}
 
-        self.operators.append(_OpCall(func, args, kwargs, self.call_depth))
+        self._record_call(_OpCall(func, args, kwargs, self.call_depth))
 
         try:
             self.call_depth += 1
@@ -232,19 +289,19 @@ class DebugMode(TorchDispatchMode):
 
         # Record the operation with its call depth
         if torch.distributed.tensor.DTensor in types:
-            self.operators.append(_OpCall(func, args, kwargs, self.call_depth))
+            self._record_call(_OpCall(func, args, kwargs, self.call_depth))
             return NotImplemented
         elif FakeTensor in types or isinstance(
             _get_current_dispatch_mode(), FakeTensorMode
         ):
             if self.record_faketensor:
                 if func != torch.ops.prim.device.default:
-                    self.operators.append(
+                    self._record_call(
                         _OpCall(func, args, kwargs, self.call_depth + 1)
                     )
         elif len(types) == 0:
             if self.record_realtensor:
-                self.operators.append(_OpCall(func, args, kwargs, self.call_depth + 1))
+                self._record_call(_OpCall(func, args, kwargs, self.call_depth + 1))
 
         result = func(*args, **kwargs)
 
@@ -296,7 +353,7 @@ class DebugMode(TorchDispatchMode):
         transform_info_str: Optional[str] = None,
     ):
         try:
-            self.operators.append(
+            self._record_call(
                 _RedistributeCall(
                     arg,
                     src_placement=src_placement,


### PR DESCRIPTION
DebugMode currently stores dispatch call args & kwargs, which is all intermediate tensors and more. This quickly OOMed on GPU when trying to debug some torchtitan / llama 8b models.

This defaults to storing the stringified version, adding a flag `DebugMode(store_original_args=True)` if users want to store the original args as-is (and for BC).

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #166440
* #166348
* __->__ #166347



cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci