### PR TITLE
Set device when init optimizer step

### DIFF
--- a/torch/optim/_adafactor.py
+++ b/torch/optim/_adafactor.py
@@ -95,7 +95,9 @@ class Adafactor(Optimizer):
             if len(state) == 0:
                 # note(crcrpar): Deliberately host `step` on CPU if both capturable and fused are off.
                 # This is because kernel launches are costly on CUDA and XLA.
-                state["step"] = torch.tensor(0.0, dtype=_get_scalar_dtype())
+                state["step"] = torch.tensor(
+                    0.0, dtype=_get_scalar_dtype(), device=p.device
+                )
 
                 if p.grad.dim() > 1:
                     row_shape = list(p.grad.shape)

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -84,7 +84,7 @@ class Adagrad(Optimizer):
                         device=p.device,
                     )
                     if group["fused"]
-                    else torch.tensor(0.0, dtype=_get_scalar_dtype())
+                    else torch.tensor(0.0, dtype=_get_scalar_dtype(), device=p.device)
                 )
                 init_value = (
                     complex(initial_accumulator_value, initial_accumulator_value)

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -172,7 +172,9 @@ class Adam(Optimizer):
                             device=p.device,
                         )
                         if group["capturable"] or group["fused"]
-                        else torch.tensor(0.0, dtype=_get_scalar_dtype())
+                        else torch.tensor(
+                            0.0, dtype=_get_scalar_dtype(), device=p.device
+                        )
                     )
                     # Exponential moving average of gradient values
                     state["exp_avg"] = torch.zeros_like(

--- a/torch/optim/adamax.py
+++ b/torch/optim/adamax.py
@@ -104,7 +104,7 @@ class Adamax(Optimizer):
                 state["step"] = (
                     torch.zeros((), dtype=_get_scalar_dtype(), device=p.device)
                     if group["capturable"]
-                    else torch.tensor(0.0, dtype=_get_scalar_dtype())
+                    else torch.tensor(0.0, dtype=_get_scalar_dtype(), device=p.device)
                 )
                 state["exp_avg"] = torch.zeros_like(
                     p, memory_format=torch.preserve_format

--- a/torch/optim/nadam.py
+++ b/torch/optim/nadam.py
@@ -131,7 +131,9 @@ class NAdam(Optimizer):  # noqa: D101
                     state["step"] = (
                         torch.zeros((), dtype=_get_scalar_dtype(), device=p.device)
                         if group["capturable"]
-                        else torch.tensor(0.0, dtype=_get_scalar_dtype())
+                        else torch.tensor(
+                            0.0, dtype=_get_scalar_dtype(), device=p.device
+                        )
                     )
                     state["mu_product"] = (
                         torch.ones((), dtype=_get_scalar_dtype(), device=p.device)

--- a/torch/optim/radam.py
+++ b/torch/optim/radam.py
@@ -107,7 +107,9 @@ class RAdam(Optimizer):  # noqa: D101
                     state["step"] = (
                         torch.zeros((), dtype=_get_scalar_dtype(), device=p.device)
                         if group["capturable"]
-                        else torch.tensor(0.0, dtype=_get_scalar_dtype())
+                        else torch.tensor(
+                            0.0, dtype=_get_scalar_dtype(), device=p.device
+                        )
                     )
                     # Exponential moving average of gradient values
                     state["exp_avg"] = torch.zeros_like(


### PR DESCRIPTION
When using torch.compile(backend="tpu") with the AdamW optimizer's optim.step(), I observed that some tensors were being placed on the CPU while the rest were on the TPU.

https://github.com/pytorch/pytorch/blob/8d5cceeb6ac1ef62f34ad86776f31046a250d295/torch/optim/adam.py#L687
<img width="1785" height="618" alt="Screenshot 2025-11-11 at 1 45 47 PM" src="https://github.com/user-attachments/assets/e9291c27-6835-4c4c-9afc-32c9686f4364" />


It appears the non-fused optimizer initializes steps on the CPU by default. Explicitly setting Adam's device=p.device during optimizer initialization resolves this issue by ensuring all tensors are on the same device. This solution should be applicable to other optimizers as well.
