### PR TITLE
huber_loss numerical issue

### DIFF
--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -815,17 +815,35 @@ void smooth_l1_kernel(TensorIteratorBase& iter, double beta) {
 void huber_kernel(TensorIterator& iter, double delta) {
   // Special-case kHalf: compute in float for numerical stability
   if (iter.dtype() == kHalf) {
-    cpu_kernel(
+    const float delta_val(static_cast<float>(delta));
+    const Vectorized<float> delta_vec(static_cast<float>(delta));
+    const Vectorized<float> point_five_vec(static_cast<float>(0.5));
+    cpu_kernel_vec(
       iter,
       // scalar lambda: convert half -> float, compute in float, cast back to half
-      [&] (at::Half a, at::Half b) -> at::Half {
+      [&delta_val] (at::Half a, at::Half b) -> at::Half {
         float af = static_cast<float>(a);
         float bf = static_cast<float>(b);
         float z = std::abs(af - bf);
-        float out = z < static_cast<float>(delta)
+        float out = z < static_cast<float>(delta_val)
           ? 0.5f * z * z
-          : static_cast<float>(delta) * (z - 0.5f * static_cast<float>(delta));
+          : static_cast<float>(delta_val) * (z - 0.5f * static_cast<float>(delta_val));
         return static_cast<at::Half>(out);
+      },
+      [&delta_vec, &point_five_vec] (Vectorized<Half> a, Vectorized<Half> b) {
+        auto [a0, a1] = convert_half_float(a);
+        auto [b0, b1] = convert_half_float(b);
+        auto z = (a0 - b0).abs();
+        a0 = Vectorized<float>::blendv(
+          point_five_vec * z * z,
+          delta_vec * (z - point_five_vec * delta_vec),
+          z >= delta_vec);
+        z = (a1 - b1).abs();
+        a1 = Vectorized<float>::blendv(
+          point_five_vec * z * z,
+          delta_vec * (z - point_five_vec * delta_vec),
+          z >= delta_vec);
+        return convert_float_half(a0, a1);
       }
     );
     return;

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -825,9 +825,9 @@ void huber_kernel(TensorIterator& iter, double delta) {
         float af = static_cast<float>(a);
         float bf = static_cast<float>(b);
         float z = std::abs(af - bf);
-        float out = z < static_cast<float>(delta_val)
+        float out = z < delta_val
           ? 0.5f * z * z
-          : static_cast<float>(delta_val) * (z - 0.5f * static_cast<float>(delta_val));
+          : delta_val * (z - 0.5f * delta_val);
         return static_cast<at::Half>(out);
       },
       [&delta_vec, &point_five_vec] (Vectorized<Half> a, Vectorized<Half> b) {

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -828,9 +828,6 @@ inductor_one_sample["cuda"] = {
     "nn.functional.fractional_max_pool3d": {f16, f32, f64},
     "nn.functional.group_norm": {f16},
     "nn.functional.hinge_embedding_loss": {f16},
-    # Enabling all tests for this test fails randomly
-    # See https://github.com/pytorch/pytorch/issues/129238
-    "nn.functional.huber_loss": {f16},
     "nn.functional.interpolate.bicubic": {f16},
     "nn.functional.interpolate.bilinear": {f16},
     "nn.functional.interpolate.trilinear": {f16},

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -945,9 +945,6 @@ inductor_one_sample["xpu"] = {
     "nn.functional.fractional_max_pool3d": {f16, f32, f64},
     "nn.functional.group_norm": {f16},
     "nn.functional.hinge_embedding_loss": {f16},
-    # Enabling all tests for this test fails randomly
-    # See https://github.com/pytorch/pytorch/issues/129238
-    "nn.functional.huber_loss": {f16},
     "nn.functional.interpolate.bicubic": {f16},
     "nn.functional.interpolate.bilinear": {f16},
     "nn.functional.interpolate.trilinear": {f16},


### PR DESCRIPTION
For GPU: Previously reported that only a single sample could be tested with huber_loss functional. Current snapshot of the code does not appear to suffer from numerical issues as reported before.

For CPU: While testing GPU, it was discovered that with Half appears to be numerically unstable. This commit resolves issue with CPU by upcasting Half to float for the computation.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben