### PR TITLE
Bugfix: Make BUILD_TEST default match match CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,7 +215,7 @@ cmake_dependent_option(
 cmake_dependent_option(
   CAFFE2_USE_MSVC_STATIC_RUNTIME "Using MSVC static runtime libraries" ON
   "NOT BUILD_SHARED_LIBS" OFF)
-option(BUILD_TEST "Build C++ test binaries (need gtest and gbenchmark)" OFF)
+option(BUILD_TEST "Build C++ test binaries (need gtest and gbenchmark)" ON)
 option(BUILD_AOT_INDUCTOR_TEST "Build C++ test binaries for aot-inductor" OFF)
 option(BUILD_STATIC_RUNTIME_BENCHMARK
        "Build C++ binaries for static runtime benchmarks (need gbenchmark)" OFF)

--- a/tools/build_pytorch_libs.py
+++ b/tools/build_pytorch_libs.py
@@ -94,7 +94,7 @@ def build_pytorch(
         and not check_env_flag("USE_SYSTEM_NCCL")
     ):
         checkout_nccl()
-    build_test = check_env_flag("BUILD_TEST")
+    build_test = not check_negative_env_flag("BUILD_TEST")
     cmake.generate(
         version, cmake_python_library, build_python, build_test, my_env, rerun_cmake
     )

--- a/tools/build_pytorch_libs.py
+++ b/tools/build_pytorch_libs.py
@@ -94,7 +94,7 @@ def build_pytorch(
         and not check_env_flag("USE_SYSTEM_NCCL")
     ):
         checkout_nccl()
-    build_test = not check_negative_env_flag("BUILD_TEST")
+    build_test = check_env_flag("BUILD_TEST")
     cmake.generate(
         version, cmake_python_library, build_python, build_test, my_env, rerun_cmake
     )


### PR DESCRIPTION
adjusted build test behavior to be off by default and match CMake. Fixes #166634


cc @malfet @seemethere