### PR TITLE
Enable custom collective op autotuning

### DIFF
--- a/test/inductor/test_collective_autotuning.py
+++ b/test/inductor/test_collective_autotuning.py
@@ -1,0 +1,110 @@
+# Owner(s): ["module: inductor"]
+
+"""
+Test collective op autotuning - Phase 1: Basic functionality with 2 ranks.
+
+This test validates that:
+1. Collective ops are detected correctly
+2. CollectiveBenchmarker is used for collective ops
+3. 2 ranks can sync and benchmark successfully
+4. Results are correct
+"""
+
+import torch
+import torch.distributed as dist
+from torch.testing._internal.common_distributed import (
+    MultiProcessTestCase,
+    skip_if_lt_x_gpu,
+)
+from torch.testing._internal.common_utils import run_tests
+
+
+class TestCollectiveAutotuning(MultiProcessTestCase):
+    @property
+    def world_size(self):
+        return 2
+
+    def setUp(self):
+        super().setUp()
+        self._spawn_processes()
+
+    @skip_if_lt_x_gpu(2)
+    def test_single_allreduce_2ranks(self):
+        """Test single all_reduce with 2 ranks"""
+
+        # Initialize distributed
+        dist.init_process_group(
+            backend="nccl",
+            init_method=f"file:///tmp/test_collective_autotune_{self.id()}",
+            world_size=self.world_size,
+            rank=self.rank,
+        )
+
+        rank = dist.get_rank()
+        device = f"cuda:{rank}"
+
+        # Register the default process group
+        from torch._C._distributed_c10d import _register_process_group
+
+        _register_process_group("default", dist.group.WORLD)
+
+        # Define custom collective op
+        @torch.library.custom_op("test::my_allreduce", mutates_args=())
+        def my_allreduce(x: torch.Tensor) -> torch.Tensor:
+            result = x.clone()
+            return torch.ops._c10d_functional.all_reduce_(result, "sum", "default")
+
+        # Fake implementation for abstract
+        @my_allreduce.register_fake
+        def _(x):
+            return torch.empty_like(x)
+
+        # Implementation 1: Direct NCCL
+        def allreduce_nccl(x):
+            result = x.clone()
+            return torch.ops._c10d_functional.all_reduce_(result, "sum", "default")
+
+        # Implementation 2: Simulate chunked (for testing multiple choices)
+        def allreduce_chunked(x, chunk_size=1024):
+            # For now, just call the regular allreduce
+            result = x.clone()
+            return torch.ops._c10d_functional.all_reduce_(result, "sum", "default")
+
+        # Register autotuning
+        from torch._inductor.kernel.custom_op import (
+            CustomOpConfig,
+            register_custom_op_autotuning,
+        )
+
+        register_custom_op_autotuning(
+            my_allreduce,
+            configs=[
+                CustomOpConfig(allreduce_nccl),
+                CustomOpConfig(allreduce_chunked, chunk_size=1024),
+            ],
+        )
+
+        # Test model
+        class SimpleModel(torch.nn.Module):
+            def forward(self, x):
+                return my_allreduce(x)
+
+        model = torch.compile(SimpleModel()).to(device)
+
+        # Run
+        x = torch.randn(128, 128, device=device)
+        x_copy = x.clone()
+        y = model(x)
+
+        # Verify: sum across 2 ranks
+        expected = x_copy * 2
+        torch.testing.assert_close(y, expected, rtol=1e-3, atol=1e-3)
+
+        if rank == 0:
+            print("Single allreduce test passed!")
+
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_collective_autotuning.py
+++ b/test/inductor/test_collective_autotuning.py
@@ -117,6 +117,8 @@ class TestCollectiveAutotuning4Ranks(MultiProcessTestCase):
             rank=self.rank,
         )
 
+        dist.barrier()
+
         rank = dist.get_rank()
         device = f"cuda:{rank}"
 
@@ -179,7 +181,7 @@ class TestCollectiveAutotuning4Ranks(MultiProcessTestCase):
 
         y = model(x)
         self.assertEqual(y.shape, x.shape)
-
+        dist.barrier()
         dist.destroy_process_group()
 
 

--- a/test/inductor/test_collective_autotuning.py
+++ b/test/inductor/test_collective_autotuning.py
@@ -177,7 +177,7 @@ class TestCollectiveAutotuning4Ranks(MultiProcessTestCase):
         model = torch.compile(VLLMAllReduceModel()).to(device)
 
         torch.manual_seed(42 + rank)
-        x = torch.randn(64, 128, device=device)
+        x = torch.randn(128, 256, device=device)
 
         y = model(x)
         self.assertEqual(y.shape, x.shape)

--- a/test/inductor/test_collective_autotuning.py
+++ b/test/inductor/test_collective_autotuning.py
@@ -1,15 +1,5 @@
 # Owner(s): ["module: inductor"]
 
-"""
-Test collective op autotuning - Phase 1: Basic functionality with 2 ranks.
-
-This test validates that:
-1. Collective ops are detected correctly
-2. CollectiveBenchmarker is used for collective ops
-3. 2 ranks can sync and benchmark successfully
-4. Results are correct
-"""
-
 import torch
 import torch.distributed as dist
 from torch.testing._internal.common_distributed import (
@@ -28,20 +18,17 @@ class TestCollectiveAutotuning(MultiProcessTestCase):
         super().setUp()
         self._spawn_processes()
 
-    @skip_if_lt_x_gpu(2)
-    def test_single_allreduce_2ranks(self):
-        """Test single all_reduce with 2 ranks"""
+    @skip_if_lt_x_gpu(4)
+    def test_all_gather_4ranks(self):
+        """Test all_gather with 4 ranks"""
 
         # Initialize distributed
         dist.init_process_group(
             backend="nccl",
-            init_method=f"file:///tmp/test_collective_autotune_{self.id()}",
+            init_method=f"file:///tmp/test_collective_allgather_4ranks_{self.id()}",
             world_size=self.world_size,
             rank=self.rank,
         )
-
-        # Add barrier to ensure all ranks are synchronized
-        dist.barrier()
 
         rank = dist.get_rank()
         device = f"cuda:{rank}"
@@ -51,27 +38,27 @@ class TestCollectiveAutotuning(MultiProcessTestCase):
 
         _register_process_group("default", dist.group.WORLD)
 
-        # Define custom collective op
-        @torch.library.custom_op("test::my_allreduce", mutates_args=())
-        def my_allreduce(x: torch.Tensor) -> torch.Tensor:
-            result = x.clone()
-            return torch.ops._c10d_functional.all_reduce_(result, "sum", "default")
+        # Define custom all_gather op
+        @torch.library.custom_op("test::my_allgather_4ranks", mutates_args=())
+        def my_allgather(x: torch.Tensor) -> torch.Tensor:
+            output = torch.ops._c10d_functional.all_gather_into_tensor(
+                x.contiguous(), 4, "default"
+            )
+            return output
 
-        # Fake implementation for abstract
-        @my_allreduce.register_fake
+        # Fake implementation
+        @my_allgather.register_fake
         def _(x):
-            return torch.empty_like(x)
+            return torch.empty(
+                x.size(0) * 4, *x.size()[1:], dtype=x.dtype, device=x.device
+            )
 
-        # Implementation 1: Direct NCCL
-        def allreduce_nccl(x):
-            result = x.clone()
-            return torch.ops._c10d_functional.all_reduce_(result, "sum", "default")
-
-        # Implementation 2: Simulate chunked (for testing multiple choices)
-        def allreduce_nccl2(x):
-            # For now, just call the regular allreduce
-            result = x.clone()
-            return torch.ops._c10d_functional.all_reduce_(result, "sum", "default")
+        # Implementation function
+        def allgather_impl(x):
+            output = torch.ops._c10d_functional.all_gather_into_tensor(
+                x.contiguous(), 4, "default"
+            )
+            return output
 
         # Register autotuning
         from torch._inductor.kernel.custom_op import (
@@ -80,27 +67,104 @@ class TestCollectiveAutotuning(MultiProcessTestCase):
         )
 
         register_custom_op_autotuning(
-            my_allreduce,
+            my_allgather,
             configs=[
-                CustomOpConfig(allreduce_nccl),
-                CustomOpConfig(allreduce_nccl2),
+                CustomOpConfig(allgather_impl),
             ],
         )
 
         # Test model
-        class SimpleModel(torch.nn.Module):
+        class GatherModel(torch.nn.Module):
             def forward(self, x):
-                return my_allreduce(x)
+                return my_allgather(x)
 
-        model = torch.compile(SimpleModel()).to(device)
+        model = torch.compile(GatherModel()).to(device)
 
-        x = torch.randn(128, 128, device=device)
-        x_copy = x.clone()
+        # Run
+        x = torch.ones(32, 64, device=device) * (rank + 1)
         y = model(x)
-        expected = x_copy * 2
-        torch.testing.assert_close(y, expected, rtol=1e-3, atol=1e-3)
 
-        # Ensure all ranks finish and then cleanup
+        # Verify shape
+        expected_shape = (32 * 4, 64)
+        self.assertEqual(y.shape, expected_shape)
+
+        if rank == 0:
+            print(
+                f"[4 ranks] All-gather test passed! Output shape: {y.shape}, World size: {self.world_size}"
+            )
+
+        dist.destroy_process_group()
+
+    @skip_if_lt_x_gpu(2)
+    def test_equivalent_allreduce_strategies(self):
+        """
+        Test autotuning between mathematically equivalent all_reduce strategies.
+
+        Strategy 1: sum all_reduce
+        Strategy 2: avg all_reduce * world_size
+
+        Both compute sum(x_i) but may have different performance characteristics.
+        """
+        dist.init_process_group(
+            backend="nccl",
+            init_method=f"file:///tmp/test_equiv_ar_{self.id()}",
+            world_size=self.world_size,
+            rank=self.rank,
+        )
+
+        dist.barrier()
+
+        rank = dist.get_rank()
+        world_size = dist.get_world_size()
+        device = f"cuda:{rank}"
+
+        from torch._C._distributed_c10d import _register_process_group
+
+        _register_process_group("default", dist.group.WORLD)
+
+        @torch.library.custom_op("test::equiv_ar", mutates_args=())
+        def equiv_ar(x: torch.Tensor) -> torch.Tensor:
+            result = x.clone()
+            return torch.ops._c10d_functional.all_reduce_(result, "sum", "default")
+
+        @equiv_ar.register_fake
+        def _(x):
+            return torch.empty_like(x)
+
+        def sum_allreduce(x: torch.Tensor) -> torch.Tensor:
+            result = x.clone()
+            return torch.ops._c10d_functional.all_reduce_(result, "sum", "default")
+
+        def avg_allreduce_scaled(x: torch.Tensor) -> torch.Tensor:
+            result = x.clone()
+            result = torch.ops._c10d_functional.all_reduce_(result, "avg", "default")
+            return result * world_size
+
+        from torch._inductor.kernel.custom_op import (
+            CustomOpConfig,
+            register_custom_op_autotuning,
+        )
+
+        register_custom_op_autotuning(
+            equiv_ar,
+            configs=[
+                CustomOpConfig(sum_allreduce),
+                CustomOpConfig(avg_allreduce_scaled),
+            ],
+        )
+
+        class EquivAllReduceModel(torch.nn.Module):
+            def forward(self, x):
+                return equiv_ar(x)
+
+        model = torch.compile(EquivAllReduceModel()).to(device)
+
+        torch.manual_seed(42)
+        x = torch.randn(128, 128, device=device)
+        dist.broadcast(x, src=0)
+
+        _ = model(x)
+
         dist.barrier()
         dist.destroy_process_group()
 

--- a/torch/_inductor/codegen/subgraph.py
+++ b/torch/_inductor/codegen/subgraph.py
@@ -169,17 +169,6 @@ class SubgraphChoiceCaller(ir.ChoiceCaller):
     def autoheuristic_id(self) -> str:
         return f"subgraph_{self.name}"
 
-    def supports_collective_benchmarking(self) -> bool:
-        """Check if this choice supports collective benchmarking.
-
-        SubgraphChoiceCaller supports collective benchmarking since it has
-        a graph module that can be benchmarked with barrier synchronization.
-
-        Returns:
-            True, indicating support for collective benchmarking
-        """
-        return True
-
 
 class SubgraphTemplate(KernelTemplate):
     """

--- a/torch/_inductor/codegen/subgraph.py
+++ b/torch/_inductor/codegen/subgraph.py
@@ -163,6 +163,7 @@ class SubgraphChoiceCaller(ir.ChoiceCaller):
         else:
             mod = self._compiled_module
             sym_inputs = self._compiled_sym_inputs
+            assert sym_inputs is not None  # Type narrowing
 
         bm_func = mod.call
         bm_func([*sym_inputs, *args])

--- a/torch/_inductor/codegen/subgraph.py
+++ b/torch/_inductor/codegen/subgraph.py
@@ -71,13 +71,20 @@ class SubgraphChoiceCaller(ir.ChoiceCaller):
 
         self.sym_inputs = get_symbolic_inputs(self.input_nodes)
 
+        # Cache compiled module to avoid recompiling on every benchmark call
+        self._compiled_module: Any = None
+        self._compiled_sym_inputs: list[Any] | None = None
+
     def __str__(self) -> str:
         return f"SubgraphCaller({self.name})"
 
-    def benchmark(self, *args: list[Any], out: torch.Tensor) -> float:
-        # Codegen Subgraph for benchmarking
-        # Need GraphLowering instead of SubgraphLowering to generate
-        # fully callable module
+    def _compile_for_benchmarking(self, *args: list[Any]) -> tuple[Any, list[Any]]:
+        """
+        Compile the subgraph for benchmarking and return (module, sym_inputs).
+
+        TODO: Add precompile() method to enable parallel compilation of all choices
+        before benchmarking.
+        """
         import torch._inductor.config as inductor_config
         from torch._inductor.graph import GraphLowering
 
@@ -125,9 +132,16 @@ class SubgraphChoiceCaller(ir.ChoiceCaller):
             ):
                 bm_graph_lowering.run(*self.example_inputs)
                 mod = bm_graph_lowering.compile_to_module()
-                bm_func = mod.call
 
-                bm_func([*sym_inputs, *args])
+        return mod, sym_inputs
+
+    def benchmark(self, *args: list[Any], out: torch.Tensor) -> float:
+        """
+        Regular benchmarking: compile and use benchmarker with warmup/rep.
+        """
+        mod, sym_inputs = self._compile_for_benchmarking(*args)
+
+        bm_func = mod.call
         if config.profile_bandwidth_with_do_bench_using_profiling:
             return do_bench_using_profiling(lambda: bm_func([*sym_inputs, *args]))
         return benchmarker.benchmark(
@@ -135,6 +149,24 @@ class SubgraphChoiceCaller(ir.ChoiceCaller):
             lambda: bm_func([*sym_inputs, *args]),
             device=benchmarker.infer_device(*sym_inputs, *args),
         )
+
+    def benchmark_collective(self, *args: list[Any], out: torch.Tensor) -> float:
+        """
+        Only run once with cached compiled module.
+        Called by benchmark_collective_choice which handles warmup
+        and timing with barrier synchronization across all ranks.
+        """
+        if self._compiled_module is None:
+            mod, sym_inputs = self._compile_for_benchmarking(*args)
+            self._compiled_module = mod
+            self._compiled_sym_inputs = sym_inputs
+        else:
+            mod = self._compiled_module
+            sym_inputs = self._compiled_sym_inputs
+
+        bm_func = mod.call
+        bm_func([*sym_inputs, *args])
+        return 0.0
 
     def hash_key(self) -> str:
         return "-".join(

--- a/torch/_inductor/codegen/subgraph.py
+++ b/torch/_inductor/codegen/subgraph.py
@@ -157,7 +157,7 @@ class SubgraphChoiceCaller(ir.ChoiceCaller):
             device=benchmarker.infer_device(*sym_inputs, *args),
         )
 
-    def benchmark_collective(self, *args: list[Any], out: torch.Tensor) -> float:
+    def benchmark_collective(self, *args: list[Any], out: torch.Tensor) -> None:
         """
         Only run once with cached compiled module.
         Called by benchmark_collective_choice which handles warmup
@@ -174,7 +174,6 @@ class SubgraphChoiceCaller(ir.ChoiceCaller):
 
         bm_func = mod.call
         bm_func([*sym_inputs, *args])
-        return 0.0
 
     def hash_key(self) -> str:
         return "-".join(

--- a/torch/_inductor/codegen/subgraph.py
+++ b/torch/_inductor/codegen/subgraph.py
@@ -81,8 +81,6 @@ class SubgraphChoiceCaller(ir.ChoiceCaller):
         import torch._inductor.config as inductor_config
         from torch._inductor.graph import GraphLowering
 
-        # Sanitize name to be a valid Python identifier
-        # Replace :: and other invalid characters with _
         safe_name = self.name.replace("::", "_").replace(".", "_")
 
         bm_graph_lowering = GraphLowering(

--- a/torch/_inductor/codegen/subgraph.py
+++ b/torch/_inductor/codegen/subgraph.py
@@ -139,7 +139,14 @@ class SubgraphChoiceCaller(ir.ChoiceCaller):
         """
         Regular benchmarking: compile and use benchmarker with warmup/rep.
         """
-        mod, sym_inputs = self._compile_for_benchmarking(*args)
+        if self._compiled_module is None:
+            mod, sym_inputs = self._compile_for_benchmarking(*args)
+            self._compiled_module = mod
+            self._compiled_sym_inputs = sym_inputs
+        else:
+            mod = self._compiled_module
+            sym_inputs = self._compiled_sym_inputs
+            assert sym_inputs is not None  # Type narrowing
 
         bm_func = mod.call
         if config.profile_bandwidth_with_do_bench_using_profiling:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -608,6 +608,19 @@ max_autotune_subproc_terminate_timeout_seconds = 0.0
 # If autotuning in subprocess, whether to use multiple devices
 autotune_multi_device = os.environ.get("TORCHINDUCTOR_AUTOTUNE_MULTI_DEVICE") == "1"
 
+# Timeout for collective operations during benchmarking (in seconds)
+# This applies to distributed collective operations like all_reduce
+# Default is 30 seconds. Can be overridden with env variable for testing.
+collective_benchmark_timeout_seconds = float(
+    os.environ.get("TORCHINDUCTOR_COLLECTIVE_BENCHMARK_TIMEOUT", "30")
+)
+
+# Number of benchmark runs for collective operations
+# Default is 10 runs, can be overridden with env variable
+collective_benchmark_nruns = int(
+    os.environ.get("TORCHINDUCTOR_COLLECTIVE_BENCHMARK_NRUNS", "10")
+)
+
 coordinate_descent_tuning = (
     os.environ.get("TORCHINDUCTOR_COORDINATE_DESCENT_TUNING") == "1"
 )

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -610,7 +610,7 @@ autotune_multi_device = os.environ.get("TORCHINDUCTOR_AUTOTUNE_MULTI_DEVICE") ==
 
 # Number of benchmark runs for collective operations
 collective_benchmark_nruns = int(
-    os.environ.get("TORCHINDUCTOR_COLLECTIVE_BENCHMARK_NRUNS", "10")
+    os.environ.get("TORCHINDUCTOR_COLLECTIVE_BENCHMARK_NRUNS", "30")
 )
 
 # Timeout in seconds for collective benchmarking

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -608,17 +608,14 @@ max_autotune_subproc_terminate_timeout_seconds = 0.0
 # If autotuning in subprocess, whether to use multiple devices
 autotune_multi_device = os.environ.get("TORCHINDUCTOR_AUTOTUNE_MULTI_DEVICE") == "1"
 
-# Timeout for collective operations during benchmarking (in seconds)
-# This applies to distributed collective operations like all_reduce
-# Default is 30 seconds. Can be overridden with env variable for testing.
-collective_benchmark_timeout_seconds = float(
-    os.environ.get("TORCHINDUCTOR_COLLECTIVE_BENCHMARK_TIMEOUT", "30")
-)
-
 # Number of benchmark runs for collective operations
-# Default is 10 runs, can be overridden with env variable
 collective_benchmark_nruns = int(
     os.environ.get("TORCHINDUCTOR_COLLECTIVE_BENCHMARK_NRUNS", "10")
+)
+
+# Timeout in seconds for collective benchmarking
+collective_benchmark_timeout = float(
+    os.environ.get("TORCHINDUCTOR_COLLECTIVE_BENCHMARK_TIMEOUT", "30")
 )
 
 coordinate_descent_tuning = (

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -610,7 +610,7 @@ autotune_multi_device = os.environ.get("TORCHINDUCTOR_AUTOTUNE_MULTI_DEVICE") ==
 
 # Number of benchmark runs for collective operations
 collective_benchmark_nruns = int(
-    os.environ.get("TORCHINDUCTOR_COLLECTIVE_BENCHMARK_NRUNS", "30")
+    os.environ.get("TORCHINDUCTOR_COLLECTIVE_BENCHMARK_NRUNS", "50")
 )
 
 # Timeout in seconds for collective benchmarking

--- a/torch/_inductor/kernel/custom_op.py
+++ b/torch/_inductor/kernel/custom_op.py
@@ -45,7 +45,9 @@ def _detect_collective_ops(choices: list) -> bool:
                 op_name = str(node.target)
 
                 # Check if this is a collective operation
-                if is_collective_op(op_name) or is_collective_op(f"torch.ops.{op_name}"):
+                if is_collective_op(op_name) or is_collective_op(
+                    f"torch.ops.{op_name}"
+                ):
                     return True
 
     return False

--- a/torch/_inductor/kernel/custom_op.py
+++ b/torch/_inductor/kernel/custom_op.py
@@ -321,6 +321,68 @@ def autotune_custom_op(
         )
         input_gen_fns = _adapt_user_input_gen_fns(inputs, arg_names, user_input_gen_fns)
 
+    # Detect collective operations for specialized benchmarking
+    is_collective = False
+    process_group = None
+
+    def check_graph_for_collective_ops(gm: torch.fx.GraphModule) -> bool:
+        """Check if a GraphModule contains any collective operations."""
+        from torch._inductor.utils import is_collective_op
+
+        for node in gm.graph.nodes:
+            if node.op == "call_function" and node.target is not None:
+                # node.target can be either a string or an OpOverload object
+                # Convert to string and check both with and without torch.ops. prefix
+                op_name = str(node.target)
+
+                # Try exact match first
+                if is_collective_op(op_name):
+                    return True
+
+                # Also try with torch.ops. prefix
+                full_op_name = f"torch.ops.{op_name}"
+                if is_collective_op(full_op_name):
+                    return True
+        return False
+
+    # Check if any choice contains collective ops
+    for choice in choices:
+        if hasattr(choice, "gm") and choice.gm is not None:
+            if check_graph_for_collective_ops(choice.gm):
+                is_collective = True
+                break
+
+    if is_collective:
+        # Extract process_group from non_tensor_args
+        for kwargs_dict in non_tensor_args:
+            if "group" in kwargs_dict:
+                process_group = kwargs_dict["group"]
+                break
+            elif "process_group" in kwargs_dict:
+                process_group = kwargs_dict["process_group"]
+                break
+
+        # Log collective op detection for debugging
+        import torch.distributed as dist
+
+        if dist.is_initialized():
+            rank = dist.get_rank(process_group)
+            world_size = dist.get_world_size(process_group)
+            log.info(
+                "[COLLECTIVE AUTOTUNE] autotune_custom_op: Detected collective op in subgraph on rank %d/%d (process_group=%s)",
+                rank,
+                world_size,
+                "default" if process_group is None else "custom",
+            )
+            log.info(
+                "[COLLECTIVE AUTOTUNE] autotune_custom_op: Will use collective benchmarking path for %d choices",
+                len(choices),
+            )
+        else:
+            log.debug(
+                "Detected collective op in subgraph (distributed not initialized)"
+            )
+
     # Run autotuning and get both result and winning choice
     selected_result, winning_choice = autotune_select_algorithm(
         name=name,
@@ -329,6 +391,8 @@ def autotune_custom_op(
         layout=choices[0].layout,
         input_gen_fns=input_gen_fns,
         return_choice=True,
+        is_collective=is_collective,
+        process_group=process_group,
     )
 
     # Apply inlining for fusion if winning_choice has graph; otherwise return result as-is(default fallback impl)

--- a/torch/_inductor/kernel/custom_op.py
+++ b/torch/_inductor/kernel/custom_op.py
@@ -24,15 +24,6 @@ log = logging.getLogger(__name__)
 def _detect_collective_ops(choices: list) -> bool:
     """
     Detect if choices contain collective operations.
-
-    For distributed training with collective ops, CollectiveBenchmarker will
-    automatically use the default process group for synchronization.
-
-    Args:
-        choices: List of algorithm choices to check
-
-    Returns:
-        True if any choice contains collective ops, False otherwise
     """
     from torch._inductor.utils import is_collective_op
 
@@ -44,7 +35,6 @@ def _detect_collective_ops(choices: list) -> bool:
             if node.op == "call_function" and node.target is not None:
                 op_name = str(node.target)
 
-                # Check if this is a collective operation
                 if is_collective_op(op_name) or is_collective_op(
                     f"torch.ops.{op_name}"
                 ):
@@ -353,7 +343,6 @@ def autotune_custom_op(
         )
         input_gen_fns = _adapt_user_input_gen_fns(inputs, arg_names, user_input_gen_fns)
 
-    # Detect collective operations for specialized benchmarking
     is_collective = _detect_collective_ops(choices)
 
     # Run autotuning and get both result and winning choice

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -3549,7 +3549,7 @@ class AlgorithmSelectorCache(PersistentCache):
             )
             work = dist.all_reduce(
                 time_tensor,
-                op=dist.ReduceOp.AVG,
+                op=dist.ReduceOp.MAX,
                 group=process_group,
                 async_op=True,
             )

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -3662,6 +3662,16 @@ class AlgorithmSelectorCache(PersistentCache):
 
             timings[choice] = timing
 
+            # If a collective choice failed or timed out, skip the rest of the choices
+            if is_collective and not math.isfinite(timing):
+                log.warning(
+                    "Choice %s failed or timed out during collective benchmarking. "
+                    "Stopping further benchmarking to avoid NCCL corruption.",
+                    getattr(choice, "name", "<unknown>"),
+                )
+                timings.update({c: float("inf") for c in choices if c not in timings})
+                break
+
         return timings
 
     @classmethod

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -3487,6 +3487,10 @@ class AlgorithmSelectorCache(PersistentCache):
 
             total_time += start_evt.elapsed_time(end_evt)
 
+        work = dist.barrier(group=process_group, async_op=True)
+        if not work.wait(timeout):
+            raise TimeoutError(f"Barrier timeout after completing {nruns} runs")
+
         return total_time
 
     @classmethod

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2309,6 +2309,10 @@ class TritonTemplateCaller(ir.TritonTemplateCallerBase):
 
 
 class ExternKernelCaller(ChoiceCaller):
+    """
+    Caller for external kernel implementations
+    """
+
     def __init__(
         self,
         choice: ExternKernelChoice,
@@ -3527,7 +3531,7 @@ class AlgorithmSelectorCache(PersistentCache):
                     return float("inf")
 
                 torch.cuda.synchronize()
-                choice.benchmark_collective(*inputs, out=output)
+                choice.benchmark_collective(*inputs, out=output)  # type: ignore[attr-defined]
                 torch.cuda.synchronize()
 
             total_time = 0.0
@@ -3557,7 +3561,7 @@ class AlgorithmSelectorCache(PersistentCache):
                 end_evt = torch.cuda.Event(enable_timing=True)
 
                 start_evt.record()
-                choice.benchmark_collective(*inputs, out=output)
+                choice.benchmark_collective(*inputs, out=output)  # type: ignore[attr-defined]
                 end_evt.record()
                 end_evt.synchronize()
 

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -3433,11 +3433,9 @@ class AlgorithmSelectorCache(PersistentCache):
 
         import torch.distributed as dist
 
-        timeout_seconds = float(
-            os.environ.get("TORCHINDUCTOR_COLLECTIVE_BENCHMARK_TIMEOUT", "30")
-        )
+        timeout_seconds = config.collective_benchmark_timeout
 
-        nruns = int(os.environ.get("TORCHINDUCTOR_COLLECTIVE_BENCHMARK_NRUNS", "10"))
+        nruns = config.collective_benchmark_nruns
 
         # Use default process group (None = all ranks)
         process_group = None

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -3390,8 +3390,6 @@ class AlgorithmSelectorCache(PersistentCache):
         output.zero_()
 
         result = choice.benchmark(*inputs, out=output)
-
-        # Synchronize device to shake out any CUDA errors
         device_type = next(
             (tensor.device.type for tensor in inputs if is_gpu(tensor.device.type)),
             "cuda",
@@ -3400,10 +3398,8 @@ class AlgorithmSelectorCache(PersistentCache):
         if device_interface.is_available():
             device_interface.synchronize()  # shake out any CUDA errors
 
-        # Verify output if requested
         if VERIFY and autotune_args.expected is not None:
             autotune_args.verify(**VERIFY)
-
         return result
 
     @classmethod

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2818,6 +2818,7 @@ class AlgorithmSelectorCache(PersistentCache):
             choices,
             precompile_fn,
             best_config_future=best_config_future,
+            is_collective=is_collective,
         )
         # if timings is empty, we really have no choice but to return a semi-random
         # choice. returning the first `ExternKernelCaller` is probably the safest bet
@@ -2861,12 +2862,18 @@ class AlgorithmSelectorCache(PersistentCache):
         layout,
         input_gen_fns,
         hint_override: Optional[int] = None,
+        is_collective=False,
     ):
         counters["inductor"]["select_algorithm_autotune"] += 1
         # TODO(nmacchioni): remove this layer of abstraction
         # construct `benchmark_fn` which should pick between in-process and sub-process autotuning
         benchmark_fn = self.make_benchmark_fn(
-            choices, input_nodes, layout, input_gen_fns, hint_override=hint_override
+            choices,
+            input_nodes,
+            layout,
+            input_gen_fns,
+            hint_override=hint_override,
+            is_collective=is_collective,
         )
         # `benchmark_fn(choices)` will execute each choice, and return a dict[choice, timing] which
         # maps each choice to its runtime, calculated by the specified benchmarker, in milliseconds
@@ -2880,6 +2887,7 @@ class AlgorithmSelectorCache(PersistentCache):
         input_gen_fns,
         choices,
         hint_override: Optional[int] = None,
+        is_collective=False,
     ):
         log.debug("Starting autotuning")
 
@@ -2890,7 +2898,12 @@ class AlgorithmSelectorCache(PersistentCache):
             metadata=_autotune_metadata(input_nodes),
         ):
             benchmark_results = self.benchmark(
-                choices, input_nodes, layout, input_gen_fns, hint_override=hint_override
+                choices,
+                input_nodes,
+                layout,
+                input_gen_fns,
+                hint_override=hint_override,
+                is_collective=is_collective,
             )
             if config.max_autotune_report_choices_stats:
                 _log_autotune_choices_stats(
@@ -2909,6 +2922,7 @@ class AlgorithmSelectorCache(PersistentCache):
         precompile_fn,
         hint_override: Optional[int] = None,
         best_config_future=None,
+        is_collective=False,
     ):
         """Execute the autotuning process for kernel algorithm selection.
 
@@ -3023,6 +3037,7 @@ class AlgorithmSelectorCache(PersistentCache):
                 input_gen_fns,
                 choices,
                 hint_override=hint_override,
+                is_collective=is_collective,
             )
 
         timings = self.lookup(

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -4098,3 +4098,31 @@ def should_fallback_by_default(node: torch.fx.Node) -> bool:
         return target in fallback_hops
 
     return not _needs_inductor_compile(node)
+
+
+# Collective operation names for specialized benchmarking
+COLLECTIVE_OPS = OrderedSet(
+    [
+        "torch.ops._c10d_functional.all_reduce.default",
+        "torch.ops._c10d_functional.all_reduce_.default",
+        "torch.ops._c10d_functional.all_gather_into_tensor.default",
+        "torch.ops._c10d_functional.reduce_scatter_tensor.default",
+        "torch.ops._c10d_functional.all_to_all_single.default",
+        "torch.ops._c10d_functional_autograd.all_reduce.default",
+        "torch.ops._c10d_functional_autograd.all_gather_into_tensor.default",
+        "torch.ops._c10d_functional_autograd.reduce_scatter_tensor.default",
+        "torch.ops._c10d_functional_autograd.all_to_all_single.default",
+    ]
+)
+
+
+def is_collective_op(op_name: str) -> bool:
+    """Check if an operation is a collective operation.
+
+    Args:
+        op_name: Name of the operation to check
+
+    Returns:
+        True if the operation is a collective op, False otherwise
+    """
+    return op_name in COLLECTIVE_OPS

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -4117,12 +4117,5 @@ COLLECTIVE_OPS = OrderedSet(
 
 
 def is_collective_op(op_name: str) -> bool:
-    """Check if an operation is a collective operation.
-
-    Args:
-        op_name: Name of the operation to check
-
-    Returns:
-        True if the operation is a collective op, False otherwise
-    """
+    """Check if an operation is a collective operation."""
     return op_name in COLLECTIVE_OPS


### PR DESCRIPTION
Add collective op autotuning with distributed benchmarking

Collective operations can have multiple equivalent implementations with different performance. Existing autotuning only supports single-process benchmarking, making it impossible to autotune collective ops that require multi-rank coordination.

**Summary:**
    
Added distributed benchmarking via `benchmark_collective_choice()` and `register_custom_op_autotuning()` API. All ranks are synchronized and benchmarked at the same time to ensure a fair comparison. The benchmark across all possible ranks(world_size) has a timeout detection(default 30s, configurable in configs.py) and exception handling to prevent deadlocks. If any rank times out or encounters an exception, all ranks fallback to regular benchmark together.


**Example:**
```python
# Define custom op with multiple implementations
@torch.library.custom_op("mylib::allreduce", mutates_args=())
def my_allreduce(x: torch.Tensor) -> torch.Tensor:
    return torch.ops._c10d_functional.all_reduce_(x.clone(), "sum", "default")

# Register autotuning choices
register_custom_op_autotuning(
    my_allreduce,
    configs=[
        CustomOpConfig(lambda x: all_reduce_(x.clone(), "sum", "default")),
        CustomOpConfig(lambda x: all_reduce_(x.clone(), "avg", "default") * world_size),
    ],
)

# Compile and autotune
model = torch.compile(MyModel())
output = model(input)  # Autotuning happens here
```

**Implementation:**
Different from regular benchmark which calls benchmarker.benchmark with warmup and rep, collective op benchmarking should handle barrier synchronization and timing. So I created `collective_benchmark` for subgraphcaller choice to only run the implementation once with cached compiled modules. Then the timing and synchronization will be handled in select_algorithm.py

**example log**
```
Autotune Choices Stats:
{"num_choices": 3, "num_triton_choices": 0, "best_kernel": "test::vllm_allreduce_autotuned_nccl_allreduce_direct_1", "best_kernel_desc": "CustomOp nccl_allreduce_direct", "best_time": 0.004397066775709391}
Autotune Choices Stats:
{"num_choices": 3, "num_triton_choices": 0, "best_kernel": "test::vllm_allreduce_autotuned_nccl_allreduce_direct_1", "best_kernel_desc": "CustomOp nccl_allreduce_direct", "best_time": 0.004397066775709391}
Autotune Choices Stats:
{"num_choices": 3, "num_triton_choices": 0, "best_kernel": "test::vllm_allreduce_autotuned_nccl_allreduce_direct_1", "best_kernel_desc": "CustomOp nccl_allreduce_direct", "best_time": 0.004397066775709391}
Autotune Choices Stats:
{"num_choices": 3, "num_triton_choices": 0, "best_kernel": "test::vllm_allreduce_autotuned_nccl_allreduce_direct_1", "best_kernel_desc": "CustomOp nccl_allreduce_direct", "best_time": 0.004397066775709391}
[rank0]:W1126 14:09:52.629000 394749 torch/_inductor/select_algorithm.py:3996] [0/0] [COLLECTIVE AUTOTUNING] All timings:
[rank0]:W1126 14:09:52.630000 394749 torch/_inductor/select_algorithm.py:3999] [0/0]   - test::vllm_allreduce_autotuned_nccl_allreduce_direct_1: 0.004397 ms ← SELECTED
[rank0]:W1126 14:09:52.630000 394749 torch/_inductor/select_algorithm.py:3999] [0/0]   - test::vllm_allreduce_autotuned_vllm_buffer_copy_allreduce_0: 0.004507 ms
[rank0]:W1126 14:09:52.630000 394749 torch/_inductor/select_algorithm.py:3999] [0/0]   - test::vllm_allreduce_autotuned_fallback_default: 0.012899 ms
```

**Test Plan:**

*   Added `test_equivalent_allreduce_strategies` (2 ranks) and `test_all_gather_4ranks` (4 ranks)
*   Verified timeout detection and exception handling prevent deadlocks


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos @chenyang78