### PR TITLE
 [ROCm] Expand triton wheel workflow to build ROCm version N and N-1

### DIFF
--- a/.ci/pytorch/binary_populate_env.sh
+++ b/.ci/pytorch/binary_populate_env.sh
@@ -85,10 +85,14 @@ fi
 
 # Set triton via PYTORCH_EXTRA_INSTALL_REQUIREMENTS for triton rocm package
 if [[ "$PACKAGE_TYPE" =~ .*wheel.* && -n "$PYTORCH_BUILD_VERSION" && "$PYTORCH_BUILD_VERSION" =~ .*rocm.* && $(uname) == "Linux" ]]; then
-    TRITON_REQUIREMENT="triton-rocm==${TRITON_VERSION}; ${TRITON_CONSTRAINT}"
+    # Extract ROCm version from PYTORCH_BUILD_VERSION (e.g., "2.6.0.dev20252111+rocm7.1" -> "7.1")
+    ROCM_VERSION=$(echo "$PYTORCH_BUILD_VERSION" | sed -n 's/.*rocm\([0-9.]*\).*/\1/p')
+    TRITON_REQUIREMENT="triton-rocm==${TRITON_VERSION}+rocm${ROCM_VERSION}; ${TRITON_CONSTRAINT}"
     if [[ -n "$PYTORCH_BUILD_VERSION" && "$PYTORCH_BUILD_VERSION" =~ .*dev.* ]]; then
         TRITON_SHORTHASH=$(cut -c1-8 $PYTORCH_ROOT/.ci/docker/ci_commit_pins/triton.txt)
-        TRITON_REQUIREMENT="triton-rocm==${TRITON_VERSION}+git${TRITON_SHORTHASH}; ${TRITON_CONSTRAINT}"
+        # Triton's setup.py generates: base + git_suffix + env_suffix
+        # e.g. 3.5.1+git{hash}.rocm{version}
+        TRITON_REQUIREMENT="triton-rocm==${TRITON_VERSION}+git${TRITON_SHORTHASH}.rocm${ROCM_VERSION}; ${TRITON_CONSTRAINT}"
     fi
     if [[ -z "${PYTORCH_EXTRA_INSTALL_REQUIREMENTS:-}" ]]; then
         export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="${TRITON_REQUIREMENT}"

--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -60,6 +60,7 @@ def build_triton(
     py_version: str | None = None,
     release: bool = False,
     with_clang_ldd: bool = False,
+    rocm_version: Optional[str] = None,
 ) -> Path:
     env = os.environ.copy()
     if "MAX_JOBS" not in env:
@@ -73,6 +74,15 @@ def build_triton(
         triton_repo = "https://github.com/openai/triton"
         if device == "rocm":
             triton_pkg_name = "triton-rocm"
+            # Set version suffix for Triton's setup.py to use
+            # Triton's setup.py generates: base_version + git_suffix + env_suffix
+            # For nightly: git_suffix = "+git{hash}", so we use ".rocm{ver}" → 3.5.1+gitXXX.rocm7.1
+            # For release: git_suffix = "", so we use "+rocm{ver}" → 3.5.1+rocm7.1
+            if rocm_version:
+                if release:
+                    env["TRITON_WHEEL_VERSION_SUFFIX"] = f"+rocm{rocm_version}"
+                else:
+                    env["TRITON_WHEEL_VERSION_SUFFIX"] = f".rocm{rocm_version}"
         elif device == "xpu":
             triton_pkg_name = "triton-xpu"
             triton_repo = "https://github.com/intel/intel-xpu-backend-for-triton"
@@ -145,20 +155,29 @@ def main() -> None:
     parser = ArgumentParser("Build Triton binaries")
     parser.add_argument("--release", action="store_true")
     parser.add_argument(
-        "--device", type=str, default="cuda", choices=["cuda", "rocm", "xpu", "aarch64"]
+        "--device",
+        type=str,
+        default="cuda",
+        choices=["cuda", "rocm-n", "rocm-n-1", "xpu", "aarch64"],
     )
     parser.add_argument("--py-version", type=str)
     parser.add_argument("--commit-hash", type=str)
     parser.add_argument("--with-clang-ldd", action="store_true")
     parser.add_argument("--triton-version", type=str, default=None)
+    parser.add_argument("--rocm-version", type=str, default=None)
     args = parser.parse_args()
 
     triton_version = read_triton_version(args.device)
     if args.triton_version:
         triton_version = args.triton_version
 
+    # Normalize device name for rocm-n rocm-n-1 builds
+    device = args.device
+    if args.device.startswith("rocm"):
+        device = "rocm"
+
     build_triton(
-        device=args.device,
+        device=device,
         commit_hash=(
             args.commit_hash if args.commit_hash else read_triton_pin(args.device)
         ),
@@ -166,6 +185,7 @@ def main() -> None:
         py_version=args.py_version,
         release=args.release,
         with_clang_ldd=args.with_clang_ldd,
+        rocm_version=args.rocm_version,
     )
 
 

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -165,7 +165,7 @@ jobs:
               docker exec -t "${container_name}" "${PYTHON_EXECUTABLE}"  -m pip install -U cmake --force-reinstall
           fi
 
-          if [[ "${{ matrix.device }}" == "cuda" || "${{ matrix.device }}" == rocm-* || "${{ matrix.device }}" == "aarch64" ]]; then
+          if [[ "${{ matrix.device }}" == "cuda" || "${{ matrix.device }}" =~ ^rocm- || "${{ matrix.device }}" == "aarch64" ]]; then
             # With this install, it gets clang 16.0.6.
             docker exec -t "${container_name}" dnf install clang lld -y
             WITH_CLANG_LDD="--with-clang-ldd"

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         py_vers: [ "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t" ]
-        device: ["cuda", "rocm", "xpu", "aarch64"]
+        device: ["cuda", "rocm-n", "rocm-n-1", "xpu", "aarch64"]
         docker-image: ["pytorch/manylinux2_28-builder:cpu"]
         exclude:
           # XPU builds for Python 3.15 are currently broken; skip until fixed.
@@ -60,8 +60,11 @@ jobs:
           - py_vers: "3.15t"
             device: "xpu"
         include:
-          - device: "rocm"
+          - device: "rocm-n"
             rocm_version: "7.2"
+            runs_on: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge"
+          - device: "rocm-n-1"
+            rocm_version: "7.1"
             runs_on: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge"
           - device: "cuda"
             rocm_version: ""
@@ -74,7 +77,7 @@ jobs:
             runs_on: "${{ needs.get-label-type.outputs.label-type }}linux.arm64.2xlarge"
     timeout-minutes: 40
     env:
-      DOCKER_IMAGE: ${{ matrix.device == 'rocm' && format('pytorch/manylinux2_28-builder:rocm{0}', matrix.rocm_version) || matrix.device == 'aarch64' && 'pytorch/manylinux2_28_aarch64-builder:cpu-aarch64' || matrix.docker-image }}
+      DOCKER_IMAGE: ${{ startsWith(matrix.device, 'rocm') && format('pytorch/manylinux2_28-builder:rocm{0}', matrix.rocm_version) || matrix.device == 'aarch64' && 'pytorch/manylinux2_28_aarch64-builder:cpu-aarch64' || matrix.docker-image }}
       PY_VERS: ${{ matrix.py_vers }}
       BUILD_DEVICE: ${{ matrix.device }}
       PLATFORM: 'manylinux_2_28_x86_64'
@@ -162,13 +165,13 @@ jobs:
               docker exec -t "${container_name}" "${PYTHON_EXECUTABLE}"  -m pip install -U cmake --force-reinstall
           fi
 
-          if [[ ("${{ matrix.device }}" == "cuda" || "${{ matrix.device }}" == "rocm" || "${{ matrix.device }}" == "aarch64" ) ]]; then
+          if [[ "${{ matrix.device }}" == "cuda" || "${{ matrix.device }}" == rocm-* || "${{ matrix.device }}" == "aarch64" ]]; then
             # With this install, it gets clang 16.0.6.
             docker exec -t "${container_name}" dnf install clang lld -y
             WITH_CLANG_LDD="--with-clang-ldd"
           fi
 
-          docker exec -t "${container_name}" bash -c "${PYTHON_EXECUTABLE} /pytorch/.github/scripts/build_triton_wheel.py --device=$BUILD_DEVICE $RELEASE $WITH_CLANG_LDD"
+          docker exec -t "${container_name}" bash -c "${PYTHON_EXECUTABLE} /pytorch/.github/scripts/build_triton_wheel.py --device=$BUILD_DEVICE --rocm-version='${{ matrix.rocm_version }}' $RELEASE $WITH_CLANG_LDD"
 
           if [[ ("${{ matrix.device }}" == "cuda" || "${{ matrix.device }}" == "xpu") ]]; then
             docker exec -t "${container_name}"  bash -c "auditwheel repair --plat ${PLATFORM} --exclude libtriton.so //artifacts/*.whl"
@@ -180,7 +183,7 @@ jobs:
 
       - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
-          name: triton-wheel-${{ matrix.py_vers }}-${{ matrix.device }}-${{ env.PLATFORM }}
+          name: triton-wheel-${{ matrix.py_vers }}-${{ matrix.rocm_version != '' && format('rocm-{0}', matrix.rocm_version) || matrix.device }}-${{ env.PLATFORM }}
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/wheelhouse/*
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/167411

Update triton whl build flow to publish pytorch-triton-rocm package built for ROCm version N and N-1 (currently 7.1 and 7.0)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @dllehr-amd