### PR TITLE
[xpu][fix] Fix XPU oneDNN memory query bug: pointer to array

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -178,7 +178,8 @@ bool onednn_strides_check(const Tensor& src) {
 
   // A custom comparator to yield linear order on perm
   auto idx_sorter = [&](const int a, const int b) -> bool {
-    if (strides[a] == strides[b] && (*md_padded_dims)[a] == (*md_padded_dims)[b])
+    if (strides[a] == strides[b] &&
+        (*md_padded_dims)[a] == (*md_padded_dims)[b])
       return a < b;
     else if (strides[a] == strides[b])
       return (*md_padded_dims)[a] < (*md_padded_dims)[b];

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -160,7 +160,7 @@ bool onednn_strides_check(const Tensor& src) {
   int perm[DNNL_MAX_NDIMS] = {0};
   for (int d = 0; d < md_ndims; ++d) {
     // no strides check needed for empty tensor
-    if ((*md_padded_dims)[d] == nullptr)
+    if ((*md_padded_dims)[d] == 0)
       return true;
 
     // no strides verification for runtime dims

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -144,7 +144,6 @@ bool onednn_strides_check(const Tensor& src) {
   dnnl_memory_desc_query(md, dnnl_query_format_kind, &md_fmt_kind);
   dnnl_memory_desc_query(md, dnnl_query_ndims_s32, &md_ndims);
   dnnl_memory_desc_query(md, dnnl_query_padded_dims, &md_padded_dims);
-  auto block_size = 1;
   // const auto& blk = md->format_desc.blocking;
   dnnl_dims_t md_inner_blks;
   dnnl_dims_t md_blk_inner_idxs;

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -157,7 +157,7 @@ bool onednn_strides_check(const Tensor& src) {
     return true;
 
   dnnl_dims_t blocks = {0};
-  int perm[DNNL_MAX_NDIMS] = {0};
+  std::array<int, DNNL_MAX_NDIMS> perm = {0};
   for (int d = 0; d < md_ndims; ++d) {
     // no strides check needed for empty tensor
     if ((*md_padded_dims)[d] == 0)

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -186,7 +186,7 @@ bool onednn_strides_check(const Tensor& src) {
     else
       return strides[a] < strides[b];
   };
-  std::sort(perm, perm + md_ndims, idx_sorter);
+  std::sort(perm.begin(), perm.begin() + md_ndims, idx_sorter);
 
   auto min_stride = block_size;
   for (int idx = 0; idx < md_ndims; ++idx) {

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -160,7 +160,7 @@ bool onednn_strides_check(const Tensor& src) {
   int perm[DNNL_MAX_NDIMS] = {0};
   for (int d = 0; d < md_ndims; ++d) {
     // no strides check needed for empty tensor
-    if (md_padded_dims[d] == nullptr)
+    if ((*md_padded_dims)[d] == 0)
       return true;
 
     // no strides verification for runtime dims
@@ -178,10 +178,10 @@ bool onednn_strides_check(const Tensor& src) {
 
   // A custom comparator to yield linear order on perm
   auto idx_sorter = [&](const int a, const int b) -> bool {
-    if (strides[a] == strides[b] && md_padded_dims[a] == md_padded_dims[b])
+    if (strides[a] == strides[b] && (*md_padded_dims)[a] == (*md_padded_dims)[b])
       return a < b;
     else if (strides[a] == strides[b])
-      return md_padded_dims[a] < md_padded_dims[b];
+      return (*md_padded_dims)[a] < (*md_padded_dims)[b];
     else
       return strides[a] < strides[b];
   };
@@ -199,7 +199,7 @@ bool onednn_strides_check(const Tensor& src) {
       return false;
 
     // update min_stride for next iteration
-    const auto padded_dim = *md_padded_dims[d];
+    const auto padded_dim = (*md_padded_dims)[d];
     min_stride = block_size * strides[d] * (padded_dim / blocks[d]);
   }
   return true;

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -144,6 +144,7 @@ bool onednn_strides_check(const Tensor& src) {
   dnnl_memory_desc_query(md, dnnl_query_format_kind, &md_fmt_kind);
   dnnl_memory_desc_query(md, dnnl_query_ndims_s32, &md_ndims);
   dnnl_memory_desc_query(md, dnnl_query_padded_dims, &md_padded_dims);
+  auto block_size = 1;
   // const auto& blk = md->format_desc.blocking;
   dnnl_dims_t md_inner_blks;
   dnnl_dims_t md_blk_inner_idxs;
@@ -155,9 +156,53 @@ bool onednn_strides_check(const Tensor& src) {
       md_fmt_kind != dnnl_format_kind_t::dnnl_blocked)
     return true;
 
-  TORCH_INTERNAL_ASSERT(
-      false,
-      "XPU backend does not support block format, this code path should be unreachable.");
+  dnnl_dims_t blocks = {0};
+  int perm[DNNL_MAX_NDIMS] = {0};
+  for (int d = 0; d < md_ndims; ++d) {
+    // no strides check needed for empty tensor
+    if ((*md_padded_dims)[d] == nullptr)
+      return true;
+
+    // no strides verification for runtime dims
+    if (strides[d] == DNNL_RUNTIME_DIM_VAL)
+      return true;
+
+    perm[d] = d;
+    blocks[d] = 1;
+  }
+
+  for (int iblk = 0; iblk < md_inner_nblks; ++iblk) {
+    blocks[md_blk_inner_idxs[iblk]] *= md_inner_blks[iblk];
+    block_size *= md_inner_blks[iblk];
+  }
+
+  // A custom comparator to yield linear order on perm
+  auto idx_sorter = [&](const int a, const int b) -> bool {
+    if (strides[a] == strides[b] &&
+        (*md_padded_dims)[a] == (*md_padded_dims)[b])
+      return a < b;
+    else if (strides[a] == strides[b])
+      return (*md_padded_dims)[a] < (*md_padded_dims)[b];
+    else
+      return strides[a] < strides[b];
+  };
+  std::sort(perm, perm + md_ndims, idx_sorter);
+
+  auto min_stride = block_size;
+  for (int idx = 0; idx < md_ndims; ++idx) {
+    const int d = perm[idx];
+
+    // Make an exception for strides[d] == 0 as it has broadcast semantics
+    // Note: owing to being sorted, these are the initial strides
+    if (strides[d] == 0)
+      continue;
+    else if (strides[d] < min_stride)
+      return false;
+
+    // update min_stride for next iteration
+    const auto padded_dim = (*md_padded_dims)[d];
+    min_stride = block_size * strides[d] * (padded_dim / blocks[d]);
+  }
 
   return true;
 }

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -156,53 +156,10 @@ bool onednn_strides_check(const Tensor& src) {
       md_fmt_kind != dnnl_format_kind_t::dnnl_blocked)
     return true;
 
-  dnnl_dims_t blocks = {0};
-  int perm[DNNL_MAX_NDIMS] = {0};
-  for (int d = 0; d < md_ndims; ++d) {
-    // no strides check needed for empty tensor
-    if ((*md_padded_dims)[d] == 0)
-      return true;
+  TORCH_INTERNAL_ASSERT(
+      false,
+      "XPU backend does not support block format, this code path should be unreachable.");
 
-    // no strides verification for runtime dims
-    if (strides[d] == DNNL_RUNTIME_DIM_VAL)
-      return true;
-
-    perm[d] = d;
-    blocks[d] = 1;
-  }
-
-  for (int iblk = 0; iblk < md_inner_nblks; ++iblk) {
-    blocks[md_blk_inner_idxs[iblk]] *= md_inner_blks[iblk];
-    block_size *= md_inner_blks[iblk];
-  }
-
-  // A custom comparator to yield linear order on perm
-  auto idx_sorter = [&](const int a, const int b) -> bool {
-    if (strides[a] == strides[b] &&
-        (*md_padded_dims)[a] == (*md_padded_dims)[b])
-      return a < b;
-    else if (strides[a] == strides[b])
-      return (*md_padded_dims)[a] < (*md_padded_dims)[b];
-    else
-      return strides[a] < strides[b];
-  };
-  std::sort(perm, perm + md_ndims, idx_sorter);
-
-  auto min_stride = block_size;
-  for (int idx = 0; idx < md_ndims; ++idx) {
-    const int d = perm[idx];
-
-    // Make an exception for strides[d] == 0 as it has broadcast semantics
-    // Note: owing to being sorted, these are the initial strides
-    if (strides[d] == 0)
-      continue;
-    else if (strides[d] < min_stride)
-      return false;
-
-    // update min_stride for next iteration
-    const auto padded_dim = (*md_padded_dims)[d];
-    min_stride = block_size * strides[d] * (padded_dim / blocks[d]);
-  }
   return true;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #166847
* #166861
* __->__ #166830

# Motivation

I believe this is a bug - here's why:
In [dnnl_common_types.h](https://github.com/uxlfoundation/oneDNN/blob/98132c49080c19caffee1f7ba65be83339cba985/include/oneapi/dnnl/dnnl_common_types.h#L116-L125) is defined as a pointer to an `int64_t[12]` array;
We can confirm this from the implementation in [memory_desc.cpp](https://github.com/uxlfoundation/oneDNN/blob/98132c49080c19caffee1f7ba65be83339cba985/src/common/memory_desc.cpp#L746-L748) where the member indeed points to an internal array.

# Solution

Therefore, when accessing `md_padded_dims`, we should first dereference the pointer and then use it with an index - directly using it without dereferencing would corrupt memory.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @gujinghui @EikanWang @fengyuan14