### PR TITLE
Repro dynamo issue for union typed annotation

### DIFF
--- a/test/distributed/tensor/test_dtensor_export.py
+++ b/test/distributed/tensor/test_dtensor_export.py
@@ -2,10 +2,8 @@
 
 import contextlib
 import unittest
-from typing import Union
 
 import torch
-
 import torch.distributed as dist
 import torch.fx.traceback as fx_traceback
 from torch._dynamo.functional_export import (
@@ -506,17 +504,17 @@ class DTensorExportTest(TestCase):
     def test_union_typed_annotation(self):
         def fn(leaf: torch.Tensor | DTensor):
             def nest_fn(leaf: torch.Tensor | DTensor):
-            # def nest_fn(leaf: Union[torch.Tensor, DTensor]):  # this works
+                # def nest_fn(leaf: Union[torch.Tensor, DTensor]):  # this works
                 if isinstance(leaf, DTensor):
                     leaf = leaf.to_local()
                 return leaf
+
             return nest_fn(leaf) + 1
 
         z = torch.randn(16, 16)
         gm = graph_capture_and_aot_export_joint_with_descriptors(fn, (z,))
 
         print(gm)
-
 
 
 instantiate_parametrized_tests(DTensorExportTest)

--- a/test/distributed/tensor/test_dtensor_export.py
+++ b/test/distributed/tensor/test_dtensor_export.py
@@ -2,8 +2,10 @@
 
 import contextlib
 import unittest
+from typing import Union
 
 import torch
+
 import torch.distributed as dist
 import torch.fx.traceback as fx_traceback
 from torch._dynamo.functional_export import (
@@ -498,6 +500,23 @@ class DTensorExportTest(TestCase):
             _count_op(joint_gm, torch.ops.higher_order.flex_attention_backward),
             2,
         )
+
+    # "Explanation: SourcelessBuilder.create does not know how to wrap <class 'types.UnionType'>"
+    @unittest.expectedFailure
+    def test_union_typed_annotation(self):
+        def fn(leaf: torch.Tensor | DTensor):
+            def nest_fn(leaf: torch.Tensor | DTensor):
+            # def nest_fn(leaf: Union[torch.Tensor, DTensor]):  # this works
+                if isinstance(leaf, DTensor):
+                    leaf = leaf.to_local()
+                return leaf
+            return nest_fn(leaf) + 1
+
+        z = torch.randn(16, 16)
+        gm = graph_capture_and_aot_export_joint_with_descriptors(fn, (z,))
+
+        print(gm)
+
 
 
 instantiate_parametrized_tests(DTensorExportTest)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #166443


when nested function has type annotation using "|",  it fails. 

it works fine with `Union[torch.Tensor, DTensor]` tho. 


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci