### PR TITLE
[CUDA][Mempool] Sort mempool registrations via allocation-time counter

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -2508,7 +2508,7 @@ class DeviceCachingAllocator {
       while (block != nullptr && block->mapped) {
         segment_info.blocks.emplace_back();
         BlockInfo& block_info = segment_info.blocks.back();
-        
+
         block_info.size = block->size;
         block_info.requested_size = block->requested_size;
         block_info.allocated = block->allocated;

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -132,6 +132,9 @@ namespace Native {
  *                  notifyCaptureDestroy.
  */
 
+// counter to track order for Mempool Registration
+thread_local int32_t registration_counter_global = -1;
+
 static char SHAREABLE_HANDLE_VERSION = 2;
 enum ShareableHandleType : char {
   SHAREABLE_CUDA_MALLOC = 'c',
@@ -187,6 +190,7 @@ struct Block {
   c10::DeviceIndex device; // gpu
   cudaStream_t stream; // allocation stream
   stream_set stream_uses; // streams on which the block was used
+  int32_t registration_counter{-1};
   size_t size; // block size in bytes
   size_t requested_size; // memory originally requested
   BlockPool* pool{nullptr}; // owning memory pool
@@ -221,11 +225,17 @@ struct Block {
         size(size),
         requested_size(0),
         pool(pool),
-        ptr(ptr) {}
+        ptr(ptr) {
+          registration_counter_global++;
+          registration_counter = registration_counter_global;	  
+	}
 
   // constructor for search key
   Block(c10::DeviceIndex device, cudaStream_t stream, size_t size)
-      : device(device), stream(stream), size(size), requested_size(0) {}
+      : device(device), stream(stream), size(size), requested_size(0) {
+        registration_counter_global++;
+        registration_counter = registration_counter_global;	  
+      }
 
   size_t gc_count() {
     TORCH_INTERNAL_ASSERT(pool);
@@ -2494,12 +2504,13 @@ class DeviceCachingAllocator {
           id == mempool_id) {
         segment_info.owner_private_pool_id = id;
       }
+      segment_info.registration_counter = head_block->registration_counter;
 
       const Block* block = head_block;
       while (block != nullptr && block->mapped) {
         segment_info.blocks.emplace_back();
         BlockInfo& block_info = segment_info.blocks.back();
-
+        
         block_info.size = block->size;
         block_info.requested_size = block->requested_size;
         block_info.allocated = block->allocated;

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -233,8 +233,7 @@ struct Block {
   // constructor for search key
   Block(c10::DeviceIndex device, cudaStream_t stream, size_t size)
       : device(device), stream(stream), size(size), requested_size(0) {
-        registration_counter_global++;
-        registration_counter = registration_counter_global;	  
+        registration_counter = ++registration_counter_global;
       }
 
   size_t gc_count() {

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -226,8 +226,7 @@ struct Block {
         requested_size(0),
         pool(pool),
         ptr(ptr) {
-          registration_counter_global++;
-          registration_counter = registration_counter_global;	  
+          registration_counter = ++registration_counter_global;
 	}
 
   // constructor for search key

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -226,14 +226,14 @@ struct Block {
         requested_size(0),
         pool(pool),
         ptr(ptr) {
-          registration_counter = ++registration_counter_global;
-	}
+    registration_counter = ++registration_counter_global;
+  }
 
   // constructor for search key
   Block(c10::DeviceIndex device, cudaStream_t stream, size_t size)
       : device(device), stream(stream), size(size), requested_size(0) {
-        registration_counter = ++registration_counter_global;
-      }
+    registration_counter = ++registration_counter_global;
+  }
 
   size_t gc_count() {
     TORCH_INTERNAL_ASSERT(pool);

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -71,6 +71,7 @@ struct BlockInfo {
 // Struct containing info of a memory segment (i.e. one contiguous cudaMalloc).
 struct SegmentInfo {
   c10::DeviceIndex device = 0;
+  int32_t registration_counter = -1;
   size_t address = 0;
   size_t total_size = 0;
   size_t requested_size = 0; // unrounded, actually requested size

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1126,12 +1126,15 @@ void ProcessGroupNCCL::registerMemPool(at::cuda::MemPool* pool, bool symm) {
   // register future segments allocated in this pool (this call is idempotent).
   attachAllocatorHooks();
   auto snapshot = c10::cuda::CUDACachingAllocator::snapshot(pool->id());
-  std::sort(snapshot.segments.begin(), snapshot.segments.end(), [](const SegmentInfo &a, const SegmentInfo &b)
-  {
-      return a.registration_counter < b.registration_counter;
-  });
+  std::sort(
+      snapshot.segments.begin(),
+      snapshot.segments.end(),
+      [](const SegmentInfo &a, const SegmentInfo &b) {
+        return a.registration_counter < b.registration_counter;
+      });
   for (const auto& segmentInfo : snapshot.segments) {
-    TORCH_INTERNAL_ASSERT(segmentInfo.registration_counter >= 0,
+    TORCH_INTERNAL_ASSERT(
+        segmentInfo.registration_counter >= 0,
         "SegmentInfo has uninitialized registration counter");
     TORCH_INTERNAL_ASSERT(
         segmentInfo.device == pool->device(),

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1104,8 +1104,8 @@ ErrorType ProcessGroupNCCL::getError() {
   return error_;
 }
 
-using c10::cuda::CUDACachingAllocator::SegmentInfo;
 void ProcessGroupNCCL::registerMemPool(at::cuda::MemPool* pool, bool symm) {
+  using c10::cuda::CUDACachingAllocator::SegmentInfo;
   const auto key = std::to_string(pool->device());
   LOG(INFO) << logPrefix()
             << "Performing NCCL user buffer registration for all buffers in "

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1129,7 +1129,7 @@ void ProcessGroupNCCL::registerMemPool(at::cuda::MemPool* pool, bool symm) {
   std::sort(
       snapshot.segments.begin(),
       snapshot.segments.end(),
-      [](const SegmentInfo &a, const SegmentInfo &b) {
+      [](const SegmentInfo& a, const SegmentInfo& b) {
         return a.registration_counter < b.registration_counter;
       });
   for (const auto& segmentInfo : snapshot.segments) {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1128,9 +1128,11 @@ void ProcessGroupNCCL::registerMemPool(at::cuda::MemPool* pool, bool symm) {
   auto snapshot = c10::cuda::CUDACachingAllocator::snapshot(pool->id());
   std::sort(snapshot.segments.begin(), snapshot.segments.end(), [](const SegmentInfo &a, const SegmentInfo &b)
   {
-      return a.address < b.address;
+      return a.registration_counter < b.registration_counter;
   });
   for (const auto& segmentInfo : snapshot.segments) {
+    TORCH_INTERNAL_ASSERT(segmentInfo.registration_counter >= 0,
+        "SegmentInfo has uninitialized registration counter");
     TORCH_INTERNAL_ASSERT(
         segmentInfo.device == pool->device(),
         "Mismatch between CUDA memory segment device and pool's device");


### PR DESCRIPTION
Otherwise we've observed NCCL being unhappy with the ordering of registrations being different e.g., across nodes.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci