### PR TITLE
Build cpuinfo into c10 shared library

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -774,10 +774,6 @@ if(USE_MKLDNN_ACL)
     list(APPEND ATen_CPU_DEPENDENCY_LIBS ${ACL_LIBRARIES})
 endif()
 
-if(NOT CMAKE_SYSTEM_PROCESSOR MATCHES "^(s390x|ppc64le)$")
-  list(APPEND ATen_CPU_DEPENDENCY_LIBS cpuinfo)
-endif()
-
 if(NOT EMSCRIPTEN AND NOT INTERN_BUILD_MOBILE)
   if(NOT MSVC)
     # Bump up optimization level for sleef to -O1, since at -O0 the compiler

--- a/c10/CMakeLists.txt
+++ b/c10/CMakeLists.txt
@@ -107,7 +107,8 @@ if(NOT BUILD_LIBTORCHLESS)
   endif()
 
   if(NOT CMAKE_SYSTEM_PROCESSOR MATCHES "s390x" AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64le")
-    target_link_libraries(c10 PRIVATE cpuinfo)
+    target_link_libraries(c10 INTERFACE cpuinfo)
+    target_link_libraries(c10 PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,cpuinfo>")
   endif()
 
   find_package(Backtrace)

--- a/c10/CMakeLists.txt
+++ b/c10/CMakeLists.txt
@@ -107,7 +107,7 @@ if(NOT BUILD_LIBTORCHLESS)
   endif()
 
   if(NOT CMAKE_SYSTEM_PROCESSOR MATCHES "^(s390x|ppc64le)$")
-    target_link_libraries(c10 INTERFACE cpuinfo)
+    target_link_libraries(c10 INTERFACE "$<BUILD_INTERFACE:cpuinfo>")
     target_link_libraries(c10 PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,cpuinfo>")
   endif()
 

--- a/c10/CMakeLists.txt
+++ b/c10/CMakeLists.txt
@@ -106,7 +106,7 @@ if(NOT BUILD_LIBTORCHLESS)
     message(STATUS "don't use NUMA")
   endif()
 
-  if(NOT CMAKE_SYSTEM_PROCESSOR MATCHES "s390x" AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64le")
+  if(NOT CMAKE_SYSTEM_PROCESSOR MATCHES "^(s390x|ppc64le)$")
     target_link_libraries(c10 INTERFACE cpuinfo)
     target_link_libraries(c10 PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,cpuinfo>")
   endif()

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -501,7 +501,6 @@ if(NOT CMAKE_SYSTEM_PROCESSOR MATCHES "^(s390x|ppc64le)$")
     # them into a shared library for Caffe2, so they need PIC.
     set_property(TARGET cpuinfo PROPERTY POSITION_INDEPENDENT_CODE ON)
   endif()
-  list(APPEND Caffe2_DEPENDENCY_LIBS cpuinfo)
 endif()
 
 


### PR DESCRIPTION
This change links the entirety of libcpuinfo into libc10, and removes libtorch_cpu's direct dependency on libcpuinfo.

This fixes a bug on where on some systems CMake reorders static and shared libraries in linker invocations, which results in the same object defined in both libc10 and libtorch_cpu. Since libtorch_cpu already depends on libc10, I think it makes sense to make libcpuinfo part of libc10's interface.

Fixes #166703


cc @seemethere @malfet @atalman @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @snadampal @milpuz01 @nikhil-arm @fadara01