### PR TITLE
Add MXFP4 grouped gemm support via. FBGEMM kernels

### DIFF
--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -762,7 +762,7 @@ class TestFP8Matmul(TestCase):
                     w_scale, wq = to_mxfp(W[i], format="mxfp8")
                     wh, wq, w_scale, w_global_scale = _convert_to_nvfp4_with_hp_ref(W[i])
                     w_global_scale_list.append(w_global_scale)
-                if format == "mxfp4":
+                elif format == "mxfp4":
                     wh, wq, w_scale = _convert_to_mxfp4_with_hp_ref(W[i])
                 else:
                     raise ValueError(f'format must be mxfp8|nvfp4|mxfp4, got "{format}"')
@@ -804,7 +804,7 @@ class TestFP8Matmul(TestCase):
                     elif format == "nvfp4":
                         xh, xq, x_scale, x_global_scale = _convert_to_nvfp4_with_hp_ref(x_slice)
                         x_global_scale_list.append(x_global_scale)
-                    if format == "mxfp4":
+                    elif format == "mxfp4":
                         xh, xq, x_scale = _convert_to_mxfp4_with_hp_ref(x_slice)
                     else:
                         raise ValueError(f'format must be mxfp8|nvfp4|mxfp4, got "{format}"')

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -43,12 +43,12 @@ from torch.testing._internal.common_utils import (
 )
 from torch.testing._internal.common_quantized import (
     _bfloat16_to_float4_e2m1fn_x2,
-    _f32_to_floatx_unpacked,
     _floatx_unpacked_to_f32,
     ceil_div, to_blocked,
     to_mxfp,
     from_blocked_format,
     generate_jagged_offs,
+    pack_uint4,
 )
 
 

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -42,10 +42,11 @@ from torch.testing._internal.common_utils import (
     TestCase,
 )
 from torch.testing._internal.common_quantized import (
+    _bfloat16_to_float4_e2m1fn_x2,
     _f32_to_floatx_unpacked,
     _floatx_unpacked_to_f32,
     ceil_div, to_blocked,
-    to_mxfp8,
+    to_mxfp,
     from_blocked_format,
     generate_jagged_offs,
 )
@@ -451,18 +452,6 @@ def data_to_nvfp4_with_global_scale(x, block_size):
     return x_fp4, S_dec_b_e4m3, S_dec.float()
 
 
-def down_size(size):
-    assert size[-1] % 2 == 0, f"{size} last dim not divisible by two"
-    return (*size[:-1], size[-1] // 2)
-
-
-def pack_uint4(uint8_data) -> torch.Tensor:
-    # converting to uint8 for operations
-    shape = uint8_data.shape
-    assert shape[-1] % 2 == 0
-    uint8_data = uint8_data.contiguous().view(-1)
-    return (uint8_data[1::2] << 4 | uint8_data[::2]).view(down_size(shape))
-
 def unpack_uint4(uint8_data) -> torch.Tensor:
     # Take a packed uint8 tensor (i.e. nvfp4) and unpack into
     # a tensor twice as wide. Useful for dequant operations.
@@ -481,13 +470,6 @@ def unpack_uint4(uint8_data) -> torch.Tensor:
     out[::2] = uint8_data_as_uint8 & 15
 
     return out.view(shape)
-
-def _bfloat16_to_float4_e2m1fn_x2(x):
-    assert x.dtype == torch.bfloat16
-    x = _f32_to_floatx_unpacked(x.float(), FP4_EBITS, FP4_MBITS)
-    x = pack_uint4(x)
-    x = x.view(torch.float4_e2m1fn_x2)
-    return x
 
 def _convert_to_nvfp4_with_hp_ref(t):
     # Convert a tensor to nvfp4, returning:
@@ -509,17 +491,34 @@ def _convert_to_nvfp4_with_hp_ref(t):
 
     return t_hp, t_lp, t_scale, t_global_scale
 
+def _convert_to_mxfp4_with_hp_ref(t):
+    # Convert a tensor to mxfp8, returning:
+    #   t_hp : reconstructed bf16 version of t_lp
+    #   t_lp : fp8_e4m3 tensor
+    #   t_scale: fp8_e8m0 block-wise scaling factors (non-swizzled)
+    t_scale, t_lp = to_mxfp(t, format="mxfp4")
+    t_hp = from_blocked_format(
+        _floatx_unpacked_to_f32(
+            unpack_uint4(t_lp),
+            FP4_EBITS,
+            FP4_MBITS),
+        t_scale,
+        blocksize=32
+    )
+
+    return t_hp, t_lp, t_scale
+
 def _convert_to_mxfp8_with_hp_ref(t):
     # Convert a tensor to mxfp8, returning:
     #   t_hp : reconstructed bf16 version of t_lp
     #   t_lp : fp8_e4m3 tensor
     #   t_scale: fp8_e8m0 block-wise scaling factors (non-swizzled)
-    t_scale, t_lp = to_mxfp8(t)
+    t_scale, t_lp = to_mxfp(t, format="mxfp8")
     t_hp = from_blocked_format(t_lp, t_scale, blocksize=32)
 
     return t_hp, t_lp, t_scale
 
-def _2d_grouped_tensor_to_mxfp8_blocked_scaled(t, MN, G, offs, format='mxfp8'):
+def _2d_grouped_tensor_to_blocked_scaled(t, MN, G, offs, format='mxfp8'):
     # Convert scales to blocked format. either mxfp8 or nvfp4
     th_list = []
     t_list = []
@@ -547,15 +546,18 @@ def _2d_grouped_tensor_to_mxfp8_blocked_scaled(t, MN, G, offs, format='mxfp8'):
                     t_slice,
                 )
                 t_global_scale_list.append(tq_global)
+            elif format == 'mxfp4':
+                th_slice, tq_slice, t_scale_slice = _convert_to_mxfp4_with_hp_ref(t_slice)
             else:
                 raise ValueError(f'format must be mxfp8|nvfp4, got "{format}"')
             t_list.append(tq_slice)
             th_list.append(th_slice)
 
             # Convert scales to blocked format.
-            t_scale_slice_blocked = to_blocked(
-                t_scale_slice
-            )  # (round_up(M, 128), round_up(K_group//32, 4))
+            if torch.version.cuda:
+                t_scale_slice_blocked = to_blocked(
+                    t_scale_slice
+                )  # (round_up(M, 128), round_up(K_group//32, 4))
             t_blocked_scale_list.append(t_scale_slice_blocked)
 
     # Assemble the full XQ and WQ
@@ -576,15 +578,18 @@ def _2d_grouped_tensor_to_mxfp8_blocked_scaled(t, MN, G, offs, format='mxfp8'):
 
 def _build_scaled_grouped_mm_kwargs(scale_a, scale_b, offs, format):
     # Build some standard args that are wordy
-    # Note: if/when ROCm support added, need to change swizzle handling
+    swizzle = SwizzleType.NO_SWIZZLE
+    if torch.version.cuda:
+        swizzle = SwizzleType.SWIZZLE_32_4_4
+
     kwargs = {
         'mxfp8': {
             'scale_a': scale_a,
             'scale_b': scale_b,
             'scale_recipe_a': ScalingType.BlockWise1x32,
             'scale_recipe_b': ScalingType.BlockWise1x32,
-            'swizzle_a': SwizzleType.SWIZZLE_32_4_4,
-            'swizzle_b': SwizzleType.SWIZZLE_32_4_4,
+            'swizzle_a': swizzle,
+            'swizzle_b': swizzle,
             'offs': offs,  # (G,)
             'out_dtype': torch.bfloat16,
             'wrap_v2': True,
@@ -594,13 +599,15 @@ def _build_scaled_grouped_mm_kwargs(scale_a, scale_b, offs, format):
             'scale_b': scale_b,
             'scale_recipe_a': [ScalingType.BlockWise1x16, ScalingType.TensorWise],
             'scale_recipe_b': [ScalingType.BlockWise1x16, ScalingType.TensorWise],
-            'swizzle_a': SwizzleType.SWIZZLE_32_4_4,
-            'swizzle_b': SwizzleType.SWIZZLE_32_4_4,
+            'swizzle_a': swizzle,
+            'swizzle_b': swizzle,
             'offs': offs,  # (G,)
             'out_dtype': torch.bfloat16,
             'wrap_v2': True,
         },
     }
+    # MXFP4 is exactly the same setup as mxfp8
+    kwargs['mxfp4'] = kwargs['mxfp8']
     return kwargs[format]
 
 class TestFP8Matmul(TestCase):
@@ -665,7 +672,7 @@ class TestFP8Matmul(TestCase):
     @parametrize("M", [2048, 2049])
     @parametrize("N", [8192])
     @parametrize("K", [16640])
-    @parametrize("format", ["mxfp8"] + (["nvfp4"] if torch.version.cuda else []))
+    @parametrize("format", ["mxfp8"] + (["nvfp4", "mxfp4"] if torch.version.cuda else []))
     def test_mxfp8_nvfp4_scaled_grouped_mm_2d_2d(self, G, M, N, K, format):
         torch.manual_seed(42)
         total_K = K  # Alias for clarity, communicating this consists of several groups along this dim
@@ -675,14 +682,14 @@ class TestFP8Matmul(TestCase):
         X = torch.randn((M, total_K), dtype=torch.bfloat16, device="cuda") * 0.1
         W = torch.randn((N, total_K), dtype=torch.bfloat16, device="cuda") * 0.01
 
-        xh, xq, x_blocked_scales, x_global_scales = _2d_grouped_tensor_to_mxfp8_blocked_scaled(
+        xh, xq, x_blocked_scales, x_global_scales = _2d_grouped_tensor_to_blocked_scaled(
             X, M, G, input_group_end_offsets, format=format
         )
-        wh, wq, w_blocked_scales, w_global_scales = _2d_grouped_tensor_to_mxfp8_blocked_scaled(
+        wh, wq, w_blocked_scales, w_global_scales = _2d_grouped_tensor_to_blocked_scaled(
             W, N, G, input_group_end_offsets, format=format
         )
 
-        if format == "mxfp8":
+        if format in ["mxfp4", "mxfp8"]:
             kwargs = _build_scaled_grouped_mm_kwargs(
                 x_blocked_scales,
                 w_blocked_scales,
@@ -697,7 +704,7 @@ class TestFP8Matmul(TestCase):
                 format,
             )
         else:
-            raise ValueError(f'format must be mxfp8|nvfp4, got "{format}"')
+            raise ValueError(f'format must be mxfp8|nvfp4|mxfp4, got "{format}"')
 
         if format == 'nvfp4':
             assert x_global_scales.numel() == w_global_scales.numel()
@@ -718,7 +725,7 @@ class TestFP8Matmul(TestCase):
         )
 
         # Assert no NaNs
-        assert not y_lp.isnan().any(), "mxfp8 output contains NaN"
+        assert not y_lp.isnan().any(), "low-precision output contains NaN"
 
         # Assert outputs are close
         torch.testing.assert_close(y_lp, y_bf16, atol=8.0e-2, rtol=8.0e-2)
@@ -728,7 +735,7 @@ class TestFP8Matmul(TestCase):
     @parametrize("M", [16640])
     @parametrize("N", [8192])
     @parametrize("K", [4096])
-    @parametrize("format", ["mxfp8"] + (["nvfp4"] if torch.version.cuda else []))
+    @parametrize("format", ["mxfp8"] + (["nvfp4", "mxfp4"] if torch.version.cuda else []))
     def test_mxfp8_scaled_grouped_mm_2d_3d(self, G, M, N, K, format):
         torch.manual_seed(42)
         # Simulate 2d-3d grouped gemm `out = input @ weight.t()`
@@ -752,15 +759,17 @@ class TestFP8Matmul(TestCase):
                 if format == "mxfp8":
                     wh, wq, w_scale = _convert_to_mxfp8_with_hp_ref(W[i])
                 elif format == "nvfp4":
-                    w_scale, wq = to_mxfp8(W[i])
+                    w_scale, wq = to_mxfp(W[i], format="mxfp8")
                     wh, wq, w_scale, w_global_scale = _convert_to_nvfp4_with_hp_ref(W[i])
                     w_global_scale_list.append(w_global_scale)
+                if format == "mxfp4":
+                    wh, wq, w_scale = _convert_to_mxfp4_with_hp_ref(W[i])
                 else:
-                    raise ValueError(f'format must be mxfp8|nvfp4, got "{format}"')
+                    raise ValueError(f'format must be mxfp8|nvfp4|mxfp4, got "{format}"')
 
                 # Swizzle scaled
-                # TODO(slayton): gate on cuda/hip
-                w_scale = to_blocked(w_scale)
+                if torch.version.cuda:
+                    w_scale = to_blocked(w_scale)
 
                 wh_list.append(wh)
                 wq_list.append(wq)
@@ -795,10 +804,13 @@ class TestFP8Matmul(TestCase):
                     elif format == "nvfp4":
                         xh, xq, x_scale, x_global_scale = _convert_to_nvfp4_with_hp_ref(x_slice)
                         x_global_scale_list.append(x_global_scale)
+                    if format == "mxfp4":
+                        xh, xq, x_scale = _convert_to_mxfp4_with_hp_ref(x_slice)
                     else:
-                        raise ValueError(f'format must be mxfp8|nvfp4, got "{format}"')
+                        raise ValueError(f'format must be mxfp8|nvfp4|mxfp4, got "{format}"')
 
-                    x_scale = to_blocked(x_scale)
+                    if torch.version.cuda:
+                        x_scale = to_blocked(x_scale)
                     xh_list.append(xh)
                     xq_list.append(xq)
                     x_scale_list.append(x_scale)
@@ -817,7 +829,7 @@ class TestFP8Matmul(TestCase):
 
         xh, xq, x_blocked_scales, x_global_scales = _2d_to_blocked_scaled(X, K, G, input_group_end_offsets, format)
 
-        if format == "mxfp8":
+        if format in ["mxfp8", "mxfp4"]:
             kwargs = _build_scaled_grouped_mm_kwargs(
                 x_blocked_scales,
                 w_blocked_scales,
@@ -1484,8 +1496,13 @@ class TestFP8Matmul(TestCase):
 
         A, A_scale, A_global_scale = data_to_nvfp4_with_global_scale(A_ref, BLOCK_SIZE)
         B, B_scale, B_global_scale = data_to_nvfp4_with_global_scale(B_ref, BLOCK_SIZE)
-        A_scale = to_blocked(A_scale)
-        B_scale = to_blocked(B_scale)
+
+        if torch.version.cuda:
+            A_scale = to_blocked(A_scale)
+            B_scale = to_blocked(B_scale)
+            swizzle = [SwizzleType.SWIZZLE_32_4_4, SwizzleType.NO_SWIZZLE]
+        else:
+            swizzle = [SwizzleType.NO_SWIZZLE, SwizzleType.NO_SWIZZLE]
 
         C_ref = A_ref @ B_ref.t()
 
@@ -1496,8 +1513,8 @@ class TestFP8Matmul(TestCase):
             scale_recipe_a=[ScalingType.BlockWise1x16, ScalingType.TensorWise],
             scale_b=[B_scale, B_global_scale],
             scale_recipe_b=[ScalingType.BlockWise1x16, ScalingType.TensorWise],
-            swizzle_a=[SwizzleType.SWIZZLE_32_4_4, SwizzleType.NO_SWIZZLE],
-            swizzle_b=[SwizzleType.SWIZZLE_32_4_4, SwizzleType.NO_SWIZZLE],
+            swizzle_a=swizzle,
+            swizzle_b=swizzle,
             output_dtype=torch.bfloat16,
         )
 

--- a/torch/testing/_internal/common_quantized.py
+++ b/torch/testing/_internal/common_quantized.py
@@ -530,10 +530,37 @@ def to_blocked(input_matrix) -> torch.Tensor:
 
     return rearranged.flatten()
 
+
+def down_size(size):
+    assert size[-1] % 2 == 0, f"{size} last dim not divisible by two"
+    return (*size[:-1], size[-1] // 2)
+
+
+def pack_uint4(uint8_data) -> torch.Tensor:
+    # converting to uint8 for operations
+    shape = uint8_data.shape
+    assert shape[-1] % 2 == 0
+    uint8_data = uint8_data.contiguous().view(-1)
+    return (uint8_data[1::2] << 4 | uint8_data[::2]).view(down_size(shape))
+
+
+# exponent and mantissa bits of `torch.float4_e2m1fn_x2`
+FP4_EBITS, FP4_MBITS = 2, 1
+
+
+def _bfloat16_to_float4_e2m1fn_x2(x):
+    assert x.dtype == torch.bfloat16
+    x = _f32_to_floatx_unpacked(x.float(), FP4_EBITS, FP4_MBITS)
+    x = pack_uint4(x)
+    x = x.view(torch.float4_e2m1fn_x2)
+    return x
+
+
 # This function is extracted from https://github.com/pytorch/ao/blob/v0.12.0/torchao/prototype/mx_formats/mx_tensor.py#L142
-def to_mxfp8(
+def to_mxfp(
     data_hp: torch.Tensor,
     block_size: int = 32,
+    format: str = "mxfp8",
 ):
     assert data_hp.dtype in (
         torch.bfloat16,
@@ -554,8 +581,12 @@ def to_mxfp8(
     data_hp = data_hp.to(torch.float32)
     max_abs = max_abs.to(torch.float32)
 
-    F8E4M3_MAX = torch.finfo(torch.float8_e4m3fn).max  # 448.0
-    max_pos = F8E4M3_MAX
+    if format == "mxfp8":
+        F8E4M3_MAX = torch.finfo(torch.float8_e4m3fn).max  # 448.0
+        max_pos = F8E4M3_MAX
+    elif format == "mxfp4":
+        F4E2M1_MAX = 6.
+        max_pos = F4E2M1_MAX
 
     # RCEIL
     def _to_mx_rceil(
@@ -592,9 +623,15 @@ def to_mxfp8(
     scale_e8m0_biased, data_lp = _to_mx_rceil(data_hp, max_abs, max_pos)
 
     # cast to target dtype
-    data_lp = data_lp.to(torch.float8_e4m3fn)
-    # need to reshape at the end to help inductor fuse things
-    data_lp = data_lp.reshape(orig_shape)
+    if format == "mxfp8":
+        data_lp = data_lp.to(torch.float8_e4m3fn)
+        # need to reshape at the end to help inductor fuse things
+        data_lp = data_lp.reshape(orig_shape)
+    elif format == "mxfp4":
+        data_lp = _bfloat16_to_float4_e2m1fn_x2(data_lp.to(torch.bfloat16))
+        final_shape = list(orig_shape)
+        final_shape[-1] //= 2
+        data_lp = data_lp.reshape(final_shape)
 
     scale_e8m0_biased = scale_e8m0_biased.view(torch.float8_e8m0fnu)
     scale_e8m0_biased = scale_e8m0_biased.squeeze(-1)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #166530

Summary:

* Extend `_scaled_grouped_mm_v2` to include MXFP4 support
* Add testing to existing grouped routines

Test Plan:

```
pytest -svv -k "mxfp4 and group" test/test_scaled_matmul_cuda.py
```

Reviewers:

Subscribers:

Tasks:

Tags:
Signed-off-by: Simon Layton <simonlayton@meta.com>