### PR TITLE
[2/N] Use 'is' in callable comparisons

### DIFF
--- a/torch/_dynamo/_trace_wrapped_higher_order_op.py
+++ b/torch/_dynamo/_trace_wrapped_higher_order_op.py
@@ -140,7 +140,7 @@ class TransformGetItemToIndex(TorchFunctionMode):
         args: tuple[object, ...] = (),
         kwargs: Optional[dict[str, object]] = None,
     ) -> object:
-        if func == torch.Tensor.__getitem__:
+        if func is torch.Tensor.__getitem__:
             index_args = pytree.tree_leaves(args[1])
             if all(isinstance(x, torch.Tensor) for x in index_args):
                 return mod_index(args[0], index_args)

--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -1363,7 +1363,7 @@ class AutogradCompilerInstance:
                 )
 
             arg = max(input_nodes_and_users)  # last input users
-            if arg.op == "call_function" and arg.target == call_accumulate_grad:
+            if arg.op == "call_function" and arg.target is call_accumulate_grad:
                 param_node = arg.args[0]
                 post_acc_grad_hook_node = None
                 for n in list(param_node.users.keys()):

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -3560,7 +3560,7 @@ class LocalMapWrappedHigherOrderVariable(WrapHigherOrderVariable):
         if type(value) is not type(_local_map_wrapped):
             return False
 
-        return value == _local_map_wrapped and cls._enabled
+        return value is _local_map_wrapped and cls._enabled
 
     @staticmethod
     def build(**options):

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -971,7 +971,7 @@ class TS2FXGraphConverter:
         # "cannot mutate tensors with frozen storage" functionalization error.
         # To work around the issue, we override the copy to be True, so that the output
         # is for sure not an alias of input
-        if target == torch.ops.aten.to.dtype or target == torch.ops.aten.to.prim_dtype:
+        if target is torch.ops.aten.to.dtype or target is torch.ops.aten.to.prim_dtype:
             user_nodes = [use.user for use in node.output().uses()]
             user_targets = [
                 get_op_overload(user_node)
@@ -1011,7 +1011,7 @@ class TS2FXGraphConverter:
         else:
             target = get_op_overload(node)
 
-        if target == torch.ops.aten.add.t:
+        if target is torch.ops.aten.add.t:
             # special handle python list/tuple add: "aten::add.t(t[] a, t[] b) -> t[]" for
             # RuntimeError: aten::add() Expected a value of type 'List[t]' for argument 'a' but instead found type 'immutable_list'.
             args, _kwargs = self.get_args_kwargs(node, target._schema)

--- a/torch/_export/pass_base.py
+++ b/torch/_export/pass_base.py
@@ -236,10 +236,10 @@ class _ExportPassBaseDeprecatedDoNotUse(PassBase):
                     kwargs,
                     meta,
                 )
-            elif target == torch.ops.higher_order.cond:
+            elif target is torch.ops.higher_order.cond:
                 pred, true_fn, false_fn, inputs = args
                 return self.callback.call_cond(pred, true_fn, false_fn, inputs, meta)
-            elif target == torch.ops.higher_order.map_impl:
+            elif target is torch.ops.higher_order.map_impl:
                 f, mapped_args, operands = args  # type: ignore[assignment]
                 return self.callback.call_map(f, mapped_args, operands, meta)
             # For other unregistered HigherOrderOps, just interpret them blindly

--- a/torch/_export/passes/constant_folding.py
+++ b/torch/_export/passes/constant_folding.py
@@ -135,7 +135,7 @@ class ConstantFolder(torch.fx.Interpreter):
         # TODO - fix errors with this
         if (
             node.op == "call_function"
-            and node.target == aten._efficientzerotensor.default
+            and node.target is aten._efficientzerotensor.default
         ):
             return self.unknown_value
 

--- a/torch/_export/passes/replace_autocast_with_hop_pass.py
+++ b/torch/_export/passes/replace_autocast_with_hop_pass.py
@@ -59,7 +59,7 @@ def _is_autocast_sub_mod(node: torch.fx.Node) -> bool:
         if (
             first_non_ph
             and first_non_ph.op == "call_function"
-            and first_non_ph.target == torch.amp.autocast_mode._enter_autocast
+            and first_non_ph.target is torch.amp.autocast_mode._enter_autocast
         ):
             # TODO: check if current auto-cast type is the same as the args of
             # _enter_autocast. If so, return False, i.e. do not create a submodule.

--- a/torch/_export/passes/replace_set_grad_with_hop_pass.py
+++ b/torch/_export/passes/replace_set_grad_with_hop_pass.py
@@ -38,7 +38,7 @@ def _is_set_grad_enabled_sub_mod(
         if (
             first_non_ph
             and first_non_ph.op == "call_function"
-            and first_non_ph.target == torch._C._set_grad_enabled
+            and first_non_ph.target is torch._C._set_grad_enabled
         ):
             return (
                 first_non_ph.args[0] != torch.is_grad_enabled()

--- a/torch/_export/serde/schema_check.py
+++ b/torch/_export/serde/schema_check.py
@@ -129,7 +129,7 @@ def _staged_schema():
             t, cpp_type, thrift_type = dump_type(f.type, 0)
             ret = {"type": t}
             cpp_default: Optional[str] = None
-            assert typing.get_origin(f.type) == Annotated, (
+            assert typing.get_origin(f.type) is Annotated, (
                 f"Field {f.name} must be annotated with an integer id."
             )
             thrift_id = f.type.__metadata__[0]

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -2354,14 +2354,14 @@ class GraphModuleDeserializer(metaclass=Final):
         )
 
         # handle ShapeEnv asserts
-        if target == torch.ops.aten._assert_scalar.default:
+        if target is torch.ops.aten._assert_scalar.default:
             if not isinstance((arg := fx_node.args[0]), bool):
                 expr = arg.meta["val"]  # type: ignore[union-attr]
                 if isinstance(expr, torch.SymBool):
                     self.shape_env.guard_or_defer_runtime_assert(
                         expr.node.expr, "", fx_node
                     )
-        elif target == torch.ops.aten.sym_constrain_range_for_size.default:
+        elif target is torch.ops.aten.sym_constrain_range_for_size.default:
             sym = fx_node.args[0].meta["val"]  # type: ignore[union-attr]
             if isinstance(sym, torch.SymInt):
                 self.shape_env._constrain_range_for_size(sym.node.expr)

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -681,7 +681,7 @@ def _insert_aten_to_metadata_assert_pass(gm: torch.fx.GraphModule) -> None:
     for node in gm.graph.nodes:
         if node.target in aten_to_variants:
             if (
-                node.prev.target == torch.ops.aten._assert_tensor_metadata.default
+                node.prev.target is torch.ops.aten._assert_tensor_metadata.default
                 and node.args[0] == node.prev.args[0]
             ):
                 # skip if already guarded

--- a/torch/_inductor/constant_folding.py
+++ b/torch/_inductor/constant_folding.py
@@ -214,7 +214,7 @@ class ConstantFolder(torch.fx.Interpreter):
         # TODO - fix errors with this
         if (
             node.op == "call_function"
-            and node.target == aten._efficientzerotensor.default
+            and node.target is aten._efficientzerotensor.default
         ):
             return self.unknown_value
 

--- a/torch/_inductor/cudagraph_utils.py
+++ b/torch/_inductor/cudagraph_utils.py
@@ -73,7 +73,7 @@ def get_mutating_use_stack_trace_from_node(
         return next(iter(placeholder_node.users)).meta.get("stack_trace", None)
 
     for use in placeholder_node.users:
-        if use.target == torch.ops.aten.copy_.default:
+        if use.target is torch.ops.aten.copy_.default:
             if stack_trace := use.meta.get("stack_trace", None):
                 return stack_trace
 

--- a/torch/_inductor/freezing.py
+++ b/torch/_inductor/freezing.py
@@ -271,7 +271,7 @@ def convert_conv_weights_to_channels_last(gm: torch.fx.GraphModule):
     folded by freezing.
     """
     with dynamo_timed("convert_conv_weights_to_channels_last"):
-        convs = [n for n in gm.graph.nodes if n.target == aten.convolution.default]
+        convs = [n for n in gm.graph.nodes if n.target is aten.convolution.default]
         for conv in convs:
             weight_node = conv.args[1]
             if len(weight_node.meta["val"].size()) != 4 or weight_node.meta[

--- a/torch/_inductor/fx_passes/binary_folding.py
+++ b/torch/_inductor/fx_passes/binary_folding.py
@@ -284,7 +284,7 @@ def binary_folding_init():
         if binary_node.args[0].target in _computation_ops:
             computation_node = binary_node.args[0]
             other = binary_node.args[1]
-        elif binary_node.args[0].target == aten.reshape.default:
+        elif binary_node.args[0].target is aten.reshape.default:
             computation_node = binary_node.args[0].args[0]
             other = binary_node.args[1]
             has_reshape = True
@@ -295,7 +295,7 @@ def binary_folding_init():
             computation_node = binary_node.args[1].args[0]
             other = binary_node.args[0]
             has_reshape = False
-        if computation_node.target == aten.convolution.default:
+        if computation_node.target is aten.convolution.default:
             return _check_conv_and_broadcast_op(computation_node, other)
         elif computation_node.target in [aten.addmm.default, aten.mm.default]:
             return (
@@ -344,7 +344,7 @@ def binary_folding_init():
         return res
 
     def _create_new_conv_node(graph, conv_node, binary_node, other):
-        assert conv_node.target == aten.convolution.default
+        assert conv_node.target is aten.convolution.default
         conv_args = list(conv_node.args)
         weight_meta_value = conv_node.args[1].meta.get("val")
         bias = conv_args[2]
@@ -472,7 +472,7 @@ def binary_folding_init():
             reshape_node = None
             if binary_node.args[0].target in _computation_ops:
                 computation_node = binary_node.args[0]
-            elif binary_node.args[0].target == aten.reshape.default:
+            elif binary_node.args[0].target is aten.reshape.default:
                 computation_node = binary_node.args[0].args[0]
                 reshape_node = binary_node.args[0]
             elif binary_node.args[1].target in _computation_ops:
@@ -483,7 +483,7 @@ def binary_folding_init():
             graph = match.graph
             with graph.inserting_before(reshape_node if reshape_node else binary_node):
                 assert computation_node.target in _computation_ops
-                if computation_node.target == aten.convolution.default:
+                if computation_node.target is aten.convolution.default:
                     counters["inductor"]["binary_folding_conv"] += 1
                     new_computation_node = _create_new_conv_node(
                         graph, computation_node, binary_node, other
@@ -494,7 +494,7 @@ def binary_folding_init():
                     )
                 new_computation_node.meta.update(computation_node.meta)
                 if reshape_node:
-                    assert reshape_node.target == aten.reshape.default
+                    assert reshape_node.target is aten.reshape.default
                     computation_node.replace_all_uses_with(new_computation_node)
                     binary_node.replace_all_uses_with(reshape_node)
                 else:

--- a/torch/_inductor/fx_passes/bucketing.py
+++ b/torch/_inductor/fx_passes/bucketing.py
@@ -730,7 +730,7 @@ def process_collective_bucket(
             is_all_gather_into_tensor(n)
             and isinstance(node_in, torch.fx.Node)  # Add type check
             and node_in.op == "call_function"
-            and node_in.target == torch.ops.prims.convert_element_type.default
+            and node_in.target is torch.ops.prims.convert_element_type.default
             and len(node_in.users) == 1
         ):
             ag_node_to_pre_nodes[n].append(node_in)

--- a/torch/_inductor/fx_passes/ddp_fusion.py
+++ b/torch/_inductor/fx_passes/ddp_fusion.py
@@ -92,7 +92,7 @@ def get_comm_block(comm_node: fx.Node) -> CommBlock | None:
     first_user = next(iter(comm_node.users))
     if (
         len(comm_node.users) == 1
-        and first_user.target == torch.ops._c10d_functional.wait_tensor.default
+        and first_user.target is torch.ops._c10d_functional.wait_tensor.default
     ):
         # Collective with only one output
         node_list = [comm_node, first_user]

--- a/torch/_inductor/fx_passes/freezing_patterns.py
+++ b/torch/_inductor/fx_passes/freezing_patterns.py
@@ -144,7 +144,7 @@ def addmm_patterns_init():
             weight_inputs.append("w3")
 
         if not all(
-            match.kwargs[wgt].target == torch.ops.prims.convert_element_type.default
+            match.kwargs[wgt].target is torch.ops.prims.convert_element_type.default
             for wgt in weight_inputs
         ):
             return False

--- a/torch/_inductor/fx_passes/fsdp.py
+++ b/torch/_inductor/fx_passes/fsdp.py
@@ -48,7 +48,7 @@ def is_fsdp_reduce_scatter_wait(wait: torch.fx.Node) -> bool:
         return (
             is_graph_output(user)
             and user.op == "call_function"
-            and user.target == torch.ops.prims.convert_element_type.default
+            and user.target is torch.ops.prims.convert_element_type.default
         )
 
     return False

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -414,12 +414,12 @@ class BatchPointwiseMathOpsPostGradFusion(BatchPointwiseOpsFusionFactory):
             if self.graph_search_options.get("fuse_nodes_with_same_parent", False):
                 # only consider the linear case so far
                 # pyre-fixme[16]
-                if input.target == aten.select or other.target == aten.select:  # type: ignore[union-attr]
+                if input.target is aten.select or other.target is aten.select:  # type: ignore[union-attr]
                     parent = (
                         # pyre-fixme[16]
                         input.args[0]  # type: ignore[union-attr]
                         # pyre-fixme[16]
-                        if input.target == aten.select  # type: ignore[union-attr]
+                        if input.target is aten.select  # type: ignore[union-attr]
                         else other.args[0]  # type: ignore[union-attr]
                     )
                 else:

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -329,7 +329,7 @@ class UniformValueConstantFolder(ConstantFolder):
         # constructors ops
         if (
             node.op == "call_function"
-            and node.target == aten.full.default
+            and node.target is aten.full.default
             and len(node.args) == 2
         ):
             args, kwargs = self.fetch_args_kwargs_from_env(node)
@@ -340,7 +340,7 @@ class UniformValueConstantFolder(ConstantFolder):
                 return aten.full.default(*new_args, **node.kwargs)
 
         # handle before view ops because this changes value
-        if node.target == aten.view.dtype:
+        if node.target is aten.view.dtype:
             return super(ConstantFolder, self).run_node(node)
 
         # view ops, return input tensor, the first argument
@@ -438,7 +438,7 @@ def constant_fold_uniform_value(gm: torch.fx.GraphModule):
                 # the conversion from tensor and back to value can be lossy, just use the original full ctor value
                 if (
                     node.op == "call_function"
-                    and node.target == aten.full.default
+                    and node.target is aten.full.default
                     and len(node.args) == 2
                 ):
                     value = node.args[1]

--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -344,7 +344,7 @@ def should_exclude_padding_time(match: Match, arg_name: str) -> bool:
         return False
 
     if (
-        node_def.target == aten.cat.default
+        node_def.target is aten.cat.default
         and len(node_def.all_input_nodes)
         > torch._inductor.config.max_pointwise_cat_inputs
     ):

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -1867,7 +1867,7 @@ class ConstructorMoverPass:
                 noop_device_puts = [
                     user
                     for user in gpu_node.users
-                    if user.target == torch.ops.prims.device_put.default
+                    if user.target is torch.ops.prims.device_put.default
                     and user.args[1] == target_device
                 ]
                 for noop in noop_device_puts:

--- a/torch/_inductor/fx_passes/quantization.py
+++ b/torch/_inductor/fx_passes/quantization.py
@@ -1175,8 +1175,8 @@ def _register_concat_linear_int8_woq_lowering(
         mm_node_of_x = None
         for candidate in iter(x.users.keys()):
             if (
-                candidate.target == aten.mm.default
-                and list(candidate._input_nodes)[1].target == aten.cat.default
+                candidate.target is aten.mm.default
+                and list(candidate._input_nodes)[1].target is aten.cat.default
             ):
                 mm_node_of_x = candidate
                 break

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -434,7 +434,7 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
     for i, node in enumerate(reversed(graph.nodes)):
         node_order[node] = len(graph.nodes) - i - 1
         storage_to_nodes[get_node_storage(node)].append(node)
-        if node.target == aten.copy_.default and node.args[0].op in (
+        if node.target is aten.copy_.default and node.args[0].op in (
             "placeholder",
             "get_attr",
         ):
@@ -448,7 +448,7 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
                     and src.args[0].kwargs["kwargs"][src.args[1]] == node.args[0]
                 )
                 or (src.args[0].target in inplaceable_foreach_ops)
-                or (src.args[0].target == torch.ops.higher_order.auto_functionalized)
+                or (src.args[0].target is torch.ops.higher_order.auto_functionalized)
             ):
                 src = src.args[0]
 

--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -1526,7 +1526,7 @@ def merge_getitem_cat(match: Match, split_sections: list[int], dim: int):
     # 'immutable_list' object does not support mutation. Create a new copy of it
     split_sections = list(split_sections)
     for cat_user in next_users:
-        if cat_user.target == torch.cat:
+        if cat_user.target is torch.cat:
             cat_dim = get_arg_value(cat_user, 1, "dim")
             # check the all getitems in the cat_user from the same node
             # check the input of the cat has all getitem from the split
@@ -1631,7 +1631,7 @@ def mutate_cat_node(match: Match, split_sections: list[int], dim: int):
     # Find the next users (i.e. users after the getitem)
     next_users = find_next_users(split_node)
     for cat_user in next_users:
-        if cat_user.target == torch.cat:
+        if cat_user.target is torch.cat:
             cat_dim = get_arg_value(cat_user, 1, "dim") or 0
             # check that all getitems in the cat_user from the same node
             # check the input of the cat has all getitem from the split
@@ -2010,7 +2010,7 @@ def merge_unbind_stack_aten(match: Match, *args, **kwargs):
     cat_dim = get_arg_value(node, 1, "dim")
     # check the unsqueeze nodes come from the select nodes
     if not all(
-        get_arg_value(unsqueeze_node, 0, "input").target == torch.ops.aten.select
+        get_arg_value(unsqueeze_node, 0, "input").target is torch.ops.aten.select
         for unsqueeze_node in unsqueeze_nodes
     ):
         return
@@ -2755,13 +2755,13 @@ def get_view_shape_list(cat_arg: torch.fx.Node, stack_dim: int) -> list[int]:
     # cat_arg must be the split input
     view_shape_list = []
     for user in cat_arg.users.keys():
-        if user.target == torch.split:
+        if user.target is torch.split:
             for getitem in user.users.keys():
                 if getitem.target == operator.getitem:
                     reshape_user = [
                         user
                         for user in getitem.users.keys()
-                        if user.target == torch.reshape
+                        if user.target is torch.reshape
                     ]
                     if len(reshape_user) > 0:
                         view_shape_list = list(

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -661,7 +661,7 @@ class GraphLowering(torch.fx.Interpreter):
             return True
 
         conv_nodes = [
-            n for n in gm.graph.nodes if n.target == torch.ops.aten.convolution.default
+            n for n in gm.graph.nodes if n.target is torch.ops.aten.convolution.default
         ]
         nconv = len(conv_nodes)
 
@@ -860,7 +860,7 @@ class GraphLowering(torch.fx.Interpreter):
         nodes_cannot_propagate = [torch.ops.aten.bmm.default]
         output_set = OrderedSet[Node]()
         for n in reversed(self.module.graph.nodes):  # type: ignore[arg-type, union-attr]
-            if n.target == torch.ops.aten.convolution.default:
+            if n.target is torch.ops.aten.convolution.default:
                 output_set.add(n)
                 if last_conv is None:
                     last_conv = n
@@ -1988,7 +1988,7 @@ class GraphLowering(torch.fx.Interpreter):
 
         if (
             full_aoti_runtime_assert()
-            and n.target == torch.ops.aten._assert_scalar.default
+            and n.target is torch.ops.aten._assert_scalar.default
             and self.aot_mode
         ):
             node_args, _ = self.fetch_args_kwargs_from_env(n)

--- a/torch/_inductor/kernel/flex/flex_flash_attention.py
+++ b/torch/_inductor/kernel/flex/flex_flash_attention.py
@@ -72,7 +72,7 @@ def is_trivial_graph(
             return False
         return True  # party on garth
     # mask mod graph is empty if we have 4 inputs and full_default output
-    return len(placeholders) == 4 and output_val.target == torch.ops.aten.full.default
+    return len(placeholders) == 4 and output_val.target is torch.ops.aten.full.default
 
 
 def _can_use_flex_flash_attention(

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -827,7 +827,7 @@ class FakeTensor(Tensor):
     ) -> object:
         # need to handle here to avoid infinite recursion
         # see [in_kernel_invocation]
-        if func == torch.ops.prim.device.default:
+        if func is torch.ops.prim.device.default:
             assert len(args) == 1 and isinstance(args[0], FakeTensor)
             if args[0].fake_mode.in_kernel_invocation:
                 return torch.device("meta")
@@ -2378,12 +2378,12 @@ class FakeTensorMode(TorchDispatchMode):
         avoiding_device_init = False
         if self.avoid_device_init:
             if (
-                func == torch.ops.aten._to_copy.default
+                func is torch.ops.aten._to_copy.default
                 and "device" in kwargs
                 and kwargs["device"].type != "cpu"  # type: ignore[attr-defined]
             ):
                 avoiding_device_init = True
-            if func == torch.ops.prims.device_put.default:
+            if func is torch.ops.prims.device_put.default:
                 avoiding_device_init = True
 
         # skip const prop for aten._to_copy if
@@ -3226,7 +3226,7 @@ class FakeCopyMode(TorchFunctionMode):
         kwargs = kwargs if kwargs else {}
 
         # clone will get called in Parameter deepcopy
-        if func == torch._C.TensorBase.clone:
+        if func is torch._C.TensorBase.clone:
             assert isinstance(args[0], Tensor)
             return func(
                 self.fake_mode.from_tensor(args[0], static_shapes=True), **kwargs

--- a/torch/_subclasses/functional_tensor.py
+++ b/torch/_subclasses/functional_tensor.py
@@ -376,7 +376,7 @@ class FunctionalTensorMode(TorchDispatchMode):
         def _can_decompose(func):
             # See https://github.com/pytorch/pytorch/pull/115258#issuecomment-1900755832
             # Never decompose dropout in export
-            if self.export and func == torch.ops.aten.dropout.default:
+            if self.export and func is torch.ops.aten.dropout.default:
                 return False
 
             # We unconditionally decompose ops that are maybe aliasing or mutating ops
@@ -549,7 +549,7 @@ class FunctionalTensorMode(TorchDispatchMode):
                     )
 
                     if self.export:
-                        if func == torch.ops.aten.dropout.default:
+                        if func is torch.ops.aten.dropout.default:
                             torch._freeze_functional_tensor(outs_unwrapped)  # type: ignore[attr-defined]
                     outs_wrapped = pytree.tree_map_only(
                         torch.Tensor, wrap, outs_unwrapped
@@ -576,7 +576,7 @@ class FunctionalTensorMode(TorchDispatchMode):
             # aliasing correction step. Otherwise, we would be setting the storage of a
             # lifted tensor to that of an unlifted tensor.
             # Ref: https://github.com/pytorch/pytorch/issues/111506
-            or func == torch.ops.aten.lift_fresh.default
+            or func is torch.ops.aten.lift_fresh.default
         ):
             return outs_wrapped
         # for metadata mutations, need to manually mutate the metadata of the FunctionalTensor wrapper

--- a/torch/ao/quantization/fx/convert.py
+++ b/torch/ao/quantization/fx/convert.py
@@ -643,7 +643,7 @@ def _get_module_path_and_prefix(
         first_linear_use_or_first_use = users[0] if users else None
         linear_node = None
         for n in users:
-            if n.op == "call_function" and n.target == torch.nn.functional.linear:
+            if n.op == "call_function" and n.target is torch.nn.functional.linear:
                 linear_node = n
                 break
         if linear_node:

--- a/torch/ao/quantization/fx/fuse_handler.py
+++ b/torch/ao/quantization/fx/fuse_handler.py
@@ -84,7 +84,7 @@ class DefaultFuseHandler(FuseHandler):
                 n = pattern
                 if n.op == "call_module":
                     return named_modules[n.target]
-                elif n.op == "call_function" and n.target == torch.nn.functional.relu:
+                elif n.op == "call_function" and n.target is torch.nn.functional.relu:
                     relu = torch.nn.ReLU()
                     relu.training = root_module.training
                     return relu

--- a/torch/ao/quantization/fx/lstm_utils.py
+++ b/torch/ao/quantization/fx/lstm_utils.py
@@ -212,7 +212,7 @@ def _get_reference_quantized_lstm_module(
                 arg = node.args[0]
                 # Remove quantize(x), quantize(hidden[0]), and quantize(hidden[1])
                 if arg.target == "x" or (
-                    arg.target == operator.getitem and arg.args[0].target == "hidden"
+                    arg.target is operator.getitem and arg.args[0].target == "hidden"
                 ):
                     with cell.graph.inserting_before(node):
                         node.replace_all_uses_with(arg)

--- a/torch/ao/quantization/fx/utils.py
+++ b/torch/ao/quantization/fx/utils.py
@@ -215,7 +215,7 @@ def collect_producer_nodes(node: Node) -> Optional[list[Node]]:
                 # hit input, can't fold in this case
                 return None
             nodes.append(arg)
-            if not (arg.op == "call_function" and arg.target == getattr):
+            if not (arg.op == "call_function" and arg.target is getattr):
                 frontier.append(arg)
     return nodes
 

--- a/torch/ao/quantization/pt2e/lowering.py
+++ b/torch/ao/quantization/pt2e/lowering.py
@@ -38,7 +38,7 @@ def lower_pt2e_quantized_to_x86(
         aten = torch.ops.aten
         g = m.graph
         for node in g.nodes:
-            if node.target == aten.t.default:
+            if node.target is aten.t.default:
                 with g.inserting_before(node):
                     x = node.args[0]
                     dims = [1, 0]

--- a/torch/ao/quantization/pt2e/utils.py
+++ b/torch/ao/quantization/pt2e/utils.py
@@ -204,7 +204,7 @@ def _is_conv_transpose_fn(conv_fn: Callable):
 def _is_bn_node(n: Node):
     return (
         _is_supported_batch_norm_for_training(n)
-        or n.target == torch.ops.aten._native_batch_norm_legit_no_training.default
+        or n.target is torch.ops.aten._native_batch_norm_legit_no_training.default
     )
 
 

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -631,7 +631,7 @@ class AsyncCollectiveTensor(torch.Tensor):
 
     @classmethod
     def __torch_dispatch__(cls, func, types, args=(), kwargs=None):  # type: ignore[override]
-        if func == torch.ops.aten.view.default:
+        if func is torch.ops.aten.view.default:
             # Fast handle aten.view as a lot of view related op goes to aten.view
             # eventually, this avoids pytree slowdown
             # pyrefly: ignore [index-error]

--- a/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/_common.py
+++ b/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/_common.py
@@ -128,7 +128,7 @@ def _handle_col_wise_sharding_base(
     # run the operator's function for all the inputs.
     results = []
     for i, inp in enumerate(gathered_inputs):
-        if op_func == torch.nn.functional.embedding_bag:
+        if op_func is torch.nn.functional.embedding_bag:
             result = op_func(
                 inp,
                 local_shard,
@@ -139,7 +139,7 @@ def _handle_col_wise_sharding_base(
                 else None,
                 padding_idx=padding_idx,
             )
-        elif op_func == torch.nn.functional.embedding:
+        elif op_func is torch.nn.functional.embedding:
             result = op_func(
                 inp,
                 local_shard,

--- a/torch/distributed/_tools/fsdp2_mem_tracker.py
+++ b/torch/distributed/_tools/fsdp2_mem_tracker.py
@@ -507,7 +507,7 @@ class FSDPMemTracker(MemTracker):
 
     def __torch_dispatch__(self, func, types, args=..., kwargs=None):  # type: ignore[no-untyped-def]
         if (
-            func == torch.ops._c10d_functional.wait_tensor.default
+            func is torch.ops._c10d_functional.wait_tensor.default
             and active_fake_mode()
         ):
             # N.B: This is a hacky way to override the Meta IMPL of wait_tensor. The original impl returns

--- a/torch/distributed/_tools/mem_tracker.py
+++ b/torch/distributed/_tools/mem_tracker.py
@@ -930,7 +930,7 @@ class MemTracker(TorchDispatchMode):
 
     def __torch_dispatch__(self, func, types, args=(), kwargs=None):  # type: ignore[no-untyped-def]
         if (
-            func == torch.ops._c10d_functional.wait_tensor.default
+            func is torch.ops._c10d_functional.wait_tensor.default
             and active_fake_mode()
         ):
             # N.B: This is a hacky way to override the Meta IMPL of wait_tensor. The original impl returns

--- a/torch/distributed/_tools/memory_tracker.py
+++ b/torch/distributed/_tools/memory_tracker.py
@@ -26,7 +26,7 @@ class MemoryProfileDispatchMode(TorchDispatchMode):
 
     def __torch_dispatch__(self, func, types, args=..., kwargs=None):
         rs = func(*args, **kwargs)
-        if func == torch.ops.aten.detach.default:
+        if func is torch.ops.aten.detach.default:
             return rs
         func_name: str = (
             self.memory_tracker._cur_module_name

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2672,13 +2672,13 @@ def _coalescing_manager(
         # - coalesced `all_gather_into_tensor`
         # - coalesced `reduce_scatter_tensor`
         op0 = op_list[0].op
-        if op0 == all_reduce:
+        if op0 is all_reduce:
             tensors = [op.tensor for op in op_list]
             all_reduce_opts = AllreduceCoalescedOptions()
             all_reduce_opts.reduceOp = not_none(op_list[0].redop)
             all_reduce_opts.asyncOp = async_ops
             work = group.allreduce_coalesced(tensors, all_reduce_opts)
-        elif op0 == all_gather_into_tensor:
+        elif op0 is all_gather_into_tensor:
             inputs = []
             outputs = []
             for op in op_list:
@@ -2687,7 +2687,7 @@ def _coalescing_manager(
             all_gather_opts = AllgatherOptions()
             all_gather_opts.asyncOp = async_ops
             work = group.allgather_into_tensor_coalesced(outputs, inputs)
-        elif op0 == reduce_scatter_tensor:
+        elif op0 is reduce_scatter_tensor:
             inputs = []
             outputs = []
             for op in op_list:

--- a/torch/export/_remove_effect_tokens_pass.py
+++ b/torch/export/_remove_effect_tokens_pass.py
@@ -52,7 +52,7 @@ def _remove_effect_tokens_from_graph_helper(
         func = node.args[1]
         assert isinstance(func, (torch._ops.OpOverload, torch._ops.HigherOrderOperator))
 
-        if func == torch.ops.higher_order.call_torchbind:
+        if func is torch.ops.higher_order.call_torchbind:
             custom_obj_meta = node.args[2].meta["val"]  # type: ignore[union-attr]
             assert isinstance(custom_obj_meta, CustomObjArgument)
             if custom_obj_meta.fake_val:

--- a/torch/export/_swap.py
+++ b/torch/export/_swap.py
@@ -110,7 +110,7 @@ def _try_remove_connecting_pytrees(curr_module_node: torch.fx.Node) -> None:
             # pyrefly: ignore [missing-attribute]
             arg.op == "call_function"
             # pyrefly: ignore [missing-attribute]
-            and arg.target == operator.getitem
+            and arg.target is operator.getitem
             # pyrefly: ignore [missing-attribute]
             and arg.args[1] == i
         ):

--- a/torch/export/experimental/__init__.py
+++ b/torch/export/experimental/__init__.py
@@ -52,7 +52,7 @@ def _remove_detach_pass(
             if (
                 node.target is torch.ops.aten.detach.default
                 and len(node.users) == 1
-                and next(iter(node.users)).target == torch.ops.aten.detach.default
+                and next(iter(node.users)).target is torch.ops.aten.detach.default
             ):
                 next(iter(node.users)).replace_all_uses_with(node)
 

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -798,7 +798,7 @@ def _remove_unnecessary_copy_op_pass(
                     ):
                         if (
                             out.op == "call_function"
-                            and out.target == torch.ops.aten.copy.default
+                            and out.target is torch.ops.aten.copy.default
                         ):
                             out.replace_all_uses_with(out.args[1])  # type: ignore[arg-type]
                             gm.graph.erase_node(out)

--- a/torch/fx/experimental/graph_gradual_typechecker.py
+++ b/torch/fx/experimental/graph_gradual_typechecker.py
@@ -250,7 +250,7 @@ def transpose_inference_rule(n: Node):
     We check that dimensions for the transpose operations
     are within range of the tensor type of the node
     """
-    if n.target == torch.transpose:
+    if n.target is torch.transpose:
         assert isinstance(n.args[0], Node)
         t = n.args[0].type
 
@@ -674,7 +674,7 @@ class GraphTypeChecker:
             return n.type
 
         elif n.op == "call_function":
-            if n.target == getattr:
+            if n.target is getattr:
                 assert getattr in _INFERENCE_RULES
                 return _INFERENCE_RULES[n.target](n, self.traced)
 

--- a/torch/fx/experimental/migrate_gradual_types/constraint_generator.py
+++ b/torch/fx/experimental/migrate_gradual_types/constraint_generator.py
@@ -1050,7 +1050,7 @@ def gen_broadcasting_constraints(e1, e2, symbols, counter, output_var):
 @register_inference_rule(operator.add)
 def broadcasting_inference_rule(n: Node, symbols, constraints, counter):
     op_code = None
-    if n.target == operator.add or n.target == torch.add:
+    if n.target == operator.add or n.target is torch.add:
         op_code = op_add
     elif n.target == operator.mul:
         op_code = op_mul

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -1588,11 +1588,11 @@ class PreDispatchTorchFunctionMode(TorchFunctionMode):
             # TODO(tmanlaibaatar): we should systematically couple it with export verifier,
             # instead of hardcoding it here.
             # T203648563
-            if func == torch.amp.autocast_mode._exit_autocast:
+            if func is torch.amp.autocast_mode._exit_autocast:
                 enter_node = self.enter_autocast_nodes.pop()
                 args = (enter_node,)
             node = self.tracer.create_node("call_function", func, args, {})  # type: ignore[arg-type]
-            if func == torch.amp.autocast_mode._enter_autocast:
+            if func is torch.amp.autocast_mode._enter_autocast:
                 self.enter_autocast_nodes.append(node)
             if func in [
                 torch._C._set_grad_enabled,

--- a/torch/fx/interpreter.py
+++ b/torch/fx/interpreter.py
@@ -55,7 +55,7 @@ class Interpreter:
                 def call_function(
                     self, target: Target, args: Tuple, kwargs: Dict
                 ) -> Any:
-                    if target == torch.sigmoid:
+                    if target is torch.sigmoid:
                         return torch.neg(*args, **kwargs)
                     return super().call_function(target, args, kwargs)
 
@@ -489,7 +489,7 @@ class Transformer(Interpreter):
                     args: Tuple[Argument, ...],
                     kwargs: Dict[str, Any],
                 ) -> Any:
-                    if target == torch.sigmoid:
+                    if target is torch.sigmoid:
                         return torch.neg(*args, **kwargs)
                     return super().call_function(target, args, kwargs)
 

--- a/torch/fx/passes/reinplace.py
+++ b/torch/fx/passes/reinplace.py
@@ -219,7 +219,7 @@ def _get_all_later_node_usages(tensor_aliases: set[Node], op_index: int):
             if n in tensor_aliases:
                 if (
                     isinstance(n.target, torch._ops.OpOverload)
-                    or n.target == _operator.getitem
+                    or n.target is _operator.getitem
                 ):
                     continue
             nodes_used_after.add(n)

--- a/torch/fx/passes/runtime_assert.py
+++ b/torch/fx/passes/runtime_assert.py
@@ -606,7 +606,7 @@ def insert_deferred_runtime_asserts(
 
                     if (
                         expr_to_proxy[i0].node.target
-                        != cast_symbool_to_symint_guardless
+                        is not cast_symbool_to_symint_guardless
                     ):
                         # TODO(pianpwk): calling sym_constrain_range_for_size or adding bound asserts
                         # raises AOTAutograd errors on cast_symbool_to_symint_guardless

--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -502,13 +502,13 @@ def jagged_torch_function(func, *args, **kwargs):
     "self: jt_all",
 )
 def tensor_attr_supported_getter(func, *args, **kwargs):
-    if func == torch.ops.aten.is_non_overlapping_and_dense.default:
+    if func is torch.ops.aten.is_non_overlapping_and_dense.default:
         return False
 
-    if func == torch.ops.aten.sym_size.default:
+    if func is torch.ops.aten.sym_size.default:
         return args[0]._size
 
-    if func == torch.ops.aten.dim.default:
+    if func is torch.ops.aten.dim.default:
         return len(args[0]._size)
 
     if func in (torch.ops.aten.sym_numel.default, torch.ops.aten.numel.default):
@@ -516,10 +516,10 @@ def tensor_attr_supported_getter(func, *args, **kwargs):
             return int(sum(args[0]._lengths) * math.prod(args[0]._size[2:]))
         return args[0]._values.numel()
 
-    if func == torch.ops.aten.sym_stride.default:
+    if func is torch.ops.aten.sym_stride.default:
         return args[0]._strides
 
-    if func == torch.ops.aten.sym_storage_offset.default:
+    if func is torch.ops.aten.sym_storage_offset.default:
         return args[0]._values.storage_offset()
 
 
@@ -533,7 +533,7 @@ def prim_layout_default(func, *args, **kwargs):
     "self: jt_all",
 )
 def tensor_attr_unsupported_getter(func, *args, **kwargs):
-    if func == torch.ops.aten.size.default:
+    if func is torch.ops.aten.size.default:
         raise RuntimeError(
             "NestedTensor does not support directly calling torch.ops.aten.size; "
             "please use `nested_tensor.size()` instead."
@@ -1995,7 +1995,7 @@ def index_put_(func, *args, **kwargs):
             max_seqlen=max_seqlen,
         )
 
-        if func == torch.ops.aten.index_put_.default:
+        if func is torch.ops.aten.index_put_.default:
             inp._values.copy_(new_njt.values())
             return inp
         return new_njt
@@ -2024,7 +2024,7 @@ def index_put_(func, *args, **kwargs):
         + indices[inp._ragged_idx + 1 :]
     )
 
-    if func == torch.ops.aten.index_put_.default:
+    if func is torch.ops.aten.index_put_.default:
         inp._values = func(inp._values, func_indices, **new_kwargs)
         return inp
 

--- a/torch/nn/utils/_expanded_weights/expanded_weights_impl.py
+++ b/torch/nn/utils/_expanded_weights/expanded_weights_impl.py
@@ -140,7 +140,7 @@ class ExpandedWeight(torch.Tensor):
             if decomp is not None:
                 with setup_rnn(use_input_variant, args, kwargs):
                     return decomp(*args, **kwargs)
-        if func == torch._cudnn_rnn_flatten_weight:
+        if func is torch._cudnn_rnn_flatten_weight:
             # since we aren't using the fused cuda kernels for RNNs, don't do this
             return
         if func in cls.handled_functions:

--- a/torch/onnx/_internal/exporter/_core.py
+++ b/torch/onnx/_internal/exporter/_core.py
@@ -456,7 +456,7 @@ def _convert_fx_arg_to_onnx_arg(
         # The actual dropping of a None attribute value is done by OpRecorder
         return None
     if hasattr(arg, "name"):
-        if isinstance(arg, torch.fx.Node) and arg.target == operator.getitem:
+        if isinstance(arg, torch.fx.Node) and arg.target is operator.getitem:
             source = arg.all_input_nodes[0]
             source_outputs = node_name_to_values[source.name]
             if isinstance(source_outputs, Sequence):

--- a/torch/testing/_internal/composite_compliance.py
+++ b/torch/testing/_internal/composite_compliance.py
@@ -186,7 +186,7 @@ def generate_cct_and_mode(autograd_view_consistency=True):
             def wrap(e):
                 return CompositeCompliantTensor(e, self) if isinstance(e, torch.Tensor) else e
 
-            if func == torch.ops.aten._local_scalar_dense.default:
+            if func is torch.ops.aten._local_scalar_dense.default:
                 raise RuntimeError(
                     ".item() is not allowed to be called inside of composite "
                     "functions in the PyTorch library because not all backends "


### PR DESCRIPTION
It is generally advised to use `is/is not` for comparisons against torch functions.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @ezyang @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @Lucaskabela @xmfan