### PR TITLE
make FXConverter.generate use V.fake_mode instead of _detect_fake_mode_from_gm

### DIFF
--- a/test/inductor/test_fxir_backend.py
+++ b/test/inductor/test_fxir_backend.py
@@ -1114,6 +1114,58 @@ def forward(self, arg0_1, arg1_1, arg2_1):
             dynamic_shapes=dynamic_shapes,
         )
 
+    def test_const_folded_subgraph(self):
+        """
+        If a graph only contains a call_module node to a subgraph,
+        where the subgraph can be const-folded away,
+        validate the fake mode used in FXConverter generation is not None.
+        """
+        device = self.device
+        shape = (5, 10)
+
+        class Submodule(torch.nn.Module):
+            def forward(self):
+                return torch.randn(*shape, device=device) + 1
+
+        # Create a parent graph with this module as a subgraph and output
+        ep = torch.export.export(Submodule(), ())
+        parent_graph = torch.fx.Graph()
+        call_mod = parent_graph.call_module("sub", args=())
+        get_item = parent_graph.call_function(
+            operator.getitem, args=(call_mod, slice(None))
+        )
+        parent_graph.output((get_item,))
+        parent = torch.fx.GraphModule({"sub": ep.module()}, parent_graph)
+
+        # Verify FXConverter.generate uses non-null fake mode
+        # Intercept _set_node_metadata_hook to ensure fake_mode is not None
+        orig_set_hook = torch._inductor.codegen.wrapper_fxir._set_node_metadata_hook
+        called = False
+
+        def mock_set_hook(gm: torch.fx.GraphModule, fn):
+            nonlocal called
+            called = True
+            # Please update this check if `fake_mode` is
+            # no longer used in FXConverter call to _node_metadata_hook
+            self.assertTrue("fake_mode" in fn.keywords)
+            self.assertIsNotNone(fn.keywords["fake_mode"])
+            return orig_set_hook(gm, fn)
+
+        self.assertFalse(called)
+        with unittest.mock.patch.object(
+            torch._inductor.codegen.wrapper_fxir,
+            "_set_node_metadata_hook",
+            mock_set_hook,
+        ):
+            args = ()
+            compiled = torch._inductor.aot_compile(
+                parent, args, options={"fx_wrapper": True}
+            )
+            self.assertTrue(called)
+
+            compiled_out = compiled(*args)
+            self.assertEqual(compiled_out.shape, shape)
+
 
 class TestReplaceFloorDiv(InductorTestCase):
     """

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -14,7 +14,6 @@ from torch._export.passes._node_metadata_hook import (
     _node_metadata_hook,
     _set_node_metadata_hook,
 )
-from torch._export.utils import _detect_fake_mode_from_gm
 from torch._higher_order_ops.triton_kernel_wrap import (
     TraceableTritonKernelWrapper,
     tracing_triton_hopifier_singleton,
@@ -23,7 +22,7 @@ from torch._higher_order_ops.triton_kernel_wrap import (
 from torch._inductor.codecache import LambdaFuture, PyCodeCache
 from torch._inductor.runtime.triton_heuristics import CachingAutotuner
 from torch._inductor.select_algorithm import extern_kernels  # noqa: F401
-from torch._inductor.utils import convert_shape_to_symint, convert_to_symint
+from torch._inductor.utils import convert_to_symint
 from torch._inductor.virtualized import V
 from torch._library.triton import wrap_triton
 from torch.fx import GraphModule
@@ -315,21 +314,6 @@ class FxConverter:
 
         return kernel
 
-    def _fake_tensor(
-        self,
-        size: tuple[Any, ...],
-        stride: tuple[Any, ...],
-        dtype: Optional[torch.dtype] = None,
-        device: Optional[torch.device] = None,
-    ) -> torch.Tensor:
-        with V.fake_mode:
-            return torch.empty_strided(
-                convert_shape_to_symint(size),
-                convert_shape_to_symint(stride),
-                dtype=dtype,
-                device=device,
-            )
-
     def _create_as_strided(
         self,
         input_node: torch.fx.Node,
@@ -606,11 +590,9 @@ class FxConverter:
         self._generate_graph_constants()
         self._generate_subgm_getattrs()
 
-        fake_mode = _detect_fake_mode_from_gm(self.gm)
-
         with _set_node_metadata_hook(
             self.gm,
-            functools.partial(_node_metadata_hook, fake_mode=fake_mode),
+            functools.partial(_node_metadata_hook, fake_mode=V.fake_mode),
         ):
             self._generate_graph_input_shapes()
 


### PR DESCRIPTION
Summary:
FXConverter configurs _node_metadata_hook passing in `fake_mode` explicitly, which is relevant for cases down the line like `_generate_triton_call` that inserts a `triton_kernel_wrapper_mutation` node. 

This `fake_mode` is obtained from `_detect_fake_mode_from_gm`, which can be different from inductor set `V.fake_mode`. 

For example, while `V.fake_mode` is not None, `_detect_fake_mode_from_gm` can be **None** for a parent graph containing only a submodule which has no input args and only constants
```
parent graph():
    %sub : [num_users=1] = call_module[target=sub](args = (), kwargs = {})
    %getitem : [num_users=1] = call_function[target=operator.getitem](args = (%sub, slice(None, None, None)), kwargs = {})
    return (getitem,)

submodule graph():
    %randn : [num_users=1] = call_function[target=torch.ops.aten.randn.default](args = ([5, 10],), kwargs = {device: cuda, pin_memory: False})
    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%randn, 1), kwargs = {})
    return (add,)

``` 

Getting this discrepnancy is flawed, it makes `_node_metadata_hook` try running inputs in a different "fake_mode" or no fake_mode when the rest of lowering uses `V.fake_mode`. In some cases where input is placed on custom non-gpu device, it can even complain with "requires device to be started" or tensor device mismatch.

So this diff updates FXConverter.generate to use `V.fake_mode` which is populated by inductor properly.

Test Plan:
added a test `test_const_folded_subgraph` in `test_fxir_backend.py`, this test:
- creates a graph module that calls a subgraph with no inputs and containing only const-foldable ops
- const fold the subgraph  
- run FXConverter.generate, expect `fake_mode` used to code-generate is not None

On the prior implementation when `_detect_fake_mode_from_gm` was used, this test would fail as fake_mode would be `None`. 

With this change, the test passes, `fake_mode` is properly collected from `V.fake_mode` which is not None.

Differential Revision: D85767475




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben