### PR TITLE
[CI] Parse xml and upload json while running

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -73,10 +73,20 @@ from tools.testing.test_selections import (
     ShardedTest,
     THRESHOLD,
 )
-from tools.testing.upload_artifacts import (
-    parse_xml_and_upload_json,
-    zip_and_upload_artifacts,
-)
+
+
+try:
+    from tools.testing.upload_artifacts import (
+        parse_xml_and_upload_json,
+        zip_and_upload_artifacts,
+    )
+except ImportError:
+    # upload_artifacts.py may not be available in some environments
+    def parse_xml_and_upload_json():
+        pass
+
+    def zip_and_upload_artifacts(failed: bool):
+        pass
 
 
 # Make sure to remove REPO_ROOT after import is done

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1889,8 +1889,8 @@ def run_tests(
 
     def handle_complete(failure: Optional[TestFailure]):
         failed = failure is not None
-        parse_xml_and_upload_json()
         if IS_CI and options.upload_artifacts_while_running:
+            parse_xml_and_upload_json()
             zip_and_upload_artifacts(failed)
         if not failed:
             return False

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -73,7 +73,10 @@ from tools.testing.test_selections import (
     ShardedTest,
     THRESHOLD,
 )
-from tools.testing.upload_artifacts import zip_and_upload_artifacts
+from tools.testing.upload_artifacts import (
+    parse_xml_and_upload_json,
+    zip_and_upload_artifacts,
+)
 
 
 # Make sure to remove REPO_ROOT after import is done
@@ -1886,6 +1889,7 @@ def run_tests(
 
     def handle_complete(failure: Optional[TestFailure]):
         failed = failure is not None
+        parse_xml_and_upload_json()
         if IS_CI and options.upload_artifacts_while_running:
             zip_and_upload_artifacts(failed)
         if not failed:

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -81,7 +81,9 @@ try:
         zip_and_upload_artifacts,
     )
 except ImportError:
-    # upload_artifacts.py may not be available in some environments
+    # some imports in those files might fail, e.g., boto3 not installed. These
+    # functions are only needed under specific circumstances (CI) so we can
+    # define dummy functions here.
     def parse_xml_and_upload_json():
         pass
 

--- a/tools/stats/upload_test_stats.py
+++ b/tools/stats/upload_test_stats.py
@@ -24,12 +24,14 @@ def parse_xml_report(
     report: Path,
     workflow_id: int,
     workflow_run_attempt: int,
+    job_id: int | None = None,
 ) -> list[dict[str, Any]]:
     """Convert a test report xml file into a JSON-serializable list of test cases."""
     print(f"Parsing {tag}s for test report: {report}")
 
-    job_id = get_job_id(report)
-    print(f"Found job id: {job_id}")
+    if job_id is None:
+        job_id = get_job_id(report)
+        print(f"Found job id: {job_id}")
 
     test_cases: list[dict[str, Any]] = []
 

--- a/tools/testing/upload_artifacts.py
+++ b/tools/testing/upload_artifacts.py
@@ -8,6 +8,8 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, Optional
 
+from filelock import FileLock, Timeout
+
 from tools.stats.upload_test_stats import parse_xml_report
 
 
@@ -148,13 +150,9 @@ def trigger_upload_test_stats_intermediate_workflow() -> None:
 def parse_xml_and_upload_json() -> None:
     """
     Parse xml test reports that do not yet have a corresponding json report
-    uploaded to s3, and upload the json reports to s3.
+    uploaded to s3, and upload the json reports to s3. Use filelock to avoid
+    uploading the same file from multiple processes.
     """
-    json_files = [
-        Path(f).with_suffix("")
-        for f in glob.glob(f"{REPO_ROOT}/test/test-reports/**/*.json", recursive=True)
-    ]
-
     try:
         job_id: Optional[int] = int(os.environ.get("JOB_ID", 0))
         if job_id == 0:
@@ -167,35 +165,43 @@ def parse_xml_and_upload_json() -> None:
     ):
         xml_path = Path(xml_file)
         json_file = xml_path.with_suffix(".json")
-        if json_file in json_files:
-            # It has already been parsed and uploaded
-            continue
+        lock = FileLock(str(json_file) + ".lock")
 
-        test_cases = parse_xml_report(
-            "testcase",
-            xml_path,
-            int(os.environ.get("GITHUB_RUN_ID", "0")),
-            int(os.environ.get("GITHUB_RUN_ATTEMPT", "0")),
-            job_id,
-        )
-        line_by_line_jsons = "\n".join([json.dumps(tc) for tc in test_cases])
+        try:
+            lock.acquire(timeout=0)  # immediately fails if already locked
+            if json_file.exists():
+                continue  # already uploaded
+            test_cases = parse_xml_report(
+                "testcase",
+                xml_path,
+                int(os.environ.get("GITHUB_RUN_ID", "0")),
+                int(os.environ.get("GITHUB_RUN_ATTEMPT", "0")),
+                job_id,
+            )
+            line_by_line_jsons = "\n".join([json.dumps(tc) for tc in test_cases])
 
-        gzipped = gzip.compress(line_by_line_jsons.encode("utf-8"))
-        s3_key = (
-            json_file.relative_to(REPO_ROOT / "test/test-reports")
-            .as_posix()
-            .replace("/", "_")
-        )
-        get_s3_resource().put_object(
-            Body=gzipped,
-            Bucket="gha-artifacts",
-            Key=f"test_jsons_while_running/{os.environ.get('GITHUB_RUN_ID')}/{job_id}/{s3_key}",
-            ContentType="application/json",
-            ContentEncoding="gzip",
-        )
+            gzipped = gzip.compress(line_by_line_jsons.encode("utf-8"))
+            s3_key = (
+                json_file.relative_to(REPO_ROOT / "test/test-reports")
+                .as_posix()
+                .replace("/", "_")
+            )
 
-        # We don't need to save the json file locally, but doing so lets us
-        # track which ones have been uploaded already. We could probably also
-        # check S3
-        with open(json_file, "w") as f:
-            f.write(line_by_line_jsons)
+            # We don't need to save the json file locally, but doing so lets us
+            # track which ones have been uploaded already. We could probably also
+            # check S3
+            with open(json_file, "w") as f:
+                f.write(line_by_line_jsons)
+
+            get_s3_resource().put_object(
+                Body=gzipped,
+                Bucket="gha-artifacts",
+                Key=f"test_jsons_while_running/{os.environ.get('GITHUB_RUN_ID')}/{job_id}/{s3_key}",
+                ContentType="application/json",
+                ContentEncoding="gzip",
+            )
+        except Timeout:
+            continue  # another process is working on this file
+        finally:
+            if lock.is_locked:
+                lock.release()

--- a/tools/testing/upload_artifacts.py
+++ b/tools/testing/upload_artifacts.py
@@ -166,8 +166,8 @@ def parse_xml_and_upload_json() -> None:
         f"{REPO_ROOT}/test/test-reports/**/*.xml", recursive=True
     ):
         xml_path = Path(xml_file)
-        json_version = xml_path.with_suffix(".json")
-        if json_version in json_files:
+        json_file = xml_path.with_suffix(".json")
+        if json_file in json_files:
             # It has already been parsed and uploaded
             continue
 
@@ -182,7 +182,9 @@ def parse_xml_and_upload_json() -> None:
 
         gzipped = gzip.compress(line_by_line_jsons.encode("utf-8"))
         s3_key = (
-            json_version.relative_to("test/test-reports").as_posix().replace("/", "_")
+            json_file.relative_to(REPO_ROOT / "test/test-reports")
+            .as_posix()
+            .replace("/", "_")
         )
         get_s3_resource().put_object(
             Body=gzipped,
@@ -195,5 +197,5 @@ def parse_xml_and_upload_json() -> None:
         # We don't need to save the json file locally, but doing so lets us
         # track which ones have been uploaded already. We could probably also
         # check S3
-        with open(json_version, "w") as f:
+        with open(json_file, "w") as f:
             f.write(line_by_line_jsons)

--- a/tools/testing/upload_artifacts.py
+++ b/tools/testing/upload_artifacts.py
@@ -160,48 +160,51 @@ def parse_xml_and_upload_json() -> None:
     except (ValueError, TypeError):
         job_id = None
 
-    for xml_file in glob.glob(
-        f"{REPO_ROOT}/test/test-reports/**/*.xml", recursive=True
-    ):
-        xml_path = Path(xml_file)
-        json_file = xml_path.with_suffix(".json")
-        lock = FileLock(str(json_file) + ".lock")
+    try:
+        for xml_file in glob.glob(
+            f"{REPO_ROOT}/test/test-reports/**/*.xml", recursive=True
+        ):
+            xml_path = Path(xml_file)
+            json_file = xml_path.with_suffix(".json")
+            lock = FileLock(str(json_file) + ".lock")
 
-        try:
-            lock.acquire(timeout=0)  # immediately fails if already locked
-            if json_file.exists():
-                continue  # already uploaded
-            test_cases = parse_xml_report(
-                "testcase",
-                xml_path,
-                int(os.environ.get("GITHUB_RUN_ID", "0")),
-                int(os.environ.get("GITHUB_RUN_ATTEMPT", "0")),
-                job_id,
-            )
-            line_by_line_jsons = "\n".join([json.dumps(tc) for tc in test_cases])
+            try:
+                lock.acquire(timeout=0)  # immediately fails if already locked
+                if json_file.exists():
+                    continue  # already uploaded
+                test_cases = parse_xml_report(
+                    "testcase",
+                    xml_path,
+                    int(os.environ.get("GITHUB_RUN_ID", "0")),
+                    int(os.environ.get("GITHUB_RUN_ATTEMPT", "0")),
+                    job_id,
+                )
+                line_by_line_jsons = "\n".join([json.dumps(tc) for tc in test_cases])
 
-            gzipped = gzip.compress(line_by_line_jsons.encode("utf-8"))
-            s3_key = (
-                json_file.relative_to(REPO_ROOT / "test/test-reports")
-                .as_posix()
-                .replace("/", "_")
-            )
+                gzipped = gzip.compress(line_by_line_jsons.encode("utf-8"))
+                s3_key = (
+                    json_file.relative_to(REPO_ROOT / "test/test-reports")
+                    .as_posix()
+                    .replace("/", "_")
+                )
 
-            # We don't need to save the json file locally, but doing so lets us
-            # track which ones have been uploaded already. We could probably also
-            # check S3
-            with open(json_file, "w") as f:
-                f.write(line_by_line_jsons)
+                get_s3_resource().put_object(
+                    Body=gzipped,
+                    Bucket="gha-artifacts",
+                    Key=f"test_jsons_while_running/{os.environ.get('GITHUB_RUN_ID')}/{job_id}/{s3_key}",
+                    ContentType="application/json",
+                    ContentEncoding="gzip",
+                )
 
-            get_s3_resource().put_object(
-                Body=gzipped,
-                Bucket="gha-artifacts",
-                Key=f"test_jsons_while_running/{os.environ.get('GITHUB_RUN_ID')}/{job_id}/{s3_key}",
-                ContentType="application/json",
-                ContentEncoding="gzip",
-            )
-        except Timeout:
-            continue  # another process is working on this file
-        finally:
-            if lock.is_locked:
-                lock.release()
+                # We don't need to save the json file locally, but doing so lets us
+                # track which ones have been uploaded already. We could probably also
+                # check S3
+                with open(json_file, "w") as f:
+                    f.write(line_by_line_jsons)
+            except Timeout:
+                continue  # another process is working on this file
+            finally:
+                if lock.is_locked:
+                    lock.release()
+    except Exception as e:
+        print(f"Failed to parse and upload json test reports: {e}")


### PR DESCRIPTION
Then we can point an ClickHouse ingestor at this s3 path and get them into ClickHouse while the job is running.

use filelock to make sure each json is uploaded once so we don't end up with dups in ClickHouse