### PR TITLE
Cache the pinned_use_background_threads value in host allocator

### DIFF
--- a/aten/src/ATen/xpu/CachingHostAllocator.cpp
+++ b/aten/src/ATen/xpu/CachingHostAllocator.cpp
@@ -9,6 +9,8 @@ using Block = HostBlock<XPUStream>;
 
 struct XPUCachingHostAllocatorImpl
     : public CachingHostAllocatorImpl<XPUStream, XPUEvent> {
+  XPUCachingHostAllocatorImpl() : active_(false) {}
+
   /* These following functions are runtime-related. */
   void allocate_host_memory(size_t size, void** ptr) override {
     *ptr = sycl::aligned_alloc_host(


### PR DESCRIPTION
There have been report of flaky crash that `~CachingHostAllocatorImpl()` is creating a new AcceleratorAllocatorConfig which fails to parse and errors out.

The flakyness there is most likely due to static initialization order fiasco and the fact that this config was never initialized before.

Not 100% sure but this should be a noop anyways, so trying it out.