### PR TITLE
[ROCm][CI] Change rocm.yml and inductor-rocm.yml cron schedule to run every hour

### DIFF
--- a/.github/workflows/inductor-rocm.yml
+++ b/.github/workflows/inductor-rocm.yml
@@ -1,9 +1,10 @@
 name: inductor-rocm
 
 on:
+  schedule:
+    - cron: 0 * * * *
   push:
     branches:
-      - main
       - release/*
     tags:
       - ciflow/inductor-rocm/*

--- a/.github/workflows/rocm.yml
+++ b/.github/workflows/rocm.yml
@@ -3,13 +3,13 @@ name: rocm
 on:
   push:
     branches:
-      - main
       - release/*
     tags:
       - ciflow/rocm/*
   workflow_dispatch:
   schedule:
     - cron: 29 8 * * *  # about 1:29am PDT
+    - cron: 0 * * * *
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}


### PR DESCRIPTION
Temporary PR to change the rocm.yml and inductor-rocm.yml workflows to run on an hourly basis rather than on every commit. This is caused by the following:

We are observing cirrascale network timeouts as of 11/03/2025. [HUD Link](https://hud.pytorch.org/hud/pytorch/pytorch/94f2657c4b534136aa8958bc35d44ceac5ccd60c/1?per_page=50&name_filter=rocm&mergeEphemeralLF=true)
[SEV](https://github.com/pytorch/pytorch/issues/166866)


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd