### PR TITLE
[TorchElastic] fix #135712, clear MASTER_ADDR in store on agent shutdown

### DIFF
--- a/torch/distributed/elastic/agent/server/local_elastic_agent.py
+++ b/torch/distributed/elastic/agent/server/local_elastic_agent.py
@@ -36,6 +36,7 @@ from torch.distributed.elastic.multiprocessing import (
     PContext,
     start_processes,
 )
+from torch.distributed.elastic.rendezvous.api import RendezvousStoreInfo
 from torch.distributed.elastic.utils import macros
 from torch.distributed.elastic.utils.logging import get_logger
 
@@ -371,6 +372,8 @@ class LocalElasticAgent(SimpleElasticAgent):
             self._health_check_server = None
         if self._pcontext:
             self._pcontext.close(death_sig)
+        if self._rdzv_handler and self._rdzv_handler.use_agent_store:
+            RendezvousStoreInfo.clean_up(self._store)
 
     # pyre-fixme[56]: Pyre was not able to infer the type of the decorator
     #  `torch.distributed.elastic.metrics.prof`.

--- a/torch/distributed/elastic/rendezvous/api.py
+++ b/torch/distributed/elastic/rendezvous/api.py
@@ -11,7 +11,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, ClassVar, Optional
 
-from torch.distributed import Store
+from torch.distributed import Store, TCPStore
 from torch.distributed.elastic.utils.distributed import get_free_port
 
 
@@ -104,6 +104,14 @@ class RendezvousStoreInfo:
             store.get(RendezvousStoreInfo.MASTER_PORT_KEY).decode(encoding="UTF-8")
         )
         return RendezvousStoreInfo(master_addr=addr, master_port=port)
+
+    @staticmethod
+    def clean_up(store: Store) -> None:
+        """Clear master_addr/master_port keys from the store."""
+        # TODO: support EtcdStore after it supports delete_key
+        if isinstance(store, TCPStore):
+            store.delete_key(RendezvousStoreInfo.MASTER_ADDR_KEY)
+            store.delete_key(RendezvousStoreInfo.MASTER_PORT_KEY)
 
 
 class RendezvousInfo:


### PR DESCRIPTION
 #135712 left an unsolved problem: while use_agent_store is enabled by default, if a node failure occurs on the host where rank0 resides, the fault tolerance of torch elastic fails because the stale MASTER_ADDR persists in the Store.
This PR fixes the issue.

Related PR #152525

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci