### PR TITLE
nn: add return type annotation to named_modules()

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -2837,7 +2837,7 @@ class Module:
         memo: Optional[set["Module"]] = None,
         prefix: str = "",
         remove_duplicate: bool = True,
-    ):
+    ) -> Iterator[tuple[str, "Module"]]:
         r"""Return an iterator over all modules in the network, yielding both the name of the module as well as the module itself.
 
         Args:


### PR DESCRIPTION
**Description:**

This PR adds an explicit return type annotation to the `named_modules()` method in `torch/nn/modules/module.py`.
Currently, the method lacks a return type, which limits type inference and static analysis tools like MyPy and Pyright.
The added annotation improves type safety, IDE autocompletion and consistency with similar methods such as `named_children()` and `named_parameters()`.

Fixes #166905
