### PR TITLE
[fx] Add strict argument validation to Interpreter.boxed_run

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -2032,6 +2032,31 @@ class TestFX(JitTestCase):
         self.assertEqual(interpreter.run(input), gm(input))
         self.assertEqual(interpreter.run(input), m(input))
 
+    def test_interpreter_boxed_run_argument_validation(self):
+        class AddModule(torch.nn.Module):
+            def forward(self, lhs, rhs):
+                return lhs + rhs
+
+        gm = torch.fx.symbolic_trace(AddModule())
+        interpreter = Interpreter(gm)
+
+        lhs = torch.tensor(1.0)
+        rhs = torch.tensor(2.0)
+        good_args = [lhs.clone(), rhs.clone()]
+        result = interpreter.boxed_run(good_args)
+        torch.testing.assert_close(result, lhs + rhs)
+        self.assertEqual(good_args, [])
+
+        extra_args = [lhs.clone(), rhs.clone(), torch.tensor(3.0)]
+        with self.assertRaisesRegex(RuntimeError, "extra arguments"):
+            interpreter.boxed_run(extra_args)
+        self.assertEqual(len(extra_args), 3)
+
+        missing_args = [lhs.clone()]
+        with self.assertRaisesRegex(RuntimeError, "missing arguments"):
+            interpreter.boxed_run(missing_args)
+        self.assertEqual(len(missing_args), 1)
+
     def test_interpreter_other_graph(self):
         class MyModule(torch.nn.Module):
             def __init__(self) -> None:

--- a/torch/fx/interpreter.py
+++ b/torch/fx/interpreter.py
@@ -220,22 +220,19 @@ class Interpreter:
         calling convention, where you pass a list of arguments, which will be cleared
         by the interpreter.  This ensures that input tensors are promptly deallocated.
         """
-        args_iter = iter(args_list)
-        env = {}
-        try:
-            for n in self.graph.nodes:
-                if n.op == "placeholder":
-                    env[n] = next(args_iter)
-        except StopIteration as e:
+        # Collect placeholder nodes first
+        placeholder_nodes = [n for n in self.graph.nodes if n.op == "placeholder"]
+
+        # Check argument count
+        if len(args_list) != len(placeholder_nodes):
+            detail = "extra arguments" if len(args_list) > len(placeholder_nodes) else "missing arguments"
             raise RuntimeError(
-                f"Interpreter.boxed_run expected {len(env) + 1} arguments for placeholders "
-                f"but received {len(args_list)} (missing arguments)"
-            ) from e
-        if len(args_list) != len(env):
-            raise RuntimeError(
-                f"Interpreter.boxed_run expected {len(env)} arguments for placeholders "
-                f"but received {len(args_list)} (extra arguments)"
+                f"Interpreter.boxed_run expected {len(placeholder_nodes)} arguments for placeholders "
+                f"but received {len(args_list)} ({detail})"
             )
+
+        # Assign arguments to placeholders
+        env = dict(zip(placeholder_nodes, args_list))
         args_list.clear()
         return self.run(initial_env=env)
 

--- a/torch/fx/interpreter.py
+++ b/torch/fx/interpreter.py
@@ -225,7 +225,11 @@ class Interpreter:
 
         # Check argument count
         if len(args_list) != len(placeholder_nodes):
-            detail = "extra arguments" if len(args_list) > len(placeholder_nodes) else "missing arguments"
+            detail = (
+                "extra arguments"
+                if len(args_list) > len(placeholder_nodes)
+                else "missing arguments"
+            )
             raise RuntimeError(
                 f"Interpreter.boxed_run expected {len(placeholder_nodes)} arguments for placeholders "
                 f"but received {len(args_list)} ({detail})"


### PR DESCRIPTION
# Summary

This PR fixes an issue where `torch.fx.Interpreter.boxed_run` would silently ignore extra input arguments instead of validating the argument count.

Previously, `boxed_run` would only consume as many inputs as there were placeholder nodes and then clear the entire `args_list`, hiding potential bugs. This change introduces a strict check to ensure `len(args_list)` matches the number of placeholder nodes, raising a `RuntimeError` on a mismatch.

Fixes #166583.

# Changes

* Validate `len(args_list)` against the number of placeholder nodes at the beginning of `boxed_run`.
* Raise a `RuntimeError` with a clear message ("extra arguments" or "missing arguments") if the counts do not match.
* Move `args_list.clear()` to only execute after successful validation and environment setup. If an error is raised, `args_list` is preserved for debugging.

# Testing

* Added `test_interpreter_boxed_run_argument_validation` to `test/test_fx.py`.
* This test covers three scenarios:
    1.  Correct number of arguments (succeeds, `args_list` is cleared).
    2.  Extra arguments (raises `RuntimeError`, `args_list` is preserved).
    3.  Missing arguments (raises `RuntimeError`, `args_list` is preserved).

# User-facing impact / BC notes

This is a bug fix. Code that was incorrectly passing the wrong number of arguments to `boxed_run` will now fail fast with a `RuntimeError` instead of executing silently with unintended inputs. Correctly written code is unaffected.


cc @ezyang @EikanWang @jgong5 @wenzhe-nrv @chauhang @penguinwu @xmfan 