### PR TITLE
Remove unused inplace loop in test_conv2d_clamp of test_jit_llga_fuser.py‎

### DIFF
--- a/test/test_jit_llga_fuser.py
+++ b/test/test_jit_llga_fuser.py
@@ -507,13 +507,12 @@ class TestFusionPattern(JitLlgaTestCase):
                 x = torch.clamp(x, max=2)
                 return x
 
-        for inplace in [False, True]:  # noqa: F841
-            for memory_format in [torch.contiguous_format, torch.channels_last]:
-                x = torch.rand(1, 32, 28, 28).to(memory_format=memory_format)
-                m = M()
-                _, graph = self.checkTrace(m, [x], dtype)
-                self.assertGraphContainsExactly(graph, LLGA_FUSION_GROUP, 5)
-                self.assertFused(graph, ['aten::_convolution', "aten::clamp"])
+        for memory_format in [torch.contiguous_format, torch.channels_last]:
+            x = torch.rand(1, 32, 28, 28).to(memory_format=memory_format)
+            m = M()
+            _, graph = self.checkTrace(m, [x], dtype)
+            self.assertGraphContainsExactly(graph, LLGA_FUSION_GROUP, 5)
+            self.assertFused(graph, ['aten::_convolution', "aten::clamp"])
 
     @onlyCPU
     @dtypes(torch.float32, torch.bfloat16)


### PR DESCRIPTION
`inplace` is not used and not the test target in this unit test.

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @mingfeima @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal