### PR TITLE
Fix syntax for suppression comments.

### DIFF
--- a/torch/_dynamo/graph_deduplication.py
+++ b/torch/_dynamo/graph_deduplication.py
@@ -456,10 +456,10 @@ def _add_mutation_dependencies(
             for user in mutated_arg.users:
                 if user is node:
                     continue
-                # pyrefly: ignore  # unsupported-operation
+                # pyrefly: ignore [unsupported-operation]
                 elif user < node:
                     node_to_additional_deps[node].add(user)
-                # pyrefly: ignore  # unsupported-operation
+                # pyrefly: ignore [unsupported-operation]
                 elif user > node:
                     node_to_additional_deps[user].add(node)
 

--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -419,7 +419,7 @@ if "__compile_source__" in globals():
                 # pyrefly: ignore [missing-attribute]
                 kernel._fn_name
                 if isinstance(kernel, JITFunction)
-                # pyrefly: ignore  # missing-attribute
+                # pyrefly: ignore [missing-attribute]
                 else kernel.fn._fn_name
             )
             fn_name = fn_name.split(".")[-1]

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -264,7 +264,7 @@ def generate_ttir(
 
     assert isinstance(kernel, JITFunction)
 
-    # pyrefly: ignore  # missing-attribute
+    # pyrefly: ignore [missing-attribute]
     context = triton._C.libtriton.ir.context()
     target = triton.runtime.driver.active.get_current_target()
     backend = triton.compiler.compiler.make_backend(target)
@@ -306,7 +306,7 @@ def generate_ttir(
                 base_tensor = torch.empty(
                     [elements_per_dim] * len(block_shape), dtype=a.dtype
                 )
-            # pyrefly: ignore  # bad-argument-type
+            # pyrefly: ignore [bad-argument-type]
             ordered_args[name] = TensorDescriptor.from_tensor(base_tensor, block_shape)
         elif isinstance(a, (FakeTensor, torch._inductor.ir.TensorBox)):
             with torch._C._DisableTorchDispatch():
@@ -370,7 +370,7 @@ def generate_ttir(
 
             target = triton.runtime.driver.active.get_current_target()
             backend_ = triton.compiler.compiler.make_backend(target)
-            # pyrefly: ignore  # missing-attribute
+            # pyrefly: ignore [missing-attribute]
             return backend_.get_attrs_descriptor(args, kernel.params)
         else:
             assert (
@@ -387,7 +387,7 @@ def generate_ttir(
                 except TypeError:  # Unknown arg `specialize_extra`
                     # Older versions of Triton take specialize_extra as an arg to specialize_impl
                     specialize_impl = functools.partial(
-                        # pyrefly: ignore  # missing-argument
+                        # pyrefly: ignore [missing-argument]
                         triton.runtime.jit.create_specialize_impl(),
                         specialize_extra=backend.get_arg_specialization,  # pyrefly: ignore [missing-attribute]
                     )
@@ -472,7 +472,7 @@ def generate_ttir(
             if i not in constexprs
         }
 
-    # pyrefly: ignore  # missing-attribute
+    # pyrefly: ignore [missing-attribute]
     triton._C.libtriton.ir.load_dialects(context)
     backend.load_dialects(context)
 
@@ -482,30 +482,30 @@ def generate_ttir(
     # backward compatibility here.
     make_ir_sig_params = len(inspect.signature(src.make_ir).parameters)
     get_codegen_implementation_sig_params = len(
-        # pyrefly: ignore  # missing-attribute
+        # pyrefly: ignore [missing-attribute]
         inspect.signature(backend.get_codegen_implementation).parameters
     )
     if make_ir_sig_params == 2:
-        # pyrefly: ignore  # missing-argument
+        # pyrefly: ignore [missing-argument]
         ttir_module = src.make_ir(options, context)
     elif make_ir_sig_params == 3:
-        # pyrefly: ignore  # missing-attribute
+        # pyrefly: ignore [missing-attribute]
         codegen_fns = backend.get_codegen_implementation()
-        # pyrefly: ignore  # missing-argument
+        # pyrefly: ignore [missing-argument]
         ttir_module = src.make_ir(options, codegen_fns, context)
     elif make_ir_sig_params == 4:
         codegen_args = [options] if get_codegen_implementation_sig_params == 1 else []
-        # pyrefly: ignore  # missing-attribute
+        # pyrefly: ignore [missing-attribute]
         codegen_fns = backend.get_codegen_implementation(*codegen_args)
         module_map = backend.get_module_map()
         # pyrefly: ignore[missing-argument,bad-argument-type]
         ttir_module = src.make_ir(options, codegen_fns, module_map, context)
     else:
         codegen_args = [options] if get_codegen_implementation_sig_params == 1 else []
-        # pyrefly: ignore  # missing-attribute
+        # pyrefly: ignore [missing-attribute]
         codegen_fns = backend.get_codegen_implementation(*codegen_args)
         module_map = backend.get_module_map()
-        # pyrefly: ignore  # bad-argument-count
+        # pyrefly: ignore [bad-argument-count]
         ttir_module = src.make_ir(target, options, codegen_fns, module_map, context)
     if not ttir_module.verify():
         raise RuntimeError("Verification for TTIR module has failed")
@@ -1127,7 +1127,7 @@ def triton_kernel_wrapper_mutation_dense(
                 from triton.tools.tensor_descriptor import TensorDescriptor
 
                 block_shape = stable_meta[0]
-                # pyrefly: ignore  # bad-argument-type
+                # pyrefly: ignore [bad-argument-type]
                 kwargs[k] = TensorDescriptor.from_tensor(tensor, block_shape)
 
     # move as many positional arguments from dicts to args as we
@@ -1684,7 +1684,7 @@ class TritonHOPifier:
                     "Passing multiple @triton.autotune decorators is not supported. "
                     "Please use a single @triton.autotune decorator instead."
                 )
-            # pyrefly: ignore  # missing-attribute
+            # pyrefly: ignore [missing-attribute]
             iter_kernel = iter_kernel.fn
 
         # Process the @triton.heuristics decorator:
@@ -1895,7 +1895,7 @@ class TritonHOPifier:
 
         # Both for grid's meta as well as for the kernel, we need combined
         # args and kwargs combined and normalized
-        # pyrefly: ignore  # missing-attribute
+        # pyrefly: ignore [missing-attribute]
         combined_args_raw = {**dict(zip(variable.kernel.arg_names, args)), **kwargs}
 
         # precompute the grid for the kernel
@@ -2089,7 +2089,7 @@ class TraceableTritonKernelWrapper:
         kernel_idx: Optional[int],
         grid: Optional["TritonGridType"],
     ) -> None:
-        # pyrefly: ignore  # bad-assignment
+        # pyrefly: ignore [bad-assignment]
         self.kernel = None
         self.grid = None
         tracing_triton_hopifier_singleton.init_variable(self, kernel, kernel_idx, grid)

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -325,14 +325,14 @@ def user_defined_triton_kernel_transitive_closure_source_code(kernel) -> str:
                 if isinstance(symbol, JITFunction):
                     compile_wrapper.newline()
                     compile_wrapper.writeline("@triton.jit")
-                    # pyrefly: ignore  # missing-attribute
+                    # pyrefly: ignore [missing-attribute]
                     compile_wrapper.splice(symbol.src, strip=True)
                     symbols_included.add(symbol_name)
                     traverse(symbol)
                 elif hasattr(triton, "constexpr_function") and isinstance(
-                    # pyrefly: ignore  # missing-attribute
+                    # pyrefly: ignore [missing-attribute]
                     symbol,
-                    # pyrefly: ignore  # missing-attribute
+                    # pyrefly: ignore [missing-attribute]
                     triton.runtime.jit.ConstexprFunction,
                 ):
                     compile_wrapper.newline()

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -950,9 +950,9 @@ class FxConverter:
             from triton.runtime import driver
 
             log.info("Autotuning Triton kernel %s at compile time.", kernel_name)
-            # pyrefly: ignore  # missing-attribute
+            # pyrefly: ignore [missing-attribute]
             device = driver.active.get_current_device()
-            # pyrefly: ignore  # missing-attribute
+            # pyrefly: ignore [missing-attribute]
             stream = driver.active.get_current_stream(device)
 
             def node_to_tuning_arg(arg: Any) -> Any:

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6982,7 +6982,7 @@ class UserDefinedTritonKernel(ExternKernel):
 
             configs = kernel.configs
             kernel = kernel.fn
-        # pyrefly: ignore  # bad-return
+        # pyrefly: ignore [bad-return]
         return kernel, configs, restore_value_args, reset_to_zero_args
 
     @override
@@ -7138,7 +7138,7 @@ class UserDefinedTritonKernel(ExternKernel):
         self.mutable_args = [
             kernel_args[key]
             for key in identify_mutated_tensors(
-                # pyrefly: ignore  # bad-argument-type
+                # pyrefly: ignore [bad-argument-type]
                 kernel,
                 {**kernel_args, **autotuned_kwargs},
                 tma_descriptor_metadata,

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2683,14 +2683,14 @@ def get_device_tflops(dtype: torch.dtype) -> float:
             return get_max_simd_tflops(torch.float32, sm_clock)
     else:
         if dtype in (torch.float16, torch.bfloat16) and SM80OrLater:
-            # pyrefly: ignore  # missing-argument
+            # pyrefly: ignore [missing-argument]
             return get_max_tensorcore_tflops(dtype)
 
         if torch.backends.cuda.matmul.allow_tf32:
-            # pyrefly: ignore  # missing-argument
+            # pyrefly: ignore [missing-argument]
             return get_max_tensorcore_tflops(torch.float32)
         else:
-            # pyrefly: ignore  # missing-argument
+            # pyrefly: ignore [missing-argument]
             return get_max_simd_tflops(torch.float32)
 
 
@@ -2704,7 +2704,7 @@ def get_gpu_dram_gbps() -> int:
 def get_gpu_shared_memory() -> int:
     from triton.runtime import driver
 
-    # pyrefly: ignore  # missing-attribute
+    # pyrefly: ignore [missing-attribute]
     return driver.active.utils.get_device_properties(0).get("max_shared_mem", 0)
 
 

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -3392,7 +3392,7 @@ def gather_object(
 
     if object_gather_list is None:
         raise AssertionError("Must provide object_gather_list on dst rank")
-    # pyrefly: ignore  # unbound-name
+    # pyrefly: ignore [unbound-name]
     for i, tensor in enumerate(output_tensors):
         tensor = tensor.type(torch.uint8)
         tensor_size = object_size_list[i]

--- a/torch/nn/parallel/scatter_gather.py
+++ b/torch/nn/parallel/scatter_gather.py
@@ -60,7 +60,7 @@ def scatter(inputs, target_gpus, dim=0):
             return [
                 # pyrefly: ignore [no-matching-overload]
                 type(obj)(*args)
-                # pyrefly: ignore  # no-matching-overload
+                # pyrefly: ignore [no-matching-overload]
                 for args in zip(*map(scatter_map, obj), strict=False)
             ]
         if isinstance(obj, tuple) and len(obj) > 0:
@@ -74,7 +74,7 @@ def scatter(inputs, target_gpus, dim=0):
             return [
                 # pyrefly: ignore [no-matching-overload]
                 type(obj)(i)
-                # pyrefly: ignore  # no-matching-overload
+                # pyrefly: ignore [no-matching-overload]
                 for i in zip(*map(scatter_map, obj.items()), strict=False)
             ]
         return [obj for _ in target_gpus]

--- a/torch/sparse/_triton_ops.py
+++ b/torch/sparse/_triton_ops.py
@@ -1339,28 +1339,28 @@ def bsr_dense_addmm(
         # pyrefly: ignore [unsupported-operation]
         _bsr_strided_addmm_kernel[grid](
             *ptr_stride_extractor(*sliced_tensors),
-            # pyrefly: ignore  # bad-argument-count
+            # pyrefly: ignore [bad-argument-count]
             beta,
             alpha,
-            # pyrefly: ignore  # bad-keyword-argument, bad-argument-type
+            # pyrefly: ignore [bad-keyword-argument, bad-argument-type]
             beta_is_one=beta == 1,
-            # pyrefly: ignore  # bad-keyword-argument, bad-argument-type
+            # pyrefly: ignore [bad-keyword-argument, bad-argument-type]
             beta_is_nonzero=beta != 0,
-            # pyrefly: ignore  # bad-keyword-argument, bad-argument-type
+            # pyrefly: ignore [bad-keyword-argument, bad-argument-type]
             alpha_is_one=alpha == 1,
-            # pyrefly: ignore  # bad-keyword-argument, bad-argument-type
+            # pyrefly: ignore [bad-keyword-argument, bad-argument-type]
             left_alpha_is_one=left_alpha_is_one,
-            # pyrefly: ignore  # bad-keyword-argument, bad-argument-type
+            # pyrefly: ignore [bad-keyword-argument, bad-argument-type]
             right_alpha_is_one=right_alpha_is_one,
-            # pyrefly: ignore  # bad-keyword-argument, bad-argument-type
+            # pyrefly: ignore [bad-keyword-argument, bad-argument-type]
             BLOCKSIZE_ROW=BM,
-            # pyrefly: ignore  # bad-keyword-argument, bad-argument-type
+            # pyrefly: ignore [bad-keyword-argument, bad-argument-type]
             BLOCKSIZE_INNER=BK,
-            # pyrefly: ignore  # bad-keyword-argument
+            # pyrefly: ignore [bad-keyword-argument]
             BLOCKSIZE_COL=BN,
-            # pyrefly: ignore  # bad-keyword-argument
+            # pyrefly: ignore [bad-keyword-argument]
             allow_tf32=dot_out_dtype == tl.float32,
-            # pyrefly: ignore  # bad-keyword-argument, bad-argument-type
+            # pyrefly: ignore [bad-keyword-argument, bad-argument-type]
             acc_dtype=dot_out_dtype,
             **meta,
         )
@@ -1681,17 +1681,17 @@ if has_triton():
                 beta,
                 is_beta_zero,
                 *blocksize,
-                # pyrefly: ignore  # bad-argument-count
+                # pyrefly: ignore [bad-argument-count]
                 k,
                 tile_k,
                 *ptr_stride_extractor(*sliced_tensors),
-                # pyrefly: ignore  # bad-keyword-argument, bad-argument-type
+                # pyrefly: ignore [bad-keyword-argument, bad-argument-type]
                 acc_dtype=acc_dtype,
-                # pyrefly: ignore  # bad-keyword-argument, bad-argument-type
+                # pyrefly: ignore [bad-keyword-argument, bad-argument-type]
                 allow_tf32=allow_tf32,
-                # pyrefly: ignore  # unexpected-keyword
+                # pyrefly: ignore [unexpected-keyword]
                 num_stages=1,
-                # pyrefly: ignore  # unexpected-keyword
+                # pyrefly: ignore [unexpected-keyword]
                 num_warps=4,
             )
 
@@ -1976,7 +1976,7 @@ if has_triton():
         def kernel(grid, *sliced_tensors):
             _bsr_softmax_kernel[grid](
                 *ptr_stride_extractor(*sliced_tensors),
-                # pyrefly: ignore  # bad-argument-count
+                # pyrefly: ignore [bad-argument-count]
                 row_block,
                 col_block,
                 max_row_nnz,
@@ -2151,11 +2151,11 @@ if has_triton():
         if "allow_tf32" not in meta:
             meta.update(allow_tf32=dot_out_dtype == tl.float32)
         _scatter_mm2_kernel[grid](
-            # pyrefly: ignore  # bad-argument-type
+            # pyrefly: ignore [bad-argument-type]
             M,
-            # pyrefly: ignore  # bad-argument-type
+            # pyrefly: ignore [bad-argument-type]
             K,
-            # pyrefly: ignore  # bad-argument-type
+            # pyrefly: ignore [bad-argument-type]
             N,
             blocks,
             blocks.stride(0),
@@ -2174,9 +2174,9 @@ if has_triton():
             pq_indices,
             pq_indices.stride(0),
             pq_indices.stride(1),
-            # pyrefly: ignore  # bad-argument-type
+            # pyrefly: ignore [bad-argument-type]
             dot_out_dtype=dot_out_dtype,
-            # pyrefly: ignore  # bad-argument-type
+            # pyrefly: ignore [bad-argument-type]
             **meta,
         )
 
@@ -2373,7 +2373,7 @@ if has_triton():
         _scatter_mm6_kernel[grid](
             B,
             Ms,
-            # pyrefly: ignore  # bad-argument-type
+            # pyrefly: ignore [bad-argument-type]
             Ks,
             N,
             blocks,
@@ -2392,7 +2392,7 @@ if has_triton():
             r_offsets,
             p_offsets,
             q_offsets,
-            # pyrefly: ignore  # bad-argument-type
+            # pyrefly: ignore [bad-argument-type]
             dot_out_dtype=dot_out_dtype,
             **meta,
         )


### PR DESCRIPTION
Cleaning up the last few remaining pyrefly suppressions using the incorrect syntax. 


these will now correctly only silence the error code found between the brackets. 

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @chenyang78