### PR TITLE
Remove c10::is_pod

### DIFF
--- a/c10/util/C++17.h
+++ b/c10/util/C++17.h
@@ -34,15 +34,6 @@
 
 namespace c10 {
 
-// std::is_pod is deprecated in C++20, std::is_standard_layout and
-// std::is_trivial are introduced in C++11, std::conjunction has been introduced
-// in C++17.
-template <typename T>
-using is_pod = std::conjunction<std::is_standard_layout<T>, std::is_trivial<T>>;
-
-template <typename T>
-constexpr bool is_pod_v = is_pod<T>::value;
-
 namespace guts {
 
 #if defined(__HIP__)


### PR DESCRIPTION
`c10::is_pod` is not used in OSS. New code should instead use `std::is_trivial`.