### PR TITLE
[dynamo, 3.14] disable dynamo cpython tests in 3.14 (again)

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1672,7 +1672,7 @@ def get_selected_tests(options) -> list[str]:
             ]
         )
 
-    if sys.version_info[:2] < (3, 13) or sys.version_info[:2] >= (3, 14)
+    if sys.version_info[:2] < (3, 13) or sys.version_info[:2] >= (3, 14):
         # Skip tests for older Python versions as they may use syntax or features
         # not supported in those versions
         options.exclude.extend(

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1672,7 +1672,7 @@ def get_selected_tests(options) -> list[str]:
             ]
         )
 
-    if sys.version_info[:2] < (3, 13):
+    if sys.version_info[:2] < (3, 13) or sys.version_info[:2] >= (3, 14)
         # Skip tests for older Python versions as they may use syntax or features
         # not supported in those versions
         options.exclude.extend(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #166679
* __->__ #167000

The previous PR was not enough to prevent errors caused by cpython dynamo tests in 3.14