### PR TITLE
Remove outdated AT_USE_HIPSPARSE_TRIANGULAR_SOLVE branches

### DIFF
--- a/aten/src/ATen/cuda/CUDASparse.h
+++ b/aten/src/ATen/cuda/CUDASparse.h
@@ -27,10 +27,3 @@
 #else
 #define AT_USE_CUSPARSE_GENERIC_SDDMM() 0
 #endif
-
-// BSR triangular solve functions were added in hipSPARSE 1.11.2 (ROCm 4.5.0)
-#if defined(CUDART_VERSION) || defined(USE_ROCM)
-#define AT_USE_HIPSPARSE_TRIANGULAR_SOLVE() 1
-#else
-#define AT_USE_HIPSPARSE_TRIANGULAR_SOLVE() 0
-#endif

--- a/aten/src/ATen/cuda/CUDASparseBlas.cpp
+++ b/aten/src/ATen/cuda/CUDASparseBlas.cpp
@@ -390,8 +390,6 @@ void bsrmv<c10::complex<double>>(
       reinterpret_cast<cuDoubleComplex*>(y)));
 }
 
-#if AT_USE_HIPSPARSE_TRIANGULAR_SOLVE()
-
 template <>
 void bsrsv2_bufferSize<float>(CUSPARSE_BSRSV2_BUFFER_ARGTYPES(float)) {
   TORCH_CUDASPARSE_CHECK(cusparseSbsrsv2_bufferSize(
@@ -883,7 +881,5 @@ void bsrsm2_solve<c10::complex<double>>(
       policy,
       pBuffer));
 }
-
-#endif // AT_USE_HIPSPARSE_TRIANGULAR_SOLVE
 
 } // namespace at::cuda::sparse

--- a/aten/src/ATen/cuda/CUDASparseBlas.h
+++ b/aten/src/ATen/cuda/CUDASparseBlas.h
@@ -154,7 +154,6 @@ void bsrmv<c10::complex<float>>(CUSPARSE_BSRMV_ARGTYPES(c10::complex<float>));
 template <>
 void bsrmv<c10::complex<double>>(CUSPARSE_BSRMV_ARGTYPES(c10::complex<double>));
 
-#if AT_USE_HIPSPARSE_TRIANGULAR_SOLVE()
 
 #define CUSPARSE_BSRSV2_BUFFER_ARGTYPES(scalar_t)                 \
   cusparseHandle_t handle, cusparseDirection_t dirA,              \
@@ -314,7 +313,6 @@ template <>
 void bsrsm2_solve<c10::complex<double>>(
     CUSPARSE_BSRSM2_SOLVE_ARGTYPES(c10::complex<double>));
 
-#endif // AT_USE_HIPSPARSE_TRIANGULAR_SOLVE
 
 } // namespace at::cuda::sparse
 // NOLINTEND(misc-misplaced-const)

--- a/aten/src/ATen/cuda/CUDASparseDescriptors.h
+++ b/aten/src/ATen/cuda/CUDASparseDescriptors.h
@@ -65,10 +65,8 @@ using cusparseDnVecDescr = std::remove_pointer_t<hipsparseDnVecDescr_t>;
 using cusparseSpMatDescr = std::remove_pointer_t<hipsparseSpMatDescr_t>;
 using cusparseSpMatDescr = std::remove_pointer_t<hipsparseSpMatDescr_t>;
 using cusparseSpGEMMDescr = std::remove_pointer_t<hipsparseSpGEMMDescr_t>;
-#if AT_USE_HIPSPARSE_TRIANGULAR_SOLVE()
 using bsrsv2Info = std::remove_pointer_t<bsrsv2Info_t>;
 using bsrsm2Info = std::remove_pointer_t<bsrsm2Info_t>;
-#endif
 #endif
 
 // NOTE: This is only needed for CUDA 11 and earlier, since CUDA 12 introduced
@@ -97,7 +95,6 @@ class TORCH_CUDA_CPP_API CuSparseMatDescriptor
   }
 };
 
-#if AT_USE_HIPSPARSE_TRIANGULAR_SOLVE()
 
 class TORCH_CUDA_CPP_API CuSparseBsrsv2Info
     : public CuSparseDescriptor<bsrsv2Info, &cusparseDestroyBsrsv2Info> {
@@ -119,7 +116,6 @@ class TORCH_CUDA_CPP_API CuSparseBsrsm2Info
   }
 };
 
-#endif // AT_USE_HIPSPARSE_TRIANGULAR_SOLVE
 
 cusparseIndexType_t getCuSparseIndexType(const c10::ScalarType& scalar_type);
 

--- a/aten/src/ATen/native/sparse/cuda/SparseBlasImpl.cpp
+++ b/aten/src/ATen/native/sparse/cuda/SparseBlasImpl.cpp
@@ -100,13 +100,6 @@ void block_sparse_triangular_solve_vec(
     bool upper,
     bool transpose,
     bool unitriangular) {
-#if !AT_USE_HIPSPARSE_TRIANGULAR_SOLVE()
-  TORCH_CHECK(
-      false,
-      "Calling triangular solver with block sparse GPU tensors requires compiling ",
-      "PyTorch with ROCm 4.5.0+. ",
-      "Please use PyTorch built with newer ROCm version.");
-#else
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(A.layout() == kSparseBsr);
   // values is expected to be a blocks of sparse matrix
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(A.values().dim() == 3);
@@ -217,7 +210,6 @@ void block_sparse_triangular_solve_vec(
   if (!X.is_same(*X_)) {
     X.copy_(*X_);
   }
-#endif
 }
 
 void block_sparse_triangular_solve_mat(
@@ -227,13 +219,6 @@ void block_sparse_triangular_solve_mat(
     bool upper,
     bool transpose,
     bool unitriangular) {
-#if !AT_USE_HIPSPARSE_TRIANGULAR_SOLVE()
-  TORCH_CHECK(
-      false,
-      "Calling triangular solver with block sparse GPU tensors requires compiling ",
-      "PyTorch with ROCm 4.5.0+. ",
-      "Please use PyTorch built with newer ROCm version.");
-#else
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(A.layout() == kSparseBsr);
   // values is expected to be a blocks of sparse matrix
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(A.values().dim() == 3);
@@ -357,7 +342,6 @@ void block_sparse_triangular_solve_mat(
   if (!X.is_same(*X_)) {
     X.copy_(*X_);
   }
-#endif
 }
 
 void block_sparse_mv(


### PR DESCRIPTION
Because the functionality is supported both in current versions of CUDA and ROCm.
