### PR TITLE
[CD][CUDA] PRELOAD libnvrtc-builtins.so.*

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -351,6 +351,8 @@ def _preload_cuda_deps(err: _Optional[OSError] = None) -> None:
 
     # libnvToolsExt is Optional Dependency
     _preload_cuda_lib("nvtx", "libnvToolsExt.so.*[0-9]", required=False)
+    # libnvrtc-builtins.so is not Optional Dependency
+    _preload_cuda_lib("cuda_nvrtc", "libnvrtc-builtins.so.*[0-9]", required=True)
 
 
 # See Note [Global dependencies]


### PR DESCRIPTION
Current nightly (at least arm cuda13 wheel) is not able to run stable diffusion due to cudnn not able to find libnvrtc-builtins.so due to missing LD_PRELOAD due a refactoring https://github.com/pytorch/pytorch/pull/167046 . 

Thanks @Aidyn-A for noticing this issue!  https://github.com/pytorch/pytorch/issues/167602 
cc @ptrblck @eqy @tinglvv @atalman @malfet 