### PR TITLE
Fix issue with inductor pointwise kernels always autotuning

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -2835,7 +2835,7 @@ class TestMaxAutotuneRemoteCache(TestCase):
                 torch.compile(mm, dynamic=dynamic)(a, b)
                 reset()
             global_stats.report()
-            self.assertEqual(global_stats.autotune_remote, Stats(2, 3, 2))
+            self.assertEqual(global_stats.autotune_remote, Stats(0, 0, 0))
 
 
 class _TestTritonTemplateCaller(TritonTemplateCaller):

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2590,7 +2590,7 @@ def pointwise(
 
     configs = None
     if len(size_hints) == 1:
-        if not inductor_meta.get("autotune_pointwise", True) and not (
+        if not (
             inductor_meta.get("max_autotune")
             or inductor_meta.get("max_autotune_pointwise")
         ):
@@ -2626,13 +2626,10 @@ def pointwise(
     if len(size_hints) == 2:
         # Only avoiding tuning on TileHint.SQUARE if not on ROCm builds
         # ROCm has observed improvement by diverging here
-        if (
-            not inductor_meta.get("autotune_pointwise", True)
-            or (torch.version.hip is None and tile_hint == TileHint.SQUARE)
-        ) and not (
+        if not (
             inductor_meta.get("max_autotune")
             or inductor_meta.get("max_autotune_pointwise")
-        ):
+        ) or (torch.version.hip is None and tile_hint == TileHint.SQUARE):
             configs = [triton_config_with_settings(size_hints, 32, 32)]
         else:
             configs = [
@@ -2663,7 +2660,10 @@ def pointwise(
                     ]
                 )
     if len(size_hints) == 3:
-        if not inductor_meta.get("autotune_pointwise", True):
+        if not (
+            inductor_meta.get("max_autotune")
+            or inductor_meta.get("max_autotune_pointwise")
+        ):
             configs = [triton_config_with_settings(size_hints, 16, 16, 16)]
         else:
             configs = [


### PR DESCRIPTION
We noticed for pointwise examples currently we are always running into autotune path

Example
```
import torch
@torch.compile()
def add_seven(x):
    return x + 7
x = torch.randn(65534, device='cuda')
y = add_seven(x)
```

Logs:
```
V1029 11:30:39.839000 739 site-packages/torch/_inductor/runtime/triton_heuristics.py:315] [0/0] CachingAutotuner gets 5 configs for triton_poi_fused_add_0
V1029 11:30:39.839000 739 site-packages/torch/_inductor/runtime/triton_heuristics.py:321] [0/0] XBLOCK: 512, num_warps: 2, num_ctas: 1, num_stages: 1, maxnreg: None
V1029 11:30:39.839000 739 site-packages/torch/_inductor/runtime/triton_heuristics.py:321] [0/0] XBLOCK: 256, num_warps: 4, num_ctas: 1, num_stages: 1, maxnreg: None
V1029 11:30:39.839000 739 site-packages/torch/_inductor/runtime/triton_heuristics.py:321] [0/0] XBLOCK: 8192, waves_per_eu: 2, num_warps: 4, num_ctas: 1, num_stages: 1, maxnreg: None
V1029 11:30:39.839000 739 site-packages/torch/_inductor/runtime/triton_heuristics.py:321] [0/0] XBLOCK: 4096, num_warps: 4, num_ctas: 1, num_stages: 1, maxnreg: None
V1029 11:30:39.839000 739 site-packages/torch/_inductor/runtime/triton_heuristics.py:321] [0/0] XBLOCK: 2048, waves_per_eu: 1, num_warps: 8, num_ctas: 1, num_stages: 2, maxnreg: None
```

The root cause of this seems to be a regression from https://github.com/pytorch/pytorch/pull/164905 which introduced inductor_meta.get("autotune_pointwise") into the autotune logic.

This PR simplifies these autotune conditions slightly to ensure tuning is only performed when relevant env vars are set

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @mlazos