### PR TITLE
[3/N] Use 'is' in callable comparisons

### DIFF
--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -58,7 +58,7 @@ def _should_decompose_because_unsafe_op(op: torch._ops.OperatorBase) -> bool:
         return False
     if torch.Tag.maybe_aliasing_or_mutating in op.tags:
         return True
-    return op == torch.ops.aten.native_batch_norm.default
+    return op is torch.ops.aten.native_batch_norm.default
 
 
 def _add_op_to_registry(registry, op, fn):

--- a/torch/_dispatch/python.py
+++ b/torch/_dispatch/python.py
@@ -115,7 +115,7 @@ def make_crossref_functionalize(
     from torch._subclasses.fake_tensor import FakeTensorMode
 
     # This case is pretty weird, suppress it for now
-    if op == torch.ops.aten.lift_fresh.default:
+    if op is torch.ops.aten.lift_fresh.default:
         return final_key
 
     def handler(*args: _P.args, **kwargs: _P.kwargs) -> _T:

--- a/torch/_dynamo/backends/common.py
+++ b/torch/_dynamo/backends/common.py
@@ -104,7 +104,7 @@ class AotAutograd:
 
         # debug asserts slow down compile time noticeably,
         # So only default them on when the aot_eager backend is used.
-        if self.kwargs.get("fw_compiler", None) == nop:
+        if self.kwargs.get("fw_compiler", None) is nop:
             patch_config: contextlib.AbstractContextManager[Any] = patch(
                 "functorch.compile.config.debug_assert", True
             )

--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -147,7 +147,7 @@ class NaNChecker:
             # so Compiled Autograd will always lift the param and
             # this should always be true
             assert (
-                param_node.target == operator.getitem
+                param_node.target is operator.getitem
                 and param_node.args[0] is inputs_node  # type: ignore[possibly-undefined]
                 and isinstance(param_node.args[1], int)
             )
@@ -997,7 +997,7 @@ class AutogradCompilerInstance:
         assert sizes_node.name == "sizes"
 
         for getitem_node in sizes_node.users.keys():
-            assert getitem_node.target == operator.getitem
+            assert getitem_node.target is operator.getitem
             if getitem_node.users:
                 used_sizes.append(getitem_node)
             else:
@@ -1159,7 +1159,7 @@ class AutogradCompilerInstance:
     def is_placeholder(node: torch.fx.Node) -> bool:
         if node.op == "placeholder" or (
             node.op == "call_function"
-            and node.target == operator.getitem
+            and node.target is operator.getitem
             and node.args[0].op == "placeholder"  # type: ignore[union-attr, arg-type]
         ):
             return True
@@ -1176,7 +1176,7 @@ class AutogradCompilerInstance:
         ):
             param_node, grad_node = node.args[0], node.args[1]
             getitem_node = None
-            if grad_node.target == operator.getitem:
+            if grad_node.target is operator.getitem:
                 getitem_node = grad_node
                 grad_node = getitem_node.args[0]
 
@@ -1279,7 +1279,7 @@ class AutogradCompilerInstance:
 
             # users are all getitem ops and they are used by same registered node
             assert all(
-                user.op == "call_function" and user.target == operator.getitem
+                user.op == "call_function" and user.target is operator.getitem
                 for user in users
             )
             registered_node = next(iter(users[0].users.keys()))
@@ -1357,7 +1357,7 @@ class AutogradCompilerInstance:
                     for user in list(input_node.users.keys())
                     if not (
                         user.op == "call_function"
-                        and user.target == call_hook
+                        and user.target is call_hook
                         and node.kwargs.get("hook_type", None) == "post_hook"
                     )
                 )

--- a/torch/_dynamo/graph_deduplication.py
+++ b/torch/_dynamo/graph_deduplication.py
@@ -529,7 +529,7 @@ def _is_tuple_node(node: Node) -> bool:
 
 def _get_children_getitems(node: Node) -> Generator[Node, None, None]:
     for user in node.users:
-        if user.target == operator.getitem and isinstance(user.args[1], int):
+        if user.target is operator.getitem and isinstance(user.args[1], int):
             yield user
 
 

--- a/torch/_export/pass_base.py
+++ b/torch/_export/pass_base.py
@@ -214,7 +214,7 @@ class _ExportPassBaseDeprecatedDoNotUse(PassBase):
         ) -> ProxyValue:
             meta = NodeMetadata(self.node.meta)
 
-            if target == operator.getitem:
+            if target is operator.getitem:
                 value, key = args
                 return self.callback.call_getitem(value, key, meta)
             elif getattr(target, "__module__", None) in {

--- a/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
+++ b/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
@@ -224,7 +224,7 @@ def _get_existing_inline_assertions(
             lhs = maybe_get_symint(lhs)
             rhs = maybe_get_symint(rhs)
 
-            if compare_op == operator.ge:
+            if compare_op is operator.ge:
                 lhs, rhs = rhs, lhs
 
             if isinstance(lhs, sympy.Symbol) and isinstance(rhs, int):

--- a/torch/_export/passes/collect_tracepoints_pass.py
+++ b/torch/_export/passes/collect_tracepoints_pass.py
@@ -130,7 +130,7 @@ class CollectTracepointsPass(PassBase):
                         if isinstance(arg, torch.fx.Node):
                             for user in node.users:
                                 assert user.op == "call_function"
-                                assert user.target == operator.getitem
+                                assert user.target is operator.getitem
                                 assert isinstance(user.args[1], int)
                                 if user.args[1] == i:
                                     user.replace_all_uses_with(arg)

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -3219,7 +3219,7 @@ def serialize(
 
 def _dict_to_dataclass(cls, data):
     assert not isinstance(cls, str), f"Unresolved class type: '{cls}'."
-    if typing.get_origin(cls) == Annotated:
+    if typing.get_origin(cls) is Annotated:
         return _dict_to_dataclass(cls.__origin__, data)
     if typing.get_origin(cls) == typing.Union and type(None) in typing.get_args(cls):
         if data is None:

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -850,7 +850,7 @@ def node_inline_(call_mod_node: torch.fx.Node) -> Optional[torch.fx.GraphModule]
                 get_item_users = nodes_filter(
                     list(call_mod_node.users.keys()),
                     lambda node: node.op == "call_function"
-                    and node.target == operator.getitem,
+                    and node.target is operator.getitem,
                 )
                 # get_item_node.args[1] is the idx referring to new_output[idx]
                 nodes_map(

--- a/torch/_functorch/_aot_autograd/utils.py
+++ b/torch/_functorch/_aot_autograd/utils.py
@@ -295,7 +295,7 @@ def unlift_tokens(fw_module, fw_metadata, aot_config, bw_module=None):
         for output_token_node in output_token_nodes:
             assert (
                 output_token_node.op == "call_function"
-                and output_token_node.target == operator.getitem
+                and output_token_node.target is operator.getitem
                 and output_token_node.args[1] == 0
             )
         with module.graph.inserting_before(node):
@@ -327,7 +327,7 @@ def unlift_tokens(fw_module, fw_metadata, aot_config, bw_module=None):
                     if (
                         isinstance(out, torch.fx.node.Node)
                         and out.op == "call_function"
-                        and out.target == operator.getitem
+                        and out.target is operator.getitem
                         and out.args[1] == 0
                         and out.args[0] in with_effect_nodes
                     ):

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -1096,7 +1096,7 @@ def default_partition(
         ):
             # Since we can't save tuple of tensor values, we need to flatten out what we're saving
             users = node.users
-            assert all(user.target == operator.getitem for user in users)
+            assert all(user.target is operator.getitem for user in users)
             saved_values.extend(users)
         else:
             backward_usages = [
@@ -1752,7 +1752,7 @@ def solve_min_cut(
     def should_ban_recomputation(node):
         if node.op != "call_function":
             return False
-        if node.target == operator.getitem:
+        if node.target is operator.getitem:
             return False
         if node.meta.get("recompute", None) == CheckpointPolicy.MUST_SAVE:
             return True

--- a/torch/_higher_order_ops/out_dtype.py
+++ b/torch/_higher_order_ops/out_dtype.py
@@ -106,7 +106,7 @@ def out_dtype_dense(op: torch._ops.OpOverload, output_dtype: torch.dtype, *args)
 
 def is_int_mm(op, output_dtype, args):
     return (
-        op == torch.ops.aten.mm.default
+        op is torch.ops.aten.mm.default
         and output_dtype == torch.int32
         and len(args) == 2
         and args[0].dtype == torch.int8

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -780,7 +780,7 @@ class DataTypePropagation:
             # we can infer output node if it only have 1 arg
             return None
 
-        if node.target == operator.getitem:
+        if node.target is operator.getitem:
             node_arg = node.args[0]
             assert isinstance(node_arg, torch.fx.Node), type(node_arg)
             return self.deduce_node_dtype(node_arg)

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -1187,7 +1187,7 @@ class CppVecOverrides(CppOverrides):
                     # 3. int32 and fp32 in test_torchinductor_dynamic_shapes.py::test_avg_pool2d8_dynamic_shapes_cpu
                     if len(new_args) == 2:
                         new_args = promote_args(new_args)
-                    elif func == CppVecOverrides.where:
+                    elif func is CppVecOverrides.where:
                         new_args[1:] = promote_args(new_args[1:])
 
                 # Broadcast scalar args to vector

--- a/torch/_inductor/comms.py
+++ b/torch/_inductor/comms.py
@@ -1606,7 +1606,7 @@ def reinplace_fsdp_all_gather(graph: torch.fx.Graph) -> None:
         node_list = list(g.nodes)
         for n in node_list:
             if (
-                n.target == operator.getitem
+                n.target is operator.getitem
                 and n.args[0].target is torch.ops.fsdp.all_gather_copy_in.default
                 and n.args[1] == 1
             ):

--- a/torch/_inductor/fx_passes/ddp_fusion.py
+++ b/torch/_inductor/fx_passes/ddp_fusion.py
@@ -97,7 +97,7 @@ def get_comm_block(comm_node: fx.Node) -> CommBlock | None:
         # Collective with only one output
         node_list = [comm_node, first_user]
         wait_nodes.append(first_user)
-    elif len(comm_node.users) > 1 and first_user.target == operator.getitem:
+    elif len(comm_node.users) > 1 and first_user.target is operator.getitem:
         # Collective with only more than one output
         node_list.append(comm_node)
         for user in comm_node.users:

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -71,9 +71,9 @@ def update_stack_example_value(node, metadata, dim=0, op=torch.stack):
     Update the example value of the node in the graph to enable followup split cat opt.
     """
     if node is not None and hasattr(node, "meta"):
-        if op == torch.stack:
+        if op is torch.stack:
             example_value = torch.stack(metadata, dim=dim)
-        elif op == torch.unbind:
+        elif op is torch.unbind:
             example_value = torch.unbind(metadata, dim=dim)  # type: ignore[assignment]
         else:
             return
@@ -85,9 +85,9 @@ def update_pointwise_example_value(pointwise_node, input, other, op):
     Update the example value of the add node in the graph to enable followup split cat opt.
     """
     if pointwise_node is not None and hasattr(pointwise_node, "meta"):
-        if op == torch.add:
+        if op is torch.add:
             example_value = torch.add(input, other)
-        elif op == torch.mul:
+        elif op is torch.mul:
             example_value = torch.mul(input, other)
         else:
             return
@@ -950,7 +950,7 @@ class BatchPointwiseOpsPreGradFusion(BatchPointwiseOpsFusionFactory):
                 torch.stack, args=(batch_inputs,), kwargs={"dim": 0}
             )
             update_stack_example_value(stack_inputs, batch_inputs_metadata)
-            if self.op == torch.nn.functional.relu:
+            if self.op is torch.nn.functional.relu:
                 batch_op = graph.call_function(  # type: ignore[operator]
                     self.op,
                     args=(stack_inputs,),

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -535,7 +535,7 @@ def canonicalize_quant_mapping(gm: torch.fx.GraphModule):
             if (
                 len(invoke_quant_replacement.users) == 1
                 and len(subgraph.users) == 1
-                and first_user.target == operator.getitem
+                and first_user.target is operator.getitem
                 and first_user.args[1] == 0
             ):
                 subgraph_graph = getattr(gm, subgraph.target)

--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -305,7 +305,7 @@ def should_pad_bench_key(
 
 
 def get_non_view_def(node: torch.fx.Node) -> torch.fx.Node:
-    if node.op == operator.getitem:
+    if node.op is operator.getitem:
         return get_non_view_def(node.args[0])  # type: ignore[arg-type]
 
     if (

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -442,7 +442,7 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
             src = node.args[1]
             # If the target is a getitem and it indexes a possible clone,
             # then skip over it
-            if src.target == operator.getitem and (
+            if src.target is operator.getitem and (
                 (
                     src.args[0].target == triton_kernel_wrapper_functional
                     and src.args[0].kwargs["kwargs"][src.args[1]] == node.args[0]
@@ -643,7 +643,7 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
                         # output atindex size(out)+i.
                         # This used to compare string with integers before for auto_functionalize_v2. Not sure
                         # if it was needed for inplaceable_triton_ops?
-                        if user.target == operator.getitem and user.args[1] == arg:
+                        if user.target is operator.getitem and user.args[1] == arg:
                             replace_dict[user] = mutated_arg
 
                 if isinstance(mutated_arg, (list, tuple)):

--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -2319,7 +2319,7 @@ def construct_cat_args(
 def remove_split_unbind_children(graph: torch.fx.Graph, inputs: list[torch.fx.Node]):
     nodes = OrderedSet[Any]()
     for input in inputs:
-        if input.target == operator.getitem:
+        if input.target is operator.getitem:
             nodes.add(input.args[0])  # type: ignore[union-attr]
         if len(input.users.keys()) == 0:
             graph.erase_node(input)
@@ -2757,7 +2757,7 @@ def get_view_shape_list(cat_arg: torch.fx.Node, stack_dim: int) -> list[int]:
     for user in cat_arg.users.keys():
         if user.target is torch.split:
             for getitem in user.users.keys():
-                if getitem.target == operator.getitem:
+                if getitem.target is operator.getitem:
                     reshape_user = [
                         user
                         for user in getitem.users.keys()
@@ -2931,7 +2931,7 @@ def move_view_after_cat(match: Match, *args, **kwargs):
     split_input, split_section, split_dim = _get_split_args_default(split_node)
     split_users = list(split_node.users.keys())
     getitem_indices = [
-        getitem.args[1] for getitem in split_users if getitem.target == operator.getitem
+        getitem.args[1] for getitem in split_users if getitem.target is operator.getitem
     ]
     if not is_sorted_and_consecutive(getitem_indices):  # type: ignore[arg-type]
         return
@@ -2956,7 +2956,7 @@ def move_view_after_cat(match: Match, *args, **kwargs):
             continue
         # check if the view nodes are all from getitem nodes
         if not all(
-            view_node.args[0].target == operator.getitem for view_node in cat_inputs
+            view_node.args[0].target is operator.getitem for view_node in cat_inputs
         ):
             continue
         view_indices = [view.args[0].args[1] for view in cat_inputs]
@@ -3037,7 +3037,7 @@ def replace_einsum_to_pointwise(match: Match, *args, **kwargs):
             and is_node_meta_valid(input)
             and is_node_meta_valid(weights)
             and any(
-                user.target == "add" or user.target == operator.add for user in users
+                user.target == "add" or user.target is operator.add for user in users
             )
             and match_einsum_strings(equation)
         )

--- a/torch/_inductor/fx_utils.py
+++ b/torch/_inductor/fx_utils.py
@@ -146,7 +146,7 @@ class FakeTensorUpdater:
                             (torch._ops.OpOverload, torch._ops.HigherOrderOperator),
                         )
                         or user.target
-                        == torch._inductor.fx_passes.reinplace._generalized_scatter
+                        is torch._inductor.fx_passes.reinplace._generalized_scatter
                     ):
                         return True
                     if isinstance(user.target, torch._ops.HigherOrderOperator):
@@ -200,9 +200,9 @@ class FakeTensorUpdater:
             # tensors from an op.
             return node.op == "call_function" and (
                 isinstance(node.target, torch._ops.OpOverload)
-                or node.target == operator.getitem
+                or node.target is operator.getitem
                 or node.target
-                == torch._inductor.fx_passes.reinplace._generalized_scatter
+                is torch._inductor.fx_passes.reinplace._generalized_scatter
             )
 
         to_process = OrderedSet[int]()

--- a/torch/_inductor/memory.py
+++ b/torch/_inductor/memory.py
@@ -928,7 +928,7 @@ def reorder_for_peak_memory(
     # other methods
     for method in methods:
         try:
-            if method == topological_sort_lpmf:
+            if method is topological_sort_lpmf:
                 order = method(
                     nodes, name_to_freeable_input_buf, name_to_buf, graph_outputs
                 )

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -2099,7 +2099,7 @@ def fx_to_pattern(
         ) -> PatternExpr:
             process_arg_fn = process_arg
             # Indexing is critical for matching getitem nodes, so we can't ignore int args here
-            if target == operator.getitem:
+            if target is operator.getitem:
 
                 def process_arg_fn_impl(
                     x: T,

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1665,7 +1665,7 @@ class FakeTensorMode(TorchDispatchMode):
         if torch.Tag.inplace_view in func.tags:
             raise _BypassDispatchCache("inplace view")
 
-        if func == aten._unsafe_view.default:
+        if func is aten._unsafe_view.default:
             raise _BypassDispatchCache("unsafe view")
 
         if func in self.lift_fns:
@@ -3231,7 +3231,7 @@ class FakeCopyMode(TorchFunctionMode):
             return func(
                 self.fake_mode.from_tensor(args[0], static_shapes=True), **kwargs
             )
-        elif func == Tensor.__deepcopy__:
+        elif func is Tensor.__deepcopy__:
             assert len(args) == 2 and len(kwargs) == 0
             tensor = cast(Tensor, args[0])
             memo = cast(dict[int, FakeTensor], args[1])

--- a/torch/ao/quantization/fx/utils.py
+++ b/torch/ao/quantization/fx/utils.py
@@ -706,7 +706,7 @@ def _maybe_get_custom_module_lstm_from_node_arg(
         return _is_custom_module_lstm(a, named_modules)
 
     def match_getitem(a):
-        return a.op == "call_function" and a.target == operator.getitem
+        return a.op == "call_function" and a.target is operator.getitem
 
     def match_tuple(a):
         return a.op == "call_function" and a.target is tuple
@@ -722,7 +722,7 @@ def _maybe_get_custom_module_lstm_from_node_arg(
                 return None
             # Match next arg, for tuple the arg is a tuple of a list, e.g. ([dq_1, other_node],)
             if i < len(match_pattern) - 1:
-                if match == match_tuple:
+                if match is match_tuple:
                     a = a.args[0][0]  # type: ignore[assignment,index]
                 else:
                     a = a.args[0]  # type: ignore[assignment]
@@ -810,7 +810,7 @@ def _reroute_tuple_getitem_pattern(graph: Graph):
                         find_patterns(
                             user, index_stack, current_pattern, matched_patterns, seen
                         )
-            elif user.op == "call_function" and user.target == operator.getitem:
+            elif user.op == "call_function" and user.target is operator.getitem:
                 if len(index_stack) > 0:
                     if user.args[1] == index_stack[-1]:
                         index_stack.pop()
@@ -837,7 +837,7 @@ def _reroute_tuple_getitem_pattern(graph: Graph):
             )
         if not (
             last_getitem.op == "call_function"
-            and last_getitem.target == operator.getitem
+            and last_getitem.target is operator.getitem
         ):
             raise AssertionError(
                 "last getitem node must be a call_function with target operator.getitem"

--- a/torch/ao/quantization/pt2e/duplicate_dq_pass.py
+++ b/torch/ao/quantization/pt2e/duplicate_dq_pass.py
@@ -64,7 +64,7 @@ class DuplicateDQPass(PassBase):
                     if (
                         isinstance(getitem_node, torch.fx.node.Node)
                         and getitem_node.op == "call_function"
-                        and getitem_node.target == operator.getitem
+                        and getitem_node.target is operator.getitem
                     ):
                         choose_qparam_node = getitem_node.args[0]
                         if (

--- a/torch/ao/quantization/pt2e/qat_utils.py
+++ b/torch/ao/quantization/pt2e/qat_utils.py
@@ -396,7 +396,7 @@ def _get_conv_bn_pattern_nodes(r: ReplacedPatterns) -> dict[str, tuple[Node, Nod
                         f"Found multiple bn nodes in match, previous: {bn_node}, new: {n}"
                     )
                 bn_node = n
-            if n.target == operator.getitem:
+            if n.target is operator.getitem:
                 if getitem_node is not None:
                     raise AssertionError(
                         f"Found multiple getitem nodes in match, previous: {getitem_node}, new: {n}"

--- a/torch/distributed/_tools/fake_collectives.py
+++ b/torch/distributed/_tools/fake_collectives.py
@@ -276,14 +276,14 @@ class CollectiveOp:
             return res.untyped_storage().nbytes()
         if func in CollectiveOp.COMM_TENSOR_SINGLE_UNTYPED_STORAGE:
             return args[0].untyped_storage().nbytes()
-        if func == c10d._reduce_scatter_base_.default:
+        if func is c10d._reduce_scatter_base_.default:
             return args[1].untyped_storage().nbytes()
-        if func == c10d.alltoall_.default:
+        if func is c10d.alltoall_.default:
             # TODO(@sanketpurandare) - Confirm size computation
             return max(
                 CollectiveOp.sum_tensors(args[0]), CollectiveOp.sum_tensors(args[1])
             )
-        if func == c10d.alltoall_base_.default:
+        if func is c10d.alltoall_base_.default:
             # TODO(@sanketpurandare) - Confirm size computation
             return max(
                 args[0].untyped_storage().nbytes(), args[1].untyped_storage().nbytes()

--- a/torch/distributed/_tools/fsdp2_mem_tracker.py
+++ b/torch/distributed/_tools/fsdp2_mem_tracker.py
@@ -525,7 +525,7 @@ class FSDPMemTracker(MemTracker):
             reftype = _FSDPRefType.TEMP
         else:
             reftype = _FSDPRefType.ACT
-        if func == c10d._allgather_base_.default and self._fsdp_state in [
+        if func is c10d._allgather_base_.default and self._fsdp_state in [
             _FSDPState.PRE_FW,
             _FSDPState.PRE_BW,
         ]:
@@ -537,7 +537,7 @@ class FSDPMemTracker(MemTracker):
                 update_existing=True,
             )
         if (
-            func == c10d._reduce_scatter_base_.default
+            func is c10d._reduce_scatter_base_.default
             and self._fsdp_state == _FSDPState.POST_BW
         ):
             # pyrefly: ignore [unsupported-operation]

--- a/torch/distributed/algorithms/_quantization/quantization.py
+++ b/torch/distributed/algorithms/_quantization/quantization.py
@@ -131,7 +131,7 @@ def auto_quantize(func, qtype, quant_loss=None):
             ):
                 tensors[i] = t
 
-        elif func == dist.all_to_all_single:
+        elif func is dist.all_to_all_single:
             tensors = args[0]
             out_splits = kwargs.get("out_splits")
             in_splits = kwargs.get("in_splits")

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2816,7 +2816,7 @@ def batch_isend_irecv(p2p_op_list: list[P2POp]) -> list[Work]:
     device = p2p_op_list[0].tensor.device
 
     def peer_kwarg(op: P2POp) -> dict[str, int]:
-        key = "group_dst" if op.op == isend else "group_src"
+        key = "group_dst" if op.op is isend else "group_src"
         return {key: op.group_peer}
 
     if type(group) is ProcessGroup and group._get_backend(device).supports_coalescing:

--- a/torch/distributed/pipelining/_IR.py
+++ b/torch/distributed/pipelining/_IR.py
@@ -133,7 +133,7 @@ def _insert_stage_symbolic_backward(
             # In the forward pass, only emit placeholder, module calls, and
             # getitem calls. If we have a target other than getitem in this
             # (forward-only) code, there is a bug.
-            assert node.target == operator.getitem, (
+            assert node.target is operator.getitem, (
                 "Found non-getitem call in forward pass. Please report a bug to PiPPy"
             )
             assert len(node.args) == 2, (
@@ -407,7 +407,7 @@ class DetachExecutor(fx.Interpreter):
 
     def call_function(self, target, args, kwargs):
         # HACK to reroute saved input tensors to point to the detach()ed version
-        if target == stage_backward:
+        if target is stage_backward:
             kwargs = dict(kwargs)
             kwargs["input_values"] = [
                 self.value_remap.get(v, v) for v in kwargs["input_values"]

--- a/torch/distributed/rpc/rref_proxy.py
+++ b/torch/distributed/rpc/rref_proxy.py
@@ -40,7 +40,7 @@ def _invoke_rpc(rref, rpc_api, func_name, timeout, *args, **kwargs):
 
     rref_fut = rref._get_type(timeout=timeout, blocking=False)
 
-    if rpc_api != rpc_async:
+    if rpc_api is not rpc_async:
         rref_fut.wait()
         return _rref_type_cont(rref_fut)
     else:

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -1060,10 +1060,10 @@ def _dtensor_init_helper(  # type: ignore[no-untyped-def]
     )
 
     # initialize the local tensor
-    if init_op == torch.full:
+    if init_op is torch.full:
         fill_value = kwargs.pop("fill_value", 0)
         local_tensor = init_op(local_shape, fill_value, **kwargs)
-    elif init_op == torch.rand or init_op == torch.randn:
+    elif init_op is torch.rand or init_op is torch.randn:
         # this tensor meta is not used except `shape`
         dtype = kwargs.get("dtype", torch.get_default_dtype())
 

--- a/torch/distributed/tensor/experimental/_tp_transform.py
+++ b/torch/distributed/tensor/experimental/_tp_transform.py
@@ -203,7 +203,7 @@ def _mark_sharding(
                 )
             node.meta["sharding"] = placement_strategies[node]
         elif node.op == "call_function":
-            if node.target == operator.getitem:
+            if node.target is operator.getitem:
                 input_nodes = node.all_input_nodes
                 assert len(input_nodes) == 1, (
                     f"non-compute op only support one input now, found node: {node} with length of inputs: {len(node.args)}"

--- a/torch/export/_remove_effect_tokens_pass.py
+++ b/torch/export/_remove_effect_tokens_pass.py
@@ -83,7 +83,7 @@ def _remove_effect_tokens_from_graph_helper(
 
         # Update user getitem nodes
         for user in list(new_node.users.keys()):
-            assert user.target == operator.getitem
+            assert user.target is operator.getitem
             # getitem(with_effects, 0) == token
             if user.args[1] == 0:
                 ep.graph.erase_node(user)

--- a/torch/export/_swap.py
+++ b/torch/export/_swap.py
@@ -26,7 +26,7 @@ def _get_getitem_users(node: torch.fx.Node) -> set[torch.fx.Node]:
         if user.op == "output":
             continue
 
-        assert user.op == "call_function" and user.target == operator.getitem, (
+        assert user.op == "call_function" and user.target is operator.getitem, (
             f"Expected getitem node as user for {node}, instead got {user}"
         )
         getitem_users.update(list(user.users.keys()))

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -817,7 +817,7 @@ def _common_getitem_elimination_pass(
             node_id: dict[torch.fx.Node, str] = {}
             getitems: dict[str, torch.fx.Node] = {}
             for node in list(module.graph.nodes):
-                if node.op == "call_function" and node.target == operator.getitem:
+                if node.op == "call_function" and node.target is operator.getitem:
                     source, idx = node.args
                     new_id = f"{node_id[source]}.{idx}"
                     if new_id in getitems:

--- a/torch/fx/experimental/accelerator_partitioner.py
+++ b/torch/fx/experimental/accelerator_partitioner.py
@@ -581,7 +581,7 @@ class Partitioner:
                 break
             if node.op in {"placeholder", "get_attr"}:
                 continue
-            if node.target == operator.__getitem__:
+            if node.target is operator.__getitem__:
                 continue
             input_nodes: dict[Node, None] = {}
             map_arg(node.args, input_nodes.setdefault)

--- a/torch/fx/experimental/migrate_gradual_types/constraint_generator.py
+++ b/torch/fx/experimental/migrate_gradual_types/constraint_generator.py
@@ -1050,9 +1050,9 @@ def gen_broadcasting_constraints(e1, e2, symbols, counter, output_var):
 @register_inference_rule(operator.add)
 def broadcasting_inference_rule(n: Node, symbols, constraints, counter):
     op_code = None
-    if n.target == operator.add or n.target is torch.add:
+    if n.target is operator.add or n.target is torch.add:
         op_code = op_add
-    elif n.target == operator.mul:
+    elif n.target is operator.mul:
         op_code = op_mul
 
     if isinstance(n.args[0], Node) and isinstance(n.args[1], Node):

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -1718,7 +1718,7 @@ class ProxyTorchDispatchMode(TorchDispatchMode):
     ) -> object:
         # Peephole optimize multiply by one
         # NB: be careful not to trigger guards here!
-        if func == operator.mul:
+        if func is operator.mul:
             if isinstance(args[1], int) and args[1] == 1:
                 return args[0]
             elif isinstance(args[0], int) and args[0] == 1:

--- a/torch/fx/experimental/validator.py
+++ b/torch/fx/experimental/validator.py
@@ -357,7 +357,7 @@ try:
         def call_function(
             self, target: Target, args: tuple[Argument, ...], kwargs: dict[str, Any]
         ) -> Any:
-            if target != torch._assert:
+            if target is not torch._assert:
                 # Lift and runs the node target function
                 return super().call_function(z3op(target, self.validator), args, kwargs)  # type: ignore[arg-type]
             # Adds the Z3 expression corresponding to the first argument

--- a/torch/fx/passes/annotate_getitem_nodes.py
+++ b/torch/fx/passes/annotate_getitem_nodes.py
@@ -16,7 +16,7 @@ def annotate_getitem_nodes(graph: torch.fx.Graph) -> None:
         graph (Graph): The graph to be annotated
     """
     for node in graph.nodes:
-        if node.target == operator.getitem:
+        if node.target is operator.getitem:
             sequence_node, index_node = node.args
             if not sequence_node.type:
                 continue

--- a/torch/fx/passes/backends/cudagraphs.py
+++ b/torch/fx/passes/backends/cudagraphs.py
@@ -18,7 +18,7 @@ class CudaGraphsSupport(OperatorSupport):
         if node.target is torch.ops.aten.embedding_dense_backward.default:
             return False
 
-        if node.target == operator.getitem:
+        if node.target is operator.getitem:
             return True
 
         found_not_cuda = False

--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -909,7 +909,7 @@ if _enabled:
             self_method = self.__dir__
             if (
                 self_method.__func__  # type: ignore[attr-defined]
-                == _get_function_from_type(RecursiveScriptModule, "__dir__")
+                is _get_function_from_type(RecursiveScriptModule, "__dir__")
             ):
                 return super().__dir__()
             return self_method()
@@ -921,7 +921,7 @@ if _enabled:
             self_method = self.__bool__
             if (
                 self_method.__func__  # type: ignore[attr-defined]
-                == _get_function_from_type(RecursiveScriptModule, "__bool__")
+                is _get_function_from_type(RecursiveScriptModule, "__bool__")
             ):
                 return True
             return self_method()

--- a/torch/nn/utils/_expanded_weights/conv_utils.py
+++ b/torch/nn/utils/_expanded_weights/conv_utils.py
@@ -14,12 +14,12 @@ THRESHOLD = 32
 
 
 def conv_picker(func, conv1dOpt, conv2dOpt, conv3dOpt):
-    if func == F.conv1d:
+    if func is F.conv1d:
         return conv1dOpt
-    if func == F.conv2d:
+    if func is F.conv2d:
         return conv2dOpt
     else:
-        assert func == F.conv3d
+        assert func is F.conv3d
         return conv3dOpt
 
 

--- a/torch/onnx/_internal/exporter/_core.py
+++ b/torch/onnx/_internal/exporter/_core.py
@@ -392,7 +392,7 @@ def _handle_call_function_node(
         node: The FX node to translate.
         node_name_to_values: A mapping of FX node names to their produced ir.Value.
     """
-    if node.target == operator.getitem:
+    if node.target is operator.getitem:
         _handle_getitem_node(node, node_name_to_values)
     # Add op to the graph
     op = str(node.target)
@@ -402,7 +402,7 @@ def _handle_call_function_node(
         if input_ is None:
             inputs.append(None)
         elif hasattr(input_, "name"):
-            if isinstance(input_, torch.fx.Node) and input_.target == operator.getitem:
+            if isinstance(input_, torch.fx.Node) and input_.target is operator.getitem:
                 actual_input = _handle_getitem_node(input_, node_name_to_values)
                 inputs.append(actual_input)
             else:
@@ -527,7 +527,7 @@ def _handle_call_function_node_with_lowering(
         opset: The ONNX Script opset object for constructing ONNX nodes.
         node_name_to_local_functions: A mapping of subgraph names to the corresponding ONNX functions.
     """
-    if node.target == operator.getitem:
+    if node.target is operator.getitem:
         source = node.all_input_nodes[0]
         source_outputs = node_name_to_values[source.name]
         if isinstance(source_outputs, Sequence):

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -1657,7 +1657,8 @@ def _get_overloaded_args(
         if (
             arg_type not in overloaded_types
             and hasattr(arg_type, "__torch_function__")
-            and arg_type.__torch_function__ != torch._C._disabled_torch_function_impl
+            and arg_type.__torch_function__
+            is not torch._C._disabled_torch_function_impl
         ):
             # Create lists explicitly for the first type (usually the only one
             # done) to avoid setting up the iterator for overloaded_args.

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -6467,7 +6467,7 @@ class DistributedTest:
         def _run_reduction_test(
             self, tensor, expected_tensor, op, reduction_fn=dist.all_reduce, dst=None
         ):
-            if reduction_fn != dist.all_reduce and dst is None:
+            if reduction_fn is not dist.all_reduce and dst is None:
                 raise ValueError(f"Reduction fn {reduction_fn} must specify dst!")
             if dst is not None:
                 reduction_fn(tensor, dst, op)

--- a/torch/testing/_internal/opinfo/definitions/special.py
+++ b/torch/testing/_internal/opinfo/definitions/special.py
@@ -42,7 +42,7 @@ if TEST_SCIPY:
 #       supports `exclude` argument.
 #       For more context: https://github.com/pytorch/pytorch/pull/56352#discussion_r633277617
 def sample_inputs_i0_i1(op_info, device, dtype, requires_grad, **kwargs):
-    exclude_zero = requires_grad and op_info.op == torch.special.i0e
+    exclude_zero = requires_grad and op_info.op is torch.special.i0e
     make_arg = partial(
         make_tensor,
         dtype=dtype,

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1518,7 +1518,7 @@ def _checkpoint_without_reentrant_generator(
     device_type = _infer_device_type(*args)
     device_module = _get_device_module(device_type)
     forward_context, recompute_context = context_fn()
-    if _is_compiling(fn, args, kwargs) and context_fn != noop_context_fn:
+    if _is_compiling(fn, args, kwargs) and context_fn is not noop_context_fn:
         if (
             not isinstance(forward_context, TorchDispatchMode)
             or not isinstance(recompute_context, TorchDispatchMode)


### PR DESCRIPTION
It is generally advised to use `is/is not` for comparisons against torch functions.



cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @EikanWang @jgong5 @wenzhe-nrv @sanchitintel @ezyang @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @Lucaskabela @xmfan