### PR TITLE
Integrate NVIDIA cuSolver backend into ATen/Linalg (initial implementation for eig/eigval)

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -2924,11 +2924,6 @@ static std::tuple<Tensor&, Tensor&> linalg_eig_out_info(const Tensor& input, Ten
   TORCH_WARN("Entered linalg_eig_out_info");
   auto options = input.options();
 
-  TORCH_WARN("Type of 'options': ", typeid(options).name());
-  TORCH_WARN("Device in options: ", options.device());
-  TORCH_WARN("Dtype in options: ", options.dtype());
-  TORCH_WARN("Dtype vectors: ", vectors.dtype());
-
 
   // These internal asserts make explicit the assumptions in the implementation
   // Error check with the actual error messages are done on the higher level of the hierarchy of calls

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -3121,7 +3121,6 @@ std::tuple<Tensor, Tensor> linalg_eig(const Tensor& input) {
 
 Tensor& linalg_eigvals_out(const Tensor& input, Tensor& values) {
   squareCheckInputs(input, "linalg.eigvals");
-  TORCH_CHECK(input.isfinite().all().item<bool>(), "torch.linalg.eigvals: input tensor should not contain infs or NaNs.");
 
   // unlike NumPy for real-valued inputs the output is always complex-valued
   checkLinalgCompatibleDtype("torch.linalg.eigvals", values.scalar_type(), toComplexType(input.scalar_type()), "eigenvalues");

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -3007,8 +3007,8 @@ static std::tuple<Tensor&, Tensor&> linalg_eig_out_info(const Tensor& input, Ten
     if (compute_eigenvectors) {
       if (vectors.is_complex()) {
         // We move to the CPU because linalg_eig_make_complex_eigenvectors requires it.
-		// Performance note: this function could be implemented via a TensorIterator,
-		// which would avoid an explicit host-device synchronization.
+        // Performance note: this function could be implemented via a TensorIterator,
+        // which would avoid an explicit host-device synchronization.
         auto vectors_cpu = vectors.cpu();
         auto values_cpu  = values.cpu();
         auto maybe_complex_vectors_cpu = maybe_complex_vectors.cpu();

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -3031,17 +3031,13 @@ static std::tuple<Tensor&, Tensor&> linalg_eig_out_info(const Tensor& input, Ten
     if (compute_eigenvectors) {
       if (vectors.is_complex()) {
         // move tensors to CPU if they are not already there for post-processing
-        auto vectors_cpu = vectors.device().is_cpu() ? vectors : vectors.cpu();
-        auto values_cpu  = values.device().is_cpu()  ? values  : values.cpu();
-        auto maybe_complex_vectors_cpu = maybe_complex_vectors.device().is_cpu()
-                                ? maybe_complex_vectors
-                                : maybe_complex_vectors.cpu();
+        auto vectors_cpu = vectors.cpu();
+        auto values_cpu  = values.cpu();
+        auto maybe_complex_vectors_cpu = maybe_complex_vectors.cpu();
 
         vectors = linalg_eig_make_complex_eigenvectors(vectors_cpu, values_cpu, maybe_complex_vectors_cpu);
 
-        if (!vectors.device().is_cpu()) {//move tensors back to device if needed
-          vectors.copy_(vectors_cpu.to(vectors.device()));
-        }
+        vectors.copy_(vectors_cpu.to(vectors.device()));
 
 
       } else {
@@ -3139,7 +3135,6 @@ std::tuple<Tensor, Tensor> linalg_eig(const Tensor& input) {
   ScalarType complex_dtype = toComplexType(input.scalar_type());
   Tensor values = at::empty({0}, input.options().dtype(complex_dtype));
   Tensor vectors = at::empty({0}, input.options().dtype(complex_dtype));
-
 
   at::linalg_eig_outf(input, values, vectors);
 

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -3012,12 +3012,8 @@ static std::tuple<Tensor&, Tensor&> linalg_eig_out_info(const Tensor& input, Ten
         auto vectors_cpu = vectors.cpu();
         auto values_cpu  = values.cpu();
         auto maybe_complex_vectors_cpu = maybe_complex_vectors.cpu();
-
         vectors = linalg_eig_make_complex_eigenvectors(vectors_cpu, values_cpu, maybe_complex_vectors_cpu);
-
         vectors.copy_(vectors_cpu);
-
-
       } else {
         TORCH_CHECK(false, "torch.linalg.eig: imaginary part of eigenvectors is non-zero, can't safely cast eigenvectors to non-complex dtype.")
       }

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -2928,16 +2928,13 @@ static std::tuple<Tensor&, Tensor&> linalg_eig_out_info(const Tensor& input, Ten
 
   // for real-valued 'input', eigenvalues can be real-valued or complex-valued
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY((toComplexType(input.scalar_type()) == values.scalar_type()) || (input.scalar_type() == values.scalar_type()));
-  //TORCH_INTERNAL_ASSERT_DEBUG_ONLY(values.device() == at::kCPU);
 
   // for real-valued 'input', eigenvectors can be real-valued or complex-valued
   if (compute_eigenvectors) {
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY((toComplexType(input.scalar_type()) == vectors.scalar_type()) || (input.scalar_type() == vectors.scalar_type()));
-    //TORCH_INTERNAL_ASSERT_DEBUG_ONLY(vectors.device() == at::kCPU);
   }
 
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(infos.scalar_type() == at::kInt);
-  //TORCH_INTERNAL_ASSERT_DEBUG_ONLY(infos.device() == at::kCPU);
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(infos.numel() == std::max<int64_t>(1, batchCount(input)));
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(infos.is_contiguous());
 

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -3151,9 +3151,7 @@ Tensor& linalg_eigvals_out(const Tensor& input, Tensor& values) {
   }
 
   Tensor vectors;
-  if (!vectors.defined()) {
-    vectors = at::empty({0}, input.options());
-  }
+  vectors = at::empty({0}, input.options());
   if (values_tmp_needed) {
     Tensor values_tmp = at::empty({0}, options.dtype(values_type));
     std::tie(values_tmp, std::ignore) = linalg_eig_out_info(input, values_tmp, vectors, infos, /*compute_eigenvectors=*/false);

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -3046,22 +3046,22 @@ static std::tuple<Tensor&, Tensor&> linalg_eig_out_info(const Tensor& input, Ten
       }
     }
   }
-  TORCH_WARN("=== Debug native/BatchLinarAlgebra/linalg_eig_out_info ===");
-  TORCH_WARN("input dtype: ", input.dtype(), " device: ", input.device());
-  TORCH_WARN("real_imag_values: sizes=", real_imag_values.sizes(),
-             " dtype=", real_imag_values.dtype(),
-             " device=", real_imag_values.device());
-  TORCH_WARN("values (final): sizes=", values.sizes(),
-             " dtype=", values.dtype(),
-             " device=", values.device());
-  if (compute_eigenvectors) {
-    TORCH_WARN("maybe_complex_vectors: sizes=", maybe_complex_vectors.sizes(),
-               " dtype=", maybe_complex_vectors.dtype(),
-               " device=", maybe_complex_vectors.device());
-    TORCH_WARN("vectors (final): sizes=", vectors.sizes(),
-               " dtype=", vectors.dtype(),
-               " device=", vectors.device());
-  }
+  // TORCH_WARN("=== Debug native/BatchLinarAlgebra/linalg_eig_out_info ===");
+  // TORCH_WARN("input dtype: ", input.dtype(), " device: ", input.device());
+  // TORCH_WARN("real_imag_values: sizes=", real_imag_values.sizes(),
+  //            " dtype=", real_imag_values.dtype(),
+  //            " device=", real_imag_values.device());
+  // TORCH_WARN("values (final): sizes=", values.sizes(),
+  //            " dtype=", values.dtype(),
+  //            " device=", values.device());
+  // if (compute_eigenvectors) {
+  //   TORCH_WARN("maybe_complex_vectors: sizes=", maybe_complex_vectors.sizes(),
+  //              " dtype=", maybe_complex_vectors.dtype(),
+  //              " device=", maybe_complex_vectors.device());
+  //   TORCH_WARN("vectors (final): sizes=", vectors.sizes(),
+  //              " dtype=", vectors.dtype(),
+  //              " device=", vectors.device());
+  // }
 
   auto n = input.size(-1);
   TORCH_CHECK(values.is_complex(), "values (complex_values) not complex");
@@ -3162,6 +3162,11 @@ std::tuple<Tensor, Tensor> linalg_eig(const Tensor& input) {
   ScalarType complex_dtype = toComplexType(input.scalar_type());
   Tensor values = at::empty({0}, input.options().dtype(complex_dtype));
   Tensor vectors = at::empty({0}, input.options().dtype(complex_dtype));
+
+  // TORCH_WARN("input shape: ", input.sizes());
+  // TORCH_WARN("values shape: ", values.sizes());
+  // TORCH_WARN("vectors shape: ", vectors.sizes());
+
 
   at::linalg_eig_outf(input, values, vectors);
 

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -17,8 +17,6 @@
 #include <utility>
 #include <vector>
 
-#include "jit/tensorexpr/bounds_overlap.h"
-
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -2983,25 +2983,6 @@ static std::tuple<Tensor&, Tensor&> linalg_eig_out_info(const Tensor& input, Ten
     }
   }
 
-
-  // Historically, the MAGMA backend used a switchover threshold because
-  // CPU routines outperformed MAGMA for small matrices due to its hybrid
-  // CPU-GPU algorithm. See: https://github.com/pytorch/pytorch/pull/52491#issuecomment-795685687
-  //
-  // cuSOLVER, however, is GPU-based and much faster even for small matrices
-  // (e.g. 128x128 on RTX 4070). It is therefore reasonable to omit this threshold
-  // and let users select the preferred backend (CPU or CUDA) explicitly.
-  //
-  // MAGMA uses a hybrid CPU-GPU algorithm that performs well only for large matrices
-  // See: https://github.com/pytorch/pytorch/pull/52491#issuecomment-795685687
-  // Here we call CPU path for matrices smaller than 2048x2048
-  // that should be in general significantly faster than calling MAGMA
-  // if (input.size(-1) <= 2048) {
-  //   linalg_eig_stub(at::kCPU, real_imag_values, maybe_complex_vectors, infos, input.to(kCPU), compute_eigenvectors);
-  // } else {
-  //linalg_eig_stub(input.device().type(), real_imag_values, maybe_complex_vectors, infos, input, compute_eigenvectors);
-  // }
-
   linalg_eig_stub(input.device().type(), real_imag_values, maybe_complex_vectors, infos, input, compute_eigenvectors);
 
   // if input is not complex we need to do some post-processing

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -3015,7 +3015,7 @@ static std::tuple<Tensor&, Tensor&> linalg_eig_out_info(const Tensor& input, Ten
 
         vectors = linalg_eig_make_complex_eigenvectors(vectors_cpu, values_cpu, maybe_complex_vectors_cpu);
 
-        vectors.copy_(vectors_cpu.to(vectors.device()));
+        vectors.copy_(vectors_cpu);
 
 
       } else {

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -3006,7 +3006,9 @@ static std::tuple<Tensor&, Tensor&> linalg_eig_out_info(const Tensor& input, Ten
     }
     if (compute_eigenvectors) {
       if (vectors.is_complex()) {
-        // move tensors to CPU if they are not already there for post-processing
+        // We move to the CPU because linalg_eig_make_complex_eigenvectors requires it.
+		// Performance note: this function could be implemented via a TensorIterator,
+		// which would avoid an explicit host-device synchronization.
         auto vectors_cpu = vectors.cpu();
         auto values_cpu  = values.cpu();
         auto maybe_complex_vectors_cpu = maybe_complex_vectors.cpu();

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -3012,7 +3012,7 @@ static std::tuple<Tensor&, Tensor&> linalg_eig_out_info(const Tensor& input, Ten
         auto vectors_cpu = vectors.cpu();
         auto values_cpu  = values.cpu();
         auto maybe_complex_vectors_cpu = maybe_complex_vectors.cpu();
-        vectors = linalg_eig_make_complex_eigenvectors(vectors_cpu, values_cpu, maybe_complex_vectors_cpu);
+        vectors_cpu = linalg_eig_make_complex_eigenvectors(vectors_cpu, values_cpu, maybe_complex_vectors_cpu);
         vectors.copy_(vectors_cpu);
       } else {
         TORCH_CHECK(false, "torch.linalg.eig: imaginary part of eigenvectors is non-zero, can't safely cast eigenvectors to non-complex dtype.")

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -17,6 +17,8 @@
 #include <utility>
 #include <vector>
 
+#include "jit/tensorexpr/bounds_overlap.h"
+
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
@@ -2990,7 +2992,7 @@ static std::tuple<Tensor&, Tensor&> linalg_eig_out_info(const Tensor& input, Ten
   // See: https://github.com/pytorch/pytorch/pull/52491#issuecomment-795685687
   // Here we call CPU path for matrices smaller than 2048x2048
   // that should be in general significantly faster than calling MAGMA
-  if (input.size(-1) <= 2048) {
+  if (false) { //(input.size(-1) <= 2048) { //replaced with false to force GPU path for testing
     linalg_eig_stub(at::kCPU, real_imag_values, maybe_complex_vectors, infos, input.to(kCPU), compute_eigenvectors);
   } else {
     linalg_eig_stub(input.device().type(), real_imag_values, maybe_complex_vectors, infos, input, compute_eigenvectors);

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -18,8 +18,6 @@
 #include <ATen/native/cuda/linalg/MagmaUtils.h>
 #include <ATen/native/cpu/zmath.h>
 
-#include "ATen/core/function_schema.h"
-
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -18,6 +18,8 @@
 #include <ATen/native/cuda/linalg/MagmaUtils.h>
 #include <ATen/native/cpu/zmath.h>
 
+#include "ATen/core/function_schema.h"
+
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
@@ -2092,13 +2094,13 @@ void linalg_eig_kernel(Tensor& eigenvalues, Tensor& eigenvectors, Tensor& infos,
   switch (preferred_backend) {
     case at::LinalgBackend::Cusolver:
     default:
-      linalg_eig_cusolver_xgeev(eigenvalues, eigenvectors, infos, compute_eigenvectors);
+      linalg_eig_cusolver_xgeev(eigenvalues, eigenvectors, input, infos, compute_eigenvectors);
       return;
     case at::LinalgBackend::Magma:
       break; // fallback to CPU path below
   }
 #endif
-
+  TORCH_WARN("Going to CPU");
   Tensor input_working_copy = at::empty(input.sizes(), input.options().device(kCPU));
   input_working_copy.transpose_(-2, -1);  // make input_working_copy to have Fortran contiguous memory layout
   input_working_copy.copy_(input);

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -2084,7 +2084,7 @@ void linalg_eig_kernel(Tensor& eigenvalues, Tensor& eigenvectors, Tensor& infos,
   // apply_linalg_eig modifies the provided input matrix in-place, therefore we need a copy
   // MAGMA doesn't have GPU interface for the eigendecomposition, and it forces us to transfer 'input' to CPU
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(input.is_cuda());
-#if defined(USE_CUSOLVER_64_BIT) && defined(CUSOLVER_VERSION) && (CUSOLVER_VERSION >= 11702)
+#if defined(CUSOLVER_VERSION) && (CUSOLVER_VERSION >= 11702)
   // ───────────────────────────────────────────────
   // New CUDA 12.6+ path using cuSOLVER Xgeev
   // ───────────────────────────────────────────────
@@ -2092,7 +2092,7 @@ void linalg_eig_kernel(Tensor& eigenvalues, Tensor& eigenvectors, Tensor& infos,
   switch (preferred_backend) {
     case at::LinalgBackend::Cusolver:
     default:
-      linalg_eig_cusolver(eigenvalues, eigenvectors, infos, compute_eigenvectors);
+      linalg_eig_cusolver_xgeev(eigenvalues, eigenvectors, infos, compute_eigenvectors);
       return;
     case at::LinalgBackend::Magma:
       break; // fallback to CPU path below

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -1883,6 +1883,8 @@ void geqrf_kernel(const Tensor& input, const Tensor& tau) {
 
 REGISTER_CUDA_DISPATCH(geqrf_stub, &geqrf_kernel)
 
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ linalg_eigh ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 template <typename scalar_t>
 static void apply_magma_eigh(const Tensor& values, const Tensor& vectors, const Tensor& infos, bool upper, bool compute_eigenvectors) {
 #if !AT_MAGMA_ENABLED()
@@ -1957,8 +1959,6 @@ static void apply_magma_eigh(const Tensor& values, const Tensor& vectors, const 
 #endif
 }
 
-// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ linalg_eigh ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 // This is a type dispatch function for 'apply_magma_eigh'
 // For small inputs result is computed on CPU
 void linalg_eigh_magma(const Tensor& eigenvalues, const Tensor& eigenvectors, const Tensor& infos, bool upper, bool compute_eigenvectors) {
@@ -2021,10 +2021,10 @@ This is an in-place routine, content of 'input', 'values', 'vectors' is overwrit
 For more information see MAGMA's documentation for GEEV routine.
 */
 template <typename scalar_t>
-void linalg_eig_magma(Tensor& values, Tensor& vectors, Tensor& input, Tensor& infos, bool compute_eigenvectors) {
+void apply_magma_eig(Tensor& values, Tensor& vectors, Tensor& input, Tensor& infos, bool compute_eigenvectors) {
 #if !AT_MAGMA_ENABLED()
-TORCH_CHECK(false, "Calling torch.linalg.eig on a CUDA tensor requires compiling PyTorch with MAGMA. "
-                   "Either transfer the tensor to the CPU before calling torch.linalg.eig or recompile with MAGMA.");
+TORCH_CHECK(false, "Calling torch.linalg.eig with MAGMA requires compiling PyTorch with MAGMA. "
+                   "Either transfer the tensor to the CPU before calling torch.linalg.eig or use cuSolver.");
 #else
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(input.device() == at::kCPU);
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(values.device() == at::kCPU);
@@ -2078,6 +2078,25 @@ TORCH_CHECK(false, "Calling torch.linalg.eig on a CUDA tensor requires compiling
 #endif
 }
 
+// MAGMA wrapper: transfers tensors to CPU, calls apply_magma_eig, then copies results back.
+void linalg_eig_magma(Tensor& eigenvalues, Tensor& eigenvectors, Tensor& infos, const Tensor& input, bool compute_eigenvectors){
+  // MAGMA doesn't have GPU interface for the eigendecomposition, and it forces us to transfer to CPU
+  auto eigenvalues_cpu = eigenvalues.cpu();
+  auto eigenvectors_cpu = eigenvectors.cpu();
+  auto infos_cpu = infos.cpu();
+
+  Tensor input_cpu = at::empty(input.sizes(), input.options().device(kCPU));
+  input_cpu.transpose_(-2, -1);
+  input_cpu.copy_(input);
+
+  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(input.scalar_type(), "linalg_eig_out_cuda", [&]{
+    apply_magma_eig<scalar_t>(eigenvalues_cpu, eigenvectors_cpu, input_cpu, infos_cpu, compute_eigenvectors);
+  });
+
+  eigenvalues.copy_(eigenvalues_cpu);
+  eigenvectors.copy_(eigenvectors_cpu);
+  infos.copy_(infos_cpu);
+}
 void linalg_eig_kernel(Tensor& eigenvalues, Tensor& eigenvectors, Tensor& infos, const Tensor& input, bool compute_eigenvectors) {
   // This function calculates the non-symmetric eigendecomposition in-place
   // tensors should be in batched column major memory format
@@ -2096,22 +2115,7 @@ void linalg_eig_kernel(Tensor& eigenvalues, Tensor& eigenvectors, Tensor& infos,
       break; // MAGMA path handled below
   }
 #endif
-  // MAGMA doesn't have GPU interface for the eigendecomposition, and it forces us to transfer 'input' to CPU
-  auto eigenvalues_cpu = eigenvalues.cpu();
-  auto eigenvectors_cpu = eigenvectors.cpu();
-  auto infos_cpu = infos.cpu();
-
-  Tensor input_working_copy = at::empty(input.sizes(), input.options().device(kCPU));
-  input_working_copy.transpose_(-2, -1);  // make input_working_copy to have Fortran contiguous memory layout
-  input_working_copy.copy_(input);
-
-  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(input.scalar_type(), "linalg_eig_out_cuda", [&]{
-    linalg_eig_magma<scalar_t>(eigenvalues_cpu, eigenvectors_cpu, input_working_copy, infos_cpu, compute_eigenvectors);
-  });
-  eigenvalues.copy_(eigenvalues_cpu);
-  eigenvectors.copy_(eigenvectors_cpu);
-  infos.copy_(infos_cpu);
-
+  linalg_eig_magma(eigenvalues, eigenvectors, infos, input, compute_eigenvectors);
 }
 
 REGISTER_CUDA_DISPATCH(linalg_eig_stub, &linalg_eig_kernel)

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -2079,6 +2079,7 @@ TORCH_CHECK(false, "Calling torch.linalg.eig on a CUDA tensor requires compiling
 }
 
 void linalg_eig_kernel(Tensor& eigenvalues, Tensor& eigenvectors, Tensor& infos, const Tensor& input, bool compute_eigenvectors) {
+  TORCH_WARN("entered linalg_eig_kernel");
   // This function calculates the non-symmetric eigendecomposition in-place
   // tensors should be in batched column major memory format
   // the content of eigenvalues, eigenvectors and infos is overwritten by 'apply_linalg_eig'

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -2079,16 +2079,15 @@ TORCH_CHECK(false, "Calling torch.linalg.eig on a CUDA tensor requires compiling
 }
 
 void linalg_eig_kernel(Tensor& eigenvalues, Tensor& eigenvectors, Tensor& infos, const Tensor& input, bool compute_eigenvectors) {
-  TORCH_WARN("entered linalg_eig_kernel CUDA implementation");
   // This function calculates the non-symmetric eigendecomposition in-place
   // tensors should be in batched column major memory format
   // the content of eigenvalues, eigenvectors and infos is overwritten by 'linalg_eig_magma' or 'linalg_eig_cusolver_xgeev'
-
   // both geev routines modify the provided input matrix in-place, therefore we need a copy
+
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(input.is_cuda());
 #if defined(CUSOLVER_VERSION) && (CUSOLVER_VERSION >= 11702)
   // ───────────────────────────────────────────────
-  // New CUDA 12.6+ path using cuSOLVER Xgeev
+  // New CUDA 12.8+ path using cuSOLVER Xgeev
   // ───────────────────────────────────────────────
   auto preferred_backend = at::globalContext().linalgPreferredBackend();
   switch (preferred_backend) {

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -1635,10 +1635,6 @@ void linalg_eigh_cusolver(const Tensor& eigenvalues, const Tensor& eigenvectors,
 template <typename scalar_t>
 void apply_xgeev(const Tensor& values, const Tensor& vectors, const Tensor& input, const Tensor& infos, bool compute_eigenvectors) {
   TORCH_WARN("Entered experimental cuSOLVER Xgeev path");
-  TORCH_WARN("values device: ", values.device());
-  TORCH_WARN("vectors device: ", vectors.device());
-  TORCH_WARN("input device: ", input.device());
-  TORCH_WARN("infos device: ", infos.device());
 
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(values.is_cuda());
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(vectors.is_cuda());
@@ -1711,16 +1707,16 @@ void apply_xgeev(const Tensor& values, const Tensor& vectors, const Tensor& inpu
   auto& host_allocator = *at::cuda::getPinnedMemoryAllocator();
   auto work_host_data = host_allocator.allocate(ws_host);
 
-  TORCH_WARN("=== XGEEV DEBUG ===");
-  TORCH_WARN("vectors shape: ", vectors.sizes());
-  TORCH_WARN("values  shape: ", values.sizes());
-  TORCH_WARN("input   shape: ", input.sizes());
-  TORCH_WARN("vectors dtype: ", vectors.scalar_type());
-  TORCH_WARN("values  dtype: ", values.scalar_type());
-  TORCH_WARN("vectors numel: ", vectors.numel());
-  TORCH_WARN("values  numel: ", values.numel());
-  TORCH_WARN("input   numel: ", input.numel());
-  TORCH_WARN("===================");
+  // TORCH_WARN("=== XGEEV DEBUG ===");
+  // TORCH_WARN("vectors shape: ", vectors.sizes());
+  // TORCH_WARN("values  shape: ", values.sizes());
+  // TORCH_WARN("input   shape: ", input.sizes());
+  // TORCH_WARN("vectors dtype: ", vectors.scalar_type());
+  // TORCH_WARN("values  dtype: ", values.scalar_type());
+  // TORCH_WARN("vectors numel: ", vectors.numel());
+  // TORCH_WARN("values  numel: ", values.numel());
+  // TORCH_WARN("input   numel: ", input.numel());
+  // TORCH_WARN("===================");
 
   for (decltype(batch_size) i = 0; i < batch_size; ++i) {
     scalar_t* Ai   = A_data      + i * A_stride;

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -1643,7 +1643,7 @@ void apply_xgeev(const Tensor& values, const Tensor& vectors, const Tensor& inpu
 
   int n = cuda_int_cast(input.size(-1), "n");
   int lda = std::max<int64_t>(1, n);
-  auto batch_size = batchCount(vectors);
+  auto batch_size = batchCount(input);
 
   if (n == 0 || batch_size == 0) {
     //XGeev does not support empty input, so we need to handle this case separately to

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -1625,6 +1625,49 @@ void linalg_eigh_cusolver(const Tensor& eigenvalues, const Tensor& eigenvectors,
 #endif
 }
 
+
+// ---------------------------------------------------------------------------
+// cuSOLVERDnXgeev (CUDA >= 12.6 Update 2 / cuSOLVER >= 11.7.2)
+// ---------------------------------------------------------------------------
+#if defined(CUSOLVER_VERSION) && (CUSOLVER_VERSION >= 11702)
+
+void linalg_eig_cusolver_xgeev(const Tensor& eigenvalues, const Tensor& eigenvectors, const Tensor& infos, bool compute_eigenvectors) {
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(eigenvalues.is_cuda());
+  TORCH_WARN("Entered experimental cuSOLVER Xgeev path");
+
+  cusolverDnHandle_t handle = at::cuda::getCurrentCUDASolverDnHandle();
+  cusolverDnParams_t params = nullptr;
+  TORCH_CUSOLVER_CHECK(cusolverDnCreateParams(&params));
+
+  const double* A = nullptr;
+  const double* W = nullptr;
+  const double* VL = nullptr;
+  const double* VR = nullptr;
+
+
+  // Query workspace (dummy for now)
+  size_t ws_dev = 0, ws_host = 0;
+  cuda::solver::xgeev_bufferSize(
+      handle,
+      params,
+      CUSOLVER_EIG_MODE_VECTOR,
+      CUSOLVER_EIG_MODE_VECTOR,
+      3, // dummy n
+      A,
+      3,
+      W,
+      VL,
+      3,
+      VR,
+      3,
+      &ws_dev,
+      &ws_host);
+
+  TORCH_WARN("linalg_eig_cusolver_xgeev: bufferSize query complete (placeholder)");
+}
+
+#endif // defined(CUSOLVER_VERSION) && (CUSOLVER_VERSION >= 11702)
+
 // The 'apply_' word is used for templated by dtype functions that call an API routine
 // underneath. Since the cusolver API has a slightly different structure we do not prepend
 // apply_ to this function.

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -1699,9 +1699,7 @@ void apply_xgeev(const Tensor& values, const Tensor& vectors, const Tensor& inpu
 //    VR_tensor = at::empty(vectors.sizes(), vectors.options().dtype(
 //    	c10::CppTypeToScalarType<eig_t>::value));
 //  }
-  Tensor VR_tensor;
-  VR_tensor = at::empty_like(vectors);
-  scalar_t* VR = VR_tensor.data_ptr<scalar_t>();
+  scalar_t* VR = vectors.data_ptr<scalar_t>();
 
 
 

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -1630,6 +1630,7 @@ void linalg_eigh_cusolver(const Tensor& eigenvalues, const Tensor& eigenvectors,
 // cuSOLVERDnXgeev (CUDA >= 12.6 Update 2 / cuSOLVER >= 11.7.2)
 // ---------------------------------------------------------------------------
 #if defined(CUSOLVER_VERSION) && (CUSOLVER_VERSION >= 11702)
+#pragma message("Compiling with cuSOLVER >= 11.7.2 — Xgeev bindings enabled")
 
 void linalg_eig_cusolver_xgeev(const Tensor& eigenvalues, const Tensor& eigenvectors, const Tensor& infos, bool compute_eigenvectors) {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(eigenvalues.is_cuda());
@@ -1647,7 +1648,7 @@ void linalg_eig_cusolver_xgeev(const Tensor& eigenvalues, const Tensor& eigenvec
 
   // Query workspace (dummy for now)
   size_t ws_dev = 0, ws_host = 0;
-  cuda::solver::xgeev_bufferSize(
+  ::at::cuda::solver::xgeev_bufferSize(
       handle,
       params,
       CUSOLVER_EIG_MODE_VECTOR,

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -1726,7 +1726,7 @@ at::cuda::solver::xgeev_bufferSize<scalar_t>(
   // allocate workspace storage on device and host
   auto& device_allocator = *at::cuda::getCUDADeviceAllocator();
   auto work_device_data = device_allocator.allocate(ws_dev);
-  auto& host_allocator = *at::getCPUAllocator();//TODO: use pinned allocator (CUDACachingHostAllocator)
+  auto& host_allocator = *at::cuda::getPinnedMemoryAllocator();
   auto work_host_data = host_allocator.allocate(ws_host);
 
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(infos.is_cuda());
@@ -1758,9 +1758,6 @@ at::cuda::solver::xgeev_bufferSize<scalar_t>(
 
 
   TORCH_CUSOLVER_CHECK(cusolverDnDestroyParams(params));
-  values.copy_(values.to(values.device()));
-  vectors.copy_(vectors.to(vectors.device()));
-  infos.copy_(infos.to(infos.device()));
 
 
 }

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.h
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.h
@@ -73,6 +73,11 @@ void ormqr_cusolver(const Tensor& input, const Tensor& tau, const Tensor& other,
 Tensor& orgqr_helper_cusolver(Tensor& result, const Tensor& tau);
 
 void linalg_eigh_cusolver(const Tensor& eigenvalues, const Tensor& eigenvectors, const Tensor& infos, bool upper, bool compute_eigenvectors);
+
+void linalg_eig_cusolver_xgeev(const Tensor& eigenvalues, const Tensor& eigenvectors, const Tensor& infos, bool compute_eigenvectors);
+
+
+
 void lu_solve_looped_cusolver(const Tensor& LU, const Tensor& pivots, const Tensor& B, TransposeType transpose);
 
 void lu_factor_looped_cusolver(const Tensor& self, const Tensor& pivots, const Tensor& infos, bool get_pivots);

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.h
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.h
@@ -74,7 +74,7 @@ Tensor& orgqr_helper_cusolver(Tensor& result, const Tensor& tau);
 
 void linalg_eigh_cusolver(const Tensor& eigenvalues, const Tensor& eigenvectors, const Tensor& infos, bool upper, bool compute_eigenvectors);
 
-void linalg_eig_cusolver_xgeev(const Tensor& eigenvalues, const Tensor& eigenvectors, const Tensor& infos, bool compute_eigenvectors);
+void linalg_eig_cusolver_xgeev(const Tensor& eigenvalues, const Tensor& eigenvectors, const Tensor& input, const Tensor& infos, bool compute_eigenvectors);
 
 
 

--- a/aten/src/ATen/native/cuda/linalg/CUDASolver.cpp
+++ b/aten/src/ATen/native/cuda/linalg/CUDASolver.cpp
@@ -1955,14 +1955,8 @@ void xsyevd<c10::complex<double>, double>(
       info));
 }
 
-
-// ---------------------------------------------------------------------------
-// Experimental: cuSOLVERDnXgeev (CUDA >= 12.8)
-// Placeholder to verify build detection of cuSOLVER version.
-// Implementation will follow in later revision.
-// ---------------------------------------------------------------------------
+// cuSOLVER Xgeev bindings (requires cuSOLVER >= 11.7.2, i.e. CUDA 12.8+)
 #if defined(CUSOLVER_VERSION) && (CUSOLVER_VERSION >= 11702)
-#pragma message("Compiling with cuSOLVER >= 11.7.2 — Xgeev bindings enabled")
 
 template <>
 void xgeev_bufferSize<float>(

--- a/aten/src/ATen/native/cuda/linalg/CUDASolver.cpp
+++ b/aten/src/ATen/native/cuda/linalg/CUDASolver.cpp
@@ -1954,6 +1954,60 @@ void xsyevd<c10::complex<double>, double>(
       workspaceInBytesOnHost,
       info));
 }
+
+
+// ---------------------------------------------------------------------------
+// Experimental: cuSOLVERDnXgeev (CUDA >= 12.8)
+// Placeholder to verify build detection of cuSOLVER version.
+// Implementation will follow in later revision.
+// ---------------------------------------------------------------------------
+#if defined(CUSOLVER_VERSION) && (CUSOLVER_VERSION >= 11702)
+#pragma message("Compiling with cuSOLVER >= 11.7.2 — Xgeev bindings enabled")
+
+template <>
+void xgeev_bufferSize<double>(
+    cusolverDnHandle_t handle,
+    cusolverDnParams_t params,
+    cusolverEigMode_t jobvl,
+    cusolverEigMode_t jobvr,
+    int64_t n,
+    const double* A,
+    int64_t lda,
+    const double* W,
+    const double* VL,
+    int64_t ldvl,
+    const double* VR,
+    int64_t ldvr,
+    size_t* workspaceInBytesOnDevice,
+    size_t* workspaceInBytesOnHost) {
+  TORCH_WARN("xgeev_bufferSize<double> not implemented yet");
+}
+
+template <>
+void at::cuda::solver::xgeev<double, double>(
+    cusolverDnHandle_t handle,
+    cusolverDnParams_t params,
+    cusolverEigMode_t jobvl,
+    cusolverEigMode_t jobvr,
+    int64_t n,
+    double* A,
+    int64_t lda,
+    double* W,
+    double* VL,
+    int64_t ldvl,
+    double* VR,
+    int64_t ldvr,
+    double* bufferOnDevice,
+    size_t workspaceInBytesOnDevice,
+    double* bufferOnHost,
+    size_t workspaceInBytesOnHost,
+    int* info) {
+  TORCH_WARN("xgeev<double> not implemented yet");
+}
+
+
+#endif // defined(CUSOLVER_VERSION) && (CUSOLVER_VERSION >= 11702)
+
 #endif // USE_CUSOLVER_64_BIT
 
 #ifdef USE_CUSOLVER_64_BIT_XSYEV_BATCHED

--- a/aten/src/ATen/native/cuda/linalg/CUDASolver.cpp
+++ b/aten/src/ATen/native/cuda/linalg/CUDASolver.cpp
@@ -2169,18 +2169,18 @@ void xgeev<double>(
       jobvl,
       jobvr,
       n,
-      CUDA_R_64F,  // Datentyp der Matrix
+      CUDA_R_64F,
       reinterpret_cast<void*>(A),
       lda,
-      CUDA_R_64F,  // Datentyp der Eigenwerte (reell)
+      CUDA_R_64F,
       reinterpret_cast<void*>(W),
-      CUDA_R_64F,  // Datentyp der linken EV
+      CUDA_R_64F,
       reinterpret_cast<void*>(VL),
       ldvl,
-      CUDA_R_64F,  // Datentyp der rechten EV
+      CUDA_R_64F,
       reinterpret_cast<void*>(VR),
       ldvr,
-      CUDA_R_64F,  // Arbeitsbereich-Typ
+      CUDA_R_64F,
       reinterpret_cast<void*>(bufferOnDevice),
       workspaceInBytesOnDevice,
       reinterpret_cast<void*>(bufferOnHost),

--- a/aten/src/ATen/native/cuda/linalg/CUDASolver.cpp
+++ b/aten/src/ATen/native/cuda/linalg/CUDASolver.cpp
@@ -1965,6 +1965,41 @@ void xsyevd<c10::complex<double>, double>(
 #pragma message("Compiling with cuSOLVER >= 11.7.2 — Xgeev bindings enabled")
 
 template <>
+void xgeev_bufferSize<float>(
+    cusolverDnHandle_t handle,
+    cusolverDnParams_t params,
+    cusolverEigMode_t jobvl,
+    cusolverEigMode_t jobvr,
+    int64_t n,
+    const float* A,
+    int64_t lda,
+    const float* W,
+    const float* VL,
+    int64_t ldvl,
+    const float* VR,
+    int64_t ldvr,
+    size_t* workspaceInBytesOnDevice,
+    size_t* workspaceInBytesOnHost) {
+  TORCH_WARN("called experimental xgeev_bufferSize<float>");
+  TORCH_CUSOLVER_CHECK(cusolverDnXgeev_bufferSize(
+      handle, params, jobvl, jobvr, n,
+      CUDA_R_32F,
+      reinterpret_cast<const void*>(A),
+      lda,
+      CUDA_R_32F,
+      reinterpret_cast<const void*>(W),
+      CUDA_R_32F,
+      reinterpret_cast<const void*>(VL),
+      ldvl,
+      CUDA_R_32F,
+      reinterpret_cast<const void*>(VR),
+      ldvr,
+      CUDA_R_32F,
+      workspaceInBytesOnDevice,
+      workspaceInBytesOnHost));
+}
+
+template <>
 void xgeev_bufferSize<double>(
     cusolverDnHandle_t handle,
     cusolverDnParams_t params,
@@ -1980,11 +2015,147 @@ void xgeev_bufferSize<double>(
     int64_t ldvr,
     size_t* workspaceInBytesOnDevice,
     size_t* workspaceInBytesOnHost) {
-  TORCH_WARN("xgeev_bufferSize<double> not implemented yet");
+  TORCH_WARN("called experimental xgeev_bufferSize<double>");
+  TORCH_CUSOLVER_CHECK(cusolverDnXgeev_bufferSize(
+      handle, params, jobvl, jobvr, n,
+      CUDA_R_64F,
+      reinterpret_cast<const void*>(A),
+      lda,
+      CUDA_R_64F,
+      reinterpret_cast<const void*>(W),
+      CUDA_R_64F,
+      reinterpret_cast<const void*>(VL),
+      ldvl,
+      CUDA_R_64F,
+      reinterpret_cast<const void*>(VR),
+      ldvr,
+      CUDA_R_64F,
+      workspaceInBytesOnDevice,
+      workspaceInBytesOnHost));
+}
+
+
+template <>
+void xgeev_bufferSize<c10::complex<float>>(
+    cusolverDnHandle_t handle,
+    cusolverDnParams_t params,
+    cusolverEigMode_t jobvl,
+    cusolverEigMode_t jobvr,
+    int64_t n,
+    const c10::complex<float>* A,
+    int64_t lda,
+    const c10::complex<float>* W,
+    const c10::complex<float>* VL,
+    int64_t ldvl,
+    const c10::complex<float>* VR,
+    int64_t ldvr,
+    size_t* workspaceInBytesOnDevice,
+    size_t* workspaceInBytesOnHost) {
+  TORCH_WARN("called experimental xgeev_bufferSize<complex<float>>");
+  TORCH_CUSOLVER_CHECK(cusolverDnXgeev_bufferSize(
+      handle, params, jobvl, jobvr, n,
+      CUDA_C_32F,
+      reinterpret_cast<const void*>(A),
+      lda,
+      CUDA_C_32F,
+      reinterpret_cast<const void*>(W),
+      CUDA_C_32F,
+      reinterpret_cast<const void*>(VL),
+      ldvl,
+      CUDA_C_32F,
+      reinterpret_cast<const void*>(VR),
+      ldvr,
+      CUDA_C_32F,
+      workspaceInBytesOnDevice,
+      workspaceInBytesOnHost));
 }
 
 template <>
-void at::cuda::solver::xgeev<double, double>(
+void xgeev_bufferSize<c10::complex<double>>(
+    cusolverDnHandle_t handle,
+    cusolverDnParams_t params,
+    cusolverEigMode_t jobvl,
+    cusolverEigMode_t jobvr,
+    int64_t n,
+    const c10::complex<double>* A,
+    int64_t lda,
+    const c10::complex<double>* W,
+    const c10::complex<double>* VL,
+    int64_t ldvl,
+    const c10::complex<double>* VR,
+    int64_t ldvr,
+    size_t* workspaceInBytesOnDevice,
+    size_t* workspaceInBytesOnHost) {
+  TORCH_WARN("called experimental xgeev_bufferSize<complex<double>>");
+  TORCH_CUSOLVER_CHECK(cusolverDnXgeev_bufferSize(
+      handle, params, jobvl, jobvr, n,
+      CUDA_C_64F,
+      reinterpret_cast<const void*>(A),
+      lda,
+      CUDA_C_64F,
+      reinterpret_cast<const void*>(W),
+      CUDA_C_64F,
+      reinterpret_cast<const void*>(VL),
+      ldvl,
+      CUDA_C_64F,
+      reinterpret_cast<const void*>(VR),
+      ldvr,
+      CUDA_C_64F,
+      workspaceInBytesOnDevice,
+      workspaceInBytesOnHost));
+}
+
+template <>
+void at::cuda::solver::xgeev<float>(
+    cusolverDnHandle_t handle,
+    cusolverDnParams_t params,
+    cusolverEigMode_t jobvl,
+    cusolverEigMode_t jobvr,
+    int64_t n,
+    float* A,
+    int64_t lda,
+    float* W,
+    float* VL,
+    int64_t ldvl,
+    float* VR,
+    int64_t ldvr,
+    float* bufferOnDevice,
+    size_t workspaceInBytesOnDevice,
+    float* bufferOnHost,
+    size_t workspaceInBytesOnHost,
+    int* info) {
+  TORCH_WARN("Launching cuSOLVER Xgeev<float>");
+
+  TORCH_CUSOLVER_CHECK(cusolverDnXgeev(
+      handle,
+      params,
+      jobvl,
+      jobvr,
+      n,
+      CUDA_R_32F,
+      reinterpret_cast<void*>(A),
+      lda,
+      CUDA_R_32F,
+      reinterpret_cast<void*>(W),
+      CUDA_R_32F,
+      reinterpret_cast<void*>(VL),
+      ldvl,
+      CUDA_R_32F,
+      reinterpret_cast<void*>(VR),
+      ldvr,
+      CUDA_R_32F,
+      reinterpret_cast<void*>(bufferOnDevice),
+      workspaceInBytesOnDevice,
+      reinterpret_cast<void*>(bufferOnHost),
+      workspaceInBytesOnHost,
+      info));
+}
+
+
+
+
+template <>
+void at::cuda::solver::xgeev<double>(
     cusolverDnHandle_t handle,
     cusolverDnParams_t params,
     cusolverEigMode_t jobvl,
@@ -2002,8 +2173,127 @@ void at::cuda::solver::xgeev<double, double>(
     double* bufferOnHost,
     size_t workspaceInBytesOnHost,
     int* info) {
-  TORCH_WARN("xgeev<double> not implemented yet");
+    TORCH_WARN("Launching cuSOLVER Xgeev<double>");
+
+  TORCH_CUSOLVER_CHECK(cusolverDnXgeev(
+      handle,
+      params,
+      jobvl,
+      jobvr,
+      n,
+      CUDA_R_64F,  // Datentyp der Matrix
+      reinterpret_cast<void*>(A),
+      lda,
+      CUDA_R_64F,  // Datentyp der Eigenwerte (reell)
+      reinterpret_cast<void*>(W),
+      CUDA_R_64F,  // Datentyp der linken EV
+      reinterpret_cast<void*>(VL),
+      ldvl,
+      CUDA_R_64F,  // Datentyp der rechten EV
+      reinterpret_cast<void*>(VR),
+      ldvr,
+      CUDA_R_64F,  // Arbeitsbereich-Typ
+      reinterpret_cast<void*>(bufferOnDevice),
+      workspaceInBytesOnDevice,
+      reinterpret_cast<void*>(bufferOnHost),
+      workspaceInBytesOnHost,
+      info));
+
 }
+
+template <>
+void at::cuda::solver::xgeev<c10::complex<float>>(
+    cusolverDnHandle_t handle,
+    cusolverDnParams_t params,
+    cusolverEigMode_t jobvl,
+    cusolverEigMode_t jobvr,
+    int64_t n,
+    c10::complex<float>* A,
+    int64_t lda,
+    c10::complex<float>* W,
+    c10::complex<float>* VL,
+    int64_t ldvl,
+    c10::complex<float>* VR,
+    int64_t ldvr,
+    c10::complex<float>* bufferOnDevice,
+    size_t workspaceInBytesOnDevice,
+    c10::complex<float>* bufferOnHost,
+    size_t workspaceInBytesOnHost,
+    int* info) {
+  TORCH_WARN("Launching cuSOLVER Xgeev<complex<float>>");
+
+  TORCH_CUSOLVER_CHECK(cusolverDnXgeev(
+      handle,
+      params,
+      jobvl,
+      jobvr,
+      n,
+      CUDA_C_32F,
+      reinterpret_cast<void*>(A),
+      lda,
+      CUDA_C_32F,
+      reinterpret_cast<void*>(W),
+      CUDA_C_32F,
+      reinterpret_cast<void*>(VL),
+      ldvl,
+      CUDA_C_32F,
+      reinterpret_cast<void*>(VR),
+      ldvr,
+      CUDA_C_32F,
+      reinterpret_cast<void*>(bufferOnDevice),
+      workspaceInBytesOnDevice,
+      reinterpret_cast<void*>(bufferOnHost),
+      workspaceInBytesOnHost,
+      info));
+}
+
+template <>
+void at::cuda::solver::xgeev<c10::complex<double>>(
+    cusolverDnHandle_t handle,
+    cusolverDnParams_t params,
+    cusolverEigMode_t jobvl,
+    cusolverEigMode_t jobvr,
+    int64_t n,
+    c10::complex<double>* A,
+    int64_t lda,
+    c10::complex<double>* W,
+    c10::complex<double>* VL,
+    int64_t ldvl,
+    c10::complex<double>* VR,
+    int64_t ldvr,
+    c10::complex<double>* bufferOnDevice,
+    size_t workspaceInBytesOnDevice,
+    c10::complex<double>* bufferOnHost,
+    size_t workspaceInBytesOnHost,
+    int* info) {
+  TORCH_WARN("Launching cuSOLVER Xgeev<complex<double>>");
+
+  TORCH_CUSOLVER_CHECK(cusolverDnXgeev(
+      handle,
+      params,
+      jobvl,
+      jobvr,
+      n,
+      CUDA_C_64F,
+      reinterpret_cast<void*>(A),
+      lda,
+      CUDA_C_64F,
+      reinterpret_cast<void*>(W),
+      CUDA_C_64F,
+      reinterpret_cast<void*>(VL),
+      ldvl,
+      CUDA_C_64F,
+      reinterpret_cast<void*>(VR),
+      ldvr,
+      CUDA_C_64F,
+      reinterpret_cast<void*>(bufferOnDevice),
+      workspaceInBytesOnDevice,
+      reinterpret_cast<void*>(bufferOnHost),
+      workspaceInBytesOnHost,
+      info));
+}
+
+
 
 
 #endif // defined(CUSOLVER_VERSION) && (CUSOLVER_VERSION >= 11702)

--- a/aten/src/ATen/native/cuda/linalg/CUDASolver.cpp
+++ b/aten/src/ATen/native/cuda/linalg/CUDASolver.cpp
@@ -1980,7 +1980,6 @@ void xgeev_bufferSize<float>(
     int64_t ldvr,
     size_t* workspaceInBytesOnDevice,
     size_t* workspaceInBytesOnHost) {
-  TORCH_WARN("called experimental xgeev_bufferSize<float>");
   TORCH_CUSOLVER_CHECK(cusolverDnXgeev_bufferSize(
       handle, params, jobvl, jobvr, n,
       CUDA_R_32F,
@@ -2015,7 +2014,6 @@ void xgeev_bufferSize<double>(
     int64_t ldvr,
     size_t* workspaceInBytesOnDevice,
     size_t* workspaceInBytesOnHost) {
-  TORCH_WARN("called experimental xgeev_bufferSize<double>");
   TORCH_CUSOLVER_CHECK(cusolverDnXgeev_bufferSize(
       handle, params, jobvl, jobvr, n,
       CUDA_R_64F,
@@ -2051,7 +2049,6 @@ void xgeev_bufferSize<c10::complex<float>>(
     int64_t ldvr,
     size_t* workspaceInBytesOnDevice,
     size_t* workspaceInBytesOnHost) {
-  TORCH_WARN("called experimental xgeev_bufferSize<complex<float>>");
   TORCH_CUSOLVER_CHECK(cusolverDnXgeev_bufferSize(
       handle, params, jobvl, jobvr, n,
       CUDA_C_32F,
@@ -2086,7 +2083,6 @@ void xgeev_bufferSize<c10::complex<double>>(
     int64_t ldvr,
     size_t* workspaceInBytesOnDevice,
     size_t* workspaceInBytesOnHost) {
-  TORCH_WARN("called experimental xgeev_bufferSize<complex<double>>");
   TORCH_CUSOLVER_CHECK(cusolverDnXgeev_bufferSize(
       handle, params, jobvl, jobvr, n,
       CUDA_C_64F,
@@ -2124,7 +2120,6 @@ void at::cuda::solver::xgeev<float>(
     float* bufferOnHost,
     size_t workspaceInBytesOnHost,
     int* info) {
-  TORCH_WARN("Launching cuSOLVER Xgeev<float>");
 
   TORCH_CUSOLVER_CHECK(cusolverDnXgeev(
       handle,
@@ -2173,7 +2168,6 @@ void at::cuda::solver::xgeev<double>(
     double* bufferOnHost,
     size_t workspaceInBytesOnHost,
     int* info) {
-    TORCH_WARN("Launching cuSOLVER Xgeev<double>");
 
   TORCH_CUSOLVER_CHECK(cusolverDnXgeev(
       handle,
@@ -2220,7 +2214,6 @@ void at::cuda::solver::xgeev<c10::complex<float>>(
     c10::complex<float>* bufferOnHost,
     size_t workspaceInBytesOnHost,
     int* info) {
-  TORCH_WARN("Launching cuSOLVER Xgeev<complex<float>>");
 
   TORCH_CUSOLVER_CHECK(cusolverDnXgeev(
       handle,
@@ -2266,7 +2259,6 @@ void at::cuda::solver::xgeev<c10::complex<double>>(
     c10::complex<double>* bufferOnHost,
     size_t workspaceInBytesOnHost,
     int* info) {
-  TORCH_WARN("Launching cuSOLVER Xgeev<complex<double>>");
 
   TORCH_CUSOLVER_CHECK(cusolverDnXgeev(
       handle,

--- a/aten/src/ATen/native/cuda/linalg/CUDASolver.cpp
+++ b/aten/src/ATen/native/cuda/linalg/CUDASolver.cpp
@@ -2096,7 +2096,7 @@ void xgeev_bufferSize<c10::complex<double>>(
 }
 
 template <>
-void at::cuda::solver::xgeev<float>(
+void xgeev<float>(
     cusolverDnHandle_t handle,
     cusolverDnParams_t params,
     cusolverEigMode_t jobvl,
@@ -2144,7 +2144,7 @@ void at::cuda::solver::xgeev<float>(
 
 
 template <>
-void at::cuda::solver::xgeev<double>(
+void xgeev<double>(
     cusolverDnHandle_t handle,
     cusolverDnParams_t params,
     cusolverEigMode_t jobvl,
@@ -2190,7 +2190,7 @@ void at::cuda::solver::xgeev<double>(
 }
 
 template <>
-void at::cuda::solver::xgeev<c10::complex<float>>(
+void xgeev<c10::complex<float>>(
     cusolverDnHandle_t handle,
     cusolverDnParams_t params,
     cusolverEigMode_t jobvl,
@@ -2235,7 +2235,7 @@ void at::cuda::solver::xgeev<c10::complex<float>>(
 }
 
 template <>
-void at::cuda::solver::xgeev<c10::complex<double>>(
+void xgeev<c10::complex<double>>(
     cusolverDnHandle_t handle,
     cusolverDnParams_t params,
     cusolverEigMode_t jobvl,

--- a/aten/src/ATen/native/cuda/linalg/CUDASolver.h
+++ b/aten/src/ATen/native/cuda/linalg/CUDASolver.h
@@ -674,6 +674,47 @@ template <>
 void xsyevd<c10::complex<double>, double>(
     CUDASOLVER_XSYEVD_ARGTYPES(c10::complex<double>, double));
 
+
+
+// new xgeev implementation
+
+#define CUDASOLVER_XGEEV_BUFFERSIZE_ARGTYPES(scalar_t, value_t)              \
+cusolverDnHandle_t handle, cusolverDnParams_t params,                      \
+cusolverEigMode_t jobvl, cusolverEigMode_t jobvr, int64_t n,           \
+const scalar_t* A, int64_t lda, const value_t* W,                      \
+const value_t* VL, int64_t ldvl, const value_t* VR, int64_t ldvr,      \
+size_t* workspaceInBytesOnDevice, size_t* workspaceInBytesOnHost
+
+template <class scalar_t, class value_t = scalar_t>
+void xgeev_bufferSize(
+    CUDASOLVER_XGEEV_BUFFERSIZE_ARGTYPES(scalar_t, value_t)) {
+  static_assert(false&&sizeof(scalar_t),
+      "at::cuda::solver::xgeev_bufferSize: not implemented");
+}
+
+template <>
+void xgeev_bufferSize<double>(
+    CUDASOLVER_XGEEV_BUFFERSIZE_ARGTYPES(double, double));
+
+#define CUDASOLVER_XGEEV_ARGTYPES(scalar_t, value_t)                        \
+cusolverDnHandle_t handle, cusolverDnParams_t params,                      \
+cusolverEigMode_t jobvl, cusolverEigMode_t jobvr, int64_t n, scalar_t *A, \
+int64_t lda, value_t *W, value_t *VL, int64_t ldvl, value_t *VR, int64_t ldvr, \
+scalar_t *bufferOnDevice, size_t workspaceInBytesOnDevice, scalar_t *bufferOnHost,               \
+size_t workspaceInBytesOnHost, int *info
+
+template <class scalar_t, class value_t = scalar_t>
+void xgeev(CUDASOLVER_XGEEV_ARGTYPES(scalar_t, value_t)) {
+  static_assert(false&&sizeof(scalar_t),
+      "at::cuda::solver::xgeev: not implemented");
+}
+
+template <>
+void xgeev<double>(CUDASOLVER_XGEEV_ARGTYPES(double, double));
+
+// end new implementation
+
+
 #endif // USE_CUSOLVER_64_BIT
 
 #ifdef USE_CUSOLVER_64_BIT_XSYEV_BATCHED

--- a/aten/src/ATen/native/cuda/linalg/CUDASolver.h
+++ b/aten/src/ATen/native/cuda/linalg/CUDASolver.h
@@ -676,13 +676,14 @@ void xsyevd<c10::complex<double>, double>(
 
 
 
-// new xgeev implementation
+// cuSOLVER Xgeev (non-Hermitian eigen decomposition, CUDA >= 12.8)
+#if defined(CUSOLVER_VERSION) && (CUSOLVER_VERSION >= 11702)
 
-#define CUDASOLVER_XGEEV_BUFFERSIZE_ARGTYPES(scalar_t)              \
-cusolverDnHandle_t handle, cusolverDnParams_t params,                      \
-cusolverEigMode_t jobvl, cusolverEigMode_t jobvr, int64_t n,           \
-const scalar_t* A, int64_t lda, const scalar_t* W,                      \
-const scalar_t* VL, int64_t ldvl, const scalar_t* VR, int64_t ldvr,      \
+#define CUDASOLVER_XGEEV_BUFFERSIZE_ARGTYPES(scalar_t)                        \
+cusolverDnHandle_t handle, cusolverDnParams_t params,                         \
+cusolverEigMode_t jobvl, cusolverEigMode_t jobvr, int64_t n,                  \
+const scalar_t* A, int64_t lda, const scalar_t* W,                            \
+const scalar_t* VL, int64_t ldvl, const scalar_t* VR, int64_t ldvr,           \
 size_t* workspaceInBytesOnDevice, size_t* workspaceInBytesOnHost
 
 template <class scalar_t>
@@ -693,12 +694,10 @@ void xgeev_bufferSize(
 }
 
 template <>
-void xgeev_bufferSize<double>(
-    CUDASOLVER_XGEEV_BUFFERSIZE_ARGTYPES(double));
+void xgeev_bufferSize<float>(CUDASOLVER_XGEEV_BUFFERSIZE_ARGTYPES(float));
 
 template <>
-void xgeev_bufferSize<float>(
-    CUDASOLVER_XGEEV_BUFFERSIZE_ARGTYPES(float));
+void xgeev_bufferSize<double>(CUDASOLVER_XGEEV_BUFFERSIZE_ARGTYPES(double));
 
 template <>
 void xgeev_bufferSize<c10::complex<float>>(
@@ -708,11 +707,11 @@ template <>
 void xgeev_bufferSize<c10::complex<double>>(
     CUDASOLVER_XGEEV_BUFFERSIZE_ARGTYPES(c10::complex<double>));
 
-#define CUDASOLVER_XGEEV_ARGTYPES(scalar_t)                        \
-cusolverDnHandle_t handle, cusolverDnParams_t params,                      \
-cusolverEigMode_t jobvl, cusolverEigMode_t jobvr, int64_t n, scalar_t *A, \
-int64_t lda, scalar_t *W, scalar_t *VL, int64_t ldvl, scalar_t *VR, int64_t ldvr, \
-scalar_t *bufferOnDevice, size_t workspaceInBytesOnDevice, scalar_t *bufferOnHost,               \
+#define CUDASOLVER_XGEEV_ARGTYPES(scalar_t)                                    \
+cusolverDnHandle_t handle, cusolverDnParams_t params,                          \
+cusolverEigMode_t jobvl, cusolverEigMode_t jobvr, int64_t n, scalar_t *A,      \
+int64_t lda, scalar_t *W, scalar_t *VL, int64_t ldvl, scalar_t *VR, int64_t ldvr,\
+scalar_t *bufferOnDevice, size_t workspaceInBytesOnDevice, scalar_t *bufferOnHost,\
 size_t workspaceInBytesOnHost, int *info
 
 template <class scalar_t>
@@ -722,25 +721,18 @@ void xgeev(CUDASOLVER_XGEEV_ARGTYPES(scalar_t)) {
 }
 
 template <>
-void xgeev<float>
-	(CUDASOLVER_XGEEV_ARGTYPES(float));
-
+void xgeev<float>(CUDASOLVER_XGEEV_ARGTYPES(float));
 
 template <>
-void xgeev<double>
-	(CUDASOLVER_XGEEV_ARGTYPES(double));
+void xgeev<double>(CUDASOLVER_XGEEV_ARGTYPES(double));
 
 template <>
-void xgeev<c10::complex<float>>
-	(CUDASOLVER_XGEEV_ARGTYPES(c10::complex<float>));
+void xgeev<c10::complex<float>>(CUDASOLVER_XGEEV_ARGTYPES(c10::complex<float>));
 
 template <>
-void xgeev<c10::complex<double>>
-	(CUDASOLVER_XGEEV_ARGTYPES(c10::complex<double>));
+void xgeev<c10::complex<double>>(CUDASOLVER_XGEEV_ARGTYPES(c10::complex<double>));
 
-
-// end new implementation
-
+#endif // defined(CUSOLVER_VERSION) && (CUSOLVER_VERSION >= 11702)
 
 #endif // USE_CUSOLVER_64_BIT
 

--- a/aten/src/ATen/native/cuda/linalg/CUDASolver.h
+++ b/aten/src/ATen/native/cuda/linalg/CUDASolver.h
@@ -678,39 +678,66 @@ void xsyevd<c10::complex<double>, double>(
 
 // new xgeev implementation
 
-#define CUDASOLVER_XGEEV_BUFFERSIZE_ARGTYPES(scalar_t, value_t)              \
+#define CUDASOLVER_XGEEV_BUFFERSIZE_ARGTYPES(scalar_t)              \
 cusolverDnHandle_t handle, cusolverDnParams_t params,                      \
 cusolverEigMode_t jobvl, cusolverEigMode_t jobvr, int64_t n,           \
-const scalar_t* A, int64_t lda, const value_t* W,                      \
-const value_t* VL, int64_t ldvl, const value_t* VR, int64_t ldvr,      \
+const scalar_t* A, int64_t lda, const scalar_t* W,                      \
+const scalar_t* VL, int64_t ldvl, const scalar_t* VR, int64_t ldvr,      \
 size_t* workspaceInBytesOnDevice, size_t* workspaceInBytesOnHost
 
-template <class scalar_t, class value_t = scalar_t>
+template <class scalar_t>
 void xgeev_bufferSize(
-    CUDASOLVER_XGEEV_BUFFERSIZE_ARGTYPES(scalar_t, value_t)) {
+    CUDASOLVER_XGEEV_BUFFERSIZE_ARGTYPES(scalar_t)) {
   static_assert(false&&sizeof(scalar_t),
       "at::cuda::solver::xgeev_bufferSize: not implemented");
 }
 
 template <>
 void xgeev_bufferSize<double>(
-    CUDASOLVER_XGEEV_BUFFERSIZE_ARGTYPES(double, double));
+    CUDASOLVER_XGEEV_BUFFERSIZE_ARGTYPES(double));
 
-#define CUDASOLVER_XGEEV_ARGTYPES(scalar_t, value_t)                        \
+template <>
+void xgeev_bufferSize<float>(
+    CUDASOLVER_XGEEV_BUFFERSIZE_ARGTYPES(float));
+
+template <>
+void xgeev_bufferSize<c10::complex<float>>(
+    CUDASOLVER_XGEEV_BUFFERSIZE_ARGTYPES(c10::complex<float>));
+
+template <>
+void xgeev_bufferSize<c10::complex<double>>(
+    CUDASOLVER_XGEEV_BUFFERSIZE_ARGTYPES(c10::complex<double>));
+
+#define CUDASOLVER_XGEEV_ARGTYPES(scalar_t)                        \
 cusolverDnHandle_t handle, cusolverDnParams_t params,                      \
 cusolverEigMode_t jobvl, cusolverEigMode_t jobvr, int64_t n, scalar_t *A, \
-int64_t lda, value_t *W, value_t *VL, int64_t ldvl, value_t *VR, int64_t ldvr, \
+int64_t lda, scalar_t *W, scalar_t *VL, int64_t ldvl, scalar_t *VR, int64_t ldvr, \
 scalar_t *bufferOnDevice, size_t workspaceInBytesOnDevice, scalar_t *bufferOnHost,               \
 size_t workspaceInBytesOnHost, int *info
 
-template <class scalar_t, class value_t = scalar_t>
-void xgeev(CUDASOLVER_XGEEV_ARGTYPES(scalar_t, value_t)) {
+template <class scalar_t>
+void xgeev(CUDASOLVER_XGEEV_ARGTYPES(scalar_t)) {
   static_assert(false&&sizeof(scalar_t),
       "at::cuda::solver::xgeev: not implemented");
 }
 
 template <>
-void xgeev<double>(CUDASOLVER_XGEEV_ARGTYPES(double, double));
+void xgeev<float>
+	(CUDASOLVER_XGEEV_ARGTYPES(float));
+
+
+template <>
+void xgeev<double>
+	(CUDASOLVER_XGEEV_ARGTYPES(double));
+
+template <>
+void xgeev<c10::complex<float>>
+	(CUDASOLVER_XGEEV_ARGTYPES(c10::complex<float>));
+
+template <>
+void xgeev<c10::complex<double>>
+	(CUDASOLVER_XGEEV_ARGTYPES(c10::complex<double>));
+
 
 // end new implementation
 


### PR DESCRIPTION
### Summary

Adds support for NVIDIA’s cuSolver backend to torch.linalg.eig and torch.linalg.eigvals within the ATen/Linalg framework.

### Motivation

Extending PyTorch’s Linalg backends with NVIDIA’s cuSolver enables faster execution of torch.linalg.eig and torch.linalg.eigvals, complementing existing MAGMA and CPU implementations.

The speedup observed on consumer hardware (RTX4070/Ryzen 5700x) is in the order of **2x**, with preliminary testing on HPC hardware (H100, EPYC 9454) suggesting **up to 10x speedup**. 

### Details

- Implements cuSolver support for linalg_eig and linalg_eigvals using the interface described in [NVIDIA cuSolver documentation](https://docs.nvidia.com/cuda/cusolver/index.html#cusolverdnxgeev)  as introduced in CUDA 12.8 [CUDA 12.8 release notes](https://docs.nvidia.com/cuda/archive/12.8.0/cuda-toolkit-release-notes/index.html)
- Follows the existing MAGMA backend design, adapting it for cuSolver’s cusolverDnXgeev API.
- Integrates with existing eig/eigvals dispatch mechanism.
- No automatic CPU↔GPU backend switching. (Happy to discuss)
- Verified via existing Linalg test coverage; no new tests introduced in this PR.
- Tested successfully against both test_linalg.py including slow test suites.
- Tested MAGMA fallback successfully using CUDA 12.4. (observed unrelated test failures)


### Impact

- Enables much faster solving of eigenvalue problems
- Maintains numerical consistency and test stability across backends.
- No change to public API or user-facing behavior.

Special thanks to @AlbanD for prior feedback and discussions regarding the PR and @lezcano for feedback on the related testing PR [https://github.com/pytorch/pytorch/pull/166322](https://github.com/pytorch/pytorch/pull/166322).

Happy to discuss backend dispatch strategy, results from performance and stability testing can be seen here [https://dev-discuss.pytorch.org/](https://dev-discuss.pytorch.org/t/cusolver-dnxgeev-faster-cuda-eigenvalue-calculations/3248/7)

cc @jianyuh @nikitaved @mruberry @walterddr @xwang233 @Lezcano @albanD 