### PR TITLE
[annotation] Skip copying custom meta for gradient accumulation nodes; tag with is_gradient_acc=True

### DIFF
--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -950,7 +950,7 @@ SeqNr|OrigAten|SrcFn|FwdSrcFn
 2|aten.threshold_backward.default||relu
 1|aten.native_batch_norm_backward.default||batch_norm
 0|aten.convolution_backward.default||conv2d
-11|aten.add.Tensor||l1_loss
+11|aten.add.Tensor||
 """
             ),
         )

--- a/torch/_functorch/_aot_autograd/logging_utils.py
+++ b/torch/_functorch/_aot_autograd/logging_utils.py
@@ -125,9 +125,7 @@ def setup_stacktrace_preservation_hooks(roots: list):
         node.register_prehook(get_prehook(forward_node_stack, node._sequence_nr()))
 
         special_stack = forward_node_stack.copy()
-        special_stack.append(
-            "Gradient addition node due to multiple use of tensor around:"
-        )
+        special_stack.append(fx_traceback.GRADIENT_ACC_SPECIAL_STACK)
         node.register_hook(get_posthook(special_stack, node._sequence_nr()))
 
 

--- a/torch/_functorch/_aot_autograd/utils.py
+++ b/torch/_functorch/_aot_autograd/utils.py
@@ -454,6 +454,11 @@ def _copy_metadata_to_bw_nodes_in_subgraph(
         if not _is_backward_node_with_seq_nr(node):
             continue
 
+        # We exclude gradient accumulation nodes from copying tags
+        if node.meta.get("is_gradient_acc", False):
+            annotation_log.debug("is_gradient_acc")
+            continue
+
         # fwd_node should always exist, but handle non-existence just in case
         fwd_node = fwd_seq_nr_to_node.get(node.meta["seq_nr"])
         if fwd_node is not None:

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -187,6 +187,10 @@ class TracerBase:
             stack_trace = current_meta.get("stack_trace")
             if stack_trace:
                 node.stack_trace = stack_trace
+
+                if fx_traceback.GRADIENT_ACC_SPECIAL_STACK in stack_trace:
+                    node.meta["is_gradient_acc"] = True
+
             # Explicitly set the stack_trace, nn_module_stack and source_fn on the node.meta
             # If other meta fields are needed, they can be added here
             for field in _COPY_META_FIELDS:

--- a/torch/fx/traceback.py
+++ b/torch/fx/traceback.py
@@ -38,6 +38,9 @@ current_meta: dict[str, Any] = {}
 current_replay_node: Optional[Node] = None
 should_preserve_node_meta = False
 
+GRADIENT_ACC_SPECIAL_STACK = (
+    "Gradient addition node due to multiple use of tensor around:"
+)
 # =============================================================================
 # FX Metadata Registry for Memory Profiler
 # =============================================================================
@@ -276,6 +279,8 @@ def annotate(annotation_dict: dict):
     This context manager allows you to insert arbitrary metadata into the PT2
     tracing system by updating the global `current_meta["custom"]` dictionary.
     The annotations are automatically reverted after the context exits.
+
+    Gradient accumulation nodes will not be annotated.
 
     This is intended for advanced users who need to attach additional metadata to the fx nodes
     (e.g., for debugging, analysis, or external tooling) during export tracing.


### PR DESCRIPTION
The seq_nr  doesn't always increment for gradient accumulation nodes, and they might be copying annotation from forward nodes. 

I'm just going to skip copying the custom meta for any gradient accumulation nodes and give them a special tag e.g. node.meta["is_gradient_acc"]=True

Example repro for deepseek torchtitan (without using DTensor): https://gist.github.com/yushangdi/aae13ea382732f31d0fdfb3ffeda12c8

(side note: if you want some more hints on these gradient acc node: 1) they have torch.ops.aten.add.Tensor op, not add.default. 2) they have the highest seq_nr(s) )

cc @ezyang @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela