### PR TITLE
[invoke_subgraph] Add backend_options to nested_compile_region to be used by regional_inductor

### DIFF
--- a/test/dynamo/test_regional_inductor.py
+++ b/test/dynamo/test_regional_inductor.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: dynamo"]
 
+import copy
 import functools
 import sys
 import warnings
@@ -10,13 +11,18 @@ import torch._inductor.test_case
 import torch.fx.traceback as fx_traceback
 import torch.utils.checkpoint
 from torch._dynamo.backends.common import aot_autograd
+from torch._dynamo.testing import _testing_capture_invoke_subgraph_inductor_compile_gms
 from torch._functorch._aot_autograd.autograd_cache import BundledCompiledForward
 from torch._guards import detect_fake_mode
+from torch._higher_order_ops.invoke_subgraph import get_invoke_subgraph_compile_options
 from torch._inductor.output_code import RegionalOutputCode
 from torch._inductor.test_case import run_tests
 from torch._inductor.utils import run_fw_bw_and_get_code
 from torch.fx._graph_pickler import GraphPickler
 from torch.fx.passes.regional_inductor import regional_inductor
+from torch.fx.passes.regional_inductor_invoke_subgraph import (
+    regional_inductor_invoke_subgraph,
+)
 from torch.nn.attention.flex_attention import create_block_mask, flex_attention
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
@@ -51,11 +57,25 @@ if TYPE_CHECKING:
 #   f) disallow nested regional compile
 
 
-def aot_eager_regional_inductor(serialize=False):
+def aot_eager_regional_inductor(
+    serialize=False, on_invoke_subgraph=False, captured_gms=None, partitioner=None
+):
+    def regional_inductor_fn(gm, *args, **kwargs):
+        if captured_gms is not None:
+            captured_gms.append(copy.deepcopy(gm))
+
+        if on_invoke_subgraph:
+            return regional_inductor_invoke_subgraph(gm, *args, **kwargs)
+        else:
+            return regional_inductor(gm, *args, **kwargs)
+
+    kwargs = {}
+    if partitioner:
+        kwargs["partition_fn"] = partitioner
     if serialize:
 
         def regional_inductor_pickle(gm, *example_args):
-            result = regional_inductor(gm, *example_args)
+            result = regional_inductor_fn(gm, *example_args)
             serialized = GraphPickler.dumps(result)
 
             fake_mode = detect_fake_mode(example_args)
@@ -72,11 +92,13 @@ def aot_eager_regional_inductor(serialize=False):
         return aot_autograd(
             fw_compiler=regional_inductor_pickle,
             bw_compiler=regional_inductor_pickle,
+            **kwargs,
         )
 
     return aot_autograd(
-        fw_compiler=regional_inductor,
-        bw_compiler=regional_inductor,
+        fw_compiler=regional_inductor_fn,
+        bw_compiler=regional_inductor_fn,
+        **kwargs,
     )
 
 
@@ -546,6 +568,788 @@ class RegionalInductorTests(torch._inductor.test_case.TestCase):
         def fn(x):
             with fx_traceback.annotate({"compile_with_inductor": 0}):
                 return MyAutogradFunction.apply(x)
+
+        x = torch.ones(10, 10, requires_grad=True)
+
+        fn(x).sum().backward()
+        self.assertEqual(x.grad, x * 3)
+
+
+@skipIfTorchDynamo("Not a suitable dynamo wrapped test")
+@torch._dynamo.config.patch("enable_invoke_subgraph_regional_compile", True)
+@instantiate_parametrized_tests
+class RegionalInductorInvokeSubgraphTests(torch._inductor.test_case.TestCase):
+    def test_custom_decomposition(self):
+        # Test that custom decompositions are applied to the subgraph.
+
+        def my_add_decomp(a, b):
+            return a.sin()
+
+        nested_config = get_invoke_subgraph_compile_options(
+            decompositions={
+                torch.ops.aten.add.Tensor: my_add_decomp,
+                torch.ops.aten.add.default: my_add_decomp,
+            }
+        )
+
+        @torch.compiler.nested_compile_region(options=nested_config)
+        def g(y):
+            return y + 1
+
+        def fn(x, y):
+            y = x + 1  # this should still be add
+            add = g(y)  # this should be decomposed to y.sin()
+            return add * 2
+
+        opt_mod = torch.compile(
+            fn,
+            backend=aot_eager_regional_inductor(
+                serialize=False, on_invoke_subgraph=True
+            ),
+            fullgraph=True,
+        )
+        x = torch.randn(10, requires_grad=True)
+        y = torch.randn(10, requires_grad=True)
+
+        with _testing_capture_invoke_subgraph_inductor_compile_gms() as captured_gms:
+            # Check that inductor compilation is called 2 times only
+            # So there's not double-compilation like when we using fx.annotate.
+            result, codes = run_fw_bw_and_get_code(lambda: opt_mod(x, y))
+            self.assertEqual(len(codes), 2)
+            self.assertEqual(
+                result, 2 * torch.sin(x + 1)
+            )  # note that the g() should be decomposed to sin()
+
+            self.assertEqual(len(captured_gms), 2)
+            # dynamo captured forward graph
+            self.assertExpectedInline(
+                captured_gms[0].code.strip(),
+                """\
+def forward(self, primals_0):
+    sin = torch.ops.aten.sin.default(primals_0);  primals_0 = None
+    return (sin,)""",
+                ignore_comments=True,
+                ignore_empty_lines=True,
+            )
+            # dynamo captured backward graph
+            self.assertExpectedInline(
+                captured_gms[1].code.strip(),
+                """\
+def forward(self, tangents_0):
+    clone = torch.ops.aten.clone.default(tangents_0);  tangents_0 = None
+    return (clone,)""",
+                ignore_comments=True,
+                ignore_empty_lines=True,
+            )
+
+    @parametrize("serialize", [False])  # , True
+    def test_simple(self, serialize):
+        nested_config = get_invoke_subgraph_compile_options()
+
+        @torch.compiler.nested_compile_region(options=nested_config)
+        def g(sin, y):
+            mul = sin * y
+            add = mul + 1
+            return add
+
+        def fn(x, y):
+            sin = torch.sin(x)
+            add = g(sin, y)
+            return torch.sin(add)
+
+        opt_fn = torch.compile(
+            fn,
+            backend=aot_eager_regional_inductor(
+                serialize=serialize, on_invoke_subgraph=True
+            ),
+            fullgraph=True,
+        )
+        x = torch.randn(10, requires_grad=True)
+        y = torch.randn(10, requires_grad=True)
+
+        # Check that inductor compilation is called twice
+        result, codes = run_fw_bw_and_get_code(lambda: opt_fn(x, y))
+        self.assertEqual(len(codes), 2)
+        self.assertEqual(result, fn(x, y))
+
+    @parametrize("serialize", [False])  # , True
+    def test_two_graphs(self, serialize):
+        nested_config = get_invoke_subgraph_compile_options()
+
+        @torch.compiler.nested_compile_region(options=nested_config)
+        def g1(sin, y):
+            mul = sin * y
+            add = mul + 1
+            return add
+
+        @torch.compiler.nested_compile_region(options=nested_config)
+        def g2(x):
+            return x / 3
+
+        def fn(x, y):
+            sin = torch.sin(x)
+            add = g1(sin, y)
+            div = g2(add)
+            return div
+
+        opt_fn = torch.compile(
+            fn,
+            backend=aot_eager_regional_inductor(
+                serialize=serialize, on_invoke_subgraph=True
+            ),
+            fullgraph=True,
+        )
+        x = torch.randn(10, requires_grad=True)
+        y = torch.randn(10, requires_grad=True)
+
+        # Check that inductor compilation is called 4 times, twice for each nested region
+        result, codes = run_fw_bw_and_get_code(lambda: opt_fn(x, y))
+        self.assertEqual(len(codes), 4)
+        self.assertEqual(result, fn(x, y))
+
+    @parametrize("serialize", [False])  # , True
+    def test_unbacked_expr_input(self, serialize):
+        # https://github.com/pytorch/pytorch/issues/167012
+
+        nested_config = get_invoke_subgraph_compile_options()
+
+        @torch.compiler.nested_compile_region(options=nested_config)
+        def gn(x):
+            return x + 1
+
+        def fn(c):
+            d = torch.concat([c, c], dim=0)
+            d = gn(d)
+            return d
+
+        c = torch.randn((64, 32), requires_grad=True)
+        torch._dynamo.decorators.mark_unbacked(c, 0)
+
+        opt_fn = torch.compile(
+            fn,
+            backend=aot_eager_regional_inductor(
+                serialize=serialize,
+                on_invoke_subgraph=True,
+            ),
+            fullgraph=True,
+        )
+
+        result, codes = run_fw_bw_and_get_code(lambda: opt_fn(c))
+        # self.assertEqual(len(codes), 2)
+        self.assertEqual(result, fn(c))
+
+    @parametrize("serialize", [False])
+    def test_repeated_blocks(self, serialize):
+        nested_config = get_invoke_subgraph_compile_options()
+
+        @torch.compiler.nested_compile_region(options=nested_config)
+        def g(sin, y):
+            mul = sin * y
+            add = mul + 1
+            return add
+
+        def fn(x, y):
+            sin = torch.sin(x)
+            add = g(sin, y)
+            return torch.sin(add)
+
+        class Mod(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                a = fn(x, y)
+                return fn(a, y)
+
+        mod = Mod()
+
+        captured_gms = []
+        opt_mod = torch.compile(
+            mod,
+            backend=aot_eager_regional_inductor(
+                serialize=serialize, on_invoke_subgraph=True, captured_gms=captured_gms
+            ),
+            fullgraph=True,
+        )
+        x = torch.randn(10, requires_grad=True)
+        y = torch.randn(10, requires_grad=True)
+
+        with (
+            _testing_capture_invoke_subgraph_inductor_compile_gms() as inner_captured_gms
+        ):
+            # Check that inductor compilation is called 2 times only
+            # So there's not double-compilation like when we using fx.annotate.
+            result, codes = run_fw_bw_and_get_code(lambda: opt_mod(x, y))
+            self.assertEqual(len(codes), 2)
+            self.assertEqual(result, mod(x, y))
+
+            self.assertEqual(len(captured_gms), 2)
+            # inductor compiled forward graph
+            self.assertExpectedInline(
+                inner_captured_gms[0].code.strip(),
+                """\
+def forward(self, primals_0, primals_1):
+    mul = torch.ops.aten.mul.Tensor(primals_0, primals_1)
+    add = torch.ops.aten.add.Tensor(mul, 1);  mul = None
+    return (add, primals_0, primals_1)""",
+                ignore_comments=True,
+                ignore_empty_lines=True,
+            )
+            # inductor compiled backward graph
+            self.assertExpectedInline(
+                inner_captured_gms[1].code.strip(),
+                """\
+def forward(self, primals_0, primals_1, tangents_0):
+    mul_1 = torch.ops.aten.mul.Tensor(tangents_0, primals_0);  primals_0 = None
+    mul_2 = torch.ops.aten.mul.Tensor(tangents_0, primals_1);  tangents_0 = primals_1 = None
+    return (mul_2, mul_1)""",
+                ignore_comments=True,
+                ignore_empty_lines=True,
+            )
+
+        # Graph modules compiled by aot_eager_regional_inductor backend
+        self.assertExpectedInline(
+            captured_gms[0].code.strip(),
+            """\
+def forward(self, primals_1, primals_2):
+    sin = torch.ops.aten.sin.default(primals_1)
+    partitioned_fw_subgraph_0_0 = self.partitioned_fw_subgraph_0_0
+    invoke_subgraph_4 = torch.ops.higher_order.invoke_subgraph(partitioned_fw_subgraph_0_0, 'partitioned_fw_subgraph_0_0', sin, primals_2);  partitioned_fw_subgraph_0_0 = sin = None
+    getitem_9 = invoke_subgraph_4[2]
+    getitem_8 = invoke_subgraph_4[1]
+    getitem = invoke_subgraph_4[0];  invoke_subgraph_4 = None
+    sin_1 = torch.ops.aten.sin.default(getitem)
+    sin_2 = torch.ops.aten.sin.default(sin_1)
+    partitioned_fw_subgraph_0_1 = self.partitioned_fw_subgraph_0_0
+    invoke_subgraph_6 = torch.ops.higher_order.invoke_subgraph(partitioned_fw_subgraph_0_1, 'partitioned_fw_subgraph_0_0', sin_2, primals_2);  partitioned_fw_subgraph_0_1 = sin_2 = primals_2 = None
+    getitem_11 = invoke_subgraph_6[2]
+    getitem_10 = invoke_subgraph_6[1]
+    getitem_1 = invoke_subgraph_6[0];  invoke_subgraph_6 = None
+    sin_3 = torch.ops.aten.sin.default(getitem_1)
+    return (sin_3, primals_1, getitem_9, getitem_8, getitem, sin_1, getitem_11, getitem_10, getitem_1)""",  # noqa: B950
+            ignore_comments=True,
+            ignore_empty_lines=True,
+        )
+        self.assertExpectedInline(
+            captured_gms[1].code.strip(),
+            """\
+def forward(self, primals_1, getitem_9, getitem_8, getitem, sin_1, getitem_11, getitem_10, getitem_1, tangents_1):
+    cos = torch.ops.aten.cos.default(getitem_1);  getitem_1 = None
+    mul = torch.ops.aten.mul.Tensor(tangents_1, cos);  tangents_1 = cos = None
+    partitioned_bw_subgraph_0_1 = self.partitioned_bw_subgraph_0_0
+    invoke_subgraph_7 = torch.ops.higher_order.invoke_subgraph(partitioned_bw_subgraph_0_1, 'partitioned_bw_subgraph_0_0', getitem_10, getitem_11, mul);  partitioned_bw_subgraph_0_1 = getitem_10 = getitem_11 = mul = None
+    getitem_2 = invoke_subgraph_7[0]
+    getitem_3 = invoke_subgraph_7[1];  invoke_subgraph_7 = None
+    cos_1 = torch.ops.aten.cos.default(sin_1);  sin_1 = None
+    mul_1 = torch.ops.aten.mul.Tensor(getitem_2, cos_1);  getitem_2 = cos_1 = None
+    cos_2 = torch.ops.aten.cos.default(getitem);  getitem = None
+    mul_2 = torch.ops.aten.mul.Tensor(mul_1, cos_2);  mul_1 = cos_2 = None
+    partitioned_bw_subgraph_0_0 = self.partitioned_bw_subgraph_0_0
+    invoke_subgraph_5 = torch.ops.higher_order.invoke_subgraph(partitioned_bw_subgraph_0_0, 'partitioned_bw_subgraph_0_0', getitem_8, getitem_9, mul_2);  partitioned_bw_subgraph_0_0 = getitem_8 = getitem_9 = mul_2 = None
+    getitem_5 = invoke_subgraph_5[0]
+    getitem_6 = invoke_subgraph_5[1];  invoke_subgraph_5 = None
+    add = torch.ops.aten.add.Tensor(getitem_3, getitem_6);  getitem_3 = getitem_6 = None
+    cos_3 = torch.ops.aten.cos.default(primals_1);  primals_1 = None
+    mul_3 = torch.ops.aten.mul.Tensor(getitem_5, cos_3);  getitem_5 = cos_3 = None
+    return (mul_3, add)""",  # noqa: B950
+            ignore_comments=True,
+            ignore_empty_lines=True,
+        )
+
+    @parametrize("serialize", [False])  # , True
+    def test_invoke_subgraph_inner(self, serialize):
+        # Checks that the inductor regions are searched recursively.
+
+        nested_config = get_invoke_subgraph_compile_options()
+
+        @torch.compiler.nested_compile_region(options=nested_config)
+        def g(y):
+            return y * 2
+
+        @torch.compiler.nested_compile_region
+        def gn(x):
+            x = g(x)
+            return torch.sin(x)
+
+        def fn(x):
+            x = x + 1
+            x = gn(x)
+            x = x + 1
+            x = gn(x)
+            return torch.sigmoid(x)
+
+        opt_fn = torch.compile(
+            fn,
+            backend=aot_eager_regional_inductor(
+                serialize=serialize, on_invoke_subgraph=True
+            ),
+            fullgraph=True,
+        )
+        x = torch.randn(10, requires_grad=True)
+
+        with _testing_capture_invoke_subgraph_inductor_compile_gms() as captured_gms:
+            _, codes = run_fw_bw_and_get_code(lambda: opt_fn(x))
+            # the invoke_subgraph is called twice - but the inside code is compiled
+            # once - so in total 2 (1 fwd + 1 bwd)
+            self.assertEqual(len(codes), 2)
+
+            self.assertEqual(len(captured_gms), 2)
+            # inductor compiled forward graph
+            self.assertExpectedInline(
+                captured_gms[0].code.strip(),
+                """\
+def forward(self, arg0_1):
+    mul = torch.ops.aten.mul.Tensor(arg0_1, 2);  arg0_1 = None
+    return (mul,)""",
+                ignore_comments=True,
+                ignore_empty_lines=True,
+            )
+            # inductor compiled backward graph
+            self.assertExpectedInline(
+                captured_gms[1].code.strip(),
+                """\
+def forward(self, arg0_1, arg1_1):
+    mul = torch.ops.aten.mul.Tensor(arg0_1, 2);  arg0_1 = None
+    mul_1 = torch.ops.aten.mul.Tensor(arg1_1, 2);  arg1_1 = None
+    return (mul_1, mul)""",
+                ignore_comments=True,
+                ignore_empty_lines=True,
+            )
+
+    @requires_cuda_and_triton
+    @parametrize("serialize", [False])  # , True
+    def test_flex_attention(self, serialize):
+        def _squared(score, b, h, m, n):
+            return score * score
+
+        def mask_mod(b, h, q, k):
+            return q >= 0
+
+        a = 12
+        b = 64
+        block_mask = create_block_mask(mask_mod, None, None, a * b, a * b)
+
+        # must decompose aten.zeros.default, otherwise inductor complain
+        nested_config = get_invoke_subgraph_compile_options(
+            decompositions=torch._decomp.core_aten_decompositions()
+        )
+
+        @torch.compiler.nested_compile_region(options=nested_config)
+        def f_flex_attention(x, y, z, block_mask, score_mod):
+            x = flex_attention(x, y, z, block_mask=block_mask, score_mod=score_mod)
+            return x
+
+        def fn(x):
+            x = torch.sin(x)
+            x = f_flex_attention(x, x, x, block_mask=block_mask, score_mod=_squared)
+            return torch.cos(x)
+
+        x = torch.randn(
+            1,
+            1,
+            a * b,
+            b,
+            dtype=torch.bfloat16,
+            device="cuda",
+            requires_grad=True,
+        )
+
+        opt_fn = torch.compile(
+            fn,
+            backend=aot_eager_regional_inductor(serialize, on_invoke_subgraph=True),
+            fullgraph=True,
+        )
+
+        with _testing_capture_invoke_subgraph_inductor_compile_gms() as captured_gms:
+            res, codes = run_fw_bw_and_get_code(lambda: opt_fn(x))
+            # flex in forward and flex_backward in backward
+            self.assertEqual(len(codes), 2)
+            true_res = fn(x)
+            self.assertEqual(res, true_res)
+
+            self.assertEqual(len(captured_gms), 2)
+            # inductor compiled forward graph
+            self.assertExpectedInline(
+                captured_gms[0].code.strip(),
+                """\
+def forward(self, primals_0, primals_1, primals_2, primals_3, primals_4, primals_5, primals_6, primals_7, primals_8):
+    sdpa_score0 = self.sdpa_score0
+    sdpa_mask0 = self.sdpa_mask0
+    flex_attention = torch.ops.higher_order.flex_attention(primals_0, primals_0, primals_0, sdpa_score0, (768, 768, primals_1, primals_2, primals_3, primals_4, primals_5, primals_6, primals_7, primals_8, 128, 128, sdpa_mask0), 0.125, {'BACKEND': 'AUTO', 'PRESCALE_QK': False, 'ROWS_GUARANTEED_SAFE': False, 'BLOCKS_ARE_CONTIGUOUS': False, 'WRITE_DQ': True, 'OUTPUT_LOGSUMEXP': True, 'OUTPUT_MAX': False}, (), ());  sdpa_score0 = sdpa_mask0 = None
+    getitem = flex_attention[0]
+    getitem_1 = flex_attention[1];  flex_attention = None
+    alias = torch.ops.aten.alias.default(getitem)
+    alias_1 = torch.ops.aten.alias.default(getitem_1);  getitem_1 = None
+    alias_2 = torch.ops.aten.alias.default(alias);  alias = None
+    alias_3 = torch.ops.aten.alias.default(alias_1);  alias_1 = None
+    return (getitem, primals_0, primals_1, primals_2, primals_3, primals_4, primals_5, primals_6, primals_7, primals_8, alias_2, alias_3)""",  # noqa: B950
+                ignore_comments=True,
+                ignore_empty_lines=True,
+            )
+            # inductor compiled backward graph
+            self.assertExpectedInline(
+                captured_gms[1].code.strip(),
+                """\
+def forward(self, primals_0, primals_1, primals_2, primals_3, primals_4, primals_5, primals_6, primals_7, primals_8, alias_2, alias_3, tangents_0):
+    full_10 = torch.ops.aten.full.default([1, 1, 768], 0, dtype = torch.float32, layout = torch.strided, device = device(type='cuda', index=0), pin_memory = False)
+    fw_graph0 = self.fw_graph0
+    joint_graph0 = self.joint_graph0
+    mask_graph0 = self.mask_graph0
+    flex_attention_backward = torch.ops.higher_order.flex_attention_backward(primals_0, primals_0, primals_0, alias_2, alias_3, tangents_0, full_10, fw_graph0, joint_graph0, (768, 768, primals_1, primals_2, primals_3, primals_4, primals_5, primals_6, primals_7, primals_8, 128, 128, mask_graph0), 0.125, {'BACKEND': 'AUTO', 'PRESCALE_QK': False, 'ROWS_GUARANTEED_SAFE': False, 'BLOCKS_ARE_CONTIGUOUS': False, 'WRITE_DQ': True, 'OUTPUT_LOGSUMEXP': True, 'OUTPUT_MAX': False}, (), ());  primals_0 = alias_2 = alias_3 = tangents_0 = full_10 = fw_graph0 = joint_graph0 = primals_1 = primals_2 = primals_3 = primals_4 = primals_5 = primals_6 = primals_7 = primals_8 = mask_graph0 = None
+    getitem_3 = flex_attention_backward[0]
+    getitem_4 = flex_attention_backward[1]
+    getitem_5 = flex_attention_backward[2];  flex_attention_backward = None
+    add = torch.ops.aten.add.Tensor(getitem_3, getitem_4);  getitem_3 = getitem_4 = None
+    add_1 = torch.ops.aten.add.Tensor(add, getitem_5);  add = getitem_5 = None
+    return (add_1, None, None, None, None, None, None, None, None)""",  # noqa: B950
+                ignore_comments=True,
+                ignore_empty_lines=True,
+            )
+
+    @parametrize("serialize", [False])  # , True
+    def test_max_autotune_no_cudagraphs(self, serialize):
+        """Test that max-autotune-no-cudagraphs options are properly applied inductor_config_patches."""
+        import torch._inductor.config as inductor_config
+
+        nested_config = get_invoke_subgraph_compile_options(
+            inductor_config_patches={
+                "max_autotune": True,
+                "triton.cudagraphs": False,
+            }
+        )
+
+        @torch.compiler.nested_compile_region(options=nested_config)
+        def g(sin, y):
+            mul = sin * y
+            add = mul + 1
+            return add
+
+        def fn(x, y):
+            sin = torch.sin(x)
+            add = g(sin, y)
+            return torch.sin(add)
+
+        # Hook to verify options
+        original_compile = torch._inductor.compile_fx._compile_fx_inner
+        captured_options = []
+
+        def verify_options(*args, **kwargs):
+            options = kwargs.get("inductor_config_patches", {})
+            captured_options.append(options)
+
+            # Verify config is set as expected from explicit options
+            assert torch._inductor.config.max_autotune, "max_autotune should be True"
+            assert not inductor_config.triton.cudagraphs, (
+                "triton.cudagraphs should be False"
+            )
+
+            return original_compile(*args, **kwargs)
+
+        torch._inductor.compile_fx._compile_fx_inner = verify_options
+
+        try:
+            # Use backend without options - they come from annotations
+            backend = aot_eager_regional_inductor(
+                serialize=serialize, on_invoke_subgraph=True
+            )
+
+            opt_fn = torch.compile(fn, backend=backend, fullgraph=True)
+            x = torch.randn(10, requires_grad=True)
+            y = torch.randn(10, requires_grad=True)
+
+            # Run and check that options were passed
+            _, codes = run_fw_bw_and_get_code(lambda: opt_fn(x, y))
+            self.assertEqual(len(codes), 2)
+
+            # Verify that compilation happened
+            self.assertTrue(
+                len(captured_options) > 0, "Compilation should have occurred"
+            )
+
+        finally:
+            torch._inductor.compile_fx._compile_fx_inner = original_compile
+
+    def test_invalid_inductor_config(self):
+        """Test that invalid inductor config keys are caught with a clear error."""
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Invalid inductor config key 'invalid_config_key'",
+        ):
+            get_invoke_subgraph_compile_options(
+                inductor_config_patches={
+                    "invalid_config_key": True,
+                }
+            )
+
+    @requires_cuda_and_triton
+    @parametrize("serialize", [False])  # , True
+    def test_selective_ac_flex(self, serialize):
+        # must decompose the following fallback ops in inductor
+        # e.g. AssertionError: both a fallback and a decomp for same op: aten.zeros.default
+        decomp_table = torch._decomp.core_aten_decompositions()
+        decomp_table.update(
+            torch._decomp.get_decompositions(
+                {
+                    torch.ops.aten.arange.start_step,
+                    torch.ops.aten._to_copy.default,
+                }
+            )
+        )
+        nested_config = get_invoke_subgraph_compile_options(decompositions=decomp_table)
+
+        @torch.compiler.nested_compile_region(options=nested_config)
+        def f_flex_attention(x, y, z):
+            x = flex_attention(x, y, z)
+            return x
+
+        class FlexAttentionModule(torch.nn.Module):
+            def __init__(self, hidden_size, num_heads):
+                super().__init__()
+                self.hidden_size = hidden_size
+                self.num_heads = num_heads
+                self.head_dim = hidden_size // num_heads
+
+                # In-projections (query, key, value)
+                self.q_proj = torch.nn.Linear(hidden_size, hidden_size)
+                self.k_proj = torch.nn.Linear(hidden_size, hidden_size)
+                self.v_proj = torch.nn.Linear(hidden_size, hidden_size)
+
+                # Out-projection
+                self.out_proj = torch.nn.Linear(hidden_size, hidden_size)
+
+            def forward(self, x):
+                batch_size, seq_len, _ = x.size()
+
+                # Project queries, keys, and values
+                q = (
+                    self.q_proj(x)
+                    .view(batch_size, seq_len, self.num_heads, self.head_dim)
+                    .transpose(1, 2)
+                )
+                k = (
+                    self.k_proj(x)
+                    .view(batch_size, seq_len, self.num_heads, self.head_dim)
+                    .transpose(1, 2)
+                )
+                v = (
+                    self.v_proj(x)
+                    .view(batch_size, seq_len, self.num_heads, self.head_dim)
+                    .transpose(1, 2)
+                )
+
+                # Apply flex attention
+                attn_output = f_flex_attention(
+                    q,
+                    k,
+                    v,
+                )
+
+                # Reshape output
+                attn_output = (
+                    attn_output.transpose(1, 2)
+                    .contiguous()
+                    .view(batch_size, seq_len, self.hidden_size)
+                )
+
+                # Out projection
+                output = self.out_proj(attn_output)
+
+                return output
+
+        from torch.utils.checkpoint import (
+            checkpoint,
+            create_selective_checkpoint_contexts,
+        )
+
+        ops_to_save = [
+            torch.ops.aten.mm.default,
+        ]
+        context_fn = functools.partial(
+            create_selective_checkpoint_contexts, ops_to_save
+        )
+
+        # Define a model that uses FlexAttention with selective activation checkpointing
+        class SacModule(torch.nn.Module):
+            def __init__(self, hidden_size, num_heads, context_fn):
+                super().__init__()
+                self.flex_attn = FlexAttentionModule(hidden_size, num_heads)
+                self.context_fn = context_fn
+
+            def forward(self, x):
+                def flex_attn_fn(x):
+                    return self.flex_attn(x)
+
+                output = checkpoint(
+                    flex_attn_fn,
+                    x,
+                    use_reentrant=False,
+                    context_fn=self.context_fn,
+                )
+
+                return output
+
+        flex_module = SacModule(hidden_size=512, num_heads=8, context_fn=context_fn).to(
+            "cuda", dtype=torch.bfloat16
+        )
+        x = torch.ones(8, 1024, 512, device="cuda", dtype=torch.bfloat16)
+        compiled_module = torch.compile(
+            flex_module,
+            backend=aot_eager_regional_inductor(serialize, on_invoke_subgraph=True),
+            fullgraph=True,
+        )
+
+        res, codes = run_fw_bw_and_get_code(lambda: compiled_module(x))
+        # flex in forward and flex_backward in backward
+        self.assertEqual(len(codes), 2)
+        true_res = flex_module(x)
+        self.assertEqual(res, true_res)
+
+    @parametrize("serialize", [False])  # True,
+    def test_invoke_subgraph_regional_compile_decomposition(self, serialize):
+        def my_sin_decomp(x):
+            return torch.cos(x)
+
+        decompositions = {torch.ops.aten.sin.default: my_sin_decomp}
+        nested_config = get_invoke_subgraph_compile_options(
+            decompositions=decompositions
+        )
+
+        @torch.compiler.nested_compile_region(options=nested_config)
+        def gn_with_backend(x):
+            return torch.sin(x)
+
+        @torch.compiler.nested_compile_region
+        def gn_without_backend(x):
+            return torch.sin(x)
+
+        def fn(x):
+            return gn_with_backend(x) + gn_without_backend(x)
+
+        backend = aot_eager_regional_inductor(
+            serialize=serialize, on_invoke_subgraph=True
+        )
+
+        opt_fn = torch.compile(fn, backend=backend, fullgraph=True)
+
+        x = torch.randn(8, 8, requires_grad=True)
+        res, codes = run_fw_bw_and_get_code(lambda: opt_fn(x))
+        self.assertEqual(len(codes), 2)
+        true_res = torch.sin(x) + torch.cos(x)
+        self.assertEqual(res, true_res)
+
+    @torch._dynamo.config.patch("enable_invoke_subgraph_regional_compile", True)
+    @parametrize("serialize", [False])  # True,
+    def test_invoke_subgraph_regional_compile(self, serialize):
+        call_test_partitioner_ct = 0
+        original_mincut_partitioner = (
+            torch._functorch.partitioners.min_cut_rematerialization_partition
+        )
+
+        def test_partitioner(
+            *args, **kwargs
+        ) -> tuple[torch.fx.GraphModule, torch.fx.GraphModule]:
+            nonlocal call_test_partitioner_ct
+            call_test_partitioner_ct += 1
+            return original_mincut_partitioner(*args, **kwargs)
+
+        # pyrefly: ignore [not-iterable]
+        if serialize:
+            # Callable cannot be serialized
+            torch._functorch.partitioners.default_partition = test_partitioner
+            partitioner = "default_partition"
+        else:
+            partitioner = test_partitioner
+
+        config_patches = {
+            "max_autotune": True,
+            "triton.cudagraphs": False,
+        }
+        decompositions = {}
+        nested_config = get_invoke_subgraph_compile_options(
+            config_patches, decompositions, partitioner
+        )
+
+        @torch.compiler.nested_compile_region(options=nested_config)
+        def gn_with_backend(x):
+            return torch.sin(x)
+
+        @torch.compiler.nested_compile_region
+        def gn_without_backend(x):
+            return torch.cos(x)
+
+        def fn(x):
+            return gn_with_backend(x) + gn_without_backend(x)
+
+        backend = aot_eager_regional_inductor(
+            serialize=serialize, on_invoke_subgraph=True
+        )
+        opt_fn = torch.compile(fn, backend=backend, fullgraph=True)
+
+        try:
+            x = torch.randn(8, 8, requires_grad=True)
+            # opt_fn(x)
+            res, codes = run_fw_bw_and_get_code(lambda: opt_fn(x))
+            self.assertEqual(len(codes), 2)
+            self.assertEqual(call_test_partitioner_ct, 1)
+            true_res = fn(x)
+            self.assertEqual(res, true_res)
+        finally:
+            torch._functorch.partitioners.min_cut_rematerialization_partition = (
+                original_mincut_partitioner
+            )
+
+    def test_refcounts(self):
+        """Tests that activations can be cleared before the end of graph"""
+
+        class RefcountCheckPassed(Exception):
+            pass
+
+        def regional_inductor_with_refcounting(gm, *example_args):
+            fn = regional_inductor_invoke_subgraph(gm, *example_args)
+            assert fn._boxed_call
+
+            def run(args: Any) -> Any:
+                assert type(args) is list
+
+                # NOTE: sys.getrefcount adds a temporary reference to the object
+                # So sys.getrefcount(x) == 2 actually means we hold the single reference to x
+                # There should be one activation for `fn`.
+                self.assertTrue(
+                    2 in [sys.getrefcount(args[i]) for i in range(len(args))]
+                )
+                return fn(args)
+
+            run._boxed_call = True  # type: ignore[attr-defined]
+            return run
+
+        class MyAutogradFunction(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):  # tensor of 1s
+                act = x + x  # tensor of 2s
+                ctx.save_for_backward(act)
+                return act
+
+            @staticmethod
+            def backward(ctx, grad_output):  # tensor of 1s
+                saved_act = ctx.saved_tensors  # tensor of 2s
+                return saved_act[0] + grad_output  # tensor of 3s
+
+        nested_config = get_invoke_subgraph_compile_options()
+
+        @torch.compiler.nested_compile_region(options=nested_config)
+        def autograd_apply(x):
+            return MyAutogradFunction.apply(x)
+
+        @torch.compile(
+            backend=aot_autograd(
+                fw_compiler=regional_inductor_invoke_subgraph,
+                bw_compiler=regional_inductor_with_refcounting,
+            ),
+            fullgraph=True,
+        )
+        def fn(x):
+            return autograd_apply(x)
 
         x = torch.ones(10, 10, requires_grad=True)
 

--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -1791,6 +1791,39 @@ class GraphModule(torch.nn.Module):
         res = opt_fn(x)
         self.assertEqual(ref, res)
 
+    def test_grad_accumulation(self):
+        mod1 = torch.nn.Linear(8, 8)
+        mod2 = torch.nn.Linear(8, 8)
+        mod3 = torch.nn.Linear(8, 8)
+
+        @nested_compile_region
+        def gn(x):
+            return mod1(x) - mod2(x)
+
+        def fn(c):
+            d = gn(c) - mod3(c)
+            return d * 2
+
+        c = torch.randn((8, 8), requires_grad=True)
+
+        backend = AotEagerAndRecordGraphs()
+        opt_fn = torch.compile(fn, backend=backend, fullgraph=True)
+        res = opt_fn(c)
+        res.sum().backward()
+
+        # The gradient addition node for mod3 is not in the subgraph.
+        bw_add_nodes = backend.bw_graphs[0].graph.find_nodes(
+            op="call_function", target=torch.ops.aten.add.Tensor
+        )
+        self.assertEqual(len(bw_add_nodes), 1)
+        subgraph_node = backend.bw_graphs[0].graph.find_nodes(op="get_attr")[0]
+        subgraph_name = subgraph_node.target
+        # The gradient addition node between mod1 and mode2 will be in the subgraph
+        bw_add_nodes = getattr(backend.bw_graphs[0], subgraph_name).graph.find_nodes(
+            op="call_function", target=torch.ops.aten.add.Tensor
+        )
+        self.assertEqual(len(bw_add_nodes), 1)
+
     def test_complex(self):
         # Observed in Wan2.1
         @nested_compile_region

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -779,6 +779,10 @@ _custom_ops_profile: Optional[Any] = None
 # Deprecated! Please use the config in torch/fx/experimental/_config instead.
 enrich_profiler_metadata: bool = False
 
+# Experimental flag to enable regional compile on invoke_subgraph HOP.
+# For testing only!
+enable_invoke_subgraph_regional_compile: bool = False
+
 if TYPE_CHECKING:
     from torch.utils._config_typing import *  # noqa: F401, F403
 

--- a/torch/_dynamo/testing.py
+++ b/torch/_dynamo/testing.py
@@ -581,3 +581,25 @@ def _skipped_function_for_test_reconstruct(
     f: Callable[_P, _T], *args: _P.args, **kwargs: _P.kwargs
 ) -> _T:
     return f(*args, **kwargs)
+
+
+_testing_invoke_subgraph_inductor_compile_captured_gms = None
+
+
+@contextlib.contextmanager
+def _testing_capture_invoke_subgraph_inductor_compile_gms():
+    """
+    Context manager to capture graph modules compiled by invoke_subgraph_inductor_compile.
+
+    Usage:
+        with _testing_capture_invoke_subgraph_inductor_compile_gms() as captured_gms:
+            # code that triggers invoke_subgraph_inductor_compile
+            pass
+        # captured_gms will contain the list of captured graph modules
+    """
+    global _testing_invoke_subgraph_inductor_compile_captured_gms
+    _testing_invoke_subgraph_inductor_compile_captured_gms = []
+    try:
+        yield _testing_invoke_subgraph_inductor_compile_captured_gms
+    finally:
+        _testing_invoke_subgraph_inductor_compile_captured_gms = None

--- a/torch/_higher_order_ops/invoke_subgraph.py
+++ b/torch/_higher_order_ops/invoke_subgraph.py
@@ -1,9 +1,12 @@
 # mypy: allow-untyped-defs
 
 import contextlib
+import copy
+import functools
+from collections.abc import Callable
 from contextlib import nullcontext
 from dataclasses import dataclass, field
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 import torch
 import torch.utils._pytree as pytree
@@ -17,6 +20,7 @@ from torch._higher_order_ops.utils import (
     get_dummy_aot_autograd_config,
     HopInstance,
     prepare_fw_with_masks,
+    redirect_to_mode,
     reenter_make_fx,
     register_fake,
     save_tensors_and_symints_for_backward,
@@ -31,6 +35,7 @@ from torch.fx.experimental.proxy_tensor import (
 )
 from torch.fx.graph_module import GraphModule
 from torch.fx.passes.runtime_assert import insert_deferred_runtime_asserts
+from torch.utils.checkpoint import _CachedTorchDispatchMode, _CachingTorchDispatchMode
 
 
 invoke_subgraph_counter = 0
@@ -44,6 +49,50 @@ class OutputMetadata:
     num_fw_outs: Optional[int] = None
     indexes_with_symint: set[int] = field(default_factory=set)
     indexes_with_no_grad: set[int] = field(default_factory=set)
+
+
+# This config will be stored in invoke_subgraph HOP node.meta["custom"]["nested_region_config"]
+# as well as the subgraph's gm.meta["nested_region_config"].
+@dataclass
+class NestedCompileRegionOptions:
+    # A Callable that takes (gm, example_inputs, decompositions=None, **kwargs) as inputs.
+    # Returns AOTCompiledArtifact
+    fw_compiler: Optional[Callable] = None
+    bw_compiler: Optional[Callable] = None
+
+    # Note: [InvokeSubgraphHOP Partitioner]
+    # If not None, add "partitioner" to HOP node meta.
+    # If Callable, directly assign the callable, but the callable cannot be pickled
+    # If str, the options are "default_partition" and "min_cut_rematerialization_partition".
+    # The HOP joint graph will be partitioned using the corresponding functions in
+    # torch/_functorch/partitioners.py
+    partitioner: Optional[Callable | str] = None
+
+    # If it's None, we'll inherit the parent call's decompositions.
+    # Otherwise, the nested region will use this decompositions.
+    decompositions: Optional[dict[str, Any]] = None
+
+
+def _extract_nested_region_config(fn):
+    """
+    Extract the NestedCompileRegionOptions from the HOP subgraph gm.meta["nested_region_config"]
+    """
+    gm_to_compile = None
+    if isinstance(fn, torch.fx.GraphModule):
+        gm_to_compile = fn
+    elif isinstance(fn, FunctionalizeCtxWrapper):
+        gm_to_compile = fn.subgraph
+
+    if (
+        isinstance(gm_to_compile, torch.fx.GraphModule)
+        and hasattr(gm_to_compile, "meta")
+        and "nested_region_config" in gm_to_compile.meta
+    ):
+        if isinstance(
+            gm_to_compile.meta["nested_region_config"], NestedCompileRegionOptions
+        ):
+            return gm_to_compile.meta["nested_region_config"].decompositions
+    return None
 
 
 class InvokeSubgraphHOP(HigherOrderOperator):
@@ -89,7 +138,10 @@ class InvokeSubgraphHOP(HigherOrderOperator):
             materialize_as_graph,
         )
 
-        gm: torch.fx.GraphModule = materialize_as_graph(subgraph, operands)
+        subgraph_decomp_table = _extract_nested_region_config(subgraph)
+        gm: torch.fx.GraphModule = materialize_as_graph(
+            subgraph, operands, subgraph_decomp_table=subgraph_decomp_table
+        )
 
         schema_gen = HopSchemaGenerator(self)
         schema_gen.add_arg("subgraph", gm)
@@ -110,6 +162,11 @@ class InvokeSubgraphHOP(HigherOrderOperator):
 
 
 invoke_subgraph = InvokeSubgraphHOP()
+
+
+# Registers dispatches for SAC
+redirect_to_mode(invoke_subgraph, _CachingTorchDispatchMode)
+redirect_to_mode(invoke_subgraph, _CachedTorchDispatchMode)
 
 
 def invoke_subgraph_placeholder(func, *args, **kwargs):
@@ -135,7 +192,7 @@ def invoke_subgraph_placeholder(func, *args, **kwargs):
     return func(*args, **kwargs)
 
 
-def mark_compile_region(fn=None):
+def mark_compile_region(fn=None, options: Optional[NestedCompileRegionOptions] = None):
     """
     This wrapper instructs torch.compile to compile the wrapped region once and
     reuse the compiled artifact, instead of the usual way of aggressively
@@ -143,6 +200,12 @@ def mark_compile_region(fn=None):
 
     Under the hood, it tells TorchDynamo to use InvokeSubgraph HOP for the
     region. For PyTorch eager, this is a no-op.
+
+    Args:
+        fn: The function to wrap
+        options: Optional config to use for compiling the subgraph.
+            Warning: this is an experimental feature under development and
+            not ready for use yet.
     """
 
     def wrap(func):
@@ -154,6 +217,7 @@ def mark_compile_region(fn=None):
             return invoke_subgraph_placeholder(inner_func, *args, **kwargs)
 
         inner.__marked_compile_region_fn__ = func  # type: ignore[attr-defined]
+        func.__marked_compile_region_config__ = options  # type: ignore[attr-defined]
 
         return inner
 
@@ -423,8 +487,11 @@ def trace_joint_graph_as_bwd(
                 stack.enter_context(
                     torch._C._ForceDispatchKeyGuard(include_key_set, exclude_key_set),
                 )
+                subgraph_decomp_table = _extract_nested_region_config(subgraph)
                 with torch.enable_grad():
-                    return _maybe_reenter_make_fx(joint_fn)(*joint_operands)
+                    return _maybe_reenter_make_fx(
+                        joint_fn, subgraph_decomp_table=subgraph_decomp_table
+                    )(*joint_operands)
 
 
 class InvokeSubgraphAutogradOp(torch.autograd.Function):
@@ -544,6 +611,13 @@ class InvokeSubgraphAutogradOp(torch.autograd.Function):
                     ctx._fw_include_key_set,
                     ctx._fw_exclude_key_set,
                 )
+                if (
+                    hasattr(subgraph, "meta")
+                    and "nested_region_config" in subgraph.meta
+                ):
+                    bw_graph.meta["nested_region_config"] = subgraph.meta[
+                        "nested_region_config"
+                    ]
 
         if invoke_subgraph_cache and not cache_hit:
             suffix = invoke_subgraph_cache.add_lazy_bwd_entry(
@@ -697,7 +771,10 @@ def _(proxy_mode: ProxyTorchDispatchMode, subgraph, identifier, *operands):
         from torch._dynamo.utils import dynamo_timed
 
         with dynamo_timed("invoke_subgraph_proxy_tensor", log_pt2_compile_event=True):
-            graph = reenter_make_fx(subgraph)(*operands)
+            subgraph_decomp_table = _extract_nested_region_config(subgraph)
+            graph = reenter_make_fx(
+                subgraph, subgraph_decomp_table=subgraph_decomp_table
+            )(*operands)
 
         from torch._guards import detect_fake_mode
 
@@ -754,4 +831,79 @@ def _(proxy_mode: ProxyTorchDispatchMode, subgraph, identifier, *operands):
     example_out = invoke_subgraph(graph, identifier, *operands)
     return track_tensor_tree(
         example_out, out_proxy, constant=None, tracer=proxy_mode.tracer
+    )
+
+
+def invoke_subgraph_inductor_compile(
+    gm, example_inputs, inductor_config_patches=None, **kwargs
+):
+    from torch._functorch._aot_autograd.runtime_wrappers import (
+        SerializableCompiledFunction,
+    )
+    from torch._functorch._aot_autograd.utils import simple_wraps
+    from torch._inductor import config
+    from torch._inductor.compile_fx import compile_fx_inner
+    from torch._inductor.standalone_compile import AOTCompiledArtifact
+
+    # Used for testing only, should only be changed via _testing_capture_invoke_subgraph_inductor_compile_gms()
+    if (
+        torch._dynamo.testing._testing_invoke_subgraph_inductor_compile_captured_gms
+        is not None
+    ):
+        torch._dynamo.testing._testing_invoke_subgraph_inductor_compile_captured_gms.append(
+            copy.deepcopy(gm)
+        )
+
+    if inductor_config_patches is None:
+        inductor_config_patches = {}
+    compile_fn = config.patch(inductor_config_patches)(compile_fx_inner)
+    compiled_fn_inner = compile_fn(gm, example_inputs)
+    assert compiled_fn_inner._boxed_call
+
+    # Follow boxed calling convention
+    @simple_wraps(compiled_fn_inner)
+    def forward(*runtime_args: tuple[Any]):
+        full_args = []
+        full_args.extend(runtime_args)
+        return compiled_fn_inner(full_args)
+
+    # Just for convenience
+    forward.zero_grad = gm.zero_grad  # type: ignore[attr-defined]
+    forward.named_parameters = gm.named_parameters  # type: ignore[attr-defined]
+    forward.named_buffers = gm.named_buffers  # type: ignore[attr-defined]
+
+    # TODO: Do we need the post compile passes in _aot_stage2b_compile_forward_or_inference?
+    # TODO: add a real serialize function for SerializableCompiledFunction like _cache_inference_info
+    forward.serialize = SerializableCompiledFunction(forward, lambda: None)  # type: ignore[attr-defined]
+    return AOTCompiledArtifact(forward)
+
+
+def get_invoke_subgraph_compile_options(
+    inductor_config_patches=None,
+    decompositions=None,
+    partitioner="min_cut_rematerialization_partition",
+):
+    if inductor_config_patches is None:
+        inductor_config_patches = {"triton.autotune_at_compile_time": True}
+    inductor_compile = functools.partial(
+        invoke_subgraph_inductor_compile,
+        inductor_config_patches=inductor_config_patches,
+    )
+
+    if inductor_config_patches:
+        from torch._inductor import config as inductor_config
+
+        # Validate that all config keys exist
+        for key in inductor_config_patches:
+            if not hasattr(inductor_config, key):
+                raise ValueError(
+                    f"Invalid inductor config key '{key}' in get_invoke_subgraph_compile_options. "
+                    f"Available config keys can be found in torch._inductor.config"
+                )
+
+    return NestedCompileRegionOptions(
+        fw_compiler=inductor_compile,
+        bw_compiler=inductor_compile,
+        partitioner=partitioner,
+        decompositions=decompositions,
     )

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 import contextlib
 import functools
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from contextlib import AbstractContextManager, contextmanager, ExitStack, nullcontext
 from dataclasses import dataclass
 from typing import Any, Optional, overload, TypeVar, Union
@@ -102,7 +102,7 @@ def _maybe_compile_and_run_fn(fn, *args):
         return fn(*args)
 
 
-def reenter_make_fx(fn):
+def reenter_make_fx(fn, subgraph_decomp_table=None):
     from torch.fx.experimental.proxy_tensor import _CURRENT_MAKE_FX_TRACER
 
     @functools.wraps(fn)
@@ -110,19 +110,25 @@ def reenter_make_fx(fn):
         assert _CURRENT_MAKE_FX_TRACER is not None, (
             "Cannot reenter make_fx when we're not under a make_fx tracing session"
         )
-        gm = _CURRENT_MAKE_FX_TRACER.trace_subgraph(
-            _maybe_run_with_interpreter(fn), *args
-        )
+        if subgraph_decomp_table is None:
+            gm = _CURRENT_MAKE_FX_TRACER.trace_subgraph(
+                _maybe_run_with_interpreter(fn), *args
+            )
+        else:
+            gm = _CURRENT_MAKE_FX_TRACER.trace_subgraph_custom_decomp(
+                _maybe_run_with_interpreter(fn), subgraph_decomp_table, *args
+            )
+
         return gm
 
     return wrapped
 
 
-def _maybe_reenter_make_fx(fn):
+def _maybe_reenter_make_fx(fn, subgraph_decomp_table=None):
     from torch.fx.experimental.proxy_tensor import _CURRENT_MAKE_FX_TRACER
 
     if _CURRENT_MAKE_FX_TRACER is not None:
-        return reenter_make_fx(fn)
+        return reenter_make_fx(fn, subgraph_decomp_table=subgraph_decomp_table)
     else:
 
         def _maybe_make_fx_with_fake_mode(fn):
@@ -134,9 +140,13 @@ def _maybe_reenter_make_fx(fn):
                 if fake_mode is None:
                     # we creaeta a fake_mode here to make sure we could
                     # trace the graph with data-dependent calls e.g. .item()
-                    return make_fx(fn, tracing_mode="fake")(*args)
+                    return make_fx(
+                        fn,
+                        tracing_mode="fake",
+                        decomposition_table=subgraph_decomp_table,
+                    )(*args)
                 # Tracing with real if all inputs have been fakfied
-                return make_fx(fn)(*args)
+                return make_fx(fn, decomposition_table=subgraph_decomp_table)(*args)
 
             return wrapped
 
@@ -1161,6 +1171,7 @@ def materialize_as_graph(
     include_key_set: Optional[torch._C.DispatchKeySet] = None,
     exclude_key_set: Optional[torch._C.DispatchKeySet] = None,
     force_enable_grad=False,
+    subgraph_decomp_table: Optional[Mapping[OpOverload, Callable]] = None,
 ) -> torch.fx.GraphModule:
     if include_key_set is None:
         include_key_set = torch._C._dispatch_tls_local_include_set()
@@ -1188,7 +1199,9 @@ def materialize_as_graph(
                 # make sure the fake mode when tracing subgraph is consistent.
                 if fake_mode := detect_fake_mode(unfunc_t):
                     stack.enter_context(fake_mode)
-                return _maybe_reenter_make_fx(fn)(*unfunc_t)
+                return _maybe_reenter_make_fx(
+                    fn, subgraph_decomp_table=subgraph_decomp_table
+                )(*unfunc_t)
 
     gm = _materialize_as_graph_inner()
     assert gm is not None

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -2646,6 +2646,24 @@ class _MakefxTracer:
         with sub_tracer._init_modes_from_parent(self):
             return sub_tracer._trace_inner(f, *args)
 
+    def trace_subgraph_custom_decomp(
+        self, f: Callable, decomp_table: Mapping[OpOverload, Callable], *args
+    ) -> GraphModule:
+        assert isinstance(decomp_table, Mapping)
+        # Create a new tracer based on parent's config, but use a different decomposition table
+        sub_tracer = _MakefxTracer(
+            decomp_table,
+            "real",
+            self._allow_non_fake_inputs,
+            self.pre_dispatch,
+            self.record_module_stack,
+            self._allow_fake_constant,
+            self._error_on_data_dependent_ops,
+            parent_tracer=self,
+        )
+        with sub_tracer._init_modes_from_parent(self):
+            return sub_tracer._trace_inner(f, *args)
+
 
 _CURRENT_MAKE_FX_TRACER: Optional[_MakefxTracer] = None
 

--- a/torch/fx/passes/regional_inductor_invoke_subgraph.py
+++ b/torch/fx/passes/regional_inductor_invoke_subgraph.py
@@ -1,0 +1,165 @@
+# mypy: allow-untyped-defs
+
+import copy
+import logging
+from collections import defaultdict
+
+import torch
+from torch._inductor.standalone_compile import AOTCompiledArtifact
+from torch.compiler._cache import CacheArtifactManager
+from torch.fx._compatibility import compatibility
+from torch.fx.passes.regional_inductor import _dummy_wrapper
+
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["regional_inductor_invoke_subgraph"]
+
+
+def _compile_submod(
+    gm: torch.fx.GraphModule, subgraph: str, subgraph_users: list[torch.fx.Node]
+):
+    """
+    Compiles subgraph submodule in gm. subgraph is used by subgraph_users.
+    subgraph_users must all be  torch.ops.higher_order.invoke_subgraph HOP.
+    """
+
+    submod = getattr(gm, subgraph)
+
+    compile_config = None
+    fake_inputs = []
+
+    # We use the first user for compile configs and inputs
+    sub_node = subgraph_users[0]
+    assert _needs_inductor_compile(sub_node)
+    compile_config = sub_node.meta["custom"]["nested_region_config"]
+    if sub_node.meta.get("partitioner_tag") == "is_forward":
+        compile_fn = compile_config.fw_compiler
+    else:
+        compile_fn = compile_config.bw_compiler
+
+    for inp_node in sub_node.all_input_nodes[
+        1:
+    ]:  # exlucde the graph module input to torch.ops.higher_order.invoke_subgraph
+        if hasattr(inp_node, "meta") and "val" in inp_node.meta:
+            fake_inputs.append(inp_node.meta["val"])
+        else:
+            raise RuntimeError(
+                f"Partition is bad because non fake tensor value is seen {inp_node}"
+            )
+
+    # Log the options being used
+    logger.info(
+        "Compiling submodule %s with inductor options: %s",
+        subgraph,
+        compile_config,
+    )
+
+    def get_compiled_fn():
+        context = torch._guards.TracingContext.get()
+        assert context.fake_mode is not None
+
+        context = torch._guards.TracingContext(context.fake_mode)
+
+        with (
+            torch._guards.tracing(context),
+            CacheArtifactManager.with_fresh_cache(),
+            torch._functorch.config.patch("bundled_autograd_cache", True),
+        ):
+            # compile_fx can mutate gm
+            gm = copy.deepcopy(submod)
+
+            compiled_fn = compile_fn(gm, fake_inputs)
+            return compiled_fn
+
+    compiled_fn = get_compiled_fn()
+    assert isinstance(compiled_fn, AOTCompiledArtifact)
+
+    # _dummy_wrapper is to make call_function happy
+    compiled_submod = _dummy_wrapper(compiled_fn)
+    for node in subgraph_users:
+        with gm.graph.inserting_after(node):
+            new_node = gm.graph.call_function(
+                # exclude graph nodes input args
+                compiled_submod,
+                args=node.args[2:],
+                kwargs=node.kwargs,
+            )
+            new_node.meta = node.meta
+            node.replace_all_uses_with(new_node)
+            gm.graph.erase_node(node)
+
+    gm.recompile()
+    return gm
+
+
+def _needs_inductor_compile(node: torch.fx.Node):
+    # TODO: maybe we could change to check
+    # node.meta.get("partitioner_tag") != "is_forward"
+    # if the tag is relibable
+    return (
+        node.op not in ("placeholder", "output")
+        and hasattr(node, "meta")
+        and node.meta.get("custom", None)
+        and node.meta["custom"].get("nested_region_config", None)
+        and node.meta["custom"]["nested_region_config"].fw_compiler
+        and node.meta.get("partitioner_tag") != "is_backward"
+    ) or (
+        node.op not in ("placeholder", "output")
+        and hasattr(node, "meta")
+        and node.meta.get("custom", None)
+        and node.meta["custom"].get("nested_region_config", None)
+        and node.meta["custom"]["nested_region_config"].bw_compiler
+        and node.meta.get("partitioner_tag") == "is_backward"
+    )
+
+
+def _compile_invoke_subgraph_nodes_with_inductor(gm):
+    map_subgraph_to_nodes = defaultdict(list)
+    subgraphs: set[str] = set()
+
+    for node in gm.graph.find_nodes(
+        op="call_function", target=torch.ops.higher_order.invoke_subgraph
+    ):
+        if not _needs_inductor_compile(node):
+            continue
+        assert node.args[0].op == "get_attr"
+        subgraph_name = node.args[0].target
+        assert isinstance(subgraph_name, str)
+        subgraphs.add(subgraph_name)
+        map_subgraph_to_nodes[subgraph_name].append(node)
+
+    for subgraph in subgraphs:
+        gm = _compile_submod(gm, subgraph, map_subgraph_to_nodes[subgraph])
+
+    return gm
+
+
+def _recursive_compile_invoke_subgraph_nodes(gm):
+    for node in gm.graph.find_nodes(op="get_attr"):
+        if _needs_inductor_compile(node):
+            # If the get_attr itself is marked for compile, the outer graph will
+            # take care of it. If we dont do that, we end up with nested
+            # regional inductor compiles that do not work well.
+            continue
+        submod = getattr(gm, node.target)
+        if isinstance(submod, torch.fx.GraphModule):
+            _recursive_compile_invoke_subgraph_nodes(submod)
+
+    return _compile_invoke_subgraph_nodes_with_inductor(gm)
+
+
+@compatibility(is_backward_compatible=False)
+def regional_inductor_invoke_subgraph(gm, *example_args):
+    """
+    Compile invoke_subgraph nodes if they have custom compiler specified
+    in node.meta["nested_region_config"].bw_compiler or fw_compiler
+    """
+    # fuser utils create new nodes using create_proxy which retains the seq_nr
+    # metadata and cause issues
+    with torch.fx.traceback.preserve_node_meta(enable=False):
+        compiled_gm = _recursive_compile_invoke_subgraph_nodes(gm)
+        # TODO: might not need this boxed_nop after we switch to _RegionCompiler
+        return torch._dynamo.backends.debugging.boxed_nop(
+            compiled_gm, example_inputs=[]
+        )


### PR DESCRIPTION
- Add `aot_config` arg to `nested_compile_region`.  The config looks like below. 

```
@dataclass
class NestedCompileRegionOptions:
    # A Callable that takes (gm, example_inputs, decompositions=None, **kwargs) as inputs.
    fw_compiler: Optional[Callable] = None
    bw_compiler: Optional[Callable] = None

    # Note: [InvokeSubgraphHOP Partitioner]
    # If not None, add "partitioner" to HOP node meta.
    # If Callable, directly assign the callable, but the callable cannot be pickled
    # If str, the options are "default_partition" and "min_cut_rematerialization_partition".
    # The HOP joint graph will be partitioned using the corresponding functions in
    # torch/_functorch/partitioners.py
    partitioner: Optional[Callable | str] = None

    decompositions: Optional[dict[str, Any]] = None
```

For nested region that has this aot_config option, it will have `node.meta["custom"]["nested_region_config"]=this_option` on the `torch.ops.higher_order.invoke_subgraph` node. 

The subgraph used in torch.ops.higher_order.invoke_subgraph will be compied with fw/bw_compiler specified in the config. If the compiler is None, it will not be compiled. 


We provide the following convenient util function to get a config that is used for compiling the nested region using inductor:

```
get_invoke_subgraph_compile_options(
    inductor_config_patches=None,
    decompositions=None,
    partitioner="min_cut_rematerialization_partition",
)
```


Example using this (flex_attention will be compiled with default inductor configs): 

```
        nested_config = get_invoke_subgraph_compile_options(decompositions=decomp_table)

        @torch.compiler.nested_compile_region(aot_config=nested_config)
        def f_flex_attention(x, y, z, block_mask, score_mod):
            x = flex_attention(x, y, z, block_mask=block_mask, score_mod=score_mod)
            return x

        def fn(x):
            x = torch.sin(x)
            x = f_flex_attention(x, x, x, block_mask=block_mask, score_mod=_squared)
            return torch.cos(x)
```


How the regional inductor implementation works:

We recursively look for `torch.ops.higher_order.invoke_subgraph` nodes that has the `node.meta["custom"]["nested_region_config"]` config. 

e.g. if the node `invoke_subgraph_3 = torch.ops.higher_order.invoke_subgraph(partitioned_bw_subgraph_0_0, 'partitioned_bw_subgraph_0_0', arg0, arg1);` has the node meta, we take the submodule corresponding to `partitioned_bw_subgraph_0_0` getattr node, and compile it. 

The example inputs are obtained from the input node `arg0` and `arg1`'s node.meta["val"].


Then, we replace `invoke_subgraph_3` with a call to the new compiled_submod. 

We add a `compile_fn` option to `standalone_compile` so `standalone_compile` uses the custom compile fn to compile. 


https://docs.google.com/document/d/1vkvyP_BH_-tbvjLugmCl4kULsZU1uf1Fag2dAEBhebE/edit?tab=t.0


Nested:

You can nest `nested_compile_region`, but you CANNOT nest `nested_compile_region(aot_config=nested_config)`. Only at most 1 `nested_compile_region` in the nested stack should have `aot_config`. 

You can have multiple `nested_compile_region(aot_config=nested_config)` in parallel, just don't nest them.

```
# valid example
        @torch.compiler.nested_compile_region(aot_config=nested_config)
        def g(y):
            return y * 2

        @torch.compiler.nested_compile_region
        def gn(x):
            x = g(x)
            return torch.sin(x)

        def fn(x):
            x = x + 1
            x = gn(x)
            x = x + 1
            x = gn(x)
            return torch.sigmoid(x)
```


Compile time:

Let's say I want to compile flex attention for 10 times like:

```
layer = 10

        @torch.compiler.nested_compile_region(aot_config=nested_config)
        def f_flex_attention(x, y, z, block_mask, score_mod):
            x = flex_attention(x, y, z, block_mask=block_mask, score_mod=score_mod)
            return x

        def fn2(x):
            x = torch.sin(x)
            x = f_flex_attention(x, x, x, block_mask=block_mask, score_mod=_squared)
            return torch.cos(x)

        def fn(x):
            for i in range(layer):
                x = fn2(x)
            return x
```

Using annotation:

14,552,485 us
<img width="992" height="329" alt="Screenshot 2025-12-01 at 7 58 33 PM" src="https://github.com/user-attachments/assets/903d9e1c-7e9b-42ab-9529-19bb3f32371d" />


Using invoke_subgraph:

6, 466,116 us

<img width="988" height="313" alt="Screenshot 2025-12-01 at 8 00 43 PM" src="https://github.com/user-attachments/assets/be09be3e-37ab-4ae5-af65-45bb9dbb3206" />


We can see that using invoke_subgraph is faster. (benchmark code: P2063033678)

Caveats/future work:

- currently serialization doesn't work yet
- the returned values in the compiled region will be detached twice (once in subgraph, once outside), will this hurt performance?
- we should test if this is composable with cudagraph using torchtitan


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @chenyang78