### PR TITLE
 Fix incomplete torch.cdist tests

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2598,7 +2598,7 @@ class TestTorchDeviceType(TestCase):
             dist_grad = torch.randn((1, 27, 27), device=device, dtype=torch.float)
             y = x.clone()
             x.requires_grad = True
-            d = torch.cdist(x, y)
+            d = torch.cdist(x, y, p=p)
             d.backward(dist_grad)
             # Check that the backward pass does not contain invalid
             # values such as nan or inf


### PR DESCRIPTION
Because the `p` value is not used.