### PR TITLE
[inductor] Use custom triton kernel subclass when available

### DIFF
--- a/test/inductor/extension_backends/triton/extension_triton_heuristics.py
+++ b/test/inductor/extension_backends/triton/extension_triton_heuristics.py
@@ -1,0 +1,35 @@
+from torch._inductor.runtime import triton_heuristics
+from torch._inductor.runtime.triton_heuristics import user_autotune
+from typing import Any
+
+EXTENSION_TRITON_META_FIELD = "extension_custom_field"
+class ExtensionCachingAutotuner(triton_heuristics.CachingAutotuner):
+    def _create_compile_meta(
+        self, cfg: triton_heuristics.Config,
+    ) -> dict[str, Any]:
+        assert EXTENSION_TRITON_META_FIELD in self.triton_meta
+        compile_meta = super()._create_compile_meta(cfg)
+        assert EXTENSION_TRITON_META_FIELD in compile_meta
+        return compile_meta
+
+def pointwise(
+    size_hints,
+    triton_meta,
+    tile_hint=None,
+    filename=None,
+    min_elem_per_thread=0,
+    inductor_meta=None,
+):
+    """
+    Construct @triton.heuristics() based on size_hints.
+    """
+    configs = [triton_heuristics.Config({"XBLOCK": 32})]
+    return triton_heuristics.cached_autotune(
+        size_hints,
+        configs,
+        triton_meta = triton_meta,
+        inductor_meta = inductor_meta,
+        heuristic_type = triton_heuristics.HeuristicType.POINTWISE,
+        filename=filename,
+        caching_autotuner_cls = ExtensionCachingAutotuner
+    )

--- a/test/inductor/extension_backends/triton/extension_triton_heuristics.py
+++ b/test/inductor/extension_backends/triton/extension_triton_heuristics.py
@@ -1,16 +1,22 @@
-from torch._inductor.runtime import triton_heuristics
-from torch._inductor.runtime.triton_heuristics import user_autotune
 from typing import Any
 
+from torch._inductor.runtime import triton_heuristics
+from torch._inductor.runtime.triton_heuristics import user_autotune  # noqa: F401
+
+
 EXTENSION_TRITON_META_FIELD = "extension_custom_field"
+
+
 class ExtensionCachingAutotuner(triton_heuristics.CachingAutotuner):
     def _create_compile_meta(
-        self, cfg: triton_heuristics.Config,
+        self,
+        cfg: triton_heuristics.Config,
     ) -> dict[str, Any]:
         assert EXTENSION_TRITON_META_FIELD in self.triton_meta
         compile_meta = super()._create_compile_meta(cfg)
         assert EXTENSION_TRITON_META_FIELD in compile_meta
         return compile_meta
+
 
 def pointwise(
     size_hints,
@@ -27,9 +33,9 @@ def pointwise(
     return triton_heuristics.cached_autotune(
         size_hints,
         configs,
-        triton_meta = triton_meta,
-        inductor_meta = inductor_meta,
-        heuristic_type = triton_heuristics.HeuristicType.POINTWISE,
+        triton_meta=triton_meta,
+        inductor_meta=inductor_meta,
+        heuristic_type=triton_heuristics.HeuristicType.POINTWISE,
         filename=filename,
-        caching_autotuner_cls = ExtensionCachingAutotuner
+        caching_autotuner_cls=ExtensionCachingAutotuner,
     )

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -655,7 +655,7 @@ class CudaReproTests(TestCase):
         """
         from torch._C import _cuda_getCurrentRawStream as get_cuda_stream
         from torch._inductor.runtime.hints import AttrsDescriptorWrapper, HeuristicType
-        from torch._inductor.runtime.triton_heuristics import get_heuristic_config
+        from torch._inductor.runtime.triton_heuristics import CachingAutotuner
         from torch._inductor.utils import triton_version_uses_attrs_dict
 
         def autotune(configs, meta):
@@ -665,8 +665,7 @@ class CudaReproTests(TestCase):
                     # Ref: https://github.com/pytorch/pytorch/pull/145051
                     meta["signature"]["XBLOCK"] = "constexpr"
 
-                heuristic_config = get_heuristic_config("cuda")
-                return heuristic_config.caching_autotuner_cls(
+                return CachingAutotuner(
                     # force autotune by setting save_cache_hook to False
                     fn,
                     triton_meta=meta,

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -655,7 +655,7 @@ class CudaReproTests(TestCase):
         """
         from torch._C import _cuda_getCurrentRawStream as get_cuda_stream
         from torch._inductor.runtime.hints import AttrsDescriptorWrapper, HeuristicType
-        from torch._inductor.runtime.triton_heuristics import CachingAutotuner
+        from torch._inductor.runtime.triton_heuristics import get_heuristic_config
         from torch._inductor.utils import triton_version_uses_attrs_dict
 
         def autotune(configs, meta):
@@ -665,7 +665,8 @@ class CudaReproTests(TestCase):
                     # Ref: https://github.com/pytorch/pytorch/pull/145051
                     meta["signature"]["XBLOCK"] = "constexpr"
 
-                return CachingAutotuner(
+                heuristic_config = get_heuristic_config("cuda")
+                return heuristic_config.caching_autotuner_cls(
                     # force autotune by setting save_cache_hook to False
                     fn,
                     triton_meta=meta,

--- a/test/inductor/test_triton_extension_backend.py
+++ b/test/inductor/test_triton_extension_backend.py
@@ -13,7 +13,7 @@ from torch._inductor import config
 
 
 try:
-    from extension_backends.triton.device_interface import (  # @manual=fbcode//caffe2/test/inductor/extension_backends:extension_codegen_backend  # noqa: B950
+    from extension_backends.triton.device_interface import (  # @manual=fbcode//caffe2/test/inductor/extension_backends:device_interface  # noqa: B950
         DeviceInterface,
     )
     from extension_backends.triton.extension_codegen_backend import (  # @manual=fbcode//caffe2/test/inductor/extension_backends:extension_codegen_backend  # noqa: B950
@@ -21,7 +21,7 @@ try:
         ExtensionScheduling,
         ExtensionWrapperCodegen,
     )
-    from extension_backends.triton.extension_triton_heuristics import (
+    from extension_backends.triton.extension_triton_heuristics import ( # @manual=fbcode//caffe2/test/inductor/extension_backends:extension_triton_heuristics  # noqa: B950
         EXTENSION_TRITON_META_FIELD,
     )
 except ImportError:

--- a/test/inductor/test_triton_extension_backend.py
+++ b/test/inductor/test_triton_extension_backend.py
@@ -2,7 +2,6 @@
 import functools
 import random
 import string
-import sys
 import unittest
 from pathlib import Path
 from typing import Any, Optional
@@ -55,19 +54,14 @@ from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CPU, HAS_GPU_AN
 from torch.testing._internal.triton_utils import requires_cuda_and_triton
 
 
+try:
+    from .test_extension_backend import BaseExtensionBackendTests
+except ImportError:
+    from test_extension_backend import BaseExtensionBackendTests
+
 if HAS_GPU_AND_TRITON:
     import triton
     import triton.language as tl
-
-try:
-    try:
-        from . import test_torchinductor
-    except ImportError:
-        import test_torchinductor  # @manual=fbcode//caffe2/test/inductor:test_inductor-library
-except unittest.SkipTest:
-    if __name__ == "__main__":
-        sys.exit(0)
-    raise
 
 
 def mock_triton_hash_with_backend(*args, **kwargs):
@@ -77,7 +71,7 @@ def mock_triton_hash_with_backend(*args, **kwargs):
 
 
 @unittest.skipIf(IS_FBCODE, "cpp_extension doesn't work in fbcode right now")
-class TritonExtensionBackendTests(test_torchinductor.TestCase):
+class TritonExtensionBackendTests(BaseExtensionBackendTests):
     """
     Test creating a backend for inductor with Triton scheduling.
     """
@@ -197,7 +191,7 @@ class TritonExtensionBackendTests(test_torchinductor.TestCase):
 
     @requires_cuda_and_triton
     def test_codegen_with_custom_heuristics_module(self):
-        self._custom_triton_backend_registration_fixture(GPU_TYPE)
+        self._register_custom_backend_with_heuristics(GPU_TYPE)
 
         def add(x, y):
             return x + y
@@ -213,7 +207,7 @@ class TritonExtensionBackendTests(test_torchinductor.TestCase):
 
     @requires_cuda_and_triton
     def test_codegen_with_custom_heuristics_module_udtk(self):
-        self._custom_triton_backend_registration_fixture(GPU_TYPE)
+        self._register_custom_backend_with_heuristics(GPU_TYPE)
 
         @triton.jit
         def add_kernel(

--- a/test/inductor/test_triton_extension_backend.py
+++ b/test/inductor/test_triton_extension_backend.py
@@ -51,18 +51,13 @@ from torch._inductor.codegen.common import (
 from torch._inductor.codegen.wrapper import PythonWrapperCodegen
 from torch._inductor.utils import get_triton_code, run_and_get_triton_code
 from torch.testing._internal.common_utils import IS_FBCODE, IS_MACOS
-from torch.testing._internal.inductor_utils import HAS_CPU
+from torch.testing._internal.inductor_utils import HAS_CPU, HAS_TRITON
 from torch.testing._internal.triton_utils import requires_cuda_and_triton
 
 
 if HAS_TRITON:
     import triton
     import triton.language as tl
-
-try:
-    from .test_extension_backend import BaseExtensionBackendTests
-except ImportError:
-    pass
 
 try:
     try:

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -46,7 +46,7 @@ from torch._inductor.runtime.hints import (
 from torch._inductor.runtime.triton_helpers import math as tl_math
 from torch._inductor.runtime.triton_heuristics import (
     autotune_hints_to_configs,
-    CachingAutotuner,
+    get_heuristic_config,
     template,
     triton_config,
 )
@@ -191,8 +191,9 @@ class TestTritonHeuristics(TestCase):
         for cfg in args["configs"]:
             cfg.pre_hook = pre_hook
 
+        heuristic_config = get_heuristic_config(GPU_TYPE)
         with self.assertRaisesRegex(AssertionError, "pre_hook"):
-            CachingAutotuner(**args)
+            heuristic_config.caching_autotuner_cls(**args)
 
     def test_autotune_hints_to_configs(self):
         device_props = DeviceProperties.create(torch.device(GPU_TYPE))
@@ -315,7 +316,8 @@ class TestArgumentCloneAndRestore(TestCase):
         args = TestTritonHeuristics._get_cos_kernel_caching_autotuner_args()
         args["optimize_mem"] = True
         args["mutated_arg_names"] = ["in_ptr0"]
-        autotuner = CachingAutotuner(**args)
+        heuristic_config = get_heuristic_config(GPU_TYPE)
+        autotuner = heuristic_config.caching_autotuner_cls(**args)
         return autotuner
 
     def _create_tensor(self, pad=1, with_offset=False):

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -46,7 +46,7 @@ from torch._inductor.runtime.hints import (
 from torch._inductor.runtime.triton_helpers import math as tl_math
 from torch._inductor.runtime.triton_heuristics import (
     autotune_hints_to_configs,
-    get_heuristic_config,
+    CachingAutotuner,
     template,
     triton_config,
 )
@@ -191,9 +191,8 @@ class TestTritonHeuristics(TestCase):
         for cfg in args["configs"]:
             cfg.pre_hook = pre_hook
 
-        heuristic_config = get_heuristic_config(GPU_TYPE)
         with self.assertRaisesRegex(AssertionError, "pre_hook"):
-            heuristic_config.caching_autotuner_cls(**args)
+            CachingAutotuner(**args)
 
     def test_autotune_hints_to_configs(self):
         device_props = DeviceProperties.create(torch.device(GPU_TYPE))
@@ -316,8 +315,7 @@ class TestArgumentCloneAndRestore(TestCase):
         args = TestTritonHeuristics._get_cos_kernel_caching_autotuner_args()
         args["optimize_mem"] = True
         args["mutated_arg_names"] = ["in_ptr0"]
-        heuristic_config = get_heuristic_config(GPU_TYPE)
-        autotuner = heuristic_config.caching_autotuner_cls(**args)
+        autotuner = CachingAutotuner(**args)
         return autotuner
 
     def _create_tensor(self, pad=1, with_offset=False):

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -2305,6 +2305,7 @@ class SIMDScheduling(BaseScheduling):
         enable_autotune: bool,
         mixed_sizes: bool,
         only_gen_src_code: bool = False,
+<<<<<<< HEAD
     ) -> list[tuple[Optional[str], Any, Any]]:
         """
         Generate kernel code for combo kernel partitions.
@@ -2315,7 +2316,14 @@ class SIMDScheduling(BaseScheduling):
 
         Returns a list of (src_code, kernel, node_group) tuples.
         """
+=======
+    ) -> list[tuple[str, Any, Any]]:
+        from .triton import TritonKernel
+>>>>>>> 95e8a2bf196 (Make triton kernel class type resolution more robust)
         from .triton_combo_kernel import ComboKernel
+
+        # This is currently the only type supported by this method
+        assert issubclass(self.kernel_type, TritonKernel)
 
         fused_node_lists = [node.get_nodes() for node in subkernel_nodes]
         node_schedule_map: dict[Any, NodeInfo] = {}
@@ -2323,6 +2331,7 @@ class SIMDScheduling(BaseScheduling):
             _, (numel, rnumel) = max(nodes, key=lambda x: int(x.is_reduction())).group
             node_schedule = self.generate_node_schedule(nodes, numel, rnumel)
             tiling = self.select_tiling(node_schedule, numel, rnumel)
+<<<<<<< HEAD
             features = SIMDKernelFeatures(node_schedule, numel, rnumel)
             is_persistent_reduction = (
                 features.is_reduction()
@@ -2337,6 +2346,14 @@ class SIMDScheduling(BaseScheduling):
                 rnumel=rnumel,
                 features=features,
                 is_persistent_reduction=is_persistent_reduction,
+=======
+            node_schedule_map[pn] = node_schedule, tiling, numel, rnumel
+            subkernel_map[pn] = ComboKernel.create_triton_kernel(
+                tiling,
+                features=SIMDKernelFeatures(node_schedule, numel, rnumel),
+                optimize_mask=not mixed_sizes,
+                triton_kernel_cls=self.kernel_type,
+>>>>>>> 95e8a2bf196 (Make triton kernel class type resolution more robust)
             )
 
         partitions = ComboKernel.horizontal_partition(
@@ -2354,6 +2371,14 @@ class SIMDScheduling(BaseScheduling):
         for node_group in partitions:
             if len(node_group) == 0:
                 continue
+<<<<<<< HEAD
+=======
+            kernel = ComboKernel(
+                triton_kernel_cls=self.kernel_type,
+                enable_autotune=enable_autotune,
+                mixed_sizes=mixed_sizes,
+            )
+>>>>>>> 95e8a2bf196 (Make triton kernel class type resolution more robust)
 
             if len(node_group) == 1:
                 # Single-node partition

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -2305,7 +2305,6 @@ class SIMDScheduling(BaseScheduling):
         enable_autotune: bool,
         mixed_sizes: bool,
         only_gen_src_code: bool = False,
-<<<<<<< HEAD
     ) -> list[tuple[Optional[str], Any, Any]]:
         """
         Generate kernel code for combo kernel partitions.
@@ -2316,10 +2315,7 @@ class SIMDScheduling(BaseScheduling):
 
         Returns a list of (src_code, kernel, node_group) tuples.
         """
-=======
-    ) -> list[tuple[str, Any, Any]]:
         from .triton import TritonKernel
->>>>>>> 95e8a2bf196 (Make triton kernel class type resolution more robust)
         from .triton_combo_kernel import ComboKernel
 
         # This is currently the only type supported by this method
@@ -2331,7 +2327,6 @@ class SIMDScheduling(BaseScheduling):
             _, (numel, rnumel) = max(nodes, key=lambda x: int(x.is_reduction())).group
             node_schedule = self.generate_node_schedule(nodes, numel, rnumel)
             tiling = self.select_tiling(node_schedule, numel, rnumel)
-<<<<<<< HEAD
             features = SIMDKernelFeatures(node_schedule, numel, rnumel)
             is_persistent_reduction = (
                 features.is_reduction()
@@ -2346,14 +2341,6 @@ class SIMDScheduling(BaseScheduling):
                 rnumel=rnumel,
                 features=features,
                 is_persistent_reduction=is_persistent_reduction,
-=======
-            node_schedule_map[pn] = node_schedule, tiling, numel, rnumel
-            subkernel_map[pn] = ComboKernel.create_triton_kernel(
-                tiling,
-                features=SIMDKernelFeatures(node_schedule, numel, rnumel),
-                optimize_mask=not mixed_sizes,
-                triton_kernel_cls=self.kernel_type,
->>>>>>> 95e8a2bf196 (Make triton kernel class type resolution more robust)
             )
 
         partitions = ComboKernel.horizontal_partition(
@@ -2371,14 +2358,6 @@ class SIMDScheduling(BaseScheduling):
         for node_group in partitions:
             if len(node_group) == 0:
                 continue
-<<<<<<< HEAD
-=======
-            kernel = ComboKernel(
-                triton_kernel_cls=self.kernel_type,
-                enable_autotune=enable_autotune,
-                mixed_sizes=mixed_sizes,
-            )
->>>>>>> 95e8a2bf196 (Make triton kernel class type resolution more robust)
 
             if len(node_group) == 1:
                 # Single-node partition
@@ -2401,6 +2380,7 @@ class SIMDScheduling(BaseScheduling):
             else:
                 # Multi-node: create ComboKernel with combo subkernels
                 kernel = ComboKernel(
+                    triton_kernel_cls=self.kernel_type,
                     enable_autotune=enable_autotune,
                     mixed_sizes=mixed_sizes,
                 )
@@ -2410,6 +2390,7 @@ class SIMDScheduling(BaseScheduling):
                         node_info.tiling,
                         features=node_info.features,
                         optimize_mask=not mixed_sizes,
+                        triton_kernel_cls=self.kernel_type,
                     )
                     self.process_kernel(
                         kernel.create_sub_kernel(subkernel),

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5202,7 +5202,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         return {
             "enable_fp_fusion": not config.emulate_precision_casts,
             "launch_pdl": cls._enable_pdl_codegen(),
-            "disable_ftz": config.eager_numerics.disable_ftz
+            "disable_ftz": config.eager_numerics.disable_ftz,
         }
 
     @classmethod

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5202,6 +5202,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         return {
             "enable_fp_fusion": not config.emulate_precision_casts,
             "launch_pdl": cls._enable_pdl_codegen(),
+            "disable_ftz": config.eager_numerics.disable_ftz
         }
 
     @classmethod

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5199,7 +5199,11 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
     @classmethod
     def triton_meta_common(cls):
-        return {"enable_fp_fusion": not config.emulate_precision_casts, "disable_ftz": config.eager_numerics.disable_ftz, "launch_pdl": cls._enable_pdl_codegen()}
+        return {
+            "enable_fp_fusion": not config.emulate_precision_casts,
+            "disable_ftz": config.eager_numerics.disable_ftz,
+            "launch_pdl": cls._enable_pdl_codegen(),
+        }
 
     @classmethod
     def inductor_meta_common(cls):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5201,7 +5201,6 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
     def triton_meta_common(cls):
         return {
             "enable_fp_fusion": not config.emulate_precision_casts,
-            "disable_ftz": config.eager_numerics.disable_ftz,
             "launch_pdl": cls._enable_pdl_codegen(),
         }
 

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -347,7 +347,10 @@ class ComboKernel(Kernel):
                 code.splice(f"pid_offset = pid // {num_kernels}")
 
     def __init__(
-        self, triton_kernel_cls: type[TritonKernel], enable_autotune: bool = False, mixed_sizes: bool = False,
+        self,
+        triton_kernel_cls: type[TritonKernel],
+        enable_autotune: bool = False,
+        mixed_sizes: bool = False,
     ) -> None:
         super().__init__()
         self.triton_kernel_cls = triton_kernel_cls
@@ -384,7 +387,7 @@ class ComboKernel(Kernel):
         tiling: dict[str, sympy.Expr],
         features: SIMDKernelFeatures,
         optimize_mask: bool,
-        triton_kernel_cls: type[TritonKernel]
+        triton_kernel_cls: type[TritonKernel],
     ) -> TritonKernel:
         """
         Only allow optimize_mask=True when 1) sequential dispatch is used,

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -388,7 +388,7 @@ class ComboKernel(Kernel):
         Only allow optimize_mask=True when 1) sequential dispatch is used,
         2) numels except x dimension are the same for each sub kernel.
         """
-        return TritonKernel(
+        return ComboKernel._get_triton_kernel_cls_type(
             tiling,
             features=features,
             pid_cache={"tl.program_id(0)": "pid_offset"},
@@ -748,13 +748,12 @@ class ComboKernel(Kernel):
                     )
         return extra_args
 
-    def _get_triton_kernel_cls_type(self) -> type[TritonKernel]:
-        triton_scheduler = V.graph.scheduler
-        assert isinstance(V.graph.scheduler, TritonScheduling)
-        triton_scheduler = cast(TritonScheduling, V.graph.scheduler)
+    @staticmethod
+    def _get_triton_kernel_cls_type() -> type[TritonKernel]:
         triton_kernel_cls = TritonKernel
-        if issubclass(triton_scheduler.kernel_type, TritonKernel):
-            triton_kernel_cls = triton_scheduler.kernel_type
+        maybe_triton_scheduler = V.graph.scheduler
+        if issubclass(maybe_triton_scheduler, TritonScheduling) and issubclass(maybe_triton_scheduler.kernel_type, TritonKernel):
+            triton_kernel_cls = maybe_triton_scheduler.kernel_type
             triton_kernel_cls = cast(type[TritonKernel], triton_kernel_cls)
         return triton_kernel_cls
 

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -599,6 +599,8 @@ class ComboKernel(Kernel):
         argdefs: list[ArgName],
         pointwise_with_reduce: bool = False,
     ) -> str:
+        """Write the @triton_heuristics.<heuristics> decorator line for the combo kernel."""
+
         can_use_32bit = all(k.index_dtype == "tl.int32" for k in self.sub_kernels)
         size_dtype = "tl.int32" if can_use_32bit else "tl.int64"
         for i, sub in enumerate(self.sub_kernels):

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -35,7 +35,7 @@ from .common import (
 )
 from .simd import NodeInfo, prefix_is_reduction, SIMDScheduling
 from .simd_kernel_features import SIMDKernelFeatures
-from .triton import TritonKernel, TritonScheduling
+from .triton import TritonKernel
 from .triton_utils import config_of, equal_1_arg_indices, signature_to_meta
 
 

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -15,7 +15,7 @@ import re
 import tempfile
 from collections.abc import Callable
 from itertools import chain, count
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, cast, Union
 
 import sympy
 from sympy import Expr

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -15,7 +15,7 @@ import re
 import tempfile
 from collections.abc import Callable
 from itertools import chain, count
-from typing import Any, Optional, TYPE_CHECKING, cast, Union
+from typing import Any, Optional, TYPE_CHECKING, Union
 
 import sympy
 from sympy import Expr
@@ -66,7 +66,6 @@ from .common import (
     ArgName,
     CodeGen,
     DeferredLine,
-    get_scheduling_for_device,
     PythonPrinter,
     WorkspaceArg,
     WorkspaceZeroMode,
@@ -74,6 +73,7 @@ from .common import (
 from .cpp_utils import cexpr
 from .custom_extern_kernel_codegen import CUSTOM_EXTERN_KERNEL_CODEGEN
 from .triton_utils import config_of, should_unwrap_unspec_arg, signature_to_meta
+
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
@@ -1077,7 +1077,7 @@ class PythonWrapperCodegen(CodeGen):
     Generate outer wrapper in Python that calls the kernels.
     """
 
-    supports_caching: bool= True  # Whether the output code is cacheable.
+    supports_caching: bool = True  # Whether the output code is cacheable.
 
     def __init__(self):
         super().__init__()
@@ -1184,8 +1184,8 @@ class PythonWrapperCodegen(CodeGen):
         if is_subgraph:
             assert subgraph_name is not None
             assert parent_wrapper is not None
-            return SubgraphPythonWrapperCodegen(
-                subgraph_name, parent_wrapper, partition_signatures
+            return PythonWrapperCodegen.create(
+                is_subgraph, subgraph_name, parent_wrapper, partition_signatures
             )
         return PythonWrapperCodegen()
 
@@ -2424,12 +2424,13 @@ class PythonWrapperCodegen(CodeGen):
         self.subgraph_definitions.splice(subgraph_code.value)
 
     @classmethod
-    def _get_triton_info_kernel_cls(cls) -> "TritonKernel":
+    def _get_triton_info_kernel_cls(cls):
         # Other inductor triton backends may be subclass from
         # the TritonKernel class. An override of this method
         # allows them to set which subclass to use to get information
         # such as common triton imports or inductor metadata
         from .triton import TritonKernel
+
         return TritonKernel
 
     def define_user_defined_triton_kernel(
@@ -2453,7 +2454,6 @@ class PythonWrapperCodegen(CodeGen):
             TensorArg,
             TMADescriptorArg,
         )
-        from .triton import TritonKernel, TritonScheduling
 
         original_name = kernel.__name__
         signature: list[KernelArgType] = []

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -2425,8 +2425,8 @@ class PythonWrapperCodegen(CodeGen):
 
     @classmethod
     def _get_triton_info_kernel_cls(cls):
-        # Other inductor triton backends may be subclass from
-        # the TritonKernel class. An override of this method
+        # Other inductor triton backends may subclass from
+        # the `TritonKernel` class. An override of this method
         # allows them to set which subclass to use to get information
         # such as common triton imports or inductor metadata
         from .triton import TritonKernel

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1184,8 +1184,8 @@ class PythonWrapperCodegen(CodeGen):
         if is_subgraph:
             assert subgraph_name is not None
             assert parent_wrapper is not None
-            return PythonWrapperCodegen.create(
-                is_subgraph, subgraph_name, parent_wrapper, partition_signatures
+            return SubgraphPythonWrapperCodegen(
+                subgraph_name, parent_wrapper, partition_signatures
             )
         return PythonWrapperCodegen()
 

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -2453,8 +2453,10 @@ class PythonWrapperCodegen(CodeGen):
         # user defined triton kernel
         device = V.graph.get_current_device_or_throw()
         device_scheduler = get_scheduling_for_device(device)
-        if isinstance(device_scheduler, TritonScheduling):
-            triton_kernel_cls = device_scheduler.kernel_type
+        if isinstance(device_scheduler, TritonScheduling) and issubclass(
+            device_scheduler.kernel_type, TritonKernel
+        ):
+            triton_kernel_cls = cast(type[TritonKernel], device_scheduler.kernel_type)
 
         original_name = kernel.__name__
         signature: list[KernelArgType] = []

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1,7 +1,6 @@
 # mypy: allow-untyped-defs
 from __future__ import annotations
 
-import importlib
 import builtins
 import copy
 import dataclasses
@@ -2230,7 +2229,7 @@ def cached_autotune(
     inductor_meta=None,
     custom_kernel=False,
     caching_autotuner_cls: type[CachingAutotuner] = CachingAutotuner,
-    debug_autotuner_cls: type[DebugAutotuner] = DebugAutotuner
+    debug_autotuner_cls: type[DebugAutotuner] = DebugAutotuner,
 ):
     """
     A copy of triton.autotune that calls our subclass.  Our subclass

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2259,7 +2259,6 @@ def cached_autotune(
         # Context: When TritonKernel.no_x_dim is True, we hardcode XBLOCK to 1.
         import inspect
 
-        device: DeviceProperties = triton_meta["device"]
         if "XBLOCK" not in inspect.signature(fn.fn).parameters:
             for tconfig in configs:
                 if "XBLOCK" in tconfig.kwargs:

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 from __future__ import annotations
 
+import importlib
 import builtins
 import copy
 import dataclasses
@@ -2257,14 +2258,16 @@ def cached_autotune(
         # Context: When TritonKernel.no_x_dim is True, we hardcode XBLOCK to 1.
         import inspect
 
+        device: DeviceProperties = triton_meta["device"]
         if "XBLOCK" not in inspect.signature(fn.fn).parameters:
             for tconfig in configs:
                 if "XBLOCK" in tconfig.kwargs:
                     assert tconfig.kwargs["XBLOCK"] == 1
                     tconfig.kwargs.pop("XBLOCK")
 
+        heuristic_config = get_heuristic_config(device.type)
         if inductor_meta.get("profile_bandwidth"):
-            return DebugAutotuner(
+            return heuristic_config.debug_autotuner_cls(
                 fn,
                 triton_meta=triton_meta,
                 inductor_meta=inductor_meta,
@@ -2283,7 +2286,7 @@ def cached_autotune(
                 filename=filename,
                 with_bandwidth_info=True,
             )
-        return CachingAutotuner(
+        return heuristic_config.caching_autotuner_cls(
             fn,
             triton_meta=triton_meta,
             inductor_meta=inductor_meta,
@@ -4038,3 +4041,38 @@ class RoundRobinComboKernelGrid(ComboKernelGrid):
         if xnumels_x_dim:
             exprs.append(self.ceildiv(self.maximum(xnumels_x_dim), meta.get("XBLOCK")))
         return f"({self.maximum(exprs)}) * {num_kernels}"
+
+
+
+@dataclasses.dataclass(frozen=True)
+class HeuristicConfig:
+    heuristic_module: str
+    caching_autotuner_cls: type[CachingAutotuner]
+    debug_autotuner_cls: type[DebugAutotuner]
+    def __post_init__(self):
+        assert issubclass(self.caching_autotuner_cls, CachingAutotuner)
+        assert issubclass(self.debug_autotuner_cls, CachingAutotuner)
+        try:
+            importlib.import_module(self.heuristic_module)
+        except ImportError as e:
+            raise ImportError(f"{self.heuristic_module=} must be importable") from e
+
+
+DEFAULT_HEURISTIC_CONFIG = HeuristicConfig(__name__, CachingAutotuner, DebugAutotuner)
+HEURISTIC_PROVIDER: dict[str, HeuristicConfig] = {"cpu": DEFAULT_HEURISTIC_CONFIG, "cuda": DEFAULT_HEURISTIC_CONFIG}
+
+def register_heuristic_config(device: str, heuristic_config: HeuristicConfig, *, allow_override: bool = False) -> None:
+    if device in HEURISTIC_PROVIDER and not allow_override:
+        raise RuntimeError(
+            f"{device=} has an existing registration {HEURISTIC_PROVIDER[device]}. "
+            "To override this set `allow_override` to True"
+        )
+    HEURISTIC_PROVIDER[device] = heuristic_config
+
+def get_heuristic_config(device: str, *, allow_fallback: bool = True):
+    if not allow_fallback and device not in HEURISTIC_PROVIDER:
+        raise RuntimeError(
+            f"{device=} does not have a heuristic config registered and {allow_fallback=}."
+            f" Available configs: {HEURISTIC_PROVIDER}"
+        )
+    return HEURISTIC_PROVIDER.get(device, DEFAULT_HEURISTIC_CONFIG)

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2267,7 +2267,6 @@ def cached_autotune(
                     assert tconfig.kwargs["XBLOCK"] == 1
                     tconfig.kwargs.pop("XBLOCK")
 
-        heuristic_config = get_heuristic_config(device.type)
         if inductor_meta.get("profile_bandwidth"):
             return debug_autotuner_cls(
                 fn,

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -63,7 +63,6 @@ from .codegen.common import (
 from .codegen.simd_kernel_features import SIMDKernelFeatures
 from .codegen.subgraph import SubgraphChoiceCaller
 from .codegen.triton import (
-    gen_common_triton_imports,
     texpr,
     TMACompatibilityChecker,
     TritonKernel,
@@ -787,7 +786,7 @@ class TritonTemplateKernel(TritonKernel):
             # python_argdefs() cannot be run until after the rest of the template lazily adds more args
             arg_defs, *_ = self.args.python_argdefs()
             code = IndentedBuffer()
-            code.splice(gen_common_triton_imports())
+            code.splice(self.gen_common_triton_imports())
             code.splice(self.jit_lines())
             code.writeline(
                 f"def {self.kernel_name}({', '.join(x.full_name() for x in arg_defs)}):"


### PR DESCRIPTION
This refactor replaces direct uses of TritonKernel in cases where a subclass type is available since out of tree / custom backends can:
- have their own configs that they would like to place in `inductor_meta` via a `TritonKernel` subclass for the autotuner to handle
- have their own triton heuristics for the different types of operations (pointwise, reduction e.t.c). These heuristics can currently only be reached by patching. This change allows custom backends to inject their own imports directly via a subclass

Example out of tree backends with their own heuristic modules: 

Ascend NPU: https://github.com/Ascend/pytorch/blob/045a034dbcec287a5997aa13fd129a1cd6b1e215/torch_npu/_inductor/npu_triton_heuristics.py#L4

Intel XPU: https://github.com/intel/intel-extension-for-pytorch/blob/5dcc9d57e5422cf295e1a1ee97896d6b6a554a85/intel_extension_for_pytorch/_inductor/xpu/triton_ops/autotune.py

It also adds a `triton_meta_common` method that is analogous to `inductor_meta_common` that is overridable, so that compile options can be directly provided.

Test plan:

Added unit tests to test_triton_extension_backend.py


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @chenyang78