### PR TITLE
[3.14] Skip failing spherical_bessel_j0 tests

### DIFF
--- a/torch/testing/_internal/opinfo/definitions/special.py
+++ b/torch/testing/_internal/opinfo/definitions/special.py
@@ -13,7 +13,11 @@ from torch.testing._internal.common_device_type import (
     tol,
     toleranceOverride,
 )
-from torch.testing._internal.common_dtype import all_types_and, floating_types
+from torch.testing._internal.common_dtype import (
+    all_types,
+    all_types_and,
+    floating_types,
+)
 from torch.testing._internal.common_utils import TEST_SCIPY, torch_to_numpy_dtype_dict
 from torch.testing._internal.opinfo.core import (
     BinaryUfuncInfo,
@@ -645,7 +649,7 @@ op_db: list[OpInfo] = [
                 }
             ),
         ),
-        dtypes=all_types_and(torch.bool),
+        dtypes=all_types(),
         ref=lambda x: scipy.special.spherical_jn(0, x) if TEST_SCIPY else None,
         supports_autograd=False,
     ),

--- a/torch/testing/_internal/opinfo/definitions/special.py
+++ b/torch/testing/_internal/opinfo/definitions/special.py
@@ -13,11 +13,7 @@ from torch.testing._internal.common_device_type import (
     tol,
     toleranceOverride,
 )
-from torch.testing._internal.common_dtype import (
-    all_types,
-    all_types_and,
-    floating_types,
-)
+from torch.testing._internal.common_dtype import all_types_and, floating_types
 from torch.testing._internal.common_utils import TEST_SCIPY, torch_to_numpy_dtype_dict
 from torch.testing._internal.opinfo.core import (
     BinaryUfuncInfo,
@@ -649,9 +645,19 @@ op_db: list[OpInfo] = [
                 }
             ),
         ),
-        dtypes=all_types(),
+        dtypes=all_types_and(torch.bool),
         ref=lambda x: scipy.special.spherical_jn(0, x) if TEST_SCIPY else None,
         supports_autograd=False,
+        skips=(
+            DecorateInfo(
+                unittest.skip(
+                    "Scipy doesn't support bool inputs to spherical_bessel_j0"
+                ),
+                "TestUnaryUfuncs",
+                "test_reference_numerics_normal",
+                dtypes=(torch.bool,),
+            ),
+        ),
     ),
 ]
 
@@ -770,6 +776,16 @@ python_ref_db: list[OpInfo] = [
                     torch.float32: tol(atol=1e-03, rtol=1e-03),
                     torch.float64: tol(atol=1e-05, rtol=1e-03),
                 }
+            ),
+        ),
+        skips=(
+            DecorateInfo(
+                unittest.skip(
+                    "Scipy doesn't support bool inputs to spherical_bessel_j0"
+                ),
+                "TestUnaryUfuncs",
+                "test_reference_numerics_normal",
+                dtypes=(torch.bool,),
             ),
         ),
     ),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #167691

Starting with scipy 1.15, bool inputs error out.