### PR TITLE
[DTensor] Allow None bias in convolution sharding propagation.

### DIFF
--- a/test/distributed/tensor/test_convolution_ops.py
+++ b/test/distributed/tensor/test_convolution_ops.py
@@ -230,19 +230,12 @@ class DistConvolutionOpsTest(DTensorTestBase):
         out_dt, out = self._run_single_arg_fwd(model, x, [Shard(0)])
         self.assertEqual(out_dt, out)
 
-    @with_comms
-    def test_conv2d_bias_none(self):
-        model = nn.Conv2d(4, 8, 3, padding=1, bias=False)
-        x = torch.randn(1, 4, 5, 5, device=self.device_type)
-        out_dt, out = self._run_single_arg_fwd(model, x)
-        self.assertEqual(out_dt.shape, out.shape)
 
 DistConvolutionOpsTestWithLocalTensor = create_local_tensor_test_class(
     DistConvolutionOpsTest,
     # Send / recv ops are not supported
     skipped_tests=[
         "test_conv1d",
-        "test_conv2d_bias_none",
         "test_conv3d",
         "test_conv_backward_none_grad_inp",
         "test_depthwise_convolution",

--- a/test/distributed/tensor/test_convolution_ops.py
+++ b/test/distributed/tensor/test_convolution_ops.py
@@ -230,11 +230,20 @@ class DistConvolutionOpsTest(DTensorTestBase):
         out_dt, out = self._run_single_arg_fwd(model, x, [Shard(0)])
         self.assertEqual(out_dt, out)
 
+    @with_comms
+    def test_conv2d_bias_none(self):
+        model = nn.Conv2d(4, 8, 3, padding=1, bias=False)
+        x = torch.randn(1, 4, 5, 5, device=self.device_type)
+        out_dt, out = self._run_single_arg_fwd(model, x)
+        self.assertEqual(out_dt.shape, out.shape)
 
 DistConvolutionOpsTestWithLocalTensor = create_local_tensor_test_class(
     DistConvolutionOpsTest,
     # Send / recv ops are not supported
     skipped_tests=[
+        "test_conv1d",
+        "test_conv2d_bias_none",
+        "test_conv3d",
         "test_conv_backward_none_grad_inp",
         "test_depthwise_convolution",
         "test_downsampling_convolution",

--- a/test/distributed/tensor/test_convolution_ops.py
+++ b/test/distributed/tensor/test_convolution_ops.py
@@ -14,7 +14,11 @@ from torch.distributed.tensor import (
     Shard,
 )
 from torch.nn import functional as F
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorTestBase,

--- a/torch/distributed/tensor/_ops/_conv_ops.py
+++ b/torch/distributed/tensor/_ops/_conv_ops.py
@@ -26,7 +26,7 @@ def convolution_rules(op_schema: OpSchema) -> OutputSharding:
 
     assert isinstance(input_spec, DTensorSpec)
     assert isinstance(weight_spec, DTensorSpec)
-    assert isinstance(bias_spec, DTensorSpec)
+    assert bias_spec is None or isinstance(bias_spec, DTensorSpec)
     assert input_spec.tensor_meta is not None
     assert weight_spec.tensor_meta is not None
     in_shape = input_spec.tensor_meta.shape


### PR DESCRIPTION
The convolution_rules function in _conv_ops.py had an assertion that required bias_spec to be a DTensorSpec, causing F.conv2d to fail when bias=None. This is inconsistent with regular PyTorch convolution which supports optional bias.

Added test case to verify conv2d with bias=False works correctly.

Fixes #167090 


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci