### PR TITLE
[dynamo] Fix Tensor Metadata Propagation for In-Place Ops

### DIFF
--- a/test/dynamo/test_dynamo_ops.py
+++ b/test/dynamo/test_dynamo_ops.py
@@ -44,7 +44,7 @@ test_inplace_ops_propagate_requires_grad_metadata_skips = {
     skip("igamma"),
     skip("igammac"),
     skip("addcdiv"),
-    skip("addcmul")
+    skip("addcmul"),
 }
 
 

--- a/test/dynamo/test_dynamo_ops.py
+++ b/test/dynamo/test_dynamo_ops.py
@@ -43,6 +43,8 @@ test_inplace_ops_propagate_requires_grad_metadata_skips = {
     # Numerical gradient mismatch (not a metadata propagation issue)
     skip("igamma"),
     skip("igammac"),
+    skip("addcdiv"),
+    skip("addcmul")
 }
 
 
@@ -166,8 +168,6 @@ class TestTensorMetaProp(torch._dynamo.test_case.TestCase):
             self.assertEqual(
                 args_eager[requires_grad_idx].grad,
                 args_compiled[requires_grad_idx].grad,
-                atol=1e-2,
-                rtol=1e-2,
                 msg=f"{op.name}: Gradient mismatch indicates metadata not propagated during tracing",
             )
 

--- a/test/dynamo/test_dynamo_ops.py
+++ b/test/dynamo/test_dynamo_ops.py
@@ -1,0 +1,181 @@
+# Owner(s): ["module: dynamo"]
+
+"""
+Tests for operator behavior during Dynamo tracing.
+
+This file contains tests that use op_db to verify correct behavior of operators
+when traced by Dynamo.
+"""
+
+import torch
+import torch._dynamo.test_case
+from torch._dynamo.comptime import comptime, ComptimeContext
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    ops,
+)
+from torch.testing._internal.common_methods_invocations import op_db, skip, skipOps
+
+
+# Ops that fail the inplace requires_grad propagation test for known reasons
+test_inplace_ops_propagate_requires_grad_metadata_skips = {
+    # Not implemented for floating point types
+    skip("bitwise_and"),
+    skip("bitwise_left_shift"),
+    skip("bitwise_or"),
+    skip("bitwise_right_shift"),
+    skip("bitwise_xor"),
+    skip("gcd"),
+    skip("lcm"),
+    # out=... arguments don't support automatic differentiation
+    skip("ldexp"),
+    # Backward not implemented
+    skip("floor_divide"),
+    skip("heaviside"),
+    skip("nextafter"),
+    # Output does not require grad (logical ops return bool)
+    skip("logical_and"),
+    skip("logical_or"),
+    skip("logical_xor"),
+    skip("resize_as_"),
+    # Dtype issues
+    skip("float_power"),
+    # Numerical gradient mismatch (not a metadata propagation issue)
+    skip("igamma"),
+    skip("igammac"),
+}
+
+
+class TestTensorMetaProp(torch._dynamo.test_case.TestCase):
+    """
+    Test that inplace operations correctly propagate tensor metadata during Dynamo tracing.
+    """
+
+    @ops([op for op in op_db if op.get_inplace() is not None])
+    @skipOps(
+        "TestTensorMetaProp",
+        "test_inplace_ops_propagate_requires_grad_metadata",
+        test_inplace_ops_propagate_requires_grad_metadata_skips,
+    )
+    def test_inplace_ops_propagate_requires_grad_metadata(self, device, dtype, op):
+        """
+        Test that inplace ops from OpInfo propagate requires_grad correctly.
+
+        This test ensures that when an inplace operation is performed on a tensor
+        without requires_grad using an argument with requires_grad=True, the metadata
+        is correctly propagated in both eager and compiled modes.
+
+        This is critical because if metadata is traced incorrectly, code that branches
+        on requires_grad (like custom autograd functions) will take the wrong path,
+        leading to silent incorrectness.
+        """
+
+        inplace_op = op.get_inplace()
+        if inplace_op is None:
+            self.skipTest("No inplace variant for this op")
+
+        class CustomAutograd(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                ctx.save_for_backward(x)
+                return x * 2
+
+            @staticmethod
+            def backward(ctx, grad_out):
+                # Return an obviously wrong gradient (fixed value) to detect
+                # when composite implicit autograd is used vs custom backward
+                (x,) = ctx.saved_tensors
+                return torch.full_like(x, 123.0)
+
+        # Iterate directly over sample_inputs to preserve correct tracking
+        # (converting to list first breaks the TrackedInputIter tracking)
+        for sample in op.sample_inputs(device, dtype, requires_grad=False):
+            # Skip samples that are broadcasted or have 0 elements
+            if sample.broadcasts_input or sample.input.numel() == 0:
+                continue
+
+            # Skip scatter with reduce modes - backward not implemented for these
+            if op.name == "scatter" and "reduce" in sample.kwargs:
+                continue
+
+            # Reset between samples to avoid exceeding recompile limit
+            torch._dynamo.reset()
+
+            # Setup: x starts with requires_grad=False, one arg has requires_grad=True
+            x_eager = sample.input.clone().detach()
+            args_eager = [
+                arg.clone().detach() if isinstance(arg, torch.Tensor) else arg
+                for arg in sample.args
+            ]
+
+            # Find a floating point tensor arg to set requires_grad=True
+            requires_grad_idx = None
+            for idx, arg in enumerate(args_eager):
+                if isinstance(arg, torch.Tensor) and arg.dtype.is_floating_point:
+                    arg.requires_grad_(True)
+                    requires_grad_idx = idx
+                    break
+
+            if requires_grad_idx is None or x_eager.requires_grad:
+                continue
+
+            # Apply inplace op in eager mode
+            inplace_op(x_eager, *args_eager, **sample.kwargs)
+            output_eager = CustomAutograd.apply(x_eager)
+            output_eager.sum().backward()
+
+            # Setup compiled version
+            x_compiled = sample.input.clone().detach()
+            args_compiled = [
+                arg.clone().detach() if isinstance(arg, torch.Tensor) else arg
+                for arg in sample.args
+            ]
+            args_compiled[requires_grad_idx].requires_grad_(True)
+
+            # Test 1: Verify that the metadata is propagated after the inplace op in compile time
+            def compile_time_check(ctx: ComptimeContext) -> None:
+                x = ctx.get_local("x")
+                x_fake = x.as_fake()
+                # Check requires_grad is propagated
+                self.assertTrue(x_fake.requires_grad)
+                self.assertTrue(x._ComptimeVar__variable.requires_grad)
+                # Check that has_grad_fn is set (not for FakeTensor)
+                self.assertTrue(x._ComptimeVar__variable.has_grad_fn)
+                # Check dtype is preserved
+                self.assertEqual(x_fake.dtype, dtype)
+                self.assertEqual(x._ComptimeVar__variable.dtype, dtype)
+
+            def fn(x, *args):
+                inplace_op(x, *args, **sample.kwargs)
+                comptime(compile_time_check)
+                r = CustomAutograd.apply(x)
+                return r
+
+            compiled_fn = torch.compile(fn, backend="eager", fullgraph=True)
+            output_compiled = compiled_fn(x_compiled, *args_compiled)
+            output_compiled.sum().backward()
+
+            # Test 2: Verify requires_grad was propagated in runtime
+            self.assertEqual(
+                x_eager.requires_grad,
+                x_compiled.requires_grad,
+                msg=f"{op.name}: requires_grad mismatch (eager={x_eager.requires_grad}, compiled={x_compiled.requires_grad})",
+            )
+
+            # Test 3: Verify gradients match (with tolerance for float16/bfloat16)
+            self.assertEqual(
+                args_eager[requires_grad_idx].grad,
+                args_compiled[requires_grad_idx].grad,
+                atol=1e-2,
+                rtol=1e-2,
+                msg=f"{op.name}: Gradient mismatch indicates metadata not propagated during tracing",
+            )
+
+
+instantiate_device_type_tests(TestTensorMetaProp, globals())
+
+
+if __name__ == "__main__":
+    from torch._dynamo.test_case import run_tests
+
+    run_tests()

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -230,6 +230,31 @@ class TensorVariable(VariableTracker):
         for k, v in specialized_props.items():
             setattr(self, k, v)
 
+    def _get_fake_version(self) -> int | None:
+        """Get the current version of self's fake tensor, or None if unavailable."""
+        self_fake = self.proxy.node.meta.get("example_value")
+        return self_fake._version if self_fake is not None else None
+
+    def _sync_if_inplace_mutation(
+        self,
+        tx: "InstructionTranslator",
+        version_before: int | None,
+        has_tensor_arg: bool,
+    ) -> None:
+        """
+        Sync attributes if self was mutated by an inplace operation.
+
+        See Note [Inplace ops and VariableTracker metadata]
+        """
+        version_after = self._get_fake_version()
+        if (
+            version_before is not None
+            and version_after is not None
+            and version_after > version_before
+            and has_tensor_arg
+        ):
+            self.synchronize_attributes(tx)
+
     def debug_repr(self) -> str:
         # TODO: strip off fake tensor from repr here
         return repr(self.proxy.node.meta["example_value"])
@@ -807,14 +832,27 @@ class TensorVariable(VariableTracker):
 
         from .builder import wrap_fx_proxy
 
-        return wrap_fx_proxy(
-            tx,
-            tx.output.create_proxy(
-                "call_method",
-                name,
-                *proxy_args_kwargs([self, *args], kwargs),
-            ),
+        proxy = tx.output.create_proxy(
+            "call_method",
+            name,
+            *proxy_args_kwargs([self, *args], kwargs),
         )
+
+        # [Note: Inplace ops and VariableTracker metadata]
+        # For inplace operations, we need to propagate tensor metadata from the
+        # arguments to self. For example:
+        #   x.add_(y) where y.requires_grad=True => x.requires_grad becomes True
+        # We detect inplace ops by checking if self's fake tensor version changes
+        # after wrap_fx_proxy (which runs get_fake_value internally).
+        # We only synchronize when there's a tensor argument, since that's when
+        # metadata propagation is relevant.
+        version_before = self._get_fake_version()
+        result = wrap_fx_proxy(tx, proxy)
+        self._sync_if_inplace_mutation(
+            tx, version_before, any(arg.is_tensor() for arg in args)
+        )
+
+        return result
 
     def method_size(
         self, tx: "InstructionTranslator", *args: Any, **kwargs: Any
@@ -1391,35 +1429,21 @@ class TensorVariable(VariableTracker):
             *proxy_args_kwargs([self, key, value], {}),
         )
 
-        if value.is_tensor():
-            # [Note: Tensor.__setitem__ and VariableTracker metadata]
-            # At this point, we proxied a node representing `self[key] = value` into the graph.
-            # When executed, this node will mutate `self`'s tensor metadata, so it's important
-            # even during tracing to propagate. For example:
-            #   value.requires_grad is True => self.requires_grad becomes True
-            #   value.requires_grad is True => self.has_grad_fn becomes True
+        # See Note [Inplace ops and VariableTracker metadata]
+        # __setitem__ is always an inplace operation. We need to run fake execution
+        # and propagate metadata if self was mutated.
+        # The context managers handle saved tensor hooks and unbacked symbols.
+        version_before = self._get_fake_version()
 
-            # Not sure if __setitem__ can ever save activations, disabling just in case
+        with (
+            torch._dynamo.utils._disable_saved_tensors_hooks_during_tracing(),
+            tx.fake_mode.shape_env.ignore_fresh_unbacked_symbols()
+            if tx.fake_mode and tx.fake_mode.shape_env
+            else nullcontext(),
+        ):
+            get_fake_value(proxy.node, tx, allow_non_graph_fake=False)
 
-            # Ignore fresh unbacked symbols that could arise from the internal indexing (selection),
-            # that happen in code like t[idx] += 1 when idx is unbacked. Namely the selection
-            # during 'setitem'.
-            # When the selection happens if idx is unbacked we allocate a new unbacked symbol for the
-            # storage offset in select_meta, but the output of the operation 'setitem' does not depend
-            # on the selection.
-            with (
-                torch._dynamo.utils._disable_saved_tensors_hooks_during_tracing(),
-                tx.fake_mode.shape_env.ignore_fresh_unbacked_symbols()
-                if tx.fake_mode and tx.fake_mode.shape_env
-                else nullcontext(),
-            ):
-                get_fake_value(proxy.node, tx, allow_non_graph_fake=False)
-
-            vt = value
-            if isinstance(vt, variables.lazy.LazyVariableTracker):
-                vt = variables.lazy.LazyVariableTracker.realize_all(vt)
-
-            self.synchronize_attributes(tx, type(vt))
+        self._sync_if_inplace_mutation(tx, version_before, value.is_tensor())
 
         if config.use_graph_deduplication or config.track_nodes_for_deduplication:
             tx.output.region_tracker.add_node_mutation(proxy.node, 0)


### PR DESCRIPTION
Fixes #161275

Introduces `TensorVariable._propagate_inplace_metadata` to propagate tensor metadata for inplace ops correctly. This is done by reusing the change introduced in https://github.com/pytorch/pytorch/pull/161036/files#r2288498099 for setitem, but for all ops ending in "_" instead.

**Test Plan:** Added the `test/dynamo/test_dynamo_ops.py` test file, with the `TestTensorMetaProp.test_inplace_ops_propagate_requires_grad_metadata` test case. This uses a `CustomAutograd` to verify tensor metadata is propagated the same in eager and compiled (with eager backend). Without the fix, the test results in the following error.

```
======================================================================
ERROR: test_inplace_ops_propagate_requires_grad_metadata_add_cuda_float64 (__main__.TestTensorMetaPropCUDA.test_inplace_ops_propagate_requires_grad_metadata_add_cuda_float64)
Test that inplace ops from OpInfo propagate requires_grad correctly.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/data/users/arshzahed/pytorch/torch/testing/_internal/common_device_type.py", line 1151, in test_wrapper
    return test(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/arshzahed/pytorch/test/dynamo/test_dynamo_ops.py", line 3121, in test_inplace_ops_propagate_requires_grad_metadata
    self.assertEqual(
  File "/data/users/arshzahed/pytorch/torch/testing/_internal/common_utils.py", line 4255, in assertEqual
    raise error_metas.pop()[0].to_error(  # type: ignore[index]
AssertionError: Scalars are not close!

Expected -6.649254588811632 but got -13.298509177623265.
Absolute difference: 6.649254588811632 (up to 1e-07 allowed)
Relative difference: 1.0 (up to 1e-07 allowed)
add: Output mismatch indicates metadata not propagated during tracing (issue #161275)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/data/users/arshzahed/pytorch/torch/testing/_internal/common_utils.py", line 3300, in wrapper
    method(*args, **kwargs)
  File "/data/users/arshzahed/pytorch/torch/testing/_internal/common_utils.py", line 3300, in wrapper
    method(*args, **kwargs)
  File "/data/users/arshzahed/pytorch/torch/testing/_internal/common_device_type.py", line 428, in instantiated_test
    result = test(self, **param_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/arshzahed/pytorch/torch/testing/_internal/common_utils.py", line 1707, in wrapper
    fn(*args, **kwargs)
  File "/data/users/arshzahed/pytorch/torch/testing/_internal/common_device_type.py", line 1163, in test_wrapper
    raise e_tracked from e
Exception: Scalars are not close!

Expected -6.649254588811632 but got -13.298509177623265.
Absolute difference: 6.649254588811632 (up to 1e-07 allowed)
Relative difference: 1.0 (up to 1e-07 allowed)
add: Output mismatch indicates metadata not propagated during tracing (issue #161275)

Caused by sample input at index 10: SampleInput(input=Tensor[size=(5, 5), device="cuda:0", dtype=torch.float64], args=TensorList[Tensor[size=(5, 5), device="cuda:0", dtype=torch.float64]], kwargs={'alpha': '-3.125'}, broadcasts_input=False, name='')

To execute this test, run the following from the base repo dir:
    PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=10 python test/dynamo/test_dynamo_ops.py TestTensorMetaPropCUDA.test_inplace_ops_propagate_requires_grad_metadata_add_cuda_float64

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @chenyang78