### PR TITLE
Fix MSAN errors in get_env_mutex

### DIFF
--- a/c10/util/env.cpp
+++ b/c10/util/env.cpp
@@ -3,7 +3,9 @@
 #include <fmt/format.h>
 #include <cstdlib>
 #include <mutex>
+#include <optional>
 #include <shared_mutex>
+#include <string>
 
 namespace c10::utils {
 

--- a/c10/util/env.cpp
+++ b/c10/util/env.cpp
@@ -9,9 +9,10 @@
 
 namespace c10::utils {
 
-static std::shared_mutex& get_env_mutex() {
-  static std::shared_mutex env_mutex;
-  return env_mutex;
+std::shared_mutex& get_env_mutex() {
+  // Leaked to ensure the destructor isn't called during process shutdown
+  static std::shared_mutex* env_mutex = new std::shared_mutex();
+  return *env_mutex;
 }
 
 // Set an environment variable.


### PR DESCRIPTION
When running MSAN over PyTorch, this is detected as `use-of-uninitialized-value` and should be heap-allocated.

Also noticed that both `std::optional` and `std::string` are being used without the headers directly included, so that has been updated in this PR as well.