### PR TITLE
Fixes: Node arguments contain sym int size which can be either declared in future or in backward graph

### DIFF
--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -815,6 +815,24 @@ class TestInductorDynamic(TestCase):
         actual = cfn(5)
         self.assertEqual(expect, actual)
 
+    def test_replace_future_symints_with_constants(self, device):
+        def fn(arg0, sentinel):
+            t0 = arg0
+            t1 = t0.clone()
+            t1.zero_()
+            t2 = t1.contiguous().view((34, 9, 77))
+            t3 = t2.clone()
+            t3.zero_()
+            output = t3 + sentinel
+            return output
+
+        cfn = self.compile_fn(fn)
+        arg0 = torch.rand([714, 33], dtype=torch.float16, device=device)
+        sentinel = torch.rand([34, 9, 77], dtype=torch.float16, device=device)
+        expect = fn(arg0, sentinel)
+        actual = cfn(arg0, sentinel)
+        self.assertEqual(expect, actual)
+
     def test_interpolate_ceil_eq(self, device):
         ceiling = math.ceil
         IntTrueDiv = operator.truediv

--- a/test/test_torchfuzz_repros.py
+++ b/test/test_torchfuzz_repros.py
@@ -73,32 +73,6 @@ class TestFuzzerCompileIssues(TestCase):
         out_compiled.sum().backward()
         print("Compile Success! ✅")
 
-    @pytest.mark.xfail(reason="Issue #164186")
-    def test_fuzzer_issue_164186(self):
-        torch.manual_seed(0)
-
-        def foo(arg0):
-            t0 = arg0  # size=(714, 33), stride=(33, 1), dtype=float16, device=cuda
-            t1 = t0.clone()
-            t1.zero_()
-            t2 = t1.contiguous().view((34, 9, 77))
-            t3 = t2.clone()
-            t3.zero_()
-            output = t3
-            return output
-
-        arg0 = torch.rand(
-            [714, 33], dtype=torch.float16, device="cuda", requires_grad=True
-        )
-
-        out_eager = foo(arg0)
-        out_eager.sum().backward()
-        print("Eager Success! ✅")
-        compiled_foo = torch.compile(foo, fullgraph=True, dynamic=True)
-        out_compiled = compiled_foo(arg0)
-        out_compiled.sum().backward()
-        print("Compile Success! ✅")
-
     @pytest.mark.xfail(reason="Issue #164185")
     def test_fuzzer_issue_164185(self):
         torch.manual_seed(0)


### PR DESCRIPTION
Fixes #164186 

Sym Int size can be used in node to define size which have been either declared in future or in backward graph. This can result in output as InvalidNode or sym size used before declaration. 

If they have been provided as arg to forward function or some declaration then they would be considered as primals (or placeholders). Therefore only possibility is to consider them as constant or unbacked Sym int.  Unbacked Sym int is not considered in this PR as inductor is not able to support unbacked sym int size yet and would probably be a feature enhancement.

Below is example  graph seen after aot from the script mentioned in issue 164186:

Model Tried:

```
def foo(arg0, sentinel):
    t0 = arg0 # size=(714, 33), stride=(33, 1), dtype=float16, device=cuda
    t1 = t0.clone(); t1.zero_() # size=(714, 33), stride=(33, 1), dtype=float16, device=cuda
    # t1 = torch.zeros_like(t0)
    t2 = t1.contiguous().view((34, 9, 77)) # size=(34, 9, 77), stride=(693, 77, 1), dtype=float16, device=cuda
    t3 = t2.clone(); t3.zero_() # size=(34, 9, 77), stride=(693, 77, 1), dtype=float16, device=cuda
    # t3 = torch.zeros_like(t2)
    output = t3 + sentinel  # output tensor with sentinel for gradient flow
    return output
```

Post AOT grad
```
 def forward(self, primals_1: "Sym(s14)", primals_2: "Sym(s46)", primals_3: "f16[s14, s46][s46, 1]cpu", primals_4: "f16[][]cpu"):
           full_default: "f16[34, 9, 77][693, 77, 1]cpu" = torch.ops.aten.full.default([34, 9, 77], 0.0, dtype = torch.float16, layout = torch.strided, device = device(type='cpu'), pin_memory = False)
          sym_size_int_3: "Sym(((s46*((s14//34)))//9))" = torch.ops.aten.sym_size.int(full_default, 2);  full_default = None
          full_default_1: "f16[34, 9, 77][693, 77, 1]cpu" = torch.ops.aten.full.default([34, 9, sym_size_int_3], 0, dtype = torch.float16, layout = torch.strided, device = device(type='cpu'), pin_memory = False);  sym_size_int_3 = None
          add_25: "f16[34, 9, 77][693, 77, 1]cpu" = torch.ops.aten.add.Tensor(full_default_1, primals_4);  full_default_1 = primals_4 = None
          return (add_25, primals_1, primals_2)
 ```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @chenyang78