### PR TITLE
Add type validation for RNN module parameters

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4049,6 +4049,29 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             with self.assertRaisesRegex(ValueError, error_msg):
                 rnn = getattr(nn, mode)(30, 20, 2, proj_size=10)
 
+    def test_rnn_bias_and_batch_first_type_validation(self):
+        # test that RNN modules raise TypeError when bias or batch_first is not a bool
+        for mode in ['RNN', 'LSTM', 'GRU']:
+            # test bias parameter validation
+            with self.assertRaisesRegex(TypeError, "bias should be of type bool, got: int"):
+                getattr(nn, mode)(input_size=3, hidden_size=5, bias=0)
+
+            with self.assertRaisesRegex(TypeError, "bias should be of type bool, got: int"):
+                getattr(nn, mode)(input_size=3, hidden_size=5, bias=1)
+
+            with self.assertRaisesRegex(TypeError, "bias should be of type bool, got: str"):
+                getattr(nn, mode)(input_size=3, hidden_size=5, bias="True")
+
+            # test batch_first parameter validation
+            with self.assertRaisesRegex(TypeError, "batch_first should be of type bool, got: int"):
+                getattr(nn, mode)(input_size=3, hidden_size=5, batch_first=0)
+
+            with self.assertRaisesRegex(TypeError, "batch_first should be of type bool, got: int"):
+                getattr(nn, mode)(input_size=3, hidden_size=5, batch_first=1)
+
+            with self.assertRaisesRegex(TypeError, "batch_first should be of type bool, got: str"):
+                getattr(nn, mode)(input_size=3, hidden_size=5, batch_first="False")
+
     def _test_RNN_cpu_vs_cudnn(self, dropout, dtype=torch.double):
 
         def forward_backward(cuda, rnn, input_val, grad_output, weights_val, hx_val, grad_hy,

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4049,29 +4049,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             with self.assertRaisesRegex(ValueError, error_msg):
                 rnn = getattr(nn, mode)(30, 20, 2, proj_size=10)
 
-    def test_rnn_bias_and_batch_first_type_validation(self):
-        # test that RNN modules raise TypeError when bias or batch_first is not a bool
-        for mode in ['RNN', 'LSTM', 'GRU']:
-            # test bias parameter validation
-            with self.assertRaisesRegex(TypeError, "bias should be of type bool, got: int"):
-                getattr(nn, mode)(input_size=3, hidden_size=5, bias=0)
-
-            with self.assertRaisesRegex(TypeError, "bias should be of type bool, got: int"):
-                getattr(nn, mode)(input_size=3, hidden_size=5, bias=1)
-
-            with self.assertRaisesRegex(TypeError, "bias should be of type bool, got: str"):
-                getattr(nn, mode)(input_size=3, hidden_size=5, bias="True")
-
-            # test batch_first parameter validation
-            with self.assertRaisesRegex(TypeError, "batch_first should be of type bool, got: int"):
-                getattr(nn, mode)(input_size=3, hidden_size=5, batch_first=0)
-
-            with self.assertRaisesRegex(TypeError, "batch_first should be of type bool, got: int"):
-                getattr(nn, mode)(input_size=3, hidden_size=5, batch_first=1)
-
-            with self.assertRaisesRegex(TypeError, "batch_first should be of type bool, got: str"):
-                getattr(nn, mode)(input_size=3, hidden_size=5, batch_first="False")
-
     def _test_RNN_cpu_vs_cudnn(self, dropout, dtype=torch.double):
 
         def forward_backward(cuda, rnn, input_val, grad_output, weights_val, hx_val, grad_hy,

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -128,6 +128,12 @@ class RNNBase(Module):
                 stacklevel=2,
             )
 
+        if not isinstance(bias, bool):
+            raise TypeError(f"bias should be of type bool, got: {type(bias).__name__}")
+        if not isinstance(batch_first, bool):
+            raise TypeError(
+                f"batch_first should be of type bool, got: {type(batch_first).__name__}"
+            )
         if not isinstance(hidden_size, int):
             raise TypeError(
                 f"hidden_size should be of type int, got: {type(hidden_size).__name__}"

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -3354,6 +3354,44 @@ def module_error_inputs_torch_nn_RNN_GRU(module_info, device, dtype, requires_gr
             error_type=ValueError,
             error_regex="num_layers must be greater than zero"
         ),
+        # Test bias parameter type validation
+        ErrorModuleInput(
+            ModuleInput(constructor_input=FunctionInput(3, 5, bias=0)),
+            error_on=ModuleErrorEnum.CONSTRUCTION_ERROR,
+            error_type=TypeError,
+            error_regex="bias should be of type bool, got: int"
+        ),
+        ErrorModuleInput(
+            ModuleInput(constructor_input=FunctionInput(3, 5, bias=1)),
+            error_on=ModuleErrorEnum.CONSTRUCTION_ERROR,
+            error_type=TypeError,
+            error_regex="bias should be of type bool, got: int"
+        ),
+        ErrorModuleInput(
+            ModuleInput(constructor_input=FunctionInput(3, 5, bias="True")),
+            error_on=ModuleErrorEnum.CONSTRUCTION_ERROR,
+            error_type=TypeError,
+            error_regex="bias should be of type bool, got: str"
+        ),
+        # Test batch_first parameter type validation
+        ErrorModuleInput(
+            ModuleInput(constructor_input=FunctionInput(3, 5, batch_first=0)),
+            error_on=ModuleErrorEnum.CONSTRUCTION_ERROR,
+            error_type=TypeError,
+            error_regex="batch_first should be of type bool, got: int"
+        ),
+        ErrorModuleInput(
+            ModuleInput(constructor_input=FunctionInput(3, 5, batch_first=1)),
+            error_on=ModuleErrorEnum.CONSTRUCTION_ERROR,
+            error_type=TypeError,
+            error_regex="batch_first should be of type bool, got: int"
+        ),
+        ErrorModuleInput(
+            ModuleInput(constructor_input=FunctionInput(3, 5, batch_first="False")),
+            error_on=ModuleErrorEnum.CONSTRUCTION_ERROR,
+            error_type=TypeError,
+            error_regex="batch_first should be of type bool, got: str"
+        ),
     ]
     return samples
 


### PR DESCRIPTION
Validate bias, and batch_first parameter types in RNN/LSTM/GRU modules with clear error messages. Add comprehensive test coverage.

Fixes #136954
