### PR TITLE
[CD] Preload `libnvrtc-builtinso.so`

### DIFF
--- a/.ci/pytorch/smoke_test/smoke_test.py
+++ b/.ci/pytorch/smoke_test/smoke_test.py
@@ -353,6 +353,17 @@ def test_linalg(device="cpu") -> None:
             torch.linalg.svd(A)
 
 
+def test_sdpa(device="cpu", dtype=torch.float16) -> None:
+    """ Regression test for https://github.com/pytorch/pytorch/issues/167602
+    Without nvrtc_builtins on CuDNN-9.13 on CUDA-13 fails with ` No valid execution plans built.`
+    """
+    print(f"Testing SDPA on {device} using type {dtype}")
+    k,q,v=torch.rand(3, 1, 16, 77, 64, dtype=dtype, device=device).unbind(0);
+    attn = torch.rand(1, 1, 77, 77, dtype=dtype, device=device)
+    rc = torch.nn.functional.scaled_dot_product_attention(q, k, v, attn)
+    assert rc.isnan().any().item() is False
+
+
 def smoke_test_compile(device: str = "cpu") -> None:
     supported_dtypes = [torch.float16, torch.float32, torch.float64]
 
@@ -489,10 +500,12 @@ def main() -> None:
     smoke_test_conv2d()
     test_linalg()
     test_numpy()
+    test_sdpa()
 
     if is_cuda_system:
         test_linalg("cuda")
         test_cuda_gds_errors_captured()
+        test_sdpa("cuda")
 
     if options.package == "all":
         smoke_test_modules()

--- a/.ci/pytorch/smoke_test/smoke_test.py
+++ b/.ci/pytorch/smoke_test/smoke_test.py
@@ -354,11 +354,11 @@ def test_linalg(device="cpu") -> None:
 
 
 def test_sdpa(device="cpu", dtype=torch.float16) -> None:
-    """ Regression test for https://github.com/pytorch/pytorch/issues/167602
+    """Regression test for https://github.com/pytorch/pytorch/issues/167602
     Without nvrtc_builtins on CuDNN-9.13 on CUDA-13 fails with ` No valid execution plans built.`
     """
     print(f"Testing SDPA on {device} using type {dtype}")
-    k,q,v=torch.rand(3, 1, 16, 77, 64, dtype=dtype, device=device).unbind(0);
+    k, q, v = torch.rand(3, 1, 16, 77, 64, dtype=dtype, device=device).unbind(0)
     attn = torch.rand(1, 1, 77, 77, dtype=dtype, device=device)
     rc = torch.nn.functional.scaled_dot_product_attention(q, k, v, attn)
     assert rc.isnan().any().item() is False

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -321,32 +321,32 @@ def _preload_cuda_lib(lib_folder: str, lib_name: str, required: bool = True) -> 
 
 
 def _preload_cuda_deps(err: _Optional[OSError] = None) -> None:
-    cuda_libs: dict[str, str] = {
-        "cublas": "libcublas.so.*[0-9]",
-        "cudnn": "libcudnn.so.*[0-9]",
-        "cuda_nvrtc": "libnvrtc.so.*[0-9]",
-        "cuda_runtime": "libcudart.so.*[0-9]",
-        "cuda_cupti": "libcupti.so.*[0-9]",
-        "cufft": "libcufft.so.*[0-9]",
-        "curand": "libcurand.so.*[0-9]",
-        "nvjitlink": "libnvJitLink.so.*[0-9]",
-        "cusparse": "libcusparse.so.*[0-9]",
-        "cusparselt": "libcusparseLt.so.*[0-9]",
-        "cusolver": "libcusolver.so.*[0-9]",
-        "nccl": "libnccl.so.*[0-9]",
-        "nvshmem": "libnvshmem_host.so.*[0-9]",
-        "cufile": "libcufile.so.*[0-9]",
-    }
-
+    cuda_libs: list[tuple[str, str]] = [
+        ("cublas", "libcublas.so.*[0-9]"),
+        ("cudnn", "libcudnn.so.*[0-9]"),
+        ("cuda_nvrtc", "libnvrtc.so.*[0-9]"),
+        ("cuda_nvrtc", "libnvrtc-builtins.so.*[0-9]"),
+        ("cuda_runtime", "libcudart.so.*[0-9]"),
+        ("cuda_cupti", "libcupti.so.*[0-9]"),
+        ("cufft", "libcufft.so.*[0-9]"),
+        ("curand", "libcurand.so.*[0-9]"),
+        ("nvjitlink", "libnvJitLink.so.*[0-9]"),
+        ("cusparse", "libcusparse.so.*[0-9]"),
+        ("cusparselt", "libcusparseLt.so.*[0-9]"),
+        ("cusolver", "libcusolver.so.*[0-9]"),
+        ("nccl", "libnccl.so.*[0-9]"),
+        ("nvshmem", "libnvshmem_host.so.*[0-9]"),
+        ("cufile", "libcufile.so.*[0-9]"),
+    ]
     # If error is passed, re-raise it if it's not about one of the abovementioned
     # libraries
     if err is not None and [
-        lib for lib in cuda_libs.values() if lib.split(".", 1)[0] in err.args[0]
+        lib for _, lib in cuda_libs if lib.split(".", 1)[0] in err.args[0]
     ]:
         raise err
 
     # Otherwise, try to preload dependencies from site-packages
-    for lib_folder, lib_name in cuda_libs.items():
+    for lib_folder, lib_name in cuda_libs:
         _preload_cuda_lib(lib_folder, lib_name)
 
     # libnvToolsExt is Optional Dependency


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #167614

Which is a regression introduced by https://github.com/pytorch/pytorch/pull/167046
That causes CuDNN SDPA fail with actionable `cuDNN Frontend error: [cudnn_frontend] Error: No valid execution plans built.` error

Change `cuda_libs` from dict to list, and add `test_sdpa` regression test to binary smoke tests

Fixes https://github.com/pytorch/pytorch/issues/167602