### PR TITLE
Fix distributed plugin backend _set_default_backend fail bug

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -1999,7 +1999,7 @@ def _new_process_group_helper(
             pg._set_default_backend(ProcessGroup.BackendType.NCCL)
         elif Backend._plugins.keys():
             custom_backend = next(iter(Backend._plugins.keys()))
-            if custom_backend in backend_config.device_backend_map.values():
+            if custom_backend.lower() in backend_config.device_backend_map.values():
                 pg._set_default_backend(ProcessGroup.BackendType.CUSTOM)
         else:
             pg._set_default_backend(ProcessGroup.BackendType.GLOO)


### PR DESCRIPTION
1. The backend name obtained by custom_backend is always in uppercase;
2. Howerver, backend_config.device_backend_map get user defined backend name always lowercase;
3. So this line:  if custom_backend in backend_config.device_backend_map.values() alway False, this may be a bug.



cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci