### PR TITLE
[3.14] Fix torch.package.importer

### DIFF
--- a/torch/package/importer.py
+++ b/torch/package/importer.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 import importlib
 import logging
+import sys
 from abc import ABC, abstractmethod
 
 # pyrefly: ignore [missing-module-attribute]
@@ -102,7 +103,12 @@ class Importer(ABC):
         # Check that this name will indeed return the correct object
         try:
             module = self.import_module(module_name)
-            obj2, _ = _getattribute(module, name)
+            if sys.version_info >= (3, 14):
+                # pickle._getatribute signature changes in 3.14
+                # to take iterable and return just one object
+                obj2 = _getattribute(module, name.split("."))
+            else:
+                obj2, _ = _getattribute(module, name)
         except (ImportError, KeyError, AttributeError):
             raise ObjNotFoundError(
                 f"{obj} was not found as {module_name}.{name}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #166768
* __->__ #166767

That relies on internal implementation of `picker._getattribute` which
changed from (i.e. takes object and string and returns tuple)
https://github.com/python/cpython/blob/9ab89c026aa9611c4b0b67c288b8303a480fe742/Lib/pickle.py#L316
To (takes object and iterable of strings and returns object
https://github.com/python/cpython/blob/631ba3407e3348ccd56ce5160c4fb2c5dc5f4d84/Lib/pickle.py#L315

Test plan:
```
python -c "import torch; print(torch.package.sys_importer.get_name(torch.cuda.Stream))"
```