### PR TITLE
[ez] Remove spammy deprecation log

### DIFF
--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1806,7 +1806,7 @@ class FrozenDataClassVariable(UserDefinedObjectVariable):
         # Handle specific pytree classes
         import torch.utils._pytree as pytree
 
-        if isinstance(self.value_type, pytree.TreeSpec) and self.value_type.is_leaf():
+        if isinstance(self.value, pytree.TreeSpec) and self.value.is_leaf():
             # Create a new LeafSpec instance by calling the constructor
             codegen.add_push_null(
                 lambda: codegen.load_import_from("torch.utils._pytree", "LeafSpec")

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1806,7 +1806,7 @@ class FrozenDataClassVariable(UserDefinedObjectVariable):
         # Handle specific pytree classes
         import torch.utils._pytree as pytree
 
-        if self.value_type is pytree.LeafSpec:
+        if isinstance(self.value_type, pytree.TreeSpec) and self.value_type.is_leaf():
             # Create a new LeafSpec instance by calling the constructor
             codegen.add_push_null(
                 lambda: codegen.load_import_from("torch.utils._pytree", "LeafSpec")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #167470


"
/packages/pytorch_latest_sixlib_conda/conda/lib/python3.12/site-packages/torch/_dynamo/variables/user_defined.py:1815: FutureWarning: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.
  return ctor(*args, **kwargs)"

is too spammy


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela