### PR TITLE
[ROCm] Optimizing PyTorch TopK Operator on ROCm

### DIFF
--- a/aten/src/ATen/cuda/DeviceUtils.cuh
+++ b/aten/src/ATen/cuda/DeviceUtils.cuh
@@ -110,16 +110,11 @@ __device__ __forceinline__ c10::complex<T> WARP_SHFL_DOWN(c10::complex<T> value,
 
 /**
  * For CC 3.5+, perform a load using __ldg
- * For ROCm, use non-caching load (equivalent performance benefit)
  */
 template <typename T>
 __device__ __forceinline__ T doLdg(const T* p) {
 #if __CUDA_ARCH__ >= 350 && !defined(USE_ROCM)
   return __ldg(p);
-#elif defined(USE_ROCM) && defined(__gfx9__)
-  // ROCm on CDNA: Use non-temporal (non-caching) load via builtin
-  // This reduces cache pollution for streaming reads (similar to __ldg on CUDA)
-  return __builtin_nontemporal_load(p);
 #else
   return *p;
 #endif

--- a/aten/src/ATen/native/cuda/TensorTopK.cpp
+++ b/aten/src/ATen/native/cuda/TensorTopK.cpp
@@ -40,19 +40,19 @@ bool should_use_sort(const Tensor& self, int64_t dim) {
   }
 
   /* Strategy: Balance between full sort and TopK selection based on size, k, and dtype
-  
+
   Analysis:
   - TopK (mbtopk): O(n * radix_passes) - radix passes vary by dtype
     - float32: 4 passes (32 bits / 8 bits per pass)
     - bfloat16/float16: 2 passes (16 bits / 8 bits per pass)
     - Has multi-block overhead and atomics
     - Better for very large n with small k, especially for float32
-  
+
   - Full sort: O(n * log2(n))
     - Better memory patterns and cache locality
     - Efficient rocThrust implementation for moderate sizes
     - Crossover depends on n, k, and dtype
-  
+
   Empirical thresholds (based on benchmarks):
     For n < 500k:  Use sort (rocThrust is well-optimized for moderate sizes)
     For n >= 500k: Dtype-aware strategy

--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -3,6 +3,7 @@
 #include <ATen/core/TensorBase.h>
 #include <ATen/ceil_div.h>
 #include <ATen/Dispatch.h>
+#include <c10/macros/Macros.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/detail/TensorInfo.cuh>
 #include <ATen/cuda/detail/OffsetCalculator.cuh>
@@ -14,8 +15,6 @@
 #include <ATen/cuda/cub.cuh>
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <ATen/cuda/detail/KernelUtils.h>
-
-#include <c10/macros/Macros.h>
 
 #if defined(USE_ROCM)
 #include <rocprim/block/block_scan.hpp>
@@ -30,7 +29,7 @@ namespace sbtopk { // single_block_topk
 template <typename T>
 struct AddOp {
   __device__ __forceinline__ T operator()(T const &lhs, T const &rhs) {
-    return (lhs + rhs);
+    return lhs + rhs;
   }
 };
 
@@ -54,11 +53,6 @@ __global__ void gatherTopK(at::cuda::detail::TensorInfo<const T, IndexType> inpu
   // int32, regardless of IndexType
 #if defined(USE_ROCM)
   __shared__ int smem[64];
-  // For ROCm, replace manual prefix scans with rocPRIM block scans.
-  // Use a fixed block size for ROCm path (configured in launch).
-  using BlockScan = rocprim::block_scan<int, 256>;
-  __shared__ typename BlockScan::storage_type scan_storage;
-  __shared__ int carry_shared;
 #else
   __shared__ int smem[32]; // one per each warp, up to warp limit
 #endif
@@ -123,19 +117,8 @@ __global__ void gatherTopK(at::cuda::detail::TensorInfo<const T, IndexType> inpu
 
     int index;
     int carry;
-#if defined(USE_ROCM)
-    const int flag = hasTopK ? 1 : 0;
-    int block_total = 0;
-    BlockScan().exclusive_scan(flag, index, 0, block_total, scan_storage);
-    if (threadIdx.x == blockDim.x - 1) {
-      carry_shared = block_total;
-    }
-    __syncthreads();
-    carry = carry_shared;
-#else
     at::cuda::exclusiveBinaryPrefixScan<int, true>(
         smem, hasTopK, &index, &carry, AddOp<int>());
-#endif
 
     if (hasTopK) {
       int writeIndex = writeIndexStart + index;
@@ -168,19 +151,8 @@ __global__ void gatherTopK(at::cuda::detail::TensorInfo<const T, IndexType> inpu
 
     int index;
     int carry;
-#if defined(USE_ROCM)
-    const int flag = hasTopK ? 1 : 0;
-    int block_total = 0;
-    BlockScan().exclusive_scan(flag, index, 0, block_total, scan_storage);
-    if (threadIdx.x == blockDim.x - 1) {
-      carry_shared = block_total;
-    }
-    __syncthreads();
-    carry = carry_shared;
-#else
     at::cuda::exclusiveBinaryPrefixScan<int, true>(
         smem, hasTopK, &index, &carry, AddOp<int>());
-#endif
 
     if (hasTopK && index < topKRemaining) {
       int writeIndex = writeIndexStart + index;
@@ -201,7 +173,7 @@ __global__ void gatherTopK(at::cuda::detail::TensorInfo<const T, IndexType> inpu
     writeIndexStart += carry;
   }
 
-};
+}
 
 template <typename T, typename IndexType, int Dim>
 void launch(
@@ -221,13 +193,8 @@ void launch(
 
     dim3 grid;
     TORCH_INTERNAL_ASSERT(getGridFromTiles(numInputSlices, grid), "Too many slices for topk");
-#if defined(USE_ROCM)
-    // Use fixed block size to match rocPRIM block_scan configuration in kernel
-    dim3 block(256);
-#else
     int warp_size = at::cuda::warp_size();
     dim3 block(std::min(at::ceil_div((int64_t)inputSliceSize, (int64_t)warp_size) * (int64_t)warp_size, (int64_t)1024));
-#endif
     gatherTopK<T, IndexType, Dim, /* WithKthValues= */false><<<grid, block, 0, c10::cuda::getCurrentCUDAStream()>>>(
         input,
         inputSliceSize,
@@ -306,25 +273,13 @@ __global__ void computeBlockDigitCounts(
   static_assert(MAX_ITEMS_PER_THREAD * BLOCK_THREADS < std::numeric_limits<short>::max(),
     "blockwise counter too large");
   union __align__(16) TempStorage {
-    uint32_t digit_counters[
-#if defined(USE_ROCM)
-      RADIX_DIGITS + (RADIX_DIGITS / 32)
-#else
-      RADIX_DIGITS
-#endif
-    ];
+    uint32_t digit_counters[RADIX_DIGITS];
   };
   __shared__ TempStorage temp_storage;
 
   // fill digit_counters with zeros
   if (tidx < RADIX_DIGITS) {
-    temp_storage.digit_counters[
-#if defined(USE_ROCM)
-      tidx + tidx / 32
-#else
-      tidx
-#endif
-    ] = 0;
+    temp_storage.digit_counters[tidx] = 0;
   }
   __syncthreads();
 
@@ -342,13 +297,7 @@ __global__ void computeBlockDigitCounts(
       bool has_val = ((val & desiredMask) == (desired & desiredMask));
       Bitwise digit = at::cuda::Bitfield<Bitwise>::getBitfield(val, current_bit, RADIX_BITS);
       if (has_val) {
-        atomicAdd(&temp_storage.digit_counters[
-#if defined(USE_ROCM)
-          digit + digit / 32
-#else
-          digit
-#endif
-        ], 1);
+        atomicAdd(&temp_storage.digit_counters[digit], 1);
       }
     }
   }
@@ -359,13 +308,7 @@ __global__ void computeBlockDigitCounts(
   static_assert(RADIX_DIGITS <= BLOCK_THREADS, "this kernel requires RADIX_DIGITS <= BLOCK_THREADS");
   uint32_t digit_count = 0;
   if (tidx < RADIX_DIGITS) {
-    digit_count = temp_storage.digit_counters[
-#if defined(USE_ROCM)
-      tidx + tidx / 32
-#else
-      tidx
-#endif
-    ];
+    digit_count = temp_storage.digit_counters[tidx];
   }
 
   // We always write out counts regardless if blocks_per_slice == 1 because
@@ -418,17 +361,17 @@ template <typename Bitwise, typename T>
 C10_LAUNCH_BOUNDS_1(RADIX_DIGITS)  // one thread per digit
 __global__ void computeBlockwiseWithinKCounts(
   Bitwise* desires_in,          // size: num_slices
-  short* counts,             // size: num_slices * blocks_per_slice * radix_digits
-  uint32_t* digit_cum_sum,
-  uint32_t* ks_to_find_in,  // size: num_slices
+  short* counts,                // size: num_slices * blocks_per_slice * radix_digits
+  uint32_t* ks_to_find_in,      // size: num_slices
   uint32_t blocks_per_slice,
   int current_bit,
   bool largest,
   // outputs:
-  uint32_t* withinKCounts,  // size: num_slices * blocks_per_slice == num_blocks
-  T* kthValues,           // size: num_slices, only write when current_bit reaches 0
+  uint32_t* withinKCounts,      // size: num_slices * blocks_per_slice == num_blocks
+  T* kthValues,                 // size: num_slices, only write when current_bit reaches 0
   uint32_t* ks_to_find_out,
   Bitwise* desires_out,
+  uint32_t* kthCounts,          // size: num_slices * blocks_per_slice == num_blocks
   uint32_t num_blocks
 ) {
   // This kernel should be launched with the same number of blocks as the `computeBlockDigitCounts` kernel.
@@ -449,10 +392,29 @@ __global__ void computeBlockwiseWithinKCounts(
   __shared__ Bitwise desired;
   uint32_t k_to_find = ks_to_find_in[slice_idx];
 
+  // Build per-slice digit totals in shared memory and compute inclusive cumsum
+  __shared__ uint32_t digit_totals[RADIX_DIGITS];
   if (tidx < RADIX_DIGITS) {
-    uint32_t position = slice_idx * RADIX_DIGITS + tidx;
-    uint32_t digit_count_cumsum = digit_cum_sum[position];
-    uint32_t digit_count_cumsum_left = (tidx == 0) ? 0 : digit_cum_sum[position - 1];
+    uint32_t sum = 0;
+    // Accumulate counts across all blocks in the slice for this digit
+    for (uint32_t blk = 0; blk < blocks_per_slice; ++blk) {
+      sum += counts[(slice_idx * blocks_per_slice + blk) * RADIX_DIGITS + tidx];
+    }
+    digit_totals[tidx] = sum;
+  }
+  __syncthreads();
+
+  // Inclusive scan over RADIX_DIGITS entries
+  for (int offset = 1; offset < RADIX_DIGITS; offset <<= 1) {
+    uint32_t v = (tidx >= offset) ? digit_totals[tidx - offset] : 0u;
+    __syncthreads();
+    if (tidx < RADIX_DIGITS) digit_totals[tidx] += v;
+    __syncthreads();
+  }
+
+  if (tidx < RADIX_DIGITS) {
+    uint32_t digit_count_cumsum = digit_totals[tidx];
+    uint32_t digit_count_cumsum_left = (tidx == 0) ? 0 : digit_totals[tidx - 1];
 
     // if not the last pass: update desired and ks_to_find
     // if last pass: write out the kth value
@@ -525,6 +487,12 @@ __global__ void computeBlockwiseWithinKCounts(
   }
   if (tidx == 0) {
     withinKCounts[block_idx] += count;
+  }
+
+  // On the last pass (current_bit == 0), write out block-wise kthCounts directly
+  if (tidx == 0 && current_bit == 0) {
+    Bitwise desired_digit0 = at::cuda::Bitfield<Bitwise>::getBitfield(desired, 0, RADIX_BITS);
+    kthCounts[block_idx] = doLdg(counts + block_idx * RADIX_DIGITS + desired_digit0);
   }
 }
 
@@ -607,14 +575,30 @@ __global__ void gatherTopK(at::cuda::detail::TensorInfo<const T, IndexType> inpu
   const auto kthValueConverted = at::native::TopKTypeConfig<T>::convert(kthValue);
 
   // Find the start index in output tensor of this block
-  uint32_t startWithinK = 0;
-  if (blk_idx_in_slice > 0) {
-    startWithinK = withinKCounts[block_idx - 1];
+  __shared__ uint32_t slice_prefix_within;
+  __shared__ uint32_t slice_prefix_kth;
+  __shared__ uint32_t slice_total_within;
+  if (threadIdx.x == 0) {
+    uint32_t prefix_within = 0;
+    uint32_t prefix_kth = 0;
+    uint32_t total_within = 0;
+    uint32_t slice_offset = slice_idx * blocks_per_slice;
+    for (uint32_t blk = 0; blk < blocks_per_slice; ++blk) {
+      uint32_t within_val = withinKCounts[slice_offset + blk];
+      total_within += within_val;
+      if (blk < blk_idx_in_slice) {
+        prefix_within += within_val;
+        prefix_kth += kthCounts[slice_offset + blk];
+      }
+    }
+    slice_prefix_within = prefix_within;
+    slice_prefix_kth = prefix_kth;
+    slice_total_within = total_within;
   }
-  uint32_t startKth = withinKCounts[slice_idx * blocks_per_slice + blocks_per_slice - 1];
-  if (blk_idx_in_slice > 0) {
-    startKth += kthCounts[block_idx - 1];
-  }
+  __syncthreads();
+
+  uint32_t startWithinK = slice_prefix_within;
+  uint32_t startKth = slice_total_within + slice_prefix_kth;
 
   // Read input, select topk out and write
   typedef cub::BlockScan<uint32_t, BLOCK_THREADS> BlockScan;
@@ -659,191 +643,6 @@ __global__ void gatherTopK(at::cuda::detail::TensorInfo<const T, IndexType> inpu
     }
   }
 }
-
-#ifdef USE_ROCM
-
-
-
-//fused radix pass
-template <typename T, typename IndexType, typename Bitwise, int Dim>
-C10_LAUNCH_BOUNDS_1(BLOCK_THREADS)
-__attribute__((amdgpu_flat_work_group_size(64, 1024)))
-__global__ void fusedRadixPassKernel(
-    at::cuda::detail::TensorInfo<const T, IndexType> input,
-    uint32_t slice_size,
-    uint32_t num_slices,
-    IndexType withinSliceStride,
-    int current_bit,
-    int items_per_thread,
-    uint32_t blocks_per_slice,
-    bool largest,
-    Bitwise desiredMask,
-    Bitwise* desires_in,
-    uint32_t* ks_to_find_in,
-    // outputs:
-    Bitwise* desires_out,
-    uint32_t* ks_to_find_out,
-    T* kthValues,
-    uint32_t* withinKCounts,
-    short* counts_out) {
-
-  const uint32_t tidx = threadIdx.x;
-  const uint32_t block_idx = getLinearBlockId<uint32_t>();
-  const uint32_t slice_idx = block_idx / blocks_per_slice;
-  const uint32_t blk_idx_in_slice = block_idx % blocks_per_slice;
-  if (slice_idx >= num_slices) return;
-
-  //phase 1
-  const Bitwise desired = desires_in[slice_idx];
-  const IndexType slice_start_index =
-      at::cuda::detail::IndexToOffset<const T, IndexType, Dim>::get(slice_idx, input);
-  const T* data = &input.data[slice_start_index];
-
-  __shared__ uint32_t digit_counters[
-      RADIX_DIGITS
-      #if defined(USE_ROCM)
-        + (RADIX_DIGITS / 32)
-      #endif
-  ];
-  if (tidx < RADIX_DIGITS)
-    digit_counters[
-      #if defined(USE_ROCM)
-        tidx + tidx / 32
-      #else
-        tidx
-      #endif
-    ] = 0;
-  __syncthreads();
-
-  const int items_per_block = items_per_thread * BLOCK_THREADS;
-  const int local_items_per_thread =
-      (blk_idx_in_slice + 1 < blocks_per_slice)
-          ? items_per_thread
-          : at::ceil_div(
-                (int64_t)(slice_size - blk_idx_in_slice * items_per_block),
-                (int64_t)BLOCK_THREADS);
-
-  for (int i = 0; i < local_items_per_thread; ++i) {
-    const IndexType idx =
-        blk_idx_in_slice * items_per_block + i * BLOCK_THREADS + tidx;
-    if (idx < slice_size) {
-      const Bitwise val =
-          TopKTypeConfig<T>::convert(doLdg(&data[idx * withinSliceStride]));
-      if ((val & desiredMask) == (desired & desiredMask)) {
-        const Bitwise digit =
-            at::cuda::Bitfield<Bitwise>::getBitfield(val, current_bit, RADIX_BITS);
-        atomicAdd(&digit_counters[
-          #if defined(USE_ROCM)
-            digit + digit / 32
-          #else
-            digit
-          #endif
-        ], 1);
-      }
-    }
-  }
-  __syncthreads();
-
-  // Write block-local histogram to global counts buffer
-  if (tidx < RADIX_DIGITS)
-    counts_out[block_idx * RADIX_DIGITS + tidx] = static_cast<short>(
-        digit_counters[
-          #if defined(USE_ROCM)
-            tidx + tidx / 32
-          #else
-            tidx
-          #endif
-        ]);
-
-  //phase 2
-  if (blk_idx_in_slice == 0) {
-    __syncthreads();
-    
-    // Accumulate counts across all blocks for this slice
-    uint32_t digit_total = 0;
-    if (tidx < RADIX_DIGITS) {
-      uint32_t total = 0;
-      for (uint32_t blk = 0; blk < blocks_per_slice; ++blk) {
-        total += static_cast<uint32_t>(
-            counts_out[(slice_idx * blocks_per_slice + blk) * RADIX_DIGITS + tidx]);
-      }
-      digit_total = total;
-    }
-
-    // Inclusive scan using rocPRIM
-    using BlockScan = rocprim::block_scan<uint32_t, RADIX_DIGITS>;
-    __shared__ typename BlockScan::storage_type scan_storage;
-    uint32_t digit_cumsum = 0;
-    BlockScan().inclusive_scan(digit_total, digit_cumsum, scan_storage);
-    __syncthreads();
-
-    __shared__ uint32_t digit_cumsum_shared[RADIX_DIGITS];
-    if (tidx < RADIX_DIGITS)
-      digit_cumsum_shared[tidx] = digit_cumsum;
-    __syncthreads();
-
-    const uint32_t k_to_find = ks_to_find_in[slice_idx];
-
-    if (tidx < RADIX_DIGITS) {
-      const uint32_t left = (tidx == 0) ? 0 : digit_cumsum_shared[tidx - 1];
-      const uint32_t right = digit_cumsum_shared[tidx];
-      if (left < k_to_find && k_to_find <= right) {
-        Bitwise updated = desires_in[slice_idx];
-        updated = at::cuda::Bitfield<Bitwise>::setBitfield(updated, tidx, current_bit, RADIX_BITS);
-        desires_out[slice_idx] = updated;
-        if (current_bit > 0)
-          ks_to_find_out[slice_idx] = k_to_find - left;
-        else
-          kthValues[slice_idx] = TopKTypeConfig<T>::deconvert(updated);
-      }
-    }
-  }
-
-
-  //phase 3
-  const Bitwise slice_desired = desires_out[slice_idx];
-  const Bitwise desired_digit =
-      at::cuda::Bitfield<Bitwise>::getBitfield(slice_desired, current_bit, RADIX_BITS);
-
-  // Each block computes its own count
-  bool thread_is_active = false;
-  if (tidx < RADIX_DIGITS) {
-    if (largest)
-      thread_is_active = (tidx > desired_digit);
-    else
-      thread_is_active = (tidx < desired_digit);
-  }
-
-  uint32_t my_count = 0;
-  if (thread_is_active) {
-    // Read THIS block's count for this digit
-    my_count = static_cast<uint32_t>(
-        counts_out[block_idx * RADIX_DIGITS + tidx]);
-  }
-
-  // Warp reduction
-  for (int offset = C10_WARP_SIZE / 2; offset > 0; offset /= 2)
-    my_count += WARP_SHFL_DOWN(my_count, offset);
-
-  // Reduce warp results
-  constexpr int NUM_WARPS = RADIX_DIGITS / C10_WARP_SIZE;
-  __shared__ uint32_t warp_sum[NUM_WARPS];
-  if (tidx % C10_WARP_SIZE == 0 && tidx / C10_WARP_SIZE < NUM_WARPS)
-    warp_sum[tidx / C10_WARP_SIZE] = my_count;
-  __syncthreads();
-
-  if (tidx < NUM_WARPS) {
-    uint32_t val = warp_sum[tidx];
-    for (int offset = NUM_WARPS / 2; offset > 0; offset /= 2)
-      val += WARP_SHFL_DOWN(val, offset);
-    if (tidx == 0) {
-      // Each block writes its own withinKCount
-      withinKCounts[block_idx] = val;
-    }
-  }
-
-}
-#endif // USE_ROCM
 
 int get_items_per_thread(uint64_t num_slices, uint64_t slice_size) {
   // occupancy of this kernel is limited by registers per threads
@@ -917,9 +716,7 @@ void launch(
   static_assert(MAX_ITEMS_PER_THREAD * BLOCK_THREADS < std::numeric_limits<short>::max(),
     "blockwise counter too large");
 
-  auto digit_cum_sum_buffer = allocator.allocate(numInputSlices * RADIX_DIGITS * sizeof(uint32_t));
-  uint32_t* digit_cum_sum = reinterpret_cast<uint32_t*>(digit_cum_sum_buffer.get());
-  AT_CUDA_CHECK(cudaMemsetAsync(digit_cum_sum, 0, numInputSlices * RADIX_DIGITS * sizeof(uint32_t), stream));
+  // No separate digit cumsum buffer; fused into computeBlockwiseWithinKCounts
 
   auto withinKCounts_buffer = allocator.allocate(num_blocks * sizeof(uint32_t));
   uint32_t* withinKCounts = reinterpret_cast<uint32_t*>(withinKCounts_buffer.get());
@@ -940,16 +737,6 @@ void launch(
 
   // iterate radix bits for multiple passes
   for (int current_bit = sizeof(T) * 8 - RADIX_BITS; current_bit >= 0; current_bit -= RADIX_BITS) {
-  #ifdef USE_ROCM
-    fusedRadixPassKernel<T, IndexType, Bitwise, Dim>
-        <<<grid, block, 0, stream>>>(
-            input, inputSliceSize, numInputSlices, inputWithinSliceStride,
-            current_bit, items_per_thread, blocks_per_slice, largest, desiredMask,
-            desired_in, ks_to_find_in, desired_out, ks_to_find_out, kthValues,
-            withinKCounts, counts);
-    C10_CUDA_KERNEL_LAUNCH_CHECK();
-  #else
-    
     computeBlockDigitCounts<T, IndexType, Bitwise, Dim><<<grid, block, 0, stream>>>(
         input,
         inputSliceSize,
@@ -964,16 +751,13 @@ void launch(
         counts);
     C10_CUDA_KERNEL_LAUNCH_CHECK();
 
-    computeDigitCumSum<<<numInputSlices, RADIX_DIGITS, 0, stream>>>(counts, digit_cum_sum, blocks_per_slice);
-    C10_CUDA_KERNEL_LAUNCH_CHECK();
-
     // we unconditionally call this kernel to update desired/ks_to_find/kthValues
     // if cub supports scan_by_key we additionally do k counts
     computeBlockwiseWithinKCounts<Bitwise, T><<<grid, RADIX_DIGITS, 0, stream>>>(
-      desired_in, counts, digit_cum_sum, ks_to_find_in, blocks_per_slice, current_bit, largest, withinKCounts, kthValues, ks_to_find_out, desired_out, num_blocks);
+      desired_in, counts, ks_to_find_in, blocks_per_slice, current_bit, largest,
+      withinKCounts, kthValues, ks_to_find_out, desired_out, kthCounts, num_blocks);
     C10_CUDA_KERNEL_LAUNCH_CHECK();
     // swap desired/ks_to_find in and out for next iter
-    #endif
     auto tmp_desired = desired_in;
     desired_in = desired_out;
     desired_out = tmp_desired;
@@ -984,15 +768,7 @@ void launch(
   }
   desired = desired_in;
 
-  computeBlockwiseKthCounts<Bitwise><<<std::min(((int64_t)numInputSlices + 255) / 256, (int64_t)1073741824), 256, 0, stream>>>(
-    desired, counts, num_blocks, blocks_per_slice, kthCounts);
-  C10_CUDA_KERNEL_LAUNCH_CHECK();
-  // Do a prefix scan of withinKCounts and kthCounts using slice_idx as keys to get the starting index of each block
-  using counting_iter_t = ATEN_CUB_COUNTING_ITERATOR(uint32_t, uint32_t);
-  using slice_idx_iter_t = ATEN_CUB_TRANSFORM_ITERATOR(uint32_t, BlockIdxToKey, counting_iter_t);
-  slice_idx_iter_t slice_idx_iter(counting_iter_t(0), BlockIdxToKey(blocks_per_slice));
-  at::cuda::cub::inclusive_sum_by_key(slice_idx_iter, withinKCounts, withinKCounts, num_blocks);
-  at::cuda::cub::inclusive_sum_by_key(slice_idx_iter, kthCounts, kthCounts, num_blocks);
+  // kthCounts already produced in computeBlockwiseWithinKCounts at last pass
   // copy topk values to output tensor
   gatherTopK<T, IndexType, Dim><<<grid, block, 0, stream>>>(
     input, inputSliceSize, outputSliceSize, largest, numInputSlices, inputWithinSliceStride,
@@ -1115,8 +891,6 @@ void launch_gather_topk_kernel(
   // the below is safe with 0-dimensional tensors because it is based on
   // TensorInfo which implicitly expands to 1-dimensional.
   if (input.numel() > 0) {
-    // Based on required index size, run the algorithm with the
-    // appropriate index type
     if (at::cuda::detail::canUse32BitIndexMath(input) &&
         at::cuda::detail::canUse32BitIndexMath(values) &&
         at::cuda::detail::canUse32BitIndexMath(indices)) {
@@ -1127,6 +901,7 @@ void launch_gather_topk_kernel(
   }
 #undef RUN_T
 #undef RUN_DIM
+#undef RUN_MB
 #undef RUN_K
 }
 

--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -271,14 +271,12 @@ __global__ void warpMergeSortTopK(
                 "sort_size must be a multiple of C10_WARP_SIZE");
 
   using LoadKeys = cub::WarpLoad<scalar_t, items_per_thread, cub::WARP_LOAD_TRANSPOSE>;
-  using LoadIndices = cub::WarpLoad<int64_t, items_per_thread, cub::WARP_LOAD_TRANSPOSE>;
   using Sort = cub::WarpMergeSort<scalar_t, items_per_thread, C10_WARP_SIZE, int64_t>;
   using StoreKeys = cub::WarpStore<scalar_t, items_per_thread, cub::WARP_STORE_TRANSPOSE>;
   using StoreIndices = cub::WarpStore<int64_t, items_per_thread, cub::WARP_STORE_TRANSPOSE>;
 
   __shared__ union {
     typename LoadKeys::TempStorage load_keys;
-    typename LoadIndices::TempStorage load_indices;
     typename Sort::TempStorage sort;
     typename StoreKeys::TempStorage store_keys;
     typename StoreIndices::TempStorage store_indices;

--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -31,7 +31,7 @@ namespace sbtopk { // single_block_topk
 template <typename T>
 struct AddOp {
   __device__ __forceinline__ T operator()(T const &lhs, T const &rhs) {
-    return lhs + rhs;
+    return (lhs + rhs);
   }
 };
 

--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -354,7 +354,7 @@ void launch(
 
   // We have specialized launches for different sizes, as sort_size affects
   // shared memory, registers per thread and occupancy. We can use 'LAUNCH_KERNEL(512, false);'
-  // however, that results in lower performance. 
+  // however, that results in lower performance.
   if (largest) {
     if (inputSliceSize <= 64) {
       LAUNCH_KERNEL(64, true);
@@ -805,7 +805,7 @@ __global__ void computeBlockwiseWithinKCounts(
     warp_counts[warp] = count;
   }
   __syncthreads();
-  
+
   CUDA_KERNEL_ASSERT(RADIX_DIGITS < C10_WARP_SIZE * C10_WARP_SIZE);
   if (warp != 0) {
     return;


### PR DESCRIPTION
- We noticed regressions in topK performance, and wanted to improve the performance. We noticed that the small cases had a lot of redundant kernel launches, and wrote a dedicated kernel for the small path, observing these perf boosts(lower the better). Although `sort.cu` presents a similar implementation as seen in warptopk, the warptopk approach is faster because:
  - WarpTopK runs entirely at warp scope: it loads the slice into registers/shared, uses WarpMergeSort, and writes only the first k values/indices to the outputs.
  - No temporary memory allocations are made, one load of slice_size and one write of k, instead of full-slice writes plus narrow/copy. 
  - We use warptopk utility defined under `HAS_WARP_MERGE_SORT()`, to load data, however, we do not use `LoadIndices` construct to load the indices, as the indices do not need to be loaded from memory here, as they are just sequential integers `[0, 1, 2...]`. This is much faster than allocating and loading from shared memory. 
 

<img width="1259" height="637" alt="perf_small" src="https://github.com/user-attachments/assets/a2967ed9-7467-4fcb-a05d-da022b2e4604" />

- We also noticed that the bigger cases were taking the sort path on ROCm, regardless of the k-value, often resulting in unnecessary work for a small subset of topk values with float32. We have attempted to tune this heuristic better by adding datatype aware dispatch, as the optimal strategy differs for different datatypes, float32 has 4 radix passes, while bfloat16/float16 has 2 radix passes, making the sort path optimal. 

<img width="1256" height="619" alt="perf_1M" src="https://github.com/user-attachments/assets/61c43071-2a71-41c7-9828-590ff1f6441a" />

- We also noticed opportunity to fuse some work in the gathertopk kernel, for the 2D case, allowing us a better speedup for the same. For the ROCm path, we have:
    - Fused Histogram Cumsum Computation into computeBlockwiseWithinKCounts using inline block scan, eliminating 1 kernel launch per radix iteration. Eliminates 1 kernel launch per radix iteration (4 launches for float32)
    - Fused kthCounts Computation into computeBlockwiseWithinKCounts at final pass. Eliminates 1 additional kernel launch.
    - Fused Prefix Sum in gatherTopK, inline prefix computation in gatherTopK itself. Eliminates 2 CUB scan operations, reduces memory traffic.
 - We have also done some general performance tuning:
    - MAX_ITEMS_PER_THREAD: Increased to `96` for ROCm 
         - Reduces blocks_per_slice for large arrays (1M: 245→82 blocks with ipt=48)
        - Critical for fused kernels where loop iteration count = blocks_per_slice
    - Loop unrolling: 4x unroll in accumulation loops for better ILP
    - Memory access optimization: Strided patterns for better coalescing(we tried to optimize by using `counts` itself instead of `count_ptr`, however, the compiler can optimize `const` better, and using `counts` regressed perf by ` ~8%`.
   
<img width="1259" height="638" alt="perf_2D" src="https://github.com/user-attachments/assets/38c97d70-6229-45c1-8315-ca84ef02b313" />


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @dllehr-amd