### PR TITLE
Make the new Node* fn parameter optional so it can be backward compatible (#167045)

### DIFF
--- a/torch/csrc/autograd/input_buffer.cpp
+++ b/torch/csrc/autograd/input_buffer.cpp
@@ -234,7 +234,7 @@ void InputBuffer::add(
 
   TORCH_INTERNAL_ASSERT(opt_consumer_stream && opt_producer_stream);
 
-  if (*opt_consumer_stream != *opt_producer_stream &&
+  if (fn != nullptr && *opt_consumer_stream != *opt_producer_stream &&
       dynamic_cast<AccumulateGrad*>(fn) &&
       at::globalContext().warnOnAccumulateGradStreamMismatch()) {
     TORCH_WARN_ONCE(

--- a/torch/csrc/autograd/input_buffer.h
+++ b/torch/csrc/autograd/input_buffer.h
@@ -33,7 +33,7 @@ struct InputBuffer {
       Variable&& var,
       const std::optional<c10::Stream>& opt_producer_stream,
       const std::optional<c10::Stream>& opt_consumer_stream,
-      Node* fn);
+      Node* fn = nullptr);
 
   Variable operator[](size_t pos) {
     return buffer[pos];


### PR DESCRIPTION
Summary:

X-link: monarch/pull/1755

D85360862 added this new parameter `Node* fn` to method `add`. This change is not backward compatible, and it breaks monarch's contbuild in the following way:

1. `Monarch` has 2 type of build targets, one is built direct from fbcode. In order to build those targets, this `add` method' callsite in monarch is updated. (this was done as part of D85360862)
2. However, `monarch` also has a `wheel` target. This wheel does not build torget from fbcode. Instead it fetches from [an fbpkg](https://www.internalfb.com/code/fbsource/[2434d07c3b73]/fbcode/monarch/python/monarch/BUCK?lines=116), which still contains the old torch version.

In other words, monarch needs to build with both old and new version of torch, and we could not figure out a good way to resolve this.

## Proposal

Wondering if we could make this `Node* fn` parameter optional, so the method can become backward compatible? The change potentially can benefit other users too, not just monarch.

Test Plan: sandcastle

Reviewed By: dulinriley

Differential Revision: D86256198


