### PR TITLE
[Fix] fix array out-of-bound  in LossCTC alpha kernel

### DIFF
--- a/aten/src/ATen/native/cuda/LossCTC.cu
+++ b/aten/src/ATen/native/cuda/LossCTC.cu
@@ -88,14 +88,15 @@ ctc_loss_log_alpha_gpu_kernel(scalar_t* __restrict__ log_alpha_data,
 
   // bookkeeping
   int64_t b = threadIdx.y + blockIdx.y * blockDim.y;
+
+  if (b >= batch_size)
+    return;
+
   int64_t input_length = input_lengths[b];
   int64_t target_length = target_lengths[b];
   int64_t lp_batch_offset = b*lp_batch_stride;
   int64_t la_batch_offset = b*la_batch_stride;
   int64_t tg_batch_offset = tg_batch_offsets[b];
-
-  if (b >= batch_size)
-    return;
 
   if (input_length == 0) {
     if (threadIdx.x == 0) {


### PR DESCRIPTION
#141607 fixes oob problem in beta kernel. However, alpha kernel shares similar issues.

https://github.com/pytorch/pytorch/blob/52e744d68a6ea5319d0e8f7bc0e3a2f3cc599ae1/aten/src/ATen/native/cuda/LossCTC.cu#L332-L341
