### PR TITLE
Add huggingface storage reader for MXFP4 quantized GPT-OSS checkpoint

### DIFF
--- a/torch/distributed/checkpoint/quantized_hf_storage.py
+++ b/torch/distributed/checkpoint/quantized_hf_storage.py
@@ -1,12 +1,14 @@
 # mypy: allow-untyped-defs
 import json
 import logging
+import math
 from pathlib import Path
 from typing import Any
 
 import torch
+from torch._subclasses.fake_tensor import TensorMetadata
 from torch.distributed.checkpoint._hf_utils import _metadata_fn
-from torch.distributed.checkpoint.metadata import TensorStorageMetadata
+from torch.distributed.checkpoint.metadata import MetadataIndex, TensorStorageMetadata
 from torch.distributed.checkpoint.planner import LoadPlanner, ReadItem
 
 from .hf_storage import HuggingFaceStorageReader
@@ -56,13 +58,27 @@ class QuantizedHuggingFaceStorageReader(HuggingFaceStorageReader):
 
     def read_metadata(self) -> Any:
         metadata = super().read_metadata()
-        # Build a cache of FQN -> full tensor shape for faster lookups.
-        for fqn, tensor_metadata in metadata.state_dict_metadata.items():
-            # Only process TensorStorageMetadata which has size attribute
-            if isinstance(tensor_metadata, TensorStorageMetadata):
-                self._tensor_full_shapes[fqn] = tensor_metadata.size
 
+        # Load quantization metadata first.
         self._load_quantization_metadata()
+
+        # Build a cache of FQN -> full tensor shape, correcting for quantized tensors.
+        for fqn, tensor_metadata in metadata.state_dict_metadata.items():
+            # Only process TensorStorageMetadata which has size attribute.
+            if isinstance(tensor_metadata, TensorStorageMetadata):
+                # Check if this is a MXFP4 quantized tensor that needs shape correction.
+                if fqn.endswith('_blocks'):
+                    # Save the quantized tensor shapes for lookup when dequantization.
+                    self._tensor_full_shapes[fqn + '_quantized'] = tensor_metadata.size
+                    *prefix_shape, G, B = tensor_metadata.size
+                    dequantized_size = torch.Size([*prefix_shape, G * B * 2])
+
+                    # Update the metadata with the size after dequantization.
+                    # Metadata used by planner to slice state dict.
+                    tensor_metadata.size = dequantized_size
+                    self._tensor_full_shapes[fqn] = dequantized_size
+                else:
+                    self._tensor_full_shapes[fqn] = tensor_metadata.size
 
         return metadata
 
@@ -79,7 +95,7 @@ class QuantizedHuggingFaceStorageReader(HuggingFaceStorageReader):
 
     def _build_weight_scale_mapping(self, weight_map: dict[str, str]):
         """Analyze and build weight-scale tensor pairs from weight mapping."""
-        # Store the complete weight map for file location lookups
+        # Store the complete weight map for file location lookups.
         self._weight_map = weight_map
 
         for tensor_name in weight_map:
@@ -87,6 +103,11 @@ class QuantizedHuggingFaceStorageReader(HuggingFaceStorageReader):
                 weight_name = tensor_name.replace(".weight_scale_inv", ".weight")
                 if weight_name in weight_map:
                     self._weight_scale_mapping[weight_name] = tensor_name
+            # Handle MXFP4 format: _blocks and _scales.
+            elif tensor_name.endswith("_scales"):
+                blocks_name = tensor_name.replace("_scales", "_blocks")
+                if blocks_name in weight_map:
+                    self._weight_scale_mapping[blocks_name] = tensor_name
 
     def _process_read_request(
         self, f: Any, req: ReadItem, planner: LoadPlanner
@@ -148,6 +169,92 @@ class QuantizedHuggingFaceStorageReader(HuggingFaceStorageReader):
             row_slice,
             col_slice,
         )
+
+    def _dequantize_tensor_mxfp4(
+        self,
+        blocks: torch.Tensor,
+        scales: torch.Tensor,
+        req: ReadItem,
+        group_start: int,
+        offset_in_first_group: int,
+    ) -> torch.Tensor:
+        """
+        Dequantize a 4D tensor using MXFP4 format.
+        Adapted from openai's implementation:
+        https://github.com/openai/gpt-oss/blob/8890e95919f975a490fc0ba09ffb10890ec7319d/gpt_oss/torch/weights.py#L68
+
+        Args:
+            blocks: Sliced quantized weight tensor of shape [a_slice, b_slice, groups_slice, B] in uint8
+            scales: FULL scale tensor of shape [a, b, c] in uint8 (will be converted to exponents)
+            req: Read request containing slice information
+            group_start: The starting group index in the checkpoint
+            offset_in_first_group: Offset in values within the first group
+
+        Returns:
+            Dequantized tensor matching the requested shape
+        """
+        # FP4 lookup table
+        FP4_VALUES = [
+            +0.0, +0.5, +1.0, +1.5, +2.0, +3.0, +4.0, +6.0,
+            -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0,
+        ]
+
+        # blocks: [a_slice, b_slice, groups_slice, B] uint8.
+        # Read slightly more groups than needed, and slice at the end.
+
+        # Slice the scales to match the blocks dimensions.
+        # [a_full, b_full, c_full] -> [a_slice, b_slice, groups_slice]
+        dim0_start = req.storage_offsets[0]
+        dim0_end = dim0_start + req.lengths[0]
+        dim1_start = req.storage_offsets[1]
+        dim1_end = dim1_start + req.lengths[1]
+        num_groups = blocks.shape[2]
+        scales = scales[dim0_start:dim0_end, dim1_start:dim1_end, group_start:group_start+num_groups]
+
+        scales = scales.to(torch.int32) - 127
+
+        assert blocks.shape[:-1] == scales.shape, (
+            f"{blocks.shape=} does not match {scales.shape=}"
+        )
+
+        lut = torch.tensor(FP4_VALUES, dtype=self.target_dtype, device=blocks.device)
+
+        *prefix_shape, G, B = blocks.shape
+        rows_total = math.prod(prefix_shape) * G
+
+        blocks = blocks.reshape(rows_total, B)
+        scales = scales.reshape(rows_total, 1)
+
+        out = torch.empty(rows_total, B * 2, dtype=self.target_dtype, device=blocks.device)
+
+        rows_per_chunk = 16384 * 512
+
+        for r0 in range(0, rows_total, rows_per_chunk):
+            r1 = min(r0 + rows_per_chunk, rows_total)
+
+            blk = blocks[r0:r1]
+            exp = scales[r0:r1]
+
+            # nibble indices -> int64
+            idx_lo = (blk & 0x0F).to(torch.long)
+            idx_hi = (blk >> 4).to(torch.long)
+
+            sub = out[r0:r1]
+            sub[:, 0::2] = lut[idx_lo]
+            sub[:, 1::2] = lut[idx_hi]
+
+            torch.ldexp(sub, exp, out=sub)
+
+            del idx_lo, idx_hi, blk, exp
+
+        result = out.reshape(*prefix_shape, G, B * 2).view(*prefix_shape, G * B * 2)
+
+        # Slice the last dimension to match the requested range.
+        if offset_in_first_group > 0 or result.shape[-1] > req.lengths[2]:
+            end_offset = offset_in_first_group + req.lengths[2]
+            result = result[..., offset_in_first_group:end_offset]
+
+        return result
 
     def _dequantize_tensor(
         self,
@@ -245,7 +352,7 @@ class QuantizedHuggingFaceStorageReader(HuggingFaceStorageReader):
             False otherwise
         """
         # Skip scale tensors themselves
-        if tensor_fqn.endswith(".weight_scale_inv"):
+        if tensor_fqn.endswith(".weight_scale_inv") or tensor_fqn.endswith("_scales"):
             return False
 
         # Check if this weight tensor has a corresponding scale tensor
@@ -271,12 +378,50 @@ class QuantizedHuggingFaceStorageReader(HuggingFaceStorageReader):
         scale_fqn = self._weight_scale_mapping[tensor_fqn]
 
         try:
-            # Load the sliced quantized weight
-            weight_slices = tuple(
-                slice(offset, offset + length)
-                for offset, length in zip(req.storage_offsets, req.lengths)
-            )
-            quantized_tensor = safetensor_file.get_slice(tensor_fqn)[weight_slices]
+            if tensor_fqn.endswith('_blocks'):
+                # Full tensor is a 4D MXFP4 quantized tensor: [..., G, B].
+                # Each group G produces B * 2 dequantized values.
+                # Checkpoint [..., G, B] -> dequantized [..., G*B*2].
+
+                # The planner gives 3D requests based on the dequantized shape.
+                # Need to figure out which groups (dimension 2 in checkpoint) to read.
+
+                # Use the quantized checkpoint shape to get the correct B.
+                *prefix_shape, B = self._tensor_full_shapes[tensor_fqn + '_quantized']
+                values_per_group = B * 2  # Each byte has 2 nibbles (4-bit values).
+
+                # Calculate which groups we need based on the requested range in dim 2.
+                # Ensure the reequest is in 3D.
+                assert len(req.storage_offsets) == 3
+
+                # Positions in dequantized space.
+                dim2_start_deq = req.storage_offsets[2]
+                dim2_length_deq = req.lengths[2]
+                dim2_end_deq = dim2_start_deq + dim2_length_deq
+
+                # Convert to group indices.
+                group_start = dim2_start_deq // values_per_group
+                group_end = (dim2_end_deq + values_per_group - 1) // values_per_group
+
+                # Read only the necessary groups from checkpoint.
+                weight_slices_4d = (
+                    slice(req.storage_offsets[0], req.storage_offsets[0] + req.lengths[0]),
+                    slice(req.storage_offsets[1], req.storage_offsets[1] + req.lengths[1]),
+                    slice(group_start, group_end),
+                    slice(None),  # Read all B values for each group.
+                )
+                quantized_tensor = safetensor_file.get_slice(tensor_fqn)[weight_slices_4d]
+
+                # Also track the offset within the first group
+                offset_in_first_group = dim2_start_deq - (group_start * values_per_group)
+            else:
+                # 2D quantized tensor, use 2d block partition.
+                weight_slices = tuple(
+                    slice(offset, offset + length)
+                    for offset, length in zip(req.storage_offsets, req.lengths)
+                )
+                quantized_tensor = safetensor_file.get_slice(tensor_fqn)[weight_slices]
+                offset_in_first_group = 0
 
             # Load the corresponding scale inverse tensor (full tensor)
             scale_file_name = self._weight_map.get(scale_fqn)
@@ -304,16 +449,27 @@ class QuantizedHuggingFaceStorageReader(HuggingFaceStorageReader):
             if full_tensor_shape is None:
                 raise ValueError(f"Could not find full tensor shape for {tensor_fqn}")
 
-            # Get slice to block mapping
-            slice_info = self._get_slice_to_block_mapping(req)
-
-            # Perform dequantization with proper block alignment
-            dequantized_tensor = self._dequantize_tensor(
-                weight=quantized_tensor,
-                scale_inv=scale_inv,
-                full_tensor_shape=full_tensor_shape,
-                slice_info=slice_info,
-            )
+            # Determine which dequantization function to use.
+            if len(full_tensor_shape) == 2:
+                # 2D block-wise quantization, e.g., used in deepseek v3.1
+                slice_info = self._get_slice_to_block_mapping(req)
+                dequantized_tensor = self._dequantize_tensor(
+                    weight=quantized_tensor,
+                    scale_inv=scale_inv,
+                    full_tensor_shape=full_tensor_shape,
+                    slice_info=slice_info,
+                )
+            elif tensor_fqn.endswith("_blocks"):
+                # 4D with blocks along dimension 2, used in MXFP4, e.g. gpt-oss
+                dequantized_tensor = self._dequantize_tensor_mxfp4(
+                    blocks=quantized_tensor,
+                    scales=scale_inv,
+                    req=req,
+                    group_start=group_start,
+                    offset_in_first_group=offset_in_first_group,
+                )
+            else:
+                raise ValueError(f"Unsupported quantization types")
 
             return dequantized_tensor
 


### PR DESCRIPTION
As titled, the updated `QuantizedHuggingFaceStorageReader` can be used to load MXFP4 quantized GPT-OSS HF checkpoint. For example, this feature enables TorchTitan to load GPT-OSS models with de-quantization happening under the hood.  

1. Test 1. We use `dcp.load(hf_state_dict, storage_reader=QuantizedHuggingFaceStorageReader(path=input_dir))` to load from GPT-OSS HF checkpoint, and map the `hf_state_dict` back to TorchTitan state dict. We build one test input, and compare two outputs: 1. Using `transformer` library to load GPT-OSS HF checkpoint and run inference on the test input; 2. We use the converted TorchTitan model to run inference on the test input. We compare the outputs by comparing the KL divergence of two output probability distributions. The result shows two models are very similar. <img width="1191" height="191" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/bb6a75e9-3dd7-43fa-847e-3f5f4fb5fd93" />

2. Test 2. With TorchTitan, we load the model directly from quantized GPT-OSS HF checkpoint, and do a test training. 
    <img width="1198" height="408" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/49ab42ff-0115-4e79-b069-c556e0dd23f6" />




cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci