### PR TITLE
Fix integer overflow in (fake) quantization

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -2807,21 +2807,16 @@ void _fake_quant_per_channel_cachemask_cpu_helper(
       // write mask
       cpu_kernel(iter_mask, [=](SelfType self, float scale, scalar_t zero_point) -> bool {
         float inv_scale = 1.0f / scale;
-        const auto qval = std::lrintf(zero_point + (self * inv_scale));
+        const auto qval = std::round(zero_point + (self * inv_scale));
         return ((quant_min <= qval) && (qval <= quant_max));
       });
 
       // write fake_quant
       cpu_kernel(iter, [=](SelfType self, float scale, scalar_t zero_point) -> SelfType {
         float inv_scale = 1.0f / scale;
-        // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-        return (std::fmin(
-                    std::fmax(
-                        std::lrintf(zero_point + self * inv_scale),
-                        quant_min),
-                    quant_max) -
-                zero_point) *
-            scale;
+        const auto qval = std::round(self * inv_scale + zero_point);
+        const auto bounded_qval = std::fmin(quant_max, std::fmax(quant_min, qval));
+        return (bounded_qval - zero_point) * scale;
       });
     });
 
@@ -2829,22 +2824,16 @@ void _fake_quant_per_channel_cachemask_cpu_helper(
       // write mask
       cpu_kernel(iter_mask, [=](SelfType self, float scale, int32_t zero_point) -> bool {
         float inv_scale = 1.0f / scale;
-        const auto qval = static_cast<int64_t>(zero_point + std::nearbyint(self * inv_scale));
+        const auto qval = std::round(zero_point + (self * inv_scale));
         return ((quant_min <= qval) && (qval <= quant_max));
       });
 
       // write fake_quant
       cpu_kernel(iter, [=](SelfType self, float scale, int32_t zero_point) -> SelfType {
         float inv_scale = 1.0f / scale;
-        // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-        return (std::fmin(
-                    std::fmax(
-                        static_cast<int64_t>(
-                            zero_point + std::nearbyint(self * inv_scale)),
-                        quant_min),
-                    quant_max) -
-                zero_point) *
-            scale;
+        const auto qval = std::round(self * inv_scale + zero_point);
+        const auto bounded_qval = std::fmin(quant_max, std::fmax(quant_min, qval));
+        return (bounded_qval - zero_point) * scale;
       });
   }
 

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -2807,14 +2807,14 @@ void _fake_quant_per_channel_cachemask_cpu_helper(
       // write mask
       cpu_kernel(iter_mask, [=](SelfType self, float scale, scalar_t zero_point) -> bool {
         float inv_scale = 1.0f / scale;
-        const auto qval = std::round(zero_point + (self * inv_scale));
+        const auto qval = std::nearbyint(zero_point + (self * inv_scale));
         return ((quant_min <= qval) && (qval <= quant_max));
       });
 
       // write fake_quant
       cpu_kernel(iter, [=](SelfType self, float scale, scalar_t zero_point) -> SelfType {
         float inv_scale = 1.0f / scale;
-        const auto qval = std::round(self * inv_scale + zero_point);
+        const auto qval = std::nearbyint(self * inv_scale + zero_point);
         const auto bounded_qval = std::fmin(quant_max, std::fmax(quant_min, qval));
         return (bounded_qval - zero_point) * scale;
       });
@@ -2824,14 +2824,14 @@ void _fake_quant_per_channel_cachemask_cpu_helper(
       // write mask
       cpu_kernel(iter_mask, [=](SelfType self, float scale, int32_t zero_point) -> bool {
         float inv_scale = 1.0f / scale;
-        const auto qval = std::round(zero_point + (self * inv_scale));
+        const auto qval = std::nearbyint(zero_point + (self * inv_scale));
         return ((quant_min <= qval) && (qval <= quant_max));
       });
 
       // write fake_quant
       cpu_kernel(iter, [=](SelfType self, float scale, int32_t zero_point) -> SelfType {
         float inv_scale = 1.0f / scale;
-        const auto qval = std::round(self * inv_scale + zero_point);
+        const auto qval = std::nearbyint(self * inv_scale + zero_point);
         const auto bounded_qval = std::fmin(quant_max, std::fmax(quant_min, qval));
         return (bounded_qval - zero_point) * scale;
       });

--- a/aten/src/ATen/native/quantized/cuda/FakeQuantizeCore.cu
+++ b/aten/src/ATen/native/quantized/cuda/FakeQuantizeCore.cu
@@ -188,7 +188,7 @@ void _fake_quant_per_channel_cachemask_cuda_helper(
       gpu_kernel(iter_mask,
         [=] GPU_LAMBDA (const SelfType input_val, const float scale, const scalar_t zero_point) -> bool {
           const float inv_scale = 1.0f / scale;
-          const auto qval = std::round(input_val * inv_scale + zero_point);
+          const auto qval = std::nearbyint(input_val * inv_scale + zero_point);
           return ((quant_min <= qval) && (qval <= quant_max));
       });
 
@@ -196,7 +196,7 @@ void _fake_quant_per_channel_cachemask_cuda_helper(
       gpu_kernel(iter,
         [=] GPU_LAMBDA (const SelfType input_val, const float scale, const scalar_t zero_point) -> SelfType {
           const float inv_scale = 1.0f / scale;
-          const auto qval = std::round(input_val * inv_scale + zero_point);
+          const auto qval = std::nearbyint(input_val * inv_scale + zero_point);
           const auto bounded_qval = std::fmin(quant_max, std::fmax(quant_min, qval));
           return (bounded_qval - zero_point) * scale;
       });
@@ -207,7 +207,7 @@ void _fake_quant_per_channel_cachemask_cuda_helper(
     gpu_kernel(iter_mask,
       [=] GPU_LAMBDA (const SelfType input_val, const float scale, const int64_t zero_point) -> bool {
         const float inv_scale = 1.0f / scale;
-        const auto qval = std::round(input_val * inv_scale + zero_point);
+        const auto qval = std::nearbyint(input_val * inv_scale + zero_point);
         return ((quant_min <= qval) && (qval <= quant_max));
     });
 
@@ -215,7 +215,7 @@ void _fake_quant_per_channel_cachemask_cuda_helper(
     gpu_kernel(iter,
       [=] GPU_LAMBDA (const SelfType input_val, const float scale, const int64_t zero_point) -> SelfType {
         const float inv_scale = 1.0f / scale;
-        const auto qval = std::round(input_val * inv_scale + zero_point);
+        const auto qval = std::nearbyint(input_val * inv_scale + zero_point);
         const auto bounded_qval = std::fmin(quant_max, std::fmax(quant_min, qval));
         return (bounded_qval - zero_point) * scale;
     });

--- a/aten/src/ATen/native/quantized/cuda/FakeQuantizeCore.cu
+++ b/aten/src/ATen/native/quantized/cuda/FakeQuantizeCore.cu
@@ -5,6 +5,7 @@
 #include <ATen/native/cuda/Loops.cuh>
 #include <thrust/tuple.h>
 #include <cmath>
+#include <type_traits>
 
 /* Fake quantize a tensor
 Args:
@@ -163,6 +164,38 @@ REGISTER_DISPATCH(fake_quant_tensor_cachemask_stub, &fake_quantize_tensor_cachem
 REGISTER_DISPATCH(fake_quant_tensor_cachemask_tensor_qparams_stub, &fake_quantize_tensor_cachemask_tensor_qparams_kernel_cuda)
 REGISTER_DISPATCH(fake_quant_grad_learnable_tensor_stub, &_fake_quantize_grad_learnable_tensor_kernel_cuda)
 
+// Type to be used for min/max operations on floating point types
+// - long double if either input is long double
+// - double if either input is double or an integer type
+// - float otherwise
+template<typename T1, typename T2>
+struct fmin_max_type {
+  static constexpr bool has_long_double = std::is_same_v<T1, long double> || std::is_same_v<T2, long double>;
+  static constexpr bool has_double = std::is_same_v<T1, double> || std::is_same_v<T2, double>;
+  static constexpr bool has_int = std::is_integral_v<T1> || std::is_integral_v<T2>;
+
+  using type = std::conditional_t<has_long_double, long double,
+                                  std::conditional_t<has_double || has_int, double, float>
+                                 >;
+};
+template<typename T1, typename T2>
+using fmin_max_t = typename fmin_max_type<T1, T2>::type;
+
+// fmin/fmax-like functions available on host & device
+// Doesn't handle NaNs or signed zero as std::fmin/fmax do
+
+template<typename T1, typename T2>
+__host__ __device__ auto _fmin(T1 a, T2 b) {
+  using result_t = fmin_max_t<T1, T2>;
+  return std::min(static_cast<result_t>(a), static_cast<result_t>(b));
+}
+
+template<typename T1, typename T2>
+__host__ __device__ auto _fmax(T1 a, T2 b) {
+  using result_t = fmin_max_t<T1, T2>;
+  return std::max(static_cast<result_t>(a), static_cast<result_t>(b));
+}
+
 // Fake quantize per channel
 
 template<typename SelfType>
@@ -197,7 +230,7 @@ void _fake_quant_per_channel_cachemask_cuda_helper(
         [=] GPU_LAMBDA (const SelfType input_val, const float scale, const scalar_t zero_point) -> SelfType {
           const float inv_scale = 1.0f / scale;
           const auto qval = std::nearbyint(input_val * inv_scale + zero_point);
-          const auto bounded_qval = std::fmin(quant_max, std::fmax(quant_min, qval));
+          const auto bounded_qval = _fmin(quant_max, _fmax(quant_min, qval));
           return (bounded_qval - zero_point) * scale;
       });
     });
@@ -216,7 +249,7 @@ void _fake_quant_per_channel_cachemask_cuda_helper(
       [=] GPU_LAMBDA (const SelfType input_val, const float scale, const int64_t zero_point) -> SelfType {
         const float inv_scale = 1.0f / scale;
         const auto qval = std::nearbyint(input_val * inv_scale + zero_point);
-        const auto bounded_qval = std::fmin(quant_max, std::fmax(quant_min, qval));
+        const auto bounded_qval = _fmin(quant_max, _fmax(quant_min, qval));
         return (bounded_qval - zero_point) * scale;
     });
   }

--- a/aten/src/ATen/native/quantized/cuda/FakeQuantizeCore.cu
+++ b/aten/src/ATen/native/quantized/cuda/FakeQuantizeCore.cu
@@ -188,7 +188,7 @@ void _fake_quant_per_channel_cachemask_cuda_helper(
       gpu_kernel(iter_mask,
         [=] GPU_LAMBDA (const SelfType input_val, const float scale, const scalar_t zero_point) -> bool {
           const float inv_scale = 1.0f / scale;
-          const auto qval = std::lrint(input_val * inv_scale + zero_point);
+          const auto qval = std::round(input_val * inv_scale + zero_point);
           return ((quant_min <= qval) && (qval <= quant_max));
       });
 
@@ -196,8 +196,8 @@ void _fake_quant_per_channel_cachemask_cuda_helper(
       gpu_kernel(iter,
         [=] GPU_LAMBDA (const SelfType input_val, const float scale, const scalar_t zero_point) -> SelfType {
           const float inv_scale = 1.0f / scale;
-          const auto qval = std::lrint(input_val * inv_scale + zero_point);
-          const auto bounded_qval = fminf(quant_max, fmaxf(quant_min, qval));
+          const auto qval = std::round(input_val * inv_scale + zero_point);
+          const auto bounded_qval = std::fmin(quant_max, std::fmax(quant_min, qval));
           return (bounded_qval - zero_point) * scale;
       });
     });
@@ -207,7 +207,7 @@ void _fake_quant_per_channel_cachemask_cuda_helper(
     gpu_kernel(iter_mask,
       [=] GPU_LAMBDA (const SelfType input_val, const float scale, const int64_t zero_point) -> bool {
         const float inv_scale = 1.0f / scale;
-        const auto qval = static_cast<int64_t>(std::nearbyint(input_val * inv_scale)) + zero_point;
+        const auto qval = std::round(input_val * inv_scale + zero_point);
         return ((quant_min <= qval) && (qval <= quant_max));
     });
 
@@ -215,8 +215,8 @@ void _fake_quant_per_channel_cachemask_cuda_helper(
     gpu_kernel(iter,
       [=] GPU_LAMBDA (const SelfType input_val, const float scale, const int64_t zero_point) -> SelfType {
         const float inv_scale = 1.0f / scale;
-        const auto qval = static_cast<int64_t>(std::nearbyint(input_val * inv_scale)) + zero_point;
-        const auto bounded_qval = std::min(quant_max, std::max(quant_min, qval));
+        const auto qval = std::round(input_val * inv_scale + zero_point);
+        const auto bounded_qval = std::fmin(quant_max, std::fmax(quant_min, qval));
         return (bounded_qval - zero_point) * scale;
     });
   }


### PR DESCRIPTION
The `static_cast<int64_t>` can overflow for large float values and/or a small scale (e.g. 9.2e14 & 1e-4)
Fix a similar issue in the mask calculation where `std::lrint` is used which may convert to a 32 bit float returning an implementation defined value on overflow.

Stay in float mode using `std::round` and `fmin/fmax` to avoid this.

Fixes #111471

I actually fixed the CUDA code first and copied that.

I didn't touch the code duplication which can likely be removed by using a fitting `AT_DISPATCH` but for some reason the zero_point is `int32_t` while the limits are `int64_t` which to me doesn't make much sense and the actual type could always be used.

See https://github.com/pytorch/pytorch/pull/129127

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01