### PR TITLE
[dcp] Add more granularity on what collectives to apply for rank-local checkpointing

### DIFF
--- a/torch/distributed/checkpoint/_async_executor.py
+++ b/torch/distributed/checkpoint/_async_executor.py
@@ -6,6 +6,7 @@ from concurrent.futures import Future
 from typing import Optional, Union
 
 import torch.distributed as dist
+from torch.distributed.checkpoint._enums import Collectives
 from torch.distributed.checkpoint.metadata import STATE_DICT_TYPE
 from torch.distributed.checkpoint.planner import SavePlanner
 from torch.distributed.checkpoint.storage import StorageWriter
@@ -22,7 +23,7 @@ class _AsyncCheckpointExecutor(abc.ABC):
         planner: Optional[SavePlanner] = None,
         process_group: Optional[dist.ProcessGroup] = None,
         no_dist: bool = False,
-        use_collectives: bool = True,
+        use_collectives: Union[bool, Collectives] = Collectives.ALL,
     ) -> Future:
         """
         Execute the checkpoint save request asynchronously.

--- a/torch/distributed/checkpoint/_async_process_executor.py
+++ b/torch/distributed/checkpoint/_async_process_executor.py
@@ -12,6 +12,7 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 from torch.distributed import PrefixStore, TCPStore
 from torch.distributed.checkpoint._async_executor import _AsyncCheckpointExecutor
+from torch.distributed.checkpoint._enums import Collectives
 from torch.distributed.checkpoint.logger import _dcp_method_logger, _init_logger
 from torch.distributed.checkpoint.metadata import Metadata, STATE_DICT_TYPE
 from torch.distributed.checkpoint.planner import SavePlanner
@@ -46,7 +47,7 @@ class _AsyncCheckpointRequest:
     storage_writer: Optional[StorageWriter] = None
     planner: Optional[SavePlanner] = None
     no_dist: bool = False
-    use_collectives: bool = True
+    use_collectives: Union[bool, Collectives] = Collectives.ALL
 
 
 @dataclass(init=False)
@@ -177,7 +178,7 @@ class _AsyncCheckpointProcess:
         storage_writer: Optional[StorageWriter] = None,
         planner: Optional[SavePlanner] = None,
         no_dist: bool = False,
-        use_collectives: bool = True,
+        use_collectives: Union[bool, Collectives] = Collectives.ALL,
     ) -> Metadata:
         # Create a unique identifier to locate requests/responses
         # from the checkpoint daemon process.
@@ -204,7 +205,7 @@ class _AsyncCheckpointProcess:
         storage_writer: Optional[StorageWriter] = None,
         planner: Optional[SavePlanner] = None,
         no_dist: bool = False,
-        use_collectives: bool = True,
+        use_collectives: Union[bool, Collectives] = Collectives.ALL,
     ) -> Metadata:
         from torch.distributed.checkpoint.state_dict_saver import save
 
@@ -332,7 +333,7 @@ class _ProcessBasedAsyncCheckpointExecutor(_AsyncCheckpointExecutor):
         planner: Optional[SavePlanner] = None,
         process_group: Optional[dist.ProcessGroup] = None,
         no_dist: bool = False,
-        use_collectives: bool = True,
+        use_collectives: Union[bool, Collectives] = Collectives.ALL,
     ) -> Metadata:
         global _CHECKPOINT_PROCESS
         if _CHECKPOINT_PROCESS is None:
@@ -380,7 +381,7 @@ class _ProcessBasedAsyncCheckpointExecutor(_AsyncCheckpointExecutor):
         planner: Optional[SavePlanner] = None,
         process_group: Optional[dist.ProcessGroup] = None,
         no_dist: bool = False,
-        use_collectives: bool = True,
+        use_collectives: Union[bool, Collectives] = Collectives.ALL,
     ) -> Future:
         """
         NOTE:

--- a/torch/distributed/checkpoint/_async_thread_executor.py
+++ b/torch/distributed/checkpoint/_async_thread_executor.py
@@ -6,6 +6,7 @@ from typing import Optional, Union
 
 import torch.distributed as dist
 from torch.distributed.checkpoint._async_executor import _AsyncCheckpointExecutor
+from torch.distributed.checkpoint._enums import Collectives
 from torch.distributed.checkpoint.metadata import STATE_DICT_TYPE
 from torch.distributed.checkpoint.planner import SavePlanner
 from torch.distributed.checkpoint.storage import StorageWriter
@@ -19,7 +20,7 @@ def save_wrapper(
     planner: Optional[SavePlanner] = None,
     process_group: Optional[dist.ProcessGroup] = None,
     no_dist: bool = False,
-    use_collectives: bool = True,
+    use_collectives: Union[bool, Collectives] = Collectives.ALL,
 ) -> Future:
     from torch.distributed.checkpoint.state_dict_saver import save
 
@@ -54,7 +55,7 @@ class _ThreadBasedAsyncCheckpointExecutor(_AsyncCheckpointExecutor):
         planner: Optional[SavePlanner] = None,
         process_group: Optional[dist.ProcessGroup] = None,
         no_dist: bool = False,
-        use_collectives: bool = True,
+        use_collectives: Union[bool, Collectives] = Collectives.ALL,
     ) -> Future:
         f: Future = self._executor.submit(
             save_wrapper,

--- a/torch/distributed/checkpoint/_enums.py
+++ b/torch/distributed/checkpoint/_enums.py
@@ -1,0 +1,13 @@
+from enum import Enum
+
+
+__all__ = ["Collectives"]
+
+
+class Collectives(Enum):
+    """Enum for collectives usage during checkpoint save."""
+
+    ALL = "all"
+    PLANNING_ONLY = "planning_only"
+    METADATA_ONLY = "metadata_only"
+    NONE = "none"


### PR DESCRIPTION
Summary: Currently we only have a boolean to represent whether we do collectives on checkpointing. But we should have more granularity on this, to be able to skip only certain collectives. This is specifically useful to be able to skip the planning collective on anchor checkpoints, but continue to do the metadata collective so that we can output the anchor checkpoint in the format that can be used by downstream users. The planning collective is the more expensive of the two, so we will still see some of the wins for anchor checkpoints.

Test Plan: ensure existing tests pass

Differential Revision: D86347143




cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci