### PR TITLE
[user-streams] Mark stream ops as side effectful

### DIFF
--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -486,6 +486,22 @@ class GraphModule(torch.nn.Module):
             torch.accelerator.set_stream(original_stream)
             reset_user_object_tracking()
 
+    def test_is_marked_side_effectful(self):
+        self.assertIn(
+            torch.ops.streams.fork.default, torch.fx.node._side_effectful_functions
+        )
+        self.assertIn(
+            torch.ops.streams.join.default, torch.fx.node._side_effectful_functions
+        )
+        self.assertIn(
+            torch.ops.streams.wait_event.default,
+            torch.fx.node._side_effectful_functions,
+        )
+        self.assertIn(
+            torch.ops.streams.record_event.default,
+            torch.fx.node._side_effectful_functions,
+        )
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_dynamo/variables/streams.py
+++ b/torch/_dynamo/variables/streams.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 import torch
 from torch._dynamo.variables.dicts import ConstDictVariable
 from torch._dynamo.variables.lists import TupleVariable
-from torch.fx import Proxy
+from torch.fx import has_side_effect, Proxy
 
 from .. import graph_break_hints
 from ..bytecode_transformation import create_call_function
@@ -60,6 +60,9 @@ def _(
     pass
 
 
+has_side_effect(torch.ops.streams.fork.default)
+
+
 @custom_op("streams::join", mutates_args=())
 def join_stream(from_index: int, to_index: int) -> None:
     torch.accelerator.set_stream(_get_stream_by_index(to_index))
@@ -71,6 +74,9 @@ def _(
     to_index: int,
 ) -> None:
     pass
+
+
+has_side_effect(torch.ops.streams.join.default)
 
 
 @custom_op("streams::record_event", mutates_args=())
@@ -88,6 +94,9 @@ def _(
     pass
 
 
+has_side_effect(torch.ops.streams.record_event.default)
+
+
 @custom_op("streams::wait_event", mutates_args=())
 def wait_event(event_index: int, stream_index: int) -> None:
     event = _get_event_by_index(event_index)
@@ -101,6 +110,9 @@ def _(
     stream_index: int,
 ) -> None:
     pass
+
+
+has_side_effect(torch.ops.streams.wait_event.default)
 
 
 class SymbolicStreamState:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #167177
* #167180
* #167176
* #167175
* __->__ #167152
* #167151
* #167141



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela