### PR TITLE
Make the new Node* fn parameter optional so it can be backward compatible

### DIFF
--- a/torch/csrc/autograd/input_buffer.cpp
+++ b/torch/csrc/autograd/input_buffer.cpp
@@ -234,7 +234,7 @@ void InputBuffer::add(
 
   TORCH_INTERNAL_ASSERT(opt_consumer_stream && opt_producer_stream);
 
-  if (*opt_consumer_stream != *opt_producer_stream &&
+  if (fn != nullptr && *opt_consumer_stream != *opt_producer_stream &&
       dynamic_cast<AccumulateGrad*>(fn) &&
       at::globalContext().warnOnAccumulateGradStreamMismatch()) {
     TORCH_WARN_ONCE(

--- a/torch/csrc/autograd/input_buffer.h
+++ b/torch/csrc/autograd/input_buffer.h
@@ -33,7 +33,7 @@ struct InputBuffer {
       Variable&& var,
       const std::optional<c10::Stream>& opt_producer_stream,
       const std::optional<c10::Stream>& opt_consumer_stream,
-      Node* fn);
+      Node* fn = nullptr);
 
   Variable operator[](size_t pos) {
     return buffer[pos];


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-pytorch/monarch/pull/1755

P2023144075

Test Plan: sandcastle

Differential Revision: D86256198


