### PR TITLE
[Dynamo] Imporve-graph-break-skip-logs

### DIFF
--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -1708,6 +1708,110 @@ from user code:
             )
 
 
+class NestedGraphBreakLoggingTests(
+    LoggingTestCase, torch._dynamo.test_case.TestCaseWithNestedGraphBreaks
+):
+    @make_logging_test(graph_breaks=True)
+    def test_skipped_frame_with_verbose_traceback_nested(self, records):
+        global f1, f2, f3
+
+        class GenericCtxMgr:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                pass
+
+        def f1(x):
+            with GenericCtxMgr():
+                torch._dynamo.graph_break()
+                return x + 1
+
+        def f2(x):
+            return f1(x + 2)
+
+        def f3(x):
+            return f2(x + 3)
+
+        torch.compile(f3, backend="eager")(torch.randn(3))
+        self.assertEqual(len(records), 1)
+        self.assertExpectedInline(
+            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+            """\
+Graph break in user code at test_error_messages.py:N
+Graph Break Reason: Encountered graph break that we cannot resume from. Compiling up to the previous resumable state, then skipping the rest of the function. Graph break encountered:
+Graph break under GenericContextWrappingVariable
+  Explanation: Attempted to graph break in an active context manager(s) that doesn't support graph breaking.
+  Hint: Move the offending context manager(s) to outside the compiled region.
+  Hint: This graph break may have been caused by an earlier graph break. Resolving the earlier graph break may resolve this one.
+
+  Developer debug context: Active generic context managers: [GenericContextWrappingVariable(GenericCtxMgr)]
+
+ For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0066.html
+User code traceback:
+  File "test_error_messages.py", line N, in test_skipped_frame_with_verbose_traceback_nested
+    torch.compile(f3, backend="eager")(torch.randn(3))
+  File "test_error_messages.py", line N, in f3
+    return f2(x + 3)
+  File "test_error_messages.py", line N, in f2
+    return f1(x + 2)
+  File "test_error_messages.py", line N, in f1
+    torch._dynamo.graph_break()
+""",
+        )
+
+    @make_logging_test(graph_breaks=True)
+    def test_skip_frame_in_loop_message_nested(self, records):
+        global f1, f2, f3
+
+        class GenericCtxMgr:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                pass
+
+        def f1(x):
+            for i in range(2):
+                with GenericCtxMgr():
+                    if x.sum() > 0:
+                        x = x + 1
+            return x
+
+        def f2(x):
+            return f1(x + 4)
+
+        def f3(x):
+            return f2(x + 5)
+
+        result = torch.compile(f3, backend="eager")(torch.randn(3))  # noqa: F841
+        self.assertEqual(len(records), 1)
+        self.assertExpectedInline(
+            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+            """\
+Graph break in user code at test_error_messages.py:N
+Graph Break Reason: Encountered graph break that we cannot resume from. Compiling up to the previous resumable state, then skipping the rest of the function. Graph break encountered:
+Data-dependent branching
+  Explanation: Detected data-dependent branching (e.g. `if my_tensor.sum() > 0:`). Dynamo does not support tracing dynamic control flow.
+  Hint: This graph break is fundamental - it is unlikely that Dynamo will ever be able to trace through your code. Consider finding a workaround.
+  Hint: Use `torch.cond` to express dynamic control flow.
+
+  Developer debug context: attempted to jump with TensorVariable()
+
+ For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0170.html
+User code traceback:
+  File "test_error_messages.py", line N, in test_skip_frame_in_loop_message_nested
+    result = torch.compile(f3, backend="eager")(torch.randn(3))  # noqa: F841
+  File "test_error_messages.py", line N, in f3
+    return f2(x + 5)
+  File "test_error_messages.py", line N, in f2
+    return f1(x + 4)
+  File "test_error_messages.py", line N, in f1
+    if x.sum() > 0:
+""",
+        )
+
+
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -1080,51 +1080,42 @@ from user code:
 """,
         )
 
-    @make_logging_test(graph_breaks=True)
-    def test_skipped_frame_no_verbose_traceback(self, records):
-        def fn(x):
-            with GenericCtxMgr():
-                assert x is None
-
-        with self.assertRaises(AssertionError):
-            torch.compile(fn, backend="eager")(torch.randn(3))
-
-        self.assertEqual(len(records), 1)
-
-        message = records[0].getMessage()
-        files = [
-            "convert_frame.py",
-            "symbolic_convert.py",
-            "bytecode_transformation.py",
-        ]
-        for file in files:
-            self.assertNotIn(file, message)
-        expected_content = [
-            "assert x is None",
-            "torch.compile will skip tracing the frame",
-        ]
-        for content in expected_content:
-            self.assertIn(content, message)
-
     @torch._dynamo.config.patch(verbose=True)
     @make_logging_test(graph_breaks=True)
     def test_skipped_frame_with_verbose_traceback(self, records):
         def fn(x):
             with GenericCtxMgr():
-                assert x is None
+                torch._dynamo.graph_break()
+                return x + 1
 
-        with self.assertRaises(AssertionError):
-            torch.compile(fn, backend="eager")(torch.randn(3))
-
+        torch.compile(fn, backend="eager")(torch.randn(3))
         self.assertEqual(len(records), 1)
-        exc_text = "".join(traceback.format_exception(*records[0].exc_info))
-        has_internal_trace = (
-            "convert_frame.py" in exc_text
-            or "symbolic_convert.py" in exc_text
-            or "exc.py" in exc_text
+        self.assertExpectedInline(
+            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+            """\
+Graph break: torch.compile cannot properly resume from this graph break, which results in a skip.
+torch.compile will skip tracing the frame fn (test_error_messages.py line N) and fall back to eager.
+The graph break occurred in the following user code:
+  File "test_error_messages.py", line N, in fn
+    torch._dynamo.graph_break()
+""",
         )
-        self.assertTrue(
-            has_internal_trace, "Expected internal stack trace with verbose=True"
+        self.assertExpectedInline(
+            munge_exc(records[0].exc_info[1], suppress_suffix=True, skip=0),
+            """\
+Graph break under GenericContextWrappingVariable
+  Explanation: Attempted to graph break in an active context manager(s) that doesn't support graph breaking.
+  Hint: Move the offending context manager(s) to outside the compiled region.
+  Hint: This graph break may have been caused by an earlier graph break. Resolving the earlier graph break may resolve this one.
+
+  Developer debug context: Active generic context managers: [GenericContextWrappingVariable(GenericCtxMgr)]
+
+ For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0066.html
+
+from user code:
+   File "test_error_messages.py", line N, in fn
+    torch._dynamo.graph_break()
+""",
         )
 
     @make_logging_test(graph_breaks=True)
@@ -1136,16 +1127,17 @@ from user code:
                         x = x + 1
             return x
 
-        result = torch.compile(fn, backend="eager")(torch.randn(3))  # noqa: F841
-
-        skip_messages = [
-            r
-            for r in records
-            if "skip" in r.getMessage().lower()
-            or "fall back to eager" in r.getMessage().lower()
-        ]
-        self.assertGreater(
-            len(skip_messages), 0, "Expected at least one skip/fallback message"
+        torch.compile(fn, backend="eager")(torch.randn(3))
+        self.assertEqual(len(records), 1)
+        self.assertExpectedInline(
+            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+            """\
+Graph break: torch.compile cannot properly resume from this graph break, which results in a skip.
+torch.compile will skip tracing the frame fn (test_error_messages.py line N) and fall back to eager.
+The graph break occurred in the following user code:
+  File "test_error_messages.py", line N, in fn
+    if x.sum() > 0:
+""",
         )
 
     @make_logging_test(graph_breaks=True)

--- a/test/dynamo/test_nested_graph_breaks.py
+++ b/test/dynamo/test_nested_graph_breaks.py
@@ -6,6 +6,8 @@ import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._dynamo import config
 from torch._dynamo.testing import make_test_cls_with_patches
+from torch.testing._internal.common_utils import munge_exc
+from torch.testing._internal.logging_utils import LoggingTestCase, make_logging_test
 
 
 try:
@@ -227,81 +229,6 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCaseWithNestedGraphBreak
 
         self.assertEqual(f4(torch.zeros(3)), torch.zeros(3) + 255)
         self.assertEqual(len(torch._dynamo.utils.counters["graph_break"]), 2)
-
-    def test_skip_frame_nested_with_context_manager(self):
-        global f1, f2
-
-        class CtxMgr:
-            def __enter__(self):
-                return self
-
-            def __exit__(self, exc_type, exc_value, traceback):
-                pass
-
-        def f1(x):
-            x = x + 1
-            with CtxMgr():
-                if x.sum() > 0:
-                    x = x + 2
-            return x + 4
-
-        def f2(x):
-            return f1(x + 8) + 16
-
-        result = torch.compile(f2, backend="eager")(torch.randn(3))
-        expected = f2(torch.randn(3))
-        self.assertEqual(result.shape, expected.shape)
-
-    def test_skip_frame_message_in_nested_calls(self):
-        global f1, f2, f3
-
-        class CtxMgr:
-            def __enter__(self):
-                return self
-
-            def __exit__(self, exc_type, exc_value, traceback):
-                pass
-
-        def f1(x):
-            with CtxMgr():
-                assert x is not None
-            return x + 1
-
-        def f2(x):
-            return f1(x + 2) + 4
-
-        def f3(x):
-            return f2(x + 8) + 16
-
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch._dynamo.optimize(backend=cnts)(f3)
-        x = torch.randn(3)
-        result = opt_fn(x)
-        expected = f3(x)
-        self.assertEqual(result.shape, expected.shape)
-
-    def test_skip_frame_with_loop_nested(self):
-        global f1, f2
-
-        class CtxMgr:
-            def __enter__(self):
-                return self
-
-            def __exit__(self, exc_type, exc_value, traceback):
-                pass
-
-        def f1(x):
-            for i in range(2):
-                with CtxMgr():
-                    if x.sum() > i:
-                        x = x + 1
-            return x
-
-        def f2(x):
-            return f1(x + 4) + 8
-
-        result = torch.compile(f2, backend="eager")(torch.randn(3))
-        self.assertIsNotNone(result)
 
     def test_supported_ctx_manager(self):
         global check, check_disabled, f1, f2, f3
@@ -948,6 +875,110 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCaseWithNestedGraphBreak
         # 2 frames from each of f5+f4, f3, f2, f1
         self.assertEqual(cnts.frame_count, 8)
         self.assertEqual(cnts.op_count, 10)
+
+
+class NestedGraphBreakLoggingTests(
+    LoggingTestCase, torch._dynamo.test_case.TestCaseWithNestedGraphBreaks
+):
+    @make_logging_test(graph_breaks=True)
+    def test_skipped_frame_with_verbose_traceback_nested(self, records):
+        global f1, f2, f3
+
+        class GenericCtxMgr:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                pass
+
+        def f1(x):
+            with GenericCtxMgr():
+                torch._dynamo.graph_break()
+                return x + 1
+
+        def f2(x):
+            return f1(x + 2)
+
+        def f3(x):
+            return f2(x + 3)
+
+        torch.compile(f3, backend="eager")(torch.randn(3))
+        self.assertEqual(len(records), 1)
+        self.assertExpectedInline(
+            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+            """\
+Graph break in user code at test_nested_graph_breaks.py:N
+Graph Break Reason: Encountered graph break that we cannot resume from. Compiling up to the previous resumable state, then skipping the rest of the function. Graph break encountered:
+Graph break under GenericContextWrappingVariable
+  Explanation: Attempted to graph break in an active context manager(s) that doesn't support graph breaking.
+  Hint: Move the offending context manager(s) to outside the compiled region.
+  Hint: This graph break may have been caused by an earlier graph break. Resolving the earlier graph break may resolve this one.
+
+  Developer debug context: Active generic context managers: [GenericContextWrappingVariable(GenericCtxMgr)]
+
+ For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0066.html
+User code traceback:
+  File "test_nested_graph_breaks.py", line N, in test_skipped_frame_with_verbose_traceback_nested
+    torch.compile(f3, backend="eager")(torch.randn(3))
+  File "test_nested_graph_breaks.py", line N, in f3
+    return f2(x + 3)
+  File "test_nested_graph_breaks.py", line N, in f2
+    return f1(x + 2)
+  File "test_nested_graph_breaks.py", line N, in f1
+    torch._dynamo.graph_break()
+""",
+        )
+
+    @make_logging_test(graph_breaks=True)
+    def test_skip_frame_in_loop_message_nested(self, records):
+        global f1, f2, f3
+
+        class GenericCtxMgr:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                pass
+
+        def f1(x):
+            for i in range(2):
+                with GenericCtxMgr():
+                    if x.sum() > 0:
+                        x = x + 1
+            return x
+
+        def f2(x):
+            return f1(x + 4)
+
+        def f3(x):
+            return f2(x + 5)
+
+        result = torch.compile(f3, backend="eager")(torch.randn(3))  # noqa: F841
+        self.assertEqual(len(records), 1)
+        self.assertExpectedInline(
+            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+            """\
+Graph break in user code at test_nested_graph_breaks.py:N
+Graph Break Reason: Encountered graph break that we cannot resume from. Compiling up to the previous resumable state, then skipping the rest of the function. Graph break encountered:
+Data-dependent branching
+  Explanation: Detected data-dependent branching (e.g. `if my_tensor.sum() > 0:`). Dynamo does not support tracing dynamic control flow.
+  Hint: This graph break is fundamental - it is unlikely that Dynamo will ever be able to trace through your code. Consider finding a workaround.
+  Hint: Use `torch.cond` to express dynamic control flow.
+
+  Developer debug context: attempted to jump with TensorVariable()
+
+ For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0170.html
+User code traceback:
+  File "test_nested_graph_breaks.py", line N, in test_skip_frame_in_loop_message_nested
+    result = torch.compile(f3, backend="eager")(torch.randn(3))  # noqa: F841
+  File "test_nested_graph_breaks.py", line N, in f3
+    return f2(x + 5)
+  File "test_nested_graph_breaks.py", line N, in f2
+    return f1(x + 4)
+  File "test_nested_graph_breaks.py", line N, in f1
+    if x.sum() > 0:
+""",
+        )
 
 
 if __name__ == "__main__":

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1885,11 +1885,7 @@ class ConvertFrame:
                         user_stack_formatted = "".join(
                             traceback.format_list(user_stack)
                         )
-                        frame_info = (
-                            f"{getattr(code, 'co_name', '<unknown>')} "
-                            f"({getattr(code, 'co_filename', '<unknown>')} "
-                            f"line {getattr(code, 'co_firstlineno', 0)})"
-                        )
+                        frame_info = exc.format_frame_info(code)
                         user_stack_trace = (
                             "Graph break: torch.compile cannot properly resume from this graph break, which results in a skip.\n"
                             f"torch.compile will skip tracing the frame {frame_info} and fall back to eager.\n"
@@ -1904,18 +1900,11 @@ class ConvertFrame:
                             },
                             payload_fn=lambda: f"{user_stack_trace}\n{traceback.format_exc()}",
                         )
-                        if config.verbose:
-                            graph_break_log.debug(
-                                user_stack_trace,
-                                exc_info=True,
-                                stack_info=True,
-                            )
-                        else:
-                            graph_break_log.debug(
-                                user_stack_trace,
-                                exc_info=True,
-                                stack_info=False,
-                            )
+                        graph_break_log.debug(
+                            user_stack_trace,
+                            exc_info=True,
+                            stack_info=config.verbose,
+                        )
 
             if not config.suppress_errors and not soft_fail:
                 raise

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -802,5 +802,14 @@ def format_error_msg(
 ) -> str:
     if config.verbose:
         return format_error_msg_verbose(exc, code, record_filename, frame)
-    return f"WON'T CONVERT {code.co_name} {code.co_filename}\
- line {code.co_firstlineno} \ndue to: \n{format_exc()}"
+    exc_msg = str(exc.args[0]) if exc.args else str(exc)
+    frame_info = (
+        f"{getattr(code, 'co_name', '<unknown>')} "
+        f"({getattr(code, 'co_filename', '<unknown>')} "
+        f"line {getattr(code, 'co_firstlineno', 0)})"
+    )
+    msg = (
+        f"torch.compile will skip tracing the frame {frame_info} and fall back to eager.\n"
+        f"Reason: {exc_msg}"
+    )
+    return msg

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -802,12 +802,18 @@ def format_frame_info(code: types.CodeType) -> str:
     )
 
 
-def format_skip_frame_message(code: types.CodeType, reason: str) -> str:
-    frame_info = format_frame_info(code)
-    return (
-        f"torch.compile intentionally decided to skip the frame {frame_info} and fall back to eager.\n"
-        f"Reason: {reason}"
-    )
+def format_skip_frame_message(code: Optional[types.CodeType], reason: str) -> str:
+    if code is not None:
+        frame_info = format_frame_info(code)
+        return (
+            f"torch.compile intentionally decided to skip the frame {frame_info} and fall back to eager.\n"
+            f"Reason: {reason}"
+        )
+    else:
+        return (
+            f"torch.compile intentionally decided to skip the frame and fall back to eager.\n"
+            f"Reason: {reason}"
+        )
 
 
 def format_loop_skip_frame_message(code: types.CodeType, frame_summary: str) -> str:

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -93,9 +93,9 @@ from .exc import (
     ArgsMismatchError,
     BackendCompilerFailed,
     collapse_resume_frames,
-    format_frame_info,
     format_graph_break_message,
     format_loop_skip_frame_message,
+    format_skip_frame_message,
     get_stack_above_dynamo,
     ResumePrologueTracingError,
     StepUnsupported,
@@ -4628,10 +4628,8 @@ class InstructionTranslator(InstructionTranslatorBase):
             and not self.error_on_graph_break
             and not self.is_tracing_resume_prologue
         ):
-            frame_info = format_frame_info(self.f_code)
             raise exc.SkipFrame(
-                f"torch.compile intentionally decided to skip the frame {frame_info} and fall back to eager.\n"
-                "Reason: no content in function call"
+                format_skip_frame_message(self.f_code, "no content in function call")
             )
         self.instruction_pointer = None
         _step_logger()(

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -605,8 +605,14 @@ def generic_jump(
         )
         # compile a partial subgraph prefix then jump into user code
         if self.maybe_has_backedge():
+            frame_info = (
+                f"{getattr(self.f_code, 'co_name', '<unknown>')} "
+                f"({getattr(self.f_code, 'co_filename', '<unknown>')} "
+                f"line {getattr(self.f_code, 'co_firstlineno', 0)})"
+            )
             msg = (
-                "Skipping frame because there is a graph break in a for/while loop\n"
+                f"torch.compile intentionally decided to skip the frame {frame_info} and fall back to eager.\n"
+                f"Reason: Skipping frame because there is a graph break in a for/while loop.\n"
                 f"{self.frame_summary()}"
             )
             log.info(msg)
@@ -883,8 +889,14 @@ def break_graph_if_unsupported(
                 )
 
                 if self.maybe_has_backedge():
+                    frame_info = (
+                        f"{getattr(self.f_code, 'co_name', '<unknown>')} "
+                        f"({getattr(self.f_code, 'co_filename', '<unknown>')} "
+                        f"line {getattr(self.f_code, 'co_firstlineno', 0)})"
+                    )
                     msg = (
-                        "Skipping frame because there is a graph break in a for/while loop\n"
+                        f"torch.compile intentionally decided to skip the frame {frame_info} and fall back to eager.\n"
+                        f"Reason: Skipping frame because there is a graph break in a for/while loop.\n"
                         f"{self.frame_summary()}"
                     )
                     log.info(msg)
@@ -4626,8 +4638,15 @@ class InstructionTranslator(InstructionTranslatorBase):
             and not self.error_on_graph_break
             and not self.is_tracing_resume_prologue
         ):
-            raise exc.SkipFrame("because no content in function call")
-
+            frame_info = (
+                f"{getattr(self.f_code, 'co_name', '<unknown>')} "
+                f"({getattr(self.f_code, 'co_filename', '<unknown>')} "
+                f"line {getattr(self.f_code, 'co_firstlineno', 0)})"
+            )
+            raise exc.SkipFrame(
+                f"torch.compile intentionally decided to skip the frame {frame_info} and fall back to eager.\n"
+                "Reason: no content in function call"
+            )
         self.instruction_pointer = None
         _step_logger()(
             logging.INFO,

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2248,13 +2248,15 @@ def skip_frame_if_in_functorch_mode(val: torch.Tensor) -> None:
     try:
         val.data_ptr()  # will throw for functorch tensors
     except RuntimeError as e:
-        from .exc import SkipFrame
+        from .exc import format_skip_frame_message, SkipFrame
 
         # This will be GradTrackingTensor/BatchedTensor/etc
         functorch_subclass_name = re.sub(r"\(.*", "", repr(val))
         raise SkipFrame(
-            f"torch.compile intentionally decided to skip the frame and fall back to eager.\n"
-            f"Reason: torch.compile cannot be run in context: {functorch_subclass_name}"
+            format_skip_frame_message(
+                None,
+                f"torch.compile cannot be run in context: {functorch_subclass_name}",
+            )
         ) from e
 
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2253,7 +2253,8 @@ def skip_frame_if_in_functorch_mode(val: torch.Tensor) -> None:
         # This will be GradTrackingTensor/BatchedTensor/etc
         functorch_subclass_name = re.sub(r"\(.*", "", repr(val))
         raise SkipFrame(
-            f"torch.compile cannot be run in context: {functorch_subclass_name}"
+            f"torch.compile intentionally decided to skip the frame and fall back to eager.\n"
+            f"Reason: torch.compile cannot be run in context: {functorch_subclass_name}"
         ) from e
 
 

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -1642,9 +1642,17 @@ class SkipFunctionVariable(VariableTracker):
             skip_frame_msg = kwargs.get("msg")
             if skip_frame_msg:
                 skip_frame_msg = skip_frame_msg.as_python_constant()
-            raise SkipFrame(
                 f"Skip frame due to `torch._dynamo.skip_frame()`. Message: {skip_frame_msg}"
+            frame_info = (
+                f"{getattr(tx.f_code, 'co_name', '<unknown>')} "
+                f"({getattr(tx.f_code, 'co_filename', '<unknown>')} "
+                f"line {getattr(tx.f_code, 'co_firstlineno', 0)})"
             )
+            msg = (
+                f"torch.compile intentionally decided to skip the frame {frame_info} and fall back to eager.\n"
+                f"Reason: Skip frame due to `torch._dynamo.skip_frame()`. Message: {skip_frame_msg}"
+            )
+            raise SkipFrame(msg)
         elif self.value is torch._dynamo.step_unsupported:
             raise StepUnsupported
         else:

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -42,6 +42,7 @@ from torch._guards import Source
 from .. import config, graph_break_hints, polyfills, variables
 from ..bytecode_transformation import create_call_function, create_rot_n, is_generator
 from ..exc import (
+    format_frame_info,
     get_dynamo_observed_exception,
     handle_observed_exception,
     InfiniteGeneratorError,
@@ -1643,11 +1644,7 @@ class SkipFunctionVariable(VariableTracker):
             if skip_frame_msg:
                 skip_frame_msg = skip_frame_msg.as_python_constant()
                 f"Skip frame due to `torch._dynamo.skip_frame()`. Message: {skip_frame_msg}"
-            frame_info = (
-                f"{getattr(tx.f_code, 'co_name', '<unknown>')} "
-                f"({getattr(tx.f_code, 'co_filename', '<unknown>')} "
-                f"line {getattr(tx.f_code, 'co_firstlineno', 0)})"
-            )
+            frame_info = format_frame_info(tx.f_code)
             msg = (
                 f"torch.compile intentionally decided to skip the frame {frame_info} and fall back to eager.\n"
                 f"Reason: Skip frame due to `torch._dynamo.skip_frame()`. Message: {skip_frame_msg}"

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -891,10 +891,14 @@ class TorchLogsFormatter(logging.Formatter):
         # exception handling - copied from logging.Formatter.format
         s = record.message
         if record.exc_info:
+            from torch._dynamo import config
+
+            should_format_exc = config.verbose or artifact_name != "graph_breaks"
             # Cache the traceback text to avoid converting it multiple times
             # (it's constant anyway)
-            if not record.exc_text:
-                record.exc_text = self.formatException(record.exc_info)
+            if should_format_exc:
+                if not record.exc_text:
+                    record.exc_text = self.formatException(record.exc_info)
         if record.exc_text:
             if s[-1:] != "\n":
                 s = s + "\n"


### PR DESCRIPTION
Fixes #150477 

### Summary:

- Added frame information (function name, file, line number) to all graph break/skip messages
- Standardized message format: "torch.compile will skip tracing the frame <name> (<file> line <N>) and fall back to eager. Reason: <reason>"

### Impacts:
module: dynamo

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela