### PR TITLE
Replace decltype(auto) with auto

### DIFF
--- a/c10/test/util/TypeList_test.cpp
+++ b/c10/test/util/TypeList_test.cpp
@@ -239,7 +239,7 @@ struct Class2 {
 
 struct mapper_call_func {
   template <class T>
-  decltype(auto) operator()(T) {
+  auto operator()(T) {
     return T::type::func();
   }
 };
@@ -254,7 +254,7 @@ TEST(TypeListTest, MapTypesToValues_members) {
 
 struct mapper_call_nonexistent_function {
   template <class T>
-  decltype(auto) operator()(T) {
+  auto operator()(T) {
     return T::type::this_doesnt_exist();
   }
 };

--- a/c10/util/C++17.h
+++ b/c10/util/C++17.h
@@ -53,7 +53,7 @@ namespace guts {
 // member functions.
 namespace detail {
 template <class F, class Tuple, std::size_t... INDEX>
-C10_HOST_DEVICE constexpr decltype(auto) apply_impl(
+C10_HOST_DEVICE constexpr auto apply_impl(
     F&& f,
     Tuple&& t,
     std::index_sequence<INDEX...>) {
@@ -62,7 +62,7 @@ C10_HOST_DEVICE constexpr decltype(auto) apply_impl(
 } // namespace detail
 
 template <class F, class Tuple>
-C10_HOST_DEVICE constexpr decltype(auto) apply(F&& f, Tuple&& t) {
+C10_HOST_DEVICE constexpr auto apply(F&& f, Tuple&& t) {
   return detail::apply_impl(
       std::forward<F>(f),
       std::forward<Tuple>(t),

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -469,7 +469,7 @@ C10_API std::string GetExceptionString(const std::exception& e);
 
 namespace c10::detail {
 template <typename... Args>
-decltype(auto) torchCheckMsgImpl(const char* /*msg*/, const Args&... args) {
+auto torchCheckMsgImpl(const char* /*msg*/, const Args&... args) {
   return ::c10::str(args...);
 }
 inline C10_API const char* torchCheckMsgImpl(const char* msg) {

--- a/c10/util/StringUtil.h
+++ b/c10/util/StringUtil.h
@@ -135,7 +135,7 @@ struct _str_wrapper<> final {
 
 // Convert a list of string-like arguments into a single string.
 template <typename... Args>
-inline decltype(auto) str(const Args&... args) {
+inline auto str(const Args&... args) {
   return detail::_str_wrapper<
       typename detail::CanonicalizeStrTypes<Args>::type...>::call(args...);
 }

--- a/c10/util/TypeList.h
+++ b/c10/util/TypeList.h
@@ -507,7 +507,7 @@ struct map_types_to_values<typelist<Types...>> final {
 } // namespace detail
 
 template <class TypeList, class Func>
-decltype(auto) map_types_to_values(Func&& func) {
+auto map_types_to_values(Func&& func) {
   return detail::map_types_to_values<TypeList>::call(std::forward<Func>(func));
 }
 

--- a/torch/csrc/api/include/torch/nn/options/conv.h
+++ b/torch/csrc/api/include/torch/nn/options/conv.h
@@ -60,7 +60,7 @@ struct ConvNdOptions {
   TORCH_ARG(padding_t, padding) = 0;
 
  public:
-  decltype(auto) padding(std::initializer_list<int64_t> il) {
+  auto padding(std::initializer_list<int64_t> il) {
     return padding(IntArrayRef{il});
   }
 
@@ -139,7 +139,7 @@ struct ConvOptions {
   TORCH_ARG(padding_t, padding) = 0;
 
  public:
-  decltype(auto) padding(std::initializer_list<int64_t> il) {
+  auto padding(std::initializer_list<int64_t> il) {
     return padding(IntArrayRef{il});
   }
 
@@ -209,7 +209,7 @@ struct ConvFuncOptions {
   TORCH_ARG(padding_t, padding) = 0;
 
  public:
-  decltype(auto) padding(std::initializer_list<int64_t> il) {
+  auto padding(std::initializer_list<int64_t> il) {
     return padding(IntArrayRef{il});
   }
 

--- a/torch/csrc/api/include/torch/nn/pimpl.h
+++ b/torch/csrc/api/include/torch/nn/pimpl.h
@@ -130,7 +130,7 @@ class ModuleHolder : torch::detail::ModuleHolderIndicator {
   /// NOTE: std::forward is qualified to prevent VS2017 emitting
   ///       error C2872: 'std': ambiguous symbol
   template <typename Arg>
-  decltype(auto) operator[](Arg&& arg) {
+  auto operator[](Arg&& arg) {
     return (*impl_)[::std::forward<Arg>(arg)];
   }
 

--- a/torch/csrc/distributed/c10d/error.h
+++ b/torch/csrc/distributed/c10d/error.h
@@ -15,13 +15,12 @@ namespace fmt {
 
 template <>
 struct formatter<std::error_category> {
-  constexpr decltype(auto) parse(format_parse_context& ctx) const {
+  constexpr auto parse(format_parse_context& ctx) const {
     return ctx.begin();
   }
 
   template <typename FormatContext>
-  decltype(auto) format(const std::error_category& cat, FormatContext& ctx)
-      const {
+  auto format(const std::error_category& cat, FormatContext& ctx) const {
     if (std::strcmp(cat.name(), "generic") == 0) {
       return fmt::format_to(ctx.out(), "errno");
     } else {
@@ -32,12 +31,12 @@ struct formatter<std::error_category> {
 
 template <>
 struct formatter<std::error_code> {
-  constexpr decltype(auto) parse(format_parse_context& ctx) const {
+  constexpr auto parse(format_parse_context& ctx) const {
     return ctx.begin();
   }
 
   template <typename FormatContext>
-  decltype(auto) format(const std::error_code& err, FormatContext& ctx) const {
+  auto format(const std::error_code& err, FormatContext& ctx) const {
     return fmt::format_to(
         ctx.out(), "({}: {} - {})", err.category(), err.value(), err.message());
   }

--- a/torch/csrc/distributed/c10d/socket.cpp
+++ b/torch/csrc/distributed/c10d/socket.cpp
@@ -247,12 +247,12 @@ namespace fmt {
 
 template <>
 struct formatter<::addrinfo> {
-  constexpr decltype(auto) parse(format_parse_context& ctx) const {
+  constexpr auto parse(format_parse_context& ctx) const {
     return ctx.begin();
   }
 
   template <typename FormatContext>
-  decltype(auto) format(const ::addrinfo& addr, FormatContext& ctx) const {
+  auto format(const ::addrinfo& addr, FormatContext& ctx) const {
     return fmt::format_to(
         ctx.out(),
         "{}",
@@ -262,14 +262,13 @@ struct formatter<::addrinfo> {
 
 template <>
 struct formatter<c10d::detail::SocketImpl> {
-  constexpr decltype(auto) parse(format_parse_context& ctx) const {
+  constexpr auto parse(format_parse_context& ctx) const {
     return ctx.begin();
   }
 
   template <typename FormatContext>
-  decltype(auto) format(
-      const c10d::detail::SocketImpl& socket,
-      FormatContext& ctx) const {
+  auto format(const c10d::detail::SocketImpl& socket, FormatContext& ctx)
+      const {
     ::sockaddr_storage addr_s{};
 
     auto addr_ptr = reinterpret_cast<::sockaddr*>(&addr_s);

--- a/torch/csrc/jit/runtime/register_ops_utils.h
+++ b/torch/csrc/jit/runtime/register_ops_utils.h
@@ -121,7 +121,7 @@ double radians(double x);
 
 // Equivalent to list.at(idx)
 template <typename T>
-decltype(auto) getItem(const c10::List<T>& list, int64_t idx) {
+auto getItem(const c10::List<T>& list, int64_t idx) {
   const int64_t list_size = list.size();
   const int64_t normalized_idx = normalizeIndex(idx, list_size);
   if (normalized_idx < 0 || normalized_idx >= list_size) {

--- a/torch/csrc/profiler/collection.h
+++ b/torch/csrc/profiler/collection.h
@@ -380,12 +380,12 @@ struct TORCH_API Result : public std::enable_shared_from_this<Result> {
   }
 
   template <typename T>
-  decltype(auto) visit(T&& visitor) {
+  auto visit(T&& visitor) {
     return std::visit(std::forward<T>(visitor), extra_fields_);
   }
 
   template <typename T>
-  decltype(auto) visit(T&& visitor) const {
+  auto visit(T&& visitor) const {
     return std::visit(std::forward<T>(visitor), extra_fields_);
   }
 


### PR DESCRIPTION
This PR replaces `decltype(auto)` with `auto` for C++ return type deduction and simplifies some templates.  

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @EikanWang @jgong5 @wenzhe-nrv @sanchitintel