### PR TITLE
Improve RNN dtype mismatch error message

### DIFF
--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -158,7 +158,9 @@ class TestAutocastCPU(TestAutocast):
             m = torch.nn.LSTM(1, 1, 2).to(torch.bfloat16)
 
             # Raise ValueError when autocast is not enabled
-            with self.assertRaisesRegex(ValueError, "input must have the type"):
+            with self.assertRaisesRegex(
+                ValueError, r"RNN input dtype .* does not match weight dtype"
+            ):
                 m(x, (hx, cx))
 
             # Should be able to run the below case with autocast

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3882,37 +3882,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             hidden_shape = update_shape(correct_hidden_shape, 0, bad_size)
             test(input_shape, hidden_shape, mode)
 
-    def test_rnn_dtype_mismatch_error_message(self):
-        """test that RNN provides helpful error message for dtype mismatch."""
-        input_size = 3
-        hidden_size = 5
-
-        # test all RNN types
-        for rnn_type in [nn.RNN, nn.GRU, nn.LSTM]:
-            # create RNN with default dtype (float32)
-            rnn = rnn_type(input_size, hidden_size)
-
-            # create input with different dtype (float64)
-            input_tensor = torch.randn(2, 4, input_size, dtype=torch.float64)
-
-            # Check that error message is helpful
-            with self.assertRaisesRegex(
-                ValueError,
-                r"RNN input dtype \(torch\.float64\) does not match weight dtype \(torch\.float32\)\. "
-                r"Convert input: input\.to\(torch\.float32\), or convert model: model\.to\(torch\.float64\)"
-            ):
-                rnn(input_tensor)
-
-            # convert input to match model
-            input_converted = input_tensor.to(torch.float32)
-            output = rnn(input_converted)  # Should not raise
-            self.assertEqual(output[0].dtype, torch.float32)
-
-            # convert model to match input
-            rnn_converted = rnn.to(torch.float64)
-            output = rnn_converted(input_tensor)  # Should not raise
-            self.assertEqual(output[0].dtype, torch.float64)
-
     def test_projections_lstm_args_check(self):
         input_size = 3
         hidden_size = 5

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -317,7 +317,8 @@ class RNNBase(Module):
                 and not torch._C._is_any_autocast_enabled()
             ):
                 raise ValueError(
-                    f"input must have the type {self._flat_weights[0].dtype}, got type {input.dtype}"  # type: ignore[union-attr]
+                    f"RNN input dtype ({input.dtype}) does not match weight dtype ({self._flat_weights[0].dtype}). "  # type: ignore[union-attr]
+                    f"Convert input: input.to({self._flat_weights[0].dtype}), or convert model: model.to({input.dtype})"  # type: ignore[union-attr]
                 )
         expected_input_dim = 2 if batch_sizes is not None else 3
         if input.dim() != expected_input_dim:

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -3343,8 +3343,10 @@ def module_error_inputs_torch_nn_LSTMCell(module_info, device, dtype, requires_g
 def module_error_inputs_torch_nn_RNN_GRU(module_info, device, dtype, requires_grad, training, **kwargs):
     # use float64 for dtype mismatch test if current dtype is float32, otherwise use float32
     # MPS doesn't support float64, so use float16 instead
+    # Extract device type from device string (e.g., 'mps:0' -> 'mps')
+    device_type = device.split(':')[0] if isinstance(device, str) else device.type
     if dtype == torch.float32:
-        mismatched_dtype = torch.float16 if device == 'mps' else torch.float64
+        mismatched_dtype = torch.float16 if device_type == 'mps' else torch.float64
     else:
         mismatched_dtype = torch.float32
     make_input = partial(make_tensor, device=device, dtype=mismatched_dtype, requires_grad=requires_grad)

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -3361,7 +3361,7 @@ def module_error_inputs_torch_nn_RNN_GRU(module_info, device, dtype, requires_gr
         # Test dtype mismatch error message
         ErrorModuleInput(
             ModuleInput(
-                constructor_input=FunctionInput(3, 5),
+                constructor_input=FunctionInput(3, 5, dtype=dtype, device=device),
                 forward_input=FunctionInput(make_input((2, 4, 3))),
             ),
             error_on=ModuleErrorEnum.FORWARD_ERROR,

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -3341,6 +3341,10 @@ def module_error_inputs_torch_nn_LSTMCell(module_info, device, dtype, requires_g
 
 
 def module_error_inputs_torch_nn_RNN_GRU(module_info, device, dtype, requires_grad, training, **kwargs):
+    # use float64 for dtype mismatch test if current dtype is float32, otherwise use float32
+    mismatched_dtype = torch.float64 if dtype == torch.float32 else torch.float32
+    make_input = partial(make_tensor, device=device, dtype=mismatched_dtype, requires_grad=requires_grad)
+
     samples = [
         ErrorModuleInput(
             ModuleInput(constructor_input=FunctionInput(10, 0, 1)),
@@ -3353,6 +3357,17 @@ def module_error_inputs_torch_nn_RNN_GRU(module_info, device, dtype, requires_gr
             error_on=ModuleErrorEnum.CONSTRUCTION_ERROR,
             error_type=ValueError,
             error_regex="num_layers must be greater than zero"
+        ),
+        # Test dtype mismatch error message
+        ErrorModuleInput(
+            ModuleInput(
+                constructor_input=FunctionInput(3, 5),
+                forward_input=FunctionInput(make_input((2, 4, 3))),
+            ),
+            error_on=ModuleErrorEnum.FORWARD_ERROR,
+            error_type=ValueError,
+            error_regex=(r"RNN input dtype .* does not match weight dtype .* "
+                         r"Convert input: input\.to\(.*\), or convert model: model\.to\(.*\)")
         ),
         # Test bias parameter type validation
         ErrorModuleInput(

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -3344,7 +3344,7 @@ def module_error_inputs_torch_nn_RNN_GRU(module_info, device, dtype, requires_gr
     # use float64 for dtype mismatch test if current dtype is float32, otherwise use float32
     # MPS doesn't support float64, so use float16 instead
     if dtype == torch.float32:
-        mismatched_dtype = torch.float16 if device.type == 'mps' else torch.float64
+        mismatched_dtype = torch.float16 if device == 'mps' else torch.float64
     else:
         mismatched_dtype = torch.float32
     make_input = partial(make_tensor, device=device, dtype=mismatched_dtype, requires_grad=requires_grad)

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -3342,7 +3342,11 @@ def module_error_inputs_torch_nn_LSTMCell(module_info, device, dtype, requires_g
 
 def module_error_inputs_torch_nn_RNN_GRU(module_info, device, dtype, requires_grad, training, **kwargs):
     # use float64 for dtype mismatch test if current dtype is float32, otherwise use float32
-    mismatched_dtype = torch.float64 if dtype == torch.float32 else torch.float32
+    # MPS doesn't support float64, so use float16 instead
+    if dtype == torch.float32:
+        mismatched_dtype = torch.float16 if device.type == 'mps' else torch.float64
+    else:
+        mismatched_dtype = torch.float32
     make_input = partial(make_tensor, device=device, dtype=mismatched_dtype, requires_grad=requires_grad)
 
     samples = [


### PR DESCRIPTION
/Enhance error message to explain mismatch and provide two actionable fixes: convert input with input.to(dtype) or convert model with model.to(dtype). Add test to validate error message and verify both suggested fixes work.

Fixes #136931 

cc @mcarilli @ptrblck @leslie-fang-intel @jgong5