### PR TITLE
Add overridable _get_factor_dims in Adafactor, default to factoring out the biggest dims

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -772,8 +772,11 @@ class TestOptimRenewed(TestCase):
                     if torch.is_tensor(new_p_state.get("step", None)):
                         self.assertEqual(new_p_state["step"].dtype, assert_step_dtype)
                 for k in og_p_state:
-                    tracker.add(og_p_state[k])
-                    tracker.pop_check_set(new_p_state[k], self)
+                    if torch.is_tensor(og_p_state[k]):
+                        tracker.add(og_p_state[k])
+                        tracker.pop_check_set(new_p_state[k], self)
+                    else:
+                        self.assertEqual(og_p_state[k], new_p_state[k])
 
             self.assertTrue(tracker.all_popped())
 


### PR DESCRIPTION
Inspired by https://x.com/wightmanr/status/1855004288726045094 -- sorry it's been almost a whole year before I got to this. Welp.

There are some interesting considerations I was thinking through.
q1: should factor_dims live in optimizer state or param_groups? This PR currently puts it in parameter state as it is initialized once the grad shape is known in `_init_group`, like the rest of state. The difference between factor_dims and the rest of state is that we don't anticipate factor_dims to change, and so it is the only non-Tensor state. If factor_dims were determinable at constructor time, it may be more fitting to go in the param_groups.

q2: is adding an overridable private function the right abstraction? I threw in the param name to this function as I figure people would want to make policies off of the FQN...but it's unused/untested today. If this is the right abstraction, I will add a test for this!

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #166431

