### PR TITLE
[DTensor] Fix silently skipping Partial related redistribution in backward

### DIFF
--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -4,6 +4,7 @@
 import contextlib
 import itertools
 import unittest
+from unittest.mock import patch
 
 import torch
 from torch.distributed._local_tensor import (
@@ -21,6 +22,7 @@ from torch.distributed.tensor import (
 )
 from torch.distributed.tensor._collective_utils import shard_dim_alltoall
 from torch.distributed.tensor._dtensor_spec import ShardOrderEntry
+from torch.distributed.tensor._redistribute import DTensorRedistributePlanner
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.placement_types import _StridedShard, MaskPartial
 from torch.testing._internal.common_utils import (
@@ -1062,6 +1064,110 @@ class DistributeWithDeviceOrderTest(DTensorTestBase):
             shard_order=(ShardOrderEntry(tensor_dim=0, mesh_dims=(1, 0)),),
         )
         self.assertEqual(x_ordered_dt.to_local(), x_strided_dt.to_local())
+
+    @with_comms
+    @patch.object(DTensorRedistributePlanner, "find_min_cost_path")
+    def test_with_partial_in_backward(self, mock_find_path):
+        """
+        Test with backward redistribution path contains Partial().
+        """
+
+        # generate ground truth
+        input_tensor = torch.randn(8, 8, requires_grad=True)
+        input_tensor_orig = input_tensor.clone().detach().requires_grad_(True)
+        loss = input_tensor_orig.sum()
+        loss.backward()
+
+        forward_path = [
+            DTensorRedistributePlanner.DistState(
+                placements=(Replicate(), Replicate()),
+                tensor_dim_to_mesh_dim=(),
+            ),
+            DTensorRedistributePlanner.DistState(
+                placements=(Shard(0), Replicate()),
+                tensor_dim_to_mesh_dim=(),
+            ),
+        ]
+
+        backward_path = [
+            DTensorRedistributePlanner.DistState(
+                placements=(Replicate(), Replicate()),
+                tensor_dim_to_mesh_dim=(),
+            ),
+            # Note: The current DTensor implementation silently skips the
+            # transition from Replicate to Partial (R->P) during the backward
+            # pass. This can lead to numerical correctness issues if any
+            # operations are performed on that mesh dimension after the
+            # Partial() conversion. If we change the Partial() to something like
+            # Shard(0), the issue will be resolved. The will not be an issue for
+            # greedy solution, because it won't generate a path like P->R, but
+            # this may happen in graph based redistribution.
+            DTensorRedistributePlanner.DistState(
+                placements=(Partial(), Replicate()),
+                tensor_dim_to_mesh_dim=(),
+            ),
+            DTensorRedistributePlanner.DistState(
+                placements=(Replicate(), Replicate()),
+                tensor_dim_to_mesh_dim=(),
+            ),
+        ]
+
+        # set side_effect with a list - first call gets first item, second call gets second item
+        mock_find_path.side_effect = [forward_path, backward_path]
+        import torch.distributed.tensor._redistribute as redistribute_module
+
+        original_redistribute = redistribute_module.redistribute_local_tensor
+
+        def force_graph_based(*args, **kwargs):
+            kwargs["use_graph_based_transform"] = True
+            return original_redistribute(*args, **kwargs)
+
+        def disable_graph_based(*args, **kwargs):
+            kwargs["use_graph_based_transform"] = False
+            return original_redistribute(*args, **kwargs)
+
+        device_mesh = init_device_mesh(self.device_type, (4, 2))
+
+        # disable the graph based path finding in `distribute_tensor`
+        with patch.object(
+            redistribute_module,
+            "redistribute_local_tensor",
+            side_effect=disable_graph_based,
+        ):
+            # when set disable_graph_based, it won't consume the mock_find_path.side_effect
+            dtensor = distribute_tensor(
+                input_tensor, device_mesh, [Replicate(), Replicate()]
+            )
+            assert mock_find_path.call_count == 0
+
+        # enable the graph based path finding in `distribute_tensor`, so that
+        # mock_find_path.side_effect will be used
+        with patch.object(
+            redistribute_module,
+            "redistribute_local_tensor",
+            side_effect=force_graph_based,
+        ):
+            with DebugMode() as debug_mode:
+                dtensor_sharded = dtensor.redistribute(
+                    device_mesh,
+                    [Shard(0), Replicate()],
+                )
+                loss = dtensor_sharded.sum()
+                assert type(loss) is DTensor
+                # loss.placement is supposed to be [Partial(), Replicate()], but at
+                # some place, it silently get updated to [Replicate(), Replicate()].
+                loss.backward()
+
+        # verify forward and backward paths in mock_find_path.side_effect were used
+        assert mock_find_path.call_count == 2, (
+            f"Run {mock_find_path.call_count} calls to find_min_cost_path"
+        )
+        trace_str = self._extract_redistribute_trace_from_debug_mode(
+            debug_mode.debug_string()
+        )
+        # Partial should be removed after adjustment
+        self.assertTrue("P" not in trace_str)
+        self.assertEqual(input_tensor_orig.grad, make_full_tensor(dtensor.grad))
 
 
 RedistributeTestWithLocalTensor = create_local_tensor_test_class(

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -206,10 +206,9 @@ class _FromTorchTensor(torch.autograd.Function):
                 tensor_meta=grad_output._spec.tensor_meta,
             )
             local_tensor = grad_output._local_tensor
-            output, new_placements = redistribute_local_tensor(
+            output, _ = redistribute_local_tensor(
                 local_tensor, current_spec, target_spec, is_backward=True
             )
-            assert tuple(new_placements) == target_spec.placements
             # TODO: return the redistributed local tensor directly without
             # differentiable backward. see if this make sense for all cases.
             return output, None, None, None, None, None

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -206,9 +206,10 @@ class _FromTorchTensor(torch.autograd.Function):
                 tensor_meta=grad_output._spec.tensor_meta,
             )
             local_tensor = grad_output._local_tensor
-            output = redistribute_local_tensor(
+            output, new_placements = redistribute_local_tensor(
                 local_tensor, current_spec, target_spec, is_backward=True
             )
+            assert tuple(new_placements) == target_spec.placements
             # TODO: return the redistributed local tensor directly without
             # differentiable backward. see if this make sense for all cases.
             return output, None, None, None, None, None

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -417,7 +417,7 @@ class OpDispatcher:
                             f"Implicit redistribution occurred for {op_info.schema} while ExplicitRedistributionContext was active"
                         )
                     with redistribute_context:
-                        resharded_local_tensor = redistribute_local_tensor(
+                        resharded_local_tensor, _ = redistribute_local_tensor(
                             local_tensor,
                             arg_spec,
                             # pyrefly: ignore [bad-argument-type]

--- a/torch/distributed/tensor/experimental/_tp_transform.py
+++ b/torch/distributed/tensor/experimental/_tp_transform.py
@@ -452,11 +452,13 @@ def _insert_reshard_gm(
 
     # insert reshard operation
     def reshard_fn(local_tensor: torch.Tensor) -> torch.Tensor:
-        return redistribute_local_tensor(
+        new_tensor, new_placements = redistribute_local_tensor(
             local_tensor,
             input_arg_spec,
             desired_spec,
         )
+        assert tuple(new_placements) == desired_spec.placements
+        return new_tensor
 
     reshard_gm = make_fx(reshard_fn)(input_arg_tensor)
     reshard_gm_nodes = list(reshard_gm.graph.nodes)

--- a/torch/distributed/tensor/experimental/_tp_transform.py
+++ b/torch/distributed/tensor/experimental/_tp_transform.py
@@ -452,12 +452,11 @@ def _insert_reshard_gm(
 
     # insert reshard operation
     def reshard_fn(local_tensor: torch.Tensor) -> torch.Tensor:
-        new_tensor, new_placements = redistribute_local_tensor(
+        new_tensor, _ = redistribute_local_tensor(
             local_tensor,
             input_arg_spec,
             desired_spec,
         )
-        assert tuple(new_placements) == desired_spec.placements
         return new_tensor
 
     reshard_gm = make_fx(reshard_fn)(input_arg_tensor)

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -861,7 +861,7 @@ def redistribute(
             old_spec,
             new_spec,
             use_graph_based_transform=use_graph_based_transform,
-        ),
+        )[0],
         device_mesh,
     )
     dtensor_input._spec = copy.deepcopy(new_spec)


### PR DESCRIPTION
### Summary
This PR removes redistribution "hacks" in `Redistribute.backward` that silently skips Partial related operation. Instead, we let `redistribute_local_tensor` control whether to do the hack / optimization or not. If we do the optimization, `redistribute_local_tensor` will 
- return the final updated placements (where Partial will mostly be getting rid of during backward), and
- update `torch.utils._debug_mode` with the real _TransformInfo executed.
- even we set `is_backward=False` for backward path, the result should also be correct. We just skip the optimization in this case.

The idea is simple, we update `redistribute_local_tensor` to return both the redistributed tensor and the corresponding placement of the returned tensor:
```
def redistribute_local_tensor(..., is_backward: bool = False, ,...) -> tuple[torch.Tensor, list[Placement]]:
```


### Background
If we go through this part of code https://github.com/pytorch/pytorch/blob/a344069f2aba6a87c0ab3fab488e83b80691457f/torch/distributed/tensor/_redistribute.py#L921-L939
- redistribute_local_tensor function silently skips the redistribution when we redistribute R->P in the backward.
- But also in the backward, we update placement hint of Partial into Replicate.  

Those two "hacks" make the code hard to maintain. Also it confuses users that the real redistribution doesn't follow the computed redistribution path.

Fixes #167655


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @aditvenk