### PR TITLE
Increase timeout for linux-jammy-cuda12_8-py3_10-gcc11-test to 400 minutes

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -93,7 +93,7 @@ jobs:
       - linux-jammy-cuda12_8-py3_10-gcc11-build
       - target-determination
     with:
-      timeout-minutes: 360
+      timeout-minutes: 400
       build-environment: linux-jammy-cuda12.8-py3.10-gcc11
       docker-image: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc11-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda12_8-py3_10-gcc11-build.outputs.test-matrix }}


### PR DESCRIPTION
short term mitigation for the recent timeouts, [see hud](https://hud.pytorch.org/hud/pytorch/pytorch/0c7a4a6b48d49306eae8d0a9ee8d32b1899e5e23/1?per_page=200&name_filter=trunk%20%2F%20linux-jammy-cuda12.8-py3.10-gcc11%20%2F%20test&mergeEphemeralLF=true).