### PR TITLE
Remove outdated skip conditons of CUDA and ROCm

### DIFF
--- a/test/test_jiterator.py
+++ b/test/test_jiterator.py
@@ -8,7 +8,7 @@ from itertools import product
 from torch.testing._internal.common_utils import TestCase, parametrize, run_tests, TEST_CUDA, NoTest
 from torch.testing._internal.common_dtype import all_types_and_complex_and
 from torch.testing._internal.common_device_type import (
-    skipCUDAIfVersionLessThan, instantiate_device_type_tests, dtypes, toleranceOverride, tol)
+    instantiate_device_type_tests, dtypes, toleranceOverride, tol)
 
 if not TEST_CUDA:
     print('CUDA not available, skipping tests', file=sys.stderr)
@@ -39,10 +39,6 @@ class TestPythonJiterator(TestCase):
 
         self.assertEqual(expected, result)
 
-    # See https://github.com/pytorch/pytorch/pull/76394#issuecomment-1118018287 for details
-    # On cuda 11.3, nvrtcCompileProgram is taking too long to
-    # compile jiterator generated kernels for non-contiguous input that requires dynamic-casting.
-    @skipCUDAIfVersionLessThan((11, 6))
     @parametrize("shape_strides", [
         (([3, 3], [1, 3]), ([3, 1], [1, 3])),  # non-contiguous
     ])

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -31,8 +31,7 @@ from torch.testing._internal.common_device_type import \
      toleranceOverride, tol, skipXPU)
 from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FLASH_ATTENTION, PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
-    SM53OrLater, SM80OrLater, SM89OrLater, with_tf32_off, TEST_CUDNN, _get_torch_cuda_version,
-    _get_torch_rocm_version,
+    SM53OrLater, SM80OrLater, SM89OrLater, with_tf32_off, TEST_CUDNN,
 )
 from torch.testing._internal.common_quantized import (
     _bfloat16_to_float4_e2m1fn_x2,
@@ -13822,9 +13821,6 @@ op_db: list[OpInfo] = [
            supports_autograd=True,
            sample_inputs_func=sample_inputs_sparse_sampled_addmm,
            decorators=[
-               skipCUDAIf(not ((_get_torch_cuda_version() >= (11, 3))
-                               or (_get_torch_rocm_version() >= (5, 2))),
-                          "cusparseSDDMM was added in 11.2.1"),
                skipCPUIfNoMklSparse,
                skipXPU],
            skips=(
@@ -16628,7 +16624,7 @@ op_db: list[OpInfo] = [
             DecorateInfo(unittest.skip("Skipped!"), 'TestCompositeCompliance', 'test_backward', device_type='cuda'),
             # This is only failing on Linux Bionic 3.10 Cuda 11.6
             DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_dtypes',
-                         device_type='cuda', active_if=_get_torch_cuda_version() >= (11, 6)),
+                         device_type='cuda'),
             DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_noncontiguous_samples',
                          dtypes=(torch.float32,)),
             # AssertionError: JIT Test does not execute any logic

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -12,15 +12,10 @@ from numpy import inf
 
 import torch
 from torch.testing import make_tensor
-from torch.testing._internal.common_cuda import (
-    _get_magma_version,
-    _get_torch_cuda_version,
-    with_tf32_off,
-)
+from torch.testing._internal.common_cuda import _get_magma_version, with_tf32_off
 from torch.testing._internal.common_device_type import (
     has_cusolver,
     skipCPUIfNoLapack,
-    skipCUDAIf,
     skipCUDAIfNoCusolver,
     skipCUDAIfNoMagma,
     skipCUDAIfNoMagmaAndNoCusolver,
@@ -1484,9 +1479,6 @@ op_db: list[OpInfo] = [
         supports_autograd=False,
         sample_inputs_func=sample_inputs_linalg_ldl_solve,
         decorators=[
-            skipCUDAIf(
-                _get_torch_cuda_version() < (11, 4), "not available before CUDA 11.3.1"
-            ),
             skipCUDAIfNoCusolver,
             skipCUDAIfRocm,
             skipCPUIfNoLapack,


### PR DESCRIPTION
This PR removes outdated skip conditions of CUDA 11 and ROCm 5

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @dllehr-amd