### PR TITLE
Fix torch.full with dynamic tensor fill_value in torch.compile

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -5215,37 +5215,63 @@ class DefaultsTests(torch._dynamo.test_case.TestCase):
         opt_mod = torch.compile(mod, backend="eager", fullgraph=True)
         x = torch.randn(1)
         self.assertEqual(opt_mod(x), x + 1)
-    
+
     def test_full_with_tensor_fill_value(self):
         """Test that torch.full works correctly with dynamic tensor fill_value"""
-        def func(x):
+
+        # Test with tensor fill_value (the bug case)
+        def func_tensor(x):
             return torch.full((2,), x, dtype=torch.float64)
-        
-        func_compiled = torch.compile(func)
-        
+
+        func_compiled = torch.compile(func_tensor)
+
         # Test with different values
         x1 = torch.tensor(5.0, dtype=torch.float64)
         x2 = torch.tensor(10.0, dtype=torch.float64)
-        
+
         result1 = func_compiled(x1)
         expected1 = torch.full((2,), x1, dtype=torch.float64)
         self.assertEqual(result1, expected1)
-        
+
         # This is where the bug occurred - second call reused first value
         result2 = func_compiled(x2)
         expected2 = torch.full((2,), x2, dtype=torch.float64)
         self.assertEqual(result2, expected2)
-        
+
         # Test with different dtypes
         for dtype in [torch.float32, torch.float64, torch.int32, torch.int64]:
+
             def func_typed(x):
                 return torch.full((3,), x, dtype=dtype)
-            
+
             func_typed_compiled = torch.compile(func_typed)
             x_typed = torch.tensor(7, dtype=dtype)
             result = func_typed_compiled(x_typed)
             expected = torch.full((3,), x_typed, dtype=dtype)
             self.assertEqual(result, expected)
+
+        # Test with non-tensor fill_value (scalar) to ensure we didn't break existing behavior
+        def func_scalar(size):
+            return torch.full((size,), 42.0, dtype=torch.float32)
+
+        func_scalar_compiled = torch.compile(func_scalar)
+
+        result_scalar = func_scalar_compiled(5)
+        expected_scalar = torch.full((5,), 42.0, dtype=torch.float32)
+        self.assertEqual(result_scalar, expected_scalar)
+
+        # Test with different scalar values
+        def func_scalar_param():
+            # Test multiple calls with different hardcoded scalar values
+            a = torch.full((2,), 3.14, dtype=torch.float32)
+            b = torch.full((2,), 2.71, dtype=torch.float32)
+            return a, b
+
+        func_scalar_param_compiled = torch.compile(func_scalar_param)
+        result_a, result_b = func_scalar_param_compiled()
+
+        self.assertEqual(result_a, torch.full((2,), 3.14, dtype=torch.float32))
+        self.assertEqual(result_b, torch.full((2,), 2.71, dtype=torch.float32))
 
 
 instantiate_parametrized_tests(FunctionTests)

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -841,18 +841,6 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
                 )
                 # Call fill_ method on the empty tensor
                 return empty_result.call_method(tx, "fill_", [fill_value], {})
-            else:
-                # For Python scalars and other non-tensor types, use default lowering
-                from .builder import wrap_fx_proxy
-
-                return wrap_fx_proxy(
-                    tx=tx,
-                    proxy=tx.output.create_proxy(
-                        "call_function",
-                        torch.ops.aten.full.default,
-                        *proxy_args_kwargs([size, fill_value], kwargs),
-                    ),
-                )
 
         @register(torch._foreach_lerp_)
         def handle_inplace_foreach_lerp_scalar(


### PR DESCRIPTION
Fixes #166253

## Summary
When `torch.full` is called with a 0-D tensor as `fill_value` inside a `torch.compile`'d function, the value was being incorrectly cached, causing subsequent calls with different values to return the first value.

## Root Cause
The Dynamo handler for `torch.full` was calling `aten._local_scalar_dense` to convert tensor fill_values to Python scalars at compile time, which baked the value into the compiled graph as a constant.

## Solution
Modified the Dynamo handler to decompose `torch.full(size, tensor_fill_value)` into `empty(size).fill_(tensor_fill_value)` when `fill_value` is a `TensorVariable`, keeping the fill value dynamic in the compiled graph.

## Testing
Added test case that verifies torch.full works correctly with dynamic tensor fill_values across multiple calls and dtypes.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela