### PR TITLE
[xpu][test] Reuse native_mm and mix_order_reduction for Intel GPU.

### DIFF
--- a/test/inductor/test_inductor_scheduler.py
+++ b/test/inductor/test_inductor_scheduler.py
@@ -133,7 +133,7 @@ class TestScheduler(TestCase):
         torch._logging.set_logs()
 
 
-instantiate_device_type_tests(TestScheduler, globals())
+instantiate_device_type_tests(TestScheduler, globals(), allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/inductor/test_native_matmul.py
+++ b/test/inductor/test_native_matmul.py
@@ -10,6 +10,7 @@ from torch._inductor import config as inductor_config
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import run_and_get_triton_code
 from torch.testing import FileCheck
+from torch.testing._internal.common_utils import skipIfXpu
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
 
@@ -106,6 +107,9 @@ class TestTritonDotReduction(TestCase):
         self._check_equal(f, (x, y))
         self._check_code(f, (x, y), 1, 1)
 
+    @skipIfXpu(
+        msg="Intel triton issue: https://github.com/intel/intel-xpu-backend-for-triton/issues/5394"
+    )
     def test_3mm_add(self):
         def f(x, y, z, w, r, t):
             return x @ y + z @ w + r @ t
@@ -152,6 +156,5 @@ if HAS_GPU:
     torch.set_default_device(GPU_TYPE)
 
 if __name__ == "__main__":
-    # TODO: support native matmul on xpu
-    if HAS_GPU and GPU_TYPE != "xpu":
+    if HAS_GPU:
         run_tests()

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1930,7 +1930,7 @@ cpu_backend: Literal["cpp", "triton", "halide"] = "cpp"
 # Backend to use for CUDA codegen either "triton" or "halide" (experimental)
 cuda_backend: Literal["triton", "halide"] = "triton"
 
-# Backend to use for CUDA codegen either "triton"
+# Backend to use for XPU codegen either "triton"
 xpu_backend: Literal["triton"] = "triton"
 
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1930,6 +1930,9 @@ cpu_backend: Literal["cpp", "triton", "halide"] = "cpp"
 # Backend to use for CUDA codegen either "triton" or "halide" (experimental)
 cuda_backend: Literal["triton", "halide"] = "triton"
 
+# Backend to use for CUDA codegen either "triton"
+xpu_backend: Literal["triton"] = "triton"
+
 
 class halide:
     # Base halide target to use for CPU devices

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -145,7 +145,9 @@ def use_native_matmul(mat1, mat2):
         raise AssertionError("native matmul doesn't support block_ptr codegen yet")
 
     # Currently only enable native matmul for triton on GPU.
-    if not (mat1.get_device().type == "cuda" and config.cuda_backend == "triton"):
+    if not (
+        mat1.get_device().type in ["cuda", "xpu"] and config.cuda_backend == "triton"
+    ):
         return False
 
     # Currently, tl.dot only supports following dtypes

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import torch
 from torch._inductor.select_algorithm import realize_inputs, SymbolicGridFn
-from torch._inductor.utils import sympy_product
+from torch._inductor.utils import get_current_backend, sympy_product
 from torch._inductor.virtualized import V
 from torch.fx.experimental.symbolic_shapes import has_free_unbacked_symbols
 
@@ -145,8 +145,9 @@ def use_native_matmul(mat1, mat2):
         raise AssertionError("native matmul doesn't support block_ptr codegen yet")
 
     # Currently only enable native matmul for triton on GPU.
+    device_type = mat1.get_device().type
     if not (
-        mat1.get_device().type in ["cuda", "xpu"] and config.cuda_backend == "triton"
+        device_type in ("cuda", "xpu") and get_current_backend(device_type) == "triton"
     ):
         return False
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -197,11 +197,11 @@ class MixOrderReduction:
             return False
         if not node1.is_gpu() or not node2.is_gpu():
             return False
-        device_type = node1.get_device().type
+        device_type = node1.get_device().type  # type: ignore[union-attr]
         if (
             device_type not in ("cuda", "xpu")
             or get_current_backend(device_type) != "triton"
-        ):  # type: ignore[union-attr]
+        ):
             return False
         if not node1.is_reduction() or not node2.is_reduction():
             return False

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -68,6 +68,7 @@ from .utils import (
     cache_on_self,
     cmp,
     device_need_guard,
+    get_current_backend,
     get_device_tflops,
     get_dtype_size,
     get_gpu_dram_gbps,
@@ -196,9 +197,10 @@ class MixOrderReduction:
             return False
         if not node1.is_gpu() or not node2.is_gpu():
             return False
+        device_type = node1.get_device().type
         if (
-            node1.get_device().type not in ("cuda", "xpu")
-            or config.cuda_backend != "triton"
+            device_type not in ("cuda", "xpu")
+            or get_current_backend(device_type) != "triton"
         ):  # type: ignore[union-attr]
             return False
         if not node1.is_reduction() or not node2.is_reduction():

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -196,7 +196,10 @@ class MixOrderReduction:
             return False
         if not node1.is_gpu() or not node2.is_gpu():
             return False
-        if node1.get_device().type != "cuda" or config.cuda_backend != "triton":  # type: ignore[union-attr]
+        if (
+            node1.get_device().type not in ("cuda", "xpu")
+            or config.cuda_backend != "triton"
+        ):  # type: ignore[union-attr]
             return False
         if not node1.is_reduction() or not node2.is_reduction():
             return False

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -3315,14 +3315,17 @@ def register_op_requires_libdevice_fp64(name: str) -> None:
     op_requires_libdevice_fp64.add(name)
 
 
-def get_current_backend() -> str:
+def get_current_backend(device_type: Optional[str] = None) -> str:
     from torch._inductor.virtualized import V
 
-    device_str = V.graph.get_current_device_or_throw().type
-    if device_str == "cpu":
+    if not device_type:
+        device_type = V.graph.get_current_device_or_throw().type
+    if device_type == "cpu":
         return config.cpu_backend
-    elif device_str == "mps":
+    elif device_type == "mps":
         return "mps"
+    elif device_type == "xpu":
+        return config.xpu_backend
     else:
         return config.cuda_backend
 


### PR DESCRIPTION
This PR reused native_mm and mix_order_reduction for Intel GPU and enabled the corresonding test.
Fixes #165370

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben