### PR TITLE
Add missing super().setUp()

### DIFF
--- a/test/ao/sparsity/test_scheduler.py
+++ b/test/ao/sparsity/test_scheduler.py
@@ -75,7 +75,7 @@ class TestScheduler(TestCase):
 
 class TestCubicScheduler(TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self.model_sparse_config = [
             {"tensor_fqn": "0.weight", "sparsity_level": 0.8},
             {"tensor_fqn": "2.weight", "sparsity_level": 0.4},

--- a/test/ao/sparsity/test_scheduler.py
+++ b/test/ao/sparsity/test_scheduler.py
@@ -75,6 +75,7 @@ class TestScheduler(TestCase):
 
 class TestCubicScheduler(TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         self.model_sparse_config = [
             {"tensor_fqn": "0.weight", "sparsity_level": 0.8},
             {"tensor_fqn": "2.weight", "sparsity_level": 0.4},

--- a/test/backends/xeon/test_launch.py
+++ b/test/backends/xeon/test_launch.py
@@ -11,6 +11,7 @@ from torch.testing._internal.common_utils import IS_LINUX, run_tests, TestCase
 @unittest.skipIf(not IS_LINUX, "Only works on linux")
 class TestTorchrun(TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         self._test_dir = tempfile.mkdtemp(prefix=self.__class__.__name__)
 
     def tearDown(self):

--- a/test/backends/xeon/test_launch.py
+++ b/test/backends/xeon/test_launch.py
@@ -11,7 +11,7 @@ from torch.testing._internal.common_utils import IS_LINUX, run_tests, TestCase
 @unittest.skipIf(not IS_LINUX, "Only works on linux")
 class TestTorchrun(TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self._test_dir = tempfile.mkdtemp(prefix=self.__class__.__name__)
 
     def tearDown(self):

--- a/test/custom_backend/test_custom_backend.py
+++ b/test/custom_backend/test_custom_backend.py
@@ -11,7 +11,7 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 class TestCustomBackend(TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         # Load the library containing the custom backend.
         self.library_path = get_custom_backend_library_path()
         torch.ops.load_library(self.library_path)

--- a/test/custom_backend/test_custom_backend.py
+++ b/test/custom_backend/test_custom_backend.py
@@ -11,6 +11,7 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 class TestCustomBackend(TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         # Load the library containing the custom backend.
         self.library_path = get_custom_backend_library_path()
         torch.ops.load_library(self.library_path)

--- a/test/custom_operator/test_custom_ops.py
+++ b/test/custom_operator/test_custom_ops.py
@@ -18,6 +18,7 @@ torch.ops.import_module("pointwise")
 
 class TestCustomOperators(TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         self.library_path = get_custom_op_library_path()
         ops.load_library(self.library_path)
 

--- a/test/custom_operator/test_custom_ops.py
+++ b/test/custom_operator/test_custom_ops.py
@@ -18,7 +18,7 @@ torch.ops.import_module("pointwise")
 
 class TestCustomOperators(TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self.library_path = get_custom_op_library_path()
         ops.load_library(self.library_path)
 

--- a/test/distributed/checkpoint/_experimental/test_builder.py
+++ b/test/distributed/checkpoint/_experimental/test_builder.py
@@ -22,6 +22,7 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 class TestMakeCheckpointer(TestCase):
     def setUp(self) -> None:
+        TestCase.setUp(self)
         # Create a temporary directory for checkpoints
         self.temp_dir = tempfile.mkdtemp()
 

--- a/test/distributed/checkpoint/_experimental/test_builder.py
+++ b/test/distributed/checkpoint/_experimental/test_builder.py
@@ -22,7 +22,7 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 class TestMakeCheckpointer(TestCase):
     def setUp(self) -> None:
-        TestCase.setUp(self)
+        super().setUp()
         # Create a temporary directory for checkpoints
         self.temp_dir = tempfile.mkdtemp()
 

--- a/test/distributed/checkpoint/_experimental/test_checkpoint_process.py
+++ b/test/distributed/checkpoint/_experimental/test_checkpoint_process.py
@@ -161,6 +161,7 @@ class TestCheckpointProcessConfig(TestCase):
 
 class TestCheckpointProcess(TestCase):
     def setUp(self) -> None:
+        TestCase.setUp(self)
         """Set up common test fixtures."""
         self.rank_info = RankInfo(
             global_world_size=1,

--- a/test/distributed/checkpoint/_experimental/test_checkpoint_process.py
+++ b/test/distributed/checkpoint/_experimental/test_checkpoint_process.py
@@ -161,7 +161,7 @@ class TestCheckpointProcessConfig(TestCase):
 
 class TestCheckpointProcess(TestCase):
     def setUp(self) -> None:
-        TestCase.setUp(self)
+        super().setUp()
         """Set up common test fixtures."""
         self.rank_info = RankInfo(
             global_world_size=1,

--- a/test/distributed/checkpoint/_experimental/test_checkpoint_reader.py
+++ b/test/distributed/checkpoint/_experimental/test_checkpoint_reader.py
@@ -14,7 +14,7 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 class TestCheckpointReader(TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         # Create a temporary directory for test checkpoints
         self.temp_dir = tempfile.mkdtemp()
 

--- a/test/distributed/checkpoint/_experimental/test_checkpoint_reader.py
+++ b/test/distributed/checkpoint/_experimental/test_checkpoint_reader.py
@@ -14,6 +14,7 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 class TestCheckpointReader(TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         # Create a temporary directory for test checkpoints
         self.temp_dir = tempfile.mkdtemp()
 

--- a/test/distributed/checkpoint/_experimental/test_checkpoint_writer.py
+++ b/test/distributed/checkpoint/_experimental/test_checkpoint_writer.py
@@ -52,7 +52,7 @@ class TestCheckpointWriterConfig(TestCase):
 
 class TestCheckpointWriter(TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         # Create a temporary directory for test checkpoints
         self.temp_dir = tempfile.mkdtemp()
 

--- a/test/distributed/checkpoint/_experimental/test_checkpoint_writer.py
+++ b/test/distributed/checkpoint/_experimental/test_checkpoint_writer.py
@@ -52,6 +52,7 @@ class TestCheckpointWriterConfig(TestCase):
 
 class TestCheckpointWriter(TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         # Create a temporary directory for test checkpoints
         self.temp_dir = tempfile.mkdtemp()
 

--- a/test/distributed/checkpoint/_experimental/test_checkpointer.py
+++ b/test/distributed/checkpoint/_experimental/test_checkpointer.py
@@ -52,6 +52,7 @@ class TestCheckpointer(TestCase):
     """Parameterized tests that work with both sync and async checkpointers."""
 
     def setUp(self):
+        TestCase.setUp(self)
         # Create a temporary directory for checkpoints
         self.temp_dir = tempfile.mkdtemp()
 
@@ -397,6 +398,7 @@ class TestAsyncCheckpointerSpecific(TestCase):
     """Tests specific to AsyncCheckpointer functionality."""
 
     def setUp(self):
+        TestCase.setUp(self)
         # Create a temporary directory for checkpoints
         self.temp_dir = tempfile.mkdtemp()
 

--- a/test/distributed/checkpoint/_experimental/test_checkpointer.py
+++ b/test/distributed/checkpoint/_experimental/test_checkpointer.py
@@ -52,7 +52,7 @@ class TestCheckpointer(TestCase):
     """Parameterized tests that work with both sync and async checkpointers."""
 
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         # Create a temporary directory for checkpoints
         self.temp_dir = tempfile.mkdtemp()
 
@@ -398,7 +398,7 @@ class TestAsyncCheckpointerSpecific(TestCase):
     """Tests specific to AsyncCheckpointer functionality."""
 
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         # Create a temporary directory for checkpoints
         self.temp_dir = tempfile.mkdtemp()
 

--- a/test/distributed/checkpoint/_experimental/test_staging.py
+++ b/test/distributed/checkpoint/_experimental/test_staging.py
@@ -12,7 +12,7 @@ from torch.testing._internal.common_utils import requires_cuda, run_tests, TestC
 
 class TestDefaultStager(TestCase):
     def setUp(self) -> None:
-        TestCase.setUp(self)
+        super().setUp()
         # Create a test state dictionary with various data types
         self.state_dict = {
             "model": torch.nn.Linear(10, 5).state_dict(),

--- a/test/distributed/checkpoint/_experimental/test_staging.py
+++ b/test/distributed/checkpoint/_experimental/test_staging.py
@@ -12,6 +12,7 @@ from torch.testing._internal.common_utils import requires_cuda, run_tests, TestC
 
 class TestDefaultStager(TestCase):
     def setUp(self) -> None:
+        TestCase.setUp(self)
         # Create a test state dictionary with various data types
         self.state_dict = {
             "model": torch.nn.Linear(10, 5).state_dict(),

--- a/test/distributed/checkpoint/test_quantized_hf_storage.py
+++ b/test/distributed/checkpoint/test_quantized_hf_storage.py
@@ -15,7 +15,7 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 class TestQuantizedHfStorage(TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         """Set up common test fixtures."""
         self.temp_dir = tempfile.TemporaryDirectory()
         self.path = self.temp_dir.name

--- a/test/distributed/checkpoint/test_quantized_hf_storage.py
+++ b/test/distributed/checkpoint/test_quantized_hf_storage.py
@@ -15,6 +15,7 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 class TestQuantizedHfStorage(TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         """Set up common test fixtures."""
         self.temp_dir = tempfile.TemporaryDirectory()
         self.path = self.temp_dir.name

--- a/test/distributed/elastic/multiprocessing/test_api.py
+++ b/test/distributed/elastic/multiprocessing/test_api.py
@@ -21,6 +21,7 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 class SignalHandlingTest(TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         # Save original environment variable if it exists
         self.original_signals_env = os.environ.get(
             "TORCHELASTIC_SIGNALS_TO_HANDLE", None

--- a/test/distributed/elastic/multiprocessing/test_api.py
+++ b/test/distributed/elastic/multiprocessing/test_api.py
@@ -21,7 +21,7 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 class SignalHandlingTest(TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         # Save original environment variable if it exists
         self.original_signals_env = os.environ.get(
             "TORCHELASTIC_SIGNALS_TO_HANDLE", None

--- a/test/distributed/launcher/test_api.py
+++ b/test/distributed/launcher/test_api.py
@@ -16,6 +16,7 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 class LauncherApiTest(TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         # Save original environment variable if it exists
         self.original_signals_env = os.environ.get(
             "TORCHELASTIC_SIGNALS_TO_HANDLE", None

--- a/test/distributed/launcher/test_api.py
+++ b/test/distributed/launcher/test_api.py
@@ -16,7 +16,7 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 class LauncherApiTest(TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         # Save original environment variable if it exists
         self.original_signals_env = os.environ.get(
             "TORCHELASTIC_SIGNALS_TO_HANDLE", None

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -2357,6 +2357,7 @@ class ReducerModule(nn.Module):
 
 class ReducerTest(TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         self.file = tempfile.NamedTemporaryFile(delete=False)
         world_size = 1
         self.store = c10d.FileStore(self.file.name, world_size)

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -2357,7 +2357,7 @@ class ReducerModule(nn.Module):
 
 class ReducerTest(TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self.file = tempfile.NamedTemporaryFile(delete=False)
         world_size = 1
         self.store = c10d.FileStore(self.file.name, world_size)

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -252,7 +252,7 @@ class ProcessGroupNCCLNoGPUTest(TestCase):
     MAIN_PROCESS_RANK = 0
 
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self.rank = self.MAIN_PROCESS_RANK
         self.world_size = 1
         self.file = tempfile.NamedTemporaryFile(delete=False)

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -252,6 +252,7 @@ class ProcessGroupNCCLNoGPUTest(TestCase):
     MAIN_PROCESS_RANK = 0
 
     def setUp(self):
+        TestCase.setUp(self)
         self.rank = self.MAIN_PROCESS_RANK
         self.world_size = 1
         self.file = tempfile.NamedTemporaryFile(delete=False)

--- a/test/distributed/test_run.py
+++ b/test/distributed/test_run.py
@@ -17,7 +17,7 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 class RunTest(TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         # Save original environment variable if it exists
         self.original_signals_env = os.environ.get(
             "TORCHELASTIC_SIGNALS_TO_HANDLE", None

--- a/test/distributed/test_run.py
+++ b/test/distributed/test_run.py
@@ -17,6 +17,7 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 class RunTest(TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         # Save original environment variable if it exists
         self.original_signals_env = os.environ.get(
             "TORCHELASTIC_SIGNALS_TO_HANDLE", None

--- a/test/distributed/test_serialization.py
+++ b/test/distributed/test_serialization.py
@@ -25,7 +25,7 @@ class MyClass:
 
 class TestSerialization(TestCase):
     def setUp(self) -> None:
-        TestCase.setUp(self)
+        super().setUp()
         # disable debug asserts
         self._old_debug = os.environ.get(DEBUG_ENV)
         os.environ[DEBUG_ENV] = "0"

--- a/test/distributed/test_serialization.py
+++ b/test/distributed/test_serialization.py
@@ -25,6 +25,7 @@ class MyClass:
 
 class TestSerialization(TestCase):
     def setUp(self) -> None:
+        TestCase.setUp(self)
         # disable debug asserts
         self._old_debug = os.environ.get(DEBUG_ENV)
         os.environ[DEBUG_ENV] = "0"

--- a/test/distributed/test_store.py
+++ b/test/distributed/test_store.py
@@ -317,6 +317,7 @@ class HashStoreTest(TestCase, StoreTestBase):
 
 class PrefixStoreTest(TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         # delete is false as FileStore will automatically clean up the file
         self.file = tempfile.NamedTemporaryFile(delete=False)
 

--- a/test/distributed/test_store.py
+++ b/test/distributed/test_store.py
@@ -317,7 +317,7 @@ class HashStoreTest(TestCase, StoreTestBase):
 
 class PrefixStoreTest(TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         # delete is false as FileStore will automatically clean up the file
         self.file = tempfile.NamedTemporaryFile(delete=False)
 

--- a/test/export/test_lift_unlift.py
+++ b/test/export/test_lift_unlift.py
@@ -138,7 +138,7 @@ class GraphBuilder:
 
 class TestLift(TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         load_torchbind_test_lib()
 
     def test_lift_basic(self):
@@ -361,7 +361,7 @@ class TestLift(TestCase):
 
 class ConstantAttrMapTest(TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         load_torchbind_test_lib()
 
     def test_dict_api(self):

--- a/test/export/test_lift_unlift.py
+++ b/test/export/test_lift_unlift.py
@@ -138,6 +138,7 @@ class GraphBuilder:
 
 class TestLift(TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         load_torchbind_test_lib()
 
     def test_lift_basic(self):
@@ -360,6 +361,7 @@ class TestLift(TestCase):
 
 class ConstantAttrMapTest(TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         load_torchbind_test_lib()
 
     def test_dict_api(self):

--- a/test/export/test_sparse.py
+++ b/test/export/test_sparse.py
@@ -96,7 +96,7 @@ class SparseActivationCSR(torch.nn.Module):
 )
 class TestSparseProp(TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
 
     def assertEqualMeta(self, x, y):
         self.assertIsInstance(x, FakeTensor)

--- a/test/export/test_upgrader.py
+++ b/test/export/test_upgrader.py
@@ -8,6 +8,7 @@ from torch.testing._internal.common_utils import TestCase
 
 class TestUpgrader(TestCase):
     def setUp(self) -> None:
+        TestCase.setUp(self)
         # Register example upgraders dynamically
         torch._C._export.register_example_upgraders()
 

--- a/test/export/test_upgrader.py
+++ b/test/export/test_upgrader.py
@@ -8,7 +8,7 @@ from torch.testing._internal.common_utils import TestCase
 
 class TestUpgrader(TestCase):
     def setUp(self) -> None:
-        TestCase.setUp(self)
+        super().setUp()
         # Register example upgraders dynamically
         torch._C._export.register_example_upgraders()
 

--- a/test/functorch/dim/test_getsetitem.py
+++ b/test/functorch/dim/test_getsetitem.py
@@ -8,6 +8,7 @@ class TestGetSetItem(TestCase):
     """Comprehensive tests for first-class dimension indexing operations."""
 
     def setUp(self):
+        TestCase.setUp(self)
         """Set up common test fixtures."""
         self.batch, self.height, self.width = dims(3)
 

--- a/test/functorch/dim/test_getsetitem.py
+++ b/test/functorch/dim/test_getsetitem.py
@@ -8,7 +8,7 @@ class TestGetSetItem(TestCase):
     """Comprehensive tests for first-class dimension indexing operations."""
 
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         """Set up common test fixtures."""
         self.batch, self.height, self.width = dims(3)
 

--- a/test/functorch/test_ac_logging.py
+++ b/test/functorch/test_ac_logging.py
@@ -13,7 +13,7 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 class TestAcLogging(TestCase):
     def setUp(self) -> None:
-        TestCase.setUp(self)
+        super().setUp()
         self.graph: MagicMock = MagicMock(spec=Graph)
         self.node1: MagicMock = MagicMock(spec=Node)
         self.node2: MagicMock = MagicMock(spec=Node)

--- a/test/functorch/test_ac_logging.py
+++ b/test/functorch/test_ac_logging.py
@@ -13,6 +13,7 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 class TestAcLogging(TestCase):
     def setUp(self) -> None:
+        TestCase.setUp(self)
         self.graph: MagicMock = MagicMock(spec=Graph)
         self.node1: MagicMock = MagicMock(spec=Node)
         self.node2: MagicMock = MagicMock(spec=Node)

--- a/test/fx/test_fx_split_node_finder.py
+++ b/test/fx/test_fx_split_node_finder.py
@@ -27,7 +27,7 @@ def sup_f(x):
 
 class TestFxSplitNodeFinder(TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self.save_path = sys.path[:]
         self.tmpdir = tempfile.mkdtemp()
         sys.path.insert(0, self.tmpdir)

--- a/test/fx/test_fx_split_node_finder.py
+++ b/test/fx/test_fx_split_node_finder.py
@@ -27,6 +27,7 @@ def sup_f(x):
 
 class TestFxSplitNodeFinder(TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         self.save_path = sys.path[:]
         self.tmpdir = tempfile.mkdtemp()
         sys.path.insert(0, self.tmpdir)

--- a/test/fx/test_graph_pickler.py
+++ b/test/fx/test_graph_pickler.py
@@ -66,7 +66,7 @@ if HAS_CPU:
 class TestGraphPickler(TestCase):
     def setUp(self):
         torch._dynamo.reset()
-        TestCase.setUp(self)
+        super().setUp()
 
         self._stack = contextlib.ExitStack()
         self._stack.enter_context(

--- a/test/fx/test_net_min_base.py
+++ b/test/fx/test_net_min_base.py
@@ -14,6 +14,7 @@ from torch.testing._internal.common_utils import TestCase
 
 class TestNetMinBaseBlock(TestCase):
     def setUp(self) -> None:
+        TestCase.setUp(self)
         # Setup test fixtures for each test method
 
         class SimpleModule(torch.nn.Module):

--- a/test/fx/test_net_min_base.py
+++ b/test/fx/test_net_min_base.py
@@ -14,7 +14,7 @@ from torch.testing._internal.common_utils import TestCase
 
 class TestNetMinBaseBlock(TestCase):
     def setUp(self) -> None:
-        TestCase.setUp(self)
+        super().setUp()
         # Setup test fixtures for each test method
 
         class SimpleModule(torch.nn.Module):

--- a/test/inductor/test_augmented_graph_helper.py
+++ b/test/inductor/test_augmented_graph_helper.py
@@ -13,7 +13,7 @@ class TestAugmentedGraphHelper(TestCase):
 
     def setUp(self):
         """Create a simple graph structure for testing."""
-        TestCase.setUp(self)
+        super().setUp()
         # Create a torch.fx.Graph with multiple nodes
         self.graph = fx.Graph()
 

--- a/test/inductor/test_augmented_graph_helper.py
+++ b/test/inductor/test_augmented_graph_helper.py
@@ -13,6 +13,7 @@ class TestAugmentedGraphHelper(TestCase):
 
     def setUp(self):
         """Create a simple graph structure for testing."""
+        TestCase.setUp(self)
         # Create a torch.fx.Graph with multiple nodes
         self.graph = fx.Graph()
 

--- a/test/inductor/test_compile_subprocess.py
+++ b/test/inductor/test_compile_subprocess.py
@@ -70,7 +70,7 @@ class TestSubprocess(TestCase):
         torch._dynamo.reset()
         FxCompile._reset_stats()
 
-        TestCase.setUp(self)
+        super().setUp()
 
         self._stack = contextlib.ExitStack()
         self._stack.enter_context(

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -142,7 +142,7 @@ def cal_conv_generated_kernel_number(mod, input, dtype, dim=4, device="cpu"):
 
 class TestPatternMatcherBase(TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self.ctx_stack = contextlib.ExitStack()
         self.ctx_stack.enter_context(config.patch({"freezing": True}))
 

--- a/test/inductor/test_ordered_set.py
+++ b/test/inductor/test_ordered_set.py
@@ -57,7 +57,7 @@ class TestJointOps(TestCase):
     basetype = OrderedSet
 
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self.word = word = "simsalabim"
         self.otherword = "madagascar"
         self.letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -852,7 +852,7 @@ class TestBasicOps(TestCase):
 
 class TestBasicOpsEmpty(TestBasicOps, TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self.case = "empty OrderedSet"
         self.values = []
         self.OrderedSet = OrderedSet(self.values)
@@ -866,7 +866,7 @@ class TestBasicOpsEmpty(TestBasicOps, TestCase):
 
 class TestBasicOpsSingleton(TestBasicOps, TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self.case = "unit OrderedSet (number)"
         self.values = [3]
         self.OrderedSet = OrderedSet(self.values)
@@ -886,7 +886,7 @@ class TestBasicOpsSingleton(TestBasicOps, TestCase):
 
 class TestBasicOpsTuple(TestBasicOps, TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self.case = "unit OrderedSet (tuple)"
         self.values = [(0, "zero")]
         self.OrderedSet = OrderedSet(self.values)
@@ -906,7 +906,7 @@ class TestBasicOpsTuple(TestBasicOps, TestCase):
 
 class TestBasicOpsTriple(TestBasicOps, TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self.case = "triple OrderedSet"
         self.values = [0, "zero", operator.add]
         self.OrderedSet = OrderedSet(self.values)
@@ -920,7 +920,7 @@ class TestBasicOpsTriple(TestBasicOps, TestCase):
 
 class TestBasicOpsString(TestBasicOps, TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self.case = "string OrderedSet"
         self.values = ["a", "b", "c"]
         self.OrderedSet = OrderedSet(self.values)
@@ -937,7 +937,7 @@ class TestBasicOpsString(TestBasicOps, TestCase):
 
 class TestBasicOpsBytes(TestBasicOps, TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self.case = "bytes OrderedSet"
         self.values = [b"a", b"b", b"c"]
         self.OrderedSet = OrderedSet(self.values)
@@ -954,7 +954,7 @@ class TestBasicOpsBytes(TestBasicOps, TestCase):
 
 class TestBasicOpsMixedStringBytes(TestBasicOps, TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         warnings.simplefilter("ignore", BytesWarning)
         self.case = "string and bytes OrderedSet"
         self.values = ["a", "b", b"a", b"b"]
@@ -1026,7 +1026,7 @@ class TestSetOfSets(TestCase):
 
 class TestBinaryOps(TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self.OrderedSet = OrderedSet((2, 4, 6))
 
     def test_eq(self):  # SF bug 643115
@@ -1102,7 +1102,7 @@ class TestBinaryOps(TestCase):
 
 class TestUpdateOps(TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self.OrderedSet = OrderedSet((2, 4, 6))
 
     def test_union_subset(self):
@@ -1191,7 +1191,7 @@ class TestUpdateOps(TestCase):
 
 class TestMutate(TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self.values = ["a", "b", "c"]
         self.OrderedSet = OrderedSet(self.values)
 
@@ -1480,7 +1480,7 @@ class TestOnlySetsInBinaryOps(TestCase):
 
 class TestOnlySetsNumeric(TestOnlySetsInBinaryOps, TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self.OrderedSet = OrderedSet((1, 2, 3))
         self.other = 19
         self.otherIsIterable = False
@@ -1491,7 +1491,7 @@ class TestOnlySetsNumeric(TestOnlySetsInBinaryOps, TestCase):
 
 class TestOnlySetsDict(TestOnlySetsInBinaryOps, TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self.OrderedSet = OrderedSet((1, 2, 3))
         self.other = {1: 2, 3: 4}
         self.otherIsIterable = True
@@ -1502,7 +1502,7 @@ class TestOnlySetsDict(TestOnlySetsInBinaryOps, TestCase):
 
 class TestOnlySetsOperator(TestOnlySetsInBinaryOps, TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self.OrderedSet = OrderedSet((1, 2, 3))
         self.other = operator.add
         self.otherIsIterable = False
@@ -1513,7 +1513,7 @@ class TestOnlySetsOperator(TestOnlySetsInBinaryOps, TestCase):
 
 class TestOnlySetsTuple(TestOnlySetsInBinaryOps, TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self.OrderedSet = OrderedSet((1, 2, 3))
         self.other = (2, 4, 6)
         self.otherIsIterable = True
@@ -1524,7 +1524,7 @@ class TestOnlySetsTuple(TestOnlySetsInBinaryOps, TestCase):
 
 class TestOnlySetsString(TestOnlySetsInBinaryOps, TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self.OrderedSet = OrderedSet((1, 2, 3))
         self.other = "abc"
         self.otherIsIterable = True
@@ -1535,7 +1535,7 @@ class TestOnlySetsString(TestOnlySetsInBinaryOps, TestCase):
 
 class TestOnlySetsGenerator(TestOnlySetsInBinaryOps, TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
 
         def gen():
             for i in range(0, 10, 2):  # noqa: UP028
@@ -1574,7 +1574,7 @@ class TestCopying:
 
 class TestCopyingEmpty(TestCopying, TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self.OrderedSet = OrderedSet()
 
 
@@ -1583,7 +1583,7 @@ class TestCopyingEmpty(TestCopying, TestCase):
 
 class TestCopyingSingleton(TestCopying, TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self.OrderedSet = OrderedSet(["hello"])
 
 
@@ -1592,7 +1592,7 @@ class TestCopyingSingleton(TestCopying, TestCase):
 
 class TestCopyingTriple(TestCopying, TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self.OrderedSet = OrderedSet(["zero", 0, None])
 
 
@@ -1601,7 +1601,7 @@ class TestCopyingTriple(TestCopying, TestCase):
 
 class TestCopyingTuple(TestCopying, TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self.OrderedSet = OrderedSet([(1, 2)])
 
 
@@ -1610,7 +1610,7 @@ class TestCopyingTuple(TestCopying, TestCase):
 
 class TestCopyingNested(TestCopying, TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self.OrderedSet = OrderedSet([((1, 2), (3, 4))])
 
 
@@ -1621,7 +1621,7 @@ del TestCopying
 
 class TestIdentities(TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self.a = OrderedSet("abracadabra")
         self.b = OrderedSet("alacazam")
 

--- a/test/inductor/test_ordered_set.py
+++ b/test/inductor/test_ordered_set.py
@@ -57,6 +57,7 @@ class TestJointOps(TestCase):
     basetype = OrderedSet
 
     def setUp(self):
+        TestCase.setUp(self)
         self.word = word = "simsalabim"
         self.otherword = "madagascar"
         self.letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -851,6 +852,7 @@ class TestBasicOps(TestCase):
 
 class TestBasicOpsEmpty(TestBasicOps, TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         self.case = "empty OrderedSet"
         self.values = []
         self.OrderedSet = OrderedSet(self.values)
@@ -864,6 +866,7 @@ class TestBasicOpsEmpty(TestBasicOps, TestCase):
 
 class TestBasicOpsSingleton(TestBasicOps, TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         self.case = "unit OrderedSet (number)"
         self.values = [3]
         self.OrderedSet = OrderedSet(self.values)
@@ -883,6 +886,7 @@ class TestBasicOpsSingleton(TestBasicOps, TestCase):
 
 class TestBasicOpsTuple(TestBasicOps, TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         self.case = "unit OrderedSet (tuple)"
         self.values = [(0, "zero")]
         self.OrderedSet = OrderedSet(self.values)
@@ -902,6 +906,7 @@ class TestBasicOpsTuple(TestBasicOps, TestCase):
 
 class TestBasicOpsTriple(TestBasicOps, TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         self.case = "triple OrderedSet"
         self.values = [0, "zero", operator.add]
         self.OrderedSet = OrderedSet(self.values)
@@ -915,6 +920,7 @@ class TestBasicOpsTriple(TestBasicOps, TestCase):
 
 class TestBasicOpsString(TestBasicOps, TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         self.case = "string OrderedSet"
         self.values = ["a", "b", "c"]
         self.OrderedSet = OrderedSet(self.values)
@@ -931,6 +937,7 @@ class TestBasicOpsString(TestBasicOps, TestCase):
 
 class TestBasicOpsBytes(TestBasicOps, TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         self.case = "bytes OrderedSet"
         self.values = [b"a", b"b", b"c"]
         self.OrderedSet = OrderedSet(self.values)
@@ -947,6 +954,7 @@ class TestBasicOpsBytes(TestBasicOps, TestCase):
 
 class TestBasicOpsMixedStringBytes(TestBasicOps, TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         warnings.simplefilter("ignore", BytesWarning)
         self.case = "string and bytes OrderedSet"
         self.values = ["a", "b", b"a", b"b"]
@@ -1018,6 +1026,7 @@ class TestSetOfSets(TestCase):
 
 class TestBinaryOps(TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         self.OrderedSet = OrderedSet((2, 4, 6))
 
     def test_eq(self):  # SF bug 643115
@@ -1093,6 +1102,7 @@ class TestBinaryOps(TestCase):
 
 class TestUpdateOps(TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         self.OrderedSet = OrderedSet((2, 4, 6))
 
     def test_union_subset(self):
@@ -1181,6 +1191,7 @@ class TestUpdateOps(TestCase):
 
 class TestMutate(TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         self.values = ["a", "b", "c"]
         self.OrderedSet = OrderedSet(self.values)
 
@@ -1469,6 +1480,7 @@ class TestOnlySetsInBinaryOps(TestCase):
 
 class TestOnlySetsNumeric(TestOnlySetsInBinaryOps, TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         self.OrderedSet = OrderedSet((1, 2, 3))
         self.other = 19
         self.otherIsIterable = False
@@ -1479,6 +1491,7 @@ class TestOnlySetsNumeric(TestOnlySetsInBinaryOps, TestCase):
 
 class TestOnlySetsDict(TestOnlySetsInBinaryOps, TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         self.OrderedSet = OrderedSet((1, 2, 3))
         self.other = {1: 2, 3: 4}
         self.otherIsIterable = True
@@ -1489,6 +1502,7 @@ class TestOnlySetsDict(TestOnlySetsInBinaryOps, TestCase):
 
 class TestOnlySetsOperator(TestOnlySetsInBinaryOps, TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         self.OrderedSet = OrderedSet((1, 2, 3))
         self.other = operator.add
         self.otherIsIterable = False
@@ -1499,6 +1513,7 @@ class TestOnlySetsOperator(TestOnlySetsInBinaryOps, TestCase):
 
 class TestOnlySetsTuple(TestOnlySetsInBinaryOps, TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         self.OrderedSet = OrderedSet((1, 2, 3))
         self.other = (2, 4, 6)
         self.otherIsIterable = True
@@ -1509,6 +1524,7 @@ class TestOnlySetsTuple(TestOnlySetsInBinaryOps, TestCase):
 
 class TestOnlySetsString(TestOnlySetsInBinaryOps, TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         self.OrderedSet = OrderedSet((1, 2, 3))
         self.other = "abc"
         self.otherIsIterable = True
@@ -1519,6 +1535,7 @@ class TestOnlySetsString(TestOnlySetsInBinaryOps, TestCase):
 
 class TestOnlySetsGenerator(TestOnlySetsInBinaryOps, TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         def gen():
             for i in range(0, 10, 2):  # noqa: UP028
                 yield i
@@ -1556,6 +1573,7 @@ class TestCopying:
 
 class TestCopyingEmpty(TestCopying, TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         self.OrderedSet = OrderedSet()
 
 
@@ -1564,6 +1582,7 @@ class TestCopyingEmpty(TestCopying, TestCase):
 
 class TestCopyingSingleton(TestCopying, TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         self.OrderedSet = OrderedSet(["hello"])
 
 
@@ -1572,6 +1591,7 @@ class TestCopyingSingleton(TestCopying, TestCase):
 
 class TestCopyingTriple(TestCopying, TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         self.OrderedSet = OrderedSet(["zero", 0, None])
 
 
@@ -1580,6 +1600,7 @@ class TestCopyingTriple(TestCopying, TestCase):
 
 class TestCopyingTuple(TestCopying, TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         self.OrderedSet = OrderedSet([(1, 2)])
 
 
@@ -1588,6 +1609,7 @@ class TestCopyingTuple(TestCopying, TestCase):
 
 class TestCopyingNested(TestCopying, TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         self.OrderedSet = OrderedSet([((1, 2), (3, 4))])
 
 
@@ -1598,6 +1620,7 @@ del TestCopying
 
 class TestIdentities(TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         self.a = OrderedSet("abracadabra")
         self.b = OrderedSet("alacazam")
 

--- a/test/inductor/test_ordered_set.py
+++ b/test/inductor/test_ordered_set.py
@@ -1536,6 +1536,7 @@ class TestOnlySetsString(TestOnlySetsInBinaryOps, TestCase):
 class TestOnlySetsGenerator(TestOnlySetsInBinaryOps, TestCase):
     def setUp(self):
         TestCase.setUp(self)
+
         def gen():
             for i in range(0, 10, 2):  # noqa: UP028
                 yield i

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -159,7 +159,7 @@ class TestInductorDynamic(TestCase):
         if not HAS_GPU:
             self.skipTest("Triton not available")
         torch._dynamo.reset()
-        TestCase.setUp(self)
+        super().setUp()
         # this should be in setUpClass, but device-generic tests
         # don't work with setUpClass well (non-deterministically the wrong setUpClass is resolved),
         # so put it in test setUp, it's cheap

--- a/test/onnx/exporter/test_building.py
+++ b/test/onnx/exporter/test_building.py
@@ -14,7 +14,7 @@ from torch.testing._internal import common_utils
 
 class TestOpRecorder(common_utils.TestCase):
     def setUp(self):
-        common_utils.TestCase.setUp(self)
+        super().setUp()
         self.opset_version = 17
         self.opset = onnxscript.values.Opset("", self.opset_version)
         self.recorder = _building.OpRecorder(opset=self.opset, constant_farm={})

--- a/test/onnx/exporter/test_building.py
+++ b/test/onnx/exporter/test_building.py
@@ -14,6 +14,7 @@ from torch.testing._internal import common_utils
 
 class TestOpRecorder(common_utils.TestCase):
     def setUp(self):
+        common_utils.TestCase.setUp(self)
         self.opset_version = 17
         self.opset = onnxscript.values.Opset("", self.opset_version)
         self.recorder = _building.OpRecorder(opset=self.opset, constant_farm={})

--- a/test/onnx/internal/test_registraion.py
+++ b/test/onnx/internal/test_registraion.py
@@ -49,6 +49,7 @@ class TestGlobalHelpers(common_utils.TestCase):
 
 class TestOverrideDict(common_utils.TestCase):
     def setUp(self):
+        common_utils.TestCase.setUp(self)
         self.override_dict: registration.OverrideDict[str, int] = (
             registration.OverrideDict()
         )

--- a/test/onnx/internal/test_registration.py
+++ b/test/onnx/internal/test_registration.py
@@ -49,7 +49,7 @@ class TestGlobalHelpers(common_utils.TestCase):
 
 class TestOverrideDict(common_utils.TestCase):
     def setUp(self):
-        common_utils.TestCase.setUp(self)
+        super().setUp()
         self.override_dict: registration.OverrideDict[str, int] = (
             registration.OverrideDict()
         )

--- a/test/onnx/test_pytorch_onnx_shape_inference.py
+++ b/test/onnx/test_pytorch_onnx_shape_inference.py
@@ -44,6 +44,7 @@ def g_op(graph: torch.Graph, op_name: str, *args, **kwargs):
 
 class TestONNXShapeInference(pytorch_test_common.ExportTestCase):
     def setUp(self):
+        pytorch_test_common.ExportTestCase.setUp(self)
         self.opset_version = _constants.ONNX_TORCHSCRIPT_EXPORTER_MAX_OPSET
         GLOBALS.export_onnx_opset_version = self.opset_version
 

--- a/test/onnx/test_pytorch_onnx_shape_inference.py
+++ b/test/onnx/test_pytorch_onnx_shape_inference.py
@@ -44,7 +44,6 @@ def g_op(graph: torch.Graph, op_name: str, *args, **kwargs):
 
 class TestONNXShapeInference(pytorch_test_common.ExportTestCase):
     def setUp(self):
-        pytorch_test_common.ExportTestCase.setUp(self)
         self.opset_version = _constants.ONNX_TORCHSCRIPT_EXPORTER_MAX_OPSET
         GLOBALS.export_onnx_opset_version = self.opset_version
 

--- a/test/profiler/test_cpp_thread.py
+++ b/test/profiler/test_cpp_thread.py
@@ -88,6 +88,7 @@ class CppThreadTestCUDA(TestCase):
             torch.testing._internal.common_utils.remove_cpp_extensions_build_root()
 
     def setUp(self) -> None:
+        TestCase.setUp(self)
         if not torch.cuda.is_available():
             self.skipTest("Test machine does not have cuda")
         global device
@@ -230,6 +231,7 @@ class CppThreadTestXPU(TestCase):
             torch.testing._internal.common_utils.remove_cpp_extensions_build_root()
 
     def setUp(self) -> None:
+        TestCase.setUp(self)
         if not torch.xpu.is_available():
             self.skipTest("Test machine does not have xpu")
         global device

--- a/test/profiler/test_cpp_thread.py
+++ b/test/profiler/test_cpp_thread.py
@@ -88,7 +88,7 @@ class CppThreadTestCUDA(TestCase):
             torch.testing._internal.common_utils.remove_cpp_extensions_build_root()
 
     def setUp(self) -> None:
-        TestCase.setUp(self)
+        super().setUp()
         if not torch.cuda.is_available():
             self.skipTest("Test machine does not have cuda")
         global device
@@ -231,7 +231,7 @@ class CppThreadTestXPU(TestCase):
             torch.testing._internal.common_utils.remove_cpp_extensions_build_root()
 
     def setUp(self) -> None:
-        TestCase.setUp(self)
+        super().setUp()
         if not torch.xpu.is_available():
             self.skipTest("Test machine does not have xpu")
         global device

--- a/test/test_cuda_primary_ctx.py
+++ b/test/test_cuda_primary_ctx.py
@@ -24,6 +24,7 @@ class TestCudaPrimaryCtx(TestCase):
     )
 
     def setUp(self):
+        TestCase.setUp(self)
         for device in range(torch.cuda.device_count()):
             # Ensure context has not been created beforehand
             self.assertFalse(

--- a/test/test_cuda_primary_ctx.py
+++ b/test/test_cuda_primary_ctx.py
@@ -24,7 +24,7 @@ class TestCudaPrimaryCtx(TestCase):
     )
 
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         for device in range(torch.cuda.device_count()):
             # Ensure context has not been created beforehand
             self.assertFalse(

--- a/test/test_cuda_sanitizer.py
+++ b/test/test_cuda_sanitizer.py
@@ -143,6 +143,7 @@ def event_id(i: int) -> EventId:
 
 class TestEventHandler(TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         self.handler = csan.EventHandler()
 
     def kernel_launch(
@@ -397,6 +398,7 @@ class TestEventHandler(TestCase):
 
 class TestMessages(TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         self.handler = csan.EventHandler()
 
     def test_ensure_exists(self):

--- a/test/test_cuda_sanitizer.py
+++ b/test/test_cuda_sanitizer.py
@@ -143,7 +143,7 @@ def event_id(i: int) -> EventId:
 
 class TestEventHandler(TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self.handler = csan.EventHandler()
 
     def kernel_launch(
@@ -398,7 +398,7 @@ class TestEventHandler(TestCase):
 
 class TestMessages(TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         self.handler = csan.EventHandler()
 
     def test_ensure_exists(self):

--- a/test/test_cuda_trace.py
+++ b/test/test_cuda_trace.py
@@ -20,6 +20,7 @@ if not TEST_CUDA:
 @torch.testing._internal.common_utils.markDynamoStrictTest
 class TestCudaTrace(TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         torch._C._activate_gpu_trace()
         self.mock = unittest.mock.MagicMock()
 

--- a/test/test_cuda_trace.py
+++ b/test/test_cuda_trace.py
@@ -20,7 +20,7 @@ if not TEST_CUDA:
 @torch.testing._internal.common_utils.markDynamoStrictTest
 class TestCudaTrace(TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         torch._C._activate_gpu_trace()
         self.mock = unittest.mock.MagicMock()
 

--- a/test/test_monitor.py
+++ b/test/test_monitor.py
@@ -111,6 +111,7 @@ class TestMonitor(TestCase):
 @skipIfTorchDynamo("Really weird error")
 class TestMonitorTensorboard(TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         global SummaryWriter, event_multiplexer
         try:
             from tensorboard.backend.event_processing import (

--- a/test/test_monitor.py
+++ b/test/test_monitor.py
@@ -111,7 +111,7 @@ class TestMonitor(TestCase):
 @skipIfTorchDynamo("Really weird error")
 class TestMonitorTensorboard(TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         global SummaryWriter, event_multiplexer
         try:
             from tensorboard.backend.event_processing import (

--- a/test/test_nnapi.py
+++ b/test/test_nnapi.py
@@ -28,6 +28,7 @@ def nhwc(t):
 )
 class TestNNAPI(TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         # Avoid saturation in fbgemm
         torch.backends.quantized.engine = "qnnpack"
 

--- a/test/test_nnapi.py
+++ b/test/test_nnapi.py
@@ -28,7 +28,7 @@ def nhwc(t):
 )
 class TestNNAPI(TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         # Avoid saturation in fbgemm
         torch.backends.quantized.engine = "qnnpack"
 

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -178,7 +178,7 @@ class TestSparseBase(TestCase):
 class TestSparse(TestSparseBase):
 
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
 
         self.index_tensor = lambda *args, **kwargs: torch.tensor(*args, **kwargs, dtype=torch.int64)
 

--- a/test/test_torchfuzz_repros.py
+++ b/test/test_torchfuzz_repros.py
@@ -21,7 +21,7 @@ class TestFuzzerCompileIssues(TestCase):
 
     def setUp(self):
         """Configure common test settings."""
-        TestCase.setUp(self)
+        super().setUp()
         torch._dynamo.config.capture_scalar_outputs = True
         torch._dynamo.config.capture_dynamic_output_shape_ops = True
         torch._inductor.config.emulate_precision_casts = True

--- a/test/test_torchfuzz_repros.py
+++ b/test/test_torchfuzz_repros.py
@@ -21,6 +21,7 @@ class TestFuzzerCompileIssues(TestCase):
 
     def setUp(self):
         """Configure common test settings."""
+        TestCase.setUp(self)
         torch._dynamo.config.capture_scalar_outputs = True
         torch._dynamo.config.capture_dynamic_output_shape_ops = True
         torch._inductor.config.emulate_precision_casts = True

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -649,6 +649,7 @@ class TestHipify(TestCase):
 
 class TestHipifyTrie(TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         from torch.utils.hipify import hipify_python
 
         self.trie = hipify_python.Trie()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -649,7 +649,7 @@ class TestHipify(TestCase):
 
 class TestHipifyTrie(TestCase):
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         from torch.utils.hipify import hipify_python
 
         self.trie = hipify_python.Trie()

--- a/test/test_weak.py
+++ b/test/test_weak.py
@@ -582,6 +582,7 @@ class WeakKeyDictionaryScriptObjectTestCase(TestCase):
         return x
 
     def setUp(self):
+        TestCase.setUp(self)
         if IS_MACOS:
             raise unittest.SkipTest("non-portable load_library call used in test")
 

--- a/test/test_weak.py
+++ b/test/test_weak.py
@@ -582,7 +582,7 @@ class WeakKeyDictionaryScriptObjectTestCase(TestCase):
         return x
 
     def setUp(self):
-        TestCase.setUp(self)
+        super().setUp()
         if IS_MACOS:
             raise unittest.SkipTest("non-portable load_library call used in test")
 


### PR DESCRIPTION
In a trunk failure today, we saw the same test running on both trunk and slow shards.  The reason is that this test didn't invoke `super().setUp()`, so all the test features like slow and disabled test didn't apply to them.

I use Claude to find all test classes with a `setUp()` method that didn't called `super().setUp()` and patch all of them.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @ezyang @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben