### PR TITLE
[xpu][test] Enable test_fxir_backend tests for XPU

### DIFF
--- a/test/inductor/test_fxir_backend.py
+++ b/test/inductor/test_fxir_backend.py
@@ -806,8 +806,6 @@ class AOTFxirTestCase(InductorTestCase):
     def check(
         self, model, inp, dynamic_shapes=None, strict=False
     ) -> torch.fx.GraphModule:
-        if self.device == "xpu":
-            raise unittest.SkipTest("The feature AOTFxir not currently ready for XPU")
         with torch.no_grad():
             ep = torch.export.export(
                 model, inp, dynamic_shapes=dynamic_shapes, strict=strict


### PR DESCRIPTION
This PR enables `test_fxir_backend.py`'s tests formerly skipped xpu tests. No additional changes needed for the features.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @gujinghui @fengyuan14 @guangyey