### PR TITLE
[profiler] EventList._print_tree

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -985,6 +985,12 @@ class TestProfiler(TestCase):
         )
         self.assertRegex(profiler_output, "Total M?FLOPs")
 
+        event_list_tree = kineto_profiler.events()._print_tree(
+            ["input_shapes", "flops"]
+        )
+        patt = "aten::conv2d  # {input_shapes: [[40, 16, 18, 260], [33, 16, 18, 18], [33], [], [], [], []], flops: "
+        self.assertTrue(event_list_tree.startswith(patt))
+
     def test_override_time_units(self):
         US_IN_SECOND = 1000.0 * 1000.0
         US_IN_MS = 1000.0

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -985,6 +985,12 @@ class TestProfiler(TestCase):
         )
         self.assertRegex(profiler_output, "Total M?FLOPs")
 
+        event_list_tree = kineto_profiler.events()._print_tree(["input_shapes", "flops"])
+        patt = (
+            "aten::conv2d  # {input_shapes: [[40, 16, 18, 260], [33, 16, 18, 18], [33], [], [], [], []], flops: "
+        )
+        self.assertTrue(event_list_tree.startswith(patt))
+
     def test_override_time_units(self):
         US_IN_SECOND = 1000.0 * 1000.0
         US_IN_MS = 1000.0

--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -385,6 +385,11 @@ class EventList(list):
         return total_stat
 
     def _print_tree(self, attributes=None, max_depth=None, indent="  "):
+        """Pretty-prints profiled events in a hierarchical tree format.
+
+        attributes: annotates events with corresponding FunctionEvent attributes.
+        max_depth: tree depth to truncate logs; e.g. max_depth=0 only prints top-level events.
+        """
         if not self._tree_built:
             self._build_tree()
 


### PR DESCRIPTION
starting PR for #164145 

Produces a hierarchical string dump of FunctionEvents in EventList, with optional annotated attributes. Example from `test/profiler/test_profiler.py -k test_flops`, with `prof.events()._print_tree(["input_shapes", "flops"])`:
```
aten::conv2d  # {input_shapes: [[40, 16, 18, 260], [33, 16, 18, 18], [33], [], [], [], []], flops: 3325639680}
  aten::convolution  # {input_shapes: [[40, 16, 18, 260], [33, 16, 18, 18], [33], [], [], [], [], [], []], flops: 0}
    aten::_convolution  # {input_shapes: [[40, 16, 18, 260], [33, 16, 18, 18], [33], [], [], [], [], [], [], [], [], [], []], flops: 0}
      aten::mkldnn_convolution  # {input_shapes: [[40, 16, 18, 260], [33, 16, 18, 18], [33], [], [], [], []], flops: 0}
        aten::empty  # {input_shapes: [[], [], [], [], [], []], flops: 0}
        aten::empty  # {input_shapes: [[], [], [], [], [], []], flops: 0}
        aten::as_strided_  # {input_shapes: [[40, 33, 1, 243], [], [], []], flops: 0}
        aten::resize_  # {input_shapes: [[40, 33, 1, 243], [], []], flops: 0}
aten::relu  # {input_shapes: [[40, 33, 1, 243]], flops: 0}
  aten::clamp_min  # {input_shapes: [[40, 33, 1, 243], []], flops: 0}
aten::linear  # {input_shapes: [[40, 33, 1, 243], [243, 243], [243]], flops: 0}
  aten::reshape  # {input_shapes: [[40, 33, 1, 243], []], flops: 0}
    aten::view  # {input_shapes: [[40, 33, 1, 243], []], flops: 0}
  aten::t  # {input_shapes: [[243, 243]], flops: 0}
    aten::transpose  # {input_shapes: [[243, 243], [], []], flops: 0}
      aten::as_strided  # {input_shapes: [[243, 243], [], [], []], flops: 0}
  aten::addmm  # {input_shapes: [[243], [1320, 243], [243, 243], [], []], flops: 155889360}
    aten::expand  # {input_shapes: [[243], [], []], flops: 0}
      aten::as_strided  # {input_shapes: [[243], [], [], []], flops: 0}
    aten::copy_  # {input_shapes: [[1320, 243], [1320, 243], []], flops: 0}
    aten::resolve_conj  # {input_shapes: [[1320, 243]], flops: 0}
    aten::resolve_conj  # {input_shapes: [[1320, 243]], flops: 0}
  aten::view  # {input_shapes: [[1320, 243], []], flops: 0}
aten::relu  # {input_shapes: [[40, 33, 1, 243]], flops: 0}
  aten::clamp_min  # {input_shapes: [[40, 33, 1, 243], []], flops: 0}
cudaDeviceSynchronize  # {input_shapes: [], flops: 0}
...
```

During this, I found `prof.profiler.kineto_results.experimental_event_tree()` and `ProfilerTree` from test/profiler/test_profiler_tree.py already existed, but added it since:
- EventList already post-processes events from `.kineto_results`, and experimental_event_tree returns a plain list; importing a printing utility is slightly less ergonomic.
- ProfilerTree has a lot of test-specific filtering and was hard to refactor.

But happy to be convinced to stick with either, especially the former.
