### PR TITLE
torch.fx: add debug-level logging to Interpreter.run_node (#117351)

### DIFF
--- a/torch/fx/interpreter.py
+++ b/torch/fx/interpreter.py
@@ -2,10 +2,12 @@
 import inspect
 from contextlib import contextmanager
 from typing import Any, Optional, TYPE_CHECKING, Union
+import logging
 
 import torch
 import torch.fx.traceback as fx_traceback
 from torch._logging import trace_structured
+from torch._logging import LazyString
 from torch.hub import tqdm
 
 from . import config
@@ -21,6 +23,7 @@ from .proxy import Proxy
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+log = logging.getLogger(__name__)
 
 __all__ = ["Interpreter", "Transformer"]
 
@@ -249,6 +252,7 @@ class Interpreter:
         Returns:
             Any: The result of executing ``n``
         """
+        log.debug("run_node %s", LazyString(lambda: n.format_node()))
         with self._set_current_node(n):
             args, kwargs = self.fetch_args_kwargs_from_env(n)
             assert isinstance(args, tuple)

--- a/torch/fx/interpreter.py
+++ b/torch/fx/interpreter.py
@@ -252,7 +252,15 @@ class Interpreter:
         Returns:
             Any: The result of executing ``n``
         """
-        log.debug("run_node %s", LazyString(lambda: n.format_node()))
+        log.debug(
+            "run_node %s",
+            LazyString(lambda:
+                f"{n.name} = "
+                f"{getattr(n.target, '__module__', '') + '.' if hasattr(n.target, '__module__') else ''}"
+                f"{getattr(n.target, '__name__', n.target)}"
+                f"({', '.join(map(str, n.args))})"
+            ),
+        )
         with self._set_current_node(n):
             args, kwargs = self.fetch_args_kwargs_from_env(n)
             assert isinstance(args, tuple)

--- a/torch/fx/interpreter.py
+++ b/torch/fx/interpreter.py
@@ -1,13 +1,12 @@
 # mypy: allow-untyped-defs
 import inspect
+import logging
 from contextlib import contextmanager
 from typing import Any, Optional, TYPE_CHECKING, Union
-import logging
 
 import torch
 import torch.fx.traceback as fx_traceback
-from torch._logging import trace_structured
-from torch._logging import LazyString
+from torch._logging import LazyString, trace_structured
 from torch.hub import tqdm
 
 from . import config
@@ -26,6 +25,30 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 __all__ = ["Interpreter", "Transformer"]
+
+
+def _format_fx_node(n):
+    """
+    Format a torch.fx.Node into a human-readable string for debug logging.
+
+    Args:
+        n (torch.fx.Node): The FX node being executed.
+
+    Returns:
+        str: A formatted string describing the node operation, including its
+        name, target, positional arguments, and keyword arguments.
+    """
+    module_prefix = getattr(n.target, "__module__", "")
+    module_prefix = f"{module_prefix}." if module_prefix else ""
+
+    # Handle positional and keyword arguments
+    args = ", ".join(map(str, n.args))
+    kwargs = ", ".join(f"{k}={v}" for k, v in n.kwargs.items())
+    joined = ", ".join(filter(None, [args, kwargs]))
+
+    return (
+        f"{n.name} = {module_prefix}{getattr(n.target, '__name__', n.target)}({joined})"
+    )
 
 
 @compatibility(is_backward_compatible=True)
@@ -252,15 +275,7 @@ class Interpreter:
         Returns:
             Any: The result of executing ``n``
         """
-        log.debug(
-            "run_node %s",
-            LazyString(lambda:
-                f"{n.name} = "
-                f"{getattr(n.target, '__module__', '') + '.' if hasattr(n.target, '__module__') else ''}"
-                f"{getattr(n.target, '__name__', n.target)}"
-                f"({', '.join(map(str, n.args))})"
-            ),
-        )
+        log.debug("run_node %s", LazyString(lambda: _format_fx_node(n)))
         with self._set_current_node(n):
             args, kwargs = self.fetch_args_kwargs_from_env(n)
             assert isinstance(args, tuple)


### PR DESCRIPTION
### Summary
Adds a debug-level logging statement to torch.fx.Interpreter.run_node, as proposed in [#117351](https://github.com/pytorch/pytorch/issues/117351), to make FX graph execution traceable when debugging or instrumenting model transformations.

When debug logging is enabled, each executed node emits a single structured log line formatted via `LazyString(lambda: n.format_node())`, deferring string construction unless logging is active.

### Example Output
With `logging.DEBUG` enabled:

```
run_node x = x()
run_node add = _operator.add(x, 1)
run_node clamp = torch.clamp(add, min=0.0, max=5.0)
run_node output = output(clamp)
```

With `logging.DEBUG` disabled no additional output is produced (unchanged default behavior).

### Test Plan

Verified locally with Python 3.11 on macOS using a PyTorch build from source.

- With `logging.DEBUG` enabled: each node emits a debug log via LazyString.
- With `logging.DEBUG` disabled: no additional output.
- Confirmed all `Interpreter` tests pass locally:
`pytest test/test_fx.py -k "Interpreter"`

Updated the example output to reflect the new `_format_fx_node` helper and inclusion of `kwargs`.

cc @ezyang @EikanWang @jgong5 @wenzhe-nrv