### PR TITLE
[xpu][test] Enable int4 and int8 test on Intel GPU

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -6864,9 +6864,6 @@ class AOTInductorTestsTemplate:
         self.check_model(Model(), example_inputs)
 
     @skipIfMPS
-    @skipIfXpu(
-        msg="aten::convert_weight_to_int4pack is not currently implemented for XPU"
-    )
     @parametrize("m", [32])
     @parametrize("n", [64])
     @parametrize("q_group", [32, 64])

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -3695,7 +3695,7 @@ def meta__convert_weight_to_int4pack_for_cpu(w, inner_k_tiles):
 @register_meta([aten._weight_int4pack_mm])
 def meta__weight_int4pack_mm(x, w, q_group_size, q_scale_and_zeros):
     torch._check(x.dim() == 2, lambda: "x must be a 2D tensor")
-    expected_dim = 2 if "xpu" in w.fake_device.type else 4
+    expected_dim = 2 if w.fake_device.type == "xpu" else 4
     torch._check(w.dim() == expected_dim, lambda: f"w must be a {expected_dim}D tensor")
     torch._check(
         x.dtype in [torch.float32, torch.float16, torch.bfloat16],
@@ -3705,7 +3705,7 @@ def meta__weight_int4pack_mm(x, w, q_group_size, q_scale_and_zeros):
         w.dtype is torch.int32,
         lambda: f"expected w to be int32, got {w.dtype}",
     )
-    dim_n = w.size(0) if "xpu" in w.fake_device.type else w.size(0) * 8
+    dim_n = w.size(0) if w.fake_device.type == "xpu" else w.size(0) * 8
     return x.new_empty(x.size(0), dim_n, dtype=x.dtype)
 
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -3695,7 +3695,7 @@ def meta__convert_weight_to_int4pack_for_cpu(w, inner_k_tiles):
 @register_meta([aten._weight_int4pack_mm])
 def meta__weight_int4pack_mm(x, w, q_group_size, q_scale_and_zeros):
     torch._check(x.dim() == 2, lambda: "x must be a 2D tensor")
-    torch._check(w.dim() == 4, lambda: "w must be a 4D tensor")
+    torch._check(w.dim() == 4 or w.dim() == 2, lambda: "w must be a 4D or 2D tensor")
     torch._check(
         x.dtype in [torch.float32, torch.float16, torch.bfloat16],
         lambda: f"expected x to be f32/f16/bf16, got {x.dtype}",
@@ -3704,7 +3704,10 @@ def meta__weight_int4pack_mm(x, w, q_group_size, q_scale_and_zeros):
         w.dtype is torch.int32,
         lambda: f"expected w to be int32, got {w.dtype}",
     )
-    return x.new_empty(x.size(0), w.size(0) * 8, dtype=x.dtype)
+    if w.dim() == 4:
+        return x.new_empty(x.size(0), w.size(0) * 8, dtype=x.dtype)
+    elif w.dim() == 2:
+        return x.new_empty(x.size(0), w.size(0), dtype=x.dtype)
 
 
 @register_meta([aten._weight_int4pack_mm_for_cpu])

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -3695,7 +3695,10 @@ def meta__convert_weight_to_int4pack_for_cpu(w, inner_k_tiles):
 @register_meta([aten._weight_int4pack_mm])
 def meta__weight_int4pack_mm(x, w, q_group_size, q_scale_and_zeros):
     torch._check(x.dim() == 2, lambda: "x must be a 2D tensor")
-    torch._check(w.dim() == 4 or w.dim() == 2, lambda: "w must be a 4D or 2D tensor")
+    if "xpu" in w.fake_device.type:
+        torch._check(w.dim() == 2, lambda: "w must be a 2D tensor on XPU")
+    else:
+        torch._check(w.dim() == 4, lambda: "w must be a 4D tensor")
     torch._check(
         x.dtype in [torch.float32, torch.float16, torch.bfloat16],
         lambda: f"expected x to be f32/f16/bf16, got {x.dtype}",


### PR DESCRIPTION
Enable int4 and int8 test to enhance testing on Intel GPU. 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @chenyang78