### PR TITLE
I hate colexigraphical order

### DIFF
--- a/torch/_inductor/codegen/cutedsl/cutedsl_utils.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_utils.py
@@ -1,0 +1,27 @@
+import cutlass.cute as cute
+
+
+@cute.jit
+def ssa_to_indexable(ssa_value: cute.TensorSSA, dtype) -> cute.Numeric:
+    """
+    Convert SSA form to indexable non-SSA form.
+
+    Workaround for lack of gather support: SSA values cannot be used directly
+    as indices in tensor loads. This converts SSA → fragment → scalar for indexing.
+    """
+    frag = cute.make_fragment(1, dtype)
+    frag.store(ssa_value)
+    return frag[0]
+
+
+@cute.jit
+def result_to_ssa(value: cute.Numeric, dtype) -> cute.TensorSSA:
+    """
+    Convert non-SSA result back to SSA form.
+
+    After performing operations with non-SSA values (like indexed loads),
+    convert the result back to SSA form for further computation.
+    """
+    frag = cute.make_fragment(1, dtype)
+    frag[0] = value
+    return frag.load()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #166657
* __->__ #166605
* #166359


# Summary

Okay so whle testing the mask-mod support and block-mask support I added doc_ids for testing. And noticed the numerics were off.

What was happend. By default ops.load uses the linearized form of indexing. And cutedsl tensor indexing also allows for linearized form. HOWEVER, cute is column major and triton / inductor is row-major. Thus we were incorrectly indexing in the wrong order.


So what does this do?

1. it adds some utilities which make the output code a little easier to understand.
2. It goes from linear index back to the individual dim index and then lets cute handle the majorness