### PR TITLE
[Inductor] Add traditional O(output_size * kernel_size**2) lowering for large max_pool2d kernels

### DIFF
--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -77,7 +77,7 @@ inductor_decompositions = get_decompositions(
         aten.leaky_relu,
         aten.linalg_vector_norm,
         aten._log_softmax,
-        aten.max_pool2d_with_indices_backward,
+        # aten.max_pool2d_with_indices_backward,  # Removed: use custom scatter backend lowering
         aten._native_batch_norm_legit,
         aten._native_batch_norm_legit_functional,
         aten._native_batch_norm_legit_no_training,

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -77,7 +77,7 @@ inductor_decompositions = get_decompositions(
         aten.leaky_relu,
         aten.linalg_vector_norm,
         aten._log_softmax,
-        # aten.max_pool2d_with_indices_backward,  # Removed: use custom scatter backend lowering
+        # aten.max_pool2d_with_indices_backward,  # Removed: use custom lowering (scatter + traditional Triton backends)
         aten._native_batch_norm_legit,
         aten._native_batch_norm_legit_functional,
         aten._native_batch_norm_legit_no_training,


### PR DESCRIPTION
Fixes #66042. Follow on to PR https://github.com/pytorch/pytorch/pull/164178

Adds a traditional triton backend to provide a full compile path. cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @chenyang78 @isuruf 

Tolerances for tests and some adjustments will likely be required after PR 164178 is landed. 