### PR TITLE
Expose `THPVariable_Wrap()` with a type argument

### DIFF
--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -514,6 +514,10 @@ static int THPFake_clear(THPVariable* self) {
   return 0;
 }
 
+PyObject* THPVariable_Wrap(const at::TensorBase& var, PyTypeObject* type) {
+  return THPVariable_WrapWithType(var, type);
+}
+
 static PyObject* THPVariable_pynew(
     PyTypeObject* type,
     PyObject* args,

--- a/torch/csrc/autograd/python_variable.h
+++ b/torch/csrc/autograd/python_variable.h
@@ -38,6 +38,9 @@ TORCH_PYTHON_API extern PyObject* ParameterClass;
 
 bool THPVariable_initModule(PyObject* module);
 TORCH_PYTHON_API PyObject* THPVariable_Wrap(const at::TensorBase& var);
+TORCH_PYTHON_API PyObject* THPVariable_Wrap(
+    const at::TensorBase& var,
+    PyTypeObject* type);
 
 inline bool THPVariable_CheckTypeExact(PyTypeObject* tp) {
   // Check that a python object is a `Tensor`, but not a `Tensor` subclass.


### PR DESCRIPTION
For torchdistx, which is only *mostly* dead

Differential Revision: D86712979


