### PR TITLE
Enable Doc builds for: Minor Releases RCs. Minor and Patch Releases final RC

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,9 +6,9 @@ on:
   push:
     tags:
       # NOTE: Doc build pipelines should only get triggered on:
-      # Minor release candidates builds
+      # Major or minor release candidates builds
       - v[0-9]+.[0-9]+.0+-rc[0-9]+
-      # Final RC for both minor and patch releases
+      # Final RC for major, minor and patch releases
       - v[0-9]+.[0-9]+.[0-9]+
       - ciflow/nightly/*
   workflow_dispatch:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,9 +5,9 @@ on:
     - cron: 0 0 * * *
   push:
     tags:
-      # NOTE: Doc build pipelines should only get triggered on release candidate builds
+      # NOTE: Doc build pipelines should only get triggered on minor release candidate builds
       # Release candidate tags look like: v1.11.0-rc1
-      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+      - v[0-9]+.[0-9]+.0+-rc[0-9]+
       - ciflow/nightly/*
   workflow_dispatch:
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,9 +5,11 @@ on:
     - cron: 0 0 * * *
   push:
     tags:
-      # NOTE: Doc build pipelines should only get triggered on minor release candidate builds
-      # Release candidate tags look like: v1.11.0-rc1
+      # NOTE: Doc build pipelines should only get triggered on:
+      # Minor release candidates builds
       - v[0-9]+.[0-9]+.0+-rc[0-9]+
+      # Final RC for both minor and patch releases
+      - v[0-9]+.[0-9]+.[0-9]+
       - ciflow/nightly/*
   workflow_dispatch:
 


### PR DESCRIPTION
Enable Doc builds for
1. Minor Releases RCs
2. Minor and Patch Releases final RC

This is done to prevent publishing doc for patch releases when building rcs.
See: 
https://github.com/pytorch/docs/pull/57

Followup after: https://github.com/pytorch/pytorch/pull/153973