### PR TITLE
[inductor][determinism] deterministically cache padmm

### DIFF
--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -21,6 +21,7 @@ from torch._inductor.autoheuristic.autoheuristic_utils import (
     pad_mm_operations,
     pad_mm_precondition,
 )
+from torch._inductor.runtime.caching import icache
 from torch._subclasses.fake_tensor import FakeTensor
 from torch.utils._mode_utils import no_dispatch
 
@@ -405,6 +406,21 @@ def get_do_bench() -> Callable[[Callable[[], Any]], float]:
         )
 
 
+def _should_pad_bench_params_encoder(
+    match: Match,
+    mat1: Tensor,
+    mat2: Tensor,
+    op: torch._ops.OpOverloadPacket,
+    input: Tensor | None = None,
+) -> dict[str, Any]:
+    return {
+        "key": should_pad_bench_key(
+            match, mat1, mat2, op, input, is_base_time_key=False
+        )
+    }
+
+
+@icache.record(custom_params_encoder=_should_pad_bench_params_encoder)
 def _should_pad_bench(
     match: Match,
     mat1: Tensor,

--- a/torch/_inductor/runtime/caching/interfaces.py
+++ b/torch/_inductor/runtime/caching/interfaces.py
@@ -7,15 +7,13 @@ from abc import ABC, abstractmethod
 from ast import literal_eval
 from enum import Enum
 from functools import partial, wraps
-from logging import DEBUG, getLogger, Logger
+from logging import DEBUG, getLogger, INFO, Logger
 from os import PathLike
 from pathlib import Path
 from threading import Lock
 from time import time
 from typing import Any, TYPE_CHECKING, TypeAlias
 from typing_extensions import override
-
-from filelock import FileLock
 
 from . import config, context, exceptions, implementations as impls, locks
 
@@ -329,10 +327,10 @@ class _CacheIntf(ABC):
     def record(
         self,
         ischema: context.IsolationSchema | None = None,
-        custom_params_encoder: Callable[P, Any] | None = None,
-        custom_result_encoder: Callable[[R], Any] | None = None,
-        custom_result_decoder: Callable[[Any], R] | None = None,
-    ) -> Callable[[Callable[P, R]], Callable[P, R]]:
+        custom_params_encoder: Callable[..., Any] | None = None,
+        custom_result_encoder: Callable[..., Any] | None = None,
+        custom_result_decoder: Callable[..., ...] | None = None,
+    ) -> Callable[[Callable[..., ...]], Callable[..., ...]]:
         if custom_result_encoder and not custom_result_decoder:
             raise exceptions.CustomResultDecoderRequiredError(
                 "Custom result encoder provided without custom result decoder."
@@ -506,16 +504,22 @@ class _DeterministicCacheIntf(_CacheIntf):
         super().__init__()
         self._imc: impls._InMemoryCacheImpl = impls._InMemoryCacheImpl()
 
-        if fpath := os.environ.get("TORCHINDUCTOR_PRE_POPULATE_DETERMINISTIC_CACHE"):
-            # pyrefly: ignore [bad-assignment]
-            flock: FileLock = FileLock(str(fpath) + ".lock")
-            with locks._acquire_flock_with_timeout(flock):
-                with open(fpath) as fp:
-                    dump_for_pre_population: dict[str, str] = json.load(fp)
-                for key_r, value_r in dump_for_pre_population.items():
-                    key: bytes = literal_eval(key_r)
-                    value: bytes = literal_eval(value_r)
-                    self._imc._memory[key] = value
+        if fpath_str := os.environ.get(
+            "TORCHINDUCTOR_PRE_POPULATE_DETERMINISTIC_CACHE"
+        ):
+            fpath: Path = Path(fpath_str)
+            fpath_parent: PathLike[str] = fpath.parent
+            if fpath.is_file():
+                odc: impls._OnDiskCacheImpl = impls._OnDiskCacheImpl(
+                    sub_dir=fpath_parent
+                )
+                with odc.lock():
+                    with open(fpath) as fp:
+                        dump_for_pre_population: dict[str, str] = json.load(fp)
+                    for key_r, value_r in dump_for_pre_population.items():
+                        key: bytes = literal_eval(key_r)
+                        value: bytes = literal_eval(value_r)
+                        self._imc._memory[key] = value
 
         if config.STRICTLY_PRE_POPULATED_DETERMINISM:
             # we'll never need a synchronization cache if we're in strictly pre-populated mode,
@@ -578,7 +582,7 @@ class _DeterministicCacheIntf(_CacheIntf):
                     for key, value in existing_dump.items():
                         if key not in to_dump:
                             to_dump[key] = value
-                        else:
+                        elif to_dump[key] != value:
                             raise exceptions.DeterministicCachingIMCDumpConflictError from None
 
                     w_fp = open(fpath, "w")
@@ -586,6 +590,9 @@ class _DeterministicCacheIntf(_CacheIntf):
                     assert w_fp is not None
                     try:
                         json.dump(to_dump, w_fp, indent=4)
+                        logger.log(
+                            INFO, "Dumped deterministic cache memoization to %s", fpath
+                        )
                     finally:
                         w_fp.close()
 


### PR DESCRIPTION
Summary: luckily we can just reuse the prior key calculation for matmul padding with minor tweaks, otherwise it seems like it does just work as expected

Test Plan: `buck test fbcode//mode/opt caffe2/test/inductor:caching -- test_matmul_padding`

Differential Revision: D85684098




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @chenyang78