### PR TITLE
[xpu][fix]Remove useless onednn_strides_check utils

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
@@ -39,7 +39,6 @@ dnnl::memory::dims get_onednn_dims(const at::Tensor& tensor);
 dnnl::memory::dims get_onednn_strides(const at::Tensor& tensor);
 dnnl::memory::desc get_onednn_md(const at::Tensor& tensor);
 
-bool onednn_strides_check(const at::Tensor& src);
 bool is_broadcast(const at::Tensor& t);
 void undo_broadcast_on_batch(at::Tensor& m1, at::Tensor& m2);
 void undo_broadcast(at::Tensor& tensor);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #166847
* #166861
* #166830

# Motivation
`onednn_strides_check` is a useless utility and introduces host overhead. 

# Solution
Let's remove it and could add back when we need to support block format.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @gujinghui @EikanWang @fengyuan14