### PR TITLE
[cuDNN][SDPA] Disable cuDNN for `seqlen_q % 128 != 0`

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -726,7 +726,7 @@ bool can_use_cudnn_attention(const sdp_params& params, bool debug) {
     }
     return false;
   }
-  if (params.query.size(2) % 128 != 0  && (cudnn_version <= 91500 || CUDNN_FRONTEND_VERSION < 11600)) {
+  if ((cudnn_version <= 91500 || CUDNN_FRONTEND_VERSION < 11600) && params.query.size(2) % 128 != 0) {
     if (debug) {
       TORCH_WARN("You have cuDNN backend version ",
                  CUDNN_VERSION,

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -732,7 +732,7 @@ bool can_use_cudnn_attention(const sdp_params& params, bool debug) {
                  CUDNN_VERSION,
                  " and frontend version ",
                  CUDNN_FRONTEND_VERSION,
-                 ". query seq_len % 128 != 0 requires cuDNN backend 9.15.1+ _and cuDNN frontend 1.16.0+.",
+                 ". query seq_len % 128 != 0 requires cuDNN backend 9.15.1+ _and_ cuDNN frontend 1.16.0+.",
                  "Please consider upgrading to a nightly build or newer PyTorch release if you require this functionality."
                  );
     }

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -706,7 +706,7 @@ bool can_use_cudnn_attention(const sdp_params& params, bool debug) {
 #if defined(CUDNN_VERSION)
   static auto cudnn_version = at::detail::getCUDAHooks().versionRuntimeCuDNN();
 #else
-  static audo cudnn_version = 0;
+  static auto cudnn_version = 0;
 #endif
 #if defined(USE_ROCM) || !AT_CUDNN_ENABLED() || !defined(CUDNN_VERSION)
   if (debug) {

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2809,7 +2809,7 @@ class TestSDPACudaOnly(NNTestCase):
                 f()
         else:
             f()
-    
+
     @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cudnn Attention is not supported on this system")
     def test_cudnn_attention_preserves_query_layout(self, device):
 


### PR DESCRIPTION
Seems to cause problems with CUDA graph captures, so preemptively disabling these cases.

cc @csarofeen @ptrblck @xwang233 @mcarilli @ezyang @eellison @penguinwu @BoyuanFeng