### PR TITLE
[BE][Typing][Dynamo] Type torch/_dynamo/variables/builtin.py

### DIFF
--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -1736,6 +1736,14 @@
   "GB0175": [
     {
       "Gb_type": "builtin isinstance() cannot determine type of argument",
+      "Context": "isinstance({arg}, {isinstance_type_var})",
+      "Explanation": "Dynamo doesn't have a rule to determine the type of argument {arg}",
+      "Hints": [
+        "This is likely to be a Dynamo bug. Please report an issue to PyTorch."
+      ]
+    },
+    {
+      "Gb_type": "builtin isinstance() cannot determine type of argument",
       "Context": "isinstance({arg}, {isinstance_type})",
       "Explanation": "Dynamo doesn't have a rule to determine the type of argument {arg}",
       "Hints": [

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -305,8 +305,8 @@ class BuiltinVariable(VariableTracker):
 
     @staticmethod
     @functools.cache
-    def _constant_fold_functions() -> set[object]:
-        fns: set[object] = {
+    def _constant_fold_functions() -> set[Callable[..., Any]]:
+        fns: set[Callable[..., Any]] = {
             abs,
             all,
             any,
@@ -376,7 +376,7 @@ class BuiltinVariable(VariableTracker):
 
     @staticmethod
     @functools.cache
-    def _fx_graph_functions() -> set[Any]:
+    def _fx_graph_functions() -> set[Callable[..., Any]]:
         fns = {
             operator.abs,
             operator.pos,
@@ -418,7 +418,7 @@ class BuiltinVariable(VariableTracker):
             operator.ixor,
             operator.ior,
         }
-        return fns
+        return fns  # type: ignore[return-value]
 
     @staticmethod
     @functools.cache
@@ -1927,7 +1927,7 @@ class BuiltinVariable(VariableTracker):
                 list(obj.unpack_var_sequence(tx)),
                 mutation_type=ValueMutationNew(),
             )
-        return None  # type: ignore[return-value]
+        return None
 
     def _call_iter_tuple_generator(
         self,
@@ -2136,7 +2136,6 @@ class BuiltinVariable(VariableTracker):
                 "2 args",
                 f"{len(args)} args",
             )
-        assert len(args) >= 2
         arg, value = args
         DictVariableType = (
             ConstDictVariable if user_cls is not defaultdict else DefaultDictVariable

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1070,6 +1070,7 @@ class BuiltinVariable(VariableTracker):
                 def call_binop_handlers(
                     tx: "InstructionTranslator", args: Any, _: Any
                 ) -> Any:
+                    # pyrefly: ignore [not-iterable]
                     for fn in binop_handlers:
                         rv = fn(tx, *args)
                         if rv:
@@ -2136,6 +2137,7 @@ class BuiltinVariable(VariableTracker):
                 "2 args",
                 f"{len(args)} args",
             )
+        # pyrefly: ignore [bad-unpacking]
         arg, value = args
         DictVariableType = (
             ConstDictVariable if user_cls is not defaultdict else DefaultDictVariable
@@ -2320,6 +2322,7 @@ class BuiltinVariable(VariableTracker):
                             return issubclass(arg.python_type(), ty)
 
                     dtypes = tensortype_to_dtype[ty]
+                    # pyrefly: ignore [missing-attribute]
                     return arg.dtype in dtypes
 
                 if type(tensor_type) is tuple:

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -2289,18 +2289,18 @@ class BuiltinVariable(VariableTracker):
         self,
         tx: "InstructionTranslator",
         arg: VariableTracker,
-        isinstance_type: VariableTracker,
+        isinstance_type_var: VariableTracker,
     ) -> VariableTracker:
         try:
             arg_type = arg.python_type()
         except NotImplementedError:
             unimplemented_v2(
                 gb_type="builtin isinstance() cannot determine type of argument",
-                context=f"isinstance({arg}, {isinstance_type})",
+                context=f"isinstance({arg}, {isinstance_type_var})",
                 explanation=f"Dynamo doesn't have a rule to determine the type of argument {arg}",
                 hints=[*graph_break_hints.DYNAMO_BUG],
             )
-
+        isinstance_type = isinstance_type_var.as_python_constant()
         if isinstance(arg, variables.TensorVariable) and arg.dtype is not None:
 
             def _tensor_isinstance(
@@ -2349,19 +2349,19 @@ class BuiltinVariable(VariableTracker):
             and "__instancecheck__" in isinstance_type.__class__.__dict__
         ):
             return variables.ConstantVariable.create(
-                isinstance_type.__class__.__instancecheck__(isinstance_type, arg.value)  # type: ignore[call-arg]
+                isinstance_type.__class__.__instancecheck__(isinstance_type, arg.value)
             )
 
         if isinstance(arg, variables.UserDefinedExceptionClassVariable):
             # pyrefly: ignore [unbound-name]
-            return ConstantVariable.create(isinstance(arg_type, isinstance_type))  # type: ignore[arg-type]
+            return ConstantVariable.create(isinstance(arg_type, isinstance_type))
 
         isinstance_type_tuple: tuple[type, ...]
         if isinstance(isinstance_type, type) or callable(
             # E.g. isinstance(obj, typing.Sequence)
             getattr(isinstance_type, "__instancecheck__", None)
         ):
-            isinstance_type_tuple = (isinstance_type,)  # type: ignore[assignment]
+            isinstance_type_tuple = (isinstance_type,)
         elif isinstance(isinstance_type, types.UnionType):
             isinstance_type_tuple = isinstance_type.__args__
         elif isinstance(isinstance_type, tuple) and all(
@@ -2460,7 +2460,7 @@ class BuiltinVariable(VariableTracker):
         return variables.MapVariable(
             fn,
             seq_list,  # type: ignore[arg-type]
-            mutation_type=ValueMutationNew()
+            mutation_type=ValueMutationNew(),
         )
 
     def call_filter(
@@ -2472,7 +2472,7 @@ class BuiltinVariable(VariableTracker):
         return variables.FilterVariable(
             fn,
             seq_or_list,  # type: ignore[arg-type]
-            mutation_type=ValueMutationNew()
+            mutation_type=ValueMutationNew(),
         )
 
     def var_getattr(self, tx: "InstructionTranslator", name: str) -> VariableTracker:

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -2457,7 +2457,11 @@ class BuiltinVariable(VariableTracker):
             seq.unpack_var_sequence(tx) if seq.has_unpack_var_sequence(tx) else seq
             for seq in seqs
         ]
-        return variables.MapVariable(fn, seq_list, mutation_type=ValueMutationNew())
+        return variables.MapVariable(
+            fn,
+            seq_list,  # type: ignore[arg-type]
+            mutation_type=ValueMutationNew()
+        )
 
     def call_filter(
         self, tx: "InstructionTranslator", fn: VariableTracker, seq: VariableTracker
@@ -2466,7 +2470,9 @@ class BuiltinVariable(VariableTracker):
             seq.unpack_var_sequence(tx) if seq.has_unpack_var_sequence(tx) else seq
         )
         return variables.FilterVariable(
-            fn, seq_or_list, mutation_type=ValueMutationNew()
+            fn,
+            seq_or_list,  # type: ignore[arg-type]
+            mutation_type=ValueMutationNew()
         )
 
     def var_getattr(self, tx: "InstructionTranslator", name: str) -> VariableTracker:

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -23,6 +23,7 @@ import operator
 import textwrap
 import traceback
 import types
+from collections.abc import Sequence
 from contextlib import nullcontext
 from typing import TYPE_CHECKING
 
@@ -631,7 +632,7 @@ class TensorVariable(VariableTracker):
         self,
         tx,
         name,
-        args: "list[VariableTracker]",
+        args: Sequence[VariableTracker],
         kwargs: "dict[str, VariableTracker]",
     ) -> "VariableTracker":
         from .builder import SourcelessBuilder, VariableBuilder

--- a/torch/_dynamo/variables/torch_function.py
+++ b/torch/_dynamo/variables/torch_function.py
@@ -29,6 +29,7 @@ import contextlib
 import functools
 import inspect
 import operator
+from collections.abc import Sequence
 from types import TracebackType
 from typing import Any, Generator, Iterable, Optional, TYPE_CHECKING
 
@@ -722,12 +723,12 @@ class TensorWithTFOverrideVariable(TensorVariable):
         self,
         tx: "InstructionTranslator",
         name: str,
-        args: "list[VariableTracker]",
+        args: Sequence[VariableTracker],
         kwargs: "dict[str, VariableTracker]",
     ) -> "VariableTracker":
         # This code block implements inlining the __torch_function__ override
         # of `call_method`.
-        tf_args = [self] + args
+        tf_args = [self] + list(args)
         if can_dispatch_torch_function(tx, tf_args, kwargs):
             import torch
 


### PR DESCRIPTION
Provides type coverage to torch/_dynamo/variables/builtin.py

### Coverage report:
`mypy torch/_dynamo/variables/builtin.py --linecount-report /tmp/coverage_log`
Compare before to after - we go from 2213 lines and 64 funcs covered to 3212 lines and 85 funcs covered

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames