### PR TITLE
[cuDNN][SDPA] Check-in test for #166211

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2871,9 +2871,9 @@ class TestSDPACudaOnly(NNTestCase):
                 attn_output = torch.nn.functional.scaled_dot_product_attention(q, k, v)
                 attn_output.backward(grad_attn_output)
 
-            self.assertEqual(q.grad, q_ref.grad, atol=10.0, rtol=0.05)
-            self.assertEqual(k.grad, k_ref.grad, atol=10.0, rtol=0.05)
-            self.assertEqual(v.grad, v_ref.grad, atol=10.0, rtol=0.05)
+            for x, x_ref in zip((q, k, v), (q_ref, k_ref, v_ref)):
+                self.assertEqual(x.grad, x_ref.grad, atol=10.0, rtol=0.05)
+
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Fused SDPA was not built for this system")
     @parametrize("mask_dim", [1, 2, 3, 4])

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2861,12 +2861,7 @@ class TestSDPACudaOnly(NNTestCase):
 
             grad_attn_output = torch.randn(*shape, device='cuda', dtype=torch.bfloat16) * scale
 
-            q_ref = q.detach().clone()
-            q_ref.requires_grad = True
-            k_ref = k.detach().clone()
-            k_ref.requires_grad = True
-            v_ref = v.detach().clone()
-            v_ref.requires_grad = True
+            q_ref, k_ref, v_ref = (x.detach().clone().requires_grad_() for x in [q, k, v])
 
             with torch.nn.attention.sdpa_kernel(torch.nn.attention.SDPBackend.FLASH_ATTENTION):
                 attn_output_ref = torch.nn.functional.scaled_dot_product_attention(q_ref, k_ref, v_ref)

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2871,7 +2871,7 @@ class TestSDPACudaOnly(NNTestCase):
                 attn_output = torch.nn.functional.scaled_dot_product_attention(q, k, v)
                 attn_output.backward(grad_attn_output)
 
-            for x, x_ref in zip((q, k, v), (q_ref, k_ref, v_ref)):
+            for x, x_ref in zip((q, k, v), (q_ref, k_ref, v_ref), strict=True):
                 self.assertEqual(x.grad, x_ref.grad, atol=10.0, rtol=0.05)
 
 


### PR DESCRIPTION
Repros without the neeed for specific tensor data.
Should be passing with cuDNN frontend 1.15.0 which current `main` has.

cc @csarofeen @ptrblck @xwang233