### PR TITLE
Refactor AOTAutogradCacheEntry into AOTAutogradResult

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -28,8 +28,6 @@ e3900d2ba5c9f91a24a9ce34520794c8366d5c54
 b0043072529b81276a69df29e00555333117646c
 # 2021-08-25 Reformat run_test.py
 67d8e7b659b19e1ee68208b28bfa7dba73375dbc
-# 2025-10-30 Refactor AOTAutogradCacheEntry into AOTAutogradResult and extract to aot_autograd_result.py
-36bbfcc0dab2592a1da71d29b1c44aaf24c99a8e
 # 2022-06-09 Apply clang-format to ATen headers
 95b15c266baaf989ef7b6bbd7c23a2d90bacf687
 # 2022-06-11 [lint] autoformat test/cpp and torch/csrc

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -28,6 +28,8 @@ e3900d2ba5c9f91a24a9ce34520794c8366d5c54
 b0043072529b81276a69df29e00555333117646c
 # 2021-08-25 Reformat run_test.py
 67d8e7b659b19e1ee68208b28bfa7dba73375dbc
+# 2025-10-30 Refactor AOTAutogradCacheEntry into AOTAutogradResult and extract to aot_autograd_result.py
+36bbfcc0dab2592a1da71d29b1c44aaf24c99a8e
 # 2022-06-09 Apply clang-format to ATen headers
 95b15c266baaf989ef7b6bbd7c23a2d90bacf687
 # 2022-06-11 [lint] autoformat test/cpp and torch/csrc

--- a/test/dynamo/test_regional_inductor.py
+++ b/test/dynamo/test_regional_inductor.py
@@ -471,7 +471,7 @@ class RegionalInductorTests(torch._inductor.test_case.TestCase):
 
 @skipIfTorchDynamo("Not a suitable dynamo wrapped test")
 class TestRegionalOutputCode(torch._inductor.test_case.TestCase):
-    """Tests for RegionalOutputCode and RegionalAOTAutogradCacheEntry."""
+    """Tests for RegionalOutputCode and BundledAOTAutogradResult."""
 
     def test_regional_output_code_serialization(self):
         """Test that RegionalOutputCode can be serialized and deserialized."""

--- a/torch/_dynamo/aot_compile_types.py
+++ b/torch/_dynamo/aot_compile_types.py
@@ -48,7 +48,7 @@ class BundledAOTAutogradSerializableCallable(SerializableCallable):
 
     @classmethod
     def deserialize_compile_artifacts(cls, data: bytes) -> Any:
-        from torch._functorch._aot_autograd.autograd_cache import (
+        from torch._functorch._aot_autograd.aot_autograd_result import (
             deserialize_bundled_cache_entry,
         )
 

--- a/torch/_functorch/_aot_autograd/aot_autograd_result.py
+++ b/torch/_functorch/_aot_autograd/aot_autograd_result.py
@@ -1,0 +1,676 @@
+# mypy: allow-untyped-defs
+"""
+This module provides result classes for AOT Autograd compilation.
+
+Similar to how torch._inductor.output_code provides OutputCode classes for inductor
+compilation results, this module provides AOTAutogradResult classes that represent
+the compiled artifacts produced by AOT Autograd.
+
+These results are:
+- Serializable: can be saved/loaded from disk without recompilation
+- Addressable: can be stored in caches with keys for later retrieval
+- Reusable: can be used for both caching and ahead-of-time compilation (precompile)
+
+The main result types are:
+- GenericAOTAutogradResult: Abstract base for all AOT Autograd results
+- AOTAutogradResult: Regular result that references FxGraphCache entries
+- BundledAOTAutogradResult: Result that bundles the entire compiled code directly
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from abc import ABC, abstractmethod
+from copy import copy
+from dataclasses import dataclass
+from typing import Any, Generic, Optional, TYPE_CHECKING, TypeVar
+
+import torch
+from torch._dynamo.precompile_context import BackendCacheArtifact
+from torch._inductor.codecache import FxGraphCache
+from torch._inductor.output_code import (
+    CompiledFxGraph,
+    CompiledFxGraphConstants,
+    OutputCode,
+)
+from torch._inductor.utils import should_use_remote_fx_graph_cache
+
+from .runtime_wrappers import (
+    AOTDispatchAutograd,
+    AOTDispatchSubclassWrapper,
+    CachedAutogradLazyBackwardCompileInfo,
+    CompilerWrapper,
+    FunctionalizedRngRuntimeWrapper,
+    post_compile,
+    RuntimeWrapper,
+    SerializableCompiledFunction,
+    SubclassMeta,
+)
+from .schemas import AOTAutogradCacheInfo, AOTConfig, ViewAndMutationMeta  # noqa: F401
+from .utils import simple_wraps
+
+
+if TYPE_CHECKING:
+    from typing import Callable
+    from torch._inductor.compile_fx import _CompileFxKwargs
+
+log = logging.getLogger(__name__)
+
+
+TOut = TypeVar("TOut", bound=OutputCode)
+
+
+class InductorOutput(ABC, Generic[TOut]):
+    """
+    Class representing a single inductor output
+    """
+
+    @abstractmethod
+    def pre_save(self) -> None: ...
+
+    @abstractmethod
+    def load(self, example_inputs) -> TOut: ...
+
+    @abstractmethod
+    def post_compile(self, result: TOut, fx_config: _CompileFxKwargs) -> TOut: ...
+
+
+TOutputCode = TypeVar("TOutputCode", bound=OutputCode)
+
+
+@dataclass
+class BundledOutputCodeLoadable(InductorOutput[TOutputCode], Generic[TOutputCode]):
+    """
+    A generic wrapper for OutputCode objects that are bundled directly in the cache
+    (rather than looked up via FxGraphCache).
+
+    This works for any OutputCode subclass (CompiledFxGraph, RegionalOutputCode, etc.)
+    """
+
+    result: TOutputCode
+
+    def pre_save(self) -> None:
+        disk_result = copy(self.result)
+        disk_result.prepare_for_serialization()
+        self.result = disk_result
+        return
+
+    def load(self, example_inputs) -> TOutputCode:
+        self.example_inputs = example_inputs
+        return self.result
+
+    def post_compile(
+        self, result: TOutputCode, fx_config: _CompileFxKwargs
+    ) -> TOutputCode:
+        constants = CompiledFxGraphConstants()
+
+        # Special handling for CompiledFxGraph - needs FxGraphCache.cache_hit_post_compile
+        if isinstance(result, CompiledFxGraph):
+            graph, cache_info = FxGraphCache.cache_hit_post_compile(
+                result, {}, constants
+            )
+            if graph is None:
+                raise RuntimeError("Failed to reload cache entry from disk")
+            torch._logging.trace_structured(
+                "artifact",
+                metadata_fn=lambda: {
+                    "name": "fx_graph_bundled_cache_hit",  # always a hit
+                    "encoding": "json",
+                },
+                payload_fn=lambda: json.dumps(cache_info),
+            )
+            result = graph  # type: ignore[assignment]
+
+        # Run normal post compile
+        result.post_compile(self.example_inputs, constants, fx_config)
+        return result
+
+
+# Backwards compatibility alias
+CompiledFxGraphLoadable: type[BundledOutputCodeLoadable[CompiledFxGraph]] = (
+    BundledOutputCodeLoadable[CompiledFxGraph]
+)
+
+
+@dataclass
+class FxGraphCacheLoadable(InductorOutput[CompiledFxGraph]):
+    fx_graph_cache_info: tuple[str, list[str]]
+    fx_graph_guard_expr: Optional[str]
+
+    def pre_save(self):
+        return
+
+    def _is_backward(self) -> bool:
+        return False
+
+    def load(self, example_inputs) -> CompiledFxGraph:
+        from .autograd_cache import FXGraphCacheMiss
+        # [Note: AOTAutogradCache and FXGraphCache Guard interactions]
+        # As mentioned, AOTAutograd takes in the symint inputs from dynamo's list of arguments.
+        # FXGraphCache serializes guards that are needed in the shape_env based on these symint inputs to the graph.
+        # The invariant that AOTAutograd uses here is that the sources for symints given to it by dynamo are exactly
+        # the same as the ones it passes to inductor, for both the forward and backward passes.
+        # (This does not mean that the tensor values passed in are the same: only that their symints are).
+        # That is, AOTAutograd and Inductor never create new guards based on symints with different sources
+        # than those passed to it by inductor.
+
+        # We pass the post compile function, which sets various fx_config boxed values,
+        # so we can call it only after we're sure both forward and backward have
+
+        # Clear CompiledTritonKernels before loading from FXGraphCache
+        torch._inductor.async_compile.CompiledTritonKernels.cache_clear()
+        remote_cache = None
+        constants = CompiledFxGraphConstants()
+        if should_use_remote_fx_graph_cache():
+            remote_cache = FxGraphCache.get_remote_cache()
+        (cache_key, debug_lines) = self.fx_graph_cache_info
+
+        def check_exact_guard_match(guard_expr, _hints):
+            """
+            AOTAutogradCache tracks its own guards, so we just need to treat these guard expressions as a second
+            cache key of sorts: we just check for equality, i.e. the FXGraphCache entry with
+            the exact same guards as we originally saved into the cache.
+            """
+            return guard_expr == self.fx_graph_guard_expr
+
+        result, cache_info = FxGraphCache.load_with_key(
+            cache_key,
+            debug_lines,
+            example_inputs,
+            local=True,
+            remote_cache=remote_cache,
+            is_backward=self._is_backward(),
+            constants=constants,
+            evaluate_guards=check_exact_guard_match,
+        )
+        if result is None:
+            log.info("FXGraphCache cache miss for key %s", self.fx_graph_cache_info)
+            torch._logging.trace_structured(
+                "artifact",
+                metadata_fn=lambda: {
+                    "name": "fx_graph_cache_miss",  # always a hit
+                    "encoding": "json",
+                },
+                payload_fn=lambda: json.dumps(cache_info),
+            )
+
+            raise FXGraphCacheMiss
+
+        # No need to log chromium event because AOTAutograd will log that immediately for us
+        torch._logging.trace_structured(
+            "artifact",
+            metadata_fn=lambda: {
+                "name": "fx_graph_cache_hit",  # always a hit
+                "encoding": "json",
+            },
+            payload_fn=lambda: json.dumps(cache_info),
+        )
+        self.example_inputs = example_inputs
+        self.constants = constants
+        return result
+
+    def post_compile(
+        self, result: CompiledFxGraph, fx_config: _CompileFxKwargs
+    ) -> CompiledFxGraph:
+        """
+        Called after FXGraphCacheLoadable.load, mutates fx_config
+        """
+        result.post_compile(self.example_inputs, self.constants, fx_config)
+        return result
+
+
+@dataclass
+class CompiledForward(FxGraphCacheLoadable):
+    """
+    Cacheable entry for a forward function
+    """
+
+    def _is_backward(self) -> bool:
+        return False
+
+
+@dataclass
+class GenericCompiledBackward(InductorOutput[TOut]):
+    # Used by AOTDispatchAutograd.post_compile
+    backward_state_indices: list[int]
+    num_symints_saved_for_bw_: int
+
+
+@dataclass
+class CompiledBackward(GenericCompiledBackward[CompiledFxGraph], FxGraphCacheLoadable):
+    """
+    Cacheable entry for a forward function
+    """
+
+    def _is_backward(self) -> bool:
+        return True
+
+    def post_compile(
+        self, result: CompiledFxGraph, fx_config: _CompileFxKwargs
+    ) -> CompiledFxGraph:
+        compiled_bw = super().post_compile(result, fx_config)
+        # See note [Wrapping bw_compiler in disable]
+        # This is done by _wrapped_bw_compiler in torch/_dynamo/backends/common.py
+        # But since on cache hit we do not call the bw_compiler, we need to reapply the disable
+        return torch._dynamo.disable(  # type: ignore[return-value]
+            compiled_bw, reason="do not trace generated backwards pass"
+        )
+
+
+# Generic bundled forward/backward classes that work with any OutputCode type
+@dataclass
+class BundledCompiledForward(
+    BundledOutputCodeLoadable[TOutputCode], Generic[TOutputCode]
+):
+    """
+    Generic forward function for bundled compilation.
+    Works with any OutputCode type (CompiledFxGraph, RegionalOutputCode, etc.)
+    """
+
+
+@dataclass
+class BundledCompiledBackward(
+    GenericCompiledBackward[TOutputCode],
+    BundledOutputCodeLoadable[TOutputCode],
+    Generic[TOutputCode],
+):
+    """
+    Generic backward function for bundled compilation.
+    Works with any OutputCode type (CompiledFxGraph, RegionalOutputCode, etc.)
+    """
+
+    def post_compile(
+        self, result: TOutputCode, fx_config: _CompileFxKwargs
+    ) -> TOutputCode:
+        compiled_bw = super().post_compile(result, fx_config)
+        # See note [Wrapping bw_compiler in disable]
+        # This is done by _wrapped_bw_compiler in torch/_dynamo/backends/common.py
+        # But since on cache hit we do not call the bw_compiler, we need to reapply the disable
+        return torch._dynamo.disable(  # type: ignore[return-value]
+            compiled_bw, reason="do not trace generated backwards pass"
+        )
+
+
+@dataclass
+class SerializedGraphModule:
+    fn: Callable[[dict[Any, Any], str], torch.nn.Module]
+    args: tuple[Any, ...]
+
+    def __init__(self, gm: torch.fx.GraphModule):
+        self.fn, self.args = gm.__reduce__()
+
+    def deserialize(self) -> torch.fx.GraphModule:
+        gm = self.fn(*self.args)
+        assert isinstance(gm, torch.fx.GraphModule)
+        return gm
+
+
+def serialize_graph_module(gm: torch.fx.GraphModule) -> SerializedGraphModule:
+    # NOTE: mutates the graph module
+    gm.meta = {}
+    for node in gm.graph.nodes:
+        node.meta = {}
+    return SerializedGraphModule(gm)
+
+
+TForward = TypeVar("TForward", bound=InductorOutput)
+TBackward = TypeVar("TBackward", bound=GenericCompiledBackward)
+
+
+@dataclass
+class GenericAOTAutogradResult(Generic[TForward, TBackward]):
+    """A single result from AOT Autograd compilation, genericized by Forward and Backward types.
+
+    A TForward is always an InductorOutput of some sort, which represents the
+    forward graph of the compile.
+    A TBackward is an InductorOutput + metadata about the backward, useful for specific
+    backward-only wrappers. This type is encapsulated by GenericCompiledBackward.
+
+    Each AOTAutogradResult is essentially parameterized by 1. the method of loading
+    from the cache (either Bundled or UnBundled), and 2. The type of the output. For now,
+    the only type of output we support is Python Wrapper output, i.e. OutputCode.CompiledFxGraph,
+    but the same technique works for C++ wrapper code; we'd just add an extra InductorOutput type.
+    """
+
+    # Forward and Backward info
+    compiled_fw: TForward
+    compiled_bw: Optional[TBackward]
+
+    # Code of the joint graph using print_readable()
+    # Used for logging purposes
+    aot_joint_graph_str: Optional[str]
+    aot_forward_graph_str: Optional[str]
+    aot_backward_graph_str: Optional[str]
+
+    # Runtime_metadata saved right before compilation
+    runtime_metadata: ViewAndMutationMeta
+
+    # Wrappers that run after each aot_dispatch_* function
+    dispatch_wrappers: list[CompilerWrapper]
+
+    # Used by AOTSubclassWrapper
+    maybe_subclass_meta: Optional[SubclassMeta]
+    num_fw_outs_saved_for_bw: Optional[int]
+
+    # Used by RuntimeWrapper
+    indices_of_inps_to_detach: list[int]
+
+    # Time taken to trace/compile the forward
+    # forward_time_taken includes AOTAutograd tracing time + inductor compilation time
+    # backward_time_taken is essentially just the time inductor took to compile
+    forward_time_taken_ns: int
+    backward_time_taken_ns: int
+
+    # Used by standalone_compile
+    sanitized_aot_config: AOTConfig
+
+    guards_expr: Optional[str]
+
+    # Used by Compiled Autograd
+    serialized_bw_module: Optional[SerializedGraphModule]
+
+    def pre_save(self):
+        """
+        Perform any preparations to make the result ready for serialization.
+        """
+        self.compiled_fw.pre_save()
+        if self.compiled_bw is not None:
+            self.compiled_bw.pre_save()
+
+    # Turn result into the original callable
+    def wrap_post_compile(
+        self,
+        args: list[torch.Tensor],
+        aot_config: AOTConfig,
+        fx_config: _CompileFxKwargs,
+    ) -> Callable:
+        """
+        This function takes a result and carefully reconstructs the original callable
+        that AOTAutograd returned the first time it was run. It does this by running the various
+        post compile steps that AOTAutograd runs on its compiled artifact after running the fw/bw compilers.
+
+        In the inference path, this consists of the Subclass, FunctionalzedRngRuntime, and RuntimeWrappers.
+        In the autograd path, this consists of AOTAutogradDispatch.post_compile.
+
+        The steps here should match exactly the steps that are run in aot_dispatch_base and aot_dispatch_autograd.
+
+        Notably absent from the cached path are:
+        - DebugAssertWrapper
+        - FakifiedOutWrapper
+
+        Which we'll handle separately later on, if necessary.
+        """
+        from torch._dynamo.utils import CompileEventLogger, dynamo_timed
+
+        # Log the output of AOTAutogradCache
+        if aot_config.enable_log:
+            # TODO: maybe also log to aot_graphs_log
+            # Unfortunately aot_graphs_log uses
+            # slightly different formatting though
+            if self.aot_joint_graph_str is not None:
+                torch._logging.trace_structured(
+                    "aot_joint_graph", payload_fn=lambda: self.aot_joint_graph_str
+                )
+
+            if self.aot_forward_graph_str is not None:
+                from torchgen.utils import dataclass_repr
+
+                torch._logging.trace_structured(
+                    "artifact",
+                    metadata_fn=lambda: {
+                        "name": "aot_forward_graph_fw_metadata",
+                        "encoding": "string",
+                    },
+                    payload_fn=lambda: dataclass_repr(self.runtime_metadata),
+                )
+                if self.maybe_subclass_meta is not None:
+                    torch._logging.trace_structured(
+                        "artifact",
+                        metadata_fn=lambda: {
+                            "name": "aot_forward_graph_fw_subclass_metadata",
+                            "encoding": "string",
+                        },
+                        payload_fn=lambda: dataclass_repr(self.maybe_subclass_meta),
+                    )
+
+                # It's called an inference graph if not running with autograd
+                name = (
+                    "aot_forward_graph"
+                    if self.aot_backward_graph_str is not None
+                    else "aot_inference_graph"
+                )
+                torch._logging.trace_structured(
+                    name, payload_fn=lambda: self.aot_forward_graph_str
+                )
+
+            if self.aot_backward_graph_str is not None:
+                torch._logging.trace_structured(
+                    "aot_backward_graph", payload_fn=lambda: self.aot_backward_graph_str
+                )
+        with dynamo_timed("AOTAutogradCache.inductor_load"):
+            compiled_fw_func = self.compiled_fw.load(args)
+            compiled_bw_func = None
+            if self.compiled_bw is not None:
+                compiled_bw_func = self.compiled_bw.load(args)
+                needs_autograd = True
+                CompileEventLogger.try_add_pt2_compile(
+                    "backend_compile", dispatch_mode="autograd"
+                )
+                # Now that we've loaded forward and backward, call post compile on both
+                # This avoids setting things like BoxedBools in fx_config until
+                # after both forward and backward cache hit
+                fw_fx_config: _CompileFxKwargs = {
+                    **fx_config,
+                    "is_backward": False,
+                }
+                bw_fx_config: _CompileFxKwargs = {
+                    **fx_config,
+                    "is_backward": True,
+                }
+                compiled_fw_func = self.compiled_fw.post_compile(
+                    compiled_fw_func, fw_fx_config
+                )
+                compiled_bw_func = self.compiled_bw.post_compile(
+                    compiled_bw_func, bw_fx_config
+                )
+            else:
+                inference_fx_config: _CompileFxKwargs = {
+                    **fx_config,
+                    "is_backward": False,
+                }
+
+                needs_autograd = False
+                CompileEventLogger.try_add_pt2_compile(
+                    "backend_compile", dispatch_mode="inference"
+                )
+                compiled_fw_func = self.compiled_fw.post_compile(
+                    compiled_fw_func, inference_fx_config
+                )
+
+        # Wrap the forward function in post compile wrappers
+        compiled_fw_func = AOTDispatchSubclassWrapper(
+            trace_joint=needs_autograd,
+            fw_only=None,
+            maybe_subclass_meta=self.maybe_subclass_meta,
+            num_fw_outs_saved_for_bw=self.num_fw_outs_saved_for_bw,
+        ).post_compile(
+            compiled_fw_func, aot_config, runtime_metadata=self.runtime_metadata
+        )
+
+        req_subclass_dispatch = self.maybe_subclass_meta is not None
+        CompileEventLogger.try_add_pt2_compile(
+            "backend_compile", requires_subclass_dispatch=req_subclass_dispatch
+        )
+
+        # In autograd case, functionalizedRngWrapper should not modify outs
+        return_new_outs = not needs_autograd
+        compiled_fw_func = FunctionalizedRngRuntimeWrapper(
+            return_new_outs=return_new_outs
+        ).post_compile(
+            compiled_fw_func, aot_config, runtime_metadata=self.runtime_metadata
+        )
+        disable_amp = torch._C._is_any_autocast_enabled()
+
+        if needs_autograd:
+            assert self.compiled_bw is not None
+
+            cached_lazy_backward = None
+            if self.serialized_bw_module is not None:
+                cached_lazy_backward = CachedAutogradLazyBackwardCompileInfo(
+                    self.serialized_bw_module.deserialize
+                )
+            # This function is run on both cache miss and cache hit, either here
+            # or in aot_dispatch_autograd. On a cache hit,
+            # 1. the bw is already compiled
+            # 2. we don't need to save to the cache again
+            # so those corresponding arguments are set to None.
+            compiled_function = AOTDispatchAutograd.post_compile(
+                compiled_fw_func,
+                compiled_bw_func,
+                self.maybe_subclass_meta,
+                self.compiled_bw.num_symints_saved_for_bw_,
+                self.compiled_bw.backward_state_indices,
+                disable_amp,
+                self.indices_of_inps_to_detach,
+                cached_lazy_backward,
+                aot_config,
+                fw_metadata=self.runtime_metadata,
+                try_save_cache_entry=None,
+            )
+
+        else:
+            compiled_function = RuntimeWrapper(
+                indices_of_inps_to_detach=self.indices_of_inps_to_detach,
+                trace_joint=False,
+                disable_amp=disable_amp,
+            ).post_compile(
+                compiled_fw_func, aot_config, runtime_metadata=self.runtime_metadata
+            )
+
+        # Add serialization function back onto object
+        compiled_function, _ = post_compile(
+            self.dispatch_wrappers,
+            compiled_function,
+            aot_config,
+            runtime_metadata=self.runtime_metadata,
+        )
+
+        # Now that we're pretty sure it's a successful load, add guards
+        # to the existing shape environment from the cache
+        if self.guards_expr:
+            from .autograd_cache import AOTAutogradCache
+
+            symints = AOTAutogradCache._filter_backed_symints(args)
+            check = bool(AOTAutogradCache.evaluate_guards(self.guards_expr, symints))
+            assert check is True
+
+        return compiled_function
+
+
+class AOTAutogradResult(
+    GenericAOTAutogradResult[CompiledForward, CompiledBackward]
+):
+    """
+    Regular AOTAutogradResult: saves the forward/backward FxGraphCache keys
+    and looks them up in FxGraphCache on load
+    """
+
+
+class BundledAOTAutogradResult(
+    GenericAOTAutogradResult[
+        BundledCompiledForward[TOutputCode], BundledCompiledBackward[TOutputCode]
+    ],
+    Generic[TOutputCode],
+):
+    """
+    Generic AOTAutogradResult where we bundle the entire OutputCode directly
+    (rather than looking it up via FxGraphCache).
+
+    This works with any OutputCode type:
+    - CompiledFxGraph: Traditional inductor compilation
+    - RegionalOutputCode: Regional inductor compilation with GraphPickler serialization
+    - Any future OutputCode subclasses
+
+    Type parameter:
+        TOutputCode: The OutputCode subclass (e.g., CompiledFxGraph, RegionalOutputCode)
+
+    Usage with CompiledFxGraph:
+        entry = BundledAOTAutogradResult[CompiledFxGraph](
+            compiled_fw=BundledCompiledForward(result=CompiledFxGraph(...)),
+            compiled_bw=BundledCompiledBackward(
+                result=CompiledFxGraph(...),
+                backward_state_indices=[...],
+                num_symints_saved_for_bw_=...,
+            ),
+            ...
+        )
+
+    Usage with RegionalOutputCode:
+        entry = BundledAOTAutogradResult[RegionalOutputCode](
+            compiled_fw=BundledCompiledForward(result=RegionalOutputCode(gm)),
+            compiled_bw=BundledCompiledBackward(
+                result=RegionalOutputCode(gm),
+                backward_state_indices=[...],
+                num_symints_saved_for_bw_=...,
+            ),
+            ...
+        )
+    """
+
+
+def deserialize_bundled_cache_entry(entry: BundledAOTAutogradResult) -> Callable:
+    from copy import deepcopy
+
+    from torch._inductor.cudagraph_utils import BoxedDeviceIndex
+    from torch._inductor.utils import BoxedBool
+
+    # In the precompile use case, guards are already serialized
+    # by dynamo, so we don't need to add them to the environment
+    entry.guards_expr = None
+    # TODO: this isn't exactly right, because cudagraphs needs to be a shared config
+    # which is set by compile_fx. But in precompile, we never actually call compile_fx
+    # so we don't have a place to track cudagraphs here.
+    cudagraphs = BoxedBool(torch._inductor.config.triton.cudagraphs)
+    boxed_forward_device_index = BoxedDeviceIndex(None)
+    # We need to make a clean copy of the cache entry
+    # in case it needs to be serialized again
+    serializable_copy = deepcopy(entry)
+
+    from torch._subclasses import FakeTensorMode
+    from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+    context = torch._guards.TracingContext.try_get()
+    if context is None:
+        # Create a clean environment when running fx graph post compile
+        # if one is not available
+        context = torch._guards.TracingContext(FakeTensorMode(shape_env=ShapeEnv()))
+    with torch._guards.tracing(context):
+        compiled_fn = entry.wrap_post_compile(
+            [],
+            entry.sanitized_aot_config,
+            {
+                "cudagraphs": cudagraphs,
+                "boxed_forward_device_index": boxed_forward_device_index,
+            },
+        )
+    # Ensure the deserialized cache entry is still serializable
+
+    compiled_fn = SerializableCompiledFunction(compiled_fn, lambda: serializable_copy)
+
+    # TODO: this ignores flat_params, which can exist
+    # if inline_builtin_nn_modules=False
+    @simple_wraps(compiled_fn)
+    def forward(*runtime_args: tuple[Any]):
+        return compiled_fn(list(runtime_args))
+
+    assert hasattr(compiled_fn, "serialize")
+    forward.serialize = compiled_fn.serialize  # type: ignore[attr-defined]
+
+    return forward
+
+
+@dataclass
+class BundledAOTAutogradCacheArtifact(BackendCacheArtifact[Callable]):
+    def after_deserialization(self) -> Callable:
+        return deserialize_bundled_cache_entry(self.content)

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -15,22 +15,14 @@ import pickle
 import shutil
 import time
 import traceback
-from abc import ABC, abstractmethod
-from collections.abc import Callable
-from copy import copy, deepcopy
-from dataclasses import dataclass
-from typing import Any, Generic, Optional, TYPE_CHECKING, TypeVar, Union
+from copy import copy
+from typing import Any, Optional, TYPE_CHECKING, Union
 from typing_extensions import override
 
 import torch
-from torch._dynamo.precompile_context import BackendCacheArtifact, PrecompileContext
+from torch._dynamo.precompile_context import PrecompileContext
 from torch._dynamo.trace_rules import torch_non_c_binding_in_graph_functions
-from torch._dynamo.utils import (
-    chromium_event_log_active,
-    CompileEventLogger,
-    counters,
-    dynamo_timed,
-)
+from torch._dynamo.utils import chromium_event_log_active, CompileEventLogger, counters
 from torch._functorch import config
 from torch._inductor.codecache import (
     _ident,
@@ -45,12 +37,7 @@ from torch._inductor.codecache import (
     sha256_hash,
     write_atomic,
 )
-from torch._inductor.cudagraph_utils import BoxedDeviceIndex
-from torch._inductor.output_code import (
-    CompiledFxGraph,
-    CompiledFxGraphConstants,
-    OutputCode,
-)
+from torch._inductor.output_code import OutputCode
 from torch._inductor.runtime.runtime_utils import cache_dir
 from torch._inductor.utils import BoxedBool, should_use_remote_fx_graph_cache
 from torch._logging import LazyString
@@ -62,27 +49,34 @@ from torch.compiler._cache import (
 )
 from torch.fx.experimental.symbolic_shapes import hint_int
 from torch.utils._triton import has_triton_package
-from torchgen.utils import dataclass_repr
 
+from .aot_autograd_result import (
+    AOTAutogradResult,
+    BundledAOTAutogradCacheArtifact,
+    BundledAOTAutogradResult,
+    BundledCompiledBackward,
+    BundledCompiledForward,
+    CompiledBackward,
+    CompiledForward,
+    GenericAOTAutogradResult,
+    SerializedGraphModule,
+)
 from .runtime_wrappers import (
-    AOTDispatchAutograd,
-    AOTDispatchSubclassWrapper,
-    CachedAutogradLazyBackwardCompileInfo,
     CompilerWrapper,
-    FunctionalizedRngRuntimeWrapper,
-    post_compile,
-    RuntimeWrapper,
     SerializableCompiledFunction,
     SubclassMeta,
 )
 from .schemas import AOTAutogradCacheInfo, AOTConfig, ViewAndMutationMeta  # noqa: F401
-from .utils import simple_wraps
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from torch._inductor.compile_fx import _CompileFxKwargs
+    from torch._inductor.cudagraph_utils import BoxedDeviceIndex
     from torch._inductor.remote_cache import JsonDataTy, RemoteCache
     from torch.fx.node import Node
+
 
 log = logging.getLogger(__name__)
 
@@ -506,560 +500,6 @@ def autograd_cache_key(
     return key, debug_lines
 
 
-TOut = TypeVar("TOut", bound=OutputCode)
-
-
-class InductorOutput(ABC, Generic[TOut]):
-    """
-    Class representing a single inductor output
-    """
-
-    @abstractmethod
-    def pre_save(self) -> None: ...
-
-    @abstractmethod
-    def load(self, example_inputs) -> TOut: ...
-
-    @abstractmethod
-    def post_compile(self, result: TOut, fx_config: _CompileFxKwargs) -> TOut: ...
-
-
-TOutputCode = TypeVar("TOutputCode", bound=OutputCode)
-
-
-@dataclass
-class BundledOutputCodeLoadable(InductorOutput[TOutputCode], Generic[TOutputCode]):
-    """
-    A generic wrapper for OutputCode objects that are bundled directly in the cache
-    (rather than looked up via FxGraphCache).
-
-    This works for any OutputCode subclass (CompiledFxGraph, RegionalOutputCode, etc.)
-    """
-
-    result: TOutputCode
-
-    def pre_save(self) -> None:
-        disk_result = copy(self.result)
-        disk_result.prepare_for_serialization()
-        self.result = disk_result
-        return
-
-    def load(self, example_inputs) -> TOutputCode:
-        self.example_inputs = example_inputs
-        return self.result
-
-    def post_compile(
-        self, result: TOutputCode, fx_config: _CompileFxKwargs
-    ) -> TOutputCode:
-        constants = CompiledFxGraphConstants()
-
-        # Special handling for CompiledFxGraph - needs FxGraphCache.cache_hit_post_compile
-        if isinstance(result, CompiledFxGraph):
-            graph, cache_info = FxGraphCache.cache_hit_post_compile(
-                result, {}, constants
-            )
-            if graph is None:
-                raise BypassAOTAutogradCache("Failed to reload cache entry from disk")
-            torch._logging.trace_structured(
-                "artifact",
-                metadata_fn=lambda: {
-                    "name": "fx_graph_bundled_cache_hit",  # always a hit
-                    "encoding": "json",
-                },
-                payload_fn=lambda: json.dumps(cache_info),
-            )
-            result = graph  # type: ignore[assignment]
-
-        # Run normal post compile
-        result.post_compile(self.example_inputs, constants, fx_config)
-        return result
-
-
-# Backwards compatibility alias
-CompiledFxGraphLoadable: type[BundledOutputCodeLoadable[CompiledFxGraph]] = (
-    BundledOutputCodeLoadable[CompiledFxGraph]
-)
-
-
-@dataclass
-class FxGraphCacheLoadable(InductorOutput[CompiledFxGraph]):
-    fx_graph_cache_info: tuple[str, list[str]]
-    fx_graph_guard_expr: Optional[str]
-
-    def pre_save(self):
-        return
-
-    def _is_backward(self) -> bool:
-        return False
-
-    def load(self, example_inputs) -> CompiledFxGraph:
-        # [Note: AOTAutogradCache and FXGraphCache Guard interactions]
-        # As mentioned, AOTAutograd takes in the symint inputs from dynamo's list of arguments.
-        # FXGraphCache serializes guards that are needed in the shape_env based on these symint inputs to the graph.
-        # The invariant that AOTAutograd uses here is that the sources for symints given to it by dynamo are exactly
-        # the same as the ones it passes to inductor, for both the forward and backward passes.
-        # (This does not mean that the tensor values passed in are the same: only that their symints are).
-        # That is, AOTAutograd and Inductor never create new guards based on symints with different sources
-        # than those passed to it by inductor.
-
-        # We pass the post compile function, which sets various fx_config boxed values,
-        # so we can call it only after we're sure both forward and backward have
-
-        # Clear CompiledTritonKernels before loading from FXGraphCache
-        torch._inductor.async_compile.CompiledTritonKernels.cache_clear()
-        remote_cache = None
-        constants = CompiledFxGraphConstants()
-        if should_use_remote_fx_graph_cache():
-            remote_cache = FxGraphCache.get_remote_cache()
-        (cache_key, debug_lines) = self.fx_graph_cache_info
-
-        def check_exact_guard_match(guard_expr, _hints):
-            """
-            AOTAutogradCache tracks its own guards, so we just need to treat these guard expressions as a second
-            cache key of sorts: we just check for equality, i.e. the FXGraphCache entry with
-            the exact same guards as we originally saved into the cache.
-            """
-            return guard_expr == self.fx_graph_guard_expr
-
-        result, cache_info = FxGraphCache.load_with_key(
-            cache_key,
-            debug_lines,
-            example_inputs,
-            local=True,
-            remote_cache=remote_cache,
-            is_backward=self._is_backward(),
-            constants=constants,
-            evaluate_guards=check_exact_guard_match,
-        )
-        if result is None:
-            log.info("FXGraphCache cache miss for key %s", self.fx_graph_cache_info)
-            torch._logging.trace_structured(
-                "artifact",
-                metadata_fn=lambda: {
-                    "name": "fx_graph_cache_miss",  # always a hit
-                    "encoding": "json",
-                },
-                payload_fn=lambda: json.dumps(cache_info),
-            )
-
-            raise FXGraphCacheMiss
-
-        # No need to log chromium event because AOTAutograd will log that immediately for us
-        torch._logging.trace_structured(
-            "artifact",
-            metadata_fn=lambda: {
-                "name": "fx_graph_cache_hit",  # always a hit
-                "encoding": "json",
-            },
-            payload_fn=lambda: json.dumps(cache_info),
-        )
-        self.example_inputs = example_inputs
-        self.constants = constants
-        return result
-
-    def post_compile(
-        self, result: CompiledFxGraph, fx_config: _CompileFxKwargs
-    ) -> CompiledFxGraph:
-        """
-        Called after FXGraphCacheLoadable.load, mutates fx_config
-        """
-        result.post_compile(self.example_inputs, self.constants, fx_config)
-        return result
-
-
-@dataclass
-class CompiledForward(FxGraphCacheLoadable):
-    """
-    Cacheable entry for a forward function
-    """
-
-    def _is_backward(self) -> bool:
-        return False
-
-
-@dataclass
-class GenericCompiledBackward(InductorOutput[TOut]):
-    # Used by AOTDispatchAutograd.post_compile
-    backward_state_indices: list[int]
-    num_symints_saved_for_bw_: int
-
-
-@dataclass
-class CompiledBackward(GenericCompiledBackward[CompiledFxGraph], FxGraphCacheLoadable):
-    """
-    Cacheable entry for a forward function
-    """
-
-    def _is_backward(self) -> bool:
-        return True
-
-    def post_compile(
-        self, result: CompiledFxGraph, fx_config: _CompileFxKwargs
-    ) -> CompiledFxGraph:
-        compiled_bw = super().post_compile(result, fx_config)
-        # See note [Wrapping bw_compiler in disable]
-        # This is done by _wrapped_bw_compiler in torch/_dynamo/backends/common.py
-        # But since on cache hit we do not call the bw_compiler, we need to reapply the disable
-        return torch._dynamo.disable(  # type: ignore[return-value]
-            compiled_bw, reason="do not trace generated backwards pass"
-        )
-
-
-# Generic bundled forward/backward classes that work with any OutputCode type
-@dataclass
-class BundledCompiledForward(
-    BundledOutputCodeLoadable[TOutputCode], Generic[TOutputCode]
-):
-    """
-    Generic forward function for bundled compilation.
-    Works with any OutputCode type (CompiledFxGraph, RegionalOutputCode, etc.)
-    """
-
-
-@dataclass
-class BundledCompiledBackward(
-    GenericCompiledBackward[TOutputCode],
-    BundledOutputCodeLoadable[TOutputCode],
-    Generic[TOutputCode],
-):
-    """
-    Generic backward function for bundled compilation.
-    Works with any OutputCode type (CompiledFxGraph, RegionalOutputCode, etc.)
-    """
-
-    def post_compile(
-        self, result: TOutputCode, fx_config: _CompileFxKwargs
-    ) -> TOutputCode:
-        compiled_bw = super().post_compile(result, fx_config)
-        # See note [Wrapping bw_compiler in disable]
-        # This is done by _wrapped_bw_compiler in torch/_dynamo/backends/common.py
-        # But since on cache hit we do not call the bw_compiler, we need to reapply the disable
-        return torch._dynamo.disable(  # type: ignore[return-value]
-            compiled_bw, reason="do not trace generated backwards pass"
-        )
-
-
-@dataclass
-class SerializedGraphModule:
-    fn: Callable[[dict[Any, Any], str], torch.nn.Module]
-    args: tuple[Any, ...]
-
-    def __init__(self, gm: torch.fx.GraphModule):
-        self.fn, self.args = gm.__reduce__()
-
-    def deserialize(self) -> torch.fx.GraphModule:
-        gm = self.fn(*self.args)
-        assert isinstance(gm, torch.fx.GraphModule)
-        return gm
-
-
-def serialize_graph_module(gm: torch.fx.GraphModule) -> SerializedGraphModule:
-    # NOTE: mutates the graph module
-    gm.meta = {}
-    for node in gm.graph.nodes:
-        node.meta = {}
-    return SerializedGraphModule(gm)
-
-
-TForward = TypeVar("TForward", bound=InductorOutput)
-TBackward = TypeVar("TBackward", bound=GenericCompiledBackward)
-
-
-@dataclass
-class GenericAOTAutogradCacheEntry(Generic[TForward, TBackward]):
-    """A single entry into the cache, genericized by Forward and Backward types.
-
-    A TForward is always an InductorOutput of some sort, which represents the
-    forward graph of the compile.
-    A TBackward is an InductorOutput + metadata about the backward, useful for specific
-    backward-only wrappers. This type is encapsulated by GenericCompiledBackward.
-
-    Each AOTAutogradCacheEntry is essentially parameterized by 1. the method of loading
-    from the cache (either Bundled or UnBundled), and 2. The type of the output. For now,
-    the only type of output we support is Python Wrapper output, i.e. OutputCode.CompiledFxGraph,
-    but the same technique works for C++ wrapper code; we'd just add an extra InductorOutput type.
-    """
-
-    # Forward and Backward info
-    compiled_fw: TForward
-    compiled_bw: Optional[TBackward]
-
-    # Code of the joint graph using print_readable()
-    # Used for logging purposes
-    aot_joint_graph_str: Optional[str]
-    aot_forward_graph_str: Optional[str]
-    aot_backward_graph_str: Optional[str]
-
-    # Runtime_metadata saved right before compilation
-    runtime_metadata: ViewAndMutationMeta
-
-    # Wrappers that run after each aot_dispatch_* function
-    dispatch_wrappers: list[CompilerWrapper]
-
-    # Used by AOTSubclassWrapper
-    maybe_subclass_meta: Optional[SubclassMeta]
-    num_fw_outs_saved_for_bw: Optional[int]
-
-    # Used by RuntimeWrapper
-    indices_of_inps_to_detach: list[int]
-
-    # Time taken to trace/compile the forward
-    # forward_time_taken includes AOTAutograd tracing time + inductor compilation time
-    # backward_time_taken is essentially just the time inductor took to compile
-    forward_time_taken_ns: int
-    backward_time_taken_ns: int
-
-    # Used by standalone_compile
-    sanitized_aot_config: AOTConfig
-
-    guards_expr: Optional[str]
-
-    # Used by Compiled Autograd
-    serialized_bw_module: Optional[SerializedGraphModule]
-
-    def pre_save(self):
-        """
-        Perform any preparations to make the cache entry ready for serialization.
-        """
-        self.compiled_fw.pre_save()
-        if self.compiled_bw is not None:
-            self.compiled_bw.pre_save()
-
-    # Turn cache entry into the original callable
-    def wrap_post_compile(
-        self,
-        args: list[torch.Tensor],
-        aot_config: AOTConfig,
-        fx_config: _CompileFxKwargs,
-    ) -> Callable:
-        """
-        This function takes a cache entry and carefully reconstructs the original callable
-        that AOTAutograd returned the first time it was run. It does this by running the various
-        post compile steps that AOTAutograd runs on its compiled artifact after running the fw/bw compilers.
-
-        In the inference path, this consists of the Subclass, FunctionalzedRngRuntime, and RuntimeWrappers.
-        In the autograd path, this consists of AOTAutogradDispatch.post_compile.
-
-        The steps here should match exactly the steps that are run in aot_dispatch_base and aot_dispatch_autograd.
-
-        Notably absent from the cached path are:
-        - DebugAssertWrapper
-        - FakifiedOutWrapper
-
-        Which we'll handle separately later on, if necessary.
-        """
-        # Log the output of AOTAutogradCache
-        if aot_config.enable_log:
-            # TODO: maybe also log to aot_graphs_log
-            # Unfortunately aot_graphs_log uses
-            # slightly different formatting though
-            if self.aot_joint_graph_str is not None:
-                torch._logging.trace_structured(
-                    "aot_joint_graph", payload_fn=lambda: self.aot_joint_graph_str
-                )
-
-            if self.aot_forward_graph_str is not None:
-                torch._logging.trace_structured(
-                    "artifact",
-                    metadata_fn=lambda: {
-                        "name": "aot_forward_graph_fw_metadata",
-                        "encoding": "string",
-                    },
-                    payload_fn=lambda: dataclass_repr(self.runtime_metadata),
-                )
-                if self.maybe_subclass_meta is not None:
-                    torch._logging.trace_structured(
-                        "artifact",
-                        metadata_fn=lambda: {
-                            "name": "aot_forward_graph_fw_subclass_metadata",
-                            "encoding": "string",
-                        },
-                        payload_fn=lambda: dataclass_repr(self.maybe_subclass_meta),
-                    )
-
-                # It's called an inference graph if not running with autograd
-                name = (
-                    "aot_forward_graph"
-                    if self.aot_backward_graph_str is not None
-                    else "aot_inference_graph"
-                )
-                torch._logging.trace_structured(
-                    name, payload_fn=lambda: self.aot_forward_graph_str
-                )
-
-            if self.aot_backward_graph_str is not None:
-                torch._logging.trace_structured(
-                    "aot_backward_graph", payload_fn=lambda: self.aot_backward_graph_str
-                )
-        with dynamo_timed("AOTAutogradCache.inductor_load"):
-            compiled_fw_func = self.compiled_fw.load(args)
-            compiled_bw_func = None
-            if self.compiled_bw is not None:
-                compiled_bw_func = self.compiled_bw.load(args)
-                needs_autograd = True
-                CompileEventLogger.try_add_pt2_compile(
-                    "backend_compile", dispatch_mode="autograd"
-                )
-                # Now that we've loaded forward and backward, call post compile on both
-                # This avoids setting things like BoxedBools in fx_config until
-                # after both forward and backward cache hit
-                fw_fx_config: _CompileFxKwargs = {
-                    **fx_config,
-                    "is_backward": False,
-                }
-                bw_fx_config: _CompileFxKwargs = {
-                    **fx_config,
-                    "is_backward": True,
-                }
-                compiled_fw_func = self.compiled_fw.post_compile(
-                    compiled_fw_func, fw_fx_config
-                )
-                compiled_bw_func = self.compiled_bw.post_compile(
-                    compiled_bw_func, bw_fx_config
-                )
-            else:
-                inference_fx_config: _CompileFxKwargs = {
-                    **fx_config,
-                    "is_backward": False,
-                }
-
-                needs_autograd = False
-                CompileEventLogger.try_add_pt2_compile(
-                    "backend_compile", dispatch_mode="inference"
-                )
-                compiled_fw_func = self.compiled_fw.post_compile(
-                    compiled_fw_func, inference_fx_config
-                )
-
-        # Wrap the forward function in post compile wrappers
-        compiled_fw_func = AOTDispatchSubclassWrapper(
-            trace_joint=needs_autograd,
-            fw_only=None,
-            maybe_subclass_meta=self.maybe_subclass_meta,
-            num_fw_outs_saved_for_bw=self.num_fw_outs_saved_for_bw,
-        ).post_compile(
-            compiled_fw_func, aot_config, runtime_metadata=self.runtime_metadata
-        )
-
-        req_subclass_dispatch = self.maybe_subclass_meta is not None
-        CompileEventLogger.try_add_pt2_compile(
-            "backend_compile", requires_subclass_dispatch=req_subclass_dispatch
-        )
-
-        # In autograd case, functionalizedRngWrapper should not modify outs
-        return_new_outs = not needs_autograd
-        compiled_fw_func = FunctionalizedRngRuntimeWrapper(
-            return_new_outs=return_new_outs
-        ).post_compile(
-            compiled_fw_func, aot_config, runtime_metadata=self.runtime_metadata
-        )
-        disable_amp = torch._C._is_any_autocast_enabled()
-
-        if needs_autograd:
-            assert self.compiled_bw is not None
-
-            cached_lazy_backward = None
-            if self.serialized_bw_module is not None:
-                cached_lazy_backward = CachedAutogradLazyBackwardCompileInfo(
-                    self.serialized_bw_module.deserialize
-                )
-            # This function is run on both cache miss and cache hit, either here
-            # or in aot_dispatch_autograd. On a cache hit,
-            # 1. the bw is already compiled
-            # 2. we don't need to save to the cache again
-            # so those corresponding arguments are set to None.
-            compiled_function = AOTDispatchAutograd.post_compile(
-                compiled_fw_func,
-                compiled_bw_func,
-                self.maybe_subclass_meta,
-                self.compiled_bw.num_symints_saved_for_bw_,
-                self.compiled_bw.backward_state_indices,
-                disable_amp,
-                self.indices_of_inps_to_detach,
-                cached_lazy_backward,
-                aot_config,
-                fw_metadata=self.runtime_metadata,
-                try_save_cache_entry=None,
-            )
-
-        else:
-            compiled_function = RuntimeWrapper(
-                indices_of_inps_to_detach=self.indices_of_inps_to_detach,
-                trace_joint=False,
-                disable_amp=disable_amp,
-            ).post_compile(
-                compiled_fw_func, aot_config, runtime_metadata=self.runtime_metadata
-            )
-
-        # Add serialization function back onto object
-        compiled_function, _ = post_compile(
-            self.dispatch_wrappers,
-            compiled_function,
-            aot_config,
-            runtime_metadata=self.runtime_metadata,
-        )
-
-        # Now that we're pretty sure it's a successful load, add guards
-        # to the existing shape environment from the cache
-        if self.guards_expr:
-            symints = AOTAutogradCache._filter_backed_symints(args)
-            check = bool(AOTAutogradCache.evaluate_guards(self.guards_expr, symints))
-            assert check is True
-
-        return compiled_function
-
-
-class AOTAutogradCacheEntry(
-    GenericAOTAutogradCacheEntry[CompiledForward, CompiledBackward]
-):
-    """
-    Regular AOTAutogradCacheEntry: saves the forward/backward FxGraphCache keys
-    and looks them up in FxGraphCache on load
-    """
-
-
-class BundledAOTAutogradCacheEntry(
-    GenericAOTAutogradCacheEntry[
-        BundledCompiledForward[TOutputCode], BundledCompiledBackward[TOutputCode]
-    ],
-    Generic[TOutputCode],
-):
-    """
-    Generic AOTAutogradCacheEntry where we bundle the entire OutputCode directly
-    (rather than looking it up via FxGraphCache).
-
-    This works with any OutputCode type:
-    - CompiledFxGraph: Traditional inductor compilation
-    - RegionalOutputCode: Regional inductor compilation with GraphPickler serialization
-    - Any future OutputCode subclasses
-
-    Type parameter:
-        TOutputCode: The OutputCode subclass (e.g., CompiledFxGraph, RegionalOutputCode)
-
-    Usage with CompiledFxGraph:
-        entry = BundledAOTAutogradCacheEntry[CompiledFxGraph](
-            compiled_fw=BundledCompiledForward(result=CompiledFxGraph(...)),
-            compiled_bw=BundledCompiledBackward(
-                result=CompiledFxGraph(...),
-                backward_state_indices=[...],
-                num_symints_saved_for_bw_=...,
-            ),
-            ...
-        )
-
-    Usage with RegionalOutputCode:
-        entry = BundledAOTAutogradCacheEntry[RegionalOutputCode](
-            compiled_fw=BundledCompiledForward(result=RegionalOutputCode(gm)),
-            compiled_bw=BundledCompiledBackward(
-                result=RegionalOutputCode(gm),
-                backward_state_indices=[...],
-                num_symints_saved_for_bw_=...,
-            ),
-            ...
-        )
-    """
-
-
 @contextlib.contextmanager
 def sanitize_gm_for_cache(gm: torch.fx.GraphModule):
     """
@@ -1104,62 +544,10 @@ class AOTAutogradCacheArtifact(CacheArtifact):
         return "aot_autograd"
 
 
-def deserialize_bundled_cache_entry(entry: BundledAOTAutogradCacheEntry) -> Callable:
-    # In the precompile use case, guards are already serialized
-    # by dynamo, so we don't need to add them to the environment
-    entry.guards_expr = None
-    # TODO: this isn't exactly right, because cudagraphs needs to be a shared config
-    # which is set by compile_fx. But in precompile, we never actually call compile_fx
-    # so we don't have a place to track cudagraphs here.
-    cudagraphs = BoxedBool(torch._inductor.config.triton.cudagraphs)
-    boxed_forward_device_index = BoxedDeviceIndex(None)
-    # We need to make a clean copy of the cache entry
-    # in case it needs to be serialized again
-    serializable_copy = deepcopy(entry)
-
-    from torch._subclasses import FakeTensorMode
-    from torch.fx.experimental.symbolic_shapes import ShapeEnv
-
-    context = torch._guards.TracingContext.try_get()
-    if context is None:
-        # Create a clean environment when running fx graph post compile
-        # if one is not available
-        context = torch._guards.TracingContext(FakeTensorMode(shape_env=ShapeEnv()))
-    with torch._guards.tracing(context):
-        compiled_fn = entry.wrap_post_compile(
-            [],
-            entry.sanitized_aot_config,
-            {
-                "cudagraphs": cudagraphs,
-                "boxed_forward_device_index": boxed_forward_device_index,
-            },
-        )
-    # Ensure the deserialized cache entry is still serializable
-
-    compiled_fn = SerializableCompiledFunction(compiled_fn, lambda: serializable_copy)
-
-    # TODO: this ignores flat_params, which can exist
-    # if inline_builtin_nn_modules=False
-    @simple_wraps(compiled_fn)
-    def forward(*runtime_args: tuple[Any]):
-        return compiled_fn(list(runtime_args))
-
-    assert hasattr(compiled_fn, "serialize")
-    forward.serialize = compiled_fn.serialize  # type: ignore[attr-defined]
-
-    return forward
-
-
-@dataclass
-class BundledAOTAutogradCacheArtifact(BackendCacheArtifact[Callable]):
-    def after_deserialization(self) -> Callable:
-        return deserialize_bundled_cache_entry(self.content)
-
-
-class AOTAutogradCache(GuardedCache[GenericAOTAutogradCacheEntry]):
+class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult]):
     """
     Caches the results of running AOTAutograd. This class mostly handles the save and load logic, whereas
-    AOTAutogradCacheEntry handles the wrapping/unwrapping logic.
+    AOTAutogradResult handles the wrapping/unwrapping logic.
 
     Cache Inputs (AOTAutogradCacheDetails)
     - AOTAutogradCache takes in the following inputs, which are analogous to inputs given
@@ -1177,11 +565,11 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradCacheEntry]):
     In a later PR, we'll likely generate the cache key based on the FakeTensors AOTAutograd generates
     based on the real tensor inputs, which can contain symints.
 
-    # Cache Outputs (AOTAutogradCacheEntry)
+    # Cache Outputs (AOTAutogradResult)
     - AOTAutogradCache caches the following values:
         - The compiled forward and backward functions from inductor, via keys to the FXGraphCache
         - Metadata to reconstruct the AOTModule from the compiled inductor artifacts
-        - See AOTAutogradCacheEntry for more info
+        - See AOTAutogradResult for more info
 
     [Note: Caching guards generated by AOTAutograd and Inductor]
     AOTAutograd and inductor both can introduce new guards to the shape environment. FXGraphCache saves guards with each
@@ -1229,7 +617,7 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradCacheEntry]):
                 cache_key, debug_lines = autograd_cache_key(
                     gm, args, aot_config, fx_config
                 )
-                result: Optional[tuple[GenericAOTAutogradCacheEntry, bytes]] = (
+                result: Optional[tuple[GenericAOTAutogradResult, bytes]] = (
                     AOTAutogradCache._lookup(
                         cache_key, local, remote, args, cache_info, aot_config
                     )
@@ -1401,7 +789,7 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradCacheEntry]):
         args: list[Any],
         cache_info: dict[str, Any],
         aot_config: Optional[AOTConfig],
-    ) -> Optional[tuple[GenericAOTAutogradCacheEntry, bytes]]:
+    ) -> Optional[tuple[GenericAOTAutogradResult, bytes]]:
         """Given a key generated by AOTAutogradCachePickler, look up its location in the cache."""
         remote_cache: Optional[RemoteCache[JsonDataTy]] = None
         if remote:
@@ -1465,7 +853,7 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradCacheEntry]):
         write_atomic(path, content)
 
     @staticmethod
-    def save(key: str, entry: GenericAOTAutogradCacheEntry, remote: bool):
+    def save(key: str, entry: GenericAOTAutogradResult, remote: bool):
         """Save a single entry into the cache."""
         try:
             entry.pre_save()
@@ -1548,7 +936,7 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradCacheEntry]):
         backward_state_indices: Optional[list[int]],
         num_symints_saved_for_bw: Optional[int],
         serialized_bw_module: Optional[SerializedGraphModule],
-    ) -> GenericAOTAutogradCacheEntry:
+    ) -> GenericAOTAutogradResult:
         if should_bundle_autograd_cache():
             # Helper function to unwrap all the wrappers we added during aotdispatch
             # They get reapplied on cache load
@@ -1569,7 +957,7 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradCacheEntry]):
                     compiled_bw_graph, backward_state_indices, num_symints_saved_for_bw
                 )
 
-            return BundledAOTAutogradCacheEntry(
+            return BundledAOTAutogradResult(
                 compiled_fw=bundled_compiled_forward,
                 compiled_bw=bundled_compiled_backward,
                 aot_joint_graph_str=aot_joint_graph_str,
@@ -1614,7 +1002,7 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradCacheEntry]):
                     num_symints_saved_for_bw_=num_symints_saved_for_bw,
                 )
 
-            return AOTAutogradCacheEntry(
+            return AOTAutogradResult(
                 compiled_fw=compiled_forward,
                 compiled_bw=compiled_backward,
                 aot_joint_graph_str=aot_joint_graph_str,

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -50,10 +50,9 @@ from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 from torchgen.utils import dataclass_repr
 
 from .. import config
+from .aot_autograd_result import GenericAOTAutogradResult, serialize_graph_module
 from .autograd_cache import (
     AOTAutogradCache,
-    GenericAOTAutogradCacheEntry,
-    serialize_graph_module,
     should_bundle_autograd_cache,
     should_use_remote_autograd_cache,
 )
@@ -397,7 +396,7 @@ def _cache_inference_info(
         else:
             return hasattr(compiled_fw, "_fx_graph_cache_key")
 
-    entry: Optional[GenericAOTAutogradCacheEntry] = None
+    entry: Optional[GenericAOTAutogradResult] = None
     if cache_info is not None and should_save_cache():
         time_taken_ns = time.time_ns() - cache_info.start_time_ns
         guards_expr = AOTAutogradCache.generate_guards_expression(cache_info)
@@ -2031,7 +2030,7 @@ def _cache_autograd_info(
     make_runtime_safe(fw_metadata, maybe_subclass_meta)
 
     try_save_cache_entry: Optional[Callable] = None
-    entry: Optional[GenericAOTAutogradCacheEntry] = None
+    entry: Optional[GenericAOTAutogradResult] = None
 
     if aot_config.cache_info is not None:
         forward_time_taken_ns = time.time_ns() - aot_config.cache_info.start_time_ns
@@ -2044,7 +2043,7 @@ def _cache_autograd_info(
             bw_module: torch.fx.GraphModule,
             _fw_metadata: ViewAndMutationMeta,
             aot_config: AOTConfig,
-        ) -> Optional[GenericAOTAutogradCacheEntry]:
+        ) -> Optional[GenericAOTAutogradResult]:
             cache_info = aot_config.cache_info
 
             def should_save_cache():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #166656
* #166650

This PR refactors the name AOTAutogradCacheEntry into AOTAutogradResult, and BundledAOTAutogradCacheEntry into BundledAOTAutogradResult. It also moves all coresponding files to a new file, `aot_autograd_result`, which is analogous to `output_code.py` from Inductor. 

Having all these be called cache entries made sense when all we used them for was caching. But with AOT compile using BundledAOTAutogradCacheEntry, we want a more generalized naming structure. 

This is a no-op change,  and all existing tests should pass. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela