### PR TITLE
Fix skip condition in test_overrides

### DIFF
--- a/test/test_overrides.py
+++ b/test/test_overrides.py
@@ -9,11 +9,11 @@ import pprint
 import pickle
 import collections
 import unittest
-import os
 
 from torch.testing._internal.common_utils import (
     TestCase,
     run_tests,
+    TEST_CUDA,
     TEST_WITH_CROSSREF,
     TEST_WITH_TORCHDYNAMO,
     skipIfTorchDynamo,
@@ -46,8 +46,7 @@ from torch.utils._pytree import tree_map
 
 Tensor = torch.Tensor
 
-if os.getenv("ATEN_CPU_CAPABILITY") in ("default", "avx2"):
-    # This test is not supported on ARM
+if not TEST_CUDA:
     print(
         "Skipping due to failing when cuda build runs on non cuda machine, "
         + "see https://github.com/pytorch/pytorch/pull/150059 for example"


### PR DESCRIPTION
This fixes the condition introduced in in #150059

The reason for the [failure](https://hud.pytorch.org/pytorch/pytorch/commit/bf752c36da08871d76a66fd52ad09f87e66fc770#39484562957-box) is running the test on a non-CUDA machine:
```
   File "/var/lib/jenkins/workspace/test/test_overrides.py", line 786, in <module>
     generate_tensor_like_override_tests(TestTorchFunctionOverride)
   File "/var/lib/jenkins/workspace/test/test_overrides.py", line 753, in generate_tensor_like_override_tests
     test_method = test_generator(func, override)
   File "/var/lib/jenkins/workspace/test/test_overrides.py", line 714, in test_generator
     arg_to_add = _simple_type_parser(func, arg["name"], t)
   File "/var/lib/jenkins/workspace/test/test_overrides.py", line 683, in _simple_type_parser
     return torch.Stream()
 RuntimeError: CUDA error: CUDA driver version is insufficient for CUDA runtime version
```

The printed message reflects that but neither the condition nor the comment does.

It happens to work "by accident" because `test.sh` uses 
```
if [[ $TEST_CONFIG == 'nogpu_NO_AVX2' ]]; then
  export ATEN_CPU_CAPABILITY=default
elif [[ $TEST_CONFIG == 'nogpu_AVX512' ]]; then
  export ATEN_CPU_CAPABILITY=avx2
```

However this test then still fails when run outside this specific CI environment, so use the `TEST_CUDA` constant instead to check for CUDA