### PR TITLE
Fix test_max_autotune_cutlass_threshold

### DIFF
--- a/test/inductor/test_cutlass_backend.py
+++ b/test/inductor/test_cutlass_backend.py
@@ -234,7 +234,7 @@ class TestCutlassBackend(TestCase):
                 "max_autotune": True,
                 "max_autotune_gemm_backends": "CUTLASS",
                 "compile_threads": 4,
-                # Make it slightly to large to be accepted (m*n*k)
+                # Make it slightly too large to be accepted (m*n*k)
                 "cuda.cutlass_backend_min_gemm_size": 100 * 100 * 10 + 1,
                 "cuda.cutlass_max_profiling_configs": 2,
             }

--- a/test/inductor/test_cutlass_backend.py
+++ b/test/inductor/test_cutlass_backend.py
@@ -234,7 +234,8 @@ class TestCutlassBackend(TestCase):
                 "max_autotune": True,
                 "max_autotune_gemm_backends": "CUTLASS",
                 "compile_threads": 4,
-                "cuda.cutlass_backend_min_gemm_size": 100000,
+                # Make it slightly to large to be accepted (m*n*k)
+                "cuda.cutlass_backend_min_gemm_size": 100 * 100 * 10 + 1,
                 "cuda.cutlass_max_profiling_configs": 2,
             }
         ):


### PR DESCRIPTION
Adjust the minimum GEMM size for CUTLASS backend to ensure it is slightly larger than the threshold at https://github.com/pytorch/pytorch/blob/c1e91bd4c3bef209d43896d18abbf638bed356a9/torch/_inductor/utils.py#L1982

@kadeng can you please verify that this is the intention in this test?

It fails on H100s, see https://github.com/pytorch/pytorch/pull/160180#issuecomment-3486630403 because the check is for `m*n*k < threshold` but the current threshold is equal so the check isn't triggered and choices are found.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @chenyang78