### PR TITLE
[inductor][ez] skip cache for unit test via envvar

### DIFF
--- a/torch/_inductor/test_case.py
+++ b/torch/_inductor/test_case.py
@@ -32,7 +32,10 @@ class TestCase(DynamoTestCase):
             )
         )
 
-        if "TORCHINDUCTOR_FX_GRAPH_CACHE" not in os.environ:
+        if (
+            "TORCHINDUCTOR_FX_GRAPH_CACHE" not in os.environ
+            and "TORCHINDUCTOR_FX_GRAPH_CACHE_DEFAULT" not in os.environ
+        ):
             self._inductor_test_stack.enter_context(
                 config.patch({"fx_graph_cache": True})
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #167237

It would be surprising to see the cache get hit in Unit Test when TORCHINDUCTOR_FX_GRAPH_CACHE_DEFAULT is set to 1.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben