### PR TITLE
Fix wait_idx handling of schedule_comm_wait

### DIFF
--- a/torch/_inductor/fx_passes/ddp_fusion.py
+++ b/torch/_inductor/fx_passes/ddp_fusion.py
@@ -563,8 +563,9 @@ def schedule_comm_wait(graph: fx.Graph) -> None:
         # Move wait nodes and all the subsequent nodes in the comm_block to
         # before the first user -- target_node.
         wait_idx = -1
-        for wait_idx, node in enumerate(allreduce.node_list):
+        for idx, node in enumerate(allreduce.node_list):
             if node == allreduce.wait_nodes[0]:
+                wait_idx = idx
                 break
         assert wait_idx >= 0
         move_block_before(allreduce.node_list[wait_idx:], target_node)


### PR DESCRIPTION
This PR fixes a logical error in `schedule_comm_wait`. Before this change, wait_idx still has a value when `allreduce.node_list` is not empty and the condition inside the loop is not satisfied. This is not what we want.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @chenyang78