### PR TITLE
Remove python workaround for ContextDecorator

### DIFF
--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -57,26 +57,11 @@ __all__ = [
     "MemRecordsAcc",
 ]
 
-try:
-    # Available in Python >= 3.2
-    from contextlib import ContextDecorator as _ContextDecorator
-except ImportError:
-    import functools
+from contextlib import ContextDecorator
 
-    class _ContextDecorator:  # type: ignore[no-redef]
-        def __enter__(self):
-            raise NotImplementedError
 
-        def __exit__(self, exc_type, exc_val, exc_tb):
-            raise NotImplementedError
-
-        def __call__(self, func):
-            @functools.wraps(func)
-            def wrapped(*args, **kwargs):
-                with self:
-                    return func(*args, **kwargs)
-
-            return wrapped
+# Backward-compat alias: private name used to refer to a local fallback class.
+_ContextDecorator = ContextDecorator
 
 
 # global python state - whether profiler is currently enabled
@@ -836,8 +821,7 @@ class profile:
         return all_function_events
 
 
-# pyrefly: ignore [invalid-inheritance]
-class record_function(_ContextDecorator):
+class record_function(ContextDecorator):
     """Context manager/function decorator that adds a label to a code block/function when running autograd profiler.
     Label will only appear if CPU activity tracing is enabled.
 

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -57,11 +57,8 @@ __all__ = [
     "MemRecordsAcc",
 ]
 
-from contextlib import ContextDecorator
-
-
 # Backward-compat alias: private name used to refer to a local fallback class.
-_ContextDecorator = ContextDecorator
+from contextlib import ContextDecorator as _ContextDecorator
 
 
 # global python state - whether profiler is currently enabled
@@ -821,7 +818,7 @@ class profile:
         return all_function_events
 
 
-class record_function(ContextDecorator):
+class record_function(_ContextDecorator):
     """Context manager/function decorator that adds a label to a code block/function when running autograd profiler.
     Label will only appear if CPU activity tracing is enabled.
 
@@ -869,7 +866,7 @@ class record_function(ContextDecorator):
         # self.record: Optional["torch.classes.profiler._RecordFunction"] = None
         self.record = torch.jit.annotate(
             # pyrefly: ignore [not-a-type]
-            Optional["torch.classes.profiler._RecordFunction"],  # noqa: UP045
+            Optional["torch.classes.profiler._RecordFunction"],
             None,
         )
 

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -869,7 +869,7 @@ class record_function(ContextDecorator):
         # self.record: Optional["torch.classes.profiler._RecordFunction"] = None
         self.record = torch.jit.annotate(
             # pyrefly: ignore [not-a-type]
-            Optional["torch.classes.profiler._RecordFunction"],
+            Optional["torch.classes.profiler._RecordFunction"],  # noqa: UP045
             None,
         )
 


### PR DESCRIPTION
This PR removes the import workaround for ContextDecorator because the import always succeeds in Py 3.10+. 

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel @robieta @chaekit @guotuofeng @guyang3532 @dzhulgakov @davidberard98 @briancoutinho @sraikund16 @sanrise @mwootton