### PR TITLE
Add dynamo config to HOP-ify context managers (v2)

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -516,6 +516,19 @@ debug_disable_compile_counter = False
 # torch._dynamo.utilsCompileTimeInstructionCounter.
 record_compile_time_instruction_count = False
 
+# Any context manager class that is included in this set will be generically
+# HOP-ified. The body of the ctx is captured in a subgraph and run under the ctx
+# during AOTAutograd. (Dynamo does not ever run __enter__ or __exit__.)
+#
+# WARNING: This is an experimental feature with many sharp edges.
+#
+# - The arguments to construct the ctx may only be constants.
+# - Returning something that is not None in __enter__ is not supported. e.g.
+#   the `with ctx as x:` pattern is not supported.
+# - TorchBind objects are not supported. We assume the dynamo-traced fx graph
+#   can only contain symints or tensor types.
+_enable_hopify_generic_context_manager: set[type] = set()
+
 
 def default_debug_dir_root() -> str:
     # [@compile_ignored: debug]

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1546,6 +1546,7 @@ def _get_dynamo_config_for_logging() -> Optional[str]:
             "ignore_logger_methods",
             "traceable_tensor_subclasses",
             "nontraceable_tensor_subclasses",
+            "_enable_hopify_generic_context_manager",
             "_custom_ops_profile",
         }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #167085
* #167084
* __->__ #167077

Based off of https://github.com/pytorch/pytorch/pull/152159

The big difference with the old PR is that we don't create a subtracer;
instead we let the nodes go directly into the original graph, and then extract
out a subgraph post facto.  This eliminates the need for VT tracking.

Authored with claude code assistance.

Signed-off-by: Edward Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela