### PR TITLE
[FlopCounter] Add skip_unsupported parameter for graceful handling of unsupported HOPs

### DIFF
--- a/test/test_flop_counter.py
+++ b/test/test_flop_counter.py
@@ -1653,14 +1653,17 @@ class TestSkipUnsupported(TestCase):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             with FlopCounterMode(skip_unsupported=True) as mode:
-                torch.mm(x, y)        # external: 4 * 6 * 2 * 5 = 240 FLOPs
-                _inner_mm_hop(z)      # skipped HOP with inner mm (5 * 5 * 2 * 5 = 250)
+                torch.mm(x, y)  # external: 4 * 6 * 2 * 5 = 240 FLOPs
+                _inner_mm_hop(z)  # skipped HOP with inner mm (5 * 5 * 2 * 5 = 250)
 
         # Only external mm counted; inner mm inside skipped HOP excluded
         self.assertEqual(mode.get_total_flops(), 240)
         self.assertEqual(mode.get_unsupported_ops()["mock_inner_mm_hop"], 1)
 
-    @unittest.skipIf(TEST_WITH_CROSSREF, "NotImplemented return raises under active TorchFunctionMode")
+    @unittest.skipIf(
+        TEST_WITH_CROSSREF,
+        "NotImplemented return raises under active TorchFunctionMode",
+    )
     def test_unknown_hop_without_skip_returns_not_implemented(self):
         """With skip_unsupported=False (default), the mode returns NotImplemented
         for unknown HOPs (pre-existing dispatch behavior). This is the failure

--- a/test/test_flop_counter.py
+++ b/test/test_flop_counter.py
@@ -1699,25 +1699,21 @@ class TestSkipUnsupported(TestCase):
         self.assertGreater(flops, 0)
 
     def test_flex_attention_hop_end_to_end(self):
-        """The flex_attention HOP executes under FlopCounterMode and its FLOPs
-        are counted via the registered formula (registered-HOP dispatch path)."""
-        from torch.nn.attention.flex_attention import (
-            _create_empty_block_mask,
-            _identity,
-        )
+        """The public flex_attention API executes under FlopCounterMode and its
+        FLOPs are counted via the registered formula. This is the exact call from
+        issue #134385."""
+        from torch.nn.attention.flex_attention import flex_attention
 
         q = torch.randn(2, 4, 128, 64)
         k = torch.randn(2, 4, 128, 64)
         v = torch.randn(2, 4, 128, 64)
-        block_mask = _create_empty_block_mask(q, k)
 
-        with FlopCounterMode() as mode:
-            out = torch.ops.higher_order.flex_attention(
-                q, k, v, _identity, block_mask.as_tuple(), 0.125, {}
-            )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with FlopCounterMode() as mode:
+                out = flex_attention(q, k, v)
 
-        self.assertIsInstance(out, tuple)
-        self.assertEqual(out[0].shape, q.shape)
+        self.assertEqual(out.shape, q.shape)
         self.assertEqual(
             mode.get_total_flops(), sdpa_flop_count(q.shape, k.shape, v.shape)
         )

--- a/test/test_flop_counter.py
+++ b/test/test_flop_counter.py
@@ -1676,28 +1676,6 @@ class TestSkipUnsupported(TestCase):
         self.assertIs(result, NotImplemented)
         self.assertEqual(len(mode.get_unsupported_ops()), 0)
 
-    def test_registered_hop_counts_flops(self):
-        """flex_attention is registered and its formula matches sdpa_flop_count."""
-        from torch.utils.flop_counter import flop_registry
-
-        self.assertIn(torch.ops.higher_order.flex_attention, flop_registry)
-
-        q_shape = (2, 8, 128, 64)
-        k_shape = (2, 8, 128, 64)
-        v_shape = (2, 8, 128, 64)
-
-        q = torch.randn(*q_shape, device="meta", dtype=torch.float16)
-        k = torch.randn(*k_shape, device="meta", dtype=torch.float16)
-        v = torch.randn(*v_shape, device="meta", dtype=torch.float16)
-        out = torch.randn(*q_shape, device="meta", dtype=torch.float16)
-
-        flex_attn_flop_fn = flop_registry[torch.ops.higher_order.flex_attention]
-        flops = flex_attn_flop_fn(q, k, v, out_val=(out, None, None))
-
-        expected_flops = sdpa_flop_count(q_shape, k_shape, v_shape)
-        self.assertEqual(flops, expected_flops)
-        self.assertGreater(flops, 0)
-
     def test_flex_attention_hop_end_to_end(self):
         """The public flex_attention API executes under FlopCounterMode and its
         FLOPs are counted via the registered formula. This is the exact call from
@@ -1718,6 +1696,27 @@ class TestSkipUnsupported(TestCase):
             mode.get_total_flops(), sdpa_flop_count(q.shape, k.shape, v.shape)
         )
         self.assertEqual(len(mode.get_unsupported_ops()), 0)
+
+    def test_flex_attention_broadcast_kv_batch(self):
+        """Bkv=1 broadcast against Bq counts as if KV were expanded."""
+        from torch.nn.attention.flex_attention import create_block_mask, flex_attention
+
+        q = torch.randn(4, 8, 128, 64)
+        k = torch.randn(1, 8, 128, 64)
+        v = torch.randn(1, 8, 128, 64)
+        block_mask = create_block_mask(
+            lambda b, h, qi, ki: qi >= ki, 4, 8, 128, 128, device="cpu"
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with FlopCounterMode() as mode:
+                flex_attention(q, k, v, block_mask=block_mask)
+
+        expanded_kv = (4, *k.shape[1:])
+        self.assertEqual(
+            mode.get_total_flops(), sdpa_flop_count(q.shape, expanded_kv, expanded_kv)
+        )
 
     def test_registered_hop_returns_output_not_none(self):
         """Registered HOPs return their actual output. Guards against the bug
@@ -1743,6 +1742,122 @@ class TestSkipUnsupported(TestCase):
         out, _, _ = result
         self.assertEqual(out, x * 2)
         self.assertEqual(mode.get_total_flops(), 100)
+
+    @requires_cuda_and_triton
+    def test_triton_skip_unsupported(self):
+        """Unregistered Triton kernels execute and are tracked with skip_unsupported=True."""
+        import triton
+        import triton.language as tl
+
+        @triton.jit
+        def cos_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+            pid = tl.program_id(axis=0)
+            block_start = pid * BLOCK_SIZE
+            offsets = block_start + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_elements
+            x = tl.load(x_ptr + offsets, mask=mask)
+            out = tl.cos(x)
+            tl.store(out_ptr + offsets, out, mask=mask)
+
+        x = torch.randn(3, device="cuda")
+        out = torch.full((3,), float("nan"), device="cuda")
+        expected = torch.cos(x)
+
+        def cos_grid(meta):
+            return (triton.cdiv(3, meta["BLOCK_SIZE"]),)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            with FlopCounterMode(skip_unsupported=True) as mode:
+                torch.library.wrap_triton(cos_kernel)[cos_grid](x, out, 3, 256)
+
+        self.assertEqual(out, expected)
+        self.assertEqual(mode.get_total_flops(), 0)
+        self.assertEqual(mode.get_unsupported_ops()["cos_kernel"], 1)
+        self.assertTrue(any("cos_kernel" in str(warning.message) for warning in w))
+
+    @requires_cuda_and_triton
+    def test_triton_registered_kernel_executes_with_skip_unsupported(self):
+        """Registered Triton kernels execute (not just count) with skip_unsupported=True."""
+        import triton
+        import triton.language as tl
+
+        from torch.utils.flop_counter import flop_registry, register_flop_formula
+
+        @triton.jit
+        def sin_kernel_skip(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+            pid = tl.program_id(axis=0)
+            block_start = pid * BLOCK_SIZE
+            offsets = block_start + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_elements
+            x = tl.load(x_ptr + offsets, mask=mask)
+            out = tl.sin(x)
+            tl.store(out_ptr + offsets, out, mask=mask)
+
+        @register_flop_formula(sin_kernel_skip)
+        def sin_kernel_skip_flops(*args, **kwargs) -> int:
+            return 2
+
+        self.addCleanup(lambda: flop_registry.pop(sin_kernel_skip, None))
+
+        x = torch.randn(3, device="cuda")
+        out = torch.full((3,), float("nan"), device="cuda")
+
+        def grid(meta):
+            return (triton.cdiv(3, meta["BLOCK_SIZE"]),)
+
+        with FlopCounterMode(skip_unsupported=True) as mode:
+            torch.library.wrap_triton(sin_kernel_skip)[grid](x, out, 3, 256)
+
+        self.assertEqual(out, torch.sin(x))
+        self.assertEqual(mode.get_total_flops(), 2)
+        self.assertEqual(len(mode.get_unsupported_ops()), 0)
+
+    @unittest.skipIf(not HAS_CUDA, "CUDA not available")
+    def test_flex_attention_score_mod_grad_under_debug_mode(self):
+        """DebugMode is compilable by dynamo, so flex_attention must not skip its
+        internal torch.compile under it; skipping drops grads for tensors closed
+        over by score_mod."""
+        from torch.nn.attention.flex_attention import flex_attention
+        from torch.utils._debug_mode import DebugMode
+
+        q = torch.randn(2, 2, 128, 16, device="cuda", requires_grad=True)
+        k = torch.randn(2, 2, 128, 16, device="cuda")
+        v = torch.randn(2, 2, 128, 16, device="cuda")
+        bias = torch.randn(128, device="cuda", requires_grad=True)
+
+        def score_mod(score, b, h, q_idx, kv_idx):
+            return score + bias[kv_idx]
+
+        with DebugMode():
+            out = flex_attention(q, k, v, score_mod=score_mod)
+        out.sum().backward()
+
+        self.assertIsNotNone(bias.grad)
+        self.assertIsNotNone(q.grad)
+
+    def test_registered_formula_wins_over_decompose(self):
+        """A CompositeImplicitAutograd op reached below autograd (inference_mode)
+        uses its registered formula instead of decomposing."""
+        from torch.utils.flop_counter import flop_registry, register_flop_formula
+
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            lib.define("double_mm(Tensor x) -> Tensor")
+            lib.impl("double_mm", lambda x: torch.mm(x, x), "CompositeImplicitAutograd")
+
+            op = torch.ops.mylib.double_mm
+
+            @register_flop_formula(op)
+            def double_mm_flops(x_shape, out_shape=None, **kwargs):
+                return 999
+
+            self.addCleanup(lambda: flop_registry.pop(op, None))
+
+            x = torch.randn(5, 5)
+            with torch.inference_mode(), FlopCounterMode() as mode:
+                op(x)
+
+        self.assertEqual(mode.get_total_flops(), 999)
 
 
 if __name__ == "__main__":

--- a/test/test_flop_counter.py
+++ b/test/test_flop_counter.py
@@ -2,10 +2,13 @@
 # ruff: noqa: F841
 import functools
 import unittest
+import warnings
 
 import torch
 import torch.nn.functional as F
 import torch.utils.flop_counter
+from torch._higher_order_ops.utils import autograd_not_implemented
+from torch._ops import HigherOrderOperator
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_CUDNN_ATTENTION,
@@ -16,6 +19,7 @@ from torch.testing._internal.common_cuda import (
 from torch.testing._internal.common_device_type import e4m3_type
 from torch.testing._internal.common_utils import (
     run_tests,
+    TEST_WITH_CROSSREF,
     TEST_WITH_TORCHDYNAMO,
     TestCase,
     xfailIfNoAcceleratorTriton,
@@ -1519,6 +1523,227 @@ class TestFlexAttentionEstimation(TestCase):
         sparse_flops = get_flops(sparse_node)
         self.assertGreater(dense_flops, 0)
         self.assertEqual(sparse_flops, dense_flops // 2)
+
+
+class _MockHOP(HigherOrderOperator):
+    """Minimal HOP that dispatches through super().__call__() like real HOPs."""
+
+    def __init__(self, name, impl):
+        super().__init__(name)
+        self.py_impl(torch._C.DispatchKey.CPU)(impl)
+        self.py_autograd_impl(autograd_not_implemented(self, deferred_error=True))
+
+    def __call__(self, x):
+        return super().__call__(x)
+
+
+# HOPs register into a process-global registry and cannot be unregistered, so
+# they are created once at module scope to keep in-process re-runs working.
+_unregistered_hop = _MockHOP("mock_unregistered_hop_for_flop_test", lambda x: x * 2)
+_tuple_hop = _MockHOP("mock_tuple_hop_registered", lambda x: (x * 2, x.sum(), x.max()))
+_inner_mm_hop = _MockHOP("mock_inner_mm_hop", lambda x: torch.mm(x, x))
+
+
+@unittest.skipIf(
+    TEST_WITH_TORCHDYNAMO, "torchdynamo doesn't work with __torch_dispatch__ right now"
+)
+class TestSkipUnsupported(TestCase):
+    def test_custom_op_not_tracked_by_default(self):
+        """Custom ops without a formula execute and count 0 FLOPs by default."""
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            lib.define("unregistered_op(Tensor x) -> Tensor")
+            lib.impl("unregistered_op", lambda x: x * 2, "CompositeExplicitAutograd")
+
+            x = torch.randn(10, 10)
+            with FlopCounterMode() as mode:
+                result = torch.ops.mylib.unregistered_op(x)
+
+            self.assertEqual(result, x * 2)
+        self.assertEqual(mode.get_total_flops(), 0)
+        self.assertEqual(len(mode.get_unsupported_ops()), 0)
+
+    def test_custom_op_not_tracked_with_skip_enabled(self):
+        """skip_unsupported only affects HOPs: regular ops without formulas
+        execute, count 0 FLOPs, and are neither tracked nor warned about."""
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            lib.define("unregistered_op2(Tensor x) -> Tensor")
+            lib.impl("unregistered_op2", lambda x: x * 2, "CompositeExplicitAutograd")
+
+            x = torch.randn(10, 10)
+            with warnings.catch_warnings(record=True) as ws:
+                warnings.simplefilter("always")
+                with FlopCounterMode(skip_unsupported=True) as mode:
+                    result = torch.ops.mylib.unregistered_op2(x)
+
+            self.assertEqual(result, x * 2)
+        self.assertEqual(mode.get_total_flops(), 0)
+        self.assertEqual(len(mode.get_unsupported_ops()), 0)
+        self.assertFalse(any("FLOP formula" in str(w.message) for w in ws))
+
+    def test_skip_unsupported_unknown_hop(self):
+        """Unknown HOPs execute, warn, and are tracked when skip_unsupported=True."""
+        from torch.utils.flop_counter import flop_registry
+
+        self.assertNotIn(_unregistered_hop, flop_registry)
+
+        x = torch.randn(4, 4)
+        expected = x * 2
+
+        with self.assertWarnsRegex(
+            UserWarning, "does not have a registered FLOP formula"
+        ):
+            with FlopCounterMode(skip_unsupported=True) as mode:
+                result = _unregistered_hop(x)
+
+        self.assertEqual(result, expected)
+        self.assertEqual(mode.get_total_flops(), 0)
+        self.assertEqual(
+            mode.get_unsupported_ops()["mock_unregistered_hop_for_flop_test"], 1
+        )
+
+    def test_skip_unsupported_multiple_calls(self):
+        """The unsupported ops counter tracks each call."""
+        x = torch.randn(4, 4)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with FlopCounterMode(skip_unsupported=True) as mode:
+                for _ in range(5):
+                    _unregistered_hop(x)
+
+        self.assertEqual(
+            mode.get_unsupported_ops()["mock_unregistered_hop_for_flop_test"], 5
+        )
+
+    def test_skip_unsupported_with_mixed_ops(self):
+        """Supported ops are counted while unknown HOPs are skipped and tracked."""
+        x = torch.randn(4, 5)
+        y = torch.randn(5, 6)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with FlopCounterMode(skip_unsupported=True) as mode:
+                torch.mm(x, y)
+                _unregistered_hop(torch.randn(4, 4))
+
+        self.assertEqual(mode.get_total_flops(), 240)  # 4 * 6 * 2 * 5
+        self.assertEqual(
+            mode.get_unsupported_ops()["mock_unregistered_hop_for_flop_test"], 1
+        )
+
+    def test_get_unsupported_ops_returns_copy(self):
+        """Mutating the returned Counter must not affect the mode's state."""
+        x = torch.randn(4, 4)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with FlopCounterMode(skip_unsupported=True) as mode:
+                _unregistered_hop(x)
+
+        mode.get_unsupported_ops().clear()
+        self.assertEqual(len(mode.get_unsupported_ops()), 1)
+
+    def test_skipped_hop_inner_flops_not_counted(self):
+        """FLOPs inside a skipped HOP are not counted (docstring contract).
+
+        This guards against accidentally counting inner work when a HOP is
+        skipped. The HOP's torch.mm would add FLOPs if the exclusion broke.
+        """
+        x = torch.randn(4, 5)
+        y = torch.randn(5, 6)
+        z = torch.randn(5, 5)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with FlopCounterMode(skip_unsupported=True) as mode:
+                torch.mm(x, y)        # external: 4 * 6 * 2 * 5 = 240 FLOPs
+                _inner_mm_hop(z)      # skipped HOP with inner mm (5 * 5 * 2 * 5 = 250)
+
+        # Only external mm counted; inner mm inside skipped HOP excluded
+        self.assertEqual(mode.get_total_flops(), 240)
+        self.assertEqual(mode.get_unsupported_ops()["mock_inner_mm_hop"], 1)
+
+    @unittest.skipIf(TEST_WITH_CROSSREF, "NotImplemented return raises under active TorchFunctionMode")
+    def test_unknown_hop_without_skip_returns_not_implemented(self):
+        """With skip_unsupported=False (default), the mode returns NotImplemented
+        for unknown HOPs (pre-existing dispatch behavior). This is the failure
+        mode that skip_unsupported=True addresses."""
+        x = torch.randn(4, 4)
+
+        with FlopCounterMode() as mode:
+            result = _unregistered_hop(x)
+
+        self.assertIs(result, NotImplemented)
+        self.assertEqual(len(mode.get_unsupported_ops()), 0)
+
+    def test_registered_hop_counts_flops(self):
+        """flex_attention is registered and its formula matches sdpa_flop_count."""
+        from torch.utils.flop_counter import flop_registry
+
+        self.assertIn(torch.ops.higher_order.flex_attention, flop_registry)
+
+        q_shape = (2, 8, 128, 64)
+        k_shape = (2, 8, 128, 64)
+        v_shape = (2, 8, 128, 64)
+
+        q = torch.randn(*q_shape, device="meta", dtype=torch.float16)
+        k = torch.randn(*k_shape, device="meta", dtype=torch.float16)
+        v = torch.randn(*v_shape, device="meta", dtype=torch.float16)
+        out = torch.randn(*q_shape, device="meta", dtype=torch.float16)
+
+        flex_attn_flop_fn = flop_registry[torch.ops.higher_order.flex_attention]
+        flops = flex_attn_flop_fn(q, k, v, out_val=(out, None, None))
+
+        expected_flops = sdpa_flop_count(q_shape, k_shape, v_shape)
+        self.assertEqual(flops, expected_flops)
+        self.assertGreater(flops, 0)
+
+    def test_flex_attention_hop_end_to_end(self):
+        """The flex_attention HOP executes under FlopCounterMode and its FLOPs
+        are counted via the registered formula (registered-HOP dispatch path)."""
+        from torch.nn.attention.flex_attention import (
+            _create_empty_block_mask,
+            _identity,
+        )
+
+        q = torch.randn(2, 4, 128, 64)
+        k = torch.randn(2, 4, 128, 64)
+        v = torch.randn(2, 4, 128, 64)
+        block_mask = _create_empty_block_mask(q, k)
+
+        with FlopCounterMode() as mode:
+            out = torch.ops.higher_order.flex_attention(
+                q, k, v, _identity, block_mask.as_tuple(), 0.125, {}
+            )
+
+        self.assertIsInstance(out, tuple)
+        self.assertEqual(out[0].shape, q.shape)
+        self.assertEqual(
+            mode.get_total_flops(), sdpa_flop_count(q.shape, k.shape, v.shape)
+        )
+        self.assertEqual(len(mode.get_unsupported_ops()), 0)
+
+    def test_registered_hop_returns_output_not_none(self):
+        """Registered HOPs return their actual output. Guards against the bug
+        where _handle_higher_order_ops passed None to _count_flops instead of
+        the HOP's return value, breaking tuple-returning HOPs like
+        flex_attention."""
+        from torch.utils.flop_counter import flop_registry, register_flop_formula
+
+        @register_flop_formula(_tuple_hop, get_raw=True)
+        def mock_hop_flops(*args, out_val=None, **kwargs):
+            return 100
+
+        self.addCleanup(lambda: flop_registry.pop(_tuple_hop, None))
+        self.assertIn(_tuple_hop, flop_registry)
+
+        x = torch.randn(4, 4)
+
+        with FlopCounterMode() as mode:
+            result = _tuple_hop(x)
+
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 3)
+        out, _, _ = result
+        self.assertEqual(out, x * 2)
+        self.assertEqual(mode.get_total_flops(), 100)
 
 
 if __name__ == "__main__":

--- a/test/test_flop_counter.py
+++ b/test/test_flop_counter.py
@@ -2,10 +2,13 @@
 # ruff: noqa: F841
 import functools
 import unittest
+import warnings
 
 import torch
 import torch.nn.functional as F
 import torch.utils.flop_counter
+from torch._higher_order_ops.utils import autograd_not_implemented
+from torch._ops import HigherOrderOperator
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_CUDNN_ATTENTION,
@@ -16,6 +19,7 @@ from torch.testing._internal.common_cuda import (
 from torch.testing._internal.common_device_type import e4m3_type
 from torch.testing._internal.common_utils import (
     run_tests,
+    TEST_WITH_CROSSREF,
     TEST_WITH_TORCHDYNAMO,
     TestCase,
     xfailIfNoAcceleratorTriton,
@@ -1491,6 +1495,227 @@ class TestFlexAttentionEstimation(TestCase):
         sparse_flops = get_flops(sparse_node)
         self.assertGreater(dense_flops, 0)
         self.assertEqual(sparse_flops, dense_flops // 2)
+
+
+class _MockHOP(HigherOrderOperator):
+    """Minimal HOP that dispatches through super().__call__() like real HOPs."""
+
+    def __init__(self, name, impl):
+        super().__init__(name)
+        self.py_impl(torch._C.DispatchKey.CPU)(impl)
+        self.py_autograd_impl(autograd_not_implemented(self, deferred_error=True))
+
+    def __call__(self, x):
+        return super().__call__(x)
+
+
+# HOPs register into a process-global registry and cannot be unregistered, so
+# they are created once at module scope to keep in-process re-runs working.
+_unregistered_hop = _MockHOP("mock_unregistered_hop_for_flop_test", lambda x: x * 2)
+_tuple_hop = _MockHOP("mock_tuple_hop_registered", lambda x: (x * 2, x.sum(), x.max()))
+_inner_mm_hop = _MockHOP("mock_inner_mm_hop", lambda x: torch.mm(x, x))
+
+
+@unittest.skipIf(
+    TEST_WITH_TORCHDYNAMO, "torchdynamo doesn't work with __torch_dispatch__ right now"
+)
+class TestSkipUnsupported(TestCase):
+    def test_custom_op_not_tracked_by_default(self):
+        """Custom ops without a formula execute and count 0 FLOPs by default."""
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            lib.define("unregistered_op(Tensor x) -> Tensor")
+            lib.impl("unregistered_op", lambda x: x * 2, "CompositeExplicitAutograd")
+
+            x = torch.randn(10, 10)
+            with FlopCounterMode() as mode:
+                result = torch.ops.mylib.unregistered_op(x)
+
+            self.assertEqual(result, x * 2)
+        self.assertEqual(mode.get_total_flops(), 0)
+        self.assertEqual(len(mode.get_unsupported_ops()), 0)
+
+    def test_custom_op_not_tracked_with_skip_enabled(self):
+        """skip_unsupported only affects HOPs: regular ops without formulas
+        execute, count 0 FLOPs, and are neither tracked nor warned about."""
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            lib.define("unregistered_op2(Tensor x) -> Tensor")
+            lib.impl("unregistered_op2", lambda x: x * 2, "CompositeExplicitAutograd")
+
+            x = torch.randn(10, 10)
+            with warnings.catch_warnings(record=True) as ws:
+                warnings.simplefilter("always")
+                with FlopCounterMode(skip_unsupported=True) as mode:
+                    result = torch.ops.mylib.unregistered_op2(x)
+
+            self.assertEqual(result, x * 2)
+        self.assertEqual(mode.get_total_flops(), 0)
+        self.assertEqual(len(mode.get_unsupported_ops()), 0)
+        self.assertFalse(any("FLOP formula" in str(w.message) for w in ws))
+
+    def test_skip_unsupported_unknown_hop(self):
+        """Unknown HOPs execute, warn, and are tracked when skip_unsupported=True."""
+        from torch.utils.flop_counter import flop_registry
+
+        self.assertNotIn(_unregistered_hop, flop_registry)
+
+        x = torch.randn(4, 4)
+        expected = x * 2
+
+        with self.assertWarnsRegex(
+            UserWarning, "does not have a registered FLOP formula"
+        ):
+            with FlopCounterMode(skip_unsupported=True) as mode:
+                result = _unregistered_hop(x)
+
+        self.assertEqual(result, expected)
+        self.assertEqual(mode.get_total_flops(), 0)
+        self.assertEqual(
+            mode.get_unsupported_ops()["mock_unregistered_hop_for_flop_test"], 1
+        )
+
+    def test_skip_unsupported_multiple_calls(self):
+        """The unsupported ops counter tracks each call."""
+        x = torch.randn(4, 4)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with FlopCounterMode(skip_unsupported=True) as mode:
+                for _ in range(5):
+                    _unregistered_hop(x)
+
+        self.assertEqual(
+            mode.get_unsupported_ops()["mock_unregistered_hop_for_flop_test"], 5
+        )
+
+    def test_skip_unsupported_with_mixed_ops(self):
+        """Supported ops are counted while unknown HOPs are skipped and tracked."""
+        x = torch.randn(4, 5)
+        y = torch.randn(5, 6)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with FlopCounterMode(skip_unsupported=True) as mode:
+                torch.mm(x, y)
+                _unregistered_hop(torch.randn(4, 4))
+
+        self.assertEqual(mode.get_total_flops(), 240)  # 4 * 6 * 2 * 5
+        self.assertEqual(
+            mode.get_unsupported_ops()["mock_unregistered_hop_for_flop_test"], 1
+        )
+
+    def test_get_unsupported_ops_returns_copy(self):
+        """Mutating the returned Counter must not affect the mode's state."""
+        x = torch.randn(4, 4)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with FlopCounterMode(skip_unsupported=True) as mode:
+                _unregistered_hop(x)
+
+        mode.get_unsupported_ops().clear()
+        self.assertEqual(len(mode.get_unsupported_ops()), 1)
+
+    def test_skipped_hop_inner_flops_not_counted(self):
+        """FLOPs inside a skipped HOP are not counted (docstring contract).
+
+        This guards against accidentally counting inner work when a HOP is
+        skipped. The HOP's torch.mm would add FLOPs if the exclusion broke.
+        """
+        x = torch.randn(4, 5)
+        y = torch.randn(5, 6)
+        z = torch.randn(5, 5)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with FlopCounterMode(skip_unsupported=True) as mode:
+                torch.mm(x, y)        # external: 4 * 6 * 2 * 5 = 240 FLOPs
+                _inner_mm_hop(z)      # skipped HOP with inner mm (5 * 5 * 2 * 5 = 250)
+
+        # Only external mm counted; inner mm inside skipped HOP excluded
+        self.assertEqual(mode.get_total_flops(), 240)
+        self.assertEqual(mode.get_unsupported_ops()["mock_inner_mm_hop"], 1)
+
+    @unittest.skipIf(TEST_WITH_CROSSREF, "NotImplemented return raises under active TorchFunctionMode")
+    def test_unknown_hop_without_skip_returns_not_implemented(self):
+        """With skip_unsupported=False (default), the mode returns NotImplemented
+        for unknown HOPs (pre-existing dispatch behavior). This is the failure
+        mode that skip_unsupported=True addresses."""
+        x = torch.randn(4, 4)
+
+        with FlopCounterMode() as mode:
+            result = _unregistered_hop(x)
+
+        self.assertIs(result, NotImplemented)
+        self.assertEqual(len(mode.get_unsupported_ops()), 0)
+
+    def test_registered_hop_counts_flops(self):
+        """flex_attention is registered and its formula matches sdpa_flop_count."""
+        from torch.utils.flop_counter import flop_registry
+
+        self.assertIn(torch.ops.higher_order.flex_attention, flop_registry)
+
+        q_shape = (2, 8, 128, 64)
+        k_shape = (2, 8, 128, 64)
+        v_shape = (2, 8, 128, 64)
+
+        q = torch.randn(*q_shape, device="meta", dtype=torch.float16)
+        k = torch.randn(*k_shape, device="meta", dtype=torch.float16)
+        v = torch.randn(*v_shape, device="meta", dtype=torch.float16)
+        out = torch.randn(*q_shape, device="meta", dtype=torch.float16)
+
+        flex_attn_flop_fn = flop_registry[torch.ops.higher_order.flex_attention]
+        flops = flex_attn_flop_fn(q, k, v, out_val=(out, None, None))
+
+        expected_flops = sdpa_flop_count(q_shape, k_shape, v_shape)
+        self.assertEqual(flops, expected_flops)
+        self.assertGreater(flops, 0)
+
+    def test_flex_attention_hop_end_to_end(self):
+        """The flex_attention HOP executes under FlopCounterMode and its FLOPs
+        are counted via the registered formula (registered-HOP dispatch path)."""
+        from torch.nn.attention.flex_attention import (
+            _create_empty_block_mask,
+            _identity,
+        )
+
+        q = torch.randn(2, 4, 128, 64)
+        k = torch.randn(2, 4, 128, 64)
+        v = torch.randn(2, 4, 128, 64)
+        block_mask = _create_empty_block_mask(q, k)
+
+        with FlopCounterMode() as mode:
+            out = torch.ops.higher_order.flex_attention(
+                q, k, v, _identity, block_mask.as_tuple(), 0.125, {}
+            )
+
+        self.assertIsInstance(out, tuple)
+        self.assertEqual(out[0].shape, q.shape)
+        self.assertEqual(
+            mode.get_total_flops(), sdpa_flop_count(q.shape, k.shape, v.shape)
+        )
+        self.assertEqual(len(mode.get_unsupported_ops()), 0)
+
+    def test_registered_hop_returns_output_not_none(self):
+        """Registered HOPs return their actual output. Guards against the bug
+        where _handle_higher_order_ops passed None to _count_flops instead of
+        the HOP's return value, breaking tuple-returning HOPs like
+        flex_attention."""
+        from torch.utils.flop_counter import flop_registry, register_flop_formula
+
+        @register_flop_formula(_tuple_hop, get_raw=True)
+        def mock_hop_flops(*args, out_val=None, **kwargs):
+            return 100
+
+        self.addCleanup(lambda: flop_registry.pop(_tuple_hop, None))
+        self.assertIn(_tuple_hop, flop_registry)
+
+        x = torch.randn(4, 4)
+
+        with FlopCounterMode() as mode:
+            result = _tuple_hop(x)
+
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 3)
+        out, _, _ = result
+        self.assertEqual(out, x * 2)
+        self.assertEqual(mode.get_total_flops(), 100)
 
 
 if __name__ == "__main__":

--- a/test/test_flop_counter.py
+++ b/test/test_flop_counter.py
@@ -1625,14 +1625,17 @@ class TestSkipUnsupported(TestCase):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             with FlopCounterMode(skip_unsupported=True) as mode:
-                torch.mm(x, y)        # external: 4 * 6 * 2 * 5 = 240 FLOPs
-                _inner_mm_hop(z)      # skipped HOP with inner mm (5 * 5 * 2 * 5 = 250)
+                torch.mm(x, y)  # external: 4 * 6 * 2 * 5 = 240 FLOPs
+                _inner_mm_hop(z)  # skipped HOP with inner mm (5 * 5 * 2 * 5 = 250)
 
         # Only external mm counted; inner mm inside skipped HOP excluded
         self.assertEqual(mode.get_total_flops(), 240)
         self.assertEqual(mode.get_unsupported_ops()["mock_inner_mm_hop"], 1)
 
-    @unittest.skipIf(TEST_WITH_CROSSREF, "NotImplemented return raises under active TorchFunctionMode")
+    @unittest.skipIf(
+        TEST_WITH_CROSSREF,
+        "NotImplemented return raises under active TorchFunctionMode",
+    )
     def test_unknown_hop_without_skip_returns_not_implemented(self):
         """With skip_unsupported=False (default), the mode returns NotImplemented
         for unknown HOPs (pre-existing dispatch behavior). This is the failure

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -22,7 +22,7 @@ from torch._higher_order_ops.flex_attention import flex_attention as flex_attent
 from torch._higher_order_ops.utils import setup_compilation_env
 from torch.fx.experimental.symbolic_shapes import has_free_unbacked_symbols
 from torch.nn.attention._utils import _validate_sdpa_input
-from torch.utils._python_dispatch import is_in_torch_dispatch_mode
+from torch.utils._python_dispatch import any_torch_dispatch_mode_on_stack
 from torch.utils._pytree import (
     GetAttrKey,
     tree_flatten,
@@ -2614,12 +2614,8 @@ def flex_attention(
         return flex_attention_hop(*args, **kwargs)
 
     with setup_compilation_env() as backend:
-        # Skip torch.compile when a non-infra dispatch mode (e.g. FlopCounterMode)
-        # is active - dynamo cannot compile that frame anyway, and the uncompiled
-        # path is the unfused eager implementation which these modes need.
         skip_compile = (
-            _FLEX_ATTENTION_DISABLE_COMPILE_DEBUG
-            or is_in_torch_dispatch_mode(include_infra_modes=False)
+            _FLEX_ATTENTION_DISABLE_COMPILE_DEBUG or any_torch_dispatch_mode_on_stack()
         )
         if skip_compile:
             flex_fn = _flex_attention_hop_wrapper

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -22,6 +22,7 @@ from torch._higher_order_ops.flex_attention import flex_attention as flex_attent
 from torch._higher_order_ops.utils import setup_compilation_env
 from torch.fx.experimental.symbolic_shapes import has_free_unbacked_symbols
 from torch.nn.attention._utils import _validate_sdpa_input
+from torch.utils._python_dispatch import is_in_torch_dispatch_mode
 from torch.utils._pytree import (
     GetAttrKey,
     tree_flatten,
@@ -2613,7 +2614,14 @@ def flex_attention(
         return flex_attention_hop(*args, **kwargs)
 
     with setup_compilation_env() as backend:
-        if _FLEX_ATTENTION_DISABLE_COMPILE_DEBUG:
+        # Skip torch.compile when a non-infra dispatch mode (e.g. FlopCounterMode)
+        # is active - dynamo cannot compile that frame anyway, and the uncompiled
+        # path is the unfused eager implementation which these modes need.
+        skip_compile = (
+            _FLEX_ATTENTION_DISABLE_COMPILE_DEBUG
+            or is_in_torch_dispatch_mode(include_infra_modes=False)
+        )
+        if skip_compile:
             flex_fn = _flex_attention_hop_wrapper
         else:
             flex_fn = torch.compile(
@@ -2635,6 +2643,5 @@ def flex_attention(
         max_scores,
         return_aux=return_aux,
         return_lse=return_lse,
-        stats_are_log2=_FLEX_ATTENTION_DISABLE_COMPILE_DEBUG
-        or kernel_options["BACKEND"] != "FLASH",
+        stats_are_log2=skip_compile or kernel_options["BACKEND"] != "FLASH",
     )

--- a/torch/utils/flop_counter.py
+++ b/torch/utils/flop_counter.py
@@ -92,7 +92,7 @@ from typing import Any, TypeVar
 from collections.abc import Callable
 from collections.abc import Iterator
 from typing_extensions import ParamSpec
-from collections import defaultdict
+from collections import defaultdict, Counter
 from torch.utils._python_dispatch import TorchDispatchMode
 from math import prod
 from functools import wraps
@@ -131,7 +131,58 @@ def shape_wrapper(f):
     return nf
 
 def register_flop_formula(targets, get_raw=False) -> Callable[[Callable[_P, _T]], Callable[_P, _T]]:
+    """Register a FLOP counting formula for custom operations.
 
+    This allows FlopCounterMode to count FLOPs for custom operations by providing
+    a function that calculates FLOPs based on input tensor shapes.
+
+    Args:
+        targets: OpOverloadPacket(s) (e.g., torch.ops.mylib.my_op), Triton JITFunction(s),
+                or HigherOrderOperator(s) to register the formula for. Can be a single
+                target or a list of targets.
+        get_raw: If False (default), the formula receives tensor shapes.
+                If True, the formula receives actual tensors.
+
+    Returns:
+        Decorator that registers the FLOP counting formula.
+
+    Example::
+
+        from torch.utils.flop_counter import register_flop_formula
+
+        # Define a custom operation
+        @torch.library.custom_op("mylib::my_rope", mutates_args=())
+        def my_rope(x: torch.Tensor) -> torch.Tensor:
+            return x  # RoPE implementation
+
+        @my_rope.register_fake
+        def _(x):
+            return torch.empty_like(x)
+
+        # Register FLOP formula (return 0 for negligible ops like RoPE)
+        @register_flop_formula(torch.ops.mylib.my_rope)
+        def my_rope_flops(x_shape, out_shape=None, **kwargs):
+            return 0  # RoPE doesn't add meaningful FLOPs
+
+        # Or calculate actual FLOPs based on shape, assuming mylib::my_attention
+        # is a custom op defined the same way as mylib::my_rope above
+        @register_flop_formula(torch.ops.mylib.my_attention)
+        def my_attention_flops(q_shape, k_shape, v_shape, out_shape=None, **kwargs):
+            b, h, s_q, d = q_shape
+            s_k = k_shape[2]
+            # Q @ K^T + Scores @ V
+            return b * h * s_q * s_k * 2 * d + b * h * s_q * d * 2 * s_k
+
+        # Now FlopCounterMode will count FLOPs for these operations
+        with FlopCounterMode(display=True) as mode:
+            result = my_rope(x)  # 0 FLOPs counted
+            result = my_attention(q, k, v)  # Actual FLOPs counted
+
+    Note:
+        This decorator also works for Higher Order Operators (HOPs) like flex_attention.
+        For HOPs without a registered formula, use skip_unsupported=True to execute
+        them without counting FLOPs (they will be tracked via get_unsupported_ops()).
+    """
     def register_fun(flop_formula: Callable[_P, _T]) -> Callable[_P, _T]:
         if not get_raw:
             flop_formula = shape_wrapper(flop_formula)
@@ -897,6 +948,18 @@ class FlopCounterMode:
     ``get_total_flops()`` or ``get_flop_counts()`` to read the same information
     programmatically.
 
+    Args:
+        mods: Optional module or list of modules for hierarchical output (deprecated).
+        depth: Maximum depth for hierarchical display (default: 2).
+        display: Whether to print the FLOP table on exit (default: True).
+        custom_mapping: Optional dictionary mapping operations to custom FLOP counting functions.
+        skip_unsupported: If True, Higher Order Operators (HOPs) without registered FLOP
+                         formulas are executed with a warning and tracked via
+                         get_unsupported_ops() instead of failing (default: False).
+                         Note that FLOPs of operations inside a skipped HOP are not
+                         counted. Only affects HOPs: regular ops without formulas always
+                         execute and count 0 FLOPs regardless of this setting.
+
     Example usage:
 
     .. code-block:: python
@@ -909,6 +972,28 @@ class FlopCounterMode:
 
         total = flop_counter.get_total_flops()
 
+        # For models with custom kernels or unsupported operations
+        with FlopCounterMode(display=True, skip_unsupported=True) as flop_counter:
+            output = model(input)
+            total_flops = flop_counter.get_total_flops()
+            # Check what operations were skipped
+            unsupported = flop_counter.get_unsupported_ops()
+            if unsupported:
+                print(f"Warning: Could not count FLOPs for: {unsupported}")
+
+        # To register custom FLOP formulas for your operations
+        from torch.utils.flop_counter import register_flop_formula
+
+        @register_flop_formula(torch.ops.mylib.my_op)
+        def my_op_flops(x_shape, out_shape=None, **kwargs):
+            return 0  # Return 0 for ops with negligible FLOPs, or calculate actual FLOPs
+
+        with FlopCounterMode(display=True) as flop_counter:
+            result = my_op(x)  # FLOPs will be counted using registered formula
+
+    See Also:
+        :func:`register_flop_formula`: Register custom FLOP counting formulas for operations
+
     """
 
     def __init__(
@@ -916,11 +1001,14 @@ class FlopCounterMode:
             mods: torch.nn.Module | list[torch.nn.Module] | None = None,
             depth: int = 2,
             display: bool = True,
-            custom_mapping: dict[Any, Any] | None = None) -> None:
+            custom_mapping: dict[Any, Any] | None = None,
+            skip_unsupported: bool = False) -> None:
         super().__init__()
         self.flop_counts: dict[str, dict[Any, int]] = defaultdict(lambda: defaultdict(int))
         self.depth = depth
         self.display = display
+        self.skip_unsupported = skip_unsupported
+        self._unsupported_ops: Counter[str] = Counter()
         self.mode: _FlopCounterMode | None = None
         if custom_mapping is None:
             custom_mapping = {}
@@ -934,6 +1022,15 @@ class FlopCounterMode:
 
     def get_total_flops(self) -> int:
         return sum(self.flop_counts['Global'].values())
+
+    def get_unsupported_ops(self) -> Counter[str]:
+        """Return a Counter of unsupported operations encountered.
+
+        Returns:
+            Counter[str]: A Counter mapping operation names to the number of times
+                         they were encountered without a registered FLOP formula.
+        """
+        return Counter(self._unsupported_ops)
 
     def get_flop_counts(self) -> dict[str, dict[Any, int]]:
         """Return the flop counts as a dictionary of dictionaries.
@@ -1012,6 +1109,7 @@ class FlopCounterMode:
     # NB: This context manager is NOT reentrant
     def __enter__(self):
         self.flop_counts.clear()
+        self._unsupported_ops.clear()
         self.mod_tracker.__enter__()
         self.mode = _FlopCounterMode(self)
         self.mode.__enter__()
@@ -1076,7 +1174,8 @@ class _FlopCounterMode(TorchDispatchMode):
                 else:
                     break
             return self.counter._count_flops(kernel_name, None, args, kwargs)
-        elif func is torch.ops.higher_order.cond:
+
+        if func is torch.ops.higher_order.cond:
             # The flop counter for cond counts the upper bound of flops.
             # For example, if a matmul is executed 2 times in true branch
             # but only 1 time in the false branch, the flop counter will
@@ -1119,8 +1218,24 @@ class _FlopCounterMode(TorchDispatchMode):
             # It doesn't matter which one we return since true_fn and false_fn return
             # output with the same structure.
             return true_out
-        else:
-            return NotImplemented
+
+        # HOPs with a registered formula (e.g., flex_attention)
+        if func in self.counter.flop_registry:
+            out = func(*args, **kwargs)
+            return self.counter._count_flops(func, out, args, kwargs)
+
+        if self.counter.skip_unsupported:
+            op_name = str(func)
+            self.counter._unsupported_ops[op_name] += 1
+            # The HOP executes with this mode popped, so FLOPs of ops inside
+            # it are not counted either.
+            warnings.warn(
+                f"FlopCounterMode does not have a registered FLOP formula for {op_name}. "
+                "Executing without counting FLOPs (including any operations inside it).",
+                stacklevel=2
+            )
+            return func(*args, **kwargs)
+        return NotImplemented
 
     def __torch_dispatch__(self, func, types, args=(), kwargs=None):
         kwargs = kwargs if kwargs else {}
@@ -1147,13 +1262,16 @@ class _FlopCounterMode(TorchDispatchMode):
         if isinstance(func, torch._ops.HigherOrderOperator):
             return self._handle_higher_order_ops(func, types, args, kwargs)
 
-        # If we don't have func in flop_registry, see if it can decompose
-        if func not in self.counter.flop_registry and func is not torch.ops.prim.device.default:
+        # If we don't have func_packet in flop_registry, see if it can decompose
+        func_packet = func._overloadpacket
+        if func_packet not in self.counter.flop_registry and func is not torch.ops.prim.device.default:
             with self:
                 r = func.decompose(*args, **kwargs)
                 if r is not NotImplemented:
                     return r
 
         # no further decomposition; execute & count flops
+        # (_count_flops is a no-op for ops without a registered formula, so
+        # unregistered regular ops execute and count 0 FLOPs)
         out = func(*args, **kwargs)
-        return self.counter._count_flops(func._overloadpacket, out, args, kwargs)
+        return self.counter._count_flops(func_packet, out, args, kwargs)

--- a/torch/utils/flop_counter.py
+++ b/torch/utils/flop_counter.py
@@ -949,7 +949,7 @@ class FlopCounterMode:
     programmatically.
 
     Args:
-        mods: Optional module or list of modules for hierarchical output (deprecated).
+        mods: Ignored; accepted for backward compatibility. Passing it emits a warning.
         depth: Maximum depth for hierarchical display (default: 2).
         display: Whether to print the FLOP table on exit (default: True).
         custom_mapping: Optional dictionary mapping operations to custom FLOP counting functions.
@@ -1173,6 +1173,15 @@ class _FlopCounterMode(TorchDispatchMode):
                     kernel_name = kernel_name.fn
                 else:
                     break
+            if kernel_name not in self.counter.flop_registry and self.counter.skip_unsupported:
+                op_name = getattr(kernel_name, "__name__", str(kernel_name))
+                self.counter._unsupported_ops[op_name] += 1
+                warnings.warn(
+                    f"FlopCounterMode does not have a registered FLOP formula for triton kernel {op_name}. "
+                    "Executing without counting FLOPs.",
+                    stacklevel=2
+                )
+                return func(*args, **kwargs)
             return self.counter._count_flops(kernel_name, None, args, kwargs)
 
         if func is torch.ops.higher_order.cond:

--- a/torch/utils/flop_counter.py
+++ b/torch/utils/flop_counter.py
@@ -175,8 +175,8 @@ def register_flop_formula(targets, get_raw=False) -> Callable[[Callable[_P, _T]]
 
         # Now FlopCounterMode will count FLOPs for these operations
         with FlopCounterMode(display=True) as mode:
-            result = my_rope(x)  # 0 FLOPs counted
-            result = my_attention(q, k, v)  # Actual FLOPs counted
+            result = torch.ops.mylib.my_rope(x)  # 0 FLOPs counted
+            result = torch.ops.mylib.my_attention(q, k, v)  # Actual FLOPs counted
 
     Note:
         This decorator also works for Higher Order Operators (HOPs) like flex_attention.
@@ -771,11 +771,19 @@ def _register_flex_attention_flops() -> None:
             return 0.0
         return max(0.0, min(1.0, custom.get("sparsity_hint", 0.0)))
 
+    def _expand_kv(query_shape, shape):
+        # flex_attention allows Bkv=1 broadcast against Bq
+        if shape[0] == 1 and query_shape[0] != 1:
+            return (query_shape[0], *shape[1:])
+        return shape
+
     @register_flop_formula(flex_attention, get_raw=True)
     def flex_attention_forward_flop(
         query, key, value, *args, out_val=None, **kwargs
     ) -> int:
-        flops = sdpa_flop_count(query.shape, key.shape, value.shape)
+        k_shape = _expand_kv(query.shape, key.shape)
+        v_shape = _expand_kv(query.shape, value.shape)
+        flops = sdpa_flop_count(query.shape, k_shape, v_shape)
         sparsity = _get_sparsity_hint(kwargs)
         return int(flops * (1.0 - sparsity)) if sparsity > 0 else flops
 
@@ -784,8 +792,10 @@ def _register_flex_attention_flops() -> None:
         query, key, value, out, logsumexp, grad_out, *args, out_val=None, **kwargs
     ) -> int:
         grad_out_shape = grad_out.shape if grad_out is not None else out.shape
+        k_shape = _expand_kv(query.shape, key.shape)
+        v_shape = _expand_kv(query.shape, value.shape)
         flops = sdpa_backward_flop_count(
-            grad_out_shape, query.shape, key.shape, value.shape
+            grad_out_shape, query.shape, k_shape, v_shape
         )
         sparsity = _get_sparsity_hint(kwargs)
         return int(flops * (1.0 - sparsity)) if sparsity > 0 else flops
@@ -989,7 +999,7 @@ class FlopCounterMode:
             return 0  # Return 0 for ops with negligible FLOPs, or calculate actual FLOPs
 
         with FlopCounterMode(display=True) as flop_counter:
-            result = my_op(x)  # FLOPs will be counted using registered formula
+            result = torch.ops.mylib.my_op(x)  # FLOPs will be counted using registered formula
 
     See Also:
         :func:`register_flop_formula`: Register custom FLOP counting formulas for operations
@@ -1182,7 +1192,8 @@ class _FlopCounterMode(TorchDispatchMode):
                     stacklevel=2
                 )
                 return func(*args, **kwargs)
-            return self.counter._count_flops(kernel_name, None, args, kwargs)
+            out = func(*args, **kwargs) if self.counter.skip_unsupported else None
+            return self.counter._count_flops(kernel_name, out, args, kwargs)
 
         if func is torch.ops.higher_order.cond:
             # The flop counter for cond counts the upper bound of flops.


### PR DESCRIPTION
Partially addresses #134385 (the public `flex_attention(q, k, v)` API is completed by the stacked follow-up #196988; this PR supports HOP counting through the `torch.ops.higher_order.flex_attention(...)` entry point).

`FlopCounterMode` returns `NotImplemented` when it encounters a Higher Order Operator it does not handle, which makes it hard to use for benchmarking real-world models that mix standard PyTorch ops with custom HOPs or kernels.

## What this PR does

Adds a `skip_unsupported` flag (default `False`) to `FlopCounterMode`. When enabled, HOPs without a registered FLOP formula execute with a warning and are tracked in a `Counter` exposed via the new `get_unsupported_ops()` method, instead of failing.

- The flag only affects HOPs and Triton kernels: regular ops without formulas always execute and count 0 FLOPs, as before.
- FLOPs of operations inside a skipped HOP are not counted (the warning says so).
- For Triton kernels the flag also gates execution: with the default `False` a kernel (registered or not) is counted but never executed, preserving the fake-tensor flop estimation path; with `True` kernels execute (and unregistered ones warn and are tracked).
- `get_unsupported_ops()` returns a copy, so callers cannot mutate the mode's internal state.

```python
with FlopCounterMode(skip_unsupported=True) as mode:
    out = model(x)  # unknown HOPs warn and are skipped instead of failing

print(mode.get_total_flops())
print(mode.get_unsupported_ops())  # e.g. Counter({'my_custom_hop': 3})
```

## Bug fixes in the dispatch path

- HOPs with a registered FLOP formula (e.g. `flex_attention`) are now executed and counted instead of returning `NotImplemented`.
- The registry lookup in `__torch_dispatch__` now checks `func._overloadpacket` (matching how formulas are registered), so registered formulas take precedence over decomposition.

`register_flop_formula` works for regular ops, Triton kernels, and HOPs; its docstring now documents this with examples.

## Stacked follow-up

#196988 contains the `torch/nn/attention/flex_attention.py` changes (skipping the internal `torch.compile` under non-compilable dispatch modes, the `Bkv=1` broadcast fix in the flex flop formulas, and the public-API tests), split out per review since it changes behavior for every `flex_attention` caller under a non-infra dispatch mode.

## Tests

`TestSkipUnsupported` in `test/test_flop_counter.py` covers skip/track/warn behavior for unknown HOPs, that regular custom ops are unaffected by the flag, the `NotImplemented` default behavior for unknown HOPs, the copy semantics of `get_unsupported_ops()`, Triton kernel execution under the flag (registered and unregistered), the registered-formula-over-decompose behavior for `CompositeImplicitAutograd` ops under `inference_mode`, and an end-to-end test that runs the real `flex_attention` HOP under `FlopCounterMode` and checks the counted FLOPs against `sdpa_flop_count`.

The default behavior is unchanged for backward compatibility.
