### PR TITLE
[WIP][DTensor] demo unbacked matmuls

### DIFF
--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -208,7 +208,12 @@ def all_gather_tensor(
         # and then chunk + cat avoid us going through ACT dispatching logic again
         if isinstance(res, AsyncCollectiveTensor):
             res = res.wait()  # type: ignore[attr-defined]
-        res = torch.cat(torch.chunk(res, group_size, dim=0), dim=gather_dim)
+
+        chunk_size = res.size(0) // group_size
+        chunks = [
+            torch.narrow(res, 0, i * chunk_size, chunk_size) for i in range(group_size)
+        ]
+        res = torch.cat(chunks, dim=gather_dim)
     return res
 
 
@@ -275,7 +280,11 @@ def reduce_scatter_tensor(
             f"input dimension 0 ({self.size(0)} must be a multiple of group_size {group_size})"
         )
     if scatter_dim != 0:
-        tensor_list = torch.chunk(self, group_size, dim=scatter_dim)
+        chunk_size = self.size(scatter_dim) // group_size
+        tensor_list = [
+            torch.narrow(self, scatter_dim, i * chunk_size, chunk_size)
+            for i in range(group_size)
+        ]
         self = torch.cat(tensor_list)
 
     tensor = torch.ops._c10d_functional.reduce_scatter_tensor(

--- a/torch/distributed/tensor/_collective_utils.py
+++ b/torch/distributed/tensor/_collective_utils.py
@@ -173,7 +173,9 @@ def mesh_broadcast(
 
 @maybe_run_for_local_tensor
 def pad_tensor(tensor: torch.Tensor, pad_dim: int, pad_size: int) -> torch.Tensor:
-    if pad_size == 0:
+    from torch.fx.experimental.symbolic_shapes import guard_or_false
+
+    if guard_or_false(pad_size == 0):
         return tensor
     pad = [0, 0] * (tensor.ndim - pad_dim)
     pad[-1] = pad_size
@@ -182,7 +184,9 @@ def pad_tensor(tensor: torch.Tensor, pad_dim: int, pad_size: int) -> torch.Tenso
 
 @maybe_run_for_local_tensor
 def unpad_tensor(tensor: torch.Tensor, pad_dim: int, pad_size: int) -> torch.Tensor:
-    if pad_size == 0:
+    from torch.fx.experimental.symbolic_shapes import guard_or_false
+
+    if guard_or_false(pad_size == 0):
         return tensor
     return tensor.narrow(
         pad_dim,

--- a/torch/distributed/tensor/_ops/utils.py
+++ b/torch/distributed/tensor/_ops/utils.py
@@ -160,6 +160,8 @@ def prod(xs: Iterable[int]) -> int:
 
 def is_tensor_shardable(shape: Sequence[int], spec: DTensorSpec) -> bool:
     """Check if the shape is shardable according to the spec."""
+    from torch.fx.experimental.symbolic_shapes import guard_or_false
+
     # number of shards in each tensor dimension
     shards_map = [1] * len(shape)
     for i, placement in enumerate(spec.placements):
@@ -172,7 +174,7 @@ def is_tensor_shardable(shape: Sequence[int], spec: DTensorSpec) -> bool:
     for i, dim_size in enumerate(shape):
         # TODO: maybe we should determine is_shardable based on
         #       whether it's evenly sharded or not
-        if shards_map[i] > 1 and dim_size < shards_map[i]:
+        if shards_map[i] > 1 and guard_or_false(dim_size < shards_map[i]):
             return False
 
     return True

--- a/torch/utils/_sympy/reference.py
+++ b/torch/utils/_sympy/reference.py
@@ -301,6 +301,10 @@ class PythonReferenceAnalysis(ReferenceAnalysis):
         return a / b
 
     @staticmethod
+    def int_truediv(a, b):
+        return a / b
+
+    @staticmethod
     def pow(a, b):
         return a**b
 


### PR DESCRIPTION
With this script that goes over all placements of a 2d matmul on a 2d device mesh + mark_unbacked-s the DTensors:
```python
import itertools
import torch
import torch.distributed as dist
from collections import Counter
from torch.testing._internal.distributed.fake_pg import FakeStore
from torch.distributed.device_mesh import init_device_mesh
from torch.distributed.tensor import DTensor, Replicate, Shard, Partial
from torch.distributed.tensor._ops._einsum_strategy import gen_einsum_strategies
from torch.utils._debug_mode import DebugMode

# Setup
if not dist.is_initialized():
    dist.init_process_group("fake", store=FakeStore(), rank=0, world_size=4)


mesh = init_device_mesh("cuda", (2, 2))
einsum_eq = "mk,kn->mn"
full_shape = [16, 16, 16, 16]

placement_map = {
    "r": lambda: Replicate(),
    "s0": lambda: Shard(0),
    "s1": lambda: Shard(1),
    "p": lambda: Partial(),
}
placements = ["r", "s0", "s1", "p"]

n_tests, n_pass, errs, passing = 0, 0, Counter(), []
for full_placement in itertools.product(*[placements for _ in range(4)]):
    torch._dynamo.reset()

    full_placement = list(full_placement)
    shape = list(full_shape)
    for i, placement in enumerate(full_placement):
        if placement.startswith("s"):
            td = int(placement[1:])
            j = int(2 * (i // 2) + td)
            shape[j] = int(shape[j] / mesh.shape[i % mesh.ndim])

    x = torch.randn(*shape[:mesh.ndim])
    y = torch.randn(*shape[mesh.ndim:])
    x_dtensor = DTensor.from_local(x, mesh, placements=[placement_map[p]() for p in full_placement[:mesh.ndim]])
    y_dtensor = DTensor.from_local(y, mesh, placements=[placement_map[p]() for p in full_placement[mesh.ndim:]])

    print(full_placement, x_dtensor.shape, y_dtensor.shape)
    with DebugMode() as debug_mode:
        out = x_dtensor @ y_dtensor
        print(debug_mode.debug_string() + "\n\n")

    # compiled run
    @torch.compile(backend="eager")
    def fn(x, y):
        return x @ y

    for t, i in itertools.product([x_dtensor, y_dtensor], [0, 1]):
        torch._dynamo.decorators.mark_unbacked(t, i)

    try:
        fn(x_dtensor, y_dtensor)
    except Exception as e:
        print(f"failed with {e}")
        errs[str(e)] += 1
    else:
        n_pass += 1
        passing.append(full_placement)
    finally:
        n_tests += 1

print(f"Passed: {n_pass}/{n_tests}")

```

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @ezyang @EikanWang @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @zhuhaozhe @blzheng @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @chenyang78