### PR TITLE
Add back Windows and macOS to tensorboard tests

### DIFF
--- a/test/test_tensorboard.py
+++ b/test/test_tensorboard.py
@@ -41,6 +41,8 @@ import torch
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
+    IS_MACOS,
+    IS_WINDOWS,
     run_tests,
     skipIfTorchDynamo,
     TEST_WITH_CROSSREF,
@@ -776,11 +778,15 @@ class TestTensorBoardFigure(BaseTestCase):
             figures.append(figure)
 
         writer.add_figure("add_figure/figure_list", figures, 0, close=False)
-        self.assertTrue(all(plt.fignum_exists(figure.number) is True for figure in figures))  # noqa: F812
+        self.assertTrue(
+            all(plt.fignum_exists(figure.number) is True for figure in figures)
+        )  # noqa: F812
 
         writer.add_figure("add_figure/figure_list", figures, 1)
         if matplotlib.__version__ != "3.3.0":
-            self.assertTrue(all(plt.fignum_exists(figure.number) is False for figure in figures))  # noqa: F812
+            self.assertTrue(
+                all(plt.fignum_exists(figure.number) is False for figure in figures)
+            )  # noqa: F812
         else:
             print(
                 "Skipping fignum_exists, see https://github.com/matplotlib/matplotlib/issues/18163"
@@ -797,8 +803,9 @@ class TestTensorBoardNumpy(BaseTestCase):
         self.assertIsInstance(res, np.ndarray) and self.assertEqual(res.shape, (1,))
         res = make_np(np.float16(1.00000087))
         self.assertIsInstance(res, np.ndarray) and self.assertEqual(res.shape, (1,))
-        res = make_np(np.float128(1.00008 + 9))
-        self.assertIsInstance(res, np.ndarray) and self.assertEqual(res.shape, (1,))
+        if not IS_MACOS and not IS_WINDOWS:
+            res = make_np(np.float128(1.00008 + 9))
+            self.assertIsInstance(res, np.ndarray) and self.assertEqual(res.shape, (1,))
         res = make_np(np.int64(100000000000))
         self.assertIsInstance(res, np.ndarray) and self.assertEqual(res.shape, (1,))
 

--- a/test/test_tensorboard.py
+++ b/test/test_tensorboard.py
@@ -40,8 +40,6 @@ skipIfNoMatplotlib = unittest.skipIf(not TEST_MATPLOTLIB, "no matplotlib")
 import torch
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
-    IS_MACOS,
-    IS_WINDOWS,
     parametrize,
     run_tests,
     skipIfTorchDynamo,
@@ -487,38 +485,23 @@ class TestTensorBoardSummary(BaseTestCase):
         summary.video("dummy", np.random.rand(16, 48, 1, 28, 28))
         summary.video("dummy", np.random.rand(20, 7, 1, 8, 8))
 
-    @unittest.skipIf(
-        IS_MACOS, "Skipping on mac, see https://github.com/pytorch/pytorch/pull/109349 "
-    )
     @xfailIfS390X
     def test_audio(self):
         self.assertProto(summary.audio("dummy", tensor_N(shape=(42,))))
 
-    @unittest.skipIf(
-        IS_MACOS, "Skipping on mac, see https://github.com/pytorch/pytorch/pull/109349 "
-    )
     def test_text(self):
         self.assertProto(summary.text("dummy", "text 123"))
 
-    @unittest.skipIf(
-        IS_MACOS, "Skipping on mac, see https://github.com/pytorch/pytorch/pull/109349 "
-    )
     def test_histogram_auto(self):
         self.assertProto(
             summary.histogram("dummy", tensor_N(shape=(1024,)), bins="auto", max_bins=5)
         )
 
-    @unittest.skipIf(
-        IS_MACOS, "Skipping on mac, see https://github.com/pytorch/pytorch/pull/109349 "
-    )
     def test_histogram_fd(self):
         self.assertProto(
             summary.histogram("dummy", tensor_N(shape=(1024,)), bins="fd", max_bins=5)
         )
 
-    @unittest.skipIf(
-        IS_MACOS, "Skipping on mac, see https://github.com/pytorch/pytorch/pull/109349 "
-    )
     def test_histogram_doane(self):
         self.assertProto(
             summary.histogram(
@@ -538,9 +521,6 @@ class TestTensorBoardSummary(BaseTestCase):
             layout
         )  # only smoke test. Because protobuf in python2/3 serialize dictionary differently.
 
-    @unittest.skipIf(
-        IS_MACOS, "Skipping on mac, see https://github.com/pytorch/pytorch/pull/109349 "
-    )
     def test_mesh(self):
         v = np.array([[[1, 1, 1], [-1, -1, 1], [1, -1, -1], [-1, 1, -1]]], dtype=float)
         c = np.array(
@@ -550,9 +530,6 @@ class TestTensorBoardSummary(BaseTestCase):
         mesh = summary.mesh("my_mesh", vertices=v, colors=c, faces=f, config_dict=None)
         self.assertProto(mesh)
 
-    @unittest.skipIf(
-        IS_MACOS, "Skipping on mac, see https://github.com/pytorch/pytorch/pull/109349 "
-    )
     def test_scalar_new_style(self):
         scalar = summary.scalar("test_scalar", 1.0, new_style=True)
         self.assertProto(scalar)
@@ -813,13 +790,6 @@ class TestTensorBoardFigure(BaseTestCase):
 
 
 class TestTensorBoardNumpy(BaseTestCase):
-    @unittest.skipIf(
-        IS_WINDOWS,
-        "Skipping on windows, see https://github.com/pytorch/pytorch/pull/109349 ",
-    )
-    @unittest.skipIf(
-        IS_MACOS, "Skipping on mac, see https://github.com/pytorch/pytorch/pull/109349 "
-    )
     def test_scalar(self):
         res = make_np(1.1)
         self.assertIsInstance(res, np.ndarray) and self.assertEqual(res.shape, (1,))


### PR DESCRIPTION
This PR adds back tensorboard tests on Windows and macOS because the dependency issue is resolved.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci