### PR TITLE
Fix tensor creation documentation inconsistency

### DIFF
--- a/docs/cpp/source/notes/tensor_creation.rst
+++ b/docs/cpp/source/notes/tensor_creation.rst
@@ -153,7 +153,7 @@ allowed values for these axes at the moment are:
 
 An instance of ``TensorOptions`` stores a concrete value for each of these
 axes. Here is an example of creating a ``TensorOptions`` object that represents
-a 64-bit float, strided tensor that requires a gradient, and lives on CUDA
+a 32-bit float, strided tensor that requires a gradient, and lives on CUDA
 device 1:
 
 .. code-block:: cpp


### PR DESCRIPTION
## Summary

Fixes issue #167467 - documentation inconsistency in C++ tensor creation example.

## Problem
The documentation described creating a "64-bit float" tensor but the code example used torch::kFloat32 (32-bit float).

The text said "64-bit float" but the code showed:
.dtype(torch::kFloat32)  // This is actually 32-bit\!

## Solution  
Updated the description to match the code: "32-bit float" instead of "64-bit float".

## Why This Fix is Correct
- Maintains consistency with all other examples in the documentation
- Aligns with the documented default (kFloat32) 
- Matches the final Python/C++ comparison which uses float32
- Preserves the pedagogical intent of showing explicit configuration

## Changes
- Changed 1 line in docs/cpp/source/notes/tensor_creation.rst
- Description now correctly states "32-bit float" to match torch::kFloat32

Fixes #167467