### PR TITLE
Fix torch.export.export() GPU failure with RNN modules (#155309)

### DIFF
--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -9,6 +9,7 @@ from typing_extensions import deprecated
 
 import torch
 from torch import _VF, Tensor
+from torch.multiprocessing.reductions import StorageWeakRef
 from torch.nn import init
 from torch.nn.parameter import Parameter
 from torch.nn.utils.rnn import PackedSequence
@@ -254,7 +255,7 @@ class RNNBase(Module):
         # alias would break the assumptions of the uniqueness check in
         # Module.named_parameters().
         unique_data_ptrs = {
-            p.data_ptr()  # type: ignore[union-attr]
+            StorageWeakRef(p.untyped_storage())  # type: ignore[union-attr]
             for p in self._flat_weights
         }
         if len(unique_data_ptrs) != len(self._flat_weights):


### PR DESCRIPTION
## Summary
This PR fixes issue #155309 where `torch.export.export()` fails on GPU when exporting models containing `nn.LSTM`, `nn.RNN`, or `nn.GRU` layers.

## Problem
The code was using `.data_ptr()` to detect parameter aliasing in `_flat_weights`, which is incompatible with fake tensors used during PT2 export. This caused the error:

Cannot access data pointer of Tensor (e.g. FakeTensor, FunctionalTensor)

## Solution
- Replaced `p.data_ptr()` with `StorageWeakRef(p.untyped_storage())`
- Added import: `from torch.multiprocessing.reductions import StorageWeakRef`

This approach safely detects shared storage without accessing physical memory pointers, making it compatible with fake tensors.

## Changes
- `torch/nn/modules/rnn.py`: Line 12 (import) and Line 257 (aliasing check)

## Testing
- Existing tests in `test/test_export.py` should validate this fix
- Manual testing confirms GPU export now works with cuDNN enabled
- Affects `nn.LSTM`, `nn.RNN`, and `nn.GRU` modules

Fixes #155309