### PR TITLE
Fix NestedTensor min/max operations for integer dtypes.

### DIFF
--- a/aten/src/ATen/native/nested/NestedTensorTransformerFunctions.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorTransformerFunctions.cpp
@@ -6,6 +6,8 @@
 #include <ATen/native/nested/NestedTensorUtils.h>
 
 #include <c10/util/Exception.h>
+#include <cmath>
+#include <limits>
 #include <optional>
 #include <string_view>
 
@@ -270,7 +272,18 @@ Tensor _jagged_to_padded_dense_forward_cpu(
   padded_shape.push_back(batch_size);
   padded_shape.push_back(max_length);
   padded_shape.insert(padded_shape.end(), values_shape.begin() + 1, values_shape.end());
-  Tensor padded = values.new_full(padded_shape, padding_value);
+
+  // We must clamp infinite sentinels to dtype min/max and use the typed value
+  // directly to avoid double->int overflow (e.g., int64_max as double overflows).
+  Tensor padded;
+  if (std::isinf(padding_value) && !values.is_floating_point()) {
+    AT_DISPATCH_INTEGRAL_TYPES(values.scalar_type(), "_jagged_to_padded_dense_forward_cpu", [&] {
+      scalar_t fill_value = _get_padding_value<scalar_t>(padding_value, values.is_floating_point());
+      padded = values.new_full(padded_shape, fill_value);
+    });
+  } else {
+    padded = values.new_full(padded_shape, padding_value);
+  }
 
   // copy data to padded tensor
   for (auto i : c10::irange(batch_size)) {

--- a/aten/src/ATen/native/nested/NestedTensorTransformerFunctions.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorTransformerFunctions.cpp
@@ -276,15 +276,15 @@ Tensor _jagged_to_padded_dense_forward_cpu(
   // We must clamp infinite sentinels to dtype min/max and use the typed value
   // directly to avoid double->int overflow (e.g., int64_max as double overflows).
   Tensor padded;
-  AT_DISPATCH_ALL_TYPES_AND2(
-      at::ScalarType::Half,
-      at::ScalarType::BFloat16,
+  AT_DISPATCH_V2(
       values.scalar_type(),
       "_jagged_to_padded_dense_forward_cpu",
-      [&] {
+      AT_WRAP([&] {
         scalar_t fill_value = _get_padding_value<scalar_t>(padding_value, values.is_floating_point());
         padded = values.new_full(padded_shape, fill_value);
-      });
+      }),
+      AT_EXPAND(AT_ALL_TYPES),
+      kBool, kHalf, kBFloat16);
 
   // copy data to padded tensor
   for (auto i : c10::irange(batch_size)) {

--- a/aten/src/ATen/native/nested/NestedTensorUtils.h
+++ b/aten/src/ATen/native/nested/NestedTensorUtils.h
@@ -22,6 +22,8 @@
 #include <ATen/ops/tensor.h>
 #endif
 
+#include <cmath>
+#include <limits>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -61,6 +63,17 @@ inline at::Tensor wrap_buffer(
 
 inline at::Tensor get_buffer(const at::Tensor& tensor) {
   return get_nested_tensor_impl(tensor)->get_buffer();
+}
+
+// Helper to clamp infinite padding sentinels to dtype min/max for integral types
+template <typename scalar_t>
+inline scalar_t _get_padding_value(double padding_value, bool is_floating_point) {
+  if (std::isinf(padding_value) && !is_floating_point) {
+    return padding_value > 0
+      ? std::numeric_limits<scalar_t>::max()
+      : std::numeric_limits<scalar_t>::lowest();
+  }
+  return static_cast<scalar_t>(padding_value);
 }
 
 /**

--- a/aten/src/ATen/native/nested/NestedTensorUtils.h
+++ b/aten/src/ATen/native/nested/NestedTensorUtils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/Dispatch.h>
+#include <ATen/Dispatch_v2.h>
 #include <ATen/NestedTensorImpl.h>
 #include <ATen/Parallel.h>
 #include <ATen/core/Tensor.h>

--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -28,23 +28,6 @@ def _get_padding_value(dtype, padding_type):
         return float("inf") if padding_type == "max" else float("-inf")
 
 
-def _get_padding_value(dtype, padding_type):
-    if dtype.is_floating_point:
-        return (
-            torch.finfo(dtype).max if padding_type == "max" else torch.finfo(dtype).min
-        )
-    elif dtype == torch.int64:
-        # Largest int64 value exactly representable in float64 (IEEE 754 double precision).
-        # Avoids overflow when padding_value is passed as double to _jagged_to_padded_dense_forward.
-        int64_safe_max = (1 << 53) - 1
-        int64_safe_min = -int64_safe_max
-        return int64_safe_max if padding_type == "max" else int64_safe_min
-    else:
-        return (
-            torch.iinfo(dtype).max if padding_type == "max" else torch.iinfo(dtype).min
-        )
-
-
 def _outer_to_inner_dim(ndim, dim, ragged_dim, canonicalize=False):
     from torch._prims_common import canonicalize_dims
 

--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -16,6 +16,11 @@ __all__: list[Any] = []
 
 JAGGED_OPS_TABLE: Dict[Any, Any] = {}
 
+# Largest int64 value exactly representable in float64 (IEEE 754 double precision).
+# Avoids overflow when padding_value is passed as double to _jagged_to_padded_dense_forward.
+_INT64_SAFE_MAX_FLOAT64 = (1 << 53) - 1
+_INT64_SAFE_MIN_FLOAT64 = -_INT64_SAFE_MAX_FLOAT64
+
 
 def _get_padding_value(dtype, padding_type):
     if dtype.is_floating_point:

--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -22,16 +22,10 @@ def _get_padding_value(dtype, padding_type):
         return (
             torch.finfo(dtype).max if padding_type == "max" else torch.finfo(dtype).min
         )
-    elif dtype == torch.int64:
-        # Largest int64 value exactly representable in float64 (IEEE 754 double precision).
-        # Avoids overflow when padding_value is passed as double to _jagged_to_padded_dense_forward.
-        int64_safe_max = (1 << 53) - 1
-        int64_safe_min = -int64_safe_max
-        return int64_safe_max if padding_type == "max" else int64_safe_min
     else:
-        return (
-            torch.iinfo(dtype).max if padding_type == "max" else torch.iinfo(dtype).min
-        )
+        # For integer dtypes, use infinity sentinels which the C++ implementation
+        # clamps to dtype min/max, avoiding precision loss through double.
+        return float("inf") if padding_type == "max" else float("-inf")
 
 
 def _get_padding_value(dtype, padding_type):

--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -16,10 +16,22 @@ __all__: list[Any] = []
 
 JAGGED_OPS_TABLE: Dict[Any, Any] = {}
 
-# Largest int64 value exactly representable in float64 (IEEE 754 double precision).
-# Avoids overflow when padding_value is passed as double to _jagged_to_padded_dense_forward.
-_INT64_SAFE_MAX_FLOAT64 = (1 << 53) - 1
-_INT64_SAFE_MIN_FLOAT64 = -_INT64_SAFE_MAX_FLOAT64
+
+def _get_padding_value(dtype, padding_type):
+    if dtype.is_floating_point:
+        return (
+            torch.finfo(dtype).max if padding_type == "max" else torch.finfo(dtype).min
+        )
+    elif dtype == torch.int64:
+        # Largest int64 value exactly representable in float64 (IEEE 754 double precision).
+        # Avoids overflow when padding_value is passed as double to _jagged_to_padded_dense_forward.
+        int64_safe_max = (1 << 53) - 1
+        int64_safe_min = -int64_safe_max
+        return int64_safe_max if padding_type == "max" else int64_safe_min
+    else:
+        return (
+            torch.iinfo(dtype).max if padding_type == "max" else torch.iinfo(dtype).min
+        )
 
 
 def _get_padding_value(dtype, padding_type):


### PR DESCRIPTION
Fixes: https://github.com/pytorch/pytorch/issues/162049

  ### Summary
NestedTensor `max_dim` and `min_dim` functions currently use finite padding sentinels (`(1 << 53) - 1`) which could possibly give wrong results for large int64 values outside that range.

 ### Testing
On main branch:

  ```bash
  python -m pytest test/test_nestedtensor.py -k "test_jagged_max_extreme_values or test_jagged_min_extreme_values" -v
  ```
  Output:
```
  test/test_nestedtensor.py::TestNestedTensorDeviceTypeCPU::test_jagged_max_extreme_values_cpu_int64 FAILED
  test/test_nestedtensor.py::TestNestedTensorDeviceTypeCPU::test_jagged_min_extreme_values_cpu_int64 FAILED
  test/test_nestedtensor.py::TestNestedTensorDeviceTypeCUDA::test_jagged_max_extreme_values_cuda_int64 FAILED
  test/test_nestedtensor.py::TestNestedTensorDeviceTypeCUDA::test_jagged_min_extreme_values_cuda_int64 FAILED
  AssertionError: Tensor-likes are not equal!
  Mismatched elements: 2 / 3 (66.7%)
  Greatest absolute difference: 1143914305352105983 at index (0,)
```

With this fix:
```bash
  python -m pytest test/test_nestedtensor.py -k "test_jagged_max_extreme_values or test_jagged_min_extreme_values" -v
 ```
  Output:
 ```
  test/test_nestedtensor.py::TestNestedTensorDeviceTypeCPU::test_jagged_max_extreme_values_cpu_int64 PASSED
  test/test_nestedtensor.py::TestNestedTensorDeviceTypeCPU::test_jagged_min_extreme_values_cpu_int64 PASSED
  test/test_nestedtensor.py::TestNestedTensorDeviceTypeCUDA::test_jagged_max_extreme_values_cuda_int64 PASSED
  test/test_nestedtensor.py::TestNestedTensorDeviceTypeCUDA::test_jagged_min_extreme_values_cuda_int64 PASSED
  4 passed
 ```