### PR TITLE
[CI] manually gen json for segfaults

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -309,10 +309,13 @@ class StepcurrentPlugin:
         assert config.cache is not None
         self.cache: pytest.Cache = config.cache
         self.directory = f"{STEPCURRENT_CACHE_DIR}/{config.getoption('stepcurrent')}"
+        self.lastrun_location = f"{self.directory}/lastrun"
+        self.made_failing_xml_location = f"{self.directory}/made_failing_xml"
         self.lastrun: Optional[str] = self.cache.get(self.directory, None)
         self.initial_val = self.lastrun
         self.skip: bool = config.getoption("stepcurrent_skip")
         self.run_single: bool = config.getoption("run_single")
+        self.cache.set(self.made_failing_xml_location, "False")
 
     def pytest_collection_modifyitems(self, config: Config, items: list[Any]) -> None:
         if not self.lastrun:
@@ -354,3 +357,5 @@ class StepcurrentPlugin:
     def pytest_sessionfinish(self, session, exitstatus):
         if exitstatus == 0:
             self.cache.set(self.directory, self.initial_val)
+        if exitstatus != 0:
+            self.cache.set(self.made_failing_xml_location, "True")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -308,13 +308,14 @@ class StepcurrentPlugin:
         self.report_status = ""
         assert config.cache is not None
         self.cache: pytest.Cache = config.cache
-        self.directory = f"{STEPCURRENT_CACHE_DIR}/{config.getoption('stepcurrent')}"
-        self.lastrun_location = f"{self.directory}/lastrun"
-        self.made_failing_xml_location = f"{self.directory}/made_failing_xml"
-        self.lastrun: Optional[str] = self.cache.get(self.directory, None)
+        directory = f"{STEPCURRENT_CACHE_DIR}/{config.getoption('stepcurrent')}"
+        self.lastrun_location = f"{directory}/lastrun"
+        self.lastrun: Optional[str] = self.cache.get(self.lastrun_location, None)
         self.initial_val = self.lastrun
         self.skip: bool = config.getoption("stepcurrent_skip")
         self.run_single: bool = config.getoption("run_single")
+
+        self.made_failing_xml_location = f"{directory}/made_failing_xml"
         self.cache.set(self.made_failing_xml_location, "False")
 
     def pytest_collection_modifyitems(self, config: Config, items: list[Any]) -> None:
@@ -352,10 +353,10 @@ class StepcurrentPlugin:
 
     def pytest_runtest_protocol(self, item, nextitem) -> None:
         self.lastrun = item.nodeid
-        self.cache.set(self.directory, self.lastrun)
+        self.cache.set(self.lastrun_location, self.lastrun)
 
     def pytest_sessionfinish(self, session, exitstatus):
         if exitstatus == 0:
-            self.cache.set(self.directory, self.initial_val)
+            self.cache.set(self.lastrun_location, self.initial_val)
         if exitstatus != 0:
             self.cache.set(self.made_failing_xml_location, "True")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -316,7 +316,7 @@ class StepcurrentPlugin:
         self.run_single: bool = config.getoption("run_single")
 
         self.made_failing_xml_location = f"{directory}/made_failing_xml"
-        self.cache.set(self.made_failing_xml_location, "False")
+        self.cache.set(self.made_failing_xml_location, False)
 
     def pytest_collection_modifyitems(self, config: Config, items: list[Any]) -> None:
         if not self.lastrun:
@@ -359,4 +359,4 @@ class StepcurrentPlugin:
         if exitstatus == 0:
             self.cache.set(self.lastrun_location, self.initial_val)
         if exitstatus != 0:
-            self.cache.set(self.made_failing_xml_location, "True")
+            self.cache.set(self.made_failing_xml_location, True)

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -810,7 +810,7 @@ def run_test_retries(
             # failing tests instead of reruns. [1:-1] to remove quotes
             print_to_file(f"FAILED CONSISTENTLY: {current_failure[1:-1]}")
             if (
-                read_pytest_cache("made_failing_xml") == "False"
+                read_pytest_cache("made_failing_xml") == "false"
                 and IS_CI
                 and options.upload_artifacts_while_running
             ):

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -814,7 +814,7 @@ def run_test_retries(
                 and IS_CI
                 and options.upload_artifacts_while_running
             ):
-                upload_adhoc_failure_json(test_file)
+                upload_adhoc_failure_json(test_file, current_failure[1:-1])
 
             if not continue_through_error:
                 print_to_file("Stopping at first consistent failure")

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -78,8 +78,8 @@ from tools.testing.test_selections import (
 try:
     from tools.testing.upload_artifacts import (
         parse_xml_and_upload_json,
-        zip_and_upload_artifacts,
         upload_adhoc_failure_json,
+        zip_and_upload_artifacts,
     )
 except ImportError:
     # some imports in those files might fail, e.g., boto3 not installed. These
@@ -800,7 +800,11 @@ def run_test_retries(
             # This is for log classifier so it can prioritize consistently
             # failing tests instead of reruns. [1:-1] to remove quotes
             print_to_file(f"FAILED CONSISTENTLY: {current_failure[1:-1]}")
-            if current_failure == f"'{test_file}'" and IS_CI and options.upload_artifacts_while_running:
+            if (
+                current_failure == f"'{test_file}'"
+                and IS_CI
+                and options.upload_artifacts_while_running
+            ):
                 upload_adhoc_failure_json(test_file)
 
             if not continue_through_error:

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -782,7 +782,7 @@ def run_test_retries(
 
         # Read what just failed/ran
         try:
-            current_failure = read_pytest_cache("current_failure")
+            current_failure = read_pytest_cache("lastrun")
             if current_failure is None:
                 raise FileNotFoundError
             if current_failure == "null":

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -753,7 +753,9 @@ def run_test_retries(
     num_failures = defaultdict(int)
 
     def read_pytest_cache(key: str) -> Any:
-        cache_file = REPO_ROOT / ".pytest_cache/v/cache/stepcurrent" / stepcurrent_key / key
+        cache_file = (
+            REPO_ROOT / ".pytest_cache/v/cache/stepcurrent" / stepcurrent_key / key
+        )
         try:
             with open(cache_file) as f:
                 return f.read()
@@ -782,7 +784,7 @@ def run_test_retries(
         try:
             current_failure = read_pytest_cache("current_failure")
             if current_failure is None:
-                raise FileNotFoundError()
+                raise FileNotFoundError
             if current_failure == "null":
                 current_failure = f"'{test_file}'"
         except FileNotFoundError:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -149,6 +149,11 @@ class TestCheckpoint(TestCase):
                     self.assertEqual(m.counter, 1)
 
     def test_checkpoint_valid(self):
+        # segfault
+        import signal
+
+        signal.raise_signal(signal.SIGSEGV)
+
         model = nn.Sequential(
             nn.Linear(100, 50),
             nn.ReLU(),

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -149,11 +149,6 @@ class TestCheckpoint(TestCase):
                     self.assertEqual(m.counter, 1)
 
     def test_checkpoint_valid(self):
-        # segfault
-        import signal
-
-        signal.raise_signal(signal.SIGSEGV)
-
         model = nn.Sequential(
             nn.Linear(100, 50),
             nn.ReLU(),

--- a/tools/testing/upload_artifacts.py
+++ b/tools/testing/upload_artifacts.py
@@ -230,7 +230,7 @@ def upload_adhoc_failure_json(invoking_file: str, current_failure: str) -> None:
         testName = current_failure
         className = ""
 
-    message = "The test file failed but we were not able to determine the exact unittest.  The most likely cause is a segfault"
+    message = "The test file failed but pytest did not generate xml.  The most likely cause is a segfault"
     j = {
         "invoking_file": invoking_file,
         "file": f"{invoking_file}.py",

--- a/tools/testing/upload_artifacts.py
+++ b/tools/testing/upload_artifacts.py
@@ -216,8 +216,8 @@ def upload_adhoc_failure_json(invoking_file: str) -> None:
     since xml was probably not generated in this case
     """
     try:
-        job_id = int(os.environ.get("JOB_ID"))
-        workflow_id = int(os.environ.get("GITHUB_RUN_ID"))
+        job_id = int(os.environ.get["JOB_ID"])
+        workflow_id = int(os.environ["GITHUB_RUN_ID"])
     except Exception as e:
         print(f"Failed to get job_id or workflow_id: {e}")
         return

--- a/tools/testing/upload_artifacts.py
+++ b/tools/testing/upload_artifacts.py
@@ -210,7 +210,7 @@ def parse_xml_and_upload_json() -> None:
         print(f"Failed to parse and upload json test reports: {e}")
 
 
-def upload_adhoc_failure_json(invoking_file: str) -> None:
+def upload_adhoc_failure_json(invoking_file: str, current_failure: str) -> None:
     """
     manually upload a json to s3 indicating that the entire test file failed
     since xml was probably not generated in this case
@@ -222,11 +222,20 @@ def upload_adhoc_failure_json(invoking_file: str) -> None:
         print(f"Failed to get job_id or workflow_id: {e}")
         return
 
+    split_failure = current_failure.split("::")
+    if len(split_failure) >= 2:
+        className = split_failure[-2]
+        testName = split_failure[-1]
+    else:
+        testName = current_failure
+        className = ""
+
     message = "The test file failed but we were not able to determine the exact unittest.  The most likely cause is a segfault"
     j = {
         "invoking_file": invoking_file,
         "file": f"{invoking_file}.py",
-        "name": "entire_test_suite_failure",
+        "name": testName,
+        "classname": className,
         "workflow_id": workflow_id,
         "workflow_run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT"),
         "job_id": job_id,

--- a/tools/testing/upload_artifacts.py
+++ b/tools/testing/upload_artifacts.py
@@ -216,7 +216,7 @@ def upload_adhoc_failure_json(invoking_file: str) -> None:
     since xml was probably not generated in this case
     """
     try:
-        job_id = int(os.environ.get["JOB_ID"])
+        job_id = int(os.environ["JOB_ID"])
         workflow_id = int(os.environ["GITHUB_RUN_ID"])
     except Exception as e:
         print(f"Failed to get job_id or workflow_id: {e}")


### PR DESCRIPTION
segfaults dont gen xml, so we get no info about them in clickhouse or in the xml or in the json, so this manually generates something and uploads it to s3 to be ingested

at some point some of the existing code for test reports should be changed to just use the json that gets uploaded in the job or something