### PR TITLE
Fix EMA equation documentation in get_ema_multi_avg_fn

### DIFF
--- a/docs/source/optim.md
+++ b/docs/source/optim.md
@@ -547,8 +547,11 @@ Decay is a parameter between 0 and 1 that controls how fast the averaged paramet
 {func}`torch.optim.swa_utils.get_ema_multi_avg_fn` returns a function that applies the following EMA equation to the weights:
 
 ```{math}
-W^\textrm{EMA}_{t+1} = \alpha W^\textrm{EMA}_{t} + (1 - \alpha) W^\textrm{model}_t
+W_0^\textrm{EMA} &= W_0^\textrm{model} \\
+W_{t+1}^\textrm{EMA} &= \alpha W_t^\textrm{EMA} + (1 - \alpha) W_{t+1}^\textrm{model}
 ```
+
+The initial EMA weights are set equal to the initial model weights, and at each subsequent step t+1, the EMA weights are updated using the current EMA weights and the current model weights.
 
 where alpha is the EMA decay.
 

--- a/torch/optim/swa_utils.py
+++ b/torch/optim/swa_utils.py
@@ -35,7 +35,22 @@ PARAM_LIST = Union[tuple[Tensor, ...], list[Tensor]]
 
 
 def get_ema_multi_avg_fn(decay=0.999):
-    """Get the function applying exponential moving average (EMA) across multiple params."""
+    r"""Get the function applying exponential moving average (EMA) across multiple params.
+
+    The EMA update rule is defined as:
+
+    .. math::
+        W_0^{\text{EMA}} &= W_0^{\text{model}} \\
+        W_{t+1}^{\text{EMA}} &= \alpha W_t^{\text{EMA}} + (1 - \alpha) W_{t+1}^{\text{model}}
+
+    where :math:`\alpha` is the decay parameter (defaults to 0.999).
+
+    Args:
+        decay (float): The exponential decay factor. Must be in [0, 1]. Default: 0.999
+
+    Returns:
+        Callable: A function that updates EMA parameters inplace
+    """
 
     if decay < 0.0 or decay > 1.0:
         raise ValueError(


### PR DESCRIPTION
## Summary

This PR fixes the confusing EMA equation documentation in `get_ema_multi_avg_fn()` by:
1. Adding the initial condition: $W_0^{\text{EMA}} = W_0^{\text{model}}$
2. Fixing the model weight index from $W_t^{\text{model}}$ to $W_{t+1}^{\text{model}}$
3. Updating both the docstring in `torch/optim/swa_utils.py` and `docs/source/optim.md`

## Problem

The previous equation was:
```
W_{t+1}^{EMA} = α W_t^{EMA} + (1 - α) W_t^{model}
```

This was confusing because:
- No initial condition was specified
- The model weight was indexed as `W_t` when the implementation actually uses the **current** model weights at step `t+1`

## Solution

The corrected equations now clearly show:
```
W_0^{EMA} = W_0^{model}  (initial condition)
W_{t+1}^{EMA} = α W_t^{EMA} + (1 - α) W_{t+1}^{model}  (update rule)
```

This makes it clear that at step t+1:
- We use the EMA weights from the previous step (t)
- We use the **current** model weights (t+1)

## Changes

- ✅ Updated `torch/optim/swa_utils.py`: Enhanced docstring with proper equation and initial condition
- ✅ Updated `docs/source/optim.md`: Fixed equation and added explanatory text
- ✅ No code changes (documentation only)

## Addresses Feedback from #160061

This PR addresses the maintainer feedback from the previous stalled PR:
- @janeyx99 requested `docs/source/optim.md` to be updated ✅ Done
- Only documentation files modified (no extra test or linter files)

Fixes #155551

cc @svekars @sekyondaMeta @AlannaBurke @vincentqb @janeyx99