### PR TITLE
[CI] Fix segfault at exit causing timeout

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -782,6 +782,13 @@ def run_test_retries(
             if not continue_through_error:
                 print_to_file("Stopping at first consistent failure")
                 break
+            if current_failure == f"'{test_file}'":
+                # Something failed consistently in the entire suite and we don't
+                # know how to skip only that one individual test, so stop here
+                print_to_file(
+                    "Entire suite failed consistently, stopping here"
+                )
+                break
             sc_command = f"--scs={stepcurrent_key}"
             print_to_file(
                 "Test failed consistently, "

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -785,9 +785,7 @@ def run_test_retries(
             if current_failure == f"'{test_file}'":
                 # Something failed consistently in the entire suite and we don't
                 # know how to skip only that one individual test, so stop here
-                print_to_file(
-                    "Entire suite failed consistently, stopping here"
-                )
+                print_to_file("Entire suite failed consistently, stopping here")
                 break
             sc_command = f"--scs={stepcurrent_key}"
             print_to_file(


### PR DESCRIPTION
The segfault is a real issue, but the retry mechanisms made it always retry in an infinite loop, which led to a timeout.  This stops the infinite loop

This is also only a problem that happens when keep-going is used 

test_ops
test_ops.py