### PR TITLE
Upload test stats for trunk/sha tag

### DIFF
--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -98,7 +98,10 @@ jobs:
           WORKFLOW_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
           WORKFLOW_URL: ${{ github.event.workflow_run.html_url }}
           HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          # head_branch is empty for tag-based runs (e.g., trunk/{sha})
+          # Fallback to a synthesized trunk/{head_sha} tag so downstream logic
+          # can detect trunk restarts and upload full test_run data.
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch || format('trunk/{0}', github.event.workflow_run.head_sha) }}
         run: |
           echo "${WORKFLOW_URL}"
           python3 -m tools.stats.upload_test_stats --workflow-run-id "${WORKFLOW_RUN_ID}" --workflow-run-attempt "${WORKFLOW_RUN_ATTEMPT}" --head-branch "${HEAD_BRANCH}" --head-repository "${HEAD_REPOSITORY}"

--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -98,10 +98,7 @@ jobs:
           WORKFLOW_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
           WORKFLOW_URL: ${{ github.event.workflow_run.html_url }}
           HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
-          # head_branch is empty for tag-based runs (e.g., trunk/{sha})
-          # Fallback to a synthesized trunk/{head_sha} tag so downstream logic
-          # can detect trunk restarts and upload full test_run data.
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch || format('trunk/{0}', github.event.workflow_run.head_sha) }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           echo "${WORKFLOW_URL}"
           python3 -m tools.stats.upload_test_stats --workflow-run-id "${WORKFLOW_RUN_ID}" --workflow-run-attempt "${WORKFLOW_RUN_ATTEMPT}" --head-branch "${HEAD_BRANCH}" --head-repository "${HEAD_REPOSITORY}"

--- a/tools/stats/upload_test_stats.py
+++ b/tools/stats/upload_test_stats.py
@@ -20,6 +20,19 @@ from tools.stats.upload_stats_lib import (
 )
 
 
+def should_upload_full_test_run(head_branch: str | None, head_repository: str) -> bool:
+    """Return True if we should upload the full test_run dataset.
+
+    Rules:
+    - Only for the main repository (pytorch/pytorch)
+    - If head_branch is 'main', or a tag of form 'trunk/{40-hex-sha}'
+    """
+    is_trunk_tag = bool(re.fullmatch(r"trunk/[0-9a-fA-F]{40}", (head_branch or "")))
+    return head_repository == "pytorch/pytorch" and (
+        head_branch == "main" or is_trunk_tag
+    )
+
+
 def parse_xml_report(
     tag: str,
     report: Path,
@@ -288,13 +301,8 @@ if __name__ == "__main__":
         remove_nan_inf(failed_tests_cases),
     )
 
-    # Upload full test_run only for trusted refs:
-    #  - main branch
-    #  - trunk/{sha} tag (40-hex sha)
-    is_trunk_tag = bool(re.fullmatch(r"trunk/[0-9a-fA-F]{40}", args.head_branch or ""))
-    if args.head_repository == "pytorch/pytorch" and (
-        args.head_branch == "main" or is_trunk_tag
-    ):
+    # Upload full test_run only for trusted refs (main or trunk/{sha} tags)
+    if should_upload_full_test_run(args.head_branch, args.head_repository):
         # For jobs on main branch, upload everything.
         upload_workflow_stats_to_s3(
             args.workflow_run_id,

--- a/tools/stats/upload_test_stats.py
+++ b/tools/stats/upload_test_stats.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import sys
 import xml.etree.ElementTree as ET
 from multiprocessing import cpu_count, Pool
@@ -287,7 +288,13 @@ if __name__ == "__main__":
         remove_nan_inf(failed_tests_cases),
     )
 
-    if args.head_branch == "main" and args.head_repository == "pytorch/pytorch":
+    # Upload full test_run only for trusted refs:
+    #  - main branch
+    #  - trunk/{sha} tag (40-hex sha)
+    is_trunk_tag = bool(re.fullmatch(r"trunk/[0-9a-fA-F]{40}", args.head_branch or ""))
+    if args.head_repository == "pytorch/pytorch" and (
+        args.head_branch == "main" or is_trunk_tag
+    ):
         # For jobs on main branch, upload everything.
         upload_workflow_stats_to_s3(
             args.workflow_run_id,

--- a/tools/test/test_upload_gate.py
+++ b/tools/test/test_upload_gate.py
@@ -1,0 +1,28 @@
+import unittest
+
+from tools.stats.upload_test_stats import should_upload_full_test_run
+
+
+class TestUploadGate(unittest.TestCase):
+    def test_main_branch_on_pytorch_repo(self) -> None:
+        self.assertTrue(should_upload_full_test_run("main", "pytorch/pytorch"))
+
+    def test_trunk_tag_valid_sha_on_pytorch_repo(self) -> None:
+        sha = "a" * 40
+        self.assertTrue(should_upload_full_test_run(f"trunk/{sha}", "pytorch/pytorch"))
+
+    def test_trunk_tag_invalid_sha_on_pytorch_repo(self) -> None:
+        # Not 40 hex chars
+        self.assertFalse(should_upload_full_test_run("trunk/12345", "pytorch/pytorch"))
+
+    def test_non_main_branch_on_pytorch_repo(self) -> None:
+        self.assertFalse(
+            should_upload_full_test_run("feature-branch", "pytorch/pytorch")
+        )
+
+    def test_main_branch_on_fork_repo(self) -> None:
+        self.assertFalse(should_upload_full_test_run("main", "someone/fork"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Noticed that workflow runs for `trunk/{sha}` tags (issued by autorevert) don't populate test_run_s3 Clickhouse table. 

This PR is addressing this by changing the gate condition to upload tests stats.

see https://github.com/pytorch/pytorch/actions/runs/19054297956/job/54421254448#step:8:23
as an evidence that HEAD_BRANCH is correctly populated for trunk tags.