### PR TITLE
Change round_size with 1 division behavior.  Round no more than 1 GB. 

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -2500,6 +2500,9 @@ class DeviceCachingAllocator {
           AcceleratorAllocatorConfig::roundup_power2_divisions(size);
       if (divisions > 1 && size > (kMinBlockSize * divisions)) {
         return roundup_power2_next_division(size, divisions);
+      } else if (divisions == 1) {
+        constexpr auto gib = 1024 * 1024 * 1024;
+        return std::min(llvm::PowerOf2Ceil(size), size + gib);
       } else {
         return kMinBlockSize * ((size + kMinBlockSize - 1) / kMinBlockSize);
       }

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4600,7 +4600,7 @@ class TestCudaMallocAsync(TestCase):
         if not TEST_CUDAMALLOCASYNC:
             self.assertEqual(div1_end_mem - div1_start_mem, power2_div(nbytes, 1))
             self.assertEqual(div1_end_requested - div1_start_requested, nbytes)
-        
+
         # Check power of 2 when rounding is greater than 1GB.
         torch.cuda.memory.empty_cache()
         div1_start_mem = torch.cuda.memory_stats()[key_allocated]

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4594,9 +4594,7 @@ class TestCudaMallocAsync(TestCase):
         torch.rand(nelems, device="cuda")
         div1_end_mem = torch.cuda.memory_stats()[key_allocated]
         div1_end_requested = torch.cuda.memory_stats()[key_requested]
-
         self.assertEqual(div1_start_mem - start_mem, nbytes)
-
         if not TEST_CUDAMALLOCASYNC:
             self.assertEqual(div1_end_mem - div1_start_mem, power2_div(nbytes, 1))
             self.assertEqual(div1_end_requested - div1_start_requested, nbytes)


### PR DESCRIPTION
Fixes #161139

The previous PR was reverted after merge. After further review, it was recommended to round no more than 1 GB instead of just rounding to the next greatest power of 2 in the division 1 case. 


cc @ptrblck @msaroufim @eqy @jerryzh168