### PR TITLE
[dynamo] [3.14] Support np._CopyMode

### DIFF
--- a/test/test_numpy_interop.py
+++ b/test/test_numpy_interop.py
@@ -683,6 +683,15 @@ class TestNumPyInterop(TestCase):
         ):
             f(xs)
 
+    def test_copy_mode(self):
+        @torch.compile(backend="eager", fullgraph=True)
+        def f(x):
+            return np.array(x, copy=np._CopyMode.IF_NEEDED)
+
+        x = np.array([1, 2, 3])
+        # Should run without throwing an exception
+        f(x)
+
 
 instantiate_device_type_tests(TestNumPyInterop, globals())
 

--- a/test/test_numpy_interop.py
+++ b/test/test_numpy_interop.py
@@ -684,13 +684,14 @@ class TestNumPyInterop(TestCase):
             f(xs)
 
     def test_copy_mode(self):
-        @torch.compile(backend="eager", fullgraph=True)
         def f(x):
             return np.array(x, copy=np._CopyMode.IF_NEEDED)
 
+        opt_f = torch.compile(backend="eager", fullgraph=True)(f)
         x = np.array([1, 2, 3])
         # Should run without throwing an exception
-        f(x)
+        y = opt_f(x)
+        self.assertEqual(y, f(x))
 
 
 instantiate_device_type_tests(TestNumPyInterop, globals())

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -1606,7 +1606,8 @@ class NumpyVariable(VariableTracker):
 
     def as_proxy(self):
         if config.trace_numpy:
-            if isinstance(self.value, enum.EnumType):
+            # Can replace with EnumType once we drop 3.10 support
+            if isinstance(self.value, enum.EnumMeta):
                 # This is mostly for np._CopyMode
                 return self.value
             if isinstance(self.value, type):

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -18,6 +18,7 @@ Key classes include:
 """
 
 import dataclasses
+import enum
 import functools
 import inspect
 import itertools
@@ -1604,11 +1605,15 @@ class NumpyVariable(VariableTracker):
         return self.value
 
     def as_proxy(self):
-        if config.trace_numpy and isinstance(self.value, type):
-            # This handles numpy dtype attributes such as np.float32
-            # We return a string as we don't want to serialize non-PyTorch objects in the output FX graph
-            # In torch/_numpy we normalize strings to their dtypes when the input is a dtype, as NumPy does
-            return self.value.__name__
+        if config.trace_numpy:
+            if isinstance(self.value, enum.EnumType):
+                # This is mostly for np._CopyMode
+                return self.value
+            if isinstance(self.value, type):
+                # This handles numpy dtype attributes such as np.float32
+                # We return a string as we don't want to serialize non-PyTorch objects in the output FX graph
+                # In torch/_numpy we normalize strings to their dtypes when the input is a dtype, as NumPy does
+                return self.value.__name__
 
         return super().as_proxy()
 

--- a/torch/_numpy/_util.py
+++ b/torch/_numpy/_util.py
@@ -230,6 +230,12 @@ def _coerce_to_tensor(obj, dtype=None, copy=False, ndmin=0):
     if ndim_extra > 0:
         tensor = tensor.view((1,) * ndim_extra + tensor.shape)
 
+    # special handling for np._CopyMode
+    try:
+        copy = bool(copy)
+    except ValueError:
+        # TODO handle _CopyMode.IF_NEEDED correctly
+        copy = False
     # copy if requested
     if copy:
         tensor = tensor.clone()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #167681
* __->__ #167619

Upgrading scipy to 1.16 introduced errors related to the `copy` parameter of
`np.array`.  Add special handling for `np._CopyMode.IF_NEEDED`, which is not
handled correctly, but matches the existing behavior when `copy=None`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela