### PR TITLE
[Flight Recorder] Reverted to include stack traces for dump pipe triggered FR dump

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1882,7 +1882,7 @@ void ProcessGroupNCCL::HeartbeatMonitor::runLoop() {
       LOG(INFO) << pg_->logPrefix()
                 << "Dump signal received through pipe, triggering FR dump.";
       futures.emplace_back(std::async(std::launch::async, [this, onlyActive]() {
-        return this->pg_->dumpDebuggingInfo(false, onlyActive);
+        return this->pg_->dumpDebuggingInfo(true, onlyActive);
       }));
     }
   }


### PR DESCRIPTION
Summary: We should also retry if include stacktraces failed.

Test Plan: eyes

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci