### PR TITLE
Enable SIM118

### DIFF
--- a/.ci/lumen_cli/cli/lib/common/gh_summary.py
+++ b/.ci/lumen_cli/cli/lib/common/gh_summary.py
@@ -117,7 +117,7 @@ def md_kv_table(rows: Iterable[Mapping[str, str | int | float]]) -> str:
     Render a list of dicts as a Markdown table using Jinja template.
     """
     rows = list(rows)
-    cols = list({k for r in rows for k in r.keys()})
+    cols = list({k for r in rows for k in r})
     md = _TPL_TABLE.render(cols=cols, rows=rows).strip() + "\n"
     return md
 

--- a/.github/scripts/get_workflow_job_id.py
+++ b/.github/scripts/get_workflow_job_id.py
@@ -88,7 +88,7 @@ def fetch_jobs(url: str, headers: dict[str, str]) -> list[dict[str, str]]:
     response, links = fetch_url(url, headers=headers, reader=parse_json_and_links)
     jobs = response["jobs"]
     assert type(jobs) is list
-    while "next" in links.keys():
+    while "next" in links:
         response, links = fetch_url(
             links["next"]["url"], headers=headers, reader=parse_json_and_links
         )

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -435,15 +435,13 @@ class TestTryMerge(TestCase):
         pr = GitHubPR("pytorch", "pytorch", 105260)
         conclusions = pr.get_checkrun_conclusions()
         self.assertEqual(len(conclusions), 221)
-        self.assertTrue(
-            "pull / linux-docs / build-docs-cpp-false" in conclusions.keys()
-        )
+        self.assertTrue("pull / linux-docs / build-docs-cpp-false" in conclusions)
 
     def test_cancelled_gets_ignored(self, *args: Any) -> None:
         """Tests that cancelled workflow does not override existing successful status"""
         pr = GitHubPR("pytorch", "pytorch", 110367)
         conclusions = pr.get_checkrun_conclusions()
-        lint_checks = [name for name in conclusions.keys() if "Lint" in name]
+        lint_checks = [name for name in conclusions if "Lint" in name]
         self.assertTrue(len(lint_checks) > 0)
         self.assertTrue(
             all(conclusions[name].status == "SUCCESS" for name in lint_checks)

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -2232,12 +2232,12 @@ def categorize_checks(
     # If required_checks is not set or empty, consider all names are relevant
     relevant_checknames = [
         name
-        for name in check_runs.keys()
+        for name in check_runs
         if not required_checks or any(x in name for x in required_checks)
     ]
 
     for checkname in required_checks:
-        if all(checkname not in x for x in check_runs.keys()):
+        if all(checkname not in x for x in check_runs):
             pending_checks.append((checkname, None, None))
 
     for checkname in relevant_checknames:
@@ -2398,8 +2398,7 @@ def merge(
             )
             pending, failing, _ = categorize_checks(
                 checks,
-                required_checks
-                + [x for x in checks.keys() if x not in required_checks],
+                required_checks + [x for x in checks if x not in required_checks],
                 ok_failed_checks_threshold=IGNORABLE_FAILED_CHECKS_THESHOLD
                 if ignore_flaky_failures
                 else 0,

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -2472,7 +2472,7 @@ class BenchmarkRunner:
                     for refi, resi in zip(ref, res):
                         dump_max_mean_values(tol, refi, resi)
                 elif isinstance(ref, dict):
-                    for k in ref.keys():
+                    for k in ref:
                         dump_max_mean_values(tol, ref[k], res[k])
                 elif isinstance(ref, torch.Tensor):
                     res = res.to(base_device)

--- a/benchmarks/dynamo/microbenchmarks/operator_inp_utils.py
+++ b/benchmarks/dynamo/microbenchmarks/operator_inp_utils.py
@@ -293,7 +293,7 @@ class OperatorInputsLoader:
             yield args, kwargs
 
     def get_all_ops(self):
-        for key in self.operator_db.keys():
+        for key in self.operator_db:
             try:
                 op = eval(key)
             except AttributeError:

--- a/benchmarks/dynamo/training_loss.py
+++ b/benchmarks/dynamo/training_loss.py
@@ -153,7 +153,7 @@ def main():
         "bert-base-cased", num_labels=5
     )
     optimizer_cls = getattr(sys.modules["torch.optim"], args.optimizer)
-    if "capturable" in inspect.signature(optimizer_cls).parameters.keys():
+    if "capturable" in inspect.signature(optimizer_cls).parameters:
         optimizer = optimizer_cls(model.parameters(), lr=args.lr, capturable=True)
     else:
         optimizer = optimizer_cls(model.parameters(), lr=args.lr)

--- a/benchmarks/functional_autograd_benchmark/vision_models.py
+++ b/benchmarks/functional_autograd_benchmark/vision_models.py
@@ -133,7 +133,7 @@ def get_detr(device: torch.device) -> GetterReturnType:
         weight_dict = criterion.weight_dict
         final_loss = cast(
             Tensor,
-            sum(loss[k] * weight_dict[k] for k in loss.keys() if k in weight_dict),
+            sum(loss[k] * weight_dict[k] for k in loss if k in weight_dict),
         )
         return final_loss
 

--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -303,7 +303,7 @@ class BenchmarkRunner:
             break_idxs = [-1]
             curr_brackets = []
             for i, c in enumerate(s):
-                if c in open_to_close.keys():
+                if c in open_to_close:
                     curr_brackets.append(c)
                 elif c in open_to_close.values():
                     assert curr_brackets and open_to_close[curr_brackets[-1]] == c, (

--- a/docs/source/scripts/exportdb/generate_example_rst.py
+++ b/docs/source/scripts/exportdb/generate_example_rst.py
@@ -122,7 +122,7 @@ def generate_index_rst(example_cases, tag_to_modules, support_level_to_modules):
 {module_contents}
 """
 
-    tag_names = "\n    ".join(t for t in tag_to_modules.keys())
+    tag_names = "\n    ".join(t for t in tag_to_modules)
 
     with open(os.path.join(PWD, "blurb.txt")) as file:
         blurb = file.read()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,7 +177,6 @@ ignore = [
     "SIM115", # Checks for cases where files are opened without using a context manager.
     "SIM116", # Disable Use a dictionary instead of consecutive `if` statements
     "SIM117",
-    "SIM118",
     "SIM300", # Yoda condition detected
     "UP007", # keep-runtime-typing
     "UP045", # keep-runtime-typing

--- a/test/distributed/argparse_util_test.py
+++ b/test/distributed/argparse_util_test.py
@@ -16,7 +16,7 @@ from torch.distributed.argparse_util import check_env, env
 class ArgParseUtilTest(unittest.TestCase):
     def setUp(self):
         # remove any lingering environment variables
-        for e in os.environ.keys():
+        for e in os.environ.keys():  # noqa: SIM118
             if e.startswith("PET_"):
                 del os.environ[e]
 

--- a/test/distributed/launcher/api_test.py
+++ b/test/distributed/launcher/api_test.py
@@ -137,7 +137,7 @@ class ElasticLaunchTest(unittest.TestCase):
         self.test_dir = tempfile.mkdtemp()
 
         # remove any lingering environment variables.
-        for env in os.environ.keys():
+        for env in os.environ.keys():  # noqa:SIM118
             if env.startswith("PET_"):
                 del os.environ[env]
 

--- a/test/distributed/launcher/test_run.py
+++ b/test/distributed/launcher/test_run.py
@@ -70,7 +70,7 @@ class ElasticLaunchTest(TestCase):
         self.test_dir = tempfile.mkdtemp()
 
         # remove any lingering environment variables
-        for env in os.environ.keys():
+        for env in os.environ.keys():  # noqa: SIM118
             if env.startswith("PET_"):
                 del os.environ[env]
 

--- a/test/dynamo/test_dicts.py
+++ b/test/dynamo/test_dicts.py
@@ -143,7 +143,7 @@ class DictTests(torch._dynamo.test_case.TestCase):
         def fn(x):
             for value in sd.values():
                 x = x * value
-            for key in sd.keys():
+            for key in sd:
                 x = x * key
             for k, v in sd.items():
                 x = x * k
@@ -189,7 +189,7 @@ class DictTests(torch._dynamo.test_case.TestCase):
             for value in sd.values():
                 x = x * value
             sd[6] = 14
-            for key in sd.keys():
+            for key in sd:
                 x = x * key
             for k, v in sd.items():
                 x = x * k

--- a/test/dynamo/test_guard_serialization.py
+++ b/test/dynamo/test_guard_serialization.py
@@ -339,7 +339,7 @@ class TestGuardSerializationBase(torch._inductor.test_case.TestCase):
         # NB: This is super janky and might cause unforeseen problems
         if kwarg_gen_fn is not None:
             kwargs = kwarg_gen_fn()
-            for key in self._frame_state.f_locals.keys():
+            for key in self._frame_state.f_locals:
                 if key in kwargs and isinstance(kwargs[key], Iterator):
                     self._frame_state.f_locals[key] = kwargs[key]
 

--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -2182,7 +2182,7 @@ def forward(self, child : torch.Tensor, const_unused : int):
         gm = backend.graphs[0]
         graph = gm.code.strip()
         subgraphs = []
-        for module_name in gm._modules.keys():
+        for module_name in gm._modules:
             subgraphs.append(getattr(gm, module_name).code.strip())
         return (graph, *subgraphs)
 

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -2788,7 +2788,7 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
                 )
 
             def forward(self, x):
-                for activation_name in self.activations.keys():
+                for activation_name in self.activations:
                     x = self.activations[activation_name](x)
                 return x
 

--- a/test/dynamo/test_nested_graph_breaks.py
+++ b/test/dynamo/test_nested_graph_breaks.py
@@ -835,10 +835,7 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCaseWithNestedGraphBreak
         self.assertEqual(len(torch._dynamo.utils.counters["resumes"]), 2)
         for name in ("resume_in_f4", "resume_in_f7"):
             self.assertTrue(
-                any(
-                    name in key
-                    for key in torch._dynamo.utils.counters["resumes"].keys()
-                )
+                any(name in key for key in torch._dynamo.utils.counters["resumes"])
             )
 
     def test_disable_nested_graph_breaks(self):

--- a/test/dynamo/test_precompile_context.py
+++ b/test/dynamo/test_precompile_context.py
@@ -58,7 +58,7 @@ class PrecompileContextTests(InductorTestCase):
         result.sum().backward()
         self.assertEqual(len(PrecompileContext._dynamo_cache_entries), 1)
         self.assertEqual(len(PrecompileContext._backend_artifacts_by_key), 1)
-        for key in PrecompileContext._backend_artifacts_by_key.keys():
+        for key in PrecompileContext._backend_artifacts_by_key:
             result = PrecompileContext.serialize_artifact_by_key(key)
             assert isinstance(result, BackendCacheArtifact)
             self.assertEqual(result.key, key)

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -5035,7 +5035,7 @@ def forward(self, s77 : torch.SymInt, s27 : torch.SymInt, L_x_ : torch.Tensor):
                     for i in instance_lists[1:]:
                         assert i.image_size == image_size
                 ret = Instances(image_size)
-                for k in instance_lists[0]._fields.keys():
+                for k in instance_lists[0]._fields:
                     values = [i.get(k) for i in instance_lists]
                     v0 = values[0]
                     if isinstance(v0, torch.Tensor):

--- a/test/test_torchfuzz_repros.py
+++ b/test/test_torchfuzz_repros.py
@@ -13,7 +13,6 @@ import pytest
 
 import torch
 from torch.testing._internal.common_utils import run_tests, TestCase
-from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON
 
 
 class TestFuzzerCompileIssues(TestCase):

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -1003,7 +1003,7 @@ def gen_variable_type_func(
                 result[f"type_derived_method_definitions_{key}"] = [type_definition]
                 result[f"wrapper_registrations_{key}"] = [wrapper_registration]
             else:
-                for key in fn.info.keys():
+                for key in fn.info:
                     type_definition = METHOD_DEFINITION.substitute(
                         return_type=cpp.returns_type(
                             f.func.returns, symint=True

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -354,7 +354,7 @@ class UsageLogger:
                 gpu_allocated_mem_values[gpu.uuid].append(gpu.allocated_mem_value)
                 gpu_total_mem_values[gpu.uuid] = gpu.total_mem_value
 
-        for gpu_uuid in gpu_utilization.keys():
+        for gpu_uuid in gpu_utilization:
             gpu_util_stats = self._generate_stats(gpu_utilization[gpu_uuid])
             gpu_mem_util_stats = self._generate_stats(gpu_mem_utilization[gpu_uuid])
             gpu_allocated_mem_stats = self._generate_stats(gpu_allocated_mem[gpu_uuid])

--- a/tools/stats/upload_stats_lib.py
+++ b/tools/stats/upload_stats_lib.py
@@ -49,7 +49,7 @@ def _get_artifact_urls(prefix: str, workflow_run_id: int) -> dict[Path, str]:
         headers=_get_request_headers(),
     )
     artifacts = response.json()["artifacts"]
-    while "next" in response.links.keys():
+    while "next" in response.links:
         response = requests.get(
             response.links["next"]["url"], headers=_get_request_headers()
         )

--- a/tools/test/heuristics/test_utils.py
+++ b/tools/test/heuristics/test_utils.py
@@ -21,7 +21,7 @@ class TestHeuristicsUtils(unittest.TestCase):
         self, first: dict[TestRun, Any], second: dict[TestRun, Any]
     ) -> None:
         self.assertEqual(first.keys(), second.keys())
-        for key in first.keys():
+        for key in first:
             self.assertAlmostEqual(first[key], second[key])
 
     def test_normalize_ratings(self) -> None:

--- a/tools/test/test_test_selections.py
+++ b/tools/test/test_test_selections.py
@@ -374,7 +374,7 @@ class TestCalculateShards(unittest.TestCase):
             expected_shards,
             calculate_shards(
                 2,
-                [TestRun(t) for t in test_times.keys()],
+                [TestRun(t) for t in test_times],
                 test_times,
                 gen_class_times(test_times),
             ),

--- a/tools/test/test_test_selections.py
+++ b/tools/test/test_test_selections.py
@@ -404,7 +404,7 @@ class TestCalculateShards(unittest.TestCase):
             expected_shards,
             calculate_shards(
                 2,
-                [TestRun(t) for t in test_times.keys()],
+                [TestRun(t) for t in test_times],
                 test_times,
                 gen_class_times(test_times),
             ),
@@ -422,7 +422,7 @@ class TestCalculateShards(unittest.TestCase):
             expected_shards,
             calculate_shards(
                 2,
-                [TestRun(t) for t in test_times.keys()],
+                [TestRun(t) for t in test_times],
                 test_times,
                 gen_class_times(test_times),
             ),

--- a/tools/testing/target_determination/heuristics/interface.py
+++ b/tools/testing/target_determination/heuristics/interface.py
@@ -75,7 +75,7 @@ class TestPrioritizations:
             return  # We don't need this test
 
         relevant_test_runs: list[TestRun] = [
-            tr for tr in self._test_scores.keys() if tr & test_run and tr != test_run
+            tr for tr in self._test_scores if tr & test_run and tr != test_run
         ]
 
         # Set the score of all the tests that are covered by test_run to the same score
@@ -95,7 +95,7 @@ class TestPrioritizations:
             return
 
         relevant_test_runs: list[TestRun] = [
-            tr for tr in self._test_scores.keys() if tr & test_run
+            tr for tr in self._test_scores if tr & test_run
         ]
 
         for relevant_test_run in relevant_test_runs:

--- a/torch/_inductor/tiling_utils.py
+++ b/torch/_inductor/tiling_utils.py
@@ -162,7 +162,7 @@ def find_broadcast_var(
             variables[v] = get_hint(v)
 
     zero_index = sympy_subs(index, variables)
-    for v in var_ranges.keys():
+    for v in var_ranges:
         if v not in index.free_symbols:
             continue
 

--- a/torch/distributed/_local_tensor/_c10d.py
+++ b/torch/distributed/_local_tensor/_c10d.py
@@ -238,9 +238,7 @@ def _local_functional_all_to_all_single(
         ):
             local_ints = dict(input_split_size.node._local_ints.items())
         else:
-            local_ints = {
-                rank: int(input_split_size) for rank in tensor._local_tensors.keys()
-            }
+            local_ints = {rank: int(input_split_size) for rank in tensor._local_tensors}
         for rank, split_size in local_ints.items():
             if rank not in split_local_sizes:
                 split_local_sizes[rank] = []

--- a/torch/distributed/_tools/fsdp2_mem_tracker.py
+++ b/torch/distributed/_tools/fsdp2_mem_tracker.py
@@ -383,7 +383,7 @@ class FSDPMemTracker(MemTracker):
                     if not unique_handlers.get(fsdp_state._post_forward_hook_handle):
                         unique_handlers[fsdp_state._post_forward_hook_handle] = True
         # call remove on the handles once
-        for f_hook_handle in unique_handlers.keys():
+        for f_hook_handle in unique_handlers:
             f_hook_handle.remove()
         # pyrefly: ignore  # missing-attribute
         for module in self._root_mod.modules():

--- a/torch/distributed/flight_recorder/components/builder.py
+++ b/torch/distributed/flight_recorder/components/builder.py
@@ -181,7 +181,7 @@ def build_collectives(
     mismatch = {_groups[g].id: 0 for g in _groups}
 
     # For best effort partial analysis.
-    dumps_ranks = {int(key) for key in all_entries.keys()}
+    dumps_ranks = {int(key) for key in all_entries}
     """
     - it doesn't matter what order I put collectives/ncclops into their table. we can later on re-sort it by start time
     - there could be multiple options for the "first" collective to pair up (rank 0,1 might do a bcast while rank 2,3 do a bcast)

--- a/torch/distributed/flight_recorder/components/utils.py
+++ b/torch/distributed/flight_recorder/components/utils.py
@@ -701,7 +701,7 @@ def check_no_missing_dump_files(
     all_ranks = set()
     for membership in memberships:
         all_ranks.add(int(membership.global_rank))
-    dumps_ranks = {int(key) for key in entries.keys()}
+    dumps_ranks = {int(key) for key in entries}
     assert dumps_ranks == all_ranks, (
         f"Missing dump files from ranks {all_ranks - dumps_ranks}"
     )

--- a/torch/utils/_debug_mode.py
+++ b/torch/utils/_debug_mode.py
@@ -39,7 +39,7 @@ import os
 import traceback
 import weakref
 from collections.abc import Callable
-from typing import Any, Optional, TYPE_CHECKING, Union  # noqa: F401
+from typing import Any, TYPE_CHECKING, Union  # noqa: F401
 
 import torch
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
@@ -1101,7 +1101,7 @@ class DebugMode(TorchDispatchMode):
 
                 def compare_triton_hashes(hashes1, hashes2, is_input):
                     assert set(hashes1.keys()) == set(hashes2.keys())  # type: ignore[union-attr]
-                    for key in hashes1.keys():
+                    for key in hashes1:
                         if hashes1[key] != hashes2[key]:
                             difference_info.append(
                                 {

--- a/torchgen/operator_versions/gen_mobile_upgraders.py
+++ b/torchgen/operator_versions/gen_mobile_upgraders.py
@@ -305,7 +305,7 @@ def get_upgrader_bytecode_function_to_index_map(
     upgrader_bytecode_function_to_index_map = {}
     index = 0
     for upgrader_bytecode in upgrader_dict:
-        for upgrader_name in upgrader_bytecode.keys():
+        for upgrader_name in upgrader_bytecode:
             if upgrader_name in EXCLUE_UPGRADER_SET:
                 continue
             upgrader_bytecode_function_to_index_map[upgrader_name] = index


### PR DESCRIPTION
This PR enables the `SIM118` rule of ruff, which checks for key-existence checks against dict.keys() calls.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela