### PR TITLE
[ci, test] Migrate py3.13 pull workflows to py 3.14

### DIFF
--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -49,12 +49,20 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
     export SYSROOT_DEP="sysroot_linux-64=2.17"
   fi
 
+# Install correct Python version
+# Also ensure sysroot is using a modern GLIBC to match system compilers
+if [ "$ANACONDA_PYTHON_VERSION" = "3.14" ]; then
+  as_jenkins conda create -n py_$ANACONDA_PYTHON_VERSION -y\
+             python="3.14.0rc2" \
+             ${SYSROOT_DEP} \
+             -c conda-forge/label/python_rc -c conda-forge
+else
   # Install correct Python version
   # Also ensure sysroot is using a modern GLIBC to match system compilers
   as_jenkins conda create -n py_$ANACONDA_PYTHON_VERSION -y\
              python="$ANACONDA_PYTHON_VERSION" \
              ${SYSROOT_DEP}
-
+fi
   # libstdcxx from conda default channels are too old, we need GLIBCXX_3.4.30
   # which is provided in libstdcxx 12 and up.
   conda_install libstdcxx-ng=12.3.0 --update-deps -c conda-forge

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -56,7 +56,7 @@ jobs:
           pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc9,
           pytorch-linux-jammy-cuda12.4-cudnn9-py3-gcc11,
           pytorch-linux-jammy-py3.10-clang12,
-          pytorch-linux-jammy-py3.13-clang12,
+          pytorch-linux-jammy-py3.14-clang12,
           pytorch-linux-jammy-rocm-n-py3,
           pytorch-linux-noble-rocm-n-py3,
           pytorch-linux-jammy-rocm-n-py3-benchmarks,

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -220,14 +220,14 @@ jobs:
       test-matrix: ${{ needs.linux-jammy-py3_10-clang12-build.outputs.test-matrix }}
     secrets: inherit
 
-  linux-jammy-py3_13-clang12-build:
-    name: linux-jammy-py3.13-clang12
+  linux-jammy-py3_14-clang12-build:
+    name: linux-jammy-py3.14-clang12
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-jammy-py3.13-clang12
-      docker-image-name: ci-image:pytorch-linux-jammy-py3.13-clang12
+      build-environment: linux-jammy-py3.14-clang12
+      docker-image-name: ci-image:pytorch-linux-jammy-py3.14-clang12
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
@@ -244,14 +244,14 @@ jobs:
         ]}
     secrets: inherit
 
-  linux-jammy-py3_13-clang12-test:
-    name: linux-jammy-py3.13-clang12
+  linux-jammy-py3_14-clang12-test:
+    name: linux-jammy-py3.14-clang12
     uses: ./.github/workflows/_linux-test.yml
-    needs: linux-jammy-py3_13-clang12-build
+    needs: linux-jammy-py3_14-clang12-build
     with:
-      build-environment: linux-jammy-py3.13-clang12
-      docker-image: ${{ needs.linux-jammy-py3_13-clang12-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-py3_13-clang12-build.outputs.test-matrix }}
+      build-environment: linux-jammy-py3.14-clang12
+      docker-image: ${{ needs.linux-jammy-py3_14-clang12-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-py3_14-clang12-build.outputs.test-matrix }}
     secrets: inherit
 
   linux-jammy-cuda12_8-cudnn9-py3_10-clang12-build:

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2604,8 +2604,8 @@ def compile(
     import sysconfig
 
     _C._log_api_usage_once("torch.compile")
-    if sys.version_info >= (3, 14):
-        raise RuntimeError("torch.compile is not supported on Python 3.14+")
+    if sys.version_info >= (3, 15):
+        raise RuntimeError("torch.compile is not supported on Python 3.15+")
     elif sysconfig.get_config_var("Py_GIL_DISABLED") == 1 and sys.version_info < (
         3,
         13,

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1293,8 +1293,8 @@ def argument_names(
 
 
 def check_if_dynamo_supported() -> None:
-    if sys.version_info >= (3, 14):
-        raise RuntimeError("Python 3.14+ not yet supported for torch.compile")
+    if sys.version_info >= (3, 15):
+        raise RuntimeError("Python 3.15+ not yet supported for torch.compile")
     elif sysconfig.get_config_var("Py_GIL_DISABLED") == 1 and sys.version_info < (
         3,
         13,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #166355
* #164631

Test to see if dynamo + dynamo-wrapped tests pass on 3.14

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela