### PR TITLE
[inductor][aarch64] Prefer PyTorch vendored libgomp over system libgomp on Aarch64

### DIFF
--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -1308,16 +1308,9 @@ def perload_gcc_libgomp_linux(cflags, ldflags, libs, lib_dir_paths):
         if not torch_libgomp:
             continue
         path = Path(torch_libgomp[0]).resolve()
-
         ldflags.append(f"L{path.parent}")
         ldflags.append(f"Wl,-rpath,{path.parent}")
-        ldflags.append(f"Wl,-rpath-link,{path.parent}")
-        ldflags.append("Wl,--as-needed")
-
         libs.append(f":{path.name}")
-
-        # Track the directory so it's prioritized
-        lib_dir_paths.append(str(path.parent))
 
         print(f"[DEBUG] Prioritizing TORCH libgomp: {path}")
         return True

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -1301,7 +1301,7 @@ def perload_icx_libomp_win(cpp_compiler: str) -> None:
         _load_icx_built_in_lib_by_name(cpp_compiler, lib_name)
 
 
-def preload_gcc_libgomp_linux(cflags, ldflags, libs, lib_dir_paths):
+def preload_gcc_libgomp_linux(ldflags, libs):
     torch_root = Path(torch.__file__).resolve().parent
     for d in [torch_root / "lib", torch_root.parent / "torch.libs"]:
         torch_libgomp = glob.glob(str(d / "libgomp-*.so*"))
@@ -1428,8 +1428,8 @@ def _get_openmp_args(
             else:
                 # GCC on Linux
                 # Explicitly control OpenMP linkage and prefer torch libgomp if available
-                preload_gcc_libgomp_linux(cflags, ldflags, libs, lib_dir_paths)
-                cflags += ["fopenmp"]
+                preload_gcc_libgomp_linux(ldflags, libs)
+                cflags.append("fopenmp")
 
     return cflags, ldflags, include_dir_paths, lib_dir_paths, libs, passthrough_args
 

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -5,6 +5,7 @@ import copy
 import ctypes
 import errno
 import functools
+import glob
 import json
 import locale
 import logging
@@ -19,7 +20,6 @@ import sysconfig
 import tempfile
 import textwrap
 import warnings
-import glob
 from collections.abc import Sequence
 from ctypes import cdll, wintypes
 from ctypes.util import find_library
@@ -1300,8 +1300,8 @@ def perload_icx_libomp_win(cpp_compiler: str) -> None:
     for lib_name in preload_list:
         _load_icx_built_in_lib_by_name(cpp_compiler, lib_name)
 
-def preload_gcc_libgomp_linux(cflags, ldflags, libs, lib_dir_paths):
 
+def preload_gcc_libgomp_linux(cflags, ldflags, libs, lib_dir_paths):
     torch_root = Path(torch.__file__).resolve().parent
     for d in [torch_root / "lib", torch_root.parent / "torch.libs"]:
         torch_libgomp = glob.glob(str(d / "libgomp-*.so*"))
@@ -1313,12 +1313,14 @@ def preload_gcc_libgomp_linux(cflags, ldflags, libs, lib_dir_paths):
         ldflags.append(f"Wl,-rpath,{path.parent}")
         libs.append(f":{path.name}")
 
-        print(f"[DEBUG] Prioritizing TORCH libgomp: {path}")
+        log.debug("Prioritizing TORCH libgomp: %s", path)
         break
+
     else:
         # fallback to system gomp
         libs.append("gomp")
-        print("[WARN] Falling back to system libgomp")
+        log.warning("Falling back to system libgomp")
+
 
 def _get_openmp_args(
     cpp_compiler: str,

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -1303,11 +1303,11 @@ def perload_icx_libomp_win(cpp_compiler: str) -> None:
 def preload_gcc_libgomp_linux(cflags, ldflags, libs, lib_dir_paths):
 
     torch_root = Path(torch.__file__).resolve().parent
-    for d in [torch_root / "lib", (torch_root.parent / "torch.libs").resolve()]:
+    for d in [torch_root / "lib", torch_root.parent / "torch.libs"]:
         torch_libgomp = glob.glob(str(d / "libgomp-*.so*"))
         if not torch_libgomp:
             continue
-        
+
         path = Path(torch_libgomp[0]).resolve()
         ldflags.append(f"L{path.parent}")
         ldflags.append(f"Wl,-rpath,{path.parent}")
@@ -1319,7 +1319,7 @@ def preload_gcc_libgomp_linux(cflags, ldflags, libs, lib_dir_paths):
         # fallback to system gomp
         libs.append("gomp")
         print("[WARN] Falling back to system libgomp")
-    
+
 def _get_openmp_args(
     cpp_compiler: str,
 ) -> tuple[list[str], list[str], list[str], list[str], list[str], list[str]]:


### PR DESCRIPTION
Fixes #166087

This change ensures that TorchInductor explicitly prefers PyTorch’s bundled `libgomp` runtime over the system `libgomp` when compiling JIT-generated C++ kernels on Linux/AArch64.  

Previously, the Inductor CppBuilder could link against the system `libgomp`, which can lead to symbol conflicts or runtime mismatches with PyTorch’s own OpenMP runtime.  

This patch:
- Adds logic to `_get_openmp_args()` to locate and link the torch 's `libgomp` from `torch.libs` if available.
- Includes safety checks and minimal debug prints for verification.

### Testing
- Verified Inductor JIT compilation under torch.compile: using - TORCH_COMPILE_DEBUG=1 python repro.py
        Confirmed from debug logs that JIT compilation succeeded.
- Confirmed runtime linkage resolves to PyTorch’s vendored libgomp using:  LD_DEBUG=libs python repro.py 2>&1 | grep libgomp
        Ensures all Inductor JIT kernels dynamically link against PyTorch’s vendored libgomp, not the system /lib/aarch64-linux-gnu/libgomp.so.1

Before (system libgomp)

Inductor JIT-compiled C++ kernels linked against the system libgomp instead of PyTorch’s libgomp:

```
search path=/lib/aarch64-linux-gnu
trying file=/lib/aarch64-linux-gnu/libgomp.so.1
calling init: /lib/aarch64-linux-gnu/libgomp.so.1
```

After (PyTorch’s libgomp)

Inductor now correctly links against and preloads PyTorch’s libgomp:

```
search path=/.../torch.libs
trying file=/home/.../torch.libs/libgomp-1dd373e6.so.1.0.0
calling init: /home/.../torch.libs/libgomp-1dd373e6.so.1.0.0
[DEBUG] Using torch libgomp from: /home/.../torch.libs/libgomp-1dd373e6.so.1.0.0
```
We can also test if the preferred libgomp has been loaded by using ldd. The minimal command that we use to test the binary- 
`ldd /tmp/torchinductor_gausah01/43/c43vuksae2vizxeqgfjluahbia5rcu3j2pzguakrgwtcb44weyq5.main.so `

### Release notes
**Fixes #166087**

cc @snadampal @milpuz01 @aditew01 @nikhil-arm @fadara01 @nWEIdia @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @chenyang78 