### PR TITLE
[caffe2] Ignore -Wswitch-enum warnings

### DIFF
--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -197,6 +197,7 @@ inline at::ScalarType scalar_type(at::ScalarType s) {
     /* don't use TYPE again in case it is an expensive or side-effect op */ \
     at::ScalarType _st = ::detail::scalar_type(the_type);                   \
     RECORD_KERNEL_FUNCTION_DTYPE(at_dispatch_name, _st);                    \
+    C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wswitch-enum")             \
     switch (_st) {                                                          \
       __VA_ARGS__                                                           \
       default:                                                              \
@@ -208,6 +209,7 @@ inline at::ScalarType scalar_type(at::ScalarType s) {
             toString(_st),                                                  \
             "'");                                                           \
     }                                                                       \
+    C10_DIAGNOSTIC_POP()                                                    \
   }()
 
 #define AT_DISPATCH_CASE_FLOATING_TYPES(...)            \

--- a/aten/src/ATen/core/IListRef.h
+++ b/aten/src/ATen/core/IListRef.h
@@ -190,12 +190,14 @@ class IListRef;
  * it to a function (e.g. `ImplT::<dispatch-function>(this_)`).
  */
 #define TORCH_ILISTREF_UNWRAP(TAG, BODY)                         \
+  C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wswitch-enum")    \
   switch (TAG) {                                                 \
     TORCH_ILISTREF_FORALL_TAGS(TORCH_ILISTREF_UNWRAP_CASE, BODY) \
     break;                                                       \
     default:                                                     \
       TORCH_INTERNAL_ASSERT(false, "invalid IListRef tag.");     \
-  }
+  } \
+  C10_DIAGNOSTIC_POP()
 
 enum class IListRefTag {
 #define DEFINE_TAG(tag, ...) tag,

--- a/aten/src/ATen/core/enum_type.h
+++ b/aten/src/ATen/core/enum_type.h
@@ -18,6 +18,7 @@ struct TORCH_API EnumType : public NamedType {
       TypePtr value,
       std::vector<EnumNameValue> enum_names_values,
       std::weak_ptr<::torch::jit::CompilationUnit> cu) {
+    C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wswitch-enum")
     switch (value->kind()) {
       case TypeKind::IntType:
       case TypeKind::FloatType:
@@ -34,6 +35,7 @@ struct TORCH_API EnumType : public NamedType {
             value->str(),
             "', only int, float and string are supported");
     }
+    C10_DIAGNOSTIC_POP()
   }
 
   std::string str() const override {

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -922,6 +922,7 @@ struct TORCH_API DictType : public SharedType {
     if (auto dyn = key->castRaw<DynamicType>()) {
       kind = dyn->dynamicKind();
     }
+    C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wswitch-enum")
     switch (kind) {
       case TypeKind::AnyType:
       case TypeKind::IntType:
@@ -938,6 +939,7 @@ struct TORCH_API DictType : public SharedType {
             key->str(),
             "', only int, float, complex, Tensor, device and string keys are supported");
     }
+    C10_DIAGNOSTIC_POP()
   }
 
   // aligned with the format in FunctionSchema

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/buckbuild.bzl
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/buckbuild.bzl
@@ -301,6 +301,10 @@ def define_qnnpack(third_party, labels = []):
             "-DQNNP_PRIVATE=",
             "-DQNNP_INTERNAL=",
         ],
+        fbobjc_compiler_flags = [
+            "-Wno-switch-enum",
+            "-Wno-switch-default",
+        ],
         labels = [
             "supermodule:android/default/pytorch",
             "supermodule:ios/default/public.pytorch",

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -28,6 +28,7 @@
 #include <c10/util/OptionalArrayRef.h>
 #include <c10/util/intrusive_ptr.h>
 #include <c10/macros/Export.h>
+#include <c10/macros/Macros.h>
 #include <ATen/core/CheckMemoryFormat.h>
 #include <ATen/core/DeprecatedTypePropertiesRegistry.h>
 #include <ATen/core/DeprecatedTypeProperties.h>
@@ -129,6 +130,7 @@ class TORCH_API Tensor: public TensorBase {
       return *this;
     }
 
+    C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wswitch-enum")
     switch (this->layout()) {
       case at::kSparse:
       case at::kSparseCsr:
@@ -139,6 +141,7 @@ class TORCH_API Tensor: public TensorBase {
       default:
         return this->_conj();
     }
+    C10_DIAGNOSTIC_POP()
   }
 
   // Aliased by Dimname overloads, so need explicit using

--- a/c10/core/Backend.h
+++ b/c10/core/Backend.h
@@ -3,9 +3,12 @@
 #include <c10/core/DeviceType.h>
 #include <c10/core/DispatchKey.h>
 #include <c10/core/DispatchKeySet.h>
+#include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
 
 #include <stdexcept>
+
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wswitch-enum")
 
 namespace c10 {
 
@@ -402,3 +405,5 @@ inline bool isSparseCsr(Backend b) {
 }
 
 } // namespace c10
+
+C10_DIAGNOSTIC_POP()

--- a/c10/core/DispatchKeySet.h
+++ b/c10/core/DispatchKeySet.h
@@ -15,6 +15,8 @@
 #include <string>
 #include <type_traits>
 
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wswitch-enum")
+
 namespace c10 {
 
 struct FunctionalityOffsetAndMask {
@@ -966,3 +968,5 @@ using remove_DispatchKeySet_arg_from_func = guts::make_function_traits_t<
             1>,
         typename guts::infer_function_traits_t<FuncType>::parameter_types>>;
 } // namespace c10
+
+C10_DIAGNOSTIC_POP()

--- a/c10/core/DynamicCast.h
+++ b/c10/core/DynamicCast.h
@@ -69,6 +69,7 @@ template <typename dest_t>
 C10_HOST_DEVICE inline dest_t fetch_and_cast(
     const ScalarType src_type,
     const void* ptr) {
+  C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wswitch-enum")
   switch (src_type) {
     AT_FORALL_SCALAR_TYPES_WITH_COMPLEX(FETCH_AND_CAST_CASE)
     FETCH_AND_CAST_CASE(uint16_t, UInt16)
@@ -77,6 +78,7 @@ C10_HOST_DEVICE inline dest_t fetch_and_cast(
     default:
       ERROR_UNSUPPORTED_CAST
   }
+  C10_DIAGNOSTIC_POP()
   return dest_t(0); // just to avoid compiler warning
 }
 
@@ -91,6 +93,7 @@ C10_HOST_DEVICE inline void cast_and_store(
     const ScalarType dest_type,
     void* ptr,
     src_t value) {
+  C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wswitch-enum")
   switch (dest_type) {
     AT_FORALL_SCALAR_TYPES_WITH_COMPLEX(CAST_AND_STORE_CASE)
     CAST_AND_STORE_CASE(uint16_t, UInt16)
@@ -98,6 +101,7 @@ C10_HOST_DEVICE inline void cast_and_store(
     CAST_AND_STORE_CASE(uint64_t, UInt64)
     default:;
   }
+  C10_DIAGNOSTIC_POP()
   ERROR_UNSUPPORTED_CAST
 }
 

--- a/c10/core/Layout.h
+++ b/c10/core/Layout.h
@@ -29,6 +29,7 @@ constexpr auto kSparseBsc = Layout::SparseBsc;
 constexpr auto kJagged = Layout::Jagged;
 
 inline Layout layout_from_backend(Backend backend) {
+  C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wswitch-enum")
   switch (backend) {
     case Backend::SparseCPU:
     case Backend::SparseCUDA:
@@ -52,6 +53,7 @@ inline Layout layout_from_backend(Backend backend) {
     default:
       return Layout::Strided;
   }
+  C10_DIAGNOSTIC_POP()
 }
 
 inline std::ostream& operator<<(std::ostream& stream, at::Layout layout) {
@@ -72,6 +74,7 @@ inline std::ostream& operator<<(std::ostream& stream, at::Layout layout) {
       return stream << "Mkldnn";
     case at::kJagged:
       return stream << "Jagged";
+    case Layout::NumOptions:
     default:
       TORCH_CHECK(false, "Unknown layout");
   }

--- a/c10/core/MemoryFormat.h
+++ b/c10/core/MemoryFormat.h
@@ -55,6 +55,7 @@ inline std::ostream& operator<<(
       return stream << "ChannelsLast";
     case MemoryFormat::ChannelsLast3d:
       return stream << "ChannelsLast3d";
+    case MemoryFormat::NumOptions:
     default:
       TORCH_CHECK(false, "Unknown memory format ", memory_format);
   }

--- a/c10/core/QScheme.h
+++ b/c10/core/QScheme.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
 #include <cstdint>
 #include <string>
+
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wswitch-enum")
 
 namespace c10 {
 
@@ -48,3 +51,5 @@ inline std::string toString(QScheme qscheme) {
 }
 
 } // namespace c10
+
+C10_DIAGNOSTIC_POP()

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -26,6 +26,8 @@
 
 #include <torch/headeronly/core/ScalarType.h>
 
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wswitch-enum")
+
 namespace c10 {
 
 // See [dtype Macros note] in torch/headeronly/core/ScalarType.h
@@ -288,3 +290,5 @@ C10_API std::pair<std::string, std::string> getDtypeNames(
 C10_API const std::unordered_map<std::string, ScalarType>& getStringToDtypeMap();
 
 } // namespace c10
+
+C10_DIAGNOSTIC_POP()

--- a/c10/core/TensorOptions.h
+++ b/c10/core/TensorOptions.h
@@ -21,6 +21,8 @@
 #include <type_traits>
 #include <utility>
 
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wswitch-enum")
+
 namespace c10 {
 
 inline ScalarType dtype_or_default(std::optional<ScalarType> dtype) {
@@ -780,3 +782,5 @@ inline bool backend_supports_empty_operator(const TensorOptions& options) {
 } // namespace detail
 
 } // namespace c10
+
+C10_DIAGNOSTIC_POP()

--- a/caffe2/utils/threadpool/WorkersPool.h
+++ b/caffe2/utils/threadpool/WorkersPool.h
@@ -258,6 +258,7 @@ class alignas(kGEMMLOWPCacheLineSize) Worker {
     case State::HasWork:
       DCHECK(new_state == State::Ready || new_state == State::ExitAsSoonAsPossible);
       break;
+    case State::ExitAsSoonAsPossible:
     default:
       abort();
     }
@@ -292,6 +293,8 @@ class alignas(kGEMMLOWPCacheLineSize) Worker {
         break;
       case State::ExitAsSoonAsPossible:
         return;
+      case State::Ready:
+      case State::ThreadStartup:
       default:
         abort();
       }

--- a/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
+++ b/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
@@ -28,6 +28,10 @@ namespace flatbuffers = flatbuffers_fbsource;
 #include <torch/csrc/jit/serialization/mobile_bytecode_generated.h> // NOLINT
 #endif
 
+C10_CLANG_DIAGNOSTIC_PUSH()
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wswitch-default")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wswitch-enum")
+
 namespace torch::jit {
 
 using flatbuffers::FlatBufferBuilder;
@@ -858,3 +862,5 @@ bool register_flatbuffer_serializer() {
 }
 
 } // namespace torch::jit
+
+C10_CLANG_DIAGNOSTIC_POP()

--- a/torch/headeronly/core/ScalarType.h
+++ b/torch/headeronly/core/ScalarType.h
@@ -19,6 +19,8 @@
 
 #include <cstdint>
 
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wswitch-enum")
+
 namespace c10 {
 
 // dummy struct for uint1 to uint7, actual functionality
@@ -351,3 +353,5 @@ using c10::impl::ScalarTypeToCPPTypeT;
 } // namespace impl
 
 HIDDEN_NAMESPACE_END(torch, headeronly)
+
+C10_DIAGNOSTIC_POP()

--- a/torch/headeronly/macros/Macros.h
+++ b/torch/headeronly/macros/Macros.h
@@ -1,6 +1,11 @@
 #ifndef C10_MACROS_MACROS_H_
 #define C10_MACROS_MACROS_H_
+
+#ifdef __cplusplus
 #include <cassert>
+#else
+#include <assert.h>
+#endif
 
 /* Main entry for torch/headeronly/macros (used to be c10/macros).
  *
@@ -139,6 +144,8 @@
 
 #define C10_RESTRICT __restrict
 
+#ifdef __cplusplus
+
 // Simply define the namespace, in case a dependent library want to refer to
 // the c10 namespace but not any nontrivial files.
 namespace c10 {}
@@ -175,6 +182,8 @@ using namespace c10::hip;
 namespace at::xpu {
 using namespace c10::xpu;
 } // namespace at::xpu
+
+#endif // __cplusplus
 
 // C10_LIKELY/C10_UNLIKELY
 //
@@ -236,7 +245,11 @@ using namespace c10::xpu;
 
 #define C10_ERASE C10_ALWAYS_INLINE C10_ATTR_VISIBILITY_HIDDEN
 
+#ifdef __cplusplus
 #include <cstdint>
+#else
+#include <stdint.h>
+#endif
 
 #ifdef __HIPCC__
 // Unlike CUDA, HIP requires a HIP header to be included for __host__ to work.
@@ -467,7 +480,7 @@ __host__ __device__
 // a non-negligible performance impact even if the assert condition is
 // never triggered. We choose to use abort() instead which will still
 // terminate the application but without a more useful error message.
-#if !defined(C10_USE_ROCM_KERNEL_ASSERT) and defined(USE_ROCM)
+#if !defined(C10_USE_ROCM_KERNEL_ASSERT) && defined(USE_ROCM)
 #define CUDA_KERNEL_ASSERT(cond) \
   if C10_UNLIKELY (!(cond)) {    \
     abort();                     \
@@ -517,7 +530,7 @@ __host__ __device__
     __assert_fail(                                                       \
         #cond, __FILE__, static_cast<unsigned int>(__LINE__), __func__); \
   }
-#endif //  C10_USE_ROCM_KERNEL_ASSERT and USE_ROCM
+#endif //  C10_USE_ROCM_KERNEL_ASSERT && USE_ROCM
 #endif // __APPLE__
 
 // Compile-time switch to control how assertions are logged inside CUDA kernels.

--- a/torch/library.h
+++ b/torch/library.h
@@ -353,6 +353,7 @@ inline CppFunction dispatch(c10::DispatchKey k, Func&& raw_f) {
 template <typename Func>
 inline CppFunction dispatch(c10::DeviceType type, Func&& raw_f) {
   auto deviceTypeToDispatchKey = [](c10::DeviceType t) {
+    C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wswitch-enum")
     switch (t) {
       // This list is synchronized with the k-constants in c10/core/DeviceType.h
       case c10::DeviceType::CPU:
@@ -389,6 +390,7 @@ inline CppFunction dispatch(c10::DeviceType type, Func&& raw_f) {
             " cannot be overloaded at dispatch time, "
             "please file a bug report explaining what you were trying to do.");
     }
+    C10_DIAGNOSTIC_POP()
   };
   return dispatch(deviceTypeToDispatchKey(type), std::forward<Func>(raw_f));
 }


### PR DESCRIPTION
Summary: Projects that use `-Wswitch-enum` will encounter issues when building and using *PyTorch* (`caffe2`).  Address these issues to empower more rigorous upstream compiler warnings/errors.

Test Plan: CI Pass

Differential Revision: D85893917




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01