### PR TITLE
Checking test_hook_remove 

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6074,7 +6074,6 @@ class TestTorchDeviceType(TestCase):
                         check_equal(torch.tensor(True), y, x)
 
 
-    @skipIfTorchInductor("FIXME")
     def test_hook_remove(self, device):
         # Reference: https://github.com/pytorch/pytorch/issues/58354
         def _test_helper(remove_hook):


### PR DESCRIPTION
Previously test_hook_remove had to be skipped for inductor. Locally it now passes as is. Testing in CI.