### PR TITLE
Avoid saving non-sympy.Expr symbolic nodes to prevent invalid Inductor graph inputs in solve_min_cut

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -6736,6 +6736,58 @@ def forward(self, primals_1, tangents_1):
         finally:
             handle.destroy()
 
+    def test_static_input_indices_with_effect_tokens(self):
+        """Test that static_input_indices are correctly offset when effect tokens are prepended."""
+        from torch._higher_order_ops.effects import _register_effectful_op
+        from torch._library.effects import EffectType
+
+        @torch.library.custom_op(
+            "test::effectful_static_idx_op", mutates_args=()
+        )
+        def effectful_static_idx_op(x: torch.Tensor) -> torch.Tensor:
+            return x.clone()
+
+        @effectful_static_idx_op.register_fake
+        def _(x: torch.Tensor) -> torch.Tensor:
+            return torch.empty_like(x)
+
+        handle = _register_effectful_op(effectful_static_idx_op, EffectType.ORDERED)
+
+        try:
+            fw_metadata = None
+
+            def capture_metadata_backend(graph_module, example_inputs):
+                nonlocal fw_metadata
+                fw_metadata = graph_module.meta.get("fw_metadata", None)
+                return graph_module.forward
+
+            model = torch.nn.Linear(3, 2)
+
+            @torch.compile(backend=capture_metadata_backend)
+            def fn(x, weight, bias):
+                y = x @ weight.t() + bias
+                torch.ops.test.effectful_static_idx_op(y)
+                return y
+
+            x = torch.randn(4, 3)
+            fn(x, model.weight, model.bias)
+
+            self.assertIsNotNone(fw_metadata)
+            # weight and bias are static inputs (params). When effect tokens are
+            # prepended, their indices should be offset by the number of tokens.
+            # Without the fix, indices would point to wrong inputs.
+            num_tokens = len(fw_metadata.tokens)
+            self.assertGreater(num_tokens, 0, "expected effect tokens to be present")
+            for idx in fw_metadata.static_input_indices:
+                self.assertGreaterEqual(
+                    idx,
+                    num_tokens,
+                    f"static_input_indices {fw_metadata.static_input_indices} "
+                    f"should all be >= num_tokens ({num_tokens})",
+                )
+        finally:
+            handle.destroy()
+
 
 class TestAOTDispatch(AOTTestCase):
     # Tests to add cases for (non-exhaustive list, mostly for my notes):

--- a/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
+++ b/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
@@ -1271,6 +1271,9 @@ def handle_effect_tokens_fn(
     else:
         args = [*additional_fwd_token_inputs, *args]
         args_descs = [*additional_fwd_token_inputs_descs, *args_descs]
+
+        if num_tokens > 0:
+            meta.static_input_indices = [idx + num_tokens for idx in meta.static_input_indices]
     return inner_fn, args, args_descs
 
 

--- a/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
+++ b/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
@@ -1273,7 +1273,9 @@ def handle_effect_tokens_fn(
         args_descs = [*additional_fwd_token_inputs_descs, *args_descs]
 
         if num_tokens > 0:
-            meta.static_input_indices = [idx + num_tokens for idx in meta.static_input_indices]
+            meta.static_input_indices = [
+                idx + num_tokens for idx in meta.static_input_indices
+            ]
     return inner_fn, args, args_descs
 
 


### PR DESCRIPTION
# Background

Inductor does not accept `sympy.Relational` objects as graph inputs, as shown by the assertion below from `torch/_inductor/graph.py` (line 1468):

```python
assert isinstance(
    value, (TensorBox, sympy.Expr, torch._inductor.ir.GeneratorState)
), f"Unsupported inductor graph input type: {type(value)}"
```

However, during `torch.compile`, guard conditions can introduce symbolic equality nodes (`Sym.Eq`), such as in the following example:

```python
# No stacktrace found for following nodes
sym_sum_3: "Sym(u52 + u53)" = torch.sym_sum((_local_scalar_dense_4, _local_scalar_dense_5))
eq_42: "Sym(Eq(u52 + u53, 262144))" = sym_sum_3 == 262144
_assert_scalar_11 = torch.ops.aten._assert_scalar.default(eq_42, "Runtime assertion failed for expression Eq(u4 + u5, 262144) on node 'eq'")
eq_42 = _assert_scalar_11 = None
```

Here, the node `eq_42` may be treated as a value to be saved, which causes it to appear as an input node in the backward graph. This subsequently triggers the Inductor type check error above.

# Fix

Since Inductor only accepts `sympy.Expr` symbolic inputs, the solution is to modify the `sym_node_size` function to assign `math.inf` as the weight for any symbolic node whose type is *not* `sympy.Expr`.

```python
def sym_node_size(node: fx.Node) -> int:
    val = node.meta["val"]

    if not isinstance(val._sympy_(), sympy.Expr):
        return math.inf
```

This ensures such nodes are excluded during the `solve_min_cut` process and will not be returned as `saved_values`, thereby preventing them from being included as backward graph inputs.

This fix handles the issue cleanly without changing Inductor’s graph validation logic.

**This PR Fixes** #167070

cc @yanboliang 