### PR TITLE
[c10d] Fix _set_pg_timeout not working for Gloo backend

### DIFF
--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -1048,8 +1048,11 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
     def test_gloo_set_pg_timeout_api(self):
         """
         Test _set_pg_timeout API for Gloo backend (issue #165422).
-        This test verifies that dynamically changing timeout via distributed_c10d._set_pg_timeout
-        actually affects subsequent operations.
+        This test demonstrates that dynamically changing timeout via _set_pg_timeout
+        actually affects operation timeouts by:
+        1. verifying operations complete successfully with normal timeout
+        2. setting a very short timeout via _set_pg_timeout
+        3. demonstrating that operations timeout with the new short timeout value
         """
         store = c10d.FileStore(self.file_name, self.world_size)
         dist.init_process_group(
@@ -1061,20 +1064,25 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         )
 
         pg = dist.distributed_c10d._get_default_group()
-
         backend = pg._get_backend(torch.device("cpu"))
         self.assertEqual(backend.options._timeout, timedelta(seconds=50))
 
+        # operations work normally with default timeout
         tensor = torch.rand(10)
         pg.allreduce(tensor).wait()
-        c10d.distributed_c10d._set_pg_timeout(timedelta(seconds=23), pg)
-        self.assertEqual(backend.options._timeout, timedelta(seconds=23))
-        tensor = torch.rand(10)
-        pg.allreduce(tensor).wait()
-        c10d.distributed_c10d._set_pg_timeout(timedelta(seconds=100), pg)
-        self.assertEqual(backend.options._timeout, timedelta(seconds=100))
-        tensor = torch.rand(10)
-        pg.allreduce(tensor).wait()
+
+        # change timeout to a very short value using _set_pg_timeout
+        # this is the API from issue #165422
+        c10d.distributed_c10d._set_pg_timeout(timedelta(milliseconds=1), pg)
+        self.assertEqual(backend.options._timeout, timedelta(milliseconds=1))
+
+        # demonstrate that the new timeout is actually enforced
+        # only rank 0 participates - this will cause a timeout
+        if self.rank == 0:
+            t1 = torch.zeros([1], dtype=torch.float32)
+            with self.assertRaisesRegex(RuntimeError, "Timed out waiting 1ms"):
+                pg.allreduce([t1]).wait()
+
         dist.destroy_process_group()
 
     @requires_gloo()

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -1045,6 +1045,39 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         self.assertEqual(pg.options._timeout, timedelta(seconds=23))
 
     @requires_gloo()
+    def test_gloo_set_pg_timeout_api(self):
+        """
+        Test _set_pg_timeout API for Gloo backend (issue #165422).
+        This test verifies that dynamically changing timeout via distributed_c10d._set_pg_timeout
+        actually affects subsequent operations.
+        """
+        store = c10d.FileStore(self.file_name, self.world_size)
+        dist.init_process_group(
+            backend="gloo",
+            store=store,
+            rank=self.rank,
+            world_size=self.world_size,
+            timeout=timedelta(seconds=50),
+        )
+
+        pg = dist.distributed_c10d._get_default_group()
+
+        backend = pg._get_backend(torch.device("cpu"))
+        self.assertEqual(backend.options._timeout, timedelta(seconds=50))
+
+        tensor = torch.rand(10)
+        pg.allreduce(tensor).wait()
+        c10d.distributed_c10d._set_pg_timeout(timedelta(seconds=23), pg)
+        self.assertEqual(backend.options._timeout, timedelta(seconds=23))
+        tensor = torch.rand(10)
+        pg.allreduce(tensor).wait()
+        c10d.distributed_c10d._set_pg_timeout(timedelta(seconds=100), pg)
+        self.assertEqual(backend.options._timeout, timedelta(seconds=100))
+        tensor = torch.rand(10)
+        pg.allreduce(tensor).wait()
+        dist.destroy_process_group()
+
+    @requires_gloo()
     def test_scatter_stress(self):
         inputs = [
             [torch.tensor([i + self.rank]) for _ in range(self.world_size)]

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
@@ -839,7 +839,7 @@ class AsyncBroadcastWork : public ProcessGroupGloo::AsyncWork {
     gloo::BroadcastOptions opts(context_);
     opts.setRoot(rootRank);
     opts.setTag(tag);
-    opts.setTimeout(timeout_);
+    opts.setTimeout(context_->getTimeout());
     GENERATE_ALL_TYPES(scalarType, setOutput, opts, tensor);
     gloo::broadcast(opts);
   }
@@ -1179,7 +1179,7 @@ class AsyncReduceWork : public ProcessGroupGloo::AsyncWork {
     opts.setRoot(rootRank);
     opts.setTag(tag);
     opts.setReduceFunction(getFunction(scalarType, reduceOp));
-    opts.setTimeout(timeout_);
+    opts.setTimeout(context_->getTimeout());
     GENERATE_ALL_TYPES(scalarType, setOutput, opts, tensor);
     gloo::reduce(opts);
 
@@ -1370,7 +1370,7 @@ class AsyncAllgatherWork : public ProcessGroupGloo::AsyncWork {
     const auto& scalarType = inputs[0].scalar_type();
     gloo::AllgatherOptions opts(context_);
     opts.setTag(tag);
-    opts.setTimeout(timeout_);
+    opts.setTimeout(context_->getTimeout());
 
     // Use single flattened input tensor.
     at::Tensor flatInputTensor = flattenDenseTensors(inputs);
@@ -1656,7 +1656,7 @@ class AsyncAllgatherCoalescedWork : public ProcessGroupGloo::AsyncWork {
     const auto& scalarType = input_list[0].scalar_type();
     gloo::AllgatherOptions opts(context_);
     opts.setTag(tag);
-    opts.setTimeout(timeout_);
+    opts.setTimeout(context_->getTimeout());
 
     // Use single flattened input tensor.
     at::Tensor flatInputTensor = flattenDenseTensors(input_list);
@@ -1810,7 +1810,7 @@ class AsyncGatherWork : public ProcessGroupGloo::AsyncWork {
     gloo::GatherOptions opts(context_);
     opts.setRoot(root);
     opts.setTag(tag);
-    opts.setTimeout(timeout_);
+    opts.setTimeout(context_->getTimeout());
 
     // Set single temporary tensor on root process.
     // This is later scattered to the separate output tensors.
@@ -2041,7 +2041,7 @@ class AsyncScatterWork : public ProcessGroupGloo::AsyncWork {
     gloo::ScatterOptions opts(context_);
     opts.setRoot(root);
     opts.setTag(tag);
-    opts.setTimeout(timeout_);
+    opts.setTimeout(context_->getTimeout());
 
     // Set list of input tensors on root process
     if (context_->rank == root) {
@@ -2299,7 +2299,7 @@ class AsyncAlltoallWork : public ProcessGroupGloo::AsyncWork {
       // Gloo alltoall
       gloo::AlltoallOptions opts(context_);
       opts.setTag(tag);
-      opts.setTimeout(timeout_);
+      opts.setTimeout(context_->getTimeout());
       GENERATE_ALL_TYPES(scalarType, setInput, opts, inputTensor);
       GENERATE_ALL_TYPES(scalarType, setOutput, opts, outputTensor);
       gloo::alltoall(opts);
@@ -2317,7 +2317,7 @@ class AsyncAlltoallWork : public ProcessGroupGloo::AsyncWork {
           outputCounts, outputTensor, &recvCounts, &recvOffsets);
       gloo::AlltoallvOptions opts(context_);
       opts.setTag(tag);
-      opts.setTimeout(timeout_);
+      opts.setTimeout(context_->getTimeout());
       GENERATE_ALL_TYPES(scalarType, setInput, opts, inputTensor, sendCounts);
       GENERATE_ALL_TYPES(scalarType, setOutput, opts, outputTensor, recvCounts);
       gloo::alltoallv(opts);
@@ -2594,7 +2594,7 @@ class AsyncBarrierWork : public ProcessGroupGloo::AsyncWork {
 
     gloo::BarrierOptions opts(context_);
     opts.setTag(tag);
-    opts.setTimeout(timeout_);
+    opts.setTimeout(context_->getTimeout());
     gloo::barrier(opts);
   }
 };

--- a/torch/csrc/distributed/c10d/ProcessGroupGlooDetail.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGlooDetail.hpp
@@ -302,7 +302,7 @@ class AsyncAllreduceWork : public ProcessGroupGloo::AsyncWork {
     const auto& scalarType = tensor.scalar_type();
     opts.setReduceFunction(getFunction(scalarType, reduceOp));
     opts.setTag(tag);
-    opts.setTimeout(timeout_);
+    opts.setTimeout(getTimeout());
     // Use tensor.numel() instead of tensors[0].numel() to
     // get the right number of elements when tensors[0] is complex
     GENERATE_ALL_TYPES(scalarType, setOutputs, opts, tensors, tensor.numel());
@@ -568,7 +568,7 @@ class AsyncSparseAllreduceWork : public ProcessGroupGloo::AsyncWork {
     gloo::AllgatherOptions opts(context_);
     opts.setOutput(buffer.mutable_data_ptr<int64_t>(), buffer.numel());
     opts.setTag(tag);
-    opts.setTimeout(timeout_);
+    opts.setTimeout(getTimeout());
     gloo::allgather(opts);
 
     return metadata;
@@ -600,7 +600,7 @@ class AsyncSparseAllreduceWork : public ProcessGroupGloo::AsyncWork {
         input.numel());
     opts.setOutput(output.mutable_data_ptr<int64_t>(), counts);
     opts.setTag(tag);
-    opts.setTimeout(timeout_);
+    opts.setTimeout(getTimeout());
     gloo::allgatherv(opts);
 
     // Compile indices tensor per rank.
@@ -646,7 +646,7 @@ class AsyncSparseAllreduceWork : public ProcessGroupGloo::AsyncWork {
     GENERATE_ALL_TYPES(
         valueTensor.scalar_type(), setOutput, opts, output, counts);
     opts.setTag(tag);
-    opts.setTimeout(timeout_);
+    opts.setTimeout(getTimeout());
     gloo::allgatherv(opts);
 
     // Compile values tensor per rank.


### PR DESCRIPTION
Fixes #165422

The issue was that `ProcessGroupGloo` operations were capturing the timeout value at `AsyncWork` construction time and storing it in a const member variable. When operations executed, they used this captured timeout value rather than querying the context's current timeout dynamically.



cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci