### PR TITLE
subproc_pool: Fix quiesce waitcounter

### DIFF
--- a/torch/_inductor/compile_worker/subproc_pool.py
+++ b/torch/_inductor/compile_worker/subproc_pool.py
@@ -321,7 +321,7 @@ class SubprocPool:
         self._send(MsgHeader.QUIESCE)
         if self.quiesce_waitcounter is None:
             self.quiesce_waitcounter = _WaitCounter(
-                "pytorch.wait_counter.subproc_pool.running"
+                "pytorch.wait_counter.subproc_pool.quiesced"
             ).guard()
             self.quiesce_waitcounter.__enter__()
 


### PR DESCRIPTION
Summary:
I was inspecting running jobs, and the quiesce waitcounter wasn't showing up.
Turns out this was a bad copy paste.

Test Plan: Primarily inspection

Reviewed By: masnesral

Differential Revision: D86457409




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben