### PR TITLE
Add conv_3d_configs_long for comprehensive Conv3d benchmark coverage

### DIFF
--- a/benchmarks/operator_benchmark/pt/configs.py
+++ b/benchmarks/operator_benchmark/pt/configs.py
@@ -1,6 +1,5 @@
 import operator_benchmark as op_bench
 
-
 """
 Configs shared by multiple benchmarks
 """
@@ -128,6 +127,19 @@ conv_3d_configs_short = op_bench.config_list(
     tags=["short"],
 )
 
+conv_3d_configs_long = op_bench.cross_product_configs(
+    IC=[32, 64],
+    OC=[32, 64],
+    kernel=[3],
+    stride=[1, 2],
+    N=[4, 8],
+    D=[8, 16],
+    H=[16, 32],
+    W=[16, 32],
+    device=["cpu", "cuda"],
+    tags=["long"],
+)
+
 linear_configs_short = op_bench.config_list(
     attr_names=["N", "IN", "OUT"],
     attrs=[
@@ -140,7 +152,6 @@ linear_configs_short = op_bench.config_list(
     },
     tags=["short"],
 )
-
 
 linear_configs_long = op_bench.cross_product_configs(
     N=[32, 64], IN=[128, 512], OUT=[64, 128], device=["cpu", "cuda"], tags=["long"]


### PR DESCRIPTION
This PR adds conv_3d_configs_long configuration to provide comprehensive benchmark coverage for Conv3d operations.

The new configuration includes:
- Input channels (IC): [32, 64]
- Output channels (OC): [32, 64]
- Kernel size: [3]
- Stride: [1, 2]
- Batch size (N): [4, 8]
- Depth (D): [8, 16]
- Height (H): [16, 32]
- Width (W): [16, 32]
- Devices: ["cpu", "cuda"]
- Tags: ["long"]

This follows the same pattern as other long configs in the file and provides more comprehensive coverage for 3D convolution benchmarks.