### PR TITLE
Add bfloat16/float16 support for torch.sparse.mm backward

### DIFF
--- a/aten/src/ATen/native/cpu/SampledAddmmKernel.cpp
+++ b/aten/src/ATen/native/cpu/SampledAddmmKernel.cpp
@@ -49,7 +49,7 @@ void sampled_addmm_sparse_csr_kernel_impl(
   // usually, collapse B and M is a better option,
   // but for most commonly used case (mat1 and mat2 is 2d tensor), B = 1,
   // balance partition M by using parallel_sparse_csr.
-  using Vec = vec::Vectorized<scalar_t>;
+  using fVec = vec::Vectorized<vec::vec_scalar_t<scalar_t>>;
   for (const auto b : c10::irange(B)) {
     auto crow_slice = crow_acc[b];
     auto col_slice = col_acc[b];
@@ -65,8 +65,8 @@ void sampled_addmm_sparse_csr_kernel_impl(
           int64_t n = col_slice[e];
           scalar_t val = values_slice[e];
           scalar_t dot = vec::map2_reduce_all<scalar_t>(
-              [](Vec x, Vec y) { return x * y; },
-              [](Vec x, Vec y) { return x + y; },
+              [](fVec x, fVec y) { return x * y; },
+              [](fVec x, fVec y) { return x + y; },
               mat1_ptr + m * K,
               mat2_ptr + n * K,
               K);
@@ -85,7 +85,7 @@ void sampled_addmm_sparse_csr_kernel(
     const Scalar& alpha,
     const Tensor& result) {
   const auto index_type = result.crow_indices().scalar_type();
-  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(mat1.scalar_type(), "sampled_addmm_sparse_csr_kernel", [&]() {
+  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(kHalf, kBFloat16, mat1.scalar_type(), "sampled_addmm_sparse_csr_kernel", [&]() {
     AT_DISPATCH_INDEX_TYPES(index_type, "sampled_addmm_sparse_csr_index", [&]() {
       sampled_addmm_sparse_csr_kernel_impl<scalar_t, index_t>(mat1, mat2, beta, alpha, result);
     });

--- a/aten/src/ATen/native/sparse/SparseBlas.cpp
+++ b/aten/src/ATen/native/sparse/SparseBlas.cpp
@@ -125,6 +125,7 @@ Tensor& sparse_sampled_addmm_out_sparse_csr_cpu(
   // Allow only same types as for the CUDA path
   auto t = self.scalar_type();
   TORCH_CHECK(t == ScalarType::Double || t == ScalarType::Float ||
+    t == ScalarType::Half || t == ScalarType::BFloat16 ||
     t == ScalarType::ComplexFloat || t == ScalarType::ComplexDouble,
     "sparse_sampled_addmm: Expected self to be a floating-point or complex tensor, but got ", t);
   if (&result != &self) {


### PR DESCRIPTION
Add bfloat16/float16 support for torch.sparse.mm backward
This adds half-precision support to the backward pass of torch.sparse.mm for CSR sparse tensors. Previously, backward would fail with: NotImplementedError: "sampled_addmm_out_sparse_csr" not implemented for 'BFloat16'

The fix enables memory-efficient sparse gradients with half precision while maintaining numerical stability through fp32 intermediate computations.

Fixes #144040




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01