### PR TITLE
[inductor][ck] refactor for stateless templates

### DIFF
--- a/torch/_inductor/codegen/rocm/ck_template.py
+++ b/torch/_inductor/codegen/rocm/ck_template.py
@@ -98,6 +98,12 @@ class CKTemplate(ROCmTemplate):
         else:
             return f"({self._TORCH_DTYPE_TO_CK.get(node.get_dtype())}*)({ptr})"
 
+    def _make_output_node(self, layout):
+        """Helper to create output buffer on-the-fly."""
+        from torch._inductor.ir import Buffer
+
+        return Buffer(name="buf_out", layout=layout)
+
     @override
     def get_runtime_arg_info(self) -> list[ArgInfo]:
         return [ArgInfo("kBatch", "int32_t")]

--- a/torch/_inductor/codegen/rocm/rocm_template.py
+++ b/torch/_inductor/codegen/rocm/rocm_template.py
@@ -29,58 +29,38 @@ class ArgInfo:
 
 
 class ROCmTemplate(KernelTemplate):
+    """Base class for ROCm C++ kernel templates - templates are stateless and input dependent types come in for generation."""
+
     index_counter = itertools.count()
     gfx9_threads_per_warp = 64
 
-    def __init__(
+    def generate(  # type: ignore[override]
         self,
-        name: str,
         input_nodes: list[Buffer],
         layout: Layout,
         input_reorder: Optional[list[int]] = None,
-    ) -> None:
-        """
-
-        Baseclass for ROCm C++ Templates, derived from KernelTemplate. Not to be instantiated directly.
-
-        Args:
-            name (str): The name of the ROCmTemplate object.
-            input_nodes (List[IRNode]): A list of input IRNodes.
-            layout (Layout): The layout of the output buffer / tensor.
-            input_reorder (Optional[List[int]]): An optional list that specifies the order of the input nodes.
-
-        """
-        super().__init__(name)
-        self.input_nodes = input_nodes
-        self.output_node: Buffer = Buffer(name="buf_out", layout=layout)
-        self.input_reorder = input_reorder
-        self.layout = layout
-
-    def generate(  # type: ignore[override]
-        self,
         **kwargs,
     ) -> ROCmTemplateCaller:
-        """
-        Generates the ROCm template caller object for the given GEMM template and operation. This ROCmTemplateCaller
-        may be used to call and benchmark the generated ROCm kernel in a standalone manner to enable Autotuning.
+        """Generate ROCm template caller for autotuning."""
+        output_node = Buffer(name="buf_out", layout=layout)
 
-        Args:
-            kwargs: Additional keyword arguments.
-
-        Returns:
-            A ROCmTemplateCaller object representing the generated ROCm template caller.
-        """
         kernel_name = f"rocm_{self.name}"
         kernel_hash_name = f"rocm_{self.name}_{next(self.index_counter)}"
         with (
-            patch.object(V.graph, "get_dtype", self._fake_get_dtype(self.output_node)),
+            patch.object(V.graph, "get_dtype", self._fake_get_dtype(output_node)),
             ROCmTemplateKernel(
                 kernel_name=kernel_name,
                 runtime_arg_info=self.get_runtime_arg_info(),
                 runtime_arg_values=self.get_runtime_arg_values(**kwargs),
             ) as kernel,
         ):
-            code = self.render(kernel=kernel, **kwargs)
+            code = self.render(
+                kernel=kernel,
+                input_nodes=input_nodes,
+                output_node=output_node,
+                input_reorder=input_reorder,
+                **kwargs,
+            )
             _, call_args, _, _ = kernel.args.python_argdefs()
             log.debug("Autotune key: %s, Generated Code:\n%s", kernel_hash_name, code)
             log.debug(
@@ -89,33 +69,33 @@ class ROCmTemplate(KernelTemplate):
                 kernel.args.python_argdefs(),
             )
 
-        input_reorder = (
-            self.input_reorder
-            if self.input_reorder is not None
-            else list(range(len(self.input_nodes)))
+        input_reorder_list = (
+            input_reorder
+            if input_reorder is not None
+            else list(range(len(input_nodes)))
         )
         expected_args = list(
-            unique(self.input_nodes[idx].get_name() for idx in input_reorder)
+            unique(input_nodes[idx].get_name() for idx in input_reorder_list)
         )
-        expected_args.extend([self.output_node.get_name()])
+        expected_args.extend([output_node.get_name()])
         assert list(call_args)[: len(expected_args)] == expected_args, (
             call_args,
             expected_args,
         )
 
         size_args = (
-            self.size_args() if hasattr(self, "size_args") else ()
-        )  # subclass should define def size_args()
-        size_args_ints = [
-            V.graph.sizevars.size_hint(arg) for arg in size_args
-        ]  # resolve to ints for benchmarking
+            self.size_args(input_nodes, layout, **kwargs)
+            if hasattr(self, "size_args")
+            else ()
+        )
+        size_args_ints = [V.graph.sizevars.size_hint(arg) for arg in size_args]
         # The runtime args come right after the size args
         runtime_args = self.get_runtime_arg_values(**kwargs)
         extra_args = size_args_ints + runtime_args
         bmreq = ROCmBenchmarkRequest(
             kernel_name=kernel_name,
-            input_tensor_meta=TensorMeta.from_irnodes(self.input_nodes),
-            output_tensor_meta=TensorMeta.from_irnodes(self.output_node),
+            input_tensor_meta=TensorMeta.from_irnodes(input_nodes),
+            output_tensor_meta=TensorMeta.from_irnodes(output_node),
             extra_args=extra_args,
             source_code=code,
         )
@@ -132,22 +112,28 @@ class ROCmTemplate(KernelTemplate):
             render = functools.partial(
                 self.render,
                 kernel=kernel,
+                input_nodes=input_nodes,
+                output_node=template_node if template_node is not None else output_node,
+                input_reorder=input_reorder,
                 template_buffer_node=template_node,
                 epilogue_nodes=epilogue_nodes,
-                **kwargs,  # includes "op" argument in case of CUTLASSGemmTemplate
+                **kwargs,
             )
             return kernel, render
 
         return ROCmTemplateCaller(
             kernel_hash_name,
             self.name,
-            self.input_nodes,
-            self.output_node.get_layout(),
+            input_nodes,
+            output_node.get_layout(),
             make_kernel_render,
             bmreq,
             self,
             kwargs,
         )
+
+    def _fake_get_dtype(self, buf):
+        return lambda name: buf.get_dtype() if name == buf.get_name() else None
 
     def header(self) -> IndentedBuffer:
         res = IndentedBuffer()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #167514

# why

- enable CK to go through the lookup table the same way as Triton
templates
- avoid regenerating new template instances always (minor)

# what

- refactor ROCmTemplate and derivates to be stateless templates
- make problem and config dependent information go through the
  respective methods e.g. generate
- use module wide instances of the templates (single template) when
  generating choices similar to how triton handles this

# testing

ci

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @dllehr-amd @chenyang78

Differential Revision: [D86732686](https://our.internmc.facebook.com/intern/diff/D86732686)