### PR TITLE
[OpenReg] Disable bad fork UserWarning in OpenReg

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/openreg/__init__.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/openreg/__init__.py
@@ -61,6 +61,15 @@ def _lazy_init():
     _initialized = True
 
 
+def _is_in_bad_fork() -> bool:
+    r"""Check if we are in a bad fork state.
+
+    For openreg (CPU-based emulation), fork state is not an issue,
+    so this always returns False.
+    """
+    return False
+
+
 from .random import *  # noqa: F403
 
 


### PR DESCRIPTION
Since OpenReg is a CPU-based emulator, the fork state should not be an issue. This PR fixes raising warnings `UserWarning: Set seed for 'openreg' device does not take effect, please add API's '_is_in_bad_fork' and 'manual_seed_all' to 'openreg' device module` when setting seed in OpenReg tests.

cc @fffrog 
