### PR TITLE
Print kernel/result details when throwing BrokenProcessPool in async_compile

### DIFF
--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -670,10 +670,11 @@ class AsyncCompile:
                 scope[key] = kernel
             except BrokenProcessPool as e:
                 raise RuntimeError(
-                    "A compilation subprocess exited unexpectedly. This "
+                    f"A compilation subprocess exited unexpectedly. This "
                     "is likely due to a crash. To facilitate debugging, "
                     "you can re-run with TORCHINDUCTOR_COMPILE_THREADS=1 "
                     "to cause compilation to occur in the main process."
+                    "key: {key}, result: {result}"
                 ) from e
             pbar.update(1)
 


### PR DESCRIPTION
Summary: Improve debuggability

Test Plan: CI

Differential Revision: D86358858




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben