### PR TITLE
Fix KeyError: u0 by ensuring that integer scalar symbols are properly registered in expr_to_sym_proxy before being accessed

### DIFF
--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -213,6 +213,25 @@ class TestInductorDynamic(TestCase):
                 self.assertEqual(fn(x), fn_c(x))
                 self.assertEqual(fn(y), fn_c(y))
 
+    def test_division_with_python_scalars(self):
+        """Test that division between Python scalars doesn't cause KeyError: u0"""
+        torch._dynamo.config.capture_scalar_outputs = True
+        torch._dynamo.config.capture_dynamic_output_shape_ops = True
+
+        def fn(arg_0):
+            var_1 = -6 * arg_0
+            var_2 = torch.full((), 1, dtype=torch.int64).item()
+            result = var_1 / var_2
+            return result
+
+        arg = 5
+
+        result_eager = fn(arg)
+        compiled_fn = torch.compile(fn, fullgraph=True, dynamic=True)
+        result_compiled = compiled_fn(arg)
+
+        self.assertEqual(result_eager, result_compiled)
+
     def test_arange_dynamic(self, device):
         def fn(a):
             batch_size = a.numel()


### PR DESCRIPTION

Fixes #164685

Fix `KeyError: u0` by ensuring that integer scalar symbols are properly registered in `expr_to_sym_proxy` before being accessed though they were skipped in iteration for not being float. The integer scalar are maintained in different map. Metaproxy conversion happens when they are needed while recursion (or backtracking) of all dependents . 

In integer scalar map MetaProxy is not directly added as this will create extra overhead. 


cc @ezyang @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben