### PR TITLE
Expose torch.compiler.config.force_disable_caches as a public API

### DIFF
--- a/torch/compiler/config.py
+++ b/torch/compiler/config.py
@@ -35,6 +35,7 @@ __all__ = [
     "enable_cpp_symbolic_shape_guards",
     "wrap_top_frame",
     "reorderable_logging_functions",
+    "force_disable_caches",
 ]
 
 


### PR DESCRIPTION
Exposing this flag as some upstream frameworks (like vLLM) could benefit from knowing whether torch.compile caches are enabled or not to adjust their own caching behavior.


cc @mlazos