### PR TITLE
[DTensor] Patch DeviceMesh.get_rank() for LocalTensorMode

### DIFF
--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -415,7 +415,7 @@ class RedistributeTest(DTensorTestBase):
     def test_partial_to_shard(self, dtype):
         device_mesh = self.build_device_mesh()
         partial_spec = [Partial()]
-        my_rank = self.rank
+        my_rank = device_mesh.get_rank()
 
         input_sizes_and_shard_dim = [
             ((self.world_size * 3, 3), 0),

--- a/test/distributed/test_local_tensor.py
+++ b/test/distributed/test_local_tensor.py
@@ -387,6 +387,22 @@ class TestLocalTensorWorld4(LocalTensorTestBase):
             full_tensor = dist_res.full_tensor()
             self.assertEqual(full_tensor, local_res)
 
+    def test_device_mesh_get_rank_patching(self):
+        """Test DeviceMesh.get_rank() returns per-rank values in LocalTensorMode."""
+        from torch.distributed._local_tensor import LocalIntNode
+
+        with LocalTensorMode(self.world_size):
+            device_mesh = self.build_device_mesh()
+            rank = device_mesh.get_rank()
+
+            # Verify it returns SymInt backed by LocalIntNode
+            self.assertIsInstance(rank, torch.SymInt)
+            self.assertIsInstance(rank.node, LocalIntNode)
+
+            # Verify each simulated rank has correct value
+            expected = {0: 0, 1: 1, 2: 2, 3: 3}
+            self.assertEqual(rank.node._local_ints, expected)
+
 
 class TestLocalTensorWorld8(LocalTensorTestBase):
     world_size = 8


### PR DESCRIPTION
Addresses a TODO from PR #166081 review. 
Enables device_mesh.get_rank() to work correctly in LocalTensorMode by returning per-rank SymInt values.
Follows get_coordinate() patching pattern. 
Adds  a test.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @ezyang 
