### PR TITLE
[CI] Some changes to how --save-xml in run_tests works

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -35,7 +35,6 @@ from torch.testing._internal.common_utils import (
     set_cwd,
     shell,
     TEST_CUDA,
-    TEST_SAVE_XML,
     TEST_WITH_ASAN,
     TEST_WITH_ROCM,
     TEST_WITH_SLOW_GRADCHECK,
@@ -532,7 +531,9 @@ def run_test(
 
     xml_report_dir = get_report_dir(test_file, None, options.pytest)
     if is_cpp_test:
-        unittest_args.append(f"--junit-xml-reruns={get_report_path(xml_report_dir, test_file)}")
+        unittest_args.append(
+            f"--junit-xml-reruns={get_report_path(xml_report_dir, test_file)}"
+        )
     else:
         unittest_args.append(f"--save-xml={xml_report_dir}")
 


### PR DESCRIPTION
Changes where the filename gets included in the reportdir/reportpath separation in run_tests. Previously --save-xml/TEST_SAVE_XML contained just test-report/testsource + log suffix and get_report_path contained info about the testfile and the basename.  Now --save-xml/TEST_SAVE_XML contains test-report/testsource + log suffix/testfile info, which should be the entire parent directory, and then get_report_path should just be the basename

There are also some slight changes to when xml gets created, but it should be broader than it was before

I want this so I can specify the xml location at a higher level. I could have done it using the existing logic, but there would have been extra nesting, which is kind of annoying.  I hope this also makes it slightly less confusing
