### PR TITLE
[ROCm] Optimization of Grid Sampler 2D backward

### DIFF
--- a/aten/src/ATen/native/cuda/GridSampler.cu
+++ b/aten/src/ATen/native/cuda/GridSampler.cu
@@ -301,9 +301,6 @@ namespace {
     }
   }
 
-// Note [Passing pointer and offset to fastAtomicAdd]
-// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 // ROCm-specific 2D backward kernel for grid_sample
 // - The default kernel launches N*H*W threads and loops over C.
 // - On MI300X / MI325X that "the loop over C + 4 atomics per C" is the bottleneck.
@@ -545,6 +542,8 @@ namespace {
   }
 #endif  // USE_ROCM
 
+// Note [Passing pointer and offset to fastAtomicAdd]
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // For its internal bounds checking, fastAtomicAdd needs to know where the destination address
 // lies relative to the entire tensor, so we pass the base grad_input.data and full offset information,
 // including batch * channel offset (NC_offset).

--- a/aten/src/ATen/native/cuda/KernelUtils.cuh
+++ b/aten/src/ATen/native/cuda/KernelUtils.cuh
@@ -260,6 +260,13 @@ __device__ inline void cmtdStore(void* address, T value) {
 // We identify all the threads within a warp that will perform an atomicAdd on the same destination
 // address and perform the addition on the CU. Each warp elects a leader thread which does the
 // atomicAdd to the destination address.
+//
+// Warp local "reduce-by-key":
+// - Each lane provides (index, value); -1 marks out-of-bounds, so no-op.
+// - The standard "warp-aggregated atomics" technique: the ballot (activemask) / shuffle / leader pattern
+//   - Group lanes that target the same (flat) index.
+//   - Lanes in the same group (with the same index) are detected with ballot (activemask) and their values are summed via shuffles.
+//   - A single elected leader lane issues a single global atomic for the group.
 template <class scalar_t, class index_t>
 __device__ __forceinline__ void opportunistic_fastAtomicAdd(
     scalar_t* self_ptr,


### PR DESCRIPTION
Single thread owning (n, c, h, w) instead of original (n, h, w), so avoiding looping over c...C-1, so each thread doing only 4 atomics instead of 4*C, and only channel-0 doing "sum over C". This way in the hope that precision issue could get gone.

A further effort trying rectifying https://github.com/pytorch/pytorch/pull/165337.

More details coming soon.

2nd iteration of another (relatively minor) optimization:

GridSampler backward may generate many atomics to the same grad_input addresses when threads in a warp sample nearby source pixels. On MI300X/MI325X, pre-aggregating identical targets within a warp and issuing a single global atomic per unique address can cut the number of atomics and improve throughput.

The key technique is performing a warp-local reduce-by-key using registers + warp intrinsics (`__ballot`/`__activemask`, `__shfl`, `__ffsll) and then a single global atomic by the elected lane. For each neighbor contribution we compute the flat target index, and within a warp we group lanes with the same index (using `__ballot`/`__activemask` + leader election), sum their values with `__shfl`, and have the leader issue one global atomic add.
Refs:
https://developer.nvidia.com/blog/cuda-pro-tip-optimized-filtering-warp-aggregated-atomics/
https://developer.nvidia.com/blog/voting-and-shuffling-optimize-atomic-operations/
https://www.olcf.ornl.gov/wp-content/uploads/2019/12/05_Atomics_Reductions_Warp_Shuffle.pdf

This PR uses warp-local (register + shuffles) aggregation, which is a cheaper form of "LDS aggregation" in practice because it doesn't actually allocate LDS (no bank conflicts, no extra sync).

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @dllehr-amd