### PR TITLE
[Docs] Add warning that `torch.export.load` uses `pickle`

### DIFF
--- a/torch/export/__init__.py
+++ b/torch/export/__init__.py
@@ -398,6 +398,9 @@ def load(
         Under active development, saved files may not be usable in newer versions
         of PyTorch.
 
+    .. warning::
+        :func:`torch.export.load()` uses pickle under the hood to load models. **Never load data from an untrusted source.**
+
     Loads an :class:`ExportedProgram` previously saved with
     :func:`torch.export.save <torch.export.save>`.
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #167557

