### PR TITLE
Add support for defaultdict in dynamo

### DIFF
--- a/test/dynamo/test_dicts.py
+++ b/test/dynamo/test_dicts.py
@@ -1079,6 +1079,7 @@ class DictTests(torch._dynamo.test_case.TestCase):
             d[0] = [
                 42,
             ]
+
             return x + 1, d
 
         x = torch.ones(2)
@@ -1087,11 +1088,12 @@ class DictTests(torch._dynamo.test_case.TestCase):
 
         self.assertEqual(ref, res)
 
-    @unittest.expectedFailure
     def test_newly_constructed_default_dict_with_dict(self):
         def f(x):
-            d = defaultdict(dict, {2: {"a": 1}})
-            d[0] = {"b": 2}
+            d = dict([("a", 1), ("b", 2)], c=3)
+            d = defaultdict(int, d, d=4, e=5)
+            d["a"] = 42
+
             return x + 1, d
 
         x = torch.ones(2)

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -181,6 +181,7 @@ from .ctx_manager import (
 )
 from .dicts import (
     ConstDictVariable,
+    DefaultDictClassVariable,
     DefaultDictVariable,
     DictKeySetVariable,
     FrozensetVariable,
@@ -797,6 +798,8 @@ class VariableBuilder:
                 )
 
             return self.tx.output.side_effects.track_mutable(value, result)
+        elif value is collections.defaultdict:
+            return DefaultDictClassVariable()
         elif isinstance(value, torch.nn.Module):
             return self.wrap_module(value)
         elif ConstantVariable.is_literal(value):  # non-atomic literals


### PR DESCRIPTION
What: Create new class to handle call_function for defaultdict
Why: This should allow the use of defaultdict constructor when compiling

Fixes #166238


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela