### PR TITLE
Fixing assertion fail by checking if no_sync is true before DDPsink

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -3639,6 +3639,55 @@ class DistributedDataParallelTest(
 
     @requires_nccl()
     @skip_if_lt_x_gpu(2)
+    def test_ddp_static_graph_multiple_backward_in_no_sync(self):
+        process_group = self._get_process_group()
+        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lin = torch.nn.Linear(3 * 224 * 224, 10)
+
+            def forward(self, im, seq):
+                out = self.lin(im.flatten(1))
+                loss = out.mean()
+                return loss, loss
+
+        model = Model().to(device_id)
+        ddp_model = DistributedDataParallel(
+            model,
+            device_ids=[device_id],
+            process_group=process_group,
+            static_graph=True,
+        )
+
+        im = torch.empty(1, 3, 224, 224, device=device_id)
+        seq = torch.randint(0, 1000, (1, 128), device=device_id).long()
+
+        with ddp_model.no_sync():
+            loss, speculative_loss = ddp_model(im, seq)
+            loss.backward(retain_graph=True)
+            speculative_loss.backward()
+
+        for param in ddp_model.parameters():
+            self.assertIsNotNone(param.grad)
+
+        ddp_model.zero_grad()
+        with ddp_model.no_sync():
+            loss, speculative_loss = ddp_model(im, seq)
+            loss.backward(retain_graph=True)
+            speculative_loss.backward()
+
+        ddp_model.zero_grad()
+        loss, speculative_loss = ddp_model(im, seq)
+        loss.backward(retain_graph=True)
+        speculative_loss.backward()
+
+        for param in ddp_model.parameters():
+            self.assertIsNotNone(param.grad)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
     def test_bucket_cap_mb_list_initialization(self):
         """Test that bucket_cap_mb_list is properly converted to bucket_bytes_cap_list"""
         process_group = self._get_process_group()

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -1843,7 +1843,9 @@ class DistributedDataParallel(Module, Joinable):
         # TODO: DDPSink is currently enabled for unused parameter detection and
         # static graph training for first iteration.
         if (self.find_unused_parameters and not self.static_graph) or (
-            self.static_graph and not self._static_graph_delay_allreduce_enqueued
+            self.static_graph
+            and not self._static_graph_delay_allreduce_enqueued
+            and self.require_backward_grad_sync
         ):
             (
                 output_tensor_list,


### PR DESCRIPTION
Fixes #143580 

Reason is `model.no_sync()` sets  `require_backward_grad_sync` as `False`. `forward()` does not call `reducer.prepare_for_backward()`, `expect_autograd_hooks_` is  `true` is not set. The if condition gaurding `_DDPSink.apply()` call in `_post_forward` didn't check `require_backward_grad_sync` unlike how the condition calling `_post_forward` is checking this. This ultimately triggers assertion error because it expects `expect_autograd_hooks_` is `true`
I am adding ` self.require_backward_grad_sync` to the `_DDPSink` if condition so that both paths are consistently skipped during no_sync().

@wconstab 

cc @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @aditvenk @weifengpy @kapilsh