### PR TITLE
[2/N] Add return types of Python functions

### DIFF
--- a/torch/utils/_cpp_extension_versioner.py
+++ b/torch/utils/_cpp_extension_versioner.py
@@ -27,7 +27,7 @@ def hash_build_arguments(hash_value, build_arguments):
 
 
 class ExtensionVersioner:
-    def __init__(self):
+    def __init__(self) -> None:
         self.entries = {}
 
     def get_version(self, name):

--- a/torch/utils/_debug_mode.py
+++ b/torch/utils/_debug_mode.py
@@ -60,7 +60,7 @@ def _stringify_dtensor_spec(spec) -> str:
 
 
 class TensorIdTracker:
-    def __init__(self):
+    def __init__(self) -> None:
         self.tensor_memo: dict[WeakIdRef, int] = {}
         self.next_tensor_id = 0
 
@@ -68,7 +68,7 @@ class TensorIdTracker:
         with torch._C._DisablePythonDispatcher():
             o = WeakIdRef(tensor)
 
-            def del_memo():
+            def del_memo() -> None:
                 self.tensor_memo.pop(o, None)
 
             weakref.finalize(tensor, del_memo)
@@ -157,7 +157,7 @@ class _DebugCall:
         record: Optional[dict[str, Any]] = None,
         log: Optional[dict[str, Any]] = None,
         stack: bool = False,
-    ):
+    ) -> None:
         self.call_depth = call_depth
         if stack:
             self.stack_trace = _get_stack_trace()
@@ -207,7 +207,7 @@ class _OpCall(_DebugCall):
         kwargs: dict,
         call_depth: int,
         stack: bool = False,
-    ):
+    ) -> None:
         super().__init__(call_depth, stack=stack)
         self.op = op
         self.args = args
@@ -282,7 +282,7 @@ class _RedistributeCall(_DebugCall):
         transform_info_str,
         call_depth,
         stack=False,
-    ):
+    ) -> None:
         super().__init__(call_depth, stack=stack)
         self.arg = arg
         self.src_placement = src_placement
@@ -334,7 +334,7 @@ class _RedistributeCall(_DebugCall):
 class _NNModuleCall(_DebugCall):
     """Designates entering an nn.Module's forward method"""
 
-    def __init__(self, module_name: str, call_depth: int, stack: bool = False):
+    def __init__(self, module_name: str, call_depth: int, stack: bool = False) -> None:
         super().__init__(call_depth, stack=stack)
         self.module_name = module_name
 
@@ -395,7 +395,7 @@ class DebugMode(TorchDispatchMode):
         record_stack_trace=False,
         record_output=False,
         record_ids=False,
-    ):
+    ) -> None:
         super().__init__()
         import torch.distributed.tensor  # noqa: F401
 
@@ -440,13 +440,13 @@ class DebugMode(TorchDispatchMode):
 
         self.reset()
 
-    def reset(self):
+    def reset(self) -> None:
         self.operators = []
         self.call_depth = 0
         self._tensor_memo = TensorIdTracker()
         self._output_info: dict[int, object] = {}
 
-    def _track_op_output(self, op_index, result):
+    def _track_op_output(self, op_index, result) -> None:
         """Assign IDs to output tensors and store in output_info"""
         # self._track_tensor_ids(result)
         self._output_info[op_index] = result
@@ -455,10 +455,10 @@ class DebugMode(TorchDispatchMode):
     # will force torch.compile to always use the “eager” backend
     # With this, DebugMode will not take effect on torch.compile
     @classmethod
-    def ignore_compile_internals(cls):
+    def ignore_compile_internals(cls) -> bool:
         return True
 
-    def _record_call(self, call):
+    def _record_call(self, call) -> None:
         if not self.store_original_args:
             call.stringify_args(
                 self.record_tensor_attributes,
@@ -466,7 +466,7 @@ class DebugMode(TorchDispatchMode):
             )
         self.operators.append(call)
 
-    def _record_call_output(self, call, output):
+    def _record_call_output(self, call, output) -> None:
         if not self.record_output:
             return
         call.stringify_output(
@@ -562,19 +562,19 @@ class DebugMode(TorchDispatchMode):
         if self.record_stack_trace:
             self.anomaly_for_traces.__exit__(*args)
 
-    def module_tracker_setup(self):
+    def module_tracker_setup(self) -> None:
         from torch.distributed._tools.mod_tracker import ModTracker
 
         self.module_tracker = ModTracker()
 
         # module pre-fw hook: record module call
-        def pre_fw_hook(module, input):
+        def pre_fw_hook(module, input) -> None:
             fqn = self.module_tracker._get_mod_name(module)  # type: ignore[attribute, union-attr]
             self.operators.append(_NNModuleCall(fqn, self.call_depth + 1))
             self.call_depth += 1
 
         # module post-fw hook: decrement call depth
-        def post_fw_hook(module, input, output):
+        def post_fw_hook(module, input, output) -> None:
             self.call_depth -= 1
 
         self.module_tracker.register_user_hooks(pre_fw_hook, post_fw_hook)

--- a/torch/utils/_device.py
+++ b/torch/utils/_device.py
@@ -59,7 +59,7 @@ def _device_constructors():
 
 # NB: This is directly called from C++ in torch/csrc/Device.cpp
 class DeviceContext(TorchFunctionMode):
-    def __init__(self, device):
+    def __init__(self, device) -> None:
         # pyrefly: ignore [read-only]
         self.device = torch.device(device)
 

--- a/torch/utils/_ordered_set.py
+++ b/torch/utils/_ordered_set.py
@@ -24,7 +24,7 @@ class OrderedSet(MutableSet[T], Reversible[T]):
 
     __slots__ = ("_dict",)
 
-    def __init__(self, iterable: Optional[Iterable[T]] = None):
+    def __init__(self, iterable: Optional[Iterable[T]] = None) -> None:
         self._dict = dict.fromkeys(iterable, None) if iterable is not None else {}
 
     @staticmethod

--- a/torch/utils/_python_dispatch.py
+++ b/torch/utils/_python_dispatch.py
@@ -86,7 +86,7 @@ class TorchDispatchMode:
     # Mode authors can implement how the mode interacts with higher order operators.
     supports_higher_order_operators = False
 
-    def __init__(self, _dispatch_key=None):
+    def __init__(self, _dispatch_key=None) -> None:
         if _dispatch_key is not None:
             if not isinstance(_dispatch_key, torch._C.DispatchKey):
                 raise AssertionError("_dispatch_key must be a torch._C.DispatchKey")
@@ -98,7 +98,7 @@ class TorchDispatchMode:
             deque()
         )
 
-    def _lazy_init_old_dispatch_mode_flags(self):
+    def _lazy_init_old_dispatch_mode_flags(self) -> None:
         if not hasattr(self, "old_dispatch_mode_flags"):
             self.old_dispatch_mode_flags: deque[bool] = deque()  # type: ignore[no-redef]
 
@@ -171,11 +171,11 @@ class TorchDispatchMode:
         return instance
 
     @classmethod
-    def is_infra_mode(cls):
+    def is_infra_mode(cls) -> bool:
         return False
 
     @classmethod
-    def ignore_compile_internals(cls):
+    def ignore_compile_internals(cls) -> bool:
         """Ignore operators that are compiled via torch.compile.
 
         If ``True``, then this TorchDispatchMode ignores operators that
@@ -287,7 +287,7 @@ def _get_current_dispatch_mode_stack() -> list[TorchDispatchMode]:
     return [_get_dispatch_stack_at(i) for i in range(stack_len)]
 
 
-def _push_mode(mode: TorchDispatchMode):
+def _push_mode(mode: TorchDispatchMode) -> None:
     k = mode._dispatch_key if hasattr(mode, "_dispatch_key") else None
     if k is not None and k != torch._C.DispatchKey.PreDispatch:
         raise AssertionError(
@@ -544,7 +544,7 @@ def transform_subclass(t, callback, outer_size=None, outer_stride=None):
     return sub
 
 
-def _correct_storage_aliasing(func, schema_info, args, outs):
+def _correct_storage_aliasing(func, schema_info, args, outs) -> None:
     """
     Given: an OpOverload, a SchemaInfo (cached information from torchgen about schema),
     and the inputs/outputs to the OpOverload,
@@ -563,7 +563,7 @@ def _correct_storage_aliasing(func, schema_info, args, outs):
     if not isinstance(outs, (list, tuple)):
         raise AssertionError(f"outs must be a list or tuple, got {type(args)}")
 
-    def alias_non_inplace_storage(arg, ret):
+    def alias_non_inplace_storage(arg, ret) -> None:
         # This is hopefully a reasonable assert:
         # subclasses that rely on this API for output aliasing
         # should always return wrapper tensor subclasses for us to manually alias.

--- a/torch/utils/_strobelight/cli_function_profiler.py
+++ b/torch/utils/_strobelight/cli_function_profiler.py
@@ -81,7 +81,7 @@ class StrobelightCLIFunctionProfiler:
         sample_tags: Optional[list[str]] = None,
         stack_max_len: int = 127,
         async_stack_max_len: int = 127,
-    ):
+    ) -> None:
         self.stop_at_error = stop_at_error
         self.max_profile_duration_sec = max_profile_duration_sec
         self.sample_each = sample_each

--- a/torch/utils/_strobelight/examples/cli_function_profiler_example.py
+++ b/torch/utils/_strobelight/examples/cli_function_profiler_example.py
@@ -14,7 +14,7 @@ if __name__ == "__main__":
     # use decorator with default profiler or optional profile arguments.
     @strobelight(sample_each=10000, stop_at_error=False)
     @torch.compile()
-    def work():
+    def work() -> None:
         for _ in range(10):
             torch._dynamo.reset()
             for j in range(5):
@@ -27,7 +27,7 @@ if __name__ == "__main__":
     profiler = StrobelightCLIFunctionProfiler(stop_at_error=False)
 
     @strobelight(profiler, sample_tags=["something", "another"])
-    def work2():
+    def work2() -> None:
         sum = 0
         for _ in range(100000000):
             sum += 1  # noqa: SIM113

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -471,7 +471,7 @@ class PythonMod(sympy.Function):
     def _eval_is_nonpositive(self) -> Optional[bool]:
         return True if self.args[1].is_negative else None  # type: ignore[attr-defined]
 
-    def _ccode(self, printer):
+    def _ccode(self, printer) -> str:
         # pyrefly: ignore [missing-attribute]
         p = printer.parenthesize(self.args[0], PRECEDENCE["Atom"] - 0.5)
         # pyrefly: ignore [missing-attribute]
@@ -558,7 +558,7 @@ class CeilToInt(sympy.Function):
         if isinstance(number, sympy.Number):
             return sympy.Integer(math.ceil(float(number)))
 
-    def _ccode(self, printer):
+    def _ccode(self, printer) -> str:
         # pyrefly: ignore [missing-attribute]
         number = printer.parenthesize(self.args[0], self.args[0].precedence - 0.5)
         return f"ceil({number})"
@@ -1164,7 +1164,7 @@ class IntTrueDiv(sympy.Function):
         if isinstance(base, sympy.Integer) and isinstance(divisor, sympy.Integer):
             return sympy.Float(int(base) / int(divisor))
 
-    def _ccode(self, printer):
+    def _ccode(self, printer) -> str:
         # pyrefly: ignore [missing-attribute]
         base = printer.parenthesize(self.args[0], PRECEDENCE["Atom"] - 0.5)
         # pyrefly: ignore [missing-attribute]
@@ -1331,11 +1331,11 @@ class Identity(sympy.Function):
 
     precedence = 10
 
-    def __repr__(self):  # type: ignore[override]
+    def __repr__(self) -> str:  # type: ignore[override]
         # pyrefly: ignore [missing-attribute]
         return f"Identity({self.args[0]})"
 
-    def _sympystr(self, printer):
+    def _sympystr(self, printer) -> str:
         """Controls how sympy's StrPrinter prints this"""
         # pyrefly: ignore [missing-attribute]
         return f"({printer.doprint(self.args[0])})"

--- a/torch/utils/_sympy/numbers.py
+++ b/torch/utils/_sympy/numbers.py
@@ -42,7 +42,7 @@ class IntInfinity(Number, metaclass=Singleton):
     def __new__(cls):
         return AtomicExpr.__new__(cls)
 
-    def _sympystr(self, printer):
+    def _sympystr(self, printer) -> str:
         return "int_oo"
 
     def _eval_subs(self, old, new):
@@ -237,7 +237,7 @@ class NegativeIntInfinity(Number, metaclass=Singleton):
         if self == old:
             return new
 
-    def _sympystr(self, printer):
+    def _sympystr(self, printer) -> str:
         return "-int_oo"
 
     """

--- a/torch/utils/_sympy/singleton_int.py
+++ b/torch/utils/_sympy/singleton_int.py
@@ -17,7 +17,7 @@ class SingletonInt(sympy.AtomicExpr):
 
     # The semantics of this class should match that of NestedIntSymNodeImpl in
     # c10/core/NestedIntSymNodeImpl.h
-    def __init__(self, val, *, coeff=1):
+    def __init__(self, val, *, coeff=1) -> None:
         self._val = val
         self._coeff = coeff
         super().__init__()

--- a/torch/utils/_thunk.py
+++ b/torch/utils/_thunk.py
@@ -17,7 +17,7 @@ class Thunk(Generic[R]):
 
     __slots__ = ["f", "r"]
 
-    def __init__(self, f: Callable[[], R]):
+    def __init__(self, f: Callable[[], R]) -> None:
         self.f = f
         self.r = None
 

--- a/torch/utils/_traceback.py
+++ b/torch/utils/_traceback.py
@@ -144,7 +144,7 @@ def shorten_filename(fn, *, base=None):
         return fn[len(prefix) + 1 :]
 
 
-def format_frame(frame, *, base=None, line=False):
+def format_frame(frame, *, base=None, line=False) -> str:
     """
     Format a FrameSummary in a short way, without printing full absolute path or code.
 
@@ -164,11 +164,11 @@ def format_traceback_short(tb):
 class CapturedTraceback:
     __slots__ = ["tb", "skip"]
 
-    def __init__(self, tb, skip=0):
+    def __init__(self, tb, skip=0) -> None:
         self.tb = tb
         self.skip = skip
 
-    def cleanup(self):
+    def cleanup(self) -> None:
         self.tb = None
 
     def summary(self):

--- a/torch/utils/_zip.py
+++ b/torch/utils/_zip.py
@@ -36,7 +36,7 @@ def remove_prefix(text, prefix):
     return text
 
 
-def write_to_zip(file_path, strip_file_path, zf, prepend_str=""):
+def write_to_zip(file_path, strip_file_path, zf, prepend_str="") -> None:
     stripped_file_path = prepend_str + remove_prefix(file_path, strip_file_dir + "/")
     path = Path(stripped_file_path)
     if path.name in DENY_LIST:

--- a/torch/utils/backcompat/__init__.py
+++ b/torch/utils/backcompat/__init__.py
@@ -8,11 +8,11 @@ from torch._C import (
 
 
 class Warning:
-    def __init__(self, setter, getter):
+    def __init__(self, setter, getter) -> None:
         self.setter = setter
         self.getter = getter
 
-    def set_enabled(self, value):
+    def set_enabled(self, value) -> None:
         self.setter(value)
 
     def get_enabled(self):

--- a/torch/utils/backend_registration.py
+++ b/torch/utils/backend_registration.py
@@ -82,7 +82,7 @@ def rename_privateuse1_backend(backend_name: str) -> None:
     _privateuse1_backend_name = backend_name
 
 
-def _check_register_once(module, attr):
+def _check_register_once(module, attr) -> None:
     if hasattr(module, attr):
         raise RuntimeError(
             f"The custom device module of {module} has already been registered with {attr}"
@@ -448,33 +448,33 @@ def _get_custom_mod_func(func_name: str):
 
 
 class _DummyBackendModule:
-    def is_initialized(self):
+    def is_initialized(self) -> bool:
         return True
 
-    def is_available(self):
+    def is_available(self) -> bool:
         return True
 
-    def current_device(self):
+    def current_device(self) -> int:
         return 0
 
-    def _is_in_bad_fork(self):
+    def _is_in_bad_fork(self) -> bool:
         return False
 
-    def manual_seed_all(self, seed: int):
+    def manual_seed_all(self, seed: int) -> None:
         pass
 
-    def device_count(self):
+    def device_count(self) -> int:
         return 1
 
 
 class _DummyPrivateUse1Hook(torch._C._acc.PrivateUse1Hooks):
-    def is_available(self):
+    def is_available(self) -> bool:
         return True
 
-    def has_primary_context(self, dev_id):
+    def has_primary_context(self, dev_id) -> bool:
         return True
 
-    def is_built(self):
+    def is_built(self) -> bool:
         return True
 
 
@@ -485,7 +485,7 @@ class _DummyDeviceGuard(torch._C._acc.DeviceGuard):
 
 def _setup_privateuseone_for_python_backend(
     rename=None, backend_module=None, hook=None, device_guard=None
-):
+) -> None:
     """This function will prepare the PrivateUse1 dispatch key to be used as a python backend.
 
     WARNING: this API is experimental and might change without notice.

--- a/torch/utils/benchmark/examples/compare.py
+++ b/torch/utils/benchmark/examples/compare.py
@@ -20,7 +20,7 @@ class FauxTorch:
     writing serialized measurements, but this simplifies that model to
     make the example clearer.
     """
-    def __init__(self, real_torch, extra_ns_per_element):
+    def __init__(self, real_torch, extra_ns_per_element) -> None:
         self._real_torch = real_torch
         self._extra_ns_per_element = extra_ns_per_element
 
@@ -45,7 +45,7 @@ class FauxTorch:
         return self.extra_overhead(self._real_torch.matmul(*args, **kwargs))
 
 
-def main():
+def main() -> None:
     tasks = [
         ("add", "add", "torch.add(x, y)"),
         ("add", "add (extra +0)", "torch.add(x, y + zero)"),

--- a/torch/utils/benchmark/examples/fuzzer.py
+++ b/torch/utils/benchmark/examples/fuzzer.py
@@ -9,7 +9,7 @@ import sys
 import torch.utils.benchmark as benchmark_utils
 
 
-def main():
+def main() -> None:
     add_fuzzer = benchmark_utils.Fuzzer(
         parameters=[
             [

--- a/torch/utils/benchmark/examples/op_benchmark.py
+++ b/torch/utils/benchmark/examples/op_benchmark.py
@@ -16,7 +16,7 @@ import operator
 _MEASURE_TIME = 1.0
 
 
-def assert_dicts_equal(dict_0, dict_1):
+def assert_dicts_equal(dict_0, dict_1) -> None:
     """Builtin dict comparison will not compare numpy arrays.
     e.g.
         x = {"a": np.ones((2, 1))}
@@ -28,7 +28,7 @@ def assert_dicts_equal(dict_0, dict_1):
         raise AssertionError("dict values differ for keys other than 'dtype'")
 
 
-def run(n, stmt, fuzzer_cls):
+def run(n, stmt, fuzzer_cls) -> None:
     float_iter = fuzzer_cls(seed=0, dtype=torch.float32).take(n)
     int_iter = fuzzer_cls(seed=0, dtype=torch.int32).take(n)
     raw_results = []
@@ -97,7 +97,7 @@ def run(n, stmt, fuzzer_cls):
         print(spacer)
 
 
-def main():
+def main() -> None:
     run(n=100, stmt="torch.median(x, dim=0)", fuzzer_cls=UnaryOpFuzzer)
     run(n=100, stmt="torch.square(x)", fuzzer_cls=UnaryOpFuzzer)
     run(n=100, stmt="x + y", fuzzer_cls=BinaryOpFuzzer)

--- a/torch/utils/benchmark/examples/sparse/compare.py
+++ b/torch/utils/benchmark/examples/sparse/compare.py
@@ -19,7 +19,7 @@ class FauxTorch:
     writing serialized measurements, but this simplifies that model to
     make the example clearer.
     """
-    def __init__(self, real_torch, extra_ns_per_element):
+    def __init__(self, real_torch, extra_ns_per_element) -> None:
         self._real_torch = real_torch
         self._extra_ns_per_element = extra_ns_per_element
 
@@ -28,7 +28,7 @@ class FauxTorch:
         return self.Sparse(self._real_torch, self._extra_ns_per_element)
 
     class Sparse:
-        def __init__(self, real_torch, extra_ns_per_element):
+        def __init__(self, real_torch, extra_ns_per_element) -> None:
             self._real_torch = real_torch
             self._extra_ns_per_element = extra_ns_per_element
 
@@ -73,7 +73,7 @@ def gen_sparse(size, density, dtype, device='cpu'):
     indices, values = generate_coo_data(size, sparse_dim, nnz, dtype, device)
     return torch.sparse_coo_tensor(indices, values, size, dtype=dtype, device=device)
 
-def main():
+def main() -> None:
     tasks = [
         ("matmul", "x @ y", "torch.sparse.mm(x, y)"),
         ("matmul", "x @ y + 0", "torch.sparse.mm(x, y) + zero"),

--- a/torch/utils/benchmark/examples/sparse/fuzzer.py
+++ b/torch/utils/benchmark/examples/sparse/fuzzer.py
@@ -8,7 +8,7 @@ import sys
 
 import torch.utils.benchmark as benchmark_utils
 
-def main():
+def main() -> None:
     add_fuzzer = benchmark_utils.Fuzzer(
         parameters=[
             [

--- a/torch/utils/benchmark/examples/sparse/op_benchmark.py
+++ b/torch/utils/benchmark/examples/sparse/op_benchmark.py
@@ -14,7 +14,7 @@ import operator
 
 _MEASURE_TIME = 1.0
 
-def assert_dicts_equal(dict_0, dict_1):
+def assert_dicts_equal(dict_0, dict_1) -> None:
     """Builtin dict comparison will not compare numpy arrays.
     e.g.
         x = {"a": np.ones((2, 1))}
@@ -25,7 +25,7 @@ def assert_dicts_equal(dict_0, dict_1):
     if all(np.all(v != dict_1[k]) for k, v in dict_0.items() if k != "dtype"):
         raise AssertionError("dict values differ for keys other than 'dtype'")
 
-def run(n, stmt, fuzzer_cls):
+def run(n, stmt, fuzzer_cls) -> None:
     float_iter = fuzzer_cls(seed=0, dtype=torch.float32).take(n)
     double_iter = fuzzer_cls(seed=0, dtype=torch.float64).take(n)
     raw_results = []
@@ -92,7 +92,7 @@ def run(n, stmt, fuzzer_cls):
         print(spacer)
 
 
-def main():
+def main() -> None:
     run(n=100, stmt="torch.sparse.sum(x, dim=0)", fuzzer_cls=UnaryOpSparseFuzzer)
     run(n=100, stmt="torch.sparse.softmax(x, dim=0)", fuzzer_cls=UnaryOpSparseFuzzer)
     run(n=100, stmt="x + y", fuzzer_cls=BinaryOpSparseFuzzer)

--- a/torch/utils/benchmark/examples/spectral_ops_fuzz_test.py
+++ b/torch/utils/benchmark/examples/spectral_ops_fuzz_test.py
@@ -63,7 +63,7 @@ BENCHMARK_MAP = {b.name: b for b in BENCHMARKS}
 BENCHMARK_NAMES = [b.name for b in BENCHMARKS]
 DEVICE_NAMES = ['cpu', 'cuda']
 
-def _output_csv(file, results):
+def _output_csv(file, results) -> None:
     file.write('benchmark,device,num_threads,numel,shape,contiguous,dim,mean (us),median (us),iqr (us)\n')
     for measurement in results:
         metadata = measurement.metadata

--- a/torch/utils/benchmark/op_fuzzers/binary.py
+++ b/torch/utils/benchmark/op_fuzzers/binary.py
@@ -14,7 +14,7 @@ _POW_TWO_SIZES = tuple(2 ** i for i in range(
 
 
 class BinaryOpFuzzer(Fuzzer):
-    def __init__(self, seed, dtype=torch.float32, cuda=False):
+    def __init__(self, seed, dtype=torch.float32, cuda=False) -> None:
         super().__init__(
             parameters=[
                 # Dimensionality of x and y. (e.g. 1D, 2D, or 3D.)

--- a/torch/utils/benchmark/op_fuzzers/sparse_binary.py
+++ b/torch/utils/benchmark/op_fuzzers/sparse_binary.py
@@ -14,7 +14,7 @@ _POW_TWO_SIZES = tuple(2 ** i for i in range(
 
 
 class BinaryOpSparseFuzzer(Fuzzer):
-    def __init__(self, seed, dtype=torch.float32, cuda=False):
+    def __init__(self, seed, dtype=torch.float32, cuda=False) -> None:
         super().__init__(
             parameters=[
                 # Dimensionality of x and y. (e.g. 1D, 2D, or 3D.)

--- a/torch/utils/benchmark/op_fuzzers/spectral.py
+++ b/torch/utils/benchmark/op_fuzzers/spectral.py
@@ -29,7 +29,7 @@ REGULAR_SIZES.sort()
 
 class SpectralOpFuzzer(benchmark.Fuzzer):
     def __init__(self, *, seed: int, dtype=torch.float64,
-                 cuda: bool = False, probability_regular: float = 1.0):
+                 cuda: bool = False, probability_regular: float = 1.0) -> None:
         super().__init__(
             parameters=[
                 # Dimensionality of x. (e.g. 1D, 2D, or 3D.)

--- a/torch/utils/benchmark/op_fuzzers/unary.py
+++ b/torch/utils/benchmark/op_fuzzers/unary.py
@@ -14,7 +14,7 @@ _POW_TWO_SIZES = tuple(2 ** i for i in range(
 
 
 class UnaryOpFuzzer(Fuzzer):
-    def __init__(self, seed, dtype=torch.float32, cuda=False):
+    def __init__(self, seed, dtype=torch.float32, cuda=False) -> None:
         super().__init__(
             parameters=[
                 # Dimensionality of x. (e.g. 1D, 2D, or 3D.)

--- a/torch/utils/benchmark/utils/compare.py
+++ b/torch/utils/benchmark/utils/compare.py
@@ -34,7 +34,7 @@ class _Column:
         time_unit: str,
         trim_significant_figures: bool,
         highlight_warnings: bool,
-    ):
+    ) -> None:
         self._grouped_results = grouped_results
         self._flat_results = [*it.chain.from_iterable(grouped_results)]
         self._time_scale = time_scale
@@ -79,7 +79,7 @@ def optional_min(seq):
 
 class _Row:
     def __init__(self, results, row_group, render_env, env_str_len,
-                 row_name_str_len, time_scale, colorize, num_threads=None):
+                 row_name_str_len, time_scale, colorize, num_threads=None) -> None:
         super().__init__()
         self._results = results
         self._row_group = row_group
@@ -91,7 +91,7 @@ class _Row:
         self._columns: tuple[_Column, ...] = ()
         self._num_threads = num_threads
 
-    def register_columns(self, columns: tuple[_Column, ...]):
+    def register_columns(self, columns: tuple[_Column, ...]) -> None:
         self._columns = columns
 
     def as_column_strings(self):
@@ -156,7 +156,7 @@ class Table:
             colorize: Colorize,
             trim_significant_figures: bool,
             highlight_warnings: bool
-    ):
+    ) -> None:
         if len({r.label for r in results}) != 1:
             raise AssertionError("All results must share the same label")
 
@@ -283,17 +283,17 @@ class Compare:
     Args:
         results: List of Measurement to display.
     """
-    def __init__(self, results: list[common.Measurement]):
+    def __init__(self, results: list[common.Measurement]) -> None:
         self._results: list[common.Measurement] = []
         self.extend_results(results)
         self._trim_significant_figures = False
         self._colorize = Colorize.NONE
         self._highlight_warnings = False
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "\n".join(self._render())
 
-    def extend_results(self, results):
+    def extend_results(self, results) -> None:
         """Append results to already stored ones.
 
         All added results must be instances of ``Measurement``.
@@ -305,22 +305,22 @@ class Compare:
                 )
         self._results.extend(results)
 
-    def trim_significant_figures(self):
+    def trim_significant_figures(self) -> None:
         """Enables trimming of significant figures when building the formatted table."""
         self._trim_significant_figures = True
 
-    def colorize(self, rowwise=False):
+    def colorize(self, rowwise=False) -> None:
         """Colorize formatted table.
 
         Colorize columnwise by default.
         """
         self._colorize = Colorize.ROWWISE if rowwise else Colorize.COLUMNWISE
 
-    def highlight_warnings(self):
+    def highlight_warnings(self) -> None:
         """Enables warning highlighting when building formatted table."""
         self._highlight_warnings = True
 
-    def print(self):
+    def print(self) -> None:
         """Print formatted table"""
         print(str(self))
 

--- a/torch/utils/benchmark/utils/compile.py
+++ b/torch/utils/benchmark/utils/compile.py
@@ -25,7 +25,7 @@ except ModuleNotFoundError:
     print("tabulate is not installed, please pip install tabulate to use this utility")
 
 if HAS_TABULATE:
-    def _enable_tensor_cores():
+    def _enable_tensor_cores() -> None:
         global _warned_tensor_cores
 
         if torch.cuda.is_available():
@@ -36,7 +36,7 @@ if HAS_TABULATE:
                     print("we will enable it automatically by setting `torch.set_float32_matmul_precision('high')`")
                     _warned_tensor_cores = True
 
-    def _disable_tensor_cores():
+    def _disable_tensor_cores() -> None:
         torch.set_float32_matmul_precision(_default_float_32_precision)
 
     def bench_loop(

--- a/torch/utils/benchmark/utils/fuzzer.py
+++ b/torch/utils/benchmark/utils/fuzzer.py
@@ -29,7 +29,7 @@ class FuzzedParameter:
         maxval: Optional[Union[int, float]] = None,
         distribution: Optional[Union[str, dict[Any, float]]] = None,
         strict: bool = False,
-    ):
+    ) -> None:
         """
         Args:
             name:
@@ -159,10 +159,10 @@ class ParameterAlias:
 
     Chains of alias' are allowed, but may not contain cycles.
     """
-    def __init__(self, alias_to):
+    def __init__(self, alias_to) -> None:
         self.alias_to = alias_to
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"ParameterAlias[alias_to: {self.alias_to}]"
 
 
@@ -199,7 +199,7 @@ class FuzzedTensor:
         dtype=torch.float32,
         cuda=False,
         tensor_constructor: Optional[Callable] = None
-    ):
+    ) -> None:
         """
         Args:
             name:
@@ -329,7 +329,7 @@ class FuzzedTensor:
         allocation_size = tuple(size_i * step_i for size_i, step_i in zip(size, steps, strict=True))
         return size, steps, allocation_size
 
-    def satisfies_constraints(self, params):
+    def satisfies_constraints(self, params) -> bool:
         size, _, allocation_size = self._get_size_and_steps(params)
         # Product is computed in Python to avoid integer overflow.
         num_elements = prod(size)
@@ -357,7 +357,7 @@ class Fuzzer:
         tensors: list[Union[FuzzedTensor, list[FuzzedTensor]]],
         constraints: Optional[list[Callable]] = None,
         seed: Optional[int] = None
-    ):
+    ) -> None:
         """
         Args:
             parameters:

--- a/torch/utils/benchmark/utils/sparse_fuzzer.py
+++ b/torch/utils/benchmark/utils/sparse_fuzzer.py
@@ -19,7 +19,7 @@ class FuzzedSparseTensor(FuzzedTensor):
         coalesced: Optional[str] = None,
         dtype=torch.float32,
         cuda=False
-    ):
+    ) -> None:
         """
         Args:
             name:

--- a/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
+++ b/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
@@ -311,7 +311,7 @@ class CopyIfCallgrind:
 
     See `GlobalsBridge` for why this matters.
     """
-    def __init__(self, value: Any, *, setup: Optional[str] = None):
+    def __init__(self, value: Any, *, setup: Optional[str] = None) -> None:
         for method, supported_types in _GLOBALS_ALLOWED_TYPES.items():
             if any(isinstance(value, t) for t in supported_types):
                 self._value: Any = value

--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -899,7 +899,7 @@ def get_pretty_env_info():
     return pretty_str(get_env_info())
 
 
-def main():
+def main() -> None:
     print("Collecting environment information...")
     output = get_pretty_env_info()
     print(output)

--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -15,7 +15,7 @@ from torch._utils import ExceptionWrapper
 from . import MP_STATUS_CHECK_INTERVAL
 
 
-def _pin_memory_loop(in_queue, out_queue, device_id, done_event, device):
+def _pin_memory_loop(in_queue, out_queue, device_id, done_event, device) -> None:
     # This setting is thread local, and prevents the copy in pin_memory from
     # consuming all CPU cores.
     torch.set_num_threads(1)
@@ -23,7 +23,7 @@ def _pin_memory_loop(in_queue, out_queue, device_id, done_event, device):
     torch.multiprocessing._set_thread_name("pt_data_pin")
     torch.accelerator.set_device_index(device_id)
 
-    def do_one_step():
+    def do_one_step() -> None:
         try:
             r = in_queue.get(timeout=MP_STATUS_CHECK_INTERVAL)
         except queue.Empty:

--- a/torch/utils/data/_utils/signal_handling.py
+++ b/torch/utils/data/_utils/signal_handling.py
@@ -51,7 +51,7 @@ r"""Whether SIGCHLD handler is set for DataLoader worker failures. Only one
 handler needs to be set for all DataLoaders in a process."""
 
 
-def _set_SIGCHLD_handler():
+def _set_SIGCHLD_handler() -> None:
     # Windows doesn't support SIGCHLD handler
     if IS_WINDOWS:
         return
@@ -67,7 +67,7 @@ def _set_SIGCHLD_handler():
         # no-op.
         previous_handler = None
 
-    def handler(signum, frame):
+    def handler(signum, frame) -> None:
         # This following call uses `waitid` with WNOHANG from C side. Therefore,
         # Python can still get and update the process status successfully.
         _error_if_any_worker_fails()

--- a/torch/utils/data/_utils/worker.py
+++ b/torch/utils/data/_utils/worker.py
@@ -49,7 +49,7 @@ if IS_WINDOWS:
 
             self.manager_dead = False
 
-        def is_alive(self):
+        def is_alive(self) -> bool:
             if not self.manager_dead:
                 # Value obtained from https://msdn.microsoft.com/en-us/library/windows/desktop/ms687032.aspx
                 self.manager_dead = (
@@ -64,7 +64,7 @@ else:
             self.manager_pid = os.getppid()
             self.manager_dead = False
 
-        def is_alive(self):
+        def is_alive(self) -> bool:
             if not self.manager_dead:
                 self.manager_dead = os.getppid() != self.manager_pid
             return not self.manager_dead
@@ -80,20 +80,20 @@ class WorkerInfo:
     dataset: "Dataset"
     __initialized = False
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         for k, v in kwargs.items():
             setattr(self, k, v)
         self.__keys = tuple(kwargs.keys())
         self.__initialized = True
 
-    def __setattr__(self, key, val):
+    def __setattr__(self, key, val) -> None:
         if self.__initialized:
             raise RuntimeError(
                 f"Cannot assign attributes to {self.__class__.__name__} objects"
             )
         return super().__setattr__(key, val)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         items = [f"{k}={getattr(self, k)}" for k in self.__keys]
         return f"{self.__class__.__name__}({', '.join(items)})"
 
@@ -240,7 +240,7 @@ def _worker_loop(
     num_workers,
     persistent_workers,
     shared_seed,
-):
+) -> None:
     # See NOTE [ Data Loader Multiprocessing Shutdown Logic ] for details on the
     # logic of this function.
 

--- a/torch/utils/data/backward_compatibility.py
+++ b/torch/utils/data/backward_compatibility.py
@@ -7,5 +7,5 @@ from typing_extensions import deprecated as _deprecated
     "as `DataLoader` automatically applies sharding in every worker",
     category=FutureWarning,
 )
-def worker_init_fn(worker_id):
+def worker_init_fn(worker_id) -> None:
     pass

--- a/torch/utils/data/dataframes_pipes.ipynb
+++ b/torch/utils/data/dataframes_pipes.ipynb
@@ -27,7 +27,7 @@
    "source": [
     "# Example IterDataPipe\n",
     "class ExampleIterPipe(IterDataPipe):\n",
-    "    def __init__(self, range = 20):\n",
+    "    def __init__(self, range = 20) -> None:\n",
     "        self.range = range\n",
     "    def __iter__(self):\n",
     "        yield from self.range\n",

--- a/torch/utils/data/datapipes/_hook_iterator.py
+++ b/torch/utils/data/datapipes/_hook_iterator.py
@@ -52,7 +52,7 @@ def _generate_iterdatapipe_msg(datapipe, simplify_dp_name: bool = False):
     return output_string
 
 
-def _gen_invalid_iterdatapipe_msg(datapipe):
+def _gen_invalid_iterdatapipe_msg(datapipe) -> str:
     return (
         "This iterator has been invalidated because another iterator has been created "
         f"from the same IterDataPipe: {_generate_iterdatapipe_msg(datapipe)}\n"
@@ -119,7 +119,7 @@ def _set_datapipe_valid_iterator_id(datapipe):
     return datapipe._valid_iterator_id
 
 
-def hook_iterator(namespace):
+def hook_iterator(namespace) -> None:
     r"""
     Define a hook that is applied to all `__iter__` of metaclass `_DataPipeMeta`.
 
@@ -141,7 +141,7 @@ def hook_iterator(namespace):
         Those `__iter__` method commonly returns `self` but not necessarily.
         """
 
-        def __init__(self, iterator, datapipe, iterator_id, has_next_method):
+        def __init__(self, iterator, datapipe, iterator_id, has_next_method) -> None:
             self.iterator = iterator
             self.datapipe = datapipe
             self.iterator_id = iterator_id

--- a/torch/utils/data/datapipes/_typing.py
+++ b/torch/utils/data/datapipes/_typing.py
@@ -235,10 +235,10 @@ def issubinstance(data, data_type):
 class _DataPipeType:
     r"""Save type annotation in `param`."""
 
-    def __init__(self, param):
+    def __init__(self, param) -> None:
         self.param = param
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return _type_repr(self.param)
 
     def __eq__(self, other):
@@ -300,7 +300,7 @@ class _DataPipeMeta(GenericMeta):
         )
         return super().__new__(cls, name, bases, namespace, **kwargs)  # type: ignore[call-overload]
 
-    def __init__(self, name, bases, namespace, **kwargs):
+    def __init__(self, name, bases, namespace, **kwargs) -> None:
         super().__init__(name, bases, namespace, **kwargs)  # type: ignore[call-overload]
 
     # TODO: Fix isinstance bug
@@ -388,7 +388,7 @@ class _IterDataPipeMeta(_DataPipeMeta):
             reset_func = namespace["reset"]
 
             @functools.wraps(reset_func)
-            def conditional_reset(*args, **kwargs):
+            def conditional_reset(*args, **kwargs) -> None:
                 r"""
                 Only execute DataPipe's `reset()` method if `_SnapshotState` is `Iterating` or `NotStarted`.
 
@@ -413,7 +413,7 @@ class _IterDataPipeMeta(_DataPipeMeta):
         return super().__new__(cls, name, bases, namespace, **kwargs)  # type: ignore[call-overload]
 
 
-def _dp_init_subclass(sub_cls, *args, **kwargs):
+def _dp_init_subclass(sub_cls, *args, **kwargs) -> None:
     # Add function for datapipe instance to reinforce the type
     sub_cls.reinforce_type = reinforce_type
 

--- a/torch/utils/data/datapipes/dataframe/dataframe_wrapper.py
+++ b/torch/utils/data/datapipes/dataframe/dataframe_wrapper.py
@@ -83,7 +83,7 @@ def get_df_wrapper():
     return default_wrapper
 
 
-def set_df_wrapper(wrapper):
+def set_df_wrapper(wrapper) -> None:
     global default_wrapper
     default_wrapper = wrapper
 

--- a/torch/utils/data/datapipes/dataframe/datapipes.py
+++ b/torch/utils/data/datapipes/dataframe/datapipes.py
@@ -19,7 +19,7 @@ __all__ = [
 
 @functional_datapipe("_dataframes_as_tuples")
 class DataFramesAsTuplesPipe(IterDataPipe):
-    def __init__(self, source_datapipe):
+    def __init__(self, source_datapipe) -> None:
         self.source_datapipe = source_datapipe
 
     def __iter__(self):
@@ -30,7 +30,7 @@ class DataFramesAsTuplesPipe(IterDataPipe):
 
 @functional_datapipe("_dataframes_per_row", enable_df_api_tracing=True)
 class PerRowDataFramesPipe(DFIterDataPipe):
-    def __init__(self, source_datapipe):
+    def __init__(self, source_datapipe) -> None:
         self.source_datapipe = source_datapipe
 
     def __iter__(self):
@@ -42,7 +42,7 @@ class PerRowDataFramesPipe(DFIterDataPipe):
 
 @functional_datapipe("_dataframes_concat", enable_df_api_tracing=True)
 class ConcatDataFramesPipe(DFIterDataPipe):
-    def __init__(self, source_datapipe, batch=3):
+    def __init__(self, source_datapipe, batch=3) -> None:
         self.source_datapipe = source_datapipe
         self.n_batch = batch
 
@@ -59,7 +59,7 @@ class ConcatDataFramesPipe(DFIterDataPipe):
 
 @functional_datapipe("_dataframes_shuffle", enable_df_api_tracing=True)
 class ShuffleDataFramesPipe(DFIterDataPipe):
-    def __init__(self, source_datapipe):
+    def __init__(self, source_datapipe) -> None:
         self.source_datapipe = source_datapipe
 
     def __iter__(self):
@@ -84,7 +84,7 @@ class ShuffleDataFramesPipe(DFIterDataPipe):
 
 @functional_datapipe("_dataframes_filter", enable_df_api_tracing=True)
 class FilterDataFramesPipe(DFIterDataPipe):
-    def __init__(self, source_datapipe, filter_fn):
+    def __init__(self, source_datapipe, filter_fn) -> None:
         self.source_datapipe = source_datapipe
         self.filter_fn = filter_fn
 
@@ -113,7 +113,7 @@ class FilterDataFramesPipe(DFIterDataPipe):
 
 @functional_datapipe("_to_dataframes_pipe", enable_df_api_tracing=True)
 class ExampleAggregateAsDataFrames(DFIterDataPipe):
-    def __init__(self, source_datapipe, dataframe_size=10, columns=None):
+    def __init__(self, source_datapipe, dataframe_size=10, columns=None) -> None:
         self.source_datapipe = source_datapipe
         self.columns = columns
         self.dataframe_size = dataframe_size

--- a/torch/utils/data/datapipes/datapipe.py
+++ b/torch/utils/data/datapipes/datapipe.py
@@ -153,13 +153,13 @@ class IterDataPipe(IterableDataset[_T_co], metaclass=_IterDataPipeMeta):
             )
 
     @classmethod
-    def register_function(cls, function_name, function):
+    def register_function(cls, function_name, function) -> None:
         cls.functions[function_name] = function
 
     @classmethod
     def register_datapipe_as_function(
         cls, function_name, cls_to_register, enable_df_api_tracing=False
-    ):
+    ) -> None:
         if function_name in cls.functions:
             raise Exception(  # noqa: TRY002
                 f"Unable to add DataPipe function name {function_name} as it is already taken"
@@ -203,24 +203,24 @@ class IterDataPipe(IterableDataset[_T_co], metaclass=_IterDataPipeMeta):
         return super().__reduce_ex__(*args, **kwargs)
 
     @classmethod
-    def set_getstate_hook(cls, hook_fn):
+    def set_getstate_hook(cls, hook_fn) -> None:
         if IterDataPipe.getstate_hook is not None and hook_fn is not None:
             raise RuntimeError("Attempt to override existing getstate_hook")
         IterDataPipe.getstate_hook = hook_fn
 
     @classmethod
-    def set_reduce_ex_hook(cls, hook_fn):
+    def set_reduce_ex_hook(cls, hook_fn) -> None:
         if IterDataPipe.reduce_ex_hook is not None and hook_fn is not None:
             raise RuntimeError("Attempt to override existing reduce_ex_hook")
         IterDataPipe.reduce_ex_hook = hook_fn
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self.repr_hook is not None:
             return self.repr_hook(self)
         # Instead of showing <torch. ... .MapperIterDataPipe object at 0x.....>, return the class name
         return str(self.__class__.__qualname__)
 
-    def __str__(self):
+    def __str__(self) -> str:
         if self.str_hook is not None:
             return self.str_hook(self)
         # Instead of showing <torch. ... .MapperIterDataPipe object at 0x.....>, return the class name
@@ -242,7 +242,7 @@ class IterDataPipe(IterableDataset[_T_co], metaclass=_IterDataPipeMeta):
 
 
 class DFIterDataPipe(IterDataPipe):
-    def _is_dfpipe(self):
+    def _is_dfpipe(self) -> bool:
         return True
 
 
@@ -301,11 +301,11 @@ class MapDataPipe(Dataset[_T_co], metaclass=_DataPipeMeta):
             )
 
     @classmethod
-    def register_function(cls, function_name, function):
+    def register_function(cls, function_name, function) -> None:
         cls.functions[function_name] = function
 
     @classmethod
-    def register_datapipe_as_function(cls, function_name, cls_to_register):
+    def register_datapipe_as_function(cls, function_name, cls_to_register) -> None:
         if function_name in cls.functions:
             raise Exception(  # noqa: TRY002
                 f"Unable to add DataPipe function name {function_name} as it is already taken"
@@ -342,24 +342,24 @@ class MapDataPipe(Dataset[_T_co], metaclass=_DataPipeMeta):
         return super().__reduce_ex__(*args, **kwargs)
 
     @classmethod
-    def set_getstate_hook(cls, hook_fn):
+    def set_getstate_hook(cls, hook_fn) -> None:
         if MapDataPipe.getstate_hook is not None and hook_fn is not None:
             raise RuntimeError("Attempt to override existing getstate_hook")
         MapDataPipe.getstate_hook = hook_fn
 
     @classmethod
-    def set_reduce_ex_hook(cls, hook_fn):
+    def set_reduce_ex_hook(cls, hook_fn) -> None:
         if MapDataPipe.reduce_ex_hook is not None and hook_fn is not None:
             raise RuntimeError("Attempt to override existing reduce_ex_hook")
         MapDataPipe.reduce_ex_hook = hook_fn
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self.repr_hook is not None:
             return self.repr_hook(self)
         # Instead of showing <torch. ... .MapperMapDataPipe object at 0x.....>, return the class name
         return str(self.__class__.__qualname__)
 
-    def __str__(self):
+    def __str__(self) -> str:
         if self.str_hook is not None:
             return self.str_hook(self)
         # Instead of showing <torch. ... .MapperMapDataPipe object at 0x.....>, return the class name
@@ -371,7 +371,7 @@ class MapDataPipe(Dataset[_T_co], metaclass=_DataPipeMeta):
 
 
 class _DataPipeSerializationWrapper:
-    def __init__(self, datapipe):
+    def __init__(self, datapipe) -> None:
         self._datapipe = datapipe
 
     def __getstate__(self):
@@ -395,7 +395,7 @@ class _DataPipeSerializationWrapper:
         else:
             self._datapipe = pickle.loads(value)
 
-    def __len__(self):
+    def __len__(self) -> int:
         try:
             return len(self._datapipe)
         except Exception as e:
@@ -405,7 +405,7 @@ class _DataPipeSerializationWrapper:
 
 
 class _IterDataPipeSerializationWrapper(_DataPipeSerializationWrapper, IterDataPipe):
-    def __init__(self, datapipe: IterDataPipe[_T_co]):
+    def __init__(self, datapipe: IterDataPipe[_T_co]) -> None:
         super().__init__(datapipe)
         # pyrefly: ignore [invalid-type-var]
         self._datapipe_iter: Optional[Iterator[_T_co]] = None

--- a/torch/utils/data/datapipes/gen_pyi.py
+++ b/torch/utils/data/datapipes/gen_pyi.py
@@ -52,7 +52,7 @@ def gen_from_template(
     template_name: str,
     output_name: str,
     replacements: list[tuple[str, Any, int]],
-):
+) -> None:
     template_path = os.path.join(dir, template_name)
     output_path = os.path.join(dir, output_name)
 

--- a/torch/utils/data/datapipes/iter/combinatorics.py
+++ b/torch/utils/data/datapipes/iter/combinatorics.py
@@ -189,5 +189,5 @@ class ShufflerIterDataPipe(IterDataPipe[_T_co]):
         self._rng = random.Random()
         self._rng.setstate(rng_state)
 
-    def __del__(self):
+    def __del__(self) -> None:
         self._buffer.clear()

--- a/torch/utils/data/datapipes/iter/combining.py
+++ b/torch/utils/data/datapipes/iter/combining.py
@@ -46,7 +46,7 @@ class ConcaterIterDataPipe(IterDataPipe):
 
     datapipes: tuple[IterDataPipe]
 
-    def __init__(self, *datapipes: IterDataPipe):
+    def __init__(self, *datapipes: IterDataPipe) -> None:
         if len(datapipes) == 0:
             raise ValueError("Expected at least one DataPipe, but got nothing")
         if not all(isinstance(dp, IterDataPipe) for dp in datapipes):
@@ -148,7 +148,7 @@ class _ForkerIterDataPipe(IterDataPipe, _ContainerTemplate):
         num_instances: int,
         buffer_size: int = 1000,
         copy: Optional[Literal["shallow", "deep"]] = None,
-    ):
+    ) -> None:
         self.main_datapipe = datapipe
         self._datapipe_iterator: Optional[Iterator[Any]] = None
         self.num_instances = num_instances
@@ -180,7 +180,7 @@ class _ForkerIterDataPipe(IterDataPipe, _ContainerTemplate):
         self.end_ptr: Optional[int] = None  # The index to stop child
         self._child_stop: list[bool] = [True for _ in range(num_instances)]
 
-    def __len__(self):
+    def __len__(self) -> int:
         # pyrefly: ignore [bad-argument-type]
         return len(self.main_datapipe)
 
@@ -283,12 +283,12 @@ class _ForkerIterDataPipe(IterDataPipe, _ContainerTemplate):
         self.end_ptr = None
         self._child_stop = [True for _ in range(self.num_instances)]
 
-    def _cleanup(self):
+    def _cleanup(self) -> None:
         while self.buffer:
             d = self.buffer.popleft()
             StreamWrapper.close_streams(d)
 
-    def __del__(self):
+    def __del__(self) -> None:
         self._cleanup()
 
 
@@ -324,7 +324,7 @@ class _ChildDataPipe(IterDataPipe):
 
     _is_child_datapipe: bool = True
 
-    def __init__(self, main_datapipe: IterDataPipe, instance_id: int):
+    def __init__(self, main_datapipe: IterDataPipe, instance_id: int) -> None:
         if not isinstance(main_datapipe, _ContainerTemplate):
             raise AssertionError("main_datapipe must implement _ContainerTemplate")
 
@@ -337,7 +337,7 @@ class _ChildDataPipe(IterDataPipe):
         # We want to separate the code for reset and yield, so that 'reset' executes before __next__ is called
         return self.main_datapipe.get_next_element_by_instance(self.instance_id)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return self.main_datapipe.get_length_by_instance(self.instance_id)
 
     # This method is called by `hook_iterator` in `_typing.py`.
@@ -455,7 +455,7 @@ class _DemultiplexerIterDataPipe(IterDataPipe, _ContainerTemplate):
         classifier_fn: Callable[[_T_co], Optional[int]],
         drop_none: bool,
         buffer_size: int,
-    ):
+    ) -> None:
         # pyrefly: ignore [invalid-type-var]
         self.main_datapipe = datapipe
         self._datapipe_iterator: Optional[Iterator[Any]] = None
@@ -582,7 +582,7 @@ class _DemultiplexerIterDataPipe(IterDataPipe, _ContainerTemplate):
         self._child_stop = [True for _ in range(self.num_instances)]
         self.main_datapipe_exhausted = False
 
-    def _cleanup(self, instance_id: Optional[int] = None):
+    def _cleanup(self, instance_id: Optional[int] = None) -> None:
         ids = (
             range(self.num_instances)
             if instance_id is None
@@ -596,7 +596,7 @@ class _DemultiplexerIterDataPipe(IterDataPipe, _ContainerTemplate):
                 d = q.popleft()
                 StreamWrapper.close_streams(d)
 
-    def __del__(self):
+    def __del__(self) -> None:
         self._cleanup()
 
 
@@ -623,7 +623,7 @@ class MultiplexerIterDataPipe(IterDataPipe):
         [0, 10, 20, 1, 11, 21, 2, 12, 22]
     """
 
-    def __init__(self, *datapipes):
+    def __init__(self, *datapipes) -> None:
         self.datapipes = datapipes
         self.buffer: list = []  # Store values to be yielded only when every iterator provides one
 
@@ -640,7 +640,7 @@ class MultiplexerIterDataPipe(IterDataPipe):
             yield from self.buffer
             self.buffer.clear()
 
-    def __len__(self):
+    def __len__(self) -> int:
         if all(isinstance(dp, Sized) for dp in self.datapipes):
             return min(len(dp) for dp in self.datapipes) * len(self.datapipes)
         else:
@@ -667,7 +667,7 @@ class MultiplexerIterDataPipe(IterDataPipe):
         ) = state
         self.buffer = []
 
-    def __del__(self):
+    def __del__(self) -> None:
         self.buffer.clear()
 
 
@@ -695,7 +695,7 @@ class ZipperIterDataPipe(IterDataPipe[tuple[_T_co]]):
 
     datapipes: tuple[IterDataPipe]
 
-    def __init__(self, *datapipes: IterDataPipe):
+    def __init__(self, *datapipes: IterDataPipe) -> None:
         if not all(isinstance(dp, IterDataPipe) for dp in datapipes):
             raise TypeError(
                 "All inputs are required to be `IterDataPipe` for `ZipIterDataPipe`."

--- a/torch/utils/data/datapipes/iter/fileopener.py
+++ b/torch/utils/data/datapipes/iter/fileopener.py
@@ -50,7 +50,7 @@ class FileOpenerIterDataPipe(IterDataPipe[tuple[str, IOBase]]):
         mode: str = "r",
         encoding: Optional[str] = None,
         length: int = -1,
-    ):
+    ) -> None:
         super().__init__()
         self.datapipe: Iterable[str] = datapipe
         self.mode: str = mode

--- a/torch/utils/data/datapipes/iter/streamreader.py
+++ b/torch/utils/data/datapipes/iter/streamreader.py
@@ -32,7 +32,7 @@ class StreamReaderIterDataPipe(IterDataPipe[tuple[str, bytes]]):
 
     def __init__(
         self, datapipe: IterDataPipe[tuple[str, IOBase]], chunk: Optional[int] = None
-    ):
+    ) -> None:
         self.datapipe = datapipe
         self.chunk = chunk
 

--- a/torch/utils/data/datapipes/map/combining.py
+++ b/torch/utils/data/datapipes/map/combining.py
@@ -37,7 +37,7 @@ class ConcaterMapDataPipe(MapDataPipe):
 
     datapipes: tuple[MapDataPipe]
 
-    def __init__(self, *datapipes: MapDataPipe):
+    def __init__(self, *datapipes: MapDataPipe) -> None:
         if len(datapipes) == 0:
             raise ValueError("Expected at least one DataPipe, but got nothing")
         if not all(isinstance(dp, MapDataPipe) for dp in datapipes):

--- a/torch/utils/data/datapipes/utils/decoder.py
+++ b/torch/utils/data/datapipes/utils/decoder.py
@@ -168,7 +168,7 @@ class ImageHandler:
     - pilrgba: pil None rgba
     """
 
-    def __init__(self, imagespec):
+    def __init__(self, imagespec) -> None:
         if imagespec not in list(imagespecs.keys()):
             raise AssertionError(f"unknown image specification: {imagespec}")
         self.imagespec = imagespec.lower()
@@ -335,13 +335,13 @@ class Decoder:
     handlers until some handler returns something other than None.
     """
 
-    def __init__(self, *handler, key_fn=extension_extract_fn):
+    def __init__(self, *handler, key_fn=extension_extract_fn) -> None:
         self.handlers = list(handler) if handler else []
         self.key_fn = key_fn
 
     # Insert new handler from the beginning of handlers list to make sure the new
     # handler having the highest priority
-    def add_handler(self, *handler):
+    def add_handler(self, *handler) -> None:
         if not handler:
             return
         self.handlers = list(handler) + self.handlers

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -205,7 +205,7 @@ class TensorDataset(Dataset[tuple[Tensor, ...]]):
     def __getitem__(self, index):
         return tuple(tensor[index] for tensor in self.tensors)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return self.tensors[0].size(0)
 
 
@@ -292,7 +292,7 @@ class StackDataset(Dataset[_T_stack]):
         tuple_batch: list[_T_tuple] = [tuple(sample) for sample in list_batch]
         return tuple_batch
 
-    def __len__(self):
+    def __len__(self) -> int:
         return self._length
 
 
@@ -327,7 +327,7 @@ class ConcatDataset(Dataset[_T_co]):
                 raise AssertionError("ConcatDataset does not support IterableDataset")
         self.cumulative_sizes = self.cumsum(self.datasets)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return self.cumulative_sizes[-1]
 
     def __getitem__(self, idx):
@@ -374,7 +374,7 @@ class ChainDataset(IterableDataset):
                 raise AssertionError("ChainDataset only supports IterableDataset")
             yield from d
 
-    def __len__(self):
+    def __len__(self) -> int:
         total = 0
         for d in self.datasets:
             if not isinstance(d, IterableDataset):
@@ -412,7 +412,7 @@ class Subset(Dataset[_T_co]):
         else:
             return [self.dataset[self.indices[idx]] for idx in indices]
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.indices)
 
 

--- a/torch/utils/data/graph.py
+++ b/torch/utils/data/graph.py
@@ -15,7 +15,7 @@ DataPipe = Union[IterDataPipe, MapDataPipe]
 DataPipeGraph = dict[int, tuple[DataPipe, "DataPipeGraph"]]
 
 
-def _stub_unpickler():
+def _stub_unpickler() -> str:
     return "STUB"
 
 

--- a/torch/utils/data/graph_settings.py
+++ b/torch/utils/data/graph_settings.py
@@ -58,7 +58,7 @@ def apply_sharding(
     """
     graph = traverse_dps(datapipe)
 
-    def _helper(graph, prev_applied=None):
+    def _helper(graph, prev_applied=None) -> None:
         for dp, sub_graph in graph.values():
             applied = None
             if _is_sharding_datapipe(dp):

--- a/torch/utils/data/standard_pipes.ipynb
+++ b/torch/utils/data/standard_pipes.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "# Example IterDataPipe\n",
     "class ExampleIterPipe(IterDataPipe):\n",
-    "    def __init__(self, range = 20):\n",
+    "    def __init__(self, range = 20) -> None:\n",
     "        self.range = range\n",
     "    def __iter__(self):\n",
     "        yield from self.range"

--- a/torch/utils/data/typing.ipynb
+++ b/torch/utils/data/typing.ipynb
@@ -33,7 +33,7 @@
     "import functools\n",
     "ipython = get_ipython()\n",
     "def showtraceback(self, exc_tuple=None, filename=None, tb_offset=None,\n",
-    "                  exception_only=False, running_compiled_code=False):\n",
+    "                  exception_only=False, running_compiled_code=False) -> None:\n",
     "    try:\n",
     "        try:\n",
     "            etype, value, tb = self._get_exc_info(exc_tuple)\n",
@@ -227,7 +227,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def print_helper(cls, obj):\n",
+    "def print_helper(cls, obj) -> None:\n",
     "    print(f\"DataPipe[{cls.type}]\\nInstance type: {obj.type}\")"
    ]
   },
@@ -313,7 +313,7 @@
     "\n",
     "class DP(IterDataPipe):\n",
     "    @argument_validation\n",
-    "    def __init__(self, dp: IterDataPipe[Union[int, tuple]]):\n",
+    "    def __init__(self, dp: IterDataPipe[Union[int, tuple]]) -> None:\n",
     "        self.dp = dp\n",
     "\n",
     "    def __iter__(self):\n",
@@ -411,7 +411,7 @@
     "from torch.utils.data import runtime_validation, runtime_validation_disabled\n",
     "\n",
     "class DP(IterDataPipe[tuple[int, T_co]]):\n",
-    "    def __init__(self, datasource):\n",
+    "    def __init__(self, datasource) -> None:\n",
     "        self.ds = datasource\n",
     "\n",
     "    @runtime_validation\n",
@@ -606,7 +606,7 @@
    ],
    "source": [
     "class DP(IterDataPipe[T]):\n",
-    "    def __init__(self, ds):\n",
+    "    def __init__(self, ds) -> None:\n",
     "        self.ds = ds\n",
     "\n",
     "    def __iter__(self):\n",
@@ -621,7 +621,7 @@
    "outputs": [],
    "source": [
     "class DP(IterDataPipe[T]):\n",
-    "    def __init__(self, ds):\n",
+    "    def __init__(self, ds) -> None:\n",
     "        self.ds = ds\n",
     "\n",
     "    @runtime_validation\n",
@@ -744,7 +744,7 @@
    "outputs": [],
    "source": [
     "class DP(IterDataPipe[Union[int, str]]):\n",
-    "    def __init__(self, label):\n",
+    "    def __init__(self, label) -> None:\n",
     "        if label == 'int':\n",
     "            self.reinforce_type(int)\n",
     "        elif label == 'str':\n",

--- a/torch/utils/file_baton.py
+++ b/torch/utils/file_baton.py
@@ -7,7 +7,7 @@ import warnings
 class FileBaton:
     """A primitive, file-based synchronization utility."""
 
-    def __init__(self, lock_file_path, wait_seconds=0.1, warn_after_seconds=None):
+    def __init__(self, lock_file_path, wait_seconds=0.1, warn_after_seconds=None) -> None:
         """
         Create a new :class:`FileBaton`.
 
@@ -23,7 +23,7 @@ class FileBaton:
         self.fd = None
         self.warn_after_seconds = warn_after_seconds
 
-    def try_acquire(self):
+    def try_acquire(self) -> bool | None:
         """
         Try to atomically create a file under exclusive access.
 
@@ -37,7 +37,7 @@ class FileBaton:
         except FileExistsError:
             return False
 
-    def wait(self):
+    def wait(self) -> None:
         """
         Periodically sleeps for a certain amount until the baton is released.
 
@@ -56,7 +56,7 @@ class FileBaton:
                                   f'{self.warn_after_seconds} seconds.', stacklevel=2)
                     has_warned = True
 
-    def release(self):
+    def release(self) -> None:
         """Release the baton and removes its file."""
         if self.fd is not None:
             os.close(self.fd)

--- a/torch/utils/flop_counter.py
+++ b/torch/utils/flop_counter.py
@@ -38,7 +38,7 @@ def register_flop_formula(targets, get_raw=False) -> Callable[[Callable[_P, _T]]
         if not get_raw:
             flop_formula = shape_wrapper(flop_formula)
 
-        def register(target):
+        def register(target) -> None:
             if not isinstance(target, torch._ops.OpOverloadPacket):
                 raise ValueError(
                     f"register_flop_formula(targets): expected each target to be "
@@ -624,7 +624,7 @@ def convert_num_with_suffix(number, suffix):
     # Return the value and the suffix as a string
     return value + suffixes[index]
 
-def convert_to_percent_str(num, denom):
+def convert_to_percent_str(num, denom) -> str:
     if denom == 0:
         return "0%"
     return f"{num / denom:.2%}"
@@ -664,7 +664,7 @@ class FlopCounterMode:
             mods: Optional[Union[torch.nn.Module, list[torch.nn.Module]]] = None,
             depth: int = 2,
             display: bool = True,
-            custom_mapping: Optional[dict[Any, Any]] = None):
+            custom_mapping: Optional[dict[Any, Any]] = None) -> None:
         super().__init__()
         self.flop_counts: dict[str, dict[Any, int]] = defaultdict(lambda: defaultdict(int))
         self.depth = depth
@@ -787,7 +787,7 @@ class FlopCounterMode:
 class _FlopCounterMode(TorchDispatchMode):
     supports_higher_order_operators = True
 
-    def __init__(self, counter: FlopCounterMode):
+    def __init__(self, counter: FlopCounterMode) -> None:
         self.counter = counter
 
     def _execute_with_isolated_flop_counting(self, branch_fn, operands):

--- a/torch/utils/hipify/hipify_python.py
+++ b/torch/utils/hipify/hipify_python.py
@@ -47,12 +47,12 @@ class CurrentState(Enum):
     DONE = 2
 
 class HipifyResult:
-    def __init__(self, current_state, hipified_path):
+    def __init__(self, current_state, hipified_path) -> None:
         self.current_state = current_state
         self.hipified_path = hipified_path
         self.status = ""
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (f"HipifyResult:: current_state: {self.current_state}, hipified_path : {self.hipified_path}, status: {self.status}")
 
 HipifyFinalResult = dict[str, HipifyResult]
@@ -75,11 +75,11 @@ __all__ = ['InputError', 'openf', 'bcolors', 'GeneratedFileCleaner', 'match_exte
 class InputError(Exception):
     # Exception raised for errors in the input.
 
-    def __init__(self, message):
+    def __init__(self, message) -> None:
         super().__init__(message)
         self.message = message
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"Input error: {self.message}"
 
 
@@ -109,7 +109,7 @@ class bcolors:
 # keep them (e.g. in the CI), this can be used to remove files.
 class GeneratedFileCleaner:
     """Context Manager to clean up generated files"""
-    def __init__(self, keep_intermediates=False):
+    def __init__(self, keep_intermediates=False) -> None:
         self.keep_intermediates = keep_intermediates
         self.files_to_clean = set()
         self.dirs_to_clean = []
@@ -123,7 +123,7 @@ class GeneratedFileCleaner:
         # pyrefly: ignore [not-iterable]
         return open(fn, *args, **kwargs)
 
-    def makedirs(self, dn, exist_ok=False):
+    def makedirs(self, dn, exist_ok=False) -> None:
         parent, n = os.path.split(dn)
         if not n:
             parent, n = os.path.split(parent)
@@ -222,7 +222,7 @@ def preprocess_file_and_save_result(
     HIPIFY_FINAL_RESULT[fin_path] = result
 
 
-def compute_stats(stats):
+def compute_stats(stats) -> None:
     unsupported_calls = {cuda_call for (cuda_call, _filepath) in stats["unsupported_calls"]}
 
     # Print the number of unsupported calls
@@ -616,7 +616,7 @@ def get_hip_file_path(rel_filepath, is_pytorch_extension=False):
     return os.path.join(dirpath, root + ext)
 
 
-def is_out_of_place(rel_filepath):
+def is_out_of_place(rel_filepath) -> bool:
     if os.path.isabs(rel_filepath):
         raise AssertionError("rel_filepath must be a relative path")
     if rel_filepath.startswith("torch/"):
@@ -629,7 +629,7 @@ def is_out_of_place(rel_filepath):
 
 
 # Keep this synchronized with includes/ignores in build_amd.py
-def is_pytorch_file(rel_filepath):
+def is_pytorch_file(rel_filepath) -> bool:
     if os.path.isabs(rel_filepath):
         raise AssertionError("rel_filepath must be a relative path")
     if rel_filepath.startswith("aten/"):
@@ -653,7 +653,7 @@ def is_cusparse_file(rel_filepath):
     return False
 
 
-def is_special_file(rel_filepath):
+def is_special_file(rel_filepath) -> bool:
     if is_pytorch_file(rel_filepath):
         if "sparse" in rel_filepath.lower():
             return True
@@ -678,20 +678,20 @@ class TrieNode:
        A special char '' represents end of word
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.children = {}
 
 class Trie:
     """Creates a Trie out of a list of words. The trie can be exported to a Regex pattern.
     The corresponding Regex should match much faster than a simple Regex union."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the trie with an empty root node."""
         self.root = TrieNode()
         self._hash = hashlib.md5(usedforsecurity=False)
         self._digest = self._hash.digest()
 
-    def add(self, word):
+    def add(self, word) -> None:
         """Add a word to the Trie. """
         self._hash.update(word.encode())
         self._digest = self._hash.digest()
@@ -1011,7 +1011,7 @@ def preprocessor(
         hipify_result.current_state = CurrentState.DONE
         return hipify_result
 
-def file_specific_replacement(filepath, search_string, replace_string, strict=False):
+def file_specific_replacement(filepath, search_string, replace_string, strict=False) -> None:
     with openf(filepath, "r+") as f:
         contents = f.read()
         if strict:
@@ -1023,7 +1023,7 @@ def file_specific_replacement(filepath, search_string, replace_string, strict=Fa
         f.truncate()
 
 
-def file_add_header(filepath, header):
+def file_add_header(filepath, header) -> None:
     with openf(filepath, "r+") as f:
         contents = f.read()
         if header[0] != "<" and header[-1] != ">":
@@ -1089,7 +1089,7 @@ def extract_arguments(start, string):
     return arguments
 
 
-def str2bool(v):
+def str2bool(v) -> bool:
     """ArgumentParser doesn't support type=bool. Thus, this helper method will convert
     from possible string types to True / False."""
     if v.lower() in ('yes', 'true', 't', 'y', '1'):

--- a/torch/utils/hipify/hipify_python.py
+++ b/torch/utils/hipify/hipify_python.py
@@ -1089,7 +1089,7 @@ def extract_arguments(start, string):
     return arguments
 
 
-def str2bool(v) -> bool:
+def str2bool(v : str) -> bool:
     """ArgumentParser doesn't support type=bool. Thus, this helper method will convert
     from possible string types to True / False."""
     if v.lower() in ('yes', 'true', 't', 'y', '1'):

--- a/torch/utils/hooks.py
+++ b/torch/utils/hooks.py
@@ -80,7 +80,7 @@ def unserializable_hook(f):
     return f
 
 
-def warn_if_has_hooks(tensor):
+def warn_if_has_hooks(tensor) -> None:
     if tensor._backward_hooks:
         for k in tensor._backward_hooks:
             hook = tensor._backward_hooks[k]
@@ -101,7 +101,7 @@ class BackwardHook:
       - Calling the user hook once both output and input gradients are available
     """
 
-    def __init__(self, module, user_hooks, user_pre_hooks):
+    def __init__(self, module, user_hooks, user_pre_hooks) -> None:
         self.user_hooks = user_hooks
         self.user_pre_hooks = user_pre_hooks
         self.module = module
@@ -124,7 +124,7 @@ class BackwardHook:
 
         return tuple(res)
 
-    def _set_user_hook(self, grad_fn):
+    def _set_user_hook(self, grad_fn) -> None:
         def hook(grad_input, _):
             if self.grad_outputs is None:
                 # This happens because the gradient in your nn.Module flows to
@@ -190,7 +190,7 @@ class BackwardHook:
         return out, tensors_idx
 
     def setup_input_hook(self, args):
-        def fn(grad_fn):
+        def fn(grad_fn) -> None:
             self._set_user_hook(grad_fn)
 
         res, input_idx = self._apply_on_tensors(fn, args)
@@ -199,7 +199,7 @@ class BackwardHook:
         return res
 
     def setup_output_hook(self, args):
-        def fn(grad_fn):
+        def fn(grad_fn) -> None:
             def hook(_, grad_output):
                 self.grad_outputs = self._pack_with_none(self.output_tensors_index,
                                                          grad_output,

--- a/torch/utils/mkldnn.py
+++ b/torch/utils/mkldnn.py
@@ -3,7 +3,7 @@ import torch
 
 
 class MkldnnLinear(torch.jit.ScriptModule):
-    def __init__(self, dense_module, dtype):
+    def __init__(self, dense_module, dtype) -> None:
         super().__init__()
         self.register_buffer('weight', dense_module.weight.to_mkldnn(dtype))
         if dense_module.bias is not None:
@@ -39,7 +39,7 @@ class _MkldnnConvNd(torch.jit.ScriptModule):
 
     __constants__ = ['stride', 'padding', 'dilation', 'groups']
 
-    def __init__(self, dense_module):
+    def __init__(self, dense_module) -> None:
         super().__init__()
 
         self.stride = dense_module.stride
@@ -74,7 +74,7 @@ class _MkldnnConvNd(torch.jit.ScriptModule):
 
 
 class MkldnnConv1d(_MkldnnConvNd):
-    def __init__(self, dense_module, dtype):
+    def __init__(self, dense_module, dtype) -> None:
         super().__init__(dense_module)
 
         self.register_buffer('weight', dense_module.weight.to_mkldnn(dtype))
@@ -87,7 +87,7 @@ class MkldnnConv1d(_MkldnnConvNd):
 
 
 class MkldnnConv2d(_MkldnnConvNd):
-    def __init__(self, dense_module, dtype):
+    def __init__(self, dense_module, dtype) -> None:
         super().__init__(dense_module)
 
         self.register_buffer('weight', torch._C._nn.mkldnn_reorder_conv2d_weight(
@@ -109,7 +109,7 @@ class MkldnnConv2d(_MkldnnConvNd):
         self.training = state[2]
 
 class MkldnnConv3d(_MkldnnConvNd):
-    def __init__(self, dense_module, dtype):
+    def __init__(self, dense_module, dtype) -> None:
         super().__init__(dense_module)
 
         self.register_buffer('weight', torch._C._nn.mkldnn_reorder_conv3d_weight(
@@ -134,7 +134,7 @@ class MkldnnConv3d(_MkldnnConvNd):
 class MkldnnBatchNorm(torch.jit.ScriptModule):
     __constants__ = ['exponential_average_factor', 'eps']
 
-    def __init__(self, dense_module):
+    def __init__(self, dense_module) -> None:
         super().__init__()
 
         if dense_module.training:
@@ -186,7 +186,7 @@ class MkldnnBatchNorm(torch.jit.ScriptModule):
         )
 
 class MkldnnPrelu(torch.jit.ScriptModule):
-    def __init__(self, dense_module, dtype):
+    def __init__(self, dense_module, dtype) -> None:
         super().__init__()
         self.register_buffer('weight', dense_module.weight.to_mkldnn(dtype))
 

--- a/torch/utils/model_dump/__init__.py
+++ b/torch/utils/model_dump/__init__.py
@@ -428,7 +428,7 @@ def get_info_and_burn_skeleton(path_or_bytesio, **kwargs):
     return page
 
 
-def main(argv, *, stdout=None):
+def main(argv, *, stdout=None) -> None:
     warnings.warn("torch.utils.model_dump is deprecated and will be removed in a future PyTorch release.", stacklevel=2)
     parser = argparse.ArgumentParser()
     parser.add_argument("--style", choices=["json", "html"])

--- a/torch/utils/module_tracker.py
+++ b/torch/utils/module_tracker.py
@@ -68,12 +68,12 @@ class ModuleTracker:
         self._has_callback = False
         self._hooks: list[RemovableHandle] = []
 
-    def _maybe_set_engine_callback(self):
+    def _maybe_set_engine_callback(self) -> None:
         # This assumes no concurrent calls to backward
         if self._has_callback:
             return
 
-        def callback():
+        def callback() -> None:
             self.parents = {"Global"}
             self._has_callback = False
 
@@ -99,7 +99,7 @@ class ModuleTracker:
         return mod_name
 
     def _get_append_fn(self, name, is_bw):
-        def fn(*args):
+        def fn(*args) -> None:
             if is_bw:
                 self._maybe_set_engine_callback()
             if name in self.parents:
@@ -113,7 +113,7 @@ class ModuleTracker:
         return fn
 
     def _get_pop_fn(self, name, is_bw):
-        def fn(*args):
+        def fn(*args) -> None:
             if name in self.parents:
                 self.parents.remove(name)
             else:
@@ -125,7 +125,7 @@ class ModuleTracker:
 
         return fn
 
-    def _fw_pre_hook(self, mod, input):
+    def _fw_pre_hook(self, mod, input) -> None:
         name = self._get_mod_name(mod)
         self._get_append_fn(name, False)()
 
@@ -136,7 +136,7 @@ class ModuleTracker:
                 register_multi_grad_hook(tensors, self._get_pop_fn(name, True))
             )
 
-    def _fw_post_hook(self, mod, input, output):
+    def _fw_post_hook(self, mod, input, output) -> None:
         name = self._get_mod_name(mod)
         self._get_pop_fn(name, False)()
 

--- a/torch/utils/show_pickle.py
+++ b/torch/utils/show_pickle.py
@@ -11,14 +11,14 @@ from typing import Any, IO
 __all__ = ["FakeObject", "FakeClass", "DumpUnpickler", "main"]
 
 class FakeObject:
-    def __init__(self, module, name, args):
+    def __init__(self, module, name, args) -> None:
         self.module = module
         self.name = name
         self.args = args
         # NOTE: We don't distinguish between state never set and state set to None.
         self.state = None
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         state_str = "" if self.state is None else f"(state={self.state!r})"
         return f"{self.module}.{self.name}{self.args!r}{state_str}"
 
@@ -26,7 +26,7 @@ class FakeObject:
         self.state = state
 
     @staticmethod
-    def pp_format(printer, obj, stream, indent, allowance, context, level):
+    def pp_format(printer, obj, stream, indent, allowance, context, level) -> None:
         if not obj.args and obj.state is None:
             stream.write(repr(obj))
             return
@@ -45,12 +45,12 @@ class FakeObject:
 
 
 class FakeClass:
-    def __init__(self, module, name):
+    def __init__(self, module, name) -> None:
         self.module = module
         self.name = name
         self.__new__ = self.fake_new  # type: ignore[assignment]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.module}.{self.name}"
 
     def __call__(self, *args):
@@ -66,7 +66,7 @@ class DumpUnpickler(pickle._Unpickler):  # type: ignore[name-defined]
             file,
             *,
             catch_invalid_utf8=False,
-            **kwargs):
+            **kwargs) -> None:
         super().__init__(file, **kwargs)
         self.catch_invalid_utf8 = catch_invalid_utf8
 
@@ -82,7 +82,7 @@ class DumpUnpickler(pickle._Unpickler):  # type: ignore[name-defined]
     # from their pickle (__getstate__) functions.  Install a custom loader
     # for strings that catches the decode exception and replaces it with
     # a sentinel object.
-    def load_binunicode(self):
+    def load_binunicode(self) -> None:
         strlen, = struct.unpack("<I", self.read(4))  # type: ignore[attr-defined]
         if strlen > sys.maxsize:
             raise Exception("String too long.")  # noqa: TRY002
@@ -104,7 +104,7 @@ class DumpUnpickler(pickle._Unpickler):  # type: ignore[name-defined]
         return value
 
 
-def main(argv, output_stream=None):
+def main(argv, output_stream=None) -> int | None:
     if len(argv) != 2:
         # Don't spam stderr if not using stdout.
         if output_stream is not None:

--- a/torch/utils/tensorboard/_embedding.py
+++ b/torch/utils/tensorboard/_embedding.py
@@ -21,7 +21,7 @@ def _gfile_join(a, b):
         return fs.join(a, b)
 
 
-def make_tsv(metadata, save_path, metadata_header=None):
+def make_tsv(metadata, save_path, metadata_header=None) -> None:
     if not metadata_header:
         metadata = [str(x) for x in metadata]
     else:
@@ -37,7 +37,7 @@ def make_tsv(metadata, save_path, metadata_header=None):
 
 
 # https://github.com/tensorflow/tensorboard/issues/44 image label will be squared
-def make_sprite(label_img, save_path):
+def make_sprite(label_img, save_path) -> None:
     from PIL import Image
     from io import BytesIO
 
@@ -74,13 +74,13 @@ def get_embedding_info(metadata, label_img, subdir, global_step, tag):
     return info
 
 
-def write_pbtxt(save_path, contents):
+def write_pbtxt(save_path, contents) -> None:
     config_path = _gfile_join(save_path, "projector_config.pbtxt")
     with tf.io.gfile.GFile(config_path, "wb") as f:
         f.write(tf.compat.as_bytes(contents))
 
 
-def make_mat(matlist, save_path):
+def make_mat(matlist, save_path) -> None:
     with tf.io.gfile.GFile(_gfile_join(save_path, "tensors.tsv"), "wb") as f:
         for x in matlist:
             x = [str(i.item()) for i in x]

--- a/torch/utils/tensorboard/_pytorch_graph.py
+++ b/torch/utils/tensorboard/_pytorch_graph.py
@@ -42,7 +42,7 @@ class NodeBase:
         tensor_size=None,
         op_type="UnSpecified",
         attributes="",
-    ):
+    ) -> None:
         # TODO; Specify a __slots__ for this class or potentially
         # used namedtuple instead
         self.debugName = debugName
@@ -52,7 +52,7 @@ class NodeBase:
         self.attributes = attributes
         self.scope = scope
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         repr = []
         repr.append(str(type(self)))
         repr.extend(
@@ -64,7 +64,7 @@ class NodeBase:
 
 
 class NodePy(NodeBase):
-    def __init__(self, node_cpp, valid_methods):
+    def __init__(self, node_cpp, valid_methods) -> None:
         super().__init__(node_cpp)
         valid_methods = valid_methods[:]
         self.inputs = []
@@ -89,7 +89,7 @@ class NodePy(NodeBase):
 
 
 class NodePyIO(NodePy):
-    def __init__(self, node_cpp, input_or_output=None):
+    def __init__(self, node_cpp, input_or_output=None) -> None:
         super().__init__(node_cpp, methods_IO)
         try:
             tensor_size = node_cpp.type().sizes()
@@ -109,7 +109,7 @@ class NodePyIO(NodePy):
 
 
 class NodePyOP(NodePy):
-    def __init__(self, node_cpp):
+    def __init__(self, node_cpp) -> None:
         super().__init__(node_cpp, methods_OP)
         # Replace single quote which causes strange behavior in TensorBoard
         # TODO: See if we can remove this in the future
@@ -140,32 +140,32 @@ class GraphPy:
     and scope_name_appeared.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.nodes_op = []
         self.nodes_io = OrderedDict()
         self.unique_name_to_scoped_name = {}
         self.shallowest_scope_name = "default"
         self.scope_name_appeared = []
 
-    def append(self, x):
+    def append(self, x) -> None:
         if isinstance(x, NodePyIO):
             self.nodes_io[x.debugName] = x
         if isinstance(x, NodePyOP):
             self.nodes_op.append(x)
 
-    def printall(self):
+    def printall(self) -> None:
         print("all nodes")
         for node in self.nodes_op:
             print(node)
         for key in self.nodes_io:
             print(self.nodes_io[key])
 
-    def find_common_root(self):
+    def find_common_root(self) -> None:
         for fullscope in self.scope_name_appeared:
             if fullscope:
                 self.shallowest_scope_name = fullscope.split("/")[0]
 
-    def populate_namespace_from_OP_to_IO(self):
+    def populate_namespace_from_OP_to_IO(self) -> None:
         for node in self.nodes_op:
             for node_output, outputSize in zip(node.outputs, node.outputstensor_size, strict=True):
                 self.scope_name_appeared.append(node.scopeName)

--- a/torch/utils/tensorboard/summary.py
+++ b/torch/utils/tensorboard/summary.py
@@ -115,7 +115,7 @@ _TENSOR_TYPE_MAP = {
 }
 
 
-def _calc_scale_factor(tensor):
+def _calc_scale_factor(tensor) -> int:
     converted = tensor.numpy() if not isinstance(tensor, np.ndarray) else tensor
     return 1 if converted.dtype == np.uint8 else 255
 

--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -50,7 +50,7 @@ class FileWriter:
     training.
     """
 
-    def __init__(self, log_dir, max_queue=10, flush_secs=120, filename_suffix=""):
+    def __init__(self, log_dir, max_queue=10, flush_secs=120, filename_suffix="") -> None:
         """Create a `FileWriter` and an event file.
 
         On construction the writer creates a new event file in `log_dir`.
@@ -81,7 +81,7 @@ class FileWriter:
         """Return the directory where event file will be written."""
         return self.event_writer.get_logdir()
 
-    def add_event(self, event, step=None, walltime=None):
+    def add_event(self, event, step=None, walltime=None) -> None:
         """Add an event to the event file.
 
         Args:
@@ -98,7 +98,7 @@ class FileWriter:
             event.step = int(step)
         self.event_writer.add_event(event)
 
-    def add_summary(self, summary, global_step=None, walltime=None):
+    def add_summary(self, summary, global_step=None, walltime=None) -> None:
         """Add a `Summary` protocol buffer to the event file.
 
         This method wraps the provided summary in an `Event` protocol buffer
@@ -114,7 +114,7 @@ class FileWriter:
         event = event_pb2.Event(summary=summary)
         self.add_event(event, global_step, walltime)
 
-    def add_graph(self, graph_profile, walltime=None):
+    def add_graph(self, graph_profile, walltime=None) -> None:
         """Add a `Graph` and step stats protocol buffer to the event file.
 
         Args:
@@ -133,7 +133,7 @@ class FileWriter:
         event = event_pb2.Event(tagged_run_metadata=trm)
         self.add_event(event, None, walltime)
 
-    def add_onnx_graph(self, graph, walltime=None):
+    def add_onnx_graph(self, graph, walltime=None) -> None:
         """Add a `Graph` protocol buffer to the event file.
 
         Args:
@@ -144,7 +144,7 @@ class FileWriter:
         event = event_pb2.Event(graph_def=graph.SerializeToString())
         self.add_event(event, None, walltime)
 
-    def flush(self):
+    def flush(self) -> None:
         """Flushes the event file to disk.
 
         Call this method to make sure that all pending events have been written to
@@ -152,14 +152,14 @@ class FileWriter:
         """
         self.event_writer.flush()
 
-    def close(self):
+    def close(self) -> None:
         """Flushes the event file to disk and close the file.
 
         Call this method when you do not need the summary writer anymore.
         """
         self.event_writer.close()
 
-    def reopen(self):
+    def reopen(self) -> None:
         """Reopens the EventFileWriter.
 
         Can be called after `close()` to add more events in the same directory.
@@ -188,7 +188,7 @@ class SummaryWriter:
         max_queue=10,
         flush_secs=120,
         filename_suffix="",
-    ):
+    ) -> None:
         """Create a `SummaryWriter` that will write out events and summaries to the event file.
 
         Args:
@@ -299,7 +299,7 @@ class SummaryWriter:
         hparam_domain_discrete=None,
         run_name=None,
         global_step=None,
-    ):
+    ) -> None:
         """Add a set of hyperparameters to be compared in TensorBoard.
 
         Args:
@@ -355,7 +355,7 @@ class SummaryWriter:
         walltime=None,
         new_style=False,
         double_precision=False,
-    ):
+    ) -> None:
         """Add scalar data to summary.
 
         Args:
@@ -388,7 +388,7 @@ class SummaryWriter:
         )
         self._get_file_writer().add_summary(summary, global_step, walltime)
 
-    def add_scalars(self, main_tag, tag_scalar_dict, global_step=None, walltime=None):
+    def add_scalars(self, main_tag, tag_scalar_dict, global_step=None, walltime=None) -> None:
         """Add many scalar data to summary.
 
         Args:
@@ -439,7 +439,7 @@ class SummaryWriter:
         tensor,
         global_step=None,
         walltime=None,
-    ):
+    ) -> None:
         """Add tensor data to summary.
 
         Args:
@@ -473,7 +473,7 @@ class SummaryWriter:
         bins="tensorflow",
         walltime=None,
         max_bins=None,
-    ):
+    ) -> None:
         """Add histogram to summary.
 
         Args:
@@ -520,7 +520,7 @@ class SummaryWriter:
         bucket_counts,
         global_step=None,
         walltime=None,
-    ):
+    ) -> None:
         """Add histogram with raw data.
 
         Args:
@@ -585,7 +585,7 @@ class SummaryWriter:
 
     def add_image(
         self, tag, img_tensor, global_step=None, walltime=None, dataformats="CHW"
-    ):
+    ) -> None:
         """Add image data to summary.
 
         Note that this requires the ``pillow`` package.
@@ -636,7 +636,7 @@ class SummaryWriter:
 
     def add_images(
         self, tag, img_tensor, global_step=None, walltime=None, dataformats="NCHW"
-    ):
+    ) -> None:
         """Add batched image data to summary.
 
         Note that this requires the ``pillow`` package.
@@ -688,7 +688,7 @@ class SummaryWriter:
         rescale=1,
         dataformats="CHW",
         labels=None,
-    ):
+    ) -> None:
         """Add image and draw bounding boxes on the image.
 
         Args:
@@ -767,7 +767,7 @@ class SummaryWriter:
                 dataformats="CHW",
             )
 
-    def add_video(self, tag, vid_tensor, global_step=None, fps=4, walltime=None):
+    def add_video(self, tag, vid_tensor, global_step=None, fps=4, walltime=None) -> None:
         """Add video data to summary.
 
         Note that this requires the ``moviepy`` package.
@@ -789,7 +789,7 @@ class SummaryWriter:
 
     def add_audio(
         self, tag, snd_tensor, global_step=None, sample_rate=44100, walltime=None
-    ):
+    ) -> None:
         """Add audio data to summary.
 
         Args:
@@ -807,7 +807,7 @@ class SummaryWriter:
             audio(tag, snd_tensor, sample_rate=sample_rate), global_step, walltime
         )
 
-    def add_text(self, tag, text_string, global_step=None, walltime=None):
+    def add_text(self, tag, text_string, global_step=None, walltime=None) -> None:
         """Add text data to summary.
 
         Args:
@@ -826,13 +826,13 @@ class SummaryWriter:
             text(tag, text_string), global_step, walltime
         )
 
-    def add_onnx_graph(self, prototxt):
+    def add_onnx_graph(self, prototxt) -> None:
         torch._C._log_api_usage_once("tensorboard.logging.add_onnx_graph")
         self._get_file_writer().add_onnx_graph(load_onnx_graph(prototxt))
 
     def add_graph(
         self, model, input_to_model=None, verbose=False, use_strict_trace=True
-    ):
+    ) -> None:
         """Add graph data to summary.
 
         Args:
@@ -867,7 +867,7 @@ class SummaryWriter:
         global_step=None,
         tag="default",
         metadata_header=None,
-    ):
+    ) -> None:
         """Add embedding projector data to summary.
 
         Args:
@@ -973,7 +973,7 @@ class SummaryWriter:
         num_thresholds=127,
         weights=None,
         walltime=None,
-    ):
+    ) -> None:
         """Add precision recall curve.
 
         Plotting a precision-recall curve lets you understand your model's
@@ -1026,7 +1026,7 @@ class SummaryWriter:
         num_thresholds=127,
         weights=None,
         walltime=None,
-    ):
+    ) -> None:
         """Add precision recall curve with raw data.
 
         Args:
@@ -1062,7 +1062,7 @@ class SummaryWriter:
 
     def add_custom_scalars_multilinechart(
         self, tags, category="default", title="untitled"
-    ):
+    ) -> None:
         """Shorthand for creating multilinechart. Similar to ``add_custom_scalars()``, but the only necessary argument is *tags*.
 
         Args:
@@ -1080,7 +1080,7 @@ class SummaryWriter:
 
     def add_custom_scalars_marginchart(
         self, tags, category="default", title="untitled"
-    ):
+    ) -> None:
         """Shorthand for creating marginchart.
 
         Similar to ``add_custom_scalars()``, but the only necessary argument is *tags*,
@@ -1101,7 +1101,7 @@ class SummaryWriter:
         layout = {category: {title: ["Margin", tags]}}
         self._get_file_writer().add_summary(custom_scalars(layout))
 
-    def add_custom_scalars(self, layout):
+    def add_custom_scalars(self, layout) -> None:
         """Create special chart by collecting charts tags in 'scalars'.
 
         NOTE: This function can only be called once for each SummaryWriter() object.
@@ -1134,7 +1134,7 @@ class SummaryWriter:
         config_dict=None,
         global_step=None,
         walltime=None,
-    ):
+    ) -> None:
         """Add meshes or 3D point clouds to TensorBoard.
 
         The visualization is based on Three.js,
@@ -1192,7 +1192,7 @@ class SummaryWriter:
             mesh(tag, vertices, colors, faces, config_dict), global_step, walltime
         )
 
-    def flush(self):
+    def flush(self) -> None:
         """Flushes the event file to disk.
 
         Call this method to make sure that all pending events have been written to
@@ -1203,7 +1203,7 @@ class SummaryWriter:
         for writer in self.all_writers.values():
             writer.flush()
 
-    def close(self):
+    def close(self) -> None:
         if self.all_writers is None:
             return  # ignore double close
         for writer in self.all_writers.values():

--- a/torch/utils/throughput_benchmark.py
+++ b/torch/utils/throughput_benchmark.py
@@ -3,7 +3,7 @@
 import torch._C
 
 
-def format_time(time_us=None, time_ms=None, time_s=None):
+def format_time(time_us=None, time_ms=None, time_s=None) -> str:
     """Define time formatting."""
     if sum([time_us is not None, time_ms is not None, time_s is not None]) != 1:
         raise AssertionError("Expected only one of time_us, time_ms, time_s is given.")
@@ -27,7 +27,7 @@ def format_time(time_us=None, time_ms=None, time_s=None):
 
 
 class ExecutionStats:
-    def __init__(self, c_stats, benchmark_config):
+    def __init__(self, c_stats, benchmark_config) -> None:
         self._c_stats = c_stats
         self.benchmark_config = benchmark_config
 
@@ -49,7 +49,7 @@ class ExecutionStats:
         return self.num_iters * (
             self.latency_avg_ms / 1000.0) / self.benchmark_config.num_calling_threads
 
-    def __str__(self):
+    def __str__(self) -> str:
         return '\n'.join([
             "Average latency per example: " + format_time(time_ms=self.latency_avg_ms),
             f"Total number of iterations: {self.num_iters}",
@@ -93,7 +93,7 @@ class ThroughputBenchmark:
         >>> print("Number of iterations: {}".format(stats.num_iters))
     """
 
-    def __init__(self, module):
+    def __init__(self, module) -> None:
         if isinstance(module, torch.jit.ScriptModule):
             self._benchmark = torch._C.ThroughputBenchmark(module._c)
         else:
@@ -109,7 +109,7 @@ class ThroughputBenchmark:
         """
         return self._benchmark.run_once(*args, **kwargs)
 
-    def add_input(self, *args, **kwargs):
+    def add_input(self, *args, **kwargs) -> None:
         """
         Store a single input to a module into the benchmark memory and keep it there.
 

--- a/torch/utils/viz/_cycles.py
+++ b/torch/utils/viz/_cycles.py
@@ -15,14 +15,14 @@ logger = logging.getLogger(__name__)
 def observe_garbage(observer):
     enabled = True
 
-    def disable():
+    def disable() -> None:
         # when GC runs during exit, things like `sys` will already be unloaded
         # so we have to disable the callback to avoid hitting errors.
         nonlocal enabled
         enabled = False
     atexit.register(disable)
 
-    def gc_callback(phase, info):
+    def gc_callback(phase, info) -> None:
         nonlocal enabled
         if not enabled:
             return
@@ -66,7 +66,7 @@ def observe_garbage(observer):
     gc.callbacks.append(gc_callback)
 
     # provide a way to disarm the callback
-    def remove():
+    def remove() -> None:
         gc.callbacks.remove(gc_callback)
     return remove
 
@@ -103,15 +103,15 @@ def annotated_references(obj):
     """
     references: dict[int, list[str]] = {}
 
-    def add_reference(name, obj):
+    def add_reference(name, obj) -> None:
         references.setdefault(id(obj), []).append(name)
 
-    def add_attrs(*attrs):
+    def add_attrs(*attrs) -> None:
         for attr in attrs:
             if hasattr(obj, attr):
                 add_reference(attr, getattr(obj, attr))
 
-    def add_cell_references():
+    def add_cell_references() -> None:
         try:
             add_attrs("cell_contents")
         except ValueError:
@@ -121,7 +121,7 @@ def annotated_references(obj):
             # annotate
             pass
 
-    def add_function_references():
+    def add_function_references() -> None:
         add_attrs("__defaults__",
                   "__closure__",
                   "__globals__",
@@ -134,23 +134,23 @@ def annotated_references(obj):
                   "__kwdefaults__")
 
 
-    def add_sequence_references():
+    def add_sequence_references() -> None:
         for position, item in enumerate(obj):
             add_reference(f"[{position}]", item)
 
-    def add_dict_references():
+    def add_dict_references() -> None:
         for key, value in obj.items():
             add_reference("key", key)
             add_reference(f"[{repr(key)}]", value)
 
-    def add_set_references():
+    def add_set_references() -> None:
         for elt in obj:
             add_reference("element", elt)
 
-    def add_bound_method_references():
+    def add_bound_method_references() -> None:
         add_attrs("__self__", "__func__", "im_class")
 
-    def add_weakref_references():
+    def add_weakref_references() -> None:
         # For subclasses of weakref, we can't reliably distinguish the
         # callback (if any) from other attributes.
         if type(obj) is weakref.ref:
@@ -160,7 +160,7 @@ def annotated_references(obj):
                 add_reference("__callback__", target)
 
 
-    def add_frame_references():
+    def add_frame_references() -> None:
         f_locals = obj.f_locals
         add_attrs("f_back", "f_code", "f_builtins", "f_globals", "f_trace", "f_locals")
         # Some badly-behaved code replaces the f_locals dict with
@@ -170,7 +170,7 @@ def annotated_references(obj):
             for name, local in obj.f_locals.items():
                 add_reference(f"local {name}", local)
 
-    def add_getset_descriptor_references():
+    def add_getset_descriptor_references() -> None:
         add_attrs("__objclass__", "__name__", "__doc__")
 
     type_based_references = {
@@ -473,7 +473,7 @@ def to_html(nodes):
 def observe_tensor_cycles(callback):
     torch.cuda.memory._record_memory_history(max_entries=100000)
 
-    def observer(garbage):
+    def observer(garbage) -> None:
         if garbage:
             if not any(is_cuda_tensor(obj) for obj in garbage):
                 logger.info("No CUDA Tensors found in garbage")
@@ -497,7 +497,7 @@ def warn_tensor_cycles():
     """
     logger.info("Watching Python reference cycles for CUDA Tensors.")
 
-    def write_and_log(html):
+    def write_and_log(html) -> None:
         with NamedTemporaryFile('w', suffix='.html', delete=False) as f:
             f.write(html)
             logger.warning('Reference cycle includes a CUDA Tensor see visualization of cycle %s', f.name)

--- a/torch/utils/weak.py
+++ b/torch/utils/weak.py
@@ -28,7 +28,7 @@ class _IterationGuard:
     # exits.
     # This technique should be relatively thread-safe (since sets are).
 
-    def __init__(self, weakcontainer):
+    def __init__(self, weakcontainer) -> None:
         # Don't create cycles
         self.weakcontainer = ref(weakcontainer)
 
@@ -75,7 +75,7 @@ class _IterationGuard:
 class WeakIdRef(weakref.ref):
     __slots__ = ["_id"]
 
-    def __init__(self, key, callback=None):
+    def __init__(self, key, callback=None) -> None:
         # Unlike stock weakref, which preserves hash semantics of the
         # original object but lazily defers hash calls until the first
         # time the user attempts to hash the weakref, we can eagerly
@@ -119,7 +119,7 @@ class WeakIdRef(weakref.ref):
 class _WeakHashRef(weakref.ref):
     __slots__ = ["_id"]
 
-    def __init__(self, key, callback=None):
+    def __init__(self, key, callback=None) -> None:
         # Unlike stock weakref, which preserves hash semantics of the
         # original object but lazily defers hash calls until the first
         # time the user attempts to hash the weakref, we can eagerly
@@ -151,12 +151,12 @@ class _WeakHashRef(weakref.ref):
 
 # This is directly adapted from cpython/Lib/weakref.py
 class WeakIdKeyDictionary(MutableMapping):
-    def __init__(self, dict=None, ref_type=WeakIdRef):  # CHANGED
+    def __init__(self, dict=None, ref_type=WeakIdRef) -> None:  # CHANGED
         self.data = {}
 
         self.ref_type = ref_type  # CHANGED
 
-        def remove(k, selfref=ref(self)):
+        def remove(k, selfref=ref(self)) -> None:
             self = selfref()
             if self is not None:
                 if self._iterating:
@@ -175,7 +175,7 @@ class WeakIdKeyDictionary(MutableMapping):
         if dict is not None:
             self.update(dict)
 
-    def _commit_removals(self):
+    def _commit_removals(self) -> None:
         # NOTE: We don't need to call this method before mutating the dict,
         # because a dead weakref never compares equal to a live weakref,
         # even if they happened to refer to equal objects.
@@ -193,29 +193,29 @@ class WeakIdKeyDictionary(MutableMapping):
             except KeyError:
                 pass
 
-    def _scrub_removals(self):
+    def _scrub_removals(self) -> None:
         d = self.data
         self._pending_removals = [k for k in self._pending_removals if k in d]
         self._dirty_len = False
 
-    def __delitem__(self, key):
+    def __delitem__(self, key) -> None:
         self._dirty_len = True
         del self.data[self.ref_type(key)]  # CHANGED
 
     def __getitem__(self, key):
         return self.data[self.ref_type(key)]  # CHANGED
 
-    def __len__(self):
+    def __len__(self) -> int:
         if self._dirty_len and self._pending_removals:
             # self._pending_removals may still contain keys which were
             # explicitly removed, we have to scrub them (see issue #21173).
             self._scrub_removals()
         return len(self.data) - len(self._pending_removals)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<{self.__class__.__name__} at {id(self):#x}>"
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key, value) -> None:
         self.data[self.ref_type(key, self._remove)] = value  # CHANGED
 
     def copy(self):
@@ -243,7 +243,7 @@ class WeakIdKeyDictionary(MutableMapping):
     def get(self, key, default=None):
         return self.data.get(self.ref_type(key), default)  # CHANGED
 
-    def __contains__(self, key):
+    def __contains__(self, key) -> bool:
         try:
             wr = self.ref_type(key)  # CHANGED
         except TypeError:
@@ -303,7 +303,7 @@ class WeakIdKeyDictionary(MutableMapping):
             self.ref_type(key, self._remove), default
         )  # CHANGED
 
-    def update(self, dict=None, **kwargs):  # type: ignore[override]
+    def update(self, dict=None, **kwargs) -> None:  # type: ignore[override]
         d = self.data
         if dict is not None:
             if not hasattr(dict, "items"):
@@ -351,7 +351,7 @@ class TensorWeakRef:
 
     ref: WeakRef[Tensor]
 
-    def __init__(self, tensor: Tensor):
+    def __init__(self, tensor: Tensor) -> None:
         if not isinstance(tensor, Tensor):
             raise AssertionError(f"expected torch.Tensor, got {type(tensor)}.")
         self.ref = weakref.ref(tensor)

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -94,7 +94,7 @@ def is_initialized():
     return _initialized and not _is_in_bad_fork()
 
 
-def _lazy_call(callable, **kwargs):
+def _lazy_call(callable, **kwargs) -> None:
     if is_initialized():
         callable()
     else:
@@ -108,7 +108,7 @@ def _lazy_call(callable, **kwargs):
             _queued_calls.append((callable, traceback.format_stack()))
 
 
-def init():
+def init() -> None:
     r"""Initialize PyTorch's XPU state.
     This is a Python API about lazy initialization that avoids initializing
     XPU until the first time it is accessed. Does nothing if the XPU state is
@@ -117,7 +117,7 @@ def init():
     _lazy_init()
 
 
-def _lazy_init():
+def _lazy_init() -> None:
     global _initialized, _queued_calls
     if is_initialized() or hasattr(_tls, "is_initializing"):
         return
@@ -158,7 +158,7 @@ def _lazy_init():
 
 
 class _DeviceGuard:
-    def __init__(self, index: int):
+    def __init__(self, index: int) -> None:
         self.idx = index
         self.prev_idx = -1
 
@@ -178,7 +178,7 @@ class device:
             this argument is a negative integer or ``None``.
     """
 
-    def __init__(self, device: Any):
+    def __init__(self, device: Any) -> None:
         self.idx = _get_device_index(device, optional=True)
         self.prev_idx = -1
 
@@ -200,7 +200,7 @@ class device_of(device):
         obj (Tensor or Storage): object allocated on the selected device.
     """
 
-    def __init__(self, obj):
+    def __init__(self, obj) -> None:
         idx = obj.get_device() if obj.is_xpu else -1
         super().__init__(idx)
 
@@ -324,7 +324,7 @@ class StreamContext:
 
     cur_stream: Optional["torch.xpu.Stream"]
 
-    def __init__(self, stream: Optional["torch.xpu.Stream"]):
+    def __init__(self, stream: Optional["torch.xpu.Stream"]) -> None:
         self.stream = stream
         self.idx = _get_device_index(None, True)
         if self.idx is None:
@@ -362,7 +362,7 @@ def stream(stream: Optional["torch.xpu.Stream"]) -> StreamContext:
     return StreamContext(stream)
 
 
-def _set_stream_by_id(stream_id, device_index, device_type):
+def _set_stream_by_id(stream_id, device_index, device_type) -> None:
     r"""set stream specified by the stream id, device index and device type
 
     Args: stream_id (int): not visible to the user, used to assigned to the specific stream.
@@ -376,7 +376,7 @@ def _set_stream_by_id(stream_id, device_index, device_type):
     )
 
 
-def set_stream(stream: Stream):
+def set_stream(stream: Stream) -> None:
     r"""Set the current stream.This is a wrapper API to set the stream.
         Usage of this function is discouraged in favor of the ``stream``
         context manager.
@@ -495,7 +495,7 @@ def _set_rng_state_offset(
     """
     final_device = _get_device(device)
 
-    def cb():
+    def cb() -> None:
         default_generator = _get_generator(final_device)
         default_generator.set_offset(offset)
 

--- a/torch/xpu/random.py
+++ b/torch/xpu/random.py
@@ -53,7 +53,7 @@ def set_rng_state(
     elif isinstance(device, int):
         device = torch.device("xpu", device)
 
-    def cb():
+    def cb() -> None:
         idx = device.index
         if idx is None:
             idx = current_device()
@@ -87,7 +87,7 @@ def manual_seed(seed: int) -> None:
     """
     seed = int(seed)
 
-    def cb():
+    def cb() -> None:
         idx = current_device()
         default_generator = torch.xpu.default_generators[idx]
         default_generator.manual_seed(seed)
@@ -105,7 +105,7 @@ def manual_seed_all(seed: int) -> None:
     """
     seed = int(seed)
 
-    def cb():
+    def cb() -> None:
         for i in range(device_count()):
             default_generator = torch.xpu.default_generators[i]
             default_generator.manual_seed(seed)
@@ -123,7 +123,7 @@ def seed() -> None:
         the seed on one GPU.  To initialize all GPUs, use :func:`seed_all`.
     """
 
-    def cb():
+    def cb() -> None:
         idx = current_device()
         default_generator = torch.xpu.default_generators[idx]
         default_generator.seed()
@@ -137,7 +137,7 @@ def seed_all() -> None:
     It's safe to call this function if XPU is not available; in that case, it is silently ignored.
     """
 
-    def cb():
+    def cb() -> None:
         random_seed = 0
         seeded = False
         for i in range(device_count()):

--- a/torch/xpu/streams.py
+++ b/torch/xpu/streams.py
@@ -96,7 +96,7 @@ class Stream(torch._C._XpuStreamBase):
     def __hash__(self):
         return hash((self.sycl_queue, self.device))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"torch.xpu.Stream(device={self.device} sycl_queue={self.sycl_queue:#x})"
 
 
@@ -166,7 +166,7 @@ class Event(torch._C._XpuEventBase):
     def _as_parameter_(self):
         return ctypes.c_void_p(self.sycl_event)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self.sycl_event:
             return f"torch.xpu.Event(sycl_event={self.sycl_event:#x})"
         else:


### PR DESCRIPTION
This PR adds return types of some Python functions. Most of them return `None`. The types were added automatically by ruff ANN rules.



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @ezyang @EikanWang @wenzhe-nrv