### PR TITLE
[dynamo] [3.14] Update broken numpy test

### DIFF
--- a/test/torch_np/numpy_tests/lib/test_histograms.py
+++ b/test/torch_np/numpy_tests/lib/test_histograms.py
@@ -310,7 +310,7 @@ class TestHistogram(TestCase):
         )
 
         # these should not crash
-        np.histogram([np.array(0.5) for i in range(10)] + [0.500000000000001])
+        np.histogram([np.array(0.5) for i in range(10)] + [0.500000000000002])
         np.histogram([np.array(0.5) for i in range(10)] + [0.5])
 
     @xpassIfTorchDynamo_np  # (reason="bins='auto'")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #167681
* #167619

This is related to upgrading numpy versions, not 3.14 specifically.  See https://github.com/numpy/numpy/pull/27148