### PR TITLE
Fixes absolute tolerance scaling for complex backpropagation in fast gradcheck

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -6667,25 +6667,28 @@ Done""",
         torch.manual_seed(97)
 
         def sample_func(z):
-            return 1. / torch.norm(z)
+            return 1.0 / torch.norm(z)
 
         # Input needs to be at least 2-dim. to trigger
         # in gradcheck an input projection vector u
         # that is not all 1s.
         eps = 10e-3  # eps distance factor from origin, to get
         # some interesting numerical vs analytic discrepancy.
-        z = eps * torch.rand(2,
-                             dtype=torch.complex128,
-                             requires_grad=True,
-                             )
+        z = eps * torch.rand(
+            2,
+            dtype=torch.complex128,
+            requires_grad=True,
+        )
         atol = 8.3e-6
         rtol = 1e-9
 
         # check both fast and slow gradcheck pass after the fix to _adjusted_atol()
-        self.assertTrue(gradcheck(sample_func, (z,), fast_mode=True,
-                      atol=atol, rtol=rtol))
-        self.assertTrue(gradcheck(sample_func, (z,), fast_mode=False,
-                                  atol=atol, rtol=rtol))
+        self.assertTrue(
+            gradcheck(sample_func, (z,), fast_mode=True, atol=atol, rtol=rtol)
+        )
+        self.assertTrue(
+            gradcheck(sample_func, (z,), fast_mode=False, atol=atol, rtol=rtol)
+        )
 
     def test_gradcheck_get_numerical_jacobian(self):
         # get_numerical_jacobian is deprecated and no longer used internally by gradcheck

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -6656,6 +6656,12 @@ Done""",
         c = torch.ones(2, 2, requires_grad=True, dtype=torch.complex128)
         self.assertTrue(gradcheck(fn2, (c)))
 
+    def test_gradcheck_adjusted_atol_complex_inputs(self):
+        # FIXME implement as regression test
+        # a certain input (proably large-min) with certain atol should fail the projection-specific check ('fast gradcheck') but
+        # pass the comprehensive check ('slow gradcheck').
+        pass
+
     def test_gradcheck_get_numerical_jacobian(self):
         # get_numerical_jacobian is deprecated and no longer used internally by gradcheck
         from torch.autograd.gradcheck import get_numerical_jacobian

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -6660,7 +6660,7 @@ Done""",
     def test_gradcheck_adjusted_atol_complex_inputs(self):
         # Regression test for incorrect atol transformation for
         # complex inputs, allowing fast gradcheck to fail and slow gradcheck to pass.
-        # See issue: <insert>
+        # See issue: https://github.com/pytorch/pytorch/issues/166385
 
         # this particular seed on CPU triggers a specific input tangent vector u in [0,1)^d such that
         # v^T(j_n - j_a)u is interesting.

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -6657,46 +6657,31 @@ Done""",
         self.assertTrue(gradcheck(fn2, (c)))
 
     def test_gradcheck_adjusted_atol_complex_inputs(self):
-        # Regression test for adjusted atol with complex inputs near the origin
-        # This tests a function with multi-dimensional complex tensors near the origin
-        # where the function has large derivatives, triggering _adjusted_atol with non-1-dim vectors
+        from torch.autograd.gradcheck import GradcheckError
 
-        # FIXME still need to find an atol and seed where fast gradcheck fails but slowgradcehck passes
+        torch.manual_seed(97)
 
-        # Fixed seed for reproducibility
-        torch.manual_seed(7)
+        def sample_func(z):
+            return 1. / torch.norm(z)
 
-        def complex_inv_square_sum(z1, z2):
-            # Compute sum of 1/z1^2 + 1/z2^2 element-wise
-            # Returns a multi-dimensional result
-            result = torch.abs(torch.sum(1.0 / (z1 ** 2) + 1.0 / (z2 ** 2)))
-            return result
-
-        # Create multi-dimensional complex inputs near the origin
-        # Using 10x10 tensors (100 elements) to ensure u in _adjusted_atol has dimension 100
-        # Values very close to origin create numerical challenges and large derivatives
-        z1_data = []
-        z2_data = []
-        for i in range(1000):
-            real_part = 1e-10 + 1e-10 * (i % 10)
-            imag_part = 1e-10 + 1e-10 * ((i + 5) % 10)
-            z1_data.append(complex(real_part, imag_part))
-            z2_data.append(complex(real_part + 1e-5, imag_part + 1e-5))
-
-        z1 = torch.tensor(z1_data, dtype=torch.complex128, requires_grad=True).reshape(100, 10)
-        z2 = torch.tensor(z2_data, dtype=torch.complex128, requires_grad=True).reshape(100, 10)
-
-        # Test with reduced atol - use a small value that challenges the numerical precision
-        atol = 8.8867e27 # passes slow gradcheck, just barely: decent lower bound to atol for slow gradcheck
-
-        # Note: from debugging, it looks like the existing fast gradcheck modiffied tolerance is already very lenient,
-        # eg. not really needing it, so the 2x factor bug may not be getting triggered.
-
-        # Fast gradcheck (with projection) should pass with reduced atol
-        #self.assertTrue(gradcheck(complex_inv_square_sum, (z1, z2), fast_mode=True, atol=atol))
-
-        # Slow gradcheck (comprehensive check) should also pass with reduced atol
-        self.assertTrue(gradcheck(complex_inv_square_sum, (z1, z2), fast_mode=False, atol=atol))
+        # Input needs to be at least 2-dim. to trigger
+        # in gradcheck an input projection vector u
+        # that is not all 1s.
+        eps = 10e-3  # eps distance factor from origin, to get
+        # some interesting numerical vs analytic discrepancy.
+        z = eps * torch.rand(2,
+                             dtype=torch.complex128,
+                             requires_grad=True,
+                             )
+        atol = 8.3e-6
+        rtol = 1e-9
+        # fails fast gradcheck
+        with self.assertRaises(GradcheckError):
+            gradcheck(sample_func, (z,), fast_mode=True,
+                      atol=atol, rtol=rtol)
+        # passes slow gradcheck
+        self.assertTrue(gradcheck(sample_func, (z,), fast_mode=False,
+                                  atol=atol, rtol=rtol))
 
     def test_gradcheck_get_numerical_jacobian(self):
         # get_numerical_jacobian is deprecated and no longer used internally by gradcheck

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -6661,8 +6661,10 @@ Done""",
         # This tests a function with multi-dimensional complex tensors near the origin
         # where the function has large derivatives, triggering _adjusted_atol with non-1-dim vectors
 
+        # FIXME still need to find an atol and seed where fast gradcheck fails but slowgradcehck passes
+
         # Fixed seed for reproducibility
-        torch.manual_seed(42)
+        torch.manual_seed(7)
 
         def complex_inv_square_sum(z1, z2):
             # Compute sum of 1/z1^2 + 1/z2^2 element-wise
@@ -6685,10 +6687,13 @@ Done""",
         z2 = torch.tensor(z2_data, dtype=torch.complex128, requires_grad=True).reshape(100, 10)
 
         # Test with reduced atol - use a small value that challenges the numerical precision
-        atol = 1e50
+        atol = 8.8867e27 # passes slow gradcheck, just barely: decent lower bound to atol for slow gradcheck
+
+        # Note: from debugging, it looks like the existing fast gradcheck modiffied tolerance is already very lenient,
+        # eg. not really needing it, so the 2x factor bug may not be getting triggered.
 
         # Fast gradcheck (with projection) should pass with reduced atol
-        self.assertTrue(gradcheck(complex_inv_square_sum, (z1, z2), fast_mode=True, atol=atol))
+        #self.assertTrue(gradcheck(complex_inv_square_sum, (z1, z2), fast_mode=True, atol=atol))
 
         # Slow gradcheck (comprehensive check) should also pass with reduced atol
         self.assertTrue(gradcheck(complex_inv_square_sum, (z1, z2), fast_mode=False, atol=atol))

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -1762,8 +1762,9 @@ def _adjusted_atol(atol, u, v):
     # Jacobians. Then the transformed tolerance checks being done in the torch.allclose ops
     # are of form abs(Re{q_r u_r - q_i u_i}) < atol * (abs(u_r) + abs(u_i)), and equivalently
     # for imaginary components abs(Im{q_r u_r - q_i ui}) < atol * (abs(u_r) + abs(u_i)).
-    # Since u is drawn randomly non-negative,
-    # the end effect is a factor (sum(u_r) + sum(u_i)) * sum(v) increase in atol for complex inputs.
+    # Since u is drawn randomly non-negative, the end effect is a factor
+    # (sum(u_r) + sum(u_i)) * sum(v) increase in atol for complex inputs, eg.
+    # a statistical factor of 2 as compared to the real case.
 
     modified_atol = atol
     sum_v = 1.0 if v is None else v.sum()

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -1675,12 +1675,6 @@ def _allclose_with_type_promotion(a, b, rtol, atol):
     promoted_type = torch.promote_types(a.dtype, b.dtype)
     a = a.to(dtype=promoted_type)
     b = b.to(dtype=promoted_type)
-    # below exprs lhs, effectively
-    abs_vals_re = torch.abs(torch.real(a - b))
-    abs_vals_im = torch.abs(torch.imag(a - b))
-    # checks |input_i - other_i| <= atol + rtol * |other_i|
-    rhs_cmp = atol + rtol * torch.abs(torch.real(b))
-    # effectively need lhs <= rhs_cmp
     return torch.allclose(a, b, rtol, atol)
 
 

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -1751,10 +1751,11 @@ def _adjusted_atol(atol, u, v):
     # We see that atol needs to be scaled by v^T M u (where M is an all-ones M x N
     # matrix): v^T M u = \sum_{i} \sum_{j} u_i * v_j = (\sum_{i} u_i)(\sum_{i} v_i)
     # TODO: properly handle case when u is tuple instead of only taking first element
-    u = u[0] if isinstance(u, tuple) else u
-    sum_u = u.sum()
+    ur = u[0] if isinstance(u, tuple) else u
+    sum_ur = ur.sum()
     sum_v = 1.0 if v is None else v.sum()
-    return atol * float(sum_u) * float(sum_v)
+    modified_atol = atol * float(sum_ur) * float(sum_v)
+    return modified_atol
 
 
 FAST_FAIL_SLOW_OK_MSG = """

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -1676,8 +1676,8 @@ def _allclose_with_type_promotion(a, b, rtol, atol):
     a = a.to(dtype=promoted_type)
     b = b.to(dtype=promoted_type)
     # below exprs lhs, effectively
-    abs_vals_re = torch.abs(torch.real(a-b))
-    abs_vals_im = torch.abs(torch.imag(a-b))
+    abs_vals_re = torch.abs(torch.real(a - b))
+    abs_vals_im = torch.abs(torch.imag(a - b))
     # checks |input_i - other_i| <= atol + rtol * |other_i|
     rhs_cmp = atol + rtol * torch.abs(torch.real(b))
     # effectively need lhs <= rhs_cmp
@@ -1780,7 +1780,6 @@ def _adjusted_atol(atol, u, v):
     sum_u = u.sum()
     modified_atol = atol * float(sum_u) * float(sum_v)
     return modified_atol
-
 
 
 FAST_FAIL_SLOW_OK_MSG = """

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -1766,7 +1766,6 @@ def _adjusted_atol(atol, u, v):
     # (sum(u_r) + sum(u_i)) * sum(v) increase in atol for complex inputs, eg.
     # a statistical factor of 2 as compared to the real case.
 
-    modified_atol = atol
     sum_v = 1.0 if v is None else v.sum()
 
     if isinstance(u, tuple):
@@ -1774,20 +1773,14 @@ def _adjusted_atol(atol, u, v):
         ur, ui = u[0], u[1]
         sum_ur = ur.sum()
         sum_ui = ui.sum()
-        correct_modified_atol = atol * (float(sum_ur) + float(sum_ui)) * float(sum_v)
-        # for now, use the incorrect original modified atol, so we can try to
-        # get a regression test working.
-        modified_atol = atol * float(sum_ur) * float(sum_v)
-        return modified_atol
-        # FIXME use correct_modified_atol
-#        return correct_modified_atol
+        complex_modified_atol = atol * (float(sum_ur) + float(sum_ui)) * float(sum_v)
+        return complex_modified_atol
 
-    else:
-        # case of real input
-        sum_u = u.sum()
-        modified_atol = atol * float(sum_u) * float(sum_v)
-
+    # case of real input
+    sum_u = u.sum()
+    modified_atol = atol * float(sum_u) * float(sum_v)
     return modified_atol
+
 
 
 FAST_FAIL_SLOW_OK_MSG = """


### PR DESCRIPTION
Fixes #166385 

This PR updates the `_adjusted_atol` for complex tangent input vectors `u` and also adds a regression test to `test_autograd.py` for the updated behavior (compare with the script in https://github.com/pytorch/pytorch/issues/166385).

The current absolute tolerance adjustment (`atol`) for fast gradcheck doesn't incorporate the complex component of the input tangent vector. The bound should be corrected from a factor of the sum over absolute value of real components to sum of absolute values of both real and imaginary components. The end effect of this change would be a multiplicative factor of `2`.

I haven't checked, but this bug may be relevant if there are any flaky OpInfo gradient checks, particularly over large complex matrices, since the `atol` transform also scales like the dim. `d` of the vector `u`.
